### PR TITLE
majit: Vec-ctor newlist + reserved __pyre_range, union-pair diagnostic, mixed-signedness const fold

### DIFF
--- a/majit/majit-translate/src/annotator/model.rs
+++ b/majit/majit-translate/src/annotator/model.rs
@@ -2958,6 +2958,37 @@ impl std::error::Error for AnnotatorError {}
 // union() dispatch (A4.6) — model.py:750-784 + binaryop.py pair().union().
 // ---------------------------------------------------------------------------
 
+/// Short identity of a `union` operand for the unhandled-pair error text.
+///
+/// The bare [`SomeValueTag`] is often not enough to act on: `Instance`
+/// covers every classdef, and the failing pair is usually diagnosed by
+/// *which* class collided, not by the variant. This renders the one
+/// discriminating field for the two payload-bearing variants that show up
+/// in unhandled pairs and falls back to the tag for the rest, so the error
+/// stays one short line. Same motivation as the `SomeInstance ∪
+/// SomeInstance` arm naming its two classdefs.
+fn union_operand_id(s: &SomeValue) -> String {
+    match s {
+        SomeValue::Instance(inst) => match &inst.classdef {
+            Some(cd) => format!("Instance({})", cd.borrow().name),
+            None => "Instance(classdef-less)".to_string(),
+        },
+        SomeValue::Ptr(ptr) => {
+            use crate::translator::rtyper::lltypesystem::lltype::PtrTarget;
+            let target = match &ptr.ll_ptrtype.TO {
+                PtrTarget::Struct(st) => st._name.clone(),
+                PtrTarget::Opaque(op) => op.tag.clone(),
+                PtrTarget::Func(_) => "Func".to_string(),
+                PtrTarget::Array(_) => "Array".to_string(),
+                PtrTarget::FixedSizeArray(_) => "FixedSizeArray".to_string(),
+                PtrTarget::ForwardReference(_) => "ForwardReference".to_string(),
+            };
+            format!("Ptr({target})")
+        }
+        other => format!("{:?}", other.tag()),
+    }
+}
+
 /// RPython `union(s1, s2)` (model.py:750-769).
 ///
 /// The join operation in the lattice of annotations. Returns the most
@@ -3424,7 +3455,18 @@ pub fn union(s1: &SomeValue, s2: &SomeValue) -> Result<SomeValue, UnionError> {
         _ => Err(UnionError {
             lhs: s1.clone(),
             rhs: s2.clone(),
-            msg: "no upstream pair(s1, s2).union() handler in current subset".into(),
+            // Name the two colliding operands, for the same reason the
+            // `SomeInstance` arm above names its classdefs: both sides
+            // often render as the bare `<other>` `KnownType`, which makes
+            // the skip-classified panic undiagnosable.  The classifier
+            // phrase is kept verbatim and first — `cutover.rs:1291` /
+            // `:2718` match it with `contains`.
+            msg: format!(
+                "no upstream pair(s1, s2).union() handler in current subset: \
+                 {} ∪ {}",
+                union_operand_id(s1),
+                union_operand_id(s2)
+            ),
         }),
     }
 }

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -14356,7 +14356,13 @@ fn const_eval_init_body_lit(llbc: &Llbc, u: &Unstructured, depth: usize) -> Opti
                         )?,
                         _ => return None,
                     };
-                    locals.insert(dst, value);
+                    // rustc computes each assignment at the destination's
+                    // width; re-narrow so a `Shl` that shifted bits out does
+                    // not bake a too-wide constant.
+                    locals.insert(
+                        dst,
+                        const_narrow_to_target(const_literal_ty(llbc, &place.ty), value),
+                    );
                 }
                 _ => return None,
             }
@@ -14563,8 +14569,94 @@ fn const_cast_int(n: i64, target: &serde_json::Value) -> Option<i64> {
     })
 }
 
