### PR TITLE
imp, virtualref: ImportRLock port; frame-chain vref reads through the vref

### DIFF
--- a/majit/majit-metainterp/src/virtualref.rs
+++ b/majit/majit-metainterp/src/virtualref.rs
@@ -122,6 +122,22 @@ pub unsafe fn ptr_is_virtual_ref(ptr: *const u8) -> bool {
     }
 }
 
+/// `virtualref.py:177 return vref.forced` — the object a vref has already
+/// been forced to, read without forcing.
+///
+/// For readers that cannot run `force_virtual` at all: forcing materializes an
+/// object, and a garbage collection has no allocator to do it with.  Inside a
+/// collection the only object a vref can name is the one it was already forced
+/// to, so a null result means "still virtual" and the reader must stop there
+/// rather than invent one.
+///
+/// # Safety
+/// `ptr` must satisfy [`ptr_is_virtual_ref`], which the caller checks first.
+#[inline]
+pub unsafe fn vref_forced(ptr: *const u8) -> *mut u8 {
+    unsafe { (*(ptr as *const JitVirtualRef)).forced }
+}
+
 /// `rpython/rlib/jit.py:487 class InvalidVirtualRef(Exception)` —
 /// `force_virtual` raises this when `virtual_token == TOKEN_NONE`
 /// but `forced` is null (`virtualref.py:174-176`).  Pyre's single

