### PR TITLE
interp: port the StdObjSpace finditem dict shortcut; jit: trace_limit in the single walker

### DIFF
--- a/pyre/check.py
+++ b/pyre/check.py
@@ -436,13 +436,20 @@ def _jit_stats_diff(saved, current, limit=6):
     return ", ".join(shown)
 
 
-# Sign-stable jit-stats counters: a nonzero value always means something went
-# wrong (a trace aborted, or an internal compile bug fell back to the
-# interpreter), never a tuning choice. They read 0 in every healthy baseline on
-# every platform, so a rise above baseline is a regression the regression floor
-# gates on unconditionally. The count-valued fields (guard_failures,
-# loops_compiled, bridges_compiled) are deliberately excluded: their absolute
-# value is not yet confirmed stable across runners, so they stay informational.
+# Direction-stable jit-stats counters: the regression floor gates on these two
+# because a rise is a defect whatever the absolute value happens to be.
+# `internal_compile_panics` counts an internal compile bug falling back to the
+# interpreter, so 0 is its only healthy value. `loops_aborted` is not absolute:
+# an abort is either a give-up the tracer is supposed to perform (an over-long
+# trace hits `blackhole_if_trace_too_long`, pyjitpl.py:2865) or a walker
+# coverage gap that is tracked elsewhere — the synth fixtures below carry
+# `LoopBearingCalleeInlineUnsupported`, the walker's open gap on inlining a
+# loop-bearing callee. Either way the baseline pins the count those known
+# declines produce today and the gate fires on a rise, which means a loop that
+# used to compile has stopped compiling. The count-valued fields
+# (guard_failures, loops_compiled, bridges_compiled) are deliberately excluded:
+# they move in both directions under ordinary tuning and their absolute value is
+# not yet confirmed stable across runners, so they stay informational.
 JITSTATS_BADNESS_FIELDS = ("loops_aborted", "internal_compile_panics")
 
 
@@ -783,10 +790,10 @@ class Check:
         # Regression floor — enforced on EVERY run, so a structural JIT
         # regression reddens the default `pyre/check.py` (locally, and in the
         # bare CI invocation) the instant it lands, with no --snapshot-diff
-        # needed. Only the sign-stable badness counters gate here, so this stays
+        # needed. Only the direction-stable counters gate here, so this stays
         # flake-free where the full-exact jit-stats diff (below, opt-in) cannot:
-        # healthy baselines carry 0 for both on every platform, so a trace that
-        # starts aborting or panicking is a real defect regardless of runner.
+        # the baseline pins whatever aborts a bench legitimately records, and a
+        # rise above it is a real defect regardless of runner.
         # This catches the inline-abort class (e.g. an inlined-callee LOAD_GLOBAL
         # fold that stops resolving: loops_aborted 0 -> 5). Record mode is
         # writing a fresh baseline, so it is exempt.

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -3106,12 +3106,50 @@ pub(crate) fn zip_next_method(args: &[PyObjectRef]) -> PyResult {
     next(zip_receiver(args, "__next__")?)
 }
 
+/// `objspace.py:752-753` / `:763-764` — the receiver gate both
+/// `StdObjSpace.finditem_str` and `StdObjSpace.finditem` apply before
+/// taking their shortcut: `isinstance(w_obj, W_DictMultiObject) and not
+/// w_obj.user_overridden_class`.  `is_dict` is the `isinstance` half (it
+/// answers the user-visible question, so a module dict passes); the exact
+/// class comparison is the `user_overridden_class` half, keeping a dict
+/// subclass — whose `__getitem__` or `__missing__` may override the probe
+/// — on the generic path.
+fn is_shortcut_dict(obj: PyObjectRef) -> bool {
+    unsafe {
+        if !pyre_object::is_dict(obj) {
+            return false;
+        }
+        let Some(w_type) = crate::typedef::r#type(obj) else {
+            return false;
+        };
+        let dict_type = crate::typedef::gettypeobject(&pyre_object::DICT_TYPE);
+        !dict_type.is_null() && std::ptr::eq(w_type.as_ptr(), dict_type)
+    }
+}
+
 /// `pypy/interpreter/baseobjspace.py:870 finditem` — return the value
 /// for `key` in `obj`, or `None` if absent.  PyPy catches only the
 /// `KeyError` arm and re-raises any other `OperationError`; in Rust
 /// the re-raise surfaces as `Result::Err`, the absent case as
 /// `Ok(None)`, and a hit as `Ok(Some(value))`.
