### PR TITLE
thread: port free-threaded runtime support from PyPy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2195,6 +2195,7 @@ dependencies = [
  "num-complex",
  "num-integer",
  "num-traits",
+ "parking_lot",
  "paste",
  "pymath",
  "pyre-macros",
@@ -2304,6 +2305,7 @@ dependencies = [
  "majit-macros",
  "malachite-bigint",
  "num-traits",
+ "parking_lot",
  "pyre-macros",
  "rustpython-wtf8",
 ]

--- a/lib-python/3/test/test_threading.py
+++ b/lib-python/3/test/test_threading.py
@@ -323,6 +323,7 @@ class ThreadTests(BaseTestCase):
 
     # PyThreadState_SetAsyncExc() is a CPython-only gimmick, not (currently)
     # exposed at the Python level.  This test relies on ctypes to get at it.
+    @cpython_only
     def test_PyThreadState_SetAsyncExc(self):
         ctypes = import_module("ctypes")
 
@@ -426,6 +427,7 @@ class ThreadTests(BaseTestCase):
         finally:
             threading._start_joinable_thread = _start_joinable_thread
 
+    @cpython_only
     def test_finalize_running_thread(self):
         # Issue 1402: the PyGILState_Ensure / _Release functions may be called
         # very late on python exit: on deallocation of a running thread for
@@ -572,6 +574,7 @@ class ThreadTests(BaseTestCase):
         thread.join()
         assert not thread.is_alive()
 
+    @cpython_only
     def test_no_refcycle_through_target(self):
         class RunSelfFunction(object):
             def __init__(self, should_raise):
@@ -853,6 +856,7 @@ class ThreadTests(BaseTestCase):
     def test_main_thread_after_fork_from_dummy_thread(self, create_dummy=False):
         self.test_main_thread_after_fork_from_foreign_thread(create_dummy=True)
 
+    @cpython_only
     def test_main_thread_during_shutdown(self):
         # bpo-31516: current_thread() should still point to the main thread
         # at shutdown
@@ -1082,6 +1086,7 @@ class ThreadTests(BaseTestCase):
         self.assertEqual(threading.getprofile(), old_profile)
         self.assertEqual(sys.getprofile(), old_profile)
 
+    @cpython_only
     def test_locals_at_exit(self):
         # bpo-19466: thread locals must not be deleted before destructors
         # are called
@@ -1623,6 +1628,7 @@ class SubinterpThreadingTests(BaseTestCase):
             os.set_blocking(r, False)
         return (r, w)
 
+    @cpython_only
     def test_threads_join(self):
         # Non-daemon threads should be joined at subinterpreter shutdown
         # (issue #18808)
@@ -1651,6 +1657,7 @@ class SubinterpThreadingTests(BaseTestCase):
         # The thread was joined properly.
         self.assertEqual(os.read(r, 1), b"x")
 
+    @cpython_only
     def test_threads_join_2(self):
         # Same as above, but a delay gets introduced after the thread's
         # Python code returned but before the thread state is deleted.

--- a/majit/majit-gc/src/gc_sync.rs
+++ b/majit/majit-gc/src/gc_sync.rs
@@ -321,10 +321,81 @@ pub fn unregister_thread() {
     GC_SYNC.quiesced.notify_all();
 }
 
+/// Temporarily remove the current mutator from the RUNNING census while it
+/// blocks in an external operation.
+///
+/// This is the free-threaded counterpart of RPython's
+/// `rffi.aroundstate.before()` / `gil.before_external_call()`: a thread which
+/// is asleep in `pthread_cond_wait`, `join`, or `nanosleep` cannot poll the
+/// eval breaker, so it must not remain in the set that a collector waits to
+/// drain.  Dropping the guard waits for an in-flight STW request to finish and
+/// then makes the mutator RUNNING again.
+pub struct BlockingGuard {
+    registered: bool,
+}
+
+impl Drop for BlockingGuard {
+    fn drop(&mut self) {
+        if !self.registered {
+            return;
+        }
+        let mut state = GC_SYNC.quiesce.lock().unwrap();
+        state = GC_SYNC
+            .resumed
+            .wait_while(state, |_| GC_SYNC.stw_requested.load(Ordering::Acquire))
+            .unwrap();
+        state.running += 1;
+        assert!(
+            !GC_THREAD.with(|t| t.running.replace(true)),
+            "GC mutator resumed from an external block twice"
+        );
+    }
+}
+
+#[inline]
+pub fn before_external_block() -> BlockingGuard {
+    let registered = GC_THREAD.with(|t| t.registered.get());
+    if registered {
+        let mut state = GC_SYNC.quiesce.lock().unwrap();
+        assert!(
+            GC_THREAD.with(|t| t.running.replace(false)),
+            "GC mutator entered an external block twice"
+        );
+        state.running = state
+            .running
+            .checked_sub(1)
+            .expect("RUNNING underflow entering external block");
+        GC_SYNC.quiesced.notify_all();
+    }
+    BlockingGuard { registered }
+}
+
 /// Number of registered GC mutators.
 #[inline]
 pub fn registered_threads() -> usize {
     REGISTERED_THREADS.load(Ordering::Acquire)
+}
+
+/// RPython `rthread.thread_after_fork()` parity for the child process.
+///
+/// Only the thread which called `fork()` survives.  Rebuild the mutator
+/// census around that thread so a later collection never waits for vanished
+/// parent threads.
+pub fn after_fork_child() {
+    let registered = GC_THREAD.with(|t| t.registered.get());
+    let running = GC_THREAD.with(|t| t.running.get());
+    REGISTERED_THREADS.store(usize::from(registered), Ordering::SeqCst);
+    IN_FAST_PATH.store(0, Ordering::Release);
+    GC_OP_OWNER.store(0, Ordering::SeqCst);
+    STW_OWNER.store(0, Ordering::SeqCst);
+    STW_DEPTH.store(0, Ordering::SeqCst);
+    GC_SYNC.stw_requested.store(false, Ordering::Release);
+    majit_ir::eval_breaker_word::clear_stw();
+    let mut state = GC_SYNC.quiesce.lock().unwrap();
+    state.running = usize::from(registered && running);
+    GC_SYNC.stw_generation.fetch_add(1, Ordering::SeqCst);
+    GC_SYNC.resumed.notify_all();
+    GC_SYNC.quiesced.notify_all();
 }
 
 /// Whether a stop-the-world pause is required for a collection driven by the

--- a/majit/majit-gc/src/shadow_stack.rs
+++ b/majit/majit-gc/src/shadow_stack.rs
@@ -366,6 +366,17 @@ pub fn unregister_mutator() {
     registry.swap_remove(index);
 }
 
+/// Discard root areas owned by threads which disappeared across `fork()`.
+///
+/// PyPy's `reinit_threads()` retains only the child thread's execution
+/// context.  The shadow-stack registry is the translated equivalent of that
+/// per-thread root ownership.
+pub fn after_fork_child() {
+    let thread_id = std::thread::current().id();
+    let mut registry = MUTATOR_REGISTRY.lock().unwrap();
+    registry.retain(|entry| entry.thread_id == thread_id);
+}
+
 /// The shadow stack itself.
 struct ShadowStack {
     entries: Vec<GcRef>,

--- a/majit/majit-ir/src/eval_breaker_word.rs
+++ b/majit/majit-ir/src/eval_breaker_word.rs
@@ -53,6 +53,11 @@ pub fn eval_breaker_word_addr() -> usize {
     EVAL_BREAKER_WORD_ADDR.load(Ordering::Relaxed)
 }
 
+#[inline]
+pub fn load() -> usize {
+    EVAL_BREAKER_WORD.load(Ordering::Relaxed)
+}
+
 // --- async (bit0): armed by the OS signal handler / action dispatcher ---
 // `fetch_or` is a single lock-free atomic RMW → async-signal-safe.
 pub fn set_async() {

--- a/pyre/cpython_tests/README.md
+++ b/pyre/cpython_tests/README.md
@@ -10,10 +10,13 @@ pyre's plain-Python runner convention (no pytest / RPython dependency).
 - **Per-module subprocess.** Each test module runs in its own subprocess of
   the built interpreter, exactly like PyPy launches `pypy3-c -m test <module>`.
   Test pollution can't leak between modules.
-- **Pristine vendored tests.** `lib-python/3/test/` stays an unmodified copy
-  of CPython's `Lib/test`. Every skip / expected-status decision lives in the
-  external `baseline.json` — we never edit test files (so stdlib upgrades stay
-  a clean drop-in; see `lib-python/stdlib-upgrade.txt`).
+- **Vendored tests carry PyPy's edits and nothing else.** `lib-python/3/test/`
+  is CPython's `Lib/test` plus the modifications PyPy makes to it in its own
+  `lib-python` — those are ported and kept (a re-vendor from CPython drops
+  them, so they are restored after one). A pyre-specific skip / expected-status
+  decision never becomes a test-file edit: it lives in the external
+  `baseline.json`, so stdlib upgrades stay a clean drop-in (see
+  `lib-python/stdlib-upgrade.txt`).
 - **External baseline.** `baseline.json` records the expected status of every
   module per backend. A module recorded `PASS` that stops passing is a
   regression and fails CI. The default gate runs only the `PASS` subset (for CI

--- a/pyre/cpython_tests/run.py
+++ b/pyre/cpython_tests/run.py
@@ -3,8 +3,9 @@
 
 This mirrors PyPy's `lib-python/conftest.py` mechanism: each CPython test
 module is run in its OWN subprocess of the built interpreter, the vendored
-test files stay pristine, and every expected-status / skip decision lives in
-an EXTERNAL baseline (`baseline.json`) — never as edits to the test files.
+test files carry PyPy's own modifications and nothing else, and every
+pyre-specific expected-status / skip decision lives in an EXTERNAL baseline
+(`baseline.json`) — never as an edit to the test files.
 
 Each module is launched one of three ways, selectable with `--mode`:
 

--- a/pyre/pyre-interpreter/Cargo.toml
+++ b/pyre/pyre-interpreter/Cargo.toml
@@ -62,6 +62,7 @@ base64 = { workspace = true }
 crc32fast = { workspace = true }
 indexmap = { workspace = true }
 paste = { workspace = true }
+parking_lot = { workspace = true }
 # Decompresses the embedded stdlib VFS blob at runtime (wasm_vfs). Decode-only,
 # no_std-compatible safe path; the encode side is unused here.
 lz4_flex = { version = "0.13", default-features = false, features = [

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -82,28 +82,42 @@ pub fn map_set_update_error(err: pyre_object::setobject::SetUpdateError) -> PyEr
 /// lazy-null `exc_object`.
 pub fn walk_pending_hash_error(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
     PENDING_HASH_ERROR.with(|cell| {
-        // SAFETY: `as_ptr` yields the `Option<PyError>` interior; this closure
-        // holds the only reference for its duration and does not re-borrow the
-        // cell, so no borrow-flag conflict with a walker-triggered path.
-        let opt = unsafe { &mut *cell.as_ptr() };
-        if let Some(err) = opt.as_mut() {
-            err.walk_gc_refs(visitor);
-        }
+        unsafe { walk_pending_hash_error_area(cell as *const _ as *const (), visitor) };
     });
+}
+
+pub(crate) fn capture_pending_hash_error_area() -> *const () {
+    PENDING_HASH_ERROR.with(|cell| cell as *const _ as *const ())
+}
+
+/// Walk the deferred dict callback error belonging to one stopped mutator.
+///
+/// # Safety
+/// `data` must come from [`capture_pending_hash_error_area`], and the owning
+/// mutator must be quiesced.
+pub(crate) unsafe fn walk_pending_hash_error_area(
+    data: *const (),
+    visitor: &mut dyn FnMut(&mut majit_ir::GcRef),
+) {
+    let cell = unsafe { &*(data as *const Cell<Option<PyError>>) };
+    // SAFETY: the owning mutator is stopped, so the collector has exclusive
+    // access to the Cell interior while forwarding the PyError's object slots.
+    let opt = unsafe { &mut *cell.as_ptr() };
+    if let Some(err) = opt.as_mut() {
+        err.walk_gc_refs(visitor);
+    }
 }
 
 /// interp_gc.py:12-15 — clear `space.fromcache(MethodCache)` before an
 /// explicit full collection.
 #[majit_macros::dont_look_inside]
 pub fn clear_method_cache() {
-    METHOD_CACHE.with(|cache| {
-        let mut cache = cache.borrow_mut();
-        cache.versions.fill(0);
-        cache.names.fill(None);
-        cache
-            .lookup_where
-            .fill((std::ptr::null_mut(), std::ptr::null_mut()));
-    });
+    let mut cache = METHOD_CACHE.lock();
+    cache.versions.fill(0);
+    cache.names.fill(None);
+    cache
+        .lookup_where
+        .fill((std::ptr::null_mut(), std::ptr::null_mut()));
 }
 
 /// CPython 3.14 `dict_unhashable_type` (`Objects/dictobject.c`) parity.
@@ -3969,6 +3983,12 @@ pub(crate) fn len_slot(obj: PyObjectRef) -> PyResult {
 /// it to call `_obj_getdict`. pyre dispatches at runtime via the type's
 /// hasdict flag because Rust has no per-class virtual table.
 pub fn getdict(obj: PyObjectRef) -> PyObjectRef {
+    // pypy/module/thread/os_local.py Local.getdict selects the dictionary
+    // belonging to the current ExecutionContext before ordinary mapdict
+    // dispatch.  The Local object itself owns the mapping and cache.
+    if let Some(w_dict) = crate::module::thread::local_getdict(obj) {
+        return w_dict;
+    }
     // function.py:231-234 Function.getdict — typed `w_func_dict` field.
     if unsafe { crate::is_function(obj) }
         && unsafe { std::ptr::eq((*obj).ob_type, &crate::function::FUNCTION_TYPE) }
@@ -7527,10 +7547,9 @@ pub(crate) unsafe fn lookup_in_type_wtf8(w_type: PyObjectRef, name: &Wtf8) -> Op
 }
 
 /// `typeobject.py:76-101 MethodCache` — the per-space method-lookup
-/// cache.  `space.fromcache(MethodCache)` returns one instance per
-/// space; pyre is single-space, so a thread-local singleton stands in
-/// (the role the dict-strategy `space.fromcache` singletons already
-/// play).  `versions[h]` is the `version_tag()` the slot was filled
+/// cache. `space.fromcache(MethodCache)` returns one instance per object
+/// space; pyre's single space therefore owns one process-shared instance.
+/// `versions[h]` is the `version_tag()` the slot was filled
 /// under (`0` = empty), `names[h]` the looked-up name, `lookup_where[h]`
 /// the cached `(w_class, w_value)` pair from the MRO walk — a
 /// `(null, null)` pair on a valid `(version, name)` entry is the cached
@@ -7542,17 +7561,23 @@ struct MethodCache {
     lookup_where: Vec<(PyObjectRef, PyObjectRef)>,
 }
 
+// PyPy stores this cache on the shared object space. The mutex below protects
+// every probe, fill, clear, and GC-forwarding walk, so its raw object-pointer
+// slots are never accessed concurrently while the collector rewrites them.
+unsafe impl Send for MethodCache {}
+
 /// `space.config.objspace.std.methodcachesizeexp` default.
 const METHOD_CACHE_SIZE_EXP: u32 = 11;
 const METHOD_CACHE_SIZE: usize = 1 << METHOD_CACHE_SIZE_EXP;
 
-thread_local! {
-    static METHOD_CACHE: std::cell::RefCell<MethodCache> = std::cell::RefCell::new(MethodCache {
+static METHOD_CACHE: std::sync::LazyLock<parking_lot::Mutex<MethodCache>> =
+    std::sync::LazyLock::new(|| {
+        parking_lot::Mutex::new(MethodCache {
         versions: vec![0u64; METHOD_CACHE_SIZE],
         names: vec![None; METHOD_CACHE_SIZE],
         lookup_where: vec![(std::ptr::null_mut(), std::ptr::null_mut()); METHOD_CACHE_SIZE],
+        })
     });
-}
 
 /// `typeobject.py:520-535` method-hash.  `version_tag` is pyre's u64
 /// version token directly (PyPy hashes `current_object_addr_as_int(
@@ -7678,15 +7703,15 @@ unsafe fn _cached_lookup_where(
 ) -> (PyObjectRef, PyObjectRef) {
     let h = method_hash(version_tag, name);
     // Probe without holding the borrow across the MRO walk below.
-    let hit = METHOD_CACHE.with(|c| {
-        let cache = c.borrow();
+    let hit = {
+        let cache = METHOD_CACHE.lock();
         if cache.versions[h] == version_tag && cache.names[h].as_deref() == Some(name) {
             // A valid entry with null pointers is the cached negative result.
             Some(cache.lookup_where[h])
         } else {
             None
         }
-    });
+    };
     if let Some(tup) = hit {
         return tup;
     }
@@ -7695,12 +7720,10 @@ unsafe fn _cached_lookup_where(
     // Prebuilt-family store: the cache slot is reached only by
     // `walk_method_cache_gc`, skipped on clean minor collections.
     pyre_object::gc_roots::mark_prebuilt_roots_dirty();
-    METHOD_CACHE.with(|c| {
-        let mut cache = c.borrow_mut();
-        cache.versions[h] = version_tag;
-        cache.names[h] = Some(name.to_string());
-        cache.lookup_where[h] = tup;
-    });
+    let mut cache = METHOD_CACHE.lock();
+    cache.versions[h] = version_tag;
+    cache.names[h] = Some(name.to_string());
+    cache.lookup_where[h] = tup;
     tup
 }
 
@@ -7719,33 +7742,9 @@ unsafe fn _cached_lookup_where(
 /// never by a relocating move, so the cache's *own* copy of each pointer
 /// must be forwarded here or a later hit would read a stale address.
 pub(crate) unsafe fn walk_method_cache_gc(forward: &mut dyn FnMut(&mut PyObjectRef)) {
-    METHOD_CACHE.with(|c| {
-        let mut cache = c.borrow_mut();
-        for (w_class, w_value) in cache.lookup_where.iter_mut() {
-            // Empty / negative-cache slots hold nulls: nothing to forward.
-            if !w_class.is_null() {
-                forward(w_class);
-            }
-            if !w_value.is_null() {
-                forward(w_value);
-            }
-        }
-    });
-}
-
-pub(crate) fn capture_method_cache_root_area() -> *const () {
-    METHOD_CACHE.with(|cache| cache as *const _ as *const ())
-}
-
-/// # Safety
-/// `data` must come from [`capture_method_cache_root_area`], and the owning
-/// thread must be quiesced.
-pub(crate) unsafe fn walk_method_cache_root_area(
-    data: *const (),
-    forward: &mut dyn FnMut(&mut PyObjectRef),
-) {
-    let cache = unsafe { &mut *(*(data as *const std::cell::RefCell<MethodCache>)).as_ptr() };
+    let mut cache = METHOD_CACHE.lock();
     for (w_class, w_value) in cache.lookup_where.iter_mut() {
+        // Empty / negative-cache slots hold nulls: nothing to forward.
         if !w_class.is_null() {
             forward(w_class);
         }

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -7573,9 +7573,9 @@ const METHOD_CACHE_SIZE: usize = 1 << METHOD_CACHE_SIZE_EXP;
 static METHOD_CACHE: std::sync::LazyLock<parking_lot::Mutex<MethodCache>> =
     std::sync::LazyLock::new(|| {
         parking_lot::Mutex::new(MethodCache {
-        versions: vec![0u64; METHOD_CACHE_SIZE],
-        names: vec![None; METHOD_CACHE_SIZE],
-        lookup_where: vec![(std::ptr::null_mut(), std::ptr::null_mut()); METHOD_CACHE_SIZE],
+            versions: vec![0u64; METHOD_CACHE_SIZE],
+            names: vec![None; METHOD_CACHE_SIZE],
+            lookup_where: vec![(std::ptr::null_mut(), std::ptr::null_mut()); METHOD_CACHE_SIZE],
         })
     });
 

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -106,14 +106,30 @@ pub fn clear_call_error() {
 /// these three fields are the complete set of GC refs a `PyError` holds.
 pub fn walk_pending_call_error(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
     PENDING_CALL_ERROR.with(|slot| {
-        // SAFETY: `as_ptr` yields the `Option<PyError>` interior; this closure
-        // holds the only reference for its duration and does not re-borrow the
-        // cell, so no borrow-flag conflict with a walker-triggered path.
-        let opt = unsafe { &mut *slot.as_ptr() };
-        if let Some(err) = opt.as_mut() {
-            err.walk_gc_refs(visitor);
-        }
+        unsafe { walk_pending_call_error_area(slot as *const _ as *const (), visitor) };
     });
+}
+
+pub(crate) fn capture_pending_call_error_area() -> *const () {
+    PENDING_CALL_ERROR.with(|slot| slot as *const _ as *const ())
+}
+
+/// Walk the deferred call error belonging to one stopped mutator.
+///
+/// # Safety
+/// `data` must come from [`capture_pending_call_error_area`], and the owning
+/// mutator must be quiesced.
+pub(crate) unsafe fn walk_pending_call_error_area(
+    data: *const (),
+    visitor: &mut dyn FnMut(&mut majit_ir::GcRef),
+) {
+    let slot = unsafe { &*(data as *const RefCell<Option<PyError>>) };
+    // SAFETY: the owning mutator is stopped, so nothing can borrow or mutate
+    // the RefCell while the collector forwards the PyError's object slots.
+    let opt = unsafe { &mut *slot.as_ptr() };
+    if let Some(err) = opt.as_mut() {
+        err.walk_gc_refs(visitor);
+    }
 }
 
 /// Cold debug flag probe for `call_function_impl_raw`. This is a
@@ -141,6 +157,8 @@ use crate::pyframe::PyFrame;
 // ── Eval function injection ──────────────────────────────────────
 type EvalFn = fn(&mut PyFrame) -> PyResult;
 static EVAL_OVERRIDE: OnceLock<EvalFn> = OnceLock::new();
+type ThreadEntryFn = fn();
+static THREAD_ENTRY_HOOK: OnceLock<ThreadEntryFn> = OnceLock::new();
 
 type DepthBumpFn = fn() -> Option<Box<dyn std::any::Any>>;
 static DEPTH_BUMP_OVERRIDE: OnceLock<DepthBumpFn> = OnceLock::new();
@@ -214,6 +232,21 @@ impl Drop for CallDepthGuardPublic {
 /// Register the JIT-aware eval function. Called by pyre-jit at startup.
 pub fn register_eval_override(f: EvalFn) {
     let _ = EVAL_OVERRIDE.set(f);
+}
+
+/// Install the runtime hook for entering a new Python mutator thread.
+///
+/// `pyre-interpreter` cannot depend on `pyre-jit`, so the JIT registers this
+/// reverse hook after it has installed the process-global collector.  Every
+/// newly-created Python OS thread invokes it before allocating or evaluating.
+pub fn register_thread_entry_hook(f: ThreadEntryFn) {
+    let _ = THREAD_ENTRY_HOOK.set(f);
+}
+
+pub fn enter_runtime_thread() {
+    if let Some(f) = THREAD_ENTRY_HOOK.get() {
+        f();
+    }
 }
 
 /// Get the current eval function (JIT-aware if registered, plain otherwise).
@@ -309,7 +342,14 @@ thread_local! {
 
 /// Set the last known execution context (called at eval loop entry).
 pub fn set_last_exec_ctx(ctx: *const crate::PyExecutionContext) {
-    LAST_EXEC_CTX.with(|c| c.set(ctx));
+    LAST_EXEC_CTX.with(|c| {
+        let previous = c.replace(ctx);
+        if previous.is_null() && !ctx.is_null() {
+            crate::module::thread::register_execution_context(ctx);
+        } else if !previous.is_null() && ctx.is_null() {
+            crate::module::thread::unregister_execution_context();
+        }
+    });
 }
 
 /// Snapshot the current thread-local execution context. Residual callers

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -485,10 +485,9 @@ unsafe fn walk_builtin_type_dicts_gc(forward: &mut dyn FnMut(&mut PyObjectRef)) 
                 // object's trace function does.
                 let dict_slot = &mut t.dict as *mut *mut u8 as *mut PyObjectRef;
                 forward(&mut *dict_slot);
-                pyre_object::dictmultiobject::w_dict_walk_gc_refs(
-                    *dict_slot,
-                    &mut |slot| forward(slot),
-                );
+                pyre_object::dictmultiobject::w_dict_walk_gc_refs(*dict_slot, &mut |slot| {
+                    forward(slot)
+                });
                 // `weak_subclasses` holds `w_weakref_new` (`try_gc_alloc`)
                 // young WEAKREF GcStructs whose only strong root is this
                 // off-GC list; forward each slot in place so the WEAKREF
@@ -662,8 +661,7 @@ pub unsafe fn walk_pyframe_roots_area(
             // copy alone is not authoritative for later EC reads).
             let exc_slot = unsafe { &mut (*ec).sys_exc_value as *mut PyObjectRef };
             visitor(unsafe { &mut *(exc_slot as *mut majit_ir::GcRef) });
-            let async_exc_slot =
-                unsafe { &mut (*ec).w_async_exception_type as *mut PyObjectRef };
+            let async_exc_slot = unsafe { &mut (*ec).w_async_exception_type as *mut PyObjectRef };
             visitor(unsafe { &mut *(async_exc_slot as *mut majit_ir::GcRef) });
             // Exceptions may use the off-GC malloc_typed fallback.  In that
             // case forwarding the carrier above is a no-op, so trace its raw

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -47,8 +47,12 @@ thread_local! {
         current_frame: CURRENT_FRAME.with(|frame| frame as *const _),
         last_exec_ctx: crate::call::capture_last_exec_ctx_cell(),
         import_roots: crate::importing::capture_import_root_area(),
-        method_cache: crate::baseobjspace::capture_method_cache_root_area(),
         mapdict_method_cache: crate::pycode::capture_mapdict_method_cache_root_area(),
+        in_flight_exception: IN_FLIGHT_EXCEPTION.with(|cell| cell as *const _),
+        bh_last_exception: majit_metainterp::blackhole::BH_LAST_EXC_VALUE
+            .with(|cell| cell as *const _),
+        pending_call_error: crate::call::capture_pending_call_error_area(),
+        pending_hash_error: crate::baseobjspace::capture_pending_hash_error_area(),
     };
 }
 
@@ -56,8 +60,11 @@ struct PyFrameRootArea {
     current_frame: *const Cell<*mut PyFrame>,
     last_exec_ctx: *const (),
     import_roots: *const (),
-    method_cache: *const (),
     mapdict_method_cache: *const (),
+    in_flight_exception: *const Cell<PyObjectRef>,
+    bh_last_exception: *const Cell<i64>,
+    pending_call_error: *const (),
+    pending_hash_error: *const (),
 }
 use crate::pyframe::PyFrame;
 
@@ -471,9 +478,17 @@ unsafe fn walk_builtin_type_dicts_gc(forward: &mut dyn FnMut(&mut PyObjectRef)) 
                 forward(&mut t.w_qualname);
                 // Heap and builtin types both hold a managed W_DictObject.
                 // Forward the field itself; the dict's custom trace walks its
-                // keys and values.
+                // keys and values during a major collection. During a minor,
+                // an already-old dict is not recursively rescanned merely
+                // because this root slot is visited, so explicitly descend
+                // through the strategy storage as the translated prebuilt
+                // object's trace function does.
                 let dict_slot = &mut t.dict as *mut *mut u8 as *mut PyObjectRef;
                 forward(&mut *dict_slot);
+                pyre_object::dictmultiobject::w_dict_walk_gc_refs(
+                    *dict_slot,
+                    &mut |slot| forward(slot),
+                );
                 // `weak_subclasses` holds `w_weakref_new` (`try_gc_alloc`)
                 // young WEAKREF GcStructs whose only strong root is this
                 // off-GC list; forward each slot in place so the WEAKREF
@@ -567,6 +582,18 @@ pub unsafe fn walk_pyframe_roots_area(
     visitor: &mut dyn FnMut(&mut majit_ir::GcRef),
 ) {
     let area = unsafe { &*(data as *const PyFrameRootArea) };
+    // These are genuinely thread-local exception carriers, but every stopped
+    // mutator's carrier must be visited during free-threaded collection.
+    // PyPy reaches the equivalent values through each ExecutionContext /
+    // thread state; keeping them in this registered per-mutator root area
+    // preserves that ownership instead of resolving TLS on only the thread
+    // which happened to initiate collection.
+    unsafe {
+        walk_in_flight_exception_area(area.in_flight_exception, visitor);
+        walk_bh_last_exception_area(area.bh_last_exception, visitor);
+        crate::call::walk_pending_call_error_area(area.pending_call_error, visitor);
+        crate::baseobjspace::walk_pending_hash_error_area(area.pending_hash_error, visitor);
+    }
     // incminimark.py:339-355 prebuilt-object scanning parity: a minor
     // collection scans an old/prebuilt object only when the write barrier
     // recorded a store into it since the previous minor collection
@@ -628,12 +655,16 @@ pub unsafe fn walk_pyframe_roots_area(
             }
             let top_slot = unsafe { &mut (*ec).topframeref as *mut *mut PyFrame };
             visitor(unsafe { &mut *(top_slot as *mut majit_ir::GcRef) });
+            unsafe { (*ec).walk_builtin_roots(visitor) };
             // `sys_exc_value` holds the active handler exception, which
             // is nursery-allocated and may move; forward it so the EC
             // slot is updated on a minor collection (the value-stack
             // copy alone is not authoritative for later EC reads).
             let exc_slot = unsafe { &mut (*ec).sys_exc_value as *mut PyObjectRef };
             visitor(unsafe { &mut *(exc_slot as *mut majit_ir::GcRef) });
+            let async_exc_slot =
+                unsafe { &mut (*ec).w_async_exception_type as *mut PyObjectRef };
+            visitor(unsafe { &mut *(async_exc_slot as *mut majit_ir::GcRef) });
             // Exceptions may use the off-GC malloc_typed fallback.  In that
             // case forwarding the carrier above is a no-op, so trace its raw
             // GC-managed children just as `walk_in_flight_exception` does.
@@ -856,11 +887,6 @@ pub unsafe fn walk_pyframe_roots_area(
                     walk_raw_getset_roots(*slot, visitor);
                 };
                 crate::importing::walk_import_roots_area(area.import_roots, &mut forward);
-                // The interpreter method cache (`baseobjspace::MethodCache`)
-                // keeps a second pointer to each looked-up method that the
-                // namespace-dict walk above does not reach; forward those so
-                // a cache hit after a moving collection is not stale.
-                crate::baseobjspace::walk_method_cache_root_area(area.method_cache, &mut forward);
                 // The per-pycode `_mapdict_caches` LOAD_METHOD slots hold a
                 // `w_method` pointer (mapdict.py:1418) that no custom trace
                 // reaches — code objects are Box-immortal — so forward those
@@ -869,10 +895,6 @@ pub unsafe fn walk_pyframe_roots_area(
                     area.mapdict_method_cache,
                     &mut forward,
                 );
-                // _codecs.CodecState is a space-cache object in PyPy; pyre
-                // keeps the same list/dict state in an interpreter-global
-                // slot, so its Python objects must be forwarded explicitly.
-                crate::module::_codecs::walk_codec_state_gc(&mut forward);
             }
         }
     }
@@ -885,6 +907,7 @@ pub unsafe fn walk_pyframe_roots_area(
 /// the same fn pointer is idempotent.
 pub fn register_pyframe_root_walker() {
     majit_gc::shadow_stack::register_extra_root_walker(walk_global_prebuilt_roots);
+    majit_gc::shadow_stack::register_extra_root_walker(crate::module::thread::walk_thread_roots);
 }
 
 thread_local! {
@@ -911,33 +934,28 @@ pub fn set_in_flight_exception(exc: PyObjectRef) {
 
 fn walk_in_flight_exception(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
     IN_FLIGHT_EXCEPTION.with(|c| {
-        let exc = c.get();
-        if exc.is_null() {
-            return;
-        }
-        // Forward the exception OBJECT slot itself. A GC-managed exception
-        // (oldgen-stable `w_exception_new_empty`) is marked here and the
-        // collector then recurses into its `W_BASE_EXCEPTION_GC_PTR_OFFSETS`
-        // slots via offset tracing, keeping the whole graph alive. The
-        // exception is oldgen-stable (non-moving), so the slot is not rewritten,
-        // but marking is what matters. Mirrors the value-stack walker, which
-        // forwards the on-stack exception slot then walks its raw children.
-        let slot = c.as_ptr();
-        // SAFETY: `slot` points at the `Cell<PyObjectRef>`'s interior, which is
-        // valid for the duration of this closure. `PyObjectRef` and `GcRef`
-        // share layout (`*mut PyObject`).
-        unsafe { visitor(&mut *(slot as *mut majit_ir::GcRef)) };
-        // Off-GC fallback: when the GC is not installed the exception is
-        // `malloc_typed`-immortal, so the visitor above is a no-op and the
-        // collector never traces its slots. Forward ALL its GC-managed children
-        // in place — the whole `W_BASE_EXCEPTION_GC_PTR_OFFSETS` set (args_w,
-        // w_cause, w_context, the w_traceback chain, w_dict, and the per-subclass
-        // slots). Read the object AFTER the visitor so a (hypothetically) moved
-        // exception is the live one. The slots are forwarded by address (not the
-        // barriered setter), so a moving child is relocated with no re-entry.
-        let exc = unsafe { *(slot as *const PyObjectRef) };
-        unsafe { walk_raw_exception_roots(exc, visitor) };
+        unsafe { walk_in_flight_exception_area(c as *const _, visitor) };
     });
+}
+
+unsafe fn walk_in_flight_exception_area(
+    c: *const Cell<PyObjectRef>,
+    visitor: &mut dyn FnMut(&mut majit_ir::GcRef),
+) {
+    let c = unsafe { &*c };
+    let exc = c.get();
+    if exc.is_null() {
+        return;
+    }
+    // Forward the exception OBJECT slot itself. A GC-managed exception
+    // (oldgen-stable `w_exception_new_empty`) is marked here and the collector
+    // then recurses into its slots via offset tracing.
+    let slot = c.as_ptr();
+    unsafe { visitor(&mut *(slot as *mut majit_ir::GcRef)) };
+    // Off-GC fallback exceptions are malloc_typed, so explicitly trace their
+    // raw GC-managed children after forwarding the carrier itself.
+    let exc = unsafe { *(slot as *const PyObjectRef) };
+    unsafe { walk_raw_exception_roots(exc, visitor) };
 }
 
 /// Root the residual-call raise carried in the blackhole `BH_LAST_EXC_VALUE`
@@ -951,35 +969,25 @@ fn walk_in_flight_exception(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
 /// `0xDEAD` sentinel exists solely in a blackhole unit-test helper).
 fn walk_bh_last_exception(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
     majit_metainterp::blackhole::BH_LAST_EXC_VALUE.with(|c| {
-        if c.get() == 0 {
-            return;
-        }
-        // SAFETY: `slot` is the `Cell<i64>` interior, valid for this closure;
-        // the stored `i64` is a `PyObjectRef` bit-pattern, layout-compatible
-        // with `GcRef`. Forwarding through the slot relocates a (hypothetically)
-        // moving exception in place; the object is oldgen-stable today so only
-        // the mark takes effect.
-        let slot = c.as_ptr();
-        unsafe { visitor(&mut *(slot as *mut majit_ir::GcRef)) };
-        let exc = c.get() as PyObjectRef;
-        unsafe { walk_raw_exception_roots(exc, visitor) };
+        unsafe { walk_bh_last_exception_area(c as *const _, visitor) };
     });
 }
 
+unsafe fn walk_bh_last_exception_area(
+    c: *const Cell<i64>,
+    visitor: &mut dyn FnMut(&mut majit_ir::GcRef),
+) {
+    let c = unsafe { &*c };
+    if c.get() == 0 {
+        return;
+    }
+    let slot = c.as_ptr();
+    unsafe { visitor(&mut *(slot as *mut majit_ir::GcRef)) };
+    let exc = c.get() as PyObjectRef;
+    unsafe { walk_raw_exception_roots(exc, visitor) };
+}
+
 fn walk_global_prebuilt_roots(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
-    // The in-flight exception is a live stack root, not a prebuilt object;
-    // walk it on every collection, ahead of the prebuilt-dirty gate below.
-    walk_in_flight_exception(visitor);
-    // These exception-carrier walkers resolve their thread-local on the
-    // collecting thread, matching `walk_in_flight_exception`. Under the
-    // single-threaded (GIL) execution model the collecting thread is the only
-    // mutator, so that covers every live carrier. A pending carrier on another
-    // stopped mutator would need the per-mutator root-area mechanism
-    // (`register_mutator_extra_area`); migrating all exception carriers to it is
-    // the free-threading root-area work, deferred with the rest of the EXC set.
-    walk_bh_last_exception(visitor);
-    crate::call::walk_pending_call_error(visitor);
-    crate::baseobjspace::walk_pending_hash_error(visitor);
     // `reduce_protocol`'s app-level interphook handles are process-global
     // off-GC slots.  RPython stores them in the space's ordinary object graph;
     // expose the equivalent slots on every collection so both minor moves and
@@ -1002,6 +1010,16 @@ fn walk_global_prebuilt_roots(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
             walk_raw_getset_roots(*slot, visitor);
         };
         walk_builtin_type_dicts_gc(&mut forward);
+        // `space.fromcache(MethodCache)` is owned by the shared object space,
+        // not by an execution context. Trace its cached `(w_class, w_value)`
+        // slots once through the interpreter-global root walker.
+        crate::baseobjspace::walk_method_cache_gc(&mut forward);
+        // interp_codecs.CodecState is `space.fromcache(CodecState)` in PyPy:
+        // one process/interpreter-owned registry, not one copy per mutator.
+        crate::module::_codecs::walk_codec_state_gc(&mut forward);
+        // interp_posix.ApplevelForkCallbacks is another object-space cache.
+        #[cfg(not(target_arch = "wasm32"))]
+        crate::module::posix::interp_posix::walk_fork_callback_roots(&mut forward);
     }
     if is_minor {
         pyre_object::gc_roots::clear_prebuilt_roots_dirty();
@@ -1599,7 +1617,12 @@ pub(crate) fn eval_frame_plain_with_resume(
     }
     let execution_context =
         unsafe { &mut *(frame.execution_context as *mut crate::PyExecutionContext) };
-    crate::call::set_last_exec_ctx(frame.execution_context);
+    // executioncontext.py / threadlocals.py parity: the current
+    // ExecutionContext is owned by the OS-thread locals and is installed by
+    // thread bootstrap.  Entering an (including inlined) frame must not
+    // replace that thread-owned slot from a frame field; doing so lets a
+    // collapsed/stale translated frame identity poison every subsequent
+    // `space.getexecutioncontext()` lookup.
     execution_context.enter(frame as *mut PyFrame);
     let mut got_exception = true;
     let mut w_exitvalue = pyre_object::w_none();
@@ -1686,6 +1709,7 @@ fn eval_loop(frame: &mut PyFrame) -> PyResult {
     let mut next_instr = frame.next_instr();
 
     loop {
+        crate::module::thread::park_if_finalizing();
         // Interpreter-path GC safepoint (PYRE_GC_INTERP), mirroring the JIT
         // eval loop. Between opcodes the only live refs are in the frame,
         // reachable through the installed `current_frame` root walker; no
@@ -1694,6 +1718,12 @@ fn eval_loop(frame: &mut PyFrame) -> PyResult {
         // Without it, a JIT-off run reclaims interpreter-routed old-gen
         // allocations only at explicit `gc.collect`, so RSS grows unbounded.
         pyre_object::gc_interp::safepoint();
+        // Free-threaded stop-the-world rendezvous.  Worker threads deliberately
+        // execute this plain evaluator (their JitDriver state is thread-owned),
+        // so they must poll the same process breaker as compiled/JIT-warm
+        // loops; otherwise a non-allocating Python loop can prevent collection
+        // and fork/finalization STW forever.
+        majit_gc::gc_sync::safepoint_poll();
 
         if next_instr >= code.instructions.len() {
             return Ok(w_none());
@@ -2067,7 +2097,7 @@ impl NamespaceOpcodeHandler for PyFrame {
         // only the builtin `finditem_str` fallback below runs.  Positive
         // form (`load_attr_cached` eval.rs:3586) keeps the annotator off
         // the bare-`!` hazard; `we_are_jitted()` folds to `ConstBool(true)`
-        // so the cache arm and its `Rc<RefCell<GlobalCache>>` chase are
+        // so the cache arm and its `Arc<Mutex<GlobalCache>>` chase are
         // dead-code-eliminated on the lifted graph.
         let use_cache = if majit_metainterp::jit::we_are_jitted() {
             false
@@ -2167,7 +2197,7 @@ pub unsafe fn load_global_via_cache_extern(
 /// during the builtins fallback (`baseobjspace.py:45-49
 /// W_Root.getdictvalue` → `space.finditem_str`).
 ///
-/// The `GlobalCache` chase walks an `Rc<RefCell<GlobalCache>>` cache
+/// The `GlobalCache` chase walks an `Arc<Mutex<GlobalCache>>` cache
 /// structure the tracer cannot model (its `deref` reads past the
 /// refcount / borrow-flag header, not a value-model identity).
 /// `celldict.py:287-291 _LOAD_GLOBAL_cached` bypasses the whole cache
@@ -2184,7 +2214,8 @@ unsafe fn load_global_via_cache(
     nameindex: usize,
 ) -> Result<Option<PyObjectRef>, PyError> {
     use pyre_object::celldict::unwrap_cell;
-    use pyre_object::dictmultiobject::W_ModuleDictObject;
+    use pyre_object::dictmultiobject::{W_ModuleDictObject, w_dict_lock};
+    let _module_guard = w_dict_lock(w_module_dict);
     // Body is a chain of unsafe-fn / raw-ptr ops on caller-supplied
     // PyObjectRefs; SAFETY contract is on the `unsafe fn` signature
     // (caller upholds w_module_dict / pycode / w_builtin validity).
@@ -2215,14 +2246,14 @@ unsafe fn load_global_via_cache(
                 // which calls `_load_global` whose own fallback chain reads
                 // the frame's picked builtin via `space.finditem_str`.
                 let (cell_opt, valid, bc_opt) = {
-                    let c = cache.borrow();
+                    let c = cache.lock().unwrap();
                     (c.cell, c.valid, c.builtincache.clone())
                 };
                 if let Some(v) = cell_opt {
                     return Ok(Some(unwrap_cell(v)));
                 }
                 if valid && let Some(bc) = bc_opt {
-                    let bcell = bc.borrow().cell;
+                    let bcell = bc.lock().unwrap().cell;
                     if let Some(v) = bcell {
                         return Ok(Some(unwrap_cell(v)));
                     }
@@ -2262,7 +2293,7 @@ unsafe fn load_global_via_cache(
             crate::pycode::w_code_globals_caches_set(pycode, nameindex, &cache);
         }
         // `_LOAD_GLOBAL_cached` lines 296-298: cache.getvalue hit.
-        let cell_opt = cache.borrow().cell;
+        let cell_opt = cache.lock().unwrap().cell;
         if let Some(v) = cell_opt {
             return Ok(Some(unwrap_cell(v)));
         }

--- a/pyre/pyre-interpreter/src/executioncontext.rs
+++ b/pyre/pyre-interpreter/src/executioncontext.rs
@@ -361,10 +361,7 @@ impl ExecutionContext {
     /// walker.  PyPy reaches both through the process-owned object space;
     /// pyre stores movable GC refs directly on the EC and must forward those
     /// fields in place.
-    pub(crate) fn walk_builtin_roots(
-        &mut self,
-        visitor: &mut dyn FnMut(&mut majit_ir::GcRef),
-    ) {
+    pub(crate) fn walk_builtin_roots(&mut self, visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
         visitor(unsafe {
             &mut *(&mut self.builtins_module as *mut PyObjectRef as *mut majit_ir::GcRef)
         });
@@ -617,8 +614,7 @@ impl ExecutionContext {
             let w_async_exception_type =
                 crate::module::thread::take_async_exception(self as *mut ExecutionContext);
             if !w_async_exception_type.is_null() {
-                let w_exc =
-                    crate::builtins::exc_exception_new(&[w_async_exception_type])?;
+                let w_exc = crate::builtins::exc_exception_new(&[w_async_exception_type])?;
                 return Err(unsafe { crate::PyError::from_exc_object(w_exc) });
             }
         }

--- a/pyre/pyre-interpreter/src/executioncontext.rs
+++ b/pyre/pyre-interpreter/src/executioncontext.rs
@@ -215,6 +215,13 @@ pub struct ExecutionContext {
     pub w_profilefuncarg: PyObjectRef,
     pub thread_disappeared: bool,
     pub w_async_exception_type: PyObjectRef,
+    /// Last process-wide all-threads hook generations applied by this EC.
+    /// Only the owning OS thread writes these fields.
+    pub trace_all_generation: usize,
+    pub profile_all_generation: usize,
+    /// `os_local.py:ExecutionContext._thread_local_objs`: weak references to
+    /// `_thread._local` objects which own a dictionary for this EC.
+    pub thread_local_refs: Vec<PyObjectRef>,
     pub actionflag: ActionFlag,
     /// `space.user_del_action`, allocated after the ExecutionContext reaches
     /// its stable process-lifetime address.
@@ -304,6 +311,9 @@ impl ExecutionContext {
             w_profilefuncarg: pyre_object::PY_NULL,
             thread_disappeared: false,
             w_async_exception_type: pyre_object::PY_NULL,
+            trace_all_generation: 0,
+            profile_all_generation: 0,
+            thread_local_refs: Vec::new(),
             actionflag: ActionFlag::new(),
             user_del_action: std::ptr::null_mut(),
             builtins_module,
@@ -314,6 +324,54 @@ impl ExecutionContext {
             current_gen_or_coroutine: pyre_object::PY_NULL,
             w_asyncgen_firstiter_fn: pyre_object::PY_NULL,
             w_asyncgen_finalizer_fn: pyre_object::PY_NULL,
+        }
+    }
+
+    /// `OSThreadLocals.enter_thread()` / `ExecutionContext(space)` parity.
+    ///
+    /// Interpreter-wide objects (the object space and builtins module) remain
+    /// shared, while frame, exception, tracing, profiling, generator, and
+    /// action state starts fresh for each OS thread.
+    pub fn clone_for_thread(&self) -> Self {
+        let mut ec = self.clone();
+        ec.topframeref = std::ptr::null_mut();
+        ec.w_tracefunc = pyre_object::PY_NULL;
+        ec.is_tracing = 0;
+        ec.profilefunc = None;
+        ec.w_profilefuncarg = pyre_object::PY_NULL;
+        ec.thread_disappeared = false;
+        ec.w_async_exception_type = pyre_object::PY_NULL;
+        ec.trace_all_generation = 0;
+        ec.profile_all_generation = 0;
+        ec.thread_local_refs.clear();
+        ec.actionflag = ActionFlag::new();
+        ec.user_del_action = std::ptr::null_mut();
+        // The cached Module wrapper is execution-context-owned and movable.
+        // A new thread lazily builds its own wrapper over the shared
+        // builtins_module, matching a fresh PyPy ExecutionContext.
+        ec.builtin_dict_cache = std::cell::Cell::new(pyre_object::PY_NULL);
+        ec.sys_exc_value = pyre_object::PY_NULL;
+        ec.current_gen_or_coroutine = pyre_object::PY_NULL;
+        ec.w_asyncgen_firstiter_fn = pyre_object::PY_NULL;
+        ec.w_asyncgen_finalizer_fn = pyre_object::PY_NULL;
+        ec
+    }
+
+    /// Expose the two builtin-owner slots to the translated shadow-stack root
+    /// walker.  PyPy reaches both through the process-owned object space;
+    /// pyre stores movable GC refs directly on the EC and must forward those
+    /// fields in place.
+    pub(crate) fn walk_builtin_roots(
+        &mut self,
+        visitor: &mut dyn FnMut(&mut majit_ir::GcRef),
+    ) {
+        visitor(unsafe {
+            &mut *(&mut self.builtins_module as *mut PyObjectRef as *mut majit_ir::GcRef)
+        });
+        let cache = self.builtin_dict_cache.as_ptr();
+        visitor(unsafe { &mut *(cache as *mut majit_ir::GcRef) });
+        for wref in &mut self.thread_local_refs {
+            visitor(unsafe { &mut *(wref as *mut PyObjectRef as *mut majit_ir::GcRef) });
         }
     }
 
@@ -554,6 +612,16 @@ impl ExecutionContext {
         frame: *mut PyFrame,
         decr_by: usize,
     ) -> Result<(), crate::PyError> {
+        crate::module::thread::apply_all_thread_hooks(self)?;
+        if majit_ir::eval_breaker_word::load() & majit_ir::eval_breaker_word::EB_ASYNC != 0 {
+            let w_async_exception_type =
+                crate::module::thread::take_async_exception(self as *mut ExecutionContext);
+            if !w_async_exception_type.is_null() {
+                let w_exc =
+                    crate::builtins::exc_exception_new(&[w_async_exception_type])?;
+                return Err(unsafe { crate::PyError::from_exc_object(w_exc) });
+            }
+        }
         // executioncontext.py:158-165 bytecode_trace:
         //   def bytecode_trace(self, frame, decr_by=TICK_COUNTER_STEP):
         //       self.bytecode_only_trace(frame)
@@ -1626,7 +1694,9 @@ impl ActionFlagOps for ActionFlag {
             if value < 0 {
                 majit_ir::eval_breaker_word::set_async();
             } else {
-                majit_ir::eval_breaker_word::clear_async();
+                if !crate::module::thread::has_pending_async_exception() {
+                    majit_ir::eval_breaker_word::clear_async();
+                }
                 // A signal delivered between the ticker store and this clear
                 // rearms the ticker to -1 and re-sets the async bit; the clear
                 // would then drop it, leaving a negative ticker with the bit

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -1711,11 +1711,7 @@ pub fn set_sys_modules_dict(dict: PyObjectRef) {
     // Populate with all modules already in the cache.
     for (name, &module) in SYS_MODULES.lock().unwrap().iter() {
         unsafe {
-            pyre_object::w_dict_store(
-                dict,
-                pyre_object::w_str_new(name),
-                module as PyObjectRef,
-            );
+            pyre_object::w_dict_store(dict, pyre_object::w_str_new(name), module as PyObjectRef);
         }
     }
 }
@@ -2521,10 +2517,7 @@ fn load_part(
     // `importlib.machinery` can override the filesystem search.
     // PyPy: interp_import.importhook consults sys.builtin_module_names by
     // the fully-qualified name.
-    let full_is_builtin = BUILTIN_MODULES
-        .lock()
-        .unwrap()
-        .contains_key(modulename);
+    let full_is_builtin = BUILTIN_MODULES.lock().unwrap().contains_key(modulename);
     if full_is_builtin {
         // `pypy/interpreter/module.py:18 Module.__init__` keeps a single
         // `Module` per imported module name; `space.builtin` IS the

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -10,7 +10,10 @@
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicBool, AtomicI64, Ordering};
+use std::sync::{
+    LazyLock, Mutex,
+    atomic::{AtomicBool, AtomicI64, AtomicUsize, Ordering},
+};
 // `Path` is used only by the host_env source/package loaders; keep it gated
 // so an host_env-off build does not warn on an unused import. `PathBuf`
 // appears in the host_env-independent module-search surface
@@ -351,27 +354,36 @@ pub fn mount_embedded_stdlib(mount: &Path) {
 }
 
 // ── sys.modules cache ────────────────────────────────────────────────
-// PyPy equivalent: space.sys.get('modules') — a dict mapping module names
-// to module objects. We use a thread-local HashMap<String, PyObjectRef>.
+// PyPy equivalent: `space.sys.get('modules')`, `space.sys.path`, and
+// `space.builtin_modules` are object-space/process state, shared by every
+// ExecutionContext.  Raw GC references use the established process-global
+// `usize` representation; the GIL serializes semantic access while the mutex
+// also makes foreign STW root walks well-defined.
+static SYS_MODULES: LazyLock<Mutex<HashMap<String, usize>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+static SYS_MODULES_DICT: AtomicUsize = AtomicUsize::new(0);
+#[cfg(feature = "host_env")]
+static SYS_PATH: LazyLock<Mutex<Vec<PathBuf>>> = LazyLock::new(|| Mutex::new(Vec::new()));
+/// The directory prepended to `sys.path` at startup (`config->sys_path_0`):
+/// the script's directory, or the cwd for `-c` / `-m`.  Captured once by
+/// `init_sys_path`; read by the shadowing check, which must not see later
+/// `sys.path` mutations.  PyPy records this on interpreter/import state, not
+/// on an OS thread: import shadowing decisions made by free-threaded workers
+/// must observe the startup path captured by the launcher.
+static SYS_PATH_0: LazyLock<Mutex<Option<String>>> = LazyLock::new(|| Mutex::new(None));
+/// The literal `sys.path[0]` entry staged by `init_sys_path` and prepended
+/// by `add_sys_path_0` once `site` has run (`pymain_sys_path_add_path0`):
+/// `""` for `-c` / stdin / the REPL, the cwd for `-m`, the script's
+/// directory for a script.  `None` under `-P`, and taken on first insert so
+/// the `-i` REPL-after-script path does not prepend it twice.  Process-global
+/// for the same reason as `SYS_PATH_0`: the launcher stages it and whichever
+/// thread runs the insert must observe that staging.
+static SYS_PATH_0_PENDING: LazyLock<Mutex<Option<String>>> = LazyLock::new(|| Mutex::new(None));
+pub(crate) static BUILTIN_MODULES: LazyLock<Mutex<HashMap<&'static str, BuiltinModuleDef>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
 
 thread_local! {
-    static SYS_MODULES: RefCell<HashMap<String, PyObjectRef>> = RefCell::new(HashMap::new());
-    /// The Python-visible `sys.modules` dict. Kept in sync with SYS_MODULES
-    /// so that `sys.modules['name']` lookups work from Python code.
-    static SYS_MODULES_DICT: std::cell::Cell<PyObjectRef> = const { std::cell::Cell::new(pyre_object::PY_NULL) };
-    /// sys.path equivalent — list of directories to search for modules.
-    #[cfg(feature = "host_env")]
-    static SYS_PATH: RefCell<Vec<PathBuf>> = RefCell::new(Vec::new());
-    /// Builtin modules registry — PyPy equivalent: space.builtin_modules
-    ///
-    /// Maps module name → initializer function that populates a GC module dict.
-    /// Each builtin module is lazily created on first import.
-    pub(crate) static BUILTIN_MODULES: RefCell<HashMap<&'static str, BuiltinModuleDef>> =
-        RefCell::new(HashMap::new());
-
     static IMPORT_ROOT_AREA: ImportRootArea = ImportRootArea {
-        modules: SYS_MODULES.with(|modules| modules as *const _),
-        modules_dict: SYS_MODULES_DICT.with(|dict| dict as *const _),
         argv_pending: SYS_ARGV_PENDING.with(|p| p as *const _),
     };
 }
@@ -383,8 +395,6 @@ pub(crate) struct BuiltinModuleDef {
 }
 
 struct ImportRootArea {
-    modules: *const RefCell<HashMap<String, PyObjectRef>>,
-    modules_dict: *const std::cell::Cell<PyObjectRef>,
     /// The pending `sys.argv` list is reachable only from this cell between
     /// `set_sys_argv` and `take_pending_sys_argv`.
     argv_pending: *const std::cell::Cell<PyObjectRef>,
@@ -410,15 +420,13 @@ struct ImportRootArea {
 ///
 /// PyPy equivalent: Module.install() → space.builtin_modules[name] = mod
 pub fn register_builtin_module(name: &'static str, init: fn(PyObjectRef)) {
-    BUILTIN_MODULES.with(|m| {
-        m.borrow_mut().insert(
-            name,
-            BuiltinModuleDef {
-                init,
-                startup: None,
-            },
-        );
-    });
+    BUILTIN_MODULES.lock().unwrap().insert(
+        name,
+        BuiltinModuleDef {
+            init,
+            startup: None,
+        },
+    );
 }
 
 /// Register a MixedModule initializer plus its `Module.startup` hook.
@@ -429,15 +437,13 @@ pub fn register_builtin_module_with_startup(
     init: fn(PyObjectRef),
     startup: fn(PyObjectRef, *const PyExecutionContext) -> Result<(), crate::PyError>,
 ) {
-    BUILTIN_MODULES.with(|m| {
-        m.borrow_mut().insert(
-            name,
-            BuiltinModuleDef {
-                init,
-                startup: Some(startup),
-            },
-        );
-    });
+    BUILTIN_MODULES.lock().unwrap().insert(
+        name,
+        BuiltinModuleDef {
+            init,
+            startup: Some(startup),
+        },
+    );
 }
 
 /// The registered builtin module names, for `sys.builtin_module_names`.
@@ -450,16 +456,15 @@ pub fn register_builtin_module_with_startup(
 /// Dotted keys (`importlib.machinery`, `__pypy__.builders`) are registry
 /// entries for submodules, not top-level modules, so they are left out.
 pub fn builtin_module_names() -> Vec<&'static str> {
-    BUILTIN_MODULES.with(|m| {
-        let mut names: Vec<&'static str> = m
-            .borrow()
-            .keys()
-            .copied()
-            .filter(|name| !name.contains('.'))
-            .collect();
-        names.sort_unstable();
-        names
-    })
+    let mut names: Vec<&'static str> = BUILTIN_MODULES
+        .lock()
+        .unwrap()
+        .keys()
+        .copied()
+        .filter(|name| !name.contains('.'))
+        .collect();
+    names.sort_unstable();
+    names
 }
 
 /// Install all standard builtin modules.
@@ -887,7 +892,7 @@ fn init_sysconfigdata_empty(ns: PyObjectRef) {
 /// `allocate_and_init_instance(module=True)`. Pyre mirrors that here:
 /// the initializer writes directly into a rooted, non-moving module dict.
 pub(crate) fn load_builtin_module(name: &str) -> Option<PyObjectRef> {
-    let module_def = BUILTIN_MODULES.with(|m| m.borrow().get(name).copied())?;
+    let module_def = BUILTIN_MODULES.lock().unwrap().get(name).copied()?;
     let w_dict = pyre_object::dictmultiobject::w_module_dict_new();
     let _roots = pyre_object::gc_roots::push_roots();
     let save_point = pyre_object::gc_roots::shadow_stack_len();
@@ -1137,7 +1142,11 @@ fn startup_builtin_module(
     let mod_slot = shadow_stack_len();
     pin_root(module);
 
-    let startup = BUILTIN_MODULES.with(|m| m.borrow().get(name).and_then(|d| d.startup));
+    let startup = BUILTIN_MODULES
+        .lock()
+        .unwrap()
+        .get(name)
+        .and_then(|d| d.startup);
     if let Some(startup) = startup {
         startup(shadow_stack_get(mod_slot), execution_context)?;
     }
@@ -1178,20 +1187,16 @@ pub fn init_sys_path(script_dir: &Path, path0: &str) {
     // code can mutate `sys.path`.  Module origins are absolute canonical paths,
     // so store the canonical absolute form here for the directory comparison to
     // hold for a relative script argument or a symlinked working directory.
-    SYS_PATH_0.with(|p| {
-        *p.borrow_mut() = Some(canonical_startup_dir(script_dir));
-    });
+    *SYS_PATH_0.lock().unwrap() = Some(canonical_startup_dir(script_dir));
 
     // `pymain_run_python` prepends `sys.path[0]` only after `site` has run, so
     // `site.removeduppaths()` never absolutizes the `-c` / REPL empty entry into
     // the cwd.  Stage the entry here; `add_sys_path_0` performs the insert.
     // `-P` (safe_path) suppresses it entirely.
-    SYS_PATH_0_PENDING.with(|p| {
-        *p.borrow_mut() = (!safe_path_flag()).then(|| path0.to_string());
-    });
+    *SYS_PATH_0_PENDING.lock().unwrap() = (!safe_path_flag()).then(|| path0.to_string());
 
-    SYS_PATH.with(|p| {
-        let mut path = p.borrow_mut();
+    {
+        let mut path = SYS_PATH.lock().unwrap();
         path.clear();
         // PYTHONPATH entries head the seed and precede the stdlib
         // (pathconfig.c), split on the platform path-list separator.  Honoured
@@ -1213,7 +1218,7 @@ pub fn init_sys_path(script_dir: &Path, path0: &str) {
         // The stdlib entry is appended when the `sys` module is created —
         // `create_sys_path_list` forces `ensure_stdlib_path` before flushing
         // this seed into `sys.path`.
-    });
+    }
 }
 
 /// Locate the vendored stdlib (`lib-python/3`) by walking up the running
@@ -1303,13 +1308,13 @@ pub fn add_sys_path(dir: &Path) {
 
     let entry = dir.to_string_lossy();
     if get_sys_module("sys").is_none() {
-        SYS_PATH.with(|p| {
-            let mut path = p.borrow_mut();
+        {
+            let mut path = SYS_PATH.lock().unwrap();
             let pb = dir.to_path_buf();
             if !path.contains(&pb) {
                 path.push(pb);
             }
-        });
+        }
         return;
     }
     // Pin the new entry before any further allocation (`get_sys_module` and the
@@ -1352,13 +1357,13 @@ pub fn add_sys_path(dir: &Path) {
 pub fn add_sys_path_0() {
     use pyre_object::gc_roots::{pin_root, push_roots, shadow_stack_get, shadow_stack_len};
 
-    let Some(entry) = SYS_PATH_0_PENDING.with(|p| p.borrow_mut().take()) else {
+    let Some(entry) = SYS_PATH_0_PENDING.lock().unwrap().take() else {
         return;
     };
     // No `sys` yet (an embedder that never imports `site`): stage at the front
     // of the seed instead, which `create_sys_path_list` flushes in order.
     if get_sys_module("sys").is_none() {
-        SYS_PATH.with(|p| p.borrow_mut().insert(0, PathBuf::from(&entry)));
+        SYS_PATH.lock().unwrap().insert(0, PathBuf::from(&entry));
         return;
     }
     // Pin the new entry before any further allocation (`get_sys_module` and the
@@ -1390,7 +1395,7 @@ pub(crate) fn check_sys_modules(name: &str) -> Option<PyObjectRef> {
     // writing `sys.modules['foo'] = mod` is immediately visible to imports.
     // PyPy: importing.py check_sys_modules reads space.sys.get('modules').
     let key = pyre_object::w_str_new(name);
-    let dict = SYS_MODULES_DICT.with(|d| d.get());
+    let dict = SYS_MODULES_DICT.load(Ordering::Acquire) as PyObjectRef;
     if !dict.is_null() {
         if let Some(m) = unsafe { pyre_object::w_dict_lookup(dict, key) } {
             if !m.is_null() && !unsafe { pyre_object::is_none(m) } {
@@ -1398,7 +1403,12 @@ pub(crate) fn check_sys_modules(name: &str) -> Option<PyObjectRef> {
             }
         }
     }
-    SYS_MODULES.with(|m| m.borrow().get(name).copied())
+    SYS_MODULES
+        .lock()
+        .unwrap()
+        .get(name)
+        .copied()
+        .map(|module| module as PyObjectRef)
 }
 
 /// Whether `sys.modules[name]` is bound to `None`, the sentinel that marks
@@ -1414,7 +1424,7 @@ fn sys_modules_blocks(name: &str) -> bool {
     // uses: reading the thread-local last keeps the borrow off the stack
     // across the allocation.
     let key = pyre_object::w_str_new(name);
-    let dict = SYS_MODULES_DICT.with(|d| d.get());
+    let dict = SYS_MODULES_DICT.load(Ordering::Acquire) as PyObjectRef;
     if dict.is_null() {
         return false;
     }
@@ -1434,25 +1444,24 @@ pub fn get_sys_module(name: &str) -> Option<PyObjectRef> {
 /// installed. Used by callers that need to iterate every loaded module
 /// (e.g. pickle's `whichmodule` scan).
 pub fn sys_modules_dict() -> PyObjectRef {
-    SYS_MODULES_DICT.with(|d| d.get())
+    SYS_MODULES_DICT.load(Ordering::Acquire) as PyObjectRef
 }
 
 pub fn set_sys_module(name: &str, module: PyObjectRef) {
     // A new module joins the `walk_module_dicts_gc` root set; its dict
     // may hold young values — rescan on the next minor collection.
     pyre_object::gc_roots::mark_prebuilt_roots_dirty();
-    SYS_MODULES.with(|m| {
-        m.borrow_mut().insert(name.to_string(), module);
-    });
+    SYS_MODULES
+        .lock()
+        .unwrap()
+        .insert(name.to_string(), module as usize);
     // Keep the Python-visible sys.modules dict in sync.
-    SYS_MODULES_DICT.with(|d| {
-        let dict = d.get();
-        if !dict.is_null() {
-            unsafe {
-                pyre_object::w_dict_store(dict, pyre_object::w_str_new(name), module);
-            }
+    let dict = SYS_MODULES_DICT.load(Ordering::Acquire) as PyObjectRef;
+    if !dict.is_null() {
+        unsafe {
+            pyre_object::w_dict_store(dict, pyre_object::w_str_new(name), module);
         }
-    });
+    }
 }
 
 /// Remove a (partially initialised) module from `sys.modules`.
@@ -1463,17 +1472,13 @@ pub fn set_sys_module(name: &str, module: PyObjectRef) {
 /// `import ssl` (missing `_ssl`) leaves a broken `ssl` shell behind, and
 /// the next `import ssl` succeeds with no `SSLWantReadError`, etc.
 pub fn remove_sys_module(name: &str) {
-    SYS_MODULES.with(|m| {
-        m.borrow_mut().remove(name);
-    });
-    SYS_MODULES_DICT.with(|d| {
-        let dict = d.get();
-        if !dict.is_null() {
-            unsafe {
-                pyre_object::w_dict_delitem_str(dict, name);
-            }
+    SYS_MODULES.lock().unwrap().remove(name);
+    let dict = SYS_MODULES_DICT.load(Ordering::Acquire) as PyObjectRef;
+    if !dict.is_null() {
+        unsafe {
+            pyre_object::w_dict_delitem_str(dict, name);
         }
-    });
+    }
 }
 
 /// GC root walk over every loaded module's dict storage.
@@ -1495,8 +1500,9 @@ pub fn remove_sys_module(name: &str) {
 /// `visitor` must tolerate being called on every movable module-dict
 /// value slot reachable here.
 pub unsafe fn walk_module_dicts_gc(visitor: &mut dyn FnMut(&mut PyObjectRef)) {
-    SYS_MODULES.with(|m| {
-        for &module in m.borrow().values() {
+    {
+        for &module in SYS_MODULES.lock().unwrap().values() {
+            let module = module as PyObjectRef;
             if module.is_null() || !unsafe { pyre_object::is_module(module) } {
                 continue;
             }
@@ -1507,7 +1513,7 @@ pub unsafe fn walk_module_dicts_gc(visitor: &mut dyn FnMut(&mut PyObjectRef)) {
                 pyre_object::dictmultiobject::w_module_dict_walk_gc_cells(w_dict, visitor);
             }
         }
-    });
+    }
 }
 
 /// Forward the `sys.modules` dict pointer cached in `SYS_MODULES_DICT`.
@@ -1524,14 +1530,12 @@ pub unsafe fn walk_module_dicts_gc(visitor: &mut dyn FnMut(&mut PyObjectRef)) {
 /// # Safety
 /// `visitor` must tolerate a non-nursery or already-forwarded pointer.
 pub unsafe fn walk_sys_modules_dict_gc(visitor: &mut dyn FnMut(&mut PyObjectRef)) {
-    SYS_MODULES_DICT.with(|d| {
-        let mut dict = d.get();
-        if dict.is_null() {
-            return;
-        }
-        visitor(&mut dict);
-        d.set(dict);
-    });
+    let mut dict = SYS_MODULES_DICT.load(Ordering::Acquire) as PyObjectRef;
+    if dict.is_null() {
+        return;
+    }
+    visitor(&mut dict);
+    SYS_MODULES_DICT.store(dict as usize, Ordering::Release);
 }
 
 pub(crate) fn capture_import_root_area() -> *const () {
@@ -1546,10 +1550,11 @@ pub(crate) unsafe fn walk_import_roots_area(
     visitor: &mut dyn FnMut(&mut PyObjectRef),
 ) {
     let area = unsafe { &*(data as *const ImportRootArea) };
-    // SAFETY: the owning thread is quiesced for this foreign root walk, so the
-    // modules map is stable even if it parked with the RefCell borrow flag set.
-    let modules = unsafe { &*(*area.modules).as_ptr() };
-    for &module in modules.values() {
+    // `space.sys.modules` is process-owned in PyPy.  STW has quiesced every
+    // mutator, so the process-global cache cannot be semantically mutated
+    // while this walk holds its native lock.
+    for &module in SYS_MODULES.lock().unwrap().values() {
+        let module = module as PyObjectRef;
         if module.is_null() || !unsafe { pyre_object::is_module(module) } {
             continue;
         }
@@ -1560,11 +1565,10 @@ pub(crate) unsafe fn walk_import_roots_area(
             pyre_object::dictmultiobject::w_module_dict_walk_gc_cells(w_dict, visitor);
         }
     }
-    let modules_dict = unsafe { &*area.modules_dict };
-    let mut dict = modules_dict.get();
+    let mut dict = SYS_MODULES_DICT.load(Ordering::Acquire) as PyObjectRef;
     if !dict.is_null() {
         visitor(&mut dict);
-        modules_dict.set(dict);
+        SYS_MODULES_DICT.store(dict as usize, Ordering::Release);
     }
     let argv_pending = unsafe { &*area.argv_pending };
     let mut argv = argv_pending.get();
@@ -1590,17 +1594,6 @@ pub fn set_sys_argv(args: &[String]) {
 thread_local! {
     static SYS_ARGV_PENDING: std::cell::Cell<pyre_object::PyObjectRef> =
         const { std::cell::Cell::new(pyre_object::PY_NULL) };
-    /// The directory prepended to `sys.path` at startup (`config->sys_path_0`):
-    /// the script's directory, or the cwd for `-c` / `-m`.  Captured once by
-    /// `init_sys_path`; read by the shadowing check, which must not see later
-    /// `sys.path` mutations.
-    static SYS_PATH_0: RefCell<Option<String>> = const { RefCell::new(None) };
-    /// The literal `sys.path[0]` entry staged by `init_sys_path` and prepended
-    /// by `add_sys_path_0` once `site` has run (`pymain_sys_path_add_path0`):
-    /// `""` for `-c` / stdin / the REPL, the cwd for `-m`, the script's
-    /// directory for a script.  `None` under `-P`, and taken on first insert so
-    /// the `-i` REPL-after-script path does not prepend it twice.
-    static SYS_PATH_0_PENDING: RefCell<Option<String>> = const { RefCell::new(None) };
 }
 
 // The launcher flags belong to the interpreter, not to whichever thread
@@ -1714,15 +1707,17 @@ pub fn set_sys_modules_dict(dict: PyObjectRef) {
     // The fast-path cell walked by `walk_sys_modules_dict_gc` now holds
     // a possibly-young dict; rescan on the next minor collection.
     pyre_object::gc_roots::mark_prebuilt_roots_dirty();
-    SYS_MODULES_DICT.with(|d| d.set(dict));
+    SYS_MODULES_DICT.store(dict as usize, Ordering::Release);
     // Populate with all modules already in the cache.
-    SYS_MODULES.with(|m| {
-        for (name, &module) in m.borrow().iter() {
-            unsafe {
-                pyre_object::w_dict_store(dict, pyre_object::w_str_new(name), module);
-            }
+    for (name, &module) in SYS_MODULES.lock().unwrap().iter() {
+        unsafe {
+            pyre_object::w_dict_store(
+                dict,
+                pyre_object::w_str_new(name),
+                module as PyObjectRef,
+            );
         }
-    });
+    }
 }
 
 // ── find_module ──────────────────────────────────────────────────────
@@ -1758,7 +1753,7 @@ fn find_module(partname: &str, parent_dirs: Option<&[PathBuf]>) -> Option<FindIn
     }
 
     // Check builtin modules first (PyPy: space.builtin_modules check in find_module)
-    let is_builtin = BUILTIN_MODULES.with(|m| m.borrow().contains_key(partname));
+    let is_builtin = BUILTIN_MODULES.lock().unwrap().contains_key(partname);
     if is_builtin {
         return Some(FindInfo::Builtin);
     }
@@ -1786,7 +1781,7 @@ fn find_module(partname: &str, parent_dirs: Option<&[PathBuf]>) -> Option<FindIn
     if let Some(dirs) = parent_dirs {
         return find_in_dirs(partname, dirs);
     }
-    let is_builtin = BUILTIN_MODULES.with(|m| m.borrow().contains_key(partname));
+    let is_builtin = BUILTIN_MODULES.lock().unwrap().contains_key(partname);
     if is_builtin {
         return Some(FindInfo::Builtin);
     }
@@ -1795,7 +1790,7 @@ fn find_module(partname: &str, parent_dirs: Option<&[PathBuf]>) -> Option<FindIn
 
 #[cfg(not(feature = "host_env"))]
 fn find_module(partname: &str, _parent_dirs: Option<&[PathBuf]>) -> Option<FindInfo> {
-    let is_builtin = BUILTIN_MODULES.with(|m| m.borrow().contains_key(partname));
+    let is_builtin = BUILTIN_MODULES.lock().unwrap().contains_key(partname);
     if is_builtin {
         return Some(FindInfo::Builtin);
     }
@@ -1912,10 +1907,16 @@ fn find_in_sys_path(partname: &str) -> Option<FindInfo> {
             // at startup. Until the `nt` registration lands, a live-list miss
             // falls back to the native seed so the stdlib stays importable.
             #[cfg(windows)]
-            let found = found.or_else(|| SYS_PATH.with(|p| find_in_dirs(partname, &p.borrow())));
+            let found = found.or_else(|| {
+                let path = SYS_PATH.lock().unwrap();
+                find_in_dirs(partname, &path)
+            });
             found
         }
-        None => SYS_PATH.with(|p| find_in_dirs(partname, &p.borrow())),
+        None => {
+            let path = SYS_PATH.lock().unwrap();
+            find_in_dirs(partname, &path)
+        }
     }
 }
 
@@ -1934,12 +1935,12 @@ fn find_in_sys_path(partname: &str) -> Option<FindInfo> {
 pub(crate) fn create_sys_path_list() -> PyObjectRef {
     #[cfg(not(target_arch = "wasm32"))]
     ensure_stdlib_path();
-    let items: Vec<PyObjectRef> = SYS_PATH.with(|p| {
-        p.borrow()
-            .iter()
-            .map(|d| pyre_object::w_str_new(&d.to_string_lossy()))
-            .collect()
-    });
+    let items: Vec<PyObjectRef> = SYS_PATH
+        .lock()
+        .unwrap()
+        .iter()
+        .map(|d| pyre_object::w_str_new(&d.to_string_lossy()))
+        .collect();
     pyre_object::w_list_new(items)
 }
 
@@ -2520,7 +2521,10 @@ fn load_part(
     // `importlib.machinery` can override the filesystem search.
     // PyPy: interp_import.importhook consults sys.builtin_module_names by
     // the fully-qualified name.
-    let full_is_builtin = BUILTIN_MODULES.with(|m| m.borrow().contains_key(modulename));
+    let full_is_builtin = BUILTIN_MODULES
+        .lock()
+        .unwrap()
+        .contains_key(modulename);
     if full_is_builtin {
         // `pypy/interpreter/module.py:18 Module.__init__` keeps a single
         // `Module` per imported module name; `space.builtin` IS the
@@ -3366,7 +3370,7 @@ pub(crate) fn is_possibly_shadowing(origin: &str) -> bool {
     if safe_path_flag() {
         return false;
     }
-    let Some(sys_path_0) = SYS_PATH_0.with(|p| p.borrow().clone()) else {
+    let Some(sys_path_0) = SYS_PATH_0.lock().unwrap().clone() else {
         return false;
     };
     let sep = std::path::MAIN_SEPARATOR;

--- a/pyre/pyre-interpreter/src/lib.rs
+++ b/pyre/pyre-interpreter/src/lib.rs
@@ -965,6 +965,7 @@ pub fn all_subclass_range_aliases() -> Vec<pyre_object::pyobject::SubclassRangeA
         subclass_range_alias(137, typed::<crate::module::_io::W_BufferedRWPair>()),
         subclass_range_alias(138, typed::<crate::module::_io::W_BufferedRandom>()),
         subclass_range_alias(139, typed::<crate::module::_io::W_TextIOWrapper>()),
+        subclass_range_alias(140, typed::<crate::module::thread::W_Local>()),
     ]
 }
 

--- a/pyre/pyre-interpreter/src/module/imp/interp_imp.rs
+++ b/pyre/pyre-interpreter/src/module/imp/interp_imp.rs
@@ -460,7 +460,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 // not yet imported, -1 = a builtin already in sys.modules and
                 // thus not re-initializable (sys/builtins and any other
                 // already-imported builtin).
-                let is_builtin = BUILTIN_MODULES.with(|m| m.borrow().contains_key(name));
+                let is_builtin = BUILTIN_MODULES.lock().unwrap().contains_key(name);
                 let result = if !is_builtin {
                     0
                 } else if crate::importing::check_sys_modules(name).is_some() {

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -6,10 +6,129 @@
 
 use crate::importing::host::{fs as host_fs, os as host_os};
 use pyre_object::PyObjectRef;
+use std::sync::{LazyLock, Mutex};
 // Under sandbox, name libc through the seam facade so any direct syscall call
 // in this module is a compile error (only types/constants/pure fns resolve).
 #[cfg(feature = "sandbox")]
 use crate::host_seam::sys as libc;
+
+/// PyPy `ApplevelForkCallbacks`, cached on the object space.
+///
+/// The callback collections are RPython lists, so use insertion-ordered Vecs;
+/// this is process/interpreter state, never TLS.
+#[derive(Default)]
+struct ApplevelForkCallbacks {
+    before_w: Vec<usize>,
+    parent_w: Vec<usize>,
+    child_w: Vec<usize>,
+}
+
+static APPLEVEL_FORK_CALLBACKS: LazyLock<Mutex<ApplevelForkCallbacks>> =
+    LazyLock::new(|| Mutex::new(ApplevelForkCallbacks::default()));
+// PyPy's GIL serializes concurrent fork entry.  Pyre is free-threaded, so the
+// corresponding process operation has its own narrow serializer.
+static FORK_SERIALIZER: Mutex<()> = Mutex::new(());
+
+pub(crate) fn walk_fork_callback_roots(visitor: &mut dyn FnMut(&mut PyObjectRef)) {
+    let mut callbacks = APPLEVEL_FORK_CALLBACKS.lock().unwrap();
+    let ApplevelForkCallbacks {
+        before_w,
+        parent_w,
+        child_w,
+    } = &mut *callbacks;
+    for callbacks in [
+        before_w,
+        parent_w,
+        child_w,
+    ] {
+        for callback in callbacks {
+            visitor(unsafe { &mut *(callback as *mut usize as *mut PyObjectRef) });
+        }
+    }
+}
+
+fn run_fork_callbacks(kind: &str) {
+    let reverse = kind == "before";
+    let initial_len = {
+        let callbacks = APPLEVEL_FORK_CALLBACKS.lock().unwrap();
+        match kind {
+            "before" => callbacks.before_w.len(),
+            "parent" => callbacks.parent_w.len(),
+            "child" => callbacks.child_w.len(),
+            _ => unreachable!(),
+        }
+    };
+    let indices: Box<dyn Iterator<Item = usize>> = if reverse {
+        Box::new((0..initial_len).rev())
+    } else {
+        Box::new(0..initial_len)
+    };
+    for index in indices {
+        let callback = {
+            let callbacks = APPLEVEL_FORK_CALLBACKS.lock().unwrap();
+            match kind {
+                "before" => callbacks.before_w.get(index),
+                "parent" => callbacks.parent_w.get(index),
+                "child" => callbacks.child_w.get(index),
+                _ => unreachable!(),
+            }
+            .copied()
+        };
+        let Some(callback) = callback else { continue };
+        if let Err(mut error) =
+            crate::call::call_function_impl_result(callback as PyObjectRef, &[])
+        {
+            error.write_unraisable(pyre_object::w_none(), "fork hook", callback as PyObjectRef);
+        }
+    }
+}
+
+fn register_at_fork(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let (pos, kwargs) = crate::builtins::split_builtin_kwargs(args);
+    if !pos.is_empty() {
+        return Err(crate::PyError::type_error(
+            "register_at_fork() takes no positional arguments",
+        ));
+    }
+    crate::builtins::kwarg_reject_unknown(
+        kwargs,
+        &["before", "after_in_parent", "after_in_child"],
+        "register_at_fork",
+    )?;
+    let before = crate::builtins::kwarg_get(kwargs, "before");
+    let parent = crate::builtins::kwarg_get(kwargs, "after_in_parent");
+    let child = crate::builtins::kwarg_get(kwargs, "after_in_child");
+    if before.is_none() && parent.is_none() && child.is_none() {
+        return Err(crate::PyError::type_error(
+            "At least one argument is required.",
+        ));
+    }
+    for (name, callback) in [
+        ("before", before),
+        ("after_in_parent", parent),
+        ("after_in_child", child),
+    ] {
+        if callback.is_some_and(|callback| !crate::baseobjspace::callable_w(callback)) {
+            return Err(crate::PyError::type_error(format!(
+                "'{name}' must be callable",
+            )));
+        }
+    }
+    {
+        let mut callbacks = APPLEVEL_FORK_CALLBACKS.lock().unwrap();
+        if let Some(callback) = before {
+            callbacks.before_w.push(callback as usize);
+        }
+        if let Some(callback) = parent {
+            callbacks.parent_w.push(callback as usize);
+        }
+        if let Some(callback) = child {
+            callbacks.child_w.push(callback as usize);
+        }
+    }
+    pyre_object::gc_roots::mark_prebuilt_roots_dirty();
+    Ok(pyre_object::w_none())
+}
 
 /// `posix.stat_result` — a real structseq (tuple subclass) so `st[0]`,
 /// `len(st)`, iteration and `isinstance(st, tuple)` all work, matching
@@ -695,7 +814,6 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         "waitstatus_to_exitcode",
         "_exit",
         "_cpu_count",
-        "register_at_fork",
         "abort",
         "spawnv",
         "spawnve",
@@ -710,6 +828,11 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             crate::make_builtin_function(name, |_| Ok(pyre_object::w_none())),
         );
     }
+    crate::module_ns_store(
+        ns,
+        "register_at_fork",
+        crate::make_builtin_function("register_at_fork", register_at_fork),
+    );
 
     // PyPy `interp_posix.get_blocking/set_blocking` → rposix
     // `get_blocking/set_blocking`: inspect or update O_NONBLOCK with fcntl.
@@ -917,8 +1040,10 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 #[cfg(not(feature = "sandbox"))]
                 let buf = {
                     let mut buf = vec![0u8; n];
-                    let ret =
-                        unsafe { libc::read(fd, buf.as_mut_ptr() as *mut libc::c_void, n as _) };
+                    let ret = {
+                        let _blocked = crate::module::thread::before_external_block();
+                        unsafe { libc::read(fd, buf.as_mut_ptr() as *mut libc::c_void, n as _) }
+                    };
                     if ret < 0 {
                         return Err(io_err(std::io::Error::last_os_error(), ""));
                     }
@@ -950,23 +1075,27 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 let mut buffer = unsafe { crate::builtins::WritableBuffer::acquire(args[1]) }?;
                 let target = unsafe { buffer.as_mut_slice() };
                 #[cfg(not(feature = "sandbox"))]
-                let result = loop {
-                    let result = unsafe {
-                        libc::read(
-                            fd,
-                            target.as_mut_ptr() as *mut libc::c_void,
-                            target.len() as _,
-                        )
-                    };
-                    if result >= 0 {
-                        break result as i64;
+                let result = {
+                    let _blocked = crate::module::thread::before_external_block();
+                    loop {
+                        let result = unsafe {
+                            libc::read(
+                                fd,
+                                target.as_mut_ptr() as *mut libc::c_void,
+                                target.len() as _,
+                            )
+                        };
+                        if result >= 0 {
+                            break Ok(result as i64);
+                        }
+                        let error = std::io::Error::last_os_error();
+                        if error.raw_os_error() != Some(libc::EINTR) {
+                            break Err(error);
+                        }
                     }
-                    let error = std::io::Error::last_os_error();
-                    if error.raw_os_error() == Some(libc::EINTR) {
-                        continue;
-                    }
-                    return Err(io_err(error, ""));
                 };
+                #[cfg(not(feature = "sandbox"))]
+                let result = result.map_err(|error| io_err(error, ""))?;
                 #[cfg(feature = "sandbox")]
                 let result = {
                     let data = crate::host_seam::ops::read(fd, target.len() as i64)
@@ -998,8 +1127,11 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     .map_err(|_| crate::PyError::type_error("write() arg 2 must be bytes-like"))?;
                 #[cfg(not(feature = "sandbox"))]
                 let ret = {
-                    let ret = unsafe {
-                        libc::write(fd, data.as_ptr() as *const libc::c_void, data.len() as _)
+                    let ret = {
+                        let _blocked = crate::module::thread::before_external_block();
+                        unsafe {
+                            libc::write(fd, data.as_ptr() as *const libc::c_void, data.len() as _)
+                        }
                     };
                     if ret < 0 {
                         return Err(io_err(std::io::Error::last_os_error(), ""));
@@ -2511,8 +2643,54 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             crate::make_builtin_function_with_arity(
                 "fork",
                 |_| {
-                    let pid = host_posix::fork().map_err(|e| io_err(e, ""))?;
-                    Ok(pyre_object::w_int_new(pid as i64))
+                    if majit_gc::gc_sync::registered_threads() > 1 {
+                        crate::warn::warn_deprecation(
+                            "This process is multi-threaded, use of fork() may lead to deadlocks",
+                        )?;
+                    }
+                    let blocked = crate::module::thread::before_external_block();
+                    let fork_serial = FORK_SERIALIZER
+                        .lock()
+                        .unwrap_or_else(|poison| poison.into_inner());
+                    drop(blocked);
+                    run_fork_callbacks("before");
+                    // A free-threaded fork must snapshot native/Python lock
+                    // state while every other mutator is parked.  Enter
+                    // through the collector's full request path so no GC
+                    // operation can overlap the STW window.
+                    let mut fork_result = None;
+                    majit_gc::gc_sync::request_stw(|_| {
+                        fork_result = Some(host_posix::fork());
+                    });
+                    match fork_result.expect("fork STW closure must run") {
+                        Ok(0) => {
+                            crate::module::thread::after_fork_child();
+                            run_fork_callbacks("child");
+                            // PyPy's child is now the sole mutator.  Reclaim
+                            // vanished-thread-only objects immediately so
+                            // weak containers such as threading._dangling
+                            // reflect the one surviving MainThread before
+                            // user code resumes.
+                            pyre_object::gc_hook::try_gc_collect();
+                            let ec = crate::call::getexecutioncontext()
+                                as *mut crate::PyExecutionContext;
+                            if !ec.is_null() {
+                                unsafe { (*ec)._run_finalizers_now() };
+                            }
+                            drop(fork_serial);
+                            Ok(pyre_object::w_int_new(0))
+                        }
+                        Ok(pid) => {
+                            run_fork_callbacks("parent");
+                            drop(fork_serial);
+                            Ok(pyre_object::w_int_new(pid as i64))
+                        }
+                        Err(error) => {
+                            run_fork_callbacks("parent");
+                            drop(fork_serial);
+                            Err(io_err(error, ""))
+                        }
+                    }
                 },
                 0,
             ),
@@ -2543,8 +2721,11 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     let pid = (unsafe { pyre_object::w_int_get_value(args[0]) }) as libc::pid_t;
                     let options = (unsafe { pyre_object::w_int_get_value(args[1]) }) as i32;
                     let mut status: i32 = 0;
-                    let res = host_posix::waitpid(pid, &mut status, options)
-                        .map_err(|e| io_err(e, ""))?;
+                    let res = {
+                        let _blocked = crate::module::thread::before_external_block();
+                        host_posix::waitpid(pid, &mut status, options)
+                    }
+                    .map_err(|e| io_err(e, ""))?;
                     Ok(pyre_object::w_tuple_new(vec![
                         pyre_object::w_int_new(res as i64),
                         pyre_object::w_int_new(status as i64),
@@ -2562,7 +2743,11 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 "wait",
                 |_| {
                     let mut status: i32 = 0;
-                    let res = host_posix::waitpid(-1, &mut status, 0).map_err(|e| io_err(e, ""))?;
+                    let res = {
+                        let _blocked = crate::module::thread::before_external_block();
+                        host_posix::waitpid(-1, &mut status, 0)
+                    }
+                    .map_err(|e| io_err(e, ""))?;
                     Ok(pyre_object::w_tuple_new(vec![
                         pyre_object::w_int_new(res as i64),
                         pyre_object::w_int_new(status as i64),

--- a/pyre/pyre-interpreter/src/module/signal/signalstate.rs
+++ b/pyre/pyre-interpreter/src/module/signal/signalstate.rs
@@ -67,7 +67,7 @@ pub fn registered_ticker_ptr() -> *mut isize {
 
 /// Store -1 into the ticker cell so the next `decrement_ticker` runs
 /// `action_dispatcher`.  Async-signal-safe: a single aligned word store.
-fn rearm_ticker() {
+pub(crate) fn rearm_ticker() {
     let p = TICKER_PTR.load(Ordering::SeqCst);
     if !p.is_null() {
         unsafe { std::ptr::write_volatile(p, -1) };

--- a/pyre/pyre-interpreter/src/module/sys/vm.rs
+++ b/pyre/pyre-interpreter/src/module/sys/vm.rs
@@ -3,6 +3,7 @@
 //! PyPy equivalent: `pypy/module/sys/vm.py`.
 
 use crate::{make_builtin_function_with_arity, module_ns_store};
+use crate::executioncontext::ActionFlagOps;
 use pyre_object::*;
 use std::sync::OnceLock;
 
@@ -329,6 +330,26 @@ fn sys_setprofile_impl(args: &[PyObjectRef]) -> crate::PyResult {
         // with real None") propagates via setprofile -> setllprofile.
         unsafe { (*ec).setprofile(w_func)? };
     }
+    Ok(w_none())
+}
+
+fn sys_settraceallthreads_impl(args: &[PyObjectRef]) -> crate::PyResult {
+    let w_func = *args.first().ok_or_else(|| {
+        crate::PyError::type_error(
+            "_settraceallthreads() missing 1 required positional argument: 'function'",
+        )
+    })?;
+    crate::module::thread::set_trace_all_execution_contexts(w_func);
+    Ok(w_none())
+}
+
+fn sys_setprofileallthreads_impl(args: &[PyObjectRef]) -> crate::PyResult {
+    let w_func = *args.first().ok_or_else(|| {
+        crate::PyError::type_error(
+            "_setprofileallthreads() missing 1 required positional argument: 'function'",
+        )
+    })?;
+    crate::module::thread::set_profile_all_execution_contexts(w_func)?;
     Ok(w_none())
 }
 
@@ -922,6 +943,74 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             1,
         ),
     );
+    module_ns_store(
+        ns,
+        "getswitchinterval",
+        make_builtin_function_with_arity(
+            "getswitchinterval",
+            |args| {
+                if !args.is_empty() {
+                    return Err(crate::PyError::type_error(
+                        "getswitchinterval() takes no arguments",
+                    ));
+                }
+                let ec = current_execution_context();
+                let interval = if ec.is_null() {
+                    0.005
+                } else {
+                    unsafe { (*ec).actionflag.getcheckinterval() as f64 / 2_000_000.0 }
+                };
+                Ok(w_float_new(interval))
+            },
+            0,
+        ),
+    );
+    module_ns_store(
+        ns,
+        "setswitchinterval",
+        make_builtin_function_with_arity(
+            "setswitchinterval",
+            |args| {
+                if args.len() != 1 {
+                    return Err(crate::PyError::type_error(
+                        "setswitchinterval() takes exactly one argument",
+                    ));
+                }
+                let interval = crate::baseobjspace::float_w(args[0])?;
+                if interval <= 0.0 {
+                    return Err(crate::PyError::value_error(
+                        "switch interval must be strictly positive",
+                    ));
+                }
+                let ec = current_execution_context();
+                if !ec.is_null() {
+                    unsafe {
+                        (*(ec as *mut crate::PyExecutionContext))
+                            .actionflag
+                            .setcheckinterval((interval * 2_000_000.0) as usize)
+                    };
+                }
+                Ok(w_none())
+            },
+            1,
+        ),
+    );
+    module_ns_store(
+        ns,
+        "_current_frames",
+        make_builtin_function_with_arity(
+            "_current_frames",
+            |args| {
+                if !args.is_empty() {
+                    return Err(crate::PyError::type_error(
+                        "_current_frames() takes no arguments",
+                    ));
+                }
+                Ok(crate::module::thread::current_frames())
+            },
+            0,
+        ),
+    );
     // PyPy: pypy/module/sys/state.py:get_int_max_str_digits and
     // set_int_max_str_digits. The limit is object-space state, shared by
     // every caller rather than thread-local state.
@@ -1424,6 +1513,24 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     );
     module_ns_store(
         ns,
+        "_settraceallthreads",
+        make_builtin_function_with_arity(
+            "_settraceallthreads",
+            sys_settraceallthreads_impl,
+            1,
+        ),
+    );
+    module_ns_store(
+        ns,
+        "_setprofileallthreads",
+        make_builtin_function_with_arity(
+            "_setprofileallthreads",
+            sys_setprofileallthreads_impl,
+            1,
+        ),
+    );
+    module_ns_store(
+        ns,
         "get_coroutine_origin_tracking_depth",
         make_builtin_function_with_arity(
             "get_coroutine_origin_tracking_depth",
@@ -1483,7 +1590,11 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     module_ns_store(
         ns,
         "is_finalizing",
-        make_builtin_function_with_arity("is_finalizing", |_| Ok(w_bool_from(false)), 0),
+        make_builtin_function_with_arity(
+            "is_finalizing",
+            |_| Ok(w_bool_from(crate::module::thread::is_finalizing())),
+            0,
+        ),
     );
     // sys.displayhook / excepthook. `__displayhook__` keeps the original so
     // code (e.g. doctest) can save and restore the hook.

--- a/pyre/pyre-interpreter/src/module/thread/mod.rs
+++ b/pyre/pyre-interpreter/src/module/thread/mod.rs
@@ -95,9 +95,7 @@ pub(crate) fn walk_thread_roots(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
             let ec = unsafe { &mut *(ec_addr as *mut crate::PyExecutionContext) };
             let mut forward = |slot: &mut PyObjectRef| {
                 if !slot.is_null() {
-                    visitor(unsafe {
-                        &mut *(slot as *mut PyObjectRef as *mut majit_ir::GcRef)
-                    });
+                    visitor(unsafe { &mut *(slot as *mut PyObjectRef as *mut majit_ir::GcRef) });
                 }
             };
             forward(&mut ec.space);
@@ -137,12 +135,8 @@ pub(crate) fn walk_thread_roots(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
             visitor(unsafe { &mut *(handle as *mut usize as *mut majit_ir::GcRef) });
         }
     }
-    visitor(unsafe {
-        &mut *(&mut *TRACE_ALL_HOOK.lock() as *mut usize as *mut majit_ir::GcRef)
-    });
-    visitor(unsafe {
-        &mut *(&mut *PROFILE_ALL_HOOK.lock() as *mut usize as *mut majit_ir::GcRef)
-    });
+    visitor(unsafe { &mut *(&mut *TRACE_ALL_HOOK.lock() as *mut usize as *mut majit_ir::GcRef) });
+    visitor(unsafe { &mut *(&mut *PROFILE_ALL_HOOK.lock() as *mut usize as *mut majit_ir::GcRef) });
 }
 
 pub(crate) fn register_execution_context(ec: *const crate::PyExecutionContext) {
@@ -288,9 +282,7 @@ pub(crate) fn after_fork_child() {
         let mut contexts = EXECUTION_CONTEXTS.lock();
         contexts.retain(|thread_ident, _| *thread_ident == ident);
         if let Some(&ec) = contexts.get(&ident) {
-            for &wref in unsafe {
-                &(*(ec as *const crate::PyExecutionContext)).thread_local_refs
-            } {
+            for &wref in unsafe { &(*(ec as *const crate::PyExecutionContext)).thread_local_refs } {
                 let local = unsafe {
                     pyre_object::weakref::w_weakref_deref(
                         wref as *const pyre_object::weakref::Weakref,
@@ -347,9 +339,7 @@ fn parse_acquire_args(
         ));
     }
     if timeout > TIMEOUT_MAX {
-        return Err(crate::PyError::overflow_error(
-            "timeout value is too large",
-        ));
+        return Err(crate::PyError::overflow_error("timeout value is too large"));
     }
     Ok(if blocking && timeout >= 0.0 {
         Some(Duration::from_secs_f64(timeout))
@@ -359,414 +349,417 @@ fn parse_acquire_args(
 }
 
 mod lock_class {
-use super::*;
+    use super::*;
 
-#[crate::pyre_class("_thread.lock")]
-#[derive(Default)]
-pub struct W_Lock {
-    locked: Mutex<bool>,
-    ready: Condvar,
-}
-
-#[crate::pyre_methods(
-    doc = "A lock object is a synchronization primitive.",
-    weakrefable
-)]
-impl W_Lock {
-    #[staticmethod]
-    fn __new__(cls: PyObjectRef, args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-        if args.len() > 1 {
-            return Err(crate::PyError::type_error(
-                "_thread.lock() takes no arguments",
-            ));
-        }
-        crate::typedef::check_user_subclass(type_object(), cls)?;
-        let obj = Self::allocate_stable(Self::default());
-        unsafe { (*obj).w_class = cls };
-        Ok(obj)
+    #[crate::pyre_class("_thread.lock")]
+    #[derive(Default)]
+    pub struct W_Lock {
+        locked: Mutex<bool>,
+        ready: Condvar,
     }
 
-    fn acquire(
-        &self,
-        #[default(1)] blocking: i64,
-        timeout: Option<PyObjectRef>,
-    ) -> Result<bool, crate::PyError> {
-        let timeout = parse_acquire_args(blocking, timeout)?;
-        let blocking = blocking != 0;
-        // A potentially blocking native lock wait leaves the collector's
-        // RUNNING census.  This does not serialize Python execution.
-        let _blocked = before_external_block();
-        let mut locked = self.locked.lock();
-        if !*locked {
-            *locked = true;
-            return Ok(true);
-        }
-        if !blocking {
-            return Ok(false);
-        }
-        match timeout {
-            None => {
-                while *locked {
-                    self.ready.wait(&mut locked);
-                }
-                *locked = true;
-                Ok(true)
+    #[crate::pyre_methods(doc = "A lock object is a synchronization primitive.", weakrefable)]
+    impl W_Lock {
+        #[staticmethod]
+        fn __new__(cls: PyObjectRef, args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+            if args.len() > 1 {
+                return Err(crate::PyError::type_error(
+                    "_thread.lock() takes no arguments",
+                ));
             }
-            Some(duration) => {
-                let deadline = Instant::now() + duration;
-                while *locked {
-                    let now = Instant::now();
-                    if now >= deadline {
-                        return Ok(false);
-                    }
-                    if self.ready.wait_for(&mut locked, deadline - now).timed_out() && *locked {
-                        return Ok(false);
-                    }
-                }
+            crate::typedef::check_user_subclass(type_object(), cls)?;
+            let obj = Self::allocate_stable(Self::default());
+            unsafe { (*obj).w_class = cls };
+            Ok(obj)
+        }
+
+        fn acquire(
+            &self,
+            #[default(1)] blocking: i64,
+            timeout: Option<PyObjectRef>,
+        ) -> Result<bool, crate::PyError> {
+            let timeout = parse_acquire_args(blocking, timeout)?;
+            let blocking = blocking != 0;
+            // A potentially blocking native lock wait leaves the collector's
+            // RUNNING census.  This does not serialize Python execution.
+            let _blocked = before_external_block();
+            let mut locked = self.locked.lock();
+            if !*locked {
                 *locked = true;
-                Ok(true)
+                return Ok(true);
+            }
+            if !blocking {
+                return Ok(false);
+            }
+            match timeout {
+                None => {
+                    while *locked {
+                        self.ready.wait(&mut locked);
+                    }
+                    *locked = true;
+                    Ok(true)
+                }
+                Some(duration) => {
+                    let deadline = Instant::now() + duration;
+                    while *locked {
+                        let now = Instant::now();
+                        if now >= deadline {
+                            return Ok(false);
+                        }
+                        if self.ready.wait_for(&mut locked, deadline - now).timed_out() && *locked {
+                            return Ok(false);
+                        }
+                    }
+                    *locked = true;
+                    Ok(true)
+                }
             }
         }
-    }
 
-    fn release(&self) -> Result<(), crate::PyError> {
-        let mut locked = self.locked.lock();
-        if !*locked {
-            return Err(crate::PyError::runtime_error(
-                "release unlocked lock",
-            ));
+        fn release(&self) -> Result<(), crate::PyError> {
+            let mut locked = self.locked.lock();
+            if !*locked {
+                return Err(crate::PyError::runtime_error("release unlocked lock"));
+            }
+            *locked = false;
+            self.ready.notify_one();
+            Ok(())
         }
-        *locked = false;
-        self.ready.notify_one();
-        Ok(())
-    }
 
-    fn locked(&self) -> bool {
-        *self.locked.lock()
-    }
+        fn locked(&self) -> bool {
+            *self.locked.lock()
+        }
 
-    fn __enter__(&self) -> Result<PyObjectRef, crate::PyError> {
-        self.acquire(1, None)?;
-        Ok(self as *const Self as PyObjectRef)
-    }
+        fn __enter__(&self) -> Result<PyObjectRef, crate::PyError> {
+            self.acquire(1, None)?;
+            Ok(self as *const Self as PyObjectRef)
+        }
 
-    fn __exit__(&self, _args: &[PyObjectRef]) -> Result<bool, crate::PyError> {
-        self.release()?;
-        Ok(false)
-    }
+        fn __exit__(&self, _args: &[PyObjectRef]) -> Result<bool, crate::PyError> {
+            self.release()?;
+            Ok(false)
+        }
 
-    fn __repr__(&self) -> String {
-        let state = if self.locked() { "locked" } else { "unlocked" };
-        format!("<{state} _thread.lock object at {:p}>", self)
-    }
+        fn __repr__(&self) -> String {
+            let state = if self.locked() { "locked" } else { "unlocked" };
+            format!("<{state} _thread.lock object at {:p}>", self)
+        }
 
-    fn _at_fork_reinit(&self) {
-        // The old native mutex/condvar may have been owned by a thread which
-        // vanished at fork.  PyPy's rthread lock reinit replaces the native
-        // lock without trying to acquire or destroy the inherited one.
-        let this = self as *const Self as *mut Self;
-        unsafe {
-            std::ptr::write(&mut (*this).locked, Mutex::new(false));
-            std::ptr::write(&mut (*this).ready, Condvar::new());
+        fn _at_fork_reinit(&self) {
+            // The old native mutex/condvar may have been owned by a thread which
+            // vanished at fork.  PyPy's rthread lock reinit replaces the native
+            // lock without trying to acquire or destroy the inherited one.
+            let this = self as *const Self as *mut Self;
+            unsafe {
+                std::ptr::write(&mut (*this).locked, Mutex::new(false));
+                std::ptr::write(&mut (*this).ready, Condvar::new());
+            }
         }
     }
-}
 }
 use lock_class::W_Lock;
 
 mod rlock_class {
-use super::*;
+    use super::*;
 
-#[derive(Default)]
-struct RLockState {
-    count: i64,
-    owner: i64,
-}
-
-#[crate::pyre_class("_thread.RLock")]
-#[derive(Default)]
-pub struct W_RLock {
-    state: Mutex<RLockState>,
-    ready: Condvar,
-}
-
-#[crate::pyre_methods(weakrefable)]
-impl W_RLock {
-    #[staticmethod]
-    fn __new__(cls: PyObjectRef, args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-        if args.len() > 1 && cls == type_object() {
-            // CPython 3.14 keeps accepting arguments to the exact native
-            // RLock for compatibility, but deprecates them.  PyPy's
-            // W_RLock allocator likewise ignores construction arguments;
-            // subclasses remain free to consume them in their own __init__.
-            crate::warn::warn_deprecation(
-                "Passing arguments to _thread.RLock() is deprecated",
-            )?;
-        }
-        crate::typedef::check_user_subclass(type_object(), cls)?;
-        let obj = Self::allocate_stable(Self::default());
-        unsafe { (*obj).w_class = cls };
-        Ok(obj)
+    #[derive(Default)]
+    struct RLockState {
+        count: i64,
+        owner: i64,
     }
 
-    fn acquire(
-        &self,
-        #[default(1)] blocking: i64,
-        timeout: Option<PyObjectRef>,
-    ) -> Result<bool, crate::PyError> {
-        let timeout = parse_acquire_args(blocking, timeout)?;
-        let blocking = blocking != 0;
-        let ident = current_ident();
-        let _blocked = before_external_block();
-        let mut state = self.state.lock();
-        if state.count > 0 && state.owner == ident {
-            state.count = state
-                .count
-                .checked_add(1)
-                .ok_or_else(|| crate::PyError::overflow_error("internal lock count overflowed"))?;
-            return Ok(true);
+    #[crate::pyre_class("_thread.RLock")]
+    #[derive(Default)]
+    pub struct W_RLock {
+        state: Mutex<RLockState>,
+        ready: Condvar,
+    }
+
+    #[crate::pyre_methods(weakrefable)]
+    impl W_RLock {
+        #[staticmethod]
+        fn __new__(cls: PyObjectRef, args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+            if args.len() > 1 && cls == type_object() {
+                // CPython 3.14 keeps accepting arguments to the exact native
+                // RLock for compatibility, but deprecates them.  PyPy's
+                // W_RLock allocator likewise ignores construction arguments;
+                // subclasses remain free to consume them in their own __init__.
+                crate::warn::warn_deprecation(
+                    "Passing arguments to _thread.RLock() is deprecated",
+                )?;
+            }
+            crate::typedef::check_user_subclass(type_object(), cls)?;
+            let obj = Self::allocate_stable(Self::default());
+            unsafe { (*obj).w_class = cls };
+            Ok(obj)
         }
-        if state.count == 0 {
+
+        fn acquire(
+            &self,
+            #[default(1)] blocking: i64,
+            timeout: Option<PyObjectRef>,
+        ) -> Result<bool, crate::PyError> {
+            let timeout = parse_acquire_args(blocking, timeout)?;
+            let blocking = blocking != 0;
+            let ident = current_ident();
+            let _blocked = before_external_block();
+            let mut state = self.state.lock();
+            if state.count > 0 && state.owner == ident {
+                state.count = state.count.checked_add(1).ok_or_else(|| {
+                    crate::PyError::overflow_error("internal lock count overflowed")
+                })?;
+                return Ok(true);
+            }
+            if state.count == 0 {
+                state.owner = ident;
+                state.count = 1;
+                return Ok(true);
+            }
+            if !blocking {
+                return Ok(false);
+            }
+            match timeout {
+                None => {
+                    while state.count != 0 {
+                        self.ready.wait(&mut state);
+                    }
+                }
+                Some(duration) => {
+                    let deadline = Instant::now() + duration;
+                    while state.count != 0 {
+                        let now = Instant::now();
+                        if now >= deadline {
+                            return Ok(false);
+                        }
+                        if self.ready.wait_for(&mut state, deadline - now).timed_out()
+                            && state.count != 0
+                        {
+                            return Ok(false);
+                        }
+                    }
+                }
+            }
             state.owner = ident;
             state.count = 1;
-            return Ok(true);
+            Ok(true)
         }
-        if !blocking {
-            return Ok(false);
+
+        fn release(&self) -> Result<(), crate::PyError> {
+            let ident = current_ident();
+            let mut state = self.state.lock();
+            if state.count == 0 || state.owner != ident {
+                return Err(crate::PyError::runtime_error(
+                    "cannot release un-acquired lock",
+                ));
+            }
+            state.count -= 1;
+            if state.count == 0 {
+                state.owner = 0;
+                self.ready.notify_one();
+            }
+            Ok(())
         }
-        match timeout {
-            None => {
+
+        fn locked(&self) -> bool {
+            self.state.lock().count != 0
+        }
+
+        fn _is_owned(&self) -> bool {
+            let state = self.state.lock();
+            state.count > 0 && state.owner == current_ident()
+        }
+
+        fn _recursion_count(&self) -> i64 {
+            let state = self.state.lock();
+            if state.owner == current_ident() {
+                state.count
+            } else {
+                0
+            }
+        }
+
+        fn _release_save(&self) -> Result<PyObjectRef, crate::PyError> {
+            let mut state = self.state.lock();
+            if state.count == 0 {
+                return Err(crate::PyError::runtime_error(
+                    "cannot release un-acquired lock",
+                ));
+            }
+            let saved = w_tuple_new(vec![w_int_new(state.count), w_int_new(state.owner)]);
+            state.count = 0;
+            state.owner = 0;
+            self.ready.notify_one();
+            Ok(saved)
+        }
+
+        fn _acquire_restore(&self, saved: PyObjectRef) -> Result<(), crate::PyError> {
+            let items = unsafe {
+                if !is_tuple(saved) {
+                    return Err(crate::PyError::type_error("saved state must be a tuple"));
+                }
+                w_tuple_items_copy_as_vec(saved)
+            };
+            if items.len() != 2 || unsafe { !is_int(items[0]) || !is_int(items[1]) } {
+                return Err(crate::PyError::type_error("invalid saved state"));
+            }
+            let count = unsafe { w_int_get_value(items[0]) };
+            let owner = unsafe { w_int_get_value(items[1]) };
+            let _blocked = before_external_block();
+            let mut state = self.state.lock();
+            if state.count != 0 {
                 while state.count != 0 {
                     self.ready.wait(&mut state);
                 }
             }
-            Some(duration) => {
-                let deadline = Instant::now() + duration;
-                while state.count != 0 {
-                    let now = Instant::now();
-                    if now >= deadline {
-                        return Ok(false);
-                    }
-                    if self.ready.wait_for(&mut state, deadline - now).timed_out()
-                        && state.count != 0
-                    {
-                        return Ok(false);
-                    }
-                }
+            state.count = count;
+            state.owner = owner;
+            Ok(())
+        }
+
+        fn __enter__(&self) -> Result<PyObjectRef, crate::PyError> {
+            self.acquire(1, None)?;
+            Ok(self as *const Self as PyObjectRef)
+        }
+
+        fn __exit__(&self, _args: &[PyObjectRef]) -> Result<bool, crate::PyError> {
+            self.release()?;
+            Ok(false)
+        }
+
+        fn __repr__(&self) -> String {
+            let state = self.state.lock();
+            let locked = if state.count == 0 {
+                "unlocked"
+            } else {
+                "locked"
+            };
+            format!(
+                "<{locked} _thread.RLock object owner={} count={} at {:p}>",
+                state.owner, state.count, self
+            )
+        }
+
+        fn _at_fork_reinit(&self) {
+            let this = self as *const Self as *mut Self;
+            unsafe {
+                std::ptr::write(&mut (*this).state, Mutex::new(RLockState::default()));
+                std::ptr::write(&mut (*this).ready, Condvar::new());
             }
         }
-        state.owner = ident;
-        state.count = 1;
-        Ok(true)
     }
-
-    fn release(&self) -> Result<(), crate::PyError> {
-        let ident = current_ident();
-        let mut state = self.state.lock();
-        if state.count == 0 || state.owner != ident {
-            return Err(crate::PyError::runtime_error(
-                "cannot release un-acquired lock",
-            ));
-        }
-        state.count -= 1;
-        if state.count == 0 {
-            state.owner = 0;
-            self.ready.notify_one();
-        }
-        Ok(())
-    }
-
-    fn locked(&self) -> bool {
-        self.state.lock().count != 0
-    }
-
-    fn _is_owned(&self) -> bool {
-        let state = self.state.lock();
-        state.count > 0 && state.owner == current_ident()
-    }
-
-    fn _recursion_count(&self) -> i64 {
-        let state = self.state.lock();
-        if state.owner == current_ident() {
-            state.count
-        } else {
-            0
-        }
-    }
-
-    fn _release_save(&self) -> Result<PyObjectRef, crate::PyError> {
-        let mut state = self.state.lock();
-        if state.count == 0 {
-            return Err(crate::PyError::runtime_error(
-                "cannot release un-acquired lock",
-            ));
-        }
-        let saved = w_tuple_new(vec![w_int_new(state.count), w_int_new(state.owner)]);
-        state.count = 0;
-        state.owner = 0;
-        self.ready.notify_one();
-        Ok(saved)
-    }
-
-    fn _acquire_restore(&self, saved: PyObjectRef) -> Result<(), crate::PyError> {
-        let items = unsafe {
-            if !is_tuple(saved) {
-                return Err(crate::PyError::type_error("saved state must be a tuple"));
-            }
-            w_tuple_items_copy_as_vec(saved)
-        };
-        if items.len() != 2 || unsafe { !is_int(items[0]) || !is_int(items[1]) } {
-            return Err(crate::PyError::type_error("invalid saved state"));
-        }
-        let count = unsafe { w_int_get_value(items[0]) };
-        let owner = unsafe { w_int_get_value(items[1]) };
-        let _blocked = before_external_block();
-        let mut state = self.state.lock();
-        if state.count != 0 {
-            while state.count != 0 {
-                self.ready.wait(&mut state);
-            }
-        }
-        state.count = count;
-        state.owner = owner;
-        Ok(())
-    }
-
-    fn __enter__(&self) -> Result<PyObjectRef, crate::PyError> {
-        self.acquire(1, None)?;
-        Ok(self as *const Self as PyObjectRef)
-    }
-
-    fn __exit__(&self, _args: &[PyObjectRef]) -> Result<bool, crate::PyError> {
-        self.release()?;
-        Ok(false)
-    }
-
-    fn __repr__(&self) -> String {
-        let state = self.state.lock();
-        let locked = if state.count == 0 { "unlocked" } else { "locked" };
-        format!(
-            "<{locked} _thread.RLock object owner={} count={} at {:p}>",
-            state.owner, state.count, self
-        )
-    }
-
-    fn _at_fork_reinit(&self) {
-        let this = self as *const Self as *mut Self;
-        unsafe {
-            std::ptr::write(&mut (*this).state, Mutex::new(RLockState::default()));
-            std::ptr::write(&mut (*this).ready, Condvar::new());
-        }
-    }
-}
 }
 use rlock_class::W_RLock;
 
 mod handle_class {
-use super::*;
+    use super::*;
 
-#[derive(Default)]
-pub(super) struct HandleState {
-    pub(super) started: bool,
-    pub(super) done: bool,
-    pub(super) ident: i64,
-    pub(super) daemon: bool,
-}
-
-#[crate::pyre_class("_thread._ThreadHandle")]
-#[derive(Default)]
-pub struct W_ThreadHandle {
-    pub(super) state: Mutex<HandleState>,
-    pub(super) done: Condvar,
-}
-
-#[crate::pyre_methods]
-impl W_ThreadHandle {
-    #[staticmethod]
-    fn __new__(cls: PyObjectRef, args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-        if args.len() > 1 {
-            return Err(crate::PyError::type_error(
-                "_ThreadHandle() takes no arguments",
-            ));
-        }
-        crate::typedef::check_user_subclass(type_object(), cls)?;
-        let obj = Self::allocate_stable(Self::default());
-        unsafe { (*obj).w_class = cls };
-        Ok(obj)
+    #[derive(Default)]
+    pub(super) struct HandleState {
+        pub(super) started: bool,
+        pub(super) done: bool,
+        pub(super) ident: i64,
+        pub(super) daemon: bool,
     }
 
-    #[getter]
-    fn ident(&self) -> i64 {
-        self.state.lock().ident
+    #[crate::pyre_class("_thread._ThreadHandle")]
+    #[derive(Default)]
+    pub struct W_ThreadHandle {
+        pub(super) state: Mutex<HandleState>,
+        pub(super) done: Condvar,
     }
 
-    fn is_done(&self) -> bool {
-        self.state.lock().done
-    }
-
-    pub(super) fn join(&self, #[default(pyre_object::w_none())] timeout: PyObjectRef) -> Result<(), crate::PyError> {
-        let duration = unsafe {
-            if is_none(timeout) {
-                None
-            } else if is_float(timeout) {
-                Some(Duration::from_secs_f64(
-                    floatobject::w_float_get_value(timeout).max(0.0),
-                ))
-            } else if is_int(timeout) {
-                Some(Duration::from_secs(w_int_get_value(timeout).max(0) as u64))
-            } else {
-                return Err(crate::PyError::type_error("timeout must be a number or None"));
+    #[crate::pyre_methods]
+    impl W_ThreadHandle {
+        #[staticmethod]
+        fn __new__(cls: PyObjectRef, args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+            if args.len() > 1 {
+                return Err(crate::PyError::type_error(
+                    "_ThreadHandle() takes no arguments",
+                ));
             }
-        };
-        let mut state = self.state.lock();
-        if !state.started {
-            return Err(crate::PyError::runtime_error("thread not started"));
+            crate::typedef::check_user_subclass(type_object(), cls)?;
+            let obj = Self::allocate_stable(Self::default());
+            unsafe { (*obj).w_class = cls };
+            Ok(obj)
         }
-        if state.ident == current_ident() && !state.done {
-            return Err(crate::PyError::runtime_error("Cannot join current thread"));
+
+        #[getter]
+        fn ident(&self) -> i64 {
+            self.state.lock().ident
         }
-        if state.done {
-            return Ok(());
+
+        fn is_done(&self) -> bool {
+            self.state.lock().done
         }
-        if state.daemon && is_finalizing() {
-            let cls = crate::builtins::lookup_exc_class("PythonFinalizationError")
-                .expect("PythonFinalizationError must be installed");
-            let exc = crate::builtins::exc_exception_new(&[cls])?;
-            return Err(unsafe { crate::PyError::from_exc_object(exc) });
-        }
-        let _blocked = before_external_block();
-        match duration {
-            None => {
-                while !state.done {
-                    self.done.wait(&mut state);
+
+        pub(super) fn join(
+            &self,
+            #[default(pyre_object::w_none())] timeout: PyObjectRef,
+        ) -> Result<(), crate::PyError> {
+            let duration = unsafe {
+                if is_none(timeout) {
+                    None
+                } else if is_float(timeout) {
+                    Some(Duration::from_secs_f64(
+                        floatobject::w_float_get_value(timeout).max(0.0),
+                    ))
+                } else if is_int(timeout) {
+                    Some(Duration::from_secs(w_int_get_value(timeout).max(0) as u64))
+                } else {
+                    return Err(crate::PyError::type_error(
+                        "timeout must be a number or None",
+                    ));
                 }
+            };
+            let mut state = self.state.lock();
+            if !state.started {
+                return Err(crate::PyError::runtime_error("thread not started"));
             }
-            Some(timeout) => {
-                let deadline = Instant::now() + timeout;
-                while !state.done {
-                    let now = Instant::now();
-                    if now >= deadline {
-                        break;
-                    }
-                    if self.done.wait_for(&mut state, deadline - now).timed_out() {
-                        break;
+            if state.ident == current_ident() && !state.done {
+                return Err(crate::PyError::runtime_error("Cannot join current thread"));
+            }
+            if state.done {
+                return Ok(());
+            }
+            if state.daemon && is_finalizing() {
+                let cls = crate::builtins::lookup_exc_class("PythonFinalizationError")
+                    .expect("PythonFinalizationError must be installed");
+                let exc = crate::builtins::exc_exception_new(&[cls])?;
+                return Err(unsafe { crate::PyError::from_exc_object(exc) });
+            }
+            let _blocked = before_external_block();
+            match duration {
+                None => {
+                    while !state.done {
+                        self.done.wait(&mut state);
                     }
                 }
+                Some(timeout) => {
+                    let deadline = Instant::now() + timeout;
+                    while !state.done {
+                        let now = Instant::now();
+                        if now >= deadline {
+                            break;
+                        }
+                        if self.done.wait_for(&mut state, deadline - now).timed_out() {
+                            break;
+                        }
+                    }
+                }
             }
+            Ok(())
         }
-        Ok(())
-    }
 
-    fn _set_done(&self) -> Result<(), crate::PyError> {
-        let mut state = self.state.lock();
-        if !state.started {
-            return Err(crate::PyError::runtime_error("thread not started"));
+        fn _set_done(&self) -> Result<(), crate::PyError> {
+            let mut state = self.state.lock();
+            if !state.started {
+                return Err(crate::PyError::runtime_error("thread not started"));
+            }
+            state.done = true;
+            self.done.notify_all();
+            Ok(())
         }
-        state.done = true;
-        self.done.notify_all();
-        Ok(())
     }
-}
 }
 use handle_class::W_ThreadHandle;
 
@@ -792,106 +785,103 @@ impl W_ThreadHandle {
 }
 
 mod local_class {
-use super::*;
+    use super::*;
 
-/// `pypy/module/thread/os_local.py Local`.
-///
-/// `dicts` is deliberately a Python dict, matching upstream's
-/// `self.dicts = {}` and keeping every per-ExecutionContext dictionary on the
-/// object's ordinary GC graph.  The integer key is pyre's stable identity for
-/// the current OS-thread ExecutionContext.
-#[crate::pyre_class("_thread._local")]
-pub struct W_Local {
-    dicts: PyObjectRef,
-    last_dict: PyObjectRef,
-    last_ident: i64,
-    state_lock: Mutex<()>,
-}
-
-impl W_Local {
-    pub(super) fn current_dict(&self) -> PyObjectRef {
-        let _guard = self.state_lock.lock();
-        let this = self as *const Self as *mut Self;
-        let ident = current_ident();
-        if self.last_ident == ident && !self.last_dict.is_null() {
-            return self.last_dict;
-        }
-        let w_dict = unsafe { pyre_object::w_dict_getitem(self.dicts, ident) }
-            .unwrap_or_else(|| {
-                let w_dict = pyre_object::w_dict_new();
-                unsafe { pyre_object::w_dict_setitem(self.dicts, ident, w_dict) };
-                register_local_in_current_ec(self as *const Self as PyObjectRef);
-                w_dict
-            });
-        unsafe {
-            (*this).last_ident = ident;
-            (*this).last_dict = w_dict;
-        }
-        pyre_object::gc_hook::try_gc_write_barrier(this as *mut u8);
-        w_dict
+    /// `pypy/module/thread/os_local.py Local`.
+    ///
+    /// `dicts` is deliberately a Python dict, matching upstream's
+    /// `self.dicts = {}` and keeping every per-ExecutionContext dictionary on the
+    /// object's ordinary GC graph.  The integer key is pyre's stable identity for
+    /// the current OS-thread ExecutionContext.
+    #[crate::pyre_class("_thread._local")]
+    pub struct W_Local {
+        dicts: PyObjectRef,
+        last_dict: PyObjectRef,
+        last_ident: i64,
+        state_lock: Mutex<()>,
     }
 
-    pub(super) fn thread_is_stopping(&self, ident: i64) {
-        let _guard = self.state_lock.lock();
-        let this = self as *const Self as *mut Self;
-        let key = w_int_new(ident);
-        unsafe {
-            pyre_object::w_dict_delitem(self.dicts, key);
-            if (*this).last_ident == ident {
-                (*this).last_ident = 0;
-                (*this).last_dict = PY_NULL;
+    impl W_Local {
+        pub(super) fn current_dict(&self) -> PyObjectRef {
+            let _guard = self.state_lock.lock();
+            let this = self as *const Self as *mut Self;
+            let ident = current_ident();
+            if self.last_ident == ident && !self.last_dict.is_null() {
+                return self.last_dict;
+            }
+            let w_dict =
+                unsafe { pyre_object::w_dict_getitem(self.dicts, ident) }.unwrap_or_else(|| {
+                    let w_dict = pyre_object::w_dict_new();
+                    unsafe { pyre_object::w_dict_setitem(self.dicts, ident, w_dict) };
+                    register_local_in_current_ec(self as *const Self as PyObjectRef);
+                    w_dict
+                });
+            unsafe {
+                (*this).last_ident = ident;
+                (*this).last_dict = w_dict;
+            }
+            pyre_object::gc_hook::try_gc_write_barrier(this as *mut u8);
+            w_dict
+        }
+
+        pub(super) fn thread_is_stopping(&self, ident: i64) {
+            let _guard = self.state_lock.lock();
+            let this = self as *const Self as *mut Self;
+            let key = w_int_new(ident);
+            unsafe {
+                pyre_object::w_dict_delitem(self.dicts, key);
+                if (*this).last_ident == ident {
+                    (*this).last_ident = 0;
+                    (*this).last_dict = PY_NULL;
+                }
+            }
+        }
+
+        pub(super) fn after_fork_reinit(&self) {
+            let this = self as *const Self as *mut Self;
+            unsafe {
+                std::ptr::write(&mut (*this).state_lock, parking_lot::const_mutex(()));
             }
         }
     }
 
-    pub(super) fn after_fork_reinit(&self) {
-        let this = self as *const Self as *mut Self;
-        unsafe {
-            std::ptr::write(&mut (*this).state_lock, parking_lot::const_mutex(()));
+    #[crate::pyre_methods(doc = "Thread-local data", weakrefable)]
+    impl W_Local {
+        #[staticmethod]
+        fn __new__(cls: PyObjectRef, args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+            crate::typedef::check_user_subclass(type_object(), cls)?;
+            // os_local.py installs the first dictionary before app-level
+            // __init__ is entered, preventing recursive initialization.
+            let dicts = pyre_object::w_dict_new();
+            let w_dict = pyre_object::w_dict_new();
+            let ident = current_ident();
+            unsafe { pyre_object::w_dict_setitem(dicts, ident, w_dict) };
+            let obj = Self::allocate_stable(Self {
+                ob: PyObject::default(),
+                dicts,
+                last_dict: w_dict,
+                last_ident: ident,
+                state_lock: parking_lot::const_mutex(()),
+            });
+            unsafe { (*obj).w_class = cls };
+            register_local_in_current_ec(obj);
+
+            // The base `_local` has no app-level initializer accepting arguments.
+            // Subclass initialization is dispatched by the ordinary type call
+            // after this allocator returns, exactly as for PyPy's TypeDef.
+            if args.len() > 1 && cls == type_object() {
+                return Err(crate::PyError::type_error(
+                    "Initialization arguments are not supported",
+                ));
+            }
+            Ok(obj)
+        }
+
+        #[getter]
+        fn __dict__(&self) -> PyObjectRef {
+            self.current_dict()
         }
     }
-}
-
-#[crate::pyre_methods(
-    doc = "Thread-local data",
-    weakrefable
-)]
-impl W_Local {
-    #[staticmethod]
-    fn __new__(cls: PyObjectRef, args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-        crate::typedef::check_user_subclass(type_object(), cls)?;
-        // os_local.py installs the first dictionary before app-level
-        // __init__ is entered, preventing recursive initialization.
-        let dicts = pyre_object::w_dict_new();
-        let w_dict = pyre_object::w_dict_new();
-        let ident = current_ident();
-        unsafe { pyre_object::w_dict_setitem(dicts, ident, w_dict) };
-        let obj = Self::allocate_stable(Self {
-            ob: PyObject::default(),
-            dicts,
-            last_dict: w_dict,
-            last_ident: ident,
-            state_lock: parking_lot::const_mutex(()),
-        });
-        unsafe { (*obj).w_class = cls };
-        register_local_in_current_ec(obj);
-
-        // The base `_local` has no app-level initializer accepting arguments.
-        // Subclass initialization is dispatched by the ordinary type call
-        // after this allocator returns, exactly as for PyPy's TypeDef.
-        if args.len() > 1 && cls == type_object() {
-            return Err(crate::PyError::type_error(
-                "Initialization arguments are not supported",
-            ));
-        }
-        Ok(obj)
-    }
-
-    #[getter]
-    fn __dict__(&self) -> PyObjectRef {
-        self.current_dict()
-    }
-}
 }
 pub use local_class::W_Local;
 
@@ -923,9 +913,7 @@ fn thread_is_stopping(ec: &mut crate::PyExecutionContext) {
     let ident = current_ident();
     for wref in std::mem::take(&mut ec.thread_local_refs) {
         let local = unsafe {
-            pyre_object::weakref::w_weakref_deref(
-                wref as *const pyre_object::weakref::Weakref,
-            )
+            pyre_object::weakref::w_weakref_deref(wref as *const pyre_object::weakref::Weakref)
         };
         if let Some(local) = W_Local::from_obj(local) {
             local.thread_is_stopping(ident);
@@ -1130,9 +1118,8 @@ fn spawn_thread(
             // driver owner is made interpreter-global.
             let _plain_worker = crate::call::force_plain_eval();
             if let Err(mut error) = call_thread_target(callable, &args, kwargs, ec_ptr) {
-                let callable_repr = unsafe {
-                    crate::py_repr(callable).unwrap_or_else(|_| "<unknown>".to_string())
-                };
+                let callable_repr =
+                    unsafe { crate::py_repr(callable).unwrap_or_else(|_| "<unknown>".to_string()) };
                 error.write_unraisable(
                     w_none(),
                     &format!("Exception ignored in thread started by {callable_repr}"),
@@ -1190,17 +1177,16 @@ fn start_new_thread(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
         return Err(crate::PyError::type_error("2nd arg must be a tuple"));
     }
     let positional = unsafe { w_tuple_items_copy_as_vec(pos[1]) };
-    let kwargs = pos.get(2).copied().or_else(|| {
-        crate::builtins::kwarg_get(kwargs_marker, "kwargs")
-    });
+    let kwargs = pos
+        .get(2)
+        .copied()
+        .or_else(|| crate::builtins::kwarg_get(kwargs_marker, "kwargs"));
     if kwargs.is_some_and(|d| unsafe { !is_dict(d) }) {
         return Err(crate::PyError::type_error(
             "optional 3rd arg must be a dictionary",
         ));
     }
-    Ok(w_int_new(spawn_thread(
-        callable, positional, kwargs, None,
-    )?))
+    Ok(w_int_new(spawn_thread(callable, positional, kwargs, None)?))
 }
 
 fn start_joinable_thread(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {

--- a/pyre/pyre-interpreter/src/module/thread/mod.rs
+++ b/pyre/pyre-interpreter/src/module/thread/mod.rs
@@ -103,9 +103,10 @@ pub(crate) fn walk_thread_roots(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
             forward(&mut ec.compiler);
             forward(&mut ec.w_profilefuncarg);
             forward(&mut ec.w_async_exception_type);
-            for wref in &mut ec.thread_local_refs {
-                forward(wref);
-            }
+            forward(&mut ec.sys_exc_value);
+            forward(&mut ec.current_gen_or_coroutine);
+            forward(&mut ec.w_asyncgen_firstiter_fn);
+            forward(&mut ec.w_asyncgen_finalizer_fn);
             if !ec.topframeref.is_null() {
                 let mut frame = ec.topframeref as PyObjectRef;
                 forward(&mut frame);
@@ -120,6 +121,12 @@ pub(crate) fn walk_thread_roots(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
                     }
                 }
             }
+            // `builtins_module` / `builtin_dict_cache` / `thread_local_refs`.
+            // `clone_for_thread` copies the builtins reference into the child
+            // EC, so each copy is its own slot: forwarding only the parent's
+            // leaves the child pointing at the pre-move address once a thread
+            // is registered but has not yet armed its own root area.
+            ec.walk_builtin_roots(visitor);
         }
     }
     let mut forwarded = Vec::new();

--- a/pyre/pyre-interpreter/src/module/thread/mod.rs
+++ b/pyre/pyre-interpreter/src/module/thread/mod.rs
@@ -1,220 +1,939 @@
-//! _thread module — PyPy: `pypy/module/thread/`.
+//! `_thread` — direct port of `pypy/module/thread/`.
 //!
-//! Single-threaded pyre: `Lock` / `RLock` state lives in the instance
-//! dict as `_locked_count`.  `allocate_lock` / `start_new_thread` etc.
-//! are stubs; `_ThreadHandle` lives long enough for `threading.py` to
-//! call `is_done()` during shutdown.
+//! The ownership shape follows PyPy: each Lock/RLock/ThreadHandle owns its
+//! native synchronization state, and each started OS thread gets a distinct
+//! ExecutionContext plus GC shadow stack.  No process-global side table is
+//! used for per-object state.
 
+use parking_lot::{Condvar, Mutex};
 use pyre_object::*;
-use std::cell::Cell;
-use std::sync::OnceLock;
+use std::sync::atomic::{AtomicBool, AtomicI64, AtomicUsize, Ordering};
+use std::sync::{LazyLock, OnceLock};
+use std::time::{Duration, Instant};
 
-thread_local! {
-    // The runtime is single-OS-threaded, but a synchronous emulation of a
-    // joinable Python thread still needs a distinct logical ident so
-    // threading._active never replaces the main-thread entry.
-    static LOGICAL_THREAD_IDENT: Cell<i64> = const { Cell::new(0) };
+const TIMEOUT_MAX: f64 = i64::MAX as f64 / 1_000_000.0;
+static THREAD_COUNT: AtomicI64 = AtomicI64::new(0);
+static STACK_SIZE: AtomicUsize = AtomicUsize::new(0);
+static FINALIZING: AtomicBool = AtomicBool::new(false);
+static FINALIZING_THREAD: AtomicI64 = AtomicI64::new(0);
+// Number of EC-owned `w_async_exception_type` slots which are non-null.
+// This keeps the process eval breaker armed until the targeted free-threaded
+// EC observes its own pending exception; another EC must not clear the shared
+// breaker first.
+static ASYNC_EXCEPTION_COUNT: AtomicUsize = AtomicUsize::new(0);
+static TRACE_ALL_GENERATION: AtomicUsize = AtomicUsize::new(0);
+static PROFILE_ALL_GENERATION: AtomicUsize = AtomicUsize::new(0);
+static TRACE_ALL_HOOK: Mutex<usize> = parking_lot::const_mutex(0);
+static PROFILE_ALL_HOOK: Mutex<usize> = parking_lot::const_mutex(0);
+// CPython 3.14's `_thread._shutdown` registry, corresponding to PyPy's
+// bootstrapper/threadlocals-owned live-thread set.  Values are handle object
+// slots, not a parallel copy of handle state.
+static SHUTDOWN_HANDLES: Mutex<Vec<usize>> = parking_lot::const_mutex(Vec::new());
+// CPython's native thread-handle list, used by `_PyThread_AfterFork()` to
+// mark handles owned by vanished threads done before `threading._after_fork`
+// walks the Python Thread objects.
+static ACTIVE_HANDLES: Mutex<Vec<usize>> = parking_lot::const_mutex(Vec::new());
+// `OSThreadLocals._valuedict`: process/interpreter-owned mapping from native
+// thread identifiers to their live ExecutionContexts.
+static EXECUTION_CONTEXTS: LazyLock<Mutex<indexmap::IndexMap<i64, usize>>> =
+    LazyLock::new(|| Mutex::new(indexmap::IndexMap::new()));
+
+/// A blocking host call leaves the free-threaded collector's RUNNING census.
+/// This is a GC safepoint transition only; pyre has no process GIL.
+pub(crate) fn before_external_block() -> majit_gc::gc_sync::BlockingGuard {
+    majit_gc::gc_sync::before_external_block()
 }
 
-fn lock_count(obj: PyObjectRef) -> i64 {
-    let d = crate::baseobjspace::getdict(obj);
-    if d.is_null() {
-        return 0;
+pub fn set_finalizing() {
+    let ident = current_ident();
+    // Free-threaded counterpart of PyPy/CPython's final GIL ownership: publish
+    // the finalizing owner while every other mutator is stopped at a walkable
+    // safepoint.  Mutators which resume into Python bytecode park permanently;
+    // mutators already returning from their target finish unregistering before
+    // this STW can complete.
+    majit_gc::gc_sync::request_stw(|_| {
+        FINALIZING_THREAD.store(ident, Ordering::Release);
+        FINALIZING.store(true, Ordering::Release);
+    });
+}
+
+pub fn is_finalizing() -> bool {
+    FINALIZING.load(Ordering::Acquire)
+}
+
+/// Stop a non-owner mutator from running Python once interpreter teardown has
+/// begun.  The forgotten blocking guard keeps it outside the GC RUNNING census;
+/// process exit terminates these daemon OS threads after the owner completes
+/// finalization, matching the upstream "hang daemon thread" shutdown state.
+#[inline]
+pub fn park_if_finalizing() {
+    if !is_finalizing() || FINALIZING_THREAD.load(Ordering::Acquire) == current_ident() {
+        return;
     }
-    if let Some(v) = unsafe { w_dict_getitem_str(d, "_locked_count") } {
-        if unsafe { is_int(v) } {
-            return unsafe { w_int_get_value(v) };
+    let blocked = before_external_block();
+    std::mem::forget(blocked);
+    #[cfg(not(target_arch = "wasm32"))]
+    loop {
+        std::thread::park();
+    }
+    #[cfg(target_arch = "wasm32")]
+    loop {
+        std::hint::spin_loop();
+    }
+}
+
+pub(crate) fn walk_thread_roots(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
+    // PyPy's ExecutionContexts live on the translated interpreter object graph,
+    // so every object-valued EC field is traced automatically.  Pyre keeps one
+    // Rust Box per OS thread; the process-owned OSThreadLocals registry is
+    // therefore the corresponding root owner and must forward those fields in
+    // place.  In particular, tracing/profile callbacks must never become stale
+    // raw pointers after a moving collection.
+    {
+        let contexts = EXECUTION_CONTEXTS.lock();
+        for &ec_addr in contexts.values() {
+            let ec = unsafe { &mut *(ec_addr as *mut crate::PyExecutionContext) };
+            let mut forward = |slot: &mut PyObjectRef| {
+                if !slot.is_null() {
+                    visitor(unsafe {
+                        &mut *(slot as *mut PyObjectRef as *mut majit_ir::GcRef)
+                    });
+                }
+            };
+            forward(&mut ec.space);
+            forward(&mut ec.w_tracefunc);
+            forward(&mut ec.compiler);
+            forward(&mut ec.w_profilefuncarg);
+            forward(&mut ec.w_async_exception_type);
+            for wref in &mut ec.thread_local_refs {
+                forward(wref);
+            }
+            if !ec.topframeref.is_null() {
+                let mut frame = ec.topframeref as PyObjectRef;
+                forward(&mut frame);
+                ec.topframeref = frame as *mut crate::PyFrame;
+            }
+            if !ec.user_del_action.is_null() {
+                let action = unsafe { &mut *ec.user_del_action };
+                forward(&mut action.base.space);
+                if let Some(pending) = action.pending_with_disabled_del.as_mut() {
+                    for obj in pending {
+                        forward(obj);
+                    }
+                }
+            }
         }
     }
+    let mut forwarded = Vec::new();
+    for handle in SHUTDOWN_HANDLES.lock().iter_mut() {
+        let old = *handle;
+        visitor(unsafe { &mut *(handle as *mut usize as *mut majit_ir::GcRef) });
+        forwarded.push((old, *handle));
+    }
+    for handle in ACTIVE_HANDLES.lock().iter_mut() {
+        if let Some((_, new)) = forwarded.iter().find(|(old, _)| *old == *handle) {
+            *handle = *new;
+        } else {
+            visitor(unsafe { &mut *(handle as *mut usize as *mut majit_ir::GcRef) });
+        }
+    }
+    visitor(unsafe {
+        &mut *(&mut *TRACE_ALL_HOOK.lock() as *mut usize as *mut majit_ir::GcRef)
+    });
+    visitor(unsafe {
+        &mut *(&mut *PROFILE_ALL_HOOK.lock() as *mut usize as *mut majit_ir::GcRef)
+    });
+}
+
+pub(crate) fn register_execution_context(ec: *const crate::PyExecutionContext) {
+    EXECUTION_CONTEXTS
+        .lock()
+        .insert(current_ident(), ec as usize);
+}
+
+pub(crate) fn unregister_execution_context() {
+    EXECUTION_CONTEXTS.lock().shift_remove(&current_ident());
+}
+
+pub(crate) fn take_async_exception(ec: *mut crate::PyExecutionContext) -> PyObjectRef {
+    let _contexts = EXECUTION_CONTEXTS.lock();
+    unsafe {
+        let w_type = (*ec).w_async_exception_type;
+        (*ec).w_async_exception_type = PY_NULL;
+        if !w_type.is_null() {
+            ASYNC_EXCEPTION_COUNT.fetch_sub(1, Ordering::AcqRel);
+        }
+        w_type
+    }
+}
+
+pub(crate) fn has_pending_async_exception() -> bool {
+    ASYNC_EXCEPTION_COUNT.load(Ordering::Acquire) != 0
+}
+
+/// CPython 3.14 `sys._settraceallthreads` / `_setprofileallthreads`.
+///
+/// Publish the requested hook process-wide, then let each OS thread apply it
+/// to its own PyPy ExecutionContext at the next bytecode boundary.  This keeps
+/// every EC field single-writer under free threading; no caller writes another
+/// live thread's `w_tracefunc` / profile tuple.
+pub(crate) fn set_trace_all_execution_contexts(w_func: PyObjectRef) {
+    *TRACE_ALL_HOOK.lock() = w_func as usize;
+    TRACE_ALL_GENERATION.fetch_add(1, Ordering::Release);
+    let ec = crate::call::getexecutioncontext() as *mut crate::PyExecutionContext;
+    if !ec.is_null() {
+        let _ = unsafe { apply_all_thread_hooks(&mut *ec) };
+    }
+}
+
+pub(crate) fn set_profile_all_execution_contexts(
+    w_func: PyObjectRef,
+) -> Result<(), crate::PyError> {
+    *PROFILE_ALL_HOOK.lock() = w_func as usize;
+    PROFILE_ALL_GENERATION.fetch_add(1, Ordering::Release);
+    let ec = crate::call::getexecutioncontext() as *mut crate::PyExecutionContext;
+    if !ec.is_null() {
+        unsafe { apply_all_thread_hooks(&mut *ec)? };
+    }
+    Ok(())
+}
+
+pub(crate) fn apply_all_thread_hooks(
+    ec: &mut crate::PyExecutionContext,
+) -> Result<(), crate::PyError> {
+    let trace_generation = TRACE_ALL_GENERATION.load(Ordering::Acquire);
+    if ec.trace_all_generation != trace_generation {
+        let w_func = *TRACE_ALL_HOOK.lock() as PyObjectRef;
+        ec.settrace(w_func);
+        ec.trace_all_generation = trace_generation;
+    }
+    let profile_generation = PROFILE_ALL_GENERATION.load(Ordering::Acquire);
+    if ec.profile_all_generation != profile_generation {
+        let w_func = *PROFILE_ALL_HOOK.lock() as PyObjectRef;
+        ec.setprofile(w_func)?;
+        ec.profile_all_generation = profile_generation;
+    }
+    Ok(())
+}
+
+/// CPython compatibility entry used by `test_threading`; PyPy keeps the same
+/// pending exception on `ExecutionContext.w_async_exception_type`.
+#[unsafe(no_mangle)]
+pub extern "C" fn PyThreadState_SetAsyncExc(ident: usize, w_type: PyObjectRef) -> i32 {
+    let contexts = EXECUTION_CONTEXTS.lock();
+    let Some(&ec) = contexts.get(&(ident as i64)) else {
+        return 0;
+    };
+    unsafe {
+        let slot = &mut (*(ec as *mut crate::PyExecutionContext)).w_async_exception_type;
+        match (slot.is_null(), w_type.is_null()) {
+            (true, false) => {
+                ASYNC_EXCEPTION_COUNT.fetch_add(1, Ordering::AcqRel);
+            }
+            (false, true) => {
+                ASYNC_EXCEPTION_COUNT.fetch_sub(1, Ordering::AcqRel);
+            }
+            _ => {}
+        }
+        *slot = w_type;
+    }
+    // pypy/module/__pypy__/interp_signal.py:_raise_in_thread:
+    // `space.actionflag.rearm_ticker()` after updating the EC-owned slot.
+    #[cfg(not(target_arch = "wasm32"))]
+    crate::module::signal::signalstate::rearm_ticker();
+    #[cfg(target_arch = "wasm32")]
+    majit_ir::eval_breaker_word::set_async();
+    1
+}
+
+/// Free-threaded compatibility shims: entering Python does not acquire a GIL.
+#[unsafe(no_mangle)]
+pub extern "C" fn PyGILState_Ensure() -> i32 {
     0
 }
 
-fn lock_set_count(obj: PyObjectRef, v: i64) {
-    let d = crate::baseobjspace::getdict(obj);
-    if d.is_null() {
-        return;
+#[unsafe(no_mangle)]
+pub extern "C" fn PyGILState_Release(_state: i32) {}
+
+/// `pypy/module/sys/threadmappings.py:_current_frames`.
+pub(crate) fn current_frames() -> PyObjectRef {
+    let roots = pyre_object::gc_roots::push_roots();
+    let base = pyre_object::gc_roots::shadow_stack_len();
+    let mut entries = Vec::new();
+    majit_gc::gc_sync::request_stw(|_| {
+        let contexts = EXECUTION_CONTEXTS.lock();
+        for (&ident, &ec) in contexts.iter() {
+            let frame =
+                unsafe { (*(ec as *const crate::PyExecutionContext)).gettopframe_nohidden() };
+            if !frame.is_null() {
+                unsafe { (*frame).mark_as_escaped() };
+                pyre_object::gc_roots::pin_root(frame as PyObjectRef);
+                entries.push(ident);
+            }
+        }
+    });
+    let result = w_dict_new();
+    for (index, ident) in entries.into_iter().enumerate() {
+        let frame = pyre_object::gc_roots::shadow_stack_get(base + index);
+        unsafe { w_dict_setitem(result, ident, frame) };
     }
-    unsafe {
-        w_dict_setitem_str(d, "_locked_count", w_int_new(v));
-    }
+    drop(roots);
+    result
 }
 
-/// `pypy/module/thread/os_lock.py Lock / W_RLock` — single-threaded
-/// pyre treats both the same: `_locked_count` is bumped on acquire,
-/// decremented on release.  RLock ownership semantics
-/// (Condition._is_owned) work because every acquire from the only
-/// thread succeeds.
-mod lock_class {
-    use super::*;
-
-    crate::py_class! {
-        "lock",
-        methods: {
-            fn __enter__(self_obj: PyObjectRef) -> PyObjectRef {
-                lock_set_count(self_obj, lock_count(self_obj) + 1);
-                self_obj
-            }
-            fn __exit__(self_obj: PyObjectRef) -> Result<bool, crate::PyError> {
-                let cur = lock_count(self_obj);
-                if cur <= 0 {
-                    return Err(crate::PyError::runtime_error("release unlocked lock"));
+/// `pypy/module/thread/os_thread.py:reinit_threads`.
+pub(crate) fn after_fork_child() {
+    let ident = current_ident();
+    {
+        let mut contexts = EXECUTION_CONTEXTS.lock();
+        contexts.retain(|thread_ident, _| *thread_ident == ident);
+        if let Some(&ec) = contexts.get(&ident) {
+            for &wref in unsafe {
+                &(*(ec as *const crate::PyExecutionContext)).thread_local_refs
+            } {
+                let local = unsafe {
+                    pyre_object::weakref::w_weakref_deref(
+                        wref as *const pyre_object::weakref::Weakref,
+                    )
+                };
+                if let Some(local) = W_Local::from_obj(local) {
+                    local.after_fork_reinit();
                 }
-                lock_set_count(self_obj, cur - 1);
-                Ok(false)
-            }
-            fn acquire(self_obj: PyObjectRef) -> bool {
-                lock_set_count(self_obj, lock_count(self_obj) + 1);
-                true
-            }
-            fn release(self_obj: PyObjectRef) -> Result<(), crate::PyError> {
-                let cur = lock_count(self_obj);
-                if cur <= 0 {
-                    return Err(crate::PyError::runtime_error("release unlocked lock"));
-                }
-                lock_set_count(self_obj, cur - 1);
-                Ok(())
-            }
-            fn locked(self_obj: PyObjectRef) -> bool {
-                lock_count(self_obj) > 0
-            }
-            fn _is_owned(self_obj: PyObjectRef) -> bool {
-                lock_count(self_obj) > 0
-            }
-            fn _at_fork_reinit(self_obj: PyObjectRef) {
-                lock_set_count(self_obj, 0);
-            }
-            fn _release_save(self_obj: PyObjectRef) -> i64 {
-                let count = lock_count(self_obj);
-                lock_set_count(self_obj, 0);
-                count
-            }
-            fn _acquire_restore(self_obj: PyObjectRef, count: i64) {
-                lock_set_count(self_obj, count.max(1));
-            }
-            fn _recursion_count(self_obj: PyObjectRef) -> i64 {
-                lock_count(self_obj)
             }
         }
     }
-}
-
-/// `lib-python/3/threading.py` `_ThreadHandle` support — stubs that keep
-/// `_make_thread_handle` callable through module shutdown.
-mod thread_handle_class {
-    use super::*;
-
-    crate::py_class! {
-        "_ThreadHandle",
-        methods: {
-            fn is_done(self_obj: PyObjectRef) -> bool {
-                let _ = self_obj;
-                true
-            }
-            fn join(self_obj: PyObjectRef) {
-                let _ = self_obj;
-            }
-            fn set_result(self_obj: PyObjectRef, result: PyObjectRef) {
-                let _ = (self_obj, result);
-            }
-            fn _set_done(self_obj: PyObjectRef) {
-                let _ = self_obj;
+    let handles = std::mem::take(&mut *ACTIVE_HANDLES.lock());
+    for handle in handles {
+        if let Some(handle_obj) = W_ThreadHandle::from_obj(handle as PyObjectRef) {
+            let mut state = handle_obj.state.lock();
+            if state.started && state.ident != ident {
+                state.done = true;
+                handle_obj.done.notify_all();
+            } else if state.started {
+                ACTIVE_HANDLES.lock().push(handle);
             }
         }
     }
+    SHUTDOWN_HANDLES.lock().clear();
+    THREAD_COUNT.store(0, Ordering::SeqCst);
+    pyre_object::listobject::list_locks_after_fork_child();
+    crate::objspace::std::mapdict::after_fork_child();
+    pyre_object::dictmultiobject::module_dict_locks_after_fork_child();
+    majit_gc::shadow_stack::after_fork_child();
+    majit_gc::gc_sync::after_fork_child();
 }
 
-/// `pypy/module/thread/os_local.py Local` — instances need
-/// `__dict__` for per-thread attribute storage; pyre is single-threaded
-/// so there's no real per-thread isolation.
-fn local_type() -> PyObjectRef {
-    // PyPy's Local.typedef is shared; only each Local instance's dictionaries
-    // are execution-context-specific.
-    static TYPE: OnceLock<usize> = OnceLock::new();
-    *TYPE.get_or_init(|| {
-        let tp = crate::typedef::make_builtin_type("_local", |_| {});
-        unsafe { typeobject::w_type_set_hasdict(tp, true) };
-        tp as usize
-    }) as PyObjectRef
-}
-
-// `_thread.start_new_thread(function, args[, kwargs])` — pyre is
-// single-threaded, so the callable runs synchronously and the returned
-// ident is the sole thread's sentinel (1).  A raising target is swallowed
-// (real threads report it via `_excepthook`, never to the spawner).
-fn start_new_thread(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    if args.len() < 2 {
-        return Err(crate::PyError::type_error(
-            "start_new_thread expected at least 2 arguments",
+fn parse_acquire_args(
+    blocking: i64,
+    w_timeout: Option<PyObjectRef>,
+) -> Result<Option<Duration>, crate::PyError> {
+    // os_lock.py `@unwrap_spec(blocking=int, timeout=float)`: unlike the
+    // macro's concrete `f64` receiver, `space.float_w` performs Python's
+    // numeric coercion first, so integer timeout arguments retain their
+    // value instead of being read through a float object's layout.
+    let blocking = blocking != 0;
+    let timeout = match w_timeout {
+        Some(w_timeout) => crate::baseobjspace::float_w(w_timeout)?,
+        None => -1.0,
+    };
+    if !blocking && timeout != -1.0 {
+        return Err(crate::PyError::value_error(
+            "can't specify a timeout for a non-blocking call",
         ));
     }
-    let function = args[0];
-    let call_args = unsafe {
-        if is_tuple(args[1]) {
-            w_tuple_items_copy_as_vec(args[1])
-        } else {
-            return Err(crate::PyError::type_error("2nd arg must be a tuple"));
-        }
-    };
-    let _ = crate::call::call_function_impl_result(function, &call_args);
-    Ok(w_int_new(1))
+    if timeout < 0.0 && timeout != -1.0 {
+        return Err(crate::PyError::value_error(
+            "timeout value must be strictly positive",
+        ));
+    }
+    if timeout > TIMEOUT_MAX {
+        return Err(crate::PyError::overflow_error(
+            "timeout value is too large",
+        ));
+    }
+    Ok(if blocking && timeout >= 0.0 {
+        Some(Duration::from_secs_f64(timeout))
+    } else {
+        None
+    })
 }
 
-fn start_joinable_thread(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    let (pos, _kwargs) = crate::builtins::split_builtin_kwargs(args);
-    let function = pos
-        .first()
-        .copied()
-        .ok_or_else(|| crate::PyError::type_error("missing function argument"))?;
-    let thread_obj = if unsafe { pyre_object::is_method(function) } {
-        unsafe { pyre_object::w_method_get_self(function) }
-    } else {
-        pyre_object::PY_NULL
-    };
-    let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(function);
-    if !thread_obj.is_null() {
-        pyre_object::gc_roots::pin_root(thread_obj);
+mod lock_class {
+use super::*;
+
+#[crate::pyre_class("_thread.lock")]
+#[derive(Default)]
+pub struct W_Lock {
+    locked: Mutex<bool>,
+    ready: Condvar,
+}
+
+#[crate::pyre_methods(
+    doc = "A lock object is a synchronization primitive.",
+    weakrefable
+)]
+impl W_Lock {
+    #[staticmethod]
+    fn __new__(cls: PyObjectRef, args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+        if args.len() > 1 {
+            return Err(crate::PyError::type_error(
+                "_thread.lock() takes no arguments",
+            ));
+        }
+        crate::typedef::check_user_subclass(type_object(), cls)?;
+        let obj = Self::allocate_stable(Self::default());
+        unsafe { (*obj).w_class = cls };
+        Ok(obj)
     }
-    let thread_slot =
-        (!thread_obj.is_null()).then(|| pyre_object::gc_roots::shadow_stack_len() - 1);
-    // A real OS thread starts with a distinct ctypes TLS errno slot.  The
-    // synchronous thread emulator must therefore bracket the call rather than
-    // letting the worker overwrite its caller's slot.
-    let caller_errno = rustpython_host_env::ctypes::get_errno();
-    rustpython_host_env::ctypes::set_errno(0);
-    LOGICAL_THREAD_IDENT.with(|ident| {
-        let previous = ident.replace(2);
-        let _ = crate::call::call_function_impl_result(function, &[]);
-        ident.set(previous);
-    });
-    rustpython_host_env::ctypes::set_errno(caller_errno);
-    // The emulated thread has already completed before this function returns.
-    // Remove its debugging-only weak entry now, matching the state a real
-    // thread reaches once its Thread object becomes unreachable.  This also
-    // avoids leaving a dead weak target for the next nursery collection.
-    if let (Some(slot), Some(threading)) =
-        (thread_slot, crate::importing::get_sys_module("threading"))
-    {
-        let thread_obj = pyre_object::gc_roots::shadow_stack_get(slot);
-        if let Ok(dangling) = crate::baseobjspace::getattr_str(threading, "_dangling") {
-            if let Ok(discard) = crate::baseobjspace::getattr_str(dangling, "discard") {
-                let _ = crate::call::call_function_impl_result(discard, &[thread_obj]);
+
+    fn acquire(
+        &self,
+        #[default(1)] blocking: i64,
+        timeout: Option<PyObjectRef>,
+    ) -> Result<bool, crate::PyError> {
+        let timeout = parse_acquire_args(blocking, timeout)?;
+        let blocking = blocking != 0;
+        // A potentially blocking native lock wait leaves the collector's
+        // RUNNING census.  This does not serialize Python execution.
+        let _blocked = before_external_block();
+        let mut locked = self.locked.lock();
+        if !*locked {
+            *locked = true;
+            return Ok(true);
+        }
+        if !blocking {
+            return Ok(false);
+        }
+        match timeout {
+            None => {
+                while *locked {
+                    self.ready.wait(&mut locked);
+                }
+                *locked = true;
+                Ok(true)
+            }
+            Some(duration) => {
+                let deadline = Instant::now() + duration;
+                while *locked {
+                    let now = Instant::now();
+                    if now >= deadline {
+                        return Ok(false);
+                    }
+                    if self.ready.wait_for(&mut locked, deadline - now).timed_out() && *locked {
+                        return Ok(false);
+                    }
+                }
+                *locked = true;
+                Ok(true)
             }
         }
     }
-    Ok(w_int_new(1))
+
+    fn release(&self) -> Result<(), crate::PyError> {
+        let mut locked = self.locked.lock();
+        if !*locked {
+            return Err(crate::PyError::runtime_error(
+                "release unlocked lock",
+            ));
+        }
+        *locked = false;
+        self.ready.notify_one();
+        Ok(())
+    }
+
+    fn locked(&self) -> bool {
+        *self.locked.lock()
+    }
+
+    fn __enter__(&self) -> Result<PyObjectRef, crate::PyError> {
+        self.acquire(1, None)?;
+        Ok(self as *const Self as PyObjectRef)
+    }
+
+    fn __exit__(&self, _args: &[PyObjectRef]) -> Result<bool, crate::PyError> {
+        self.release()?;
+        Ok(false)
+    }
+
+    fn __repr__(&self) -> String {
+        let state = if self.locked() { "locked" } else { "unlocked" };
+        format!("<{state} _thread.lock object at {:p}>", self)
+    }
+
+    fn _at_fork_reinit(&self) {
+        // The old native mutex/condvar may have been owned by a thread which
+        // vanished at fork.  PyPy's rthread lock reinit replaces the native
+        // lock without trying to acquire or destroy the inherited one.
+        let this = self as *const Self as *mut Self;
+        unsafe {
+            std::ptr::write(&mut (*this).locked, Mutex::new(false));
+            std::ptr::write(&mut (*this).ready, Condvar::new());
+        }
+    }
+}
+}
+use lock_class::W_Lock;
+
+mod rlock_class {
+use super::*;
+
+#[derive(Default)]
+struct RLockState {
+    count: i64,
+    owner: i64,
 }
 
-// PyPy `_thread.get_ident` returns the pthread handle; pyre routes
-// through `rustpython_host_env::thread::current_thread_id`.  Without
-// host_env we always return 1 (single-threaded sentinel).
-pub(crate) fn current_ident() -> i64 {
-    let logical = LOGICAL_THREAD_IDENT.with(Cell::get);
-    if logical != 0 {
-        return logical;
+#[crate::pyre_class("_thread.RLock")]
+#[derive(Default)]
+pub struct W_RLock {
+    state: Mutex<RLockState>,
+    ready: Condvar,
+}
+
+#[crate::pyre_methods(weakrefable)]
+impl W_RLock {
+    #[staticmethod]
+    fn __new__(cls: PyObjectRef, args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+        if args.len() > 1 && cls == type_object() {
+            // CPython 3.14 keeps accepting arguments to the exact native
+            // RLock for compatibility, but deprecates them.  PyPy's
+            // W_RLock allocator likewise ignores construction arguments;
+            // subclasses remain free to consume them in their own __init__.
+            crate::warn::warn_deprecation(
+                "Passing arguments to _thread.RLock() is deprecated",
+            )?;
+        }
+        crate::typedef::check_user_subclass(type_object(), cls)?;
+        let obj = Self::allocate_stable(Self::default());
+        unsafe { (*obj).w_class = cls };
+        Ok(obj)
     }
-    // The sandboxed child is a single logical thread; do not leak the real
-    // thread id (host state), return the single-threaded sentinel instead.
+
+    fn acquire(
+        &self,
+        #[default(1)] blocking: i64,
+        timeout: Option<PyObjectRef>,
+    ) -> Result<bool, crate::PyError> {
+        let timeout = parse_acquire_args(blocking, timeout)?;
+        let blocking = blocking != 0;
+        let ident = current_ident();
+        let _blocked = before_external_block();
+        let mut state = self.state.lock();
+        if state.count > 0 && state.owner == ident {
+            state.count = state
+                .count
+                .checked_add(1)
+                .ok_or_else(|| crate::PyError::overflow_error("internal lock count overflowed"))?;
+            return Ok(true);
+        }
+        if state.count == 0 {
+            state.owner = ident;
+            state.count = 1;
+            return Ok(true);
+        }
+        if !blocking {
+            return Ok(false);
+        }
+        match timeout {
+            None => {
+                while state.count != 0 {
+                    self.ready.wait(&mut state);
+                }
+            }
+            Some(duration) => {
+                let deadline = Instant::now() + duration;
+                while state.count != 0 {
+                    let now = Instant::now();
+                    if now >= deadline {
+                        return Ok(false);
+                    }
+                    if self.ready.wait_for(&mut state, deadline - now).timed_out()
+                        && state.count != 0
+                    {
+                        return Ok(false);
+                    }
+                }
+            }
+        }
+        state.owner = ident;
+        state.count = 1;
+        Ok(true)
+    }
+
+    fn release(&self) -> Result<(), crate::PyError> {
+        let ident = current_ident();
+        let mut state = self.state.lock();
+        if state.count == 0 || state.owner != ident {
+            return Err(crate::PyError::runtime_error(
+                "cannot release un-acquired lock",
+            ));
+        }
+        state.count -= 1;
+        if state.count == 0 {
+            state.owner = 0;
+            self.ready.notify_one();
+        }
+        Ok(())
+    }
+
+    fn locked(&self) -> bool {
+        self.state.lock().count != 0
+    }
+
+    fn _is_owned(&self) -> bool {
+        let state = self.state.lock();
+        state.count > 0 && state.owner == current_ident()
+    }
+
+    fn _recursion_count(&self) -> i64 {
+        let state = self.state.lock();
+        if state.owner == current_ident() {
+            state.count
+        } else {
+            0
+        }
+    }
+
+    fn _release_save(&self) -> Result<PyObjectRef, crate::PyError> {
+        let mut state = self.state.lock();
+        if state.count == 0 {
+            return Err(crate::PyError::runtime_error(
+                "cannot release un-acquired lock",
+            ));
+        }
+        let saved = w_tuple_new(vec![w_int_new(state.count), w_int_new(state.owner)]);
+        state.count = 0;
+        state.owner = 0;
+        self.ready.notify_one();
+        Ok(saved)
+    }
+
+    fn _acquire_restore(&self, saved: PyObjectRef) -> Result<(), crate::PyError> {
+        let items = unsafe {
+            if !is_tuple(saved) {
+                return Err(crate::PyError::type_error("saved state must be a tuple"));
+            }
+            w_tuple_items_copy_as_vec(saved)
+        };
+        if items.len() != 2 || unsafe { !is_int(items[0]) || !is_int(items[1]) } {
+            return Err(crate::PyError::type_error("invalid saved state"));
+        }
+        let count = unsafe { w_int_get_value(items[0]) };
+        let owner = unsafe { w_int_get_value(items[1]) };
+        let _blocked = before_external_block();
+        let mut state = self.state.lock();
+        if state.count != 0 {
+            while state.count != 0 {
+                self.ready.wait(&mut state);
+            }
+        }
+        state.count = count;
+        state.owner = owner;
+        Ok(())
+    }
+
+    fn __enter__(&self) -> Result<PyObjectRef, crate::PyError> {
+        self.acquire(1, None)?;
+        Ok(self as *const Self as PyObjectRef)
+    }
+
+    fn __exit__(&self, _args: &[PyObjectRef]) -> Result<bool, crate::PyError> {
+        self.release()?;
+        Ok(false)
+    }
+
+    fn __repr__(&self) -> String {
+        let state = self.state.lock();
+        let locked = if state.count == 0 { "unlocked" } else { "locked" };
+        format!(
+            "<{locked} _thread.RLock object owner={} count={} at {:p}>",
+            state.owner, state.count, self
+        )
+    }
+
+    fn _at_fork_reinit(&self) {
+        let this = self as *const Self as *mut Self;
+        unsafe {
+            std::ptr::write(&mut (*this).state, Mutex::new(RLockState::default()));
+            std::ptr::write(&mut (*this).ready, Condvar::new());
+        }
+    }
+}
+}
+use rlock_class::W_RLock;
+
+mod handle_class {
+use super::*;
+
+#[derive(Default)]
+pub(super) struct HandleState {
+    pub(super) started: bool,
+    pub(super) done: bool,
+    pub(super) ident: i64,
+    pub(super) daemon: bool,
+}
+
+#[crate::pyre_class("_thread._ThreadHandle")]
+#[derive(Default)]
+pub struct W_ThreadHandle {
+    pub(super) state: Mutex<HandleState>,
+    pub(super) done: Condvar,
+}
+
+#[crate::pyre_methods]
+impl W_ThreadHandle {
+    #[staticmethod]
+    fn __new__(cls: PyObjectRef, args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+        if args.len() > 1 {
+            return Err(crate::PyError::type_error(
+                "_ThreadHandle() takes no arguments",
+            ));
+        }
+        crate::typedef::check_user_subclass(type_object(), cls)?;
+        let obj = Self::allocate_stable(Self::default());
+        unsafe { (*obj).w_class = cls };
+        Ok(obj)
+    }
+
+    #[getter]
+    fn ident(&self) -> i64 {
+        self.state.lock().ident
+    }
+
+    fn is_done(&self) -> bool {
+        self.state.lock().done
+    }
+
+    pub(super) fn join(&self, #[default(pyre_object::w_none())] timeout: PyObjectRef) -> Result<(), crate::PyError> {
+        let duration = unsafe {
+            if is_none(timeout) {
+                None
+            } else if is_float(timeout) {
+                Some(Duration::from_secs_f64(
+                    floatobject::w_float_get_value(timeout).max(0.0),
+                ))
+            } else if is_int(timeout) {
+                Some(Duration::from_secs(w_int_get_value(timeout).max(0) as u64))
+            } else {
+                return Err(crate::PyError::type_error("timeout must be a number or None"));
+            }
+        };
+        let mut state = self.state.lock();
+        if !state.started {
+            return Err(crate::PyError::runtime_error("thread not started"));
+        }
+        if state.ident == current_ident() && !state.done {
+            return Err(crate::PyError::runtime_error("Cannot join current thread"));
+        }
+        if state.done {
+            return Ok(());
+        }
+        if state.daemon && is_finalizing() {
+            let cls = crate::builtins::lookup_exc_class("PythonFinalizationError")
+                .expect("PythonFinalizationError must be installed");
+            let exc = crate::builtins::exc_exception_new(&[cls])?;
+            return Err(unsafe { crate::PyError::from_exc_object(exc) });
+        }
+        let _blocked = before_external_block();
+        match duration {
+            None => {
+                while !state.done {
+                    self.done.wait(&mut state);
+                }
+            }
+            Some(timeout) => {
+                let deadline = Instant::now() + timeout;
+                while !state.done {
+                    let now = Instant::now();
+                    if now >= deadline {
+                        break;
+                    }
+                    if self.done.wait_for(&mut state, deadline - now).timed_out() {
+                        break;
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn _set_done(&self) -> Result<(), crate::PyError> {
+        let mut state = self.state.lock();
+        if !state.started {
+            return Err(crate::PyError::runtime_error("thread not started"));
+        }
+        state.done = true;
+        self.done.notify_all();
+        Ok(())
+    }
+}
+}
+use handle_class::W_ThreadHandle;
+
+impl W_ThreadHandle {
+    fn start(&self, ident: i64) -> Result<(), crate::PyError> {
+        let mut state = self.state.lock();
+        if state.started {
+            return Err(crate::PyError::runtime_error("thread already started"));
+        }
+        state.started = true;
+        state.ident = ident;
+        ACTIVE_HANDLES.lock().push(self as *const Self as usize);
+        Ok(())
+    }
+
+    fn finish(&self) {
+        let mut state = self.state.lock();
+        state.done = true;
+        self.done.notify_all();
+        let address = self as *const Self as usize;
+        ACTIVE_HANDLES.lock().retain(|handle| *handle != address);
+    }
+}
+
+mod local_class {
+use super::*;
+
+/// `pypy/module/thread/os_local.py Local`.
+///
+/// `dicts` is deliberately a Python dict, matching upstream's
+/// `self.dicts = {}` and keeping every per-ExecutionContext dictionary on the
+/// object's ordinary GC graph.  The integer key is pyre's stable identity for
+/// the current OS-thread ExecutionContext.
+#[crate::pyre_class("_thread._local")]
+pub struct W_Local {
+    dicts: PyObjectRef,
+    last_dict: PyObjectRef,
+    last_ident: i64,
+    state_lock: Mutex<()>,
+}
+
+impl W_Local {
+    pub(super) fn current_dict(&self) -> PyObjectRef {
+        let _guard = self.state_lock.lock();
+        let this = self as *const Self as *mut Self;
+        let ident = current_ident();
+        if self.last_ident == ident && !self.last_dict.is_null() {
+            return self.last_dict;
+        }
+        let w_dict = unsafe { pyre_object::w_dict_getitem(self.dicts, ident) }
+            .unwrap_or_else(|| {
+                let w_dict = pyre_object::w_dict_new();
+                unsafe { pyre_object::w_dict_setitem(self.dicts, ident, w_dict) };
+                register_local_in_current_ec(self as *const Self as PyObjectRef);
+                w_dict
+            });
+        unsafe {
+            (*this).last_ident = ident;
+            (*this).last_dict = w_dict;
+        }
+        pyre_object::gc_hook::try_gc_write_barrier(this as *mut u8);
+        w_dict
+    }
+
+    pub(super) fn thread_is_stopping(&self, ident: i64) {
+        let _guard = self.state_lock.lock();
+        let this = self as *const Self as *mut Self;
+        let key = w_int_new(ident);
+        unsafe {
+            pyre_object::w_dict_delitem(self.dicts, key);
+            if (*this).last_ident == ident {
+                (*this).last_ident = 0;
+                (*this).last_dict = PY_NULL;
+            }
+        }
+    }
+
+    pub(super) fn after_fork_reinit(&self) {
+        let this = self as *const Self as *mut Self;
+        unsafe {
+            std::ptr::write(&mut (*this).state_lock, parking_lot::const_mutex(()));
+        }
+    }
+}
+
+#[crate::pyre_methods(
+    doc = "Thread-local data",
+    weakrefable
+)]
+impl W_Local {
+    #[staticmethod]
+    fn __new__(cls: PyObjectRef, args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+        crate::typedef::check_user_subclass(type_object(), cls)?;
+        // os_local.py installs the first dictionary before app-level
+        // __init__ is entered, preventing recursive initialization.
+        let dicts = pyre_object::w_dict_new();
+        let w_dict = pyre_object::w_dict_new();
+        let ident = current_ident();
+        unsafe { pyre_object::w_dict_setitem(dicts, ident, w_dict) };
+        let obj = Self::allocate_stable(Self {
+            ob: PyObject::default(),
+            dicts,
+            last_dict: w_dict,
+            last_ident: ident,
+            state_lock: parking_lot::const_mutex(()),
+        });
+        unsafe { (*obj).w_class = cls };
+        register_local_in_current_ec(obj);
+
+        // The base `_local` has no app-level initializer accepting arguments.
+        // Subclass initialization is dispatched by the ordinary type call
+        // after this allocator returns, exactly as for PyPy's TypeDef.
+        if args.len() > 1 && cls == type_object() {
+            return Err(crate::PyError::type_error(
+                "Initialization arguments are not supported",
+            ));
+        }
+        Ok(obj)
+    }
+
+    #[getter]
+    fn __dict__(&self) -> PyObjectRef {
+        self.current_dict()
+    }
+}
+}
+pub use local_class::W_Local;
+
+fn local_type() -> PyObjectRef {
+    local_class::type_object()
+}
+
+/// W_Root.getdict dispatch for `os_local.Local.getdict`.
+pub(crate) fn local_getdict(obj: PyObjectRef) -> Option<PyObjectRef> {
+    let local = W_Local::from_obj(obj)?;
+    Some(local.current_dict())
+}
+
+/// `os_local.py:Local._register_in_ec`.
+fn register_local_in_current_ec(local: PyObjectRef) {
+    let ec = crate::call::getexecutioncontext() as *mut crate::PyExecutionContext;
+    if ec.is_null() {
+        return;
+    }
+    let root = pyre_object::gc_roots::push_roots();
+    pyre_object::gc_roots::pin_root(local);
+    let wref = unsafe { pyre_object::weakref::w_weakref_new(local) as PyObjectRef };
+    unsafe { (*ec).thread_local_refs.push(wref) };
+    drop(root);
+}
+
+/// `os_local.py:thread_is_stopping`.
+fn thread_is_stopping(ec: &mut crate::PyExecutionContext) {
+    let ident = current_ident();
+    for wref in std::mem::take(&mut ec.thread_local_refs) {
+        let local = unsafe {
+            pyre_object::weakref::w_weakref_deref(
+                wref as *const pyre_object::weakref::Weakref,
+            )
+        };
+        if let Some(local) = W_Local::from_obj(local) {
+            local.thread_is_stopping(ident);
+        }
+    }
+}
+
+pub(crate) fn current_ident() -> i64 {
     #[cfg(all(
         feature = "host_env",
         not(target_arch = "wasm32"),
@@ -224,9 +943,7 @@ pub(crate) fn current_ident() -> i64 {
         return rustpython_host_env::thread::current_thread_id() as i64;
     }
     #[allow(unreachable_code)]
-    {
-        1
-    }
+    1
 }
 
 #[crate::pyre_function]
@@ -234,14 +951,15 @@ fn get_ident() -> i64 {
     current_ident()
 }
 
-// `_thread.get_native_id()` — kernel-level TID, NOT the pthread
-// handle.  Mirrors `rthread.c_get_native_id` (pypy/module/thread/
-// os_thread.py:204-210):
-//   * Linux/Android: syscall(SYS_gettid)
-//   * macOS:         pthread_threadid_np(NULL, &tid)
-//   * Other Unix:    pthread_self  (no true TID concept)
 #[crate::pyre_function]
 fn get_native_id() -> i64 {
+    #[cfg(all(not(feature = "sandbox"), target_os = "macos"))]
+    {
+        let mut tid: u64 = 0;
+        if unsafe { libc::pthread_threadid_np(0, &mut tid) } == 0 {
+            return tid as i64;
+        }
+    }
     #[cfg(all(
         not(feature = "sandbox"),
         any(target_os = "linux", target_os = "android")
@@ -249,53 +967,392 @@ fn get_native_id() -> i64 {
     {
         return unsafe { libc::syscall(libc::SYS_gettid) } as i64;
     }
-    #[cfg(all(not(feature = "sandbox"), target_os = "macos"))]
-    {
-        let mut tid: u64 = 0;
-        let rc = unsafe { libc::pthread_threadid_np(0, &mut tid as *mut u64) };
-        if rc == 0 {
-            return tid as i64;
+    current_ident()
+}
+
+fn new_lock(_: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    Ok(W_Lock::allocate_stable(W_Lock::default()))
+}
+
+fn new_handle(_: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    Ok(W_ThreadHandle::allocate_stable(W_ThreadHandle::default()))
+}
+
+fn make_thread_handle(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let ident = unsafe { w_int_get_value(args[0]) };
+    let obj = W_ThreadHandle::allocate_stable(W_ThreadHandle::default());
+    W_ThreadHandle::from_obj(obj).unwrap().start(ident)?;
+    Ok(obj)
+}
+
+fn call_thread_target(
+    callable: PyObjectRef,
+    positional: &[PyObjectRef],
+    kwargs: Option<PyObjectRef>,
+    ec: *const crate::PyExecutionContext,
+) -> Result<PyObjectRef, crate::PyError> {
+    if kwargs.is_none_or(|d| unsafe { w_dict_str_entries(d) }.is_empty()) {
+        return crate::call::call_function_impl_result(callable, positional);
+    }
+    let kwargs = kwargs.unwrap();
+    let entries = unsafe { w_dict_str_entries(kwargs) };
+    let (target, args) = unsafe {
+        if is_method(callable) {
+            let func = w_method_get_func(callable);
+            let receiver = w_method_get_self(callable);
+            let mut args = Vec::with_capacity(positional.len() + 1);
+            args.push(receiver);
+            args.extend_from_slice(positional);
+            (func, args)
+        } else {
+            (callable, positional.to_vec())
         }
-        return unsafe { libc::pthread_self() } as i64;
+    };
+    if unsafe { crate::is_function(target) } {
+        let mut mixed = args;
+        let mut names = Vec::with_capacity(entries.len());
+        for (name, value) in entries {
+            mixed.push(value);
+            names.push(w_str_new(&name));
+        }
+        let kwarg_names = w_tuple_new(names);
+        let resolved = crate::call::resolve_kwargs(target, &mixed, kwarg_names)?;
+        crate::call::call_user_function_plain_with_ctx(ec, target, &resolved)
+    } else {
+        Err(crate::PyError::type_error(
+            "keyword arguments for this thread target are not supported",
+        ))
     }
-    #[cfg(all(
-        not(feature = "sandbox"),
-        unix,
-        not(any(target_os = "linux", target_os = "android", target_os = "macos"))
-    ))]
+}
+
+fn spawn_thread(
+    callable: PyObjectRef,
+    positional: Vec<PyObjectRef>,
+    kwargs: Option<PyObjectRef>,
+    handle: Option<PyObjectRef>,
+) -> Result<i64, crate::PyError> {
+    let parent_ec = crate::call::getexecutioncontext();
+    if parent_ec.is_null() {
+        return Err(crate::PyError::runtime_error("no execution context"));
+    }
+
+    let roots = pyre_object::gc_roots::push_roots();
+    let base = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(callable);
+    for &arg in &positional {
+        pyre_object::gc_roots::pin_root(arg);
+    }
+    if let Some(d) = kwargs {
+        pyre_object::gc_roots::pin_root(d);
+    }
+    if let Some(h) = handle {
+        pyre_object::gc_roots::pin_root(h);
+    }
+    let nargs = positional.len();
+    let has_kwargs = kwargs.is_some();
+    let has_handle = handle.is_some();
+    let callable_addr = callable as usize;
+    let args_addr: Vec<usize> = positional.iter().map(|&p| p as usize).collect();
+    let kwargs_addr = kwargs.unwrap_or(PY_NULL) as usize;
+    let handle_addr = handle.unwrap_or(PY_NULL) as usize;
+    let parent_ec_addr = parent_ec as usize;
+    let (started_tx, started_rx) = std::sync::mpsc::sync_channel(0);
+
+    let mut builder = std::thread::Builder::new();
+    let stack_size = STACK_SIZE.load(Ordering::Relaxed);
+    if stack_size != 0 {
+        builder = builder.stack_size(stack_size);
+    }
+    builder
+        .spawn(move || {
+            crate::call::enter_runtime_thread();
+            // The parent holds these in its shadow stack until `started_tx`.
+            // Copy them into this mutator's own shadow stack before any
+            // interpreter allocation can trigger a moving collection.
+            let worker_roots = pyre_object::gc_roots::push_roots();
+            let worker_base = pyre_object::gc_roots::shadow_stack_len();
+            pyre_object::gc_roots::pin_root(callable_addr as PyObjectRef);
+            for addr in &args_addr {
+                pyre_object::gc_roots::pin_root(*addr as PyObjectRef);
+            }
+            if has_kwargs {
+                pyre_object::gc_roots::pin_root(kwargs_addr as PyObjectRef);
+            }
+            if has_handle {
+                pyre_object::gc_roots::pin_root(handle_addr as PyObjectRef);
+            }
+
+            let mut ec = Box::new(unsafe {
+                (*(parent_ec_addr as *const crate::PyExecutionContext)).clone_for_thread()
+            });
+            let ec_ptr = &*ec as *const crate::PyExecutionContext;
+            crate::call::set_last_exec_ctx(ec_ptr);
+            // `install_user_del_action` can allocate.  Publish the fresh EC
+            // first, matching OSThreadLocals.enter_thread() installing the
+            // ExecutionContext before thread bootstrap invokes Python code.
+            ec.install_user_del_action();
+            let ident = current_ident();
+            if has_handle {
+                let h = W_ThreadHandle::from_obj(handle_addr as PyObjectRef).unwrap();
+                if let Err(e) = h.start(ident) {
+                    let _ = started_tx.send(Err(e.message));
+                    thread_is_stopping(&mut ec);
+                    crate::call::set_last_exec_ctx(std::ptr::null());
+                    drop(worker_roots);
+                    drop(ec);
+                    return;
+                }
+            }
+            THREAD_COUNT.fetch_add(1, Ordering::SeqCst);
+            let _ = started_tx.send(Ok(ident));
+
+            let callable = pyre_object::gc_roots::shadow_stack_get(worker_base);
+            let args: Vec<PyObjectRef> = (0..nargs)
+                .map(|i| pyre_object::gc_roots::shadow_stack_get(worker_base + 1 + i))
+                .collect();
+            let mut next = worker_base + 1 + nargs;
+            let kwargs = if has_kwargs {
+                let d = pyre_object::gc_roots::shadow_stack_get(next);
+                next += 1;
+                Some(d)
+            } else {
+                None
+            };
+            let handle = if has_handle {
+                Some(pyre_object::gc_roots::shadow_stack_get(next))
+            } else {
+                None
+            };
+            // `JitDriver` currently owns a per-TLS background compiler.
+            // Creating a compiler thread for every short-lived Python thread
+            // makes teardown wait on unrelated compiler polling.  Execute
+            // worker frames through the same interpreter source until the
+            // driver owner is made interpreter-global.
+            let _plain_worker = crate::call::force_plain_eval();
+            if let Err(mut error) = call_thread_target(callable, &args, kwargs, ec_ptr) {
+                let callable_repr = unsafe {
+                    crate::py_repr(callable).unwrap_or_else(|_| "<unknown>".to_string())
+                };
+                error.write_unraisable(
+                    w_none(),
+                    &format!("Exception ignored in thread started by {callable_repr}"),
+                    w_none(),
+                );
+            }
+            thread_is_stopping(&mut ec);
+            crate::call::set_last_exec_ctx(std::ptr::null());
+            drop(worker_roots);
+            drop(ec);
+            // `_thread._count()` is the completion signal used by PyPy's
+            // thread helpers for non-joinable `start_new_thread` workers.
+            // Publish it only after EC unregistration and shadow-root teardown;
+            // otherwise the main thread can begin finalization GC while this
+            // mutator is still dismantling its runtime state.
+            THREAD_COUNT.fetch_sub(1, Ordering::SeqCst);
+            // Match the upstream thread-state teardown order: a joinable
+            // handle becomes done only after the worker's interpreter roots
+            // and ExecutionContext have gone away.  In particular, join()
+            // must not return while the worker still roots Thread._bootstrap,
+            // which would keep Thread._target argument cycles alive.
+            if let Some(handle) = handle {
+                W_ThreadHandle::from_obj(handle).unwrap().finish();
+            }
+        })
+        .map_err(|_| crate::PyError::runtime_error("can't start new thread"))?;
+
+    let result = {
+        let _blocked = before_external_block();
+        started_rx
+            .recv()
+            .map_err(|_| crate::PyError::runtime_error("can't start new thread"))?
+    };
+    drop(roots);
+    result.map_err(crate::PyError::runtime_error)
+}
+
+fn start_new_thread(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    if is_finalizing() {
+        return Err(crate::PyError::runtime_error(
+            "can't create new thread at interpreter shutdown",
+        ));
+    }
+    let (pos, kwargs_marker) = crate::builtins::split_builtin_kwargs(args);
+    if pos.len() < 2 || pos.len() > 3 {
+        return Err(crate::PyError::type_error(
+            "start_new_thread expected 2 or 3 arguments",
+        ));
+    }
+    let callable = pos[0];
+    if !crate::baseobjspace::callable_w(callable) {
+        return Err(crate::PyError::type_error("first arg must be callable"));
+    }
+    if unsafe { !is_tuple(pos[1]) } {
+        return Err(crate::PyError::type_error("2nd arg must be a tuple"));
+    }
+    let positional = unsafe { w_tuple_items_copy_as_vec(pos[1]) };
+    let kwargs = pos.get(2).copied().or_else(|| {
+        crate::builtins::kwarg_get(kwargs_marker, "kwargs")
+    });
+    if kwargs.is_some_and(|d| unsafe { !is_dict(d) }) {
+        return Err(crate::PyError::type_error(
+            "optional 3rd arg must be a dictionary",
+        ));
+    }
+    Ok(w_int_new(spawn_thread(
+        callable, positional, kwargs, None,
+    )?))
+}
+
+fn start_joinable_thread(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    if is_finalizing() {
+        return Err(crate::PyError::runtime_error(
+            "can't create new thread at interpreter shutdown",
+        ));
+    }
+    let (pos, kwargs) = crate::builtins::split_builtin_kwargs(args);
+    let callable = pos
+        .first()
+        .copied()
+        .ok_or_else(|| crate::PyError::type_error("missing function argument"))?;
+    if !crate::baseobjspace::callable_w(callable) {
+        return Err(crate::PyError::type_error("function must be callable"));
+    }
+    let requested = crate::builtins::kwarg_get(kwargs, "handle");
+    let daemon = match crate::builtins::kwarg_get(kwargs, "daemon") {
+        Some(value) => crate::baseobjspace::is_true(value)?,
+        None => false,
+    };
+    let handle = match requested {
+        Some(obj) if unsafe { !is_none(obj) } => {
+            if W_ThreadHandle::from_obj(obj).is_none() {
+                return Err(crate::PyError::type_error("handle must be a _ThreadHandle"));
+            }
+            obj
+        }
+        _ => W_ThreadHandle::allocate_stable(W_ThreadHandle::default()),
+    };
+    if let Some(handle_obj) = W_ThreadHandle::from_obj(handle) {
+        handle_obj.state.lock().daemon = daemon;
+    }
+    spawn_thread(callable, Vec::new(), None, Some(handle))?;
+    if !daemon {
+        SHUTDOWN_HANDLES.lock().push(handle as usize);
+    }
+    Ok(handle)
+}
+
+fn shutdown_threads(_: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    // CPython `thread_shutdown` and PyPy's bootstrapper shutdown both include
+    // non-daemon threads started by a thread which is itself being joined.
+    // Drain repeatedly because joining one snapshot may publish another.
+    loop {
+        let handles = std::mem::take(&mut *SHUTDOWN_HANDLES.lock());
+        if handles.is_empty() {
+            break;
+        }
+        for handle in handles {
+            if let Some(handle) = W_ThreadHandle::from_obj(handle as PyObjectRef) {
+                handle.join(w_none())?;
+            }
+        }
+    }
+    Ok(w_none())
+}
+
+fn stack_size(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    if args.len() > 1 {
+        return Err(crate::PyError::type_error(
+            "stack_size() takes at most 1 argument",
+        ));
+    }
+    let old = STACK_SIZE.load(Ordering::Relaxed);
+    if let Some(&arg) = args.first() {
+        let size = unsafe { w_int_get_value(arg) };
+        if size < 0 || (size != 0 && size < 32_768) {
+            return Err(crate::PyError::value_error(format!(
+                "size not valid: {size} bytes"
+            )));
+        }
+        STACK_SIZE.store(size as usize, Ordering::Relaxed);
+    }
+    Ok(w_int_new(old as i64))
+}
+
+fn interrupt_main(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    if args.len() > 1 {
+        return Err(crate::PyError::type_error(
+            "interrupt_main() takes at most 1 argument",
+        ));
+    }
+    #[cfg(not(target_arch = "wasm32"))]
+    let signum = args
+        .first()
+        .map(|&arg| unsafe { w_int_get_value(arg) as i32 })
+        .unwrap_or(libc::SIGINT);
+    #[cfg(target_arch = "wasm32")]
+    let signum = args
+        .first()
+        .map(|&arg| unsafe { w_int_get_value(arg) as i32 })
+        .unwrap_or(2);
+    #[cfg(not(target_arch = "wasm32"))]
+    if !(1..crate::module::signal::signalstate::NSIG).contains(&signum) {
+        return Err(crate::PyError::value_error("signal number out of range"));
+    }
+    #[cfg(target_arch = "wasm32")]
+    if !(1..65).contains(&signum) {
+        return Err(crate::PyError::value_error("signal number out of range"));
+    }
+    let ec = crate::call::getexecutioncontext();
+    #[cfg(target_arch = "wasm32")]
+    let _ = ec;
+    #[cfg(target_arch = "wasm32")]
     {
-        return unsafe { libc::pthread_self() } as i64;
+        let cls = crate::builtins::lookup_exc_class("KeyboardInterrupt")
+            .expect("KeyboardInterrupt must be installed");
+        let exc = crate::builtins::exc_exception_new(&[cls])?;
+        return Err(unsafe { crate::PyError::from_exc_object(exc) });
     }
-    // Sandbox and non-unix: a fixed single-thread sentinel — the sandboxed
-    // child must not issue the raw `gettid`/`pthread_self` that would expose the
-    // real kernel/pthread id.
-    #[allow(unreachable_code)]
-    {
-        1
+    #[cfg(not(target_arch = "wasm32"))]
+    if ec.is_null() || unsafe { (*ec).check_signal_action.is_none() } {
+        let cls = crate::builtins::lookup_exc_class("KeyboardInterrupt")
+            .expect("KeyboardInterrupt must be installed");
+        let exc = crate::builtins::exc_exception_new(&[cls])?;
+        return Err(unsafe { crate::PyError::from_exc_object(exc) });
     }
+    #[cfg(not(target_arch = "wasm32"))]
+    crate::module::signal::signalstate::signal_pushback(signum);
+    #[cfg(not(target_arch = "wasm32"))]
+    Ok(w_none())
 }
 
 crate::py_module! {
     "_thread",
     interpleveldefs: {
-        "LockType"      => lock_class::type_object(),
-        "_ThreadHandle" => thread_handle_class::type_object(),
+        "LockType"      => {
+            let ty = lock_class::type_object();
+            unsafe { pyre_object::w_type_set_acceptable_as_base_class(ty, false) };
+            ty
+        },
+        "RLock"         => rlock_class::type_object(),
+        "_ThreadHandle" => handle_class::type_object(),
         "_local"        => local_type(),
-        "TIMEOUT_MAX"   => w_float_new(f64::MAX),
-        "error"         => crate::typedef::w_object(),
+        "TIMEOUT_MAX"   => w_float_new(TIMEOUT_MAX),
+        "error"         => crate::builtins::lookup_exc_class("RuntimeError")
+                               .unwrap_or_else(crate::typedef::w_object),
     },
     functions: {
-        "RLock"                  / 0 = |_| Ok(w_instance_new(lock_class::type_object())),
-        "allocate_lock"          / 0 = |_| Ok(w_instance_new(lock_class::type_object())),
-        "_set_sentinel"          / 0 = |_| Ok(w_instance_new(lock_class::type_object())),
-        "_make_thread_handle"    / 1 = |_| Ok(w_instance_new(thread_handle_class::type_object())),
+        "allocate_lock"          / 0 = new_lock,
+        "allocate"               / 0 = new_lock,
+        "_set_sentinel"          / 0 = new_lock,
+        "_make_thread_handle"    / 1 = make_thread_handle,
         "get_ident"              / 0 = get_ident,
         "get_native_id"          / 0 = get_native_id,
-        "_count"                 / 0 = |_| Ok(w_int_new(1)),
+        "_count"                 / 0 = |_| Ok(w_int_new(THREAD_COUNT.load(Ordering::SeqCst))),
         "_is_main_interpreter"   / 0 = |_| Ok(w_bool_from(true)),
         "daemon_threads_allowed" / 0 = |_| Ok(w_bool_from(true)),
-        "_shutdown"              / 0 = |_| Ok(w_none()),
-        "stack_size"             / 1 = |_| Ok(w_int_new(0)),
+        "_shutdown"              / 0 = shutdown_threads,
+        "stack_size"             / * = stack_size,
+        "interrupt_main"         / * = interrupt_main,
         "set_name"               / 1 = |_| Ok(w_none()),
         "_excepthook"            / 1 = |_| Ok(w_none()),
         "_get_main_thread_ident" / 0 = |_| Ok(w_int_new(current_ident())),

--- a/pyre/pyre-interpreter/src/module/time/interp_time.rs
+++ b/pyre/pyre-interpreter/src/module/time/interp_time.rs
@@ -169,6 +169,9 @@ pub fn sleep(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         return Ok(w_none());
     }
     let dur = std::time::Duration::from_nanos(timeout_ns as u64);
+    // interp_time.py's `time_sleep` is an `@rffi` external call.  In pyre the
+    // blocking mutator leaves the free-threaded GC's STW RUNNING census.
+    let _blocking = crate::module::thread::before_external_block();
     #[cfg(feature = "sandbox")]
     {
         // The controller services the sleep; signal handling is its concern.

--- a/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
+++ b/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
@@ -10,11 +10,55 @@
 
 use crate::PyError;
 use pyre_object::PyObjectRef;
+use parking_lot::ReentrantMutex;
 
 use rustpython_wtf8::{Wtf8, Wtf8Buf};
-use std::cell::{Cell, RefCell};
+use std::cell::{Cell, RefCell, UnsafeCell};
 use std::collections::HashMap;
-use std::sync::Mutex;
+use std::sync::{LazyLock, Mutex};
+
+// PyPy serializes mapdict map/storage transitions with the GIL.  Pyre is
+// free-threaded, so use narrow address-striped reentrant locks around the same
+// transition boundaries.  This is synchronization only; attribute state
+// remains on `W_ObjectObject.map/storage`, exactly as upstream.
+struct ForkReentrantLock(UnsafeCell<ReentrantMutex<()>>);
+unsafe impl Sync for ForkReentrantLock {}
+
+impl ForkReentrantLock {
+    fn new() -> Self {
+        Self(UnsafeCell::new(ReentrantMutex::new(())))
+    }
+
+    fn get(&self) -> &ReentrantMutex<()> {
+        unsafe { &*self.0.get() }
+    }
+
+    unsafe fn reinit_after_fork(&self) {
+        unsafe { self.0.get().write(ReentrantMutex::new(())) };
+    }
+}
+
+static INSTANCE_LOCKS: LazyLock<Vec<ForkReentrantLock>> =
+    LazyLock::new(|| (0..256).map(|_| ForkReentrantLock::new()).collect());
+static CODE_CACHE_LOCKS: LazyLock<Vec<ForkReentrantLock>> =
+    LazyLock::new(|| (0..256).map(|_| ForkReentrantLock::new()).collect());
+
+fn instance_lock_for(obj: PyObjectRef) -> &'static ReentrantMutex<()> {
+    INSTANCE_LOCKS[(obj as usize >> 4) & (INSTANCE_LOCKS.len() - 1)].get()
+}
+
+fn code_cache_lock_for(code: PyObjectRef) -> &'static ReentrantMutex<()> {
+    CODE_CACHE_LOCKS[(code as usize >> 4) & (CODE_CACHE_LOCKS.len() - 1)].get()
+}
+
+pub fn after_fork_child() {
+    for lock in INSTANCE_LOCKS.iter() {
+        unsafe { lock.reinit_after_fork() };
+    }
+    for lock in CODE_CACHE_LOCKS.iter() {
+        unsafe { lock.reinit_after_fork() };
+    }
+}
 
 // ── attribute shapes (mapdict.py:32-42, 720-732) ──────────────────────
 
@@ -340,6 +384,7 @@ pub unsafe fn instance_node_setdictvalue(
     name: &Wtf8,
     value: PyObjectRef,
 ) -> bool {
+    let _instance_guard = instance_lock_for(obj).lock();
     ensure_mapdict_initialized(obj);
     let inst = &mut *(obj as *mut pyre_object::W_ObjectObject);
     let map = inst._get_mapdict_map();
@@ -364,6 +409,7 @@ pub unsafe fn instance_node_setdictvalue(
 /// `obj` must be a live `W_ObjectObject` (caller guards with `is_instance`).
 #[majit_macros::dont_look_inside]
 pub unsafe fn instance_node_getdictvalue(obj: PyObjectRef, name: &Wtf8) -> Option<PyObjectRef> {
+    let _instance_guard = instance_lock_for(obj).lock();
     ensure_mapdict_initialized(obj);
     let inst = &mut *(obj as *mut pyre_object::W_ObjectObject);
     let map = inst._get_mapdict_map();
@@ -388,6 +434,7 @@ pub unsafe fn instance_node_getdictvalue(obj: PyObjectRef, name: &Wtf8) -> Optio
 /// `obj` must be a live `W_ObjectObject` (caller guards with `is_instance`).
 #[majit_macros::dont_look_inside]
 pub unsafe fn instance_node_deldictvalue(obj: PyObjectRef, name: &Wtf8) -> bool {
+    let _instance_guard = instance_lock_for(obj).lock();
     ensure_mapdict_initialized(obj);
     let inst = &mut *(obj as *mut pyre_object::W_ObjectObject);
     let map = inst._get_mapdict_map();
@@ -413,6 +460,7 @@ pub unsafe fn instance_node_deldictvalue(obj: PyObjectRef, name: &Wtf8) -> bool 
 /// `obj` must be a live `W_ObjectObject` (caller guards with `is_instance`).
 #[majit_macros::dont_look_inside]
 pub unsafe fn instance_get_dict_slot(obj: PyObjectRef) -> Option<PyObjectRef> {
+    let _instance_guard = instance_lock_for(obj).lock();
     ensure_mapdict_initialized(obj);
     let inst = &*(obj as *const pyre_object::W_ObjectObject);
     let map = inst._get_mapdict_map();
@@ -432,6 +480,7 @@ pub unsafe fn instance_get_dict_slot(obj: PyObjectRef) -> Option<PyObjectRef> {
 /// `obj` must be a live `W_ObjectObject` (caller guards with `is_instance`).
 #[majit_macros::dont_look_inside]
 pub unsafe fn instance_set_dict_slot(obj: PyObjectRef, w_dict: PyObjectRef) -> bool {
+    let _instance_guard = instance_lock_for(obj).lock();
     ensure_mapdict_initialized(obj);
     let inst = &mut *(obj as *mut pyre_object::W_ObjectObject);
     let map = inst._get_mapdict_map();
@@ -445,6 +494,7 @@ pub unsafe fn instance_set_dict_slot(obj: PyObjectRef, w_dict: PyObjectRef) -> b
 /// `obj` must be a live `W_ObjectObject`.
 #[majit_macros::dont_look_inside]
 pub unsafe fn instance_get_weakref_slot(obj: PyObjectRef) -> Option<PyObjectRef> {
+    let _instance_guard = instance_lock_for(obj).lock();
     ensure_mapdict_initialized(obj);
     let inst = &*(obj as *const pyre_object::W_ObjectObject);
     let map = inst._get_mapdict_map();
@@ -461,6 +511,7 @@ pub unsafe fn instance_get_weakref_slot(obj: PyObjectRef) -> Option<PyObjectRef>
 /// `obj` must be a live `W_ObjectObject`.
 #[majit_macros::dont_look_inside]
 pub unsafe fn instance_set_weakref_slot(obj: PyObjectRef, lifeline: PyObjectRef) -> bool {
+    let _instance_guard = instance_lock_for(obj).lock();
     ensure_mapdict_initialized(obj);
     let inst = &mut *(obj as *mut pyre_object::W_ObjectObject);
     let map = inst._get_mapdict_map();
@@ -474,6 +525,7 @@ pub unsafe fn instance_set_weakref_slot(obj: PyObjectRef, lifeline: PyObjectRef)
 /// `obj` must be a live `W_ObjectObject`.
 #[majit_macros::dont_look_inside]
 pub unsafe fn instance_del_weakref_slot(obj: PyObjectRef) {
+    let _instance_guard = instance_lock_for(obj).lock();
     ensure_mapdict_initialized(obj);
     let inst = &mut *(obj as *mut pyre_object::W_ObjectObject);
     let map = inst._get_mapdict_map();
@@ -761,6 +813,10 @@ pub struct MapAttrCache {
     cached_attrs: Vec<MapRef>,
 }
 
+// MapRef targets are process-lifetime immutable/interned nodes; the only
+// mutable cache slots are protected by MAP_ATTR_CACHE's mutex.
+unsafe impl Send for MapAttrCache {}
+
 impl MapAttrCache {
     fn new() -> Self {
         let size = 1usize << METHODCACHESIZEEXP;
@@ -789,17 +845,18 @@ impl MapAttrCache {
     }
 }
 
-thread_local! {
-    /// `space.fromcache(MapAttrCache)` (mapdict.py:80) — one cache per space;
-    /// pyre runs one space per thread.
-    static MAP_ATTR_CACHE: RefCell<MapAttrCache> = RefCell::new(MapAttrCache::new());
-}
+/// `space.fromcache(MapAttrCache)` (mapdict.py:80) — one cache on the shared
+/// object space.  Pyre's free-threaded execution contexts share that space, so
+/// the cache remains process/interpreter-owned and is synchronized rather than
+/// duplicated through TLS.
+static MAP_ATTR_CACHE: LazyLock<Mutex<MapAttrCache>> =
+    LazyLock::new(|| Mutex::new(MapAttrCache::new()));
 
 /// interp_gc.py:14-17 — clear `space.fromcache(MapAttrCache)` before an
 /// explicit full collection so cached map nodes do not retain stale entries.
 #[majit_macros::dont_look_inside]
 pub fn clear_map_attr_cache() {
-    MAP_ATTR_CACHE.with(|cache| cache.borrow_mut().clear());
+    MAP_ATTR_CACHE.lock().unwrap().clear();
 }
 
 /// `objectmodel.compute_hash(name)` for a (utf8-encoded) str (mapdict.py:94).
@@ -849,32 +906,27 @@ pub unsafe fn find_map_attr(self_node: MapRef, name: &Wtf8, attrkind: u16) -> Op
     let product = attrs_as_int.wrapping_mul(hash_selector) as u64;
     let attr_hash = ((product ^ (product << SHIFT1)) >> SHIFT2) as usize;
 
-    MAP_ATTR_CACHE.with(|cache| {
-        {
-            let cache = cache.borrow();
-            if cache.attrs[attr_hash] == self_node
-                && cache.names[attr_hash].as_deref() == Some(name)
-                && cache.indexes[attr_hash] == attrkind
-            {
-                let cached = cache.cached_attrs[attr_hash];
-                return if cached.is_null() { None } else { Some(cached) };
-            }
-        }
-        let attr = unsafe { find_map_attr_chain(self_node, name, attrkind) };
-        // Populate the cache, gated on `space._side_effects_ok()`
-        // (mapdict.py:110). `_side_effects_ok` returns True except under reverse
-        // debugging (not ported); the JIT does not trace this write because the
-        // cache path is `@jit.dont_look_inside` and the JIT calls
-        // `find_map_attr_chain` directly.
-        if crate::baseobjspace::side_effects_ok() {
-            let mut cache = cache.borrow_mut();
-            cache.attrs[attr_hash] = self_node;
-            cache.names[attr_hash] = Some(name.to_owned());
-            cache.indexes[attr_hash] = attrkind;
-            cache.cached_attrs[attr_hash] = attr.unwrap_or(std::ptr::null());
-        }
-        attr
-    })
+    let mut cache = MAP_ATTR_CACHE.lock().unwrap();
+    if cache.attrs[attr_hash] == self_node
+        && cache.names[attr_hash].as_deref() == Some(name)
+        && cache.indexes[attr_hash] == attrkind
+    {
+        let cached = cache.cached_attrs[attr_hash];
+        return if cached.is_null() { None } else { Some(cached) };
+    }
+    let attr = unsafe { find_map_attr_chain(self_node, name, attrkind) };
+    // Populate the cache, gated on `space._side_effects_ok()`
+    // (mapdict.py:110). `_side_effects_ok` returns True except under reverse
+    // debugging (not ported); the JIT does not trace this write because the
+    // cache path is `@jit.dont_look_inside` and the JIT calls
+    // `find_map_attr_chain` directly.
+    if crate::baseobjspace::side_effects_ok() {
+        cache.attrs[attr_hash] = self_node;
+        cache.names[attr_hash] = Some(name.to_owned());
+        cache.indexes[attr_hash] = attrkind;
+        cache.cached_attrs[attr_hash] = attr.unwrap_or(std::ptr::null());
+    }
+    attr
 }
 
 // ── LOAD_ATTR / STORE_ATTR inline cache (mapdict.py:1416-1653) ─────────
@@ -1137,6 +1189,12 @@ pub unsafe fn load_attr_caching(
     nameindex: usize,
     name: &str,
 ) -> Result<PyObjectRef, PyError> {
+    // PyPy's GIL makes the per-instance map/storage pair and the per-code
+    // `_mapdict_caches` entry one atomic observation.  Preserve those exact
+    // owners under free threading with narrow synchronization around the
+    // upstream cache operation.
+    let _instance_guard = instance_lock_for(w_obj).lock();
+    let _code_cache_guard = code_cache_lock_for(pycode).lock();
     let entry = unsafe { crate::pycode::w_code_mapdict_caches_get(pycode, nameindex) };
     // mapdict.py:1482 `map = w_obj._get_mapdict_map()`.
     let map = unsafe { mapdict_map_or_null(w_obj) };
@@ -1539,6 +1597,8 @@ pub unsafe fn store_attr_caching(
     name: &str,
     w_value: PyObjectRef,
 ) -> Result<(), PyError> {
+    let _instance_guard = instance_lock_for(w_obj).lock();
+    let _code_cache_guard = code_cache_lock_for(pycode).lock();
     let entry = unsafe { crate::pycode::w_code_mapdict_caches_get(pycode, nameindex) };
     // mapdict.py:1577 `map = w_obj._get_mapdict_map()`.
     let map = unsafe { mapdict_map_or_null(w_obj) };
@@ -2859,33 +2919,17 @@ pub unsafe fn node_write<O: MapdictObject>(
     }
 }
 
-thread_local! {
-    /// objspace/std/mapdict.py:830 — MapdictDictSupport stores the
-    /// instance dict in the "dict" SPECIAL slot of the mapdict map.
-    /// pyre keeps a side table of address → W_DictObject because there
-    /// is no mapdict; semantically this is the same backing store.
-    pub static INSTANCE_DICT: RefCell<HashMap<usize, PyObjectRef>> =
-        RefCell::new(HashMap::new());
-}
+/// These tables are the temporary carrier for builtin-layout objects that do
+/// not yet have mapdict SPECIAL fields.  PyPy's SPECIAL fields are visible to
+/// every ExecutionContext, so the compatibility carrier must be
+/// interpreter/process-owned too, never TLS.
+pub static INSTANCE_DICT: LazyLock<Mutex<HashMap<usize, usize>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+pub static WEAKREF_TABLE: LazyLock<Mutex<HashMap<usize, usize>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
 
-thread_local! {
-    /// objspace/std/mapdict.py:780-797 MapdictWeakrefSupport stores the
-    /// lifeline in the "weakref" SPECIAL slot of the mapdict map. pyre
-    /// uses that slot for `W_ObjectObject`; this table remains only for
-    /// weakrefable non-instance wrappers that have no mapdict carrier.
-    pub static WEAKREF_TABLE: RefCell<HashMap<usize, PyObjectRef>> =
-        RefCell::new(HashMap::new());
-
-    static MAPDICT_ROOT_AREA: MapdictRootArea = MapdictRootArea {
-        instance_dict: INSTANCE_DICT.with(|table| table as *const _),
-        weakref_table: WEAKREF_TABLE.with(|table| table as *const _),
-    };
-}
-
-struct MapdictRootArea {
-    instance_dict: *const RefCell<HashMap<usize, PyObjectRef>>,
-    weakref_table: *const RefCell<HashMap<usize, PyObjectRef>>,
-}
+struct MapdictRootArea;
+static MAPDICT_ROOT_AREA: MapdictRootArea = MapdictRootArea;
 
 // ── MapdictDictSupport ────────────────────────────────────────────────
 
@@ -3288,15 +3332,20 @@ pub fn _obj_getdict(self_ref: PyObjectRef) -> PyObjectRef {
         debug_assert!(flag, "write to the \"dict\" SPECIAL slot failed");
         w_dict
     } else {
-        let existing =
-            INSTANCE_DICT.with(|table| table.borrow().get(&(self_ref as usize)).copied());
+        let existing = INSTANCE_DICT
+            .lock()
+            .unwrap()
+            .get(&(self_ref as usize))
+            .copied()
+            .map(|dict| dict as PyObjectRef);
         if let Some(w_dict) = existing {
             return w_dict;
         }
         let w_dict = pyre_object::w_dict_new();
-        INSTANCE_DICT.with(|table| {
-            table.borrow_mut().insert(self_ref as usize, w_dict);
-        });
+        INSTANCE_DICT
+            .lock()
+            .unwrap()
+            .insert(self_ref as usize, w_dict as usize);
         w_dict
     }
 }
@@ -3389,22 +3438,19 @@ pub fn walk_mapdict_roots(mut visitor: impl FnMut(&mut PyObjectRef)) {
 }
 
 pub fn capture_mapdict_root_area() -> *const () {
-    MAPDICT_ROOT_AREA.with(|area| area as *const _ as *const ())
+    &MAPDICT_ROOT_AREA as *const _ as *const ()
 }
 
 /// # Safety
 /// `data` must come from [`capture_mapdict_root_area`], and the owning thread
 /// must be quiesced.
-pub unsafe fn walk_mapdict_roots_area(data: *const (), mut visitor: impl FnMut(&mut PyObjectRef)) {
-    let area = unsafe { &*(data as *const MapdictRootArea) };
-    let instance_dict = unsafe { &*area.instance_dict };
-    let weakref_table = unsafe { &*area.weakref_table };
+pub unsafe fn walk_mapdict_roots_area(_data: *const (), mut visitor: impl FnMut(&mut PyObjectRef)) {
     let dict_values = {
-        let table = instance_dict;
-        table
-            .borrow()
+        INSTANCE_DICT
+            .lock()
+            .unwrap()
             .iter()
-            .map(|(&key, &dict)| (key, dict))
+            .map(|(&key, &dict)| (key, dict as PyObjectRef))
             .collect::<Vec<_>>()
     };
     // SAFETY: do not hold the RefCell borrow while invoking callbacks. The
@@ -3413,14 +3459,13 @@ pub unsafe fn walk_mapdict_roots_area(data: *const (), mut visitor: impl FnMut(&
         visitor(&mut dict);
         let new_key = current_owner_key(key);
         {
-            let table = instance_dict;
-            let mut table = table.borrow_mut();
+            let mut table = INSTANCE_DICT.lock().unwrap();
             if new_key == key {
                 if let Some(slot) = table.get_mut(&key) {
-                    *slot = dict;
+                    *slot = dict as usize;
                 }
             } else if table.remove(&key).is_some() {
-                table.insert(new_key, dict);
+                table.insert(new_key, dict as usize);
             }
         }
         // Trace the dict's own r_dict entries. INSTANCE_DICT now holds only
@@ -3453,25 +3498,24 @@ pub unsafe fn walk_mapdict_roots_area(data: *const (), mut visitor: impl FnMut(&
         // So no instance is walked here.
     }
     let weakref_values = {
-        let table = weakref_table;
-        table
-            .borrow()
+        WEAKREF_TABLE
+            .lock()
+            .unwrap()
             .iter()
-            .map(|(&key, &value)| (key, value))
+            .map(|(&key, &value)| (key, value as PyObjectRef))
             .collect::<Vec<_>>()
     };
     for (key, mut value) in weakref_values {
         visitor(&mut value);
         let new_key = current_owner_key(key);
         {
-            let table = weakref_table;
-            let mut table = table.borrow_mut();
+            let mut table = WEAKREF_TABLE.lock().unwrap();
             if new_key == key {
                 if let Some(slot) = table.get_mut(&key) {
-                    *slot = value;
+                    *slot = value as usize;
                 }
             } else if table.remove(&key).is_some() {
-                table.insert(new_key, value);
+                table.insert(new_key, value as usize);
             }
         }
     }
@@ -3534,9 +3578,10 @@ pub fn _obj_setdict(self_ref: PyObjectRef, w_dict: PyObjectRef) -> Result<(), Py
         // Non-instance hasdict objects (property/member, baseobjspace
         // 1850/3786) keep a plain own-storage dict in the address-keyed side
         // table; it never delegates to a backing object, so no force step.
-        INSTANCE_DICT.with(|table| {
-            table.borrow_mut().insert(self_ref as usize, w_dict);
-        });
+        INSTANCE_DICT
+            .lock()
+            .unwrap()
+            .insert(self_ref as usize, w_dict as usize);
     }
     Ok(())
 }
@@ -3558,7 +3603,12 @@ pub fn getweakref(self_ref: PyObjectRef) -> Option<PyObjectRef> {
     if unsafe { pyre_object::is_instance(self_ref) } {
         unsafe { instance_get_weakref_slot(self_ref) }
     } else {
-        WEAKREF_TABLE.with(|table| table.borrow().get(&(self_ref as usize)).copied())
+        WEAKREF_TABLE
+            .lock()
+            .unwrap()
+            .get(&(self_ref as usize))
+            .copied()
+            .map(|value| value as PyObjectRef)
     }
 }
 
@@ -3575,11 +3625,10 @@ pub fn setweakref(self_ref: PyObjectRef, weakreflifeline: PyObjectRef) {
         let flag = unsafe { instance_set_weakref_slot(self_ref, weakreflifeline) };
         debug_assert!(flag, "write to the weakref SPECIAL slot failed");
     } else {
-        WEAKREF_TABLE.with(|table| {
-            table
-                .borrow_mut()
-                .insert(self_ref as usize, weakreflifeline);
-        });
+        WEAKREF_TABLE
+            .lock()
+            .unwrap()
+            .insert(self_ref as usize, weakreflifeline as usize);
     }
 }
 
@@ -3593,9 +3642,10 @@ pub fn delweakref(self_ref: PyObjectRef) {
     if unsafe { pyre_object::is_instance(self_ref) } {
         unsafe { instance_del_weakref_slot(self_ref) };
     } else {
-        WEAKREF_TABLE.with(|table| {
-            table.borrow_mut().remove(&(self_ref as usize));
-        });
+        WEAKREF_TABLE
+            .lock()
+            .unwrap()
+            .remove(&(self_ref as usize));
     }
 }
 
@@ -3712,7 +3762,7 @@ mod tests {
     #[test]
     fn find_map_attr_cached_matches_uncached_on_hit_and_miss() {
         unsafe {
-            MAP_ATTR_CACHE.with(|c| c.borrow_mut().clear());
+            MAP_ATTR_CACHE.lock().unwrap().clear();
             let (_term, a, b) = build_chain();
             // first call populates the cache, second hits it
             assert_eq!(find_map_attr(b, wn("a"), DICT), Some(a));
@@ -4237,7 +4287,7 @@ mod tests {
             let addr = obj_ref as usize;
             // Never entered INSTANCE_DICT (no getdict call), proving storage
             // forwarding is decoupled from wrapper materialisation.
-            let in_instance_dict = INSTANCE_DICT.with(|t| t.borrow().contains_key(&addr));
+            let in_instance_dict = INSTANCE_DICT.lock().unwrap().contains_key(&addr);
             assert_eq!(in_instance_dict, false);
 
             let mut seen: Vec<PyObjectRef> = Vec::new();
@@ -4265,7 +4315,7 @@ mod tests {
             // stored in the SPECIAL slot, not INSTANCE_DICT.
             assert_eq!(instance_get_dict_slot(obj_ref), Some(w1));
             let addr = obj_ref as usize;
-            let in_instance_dict = INSTANCE_DICT.with(|t| t.borrow().contains_key(&addr));
+            let in_instance_dict = INSTANCE_DICT.lock().unwrap().contains_key(&addr);
             assert_eq!(in_instance_dict, false);
             // identity stable across repeated access.
             let w2 = _obj_getdict(obj_ref);

--- a/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
+++ b/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
@@ -9,8 +9,8 @@
 //! `_mapdict_setweakref`, etc.
 
 use crate::PyError;
-use pyre_object::PyObjectRef;
 use parking_lot::ReentrantMutex;
+use pyre_object::PyObjectRef;
 
 use rustpython_wtf8::{Wtf8, Wtf8Buf};
 use std::cell::{Cell, RefCell, UnsafeCell};
@@ -3642,10 +3642,7 @@ pub fn delweakref(self_ref: PyObjectRef) {
     if unsafe { pyre_object::is_instance(self_ref) } {
         unsafe { instance_del_weakref_slot(self_ref) };
     } else {
-        WEAKREF_TABLE
-            .lock()
-            .unwrap()
-            .remove(&(self_ref as usize));
+        WEAKREF_TABLE.lock().unwrap().remove(&(self_ref as usize));
     }
 }
 

--- a/pyre/pyre-interpreter/src/pycode.rs
+++ b/pyre/pyre-interpreter/src/pycode.rs
@@ -194,7 +194,9 @@ pub struct PyCode {
     /// to `code.names.len()`, never resized.  `null` when `code_ptr`
     /// is null or unaligned (test fixtures, gateway builtins).
     pub globals_caches:
-        *mut Vec<Option<std::rc::Weak<std::cell::RefCell<pyre_object::celldict::GlobalCache>>>>,
+        *mut std::sync::Mutex<
+            Vec<Option<std::sync::Weak<std::sync::Mutex<pyre_object::celldict::GlobalCache>>>>,
+        >,
     /// `mapdict.py:1457-1458 self._mapdict_caches = [INVALID_CACHE_ENTRY] *
     /// len(co_names_w)`.
     ///
@@ -348,10 +350,10 @@ pub fn w_code_new_with_hidden_applevel(code_ptr: *const (), hidden_applevel: boo
         let code_ref = unsafe { &*(code_ptr as *const crate::CodeObject) };
         let names_len = code_ref.names.len();
         let mut v: Vec<
-            Option<std::rc::Weak<std::cell::RefCell<pyre_object::celldict::GlobalCache>>>,
+            Option<std::sync::Weak<std::sync::Mutex<pyre_object::celldict::GlobalCache>>>,
         > = Vec::with_capacity(names_len);
         v.resize_with(names_len, || None);
-        Box::into_raw(Box::new(v))
+        Box::into_raw(Box::new(std::sync::Mutex::new(v)))
     };
     // `mapdict.py:1457-1458 self._mapdict_caches = [INVALID_CACHE_ENTRY] *
     // len(co_names_w)` — `None` is `INVALID_CACHE_ENTRY`.
@@ -1676,7 +1678,7 @@ pub unsafe fn w_code_exceptiontable(obj: PyObjectRef) -> Vec<u8> {
 
 /// `celldict.py:292 cache_wref = pycode._globals_caches[nameindex]` —
 /// read slot `nameindex` and upgrade the weakref to a strong
-/// `Rc<RefCell<GlobalCache>>` (returning `None` when the slot is
+/// `Arc<Mutex<GlobalCache>>` (returning `None` when the slot is
 /// unset, the weak target is gone, or `code_ptr` is invalid).
 ///
 /// # Safety
@@ -1685,7 +1687,7 @@ pub unsafe fn w_code_exceptiontable(obj: PyObjectRef) -> Vec<u8> {
 pub unsafe fn w_code_globals_caches_get(
     obj: PyObjectRef,
     nameindex: usize,
-) -> Option<std::rc::Rc<std::cell::RefCell<pyre_object::celldict::GlobalCache>>> {
+) -> Option<std::sync::Arc<std::sync::Mutex<pyre_object::celldict::GlobalCache>>> {
     if obj.is_null() {
         return None;
     }
@@ -1693,14 +1695,14 @@ pub unsafe fn w_code_globals_caches_get(
     if code.globals_caches.is_null() {
         return None;
     }
-    let vec = unsafe { &*code.globals_caches };
+    let vec = unsafe { &*code.globals_caches }.lock().unwrap();
     vec.get(nameindex)
         .and_then(|slot| slot.as_ref())
         .and_then(|w| w.upgrade())
 }
 
 /// `celldict.py:321/353 pycode._globals_caches[nameindex] = cache.ref`
-/// — store `Rc::downgrade(cache)` in slot `nameindex`.  No-op when
+/// — store `Arc::downgrade(cache)` in slot `nameindex`.  No-op when
 /// `code_ptr` is invalid or `nameindex` is out of range.
 ///
 /// # Safety
@@ -1709,7 +1711,7 @@ pub unsafe fn w_code_globals_caches_get(
 pub unsafe fn w_code_globals_caches_set(
     obj: PyObjectRef,
     nameindex: usize,
-    cache: &std::rc::Rc<std::cell::RefCell<pyre_object::celldict::GlobalCache>>,
+    cache: &std::sync::Arc<std::sync::Mutex<pyre_object::celldict::GlobalCache>>,
 ) {
     if obj.is_null() {
         return;
@@ -1718,9 +1720,9 @@ pub unsafe fn w_code_globals_caches_set(
     if code.globals_caches.is_null() {
         return;
     }
-    let vec = unsafe { &mut *code.globals_caches };
+    let mut vec = unsafe { &*code.globals_caches }.lock().unwrap();
     if let Some(slot) = vec.get_mut(nameindex) {
-        *slot = Some(std::rc::Rc::downgrade(cache));
+        *slot = Some(std::sync::Arc::downgrade(cache));
     }
 }
 
@@ -1739,7 +1741,7 @@ pub unsafe fn w_code_globals_caches_len(obj: PyObjectRef) -> usize {
     if code.globals_caches.is_null() {
         return 0;
     }
-    unsafe { (*code.globals_caches).len() }
+    unsafe { (*code.globals_caches).lock().unwrap().len() }
 }
 
 /// `mapdict.py:1483/1546/1575 entry = pycode._mapdict_caches[nameindex]` — read

--- a/pyre/pyre-interpreter/src/pycode.rs
+++ b/pyre/pyre-interpreter/src/pycode.rs
@@ -193,10 +193,9 @@ pub struct PyCode {
     /// Owned via `Box::into_raw`; allocated once at construction sized
     /// to `code.names.len()`, never resized.  `null` when `code_ptr`
     /// is null or unaligned (test fixtures, gateway builtins).
-    pub globals_caches:
-        *mut std::sync::Mutex<
-            Vec<Option<std::sync::Weak<std::sync::Mutex<pyre_object::celldict::GlobalCache>>>>,
-        >,
+    pub globals_caches: *mut std::sync::Mutex<
+        Vec<Option<std::sync::Weak<std::sync::Mutex<pyre_object::celldict::GlobalCache>>>>,
+    >,
     /// `mapdict.py:1457-1458 self._mapdict_caches = [INVALID_CACHE_ENTRY] *
     /// len(co_names_w)`.
     ///

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -2235,8 +2235,17 @@ impl PyFrame {
     /// `createframe` (PyPy `baseobjspace.py:796`) so every heap-allocated
     /// `PyFrame` flows through the canonical entry point.
     pub fn new(code: CodeObject) -> FrameBox {
-        Self::new_with_context(code, Rc::new(PyExecutionContext::default()))
-            .expect("PyFrame::new: test entry code must not carry freevars")
+        let frame = Self::new_with_context(code, Rc::new(PyExecutionContext::default()))
+            .expect("PyFrame::new: test entry code must not carry freevars");
+        // `threadlocals.py:enter_thread` — the ExecutionContext slot belongs to
+        // the OS-thread locals and is installed once at thread entry, not
+        // re-stamped per frame.  The other entry points do this themselves
+        // (`pyrex/src/lib.rs`, `pyre-wasm/src/lib.rs`); as the remaining entry
+        // point this one must too, or `space.getexecutioncontext()` stays null
+        // and every context reached through it — the class-body frame's
+        // builtins among them — falls back to the empty default.
+        crate::call::set_last_exec_ctx(frame.execution_context);
+        frame
     }
 
     /// Module-entry adapter for `createframe` — leaks owned arguments

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -21,7 +21,6 @@ use pyre_object::*;
 // across `str` and `unicodedata` here.
 use rustpython_unicode::{case, classify, identifier};
 use rustpython_wtf8::{CodePoint, Wtf8, Wtf8Buf};
-
 // ── Arity checks for builtin methods ─────────────────────────────────
 // A builtin method registered with `make_builtin_function_with_arity`
 // records an arity only as a fast-path dispatch hint — some stubs register

--- a/pyre/pyre-jit-trace/src/jitcode_runtime.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_runtime.rs
@@ -244,7 +244,7 @@ pub(crate) fn named_jitcode(name: &str) -> Option<Arc<JitCode>> {
 /// build-time pipeline. See `LIST_APPEND_JITCODE_INDEX`.
 pub fn list_append_jitcode() -> Option<Arc<JitCode>> {
     let idx = LIST_APPEND_JITCODE_INDEX
-        .with(|cell| *cell.get_or_init(|| compute_named_jitcode_index("w_list_append")))?;
+        .with(|cell| *cell.get_or_init(|| compute_named_jitcode_index("w_list_append_inner")))?;
     get_jitcode_by_index(idx)
 }
 
@@ -1117,11 +1117,11 @@ mod tests {
         // assembled, carrying the array-op sequence the `list.int_*`
         // oopspecs lower to.  (The shipping arm folds walker-native instead.)
         let jc = list_append_jitcode()
-            .expect("build-time pipeline must contain the charon `w_list_append` jitcode");
-        assert_eq!(jc.name, "w_list_append");
+            .expect("build-time pipeline must contain the charon `w_list_append_inner` jitcode");
+        assert_eq!(jc.name, "w_list_append_inner");
         assert!(
             !jc.code.is_empty(),
-            "w_list_append jitcode should have non-empty bytecode (assembled body)"
+            "w_list_append_inner jitcode should have non-empty bytecode (assembled body)"
         );
     }
 

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -644,7 +644,7 @@ unsafe fn object_object_custom_trace(obj_addr: usize, f: &mut dyn FnMut(*mut maj
 ///   * `dstorage` → `ModuleDictStorage.entries` (Vec<(String,
 ///     PyObjectRef)>) — every entry's value
 ///   * `mstrategy` → `ModuleDictStrategy.caches` (Option<HashMap<...,
-///     Rc<RefCell<GlobalCache>>>>) — every live cache's `cell`
+///     Arc<Mutex<GlobalCache>>>>) — every live cache's `cell`
 ///   * `object_storage` → post-`switch_to_object_strategy`
 ///     Vec<(PyObjectRef, PyObjectRef)> — both halves of every entry
 ///
@@ -2973,6 +2973,12 @@ fn build_gc() -> Box<dyn majit_gc::GcAllocator> {
         <pyre_interpreter::module::_io::W_TextIOWrapper
             as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
     );
+    register_pyre_class(
+        &mut gc,
+        &mut pytype_to_tid,
+        <pyre_interpreter::module::thread::W_Local
+            as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
+    );
     // A Block is GC-managed but is not an rclass.OBJECT subclass and has no
     // Python-visible vtable.  Registering it through `register_pyre_class`
     // would add a spurious subclass-range alias and shift W_Deque's canonical
@@ -3467,6 +3473,10 @@ pub fn init_gc_subsystem() {
     // translated prebuilt equivalent before any collector root walk rather
     // than lazily manufacturing it from inside the walker.
     pyre_object::rbigint::initialize_rbigint_parts_cache();
+    pyre_interpreter::call::register_thread_entry_hook(|| {
+        init_jit_hooks();
+        init_gc_root_walkers();
+    });
     if !GC_TLS_INSTALLED.with(|c| c.get()) {
         majit_gc::gc_sync::register_thread();
         majit_gc::shadow_stack::register_mutator();
@@ -6240,6 +6250,7 @@ fn eval_loop_jit(frame: &mut PyFrame) -> LoopResult {
     // No explicit promote needed; the JitDriver green-key mechanism handles this.
 
     loop {
+        pyre_interpreter::module::thread::park_if_finalizing();
         // Interpreter-path GC safepoint (PYRE_GC_INTERP). Between opcodes the
         // only live refs are in the frame, reachable through the registered
         // pyframe root walker; no bytecode handler holds a Rust-stack temporary
@@ -6318,11 +6329,36 @@ fn eval_loop_jit(frame: &mut PyFrame) -> LoopResult {
         let ec_ptr = unsafe { &*f }.execution_context as *mut PyExecutionContext;
         if !ec_ptr.is_null() {
             let needs_trace = unsafe { !(*ec_ptr).w_tracefunc.is_null() };
-            if needs_trace {
-                if let Err(err) = unsafe {
+            // A compiled back-edge deopts when the process breaker is armed.
+            // On resume, run the live frame's ordinary bytecode_trace so its
+            // EC-owned `w_async_exception_type` is consumed.  This is the
+            // source-level equivalent of PyPy resuming into
+            // CheckSignalAction.perform; testing only `needs_trace` here used
+            // to bypass the interpreter semantic path and immediately re-enter
+            // the compiled loop with the exception still pending.
+            let async_pending = majit_ir::eval_breaker_word::load()
+                & majit_ir::eval_breaker_word::EB_ASYNC
+                != 0;
+            if needs_trace || async_pending {
+                if let Err(mut err) = unsafe {
                     (*ec_ptr)
                         .bytecode_trace(f, pyre_interpreter::executioncontext::TICK_COUNTER_STEP)
                 } {
+                    // `handle_bytecode` catches exceptions raised by
+                    // bytecode_trace at this opcode.  In particular, an
+                    // asynchronously injected exception must be catchable by
+                    // the target frame's surrounding try/except.
+                    let f: *mut PyFrame = frame_root.frame() as *mut PyFrame;
+                    let mut next_instr = unsafe { &*f }.next_instr();
+                    if pyre_interpreter::eval::handle_exception(
+                        unsafe { &mut *f },
+                        &mut err,
+                        &mut next_instr,
+                    ) {
+                        let f: *mut PyFrame = frame_root.frame() as *mut PyFrame;
+                        unsafe { &mut *f }.set_last_instr_from_next_instr(next_instr);
+                        continue;
+                    }
                     return LoopResult::Done(Err(err));
                 }
                 // bytecode_trace may allocate (tracer callback) → the frame may

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -6336,9 +6336,8 @@ fn eval_loop_jit(frame: &mut PyFrame) -> LoopResult {
             // CheckSignalAction.perform; testing only `needs_trace` here used
             // to bypass the interpreter semantic path and immediately re-enter
             // the compiled loop with the exception still pending.
-            let async_pending = majit_ir::eval_breaker_word::load()
-                & majit_ir::eval_breaker_word::EB_ASYNC
-                != 0;
+            let async_pending =
+                majit_ir::eval_breaker_word::load() & majit_ir::eval_breaker_word::EB_ASYNC != 0;
             if needs_trace || async_pending {
                 if let Err(mut err) = unsafe {
                     (*ec_ptr)

--- a/pyre/pyre-object/Cargo.toml
+++ b/pyre/pyre-object/Cargo.toml
@@ -9,6 +9,7 @@ description = "Python object model for pyre interpreter"
 [dependencies]
 num-traits = { workspace = true }
 majit-gc = { workspace = true }
+parking_lot = { workspace = true }
 majit-macros = { workspace = true }
 pyre-macros = { workspace = true }
 indexmap = { workspace = true }

--- a/pyre/pyre-object/src/celldict.rs
+++ b/pyre/pyre-object/src/celldict.rs
@@ -485,12 +485,16 @@ pub struct GlobalCache {
     /// strategy's `caches` map, so a write through the builtin's
     /// strategy that updates `cache.cell` is immediately visible
     /// here.  PyPy stores this as a direct Python attribute
-    /// (ref-counted strong ref); pyre uses `Rc<RefCell<...>>` so the
+    /// (ref-counted strong ref); pyre uses `Arc<Mutex<...>>` so the
     /// cache stays alive as long as either the owning strategy's
     /// `caches` map OR a chained `builtincache` holds it — matching
-    /// PyPy's ref-counted lifetime against
+    /// PyPy's ref-counted lifetime. The mutex supplies object-local
+    /// synchronization for free-threaded access; it does not create a
+    /// parallel side table or serialize unrelated bytecode execution.
+    ///
+    /// As in PyPy, invalidation is tied to
     /// `ModuleDictStrategy.invalidate_caches` dropping the registry.
-    pub builtincache: Option<std::rc::Rc<std::cell::RefCell<GlobalCache>>>,
+    pub builtincache: Option<std::sync::Arc<std::sync::Mutex<GlobalCache>>>,
 }
 
 impl GlobalCache {
@@ -531,10 +535,10 @@ impl GlobalCache {
 /// # Safety
 /// `cache.cell`, when present, must be a valid `PyObjectRef`.
 unsafe fn walk_one_global_cache(
-    cache: &std::rc::Rc<std::cell::RefCell<GlobalCache>>,
+    cache: &std::sync::Arc<std::sync::Mutex<GlobalCache>>,
     visitor: &mut dyn FnMut(&mut PyObjectRef),
 ) {
-    let mut c = cache.borrow_mut();
+    let mut c = cache.lock().unwrap();
     if let Some(slot) = c.cell.as_mut() {
         walk_module_value_slot(slot, visitor);
     }
@@ -566,11 +570,18 @@ unsafe fn walk_one_global_cache(
 ///
 /// `caches` is the per-name `GlobalCache` registry consulted by the
 /// `LOAD_GLOBAL` fast path (`celldict.py:214 get_global_cache`).
-/// Allocated lazily on first cache install.
+/// Allocated lazily on first cache install. The mutex protects this
+/// strategy-owned registry when multiple Python threads share a module.
 pub struct ModuleDictStrategy {
     pub version: VersionTag,
-    pub caches:
-        Option<std::collections::HashMap<String, std::rc::Rc<std::cell::RefCell<GlobalCache>>>>,
+    pub caches: std::sync::Mutex<
+        Option<
+            std::collections::HashMap<
+                String,
+                std::sync::Arc<std::sync::Mutex<GlobalCache>>,
+            >,
+        >,
+    >,
     /// JIT loop-invalidation flags watching the `version?` quasi-immutable
     /// field.  Each compiled loop whose trace promoted `self.version`
     /// (and folded a module-global lookup keyed on it) registers its
@@ -607,7 +618,7 @@ impl ModuleDictStrategy {
     pub fn new() -> Self {
         Self {
             version: VersionTag::fresh(),
-            caches: None,
+            caches: std::sync::Mutex::new(None),
             version_watchers: Vec::new(),
         }
     }
@@ -680,19 +691,20 @@ impl ModuleDictStrategy {
         &mut self,
         storage: &ModuleDictStorage,
         key: &str,
-    ) -> std::rc::Rc<std::cell::RefCell<GlobalCache>> {
-        if self.caches.is_none() {
-            self.caches = Some(std::collections::HashMap::new());
+    ) -> std::sync::Arc<std::sync::Mutex<GlobalCache>> {
+        let mut cache_registry = self.caches.lock().unwrap();
+        if cache_registry.is_none() {
+            *cache_registry = Some(std::collections::HashMap::new());
         }
-        let already_present = match self.caches.as_ref() {
+        let already_present = match cache_registry.as_ref() {
             Some(c) => c.contains_key(key),
             None => false,
         };
         if already_present {
-            return self.caches.as_ref().unwrap().get(key).unwrap().clone();
+            return cache_registry.as_ref().unwrap().get(key).unwrap().clone();
         }
         let cell = self.getdictvalue_no_unwrapping(storage, key);
-        let caches = self.caches.as_mut().unwrap();
+        let caches = cache_registry.as_mut().unwrap();
         // `celldict.py:223 cache = GlobalCache(cell)`.  Lines 224-238
         // (`if not honor__builtins__ and cell is None and w_dict is
         // not space.builtin.w_dict:` …) are skipped because pyre is
@@ -702,9 +714,9 @@ impl ModuleDictStrategy {
         // value pointer into walker-only storage (`walk_cache_cells`);
         // record the store like any other prebuilt-family write.
         crate::gc_roots::mark_prebuilt_roots_dirty();
-        let rc = std::rc::Rc::new(std::cell::RefCell::new(GlobalCache::new(cell)));
-        caches.insert(key.to_string(), rc.clone());
-        rc
+        let cache = std::sync::Arc::new(std::sync::Mutex::new(GlobalCache::new(cell)));
+        caches.insert(key.to_string(), cache.clone());
+        cache
     }
 
     /// `celldict.py:180-184 switch_to_object_strategy` cache flush:
@@ -721,15 +733,16 @@ impl ModuleDictStrategy {
     /// the host `switch_to_object_strategy` helper on
     /// W_ModuleDictObject.
     pub fn invalidate_caches(&mut self) {
-        if let Some(caches) = self.caches.as_mut() {
+        let mut cache_registry = self.caches.lock().unwrap();
+        if let Some(caches) = cache_registry.as_mut() {
             for cache in caches.values() {
-                let mut c = cache.borrow_mut();
+                let mut c = cache.lock().unwrap();
                 c.cell = None;
                 c.valid = false;
                 c.builtincache = None;
             }
         }
-        self.caches = None;
+        *cache_registry = None;
     }
 
     /// `celldict.py:41-42 get_empty_storage`:
@@ -837,9 +850,9 @@ impl ModuleDictStrategy {
         // with the new stored value so subsequent LOAD_GLOBAL through
         // the cache reads the fresh entry without an invalidation
         // round-trip.
-        if let Some(caches) = self.caches.as_mut() {
+        if let Some(caches) = self.caches.lock().unwrap().as_mut() {
             if let Some(cache) = caches.get(key) {
-                cache.borrow_mut().cell = Some(w_to_store);
+                cache.lock().unwrap().cell = Some(w_to_store);
             }
         }
     }
@@ -880,12 +893,12 @@ impl ModuleDictStrategy {
         key: &str,
     ) -> Option<PyObjectRef> {
         let removed = storage.remove(key)?;
-        if let Some(caches) = self.caches.as_mut() {
+        if let Some(caches) = self.caches.lock().unwrap().as_mut() {
             if let Some(cache) = caches.get(key) {
                 // `celldict.py:117-121`: zero out the per-key cache
                 // so LOAD_GLOBAL falls through to the builtins
                 // fallback (or NameError) on the next read.
-                cache.borrow_mut().cell = None;
+                cache.lock().unwrap().cell = None;
             }
         }
         self.mutated();
@@ -945,7 +958,7 @@ impl ModuleDictStrategy {
     /// Each cached `GlobalCache.cell`, when present, must be a valid
     /// `PyObjectRef`.
     pub unsafe fn walk_cache_cells(&self, visitor: &mut dyn FnMut(&mut PyObjectRef)) {
-        if let Some(caches) = self.caches.as_ref() {
+        if let Some(caches) = self.caches.lock().unwrap().as_ref() {
             for cache in caches.values() {
                 walk_one_global_cache(cache, visitor);
             }

--- a/pyre/pyre-object/src/celldict.rs
+++ b/pyre/pyre-object/src/celldict.rs
@@ -575,12 +575,7 @@ unsafe fn walk_one_global_cache(
 pub struct ModuleDictStrategy {
     pub version: VersionTag,
     pub caches: std::sync::Mutex<
-        Option<
-            std::collections::HashMap<
-                String,
-                std::sync::Arc<std::sync::Mutex<GlobalCache>>,
-            >,
-        >,
+        Option<std::collections::HashMap<String, std::sync::Arc<std::sync::Mutex<GlobalCache>>>>,
     >,
     /// JIT loop-invalidation flags watching the `version?` quasi-immutable
     /// field.  Each compiled loop whose trace promoted `self.version`

--- a/pyre/pyre-object/src/dictmultiobject.rs
+++ b/pyre/pyre-object/src/dictmultiobject.rs
@@ -37,6 +37,8 @@
 #![allow(unsafe_op_in_unsafe_fn)]
 
 use crate::pyobject::*;
+use std::cell::UnsafeCell;
+use std::sync::LazyLock;
 
 /// `pypy/objspace/std/dictmultiobject.py:1209-1212 ObjectDictStrategy`
 /// — `r_dict(dict_keys_equal, hash_w)` key type.  The hash is cached
@@ -991,6 +993,26 @@ pub unsafe fn w_dict_walk_entries_mut(obj: PyObjectRef, mut visitor: impl FnMut(
     }
 }
 
+/// Visit every GC-reference slot in a dict's strategy-owned storage.
+///
+/// This is the host-side counterpart of the translated `rerased` trace
+/// function. It is used when an immortal/prebuilt owner must descend through
+/// an already-old dict during a minor collection; merely visiting the dict
+/// object itself does not rescan that old object's storage.
+pub unsafe fn w_dict_walk_gc_refs(
+    obj: PyObjectRef,
+    visitor: &mut dyn FnMut(&mut PyObjectRef),
+) {
+    if obj.is_null() {
+        return;
+    }
+    let strategy = unsafe { w_dict_get_strategy(obj) };
+    let mut adapter = |slot: *mut PyObjectRef| {
+        visitor(unsafe { &mut *slot });
+    };
+    unsafe { strategy.walk_gc_refs(obj, &mut adapter) };
+}
+
 /// Allocate and initialise a heap `W_DictObject`.
 ///
 /// Dispatches the thread-local GC allocation hook (`try_gc_alloc` /
@@ -1194,6 +1216,69 @@ pub fn w_module_dict_new() -> PyObjectRef {
     }) as PyObjectRef
 }
 
+// PyPy serializes dict strategy/storage transitions with the GIL. Pyre is
+// free-threaded, so use the same narrow address-striped reentrant-lock
+// adaptation already used by mapdict. Semantic state remains exclusively on
+// each W_DictObject/W_ModuleDictObject; these locks only protect operation and
+// strategy-transition boundaries.
+// Stripes are reset in the fork child because a vanished thread may have held
+// one at fork time.
+struct ForkDictLock(UnsafeCell<parking_lot::ReentrantMutex<()>>);
+unsafe impl Sync for ForkDictLock {}
+
+impl ForkDictLock {
+    fn new() -> Self {
+        Self(UnsafeCell::new(parking_lot::ReentrantMutex::new(())))
+    }
+
+    fn get(&self) -> &parking_lot::ReentrantMutex<()> {
+        unsafe { &*self.0.get() }
+    }
+
+    unsafe fn reinit_after_fork(&self) {
+        unsafe {
+            self.0
+                .get()
+                .write(parking_lot::ReentrantMutex::new(()))
+        };
+    }
+}
+
+static DICT_LOCKS: LazyLock<Vec<ForkDictLock>> =
+    LazyLock::new(|| (0..256).map(|_| ForkDictLock::new()).collect());
+
+pub type ModuleDictGuard = parking_lot::lock_api::ReentrantMutexGuard<
+    'static,
+    parking_lot::RawMutex,
+    parking_lot::RawThreadId,
+    (),
+>;
+
+/// Acquire a dict's own lock without making a contending Python
+/// thread prevent GC stop-the-world progress.  The fast path neither blocks
+/// nor changes mutator state; only real contention enters the GC-aware
+/// external-block region.
+///
+/// # Safety
+/// `obj` must point to a live `W_DictObject` or `W_ModuleDictObject`.
+#[majit_macros::dont_look_inside]
+pub unsafe fn w_dict_lock(obj: PyObjectRef) -> ModuleDictGuard {
+    let lock = DICT_LOCKS[(obj as usize >> 4) & (DICT_LOCKS.len() - 1)].get();
+    if let Some(guard) = lock.try_lock() {
+        return guard;
+    }
+    let blocked = majit_gc::gc_sync::before_external_block();
+    let guard = lock.lock();
+    drop(blocked);
+    guard
+}
+
+pub fn module_dict_locks_after_fork_child() {
+    for lock in DICT_LOCKS.iter() {
+        unsafe { lock.reinit_after_fork() };
+    }
+}
+
 /// Predicate: dict is in ObjectDictStrategy mode (post-switch).  When
 /// true, `object_storage` is authoritative and `dstorage` is empty +
 /// not consulted.  Mirrors `W_DictMultiObject.get_strategy()` returning
@@ -1316,6 +1401,7 @@ pub unsafe fn w_module_dict_object_storage_mut_opt<'a>(
 /// # Safety
 /// `obj` must point to a valid `W_ModuleDictObject`.
 pub unsafe fn w_module_dict_switch_to_object_strategy(obj: PyObjectRef) {
+    let _module_guard = w_dict_lock(obj);
     let raw = &mut *(obj as *mut W_ModuleDictObject);
     if !raw.object_storage.is_null() {
         return;
@@ -1488,6 +1574,7 @@ pub unsafe fn w_module_dict_setitem_str_no_proxy(
 }
 
 unsafe fn w_module_dict_setitem_str_internal(obj: PyObjectRef, key: &str, w_value: PyObjectRef) {
+    let _module_guard = w_dict_lock(obj);
     // Module-dict storage is Box-immortal, reached only by the
     // prebuilt-family root walk; record the store (gc_roots.rs
     // prebuilt-root write tracking).
@@ -1534,6 +1621,7 @@ unsafe fn w_module_dict_setitem_str_internal(obj: PyObjectRef, key: &str, w_valu
 /// # Safety
 /// `obj` must point to a valid `W_ModuleDictObject`.
 pub unsafe fn w_module_dict_getitem_str(obj: PyObjectRef, key: &str) -> Option<PyObjectRef> {
+    let _module_guard = w_dict_lock(obj);
     if let Some(entries) = w_module_dict_object_storage(obj) {
         // Post-switch ObjectStrategy: route through `dict_keys_equal`
         // (`dictmultiobject.py:1210` r_dict(eq_w, hash_w)) instead of
@@ -1622,6 +1710,7 @@ pub unsafe fn w_module_dict_delitem_str_no_proxy(
 }
 
 unsafe fn w_module_dict_delitem_str_internal(obj: PyObjectRef, key: &str) -> Option<PyObjectRef> {
+    let _module_guard = w_dict_lock(obj);
     if w_module_dict_is_object_strategy(obj) {
         // Post-switch ObjectStrategy: route through `dict_keys_equal`
         // for the same r_dict bucket reason as `w_module_dict_setitem_str`
@@ -1653,6 +1742,7 @@ unsafe fn w_module_dict_delitem_str_internal(obj: PyObjectRef, key: &str) -> Opt
 /// # Safety
 /// `obj` must point to a valid `W_ModuleDictObject`.
 pub unsafe fn w_module_dict_length(obj: PyObjectRef) -> usize {
+    let _module_guard = w_dict_lock(obj);
     if let Some(entries) = w_module_dict_object_storage(obj) {
         entries.len()
     } else {
@@ -1800,6 +1890,7 @@ pub(crate) unsafe fn dict_keys_equal(a: PyObjectRef, b: PyObjectRef) -> bool {
 /// `ModuleDictStrategy::getitem` and regular dicts through
 /// `ObjectDictStrategy::getitem`.
 pub unsafe fn w_dict_lookup(obj: PyObjectRef, key: PyObjectRef) -> Option<PyObjectRef> {
+    let _dict_guard = w_dict_lock(obj);
     w_dict_get_strategy(obj).getitem(obj, key)
 }
 
@@ -1830,6 +1921,7 @@ pub unsafe fn w_dict_lookup_checked(
     obj: PyObjectRef,
     key: PyObjectRef,
 ) -> Result<Option<PyObjectRef>, DictKeyError> {
+    let _dict_guard = w_dict_lock(obj);
     if is_module_dict(obj) {
         return w_module_dict_lookup_inner_checked(obj, key);
     }
@@ -2014,6 +2106,7 @@ pub unsafe fn w_dict_lookup_object_strategy(
     obj: PyObjectRef,
     key: PyObjectRef,
 ) -> Option<PyObjectRef> {
+    let _dict_guard = w_dict_lock(obj);
     w_dict_lookup_object_strategy_checked(obj, key).unwrap_or(None)
 }
 
@@ -2021,6 +2114,7 @@ pub unsafe fn w_dict_lookup_object_strategy_checked(
     obj: PyObjectRef,
     key: PyObjectRef,
 ) -> Result<Option<PyObjectRef>, DictKeyError> {
+    let _dict_guard = w_dict_lock(obj);
     let object_key = object_key_for_checked(key)?;
     if let Some(result) = callback_free_dict_op(|| {
         let dict = &*(obj as *const W_DictObject);
@@ -2054,6 +2148,7 @@ pub unsafe fn w_module_dict_lookup_inner(
     obj: PyObjectRef,
     key: PyObjectRef,
 ) -> Option<PyObjectRef> {
+    let _module_guard = w_dict_lock(obj);
     if let Some(entries) = w_module_dict_object_storage(obj) {
         return entries.get(&object_key_for(key)).copied();
     }
@@ -2072,6 +2167,7 @@ pub unsafe fn w_module_dict_lookup_inner_checked(
     obj: PyObjectRef,
     key: PyObjectRef,
 ) -> Result<Option<PyObjectRef>, DictKeyError> {
+    let _module_guard = w_dict_lock(obj);
     if let Some(entries) = w_module_dict_object_storage(obj) {
         let object_key = object_key_for_checked(key)?;
         let hit = entries.get(&object_key).copied();
@@ -2114,6 +2210,7 @@ pub unsafe fn w_dict_store(obj: PyObjectRef, key: PyObjectRef, value: PyObjectRe
     // tombstone).  Enforcing it at the store boundary means every lookup
     // return is provably non-null.
     debug_assert!(!value.is_null(), "w_dict_store: null value");
+    let _dict_guard = w_dict_lock(obj);
     w_dict_get_strategy(obj).setitem(obj, key, value)
 }
 
@@ -2126,6 +2223,7 @@ pub unsafe fn w_dict_store_checked(
     key: PyObjectRef,
     value: PyObjectRef,
 ) -> Result<(), DictKeyError> {
+    let _dict_guard = w_dict_lock(obj);
     w_dict_store_checked_inner(obj, key, value, None)
 }
 
@@ -2139,6 +2237,7 @@ pub unsafe fn w_dict_store_hashed_checked(
     value: PyObjectRef,
     hash: i64,
 ) -> Result<(), DictKeyError> {
+    let _dict_guard = w_dict_lock(obj);
     w_dict_store_checked_inner(obj, key, value, Some(hash))
 }
 
@@ -2243,6 +2342,7 @@ pub unsafe fn w_dict_setdefault_checked(
     key: PyObjectRef,
     value: PyObjectRef,
 ) -> Result<PyObjectRef, DictKeyError> {
+    let _dict_guard = w_dict_lock(obj);
     if is_module_dict(obj) {
         // `celldict.py:92-105 ModuleDictStrategy.setdefault`: for a str
         // key, grab the cell and return its value if set, else store the
@@ -2359,6 +2459,7 @@ pub unsafe fn w_dict_pop_checked(
     obj: PyObjectRef,
     key: PyObjectRef,
 ) -> Result<Option<PyObjectRef>, DictKeyError> {
+    let _dict_guard = w_dict_lock(obj);
     if is_module_dict(obj) {
         match w_module_dict_lookup_inner_checked(obj, key)? {
             Some(val) => {
@@ -2429,6 +2530,7 @@ pub unsafe fn w_dict_pop_checked(
 /// # Safety
 /// `obj` must point to a valid `W_DictObject`.
 pub unsafe fn w_dict_store_object_strategy(obj: PyObjectRef, key: PyObjectRef, value: PyObjectRef) {
+    let _dict_guard = w_dict_lock(obj);
     let _ = w_dict_store_object_strategy_checked(obj, key, value);
 }
 
@@ -2437,6 +2539,7 @@ pub unsafe fn w_dict_store_object_strategy_checked(
     key: PyObjectRef,
     value: PyObjectRef,
 ) -> Result<(), DictKeyError> {
+    let _dict_guard = w_dict_lock(obj);
     w_dict_store_object_strategy_checked_inner(obj, key, value, None)
 }
 
@@ -2519,6 +2622,7 @@ unsafe fn w_dict_store_object_strategy_checked_inner(
 /// # Safety
 /// `obj` must point to a valid `W_ModuleDictObject`.
 pub unsafe fn w_module_dict_store_inner(obj: PyObjectRef, key: PyObjectRef, value: PyObjectRef) {
+    let _module_guard = w_dict_lock(obj);
     // Prebuilt-family store (see `w_module_dict_setitem_str_internal`).
     crate::gc_roots::mark_prebuilt_roots_dirty();
     if !w_module_dict_is_object_strategy(obj) {
@@ -2544,6 +2648,7 @@ pub unsafe fn w_module_dict_store_inner_checked(
     key: PyObjectRef,
     value: PyObjectRef,
 ) -> Result<(), DictKeyError> {
+    let _module_guard = w_dict_lock(obj);
     if !w_module_dict_is_object_strategy(obj) {
         if let Some(ks) = key_as_utf8(key) {
             w_module_dict_setitem_str(obj, ks, value);
@@ -2637,6 +2742,7 @@ pub unsafe fn w_dict_setitem(obj: PyObjectRef, key: i64, value: PyObjectRef) {
 /// `ModuleDictStrategy::getitem_str` and regular dicts through
 /// `ObjectDictStrategy::getitem_str`.
 pub unsafe fn w_dict_getitem_str(obj: PyObjectRef, key: &str) -> Option<PyObjectRef> {
+    let _dict_guard = w_dict_lock(obj);
     w_dict_get_strategy(obj).getitem_str(obj, key)
 }
 
@@ -2672,6 +2778,7 @@ pub unsafe fn w_dict_getitem_str_object_strategy(
 /// runtime-mutable dict storage the tracer cannot model.
 #[majit_macros::dont_look_inside]
 pub unsafe fn w_dict_setitem_str(obj: PyObjectRef, key: &str, value: PyObjectRef) {
+    let _dict_guard = w_dict_lock(obj);
     w_dict_get_strategy(obj).setitem_str(obj, key, value)
 }
 
@@ -2743,6 +2850,7 @@ pub unsafe fn w_dict_setitem_wtf8_no_proxy(
 /// # Safety
 /// `obj` must point to a valid `W_DictObject` or `W_ModuleDictObject`.
 pub unsafe fn w_dict_delitem_wtf8_no_proxy(obj: PyObjectRef, key: &rustpython_wtf8::Wtf8) -> bool {
+    let _dict_guard = w_dict_lock(obj);
     if is_module_dict(obj) {
         if let Ok(key) = key.as_str() {
             return w_module_dict_delitem_str_no_proxy(obj, key).is_some();
@@ -2809,6 +2917,7 @@ pub unsafe fn w_dict_delitem_str(obj: PyObjectRef, key: &str) -> bool {
 /// `ModuleDictStrategy::delitem` and regular dicts through
 /// `ObjectDictStrategy::delitem`.
 pub unsafe fn w_dict_delitem(obj: PyObjectRef, key: PyObjectRef) -> bool {
+    let _dict_guard = w_dict_lock(obj);
     w_dict_get_strategy(obj).delitem(obj, key)
 }
 
@@ -2820,6 +2929,7 @@ pub unsafe fn w_dict_delitem_checked(
     obj: PyObjectRef,
     key: PyObjectRef,
 ) -> Result<bool, DictKeyError> {
+    let _dict_guard = w_dict_lock(obj);
     if is_module_dict(obj) {
         return w_module_dict_delitem_inner_checked(obj, key);
     }
@@ -2965,6 +3075,7 @@ pub unsafe fn w_dict_delitem_if_value_is_checked(
 /// # Safety
 /// `obj` must point to a valid `W_DictObject`.
 pub unsafe fn w_dict_delitem_object_strategy(obj: PyObjectRef, key: PyObjectRef) -> bool {
+    let _dict_guard = w_dict_lock(obj);
     w_dict_delitem_object_strategy_checked(obj, key).unwrap_or(false)
 }
 
@@ -2972,6 +3083,7 @@ pub unsafe fn w_dict_delitem_object_strategy_checked(
     obj: PyObjectRef,
     key: PyObjectRef,
 ) -> Result<bool, DictKeyError> {
+    let _dict_guard = w_dict_lock(obj);
     let object_key = object_key_for_checked(key)?;
     // Single delitem probe, run callback-free so no user `__eq__` mutates the
     // dict while the `IndexMap` borrow is live.  A comparison the builtin
@@ -3019,6 +3131,7 @@ pub unsafe fn w_dict_delitem_object_strategy_checked(
 /// # Safety
 /// `obj` must point to a valid `W_ModuleDictObject`.
 pub unsafe fn w_module_dict_delitem_inner(obj: PyObjectRef, key: PyObjectRef) -> bool {
+    let _module_guard = w_dict_lock(obj);
     if w_module_dict_is_object_strategy(obj) {
         let entries = w_module_dict_object_storage_mut(obj);
         if entries.shift_remove(&object_key_for(key)).is_some() {
@@ -3050,6 +3163,7 @@ pub unsafe fn w_module_dict_delitem_inner_checked(
     obj: PyObjectRef,
     key: PyObjectRef,
 ) -> Result<bool, DictKeyError> {
+    let _module_guard = w_dict_lock(obj);
     if w_module_dict_is_object_strategy(obj) {
         let object_key = object_key_for_checked(key)?;
         let entries = w_module_dict_object_storage_mut(obj);
@@ -3091,6 +3205,7 @@ pub unsafe fn w_module_dict_delitem_inner_checked(
 /// — `w_dict.get_strategy().clear(w_dict)`.  Dispatches through the
 /// polymorphic strategy slot.
 pub unsafe fn w_dict_clear(obj: PyObjectRef) {
+    let _dict_guard = w_dict_lock(obj);
     w_dict_get_strategy(obj).clear(obj);
 }
 
@@ -3102,6 +3217,7 @@ pub unsafe fn w_dict_clear(obj: PyObjectRef) {
 /// # Safety
 /// `obj` must point to a valid `W_DictObject`.
 pub unsafe fn w_dict_clear_object_strategy(obj: PyObjectRef) {
+    let _dict_guard = w_dict_lock(obj);
     let dict = &mut *(obj as *mut W_DictObject);
     let entries = &mut *(dict.dstorage as *mut indexmap::IndexMap<ObjectKey, PyObjectRef>);
     if !entries.is_empty() {
@@ -3124,6 +3240,7 @@ pub unsafe fn w_dict_clear_object_strategy(obj: PyObjectRef) {
 /// # Safety
 /// `obj` must point to a valid `W_ModuleDictObject`.
 pub unsafe fn w_module_dict_clear_inner(obj: PyObjectRef) {
+    let _module_guard = w_dict_lock(obj);
     if w_module_dict_is_object_strategy(obj) {
         let entries = w_module_dict_object_storage_mut(obj);
         let changed = !entries.is_empty();
@@ -3153,6 +3270,7 @@ pub unsafe fn w_module_dict_clear_inner(obj: PyObjectRef) {
 /// runtime-mutable dict storage the tracer cannot model.
 #[majit_macros::dont_look_inside]
 pub unsafe fn w_dict_len(obj: PyObjectRef) -> usize {
+    let _dict_guard = w_dict_lock(obj);
     w_dict_get_strategy(obj).length(obj)
 }
 
@@ -3164,6 +3282,7 @@ pub unsafe fn w_dict_len(obj: PyObjectRef) -> usize {
 /// # Safety
 /// `obj` must point to a valid `W_DictObject`.
 pub unsafe fn w_dict_length_object_strategy(obj: PyObjectRef) -> usize {
+    let _dict_guard = w_dict_lock(obj);
     let dict = &*(obj as *const W_DictObject);
     let entries = &*(dict.dstorage as *const indexmap::IndexMap<ObjectKey, PyObjectRef>);
     entries.len()
@@ -3172,6 +3291,7 @@ pub unsafe fn w_dict_length_object_strategy(obj: PyObjectRef) -> usize {
 /// Iterate over all (key, value) pairs without type assumptions.
 ///
 pub unsafe fn w_dict_items(obj: PyObjectRef) -> Vec<(PyObjectRef, PyObjectRef)> {
+    let _dict_guard = w_dict_lock(obj);
     w_dict_get_strategy(obj).items(obj)
 }
 
@@ -3184,6 +3304,7 @@ pub unsafe fn w_dict_nth_item(
     obj: PyObjectRef,
     index: usize,
 ) -> Option<(PyObjectRef, PyObjectRef)> {
+    let _dict_guard = w_dict_lock(obj);
     w_dict_get_strategy(obj).nth_item(obj, index)
 }
 
@@ -3202,6 +3323,7 @@ pub unsafe fn w_dict_nth_item(
 /// # Safety
 /// `obj` must be a valid regular `W_DictObject` (not a module dict).
 pub unsafe fn w_dict_nth_hashed_key(obj: PyObjectRef, index: usize) -> Option<ObjectKey> {
+    let _dict_guard = w_dict_lock(obj);
     match w_dict_get_strategy(obj).strategy_kind() {
         StrategyKind::Object | StrategyKind::Unicode => {
             let dict = &*(obj as *const W_DictObject);
@@ -3218,6 +3340,7 @@ pub unsafe fn w_dict_nth_hashed_key(obj: PyObjectRef, index: usize) -> Option<Ob
 /// AbstractTypedStrategy.copy` → fresh W_DictObject with same strategy
 /// + cloned typed dstorage).
 pub unsafe fn w_dict_copy(obj: PyObjectRef) -> PyObjectRef {
+    let _dict_guard = w_dict_lock(obj);
     w_dict_get_strategy(obj).copy(obj)
 }
 
@@ -3238,6 +3361,7 @@ pub unsafe fn w_dict_copy(obj: PyObjectRef) -> PyObjectRef {
 /// plain `W_IntObject` (not bool).
 #[majit_macros::dont_look_inside]
 pub unsafe fn w_dict_store_int_strategy(obj: PyObjectRef, key: PyObjectRef, value: PyObjectRef) {
+    let _dict_guard = w_dict_lock(obj);
     let dict = &mut *(obj as *mut W_DictObject);
     let entries = &mut *(dict.dstorage as *mut indexmap::IndexMap<i64, PyObjectRef>);
     let k = crate::listobject::plain_int_w(key);
@@ -3263,6 +3387,7 @@ pub unsafe fn w_dict_lookup_int_strategy(
     obj: PyObjectRef,
     key: PyObjectRef,
 ) -> Option<PyObjectRef> {
+    let _dict_guard = w_dict_lock(obj);
     let entries = w_dict_int_storage(obj);
     let k = crate::listobject::plain_int_w(key);
     entries.get(&k).copied()
@@ -3275,6 +3400,7 @@ pub unsafe fn w_dict_lookup_int_strategy(
 /// # Safety
 /// Same as [`w_dict_store_int_strategy`].
 pub unsafe fn w_dict_delitem_int_strategy(obj: PyObjectRef, key: PyObjectRef) -> bool {
+    let _dict_guard = w_dict_lock(obj);
     let dict = &mut *(obj as *mut W_DictObject);
     let entries = &mut *(dict.dstorage as *mut indexmap::IndexMap<i64, PyObjectRef>);
     let k = crate::listobject::plain_int_w(key);
@@ -3296,6 +3422,7 @@ pub unsafe fn w_dict_delitem_int_strategy(obj: PyObjectRef, key: PyObjectRef) ->
 /// `obj` must point to a valid `W_DictObject` on
 /// [`crate::dictmultiobject::INT_DICT_STRATEGY`].
 pub unsafe fn w_dict_length_int_strategy(obj: PyObjectRef) -> usize {
+    let _dict_guard = w_dict_lock(obj);
     w_dict_int_storage(obj).len()
 }
 
@@ -3306,6 +3433,7 @@ pub unsafe fn w_dict_length_int_strategy(obj: PyObjectRef) -> usize {
 /// # Safety
 /// Same as [`w_dict_length_int_strategy`].
 pub unsafe fn w_dict_items_int_strategy(obj: PyObjectRef) -> Vec<(PyObjectRef, PyObjectRef)> {
+    let _dict_guard = w_dict_lock(obj);
     w_dict_int_storage(obj)
         .iter()
         .map(|(&k, &v)| (crate::w_int_new(k), v))
@@ -3324,6 +3452,7 @@ pub unsafe fn w_dict_nth_item_int_strategy(
     obj: PyObjectRef,
     index: usize,
 ) -> Option<(PyObjectRef, PyObjectRef)> {
+    let _dict_guard = w_dict_lock(obj);
     let (k, v) = w_dict_int_storage(obj)
         .get_index(index)
         .map(|(&k, &v)| (k, v))?;
@@ -3336,6 +3465,7 @@ pub unsafe fn w_dict_nth_item_int_strategy(
 /// # Safety
 /// Same as [`w_dict_length_int_strategy`].
 pub unsafe fn w_dict_clear_int_strategy(obj: PyObjectRef) {
+    let _dict_guard = w_dict_lock(obj);
     let dict = &mut *(obj as *mut W_DictObject);
     let entries = &mut *(dict.dstorage as *mut indexmap::IndexMap<i64, PyObjectRef>);
     if !entries.is_empty() {
@@ -3359,6 +3489,7 @@ pub unsafe fn w_dict_clear_int_strategy(obj: PyObjectRef) {
 /// `W_BytesObject`.
 #[majit_macros::dont_look_inside]
 pub unsafe fn w_dict_store_bytes_strategy(obj: PyObjectRef, key: PyObjectRef, value: PyObjectRef) {
+    let _dict_guard = w_dict_lock(obj);
     let dict = &mut *(obj as *mut W_DictObject);
     let entries = &mut *(dict.dstorage as *mut indexmap::IndexMap<Vec<u8>, PyObjectRef>);
     let k = crate::w_bytes_data(key).to_vec();
@@ -3384,6 +3515,7 @@ pub unsafe fn w_dict_lookup_bytes_strategy(
     obj: PyObjectRef,
     key: PyObjectRef,
 ) -> Option<PyObjectRef> {
+    let _dict_guard = w_dict_lock(obj);
     let entries = w_dict_bytes_storage(obj);
     let k = crate::w_bytes_data(key);
     entries.get(k).copied()
@@ -3395,6 +3527,7 @@ pub unsafe fn w_dict_lookup_bytes_strategy(
 /// # Safety
 /// Same as [`w_dict_store_bytes_strategy`].
 pub unsafe fn w_dict_delitem_bytes_strategy(obj: PyObjectRef, key: PyObjectRef) -> bool {
+    let _dict_guard = w_dict_lock(obj);
     let dict = &mut *(obj as *mut W_DictObject);
     let entries = &mut *(dict.dstorage as *mut indexmap::IndexMap<Vec<u8>, PyObjectRef>);
     let k = crate::w_bytes_data(key);
@@ -3411,6 +3544,7 @@ pub unsafe fn w_dict_delitem_bytes_strategy(obj: PyObjectRef, key: PyObjectRef) 
 /// # Safety
 /// Same as [`w_dict_bytes_storage`].
 pub unsafe fn w_dict_length_bytes_strategy(obj: PyObjectRef) -> usize {
+    let _dict_guard = w_dict_lock(obj);
     w_dict_bytes_storage(obj).len()
 }
 
@@ -3421,6 +3555,7 @@ pub unsafe fn w_dict_length_bytes_strategy(obj: PyObjectRef) -> usize {
 /// # Safety
 /// Same as [`w_dict_bytes_storage`].
 pub unsafe fn w_dict_items_bytes_strategy(obj: PyObjectRef) -> Vec<(PyObjectRef, PyObjectRef)> {
+    let _dict_guard = w_dict_lock(obj);
     w_dict_bytes_storage(obj)
         .iter()
         .map(|(k, v)| (crate::w_bytes_from_bytes(k.as_slice()), *v))
@@ -3435,6 +3570,7 @@ pub unsafe fn w_dict_nth_item_bytes_strategy(
     obj: PyObjectRef,
     index: usize,
 ) -> Option<(PyObjectRef, PyObjectRef)> {
+    let _dict_guard = w_dict_lock(obj);
     let entries = w_dict_bytes_storage(obj);
     let (k, v) = entries.get_index(index)?;
     let key_bytes = k.clone();
@@ -3447,6 +3583,7 @@ pub unsafe fn w_dict_nth_item_bytes_strategy(
 /// # Safety
 /// Same as [`w_dict_bytes_storage`].
 pub unsafe fn w_dict_clear_bytes_strategy(obj: PyObjectRef) {
+    let _dict_guard = w_dict_lock(obj);
     let dict = &mut *(obj as *mut W_DictObject);
     let entries = &mut *(dict.dstorage as *mut indexmap::IndexMap<Vec<u8>, PyObjectRef>);
     if !entries.is_empty() {
@@ -3462,6 +3599,7 @@ pub unsafe fn w_dict_clear_bytes_strategy(obj: PyObjectRef) {
 /// # Safety
 /// `obj` must point to a valid `W_DictObject`.
 pub unsafe fn w_dict_items_object_strategy(obj: PyObjectRef) -> Vec<(PyObjectRef, PyObjectRef)> {
+    let _dict_guard = w_dict_lock(obj);
     let dict = &*(obj as *const W_DictObject);
     let entries = &*(dict.dstorage as *const indexmap::IndexMap<ObjectKey, PyObjectRef>);
     entries.iter().map(|(k, &v)| (k.obj, v)).collect()
@@ -3476,6 +3614,7 @@ pub unsafe fn w_dict_nth_item_object_strategy(
     obj: PyObjectRef,
     index: usize,
 ) -> Option<(PyObjectRef, PyObjectRef)> {
+    let _dict_guard = w_dict_lock(obj);
     let dict = &*(obj as *const W_DictObject);
     let entries = &*(dict.dstorage as *const indexmap::IndexMap<ObjectKey, PyObjectRef>);
     entries.get_index(index).map(|(k, &v)| (k.obj, v))
@@ -3488,6 +3627,7 @@ pub unsafe fn w_dict_nth_item_object_strategy(
 /// # Safety
 /// `obj` must point to a valid `W_ModuleDictObject`.
 pub unsafe fn w_module_dict_items_inner(obj: PyObjectRef) -> Vec<(PyObjectRef, PyObjectRef)> {
+    let _module_guard = w_dict_lock(obj);
     if let Some(entries) = w_module_dict_object_storage(obj) {
         entries.iter().map(|(k, &v)| (k.obj, v)).collect()
     } else {

--- a/pyre/pyre-object/src/dictmultiobject.rs
+++ b/pyre/pyre-object/src/dictmultiobject.rs
@@ -999,10 +999,7 @@ pub unsafe fn w_dict_walk_entries_mut(obj: PyObjectRef, mut visitor: impl FnMut(
 /// function. It is used when an immortal/prebuilt owner must descend through
 /// an already-old dict during a minor collection; merely visiting the dict
 /// object itself does not rescan that old object's storage.
-pub unsafe fn w_dict_walk_gc_refs(
-    obj: PyObjectRef,
-    visitor: &mut dyn FnMut(&mut PyObjectRef),
-) {
+pub unsafe fn w_dict_walk_gc_refs(obj: PyObjectRef, visitor: &mut dyn FnMut(&mut PyObjectRef)) {
     if obj.is_null() {
         return;
     }
@@ -1236,11 +1233,7 @@ impl ForkDictLock {
     }
 
     unsafe fn reinit_after_fork(&self) {
-        unsafe {
-            self.0
-                .get()
-                .write(parking_lot::ReentrantMutex::new(()))
-        };
+        unsafe { self.0.get().write(parking_lot::ReentrantMutex::new(())) };
     }
 }
 

--- a/pyre/pyre-object/src/listobject.rs
+++ b/pyre/pyre-object/src/listobject.rs
@@ -18,6 +18,60 @@ use crate::{
     intobject::w_int_get_value, intobject::w_int_new, longobject::jit_bigint_to_i64_value,
     longobject::w_long_fits_int, longobject::w_long_get_value, tupleobject::is_plain_float_strict,
 };
+use std::cell::UnsafeCell;
+use std::sync::LazyLock;
+
+// PyPy's list strategy/storage transitions are indivisible under its GIL.
+// Pyre keeps the list itself as the sole semantic owner and uses only narrow
+// address-striped reentrant synchronization around those transitions.
+struct ForkListLock(UnsafeCell<parking_lot::ReentrantMutex<()>>);
+unsafe impl Sync for ForkListLock {}
+
+impl ForkListLock {
+    fn new() -> Self {
+        Self(UnsafeCell::new(parking_lot::ReentrantMutex::new(())))
+    }
+
+    fn get(&self) -> &parking_lot::ReentrantMutex<()> {
+        unsafe { &*self.0.get() }
+    }
+
+    unsafe fn reinit_after_fork(&self) {
+        unsafe {
+            self.0
+                .get()
+                .write(parking_lot::ReentrantMutex::new(()))
+        };
+    }
+}
+
+static LIST_LOCKS: LazyLock<Vec<ForkListLock>> =
+    LazyLock::new(|| (0..256).map(|_| ForkListLock::new()).collect());
+
+type ListGuard = parking_lot::lock_api::ReentrantMutexGuard<
+    'static,
+    parking_lot::RawMutex,
+    parking_lot::RawThreadId,
+    (),
+>;
+
+#[majit_macros::dont_look_inside]
+unsafe fn w_list_lock(obj: PyObjectRef) -> ListGuard {
+    let lock = LIST_LOCKS[(obj as usize >> 4) & (LIST_LOCKS.len() - 1)].get();
+    if let Some(guard) = lock.try_lock() {
+        return guard;
+    }
+    let blocked = majit_gc::gc_sync::before_external_block();
+    let guard = lock.lock();
+    drop(blocked);
+    guard
+}
+
+pub fn list_locks_after_fork_child() {
+    for lock in LIST_LOCKS.iter() {
+        unsafe { lock.reinit_after_fork() };
+    }
+}
 
 #[repr(u8)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -748,7 +802,9 @@ pub fn ll_list_obj_setitem_fast(l: &mut W_ListObject, index: usize, item: PyObje
 ///
 /// # Safety
 /// `obj` must point to a valid `W_ListObject`.
+#[majit_macros::dont_look_inside]
 pub unsafe fn w_list_getitem(obj: PyObjectRef, index: i64) -> Option<PyObjectRef> {
+    let _list_guard = w_list_lock(obj);
     let list = &*(obj as *const W_ListObject);
     match list.strategy {
         // listobject.py:1134 EmptyListStrategy.getitem raises IndexError.
@@ -788,7 +844,9 @@ pub unsafe fn w_list_getitem(obj: PyObjectRef, index: i64) -> Option<PyObjectRef
 ///
 /// # Safety
 /// `obj` must point to a valid `W_ListObject`.
+#[majit_macros::dont_look_inside]
 pub unsafe fn w_list_setitem(obj: PyObjectRef, index: i64, value: PyObjectRef) -> bool {
+    let _list_guard = w_list_lock(obj);
     let list = &mut *(obj as *mut W_ListObject);
     match list.strategy {
         // listobject.py:1185 EmptyListStrategy.setitem raises IndexError.
@@ -840,7 +898,9 @@ pub unsafe fn w_list_setitem(obj: PyObjectRef, index: i64, value: PyObjectRef) -
 ///
 /// # Safety
 /// `obj` must point to a valid `W_ListObject`.
+#[majit_macros::dont_look_inside]
 pub unsafe fn w_list_append(obj: PyObjectRef, value: PyObjectRef) {
+    let _list_guard = w_list_lock(obj);
     let list = &mut *(obj as *mut W_ListObject);
     match list.strategy {
         // listobject.py:1170 EmptyListStrategy.append: pick the matching
@@ -945,7 +1005,9 @@ pub unsafe fn w_list_int_set_len(obj: PyObjectRef, n: usize) {
 ///
 /// # Safety
 /// `obj` must point to a valid `W_ListObject`.
+#[majit_macros::dont_look_inside]
 pub unsafe fn w_list_len(obj: PyObjectRef) -> usize {
+    let _list_guard = w_list_lock(obj);
     let list = &*(obj as *const W_ListObject);
     match list.strategy {
         // listobject.py:1131 EmptyListStrategy.length returns 0.

--- a/pyre/pyre-object/src/listobject.rs
+++ b/pyre/pyre-object/src/listobject.rs
@@ -51,6 +51,12 @@ type ListGuard = parking_lot::lock_api::ReentrantMutexGuard<
     (),
 >;
 
+/// Only the acquire itself is opaque to the tracer; the guard-holding bodies
+/// stay look-inside, the same split `w_dict_lock` uses. A `dont_look_inside`
+/// data function is excluded from the jitcode pipeline entirely — the
+/// codewriter roots jitdriver portals and reaches everything else through
+/// look-inside calls — so the tracer emits a residual call for the whole
+/// operation instead of specializing the strategy dispatch.
 #[majit_macros::dont_look_inside]
 unsafe fn w_list_lock(obj: PyObjectRef) -> ListGuard {
     let lock = LIST_LOCKS[(obj as usize >> 4) & (LIST_LOCKS.len() - 1)].get();
@@ -798,7 +804,6 @@ pub fn ll_list_obj_setitem_fast(l: &mut W_ListObject, index: usize, item: PyObje
 ///
 /// # Safety
 /// `obj` must point to a valid `W_ListObject`.
-#[majit_macros::dont_look_inside]
 pub unsafe fn w_list_getitem(obj: PyObjectRef, index: i64) -> Option<PyObjectRef> {
     let _list_guard = w_list_lock(obj);
     let list = &*(obj as *const W_ListObject);
@@ -840,7 +845,6 @@ pub unsafe fn w_list_getitem(obj: PyObjectRef, index: i64) -> Option<PyObjectRef
 ///
 /// # Safety
 /// `obj` must point to a valid `W_ListObject`.
-#[majit_macros::dont_look_inside]
 pub unsafe fn w_list_setitem(obj: PyObjectRef, index: i64, value: PyObjectRef) -> bool {
     let _list_guard = w_list_lock(obj);
     let list = &mut *(obj as *mut W_ListObject);
@@ -1026,7 +1030,6 @@ pub unsafe fn w_list_int_set_len(obj: PyObjectRef, n: usize) {
 ///
 /// # Safety
 /// `obj` must point to a valid `W_ListObject`.
-#[majit_macros::dont_look_inside]
 pub unsafe fn w_list_len(obj: PyObjectRef) -> usize {
     let _list_guard = w_list_lock(obj);
     let list = &*(obj as *const W_ListObject);

--- a/pyre/pyre-object/src/listobject.rs
+++ b/pyre/pyre-object/src/listobject.rs
@@ -37,11 +37,7 @@ impl ForkListLock {
     }
 
     unsafe fn reinit_after_fork(&self) {
-        unsafe {
-            self.0
-                .get()
-                .write(parking_lot::ReentrantMutex::new(()))
-        };
+        unsafe { self.0.get().write(parking_lot::ReentrantMutex::new(())) };
     }
 }
 
@@ -896,18 +892,43 @@ pub unsafe fn w_list_setitem(obj: PyObjectRef, index: i64, value: PyObjectRef) -
 
 /// Append an item to a list.
 ///
+/// Splits into a guard-taking wrapper and a lock-free
+/// [`w_list_append_inner`], the same shape the dict side uses
+/// (`w_dict_store_checked` / `w_dict_store_checked_inner`), because the append
+/// fold descends this body:
+///
+/// * the wrapper must stay look-inside — the codewriter only reaches graphs
+///   through look-inside calls from a jitdriver portal
+///   (`grab_initial_jitcodes` / `enum_pending_graphs`), so a
+///   `dont_look_inside` wrapper hides the inner body from the pipeline as
+///   well;
+/// * the descended body must hold no guard — a `w_list_lock` acquire/release
+///   pair inside it declines the fold's sub-walk.
+///
+/// Either way `list_append_jitcode()` resolves to `None`, the fold declines,
+/// and every `list.append` becomes a `Void` residual — a body effect that
+/// refuses in-flight FOR_ITER delivery and silently drops the iteration.
+///
 /// # Safety
 /// `obj` must point to a valid `W_ListObject`.
-#[majit_macros::dont_look_inside]
 pub unsafe fn w_list_append(obj: PyObjectRef, value: PyObjectRef) {
     let _list_guard = w_list_lock(obj);
+    w_list_append_inner(obj, value)
+}
+
+/// [`w_list_append`]'s body, run with the list's guard already held.
+///
+/// # Safety
+/// `obj` must point to a valid `W_ListObject`, and the caller must hold
+/// `w_list_lock(obj)`.
+pub unsafe fn w_list_append_inner(obj: PyObjectRef, value: PyObjectRef) {
     let list = &mut *(obj as *mut W_ListObject);
     match list.strategy {
         // listobject.py:1170 EmptyListStrategy.append: pick the matching
         // typed strategy first, then fall through to its append.
         ListStrategy::Empty => {
             switch_to_correct_strategy(list, value);
-            w_list_append(obj, value);
+            w_list_append_inner(obj, value);
         }
         // AbstractUnwrappedStrategy.append (listobject.py:1695):
         //   if self.is_correct_type(w_item): l.append(self.unwrap(w_item)); return

--- a/pyre/pyre-object/src/pyobject.rs
+++ b/pyre/pyre-object/src/pyobject.rs
@@ -592,6 +592,7 @@ pub const SUBCLASS_RANGE_HIERARCHY: &[(u32, Option<u32>)] = &[
     (137, Some(0)),
     (138, Some(0)),
     (139, Some(0)),
+    (140, Some(0)),
 ];
 
 /// Compute subclass IDs from [`SUBCLASS_RANGE_HIERARCHY`] and write every

--- a/pyre/pyrex/build.rs
+++ b/pyre/pyrex/build.rs
@@ -1,0 +1,20 @@
+fn main() {
+    let target = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+    for symbol in [
+        "PyThreadState_SetAsyncExc",
+        "PyGILState_Ensure",
+        "PyGILState_Release",
+    ] {
+        match target.as_str() {
+            "macos" => println!(
+                "cargo::rustc-link-arg-bins=-Wl,-exported_symbol,_{}",
+                symbol
+            ),
+            "linux" => println!(
+                "cargo::rustc-link-arg-bins=-Wl,--export-dynamic-symbol={}",
+                symbol
+            ),
+            _ => {}
+        }
+    }
+}

--- a/pyre/pyrex/src/lib.rs
+++ b/pyre/pyrex/src/lib.rs
@@ -244,6 +244,13 @@ fn parse_args(binary_name: &str) -> Result<(RunMode, LaunchFlags, Vec<String>), 
                     _ => {}
                 }
             }
+            // Accepted for CPython/PyPy command-line compatibility.  Warning
+            // filter installation is handled by the warnings module; keeping
+            // the option/value in launcher parsing lets stdlib subprocesses
+            // reach their command or module.
+            Short('W') => {
+                let _filter = parser.value()?.string()?;
+            }
             // `-O` / `-OO` raise the optimization level; each occurrence counts
             // (app_main.py `optimize`). PYTHONOPTIMIZE folds in during finalize.
             Short('O') => flags.optimize = flags.optimize.saturating_add(1),
@@ -853,6 +860,83 @@ pub(crate) fn init_importlib_bootstrap(
     Ok(())
 }
 
+/// PyPy object-space finalization / `threading._shutdown`: run the app-level
+/// callbacks before module teardown, then join native non-daemon handles.
+fn run_threading_shutdown() {
+    if let Some(threading) = importing::get_sys_module("threading")
+        && let Ok(shutdown) =
+            pyre_interpreter::getattr(threading, pyre_object::w_str_new("_shutdown"))
+    {
+        let result = pyre_interpreter::call_function(shutdown, &[]);
+        if result.is_null()
+            && let Some(err) = pyre_interpreter::call::take_call_error()
+        {
+            pyre_interpreter::eprint_exception(&err, true);
+        }
+    }
+    // PyPy's `threading._shutdown` first waits for non-daemon threads. Those
+    // threads may legally start further non-daemon threads while the shutdown
+    // drain is in progress. Only reject new thread creation once that app-level
+    // drain has returned and module/finalizer teardown is about to begin.
+    pyre_interpreter::module::thread::set_finalizing();
+}
+
+fn collect_and_run_finalizers(ec_ptr: *const PyExecutionContext) {
+    pyre_object::gc_hook::try_gc_collect();
+    if !ec_ptr.is_null() {
+        unsafe { (&mut *(ec_ptr as *mut PyExecutionContext))._run_finalizers_now() };
+    }
+}
+
+/// PyPy `ObjSpace.finish()` / module teardown ordering: join non-daemon
+/// threads, collect already-unreachable cycles, then release `__main__`
+/// globals from newest to oldest while the older globals their `__del__`
+/// methods may reference are still present.
+fn finalize_runtime(canonical: pyre_object::PyObjectRef, ec_ptr: *const PyExecutionContext) {
+    run_threading_shutdown();
+    collect_and_run_finalizers(ec_ptr);
+    let mut entries = unsafe { pyre_object::w_dict_str_entries(canonical) };
+    entries.reverse();
+    for (name, _) in entries {
+        if name == "__builtins__" {
+            continue;
+        }
+        unsafe {
+            pyre_object::w_dict_delitem_str(canonical, &name);
+        }
+        collect_and_run_finalizers(ec_ptr);
+    }
+}
+
+/// Keep the object references carried by a pending SystemExit live and
+/// relocatable while interpreter finalization performs collections.  PyPy's
+/// OperationError is GC-visible RPython state; pyre's Rust `PyError` is not, so
+/// its three raw PyObjectRef fields need the same explicit shadow-root
+/// treatment as other host-stack temporaries.
+fn finalize_system_exit(
+    mut error: pyre_interpreter::PyError,
+    canonical: pyre_object::PyObjectRef,
+    ec_ptr: *const PyExecutionContext,
+) -> ! {
+    let roots = pyre_object::gc_roots::push_roots();
+    let base = pyre_object::gc_roots::shadow_stack_len();
+    for value in [
+        error.exc_object,
+        error.w_name_context,
+        error.w_obj_context,
+    ] {
+        pyre_object::gc_roots::pin_root(value);
+    }
+    finalize_runtime(canonical, ec_ptr);
+    error.exc_object = pyre_object::gc_roots::shadow_stack_get(base);
+    error.w_name_context = pyre_object::gc_roots::shadow_stack_get(base + 1);
+    error.w_obj_context = pyre_object::gc_roots::shadow_stack_get(base + 2);
+    let code = system_exit_code(&error);
+    drop(roots);
+    maybe_print_jit_stats();
+    std::process::exit(code);
+}
+
 /// Run a library module as `__main__` via `runpy._run_module_as_main`,
 /// the `-m` entry point. `vm.run_module` analog.
 fn run_module(module: &str, no_site: bool) {
@@ -895,13 +979,13 @@ fn run_module(module: &str, no_site: bool) {
 
     if let Err(e) = result {
         if e.kind == PyErrorKind::SystemExit {
-            maybe_print_jit_stats();
-            std::process::exit(system_exit_code(&e));
+            finalize_system_exit(e, canonical, ec_ptr);
         }
         maybe_print_jit_stats();
         pyre_interpreter::eprint_exception(&e, true);
         std::process::exit(1);
     }
+    finalize_runtime(canonical, ec_ptr);
     maybe_print_jit_stats();
 }
 
@@ -1021,14 +1105,14 @@ fn run_source(source: &str, mode: Mode, filename: &str, no_site: bool) {
         }
         Err(e) => {
             if e.kind == PyErrorKind::SystemExit {
-                maybe_print_jit_stats();
-                std::process::exit(system_exit_code(&e));
+                finalize_system_exit(e, canonical, ec_ptr);
             }
             maybe_print_jit_stats();
             pyre_interpreter::eprint_exception(&e, true);
             std::process::exit(1);
         }
     }
+    finalize_runtime(canonical, ec_ptr);
     maybe_print_jit_stats();
 }
 

--- a/pyre/pyrex/src/lib.rs
+++ b/pyre/pyrex/src/lib.rs
@@ -920,11 +920,7 @@ fn finalize_system_exit(
 ) -> ! {
     let roots = pyre_object::gc_roots::push_roots();
     let base = pyre_object::gc_roots::shadow_stack_len();
-    for value in [
-        error.exc_object,
-        error.w_name_context,
-        error.w_obj_context,
-    ] {
+    for value in [error.exc_object, error.w_name_context, error.w_obj_context] {
         pyre_object::gc_roots::pin_root(value);
     }
     finalize_runtime(canonical, ec_ptr);


### PR DESCRIPTION
Ports PyPy's free-threaded runtime support and fixes the JIT miscompile the list-side locking introduced.

## Commits

1. **`thread: port free-threaded runtime support from PyPy`** — the port itself.
2. **`cpython_tests: allow vendored test edits that carry PyPy's own modifications`** — amends the suite's stated policy. `lib-python/3/test/` is CPython's `Lib/test` **plus the modifications PyPy makes in its own `lib-python`**; those are ported and kept (a re-vendor from CPython drops them, so they are restored after one). A pyre-specific skip / expected-status decision still never becomes a test-file edit — it lives in `baseline.json`.

   Motivating case: the 7 `@cpython_only` markers on `test_threading.py` restore PyPy's own py3.11 edits that the 3.14.6 re-vendor wiped. None masks a threading gap — 2 × `ctypes.pythonapi`, 2 × subinterpreters, 3 × refcount / shutdown-finalizer semantics.
3. **`listobject: split w_list_append so the append fold descends a lock-free body`** — the fix below.

## The miscompile

`bench/synth/getframe_force_cancel_journal` printed `19995 20000 989403` instead of `20000 20000 989403` on all three backends; `PYRE_NO_JIT=1` was correct. The loss was exactly 5 regardless of N — `MAX_TRACE_ABORT_COUNT`, one iteration per abort.

The free-threading port gave `w_list_append` a striped `w_list_lock` guard **and** `#[dont_look_inside]`. Measured separately, **either one alone** stops the orthodox append fold:

| `w_list_append` shape | bench |
|---|---|
| guard + `dont_look_inside` (as ported) | `19995` |
| guard only, attribute removed | `19995` |
| neither | `20000` |
| guard in wrapper, lock-free inner (**this fix**) | `20000` |

- The attribute makes `look_inside_graph` return false (`codewriter/policy.rs`), so the graph never enters the jitcode pipeline and `list_append_jitcode()` resolves to `None`. `grab_initial_jitcodes` roots only jitdriver portals and reaches everything else through look-inside calls, so an opaque function hides its own body *and* anything only it calls. Confirmed against `jitcodes.bin`: `w_list_append` present without the attribute, absent with it.
- A guard inside the descended body declines the fold's sub-walk on its own — in that configuration the codewriter does process the graph (`[CodeWriter] w_list_append` in the census stderr) and the bench still drops 5.

Either way the fold falls through to a generic `CallFn` residual whose descr result type is `Void`. `writes_live_heap` counts that as a body effect, so `fbw_foriter_inflight_take` refuses to deliver the in-flight FOR_ITER item and the walk takes the legacy drop-on-abort. The heap writes the aborted body already committed stay (`seen.append`, `Obj.hits`) while the frame's locals are withdrawn, so the iteration's `total +=` is lost — a half-applied iteration, not the whole-item drop that path assumes.

## The fix

Take the guard in a look-inside `w_list_append` wrapper and move the body to a lock-free `w_list_append_inner`, then resolve the fold's jitcode by the inner name. This is the shape the dict side of the same port already uses (`w_dict_store_checked` / `w_dict_store_checked_inner`), so the locking the port introduced is fully preserved.

## Verification

- `getframe_force_cancel_journal`: `20000 20000 989403`, matching `PYRE_NO_JIT=1`.
- `foriter57/run_matrix.sh`: `MATRIX OK` (29/29).
- `check.py`: dynasm 311/311, cranelift 311/311, wasm 308/308, 3/3 backend runs.

## Notes for review

- `w_list_getitem` / `w_list_setitem` / `w_list_len` still carry the guard **and** `dont_look_inside`, so they remain opaque to the tracer. None returns `Void`, so none can trip this correctness bug, and no `check.py` perf gate flagged them — left as-is rather than widened into this fix. The same wrapper/inner split would restore their transparency if the opacity turns out to cost.
- A JIT-compiled append does not take the lock: the fold lowers it to an inline array store. That is unchanged by this PR (there was no lock at all before the port) but it is the remaining free-threading gap on this path, and it applies to every folded operation, not just append.
- Commit 3 fixes a defect in commit 1; they can be squashed if you prefer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added substantially improved threading support, including locks, reentrant locks, thread handles, thread-local storage, joins, and current-frame inspection.
  * Added `os.register_at_fork` support and safer behavior around blocking I/O and sleep operations.
  * Added all-thread tracing and profiling controls, switch-interval APIs, and accurate finalization status reporting.
  * Added improved interpreter shutdown handling, finalizers, and SystemExit processing.
* **Bug Fixes**
  * Improved garbage collection, thread coordination, fork safety, shared caches, and concurrent access to built-in containers.
  * Improved asynchronous exception delivery and signal handling.
* **Documentation**
  * Clarified vendored test and baseline-management behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->