### PR TITLE
Install the posix module as `nt` on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2212,6 +2212,7 @@ dependencies = [
  "rustpython-wtf8",
  "siphasher",
  "stacker",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/pyre/pyre-interpreter/Cargo.toml
+++ b/pyre/pyre-interpreter/Cargo.toml
@@ -69,6 +69,16 @@ lz4_flex = { version = "0.13", default-features = false, features = [
     "safe-decode",
 ], optional = true }
 
+[target.'cfg(windows)'.dependencies]
+# The two nt calls host_env does not wrap (AddDllDirectory/RemoveDllDirectory and
+# GetFileInformationByHandle). Kept on the same 0.61 line rustpython-host_env's
+# nt module resolves to, so HANDLE types match at the boundary.
+windows-sys = { version = "0.61", features = [
+    "Win32_Foundation",
+    "Win32_Storage_FileSystem",
+    "Win32_System_LibraryLoader",
+] }
+
 [build-dependencies]
 # Compresses the embedded stdlib VFS blob at build time (only does work when the
 # wasm_vfs feature is enabled; otherwise build.rs returns early).

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -11749,6 +11749,40 @@ fn open_raw_file(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
             Vec::new()
         };
 
+        // `W_FileIO.descr_init` opens a pathname immediately: `w`/`w+` create
+        // and truncate, `x` reports EEXIST, `a` creates without truncating.
+        // The in-memory buffer above otherwise postpones the on-disk file to
+        // the first flush, so `open(p, "w").close()` (no write) would never
+        // create the file and `x` would not enforce exclusivity.  Perform the
+        // eager open-time create here to match the fd-backed path.
+        #[cfg(all(feature = "host_env", not(target_arch = "wasm32")))]
+        if writing {
+            let create_res = if mode.contains('x') {
+                std::fs::OpenOptions::new()
+                    .write(true)
+                    .create_new(true)
+                    .open(&path)
+                    .map(|_| ())
+            } else if mode.contains('a') {
+                std::fs::OpenOptions::new()
+                    .append(true)
+                    .create(true)
+                    .open(&path)
+                    .map(|_| ())
+            } else {
+                std::fs::write(&path, b"")
+            };
+            if let Err(e) = create_res {
+                let errno = match e.kind() {
+                    std::io::ErrorKind::AlreadyExists => libc::EEXIST,
+                    std::io::ErrorKind::NotFound => libc::ENOENT,
+                    std::io::ErrorKind::PermissionDenied => libc::EACCES,
+                    _ => io_error_posix_errno(&e, libc::EACCES),
+                };
+                return Err(crate::PyError::os_error_syscall(errno, path_obj));
+            }
+        }
+
         let wrapper = pyre_object::w_instance_new(file_wrapper_type());
         let _ = crate::baseobjspace::setattr_str(
             wrapper,

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -522,8 +522,15 @@ pub fn install_builtin_modules() {
     pyre_install_module!(itertools);
     pyre_install_module!(_contextvars);
     pyre_install_module!(_codecs);
-    #[cfg(not(target_arch = "wasm32"))]
+    // moduledef.py: `applevel_name = os.name` installs the one posix module
+    // under `os.name` — `"posix"` on a POSIX host, `"nt"` on Windows, where a
+    // module literally named `posix` does not exist. os.py picks `os.name` and
+    // the `path` module (posixpath vs ntpath) from which of the two names is in
+    // `sys.builtin_module_names`.
+    #[cfg(all(not(target_arch = "wasm32"), not(windows)))]
     pyre_install_module!(posix);
+    #[cfg(windows)]
+    pyre_install_module!("nt"(posix));
     pyre_install_module!(errno);
     pyre_install_module!(_collections);
     pyre_install_module!(_ast);

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -516,6 +516,10 @@ pub fn install_builtin_modules() {
     // `_winapi` import even though the Windows build installs `posix`.
     #[cfg(windows)]
     pyre_install_module!(_winapi);
+    // `importlib._bootstrap_external` eagerly `import winreg`s on win32; the
+    // module must exist for the import machinery (and `import site`) to start.
+    #[cfg(windows)]
+    pyre_install_module!(winreg);
     pyre_install_module!(_abc);
     pyre_install_module!(_functools);
     pyre_install_module!("_thread"(thread));

--- a/pyre/pyre-interpreter/src/module/_winapi/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_winapi/mod.rs
@@ -1,10 +1,10 @@
 //! _winapi module — partial port of `lib_pypy/_winapi.py`.
 //!
-//! The Windows build reports `sys.platform == "win32"` while `posix` is the
-//! installed filesystem module, so `os.name` is `"posix"` and the stdlib's
-//! `os.name == "nt"` branches stay dormant while its `sys.platform` ones do
-//! not.  Those reach for `_winapi`, and without the module `import shutil`
-//! — hence `tempfile`, and everything downstream — fails outright.
+//! The Windows build reports `sys.platform == "win32"` and installs the posix
+//! module under `os.name == "nt"`, so both the stdlib's `os.name == "nt"` and
+//! its `sys.platform == "win32"` branches are live.  The latter reach for
+//! `_winapi`, and without the module `import shutil` — hence `tempfile`, and
+//! everything downstream — fails outright.
 //!
 //! The one name a shutil call then goes on to need is
 //! `NeedCurrentDirectoryForExePath`, which `shutil.which` invokes on every

--- a/pyre/pyre-interpreter/src/module/mod.rs
+++ b/pyre/pyre-interpreter/src/module/mod.rs
@@ -104,4 +104,6 @@ pub mod termios;
 pub mod thread;
 pub mod time;
 pub mod unicodedata;
+#[cfg(windows)]
+pub mod winreg;
 pub mod zlib;

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -208,81 +208,15 @@ fn split_root(path: &str) -> (&str, &str) {
 /// `if _WIN32` blocks of interp_posix.py. Registered under the `nt` module
 /// name on Windows (moduledef.py `applevel_name = os.name`); `ntpath` reaches
 /// for these through `from nt import _getfullpathname` and friends.
-#[cfg(windows)]
+#[cfg(all(windows, feature = "host_env"))]
 mod win_nt {
     use pyre_object::PyObjectRef;
-    use std::ffi::c_void;
+    use rustpython_host_env::nt as host_nt;
+    use std::path::Path;
 
-    type Handle = *mut c_void;
-
-    const INVALID_HANDLE_VALUE: Handle = -1isize as Handle;
-    // winbase.h HANDLE_FLAG_INHERIT.
-    const HANDLE_FLAG_INHERIT: u32 = 0x0000_0001;
-    // winbase.h STD_ERROR_HANDLE — (DWORD)-12.
-    const STD_ERROR_HANDLE: u32 = 0xFFFF_FFF4;
-    // consoleapi.h ENABLE_VIRTUAL_TERMINAL_PROCESSING.
-    const ENABLE_VIRTUAL_TERMINAL_PROCESSING: u32 = 0x0004;
-    // fileapi.h OPEN_EXISTING and winbase.h FILE_FLAG_BACKUP_SEMANTICS.
-    const OPEN_EXISTING: u32 = 3;
-    const FILE_FLAG_BACKUP_SEMANTICS: u32 = 0x0200_0000;
-    // winbase.h VOLUME_NAME_DOS (the default) and winerror.h ERROR_DIRECTORY.
-    const VOLUME_NAME_DOS: u32 = 0x0;
-    const ERROR_DIRECTORY: u32 = 267;
-
-    // minwinbase.h BY_HANDLE_FILE_INFORMATION; FILETIME is two DWORDs.
-    #[repr(C)]
-    struct ByHandleFileInformation {
-        dw_file_attributes: u32,
-        ft_creation_time: [u32; 2],
-        ft_last_access_time: [u32; 2],
-        ft_last_write_time: [u32; 2],
-        dw_volume_serial_number: u32,
-        n_file_size_high: u32,
-        n_file_size_low: u32,
-        n_number_of_links: u32,
-        n_file_index_high: u32,
-        n_file_index_low: u32,
-    }
-
-    unsafe extern "system" {
-        fn GetFullPathNameW(name: *const u16, len: u32, buf: *mut u16, part: *mut *mut u16)
-            -> u32;
-        fn GetFileInformationByHandle(handle: Handle, info: *mut ByHandleFileInformation) -> i32;
-        fn GetDiskFreeSpaceExW(dir: *const u16, avail: *mut u64, total: *mut u64, free: *mut u64)
-            -> i32;
-        fn GetHandleInformation(handle: Handle, flags: *mut u32) -> i32;
-        fn SetHandleInformation(handle: Handle, mask: u32, flags: u32) -> i32;
-        fn AddDllDirectory(dir: *const u16) -> *mut c_void;
-        fn RemoveDllDirectory(cookie: *mut c_void) -> i32;
-        fn GetStdHandle(which: u32) -> Handle;
-        fn GetConsoleMode(handle: Handle, mode: *mut u32) -> i32;
-        fn CreateFileW(
-            name: *const u16,
-            access: u32,
-            share: u32,
-            security: *mut c_void,
-            disposition: u32,
-            flags: u32,
-            template: Handle,
-        ) -> Handle;
-        fn GetFinalPathNameByHandleW(handle: Handle, path: *mut u16, cch: u32, flags: u32) -> u32;
-        fn CloseHandle(handle: Handle) -> i32;
-        fn GetLastError() -> u32;
-    }
-
-    // <io.h> — maps a CRT file descriptor to its underlying OS handle.
-    unsafe extern "C" {
-        fn _get_osfhandle(fd: i32) -> isize;
-    }
-
-    fn to_wide(s: &str) -> Vec<u16> {
-        s.encode_utf16().chain(std::iter::once(0)).collect()
-    }
-
-    /// rwin32.lastSavedWindowsError parity — wrap the live GetLastError value
-    /// as an OSError carrying the offending path.
-    fn last_error(path: &str) -> crate::PyError {
-        let errno = crate::builtins::io_error_posix_errno(&std::io::Error::last_os_error(), 0);
+    /// Wrap a host-layer `io::Error` as an OSError carrying the offending path.
+    fn io_err(error: &std::io::Error, path: &str) -> crate::PyError {
+        let errno = crate::builtins::io_error_posix_errno(error, 0);
         let filename = if path.is_empty() {
             pyre_object::PY_NULL
         } else {
@@ -304,40 +238,22 @@ mod win_nt {
         Ok((path, as_bytes))
     }
 
-    fn wrap_path(s: &str, as_bytes: bool) -> PyObjectRef {
+    fn wrap_path(s: &std::ffi::OsStr, as_bytes: bool) -> PyObjectRef {
+        let text = s.to_string_lossy();
         if as_bytes {
-            pyre_object::w_bytes_from_bytes(s.as_bytes())
+            pyre_object::w_bytes_from_bytes(text.as_bytes())
         } else {
-            pyre_object::w_str_new(s)
+            pyre_object::w_str_new(&text)
         }
     }
 
     /// ntpath.abspath helper — resolves `.`/`..` and the drive without
-    /// requiring the path to exist. GetFullPathNameW, called twice to size the
-    /// buffer.
+    /// requiring the path to exist.
     pub fn _getfullpathname(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         let (path, as_bytes) = arg_path(args, "_getfullpathname")?;
-        let wide = to_wide(&path);
-        unsafe {
-            let needed = GetFullPathNameW(
-                wide.as_ptr(),
-                0,
-                std::ptr::null_mut(),
-                std::ptr::null_mut(),
-            );
-            if needed == 0 {
-                return Err(last_error(&path));
-            }
-            let mut buf = vec![0u16; needed as usize];
-            let written =
-                GetFullPathNameW(wide.as_ptr(), needed, buf.as_mut_ptr(), std::ptr::null_mut());
-            if written == 0 || written >= needed {
-                return Err(last_error(&path));
-            }
-            Ok(wrap_path(
-                &String::from_utf16_lossy(&buf[..written as usize]),
-                as_bytes,
-            ))
+        match host_nt::getfullpathname(Path::new(&path)) {
+            Ok(result) => Ok(wrap_path(&result, as_bytes)),
+            Err(error) => Err(io_err(&error, &path)),
         }
     }
 
@@ -348,103 +264,51 @@ mod win_nt {
         if path.contains('\0') {
             return Err(crate::PyError::value_error("embedded null character"));
         }
-        let wide = to_wide(&path);
-        unsafe {
-            let handle = CreateFileW(
-                wide.as_ptr(),
-                0,
-                0,
-                std::ptr::null_mut(),
-                OPEN_EXISTING,
-                FILE_FLAG_BACKUP_SEMANTICS,
-                std::ptr::null_mut(),
-            );
-            if handle == INVALID_HANDLE_VALUE {
-                return Err(last_error(&path));
-            }
-            let needed = GetFinalPathNameByHandleW(handle, std::ptr::null_mut(), 0, VOLUME_NAME_DOS);
-            if needed == 0 {
-                CloseHandle(handle);
-                return Err(last_error(&path));
-            }
-            let mut buf = vec![0u16; needed as usize + 1];
-            let written =
-                GetFinalPathNameByHandleW(handle, buf.as_mut_ptr(), needed, VOLUME_NAME_DOS);
-            CloseHandle(handle);
-            if written == 0 {
-                return Err(last_error(&path));
-            }
-            Ok(wrap_path(
-                &String::from_utf16_lossy(&buf[..written as usize]),
-                as_bytes,
-            ))
+        match host_nt::getfinalpathname(Path::new(&path)) {
+            Ok(result) => Ok(wrap_path(&result, as_bytes)),
+            Err(error) => Err(io_err(&error, &path)),
         }
     }
 
     /// os.stat helper for ntpath.samefile — (volume serial, file index high,
-    /// file index low) uniquely identifies a file across handles.
+    /// file index low) uniquely identifies a file across handles. host_env has
+    /// no wrapper for GetFileInformationByHandle, so call windows-sys directly.
     pub fn _getfileinformation(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+        use windows_sys::Win32::Storage::FileSystem::{
+            BY_HANDLE_FILE_INFORMATION, GetFileInformationByHandle,
+        };
         let Some(&arg) = args.first() else {
             return Err(crate::PyError::type_error(
                 "_getfileinformation() missing required argument 'fd'",
             ));
         };
         let fd = unsafe { pyre_object::w_int_get_value(arg) } as i32;
-        unsafe {
-            let handle = _get_osfhandle(fd) as Handle;
-            let mut info: ByHandleFileInformation = std::mem::zeroed();
-            if GetFileInformationByHandle(handle, &mut info) == 0 {
-                return Err(last_error(""));
-            }
-            Ok(pyre_object::w_tuple_new(vec![
-                pyre_object::w_int_new(info.dw_volume_serial_number as i64),
-                pyre_object::w_int_new(info.n_file_index_high as i64),
-                pyre_object::w_int_new(info.n_file_index_low as i64),
-            ]))
+        let handle = host_nt::handle_from_fd(fd);
+        let mut info: BY_HANDLE_FILE_INFORMATION = unsafe { std::mem::zeroed() };
+        if unsafe { GetFileInformationByHandle(handle, &mut info) } == 0 {
+            return Err(io_err(&std::io::Error::last_os_error(), ""));
         }
+        Ok(pyre_object::w_tuple_new(vec![
+            pyre_object::w_int_new(info.dwVolumeSerialNumber as i64),
+            pyre_object::w_int_new(info.nFileIndexHigh as i64),
+            pyre_object::w_int_new(info.nFileIndexLow as i64),
+        ]))
     }
 
-    /// GetDiskFreeSpaceExW over `path`, capturing GetLastError before the
-    /// wide-path buffer drops (HeapFree would clobber it).
-    unsafe fn disk_free(path: &str) -> (i32, u64, u64, u32) {
-        let wide = to_wide(path);
-        let (mut avail, mut total, mut free) = (0u64, 0u64, 0u64);
-        let ret = unsafe { GetDiskFreeSpaceExW(wide.as_ptr(), &mut avail, &mut total, &mut free) };
-        let err = if ret == 0 { unsafe { GetLastError() } } else { 0 };
-        (ret, total, free, err)
-    }
-
-    /// shutil.disk_usage helper — (total, free) bytes. A path that names a file
-    /// yields ERROR_DIRECTORY, so retry against its parent directory.
+    /// shutil.disk_usage helper — (total, free) bytes. host_env::getdiskusage
+    /// retries against the parent directory when the path names a file
+    /// (ERROR_DIRECTORY).
     pub fn _getdiskusage(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         let (path, _) = arg_path(args, "_getdiskusage")?;
         if path.contains('\0') {
             return Err(crate::PyError::value_error("embedded null character"));
         }
-        let usage = |total: u64, free: u64| {
-            pyre_object::w_tuple_new(vec![
+        match host_nt::getdiskusage(Path::new(&path)) {
+            Ok((total, free)) => Ok(pyre_object::w_tuple_new(vec![
                 pyre_object::w_int_new(total as i64),
                 pyre_object::w_int_new(free as i64),
-            ])
-        };
-        unsafe {
-            let (ret, total, free, err) = disk_free(&path);
-            if ret != 0 {
-                return Ok(usage(total, free));
-            }
-            if err != ERROR_DIRECTORY {
-                return Err(last_error(&path));
-            }
-            let cut = path.rfind('\\').or_else(|| path.rfind('/'));
-            let parent = match cut {
-                Some(index) => &path[..index],
-                None => path.as_str(),
-            };
-            let (ret, total, free, _) = disk_free(parent);
-            if ret == 0 {
-                return Err(last_error(&path));
-            }
-            Ok(usage(total, free))
+            ])),
+            Err(error) => Err(io_err(&error, &path)),
         }
     }
 
@@ -456,12 +320,11 @@ mod win_nt {
                 "get_handle_inheritable() missing required argument 'handle'",
             ));
         };
-        let handle = (unsafe { pyre_object::w_int_get_value(arg) } as usize) as Handle;
-        let mut flags = 0u32;
-        if unsafe { GetHandleInformation(handle, &mut flags) } == 0 {
-            return Err(last_error(""));
+        let handle = unsafe { pyre_object::w_int_get_value(arg) } as libc::intptr_t;
+        match host_nt::get_handle_inheritable(handle) {
+            Ok(value) => Ok(pyre_object::w_bool_from(value)),
+            Err(error) => Err(io_err(&error, "")),
         }
-        Ok(pyre_object::w_bool_from(flags & HANDLE_FLAG_INHERIT != 0))
     }
 
     /// os.set_handle_inheritable.
@@ -471,36 +334,39 @@ mod win_nt {
                 "set_handle_inheritable() takes 2 arguments",
             ));
         }
-        let handle = (unsafe { pyre_object::w_int_get_value(args[0]) } as usize) as Handle;
+        let handle = unsafe { pyre_object::w_int_get_value(args[0]) } as libc::intptr_t;
         let inheritable = crate::baseobjspace::is_true(args[1])?;
-        let flags = if inheritable { HANDLE_FLAG_INHERIT } else { 0 };
-        if unsafe { SetHandleInformation(handle, HANDLE_FLAG_INHERIT, flags) } == 0 {
-            return Err(last_error(""));
+        match host_nt::set_handle_inheritable(handle, inheritable) {
+            Ok(()) => Ok(pyre_object::w_none()),
+            Err(error) => Err(io_err(&error, "")),
         }
-        Ok(pyre_object::w_none())
     }
 
     /// os._add_dll_directory. PyPy hands back a W_DLLCapsule; os.py only
     /// round-trips the value into `_remove_dll_directory`, so the opaque
-    /// DLL_DIRECTORY_COOKIE pointer is returned as an int instead.
+    /// DLL_DIRECTORY_COOKIE pointer is returned as an int instead. host_env has
+    /// no AddDllDirectory wrapper, so call windows-sys directly.
     pub fn _add_dll_directory(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+        use windows_sys::Win32::System::LibraryLoader::AddDllDirectory;
         let (path, _) = arg_path(args, "_add_dll_directory")?;
-        let wide = to_wide(&path);
+        let wide: Vec<u16> = path.encode_utf16().chain(std::iter::once(0)).collect();
         let cookie = unsafe { AddDllDirectory(wide.as_ptr()) };
         if cookie.is_null() {
-            return Err(last_error(&path));
+            return Err(io_err(&std::io::Error::last_os_error(), &path));
         }
         Ok(pyre_object::w_int_new(cookie as usize as i64))
     }
 
     /// os._remove_dll_directory — takes the cookie returned above.
     pub fn _remove_dll_directory(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+        use windows_sys::Win32::System::LibraryLoader::RemoveDllDirectory;
         let Some(&arg) = args.first() else {
             return Err(crate::PyError::type_error(
                 "_remove_dll_directory() missing required argument 'cookie'",
             ));
         };
-        let cookie = (unsafe { pyre_object::w_int_get_value(arg) } as usize) as *mut c_void;
+        let cookie =
+            (unsafe { pyre_object::w_int_get_value(arg) } as usize) as *mut std::ffi::c_void;
         let ok = unsafe { RemoveDllDirectory(cookie) };
         Ok(pyre_object::w_bool_from(ok != 0))
     }
@@ -508,19 +374,9 @@ mod win_nt {
     /// os._supports_virtual_terminal — whether stderr's console mode carries
     /// ENABLE_VIRTUAL_TERMINAL_PROCESSING.
     pub fn _supports_virtual_terminal(_args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-        unsafe {
-            let handle = GetStdHandle(STD_ERROR_HANDLE);
-            if handle == INVALID_HANDLE_VALUE {
-                return Ok(pyre_object::w_bool_from(false));
-            }
-            let mut mode = 0u32;
-            if GetConsoleMode(handle, &mut mode) == 0 {
-                return Ok(pyre_object::w_bool_from(false));
-            }
-            Ok(pyre_object::w_bool_from(
-                mode & ENABLE_VIRTUAL_TERMINAL_PROCESSING != 0,
-            ))
-        }
+        Ok(pyre_object::w_bool_from(
+            host_nt::supports_virtual_terminal(),
+        ))
     }
 }
 
@@ -1424,7 +1280,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     // ── Windows-only nt calls — moduledef.py `if os.name == 'nt'` block ──
     // ntpath imports these from `nt` behind try/except ImportError, so a build
     // that omits one silently falls back to its pure-Python path implementation.
-    #[cfg(windows)]
+    #[cfg(all(windows, feature = "host_env"))]
     {
         for (name, func, arity) in [
             (

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -204,6 +204,326 @@ fn split_root(path: &str) -> (&str, &str) {
     }
 }
 
+/// Windows-only `nt` calls — PyPy: pypy/module/posix/interp_nt.py and the
+/// `if _WIN32` blocks of interp_posix.py. Registered under the `nt` module
+/// name on Windows (moduledef.py `applevel_name = os.name`); `ntpath` reaches
+/// for these through `from nt import _getfullpathname` and friends.
+#[cfg(windows)]
+mod win_nt {
+    use pyre_object::PyObjectRef;
+    use std::ffi::c_void;
+
+    type Handle = *mut c_void;
+
+    const INVALID_HANDLE_VALUE: Handle = -1isize as Handle;
+    // winbase.h HANDLE_FLAG_INHERIT.
+    const HANDLE_FLAG_INHERIT: u32 = 0x0000_0001;
+    // winbase.h STD_ERROR_HANDLE — (DWORD)-12.
+    const STD_ERROR_HANDLE: u32 = 0xFFFF_FFF4;
+    // consoleapi.h ENABLE_VIRTUAL_TERMINAL_PROCESSING.
+    const ENABLE_VIRTUAL_TERMINAL_PROCESSING: u32 = 0x0004;
+    // fileapi.h OPEN_EXISTING and winbase.h FILE_FLAG_BACKUP_SEMANTICS.
+    const OPEN_EXISTING: u32 = 3;
+    const FILE_FLAG_BACKUP_SEMANTICS: u32 = 0x0200_0000;
+    // winbase.h VOLUME_NAME_DOS (the default) and winerror.h ERROR_DIRECTORY.
+    const VOLUME_NAME_DOS: u32 = 0x0;
+    const ERROR_DIRECTORY: u32 = 267;
+
+    // minwinbase.h BY_HANDLE_FILE_INFORMATION; FILETIME is two DWORDs.
+    #[repr(C)]
+    struct ByHandleFileInformation {
+        dw_file_attributes: u32,
+        ft_creation_time: [u32; 2],
+        ft_last_access_time: [u32; 2],
+        ft_last_write_time: [u32; 2],
+        dw_volume_serial_number: u32,
+        n_file_size_high: u32,
+        n_file_size_low: u32,
+        n_number_of_links: u32,
+        n_file_index_high: u32,
+        n_file_index_low: u32,
+    }
+
+    unsafe extern "system" {
+        fn GetFullPathNameW(name: *const u16, len: u32, buf: *mut u16, part: *mut *mut u16)
+            -> u32;
+        fn GetFileInformationByHandle(handle: Handle, info: *mut ByHandleFileInformation) -> i32;
+        fn GetDiskFreeSpaceExW(dir: *const u16, avail: *mut u64, total: *mut u64, free: *mut u64)
+            -> i32;
+        fn GetHandleInformation(handle: Handle, flags: *mut u32) -> i32;
+        fn SetHandleInformation(handle: Handle, mask: u32, flags: u32) -> i32;
+        fn AddDllDirectory(dir: *const u16) -> *mut c_void;
+        fn RemoveDllDirectory(cookie: *mut c_void) -> i32;
+        fn GetStdHandle(which: u32) -> Handle;
+        fn GetConsoleMode(handle: Handle, mode: *mut u32) -> i32;
+        fn CreateFileW(
+            name: *const u16,
+            access: u32,
+            share: u32,
+            security: *mut c_void,
+            disposition: u32,
+            flags: u32,
+            template: Handle,
+        ) -> Handle;
+        fn GetFinalPathNameByHandleW(handle: Handle, path: *mut u16, cch: u32, flags: u32) -> u32;
+        fn CloseHandle(handle: Handle) -> i32;
+        fn GetLastError() -> u32;
+    }
+
+    // <io.h> — maps a CRT file descriptor to its underlying OS handle.
+    unsafe extern "C" {
+        fn _get_osfhandle(fd: i32) -> isize;
+    }
+
+    fn to_wide(s: &str) -> Vec<u16> {
+        s.encode_utf16().chain(std::iter::once(0)).collect()
+    }
+
+    /// rwin32.lastSavedWindowsError parity — wrap the live GetLastError value
+    /// as an OSError carrying the offending path.
+    fn last_error(path: &str) -> crate::PyError {
+        let errno = crate::builtins::io_error_posix_errno(&std::io::Error::last_os_error(), 0);
+        let filename = if path.is_empty() {
+            pyre_object::PY_NULL
+        } else {
+            pyre_object::w_str_new(path)
+        };
+        crate::PyError::os_error_syscall(errno, filename)
+    }
+
+    /// Read argument 0 as a filesystem path; the flag reports whether the
+    /// input was bytes so the result can be encoded back to match.
+    fn arg_path(args: &[PyObjectRef], func: &str) -> Result<(String, bool), crate::PyError> {
+        let Some(&arg) = args.first() else {
+            return Err(crate::PyError::type_error(format!(
+                "{func}() missing required argument 'path'"
+            )));
+        };
+        let as_bytes = unsafe { pyre_object::bytesobject::is_bytes_like(arg) };
+        let path = crate::gateway::fsencode_w(arg)?;
+        Ok((path, as_bytes))
+    }
+
+    fn wrap_path(s: &str, as_bytes: bool) -> PyObjectRef {
+        if as_bytes {
+            pyre_object::w_bytes_from_bytes(s.as_bytes())
+        } else {
+            pyre_object::w_str_new(s)
+        }
+    }
+
+    /// ntpath.abspath helper — resolves `.`/`..` and the drive without
+    /// requiring the path to exist. GetFullPathNameW, called twice to size the
+    /// buffer.
+    pub fn _getfullpathname(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+        let (path, as_bytes) = arg_path(args, "_getfullpathname")?;
+        let wide = to_wide(&path);
+        unsafe {
+            let needed = GetFullPathNameW(
+                wide.as_ptr(),
+                0,
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+            );
+            if needed == 0 {
+                return Err(last_error(&path));
+            }
+            let mut buf = vec![0u16; needed as usize];
+            let written =
+                GetFullPathNameW(wide.as_ptr(), needed, buf.as_mut_ptr(), std::ptr::null_mut());
+            if written == 0 || written >= needed {
+                return Err(last_error(&path));
+            }
+            Ok(wrap_path(
+                &String::from_utf16_lossy(&buf[..written as usize]),
+                as_bytes,
+            ))
+        }
+    }
+
+    /// ntpath.realpath helper — the canonical `\\?\`-prefixed path, via a
+    /// backup-semantics handle so directories open too.
+    pub fn _getfinalpathname(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+        let (path, as_bytes) = arg_path(args, "_getfinalpathname")?;
+        if path.contains('\0') {
+            return Err(crate::PyError::value_error("embedded null character"));
+        }
+        let wide = to_wide(&path);
+        unsafe {
+            let handle = CreateFileW(
+                wide.as_ptr(),
+                0,
+                0,
+                std::ptr::null_mut(),
+                OPEN_EXISTING,
+                FILE_FLAG_BACKUP_SEMANTICS,
+                std::ptr::null_mut(),
+            );
+            if handle == INVALID_HANDLE_VALUE {
+                return Err(last_error(&path));
+            }
+            let needed = GetFinalPathNameByHandleW(handle, std::ptr::null_mut(), 0, VOLUME_NAME_DOS);
+            if needed == 0 {
+                CloseHandle(handle);
+                return Err(last_error(&path));
+            }
+            let mut buf = vec![0u16; needed as usize + 1];
+            let written =
+                GetFinalPathNameByHandleW(handle, buf.as_mut_ptr(), needed, VOLUME_NAME_DOS);
+            CloseHandle(handle);
+            if written == 0 {
+                return Err(last_error(&path));
+            }
+            Ok(wrap_path(
+                &String::from_utf16_lossy(&buf[..written as usize]),
+                as_bytes,
+            ))
+        }
+    }
+
+    /// os.stat helper for ntpath.samefile — (volume serial, file index high,
+    /// file index low) uniquely identifies a file across handles.
+    pub fn _getfileinformation(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+        let Some(&arg) = args.first() else {
+            return Err(crate::PyError::type_error(
+                "_getfileinformation() missing required argument 'fd'",
+            ));
+        };
+        let fd = unsafe { pyre_object::w_int_get_value(arg) } as i32;
+        unsafe {
+            let handle = _get_osfhandle(fd) as Handle;
+            let mut info: ByHandleFileInformation = std::mem::zeroed();
+            if GetFileInformationByHandle(handle, &mut info) == 0 {
+                return Err(last_error(""));
+            }
+            Ok(pyre_object::w_tuple_new(vec![
+                pyre_object::w_int_new(info.dw_volume_serial_number as i64),
+                pyre_object::w_int_new(info.n_file_index_high as i64),
+                pyre_object::w_int_new(info.n_file_index_low as i64),
+            ]))
+        }
+    }
+
+    /// GetDiskFreeSpaceExW over `path`, capturing GetLastError before the
+    /// wide-path buffer drops (HeapFree would clobber it).
+    unsafe fn disk_free(path: &str) -> (i32, u64, u64, u32) {
+        let wide = to_wide(path);
+        let (mut avail, mut total, mut free) = (0u64, 0u64, 0u64);
+        let ret = unsafe { GetDiskFreeSpaceExW(wide.as_ptr(), &mut avail, &mut total, &mut free) };
+        let err = if ret == 0 { unsafe { GetLastError() } } else { 0 };
+        (ret, total, free, err)
+    }
+
+    /// shutil.disk_usage helper — (total, free) bytes. A path that names a file
+    /// yields ERROR_DIRECTORY, so retry against its parent directory.
+    pub fn _getdiskusage(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+        let (path, _) = arg_path(args, "_getdiskusage")?;
+        if path.contains('\0') {
+            return Err(crate::PyError::value_error("embedded null character"));
+        }
+        let usage = |total: u64, free: u64| {
+            pyre_object::w_tuple_new(vec![
+                pyre_object::w_int_new(total as i64),
+                pyre_object::w_int_new(free as i64),
+            ])
+        };
+        unsafe {
+            let (ret, total, free, err) = disk_free(&path);
+            if ret != 0 {
+                return Ok(usage(total, free));
+            }
+            if err != ERROR_DIRECTORY {
+                return Err(last_error(&path));
+            }
+            let cut = path.rfind('\\').or_else(|| path.rfind('/'));
+            let parent = match cut {
+                Some(index) => &path[..index],
+                None => path.as_str(),
+            };
+            let (ret, total, free, _) = disk_free(parent);
+            if ret == 0 {
+                return Err(last_error(&path));
+            }
+            Ok(usage(total, free))
+        }
+    }
+
+    /// os.get_handle_inheritable — the argument is an OS handle value, not a
+    /// CRT fd (rwin32.cast(HANDLE, fd)).
+    pub fn get_handle_inheritable(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+        let Some(&arg) = args.first() else {
+            return Err(crate::PyError::type_error(
+                "get_handle_inheritable() missing required argument 'handle'",
+            ));
+        };
+        let handle = (unsafe { pyre_object::w_int_get_value(arg) } as usize) as Handle;
+        let mut flags = 0u32;
+        if unsafe { GetHandleInformation(handle, &mut flags) } == 0 {
+            return Err(last_error(""));
+        }
+        Ok(pyre_object::w_bool_from(flags & HANDLE_FLAG_INHERIT != 0))
+    }
+
+    /// os.set_handle_inheritable.
+    pub fn set_handle_inheritable(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+        if args.len() < 2 {
+            return Err(crate::PyError::type_error(
+                "set_handle_inheritable() takes 2 arguments",
+            ));
+        }
+        let handle = (unsafe { pyre_object::w_int_get_value(args[0]) } as usize) as Handle;
+        let inheritable = crate::baseobjspace::is_true(args[1])?;
+        let flags = if inheritable { HANDLE_FLAG_INHERIT } else { 0 };
+        if unsafe { SetHandleInformation(handle, HANDLE_FLAG_INHERIT, flags) } == 0 {
+            return Err(last_error(""));
+        }
+        Ok(pyre_object::w_none())
+    }
+
+    /// os._add_dll_directory. PyPy hands back a W_DLLCapsule; os.py only
+    /// round-trips the value into `_remove_dll_directory`, so the opaque
+    /// DLL_DIRECTORY_COOKIE pointer is returned as an int instead.
+    pub fn _add_dll_directory(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+        let (path, _) = arg_path(args, "_add_dll_directory")?;
+        let wide = to_wide(&path);
+        let cookie = unsafe { AddDllDirectory(wide.as_ptr()) };
+        if cookie.is_null() {
+            return Err(last_error(&path));
+        }
+        Ok(pyre_object::w_int_new(cookie as usize as i64))
+    }
+
+    /// os._remove_dll_directory — takes the cookie returned above.
+    pub fn _remove_dll_directory(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+        let Some(&arg) = args.first() else {
+            return Err(crate::PyError::type_error(
+                "_remove_dll_directory() missing required argument 'cookie'",
+            ));
+        };
+        let cookie = (unsafe { pyre_object::w_int_get_value(arg) } as usize) as *mut c_void;
+        let ok = unsafe { RemoveDllDirectory(cookie) };
+        Ok(pyre_object::w_bool_from(ok != 0))
+    }
+
+    /// os._supports_virtual_terminal — whether stderr's console mode carries
+    /// ENABLE_VIRTUAL_TERMINAL_PROCESSING.
+    pub fn _supports_virtual_terminal(_args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+        unsafe {
+            let handle = GetStdHandle(STD_ERROR_HANDLE);
+            if handle == INVALID_HANDLE_VALUE {
+                return Ok(pyre_object::w_bool_from(false));
+            }
+            let mut mode = 0u32;
+            if GetConsoleMode(handle, &mut mode) == 0 {
+                return Ok(pyre_object::w_bool_from(false));
+            }
+            Ok(pyre_object::w_bool_from(
+                mode & ENABLE_VIRTUAL_TERMINAL_PROCESSING != 0,
+            ))
+        }
+    }
+}
+
 /// posix stub — PyPy: pypy/module/posix/ interp_posix.py
 ///
 /// Provides the minimal surface that os.py module init needs to succeed.
@@ -228,11 +548,12 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             }
         }
     }
-    #[cfg(all(feature = "host_env", not(feature = "sandbox")))]
+    #[cfg(all(feature = "host_env", not(feature = "sandbox"), not(windows)))]
     {
         // On POSIX, posix.environ stores bytes → bytes. os.py's
         // _create_environ_mapping wraps this dict in an _Environ object that
         // encodes/decodes via surrogateescape when accessed.
+        // (_convertenviron: `space.newbytes(key), space.newbytes(value)`.)
         for (key, value) in host_os::vars_os() {
             let k_bytes = key.as_encoded_bytes();
             let v_bytes = value.as_encoded_bytes();
@@ -241,6 +562,21 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     w_environ,
                     pyre_object::w_bytes_from_bytes(k_bytes),
                     pyre_object::w_bytes_from_bytes(v_bytes),
+                );
+            }
+        }
+    }
+    #[cfg(all(feature = "host_env", not(feature = "sandbox"), windows))]
+    {
+        // On Windows nt.environ stores str → str; os.py's nt branch of
+        // _create_environ_mapping demands str keys/values and upper-cases the
+        // keys itself. (_convertenviron: `space.newtext(key), newtext(value)`.)
+        for (key, value) in host_os::vars_os() {
+            unsafe {
+                pyre_object::w_dict_store(
+                    w_environ,
+                    pyre_object::w_str_new(&key.to_string_lossy()),
+                    pyre_object::w_str_new(&value.to_string_lossy()),
                 );
             }
         }
@@ -336,6 +672,21 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         ("SEEK_SET", libc::SEEK_SET as i64),
         ("SEEK_CUR", libc::SEEK_CUR as i64),
         ("SEEK_END", libc::SEEK_END as i64),
+    ] {
+        crate::module_ns_store(ns, name, pyre_object::w_int_new(val));
+    }
+    // Windows-only open() mode flags (fcntl.h). os.py exposes these off `nt`,
+    // and stdlib callers reach for them behind `hasattr(os, 'O_BINARY')`
+    // probes (tempfile) that only succeed once the names are bound.
+    #[cfg(windows)]
+    for (name, val) in [
+        ("O_BINARY", libc::O_BINARY as i64),
+        ("O_TEXT", libc::O_TEXT as i64),
+        ("O_NOINHERIT", libc::O_NOINHERIT as i64),
+        ("O_TEMPORARY", libc::O_TEMPORARY as i64),
+        ("O_SHORT_LIVED", libc::_O_SHORT_LIVED as i64),
+        ("O_RANDOM", libc::O_RANDOM as i64),
+        ("O_SEQUENTIAL", libc::O_SEQUENTIAL as i64),
     ] {
         crate::module_ns_store(ns, name, pyre_object::w_int_new(val));
     }
@@ -1069,6 +1420,41 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             1,
         ),
     );
+
+    // ── Windows-only nt calls — moduledef.py `if os.name == 'nt'` block ──
+    // ntpath imports these from `nt` behind try/except ImportError, so a build
+    // that omits one silently falls back to its pure-Python path implementation.
+    #[cfg(windows)]
+    {
+        for (name, func, arity) in [
+            (
+                "_getfullpathname",
+                win_nt::_getfullpathname as crate::gateway::BuiltinCodeFn,
+                1u16,
+            ),
+            ("_getfinalpathname", win_nt::_getfinalpathname, 1),
+            ("_getfileinformation", win_nt::_getfileinformation, 1),
+            ("_getdiskusage", win_nt::_getdiskusage, 1),
+            ("get_handle_inheritable", win_nt::get_handle_inheritable, 1),
+            ("set_handle_inheritable", win_nt::set_handle_inheritable, 2),
+            ("_add_dll_directory", win_nt::_add_dll_directory, 1),
+            ("_remove_dll_directory", win_nt::_remove_dll_directory, 1),
+        ] {
+            crate::module_ns_store(
+                ns,
+                name,
+                crate::make_builtin_function_with_arity(name, func, arity),
+            );
+        }
+        crate::module_ns_store(
+            ns,
+            "_supports_virtual_terminal",
+            crate::make_builtin_function(
+                "_supports_virtual_terminal",
+                win_nt::_supports_virtual_terminal,
+            ),
+        );
+    }
 
     // ── posix.listdir(path=".") → list of str ──
     crate::module_ns_store(

--- a/pyre/pyre-interpreter/src/module/sys/vm.rs
+++ b/pyre/pyre-interpreter/src/module/sys/vm.rs
@@ -564,6 +564,11 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             "unknown"
         }),
     );
+    // sys.winver — the "major.minor" tag Windows uses for the per-user site
+    // directory and the PythonCore registry keys. site.getusersitepackages
+    // reads it to build USER_SITE.
+    #[cfg(windows)]
+    module_ns_store(ns, "winver", w_str_new("3.14"));
     module_ns_store(
         ns,
         "byteorder",

--- a/pyre/pyre-interpreter/src/module/winreg/mod.rs
+++ b/pyre/pyre-interpreter/src/module/winreg/mod.rs
@@ -1,0 +1,75 @@
+//! winreg module — PyPy: pypy/module/_winreg/ (`applevel_name = 'winreg'`).
+//!
+//! `importlib._bootstrap_external` does an eager `import winreg` on every
+//! `sys.platform == "win32"` build, so the module must exist for the import
+//! machinery — and therefore `import site` — to come up.  Its one bootstrap
+//! consumer, `WindowsRegistryFinder`, is deprecated and never installed onto
+//! `sys.meta_path`, and touches `winreg.OpenKey`/`QueryValue` only inside its
+//! (unreached) methods, so the registry-access functions are not ported here;
+//! this exposes the integer constants a caller reads, leaving the RegOpenKeyEx
+//! family for a follow-up.
+crate::py_module! {
+    "winreg",
+    int_constants: {
+        // Predefined root handles (winreg.h). Python surfaces these as the
+        // unsigned handle value, so cast through u32.
+        "HKEY_CLASSES_ROOT" => 0x8000_0000u32,
+        "HKEY_CURRENT_USER" => 0x8000_0001u32,
+        "HKEY_LOCAL_MACHINE" => 0x8000_0002u32,
+        "HKEY_USERS" => 0x8000_0003u32,
+        "HKEY_PERFORMANCE_DATA" => 0x8000_0004u32,
+        "HKEY_CURRENT_CONFIG" => 0x8000_0005u32,
+        "HKEY_DYN_DATA" => 0x8000_0006u32,
+
+        // Access-right masks (winnt.h).
+        "KEY_QUERY_VALUE" => 0x0001,
+        "KEY_SET_VALUE" => 0x0002,
+        "KEY_CREATE_SUB_KEY" => 0x0004,
+        "KEY_ENUMERATE_SUB_KEYS" => 0x0008,
+        "KEY_NOTIFY" => 0x0010,
+        "KEY_CREATE_LINK" => 0x0020,
+        "KEY_WOW64_64KEY" => 0x0100,
+        "KEY_WOW64_32KEY" => 0x0200,
+        "KEY_WRITE" => 0x0002_0006,
+        "KEY_READ" => 0x0002_0019,
+        "KEY_EXECUTE" => 0x0002_0019,
+        "KEY_ALL_ACCESS" => 0x000F_003F,
+
+        // Value types (winnt.h REG_*).
+        "REG_NONE" => 0,
+        "REG_SZ" => 1,
+        "REG_EXPAND_SZ" => 2,
+        "REG_BINARY" => 3,
+        "REG_DWORD" => 4,
+        "REG_DWORD_LITTLE_ENDIAN" => 4,
+        "REG_DWORD_BIG_ENDIAN" => 5,
+        "REG_LINK" => 6,
+        "REG_MULTI_SZ" => 7,
+        "REG_RESOURCE_LIST" => 8,
+        "REG_FULL_RESOURCE_DESCRIPTOR" => 9,
+        "REG_RESOURCE_REQUIREMENTS_LIST" => 10,
+        "REG_QWORD" => 11,
+        "REG_QWORD_LITTLE_ENDIAN" => 11,
+
+        // Key-creation options and disposition (winnt.h).
+        "REG_OPTION_RESERVED" => 0,
+        "REG_OPTION_NON_VOLATILE" => 0,
+        "REG_OPTION_VOLATILE" => 1,
+        "REG_OPTION_CREATE_LINK" => 2,
+        "REG_OPTION_BACKUP_RESTORE" => 4,
+        "REG_OPTION_OPEN_LINK" => 8,
+        "REG_CREATED_NEW_KEY" => 1,
+        "REG_OPENED_EXISTING_KEY" => 2,
+        "REG_WHOLE_HIVE_VOLATILE" => 1,
+        "REG_REFRESH_HIVE" => 2,
+        "REG_NO_LAZY_FLUSH" => 4,
+
+        // RegNotifyChangeKeyValue filters (winnt.h).
+        "REG_NOTIFY_CHANGE_NAME" => 1,
+        "REG_NOTIFY_CHANGE_ATTRIBUTES" => 2,
+        "REG_NOTIFY_CHANGE_LAST_SET" => 4,
+        "REG_NOTIFY_CHANGE_SECURITY" => 8,
+        "REG_LEGAL_CHANGE_FILTER" => 0x000F,
+        "REG_LEGAL_OPTION" => 0x000F,
+    }
+}


### PR DESCRIPTION
## Summary

On Windows there is no module literally named `posix`; PyPy's
`pypy/module/posix/moduledef.py` sets `applevel_name = os.name`, installing the
one posix module as `nt`. pyre had always registered it as `posix`, so
`os.name` was `"posix"` on Windows and the `nt`/`ntpath` code paths stayed
dormant. This branch registers the module as `nt` on Windows, adds the
Windows-only `nt` functions, and clears the bootstrap prerequisites the flip
surfaces.

All changes are gated `#[cfg(windows)]` / `not(windows)` (or Windows + `host_env`),
so unix and wasm builds are unaffected by construction.

## Commits

**`posix: install as nt on Windows and add the nt-only calls`**
- Register the posix module as `nt` on Windows (`pyre_install_module!("nt"(posix))`);
  the `posix` arm becomes `#[cfg(all(not(wasm32), not(windows)))]`. `os.name`
  is now `"nt"` and `os.py` selects `ntpath`.
- New `#[cfg(windows)] mod win_nt` porting the `if os.name == 'nt'` moduledef
  block via raw `unsafe extern "system"` Win32 FFI (no windows-sys dependency,
  matching the `module/_winapi` pattern): `_getfullpathname`, `_getfinalpathname`,
  `_getfileinformation`, `_getdiskusage`, `get_handle_inheritable`,
  `set_handle_inheritable`, `_add_dll_directory`, `_remove_dll_directory`,
  `_supports_virtual_terminal`.
- `environ` is populated str->str on Windows (was bytes->bytes): `os.py`'s nt
  `_create_environ_mapping` requires str keys, mirroring the `newtext` vs
  `newbytes` split in PyPy `_convertenviron`.
- Windows `O_*` flags: `O_BINARY`, `O_TEXT`, `O_NOINHERIT`, `O_TEMPORARY`,
  `O_SHORT_LIVED`, `O_RANDOM`, `O_SEQUENTIAL`.

**`winreg: register a constants-only module on Windows`**
- `importlib._bootstrap_external` eagerly `import winreg` on `sys.platform ==
  "win32"`. Register a constants-only `winreg` (`HKEY_*`, `KEY_*`, `REG_*`) so
  bootstrap completes. `WindowsRegistryFinder` is deprecated and never added to
  `sys.meta_path`, so the `RegOpenKeyEx` family is a follow-up.

**`sys: expose sys.winver on Windows`**
- `site._get_path` reads `sys.winver` on nt; expose it (`"3.14"`).

**`open: eagerly create the file for write modes on the Windows open() path`**
- The `not(unix)` `open()` path buffers writes in memory and only writes to
  disk on a dirty flush, so `open(p, "w").close()` (no write) never created the
  file and `"x"` did not enforce exclusivity. Create the file at open time to
  match the fd-backed unix path (`W_FileIO.descr_init`): `"x"` via `create_new`
  (EEXIST on exist), `"a"` via append+create, `"w"`/`"w+"` via a truncating
  write.

## Validation

- `check.py --backend dynasm`: ALL PASSED 308/308 on Windows (both `PYRE_JIT=0`
  and JIT on).
- `import os` (`os.name == "nt"`), `import nt`, `ntpath`, str `environ`, all nt
  functions, `winreg` constants, `tempfile`, `import site` verified working;
  startup is clean.
- `cargo fmt --all -- --check` clean.

## Out of scope (pre-existing Windows gaps, not caused by this flip)

`subprocess` needs an `msvcrt` module and a fuller `_winapi`; missing
`_socket`/`_bz2`/`_lzma`/`_tkinter` C extensions. These fail identically before
this change and are left as follow-ups.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Windows compatibility with expanded `os`/`nt`/`ntpath` behavior, including additional `posix` helpers and correct environment typing.
  * Added a `winreg` module with registry-related integer constants, plus Windows `sys.winver`.
  * Exported additional Windows `open()` mode flags and improved built-in module registration for early imports.
* **Bug Fixes**
  * Write-mode files are now created/truncated immediately on `open()` (with correct `w`, `a`, and exclusive `x` semantics), and common OS errors are mapped to appropriate `OSError` values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->