+/// Resolve a Charon type reference to its `Literal` payload
+/// (`{"Int": "I32"}` / `{"UInt": "U32"}` / …), following the
+/// `Deduplicated` / `HashConsedValue` indirections the same way
+/// [`Lowering::tyref_literal_int_atom`] does.
+fn const_literal_ty<'t>(llbc: &'t Llbc, tyref: &'t TyRef) -> Option<&'t serde_json::Value> {
+    let value = match tyref {
+        TyRef::Inline { value: (_, v) } => v,
+        TyRef::Other(v) => v,
+        TyRef::Dedup { id } => llbc.dedup_body(*id)?,
+    };
+    value.as_object()?.get("Literal")
+}
+
+/// Re-narrow a folded literal to the width and signedness of the local it
+/// is assigned to.
+///
+/// The `ConstLit` carrier is 64-bit, so an operation whose true result is
+/// computed at a narrower width can come out too wide — `Shl` is the live
+/// case, because Rust does *not* count shifted-out bits as an overflow
+/// (`200u8 << 1` is a legal const equal to 144, while the u64 carrier says
+/// 400).  rustc truncates to the destination type, so doing the same here
+/// keeps the fold bit-exact instead of baking a too-wide constant.  This is
+/// the same width reasoning the `Add`/`Sub`/`Mul` `Wrap` arms use to decline
+/// outright; with the destination type in hand the value can be corrected
+/// rather than residualized.
+///
+/// Only integer destinations narrow: a `Bool`/`Float` destination, a
+/// non-literal one (the tuple a `*Checked` pair is assigned to), or a
+/// 128-bit width leaves the value untouched.
+fn const_narrow_to_target(target: Option<&serde_json::Value>, v: ConstLit) -> ConstLit {
+    let Some(target) = target else {
+        return v;
+    };
+    let raw = match v {
+        ConstLit::Int(n) => n,
+        ConstLit::UInt(n) => n as i64,
+        _ => return v,
+    };
+    let Some(narrowed) = const_cast_int(raw, target) else {
+        return v;
+    };
+    if target.get("UInt").is_some() {
+        ConstLit::UInt(narrowed as u64)
+    } else {
+        ConstLit::Int(narrowed)
+    }
+}
+
 fn const_eval_binop(kind: &serde_json::Value, lhs: ConstLit, rhs: ConstLit) -> Option<ConstLit> {
     let name = operator_name(kind)?;
+    // A mixed-signedness pair is not an ambiguous fold for every operator.
+    // Charon emits one for two shapes that are exactly determined once the
+    // signed side is non-negative, because then both carriers agree on the
+    // mathematical value:
+    //   * a shift, whose RHS is a bit *count* and not a value in the LHS's
+    //     domain — `1u32 << 31` records `Unsigned(U32, 1)` against
+    //     `Signed(I32, 31)` because an unsuffixed shift amount defaults to
+    //     `i32`;
+    //   * a comparison, where a `Cast` upstream dropped one side's
+    //     signedness into the other carrier (`31i32 as u32 < 32u32`, the
+    //     shift-overflow assert Charon plants ahead of the shift itself).
+    // Arithmetic is deliberately excluded: its result *type* is what the
+    // mixed pair leaves undetermined, and Rust needs an explicit cast to
+    // write it, so it does not occur in a real initializer.
+    let mixed = match (lhs, rhs) {
+        (ConstLit::UInt(a), ConstLit::Int(b)) if b >= 0 => Some((a, b as u64)),
+        (ConstLit::Int(a), ConstLit::UInt(b)) if a >= 0 => Some((a as u64, b)),
+        _ => None,
+    };
+    if let Some((a, b)) = mixed {
+        return match name {
+            "Shl" => u32::try_from(b)
+                .ok()
+                .and_then(|shift| a.checked_shl(shift))
+                .map(ConstLit::UInt),
+            "Shr" => u32::try_from(b)
+                .ok()
+                .and_then(|shift| a.checked_shr(shift))
+                .map(ConstLit::UInt),
+            "Lt" => Some(ConstLit::Bool(a < b)),
+            "Le" => Some(ConstLit::Bool(a <= b)),
+            "Gt" => Some(ConstLit::Bool(a > b)),
+            "Ge" => Some(ConstLit::Bool(a >= b)),
+            "Eq" => Some(ConstLit::Bool(a == b)),
+            "Ne" => Some(ConstLit::Bool(a != b)),
+            _ => None,
+        };
+    }
     match (lhs, rhs) {
         (ConstLit::Int(a), ConstLit::Int(b)) => match name {
             // Wrapping Add/Sub/Mul: the correct result depends on the
@@ -17083,6 +17175,99 @@ mod tests {
         assert!(matches!(
             const_eval_binop(&json!("AddChecked"), ConstLit::Int(1i64 << 62), ConstLit::Int(1)),
             Some(ConstLit::Checked(v, false)) if v == (1i64 << 62) + 1
+        ));
+    }
+
+    /// `pub const MEMBER_DIRECT_FLAG: u32 = 1 << 31` (typedef.rs) records a
+    /// mixed-signedness pair, because an unsuffixed shift amount defaults to
+    /// `i32` while the shifted value is `u32`.  Charon plants the
+    /// shift-overflow assert (`31i32 as u32 < 32u32`) ahead of it, which is a
+    /// mixed pair too, so both halves have to fold or the const falls through
+    /// to a residual accessor call no registry can bind.
+    #[test]
+    fn const_eval_binop_folds_mixed_signedness_shifts_and_comparisons() {
+        use super::{ConstLit, const_eval_binop};
+        use serde_json::json;
+
+        // The shift itself: `1u32 << 31i32`.
+        assert!(matches!(
+            const_eval_binop(
+                &json!({ "Shl": "Wrap" }),
+                ConstLit::UInt(1),
+                ConstLit::Int(31)
+            ),
+            Some(ConstLit::UInt(v)) if v == 1u64 << 31
+        ));
+        // The overflow assert's comparison: `31u32 < 32u32` reached with the
+        // cast's signedness dropped into the `Int` carrier.
+        assert!(matches!(
+            const_eval_binop(&json!("Lt"), ConstLit::Int(31), ConstLit::UInt(32)),
+            Some(ConstLit::Bool(true))
+        ));
+        assert!(matches!(
+            const_eval_binop(&json!("Ge"), ConstLit::UInt(32), ConstLit::Int(31)),
+            Some(ConstLit::Bool(true))
+        ));
+
+        // A negative signed side makes the two carriers disagree on the
+        // value — stay declined, as the `Shr` sign guard already does.
+        assert!(
+            const_eval_binop(
+                &json!({ "Shl": "Wrap" }),
+                ConstLit::UInt(1),
+                ConstLit::Int(-1)
+            )
+            .is_none()
+        );
+        assert!(const_eval_binop(&json!("Lt"), ConstLit::Int(-1), ConstLit::UInt(0)).is_none());
+
+        // Mixed arithmetic stays declined: the pair leaves the result *type*
+        // undetermined, and Rust needs an explicit cast to write it at all.
+        assert!(
+            const_eval_binop(
+                &json!({ "Add": "Panic" }),
+                ConstLit::UInt(1),
+                ConstLit::Int(1)
+            )
+            .is_none()
+        );
+    }
+
+    /// A `Shl` folded at the 64-bit carrier can be wider than the local it is
+    /// assigned to — Rust does not treat shifted-out bits as an overflow, so
+    /// `200u8 << 1` is a legal const equal to 144, not 400.  rustc truncates
+    /// to the destination type and so must the fold.
+    #[test]
+    fn const_narrow_to_target_truncates_to_the_destination_width() {
+        use super::{ConstLit, const_narrow_to_target};
+        use serde_json::json;
+
+        let u8_ty = json!({ "UInt": "U8" });
+        assert!(matches!(
+            const_narrow_to_target(Some(&u8_ty), ConstLit::UInt(400)),
+            ConstLit::UInt(144)
+        ));
+        // A signed destination re-extends rather than masking.
+        let i8_ty = json!({ "Int": "I8" });
+        assert!(matches!(
+            const_narrow_to_target(Some(&i8_ty), ConstLit::UInt(200)),
+            ConstLit::Int(-56)
+        ));
+        // The u32 flag itself is already in range and must survive intact.
+        let u32_ty = json!({ "UInt": "U32" });
+        assert!(matches!(
+            const_narrow_to_target(Some(&u32_ty), ConstLit::UInt(1 << 31)),
+            ConstLit::UInt(v) if v == 1u64 << 31
+        ));
+        // Non-integer and absent destinations pass the value through.
+        assert!(matches!(
+            const_narrow_to_target(None, ConstLit::Int(7)),
+            ConstLit::Int(7)
+        ));
+        let bool_ty = json!({ "Bool": [] });
+        assert!(matches!(
+            const_narrow_to_target(Some(&bool_ty), ConstLit::Bool(true)),
+            ConstLit::Bool(true)
         ));
     }
 

--- a/majit/majit-translate/src/front/range_iter.rs
+++ b/majit/majit-translate/src/front/range_iter.rs
@@ -29,7 +29,9 @@
 //!     ... next(r) folded by front::iter_next into the native `next` op
 //! ```
 //!
-//! `range` resolves through `HOST_ENV.lookup_builtin("range")` →
+//! `range` is emitted under the reserved `["__pyre_range"]` spelling (see
+//! [`range_builtin_call`]) and resolves through
+//! `HOST_ENV.lookup_builtin("range")` →
 //! `SomeBuiltin("range")` → `builtin_range` (`SomeList` with `range_step`);
 //! `["core","slice","iter"]` is the same `iter`-op bridge the slice/Vec
 //! for-loop uses (`is_concrete_iter_constructor`), and on a range-`SomeList`
@@ -327,16 +329,24 @@ fn graph_defines(graph: &FunctionGraph, var: &Variable) -> bool {
     })
 }
 
-/// `t = range(start, end)` — the single-segment `range` builtin call the
-/// adapter resolves through `HOST_ENV.lookup_builtin("range")` →
-/// `SomeBuiltin("range")` → `builtin_range` (a `SomeList` carrying
-/// `range_step`).
+/// `t = range(start, end)` — the `range` builtin call the adapter resolves
+/// through `HOST_ENV.lookup_builtin("range")` → `SomeBuiltin("range")` →
+/// `builtin_range` (a `SomeList` carrying `range_step`).
+///
+/// Spelled with the reserved `__pyre_range` segment rather than a bare
+/// `["range"]`: the adapter resolves a single-segment path against the
+/// `PyreCallRegistry` before `HOST_ENV`, and pyre's registry is one flat
+/// namespace keyed by leaf-only `CallPath`s, so a pyre free function named
+/// `range` (`pyre_interpreter::module::_ast::convert::range`) registers as
+/// `["range"]` and would capture this call. The reserved spelling has a
+/// dedicated `translate_op` arm that binds the `HOST_ENV` singleton, keeping
+/// the Arc identity `BUILTIN_TYPER` keys `rtype_builtin_range` on.
 fn range_builtin_call(result: Variable, start: Variable, end: Variable) -> SpaceOperation {
     SpaceOperation {
         result: Some(result),
         kind: OpKind::Call {
             target: CallTarget::FunctionPath {
-                segments: vec!["range".to_string()],
+                segments: vec!["__pyre_range".to_string()],
             },
             args: vec![start, end],
             result_ty: ValueType::Ref(None),
@@ -475,7 +485,7 @@ mod tests {
         assert_eq!(rewritten, 1, "the range for-loop must be diverted");
         assert_eq!(count_range_ctors(&g), 0, "range ctor removed");
         assert_eq!(
-            count_calls_ending(&g, &["range"]),
+            count_calls_ending(&g, &["__pyre_range"]),
             1,
             "one range() builtin emitted"
         );
@@ -554,7 +564,7 @@ mod tests {
         assert_eq!(rewritten, 0, "a second range consumer declines the divert");
         assert_eq!(count_range_ctors(&g), 1, "range ctor survives");
         assert_eq!(
-            count_calls_ending(&g, &["range"]),
+            count_calls_ending(&g, &["__pyre_range"]),
             0,
             "no range() builtin emitted"
         );

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -708,6 +708,35 @@ fn is_slice_reverse_segments(segments: &[String]) -> bool {
         && segments[3] == "reverse"
 }
 
+/// `Vec::with_capacity(n)` / `Vec::new()` (Rust MIR `vec::Vec::{with_capacity,
+/// new}`) — the resizable-list constructor. Routed in [`translate_op`] to the
+/// `newlist` operation with no element args, the shape `rtype_newlist`
+/// (`rlist.py:338-344`) lowers through `newlist(llops, r_list, [])`.
+///
+/// The capacity operand is dropped: upstream keeps a size hint only through
+/// `objectmodel.newlist_hint` (`objectmodel.py:443-447`), whose
+/// `rtype_newlist(hop, v_sizehint)` path our `rtype_newlist` does not take —
+/// the hint is an allocation optimization, not a semantic difference, so an
+/// empty `newlist` is the faithful lowering of both constructors.
+///
+/// Recognizing the constructor is what lets [`is_vec_push_segments`] and
+/// [`is_slice_reverse_segments`] work at all: they emit `getattr(recv, ...)`
+/// method shapes that require the receiver to annotate as a `SomeList`. While
+/// the constructor stayed a residual host call its result was the
+/// classdef-less opaque `SomeInstance` that `foreign_container_ctor` types,
+/// and the `getattr` against it aborted annotation.
+///
+/// Like [`is_vec_push_segments`], this recognizer fires only on the
+/// `CallTarget::FunctionPath` shape, which is complete for the foreign `vec`
+/// crate: `front::mir::impl_method_owner` cannot resolve `vec::Vec` to a
+/// classdef-bound owner, so every constructor call arrives as these segments.
+fn is_vec_ctor_segments(segments: &[String]) -> bool {
+    segments.len() == 3
+        && segments[0] == "vec"
+        && segments[1] == "Vec"
+        && (segments[2] == "with_capacity" || segments[2] == "new")
+}
+
 /// `Vec::push(l, item)` (Rust MIR `vec::Vec::push`) — the resizable-list
 /// append. Routed to the resized `ListRepr.rtype_method("append")`
 /// (`rlist.py:185`) via the `getattr(recv, "append") + simple_call` method
@@ -814,6 +843,15 @@ pub(crate) fn op_canraise(kind: &OpKind) -> bool {
             target: crate::model::CallTarget::FunctionPath { segments },
             ..
         } if is_slice_reverse_segments(segments) => false,
+        // `vec::Vec::{with_capacity,new}` lowers (in `translate_op`) to the
+        // `newlist` operation, whose `canraise` is `[]` (operation.py:551-553
+        // `class NewList`); classify the originating Call non-raising so a `?`
+        // tail op installs no exception edge the lowered op cannot take.
+        // Matched before the general `Call` arm.
+        OpKind::Call {
+            target: crate::model::CallTarget::FunctionPath { segments },
+            ..
+        } if is_vec_ctor_segments(segments) => false,
         // `[__iter_next]` (`front::iter_next`) lowers to the raising
         // flowspace `next` op (`operation.rs` `OpKind::Next.can_only_throw
         // = [StopIteration, RuntimeError]`).  Matched before the general
@@ -1489,6 +1527,37 @@ pub fn translate_op(
                         ))));
                         return Ok(vec![FlowspaceOp::new("simple_call", call_args, result)]);
                     }
+                    // `front::range_iter`'s synthesized `range(start, stop)`
+                    // (the exclusive int-`Range` for-loop divert).  It carries
+                    // the reserved `__pyre_range` spelling rather than a bare
+                    // `["range"]` because the registry ladder below resolves a
+                    // single-segment path against the `PyreCallRegistry`
+                    // *first* (the `frame.globals`-before-`__builtin__` order
+                    // of `flowcontext.py:845-853`), and pyre's registry is one
+                    // flat namespace keyed by leaf-only `CallPath`s.  A pyre
+                    // free function whose leaf happens to be a builtin name —
+                    // `pyre_interpreter::module::_ast::convert::range`
+                    // registers as `["range"]` — would therefore bind this
+                    // synthesized call to *its* `HostObject`, and since
+                    // `BUILTIN_TYPER` is keyed by Arc identity
+                    // (`rbuiltin.rs:98-101`) the rtyper then fails
+                    // `findbltintyper` with "don't know about built-in
+                    // function <host range>".  Resolving the reserved
+                    // spelling straight to the `HOST_ENV` singleton keeps the
+                    // Arc identity that keys `rtype_builtin_range`
+                    // (`rrange.py:96-126`), the same discipline the
+                    // `__pyre_cast_instance` arm above documents.
+                    if segments.len() == 1 && segments[0] == "__pyre_range" {
+                        let callable_host = HOST_ENV.lookup_builtin("range").ok_or_else(|| {
+                            TyperError::message("range missing from HOST_ENV bootstrap".to_string())
+                        })?;
+                        let callable =
+                            Hlvalue::Constant(Constant::new(ConstValue::HostObject(callable_host)));
+                        let mut call_args = Vec::with_capacity(arg_hls.len() + 1);
+                        call_args.push(callable);
+                        call_args.extend(arg_hls);
+                        return Ok(vec![FlowspaceOp::new("simple_call", call_args, result)]);
+                    }
                     // The `len` operation in its three spellings: the
                     // `__len` synthetic `front/mir.rs` lowers `Rvalue::Len`
                     // (and the `<str>::is_empty` decomposition) to; the
@@ -1566,6 +1635,15 @@ pub fn translate_op(
                             ),
                             FlowspaceOp::new("simple_call", vec![bound_method], result),
                         ]);
