### PR TITLE
jit: application traceback nodes as trace IR; three exception-path defects

### DIFF
--- a/pyre/bench/synth/exception_catching_frame_tb_node.py
+++ b/pyre/bench/synth/exception_catching_frame_tb_node.py
@@ -1,0 +1,45 @@
+# The frame holding the `try` contributes its own traceback node, including
+# when its `except` is reached from inside its own compiled trace.
+#
+# When an inlined callee raises, the caller-side handler scan routes the raise
+# straight to the caller's `except` and the walk keeps going, so the handler
+# ends up inside the trace. Compiled, the trace then catches the exception
+# itself: the frame never surfaces an error to the interpreter, so unless the
+# trace records the node it is the recording pass alone that ever applies it
+# and the chain comes out missing its outermost frame.
+#
+# The dict lookup in the loop is load-bearing: it keeps the module-level loop
+# from completing a trace of its own, so `shape` is compiled as a func-entry
+# trace instead of being inlined into the caller.
+N = 4000
+
+
+def frame_names(traceback):
+    names = []
+    while traceback is not None:
+        names.append(traceback.tb_frame.f_code.co_name)
+        traceback = traceback.tb_next
+    return tuple(names)
+
+
+def raise_leaf(i):
+    raise ValueError(i)
+
+
+def raise_mid(i):
+    raise_leaf(i)
+
+
+def shape(i):
+    try:
+        raise_mid(i)
+    except ValueError as e:
+        return frame_names(e.__traceback__)
+
+
+seen = {}
+shapes = set()
+for i in range(N):
+    shapes.add(shape(i))
+    seen.get(0, 0)
+print(sorted(shapes))

--- a/pyre/bench/synth/exception_inline_callee_tb_frames.py
+++ b/pyre/bench/synth/exception_inline_callee_tb_frames.py
@@ -1,0 +1,85 @@
+# An exception raised in an inlined callee and caught two or three frames up
+# must still attach a traceback node for every frame it passed through: one at
+# the raise instruction and one per callee->caller propagation.
+#
+# The callee frames are the exposed ones.  A trace's own frame is a real
+# PyFrame, so the `exit_frame_with_exception` it finishes with surfaces as an
+# error there and `handle_operation_error` attaches that node.  An inlined
+# callee is popped symbolically by the walk and never becomes a frame, so
+# unless the trace records the node itself the chain comes out one (or, for the
+# three-deep shape, two) frames short once the loop runs compiled -- while the
+# pre-compile iterations stay correct, which is why only the per-iteration
+# shape set catches it.
+#
+# Shapes: explicit `raise` two frames down, a builtin ZeroDivisionError two
+# frames down, and an explicit `raise` three frames down.
+N = 4000
+
+
+def frame_names(traceback):
+    names = []
+    while traceback is not None:
+        names.append(traceback.tb_frame.f_code.co_name)
+        traceback = traceback.tb_next
+    return tuple(names)
+
+
+def raise_leaf(i):
+    raise ValueError(i)
+
+
+def raise_mid(i):
+    raise_leaf(i)
+
+
+def catch_two_frames(i):
+    try:
+        raise_mid(i)
+    except ValueError as e:
+        return frame_names(e.__traceback__)
+
+
+def divide_leaf(i):
+    return i // 0
+
+
+def divide_mid(i):
+    return divide_leaf(i)
+
+
+def catch_builtin_two_frames(i):
+    try:
+        divide_mid(i)
+    except ZeroDivisionError as e:
+        return frame_names(e.__traceback__)
+
+
+def deep_leaf(i):
+    raise TypeError(i)
+
+
+def deep_mid(i):
+    deep_leaf(i)
+
+
+def deep_top(i):
+    deep_mid(i)
+
+
+def catch_three_frames(i):
+    try:
+        deep_top(i)
+    except TypeError as e:
+        return frame_names(e.__traceback__)
+
+
+def survey(label, fn):
+    shapes = set()
+    for i in range(N):
+        shapes.add(fn(i))
+    print(label, sorted(shapes))
+
+
+survey("two_frames   =", catch_two_frames)
+survey("builtin_two  =", catch_builtin_two_frames)
+survey("three_frames =", catch_three_frames)

--- a/pyre/bench/synth/exception_residual_raise_caught_in_frame.py
+++ b/pyre/bench/synth/exception_residual_raise_caught_in_frame.py
@@ -1,0 +1,56 @@
+# A frame that catches an exception a residual call raised contributes its own
+# traceback node, including once its `except` is reached from inside its own
+# compiled trace.
+#
+# walk()'s SubRaise arm scans the raising frame for a `catch_exception/L` and
+# jumps straight into the handler, so the handler ends up inside the trace and
+# the frame never surfaces an error the interpreter could record a node from.
+# Unless the trace carries the record itself, the chain comes out one frame
+# short once the loop is compiled while the pre-compile iterations stay correct.
+#
+# The raise sites are builtin containers, so each one is a residual call rather
+# than an inlined callee.
+N = 4000
+
+
+def names(traceback):
+    out = []
+    while traceback is not None:
+        out.append(traceback.tb_frame.f_code.co_name)
+        traceback = traceback.tb_next
+    return tuple(out)
+
+
+def missing_key(d, i):
+    try:
+        return d[i]
+    except KeyError as e:
+        return names(e.__traceback__)
+
+
+def bad_index(seq, i):
+    try:
+        return seq[i]
+    except IndexError as e:
+        return names(e.__traceback__)
+
+
+def bad_convert(s):
+    try:
+        return int(s)
+    except ValueError as e:
+        return names(e.__traceback__)
+
+
+d = {}
+seq = []
+key_shapes = set()
+index_shapes = set()
+convert_shapes = set()
+for i in range(N):
+    key_shapes.add(missing_key(d, i))
+    index_shapes.add(bad_index(seq, i))
+    convert_shapes.add(bad_convert("x"))
+print("key    ", sorted(key_shapes))
+print("index  ", sorted(index_shapes))
+print("convert", sorted(convert_shapes))

