### PR TITLE
none: expose the CPython 3.14 slot-wrapper surface

### DIFF
--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -8460,6 +8460,13 @@ pub(crate) unsafe fn get(
     // PyPy splits BuiltinFunction from FunctionWithFixedCode at the typedef
     // layer: BuiltinFunction omits __get__, while FunctionWithFixedCode keeps
     // Function.__get__ and binds like a normal method descriptor.
+    if crate::is_slot_wrapper(descr) {
+        if obj.is_null() {
+            return Ok(Some(descr));
+        }
+        return Ok(Some(pyre_object::w_method_new(descr, obj, w_type)));
+    }
+
     if crate::is_function(descr) {
         let ob_type = unsafe { (*descr).ob_type };
         if std::ptr::eq(ob_type, &crate::BUILTIN_FUNCTION_TYPE as *const _) {
@@ -9931,6 +9938,7 @@ pub fn callable_w(obj: PyObjectRef) -> bool {
     // `__call__`.  Mirrors `builtins::builtin_callable`.
     unsafe {
         is_function(obj)
+            || crate::is_slot_wrapper(obj)
             || is_type(obj)
             || pyre_object::is_method(obj)
             || pyre_object::function::is_staticmethod(obj)

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -9042,7 +9042,11 @@ pub fn hash_value(obj: PyObjectRef) -> i64 {
             }
         }
         if pyre_object::is_none(obj) {
-            return 0;
+            // CPython 3.12+ `Objects/object.c:none_hash`; introduced by
+            // gh-99541 so singleton hashes are reproducible across processes.
+            // PyPy inherits identity hashing here, so this is an intentional
+            // CPython 3.14 surface delta rather than a PyPy semantic port.
+            return 0xFCA8_6420;
         }
         if is_tuple(obj) {
             let n = w_tuple_len(obj);

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -1873,7 +1873,7 @@ pub fn call_with_kwargs(
         }
     }
 
-    if unsafe { crate::is_function(callable) } {
+    if unsafe { crate::is_function_carrier(callable) } {
         let code = unsafe { crate::getcode(callable) };
         // For builtins: pack kwargs into a dict as last arg.
         //
@@ -2473,7 +2473,7 @@ pub fn call_function_impl_result(
             return call_function_impl_result(func, &call_args);
         }
         // All callables are Function objects.
-        if crate::is_function(callable) {
+        if crate::is_function_carrier(callable) {
             let code = crate::getcode(callable);
             if crate::is_builtin_code(code as pyre_object::PyObjectRef) {
                 // Builtin function: direct Rust call. Errors propagate

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -2708,7 +2708,7 @@ unsafe fn method_descriptor_bound(
     obj: PyObjectRef,
 ) -> PyObjectRef {
     unsafe {
-        if d != attr || !crate::is_function(d) {
+        if d != attr || !crate::is_function_carrier(d) {
             return PY_NULL;
         }
         // BuiltinFunction has no `__get__` (its typedef carries no

--- a/pyre/pyre-interpreter/src/function.rs
+++ b/pyre/pyre-interpreter/src/function.rs
@@ -13,6 +13,12 @@ pub static FUNCTION_TYPE: PyType = pyre_object::pyobject::new_pytype("function")
 /// Type descriptor for module-level builtins.
 pub static BUILTIN_FUNCTION_TYPE: PyType =
     pyre_object::pyobject::new_pytype("builtin_function_or_method");
+/// CPython-compatible slot wrapper descriptor.
+///
+/// The public type is distinct from PyPy's `FunctionWithFixedCode`, while the
+/// payload deliberately reuses [`Function`]: both are immutable BuiltinCode
+/// carriers and therefore have identical GC edges and call ABI.
+pub static SLOT_WRAPPER_TYPE: PyType = pyre_object::pyobject::new_pytype("wrapper_descriptor");
 
 /// User-defined function object.
 ///
@@ -518,6 +524,11 @@ pub fn function_new_builtin(
     )
 }
 
+/// Allocate an immutable slot-wrapper descriptor backed by `BuiltinCode`.
+pub fn function_new_slot_wrapper(code: *const (), name: String) -> PyObjectRef {
+    function_new_impl(&SLOT_WRAPPER_TYPE, code, name, PY_NULL, PY_NULL, false)
+}
+
 /// function.py:385-388 — `_check_code_mutable(attr)`:
 ///
 /// ```python
@@ -559,6 +570,21 @@ pub unsafe fn _get_immutable_code(func: PyObjectRef) -> *const () {
 #[inline]
 pub unsafe fn is_function(obj: PyObjectRef) -> bool {
     unsafe { py_type_check(obj, &FUNCTION_TYPE) || py_type_check(obj, &BUILTIN_FUNCTION_TYPE) }
+}
+
+/// Whether `obj` is a CPython-compatible slot-wrapper descriptor.
+#[inline]
+pub unsafe fn is_slot_wrapper(obj: PyObjectRef) -> bool {
+    unsafe { py_type_check(obj, &SLOT_WRAPPER_TYPE) }
+}
+
+/// Function-layout carriers accepted by the interpreter call machinery.
+///
+/// Keep this separate from [`is_function`]: wrapper descriptors must not
+/// expose Python-function metadata such as `__code__` or `__globals__`.
+#[inline]
+pub unsafe fn is_function_carrier(obj: PyObjectRef) -> bool {
+    unsafe { is_function(obj) || is_slot_wrapper(obj) }
 }
 
 /// Whether this Function carrier wraps an interp-level BuiltinCode rather

--- a/pyre/pyre-interpreter/src/gateway.rs
+++ b/pyre/pyre-interpreter/src/gateway.rs
@@ -783,6 +783,16 @@ pub fn make_builtin_function_with_arity(
     crate::function_new_with_fixed_code(code as *const (), name.to_string(), pyre_object::PY_NULL)
 }
 
+/// Build a CPython-compatible slot-wrapper descriptor with a fixed arity.
+pub fn make_slot_wrapper_with_arity(
+    name: &'static str,
+    func: BuiltinCodeFn,
+    arity: u16,
+) -> PyObjectRef {
+    let code = builtin_code_new_with_arity(name, func, arity);
+    crate::function_new_slot_wrapper(code as *const (), name.to_string())
+}
+
 /// `make_builtin_function` with `fast_natural_arity = PASSTHROUGHARGS1` —
 /// PyPy `BuiltinCodePassThroughArguments1` registration shape.
 pub fn make_builtin_function_passthrough_args1(

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -2423,6 +2423,10 @@ pub fn jit_static_pytype_addrs() -> Vec<(&'static str, i64)> {
             &crate::function::BUILTIN_FUNCTION_TYPE as *const _ as i64,
         ),
         (
+            "function::SLOT_WRAPPER_TYPE",
+            &crate::function::SLOT_WRAPPER_TYPE as *const _ as i64,
+        ),
+        (
             "gateway::BUILTIN_CODE_TYPE",
             &crate::gateway::BUILTIN_CODE_TYPE as *const _ as i64,
         ),

--- a/pyre/pyre-interpreter/src/lib.rs
+++ b/pyre/pyre-interpreter/src/lib.rs
@@ -775,6 +775,7 @@ pub use gateway::{
     make_builtin_function_with_arity, make_builtin_function_with_arity_and_maybe_sig,
     make_builtin_function_with_signature, make_module_builtin_function,
     make_module_builtin_function_with_arity, make_module_builtin_function_with_arity_and_maybe_sig,
+    make_slot_wrapper_with_arity,
 };
 pub use jit_fnaddr::*;
 pub use opcode_ops::*;
@@ -933,6 +934,7 @@ pub fn all_subclass_range_aliases() -> Vec<pyre_object::pyobject::SubclassRangeA
         subclass_range_alias(13, &crate::gateway::BUILTIN_CODE_TYPE),
         subclass_range_alias(14, &crate::function::FUNCTION_TYPE),
         subclass_range_alias(14, &crate::function::BUILTIN_FUNCTION_TYPE),
+        subclass_range_alias(14, &crate::function::SLOT_WRAPPER_TYPE),
         subclass_range_alias(43, &crate::pycode::CODE_TYPE),
         subclass_range_alias(44, &crate::pytraceback::PYTRACEBACK_TYPE),
         subclass_range_alias(56, typed::<crate::module::_random::W_Random>()),

--- a/pyre/pyre-interpreter/src/runtime_ops.rs
+++ b/pyre/pyre-interpreter/src/runtime_ops.rs
@@ -428,7 +428,7 @@ where
     // instead of letting the OS abort on a guard-page hit.
     crate::stack_check::stack_check()?;
     unsafe {
-        if is_function(callable) {
+        if crate::is_function_carrier(callable) {
             // All callables are Function objects. Check code type to distinguish
             // builtins (BuiltinCode) from user functions (PyCode).
             let code = crate::getcode(callable);

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -544,6 +544,20 @@ pub fn init_typeobjects() {
             builtin_function_type as usize,
         );
 
+        // CPython `wrapper_descriptor`: slot wrappers bind their receiver and
+        // are callable, but are not Python functions. Their Rust payload is
+        // the immutable BuiltinCode-backed Function carrier.
+        let slot_wrapper_type = new_typeobject_with_base("wrapper_descriptor", |_| {}, object_type);
+        unsafe {
+            pyre_object::w_type_set_acceptable_as_base_class(slot_wrapper_type, false);
+            pyre_object::w_type_set_disallow_instantiation(slot_wrapper_type);
+            pyre_object::typeobject::w_type_set_flag_method_descriptor(slot_wrapper_type, true);
+        }
+        reg.insert(
+            &crate::SLOT_WRAPPER_TYPE as *const PyType as usize,
+            slot_wrapper_type as usize,
+        );
+
         // builtin-code — PyPy: BuiltinCode.typedef = TypeDef('builtin-code', ...)
         reg.insert(
             &crate::BUILTIN_CODE_TYPE as *const PyType as usize,
@@ -2478,7 +2492,7 @@ fn init_none_type(ns: PyObjectRef) {
         ),
         (
             "__hash__",
-            make_builtin_function_with_arity(
+            crate::make_slot_wrapper_with_arity(
                 "__hash__",
                 |args| {
                     let self_ =
@@ -2490,7 +2504,7 @@ fn init_none_type(ns: PyObjectRef) {
         ),
         (
             "__eq__",
-            make_builtin_function_with_arity(
+            crate::make_slot_wrapper_with_arity(
                 "__eq__",
                 |args| {
                     singleton_receiver(args, "NoneType", "__eq__", pyre_object::is_none)?;
@@ -2505,7 +2519,7 @@ fn init_none_type(ns: PyObjectRef) {
         ),
         (
             "__ne__",
-            make_builtin_function_with_arity(
+            crate::make_slot_wrapper_with_arity(
                 "__ne__",
                 |args| {
                     singleton_receiver(args, "NoneType", "__ne__", pyre_object::is_none)?;
@@ -2532,7 +2546,7 @@ fn init_none_type(ns: PyObjectRef) {
             pyre_object::w_dict_setitem_str(
                 ns,
                 name,
-                make_builtin_function_with_arity(name, function, 2),
+                crate::make_slot_wrapper_with_arity(name, function, 2),
             )
         };
     }

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -1559,6 +1559,15 @@ fn build_gc() -> Box<dyn majit_gc::GcAllocator> {
         &pyre_interpreter::function::BUILTIN_FUNCTION_TYPE as *const _ as usize,
         function_tid,
     );
+    majit_gc::GcAllocator::register_vtable_for_type(
+        &mut gc,
+        &pyre_interpreter::function::SLOT_WRAPPER_TYPE as *const _ as usize,
+        function_tid,
+    );
+    pytype_to_tid.insert(
+        &pyre_interpreter::function::SLOT_WRAPPER_TYPE as *const _ as usize,
+        function_tid,
+    );
     // Cell / Method / W_SliceObject — typed payload
     // via `#[pyre_class]`.  Pre-registered ahead of the foreign-
     // pytype loop because that loop's `size_of::<PyObject>()`


### PR DESCRIPTION
Assisted-by: Codex:gpt-5.6 Sol

<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary

- Preserve PyPy’s identity-based equality semantics for `None` and its use of `NotImplemented` for ordering comparisons, while exposing the comparison and hash slots as distinct `wrapper_descriptor` objects to match CPython 3.14’s public surface.
- Reuse the immutable, `BuiltinCode`-backed Function layout without exposing Python-function-specific metadata, and extend descriptor binding, call dispatch, `LOAD_METHOD`, GC vtable registration, and JIT static-address resolution to recognize the new carrier.
- Use CPython’s reproducible `None` hash value, `0xFCA86420`, and document both its origin in [gh-99541](https://github.com/python/cpython/issues/99541) and the intentional divergence from PyPy’s identity-based hashing.

## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 will be run automatically when this is ready for review.
The prompt is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
-->

- [ ] I fully resolved all reasonable code review comments from Codex and CodeRabbit.
  - [ ] Auto-review section 1 is clear. This check is mandatory.
  - [ ] Auto-review section 2 is clear. If this is not checked, please add a comment explaining why.
- [ ] I did not use AI to write the code of this patch.
  - If this is not checked, commits must include `Assisted-by`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CPython-compatible slot wrapper descriptors for built-in operations.
  * Improved support for calling and binding slot wrappers as methods.
  * Added support for fixed-arity slot wrapper creation.

* **Bug Fixes**
  * Updated `hash(None)` to use a consistent CPython-compatible hash value.
  * Improved callable detection across function, method, and descriptor execution paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->