### PR TITLE
baseobjspace, imp, eval: Codex parity review follow-ups for #785

### DIFF
--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -312,13 +312,15 @@ impl Lock {
         true
     }
 
-    /// `rthread.py:199 release` — upstream raises when the lock was not
-    /// previously acquired.  Every caller here releases only what it owns, so
-    /// the unheld case is a bug in this crate rather than a Python-visible
-    /// error, and it is reported as one.
+    /// `rthread.py:198 release` — `if c_thread_releaselock(...) != 0: raise
+    /// error(...)`.  The check is live in every build upstream, so it is an
+    /// `assert!` and not a `debug_assert!`: releasing a lock nobody holds must
+    /// not fall through to the notify.  Every caller here releases only what it
+    /// owns, which makes this an invariant of this crate rather than a
+    /// Python-visible error.
     pub fn release(&self) {
         let mut acquired = self.acquired.lock().unwrap_or_else(|e| e.into_inner());
-        debug_assert!(*acquired, "the lock was not previously acquired");
+        assert!(*acquired, "the lock was not previously acquired");
         *acquired = false;
         self.released.notify_one();
     }

--- a/pyre/pyre-interpreter/src/module/imp/interp_imp.rs
+++ b/pyre/pyre-interpreter/src/module/imp/interp_imp.rs
@@ -277,6 +277,12 @@ impl ImportRLock {
 /// one instance per interpreter, shared by every thread.  That sharing is what
 /// makes `lockowner` meaningful, so this is a global and never a
 /// `thread_local!`.
+///
+/// A static rather than a real per-space cache entry because
+/// `ObjSpace::fromcache` re-runs `build` instead of memoizing it, and pyre runs
+/// one space per process — the same reason `sys.modules` and the builtin-module
+/// table are globals.  A second space in one process would need all of them
+/// moved together, not this one alone.
 static IMPORT_LOCK: ImportRLock = ImportRLock::new();
 
 fn getimportlock() -> &'static ImportRLock {

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -3672,8 +3672,14 @@ unsafe extern "C" fn force_pyframe_vref(
     };
     // `virtualref.py:174-176` — `token == TOKEN_NONE` with no `forced` means
     // the vref outlived the frame it stood for, which upstream reports as
-    // `jit.py:487 InvalidVirtualRef`.  Nothing in the frame chain may reach
-    // that state: `virtual_ref_finish` runs before the frame is dropped.
+    // `jit.py:487 InvalidVirtualRef`.  Upstream can raise it because the helper
+    // returns into RPython; this hook is a `extern "C"` pointer read from the
+    // frame chain with no exception channel, so the unreachable state is
+    // asserted instead.  Unreachable holds because a vref reaches the chain
+    // only between `virtual_ref` and `virtual_ref_finish`, and `finish` writes
+    // `forced` before the frame is dropped.  Whoever teaches the tracer to
+    // emit `VIRTUAL_REF` owns re-checking that: a trace aborted between the
+    // two leaves a vref naming a JIT frame that is already gone.
     forced.expect("InvalidVirtualRef: frame-chain vref forced after its frame died")
         as *mut pyre_interpreter::PyFrame
 }


### PR DESCRIPTION
Follow-ups to the Codex parity review on #785, which merged before they landed.

## Fixed

`baseobjspace::Lock::release` guarded its precondition with `debug_assert!`. The workspace has no `debug-assertions` in `[profile.release]`, so the check was absent from the shipped binaries — and the code then cleared the flag and notified anyway, making a release of an unheld lock silently succeed. `rthread.py:198` raises `error("the lock was not previously acquired")` in every build, so this is an `assert!`.

## Documented rather than ported

Two divergences stand, and the comments now say why:

- `force_pyframe_vref` cannot raise `InvalidVirtualRef` (`virtualref.py:174`) the way upstream's helper does, because it is an `extern "C"` pointer the interpreter calls while reading the frame chain, with no exception channel; upstream can raise only because its helper returns into RPython. The state is also unreachable — a vref reaches the chain only between `virtual_ref` and `virtual_ref_finish`, and `finish` writes `forced` before the frame is dropped. The comment names the condition that retires that argument: whoever teaches the tracer to emit `VIRTUAL_REF` must re-check it, since a trace aborted between the two leaves a vref naming a JIT frame that is already gone.

- `getimportlock`'s process-wide static, against `space.fromcache(ImportRLock)`. `ObjSpace::fromcache` re-runs `build` instead of memoizing, and pyre runs one space per process — the same reason `sys.modules` and the builtin-module table are globals. A second space in one process needs all of them moved together, not this one alone.

## Reported as a false positive, not fixed

The review also read `pyre/bench/synth/imp_lock_rlock_semantics.py` as encoding non-PyPy behaviour, because `importing.py:199 release_lock` returns silently while `self.lock is None`. Measured, PyPy raises:

```
$ pypy3 pyre/bench/synth/imp_lock_rlock_semantics.py | head -1
release-unheld RuntimeError: not holding the import lock
```

The guard cannot fire at user-code time, because startup imports have already allocated the lock:

```
$ pypy3 -c 'import _imp
try:
    _imp.release_lock(); print("silent -> self.lock is None")
except RuntimeError as e:
    print("raises -> already allocated:", e)'
raises -> already allocated: not holding the import lock
```

`check.py` is itself the oracle for synth fixtures — it diffs each one against pypy's own output — so the fixture passing states that pyre and PyPy agree, not that pyre matches a hand-written expectation.

The reason `release_lock`'s `if self.lock is None` branch is dropped rather than ported is a different, real divergence, and it is in the code comment: pyre's native importer never takes the import lock, so on wasm `self.lock` really was still null at user-code time and the ported branch returned silently where PyPy raises. Convergence is to bracket module execution with the lock the way `importing.py:91 importhook` brackets its own.

## Verification

Local, against the pypy3 oracle, all byte-identical: the `imp_lock_rlock_semantics` fixture (which exercises the asserted path four times), the cross-phase `-i -c` import-lock repro, and `getframe_inlined_callee_own_frame` / `getframe_residual_callee_own_frame` / `getframe_stored_fback_walk`.

The full three-backend `check.py` was ALL PASSED (dynasm 312/312, cranelift 312/312, wasm 309/309) on the tree this differs from by one `assert!` and two comments; it could not be re-run here because three sibling worktrees were building concurrently and SIGTERM'd the harness's `cargo build` twice, and perf gates are not meaningful at that load. CI runs it on quiet runners.

`main` has moved three commits ahead of this branch's base (#781, #786, #777).