### PR TITLE
long: address rbigint review follow-ups

### DIFF
--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -305,6 +305,10 @@ fn register_active_hooks(supports_guard_gc_type: bool) {
     majit_gc::set_active_alloc_nursery_typed_with_placement(Some(
         wasm_alloc_nursery_typed_with_placement,
     ));
+    majit_gc::set_active_alloc_nursery_collecting_typed(Some(wasm_alloc_nursery_collecting_typed));
+    majit_gc::set_active_alloc_nursery_collecting_typed_rooted(Some(
+        wasm_alloc_nursery_collecting_typed_rooted,
+    ));
     majit_gc::set_active_alloc_oldgen_typed(Some(wasm_alloc_oldgen_typed));
     majit_gc::set_active_root_hooks(Some(wasm_gc_add_root), Some(wasm_gc_remove_root));
     majit_gc::set_active_gc_owns_object(Some(wasm_gc_owns_object));
@@ -522,6 +526,32 @@ unsafe fn wasm_alloc_nursery_typed_with_placement(
 ) -> GcRef {
     with_wasm_active_gc_mut(|gc| unsafe {
         gc.try_alloc_nursery_no_collect_typed_with_placement(type_id, size, needs_write_barrier)
+    })
+    .unwrap_or(GcRef(0))
+}
+
+/// Host-side collecting nursery allocation used by elidable bigint payload
+/// helpers. This is the wasm twin of the dynasm/cranelift hooks: the active
+/// backend must replace every process-global allocation hook as one unit so a
+/// previously-installed native backend cannot receive wasm allocations.
+fn wasm_alloc_nursery_collecting_typed(type_id: u32, size: usize) -> GcRef {
+    with_wasm_active_gc_mut(|gc| gc.alloc_nursery_typed(type_id, size)).unwrap_or(GcRef(0))
+}
+
+/// Rooted collecting companion for a result whose GC child exists only in a
+/// native Rust slot while the parent allocation may collect.
+///
+/// # Safety
+/// `root` and `needs_write_barrier` must remain valid mutable slots until this
+/// call returns.
+unsafe fn wasm_alloc_nursery_collecting_typed_rooted(
+    type_id: u32,
+    size: usize,
+    root: *mut GcRef,
+    needs_write_barrier: *mut bool,
+) -> GcRef {
+    with_wasm_active_gc_mut(|gc| unsafe {
+        gc.alloc_nursery_collecting_typed_rooted(type_id, size, root, needs_write_barrier)
     })
     .unwrap_or(GcRef(0))
 }

--- a/majit/majit-translate/src/codewriter/annotation_state.rs
+++ b/majit/majit-translate/src/codewriter/annotation_state.rs
@@ -52,7 +52,7 @@ pub fn valuetype_to_someshell(vt: &ValueType) -> Option<SomeValue> {
             KnownType::LongLongLong,
         ))),
         ValueType::UInt128 => Some(SomeValue::Integer(SomeInteger::new_with_knowntype(
-            false,
+            true,
             KnownType::ULongLongLong,
         ))),
         // RPython `SomeBool` (`annotator/model.py:185-198`) is a
@@ -171,5 +171,15 @@ mod tests {
             }
             other => panic!("typed Ref must use fallback Instance, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn uint128_shell_is_nonnegative() {
+        let shell = valuetype_to_someshell(&ValueType::UInt128).expect("UInt128 projects");
+        let SomeValue::Integer(integer) = shell else {
+            panic!("UInt128 must project to SomeInteger");
+        };
+        assert!(integer.nonneg);
+        assert_eq!(integer.base.knowntype, KnownType::ULongLongLong);
     }
 }

--- a/majit/majit-translate/src/front/llbc_hints.rs
+++ b/majit/majit-translate/src/front/llbc_hints.rs
@@ -126,6 +126,7 @@ pub fn harvest_hints_from_llbcs(llbcs: &[Llbc]) -> HashMap<String, Vec<String>> 
                     for hint in *hints {
                         push_hint(&mut out, key.clone(), hint);
                     }
