### PR TITLE
jit: model maybe-null type pointers as niche Option<NonNull<PyObject>>

### DIFF
--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -4226,6 +4226,35 @@ impl<'a> Lowering<'a> {
                     let base = self.resolve_place(mir_bb, place)?;
                     return Ok((None, base));
                 }
+                // A niche `Option<NonNull<T>>` is one pointer word: `None`
+                // = null, `Some(p)` = the non-null pointer.  Its
+                // discriminant is the pointer-null test `base != null`
+                // (`None` = 0, `Some` = 1), not a `__discriminant` field off
+                // a two-word aggregate base (there is none).  Emit the null
+                // constant, then compare — a `ne` on two `Ref` operands
+                // lowers to `ptr_ne` (`jtransform`), and its `Int` result
+                // feeds the match switch exactly as a `__discriminant` read
+                // would.  Modelling the maybe-null pointer this way is the
+                // orthodox representation (RPython has no `Option`; a
+                // maybe-null `Ptr` tests `ptr_nonzero`).
+                if self.tyref_is_niche_option_ptr(&place.ty) {
+                    let base = self.resolve_place(mir_bb, place)?;
+                    let bb_id = self.block_id[mir_bb];
+                    let nullc = self.graph.alloc_value_var();
+                    self.graph.block_mut(bb_id).operations.push(SpaceOperation {
+                        result: Some(nullc.clone()),
+                        kind: OpKind::ConstRefNull,
+                    });
+                    return Ok((
+                        Some(OpKind::BinOp {
+                            op: "ne".to_string(),
+                            lhs: base,
+                            rhs: nullc,
+                            result_ty: ValueType::Int,
+                        }),
+                        res,
+                    ));
+                }
                 let base = self.resolve_place(mir_bb, place)?;
                 Ok((
                     Some(OpKind::FieldRead {
@@ -4357,6 +4386,16 @@ impl<'a> Lowering<'a> {
                     && let Some((owner_root, field_name, field_ty, owner_id)) =
                         self.resolve_adt_field(field_payload)
                 {
+                    // A niche `Option<NonNull<T>>` is one pointer word, so the
+                    // `Some` payload IS the base pointer — reading `Some.__pos_0`
+                    // is the identity on it, not a field off a two-word
+                    // aggregate (there is none, and its `__pos_0` attr has no
+                    // rtype clsfield).  Alias the base value with no field read,
+                    // mirroring the fieldless-enum discriminant collapse and the
+                    // `Discriminant` niche fold above.
+                    if field_name == "__pos_0" && self.tyref_is_niche_option_ptr(&inner.ty) {
+                        return self.resolve_place(mir_bb, *inner);
+                    }
                     // Narrow a classdef-less raw-pointer-deref base to
                     // `SomeInstance(<pointee root>)` before the field read.
                     // A `(*p).field` where `p: *mut/*const <Struct>` deref's to
@@ -9286,6 +9325,50 @@ impl<'a> Lowering<'a> {
             }
             _ => false,
         }
+    }
+
+    /// `true` when `ty` is a niche-optimised `Option<NonNull<T>>` — an
+    /// `Option` whose sole payload is a `core::ptr::non_null::NonNull`
+    /// wrapper.  Rust encodes such an Option in ONE pointer word (`None`
+    /// = null, `Some(p)` = the non-null pointer), so `Discriminant` on it
+    /// is a pointer-null test (`base != null`) and the `Some` payload read
+    /// is the identity on that pointer — no aggregate `__discriminant` /
+    /// `__pos_0` field exists.  This mirrors the fieldless-enum by-value
+    /// model ([`Self::tyref_is_fieldless_enum`]).
+    ///
+    /// Gated strictly to the `NonNull` payload: a raw `*mut T` / `*const T`
+    /// payload (`Option<*mut PyObject>`) has NO null niche — Rust lays it
+    /// out as a two-word tagged aggregate (discriminant word + pointer
+    /// word), so folding it to a one-word pointer would read the tag word
+    /// as the payload.  A `&T` payload is also niche, but the object
+    /// pointers this models are spelled `NonNull`, so only that shape
+    /// matches.
+    fn tyref_is_niche_option_ptr(&self, ty: &TyRef) -> bool {
+        if !crate::front::result_exc::tyref_is_option(ty, self.llbc) {
+            return false;
+        }
+        let Some(node) = tyref_node(ty, self.llbc) else {
+            return false;
+        };
+        let Some(payload) = node
+            .as_object()
+            .and_then(|m| m.get("Adt"))
+            .and_then(|a| a.get("generics"))
+            .and_then(|g| g.get("types"))
+            .and_then(|t| t.as_array())
+            .and_then(|t| t.first())
+            .and_then(|p| strip_ty_wrappers(p, self.llbc))
+        else {
+            return false;
+        };
+        let Some(def_id) = adt_node_def_id(payload) else {
+            return false;
+        };
+        self.llbc
+            .type_by_id(def_id)
+            .map(|td| td.item_meta.name_path())
+            .as_deref()
+            == Some("core::ptr::non_null::NonNull")
     }
 
     /// Lower `i64::checked_neg()` (`core::num::<Impl>::checked_neg` —
@@ -19402,6 +19485,44 @@ mod tests {
         assert!(
             has_value_switch,
             "call_intrinsic_1: expected an enum-discriminant switch after the collapse"
+        );
+    }
+
+    /// The niche-`Option<NonNull>` fold must stay INERT on the current
+    /// `Option<*mut PyObject>` tree: a raw `*mut` payload has no null
+    /// niche (two-word tagged aggregate), so `tyref_is_niche_option_ptr`
+    /// must reject it and `gettypeobject`
+    /// (`gettypefor(..).unwrap_or(PY_NULL)`, a 14-head census function)
+    /// must still lower its Option match through the aggregate
+    /// `__discriminant` FieldRead path — NOT the niche `ptr_ne` /
+    /// `ConstRefNull` fold.  Guards against the detector matching a
+    /// two-word Option before the `NonNull` source swap lands (a
+    /// miscompile: the pointer bits would be read as the tag).  Ignored by
+    /// default (loads the real LLBC).
+    #[test]
+    #[ignore]
+    fn niche_option_fold_inert_on_raw_ptr_option() {
+        use crate::model::OpKind;
+
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../build/llbc/pyre-interpreter.ullbc"
+        );
+        let llbc = Llbc::load(path).expect("load real LLBC");
+        let graph =
+            super::lower_function(&llbc, "gettypeobject").expect("lower gettypeobject");
+
+        // No niche fold artefact: the fold emits a `ConstRefNull` feeding a
+        // `ne` BinOp.  A raw-`*mut` Option must produce neither.
+        let null_consts = graph
+            .blocks
+            .iter()
+            .flat_map(|b| b.operations.iter())
+            .filter(|op| matches!(&op.kind, OpKind::ConstRefNull))
+            .count();
+        assert_eq!(
+            null_consts, 0,
+            "gettypeobject: niche fold fired on a raw-*mut Option (ConstRefNull emitted)"
         );
     }
 }

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -9097,12 +9097,14 @@ impl<'a> Lowering<'a> {
         // The payload `T` is the first type arg for both `Option<T>` and
         // `Result<T, E>`.
         let payload_ty = self.tyref_option_payload_value_type(recv_ty)?;
+        let niche = self.tyref_is_niche_option_ptr(recv_ty);
         Some(crate::front::option_unwrap_or::UnwrapOrSite {
             result_var: result_var.clone(),
             enum_owner,
             payload_owner,
             payload_ty,
             payload_on_disc_true,
+            niche,
         })
     }
 
@@ -9155,11 +9157,13 @@ impl<'a> Lowering<'a> {
         let option_owner = td.item_meta.name_path();
         let some_owner = Self::tagged_pair_payload_owner(td, &option_owner, 1)?;
         let payload_ty = self.tyref_option_payload_value_type(recv_ty)?;
+        let niche = self.tyref_is_niche_option_ptr(recv_ty);
         Some(crate::front::option_unwrap::UnwrapSite {
             result_var: result_var.clone(),
             option_owner,
             some_owner,
             payload_ty,
+            niche,
         })
     }
 
@@ -9180,11 +9184,13 @@ impl<'a> Lowering<'a> {
         let option_owner = td.item_meta.name_path();
         let some_owner = Self::tagged_pair_payload_owner(td, &option_owner, 1)?;
         let payload_ty = self.tyref_option_payload_value_type(recv_ty)?;
+        let niche = self.tyref_is_niche_option_ptr(recv_ty);
         Some(crate::front::option_try::OptionTrySite {
             branch_result_var: result_var.clone(),
             option_owner,
             some_owner,
             payload_ty,
+            niche,
         })
     }
 
@@ -9230,6 +9236,7 @@ impl<'a> Lowering<'a> {
         // `call_once` reads its `.0` from, keyed to the same `Tuple<X>` leaf
         // the read side derives at `resolve_place`.
         let args_tuple_suffix = option_payload_tuple_suffix(recv_ty, self.llbc);
+        let niche = self.tyref_is_niche_option_ptr(recv_ty);
         Some(crate::front::option_map_or::MapOrSite {
             result_var: result_var.clone(),
             option_owner,
@@ -9238,6 +9245,7 @@ impl<'a> Lowering<'a> {
             payload_ty,
             result_ty,
             args_tuple_suffix,
+            niche,
         })
     }
 
@@ -9293,6 +9301,7 @@ impl<'a> Lowering<'a> {
             | ClosureCombinator::OrElse
             | ClosureCombinator::UnwrapOrElse => tyref_to_value_type(dest_ty, self.llbc),
         };
+        let niche = self.tyref_is_niche_option_ptr(recv_ty);
         Some(crate::front::option_closure_select::ClosureSelectSite {
             kind,
             result_var: result_var.clone(),
@@ -9302,6 +9311,7 @@ impl<'a> Lowering<'a> {
             payload_ty,
             call_result_ty,
             args_tuple_suffix,
+            niche,
         })
     }
 

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -3997,6 +3997,34 @@ impl<'a> Lowering<'a> {
                         .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
                     return Ok((Some(OpKind::ConstInt(tag)), res));
                 }
+                // A niche `Option<NonNull<T>>` is one pointer word, so
+                // constructing it names either the null pointer (`None`) or
+                // the wrapped non-null pointer (`Some(p)`) directly — not a
+                // two-word aggregate with a `__discriminant` tag.  Fold `None`
+                // (zero-operand variant) to the `null_mut()` builtin call and
+                // `Some(p)` to the identity on its single pointer operand, so a
+                // constructed value is a maybe-null pointer end-to-end and both
+                // variants unify at the function return merge.  The null is a
+                // `null_mut()` call (a classdef-less nullable `SomeInstance`,
+                // the same lattice a `*mut T` value carries) rather than a
+                // `ConstRefNull` (a GCREF `_ptr`): the return merge unions the
+                // `None` value with the pointer-valued `Some` branch, and the
+                // two must share a universe — a bare `ConstRefNull` would
+                // annotate `SomePtr` and fail to union with the `SomeInstance`
+                // pointer.  (RPython has no `Option`; a maybe-null `Ptr` is the
+                // pointer itself, null for the absent case.)
+                if self.tyref_is_niche_option_ptr(dest_ty) {
+                    match operands.into_iter().next() {
+                        None => {
+                            let nullc = self.push_niche_null_ptr(mir_bb);
+                            return Ok((None, nullc));
+                        }
+                        Some(op) => {
+                            let p = self.resolve_operand(mir_bb, op)?;
+                            return Ok((None, p));
+                        }
+                    }
+                }
                 // Resolve operand Variables up front; they flow into the
                 // synthesised FieldWrite chain rather than the ctor's
                 // arg list.
@@ -4231,20 +4259,22 @@ impl<'a> Lowering<'a> {
                 // discriminant is the pointer-null test `base != null`
                 // (`None` = 0, `Some` = 1), not a `__discriminant` field off
                 // a two-word aggregate base (there is none).  Emit the null
-                // constant, then compare — a `ne` on two `Ref` operands
+                // pointer, then compare — a `ne` on two `Ref` operands
                 // lowers to `ptr_ne` (`jtransform`), and its `Int` result
                 // feeds the match switch exactly as a `__discriminant` read
-                // would.  Modelling the maybe-null pointer this way is the
-                // orthodox representation (RPython has no `Option`; a
-                // maybe-null `Ptr` tests `ptr_nonzero`).
+                // would.  The null is a `null_mut()` call, not a
+                // `ConstRefNull`: `null_mut()` rtypes to `convert_const(None)`
+                // on the result repr (`rbuiltin::rtype_ptr_null`), so it
+                // adapts to the `base` pointer's own `InstanceRepr` and the
+                // `ptr_ne` sees two same-repr operands.  A `ConstRefNull` is a
+                // fixed GCREF `_ptr`, which cannot rtype against an
+                // `InstanceRepr(PyObject)` base at the `ne`.  Modelling the
+                // maybe-null pointer this way is the orthodox representation
+                // (RPython has no `Option`; a maybe-null `Ptr` tests
+                // `ptr_nonzero`).
                 if self.tyref_is_niche_option_ptr(&place.ty) {
                     let base = self.resolve_place(mir_bb, place)?;
-                    let bb_id = self.block_id[mir_bb];
-                    let nullc = self.graph.alloc_value_var();
-                    self.graph.block_mut(bb_id).operations.push(SpaceOperation {
-                        result: Some(nullc.clone()),
-                        kind: OpKind::ConstRefNull,
-                    });
+                    let nullc = self.push_niche_null_ptr(mir_bb);
                     return Ok((
                         Some(OpKind::BinOp {
                             op: "ne".to_string(),
@@ -6721,36 +6751,38 @@ impl<'a> Lowering<'a> {
                     self.graph.set_goto(bb_id, target_bb, link_args);
                     return Ok(());
                 }
-                let alias =
-                    if let Some(payload) = self.expect_on_const_ok(&segments, &args, &arg_locals) {
-                        // Identity unwrap: the receiver variable was bound
-                        // directly to the `Ok` payload, so the result is
-                        // that variable — bind and close the block with no
-                        // op emitted.
-                        Some(payload)
-                    } else {
-                        self.reflexive_into_alias(
+                let alias = if let Some(payload) =
+                    self.expect_on_const_ok(&segments, &args, &arg_locals)
+                {
+                    // Identity unwrap: the receiver variable was bound
+                    // directly to the `Ok` payload, so the result is
+                    // that variable — bind and close the block with no
+                    // op emitted.
+                    Some(payload)
+                } else {
+                    self.reflexive_into_alias(
+                        &segments,
+                        &args,
+                        first_arg_ty.as_ref(),
+                        &call.dest.ty,
+                    )
+                    .or_else(|| {
+                        self.reflexive_into_iter_alias(
                             &segments,
                             &args,
                             first_arg_ty.as_ref(),
                             &call.dest.ty,
                         )
-                        .or_else(|| {
-                            self.reflexive_into_iter_alias(
-                                &segments,
-                                &args,
-                                first_arg_ty.as_ref(),
-                                &call.dest.ty,
-                            )
-                        })
-                        .or_else(|| self.trait_into_string_alias(&segments, &args, &call.dest.ty))
-                        .or_else(|| self.wtf8_string_identity_alias(&segments, &args))
-                        .or_else(|| {
-                            self.oparg_arg_get_alias(&reg.kind, &segments, &args, &call.dest.ty)
-                        })
-                        .or_else(|| self.oparg_value_alias(&segments, &args))
-                        .or_else(|| self.identity_passthrough_alias(&segments, &args))
-                    };
+                    })
+                    .or_else(|| self.trait_into_string_alias(&segments, &args, &call.dest.ty))
+                    .or_else(|| self.wtf8_string_identity_alias(&segments, &args))
+                    .or_else(|| {
+                        self.oparg_arg_get_alias(&reg.kind, &segments, &args, &call.dest.ty)
+                    })
+                    .or_else(|| self.oparg_value_alias(&segments, &args))
+                    .or_else(|| self.identity_passthrough_alias(&segments, &args))
+                    .or_else(|| self.nonnull_new_identity_alias(&segments, &args, &call.dest.ty))
+                };
                 if let Some(value) = alias {
                     self.local_var[dest_local] = Some(value);
                     let bb_id = self.block_id[mir_bb];
@@ -8814,6 +8846,40 @@ impl<'a> Lowering<'a> {
         is_identity.then(|| arg.clone())
     }
 
+    /// The `NonNull<T>` niche identities.  A `NonNull<T>` modelling an object
+    /// pointer is represented by its raw `*mut T`, so both constructors and
+    /// the pointer accessor are the identity on their single operand:
+    ///
+    /// - `NonNull::new(p) -> Option<NonNull<T>>` — the niche `Option`
+    ///   represents `None` as null and `Some(p)` as the pointer, so the
+    ///   constructed value *is* `p`.  Gated on the destination being that
+    ///   niche `Option<NonNull>` (`tyref_is_niche_option_ptr`).
+    /// - `NonNull::as_ptr(self) -> *mut T` — reads the pointer back out, which
+    ///   is the receiver itself.
+    ///
+    /// Aliasing drops the graph-less `NonNull` externs (otherwise "not
+    /// registered" in the rtyper census), mirroring the payload/discriminant
+    /// niche folds.
+    fn nonnull_new_identity_alias(
+        &self,
+        segments: &[String],
+        args: &[Variable],
+        dest_ty: &TyRef,
+    ) -> Option<Variable> {
+        let [arg] = args else {
+            return None;
+        };
+        if fmt_path_ends_with(segments, &["non_null", "NonNull", "new"])
+            && self.tyref_is_niche_option_ptr(dest_ty)
+        {
+            return Some(arg.clone());
+        }
+        if fmt_path_ends_with(segments, &["non_null", "NonNull", "as_ptr"]) {
+            return Some(arg.clone());
+        }
+        None
+    }
+
     /// The ADT `def_id` behind a signature [`TyRef`], whether inline
     /// or routed through the dedup table.  `None` for non-ADT shapes.
     fn tyref_adt_def_id(&self, ty: &TyRef) -> Option<u64> {
@@ -9379,6 +9445,25 @@ impl<'a> Lowering<'a> {
             .map(|td| td.item_meta.name_path())
             .as_deref()
             == Some("core::ptr::non_null::NonNull")
+    }
+
+    /// Emit a null pointer for a niche `Option<NonNull<T>>` (`None`) as a
+    /// `core::ptr::null_mut()` call, returning its result `Variable`.
+    ///
+    /// `null_mut()` is preferred over a bare `ConstRefNull`: the annotator's
+    /// `ptr_null_constant` types it as a classdef-less nullable `SomeInstance`
+    /// (joinable with any typed pointer receiver), and the rtyper's
+    /// `rtype_ptr_null` recovers the null via `convert_const(None)` on the
+    /// *result repr* — so the null adapts to whatever `InstanceRepr` /
+    /// `PtrRepr` the consuming slot carries.  A `ConstRefNull` is a fixed
+    /// GCREF `_ptr`, which fails to union (annotate) and fails to convert
+    /// (rtype) against an `InstanceRepr(PyObject)` at a `ptr_ne` or a return
+    /// merge.  Used by both the `Discriminant` null-test fold and the niche
+    /// `Aggregate` `None` construction fold so every niche-Option null shares
+    /// one repr-adaptive source.
+    fn push_niche_null_ptr(&mut self, mir_bb: usize) -> Variable {
+        let bb_id = self.block_id[mir_bb];
+        self.graph.push_null_mut_ptr(bb_id)
     }
 
     /// Lower `i64::checked_neg()` (`core::num::<Impl>::checked_neg` —
@@ -19498,20 +19583,20 @@ mod tests {
         );
     }
 
-    /// The niche-`Option<NonNull>` fold must stay INERT on the current
-    /// `Option<*mut PyObject>` tree: a raw `*mut` payload has no null
-    /// niche (two-word tagged aggregate), so `tyref_is_niche_option_ptr`
-    /// must reject it and `gettypeobject`
-    /// (`gettypefor(..).unwrap_or(PY_NULL)`, a 14-head census function)
-    /// must still lower its Option match through the aggregate
-    /// `__discriminant` FieldRead path — NOT the niche `ptr_ne` /
-    /// `ConstRefNull` fold.  Guards against the detector matching a
-    /// two-word Option before the `NonNull` source swap lands (a
-    /// miscompile: the pointer bits would be read as the tag).  Ignored by
-    /// default (loads the real LLBC).
+    /// `gettypeobject` (`gettypefor(..).map_or(PY_NULL, |p| p.as_ptr())`)
+    /// must fold its `gettypefor` match through the niche
+    /// `Option<NonNull<PyObject>>` path now that `gettypefor` returns a
+    /// one-word niche Option: the discriminant is a `ptr_ne` null-test
+    /// (`base != null_mut()`), NOT an aggregate `__discriminant` FieldRead,
+    /// and the null is a `null_mut()` call (repr-adaptive) rather than a
+    /// fixed-GCREF `ConstRefNull`.  Guards against a regression where the
+    /// niche detector stops recognising the `NonNull` payload (which would
+    /// re-introduce the classdef-less `__discriminant` base) or where the
+    /// null reverts to `ConstRefNull` (which cannot rtype against the
+    /// pointer's `InstanceRepr`).  Ignored by default (loads the real LLBC).
     #[test]
     #[ignore]
-    fn niche_option_fold_inert_on_raw_ptr_option() {
+    fn niche_option_gettypeobject_folds_to_ptr_null_test() {
         use crate::model::OpKind;
 
         let path = concat!(
@@ -19519,20 +19604,55 @@ mod tests {
             "/../../build/llbc/pyre-interpreter.ullbc"
         );
         let llbc = Llbc::load(path).expect("load real LLBC");
-        let graph =
-            super::lower_function(&llbc, "gettypeobject").expect("lower gettypeobject");
+        let graph = super::lower_function(&llbc, "gettypeobject").expect("lower gettypeobject");
 
-        // No niche fold artefact: the fold emits a `ConstRefNull` feeding a
-        // `ne` BinOp.  A raw-`*mut` Option must produce neither.
-        let null_consts = graph
+        // The niche null is a `null_mut()` call, never a `ConstRefNull`.
+        let const_ref_nulls = graph
             .blocks
             .iter()
             .flat_map(|b| b.operations.iter())
             .filter(|op| matches!(&op.kind, OpKind::ConstRefNull))
             .count();
         assert_eq!(
-            null_consts, 0,
-            "gettypeobject: niche fold fired on a raw-*mut Option (ConstRefNull emitted)"
+            const_ref_nulls, 0,
+            "gettypeobject: niche null must be null_mut(), not a fixed-GCREF ConstRefNull"
+        );
+        let null_muts = graph
+            .blocks
+            .iter()
+            .flat_map(|b| b.operations.iter())
+            .filter(|op| {
+                matches!(&op.kind, OpKind::Call { target, .. }
+                    if target.to_string() == "core::ptr::null_mut")
+            })
+            .count();
+        assert!(
+            null_muts >= 1,
+            "gettypeobject: expected a null_mut() feeding the niche ptr null-test"
+        );
+        // The niche discriminant is a `ne` pointer null-test, and no
+        // `__discriminant` FieldRead survives on the niche `gettypefor` result.
+        let has_ne = graph
+            .blocks
+            .iter()
+            .flat_map(|b| b.operations.iter())
+            .any(|op| matches!(&op.kind, OpKind::BinOp { op, .. } if op == "ne"));
+        assert!(
+            has_ne,
+            "gettypeobject: expected a `ne` pointer null-test discriminant"
+        );
+        let discriminant_reads = graph
+            .blocks
+            .iter()
+            .flat_map(|b| b.operations.iter())
+            .filter(|op| {
+                matches!(&op.kind, OpKind::FieldRead { field, .. }
+                    if field.name == "__discriminant")
+            })
+            .count();
+        assert_eq!(
+            discriminant_reads, 0,
+            "gettypeobject: niche Option must not read an aggregate __discriminant"
         );
     }
 }

--- a/majit/majit-translate/src/front/option_closure_select.rs
+++ b/majit/majit-translate/src/front/option_closure_select.rs
@@ -314,12 +314,10 @@ fn rewire_one_closure_select_site(
     if site.niche {
         // Niche `Option<NonNull>`: discriminant = `opt != null` (`None` = null
         // = 0, `Some` = non-null = 1) — a `ne` on two `Ref` operands lowers to
-        // `ptr_ne` with an `Int` result matching the aggregate read.
-        let nullc = graph.alloc_value_var();
-        graph.block_mut(a_id).operations.push(SpaceOperation {
-            result: Some(nullc.clone()),
-            kind: OpKind::ConstRefNull,
-        });
+        // `ptr_ne` with an `Int` result matching the aggregate read.  The null
+        // is a repr-adaptive `null_mut()` call, not a fixed-GCREF
+        // `ConstRefNull`, so `ptr_ne` sees the receiver's `InstanceRepr`.
+        let nullc = graph.push_null_mut_ptr(a_id);
         graph.block_mut(a_id).operations.push(SpaceOperation {
             result: Some(disc.clone()),
             kind: OpKind::BinOp {

--- a/majit/majit-translate/src/front/option_closure_select.rs
+++ b/majit/majit-translate/src/front/option_closure_select.rs
@@ -87,6 +87,12 @@ pub(crate) struct ClosureSelectSite {
     /// and the `resolve_place` read key under one classdef.  "" (bare `Tuple`)
     /// for a unit payload.
     pub args_tuple_suffix: String,
+    /// True when the receiver is a niche `Option<NonNull<_>>` — a one-word
+    /// pointer with no aggregate `__discriminant` / `__pos_0`.  The `Some`-arm
+    /// discriminant is then `opt != null` and the payload is the base pointer
+    /// itself (identity), not a `__pos_0` field read.  (The closure `Args`
+    /// tuple `__pos_0` write is unaffected — that is a real `Tuple` field.)
+    pub niche: bool,
 }
 
 /// Rewrite every recorded closure-select call site into the discriminant
@@ -305,19 +311,39 @@ fn rewire_one_closure_select_site(
         graph.blocks[a].operations.remove(ci);
     }
     let disc = graph.alloc_value_var();
-    graph.block_mut(a_id).operations.push(SpaceOperation {
-        result: Some(disc.clone()),
-        kind: OpKind::FieldRead {
-            base: opt.clone(),
-            field: FieldDescriptor {
-                name: "__discriminant".to_string(),
-                owner_root: Some(site.option_owner.clone()),
-                owner_id: None,
+    if site.niche {
+        // Niche `Option<NonNull>`: discriminant = `opt != null` (`None` = null
+        // = 0, `Some` = non-null = 1) — a `ne` on two `Ref` operands lowers to
+        // `ptr_ne` with an `Int` result matching the aggregate read.
+        let nullc = graph.alloc_value_var();
+        graph.block_mut(a_id).operations.push(SpaceOperation {
+            result: Some(nullc.clone()),
+            kind: OpKind::ConstRefNull,
+        });
+        graph.block_mut(a_id).operations.push(SpaceOperation {
+            result: Some(disc.clone()),
+            kind: OpKind::BinOp {
+                op: "ne".to_string(),
+                lhs: opt.clone(),
+                rhs: nullc,
+                result_ty: ValueType::Int,
             },
-            ty: ValueType::Int,
-            pure: true,
-        },
-    });
+        });
+    } else {
+        graph.block_mut(a_id).operations.push(SpaceOperation {
+            result: Some(disc.clone()),
+            kind: OpKind::FieldRead {
+                base: opt.clone(),
+                field: FieldDescriptor {
+                    name: "__discriminant".to_string(),
+                    owner_root: Some(site.option_owner.clone()),
+                    owner_id: None,
+                },
+                ty: ValueType::Int,
+                pure: true,
+            },
+        });
+    }
     graph.set_branch(a_id, disc, then_bb, then_sources, else_bb, else_sources);
     Ok(())
 }
@@ -332,6 +358,11 @@ fn read_some_payload(
     opt: Variable,
     site: &ClosureSelectSite,
 ) -> Variable {
+    // A niche `Option<NonNull>` has no aggregate `__pos_0`; the payload IS the
+    // base pointer, so the read is the identity on it.
+    if site.niche {
+        return opt;
+    }
     let payload = graph.alloc_value_var();
     graph.block_mut(block).operations.push(SpaceOperation {
         result: Some(payload.clone()),
@@ -421,6 +452,7 @@ mod tests {
             payload_ty: ValueType::Int,
             call_result_ty: ValueType::Int,
             args_tuple_suffix: String::new(),
+            niche: false,
         }
     }
 

--- a/majit/majit-translate/src/front/option_map_or.rs
+++ b/majit/majit-translate/src/front/option_map_or.rs
@@ -91,6 +91,11 @@ pub(crate) struct MapOrSite {
     /// and the `resolve_place` read key under one classdef.  "" (bare `Tuple`)
     /// for a unit payload.
     pub args_tuple_suffix: String,
+    /// True when the receiver is a niche `Option<NonNull<_>>` — a one-word
+    /// pointer with no aggregate `__discriminant` / `__pos_0`.  The `Some`-arm
+    /// discriminant is then `opt != null` and the payload is the base pointer
+    /// itself (identity), not a `__pos_0` field read.
+    pub niche: bool,
 }
 
 /// Rewrite every recorded `Option::map_or` call site into the discriminant
@@ -237,20 +242,27 @@ fn rewire_one_map_or_site(graph: &mut FunctionGraph, site: &MapOrSite) -> Result
         .ok_or_else(|| format!("{name}: Option value not threaded into Some arm"))?;
     let env_in_then = map_source(&then_sources, &then_inputs, &env)
         .ok_or_else(|| format!("{name}: closure env not threaded into Some arm"))?;
-    let payload = graph.alloc_value_var();
-    graph.block_mut(then_bb).operations.push(SpaceOperation {
-        result: Some(payload.clone()),
-        kind: OpKind::FieldRead {
-            base: opt_in_then,
-            field: FieldDescriptor {
-                name: "__pos_0".to_string(),
-                owner_root: Some(site.some_owner.clone()),
-                owner_id: None,
+    // A niche `Option<NonNull>` has no aggregate `__pos_0`; the payload IS the
+    // base pointer, so the closure input is the identity on it.
+    let payload = if site.niche {
+        opt_in_then
+    } else {
+        let payload = graph.alloc_value_var();
+        graph.block_mut(then_bb).operations.push(SpaceOperation {
+            result: Some(payload.clone()),
+            kind: OpKind::FieldRead {
+                base: opt_in_then,
+                field: FieldDescriptor {
+                    name: "__pos_0".to_string(),
+                    owner_root: Some(site.some_owner.clone()),
+                    owner_id: None,
+                },
+                ty: site.payload_ty.clone(),
+                pure: true,
             },
-            ty: site.payload_ty.clone(),
-            pure: true,
-        },
-    });
+        });
+        payload
+    };
     // The closure's `Args` tuple `(payload,)` — the transparent-ctor + a
     // single `__pos_0` FieldWrite, the same shape `Rvalue::Aggregate` emits for
     // a tuple (write ty `Ref(None)`).  The owner carries the per-shape `<X>`
@@ -330,19 +342,39 @@ fn rewire_one_map_or_site(graph: &mut FunctionGraph, site: &MapOrSite) -> Result
         graph.blocks[a].operations.remove(ci);
     }
     let disc = graph.alloc_value_var();
-    graph.block_mut(a_id).operations.push(SpaceOperation {
-        result: Some(disc.clone()),
-        kind: OpKind::FieldRead {
-            base: opt.clone(),
-            field: FieldDescriptor {
-                name: "__discriminant".to_string(),
-                owner_root: Some(site.option_owner.clone()),
-                owner_id: None,
+    if site.niche {
+        // Niche `Option<NonNull>`: discriminant = `opt != null` (`None` = null
+        // = 0, `Some` = non-null = 1) — a `ne` on two `Ref` operands lowers to
+        // `ptr_ne` with an `Int` result matching the aggregate read.
+        let nullc = graph.alloc_value_var();
+        graph.block_mut(a_id).operations.push(SpaceOperation {
+            result: Some(nullc.clone()),
+            kind: OpKind::ConstRefNull,
+        });
+        graph.block_mut(a_id).operations.push(SpaceOperation {
+            result: Some(disc.clone()),
+            kind: OpKind::BinOp {
+                op: "ne".to_string(),
+                lhs: opt.clone(),
+                rhs: nullc,
+                result_ty: ValueType::Int,
             },
-            ty: ValueType::Int,
-            pure: true,
-        },
-    });
+        });
+    } else {
+        graph.block_mut(a_id).operations.push(SpaceOperation {
+            result: Some(disc.clone()),
+            kind: OpKind::FieldRead {
+                base: opt.clone(),
+                field: FieldDescriptor {
+                    name: "__discriminant".to_string(),
+                    owner_root: Some(site.option_owner.clone()),
+                    owner_id: None,
+                },
+                ty: ValueType::Int,
+                pure: true,
+            },
+        });
+    }
     graph.set_branch(a_id, disc, then_bb, then_sources, else_bb, else_sources);
     Ok(())
 }
@@ -387,6 +419,7 @@ mod tests {
             payload_ty: ValueType::Int,
             result_ty: ValueType::Int,
             args_tuple_suffix: String::new(),
+            niche: false,
         }
     }
 

--- a/majit/majit-translate/src/front/option_map_or.rs
+++ b/majit/majit-translate/src/front/option_map_or.rs
@@ -345,12 +345,10 @@ fn rewire_one_map_or_site(graph: &mut FunctionGraph, site: &MapOrSite) -> Result
     if site.niche {
         // Niche `Option<NonNull>`: discriminant = `opt != null` (`None` = null
         // = 0, `Some` = non-null = 1) — a `ne` on two `Ref` operands lowers to
-        // `ptr_ne` with an `Int` result matching the aggregate read.
-        let nullc = graph.alloc_value_var();
-        graph.block_mut(a_id).operations.push(SpaceOperation {
-            result: Some(nullc.clone()),
-            kind: OpKind::ConstRefNull,
-        });
+        // `ptr_ne` with an `Int` result matching the aggregate read.  The null
+        // is a repr-adaptive `null_mut()` call, not a fixed-GCREF
+        // `ConstRefNull`, so `ptr_ne` sees the receiver's `InstanceRepr`.
+        let nullc = graph.push_null_mut_ptr(a_id);
         graph.block_mut(a_id).operations.push(SpaceOperation {
             result: Some(disc.clone()),
             kind: OpKind::BinOp {

--- a/majit/majit-translate/src/front/option_try.rs
+++ b/majit/majit-translate/src/front/option_try.rs
@@ -61,6 +61,11 @@ pub(crate) struct OptionTrySite {
     pub some_owner: String,
     /// The `Option` payload `T` — the `Some::__pos_0` field kind.
     pub payload_ty: ValueType,
+    /// True when the branched `Option` is a niche `Option<NonNull<_>>` — a
+    /// one-word pointer with no aggregate `__discriminant` / `__pos_0`.  The
+    /// tag switch is then a pointer null-test (`opt != null`) and the `Some`-arm
+    /// payload is the base pointer itself (identity).
+    pub niche: bool,
 }
 
 #[derive(Default, Debug, Clone)]
@@ -236,20 +241,27 @@ fn rewire_one_option_try_site(
 
     let opt_in_some = map_source(&some_sources, &some_inputs, &opt_a)
         .ok_or_else(|| format!("{name}: Option value not threaded into Some arm"))?;
-    let payload = graph.alloc_value_var();
-    graph.block_mut(some_bb).operations.push(SpaceOperation {
-        result: Some(payload.clone()),
-        kind: OpKind::FieldRead {
-            base: opt_in_some,
-            field: FieldDescriptor {
-                name: "__pos_0".to_string(),
-                owner_root: Some(site.some_owner.clone()),
-                owner_id: None,
+    // A niche `Option<NonNull>` has no aggregate `__pos_0`; the payload IS the
+    // base pointer (identity).
+    let payload = if site.niche {
+        opt_in_some
+    } else {
+        let payload = graph.alloc_value_var();
+        graph.block_mut(some_bb).operations.push(SpaceOperation {
+            result: Some(payload.clone()),
+            kind: OpKind::FieldRead {
+                base: opt_in_some,
+                field: FieldDescriptor {
+                    name: "__pos_0".to_string(),
+                    owner_root: Some(site.some_owner.clone()),
+                    owner_id: None,
+                },
+                ty: site.payload_ty.clone(),
+                pure: true,
             },
-            ty: site.payload_ty.clone(),
-            pure: true,
-        },
-    });
+        });
+        payload
+    };
     let some_link_args = continue_specs
         .iter()
         .map(|spec| match spec {
@@ -281,10 +293,28 @@ fn rewire_one_option_try_site(
     );
 
     let opt_disc = graph.alloc_value_var();
-    graph
-        .block_mut(graph.blocks[a].id)
-        .operations
-        .push(SpaceOperation {
+    let a_id = graph.blocks[a].id;
+    if site.niche {
+        // Niche `Option<NonNull>`: the switch value is the pointer null-test
+        // `opt != null` (`None` = null = 0, `Some` = non-null = 1) — a `ne` on
+        // two `Ref` operands lowers to `ptr_ne` with an `Int` result, feeding
+        // the `{1 => Some, 0 => None}` switch exactly as the aggregate read.
+        let nullc = graph.alloc_value_var();
+        graph.block_mut(a_id).operations.push(SpaceOperation {
+            result: Some(nullc.clone()),
+            kind: OpKind::ConstRefNull,
+        });
+        graph.block_mut(a_id).operations.push(SpaceOperation {
+            result: Some(opt_disc.clone()),
+            kind: OpKind::BinOp {
+                op: "ne".to_string(),
+                lhs: opt_a.clone(),
+                rhs: nullc,
+                result_ty: ValueType::Int,
+            },
+        });
+    } else {
+        graph.block_mut(a_id).operations.push(SpaceOperation {
             result: Some(opt_disc.clone()),
             kind: OpKind::FieldRead {
                 base: opt_a.clone(),
@@ -297,6 +327,7 @@ fn rewire_one_option_try_site(
                 pure: true,
             },
         });
+    }
     graph.set_control_flow_metadata(
         graph.blocks[a].id,
         Some(ExitSwitch::Value(opt_disc)),

--- a/majit/majit-translate/src/front/option_try.rs
+++ b/majit/majit-translate/src/front/option_try.rs
@@ -299,11 +299,9 @@ fn rewire_one_option_try_site(
         // `opt != null` (`None` = null = 0, `Some` = non-null = 1) — a `ne` on
         // two `Ref` operands lowers to `ptr_ne` with an `Int` result, feeding
         // the `{1 => Some, 0 => None}` switch exactly as the aggregate read.
-        let nullc = graph.alloc_value_var();
-        graph.block_mut(a_id).operations.push(SpaceOperation {
-            result: Some(nullc.clone()),
-            kind: OpKind::ConstRefNull,
-        });
+        // The null is a repr-adaptive `null_mut()` call, not a fixed-GCREF
+        // `ConstRefNull`, so `ptr_ne` sees the receiver's `InstanceRepr`.
+        let nullc = graph.push_null_mut_ptr(a_id);
         graph.block_mut(a_id).operations.push(SpaceOperation {
             result: Some(opt_disc.clone()),
             kind: OpKind::BinOp {

--- a/majit/majit-translate/src/front/option_unwrap.rs
+++ b/majit/majit-translate/src/front/option_unwrap.rs
@@ -203,12 +203,10 @@ fn rewire_one_unwrap_site(graph: &mut FunctionGraph, site: &UnwrapSite) -> Resul
     if site.niche {
         // Niche `Option<NonNull>`: discriminant = `opt != null` (`None` = null
         // = 0, `Some` = non-null = 1) — a `ne` on two `Ref` operands lowers to
-        // `ptr_ne` with an `Int` result matching the aggregate read.
-        let nullc = graph.alloc_value_var();
-        graph.block_mut(a_id).operations.push(SpaceOperation {
-            result: Some(nullc.clone()),
-            kind: OpKind::ConstRefNull,
-        });
+        // `ptr_ne` with an `Int` result matching the aggregate read.  The null
+        // is a repr-adaptive `null_mut()` call, not a fixed-GCREF
+        // `ConstRefNull`, so `ptr_ne` sees the receiver's `InstanceRepr`.
+        let nullc = graph.push_null_mut_ptr(a_id);
         graph.block_mut(a_id).operations.push(SpaceOperation {
             result: Some(disc.clone()),
             kind: OpKind::BinOp {

--- a/majit/majit-translate/src/front/option_unwrap.rs
+++ b/majit/majit-translate/src/front/option_unwrap.rs
@@ -60,6 +60,11 @@ pub(crate) struct UnwrapSite {
     /// The `Option`'s payload `T` projected to a [`ValueType`] — the
     /// `Some::__pos_0` field kind and the extracted result kind.
     pub payload_ty: ValueType,
+    /// True when the receiver is a niche `Option<NonNull<_>>` — a one-word
+    /// pointer with no aggregate `__discriminant` / `__pos_0`.  The `Some`-arm
+    /// discriminant is then `opt != null` and the payload is the base pointer
+    /// itself (identity), not a `__pos_0` field read.
+    pub niche: bool,
 }
 
 /// Rewrite every recorded `Option::unwrap` call site into the discriminant
@@ -151,23 +156,29 @@ fn rewire_one_unwrap_site(graph: &mut FunctionGraph, site: &UnwrapSite) -> Resul
     let (then_bb, then_inputs) = graph.create_block_with_arg_vars(then_sources.len());
     let (else_bb, _else_inputs) = graph.create_block_with_arg_vars(0);
 
-    // `then_bb`: payload = opt.__pos_0.
+    // `then_bb`: payload = opt.__pos_0.  A niche `Option<NonNull>` has no
+    // aggregate `__pos_0`; the payload IS the base pointer (identity).
     let opt_in_then = map_source(&then_sources, &then_inputs, &opt)
         .ok_or_else(|| format!("{name}: Option value not threaded into Some arm"))?;
-    let payload = graph.alloc_value_var();
-    graph.block_mut(then_bb).operations.push(SpaceOperation {
-        result: Some(payload.clone()),
-        kind: OpKind::FieldRead {
-            base: opt_in_then,
-            field: FieldDescriptor {
-                name: "__pos_0".to_string(),
-                owner_root: Some(site.some_owner.clone()),
-                owner_id: None,
+    let payload = if site.niche {
+        opt_in_then
+    } else {
+        let payload = graph.alloc_value_var();
+        graph.block_mut(then_bb).operations.push(SpaceOperation {
+            result: Some(payload.clone()),
+            kind: OpKind::FieldRead {
+                base: opt_in_then,
+                field: FieldDescriptor {
+                    name: "__pos_0".to_string(),
+                    owner_root: Some(site.some_owner.clone()),
+                    owner_id: None,
+                },
+                ty: site.payload_ty.clone(),
+                pure: true,
             },
-            ty: site.payload_ty.clone(),
-            pure: true,
-        },
-    });
+        });
+        payload
+    };
     let then_link_args = reproduce_exit_args(
         &saved_exit,
         &site.result_var,
@@ -189,19 +200,39 @@ fn rewire_one_unwrap_site(graph: &mut FunctionGraph, site: &UnwrapSite) -> Resul
     let a_id = graph.blocks[a].id;
     graph.blocks[a].operations.remove(call_idx);
     let disc = graph.alloc_value_var();
-    graph.block_mut(a_id).operations.push(SpaceOperation {
-        result: Some(disc.clone()),
-        kind: OpKind::FieldRead {
-            base: opt.clone(),
-            field: FieldDescriptor {
-                name: "__discriminant".to_string(),
-                owner_root: Some(site.option_owner.clone()),
-                owner_id: None,
+    if site.niche {
+        // Niche `Option<NonNull>`: discriminant = `opt != null` (`None` = null
+        // = 0, `Some` = non-null = 1) — a `ne` on two `Ref` operands lowers to
+        // `ptr_ne` with an `Int` result matching the aggregate read.
+        let nullc = graph.alloc_value_var();
+        graph.block_mut(a_id).operations.push(SpaceOperation {
+            result: Some(nullc.clone()),
+            kind: OpKind::ConstRefNull,
+        });
+        graph.block_mut(a_id).operations.push(SpaceOperation {
+            result: Some(disc.clone()),
+            kind: OpKind::BinOp {
+                op: "ne".to_string(),
+                lhs: opt.clone(),
+                rhs: nullc,
+                result_ty: ValueType::Int,
             },
-            ty: ValueType::Int,
-            pure: true,
-        },
-    });
+        });
+    } else {
+        graph.block_mut(a_id).operations.push(SpaceOperation {
+            result: Some(disc.clone()),
+            kind: OpKind::FieldRead {
+                base: opt.clone(),
+                field: FieldDescriptor {
+                    name: "__discriminant".to_string(),
+                    owner_root: Some(site.option_owner.clone()),
+                    owner_id: None,
+                },
+                ty: ValueType::Int,
+                pure: true,
+            },
+        });
+    }
     graph.set_branch(a_id, disc, then_bb, then_sources, else_bb, Vec::new());
     Ok(())
 }
@@ -246,6 +277,7 @@ mod tests {
                 option_owner: "core::option::Option".to_string(),
                 some_owner: "core::option::Option::Some".to_string(),
                 payload_ty: ValueType::Int,
+                niche: false,
             }],
         );
         assert_eq!(rewritten, 1, "the unwrap site must be rewritten");
@@ -314,6 +346,7 @@ mod tests {
                 option_owner: "core::option::Option".to_string(),
                 some_owner: "core::option::Option::Some".to_string(),
                 payload_ty: ValueType::Int,
+                niche: false,
             }],
         );
         assert_eq!(rewritten, 0, "a non-unary producer declines");

--- a/majit/majit-translate/src/front/option_unwrap_or.rs
+++ b/majit/majit-translate/src/front/option_unwrap_or.rs
@@ -75,6 +75,14 @@ pub(crate) struct UnwrapOrSite {
     /// false when on discriminant 0 (`Result::Ok`) — selects which `bool(disc)`
     /// arm reads `__pos_0` versus forwards the `default`.
     pub payload_on_disc_true: bool,
+    /// True when the receiver is a niche `Option<NonNull<_>>` — a one-word
+    /// pointer (`None` = null, `Some(p)` = the pointer) with no aggregate
+    /// `__discriminant` / `__pos_0` fields.  The discriminant is then the
+    /// pointer null-test (`opt != null`) and the payload read is the
+    /// identity on the base pointer (see [`super::mir`]
+    /// `tyref_is_niche_option_ptr`).  Always an `Option` (never a `Result`)
+    /// when set, so `payload_on_disc_true` is `true`.
+    pub niche: bool,
 }
 
 /// Rewrite every recorded `Option::unwrap_or` call site into the
@@ -212,22 +220,29 @@ fn rewire_one_unwrap_or_site(graph: &mut FunctionGraph, site: &UnwrapOrSite) -> 
     let (default_bb, default_inputs) = graph.create_block_with_arg_vars(default_sources.len());
 
     // Payload arm: value = recv.__pos_0 (narrowed if the call carried a cast).
+    // A niche `Option<NonNull>` has no aggregate `__pos_0`; the payload IS the
+    // base pointer, so the read is the identity on it.
     let recv_in_payload = map_source(&payload_sources, &payload_inputs, &opt)
         .ok_or_else(|| format!("{name}: receiver not threaded into payload arm"))?;
-    let payload = graph.alloc_value_var();
-    graph.block_mut(payload_bb).operations.push(SpaceOperation {
-        result: Some(payload.clone()),
-        kind: OpKind::FieldRead {
-            base: recv_in_payload,
-            field: FieldDescriptor {
-                name: "__pos_0".to_string(),
-                owner_root: Some(site.payload_owner.clone()),
-                owner_id: None,
+    let payload = if site.niche {
+        recv_in_payload
+    } else {
+        let payload = graph.alloc_value_var();
+        graph.block_mut(payload_bb).operations.push(SpaceOperation {
+            result: Some(payload.clone()),
+            kind: OpKind::FieldRead {
+                base: recv_in_payload,
+                field: FieldDescriptor {
+                    name: "__pos_0".to_string(),
+                    owner_root: Some(site.payload_owner.clone()),
+                    owner_id: None,
+                },
+                ty: site.payload_ty.clone(),
+                pure: true,
             },
-            ty: site.payload_ty.clone(),
-            pure: true,
-        },
-    });
+        });
+        payload
+    };
     let payload_value = emit_narrow(graph, payload_bb, &cast, payload);
     let payload_link_args = reproduce_exit_args(
         &saved_exit,
@@ -268,19 +283,40 @@ fn rewire_one_unwrap_or_site(graph: &mut FunctionGraph, site: &UnwrapOrSite) -> 
     }
     graph.blocks[a].operations.remove(call_idx);
     let disc = graph.alloc_value_var();
-    graph.block_mut(a_id).operations.push(SpaceOperation {
-        result: Some(disc.clone()),
-        kind: OpKind::FieldRead {
-            base: opt.clone(),
-            field: FieldDescriptor {
-                name: "__discriminant".to_string(),
-                owner_root: Some(site.enum_owner.clone()),
-                owner_id: None,
+    if site.niche {
+        // Niche `Option<NonNull>`: the discriminant is the pointer null-test
+        // `opt != null` (`None` = null = 0, `Some` = non-null = 1) — a `ne` on
+        // two `Ref` operands lowers to `ptr_ne` with an `Int` result, matching
+        // the aggregate `__discriminant` read's value for the branch.
+        let nullc = graph.alloc_value_var();
+        graph.block_mut(a_id).operations.push(SpaceOperation {
+            result: Some(nullc.clone()),
+            kind: OpKind::ConstRefNull,
+        });
+        graph.block_mut(a_id).operations.push(SpaceOperation {
+            result: Some(disc.clone()),
+            kind: OpKind::BinOp {
+                op: "ne".to_string(),
+                lhs: opt.clone(),
+                rhs: nullc,
+                result_ty: ValueType::Int,
             },
-            ty: ValueType::Int,
-            pure: true,
-        },
-    });
+        });
+    } else {
+        graph.block_mut(a_id).operations.push(SpaceOperation {
+            result: Some(disc.clone()),
+            kind: OpKind::FieldRead {
+                base: opt.clone(),
+                field: FieldDescriptor {
+                    name: "__discriminant".to_string(),
+                    owner_root: Some(site.enum_owner.clone()),
+                    owner_id: None,
+                },
+                ty: ValueType::Int,
+                pure: true,
+            },
+        });
+    }
     let ((then_bb, then_sources), (else_bb, else_sources)) = if site.payload_on_disc_true {
         ((payload_bb, payload_sources), (default_bb, default_sources))
     } else {
@@ -338,6 +374,7 @@ mod tests {
             payload_owner: "core::option::Option::Some".into(),
             payload_ty: ValueType::Int,
             payload_on_disc_true: true,
+            niche: false,
         }
     }
 
@@ -358,6 +395,7 @@ mod tests {
             payload_ty: ValueType::Int,
             // `Result::Ok = 0`, so the payload arm is the `bool(disc)`-false arm.
             payload_on_disc_true: false,
+            niche: false,
         }
     }
 
@@ -595,5 +633,75 @@ mod tests {
                 .any(|op| matches!(&op.kind, OpKind::Call { .. })),
             "residual call survives on decline"
         );
+    }
+
+    /// A niche `Option<NonNull>` receiver (`niche: true`) has no aggregate
+    /// `__discriminant` / `__pos_0`: the discriminant is the pointer null-test
+    /// `opt != null` (`ConstRefNull` + `ne` BinOp) and the `Some` payload is the
+    /// identity on the base pointer.  The rewrite must emit neither field read —
+    /// a `__pos_0` read at offset 8 of a one-word niche value would read past it.
+    #[test]
+    fn rewrite_niche_option_uses_ptr_null_test_and_identity_payload() {
+        let mut g = FunctionGraph::new("test_unwrap_or_niche");
+        let a = g.startblock;
+        let opt = g.push_op_var(a, OpKind::ConstInt(0), true).unwrap();
+        let default = g.push_op_var(a, OpKind::ConstInt(0), true).unwrap();
+        let result = g
+            .push_op_var(
+                a,
+                OpKind::Call {
+                    target: unwrap_or_target(),
+                    args: vec![opt.clone(), default.clone()],
+                    result_ty: ValueType::Ref(None),
+                },
+                true,
+            )
+            .unwrap();
+        let (b, _b_args) = g.create_block_with_arg_vars(1);
+        g.set_return(b, None);
+        g.set_goto(a, b, vec![result.clone()]);
+
+        let mut site = option_site(result.clone());
+        site.niche = true;
+        site.payload_ty = ValueType::Ref(None);
+        let rewritten = rewire_unwrap_or_call_sites(&mut g, &[site]);
+        assert_eq!(rewritten, 1, "the niche unwrap_or site is rewritten");
+
+        // No aggregate field reads anywhere: neither `__discriminant` nor
+        // `__pos_0` (the niche value is a bare pointer).
+        let field_reads = g
+            .blocks
+            .iter()
+            .flat_map(|blk| &blk.operations)
+            .filter(|op| matches!(&op.kind, OpKind::FieldRead { .. }))
+            .count();
+        assert_eq!(
+            field_reads, 0,
+            "a niche Option reads no aggregate __discriminant/__pos_0"
+        );
+        // Block A discriminant = `opt != null`: a `ConstRefNull` feeding a `ne`.
+        assert_eq!(
+            g.blocks[a.0]
+                .operations
+                .iter()
+                .filter(|op| matches!(&op.kind, OpKind::ConstRefNull))
+                .count(),
+            1,
+            "the niche discriminant emits a ConstRefNull"
+        );
+        let ne = g.blocks[a.0]
+            .operations
+            .iter()
+            .find(|op| matches!(&op.kind, OpKind::BinOp { op, .. } if op == "ne"))
+            .expect("the niche discriminant is a `ne` compare");
+        match &ne.kind {
+            OpKind::BinOp { lhs, result_ty, .. } => {
+                assert_eq!(lhs, &opt, "the null-test compares the receiver pointer");
+                assert_eq!(result_ty, &ValueType::Int, "ptr_ne yields an Int tag");
+            }
+            _ => unreachable!(),
+        }
+        // A still branches two ways (Some / None).
+        assert_eq!(g.blocks[a.0].exits.len(), 2, "A branches to Some/None arms");
     }
 }

--- a/majit/majit-translate/src/front/option_unwrap_or.rs
+++ b/majit/majit-translate/src/front/option_unwrap_or.rs
@@ -287,12 +287,11 @@ fn rewire_one_unwrap_or_site(graph: &mut FunctionGraph, site: &UnwrapOrSite) -> 
         // Niche `Option<NonNull>`: the discriminant is the pointer null-test
         // `opt != null` (`None` = null = 0, `Some` = non-null = 1) — a `ne` on
         // two `Ref` operands lowers to `ptr_ne` with an `Int` result, matching
-        // the aggregate `__discriminant` read's value for the branch.
-        let nullc = graph.alloc_value_var();
-        graph.block_mut(a_id).operations.push(SpaceOperation {
-            result: Some(nullc.clone()),
-            kind: OpKind::ConstRefNull,
-        });
+        // the aggregate `__discriminant` read's value for the branch.  The null
+        // is a `null_mut()` call (repr-adaptive) rather than a `ConstRefNull`
+        // (fixed GCREF), so `ptr_ne` sees two operands of the receiver's own
+        // `InstanceRepr`.
+        let nullc = graph.push_null_mut_ptr(a_id);
         graph.block_mut(a_id).operations.push(SpaceOperation {
             result: Some(disc.clone()),
             kind: OpKind::BinOp {
@@ -679,15 +678,20 @@ mod tests {
             field_reads, 0,
             "a niche Option reads no aggregate __discriminant/__pos_0"
         );
-        // Block A discriminant = `opt != null`: a `ConstRefNull` feeding a `ne`.
+        // Block A discriminant = `opt != null`: a `null_mut()` call feeding a
+        // `ne` (the repr-adaptive null, not a fixed-GCREF `ConstRefNull`).
         assert_eq!(
             g.blocks[a.0]
                 .operations
                 .iter()
-                .filter(|op| matches!(&op.kind, OpKind::ConstRefNull))
+                .filter(|op| matches!(
+                    &op.kind,
+                    OpKind::Call { target, .. }
+                        if target.to_string() == "core::ptr::null_mut"
+                ))
                 .count(),
             1,
-            "the niche discriminant emits a ConstRefNull"
+            "the niche discriminant emits a null_mut() call"
         );
         let ne = g.blocks[a.0]
             .operations

--- a/majit/majit-translate/src/model.rs
+++ b/majit/majit-translate/src/model.rs
@@ -4582,6 +4582,27 @@ impl FunctionGraph {
         self.alloc_value_var_with_type(ConcreteType::Unknown)
     }
 
+    /// Emit a `core::ptr::null_mut()` call into `block` and return its result
+    /// `Variable` — the repr-adaptive null pointer used for a niche
+    /// `Option<NonNull<T>>` `None` (the discriminant null-test rhs and the
+    /// `Some`/`None` combinator folds).  `null_mut()` types as a classdef-less
+    /// nullable `SomeInstance` (annotate) and recovers the null via
+    /// `convert_const(None)` on the result repr (rtype), so it unions and
+    /// converts against the pointer receiver's own `InstanceRepr`; a bare
+    /// `ConstRefNull` is a fixed GCREF `_ptr` that does neither.
+    pub fn push_null_mut_ptr(&mut self, block: BlockId) -> crate::flowspace::model::Variable {
+        let res = self.alloc_value_var();
+        self.block_mut(block).operations.push(SpaceOperation {
+            result: Some(res.clone()),
+            kind: OpKind::Call {
+                target: CallTarget::function_path(["core", "ptr", "null_mut"]),
+                args: vec![],
+                result_ty: ValueType::Ref(None),
+            },
+        });
+        res
+    }
+
     /// Mint a fresh value [`crate::flowspace::model::Variable`] with its
     /// [`ConcreteType`] stamped at construction — pyre's analogue of
     /// upstream `Variable(concretetype=...)` (RPython

--- a/pyre/pyre-interpreter/src/_pypy_generic_alias.rs
+++ b/pyre/pyre-interpreter/src/_pypy_generic_alias.rs
@@ -328,11 +328,11 @@ fn is_typevartuple(param: PyObjectRef) -> bool {
     let Some(t) = crate::typedef::r#type(param) else {
         return false;
     };
-    if unsafe { pyre_object::w_type_get_name(t) } != "TypeVarTuple" {
+    if unsafe { pyre_object::w_type_get_name(t.as_ptr()) } != "TypeVarTuple" {
         return false;
     }
     matches!(
-        crate::baseobjspace::getattr_str(t, "__module__")
+        crate::baseobjspace::getattr_str(t.as_ptr(), "__module__")
             .ok()
             .and_then(|m| crate::baseobjspace::text_w(m).ok()),
         Some("typing")

--- a/pyre/pyre-interpreter/src/argument.rs
+++ b/pyre/pyre-interpreter/src/argument.rs
@@ -29,7 +29,7 @@ fn type_name_of(w_obj: PyObjectRef) -> String {
     }
     unsafe {
         match crate::typedef::r#type(w_obj) {
-            Some(tp) => pyre_object::w_type_get_name(tp).to_string(),
+            Some(tp) => pyre_object::w_type_get_name(tp.as_ptr()).to_string(),
             None => (*(*w_obj).ob_type).name.to_string(),
         }
     }
@@ -465,7 +465,8 @@ pub fn combine_starstarargs_wrapped(
             // Pyre's `findattr` matches the same shape (Option<W>),
             // modulo async-propagation (still a known gap covered by
             // the `findattr` TODO).
-            let w_obj_type = crate::typedef::r#type(w_starstararg).unwrap_or(pyre_object::PY_NULL);
+            let w_obj_type =
+                crate::typedef::r#type(w_starstararg).map_or(pyre_object::PY_NULL, |p| p.as_ptr());
             let lhs = if w_obj_type.is_null() {
                 None
             } else {

--- a/pyre/pyre-interpreter/src/argument.rs
+++ b/pyre/pyre-interpreter/src/argument.rs
@@ -837,10 +837,9 @@ impl Arguments {
     /// ```
     #[inline]
     pub fn firstarg(&self) -> Option<PyObjectRef> {
-        if !self.arguments_w.is_empty() {
-            Some(self.arguments_w[0])
-        } else {
-            None
+        match self.arguments_w.first() {
+            Some(&w) if !w.is_null() => Some(w),
+            _ => None,
         }
     }
 

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -135,7 +135,7 @@ pub fn wrap_dict_key_hash_error(key: PyObjectRef, err: PyError) -> PyError {
     }
     if !err.exc_object.is_null() {
         let exact_type_error = crate::builtins::lookup_exc_class("TypeError");
-        let raised_type = crate::typedef::r#type(err.exc_object).unwrap_or(PY_NULL);
+        let raised_type = crate::typedef::r#type(err.exc_object).map_or(PY_NULL, |p| p.as_ptr());
         if exact_type_error.is_none_or(|expected| !std::ptr::eq(raised_type, expected)) {
             return err;
         }
@@ -154,7 +154,7 @@ pub fn wrap_set_element_hash_error(item: PyObjectRef, err: PyError) -> PyError {
     }
     if !err.exc_object.is_null() {
         let exact_type_error = crate::builtins::lookup_exc_class("TypeError");
-        let raised_type = crate::typedef::r#type(err.exc_object).unwrap_or(PY_NULL);
+        let raised_type = crate::typedef::r#type(err.exc_object).map_or(PY_NULL, |p| p.as_ptr());
         if exact_type_error.is_none_or(|expected| !std::ptr::eq(raised_type, expected)) {
             return err;
         }
@@ -329,7 +329,7 @@ pub unsafe fn exception_is_valid_class_w(w_cls: PyObjectRef) -> bool {
 ///   def exception_getclass(self, w_obj):
 ///       return self.type(w_obj)
 pub fn exception_getclass(w_obj: PyObjectRef) -> PyObjectRef {
-    crate::typedef::r#type(w_obj).unwrap_or(pyre_object::PY_NULL)
+    crate::typedef::r#type(w_obj).map_or(pyre_object::PY_NULL, |p| p.as_ptr())
 }
 
 /// True when `obj` is a `BlockingIOError` whose constructor took the numeric
@@ -467,7 +467,7 @@ unsafe fn p_recursive_isinstance_type_w(
         Err(e) if e.kind == PyErrorKind::AttributeError => return Ok(false),
         Err(e) => return Err(e),
     };
-    let w_inst_type = crate::typedef::r#type(w_inst).unwrap_or(pyre_object::PY_NULL);
+    let w_inst_type = crate::typedef::r#type(w_inst).map_or(pyre_object::PY_NULL, |p| p.as_ptr());
     if !std::ptr::eq(w_abstractclass, w_inst_type) && is_type_like_w(w_abstractclass) {
         return Ok(issubtype_w(w_abstractclass, w_type));
     }
@@ -669,7 +669,7 @@ pub fn isinstance(obj: PyObjectRef, classinfo: PyObjectRef) -> Result<bool, PyEr
     unsafe {
         // abstractinst.py:104-106 — quick exact-type test.
         if let Some(t) = crate::typedef::r#type(obj) {
-            if std::ptr::eq(t, classinfo) {
+            if std::ptr::eq(t.as_ptr(), classinfo) {
                 return Ok(true);
             }
         }
@@ -714,11 +714,11 @@ pub fn isinstance(obj: PyObjectRef, classinfo: PyObjectRef) -> Result<bool, PyEr
         // PyPy's `type.__instancecheck__` slot calling back into
         // `p_recursive_isinstance_type_w`.
         if let Some(cls_type) = crate::typedef::r#type(classinfo) {
-            if let Some(check) = lookup_in_type(cls_type, "__instancecheck__") {
+            if let Some(check) = lookup_in_type(cls_type.as_ptr(), "__instancecheck__") {
                 // abstractinst.py:122 `space.get_and_call_function(w_check,
                 // w_klass_or_tuple, w_obj)` — bind the descriptor to
                 // `classinfo` before calling with `obj`.
-                let result = get_and_call_function(check, classinfo, cls_type, &[obj])?;
+                let result = get_and_call_function(check, classinfo, cls_type.as_ptr(), &[obj])?;
                 return Ok(is_true(result)?);
             }
         }
@@ -764,11 +764,12 @@ pub fn issubclass(derived: PyObjectRef, classinfo: PyObjectRef) -> Result<bool, 
         // Same `lookup_in_type(type(classinfo), …)` rationale as
         // `isinstance` above.
         if let Some(cls_type) = crate::typedef::r#type(classinfo) {
-            if let Some(check) = lookup_in_type(cls_type, "__subclasscheck__") {
+            if let Some(check) = lookup_in_type(cls_type.as_ptr(), "__subclasscheck__") {
                 // abstractinst.py:195 `space.get_and_call_function(w_check,
                 // w_klass_or_tuple, w_derived)` — bind the descriptor to
                 // `classinfo` before calling with `derived`.
-                let result = get_and_call_function(check, classinfo, cls_type, &[derived])?;
+                let result =
+                    get_and_call_function(check, classinfo, cls_type.as_ptr(), &[derived])?;
                 return Ok(is_true(result)?);
             }
         }
@@ -835,7 +836,7 @@ pub(crate) unsafe fn subclass_special_override(
         return None;
     }
     let w_type = crate::typedef::r#type(obj)?;
-    let method = lookup_in_type_where(w_type, name)?;
+    let method = lookup_in_type_where(w_type.as_ptr(), name)?;
     // The builtin layout type for `obj` — the canonical type object for its
     // `ob_type`.  When the MRO resolution matches that type's own slot the
     // method is inherited, not overridden.
@@ -847,7 +848,7 @@ pub(crate) unsafe fn subclass_special_override(
             }
         }
     }
-    Some((method, w_type))
+    Some((method, w_type.as_ptr()))
 }
 
 /// descroperation.py:265-285 `is_true`.
@@ -896,8 +897,8 @@ pub fn is_true(obj: PyObjectRef) -> Result<bool, PyError> {
 /// over an overridden `__len__`.
 fn is_true_lookup(obj: PyObjectRef) -> Result<bool, PyError> {
     if let Some(w_type) = crate::typedef::r#type(obj) {
-        if let Some(w_descr) = unsafe { lookup_in_type(w_type, "__bool__") } {
-            let w_res = unsafe { get_and_call_function(w_descr, obj, w_type, &[]) }?;
+        if let Some(w_descr) = unsafe { lookup_in_type(w_type.as_ptr(), "__bool__") } {
+            let w_res = unsafe { get_and_call_function(w_descr, obj, w_type.as_ptr(), &[]) }?;
             // The only instances of bool are `w_False` / `w_True`, so a
             // non-bool result is a TypeError reporting the receiver's type
             // (upstream's `%T` on `w_obj`).
@@ -909,8 +910,8 @@ fn is_true_lookup(obj: PyObjectRef) -> Result<bool, PyError> {
                 object_functionstr_type_name(obj),
             )));
         }
-        if let Some(w_descr) = unsafe { lookup_in_type(w_type, "__len__") } {
-            let w_res = unsafe { get_and_call_function(w_descr, obj, w_type, &[]) }?;
+        if let Some(w_descr) = unsafe { lookup_in_type(w_type.as_ptr(), "__len__") } {
+            let w_res = unsafe { get_and_call_function(w_descr, obj, w_type.as_ptr(), &[]) }?;
             let w_index = space_index(w_res)?;
             return Ok(_check_len_result(w_index)? != 0);
         }
@@ -1142,7 +1143,7 @@ pub fn get_awaitable_iter(w_obj: PyObjectRef, context: u32) -> PyResult {
         return Ok(w_obj);
     }
     let w_await = crate::typedef::r#type(w_obj)
-        .and_then(|w_type| unsafe { lookup_in_type(w_type, "__await__") });
+        .and_then(|w_type| unsafe { lookup_in_type(w_type.as_ptr(), "__await__") });
     let Some(w_await) = w_await else {
         let msg = match context {
             1 => format!(
@@ -1162,7 +1163,7 @@ pub fn get_awaitable_iter(w_obj: PyObjectRef, context: u32) -> PyResult {
         };
         return Err(PyError::type_error(msg));
     };
-    let w_type = crate::typedef::r#type(w_obj).unwrap_or(w_obj);
+    let w_type = crate::typedef::r#type(w_obj).map_or(w_obj, |p| p.as_ptr());
     let w_res = unsafe { get_and_call_function(w_await, w_obj, w_type, &[]) }?;
     if is_coroutine(w_res) {
         return Err(PyError::type_error(
@@ -1176,7 +1177,7 @@ pub fn get_awaitable_iter(w_obj: PyObjectRef, context: u32) -> PyResult {
     // iterators expose `__next__` on their type.
     let has_next = unsafe { pyre_object::generator::is_generator(w_res) }
         || crate::typedef::r#type(w_res)
-            .is_some_and(|w_type| unsafe { lookup_in_type(w_type, "__next__") }.is_some());
+            .is_some_and(|w_type| unsafe { lookup_in_type(w_type.as_ptr(), "__next__") }.is_some());
     if !has_next {
         return Err(PyError::type_error(format!(
             "__await__() returned non-iterator of type '{}'",
@@ -1202,14 +1203,21 @@ pub(crate) unsafe fn set_name(
         Some(t) => t,
         None => return Ok(()),
     };
-    let set_name_meth = match unsafe { lookup_in_type_where(w_valtype, "__set_name__") } {
+    let set_name_meth = match unsafe { lookup_in_type_where(w_valtype.as_ptr(), "__set_name__") } {
         Some(m) => m,
         None => return Ok(()),
     };
     // `space.get_and_call_function(w_meth, w_value, w_type, key)` — `w_value`
     // is the descriptor instance (bound as the receiver), and the call args
     // are `(owner, name)`: `__set_name__(self, owner, name)`.
-    match unsafe { get_and_call_function(set_name_meth, w_value, w_valtype, &[w_owner, w_name]) } {
+    match unsafe {
+        get_and_call_function(
+            set_name_meth,
+            w_value,
+            w_valtype.as_ptr(),
+            &[w_owner, w_name],
+        )
+    } {
         Ok(_) => Ok(()),
         Err(e) => {
             if !e.exc_object.is_null() {
@@ -1218,7 +1226,8 @@ pub(crate) unsafe fn set_name(
                 } else {
                     String::new()
                 };
-                let val_type_name = unsafe { pyre_object::w_type_get_name(w_valtype) }.to_string();
+                let val_type_name =
+                    unsafe { pyre_object::w_type_get_name(w_valtype.as_ptr()) }.to_string();
                 let owner_name = unsafe { pyre_object::w_type_get_name(w_owner) }.to_string();
                 let note = w_str_new(&format!(
                     "Error calling __set_name__ on '{val_type_name}' instance {name_repr} in '{owner_name}'"
@@ -1239,11 +1248,13 @@ pub(crate) unsafe fn set_name(
 pub(crate) fn dict_missing_or_key_error(obj: PyObjectRef, index: PyObjectRef) -> PyResult {
     if let Some(w_type_obj) = crate::typedef::r#type(obj) {
         let dict_type = crate::typedef::gettypeobject(&pyre_object::DICT_TYPE);
-        if dict_type.is_null() == false && std::ptr::eq(w_type_obj, dict_type) == false {
-            if let Some(w_missing) = unsafe { lookup_in_type(w_type_obj, "__missing__") } {
+        if dict_type.is_null() == false && std::ptr::eq(w_type_obj.as_ptr(), dict_type) == false {
+            if let Some(w_missing) = unsafe { lookup_in_type(w_type_obj.as_ptr(), "__missing__") } {
                 // dictmultiobject.py:166 space.get_and_call_function(
                 //     w_missing, self, w_key)
-                return unsafe { get_and_call_function(w_missing, obj, w_type_obj, &[index]) };
+                return unsafe {
+                    get_and_call_function(w_missing, obj, w_type_obj.as_ptr(), &[index])
+                };
             }
         }
     }
@@ -1333,8 +1344,8 @@ pub(crate) fn getitem_slot(obj: PyObjectRef, index: PyObjectRef) -> PyResult {
         // types).  Covers W_Root types like `re.Match` whose typedef
         // registers `__getitem__`.
         if let Some(w_type) = crate::typedef::r#type(obj) {
-            if let Some(method) = lookup_in_type_where(w_type, "__getitem__") {
-                return get_and_call_function(method, obj, w_type, &[index]);
+            if let Some(method) = lookup_in_type_where(w_type.as_ptr(), "__getitem__") {
+                return get_and_call_function(method, obj, w_type.as_ptr(), &[index]);
             }
         }
         Err(PyError::type_error(format!(
@@ -1667,8 +1678,8 @@ unsafe fn getitem_type(obj: PyObjectRef, index: PyObjectRef) -> PyResult {
     // .__getitem__(Color, 'RED')`.  `type` itself defines no `__getitem__`,
     // so an ordinary class still takes the `__class_getitem__` path below.
     if let Some(w_meta) = crate::typedef::r#type(obj) {
-        if let Some(method) = lookup_in_type_where(w_meta, "__getitem__") {
-            return get_and_call_function(method, obj, w_meta, &[index]);
+        if let Some(method) = lookup_in_type_where(w_meta.as_ptr(), "__getitem__") {
+            return get_and_call_function(method, obj, w_meta.as_ptr(), &[index]);
         }
     }
     // descroperation.py:362 — `type[X]` (the operand is exactly `type`) builds
@@ -2353,7 +2364,10 @@ pub(crate) fn range_iter_setstate_method(args: &[PyObjectRef]) -> PyResult {
             // CPython 3.14 `longrangeiter_setstate` requires an exact int,
             // then compares/clips it at arbitrary precision.
             let int_type = crate::typedef::gettypeobject(&pyre_object::INT_TYPE);
-            if !std::ptr::eq(crate::typedef::r#type(args[1]).unwrap_or(PY_NULL), int_type) {
+            if !std::ptr::eq(
+                crate::typedef::r#type(args[1]).map_or(PY_NULL, |p| p.as_ptr()),
+                int_type,
+            ) {
                 return Err(PyError::type_error(format!(
                     "state must be an int, not {}",
                     object_functionstr_type_name(args[1])
@@ -2437,7 +2451,7 @@ pub(crate) fn enumerate_reduce_method(args: &[PyObjectRef]) -> PyResult {
         pyre_object::gc_roots::pin_root(args[0]);
         let self_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let self_ = pyre_object::gc_roots::shadow_stack_get(self_slot);
-        let self_type = crate::typedef::r#type(self_).unwrap_or(pyre_object::PY_NULL);
+        let self_type = crate::typedef::r#type(self_).map_or(pyre_object::PY_NULL, |p| p.as_ptr());
         pyre_object::gc_roots::pin_root(self_type);
         let self_type_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let i64_index = pyre_object::functional::w_enumerate_get_index(self_);
@@ -2525,7 +2539,7 @@ pub(crate) fn reversed_reduce_method(args: &[PyObjectRef]) -> PyResult {
         pyre_object::gc_roots::pin_root(self_);
         let self_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let self_ = pyre_object::gc_roots::shadow_stack_get(self_slot);
-        let self_type = crate::typedef::r#type(self_).unwrap_or(pyre_object::PY_NULL);
+        let self_type = crate::typedef::r#type(self_).map_or(pyre_object::PY_NULL, |p| p.as_ptr());
         pyre_object::gc_roots::pin_root(self_type);
         let self_type_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let seq = pyre_object::functional::w_reversed_get_sequence(self_);
@@ -2665,7 +2679,7 @@ pub(crate) fn filter_reduce_method(args: &[PyObjectRef]) -> PyResult {
         pyre_object::gc_roots::pin_root(self_);
         let self_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let self_ = pyre_object::gc_roots::shadow_stack_get(self_slot);
-        let self_type = crate::typedef::r#type(self_).unwrap_or(pyre_object::PY_NULL);
+        let self_type = crate::typedef::r#type(self_).map_or(pyre_object::PY_NULL, |p| p.as_ptr());
         pyre_object::gc_roots::pin_root(self_type);
         let self_type_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let raw_predicate = pyre_object::functional::w_filter_get_predicate(self_);
@@ -2856,7 +2870,7 @@ pub(crate) fn map_reduce_method(args: &[PyObjectRef]) -> PyResult {
         pyre_object::gc_roots::pin_root(self_);
         let self_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let self_ = pyre_object::gc_roots::shadow_stack_get(self_slot);
-        let self_type = crate::typedef::r#type(self_).unwrap_or(pyre_object::PY_NULL);
+        let self_type = crate::typedef::r#type(self_).map_or(pyre_object::PY_NULL, |p| p.as_ptr());
         pyre_object::gc_roots::pin_root(self_type);
         let self_type_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let w_fun = pyre_object::functional::w_map_get_fun(self_);
@@ -2945,7 +2959,7 @@ pub(crate) fn zip_reduce_method(args: &[PyObjectRef]) -> PyResult {
         pyre_object::gc_roots::pin_root(self_);
         let self_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let self_ = pyre_object::gc_roots::shadow_stack_get(self_slot);
-        let self_type = crate::typedef::r#type(self_).unwrap_or(pyre_object::PY_NULL);
+        let self_type = crate::typedef::r#type(self_).map_or(pyre_object::PY_NULL, |p| p.as_ptr());
         pyre_object::gc_roots::pin_root(self_type);
         let self_type_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let w_iterators = pyre_object::functional::w_zip_get_iterators(self_);
@@ -3101,8 +3115,8 @@ pub(crate) fn setitem_slot(obj: PyObjectRef, index: PyObjectRef, value: PyObject
         // `getitem_slot`; covers native W_Root types like `memoryview`
         // whose typedef registers `__setitem__`.
         if let Some(w_type) = crate::typedef::r#type(obj) {
-            if let Some(method) = lookup_in_type_where(w_type, "__setitem__") {
-                return get_and_call_function(method, obj, w_type, &[index, value]);
+            if let Some(method) = lookup_in_type_where(w_type.as_ptr(), "__setitem__") {
+                return get_and_call_function(method, obj, w_type.as_ptr(), &[index, value]);
             }
         }
         Err(PyError::type_error(format!(
@@ -3853,8 +3867,8 @@ pub(crate) fn len_slot(obj: PyObjectRef) -> PyResult {
         // a class whose metaclass defines `__len__` (e.g. `EnumMeta.__len__`)
         // all dispatch correctly.
         if let Some(w_type) = crate::typedef::r#type(obj) {
-            if let Some(method) = lookup_in_type_where(w_type, "__len__") {
-                return get_and_call_function(method, obj, w_type, &[]);
+            if let Some(method) = lookup_in_type_where(w_type.as_ptr(), "__len__") {
+                return get_and_call_function(method, obj, w_type.as_ptr(), &[]);
             }
         }
         // Per-instance __len__ via the unified getattr path (live dict).
@@ -3911,7 +3925,7 @@ pub fn getdict(obj: PyObjectRef) -> PyObjectRef {
         let Some(w_type) = crate::typedef::r#type(obj) else {
             return PY_NULL;
         };
-        if unsafe { pyre_object::w_type_get_hasdict(w_type) } {
+        if unsafe { pyre_object::w_type_get_hasdict(w_type.as_ptr()) } {
             let existing = unsafe { pyre_object::bytesobject::w_bytes_getdict(obj) };
             if !existing.is_null() {
                 return existing;
@@ -3933,7 +3947,7 @@ pub fn getdict(obj: PyObjectRef) -> PyObjectRef {
         let Some(w_type) = crate::typedef::r#type(obj) else {
             return PY_NULL;
         };
-        if unsafe { pyre_object::w_type_get_hasdict(w_type) } {
+        if unsafe { pyre_object::w_type_get_hasdict(w_type.as_ptr()) } {
             let existing = unsafe { pyre_object::bytearrayobject::w_bytearray_getdict(obj) };
             if !existing.is_null() {
                 return existing;
@@ -3955,7 +3969,7 @@ pub fn getdict(obj: PyObjectRef) -> PyObjectRef {
         Some(tp) => tp,
         None => return pyre_object::PY_NULL,
     };
-    if unsafe { pyre_object::w_type_get_hasdict(w_type) } {
+    if unsafe { pyre_object::w_type_get_hasdict(w_type.as_ptr()) } {
         crate::objspace::std::mapdict::_obj_getdict(obj)
     } else {
         // W_Root.getdict default — return None
@@ -4103,10 +4117,10 @@ pub fn setdict(obj: PyObjectRef, w_dict: PyObjectRef) -> Result<(), PyError> {
             ));
         }
     };
-    if unsafe { pyre_object::w_type_get_hasdict(w_type) } {
+    if unsafe { pyre_object::w_type_get_hasdict(w_type.as_ptr()) } {
         crate::objspace::std::mapdict::_obj_setdict(obj, w_dict)
     } else {
-        let tp_name = unsafe { pyre_object::w_type_get_name(w_type) };
+        let tp_name = unsafe { pyre_object::w_type_get_name(w_type.as_ptr()) };
         Err(PyError::type_error(format!(
             "attribute '__dict__' of '{}' objects is not writable",
             tp_name,
@@ -4146,7 +4160,7 @@ pub fn getweakref(obj: PyObjectRef) -> Option<PyObjectRef> {
     }
     if unsafe { pyre_object::bytesobject::is_bytes(obj) } {
         if crate::typedef::r#type(obj)
-            .is_some_and(|w_type| unsafe { pyre_object::w_type_get_weakrefable(w_type) })
+            .is_some_and(|w_type| unsafe { pyre_object::w_type_get_weakrefable(w_type.as_ptr()) })
         {
             let lifeline = unsafe { pyre_object::bytesobject::w_bytes_getweakref(obj) };
             return (!lifeline.is_null()).then_some(lifeline);
@@ -4155,7 +4169,7 @@ pub fn getweakref(obj: PyObjectRef) -> Option<PyObjectRef> {
     }
     if unsafe { pyre_object::bytearrayobject::is_bytearray(obj) } {
         if crate::typedef::r#type(obj)
-            .is_some_and(|w_type| unsafe { pyre_object::w_type_get_weakrefable(w_type) })
+            .is_some_and(|w_type| unsafe { pyre_object::w_type_get_weakrefable(w_type.as_ptr()) })
         {
             let lifeline = unsafe { pyre_object::bytearrayobject::w_bytearray_getweakref(obj) };
             return (!lifeline.is_null()).then_some(lifeline);
@@ -4163,7 +4177,7 @@ pub fn getweakref(obj: PyObjectRef) -> Option<PyObjectRef> {
         return None;
     }
     let w_type = crate::typedef::r#type(obj)?;
-    if unsafe { pyre_object::w_type_get_weakrefable(w_type) } {
+    if unsafe { pyre_object::w_type_get_weakrefable(w_type.as_ptr()) } {
         crate::objspace::std::mapdict::getweakref(obj)
     } else {
         None
@@ -4186,7 +4200,7 @@ pub fn setweakref(obj: PyObjectRef, weakreflifeline: PyObjectRef) -> Result<(), 
     }
     if unsafe { pyre_object::bytesobject::is_bytes(obj) } {
         if crate::typedef::r#type(obj)
-            .is_some_and(|w_type| unsafe { pyre_object::w_type_get_weakrefable(w_type) })
+            .is_some_and(|w_type| unsafe { pyre_object::w_type_get_weakrefable(w_type.as_ptr()) })
         {
             unsafe { pyre_object::bytesobject::w_bytes_setweakref(obj, weakreflifeline) };
             return Ok(());
@@ -4194,7 +4208,7 @@ pub fn setweakref(obj: PyObjectRef, weakreflifeline: PyObjectRef) -> Result<(), 
     }
     if unsafe { pyre_object::bytearrayobject::is_bytearray(obj) } {
         if crate::typedef::r#type(obj)
-            .is_some_and(|w_type| unsafe { pyre_object::w_type_get_weakrefable(w_type) })
+            .is_some_and(|w_type| unsafe { pyre_object::w_type_get_weakrefable(w_type.as_ptr()) })
         {
             unsafe { pyre_object::bytearrayobject::w_bytearray_setweakref(obj, weakreflifeline) };
             return Ok(());
@@ -4208,11 +4222,11 @@ pub fn setweakref(obj: PyObjectRef, weakreflifeline: PyObjectRef) -> Result<(), 
             ));
         }
     };
-    if unsafe { pyre_object::w_type_get_weakrefable(w_type) } {
+    if unsafe { pyre_object::w_type_get_weakrefable(w_type.as_ptr()) } {
         crate::objspace::std::mapdict::setweakref(obj, weakreflifeline);
         Ok(())
     } else {
-        let tp_name = unsafe { pyre_object::w_type_get_name(w_type) };
+        let tp_name = unsafe { pyre_object::w_type_get_name(w_type.as_ptr()) };
         Err(PyError::type_error(format!(
             "cannot create weak reference to '{}' object",
             tp_name,
@@ -4233,7 +4247,7 @@ pub fn delweakref(obj: PyObjectRef) {
     }
     if unsafe { pyre_object::bytesobject::is_bytes(obj) } {
         if crate::typedef::r#type(obj)
-            .is_some_and(|w_type| unsafe { pyre_object::w_type_get_weakrefable(w_type) })
+            .is_some_and(|w_type| unsafe { pyre_object::w_type_get_weakrefable(w_type.as_ptr()) })
         {
             unsafe { pyre_object::bytesobject::w_bytes_setweakref(obj, PY_NULL) };
             return;
@@ -4241,7 +4255,7 @@ pub fn delweakref(obj: PyObjectRef) {
     }
     if unsafe { pyre_object::bytearrayobject::is_bytearray(obj) } {
         if crate::typedef::r#type(obj)
-            .is_some_and(|w_type| unsafe { pyre_object::w_type_get_weakrefable(w_type) })
+            .is_some_and(|w_type| unsafe { pyre_object::w_type_get_weakrefable(w_type.as_ptr()) })
         {
             unsafe { pyre_object::bytearrayobject::w_bytearray_setweakref(obj, PY_NULL) };
             return;
@@ -4251,7 +4265,7 @@ pub fn delweakref(obj: PyObjectRef) {
         Some(tp) => tp,
         None => return,
     };
-    if unsafe { pyre_object::w_type_get_weakrefable(w_type) } {
+    if unsafe { pyre_object::w_type_get_weakrefable(w_type.as_ptr()) } {
         crate::objspace::std::mapdict::delweakref(obj);
     }
 }
@@ -4339,7 +4353,7 @@ fn getattr_str_impl(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyResul
             } else if is_instance(bound_obj) {
                 w_instance_get_type(bound_obj)
             } else if let Some(cls) = crate::typedef::r#type(bound_obj) {
-                cls
+                cls.as_ptr()
             } else {
                 return Err(PyError::type_error("super: bad obj type"));
             };
@@ -4663,7 +4677,7 @@ fn getattr_str_impl(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyResul
     // `__getattr__` (the tail below).
     unsafe {
         if is_module(obj) {
-            let w_type = crate::typedef::r#type(obj).unwrap_or(PY_NULL);
+            let w_type = crate::typedef::r#type(obj).map_or(PY_NULL, |p| p.as_ptr());
             // module.py Module.descr_getattribute is the default module slot
             // inlined below.  A retagged module may replace that slot (for
             // example importlib.util._LazyModule), in which case space.getattr
@@ -4754,7 +4768,7 @@ fn getattr_str_impl(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyResul
                     // (`__name__` / `__qualname__` / `__code__` / `__doc__` /
                     // `__defaults__` / `__annotations__` / …).
                     let on_method_type = crate::typedef::r#type(obj)
-                        .map(|t| lookup_in_type_where(t, name).is_some())
+                        .map(|t| lookup_in_type_where(t.as_ptr(), name).is_some())
                         .unwrap_or(false);
                     if !on_method_type {
                         let func = pyre_object::function::w_method_get_func(obj);
@@ -4889,16 +4903,16 @@ fn getattr_str_impl(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyResul
             // here; the bare `object.__getattribute__` slot runs the terminal
             // lookup without re-dispatching to the override.
             if let Some(w_metatype) = crate::typedef::r#type(obj) {
-                if let Some(slot) = getattribute_if_not_from_object(w_metatype) {
+                if let Some(slot) = getattribute_if_not_from_object(w_metatype.as_ptr()) {
                     let name_obj = w_str_new(name);
                     // objspace.py:666 — bind the metaclass `__getattribute__`
                     // through `__get__` and call it with the attribute name.
-                    match get_and_call_function(slot, obj, w_metatype, &[name_obj]) {
+                    match get_and_call_function(slot, obj, w_metatype.as_ptr(), &[name_obj]) {
                         Ok(v) => return Ok(v),
                         Err(e) if e.kind == PyErrorKind::AttributeError => {
                             return type_getattr_hook_or_err(
                                 obj,
-                                &[Some(w_metatype), None],
+                                &[Some(w_metatype.as_ptr()), None],
                                 name,
                                 e,
                                 call_getattr,
@@ -4932,7 +4946,7 @@ fn getattr_str_impl(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyResul
             Err(e) if e.kind == PyErrorKind::AttributeError => e,
             Err(e) => return Err(e),
         };
-        let w_type = crate::typedef::r#type(obj).unwrap_or(PY_NULL);
+        let w_type = crate::typedef::r#type(obj).map_or(PY_NULL, |p| p.as_ptr());
         return unsafe { instance_getattr_hook_or_err(w_type, obj, name, err) };
     }
 
@@ -5035,7 +5049,8 @@ unsafe fn getattr_surrogate(obj: PyObjectRef, w_name: PyObjectRef, name: &Wtf8) 
                 // hook through `__get__` before calling it, so a
                 // staticmethod / classmethod / custom-descriptor `__getattr__`
                 // is handled.  The hook's result or its own exception is final.
-                let w_objtype = crate::typedef::r#type(obj).unwrap_or(std::ptr::null_mut());
+                let w_objtype =
+                    crate::typedef::r#type(obj).map_or(std::ptr::null_mut(), |p| p.as_ptr());
                 if !w_objtype.is_null() {
                     if let Some(getattr_fn) = lookup_in_type_where(w_objtype, "__getattr__") {
                         return get_and_call_function(getattr_fn, obj, w_objtype, &[w_name]);
@@ -5075,7 +5090,7 @@ pub(crate) unsafe fn object_getattribute_surrogate(
             // applies: a metatype data descriptor wins first, then the type's
             // own MRO value bound through `__get__(None, type)`, then a
             // metatype non-data descriptor.
-            let metatype = crate::typedef::r#type(obj).unwrap_or(std::ptr::null_mut());
+            let metatype = crate::typedef::r#type(obj).map_or(std::ptr::null_mut(), |p| p.as_ptr());
             let w_descr = if metatype.is_null() {
                 None
             } else {
@@ -5117,7 +5132,7 @@ pub(crate) unsafe fn object_getattribute_surrogate(
         // `setattr(cls, '\udc80', descr)`, so a data descriptor's
         // `__get__` takes priority over the instance dict, and a non-data
         // descriptor binds after it (descroperation.py:88-112).
-        let w_type = crate::typedef::r#type(obj).unwrap_or(std::ptr::null_mut());
+        let w_type = crate::typedef::r#type(obj).map_or(std::ptr::null_mut(), |p| p.as_ptr());
         let w_descr = if w_type.is_null() {
             None
         } else {
@@ -5169,7 +5184,7 @@ unsafe fn setattr_surrogate(
         let w_type = if is_instance(obj) {
             w_instance_get_type(obj)
         } else {
-            crate::typedef::r#type(obj).unwrap_or(PY_NULL)
+            crate::typedef::r#type(obj).map_or(PY_NULL, |p| p.as_ptr())
         };
         if !w_type.is_null() {
             if let Some(sa) = setattr_if_not_from_object(w_type) {
@@ -5201,7 +5216,7 @@ pub(crate) unsafe fn object_setattr_surrogate(
         let w_type = if is_instance(obj) {
             w_instance_get_type(obj)
         } else {
-            crate::typedef::r#type(obj).unwrap_or(std::ptr::null_mut())
+            crate::typedef::r#type(obj).map_or(std::ptr::null_mut(), |p| p.as_ptr())
         };
         if !w_type.is_null() {
             if let Some(descr) = lookup_in_type_wtf8(w_type, name) {
@@ -5263,7 +5278,7 @@ unsafe fn delattr_surrogate(obj: PyObjectRef, w_name: PyObjectRef, name: &Wtf8) 
         let w_type = if is_instance(obj) {
             w_instance_get_type(obj)
         } else {
-            crate::typedef::r#type(obj).unwrap_or(PY_NULL)
+            crate::typedef::r#type(obj).map_or(PY_NULL, |p| p.as_ptr())
         };
         if !w_type.is_null() {
             if let Some(da) = lookup_in_type(w_type, "__delattr__") {
@@ -5295,7 +5310,7 @@ pub(crate) unsafe fn object_delattr_surrogate(
         let w_type = if is_instance(obj) {
             w_instance_get_type(obj)
         } else {
-            crate::typedef::r#type(obj).unwrap_or(std::ptr::null_mut())
+            crate::typedef::r#type(obj).map_or(std::ptr::null_mut(), |p| p.as_ptr())
         };
         if !w_type.is_null() {
             if let Some(descr) = lookup_in_type_wtf8(w_type, name) {
@@ -5345,7 +5360,7 @@ pub(crate) unsafe fn object_delattr_surrogate(
 fn attr_error_wtf8(obj: PyObjectRef, name: &Wtf8) -> PyError {
     let tp_name = unsafe {
         match crate::typedef::r#type(obj) {
-            Some(tp) => pyre_object::w_type_get_name(tp).to_string(),
+            Some(tp) => pyre_object::w_type_get_name(tp.as_ptr()).to_string(),
             None => (*(*obj).ob_type).name.to_string(),
         }
     };
@@ -6035,14 +6050,14 @@ fn object_getattr_miss(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyRe
     unsafe {
         if is_property(obj) {
             if let Some(w_type) = crate::typedef::r#type(obj) {
-                let w_descr = lookup_in_type_where(w_type, name);
+                let w_descr = lookup_in_type_where(w_type.as_ptr(), name);
                 if let Some(descr) = w_descr {
                     if is_data_descr(descr) {
-                        match get(descr, obj, w_type) {
+                        match get(descr, obj, w_type.as_ptr()) {
                             Ok(Some(result)) => return Ok(result),
                             Ok(None) => {}
                             Err(e) if e.kind == PyErrorKind::AttributeError => {
-                                return instance_getattr_hook_or_err(w_type, obj, name, e);
+                                return instance_getattr_hook_or_err(w_type.as_ptr(), obj, name, e);
                             }
                             Err(e) => return Err(e),
                         }
@@ -6056,13 +6071,13 @@ fn object_getattr_miss(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyRe
                 }
                 if let Some(descr) = w_descr {
                     if crate::is_function(descr) {
-                        return Ok(pyre_object::w_method_new(descr, obj, w_type));
+                        return Ok(pyre_object::w_method_new(descr, obj, w_type.as_ptr()));
                     }
-                    match get(descr, obj, w_type) {
+                    match get(descr, obj, w_type.as_ptr()) {
                         Ok(Some(result)) => return Ok(result),
                         Ok(None) => {}
                         Err(e) if e.kind == PyErrorKind::AttributeError => {
-                            return instance_getattr_hook_or_err(w_type, obj, name, e);
+                            return instance_getattr_hook_or_err(w_type.as_ptr(), obj, name, e);
                         }
                         Err(e) => return Err(e),
                     }
@@ -6085,15 +6100,17 @@ fn object_getattr_miss(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyRe
         // types: a data descriptor wins, then the instance dict, then a
         // non-data descriptor / class var. Exact builtins carry no instance
         // dict (`hasdict` false) and take the direct class-attr fast path.
-        if unsafe { pyre_object::w_type_get_hasdict(w_type) } {
-            let w_descr = unsafe { lookup_in_type_where(w_type, name) };
+        if unsafe { pyre_object::w_type_get_hasdict(w_type.as_ptr()) } {
+            let w_descr = unsafe { lookup_in_type_where(w_type.as_ptr(), name) };
             if let Some(descr) = w_descr {
                 if unsafe { is_data_descr(descr) } {
-                    match unsafe { get(descr, obj, w_type) } {
+                    match unsafe { get(descr, obj, w_type.as_ptr()) } {
                         Ok(Some(result)) => return Ok(result),
                         Ok(None) => {}
                         Err(e) if e.kind == crate::PyErrorKind::AttributeError => {
-                            return unsafe { instance_getattr_hook_or_err(w_type, obj, name, e) };
+                            return unsafe {
+                                instance_getattr_hook_or_err(w_type.as_ptr(), obj, name, e)
+                            };
                         }
                         Err(e) => return Err(e),
                     }
@@ -6106,11 +6123,13 @@ fn object_getattr_miss(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyRe
                 }
             }
             if let Some(method) = w_descr {
-                match unsafe { get(method, obj, w_type) } {
+                match unsafe { get(method, obj, w_type.as_ptr()) } {
                     Ok(Some(result)) => return Ok(result),
                     Ok(None) => {}
                     Err(e) if e.kind == crate::PyErrorKind::AttributeError => {
-                        return unsafe { instance_getattr_hook_or_err(w_type, obj, name, e) };
+                        return unsafe {
+                            instance_getattr_hook_or_err(w_type.as_ptr(), obj, name, e)
+                        };
                     }
                     Err(e) => return Err(e),
                 }
@@ -6124,7 +6143,7 @@ fn object_getattr_miss(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyRe
                             crate::function_get_code(method) as pyre_object::PyObjectRef
                         )
                 } {
-                    return Ok(pyre_object::w_method_new(method, obj, w_type));
+                    return Ok(pyre_object::w_method_new(method, obj, w_type.as_ptr()));
                 }
                 return Ok(method);
             }
@@ -6132,11 +6151,11 @@ fn object_getattr_miss(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyRe
             // matched.  Fall through to the shared resolvers below (exception
             // typed slots, function/code attributes, the generic type-dict
             // path) — the terminal `__getattr__` hook runs at the final miss.
-        } else if let Some(method) = unsafe { lookup_in_type_where(w_type, name) } {
+        } else if let Some(method) = unsafe { lookup_in_type_where(w_type.as_ptr(), name) } {
             if unsafe { crate::is_function(method) } {
-                return Ok(pyre_object::w_method_new(method, obj, w_type));
+                return Ok(pyre_object::w_method_new(method, obj, w_type.as_ptr()));
             }
-            if let Some(result) = unsafe { get(method, obj, w_type)? } {
+            if let Some(result) = unsafe { get(method, obj, w_type.as_ptr())? } {
                 return Ok(result);
             }
             return Ok(method);
@@ -6709,7 +6728,7 @@ fn object_getattr_miss(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyRe
     // objectobject.py:133-134 descr_get___class__ → space.type(w_obj)
     if name == "__class__" {
         if let Some(tp) = crate::typedef::r#type(obj) {
-            return Ok(tp);
+            return Ok(tp.as_ptr());
         }
     }
 
@@ -6745,7 +6764,7 @@ fn object_getattr_miss(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyRe
     // `CAN_BE_TAGGED` (default false).
     let w_class =
         if pyre_object::tagged_int::CAN_BE_TAGGED && pyre_object::tagged_int::is_tagged_int(obj) {
-            crate::typedef::r#type(obj).unwrap_or(std::ptr::null_mut())
+            crate::typedef::r#type(obj).map_or(std::ptr::null_mut(), |p| p.as_ptr())
         } else {
             unsafe { (*obj).w_class }
         };
@@ -6771,7 +6790,7 @@ fn object_getattr_miss(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyRe
         // (a tagged immediate has no `ob_type` slot to deref).
         let w_type = crate::typedef::r#type(obj);
         let tp_name = match w_type {
-            Some(tp) => pyre_object::w_type_get_name(tp).to_string(),
+            Some(tp) => pyre_object::w_type_get_name(tp.as_ptr()).to_string(),
             None => "NULL".to_string(),
         };
         let e = PyError::attribute_error_with_context(
@@ -6785,7 +6804,7 @@ fn object_getattr_miss(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyRe
         // the AttributeError unchanged.
         if call_getattr {
             if let Some(w_type) = w_type {
-                return instance_getattr_hook_or_err(w_type, obj, name, e);
+                return instance_getattr_hook_or_err(w_type.as_ptr(), obj, name, e);
             }
         }
         Err(e)
@@ -6815,7 +6834,7 @@ pub(crate) fn space_int(obj: PyObjectRef) -> Result<PyObjectRef, PyError> {
     let w_result = crate::builtins::call_and_check(method, &[obj])?;
     // baseobjspace.py:326-327 — an exact int returns directly.
     let w_int = crate::typedef::gettypefor(&pyre_object::INT_TYPE).map_or(PY_NULL, |p| p.as_ptr());
-    if crate::typedef::r#type(w_result).unwrap_or(PY_NULL) == w_int {
+    if crate::typedef::r#type(w_result).map_or(PY_NULL, |p| p.as_ptr()) == w_int {
         return Ok(w_result);
     }
     // baseobjspace.py:328-336 — a strict int subclass is accepted for now,
@@ -7150,7 +7169,7 @@ pub fn charbuf_w(obj: PyObjectRef) -> Result<&'static [u8], PyError> {
 /// PyPy equivalent: `space.lookup(w_obj, name)`.
 pub unsafe fn lookup(obj: PyObjectRef, name: &str) -> Option<PyObjectRef> {
     let w_type = crate::typedef::r#type(obj)?;
-    lookup_in_type(w_type, name)
+    lookup_in_type(w_type.as_ptr(), name)
 }
 
 /// `_PyObject_LookupSpecial(obj, name)` — resolve a special method on the
@@ -7170,7 +7189,7 @@ pub unsafe fn lookup_special(
     let Some(w_type) = crate::typedef::r#type(obj) else {
         return Ok(Some(descr));
     };
-    match get(descr, obj, w_type)? {
+    match get(descr, obj, w_type.as_ptr())? {
         Some(bound) => Ok(Some(bound)),
         None => Ok(Some(descr)),
     }
@@ -7745,7 +7764,7 @@ pub(crate) unsafe fn lookup_in_type_where(w_type: PyObjectRef, name: &str) -> Op
 /// `w_obj` must be a valid, non-null `PyObject`.
 pub unsafe fn getfulltypename(w_obj: PyObjectRef) -> String {
     match crate::typedef::r#type(w_obj) {
-        Some(w_type) => getfulltypename_of_type(w_type),
+        Some(w_type) => getfulltypename_of_type(w_type.as_ptr()),
         None => "object".to_string(),
     }
 }
@@ -7842,7 +7861,7 @@ pub unsafe fn load_method_fast_path(
     // `self` here; builtin functions, staticmethod / classmethod / property
     // / member / type descriptors all carry the `False` default.
     let w_descr_type = crate::typedef::r#type(w_descr)?;
-    if !pyre_object::typeobject::w_type_get_flag_method_descriptor(w_descr_type) {
+    if !pyre_object::typeobject::w_type_get_flag_method_descriptor(w_descr_type.as_ptr()) {
         return None;
     }
     // callmethod.py:66-67 `w_value = w_obj.getdictvalue(space, name)`: a
@@ -8285,7 +8304,7 @@ pub unsafe fn isinstance_w(w_obj: PyObjectRef, w_cls: PyObjectRef) -> bool {
     let w_obj_type = if is_instance(w_obj) {
         w_instance_get_type(w_obj)
     } else {
-        crate::typedef::r#type(w_obj).unwrap_or(pyre_object::PY_NULL)
+        crate::typedef::r#type(w_obj).map_or(pyre_object::PY_NULL, |p| p.as_ptr())
     };
     if w_obj_type.is_null() {
         return false;
@@ -8364,7 +8383,7 @@ pub fn descr_call_mismatch(
         "NoneType".to_string()
     } else {
         match crate::typedef::r#type(w_obj) {
-            Some(tp) => unsafe { pyre_object::w_type_get_name(tp).to_string() },
+            Some(tp) => unsafe { pyre_object::w_type_get_name(tp.as_ptr()).to_string() },
             None => unsafe { (*(*w_obj).ob_type).name.to_string() },
         }
     };
@@ -8422,7 +8441,7 @@ unsafe fn descr_has_delete(descr: PyObjectRef) -> bool {
         return true;
     }
     if let Some(descr_type) = crate::typedef::r#type(descr) {
-        return lookup_in_type_where(descr_type, "__delete__").is_some();
+        return lookup_in_type_where(descr_type.as_ptr(), "__delete__").is_some();
     }
     false
 }
@@ -8434,7 +8453,7 @@ unsafe fn descr_has_delete(descr: PyObjectRef) -> bool {
 #[majit_macros::dont_look_inside]
 unsafe fn descr_not_settable_error(descr: PyObjectRef) -> crate::PyError {
     let tp_name = match crate::typedef::r#type(descr) {
-        Some(tp) => pyre_object::w_type_get_name(tp).to_string(),
+        Some(tp) => pyre_object::w_type_get_name(tp.as_ptr()).to_string(),
         None => (*(*descr).ob_type).name.to_string(),
     };
     crate::PyError::new(
@@ -8556,7 +8575,7 @@ pub(crate) unsafe fn get(
 
     // General __get__: look up __get__ on the descriptor's own type MRO
     if let Some(descr_type) = crate::typedef::r#type(descr) {
-        if let Some(get_fn) = lookup_in_type_where(descr_type, "__get__") {
+        if let Some(get_fn) = lookup_in_type_where(descr_type.as_ptr(), "__get__") {
             if !get_fn.is_null() {
                 let visible_obj = if obj.is_null() { w_none() } else { obj };
                 let result =
@@ -8644,7 +8663,7 @@ unsafe fn set(
     // the type through `crate::typedef::r#type` rather than the
     // `is_instance` branch.
     let descr_type = if pyre_object::typedef::is_getset_property(descr) {
-        crate::typedef::r#type(descr).unwrap_or(std::ptr::null_mut())
+        crate::typedef::r#type(descr).map_or(std::ptr::null_mut(), |p| p.as_ptr())
     } else if is_instance(descr) {
         w_instance_get_type(descr)
     } else {
@@ -8711,7 +8730,7 @@ unsafe fn delete(descr: PyObjectRef, obj: PyObjectRef) -> Result<(), crate::PyEr
     // shape as `set` above (resolve type through `r#type` so non-
     // INSTANCE_TYPE descriptors like `GetSetProperty` are reached).
     let descr_type = if pyre_object::typedef::is_getset_property(descr) {
-        crate::typedef::r#type(descr).unwrap_or(std::ptr::null_mut())
+        crate::typedef::r#type(descr).map_or(std::ptr::null_mut(), |p| p.as_ptr())
     } else if is_instance(descr) {
         w_instance_get_type(descr)
     } else {
@@ -8773,9 +8792,9 @@ pub(crate) fn descr_set___class__(w_obj: PyObjectRef, w_newcls: PyObjectRef) -> 
         // typeobject.py:125-129 Layout.expand() compares 5-tuple:
         //   (typedef, newslotnames, base_layout, hasdict, weakrefable)
         let layouts_compatible = pyre_object::typeobject::Layout::expands_equal(
-            pyre_object::w_type_get_layout_ptr(w_oldcls),
-            pyre_object::w_type_get_hasdict(w_oldcls),
-            pyre_object::w_type_get_weakrefable(w_oldcls),
+            pyre_object::w_type_get_layout_ptr(w_oldcls.as_ptr()),
+            pyre_object::w_type_get_hasdict(w_oldcls.as_ptr()),
+            pyre_object::w_type_get_weakrefable(w_oldcls.as_ptr()),
             pyre_object::w_type_get_layout_ptr(w_newcls),
             pyre_object::w_type_get_hasdict(w_newcls),
             pyre_object::w_type_get_weakrefable(w_newcls),
@@ -8783,7 +8802,7 @@ pub(crate) fn descr_set___class__(w_obj: PyObjectRef, w_newcls: PyObjectRef) -> 
         if !layouts_compatible {
             return Err(crate::PyError::type_error(format!(
                 "__class__ assignment: '{}' object layout differs from '{}'",
-                pyre_object::w_type_get_name(w_oldcls),
+                pyre_object::w_type_get_name(w_oldcls.as_ptr()),
                 pyre_object::w_type_get_name(w_newcls),
             )));
         }
@@ -8824,9 +8843,10 @@ pub fn setattr_str(obj: PyObjectRef, name: &str, value: PyObjectRef) -> PyResult
             // (e.g. structseq tuple subclasses) may install a non-default
             // __setattr__; only a real override (≠ object.__setattr__)
             // needs invoking — the default terminal path is object_setattr.
-            if let Some(sa) = setattr_if_not_from_object(w_type) {
+            if let Some(sa) = setattr_if_not_from_object(w_type.as_ptr()) {
                 let w_name = w_str_new(name);
-                return get_and_call_function(sa, obj, w_type, &[w_name, value]).map(|_| w_none());
+                return get_and_call_function(sa, obj, w_type.as_ptr(), &[w_name, value])
+                    .map(|_| w_none());
             }
         }
     }
@@ -8853,7 +8873,7 @@ pub fn object_setattr(obj: PyObjectRef, name: &str, value: PyObjectRef) -> PyRes
             // For type objects pyre stores attributes in the type's own
             // dict below; the descriptor walk uses the metaclass MRO so
             // metatype-installed setters (e.g. on `type`) still fire.
-            crate::typedef::r#type(obj).unwrap_or(std::ptr::null_mut())
+            crate::typedef::r#type(obj).map_or(std::ptr::null_mut(), |p| p.as_ptr())
         };
         if w_type.is_null() {
             None
@@ -9050,7 +9070,8 @@ pub fn object_setattr(obj: PyObjectRef, name: &str, value: PyObjectRef) -> PyRes
                 // OR an instance whose type derives from `BaseException`,
                 // and always flips `suppress_context` to True.
                 if !unsafe { pyre_object::is_none(value) } {
-                    let value_type = crate::typedef::r#type(value).unwrap_or(pyre_object::PY_NULL);
+                    let value_type =
+                        crate::typedef::r#type(value).map_or(pyre_object::PY_NULL, |p| p.as_ptr());
                     if value_type.is_null() || !unsafe { exception_is_valid_class_w(value_type) } {
                         return Err(PyError::type_error(
                             "exception cause must be None or derive from BaseException",
@@ -9067,7 +9088,8 @@ pub fn object_setattr(obj: PyObjectRef, name: &str, value: PyObjectRef) -> PyRes
                 // `interp_exceptions.py:183-190 descr_setcontext` — None
                 // OR an instance whose type derives from `BaseException`.
                 if !unsafe { pyre_object::is_none(value) } {
-                    let value_type = crate::typedef::r#type(value).unwrap_or(pyre_object::PY_NULL);
+                    let value_type =
+                        crate::typedef::r#type(value).map_or(pyre_object::PY_NULL, |p| p.as_ptr());
                     if value_type.is_null() || !unsafe { exception_is_valid_class_w(value_type) } {
                         return Err(PyError::type_error(
                             "exception context must be None or derive from BaseException",
@@ -9392,10 +9414,10 @@ pub unsafe fn exception_attr_slot_fold(
     let w_type = crate::typedef::r#type(obj)?;
     // Any hit precedes the hard-coded exception arm.  The version-tag guard
     // below pins this miss across later heap-subclass mutations.
-    if unsafe { lookup_in_type_where(w_type, name) }.is_some() {
+    if unsafe { lookup_in_type_where(w_type.as_ptr(), name) }.is_some() {
         return None;
     }
-    let version_tag = unsafe { w_type_version_tag(w_type) };
+    let version_tag = unsafe { w_type_version_tag(w_type.as_ptr()) };
     if version_tag == 0 {
         return None;
     }
@@ -9432,7 +9454,7 @@ pub unsafe fn exception_attr_slot_fold(
             return None;
         }
     }
-    Some((slot, kind, w_type, version_tag, stored))
+    Some((slot, kind, w_type.as_ptr(), version_tag, stored))
 }
 
 /// `pypy/module/exceptions/interp_exceptions.py:156-157
@@ -9501,7 +9523,7 @@ fn raiseattrerror(obj: PyObjectRef, name: &str, w_descr: Option<PyObjectRef>) ->
     if w_descr.is_some() {
         let tp_name = unsafe {
             match crate::typedef::r#type(obj) {
-                Some(tp) => pyre_object::w_type_get_name(tp).to_string(),
+                Some(tp) => pyre_object::w_type_get_name(tp.as_ptr()).to_string(),
                 None => (*(*obj).ob_type).name.to_string(),
             }
         };
@@ -9517,7 +9539,7 @@ fn raiseattrerror(obj: PyObjectRef, name: &str, w_descr: Option<PyObjectRef>) ->
             format!("type object '{}'", pyre_object::w_type_get_name(obj))
         } else {
             let tp_name = match crate::typedef::r#type(obj) {
-                Some(tp) => pyre_object::w_type_get_name(tp).to_string(),
+                Some(tp) => pyre_object::w_type_get_name(tp.as_ptr()).to_string(),
                 None => (*(*obj).ob_type).name.to_string(),
             };
             format!("'{}' object", tp_name)
@@ -9552,12 +9574,13 @@ pub fn delattr_str(obj: PyObjectRef, name: &str) -> PyResult {
             // regardless of receiver kind.  This includes a module retagged
             // to a subclass as well as a type receiver whose metaclass
             // customises deletion.
-            if let Some(da) = lookup_in_type(w_type, "__delattr__") {
+            if let Some(da) = lookup_in_type(w_type.as_ptr(), "__delattr__") {
                 let is_default = lookup_in_type(crate::typedef::w_object(), "__delattr__")
                     .is_some_and(|d| std::ptr::eq(da, d));
                 if !is_default {
                     let w_name = w_str_new(name);
-                    return get_and_call_function(da, obj, w_type, &[w_name]).map(|_| w_none());
+                    return get_and_call_function(da, obj, w_type.as_ptr(), &[w_name])
+                        .map(|_| w_none());
                 }
             }
         }
@@ -9579,7 +9602,7 @@ pub fn object_delattr(obj: PyObjectRef, name: &str) -> PyResult {
         let w_type = if is_instance(obj) {
             w_instance_get_type(obj)
         } else {
-            crate::typedef::r#type(obj).unwrap_or(std::ptr::null_mut())
+            crate::typedef::r#type(obj).map_or(std::ptr::null_mut(), |p| p.as_ptr())
         };
         if w_type.is_null() {
             None
@@ -9942,7 +9965,7 @@ pub fn callable_w(obj: PyObjectRef) -> bool {
             || pyre_object::is_method(obj)
             || pyre_object::function::is_staticmethod(obj)
             || crate::typedef::r#type(obj)
-                .and_then(|t| lookup_in_type(t, "__call__"))
+                .and_then(|t| lookup_in_type(t.as_ptr(), "__call__"))
                 .is_some()
     }
 }
@@ -10059,7 +10082,7 @@ pub fn iterator_greenkey(w_iterable: PyObjectRef) -> PyObjectRef {
     if w_iterable.is_null() {
         return pyre_object::PY_NULL;
     }
-    crate::typedef::r#type(w_iterable).unwrap_or(pyre_object::PY_NULL)
+    crate::typedef::r#type(w_iterable).map_or(pyre_object::PY_NULL, |p| p.as_ptr())
 }
 
 /// pypy/interpreter/baseobjspace.py:29-32
@@ -10278,7 +10301,7 @@ pub fn length_hint(w_obj: PyObjectRef, default: i64) -> Result<i64, crate::PyErr
     // `__getattr__` hook, so the lookup stays type-MRO-faithful.  A user-class
     // instance (is_instance) is excluded entirely so its instance dict is
     // never consulted; a type miss there takes the default.
-    let w_type = crate::typedef::r#type(w_obj).unwrap_or(std::ptr::null_mut());
+    let w_type = crate::typedef::r#type(w_obj).map_or(std::ptr::null_mut(), |p| p.as_ptr());
     let w_descr = if w_type.is_null() {
         None
     } else {
@@ -10427,7 +10450,7 @@ pub fn space_index(obj: PyObjectRef) -> Result<PyObjectRef, PyError> {
     };
     let w_result = crate::builtins::call_and_check(method, &[obj])?;
     let w_int = crate::typedef::gettypefor(&pyre_object::INT_TYPE).map_or(PY_NULL, |p| p.as_ptr());
-    if crate::typedef::r#type(w_result).unwrap_or(PY_NULL) == w_int {
+    if crate::typedef::r#type(w_result).map_or(PY_NULL, |p| p.as_ptr()) == w_int {
         return Ok(w_result);
     }
     if unsafe { pyre_object::is_bool(w_result) || pyre_object::pyobject::is_int_or_long(w_result) }
@@ -11047,7 +11070,7 @@ fn object_functionstr_text_w(w_obj: PyObjectRef) -> Result<String, crate::PyErro
 pub(crate) fn object_functionstr_type_name(w_obj: PyObjectRef) -> String {
     unsafe {
         match crate::typedef::r#type(w_obj) {
-            Some(tp) => pyre_object::w_type_get_name(tp).to_string(),
+            Some(tp) => pyre_object::w_type_get_name(tp.as_ptr()).to_string(),
             None => "object".to_string(),
         }
     }
@@ -11111,7 +11134,7 @@ pub fn ismapping_w(w_obj: PyObjectRef) -> bool {
         if is_dict(w_obj) {
             return true;
         }
-        let w_type = crate::typedef::r#type(w_obj).unwrap_or(std::ptr::null_mut());
+        let w_type = crate::typedef::r#type(w_obj).map_or(std::ptr::null_mut(), |p| p.as_ptr());
         let flag = pyre_object::typeobject::w_type_get_flag_map_or_seq(w_type);
         if flag == b'M' {
             return true;
@@ -11166,7 +11189,7 @@ pub fn is_iterable(obj: PyObjectRef) -> bool {
         // lives on `W_TypeObject` (typeobject.py:169) so user-defined
         // `dict`/`list`/`tuple` subclasses inherit the marker via
         // `inherit_flag_map_or_seq` at heap-type construction.
-        let w_type = crate::typedef::r#type(obj).unwrap_or(std::ptr::null_mut());
+        let w_type = crate::typedef::r#type(obj).map_or(std::ptr::null_mut(), |p| p.as_ptr());
         let is_mapping = pyre_object::typeobject::w_type_get_flag_map_or_seq(w_type) == b'M';
         if !is_mapping && lookup(obj, "__getitem__").is_some() {
             return true;
@@ -11214,7 +11237,7 @@ pub fn fixedview(
 /// so a heap subclass reports its own name.
 unsafe fn obj_type_name(obj: PyObjectRef) -> &'static str {
     match crate::typedef::r#type(obj) {
-        Some(tp) => pyre_object::typeobject::w_type_get_name(tp),
+        Some(tp) => pyre_object::typeobject::w_type_get_name(tp.as_ptr()),
         None => (*(*obj).ob_type).name,
     }
 }
@@ -11231,7 +11254,7 @@ unsafe fn not_iterable_type_name(obj: PyObjectRef) -> &'static str {
 }
 
 unsafe fn iter_check_is_iterator(w_iterator: PyObjectRef) -> PyResult {
-    let w_type = crate::typedef::r#type(w_iterator).unwrap_or(std::ptr::null_mut());
+    let w_type = crate::typedef::r#type(w_iterator).map_or(std::ptr::null_mut(), |p| p.as_ptr());
     let has_next = if !w_type.is_null() && lookup_in_type_where(w_type, "__next__").is_some() {
         true
     } else if is_instance(w_iterator) {
@@ -11517,7 +11540,8 @@ pub fn iter(obj: PyObjectRef) -> PyResult {
             // the user `W_TypeObject` (typeobject.py:169) so heap-type
             // dict/list/tuple subclasses inherit the marker — see
             // `is_iterable` (this file) for the same pattern.
-            let w_user_type = crate::typedef::r#type(obj).unwrap_or(std::ptr::null_mut());
+            let w_user_type =
+                crate::typedef::r#type(obj).map_or(std::ptr::null_mut(), |p| p.as_ptr());
             let is_mapping =
                 pyre_object::typeobject::w_type_get_flag_map_or_seq(w_user_type) == b'M';
             // descroperation.py:333-334 — `space.lookup(w_obj, '__getitem__')`
@@ -11574,7 +11598,7 @@ pub fn iter(obj: PyObjectRef) -> PyResult {
         // `!is_instance` so the instance path above is untouched.
         if !is_instance(obj) {
             if let Some(w_type) = crate::typedef::r#type(obj) {
-                if let Some(method) = lookup_in_type_where(w_type, "__iter__") {
+                if let Some(method) = lookup_in_type_where(w_type.as_ptr(), "__iter__") {
                     if is_none(method) {
                         return Err(PyError::type_error(format!(
                             "'{}' object is not iterable",
@@ -11585,8 +11609,8 @@ pub fn iter(obj: PyObjectRef) -> PyResult {
                     return iter_check_is_iterator(w_iter);
                 }
                 let is_mapping =
-                    pyre_object::typeobject::w_type_get_flag_map_or_seq(w_type) == b'M';
-                if !is_mapping && lookup_in_type_where(w_type, "__getitem__").is_some() {
+                    pyre_object::typeobject::w_type_get_flag_map_or_seq(w_type.as_ptr()) == b'M';
+                if !is_mapping && lookup_in_type_where(w_type.as_ptr(), "__getitem__").is_some() {
                     return Ok(pyre_object::w_seq_iter_new(obj, 0));
                 }
             }
@@ -12679,7 +12703,7 @@ pub fn next(obj: PyObjectRef) -> PyResult {
         // iterator's own `__next__` from its type.
         if crate::module::r#struct::is_unpack_iter(obj) {
             if let Some(w_type) = crate::typedef::r#type(obj) {
-                if let Some(method) = lookup_in_type_where(w_type, "__next__") {
+                if let Some(method) = lookup_in_type_where(w_type.as_ptr(), "__next__") {
                     return crate::call::call_function_impl_result(method, &[obj]);
                 }
             }
@@ -12697,7 +12721,7 @@ pub fn next(obj: PyObjectRef) -> PyResult {
         // above instead of requiring one hardcoded branch per iterator type.
         if !is_instance(obj) {
             if let Some(w_type) = crate::typedef::r#type(obj) {
-                if let Some(method) = lookup_in_type_where(w_type, "__next__") {
+                if let Some(method) = lookup_in_type_where(w_type.as_ptr(), "__next__") {
                     return crate::call::call_function_impl_result(method, &[obj]);
                 }
             }
@@ -12757,6 +12781,7 @@ unsafe fn property_copy(
     // instance's own type so a `property` subclass is preserved; the
     // constructor re-runs the doc capture.
     let w_type = crate::typedef::r#type(prop)
+        .map(|p| p.as_ptr())
         .unwrap_or_else(|| crate::typedef::gettypeobject(&pyre_object::descriptor::PROPERTY_TYPE));
     let w_res = crate::call::call_function_impl_result(w_type, &[getter, setter, deleter, w_doc])?;
     // descriptor.py:270-271 `if isinstance(w_res, W_Property): w_res.w_name
@@ -12778,9 +12803,9 @@ unsafe fn property_no_accessor(
     kind: &str,
 ) -> Result<crate::PyError, crate::PyError> {
     let qualname = match crate::typedef::r#type(obj) {
-        Some(w_type) => match getattr_str(w_type, "__qualname__") {
+        Some(w_type) => match getattr_str(w_type.as_ptr(), "__qualname__") {
             Ok(q) if !q.is_null() && is_str(q) => pyre_object::w_str_get_value(q).to_string(),
-            _ => pyre_object::w_type_get_name(w_type).to_string(),
+            _ => pyre_object::w_type_get_name(w_type.as_ptr()).to_string(),
         },
         None => (*(*obj).ob_type).name.to_string(),
     };
@@ -13148,7 +13173,7 @@ fn throw_yield_from(
         return crate::call::call_function_impl_result(throw, &args[..argc]);
     }
     let w_exc = err.to_exc_object();
-    let w_type = crate::typedef::r#type(w_exc).unwrap_or(pyre_object::PY_NULL);
+    let w_type = crate::typedef::r#type(w_exc).map_or(pyre_object::PY_NULL, |p| p.as_ptr());
     crate::call::call_function_impl_result(throw, &[w_type, w_exc])
 }
 
@@ -13302,7 +13327,7 @@ fn cycle_reduce_method(args: &[PyObjectRef]) -> PyResult {
     // `w_tuple_new` may collect): the saved elements go into a `Vec`
     // that `w_list_new` pins, and `w_iterable` / `index` are read up
     // front rather than across an allocation.
-    let w_type = crate::typedef::r#type(args[0]).unwrap_or(PY_NULL);
+    let w_type = crate::typedef::r#type(args[0]).map_or(PY_NULL, |p| p.as_ptr());
     let it = unsafe { &*(args[0] as *const pyre_object::interp_itertools::W_Cycle) };
     let w_iterable = it.w_iterable;
     let index = it.index;
@@ -13356,7 +13381,7 @@ fn cycle_setstate_method(args: &[PyObjectRef]) -> PyResult {
 fn chain_reduce_method(args: &[PyObjectRef]) -> PyResult {
     // Read the pointer fields before any allocation (`w_tuple_new` may
     // collect); `w_type` mirrors `space.type(self)`.
-    let w_type = crate::typedef::r#type(args[0]).unwrap_or(PY_NULL);
+    let w_type = crate::typedef::r#type(args[0]).map_or(PY_NULL, |p| p.as_ptr());
     let w_iterables = unsafe { pyre_object::interp_itertools::w_chain_get_iterables(args[0]) };
     let w_it = unsafe { pyre_object::interp_itertools::w_chain_get_it(args[0]) };
     if !w_iterables.is_null() {
@@ -14162,7 +14187,7 @@ mod tests {
     #[test]
     fn test_isinstance_tuple_with_non_class_raises_typeerror() {
         crate::typedef::init_typeobjects();
-        let float_type = crate::typedef::r#type(w_float_new(0.0)).unwrap();
+        let float_type = crate::typedef::r#type(w_float_new(0.0)).unwrap().as_ptr();
         let bad = w_tuple_new(vec![float_type, w_int_new(6)]);
         let err = super::isinstance(w_int_new(5), bad).unwrap_err();
         assert!(matches!(err.kind, PyErrorKind::TypeError));
@@ -14173,7 +14198,7 @@ mod tests {
     #[test]
     fn test_issubclass_non_class_arg1_raises_typeerror() {
         crate::typedef::init_typeobjects();
-        let int_type = crate::typedef::r#type(w_int_new(0)).unwrap();
+        let int_type = crate::typedef::r#type(w_int_new(0)).unwrap().as_ptr();
         let err = super::issubclass(w_int_new(5), int_type).unwrap_err();
         assert!(matches!(err.kind, PyErrorKind::TypeError));
         assert!(err.message.contains("issubclass() arg 1"));
@@ -14184,7 +14209,7 @@ mod tests {
     #[test]
     fn test_issubclass_non_class_arg2_raises_typeerror() {
         crate::typedef::init_typeobjects();
-        let int_type = crate::typedef::r#type(w_int_new(0)).unwrap();
+        let int_type = crate::typedef::r#type(w_int_new(0)).unwrap().as_ptr();
         let err = super::issubclass(int_type, w_int_new(6)).unwrap_err();
         assert!(matches!(err.kind, PyErrorKind::TypeError));
         assert!(err.message.contains("issubclass() arg 2"));
@@ -14539,7 +14564,7 @@ pub(crate) fn contains_slot(haystack: PyObjectRef, needle: PyObjectRef) -> Resul
                 return Ok(sub.is_empty() || hay.windows(sub.len()).any(|w| w == sub));
             }
             let tname = match crate::typedef::r#type(needle) {
-                Some(tp) => pyre_object::w_type_get_name(tp).to_string(),
+                Some(tp) => pyre_object::w_type_get_name(tp.as_ptr()).to_string(),
                 None => "object".to_string(),
             };
             return Err(PyError::type_error(format!(
@@ -14580,7 +14605,7 @@ pub(crate) fn contains_slot(haystack: PyObjectRef, needle: PyObjectRef) -> Resul
     // is_instance receivers are already handled above.
     unsafe {
         if let Some(w_type) = crate::typedef::r#type(haystack) {
-            if let Some(method) = lookup_in_type_where(w_type, "__contains__") {
+            if let Some(method) = lookup_in_type_where(w_type.as_ptr(), "__contains__") {
                 if is_none(method) {
                     return Err(not_container_error(haystack));
                 }
@@ -14885,7 +14910,7 @@ pub(crate) fn delitem_slot(obj: PyObjectRef, index: PyObjectRef) -> Result<(), P
         // paths for the builtin sequence/mapping layouts.  Covers typed-payload
         // types like `deque` whose typedef binds `__delitem__`.
         if let Some(w_type) = crate::typedef::r#type(obj) {
-            if let Some(method) = lookup_in_type_where(w_type, "__delitem__") {
+            if let Some(method) = lookup_in_type_where(w_type.as_ptr(), "__delitem__") {
                 crate::builtins::call_and_check(method, &[obj, index])?;
                 return Ok(());
             }

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -3028,6 +3028,7 @@ pub(crate) fn zip_next_method(args: &[PyObjectRef]) -> PyResult {
 /// `Ok(None)`, and a hit as `Ok(Some(value))`.
 pub fn finditem(obj: PyObjectRef, index: PyObjectRef) -> Result<Option<PyObjectRef>, PyError> {
     match getitem(obj, index) {
+        Ok(value) if value.is_null() => Ok(None),
         Ok(value) => Ok(Some(value)),
         Err(err) if err.kind == crate::PyErrorKind::KeyError => Ok(None),
         Err(err) => Err(err),
@@ -3672,6 +3673,7 @@ pub fn findattr(obj: PyObjectRef, name: &str) -> Option<PyObjectRef> {
         return None;
     }
     match getattr_str(obj, name) {
+        Ok(value) if value.is_null() => None,
         Ok(value) => Some(value),
         Err(err) => {
             if err.kind == crate::PyErrorKind::AttributeError
@@ -3693,6 +3695,7 @@ pub fn findattr_result(obj: PyObjectRef, name: &str) -> Result<Option<PyObjectRe
         return Ok(None);
     }
     match getattr_str(obj, name) {
+        Ok(value) if value.is_null() => Ok(None),
         Ok(value) => Ok(Some(value)),
         Err(err) => {
             if err.kind == crate::PyErrorKind::AttributeError
@@ -8488,8 +8491,10 @@ pub(crate) unsafe fn get(
             return Err(property_no_accessor(descr, obj, "getter")?);
         }
         // W_Property.get → `space.call_function(self.fget, w_obj)`: the
-        // getter's exception propagates rather than being swallowed.
-        return Ok(Some(crate::call::call_function_impl_result(fget, &[obj])?));
+        // getter's exception propagates rather than being swallowed.  A null
+        // result is no binding, reported as absence rather than `Some(null)`.
+        let r = crate::call::call_function_impl_result(fget, &[obj])?;
+        return Ok(if r.is_null() { None } else { Some(r) });
     }
 
     // typedef.py:504-516 Member.descr_member_get:
@@ -8554,7 +8559,7 @@ pub(crate) unsafe fn get(
                 let visible_obj = if obj.is_null() { w_none() } else { obj };
                 let result =
                     crate::call::call_function_impl_result(get_fn, &[descr, visible_obj, w_type])?;
-                return Ok(Some(result));
+                return Ok(if result.is_null() { None } else { Some(result) });
             }
         }
     }
@@ -11016,6 +11021,7 @@ fn object_functionstr_findattr(
         return Ok(None);
     }
     match getattr_str(obj, name) {
+        Ok(value) if value.is_null() => Ok(None),
         Ok(value) => Ok(Some(value)),
         Err(e) if e.kind == crate::PyErrorKind::SystemExit => Err(e),
         Err(_) => Ok(None),
@@ -13030,7 +13036,7 @@ fn generator_send_ex(
         // resume to `frame.execute_frame(w_arg_or_err)`.  In particular,
         // `PyFrame.resume_execute_frame` handles `w_yielding_from` only after
         // the outer frame has entered the execution context.
-        let w_inputvalue = if already_started && operr.is_none() {
+        let w_inputvalue = if already_started && operr.is_none() && !w_arg.is_null() {
             Some(w_arg)
         } else {
             None

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -524,7 +524,7 @@ pub unsafe fn isinstance_str_w(obj: PyObjectRef) -> bool {
         return true;
     }
     if let Some(str_type) = crate::typedef::gettypefor(&pyre_object::STR_TYPE) {
-        return isinstance_w(obj, str_type);
+        return isinstance_w(obj, str_type.as_ptr());
     }
     false
 }
@@ -541,7 +541,7 @@ pub unsafe fn isinstance_int_w(obj: PyObjectRef) -> bool {
         return true;
     }
     if let Some(int_type) = crate::typedef::gettypefor(&pyre_object::INT_TYPE) {
-        return isinstance_w(obj, int_type);
+        return isinstance_w(obj, int_type.as_ptr());
     }
     false
 }
@@ -556,7 +556,7 @@ pub unsafe fn isinstance_bytes_w(obj: PyObjectRef) -> bool {
         return true;
     }
     if let Some(bytes_type) = crate::typedef::gettypefor(&pyre_object::BYTES_TYPE) {
-        return isinstance_w(obj, bytes_type);
+        return isinstance_w(obj, bytes_type.as_ptr());
     }
     false
 }
@@ -574,12 +574,12 @@ pub unsafe fn isinstance_bytes_like_w(obj: PyObjectRef) -> bool {
         return true;
     }
     if let Some(bytes_type) = crate::typedef::gettypefor(&pyre_object::BYTES_TYPE) {
-        if isinstance_w(obj, bytes_type) {
+        if isinstance_w(obj, bytes_type.as_ptr()) {
             return true;
         }
     }
     if let Some(bytearray_type) = crate::typedef::gettypefor(&pyre_object::BYTEARRAY_TYPE) {
-        return isinstance_w(obj, bytearray_type);
+        return isinstance_w(obj, bytearray_type.as_ptr());
     }
     false
 }
@@ -595,7 +595,7 @@ pub unsafe fn isinstance_list_w(obj: PyObjectRef) -> bool {
         return true;
     }
     if let Some(list_type) = crate::typedef::gettypefor(&pyre_object::LIST_TYPE) {
-        return isinstance_w(obj, list_type);
+        return isinstance_w(obj, list_type.as_ptr());
     }
     false
 }
@@ -5705,8 +5705,10 @@ fn object_getattr_miss(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyRe
                     None
                 }
             };
-            let w_metaclasses: [Option<PyObjectRef>; 2] =
-                [w_metaclass, crate::typedef::gettypefor((*obj).ob_type)];
+            let w_metaclasses: [Option<PyObjectRef>; 2] = [
+                w_metaclass,
+                crate::typedef::gettypefor((*obj).ob_type).map(|p| p.as_ptr()),
+            ];
             // typeobject.py:811-819 — `space.lookup(self, name)` searches the
             // complete metaclass MRO, and any data descriptor found there is
             // consulted before the class's own MRO.  This includes getsets
@@ -6812,8 +6814,8 @@ pub(crate) fn space_int(obj: PyObjectRef) -> Result<PyObjectRef, PyError> {
     // baseobjspace.py:324 `w_result = space.get_and_call_function(w_impl, self)`
     let w_result = crate::builtins::call_and_check(method, &[obj])?;
     // baseobjspace.py:326-327 — an exact int returns directly.
-    let w_int = crate::typedef::gettypefor(&pyre_object::INT_TYPE);
-    if crate::typedef::r#type(w_result) == w_int {
+    let w_int = crate::typedef::gettypefor(&pyre_object::INT_TYPE).map_or(PY_NULL, |p| p.as_ptr());
+    if crate::typedef::r#type(w_result).unwrap_or(PY_NULL) == w_int {
         return Ok(w_result);
     }
     // baseobjspace.py:328-336 — a strict int subclass is accepted for now,
@@ -7868,7 +7870,7 @@ unsafe fn is_object_getattribute_descr(w_descr: PyObjectRef) -> bool {
 unsafe fn is_module_getattribute_descr(w_descr: PyObjectRef) -> bool {
     let w_module_type =
         crate::typedef::gettypefor(&pyre_object::MODULE_TYPE as *const pyre_object::PyType)
-            .unwrap_or(PY_NULL);
+            .map_or(PY_NULL, |p| p.as_ptr());
     !w_module_type.is_null()
         && lookup_in_type_where(w_module_type, "__getattribute__")
             .is_some_and(|d| std::ptr::eq(w_descr, d))
@@ -8751,7 +8753,7 @@ pub(crate) fn descr_set___class__(w_obj: PyObjectRef, w_newcls: PyObjectRef) -> 
         // its receiver to ModuleType after temporarily overriding the slots.
         let w_module_type =
             crate::typedef::gettypefor(&pyre_object::MODULE_TYPE as *const pyre_object::PyType)
-                .unwrap_or(PY_NULL);
+                .map_or(PY_NULL, |p| p.as_ptr());
         if !w_type_is_heaptype(w_newcls) && !std::ptr::eq(w_newcls, w_module_type) {
             return Err(crate::PyError::type_error(
                 "__class__ assignment only supported for heap types or ModuleType subclasses"
@@ -10424,8 +10426,8 @@ pub fn space_index(obj: PyObjectRef) -> Result<PyObjectRef, PyError> {
         )));
     };
     let w_result = crate::builtins::call_and_check(method, &[obj])?;
-    let w_int = crate::typedef::gettypefor(&pyre_object::INT_TYPE);
-    if crate::typedef::r#type(w_result) == w_int {
+    let w_int = crate::typedef::gettypefor(&pyre_object::INT_TYPE).map_or(PY_NULL, |p| p.as_ptr());
+    if crate::typedef::r#type(w_result).unwrap_or(PY_NULL) == w_int {
         return Ok(w_result);
     }
     if unsafe { pyre_object::is_bool(w_result) || pyre_object::pyobject::is_int_or_long(w_result) }
@@ -11557,7 +11559,7 @@ pub fn iter(obj: PyObjectRef) -> PyResult {
             // Fallback: check type type's MRO
             if let Some(w_type_type) = crate::typedef::gettypefor(&pyre_object::pyobject::TYPE_TYPE)
             {
-                if let Some(method) = lookup_in_type_where(w_type_type, "__iter__") {
+                if let Some(method) = lookup_in_type_where(w_type_type.as_ptr(), "__iter__") {
                     let w_iter = crate::call::call_function_impl_result(method, &[obj])?;
                     return iter_check_is_iterator(w_iter);
                 }

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -2299,7 +2299,7 @@ pub fn install_default_builtins(ns: PyObjectRef) {
     crate::module_ns_get_or_insert_with(ns, "slice", || {
         // The slice type object, for isinstance(x, slice) checks.
         crate::typedef::gettypefor(&pyre_object::sliceobject::SLICE_TYPE)
-            .unwrap_or(pyre_object::PY_NULL)
+            .map_or(pyre_object::PY_NULL, |p| p.as_ptr())
     });
     crate::module_ns_get_or_insert_with(ns, "frozenset", || {
         crate::typedef::gettypeobject(&pyre_object::setobject::FROZENSET_TYPE)
@@ -5196,8 +5196,8 @@ fn exc_unicode_decode_error_init(args: &[PyObjectRef]) -> Result<PyObjectRef, cr
             w_object_in
         } else {
             let bytes_type = crate::typedef::gettypefor(&pyre_object::BYTES_TYPE);
-            let inherits_bytes =
-                bytes_type.is_some_and(|bt| crate::baseobjspace::isinstance_w(w_object_in, bt));
+            let inherits_bytes = bytes_type
+                .is_some_and(|bt| crate::baseobjspace::isinstance_w(w_object_in, bt.as_ptr()));
             let data = if inherits_bytes {
                 pyre_object::bytesobject::w_bytes_data(w_object_in)
             } else {
@@ -6478,7 +6478,7 @@ pub fn builtin_int(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
     if w_base.is_none() {
         // intobject.py:991: space.is_w(space.type(w_value), space.w_int)
         let w_type = crate::typedef::r#type(obj);
-        let w_int = crate::typedef::gettypefor(&INT_TYPE);
+        let w_int = crate::typedef::gettypefor(&INT_TYPE).map(|p| p.as_ptr());
         if w_type.is_some() && w_type == w_int {
             return Ok(obj);
         }
@@ -8662,8 +8662,8 @@ pub fn try_hash_value(obj: PyObjectRef) -> Result<i64, crate::PyError> {
                     } else {
                         crate::typedef::gettypefor(&pyre_object::setobject::FROZENSET_TYPE)
                     };
-                    let base_hash =
-                        base.and_then(|b| crate::baseobjspace::lookup_in_type(b, "__hash__"));
+                    let base_hash = base
+                        .and_then(|b| crate::baseobjspace::lookup_in_type(b.as_ptr(), "__hash__"));
                     if Some(method) != base_hash {
                         return hash_call_normalize(method, obj, w_type);
                     }

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -513,7 +513,7 @@ pub(crate) fn w_memoryview_new(w_obj: PyObjectRef) -> Result<PyObjectRef, crate:
             Some(p) => p,
             None => {
                 let tname = crate::typedef::r#type(w_obj)
-                    .map(|t| pyre_object::w_type_get_name(t))
+                    .map(|t| pyre_object::w_type_get_name(t.as_ptr()))
                     .unwrap_or("object");
                 return Err(crate::PyError::type_error(&format!(
                     "memoryview: a bytes-like object is required, not '{tname}'"
@@ -1386,7 +1386,7 @@ fn memoryview_cast(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
             let shape_seq = shape_obj.unwrap();
             if !(pyre_object::is_list(shape_seq) || pyre_object::is_tuple(shape_seq)) {
                 let tname = match crate::typedef::r#type(shape_seq) {
-                    Some(tp) => pyre_object::w_type_get_name(tp).to_string(),
+                    Some(tp) => pyre_object::w_type_get_name(tp.as_ptr()).to_string(),
                     None => (*(*shape_seq).ob_type).name.to_string(),
                 };
                 return Err(crate::PyError::type_error(format!(
@@ -1593,7 +1593,7 @@ fn memoryview_receiver(args: &[PyObjectRef], name: &str) -> Result<PyObjectRef, 
     }
     if !unsafe { pyre_object::memoryview::is_w_memoryview(mv) } {
         let received = crate::typedef::r#type(mv)
-            .map(|t| unsafe { pyre_object::w_type_get_name(t) })
+            .map(|t| unsafe { pyre_object::w_type_get_name(t.as_ptr()) })
             .unwrap_or("object");
         return Err(crate::PyError::type_error(format!(
             "descriptor '{name}' requires a 'memoryview' object but received a '{received}'"
@@ -3494,7 +3494,9 @@ pub(crate) fn space_index_w(obj: PyObjectRef) -> Result<i64, crate::PyError> {
             return v;
         }
         if let Some(w_type) = crate::typedef::r#type(obj) {
-            if let Some(index_fn) = crate::baseobjspace::lookup_in_type(w_type, "__index__") {
+            if let Some(index_fn) =
+                crate::baseobjspace::lookup_in_type(w_type.as_ptr(), "__index__")
+            {
                 let result = crate::call::call_function_impl_result(index_fn, &[obj])?;
                 if let Some(v) = as_index_value(result) {
                     return v;
@@ -3504,7 +3506,7 @@ pub(crate) fn space_index_w(obj: PyObjectRef) -> Result<i64, crate::PyError> {
     }
     let tp_name = unsafe {
         match crate::typedef::r#type(obj) {
-            Some(tp) => pyre_object::w_type_get_name(tp).to_string(),
+            Some(tp) => pyre_object::w_type_get_name(tp.as_ptr()).to_string(),
             None => "object".to_string(),
         }
     };
@@ -3924,7 +3926,9 @@ fn type_descr_new_with_metaclass(
                 if key.as_str() == Ok("__classcell__") {
                     if !unsafe { pyre_object::is_cell(value) } {
                         let tp_name = match unsafe { crate::typedef::r#type(value) } {
-                            Some(tp) => unsafe { pyre_object::w_type_get_name(tp) }.to_string(),
+                            Some(tp) => {
+                                unsafe { pyre_object::w_type_get_name(tp.as_ptr()) }.to_string()
+                            }
                             None => "object".to_string(),
                         };
                         return Err(crate::PyError::type_error(format!(
@@ -4154,7 +4158,7 @@ fn type_descr_new_with_metaclass(
     // typedef::type() respects __class__ override for all object kinds.
     let obj = args[0];
     if let Some(tp) = crate::typedef::r#type(obj) {
-        return Ok(tp);
+        return Ok(tp.as_ptr());
     }
     if obj.is_null() {
         return Ok(crate::typedef::gettypeobject(
@@ -4371,7 +4375,7 @@ fn exc_base_exception_init(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::P
         if has_keyword {
             let type_name = unsafe {
                 match crate::typedef::r#type(w_self) {
-                    Some(tp) => pyre_object::w_type_get_name(tp).to_string(),
+                    Some(tp) => pyre_object::w_type_get_name(tp.as_ptr()).to_string(),
                     None => "BaseException".to_string(),
                 }
             };
@@ -4432,7 +4436,7 @@ fn os_error_build(
 fn exc_is_blocking_io_error(exc: PyObjectRef) -> bool {
     matches!(
         (crate::typedef::r#type(exc), lookup_exc_class("BlockingIOError")),
-        (Some(c), Some(b)) if std::ptr::eq(c, b)
+        (Some(c), Some(b)) if std::ptr::eq(c.as_ptr(), b)
     )
 }
 
@@ -4627,7 +4631,7 @@ fn os_error_use_init(w_self: PyObjectRef) -> bool {
     let Some(w_type) = crate::typedef::r#type(w_self) else {
         return false;
     };
-    os_error_type_use_init(w_type)
+    os_error_type_use_init(w_type.as_ptr())
 }
 
 /// `_use_init` keyed on the type object directly (the `__new__` half has the
@@ -4699,7 +4703,9 @@ fn exc_os_error_init(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
     let (positional, kwargs) = split_builtin_kwargs(&args[1..]);
     // `descr_init` line 621-623: OSError takes no keyword arguments.
     if has_real_kwargs(kwargs) {
-        return Err(os_error_no_keywords_error(crate::typedef::r#type(w_self)));
+        return Err(os_error_no_keywords_error(
+            crate::typedef::r#type(w_self).map(|p| p.as_ptr()),
+        ));
     }
     os_error_fill_slots(w_self, positional);
     Ok(pyre_object::w_none())
@@ -4714,6 +4720,7 @@ fn base_exception_reduce(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyE
         crate::PyError::type_error("__reduce__() missing 1 required positional argument: 'self'")
     })?;
     let cls = crate::typedef::r#type(w_self)
+        .map(|p| p.as_ptr())
         .unwrap_or_else(|| crate::baseobjspace::exception_getclass(w_self));
     let w_args = unsafe { pyre_object::interp_exceptions::w_exception_get_args(w_self) };
     let w_dict = unsafe { pyre_object::interp_exceptions::w_exception_peek_dict(w_self) };
@@ -4752,6 +4759,7 @@ fn import_error_reduce(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErr
         crate::PyError::type_error("__reduce__() missing 1 required positional argument: 'self'")
     })?;
     let cls = crate::typedef::r#type(w_self)
+        .map(|p| p.as_ptr())
         .unwrap_or_else(|| crate::baseobjspace::exception_getclass(w_self));
     let w_args = unsafe { interp_exceptions::w_exception_get_args(w_self) };
     let stored = unsafe { interp_exceptions::w_exception_peek_dict(w_self) };
@@ -4839,6 +4847,7 @@ fn os_error_reduce(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
         crate::PyError::type_error("__reduce__() missing 1 required positional argument: 'self'")
     })?;
     let cls = crate::typedef::r#type(w_self)
+        .map(|p| p.as_ptr())
         .unwrap_or_else(|| crate::baseobjspace::exception_getclass(w_self));
     let w_args = unsafe { interp_exceptions::w_exception_get_args(w_self) };
     let n = unsafe { pyre_object::w_tuple_len(w_args) };
@@ -6057,7 +6066,7 @@ fn exception_group_repr(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyEr
     let w_self = args[0];
     let (message, exceptions) = exception_group_fields(w_self)?;
     let cls = crate::typedef::r#type(w_self).unwrap();
-    let name = unsafe { pyre_object::w_type_get_name(cls) };
+    let name = unsafe { pyre_object::w_type_get_name(cls.as_ptr()) };
     let message_repr = unsafe { crate::display::py_repr(message)? };
     let items = unsafe { pyre_object::w_tuple_items_copy_as_vec(exceptions) };
     let list_repr = unsafe { crate::display::py_repr(pyre_object::w_list_new(items))? };
@@ -6409,10 +6418,11 @@ fn py_ascii_obj(obj: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
     let Some(tp) = (unsafe { crate::typedef::r#type(r) }) else {
         return Ok(w_str_new(&out));
     };
-    let Some(new_fn) = (unsafe { crate::baseobjspace::lookup_in_type(tp, "__new__") }) else {
+    let Some(new_fn) = (unsafe { crate::baseobjspace::lookup_in_type(tp.as_ptr(), "__new__") })
+    else {
         return Ok(w_str_new(&out));
     };
-    crate::builtins::call_and_check(new_fn, &[tp, w_str_new(&out)])
+    crate::builtins::call_and_check(new_fn, &[tp.as_ptr(), w_str_new(&out)])
 }
 
 /// `bltinmodule.c:builtin_ascii` — like `repr`, but escape every
@@ -6478,7 +6488,7 @@ pub fn builtin_int(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
     if w_base.is_none() {
         // intobject.py:991: space.is_w(space.type(w_value), space.w_int)
         let w_type = crate::typedef::r#type(obj);
-        let w_int = crate::typedef::gettypefor(&INT_TYPE).map(|p| p.as_ptr());
+        let w_int = crate::typedef::gettypefor(&INT_TYPE);
         if w_type.is_some() && w_type == w_int {
             return Ok(obj);
         }
@@ -6923,7 +6933,9 @@ pub(crate) fn builtin_float(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::
     }
     // descroperation.py float — type-MRO __float__ then __index__
     if let Some(tp) = crate::typedef::r#type(obj) {
-        if let Some(method) = unsafe { crate::baseobjspace::lookup_in_type(tp, "__float__") } {
+        if let Some(method) =
+            unsafe { crate::baseobjspace::lookup_in_type(tp.as_ptr(), "__float__") }
+        {
             let result = crate::call::call_function_impl_result(method, &[obj])?;
             unsafe {
                 if is_float(result) {
@@ -6950,7 +6962,9 @@ pub(crate) fn builtin_float(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::
                 "__float__ returned non-float (type '{result_type}')",
             )));
         }
-        if let Some(method) = unsafe { crate::baseobjspace::lookup_in_type(tp, "__index__") } {
+        if let Some(method) =
+            unsafe { crate::baseobjspace::lookup_in_type(tp.as_ptr(), "__index__") }
+        {
             let r = crate::call::call_function_impl_result(method, &[obj])?;
             // descroperation.py:609 `space.index` returns an arbitrary-size
             // Python int.  Accept both the machine-word and W_LongObject
@@ -7452,8 +7466,8 @@ pub(crate) fn super_check(
             return Ok(obj_or_type);
         }
         if let Some(obj_type) = crate::typedef::r#type(obj_or_type) {
-            if crate::baseobjspace::issubtype_w(obj_type, start_type) {
-                return Ok(obj_type);
+            if crate::baseobjspace::issubtype_w(obj_type.as_ptr(), start_type) {
+                return Ok(obj_type.as_ptr());
             }
         }
         match crate::baseobjspace::getattr_str(obj_or_type, "__class__") {
@@ -7479,7 +7493,7 @@ pub(crate) fn super_check(
         })
     } else {
         let obj_type_name = crate::typedef::r#type(obj_or_type)
-            .map(|t| unsafe { pyre_object::w_type_get_name(t) })
+            .map(|t| unsafe { pyre_object::w_type_get_name(t.as_ptr()) })
             .unwrap_or("object");
         format!("instance of {obj_type_name}")
     };
@@ -7564,7 +7578,7 @@ fn builtin_callable(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
             || pyre_object::is_method(obj)
             || pyre_object::function::is_staticmethod(obj)
             || crate::typedef::r#type(obj)
-                .and_then(|t| crate::baseobjspace::lookup_in_type(t, "__call__"))
+                .and_then(|t| crate::baseobjspace::lookup_in_type(t.as_ptr(), "__call__"))
                 .is_some()
     };
     Ok(w_bool_from(is_callable))
@@ -7926,7 +7940,7 @@ fn exec_or_eval(
         }
         unsafe {
             match crate::typedef::r#type(w_obj) {
-                Some(tp) => pyre_object::w_type_get_name(tp).to_string(),
+                Some(tp) => pyre_object::w_type_get_name(tp.as_ptr()).to_string(),
                 None => (*(*w_obj).ob_type).name.to_string(),
             }
         }
@@ -8372,8 +8386,8 @@ pub(crate) fn object_dir_default(obj: PyObjectRef) -> Result<PyObjectRef, crate:
             }
         }
         if let Some(w_type) = crate::typedef::r#type(obj) {
-            if pyre_object::is_type(w_type) {
-                classdir_into(w_type, &mut names)?;
+            if pyre_object::is_type(w_type.as_ptr()) {
+                classdir_into(w_type.as_ptr(), &mut names)?;
             }
         }
     }
@@ -8434,7 +8448,7 @@ pub(crate) fn builtin_dir(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
     // builtin such as traceback) and drives dir() directly.
     if let Some(w_type) = crate::typedef::r#type(obj) {
         if let Some((owner, dir_meth)) =
-            unsafe { crate::baseobjspace::lookup_where_pair(w_type, "__dir__") }
+            unsafe { crate::baseobjspace::lookup_where_pair(w_type.as_ptr(), "__dir__") }
         {
             // The default object.__dir__ is implemented by the manual generic
             // paths below.  Keep descending when it is merely inherited so
@@ -8444,7 +8458,7 @@ pub(crate) fn builtin_dir(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
             // app_inspect.py's lookup_special requires.
             if !std::ptr::eq(owner, crate::typedef::w_object()) {
                 let result = unsafe {
-                    crate::baseobjspace::get_and_call_function(dir_meth, obj, w_type, &[])
+                    crate::baseobjspace::get_and_call_function(dir_meth, obj, w_type.as_ptr(), &[])
                 }?;
                 return builtin_sorted(&[result]);
             }
@@ -8538,8 +8552,8 @@ pub(crate) fn builtin_dir(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
             // above because those have richer paths that combine instance and
             // class entries.
             if let Some(w_type) = crate::typedef::r#type(obj) {
-                if pyre_object::is_type(w_type) {
-                    classdir_into(w_type, &mut names)?;
+                if pyre_object::is_type(w_type.as_ptr()) {
+                    classdir_into(w_type.as_ptr(), &mut names)?;
                 }
             }
         }
@@ -8622,9 +8636,11 @@ pub fn try_hash_value(obj: PyObjectRef) -> Result<i64, crate::PyError> {
             // value (`descroperation.py:556-565`), so only reject the object
             // after giving a non-None override the call.
             if let Some(w_type) = crate::typedef::r#type(obj) {
-                if let Some(method) = crate::baseobjspace::lookup_in_type(w_type, "__hash__") {
+                if let Some(method) =
+                    crate::baseobjspace::lookup_in_type(w_type.as_ptr(), "__hash__")
+                {
                     if !pyre_object::is_none(method) {
-                        return hash_call_normalize(method, obj, w_type);
+                        return hash_call_normalize(method, obj, w_type.as_ptr());
                     }
                 }
             }
@@ -8653,7 +8669,9 @@ pub fn try_hash_value(obj: PyObjectRef) -> Result<i64, crate::PyError> {
             || (is_frozenset_recv && !is_exact_type(obj, &pyre_object::setobject::FROZENSET_TYPE))
         {
             if let Some(w_type) = crate::typedef::r#type(obj) {
-                if let Some(method) = crate::baseobjspace::lookup_in_type(w_type, "__hash__") {
+                if let Some(method) =
+                    crate::baseobjspace::lookup_in_type(w_type.as_ptr(), "__hash__")
+                {
                     if pyre_object::is_none(method) {
                         return Err(unhashable_type_error(obj));
                     }
@@ -8665,7 +8683,7 @@ pub fn try_hash_value(obj: PyObjectRef) -> Result<i64, crate::PyError> {
                     let base_hash = base
                         .and_then(|b| crate::baseobjspace::lookup_in_type(b.as_ptr(), "__hash__"));
                     if Some(method) != base_hash {
-                        return hash_call_normalize(method, obj, w_type);
+                        return hash_call_normalize(method, obj, w_type.as_ptr());
                     }
                 }
             }
@@ -8721,7 +8739,7 @@ pub fn try_hash_value(obj: PyObjectRef) -> Result<i64, crate::PyError> {
         // covers the builtin/typed-payload layouts before the identity-hash
         // fallback.
         if let Some(w_type) = crate::typedef::r#type(obj) {
-            if let Some(method) = crate::baseobjspace::lookup_in_type(w_type, "__hash__") {
+            if let Some(method) = crate::baseobjspace::lookup_in_type(w_type.as_ptr(), "__hash__") {
                 if pyre_object::is_none(method) {
                     return Err(unhashable_type_error(obj));
                 }
@@ -8733,7 +8751,7 @@ pub fn try_hash_value(obj: PyObjectRef) -> Result<i64, crate::PyError> {
                 let default_hash =
                     crate::baseobjspace::lookup_in_type(crate::typedef::w_object(), "__hash__");
                 if default_hash != Some(method) {
-                    return hash_call_normalize(method, obj, w_type);
+                    return hash_call_normalize(method, obj, w_type.as_ptr());
                 }
             }
         }
@@ -8795,7 +8813,7 @@ fn hash_call_normalize(
 fn unhashable_type_error(obj: PyObjectRef) -> crate::PyError {
     let name = unsafe {
         match crate::typedef::r#type(obj) {
-            Some(tp) => pyre_object::w_type_get_name(tp).to_string(),
+            Some(tp) => pyre_object::w_type_get_name(tp.as_ptr()).to_string(),
             None if !obj.is_null() => (*(*obj).ob_type).name.to_string(),
             None => "NULL".to_string(),
         }
@@ -9511,7 +9529,9 @@ pub(crate) fn builtin_reversed(args: &[PyObjectRef]) -> Result<PyObjectRef, crat
     // and any user object defining `__reversed__`.
     let obj = unsafe { pyre_object::gc_roots::shadow_stack_get(obj_slot) };
     if let Some(tp) = crate::typedef::r#type(obj) {
-        if let Some(method) = unsafe { crate::baseobjspace::lookup_in_type(tp, "__reversed__") } {
+        if let Some(method) =
+            unsafe { crate::baseobjspace::lookup_in_type(tp.as_ptr(), "__reversed__") }
+        {
             // Python 3.14 `slot1` semantics: explicitly assigning None disables
             // the protocol and does not fall back to `__len__`/`__getitem__`.
             if unsafe { pyre_object::is_none(method) } {
@@ -9536,7 +9556,7 @@ pub(crate) fn builtin_reversed(args: &[PyObjectRef]) -> Result<PyObjectRef, crat
     // raises the regular "has no len()" from `len`.
     if let Some(tp) = crate::typedef::r#type(obj) {
         let has_getitem =
-            unsafe { crate::baseobjspace::lookup_in_type(tp, "__getitem__") }.is_some();
+            unsafe { crate::baseobjspace::lookup_in_type(tp.as_ptr(), "__getitem__") }.is_some();
         if has_getitem {
             // `functional.py:354-359` — reverse lazily through `W_ReversedIterator`.
             let n = crate::baseobjspace::len_w(obj)?;
@@ -10179,7 +10199,7 @@ fn fileio_method_repr(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErro
         .ok_or_else(|| crate::PyError::type_error("__repr__ requires self"))?;
     let type_name = unsafe {
         crate::typedef::r#type(self_obj)
-            .map(|tp| pyre_object::w_type_get_name(tp).to_string())
+            .map(|tp| pyre_object::w_type_get_name(tp.as_ptr()).to_string())
             .unwrap_or_else(|| "FileIO".to_string())
     };
     // CPython 3.14's subclass repr names the concrete subclass; the builtin
@@ -11574,7 +11594,7 @@ fn open_raw_file(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
             let data = pyre_object::bytesobject::bytes_like_data(path_obj);
             String::from_utf8_lossy(data).into_owned()
         } else if let Some(fspath_fn) = crate::typedef::r#type(path_obj)
-            .and_then(|pt| crate::baseobjspace::lookup_in_type(pt, "__fspath__"))
+            .and_then(|pt| crate::baseobjspace::lookup_in_type(pt.as_ptr(), "__fspath__"))
         {
             // `type(path).__fspath__(path)` — unbound descriptor + single arg.
             let result = crate::call::call_function_impl_result(fspath_fn, &[path_obj])?;
@@ -11987,7 +12007,9 @@ pub(crate) fn builtin_round(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::
     // operation.py:97 — lookup __round__ on user objects.  An omitted or
     // explicit-None `ndigits` calls `__round__()` with no second argument.
     if let Some(tp) = crate::typedef::r#type(obj) {
-        if let Some(method) = unsafe { crate::baseobjspace::lookup_in_type(tp, "__round__") } {
+        if let Some(method) =
+            unsafe { crate::baseobjspace::lookup_in_type(tp.as_ptr(), "__round__") }
+        {
             let result = match ndigits {
                 Some(nd) if !unsafe { pyre_object::is_none(*nd) } => {
                     crate::call::call_function_impl_result(method, &[obj, *nd])?
@@ -11998,7 +12020,7 @@ pub(crate) fn builtin_round(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::
         }
     }
     let type_name = match crate::typedef::r#type(obj) {
-        Some(tp) => unsafe { pyre_object::w_type_get_name(tp).to_string() },
+        Some(tp) => unsafe { pyre_object::w_type_get_name(tp.as_ptr()).to_string() },
         None => unsafe { (*(*obj).ob_type).name.to_string() },
     };
     Err(crate::PyError::type_error(format!(
@@ -12592,7 +12614,7 @@ mod tests {
         assert!(!closed.is_null());
 
         let raw = builtin_open(&[w_str_new(path_text), w_str_new("rb"), w_int_new(0)]).unwrap();
-        let raw_type = crate::typedef::r#type(raw).unwrap();
+        let raw_type = crate::typedef::r#type(raw).unwrap().as_ptr();
         assert_eq!(unsafe { pyre_object::w_type_get_name(raw_type) }, "FileIO");
         let closed = crate::baseobjspace::call_method(raw, "close", &[]);
         assert!(!closed.is_null());

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -1074,7 +1074,7 @@ pub fn call_kw(
 /// the default class-instantiation path should run.
 fn metaclass_call_override(callable: PyObjectRef) -> Option<PyObjectRef> {
     let metaclass = crate::typedef::r#type(callable)?;
-    if std::ptr::eq(metaclass, crate::typedef::w_type()) {
+    if std::ptr::eq(metaclass.as_ptr(), crate::typedef::w_type()) {
         return None;
     }
     // Resolve WHERE `__call__` is defined first; the default `type.__call__`
@@ -1082,14 +1082,16 @@ fn metaclass_call_override(callable: PyObjectRef) -> Option<PyObjectRef> {
     // that merely inherits it — e.g. ABCMeta — keeps the fast path.  The
     // defining-class half is the cheap guard, so it runs before the value
     // half's second residual walk (avoided on the common fast path).
-    let where_defined =
-        unsafe { crate::baseobjspace::lookup_where_class_uncached(metaclass, "__call__") }?;
+    let where_defined = unsafe {
+        crate::baseobjspace::lookup_where_class_uncached(metaclass.as_ptr(), "__call__")
+    }?;
     if std::ptr::eq(where_defined, crate::typedef::w_type()) {
         return None;
     }
-    let call_descr =
-        unsafe { crate::baseobjspace::lookup_in_type_where_uncached(metaclass, "__call__") }?;
-    let bound = unsafe { crate::baseobjspace::get(call_descr, callable, metaclass) }
+    let call_descr = unsafe {
+        crate::baseobjspace::lookup_in_type_where_uncached(metaclass.as_ptr(), "__call__")
+    }?;
+    let bound = unsafe { crate::baseobjspace::get(call_descr, callable, metaclass.as_ptr()) }
         .ok()
         .flatten()
         .unwrap_or(call_descr);
@@ -1107,12 +1109,13 @@ fn classmethod_call_override(callable: PyObjectRef) -> Result<Option<PyObjectRef
     let Some(w_type) = crate::typedef::r#type(callable) else {
         return Ok(None);
     };
-    let Some(call_descr) = (unsafe { crate::baseobjspace::lookup_in_type(w_type, "__call__") })
+    let Some(call_descr) =
+        (unsafe { crate::baseobjspace::lookup_in_type(w_type.as_ptr(), "__call__") })
     else {
         return Ok(None);
     };
-    let bound =
-        unsafe { crate::baseobjspace::get(call_descr, callable, w_type) }?.unwrap_or(call_descr);
+    let bound = unsafe { crate::baseobjspace::get(call_descr, callable, w_type.as_ptr()) }?
+        .unwrap_or(call_descr);
     Ok(Some(bound))
 }
 
@@ -1129,12 +1132,13 @@ fn staticmethod_call_override(callable: PyObjectRef) -> Result<Option<PyObjectRe
     let Some(w_type) = crate::typedef::r#type(callable) else {
         return Ok(None);
     };
-    let Some(call_descr) = (unsafe { crate::baseobjspace::lookup_in_type(w_type, "__call__") })
+    let Some(call_descr) =
+        (unsafe { crate::baseobjspace::lookup_in_type(w_type.as_ptr(), "__call__") })
     else {
         return Ok(None);
     };
-    let bound =
-        unsafe { crate::baseobjspace::get(call_descr, callable, w_type) }?.unwrap_or(call_descr);
+    let bound = unsafe { crate::baseobjspace::get(call_descr, callable, w_type.as_ptr()) }?
+        .unwrap_or(call_descr);
     Ok(Some(bound))
 }
 
@@ -1846,7 +1850,7 @@ pub fn call_with_kwargs(
             return call_with_kwargs(frame, bound, pos_args, kwargs);
         }
         let type_name = crate::typedef::r#type(callable)
-            .map(|tp| unsafe { pyre_object::w_type_get_name(tp) })
+            .map(|tp| unsafe { pyre_object::w_type_get_name(tp.as_ptr()) })
             .unwrap_or("classmethod");
         return Err(PyError::type_error(format!(
             "'{type_name}' object is not callable"
@@ -2548,7 +2552,7 @@ pub fn call_function_impl_result(
         }
     }
     let type_name = crate::typedef::r#type(callable)
-        .map(|tp| unsafe { pyre_object::w_type_get_name(tp) })
+        .map(|tp| unsafe { pyre_object::w_type_get_name(tp.as_ptr()) })
         .unwrap_or_else(|| unsafe { (*(*callable).ob_type).name });
     Err(PyError::type_error(format!(
         "'{type_name}' object is not callable"
@@ -2574,11 +2578,13 @@ pub(crate) fn calculate_metaclass(
         let Some(w_base_type) = crate::typedef::r#type(base) else {
             continue;
         };
-        if std::ptr::eq(w_winner, w_base_type) || issubtype_ptr(w_winner, w_base_type) {
+        if std::ptr::eq(w_winner, w_base_type.as_ptr())
+            || issubtype_ptr(w_winner, w_base_type.as_ptr())
+        {
             continue;
         }
-        if issubtype_ptr(w_base_type, w_winner) {
-            w_winner = w_base_type;
+        if issubtype_ptr(w_base_type.as_ptr(), w_winner) {
+            w_winner = w_base_type.as_ptr();
             continue;
         }
         return Err(PyError::type_error(
@@ -2706,7 +2712,7 @@ fn check_init_returned_none(result: PyObjectRef) -> Result<(), PyError> {
         return Ok(());
     }
     let tname = crate::typedef::r#type(result)
-        .map(|t| unsafe { pyre_object::w_type_get_name(t) })
+        .map(|t| unsafe { pyre_object::w_type_get_name(t.as_ptr()) })
         .unwrap_or("object");
     Err(PyError::type_error(format!(
         "__init__() should return None, not '{tname}'"
@@ -2715,8 +2721,8 @@ fn check_init_returned_none(result: PyObjectRef) -> Result<(), PyError> {
 
 fn type_call_init_type(instance: PyObjectRef, w_type: PyObjectRef) -> Option<PyObjectRef> {
     let w_insttype = crate::typedef::r#type(instance)?;
-    if std::ptr::eq(w_insttype, w_type) || issubtype_ptr(w_insttype, w_type) {
-        Some(w_insttype)
+    if std::ptr::eq(w_insttype.as_ptr(), w_type) || issubtype_ptr(w_insttype.as_ptr(), w_type) {
+        Some(w_insttype.as_ptr())
     } else {
         None
     }
@@ -3288,7 +3294,7 @@ fn build_class_inner(
                     };
                     let result_type = unsafe {
                         match crate::typedef::r#type(ns_obj) {
-                            Some(tp) => pyre_object::w_type_get_name(tp).to_string(),
+                            Some(tp) => pyre_object::w_type_get_name(tp.as_ptr()).to_string(),
                             None => (*(*ns_obj).ob_type).name.to_string(),
                         }
                     };

--- a/pyre/pyre-interpreter/src/display.rs
+++ b/pyre/pyre-interpreter/src/display.rs
@@ -40,7 +40,7 @@ pub(crate) unsafe fn try_call_dunder_obj(
         }
         // A raising `__repr__`/`__str__` propagates; a non-string return is a
         // TypeError (`object.c slot_tp_repr` / `slot_tp_str`).
-        let w_type = crate::typedef::r#type(obj).unwrap_or(pyre_object::PY_NULL);
+        let w_type = crate::typedef::r#type(obj).map_or(pyre_object::PY_NULL, |p| p.as_ptr());
         let result = crate::baseobjspace::get_and_call_function(method, obj, w_type, &[])?;
         if pyre_object::is_str(result) {
             return Ok(Some(result));
@@ -60,13 +60,14 @@ pub(crate) unsafe fn try_call_dunder_obj_above_object(
         let Some(w_type) = crate::typedef::r#type(obj) else {
             return Ok(None);
         };
-        let Some((src, method)) = crate::baseobjspace::lookup_where_pair(w_type, name) else {
+        let Some((src, method)) = crate::baseobjspace::lookup_where_pair(w_type.as_ptr(), name)
+        else {
             return Ok(None);
         };
         if method.is_null() || std::ptr::eq(src, crate::typedef::w_object()) {
             return Ok(None);
         }
-        let result = crate::baseobjspace::get_and_call_function(method, obj, w_type, &[])?;
+        let result = crate::baseobjspace::get_and_call_function(method, obj, w_type.as_ptr(), &[])?;
         if pyre_object::is_str(result) {
             return Ok(Some(result));
         }
@@ -91,7 +92,7 @@ unsafe fn try_call_dunder_wtf8(
 /// override returned a non-`str` (`descroperation.py:918-920`).
 unsafe fn dunder_returned_non_string(name: &str, result: PyObjectRef) -> crate::PyError {
     let type_name = match unsafe { crate::typedef::r#type(result) } {
-        Some(tp) => unsafe { pyre_object::w_type_get_name(tp) }.to_string(),
+        Some(tp) => unsafe { pyre_object::w_type_get_name(tp.as_ptr()) }.to_string(),
         None => "object".to_string(),
     };
     crate::PyError::type_error(format!("{name} returned non-string (type '{type_name}')"))
@@ -391,10 +392,11 @@ pub(crate) unsafe fn type_metaclass_dunder_obj(
         let Some(metaclass) = crate::typedef::r#type(obj) else {
             return Ok(None);
         };
-        if !pyre_object::is_type(metaclass) {
+        if !pyre_object::is_type(metaclass.as_ptr()) {
             return Ok(None);
         }
-        let Some((src, method)) = crate::baseobjspace::lookup_where_pair(metaclass, name) else {
+        let Some((src, method)) = crate::baseobjspace::lookup_where_pair(metaclass.as_ptr(), name)
+        else {
             return Ok(None);
         };
         if std::ptr::eq(src, crate::typedef::w_type())
@@ -671,7 +673,7 @@ pub unsafe fn py_repr(obj: PyObjectRef) -> Result<String, crate::PyError> {
             let is_frozen = pyre_object::is_frozenset(obj);
             let is_exact_set = pyre_object::is_exact_type(obj, &pyre_object::setobject::SET_TYPE);
             let class_name = crate::typedef::r#type(obj)
-                .map(|w_type| pyre_object::w_type_get_name(w_type))
+                .map(|w_type| pyre_object::w_type_get_name(w_type.as_ptr()))
                 .unwrap_or(if is_frozen { "frozenset" } else { "set" });
             let Some(_guard) = ReprGuard::enter(obj) else {
                 return Ok(format!("{class_name}(...)"));
@@ -742,7 +744,7 @@ pub unsafe fn py_repr(obj: PyObjectRef) -> Result<String, crate::PyError> {
             // produced outside the constructor path (`gateway.rs` raise
             // sites that bypass `exc_constructor!`).
             let class_name = if let Some(cls) = crate::typedef::r#type(obj) {
-                pyre_object::w_type_get_name(cls).to_string()
+                pyre_object::w_type_get_name(cls.as_ptr()).to_string()
             } else {
                 pyre_object::interp_exceptions::exc_kind_name(pyre_object::w_exception_get_kind(
                     obj,

--- a/pyre/pyre-interpreter/src/error.rs
+++ b/pyre/pyre-interpreter/src/error.rs
@@ -1430,7 +1430,8 @@ fn exc_object_class_name(exc: PyObjectRef) -> Option<String> {
     if exc.is_null() || !unsafe { pyre_object::is_exception(exc) } {
         return None;
     }
-    crate::typedef::r#type(exc).map(|tp| unsafe { pyre_object::w_type_get_name(tp).to_string() })
+    crate::typedef::r#type(exc)
+        .map(|tp| unsafe { pyre_object::w_type_get_name(tp.as_ptr()).to_string() })
 }
 
 impl std::fmt::Display for PyError {

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -1281,7 +1281,7 @@ pub fn check_exc_match_against(exc_value: PyObjectRef, exc_type: PyObjectRef) ->
     let Some(w_exc_class) = crate::typedef::r#type(exc_value) else {
         return false;
     };
-    crate::baseobjspace::exception_match(w_exc_class, exc_type)
+    crate::baseobjspace::exception_match(w_exc_class.as_ptr(), exc_type)
 }
 
 /// Try to dispatch an exception using the exception table or block stack.
@@ -2446,7 +2446,7 @@ impl IterOpcodeHandler for PyFrame {
             // this only sees non-iterator containers.
             if pyre_object::is_instance(iter)
                 || crate::typedef::r#type(iter).is_some_and(|t| {
-                    crate::baseobjspace::lookup_in_type_where(t, "__iter__").is_some()
+                    crate::baseobjspace::lookup_in_type_where(t.as_ptr(), "__iter__").is_some()
                 })
             {
                 let result = crate::baseobjspace::iter(iter)?;
@@ -2792,7 +2792,7 @@ pub fn compute_load_method_bound(obj: PyObjectRef, attr: PyObjectRef, name: &str
                     // metaclass MRO; bind the type for a method-descriptor
                     // function getattr surfaced unchanged.
                     match crate::typedef::r#type(obj)
-                        .and_then(|meta| crate::baseobjspace::lookup_in_type(meta, name))
+                        .and_then(|meta| crate::baseobjspace::lookup_in_type(meta.as_ptr(), name))
                     {
                         Some(d) => method_descriptor_bound(d, attr, obj),
                         None => PY_NULL,
@@ -2808,9 +2808,9 @@ pub fn compute_load_method_bound(obj: PyObjectRef, attr: PyObjectRef, name: &str
             // FunctionWithFixedCode (interp2app) attrs that getattr
             // returns unchanged, while staticmethods (str.maketrans) and
             // classmethods (dict.fromkeys) were already unwrapped.
-            match crate::baseobjspace::lookup_in_type(w_type, name) {
+            match crate::baseobjspace::lookup_in_type(w_type.as_ptr(), name) {
                 Some(d) if pyre_object::is_staticmethod(d) => PY_NULL,
-                Some(d) if pyre_object::is_classmethod(d) => w_type,
+                Some(d) if pyre_object::is_classmethod(d) => w_type.as_ptr(),
                 Some(d) => method_descriptor_bound(d, attr, obj),
                 None => PY_NULL,
             }
@@ -2879,7 +2879,7 @@ impl OpcodeStepExecutor for PyFrame {
         let val = self.locals_w()[depth - 1];
         let exit_self = self.locals_w()[depth - 4];
         let exit_func = self.locals_w()[depth - 5];
-        let exc_type = crate::typedef::r#type(val).unwrap_or(pyre_object::w_none());
+        let exc_type = crate::typedef::r#type(val).map_or(pyre_object::w_none(), |p| p.as_ptr());
         let exc_tb =
             crate::baseobjspace::getattr_str(val, "__traceback__").unwrap_or(pyre_object::w_none());
         let res = if exit_self.is_null() {
@@ -3600,7 +3600,7 @@ impl OpcodeStepExecutor for PyFrame {
     fn match_mapping(&mut self) -> Result<(), PyError> {
         let subject = PyFrame::peek_at(self, 0);
         let is_mapping = unsafe {
-            let ty = crate::typedef::r#type(subject).unwrap_or(std::ptr::null_mut());
+            let ty = crate::typedef::r#type(subject).map_or(std::ptr::null_mut(), |p| p.as_ptr());
             pyre_object::typeobject::w_type_get_flag_map_or_seq(ty) == b'M'
         };
         self.push(pyre_object::boolobject::w_bool_from(is_mapping));
@@ -3610,7 +3610,7 @@ impl OpcodeStepExecutor for PyFrame {
     fn match_sequence(&mut self) -> Result<(), PyError> {
         let subject = PyFrame::peek_at(self, 0);
         let is_sequence = unsafe {
-            let ty = crate::typedef::r#type(subject).unwrap_or(std::ptr::null_mut());
+            let ty = crate::typedef::r#type(subject).map_or(std::ptr::null_mut(), |p| p.as_ptr());
             pyre_object::typeobject::w_type_get_flag_map_or_seq(ty) == b'S'
         };
         self.push(pyre_object::boolobject::w_bool_from(is_sequence));
@@ -3701,7 +3701,8 @@ impl OpcodeStepExecutor for PyFrame {
                 if unsafe { !pyre_object::is_tuple(match_args) } {
                     let got = unsafe {
                         pyre_object::w_type_get_name(
-                            crate::typedef::r#type(match_args).unwrap_or(std::ptr::null_mut()),
+                            crate::typedef::r#type(match_args)
+                                .map_or(std::ptr::null_mut(), |p| p.as_ptr()),
                         )
                     };
                     return Err(crate::PyError::type_error(format!(
@@ -3723,7 +3724,7 @@ impl OpcodeStepExecutor for PyFrame {
                             let got = unsafe {
                                 pyre_object::w_type_get_name(
                                     crate::typedef::r#type(attr_obj)
-                                        .unwrap_or(std::ptr::null_mut()),
+                                        .map_or(std::ptr::null_mut(), |p| p.as_ptr()),
                                 )
                             };
                             return Err(crate::PyError::type_error(format!(

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -3100,7 +3100,11 @@ impl OpcodeStepExecutor for PyFrame {
             2 => {
                 // pyopcode.py:704-722 — pop+normalize cause first, then exc.
                 let raw_cause = self.pop();
-                let cause = Some(normalize_raise_cause(raw_cause)?);
+                // `normalize_raise_cause` returns `Ok(null)` for a null/absent
+                // cause; report absence as `None` so the value is never
+                // `Some(null)` (mirrors the JIT paths call_jit.rs / trace_opcode.rs).
+                let c = normalize_raise_cause(raw_cause)?;
+                let cause = if c.is_null() { None } else { Some(c) };
                 let w_value = self.pop();
                 unsafe {
                     if crate::baseobjspace::exception_is_valid_obj_as_class_w(w_value) {

--- a/pyre/pyre-interpreter/src/executioncontext.rs
+++ b/pyre/pyre-interpreter/src/executioncontext.rs
@@ -121,7 +121,7 @@ pub fn maybe_register_user_finalizer(obj: PyObjectRef) {
     let Some(w_type) = crate::typedef::r#type(obj) else {
         return;
     };
-    if unsafe { pyre_object::w_type_get_hasuserdel(w_type) } {
+    if unsafe { pyre_object::w_type_get_hasuserdel(w_type.as_ptr()) } {
         pyre_object::gc_hook::try_gc_register_finalizer(0, obj, finalizer_queue_trigger);
     }
 }
@@ -152,7 +152,7 @@ pub fn register_native_buffer_finalizer(obj: PyObjectRef) {
 /// registered twice.
 pub fn register_weakref_finalizer(obj: PyObjectRef) {
     let already_registered = crate::typedef::r#type(obj)
-        .map(|w_type| unsafe { pyre_object::w_type_get_hasuserdel(w_type) })
+        .map(|w_type| unsafe { pyre_object::w_type_get_hasuserdel(w_type.as_ptr()) })
         .unwrap_or(false);
     let native_buffer_finalizer = crate::module::__pypy__::W_PickleBuffer::from_obj(obj).is_some()
         || crate::module::r#struct::unpack_iter::W_UnpackIter::from_obj(obj).is_some();
@@ -448,8 +448,8 @@ impl ExecutionContext {
                 if crate::is_function_with_fixed_code(w_func) {
                     if let Some(w_firstarg) = args.firstarg() {
                         if !w_firstarg.is_null() {
-                            let w_type =
-                                crate::typedef::r#type(w_firstarg).unwrap_or(pyre_object::PY_NULL);
+                            let w_type = crate::typedef::r#type(w_firstarg)
+                                .map_or(pyre_object::PY_NULL, |p| p.as_ptr());
                             w_func = crate::descr_function_get(w_func, w_firstarg, w_type);
                         }
                     }
@@ -920,7 +920,7 @@ impl ExecutionContext {
             let w_arg = if let Some(operr) = operr {
                 let w_value = operr.normalize_exception(space)?;
                 let w_type = if operr.w_type.is_null() {
-                    crate::typedef::r#type(w_value).unwrap_or_else(pyre_object::w_none)
+                    crate::typedef::r#type(w_value).map_or_else(pyre_object::w_none, |p| p.as_ptr())
                 } else {
                     operr.w_type
                 };
@@ -2039,7 +2039,8 @@ impl UserDelAction {
         let Some(w_type) = crate::typedef::r#type(w_obj) else {
             return;
         };
-        let Some(w_del) = (unsafe { crate::baseobjspace::lookup_in_type(w_type, "__del__") })
+        let Some(w_del) =
+            (unsafe { crate::baseobjspace::lookup_in_type(w_type.as_ptr(), "__del__") })
         else {
             return;
         };
@@ -2048,9 +2049,9 @@ impl UserDelAction {
         }
         // pyre's combined helper cannot distinguish get-vs-call errors;
         // report through the call arm (executioncontext.py:680-690).
-        if let Err(error) =
-            unsafe { crate::baseobjspace::get_and_call_function(w_del, w_obj, w_type, &[]) }
-        {
+        if let Err(error) = unsafe {
+            crate::baseobjspace::get_and_call_function(w_del, w_obj, w_type.as_ptr(), &[])
+        } {
             report_error(self.base.space, &error, "", w_del);
         }
     }

--- a/pyre/pyre-interpreter/src/function.rs
+++ b/pyre/pyre-interpreter/src/function.rs
@@ -2171,7 +2171,7 @@ pub unsafe fn descr_method__new__(
     if w_instance.is_null() || unsafe { pyre_object::is_none(w_instance) } {
         return Err(crate::PyError::type_error("instance must not be None"));
     }
-    let w_class = crate::typedef::r#type(w_instance).unwrap_or(pyre_object::PY_NULL);
+    let w_class = crate::typedef::r#type(w_instance).map_or(pyre_object::PY_NULL, |p| p.as_ptr());
     Ok(pyre_object::w_method_new(w_function, w_instance, w_class))
 }
 
@@ -2182,7 +2182,7 @@ pub unsafe fn descr_method__new__(
 pub fn require_method(method: PyObjectRef, name: &str) -> Result<PyObjectRef, crate::PyError> {
     if method.is_null() || !unsafe { pyre_object::function::is_method(method) } {
         let received = crate::typedef::r#type(method)
-            .map(|tp| unsafe { pyre_object::w_type_get_name(tp) })
+            .map(|tp| unsafe { pyre_object::w_type_get_name(tp.as_ptr()) })
             .unwrap_or("object");
         return Err(crate::PyError::type_error(format!(
             "descriptor '{name}' requires a 'method' object but received a '{received}'"

--- a/pyre/pyre-interpreter/src/gateway.rs
+++ b/pyre/pyre-interpreter/src/gateway.rs
@@ -953,7 +953,7 @@ pub fn fsencode_w(obj: pyre_object::PyObjectRef) -> Result<String, crate::PyErro
     // `type(path).__fspath__(path)` — the descriptor read off the type is
     // unbound, so `path` is supplied as the sole argument.
     if let Some(fspath_fn) = crate::typedef::r#type(obj)
-        .and_then(|pt| unsafe { crate::baseobjspace::lookup_in_type(pt, "__fspath__") })
+        .and_then(|pt| unsafe { crate::baseobjspace::lookup_in_type(pt.as_ptr(), "__fspath__") })
     {
         let result = crate::call::call_function_impl_result(fspath_fn, &[obj])?;
         unsafe {

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -3392,7 +3392,7 @@ pub fn import_from(
 fn type_name_for_err(w_obj: PyObjectRef) -> String {
     unsafe {
         match crate::typedef::r#type(w_obj) {
-            Some(tp) => pyre_object::w_type_get_name(tp).to_string(),
+            Some(tp) => pyre_object::w_type_get_name(tp.as_ptr()).to_string(),
             None => (*(*w_obj).ob_type).name.to_string(),
         }
     }

--- a/pyre/pyre-interpreter/src/module/__pypy__/interp_buffer.rs
+++ b/pyre/pyre-interpreter/src/module/__pypy__/interp_buffer.rs
@@ -129,7 +129,7 @@ impl W_PickleBuffer {
             let callback_result = if let Some(w_release) =
                 unsafe { crate::baseobjspace::lookup(w_exporter, "__release_buffer__") }
             {
-                let w_type = crate::typedef::r#type(w_exporter).unwrap_or(w_exporter);
+                let w_type = crate::typedef::r#type(w_exporter).map_or(w_exporter, |p| p.as_ptr());
                 unsafe {
                     crate::baseobjspace::get_and_call_function(
                         w_release,
@@ -195,7 +195,7 @@ fn released_error() -> PyError {
 
 fn type_name(obj: PyObjectRef) -> String {
     match crate::typedef::r#type(obj) {
-        Some(t) => unsafe { pyre_object::w_type_get_name(t) }.to_string(),
+        Some(t) => unsafe { pyre_object::w_type_get_name(t.as_ptr()) }.to_string(),
         None => "object".to_string(),
     }
 }
@@ -228,7 +228,7 @@ fn acquire_pickle_buffer(obj: PyObjectRef) -> Result<(PyObjectRef, bool, PyObjec
         let r_obj = pyre_object::gc_roots::shadow_stack_get(sp);
         if let Some(w_impl) = crate::baseobjspace::lookup(r_obj, "__buffer__") {
             pyre_object::gc_roots::pin_root(w_impl);
-            let w_type = crate::typedef::r#type(r_obj).unwrap_or(r_obj);
+            let w_type = crate::typedef::r#type(r_obj).map_or(r_obj, |p| p.as_ptr());
             let w_result = crate::baseobjspace::get_and_call_function(
                 pyre_object::gc_roots::shadow_stack_get(sp + 2),
                 r_obj,

--- a/pyre/pyre-interpreter/src/module/_abc/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_abc/mod.rs
@@ -202,7 +202,7 @@ fn instancecheck(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     // carry the generic layout marker in `ob_type` and the real class in
     // `w_class`, so reading `ob_type` directly would resolve to `object`;
     // `r#type` returns the class for both builtin and user instances.
-    let subclass = crate::typedef::r#type(instance).unwrap_or(std::ptr::null_mut());
+    let subclass = crate::typedef::r#type(instance).map_or(std::ptr::null_mut(), |p| p.as_ptr());
     if subclass.is_null() {
         return Ok(w_bool_from(false));
     }

--- a/pyre/pyre-interpreter/src/module/_ast/convert.rs
+++ b/pyre/pyre-interpreter/src/module/_ast/convert.rs
@@ -1413,8 +1413,8 @@ impl Converter<'_> {
     fn number(&self, value: &ast::Number) -> crate::PyResult {
         Ok(match value {
             ast::Number::Int(value) => {
-                let int_type =
-                    crate::typedef::gettypefor(&pyre_object::INT_TYPE).unwrap_or(PY_NULL);
+                let int_type = crate::typedef::gettypefor(&pyre_object::INT_TYPE)
+                    .map_or(PY_NULL, |p| p.as_ptr());
                 crate::call::call_function_impl_result(
                     int_type,
                     &[self.string(&value.to_string())],
@@ -1434,8 +1434,8 @@ impl Converter<'_> {
             ast::ConstantValue::Str(value) => self.string(value),
             ast::ConstantValue::Bytes(value) => self.pin(pyre_object::w_bytes_from_bytes(value)),
             ast::ConstantValue::Integer(value) => {
-                let int_type =
-                    crate::typedef::gettypefor(&pyre_object::INT_TYPE).unwrap_or(PY_NULL);
+                let int_type = crate::typedef::gettypefor(&pyre_object::INT_TYPE)
+                    .map_or(PY_NULL, |p| p.as_ptr());
                 crate::call::call_function_impl_result(int_type, &[self.string(value)])?
             }
             ast::ConstantValue::Float(value) => self.pin(pyre_object::w_float_new(*value)),

--- a/pyre/pyre-interpreter/src/module/_csv/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_csv/mod.rs
@@ -612,7 +612,7 @@ fn save_field(
 fn to_float(w_str: PyObjectRef) -> Result<PyObjectRef, PyError> {
     let float_type = crate::typedef::gettypefor(&pyre_object::FLOAT_TYPE)
         .ok_or_else(|| PyError::runtime_error("float type unavailable"))?;
-    crate::call::call_function_impl_result(float_type, &[w_str])
+    crate::call::call_function_impl_result(float_type.as_ptr(), &[w_str])
 }
 
 /// `W_Reader.next_w` — parse the next CSV record from the underlying line

--- a/pyre/pyre-interpreter/src/module/_ctypes/funcptr.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/funcptr.rs
@@ -109,7 +109,8 @@ fn cfuncptr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         Some(a) => {
             let callable = unsafe { crate::function::is_function(a) }
                 || crate::typedef::r#type(a).is_some_and(|ty| {
-                    unsafe { crate::baseobjspace::lookup_in_type(ty, "__call__") }.is_some()
+                    unsafe { crate::baseobjspace::lookup_in_type(ty.as_ptr(), "__call__") }
+                        .is_some()
                 });
             if !callable {
                 return Err(crate::PyError::type_error(

--- a/pyre/pyre-interpreter/src/module/_sre/interp_sre.rs
+++ b/pyre/pyre-interpreter/src/module/_sre/interp_sre.rs
@@ -1289,8 +1289,8 @@ fn subx(args: &[PyObjectRef]) -> Result<(PyObjectRef, i64), crate::PyError> {
 fn is_exact_str_or_bytes(w: PyObjectRef) -> bool {
     match crate::typedef::r#type(w) {
         Some(t) => unsafe {
-            std::ptr::eq(t, pyre_object::get_instantiate(&pyre_object::STR_TYPE))
-                || std::ptr::eq(t, pyre_object::get_instantiate(&pyre_object::BYTES_TYPE))
+            std::ptr::eq(t.as_ptr(), pyre_object::get_instantiate(&pyre_object::STR_TYPE))
+                || std::ptr::eq(t.as_ptr(), pyre_object::get_instantiate(&pyre_object::BYTES_TYPE))
         },
         None => false,
     }

--- a/pyre/pyre-interpreter/src/module/_warnings/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_warnings/mod.rs
@@ -100,6 +100,7 @@ fn get_category(message: PyObjectRef, category: PyObjectRef) -> Result<PyObjectR
     let warning = warning_class("Warning");
     if crate::baseobjspace::isinstance(message, warning)? {
         return crate::typedef::r#type(message)
+            .map(|p| p.as_ptr())
             .ok_or_else(|| PyError::type_error("warning instance has no type"));
     }
     let category = if category.is_null() || unsafe { is_none(category) } {
@@ -585,6 +586,7 @@ fn do_warn_explicit(
             )])?,
             pyre_object::gc_roots::shadow_stack_get(input_message_slot),
             crate::typedef::r#type(pyre_object::gc_roots::shadow_stack_get(input_message_slot))
+                .map(|p| p.as_ptr())
                 .unwrap_or(category),
         )
     } else {

--- a/pyre/pyre-interpreter/src/module/_weakref/interp__weakref.rs
+++ b/pyre/pyre-interpreter/src/module/_weakref/interp__weakref.rs
@@ -681,10 +681,10 @@ pub fn descr__repr__(args: &[PyObjectRef]) -> Result<PyObjectRef, PyError> {
     let w_obj = dereference(w_self);
     let type_name = unsafe {
         match crate::typedef::r#type(w_self) {
-            Some(tp) if std::ptr::eq(tp, weakref_type()) => "weakref",
-            Some(tp) if std::ptr::eq(tp, proxy_type()) => "weakproxy",
-            Some(tp) if std::ptr::eq(tp, callable_proxy_type()) => "weakcallableproxy",
-            Some(tp) => pyre_object::w_type_get_name(tp),
+            Some(tp) if std::ptr::eq(tp.as_ptr(), weakref_type()) => "weakref",
+            Some(tp) if std::ptr::eq(tp.as_ptr(), proxy_type()) => "weakproxy",
+            Some(tp) if std::ptr::eq(tp.as_ptr(), callable_proxy_type()) => "weakcallableproxy",
+            Some(tp) => pyre_object::w_type_get_name(tp.as_ptr()),
             None => "weakref",
         }
     };
@@ -693,7 +693,7 @@ pub fn descr__repr__(args: &[PyObjectRef]) -> Result<PyObjectRef, PyError> {
     } else {
         let objtype_name = unsafe {
             match crate::typedef::r#type(w_obj) {
-                Some(tp) => pyre_object::w_type_get_name(tp).to_string(),
+                Some(tp) => pyre_object::w_type_get_name(tp.as_ptr()).to_string(),
                 None => "object".to_string(),
             }
         };
@@ -1217,7 +1217,10 @@ pub fn is_w_abstract_proxy(obj: PyObjectRef) -> bool {
         return false;
     }
     match crate::typedef::r#type(obj) {
-        Some(tp) => std::ptr::eq(tp, proxy_type()) || std::ptr::eq(tp, callable_proxy_type()),
+        Some(tp) => {
+            std::ptr::eq(tp.as_ptr(), proxy_type())
+                || std::ptr::eq(tp.as_ptr(), callable_proxy_type())
+        }
         None => false,
     }
 }
@@ -2262,7 +2265,9 @@ mod tests {
     fn test_isinstance_through_proxy() {
         let _g = super::lock_proxy_tests();
         crate::typedef::init_typeobjects();
-        let int_type = crate::typedef::r#type(pyre_object::w_int_new(0)).unwrap();
+        let int_type = crate::typedef::r#type(pyre_object::w_int_new(0))
+            .unwrap()
+            .as_ptr();
         let proxy = W_Proxy_new(int_type, PY_NULL);
         // 7 is an int — through the proxy it must still resolve.
         let yes = crate::baseobjspace::isinstance(pyre_object::w_int_new(7), proxy).unwrap();
@@ -2278,8 +2283,12 @@ mod tests {
     fn test_issubclass_through_proxy() {
         let _g = super::lock_proxy_tests();
         crate::typedef::init_typeobjects();
-        let int_type = crate::typedef::r#type(pyre_object::w_int_new(0)).unwrap();
-        let str_type = crate::typedef::r#type(pyre_object::w_str_new("")).unwrap();
+        let int_type = crate::typedef::r#type(pyre_object::w_int_new(0))
+            .unwrap()
+            .as_ptr();
+        let str_type = crate::typedef::r#type(pyre_object::w_str_new(""))
+            .unwrap()
+            .as_ptr();
         let proxy = W_Proxy_new(int_type, PY_NULL);
         let yes = crate::baseobjspace::issubclass(int_type, proxy).unwrap();
         assert!(yes);
@@ -2326,7 +2335,9 @@ mod tests {
             };
         });
         let checker = pyre_object::objectobject::w_instance_new(user_type);
-        let int_type = crate::typedef::r#type(pyre_object::w_int_new(0)).unwrap();
+        let int_type = crate::typedef::r#type(pyre_object::w_int_new(0))
+            .unwrap()
+            .as_ptr();
         let yes = crate::baseobjspace::issubclass(int_type, checker).unwrap();
         assert!(yes);
     }

--- a/pyre/pyre-interpreter/src/module/array/mod.rs
+++ b/pyre/pyre-interpreter/src/module/array/mod.rs
@@ -1138,7 +1138,7 @@ fn array_reduce_ex_method(args: &[PyObjectRef]) -> PyResult {
     check_arity(args, 2, "array.__reduce_ex__")?;
     let obj = args[0];
     let protocol = crate::baseobjspace::int_w(args[1])?;
-    let w_type = crate::typedef::r#type(obj).unwrap_or(PY_NULL);
+    let w_type = crate::typedef::r#type(obj).map_or(PY_NULL, |p| p.as_ptr());
     let typecode = unsafe { arr::w_array_typecode(obj) };
     let tc = typecode as char;
     let w_typecode = pyre_object::w_str_new(&tc.to_string());

--- a/pyre/pyre-interpreter/src/module/array/mod.rs
+++ b/pyre/pyre-interpreter/src/module/array/mod.rs
@@ -258,7 +258,7 @@ fn array_descr_new(args: &[PyObjectRef]) -> PyResult {
     if !cls.is_null() && unsafe { pyre_object::is_type(cls) } {
         if let Some(canonical) = crate::typedef::gettypefor(&pyre_object::interp_array::ARRAY_TYPE)
         {
-            if !std::ptr::eq(cls, canonical) {
+            if !std::ptr::eq(cls, canonical.as_ptr()) {
                 unsafe {
                     (*obj).w_class = cls;
                 }

--- a/pyre/pyre-interpreter/src/module/imp/interp_imp.rs
+++ b/pyre/pyre-interpreter/src/module/imp/interp_imp.rs
@@ -161,7 +161,7 @@ fn missing_frozen_error(name: &str) -> crate::PyError {
 /// The receiver's type name, for argument-type error messages.
 fn type_name(obj: pyre_object::PyObjectRef) -> String {
     match crate::typedef::r#type(obj) {
-        Some(tp) => unsafe { pyre_object::w_type_get_name(tp) }.to_string(),
+        Some(tp) => unsafe { pyre_object::w_type_get_name(tp.as_ptr()) }.to_string(),
         None => "object".to_string(),
     }
 }

--- a/pyre/pyre-interpreter/src/module/itertools/interp_itertools.rs
+++ b/pyre/pyre-interpreter/src/module/itertools/interp_itertools.rs
@@ -105,8 +105,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     crate::module_ns_store(
         ns,
         "starmap",
-        crate::typedef::gettypefor(&pyre_object::interp_itertools::STARMAP_TYPE)
-            .expect("itertools.starmap TypeDef initialized"),
+        crate::typedef::gettypefor(&pyre_object::interp_itertools::STARMAP_TYPE).expect("itertools.starmap TypeDef initialized").as_ptr(),
     );
     // PyPy exposes W_Count.typedef / W_Repeat.typedef themselves from the
     // module, not function-shaped constructor shims.  Their `__new__` slots
@@ -114,14 +113,12 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     crate::module_ns_store(
         ns,
         "count",
-        crate::typedef::gettypefor(&pyre_object::interp_itertools::COUNT_TYPE)
-            .expect("itertools.count TypeDef initialized"),
+        crate::typedef::gettypefor(&pyre_object::interp_itertools::COUNT_TYPE).expect("itertools.count TypeDef initialized").as_ptr(),
     );
     crate::module_ns_store(
         ns,
         "repeat",
-        crate::typedef::gettypefor(&pyre_object::interp_itertools::REPEAT_TYPE)
-            .expect("itertools.repeat TypeDef initialized"),
+        crate::typedef::gettypefor(&pyre_object::interp_itertools::REPEAT_TYPE).expect("itertools.repeat TypeDef initialized").as_ptr(),
     );
     // islice(iterable, stop) | islice(iterable, start, stop[, step]) —
     // PyPy: W_ISlice.__init__.  Pulled lazily from the source iterator so
@@ -447,8 +444,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     crate::module_ns_store(
         ns,
         "zip_longest",
-        crate::typedef::gettypefor(&pyre_object::interp_itertools::ZIP_LONGEST_TYPE)
-            .expect("itertools.zip_longest TypeDef initialized"),
+        crate::typedef::gettypefor(&pyre_object::interp_itertools::ZIP_LONGEST_TYPE).expect("itertools.zip_longest TypeDef initialized").as_ptr(),
     );
     // PyPy exports the live W_Accumulate iterator TypeDef.  Its running total,
     // optional function, and initial value stay on the object and next_w
@@ -456,36 +452,31 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     crate::module_ns_store(
         ns,
         "accumulate",
-        crate::typedef::gettypefor(&pyre_object::interp_itertools::ACCUMULATE_TYPE)
-            .expect("itertools.accumulate TypeDef initialized"),
+        crate::typedef::gettypefor(&pyre_object::interp_itertools::ACCUMULATE_TYPE).expect("itertools.accumulate TypeDef initialized").as_ptr(),
     );
     // W_Compress.typedef is exported directly, matching PyPy's dedicated
     // live iterator rather than materializing both inputs into a list.
     crate::module_ns_store(
         ns,
         "compress",
-        crate::typedef::gettypefor(&pyre_object::interp_itertools::COMPRESS_TYPE)
-            .expect("itertools.compress TypeDef initialized"),
+        crate::typedef::gettypefor(&pyre_object::interp_itertools::COMPRESS_TYPE).expect("itertools.compress TypeDef initialized").as_ptr(),
     );
     // PyPy exposes these W_Root subclasses through their TypeDefs.  Their
     // `__new__` slots retain the two-argument/subclass-init gateway behavior.
     crate::module_ns_store(
         ns,
         "takewhile",
-        crate::typedef::gettypefor(&pyre_object::interp_itertools::TAKEWHILE_TYPE)
-            .expect("itertools.takewhile TypeDef initialized"),
+        crate::typedef::gettypefor(&pyre_object::interp_itertools::TAKEWHILE_TYPE).expect("itertools.takewhile TypeDef initialized").as_ptr(),
     );
     crate::module_ns_store(
         ns,
         "dropwhile",
-        crate::typedef::gettypefor(&pyre_object::interp_itertools::DROPWHILE_TYPE)
-            .expect("itertools.dropwhile TypeDef initialized"),
+        crate::typedef::gettypefor(&pyre_object::interp_itertools::DROPWHILE_TYPE).expect("itertools.dropwhile TypeDef initialized").as_ptr(),
     );
     crate::module_ns_store(
         ns,
         "filterfalse",
-        crate::typedef::gettypefor(&pyre_object::interp_itertools::FILTERFALSE_TYPE)
-            .expect("itertools.filterfalse TypeDef initialized"),
+        crate::typedef::gettypefor(&pyre_object::interp_itertools::FILTERFALSE_TYPE).expect("itertools.filterfalse TypeDef initialized").as_ptr(),
     );
     // pairwise(iterable) — W_Pairwise__new__: store `space.iter(w_iterable)`;
     // pairs are produced lazily by W_Pairwise.next_w (baseobjspace::next).

--- a/pyre/pyre-interpreter/src/module/mmap/interp_mmap.rs
+++ b/pyre/pyre-interpreter/src/module/mmap/interp_mmap.rs
@@ -138,7 +138,7 @@ fn mmap_ptr(obj: pyre_object::PyObjectRef) -> Result<(*mut u8, usize), crate::Py
 /// True when `obj` is an `mmap` instance.
 #[cfg(unix)]
 pub(crate) fn is_mmap(obj: pyre_object::PyObjectRef) -> bool {
-    crate::typedef::r#type(obj).is_some_and(|tp| std::ptr::eq(tp, mmap_type()))
+    crate::typedef::r#type(obj).is_some_and(|tp| std::ptr::eq(tp.as_ptr(), mmap_type()))
 }
 
 /// `_exports` — how many buffers are currently exported from the mapping.
@@ -179,7 +179,7 @@ pub(crate) fn mmap_buffer_view(
     obj: pyre_object::PyObjectRef,
 ) -> Option<Result<(usize, usize, bool), crate::PyError>> {
     let w_type = crate::typedef::r#type(obj)?;
-    if !std::ptr::eq(w_type, mmap_type()) {
+    if !std::ptr::eq(w_type.as_ptr(), mmap_type()) {
         return None;
     }
     Some(mmap_ptr(obj).map(|(ptr, len)| {

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -988,7 +988,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 Some(v) if !unsafe { pyre_object::is_none(v) } => {
                     if !unsafe { pyre_object::is_int(v) } {
                         let type_name = crate::typedef::r#type(v)
-                            .map(|t| unsafe { pyre_object::typeobject::w_type_get_name(t) })
+                            .map(|t| unsafe { pyre_object::typeobject::w_type_get_name(t.as_ptr()) })
                             .unwrap_or("object");
                         return Err(crate::PyError::type_error(format!(
                             "argument should be integer or None, not {type_name}"
@@ -1211,13 +1211,13 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 let path_type = crate::typedef::r#type(arg);
                 if let Some(pt) = path_type {
                     if let Some(fspath_fn) =
-                        unsafe { crate::baseobjspace::lookup_in_type(pt, "__fspath__") }
+                        unsafe { crate::baseobjspace::lookup_in_type(pt.as_ptr(), "__fspath__") }
                     {
                         return crate::call::call_function_impl_result(fspath_fn, &[arg]);
                     }
                 }
                 let type_name = match path_type {
-                    Some(pt) => unsafe { pyre_object::typeobject::w_type_get_name(pt) },
+                    Some(pt) => unsafe { pyre_object::typeobject::w_type_get_name(pt.as_ptr()) },
                     None => "object",
                 };
                 Err(crate::PyError::type_error(format!(

--- a/pyre/pyre-interpreter/src/module/struct/mod.rs
+++ b/pyre/pyre-interpreter/src/module/struct/mod.rs
@@ -335,7 +335,7 @@ unsafe fn accept_int(arg: PyObjectRef) -> Result<BigInt, crate::PyError> {
             return Ok(BigInt::from(if w_bool_get_value(arg) { 1 } else { 0 }));
         }
         if let Some(tp) = crate::typedef::r#type(arg) {
-            if let Some(index_fn) = crate::baseobjspace::lookup_in_type(tp, "__index__") {
+            if let Some(index_fn) = crate::baseobjspace::lookup_in_type(tp.as_ptr(), "__index__") {
                 let r = crate::call::call_function_impl_result(index_fn, &[arg])?;
                 if is_int(r) || is_long(r) {
                     return Ok(crate::builtins::obj_to_bigint(r));
@@ -373,7 +373,7 @@ unsafe fn accept_float(arg: PyObjectRef) -> Result<f64, crate::PyError> {
             return Ok(if w_bool_get_value(arg) { 1.0 } else { 0.0 });
         }
         if let Some(tp) = crate::typedef::r#type(arg) {
-            if let Some(float_fn) = crate::baseobjspace::lookup_in_type(tp, "__float__") {
+            if let Some(float_fn) = crate::baseobjspace::lookup_in_type(tp.as_ptr(), "__float__") {
                 let r = crate::call::call_function_impl_result(float_fn, &[arg])?;
                 if is_float(r) {
                     return Ok(w_float_get_value(r));

--- a/pyre/pyre-interpreter/src/module/time/interp_time.rs
+++ b/pyre/pyre-interpreter/src/module/time/interp_time.rs
@@ -142,7 +142,7 @@ pub fn sleep(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
                     || crate::baseobjspace::lookup(args[0], "__index__").is_some();
                 if !has_int {
                     let name = crate::typedef::r#type(args[0])
-                        .map(|tp| w_type_get_name(tp).to_string())
+                        .map(|tp| w_type_get_name(tp.as_ptr()).to_string())
                         .unwrap_or_else(|| "object".to_string());
                     return Err(crate::PyError::type_error(format!(
                         "'{name}' object cannot be interpreted as an integer"

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -2234,8 +2234,8 @@ unsafe fn try_compare_override(
     let comparison_method = |obj: PyObjectRef, name: &str| {
         if is_instance(obj) {
             let w_type = crate::typedef::r#type(obj)?;
-            let method = lookup_in_type_where(w_type, name)?;
-            Some((method, w_type))
+            let method = lookup_in_type_where(w_type.as_ptr(), name)?;
+            Some((method, w_type.as_ptr()))
         } else {
             crate::baseobjspace::subclass_special_override(obj, name)
         }
@@ -2244,8 +2244,7 @@ unsafe fn try_compare_override(
     let b_type = crate::typedef::r#type(b);
     let a_ov = comparison_method(a, dunder);
     let mut b_ov = comparison_method(b, rdunder);
-    if dunder == rdunder && matches!((a_type, b_type), (Some(at), Some(bt)) if std::ptr::eq(at, bt))
-    {
+    if dunder == rdunder && matches!((a_type, b_type), (Some(at), Some(bt)) if at == bt) {
         // descroperation.py: for __eq__ and __ne__, objects of the same
         // class resolve the same method, so do not invoke it twice.
         b_ov = None;
@@ -2258,7 +2257,7 @@ unsafe fn try_compare_override(
     // first.
     let b_first = b_ov.is_some()
         && match (a_type, b_type) {
-            (Some(at), Some(bt)) => !std::ptr::eq(at, bt) && issubtype_cached(bt, at),
+            (Some(at), Some(bt)) => at != bt && issubtype_cached(bt.as_ptr(), at.as_ptr()),
             _ => false,
         };
     let order = if b_first {
@@ -2329,7 +2328,9 @@ unsafe fn try_instance_unaryop(
 /// `str`/`list`/`tuple` install `__add__`/`__radd__` on their own type;
 /// an inherited (non-overridden) lookup resolves back to `tp`.
 unsafe fn dunder_overridden(obj: PyObjectRef, dunder: &str, tp: PyObjectRef) -> bool {
-    match crate::typedef::r#type(obj).and_then(|t| lookup_where_with_method_cache(t, dunder)) {
+    match crate::typedef::r#type(obj)
+        .and_then(|t| lookup_where_with_method_cache(t.as_ptr(), dunder))
+    {
         Some((src, _)) => !std::ptr::eq(src, tp),
         None => false,
     }
@@ -2518,7 +2519,7 @@ unsafe fn try_numeric_unaryop_override(
     let Some(t) = crate::typedef::r#type(a) else {
         return Ok(None);
     };
-    let Some(method) = lookup_in_type_where(t, dunder) else {
+    let Some(method) = lookup_in_type_where(t.as_ptr(), dunder) else {
         return Ok(None);
     };
     Ok(Some(crate::call::call_function_impl_result(method, &[a])?))
@@ -2820,7 +2821,7 @@ pub fn mod_(a: PyObjectRef, b: PyObjectRef) -> PyResult {
                 crate::baseobjspace::subclass_special_override(b, "__rmod__")
             {
                 let priority = match (crate::typedef::r#type(a), crate::typedef::r#type(b)) {
-                    (Some(at), Some(bt)) => !std::ptr::eq(at, bt) && issubtype_cached(bt, at),
+                    (Some(at), Some(bt)) => at != bt && issubtype_cached(bt.as_ptr(), at.as_ptr()),
                     _ => false,
                 };
                 if priority {
@@ -3173,7 +3174,7 @@ pub(crate) fn xor_builtin(a: PyObjectRef, b: PyObjectRef) -> PyResult {
 
 /// `space.lookup(w_obj, dunder)` — descroperation.py.
 pub(crate) unsafe fn lookup_type_special(obj: PyObjectRef, dunder: &str) -> Option<PyObjectRef> {
-    crate::typedef::r#type(obj).and_then(|tp| lookup_in_type(tp, dunder))
+    crate::typedef::r#type(obj).and_then(|tp| lookup_in_type(tp.as_ptr(), dunder))
 }
 
 /// Call a special method and treat NotImplemented as "no result", per
@@ -3209,17 +3210,19 @@ pub(crate) fn try_dispatch_binary_special(
         let Some(w_typ2) = crate::typedef::r#type(rhs) else {
             return Ok(None);
         };
-        let (w_left_src, mut w_left_impl) = match lookup_where_with_method_cache(w_typ1, dunder) {
-            Some((src, imp)) => (Some(src), Some(imp)),
-            None => (None, None),
-        };
+        let (w_left_src, mut w_left_impl) =
+            match lookup_where_with_method_cache(w_typ1.as_ptr(), dunder) {
+                Some((src, imp)) => (Some(src), Some(imp)),
+                None => (None, None),
+            };
         let mut w_obj1 = lhs;
         let mut w_obj2 = rhs;
         let mut w_right_impl: Option<PyObjectRef> = None;
         // descroperation.py:652 — same type means the reflected method is
         // never considered.
-        if !std::ptr::eq(w_typ1, w_typ2) {
-            let (w_right_src, wri) = match lookup_where_with_method_cache(w_typ2, rdunder) {
+        if w_typ1 != w_typ2 {
+            let (w_right_src, wri) = match lookup_where_with_method_cache(w_typ2.as_ptr(), rdunder)
+            {
                 Some((src, imp)) => (Some(src), Some(imp)),
                 None => (None, None),
             };
@@ -3230,13 +3233,13 @@ pub(crate) fn try_dispatch_binary_special(
                 if !std::ptr::eq(lsrc, rsrc) {
                     // descroperation.py:667-670.
                     let prefer_reverse = (seq_bug_compat
-                        && crate::baseobjspace::flag_sequence_bug_compat(w_typ1)
-                        && !crate::baseobjspace::flag_sequence_bug_compat(w_typ2))
-                        || issubtype_w(w_typ2, w_typ1);
+                        && crate::baseobjspace::flag_sequence_bug_compat(w_typ1.as_ptr())
+                        && !crate::baseobjspace::flag_sequence_bug_compat(w_typ2.as_ptr()))
+                        || issubtype_w(w_typ2.as_ptr(), w_typ1.as_ptr());
                     // descroperation.py:671-672.
                     if prefer_reverse
                         && !p_abstract_issubclass_w(lsrc, rsrc)?
-                        && !p_abstract_issubclass_w(w_typ1, rsrc)?
+                        && !p_abstract_issubclass_w(w_typ1.as_ptr(), rsrc)?
                     {
                         std::mem::swap(&mut w_obj1, &mut w_obj2);
                         std::mem::swap(&mut w_left_impl, &mut w_right_impl);
@@ -3291,8 +3294,8 @@ pub(crate) fn try_inplace_special(
                 if let (Some(lhs_type), Some(rhs_type)) =
                     (crate::typedef::r#type(lhs), crate::typedef::r#type(rhs))
                 {
-                    if crate::baseobjspace::flag_sequence_bug_compat(lhs_type)
-                        && !crate::baseobjspace::flag_sequence_bug_compat(rhs_type)
+                    if crate::baseobjspace::flag_sequence_bug_compat(lhs_type.as_ptr())
+                        && !crate::baseobjspace::flag_sequence_bug_compat(rhs_type.as_ptr())
                     {
                         if let Some(rmethod) = unsafe { lookup_type_special(rhs, rd) } {
                             if let Some(result) = try_call_special(rmethod, &[rhs, lhs])? {
@@ -3398,7 +3401,7 @@ fn pow_mod_result(value: BigInt, all_int_like: bool) -> PyObjectRef {
 fn operand_type_name(obj: PyObjectRef) -> String {
     unsafe {
         match crate::typedef::r#type(obj) {
-            Some(tp) => pyre_object::w_type_get_name(tp).to_string(),
+            Some(tp) => pyre_object::w_type_get_name(tp.as_ptr()).to_string(),
             None => (*ll_type(obj)).name.to_string(),
         }
     }
@@ -4185,7 +4188,7 @@ pub fn compare_slot(a: PyObjectRef, b: PyObjectRef, op: CompareOp) -> PyResult {
         // path is the one that succeeds for `set == d.keys()`.
         if !is_instance(a) {
             if let Some(a_type) = crate::typedef::r#type(a) {
-                if let Some(method) = lookup_in_type_where(a_type, dunder) {
+                if let Some(method) = lookup_in_type_where(a_type.as_ptr(), dunder) {
                     // A raised exception (not NotImplemented) propagates; only
                     // NotImplemented falls through to the reflected comparison.
                     let result = crate::call::call_function_impl_result(method, &[a, b])?;
@@ -4198,7 +4201,7 @@ pub fn compare_slot(a: PyObjectRef, b: PyObjectRef, op: CompareOp) -> PyResult {
         if !is_instance(b) {
             if let Some(rdunder) = reverse_dunder(dunder) {
                 if let Some(b_type) = crate::typedef::r#type(b) {
-                    if let Some(method) = lookup_in_type_where(b_type, rdunder) {
+                    if let Some(method) = lookup_in_type_where(b_type.as_ptr(), rdunder) {
                         let result = crate::call::call_function_impl_result(method, &[b, a])?;
                         if !is_not_implemented(result) {
                             return Ok(result);

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -2373,6 +2373,7 @@ unsafe fn needs_seq_binop_dispatch(
     let Some(t) = crate::typedef::gettypefor(tp) else {
         return false;
     };
+    let t = t.as_ptr();
     dunder_overridden(a, fwd, t)
         || dunder_overridden(a, rev, t)
         || dunder_overridden(b, fwd, t)
@@ -2402,6 +2403,7 @@ unsafe fn bytes_operand_overrides(obj: PyObjectRef, fwd: &str, rev: &str) -> boo
     let Some(t) = crate::typedef::gettypefor(tp) else {
         return false;
     };
+    let t = t.as_ptr();
     dunder_overridden(obj, fwd, t) || dunder_overridden(obj, rev, t)
 }
 
@@ -2436,7 +2438,9 @@ unsafe fn numeric_base_type(obj: PyObjectRef) -> Option<*const pyre_object::PyTy
 /// UTF-8-keyed cache probe per dunder) are the dominant per-iteration cost
 /// of the interpreter numeric fast path.  This mirrors the exact-builtin
 /// gate already opening `subclass_special_override` / `is_true`.
-unsafe fn numeric_base_type_of_overriding_subclass(obj: PyObjectRef) -> Option<PyObjectRef> {
+unsafe fn numeric_base_type_of_overriding_subclass(
+    obj: PyObjectRef,
+) -> Option<std::ptr::NonNull<pyre_object::PyObject>> {
     if pyre_object::is_exact_builtin_instance(obj) {
         return None;
     }
@@ -2455,6 +2459,7 @@ unsafe fn numeric_operand_overrides(obj: PyObjectRef, dunder: &str, rdunder: &st
     let Some(t) = numeric_base_type_of_overriding_subclass(obj) else {
         return false;
     };
+    let t = t.as_ptr();
     dunder_overridden(obj, dunder, t) || dunder_overridden(obj, rdunder, t)
 }
 
@@ -2497,7 +2502,7 @@ unsafe fn needs_numeric_unaryop_dispatch(a: PyObjectRef, dunder: &str) -> bool {
     let Some(t) = numeric_base_type_of_overriding_subclass(a) else {
         return false;
     };
-    dunder_overridden(a, dunder, t)
+    dunder_overridden(a, dunder, t.as_ptr())
 }
 
 /// Call the overriding unary special on a numeric subclass operand before

--- a/pyre/pyre-interpreter/src/objspace/std/formatting.rs
+++ b/pyre/pyre-interpreter/src/objspace/std/formatting.rs
@@ -383,7 +383,7 @@ unsafe fn bytes_char_arg(obj: PyObjectRef) -> Result<u8, PyError> {
 /// `%(key)s` spec can index it.
 unsafe fn has_getitem(obj: PyObjectRef) -> bool {
     match crate::typedef::r#type(obj) {
-        Some(tp) => crate::baseobjspace::lookup_in_type(tp, "__getitem__").is_some(),
+        Some(tp) => crate::baseobjspace::lookup_in_type(tp.as_ptr(), "__getitem__").is_some(),
         None => false,
     }
 }
@@ -527,7 +527,7 @@ unsafe fn char_arg(obj: PyObjectRef) -> Result<CodePoint, PyError> {
         crate::builtins::obj_to_bigint(crate::baseobjspace::space_index(obj)?)
     } else {
         let tn = match crate::typedef::r#type(obj) {
-            Some(w_type) => crate::baseobjspace::type_repr_qualified_name(w_type),
+            Some(w_type) => crate::baseobjspace::type_repr_qualified_name(w_type.as_ptr()),
             None => crate::baseobjspace::object_functionstr_type_name(obj),
         };
         return Err(PyError::type_error(format!(
@@ -547,7 +547,7 @@ unsafe fn char_arg(obj: PyObjectRef) -> Result<CodePoint, PyError> {
 /// True when `obj`'s type carries `name` above `object`'s default.
 unsafe fn has_dunder(obj: PyObjectRef, name: &str) -> bool {
     match crate::typedef::r#type(obj) {
-        Some(tp) => crate::baseobjspace::lookup_in_type(tp, name).is_some(),
+        Some(tp) => crate::baseobjspace::lookup_in_type(tp.as_ptr(), name).is_some(),
         None => false,
     }
 }

--- a/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
+++ b/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
@@ -1113,7 +1113,7 @@ unsafe fn classify_attr(
 /// `w_descr` must be a live object.
 unsafe fn descr_type_is_heaptype(w_descr: PyObjectRef) -> bool {
     match crate::typedef::r#type(w_descr) {
-        Some(t) => unsafe { pyre_object::typeobject::w_type_is_heaptype(t) },
+        Some(t) => unsafe { pyre_object::typeobject::w_type_is_heaptype(t.as_ptr()) },
         None => true,
     }
 }
@@ -2041,7 +2041,7 @@ unsafe fn is_unboxable_int(w_value: PyObjectRef) -> bool {
     let Some(actual) = crate::typedef::r#type(w_value) else {
         return false;
     };
-    std::ptr::eq(actual, exact)
+    std::ptr::eq(actual.as_ptr(), exact)
 }
 
 /// Float half of `_pick_unbox_type`: PyPy uses
@@ -2058,7 +2058,7 @@ unsafe fn is_unboxable_float(w_value: PyObjectRef) -> bool {
     let Some(actual) = crate::typedef::r#type(w_value) else {
         return false;
     };
-    std::ptr::eq(actual, exact)
+    std::ptr::eq(actual.as_ptr(), exact)
 }
 
 /// mapdict.py:586-590 `UnboxedPlainAttribute._convert_to_boxed` — rebuild the

--- a/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
+++ b/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
@@ -448,7 +448,10 @@ pub unsafe fn instance_get_weakref_slot(obj: PyObjectRef) -> Option<PyObjectRef>
     ensure_mapdict_initialized(obj);
     let inst = &*(obj as *const pyre_object::W_ObjectObject);
     let map = inst._get_mapdict_map();
-    node_read(map, inst, Wtf8::new("weakref"), SPECIAL)
+    // A cleared lifeline (mapdict.py:802 writes `None` = null into the retained
+    // node) reads back as a null slot; report it as absent rather than
+    // `Some(null)`.
+    node_read(map, inst, Wtf8::new("weakref"), SPECIAL).filter(|w| !w.is_null())
 }
 
 /// Write the weakref lifeline into the instance's `"weakref"` SPECIAL slot

--- a/pyre/pyre-interpreter/src/reduce_protocol.rs
+++ b/pyre/pyre-interpreter/src/reduce_protocol.rs
@@ -92,7 +92,7 @@ pub(crate) fn walk_handle_roots(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
 /// `%T`-style class name of `w_obj` for error messages.
 fn typename(w_obj: PyObjectRef) -> String {
     match crate::typedef::r#type(w_obj) {
-        Some(tp) => unsafe { pyre_object::w_type_get_name(tp) }.to_string(),
+        Some(tp) => unsafe { pyre_object::w_type_get_name(tp.as_ptr()) }.to_string(),
         None => "object".to_string(),
     }
 }
@@ -226,7 +226,7 @@ pub fn set_reduce(w_obj: PyObjectRef) -> PyResult {
 
     let w_type = crate::typedef::r#type(w_obj)
         .ok_or_else(|| PyError::type_error("cannot determine type for __reduce__"))?;
-    pyre_object::gc_roots::pin_root(w_type);
+    pyre_object::gc_roots::pin_root(w_type.as_ptr());
     let type_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
 
     // PySequence_List(self): no GC between reading the items and `w_list_new`
@@ -277,7 +277,7 @@ pub fn descr_reduce_ex(w_obj: PyObjectRef, proto: i64) -> PyResult {
     if let Some(w_reduce) = w_reduce {
         let w_type = crate::typedef::r#type(w_obj)
             .ok_or_else(|| PyError::type_error("cannot determine type for __reduce_ex__"))?;
-        let w_cls_reduce = crate::baseobjspace::getattr_str(w_type, "__reduce__")?;
+        let w_cls_reduce = crate::baseobjspace::getattr_str(w_type.as_ptr(), "__reduce__")?;
         let w_obj_reduce =
             crate::baseobjspace::getattr_str(crate::typedef::w_object(), "__reduce__")?;
         let mut override_ = !crate::baseobjspace::is_w(w_cls_reduce, w_obj_reduce);

--- a/pyre/pyre-interpreter/src/runtime_ops.rs
+++ b/pyre/pyre-interpreter/src/runtime_ops.rs
@@ -439,7 +439,7 @@ where
             }
         } else {
             let type_name = crate::typedef::r#type(callable)
-                .map(|tp| unsafe { pyre_object::w_type_get_name(tp) })
+                .map(|tp| unsafe { pyre_object::w_type_get_name(tp.as_ptr()) })
                 .unwrap_or_else(|| unsafe { (*(*callable).ob_type).name });
             Err(PyError::type_error(format!(
                 "'{type_name}' object is not callable"

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -906,7 +906,7 @@ fn parse_split_sep(value: PyObjectRef) -> Result<Option<Wtf8Buf>, crate::PyError
     }
     let tp_name = unsafe {
         match crate::typedef::r#type(value) {
-            Some(tp) => pyre_object::w_type_get_name(tp).to_string(),
+            Some(tp) => pyre_object::w_type_get_name(tp.as_ptr()).to_string(),
             None => "object".to_string(),
         }
     };
@@ -2291,7 +2291,7 @@ pub(crate) fn call_format_dispatch(
     spec_obj: PyObjectRef,
 ) -> Result<Wtf8Buf, crate::PyError> {
     unsafe {
-        let w_type = crate::typedef::r#type(val).unwrap_or(pyre_object::PY_NULL);
+        let w_type = crate::typedef::r#type(val).map_or(pyre_object::PY_NULL, |p| p.as_ptr());
         let result = crate::baseobjspace::get_and_call_function(meth, val, w_type, &[spec_obj])?;
         if !pyre_object::is_str(result) {
             return Err(crate::PyError::type_error(format!(
@@ -2343,7 +2343,7 @@ pub(crate) fn arg_type_name(obj: PyObjectRef) -> String {
     }
     unsafe {
         match crate::typedef::r#type(obj) {
-            Some(tp) => w_type_get_name(tp).to_string(),
+            Some(tp) => w_type_get_name(tp.as_ptr()).to_string(),
             None => (*(*obj).ob_type).name.to_string(),
         }
     }
@@ -5369,7 +5369,7 @@ pub fn resolve_dict_backing(obj: PyObjectRef) -> PyObjectRef {
             // Read that reserved layout slot directly: going through
             // `getattr_str` would incorrectly expose internal dict operations
             // to a subclass's Python-level `__getattribute__` hook.
-            let w_type = crate::typedef::r#type(obj).unwrap_or(PY_NULL);
+            let w_type = crate::typedef::r#type(obj).map_or(PY_NULL, |p| p.as_ptr());
             if !w_type.is_null() {
                 let mut layout = pyre_object::w_type_get_layout_ptr(w_type);
                 while !layout.is_null() {
@@ -5892,10 +5892,11 @@ fn dict_subclass_uses_default_iter(other: PyObjectRef) -> bool {
     }
     // Real `dict` type — no subclass at all, so __iter__ is by
     // definition unshadowed.
-    if std::ptr::eq(other_type as *const _, dict_type as *const _) {
+    if std::ptr::eq(other_type.as_ptr() as *const _, dict_type as *const _) {
         return true;
     }
-    let other_iter = unsafe { crate::baseobjspace::lookup_in_type(other_type, "__iter__") };
+    let other_iter =
+        unsafe { crate::baseobjspace::lookup_in_type(other_type.as_ptr(), "__iter__") };
     let dict_iter = unsafe { crate::baseobjspace::lookup_in_type(dict_type, "__iter__") };
     match (other_iter, dict_iter) {
         (Some(a), Some(b)) => std::ptr::eq(a, b),

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -11,6 +11,7 @@
 //! unifies attribute lookup for all object types.
 
 use std::collections::HashMap;
+use std::ptr::NonNull;
 use std::sync::OnceLock;
 
 use pyre_object::pyobject::*;
@@ -175,12 +176,17 @@ pub static TYPEOBJECT_CACHE: OnceLock<HashMap<usize, usize>> = OnceLock::new();
 /// `set_instantiate` loop — the same source that backs
 /// `TYPEOBJECT_CACHE`. The slot read is a single field load the JIT can
 /// model, where the `usize`-keyed `HashMap` lookup is not.
-pub fn gettypefor(tp: *const PyType) -> Option<PyObjectRef> {
+pub fn gettypefor(tp: *const PyType) -> Option<NonNull<PyObject>> {
     if tp.is_null() {
         return None;
     }
     let w = unsafe { pyre_object::get_instantiate(&*tp) };
-    if w.is_null() { None } else { Some(w) }
+    // The `instantiate` slot is a maybe-null object pointer: null while the
+    // type is still bootstrapping, otherwise the type object.  Modelled as a
+    // one-word niche `Option<NonNull<PyObject>>` (None = null, Some(p) = the
+    // type object) so a payload read is a pointer identity and the match is a
+    // pointer null-test.
+    NonNull::new(w)
 }
 
 /// Get the W_TypeObject for any PyObjectRef.
@@ -200,7 +206,7 @@ pub fn r#type(obj: PyObjectRef) -> Option<PyObjectRef> {
     // derefs below (which would fault on the immediate). Gated on
     // `CAN_BE_TAGGED` (default false), so the derefs stay the only live path.
     if pyre_object::tagged_int::CAN_BE_TAGGED && pyre_object::tagged_int::is_tagged_int(obj) {
-        return gettypefor(&pyre_object::INT_TYPE);
+        return gettypefor(&pyre_object::INT_TYPE).map(|p| p.as_ptr());
     }
     unsafe {
         // Exception instances share a single W_BaseException layout
@@ -234,7 +240,7 @@ pub fn r#type(obj: PyObjectRef) -> Option<PyObjectRef> {
         // so writing to (*obj).w_class would SIGBUS — just look it up via
         // gettypefor(), which reads an AtomicPtr on the PyType.
         let tp = (*obj).ob_type;
-        gettypefor(tp)
+        gettypefor(tp).map(|p| p.as_ptr())
     }
 }
 
@@ -1259,7 +1265,8 @@ fn patch_object_class_descriptor() {
 /// namespace (it is created by the same call that runs the initializer), so
 /// the two descriptors are stored here, once the type is registered.
 fn patch_complex_realimag_descriptors() {
-    let complex_type = gettypefor(&pyre_object::COMPLEX_TYPE).unwrap_or(pyre_object::PY_NULL);
+    let complex_type =
+        gettypefor(&pyre_object::COMPLEX_TYPE).map_or(pyre_object::PY_NULL, |p| p.as_ptr());
     if complex_type.is_null() || !crate::type_dict_has_storage(complex_type) {
         return;
     }
@@ -1378,7 +1385,7 @@ pub fn w_type() -> PyObjectRef {
 }
 
 pub fn gettypeobject(tp: &PyType) -> PyObjectRef {
-    gettypefor(tp as *const PyType).unwrap_or(PY_NULL)
+    gettypefor(tp as *const PyType).map_or(PY_NULL, |p| p.as_ptr())
 }
 
 /// Get the wrapped `object` typeobject.
@@ -1685,7 +1692,7 @@ fn int_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     // intobject.py _new_int → check_user_subclass
     if !cls.is_null() && unsafe { pyre_object::is_type(cls) } {
         if let Some(w_int) = gettypefor(&pyre_object::INT_TYPE) {
-            check_user_subclass(w_int, cls)?;
+            check_user_subclass(w_int.as_ptr(), cls)?;
         }
     }
     let value = crate::builtins::builtin_int(&args[1..])?;
@@ -1694,7 +1701,7 @@ fn int_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         return Ok(value);
     }
     let int_typeobj = gettypefor(&pyre_object::INT_TYPE);
-    if int_typeobj.map_or(false, |t| std::ptr::eq(cls, t)) {
+    if int_typeobj.map_or(false, |t| std::ptr::eq(cls, t.as_ptr())) {
         return Ok(value);
     }
     // cls is a subclass of int. Create a unique instance (bypassing the
@@ -1769,7 +1776,7 @@ fn complex_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
         return Ok(value);
     }
     let complex_typeobj = gettypefor(&pyre_object::COMPLEX_TYPE);
-    if complex_typeobj.map_or(false, |t| std::ptr::eq(cls, t)) {
+    if complex_typeobj.map_or(false, |t| std::ptr::eq(cls, t.as_ptr())) {
         return Ok(value);
     }
     // Subclass path — retag a fresh W_ComplexObject with the subclass.
@@ -2015,7 +2022,7 @@ fn module_descr_dir(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
         || (!unsafe { pyre_object::is_dict(w_dict) }
             && !unsafe { pyre_object::dictmultiobject::is_module_dict(w_dict) }
             && !gettypefor(&pyre_object::DICT_TYPE).is_some_and(|dict_type| unsafe {
-                crate::baseobjspace::isinstance_w(w_dict, dict_type)
+                crate::baseobjspace::isinstance_w(w_dict, dict_type.as_ptr())
             }))
     {
         return Err(crate::PyError::type_error(format!(
@@ -2266,7 +2273,7 @@ fn ellipsis_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErro
     }
     let cls = positional.first().copied().unwrap_or(pyre_object::PY_NULL);
     if let Some(w_ellipsis) = gettypefor(&pyre_object::ELLIPSIS_TYPE) {
-        check_user_subclass(w_ellipsis, cls)?;
+        check_user_subclass(w_ellipsis.as_ptr(), cls)?;
     }
     Ok(pyre_object::special::w_ellipsis())
 }
@@ -2326,7 +2333,7 @@ fn notimplemented_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::
     }
     let cls = positional.first().copied().unwrap_or(pyre_object::PY_NULL);
     if let Some(w_notimplemented) = gettypefor(&pyre_object::pyobject::NOTIMPLEMENTED_TYPE) {
-        check_user_subclass(w_notimplemented, cls)?;
+        check_user_subclass(w_notimplemented.as_ptr(), cls)?;
     }
     Ok(pyre_object::special::w_not_implemented())
 }
@@ -2421,7 +2428,7 @@ fn none_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     }
     let cls = positional.first().copied().unwrap_or(pyre_object::PY_NULL);
     if let Some(w_none_type) = gettypefor(&pyre_object::NONE_TYPE) {
-        check_user_subclass(w_none_type, cls)?;
+        check_user_subclass(w_none_type.as_ptr(), cls)?;
     }
     Ok(pyre_object::w_none())
 }
@@ -2555,7 +2562,7 @@ fn str_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         return Ok(value);
     }
     let str_typeobj = gettypefor(&pyre_object::STR_TYPE);
-    if str_typeobj.map_or(false, |t| std::ptr::eq(cls, t)) {
+    if str_typeobj.map_or(false, |t| std::ptr::eq(cls, t.as_ptr())) {
         return Ok(value);
     }
     if !unsafe { pyre_object::is_type(cls) } {
@@ -2564,7 +2571,7 @@ fn str_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         ));
     }
     if let Some(w_str) = str_typeobj {
-        if !unsafe { crate::baseobjspace::issubtype_w(cls, w_str) } {
+        if !unsafe { crate::baseobjspace::issubtype_w(cls, w_str.as_ptr()) } {
             let cls_name = unsafe { pyre_object::w_type_get_name(cls) };
             return Err(crate::PyError::type_error(format!(
                 "str.__new__({cls_name}): {cls_name} is not a subtype of str"
@@ -2620,7 +2627,7 @@ fn bool_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     // args[0] = w_booltype (cls)
     let w_booltype = args.first().copied().unwrap_or(pyre_object::PY_NULL);
     if let Some(w_bool) = gettypefor(&pyre_object::BOOL_TYPE) {
-        check_user_subclass(w_bool, w_booltype)?;
+        check_user_subclass(w_bool.as_ptr(), w_booltype)?;
     }
     // boolobject.py: descr_new(space, w_booltype, w_obj)
     // Takes exactly (cls) or (cls, obj). No extra args, no kwargs.
@@ -2709,7 +2716,7 @@ fn subclass_to_tag(
         return Ok(None);
     }
     let base_obj = match gettypefor(base) {
-        Some(t) => t,
+        Some(t) => t.as_ptr(),
         None => return Ok(Some(cls)),
     };
     // `cls` is the builtin base itself → keep the canonical layout, no retag.
@@ -2894,8 +2901,8 @@ fn filter_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
         pyre_object::gc_roots::shadow_stack_len() - 1
     });
     let cls = unsafe { pyre_object::gc_roots::shadow_stack_get(cls_slot) };
-    let filter_type =
-        gettypefor(&pyre_object::functional::FILTER_TYPE).unwrap_or(pyre_object::PY_NULL);
+    let filter_type = gettypefor(&pyre_object::functional::FILTER_TYPE)
+        .map_or(pyre_object::PY_NULL, |p| p.as_ptr());
     let init_matches = std::ptr::eq(cls, filter_type)
         || unsafe {
             match (
@@ -7850,7 +7857,8 @@ fn slice_method_indices(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyEr
 /// sliceobject.py `W_SliceObject.descr__new__` — `slice([start,] stop[, step])`.
 fn slice_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let cls = args.first().copied().unwrap_or(pyre_object::PY_NULL);
-    let slice_type = gettypefor(&pyre_object::sliceobject::SLICE_TYPE).unwrap_or(PY_NULL);
+    let slice_type =
+        gettypefor(&pyre_object::sliceobject::SLICE_TYPE).map_or(PY_NULL, |p| p.as_ptr());
     check_user_subclass(slice_type, cls)?;
     let (params, kwargs) = crate::builtins::split_builtin_kwargs(args.get(1..).unwrap_or(&[]));
     if crate::builtins::has_real_kwargs(kwargs) {
@@ -10618,8 +10626,8 @@ fn init_builtin_function_type(ns: PyObjectRef) {
 /// inherited descriptors; CPython's `PyGetSetDef` / `PyMemberDef` entries all
 /// carry `PyCFunction_Type` as their owner.
 fn patch_builtin_function_descriptors() {
-    let bf_type =
-        gettypefor(&crate::BUILTIN_FUNCTION_TYPE as *const PyType).unwrap_or(pyre_object::PY_NULL);
+    let bf_type = gettypefor(&crate::BUILTIN_FUNCTION_TYPE as *const PyType)
+        .map_or(pyre_object::PY_NULL, |p| p.as_ptr());
     if bf_type.is_null() {
         return;
     }
@@ -10650,8 +10658,8 @@ fn patch_builtin_function_descriptors() {
 /// the Function W_TypeObject is available. This is the Member counterpart of
 /// the GetSetProperty reqcls patch immediately above.
 fn patch_function_member_descriptors() {
-    let function_type =
-        gettypefor(&crate::FUNCTION_TYPE as *const PyType).unwrap_or(pyre_object::PY_NULL);
+    let function_type = gettypefor(&crate::FUNCTION_TYPE as *const PyType)
+        .map_or(pyre_object::PY_NULL, |p| p.as_ptr());
     if function_type.is_null() || !crate::type_dict_has_storage(function_type) {
         return;
     }
@@ -10674,8 +10682,8 @@ fn patch_function_member_descriptors() {
 /// stamp that inferred `cls=Module` after the W_TypeObject is registered so
 /// foreign receivers fail in GetSetProperty.typecheck before field access.
 fn patch_module_descriptors() {
-    let module_type =
-        gettypefor(&pyre_object::MODULE_TYPE as *const PyType).unwrap_or(pyre_object::PY_NULL);
+    let module_type = gettypefor(&pyre_object::MODULE_TYPE as *const PyType)
+        .map_or(pyre_object::PY_NULL, |p| p.as_ptr());
     if module_type.is_null() || !crate::type_dict_has_storage(module_type) {
         return;
     }
@@ -10693,8 +10701,8 @@ fn patch_module_descriptors() {
 /// field in the same post-registration pass used for BuiltinFunction and
 /// frame descriptors.
 fn patch_cell_descriptor() {
-    let cell_type =
-        gettypefor(&pyre_object::nestedscope::CELL_TYPE).unwrap_or(pyre_object::PY_NULL);
+    let cell_type = gettypefor(&pyre_object::nestedscope::CELL_TYPE)
+        .map_or(pyre_object::PY_NULL, |p| p.as_ptr());
     if cell_type.is_null() || !crate::type_dict_has_storage(cell_type) {
         return;
     }
@@ -10722,7 +10730,7 @@ fn patch_frame_traceback_descriptors() {
         &crate::pyframe::FRAME_TYPE as *const PyType,
         &crate::pytraceback::PYTRACEBACK_TYPE as *const PyType,
     ] {
-        let w_type = gettypefor(layout).unwrap_or(pyre_object::PY_NULL);
+        let w_type = gettypefor(layout).map_or(pyre_object::PY_NULL, |p| p.as_ptr());
         if w_type.is_null() {
             continue;
         }
@@ -11601,7 +11609,8 @@ fn cell_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         ));
     }
     let cls = positional.first().copied().unwrap_or(PY_NULL);
-    let cell_type = gettypefor(&pyre_object::nestedscope::CELL_TYPE).unwrap_or(PY_NULL);
+    let cell_type =
+        gettypefor(&pyre_object::nestedscope::CELL_TYPE).map_or(PY_NULL, |p| p.as_ptr());
     check_user_subclass(cell_type, cls)?;
     let contents = match positional.get(1..) {
         Some([]) | None => PY_NULL,
@@ -22273,7 +22282,7 @@ fn count_check_number(obj: PyObjectRef) -> Result<(), crate::PyError> {
     // wording (`a number is required`) in place of PyPy 3.11's older text.
     let has_int = unsafe { crate::baseobjspace::lookup(obj, "__int__") }.is_some();
     let has_float = unsafe { crate::baseobjspace::lookup(obj, "__float__") }.is_some();
-    let complex_type = gettypefor(&pyre_object::COMPLEX_TYPE).unwrap_or(PY_NULL);
+    let complex_type = gettypefor(&pyre_object::COMPLEX_TYPE).map_or(PY_NULL, |p| p.as_ptr());
     if !has_int
         && !has_float
         && (complex_type.is_null()
@@ -22297,14 +22306,15 @@ fn count_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
     let w_step = scope[1];
     count_check_number(w_start)?;
     count_check_number(w_step)?;
-    let exact = gettypefor(&pyre_object::interp_itertools::COUNT_TYPE).unwrap_or(PY_NULL);
+    let exact =
+        gettypefor(&pyre_object::interp_itertools::COUNT_TYPE).map_or(PY_NULL, |p| p.as_ptr());
     let obj = pyre_object::interp_itertools::w_count_new(w_start, w_step);
     itertools_alloc_for_class(cls, exact, obj)
 }
 
 fn count_single_argument(w_step: PyObjectRef) -> Result<bool, crate::PyError> {
     // W_Count.single_argument: isinstance(step, int) and step == 1.
-    let int_type = gettypefor(&pyre_object::INT_TYPE).unwrap_or(PY_NULL);
+    let int_type = gettypefor(&pyre_object::INT_TYPE).map_or(PY_NULL, |p| p.as_ptr());
     Ok(!int_type.is_null()
         && unsafe { crate::baseobjspace::isinstance_w(w_step, int_type) }
         && crate::baseobjspace::eq_w(w_step, w_int_new(1))?)
@@ -22369,7 +22379,8 @@ fn repeat_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
     } else {
         Some(crate::builtins::space_index_w(w_times)?)
     };
-    let exact = gettypefor(&pyre_object::interp_itertools::REPEAT_TYPE).unwrap_or(PY_NULL);
+    let exact =
+        gettypefor(&pyre_object::interp_itertools::REPEAT_TYPE).map_or(PY_NULL, |p| p.as_ptr());
     let obj = pyre_object::interp_itertools::w_repeat_new(w_obj, times);
     itertools_alloc_for_class(cls, exact, obj)
 }
@@ -22473,7 +22484,8 @@ fn itertools_twoarg_new(
 }
 
 fn takewhile_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    let exact = gettypefor(&pyre_object::interp_itertools::TAKEWHILE_TYPE).unwrap_or(PY_NULL);
+    let exact =
+        gettypefor(&pyre_object::interp_itertools::TAKEWHILE_TYPE).map_or(PY_NULL, |p| p.as_ptr());
     let (cls, predicate, iterable) = itertools_twoarg_new(args, exact, "takewhile")?;
     let iterator = crate::baseobjspace::iter(iterable)?;
     let obj = pyre_object::interp_itertools::w_takewhile_new(predicate, iterator);
@@ -22481,7 +22493,8 @@ fn takewhile_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErr
 }
 
 fn dropwhile_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    let exact = gettypefor(&pyre_object::interp_itertools::DROPWHILE_TYPE).unwrap_or(PY_NULL);
+    let exact =
+        gettypefor(&pyre_object::interp_itertools::DROPWHILE_TYPE).map_or(PY_NULL, |p| p.as_ptr());
     let (cls, predicate, iterable) = itertools_twoarg_new(args, exact, "dropwhile")?;
     let iterator = crate::baseobjspace::iter(iterable)?;
     let obj = pyre_object::interp_itertools::w_dropwhile_new(predicate, iterator);
@@ -22489,7 +22502,8 @@ fn dropwhile_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErr
 }
 
 fn filterfalse_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    let exact = gettypefor(&pyre_object::interp_itertools::FILTERFALSE_TYPE).unwrap_or(PY_NULL);
+    let exact = gettypefor(&pyre_object::interp_itertools::FILTERFALSE_TYPE)
+        .map_or(PY_NULL, |p| p.as_ptr());
     let (cls, predicate, iterable) = itertools_twoarg_new(args, exact, "filterfalse")?;
     let predicate = if unsafe { pyre_object::is_none(predicate) } {
         PY_NULL
@@ -22505,7 +22519,8 @@ fn compress_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErro
     // PyPy W_Compress__new__ allocates the subtype and applies space.iter to
     // both inputs.  Python 3.14's Argument Clinic surface additionally
     // accepts the `data` and `selectors` keyword names.
-    let exact = gettypefor(&pyre_object::interp_itertools::COMPRESS_TYPE).unwrap_or(PY_NULL);
+    let exact =
+        gettypefor(&pyre_object::interp_itertools::COMPRESS_TYPE).map_or(PY_NULL, |p| p.as_ptr());
     let (cls, scope_w) =
         itertools_constructor_scope(args, "compress", vec!["data", "selectors"], &[])?;
     let _roots = pyre_object::gc_roots::push_roots();
@@ -22555,7 +22570,8 @@ fn compress_iter_next(args: &[PyObjectRef]) -> crate::PyResult {
 
 fn starmap_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     // interp_itertools.py W_StarMap___new__, kept in source order.
-    let exact = gettypefor(&pyre_object::interp_itertools::STARMAP_TYPE).unwrap_or(PY_NULL);
+    let exact =
+        gettypefor(&pyre_object::interp_itertools::STARMAP_TYPE).map_or(PY_NULL, |p| p.as_ptr());
     let (cls, w_fun, w_iterable) = itertools_twoarg_new(args, exact, "starmap")?;
     let _roots = pyre_object::gc_roots::push_roots();
     pyre_object::gc_roots::pin_root(cls);
@@ -22600,7 +22616,8 @@ fn starmap_iter_next(args: &[PyObjectRef]) -> crate::PyResult {
 fn accumulate_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     // W_Accumulate__new__(space, w_subtype, w_iterable, w_func=None,
     //                     __kwonly__=None, w_initial=None).
-    let exact = gettypefor(&pyre_object::interp_itertools::ACCUMULATE_TYPE).unwrap_or(PY_NULL);
+    let exact =
+        gettypefor(&pyre_object::interp_itertools::ACCUMULATE_TYPE).map_or(PY_NULL, |p| p.as_ptr());
     let w_none = pyre_object::w_none();
     let (cls, scope_w) = itertools_constructor_scope(
         args,
@@ -22639,7 +22656,8 @@ fn accumulate_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyEr
 fn zip_longest_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     // W_ZipLongest___new__: keep all positional sources as live iterators and
     // accept only the fillvalue keyword.
-    let exact = gettypefor(&pyre_object::interp_itertools::ZIP_LONGEST_TYPE).unwrap_or(PY_NULL);
+    let exact = gettypefor(&pyre_object::interp_itertools::ZIP_LONGEST_TYPE)
+        .map_or(PY_NULL, |p| p.as_ptr());
     let (positional, kwargs) = crate::builtins::split_builtin_kwargs(args);
     let cls = positional.first().copied().unwrap_or(PY_NULL);
     let sources = positional.get(1..).unwrap_or(&[]);
@@ -23202,7 +23220,8 @@ mod tests {
     fn check_cell_typedef_python314_surface() {
         crate::typedef::init_typeobjects();
         let w_type = crate::typedef::gettypefor(&pyre_object::nestedscope::CELL_TYPE)
-            .expect("cell should resolve to a W_TypeObject");
+            .expect("cell should resolve to a W_TypeObject")
+            .as_ptr();
         let expected = [
             "__doc__",
             "__eq__",

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -197,7 +197,7 @@ pub fn gettypefor(tp: *const PyType) -> Option<NonNull<PyObject>> {
 /// `gettypefor(ob_type)` for objects created before init_typeobjects()
 /// (singletons such as None/True/False/Ellipsis live in read-only static
 /// memory, so we never write w_class back into them).
-pub fn r#type(obj: PyObjectRef) -> Option<PyObjectRef> {
+pub fn r#type(obj: PyObjectRef) -> Option<NonNull<PyObject>> {
     if obj.is_null() {
         return None;
     }
@@ -206,7 +206,7 @@ pub fn r#type(obj: PyObjectRef) -> Option<PyObjectRef> {
     // derefs below (which would fault on the immediate). Gated on
     // `CAN_BE_TAGGED` (default false), so the derefs stay the only live path.
     if pyre_object::tagged_int::CAN_BE_TAGGED && pyre_object::tagged_int::is_tagged_int(obj) {
-        return gettypefor(&pyre_object::INT_TYPE).map(|p| p.as_ptr());
+        return gettypefor(&pyre_object::INT_TYPE);
     }
     unsafe {
         // Exception instances share a single W_BaseException layout
@@ -223,24 +223,24 @@ pub fn r#type(obj: PyObjectRef) -> Option<PyObjectRef> {
             let exc_stub =
                 pyre_object::get_instantiate(&pyre_object::interp_exceptions::EXCEPTION_TYPE);
             if !w_class.is_null() && !std::ptr::eq(w_class, exc_stub) {
-                return Some(w_class);
+                return NonNull::new(w_class);
             }
             let kind = pyre_object::w_exception_get_kind(obj);
             let cls = pyre_object::interp_exceptions::lookup_exc_class_for_kind(kind);
             if !cls.is_null() {
-                return Some(cls);
+                return NonNull::new(cls);
             }
         }
         let w_class = (*obj).w_class;
         if !w_class.is_null() {
-            return Some(w_class);
+            return NonNull::new(w_class);
         }
         // Fallback for objects created before init_typeobjects (None, True,
         // False, Ellipsis, NotImplemented). These are `static`s in RODATA,
         // so writing to (*obj).w_class would SIGBUS — just look it up via
         // gettypefor(), which reads an AtomicPtr on the PyType.
         let tp = (*obj).ob_type;
-        gettypefor(tp).map(|p| p.as_ptr())
+        gettypefor(tp)
     }
 }
 
@@ -1234,7 +1234,7 @@ fn patch_object_class_descriptor() {
     }
     let class_getter = make_builtin_function_with_arity(
         "__class__",
-        |args| Ok(crate::typedef::r#type(args[1]).unwrap_or(pyre_object::PY_NULL)),
+        |args| Ok(crate::typedef::r#type(args[1]).map_or(pyre_object::PY_NULL, |p| p.as_ptr())),
         2,
     );
     let class_setter = make_builtin_function_with_arity(
@@ -1897,7 +1897,7 @@ fn module_descr_init(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
             "None".to_string()
         } else {
             crate::typedef::r#type(w_name)
-                .map(|tp| unsafe { pyre_object::w_type_get_name(tp) }.to_string())
+                .map(|tp| unsafe { pyre_object::w_type_get_name(tp.as_ptr()) }.to_string())
                 .unwrap_or_else(|| unsafe { (*(*w_name).ob_type).name }.to_string())
         };
         return Err(crate::PyError::type_error(format!(
@@ -2056,7 +2056,7 @@ fn module_annotations_get(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
             )?;
             if !unsafe { pyre_object::is_dict(result) } {
                 let received = crate::typedef::r#type(result)
-                    .map(|tp| unsafe { pyre_object::w_type_get_name(tp) }.to_string())
+                    .map(|tp| unsafe { pyre_object::w_type_get_name(tp.as_ptr()) }.to_string())
                     .unwrap_or_else(|| unsafe { (*(*result).ob_type).name }.to_string());
                 return Err(crate::PyError::type_error(format!(
                     "__annotate__ returned non-dict of type '{received}'"
@@ -2647,7 +2647,7 @@ fn bool_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     // W_ObjectObject and int/float subclass instances.
     unsafe {
         if let Some(w_type) = crate::typedef::r#type(w_obj) {
-            if let Some(method) = crate::baseobjspace::lookup_in_type(w_type, "__bool__") {
+            if let Some(method) = crate::baseobjspace::lookup_in_type(w_type.as_ptr(), "__bool__") {
                 if pyre_object::is_none(method) {
                     return Err(crate::PyError::type_error(
                         "object of this type has no bool()",
@@ -2676,7 +2676,7 @@ fn bool_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
                 }
                 return Ok(result);
             }
-            if let Some(len_m) = crate::baseobjspace::lookup_in_type(w_type, "__len__") {
+            if let Some(len_m) = crate::baseobjspace::lookup_in_type(w_type.as_ptr(), "__len__") {
                 if pyre_object::is_none(len_m) {
                     return Err(crate::PyError::type_error(
                         "object of this type has no len()",
@@ -2776,7 +2776,7 @@ fn list_descr_init(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
     // ignored here when the subclass overrides __new__ (that override already
     // received them through type.__call__).
     let list_type = gettypeobject(&pyre_object::LIST_TYPE);
-    let instance_type = crate::typedef::r#type(list).unwrap_or(list_type);
+    let instance_type = crate::typedef::r#type(list).map_or(list_type, |p| p.as_ptr());
     let inherits_list_new = unsafe {
         match (
             crate::baseobjspace::lookup_in_type(instance_type, "__new__"),
@@ -3062,7 +3062,9 @@ fn super_descr_get(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
             "__get__(x) is invalid on an uninitialized instance of 'super'",
         ));
     }
-    let cls = r#type(self_).unwrap_or_else(|| gettypeobject(&pyre_object::descriptor::SUPER_TYPE));
+    let cls = r#type(self_)
+        .map(|p| p.as_ptr())
+        .unwrap_or_else(|| gettypeobject(&pyre_object::descriptor::SUPER_TYPE));
     crate::call::call_function_impl_result(cls, &[start, obj])
 }
 
@@ -3899,7 +3901,7 @@ fn set_descr_init(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
 fn arg_type_name(obj: PyObjectRef) -> String {
     unsafe {
         match r#type(obj) {
-            Some(tp) => pyre_object::w_type_get_name(tp).to_string(),
+            Some(tp) => pyre_object::w_type_get_name(tp.as_ptr()).to_string(),
             None => (*(*obj).ob_type).name.to_string(),
         }
     }
@@ -7072,7 +7074,9 @@ fn mappingproxy_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
         }
     };
     let has_getitem = r#type(w_mapping)
-        .map(|t| unsafe { crate::baseobjspace::lookup_in_type(t, "__getitem__") }.is_some())
+        .map(|t| {
+            unsafe { crate::baseobjspace::lookup_in_type(t.as_ptr(), "__getitem__") }.is_some()
+        })
         .unwrap_or(false);
     let is_seq = unsafe { pyre_object::is_list(w_mapping) || pyre_object::is_tuple(w_mapping) };
     if !has_getitem || is_seq {
@@ -8072,7 +8076,7 @@ fn slice_descr_reduce(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErro
     let _roots = pyre_object::gc_roots::push_roots();
     pyre_object::gc_roots::pin_root(s);
     let s_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-    let ty = r#type(s).unwrap_or(pyre_object::PY_NULL);
+    let ty = r#type(s).map_or(pyre_object::PY_NULL, |p| p.as_ptr());
     pyre_object::gc_roots::pin_root(ty);
     let ty_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let components =
@@ -8497,8 +8501,8 @@ fn init_getset_descriptor_type(ns: PyObjectRef) {
                 let w_obj = args.get(1).copied().unwrap_or(pyre_object::PY_NULL);
                 let w_cls = args.get(2).copied().unwrap_or(pyre_object::PY_NULL);
                 let w_obj_is_none = !w_obj.is_null() && unsafe { pyre_object::is_none(w_obj) };
-                let none_type =
-                    crate::typedef::r#type(pyre_object::w_none()).unwrap_or(pyre_object::PY_NULL);
+                let none_type = crate::typedef::r#type(pyre_object::w_none())
+                    .map_or(pyre_object::PY_NULL, |p| p.as_ptr());
                 let w_cls_is_none_type = !w_cls.is_null() && std::ptr::eq(w_cls, none_type);
                 // typedef.py:352-353 if w_obj is None and w_cls is not type(None):
                 if w_obj_is_none && !w_cls_is_none_type {
@@ -8629,7 +8633,7 @@ fn init_getset_descriptor_type(ns: PyObjectRef) {
                             };
                         let type_name = unsafe {
                             match crate::typedef::r#type(w_obj) {
-                                Some(tp) => pyre_object::w_type_get_name(tp).to_string(),
+                                Some(tp) => pyre_object::w_type_get_name(tp.as_ptr()).to_string(),
                                 None => (*(*w_obj).ob_type).name.to_string(),
                             }
                         };
@@ -8676,7 +8680,9 @@ fn init_getset_descriptor_type(ns: PyObjectRef) {
                             "NoneType".to_string()
                         } else {
                             crate::typedef::r#type(descr)
-                                .map(|tp| unsafe { pyre_object::w_type_get_name(tp) }.to_string())
+                                .map(|tp| {
+                                    unsafe { pyre_object::w_type_get_name(tp.as_ptr()) }.to_string()
+                                })
                                 .unwrap_or_else(|| "object".to_string())
                         };
                         return Err(crate::PyError::type_error(format!(
@@ -9603,7 +9609,7 @@ fn function_receiver(obj: PyObjectRef, name: &str) -> Result<PyObjectRef, crate:
             "object"
         } else {
             crate::typedef::r#type(obj)
-                .map(|tp| unsafe { pyre_object::w_type_get_name(tp) })
+                .map(|tp| unsafe { pyre_object::w_type_get_name(tp.as_ptr()) })
                 .unwrap_or("object")
         };
         return Err(crate::PyError::type_error(format!(
@@ -10371,7 +10377,7 @@ fn init_function_type(ns: PyObjectRef) {
                     // function.py:470 Method(space, w_function, w_obj, w_cls),
                     // with CPython's inferred owner when `type` is omitted.
                     let owner = if cls_is_none {
-                        r#type(w_obj).unwrap_or(pyre_object::PY_NULL)
+                        r#type(w_obj).map_or(pyre_object::PY_NULL, |p| p.as_ptr())
                     } else {
                         w_cls
                     };
@@ -10408,7 +10414,7 @@ fn builtin_function_receiver(obj: PyObjectRef, name: &str) -> Result<PyObjectRef
             "object"
         } else {
             crate::typedef::r#type(obj)
-                .map(|tp| unsafe { pyre_object::w_type_get_name(tp) })
+                .map(|tp| unsafe { pyre_object::w_type_get_name(tp.as_ptr()) })
                 .unwrap_or("object")
         };
         return Err(crate::PyError::type_error(format!(
@@ -11708,7 +11714,7 @@ fn cell_descr_repr(args: &[PyObjectRef]) -> crate::PyResult {
         format!("<cell at 0x{:x}: empty>", cell as usize)
     } else {
         let type_name = crate::typedef::r#type(value)
-            .map(|tp| unsafe { pyre_object::w_type_get_name(tp) })
+            .map(|tp| unsafe { pyre_object::w_type_get_name(tp.as_ptr()) })
             .unwrap_or_else(|| unsafe { (*(*value).ob_type).name });
         let type_name: String = type_name.chars().take(80).collect();
         format!(
@@ -12203,7 +12209,7 @@ fn classmethod_descr_get(args: &[PyObjectRef]) -> crate::PyResult {
         if w_obj.is_null() || unsafe { pyre_object::is_none(w_obj) } {
             return Err(crate::PyError::type_error("__get__(None, None) is invalid"));
         }
-        w_klass = r#type(w_obj).unwrap_or(PY_NULL);
+        w_klass = r#type(w_obj).map_or(PY_NULL, |p| p.as_ptr());
     }
     let function = unsafe { pyre_object::function::w_classmethod_get_func(cm) };
     Ok(pyre_object::w_method_new(function, w_klass, w_klass))
@@ -12566,7 +12572,7 @@ fn property_descr_init(args: &[PyObjectRef]) -> crate::PyResult {
     };
 
     let property_type = gettypeobject(&pyre_object::descriptor::PROPERTY_TYPE);
-    let exact = r#type(prop).is_some_and(|tp| std::ptr::eq(tp, property_type));
+    let exact = r#type(prop).is_some_and(|tp| std::ptr::eq(tp.as_ptr(), property_type));
     if exact {
         if let Some(doc) = prop_doc {
             unsafe {
@@ -14979,7 +14985,7 @@ fn object_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
     // Python type of `cls` (tag-safe via `r#type`), not its raw C layout.
     if !unsafe { is_type(cls) } {
         let name = crate::typedef::r#type(cls)
-            .map(|t| unsafe { pyre_object::w_type_get_name(t) })
+            .map(|t| unsafe { pyre_object::w_type_get_name(t.as_ptr()) })
             .unwrap_or("object");
         return Err(crate::PyError::type_error(format!(
             "object.__new__(X): X is not a type object ({name})"
@@ -15030,17 +15036,17 @@ fn object_descr_init(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
         return Ok(w_none());
     };
     if let Some(w_type) = crate::typedef::r#type(w_obj) {
-        let tp_init = unsafe { crate::baseobjspace::lookup_in_type(w_type, "__init__") };
+        let tp_init = unsafe { crate::baseobjspace::lookup_in_type(w_type.as_ptr(), "__init__") };
         let obj_init = unsafe { crate::baseobjspace::lookup_in_type(w_object, "__init__") };
         if !same_inherited_slot(tp_init, obj_init) {
             return Err(crate::PyError::type_error(
                 "object.__init__() takes exactly one argument (the instance to initialize)",
             ));
         }
-        let tp_new = unsafe { crate::baseobjspace::lookup_in_type(w_type, "__new__") };
+        let tp_new = unsafe { crate::baseobjspace::lookup_in_type(w_type.as_ptr(), "__new__") };
         let obj_new = unsafe { crate::baseobjspace::lookup_in_type(w_object, "__new__") };
         if same_inherited_slot(tp_new, obj_new) {
-            let name = unsafe { pyre_object::w_type_get_name(w_type) };
+            let name = unsafe { pyre_object::w_type_get_name(w_type.as_ptr()) };
             return Err(crate::PyError::type_error(format!(
                 "{name}.__init__() takes exactly one argument (the instance to initialize)"
             )));
@@ -15057,8 +15063,8 @@ fn object_descr_sizeof(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErr
     crate::type_methods::arity_slot(args, 0)?;
     let mut size = std::mem::size_of::<pyre_object::PyObject>();
     if let Some(w_type) = crate::typedef::r#type(args[0]) {
-        if unsafe { pyre_object::is_type(w_type) } {
-            let layout = unsafe { pyre_object::w_type_get_layout_ptr(w_type) };
+        if unsafe { pyre_object::is_type(w_type.as_ptr()) } {
+            let layout = unsafe { pyre_object::w_type_get_layout_ptr(w_type.as_ptr()) };
             if !layout.is_null() {
                 size += unsafe { (*layout).nslots as usize }
                     * std::mem::size_of::<pyre_object::PyObjectRef>();
@@ -15142,7 +15148,7 @@ fn init_object_type(ns: PyObjectRef) {
                         crate::baseobjspace::get_and_call_function(
                             eq_descr,
                             args[0],
-                            w_type,
+                            w_type.as_ptr(),
                             &[args[1]],
                         )?
                     };
@@ -16590,7 +16596,7 @@ fn type_name_of(obj: PyObjectRef) -> String {
         return "int".to_string();
     }
     match r#type(obj) {
-        Some(tp) => unsafe { pyre_object::w_type_get_name(tp) }.to_string(),
+        Some(tp) => unsafe { pyre_object::w_type_get_name(tp.as_ptr()) }.to_string(),
         None => unsafe { (*(*obj).ob_type).name.to_string() },
     }
 }
@@ -18797,7 +18803,7 @@ fn bytearray_descr_repr(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyEr
     crate::type_methods::require_receiver(args, "__repr__")?;
     let data = unsafe { pyre_object::bytesobject::bytes_like_data(args[0]) };
     let class_name = crate::typedef::r#type(args[0])
-        .map(|tp| unsafe { pyre_object::w_type_get_name(tp) })
+        .map(|tp| unsafe { pyre_object::w_type_get_name(tp.as_ptr()) })
         .unwrap_or("bytearray");
     Ok(w_str_new_managed(&crate::display::bytearray_repr_string(
         data, class_name,
@@ -18820,6 +18826,7 @@ fn bytearray_reduce_impl(
         w_tuple_new(vec![w_str_new(&latin1), w_str_new("latin-1")])
     };
     let cls = crate::typedef::r#type(obj)
+        .map(|p| p.as_ptr())
         .unwrap_or_else(|| gettypeobject(&pyre_object::bytearrayobject::BYTEARRAY_TYPE));
     let state = crate::reduce_protocol::object_getstate_default(obj)?;
     Ok(w_tuple_new(vec![cls, args, state]))
@@ -22322,7 +22329,7 @@ fn count_single_argument(w_step: PyObjectRef) -> Result<bool, crate::PyError> {
 
 fn count_descr_repr(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let obj = args.first().copied().unwrap_or(PY_NULL);
-    let cls = r#type(obj).unwrap_or(PY_NULL);
+    let cls = r#type(obj).map_or(PY_NULL, |p| p.as_ptr());
     let full_name = unsafe { pyre_object::w_type_get_name(cls) };
     let cls_name = full_name.rsplit('.').next().unwrap_or(full_name);
     let w_c = unsafe { pyre_object::interp_itertools::w_count_get_c(obj) };
@@ -22399,7 +22406,7 @@ fn repeat_descr_length_hint(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::
 
 fn repeat_descr_repr(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let obj = args.first().copied().unwrap_or(PY_NULL);
-    let cls = r#type(obj).unwrap_or(PY_NULL);
+    let cls = r#type(obj).map_or(PY_NULL, |p| p.as_ptr());
     let full_name = unsafe { pyre_object::w_type_get_name(cls) };
     let cls_name = full_name.rsplit('.').next().unwrap_or(full_name);
     let w_obj = unsafe { pyre_object::interp_itertools::w_repeat_get_obj(obj) };
@@ -23208,7 +23215,8 @@ mod tests {
     fn test_ellipsis_has_registered_typeobject() {
         crate::typedef::init_typeobjects();
         let w_type = crate::typedef::r#type(pyre_object::special::w_ellipsis())
-            .expect("Ellipsis should resolve to a W_TypeObject");
+            .expect("Ellipsis should resolve to a W_TypeObject")
+            .as_ptr();
         unsafe {
             assert_eq!(pyre_object::w_type_get_name(w_type), "ellipsis");
             assert!(!pyre_object::w_type_get_acceptable_as_base_class(w_type));

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -2789,8 +2789,8 @@ pub(crate) fn try_walker_inline_user_binop<Sym: WalkSym>(
     let Some(w_typ_r) = pyre_interpreter::typedef::r#type(concrete_rhs) else {
         return Ok(None);
     };
-    if !std::ptr::eq(w_class, w_typ_r)
-        && unsafe { pyre_object::typeobject::w_type_issubtype(w_typ_r, w_class) }
+    if !std::ptr::eq(w_class, w_typ_r.as_ptr())
+        && unsafe { pyre_object::typeobject::w_type_issubtype(w_typ_r.as_ptr(), w_class) }
     {
         return Ok(None);
     }
@@ -2836,7 +2836,7 @@ pub(crate) fn try_walker_inline_user_binop<Sym: WalkSym>(
         nparams,
         has_closure,
         Some((lhs, concrete_lhs, w_class, version_tag)),
-        Some((rhs, concrete_rhs, w_typ_r)),
+        Some((rhs, concrete_rhs, w_typ_r.as_ptr())),
         false,
         false,
     )?
@@ -2933,8 +2933,8 @@ pub(crate) fn try_walker_inline_user_compareop<Sym: WalkSym>(
     let Some(w_typ_r) = pyre_interpreter::typedef::r#type(concrete_rhs) else {
         return Ok(None);
     };
-    if !std::ptr::eq(w_class, w_typ_r)
-        && unsafe { pyre_object::typeobject::w_type_issubtype(w_typ_r, w_class) }
+    if !std::ptr::eq(w_class, w_typ_r.as_ptr())
+        && unsafe { pyre_object::typeobject::w_type_issubtype(w_typ_r.as_ptr(), w_class) }
     {
         return Ok(None);
     }
@@ -2980,7 +2980,7 @@ pub(crate) fn try_walker_inline_user_compareop<Sym: WalkSym>(
         nparams,
         has_closure,
         Some((lhs, concrete_lhs, w_class, version_tag)),
-        Some((rhs, concrete_rhs, w_typ_r)),
+        Some((rhs, concrete_rhs, w_typ_r.as_ptr())),
         false,
         false,
     )?

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -3518,7 +3518,7 @@ unsafe fn trace_check_exc_match_against(
     let Some(w_exc_class) = pyre_interpreter::typedef::r#type(exc_value) else {
         return false;
     };
-    pyre_interpreter::baseobjspace::exception_match(w_exc_class, exc_type)
+    pyre_interpreter::baseobjspace::exception_match(w_exc_class.as_ptr(), exc_type)
 }
 
 fn classify_concrete(cv: ConcreteValue) -> (bool, bool) {

--- a/pyre/pyre-macros/src/lib.rs
+++ b/pyre/pyre-macros/src/lib.rs
@@ -1834,7 +1834,7 @@ fn expand_pyre_methods(
                             <#self_ty as ::pyre_object::lltype::PyreClassPyTypeOf>::PYTYPE,
                         );
                         let __pyre_same_tp = match __pyre_static_tp {
-                            ::std::option::Option::Some(t) => __pyre_cls == t,
+                            ::std::option::Option::Some(t) => __pyre_cls == t.as_ptr(),
                             ::std::option::Option::None => false,
                         };
                         if !__pyre_same_tp {

--- a/pyre/pyre-object/src/celldict.rs
+++ b/pyre/pyre-object/src/celldict.rs
@@ -287,6 +287,7 @@ pub unsafe fn walk_module_value_slot(
 /// `w_cell` must be either `None` or a valid PyObjectRef.  `w_value`
 /// must be a valid non-null PyObjectRef.
 pub unsafe fn write_cell(w_cell: Option<PyObjectRef>, w_value: PyObjectRef) -> Option<PyObjectRef> {
+    debug_assert!(!w_value.is_null(), "write_cell: null value");
     // The cell payload lives in a Box-immortal structure reached only by the
     // prebuilt-family root walk; record the store so the next minor
     // collection rescans it (gc_roots.rs prebuilt-root write tracking).
@@ -506,7 +507,12 @@ impl GlobalCache {
     /// absent at install time).
     #[inline]
     pub unsafe fn getvalue(&self) -> Option<PyObjectRef> {
-        self.cell.map(|c| unwrap_cell(c))
+        // A cached cell whose unwrapped value is null is a stale/empty binding:
+        // treat it as a cache miss rather than surfacing `Some(null)`.
+        self.cell.and_then(|c| {
+            let v = unwrap_cell(c);
+            if v.is_null() { None } else { Some(v) }
+        })
     }
 }
 
@@ -857,7 +863,11 @@ impl ModuleDictStrategy {
     /// ```
     pub fn getitem_str(&self, storage: &ModuleDictStorage, key: &str) -> Option<PyObjectRef> {
         let raw = self.getdictvalue_no_unwrapping(storage, key)?;
-        Some(unsafe { unwrap_cell(raw) })
+        // `unwrap_cell` is null-tolerant and an `ObjectMutableCell` may hold a
+        // null `w_value`; a null unwrap means the name has no live binding, so
+        // report absence rather than `Some(null)`.
+        let v = unsafe { unwrap_cell(raw) };
+        if v.is_null() { None } else { Some(v) }
     }
 
     /// `celldict.py:106-126 delitem` — minimal str-key path

--- a/pyre/pyre-object/src/dictmultiobject.rs
+++ b/pyre/pyre-object/src/dictmultiobject.rs
@@ -813,7 +813,11 @@ pub unsafe fn module_dict_cell_at(obj: PyObjectRef, slot: usize) -> Option<PyObj
     if !md.object_storage.is_null() || md.dstorage.is_null() {
         return None;
     }
-    (*md.dstorage).entries.get_index(slot).map(|(_, v)| *v)
+    (*md.dstorage)
+        .entries
+        .get_index(slot)
+        .map(|(_, v)| *v)
+        .filter(|p| !p.is_null())
 }
 
 /// Direct O(1) entry count of a module dict's `ModuleDictStorage`
@@ -2105,6 +2109,11 @@ pub unsafe fn w_module_dict_lookup_inner_checked(
 /// go through `ModuleDictStrategy::setitem` and regular dicts through
 /// `ObjectDictStrategy::setitem`.
 pub unsafe fn w_dict_store(obj: PyObjectRef, key: PyObjectRef, value: PyObjectRef) {
+    // A stored value is always a live object reference — null is never a
+    // dict value (deletes `shift_remove` the entry; there is no null
+    // tombstone).  Enforcing it at the store boundary means every lookup
+    // return is provably non-null.
+    debug_assert!(!value.is_null(), "w_dict_store: null value");
     w_dict_get_strategy(obj).setitem(obj, key, value)
 }
 
@@ -2139,6 +2148,7 @@ unsafe fn w_dict_store_checked_inner(
     value: PyObjectRef,
     hash: Option<i64>,
 ) -> Result<(), DictKeyError> {
+    debug_assert!(!value.is_null(), "w_dict_store_checked: null value");
     if is_module_dict(obj) {
         return w_module_dict_store_inner_checked(obj, key, value);
     }
@@ -2436,6 +2446,7 @@ unsafe fn w_dict_store_object_strategy_checked_inner(
     value: PyObjectRef,
     hash: Option<i64>,
 ) -> Result<(), DictKeyError> {
+    debug_assert!(!value.is_null(), "w_dict_store_object_strategy: null value");
     let object_key = match hash {
         Some(hash) => object_key_hashed(key, hash),
         None => object_key_for_checked(key)?,


### PR DESCRIPTION
## What

Retires a class of two-phase-rtyper `[PREPASS phaseB fail]` census heads (gh#346) by remodelling `gettypefor` and `r#type` — the two producers of a maybe-null type object — from a two-word `Option<PyObjectRef>` to a one-word niche `Option<NonNull<PyObject>>`.

A niche `Option<NonNull<T>>` is a single pointer word: `None` is the null pointer, `Some(p)` is the non-null pointer. This matches RPython exactly — RPython has no `Option` type; a maybe-null `W_Root` **is** a nullable pointer, and `w is not None` is a pointer null-test. The front-end folds the niche `Option`'s discriminant read to `ptr_ne(p, null)` and its `Some(x)` payload read to the pointer identity, so the rtyper prepass no longer reads a `__pos_0` payload that rtypes to `Void`.

## How

Six commits, bottom-to-top:

- **interp: fold null-valued Option<PyObjectRef> producers to None** — the front-end recognizes a producer whose `Some` arm is a proven-null pointer and collapses it to `None`.
- **jit: fold niche Option<NonNull<T>> discriminant/payload to pointer null-test** — `Rvalue::Discriminant` becomes `ptr_ne(base, null)`; the `Some(x)` `__pos_0` read becomes the identity on the pointer.
- **jit: fold niche Option<NonNull> in the Option combinator post-passes** — `unwrap_or` / `map_or` / `unwrap` / `?` / `map`+`and_then`+`unwrap_or_else` residual-combinator lifts skip the synthetic `__discriminant`+`__pos_0` switch for a niche pointer Option.
- **jit: fold niche Option<NonNull> construction and route its null through null_mut()** — `Rvalue::Aggregate` construction folds (`None` → `null_mut()` call, `Some(p)` → identity); every niche null is a repr-adaptive `core::ptr::null_mut()` call rather than a fixed-GCREF `ConstRefNull`, so it unions/converts against the pointer receiver's own `InstanceRepr`.
- **interp: return Option<NonNull<PyObject>> from gettypefor** — producer swap; callers adapt at the leaf.
- **interp: return Option<NonNull<PyObject>> from r#type** — producer swap across the interpreter and the two `pyre-jit-trace` walker call sites; `if-let` / `match` / `let-else` control structures are left untouched (the niche fold handles them natively), `.as_ptr()` is added only at leaf sites that thread a `NonNull` into a `*mut`-typed helper, and `.map_or(NULL, |p| p.as_ptr())` at raw-consuming producers.

## Verification

- `cargo test -p majit-translate` — full suite green (3020 lib + all integration + 5 real-LLBC rbigint anchors), 0 failed.
- `check.py --backend dynasm,cranelift` — bit-exact **308/308** on both backends.

Rebased onto `main` (`#761` rbigint port); one conflict in `model.rs` resolved by keeping upstream's `tuple_owner_for_var` deletion plus this branch's `push_null_mut_ptr` addition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)