### PR TITLE
majit: emit the two already-wired opcodes the #[jit_interp] front-end never produced

### DIFF
--- a/majit/majit-macros/src/jit_interp/jitcode_lower/helpers.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/helpers.rs
@@ -395,6 +395,22 @@ pub(super) fn is_supported_ref_type(ty: &Type) -> bool {
     }
 }
 
+/// Whether an `as <ty>` target is a full machine word, i.e. a cast that neither
+/// truncates nor extends the 64-bit value. Only these are safe targets for a
+/// `<float> as <ty>` cast: Rust saturates at the TARGET type's bounds, which a
+/// float->i64 followed by an int narrowing would not reproduce.
+pub(super) fn is_word_width_int(ty: &Type) -> bool {
+    match ty {
+        Type::Path(type_path) => {
+            type_path.path.is_ident("i64")
+                || type_path.path.is_ident("u64")
+                || type_path.path.is_ident("isize")
+                || type_path.path.is_ident("usize")
+        }
+        _ => false,
+    }
+}
+
 pub(super) fn is_supported_float_type(ty: &Type) -> bool {
     match ty {
         Type::Path(type_path) => type_path.path.is_ident("f64"),

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_value.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_value.rs
@@ -275,7 +275,7 @@ impl<'c> Lowerer<'c> {
                 // Unsigned compare intrinsics `majit_uint_lt(a, b)` /
                 // `majit_uint_le(a, b)` → uint_lt / uint_le (the signed opcode
                 // the generic binop path emits is wrong for uint).
-                if let Some(binding) = self.lower_uint_compare_call(call) {
+                if let Some(binding) = self.lower_uint_intrinsic_call(call) {
                     return Some(binding);
                 }
                 self.lower_call_value(call)
@@ -353,16 +353,40 @@ impl<'c> Lowerer<'c> {
         }
     }
 
-    /// Lower the unsigned integer comparison intrinsics `majit_uint_lt(a, b)` /
-    /// `majit_uint_le(a, b)` to `uint_lt` / `uint_le` (`bhimpl_uint_lt` /
-    /// `bhimpl_uint_le`). Both operands are read from the int bank as unsigned
-    /// 64-bit values; the op writes a `0`/`1` int result. `opcode_for_binop`
-    /// maps `<`/`<=` to the signed `IntLt`/`IntLe`, so an explicit intrinsic is
-    /// the only way to select the unsigned opcode from the tracing frontend.
-    fn lower_uint_compare_call(&mut self, call: &syn::ExprCall) -> Option<Binding> {
-        let opcode_name = match canonical_expr_segments(&call.func)?.last()?.as_str() {
-            "majit_uint_lt" => "UintLt",
-            "majit_uint_le" => "UintLe",
+    /// Lower the unsigned integer intrinsics. Both operands are read from the
+    /// int bank as unsigned 64-bit values. `opcode_for_binop` collapses every
+    /// Rust binary operator to its SIGNED opcode (`<` to `IntLt`, `/` to
+    /// `IntFloorDiv`) and `BindingKind` has no signedness at all, so an
+    /// explicit intrinsic is the only way to select an unsigned operation from
+    /// the tracing frontend.
+    ///
+    /// The two families lower differently, mirroring RPython:
+    ///   * `majit_uint_lt`/`majit_uint_le` become the `uint_lt`/`uint_le`
+    ///     primitives (`bhimpl_uint_lt`/`bhimpl_uint_le`), because
+    ///     `resoperation.py:1017-1018` keeps `UINT_LT`/`UINT_LE` as real
+    ///     resops.
+    ///   * `majit_uint_div`/`majit_uint_mod` become the `int.udiv`/`int.umod`
+    ///     oopspec residual calls, because `UINT_FLOORDIV` was REMOVED from the
+    ///     resop set in 2016 and `rint.py:434,525` route unsigned `/` and `%`
+    ///     through `ll_uint_py_div`/`ll_uint_py_mod` instead. This is the same
+    ///     redirect `binop_i_emit_tokens` already performs for the signed
+    ///     `IntFloorDiv`/`IntMod`.
+    ///
+    /// The division intrinsics carry `ll_uint_py_div`'s `rhs != 0`
+    /// precondition: the caller must guard the zero divisor, exactly as
+    /// RPython's inlined `ll_uint_py_div_zer` wrapper does.
+    fn lower_uint_intrinsic_call(&mut self, call: &syn::ExprCall) -> Option<Binding> {
+        enum UintEmit {
+            /// A real unsigned resop recorded through `record_binop_i`.
+            Opcode(&'static str),
+            /// An oopspec residual call recorded through its own `record_*`.
+            OopspecCall(&'static str),
+        }
+        let emit = match canonical_expr_segments(&call.func)?.last()?.as_str() {
+            "majit_uint_lt" => UintEmit::Opcode("UintLt"),
+            "majit_uint_le" => UintEmit::Opcode("UintLe"),
+            "majit_uint_div" => UintEmit::OopspecCall("record_uint_py_div"),
+            "majit_uint_mod" => UintEmit::OopspecCall("record_uint_py_mod"),
             _ => return None,
         };
         if call.args.len() != 2 {
@@ -375,14 +399,23 @@ impl<'c> Lowerer<'c> {
         }
         let (lhs_reg, rhs_reg) = (lhs.reg, rhs.reg);
         let dst = self.alloc_reg();
-        let opcode = format_ident!("{opcode_name}");
+        let tokens = match emit {
+            UintEmit::Opcode(opcode_name) => {
+                let opcode = format_ident!("{opcode_name}");
+                binop_i_emit_tokens(dst, &opcode, lhs_reg, rhs_reg)
+            }
+            UintEmit::OopspecCall(method_name) => {
+                let method = format_ident!("{method_name}");
+                quote! { __builder.#method(#dst, #lhs_reg, #rhs_reg); }
+            }
+        };
         self.emit_op(
             OpMeta::linear(
                 OpKind::BinopI,
                 Register::ints(&[lhs_reg, rhs_reg]),
                 vec![Register::int(dst)],
             ),
-            binop_i_emit_tokens(dst, &opcode, lhs_reg, rhs_reg),
+            tokens,
         );
         Some(Binding {
             reg: dst,

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_value.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_value.rs
@@ -215,10 +215,18 @@ impl<'c> Lowerer<'c> {
             }
             Expr::Cast(ExprCast { expr, ty, .. }) if is_supported_int_cast(ty) => {
                 let binding = self.lower_value_expr(expr)?;
-                if !matches!(binding.kind, BindingKind::Int) {
-                    return None;
+                match binding.kind {
+                    BindingKind::Int => self.lower_int_cast(binding, ty),
+                    // A FLOAT operand is the `cast_int_to_float` arm above run
+                    // backwards. Only a word-width target lowers: Rust saturates
+                    // an `as` cast at the TARGET type's bounds, so `300.0 as i8`
+                    // is `127`, which a float->i64 followed by an int narrowing
+                    // (`44`) would not reproduce.
+                    BindingKind::Float if is_word_width_int(ty) => {
+                        self.lower_float_to_int_cast(binding)
+                    }
+                    _ => None,
                 }
-                self.lower_int_cast(binding, ty)
             }
             Expr::Paren(ExprParen { expr, .. }) => self.lower_value_expr(expr),
             Expr::If(expr_if) => self.lower_if_value(expr_if),
@@ -2055,6 +2063,33 @@ impl<'c> Lowerer<'c> {
         Some(Binding {
             reg,
             kind: BindingKind::Float,
+            depends_on_stack: binding.depends_on_stack,
+            struct_type: None,
+        })
+    }
+
+    /// Lower a `<float> as i64` cast to RPython's `cast_float_to_int`
+    /// (`bhimpl_cast_float_to_int`), the inverse of
+    /// [`Self::lower_int_to_float_cast`]. The operand is read from the float
+    /// bank and truncated toward zero into the int bank; the result is an int
+    /// binding. `UnaryI` is the op-kind label, as for the neighbouring
+    /// `convert_float_bytes_to_longlong`; the float bank of the SOURCE and the
+    /// int bank of the result are carried by the `Register`s, which is what
+    /// liveness/regalloc read.
+    fn lower_float_to_int_cast(&mut self, binding: Binding) -> Option<Binding> {
+        let src_reg = binding.reg;
+        let reg = self.alloc_reg();
+        self.emit_op(
+            OpMeta::linear(
+                OpKind::UnaryI,
+                vec![Register::float(src_reg)],
+                vec![Register::int(reg)],
+            ),
+            quote! { __builder.record_cast_float_to_int(#reg, #src_reg); },
+        );
+        Some(Binding {
+            reg,
+            kind: BindingKind::Int,
             depends_on_stack: binding.depends_on_stack,
             struct_type: None,
         })

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/mod.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/mod.rs
@@ -41,7 +41,7 @@ mod reexports {
         extract_pat_switch_case_tokens, extract_pat_value_tokens, extract_stmts,
         inline_builder_path, inline_call_tokens, inline_call_tokens_void, inline_float_arg_tokens,
         inline_int_arg_tokens, inline_prebuild_path, inline_ref_arg_tokens, int_arg_regs,
-        is_supported_float_type, is_supported_int_cast, is_supported_ref_type,
+        is_supported_float_type, is_supported_int_cast, is_supported_ref_type, is_word_width_int,
         opcode_for_assign_binop, opcode_for_binop, opcode_for_binop_f, opcode_for_compare_f,
         stmt_has_loop_control, typed_call_arg_tokens,
     };

--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -4244,6 +4244,31 @@ pub extern "C" fn ll_int_py_mod(a: i64, b: i64) -> i64 {
     }
 }
 
+/// RPython `rint.py:434-436 ll_uint_py_div` (oopspec `int.udiv`).  The
+/// `OS_INT_UDIV` residual call lands here at runtime.  Unsigned division
+/// has no sign correction to make — `llop.uint_floordiv` translates to
+/// the C macro `OP_UINT_FLOORDIV(x, y, r) r = (x) / (y)` — so the whole
+/// helper is the raw unsigned quotient of the two operands' bit patterns.
+///
+/// Unlike the signed [`ll_int_py_div`] there is no `INT_MIN / -1`
+/// corner: every pair of `u64` operands with a nonzero divisor has a
+/// representable quotient.  The zero divisor remains a precondition
+/// (`wrapping_div(0)` panics in every Rust build), spelled in RPython as
+/// the `rint.py:438 ll_uint_py_div_zer` wrapper whose check is inlined
+/// into the caller and becomes a runtime guard in the trace.
+///
+/// `extern "C"` for the same residual-call ABI reason as [`ll_int_py_div`].
+pub extern "C" fn ll_uint_py_div(a: i64, b: i64) -> i64 {
+    ((a as u64) / (b as u64)) as i64
+}
+
+/// RPython `rint.py:525-527 ll_uint_py_mod` (oopspec `int.umod`).  The
+/// unsigned remainder needs no sign correction either; see
+/// [`ll_uint_py_div`] for the zero-divisor precondition.
+pub extern "C" fn ll_uint_py_mod(a: i64, b: i64) -> i64 {
+    ((a as u64) % (b as u64)) as i64
+}
+
 /// RPython `support.py:255-264 _ll_2_int_floordiv`: C-truncating
 /// floor-division helper.  The upstream comment calls it "the reverse
 /// of `rpython.rtyper.rint.ll_int_py_div()`" — i.e. given an input

--- a/majit/majit-metainterp/src/call_descr.rs
+++ b/majit/majit-metainterp/src/call_descr.rs
@@ -366,6 +366,68 @@ pub const INT_PY_MOD_EFFECT_INFO: EffectInfo = EffectInfo {
     call_release_gil_target: EffectInfo::_NO_CALL_RELEASE_GIL_TARGET,
 };
 
+/// `EF_ELIDABLE_CANNOT_RAISE` with `OS_INT_UDIV` oopspec — unsigned `/`.
+/// RPython parity: `rint.py:434 ll_uint_py_div` carries
+/// `@jit.oopspec("int.udiv(x, y)")`, and jtransform.py:2043-2047
+/// `_handle_int_special` classifies every `int.*div`/`int.*mod` oopspec as
+/// `EF_ELIDABLE_CANNOT_RAISE`.
+///
+/// Unsigned division deliberately has NO trace opcode. RPython removed
+/// `UINT_FLOORDIV` from the resop set (2016-05-10, "Remove divisions and
+/// modulos from regular JIT operations, uses oopspec calls") and routes it
+/// through this residual call instead, exactly as the signed
+/// [`INT_PY_DIV_EFFECT_INFO`] does — the oopspec index, not an opcode, is
+/// what the optimizer matches on (`rewrite.rs` `optimize_call_int_udiv`).
+/// Callee is pure: no heap touched, no GC trigger, no raise.
+pub const UINT_PY_DIV_EFFECT_INFO: EffectInfo = EffectInfo {
+    extraeffect: ExtraEffect::ElidableCannotRaise,
+    oopspecindex: OopSpecIndex::IntUdiv,
+    pyre_helper: PyreHelperKind::None,
+    _readonly_descrs_fields: Some(Vec::new()),
+    _write_descrs_fields: Some(Vec::new()),
+    _readonly_descrs_arrays: Some(Vec::new()),
+    _write_descrs_arrays: Some(Vec::new()),
+    _readonly_descrs_interiorfields: Some(Vec::new()),
+    _write_descrs_interiorfields: Some(Vec::new()),
+    readonly_descrs_fields: Some(Vec::new()),
+    write_descrs_fields: Some(Vec::new()),
+    readonly_descrs_arrays: Some(Vec::new()),
+    write_descrs_arrays: Some(Vec::new()),
+    readonly_descrs_interiorfields: Some(Vec::new()),
+    write_descrs_interiorfields: Some(Vec::new()),
+    can_invalidate: false,
+    can_collect: false,
+    single_write_descr_array: None,
+    extradescrs: None,
+    call_release_gil_target: EffectInfo::_NO_CALL_RELEASE_GIL_TARGET,
+};
+
+/// Counterpart of [`UINT_PY_DIV_EFFECT_INFO`] for unsigned `%`.
+/// RPython parity: `rint.py:525 ll_uint_py_mod` carries
+/// `@jit.oopspec("int.umod(x, y)")`.
+pub const UINT_PY_MOD_EFFECT_INFO: EffectInfo = EffectInfo {
+    extraeffect: ExtraEffect::ElidableCannotRaise,
+    oopspecindex: OopSpecIndex::IntUmod,
+    pyre_helper: PyreHelperKind::None,
+    _readonly_descrs_fields: Some(Vec::new()),
+    _write_descrs_fields: Some(Vec::new()),
+    _readonly_descrs_arrays: Some(Vec::new()),
+    _write_descrs_arrays: Some(Vec::new()),
+    _readonly_descrs_interiorfields: Some(Vec::new()),
+    _write_descrs_interiorfields: Some(Vec::new()),
+    readonly_descrs_fields: Some(Vec::new()),
+    write_descrs_fields: Some(Vec::new()),
+    readonly_descrs_arrays: Some(Vec::new()),
+    write_descrs_arrays: Some(Vec::new()),
+    readonly_descrs_interiorfields: Some(Vec::new()),
+    write_descrs_interiorfields: Some(Vec::new()),
+    can_invalidate: false,
+    can_collect: false,
+    single_write_descr_array: None,
+    extradescrs: None,
+    call_release_gil_target: EffectInfo::_NO_CALL_RELEASE_GIL_TARGET,
+};
+
 /// `EF_ELIDABLE_CANNOT_RAISE` (effectinfo.py:17). Selected by
 /// `call.py:299 getcalldescr` when `_canraise(op) == False` for an
 /// elidable callee — `pyjitpl.py:2126 do_residual_call` records

--- a/majit/majit-metainterp/src/jitcode/assembler.rs
+++ b/majit/majit-metainterp/src/jitcode/assembler.rs
@@ -1822,6 +1822,36 @@ impl JitCodeBuilder {
         );
     }
 
+    /// Unsigned `/` — the `int.udiv` oopspec residual call
+    /// (`rint.py:434 ll_uint_py_div`).  RPython has no unsigned division
+    /// resop at all: `UINT_FLOORDIV` was deleted in 2016 in favour of this
+    /// oopspec call, so unlike the unsigned comparisons (which do have
+    /// `uint_lt`/`uint_le` primitives reachable through `record_binop_i`)
+    /// there is nothing here to record but the call.  Same
+    /// `rhs != 0` precondition as [`Self::record_int_py_div`]; unsigned has no
+    /// `INT_MIN / -1` corner.
+    pub fn record_uint_py_div(&mut self, dst: u16, lhs: u16, rhs: u16) {
+        self.record_int_py_helper(
+            dst,
+            lhs,
+            rhs,
+            crate::blackhole::ll_uint_py_div as *const (),
+            crate::call_descr::UINT_PY_DIV_EFFECT_INFO,
+        );
+    }
+
+    /// Unsigned `%` — the `int.umod` oopspec residual call
+    /// (`rint.py:525 ll_uint_py_mod`).  See [`Self::record_uint_py_div`].
+    pub fn record_uint_py_mod(&mut self, dst: u16, lhs: u16, rhs: u16) {
+        self.record_int_py_helper(
+            dst,
+            lhs,
+            rhs,
+            crate::blackhole::ll_uint_py_mod as *const (),
+            crate::call_descr::UINT_PY_MOD_EFFECT_INFO,
+        );
+    }
+
     fn record_int_py_helper(
         &mut self,
         dst: u16,

--- a/majit/majit-metainterp/src/jitcode/assembler.rs
+++ b/majit/majit-metainterp/src/jitcode/assembler.rs
@@ -4450,6 +4450,19 @@ impl JitCodeBuilder {
         self.push_u8(dst as u8);
     }
 
+    /// Narrow a float-bank value to the int bank — RPython `cast_float_to_int`
+    /// (`blackhole.py:801-810 bhimpl_cast_float_to_int`). The inverse of
+    /// [`Self::record_cast_int_to_float`]: a VALUE cast that truncates toward
+    /// zero, NOT the `convert_float_bytes_to_longlong` bitcast below. Same
+    /// `f>i` operand crossing — float source, int result, `[src][dst]`.
+    pub fn record_cast_float_to_int(&mut self, dst: u16, src: u16) {
+        self.touch_reg(dst);
+        self.touch_float_reg(src);
+        self.write_insn("cast_float_to_int/f>i");
+        self.push_u8(src as u8);
+        self.push_u8(dst as u8);
+    }
+
     /// Reinterpret a float's 64-bit pattern as an int — RPython
     /// `convert_float_bytes_to_longlong` (`blackhole.py:828-830`). A bitcast
     /// (`f>i`), NOT a value cast: float source, int result, `[src][dst]` layout.

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -6866,6 +6866,7 @@ where
             jitcode::insns::BC_FLOAT_GT => self.trace_compare_f(ctx, OpCode::FloatGt),
             jitcode::insns::BC_FLOAT_GE => self.trace_compare_f(ctx, OpCode::FloatGe),
             jitcode::insns::BC_CAST_INT_TO_FLOAT => self.trace_cast_int_to_float(ctx),
+            jitcode::insns::BC_CAST_FLOAT_TO_INT => self.trace_cast_float_to_int(ctx),
             jitcode::insns::BC_CONVERT_FLOAT_BYTES_TO_LONGLONG => {
                 self.trace_convert_float_bytes_to_longlong(ctx)
             }
@@ -7562,6 +7563,28 @@ where
         let opref = ctx.record_op(OpCode::CastIntToFloat, &[src]);
         ctx.set_opref_concrete(opref, majit_ir::Value::Float(fvalue));
         self.set_float_reg(dst, Some(opref), Some(fvalue.to_bits() as i64));
+    }
+
+    /// `cast_float_to_int/f>i`: truncate a float-bank value toward zero into the
+    /// int bank — the inverse of `trace_cast_int_to_float`, and a VALUE cast, not
+    /// the bitcast below. `[src][dst]`. The float travels as its `i64` bits, so
+    /// the concrete value is `f64::from_bits(bits) as i64`, matching
+    /// `bhimpl_cast_float_to_int` (`blackhole.py:801-810`) exactly — including
+    /// Rust's saturating behaviour on non-finite and out-of-range inputs, which
+    /// `execute_cast_const` deliberately refuses to constant-fold so the runtime
+    /// stays the single source of that policy.
+    fn trace_cast_float_to_int(&mut self, ctx: &mut TraceCtx) {
+        let (src_idx, dst) = {
+            let frame = self.frames.current_mut();
+            let src_idx = frame.next_u8() as usize;
+            let dst = frame.next_u8() as usize;
+            (src_idx, dst)
+        };
+        let (src, bits) = self.read_float_reg(src_idx);
+        let ivalue = f64::from_bits(bits as u64) as i64;
+        let opref = ctx.record_op(OpCode::CastFloatToInt, &[src]);
+        ctx.set_opref_concrete(opref, majit_ir::Value::Int(ivalue));
+        self.set_int_reg(dst, Some(opref), Some(ivalue));
     }
 
     /// `convert_float_bytes_to_longlong/f>i`: reinterpret a float's 64-bit


### PR DESCRIPTION
Two `majit-macros` gaps of the same shape: the IR opcode, the blackhole handler, the executor arm and all three backends already existed, and **nothing emitted the bytecode**. Both are found and driven by the cel-jit client (`youknowone/cel-jit`, branch `majit`), which is the only user of the `#[jit_interp]` front-end besides the wasmi kernel and the examples.

### `<float> as i64` → `cast_float_to_int` (`d13056b`)

The macro lowered only the widening direction: an `as <int>` cast required an int-banked operand, so a float operand returned `None` and the whole statement failed to lower. Adds `is_word_width_int`, a Float arm calling the new `lower_float_to_int_cast`, `record_cast_float_to_int`, and the `BC_CAST_FLOAT_TO_INT` tracer dispatch.

Only word-width targets lower. Rust saturates an `as` cast at the target type's bounds, so `300.0 as i8` is 127, which float→i64 followed by an int narrowing (44) would not reproduce; narrower targets keep returning `None`.

### unsigned `/` and `%` → `int.udiv`/`int.umod` oopspec calls (`4089c4e`)

⭐ The premise this started from was wrong, and checking it against RPython is the interesting part: a **new IR opcode would have been anti-orthodox**. RPython *deleted* `UINT_FLOORDIV` from the resop set in 2016 (Armin Rigo, `aaa11e80f52`, "Remove divisions and modulos from regular JIT operations, uses oopspec calls"), together with `INT_FLOORDIV`/`INT_MOD`; `UINT_MOD` was never a resop at all. Current PyPy has no division opcode of any signedness — `rint.py` carries `@jit.oopspec("int.udiv")`/`("int.umod")` and jtransform turns them into `residual_call_ir_i` with `EF_ELIDABLE_CANNOT_RAISE`.

majit already mirrored this for signed (`IntFloorDiv` is a macro emit key that `binop_i_emit_tokens` redirects to `record_int_py_div`), and `OopSpecIndex::IntUdiv`/`IntUmod` already existed with a consumer in the optimizer and no producer. This adds the producers: `ll_uint_py_div`/`ll_uint_py_mod`, the two `EffectInfo`s, `record_uint_py_div`/`record_uint_py_mod`, and `lower_uint_compare_call` → `lower_uint_intrinsic_call` also recognizing `majit_uint_div`/`majit_uint_mod`.

### Impact on pyre

Inert. No pyre code uses `#[jit_interp]` (pyre is on the `majit-translate` front-end), and each new dispatch arm is reachable only from bytecode the new macro arms emit.

### Verification

`cargo test -p majit-macros --features majit-metainterp/cranelift` → 105 + 34 passed, 0 failed.
`cargo test -p majit-metainterp --features cranelift` → 1409 passed, 0 failed (plus the per-module binaries, all green).

— *opened by Claude*