+                    break;
                 }
             }
         }

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -6406,24 +6406,6 @@ impl<'a> Lowering<'a> {
                 // `name_path()`; the scope predicate keys on the module
                 // path, which the built `CallTarget::Method` drops.
                 callee_name_path = Some(segments.join("::"));
-                // Rust's shallow `Clone` shim has no RPython operation:
-                // `rbigint` values are immutable GC references, so cloning a
-                // reference is an identity assignment. Preserve that exact
-                // owner shape instead of descending into field copies of a
-                // classdef-less external declaration.
-                if args.len() == 1
-                    && segments.last().is_some_and(|leaf| leaf == "clone")
-                    && first_arg_ty
-                        .as_ref()
-                        .is_some_and(|ty| tyref_is_rbigint(ty, self.llbc))
-                    && tyref_is_rbigint(&call.dest.ty, self.llbc)
-                {
-                    self.local_var[dest_local] = Some(args[0].clone());
-                    let target_bb = self.block_id[target];
-                    let link_args = self.edge_args(mir_bb, target)?;
-                    self.graph.set_goto(bb_id, target_bb, link_args);
-                    return Ok(());
-                }
                 if self.try_lower_checked_neg(
                     mir_bb,
                     &reg.kind,
@@ -6847,6 +6829,36 @@ impl<'a> Lowering<'a> {
             OpKind::Hint {
                 value: args[0].clone(),
                 kind,
+            }
+        } else {
+            op_kind
+        };
+
+        // Rust's `RBigInt::clone` returns a new by-value handle sharing the
+        // immutable digit array. In the translated one-GC-reference shape that
+        // requires a fresh payload allocation: neither a reference-identity
+        // assignment nor descending into the classdef-less `_digits` field is
+        // correct. Retarget the exact receiver/result pair to the GC-aware
+        // shallow-clone residual.
+        let op_kind = if let OpKind::Call { target, args, .. } = &op_kind
+            && args.len() == 1
+            && first_arg_ty
+                .as_ref()
+                .is_some_and(|ty| tyref_is_rbigint(ty, self.llbc))
+            && tyref_is_rbigint(&call.dest.ty, self.llbc)
+            && let Some(segments) = match target {
+                CallTarget::FunctionPath { segments } => segments
+                    .last()
+                    .and_then(|leaf| crate::front::rbigint_call::clone_residual_for_method(leaf)),
+                CallTarget::Method { name, .. } => {
+                    crate::front::rbigint_call::clone_residual_for_method(name)
+                }
+                _ => None,
+            } {
+            OpKind::Call {
+                target: CallTarget::FunctionPath { segments },
+                args: args.clone(),
+                result_ty: ValueType::Ref(None),
             }
         } else {
             op_kind
@@ -12294,7 +12306,10 @@ fn tyref_is_rbigint(ty: &TyRef, llbc: &Llbc) -> bool {
         .and_then(|n| strip_ty_wrappers(n, llbc))
         .and_then(adt_node_def_id)
         .and_then(|id| llbc.type_by_id(id))
-        .is_some_and(|td| td.item_meta.name_path().ends_with("rbigint::RBigInt"))
+        .is_some_and(|td| {
+            let path = td.item_meta.name_path();
+            path == "rbigint::RBigInt" || path.ends_with("::rbigint::RBigInt")
+        })
 }
 
 /// True when `ty` (after stripping `&`/`&mut`/`*` wrappers) resolves to

--- a/majit/majit-translate/src/front/rbigint_call.rs
+++ b/majit/majit-translate/src/front/rbigint_call.rs
@@ -31,7 +31,9 @@ pub(crate) fn constructor_residual_path(
     let matches_constructor = match leaf {
         "from" => true,
         "fromint" => !unsigned,
-        "from_u128" => unsigned,
+        // RPython's JIT has no longlonglong register kind. Keep the decline
+        // local to this mapper instead of relying on the caller's width gate.
+        "from_u128" => return None,
         _ => false,
     };
     if !matches_constructor
@@ -54,6 +56,23 @@ pub(crate) fn constructor_residual_path(
         .to_string(),
     );
     Some(path)
+}
+
+/// Translate Rust's shallow handle clone to a fresh one-GC-reference payload.
+///
+/// The caller proves both the receiver and destination are the exact local
+/// RBigInt ADT. The residual preserves `Clone`'s shared immutable digit array
+/// while giving the returned by-value handle its own translated GC object.
+pub(crate) fn clone_residual_for_method(leaf: &str) -> Option<Vec<String>> {
+    if leaf != "clone" {
+        return None;
+    }
+    Some(
+        ["pyre_object", "longobject", "jit_bigint_clone"]
+            .into_iter()
+            .map(str::to_string)
+            .collect(),
+    )
 }
 
 /// Bare-payload residual for scalar RBigInt queries. The caller has already
@@ -276,7 +295,19 @@ mod tests {
         assert!(
             constructor_residual_path(&segs(&["rbigint", "RBigInt", "fromint"]), true).is_none()
         );
+        assert!(
+            constructor_residual_path(&segs(&["rbigint", "RBigInt", "from_u128"]), true).is_none()
+        );
         assert!(constructor_residual_path(&segs(&["rbigint", "RBigInt", "add"]), false).is_none());
+    }
+
+    #[test]
+    fn maps_only_the_exact_clone_method() {
+        assert_eq!(
+            clone_residual_for_method("clone"),
+            Some(segs(&["pyre_object", "longobject", "jit_bigint_clone"]))
+        );
+        assert!(clone_residual_for_method("clone_from").is_none());
     }
 
     #[test]

--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -1938,6 +1938,7 @@ pub(crate) fn lift_callee_to_pygraph(
     } else {
         AlwaysInline::Absent
     };
+    graph.borrow_mut().func = Some(func.clone());
     let pygraph = Rc::new(PyGraph {
         graph,
         func,
@@ -4521,6 +4522,15 @@ mod tests {
             pygraph.func._always_inline_,
             AlwaysInline::True,
             "legacy always_inline hint must land on graph.func"
+        );
+        assert!(
+            pygraph
+                .graph
+                .borrow()
+                .func
+                .as_ref()
+                .is_some_and(|func| func._always_inline_ == AlwaysInline::True),
+            "legacy always_inline hint must land on the registered FunctionGraph.func"
         );
         // Capture the callee's flowspace graph `Rc` before the pygraph
         // is moved into `register_callee`; this is the identity that

--- a/majit/majit-translate/tests/test_rbigint_mir.rs
+++ b/majit/majit-translate/tests/test_rbigint_mir.rs
@@ -495,6 +495,10 @@ fn rbigint_impl_methods_preserve_upstream_elidable_markers() {
         "missing upstream _always_inline_='try' marker for rbigint::<Impl>::rshift: {hints:?}"
     );
     assert!(
+        !hints.contains_key("rbigint::<Impl>::rshift::try_rshift"),
+        "_always_inline_try_ must not also match the shorter _always_inline_ prefix"
+    );
+    assert!(
         hints
             .get("rbigint::_AsDouble")
             .is_some_and(|values| values.iter().any(|hint| hint == "dont_look_inside")),
@@ -937,6 +941,8 @@ fn dependent_crate_rbigint_identity_retargets_opaque_llbc_declaration() {
         "objspace::descroperation::jit_bigint_int_xor",
         "objspace::descroperation::jit_bigint_shl",
         "objspace::descroperation::jit_bigint_pow_nomod",
+        "objspace::descroperation::jit_bigint_div",
+        "objspace::descroperation::jit_bigint_rem",
         "objspace::descroperation::jit_bigint_div_floor",
         "objspace::descroperation::jit_bigint_mod_floor",
         "jit_compiler_bigint_to_rbigint",
@@ -1336,5 +1342,29 @@ fn rbigint_operator_calls_retarget_to_gc_reference_residuals() {
     assert_eq!(
         constructor_residuals, 1,
         "RBigInt::from(i64) must return one GC reference through its residual"
+    );
+
+    let clone_caller = program
+        .functions
+        .iter()
+        .find(|function| {
+            function.name == "box_bigint_constant" && function.module_path == "longobject"
+        })
+        .expect("longobject::box_bigint_constant graph");
+    assert!(
+        clone_caller
+            .graph
+            .blocks
+            .iter()
+            .flat_map(|block| &block.operations)
+            .any(|operation| matches!(
+                &operation.kind,
+                OpKind::Call {
+                    target: CallTarget::FunctionPath { segments },
+                    result_ty: ValueType::Ref(None),
+                    ..
+                } if segments.last().is_some_and(|leaf| leaf == "jit_bigint_clone")
+            )),
+        "RBigInt::clone must allocate a translated shallow-copy payload, not collapse to an alias"
     );
 }

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -1869,7 +1869,7 @@ pub(crate) fn range_count_method(args: &[PyObjectRef]) -> PyResult {
         match next(it) {
             Ok(item) => {
                 if is_true(compare(item, needle, CompareOp::Eq)?)? {
-                    count += BigInt::from(1);
+                    count = count.int_add(1);
                 }
             }
             Err(e) if e.kind == PyErrorKind::StopIteration => break,

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -12429,7 +12429,11 @@ mod tests {
             -BigInt::from(u128::MAX),
         ];
         for b in &bigs {
-            assert_eq!(_hash_long(b), _hash_long(b), "rbigint.hash vs _hash_long");
+            assert_eq!(
+                _hash_long(b),
+                rustpython_common::hash::hash_bigint(&crate::rbigint_to_compiler_bigint(b)),
+                "rbigint.hash vs independent compiler-bigint hash"
+            );
         }
     }
 

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -1095,6 +1095,12 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
     );
     push_alias_pair(
         &mut entries,
+        "pyre_object::longobject::jit_bigint_clone",
+        "pyre_object::jit_bigint_clone",
+        pyre_object::jit_bigint_clone as *const (),
+    );
+    push_alias_pair(
+        &mut entries,
         "pyre_object::longobject::jit_bigint_eq",
         "pyre_object::jit_bigint_eq",
         pyre_object::jit_bigint_eq as *const (),

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -209,7 +209,7 @@ pub extern "C" fn jit_bigint_bit_count(value: i64) -> i64 {
 /// its operand pointers rooted across the alloc), matching the arithmetic
 /// residuals. Returns a freshly heap-allocated `*mut BigInt` encoded as the
 /// JIT's uniform i64 word; the MIR retarget keeps the result modeled as GcRef.
-#[majit_macros::elidable]
+#[majit_macros::elidable_or_memerror]
 pub extern "C" fn jit_bigint_div(a: i64, b: i64) -> pyre_object::longobject::JitBigIntResult {
     let (a, b) = (a as *const BigInt, b as *const BigInt);
     unsafe {
@@ -225,7 +225,7 @@ pub extern "C" fn jit_bigint_div(a: i64, b: i64) -> pyre_object::longobject::Jit
 
 /// `_divrem`'s truncated remainder.
 /// See [`jit_bigint_div`]; both project the same upstream helper.
-#[majit_macros::elidable]
+#[majit_macros::elidable_or_memerror]
 pub extern "C" fn jit_bigint_rem(a: i64, b: i64) -> pyre_object::longobject::JitBigIntResult {
     let (a, b) = (a as *const BigInt, b as *const BigInt);
     unsafe {

--- a/pyre/pyre-interpreter/src/pyopcode.rs
+++ b/pyre/pyre-interpreter/src/pyopcode.rs
@@ -515,10 +515,10 @@ fn load_const_value<H: ConstantOpcodeHandler + ?Sized>(
 ) -> Result<H::Value, PyError> {
     match constant {
         ConstantData::Integer { value } => {
-            let value = crate::compiler_bigint_to_rbigint(value);
-            if pyre_object::longobject::jit_bigint_to_i64_fits(&value) != 0 {
-                handler.int_constant(pyre_object::longobject::jit_bigint_to_i64_value(&value))
+            if let Some(value) = num_traits::ToPrimitive::to_i64(value) {
+                handler.int_constant(value)
             } else {
+                let value = crate::compiler_bigint_to_rbigint(value);
                 handler.bigint_constant(&value)
             }
         }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -3514,49 +3514,46 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
                     } else {
                         // int specialization first; float (incl. mixed int/float)
                         // as a fallback so two-int operands keep int arithmetic.
-                        match try_walker_specialize_binary_op_int(
+                        let mut specialized = try_walker_specialize_binary_op_int(
                             ctx, op.pc, op_tag, &r_args, &allboxes, call_descr, dst, dst_bank,
-                        )? {
-                            Some(()) => Some(()),
+                        )?;
+                        if specialized.is_none() {
                             // longobject.py `_make_generic_descr_binop` and
                             // `descr_sub` use the rbigint.int_* family for
                             // mixed Long/Int operands.
-                            None => match try_walker_specialize_binary_op_long_int(
+                            specialized = try_walker_specialize_binary_op_long_int(
                                 ctx, op.pc, op_tag, &r_args, &allboxes, call_descr, dst, dst_bank,
-                            )? {
-                                Some(()) => Some(()),
-                                // `_make_descr_binop` gives shifts with an Int
-                                // count their own `_int_lshift` /
-                                // `_int_rshift` path before Long/Long.
-                                None => match try_walker_specialize_binary_op_long_int_shift(
-                                    ctx, op.pc, op_tag, &r_args, &allboxes, call_descr, dst,
-                                    dst_bank,
-                                )? {
-                                    Some(()) => Some(()),
-                                    // W_LongObject operands take the long fast
-                                    // path before float so bigint arithmetic
-                                    // retains its payload representation.
-                                    None => match try_walker_specialize_binary_op_long(
-                                        ctx, op.pc, op_tag, &r_args, &allboxes, call_descr, dst,
-                                        dst_bank,
-                                    )? {
-                                        Some(()) => Some(()),
-                                        // Two-long true-divide → float fast
-                                        // path (CallPureF + wrapfloat).
-                                        None => match try_walker_specialize_truediv_op_long(
-                                            ctx, op.pc, op_tag, &r_args, &allboxes, call_descr,
-                                            dst, dst_bank,
-                                        )? {
-                                            Some(()) => Some(()),
-                                            None => try_walker_specialize_binary_op_float(
-                                                ctx, op.pc, op_tag, &r_args, &allboxes, call_descr,
-                                                dst, dst_bank,
-                                            )?,
-                                        },
-                                    },
-                                },
-                            },
+                            )?;
                         }
+                        if specialized.is_none() {
+                            // `_make_descr_binop` gives shifts with an Int
+                            // count their own `_int_lshift` / `_int_rshift`
+                            // path before Long/Long.
+                            specialized = try_walker_specialize_binary_op_long_int_shift(
+                                ctx, op.pc, op_tag, &r_args, &allboxes, call_descr, dst, dst_bank,
+                            )?;
+                        }
+                        if specialized.is_none() {
+                            // W_LongObject operands take the long fast path
+                            // before float so bigint arithmetic retains its
+                            // payload representation.
+                            specialized = try_walker_specialize_binary_op_long(
+                                ctx, op.pc, op_tag, &r_args, &allboxes, call_descr, dst, dst_bank,
+                            )?;
+                        }
+                        if specialized.is_none() {
+                            // Two-long true-divide → float fast path
+                            // (CallPureF + wrapfloat).
+                            specialized = try_walker_specialize_truediv_op_long(
+                                ctx, op.pc, op_tag, &r_args, &allboxes, call_descr, dst, dst_bank,
+                            )?;
+                        }
+                        if specialized.is_none() {
+                            specialized = try_walker_specialize_binary_op_float(
+                                ctx, op.pc, op_tag, &r_args, &allboxes, call_descr, dst, dst_bank,
+                            )?;
+                        }
+                        specialized
                     }
                 } else if op_tag == 10 && ctx.is_authoritative_executor {
                     // B3: `op_tag == 10` is CHECK_EXC_MATCH

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -738,6 +738,10 @@ pub(crate) fn try_walker_specialize_binary_op_long_int<Sym: WalkSym>(
         *((boxed_result_obj as *const u8).add(pyre_object::longobject::LONG_VALUE_OFFSET)
             as *const i64)
     };
+    let fits_concrete = pyre_object::longobject::jit_bigint_fits_int(raw_concrete);
+    if fits_concrete != 0 {
+        return Ok(None);
+    }
 
     let long_type_addr = &pyre_object::pyobject::LONG_TYPE as *const _ as i64;
     walker_guard_class(ctx, op_pc, long, long_type_addr)?;
@@ -787,7 +791,7 @@ pub(crate) fn try_walker_specialize_binary_op_long_int<Sym: WalkSym>(
         majit_metainterp::cannot_raise_effect_info(),
     );
     ctx.trace_ctx
-        .set_opref_concrete(fits, majit_ir::Value::Int(0));
+        .set_opref_concrete(fits, majit_ir::Value::Int(fits_concrete));
     walker_emit_guard_with_snapshot(ctx, op_pc, OpCode::GuardFalse, &[fits])?;
 
     let result = crate::helpers::emit_box_long_inline(
@@ -882,6 +886,10 @@ pub(crate) fn try_walker_specialize_binary_op_long_int_shift<Sym: WalkSym>(
         *((boxed_result_obj as *const u8).add(pyre_object::longobject::LONG_VALUE_OFFSET)
             as *const i64)
     };
+    let fits_concrete = pyre_object::longobject::jit_bigint_fits_int(raw_concrete);
+    if fits_concrete != 0 {
+        return Ok(None);
+    }
 
     let long_type_addr = &pyre_object::pyobject::LONG_TYPE as *const _ as i64;
     walker_guard_class(ctx, op_pc, lhs, long_type_addr)?;
@@ -941,7 +949,7 @@ pub(crate) fn try_walker_specialize_binary_op_long_int_shift<Sym: WalkSym>(
         majit_metainterp::cannot_raise_effect_info(),
     );
     ctx.trace_ctx
-        .set_opref_concrete(fits, majit_ir::Value::Int(0));
+        .set_opref_concrete(fits, majit_ir::Value::Int(fits_concrete));
     walker_emit_guard_with_snapshot(ctx, op_pc, OpCode::GuardFalse, &[fits])?;
 
     let result = crate::helpers::emit_box_long_inline(

--- a/pyre/pyre-object/src/longobject.rs
+++ b/pyre/pyre-object/src/longobject.rs
@@ -221,6 +221,18 @@ pub extern "C" fn jit_bigint_from_u64(value: u64) -> JitBigIntResult {
     )))
 }
 
+/// Rust handle clone for the translated one-GC-reference rbigint shape.
+///
+/// `RBigInt::clone` shares the immutable digit array but returns a new by-value
+/// handle. Translation therefore needs a fresh GC payload containing that
+/// shallow handle, rather than either descending into the classdef-less Rust
+/// fields or collapsing the clone to reference identity.
+#[majit_macros::elidable_or_memerror]
+pub extern "C" fn jit_bigint_clone(value: i64) -> JitBigIntResult {
+    let value = value as *const BigInt;
+    unsafe { encode_jit_bigint_result(alloc_bigint_nursery_collecting((*value).clone())) }
+}
+
 macro_rules! bigint_comparison_residual {
     ($name:ident, $method:ident) => {
         #[doc = "Bare-RBigInt comparison residual using the translated GC-reference ABI."]
@@ -717,9 +729,12 @@ mod tests {
     fn test_bare_bigint_constructor_comparison_and_scalar_residuals() {
         let a = jit_bigint_from_i64(-42);
         let b = jit_bigint_from_u64(42);
+        let cloned = jit_bigint_clone(a as i64);
         unsafe {
             assert_eq!(&*a, &BigInt::from(-42));
             assert_eq!(&*b, &BigInt::from(42));
+            assert_eq!(&*cloned, &*a);
+            assert_ne!(cloned, a);
         }
         assert_eq!(jit_bigint_eq(a as i64, b as i64), 0);
         assert_eq!(jit_bigint_lt(a as i64, b as i64), 1);


### PR DESCRIPTION
## Summary

Follow up on the review findings from the merged rbigint port in #761.

- register wasm collecting and rooted bigint GC allocation hooks
- preserve `RBigInt::clone` as a GC-aware shallow-copy residual instead of collapsing it to reference identity
- propagate unsigned and always-inline annotation metadata correctly
- tighten rbigint MIR residual matching and decline unsupported `u128` construction
- avoid eager compiler-bigint conversion for small constants
- correct mixed long/int specialization guards and bigint allocation effect annotations
- add focused MIR, annotation, residual mapping, and hash-oracle coverage

## Root cause and impact

Several review findings came from gaps between Rust source shapes and the translated one-GC-reference RPython model. The most important was `RBigInt::clone`: translating the Rust method directly exposed classdef-less fields to the rtyper, while treating it as a pure alias lost the by-value handle semantics. The new residual allocates a fresh GC payload while sharing the immutable digit array, matching the source behavior and keeping the result rooted.

The wasm backend also did not replace the process-global collecting allocation hooks as part of backend activation, which could leave stale native-backend hooks installed in mixed-backend processes.

## Validation

- re-extracted `pyre-object` and `pyre-interpreter` LLBC artifacts
- rbigint MIR tests: 5/5 passed
- `cargo check --features dynasm`
- `cargo test --features dynasm`
- `cargo test -p pyre-jit-trace --features dynasm`: 306 passed, 6 ignored
- `cargo test -p majit-backend-wasm`: 24 passed, 2 ignored
- dynasm benchmark/regression suite: 14/14 passed
- prepass clone failures removed; phaseB failures reduced from 42 to 33