+                    }
+                    // `Vec::with_capacity(n)` / `Vec::new()` lower (in Rust
+                    // MIR) to a call to `vec::Vec::{with_capacity,new}`.  Emit
+                    // the `newlist` operation with no element args, which
+                    // `rtype_newlist` (`rlist.py:338-344`) lowers through
+                    // `newlist(llops, r_list, [])`.  The capacity operand is
+                    // dropped — see [`is_vec_ctor_segments`].
+                    if is_vec_ctor_segments(segments) {
+                        return Ok(vec![FlowspaceOp::new("newlist", vec![], result)]);
                     }
                     // `Vec::push(recv, item)` lowers (in Rust MIR) to a call
                     // to `vec::Vec::push`. Emit the *method* shape

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -7834,10 +7834,16 @@ pub(crate) unsafe fn lookup_where_with_method_cache(
     // self._pure_lookup_where_with_method_cache(name, version_tag)`.  The
     // tuple is split across two single-register elidable residuals over the
     // same cache entry (see `_pure_lookup_class_with_method_cache`), so the
-    // thread-local `MethodCache` read stays off the trace surface and the
-    // lookup folds to a `CALL_PURE_R` instead of aborting the trace.  The
-    // interned, immortal `w_name` (`box_str_constant`) is the green token the
-    // trace folds on; both residuals share it.
+    // `MethodCache` read stays off the trace surface and the lookup folds to
+    // a `CALL_PURE_R` instead of aborting the trace.  The interned, immortal
+    // `w_name` (`box_str_constant`) is the green token the trace folds on;
+    // both residuals share it.  Upstream reads the pair atomically because it
+    // returns one tuple, whereas each residual here takes the cache mutex
+    // separately, so a concurrent `mutated()` can land between them.  That is
+    // no weaker than the `version_tag` promotion above, which is likewise
+    // only stable while no other thread invalidates the type: both halves are
+    // then read under a tag that is no longer current, exactly as a lookup
+    // that had completed one instruction earlier would have been.
     let w_name = pyre_object::unicodeobject::box_str_constant(rustpython_wtf8::Wtf8::new(name));
     let w_value = _pure_lookup_where_with_method_cache(w_type, w_name, version_tag);
     if w_value.is_null() {


### PR DESCRIPTION
## Summary

Three `majit-translate` fixes found while walking the rtyper prepass census (`#73`), plus one comment fix in the method-cache front door.

**`majit`: name the colliding operands in the union fallthrough error**
`union()`'s unhandled-pair arm reported only `no upstream pair(s1, s2).union() handler in current subset`, and both operands usually render as the bare `<other>` `KnownType`, so the skip-classified panic could not be acted on. It now appends the classdef name for `Instance` / the pointer target for `Ptr`, the way the `SomeInstance` arm already names its two classdefs. The existing phrase stays first and verbatim — `cutover.rs:1291` (`is_known_unported`) and `:2718` (bucket `UNION-PAIR-PORT`) match it with `contains`.

**`majit`: lower `Vec::{new,with_capacity}` to `newlist`, reserve a `__pyre_range` path**
- `vec::Vec::{with_capacity,new}` fell through to `foreign_container_ctor`, so the result annotated as a classdef-less opaque `SomeInstance` and the already-wired `push`→`append` / `reverse` recognizers aborted their `getattr` against it. The adapter now emits `newlist` with no element args (`rtype_newlist`, `rlist.py:338-344`). The capacity operand is dropped — upstream keeps a size hint only through `objectmodel.newlist_hint` (`objectmodel.py:443-447`), a path `rtype_newlist` here does not take. `op_canraise` classifies the call non-raising: `operation.py:551-553` gives `NewList` `canraise = []`.
- `front::range_iter`'s synthesized range call moves from a bare `["range"]` to a reserved `["__pyre_range"]` spelling with its own `translate_op` arm binding the `HOST_ENV` singleton. A single-segment path resolves against the `PyreCallRegistry` before `HOST_ENV`, and that registry is one flat leaf-keyed namespace, so `pyre_interpreter::module::_ast::convert::range` registered as `["range"]` and captured the call; `findbltintyper` is keyed by `Arc` identity (`rbuiltin.rs:98-101`) and then failed with *"don't know about built-in function `<host range>`"*. This also un-poisons the `_ast::convert::range` / `_ast::convert::<Impl>::parts` annotations that #767's bare spelling was capturing on main.

Census at `2360d766bfa`: phaseA 318 → **311**, phaseB 22 → **19**, classdef-less roots 38 → **6**, no new failures.

**`majit`: fold mixed-signedness shifts and comparisons in `const_eval_binop`**
`const_eval_binop` had arms for `(Int,Int)`, `(UInt,UInt)` and `(Bool,Bool)` only, so every mixed-signedness pair hit the catch-all decline. `pub const MEMBER_DIRECT_FLAG: u32 = 1 << 31` records one — an unsuffixed shift amount defaults to `i32` while the shifted value is `u32` — and the shift-overflow assert Charon plants ahead of it (`31i32 as u32 < 32u32`) is mixed too, so the const stayed a residual accessor call no registry can bind. The new arm fires only when the signed side is non-negative (both carriers then agree on the mathematical value) and only for shifts and comparisons; **arithmetic stays declined**, since a mixed pair is exactly what leaves the result *type* undetermined.

It also closes a latent wrong-constant hole: `const_narrow_to_target` re-narrows every `Assign` result to the destination width, because the `ConstLit` carrier is 64-bit while rustc computes at the destination width and Rust does not count shifted-out bits as an overflow (`200u8 << 1` is a legal const equal to **144**, not 400).

Census at `beee634acb7`: phaseA 295 → **292**, skips 338 → **335**, no new failures; `MEMBER_DIRECT_FLAG` mentions 15 → 0.

**`typeobject`: note the pair-coherence consequence of the split elidable lookup**
`lookup_where_with_method_cache` reads `(w_class, w_value)` through two single-register elidable residuals because the residual-call ABI carries one raw register, where `typeobject.py:510` returns one tuple. Each residual takes the cache mutex separately, so a concurrent `mutated()` can land between them — worth stating, and no weaker than the `version_tag` promotion immediately above it. The same comment still said "thread-local `MethodCache`", which #784 made stale.

### Dropped during the rebase onto `0b706504dde`
This branch previously carried a fourth line of work — converting `baseobjspace::METHOD_CACHE` from `thread_local!` to a process-global prebuilt singleton, on the grounds that `space.fromcache` is a `specialize:memo` and a thread-local space cache is a deviation. **`#784` (free-threaded runtime port) landed the same conversion on main and did it properly**, as `LazyLock<parking_lot::Mutex<MethodCache>>` with every probe, fill, clear and GC walk under the lock, plus the same treatment for `MAP_ATTR_CACHE`. The local version's premise — one mutator, so an unlocked publication protocol suffices — is false as of #784, so re-applying it would have replaced a correct mutex with a racy protocol. Those three commits were dropped rather than rebased; only the comment fix above survives.

### Verification
- `cargo test --all --no-default-features --features dynasm` — **7084 passed, 0 failed**.
- `python3 pyre/check.py --backend dynasm,cranelift`.
- Capstone gate for the `newlist` adapter arm: `strings target/release/build/pyre-jit-trace-*/out/insns.bin | rg newlist` is empty (a raw `newlist/…>r` reaching the assembler default arm would be an opname with no blackhole handler), and `default_bh_builder_unwired_set_matches_task_85_snapshot` is green.
- The LLBC corpus was re-extracted (`scripts/extract-llbc.py --force`) after the rebase; a stale corpus fails `test_rbigint_mir` on the `jit_bigint_div` marker, which is not a code defect.

## Self-review

Reviewed against the upstream sources cited above (`typeobject.py`, `rlist.py`, `objectmodel.py`, `operation.py`, `rbuiltin.rs`). One thing worth reviewer attention:

- `const_narrow_to_target` changes the behaviour of the pre-existing `(UInt,UInt)` `Shl` arm, not only the new mixed arm. That is deliberate — the old arm could bake a constant wider than its destination type.

- [ ] I fully resolved all reasonable code review comments from Codex and CodeRabbit.
  - [ ] Auto-review section 1 is clear. This check is mandatory.
  - [ ] Auto-review section 2 is clear. If this is not checked, please add a comment explaining why.
- [ ] I did not use AI to write the code of this patch.
  - If this is not checked, commits must include `Assisted-by`
