### PR TITLE
builtins: receiver + arity validation, unoptimized locals scopes, breakpoint(), exact int↔float compare, posix env

### DIFF
--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -13123,11 +13123,7 @@ pub(crate) fn property_descr_set_impl(args: &[PyObjectRef]) -> PyResult {
     unsafe {
         let prop = property_require_obj(args.first().copied().unwrap_or(PY_NULL), "__set__")?;
         let obj = args[1];
-        let value = if args.len() > 2 {
-            args[2]
-        } else {
-            pyre_object::PY_NULL
-        };
+        let value = args[2];
         let fset = w_property_get_fset(prop);
         if fset.is_null() || is_none(fset) {
             return Err(property_no_accessor(prop, obj, "setter")?);

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -9806,14 +9806,14 @@ pub(crate) fn init_file_wrapper_type(ns: PyObjectRef) {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
             ns,
             "readline",
-            make_builtin_function_with_arity("readline", file_method_readline, 1),
+            make_builtin_function("readline", file_method_readline),
         )
     };
     unsafe {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
             ns,
             "readlines",
-            make_builtin_function_with_arity("readlines", file_method_readlines, 1),
+            make_builtin_function("readlines", file_method_readlines),
         )
     };
     unsafe {

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -6725,6 +6725,17 @@ fn parse_int_from_str(
     } else {
         (1i64, s)
     };
+    // intobject.py passes `disallow_whitespace_after_sign=True` to
+    // NumberStringParser.  Its sign branch advances `start` without calling
+    // `_strip_spaces`, so whitespace immediately after either sign remains
+    // part of the digit stream and makes the literal invalid.
+    if rest
+        .as_bytes()
+        .first()
+        .is_some_and(|c| matches!(c, b' ' | b'\x0c' | b'\n' | b'\r' | b'\t' | b'\x0b'))
+    {
+        return Err(invalid_int_literal(w_source, base));
+    }
     let (radix, digits, had_base_prefix, implicit_zero_only) = if base == 0 {
         if let Some(r) = rest.strip_prefix("0x").or(rest.strip_prefix("0X")) {
             (16u32, r, true, false)
@@ -12674,6 +12685,16 @@ mod tests {
             err.message
                 .starts_with("invalid literal for int() with base 10:")
         );
+    }
+
+    #[test]
+    fn int_string_rejects_whitespace_after_sign() {
+        crate::typedef::init_typeobjects();
+        for text in ["- 1", "+ 1", " + 1 "] {
+            let source = w_str_new(text);
+            let err = parse_int_from_str(source, text, 10).unwrap_err();
+            assert_eq!(err.kind, crate::PyErrorKind::ValueError);
+        }
     }
 
     /// PyPy `interp_io._open` constructs `W_FileIO`, and

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -5360,7 +5360,12 @@ fn make_exc_type_with_init(
     if let Some(cls) = lookup_exc_class(name) {
         return cls;
     }
-    let cls = crate::typedef::make_builtin_type_with_base(
+    // Every exception class shares one instance layout, distinct from
+    // `object`'s: `class E(Exception, ValueError)` is fine, `class E(Exception,
+    // list)` is an instance lay-out conflict.  The subclasses reach the same
+    // Layout object through the reuse rule (their parent layout already names
+    // this typedef).
+    let cls = crate::typedef::make_builtin_type_with_layout(
         name,
         move |ns| {
             unsafe {
@@ -5558,6 +5563,7 @@ fn make_exc_type_with_init(
             }
         },
         base,
+        &pyre_object::interp_exceptions::EXCEPTION_TYPE as *const pyre_object::PyType,
     );
     // Record the class so typedef::r#type can map a raised exception
     // back to its specific builtin class (TypeError, ValueError, ...).

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -2273,6 +2273,9 @@ pub fn install_default_builtins(ns: PyObjectRef) {
     crate::module_ns_get_or_insert_with(ns, "anext", || {
         make_module_builtin_function("anext", crate::async_operation::builtin_anext)
     });
+    crate::module_ns_get_or_insert_with(ns, "breakpoint", || {
+        make_module_builtin_function("breakpoint", builtin_breakpoint)
+    });
     crate::module_ns_get_or_insert_with(ns, "callable", || {
         make_module_builtin_function_with_arity("callable", builtin_callable, 1)
     });
@@ -12406,6 +12409,46 @@ fn builtin_format(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
 }
 
 /// `__import__(name, globals=None, locals=None, fromlist=(), level=0)`
+/// Call `callable` with a builtin's own argument slice, re-splitting the
+/// trailing `__pyre_kw__` marker back into real keyword arguments.  This is
+/// what a builtin that forwards `*args, **kwargs` onward needs: passing the
+/// slice through unchanged would hand the marker dict over as a positional.
+pub(crate) fn call_forwarding_args(
+    callable: PyObjectRef,
+    args: &[PyObjectRef],
+) -> Result<PyObjectRef, crate::PyError> {
+    let (positional, kwargs) = split_builtin_kwargs(args);
+    if !has_real_kwargs(kwargs) {
+        return crate::call::call_function_impl_result(callable, positional);
+    }
+    let keyword_args: Vec<(rustpython_wtf8::Wtf8Buf, PyObjectRef)> = unsafe {
+        pyre_object::w_dict_str_entries(kwargs.unwrap())
+            .into_iter()
+            .filter(|(name, _)| name != "__pyre_kw__")
+            .map(|(name, value)| (rustpython_wtf8::Wtf8Buf::from_string(name), value))
+            .collect()
+    };
+    crate::eval::CURRENT_FRAME.with(|current| {
+        let frame = current.get();
+        if frame.is_null() {
+            return Err(crate::PyError::runtime_error("call has no current frame"));
+        }
+        crate::call::call_with_kwargs(unsafe { &mut *frame }, callable, positional, &keyword_args)
+    })
+}
+
+/// `app_breakpoint.py breakpoint` — forward to `sys.breakpointhook`, which
+/// must accept whatever arguments are passed.  By default that drops into pdb.
+fn builtin_breakpoint(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let Some(sys) = crate::importing::get_sys_module("sys") else {
+        return Err(crate::PyError::runtime_error("lost sys.breakpointhook"));
+    };
+    let Ok(hook) = crate::baseobjspace::getattr_str(sys, "breakpointhook") else {
+        return Err(crate::PyError::runtime_error("lost sys.breakpointhook"));
+    };
+    call_forwarding_args(hook, args)
+}
+
 /// — PyPy: `_frozen_importlib/interp_import.py:interp___import__`.
 fn builtin_dunder_import(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     // `__import__(name, globals, locals, fromlist, level)` — PyPy's gateway

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -772,17 +772,16 @@ fn call_builtin_code_positional(code: PyObjectRef, args: &[PyObjectRef]) -> PyRe
             .collect::<Vec<_>>()
     };
 
-    let func = unsafe { builtin_code_get(current_code()) };
     if let Some(sig) = unsafe { crate::builtin_code_get_signature(current_code()) } {
         if sig.has_vararg() || sig.has_kwarg() || sig.num_kwonlyargnames() > 0 {
             let fname = unsafe { crate::builtin_code_name(current_code()) };
             let args = current_args();
             let bound = bind_kwargs_to_signature(sig, fname, &args, &[])?;
-            return func(&bound);
+            return unsafe { crate::builtin_code_call(current_code(), &bound) };
         }
     }
     let args = current_args();
-    func(&args)
+    unsafe { crate::builtin_code_call(current_code(), &args) }
 }
 
 /// Leaf execution mode for a user-function call reached through
@@ -1982,8 +1981,9 @@ pub fn call_with_kwargs(
                 // builtin directly — routing back through `call_callable`
                 // would re-enter `call_builtin_code_positional` and pack the
                 // tail a second time.
-                let func = unsafe { crate::builtin_code_get(code as pyre_object::PyObjectRef) };
-                return func(&bound);
+                return unsafe {
+                    crate::builtin_code_call(code as pyre_object::PyObjectRef, &bound)
+                };
             }
             let mut full_args = pos_args.to_vec();
             if !kwargs.is_empty() {

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -1181,6 +1181,32 @@ fn staticmethod_call_override(callable: PyObjectRef) -> Result<Option<PyObjectRe
     Ok(Some(bound))
 }
 
+/// descroperation.py `descr__call__` — `space.lookup(w_obj, '__call__')`.
+///
+/// Consulted once the builtin callables above have had their turn, so it
+/// admits only the receivers none of them claim: an object carrying a generic
+/// payload (`weakref.ref` and friends, whose class holds the `__call__`), and
+/// an instance of a user-defined class — including one deriving from a builtin
+/// type, where `class C(int)` carries its `__call__` on the type just as a
+/// plain `class C` does.
+fn user_call_slot(callable: PyObjectRef) -> Result<Option<PyObjectRef>, PyError> {
+    let Some(w_type) = crate::typedef::r#type(callable) else {
+        return Ok(None);
+    };
+    let w_type = w_type.as_ptr();
+    if !unsafe { pyre_object::is_instance(callable) || pyre_object::w_type_is_heaptype(w_type) } {
+        return Ok(None);
+    }
+    let Some(call_fn) = (unsafe { crate::baseobjspace::lookup_in_type(w_type, "__call__") }) else {
+        return Ok(None);
+    };
+    // `A.__call__ = A()` makes this edge feed itself, and the callers below
+    // recurse natively.  The interpreter-level check turns that into
+    // RecursionError instead of exhausting the machine stack.
+    crate::stack_check::stack_check()?;
+    Ok(Some(call_fn))
+}
+
 fn call_callable_with_mode(
     frame: &mut PyFrame,
     callable: PyObjectRef,
@@ -1226,15 +1252,11 @@ fn call_callable_with_mode(
     // The base ClassMethod defines no descr_call (function.py), so a raw
     // classmethod object falls through to the not-callable error.
 
-    // Instance with __call__ — PyPy: descroperation.py descr_call
-    if unsafe { pyre_object::is_instance(callable) } {
-        let w_type = unsafe { pyre_object::w_instance_get_type(callable) };
-        if let Some(call_fn) = unsafe { crate::baseobjspace::lookup_in_type(w_type, "__call__") } {
-            let mut call_args = Vec::with_capacity(1 + args.len());
-            call_args.push(callable);
-            call_args.extend_from_slice(args);
-            return call_callable_with_mode(frame, call_fn, &call_args, mode);
-        }
+    if let Some(call_fn) = user_call_slot(callable)? {
+        let mut call_args = Vec::with_capacity(1 + args.len());
+        call_args.push(callable);
+        call_args.extend_from_slice(args);
+        return call_callable_with_mode(frame, call_fn, &call_args, mode);
     }
 
     // GenericAlias.__call__ (`_pypy_generic_alias.py:41`) —
@@ -2391,15 +2413,11 @@ pub fn call_with_kwargs(
         return call_with_kwargs(frame, func, &full_args, kwargs);
     }
 
-    // For instances with __call__: dispatch
-    if unsafe { pyre_object::is_instance(callable) } {
-        let w_type = unsafe { pyre_object::w_instance_get_type(callable) };
-        if let Some(call_fn) = unsafe { crate::baseobjspace::lookup_in_type(w_type, "__call__") } {
-            let mut call_args = Vec::with_capacity(1 + pos_args.len());
-            call_args.push(callable);
-            call_args.extend_from_slice(pos_args);
-            return call_with_kwargs(frame, call_fn, &call_args, kwargs);
-        }
+    if let Some(call_fn) = user_call_slot(callable)? {
+        let mut call_args = Vec::with_capacity(1 + pos_args.len());
+        call_args.push(callable);
+        call_args.extend_from_slice(pos_args);
+        return call_with_kwargs(frame, call_fn, &call_args, kwargs);
     }
 
     // GenericAlias.__call__ (`_pypy_generic_alias.py:41`) —
@@ -2580,15 +2598,11 @@ pub fn call_function_impl_result(
             set_orig_class(result, callable)?;
             return Ok(result);
         }
-        // Instance with __call__ — PyPy: descroperation.py
-        if pyre_object::is_instance(callable) {
-            let w_type = pyre_object::w_instance_get_type(callable);
-            if let Some(call_fn) = crate::baseobjspace::lookup_in_type(w_type, "__call__") {
-                let mut call_args = Vec::with_capacity(1 + args.len());
-                call_args.push(callable);
-                call_args.extend_from_slice(args);
-                return call_function_impl_result(call_fn, &call_args);
-            }
+        if let Some(call_fn) = user_call_slot(callable)? {
+            let mut call_args = Vec::with_capacity(1 + args.len());
+            call_args.push(callable);
+            call_args.extend_from_slice(args);
+            return call_function_impl_result(call_fn, &call_args);
         }
     }
     let type_name = crate::typedef::r#type(callable)

--- a/pyre/pyre-interpreter/src/function.rs
+++ b/pyre/pyre-interpreter/src/function.rs
@@ -2540,7 +2540,8 @@ pub fn funccall_valuestack(
             (fast_natural_arity & crate::FLATPYCALL as usize) == 0,
             "FLATPYCALL bit set on arity {fast_natural_arity} — not a builtin code"
         );
-        let builtin_fn = unsafe { crate::builtin_code_get(code as PyObjectRef) };
+        let builtin_fn =
+            |args: &[PyObjectRef]| unsafe { crate::builtin_code_call(code as PyObjectRef, args) };
         // function.py:154-184 — BuiltinCodeN.fastcall_N dispatch.
         // Pyre builtins share a single fn(&[PyObjectRef]) signature, so we
         // build a fixed-size stack array instead of heap-allocating a Vec.
@@ -2625,14 +2626,13 @@ pub fn funccall_valuestack(
     // peek/Arguments split is structural — the final closure invocation
     // sees `[w_obj, ...rest]` exactly as PyPy's post-merge args_w.
     if fast_natural_arity == crate::PASSTHROUGHARGS1 as usize && nargs >= 1 {
-        let builtin_fn = unsafe { crate::builtin_code_get(code as PyObjectRef) };
         let w_obj = frame.peekvalue(nargs - 1);
         let rest = frame.make_arguments(nargs - 1, false, func);
         let mut args_w = Vec::with_capacity(nargs);
         args_w.push(w_obj);
         args_w.extend_from_slice(&rest);
         frame.dropvalues(dropvalues);
-        return match builtin_fn(&args_w) {
+        return match unsafe { crate::builtin_code_call(code as PyObjectRef, &args_w) } {
             Ok(v) => v,
             Err(e) => {
                 crate::call::set_call_error(e);

--- a/pyre/pyre-interpreter/src/gateway.rs
+++ b/pyre/pyre-interpreter/src/gateway.rs
@@ -683,10 +683,11 @@ pub unsafe fn builtin_code_set_owner(obj: PyObjectRef, owner: &'static MethodOwn
     unsafe { (*(obj as *mut BuiltinCode)).owner = owner };
 }
 
-/// Invoke a `BuiltinCode` after applying the receiver check its owning type
-/// requires.  Every dispatch path — the interpreter's call paths, the JIT's
-/// residual call, and the bound-method fast paths — goes through here, so a
-/// call can never reach the implementation with an unchecked receiver.
+/// Invoke a `BuiltinCode` after applying the receiver and arity checks its
+/// registration requires.  Every dispatch path — the interpreter's call paths,
+/// the JIT's residual call, and the bound-method fast paths — goes through
+/// here, so a call can never reach the implementation with an unchecked
+/// receiver or a slice the implementation is not written for.
 ///
 /// # Safety
 /// `obj` must point to a valid `BuiltinCode`.
@@ -704,7 +705,52 @@ pub unsafe fn builtin_code_call(
             return Err(receiver_mismatch(owner, unsafe { (*code).name }, args));
         }
     }
+    // eval.py:16-23 — a `fast_natural_arity` of 0..=4 is the exact positional
+    // count the implementation was registered for; `HOPELESS`,
+    // `PASSTHROUGHARGS1` and the `FLATPYCALL` bit all exceed 4.  A body with a
+    // fixed arity indexes its slice directly, so a call that supplies a
+    // different number of arguments is rejected before the body runs.  The
+    // slice length is the positional count on every call but a keyword one, so
+    // the trailing marker dict is only looked for once a length already
+    // mismatched.
+    let arity = unsafe { (*code).fast_natural_arity } as usize;
+    if arity <= 4 && args.len() != arity {
+        let (positional, _) = crate::builtins::split_builtin_kwargs(args);
+        if positional.len() != arity {
+            return Err(arity_mismatch(unsafe { &*code }, arity, positional.len()));
+        }
+    }
     unsafe { ((*code).func)(args) }
+}
+
+/// The `_match_signature` wording (argument.py:283-297) for a call whose
+/// positional count does not match the implementation's.  The qualified name
+/// follows `func.qualname`: a method descriptor reports `type.name`, a
+/// module-level builtin its bare name.
+///
+/// The too-few form omits the `: 'name'` tail upstream appends, because a
+/// builtin registered by arity alone carries no parameter names.
+#[cold]
+#[inline(never)]
+fn arity_mismatch(code: &BuiltinCode, expected: usize, given: usize) -> crate::PyError {
+    let qualname = match unsafe { code.owner.as_ref() } {
+        Some(owner) => format!("{}.{}", owner.type_name, code.name),
+        None => code.name.to_string(),
+    };
+    let message = if given > expected {
+        format!(
+            "{qualname}() takes {expected} positional argument{} but {given} {} given",
+            if expected == 1 { "" } else { "s" },
+            if given == 1 { "was" } else { "were" },
+        )
+    } else {
+        let missing = expected - given;
+        format!(
+            "{qualname}() missing {missing} required positional argument{}",
+            if missing == 1 { "" } else { "s" },
+        )
+    };
+    crate::PyError::type_error(message)
 }
 
 /// Python 3.14 fills a type's slots with `wrapper_descriptor`s and its

--- a/pyre/pyre-interpreter/src/gateway.rs
+++ b/pyre/pyre-interpreter/src/gateway.rs
@@ -498,6 +498,22 @@ pub const BUILTIN_CODE_GC_TYPE_ID: u32 = 13;
 /// pyre equivalent: returns Result so errors propagate through the call stack.
 pub type BuiltinCodeFn = fn(&[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>;
 
+/// The type a method descriptor belongs to, and the layout test its receiver
+/// must satisfy — `PyDescrObject.d_type`, and the `self` entry of PyPy's
+/// `interp2app` unwrap_spec.
+///
+/// An unbound descriptor validates its receiver against this before the
+/// implementation runs, so a foreign object can never reach an accessor that
+/// reads the receiver's payload at the owning type's layout.  Without it,
+/// `str.split(x)` on an `x` whose `__class__` merely claims to be `str`
+/// reaches `w_str_get_wtf8` and dereferences arbitrary memory.
+pub struct MethodOwner {
+    /// The owning type's name as it appears in the mismatch message.
+    pub type_name: &'static str,
+    /// Layout membership, true for instances of subclasses as well.
+    pub is_instance: fn(PyObjectRef) -> bool,
+}
+
 /// A built-in function object.
 ///
 /// `docstring` mirrors PyPy `BuiltinCode.docstring` (gateway.py:673
@@ -522,6 +538,14 @@ pub struct BuiltinCode {
     /// raw pointer carries no Drop obligation and is not a GC pointer,
     /// matching the `func` function-pointer convention.
     pub sig: *const Signature,
+    /// The type this code object is a descriptor of, or null for a builtin
+    /// with no receiver to check (a module-level function, a `__new__`
+    /// carrier, a class or static method).  `stamp_method_owners` fills it
+    /// in once a type's namespace is fully populated, mirroring
+    /// `PyType_Ready` handing each `PyMethodDef` to `PyDescr_NewMethod`.
+    /// The pointee is `'static`, so it carries no Drop obligation and is not
+    /// a GC pointer.
+    pub owner: *const MethodOwner,
 }
 
 /// Fixed payload size used by `gct_fv_gc_malloc`'s `c_size`
@@ -611,6 +635,7 @@ fn builtin_code_new_full(
         docstring,
         fast_natural_arity,
         sig,
+        owner: std::ptr::null(),
     }) as PyObjectRef
 }
 
@@ -647,6 +672,142 @@ pub unsafe fn is_builtin_code(obj: PyObjectRef) -> bool {
 pub unsafe fn builtin_code_get(obj: PyObjectRef) -> BuiltinCodeFn {
     let func_obj = obj as *const BuiltinCode;
     unsafe { (*func_obj).func }
+}
+
+/// Record the type whose namespace this code object was installed in, so its
+/// receiver is checked before the implementation runs.
+///
+/// # Safety
+/// `obj` must point to a valid `BuiltinCode`.
+pub unsafe fn builtin_code_set_owner(obj: PyObjectRef, owner: &'static MethodOwner) {
+    unsafe { (*(obj as *mut BuiltinCode)).owner = owner };
+}
+
+/// Invoke a `BuiltinCode` after applying the receiver check its owning type
+/// requires.  Every dispatch path — the interpreter's call paths, the JIT's
+/// residual call, and the bound-method fast paths — goes through here, so a
+/// call can never reach the implementation with an unchecked receiver.
+///
+/// # Safety
+/// `obj` must point to a valid `BuiltinCode`.
+#[inline]
+pub unsafe fn builtin_code_call(
+    obj: PyObjectRef,
+    args: &[PyObjectRef],
+) -> Result<PyObjectRef, crate::PyError> {
+    let code = obj as *const BuiltinCode;
+    let owner = unsafe { (*code).owner };
+    if !owner.is_null() {
+        let owner = unsafe { &*owner };
+        let accepted = matches!(args.first(), Some(&receiver) if (owner.is_instance)(receiver));
+        if !accepted {
+            return Err(receiver_mismatch(owner, unsafe { (*code).name }, args));
+        }
+    }
+    unsafe { ((*code).func)(args) }
+}
+
+/// Python 3.14 fills a type's slots with `wrapper_descriptor`s and its
+/// `tp_methods` with `method_descriptor`s, and the two kinds word their
+/// receiver errors differently, so only the slot names need listing — every
+/// other name is an ordinary method.  `__contains__` and `__getitem__` are
+/// slots everywhere except on the types that expose them through `tp_methods`.
+fn is_slot_wrapper(type_name: &str, name: &str) -> bool {
+    match name {
+        "__contains__" => !matches!(type_name, "dict" | "set" | "frozenset"),
+        "__getitem__" => !matches!(type_name, "dict" | "list"),
+        _ => matches!(
+            name,
+            "__abs__"
+                | "__add__"
+                | "__and__"
+                | "__bool__"
+                | "__buffer__"
+                | "__call__"
+                | "__delattr__"
+                | "__delete__"
+                | "__delitem__"
+                | "__divmod__"
+                | "__eq__"
+                | "__float__"
+                | "__floordiv__"
+                | "__ge__"
+                | "__get__"
+                | "__getattribute__"
+                | "__gt__"
+                | "__hash__"
+                | "__iadd__"
+                | "__iand__"
+                | "__imul__"
+                | "__index__"
+                | "__init__"
+                | "__int__"
+                | "__invert__"
+                | "__ior__"
+                | "__isub__"
+                | "__iter__"
+                | "__ixor__"
+                | "__le__"
+                | "__len__"
+                | "__lshift__"
+                | "__lt__"
+                | "__mod__"
+                | "__mul__"
+                | "__ne__"
+                | "__neg__"
+                | "__next__"
+                | "__or__"
+                | "__pos__"
+                | "__pow__"
+                | "__radd__"
+                | "__rand__"
+                | "__rdivmod__"
+                | "__release_buffer__"
+                | "__repr__"
+                | "__rfloordiv__"
+                | "__rlshift__"
+                | "__rmod__"
+                | "__rmul__"
+                | "__ror__"
+                | "__rpow__"
+                | "__rrshift__"
+                | "__rshift__"
+                | "__rsub__"
+                | "__rtruediv__"
+                | "__rxor__"
+                | "__set__"
+                | "__setattr__"
+                | "__setitem__"
+                | "__str__"
+                | "__sub__"
+                | "__truediv__"
+                | "__xor__"
+        ),
+    }
+}
+
+/// Build the TypeError an unbound descriptor raises for a missing or
+/// foreign receiver.  Cold: it runs only on the failing call.
+#[cold]
+#[inline(never)]
+fn receiver_mismatch(owner: &MethodOwner, name: &str, args: &[PyObjectRef]) -> crate::PyError {
+    let ty = owner.type_name;
+    let slot_wrapper = is_slot_wrapper(ty, name);
+    let message = match args.first() {
+        None if slot_wrapper => format!("descriptor '{name}' of '{ty}' object needs an argument"),
+        None => format!("unbound method {ty}.{name}() needs an argument"),
+        Some(&receiver) => {
+            let received = crate::baseobjspace::object_functionstr_type_name(receiver);
+            if slot_wrapper {
+                format!("descriptor '{name}' requires a '{ty}' object but received a '{received}'")
+            } else {
+                format!(
+                    "descriptor '{name}' for '{ty}' objects doesn't apply to a '{received}' object"
+                )
+            }
+        }
+    };
+    crate::PyError::type_error(message)
 }
 
 /// eval.py:16-23 — read `fast_natural_arity` from a BuiltinCode.

--- a/pyre/pyre-interpreter/src/lib.rs
+++ b/pyre/pyre-interpreter/src/lib.rs
@@ -766,8 +766,9 @@ pub use error::*;
 pub use executioncontext::*;
 pub use function::*;
 pub use gateway::{
-    BUILTIN_CODE_TYPE, BuiltinCode, BuiltinCodeFn, FLATPYCALL, HOPELESS, PASSTHROUGHARGS1,
-    Signature, SignatureBuilder, builtin_code_get, builtin_code_get_fast_natural_arity,
+    BUILTIN_CODE_TYPE, BuiltinCode, BuiltinCodeFn, FLATPYCALL, HOPELESS, MethodOwner,
+    PASSTHROUGHARGS1, Signature, SignatureBuilder, builtin_code_call, builtin_code_get,
+    builtin_code_get_fast_natural_arity,
     builtin_code_get_signature, builtin_code_name, builtin_code_new,
     builtin_code_new_passthrough_args1, builtin_code_new_with_arity,
     builtin_code_new_with_signature, is_builtin_code, make_builtin_function,

--- a/pyre/pyre-interpreter/src/lib.rs
+++ b/pyre/pyre-interpreter/src/lib.rs
@@ -292,7 +292,7 @@ macro_rules! py_module {
                         $crate::make_module_builtin_function_with_arity_and_maybe_sig(
                             stringify!($ifn_name),
                             $ifn_name,
-                            $crate::pyre_count_typed_args!($($ifn_args)*) as u16,
+                            $crate::pyre_typed_args_arity!($($ifn_args)*),
                             ::paste::paste! { [<$ifn_name _pyre_sig>]() },
                         ),
                     );
@@ -334,6 +334,34 @@ macro_rules! pyre_count_typed_args {
     ( $(#[$m:meta])* $a:ident : $t:ty, $($rest:tt)* ) => {
         1usize + $crate::pyre_count_typed_args!($($rest)*)
     };
+}
+
+/// Count the leading parameters that a caller must supply — the prefix
+/// before the first `#[default(...)]`.  A `#[default(...)]` arm is listed
+/// ahead of the catch-all so it wins over the `#[$m:meta]` repetition.
+#[macro_export]
+macro_rules! pyre_count_required_typed_args {
+    () => { 0usize };
+    ( #[default($($d:tt)*)] $($rest:tt)* ) => { 0usize };
+    ( $(#[$m:meta])* $a:ident : $t:ty ) => { 1usize };
+    ( $(#[$m:meta])* $a:ident : $t:ty, $($rest:tt)* ) => {
+        1usize + $crate::pyre_count_required_typed_args!($($rest)*)
+    };
+}
+
+/// The `fast_natural_arity` a typed parameter list declares.  A parameter
+/// with a `#[default(...)]` makes the call variadic, so the whole list is
+/// `HOPELESS` rather than a fixed count the call machinery may enforce.
+#[macro_export]
+macro_rules! pyre_typed_args_arity {
+    ( $($args:tt)* ) => {{
+        let total = $crate::pyre_count_typed_args!($($args)*);
+        if total == $crate::pyre_count_required_typed_args!($($args)*) {
+            total as u16
+        } else {
+            $crate::HOPELESS
+        }
+    }};
 }
 
 /// PyPy `class W_X(W_Root) + TypeDef(...)` equivalent — emits a thread-

--- a/pyre/pyre-interpreter/src/lib.rs
+++ b/pyre/pyre-interpreter/src/lib.rs
@@ -796,9 +796,8 @@ pub use function::*;
 pub use gateway::{
     BUILTIN_CODE_TYPE, BuiltinCode, BuiltinCodeFn, FLATPYCALL, HOPELESS, MethodOwner,
     PASSTHROUGHARGS1, Signature, SignatureBuilder, builtin_code_call, builtin_code_get,
-    builtin_code_get_fast_natural_arity,
-    builtin_code_get_signature, builtin_code_name, builtin_code_new,
-    builtin_code_new_passthrough_args1, builtin_code_new_with_arity,
+    builtin_code_get_fast_natural_arity, builtin_code_get_signature, builtin_code_name,
+    builtin_code_new, builtin_code_new_passthrough_args1, builtin_code_new_with_arity,
     builtin_code_new_with_signature, is_builtin_code, make_builtin_function,
     make_builtin_function_maybe_sig, make_builtin_function_passthrough_args1,
     make_builtin_function_with_arity, make_builtin_function_with_arity_and_maybe_sig,

--- a/pyre/pyre-interpreter/src/module/_contextvars/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_contextvars/mod.rs
@@ -60,10 +60,12 @@ fn context_var(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         obj,
         "get",
         // `W_ContextVar.get(*default)` raises LookupError when no
-        // current value and no default supplied.
+        // current value and no default supplied.  Both accessors live in the
+        // instance dict, which is read without the descriptor protocol, so
+        // they receive no bound receiver.
         crate::make_builtin_function("get", |args| {
-            if args.len() > 1 {
-                return Ok(args[1]);
+            if let Some(&w_default) = args.first() {
+                return Ok(w_default);
             }
             Err(crate::PyError::lookup_error(
                 "context variable has no value and no default supplied",
@@ -73,7 +75,7 @@ fn context_var(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let _ = crate::baseobjspace::setattr_str(
         obj,
         "set",
-        crate::make_builtin_function_with_arity("set", |_| Ok(w_none()), 2),
+        crate::make_builtin_function_with_arity("set", |_| Ok(w_none()), 1),
     );
     Ok(obj)
 }

--- a/pyre/pyre-interpreter/src/module/gc/mod.rs
+++ b/pyre/pyre-interpreter/src/module/gc/mod.rs
@@ -65,9 +65,9 @@ crate::py_module! {
         "DEBUG_LEAK"          => w_int_new(38),
     },
     functions: {
-        // `interp_gc.py:7-26 collect` — argument `generation` ignored per
-        // upstream.
-        "collect"       / 1 = |_| {
+        // `interp_gc.py:7-26 collect` — the optional `generation` argument is
+        // ignored per upstream.
+        "collect"       / * = |_| {
             crate::baseobjspace::clear_method_cache();
             crate::objspace::std::mapdict::clear_map_attr_cache();
             pyre_object::gc_hook::try_gc_collect();
@@ -112,7 +112,8 @@ crate::py_module! {
             };
             Ok(w_bool_from(enabled))
         },
-        "get_objects"   / 1 = |_| Ok(w_list_new(vec![])),
+        // `generation` is optional.
+        "get_objects"   / * = |_| Ok(w_list_new(vec![])),
         "get_referrers" / * = |_| Ok(w_list_new(vec![])),
         "get_referents" / * = |_| Ok(w_list_new(vec![])),
         "set_threshold" / 0 = |_| Ok(w_none()),

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -1541,7 +1541,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     crate::module_ns_store(
         ns,
         "get_terminal_size",
-        crate::make_builtin_function_with_arity(
+        crate::make_builtin_function(
             "get_terminal_size",
             |_args| {
                 let (cols, rows) = {
@@ -1562,7 +1562,6 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 };
                 Ok(make_terminal_size(cols, rows))
             },
-            0,
         ),
     );
     // os.fspath() — posixmodule.c posix_fspath / PyOS_FSPath.  str/bytes

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -499,27 +499,49 @@ mod win_nt {
     }
 }
 
-/// posix stub — PyPy: pypy/module/posix/ interp_posix.py
+/// A fresh dict holding the current process environment.
 ///
-/// Provides the minimal surface that os.py module init needs to succeed.
-/// Real posix calls are not implemented — they raise or return defaults.
-pub fn register_module(ns: pyre_object::PyObjectRef) {
-    // environ — dict populated from the host environment.
-    // PyPy equivalent: posix.State.startup → _convertenviron copies
-    // os.environ.items() into w_environ at interpreter startup.
-    let w_environ = pyre_object::w_dict_new();
+/// PyPy equivalent: posix.State.startup → `_convertenviron`, which copies the
+/// environment into `posix.environ` at interpreter startup. os.py seeds
+/// `environ` from it at import time and re-reads it from `reload_environ()`.
+fn create_environ() -> pyre_object::PyObjectRef {
+    let _roots = pyre_object::gc_roots::push_roots();
+    let dict_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(pyre_object::w_dict_new());
+    // Both halves of an entry stay rooted across the store: either allocation
+    // may move what the other one already produced.
+    #[cfg_attr(
+        not(any(feature = "sandbox", feature = "host_env")),
+        expect(dead_code, reason = "no environment source is compiled in")
+    )]
+    fn store(
+        dict_slot: usize,
+        key: impl FnOnce() -> pyre_object::PyObjectRef,
+        value: impl FnOnce() -> pyre_object::PyObjectRef,
+    ) {
+        let _entry = pyre_object::gc_roots::push_roots();
+        let key_slot = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(key());
+        let value_slot = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(value());
+        unsafe {
+            pyre_object::w_dict_store(
+                pyre_object::gc_roots::shadow_stack_get(dict_slot),
+                pyre_object::gc_roots::shadow_stack_get(key_slot),
+                pyre_object::gc_roots::shadow_stack_get(value_slot),
+            );
+        }
+    }
     #[cfg(feature = "sandbox")]
     {
         // The controller delivers the virtual environment as (bytes, bytes).
         if let Ok(items) = crate::host_seam::ops::envitems() {
             for (k_bytes, v_bytes) in items {
-                unsafe {
-                    pyre_object::w_dict_store(
-                        w_environ,
-                        pyre_object::w_bytes_from_bytes(&k_bytes),
-                        pyre_object::w_bytes_from_bytes(&v_bytes),
-                    );
-                }
+                store(
+                    dict_slot,
+                    || pyre_object::w_bytes_from_bytes(&k_bytes),
+                    || pyre_object::w_bytes_from_bytes(&v_bytes),
+                );
             }
         }
     }
@@ -530,15 +552,11 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         // encodes/decodes via surrogateescape when accessed.
         // (_convertenviron: `space.newbytes(key), space.newbytes(value)`.)
         for (key, value) in host_os::vars_os() {
-            let k_bytes = key.as_encoded_bytes();
-            let v_bytes = value.as_encoded_bytes();
-            unsafe {
-                pyre_object::w_dict_store(
-                    w_environ,
-                    pyre_object::w_bytes_from_bytes(k_bytes),
-                    pyre_object::w_bytes_from_bytes(v_bytes),
-                );
-            }
+            store(
+                dict_slot,
+                || pyre_object::w_bytes_from_bytes(key.as_encoded_bytes()),
+                || pyre_object::w_bytes_from_bytes(value.as_encoded_bytes()),
+            );
         }
     }
     #[cfg(all(feature = "host_env", not(feature = "sandbox"), windows))]
@@ -547,16 +565,96 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         // _create_environ_mapping demands str keys/values and upper-cases the
         // keys itself. (_convertenviron: `space.newtext(key), newtext(value)`.)
         for (key, value) in host_os::vars_os() {
-            unsafe {
-                pyre_object::w_dict_store(
-                    w_environ,
-                    pyre_object::w_str_new(&key.to_string_lossy()),
-                    pyre_object::w_str_new(&value.to_string_lossy()),
-                );
-            }
+            store(
+                dict_slot,
+                || pyre_object::w_str_new(&key.to_string_lossy()),
+                || pyre_object::w_str_new(&value.to_string_lossy()),
+            );
         }
     }
-    crate::module_ns_store(ns, "environ", w_environ);
+    pyre_object::gc_roots::shadow_stack_get(dict_slot)
+}
+
+/// posix stub — PyPy: pypy/module/posix/ interp_posix.py
+///
+/// Provides the minimal surface that os.py module init needs to succeed.
+/// Real posix calls are not implemented — they raise or return defaults.
+pub fn register_module(ns: pyre_object::PyObjectRef) {
+    crate::module_ns_store(ns, "environ", create_environ());
+    crate::module_ns_store(
+        ns,
+        "_create_environ",
+        crate::make_builtin_function_with_arity(
+            "_create_environ",
+            |_args| Ok(create_environ()),
+            0,
+        ),
+    );
+
+    // ── posix.putenv(name, value) / posix.unsetenv(name) ──
+    // `os.environ.__setitem__` calls `putenv` before updating its own dict, so
+    // without these the mapping and the real process environment drift apart:
+    // child processes and any native reader of the environment keep seeing the
+    // values captured at startup.
+    #[cfg(all(feature = "host_env", not(feature = "sandbox")))]
+    {
+        /// The environment block is a list of NUL-terminated `NAME=VALUE`
+        /// strings, so neither half may embed a NUL.
+        fn env_str(arg: PyObjectRef) -> Result<String, crate::PyError> {
+            let text = crate::gateway::fsencode_w(arg)?;
+            if text.contains('\0') {
+                return Err(crate::PyError::value_error("embedded null byte"));
+            }
+            Ok(text)
+        }
+        /// A name that is empty or contains `=` cannot be expressed in the
+        /// environment block.
+        fn illegal_name(name: &str) -> bool {
+            name.is_empty() || name.contains('=')
+        }
+        crate::module_ns_store(
+            ns,
+            "putenv",
+            crate::make_builtin_function_with_arity(
+                "putenv",
+                |args| {
+                    // interp_posix.py putenv_impl rejects the name itself...
+                    let name = env_str(args[0])?;
+                    if illegal_name(&name) {
+                        return Err(crate::PyError::value_error(
+                            "illegal environment variable name",
+                        ));
+                    }
+                    let value = env_str(args[1])?;
+                    unsafe { host_os::set_var(&name, &value) };
+                    Ok(pyre_object::w_none())
+                },
+                2,
+            ),
+        );
+        crate::module_ns_store(
+            ns,
+            "unsetenv",
+            crate::make_builtin_function_with_arity(
+                "unsetenv",
+                |args| {
+                    let name = env_str(args[0])?;
+                    // ...while unsetenv leaves the same rejection to the
+                    // syscall, which reports EINVAL.
+                    if illegal_name(&name) {
+                        return Err(crate::PyError::os_error_syscall(
+                            libc::EINVAL,
+                            pyre_object::PY_NULL,
+                        ));
+                    }
+                    unsafe { host_os::remove_var(&name) };
+                    Ok(pyre_object::w_none())
+                },
+                1,
+            ),
+        );
+    }
+
     // _have_functions — list of HAVE_* macro names that were defined at
     // build time. os.py uses this to populate the supports_* capability sets
     // (supports_dir_fd / supports_fd / supports_follow_symlinks), which
@@ -792,7 +890,11 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         "sysconf_names",
         "pathconf_names",
         "setenv",
+        // putenv/unsetenv are implemented above unless the host environment is
+        // out of reach.
+        #[cfg(any(not(feature = "host_env"), feature = "sandbox"))]
         "unsetenv",
+        #[cfg(any(not(feature = "host_env"), feature = "sandbox"))]
         "putenv",
         "device_encoding",
         "ttyname",

--- a/pyre/pyre-interpreter/src/module/select/interp_select.rs
+++ b/pyre/pyre-interpreter/src/module/select/interp_select.rs
@@ -415,7 +415,10 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         crate::module_ns_store(
             ns,
             "poll",
-            crate::make_builtin_function_with_arity(
+            // A module-level function, not a descriptor: `selectors.py` keeps
+            // it as a class attribute (`_selector_cls = select.poll`) and
+            // calling it through the instance must not bind a receiver.
+            crate::make_module_builtin_function_with_arity(
                 "poll",
                 |_args| Ok(Poll::allocate(Poll::default())),
                 0,

--- a/pyre/pyre-interpreter/src/module/sys/vm.rs
+++ b/pyre/pyre-interpreter/src/module/sys/vm.rs
@@ -2,8 +2,8 @@
 //!
 //! PyPy equivalent: `pypy/module/sys/vm.py`.
 
-use crate::{make_builtin_function_with_arity, module_ns_store};
 use crate::executioncontext::ActionFlagOps;
+use crate::{make_builtin_function, make_builtin_function_with_arity, module_ns_store};
 use pyre_object::*;
 use std::sync::OnceLock;
 
@@ -492,6 +492,49 @@ fn sys_set_asyncgen_hooks_impl(args: &[PyObjectRef]) -> crate::PyResult {
         }
     }
     Ok(w_none())
+}
+
+/// `app.py breakpointhook` — the hook `breakpoint()` calls.
+///
+/// `$PYTHONBREAKPOINT` names the callable to run: unset or empty means
+/// `pdb.set_trace`, `"0"` disables the hook outright, and any other value is
+/// imported as a dotted path (a bare name resolves against `builtins`).  An
+/// unimportable value warns and returns None rather than propagating, so a
+/// stray environment variable cannot break an otherwise working program.
+fn sys_breakpointhook(args: &[PyObjectRef]) -> crate::PyResult {
+    let hookname = match crate::importing::host::os::var("PYTHONBREAKPOINT") {
+        Ok(name) if name == "0" => return Ok(w_none()),
+        Ok(name) if !name.is_empty() => name,
+        _ => "pdb.set_trace".to_string(),
+    };
+    let (modname, funcname) = match hookname.rsplit_once('.') {
+        Some((modname, funcname)) => (modname, funcname),
+        None => ("builtins", hookname.as_str()),
+    };
+
+    // `dunder_import` returns the root package, so reach the leaf through
+    // `sys.modules` before pulling the attribute off it.
+    let hook = crate::importing::dunder_import(
+        modname,
+        pyre_object::PY_NULL,
+        pyre_object::PY_NULL,
+        pyre_object::PY_NULL,
+        0,
+        std::ptr::null(),
+    )
+    .ok()
+    .and_then(|_| crate::importing::get_sys_module(modname))
+    .and_then(|module| crate::baseobjspace::getattr_str(module, funcname).ok());
+    let Some(hook) = hook else {
+        crate::warn::warn_category(
+            &format!("Ignoring unimportable $PYTHONBREAKPOINT: \"{hookname}\""),
+            "RuntimeWarning",
+            1,
+        )?;
+        return Ok(w_none());
+    };
+    // The hook "must accept whatever arguments are passed".
+    crate::builtins::call_forwarding_args(hook, args)
 }
 
 fn sys_unraisablehook(args: &[PyObjectRef]) -> crate::PyResult {
@@ -1613,6 +1656,11 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         "excepthook",
         make_builtin_function_with_arity("excepthook", |_| Ok(w_none()), 3),
     );
+    // sys.breakpointhook — `app.py breakpointhook`, called by `breakpoint()`.
+    // `__breakpointhook__` keeps the original so code can restore it.
+    let breakpointhook_fn = make_builtin_function("breakpointhook", sys_breakpointhook);
+    module_ns_store(ns, "breakpointhook", breakpointhook_fn);
+    module_ns_store(ns, "__breakpointhook__", breakpointhook_fn);
     // sys.unraisablehook(unraisable) — handles exceptions raised where they
     // cannot propagate (e.g. __del__).  Stored alongside the read-only
     // `__unraisablehook__` original so code can save and restore it.

--- a/pyre/pyre-interpreter/src/module/sys/vm.rs
+++ b/pyre/pyre-interpreter/src/module/sys/vm.rs
@@ -1494,11 +1494,16 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     module_ns_store(
         ns,
         "getsizeof",
-        make_builtin_function_with_arity(
+        make_builtin_function(
             "getsizeof",
             |args| {
-                if unsafe { pyre_object::is_str(args[0]) } {
-                    let method = crate::baseobjspace::getattr_str(args[0], "__sizeof__")?;
+                let Some(&w_obj) = args.first() else {
+                    return Err(crate::PyError::type_error(
+                        "getsizeof() takes at least 1 argument (0 given)",
+                    ));
+                };
+                if unsafe { pyre_object::is_str(w_obj) } {
+                    let method = crate::baseobjspace::getattr_str(w_obj, "__sizeof__")?;
                     return crate::call::call_function_impl_result(method, &[]);
                 }
                 match args.get(1).copied() {
@@ -1508,7 +1513,6 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     )),
                 }
             },
-            1,
         ),
     );
     // PyPy normally omits CPython's raw refcount API.  The shared ctypes

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -1808,28 +1808,76 @@ fn reverse_compare_op(op: CompareOp) -> CompareOp {
     }
 }
 
-unsafe fn float_lt(a: PyObjectRef, b: PyObjectRef) -> PyResult {
-    Ok(w_bool_from(as_float(a) < as_float(b)))
+#[inline]
+fn compare_f64(f1: f64, f2: f64, op: CompareOp) -> bool {
+    match op {
+        CompareOp::Lt => f1 < f2,
+        CompareOp::Le => f1 <= f2,
+        CompareOp::Gt => f1 > f2,
+        CompareOp::Ge => f1 >= f2,
+        CompareOp::Eq => f1 == f2,
+        CompareOp::Ne => f1 != f2,
+    }
 }
 
-unsafe fn float_le(a: PyObjectRef, b: PyObjectRef) -> PyResult {
-    Ok(w_bool_from(as_float(a) <= as_float(b)))
+/// floatobject.py:106-129 `do_compare_bigint` — compare a float against a
+/// bigint without converting the bigint to a double, which would round it.
+fn do_compare_bigint(f1: f64, b2: &BigInt, op: CompareOp) -> bool {
+    if matches!(op, CompareOp::Eq | CompareOp::Ne) {
+        let ne = matches!(op, CompareOp::Ne);
+        // A non-finite or fractional float is never equal to an integer.
+        if !f1.is_finite() || f1.floor() != f1 {
+            return ne;
+        }
+        return BigInt::_fromfloat_finite(f1).eq(b2) != ne;
+    }
+    if !f1.is_finite() {
+        return compare_f64(f1, 0.0, op);
+    }
+    let f1 = if matches!(op, CompareOp::Gt | CompareOp::Le) {
+        // 'float > long'  <==> 'ceil(float) > long'
+        // 'float <= long' <==> 'ceil(float) <= long'
+        f1.ceil()
+    } else {
+        // 'float < long'  <==> 'floor(float) < long'
+        // 'float >= long' <==> 'floor(float) >= long'
+        f1.floor()
+    };
+    let b1 = BigInt::_fromfloat_finite(f1);
+    match op {
+        CompareOp::Lt => b1.lt(b2),
+        CompareOp::Le => b1.le(b2),
+        CompareOp::Gt => b1.gt(b2),
+        CompareOp::Ge => b1.ge(b2),
+        CompareOp::Eq | CompareOp::Ne => unreachable!("handled above"),
+    }
 }
 
-unsafe fn float_gt(a: PyObjectRef, b: PyObjectRef) -> PyResult {
-    Ok(w_bool_from(as_float(a) > as_float(b)))
-}
-
-unsafe fn float_ge(a: PyObjectRef, b: PyObjectRef) -> PyResult {
-    Ok(w_bool_from(as_float(a) >= as_float(b)))
-}
-
-unsafe fn float_eq(a: PyObjectRef, b: PyObjectRef) -> PyResult {
-    Ok(w_bool_from(as_float(a) == as_float(b)))
-}
-
-unsafe fn float_ne(a: PyObjectRef, b: PyObjectRef) -> PyResult {
-    Ok(w_bool_from(as_float(a) != as_float(b)))
+/// floatobject.py:132-148 `_compare` — the float side of a numeric
+/// comparison.  `w_float` is a float; `w_other` is a float, an int, a bool
+/// or a long.  The relation is evaluated exactly: only an int small enough
+/// that a double represents it losslessly takes the plain f64 path.
+unsafe fn float_compare(w_float: PyObjectRef, w_other: PyObjectRef, op: CompareOp) -> bool {
+    let f1 = w_float_get_value(w_float);
+    if is_float(w_other) {
+        return compare_f64(f1, w_float_get_value(w_other), op);
+    }
+    if is_long(w_other) {
+        return do_compare_bigint(f1, w_long_get_value(w_other), op);
+    }
+    let i2 = if is_bool(w_other) {
+        w_bool_get_value(w_other) as i64
+    } else {
+        w_int_get_value(w_other)
+    };
+    // (double-)floats have always at least 48 bits of precision, so an int
+    // whose bit 48 and above are a plain sign extension converts exactly.
+    // `int_between(-1, i2 >> 48, 1)` (rarithmetic.py) is `-1 <= i2 >> 48 < 1`.
+    let top = i2 >> 48;
+    if !(-1..1).contains(&top) {
+        return do_compare_bigint(f1, &BigInt::from(i2), op);
+    }
+    compare_f64(f1, i2 as f64, op)
 }
 
 // ── Complex arithmetic operations ────────────────────────────────────
@@ -3931,14 +3979,14 @@ pub fn compare_slot(a: PyObjectRef, b: PyObjectRef, op: CompareOp) -> PyResult {
             }));
         }
         if is_float_pair(a, b) {
-            return match op {
-                CompareOp::Lt => float_lt(a, b),
-                CompareOp::Le => float_le(a, b),
-                CompareOp::Gt => float_gt(a, b),
-                CompareOp::Ge => float_ge(a, b),
-                CompareOp::Eq => float_eq(a, b),
-                CompareOp::Ne => float_ne(a, b),
-            };
+            // `_compare` is a method on the float operand; the int-left order
+            // reaches it through the reflected comparison, with the relation
+            // reversed.
+            return Ok(w_bool_from(if is_float(a) {
+                float_compare(a, b, op)
+            } else {
+                float_compare(b, a, reverse_compare_op(op))
+            }));
         }
         // complexobject.py only implements equality here.  Its ordering
         // dunders return NotImplemented, which must continue through the

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -2070,6 +2070,32 @@ impl PyFrame {
         PY_NULL
     }
 
+    /// pyframe.py:213-218 — bind the locals namespace of code that is not
+    /// `OPTIMIZED`.  A class body gets a fresh namespace mapping; anything
+    /// else (module-level code, and the same code reached through
+    /// `FunctionType(co, globals)`) aliases its globals, so `STORE_NAME` /
+    /// `LOAD_NAME` / `DELETE_NAME` and `locals()` land there.  Optimized code
+    /// keeps its fast-locals array and binds nothing.
+    ///
+    /// The binding is the canonical `W_DictObject`, not the raw `DictStorage`
+    /// proxy, so those opcodes route through the object.
+    fn bind_unoptimized_locals_scope(&mut self) {
+        let flags = unsafe { (*pyframe_get_pycode(self)).flags };
+        if flags.contains(CodeFlags::OPTIMIZED) {
+            return;
+        }
+        if flags.contains(CodeFlags::NEWLOCALS) {
+            // `build_class` replaces this with the `__prepare__` namespace via
+            // `setdictscope`; an orphan NEWLOCALS frame still has a usable
+            // mapping.
+            let w_locals = unsafe { pyre_object::w_dict_new() };
+            self.getorcreate_debug_data(-1).w_locals = w_locals;
+        } else {
+            let w_globals = self.get_w_globals();
+            self.getorcreate_debug_data(-1).w_locals = w_globals;
+        }
+    }
+
     /// pyframe.py:223-261 initialize_frame_scopes.
     ///
     /// Errors mirror pyframe.py:242-246 (TypeError "directly executed code
@@ -2083,27 +2109,9 @@ impl PyFrame {
         outer_func: PyObjectRef,
         _code: *const (),
     ) -> Result<(), crate::PyError> {
-        let code = unsafe { &*pyframe_get_pycode(self) };
-        let flags = code.flags;
-        if !flags.contains(CodeFlags::OPTIMIZED) {
-            if flags.contains(CodeFlags::NEWLOCALS) {
-                // pyframe.py:213 — class body binds a fresh locals namespace
-                // dict object (`space.newdict(module=True)`).  `build_class`
-                // replaces it with the `__prepare__` namespace via
-                // `setdictscope`; an orphan NEWLOCALS frame still has a
-                // usable mapping.
-                let w_locals = unsafe { pyre_object::w_dict_new() };
-                self.getorcreate_debug_data(-1).w_locals = w_locals;
-            } else {
-                // pyframe.py:216-218 — module scope binds `w_locals = w_globals`.
-                // Bind the canonical W_DictObject so STORE_NAME / LOAD_NAME /
-                // DELETE_NAME and `locals()` route through the object instead of
-                // the raw DictStorage proxy.
-                let w_globals = self.get_w_globals();
-                self.getorcreate_debug_data(-1).w_locals = w_globals;
-            }
-        }
+        self.bind_unoptimized_locals_scope();
 
+        let code = unsafe { &*pyframe_get_pycode(self) };
         let npure = npure_cellvars(code);
         let nfreevars = code.freevars.len();
         if npure == 0 && nfreevars == 0 {
@@ -3795,6 +3803,11 @@ impl PyFrame {
             w_builtin: pyre_object::gc_roots::shadow_stack_get(root_base + 3),
             w_globals: pyre_object::gc_roots::shadow_stack_get(root_base + 1),
         };
+        // This constructor bypasses `initialize_frame_scopes`, so apply the
+        // scope binding it would have done.  `FunctionType(co, globals)` over
+        // a module-level code object arrives here, and without the binding its
+        // `STORE_NAME`s land in a throwaway mapping instead of `globals`.
+        frame.bind_unoptimized_locals_scope();
         frame.init_cells();
         frame
     }

--- a/pyre/pyre-interpreter/src/runtime_ops.rs
+++ b/pyre/pyre-interpreter/src/runtime_ops.rs
@@ -241,9 +241,8 @@ fn call_builtin_with_args(callable: i64, args: &[i64]) -> i64 {
     let callable = callable as PyObjectRef;
     unsafe {
         let code = crate::getcode(callable);
-        let func = builtin_code_get(code as PyObjectRef);
         let arg_slice = std::slice::from_raw_parts(args.as_ptr() as *const PyObjectRef, args.len());
-        match func(arg_slice) {
+        match crate::builtin_code_call(code as PyObjectRef, arg_slice) {
             Ok(result) => result as i64,
             Err(mut e) => {
                 jit_publish_exception(e.to_exc_object());

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -5338,6 +5338,17 @@ pub fn str_method_translate(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::
 /// PyPy: W_DictMultiObject subclass instances ARE dicts, so no indirection
 /// is needed. In pyre, dict subclass instances are W_ObjectObject with a
 /// backing dict stored as an attribute.
+/// True when `obj` can be read as a dict — an exact dict, a dict subclass
+/// carrying a `__dict_data__` backing, or a mapping proxy wrapping one.  This
+/// is the receiver test a `dict` method descriptor applies, so an object that
+/// merely claims `__class__ is dict` never reaches the backing lookup.
+///
+/// # Safety
+/// `obj` must be a valid, non-null pointer to a `PyObject`.
+pub unsafe fn has_dict_backing(obj: PyObjectRef) -> bool {
+    !resolve_dict_backing(obj).is_null()
+}
+
 pub fn resolve_dict_backing(obj: PyObjectRef) -> PyObjectRef {
     unsafe {
         if is_dict(obj) {

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -1798,11 +1798,7 @@ pub fn make_builtin_type_with_layout(
 /// If cls is a subclass of int, returns a W_ObjectObject with the
 /// int value stored internally (for int subclasses like IntFlag).
 fn int_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    let cls = if args.is_empty() {
-        std::ptr::null_mut() as PyObjectRef
-    } else {
-        args[0]
-    };
+    let cls = new_descr_class(args, "int")?;
     // intobject.py _new_int → check_user_subclass
     if !cls.is_null() && unsafe { pyre_object::is_type(cls) } {
         if let Some(w_int) = gettypefor(&pyre_object::INT_TYPE) {
@@ -1844,11 +1840,7 @@ fn int_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
 /// returns a fresh W_FloatObject with `w_class = cls` so `type(obj) == cls`
 /// and `__ceil__`/`__floor__`/`__trunc__` dunders on the subclass dispatch.
 fn float_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    let cls = if args.is_empty() {
-        pyre_object::PY_NULL
-    } else {
-        args[0]
-    };
+    let cls = new_descr_class(args, "float")?;
     // floatobject.py descr__new__: `w_x` is positional-only, so a surplus
     // positional or any keyword is rejected by builtinclass_new_args_check
     // (skipped when a subtype overrides __init__, which absorbs the surplus).
@@ -1880,11 +1872,7 @@ fn float_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
 }
 
 fn complex_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    let cls = if args.is_empty() {
-        pyre_object::PY_NULL
-    } else {
-        args[0]
-    };
+    let cls = new_descr_class(args, "complex")?;
     let value = crate::builtins::builtin_complex(&args[1..])?;
     if cls.is_null() || !unsafe { pyre_object::is_type(cls) } {
         return Ok(value);
@@ -1925,6 +1913,15 @@ pub(crate) fn make_new_descr(
     // stamped at type-finalisation via `stamp_new_descr_self`.
     let f = crate::gateway::make_builtin_function_as_builtin("__new__", func);
     pyre_object::w_staticmethod_new(f)
+}
+
+/// `typeobject.c tp_new_wrapper` — `__new__` takes the class to instantiate
+/// as its first argument, so a call without one is rejected before the body
+/// reads the value positionals behind it.
+fn new_descr_class(args: &[PyObjectRef], type_name: &str) -> Result<PyObjectRef, crate::PyError> {
+    args.first().copied().ok_or_else(|| {
+        crate::PyError::type_error(format!("{type_name}.__new__(): not enough arguments"))
+    })
 }
 
 /// Wrap a `maketrans` builtin function in a staticmethod descriptor.
@@ -3164,8 +3161,12 @@ fn super_descr_getattribute(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::
 }
 
 fn super_descr_get(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    // The owning type is bound as `args[0]`; `obj` is required and the class
+    // it is looked up on is optional.
+    crate::type_methods::arity_at_least(args, "__get__", 1)?;
+    crate::type_methods::arity_at_most(args, "__get__", 2)?;
     let self_ = args[0];
-    let obj = args.get(1).copied().unwrap_or_else(w_none);
+    let obj = args[1];
     let bound = unsafe { pyre_object::descriptor::w_super_get_obj(self_) };
     if !bound.is_null() || unsafe { pyre_object::is_none(obj) } {
         return Ok(self_);
@@ -8611,8 +8612,10 @@ fn init_getset_descriptor_type(ns: PyObjectRef) {
             ns,
             "__get__",
             make_builtin_function("__get__", |args| {
+                crate::type_methods::arity_at_least(args, "__get__", 1)?;
+                crate::type_methods::arity_at_most(args, "__get__", 2)?;
                 let w_self = args[0];
-                let w_obj = args.get(1).copied().unwrap_or(pyre_object::PY_NULL);
+                let w_obj = args[1];
                 let w_cls = args.get(2).copied().unwrap_or(pyre_object::PY_NULL);
                 let w_obj_is_none = !w_obj.is_null() && unsafe { pyre_object::is_none(w_obj) };
                 let none_type = crate::typedef::r#type(pyre_object::w_none())
@@ -12816,7 +12819,11 @@ fn init_property_type(ns: PyObjectRef) {
         ),
         (
             "__set__",
-            make_builtin_function("__set__", crate::baseobjspace::property_descr_set_impl),
+            make_builtin_function_with_arity(
+                "__set__",
+                crate::baseobjspace::property_descr_set_impl,
+                3,
+            ),
         ),
         (
             "__delete__",
@@ -13801,8 +13808,9 @@ fn init_int_type(ns: PyObjectRef) {
             ),
         )
     };
+    // A getset `fget` is always called as `(descriptor, receiver)`.
     let denom_getter =
-        make_builtin_function_with_arity("denominator", |_| Ok(pyre_object::w_int_new(1)), 1);
+        make_builtin_function_with_arity("denominator", |_| Ok(pyre_object::w_int_new(1)), 2);
     unsafe {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
             ns,
@@ -13921,7 +13929,6 @@ fn init_int_type(ns: PyObjectRef) {
         ("__rmod__", int_dunder_rmod),
         ("__divmod__", int_dunder_divmod),
         ("__rdivmod__", int_dunder_rdivmod),
-        ("__rpow__", int_dunder_rpow),
         ("__lshift__", int_dunder_lshift),
         ("__rlshift__", int_dunder_rlshift),
         ("__rshift__", int_dunder_rshift),
@@ -13941,14 +13948,19 @@ fn init_int_type(ns: PyObjectRef) {
             )
         };
     }
-    // `__pow__` takes an optional modulus, so it is variadic.
-    unsafe {
-        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-            ns,
-            "__pow__",
-            make_builtin_function("__pow__", int_dunder_pow),
-        )
-    };
+    // `__pow__` and `__rpow__` take an optional modulus, so they are variadic.
+    for (name, func) in [
+        ("__pow__", int_dunder_pow as DunderFn),
+        ("__rpow__", int_dunder_rpow),
+    ] {
+        unsafe {
+            pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+                ns,
+                name,
+                make_builtin_function(name, func),
+            )
+        };
+    }
     for (name, func) in [
         ("__eq__", int_dunder_eq as DunderFn),
         ("__ne__", int_dunder_ne),
@@ -14219,14 +14231,25 @@ fn init_complex_type(ns: PyObjectRef) {
         ("__rmul__", complex_dunder_rmul),
         ("__truediv__", complex_dunder_truediv),
         ("__rtruediv__", complex_dunder_rtruediv),
-        ("__pow__", complex_dunder_pow),
-        ("__rpow__", complex_dunder_rpow),
     ] {
         unsafe {
             pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
                 ns,
                 name,
                 make_builtin_function_with_arity(name, func, 2),
+            )
+        };
+    }
+    // `__pow__` and `__rpow__` take an optional modulus, so they are variadic.
+    for (name, func) in [
+        ("__pow__", complex_dunder_pow as DunderFn),
+        ("__rpow__", complex_dunder_rpow),
+    ] {
+        unsafe {
+            pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+                ns,
+                name,
+                make_builtin_function(name, func),
             )
         };
     }
@@ -14670,7 +14693,7 @@ fn init_float_type(ns: PyObjectRef) {
         )
     };
     // Binary arithmetic dunders (forward + reflected).  float has no
-    // bitwise ops; `__pow__` takes no modulus.
+    // bitwise ops.
     for (name, func) in [
         ("__add__", float_dunder_add as DunderFn),
         ("__radd__", float_dunder_radd),
@@ -14686,14 +14709,26 @@ fn init_float_type(ns: PyObjectRef) {
         ("__rmod__", float_dunder_rmod),
         ("__divmod__", float_dunder_divmod),
         ("__rdivmod__", float_dunder_rdivmod),
-        ("__pow__", float_dunder_pow),
-        ("__rpow__", float_dunder_rpow),
     ] {
         unsafe {
             pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
                 ns,
                 name,
                 make_builtin_function_with_arity(name, func, 2),
+            )
+        };
+    }
+    // A float rejects a non-`None` modulus, but still accepts the argument,
+    // so `__pow__` and `__rpow__` are variadic.
+    for (name, func) in [
+        ("__pow__", float_dunder_pow as DunderFn),
+        ("__rpow__", float_dunder_rpow),
+    ] {
+        unsafe {
+            pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+                ns,
+                name,
+                make_builtin_function(name, func),
             )
         };
     }
@@ -16930,7 +16965,8 @@ fn bytes_method_replace(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyEr
             unsafe { pyre_object::type_name_of(pos[0]) }
         )));
     }
-    assert!(pos.len() >= 3, "replace() takes at least 2 arguments");
+    crate::type_methods::arity_at_least(pos, "replace", 2)?;
+    crate::type_methods::arity_at_most(pos, "replace", 3)?;
     let data = unsafe { pyre_object::bytesobject::bytes_like_data(pos[0]) };
     let old = require_bytes_like(pos[1])?;
     let new = require_bytes_like(pos[2])?;
@@ -18894,7 +18930,20 @@ fn bytearray_method_copy(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyE
 /// `bytearrayobject.py descr_releasebuffer` — the Python 3.12
 /// `__release_buffer__` protocol entry for a released bytearray export.
 fn bytearray_method_release_buffer(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    unsafe { pyre_object::bytearrayobject::w_bytearray_exports_decref(args[0]) };
+    // `bytearray_releasebuffer` drops one export, so the view handed back has
+    // to be one this bytearray exported — the export count is an invariant
+    // the accessor asserts, and Python may pass anything.
+    unsafe {
+        if !pyre_object::memoryview::is_w_memoryview(args[1]) {
+            return Err(crate::PyError::type_error("expected a memoryview object"));
+        }
+        if !std::ptr::eq(pyre_object::memoryview::w_memoryview_backing(args[1]), args[0]) {
+            return Err(crate::PyError::value_error(
+                "memoryview's buffer is not this object",
+            ));
+        }
+        pyre_object::bytearrayobject::w_bytearray_exports_decref(args[0]);
+    }
     Ok(pyre_object::w_none())
 }
 

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -19044,7 +19044,10 @@ fn bytearray_method_release_buffer(args: &[PyObjectRef]) -> Result<PyObjectRef, 
         if !pyre_object::memoryview::is_w_memoryview(args[1]) {
             return Err(crate::PyError::type_error("expected a memoryview object"));
         }
-        if !std::ptr::eq(pyre_object::memoryview::w_memoryview_backing(args[1]), args[0]) {
+        if !std::ptr::eq(
+            pyre_object::memoryview::w_memoryview_backing(args[1]),
+            args[0],
+        ) {
             return Err(crate::PyError::value_error(
                 "memoryview's buffer is not this object",
             ));

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -1399,6 +1399,114 @@ pub fn w_object() -> PyObjectRef {
         .unwrap_or(PY_NULL)
 }
 
+/// The receiver type of every method descriptor a builtin type defines.
+///
+/// Python 3.14 gives each entry of a type's `tp_methods` / slot table a
+/// descriptor that remembers its `d_type` and refuses a receiver that is not
+/// an instance of it.  Pyre's builtin methods reach the receiver's payload
+/// through layout-typed accessors (`w_str_get_wtf8`, `w_dict_getitem`, …), so
+/// without the same check an object that merely claims `__class__ is str`
+/// gets its memory read at the wrong layout.
+///
+/// The predicates test the *layout*, which is what those accessors require;
+/// an instance of a Python-level subclass keeps its base's layout, so
+/// `str.upper(MyStr('a'))` still passes.
+///
+/// `object`'s predicate accepts everything, since every receiver really is an
+/// `object`; listing it still rejects a *missing* receiver, which its methods
+/// would otherwise index straight off an empty argument slice.
+fn method_owner(type_name: &str) -> Option<&'static crate::gateway::MethodOwner> {
+    macro_rules! owners {
+        ($($name:literal => $pred:path),+ $(,)?) => {
+            match type_name {
+                $($name => {
+                    static OWNER: crate::gateway::MethodOwner = crate::gateway::MethodOwner {
+                        type_name: $name,
+                        is_instance: |obj| unsafe { $pred(obj) },
+                    };
+                    Some(&OWNER)
+                })+
+                _ => None,
+            }
+        };
+    }
+    owners! {
+        "str" => pyre_object::is_str,
+        "bytes" => pyre_object::is_bytes,
+        "bytearray" => pyre_object::is_bytearray,
+        // `int` covers `bool` and the arbitrary-precision layout: all three
+        // are `int` instances at Python level.
+        "int" => pyre_object::is_int_or_long,
+        "bool" => pyre_object::is_bool,
+        "float" => pyre_object::is_float,
+        "complex" => pyre_object::is_complex,
+        // A dict subclass keeps its entries in a `__dict_data__` backing
+        // rather than the dict layout, and the dict methods already read
+        // through to it, so "has a dict backing" is the receiver test.
+        "dict" => crate::type_methods::has_dict_backing,
+        "list" => pyre_object::is_list,
+        "tuple" => pyre_object::is_tuple,
+        "set" => pyre_object::is_set,
+        "frozenset" => pyre_object::is_frozenset,
+        "range" => pyre_object::functional::is_w_range,
+        "slice" => pyre_object::is_slice,
+        "memoryview" => pyre_object::memoryview::is_w_memoryview,
+        "type" => pyre_object::is_type,
+        "object" => is_any_object,
+        "BaseException" => pyre_object::interp_exceptions::is_exception,
+    }
+}
+
+/// The receiver test for `object`'s own methods: they accept any instance, so
+/// only a missing receiver is rejected.
+///
+/// # Safety
+/// Trivially safe; the signature matches the other receiver predicates.
+unsafe fn is_any_object(_obj: PyObjectRef) -> bool {
+    true
+}
+
+/// Bind every method descriptor in a freshly built namespace to the type that
+/// defines it, so its receiver is checked before the implementation runs —
+/// `PyType_Ready` handing each `PyMethodDef` to `PyDescr_NewMethod`.
+///
+/// Only bare functions are descriptors of the type: `maketrans` and the class
+/// methods are already wrapped in static/class-method objects by the time the
+/// namespace is complete, and they take a type or no receiver at all.
+/// `__new__` is skipped explicitly because it receives the type being
+/// instantiated rather than an instance, whether or not this namespace
+/// happens to wrap it.
+///
+/// # Safety
+/// `ns` must be a valid, live `W_DictObject`.
+unsafe fn stamp_method_owners(ns: PyObjectRef, owner: &'static crate::gateway::MethodOwner) {
+    let _roots = pyre_object::gc_roots::push_roots();
+    let ns_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(ns);
+
+    let keys: Vec<String> = pyre_object::w_dict_items(ns)
+        .into_iter()
+        .filter_map(|(key, _)| pyre_object::w_str_get_value_opt(key).map(str::to_owned))
+        .collect();
+    for key in keys {
+        if key == "__new__" {
+            continue;
+        }
+        let ns = pyre_object::gc_roots::shadow_stack_get(ns_slot);
+        let Some(descr) = pyre_object::w_dict_getitem_str(ns, &key) else {
+            continue;
+        };
+        if descr.is_null() || !crate::function::is_function(descr) {
+            continue;
+        }
+        let code = crate::function::getcode(descr) as PyObjectRef;
+        if code.is_null() || !crate::gateway::is_builtin_code(code) {
+            continue;
+        }
+        crate::gateway::builtin_code_set_owner(code, owner);
+    }
+}
+
 /// Stamp the builtin `__new__` carrier in `ns` with `__self__ =
 /// type_obj` (the type that defines `tp_new`), mirroring
 /// `typeobject.c add_tp_new_wrapper`.  `copyreg._reduce_ex` walks the
@@ -1524,6 +1632,12 @@ fn new_typeobject_with_base_and_layout(
     let ns = pyre_object::w_dict_new();
     pyre_object::gc_roots::pin_root(ns);
     init(ns);
+    // The namespace is complete, so every method descriptor in it can be
+    // bound to the type that defines it before the type goes live.
+    if let Some(owner) = method_owner(name) {
+        let ns = pyre_object::gc_roots::shadow_stack_get(ns_slot);
+        unsafe { stamp_method_owners(ns, owner) };
+    }
     let bases = w_tuple_new(vec![base]);
     let ns = pyre_object::gc_roots::shadow_stack_get(ns_slot);
     let type_obj = w_type_new_builtin(name, bases, ns as *mut u8, layout_pytype);
@@ -14218,31 +14332,29 @@ fn init_float_type(ns: PyObjectRef) {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
             ns,
             "__getformat__",
-            make_builtin_function("__getformat__", |args| {
-                // Python classmethod signature: float.__getformat__(kind).
-                // pyre may pass either (kind,) or (self, kind); accept both by
-                // scanning for the first str argument.
-                let kind = args
-                    .iter()
-                    .find_map(|&a| unsafe {
-                        if pyre_object::is_str(a) {
-                            Some(pyre_object::w_str_get_value(a).to_string())
-                        } else {
-                            None
-                        }
-                    })
-                    .ok_or_else(|| {
-                        crate::PyError::type_error(
+            pyre_object::function::w_classmethod_new(make_builtin_function(
+                "__getformat__",
+                |args| {
+                    // A class method, so `args[0]` is the class and the kind
+                    // follows it.
+                    let kind = args
+                        .get(1)
+                        .copied()
+                        .filter(|&a| unsafe { pyre_object::is_str(a) })
+                        .map(|a| unsafe { pyre_object::w_str_get_value(a).to_string() })
+                        .ok_or_else(|| {
+                            crate::PyError::type_error(
+                                "__getformat__() argument must be 'double' or 'float'",
+                            )
+                        })?;
+                    match kind.as_str() {
+                        "double" | "float" => Ok(pyre_object::w_str_new("IEEE, little-endian")),
+                        _ => Err(crate::PyError::value_error(
                             "__getformat__() argument must be 'double' or 'float'",
-                        )
-                    })?;
-                match kind.as_str() {
-                    "double" | "float" => Ok(pyre_object::w_str_new("IEEE, little-endian")),
-                    _ => Err(crate::PyError::value_error(
-                        "__getformat__() argument must be 'double' or 'float'",
-                    )),
-                }
-            }),
+                        )),
+                    }
+                },
+            )),
         )
     };
     unsafe {

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -384,17 +384,32 @@ pub fn init_typeobjects() {
         // list — PyPy: listobject.py, bases=(object,)
         reg.insert(
             &LIST_TYPE as *const PyType as usize,
-            new_typeobject_with_base("list", init_list_type, object_type) as usize,
+            new_typeobject_with_base_and_layout(
+                "list",
+                init_list_type,
+                object_type,
+                &LIST_TYPE as *const PyType,
+            ) as usize,
         );
 
         // tuple — PyPy: tupleobject.py, bases=(object,)
         reg.insert(
             &TUPLE_TYPE as *const PyType as usize,
-            new_typeobject_with_base("tuple", init_tuple_type, object_type) as usize,
+            new_typeobject_with_base_and_layout(
+                "tuple",
+                init_tuple_type,
+                object_type,
+                &TUPLE_TYPE as *const PyType,
+            ) as usize,
         );
 
         // dict — PyPy: dictmultiobject.py, bases=(object,)
-        let dict_type = new_typeobject_with_base("dict", init_dict_type, object_type);
+        let dict_type = new_typeobject_with_base_and_layout(
+            "dict",
+            init_dict_type,
+            object_type,
+            &DICT_TYPE as *const PyType,
+        );
         reg.insert(&DICT_TYPE as *const PyType as usize, dict_type as usize);
         // `pypy/objspace/std/dictmultiobject.py:67
         // allocate_instance(W_ModuleDictObject, space.w_dict)` —
@@ -601,7 +616,12 @@ pub fn init_typeobjects() {
         // property — PyPy: descriptor.py W_Property, bases=(object,)
         reg.insert(
             &pyre_object::descriptor::PROPERTY_TYPE as *const PyType as usize,
-            new_typeobject_with_base("property", init_property_type, object_type) as usize,
+            new_typeobject_with_base_and_layout(
+                "property",
+                init_property_type,
+                object_type,
+                &pyre_object::descriptor::PROPERTY_TYPE as *const PyType,
+            ) as usize,
         );
 
         // exception — pyre uses one shared W_TypeObject for all builtin
@@ -717,13 +737,23 @@ pub fn init_typeobjects() {
         // bytearray — PyPy: bytearrayobject.py, bases=(object,)
         reg.insert(
             &pyre_object::bytearrayobject::BYTEARRAY_TYPE as *const PyType as usize,
-            new_typeobject_with_base("bytearray", init_bytearray_type, object_type) as usize,
+            new_typeobject_with_base_and_layout(
+                "bytearray",
+                init_bytearray_type,
+                object_type,
+                &pyre_object::bytearrayobject::BYTEARRAY_TYPE as *const PyType,
+            ) as usize,
         );
 
         // bytes — PyPy: bytesobject.py W_BytesObject, bases=(object,)
         reg.insert(
             &pyre_object::bytesobject::BYTES_TYPE as *const PyType as usize,
-            new_typeobject_with_base("bytes", init_bytes_type, object_type) as usize,
+            new_typeobject_with_base_and_layout(
+                "bytes",
+                init_bytes_type,
+                object_type,
+                &pyre_object::bytesobject::BYTES_TYPE as *const PyType,
+            ) as usize,
         );
 
         // set / frozenset — PyPy: setobject.py, bases=(object,).
@@ -771,7 +801,12 @@ pub fn init_typeobjects() {
         // the typedef itself stays empty.
         reg.insert(
             &pyre_object::descriptor::SUPER_TYPE as *const PyType as usize,
-            new_typeobject_with_base("super", init_super_type, object_type) as usize,
+            new_typeobject_with_base_and_layout(
+                "super",
+                init_super_type,
+                object_type,
+                &pyre_object::descriptor::SUPER_TYPE as *const PyType,
+            ) as usize,
         );
         let generator_type =
             new_typeobject_with_base("generator", init_generator_type, object_type);
@@ -942,23 +977,48 @@ pub fn init_typeobjects() {
         );
         reg.insert(
             &pyre_object::functional::ENUMERATE_TYPE as *const PyType as usize,
-            new_typeobject_with_base("enumerate", init_enumerate_type, object_type) as usize,
+            new_typeobject_with_base_and_layout(
+                "enumerate",
+                init_enumerate_type,
+                object_type,
+                &pyre_object::functional::ENUMERATE_TYPE as *const PyType,
+            ) as usize,
         );
         reg.insert(
             &pyre_object::functional::REVERSED_TYPE as *const PyType as usize,
-            new_typeobject_with_base("reversed", init_reversed_type, object_type) as usize,
+            new_typeobject_with_base_and_layout(
+                "reversed",
+                init_reversed_type,
+                object_type,
+                &pyre_object::functional::REVERSED_TYPE as *const PyType,
+            ) as usize,
         );
         reg.insert(
             &pyre_object::functional::FILTER_TYPE as *const PyType as usize,
-            new_typeobject_with_base("filter", init_filter_type, object_type) as usize,
+            new_typeobject_with_base_and_layout(
+                "filter",
+                init_filter_type,
+                object_type,
+                &pyre_object::functional::FILTER_TYPE as *const PyType,
+            ) as usize,
         );
         reg.insert(
             &pyre_object::functional::MAP_TYPE as *const PyType as usize,
-            new_typeobject_with_base("map", init_map_type, object_type) as usize,
+            new_typeobject_with_base_and_layout(
+                "map",
+                init_map_type,
+                object_type,
+                &pyre_object::functional::MAP_TYPE as *const PyType,
+            ) as usize,
         );
         reg.insert(
             &pyre_object::functional::ZIP_TYPE as *const PyType as usize,
-            new_typeobject_with_base("zip", init_zip_type, object_type) as usize,
+            new_typeobject_with_base_and_layout(
+                "zip",
+                init_zip_type,
+                object_type,
+                &pyre_object::functional::ZIP_TYPE as *const PyType,
+            ) as usize,
         );
         // `iter(callable, sentinel)` produces a `_CallableIterator`; register
         // its type so `type(it)` / `it.__class__` resolve like the other
@@ -1707,8 +1767,18 @@ pub fn make_builtin_type_with_bases(
     init: impl FnOnce(PyObjectRef),
     bases: &[PyObjectRef],
 ) -> PyObjectRef {
-    let layout_pytype = &INSTANCE_TYPE as *const PyType;
     let base = bases[0];
+    // A multi-base builtin class introduces no instance layout of its own, so
+    // it names the primary base's typedef and the reuse rule below hands back
+    // that same Layout.
+    let layout_pytype = unsafe {
+        let parent_layout = pyre_object::w_type_get_layout_ptr(base);
+        if parent_layout.is_null() {
+            &INSTANCE_TYPE as *const PyType
+        } else {
+            (*parent_layout).typedef
+        }
+    };
     let _roots = pyre_object::gc_roots::push_roots();
     let ns_slot = pyre_object::gc_roots::shadow_stack_len();
     let ns = pyre_object::w_dict_new();
@@ -8748,10 +8818,18 @@ fn init_getset_descriptor_type(ns: PyObjectRef) {
                             } else {
                                 "<generic property>"
                             };
+                        // `%N` names a type argument directly — the attribute
+                        // belongs to `w_obj` itself, not to `type(w_obj)`.
                         let type_name = unsafe {
-                            match crate::typedef::r#type(w_obj) {
-                                Some(tp) => pyre_object::w_type_get_name(tp.as_ptr()).to_string(),
-                                None => (*(*w_obj).ob_type).name.to_string(),
+                            if pyre_object::is_type(w_obj) {
+                                pyre_object::w_type_get_name(w_obj).to_string()
+                            } else {
+                                match crate::typedef::r#type(w_obj) {
+                                    Some(tp) => {
+                                        pyre_object::w_type_get_name(tp.as_ptr()).to_string()
+                                    }
+                                    None => (*(*w_obj).ob_type).name.to_string(),
+                                }
                             }
                         };
                         return Err(crate::PyError::attribute_error(format!(
@@ -9615,6 +9693,25 @@ unsafe fn mro_subclasses(w_type: PyObjectRef) {
     }
 }
 
+/// Whether `w_type` appears in `w_base`'s MRO — the `w_type in
+/// w_newbase.compute_mro()` test of `descr_set__bases__`.  A non-type entry
+/// answers `false`; the type check that rejects it follows separately.
+unsafe fn type_in_mro(w_base: PyObjectRef, w_type: PyObjectRef) -> bool {
+    if std::ptr::eq(w_base, w_type) {
+        return true;
+    }
+    if !unsafe { pyre_object::is_type(w_base) } {
+        return false;
+    }
+    let mro = unsafe { pyre_object::w_type_get_mro(w_base) };
+    if mro.is_null() {
+        return false;
+    }
+    unsafe { (*mro).as_slice() }
+        .iter()
+        .any(|&entry| std::ptr::eq(entry, w_type))
+}
+
 /// `type.__bases__` setter (typeobject.py:1064-1105 `descr_set__bases__`).
 /// Heap types only; the new bases must be a non-empty tuple of classes whose
 /// best base shares the current instance layout (so instances stay valid).
@@ -9632,7 +9729,8 @@ fn type_set_bases(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         }
         if w_value.is_null() || !pyre_object::is_tuple(w_value) {
             return Err(crate::PyError::type_error(format!(
-                "can only assign tuple to {type_name}.__bases__"
+                "can only assign tuple to {type_name}.__bases__, not {}",
+                pyre_object::type_name_of(w_value)
             )));
         }
         let n = pyre_object::w_tuple_len(w_value);
@@ -9648,7 +9746,11 @@ fn type_set_bases(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
             let Some(w_base) = pyre_object::w_tuple_getitem(w_value, i as i64) else {
                 continue;
             };
-            if std::ptr::eq(w_base, w_type) {
+            // `descr_set__bases__` tests `w_type in w_newbase.compute_mro()`,
+            // not just identity: a base that already derives from `w_type`
+            // closes the same loop one step further out, and the subsequent
+            // `mro_subclasses` walk would never terminate.
+            if type_in_mro(w_base, w_type) {
                 return Err(crate::PyError::type_error(
                     "a __bases__ item causes an inheritance cycle",
                 ));
@@ -9682,6 +9784,11 @@ fn type_set_bases(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
                 pyre_object::w_type_get_name(pyre_object::typeobject::w_type_get_best_base(w_type))
             )));
         }
+        // The linearization has to hold for the new bases before anything is
+        // mutated; recomputing it afterwards would leave the type half-changed
+        // (typeobject.py:1148 restores the old bases when `mro_subclasses`
+        // raises).
+        crate::baseobjspace::validate_c3_mro(w_value)?;
         // Invalidate the method cache of w_type and every subclass before the
         // hierarchy changes (typeobject.py:1130 `w_type.mutated(None)`).
         crate::baseobjspace::mutated(w_type, None);

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -6377,7 +6377,9 @@ fn walker_guard_int_exact_as_float<Sym: WalkSym>(
     value: i64,
 ) -> Result<(), DispatchError> {
     let shift = ctx.trace_ctx.const_int(48);
-    let top = ctx.trace_ctx.record_op(OpCode::IntRshift, &[raw_int, shift]);
+    let top = ctx
+        .trace_ctx
+        .record_op(OpCode::IntRshift, &[raw_int, shift]);
     ctx.trace_ctx
         .set_opref_concrete(top, majit_ir::Value::Int(value >> 48));
     let low = ctx.trace_ctx.const_int(-1);

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -6358,11 +6358,49 @@ fn walker_unbox_float<Sym: WalkSym>(
     ))
 }
 
+/// floatobject.py:139 `int_between(-1, i2 >> 48, 1)` — true while a double
+/// represents `value` exactly, doubles carrying at least 48 bits of precision.
+/// A wider int must be compared through its bigint, not through a rounded
+/// double.
+pub(crate) fn int_is_exact_as_float(value: i64) -> bool {
+    (-1..1).contains(&(value >> 48))
+}
+
+/// Emit [`int_is_exact_as_float`] as a trace precondition, lowered exactly as
+/// `int_between` is (`INT_SUB` + `UINT_LT`), so a re-entered trace carrying a
+/// wider int bails out to the exact comparison instead of comparing rounded
+/// doubles.
+fn walker_guard_int_exact_as_float<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    op_pc: usize,
+    raw_int: OpRef,
+    value: i64,
+) -> Result<(), DispatchError> {
+    let shift = ctx.trace_ctx.const_int(48);
+    let top = ctx.trace_ctx.record_op(OpCode::IntRshift, &[raw_int, shift]);
+    ctx.trace_ctx
+        .set_opref_concrete(top, majit_ir::Value::Int(value >> 48));
+    let low = ctx.trace_ctx.const_int(-1);
+    let offset = ctx.trace_ctx.record_op(OpCode::IntSub, &[top, low]);
+    ctx.trace_ctx
+        .set_opref_concrete(offset, majit_ir::Value::Int((value >> 48) + 1));
+    let width = ctx.trace_ctx.const_int(2);
+    let fits = ctx.trace_ctx.record_op(OpCode::UintLt, &[offset, width]);
+    ctx.trace_ctx
+        .set_opref_concrete(fits, majit_ir::Value::Int(1));
+    walker_emit_guard_with_snapshot(ctx, op_pc, OpCode::GuardTrue, &[fits])
+}
+
 /// Coerce a boxed operand to a raw `f64` OpRef for a float op: float →
 /// `walker_unbox_float`; int → `walker_unbox_int` then `cast_int_to_float`
 /// (`space.float_w` dispatches int through int2float).  Stamps the result
 /// with the already-known concrete `val` so downstream `box_value` sees it.
 /// Shared by the float-binary and float-compare specializations.
+///
+/// `exact_int` additionally guards that an int operand converts losslessly.
+/// A float arithmetic operand legitimately rounds (`space.float_w`), but a
+/// comparison is decided against the int's exact value (`_compare`), so only
+/// the compare specialization sets it.
 fn walker_coerce_operand_to_float<Sym: WalkSym>(
     ctx: &mut WalkContext<'_, '_, Sym>,
     op_pc: usize,
@@ -6370,11 +6408,16 @@ fn walker_coerce_operand_to_float<Sym: WalkSym>(
     concrete_obj: pyre_object::PyObjectRef,
     is_int: bool,
     val: f64,
+    exact_int: bool,
 ) -> Result<OpRef, DispatchError> {
     let raw = if is_int {
         // bool shares int's `intval`; guard its own &BOOL_TYPE before the cast.
         let (type_addr, descr) = crate::state::int_or_bool_unbox_type_descr(concrete_obj);
         let raw_int = walker_unbox_int_typed(ctx, op_pc, obj, type_addr, descr)?;
+        if exact_int {
+            let value = unsafe { pyre_object::w_int_get_value(concrete_obj) };
+            walker_guard_int_exact_as_float(ctx, op_pc, raw_int, value)?;
+        }
         ctx.trace_ctx.record_op(OpCode::CastIntToFloat, &[raw_int])
     } else {
         let float_type_addr = &pyre_object::pyobject::FLOAT_TYPE as *const _ as i64;

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -3274,8 +3274,10 @@ pub(crate) fn try_walker_specialize_binary_op_float<Sym: WalkSym>(
     }
 
     // --- emit the specialized IR (walker-native) ---
-    let lhs_raw = walker_coerce_operand_to_float(ctx, op_pc, lhs, lhs_obj, lhs_is_int, lhs_f64)?;
-    let rhs_raw = walker_coerce_operand_to_float(ctx, op_pc, rhs, rhs_obj, rhs_is_int, rhs_f64)?;
+    let lhs_raw =
+        walker_coerce_operand_to_float(ctx, op_pc, lhs, lhs_obj, lhs_is_int, lhs_f64, false)?;
+    let rhs_raw =
+        walker_coerce_operand_to_float(ctx, op_pc, rhs, rhs_obj, rhs_is_int, rhs_f64, false)?;
     // rint.py `_ovf_zer` analogue for float true-division: emit a
     // `float_eq(rhs, 0.0) → guard_false` precondition ahead of the bare
     // `FloatTrueDiv` llop so a future zero divisor deopts to the checked
@@ -6178,9 +6180,22 @@ pub(crate) fn try_walker_specialize_compare_op_float<Sym: WalkSym>(
         return Ok(None);
     };
 
+    // floatobject.py:139-146 — an int wider than a double represents exactly
+    // is compared through its bigint, which this fold cannot express.  Decline
+    // so the residual call decides it; the in-range case emits the same
+    // precondition as a guard (`exact_int` below).
+    let out_of_range = |is_int: bool, obj| {
+        is_int && !int_is_exact_as_float(unsafe { pyre_object::w_int_get_value(obj) })
+    };
+    if out_of_range(lhs_is_int, lhs_obj) || out_of_range(rhs_is_int, rhs_obj) {
+        return Ok(None);
+    }
+
     // --- emit the specialized IR (walker-native) ---
-    let lhs_raw = walker_coerce_operand_to_float(ctx, op_pc, lhs, lhs_obj, lhs_is_int, lhs_f64)?;
-    let rhs_raw = walker_coerce_operand_to_float(ctx, op_pc, rhs, rhs_obj, rhs_is_int, rhs_f64)?;
+    let lhs_raw =
+        walker_coerce_operand_to_float(ctx, op_pc, lhs, lhs_obj, lhs_is_int, lhs_f64, true)?;
+    let rhs_raw =
+        walker_coerce_operand_to_float(ctx, op_pc, rhs, rhs_obj, rhs_is_int, rhs_f64, true)?;
     let truth = ctx.trace_ctx.record_op(cmp, &[lhs_raw, rhs_raw]);
     let folded =
         majit_metainterp::eval_float_cmp(cmp, lhs_f64.to_bits() as i64, rhs_f64.to_bits() as i64);

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -4712,10 +4712,10 @@ fn bh_call_fn_impl(callable: PyObjectRef, null_or_self: PyObjectRef, args: &[PyO
     if unsafe { is_function(callable) } {
         let code = unsafe { pyre_interpreter::getcode(callable) };
         if unsafe { pyre_interpreter::is_builtin_code(code as pyre_object::PyObjectRef) } {
-            let func =
-                unsafe { pyre_interpreter::builtin_code_get(code as pyre_object::PyObjectRef) };
             let call_args = reload_args();
-            return match func(&call_args) {
+            return match unsafe {
+                pyre_interpreter::builtin_code_call(code as pyre_object::PyObjectRef, &call_args)
+            } {
                 Ok(result) if !result.is_null() => result as i64,
                 Ok(_) => 0,
                 Err(mut err) => {


### PR DESCRIPTION
Six independent builtin-layer fixes.

## 1. Receiver validation for unbound builtin method descriptors

`str.split(x)` where `x` merely claims `__class__ is str` reached the `str` implementation
and dereferenced a non-`str` payload. The exposure was not one type: `str`, `bytes`,
`bytearray`, `int`, `complex`, `range` and `memoryview` crashed, while `dict`, `float`,
`bool`, `type` and `object` silently returned garbage — `int.__index__(spoof)` handed the
spoof object straight back. A sweep counted ~155 reachable crash sites.

Rather than 500 per-method guards, this ports the `PyDescrObject.d_type` + `descr_check`
structure: `BuiltinCode` gains an `owner` field, all dispatch (including the JIT residual
call path) funnels through a single `builtin_code_call`, and `stamp_method_owners` binds
every plain-function descriptor in a type namespace to that type once the namespace is
complete and before the type goes live.

Blanket stamping is safe because `__new__`/`maketrans`/`from_bytes` and friends are already
wrapped as static/class methods, so the bare `function` entries are exactly the descriptors
that take a receiver. Diffing that set against CPython's own instance-method descriptors
gives `EXTRA = 0` for all 18 stamped types.

- A `dict` subclass keeps its entries in a `__dict_data__` backing rather than the `dict`
  layout, so the receiver test is `has_dict_backing`, not `is_dict`.
- `float.__getformat__` is a `classmethod_descriptor`; it was registered bare and is now a
  real classmethod.

Result: spoofed receivers produce 0 crashes and 0 silent accepts, with messages matching
CPython.

## 2. `pyframe`: bind the locals scope of unoptimized code reached through a call

`finish_for_call_with_globals_obj` never ran the scope initialization, so non-`CO_OPTIMIZED`
code entered through a *call* got no locals binding and its `STORE_NAME`s went into a
throwaway mapping. `FunctionType(compile("a = 1", "?", "exec"), g)()` left `g["a"]`
unchanged; CPython and PyPy both write `1`.

## 3. `breakpoint()` and `sys.breakpointhook`

Ports PyPy `pypy/module/__builtin__/app_breakpoint.py` and `pypy/module/sys/app.py`.
`$PYTHONBREAKPOINT` handling (unset → `pdb.set_trace`, `"0"` → no-op, otherwise a dotted
import with a `RuntimeWarning` on failure) matches CPython.

This also adds `builtins::call_forwarding_args`, the reusable form for a builtin that
forwards `*args, **kwargs`: passing the argument slice through verbatim would hand the
trailing `__pyre_kw__` marker dict to the callee as a positional argument.

## 4. Comparing an int against a float compares exactly

`float.__eq__`/`__lt__` and friends converted the int operand to a double, so
`2**53 + 1 == float(2**53)` was `True` and `10**400 > 1e308` was `False`. This ports
`floatobject.py`'s `_compare` / `do_compare_bigint`: an operand outside the range where a
double is exact (`int_between(-1, i2 >> 48, 1)`) is compared as a bigint, with the float
floored or ceiled according to the operator.

The JIT folded the same comparison in its own float fast path. The walker now emits the
`int_between` precondition as a guard and declines to specialize when the recorded operand
is already out of range, so a hot loop cannot diverge from the interpreter.

## 5. Builtin calls are checked against the declared positional arity

`builtin_code_call` compares the positional argument count against `fast_natural_arity`
when the code declares an exact arity (0..=4) and raises TypeError instead of letting the
callee index past the slice. A runtime matrix over 679 type-method pairs and 276 module
functions drove out 46 Rust panics, all of which are now TypeErrors.

The same sweep surfaced registrations whose declared arity did not match the
implementation (`int.denominator`'s getset getter, the `__pow__`/`__rpow__` pairs on
int/float/complex, `property.__set__`, `sys.getsizeof`, `gc.collect`, `gc.get_objects`,
`posix.get_terminal_size`, `ContextVar.get`/`set`, the file wrapper's
`readline`/`readlines`), plus two latent defects the gate exposed:

- `py_module!`'s `inline_functions:` arity counted `#[default(...)]` parameters as
  required, so `pickle.dumps(obj, protocol)` was rejected (169 such parameters tree-wide).
  It now counts only the leading required prefix and reports HOPELESS when any parameter
  is optional.
- `select.poll` was registered as a descriptor, so `selectors.py`'s
  `_selector_cls = select.poll` bound a receiver when called through the instance.

`bytearray.__release_buffer__` aborted the process on `_exports` underflow; it now
validates that its argument is a memoryview backed by the receiver.

## 6. `posix.putenv` / `unsetenv` / `_create_environ`

`putenv` and `unsetenv` were registered among the no-op stubs, so `os.environ[k] = v`
updated only the mapping's own dict while the process environment kept the values captured
at startup — child processes never saw an assignment, and neither did any native reader.
They now reach the host, rejecting an embedded NUL with ValueError, an empty or
`=`-bearing name with ValueError from `putenv` and with EINVAL from `unsetenv`; all seven
error cases match PyPy exactly.

The environ snapshot moves into `create_environ` (which roots both halves of an entry
across the store) and is exposed as `posix._create_environ`, the predicate os.py tests
before defining `os.reload_environ`.

## Verification

`python3 pyre/check.py --synthetic-only --backend dynasm` — **dynasm 299/299**.

CPython test deltas: `test_range` 182 errors → OK, `test_set` 27 → OK (630 tests),
`test_tuple` → OK, `test_bool` → OK, `test_operator` 74 → 2, `test_dict` 9 → 0,
`test_str` 22 → 1, `test_list` 5 → 1, `test_builtin` 154 → 10,
`test_itertools` 18 → 16, `test_os.EnvironTests` 32/32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
