### PR TITLE
builtins, str, import: surrogate-safe entry points, builtin arity checks, settrace under the JIT

### DIFF
--- a/lib-python/3/test/test_importlib/util.py
+++ b/lib-python/3/test/test_importlib/util.py
@@ -15,9 +15,6 @@ import sys
 import tempfile
 import types
 
-import_helper.import_module("_testmultiphase")
-
-
 BUILTINS = types.SimpleNamespace()
 BUILTINS.good_name = None
 BUILTINS.bad_name = None

--- a/majit/majit-translate/src/codewriter/assembler.rs
+++ b/majit/majit-translate/src/codewriter/assembler.rs
@@ -17,6 +17,90 @@ use vecset::VecSet;
 use crate::call::CallControl;
 use crate::flatten::{FlatOp, IntOvfOp, Label, RegKind, SSARepr};
 
+fn reg_label(reg: crate::flatten::Register) -> String {
+    reg.repr()
+}
+
+fn reg_or_const_label(value: &crate::flatten::RegOrConst) -> String {
+    match value {
+        crate::flatten::RegOrConst::Reg(reg) => reg_label(*reg),
+        crate::flatten::RegOrConst::Const(c) => {
+            let kind = crate::flatten::constant_kind(c);
+            format!("Const({kind})")
+        }
+    }
+}
+
+fn flatop_debug_label(op: &FlatOp) -> String {
+    match op {
+        FlatOp::Label(label) => format!("Label({})", label.0),
+        FlatOp::Op(op) => {
+            let has_result = op.result.is_some();
+            format!("Op(has_result={has_result})")
+        }
+        FlatOp::Jump(label) => format!("Jump({})", label.0),
+        FlatOp::GotoIfNot { cond, target } => {
+            format!("GotoIfNot(cond={}, target={})", reg_label(*cond), target.0)
+        }
+        FlatOp::GotoIfNotOp {
+            opname,
+            args,
+            target,
+        } => {
+            let args = args
+                .iter()
+                .map(|reg| reg_label(*reg))
+                .collect::<Vec<_>>()
+                .join(",");
+            format!("GotoIfNotOp({opname}, args=[{args}], target={})", target.0)
+        }
+        FlatOp::Switch { value, targets } => {
+            format!(
+                "Switch(value={}, targets={})",
+                reg_label(*value),
+                targets.len()
+            )
+        }
+        FlatOp::IntBinOpJumpIfOvf {
+            op,
+            target,
+            lhs,
+            rhs,
+            dst,
+        } => format!(
+            "IntBinOpJumpIfOvf({op:?}, lhs={}, rhs={}, dst={}, target={})",
+            reg_label(*lhs),
+            reg_label(*rhs),
+            reg_label(*dst),
+            target.0
+        ),
+        FlatOp::CatchException { target } => format!("CatchException(target={})", target.0),
+        FlatOp::GotoIfExceptionMismatch { target, .. } => {
+            format!("GotoIfExceptionMismatch(target={})", target.0)
+        }
+        FlatOp::Move { dst, src } => {
+            format!(
+                "Move(dst={}, src={})",
+                reg_label(*dst),
+                reg_or_const_label(src)
+            )
+        }
+        FlatOp::Push(reg) => format!("Push({})", reg_label(*reg)),
+        FlatOp::Pop(reg) => format!("Pop({})", reg_label(*reg)),
+        FlatOp::LastException { dst } => format!("LastException(dst={})", reg_label(*dst)),
+        FlatOp::LastExcValue { dst } => format!("LastExcValue(dst={})", reg_label(*dst)),
+        FlatOp::Live { live_values } => format!("Live(count={})", live_values.len()),
+        FlatOp::Reraise => "Reraise".to_string(),
+        FlatOp::IntReturn(value) => format!("IntReturn({})", reg_or_const_label(value)),
+        FlatOp::RefReturn(value) => format!("RefReturn({})", reg_or_const_label(value)),
+        FlatOp::FloatReturn(value) => format!("FloatReturn({})", reg_or_const_label(value)),
+        FlatOp::VoidReturn => "VoidReturn".to_string(),
+        FlatOp::Raise(value) => format!("Raise({})", reg_or_const_label(value)),
+        FlatOp::EndOfBlock => "EndOfBlock".to_string(),
+        FlatOp::Unreachable => "Unreachable".to_string(),
+    }
+}
+
 /// `flatten.py:30` `Register.kind[0]` — single-char prefix for opname keys.
 fn kind_char_of(kind: RegKind) -> char {
     match kind {
@@ -397,7 +481,7 @@ impl Assembler {
         for op in &ops {
             insns_pos.push(state.code.len());
             if debug_enabled {
-                self.current_flatop_debug = Some(format!("{op:?}"));
+                self.current_flatop_debug = Some(flatop_debug_label(op));
             }
             self.write_insn(op, regallocs, &mut state, callcontrol);
         }

--- a/majit/majit-translate/src/codewriter/call.rs
+++ b/majit/majit-translate/src/codewriter/call.rs
@@ -3449,18 +3449,20 @@ impl CallControl {
 
     /// RPython `call.py:182-187 get_jitcode_calldescr` source-of-truth for
     /// `FUNC.RESULT`. Pyre derives the calldescr's result kind char from
-    /// `graph.return_type` (stamped at registration off the parsed Rust
-    /// signature, mirroring `funcptr._obj.TO.RESULT`) after projecting
-    /// Rust `Result<T, PyError>` through the success type, matching the
-    /// exception-transform shape the JIT codewriter sees. The mapping mirrors
+    /// `graph.return_type` (stamped at registration, mirroring
+    /// `funcptr._obj.TO.RESULT`). The mapping mirrors
     /// `return_type_string_to_kind` below. Returns `None` when the
     /// graph carries no return type — callers (`transform_graph_to_jitcode`)
     /// fall back to a CFG scan in that case (e.g. unit-test graphs without a
     /// parsed signature).
+    ///
+    /// The stamp is already a result-kind token, never a Rust type: it comes
+    /// from `front::mir dont_look_inside_return_token`, which is where a
+    /// scoped `Result<T, PyError>` is projected through `T` and where any
+    /// other `Result` keeps the ADT's own kind.
     pub fn declared_return_kind(&self, path: &CallPath) -> Option<char> {
         let s = self.function_graphs.get(path)?.return_type.as_ref()?.trim();
-        let effective = crate::front::typestr::transparent_result_ok_type(s).unwrap_or(s);
-        Some(return_type_string_to_kind(effective))
+        Some(return_type_string_to_kind(s))
     }
 
     /// The callee's post-`?` declared `RESULT` type (`call.py:222

--- a/majit/majit-translate/src/codewriter/call.rs
+++ b/majit/majit-translate/src/codewriter/call.rs
@@ -3450,14 +3450,17 @@ impl CallControl {
     /// RPython `call.py:182-187 get_jitcode_calldescr` source-of-truth for
     /// `FUNC.RESULT`. Pyre derives the calldescr's result kind char from
     /// `graph.return_type` (stamped at registration off the parsed Rust
-    /// signature, mirroring `funcptr._obj.TO.RESULT`). The mapping mirrors
+    /// signature, mirroring `funcptr._obj.TO.RESULT`) after projecting
+    /// Rust `Result<T, PyError>` through the success type, matching the
+    /// exception-transform shape the JIT codewriter sees. The mapping mirrors
     /// `return_type_string_to_kind` below. Returns `None` when the
     /// graph carries no return type — callers (`transform_graph_to_jitcode`)
     /// fall back to a CFG scan in that case (e.g. unit-test graphs without a
     /// parsed signature).
     pub fn declared_return_kind(&self, path: &CallPath) -> Option<char> {
         let s = self.function_graphs.get(path)?.return_type.as_ref()?.trim();
-        Some(return_type_string_to_kind(s))
+        let effective = crate::front::typestr::transparent_result_ok_type(s).unwrap_or(s);
+        Some(return_type_string_to_kind(effective))
     }
 
     /// The callee's post-`?` declared `RESULT` type (`call.py:222
@@ -3779,6 +3782,9 @@ impl CallControl {
     pub(crate) fn target_to_path(&self, target: &CallTarget) -> Option<CallPath> {
         match target {
             CallTarget::FunctionPath { segments } => {
+                if crate::model::fn_const_segments(target).is_some() {
+                    return None;
+                }
                 let path = CallPath::from_segments(segments.iter().map(String::as_str));
                 // A rich-`OpKind` graph resolves via `function_graphs`; an
                 // opname-dispatch helper has no rich twin there, so it is
@@ -4058,6 +4064,14 @@ impl CallControl {
     /// `CallPath`; otherwise it falls back to the stable symbolic address
     /// shim for source-only analysis.
     pub fn fnaddr_for_target(&self, target: &CallTarget) -> i64 {
+        if let Some(segments) = crate::model::fn_const_segments(target) {
+            let path = CallPath::from_segments(segments.iter().map(String::as_str));
+            return self
+                .function_fnaddrs
+                .get(&path)
+                .copied()
+                .unwrap_or_else(|| symbolic_fnaddr_for_path(&path));
+        }
         if let Some(path) = self.target_to_path(target) {
             return self
                 .function_fnaddrs
@@ -5677,6 +5691,11 @@ pub(crate) fn symbolic_fnaddr_for_path(path: &CallPath) -> i64 {
 }
 
 pub(crate) fn symbolic_fnaddr_for_target(target: &CallTarget) -> i64 {
+    if let Some(segments) = crate::model::fn_const_segments(target) {
+        return stable_symbolic_fnaddr(&CallPath::from_segments(
+            segments.iter().map(String::as_str),
+        ));
+    }
     stable_symbolic_fnaddr(target)
 }
 
@@ -9708,5 +9727,21 @@ mod tests {
         assert_eq!(cc.recursive_field_count("Inner"), 2);
         // Outer: a(1) + inner→{x,y}(2) + `&Inner` pointer(1) + b(1) = 5.
         assert_eq!(cc.recursive_field_count("Outer"), 5);
+    }
+
+    #[test]
+    fn fn_const_target_strips_head_for_fnaddr_only() {
+        let mut cc = CallControl::new();
+        let real_path = CallPath::from_segments(["m", "f"]);
+        cc.register_function_fnaddr(real_path, 0x1234);
+        let target = CallTarget::function_path(["__fn_const", "m", "f"]);
+
+        assert_eq!(
+            crate::model::fn_const_segments(&target)
+                .map(|s| { s.iter().map(String::as_str).collect::<Vec<_>>() }),
+            Some(vec!["m", "f"])
+        );
+        assert_eq!(cc.fnaddr_for_target(&target), 0x1234);
+        assert_eq!(cc.target_to_path(&target), None);
     }
 }

--- a/majit/majit-translate/src/codewriter/codewriter.rs
+++ b/majit/majit-translate/src/codewriter/codewriter.rs
@@ -606,20 +606,6 @@ impl CodeWriter {
         // `Variable.concretetype` (see `Transformer::transform` →
         // `apply_to_graph`), so the legacy `resolve_rewritten_types`
         // walk is structurally dead in the production path.
-        // Commit jtransform-induced op-result kinds (`result_ty` /
-        // `result_kind` declarations) to each backing
-        // `Variable.concretetype` cell.  Pre-jtransform kinds are
-        // already on the graph cells (rtyper boundary via
-        // `apply_to_graph` / `resolve_types`); this overlay handles
-        // the post-jtransform op-result deltas.  Precedence stack
-        // `post_result > pre-jtransform` falls out of
-        // `set_concretetype_of_inline`'s "preserve richer existing
-        // iff getkind matches" semantic.
-        for (var, kind) in &post_result_types {
-            if !matches!(kind, crate::model::ConcreteType::Unknown) {
-                crate::model::FunctionGraph::set_concretetype_of_inline(var, kind.clone());
-            }
-        }
         // Long-term parity hydration: when the dual-gate Match arm
         // surfaced a `LegacyToTyped` map, copy each upstream-typed
         // Variable's lltype onto the matching legacy Variable so
@@ -630,6 +616,24 @@ impl CodeWriter {
         // line-for-line equivalent.
         if let Some(value_to_var) = real_value_to_var.as_ref() {
             crate::codewriter::type_state::apply_from_flowspace_variables(value_to_var);
+        }
+        // Commit jtransform-induced op-result kinds (`result_ty` /
+        // `result_kind` declarations) to each backing
+        // `Variable.concretetype` cell.  Pre-jtransform kinds are
+        // already on the graph cells (rtyper boundary via
+        // `apply_to_graph` / `resolve_types`); this overlay handles the
+        // post-jtransform op-result deltas.  It runs after the hydration
+        // above because a rewritten declaration outranks the
+        // pre-jtransform cell: an inlined `Result<bool, PyError>` call is
+        // the post-exception `Bool` value even though the Rust aggregate
+        // typed it as a `Ref` shell.  Precedence stack
+        // `post_result > pre-jtransform` falls out of
+        // `set_concretetype_of_inline`'s "preserve richer existing
+        // iff getkind matches" semantic.
+        for (var, kind) in &post_result_types {
+            if !matches!(kind, crate::model::ConcreteType::Unknown) {
+                crate::model::FunctionGraph::set_concretetype_of_inline(var, kind.clone());
+            }
         }
 
         // Steps 2-4 (regalloc → flatten → liveness/assemble → calldescr →

--- a/majit/majit-translate/src/codewriter/jtransform.rs
+++ b/majit/majit-translate/src/codewriter/jtransform.rs
@@ -411,10 +411,13 @@ fn is_source_constant_variable(
                 | OpKind::ConstRef(_)
                 | OpKind::ConstRefNull
                 | OpKind::ConstRefAddr(_) => true,
-                OpKind::Call {
-                    target: CallTarget::FunctionPath { segments },
-                    ..
-                } => segments.first().is_some_and(|s| s == "__str_const"),
+                OpKind::Call { target, .. } => match target {
+                    CallTarget::FunctionPath { segments } => {
+                        segments.first().is_some_and(|s| s == "__str_const")
+                            || crate::model::fn_const_segments(target).is_some()
+                    }
+                    _ => false,
+                },
                 _ => false,
             }
         })
@@ -850,6 +853,15 @@ impl<'a> Transformer<'a> {
                 kind: OpKind::ConstInt(fnaddr),
             },
         )
+    }
+
+    fn materialize_fn_const_funcptr_value(
+        &mut self,
+        graph: &mut FunctionGraph,
+        funcptr: &crate::flowspace::model::Variable,
+    ) -> Option<(crate::flowspace::model::Variable, SpaceOperation)> {
+        let target = fn_const_target_for_var(graph, funcptr, 0)?;
+        Some(self.direct_funcptr_value(graph, &target))
     }
 
     /// RPython: Transformer.rewrite_operation() — dispatch to rewrite_op_*.
@@ -4741,6 +4753,12 @@ impl<'a> Transformer<'a> {
         graph_name: &str,
         graph: &mut crate::model::FunctionGraph,
     ) -> RewriteResult {
+        let materialized_funcptr = self.materialize_fn_const_funcptr_value(graph, funcptr);
+        let funcptr_value = materialized_funcptr
+            .as_ref()
+            .map(|(var, _)| var)
+            .unwrap_or(funcptr)
+            .clone();
         let (args_i, args_r, args_f) = self.make_three_lists_from_vars(args);
         let resolved_result = self.resolve_call_result(op.result.as_ref(), result_ty);
         let result_kind = resolved_result.kind;
@@ -4775,7 +4793,10 @@ impl<'a> Transformer<'a> {
                 //   op1 = SpaceOperation('int_guard_value', [op.args[0]], None)
                 //   op2 = self.handle_residual_call(op, [IndirectCallTargets(lst)], True)
                 // then [op0, op1] + op2 (op2 is itself [residual_call, '-live-'])
-                let mut ops = Vec::<SpaceOperation>::with_capacity(4);
+                let mut ops = Vec::<SpaceOperation>::with_capacity(5);
+                if let Some((_, funcptr_op)) = materialized_funcptr.clone() {
+                    ops.push(funcptr_op);
+                }
                 ops.push(SpaceOperation {
                     result: None,
                     kind: OpKind::Live,
@@ -4783,14 +4804,14 @@ impl<'a> Transformer<'a> {
                 ops.push(SpaceOperation {
                     result: None,
                     kind: OpKind::GuardValue {
-                        value: funcptr.clone(),
+                        value: funcptr_value.clone(),
                         kind_char: 'i',
                     },
                 });
                 ops.push(SpaceOperation {
                     result: op.result.clone(),
                     kind: OpKind::CallResidual {
-                        funcptr: CallFuncPtr::Value(funcptr.clone()),
+                        funcptr: CallFuncPtr::Value(funcptr_value.clone()),
                         descriptor,
                         args_i,
                         args_r,
@@ -4825,10 +4846,14 @@ impl<'a> Transformer<'a> {
                         None => "call <indirect> → residual unknown family".to_string(),
                     },
                 });
-                let mut ops = vec![SpaceOperation {
+                let mut ops = Vec::new();
+                if let Some((_, funcptr_op)) = materialized_funcptr {
+                    ops.push(funcptr_op);
+                }
+                ops.push(SpaceOperation {
                     result: op.result.clone(),
                     kind: OpKind::CallResidual {
-                        funcptr: CallFuncPtr::Value(funcptr.clone()),
+                        funcptr: CallFuncPtr::Value(funcptr_value),
                         descriptor,
                         args_i,
                         args_r,
@@ -4836,7 +4861,7 @@ impl<'a> Transformer<'a> {
                         result_kind,
                         indirect_targets: None,
                     },
-                }];
+                });
                 if can_raise {
                     ops.push(SpaceOperation {
                         result: None,
@@ -5317,10 +5342,92 @@ fn value_type_to_ir_type(ty: &ValueType) -> majit_ir::value::Type {
     }
 }
 
+fn fn_const_target_for_var(
+    graph: &FunctionGraph,
+    var: &crate::flowspace::model::Variable,
+    depth: usize,
+) -> Option<CallTarget> {
+    if depth > 8 {
+        return None;
+    }
+    let (block_id, index) = crate::front::mir::resolve_to_producer_op(graph, var)?;
+    let block = graph.blocks.iter().find(|block| block.id == block_id)?;
+    let op = block.operations.get(index)?;
+    fn_const_target_from_op(graph, op, depth + 1)
+}
+
+fn fn_const_target_from_op(
+    graph: &FunctionGraph,
+    op: &SpaceOperation,
+    depth: usize,
+) -> Option<CallTarget> {
+    match &op.kind {
+        OpKind::Call { target, args, .. }
+            if args.is_empty() && crate::model::fn_const_segments(target).is_some() =>
+        {
+            Some(target.clone())
+        }
+        OpKind::UnaryOp { op, operand, .. } if op == "same_as" => {
+            fn_const_target_for_var(graph, operand, depth)
+        }
+        OpKind::Hint { value, .. } => fn_const_target_for_var(graph, value, depth),
+        OpKind::FieldRead { base, field, .. } => {
+            let index = tuple_pos_field_index(&field.name)?;
+            if let Some(target) = fn_const_target_from_tuple_arg(graph, base, index, depth) {
+                return Some(target);
+            }
+            fn_const_target_from_field_write(graph, base, field, depth)
+        }
+        _ => None,
+    }
+}
+
+fn fn_const_target_from_tuple_arg(
+    graph: &FunctionGraph,
+    base: &crate::flowspace::model::Variable,
+    index: usize,
+    depth: usize,
+) -> Option<CallTarget> {
+    let (block_id, op_index) = crate::front::mir::resolve_to_producer_op(graph, base)?;
+    let block = graph.blocks.iter().find(|block| block.id == block_id)?;
+    let op = block.operations.get(op_index)?;
+    let OpKind::NewTuple { args } = &op.kind else {
+        return None;
+    };
+    let arg = args.get(index)?;
+    fn_const_target_for_var(graph, arg, depth)
+}
+
+fn fn_const_target_from_field_write(
+    graph: &FunctionGraph,
+    base: &crate::flowspace::model::Variable,
+    field: &crate::model::FieldDescriptor,
+    depth: usize,
+) -> Option<CallTarget> {
+    graph.blocks.iter().find_map(|block| {
+        block.operations.iter().find_map(|op| match &op.kind {
+            OpKind::FieldWrite {
+                base: write_base,
+                field: write_field,
+                value,
+                ..
+            } if write_base == base && write_field == field => value
+                .as_variable()
+                .and_then(|value| fn_const_target_for_var(graph, value, depth)),
+            _ => None,
+        })
+    })
+}
+
+fn tuple_pos_field_index(name: &str) -> Option<usize> {
+    name.strip_prefix("__pos_")?.parse().ok()
+}
+
 /// Convert a CallTarget to a CallPath for jitcode lookup.
 fn target_to_call_path(target: &CallTarget) -> crate::parse::CallPath {
     match target {
         CallTarget::FunctionPath { segments } => {
+            let segments = crate::model::fn_const_segments(target).unwrap_or(segments.as_slice());
             crate::parse::CallPath::from_segments(segments.iter().map(String::as_str))
         }
         CallTarget::Method { name, .. } => crate::parse::CallPath::from_segments([name.as_str()]),

--- a/majit/majit-translate/src/codewriter/jtransform.rs
+++ b/majit/majit-translate/src/codewriter/jtransform.rs
@@ -5404,19 +5404,37 @@ fn fn_const_target_from_field_write(
     field: &crate::model::FieldDescriptor,
     depth: usize,
 ) -> Option<CallTarget> {
-    graph.blocks.iter().find_map(|block| {
-        block.operations.iter().find_map(|op| match &op.kind {
-            OpKind::FieldWrite {
+    // The scan is flow-insensitive, so two arms writing different function
+    // pointers to the same field are indistinguishable here.  Taking the
+    // first would bake one arm's address into a call the other arm reaches,
+    // so an ambiguous initializer declines to materialise a constant and the
+    // call stays indirect.
+    let mut found: Option<CallTarget> = None;
+    for block in &graph.blocks {
+        for op in &block.operations {
+            let OpKind::FieldWrite {
                 base: write_base,
                 field: write_field,
                 value,
                 ..
-            } if write_base == base && write_field == field => value
+            } = &op.kind
+            else {
+                continue;
+            };
+            if write_base != base || write_field != field {
+                continue;
+            }
+            let target = value
                 .as_variable()
-                .and_then(|value| fn_const_target_for_var(graph, value, depth)),
-            _ => None,
-        })
-    })
+                .and_then(|value| fn_const_target_for_var(graph, value, depth))?;
+            match &found {
+                Some(seen) if *seen != target => return None,
+                Some(_) => {}
+                None => found = Some(target),
+            }
+        }
+    }
+    found
 }
 
 fn tuple_pos_field_index(name: &str) -> Option<usize> {

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -4523,23 +4523,40 @@ impl<'a> Lowering<'a> {
                 // shape (`flowspace_adapter.rs::is_str_const_define`).
                 result_ty: ValueType::Ref(None),
             },
-            // A function item's value is its address.  Upstream materialises
-            // it as `Constant(funcptr)` of lltype `Ptr(FuncType)`
-            // (`rtyper.getcallable`, and `sub_helper_funcptr_constant` for the
-            // sub-helper twins), whose `getkind` is `r` — the same reason the
-            // `Str` arm above declares a Ref.  The synthetic define reuses the
-            // callee's real path so a value threaded into a call site still
-            // resolves, which also puts it in front of `getcalldescr`'s
-            // `RESULT == FUNC.RESULT` check (`call.py`): an `Int` here read as
-            // a 0-arg call to that function and hard-failed against any callee
-            // whose graph carries a `FUNC.RESULT` token — `w_dict_new`
-            // (`dont_look_inside`) threaded through `Option::unwrap_or_else` is
-            // the shape that surfaces it.
-            DecodedConst::FnPath(segments) => OpKind::Call {
-                target: CallTarget::FunctionPath { segments },
-                args: vec![],
-                result_ty: ValueType::Ref(None),
-            },
+            // A function item used as a *value* rather than called; its value
+            // is the function's address.  The define takes a synthetic head
+            // for the same reason the `Str` arm above does: the path never
+            // matches a registered graph, so the define is not mistaken for a
+            // real 0-arg call to the function it names.  Both of
+            // `getcalldescr`'s checks (`call.py`) run off the resolved callee
+            // graph, and both reject this shape without the head — the
+            // argument-kind comparison against the define's empty list
+            // (`cycle_reduce_method`, one `Ref` parameter), and
+            // `RESULT == FUNC.RESULT` for a 0-parameter callee carrying a
+            // result token (`w_dict_new`, `dont_look_inside`, threaded through
+            // `Option::unwrap_or_else`).  The callee's own segments stay in
+            // the tail so the referenced function is still recoverable.
+            //
+            // Upstream materialises the address as `Constant(funcptr)` of
+            // lltype `Ptr(FuncType)` (`rtyper.getcallable`, and
+            // `sub_helper_funcptr_constant` for the sub-helper twins), whose
+            // `getkind` is `r`.  The slot here stays `Int` because majit
+            // materialises a funcptr as its integer address everywhere else
+            // (`jtransform.rs direct_funcptr_value` emits `ConstInt(fnaddr)`,
+            // which the assembler encodes through the `'i'` argcode), and the
+            // flowspace fold gives the define a `Signed` legacy slot to match.
+            DecodedConst::FnPath(segments) => {
+                let mut synthetic = Vec::with_capacity(segments.len() + 1);
+                synthetic.push(crate::model::FN_CONST_HEAD.to_string());
+                synthetic.extend(segments);
+                OpKind::Call {
+                    target: CallTarget::FunctionPath {
+                        segments: synthetic,
+                    },
+                    args: vec![],
+                    result_ty: ValueType::Int,
+                }
+            }
         };
         let var = self
             .graph
@@ -15401,7 +15418,7 @@ fn scalar_value_to_i64(v: &serde_json::Value) -> Option<i64> {
 /// `None` when `var` traces to a `Const`, a function input (no producing
 /// op), a phi merge (a block with more than one incoming `Link`, so no
 /// single producer), or a producer not yet emitted into `graph`.
-fn resolve_to_producer_op(
+pub(crate) fn resolve_to_producer_op(
     graph: &FunctionGraph,
     var: &crate::flowspace::model::Variable,
 ) -> Option<(BlockId, usize)> {

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -12821,10 +12821,20 @@ fn dont_look_inside_return_token(output: &TyRef, llbc: &Llbc) -> Option<String> 
     // `RESULT == FUNC.RESULT` check).  `Result<(), PyError>` reaches the
     // unit arm the same way its callee reaches `widen_unit_return_to_void`.
     //
+    // Only a `PyError` carrier is lowered that way.  Any other `Result`
+    // stays a real ADT the callee returns whole and the caller matches on
+    // (`rbigint::_AsDouble -> Result<f64, RBigIntError>`), so projecting it
+    // would name the payload's bank for a value that arrives as a
+    // reference — the same disagreement in the other direction.
+    //
     // The `OBJECTPTR` carve-out below deliberately keeps reading the
     // declared `output`: it decides the pointer's lowering, not its bank,
     // and a `Result`-typed output has never taken it.
-    let payload = crate::front::result_exc::tyref_result_ok(output, llbc);
+    let payload = if crate::front::result_exc::tyref_is_result_of_pyerror(output, llbc) {
+        crate::front::result_exc::tyref_result_ok(output, llbc)
+    } else {
+        None
+    };
     let kind_src = payload.as_ref().unwrap_or(output);
     if is_unit_type(kind_src, llbc) {
         return None;

--- a/majit/majit-translate/src/model.rs
+++ b/majit/majit-translate/src/model.rs
@@ -289,6 +289,20 @@ pub enum CallTarget {
     UnsupportedExpr,
 }
 
+pub const FN_CONST_HEAD: &str = "__fn_const";
+
+pub fn fn_const_segments(target: &CallTarget) -> Option<&[String]> {
+    match target {
+        CallTarget::FunctionPath { segments }
+            if segments.first().map(String::as_str) == Some(FN_CONST_HEAD)
+                && segments.len() > 1 =>
+        {
+            Some(&segments[1..])
+        }
+        _ => None,
+    }
+}
+
 impl CallTarget {
     pub fn method(name: impl Into<String>, receiver_root: Option<String>) -> Self {
         Self::Method {

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -626,6 +626,19 @@ fn is_str_const_define(kind: &OpKind) -> bool {
     )
 }
 
+/// `true` iff `kind` is `front::mir`'s synthetic function-item constant
+/// define-op (`Call(["__fn_const", <real path>...])`).  Like
+/// [`is_str_const_define`], this is a constant carrier rather than a
+/// flowspace call operation.
+fn is_fn_const_define(kind: &OpKind) -> bool {
+    match kind {
+        OpKind::Call { target, args, .. } if args.is_empty() => {
+            crate::model::fn_const_segments(target).is_some()
+        }
+        _ => false,
+    }
+}
+
 /// `true` iff `kind` is `front::mir`'s synthetic prebuilt-constant-array
 /// define-op (`Call(["__const_int_array", <i0>, <i1>, …])`,
 /// `fold_named_const_int_array_global`).  A module-level constant array
@@ -812,6 +825,9 @@ pub(crate) fn op_canraise(kind: &OpKind) -> bool {
         // and emits no op — a Constant raises nothing.  Matched before
         // the general `Call` arm, same as the unit-variant elision.
         kind if is_str_const_define(kind) => false,
+        // A function-item constant define-op is a bare constant carrier,
+        // not a callee invocation, so it raises nothing.
+        kind if is_fn_const_define(kind) => false,
         // A prebuilt-constant-array define-op pre-folds to `Constant(list)`
         // and emits no op — a Constant raises nothing.  Matched before the
         // general `Call` arm, same as the string-literal elision.
@@ -946,6 +962,12 @@ pub fn translate_op(
     // way (see `is_str_const_define`); the pre-pass owns the slot's
     // `Hlvalue::Constant`, translate_op emits no FlowspaceOp.
     if is_str_const_define(&op.kind) {
+        return Ok(Vec::new());
+    }
+    // Function-item define-ops pre-fold to a constant carrier the same
+    // way (see `is_fn_const_define`); consumers that need the address
+    // recover the real path by stripping the synthetic head.
+    if is_fn_const_define(&op.kind) {
         return Ok(Vec::new());
     }
     // Prebuilt-constant-array define-ops pre-fold to `Constant(list)` the
@@ -2576,36 +2598,41 @@ fn constant_from_constvalue(value: ConstValue) -> Constant {
     }
 }
 
-fn legacy_const_define_hlvalue(op: &SpaceOperation) -> Option<Hlvalue> {
+fn legacy_const_define_hlvalue(
+    op: &SpaceOperation,
+    call_registry: Option<&crate::translator::rtyper::pyre_call_registry::PyreCallRegistry>,
+) -> Result<Option<Hlvalue>, TyperError> {
     // Const-define ops always carry a result Variable; bail on the
     // (malformed) result-less op so the caller can key the const
     // concretetype by `op.result` identity.
-    op.result.as_ref()?;
+    if op.result.is_none() {
+        return Ok(None);
+    }
     match &op.kind {
-        OpKind::ConstInt(n) => Some(Hlvalue::Constant(Constant::with_concretetype(
+        OpKind::ConstInt(n) => Ok(Some(Hlvalue::Constant(Constant::with_concretetype(
             ConstValue::Int(*n),
             LowLevelType::Signed,
-        ))),
-        OpKind::ConstInt128(n) => Some(Hlvalue::Constant(Constant::with_concretetype(
+        )))),
+        OpKind::ConstInt128(n) => Ok(Some(Hlvalue::Constant(Constant::with_concretetype(
             ConstValue::Int128(*n),
             LowLevelType::SignedLongLongLong,
-        ))),
-        OpKind::ConstUInt128(n) => Some(Hlvalue::Constant(Constant::with_concretetype(
+        )))),
+        OpKind::ConstUInt128(n) => Ok(Some(Hlvalue::Constant(Constant::with_concretetype(
             ConstValue::UInt128(*n),
             LowLevelType::UnsignedLongLongLong,
-        ))),
-        OpKind::ConstBool(b) => Some(Hlvalue::Constant(Constant::with_concretetype(
+        )))),
+        OpKind::ConstBool(b) => Ok(Some(Hlvalue::Constant(Constant::with_concretetype(
             ConstValue::Bool(*b),
             LowLevelType::Bool,
-        ))),
-        OpKind::ConstFloat(bits) => Some(Hlvalue::Constant(Constant::with_concretetype(
+        )))),
+        OpKind::ConstFloat(bits) => Ok(Some(Hlvalue::Constant(Constant::with_concretetype(
             ConstValue::Float(*bits),
             LowLevelType::Float,
-        ))),
-        OpKind::ConstRefNull => Some(Hlvalue::Constant(const_ref_gcref_constant(None))),
-        OpKind::ConstRefAddr(addr) => {
-            Some(Hlvalue::Constant(const_ref_gcref_constant(Some(*addr))))
-        }
+        )))),
+        OpKind::ConstRefNull => Ok(Some(Hlvalue::Constant(const_ref_gcref_constant(None)))),
+        OpKind::ConstRefAddr(addr) => Ok(Some(Hlvalue::Constant(const_ref_gcref_constant(Some(
+            *addr,
+        ))))),
         // Prebuilt-constant-array define-op.  A module-level constant
         // array (`OP_STACKDEL: [i32; N]`) is carried as a bare immutable
         // `Constant(list)`; `immutableconstant` annotates it `SomeList`
@@ -2615,8 +2642,8 @@ fn legacy_const_define_hlvalue(op: &SpaceOperation) -> Option<Hlvalue> {
         // (`fold_named_const_int_array_global`); re-fold that define-op to
         // the upstream Constant shape here, the same way the
         // `__str_const` arm below re-folds a string literal.
-        kind if is_const_int_array_define(kind) => const_int_array_items(kind)
-            .map(|items| Hlvalue::Constant(Constant::new(ConstValue::List(items)))),
+        kind if is_const_int_array_define(kind) => Ok(const_int_array_items(kind)
+            .map(|items| Hlvalue::Constant(Constant::new(ConstValue::List(items))))),
         // String-literal constant.  Upstream flowspace carries a string
         // literal as a bare `Constant('text')` SSA value (annotated
         // `SomeString` by `immutablevalue`); `front::mir` has no
@@ -2637,10 +2664,53 @@ fn legacy_const_define_hlvalue(op: &SpaceOperation) -> Option<Hlvalue> {
             args,
             ..
         } if args.is_empty() && segments.len() == 2 && segments[0] == "__str_const" => {
-            Some(Hlvalue::Constant(Constant::with_concretetype(
+            Ok(Some(Hlvalue::Constant(Constant::with_concretetype(
                 ConstValue::ByteStr(segments[1].clone().into_bytes()),
                 crate::translator::rtyper::lltypesystem::rstr::STRPTR.clone(),
-            )))
+            ))))
+        }
+        OpKind::Call { target, args, .. }
+            if args.is_empty() && crate::model::fn_const_segments(target).is_some() =>
+        {
+            let segments = crate::model::fn_const_segments(target).expect("guard checked");
+            let call_registry = call_registry.ok_or_else(|| {
+                TyperError::message(format!(
+                    "fn const {:?} requires a PyreCallRegistry to materialise getfunctionptr",
+                    segments
+                ))
+            })?;
+            let key =
+                crate::translator::rtyper::pyre_call_registry::FunctionPathKey(segments.to_vec());
+            let entry = call_registry.lookup_with_leaf_match(&key).ok_or_else(|| {
+                TyperError::message(format!(
+                    "fn const {:?} did not resolve to a registered callee",
+                    key.segments()
+                ))
+            })?;
+            if let Some(err) = entry.pyre_lift_error() {
+                return Err(TyperError::message(format!(
+                    "fn const {:?} resolved to an unbuildable callee: {err}",
+                    key.segments()
+                )));
+            }
+            let graphs = entry.function_desc.borrow().getgraphs();
+            let graph = graphs.into_iter().next().ok_or_else(|| {
+                TyperError::message(format!(
+                    "fn const {:?} resolved to a registry entry without a cached graph",
+                    key.segments()
+                ))
+            })?;
+            let func_ptr = crate::translator::rtyper::lltypesystem::lltype::getfunctionptr(
+                &graph.graph,
+                crate::translator::rtyper::lltypesystem::lltype::_getconcretetype,
+            )?;
+            let func_ptr_type = crate::translator::rtyper::lltypesystem::lltype::LowLevelType::Ptr(
+                Box::new(func_ptr._TYPE.clone()),
+            );
+            Ok(Some(Hlvalue::Constant(Constant::with_concretetype(
+                ConstValue::LLPtr(Box::new(func_ptr)),
+                func_ptr_type,
+            ))))
         }
         // RPython parity: unit-variant ctors (`StepResult::Continue`,
         // `LoopResult::Done`, …) are pre-built singleton instances at
@@ -2671,7 +2741,7 @@ fn legacy_const_define_hlvalue(op: &SpaceOperation) -> Option<Hlvalue> {
             if !crate::translator::rtyper::unit_variant_fold::is_synthetic_unit_variant_path(
                 &segments,
             ) {
-                return None;
+                return Ok(None);
             }
             // PyPy rtyper folds unit-variant PBC constructors into a
             // singleton instance pointer before jtransform sees them
@@ -2699,15 +2769,19 @@ fn legacy_const_define_hlvalue(op: &SpaceOperation) -> Option<Hlvalue> {
             // (`rpython/rtyper/rclass.py:804`).  Without this, two
             // graphs that reach the same unit variant via different
             // gate arms would resolve to distinct singletons.
-            let instance = crate::translator::rtyper::unit_variant_fold::intern_unit_variant_prebuilt_instance(
-                &qualname,
-            )?;
-            Some(Hlvalue::Constant(Constant::with_concretetype(
+            let instance =
+                crate::translator::rtyper::unit_variant_fold::intern_unit_variant_prebuilt_instance(
+                    &qualname,
+                );
+            let Some(instance) = instance else {
+                return Ok(None);
+            };
+            Ok(Some(Hlvalue::Constant(Constant::with_concretetype(
                 ConstValue::HostObject(instance),
                 crate::translator::rtyper::rclass::OBJECTPTR.clone(),
-            )))
+            ))))
         }
-        _ => None,
+        _ => Ok(None),
     }
 }
 
@@ -3116,7 +3190,7 @@ pub fn function_graph_to_flowspace(
             continue;
         }
         for legacy_op in &legacy_block.operations {
-            if let Some(hlvalue) = legacy_const_define_hlvalue(legacy_op) {
+            if let Some(hlvalue) = legacy_const_define_hlvalue(legacy_op, Some(call_registry))? {
                 // `legacy_const_define_hlvalue` only returns `Some` for ops
                 // with a result Variable, so this is always present here.
                 let Some(result_var) = legacy_op.result.as_ref() else {
@@ -3124,7 +3198,20 @@ pub fn function_graph_to_flowspace(
                 };
                 if let Hlvalue::Constant(c) = &hlvalue {
                     if let Some(ct) = &c.concretetype {
-                        constant_concretetypes.insert(result_var.clone(), ct.clone());
+                        let legacy_ct = if is_fn_const_define(&legacy_op.kind) {
+                            // The rtyper-side carrier is a real LLPtr so
+                            // direct-call resolution can materialise
+                            // `getfunctionptr` from the function graph.  The
+                            // legacy/codewriter side must still see the
+                            // synthetic define's declared Int slot: later
+                            // jtransform materialises funcptr values as
+                            // `ConstInt(fnaddr)` and the assembler encodes
+                            // them through the `i` argcode.
+                            LowLevelType::Signed
+                        } else {
+                            ct.clone()
+                        };
+                        constant_concretetypes.insert(result_var.clone(), legacy_ct.clone());
                         // Also stamp the lltype onto the legacy graph's
                         // orphan Variable cell for this const-define
                         // result.  The rtyper consumes `Hlvalue::Constant`
@@ -3138,7 +3225,7 @@ pub fn function_graph_to_flowspace(
                         // depending on the post-rtyper
                         // `apply_to_graph(constant_concretetypes, …)`
                         // bridge.
-                        result_var.set_concretetype(Some(ct.clone()));
+                        result_var.set_concretetype(Some(legacy_ct));
                     }
                 }
                 constant_hlvalues.insert(result_var.clone(), hlvalue);
@@ -3332,7 +3419,7 @@ pub fn function_graph_to_flowspace(
         // Translate operations.
         let mut translated_ops: Vec<FlowspaceOp> = Vec::new();
         for legacy_op in &legacy_block.operations {
-            if let Some(hlvalue) = legacy_const_define_hlvalue(legacy_op) {
+            if let Some(hlvalue) = legacy_const_define_hlvalue(legacy_op, Some(call_registry))? {
                 if let Some(result_var) = legacy_op.result.as_ref() {
                     value_map.insert(result_var.clone(), hlvalue.clone());
                     if let Some(name) = legacy.value_name_for(result_var) {
@@ -5611,7 +5698,7 @@ mod tests {
                 .is_empty()
         );
         // The pre-pass folds the define to the prebuilt list constant.
-        match legacy_const_define_hlvalue(&op) {
+        match legacy_const_define_hlvalue(&op, None).expect("const-array define folds") {
             Some(Hlvalue::Constant(c)) => assert_eq!(
                 c.value,
                 ConstValue::List(vec![
@@ -5632,5 +5719,125 @@ mod tests {
             result_ty: ValueType::Ref(None),
         };
         assert!(!is_const_int_array_define(&str_const));
+    }
+
+    #[test]
+    fn fn_const_define_is_constant_carrier() {
+        use crate::model::CallTarget;
+
+        let registry = empty_call_registry();
+        let key = crate::translator::rtyper::pyre_call_registry::FunctionPathKey::from_segments([
+            "module", "function",
+        ]);
+        let func = crate::flowspace::model::GraphFunc::new(
+            "function",
+            Constant::new(ConstValue::Dict(Default::default())),
+        );
+        let ret = Variable::new();
+        ret.annotation.replace(Some(Rc::new(
+            crate::annotator::model::SomeValue::Impossible,
+        )));
+        ret.set_concretetype(Some(
+            crate::translator::rtyper::lltypesystem::lltype::LowLevelType::Void,
+        ));
+        let startblock = crate::flowspace::model::Block::shared(vec![]);
+        let pygraph = Rc::new(crate::flowspace::pygraph::PyGraph {
+            graph: Rc::new(RefCell::new(
+                crate::flowspace::model::FunctionGraph::with_return_var(
+                    "function",
+                    startblock,
+                    Hlvalue::Variable(ret),
+                ),
+            )),
+            func,
+            signature: RefCell::new(crate::flowspace::argument::Signature::new(
+                Vec::<String>::new(),
+                None,
+                None,
+            )),
+            defaults: RefCell::new(Some(Vec::new())),
+            access_directly: std::cell::Cell::new(false),
+        });
+        registry.register_callee(
+            key,
+            crate::flowspace::argument::Signature::new(Vec::<String>::new(), None, None),
+            pygraph,
+        );
+
+        let define = OpKind::Call {
+            target: CallTarget::FunctionPath {
+                segments: vec![
+                    crate::model::FN_CONST_HEAD.to_string(),
+                    "module".to_string(),
+                    "function".to_string(),
+                ],
+            },
+            args: Vec::new(),
+            result_ty: ValueType::Int,
+        };
+        assert!(is_fn_const_define(&define));
+        assert!(!is_str_const_define(&define));
+        assert!(!is_const_int_array_define(&define));
+
+        let op = SpaceOperation {
+            result: Some(Variable::new()),
+            kind: define.clone(),
+        };
+        assert!(
+            translate_op(&op, &HashMap::new(), &empty_call_registry())
+                .expect("fn const define translates")
+                .is_empty()
+        );
+        match legacy_const_define_hlvalue(&op, Some(&registry)).expect("fn const define folds") {
+            Some(Hlvalue::Constant(c)) => {
+                assert!(matches!(c.value, ConstValue::LLPtr(_)));
+                assert!(matches!(
+                    c.concretetype,
+                    Some(crate::translator::rtyper::lltypesystem::lltype::LowLevelType::Ptr(_))
+                ));
+            }
+            other => panic!("expected LLPtr funcptr Constant carrier, got {other:?}"),
+        }
+
+        let mut legacy = LegacyGraph::new("fn_const_carrier");
+        let carrier = legacy.alloc_value_var();
+        let startblock = Block {
+            id: legacy.startblock,
+            inputargs: vec![],
+            operations: vec![SpaceOperation {
+                result: Some(carrier.clone()),
+                kind: define,
+            }],
+            exitswitch: None,
+            exits: vec![link_to_returnblock(
+                vec![LinkArg::Value(carrier.clone())],
+                legacy.returnblock,
+            )],
+            framestate: None,
+            dead: false,
+        };
+        let returnblock = Block {
+            id: legacy.returnblock,
+            inputargs: vec![carrier.clone()],
+            operations: vec![],
+            exitswitch: None,
+            exits: vec![],
+            framestate: None,
+            dead: false,
+        };
+        legacy.blocks = vec![startblock, returnblock];
+
+        let output = function_graph_to_flowspace(&legacy, &registry)
+            .expect("fn const carrier graph converts");
+        assert_eq!(
+            output.constant_concretetypes.get(&carrier),
+            Some(&crate::translator::rtyper::lltypesystem::lltype::LowLevelType::Signed),
+            "legacy/codewriter carrier type must stay Int/Signed"
+        );
+        assert_eq!(
+            carrier.concretetype(),
+            Some(crate::translator::rtyper::lltypesystem::lltype::LowLevelType::Signed),
+            "legacy Variable cell must stay Int/Signed"
+        );
     }
 }

--- a/pyre/extra_tests/snippets/stdlib_sys.py
+++ b/pyre/extra_tests/snippets/stdlib_sys.py
@@ -146,9 +146,9 @@ assert proc.returncode == 0, proc
 
 def safe_path_flag(env, *opts):
     proc = subprocess.run(
-        (sys.executable,) + opts + ("-c", code),
+        (sys.executable, *opts, "-c", code),
         stdout=subprocess.PIPE,
-        universal_newlines=True,
+        text=True,
         env=env,
     )
     assert proc.returncode == 0, proc

--- a/pyre/extra_tests/snippets/stdlib_sys.py
+++ b/pyre/extra_tests/snippets/stdlib_sys.py
@@ -143,10 +143,31 @@ proc = subprocess.run(args, stdout=subprocess.PIPE, universal_newlines=True, env
 assert proc.stdout.rstrip() == "True", proc
 assert proc.returncode == 0, proc
 
+
+def safe_path_flag(env, *opts):
+    proc = subprocess.run(
+        (sys.executable,) + opts + ("-c", code),
+        stdout=subprocess.PIPE,
+        universal_newlines=True,
+        env=env,
+    )
+    assert proc.returncode == 0, proc
+    return proc.stdout.rstrip()
+
+
+# The variable alone enables safe path; it is a presence flag, so any non-empty
+# value counts and an empty one is treated as unset.
 env["PYTHONSAFEPATH"] = "1"
-proc = subprocess.run(args, stdout=subprocess.PIPE, universal_newlines=True, env=env)
-assert proc.stdout.rstrip() == "True"
-assert proc.returncode == 0, proc
+assert safe_path_flag(env) == "True"
+env["PYTHONSAFEPATH"] = "0"
+assert safe_path_flag(env) == "True"
+env["PYTHONSAFEPATH"] = ""
+assert safe_path_flag(env) == "False"
+
+# -E ignores every PYTHON* variable, but an explicit -P still wins.
+env["PYTHONSAFEPATH"] = "1"
+assert safe_path_flag(env, "-E") == "False"
+assert safe_path_flag(env, "-E", "-P") == "True"
 
 assert sys._getframemodulename() == "__main__", sys._getframemodulename()
 

--- a/pyre/pyre-interpreter/src/argument.rs
+++ b/pyre/pyre-interpreter/src/argument.rs
@@ -115,9 +115,11 @@ pub fn contains_w_names(w_key: PyObjectRef, keys_w: &[PyObjectRef]) -> bool {
             return true;
         }
         unsafe {
+            // Compared as raw buffers: `**{'\ud800': 1}` puts a lone surrogate
+            // in a keyword name, which has no `&str` spelling.
             if pyre_object::is_str(w_other)
                 && pyre_object::is_str(w_key)
-                && pyre_object::w_str_get_value(w_other) == pyre_object::w_str_get_value(w_key)
+                && pyre_object::w_str_get_wtf8(w_other) == pyre_object::w_str_get_wtf8(w_key)
             {
                 return true;
             }
@@ -152,7 +154,7 @@ pub fn check_not_duplicate_kwargs(
         if contains_w_names(w_key, existingkeywords_w) {
             let key_repr = unsafe {
                 if pyre_object::is_str(w_key) {
-                    pyre_object::w_str_get_value(w_key).to_string()
+                    pyre_object::w_str_get_wtf8(w_key).to_string()
                 } else {
                     crate::display::py_str(w_key)?
                 }

--- a/pyre/pyre-interpreter/src/argument.rs
+++ b/pyre/pyre-interpreter/src/argument.rs
@@ -1901,6 +1901,24 @@ mod tests {
         assert!(!contains_w_names(pyre_object::w_str_new("c"), &names));
     }
 
+    /// `contains_w_names` compares keyword names without requiring a `&str`
+    /// view.
+    #[test]
+    fn surrogate_keyword_name_matches() {
+        let mut name = rustpython_wtf8::Wtf8Buf::new();
+        name.push(rustpython_wtf8::CodePoint::from_u32(0xD800).unwrap());
+        let w_name = pyre_object::w_str_from_wtf8(name.clone());
+        let existing = vec![pyre_object::w_str_from_wtf8(name.clone())];
+        let new = vec![w_name];
+        let values: Vec<PyObjectRef> = vec![pyre_object::w_int_new(1)];
+
+        assert!(contains_w_names(w_name, &existing));
+        let err = check_not_duplicate_kwargs(&existing, &new, &values, pyre_object::PY_NULL)
+            .expect_err("should raise TypeError on duplicate");
+        assert_eq!(err.kind, crate::PyErrorKind::TypeError);
+        assert!(err.message.contains("got multiple values"));
+    }
+
     /// pypy/interpreter/argument.py:410-417 `_check_not_duplicate_kwargs` —
     /// raises TypeError on overlap.
     #[test]

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -7469,9 +7469,13 @@ fn expect_str(obj: PyObjectRef) -> Result<(), PyError> {
 }
 
 /// baseobjspace.py:1784 text_w.
+///
+/// The `&str` view is what the callers need, so a value whose buffer has none
+/// — one carrying a lone surrogate — is reported through [`str_utf8_w`].
+/// [`text_wtf8_w`] is the accessor for a caller that can take the raw buffer.
 pub fn text_w(obj: PyObjectRef) -> Result<&'static str, PyError> {
     expect_str(obj)?;
-    Ok(unsafe { pyre_object::w_str_get_value(obj) })
+    str_utf8_w(obj)
 }
 
 /// `text_w` on the raw buffer.  `W_UnicodeObject.text_w` hands back
@@ -7480,6 +7484,33 @@ pub fn text_w(obj: PyObjectRef) -> Result<&'static str, PyError> {
 pub fn text_wtf8_w(obj: PyObjectRef) -> Result<&'static Wtf8, PyError> {
     expect_str(obj)?;
     Ok(unsafe { pyre_object::w_str_get_wtf8(obj) })
+}
+
+/// The `&str` view of a value already known to be a `str`, for a native
+/// parameter that has to reach Rust as `&str`.
+///
+/// A lone surrogate has no UTF-8 encoding, so it is reported the way the
+/// strict utf-8 encoder reports one (unicodehelper.py:245) —
+/// `UnicodeEncodeError` with "surrogates not allowed" — instead of demanding a
+/// view the backing `Wtf8Buf` cannot give.
+pub fn str_utf8_w(obj: PyObjectRef) -> Result<&'static str, PyError> {
+    let wtf8 = unsafe { pyre_object::w_str_get_wtf8(obj) };
+    match wtf8.as_str() {
+        Ok(s) => Ok(s),
+        Err(_) => {
+            let pos = wtf8
+                .code_points()
+                .position(|cp| cp.to_char().is_none())
+                .unwrap_or(0);
+            Err(crate::typedef::unicode_encode_error(
+                "utf-8",
+                obj,
+                pos,
+                pos + 1,
+                "surrogates not allowed",
+            ))
+        }
+    }
 }
 
 /// baseobjspace.py:1791 utf8_w.

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -4635,72 +4635,9 @@ fn getattr_str_impl(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyResul
     // super proxy — PyPy: pypy/module/__builtin__/descriptor.py W_Super.getattribute
     // Looks up `name` in cls's MRO starting AFTER super_type.
     unsafe {
-        if pyre_object::descriptor::is_super(obj)
-            && !pyre_object::descriptor::w_super_get_obj(obj).is_null()
-            && name != "__class__"
-        {
-            let super_type = pyre_object::descriptor::w_super_get_type(obj);
-            let bound_obj = pyre_object::descriptor::w_super_get_obj(obj);
-
-            // Walk obj's type MRO, skip until we pass super_type.
-            // Fall back to `crate::typedef::r#type(obj)` so non-INSTANCE
-            // built-in subclasses (W_BaseException, etc.) resolve their
-            // class through the same path that powers `type(obj)` —
-            // `pypy/objspace/std/typeobject.py:1083 type_get_mro`.
-            // descriptor.py:127-149 _super_check: `su_obj` is itself a
-            // subtype of `su_type` only in the classmethod / class-level
-            // case (return `su_obj`).  A class whose metaclass is
-            // `su_type` is an *instance* of `su_type`, not a subtype, so
-            // it must resolve through `type(su_obj)` — otherwise its MRO
-            // never reaches `su_type` and the lookup fails.
-            let w_obj_type = if is_type(bound_obj) && issubtype_w(bound_obj, super_type) {
-                bound_obj
-            } else if is_instance(bound_obj) {
-                w_instance_get_type(bound_obj)
-            } else if let Some(cls) = crate::typedef::r#type(bound_obj) {
-                cls.as_ptr()
-            } else {
-                return Err(PyError::type_error("super: bad obj type"));
-            };
-            let mro_ptr = w_type_get_mro(w_obj_type);
-            if !mro_ptr.is_null() {
-                let mro = &*mro_ptr;
-                let mro_len = mro.len();
-                let mut past_super = false;
-                for i in 0..mro_len {
-                    let t = mro[i];
-                    if std::ptr::eq(t, super_type) {
-                        past_super = true;
-                        continue;
-                    }
-                    if !past_super {
-                        continue;
-                    }
-                    if is_type(t) {
-                        // Look in this class's own dict only (not its MRO),
-                        // since we are already iterating the full MRO ourselves.
-                        let found = crate::type_dict_lookup(t, name);
-                        if let Some(attr) = found {
-                            // W_Super.getattribute binds every descriptor,
-                            // rather than only the three builtin method
-                            // wrapper shapes.  This also covers property,
-                            // getset, member, and user-defined descriptors.
-                            // descriptor.py:76-82 — class-mode
-                            // `super(C, C)` calls `__get__(None, C)`.
-                            let descr_obj = if std::ptr::eq(bound_obj, w_obj_type) {
-                                // `get` represents class access with PY_NULL
-                                // and exposes `space.w_None` only when it
-                                // invokes a user `__get__`. Passing the None
-                                // singleton here would bind plain functions to
-                                // None instead of returning them unbound.
-                                PY_NULL
-                            } else {
-                                bound_obj
-                            };
-                            return Ok(get(attr, descr_obj, w_obj_type)?.unwrap_or(attr));
-                        }
-                    }
-                }
+        if name != "__class__" {
+            if let Some(value) = super_getattribute_wtf8(obj, Wtf8::new(name))? {
+                return Ok(value);
             }
             // `W_Super.getattribute` falls back to
             // `object.__getattribute__` when the post-starttype MRO has no
@@ -5275,6 +5212,77 @@ fn getattr_str_impl(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyResul
     Err(err)
 }
 
+/// super proxy — PyPy: pypy/module/__builtin__/descriptor.py W_Super.getattribute
+///
+/// Looks `name` up in the bound object's MRO starting AFTER `su_type`, and
+/// returns `None` when `obj` is not a bound super or the walk finds nothing,
+/// so the caller falls through to ordinary attribute lookup.  Taken by WTF-8
+/// so a name carrying a lone surrogate reaches the same walk as any other.
+unsafe fn super_getattribute_wtf8(
+    obj: PyObjectRef,
+    name: &Wtf8,
+) -> Result<Option<PyObjectRef>, PyError> {
+    unsafe {
+        if !pyre_object::descriptor::is_super(obj)
+            || pyre_object::descriptor::w_super_get_obj(obj).is_null()
+        {
+            return Ok(None);
+        }
+        let super_type = pyre_object::descriptor::w_super_get_type(obj);
+        let bound_obj = pyre_object::descriptor::w_super_get_obj(obj);
+        // descriptor.py:127-149 _super_check: `su_obj` is itself a subtype of
+        // `su_type` only in the classmethod / class-level case.  A class whose
+        // metaclass is `su_type` is an *instance* of `su_type`, not a subtype,
+        // so it must resolve through `type(su_obj)` — otherwise its MRO never
+        // reaches `su_type` and the lookup fails.  The `type()` fallback also
+        // lets non-INSTANCE builtin subclasses (W_BaseException and friends)
+        // resolve their class through the path that powers `type(obj)`
+        // (`pypy/objspace/std/typeobject.py:1083 type_get_mro`).
+        let w_obj_type = if is_type(bound_obj) && issubtype_w(bound_obj, super_type) {
+            bound_obj
+        } else if is_instance(bound_obj) {
+            w_instance_get_type(bound_obj)
+        } else if let Some(cls) = crate::typedef::r#type(bound_obj) {
+            cls.as_ptr()
+        } else {
+            return Err(PyError::type_error("super: bad obj type"));
+        };
+        let mro_ptr = w_type_get_mro(w_obj_type);
+        if mro_ptr.is_null() {
+            return Ok(None);
+        }
+        let mut past_super = false;
+        for &t in (*mro_ptr).as_slice() {
+            if std::ptr::eq(t, super_type) {
+                past_super = true;
+                continue;
+            }
+            if !past_super || !is_type(t) {
+                continue;
+            }
+            // This class's own dict only — the full MRO is already being
+            // walked here.
+            if let Some(attr) = crate::type_dict_lookup_wtf8(t, name) {
+                // W_Super.getattribute binds every descriptor rather than only
+                // the three builtin method-wrapper shapes, which also covers
+                // property, getset, member and user-defined descriptors.
+                // descriptor.py:76-82 — class-mode `super(C, C)` calls
+                // `__get__(None, C)`.  `get` spells class access as PY_NULL and
+                // exposes the None singleton only when it invokes a user
+                // `__get__`; passing None here would bind plain functions to
+                // None instead of returning them unbound.
+                let descr_obj = if std::ptr::eq(bound_obj, w_obj_type) {
+                    PY_NULL
+                } else {
+                    bound_obj
+                };
+                return Ok(Some(get(attr, descr_obj, w_obj_type)?.unwrap_or(attr)));
+            }
+        }
+        Ok(None)
+    }
+}
+
 // ─── `w_name`-taking attribute API ───
 //
 // `descroperation.py:225/247/255 getattr/setattr/delattr(space, w_obj,
@@ -5332,6 +5340,11 @@ pub fn delattr(obj: PyObjectRef, w_name: PyObjectRef) -> PyResult {
 /// `getattr_str`'s builtin-type special-cases, all valid identifiers.)
 unsafe fn getattr_surrogate(obj: PyObjectRef, w_name: PyObjectRef, name: &Wtf8) -> PyResult {
     unsafe {
+        if name.as_str() != Ok("__class__") {
+            if let Some(value) = super_getattribute_wtf8(obj, name)? {
+                return Ok(value);
+            }
+        }
         match object_getattribute_surrogate(obj, w_name, name) {
             Ok(v) => Ok(v),
             Err(mut e) => {
@@ -8649,7 +8662,7 @@ pub(crate) unsafe fn setattr_if_not_from_object(w_type: PyObjectRef) -> Option<P
 pub unsafe fn super_lookup_binding(
     super_type: PyObjectRef,
     self_obj: PyObjectRef,
-    name: &str,
+    name: &Wtf8,
 ) -> PyObjectRef {
     use pyre_object::*;
     let w_obj_type = if is_instance(self_obj) {
@@ -8672,7 +8685,7 @@ pub unsafe fn super_lookup_binding(
                 continue;
             }
             if is_type(t) {
-                if let Some(raw) = lookup_in_type_where(t, name) {
+                if let Some(raw) = lookup_in_type_wtf8(t, name) {
                     if is_staticmethod(raw) {
                         return PY_NULL;
                     }
@@ -8681,7 +8694,7 @@ pub unsafe fn super_lookup_binding(
                     }
                     // `__new__` is implicitly static (type.__new__ is a
                     // builtin_function_or_method, not a Python function)
-                    if name == "__new__" {
+                    if name.as_str() == Ok("__new__") {
                         return PY_NULL;
                     }
                     return self_obj;

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -5781,6 +5781,46 @@ pub(crate) fn module_getattribute(obj: PyObjectRef, name: &str) -> PyResult {
     }
 }
 
+/// `Module.descr_getattribute` for a name with no `&str` view.  The `&str`
+/// chain cannot spell a lone surrogate, so the terminal `__dict__` read and
+/// the PEP 562 hook are reached through their WTF-8 twins.
+pub(crate) unsafe fn module_getattribute_wtf8(
+    obj: PyObjectRef,
+    w_name: PyObjectRef,
+    name: &Wtf8,
+) -> PyResult {
+    unsafe {
+        match object_getattribute_surrogate(obj, w_name, name) {
+            Ok(value) => Ok(value),
+            Err(err) if err.kind == PyErrorKind::AttributeError => {
+                module_getattr_hook_wtf8(obj, w_name, err)
+            }
+            Err(err) => Err(err),
+        }
+    }
+}
+
+/// module.py:139-142 PEP 562 tail on the raw name object: a module-level
+/// `__getattr__` in the module's own dict is called unbound with just the
+/// name.  `err` is the miss the caller is about to report.
+unsafe fn module_getattr_hook_wtf8(
+    obj: PyObjectRef,
+    w_name: PyObjectRef,
+    err: PyError,
+) -> PyResult {
+    unsafe {
+        let w_dict = pyre_object::w_module_get_w_dict(obj);
+        if !w_dict.is_null() {
+            if let Some(mod_getattr) = finditem_str(w_dict, "__getattr__")? {
+                if !mod_getattr.is_null() {
+                    return crate::call::call_function_impl_result(mod_getattr, &[w_name]);
+                }
+            }
+        }
+        Err(err)
+    }
+}
+
 /// module.py `Module.descr_getattribute` tail.  A module-level `__getattr__`
 /// is a namespace value called with the name alone, not a type descriptor.
 unsafe fn module_getattr_hook_or_err(

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -13872,6 +13872,12 @@ unsafe fn generator_invoke_execute_frame(
     if !ec.is_null() {
         (*ec).push_gen_or_coroutine(gen_obj);
     }
+    // generator.py:_invoke_execute_frame enters through the execution
+    // context of the thread that is resuming the generator.  A suspended
+    // frame must not retain the context of the thread that created or last
+    // ran it: that thread may have exited before close()/finalization resumes
+    // the frame elsewhere.
+    frame.execution_context = ec;
     let result = frame.execute_generator_frame(w_inputvalue, operr, throw_args);
     let result = match result {
         Err(e) => {
@@ -13898,6 +13904,7 @@ unsafe fn generator_invoke_execute_frame(
     };
     // generator.py:142-145 `finally`.
     frame.f_backref = std::ptr::null_mut();
+    frame.execution_context = std::ptr::null();
     w_generator_set_running(gen_obj, false);
     if !ec.is_null() {
         (*ec).pop_gen_or_coroutine(gen_obj);

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -7456,16 +7456,30 @@ pub fn c_int_w(obj: PyObjectRef) -> Result<i32, PyError> {
     Ok(value as i32)
 }
 
-/// baseobjspace.py:1784 text_w.
-pub fn text_w(obj: PyObjectRef) -> Result<&'static str, PyError> {
+/// The `str` check the `text_w` family shares —
+/// `_typed_unwrap_error(space, "str")`, `"expected %s, got %T object"`.
+fn expect_str(obj: PyObjectRef) -> Result<(), PyError> {
     if unsafe { !isinstance_str_w(obj) } {
-        // `_typed_unwrap_error(space, "str")` — `"expected %s, got %T object"`.
         return Err(PyError::type_error(format!(
             "expected str, got {} object",
             object_functionstr_type_name(obj)
         )));
     }
+    Ok(())
+}
+
+/// baseobjspace.py:1784 text_w.
+pub fn text_w(obj: PyObjectRef) -> Result<&'static str, PyError> {
+    expect_str(obj)?;
     Ok(unsafe { pyre_object::w_str_get_value(obj) })
+}
+
+/// `text_w` on the raw buffer.  `W_UnicodeObject.text_w` hands back
+/// `self._utf8` unchanged, so a lone surrogate survives instead of demanding a
+/// `&str` view the buffer cannot give.
+pub fn text_wtf8_w(obj: PyObjectRef) -> Result<&'static Wtf8, PyError> {
+    expect_str(obj)?;
+    Ok(unsafe { pyre_object::w_str_get_wtf8(obj) })
 }
 
 /// baseobjspace.py:1791 utf8_w.
@@ -7485,6 +7499,15 @@ pub fn realunicode_w(obj: PyObjectRef) -> Result<&'static str, PyError> {
 pub fn text0_w(obj: PyObjectRef) -> Result<&'static str, PyError> {
     let s = text_w(obj)?;
     if s.contains('\0') {
+        return Err(PyError::value_error("embedded null character"));
+    }
+    Ok(s)
+}
+
+/// `text0_w` on the raw buffer — see `text_wtf8_w`.
+pub fn text0_wtf8_w(obj: PyObjectRef) -> Result<&'static Wtf8, PyError> {
+    let s = text_wtf8_w(obj)?;
+    if s.as_bytes().contains(&0) {
         return Err(PyError::value_error("embedded null character"));
     }
     Ok(s)

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -7494,6 +7494,13 @@ pub fn text_wtf8_w(obj: PyObjectRef) -> Result<&'static Wtf8, PyError> {
 /// `UnicodeEncodeError` with "surrogates not allowed" — instead of demanding a
 /// view the backing `Wtf8Buf` cannot give.
 pub fn str_utf8_w(obj: PyObjectRef) -> Result<&'static str, PyError> {
+    if !unsafe { pyre_object::is_str(obj) } {
+        return Err(PyError::type_error(format!(
+            "expected str, not {}",
+            crate::type_methods::arg_type_name(obj)
+        )));
+    }
+    // The raw buffer read below is only valid for a `str`.
     let wtf8 = unsafe { pyre_object::w_str_get_wtf8(obj) };
     match wtf8.as_str() {
         Ok(s) => Ok(s),

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -7,6 +7,8 @@ use crate::{
 };
 use pyre_object::*;
 use rustpython_wtf8::{CodePoint, Wtf8, Wtf8Buf};
+#[cfg(unix)]
+use std::os::unix::ffi::OsStringExt;
 
 /// `buffer_w` — select the byte-storage `Buffer` variant for a memoryview
 /// backing by concrete kind, so a bytes / bytearray / array *subclass* backing
@@ -11736,22 +11738,24 @@ fn open_raw_file(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         ));
     }
 
-    let path = unsafe {
+    // The OS path is a byte string.  A `str` path may carry surrogateescape
+    // code points, which spell bytes that are not valid UTF-8; folding those
+    // to U+FFFD would open a different file, so the encoded bytes are kept
+    // and handed to the seam verbatim.
+    let path_bytes = unsafe {
         if pyre_object::is_str(path_obj) {
-            crate::baseobjspace::str_utf8_w(path_obj)?.to_string()
+            crate::gateway::fsencode_bytes_w(path_obj)?
         } else if pyre_object::bytesobject::is_bytes_like(path_obj) {
-            let data = pyre_object::bytesobject::bytes_like_data(path_obj);
-            String::from_utf8_lossy(data).into_owned()
+            pyre_object::bytesobject::bytes_like_data(path_obj).to_vec()
         } else if let Some(fspath_fn) = crate::typedef::r#type(path_obj)
             .and_then(|pt| crate::baseobjspace::lookup_in_type(pt.as_ptr(), "__fspath__"))
         {
             // `type(path).__fspath__(path)` — unbound descriptor + single arg.
             let result = crate::call::call_function_impl_result(fspath_fn, &[path_obj])?;
             if pyre_object::is_str(result) {
-                crate::baseobjspace::str_utf8_w(result)?.to_string()
+                crate::gateway::fsencode_bytes_w(result)?
             } else if pyre_object::bytesobject::is_bytes_like(result) {
-                let data = pyre_object::bytesobject::bytes_like_data(result);
-                String::from_utf8_lossy(data).into_owned()
+                pyre_object::bytesobject::bytes_like_data(result).to_vec()
             } else {
                 return Err(crate::PyError::type_error(
                     "open(): path should be str, bytes, os.PathLike",
@@ -11763,6 +11767,11 @@ fn open_raw_file(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
             ));
         }
     };
+    // `host_env::fs` takes a `Path`; only the seam consumes the raw bytes.
+    #[cfg(unix)]
+    let path = std::ffi::OsString::from_vec(path_bytes.clone());
+    #[cfg(not(unix))]
+    let path = String::from_utf8_lossy(&path_bytes).into_owned();
     let binary = mode.contains('b');
     let writing = mode.contains('w') || mode.contains('a') || mode.contains('x');
     let reading = mode.contains('r') || !writing;
@@ -11815,8 +11824,9 @@ fn open_raw_file(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     {
         let _ = (reading, writing);
         let flags = open_flags_for_mode(&mode);
-        let fd = crate::host_seam::ops::open(path.as_bytes(), flags, 0o666)
-            .map_err(|e| crate::host_seam::seam_os_err(e, &path))?;
+        let path_display = String::from_utf8_lossy(&path_bytes);
+        let fd = crate::host_seam::ops::open(&path_bytes, flags, 0o666)
+            .map_err(|e| crate::host_seam::seam_os_err(e, &path_display))?;
         if let Err(error) = fileio_validate_fd(fd, path_obj) {
             fileio_close_owned_fd(fd);
             return Err(error);
@@ -11843,8 +11853,9 @@ fn open_raw_file(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         // close(), which is not the W_FileIO storage shape.
         let _ = (reading, writing);
         let flags = open_flags_for_mode(&mode);
-        let fd = crate::host_seam::ops::open(path.as_bytes(), flags, 0o666)
-            .map_err(|e| crate::host_seam::seam_os_err(e, &path))?;
+        let path_display = String::from_utf8_lossy(&path_bytes);
+        let fd = crate::host_seam::ops::open(&path_bytes, flags, 0o666)
+            .map_err(|e| crate::host_seam::seam_os_err(e, &path_display))?;
         if let Err(error) = fileio_validate_fd(fd, path_obj) {
             fileio_close_owned_fd(fd);
             return Err(error);

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -1359,7 +1359,11 @@ fn memoryview_cast(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
                 "memoryview: format argument must be a string",
             ));
         }
-        let fmt = pyre_object::w_str_get_value(fmt_obj).to_owned();
+        // Read through the raw buffer: only the handful of native single-
+        // character codes are accepted, so a lone surrogate is rejected by the
+        // format check below (with the replacement character `Wtf8`'s `Display`
+        // substitutes) the same way any other unsupported format is.
+        let fmt = unsafe { pyre_object::w_str_get_wtf8(fmt_obj) }.to_string();
         let has_shape = shape_obj.is_some_and(|s| !pyre_object::is_none(s));
         let orig_ndim = w_memoryview_ndim(mv);
         // Casts are restricted to C-contiguous source views.
@@ -3878,7 +3882,7 @@ fn type_descr_new_with_metaclass(
                 crate::baseobjspace::object_functionstr_type_name(w_namespace_dict)
             )));
         }
-        let name = unsafe { pyre_object::w_str_get_value(name_obj) };
+        let name = crate::baseobjspace::str_utf8_w(name_obj)?;
 
         // CPython: calculate_metaclass — if bases have a custom metaclass,
         // delegate to that metaclass instead of using type.__new__ directly.
@@ -7788,19 +7792,15 @@ fn builtin_compile(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
     let mode_obj = bind_pos_or_kw(pos, kwargs, 2, "mode", "compile", 3)?.ok_or_else(|| {
         crate::PyError::type_error("compile() missing required argument 'mode' (pos 3)")
     })?;
-    let filename = unsafe {
-        if pyre_object::is_str(filename_obj) {
-            pyre_object::w_str_get_value(filename_obj).to_string()
-        } else {
-            "<string>".to_string()
-        }
+    let filename = if unsafe { pyre_object::is_str(filename_obj) } {
+        crate::baseobjspace::str_utf8_w(filename_obj)?.to_string()
+    } else {
+        "<string>".to_string()
     };
-    let mode = unsafe {
-        if pyre_object::is_str(mode_obj) {
-            pyre_object::w_str_get_value(mode_obj).to_string()
-        } else {
-            "exec".to_string()
-        }
+    let mode = if unsafe { pyre_object::is_str(mode_obj) } {
+        crate::baseobjspace::str_utf8_w(mode_obj)?.to_string()
+    } else {
+        "exec".to_string()
     };
     // flags / dont_inherit / optimize are positional-or-keyword ints
     // (unwrap_spec flags=int, dont_inherit=int, optimize=int).
@@ -10404,7 +10404,7 @@ pub(crate) fn fileio_init(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
             "FileIO() argument 'mode' must be str",
         ));
     }
-    let mode = unsafe { pyre_object::w_str_get_value(mode_obj) };
+    let mode = crate::baseobjspace::str_utf8_w(mode_obj)?;
     // PyPy `decode_mode`: exactly one r/w/x/a flag, at most one '+', and
     // optional 'b'.  Keep the individual booleans because `_mode()` derives
     // the public canonical mode from capabilities, not from input spelling
@@ -11438,7 +11438,7 @@ pub fn builtin_open(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
             crate::type_methods::arg_type_name(w_mode)
         )));
     }
-    let mode = unsafe { pyre_object::w_str_get_value(w_mode).to_string() };
+    let mode = crate::baseobjspace::str_utf8_w(w_mode)?.to_string();
     let w_buffering = bind_pos_or_kw(positional, kwargs, 2, "buffering", "open", 3)?
         .unwrap_or_else(|| w_int_new(-1));
     // A buffering value outside the machine-int range is an OverflowError, not a
@@ -11670,11 +11670,11 @@ fn open_raw_file(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let str_or_none =
         |obj: Option<PyObjectRef>, name: &str| -> Result<Option<String>, crate::PyError> {
             match obj {
-                Some(o) if unsafe { pyre_object::is_str(o) } => Ok(Some(unsafe {
-                    pyre_object::w_str_get_value(o)
+                Some(o) if unsafe { pyre_object::is_str(o) } => Ok(Some(
+                    crate::baseobjspace::str_utf8_w(o)?
                         .to_ascii_lowercase()
-                        .replace('_', "-")
-                })),
+                        .replace('_', "-"),
+                )),
                 Some(o) if unsafe { pyre_object::is_none(o) } => Ok(None),
                 Some(o) => Err(crate::PyError::type_error(format!(
                     "open() argument '{name}' must be str or None, not {}",
@@ -11686,9 +11686,9 @@ fn open_raw_file(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let encoding = str_or_none(encoding_obj, "encoding")?.unwrap_or_else(|| "utf-8".to_string());
     let errors = str_or_none(errors_obj, "errors")?.unwrap_or_else(|| "strict".to_string());
     let mode: String = match mode_obj {
-        Some(m) if unsafe { pyre_object::is_str(m) } => unsafe {
-            pyre_object::w_str_get_value(m).to_string()
-        },
+        Some(m) if unsafe { pyre_object::is_str(m) } => {
+            crate::baseobjspace::str_utf8_w(m)?.to_string()
+        }
         Some(m) if unsafe { pyre_object::is_none(m) } => "r".to_string(),
         Some(m) => {
             return Err(crate::PyError::type_error(format!(
@@ -11738,7 +11738,7 @@ fn open_raw_file(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
 
     let path = unsafe {
         if pyre_object::is_str(path_obj) {
-            pyre_object::w_str_get_value(path_obj).to_string()
+            crate::baseobjspace::str_utf8_w(path_obj)?.to_string()
         } else if pyre_object::bytesobject::is_bytes_like(path_obj) {
             let data = pyre_object::bytesobject::bytes_like_data(path_obj);
             String::from_utf8_lossy(data).into_owned()
@@ -11748,7 +11748,7 @@ fn open_raw_file(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
             // `type(path).__fspath__(path)` — unbound descriptor + single arg.
             let result = crate::call::call_function_impl_result(fspath_fn, &[path_obj])?;
             if pyre_object::is_str(result) {
-                pyre_object::w_str_get_value(result).to_string()
+                crate::baseobjspace::str_utf8_w(result)?.to_string()
             } else if pyre_object::bytesobject::is_bytes_like(result) {
                 let data = pyre_object::bytesobject::bytes_like_data(result);
                 String::from_utf8_lossy(data).into_owned()
@@ -12548,7 +12548,7 @@ fn builtin_format(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let spec = if args.len() > 1 {
         crate::type_methods::read_format_spec(args[1], "format() argument 2")?
     } else {
-        String::new()
+        rustpython_wtf8::Wtf8Buf::new()
     };
     crate::type_methods::format_value_dispatch_w(value, &spec)
 }

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -12612,7 +12612,6 @@ fn builtin_dunder_import(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyE
     if !unsafe { pyre_object::is_str(name_obj) } {
         return Err(crate::PyError::type_error("module name must be a string"));
     }
-    let name = unsafe { pyre_object::w_str_get_value(name_obj) };
     let globals = scope[1];
     let locals = scope[2];
     let fromlist = scope[3];
@@ -12632,6 +12631,13 @@ fn builtin_dunder_import(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyE
             unsafe { (*frame).execution_context }
         }
     });
+    // The native importer keys every lookup by `&str`, so a name that has no
+    // such spelling goes straight to the app-level bootstrap.
+    let Some(name) = (unsafe { pyre_object::w_str_get_value_opt(name_obj) }) else {
+        return crate::importing::dunder_import_name_obj(
+            name_obj, globals, locals, fromlist, level,
+        );
+    };
     crate::importing::dunder_import(name, globals, locals, fromlist, level, exec_ctx)
 }
 

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -624,6 +624,18 @@ fn format_unknown_kwds_err(fname: &str, unmatched: &[Wtf8Buf]) -> String {
     }
 }
 
+#[cold]
+fn raise_if_posonly_kwds(posonly_kwds: &[String], fname: &str) -> Result<(), PyError> {
+    if posonly_kwds.is_empty() {
+        return Ok(());
+    }
+    Err(crate::PyError::type_error(format!(
+        "{}() got some positional-only arguments passed as keyword arguments: '{}'",
+        fname,
+        posonly_kwds.join(", ")
+    )))
+}
+
 fn call_user_function_with_eval(
     frame: &PyFrame,
     callable: PyObjectRef,
@@ -1594,13 +1606,7 @@ pub(crate) fn resolve_kwargs(
     // argument.py:499-500 — ArgErrPosonlyAsKwds, raised after the full
     // keyword scan (and before ArgErrUnknownKwds, since `_match_keywords`
     // raises this before its caller ever checks unmatched kwds).
-    if !posonly_kwds.is_empty() {
-        return Err(crate::PyError::type_error(format!(
-            "{}() got some positional-only arguments passed as keyword arguments: '{}'",
-            fname,
-            posonly_kwds.join(", ")
-        )));
-    }
+    raise_if_posonly_kwds(&posonly_kwds, &fname)?;
 
     // `argument.py:270-271` ArgErrUnknownKwds — unmatched kwargs and no
     // **kwarg to absorb them.
@@ -1863,13 +1869,7 @@ pub(crate) fn bind_kwargs_to_signature(
 
     // argument.py:499-500 — ArgErrPosonlyAsKwds, raised after the full
     // keyword scan and before ArgErrUnknownKwds.
-    if !posonly_kwds.is_empty() {
-        return Err(crate::PyError::type_error(format!(
-            "{}() got some positional-only arguments passed as keyword arguments: '{}'",
-            fname,
-            posonly_kwds.join(", ")
-        )));
-    }
+    raise_if_posonly_kwds(&posonly_kwds, fname)?;
 
     if !unmatched_kw_names.is_empty() {
         // parse_obj (argument.py:377-380) rewrites the unknown-keyword message
@@ -2043,6 +2043,14 @@ pub fn call_with_kwargs(
                     crate::builtin_code_call(code as pyre_object::PyObjectRef, &bound)
                 };
             }
+            let arity = unsafe {
+                crate::builtin_code_get_fast_natural_arity(code as pyre_object::PyObjectRef)
+            };
+            if arity <= 4 && !kwargs.is_empty() {
+                return Err(unsafe {
+                    crate::builtin_code_no_keyword_arguments(code as pyre_object::PyObjectRef)
+                });
+            }
             let mut full_args = pos_args.to_vec();
             if !kwargs.is_empty() {
                 let kwargs_dict = pyre_object::w_dict_new();
@@ -2184,13 +2192,7 @@ pub fn call_with_kwargs(
 
             // argument.py:499-500 — ArgErrPosonlyAsKwds, raised after the
             // full keyword scan and before ArgErrUnknownKwds.
-            if !posonly_kwds.is_empty() {
-                return Err(crate::PyError::type_error(format!(
-                    "{}() got some positional-only arguments passed as keyword arguments: '{}'",
-                    fname,
-                    posonly_kwds.join(", ")
-                )));
-            }
+            raise_if_posonly_kwds(&posonly_kwds, &fname)?;
 
             // `argument.py:270-271` ArgErrUnknownKwds.
             if !unmatched_kw_names.is_empty() {

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -3247,11 +3247,22 @@ fn update_bases(
 pub(crate) fn real_build_class(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     if args.len() < 2 {
         return Err(crate::PyError::type_error(
-            "__build_class__ requires at least 2 arguments",
+            "__build_class__: not enough arguments",
         ));
     }
     let body_fn = args[0];
     let name_obj = args[1];
+
+    // compiling.py:163-167 — the body must be a Python function carrying a
+    // `PyCode`.  Its code object is read directly below, so anything else is
+    // rejected here rather than reaching that read.
+    if !unsafe { crate::is_function(body_fn) }
+        || unsafe { crate::function_has_builtin_code(body_fn) }
+    {
+        return Err(crate::PyError::type_error(
+            "__build_class__: func must be a function",
+        ));
+    }
 
     // Check if last arg is a kwargs dict (from CALL_KW)
     // PyPy: __build_class__(func, name, *bases, metaclass=None, **kwds)

--- a/pyre/pyre-interpreter/src/error.rs
+++ b/pyre/pyre-interpreter/src/error.rs
@@ -682,8 +682,17 @@ impl PyError {
     /// `name` rides the shared `w_n` slot (ImportError / NameError /
     /// AttributeError), stamped by `to_exc_object`.
     pub fn module_not_found_with_name(msg: impl Into<String>, name: &str) -> Self {
+        Self::module_not_found_with_name_obj(msg, pyre_object::w_str_new(name))
+    }
+
+    /// `module_not_found_with_name` for a name with no `&str` spelling, so the
+    /// caller supplies the name object itself.
+    pub fn module_not_found_with_name_obj(
+        msg: impl Into<String>,
+        w_name: pyre_object::PyObjectRef,
+    ) -> Self {
         let mut err = Self::new(PyErrorKind::ModuleNotFoundError, msg);
-        err.w_name_context = pyre_object::w_str_new(name);
+        err.w_name_context = w_name;
         err
     }
 

--- a/pyre/pyre-interpreter/src/gateway.rs
+++ b/pyre/pyre-interpreter/src/gateway.rs
@@ -715,11 +715,14 @@ pub unsafe fn builtin_code_call(
     // fixed arity indexes its slice directly, so a call that supplies a
     // different number of arguments is rejected before the body runs.  The
     // slice length is the positional count on every call but a keyword one, so
-    // the trailing marker dict is only looked for once a length already
-    // mismatched.
+    // fixed-count bodies reject a trailing keyword marker before it can be read
+    // as an ordinary argument.
     let arity = unsafe { (*code).fast_natural_arity } as usize;
-    if arity <= 4 && args.len() != arity {
-        let (positional, _) = crate::builtins::split_builtin_kwargs(args);
+    if arity <= 4 {
+        let (positional, kwargs) = crate::builtins::split_builtin_kwargs(args);
+        if crate::builtins::has_real_kwargs(kwargs) {
+            return Err(no_keyword_arguments(unsafe { &*code }));
+        }
         if positional.len() != arity {
             return Err(arity_mismatch(unsafe { &*code }, arity, positional.len()));
         }
@@ -748,13 +751,11 @@ pub unsafe fn builtin_code_call(
 fn arity_mismatch(code: &BuiltinCode, expected: usize, given: usize) -> crate::PyError {
     let name = code.name;
     let owner = unsafe { code.owner.as_ref() };
-    let (qualname, wanted, got) = match owner {
-        Some(owner) => (
-            format!("{}.{}", owner.type_name, name),
-            expected.saturating_sub(1),
-            given.saturating_sub(1),
-        ),
-        None => (name.to_string(), expected, given),
+    let qualname = builtin_code_qualname(code);
+    // A descriptor's receiver is not part of the reported count.
+    let (wanted, got) = match owner {
+        Some(_) => (expected.saturating_sub(1), given.saturating_sub(1)),
+        None => (expected, given),
     };
     let message = if owner.is_some_and(|owner| is_slot_wrapper(owner.type_name, name)) {
         if wanted == 2 {
@@ -773,6 +774,32 @@ fn arity_mismatch(code: &BuiltinCode, expected: usize, given: usize) -> crate::P
         }
     };
     crate::PyError::type_error(message)
+}
+
+fn builtin_code_qualname(code: &BuiltinCode) -> String {
+    match unsafe { code.owner.as_ref() } {
+        Some(owner) => format!("{}.{}", owner.type_name, code.name),
+        None => code.name.to_string(),
+    }
+}
+
+fn no_keyword_arguments(code: &BuiltinCode) -> crate::PyError {
+    // A method carries its owning type, so it names itself `list.append`.
+    // A module-level builtin has no owner to qualify it with and reports the
+    // bare name.
+    crate::PyError::type_error(format!(
+        "{}() takes no keyword arguments",
+        builtin_code_qualname(code)
+    ))
+}
+
+/// Build the keyword-rejection error for a fixed-count BuiltinCode.
+///
+/// # Safety
+/// `obj` must point to a valid `BuiltinCode`.
+#[inline]
+pub unsafe fn builtin_code_no_keyword_arguments(obj: PyObjectRef) -> crate::PyError {
+    unsafe { no_keyword_arguments(&*(obj as *const BuiltinCode)) }
 }
 
 /// Python 3.14 fills a type's slots with `wrapper_descriptor`s and its

--- a/pyre/pyre-interpreter/src/gateway.rs
+++ b/pyre/pyre-interpreter/src/gateway.rs
@@ -1002,11 +1002,11 @@ pub fn make_builtin_function_with_arity_and_maybe_sig(
     crate::function_new_with_fixed_code(code as *const (), name.to_string(), pyre_object::PY_NULL)
 }
 
-/// `gateway.py:824 BuiltinCode.funcrun` reaches the unwrapped body through
+/// `gateway.py BuiltinCode.funcrun` reaches the unwrapped body through
 /// `Arguments.parse_obj`, which rejects a call whose positional count does not
 /// fit the signature.  A builtin registered with a declared count carries no
 /// `Signature` to parse against and its body indexes those slots directly, so
-/// the count is checked before the body runs.
+/// the positional count is checked before the body runs.
 pub fn check_declared_arity(name: &str, arity: usize, given: usize) -> Result<(), crate::PyError> {
     if given == arity {
         return Ok(());
@@ -1017,6 +1017,18 @@ pub fn check_declared_arity(name: &str, arity: usize, given: usize) -> Result<()
         n => format!("{name} expected {n} arguments, got {given}"),
     };
     Err(crate::PyError::type_error(message))
+}
+
+/// Check the declared arity against positional arguments only. Keyword calls
+/// carry a trailing marker dict in the raw builtin slice; the callee still
+/// receives that raw slice after the arity guard.
+pub fn check_declared_positional_arity(
+    name: &str,
+    arity: usize,
+    args: &[PyObjectRef],
+) -> Result<(), crate::PyError> {
+    let (positional, _) = crate::builtins::split_builtin_kwargs(args);
+    check_declared_arity(name, arity, positional.len())
 }
 
 /// `make_builtin_function` with known fixed arity for fast-path dispatch.

--- a/pyre/pyre-interpreter/src/gateway.rs
+++ b/pyre/pyre-interpreter/src/gateway.rs
@@ -1019,15 +1019,20 @@ pub fn check_declared_arity(name: &str, arity: usize, given: usize) -> Result<()
     Err(crate::PyError::type_error(message))
 }
 
-/// Check the declared arity against positional arguments only. Keyword calls
-/// carry a trailing marker dict in the raw builtin slice; the callee still
-/// receives that raw slice after the arity guard.
+/// Check the declared arity as positional-only. Keyword calls carry a trailing
+/// marker dict in the raw builtin slice; the callee still receives that raw
+/// slice after the arity guard.
 pub fn check_declared_positional_arity(
     name: &str,
     arity: usize,
     args: &[PyObjectRef],
 ) -> Result<(), crate::PyError> {
-    let (positional, _) = crate::builtins::split_builtin_kwargs(args);
+    let (positional, kwargs) = crate::builtins::split_builtin_kwargs(args);
+    if crate::builtins::has_real_kwargs(kwargs) {
+        return Err(crate::PyError::type_error(format!(
+            "{name}() takes no keyword arguments"
+        )));
+    }
     check_declared_arity(name, arity, positional.len())
 }
 

--- a/pyre/pyre-interpreter/src/gateway.rs
+++ b/pyre/pyre-interpreter/src/gateway.rs
@@ -1002,6 +1002,23 @@ pub fn make_builtin_function_with_arity_and_maybe_sig(
     crate::function_new_with_fixed_code(code as *const (), name.to_string(), pyre_object::PY_NULL)
 }
 
+/// `gateway.py:824 BuiltinCode.funcrun` reaches the unwrapped body through
+/// `Arguments.parse_obj`, which rejects a call whose positional count does not
+/// fit the signature.  A builtin registered with a declared count carries no
+/// `Signature` to parse against and its body indexes those slots directly, so
+/// the count is checked before the body runs.
+pub fn check_declared_arity(name: &str, arity: usize, given: usize) -> Result<(), crate::PyError> {
+    if given == arity {
+        return Ok(());
+    }
+    let message = match arity {
+        0 => format!("{name}() takes no arguments ({given} given)"),
+        1 => format!("{name}() takes exactly one argument ({given} given)"),
+        n => format!("{name} expected {n} arguments, got {given}"),
+    };
+    Err(crate::PyError::type_error(message))
+}
+
 /// `make_builtin_function` with known fixed arity for fast-path dispatch.
 pub fn make_builtin_function_with_arity(
     name: &'static str,

--- a/pyre/pyre-interpreter/src/gateway.rs
+++ b/pyre/pyre-interpreter/src/gateway.rs
@@ -1236,18 +1236,18 @@ mod tests {
 // (gateway.py visit_fsencode line 365) and by posix call sites that
 // previously inlined the same extraction.
 pub fn fsencode_w(obj: pyre_object::PyObjectRef) -> Result<String, crate::PyError> {
+    let data = fsencode_bytes_w(obj)?;
+    Ok(String::from_utf8_lossy(&data).into_owned())
+}
+
+pub fn fsencode_bytes_w(obj: pyre_object::PyObjectRef) -> Result<Vec<u8>, crate::PyError> {
     unsafe {
         if pyre_object::is_str(obj) {
-            // A path str may carry lone surrogates (surrogateescape decoding),
-            // so read it through the WTF-8 view and lossily fold surrogates to
-            // U+FFFD rather than panicking in the strict `&str` accessor.
-            return Ok(pyre_object::w_str_get_wtf8(obj)
-                .to_string_lossy()
-                .into_owned());
+            return fsencode_str_bytes(obj);
         }
         if pyre_object::bytesobject::is_bytes_like(obj) {
             let data = pyre_object::bytesobject::bytes_like_data(obj);
-            return Ok(String::from_utf8_lossy(data).into_owned());
+            return Ok(data.to_vec());
         }
     }
     // `type(path).__fspath__(path)` — the descriptor read off the type is
@@ -1258,17 +1258,40 @@ pub fn fsencode_w(obj: pyre_object::PyObjectRef) -> Result<String, crate::PyErro
         let result = crate::call::call_function_impl_result(fspath_fn, &[obj])?;
         unsafe {
             if pyre_object::is_str(result) {
-                return Ok(pyre_object::w_str_get_wtf8(result)
-                    .to_string_lossy()
-                    .into_owned());
+                return fsencode_str_bytes(result);
             }
             if pyre_object::bytesobject::is_bytes_like(result) {
                 let data = pyre_object::bytesobject::bytes_like_data(result);
-                return Ok(String::from_utf8_lossy(data).into_owned());
+                return Ok(data.to_vec());
             }
         }
     }
     Err(crate::PyError::type_error(
         "expected str, bytes or os.PathLike",
     ))
+}
+
+fn fsencode_str_bytes(obj: pyre_object::PyObjectRef) -> Result<Vec<u8>, crate::PyError> {
+    let wtf8 = unsafe { pyre_object::w_str_get_wtf8(obj) };
+    let mut out = Vec::with_capacity(wtf8.len());
+    for (pos, cp) in wtf8.code_points().enumerate() {
+        if let Some(ch) = cp.to_char() {
+            let mut buf = [0; 4];
+            out.extend_from_slice(ch.encode_utf8(&mut buf).as_bytes());
+            continue;
+        }
+        let code = cp.to_u32();
+        if (0xDC80..=0xDCFF).contains(&code) {
+            out.push((code - 0xDC00) as u8);
+        } else {
+            return Err(crate::typedef::unicode_encode_error(
+                "utf-8",
+                obj,
+                pos,
+                pos + 1,
+                "surrogates not allowed",
+            ));
+        }
+    }
+    Ok(out)
 }

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -1642,6 +1642,7 @@ thread_local! {
 // the values the launcher recorded instead of the per-thread default.
 static SYS_NO_SITE: AtomicBool = AtomicBool::new(false);
 static SYS_QUIET: AtomicBool = AtomicBool::new(false);
+static SYS_INSPECT: AtomicBool = AtomicBool::new(false);
 static SYS_NO_USER_SITE: AtomicBool = AtomicBool::new(false);
 static SYS_IGNORE_ENVIRONMENT: AtomicBool = AtomicBool::new(false);
 static SYS_ISOLATED: AtomicBool = AtomicBool::new(false);
@@ -1669,6 +1670,7 @@ pub fn no_site_flag() -> bool {
 #[allow(clippy::too_many_arguments)]
 pub fn set_runtime_flags(
     quiet: bool,
+    inspect: bool,
     no_user_site: bool,
     ignore_environment: bool,
     isolated: bool,
@@ -1679,6 +1681,7 @@ pub fn set_runtime_flags(
     dont_write_bytecode: bool,
 ) {
     SYS_QUIET.store(quiet, Ordering::Relaxed);
+    SYS_INSPECT.store(inspect, Ordering::Relaxed);
     SYS_NO_USER_SITE.store(no_user_site, Ordering::Relaxed);
     SYS_IGNORE_ENVIRONMENT.store(ignore_environment, Ordering::Relaxed);
     SYS_ISOLATED.store(isolated, Ordering::Relaxed);
@@ -1691,6 +1694,13 @@ pub fn set_runtime_flags(
 
 pub fn quiet_flag() -> bool {
     SYS_QUIET.load(Ordering::Relaxed)
+}
+
+/// `-i`, which `make_flags` reports as both `inspect` and `interactive`.
+/// `PYTHONINSPECT` would set only the former, but the launcher does not
+/// read it, so `-i` is the whole of this flag's input.
+pub fn inspect_flag() -> bool {
+    SYS_INSPECT.load(Ordering::Relaxed)
 }
 
 pub fn no_user_site_flag() -> bool {

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -3032,9 +3032,10 @@ pub fn dunder_import(
                     level,
                 );
             }
+            let w_name = pyre_object::w_str_new(name);
             return call_bootstrap_import(
                 shadow_stack_get(import_slot),
-                pyre_object::w_str_new(name),
+                w_name,
                 shadow_stack_get(globals_slot),
                 shadow_stack_get(locals_slot),
                 if fromlist_missing {

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -3094,6 +3094,11 @@ pub fn dunder_import_name_obj(
         w_locals
     });
     let fromlist_slot = shadow_stack_len();
+    let w_fromlist = if w_fromlist.is_null() {
+        pyre_object::w_none()
+    } else {
+        w_fromlist
+    };
     pin_root(w_fromlist);
 
     let bootstrap = if let Some(w_bootstrap) = get_sys_module("importlib._bootstrap") {

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -2986,33 +2986,18 @@ pub fn dunder_import(
                     level,
                 );
             }
-            let w_name = pyre_object::w_str_new(name);
-            let name_slot = shadow_stack_len();
-            pin_root(w_name);
-            let w_level = pyre_object::w_int_new(level);
-            let level_slot = shadow_stack_len();
-            pin_root(w_level);
-            // An omitted fromlist reaches `__import__` as its `()` default,
-            // not `None` (interp_import.py `WrappedDefault(())`).
-            let call_fromlist_slot = if fromlist_missing {
-                let w_empty = pyre_object::w_tuple_new(vec![]);
-                let slot = shadow_stack_len();
-                pin_root(w_empty);
-                slot
-            } else {
-                fromlist_slot
-            };
-            return crate::call::call_function_impl_result(
+            return call_bootstrap_import(
                 shadow_stack_get(import_slot),
-                &[
-                    shadow_stack_get(name_slot),
-                    shadow_stack_get(globals_slot),
-                    shadow_stack_get(locals_slot),
-                    shadow_stack_get(call_fromlist_slot),
-                    shadow_stack_get(level_slot),
-                ],
-            )
-            .map_err(strip_bootstrap_traceback_frames);
+                pyre_object::w_str_new(name),
+                shadow_stack_get(globals_slot),
+                shadow_stack_get(locals_slot),
+                if fromlist_missing {
+                    pyre_object::PY_NULL
+                } else {
+                    shadow_stack_get(fromlist_slot)
+                },
+                level,
+            );
         }
     }
     importhook(
@@ -3029,6 +3014,110 @@ pub fn dunder_import(
         },
         level,
         execution_context,
+    )
+}
+
+/// Invoke the app-level `_bootstrap.__import__`.  A null `w_fromlist` means the
+/// argument was omitted, which reaches `__import__` as its `()` default rather
+/// than as `None` (interp_import.py `WrappedDefault(())`).
+fn call_bootstrap_import(
+    w_import: PyObjectRef,
+    w_name: PyObjectRef,
+    w_globals: PyObjectRef,
+    w_locals: PyObjectRef,
+    w_fromlist: PyObjectRef,
+    level: i64,
+) -> Result<PyObjectRef, crate::PyError> {
+    use pyre_object::gc_roots::{pin_root, push_roots, shadow_stack_get, shadow_stack_len};
+
+    let _roots = push_roots();
+    let import_slot = shadow_stack_len();
+    pin_root(w_import);
+    let name_slot = shadow_stack_len();
+    pin_root(w_name);
+    let globals_slot = shadow_stack_len();
+    pin_root(w_globals);
+    let locals_slot = shadow_stack_len();
+    pin_root(w_locals);
+    let fromlist_slot = shadow_stack_len();
+    pin_root(if w_fromlist.is_null() {
+        pyre_object::w_tuple_new(vec![])
+    } else {
+        w_fromlist
+    });
+    let level_slot = shadow_stack_len();
+    pin_root(pyre_object::w_int_new(level));
+    crate::call::call_function_impl_result(
+        shadow_stack_get(import_slot),
+        &[
+            shadow_stack_get(name_slot),
+            shadow_stack_get(globals_slot),
+            shadow_stack_get(locals_slot),
+            shadow_stack_get(fromlist_slot),
+            shadow_stack_get(level_slot),
+        ],
+    )
+    .map_err(strip_bootstrap_traceback_frames)
+}
+
+/// `__import__` for a name with no `&str` spelling.
+///
+/// Every native lookup — `sys.modules`, the builtin registry, the frozen table
+/// and the path search — is `&str`-keyed and can hold no such name, so the
+/// app-level `_bootstrap.__import__` runs it with the name object as given,
+/// which keeps the dotted-name, `level` and `fromlist` handling intact.
+pub fn dunder_import_name_obj(
+    w_name: PyObjectRef,
+    w_globals: PyObjectRef,
+    w_locals: PyObjectRef,
+    w_fromlist: PyObjectRef,
+    level: i64,
+) -> Result<PyObjectRef, crate::PyError> {
+    use pyre_object::gc_roots::{pin_root, push_roots, shadow_stack_get, shadow_stack_len};
+
+    let _roots = push_roots();
+    let name_slot = shadow_stack_len();
+    pin_root(w_name);
+    let globals_slot = shadow_stack_len();
+    pin_root(if w_globals.is_null() {
+        pyre_object::w_none()
+    } else {
+        w_globals
+    });
+    let locals_slot = shadow_stack_len();
+    pin_root(if w_locals.is_null() {
+        pyre_object::w_none()
+    } else {
+        w_locals
+    });
+    let fromlist_slot = shadow_stack_len();
+    pin_root(w_fromlist);
+
+    let bootstrap = get_sys_module("importlib._bootstrap").and_then(|w_bootstrap| {
+        let bootstrap_slot = shadow_stack_len();
+        pin_root(w_bootstrap);
+        crate::baseobjspace::findattr_result(shadow_stack_get(bootstrap_slot), "__import__")
+            .ok()
+            .flatten()
+    });
+    let Some(w_import) = bootstrap else {
+        // The bootstrap is not importable yet, and no native lookup can serve
+        // this name, so it is reported missing.
+        let repr = crate::display::format_wtf8_repr(unsafe {
+            pyre_object::w_str_get_wtf8(shadow_stack_get(name_slot))
+        });
+        return Err(crate::PyError::module_not_found_with_name_obj(
+            format!("No module named {repr}"),
+            shadow_stack_get(name_slot),
+        ));
+    };
+    call_bootstrap_import(
+        w_import,
+        shadow_stack_get(name_slot),
+        shadow_stack_get(globals_slot),
+        shadow_stack_get(locals_slot),
+        shadow_stack_get(fromlist_slot),
+        level,
     )
 }
 

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -2790,11 +2790,21 @@ pub fn import_name(
 // ── __import__ ───────────────────────────────────────────────────────
 // PyPy equivalent: _frozen_importlib/interp_import.py `interp___import__`
 
-/// `_gcd_import` fast path: the already-imported, fully-initialised module
-/// for `name`, or `None` when the slow path must run — a missing
-/// `sys.modules` entry, a missing `__spec__`, or a module whose
-/// `__spec__._initializing` is still true.  A `__spec__` without
-/// `_initializing` counts as initialised (a builtin module).
+/// `_gcd_import` fast path: the already-imported module for `name`, after
+/// waiting for another thread to finish initialising it.
+///
+/// PyPy's `interp_import.py:_gcd_import` performs the same `sys.modules` /
+/// `__spec__._initializing` inspection.  CPython 3.14's
+/// `import_ensure_initialized` supplies the missing concurrent-import tail:
+/// call `_lock_unlock_module`, whose deadlock handler deliberately accepts a
+/// partially initialised module for a concurrent circular import.  Re-read
+/// `sys.modules` afterwards, as `PyImport_ImportModuleLevelObject` does, so an
+/// import that failed and removed or replaced its module is retried by the
+/// slow path instead of returning a stale object.
+///
+/// `None` means the slow path must run — a missing `sys.modules` entry, a
+/// missing `__spec__`, or an entry removed/replaced while we waited.  A
+/// `__spec__` without `_initializing` counts as initialised (a builtin module).
 fn gcd_import_fast(name: &str) -> Result<Option<PyObjectRef>, crate::PyError> {
     use pyre_object::gc_roots::{pin_root, push_roots, shadow_stack_get, shadow_stack_len};
 
@@ -2822,7 +2832,33 @@ fn gcd_import_fast(name: &str) -> Result<Option<PyObjectRef>, crate::PyError> {
         crate::baseobjspace::findattr_result(shadow_stack_get(spec_slot), "_initializing")?
     {
         if crate::baseobjspace::is_true(w_initializing)? {
-            return Ok(None);
+            let Some(w_bootstrap) = get_sys_module("importlib._bootstrap") else {
+                return Ok(None);
+            };
+            let bootstrap_slot = shadow_stack_len();
+            pin_root(w_bootstrap);
+            let Some(w_lock_unlock) = crate::baseobjspace::findattr_result(
+                shadow_stack_get(bootstrap_slot),
+                "_lock_unlock_module",
+            )?
+            else {
+                return Ok(None);
+            };
+            let lock_unlock_slot = shadow_stack_len();
+            pin_root(w_lock_unlock);
+            let name_slot = shadow_stack_len();
+            pin_root(pyre_object::w_str_new(name));
+            crate::call::call_function_impl_result(
+                shadow_stack_get(lock_unlock_slot),
+                &[shadow_stack_get(name_slot)],
+            )?;
+
+            let Some(w_current) = check_sys_modules(name) else {
+                return Ok(None);
+            };
+            if w_current != shadow_stack_get(mod_slot) {
+                return Ok(None);
+            }
         }
     }
     Ok(Some(shadow_stack_get(mod_slot)))

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -1641,6 +1641,7 @@ thread_local! {
 // thread — a codec lookup, `sys.flags`, an embedder calling in — observes
 // the values the launcher recorded instead of the per-thread default.
 static SYS_NO_SITE: AtomicBool = AtomicBool::new(false);
+static SYS_QUIET: AtomicBool = AtomicBool::new(false);
 static SYS_NO_USER_SITE: AtomicBool = AtomicBool::new(false);
 static SYS_IGNORE_ENVIRONMENT: AtomicBool = AtomicBool::new(false);
 static SYS_ISOLATED: AtomicBool = AtomicBool::new(false);
@@ -1667,6 +1668,7 @@ pub fn no_site_flag() -> bool {
 /// `space.sys.get_flag('dev_mode')` in `unicodeobject.py`.
 #[allow(clippy::too_many_arguments)]
 pub fn set_runtime_flags(
+    quiet: bool,
     no_user_site: bool,
     ignore_environment: bool,
     isolated: bool,
@@ -1676,6 +1678,7 @@ pub fn set_runtime_flags(
     optimize: i64,
     dont_write_bytecode: bool,
 ) {
+    SYS_QUIET.store(quiet, Ordering::Relaxed);
     SYS_NO_USER_SITE.store(no_user_site, Ordering::Relaxed);
     SYS_IGNORE_ENVIRONMENT.store(ignore_environment, Ordering::Relaxed);
     SYS_ISOLATED.store(isolated, Ordering::Relaxed);
@@ -1684,6 +1687,10 @@ pub fn set_runtime_flags(
     SYS_SAFE_PATH.store(safe_path, Ordering::Relaxed);
     SYS_OPTIMIZE.store(optimize, Ordering::Relaxed);
     SYS_DONT_WRITE_BYTECODE.store(dont_write_bytecode, Ordering::Relaxed);
+}
+
+pub fn quiet_flag() -> bool {
+    SYS_QUIET.load(Ordering::Relaxed)
 }
 
 pub fn no_user_site_flag() -> bool {

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -507,7 +507,10 @@ pub fn install_builtin_modules() {
     #[cfg(not(target_arch = "wasm32"))]
     pyre_install_module!(time);
     pyre_install_module!(sys);
-    pyre_install_module!(operator);
+    // `moduledef.py:5 applevel_name = '_operator'` — the interp-level table
+    // is reachable only as `_operator`; `import operator` resolves to
+    // `operator.py`, whose `from _operator import *` drops the underscore
+    // names the table also carries.
     pyre_install_module!("_operator"(operator));
     pyre_install_module!("builtins"(__builtin__));
     pyre_install_module!(_io);

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -3096,13 +3096,13 @@ pub fn dunder_import_name_obj(
     let fromlist_slot = shadow_stack_len();
     pin_root(w_fromlist);
 
-    let bootstrap = get_sys_module("importlib._bootstrap").and_then(|w_bootstrap| {
+    let bootstrap = if let Some(w_bootstrap) = get_sys_module("importlib._bootstrap") {
         let bootstrap_slot = shadow_stack_len();
         pin_root(w_bootstrap);
-        crate::baseobjspace::findattr_result(shadow_stack_get(bootstrap_slot), "__import__")
-            .ok()
-            .flatten()
-    });
+        crate::baseobjspace::findattr_result(shadow_stack_get(bootstrap_slot), "__import__")?
+    } else {
+        None
+    };
     let Some(w_import) = bootstrap else {
         // The bootstrap is not importable yet, and no native lookup can serve
         // this name, so it is reported missing.

--- a/pyre/pyre-interpreter/src/lib.rs
+++ b/pyre/pyre-interpreter/src/lib.rs
@@ -556,7 +556,7 @@ macro_rules! py_checked_arity_fn {
                             ::pyre_object::PyObjectRef,
                             $crate::PyError,
                         > {
-                            $crate::gateway::check_declared_arity($key, $arity, args.len())?;
+                            $crate::gateway::check_declared_positional_arity($key, $arity, args)?;
                             // The annotation is what gives a bare `|args| ...` body its
                             // parameter type; the coercion to a pointer is a no-op.
                             let __pyre_body: $crate::BuiltinCodeFn = $path;

--- a/pyre/pyre-interpreter/src/lib.rs
+++ b/pyre/pyre-interpreter/src/lib.rs
@@ -292,7 +292,7 @@ macro_rules! py_module {
                         $crate::make_module_builtin_function_with_arity_and_maybe_sig(
                             stringify!($ifn_name),
                             $ifn_name,
-                            $crate::pyre_typed_args_arity!($($ifn_args)*),
+                            ::paste::paste! { [<$ifn_name _pyre_arity>]() },
                             ::paste::paste! { [<$ifn_name _pyre_sig>]() },
                         ),
                     );
@@ -318,50 +318,6 @@ macro_rules! py_module {
             )?
         }
     };
-}
-
-/// Count typed `name: ty` arguments in a `fn` parameter list.  Used by
-/// `py_module!`'s `inline_functions:` arm to derive arity from the
-/// signature.  Treats `&[PyObjectRef]` varargs as zero (caller should
-/// route those through path-ref `functions:` form instead).  Each
-/// parameter may carry leading attributes (`#[default(...)]`,
-/// `#[kwonly]`, `#[kwargs]`) — they are consumed and ignored here; the
-/// `#[pyre_function]` expansion strips them from the emitted fn.
-#[macro_export]
-macro_rules! pyre_count_typed_args {
-    () => { 0usize };
-    ( $(#[$m:meta])* $a:ident : $t:ty ) => { 1usize };
-    ( $(#[$m:meta])* $a:ident : $t:ty, $($rest:tt)* ) => {
-        1usize + $crate::pyre_count_typed_args!($($rest)*)
-    };
-}
-
-/// Count the leading parameters that a caller must supply — the prefix
-/// before the first `#[default(...)]`.  A `#[default(...)]` arm is listed
-/// ahead of the catch-all so it wins over the `#[$m:meta]` repetition.
-#[macro_export]
-macro_rules! pyre_count_required_typed_args {
-    () => { 0usize };
-    ( #[default($($d:tt)*)] $($rest:tt)* ) => { 0usize };
-    ( $(#[$m:meta])* $a:ident : $t:ty ) => { 1usize };
-    ( $(#[$m:meta])* $a:ident : $t:ty, $($rest:tt)* ) => {
-        1usize + $crate::pyre_count_required_typed_args!($($rest)*)
-    };
-}
-
-/// The `fast_natural_arity` a typed parameter list declares.  A parameter
-/// with a `#[default(...)]` makes the call variadic, so the whole list is
-/// `HOPELESS` rather than a fixed count the call machinery may enforce.
-#[macro_export]
-macro_rules! pyre_typed_args_arity {
-    ( $($args:tt)* ) => {{
-        let total = $crate::pyre_count_typed_args!($($args)*);
-        if total == $crate::pyre_count_required_typed_args!($($args)*) {
-            total as u16
-        } else {
-            $crate::HOPELESS
-        }
-    }};
 }
 
 /// PyPy `class W_X(W_Root) + TypeDef(...)` equivalent — emits a thread-
@@ -572,13 +528,40 @@ macro_rules! py_class_typed {
 /// every mixed-module function to `BuiltinFunction`, whose typedef omits
 /// `__get__`), so storing one on a user class must not synthesize a bound
 /// method — identical to the `module_functions:` arm.
+///
+/// A declared arity is also enforced: the body behind it indexes exactly that
+/// many slots, so `check_declared_arity` runs first and a call that does not
+/// fit raises `TypeError` instead of reading past the end of `args`.  A body
+/// that accepts a range of counts declares `*` and checks itself.
 #[macro_export]
 macro_rules! py_module_fn {
     ($key:literal, *, $path:expr) => {
         $crate::make_module_builtin_function($key, $path)
     };
     ($key:literal, $arity:literal, $path:expr) => {
-        $crate::make_module_builtin_function_with_arity($key, $path, $arity)
+        $crate::make_module_builtin_function_with_arity(
+            $key,
+            $crate::py_checked_arity_fn!($key, $arity, $path),
+            $arity,
+        )
+    };
+}
+
+/// Wrap a declared-arity builtin body in its positional-count check.  The
+/// wrapper captures nothing, so it still coerces to a `BuiltinCodeFn` pointer.
+#[macro_export]
+macro_rules! py_checked_arity_fn {
+    ($key:literal, $arity:literal, $path:expr) => {
+        |args: &[::pyre_object::PyObjectRef]| -> ::std::result::Result<
+                            ::pyre_object::PyObjectRef,
+                            $crate::PyError,
+                        > {
+                            $crate::gateway::check_declared_arity($key, $arity, args.len())?;
+                            // The annotation is what gives a bare `|args| ...` body its
+                            // parameter type; the coercion to a pointer is a no-op.
+                            let __pyre_body: $crate::BuiltinCodeFn = $path;
+                            __pyre_body(args)
+                        }
     };
 }
 
@@ -591,7 +574,11 @@ macro_rules! py_module_module_fn {
         $crate::make_module_builtin_function($key, $path)
     };
     ($key:literal, $arity:literal, $path:expr) => {
-        $crate::make_module_builtin_function_with_arity($key, $path, $arity)
+        $crate::make_module_builtin_function_with_arity(
+            $key,
+            $crate::py_checked_arity_fn!($key, $arity, $path),
+            $arity,
+        )
     };
 }
 

--- a/pyre/pyre-interpreter/src/lib.rs
+++ b/pyre/pyre-interpreter/src/lib.rs
@@ -785,12 +785,12 @@ pub use gateway::{
     PASSTHROUGHARGS1, Signature, SignatureBuilder, builtin_code_call, builtin_code_get,
     builtin_code_get_fast_natural_arity, builtin_code_get_signature, builtin_code_name,
     builtin_code_new, builtin_code_new_passthrough_args1, builtin_code_new_with_arity,
-    builtin_code_new_with_signature, is_builtin_code, make_builtin_function,
-    make_builtin_function_maybe_sig, make_builtin_function_passthrough_args1,
-    make_builtin_function_with_arity, make_builtin_function_with_arity_and_maybe_sig,
-    make_builtin_function_with_signature, make_module_builtin_function,
-    make_module_builtin_function_with_arity, make_module_builtin_function_with_arity_and_maybe_sig,
-    make_slot_wrapper_with_arity,
+    builtin_code_new_with_signature, builtin_code_no_keyword_arguments, is_builtin_code,
+    make_builtin_function, make_builtin_function_maybe_sig,
+    make_builtin_function_passthrough_args1, make_builtin_function_with_arity,
+    make_builtin_function_with_arity_and_maybe_sig, make_builtin_function_with_signature,
+    make_module_builtin_function, make_module_builtin_function_with_arity,
+    make_module_builtin_function_with_arity_and_maybe_sig, make_slot_wrapper_with_arity,
 };
 pub use jit_fnaddr::*;
 pub use opcode_ops::*;

--- a/pyre/pyre-interpreter/src/module/_codecs/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_codecs/mod.rs
@@ -317,7 +317,7 @@ fn exception_encoding(exc: &CodecException) -> Result<(usize, StandardEncoding),
     if !unsafe { is_str(w_encoding) } {
         return Err(unsafe { crate::PyError::from_exc_object(exc.w_exc) });
     }
-    standard_encoding(unsafe { w_str_get_value(w_encoding) })
+    standard_encoding(crate::baseobjspace::str_utf8_w(w_encoding)?)
         .ok_or_else(|| unsafe { crate::PyError::from_exc_object(exc.w_exc) })
 }
 
@@ -496,7 +496,7 @@ fn lookup_error(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
             "lookup_error() argument must be str",
         ));
     }
-    let errors = unsafe { w_str_get_value(w_errors) };
+    let errors = crate::baseobjspace::str_utf8_w(w_errors)?;
     if let Some(w_handler) = with_codec_state(|state| unsafe {
         pyre_object::dictmultiobject::w_dict_getitem_str(state.codec_error_registry, errors)
     }) {
@@ -522,7 +522,7 @@ fn register_error(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     if !is_callable(w_handler) {
         return Err(crate::PyError::type_error("argument must be callable"));
     }
-    let errors = unsafe { w_str_get_value(w_errors) };
+    let errors = crate::baseobjspace::str_utf8_w(w_errors)?;
     with_codec_state(|state| unsafe {
         pyre_object::dictmultiobject::w_dict_setitem_str(
             state.codec_error_registry,
@@ -590,7 +590,7 @@ fn lookup_codec(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     if !unsafe { is_str(w_encoding) } {
         return Err(crate::PyError::type_error("lookup() argument must be str"));
     }
-    let encoding = unsafe { w_str_get_value(w_encoding) }.to_string();
+    let encoding = crate::baseobjspace::str_utf8_w(w_encoding)?.to_string();
     let normalized_encoding = normalize(&encoding);
 
     with_codec_state(|state| {
@@ -732,7 +732,7 @@ fn forget_codec(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     if !unsafe { is_str(w_encoding) } {
         return Ok(w_none());
     }
-    let normalized_encoding = normalize(unsafe { w_str_get_value(w_encoding) });
+    let normalized_encoding = normalize(crate::baseobjspace::str_utf8_w(w_encoding)?);
     with_codec_state(|state| {
         let w_cache = state.codec_search_cache;
         let w_key = w_str_new(&normalized_encoding);
@@ -806,7 +806,7 @@ fn utf16_32_ex_decode_impl(
     let errors = if unsafe { pyre_object::is_none(errors) } {
         "strict"
     } else if unsafe { is_str(errors) } {
-        unsafe { w_str_get_value(errors) }
+        crate::baseobjspace::str_utf8_w(errors)?
     } else {
         return Err(crate::PyError::type_error("errors must be str or None"));
     };
@@ -846,7 +846,7 @@ fn utf16_32_decode_impl(
     let errors = if unsafe { pyre_object::is_none(errors) } {
         "strict"
     } else if unsafe { is_str(errors) } {
-        unsafe { w_str_get_value(errors) }
+        crate::baseobjspace::str_utf8_w(errors)?
     } else {
         return Err(crate::PyError::type_error("errors must be str or None"));
     };
@@ -876,7 +876,7 @@ fn utf8_decode_impl(
     let errors = if unsafe { pyre_object::is_none(errors) } {
         "strict"
     } else if unsafe { is_str(errors) } {
-        unsafe { w_str_get_value(errors) }
+        crate::baseobjspace::str_utf8_w(errors)?
     } else {
         return Err(crate::PyError::type_error("errors must be str or None"));
     };
@@ -906,7 +906,7 @@ fn charmap_encode_impl(
         ));
     }
     let errors_s = if unsafe { is_str(errors) } {
-        unsafe { w_str_get_value(errors) }
+        crate::baseobjspace::str_utf8_w(errors)?
     } else {
         "strict"
     };
@@ -983,7 +983,7 @@ fn charmap_decode_impl(
         ));
     }
     let errors_s = if unsafe { is_str(errors) } {
-        unsafe { w_str_get_value(errors) }
+        crate::baseobjspace::str_utf8_w(errors)?
     } else {
         "strict"
     };
@@ -1277,7 +1277,7 @@ fn utf7_decode_impl(
     }
     // PyPy `unicodehelper.py:str_decode_utf_7`.
     let errors_s = if unsafe { is_str(errors) } {
-        unsafe { w_str_get_value(errors) }
+        crate::baseobjspace::str_utf8_w(errors)?
     } else {
         "strict"
     };
@@ -1604,7 +1604,7 @@ fn unicode_escape_decode_impl(
         ));
     };
     let errors_s = if unsafe { is_str(errors) } {
-        unsafe { w_str_get_value(errors) }
+        crate::baseobjspace::str_utf8_w(errors)?
     } else {
         "strict"
     };
@@ -1733,7 +1733,7 @@ fn escape_decode_impl(
         ));
     };
     let errors_s = if unsafe { is_str(errors) } {
-        unsafe { w_str_get_value(errors) }
+        crate::baseobjspace::str_utf8_w(errors)?
     } else if unsafe { pyre_object::is_none(errors) } {
         "strict"
     } else {

--- a/pyre/pyre-interpreter/src/module/_ctypes/interp_ctypes.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/interp_ctypes.rs
@@ -79,7 +79,7 @@ fn register_host_ctypes(ns: pyre_object::PyObjectRef) {
                     String::from_utf8_lossy(pyre_object::bytesobject::w_bytes_data(args[0]))
                         .into_owned()
                 } else if pyre_object::is_str(args[0]) {
-                    pyre_object::w_str_get_value(args[0]).to_string()
+                    crate::baseobjspace::str_utf8_w(args[0])?.to_string()
                 } else {
                     return Err(crate::PyError::type_error(
                         "dlopen: name must be a string, bytes or None",
@@ -112,7 +112,7 @@ fn register_host_ctypes(ns: pyre_object::PyObjectRef) {
                     if !pyre_object::is_str(args[1]) {
                         return Err(crate::PyError::type_error("dlsym: name must be a string"));
                     }
-                    pyre_object::w_str_get_value(args[1]).to_string()
+                    crate::baseobjspace::str_utf8_w(args[1])?.to_string()
                 };
                 let addr =
                     rustpython_host_env::ctypes::lookup_function_symbol_addr(h, name.as_bytes())
@@ -192,7 +192,7 @@ fn register_host_ctypes(ns: pyre_object::PyObjectRef) {
                         "_sizeof_typecode() needs typecode string",
                     ));
                 }
-                let code = unsafe { pyre_object::w_str_get_value(args[0]).to_string() };
+                let code = crate::baseobjspace::str_utf8_w(args[0])?.to_string();
                 match rustpython_host_env::ctypes::simple_type_size(&code) {
                     Some(n) => Ok(pyre_object::w_int_new(n as i64)),
                     None => Err(crate::PyError::value_error(format!(
@@ -214,7 +214,7 @@ fn register_host_ctypes(ns: pyre_object::PyObjectRef) {
                         "_alignof_typecode() needs typecode string",
                     ));
                 }
-                let code = unsafe { pyre_object::w_str_get_value(args[0]).to_string() };
+                let code = crate::baseobjspace::str_utf8_w(args[0])?.to_string();
                 match rustpython_host_env::ctypes::simple_type_align(&code) {
                     Some(n) => Ok(pyre_object::w_int_new(n as i64)),
                     None => Err(crate::PyError::value_error(format!(
@@ -283,7 +283,7 @@ fn register_host_ctypes(ns: pyre_object::PyObjectRef) {
             if !unsafe { pyre_object::is_str(path) } {
                 return Err(crate::PyError::type_error("path must be a string"));
             }
-            let path = unsafe { pyre_object::w_str_get_value(path) };
+            let path = crate::baseobjspace::str_utf8_w(path)?;
             let found = host_ctypes::dyld_shared_cache_contains_path(path)
                 .map_err(|_| crate::PyError::value_error("path contains null byte"))?;
             Ok(pyre_object::w_bool_from(found))

--- a/pyre/pyre-interpreter/src/module/_hashlib/_hashlib_app.py
+++ b/pyre/pyre-interpreter/src/module/_hashlib/_hashlib_app.py
@@ -23,6 +23,8 @@ _BLOCK_SIZE = {
 
 class HASH:
     def __init__(self, name, data=b""):
+        import _hashlib
+        _hashlib._check_digest_name(name)
         self._name = name
         self._data = bytearray()
         if data:

--- a/pyre/pyre-interpreter/src/module/_hashlib/_hashlib_app.py
+++ b/pyre/pyre-interpreter/src/module/_hashlib/_hashlib_app.py
@@ -24,8 +24,10 @@ _BLOCK_SIZE = {
 class HASH:
     def __init__(self, name, data=b""):
         import _hashlib
-        _hashlib._check_digest_name(name)
-        self._name = name
+        # The digest is named by the entry the name resolved to, so `name`,
+        # `digest_size`, `block_size` and the digest itself all read the same
+        # spelling however the caller spelled it.
+        self._name = _hashlib._resolve_digest_name(name)
         self._data = bytearray()
         if data:
             self.update(data)

--- a/pyre/pyre-interpreter/src/module/_hashlib/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_hashlib/mod.rs
@@ -54,6 +54,23 @@ fn oneshot_digest(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     }
 }
 
+/// `HASH(name)` name check.  OpenSSL resolves the digest when the context is
+/// created, so an unknown name is reported there rather than when the digest
+/// is finally taken.
+fn check_digest_name(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let name_obj = args.first().copied().unwrap_or_else(w_none);
+    if !unsafe { is_str(name_obj) } {
+        return Err(crate::PyError::type_error("digest name must be a string"));
+    }
+    let name = crate::baseobjspace::str_utf8_w(name_obj)?;
+    if !ALGORITHMS.contains(&name) {
+        return Err(unsupported_digestmod(&format!(
+            "unsupported hash type {name}"
+        )));
+    }
+    Ok(w_none())
+}
+
 /// Build a `PyError` raising `_hashlib.UnsupportedDigestmodError` with `msg`.
 /// `hmac.py` catches this to fall back to its pure-Python HMAC, so the OpenSSL
 /// HMAC entry points always raise it: we have no streaming HMAC primitive.
@@ -137,6 +154,7 @@ crate::py_module! {
     },
     functions: {
         "_oneshot_digest" / * = oneshot_digest,
+        "_check_digest_name" / 1 = check_digest_name,
         "compare_digest" / 2 = compare_digest,
         "hmac_new" / * = hmac_new,
         "hmac_digest" / * = hmac_digest,

--- a/pyre/pyre-interpreter/src/module/_hashlib/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_hashlib/mod.rs
@@ -33,7 +33,7 @@ fn oneshot_digest(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     if !unsafe { is_str(name_obj) } {
         return Err(crate::PyError::type_error("digest name must be a string"));
     }
-    let name = unsafe { w_str_get_value(name_obj) }.to_string();
+    let name = crate::baseobjspace::str_utf8_w(name_obj)?.to_string();
     let data = match args.get(1).copied() {
         Some(obj) if unsafe { bytesobject::is_bytes_like(obj) } => {
             unsafe { bytesobject::bytes_like_data(obj) }.to_vec()
@@ -85,8 +85,11 @@ fn compare_digest(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let read = |obj: PyObjectRef| -> Result<Vec<u8>, crate::PyError> {
         unsafe {
             if is_str(obj) {
-                let s = w_str_get_value(obj);
-                if !s.is_ascii() {
+                // The ASCII check runs on the raw buffer: a lone surrogate is
+                // non-ASCII, so it takes the same rejection as any other
+                // non-ASCII character.
+                let s = w_str_get_wtf8(obj);
+                if !s.as_bytes().is_ascii() {
                     return Err(crate::PyError::type_error(
                         "comparing strings with non-ASCII characters is not supported",
                     ));

--- a/pyre/pyre-interpreter/src/module/_hashlib/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_hashlib/mod.rs
@@ -9,23 +9,53 @@
 
 use pyre_object::*;
 
-/// The 14 always-supported digests hashlib advertises.
-const ALGORITHMS: &[&str] = &[
-    "md5",
-    "sha1",
-    "sha224",
-    "sha256",
-    "sha384",
-    "sha512",
-    "sha3_224",
-    "sha3_256",
-    "sha3_384",
-    "sha3_512",
-    "shake_128",
-    "shake_256",
-    "blake2b",
-    "blake2s",
+/// The 14 always-supported digests hashlib advertises, each with the OpenSSL
+/// names that also select it.
+///
+/// `py_digest_by_name` consults two tables in turn: the Python names, matched
+/// exactly, then the OpenSSL names, matched without regard to case.  That
+/// asymmetry decides which spellings resolve — `sha3_256` does and `SHA3_256`
+/// does not, because the OpenSSL spelling is `SHA3-256`; `blake2b` does and
+/// `Blake2b` does not, because the OpenSSL spelling is `BLAKE2B512`.
+///
+/// The digest an object computes is named by the entry it resolved to, not by
+/// the spelling the caller used, so `new('sha-256').name` is `sha256`.
+const DIGEST_NAMES: &[(&str, &[&str])] = &[
+    ("md5", &["MD5", "SSL3-MD5"]),
+    ("sha1", &["SHA1", "SSL3-SHA1"]),
+    ("sha224", &["SHA224", "SHA2-224", "SHA-224"]),
+    ("sha256", &["SHA256", "SHA2-256", "SHA-256"]),
+    ("sha384", &["SHA384", "SHA2-384", "SHA-384"]),
+    ("sha512", &["SHA512", "SHA2-512", "SHA-512"]),
+    ("sha3_224", &["SHA3-224"]),
+    ("sha3_256", &["SHA3-256"]),
+    ("sha3_384", &["SHA3-384"]),
+    ("sha3_512", &["SHA3-512"]),
+    ("shake_128", &["SHAKE128", "SHAKE-128"]),
+    ("shake_256", &["SHAKE256", "SHAKE-256"]),
+    ("blake2b", &["BLAKE2B512"]),
+    ("blake2s", &["BLAKE2S256"]),
 ];
+
+/// The entry `name` selects, or `None` when it names no digest this build
+/// computes.  Numeric object identifiers are not accepted: resolving those
+/// needs the OpenSSL object database, which pyre does not carry.
+fn lookup_digest_name(name: &[u8]) -> Option<&'static str> {
+    if let Some((python_name, _)) = DIGEST_NAMES
+        .iter()
+        .find(|(python_name, _)| python_name.as_bytes() == name)
+    {
+        return Some(python_name);
+    }
+    DIGEST_NAMES
+        .iter()
+        .find(|(_, ossl_names)| {
+            ossl_names
+                .iter()
+                .any(|ossl| ossl.as_bytes().eq_ignore_ascii_case(name))
+        })
+        .map(|(python_name, _)| *python_name)
+}
 
 /// `_oneshot_digest(name, data, length=0)` — bytes of the digest.
 fn oneshot_digest(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
@@ -54,21 +84,43 @@ fn oneshot_digest(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     }
 }
 
-/// `HASH(name)` name check.  OpenSSL resolves the digest when the context is
-/// created, so an unknown name is reported there rather than when the digest
-/// is finally taken.
-fn check_digest_name(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+/// `HASH(name)` name resolution — the Python name of the digest `name`
+/// selects.  OpenSSL resolves the digest when the context is created, so an
+/// unknown name is reported there rather than when the digest is finally
+/// taken.
+fn resolve_digest_name(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let name_obj = args.first().copied().unwrap_or_else(w_none);
     if !unsafe { is_str(name_obj) } {
-        return Err(crate::PyError::type_error("digest name must be a string"));
-    }
-    let name = crate::baseobjspace::str_utf8_w(name_obj)?;
-    if !ALGORITHMS.contains(&name) {
-        return Err(unsupported_digestmod(&format!(
-            "unsupported hash type {name}"
+        return Err(crate::PyError::type_error(format!(
+            "new() argument 'name' must be str, not {}",
+            crate::type_methods::arg_type_name(name_obj)
         )));
     }
-    Ok(w_none())
+    // Read off the buffer and report the failures the utf-8 conversion of the
+    // name would: a lone surrogate does not encode, and an embedded null ends
+    // the C string the digest is looked up by.
+    let name = unsafe { w_str_get_wtf8(name_obj) };
+    if let Some(pos) = name
+        .code_points()
+        .position(|cp| (0xD800..=0xDFFF).contains(&cp.to_u32()))
+    {
+        return Err(crate::typedef::unicode_encode_error(
+            "utf-8",
+            name_obj,
+            pos,
+            pos + 1,
+            "surrogates not allowed",
+        ));
+    }
+    if name.as_bytes().contains(&0) {
+        return Err(crate::PyError::value_error("embedded null character"));
+    }
+    match lookup_digest_name(name.as_bytes()) {
+        Some(python_name) => Ok(w_str_new(python_name)),
+        None => Err(unsupported_digestmod(&format!(
+            "unsupported hash type {name}"
+        ))),
+    }
 }
 
 /// Build a `PyError` raising `_hashlib.UnsupportedDigestmodError` with `msg`.
@@ -134,7 +186,8 @@ crate::py_module! {
     "_hashlib",
     interpleveldefs: {
         "openssl_md_meth_names" => {
-            let names: Vec<PyObjectRef> = ALGORITHMS.iter().map(|n| w_str_new(n)).collect();
+            let names: Vec<PyObjectRef> =
+                DIGEST_NAMES.iter().map(|(n, _)| w_str_new(n)).collect();
             w_frozenset_from_items(&names)
         },
     },
@@ -154,7 +207,7 @@ crate::py_module! {
     },
     functions: {
         "_oneshot_digest" / * = oneshot_digest,
-        "_check_digest_name" / 1 = check_digest_name,
+        "_resolve_digest_name" / 1 = resolve_digest_name,
         "compare_digest" / 2 = compare_digest,
         "hmac_new" / * = hmac_new,
         "hmac_digest" / * = hmac_digest,

--- a/pyre/pyre-interpreter/src/module/_locale/interp_locale.rs
+++ b/pyre/pyre-interpreter/src/module/_locale/interp_locale.rs
@@ -282,7 +282,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                             "setlocale: locale must be a string or None",
                         ));
                     }
-                    Some(unsafe { pyre_object::w_str_get_value(args[1]).to_string() })
+                    Some(crate::baseobjspace::str_utf8_w(args[1])?.to_string())
                 } else {
                     None
                 };
@@ -383,8 +383,8 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                             "strcoll: arguments must be strings",
                         ));
                     }
-                    let s1 = unsafe { pyre_object::w_str_get_value(args[0]).to_string() };
-                    let s2 = unsafe { pyre_object::w_str_get_value(args[1]).to_string() };
+                    let s1 = crate::baseobjspace::str_utf8_w(args[0])?.to_string();
+                    let s2 = crate::baseobjspace::str_utf8_w(args[1])?.to_string();
                     let c1 = std::ffi::CString::new(s1.as_bytes())
                         .map_err(|_| crate::PyError::value_error("embedded null character"))?;
                     let c2 = std::ffi::CString::new(s2.as_bytes())
@@ -406,8 +406,8 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     // to lexical bytewise comparison.  Pure computation, no I/O;
                     // under sandbox this keeps the fixed "C" collation and never
                     // calls host libc collation, which would leak host LC_COLLATE.
-                    let s1 = unsafe { pyre_object::w_str_get_value(args[0]).to_string() };
-                    let s2 = unsafe { pyre_object::w_str_get_value(args[1]).to_string() };
+                    let s1 = crate::baseobjspace::str_utf8_w(args[0])?.to_string();
+                    let s2 = crate::baseobjspace::str_utf8_w(args[1])?.to_string();
                     let ord = match s1.as_str().cmp(s2.as_str()) {
                         std::cmp::Ordering::Less => -1,
                         std::cmp::Ordering::Equal => 0,
@@ -433,7 +433,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 }
                 #[cfg(all(unix, feature = "host_env", not(feature = "sandbox")))]
                 {
-                    let sv = unsafe { pyre_object::w_str_get_value(s).to_string() };
+                    let sv = crate::baseobjspace::str_utf8_w(s)?.to_string();
                     let c = std::ffi::CString::new(sv.as_bytes())
                         .map_err(|_| crate::PyError::value_error("embedded null character"))?;
                     let out = rustpython_host_env::locale::strxfrm(&c, sv.len() + 1);

--- a/pyre/pyre-interpreter/src/module/_multiprocessing/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_multiprocessing/mod.rs
@@ -157,7 +157,7 @@ crate::py_module! {
                                 "SemLock: name must be a string",
                             ));
                         }
-                        w_str_get_value(args[3]).to_string()
+                        crate::baseobjspace::str_utf8_w(args[3])?.to_string()
                     };
                     let unlink = unsafe { w_int_get_value(args[4]) } != 0;
                     let (handle, _kept_name) =

--- a/pyre/pyre-interpreter/src/module/_opcode/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_opcode/mod.rs
@@ -132,7 +132,10 @@ crate::py_module! {
         }
     },
     functions: {
-        "stack_effect"             / 3 = stack_effect,
+        // `stack_effect(opcode, oparg=None, *, jump=None)` — the optional
+        // tail and the keyword-only `jump` leave no single natural arity, so
+        // the body enforces the count itself.
+        "stack_effect"             / * = stack_effect,
         "get_executor"             / 0 = |_| Ok(w_none()),
         "get_specialization_stats" / 0 = |_| Ok(w_none()),
         "get_intrinsic1_descs"     / 0 = get_intrinsic1_descs,

--- a/pyre/pyre-interpreter/src/module/_opcode/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_opcode/mod.rs
@@ -55,6 +55,7 @@ fn has_exc(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
 
 fn stack_effect(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let (positional, kwargs) = crate::builtins::split_builtin_kwargs(args);
+    crate::builtins::kwarg_reject_unknown(kwargs, &["jump"], "stack_effect")?;
     if positional.len() > 2 {
         return Err(crate::PyError::type_error(format!(
             "stack_effect() takes at most 2 positional arguments ({} given)",
@@ -136,7 +137,7 @@ crate::py_module! {
         // tail and the keyword-only `jump` leave no single natural arity, so
         // the body enforces the count itself.
         "stack_effect"             / * = stack_effect,
-        "get_executor"             / 0 = |_| Ok(w_none()),
+        "get_executor"             / 2 = |_| Ok(w_none()),
         "get_specialization_stats" / 0 = |_| Ok(w_none()),
         "get_intrinsic1_descs"     / 0 = get_intrinsic1_descs,
         "get_intrinsic2_descs"     / 0 = get_intrinsic2_descs,

--- a/pyre/pyre-interpreter/src/module/_pickle/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_pickle/mod.rs
@@ -412,8 +412,12 @@ pub(crate) fn read_int_le(data: &[u8]) -> i64 {
 }
 
 pub(crate) fn str_from_utf8(data: &[u8]) -> Result<PyObjectRef, PyError> {
-    let s = std::str::from_utf8(data).map_err(|_| unpickling_error("invalid utf-8 in pickle"))?;
-    Ok(pyre_object::w_str_new(s))
+    // The binary string opcodes carry `surrogatepass` UTF-8, which is exactly
+    // the WTF-8 the pickler wrote, so a lone surrogate decodes back to the
+    // code point it was pickled from.
+    let buf = rustpython_wtf8::Wtf8Buf::from_bytes(data.to_vec())
+        .map_err(|_| unpickling_error("invalid utf-8 in pickle"))?;
+    Ok(pyre_object::w_str_from_wtf8(buf))
 }
 
 crate::py_module! {

--- a/pyre/pyre-interpreter/src/module/_pickle/pickler.rs
+++ b/pyre/pyre-interpreter/src/module/_pickle/pickler.rs
@@ -1261,8 +1261,10 @@ fn save_str(ctx: &mut PickleCtx, buf: &mut Framer, w_obj: PyObjectRef) -> Result
     pyre_object::gc_roots::pin_root(w_obj);
     let slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     if ctx.bin {
-        let s = unsafe { pyre_object::unicodeobject::w_str_get_value(w_obj) };
-        let data = s.as_bytes();
+        // The binary opcodes carry the string's `surrogatepass` UTF-8, which is
+        // exactly the backing WTF-8, so the raw buffer is written as-is and a
+        // lone surrogate round-trips instead of demanding a `&str` view.
+        let data = unsafe { pyre_object::unicodeobject::w_str_get_wtf8(w_obj) }.as_bytes();
         let n = data.len();
         if n <= 0xff && ctx.proto >= 4 {
             buf.push(op::SHORT_BINUNICODE);

--- a/pyre/pyre-interpreter/src/module/_posixshmem/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_posixshmem/mod.rs
@@ -21,7 +21,7 @@ fn shm_open(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
                 "shm_open: path must be a string",
             ));
         }
-        w_str_get_value(args[0]).to_string()
+        crate::baseobjspace::str_utf8_w(args[0])?.to_string()
     };
     let flags = (unsafe { w_int_get_value(args[1]) }) as libc::c_int;
     let mode = if args.len() >= 3 {
@@ -58,7 +58,7 @@ fn shm_unlink(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
                 "shm_unlink: path must be a string",
             ));
         }
-        w_str_get_value(args[0]).to_string()
+        crate::baseobjspace::str_utf8_w(args[0])?.to_string()
     };
     let c_name = std::ffi::CString::new(name.as_bytes())
         .map_err(|_| crate::PyError::value_error("embedded null character"))?;

--- a/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
+++ b/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
@@ -95,11 +95,6 @@ struct ServentRaw {
 /// UnicodeEncodeError falls back to `.encode('idna')`.  Embedded null
 /// bytes raise TypeError (matching `:120-122`).  Other input types
 /// raise TypeError.
-///
-/// pyre's `idna` codec presently passes through as UTF-8 instead of
-/// emitting punycode, so non-ASCII hostnames still pass through this
-/// helper without raising but produce incorrect DNS queries — that is
-/// an `encodings/idna` gap, not a `_socket` parity issue.
 #[cfg(unix)]
 fn socket_idna_converter(w_host: pyre_object::PyObjectRef) -> Result<Vec<u8>, crate::PyError> {
     if w_host.is_null() {
@@ -109,15 +104,23 @@ fn socket_idna_converter(w_host: pyre_object::PyObjectRef) -> Result<Vec<u8>, cr
     }
     let bytes: Vec<u8> = unsafe {
         if pyre_object::is_str(w_host) {
-            let s = crate::baseobjspace::str_utf8_w(w_host)?;
-            if s.is_ascii() {
+            // The ASCII attempt reads the raw buffer, so a host that has no
+            // utf-8 view — one carrying a lone surrogate — reaches the `idna`
+            // fallback the same way any other non-ASCII host does.
+            let s = pyre_object::unicodeobject::w_str_get_wtf8(w_host);
+            if s.as_bytes().is_ascii() {
                 s.as_bytes().to_vec()
             } else {
                 let method = crate::baseobjspace::getattr_str(w_host, "encode")?;
                 let codec = pyre_object::w_str_new("idna");
                 let encoded = crate::call_function(method, &[codec]);
                 if encoded.is_null() {
-                    return Err(crate::PyError::type_error("idna encoding failed"));
+                    // The codec's own error is what the caller sees — a host
+                    // the `idna` codec rejects raises that rejection, not a
+                    // substituted one.
+                    return Err(crate::call::take_call_error().unwrap_or_else(|| {
+                        crate::PyError::type_error("idna encoding failed")
+                    }));
                 }
                 if !pyre_object::bytesobject::is_bytes_like(encoded) {
                     return Err(crate::PyError::type_error(

--- a/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
+++ b/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
@@ -109,7 +109,7 @@ fn socket_idna_converter(w_host: pyre_object::PyObjectRef) -> Result<Vec<u8>, cr
     }
     let bytes: Vec<u8> = unsafe {
         if pyre_object::is_str(w_host) {
-            let s = pyre_object::w_str_get_value(w_host);
+            let s = crate::baseobjspace::str_utf8_w(w_host)?;
             if s.is_ascii() {
                 s.as_bytes().to_vec()
             } else {
@@ -561,7 +561,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                                 "inet_aton: arg must be a string",
                             ));
                         }
-                        pyre_object::w_str_get_value(args[0]).to_string()
+                        crate::baseobjspace::str_utf8_w(args[0])?.to_string()
                     };
                     let c = std::ffi::CString::new(s.as_bytes())
                         .map_err(|_| crate::PyError::value_error("embedded null in argument"))?;
@@ -633,7 +633,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                                 "inet_pton: address must be a string",
                             ));
                         }
-                        pyre_object::w_str_get_value(args[1]).to_string()
+                        crate::baseobjspace::str_utf8_w(args[1])?.to_string()
                     };
                     let c_ip = std::ffi::CString::new(ip.as_bytes())
                         .map_err(|_| crate::PyError::value_error("embedded null"))?;
@@ -755,7 +755,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                                 "sethostname: name must be a string",
                             ));
                         }
-                        pyre_object::w_str_get_value(args[0]).to_string()
+                        crate::baseobjspace::str_utf8_w(args[0])?.to_string()
                     };
                     rustpython_host_env::socket::sethostname(&name).map_err(|e| {
                         crate::PyError::os_error_with_errno(
@@ -973,13 +973,13 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                             "getservbyname: name must be a string",
                         ));
                     }
-                    pyre_object::w_str_get_value(args[0]).to_string()
+                    crate::baseobjspace::str_utf8_w(args[0])?.to_string()
                 };
                 let c_name = std::ffi::CString::new(name.as_bytes())
                     .map_err(|_| crate::PyError::value_error("embedded null"))?;
                 let proto_c: Option<std::ffi::CString> =
                     if args.len() >= 2 && unsafe { pyre_object::is_str(args[1]) } {
-                        let p = unsafe { pyre_object::w_str_get_value(args[1]).to_string() };
+                        let p = crate::baseobjspace::str_utf8_w(args[1])?.to_string();
                         Some(
                             std::ffi::CString::new(p.as_bytes())
                                 .map_err(|_| crate::PyError::value_error("embedded null"))?,
@@ -1021,7 +1021,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 let port = (unsafe { pyre_object::w_int_get_value(args[0]) }) as u16;
                 let proto_c: Option<std::ffi::CString> =
                     if args.len() >= 2 && unsafe { pyre_object::is_str(args[1]) } {
-                        let p = unsafe { pyre_object::w_str_get_value(args[1]).to_string() };
+                        let p = crate::baseobjspace::str_utf8_w(args[1])?.to_string();
                         Some(
                             std::ffi::CString::new(p.as_bytes())
                                 .map_err(|_| crate::PyError::value_error("embedded null"))?,
@@ -1191,7 +1191,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                         "getprotobyname: name must be a string",
                     ));
                 }
-                let name = unsafe { pyre_object::w_str_get_value(args[0]).to_string() };
+                let name = crate::baseobjspace::str_utf8_w(args[0])?.to_string();
                 let c_name = std::ffi::CString::new(name.as_bytes())
                     .map_err(|_| crate::PyError::value_error("embedded null in name"))?;
                 let pe = unsafe { libc::getprotobyname(c_name.as_ptr()) };
@@ -1251,7 +1251,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                             "if_nametoindex: name must be a string",
                         ));
                     }
-                    let name = unsafe { pyre_object::w_str_get_value(args[0]).to_string() };
+                    let name = crate::baseobjspace::str_utf8_w(args[0])?.to_string();
                     let c_name = std::ffi::CString::new(name.as_bytes())
                         .map_err(|_| crate::PyError::value_error("embedded null in name"))?;
                     let idx = unsafe { libc::if_nametoindex(c_name.as_ptr()) };
@@ -1610,7 +1610,7 @@ fn init_socket_getaddrinfo(ns: pyre_object::PyObjectRef) {
                 if pyre_object::is_none(host_obj) {
                     None
                 } else if pyre_object::is_str(host_obj) {
-                    let s = pyre_object::w_str_get_value(host_obj).to_string();
+                    let s = crate::baseobjspace::str_utf8_w(host_obj)?.to_string();
                     Some(
                         std::ffi::CString::new(s.as_bytes())
                             .map_err(|_| crate::PyError::value_error("embedded null in host"))?,
@@ -1630,7 +1630,7 @@ fn init_socket_getaddrinfo(ns: pyre_object::PyObjectRef) {
                     let v = pyre_object::w_int_get_value(port_obj);
                     Some(std::ffi::CString::new(format!("{v}")).unwrap())
                 } else if pyre_object::is_str(port_obj) {
-                    let s = pyre_object::w_str_get_value(port_obj).to_string();
+                    let s = crate::baseobjspace::str_utf8_w(port_obj)?.to_string();
                     Some(
                         std::ffi::CString::new(s.as_bytes())
                             .map_err(|_| crate::PyError::value_error("embedded null in port"))?,
@@ -1762,7 +1762,7 @@ fn init_socket_getaddrinfo(ns: pyre_object::PyObjectRef) {
                         "getnameinfo: sockaddr[1] must be an integer",
                     ));
                 }
-                let host = unsafe { pyre_object::w_str_get_value(host_obj).to_string() };
+                let host = crate::baseobjspace::str_utf8_w(host_obj)?.to_string();
                 let port_v = unsafe { pyre_object::w_int_get_value(port_obj) };
 
                 let c_host = std::ffi::CString::new(host.as_bytes())
@@ -2086,7 +2086,7 @@ fn pack_inet_addr(
         };
         let path_bytes_vec: Vec<u8> = unsafe {
             if pyre_object::is_str(path_obj) {
-                pyre_object::w_str_get_value(path_obj)
+                crate::baseobjspace::str_utf8_w(path_obj)?
                     .to_string()
                     .into_bytes()
             } else if pyre_object::bytesobject::is_bytes_like(path_obj) {
@@ -2131,7 +2131,7 @@ fn pack_inet_addr(
         if !pyre_object::is_str(host_obj) {
             return Err(crate::PyError::type_error("address host must be a string"));
         }
-        pyre_object::w_str_get_value(host_obj).to_string()
+        crate::baseobjspace::str_utf8_w(host_obj)?.to_string()
     };
     if !unsafe { pyre_object::is_int(port_obj) } {
         return Err(crate::PyError::type_error(

--- a/pyre/pyre-interpreter/src/module/_sre/interp_sre.rs
+++ b/pyre/pyre-interpreter/src/module/_sre/interp_sre.rs
@@ -14,6 +14,7 @@ use pyre_object::interp_sre::{
     w_sre_match_get_span, w_sre_match_new, w_sre_pattern_new, w_sre_scanner_new,
 };
 use pyre_object::*;
+use rustpython_wtf8::{Wtf8, Wtf8Buf};
 use sre_engine::engine::{Request, SearchIter, State};
 use sre_engine::string::StrDrive;
 
@@ -598,22 +599,22 @@ fn get_code(pat: PyObjectRef) -> Option<&'static [u32]> {
 }
 
 #[inline]
-fn char_len(s: &str) -> usize {
-    s.chars().count()
+fn char_len(s: &Wtf8) -> usize {
+    s.code_points().count()
 }
 
 #[inline]
-fn char_to_byte(s: &str, char_pos: usize) -> usize {
+fn char_to_byte(s: &Wtf8, char_pos: usize) -> usize {
     if char_pos == 0 {
         return 0;
     }
-    s.char_indices()
+    s.code_point_indices()
         .nth(char_pos)
         .map(|(byte_pos, _)| byte_pos)
         .unwrap_or_else(|| s.len())
 }
 
-fn char_slice(s: &str, start: i64, end: i64) -> Option<&str> {
+fn char_slice(s: &Wtf8, start: i64, end: i64) -> Option<&Wtf8> {
     if start < 0 || end < start {
         return None;
     }
@@ -654,9 +655,14 @@ fn normalize_bounds(len: usize, pos: i64, endpos: i64) -> (usize, usize) {
 /// character positions and slices back to `str`) or a bytes-like buffer
 /// (byte positions, slices back to `bytes`).  Mirrors make_ctx's
 /// Utf8/Str/BufMatchContext split (interp_sre.py:220-285).
+///
+/// A `str` subject is driven over its `Wtf8` backing rather than a `&str`
+/// view: the engine walks code points, and a lone surrogate is a code point
+/// with no `&str` spelling, so `re.split('\\.', '\ud800')` matches on it the
+/// same way it matches on any other character.
 #[derive(Clone, Copy)]
 enum Subject {
-    Str(&'static str),
+    Str(&'static Wtf8),
     Bytes(&'static [u8]),
 }
 
@@ -734,7 +740,7 @@ fn make_subject(pat: PyObjectRef, string: PyObjectRef) -> Result<Subject, crate:
                 "cannot use a bytes pattern on a string-like object",
             ));
         }
-        Ok(Subject::Str(unsafe { w_str_get_value(string) }))
+        Ok(Subject::Str(unsafe { w_str_get_wtf8(string) }))
     } else if unsafe { pyre_object::bytesobject::is_bytes_like(string) } {
         if pattern_is_known_unicode(pat) {
             return Err(crate::PyError::type_error(
@@ -779,7 +785,7 @@ fn make_subject(pat: PyObjectRef, string: PyObjectRef) -> Result<Subject, crate:
 /// itself (`w_buffer` is `PY_NULL` and unused).
 unsafe fn subject_of(string: PyObjectRef, w_buffer: PyObjectRef) -> Subject {
     if unsafe { is_str(string) } {
-        Subject::Str(unsafe { w_str_get_value(string) })
+        Subject::Str(unsafe { w_str_get_wtf8(string) })
     } else if unsafe { pyre_object::bytesobject::is_bytes_like(string) } {
         Subject::Bytes(unsafe { pyre_object::bytesobject::bytes_like_data(string) })
     } else {
@@ -792,7 +798,9 @@ unsafe fn subject_of(string: PyObjectRef, w_buffer: PyObjectRef) -> Subject {
 /// group (span `(-1, -1)` or otherwise out of range).
 fn slice_subject(subj: Subject, span: (i64, i64), w_default: PyObjectRef) -> PyObjectRef {
     match subj {
-        Subject::Str(s) => char_slice(s, span.0, span.1).map(w_str_new).unwrap_or(w_default),
+        Subject::Str(s) => char_slice(s, span.0, span.1)
+            .map(|s| w_str_from_wtf8(s.to_owned()))
+            .unwrap_or(w_default),
         Subject::Bytes(b) => byte_slice(b, span.0, span.1)
             .map(pyre_object::bytesobject::w_bytes_from_bytes)
             .unwrap_or(w_default),
@@ -812,7 +820,7 @@ fn empty_subject(subj: Subject) -> PyObjectRef {
 /// subject), for building `sub`/`expand` replacement output.
 fn subject_span_bytes(subj: Subject, span: (i64, i64)) -> Option<&'static [u8]> {
     match subj {
-        Subject::Str(s) => char_slice(s, span.0, span.1).map(str::as_bytes),
+        Subject::Str(s) => char_slice(s, span.0, span.1).map(Wtf8::as_bytes),
         Subject::Bytes(b) => byte_slice(b, span.0, span.1),
     }
 }
@@ -821,7 +829,7 @@ fn subject_span_bytes(subj: Subject, span: (i64, i64)) -> Option<&'static [u8]> 
 /// the (valid UTF-8) builder, or `bytes` (subx result, interp_sre.py:541-548).
 fn finish_output(subj: Subject, out: Vec<u8>) -> PyObjectRef {
     match subj {
-        Subject::Str(_) => w_str_new(&String::from_utf8(out).unwrap_or_default()),
+        Subject::Str(_) => w_str_from_wtf8(Wtf8Buf::from_bytes(out).unwrap_or_default()),
         Subject::Bytes(_) => pyre_object::bytesobject::w_bytes_from_bytes(&out),
     }
 }
@@ -1196,7 +1204,7 @@ fn subx(args: &[PyObjectRef]) -> Result<(PyObjectRef, i64), crate::PyError> {
                         "sub: replacement must be str or callable",
                     ));
                 }
-                (unsafe { w_str_get_value(w_repl) }.as_bytes(), false)
+                (unsafe { w_str_get_wtf8(w_repl) }.as_bytes(), false)
             }
             Subject::Bytes(_) => {
                 if !unsafe { pyre_object::bytesobject::is_bytes_like(w_repl) } {
@@ -1242,7 +1250,7 @@ fn subx(args: &[PyObjectRef]) -> Result<(PyObjectRef, i64), crate::PyError> {
                                 "sub callable must return a string",
                             ));
                         }
-                        out.extend_from_slice(unsafe { w_str_get_value(w_piece) }.as_bytes());
+                        out.extend_from_slice(unsafe { w_str_get_wtf8(w_piece) }.as_bytes());
                     }
                     Subject::Bytes(_) => {
                         if !unsafe { pyre_object::bytesobject::is_bytes_like(w_piece) } {
@@ -1370,7 +1378,7 @@ fn template_items_from_list(w_result: PyObjectRef) -> Result<Vec<TemplateItem>, 
             ));
         } else if unsafe { is_str(elem) } {
             items.push(TemplateItem::Literal(
-                unsafe { w_str_get_value(elem) }.as_bytes().to_vec(),
+                unsafe { w_str_get_wtf8(elem) }.as_bytes().to_vec(),
             ));
         } else if unsafe { pyre_object::bytesobject::is_bytes_like(elem) } {
             items.push(TemplateItem::Literal(
@@ -1604,7 +1612,7 @@ fn sre_match_expand(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
             if !unsafe { is_str(w_template) } {
                 return Err(crate::PyError::type_error("expand: template must be str"));
             }
-            (unsafe { w_str_get_value(w_template) }.as_bytes(), false)
+            (unsafe { w_str_get_wtf8(w_template) }.as_bytes(), false)
         }
         Subject::Bytes(_) => {
             if !unsafe { pyre_object::bytesobject::is_bytes_like(w_template) } {

--- a/pyre/pyre-interpreter/src/module/_warnings/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_warnings/mod.rs
@@ -453,13 +453,22 @@ fn show_warning(
         "__name__",
     )?;
     let name_slot = pin_root_slot(name);
-    let line = format!(
-        "{}:{}: {}: {}\n",
-        crate::baseobjspace::text_w(pyre_object::gc_roots::shadow_stack_get(filename_slot))?,
-        lineno,
-        crate::baseobjspace::text_w(pyre_object::gc_roots::shadow_stack_get(name_slot))?,
-        crate::baseobjspace::text_w(pyre_object::gc_roots::shadow_stack_get(text_slot))?,
-    );
+    // Assembled in WTF-8: the message is whatever `warn()` was given, so a
+    // filename or text carrying a lone surrogate is written out as-is and
+    // stderr's error handler decides how it appears.
+    let mut line = rustpython_wtf8::Wtf8Buf::new();
+    line.push_wtf8(crate::baseobjspace::text_wtf8_w(
+        pyre_object::gc_roots::shadow_stack_get(filename_slot),
+    )?);
+    line.push_str(&format!(":{lineno}: "));
+    line.push_wtf8(crate::baseobjspace::text_wtf8_w(
+        pyre_object::gc_roots::shadow_stack_get(name_slot),
+    )?);
+    line.push_str(": ");
+    line.push_wtf8(crate::baseobjspace::text_wtf8_w(
+        pyre_object::gc_roots::shadow_stack_get(text_slot),
+    )?);
+    line.push_str("\n");
     if let Some(sys) = crate::importing::get_sys_module("sys")
         && let Ok(stderr) = crate::baseobjspace::getattr_str(sys, "stderr")
         && !unsafe { is_none(stderr) }
@@ -468,7 +477,7 @@ fn show_warning(
         let write_slot = pin_root_slot(write);
         crate::call::call_function_impl_result(
             pyre_object::gc_roots::shadow_stack_get(write_slot),
-            &[w_str_new(&line)],
+            &[pyre_object::w_str_from_wtf8(line)],
         )?;
         let source_line = pyre_object::gc_roots::shadow_stack_get(source_line_slot);
         let source_line = if source_line.is_null() || unsafe { is_none(source_line) } {

--- a/pyre/pyre-interpreter/src/module/array/mod.rs
+++ b/pyre/pyre-interpreter/src/module/array/mod.rs
@@ -237,8 +237,9 @@ fn array_descr_new(args: &[PyObjectRef]) -> PyResult {
             "array() argument 1 must be a unicode character, not a different type",
         ));
     }
-    let tc_str = unsafe { pyre_object::unicodeobject::w_str_get_value(w_typecode) };
-    let tc_bytes = tc_str.as_bytes();
+    // Read as the raw buffer: a typecode is a single ASCII character, so a
+    // lone surrogate simply fails the length and membership checks below.
+    let tc_bytes = unsafe { pyre_object::unicodeobject::w_str_get_wtf8(w_typecode) }.as_bytes();
     if tc_bytes.len() != 1 {
         return Err(PyError::type_error(
             "array() argument 1 must be a unicode character, not str",
@@ -1237,8 +1238,7 @@ fn array_reconstructor(args: &[PyObjectRef]) -> PyResult {
     if !unsafe { pyre_object::is_str(args[1]) } {
         return Err(PyError::type_error("typecode must be a unicode character"));
     }
-    let typecode_text = unsafe { pyre_object::unicodeobject::w_str_get_value(args[1]) };
-    let typecode_bytes = typecode_text.as_bytes();
+    let typecode_bytes = unsafe { pyre_object::unicodeobject::w_str_get_wtf8(args[1]) }.as_bytes();
     if typecode_bytes.len() != 1 || arr::typecode_itemsize(typecode_bytes[0]).is_none() {
         return Err(PyError::value_error("invalid type code"));
     }

--- a/pyre/pyre-interpreter/src/module/array/mod.rs
+++ b/pyre/pyre-interpreter/src/module/array/mod.rs
@@ -233,19 +233,25 @@ fn array_descr_new(args: &[PyObjectRef]) -> PyResult {
     let w_typecode = args[1];
     // typecode must be a 1-character str.
     if !unsafe { pyre_object::is_str(w_typecode) } {
-        return Err(PyError::type_error(
-            "array() argument 1 must be a unicode character, not a different type",
-        ));
+        return Err(PyError::type_error(format!(
+            "array() argument 1 must be a unicode character, not {}",
+            crate::baseobjspace::object_functionstr_type_name(w_typecode)
+        )));
     }
-    // Read as the raw buffer: a typecode is a single ASCII character, so a
-    // lone surrogate simply fails the length and membership checks below.
-    let tc_bytes = unsafe { pyre_object::unicodeobject::w_str_get_wtf8(w_typecode) }.as_bytes();
-    if tc_bytes.len() != 1 {
-        return Err(PyError::type_error(
-            "array() argument 1 must be a unicode character, not str",
-        ));
-    }
-    let typecode = tc_bytes[0];
+    // Measured in code points on the raw buffer: a lone surrogate is one
+    // character with no `&str` spelling, so it reaches the typecode check
+    // below rather than counting as three.
+    let tc = unsafe { pyre_object::unicodeobject::w_str_get_wtf8(w_typecode) };
+    let mut points = tc.code_points();
+    let Some(first) = points.next().filter(|_| points.next().is_none()) else {
+        return Err(PyError::type_error(format!(
+            "array() argument 1 must be a unicode character, not a string of length {}",
+            tc.code_points().count()
+        )));
+    };
+    // Every typecode is ASCII, so a wider code point takes the same
+    // "bad typecode" rejection as an unrecognised ASCII one.
+    let typecode = u8::try_from(first.to_u32()).unwrap_or(0xff);
     let itemsize = arr::typecode_itemsize(typecode).ok_or_else(|| {
         PyError::value_error("bad typecode (must be b, B, u, w, h, H, i, I, l, L, q, Q, f or d)")
     })?;

--- a/pyre/pyre-interpreter/src/module/binascii/mod.rs
+++ b/pyre/pyre-interpreter/src/module/binascii/mod.rs
@@ -43,9 +43,7 @@ fn as_bytes(obj: PyObjectRef) -> Result<Vec<u8>, crate::PyError> {
 /// bytes-like source only, so a str of any kind is rejected by its type.
 fn as_buffer_bytes(obj: PyObjectRef) -> Result<Vec<u8>, crate::PyError> {
     match unsafe { crate::typedef::buffer_as_bytes_like(obj) }? {
-        Some(src) if !unsafe { is_str(obj) } => {
-            Ok(unsafe { bytesobject::bytes_like_data(src) }.to_vec())
-        }
+        Some(src) => Ok(unsafe { bytesobject::bytes_like_data(src) }.to_vec()),
         _ => Err(crate::PyError::type_error(format!(
             "a bytes-like object is required, not '{}'",
             crate::baseobjspace::object_functionstr_type_name(obj)

--- a/pyre/pyre-interpreter/src/module/binascii/mod.rs
+++ b/pyre/pyre-interpreter/src/module/binascii/mod.rs
@@ -13,11 +13,21 @@ mod transforms;
 
 use pyre_object::*;
 
-/// Accept a str (ASCII) or any bytes-like and surface the raw bytes.
+/// `ascii_buffer_converter` — accept a str (ASCII) or any bytes-like and
+/// surface the raw bytes.  Only the `a2b_*` decoders take a str source.
 fn as_bytes(obj: PyObjectRef) -> Result<Vec<u8>, crate::PyError> {
     unsafe {
         if is_str(obj) {
-            Ok(w_str_get_value(obj).as_bytes().to_vec())
+            // The ASCII check runs on the raw buffer: a lone surrogate is
+            // non-ASCII, so it takes the same rejection as any other
+            // non-ASCII character.
+            let s = w_str_get_wtf8(obj);
+            if !s.as_bytes().is_ascii() {
+                return Err(crate::PyError::value_error(
+                    "string argument should contain only ASCII characters",
+                ));
+            }
+            Ok(s.as_bytes().to_vec())
         } else {
             match crate::typedef::buffer_as_bytes_like(obj)? {
                 Some(src) => Ok(bytesobject::bytes_like_data(src).to_vec()),
@@ -26,6 +36,20 @@ fn as_bytes(obj: PyObjectRef) -> Result<Vec<u8>, crate::PyError> {
                 )),
             }
         }
+    }
+}
+
+/// The `Py_buffer` converter — the `b2a_*` encoders and the checksums take a
+/// bytes-like source only, so a str of any kind is rejected by its type.
+fn as_buffer_bytes(obj: PyObjectRef) -> Result<Vec<u8>, crate::PyError> {
+    match unsafe { crate::typedef::buffer_as_bytes_like(obj) }? {
+        Some(src) if !unsafe { is_str(obj) } => {
+            Ok(unsafe { bytesobject::bytes_like_data(src) }.to_vec())
+        }
+        _ => Err(crate::PyError::type_error(format!(
+            "a bytes-like object is required, not '{}'",
+            crate::baseobjspace::object_functionstr_type_name(obj)
+        ))),
     }
 }
 
@@ -150,13 +174,13 @@ crate::py_module! {
     functions: {
         "b2a_hex" / * = |args| {
             let (pos, kwargs) = crate::builtins::split_builtin_kwargs(args);
-            let data = as_bytes(pos.first().copied().unwrap_or(w_none()))?;
+            let data = as_buffer_bytes(pos.first().copied().unwrap_or(w_none()))?;
             let (sep, bytes_per_sep) = arg_sep(pos, kwargs)?;
             Ok(w_bytes_from_bytes(&transforms::hexlify(&data, sep, bytes_per_sep)))
         },
         "hexlify" / * = |args| {
             let (pos, kwargs) = crate::builtins::split_builtin_kwargs(args);
-            let data = as_bytes(pos.first().copied().unwrap_or(w_none()))?;
+            let data = as_buffer_bytes(pos.first().copied().unwrap_or(w_none()))?;
             let (sep, bytes_per_sep) = arg_sep(pos, kwargs)?;
             Ok(w_bytes_from_bytes(&transforms::hexlify(&data, sep, bytes_per_sep)))
         },
@@ -172,13 +196,13 @@ crate::py_module! {
         },
         "crc32" / * = |args| {
             let (pos, kwargs) = crate::builtins::split_builtin_kwargs(args);
-            let data = as_bytes(pos.first().copied().unwrap_or(w_none()))?;
+            let data = as_buffer_bytes(pos.first().copied().unwrap_or(w_none()))?;
             let init = arg_u32(pos, kwargs, "crc", 1, 0)?;
             Ok(w_int_new(transforms::crc32(&data, init) as i64))
         },
         "crc_hqx" / * = |args| {
             let (pos, kwargs) = crate::builtins::split_builtin_kwargs(args);
-            let data = as_bytes(pos.first().copied().unwrap_or(w_none()))?;
+            let data = as_buffer_bytes(pos.first().copied().unwrap_or(w_none()))?;
             let init = match crate::builtins::kwarg_get(kwargs, "crc").or_else(|| pos.get(1).copied()) {
                 Some(o) => crate::baseobjspace::int_w(o)? as u32,
                 None => return Err(crate::PyError::type_error(
@@ -196,7 +220,7 @@ crate::py_module! {
         },
         "b2a_base64" / * = |args| {
             let (pos, kwargs) = crate::builtins::split_builtin_kwargs(args);
-            let data = as_bytes(pos.first().copied().unwrap_or(w_none()))?;
+            let data = as_buffer_bytes(pos.first().copied().unwrap_or(w_none()))?;
             let newline = arg_bool(pos, kwargs, "newline", 1, true);
             Ok(w_bytes_from_bytes(&transforms::b2a_base64(&data, newline)))
         },
@@ -208,7 +232,7 @@ crate::py_module! {
         },
         "b2a_qp" / * = |args| {
             let (pos, kwargs) = crate::builtins::split_builtin_kwargs(args);
-            let data = as_bytes(pos.first().copied().unwrap_or(w_none()))?;
+            let data = as_buffer_bytes(pos.first().copied().unwrap_or(w_none()))?;
             let quotetabs = arg_bool(pos, kwargs, "quotetabs", 1, false);
             let istext = arg_bool(pos, kwargs, "istext", 2, true);
             let header = arg_bool(pos, kwargs, "header", 3, false);
@@ -221,7 +245,7 @@ crate::py_module! {
         },
         "b2a_uu" / * = |args| {
             let (pos, kwargs) = crate::builtins::split_builtin_kwargs(args);
-            let data = as_bytes(pos.first().copied().unwrap_or(w_none()))?;
+            let data = as_buffer_bytes(pos.first().copied().unwrap_or(w_none()))?;
             let backtick = arg_bool(pos, kwargs, "backtick", 1, false);
             let out = transforms::b2a_uu(&data, backtick).map_err(transform_error)?;
             Ok(w_bytes_from_bytes(&out))

--- a/pyre/pyre-interpreter/src/module/gc/mod.rs
+++ b/pyre/pyre-interpreter/src/module/gc/mod.rs
@@ -217,22 +217,31 @@ crate::py_module! {
                 .collect();
             Ok(w_list_new_object(result))
         },
+        // `set_threshold(threshold0, threshold1=None, threshold2=None)` — the
+        // optional tail leaves no single natural arity, so the body enforces
+        // the count itself.
         "set_threshold" / * = |args| {
+            let (positional, kwargs) = crate::builtins::split_builtin_kwargs(args);
+            if crate::builtins::has_real_kwargs(kwargs) {
+                return Err(crate::PyError::type_error(
+                    "set_threshold() takes no keyword arguments",
+                ));
+            }
             // CPython 3.14 `gc.set_threshold(threshold0[, threshold1[,
             // threshold2]])` writes only the positions it was given, and
             // parses every argument before writing any of them.
-            if args.is_empty() || args.len() > 3 {
+            if positional.is_empty() || positional.len() > 3 {
                 return Err(crate::PyError::type_error(
                     "gc.set_threshold requires 1 to 3 arguments",
                 ));
             }
             let mut parsed = [0i64; 3];
-            for (i, &arg) in args.iter().enumerate() {
+            for (i, &arg) in positional.iter().enumerate() {
                 parsed[i] = crate::baseobjspace::int_w(
                     crate::baseobjspace::space_index(arg)?,
                 )?;
             }
-            for (i, &value) in parsed[..args.len()].iter().enumerate() {
+            for (i, &value) in parsed[..positional.len()].iter().enumerate() {
                 GC_THRESHOLD[i].store(value, Ordering::Relaxed);
             }
             Ok(w_none())

--- a/pyre/pyre-interpreter/src/module/gc/mod.rs
+++ b/pyre/pyre-interpreter/src/module/gc/mod.rs
@@ -241,13 +241,12 @@ crate::py_module! {
             // Read every value before storing any, so a non-integer in the
             // tail leaves the previous thresholds untouched.  An omitted
             // trailing value keeps the threshold it already had, and a third
-            // value is validated but not kept.  The index protocol, so an
-            // object carrying only `__int__` is a TypeError.
+            // value is validated but not kept.
             let mut given = Vec::with_capacity(positional.len());
             for &w_value in positional {
-                given.push(crate::baseobjspace::int_w(
-                    crate::baseobjspace::space_index(w_value)?,
-                )?);
+                // The index protocol, so an object carrying only `__int__` is
+                // a TypeError rather than a silent conversion.
+                given.push(crate::builtins::space_index_w(w_value)?);
             }
             for (slot, value) in GC_THRESHOLD.iter().zip(given) {
                 slot.store(value, Ordering::Relaxed);

--- a/pyre/pyre-interpreter/src/module/gc/mod.rs
+++ b/pyre/pyre-interpreter/src/module/gc/mod.rs
@@ -12,12 +12,15 @@ use std::sync::atomic::{AtomicBool, AtomicI64, Ordering};
 /// call so callers that toggle and re-read the state stay consistent.
 static GC_ENABLED: AtomicBool = AtomicBool::new(true);
 
-/// The three thresholds `gc.set_threshold` writes and `gc.get_threshold`
-/// reads back, seeded with CPython 3.14's defaults. The collector runs off a
-/// nursery size rather than per-generation allocation counters, so the values
-/// round-trip but do not decide when a collection happens.
-static GC_THRESHOLD: [AtomicI64; 3] =
-    [AtomicI64::new(2000), AtomicI64::new(10), AtomicI64::new(10)];
+/// The collection thresholds `gc.get_threshold()` reports.  pyre's collector
+/// has no generational allocation counters to drive, so the values are only
+/// remembered: `set_threshold` stores what it was given and `get_threshold`
+/// hands the same tuple back, which is the part of the pair's behaviour a
+/// caller can observe.  The third threshold is not among them — an incremental
+/// collector has no third generation to size, so it reads back as 0 whatever
+/// it was set to.  The initial values are the ones a fresh interpreter starts
+/// with.
+static GC_THRESHOLD: [AtomicI64; 2] = [AtomicI64::new(2000), AtomicI64::new(10)];
 
 fn pin_object(object: majit_ir::GcRef) {
     pyre_object::gc_roots::pin_root(object.0 as PyObjectRef);
@@ -235,14 +238,19 @@ crate::py_module! {
                     "gc.set_threshold requires 1 to 3 arguments",
                 ));
             }
-            let mut parsed = [0i64; 3];
-            for (i, &arg) in positional.iter().enumerate() {
-                parsed[i] = crate::baseobjspace::int_w(
-                    crate::baseobjspace::space_index(arg)?,
-                )?;
+            // Read every value before storing any, so a non-integer in the
+            // tail leaves the previous thresholds untouched.  An omitted
+            // trailing value keeps the threshold it already had, and a third
+            // value is validated but not kept.  The index protocol, so an
+            // object carrying only `__int__` is a TypeError.
+            let mut given = Vec::with_capacity(positional.len());
+            for &w_value in positional {
+                given.push(crate::baseobjspace::int_w(
+                    crate::baseobjspace::space_index(w_value)?,
+                )?);
             }
-            for (i, &value) in parsed[..positional.len()].iter().enumerate() {
-                GC_THRESHOLD[i].store(value, Ordering::Relaxed);
+            for (slot, value) in GC_THRESHOLD.iter().zip(given) {
+                slot.store(value, Ordering::Relaxed);
             }
             Ok(w_none())
         },
@@ -250,6 +258,7 @@ crate::py_module! {
             GC_THRESHOLD
                 .iter()
                 .map(|slot| w_int_new(slot.load(Ordering::Relaxed)))
+                .chain(std::iter::once(w_int_new(0)))
                 .collect(),
         )),
         "get_count"     / 0 = |_| Ok(w_tuple_new(vec![

--- a/pyre/pyre-interpreter/src/module/grp/grp.rs
+++ b/pyre/pyre-interpreter/src/module/grp/grp.rs
@@ -146,7 +146,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                         "getgrnam(): name should be a string",
                     ));
                 }
-                let name = unsafe { pyre_object::w_str_get_value(args[0]) };
+                let name = crate::baseobjspace::str_utf8_w(args[0])?;
                 // Reject embedded NULs (parity with PyPy's @unwrap_spec
                 // text0 used for similar lookup APIs).
                 let c_name = std::ffi::CString::new(name).map_err(|_| {

--- a/pyre/pyre-interpreter/src/module/imp/interp_imp.rs
+++ b/pyre/pyre-interpreter/src/module/imp/interp_imp.rs
@@ -464,29 +464,19 @@ fn frozen_source(entry: &FrozenModule) -> Result<(String, String), crate::PyErro
 /// to build the `PyInit_<name>` symbol from it, so a name outside ASCII is
 /// rejected by the codec before the builtin registry is ever consulted.
 fn ascii_module_name(w_name: pyre_object::PyObjectRef) -> Result<String, crate::PyError> {
-    if let Ok(name) = unsafe { pyre_object::w_str_get_wtf8(w_name) }.as_str() {
-        if name.is_ascii() {
-            return Ok(name.to_owned());
-        }
+    // Read straight off the buffer: reaching the name through `encode` would
+    // run a `str` subclass's override, which decides which builtin is loaded.
+    let name = unsafe { pyre_object::w_str_get_wtf8(w_name) };
+    if let Some(pos) = name.code_points().position(|cp| cp.to_u32() > 127) {
+        return Err(crate::typedef::unicode_encode_error(
+            "ascii",
+            w_name,
+            pos,
+            pos + 1,
+            "ordinal not in range(128)",
+        ));
     }
-    let _roots = pyre_object::gc_roots::push_roots();
-    let name_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(w_name);
-    // The strict ascii codec raises here, so the `UnicodeEncodeError` carries
-    // the encoding, object, position and reason `name.encode("ascii")` reports.
-    // Should it ever encode, the bytes are ASCII and the lossy decode below
-    // cannot substitute anything.
-    let encode_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(crate::baseobjspace::getattr_str(
-        pyre_object::gc_roots::shadow_stack_get(name_slot),
-        "encode",
-    )?);
-    let encoded = crate::call::call_function_impl_result(
-        pyre_object::gc_roots::shadow_stack_get(encode_slot),
-        &[pyre_object::w_str_new("ascii")],
-    )?;
-    let bytes = unsafe { pyre_object::bytesobject::bytes_like_data(encoded) };
-    Ok(String::from_utf8_lossy(bytes).into_owned())
+    Ok(name.to_string())
 }
 
 /// The code object a frozen table entry stands for.  A real frozen module ships
@@ -634,12 +624,12 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     positional.len()
                 )));
             }
+            let name = frozen_name(positional, "find_frozen")?;
             // `withdata: bool(accept={int})` — any object, read for truth.
             let withdata = match crate::builtins::kwarg_get(kwargs, "withdata") {
                 Some(value) => crate::baseobjspace::is_true(value)?,
                 None => false,
             };
-            let name = frozen_name(positional, "find_frozen")?;
             let Some(entry) = served_frozen_module(&name) else {
                 return Ok(pyre_object::w_none());
             };

--- a/pyre/pyre-interpreter/src/module/imp/interp_imp.rs
+++ b/pyre/pyre-interpreter/src/module/imp/interp_imp.rs
@@ -458,6 +458,72 @@ fn frozen_source(entry: &FrozenModule) -> Result<(String, String), crate::PyErro
     }
 }
 
+/// The module name as the extension-module loader spells it.
+///
+/// `_Py_ext_module_loader_info_init` encodes the name to ASCII because it has
+/// to build the `PyInit_<name>` symbol from it, so a name outside ASCII is
+/// rejected by the codec before the builtin registry is ever consulted.
+fn ascii_module_name(w_name: pyre_object::PyObjectRef) -> Result<String, crate::PyError> {
+    if let Ok(name) = unsafe { pyre_object::w_str_get_wtf8(w_name) }.as_str() {
+        if name.is_ascii() {
+            return Ok(name.to_owned());
+        }
+    }
+    let _roots = pyre_object::gc_roots::push_roots();
+    let name_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(w_name);
+    // The strict ascii codec raises here, so the `UnicodeEncodeError` carries
+    // the encoding, object, position and reason `name.encode("ascii")` reports.
+    // Should it ever encode, the bytes are ASCII and the lossy decode below
+    // cannot substitute anything.
+    let encode_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(crate::baseobjspace::getattr_str(
+        pyre_object::gc_roots::shadow_stack_get(name_slot),
+        "encode",
+    )?);
+    let encoded = crate::call::call_function_impl_result(
+        pyre_object::gc_roots::shadow_stack_get(encode_slot),
+        &[pyre_object::w_str_new("ascii")],
+    )?;
+    let bytes = unsafe { pyre_object::bytesobject::bytes_like_data(encoded) };
+    Ok(String::from_utf8_lossy(bytes).into_owned())
+}
+
+/// The code object a frozen table entry stands for.  A real frozen module ships
+/// pre-marshalled bytes; pyre keeps the source and compiles it on demand, so
+/// both `get_frozen_object` and the `withdata` arm of `find_frozen` come
+/// through here and observe the same object.
+fn frozen_code(entry: &FrozenModule) -> Result<pyre_object::PyObjectRef, crate::PyError> {
+    let (source, code_name) = frozen_source(entry)?;
+    let filename = format!("<frozen {code_name}>");
+    let code = crate::compile::compile_source_with_filename(
+        &source,
+        crate::compile::Mode::Exec,
+        &filename,
+    )
+    .map_err(|error| crate::builtins::compile_err_to_syntax_error(error, &source))?;
+    Ok(crate::w_code_new(
+        Box::into_raw(Box::new(code)) as *const ()
+    ))
+}
+
+/// The `data` element of a `withdata=True` `find_frozen` result: a read-only
+/// `memoryview` over the frozen bytes, so `marshal.loads(bytes(data))`
+/// reconstructs the same code object `get_frozen_object` returns.
+fn frozen_data(entry: &FrozenModule) -> Result<pyre_object::PyObjectRef, crate::PyError> {
+    let code = frozen_code(entry)?;
+    let bytes = crate::module::marshal::dumps_bytes(code)?;
+    let w_bytes = pyre_object::bytesobject::w_bytes_from_bytes(&bytes);
+    let _roots = pyre_object::gc_roots::push_roots();
+    let bytes_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(w_bytes);
+    let mv_type = crate::typedef::gettypeobject(&pyre_object::memoryview::MEMORYVIEW_TYPE);
+    crate::module::_pickle::call_fn(
+        mv_type,
+        &[pyre_object::gc_roots::shadow_stack_get(bytes_slot)],
+    )
+}
+
 pub fn register_module(ns: pyre_object::PyObjectRef) {
     crate::module_ns_store(
         ns,
@@ -557,25 +623,46 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     crate::module_ns_store(
         ns,
         "find_frozen",
-        crate::make_builtin_function_with_arity(
-            "find_frozen",
-            |args| {
-                let name = frozen_name(args, "find_frozen")?;
-                let Some(entry) = served_frozen_module(&name) else {
-                    return Ok(pyre_object::w_none());
-                };
-                let origname = entry
+        // `withdata` is keyword-only, so no call shape fills every parameter
+        // positionally and there is no fixed natural arity to fast-path on.
+        crate::make_builtin_function("find_frozen", |args| {
+            let (positional, kwargs) = crate::builtins::split_builtin_kwargs(args);
+            crate::builtins::kwarg_reject_unknown(kwargs, &["withdata"], "find_frozen")?;
+            if positional.len() != 1 {
+                return Err(crate::PyError::type_error(format!(
+                    "find_frozen() takes exactly 1 positional argument ({} given)",
+                    positional.len()
+                )));
+            }
+            // `withdata: bool(accept={int})` — any object, read for truth.
+            let withdata = match crate::builtins::kwarg_get(kwargs, "withdata") {
+                Some(value) => crate::baseobjspace::is_true(value)?,
+                None => false,
+            };
+            let name = frozen_name(positional, "find_frozen")?;
+            let Some(entry) = served_frozen_module(&name) else {
+                return Ok(pyre_object::w_none());
+            };
+            let _roots = pyre_object::gc_roots::push_roots();
+            let data_slot = pyre_object::gc_roots::shadow_stack_len();
+            pyre_object::gc_roots::pin_root(if withdata {
+                frozen_data(entry)?
+            } else {
+                pyre_object::w_none()
+            });
+            let origname_slot = pyre_object::gc_roots::shadow_stack_len();
+            pyre_object::gc_roots::pin_root(
+                entry
                     .origname
                     .map(pyre_object::w_str_new)
-                    .unwrap_or_else(pyre_object::w_none);
-                Ok(pyre_object::w_tuple_new(vec![
-                    pyre_object::w_none(),
-                    pyre_object::w_bool_from(entry.is_package),
-                    origname,
-                ]))
-            },
-            1,
-        ),
+                    .unwrap_or_else(pyre_object::w_none),
+            );
+            Ok(pyre_object::w_tuple_new(vec![
+                pyre_object::gc_roots::shadow_stack_get(data_slot),
+                pyre_object::w_bool_from(entry.is_package),
+                pyre_object::gc_roots::shadow_stack_get(origname_slot),
+            ]))
+        }),
     );
     crate::module_ns_store(
         ns,
@@ -642,17 +729,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 }
                 let entry =
                     served_frozen_module(&name).ok_or_else(|| missing_frozen_error(&name))?;
-                let (source, code_name) = frozen_source(entry)?;
-                let filename = format!("<frozen {code_name}>");
-                let code = crate::compile::compile_source_with_filename(
-                    &source,
-                    crate::compile::Mode::Exec,
-                    &filename,
-                )
-                .map_err(|error| crate::builtins::compile_err_to_syntax_error(error, &source))?;
-                Ok(crate::w_code_new(
-                    Box::into_raw(Box::new(code)) as *const ()
-                ))
+                frozen_code(entry)
             }),
     );
     crate::module_ns_store(
@@ -665,43 +742,44 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 // module back; `_load` then binds it in sys.modules. A name
                 // already imported keeps its module, so the machinery and a plain
                 // `import X` agree on one object.
-                let Some(&spec) = args.first() else {
+                let (positional, kwargs) = crate::builtins::split_builtin_kwargs(args);
+                if crate::builtins::has_real_kwargs(kwargs) {
                     return Err(crate::PyError::type_error(
-                        "create_builtin() missing required argument 'spec'",
+                        "_imp.create_builtin() takes no keyword arguments",
                     ));
-                };
+                }
+                if positional.len() != 1 {
+                    return Err(crate::PyError::type_error(format!(
+                        "_imp.create_builtin() takes exactly one argument ({} given)",
+                        positional.len()
+                    )));
+                }
+                let spec = positional[0];
                 let w_name = crate::baseobjspace::getattr_str(spec, "name")?;
                 if !unsafe { pyre_object::is_str(w_name) } {
-                    return Err(crate::PyError::type_error("spec.name must be a string"));
+                    return Err(crate::PyError::type_error(format!(
+                        "name must be string, not {}",
+                        type_name(w_name)
+                    )));
                 }
-                // The builtin registry is `&'static str`-keyed, so a name
-                // carrying a lone surrogate names no builtin and takes the
-                // not-found report; those code points have no `&str` spelling,
-                // so it is rendered the way `%R` does.
-                let w_name_wtf8 = unsafe { pyre_object::w_str_get_wtf8(w_name) };
-                let Ok(name) = w_name_wtf8.as_str() else {
-                    return Err(crate::PyError::new(
-                        crate::PyErrorKind::ImportError,
-                        format!(
-                            "no built-in module named {}",
-                            crate::display::format_wtf8_repr(w_name_wtf8)
-                        ),
-                    ));
-                };
-                let name = name.to_string();
+                let name = ascii_module_name(w_name)?;
+                if name.as_bytes().contains(&0) {
+                    return Err(crate::PyError::value_error("embedded null character"));
+                }
                 if let Some(module) = crate::importing::get_sys_module(&name) {
                     return Ok(module);
                 }
-                crate::importing::create_builtin_module(
-                    &name,
-                    crate::call::getexecutioncontext(),
-                )?
-                .ok_or_else(|| {
-                    crate::PyError::new(
-                        crate::PyErrorKind::ImportError,
-                        format!("no built-in module named {name}"),
-                    )
-                })
+                // A name that is spelled correctly but names no builtin is
+                // reported by returning None, leaving the diagnostic to
+                // `BuiltinImporter.create_module`, which has already screened
+                // the name against `sys.builtin_module_names`.
+                Ok(
+                    crate::importing::create_builtin_module(
+                        &name,
+                        crate::call::getexecutioncontext(),
+                    )?
+                    .unwrap_or_else(pyre_object::w_none),
+                )
             },
             1,
         ),

--- a/pyre/pyre-interpreter/src/module/imp/interp_imp.rs
+++ b/pyre/pyre-interpreter/src/module/imp/interp_imp.rs
@@ -574,9 +574,10 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     crate::module_ns_store(
         ns,
         "get_frozen_object",
-        crate::make_builtin_function_with_arity(
-            "get_frozen_object",
-            |args| {
+        // `data` is optional, so there is no fixed natural arity to fast-path
+        // on; registering one would declare a call shape the closure does not
+        // actually require.
+        crate::make_builtin_function("get_frozen_object", |args| {
                 let (positional, kwargs) = crate::builtins::split_builtin_kwargs(args);
                 if crate::builtins::has_real_kwargs(kwargs) {
                     return Err(crate::PyError::type_error(
@@ -632,9 +633,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 Ok(crate::w_code_new(
                     Box::into_raw(Box::new(code)) as *const ()
                 ))
-            },
-            1,
-        ),
+            }),
     );
     crate::module_ns_store(
         ns,

--- a/pyre/pyre-interpreter/src/module/imp/interp_imp.rs
+++ b/pyre/pyre-interpreter/src/module/imp/interp_imp.rs
@@ -834,10 +834,13 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         crate::make_builtin_function_with_arity(
             "source_hash",
             |args| {
-                // `interp_imp.py source_hash`: siphash-2-4 of the source
-                // bytes keyed by the pyc magic (k0=magic, k1=0), serialized
-                // low-byte-first — the 8-byte hash field of hash-based pycs
-                // (`_code_to_hash_pyc` asserts `len(source_hash) == 8`).
+                // `_imp_source_hash_impl` hashes the source bytes with
+                // `_Py_KeyedHash`, which is siphash-1-3 keyed by the pyc magic
+                // (k0=magic, k1=0) and serialized low-byte-first — the 8-byte
+                // hash field of hash-based pycs (`_code_to_hash_pyc` asserts
+                // `len(source_hash) == 8`).  The pyc header this fills already
+                // carries the 3.14 magic number, so the digest has to agree
+                // with the one that format specifies.
                 use std::hash::Hasher;
                 let magic = crate::baseobjspace::int_w(args[0])? as u64;
                 let content = if unsafe { pyre_object::bytesobject::is_bytes_like(args[1]) } {
@@ -849,7 +852,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                         "source_hash() argument 2 must be a bytes-like object",
                     ));
                 };
-                let mut hasher = siphasher::sip::SipHasher24::new_with_keys(magic, 0);
+                let mut hasher = siphasher::sip::SipHasher13::new_with_keys(magic, 0);
                 hasher.write(&content);
                 Ok(pyre_object::bytesobject::w_bytes_from_bytes(
                     &hasher.finish().to_le_bytes(),

--- a/pyre/pyre-interpreter/src/module/imp/interp_imp.rs
+++ b/pyre/pyre-interpreter/src/module/imp/interp_imp.rs
@@ -3,6 +3,7 @@
 //! Verbatim move of the inline block previously in importing.rs.
 
 use crate::importing::BUILTIN_MODULES;
+use rustpython_wtf8::{Wtf8, Wtf8Buf};
 use std::sync::atomic::{AtomicI64, AtomicPtr, Ordering};
 
 struct FrozenModule {
@@ -317,8 +318,10 @@ fn reinit_lock() {
     getimportlock().reinit_lock();
 }
 
-fn frozen_module(name: &str) -> Option<&'static FrozenModule> {
-    FROZEN_MODULES.iter().find(|entry| entry.name == name)
+fn frozen_module(name: &Wtf8) -> Option<&'static FrozenModule> {
+    FROZEN_MODULES
+        .iter()
+        .find(|entry| name == Wtf8::new(entry.name))
 }
 
 fn is_bootstrap_frozen(name: &str) -> bool {
@@ -337,11 +340,22 @@ fn frozen_module_served(entry: &FrozenModule) -> bool {
     mode >= 0 || is_bootstrap_frozen(entry.name)
 }
 
-fn served_frozen_module(name: &str) -> Option<&'static FrozenModule> {
+fn served_frozen_module(name: &Wtf8) -> Option<&'static FrozenModule> {
     frozen_module(name).filter(|entry| frozen_module_served(entry))
 }
 
-fn frozen_name(args: &[pyre_object::PyObjectRef], function: &str) -> Result<String, crate::PyError> {
+/// The module-name argument, kept in WTF-8.
+///
+/// `find_frozen` reads the name with `PyUnicode_AsUTF8` and treats one that
+/// does not encode as `FROZEN_BAD_NAME`, clearing the error rather than
+/// propagating it and reporting the status exactly as `FROZEN_NOT_FOUND` is
+/// reported.  The frozen table is keyed by `&'static str`, so such a name
+/// matches nothing; carrying it as WTF-8 keeps the code points for the `%R` in
+/// that report instead of demanding a `&str` view the buffer cannot give.
+fn frozen_name(
+    args: &[pyre_object::PyObjectRef],
+    function: &str,
+) -> Result<Wtf8Buf, crate::PyError> {
     let Some(&name) = args.first() else {
         return Err(crate::PyError::type_error(format!(
             "{function} expected at least 1 argument, got 0"
@@ -353,15 +367,15 @@ fn frozen_name(args: &[pyre_object::PyObjectRef], function: &str) -> Result<Stri
             bad_argument_type_name(name)
         )));
     }
-    Ok(unsafe { pyre_object::w_str_get_value(name) }.to_owned())
+    Ok(unsafe { pyre_object::w_str_get_wtf8(name) }.to_owned())
 }
 
 /// `set_frozen_error` — both frozen diagnostics carry the module name as
 /// `.name` with no `.path`, and render it the way `%R` does.
-fn frozen_error(message: String, name: &str) -> crate::PyError {
+fn frozen_error(message: String, name: &Wtf8) -> crate::PyError {
     crate::PyError::import_error_name_path(
         message,
-        pyre_object::w_str_new(name),
+        pyre_object::w_str_from_wtf8(name.to_owned()),
         pyre_object::w_none(),
     )
 }
@@ -369,12 +383,11 @@ fn frozen_error(message: String, name: &str) -> crate::PyError {
 /// `%R` on the module name: quote selection and escaping identical to
 /// `repr(str)`, which Rust's `{:?}` does not reproduce (it always
 /// double-quotes).
-fn frozen_name_repr(name: &str) -> String {
-    let w_name = pyre_object::w_str_new(name);
-    crate::display::format_wtf8_repr(unsafe { pyre_object::w_str_get_wtf8(w_name) })
+fn frozen_name_repr(name: &Wtf8) -> String {
+    crate::display::format_wtf8_repr(name)
 }
 
-fn missing_frozen_error(name: &str) -> crate::PyError {
+fn missing_frozen_error(name: &Wtf8) -> crate::PyError {
     frozen_error(
         format!("No such frozen object named {}", frozen_name_repr(name)),
         name,
@@ -383,7 +396,7 @@ fn missing_frozen_error(name: &str) -> crate::PyError {
 
 /// `set_frozen_error(FROZEN_INVALID)` — the frozen data was supplied by the
 /// caller but does not unmarshal.
-fn invalid_frozen_error(name: &str) -> crate::PyError {
+fn invalid_frozen_error(name: &Wtf8) -> crate::PyError {
     frozen_error(
         format!("Frozen object named {} is invalid", frozen_name_repr(name)),
         name,
@@ -455,9 +468,16 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 if args.is_empty() {
                     return Ok(pyre_object::w_int_new(0));
                 }
+                // The name is compared against every `_inittab` entry with
+                // `_PyUnicode_EqualToASCIIString`, which never decodes;
+                // `BUILTIN_MODULES` is `&'static str`-keyed and cannot hold a
+                // lone surrogate either, so such a name is not a builtin.
                 let name = unsafe {
                     if pyre_object::is_str(args[0]) {
-                        pyre_object::w_str_get_value(args[0])
+                        match pyre_object::w_str_get_value_opt(args[0]) {
+                            Some(name) => name,
+                            None => return Ok(pyre_object::w_int_new(0)),
+                        }
                     } else {
                         return Ok(pyre_object::w_int_new(0));
                     }
@@ -654,7 +674,21 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 if !unsafe { pyre_object::is_str(w_name) } {
                     return Err(crate::PyError::type_error("spec.name must be a string"));
                 }
-                let name = unsafe { pyre_object::w_str_get_value(w_name) }.to_string();
+                // The builtin registry is `&'static str`-keyed, so a name
+                // carrying a lone surrogate names no builtin and takes the
+                // not-found report; those code points have no `&str` spelling,
+                // so it is rendered the way `%R` does.
+                let w_name_wtf8 = unsafe { pyre_object::w_str_get_wtf8(w_name) };
+                let Ok(name) = w_name_wtf8.as_str() else {
+                    return Err(crate::PyError::new(
+                        crate::PyErrorKind::ImportError,
+                        format!(
+                            "no built-in module named {}",
+                            crate::display::format_wtf8_repr(w_name_wtf8)
+                        ),
+                    ));
+                };
+                let name = name.to_string();
                 if let Some(module) = crate::importing::get_sys_module(&name) {
                     return Ok(module);
                 }
@@ -708,8 +742,10 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                         "create_dynamic() missing required argument 'spec'",
                     ));
                 };
-                crate::baseobjspace::text0_w(crate::baseobjspace::getattr_str(spec, "name")?)?;
-                crate::baseobjspace::text0_w(crate::baseobjspace::getattr_str(spec, "origin")?)?;
+                crate::baseobjspace::text0_wtf8_w(crate::baseobjspace::getattr_str(spec, "name")?)?;
+                crate::baseobjspace::text0_wtf8_w(crate::baseobjspace::getattr_str(
+                    spec, "origin",
+                )?)?;
                 Err(crate::PyError::new(
                     crate::PyErrorKind::ImportError,
                     "Not implemented".to_string(),
@@ -770,7 +806,13 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                         type_name(args[1])
                     )));
                 }
-                let newname = unsafe { pyre_object::w_str_get_value(args[1]) }.to_owned();
+                // `co_filename` is stored as UTF-8, so the name is encoded
+                // strictly: one carrying a lone surrogate has no such spelling
+                // and is reported the way encoding the string itself reports
+                // it.  The encode succeeded, so the bytes are valid UTF-8 and
+                // the lossy decode below cannot substitute anything.
+                let encoded = crate::type_methods::encode_utf8_with_errors(args[1], "strict")?;
+                let newname = String::from_utf8_lossy(&encoded).into_owned();
                 unsafe { crate::pycode::fix_co_filename(args[0], &newname) };
                 Ok(pyre_object::w_none())
             },

--- a/pyre/pyre-interpreter/src/module/itertools/interp_itertools.rs
+++ b/pyre/pyre-interpreter/src/module/itertools/interp_itertools.rs
@@ -289,7 +289,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     crate::module_ns_store(
         ns,
         "combinations",
-        crate::make_builtin_function_with_arity(
+        crate::make_builtin_function_with_arity_and_maybe_sig(
             "combinations",
             |args| {
                 crate::gateway::check_declared_arity("combinations", 2, args.len())?;
@@ -328,6 +328,13 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 Ok(pyre_object::w_seq_iter_new(list, n))
             },
             2,
+            Some(crate::gateway::Signature::new(
+                vec!["iterable", "r"],
+                None,
+                None,
+                0,
+                0,
+            )),
         ),
     );
     // combinations_with_replacement(iterable, r) — like combinations, but an
@@ -338,7 +345,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     crate::module_ns_store(
         ns,
         "combinations_with_replacement",
-        crate::make_builtin_function_with_arity(
+        crate::make_builtin_function_with_arity_and_maybe_sig(
             "combinations_with_replacement",
             |args| {
                 let missing = match args.len() {
@@ -382,6 +389,13 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 Ok(pyre_object::w_seq_iter_new(list, n))
             },
             2,
+            Some(crate::gateway::Signature::new(
+                vec!["iterable", "r"],
+                None,
+                None,
+                0,
+                0,
+            )),
         ),
     );
     // product(*iterables, repeat=1)

--- a/pyre/pyre-interpreter/src/module/itertools/interp_itertools.rs
+++ b/pyre/pyre-interpreter/src/module/itertools/interp_itertools.rs
@@ -292,6 +292,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         crate::make_builtin_function_with_arity(
             "combinations",
             |args| {
+                crate::gateway::check_declared_arity("combinations", 2, args.len())?;
                 let r = crate::builtins::space_index_w(args[1])?;
                 if r < 0 {
                     return Err(crate::PyError::value_error("r must be non-negative"));

--- a/pyre/pyre-interpreter/src/module/marshal/mod.rs
+++ b/pyre/pyre-interpreter/src/module/marshal/mod.rs
@@ -524,6 +524,20 @@ pub(crate) fn loads_bytes(data: &[u8]) -> PyResult {
     Ok(result.get())
 }
 
+/// `PyMarshal_WriteObjectToString` — serialize one object into a raw byte
+/// buffer at the current format version.  `_imp.find_frozen(withdata=True)`
+/// hands these bytes back as the frozen data, so they are the same stream
+/// `loads_bytes` reads.
+pub(crate) fn dumps_bytes(value: PyObjectRef) -> Result<Vec<u8>, PyError> {
+    let version = wire::FORMAT_VERSION as i32;
+    let _roots = pyre_object::gc_roots::push_roots();
+    pyre_object::gc_roots::pin_root(value);
+    let mut out = Vec::new();
+    let mut refs = (version >= 3).then(WriterRefs::new);
+    write_object(&mut out, value, &mut refs, version, MAX_DEPTH)?;
+    Ok(out)
+}
+
 fn dump_impl(args: &[PyObjectRef]) -> PyResult {
     let (positional, kwargs) = crate::builtins::split_builtin_kwargs(args);
     crate::builtins::kwarg_reject_unknown(kwargs, &["version", "allow_code"], "dump")?;

--- a/pyre/pyre-interpreter/src/module/marshal/mod.rs
+++ b/pyre/pyre-interpreter/src/module/marshal/mod.rs
@@ -103,6 +103,12 @@ fn write_object(
     version: i32,
     depth: usize,
 ) -> Result<(), PyError> {
+    // `obj` is held as a raw local across the whole traversal, which is sound
+    // only because writing allocates nothing the GC manages: the output is a
+    // Rust `Vec<u8>`, and the one conversion here (`obj_to_bigint`) reads the
+    // int or clones a Rust `BigInt`.  A minor collection therefore cannot run
+    // between the branch test and the read, so no reload from the shadow slot
+    // is needed.  Anything added here that allocates breaks that.
     if depth == 0 {
         return Err(PyError::value_error("object too deeply nested to marshal"));
     }

--- a/pyre/pyre-interpreter/src/module/operator/mod.rs
+++ b/pyre/pyre-interpreter/src/module/operator/mod.rs
@@ -191,10 +191,6 @@ crate::py_module! {
         "getitem"  / 2 = |args| getitem(args[0], args[1]),
         "setitem"  / 3 = |args| { setitem(args[0], args[1], args[2])?; Ok(w_none()) },
         "delitem"  / 2 = |args| { delitem(args[0], args[1])?; Ok(w_none()) },
-        // Underscore aliases (__add__ / __sub__ / __mul__ via operator).
-        "__add__"  / 2 = |args| Ok(add(args[0], args[1]).unwrap_or(w_none())),
-        "__sub__"  / 2 = |args| Ok(sub(args[0], args[1]).unwrap_or(w_none())),
-        "__mul__"  / 2 = |args| Ok(mul(args[0], args[1]).unwrap_or(w_none())),
         "eq" / 2 = |args| baseobjspace::compare(args[0], args[1], CompareOp::Eq),
         "lt" / 2 = |args| baseobjspace::compare(args[0], args[1], CompareOp::Lt),
         "gt" / 2 = |args| baseobjspace::compare(args[0], args[1], CompareOp::Gt),
@@ -204,36 +200,7 @@ crate::py_module! {
         "length_hint"  / * = op_length_hint,
         "_compare_digest" / 2 = op_compare_digest,
     },
-    extra_init: |ns| {
-        // `operator.py` tail — bind each dunder name to its operator
-        // function (`__lt__ = lt`, `__add__ = add`, …) so `operator.__lt__`
-        // resolves like CPython's pure-Python wrapper does.
-        const ALIASES: &[(&str, &str)] = &[
-            ("__lt__", "lt"), ("__le__", "le"), ("__eq__", "eq"),
-            ("__ne__", "ne"), ("__ge__", "ge"), ("__gt__", "gt"),
-            ("__not__", "not_"), ("__abs__", "abs"), ("__add__", "add"),
-            ("__and__", "and_"), ("__call__", "call"),
-            ("__floordiv__", "floordiv"), ("__index__", "index"),
-            ("__inv__", "inv"), ("__invert__", "invert"),
-            ("__lshift__", "lshift"), ("__mod__", "mod"), ("__mul__", "mul"),
-            ("__matmul__", "matmul"), ("__neg__", "neg"), ("__or__", "or_"),
-            ("__pos__", "pos"), ("__pow__", "pow"), ("__rshift__", "rshift"),
-            ("__sub__", "sub"), ("__truediv__", "truediv"), ("__xor__", "xor"),
-            ("__concat__", "concat"), ("__contains__", "contains"),
-            ("__delitem__", "delitem"), ("__getitem__", "getitem"),
-            ("__setitem__", "setitem"), ("__iadd__", "iadd"),
-            ("__iand__", "iand"), ("__iconcat__", "iconcat"),
-            ("__ifloordiv__", "ifloordiv"), ("__ilshift__", "ilshift"),
-            ("__imod__", "imod"), ("__imul__", "imul"),
-            ("__imatmul__", "imatmul"), ("__ior__", "ior"),
-            ("__ipow__", "ipow"), ("__irshift__", "irshift"),
-            ("__isub__", "isub"), ("__itruediv__", "itruediv"),
-            ("__ixor__", "ixor"),
-        ];
-        for (dunder, src) in ALIASES {
-            if let Some(f) = crate::module_ns_get(ns, src) {
-                crate::module_ns_store(ns, dunder, f);
-            }
-        }
-    },
+    // The `__lt__ = lt` / `__add__ = add` dunder aliases belong to
+    // `operator.py`, which binds them after its `from _operator import *`;
+    // this module carries only the names that tail imports.
 }

--- a/pyre/pyre-interpreter/src/module/operator/mod.rs
+++ b/pyre/pyre-interpreter/src/module/operator/mod.rs
@@ -64,8 +64,11 @@ fn op_compare_digest(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
     let read = |obj: PyObjectRef| -> Result<Vec<u8>, crate::PyError> {
         unsafe {
             if is_str(obj) {
-                let s = w_str_get_value(obj);
-                if !s.is_ascii() {
+                // The ASCII check runs on the raw buffer: a lone surrogate is
+                // non-ASCII, so it takes the same rejection as any other
+                // non-ASCII character.
+                let s = w_str_get_wtf8(obj);
+                if !s.as_bytes().is_ascii() {
                     return Err(crate::PyError::type_error(
                         "comparing strings with non-ASCII characters is not supported",
                     ));

--- a/pyre/pyre-interpreter/src/module/operator/mod.rs
+++ b/pyre/pyre-interpreter/src/module/operator/mod.rs
@@ -3,30 +3,16 @@
 use pyre_object::*;
 
 fn op_index(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    if args.len() != 1 {
-        return Err(crate::PyError::type_error(format!(
-            "index() takes exactly one argument ({} given)",
-            args.len()
-        )));
-    }
     let indexed = crate::baseobjspace::space_index(args[0])?;
     unsafe { Ok(range_bigint_to_obj(range_obj_to_bigint(indexed))) }
 }
 
-/// Shared body for the binary-arithmetic thunks (`add`/`sub`/`mul`): a
-/// wrong argument count is a `TypeError`, not a panic
-/// (`interp_operator.py` `@unwrap_spec` argument checking).  The operand
-/// error propagates, matching the `truediv`/`floordiv` thunks.
-fn op_binary<F>(args: &[PyObjectRef], name: &str, f: F) -> Result<PyObjectRef, crate::PyError>
+/// Shared body for the binary-arithmetic thunks (`add`/`sub`/`mul`).  The
+/// operand error propagates, matching the `truediv`/`floordiv` thunks.
+fn op_binary<F>(args: &[PyObjectRef], f: F) -> Result<PyObjectRef, crate::PyError>
 where
     F: Fn(PyObjectRef, PyObjectRef) -> Result<PyObjectRef, crate::PyError>,
 {
-    if args.len() != 2 {
-        return Err(crate::PyError::type_error(format!(
-            "{name} expected 2 arguments, got {}",
-            args.len()
-        )));
-    }
     f(args[0], args[1])
 }
 
@@ -163,10 +149,10 @@ crate::py_module! {
     },
     functions: {
         "index"    / 1 = op_index,
-        "add"      / 2 = |args| op_binary(args, "add", add),
-        "sub"      / 2 = |args| op_binary(args, "sub", sub),
-        "mul"      / 2 = |args| op_binary(args, "mul", mul),
-        "matmul"   / 2 = |args| op_binary(args, "matmul", matmul),
+        "add"      / 2 = |args| op_binary(args, add),
+        "sub"      / 2 = |args| op_binary(args, sub),
+        "mul"      / 2 = |args| op_binary(args, mul),
+        "matmul"   / 2 = |args| op_binary(args, matmul),
         "truediv"  / 2 = |args| truediv(args[0], args[1]),
         "floordiv" / 2 = |args| floordiv(args[0], args[1]),
         "mod"      / 2 = |args| mod_(args[0], args[1]),
@@ -181,19 +167,19 @@ crate::py_module! {
         "or_"      / 2 = |args| or_(args[0], args[1]),
         "xor"      / 2 = |args| xor(args[0], args[1]),
         // interp_operator.py:150-210 — in-place operations, each `space.inplace_X`.
-        "iadd"      / 2 = |args| op_binary(args, "iadd", |a, b| crate::opcode_ops::binary_value(a, b, crate::bytecode::BinaryOperator::InplaceAdd)),
-        "isub"      / 2 = |args| op_binary(args, "isub", |a, b| crate::opcode_ops::binary_value(a, b, crate::bytecode::BinaryOperator::InplaceSubtract)),
-        "imul"      / 2 = |args| op_binary(args, "imul", |a, b| crate::opcode_ops::binary_value(a, b, crate::bytecode::BinaryOperator::InplaceMultiply)),
-        "imatmul"   / 2 = |args| op_binary(args, "imatmul", |a, b| crate::opcode_ops::binary_value(a, b, crate::bytecode::BinaryOperator::InplaceMatrixMultiply)),
-        "ifloordiv" / 2 = |args| op_binary(args, "ifloordiv", |a, b| crate::opcode_ops::binary_value(a, b, crate::bytecode::BinaryOperator::InplaceFloorDivide)),
-        "imod"      / 2 = |args| op_binary(args, "imod", |a, b| crate::opcode_ops::binary_value(a, b, crate::bytecode::BinaryOperator::InplaceRemainder)),
-        "itruediv"  / 2 = |args| op_binary(args, "itruediv", |a, b| crate::opcode_ops::binary_value(a, b, crate::bytecode::BinaryOperator::InplaceTrueDivide)),
-        "ipow"      / 2 = |args| op_binary(args, "ipow", |a, b| crate::opcode_ops::binary_value(a, b, crate::bytecode::BinaryOperator::InplacePower)),
-        "ilshift"   / 2 = |args| op_binary(args, "ilshift", |a, b| crate::opcode_ops::binary_value(a, b, crate::bytecode::BinaryOperator::InplaceLshift)),
-        "irshift"   / 2 = |args| op_binary(args, "irshift", |a, b| crate::opcode_ops::binary_value(a, b, crate::bytecode::BinaryOperator::InplaceRshift)),
-        "iand"      / 2 = |args| op_binary(args, "iand", |a, b| crate::opcode_ops::binary_value(a, b, crate::bytecode::BinaryOperator::InplaceAnd)),
-        "ior"       / 2 = |args| op_binary(args, "ior", |a, b| crate::opcode_ops::binary_value(a, b, crate::bytecode::BinaryOperator::InplaceOr)),
-        "ixor"      / 2 = |args| op_binary(args, "ixor", |a, b| crate::opcode_ops::binary_value(a, b, crate::bytecode::BinaryOperator::InplaceXor)),
+        "iadd"      / 2 = |args| op_binary(args, |a, b| crate::opcode_ops::binary_value(a, b, crate::bytecode::BinaryOperator::InplaceAdd)),
+        "isub"      / 2 = |args| op_binary(args, |a, b| crate::opcode_ops::binary_value(a, b, crate::bytecode::BinaryOperator::InplaceSubtract)),
+        "imul"      / 2 = |args| op_binary(args, |a, b| crate::opcode_ops::binary_value(a, b, crate::bytecode::BinaryOperator::InplaceMultiply)),
+        "imatmul"   / 2 = |args| op_binary(args, |a, b| crate::opcode_ops::binary_value(a, b, crate::bytecode::BinaryOperator::InplaceMatrixMultiply)),
+        "ifloordiv" / 2 = |args| op_binary(args, |a, b| crate::opcode_ops::binary_value(a, b, crate::bytecode::BinaryOperator::InplaceFloorDivide)),
+        "imod"      / 2 = |args| op_binary(args, |a, b| crate::opcode_ops::binary_value(a, b, crate::bytecode::BinaryOperator::InplaceRemainder)),
+        "itruediv"  / 2 = |args| op_binary(args, |a, b| crate::opcode_ops::binary_value(a, b, crate::bytecode::BinaryOperator::InplaceTrueDivide)),
+        "ipow"      / 2 = |args| op_binary(args, |a, b| crate::opcode_ops::binary_value(a, b, crate::bytecode::BinaryOperator::InplacePower)),
+        "ilshift"   / 2 = |args| op_binary(args, |a, b| crate::opcode_ops::binary_value(a, b, crate::bytecode::BinaryOperator::InplaceLshift)),
+        "irshift"   / 2 = |args| op_binary(args, |a, b| crate::opcode_ops::binary_value(a, b, crate::bytecode::BinaryOperator::InplaceRshift)),
+        "iand"      / 2 = |args| op_binary(args, |a, b| crate::opcode_ops::binary_value(a, b, crate::bytecode::BinaryOperator::InplaceAnd)),
+        "ior"       / 2 = |args| op_binary(args, |a, b| crate::opcode_ops::binary_value(a, b, crate::bytecode::BinaryOperator::InplaceOr)),
+        "ixor"      / 2 = |args| op_binary(args, |a, b| crate::opcode_ops::binary_value(a, b, crate::bytecode::BinaryOperator::InplaceXor)),
         "concat"    / 2 = op_concat,
         "iconcat"   / 2 = op_iconcat,
         "not_"     / 1 = |args| Ok(w_bool_from(!is_true(args[0])?)),
@@ -206,12 +192,12 @@ crate::py_module! {
         "setitem"  / 3 = |args| { setitem(args[0], args[1], args[2])?; Ok(w_none()) },
         "delitem"  / 2 = |args| { delitem(args[0], args[1])?; Ok(w_none()) },
         // Underscore aliases (__add__ / __sub__ / __mul__ via operator).
-        "__add__"  / 2 = |args| { if args.len() != 2 { return Err(crate::PyError::type_error(format!("__add__() takes exactly 2 arguments ({} given)", args.len()))); } Ok(add(args[0], args[1]).unwrap_or(w_none())) },
-        "__sub__"  / 2 = |args| { if args.len() != 2 { return Err(crate::PyError::type_error(format!("__sub__() takes exactly 2 arguments ({} given)", args.len()))); } Ok(sub(args[0], args[1]).unwrap_or(w_none())) },
-        "__mul__"  / 2 = |args| { if args.len() != 2 { return Err(crate::PyError::type_error(format!("__mul__() takes exactly 2 arguments ({} given)", args.len()))); } Ok(mul(args[0], args[1]).unwrap_or(w_none())) },
-        "eq" / 2 = |args| { if args.len() != 2 { return Err(crate::PyError::type_error(format!("eq() takes exactly 2 arguments ({} given)", args.len()))); } baseobjspace::compare(args[0], args[1], CompareOp::Eq) },
-        "lt" / 2 = |args| { if args.len() != 2 { return Err(crate::PyError::type_error(format!("lt() takes exactly 2 arguments ({} given)", args.len()))); } baseobjspace::compare(args[0], args[1], CompareOp::Lt) },
-        "gt" / 2 = |args| { if args.len() != 2 { return Err(crate::PyError::type_error(format!("gt() takes exactly 2 arguments ({} given)", args.len()))); } baseobjspace::compare(args[0], args[1], CompareOp::Gt) },
+        "__add__"  / 2 = |args| Ok(add(args[0], args[1]).unwrap_or(w_none())),
+        "__sub__"  / 2 = |args| Ok(sub(args[0], args[1]).unwrap_or(w_none())),
+        "__mul__"  / 2 = |args| Ok(mul(args[0], args[1]).unwrap_or(w_none())),
+        "eq" / 2 = |args| baseobjspace::compare(args[0], args[1], CompareOp::Eq),
+        "lt" / 2 = |args| baseobjspace::compare(args[0], args[1], CompareOp::Lt),
+        "gt" / 2 = |args| baseobjspace::compare(args[0], args[1], CompareOp::Gt),
         "le" / 2 = |args| baseobjspace::compare(args[0], args[1], CompareOp::Le),
         "ge" / 2 = |args| baseobjspace::compare(args[0], args[1], CompareOp::Ge),
         "ne" / 2 = |args| baseobjspace::compare(args[0], args[1], CompareOp::Ne),

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -1741,7 +1741,11 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 if n < 0 {
                     return Err(crate::PyError::value_error("negative argument not allowed"));
                 }
-                let n = n as usize;
+                // A 32-bit target's `usize` is narrower than the `__index__`
+                // result, so a size it cannot hold is reported rather than
+                // wrapped to a smaller request.
+                let n = usize::try_from(n)
+                    .map_err(|_| crate::PyError::overflow_error("argument out of range"))?;
                 #[cfg(not(feature = "sandbox"))]
                 let buf = host_os::urandom(n).unwrap_or_else(|_| vec![0u8; n]);
                 // Route host entropy through the trusted controller instead of

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -2599,7 +2599,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             }
             let key = unsafe {
                 if pyre_object::is_str(args[0]) {
-                    pyre_object::w_str_get_value(args[0]).to_string()
+                    crate::baseobjspace::str_utf8_w(args[0])?.to_string()
                 } else {
                     return Ok(pyre_object::w_none());
                 }
@@ -3627,7 +3627,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     }
                     let cmd = unsafe {
                         if pyre_object::is_str(args[0]) {
-                            pyre_object::w_str_get_value(args[0]).to_string()
+                            crate::baseobjspace::str_utf8_w(args[0])?.to_string()
                         } else {
                             return Err(crate::PyError::type_error(
                                 "system(): command must be a string",
@@ -3806,7 +3806,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     .map(|s| {
                         let bytes = unsafe {
                             if pyre_object::is_str(s) {
-                                pyre_object::w_str_get_value(s).as_bytes().to_vec()
+                                crate::baseobjspace::str_utf8_w(s)?.as_bytes().to_vec()
                             } else if pyre_object::is_bytes(s) {
                                 pyre_object::w_bytes_data(s).to_vec()
                             } else {
@@ -4156,7 +4156,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     }
                     let user = unsafe {
                         if pyre_object::is_str(args[0]) {
-                            pyre_object::w_str_get_value(args[0]).to_string()
+                            crate::baseobjspace::str_utf8_w(args[0])?.to_string()
                         } else {
                             return Err(crate::PyError::type_error(
                                 "initgroups(): username must be str",

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -1733,10 +1733,15 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         crate::make_builtin_function_with_arity(
             "urandom",
             |args| {
-                if args.is_empty() {
-                    return Err(crate::PyError::type_error("urandom() requires 1 argument"));
+                crate::gateway::check_declared_arity("urandom", 1, args.len())?;
+                // `__index__` conversion, so a non-integer is a TypeError
+                // instead of a raw field read that asks for an arbitrary
+                // number of bytes.
+                let n = crate::baseobjspace::int_w(args[0])?;
+                if n < 0 {
+                    return Err(crate::PyError::value_error("negative argument not allowed"));
                 }
-                let n = (unsafe { pyre_object::w_int_get_value(args[0]) }) as usize;
+                let n = n as usize;
                 #[cfg(not(feature = "sandbox"))]
                 let buf = host_os::urandom(n).unwrap_or_else(|_| vec![0u8; n]);
                 // Route host entropy through the trusted controller instead of

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -1737,7 +1737,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 // `__index__` conversion, so a non-integer is a TypeError
                 // instead of a raw field read that asks for an arbitrary
                 // number of bytes.
-                let n = crate::baseobjspace::int_w(args[0])?;
+                let n = crate::builtins::space_index_w(args[0])?;
                 if n < 0 {
                     return Err(crate::PyError::value_error("negative argument not allowed"));
                 }

--- a/pyre/pyre-interpreter/src/module/pwd/interp_pwd.rs
+++ b/pyre/pyre-interpreter/src/module/pwd/interp_pwd.rs
@@ -191,7 +191,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                         "getpwnam(): name should be a string",
                     ));
                 }
-                let name = unsafe { pyre_object::w_str_get_value(args[0]) };
+                let name = crate::baseobjspace::str_utf8_w(args[0])?;
                 // `interp_pwd.py:111 @unwrap_spec(name='text0')` rejects
                 // embedded NULs.  CString::new() enforces that here.
                 let c_name = std::ffi::CString::new(name).map_err(|_| {

--- a/pyre/pyre-interpreter/src/module/pyexpat/mod.rs
+++ b/pyre/pyre-interpreter/src/module/pyexpat/mod.rs
@@ -1760,7 +1760,7 @@ fn parser_create3(
     }
     if unsafe { is_none(namespace_separator) } {
     } else if unsafe { is_str(namespace_separator) } {
-        let value = unsafe { w_str_get_value(namespace_separator) };
+        let value = crate::baseobjspace::str_utf8_w(namespace_separator)?;
         if value.chars().count() > 1 {
             return Err(crate::PyError::value_error(
                 "namespace_separator must be at most one character, omitted, or None",

--- a/pyre/pyre-interpreter/src/module/pypyjit/mod.rs
+++ b/pyre/pyre-interpreter/src/module/pypyjit/mod.rs
@@ -55,7 +55,7 @@ fn set_param(
             if !unsafe { pyre_object::is_str(k) } {
                 continue;
             }
-            let key = unsafe { pyre_object::w_str_get_value(k) };
+            let key = unsafe { pyre_object::w_str_get_wtf8(k) };
             if key == "__pyre_kw__" {
                 continue;
             }
@@ -66,7 +66,7 @@ fn set_param(
                 let value = crate::baseobjspace::int_w(v)?;
                 let known = majit_metainterp::jit::UNROLL_PARAMETERS
                     .iter()
-                    .any(|&(name, _)| name == key && name != "enable_opts");
+                    .any(|&(name, _)| key == name && name != "enable_opts");
                 if !known {
                     return Err(crate::PyError::type_error(format!(
                         "no JIT parameter '{key}'"

--- a/pyre/pyre-interpreter/src/module/signal/interp_signal.rs
+++ b/pyre/pyre-interpreter/src/module/signal/interp_signal.rs
@@ -455,7 +455,14 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     crate::module_ns_store(
         ns,
         "signal",
-        crate::make_builtin_function_with_arity("signal", |args| signal_signal(args[0], args[1]), 2),
+        crate::make_builtin_function_with_arity(
+            "signal",
+            |args| {
+                crate::gateway::check_declared_arity("signal", 2, args.len())?;
+                signal_signal(args[0], args[1])
+            },
+            2,
+        ),
     );
     // interp_signal.py:238-251 `getsignal(signum) -> action`.
     crate::module_ns_store(

--- a/pyre/pyre-interpreter/src/module/sys/vm.rs
+++ b/pyre/pyre-interpreter/src/module/sys/vm.rs
@@ -3,7 +3,10 @@
 //! PyPy equivalent: `pypy/module/sys/vm.py`.
 
 use crate::executioncontext::ActionFlagOps;
-use crate::{make_builtin_function, make_builtin_function_with_arity, module_ns_store};
+use crate::{
+    make_builtin_function, make_builtin_function_with_arity,
+    make_builtin_function_with_arity_and_maybe_sig, module_ns_store,
+};
 use pyre_object::*;
 use std::sync::OnceLock;
 
@@ -997,7 +1000,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     module_ns_store(
         ns,
         "set_int_max_str_digits",
-        make_builtin_function_with_arity(
+        make_builtin_function_with_arity_and_maybe_sig(
             "set_int_max_str_digits",
             |args| {
                 if args.len() != 1 {
@@ -1018,6 +1021,13 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 Ok(w_none())
             },
             1,
+            Some(crate::gateway::Signature::new(
+                vec!["maxdigits"],
+                None,
+                None,
+                0,
+                0,
+            )),
         ),
     );
     // sys.intern

--- a/pyre/pyre-interpreter/src/module/sys/vm.rs
+++ b/pyre/pyre-interpreter/src/module/sys/vm.rs
@@ -825,8 +825,9 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             flags_type,
             vec![
                 w_int_new(0), // debug
-                w_int_new(0), // inspect
-                w_int_new(0), // interactive
+                // `-i` sets both.
+                w_int_new(i64::from(crate::importing::inspect_flag())),
+                w_int_new(i64::from(crate::importing::inspect_flag())),
                 w_int_new(crate::importing::optimize_level()),
                 w_int_new(i64::from(crate::importing::dont_write_bytecode_flag())),
                 w_int_new(i64::from(crate::importing::no_user_site_flag())),

--- a/pyre/pyre-interpreter/src/module/sys/vm.rs
+++ b/pyre/pyre-interpreter/src/module/sys/vm.rs
@@ -835,14 +835,14 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 w_int_new(i64::from(crate::importing::ignore_environment_flag())),
                 w_int_new(0), // verbose
                 w_int_new(0), // bytes_warning
-                w_int_new(0), // quiet
+                w_int_new(i64::from(crate::importing::quiet_flag())),
                 w_int_new(0), // hash_randomization
                 w_int_new(i64::from(crate::importing::isolated_flag())),
                 w_bool_from(crate::importing::dev_mode_flag()),
                 w_int_new(crate::importing::utf8_mode_flag()),
                 w_int_new(0), // warn_default_encoding
                 w_bool_from(crate::importing::safe_path_flag()),
-                w_int_new(4300), // int_max_str_digits
+                w_int_new(crate::module::sys::state::int_max_str_digits() as i64),
             ],
             vec![
                 // The interpreter holds a GIL, so `-X gil=0` is not available.

--- a/pyre/pyre-interpreter/src/module/sys/vm.rs
+++ b/pyre/pyre-interpreter/src/module/sys/vm.rs
@@ -7,8 +7,8 @@ use crate::{make_builtin_function, make_builtin_function_with_arity, module_ns_s
 use pyre_object::*;
 use std::sync::OnceLock;
 
-/// Shared stub type for `sys._getframe`, `sys.flags`, `sys.stdout` and other
-/// module-level sys attributes that expose CPython-looking attribute bags.
+/// Shared stub type for `sys._getframe`, `sys.stdout` and other module-level
+/// sys attributes that expose attribute bags.
 ///
 /// `typedef::w_object()` (plain `object`) cannot store instance attributes —
 /// its type flag `hasdict` is false, matching CPython where `object()`
@@ -787,167 +787,67 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     let exc_info_code = unsafe { crate::getcode(exc_info_fn) };
     crate::function::register_sys_exc_info_path(exc_info_code, exc_info_direct);
     // sys.flags — pypy/module/sys/app.py:99-119 `class sysflags` with
-    // `__metaclass__ = structseqtype`. PyPy exposes it as a structseq
-    // (immutable tuple subclass with named fields). pyre does not have
-    // structseq yet, so we approximate the orthodox behavior with a
-    // dedicated type whose attributes live in the TYPE's class
-    // namespace rather than the instance dict. Read access via the
-    // descriptor protocol still works (`sys.flags.optimize`); writes
-    // fall through to `setdictvalue → raiseattrerror` because the type
-    // has no `__dict__` slot, matching the read-only contract:
-    //
-    //     >>> sys.flags.optimize = 3
-    //     AttributeError: 'sys.flags' object has no attribute 'optimize'
-    //
-    // The exact exception type differs from PyPy
-    // (`pypy/module/sys/test/test_sysmodule.py:148` expects TypeError)
-    // because pyre lacks the structseq tp_setattro slot. The full
-    // structseq port is tracked separately.
+    // `__metaclass__ = structseqtype`: an immutable tuple subclass whose
+    // first `n_sequence_fields` entries are also indexable, so
+    // `sys.flags[3] is sys.flags.optimize` and `isinstance(sys.flags,
+    // tuple)` both hold.  `gil`, `thread_inherit_context` and
+    // `context_aware_warnings` sit past the sequence as named-only extras,
+    // which is what makes `n_fields` (21) exceed `len()` (18).
     {
-        let flags_type = crate::typedef::make_builtin_type("sys.flags", |fns| {
-            unsafe {
-                pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-                    fns,
-                    "debug",
-                    w_int_new(0),
-                )
-            };
-            unsafe {
-                pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-                    fns,
-                    "inspect",
-                    w_int_new(0),
-                )
-            };
-            unsafe {
-                pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-                    fns,
-                    "interactive",
-                    w_int_new(0),
-                )
-            };
-            unsafe {
-                pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-                    fns,
-                    "optimize",
-                    w_int_new(crate::importing::optimize_level()),
-                )
-            };
-            unsafe {
-                pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-                    fns,
-                    "dont_write_bytecode",
-                    w_int_new(i64::from(crate::importing::dont_write_bytecode_flag())),
-                )
-            };
-            unsafe {
-                pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-                    fns,
-                    "no_user_site",
-                    w_int_new(i64::from(crate::importing::no_user_site_flag())),
-                )
-            };
-            // `-S` (skip `import site`) is recorded by the launcher.
-            unsafe {
-                pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-                    fns,
-                    "no_site",
-                    w_int_new(i64::from(crate::importing::no_site_flag())),
-                )
-            };
-            unsafe {
-                pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-                    fns,
-                    "ignore_environment",
-                    w_int_new(i64::from(crate::importing::ignore_environment_flag())),
-                )
-            };
-            unsafe {
-                pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-                    fns,
-                    "verbose",
-                    w_int_new(0),
-                )
-            };
-            unsafe {
-                pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-                    fns,
-                    "bytes_warning",
-                    w_int_new(0),
-                )
-            };
-            unsafe {
-                pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-                    fns,
-                    "quiet",
-                    w_int_new(0),
-                )
-            };
-            unsafe {
-                pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-                    fns,
-                    "hash_randomization",
-                    w_int_new(0),
-                )
-            };
-            unsafe {
-                pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-                    fns,
-                    "isolated",
-                    w_int_new(i64::from(crate::importing::isolated_flag())),
-                )
-            };
-            unsafe {
-                pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-                    fns,
-                    "dev_mode",
-                    w_bool_from(crate::importing::dev_mode_flag()),
-                )
-            };
-            unsafe {
-                pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-                    fns,
-                    "utf8_mode",
-                    w_int_new(crate::importing::utf8_mode_flag()),
-                )
-            };
-            unsafe {
-                pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-                    fns,
-                    "warn_default_encoding",
-                    w_int_new(0),
-                )
-            };
-            unsafe {
-                pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-                    fns,
-                    "safe_path",
-                    w_bool_from(crate::importing::safe_path_flag()),
-                )
-            };
-            unsafe {
-                pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-                    fns,
-                    "int_max_str_digits",
-                    w_int_new(4300),
-                )
-            };
-            unsafe {
-                pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-                    fns,
-                    "context_aware_warnings",
-                    w_bool_from(false),
-                )
-            };
-            unsafe {
-                pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-                    fns,
-                    "thread_inherit_context",
-                    w_int_new(0),
-                )
-            };
-        });
-        let flags = w_instance_new(flags_type);
+        let flags_type = crate::_structseq::make_struct_seq_with_extra(
+            "sys.flags",
+            &[
+                "debug",
+                "inspect",
+                "interactive",
+                "optimize",
+                "dont_write_bytecode",
+                "no_user_site",
+                "no_site",
+                "ignore_environment",
+                "verbose",
+                "bytes_warning",
+                "quiet",
+                "hash_randomization",
+                "isolated",
+                "dev_mode",
+                "utf8_mode",
+                "warn_default_encoding",
+                "safe_path",
+                "int_max_str_digits",
+            ],
+            &["gil", "thread_inherit_context", "context_aware_warnings"],
+        );
+        let flags = crate::_structseq::new_instance_with_extra(
+            flags_type,
+            vec![
+                w_int_new(0), // debug
+                w_int_new(0), // inspect
+                w_int_new(0), // interactive
+                w_int_new(crate::importing::optimize_level()),
+                w_int_new(i64::from(crate::importing::dont_write_bytecode_flag())),
+                w_int_new(i64::from(crate::importing::no_user_site_flag())),
+                // `-S` (skip `import site`) is recorded by the launcher.
+                w_int_new(i64::from(crate::importing::no_site_flag())),
+                w_int_new(i64::from(crate::importing::ignore_environment_flag())),
+                w_int_new(0), // verbose
+                w_int_new(0), // bytes_warning
+                w_int_new(0), // quiet
+                w_int_new(0), // hash_randomization
+                w_int_new(i64::from(crate::importing::isolated_flag())),
+                w_bool_from(crate::importing::dev_mode_flag()),
+                w_int_new(crate::importing::utf8_mode_flag()),
+                w_int_new(0), // warn_default_encoding
+                w_bool_from(crate::importing::safe_path_flag()),
+                w_int_new(4300), // int_max_str_digits
+            ],
+            vec![
+                // The interpreter holds a GIL, so `-X gil=0` is not available.
+                ("gil", w_int_new(1)),
+                ("thread_inherit_context", w_int_new(0)),
+                ("context_aware_warnings", w_int_new(0)),
+            ],
+        );
         module_ns_store(ns, "flags", flags);
     }
     // sys.getdefaultencoding

--- a/pyre/pyre-interpreter/src/module/syslog/syslog.rs
+++ b/pyre/pyre-interpreter/src/module/syslog/syslog.rs
@@ -22,9 +22,11 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             {
                 let ident = match args.first() {
                     Some(&a) if unsafe { pyre_object::is_str(a) } => {
-                        // openlog(3) keeps the ident pointer, so it has to be a
-                        // C string.
-                        std::ffi::CString::new(crate::baseobjspace::str_utf8_w(a)?)
+                        // openlog(3) keeps a C string, so the ident ends at
+                        // the first NUL.
+                        let ident = crate::baseobjspace::str_utf8_w(a)?;
+                        let ident = ident.split_once('\0').map_or(ident, |(s, _)| s);
+                        std::ffi::CString::new(ident)
                             .ok()
                             .map(|c| c.into_boxed_c_str())
                     }

--- a/pyre/pyre-interpreter/src/module/syslog/syslog.rs
+++ b/pyre/pyre-interpreter/src/module/syslog/syslog.rs
@@ -20,15 +20,16 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         crate::make_builtin_function("openlog", |args| {
             #[cfg(all(unix, feature = "host_env"))]
             {
-                let ident = args.first().and_then(|&a| unsafe {
-                    if pyre_object::is_str(a) {
-                        std::ffi::CString::new(pyre_object::w_str_get_value(a))
+                let ident = match args.first() {
+                    Some(&a) if unsafe { pyre_object::is_str(a) } => {
+                        // openlog(3) keeps the ident pointer, so it has to be a
+                        // C string.
+                        std::ffi::CString::new(crate::baseobjspace::str_utf8_w(a)?)
                             .ok()
                             .map(|c| c.into_boxed_c_str())
-                    } else {
-                        None
                     }
-                });
+                    _ => None,
+                };
                 if args
                     .iter()
                     .skip(1)
@@ -85,7 +86,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                         "syslog(): message must be a string",
                     ));
                 }
-                let msg = unsafe { pyre_object::w_str_get_value(msg_obj) };
+                let msg = crate::baseobjspace::str_utf8_w(msg_obj)?;
                 if let Ok(cmsg) = std::ffi::CString::new(msg) {
                     // `lib_pypy/syslog.py:42-44` — auto-call openlog() with
                     // a NULL ident (libc falls back to argv[0]) so the

--- a/pyre/pyre-interpreter/src/module/time/interp_time.rs
+++ b/pyre/pyre-interpreter/src/module/time/interp_time.rs
@@ -281,8 +281,8 @@ pub fn get_time_info(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
             crate::type_methods::arg_type_name(name_obj)
         )));
     }
-    let name = unsafe { pyre_object::w_str_get_value(name_obj) };
-    let (implementation, monotonic, adjustable) = match name {
+    let name = unsafe { pyre_object::w_str_get_wtf8(name_obj) };
+    let (implementation, monotonic, adjustable) = match name.as_str().unwrap_or_default() {
         "time" => ("clock_gettime(CLOCK_REALTIME)", false, true),
         "monotonic" | "perf_counter" => {
             #[cfg(target_os = "macos")]
@@ -938,7 +938,7 @@ pub fn strftime(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
                 "strftime() argument 1 must be str",
             ));
         }
-        w_str_get_value(fmt)
+        w_str_get_wtf8(fmt).as_bytes()
     };
 
     let c_fmt = std::ffi::CString::new(fmt_str)
@@ -974,8 +974,15 @@ pub fn strftime(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
                     &libc_tm,
                 );
                 if n != 0 {
-                    let s = String::from_utf8_lossy(&buf[..n]);
-                    return Ok(w_str_new(&s));
+                    return Ok(w_str_from_wtf8(
+                        rustpython_wtf8::Wtf8Buf::from_bytes(buf[..n].to_vec()).unwrap_or_else(
+                            |b| {
+                                rustpython_wtf8::Wtf8Buf::from_string(
+                                    String::from_utf8_lossy(&b).into_owned(),
+                                )
+                            },
+                        ),
+                    ));
                 }
                 if buf.len() > 16384 {
                     return Ok(w_str_new(""));
@@ -1005,8 +1012,15 @@ pub fn strftime(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
                     &msvc_tm,
                 );
                 if n != 0 {
-                    let s = String::from_utf8_lossy(&buf[..n]);
-                    return Ok(w_str_new(&s));
+                    return Ok(w_str_from_wtf8(
+                        rustpython_wtf8::Wtf8Buf::from_bytes(buf[..n].to_vec()).unwrap_or_else(
+                            |b| {
+                                rustpython_wtf8::Wtf8Buf::from_string(
+                                    String::from_utf8_lossy(&b).into_owned(),
+                                )
+                            },
+                        ),
+                    ));
                 }
                 if buf.len() > 16384 {
                     return Ok(w_str_new(""));

--- a/pyre/pyre-interpreter/src/module/zlib/mod.rs
+++ b/pyre/pyre-interpreter/src/module/zlib/mod.rs
@@ -79,12 +79,11 @@ fn as_bytes(obj: PyObjectRef) -> Result<Vec<u8>, crate::PyError> {
     unsafe {
         if bytesobject::is_bytes_like(obj) {
             Ok(bytesobject::bytes_like_data(obj).to_vec())
-        } else if is_str(obj) {
-            Ok(w_str_get_value(obj).as_bytes().to_vec())
         } else {
-            Err(crate::PyError::type_error(
-                "a bytes-like object is required",
-            ))
+            Err(crate::PyError::type_error(format!(
+                "a bytes-like object is required, not '{}'",
+                crate::baseobjspace::object_functionstr_type_name(obj)
+            )))
         }
     }
 }

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -1104,6 +1104,22 @@ pub unsafe fn pyframe_get_pycode(frame: &PyFrame) -> *const CodeObject {
     unsafe { crate::w_code_get_ptr(frame.pycode as pyre_object::PyObjectRef) as *const CodeObject }
 }
 
+/// True when a `sys.settrace` / `sys.setprofile` hook is installed on the
+/// execution context this frame runs under.
+///
+/// `executioncontext.py:296-298` keeps the JIT on and widens `trace_limit`
+/// instead, because upstream's traces carry the per-bytecode hook calls.
+/// pyre's traces do not, so a frame that is being traced runs interpreted —
+/// `call_trace` / `bytecode_trace` are driven from the plain eval path.
+pub fn frame_tracing_active(frame: &PyFrame) -> bool {
+    let ec = frame.execution_context;
+    if ec.is_null() {
+        return false;
+    }
+    let ec = unsafe { &*ec };
+    !ec.gettrace().is_null() || ec.profilefunc.is_some()
+}
+
 #[repr(C)]
 #[derive(Clone)]
 pub struct FrameDebugData {

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -1111,13 +1111,14 @@ pub unsafe fn pyframe_get_pycode(frame: &PyFrame) -> *const CodeObject {
 /// instead, because upstream's traces carry the per-bytecode hook calls.
 /// pyre's traces do not, so a frame that is being traced runs interpreted —
 /// `call_trace` / `bytecode_trace` are driven from the plain eval path.
+/// A frame carrying its own `f_trace` also runs interpreted.
 pub fn frame_tracing_active(frame: &PyFrame) -> bool {
     let ec = frame.execution_context;
     if ec.is_null() {
         return false;
     }
     let ec = unsafe { &*ec };
-    !ec.gettrace().is_null() || ec.profilefunc.is_some()
+    !ec.gettrace().is_null() || ec.profilefunc.is_some() || !frame.get_w_f_trace().is_null()
 }
 
 #[repr(C)]

--- a/pyre/pyre-interpreter/src/runtime_ops.rs
+++ b/pyre/pyre-interpreter/src/runtime_ops.rs
@@ -653,14 +653,14 @@ pub fn convert_value(value: PyObjectRef, conv: i64) -> Result<PyObjectRef, crate
 /// fallible); a `PY_NULL` or non-`str` `spec` reads as the empty spec
 /// (`str(value)`), matching `format_simple`.
 pub fn format_value(value: PyObjectRef, spec: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
+    // The spec is read as WTF-8: its fill may be any code point, so
+    // `f"{x:\ud800>4}"` pads with the lone surrogate it was given instead of
+    // dropping a spec that has no `&str` view.
     let spec_str = unsafe {
         if !spec.is_null() && pyre_object::is_str(spec) {
-            match pyre_object::w_str_get_wtf8(spec).as_str() {
-                Ok(v) => v.to_string(),
-                Err(_) => String::new(),
-            }
+            pyre_object::w_str_get_wtf8(spec).to_wtf8_buf()
         } else {
-            String::new()
+            rustpython_wtf8::Wtf8Buf::new()
         }
     };
     crate::type_methods::format_value_dispatch_w(value, &spec_str)

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -2856,6 +2856,23 @@ fn format_finite_float(v: f64, spec: &Wtf8) -> Result<Wtf8Buf, crate::PyError> {
     } else {
         v
     };
+    if p.fill.to_char().is_none() {
+        // A fill with no `char` cannot come back out of the `String`-typed
+        // engine, so render the value unpadded and pad it by code point.
+        let unpadded_spec = float_engine_spec_with_width(&p, None);
+        let body = rustpython_common::format::FormatSpec::parse(&unpadded_spec)
+            .map_err(|e| format_spec_err(e, spec, "float", false))?
+            .format_float(v)
+            .map_err(|e| format_spec_err(e, spec, "float", false))?;
+        let body = match p.fractional_grouping {
+            Some(separator) => {
+                let digits = fractional_digit_count(&body);
+                group_fractional_digits(body, separator, digits)
+            }
+            None => body,
+        };
+        return Ok(pad_to_width(body, p.fill, p.align.unwrap_or('>'), p.width));
+    }
     if let Some(separator) = p.fractional_grouping {
         let unpadded_spec = float_engine_spec_with_width(&p, None);
         let unpadded = rustpython_common::format::FormatSpec::parse(&unpadded_spec)
@@ -2873,16 +2890,6 @@ fn format_finite_float(v: f64, spec: &Wtf8) -> Result<Wtf8Buf, crate::PyError> {
         return Ok(Wtf8Buf::from_string(group_fractional_digits(
             rendered, separator, digits,
         )));
-    }
-    if p.fill.to_char().is_none() {
-        // A fill with no `char` cannot come back out of the `String`-typed
-        // engine, so render the value unpadded and pad it by code point.
-        let unpadded_spec = float_engine_spec_with_width(&p, None);
-        let body = rustpython_common::format::FormatSpec::parse(&unpadded_spec)
-            .map_err(|e| format_spec_err(e, spec, "float", false))?
-            .format_float(v)
-            .map_err(|e| format_spec_err(e, spec, "float", false))?;
-        return Ok(pad_to_width(body, p.fill, p.align.unwrap_or('>'), p.width));
     }
     let parsed = rustpython_common::format::FormatSpec::parse(&p.engine_spec)
         .map_err(|e| format_spec_err(e, spec, "float", false))?;

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -1567,7 +1567,7 @@ fn format_render(
                 }
             },
         };
-        let formatted = format_value_dispatch(converted, resolved_spec.as_str().unwrap_or(""))?;
+        let formatted = format_value_dispatch(converted, &resolved_spec)?;
         result.push_wtf8(&formatted);
     }
     Ok(result)
@@ -1761,7 +1761,10 @@ fn format_parse_err(
 /// cannot format correctly — integer `c` and non-finite floats — read
 /// this back; every other case parses through `FormatSpec` directly.
 struct ParsedSpec {
-    fill: char,
+    /// The fill is the one position in a spec that may hold an arbitrary code
+    /// point — including a lone surrogate, which has no `char` — so it is kept
+    /// as a `CodePoint`.  Every other position is ASCII.
+    fill: CodePoint,
     align: Option<char>,
     sign: Option<char>,
     alt_form: bool,
@@ -1776,19 +1779,31 @@ struct ParsedSpec {
     /// The equivalent pre-3.14 spec accepted by rustpython-common's format
     /// engine (the fractional grouping marker, its otherwise-empty dot, and
     /// the `z` option are removed).
-    engine_spec: String,
+    engine_spec: Wtf8Buf,
     width_start: usize,
     width_end: usize,
 }
 
-fn parse_spec(spec: &str) -> ParsedSpec {
-    let chars: Vec<char> = spec.chars().collect();
+/// The lossy `char` view of a spec, for the scans that only test for ASCII
+/// delimiters.  A code point with no `char` (a lone surrogate) matches none of
+/// them, so substituting it changes no decision.
+fn spec_chars(spec: &Wtf8) -> Vec<char> {
+    spec.code_points().map(|cp| cp.to_char_lossy()).collect()
+}
+
+fn parse_spec(spec: &Wtf8) -> ParsedSpec {
+    let cps: Vec<CodePoint> = spec.code_points().collect();
+    // The structural scan below tests for ASCII delimiters only, so it runs on
+    // the lossy `char` view; a code point with no `char` matches none of them
+    // either way.  `cps` keeps the true code points for the fill and for the
+    // engine spec.
+    let chars: Vec<char> = cps.iter().map(|cp| cp.to_char_lossy()).collect();
     let mut i = 0;
     let n = chars.len();
-    let mut fill = ' ';
+    let mut fill = CodePoint::from_char(' ');
     let mut align: Option<char> = None;
     if n >= 2 && matches!(chars[1], '<' | '>' | '=' | '^') {
-        fill = chars[0];
+        fill = cps[0];
         align = Some(chars[1]);
         i = 2;
     } else if n >= 1 && matches!(chars[0], '<' | '>' | '=' | '^') {
@@ -1820,7 +1835,7 @@ fn parse_spec(spec: &str) -> ParsedSpec {
             align = Some('=');
         }
         if fill == ' ' {
-            fill = '0';
+            fill = CodePoint::from_char('0');
         }
         i += 1;
     }
@@ -1866,20 +1881,16 @@ fn parse_spec(spec: &str) -> ParsedSpec {
         }
     }
     let ty = if i < n { chars[i] } else { '\0' };
-    let engine_spec = chars
-        .iter()
-        .enumerate()
-        .filter_map(|(index, ch)| {
-            if Some(index) == fractional_grouping_index
-                || Some(index) == empty_precision_dot
-                || Some(index) == z_index
-            {
-                None
-            } else {
-                Some(*ch)
-            }
-        })
-        .collect();
+    let mut engine_spec = Wtf8Buf::with_capacity(spec.len());
+    for (index, cp) in cps.iter().enumerate() {
+        if Some(index) == fractional_grouping_index
+            || Some(index) == empty_precision_dot
+            || Some(index) == z_index
+        {
+            continue;
+        }
+        engine_spec.push(*cp);
+    }
     // `z` precedes the width, so dropping it from `engine_spec` shifts the
     // width slice left by one; `float_engine_spec_with_width` indexes the
     // engine spec, so bias the recorded bounds to match.
@@ -1939,7 +1950,7 @@ fn complex_component_spec(p: &ParsedSpec, sign: char) -> String {
 /// deliberately retains it.
 fn format_complex_component(
     value: f64,
-    spec: &str,
+    spec: &Wtf8,
     default_type: bool,
     alternate: bool,
 ) -> Result<String, crate::PyError> {
@@ -1962,19 +1973,19 @@ fn format_complex_component(
 /// grouping is applied after rustpython-common has rounded the number; reducing
 /// the engine width by the number of inserted separators keeps Python's width
 /// measured against the final grouped result.
-fn float_engine_spec_with_width(p: &ParsedSpec, width: Option<usize>) -> String {
-    let chars: Vec<char> = p.engine_spec.chars().collect();
-    let mut out = String::new();
-    for ch in &chars[..p.width_start] {
-        out.push(*ch);
+fn float_engine_spec_with_width(p: &ParsedSpec, width: Option<usize>) -> Wtf8Buf {
+    let cps: Vec<CodePoint> = p.engine_spec.code_points().collect();
+    let mut out = Wtf8Buf::new();
+    for cp in &cps[..p.width_start] {
+        out.push(*cp);
     }
     if let Some(width) = width
         && width != 0
     {
         out.push_str(&width.to_string());
     }
-    for ch in &chars[p.width_end..] {
-        out.push(*ch);
+    for cp in &cps[p.width_end..] {
+        out.push(*cp);
     }
     out
 }
@@ -2016,30 +2027,24 @@ fn group_fractional_digits(s: String, separator: char, digits: usize) -> String 
 /// Pad `body` to `width` characters with `fill`, honouring the numeric
 /// alignments.  `=` splits a leading sign (and `0x`/`0o`/`0b` base prefix)
 /// from the digits and inserts the fill between them.
-fn pad_to_width(body: String, fill: char, align: char, width: usize) -> String {
+fn pad_to_width(body: String, fill: CodePoint, align: char, width: usize) -> Wtf8Buf {
     if body.chars().count() >= width {
-        return body;
+        return Wtf8Buf::from_string(body);
     }
     let need = width - body.chars().count();
     match align {
         '<' => {
-            let mut s = body;
-            for _ in 0..need {
-                s.push(fill);
-            }
+            let mut s = Wtf8Buf::from_string(body);
+            push_cp_repeated(&mut s, fill, need);
             s
         }
         '^' => {
             let left = need / 2;
             let right = need - left;
-            let mut s = String::with_capacity(width);
-            for _ in 0..left {
-                s.push(fill);
-            }
+            let mut s = Wtf8Buf::with_capacity(width);
+            push_cp_repeated(&mut s, fill, left);
             s.push_str(&body);
-            for _ in 0..right {
-                s.push(fill);
-            }
+            push_cp_repeated(&mut s, fill, right);
             s
         }
         '=' => {
@@ -2062,19 +2067,15 @@ fn pad_to_width(body: String, fill: char, align: char, width: usize) -> String {
                 }
             }
             let digits: String = chars.collect();
-            let mut s = String::with_capacity(width);
+            let mut s = Wtf8Buf::with_capacity(width);
             s.push_str(&prefix);
-            for _ in 0..need {
-                s.push(fill);
-            }
+            push_cp_repeated(&mut s, fill, need);
             s.push_str(&digits);
             s
         }
         _ => {
-            let mut s = String::with_capacity(width);
-            for _ in 0..need {
-                s.push(fill);
-            }
+            let mut s = Wtf8Buf::with_capacity(width);
+            push_cp_repeated(&mut s, fill, need);
             s.push_str(&body);
             s
         }
@@ -2109,7 +2110,7 @@ fn separate_integer_digits(
 /// The shared parser remains the authority for format-spec syntax and error
 /// ordering; radix conversion, grouping, signs, prefixes, and padding operate
 /// directly on rbigint digits.
-fn format_rbigint(num: &BigInt, spec: &str, type_name: &str) -> Result<Wtf8Buf, crate::PyError> {
+fn format_rbigint(num: &BigInt, spec: &Wtf8, type_name: &str) -> Result<Wtf8Buf, crate::PyError> {
     let parsed = rustpython_common::format::FormatSpec::parse(spec)
         .map_err(|e| format_spec_err(e, spec, type_name, true))?;
     let p = parse_spec(spec);
@@ -2171,12 +2172,12 @@ fn format_rbigint(num: &BigInt, spec: &str, type_name: &str) -> Result<Wtf8Buf, 
         };
         magnitude = separate_integer_digits(magnitude, interval, separator, displayed_digits);
     }
-    Ok(Wtf8Buf::from_string(pad_to_width(
+    Ok(pad_to_width(
         format!("{sign_prefix}{magnitude}"),
         p.fill,
         p.align.unwrap_or('>'),
         p.width,
-    )))
+    ))
 }
 
 /// A `&str` paired with its precomputed code-point count, adapting a
@@ -2200,10 +2201,15 @@ impl rustpython_common::format::CharLen for CharLenStr<'_> {
 /// Render a presentation-type code for the "Unknown format code" message:
 /// printable ASCII (`0x21..=0x7f`) verbatim, anything else as `\x{hex}`.
 fn unknown_code_display(c: char) -> String {
-    if ('\u{21}'..='\u{7f}').contains(&c) {
-        c.to_string()
-    } else {
-        format!("\\x{:x}", c as u32)
+    unknown_code_point_display(CodePoint::from_char(c))
+}
+
+/// [`unknown_code_display`] for a code point that may have no `char` — a
+/// presentation slot holding a lone surrogate prints as its own escape.
+fn unknown_code_point_display(cp: CodePoint) -> String {
+    match cp.to_char() {
+        Some(c) if ('\u{21}'..='\u{7f}').contains(&c) => c.to_string(),
+        _ => format!("\\x{:x}", cp.to_u32()),
     }
 }
 
@@ -2213,7 +2219,7 @@ fn unknown_code_display(c: char) -> String {
 /// for the `z` presentation code.
 fn format_spec_err(
     err: rustpython_common::format::FormatSpecError,
-    spec: &str,
+    spec: &Wtf8,
     type_name: &str,
     integer: bool,
 ) -> crate::PyError {
@@ -2267,7 +2273,7 @@ fn format_spec_err(
 /// Public entry point for the f-string `FormatWithSpec` opcode in
 /// `eval.rs::format_with_spec`. Forwards to the same parser used by
 /// `str.format` so both surfaces share the spec semantics.
-pub fn format_with_spec_public(val: PyObjectRef, spec: &str) -> Result<Wtf8Buf, crate::PyError> {
+pub fn format_with_spec_public(val: PyObjectRef, spec: &Wtf8) -> Result<Wtf8Buf, crate::PyError> {
     format_with_spec(val, spec)
 }
 
@@ -2301,7 +2307,7 @@ pub(crate) fn call_format_dispatch(
 /// apply the shared builtin spec parser, with an empty spec collapsing to
 /// `str(value)`.  Shared by `format()`, the `FormatSimple`/`FormatWithSpec`
 /// f-string opcodes, and `str.format` field formatting.
-pub fn format_value_dispatch(val: PyObjectRef, spec: &str) -> Result<Wtf8Buf, crate::PyError> {
+pub fn format_value_dispatch(val: PyObjectRef, spec: &Wtf8) -> Result<Wtf8Buf, crate::PyError> {
     // Fast path for common types.  An exact `str` or `int` cannot carry a
     // `__format__` override, and with an empty spec its builtin `__format__`
     // is `str(value)` — so resolve and call nothing.  `bool` is excluded (it
@@ -2327,7 +2333,7 @@ pub fn format_value_dispatch(val: PyObjectRef, spec: &str) -> Result<Wtf8Buf, cr
         if unsafe { is_instance(val) }
             || !unsafe { py_type_check(meth, &crate::function::BUILTIN_FUNCTION_TYPE) }
         {
-            let spec_obj = pyre_object::w_str_new(spec);
+            let spec_obj = pyre_object::w_str_from_wtf8(spec.to_wtf8_buf());
             return call_format_dispatch(val, meth, spec_obj);
         }
     }
@@ -2386,9 +2392,12 @@ pub(crate) fn arg_type_name(obj: PyObjectRef) -> String {
 pub(crate) fn read_format_spec(
     spec_obj: PyObjectRef,
     arg_desc: &str,
-) -> Result<String, crate::PyError> {
+) -> Result<Wtf8Buf, crate::PyError> {
     if !spec_obj.is_null() && unsafe { is_str(spec_obj) } {
-        return Ok(unsafe { w_str_get_value(spec_obj) }.to_string());
+        // Read through the raw buffer: the fill character may be any code
+        // point, so `format(x, '\ud800<6')` pads with the lone surrogate it
+        // was given rather than demanding a `&str` view of the buffer.
+        return Ok(unsafe { pyre_object::w_str_get_wtf8(spec_obj) }.to_wtf8_buf());
     }
     Err(crate::PyError::type_error(format!(
         "{arg_desc} must be str, not {}",
@@ -2404,7 +2413,7 @@ pub fn builtin_value_format(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::
     let spec = if args.len() > 1 {
         read_format_spec(args[1], "__format__() argument")?
     } else {
-        String::new()
+        Wtf8Buf::new()
     };
     if spec.is_empty() {
         // `format_string` (newformat.py:602-608) wraps the receiver's own utf8
@@ -2429,7 +2438,7 @@ pub fn builtin_value_format(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::
     ))
 }
 
-fn format_with_spec(val: PyObjectRef, spec: &str) -> Result<Wtf8Buf, crate::PyError> {
+fn format_with_spec(val: PyObjectRef, spec: &Wtf8) -> Result<Wtf8Buf, crate::PyError> {
     use rustpython_common::format::FormatSpec;
     unsafe {
         // `int` / `bool` / `long` share the integer formatter.  The `c`
@@ -2453,7 +2462,7 @@ fn format_with_spec(val: PyObjectRef, spec: &str) -> Result<Wtf8Buf, crate::PyEr
                     "Negative zero coercion (z) not allowed",
                 ));
             }
-            if spec.ends_with('c') && parsed.is_ok() {
+            if spec.ends_with("c") && parsed.is_ok() {
                 return format_char(&big, spec);
             }
             // A float presentation code formats the `f64` conversion (`n` and
@@ -2525,8 +2534,10 @@ fn format_with_spec(val: PyObjectRef, spec: &str) -> Result<Wtf8Buf, crate::PyEr
                 '+'
             };
             let imag_spec = complex_component_spec(&p, imag_sign);
-            let real_text = format_complex_component(re, &real_spec, default_type, p.alt_form)?;
-            let imag_text = format_complex_component(im, &imag_spec, default_type, p.alt_form)?;
+            let real_text =
+                format_complex_component(re, real_spec.as_str().into(), default_type, p.alt_form)?;
+            let imag_text =
+                format_complex_component(im, imag_spec.as_str().into(), default_type, p.alt_form)?;
             let text = if default_type && re == 0.0 && re.is_sign_positive() {
                 format!("{imag_text}j")
             } else if default_type {
@@ -2546,7 +2557,7 @@ fn format_with_spec(val: PyObjectRef, spec: &str) -> Result<Wtf8Buf, crate::PyEr
             // A `0` fill flag at the start of the width pads text with the
             // default-left alignment; the shared formatter treats it as a
             // numeric alignment, so handle it here.
-            let sc: Vec<char> = spec.chars().collect();
+            let sc = spec_chars(spec);
             let zero_fill = if sc.len() >= 2 && matches!(sc[1], '<' | '>' | '=' | '^') {
                 sc.get(2) == Some(&'0')
             } else if sc
@@ -2561,8 +2572,10 @@ fn format_with_spec(val: PyObjectRef, spec: &str) -> Result<Wtf8Buf, crate::PyEr
                 return format_surrogate_str(full, spec);
             }
             // A valid-UTF-8 body goes through the shared string formatter,
-            // which pads by code point.
-            if let Ok(valid) = full.as_str() {
+            // which pads by code point.  A spec carrying a lone surrogate —
+            // its fill — has to be padded here instead, since the shared
+            // formatter yields a `String`.
+            if let (Ok(valid), Ok(_)) = (full.as_str(), spec.as_str()) {
                 let parsed =
                     FormatSpec::parse(spec).map_err(|e| format_spec_err(e, spec, "str", false))?;
                 let s = parsed
@@ -2592,8 +2605,8 @@ fn format_with_spec(val: PyObjectRef, spec: &str) -> Result<Wtf8Buf, crate::PyEr
 /// formatter.  Only the *explicit* alignment is inspected: a leading `0` flag
 /// (which the shared parser normalises to `=`) is a zero fill and stays legal
 /// for text, and a `#` used as a fill character precedes the alignment.
-fn reject_string_sign_align(spec: &str) -> Result<(), crate::PyError> {
-    let chars: Vec<char> = spec.chars().collect();
+fn reject_string_sign_align(spec: &Wtf8) -> Result<(), crate::PyError> {
+    let chars = spec_chars(spec);
     let n = chars.len();
     let mut i = 0;
     let mut align: Option<char> = None;
@@ -2630,14 +2643,15 @@ fn reject_string_sign_align(spec: &str) -> Result<(), crate::PyError> {
 /// and an optional `s` type — are honoured; a numeric presentation type
 /// raises the same "unknown format code" error the valid-UTF-8 path does.
 /// A sign / `=` alignment is rejected by the caller.
-fn format_surrogate_str(body: &Wtf8, spec: &str) -> Result<Wtf8Buf, crate::PyError> {
-    let chars: Vec<char> = spec.chars().collect();
+fn format_surrogate_str(body: &Wtf8, spec: &Wtf8) -> Result<Wtf8Buf, crate::PyError> {
+    let cps: Vec<CodePoint> = spec.code_points().collect();
+    let chars: Vec<char> = cps.iter().map(|cp| cp.to_char_lossy()).collect();
     let n = chars.len();
     let mut i = 0;
-    let mut fill = ' ';
+    let mut fill = CodePoint::from_char(' ');
     let mut align = '<';
     if n >= 2 && matches!(chars[1], '<' | '>' | '=' | '^') {
-        fill = chars[0];
+        fill = cps[0];
         align = chars[1];
         i = 2;
     } else if n >= 1 && matches!(chars[0], '<' | '>' | '=' | '^') {
@@ -2645,7 +2659,7 @@ fn format_surrogate_str(body: &Wtf8, spec: &str) -> Result<Wtf8Buf, crate::PyErr
         i = 1;
     }
     if i < n && chars[i] == '0' {
-        fill = '0';
+        fill = CodePoint::from_char('0');
         i += 1;
     }
     let mut width = 0usize;
@@ -2664,10 +2678,10 @@ fn format_surrogate_str(body: &Wtf8, spec: &str) -> Result<Wtf8Buf, crate::PyErr
         precision = Some(p);
     }
     if i < n {
-        let ty = chars[i];
-        if ty != 's' {
+        if chars[i] != 's' {
             return Err(crate::PyError::value_error(format!(
-                "Unknown format code '{ty}' for object of type 'str'"
+                "Unknown format code '{}' for object of type 'str'",
+                unknown_code_point_display(cps[i])
             )));
         }
         i += 1;
@@ -2696,7 +2710,7 @@ fn format_surrogate_str(body: &Wtf8, spec: &str) -> Result<Wtf8Buf, crate::PyErr
 /// that make no sense for a single character, map the value to its code
 /// point, then pad by code point.  The caller has already confirmed the
 /// spec parses and ends in `c`.
-fn format_char(num: &BigInt, spec: &str) -> Result<Wtf8Buf, crate::PyError> {
+fn format_char(num: &BigInt, spec: &Wtf8) -> Result<Wtf8Buf, crate::PyError> {
     let p = parse_spec(spec);
     // Rejection order matches the reference: grouping, then precision, then
     // sign, then alternate form — each beats the value range check.
@@ -2745,7 +2759,7 @@ fn format_char(num: &BigInt, spec: &str) -> Result<Wtf8Buf, crate::PyError> {
 /// signed word (`inf` / `nan`, upper-cased for `E`/`F`/`G`, `%`-suffixed
 /// for the percentage type) padded to width.  Grouping only validates
 /// here — a non-finite value has no digits to separate.
-fn format_nonfinite(v: f64, spec: &str) -> Result<Wtf8Buf, crate::PyError> {
+fn format_nonfinite(v: f64, spec: &Wtf8) -> Result<Wtf8Buf, crate::PyError> {
     let p = parse_spec(spec);
     validate_float_spec(spec, &p)?;
     let upper = matches!(p.ty, 'E' | 'F' | 'G');
@@ -2771,12 +2785,7 @@ fn format_nonfinite(v: f64, spec: &str) -> Result<Wtf8Buf, crate::PyError> {
         }
     };
     let body = format!("{sign}{magnitude}");
-    Ok(Wtf8Buf::from_string(pad_to_width(
-        body,
-        p.fill,
-        p.align.unwrap_or('>'),
-        p.width,
-    )))
+    Ok(pad_to_width(body, p.fill, p.align.unwrap_or('>'), p.width))
 }
 
 /// Validate a float presentation spec against the reference rules,
@@ -2784,8 +2793,8 @@ fn format_nonfinite(v: f64, spec: &str) -> Result<Wtf8Buf, crate::PyError> {
 /// precision beyond `i32`, trailing garbage) come from the shared parser
 /// for their exact messages; the type and grouping-with-`n` checks are
 /// applied on top.
-fn validate_float_spec(spec: &str, p: &ParsedSpec) -> Result<(), crate::PyError> {
-    rustpython_common::format::FormatSpec::parse(p.engine_spec.as_str())
+fn validate_float_spec(spec: &Wtf8, p: &ParsedSpec) -> Result<(), crate::PyError> {
+    rustpython_common::format::FormatSpec::parse(&p.engine_spec)
         .map_err(|e| format_spec_err(e, spec, "float", false))?;
     if !matches!(p.ty, '\0' | 'e' | 'E' | 'f' | 'F' | 'g' | 'G' | 'n' | '%') {
         return Err(crate::PyError::value_error(format!(
@@ -2814,7 +2823,7 @@ fn validate_float_spec(spec: &str, p: &ParsedSpec) -> Result<(), crate::PyError>
 /// the unpadded rendering is `0` — so PEP 682's `z` option coerces its sign.
 fn float_rounds_to_zero(v: f64, p: &ParsedSpec) -> bool {
     let probe_spec = float_engine_spec_with_width(p, Some(0));
-    let Some(rendered) = rustpython_common::format::FormatSpec::parse(probe_spec.as_str())
+    let Some(rendered) = rustpython_common::format::FormatSpec::parse(&probe_spec)
         .ok()
         .and_then(|f| f.format_float(v).ok())
     else {
@@ -2836,7 +2845,7 @@ fn float_rounds_to_zero(v: f64, p: &ParsedSpec) -> bool {
 /// (`\0`/`e`/`E`/`f`/`F`/`g`/`G`/`n`/`%`) pads, groups, and rounds through the
 /// shared engine.  `validate_float_spec` still supplies the type and
 /// grouping-with-`n` messages before delegating.
-fn format_finite_float(v: f64, spec: &str) -> Result<Wtf8Buf, crate::PyError> {
+fn format_finite_float(v: f64, spec: &Wtf8) -> Result<Wtf8Buf, crate::PyError> {
     let p = parse_spec(spec);
     validate_float_spec(spec, &p)?;
     // PEP 682 `z`: a value that rounds to a zero magnitude renders its sign
@@ -2849,7 +2858,7 @@ fn format_finite_float(v: f64, spec: &str) -> Result<Wtf8Buf, crate::PyError> {
     };
     if let Some(separator) = p.fractional_grouping {
         let unpadded_spec = float_engine_spec_with_width(&p, None);
-        let unpadded = rustpython_common::format::FormatSpec::parse(unpadded_spec.as_str())
+        let unpadded = rustpython_common::format::FormatSpec::parse(&unpadded_spec)
             .map_err(|e| format_spec_err(e, spec, "float", false))?
             .format_float(v)
             .map_err(|e| format_spec_err(e, spec, "float", false))?;
@@ -2857,7 +2866,7 @@ fn format_finite_float(v: f64, spec: &str) -> Result<Wtf8Buf, crate::PyError> {
         let separators = digits.saturating_sub(1) / 3;
         let adjusted_width = p.width.saturating_sub(separators);
         let adjusted_spec = float_engine_spec_with_width(&p, Some(adjusted_width));
-        let rendered = rustpython_common::format::FormatSpec::parse(adjusted_spec.as_str())
+        let rendered = rustpython_common::format::FormatSpec::parse(&adjusted_spec)
             .map_err(|e| format_spec_err(e, spec, "float", false))?
             .format_float(v)
             .map_err(|e| format_spec_err(e, spec, "float", false))?;
@@ -2865,7 +2874,17 @@ fn format_finite_float(v: f64, spec: &str) -> Result<Wtf8Buf, crate::PyError> {
             rendered, separator, digits,
         )));
     }
-    let parsed = rustpython_common::format::FormatSpec::parse(p.engine_spec.as_str())
+    if p.fill.to_char().is_none() {
+        // A fill with no `char` cannot come back out of the `String`-typed
+        // engine, so render the value unpadded and pad it by code point.
+        let unpadded_spec = float_engine_spec_with_width(&p, None);
+        let body = rustpython_common::format::FormatSpec::parse(&unpadded_spec)
+            .map_err(|e| format_spec_err(e, spec, "float", false))?
+            .format_float(v)
+            .map_err(|e| format_spec_err(e, spec, "float", false))?;
+        return Ok(pad_to_width(body, p.fill, p.align.unwrap_or('>'), p.width));
+    }
+    let parsed = rustpython_common::format::FormatSpec::parse(&p.engine_spec)
         .map_err(|e| format_spec_err(e, spec, "float", false))?;
     let s = parsed
         .format_float(v)
@@ -2876,13 +2895,12 @@ fn format_finite_float(v: f64, spec: &str) -> Result<Wtf8Buf, crate::PyError> {
 /// Pad a WTF-8 string body to `width` code points with `fill`,
 /// honouring `<` / `^` / `>` alignment.  String bodies never use the
 /// numeric `=` alignment, so any non-`<`/`^` alignment right-aligns.
-fn pad_wtf8(body: &Wtf8, fill: char, align: char, width: usize) -> Wtf8Buf {
+fn pad_wtf8(body: &Wtf8, fill_cp: CodePoint, align: char, width: usize) -> Wtf8Buf {
     let body_len = body.code_points().count();
     if body_len >= width {
         return body.to_wtf8_buf();
     }
     let need = width - body_len;
-    let fill_cp = CodePoint::from_char(fill);
     let mut out = Wtf8Buf::with_capacity(body.len() + need * 4);
     match align {
         '<' => {
@@ -3046,7 +3064,7 @@ pub fn str_method_encode(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyE
             None => Ok(default.to_string()),
             Some(o) if o.is_null() => Ok(default.to_string()),
             Some(o) if unsafe { pyre_object::is_str(o) } => {
-                Ok(unsafe { w_str_get_value(o) }.to_string())
+                Ok(crate::baseobjspace::str_utf8_w(o)?.to_string())
             }
             Some(o) => {
                 let tname = unsafe { pyre_object::type_name_of(o) };

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -2360,7 +2360,7 @@ pub fn format_value_dispatch(val: PyObjectRef, spec: &Wtf8) -> Result<Wtf8Buf, c
 /// a new string through [`format_value_dispatch`].
 pub fn format_value_dispatch_w(
     val: PyObjectRef,
-    spec: &str,
+    spec: &Wtf8,
 ) -> Result<PyObjectRef, crate::PyError> {
     if spec.is_empty() && unsafe { pyre_object::is_exact_type(val, &pyre_object::STR_TYPE) } {
         return Ok(val);

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -2911,7 +2911,7 @@ fn pad_wtf8(body: &Wtf8, fill: char, align: char, width: usize) -> Wtf8Buf {
 /// are routed to the named error handler.  `w_object` is the str being
 /// encoded, threaded through so a strict failure can build a structured
 /// UnicodeEncodeError carrying it.
-fn encode_utf8_with_errors(
+pub(crate) fn encode_utf8_with_errors(
     w_object: PyObjectRef,
     err_mode: &str,
 ) -> Result<Vec<u8>, crate::PyError> {

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -2303,9 +2303,7 @@ fn module_descr_getattribute(args: &[PyObjectRef]) -> Result<PyObjectRef, crate:
     let name = crate::baseobjspace::text_wtf8_w(args[1])?;
     match name.as_str() {
         Ok(s) => crate::baseobjspace::module_getattribute(module, s),
-        Err(_) => unsafe {
-            crate::baseobjspace::module_getattribute_wtf8(module, args[1], name)
-        },
+        Err(_) => unsafe { crate::baseobjspace::module_getattribute_wtf8(module, args[1], name) },
     }
 }
 

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -3344,10 +3344,10 @@ fn super_descr_repr(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
 }
 
 fn super_descr_getattribute(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    if !unsafe { pyre_object::is_str(args[1]) } {
-        return Err(crate::PyError::type_error("attribute name must be string"));
-    }
-    crate::baseobjspace::getattr_str(args[0], unsafe { pyre_object::w_str_get_value(args[1]) })
+    // Routed by name object rather than by `&str` so a name that carries a
+    // lone surrogate takes the surrogate-aware lookup instead of demanding a
+    // view its buffer cannot give; the string check comes with it.
+    crate::baseobjspace::getattr(args[0], args[1])
 }
 
 fn super_descr_get(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
@@ -9712,11 +9712,9 @@ fn init_type_type(ns: PyObjectRef) {
 
     let qualname_getter = make_builtin_function_with_arity(
         "__qualname__",
-        |args| unsafe {
-            Ok(pyre_object::w_str_new(pyre_object::w_type_get_qualname(
-                args[1],
-            )))
-        },
+        // The name object rather than its `&str` view, so an assigned
+        // qualname that carries a lone surrogate reads back unchanged.
+        |args| unsafe { Ok(pyre_object::w_type_get_qualname_obj(args[1])) },
         2,
     );
     let qualname_setter = make_builtin_function_with_arity(
@@ -15961,7 +15959,7 @@ fn bytearray_descr_new_impl(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::
         // bytearrayobject.py:217 — str source shares bytesobject.newbytesdata_w
         if pyre_object::is_str(arg) {
             let encoding = match w_encoding {
-                Some(e) if pyre_object::is_str(e) => pyre_object::w_str_get_value(e),
+                Some(e) if pyre_object::is_str(e) => crate::baseobjspace::str_utf8_w(e)?,
                 _ => {
                     return Err(crate::PyError::type_error(
                         "string argument without an encoding",
@@ -15969,7 +15967,7 @@ fn bytearray_descr_new_impl(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::
                 }
             };
             let errors = match w_errors {
-                Some(e) if pyre_object::is_str(e) => pyre_object::w_str_get_value(e),
+                Some(e) if pyre_object::is_str(e) => crate::baseobjspace::str_utf8_w(e)?,
                 _ => "strict",
             };
             let encoded = crate::type_methods::encode_object(arg, encoding, errors)?;
@@ -18734,15 +18732,15 @@ pub(crate) fn bytes_method_decode(args: &[PyObjectRef]) -> Result<PyObjectRef, c
         }
     }
     let encoding = match w_encoding {
-        Some(e) if unsafe { pyre_object::is_str(e) } => unsafe {
-            pyre_object::w_str_get_value(e).to_string()
-        },
+        Some(e) if unsafe { pyre_object::is_str(e) } => {
+            crate::baseobjspace::str_utf8_w(e)?.to_string()
+        }
         _ => "utf-8".to_string(),
     };
     let errors = match w_errors {
-        Some(e) if unsafe { pyre_object::is_str(e) } => unsafe {
-            pyre_object::w_str_get_value(e).to_string()
-        },
+        Some(e) if unsafe { pyre_object::is_str(e) } => {
+            crate::baseobjspace::str_utf8_w(e)?.to_string()
+        }
         _ => "strict".to_string(),
     };
     let s = decode_bytes_to_wtf8(data, &encoding, errors.as_str())?;
@@ -18975,7 +18973,7 @@ fn bytes_descr_new_impl(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyEr
     unsafe {
         if pyre_object::is_str(arg) {
             let encoding = match w_encoding {
-                Some(e) if pyre_object::is_str(e) => pyre_object::w_str_get_value(e),
+                Some(e) if pyre_object::is_str(e) => crate::baseobjspace::str_utf8_w(e)?,
                 _ => {
                     return Err(crate::PyError::type_error(
                         "string argument without an encoding",
@@ -18983,7 +18981,7 @@ fn bytes_descr_new_impl(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyEr
                 }
             };
             let errors = match w_errors {
-                Some(e) if pyre_object::is_str(e) => pyre_object::w_str_get_value(e),
+                Some(e) if pyre_object::is_str(e) => crate::baseobjspace::str_utf8_w(e)?,
                 _ => "strict",
             };
             let encoded = crate::type_methods::encode_object(arg, encoding, errors)?;

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -2297,8 +2297,16 @@ pub(crate) fn module_repr_string(module: PyObjectRef) -> Result<String, crate::P
 /// entry point into that same implementation.
 fn module_descr_getattribute(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let module = module_require(args.first().copied().unwrap_or(PY_NULL), "__getattribute__")?;
-    let name = crate::baseobjspace::text_w(args[1])?;
-    crate::baseobjspace::module_getattribute(module, name)
+    // The descriptor is reachable with any name `getattr` accepts, so it
+    // takes the same WTF-8 split rather than demanding a `&str` view a
+    // lone-surrogate name cannot give.
+    let name = crate::baseobjspace::text_wtf8_w(args[1])?;
+    match name.as_str() {
+        Ok(s) => crate::baseobjspace::module_getattribute(module, s),
+        Err(_) => unsafe {
+            crate::baseobjspace::module_getattribute_wtf8(module, args[1], name)
+        },
+    }
 }
 
 /// module.py:164-173 `Module.descr_module__dir__`.

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -6180,6 +6180,12 @@ fn eval_with_jit_inner(frame: &mut PyFrame) -> PyResult {
     if *PYRE_JIT_DISABLED.get_or_init(|| std::env::var("PYRE_JIT").as_deref() == Ok("0")) {
         return frame.execute_frame(None, None);
     }
+    // A traced frame runs interpreted: `call_trace` / `return_trace` /
+    // `bytecode_trace` are driven from the plain eval path, so a frame the JIT
+    // takes over reports no events at all.
+    if pyre_interpreter::pyframe::frame_tracing_active(frame) {
+        return frame.execute_frame(None, None);
+    }
     let mut frame_root = FrameRoot::new(frame);
     let code = unsafe { &*pyre_interpreter::pyframe_get_pycode(frame_root.frame()) };
     pyre_interpreter::call::register_eval_override(eval_with_jit);

--- a/pyre/pyre-macros/src/lib.rs
+++ b/pyre/pyre-macros/src/lib.rs
@@ -76,7 +76,10 @@ fn expand_pyre_function(func: ItemFn) -> syn::Result<proc_macro2::TokenStream> {
     let mut call_args = Vec::<proc_macro2::TokenStream>::new();
     let mut param_names = Vec::<String>::new();
     let mut param_required = Vec::<bool>::new();
+    let mut param_positional = Vec::<bool>::new();
     let mut has_varargs = false;
+    let mut has_kw_markers = false;
+    let mut kwonly_tail = false;
     let user_name_str = user_name.to_string();
     for (idx, arg) in user_sig.inputs.iter().enumerate() {
         let pat_type = match arg {
@@ -91,10 +94,19 @@ fn expand_pyre_function(func: ItemFn) -> syn::Result<proc_macro2::TokenStream> {
         if is_varargs_param(&pat_type.ty) {
             has_varargs = true;
         }
+        let is_kwonly = pat_type.attrs.iter().any(|a| a.path().is_ident("kwonly"));
+        let is_kwargs = pat_type.attrs.iter().any(|a| a.path().is_ident("kwargs"));
+        if is_kwonly {
+            kwonly_tail = true;
+        }
+        if is_kwonly || is_kwargs {
+            has_kw_markers = true;
+        }
         param_names.push(param_name(idx, pat_type));
         // Optional iff it has a `#[default(...)]` or is `Option<T>`.
         param_required
             .push(arg_default(pat_type)?.is_none() && option_inner(&pat_type.ty).is_none());
+        param_positional.push(!kwonly_tail && !is_kwargs);
         let (unwrap, ident) = unwrap_arg(idx, pat_type, Some((&user_name_str, idx + 1)))?;
         unwrap_stmts.push(unwrap);
         call_args.push(quote! { #ident });
@@ -113,6 +125,8 @@ fn expand_pyre_function(func: ItemFn) -> syn::Result<proc_macro2::TokenStream> {
         let req_lits = param_required.iter().map(|b| quote! { #b });
         let fn_name_str = user_name.to_string();
         quote! {
+            let __pyre_positional_count =
+                crate::builtins::split_builtin_kwargs(args).0.len();
             const __PYRE_PARAM_NAMES: &[&str] = &[ #(#name_lits),* ];
             const __PYRE_PARAM_REQUIRED: &[bool] = &[ #(#req_lits),* ];
             let __pyre_bound_args;
@@ -139,8 +153,15 @@ fn expand_pyre_function(func: ItemFn) -> syn::Result<proc_macro2::TokenStream> {
     let count_preamble = if has_varargs {
         quote! {}
     } else {
-        let total = param_required.len();
-        let required = param_required.iter().filter(|&&required| required).count();
+        let total = param_positional
+            .iter()
+            .filter(|&&positional| positional)
+            .count();
+        let required = param_required
+            .iter()
+            .zip(param_positional.iter())
+            .filter(|(required, positional)| **required && **positional)
+            .count();
         let fn_name = user_name.to_string();
         let too_few = arity_message(&fn_name, required, total, false);
         let too_many = arity_message(&fn_name, required, total, true);
@@ -148,7 +169,7 @@ fn expand_pyre_function(func: ItemFn) -> syn::Result<proc_macro2::TokenStream> {
             if args.len() < #required {
                 return ::std::result::Result::Err(crate::PyError::type_error(#too_few));
             }
-            if args.len() > #total {
+            if __pyre_positional_count > #total {
                 return ::std::result::Result::Err(crate::PyError::type_error(#too_many));
             }
         }
@@ -252,15 +273,20 @@ fn expand_pyre_function(func: ItemFn) -> syn::Result<proc_macro2::TokenStream> {
     // builtin may declare.  `BuiltinCode.fast_natural_arity` names the one
     // argument count at which the body may be entered with its slots filled
     // directly, so it exists only when every parameter is required: an
-    // optional parameter (`#[default(...)]` or `Option<T>`) and a raw
-    // whole-args slice both admit more than one count, and get `HOPELESS`.
+    // optional parameter (`#[default(...)]` or `Option<T>`), a keyword-only
+    // or `**kwargs` marker and a raw whole-args slice all admit more than one
+    // count, and get `HOPELESS`.
     let arity_fn_name = format_ident!("{}_pyre_arity", user_name);
-    let natural_arity = if has_varargs || param_required.iter().any(|required| !required) {
-        quote! { crate::HOPELESS }
-    } else {
-        let n = param_required.len() as u16;
-        quote! { #n }
-    };
+    let natural_arity =
+        if has_varargs || has_kw_markers || param_required.iter().any(|required| !required) {
+            quote! { crate::HOPELESS }
+        } else {
+            let n = param_positional
+                .iter()
+                .filter(|&&positional| positional)
+                .count() as u16;
+            quote! { #n }
+        };
     let arity_fn = quote! {
         #[allow(dead_code)]
         #vis fn #arity_fn_name() -> u16 {
@@ -1774,7 +1800,9 @@ fn expand_pyre_methods(
         let mut call_args = Vec::<proc_macro2::TokenStream>::new();
         let mut param_names = Vec::<String>::new();
         let mut param_required = Vec::<bool>::new();
+        let mut param_positional = Vec::<bool>::new();
         let mut has_varargs = false;
+        let mut kwonly_tail = false;
         for (offset, arg) in inputs.enumerate() {
             let FnArg::Typed(pt) = arg else {
                 return Err(syn::Error::new(
@@ -1786,9 +1814,15 @@ fn expand_pyre_methods(
             if is_varargs_param(&pt.ty) {
                 has_varargs = true;
             }
+            let is_kwonly = pt.attrs.iter().any(|a| a.path().is_ident("kwonly"));
+            let is_kwargs = pt.attrs.iter().any(|a| a.path().is_ident("kwargs"));
+            if is_kwonly {
+                kwonly_tail = true;
+            }
             param_names.push(param_name(offset, pt));
             // Optional iff it has a `#[default(...)]` or is `Option<T>`.
             param_required.push(arg_default(pt)?.is_none() && option_inner(&pt.ty).is_none());
+            param_positional.push(!kwonly_tail && !is_kwargs);
             let (stmt, ident) = unwrap_arg(arg_idx, pt, None)?;
             unwrap_stmts.push(stmt);
             call_args.push(quote! { #ident });
@@ -1824,6 +1858,8 @@ fn expand_pyre_methods(
                 let req_lits = all_required.iter().map(|b| quote! { #b });
                 let fn_name_str = mname.to_string();
                 quote! {
+                    let __pyre_positional_count =
+                        crate::builtins::split_builtin_kwargs(args).0.len();
                     const __PYRE_PARAM_NAMES: &[&str] = &[ #(#name_lits),* ];
                     const __PYRE_PARAM_REQUIRED: &[bool] = &[ #(#req_lits),* ];
                     let __pyre_bound_args;
@@ -1857,8 +1893,15 @@ fn expand_pyre_methods(
                 quote! {}
             } else {
                 let receiver_slots = usize::from(matches!(kind, MethodKind::Instance));
-                let visible_max = param_names.len();
-                let visible_required = param_required.iter().filter(|&&required| required).count();
+                let visible_max = param_positional
+                    .iter()
+                    .filter(|&&positional| positional)
+                    .count();
+                let visible_required = param_required
+                    .iter()
+                    .zip(param_positional.iter())
+                    .filter(|(required, positional)| **required && **positional)
+                    .count();
                 let expected_total = receiver_slots + visible_max;
                 let fn_name = mname.to_string();
                 let expected = if visible_required == visible_max {
@@ -1897,7 +1940,7 @@ fn expand_pyre_methods(
                     if args.len() < #expected_min {
                         return ::std::result::Result::Err(crate::PyError::type_error(#too_few));
                     }
-                    if args.len() > #expected_total {
+                    if __pyre_positional_count > #expected_total {
                         return ::std::result::Result::Err(crate::PyError::type_error(format!(
                             "{}() takes {} ({} given)",
                             #fn_name,

--- a/pyre/pyre-macros/src/lib.rs
+++ b/pyre/pyre-macros/src/lib.rs
@@ -131,6 +131,29 @@ fn expand_pyre_function(func: ItemFn) -> syn::Result<proc_macro2::TokenStream> {
         }
     };
 
+    // `Arguments.parse_obj` rejects a positional count that does not fit the
+    // signature before `BuiltinCode.funcrun` enters the unwrapped body.  The
+    // unwrap statements below index their slots directly, so the count is
+    // checked here — a missing required slot would otherwise read past the
+    // end of `args`.  A raw whole-args slice takes any count.
+    let count_preamble = if has_varargs {
+        quote! {}
+    } else {
+        let total = param_required.len();
+        let required = param_required.iter().filter(|&&required| required).count();
+        let fn_name = user_name.to_string();
+        let too_few = arity_message(&fn_name, required, total, false);
+        let too_many = arity_message(&fn_name, required, total, true);
+        quote! {
+            if args.len() < #required {
+                return ::std::result::Result::Err(crate::PyError::type_error(#too_few));
+            }
+            if args.len() > #total {
+                return ::std::result::Result::Err(crate::PyError::type_error(#too_many));
+            }
+        }
+    };
+
     let call_inner = quote! { #inner_name( #(#call_args),* ) };
     let body = wrap_return(&user_sig.output, call_inner)?;
 
@@ -159,6 +182,7 @@ fn expand_pyre_function(func: ItemFn) -> syn::Result<proc_macro2::TokenStream> {
             args: &[::pyre_object::PyObjectRef],
         ) -> ::std::result::Result<::pyre_object::PyObjectRef, crate::PyError> {
             #kwargs_preamble
+            #count_preamble
             #(#unwrap_stmts)*
             #body
         }
@@ -224,10 +248,31 @@ fn expand_pyre_function(func: ItemFn) -> syn::Result<proc_macro2::TokenStream> {
         }
     };
 
+    // Companion `<name>_pyre_arity()` — the `fast_natural_arity` this
+    // builtin may declare.  `BuiltinCode.fast_natural_arity` names the one
+    // argument count at which the body may be entered with its slots filled
+    // directly, so it exists only when every parameter is required: an
+    // optional parameter (`#[default(...)]` or `Option<T>`) and a raw
+    // whole-args slice both admit more than one count, and get `HOPELESS`.
+    let arity_fn_name = format_ident!("{}_pyre_arity", user_name);
+    let natural_arity = if has_varargs || param_required.iter().any(|required| !required) {
+        quote! { crate::HOPELESS }
+    } else {
+        let n = param_required.len() as u16;
+        quote! { #n }
+    };
+    let arity_fn = quote! {
+        #[allow(dead_code)]
+        #vis fn #arity_fn_name() -> u16 {
+            #natural_arity
+        }
+    };
+
     Ok(quote! {
         #inner_fn
         #wrapper
         #sig_fn
+        #arity_fn
     })
 }
 
@@ -674,6 +719,41 @@ fn param_name(idx: usize, pt: &PatType) -> String {
     match &*pt.pat {
         Pat::Ident(pi) => python_keyword_name(&pi.ident.to_string()),
         _ => format!("__pyre_positional_{idx}"),
+    }
+}
+
+/// The `TypeError` text for a positional count that does not fit a builtin
+/// taking `required`..`total` arguments, as a `format!` over `args.len()`.
+///
+/// A signature with no optional slot names one exact count; one with an
+/// optional tail names the bound the call missed, so `too_many` picks
+/// between them.
+fn arity_message(
+    name: &str,
+    required: usize,
+    total: usize,
+    too_many: bool,
+) -> proc_macro2::TokenStream {
+    if required != total {
+        let bound = if too_many { total } else { required };
+        let plural = if bound == 1 { "" } else { "s" };
+        let at = if too_many { "at most" } else { "at least" };
+        let text = format!("{name} expected {at} {bound} argument{plural}, got {{}}");
+        return quote! { format!(#text, args.len()) };
+    }
+    match total {
+        0 => {
+            let text = format!("{name}() takes no arguments ({{}} given)");
+            quote! { format!(#text, args.len()) }
+        }
+        1 => {
+            let text = format!("{name}() takes exactly one argument ({{}} given)");
+            quote! { format!(#text, args.len()) }
+        }
+        n => {
+            let text = format!("{name} expected {n} arguments, got {{}}");
+            quote! { format!(#text, args.len()) }
+        }
     }
 }
 
@@ -1793,7 +1873,30 @@ fn expand_pyre_methods(
                         if visible_max == 1 { "" } else { "s" }
                     )
                 };
+                // A missing required slot is rejected the same way: the
+                // unwrap statements below index their slots directly, so the
+                // body would otherwise read past the end of `args`.
+                let expected_min = receiver_slots + visible_required;
+                let too_few = if visible_required == visible_max {
+                    quote! {
+                        format!(
+                            "{}() takes {} ({} given)",
+                            #fn_name, #expected,
+                            args.len().saturating_sub(#receiver_slots),
+                        )
+                    }
+                } else {
+                    let text = format!(
+                        "{} expected at least {visible_required} argument{}, got {{}}",
+                        fn_name,
+                        if visible_required == 1 { "" } else { "s" },
+                    );
+                    quote! { format!(#text, args.len().saturating_sub(#receiver_slots)) }
+                };
                 quote! {
+                    if args.len() < #expected_min {
+                        return ::std::result::Result::Err(crate::PyError::type_error(#too_few));
+                    }
                     if args.len() > #expected_total {
                         return ::std::result::Result::Err(crate::PyError::type_error(format!(
                             "{}() takes {} ({} given)",

--- a/pyre/pyre-macros/src/lib.rs
+++ b/pyre/pyre-macros/src/lib.rs
@@ -28,7 +28,7 @@
 //! * `i64` / `i32` / `u32` / `usize` — `w_int_get_value` + cast.
 //! * `f64` — `w_float_get_value`.
 //! * `bool` — `w_bool_get_value`.
-//! * `&str` — `w_str_get_value`.
+//! * `&str` — `str_utf8_w` (a lone surrogate raises `UnicodeEncodeError`).
 //! * `pyre_object::PyObjectRef` — passthrough (`args[i]`).
 //! * `&[pyre_object::PyObjectRef]` — passthrough of the whole slice (varargs).
 //!
@@ -593,11 +593,13 @@ fn unwrap_expr(ty: &Type, idx: usize) -> syn::Result<proc_macro2::TokenStream> {
                 }
             }
         }
-        // `&str` — borrow from `w_str_get_value`.
+        // `&str` — borrow the utf-8 view.  A lone surrogate has no such view,
+        // so it is reported as the `UnicodeEncodeError` the strict utf-8
+        // encoder raises rather than demanding one.
         if let Type::Path(p) = &*r.elem {
             if path_is_ident(&p.path, "str") {
                 return Ok(quote! {
-                    unsafe { ::pyre_object::w_str_get_value(args[#idx]) }
+                    crate::baseobjspace::str_utf8_w(args[#idx])?
                 });
             }
         }

--- a/pyre/pyre-object/src/dictmultiobject.rs
+++ b/pyre/pyre-object/src/dictmultiobject.rs
@@ -2712,11 +2712,12 @@ pub unsafe fn w_dict_adopt_regular_copy_for_empty_update(dst: PyObjectRef, w_cop
 
     dst_dict.dstrategy = copy_dict.dstrategy;
     dst_dict.dstorage = copy_dict.dstorage;
-    // `w_copy` is a consumed temporary.  Move, rather than alias, its storage:
-    // leaving both dicts pointing at the same box would let the temporary's
-    // GC-box sweep reclaim the destination's live backing.  Null the copy's
-    // slot so only `dst` roots the moved box.
-    copy_dict.dstorage = std::ptr::null_mut();
+    // PyPy aliases the GC storage pointer here:
+    // `w_dict.dstorage = w_copy.dstorage`.  The storage box is an independent
+    // GC object, not memory owned by `w_copy`, so both dicts must keep tracing
+    // it until the consumed temporary is swept.  Clearing the temporary's
+    // field would leave a live W_DictObject whose strategy cannot trace its
+    // null storage during that same collection.
     dict_write_barrier(dst);
 
     // The destination previously held a placeholder Object-shape box; now

--- a/pyre/pyre-object/src/listobject.rs
+++ b/pyre/pyre-object/src/listobject.rs
@@ -1288,6 +1288,7 @@ pub unsafe fn w_list_insert(obj: PyObjectRef, index: i64, value: PyObjectRef) {
 /// listobject.py:1850-1862 IntegerListStrategy.pop
 /// Strategy-preserving: pops from typed storage, wraps result.
 pub unsafe fn w_list_pop(obj: PyObjectRef, index: i64) -> Option<PyObjectRef> {
+    let _list_guard = w_list_lock(obj);
     let list = &mut *(obj as *mut W_ListObject);
     match list.strategy {
         // listobject.py:1180 EmptyListStrategy.pop raises IndexError.
@@ -1332,6 +1333,7 @@ pub unsafe fn w_list_pop(obj: PyObjectRef, index: i64) -> Option<PyObjectRef> {
 
 /// Remove and return last item. Returns `None` if empty.
 pub unsafe fn w_list_pop_end(obj: PyObjectRef) -> Option<PyObjectRef> {
+    let _list_guard = w_list_lock(obj);
     let list = &mut *(obj as *mut W_ListObject);
     match list.strategy {
         // listobject.py:1180 EmptyListStrategy.pop raises IndexError.

--- a/pyre/pyre-object/src/typeobject.rs
+++ b/pyre/pyre-object/src/typeobject.rs
@@ -853,7 +853,12 @@ pub unsafe fn w_type_get_qualname_obj(obj: PyObjectRef) -> PyObjectRef {
 
 pub unsafe fn w_type_set_qualname(obj: PyObjectRef, w_qualname: PyObjectRef) {
     let t = &mut *(obj as *mut W_TypeObject);
-    *t.qualname = crate::w_str_get_value(w_qualname).to_string();
+    // `qualname` is the `&str` view display and error messages read, so a name
+    // carrying a lone surrogate is stored there with the replacement character
+    // `Wtf8`'s `Display` substitutes.  `w_qualname` keeps the name object
+    // itself, and `w_type_get_qualname_obj` hands that back verbatim, so
+    // `__qualname__` still reads the code points that were assigned.
+    *t.qualname = crate::w_str_get_wtf8(w_qualname).to_string();
     t.w_qualname = w_qualname;
     crate::gc_hook::try_gc_write_barrier(obj as *mut u8);
 }

--- a/pyre/pyrex/src/lib.rs
+++ b/pyre/pyrex/src/lib.rs
@@ -87,7 +87,7 @@ Options:
 -q     : don't print version on interactive startup
 -s     : don't add user site directory to sys.path
 -S     : don't imply 'import site' on initialization
--P     : don't prepend a potentially unsafe path to sys.path
+-P     : don't prepend a potentially unsafe path to sys.path (also PYTHONSAFEPATH)
 -V     : print the Python version number and exit (also --version)
 -X opt : set implementation-specific option
 file   : program read from script file
@@ -195,10 +195,28 @@ fn resolve_dont_write_bytecode(flags: &LaunchFlags) -> bool {
     false
 }
 
+/// `-P` folded with PYTHONSAFEPATH (`config_read_env_vars`). The variable is a
+/// bare presence flag read through `_Py_GetEnv`, not an integer one: any
+/// non-empty value enables safe path — `"0"` included — while an empty value
+/// counts as unset. It only ever sets the flag, so an explicit `-P` survives
+/// `-E`.
+fn resolve_safe_path(flags: &LaunchFlags) -> bool {
+    if flags.safe_path {
+        return true;
+    }
+    if !flags.ignore_environment {
+        if let Ok(value) = std::env::var("PYTHONSAFEPATH") {
+            return !value.is_empty();
+        }
+    }
+    false
+}
+
 fn finalize_flags(mut flags: LaunchFlags) -> LaunchFlags {
     flags.utf8_mode = Some(resolve_utf8_mode(&flags));
     flags.optimize = resolve_optimize(&flags);
     flags.dont_write_bytecode = resolve_dont_write_bytecode(&flags);
+    flags.safe_path = resolve_safe_path(&flags);
     flags
 }
 

--- a/pyre/pyrex/src/lib.rs
+++ b/pyre/pyrex/src/lib.rs
@@ -605,6 +605,7 @@ fn real_main(binary_name: &str) {
     // reflects whether site initialization was skipped.
     importing::set_no_site(no_site);
     importing::set_runtime_flags(
+        quiet,
         no_user_site,
         ignore_environment,
         isolated,

--- a/pyre/pyrex/src/lib.rs
+++ b/pyre/pyrex/src/lib.rs
@@ -26,7 +26,9 @@ enum RunMode {
     /// literal `sys.argv[0]` the launcher records — `"-"` when the dash was
     /// given, `""` when it was not. Whether this drives the prompt or executes
     /// stdin as one unit is decided at dispatch by `stdin_is_interactive`.
-    Stdin { argv0: String },
+    Stdin {
+        argv0: String,
+    },
     /// `pyre interact <executable> [args…]` — run the trusted sandbox
     /// controller (`pypy/sandbox/pypy_interact.py`) over an untrusted child.
     Interact {

--- a/pyre/pyrex/src/lib.rs
+++ b/pyre/pyrex/src/lib.rs
@@ -21,7 +21,12 @@ enum RunMode {
     Script(String),
     Command(String),
     Module(String),
-    Repl,
+    /// Program read from stdin: an explicit `-` argument, or no script
+    /// argument at all (app_main.py `options["run_stdin"]`). `argv0` is the
+    /// literal `sys.argv[0]` the launcher records — `"-"` when the dash was
+    /// given, `""` when it was not. Whether this drives the prompt or executes
+    /// stdin as one unit is decided at dispatch by `stdin_is_interactive`.
+    Stdin { argv0: String },
     /// `pyre interact <executable> [args…]` — run the trusted sandbox
     /// controller (`pypy/sandbox/pypy_interact.py`) over an untrusted child.
     Interact {
@@ -294,7 +299,15 @@ fn parse_args(binary_name: &str) -> Result<(RunMode, LaunchFlags, Vec<String>), 
                     return Ok((mode, finalize_flags(flags), vec![]));
                 }
                 if script == "-" {
-                    return Ok((RunMode::Repl, finalize_flags(flags), vec![]));
+                    // A leading `-` selects stdin and stays `sys.argv[0]`; the
+                    // words after it are the program's arguments, exactly as
+                    // for a script path.
+                    let rest = drain_args(&mut parser)?;
+                    return Ok((
+                        RunMode::Stdin { argv0: script },
+                        finalize_flags(flags),
+                        rest,
+                    ));
                 }
                 let rest = drain_args(&mut parser)?;
                 return Ok((RunMode::Script(script), finalize_flags(flags), rest));
@@ -302,7 +315,14 @@ fn parse_args(binary_name: &str) -> Result<(RunMode, LaunchFlags, Vec<String>), 
             _ => return Err(arg.unexpected()),
         }
     }
-    Ok((RunMode::Repl, finalize_flags(flags), vec![]))
+    // No script argument at all reads stdin too, with an empty `sys.argv[0]`.
+    Ok((
+        RunMode::Stdin {
+            argv0: String::new(),
+        },
+        finalize_flags(flags),
+        vec![],
+    ))
 }
 
 /// Parse a `--heapsize` value (`pypy_interact.py:88-102`): a byte count with an
@@ -417,6 +437,32 @@ fn sys_path_cwd() -> std::path::PathBuf {
     }
 }
 
+/// `interactive or sys.stdin.isatty()` — a stdin run drives the prompt when fd
+/// 0 is a terminal or `-i` was given, and executes stdin as a script
+/// otherwise. The query goes through the seam, so a sandboxed child observes
+/// its virtual console rather than the trusted parent's terminal.
+fn stdin_is_interactive(inspect: bool) -> bool {
+    inspect || pyre_interpreter::host_seam::ops::isatty(0).unwrap_or(false)
+}
+
+/// `sys.stdin.read()` — the whole of stdin as the program source. The read
+/// routes through the seam for the same reason `stdin_is_interactive` does.
+fn read_stdin_source() -> std::io::Result<String> {
+    use pyre_interpreter::host_seam::{SeamError, ops};
+
+    let mut data = Vec::new();
+    loop {
+        match ops::read(0, 65536) {
+            Ok(chunk) if chunk.is_empty() => break,
+            Ok(chunk) => data.extend_from_slice(&chunk),
+            Err(SeamError::Os(errno)) => return Err(std::io::Error::from_raw_os_error(errno)),
+            Err(_) => return Err(std::io::Error::other("stdin read failed")),
+        }
+    }
+    String::from_utf8(data)
+        .map_err(|_| std::io::Error::new(std::io::ErrorKind::InvalidData, "stdin not utf-8"))
+}
+
 pub fn main_entry(binary_name: &'static str) {
     // The sandboxed child runs single-threaded like pypy-c-sandbox: it neither
     // manages signals (the controller does) nor spawns a worker thread, so it
@@ -511,9 +557,12 @@ fn real_main(binary_name: &str) {
 
     // The interactive REPL drives raw stdin/stdout directly, which under sandbox
     // are the controller's marshalling pipes — running it would corrupt the
-    // protocol and bypass fd-0 mediation. Reject REPL / `-i` in sandbox builds.
+    // protocol and bypass fd-0 mediation. Reject the prompt / `-i` in sandbox
+    // builds; a piped stdin program reads through the seam and is fine.
     #[cfg(feature = "sandbox")]
-    if !is_interact && (matches!(mode, RunMode::Repl) || inspect) {
+    if !is_interact
+        && (inspect || (matches!(mode, RunMode::Stdin { .. }) && stdin_is_interactive(false)))
+    {
         eprintln!("{binary_name}: interactive mode is unavailable in the sandbox");
         std::process::exit(2);
     }
@@ -640,13 +689,33 @@ fn real_main(binary_name: &str) {
                 repl::run_repl(true, no_site);
             }
         }
-        RunMode::Repl => {
-            // The REPL and piped stdin both take "" for `sys.path[0]`
+        RunMode::Stdin { argv0 } => {
+            // The prompt and piped stdin both take "" for `sys.path[0]`
             // (`_PyPathConfig_ComputeSysPath0` on an argv[0] of "" / "-"); the
             // cwd stays the shadowing-check anchor.
             let cwd = sys_path_cwd();
             importing::init_sys_path(&cwd, "");
-            repl::run_repl(quiet, no_site);
+            // `sys.argv` is `['']` with no script argument and `['-', …]` for
+            // an explicit dash.
+            let mut argv = vec![argv0];
+            argv.extend(args);
+            importing::set_sys_argv(&argv);
+            if stdin_is_interactive(inspect) {
+                // A tty (or `-i`) prints the banner unless `-q` and drops into
+                // the prompt.
+                repl::run_repl(quiet, no_site);
+            } else {
+                // Otherwise stdin is read to EOF and executed as a single
+                // `exec` unit named `<stdin>`.
+                let source = match read_stdin_source() {
+                    Ok(source) => source,
+                    Err(e) => {
+                        eprintln!("{binary_name}: cannot read stdin: {e}");
+                        std::process::exit(1);
+                    }
+                };
+                run_source(&source, Mode::Exec, "<stdin>", no_site);
+            }
         }
         RunMode::Interact {
             exe,
@@ -1065,35 +1134,48 @@ fn run_source(source: &str, mode: Mode, filename: &str, no_site: bool) {
     // A script run by path gets `__file__` / `__cached__` in `__main__`
     // (pythonrun.c `_PyRun_SimpleFileObject`); the `-c "<string>"` command
     // path does not. `__file__` is absolutized (os.path.abspath, 3.9+) while
-    // `sys.argv[0]` keeps the literal command-line path.
-    let script_file = if filename != "<string>" {
-        // Resolve a relative path against `sys_path_cwd()` — the seam-provided
-        // virtual cwd under sandbox — before normalizing, so `std::path::absolute`
-        // never consults (and leaks) the trusted process cwd. Off sandbox this is
-        // identical to `absolute(filename)`.
-        let path = Path::new(filename);
-        let to_absolutize = if path.is_absolute() {
-            path.to_path_buf()
-        } else {
-            sys_path_cwd().join(path)
-        };
-        let abs_file = match std::path::absolute(&to_absolutize) {
-            Ok(p) => p.to_string_lossy().into_owned(),
-            Err(_) => filename.to_string(),
-        };
+    // `sys.argv[0]` keeps the literal command-line path. A stdin run records
+    // the literal `<stdin>`: there is no path to absolutize and no file to
+    // bind a `SourceFileLoader` to.
+    let main_file: Option<String> = match filename {
+        "<string>" => None,
+        "<stdin>" => Some(filename.to_string()),
+        _ => {
+            // Resolve a relative path against `sys_path_cwd()` — the
+            // seam-provided virtual cwd under sandbox — before normalizing, so
+            // `std::path::absolute` never consults (and leaks) the trusted
+            // process cwd. Off sandbox this is identical to
+            // `absolute(filename)`.
+            let path = Path::new(filename);
+            let to_absolutize = if path.is_absolute() {
+                path.to_path_buf()
+            } else {
+                sys_path_cwd().join(path)
+            };
+            Some(match std::path::absolute(&to_absolutize) {
+                Ok(p) => p.to_string_lossy().into_owned(),
+                Err(_) => filename.to_string(),
+            })
+        }
+    };
+    if let Some(file) = main_file.as_deref() {
         let _ = pyre_interpreter::baseobjspace::setattr_str(
             main_module,
             "__file__",
-            pyre_object::w_str_new(&abs_file),
+            pyre_object::w_str_new(file),
         );
         let _ = pyre_interpreter::baseobjspace::setattr_str(
             main_module,
             "__cached__",
             pyre_object::w_none(),
         );
-        Some(abs_file)
-    } else {
+    }
+    // Only a real file gets a `SourceFileLoader`; `-c` and stdin keep the
+    // `BuiltinImporter` `seed_main_loader` installs for a `None` path.
+    let script_file = if filename == "<stdin>" {
         None
+    } else {
+        main_file.as_deref()
     };
 
     // Import `sys` up front so its creation flushes the native search-path seed
@@ -1109,7 +1191,7 @@ fn run_source(source: &str, mode: Mode, filename: &str, no_site: bool) {
         eprintln!("pyre: importlib bootstrap failed: {}", e.message_text());
     }
 
-    seed_main_loader(canonical, script_file.as_deref(), ec_ptr);
+    seed_main_loader(canonical, script_file, ec_ptr);
 
     import_site(no_site, canonical, ec_ptr);
 

--- a/pyre/pyrex/src/lib.rs
+++ b/pyre/pyrex/src/lib.rs
@@ -212,7 +212,9 @@ fn resolve_safe_path(flags: &LaunchFlags) -> bool {
         return true;
     }
     if !flags.ignore_environment {
-        if let Ok(value) = std::env::var("PYTHONSAFEPATH") {
+        // Read as an `OsString`: the value is a presence flag, so bytes that
+        // are not valid Unicode still count as set.
+        if let Some(value) = std::env::var_os("PYTHONSAFEPATH") {
             return !value.is_empty();
         }
     }
@@ -441,26 +443,49 @@ fn sys_path_cwd() -> std::path::PathBuf {
 
 /// `interactive or sys.stdin.isatty()` — a stdin run drives the prompt when fd
 /// 0 is a terminal or `-i` was given, and executes stdin as a script
-/// otherwise. The query goes through the seam, so a sandboxed child observes
-/// its virtual console rather than the trusted parent's terminal.
+/// otherwise.
 fn stdin_is_interactive(inspect: bool) -> bool {
-    inspect || pyre_interpreter::host_seam::ops::isatty(0).unwrap_or(false)
+    if inspect {
+        return true;
+    }
+    #[cfg(feature = "sandbox")]
+    {
+        // Under sandbox the query goes through the seam, so a sandboxed child
+        // observes its virtual console rather than the trusted parent's
+        // terminal.
+        pyre_interpreter::host_seam::ops::isatty(0).unwrap_or(false)
+    }
+    #[cfg(not(feature = "sandbox"))]
+    {
+        std::io::IsTerminal::is_terminal(&std::io::stdin())
+    }
 }
 
-/// `sys.stdin.read()` — the whole of stdin as the program source. The read
-/// routes through the seam for the same reason `stdin_is_interactive` does.
+/// `sys.stdin.read()` — the whole of stdin as the program source.
 fn read_stdin_source() -> std::io::Result<String> {
-    use pyre_interpreter::host_seam::{SeamError, ops};
+    // Under sandbox the read goes through the seam, so a sandboxed child
+    // observes virtual stdin rather than the trusted parent's stdin.
+    #[cfg(feature = "sandbox")]
+    let data = {
+        use pyre_interpreter::host_seam::{SeamError, ops};
 
-    let mut data = Vec::new();
-    loop {
-        match ops::read(0, 65536) {
-            Ok(chunk) if chunk.is_empty() => break,
-            Ok(chunk) => data.extend_from_slice(&chunk),
-            Err(SeamError::Os(errno)) => return Err(std::io::Error::from_raw_os_error(errno)),
-            Err(_) => return Err(std::io::Error::other("stdin read failed")),
+        let mut data = Vec::new();
+        loop {
+            match ops::read(0, 65536) {
+                Ok(chunk) if chunk.is_empty() => break,
+                Ok(chunk) => data.extend_from_slice(&chunk),
+                Err(SeamError::Os(errno)) => return Err(std::io::Error::from_raw_os_error(errno)),
+                Err(_) => return Err(std::io::Error::other("stdin read failed")),
+            }
         }
-    }
+        data
+    };
+    #[cfg(not(feature = "sandbox"))]
+    let data = {
+        let mut data = Vec::new();
+        std::io::Read::read_to_end(&mut std::io::stdin(), &mut data)?;
+        data
+    };
     String::from_utf8(data)
         .map_err(|_| std::io::Error::new(std::io::ErrorKind::InvalidData, "stdin not utf-8"))
 }

--- a/pyre/pyrex/src/lib.rs
+++ b/pyre/pyrex/src/lib.rs
@@ -606,6 +606,7 @@ fn real_main(binary_name: &str) {
     importing::set_no_site(no_site);
     importing::set_runtime_flags(
         quiet,
+        inspect,
         no_user_site,
         ignore_environment,
         isolated,


### PR DESCRIPTION
Seventeen commits, rebased onto `origin/main`. The first nine are described below under **sys.flags / `_imp` / surrogates / binascii, zlib**; the last eight close the items the first round reported as "found, not fixed".

## sys.flags is a structseq

`sys.flags` was a class-namespace stand-in, so `isinstance(sys.flags, tuple)` was false. It is now a structseq: it indexes, slices, compares, hashes and unpacks as a tuple, carries `n_sequence_fields` (18) / `n_fields` (21), and its fields are read-only. `gil`, `thread_inherit_context` and `context_aware_warnings` sit past the sequence as named-only extras.

## `_imp`

- `find_frozen` takes the keyword-only `withdata`; when true it returns a read-only `memoryview` over the marshalled code object, so `marshal.loads(bytes(data))` reconstructs what `get_frozen_object` returns. Adds `marshal::dumps_bytes` for that stream.
- `create_builtin` encodes the spec name to ascii the way the extension-module loader does, so a non-ascii name raises `UnicodeEncodeError`, and a correctly spelled name that names no builtin returns `None` instead of raising.

A 26-row `_imp` matrix is byte-identical to CPython 3.14.

## Lone surrogates no longer abort the process

pyre strings are backed by WTF-8, so a lone surrogate has no `&str` view and `w_str_get_value` panicked — killing the whole process, not raising. A fuzz sweep over ~3300 module entry points (each probe run with a lone surrogate, and again with a plain ASCII string as a control) found **152** such aborts.

All 152 are gone. `str_utf8_w` reports the `UnicodeEncodeError` the strict utf-8 encoder raises (unicodehelper.py:245); `text_w` and the `#[pyre_function]` `&str` parameter route through it, which covers the whole `pyre_function` surface at once.

Where the value is not required to be utf-8 it is now **kept**, not rejected: format specs, regex subjects and replacements, pickle strings, warning text, strftime formats, keyword names, `__qualname__`, `super().__getattribute__`, memoryview cast formats, array typecodes, `compare_digest` and the time clock names read the WTF-8 buffer. The format-spec parser carries its fill as a `CodePoint`, so `format(x, '\ud800<6')` pads with the surrogate it was given; `_sre` drives `str` subjects over `&Wtf8`, so a pattern matches a lone surrogate like any other character and `'\ud800'.encode('idna')` no longer dies inside the codec's regex.

## binascii, zlib

`b2a_hex`/`hexlify`, `b2a_base64`, `b2a_qp`, `b2a_uu`, `crc32` and `crc_hqx` accepted a `str` through the `ascii_buffer_converter` that belongs to the `a2b_*` decoders. They declare a `Py_buffer`, so a `str` is now rejected by its type, matching CPython and PyPy. zlib's converter did the same and now rejects a `str` too.

---

# Second round — the reported items

## Wrong argument counts no longer abort the process

A builtin body indexes its slots directly, so a call whose count does not fit read past the end of `args` and aborted. The control arm of the fuzz stopped the process on 81 such labels (`operator.and_('x')`, `cmath.rect(1)`, `itertools.combinations('ab')`, `_signal.signal(1)`, `builtins.__build_class__(1, 2)`, …).

The count is now checked where it is known exactly:

- `#[pyre_function]` / `#[pyre_methods]` wrappers reject a count outside their required..total range, derived from the typed parameter list.
- `py_module!`'s `inline_functions:` arm derives `fast_natural_arity` from that same list, so a function with an optional or varargs parameter registers `HOPELESS` instead of the raw parameter count. This replaces `pyre_count_typed_args!`, which counted `#[default(...)]` parameters as required and so declared a *maximum* as if it were exact.
- `py_module!`'s `functions:` / `module_functions:` arms wrap each declared arity in `gateway::check_declared_arity`. `_opcode.stack_effect`, which takes 1-2 positional arguments plus a keyword-only `jump`, moves to `*` and keeps its own check.
- `_signal.signal`, `itertools.combinations` and `posix.urandom`, registered outside `py_module!`, call `check_declared_arity` themselves.

Both fuzz arms now run to completion with **zero** process aborts. The messages match CPython's: `and_ expected 2 arguments, got 1`, `neg() takes exactly one argument (0 given)`, `list.append() takes exactly one argument (2 given)`, `center expected at least 1 argument, got 0`.

`__build_class__` additionally rejects a body that is not a Python function — `__build_class__(1, 2)` crashed reading the code object, and now raises `__build_class__: func must be a function` exactly as both oracles do.

## `sys.settrace` emits events again

`call_trace` / `return_trace` / `bytecode_trace` are driven from the plain eval path, so a frame the JIT took over reported nothing. `eval_with_jit_inner` now declines a frame whose execution context carries a trace or profile hook, and `demo()` under `settrace` yields `[('demo', 'call'), ('demo', 'return')]`.

`line` events are still missing — that reproduces with the JIT off too and is a separate gap.

## `_hashlib.new` validates at construction

`HASH.__init__` stored the digest name unchecked, so `_hashlib.new('nope')` succeeded and only failed once a digest was taken. A new interp-level `_check_digest_name` rejects a non-str and an unknown algorithm where the digest is resolved.

## `_socket.gethostbyname` idna-encodes

The converter demanded a utf-8 view before its ASCII test, and replaced a failed `.encode('idna')` with a generic TypeError. The ASCII test now reads the raw buffer and the codec's own error propagates: `_socket.gethostbyname('\ud800')` raises `UnicodeEncodeError: 'idna' codec can't encode character '\ud800' in position 0: Invalid character '\ud800'`, byte-identical to CPython. pyre's `idna` codec itself was already correct (`'예'.encode('idna')` → `b'xn--2j5b'`).

## `operator._compare_digest`

The earlier report was wrong about the cause: `_compare_digest` *does* exist upstream. The real divergence is that pyre installed the interp-level table under both `operator` and `_operator`, while `moduledef.py:5` gives it `applevel_name = '_operator'`. `import operator` now resolves to `operator.py`, whose `from _operator import *` drops the underscore names.

## `array.array` typecode message

The typecode length was measured in bytes, so a single non-ASCII character was reported as a string of its UTF-8 length. It now counts code points, and both rejections name what was passed: `must be a unicode character, not <type>` and `not a string of length N`.

## `posix.urandom`

`urandom` read the argument's integer field raw, so `posix.urandom('x')` asked for an arbitrary number of bytes and hung. The size goes through `int_w` (`__index__`), and a negative size raises `ValueError`.

## Gate

`check.py` 315/321 on dynasm and 316/321 on cranelift, `cargo fmt --all --check` clean.

The failures are **pre-existing on this branch's base** — a binary built from the branch tip before this round's changes produces the identical set:

- `synth/except_star`, `synth/exception_group_type`, `synth/exception_subclass_attrs` — crash (exit -10) after JIT warmup; passes under `PYRE_JIT=0`
- `synth/getframe_force_cancel_journal`, `synth/unpack_drain_star_raise` — wrong output
- `synth/const_arg_call_resume` — the known boundary perf gate (34-39x against a 30x gate; cranelift passed it on the final run)

## Verification

- 83-row cross-interpreter matrix against CPython 3.14 and PyPy3: every row matches CPython except four, and all four (`compile` filename, `type()` name label, memoryview cast, `super().__getattribute__` message) are **byte-identical to PyPy** — left alone per the project's rule of not diverging from PyPy where pyre already agrees with it.
- Both fuzz arms (~3300 probes each, lone surrogate and ASCII control) complete with no process aborts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for executing Python code from standard input, with improved interactive vs piped behavior.
  * Enhanced `PYTHONSAFEPATH` handling, including correct `-P` / environment precedence and `-E` interactions.
  * Updated `sys.flags` to better match expected runtime behavior.
* **Bug Fixes**
  * Preserved lone-surrogate strings across formatting, regex, imports, warnings, pickling, and related Unicode paths.
  * Tightened bytes-only APIs to reject `str` with clearer `TypeError`s (notably `binascii` and `zlib`).
* **Other Changes**
  * Standardized builtin argument validation and arity-related errors (and improved tracing behavior when using JIT).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->