--- a/pyre/bench/synth/exception_traceback_lineno_chain.py
+++ b/pyre/bench/synth/exception_traceback_lineno_chain.py
@@ -1,0 +1,64 @@
+# Every traceback node keeps the line its frame was executing, including for
+# a frame the JIT compiled and exited with an uncaught exception.
+#
+# `handle_exception` stamps the node with `frame.last_instr` and compiled code
+# never runs the interpreter's per-opcode store, so an intermediate frame that
+# only forwards the call reports its `def` line unless the trace publishes the
+# raise coordinate before finishing. The pre-compile iterations report the call
+# line, so the shape has to be surveyed over the whole run rather than sampled
+# once: a single miscompiled frame turns one (name, lineno) tuple into two.
+N = 4000
+
+
+def chain(traceback):
+    out = []
+    while traceback is not None:
+        out.append((traceback.tb_frame.f_code.co_name, traceback.tb_lineno))
+        traceback = traceback.tb_next
+    return tuple(out)
+
+
+def a_inner(i):
+    raise ValueError(i)
+
+
+def a_outer(i):
+    a_inner(i)
+
+
+def shape_a(i):
+    try:
+        a_outer(i)
+    except ValueError as e:
+        return chain(e.__traceback__)
+
+
+def c3(i):
+    raise TypeError(i)
+
+
+def c2(i):
+    c3(i)
+
+
+def c1(i):
+    c2(i)
+
+
+def shape_c(i):
+    try:
+        c1(i)
+    except TypeError as e:
+        return chain(e.__traceback__)
+
+
+def survey(name, fn):
+    seen = {}
+    for i in range(N):
+        t = fn(i)
+        seen[t] = seen.get(t, 0) + 1
+    print(name, sorted(seen))
+
+
+survey("two_frame  ", shape_a)
+survey("three_frame", shape_c)

--- a/pyre/bench/synth/exception_try_call_inlined_callee_raise.py
+++ b/pyre/bench/synth/exception_try_call_inlined_callee_raise.py
@@ -1,0 +1,42 @@
+# A conditional raise two call levels below a `try` must reach the enclosing
+# `except`, including once the frame holding the `try` runs as its own compiled
+# trace.
+#
+# The exposed shape is a CALL that sits inside a try-block and whose callee is
+# inlined.  A guard inside the inlined callee has no frame of its own to resume
+# into, so it collapses onto the caller's CALL boundary -- the CALL's pre-call
+# `-live-`, which precedes that CALL's own `catch_exception`.  A post-call
+# GUARD_NO_EXCEPTION failing there hands the blackhole a pending exception at a
+# coordinate from which the handler search cannot reach the catch, and the
+# raise leaves the frame past its matching `except`.
+#
+# The dict lookup in the loop is load-bearing: it keeps the module-level loop
+# from completing a trace of its own, so `shape` is compiled as a func-entry
+# trace instead of being inlined into the caller.  The raise must also be
+# conditional, so the exception edge stays off the recorded path.
+N = 6000
+
+
+def leaf(i):
+    if i % 7 == 0:
+        raise ValueError(i)
+    return i
+
+
+def mid(i):
+    return leaf(i)
+
+
+def shape(i):
+    try:
+        return mid(i)
+    except ValueError:
+        return -1
+
+
+seen = {}
+caught = 0
+for i in range(N):
+    caught += shape(i) == -1
+    seen.get(0, 0)
+print("caught =", caught)

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
@@ -1285,6 +1285,60 @@ pub(crate) fn fbw_terminate_void_with_finish<Sym: WalkSym>(
     Ok(())
 }
 