+///
+/// `objspace.py:757-766 StdObjSpace.finditem` overrides that generic form
+/// with a "performance shortcut to avoid creating the
+/// OperationError(KeyError)": a plain dict answers the probe through its
+/// own strategy slot, so a miss allocates nothing.  The generic body below
+/// pays a full exception object — key `repr` included — for every miss,
+/// which is the common outcome on attribute-lookup paths.  A raising
+/// `__hash__`/`__eq__` reaches the shortcut as `DictKeyError`; recover the
+/// concrete exception through the same `take_pending_dict_key_error` the
+/// dict arm of `getitem_slot` uses, so the 3.14 dict-key hash-error wrapping
+/// is identical on both routes.  The shortcut is that arm minus its
+/// `dict_missing_or_key_error` miss branch, which only a dict subclass — one
+/// the receiver gate already excluded — can reach through `__missing__`.
 pub fn finditem(obj: PyObjectRef, index: PyObjectRef) -> Result<Option<PyObjectRef>, PyError> {
+    if is_shortcut_dict(obj) {
+        return unsafe { pyre_object::dictmultiobject::w_dict_lookup_checked(obj, index) }
+            .map_err(|_| take_pending_dict_key_error(index));
+    }
     match getitem(obj, index) {
         Ok(value) if value.is_null() => Ok(None),
         Ok(value) => Ok(Some(value)),
@@ -3600,7 +3638,18 @@ unsafe fn setitem_instance(obj: PyObjectRef, index: PyObjectRef, value: PyObject
 }
 
 /// String-keyed `finditem` shorthand: `space.finditem_str(w_obj, key)`.
+///
+/// `objspace.py:745-755 StdObjSpace.finditem_str` shortcuts a plain dict to
+/// `w_obj.getitem_str(key)` — "performance shortcut to avoid creating the
+/// OperationError(KeyError) and allocating W_BytesObject".  Both halves
+/// apply here: `w_dict_getitem_str` probes the strategy with the borrowed
+/// `&str`, so a miss allocates neither the wrapped key nor the exception.
+/// Every other receiver falls through to `baseobjspace.py:868-871`, which
+/// wraps the key and defers to the generic `finditem`.
 pub fn finditem_str(obj: PyObjectRef, key: &str) -> Result<Option<PyObjectRef>, PyError> {
+    if is_shortcut_dict(obj) {
+        return Ok(unsafe { pyre_object::dictmultiobject::w_dict_getitem_str(obj, key) });
+    }
     finditem(obj, w_str_new(key))
 }
 

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -1753,6 +1753,11 @@ pub enum DispatchError {
     /// the callee return correctly.  The loop-rejoin case (same-frame handler)
     /// still routes.
     ExcEdgeCrossFrameReturnUnsupported { pc: usize },
+    /// The recorded trace passed `warmstate.trace_limit` (`rlib/jit.py:592`
+    /// default 6000). RPython checks this after every traced step —
+    /// `pyjitpl.py:2865 _interpret` calls `blackhole_if_trace_too_long()` right
+    /// after `run_one_step()` — and raises `SwitchToBlackhole(ABORT_TOO_LONG)`.
+    TraceTooLong { pc: usize, ops: usize },
 }
 
 impl DispatchError {
@@ -1821,6 +1826,7 @@ impl DispatchError {
                 "InplaceContainerMutationUnsupported"
             }
             Self::ExcEdgeCrossFrameReturnUnsupported { .. } => "ExcEdgeCrossFrameReturnUnsupported",
+            Self::TraceTooLong { .. } => "TraceTooLong",
         }
     }
 
@@ -2018,6 +2024,30 @@ pub fn walk<Sym: WalkSym>(
         let opcode_position = pc;
         let (outcome, next_pc) = step(code, pc, ctx)?;
         pc = next_pc;
+        // pyjitpl.py:2865 `_interpret`: `blackhole_if_trace_too_long()` runs
+        // after every `run_one_step()`. This loop is that loop's counterpart —
+        // `step` is `run_one_step` — and the check came with the per-opcode
+        // tracing loop it replaced (`pyre-jit/src/eval.rs` still runs it on
+        // that path), so nothing bounded a walk that kept recording without
+        // reaching a close. `TraceCtx::is_too_long` is the `history.length() >
+        // warmrunnerstate.trace_limit` test and `num_ops` is a `Vec::len`, so
+        // this is one comparison per step.
+        //
+        // The walker layer holds `&mut TraceCtx` and cannot reach
+        // `MetaInterp::blackhole_if_trace_too_long` for the full bookkeeping;
+        // `note_root_trace_too_long` is the warm-state half the retired loop
+        // called (`trace_next_iteration` + `mark_force_finish_tracing`, so the
+        // next attempt cuts the trace instead of growing it again). The
+        // `find_biggest_function` → `disable_noninlinable_function` half
+        // (pyjitpl.py:2793) still only runs on the per-opcode path.
+        if ctx.trace_ctx.is_too_long() {
+            let ops = ctx.trace_ctx.num_recorded_ops();
+            crate::state::note_root_trace_too_long(ctx.trace_ctx.root_green_key());
+            return Err(DispatchError::TraceTooLong {
+                pc: opcode_position,
+                ops,
+            });
+        }
         match outcome {
             DispatchOutcome::Continue => {}
             DispatchOutcome::Terminate

--- a/pyre/pyre-wasm-runner/src/main.rs
+++ b/pyre/pyre-wasm-runner/src/main.rs
@@ -106,8 +106,50 @@ struct Host {
     guest_profiler: Option<wasmtime::GuestProfiler>,
 }
 
+/// Report `PYRE_*` / `MAJIT_*` settings the guest cannot see.
+///
+/// The module is built for `wasm32-unknown-unknown`, whose `std::env` is
+/// permanently empty: every `std::env::var_os` reached from inside the guest
+/// returns `None` regardless of this process's environment. That covers every
+/// JIT knob and probe that lives in the guest crates — `PYRE_NO_JIT`,
+/// `PYRE_GC_INTERP`, `MAJIT_STRICT`, `MAJIT_LOG`, the `PYRE_FBW_*` /
+/// `PYRE_P2_DIAG` / `PYRE_JD1*` diagnostics — so setting one here changes
+/// nothing at all. Silently ignoring them is the trap: an A/B run through such
+/// a knob measures the same build twice and reads as a result. Name them
+/// instead, once, on stderr (`check.py` shows a run's stderr only when it
+/// fails, so this is invisible to a green suite and present in every failure
+/// dump and interactive run).
+///
+/// Exempt: the names this runner interprets host-side (`PYRE_WASM_*`,
+/// `PYRE_STDLIB`, `MAJIT_STATS`) and `check.py`'s own `PYRE_CHECK_*`
+/// interpreter paths. A knob that later becomes host-interpreted must be added
+/// here; the prefix match needs no upkeep for new guest-side knobs.
+fn warn_inert_guest_env() {
+    const HOST_HANDLED: &[&str] = &["PYRE_STDLIB", "MAJIT_STATS"];
+    let mut inert: Vec<String> = std::env::vars_os()
+        .filter_map(|(name, _)| name.into_string().ok())
+        .filter(|name| name.starts_with("PYRE_") || name.starts_with("MAJIT_"))
+        .filter(|name| {
+            !name.starts_with("PYRE_WASM_")
+                && !name.starts_with("PYRE_CHECK_")
+                && !HOST_HANDLED.contains(&name.as_str())
+        })
+        .collect();
+    if inert.is_empty() {
+        return;
+    }
+    inert.sort();
+    inert.dedup();
+    eprintln!(
+        "[pyre-wasm-runner] ignoring {}: the wasm guest has no environment, so \
+         guest-side knobs and probes do nothing here",
+        inert.join(", ")
+    );
+}
+
 fn main() {
     let t0_main = std::time::Instant::now();
+    warn_inert_guest_env();
     let startup_trace = std::env::var_os("PYRE_WASM_STARTUP_TRACE").is_some();
     let mut module_path: Option<PathBuf> = None;
     let mut script: Option<PathBuf> = None;


### PR DESCRIPTION
Four commits, each independent. The headline is the last one.

## `interp: port the StdObjSpace finditem/finditem_str dict shortcut`

`finditem` implemented only `baseobjspace.py:873`'s generic form — call `getitem`, catch `KeyError`, return `None`. `objspace.py:745-766` overrides both it and `finditem_str` for a plain dict with what upstream calls a *"performance shortcut to avoid creating the OperationError(KeyError) and allocating W_BytesObject"*. That override was missing here, so every dict miss built a full exception object — key `repr` included — and threw it away.

Attribute lookup takes that route on paths where a miss is the ordinary result. A guest profile of `while i < N: import math` attributes **54.9% of all samples** to `PyError::key_error_with_key`, reached three ways, all from `gcd_import_fast`:

```
getattr_str_impl -> module_getattr_hook_or_err -> getitem   (2330 samples)
getattr_str_impl -> object_getattr_miss        -> getitem   (1194)
getattr_str_impl                               -> getitem   (1117)
```

The receiver gate is upstream's `isinstance(w_obj, W_DictMultiObject) and not w_obj.user_overridden_class`: `is_dict` answers the user-visible isinstance question, so a module dict passes, and the exact-class comparison keeps a dict subclass — whose `__getitem__` or `__missing__` may override the probe — on the generic path. `finditem`'s shortcut is the dict arm of `getitem_slot` minus its `dict_missing_or_key_error` branch, which only an excluded subclass can reach, and it recovers a raising `__hash__`/`__eq__` through the same `take_pending_dict_key_error`.

| bench | dynasm | wasm |
| --- | --- | --- |
| `synth/import_from_hot` | 1.49s → 0.77s | 2.50s → 0.55s |
| `synth/import_name` | 0.28s → 0.22s | 2.10s → 0.44s |

wasm's share is larger because the discarded exception is an allocation, and allocation carries wasm's constant factor. `import_name`'s wasm/dynasm ratio goes 7.5x → 2.0x; `import_from_hot` now runs faster on wasm than on dynasm. The three benches that looked 1.24-1.31x slower in a cross-run log comparison were a load artifact — an interleaved A/B against a baseline binary (min of 7) puts them at 0.92x / 0.96x / 0.97x.

## `jit: check trace_limit in the single-walker loop`

Not an unimplemented feature — a **single-walker migration regression**. RPython calls `blackhole_if_trace_too_long()` after every `run_one_step()` (`pyjitpl.py:2865`, `trace_limit = 6000` at `rlib/jit.py:592`). pyre had the machinery and called it from the legacy per-opcode loop; `note_root_trace_too_long` still had a caller in the retired loop at `8dfa542939b`, and it did not come along to `jitcode_dispatch::walk`.

`walk()` now checks `is_too_long()` after `step` and returns a new `DispatchError::TraceTooLong` (the existing `_ => TraceAction::Abort` fall-through picks it up). Effect on `synth/gc_iterator_source_drop` (wasm): **11.80s → 4.89s**, `compile_ms` 65.0 → 9.4.

⚠️ Remaining gap, called out in the commit: the walker layer holds `&mut TraceCtx` and cannot reach `MetaInterp::blackhole_if_trace_too_long`, so the `find_biggest_function` → `disable_noninlinable_function` half still runs only on the per-opcode path.

No native bench's `loops_aborted` moved — nothing else in the suite records a >6000-op trace, so it is a pure safety net there.

## `check: describe the jit-stats regression floor by direction, not by zero`

`JITSTATS_BADNESS_FIELDS`'s comment claimed both counters "read 0 in every healthy baseline on every platform". True of `internal_compile_panics`, not of `loops_aborted`: the nine committed baselines are the only `.jitstats` fixtures in the tree and all carry 1-2 aborts. Each is `LoopBearingCalleeInlineUnsupported` — the walker's open gap on inlining a callee whose body is not a straight-line leaf — and the counts line up 1:1 with the census under `PYRE_FBW_CENSUS=1`. The gate is a ratchet on the committed value, so a nonzero baseline is what it was built for; the comments now say so.

## `wasm-runner: report PYRE_*/MAJIT_* settings the guest cannot read`

The wasm guest is built for `wasm32-unknown-unknown`, whose `std::env` is permanently empty, so `PYRE_NO_JIT`, `PYRE_GC_INTERP`, `MAJIT_STRICT`, `PYRE_FBW_*` and friends do nothing under the wasm runner — any wasm A/B through a guest-side env var is a void experiment. The runner now names them on stderr at startup. Prefix matching with a small host-handled exemption list means a new guest knob needs no maintenance here.

Side finding, left alone as out of scope: `check.py`'s wasm leg does not run in strict mode, because `MAJIT_STRICT` is one of the inert variables — an internal compile panic falls back to the interpreter silently rather than crashing.

## Verification

`python3 pyre/check.py` on this branch's tip: **dynasm 313/313, cranelift 313/313, wasm 310/310**, no jit-stats regression. Re-run after rebasing onto `7b70e1ebff9`, which pulled in #785 (ImportRLock, touching the import path this PR speeds up) and #777 (fbw tracer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved dictionary lookups, including string-key access, for faster execution in common cases.
* **Bug Fixes**
  * Trace execution now detects when a trace becomes too long and reports the condition with relevant location and operation details.
* **User Experience**
  * The WebAssembly runner now warns when configured environment variables cannot be observed by the guest runtime.
* **Documentation**
  * Clarified explanations for JIT statistics gating and regression thresholds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->