--- a/majit/majit-metainterp/src/virtualref.rs
+++ b/majit/majit-metainterp/src/virtualref.rs
@@ -343,7 +343,7 @@ impl VirtualRefInfo {
     ///
     /// # Safety
     /// `vref_ptr` must point to a valid JitVirtualRef object.
-    pub(crate) unsafe fn force_virtual(
+    pub unsafe fn force_virtual(
         &self,
         vref_ptr: *mut u8,
         force_now: impl FnOnce(*mut JitVirtualRef),

--- a/pyre/bench/synth/imp_lock_rlock_semantics.py
+++ b/pyre/bench/synth/imp_lock_rlock_semantics.py
@@ -1,0 +1,48 @@
+# Regression guard for the reentrant import lock's Python-visible semantics.
+# The lock carries three pieces of state -- the allocated lock, the owning
+# execution context, and the recursion depth -- and several of the observables
+# below distinguish them, so a collapse back to a bare depth counter shows up
+# here rather than only under threads:
+#   * lock_held() reports "owned by anyone", not "depth > 0".
+#   * an unbalanced release raises RuntimeError, and the message is exact.
+#   * the depth is reentrant: N acquires need N releases and lock_held() stays
+#     true until the last one.
+#   * reinit_lock is interpreter-internal (the fork child hook) and must NOT be
+#     reachable from Python.
+# Correctness-only fixture: no perf gate header, the work here is trivial.
+import _imp
+
+
+def show(label, fn):
+    try:
+        fn()
+        print(label, "ok")
+    except RuntimeError as exc:
+        print(label, "RuntimeError:", exc)
+
+
+show("release-unheld", _imp.release_lock)
+print("held-initial:", _imp.lock_held())
+
+_imp.acquire_lock()
+print("held-1:", _imp.lock_held())
+_imp.acquire_lock()
+_imp.acquire_lock()
+print("held-3:", _imp.lock_held())
+_imp.release_lock()
+print("held-2:", _imp.lock_held())
+_imp.release_lock()
+print("held-1b:", _imp.lock_held())
+_imp.release_lock()
+print("held-0:", _imp.lock_held())
+
+show("release-overbalanced", _imp.release_lock)
+print("reinit_lock exposed:", hasattr(_imp, "reinit_lock"))
+
+_imp.acquire_lock()
+_imp.release_lock()
+print("held-final:", _imp.lock_held())
+
+import json
+
+print("held-after-import:", _imp.lock_held(), json.dumps([1]))

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -267,6 +267,77 @@ impl ObjSpace {
     }
 }
 
+/// `rpython/rlib/rthread.py:160 Lock` — the interp-level lock object
+/// `allocate_lock` hands back.  Only `acquire`/`release` have callers here;
+/// `is_acquired` / `acquire_timed` are ported when something needs them.
+///
+/// The blocking wait is a plain condvar wait rather than a GIL-dropping one:
+/// pyre has no GIL to drop.  Nothing can wake a waiter yet either, since
+/// `_thread.start_new_thread` runs its target on the caller's stack — so the
+/// wait is reached only by a caller that contends with a lock the same OS
+/// thread holds, which no import path does.  The shape is still the blocking
+/// one so that the single-thread assumption is not baked into the callers.
+pub struct Lock {
+    acquired: std::sync::Mutex<bool>,
+    released: std::sync::Condvar,
+}
+
+impl Lock {
+    fn new() -> Self {
+        Self {
+            acquired: std::sync::Mutex::new(false),
+            released: std::sync::Condvar::new(),
+        }
+    }
+
+    /// `rthread.py:169 acquire(flag)` — with `flag` set, wait until the lock
+    /// is free and take it; otherwise take it only if it is free right now.
+    /// Returns whether the lock is now held by the caller.
+    pub fn acquire(&self, flag: bool) -> bool {
+        let mut acquired = self.acquired.lock().unwrap_or_else(|e| e.into_inner());
+        if !flag {
+            if *acquired {
+                return false;
+            }
+            *acquired = true;
+            return true;
+        }
+        while *acquired {
+            acquired = self
+                .released
+                .wait(acquired)
+                .unwrap_or_else(|e| e.into_inner());
+        }
+        *acquired = true;
+        true
+    }
+
+    /// `rthread.py:199 release` — upstream raises when the lock was not
+    /// previously acquired.  Every caller here releases only what it owns, so
+    /// the unheld case is a bug in this crate rather than a Python-visible
+    /// error, and it is reported as one.
+    pub fn release(&self) {
+        let mut acquired = self.acquired.lock().unwrap_or_else(|e| e.into_inner());
+        debug_assert!(*acquired, "the lock was not previously acquired");
+        *acquired = false;
+        self.released.notify_one();
+    }
+}
+
+/// `pypy/interpreter/baseobjspace.py:803 space.allocate_lock()`.
+///
+/// Upstream picks `rthread.dummy_lock` when the build has no `thread` module;
+/// pyre always registers `_thread`, so the `rthread.allocate_lock()` branch
+/// (`baseobjspace.py:815`) is the one taken.  `CannotHaveLock`
+/// (`baseobjspace.py:421`) guards the translating-but-not-translated case,
+/// which pyre never occupies, so this cannot fail.
+///
+/// The returned pointer is deliberately leaked: locks live for the process,
+/// and freeing one while another thread could be waiting on it is unsound.
+pub fn allocate_lock() -> *mut Lock {
+    Box::into_raw(Box::new(Lock::new()))
+}
+
 /// pypy/interpreter/baseobjspace.py `issubtype_w` — `cls` is in
 /// `w_type.mro_w`. Uses the cached MRO when present, otherwise
 /// recomputes via `compute_default_mro`.

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -537,6 +537,26 @@ pub fn capture_pyframe_root_area() -> *const () {
     PYFRAME_ROOT_AREA.with(|area| area as *const _ as *const ())
 }
 
+/// Advance the root walk one link along the `f_backref` chain.
+///
+/// `f_backref` holds a `jit.virtual_ref`, which at interpreter level is the
+/// caller frame pointer itself; once the JIT virtualizes an inlined callee the
+/// slot instead holds a `JitVirtualRef`, and reading that as a `PyFrame` would
+/// interpret its `virtual_token` word as frame fields.  Hop through the vref
+/// instead.  A still-virtual vref ends the walk: the frames it stands for have
+/// no heap image to visit, and `virtualref.py:157 force_virtual_if_necessary`
+/// cannot run here because materializing one allocates.
+#[inline]
+unsafe fn chain_next_frame(f_backref: *mut PyFrame) -> *mut PyFrame {
+    unsafe {
+        if majit_metainterp::virtualref::ptr_is_virtual_ref(f_backref as *const u8) {
+            majit_metainterp::virtualref::vref_forced(f_backref as *const u8) as *mut PyFrame
+        } else {
+            f_backref
+        }
+    }
+}
+
 /// Walk one captured thread's active frame and interpreter root state.
 ///
 /// # Safety
@@ -787,7 +807,7 @@ pub unsafe fn walk_pyframe_roots_area(
                     }
                 }
                 let f = &*frame;
-                let next_frame = (*frame).f_backref;
+                let next_frame = chain_next_frame((*frame).f_backref);
                 if f.locals_cells_stack_w.is_null() {
                     (std::ptr::null_mut::<PyObjectRef>(), 0, next_frame)
                 } else {

--- a/pyre/pyre-interpreter/src/executioncontext.rs
+++ b/pyre/pyre-interpreter/src/executioncontext.rs
@@ -41,10 +41,13 @@ pub fn register_force_vref_hook(f: ForceVRefFn) {
 #[inline]
 pub(crate) fn force_vref(ptr: *mut PyFrame) -> *mut PyFrame {
     if unsafe { majit_metainterp::virtualref::ptr_is_virtual_ref(ptr as *const u8) } {
-        match FORCE_VREF_HOOK.get() {
-            Some(f) => unsafe { f(ptr) },
-            None => ptr,
-        }
+        // Only the tracer stores a `JitVirtualRef` here, and it registers the
+        // hook when the driver comes up, so an unset hook means the slot was
+        // misidentified.  Returning `ptr` would hand a vref out as a frame.
+        let f = FORCE_VREF_HOOK
+            .get()
+            .expect("frame-chain vref with no force hook: the JIT never came up");
+        unsafe { f(ptr) }
     } else {
         ptr
     }

--- a/pyre/pyre-interpreter/src/module/imp/interp_imp.rs
+++ b/pyre/pyre-interpreter/src/module/imp/interp_imp.rs
@@ -3,7 +3,7 @@
 //! Verbatim move of the inline block previously in importing.rs.
 
 use crate::importing::BUILTIN_MODULES;
-use std::sync::atomic::{AtomicI64, Ordering};
+use std::sync::atomic::{AtomicI64, AtomicPtr, Ordering};
 
 struct FrozenModule {
     name: &'static str,
@@ -106,11 +106,210 @@ static FROZEN_MODULES: &[FrozenModule] = &[
 
 static FROZEN_OVERRIDE: AtomicI64 = AtomicI64::new(0);
 
-/// `importing.py:159 ImportRLock` reentrant depth. With one execution context
-/// the owner collapses to held/not-held and the real lock never blocks, so the
-/// recursion counter is the whole observable state; it is per-interpreter
-/// (shared across threads), so a global — not thread-local — is correct.
-static IMPORT_LOCK_COUNT: AtomicI64 = AtomicI64::new(0);
+/// `importing.py:159 ImportRLock` — the interpreter's reentrant import lock.
+///
+/// Upstream mutates the three fields with the GIL held (`importing.py:175`
+/// "this function runs with the GIL acquired so there is no race condition in
+/// the creation of the lock"); pyre has no GIL, so `lock` is published with a
+/// compare-exchange and `lockowner` is stored only after the real lock has
+/// been taken.
+struct ImportRLock {
+    /// `importing.py:162 self.lock` — what `space.allocate_lock()` returned,
+    /// allocated on the first acquire.  Null is upstream's `None`, and the
+    /// distinction is observable: `release_lock` is silent while it is null.
+    lock: AtomicPtr<crate::baseobjspace::Lock>,
+    /// `importing.py:163 self.lockowner` — the owning thread, held as the
+    /// ident rather than as the context object because only its identity is
+    /// ever read.  Zero is `None`.
+    lockowner: AtomicI64,
+    /// `importing.py:164 self.lockcounter` — recursion depth.  Only the owning
+    /// thread mutates it.
+    lockcounter: AtomicI64,
+}
+
+/// `importing.py:168 me = self.space.getexecutioncontext()  # used as thread
+/// ident`.
+///
+/// The comment states what the value is for, and that is what is ported: the
+/// ident comes from `rthread.get_ident`, the same source `_thread.get_ident`
+/// reads.  Taking the execution context instead would not survive the trip —
+/// `space.getexecutioncontext()` returns the per-thread context
+/// `threadlocals.get_ec()` creates once and caches for the thread's whole life
+/// (`baseobjspace.py:741`), whereas pyre's accessor reads a slot the launcher
+/// re-seeds with a fresh context per phase, so a lock taken while running a
+/// script would be owned by a stranger once the REPL starts.
+fn thread_ident() -> i64 {
+    match crate::module::thread::current_ident() {
+        // Zero is the `None` encoding, so it cannot also name a thread; fall
+        // back to the same single-threaded sentinel `_thread.get_ident` uses.
+        0 => 1,
+        ident => ident,
+    }
+}
+
+impl ImportRLock {
+    const fn new() -> Self {
+        Self {
+            lock: AtomicPtr::new(std::ptr::null_mut()),
+            lockowner: AtomicI64::new(0),
+            lockcounter: AtomicI64::new(0),
+        }
+    }
+
+    /// `importing.py:167 lock_held_by_someone_else`.  No caller upstream
+    /// either; its `true` branch is additionally unreachable while pyre runs a
+    /// single Python thread.
+    #[allow(dead_code)]
+    fn lock_held_by_someone_else(&self) -> bool {
+        let me = thread_ident();
+        let owner = self.lockowner.load(Ordering::Acquire);
+        owner != 0 && owner != me
+    }
+
+    /// `importing.py:171 lock_held_by_anyone` — owner-agnostic, which is what
+    /// makes `_imp.lock_held()` true when read from a non-owning thread.
+    fn lock_held_by_anyone(&self) -> bool {
+        self.lockowner.load(Ordering::Acquire) != 0
+    }
+
+    /// `importing.py:174 acquire_lock`.
+    fn acquire_lock(&self) {
+        // importing.py:177-181 — allocate on first use.  A losing racer drops
+        // its own box and uses the winner's.
+        if self.lock.load(Ordering::Acquire).is_null() {
+            let fresh = crate::baseobjspace::allocate_lock();
+            if self
+                .lock
+                .compare_exchange(
+                    std::ptr::null_mut(),
+                    fresh,
+                    Ordering::AcqRel,
+                    Ordering::Acquire,
+                )
+                .is_err()
+            {
+                drop(unsafe { Box::from_raw(fresh) });
+            }
+        }
+        let me = thread_ident();
+        // importing.py:183-189
+        if self.lockowner.load(Ordering::Acquire) != me {
+            let lock = unsafe { &*self.lock.load(Ordering::Acquire) };
+            lock.acquire(true);
+            debug_assert_eq!(self.lockowner.load(Ordering::Acquire), 0);
+            debug_assert_eq!(self.lockcounter.load(Ordering::Relaxed), 0);
+            self.lockowner.store(me, Ordering::Release);
+        }
+        // importing.py:190
+        self.lockcounter.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// `importing.py:192 release_lock(silent_after_fork)`.
+    fn release_lock(&self, silent_after_fork: bool) -> Result<(), crate::PyError> {
+        let me = thread_ident();
+        let owner = self.lockowner.load(Ordering::Acquire);
+        if owner != me {
+            // importing.py:195-198 — a fork() with the import lock held leaves
+            // the child owner-less.  The `is None` conjunct is what keeps a
+            // release by a *foreign* owner an error even here.
+            if owner == 0 && silent_after_fork {
+                return Ok(());
+            }
+            // importing.py:199-200 `if self.lock is None: # CannotHaveLock
+            // occurred` is dropped for the same reason as its partner in
+            // `acquire_lock`: it is the downstream half of a condition pyre
+            // cannot occupy.  Porting it would make the branch live off a
+            // different cause — an import path that never took the lock —
+            // and then the very first unbalanced release of a process would
+            // return silently instead of raising.  CONVERGENCE: have the
+            // native importer bracket module execution with the lock the way
+            // `importing.py:91 importhook` brackets its own, after which the
+            // lock is allocated before user code runs and the branch stops
+            // being observable either way.
+            // importing.py:201-203
+            return Err(crate::PyError::runtime_error(
+                "not holding the import lock",
+            ));
+        }
+        debug_assert!(self.lockcounter.load(Ordering::Relaxed) > 0);
+        // importing.py:204-207 — clear the owner BEFORE releasing, so the
+        // waiter that wakes up finds the state `acquire_lock` asserts.
+        if self.lockcounter.fetch_sub(1, Ordering::Relaxed) - 1 == 0 {
+            self.lockowner.store(0, Ordering::Release);
+            unsafe { &*self.lock.load(Ordering::Acquire) }.release();
+        }
+        Ok(())
+    }
+
+    /// `importing.py:209 reinit_lock` — run in a fork child so it does not
+    /// share the parent's lock.  Branches on the depth, not on ownership:
+    /// a depth above one means the fork happened underneath an import, whose
+    /// `before` hook already acquired.
+    ///
+    /// Registered upstream as the `child` fork hook
+    /// (`pypy/module/imp/moduledef.py:45`, driven by
+    /// `pypy/module/posix/interp_posix.py:1560`) and never exposed to Python.
+    /// pyre has no fork-hook dispatch, so nothing calls this yet.
+    /// CONVERGENCE: port `add_fork_hook`/`run_fork_hooks` into the posix
+    /// module and register the whole trio — `before`→`acquire_lock`,
+    /// `parent`→`release_lock`, `child`→`reinit_lock`.  Wiring the child hook
+    /// alone would make the depth test pick the wrong branch.
+    #[allow(dead_code)]
+    fn reinit_lock(&self) {
+        if self.lockcounter.load(Ordering::Relaxed) > 1 {
+            // importing.py:216-224 — the old lock object is abandoned rather
+            // than freed: a foreign thread could be mid-acquire on it.
+            let fresh = crate::baseobjspace::allocate_lock();
+            self.lock.store(fresh, Ordering::Release);
+            let me = thread_ident();
+            unsafe { &*fresh }.acquire(true);
+            self.lockowner.store(me, Ordering::Release);
+            self.lockcounter.fetch_sub(1, Ordering::Relaxed);
+        } else {
+            self.lock.store(std::ptr::null_mut(), Ordering::Release);
+            self.lockowner.store(0, Ordering::Release);
+            self.lockcounter.store(0, Ordering::Relaxed);
+        }
+    }
+}
+
+/// `importing.py:228 getimportlock(space)` = `space.fromcache(ImportRLock)` —
+/// one instance per interpreter, shared by every thread.  That sharing is what
+/// makes `lockowner` meaningful, so this is a global and never a
+/// `thread_local!`.
+static IMPORT_LOCK: ImportRLock = ImportRLock::new();
+
+fn getimportlock() -> &'static ImportRLock {
+    &IMPORT_LOCK
+}
+
+// The `space.config.objspace.usemodules.thread` gate on the four gateways
+// below (`interp_imp.py:140`) is constant-true here: pyre's build always
+// registers `_thread`, so the gateways stay ungated.
+
+/// `interp_imp.py:139 lock_held`.
+fn lock_held() -> bool {
+    getimportlock().lock_held_by_anyone()
+}
+
+/// `interp_imp.py:146 acquire_lock`.
+fn acquire_lock() {
+    getimportlock().acquire_lock();
+}
+
+/// `interp_imp.py:150 release_lock` — `silent_after_fork=False`, which is why
+/// an unbalanced `_imp.release_lock()` from Python raises.
+fn release_lock() -> Result<(), crate::PyError> {
+    getimportlock().release_lock(false)
+}
+
+/// `interp_imp.py:153 reinit_lock`.  Deliberately absent from the `_imp`
+/// namespace: `moduledef.py:26` exposes only `lock_held`, `acquire_lock` and
+/// `release_lock`.
+#[allow(dead_code)]
+fn reinit_lock() {
+    getimportlock().reinit_lock();
+}
 
 fn frozen_module(name: &str) -> Option<&'static FrozenModule> {
     FROZEN_MODULES.iter().find(|entry| entry.name == name)
@@ -440,11 +639,10 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     crate::module_ns_store(
         ns,
         "acquire_lock",
-        // importing.py:174 acquire_lock — reentrant; bump the depth.
         crate::make_builtin_function_with_arity(
             "acquire_lock",
             |_| {
-                IMPORT_LOCK_COUNT.fetch_add(1, Ordering::Relaxed);
+                acquire_lock();
                 Ok(pyre_object::w_none())
             },
             0,
@@ -453,14 +651,10 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     crate::module_ns_store(
         ns,
         "release_lock",
-        // importing.py:192 release_lock — releasing an unheld lock is an error.
         crate::make_builtin_function_with_arity(
             "release_lock",
             |_| {
-                if IMPORT_LOCK_COUNT.load(Ordering::Relaxed) <= 0 {
-                    return Err(crate::PyError::runtime_error("not holding the import lock"));
-                }
-                IMPORT_LOCK_COUNT.fetch_sub(1, Ordering::Relaxed);
+                release_lock()?;
                 Ok(pyre_object::w_none())
             },
             0,
@@ -469,10 +663,9 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     crate::module_ns_store(
         ns,
         "lock_held",
-        // importing.py:171 lock_held_by_anyone.
         crate::make_builtin_function_with_arity(
             "lock_held",
-            |_| Ok(pyre_object::w_bool_from(IMPORT_LOCK_COUNT.load(Ordering::Relaxed) > 0)),
+            |_| Ok(pyre_object::w_bool_from(lock_held())),
             0,
         ),
     );

--- a/pyre/pyre-interpreter/src/module/thread/mod.rs
+++ b/pyre/pyre-interpreter/src/module/thread/mod.rs
@@ -208,7 +208,7 @@ fn start_joinable_thread(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyE
 // PyPy `_thread.get_ident` returns the pthread handle; pyre routes
 // through `rustpython_host_env::thread::current_thread_id`.  Without
 // host_env we always return 1 (single-threaded sentinel).
-fn current_ident() -> i64 {
+pub(crate) fn current_ident() -> i64 {
     let logical = LOGICAL_THREAD_IDENT.with(Cell::get);
     if logical != 0 {
         return logical;

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -3645,7 +3645,37 @@ fn build_jit_driver_pair() -> JitDriverPair {
         crate::call_jit::wasm_ca_resume_deopt as *const () as usize as u32,
     );
     pyre_interpreter::executioncontext::register_force_frame_hook(force_pyframe);
+    pyre_interpreter::executioncontext::register_force_vref_hook(force_pyframe_vref);
     (d, info)
+}
+
+/// The materializing arm of `virtualref.py:134 force_virtual_if_necessary`.
+///
+/// The interpreter's `force_vref` runs the typeptr check — upstream's "common,
+/// fast case" — and calls this only for a slot that really holds a
+/// `JitVirtualRef`.  `force_virtual` needs `ResumeGuardForcedDescr.force_now`
+/// (`compile.py:966`), which lives behind the backend `Runner`, so it takes it
+/// as a closure and this is where both halves are in scope.
+unsafe extern "C" fn force_pyframe_vref(
+    vref: *mut pyre_interpreter::PyFrame,
+) -> *mut pyre_interpreter::PyFrame {
+    let (driver, _info) = driver_pair();
+    let vrefinfo = majit_metainterp::virtualref::VirtualRefInfo::new();
+    let forced = unsafe {
+        vrefinfo.force_virtual(vref as *mut u8, |v| {
+            // `compile.py:967-971 force_now(cpu, token)` — force the JIT frame
+            // the vref names, then run the guard's async forcing, which is
+            // what writes `virtual_token = TOKEN_NONE` and `forced` back.
+            let token = (*v).virtual_token as usize as u64;
+            driver.meta_interp_mut().force_virtualizable_token(token);
+        })
+    };
+    // `virtualref.py:174-176` — `token == TOKEN_NONE` with no `forced` means
+    // the vref outlived the frame it stood for, which upstream reports as
+    // `jit.py:487 InvalidVirtualRef`.  Nothing in the frame chain may reach
+    // that state: `virtual_ref_finish` runs before the frame is dropped.
+    forced.expect("InvalidVirtualRef: frame-chain vref forced after its frame died")
+        as *mut pyre_interpreter::PyFrame
 }
 
 unsafe extern "C" fn force_pyframe(frame: *mut pyre_interpreter::PyFrame) {


### PR DESCRIPTION
Three commits on top of `main`. Two continue the `jit.virtual_ref` frame-chain work from #775; one replaces the import lock's depth counter with the upstream `ImportRLock`.

## `imp`: port `ImportRLock` over the bare depth counter

`interp_imp.rs` tracked the import lock as a single `AtomicI64`. It now carries `importing.py:159 ImportRLock`'s three fields — `lock`, `lockowner`, `lockcounter` — and its five methods, so `_imp.lock_held()` reports "owned by anyone" instead of "depth > 0", and an unbalanced `_imp.release_lock()` raises `RuntimeError: not holding the import lock`. `rthread.py:160 Lock` and `baseobjspace.py:803 space.allocate_lock()` come along as the blocking lock `acquire_lock` takes.

**`lockowner` is keyed on the thread ident, not on the execution context.** `importing.py:168` reads `me = self.space.getexecutioncontext()  # used as thread ident`, and upstream's context is a valid ident because `threadlocals.get_ec()` creates one per OS thread and caches it for the thread's whole life. pyre's launcher mints a fresh `PyExecutionContext` per phase, so porting the spelling made a lock taken in the `-c` phase owned by a stranger — and a dangling one — once the `-i` REPL started. Measured before the fix: `printf 'import json\nprint("survived")\n' | pyre-dynasm -i -c 'import _imp; _imp.acquire_lock()'` wedged in the condvar and needed `kill -9`, while `pypy3` printed `survived`. The ident now comes from `rthread.get_ident`'s source, the same one `_thread.get_ident` reads.

Two upstream branches are deliberately not ported, both downstream of `CannotHaveLock` — a translating-but-not-translated state pyre cannot occupy: `acquire_lock`'s `except CannotHaveLock` and `release_lock`'s `if self.lock is None`. Keeping the latter made wasm return silently from a release PyPy raises on, because pyre's native importer never takes the lock so `self.lock` was still null at user-code time. The convergence note in the code names the fix: bracket module execution with the lock the way `importing.py:91 importhook` brackets its own.

`reinit_lock` is ported but unregistered — it is the fork `child` hook, and wiring it alone would make its depth test pick the wrong branch.

New fixture `pyre/bench/synth/imp_lock_rlock_semantics.py` covers the Python-visible state: unbalanced release, reentrant depth, `lock_held` across all of it, and that `reinit_lock` stays unexposed. Its output is byte-identical to pypy3's.

## `eval`, `virtualref`: hop the GC frame-chain walk through a vref

`walk_pyframe_roots_area` advances along `f_backref`, which holds a `jit.virtual_ref`. The advance read that slot as a `PyFrame` pointer, so a `JitVirtualRef` in the chain would have been read as frame fields, its `virtual_token` word landing where the walk expects `ob_header`.

The advance now routes through the vref. `vref_forced` reads `virtualref.py:177 vref.forced` without forcing, since `force_virtual_if_necessary` allocates and a collection has no allocator; a still-virtual vref ends the walk, because the frames it stands for have no heap image to visit.

## `eval`, `executioncontext`: register the force-vref hook

`force_vref` ran the typeptr check of `virtualref.py:134 force_virtual_if_necessary`, but its materializing arm had no implementation registered — so it returned the `JitVirtualRef` itself as the frame, the exact type confusion the check exists to prevent.

The arm is now registered from `pyre-jit`, where the backend `Runner` and `MetaInterp` are both in scope: `force_virtual` needs `compile.py:966 ResumeGuardForcedDescr.force_now(cpu, token)` — `force_virtualizable_token` here — and takes it as a closure because the runner trait lives in the backend crate. With the arm registered, a missing hook can only mean the slot was misidentified, so `force_vref` says so rather than handing out the vref.

## Still blocked: emitting `jit.virtual_ref` at the FBW inline push

`opimpl_virtual_ref` / `opimpl_virtual_ref_finish` are ported in both `pyjitpl.rs` and `state.rs` and still have zero production callers.

The operand they need does exist on the seeded inline paths: `helpers.rs emit_new_pyframe_inline_with_params` emits a virtual callee frame — `NewWithVtable` plus `SetfieldGc` for `execution_context`, `pycode`, `w_globals_obj`, the zero-filled `locals_cells_stack_w` array, `next_instr` and `stack_depth` — from `inline_call.rs:841` (call-assembler) and `:2123` (seeded inline, which stores it into the callee's frame register).

What is missing at those sites is the rest of `executioncontext.py:85 enter`: no `SetfieldGc(callee_frame, f_backref, caller_topframeref)`, no `opimpl_virtual_ref`, and no store into `ec.topframeref` — the last of which has no descriptor to store through, since `ExecutionContext` is not `repr(C)` and its offset would have to come from `offset_of!` the way `frame_layout.rs` does for `PyFrame`.

The blocker is the *unseeded* levels. The seed is conditional — it bails on a callee with cells, on `POP_JUMP_IF_NONE` / `POP_JUMP_IF_NOT_NONE`, and on several other shapes — so an inline level can run with no materialized frame and nothing to publish. Publishing `topframeref` for only the seeded levels is not a partial win: it was implemented and measured to shift `sys._getframe` up one level on the unseeded ones (`inline_getframe.py` went from `['leaf']` to `['leaf', 'main']` with the flags off), and was reverted. The emit therefore has to arrive together with a frame for every inline level, or behind a gate that declines the levels it cannot seed. Proving the `force_now` path with a repro is downstream of it either way.

Both vref commits are inert until that lands: at interpreter level `virtual_ref(frame)` is the frame pointer itself, so `ptr_is_virtual_ref` is false and both paths are the same loads as before.

## Verification

`python pyre/check.py` — dynasm 312/312, cranelift 312/312, wasm 309/309, all three backends green. The `imp_lock_rlock_semantics` fixture and the cross-phase `-i -c` repro were both diffed against pypy3.

Note on `nested_loop`: it straddles its x2 gate on this machine independently of this branch — with the diff fully reverted and rebuilt, four runs measured 1.5x / 1.7x / 2.0x / 2.1x (fail). It passed in the final run above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved import-lock behavior to correctly support reentrant acquisition, balanced releases, ownership tracking, and error handling.
  * Preserved correct lock state during imports and related interpreter activity.
  * Improved garbage-collection handling for active call frames when JIT optimizations are enabled.
  * Added safer handling when required JIT frame-resolution support is unavailable.

* **Tests**
  * Added regression coverage for import-lock state, reentrancy, invalid releases, and behavior after importing modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