+/// Publish the raising instruction's Python coordinate into the standard
+/// virtualizable's `last_instr` slot before the top-level frame exits with
+/// an exception.
+///
+/// `handle_exception` (pyre-interpreter) stamps this frame's traceback node
+/// with `frame.last_instr` and keys the exception-table lookup on the same
+/// field, so the value has to be the coordinate the raise actually happened
+/// at.  Compiled code never runs the per-opcode interpreter store: a frame
+/// entered through the function-entry portal still carries the `-1`
+/// initialization sentinel, which `offset2lineno` answers with the code
+/// object's first line — the `def` line — and a loop-entry frame carries the
+/// loop header.  In both shapes the node comes out stamped with a line the
+/// frame was not executing.
+///
+/// Upstream never faces this: `handle_operation_error` runs INSIDE the traced
+/// portal, so the node is recorded from the vable's own `last_instr` box
+/// (`pyopcode.py:147-148`), which every opcode writes.  pyre records the
+/// top-level frame's node from the interpreter instead — the exception
+/// surfaces there as `exit_frame_with_exception` — so the field it reads has
+/// to be published before the trace finishes.
+///
+/// The store is the static-field shape `gen_store_back_in_vable` emits for
+/// this slot, so it reaches the frame on a compiled run; the shadow mirror
+/// keeps the walker's own virtualizable view in step with it.
+pub(crate) fn fbw_publish_raise_last_instr<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    opcode_position: usize,
+) {
+    let jitcode_index = ctx.session.borrow().recording_jitcode_index;
+    let Some(py_pc) =
+        crate::state::python_pc_for_jitcode_pc_public(jitcode_index, opcode_position as i32)
+    else {
+        return;
+    };
+    let Some(vbox) = ctx.trace_ctx.standard_virtualizable_box() else {
+        return;
+    };
+    let Some(info) = ctx.trace_ctx.virtualizable_info().cloned() else {
+        return;
+    };
+    let Some(field_index) = info.static_field_index_by_name("last_instr") else {
+        return;
+    };
+    let value = ctx.trace_ctx.const_int(i64::from(py_pc));
+    ctx.trace_ctx
+        .vable_setfield_descr(vbox, value, info.static_field_descr(field_index));
+    crate::trace_opcode::mirror_vable_static_to_boxes(
+        ctx.trace_ctx,
+        "last_instr",
+        value,
+        Value::Int(i64::from(py_pc)),
+    );
+}
+
 /// Exception variant of [`fbw_terminate_with_finish`] for the top-level
 /// uncaught raise (`compile_exit_frame_with_exception`, pyjitpl.py).
 /// Stashes the exception box (`exc`, already a `Type::Ref`) as an

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -2237,11 +2237,28 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
         // committed side effect on deopt.
         //
         // Best effort: `compute_inline_caller_frame` returns `Unavailable` for a caller
