### PR TITLE
docs: remove dead CLAUDE.md references in skills and AGENTS.md

### DIFF
--- a/.claude/skills/merge/SKILL.md
+++ b/.claude/skills/merge/SKILL.md
@@ -108,7 +108,7 @@ Never "commit and fix later". `<MERGE>` must stay green at every commit.
 
 ## Step 5 — Commit on success
 
-When `pyre/check.py` is green, commit with a factual message (CLAUDE.md convention — no speculation about goals, no `Co-Authored-By`, English only):
+When `pyre/check.py` is green, commit with a factual message (no speculation about goals, no `Co-Authored-By`, English only):
 
 ```bash
 git add <files>
@@ -132,7 +132,7 @@ When the user decides to stop (either the diff is empty or the remaining work is
 - Report what landed on `<MERGE>` (`git log upstream/main..<MERGE> --oneline`).
 - Report what is deferred, per-file, with the reason it could not land.
 - Confirm the original `WORK` branch is untouched (`git log <WORK>` unchanged vs. when we started).
-- Do **not** push, merge, or open a PR unless the user explicitly asks — CLAUDE.md rule.
+- Do **not** push, merge, or open a PR unless the user explicitly asks.
 
 ## Hard rules (recap)
 

--- a/.claude/skills/merge/SKILL.md
+++ b/.claude/skills/merge/SKILL.md
@@ -108,7 +108,7 @@ Never "commit and fix later". `<MERGE>` must stay green at every commit.
 
 ## Step 5 — Commit on success
 
-When `pyre/check.py` is green, commit with a factual message (no speculation about goals, no `Co-Authored-By`, English only):
+When `pyre/check.py` is green, commit with a factual message (no speculation about goals, no `Co-Authored-By` but use `Assisted-By`, English only):
 
 ```bash
 git add <files>

--- a/.claude/skills/parity/SKILL.md
+++ b/.claude/skills/parity/SKILL.md
@@ -230,6 +230,6 @@ Keep the tone direct and the citations concrete. No vague "I'll make sure this m
 
 ## Interaction with other mindsets
 
-- The user's `CLAUDE.md` already carries "majit ↔ RPython Parity Rules" (section 1–5). This skill is the stronger form of that: under `/parity`, there is no wiggle room for "Rust language adaptations" except where the RPython line is explicitly cited. If CLAUDE.md and this skill conflict, this skill wins for the duration of the `/parity` invocation.
+- This skill is the strict enforced form of the "First principles" above: under `/parity`, there is no wiggle room for "Rust language adaptations" except where the RPython line is explicitly cited.
 - `/commit` (the commit skill) is compatible — parity auditing should happen before committing, not after.
 - If the user invokes `/parity` inside a larger plan document (e.g. `jtransform_optimize_goto_if_not_port.md`), the plan's existing PRE-EXISTING-ADAPTATION annotations are respected; the audit focuses only on changes introduced since the plan was written.

--- a/.claude/skills/rebase/SKILL.md
+++ b/.claude/skills/rebase/SKILL.md
@@ -34,7 +34,7 @@ Goal: enter the rebase with a clean, conceptually-coherent commit history. Messy
    git rev-parse --verify upstream/main
    ```
 
-2. **Unstaged / untracked changes** — if there is real uncommitted work, commit it. Use the `commit` convention from CLAUDE.md: factual English message, no `Co-Authored-By`, no speculation about goals. If the changes are clearly WIP/scratch that should not land, confirm with the user before discarding or stashing.
+2. **Unstaged / untracked changes** — if there is real uncommitted work, commit it. Use this convention: factual English message, no `Co-Authored-By`, no speculation about goals. If the changes are clearly WIP/scratch that should not land, confirm with the user before discarding or stashing.
 
 3. **Squash WIP noise** — if `git log upstream/main..HEAD` shows obvious fixups, revert-my-last-change, "typo", "trying X" commits, consolidate them with `git rebase -i upstream/main` (**before** the real rebase) or `git reset --soft` + fresh commits. Rationale: during the real rebase, each small WIP commit will re-apply and may re-introduce conflicts that were already resolved one commit later. Squashing these out collapses the noise.
 
@@ -128,7 +128,7 @@ After the rebase completes:
    - For each non-trivial resolution: file:line on our side, file:line upstream consulted, one-sentence justification.
    - Whether `pyre/check.py` is green.
 
-Do **not** push, merge, or force-push unless the user explicitly asks. CLAUDE.md rule.
+Do **not** push, merge, or force-push unless the user explicitly asks.
 
 ## Hard rules (recap)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,7 +136,7 @@ collection looks more convenient.
    direct port is acceptable only when (a) every alternative has been
    tried, (b) the deviation is the smallest possible, and (c) a comment
    cites the RPython original it stands in for. See the
-   "majit ↔ RPython Parity Rules" section in `~/.claude/CLAUDE.md`.
+   "RPython Parity Rules" section below.
 
 4. **Removing an RPython method to "simplify" things is not allowed.**
    If `optimizer.py` defines `ensure_ptr_info_arg0`, the Rust port has


### PR DESCRIPTION
<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary
- `AGENTS.md` and `.claude/skills/{parity,merge,rebase}/SKILL.md` all cite a `CLAUDE.md` file (project-local or `~/.claude/CLAUDE.md`) that doesn't exist in the repo.
- All cited content was already duplicated inline at each citation site, so no rules are lost: `AGENTS.md` now points at the equivalent in-file "RPython Parity Rules" section instead of the missing file;  `.claude/skills/{parity,merge,rebase}/SKILL.md` just drop the bare "CLAUDE.md rule/convention" attribution tag.

## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 will be run automatically when this is ready for review.
The prompt is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
-->

- [ ] I fully resolved all reasonable code review comments from Codex and CodeRabbit.
  - [ ] Auto-review section 1 is clear. This check is mandatory.
  - [ ] Auto-review section 2 is clear. If this is not checked, please add a comment explaining why.
- [ ] I did not use AI to write the code of this patch.
  - If this is not checked, commits must include `Assisted-by`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified merge workflow instructions, including stricter commit message requirements (factual-only, English, and no attribution lines).
  * Refined rebase guidance around committing work and the reminder about pushing/merging actions after rebase.
  * Tightened parity workflow notes to emphasize its strict “first principles” enforcement.
  * Updated the rules citation to reference the project’s local “RPython Parity Rules” section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->