-        // shape it cannot build yet (a CALL inside a try-block, or no result on
-        // the operand stack at the return point).  Fall back to the single-frame
-        // collapse there (do NOT decline the inline — that shape is served
-        // correctly today), so this never removes a working inline.
-        compute_inline_caller_frame(ctx, op.pc).ok()
+        // shape it cannot build yet (no result on the operand stack at the
+        // return point, missing liveness / resume tables).  Fall back to the
+        // single-frame collapse there (do NOT decline the inline — that shape is
+        // served correctly today), so this never removes a working inline.
+        //
+        // A `TryBlockCatchMarker` decline is different: the CALL is covered by
+        // the caller's exception table.  The collapse resumes at the CALL's
+        // pre-call `-live-`, which precedes the CALL's own `catch_exception`,
+        // so an in-callee `GUARD_NO_EXCEPTION` failing there hands the
+        // blackhole a pending exception at a coordinate from which neither the
+        // forward check nor the bounded backward startpoint scan
+        // (`handle_exception_in_frame`) can reach that catch — the raise exits
+        // the caller frame past its matching handler.  Decline the inline so
+        // the call stays residual, where the post-call catch resume
+        // (`GuardCaptureScope::residual_call_catch_resume`) routes the raise.
+        match compute_inline_caller_frame(ctx, op.pc) {
+            Ok(pf) => Some(pf),
+            Err(InlineCallerFrameDecline::TryBlockCatchMarker) => {
+                return Err(DispatchError::callee_inline_unsupported(op.pc));
+            }
+            Err(InlineCallerFrameDecline::Unavailable) => None,
+        }
     } else {
         // Single-frame collapse (resume at the CALL boundary, re-execute the
         // whole call on deopt): a nested strict callee

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -2734,8 +2734,13 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
         }
         DispatchOutcome::SubRaise { exc, exc_concrete } => {
             if let Some(target) = try_catch_exception_at(code, op.next_pc) {
-                record_inline_application_traceback(ctx, exc, exc_concrete, op.pc, true, false);
-                record_top_level_application_traceback(ctx, exc, exc_concrete, op.pc, true, false);
+                // The handler this routes to is part of the trace, so once the
+                // trace runs compiled it catches the exception itself and this
+                // frame never surfaces an error the interpreter's
+                // `handle_exception` could record a node from.  Emit the node
+                // at runtime as well as applying it for the recording pass.
+                record_inline_application_traceback(ctx, exc, exc_concrete, op.pc, true, true);
+                record_top_level_application_traceback(ctx, exc, exc_concrete, op.pc, true, true);
                 ctx.last_exc_value = Some(exc);
                 ctx.last_exc_value_concrete = exc_concrete;
                 Ok(Some((DispatchOutcome::Continue, target)))
@@ -3497,8 +3502,13 @@ pub(crate) fn dispatch_inline_call_dr_kind<Sym: WalkSym>(
         }
         DispatchOutcome::SubRaise { exc, exc_concrete } => {
             if let Some(target) = try_catch_exception_at(code, op.next_pc) {
-                record_inline_application_traceback(ctx, exc, exc_concrete, op.pc, true, false);
-                record_top_level_application_traceback(ctx, exc, exc_concrete, op.pc, true, false);
+                // The handler this routes to is part of the trace, so once the
+                // trace runs compiled it catches the exception itself and this
+                // frame never surfaces an error the interpreter's
+                // `handle_exception` could record a node from.  Emit the node
+                // at runtime as well as applying it for the recording pass.
+                record_inline_application_traceback(ctx, exc, exc_concrete, op.pc, true, true);
+                record_top_level_application_traceback(ctx, exc, exc_concrete, op.pc, true, true);
                 ctx.last_exc_value = Some(exc);
                 // Thread the callee's concrete
                 // exception across the frame boundary.  Without this a
@@ -3641,8 +3651,13 @@ pub(crate) fn dispatch_inline_call_dir_kind<Sym: WalkSym>(
         }
         DispatchOutcome::SubRaise { exc, exc_concrete } => {
             if let Some(target) = try_catch_exception_at(code, op.next_pc) {
-                record_inline_application_traceback(ctx, exc, exc_concrete, op.pc, true, false);
-                record_top_level_application_traceback(ctx, exc, exc_concrete, op.pc, true, false);
+                // The handler this routes to is part of the trace, so once the
+                // trace runs compiled it catches the exception itself and this
+                // frame never surfaces an error the interpreter's
+                // `handle_exception` could record a node from.  Emit the node
+                // at runtime as well as applying it for the recording pass.
+                record_inline_application_traceback(ctx, exc, exc_concrete, op.pc, true, true);
+                record_top_level_application_traceback(ctx, exc, exc_concrete, op.pc, true, true);
                 ctx.last_exc_value = Some(exc);
                 // Thread the callee's concrete
                 // exception across the frame boundary.  Without this a
@@ -3797,8 +3812,13 @@ pub(crate) fn dispatch_inline_call_dirf_kind<Sym: WalkSym>(
         }
         DispatchOutcome::SubRaise { exc, exc_concrete } => {
             if let Some(target) = try_catch_exception_at(code, op.next_pc) {
-                record_inline_application_traceback(ctx, exc, exc_concrete, op.pc, true, false);
-                record_top_level_application_traceback(ctx, exc, exc_concrete, op.pc, true, false);
+                // The handler this routes to is part of the trace, so once the
+                // trace runs compiled it catches the exception itself and this
+                // frame never surfaces an error the interpreter's
+                // `handle_exception` could record a node from.  Emit the node
+                // at runtime as well as applying it for the recording pass.
+                record_inline_application_traceback(ctx, exc, exc_concrete, op.pc, true, true);
+                record_top_level_application_traceback(ctx, exc, exc_concrete, op.pc, true, true);
                 ctx.last_exc_value = Some(exc);
                 // Thread the callee's concrete
                 // exception across the frame boundary.  Without this a

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -2739,8 +2739,24 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
                 // frame never surfaces an error the interpreter's
                 // `handle_exception` could record a node from.  Emit the node
                 // at runtime as well as applying it for the recording pass.
-                record_inline_application_traceback(ctx, exc, exc_concrete, op.pc, true, true);
-                record_top_level_application_traceback(ctx, exc, exc_concrete, op.pc, true, true);
+                let emit_runtime =
+                    !record_prepend_application_traceback(ctx, exc, exc_concrete, op.pc);
+                record_inline_application_traceback(
+                    ctx,
+                    exc,
+                    exc_concrete,
+                    op.pc,
+                    true,
+                    emit_runtime,
+                );
+                record_top_level_application_traceback(
+                    ctx,
+                    exc,
+                    exc_concrete,
+                    op.pc,
+                    true,
+                    emit_runtime,
+                );
                 ctx.last_exc_value = Some(exc);
                 ctx.last_exc_value_concrete = exc_concrete;
                 Ok(Some((DispatchOutcome::Continue, target)))
@@ -3507,8 +3523,24 @@ pub(crate) fn dispatch_inline_call_dr_kind<Sym: WalkSym>(
                 // frame never surfaces an error the interpreter's
                 // `handle_exception` could record a node from.  Emit the node
                 // at runtime as well as applying it for the recording pass.
-                record_inline_application_traceback(ctx, exc, exc_concrete, op.pc, true, true);
-                record_top_level_application_traceback(ctx, exc, exc_concrete, op.pc, true, true);
+                let emit_runtime =
+                    !record_prepend_application_traceback(ctx, exc, exc_concrete, op.pc);
+                record_inline_application_traceback(
+                    ctx,
+                    exc,
+                    exc_concrete,
+                    op.pc,
+                    true,
+                    emit_runtime,
+                );
+                record_top_level_application_traceback(
+                    ctx,
+                    exc,
+                    exc_concrete,
+                    op.pc,
+                    true,
+                    emit_runtime,
+                );
                 ctx.last_exc_value = Some(exc);
                 // Thread the callee's concrete
                 // exception across the frame boundary.  Without this a
@@ -3656,8 +3688,24 @@ pub(crate) fn dispatch_inline_call_dir_kind<Sym: WalkSym>(
                 // frame never surfaces an error the interpreter's
                 // `handle_exception` could record a node from.  Emit the node
                 // at runtime as well as applying it for the recording pass.
-                record_inline_application_traceback(ctx, exc, exc_concrete, op.pc, true, true);
-                record_top_level_application_traceback(ctx, exc, exc_concrete, op.pc, true, true);
+                let emit_runtime =
+                    !record_prepend_application_traceback(ctx, exc, exc_concrete, op.pc);
+                record_inline_application_traceback(
+                    ctx,
+                    exc,
+                    exc_concrete,
+                    op.pc,
+                    true,
+                    emit_runtime,
+                );
+                record_top_level_application_traceback(
+                    ctx,
+                    exc,
+                    exc_concrete,
+                    op.pc,
+                    true,
+                    emit_runtime,
+                );
                 ctx.last_exc_value = Some(exc);
                 // Thread the callee's concrete
                 // exception across the frame boundary.  Without this a
@@ -3817,8 +3865,24 @@ pub(crate) fn dispatch_inline_call_dirf_kind<Sym: WalkSym>(
                 // frame never surfaces an error the interpreter's
                 // `handle_exception` could record a node from.  Emit the node
                 // at runtime as well as applying it for the recording pass.
-                record_inline_application_traceback(ctx, exc, exc_concrete, op.pc, true, true);
-                record_top_level_application_traceback(ctx, exc, exc_concrete, op.pc, true, true);
+                let emit_runtime =
+                    !record_prepend_application_traceback(ctx, exc, exc_concrete, op.pc);
+                record_inline_application_traceback(
+                    ctx,
+                    exc,
+                    exc_concrete,
+                    op.pc,
+                    true,
+                    emit_runtime,
+                );
+                record_top_level_application_traceback(
+                    ctx,
+                    exc,
+                    exc_concrete,
+                    op.pc,
+                    true,
+                    emit_runtime,
+                );
                 ctx.last_exc_value = Some(exc);
                 // Thread the callee's concrete
                 // exception across the frame boundary.  Without this a

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -629,19 +629,31 @@ fn recording_instruction_is_bare_reraise<Sym: WalkSym>(
     crate::state::jitcode_pc_is_bare_reraise(jitcode_index, opcode_position as i32)
 }
 
-fn record_fresh_application_traceback<Sym: WalkSym>(
+/// The frame identity, code object and instruction coordinate one
+/// `PyTraceback` node needs, resolved from the walk's current frame.
+struct TracebackNodeSite {
+    /// `PyTraceback.frame`.  `OpRef::NONE` when the walk has no materialized
+    /// frame for this level — a branchless leaf inlined without one leaves
+    /// the color unseeded.  Recording NONE as a `SetfieldGc` operand would
+    /// put a bogus box in the trace, so every caller has to resolve it.
+    frame: OpRef,
+    w_code: usize,
+    last_instruction: i32,
+    lineno: i64,
+}
+
+/// Resolve the `PyTraceback` fields of the frame the walk is currently in.
+///
+/// `None` means no node can be built here: `w_code` is missing, is the
+/// `GcRef(usize::MAX)` sentinel a non-standard virtualizable sub-walk
+/// carries, is not a code object, or is `hidden_applevel`
+/// (`pytraceback.py record_application_traceback`'s first line — such a
+/// frame contributes no node at all).  The null / sentinel tests run before
+/// `is_code`, whose `py_type_check` would dereference the raw sentinel.
+fn traceback_node_site<Sym: WalkSym>(
     ctx: &mut WalkContext<'_, '_, Sym>,
-    exc: OpRef,
-    exc_concrete: ConcreteValue,
     opcode_position: usize,
-) {
-    let ConcreteValue::Ref(exc_ptr) = exc_concrete else {
-        return;
-    };
-    if exc_ptr.is_null() || unsafe { !pyre_object::is_exception(exc_ptr) } {
-        return;
-    }
-    let kind = unsafe { pyre_object::interp_exceptions::w_exception_get_kind(exc_ptr) };
+) -> Option<TracebackNodeSite> {
     let (jitcode_index, w_code) = if ctx.is_top_level {
         let session = ctx.session.borrow();
         let frame = session.recording_frame_ptr as *const pyre_interpreter::PyFrame;
@@ -655,28 +667,46 @@ fn record_fresh_application_traceback<Sym: WalkSym>(
         ctx.inline_callee_consts
             .map_or((-1, 0), |consts| (consts.jitcode_index, consts.w_code))
     };
-    let Some(jitcode) = crate::state::pyjitcode_for_jitcode_index(jitcode_index) else {
-        return;
-    };
-    let Some(frame) = ctx
-        .registers_r
-        .get(jitcode.metadata.portal_frame_reg as usize)
-        .copied()
-    else {
-        return;
-    };
-    let Some(last_instruction) =
-        crate::state::python_pc_for_jitcode_pc_public(jitcode_index, opcode_position as i32)
-    else {
-        return;
-    };
-    let Some(raw_code) = crate::state::raw_code_for_jitcode_index(jitcode_index) else {
-        return;
-    };
+    if w_code == 0 || w_code == usize::MAX {
+        return None;
+    }
+    if !unsafe { pyre_interpreter::pycode::is_code(w_code as pyre_object::PyObjectRef) } {
+        return None;
+    }
+    if unsafe {
+        pyre_interpreter::pycode::w_code_hidden_applevel(w_code as pyre_object::PyObjectRef)
+    } {
+        return None;
+    }
+    let jitcode = crate::state::pyjitcode_for_jitcode_index(jitcode_index)?;
+    let last_instruction =
+        crate::state::python_pc_for_jitcode_pc_public(jitcode_index, opcode_position as i32)?;
+    let raw_code = crate::state::raw_code_for_jitcode_index(jitcode_index)?;
     let lineno =
         unsafe { pyre_interpreter::pyframe::offset2lineno(&*raw_code, last_instruction as isize) }
             as i64;
+    let frame = ctx
+        .registers_r
+        .get(jitcode.metadata.portal_frame_reg as usize)
+        .copied()
+        .unwrap_or(OpRef::NONE);
+    Some(TracebackNodeSite {
+        frame,
+        w_code,
+        last_instruction,
+        lineno,
+    })
+}
 
+/// Emit the `NewWithVtable` + field stores that build one `PyTraceback`
+/// node, and stamp it as `exc`'s traceback.  `w_next` is the node's tail.
+fn emit_traceback_node<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    exc: OpRef,
+    kind: pyre_object::interp_exceptions::ExcKind,
+    site: &TracebackNodeSite,
+    w_next: OpRef,
+) {
     let traceback = ctx.trace_ctx.record_op_with_descr(
         OpCode::NewWithVtable,
         &[],
@@ -691,11 +721,11 @@ fn record_fresh_application_traceback<Sym: WalkSym>(
                 ) as i64),
             0,
         ),
-        (frame, 1),
-        (ctx.trace_ctx.const_int(i64::from(last_instruction)), 2),
-        (ctx.trace_ctx.const_ref(0), 3),
-        (ctx.trace_ctx.const_int(lineno), 4),
-        (ctx.trace_ctx.const_ref(w_code as i64), 5),
+        (site.frame, 1),
+        (ctx.trace_ctx.const_int(i64::from(site.last_instruction)), 2),
+        (w_next, 3),
+        (ctx.trace_ctx.const_int(site.lineno), 4),
+        (ctx.trace_ctx.const_ref(site.w_code as i64), 5),
     ];
     for (value, index) in fields {
         let descr = crate::descr::pytraceback_field_descr(index);
@@ -713,6 +743,102 @@ fn record_fresh_application_traceback<Sym: WalkSym>(
     );
     ctx.trace_ctx
         .heapcache_setfield_cached(exc, traceback_descr.index(), traceback);
+}
+
+/// IR-virtual PREPEND of one `PyTraceback` node — the general-case sibling
+/// of [`record_fresh_application_traceback`].
+///
+/// `pytraceback.py record_application_traceback`:
+///
+/// ```text
+///     tb = operror.get_traceback()
+///     tb = PyTraceback(space, frame, last_instruction, tb)
+///     operror.set_traceback(tb)
+/// ```
+///
+/// The fresh variant hard-codes `w_next = NULL`, sound only for an exception
+/// the walk just built.  Here `get_traceback()` is emitted as a real
+/// `GETFIELD_GC_R` on the per-kind `w_traceback` descr and threaded into
+/// `w_next`, so the node prepends instead of truncating the chain a callee
+/// already contributed to.
+///
+/// Every op is optimizer-visible, so escape analysis deletes the node when
+/// the exception never escapes.  The opaque
+/// `record_{,inline_,top_level_}application_traceback` hooks cannot be:
+/// they are `CanRaise` `call_void_typed_with_effect`s that force all lazy
+/// sets and materialize the exception, and the top-level one additionally
+/// passes the virtualizable frame box, forcing the vable.
+///
+/// Returns `false` when nothing was emitted; the caller then keeps the
+/// opaque hook.
+fn record_prepend_application_traceback<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    exc: OpRef,
+    exc_concrete: ConcreteValue,
+    opcode_position: usize,
+) -> bool {
+    if exc.is_none() || exc.is_constant() {
+        // A `Const` exception box freezes the RECORDING iteration's address
+        // (`walker_record_guard_exception` pins every raise after the first
+        // one in a walk), so reading and writing `w_traceback` through it
+        // would chain onto a stale object on every later iteration.  The
+        // opaque hook takes the live exception as an argument instead.
+        return false;
+    }
+    let ConcreteValue::Ref(exc_ptr) = exc_concrete else {
+        return false;
+    };
+    if exc_ptr.is_null() || unsafe { !pyre_object::is_exception(exc_ptr) } {
+        return false;
+    }
+    let Some(site) = traceback_node_site(ctx, opcode_position) else {
+        return false;
+    };
+    if site.frame.is_none() {
+        // No materialized frame for this level.  The opaque inline hook
+        // fabricates one from the promoted callee metadata
+        // (`record_inline_traceback_for_recording`), so `tb_frame` keeps
+        // answering a real frame there; a null here would lose it.
+        return false;
+    }
+    let kind = unsafe { pyre_object::interp_exceptions::w_exception_get_kind(exc_ptr) };
+    // `tb = operror.get_traceback()`.  MUST precede the node's own store, or
+    // the heapcache answers with the node being built and `w_next` self-links.
+    let traceback_descr = crate::descr::w_exception_traceback_descr(kind);
+    let w_next = crate::state::opimpl_getfield_gc_r(ctx.trace_ctx, exc, traceback_descr);
+    emit_traceback_node(ctx, exc, kind, &site, w_next);
+    true
+}
+
+/// IR-virtual traceback record for an exception the walk itself built: the
+/// node starts a FRESH chain, so `w_next` is NULL rather than the
+/// exception's current traceback.  Sound only where the caller has proven
+/// the exception carries no prior node (`fbw_built_exc_take`); the general
+/// case is [`record_prepend_application_traceback`].
+fn record_fresh_application_traceback<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    exc: OpRef,
+    exc_concrete: ConcreteValue,
+    opcode_position: usize,
+) {
+    let ConcreteValue::Ref(exc_ptr) = exc_concrete else {
+        return;
+    };
+    if exc_ptr.is_null() || unsafe { !pyre_object::is_exception(exc_ptr) } {
+        return;
+    }
+    let Some(mut site) = traceback_node_site(ctx, opcode_position) else {
+        return;
+    };
+    if site.frame.is_none() {
+        // No hook fallback on this route — the exception is one this walk
+        // built, so a frameless node still beats dropping it.  `tb_frame`
+        // answers None and the GC custom trace skips the null edge.
+        site.frame = ctx.trace_ctx.const_ref(0);
+    }
+    let kind = unsafe { pyre_object::interp_exceptions::w_exception_get_kind(exc_ptr) };
+    let w_next = ctx.trace_ctx.const_ref(0);
+    emit_traceback_node(ctx, exc, kind, &site, w_next);
 }
 
 /// Compile-time-constant frame fields of an inlined callee.
@@ -2139,13 +2265,19 @@ pub fn walk<Sym: WalkSym>(
                         // carries the record itself, the callee contributes no
                         // node once the trace runs compiled and the exception
                         // reaches its handler one frame short.
+                        let emit_runtime = !record_prepend_application_traceback(
+                            ctx,
+                            exc,
+                            exc_concrete,
+                            opcode_position,
+                        );
                         record_inline_application_traceback(
                             ctx,
                             exc,
                             exc_concrete,
                             opcode_position,
                             true,
-                            true,
+                            emit_runtime,
                         );
                     }
                     return Ok((DispatchOutcome::SubRaise { exc, exc_concrete }, pc));
@@ -9106,13 +9238,18 @@ fn handle<Sym: WalkSym>(
                     if freshly_normalized {
                         record_fresh_application_traceback(ctx, exc, concrete_exc, op.pc);
                     } else {
+                        // The exception may already carry callee nodes, so
+                        // the node prepends onto its chain rather than
+                        // starting a fresh one.
+                        let emit_runtime =
+                            !record_prepend_application_traceback(ctx, exc, concrete_exc, op.pc);
                         record_inline_application_traceback(
                             ctx,
                             exc,
                             concrete_exc,
                             op.pc,
                             false,
-                            true,
+                            emit_runtime,
                         );
                         record_top_level_application_traceback(
                             ctx,
@@ -9120,7 +9257,7 @@ fn handle<Sym: WalkSym>(
                             concrete_exc,
                             op.pc,
                             false,
-                            true,
+                            emit_runtime,
                         );
                     }
                 }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -2173,32 +2173,51 @@ pub fn walk<Sym: WalkSym>(
                 // `exit_frame_with_exception`, letting the exception escape a
                 // frame that actually catches it.
                 if let Some(target) = try_catch_exception_at(code, pc) {
+                    // `op.key` carries the full `opname/argcodes` spelling;
+                    // `op.opname` is only the part before the `/`.
                     let raised_in_this_frame = decode_op_at(code, opcode_position)
-                        .is_some_and(|op| matches!(op.opname, "raise/r" | "reraise/"));
-                    if !raised_in_this_frame {
-                        // finishframe_exception propagates into this frame
-                        // before catch_exception/L enters its handler. Record
-                        // that frame-boundary step once; handler entry itself
-                        // does not add a traceback node.
-                        record_inline_application_traceback(
+                        .is_some_and(|op| matches!(op.key, "raise/r" | "reraise/"));
+                    // finishframe_exception propagates into this frame
+                    // before catch_exception/L enters its handler. Record
+                    // that frame-boundary step once; handler entry itself
+                    // does not add a traceback node.
+                    //
+                    // The node has to exist on the compiled run too: the
+                    // handler is part of the trace, so this frame never
+                    // surfaces an error the interpreter's `handle_exception`
+                    // could record from.  A raise the `raise/r` / `reraise/`
+                    // arm already routed here is the exception — that arm
+                    // emits the runtime record itself, so emitting again
+                    // would give the frame two nodes.
+                    let recording_opcode_position = ctx.session.borrow().recording_opcode_position;
+                    let node_position = if ctx.is_top_level {
+                        recording_opcode_position
+                    } else {
+                        opcode_position
+                    };
+                    let emit_runtime = !raised_in_this_frame
+                        && !record_prepend_application_traceback(
                             ctx,
                             exc,
                             exc_concrete,
-                            opcode_position,
-                            true,
-                            false,
+                            node_position,
                         );
-                        let recording_opcode_position =
-                            ctx.session.borrow().recording_opcode_position;
-                        record_top_level_application_traceback(
-                            ctx,
-                            exc,
-                            exc_concrete,
-                            recording_opcode_position,
-                            true,
-                            false,
-                        );
-                    }
+                    record_inline_application_traceback(
+                        ctx,
+                        exc,
+                        exc_concrete,
+                        opcode_position,
+                        true,
+                        emit_runtime,
+                    );
+                    record_top_level_application_traceback(
+                        ctx,
+                        exc,
+                        exc_concrete,
+                        recording_opcode_position,
+                        true,
+                        emit_runtime,
+                    );
                     ctx.last_exc_value = Some(exc);
                     ctx.last_exc_value_concrete = exc_concrete;
                     // pyjitpl.py:2530-2558 `finishframe_exception` only

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -2248,9 +2248,9 @@ pub fn walk<Sym: WalkSym>(
                     continue;
                 }
                 if ctx.is_top_level {
+                    let recording_opcode_position =
+                        ctx.session.borrow().recording_opcode_position;
                     if !recording_instruction_is_bare_reraise(ctx, opcode_position) {
-                        let recording_opcode_position =
-                            ctx.session.borrow().recording_opcode_position;
                         record_top_level_application_traceback(
                             ctx,
                             exc,
@@ -2260,6 +2260,11 @@ pub fn walk<Sym: WalkSym>(
                             false,
                         );
                     }
+                    // The interpreter records this frame's own traceback node
+                    // when the trace hands it the exception, and it reads the
+                    // raise coordinate out of `frame.last_instr`.  Compiled
+                    // code never wrote that field, so publish it here.
+                    fbw_publish_raise_last_instr(ctx, recording_opcode_position);
                     // RPython parity: framestack exhausted with no handler
                     // match → `compile_exit_frame_with_exception(last_exc_box)`.
                     // Stash the exception the same way the value-return arms

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -2128,13 +2128,24 @@ pub fn walk<Sym: WalkSym>(
                     return Ok((DispatchOutcome::Terminate, pc));
                 } else {
                     if !recording_instruction_is_bare_reraise(ctx, opcode_position) {
+                        // Emit the node at runtime as well as applying it for
+                        // the recording pass.  The top-level arm above can
+                        // leave this to the interpreter: its frame is a real
+                        // `PyFrame`, so the `exit_frame_with_exception` the
+                        // trace finishes with surfaces as an error on that
+                        // frame and `handle_operation_error` records the node.
+                        // An inlined callee has no frame to return to — the
+                        // walk pops it symbolically — so unless the trace
+                        // carries the record itself, the callee contributes no
+                        // node once the trace runs compiled and the exception
+                        // reaches its handler one frame short.
                         record_inline_application_traceback(
                             ctx,
                             exc,
                             exc_concrete,
                             opcode_position,
                             true,
-                            false,
+                            true,
                         );
                     }
                     return Ok((DispatchOutcome::SubRaise { exc, exc_concrete }, pc));


### PR DESCRIPTION
Seven commits on the exception traceback path. Three fixed defects, one structural change that makes the fixes affordable, and the benches that cover them.

## Defects

**An exception escaped a matching `except`.** A guard inside an inlined callee has no frame of its own to resume into, so it collapses onto the caller's CALL boundary — the CALL's pre-call `-live-`, which precedes that CALL's own `catch_exception`. A post-call `GUARD_NO_EXCEPTION` failing there hands the blackhole a pending exception at a coordinate from which neither the forward check nor the bounded backward startpoint scan can reach the catch, so the raise left the frame past its matching handler. `compute_inline_caller_frame`'s `TryBlockCatchMarker` decline now declines the inline instead of falling to the single-frame collapse; the call stays residual, where the post-call catch resume routes it.

**A frame that caught an exception dropped its own traceback node.** Four caller-side `SubRaise` arms in `inline_call.rs`, plus `walk()`'s own current-frame catch route, recorded with `execute_concrete=true, emit_runtime=false`. The handler is part of the trace, so once compiled the trace catches the exception itself and the frame never surfaces an error the interpreter's `handle_exception` could record from — the node existed only on the recording iteration. The walk-catch route additionally had a dead guard: it compared `DecodedOp::opname` against `"raise/r"` / `"reraise/"`, but `opname` holds only the part before the slash.

**`tb_lineno` reported the `def` line.** `handle_exception` stamps the node with `frame.last_instr` and keys the exception-table lookup on the same field. Compiled code never runs the per-opcode interpreter store, so a frame entered through the function-entry portal still held the `-1` initialization sentinel, which `offset2lineno` answers with the code object's first line. A callee raising through an intermediate frame reported that frame's `def` line on every compiled iteration while the pre-compile iterations reported the call line.

## The structural change

Recording a node at runtime through `record_{inline,top_level}_application_traceback` costs a `CanRaise` `call_void_typed_with_effect` the optimizer cannot remove: it forces all lazy sets, cleans the heap caches and materializes the exception, and the top-level variant passes the virtualizable frame box. Flipping the walk-catch site onto that hook cost ~20% on the exception benches.

`record_prepend_application_traceback` builds the node as trace IR instead — `NewWithVtable` + `SetfieldGc`, with `get_traceback()` emitted as a `GETFIELD_GC_R` on the per-kind `w_traceback` descr and threaded into `w_next` so the node prepends rather than truncating a callee's chain. Every op is optimizer-visible, so escape analysis deletes the node when the exception never escapes. It declines a `Const` exception box and a level with no materialized frame; the caller keeps the hook there.

The existing `record_fresh_application_traceback` now shares its node-site resolution and field emission, picking up two fixes: an in-range but unseeded frame color was recorded as an `OpRef::NONE` operand, and a `hidden_applevel` code object contributed a node where `record_application_traceback` returns without one.

## Verification

- `check.py` dynasm 318/318, cranelift 318/318
- `cargo test --workspace --features dynasm` 7077 passed
- 73/73 byte-identical to `pypy3` across a traceback/escape repro battery and the exception synth corpus
- `exception_inlined_callee_caught` 0.51s → 0.17s; the rest of the exception benches at or below their previous times

🤖 Generated with [Claude Code](https://claude.com/claude-code)