### PR TITLE
_thread: per-thread _local initialization and interruptible lock acquire; jit(fbw): name the multi-frame adopt declines

### DIFF
--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -1650,7 +1650,11 @@ fn gc_remove_root_via_active_runtime(slot: *mut GcRef) {
 /// Host-side write-barrier trampoline for GC-managed objects updated
 /// outside compiled code.
 fn gc_write_barrier_via_active_runtime(obj: GcRef) {
-    with_cranelift_gc(|gc| gc.write_barrier(obj));
+    if CRANELIFT_ACTIVE_GC.with(|cell| cell.borrow().is_some()) {
+        with_cranelift_gc(|gc| gc.write_barrier(obj));
+    } else if majit_gc::gc_sync::is_initialized() {
+        majit_gc::gc_sync::gc_op_with_root(obj, |gc, obj| gc.write_barrier(obj));
+    }
 }
 
 /// Host-side `is_managed_heap_object` trampoline. Lets host-side

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -557,7 +557,7 @@ fn dynasm_gc_write_barrier(obj: GcRef) {
     {
         return;
     }
-    majit_gc::gc_sync::gc_op(|g| g.write_barrier(obj));
+    majit_gc::gc_sync::gc_op_with_root(obj, |g, obj| g.write_barrier(obj));
 }
 
 fn dynasm_id_or_identityhash(addr: usize) -> usize {

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -2140,6 +2140,31 @@ impl MiniMarkGC {
         }
     }
 
+    /// incminimark.py:2478-2481 `collect_nonstack_roots(); visit_all_objects()`.
+    ///
+    /// Non-stack roots may grow after the initial root snapshot while marking
+    /// is incremental.  Revisit the process/interpreter-owned root walkers and
+    /// pending-finalizer queues immediately before finalizer processing and
+    /// sweep, then drain every newly greyed object.  Thread frame/shadow-stack
+    /// roots are deliberately not repeated here: upstream repeats only
+    /// `collect_nonstack_roots`, not `collect_roots`.
+    fn rescan_major_nonstack_roots_and_drain(&mut self) {
+        crate::shadow_stack::walk_extra_roots(|gcref| {
+            self.seed_major_root(*gcref);
+        });
+        let pending: Vec<usize> = self
+            .finalizer_handlers
+            .iter()
+            .flat_map(|handler| handler.deque.iter().copied())
+            .collect();
+        for addr in pending {
+            self.seed_major_root(GcRef(addr));
+        }
+        while let Some(obj_addr) = self.incr_state.gray_stack.pop() {
+            self.mark_object(obj_addr);
+        }
+    }
+
     /// Drive incremental major-collection progress after a minor collection.
     ///
     /// This follows incminimark's accounting rule: each major step grants
@@ -2386,6 +2411,10 @@ impl MiniMarkGC {
         // modified since the last minor) before the sweep, or a cycle finished
         // between minors frees reachable old->old targets.
         self.rescan_remembered_black_and_drain();
+        // incminimark.py:2478-2481: process-global/non-stack roots can grow
+        // after the cycle's initial snapshot.  Rescan and trace them before
+        // finalizers, weakrefs, and sweep inspect VISITED.
+        self.rescan_major_nonstack_roots_and_drain();
         // incminimark.py:2961-2965 (and :2495-2499) — clear weak
         // pointers to dying objects before the sweep frees them. The
         // VISITED bit on every old-gen object is still meaningful at

--- a/majit/majit-gc/src/gc_sync.rs
+++ b/majit/majit-gc/src/gc_sync.rs
@@ -621,6 +621,31 @@ pub fn request_stw(collect_fn: impl FnOnce(&mut dyn GcAllocator)) {
     });
 }
 
+/// Run a GC operation whose object argument is a translated livevar.
+///
+/// A contended [`gc_op`] temporarily removes this mutator from the RUNNING
+/// census before it acquires `gc_mutex`. Publish the argument on the
+/// per-mutator shadow stack first so a collector which runs during that wait
+/// preserves (and, for a moving minor, forwards) it. Reload the possibly
+/// forwarded value only after the operation owns the GC.
+pub fn gc_op_with_root<R>(
+    root: crate::GcRef,
+    f: impl FnOnce(&mut dyn GcAllocator, crate::GcRef) -> R,
+) -> R {
+    struct RootGuard(usize);
+    impl Drop for RootGuard {
+        fn drop(&mut self) {
+            crate::shadow_stack::try_pop_to(self.0);
+        }
+    }
+
+    let guard = RootGuard(crate::shadow_stack::push(root));
+    gc_op(|gc| {
+        let root = crate::shadow_stack::get(guard.0);
+        f(gc, root)
+    })
+}
+
 /// Park the current thread until the ongoing STW finishes.
 fn park_until_stw_done() {
     if !GC_THREAD.with(|t| t.registered.get()) || !GC_THREAD.with(|t| t.running.get()) {

--- a/majit/majit-gc/src/lib.rs
+++ b/majit/majit-gc/src/lib.rs
@@ -767,10 +767,10 @@ impl GcAllocator for GcHandle {
         gc_sync::gc_op(|gc| gc.alloc_oldgen_typed(type_id, size))
     }
     fn write_barrier(&mut self, obj: GcRef) {
-        gc_sync::gc_op(|gc| gc.write_barrier(obj))
+        gc_sync::gc_op_with_root(obj, |gc, obj| gc.write_barrier(obj))
     }
     fn jit_remember_young_pointer_from_array(&mut self, obj: GcRef) {
-        gc_sync::gc_op(|gc| gc.jit_remember_young_pointer_from_array(obj))
+        gc_sync::gc_op_with_root(obj, |gc, obj| gc.jit_remember_young_pointer_from_array(obj))
     }
     fn remember_young_pointer_from_array2(
         &mut self,
@@ -778,7 +778,9 @@ impl GcAllocator for GcHandle {
         index: usize,
         card_page_shift: u32,
     ) {
-        gc_sync::gc_op(|gc| gc.remember_young_pointer_from_array2(obj, index, card_page_shift))
+        gc_sync::gc_op_with_root(obj, |gc, obj| {
+            gc.remember_young_pointer_from_array2(obj, index, card_page_shift)
+        })
     }
     fn collect_nursery(&mut self) {
         gc_sync::gc_op(|gc| gc.collect_nursery())

--- a/pyre/bench/synth/getframe_inline_subwalk_multiframe.py
+++ b/pyre/bench/synth/getframe_inline_subwalk_multiframe.py
@@ -20,6 +20,15 @@
 # run this is an output guard; the coverage it adds is for `PYRE_FBW_MULTIFRAME=1`
 # (5 builds), which is how the gate's owner exercises the path.
 #
+# What the decline is holding back, measured by lifting it: the resumed chain
+# shifts every `sys._getframe(n)` up exactly one level, so the read below lands
+# on the module frame and raises `KeyError: 'base'`. Variants of this shape that
+# cannot raise return a wrong number instead, silently -- `f_locals.get("base",
+# -1)` scores -1 for 7, `len(f_locals)` scores the module globals' 12 for this
+# frame's 3, `len(f_code.co_name)` scores `<module>`'s 8 for a 9-character
+# caller name. So the adopt is wrong for every outcome arm, not only the one
+# that carries a resume coordinate.
+#
 # Deliberately carries no `# pyre-check: max-pypy-ratio=` header: this guards
 # an output, and the forcing read makes it a poor perf subject.
 import sys

--- a/pyre/bench/synth/getframe_inline_subwalk_multiframe.py
+++ b/pyre/bench/synth/getframe_inline_subwalk_multiframe.py
@@ -1,0 +1,44 @@
+# Coverage for the multi-frame blackhole build path: an INLINED callee that
+# forces an outer frame while the walk is already inside a residual call.
+#
+# The walker executes a residual call concretely, so that level gets a real
+# frame from the interpreter's own call sequence; an inline push never runs
+# that sequence, so its level has none. A force fired from the inlined body
+# therefore builds a frame chain that mixes the two, and the chain's root is
+# the intermediate residual frame rather than the walked frame -- which is
+# what `try_adopt_multi_frame_blackhole` declines on today (it wants the
+# `jit.virtual_ref` emit at the inline push, `executioncontext.py:89`). This
+# fixture pins that the declined path still returns byte-identical results.
+#
+# One `sys._getframe(1)` level does NOT reach the build: the chain needs a
+# residual level under the walked frame and an inlined level under that, so
+# the force has to reach two frames up. No other fixture in the corpus gets
+# here -- swept with `PYRE_FBW_DEBUG_ABORT=1 PYRE_FBW_MULTIFRAME=1`, 0 of 310
+# reach `BUILT multi-frame`, so without this one the path has no repro at all.
+#
+# With the gate at its default the image is not built either, so under a plain
+# run this is an output guard; the coverage it adds is for `PYRE_FBW_MULTIFRAME=1`
+# (5 builds), which is how the gate's owner exercises the path.
+#
+# Deliberately carries no `# pyre-check: max-pypy-ratio=` header: this guards
+# an output, and the forcing read makes it a poor perf subject.
+import sys
+
+
+def leaf(x):
+    return sys._getframe(2).f_locals["base"] + x
+
+
+def mid(x):
+    return leaf(x) + 1
+
+
+def main():
+    base = 7
+    total = 0
+    for i in range(20000):
+        total += mid(i)
+    print(total, base)
+
+
+main()

--- a/pyre/bench/synth/inlined_helper_arith_hot.py
+++ b/pyre/bench/synth/inlined_helper_arith_hot.py
@@ -20,7 +20,15 @@
 # measures the admitted paths rather than cases that are meant to stay slow.
 # Callees are named directly rather than passed in, so the call site keeps a
 # constant callee. Output verified against CPython/PyPy.
-N = 200000
+#
+# N is sized so PyPy's startup-subtracted user-CPU stays well clear of its own
+# empty-program startup. The gate divides by that difference, so a workload
+# finishing near startup makes the denominator a residue of two similar
+# measurements: at N=200000 it lands on the 5ms floor and unchanged code
+# reports anywhere from 6x to 22x depending on runner speed. At this N the
+# ratio is 2.5x (dynasm) / 3.1x (cranelift), which is the value the gate is
+# meant to bound.
+N = 4000000
 
 
 def add_body(a, i):

--- a/pyre/bench/synth/residual_raise_except_resume.py
+++ b/pyre/bench/synth/residual_raise_except_resume.py
@@ -17,7 +17,15 @@
 # `list_extend` residual.  Previously LIST_EXTEND had no walker handler
 # and emitted an abort that, reached on the resume walk, invalidated the
 # live frame and crashed (SIGSEGV) — the residual port fixes that.
-N = 2000000
+#
+# N is sized so PyPy's startup-subtracted user-CPU stays well clear of its own
+# empty-program startup. The gate divides by that difference, so a workload
+# finishing near startup makes the denominator a residue of two similar
+# measurements: at N=2000000 PyPy's whole run is shorter than its startup, the
+# difference clamps to the 5ms floor, and unchanged code reports anywhere from
+# 3x to 18x depending on runner speed. At this N the ratio is 1.8x (dynasm) /
+# 1.9x (cranelift), which is the value the gate is meant to bound.
+N = 20000000
 
 
 def divide_by_zero_const(n):

--- a/pyre/extra_tests/parity_tests/thread_local_and_lock_acquire.py
+++ b/pyre/extra_tests/parity_tests/thread_local_and_lock_acquire.py
@@ -126,24 +126,33 @@ assert rlock.acquire() is True
 rlock.release()
 rlock.release()
 
-# The wording of these differs between implementations; only the type is part
-# of the interface.
-for call in (
-    lambda: lock.acquire(False, 1.0),
-    lambda: lock.acquire(True, -2.0),
-):
+# `TIMEOUT_MAX` is the whole-second bound of the nanosecond timestamp the
+# argument is converted to, and that conversion runs before either the
+# blocking or the sign check.
+assert _thread.TIMEOUT_MAX == 9223372036.0
+
+for timeout, exc_type, message in [
+    (float("nan"), ValueError, "Invalid value NaN (not a number)"),
+    (9223372036.9, OverflowError, "timestamp out of range for platform time_t"),
+    (float("inf"), OverflowError, "timestamp out of range for platform time_t"),
+    (-1e18, OverflowError, "timestamp out of range for platform time_t"),
+    (-2.0, ValueError, "timeout value must be a non-negative number"),
+]:
     try:
-        call()
-    except ValueError:
-        pass
+        _thread.allocate_lock().acquire(True, timeout)
+    except exc_type as exc:
+        assert str(exc) == message, (timeout, exc)
     else:
-        raise AssertionError("bad acquire arguments accepted")
+        raise AssertionError("%r accepted" % (timeout,))
 
 try:
-    lock.acquire(True, _thread.TIMEOUT_MAX * 2.0)
-except OverflowError:
-    pass
+    _thread.allocate_lock().acquire(False, 1.0)
+except ValueError as exc:
+    assert str(exc) == "can't specify a timeout for a non-blocking call", exc
 else:
-    raise AssertionError("oversized timeout accepted")
+    raise AssertionError("non-blocking acquire accepted a timeout")
+
+# The fractional tail below the nanosecond bound is still in range.
+assert _thread.allocate_lock().acquire(True, 9223372036.854) is True
 
 print("OK")

--- a/pyre/extra_tests/parity_tests/thread_local_and_lock_acquire.py
+++ b/pyre/extra_tests/parity_tests/thread_local_and_lock_acquire.py
@@ -33,7 +33,8 @@ Pinned contract:
      thread, with the arguments the object was constructed from —
      keywords included,
   2. an initializer that raises propagates out of the attribute access
-     and leaves no dictionary behind,
+     and leaves no dictionary behind — including in the per-thread cache,
+     so the next access from that same thread runs it again,
   3. construction arguments are accepted according to the initializer
      the subtype inherits, not the requested type,
   4. per-thread state is not shared,
@@ -87,6 +88,38 @@ class Failing(_thread._local):
 
 failing = Failing()
 assert run_in_thread(lambda: failing.__dict__) == ("err", "ValueError", "boom")
+
+
+# The discarded dict must be gone from the per-thread cache too.  This
+# initializer assigns an instance attribute before raising, and that assignment
+# is what publishes the dict, so the cache names the very entry the failure
+# path removes.  A cache left behind would answer the second access from the
+# same thread with the half-built dict instead of running `__init__` again.
+class FailingAfterStore(_thread._local):
+    count = 0
+
+    def __init__(self):
+        type(self).count += 1
+        if type(self).count > 1:
+            self.marker = type(self).count
+            raise ValueError("boom")
+
+
+failing_after_store = FailingAfterStore()
+
+
+def probe_twice():
+    seen = []
+    for _ in range(2):
+        try:
+            seen.append(("returned", failing_after_store.marker))
+        except ValueError as exc:
+            seen.append(("raised", str(exc)))
+    return seen
+
+
+assert run_in_thread(probe_twice) == ("ok", [("raised", "boom"), ("raised", "boom")])
+assert FailingAfterStore.count == 3, FailingAfterStore.count
 
 
 # 3. Argument acceptance follows the inherited initializer.

--- a/pyre/extra_tests/parity_tests/thread_local_and_lock_acquire.py
+++ b/pyre/extra_tests/parity_tests/thread_local_and_lock_acquire.py
@@ -1,0 +1,149 @@
+"""`_thread._local` per-thread initialization and lock acquire arguments.
+
+PyPy `os_local.py:47-64 create_new_dict`:
+
+    def create_new_dict(self, ec):
+        # create a new dict for this thread
+        space = ec.space
+        w_dict = space.newdict(instance=True)
+        self.dicts[ec] = w_dict
+        # call __init__
+        try:
+            w_type = space.type(self)
+            w_init = space.getattr(w_type, space.newtext("__init__"))
+            space.call_obj_args(w_init, self, self.initargs)
+        except:
+            # failed, forget w_dict and propagate the exception
+            del self.dicts[ec]
+            raise
+        # ready
+        self._register_in_ec(ec)
+        return w_dict
+
+and `os_local.py:78-88 descr_local__new__`:
+
+    if __args__.arguments_w or __args__.keyword_names_w:
+        w_parent_init, _ = space.lookup_in_type_where(w_subtype, '__init__')
+        if w_parent_init is space.w_object:
+            raise oefmt(space.w_TypeError,
+                        "Initialization arguments are not supported")
+
+Pinned contract:
+  1. a subclass initializer runs again on the first access from each
+     thread, with the arguments the object was constructed from —
+     keywords included,
+  2. an initializer that raises propagates out of the attribute access
+     and leaves no dictionary behind,
+  3. construction arguments are accepted according to the initializer
+     the subtype inherits, not the requested type,
+  4. per-thread state is not shared,
+  5. `os_lock.py:23-40 parse_acquire_args` rejects a timeout on a
+     non-blocking call, a negative timeout, and one past `TIMEOUT_MAX`.
+"""
+
+import _thread
+
+
+def run_in_thread(fn):
+    done = _thread.allocate_lock()
+    done.acquire()
+    box = []
+
+    def wrapper():
+        try:
+            box.append(("ok", fn()))
+        except BaseException as exc:
+            box.append(("err", type(exc).__name__, str(exc)))
+        finally:
+            done.release()
+
+    _thread.start_new_thread(wrapper, ())
+    done.acquire()
+    done.release()
+    return box[0]
+
+
+# 1. The initializer re-runs per thread with the original arguments.
+class Local(_thread._local):
+    def __init__(self, a, b=0):
+        self.a = a
+        self.b = b
+
+
+obj = Local(1, b=2)
+assert (obj.a, obj.b) == (1, 2)
+assert run_in_thread(lambda: (obj.a, obj.b)) == ("ok", (1, 2))
+
+
+# 2. A failing initializer propagates and discards the half-built dict.
+class Failing(_thread._local):
+    count = 0
+
+    def __init__(self):
+        type(self).count += 1
+        if type(self).count > 1:
+            raise ValueError("boom")
+
+
+failing = Failing()
+assert run_in_thread(lambda: failing.__dict__) == ("err", "ValueError", "boom")
+
+
+# 3. Argument acceptance follows the inherited initializer.
+class NoInit(_thread._local):
+    pass
+
+
+for factory in (_thread._local, NoInit):
+    try:
+        factory(1)
+    except TypeError as exc:
+        assert str(exc) == "Initialization arguments are not supported", exc
+    else:
+        raise AssertionError("%r accepted an argument" % (factory,))
+
+Local(1)
+_thread._local()
+
+
+# 4. Per-thread state is not shared.
+plain = _thread._local()
+plain.x = "main"
+assert run_in_thread(lambda: getattr(plain, "x", "<unset>")) == ("ok", "<unset>")
+assert plain.x == "main"
+
+
+# 5. parse_acquire_args.
+lock = _thread.allocate_lock()
+assert lock.acquire(False) is True
+assert lock.acquire(False) is False
+assert lock.acquire(True, 0.05) is False
+lock.release()
+
+rlock = _thread.RLock()
+assert rlock.acquire() is True
+assert rlock.acquire() is True
+rlock.release()
+rlock.release()
+
+# The wording of these differs between implementations; only the type is part
+# of the interface.
+for call in (
+    lambda: lock.acquire(False, 1.0),
+    lambda: lock.acquire(True, -2.0),
+):
+    try:
+        call()
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("bad acquire arguments accepted")
+
+try:
+    lock.acquire(True, _thread.TIMEOUT_MAX * 2.0)
+except OverflowError:
+    pass
+else:
+    raise AssertionError("oversized timeout accepted")
+
+print("OK")

--- a/pyre/pyre-interpreter/src/_structseq.rs
+++ b/pyre/pyre-interpreter/src/_structseq.rs
@@ -112,7 +112,7 @@ fn structseq_field_get(args: &[PyObjectRef]) -> Result<PyObjectRef, PyError> {
     };
     match resolved {
         Resolved::Extra => {
-            let w_dict = crate::baseobjspace::getdict(inst);
+            let w_dict = crate::baseobjspace::getdict_native(inst);
             if !w_dict.is_null() {
                 if let Some(v) = unsafe { pyre_object::w_dict_getitem_str(w_dict, &name) } {
                     return Ok(v);
@@ -182,7 +182,7 @@ fn structseq_reduce(args: &[PyObjectRef]) -> Result<PyObjectRef, PyError> {
     }
     let body_tuple = pyre_object::w_tuple_new(items);
     // `self.__dict__` carries the named-only extras for reconstruction.
-    let w_dict = crate::baseobjspace::getdict(inst);
+    let w_dict = crate::baseobjspace::getdict_native(inst);
     let dict = if w_dict.is_null() {
         pyre_object::w_dict_new()
     } else {

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -452,7 +452,7 @@ fn exc_blocking_written(obj: PyObjectRef) -> bool {
 /// wins, then derive the construct-time value from `args_w`, and finally
 /// fall back to the `None` class default.
 pub(crate) fn syntax_error_attr(obj: PyObjectRef, name: &str) -> PyObjectRef {
-    let w_dict = getdict_backing(obj);
+    let w_dict = getdict_backing_native(obj);
     if !w_dict.is_null() {
         if let Some(v) = unsafe { pyre_object::w_dict_getitem_str(w_dict, name) } {
             return v;
@@ -4039,7 +4039,7 @@ pub(crate) fn len_slot(obj: PyObjectRef) -> PyResult {
 /// objspace/std/mapdict.py:817-818 MapdictDictSupport.getdict overrides
 /// it to call `_obj_getdict`. pyre dispatches at runtime via the type's
 /// hasdict flag because Rust has no per-class virtual table.
-pub fn getdict(obj: PyObjectRef) -> PyObjectRef {
+pub fn getdict(obj: PyObjectRef) -> PyResult {
     // pypy/module/thread/os_local.py Local.getdict selects the dictionary
     // belonging to the current ExecutionContext before ordinary mapdict
     // dispatch.  The Local object itself owns the mapping and cache.
@@ -4050,33 +4050,33 @@ pub fn getdict(obj: PyObjectRef) -> PyObjectRef {
     if unsafe { crate::is_function(obj) }
         && unsafe { std::ptr::eq((*obj).ob_type, &crate::function::FUNCTION_TYPE) }
     {
-        return unsafe { crate::function::function_getdict(obj) };
+        return Ok(unsafe { crate::function::function_getdict(obj) });
     }
     // function.py:678-681 StaticMethod.getdict — the dictionary is a
     // real field on the descriptor object, not mapdict side storage.
     if unsafe { pyre_object::function::is_staticmethod(obj) } {
-        return unsafe { pyre_object::function::w_staticmethod_getdict(obj) };
+        return Ok(unsafe { pyre_object::function::w_staticmethod_getdict(obj) });
     }
     // function.py:726-729 ClassMethod.getdict.
     if unsafe { pyre_object::function::is_classmethod(obj) } {
-        return unsafe { pyre_object::function::w_classmethod_getdict(obj) };
+        return Ok(unsafe { pyre_object::function::w_classmethod_getdict(obj) });
     }
     // exceptions/interp_exceptions.py:222-225 W_BaseException.getdict
     // override — lazily allocates the instance dict on the typed slot.
     if unsafe { pyre_object::is_exception(obj) } {
-        return unsafe { pyre_object::interp_exceptions::w_exception_getdict(obj) };
+        return Ok(unsafe { pyre_object::interp_exceptions::w_exception_getdict(obj) });
     }
     // bytesobject.py W_BytesObject subclasses inherit mapdict support.  Their
     // dict SPECIAL slot lives on the native bytes payload so the GC sees the
     // `subclass -> dict` edge and can collect cycles through a memoryview.
     if unsafe { pyre_object::bytesobject::is_bytes(obj) } {
         let Some(w_type) = crate::typedef::r#type(obj) else {
-            return PY_NULL;
+            return Ok(PY_NULL);
         };
         if unsafe { pyre_object::w_type_get_hasdict(w_type.as_ptr()) } {
             let existing = unsafe { pyre_object::bytesobject::w_bytes_getdict(obj) };
             if !existing.is_null() {
-                return existing;
+                return Ok(existing);
             }
             let _roots = pyre_object::gc_roots::push_roots();
             let root_base = pyre_object::gc_roots::shadow_stack_len();
@@ -4088,17 +4088,17 @@ pub fn getdict(obj: PyObjectRef) -> PyObjectRef {
                     w_dict,
                 )
             };
-            return w_dict;
+            return Ok(w_dict);
         }
     }
     if unsafe { pyre_object::bytearrayobject::is_bytearray(obj) } {
         let Some(w_type) = crate::typedef::r#type(obj) else {
-            return PY_NULL;
+            return Ok(PY_NULL);
         };
         if unsafe { pyre_object::w_type_get_hasdict(w_type.as_ptr()) } {
             let existing = unsafe { pyre_object::bytearrayobject::w_bytearray_getdict(obj) };
             if !existing.is_null() {
-                return existing;
+                return Ok(existing);
             }
             let _roots = pyre_object::gc_roots::push_roots();
             let root_base = pyre_object::gc_roots::shadow_stack_len();
@@ -4110,18 +4110,18 @@ pub fn getdict(obj: PyObjectRef) -> PyObjectRef {
                     w_dict,
                 )
             };
-            return w_dict;
+            return Ok(w_dict);
         }
     }
     let w_type = match crate::typedef::r#type(obj) {
         Some(tp) => tp,
-        None => return pyre_object::PY_NULL,
+        None => return Ok(pyre_object::PY_NULL),
     };
     if unsafe { pyre_object::w_type_get_hasdict(w_type.as_ptr()) } {
-        crate::objspace::std::mapdict::_obj_getdict(obj)
+        Ok(crate::objspace::std::mapdict::_obj_getdict(obj))
     } else {
         // W_Root.getdict default — return None
-        pyre_object::PY_NULL
+        Ok(pyre_object::PY_NULL)
     }
 }
 
@@ -4133,7 +4133,11 @@ pub fn getdict(obj: PyObjectRef) -> PyObjectRef {
 /// `W_UnicodeObject` itself. Other fixed Rust payloads still fall back to an
 /// exposed instance `__dict__` when their type has one. `None`/`false` means
 /// the receiver has no writable storage.
-pub(crate) fn native_slot_get(obj: PyObjectRef, name: &str, index: u32) -> Option<PyObjectRef> {
+pub(crate) fn native_slot_get(
+    obj: PyObjectRef,
+    name: &str,
+    index: u32,
+) -> Result<Option<PyObjectRef>, PyError> {
     // Python 3.14 permits a native-layout `property` subclass to declare an
     // explicit `__doc__` slot.  PyPy's extended instance layout stores that
     // slot on the object; pyre's equivalent object-resident location is the
@@ -4141,16 +4145,16 @@ pub(crate) fn native_slot_get(obj: PyObjectRef, name: &str, index: u32) -> Optio
     // fallback below (a slots-only subclass deliberately has no dict).
     if name == "__doc__" && unsafe { pyre_object::descriptor::is_property(obj) } {
         let value = unsafe { pyre_object::descriptor::w_property_get_doc(obj) };
-        return (!value.is_null()).then_some(value);
+        return Ok((!value.is_null()).then_some(value));
     }
     if unsafe { pyre_object::is_str(obj) } {
-        return unsafe { pyre_object::unicodeobject::w_str_slot_get(obj, index as usize) };
+        return Ok(unsafe { pyre_object::unicodeobject::w_str_slot_get(obj, index as usize) });
     }
-    let w_dict = getdict(obj);
+    let w_dict = getdict(obj)?;
     if w_dict.is_null() {
-        return None;
+        return Ok(None);
     }
-    unsafe { pyre_object::dictmultiobject::w_dict_getitem_str(w_dict, name) }
+    Ok(unsafe { pyre_object::dictmultiobject::w_dict_getitem_str(w_dict, name) })
 }
 
 pub(crate) fn native_slot_set(
@@ -4158,40 +4162,40 @@ pub(crate) fn native_slot_set(
     name: &str,
     index: u32,
     value: PyObjectRef,
-) -> bool {
+) -> Result<bool, PyError> {
     if name == "__doc__" && unsafe { pyre_object::descriptor::is_property(obj) } {
         unsafe { pyre_object::descriptor::w_property_set_doc(obj, value) };
-        return true;
+        return Ok(true);
     }
     if unsafe { pyre_object::is_str(obj) } {
         unsafe { pyre_object::unicodeobject::w_str_slot_set(obj, index as usize, value) };
-        return true;
+        return Ok(true);
     }
-    let w_dict = getdict(obj);
+    let w_dict = getdict(obj)?;
     if w_dict.is_null() {
-        return false;
+        return Ok(false);
     }
     unsafe { pyre_object::dictmultiobject::w_dict_setitem_str(w_dict, name, value) };
-    true
+    Ok(true)
 }
 
-pub(crate) fn native_slot_del(obj: PyObjectRef, name: &str, index: u32) -> bool {
+pub(crate) fn native_slot_del(obj: PyObjectRef, name: &str, index: u32) -> Result<bool, PyError> {
     if name == "__doc__" && unsafe { pyre_object::descriptor::is_property(obj) } {
         let value = unsafe { pyre_object::descriptor::w_property_get_doc(obj) };
         if value.is_null() {
-            return false;
+            return Ok(false);
         }
         unsafe { pyre_object::descriptor::w_property_set_doc(obj, pyre_object::PY_NULL) };
-        return true;
+        return Ok(true);
     }
     if unsafe { pyre_object::is_str(obj) } {
-        return unsafe { pyre_object::unicodeobject::w_str_slot_del(obj, index as usize) };
+        return Ok(unsafe { pyre_object::unicodeobject::w_str_slot_del(obj, index as usize) });
     }
-    let w_dict = getdict(obj);
+    let w_dict = getdict(obj)?;
     if w_dict.is_null() {
-        return false;
+        return Ok(false);
     }
-    unsafe { pyre_object::dictmultiobject::w_dict_delitem_str(w_dict, name) }
+    Ok(unsafe { pyre_object::dictmultiobject::w_dict_delitem_str(w_dict, name) })
 }
 
 /// interpreter/baseobjspace.py:70-73 W_Root.setdict(space, w_dict).
@@ -4299,12 +4303,46 @@ pub fn setdict(obj: PyObjectRef, w_dict: PyObjectRef) -> Result<(), PyError> {
 /// backing dict.  Plain dicts, module dicts and mapdict views pass
 /// through unchanged.  The `__dict__` getter keeps returning the
 /// stored object itself (identity), so it reads `getdict` directly.
-fn getdict_backing(obj: PyObjectRef) -> PyObjectRef {
-    let w_dict = getdict(obj);
+fn getdict_backing(obj: PyObjectRef) -> PyResult {
+    let w_dict = getdict(obj)?;
     if w_dict.is_null() {
-        return w_dict;
+        return Ok(w_dict);
     }
-    crate::type_methods::resolve_dict_backing(w_dict)
+    Ok(crate::type_methods::resolve_dict_backing(w_dict))
+}
+
+/// [`getdict`] for a receiver whose layout the caller already knows: a native
+/// payload object (ctypes, socket, mmap, structseq, …) or an exception.
+/// `Local.getdict` is the one override that executes Python — the first
+/// access from a thread runs the subclass initializer (`os_local.py:73
+/// create_new_dict`) — and none of those receivers can be a `_local`, so the
+/// lookup is a plain field or mapdict read.
+pub(crate) fn getdict_native(obj: PyObjectRef) -> PyObjectRef {
+    debug_assert!(
+        !crate::module::thread::is_local(obj),
+        "getdict_native on a _thread._local receiver: its dict lookup can raise",
+    );
+    getdict(obj).unwrap_or(PY_NULL)
+}
+
+/// [`getdict_backing`] under the same restriction as [`getdict_native`].
+fn getdict_backing_native(obj: PyObjectRef) -> PyObjectRef {
+    debug_assert!(
+        !crate::module::thread::is_local(obj),
+        "getdict_backing_native on a _thread._local receiver: its dict lookup can raise",
+    );
+    getdict_backing(obj).unwrap_or(PY_NULL)
+}
+
+/// [`setdictvalue`] under the same restriction as [`getdict_native`]: the
+/// receiver's dictionary is a plain field or mapdict slot, so resolving it
+/// cannot run Python and the store is infallible.
+pub(crate) fn setdictvalue_native(obj: PyObjectRef, name: &str, value: PyObjectRef) -> bool {
+    debug_assert!(
+        !crate::module::thread::is_local(obj),
+        "setdictvalue_native on a _thread._local receiver: its dict lookup can raise",
+    );
+    setdictvalue(obj, name, value).unwrap_or(false)
 }
 
 /// `baseobjspace.py:46-50 W_Root.getdictvalue`.
@@ -4323,7 +4361,7 @@ fn getdict_backing(obj: PyObjectRef) -> PyObjectRef {
 /// key whose hash collides can run a user `__eq__`, and the raw accessor
 /// reports that as an ordinary miss — the attribute would look absent.
 fn getdictvalue(obj: PyObjectRef, name: &str) -> Result<Option<PyObjectRef>, PyError> {
-    let w_dict = getdict_backing(obj);
+    let w_dict = getdict_backing(obj)?;
     if w_dict.is_null() {
         return Ok(None);
     }
@@ -5330,7 +5368,7 @@ pub(crate) unsafe fn object_getattribute_surrogate(
                 }
             }
         }
-        let w_dict = getdict_backing(obj);
+        let w_dict = getdict_backing(obj)?;
         if !w_dict.is_null() {
             if let Some(v) = pyre_object::w_dict_lookup(w_dict, w_name) {
                 if !v.is_null() {
@@ -5447,7 +5485,7 @@ pub(crate) unsafe fn object_setattr_surrogate(
                 return Ok(w_none());
             }
         }
-        let w_dict = getdict(obj);
+        let w_dict = getdict(obj)?;
         if !w_dict.is_null() {
             setitem(w_dict, w_name, value)?;
             return Ok(w_none());
@@ -5529,7 +5567,7 @@ pub(crate) unsafe fn object_delattr_surrogate(
             }
             return Err(attr_error_wtf8(obj, name));
         }
-        let w_dict = getdict_backing(obj);
+        let w_dict = getdict_backing(obj)?;
         if !w_dict.is_null() && pyre_object::w_dict_delitem(w_dict, w_name) {
             return Ok(w_none());
         }
@@ -6897,7 +6935,7 @@ fn object_getattr_miss(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyRe
     // __dict__: use getdict() — only returns a dict for hasdict objects,
     // matching PyPy's descriptor-based __dict__ control.
     if name == "__dict__" {
-        let w_dict = getdict(obj);
+        let w_dict = getdict(obj)?;
         if !w_dict.is_null() {
             return Ok(w_dict);
         }
@@ -6923,7 +6961,7 @@ fn object_getattr_miss(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyRe
     // Check the per-instance W_DictObject here (same API PyPy's
     // `descr__getattribute__` uses at descroperation.py:50). This is the
     // second half of the "hasdict instance dict" protocol.
-    let w_dict = getdict_backing(obj);
+    let w_dict = getdict_backing(obj)?;
     if !w_dict.is_null() {
         // `w_dict` may use MapDictStrategy, whose storage is the backing
         // instance rather than a native r_dict. PyPy calls
@@ -8089,7 +8127,13 @@ pub unsafe fn bound_method_attr_fast_path(
     // from it: the emitted fold carries no dict-shape guard, so a later store
     // of `name` into the dict would not side-exit.  Admitting those receivers
     // means emitting that guard first.
-    if !getdict_backing(w_obj).is_null() {
+    // `Local.getdict` runs app-level code (os_local.py:73), which a fold
+    // precondition must not; such a receiver always carries a dict and is
+    // declined by the check below either way.
+    if crate::module::thread::is_local(w_obj) {
+        return None;
+    }
+    if !getdict_backing_native(w_obj).is_null() {
         return None;
     }
     let w_descr = lookup_in_type(w_type, name)?;
@@ -8801,7 +8845,7 @@ pub(crate) unsafe fn get(
                 obj,
                 pyre_object::w_member_get_name(descr),
                 pyre_object::w_member_get_index(descr),
-            )
+            )?
         };
         // typedef.py:512-516: if w_result is None: raise
         // AttributeError("'%T' object has no attribute '%s'")
@@ -8891,7 +8935,7 @@ unsafe fn set(
         } else {
             // Native-layout subclass instance — slot backed by __dict__.
             let slot_name = pyre_object::w_member_get_name(descr);
-            if !native_slot_set(obj, slot_name, index, value) {
+            if !native_slot_set(obj, slot_name, index, value)? {
                 return Err(crate::PyError::new(
                     crate::PyErrorKind::AttributeError,
                     format!(
@@ -8967,7 +9011,7 @@ unsafe fn delete(descr: PyObjectRef, obj: PyObjectRef) -> Result<(), crate::PyEr
                 obj,
                 pyre_object::w_member_get_name(descr),
                 pyre_object::w_member_get_index(descr),
-            )
+            )?
         };
         if !removed {
             let slot_name = pyre_object::w_member_get_name(descr);
@@ -9620,7 +9664,7 @@ pub fn object_setattr(obj: PyObjectRef, name: &str, value: PyObjectRef) -> PyRes
     // return` — exception extras land in the lazily allocated
     // `W_BaseException.w_dict` (interp_exceptions.py:113, 222-225) via
     // the `getdict` exception arm.
-    if setdictvalue(obj, name, value) {
+    if setdictvalue(obj, name, value)? {
         return Ok(w_none());
     }
     Err(raiseattrerror(obj, name, w_descr))
@@ -9923,10 +9967,14 @@ unsafe fn coerce_to_list_for_args(value: PyObjectRef) -> Result<PyObjectRef, PyE
 ///         return True
 ///     return False
 /// ```
-pub(crate) fn setdictvalue(obj: PyObjectRef, name: &str, value: PyObjectRef) -> bool {
-    let w_dict = getdict_backing(obj);
+pub(crate) fn setdictvalue(
+    obj: PyObjectRef,
+    name: &str,
+    value: PyObjectRef,
+) -> Result<bool, PyError> {
+    let w_dict = getdict_backing(obj)?;
     if w_dict.is_null() {
-        return false;
+        return Ok(false);
     }
     // For a user instance, `getdict` returns the MapDictStrategy view, so this
     // `setitem_str` routes straight to the instance map+storage
@@ -9934,7 +9982,7 @@ pub(crate) fn setdictvalue(obj: PyObjectRef, name: &str, value: PyObjectRef) -> 
     // mapdict.py:849-850). The earlier C1 explicit `instance_node_setdictvalue`
     // dual-write is now subsumed by that routing and removed.
     unsafe { pyre_object::w_dict_setitem_str(w_dict, name, value) };
-    true
+    Ok(true)
 }
 
 /// descroperation.py:63-69 raiseattrerror.
@@ -10148,7 +10196,7 @@ pub fn object_delattr(obj: PyObjectRef, name: &str) -> PyResult {
         return Err(PyError::type_error("args may not be deleted"));
     }
     // Instance/general: remove from the instance dict.
-    let w_dict = getdict_backing(obj);
+    let w_dict = getdict_backing(obj)?;
     if !w_dict.is_null() {
         let removed = unsafe { pyre_object::w_dict_delitem_str(w_dict, name) };
         if removed {

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -4758,6 +4758,7 @@ fn getattr_str_impl(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyResul
             };
             if let Some((func, sname, arity)) = entry {
                 let func_obj = crate::make_builtin_function_with_arity(sname, func, arity);
+                unsafe { crate::typedef::stamp_builtin_owner(func_obj, "range") };
                 return Ok(pyre_object::w_method_new(
                     func_obj,
                     obj,

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -4162,7 +4162,11 @@ pub(crate) fn native_slot_get(
     if w_dict.is_null() {
         return Ok(None);
     }
-    Ok(unsafe { pyre_object::dictmultiobject::w_dict_getitem_str(w_dict, name) })
+    // `finditem_str` rather than the raw layout accessor, for the reason
+    // [`getdictvalue`] documents: a stored non-string key whose hash collides
+    // runs a user `__eq__`, and the raw accessor reports a raising probe as an
+    // ordinary miss, so the slot would read as unset.
+    finditem_str(w_dict, name)
 }
 
 pub(crate) fn native_slot_set(

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -2253,17 +2253,25 @@ pub(crate) fn list_iter_reduce_method(args: &[PyObjectRef]) -> PyResult {
     }
 }
 
+/// `list_iterator.__setstate__(index)` — Python 3.14's specialized list
+/// iterator carries the exhausted state in the cursor itself, so a negative
+/// cursor exhausts the iterator instead of rewinding it to the front the way
+/// the generic sequence iterator does, and an index past the end is clamped to
+/// the length rather than stored verbatim.
 pub(crate) fn list_iter_setstate_method(args: &[PyObjectRef]) -> PyResult {
     let mut index = int_w(args[1])?;
     unsafe {
-        if pyre_object::w_list_iter_seq(args[0]).is_null() {
+        let seq = pyre_object::w_list_iter_seq(args[0]);
+        if seq.is_null() {
             return Ok(w_none());
         }
-        // PyPy `W_AbstractSeqIterObject.descr_setstate` clamps a negative
-        // cursor to zero for every live sequence iterator, including the
-        // specialised list iterator.
         if index < 0 {
-            index = 0;
+            pyre_object::w_list_iter_set_seq(args[0], PY_NULL);
+            return Ok(w_none());
+        }
+        let length = pyre_object::w_list_len(seq) as i64;
+        if index > length {
+            index = length;
         }
         pyre_object::w_list_iter_set_index(args[0], index);
     }
@@ -2346,11 +2354,20 @@ pub(crate) fn list_reverse_iter_reduce_method(args: &[PyObjectRef]) -> PyResult 
     }
 }
 
+/// `list_reverseiterator.__setstate__(index)` — the descending cursor is
+/// clamped to the last valid index, and a negative cursor exhausts the
+/// iterator, which is the state `descr_next` leaves behind once it walks off
+/// the front.
 pub(crate) fn list_reverse_iter_setstate_method(args: &[PyObjectRef]) -> PyResult {
     let mut index = int_w(args[1])?;
     unsafe {
         let seq = pyre_object::w_list_reverse_iter_seq(args[0]);
         if seq.is_null() {
+            return Ok(w_none());
+        }
+        if index < 0 {
+            pyre_object::w_list_reverse_iter_set_index(args[0], -1);
+            pyre_object::w_list_reverse_iter_set_seq(args[0], PY_NULL);
             return Ok(w_none());
         }
         let length = pyre_object::w_list_len(seq) as i64;

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -308,6 +308,14 @@ impl Lock {
     /// is free and take it; otherwise take it only if it is free right now.
     /// Returns whether the lock is now held by the caller.
     pub fn acquire(&self, flag: bool) -> bool {
+        // `rthread.acquire_timed(..., intr_flag=1)` enters the external-call
+        // aroundstate before a potentially blocking native lock wait.  In
+        // free-threaded pyre that transition removes this mutator from the GC
+        // RUNNING census; otherwise an import-lock waiter can prevent an STW
+        // collector from completing while the lock owner is parked by that
+        // same STW.  The non-blocking form must remain a poll and needs no
+        // transition.
+        let _blocked = flag.then(crate::module::thread::before_external_block);
         let mut acquired = self.acquired.lock().unwrap_or_else(|e| e.into_inner());
         if !flag {
             if *acquired {

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -1534,24 +1534,31 @@ pub(crate) fn memoryview_release(args: &[PyObjectRef]) -> Result<PyObjectRef, cr
                     "memoryview: negative export count",
                 ));
             }
-            // `_release_underlying`: read the backing before `set_released`
-            // drops the view box.  A slice / copy (`owns_export == false`)
+            // `_release_underlying`.  A slice / copy (`owns_export == false`)
             // shares the export and must not release it.
             if pyre_object::memoryview::w_memoryview_owns_export(mv) {
                 let backing = pyre_object::memoryview::w_memoryview_backing(mv);
-                // Clear the view before invoking the exporter hook so a
-                // re-entrant release is a no-op.
-                pyre_object::memoryview::w_memoryview_set_released(mv);
+                // Mark the view released before invoking the exporter hook so a
+                // re-entrant release is a no-op, but keep the view box until
+                // the hook returns: it is handed this memoryview and reads the
+                // backing back off it to identify the export it is undoing.
+                pyre_object::memoryview::w_memoryview_mark_released(mv);
                 // An `mmap` mapping keeps its count internally — it exposes no
                 // Python-callable release, so the drop cannot be forged from
                 // user code.  Every other exporter runs `__release_buffer__`.
-                if !release_external_backing(backing) {
-                    if let Some(release_fn) =
-                        crate::baseobjspace::lookup(backing, "__release_buffer__")
-                    {
-                        crate::call::call_function_impl_result(release_fn, &[backing, mv])?;
+                let released = if release_external_backing(backing) {
+                    Ok(())
+                } else {
+                    match crate::baseobjspace::lookup(backing, "__release_buffer__") {
+                        Some(release_fn) => {
+                            crate::call::call_function_impl_result(release_fn, &[backing, mv])
+                                .map(|_| ())
+                        }
+                        None => Ok(()),
                     }
-                }
+                };
+                pyre_object::memoryview::w_memoryview_drop_view(mv);
+                released?;
             } else {
                 pyre_object::memoryview::w_memoryview_set_released(mv);
             }

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -6192,6 +6192,7 @@ fn register_exc_class(name: &'static str, cls: PyObjectRef) -> PyObjectRef {
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
     let canonical = *registry.entry(name).or_insert(cls as usize) as PyObjectRef;
+    crate::typedef::stamp_exception_method_owners(canonical, name);
     if let Some(kind) = pyre_object::interp_exceptions::exc_kind_from_name(name) {
         let by_kind = pyre_object::interp_exceptions::register_exc_class_for_kind(kind, canonical);
         debug_assert_eq!(by_kind, canonical);

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -12459,11 +12459,13 @@ pub(crate) fn call_forwarding_args(
     if !has_real_kwargs(kwargs) {
         return crate::call::call_function_impl_result(callable, positional);
     }
+    // The keyword ABI keeps names byte-ish, so the surrogate-preserving reader
+    // is the one to use here: `w_dict_str_entries` drops a `**{'\udc80': v}`
+    // key outright rather than forwarding it.
     let keyword_args: Vec<(rustpython_wtf8::Wtf8Buf, PyObjectRef)> = unsafe {
-        pyre_object::w_dict_str_entries(kwargs.unwrap())
+        pyre_object::w_dict_str_entries_wtf8(kwargs.unwrap())
             .into_iter()
-            .filter(|(name, _)| name != "__pyre_kw__")
-            .map(|(name, value)| (rustpython_wtf8::Wtf8Buf::from_string(name), value))
+            .filter(|(name, _)| name.as_str() != Ok("__pyre_kw__"))
             .collect()
     };
     crate::eval::CURRENT_FRAME.with(|current| {

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -3222,25 +3222,25 @@ pub(crate) fn split_builtin_kwargs(args: &[PyObjectRef]) -> (&[PyObjectRef], Opt
 /// keyword (any entry other than the `__pyre_kw__` marker).  An empty
 /// `**{}` therefore reports `false`.
 pub(crate) fn has_real_kwargs(kwargs: Option<PyObjectRef>) -> bool {
-    let Some(dict) = kwargs else {
-        return false;
-    };
-    unsafe { pyre_object::w_dict_str_entries(dict) }
-        .iter()
-        .any(|(key, _)| key != "__pyre_kw__")
+    real_kwarg_count(kwargs) > 0
 }
 
 /// Number of real keyword arguments in the kwargs dict from
 /// [`split_builtin_kwargs`] — every entry other than the `__pyre_kw__`
 /// marker.  The clinic-style "takes at most N arguments (M given)" builtins
 /// (`sum`, `round`, `pow`) count positionals plus this against their limit.
+///
+/// Read through the surrogate-preserving iterator, the same one
+/// [`call_forwarding_args`] rebuilds the keywords with: `w_dict_str_entries`
+/// drops a `**{'\udc80': v}` key outright, which would make this report a
+/// keyword-free call and let the keyword be silently discarded.
 pub(crate) fn real_kwarg_count(kwargs: Option<PyObjectRef>) -> usize {
     let Some(dict) = kwargs else {
         return 0;
     };
-    unsafe { pyre_object::w_dict_str_entries(dict) }
+    unsafe { pyre_object::w_dict_str_entries_wtf8(dict) }
         .iter()
-        .filter(|(key, _)| key != "__pyre_kw__")
+        .filter(|(key, _)| key.as_str() != Ok("__pyre_kw__"))
         .count()
 }
 

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -3237,6 +3237,22 @@ pub(crate) fn real_kwarg_count(kwargs: Option<PyObjectRef>) -> usize {
         .count()
 }
 
+/// The real keyword `(name, value)` pairs in the kwargs dict from
+/// [`split_builtin_kwargs`] — every entry other than the `__pyre_kw__`
+/// marker.  A builtin that has to re-issue its own call as a keyword call
+/// (`_thread._local` replays the constructor per thread, `os_local.py:57`)
+/// hands these to `call::call_with_kwargs`.
+pub(crate) fn builtin_kwarg_entries(kwargs: Option<PyObjectRef>) -> Vec<(Wtf8Buf, PyObjectRef)> {
+    let Some(dict) = kwargs else {
+        return Vec::new();
+    };
+    let marker = Wtf8Buf::from_string("__pyre_kw__".to_string());
+    unsafe { pyre_object::w_dict_str_entries_wtf8(dict) }
+        .into_iter()
+        .filter(|(key, _)| *key != marker)
+        .collect()
+}
+
 /// Look up a single keyword argument from the kwargs dict produced by
 /// `split_builtin_kwargs`. Returns `None` when no kwargs dict is present
 /// or the requested key is absent.
@@ -8397,7 +8413,7 @@ unsafe fn classdir_recurse(
 pub(crate) fn object_dir_default(obj: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
     let mut names: Vec<Wtf8Buf> = Vec::new();
     unsafe {
-        let w_dict = crate::baseobjspace::getdict(obj);
+        let w_dict = crate::baseobjspace::getdict(obj)?;
         if !w_dict.is_null() && pyre_object::is_dict(w_dict) {
             for (key, _) in pyre_object::w_dict_items(w_dict) {
                 if pyre_object::is_str(key) {
@@ -10371,9 +10387,9 @@ pub(crate) fn fileio_init(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
     // descriptors.  Our generic instance layout stores the corresponding
     // fields under private mapdict names so descriptor writes cannot be
     // shadowed by user attributes.
-    if !crate::baseobjspace::setdictvalue(self_obj, "__file_public_mode__", w_str_new(binary_mode))
-        || !crate::baseobjspace::setdictvalue(self_obj, "__file_closefd__", w_bool_from(closefd))
-        || !crate::baseobjspace::setdictvalue(self_obj, "__file_closed__", w_bool_from(false))
+    if !crate::baseobjspace::setdictvalue(self_obj, "__file_public_mode__", w_str_new(binary_mode))?
+        || !crate::baseobjspace::setdictvalue(self_obj, "__file_closefd__", w_bool_from(closefd))?
+        || !crate::baseobjspace::setdictvalue(self_obj, "__file_closed__", w_bool_from(false))?
     {
         return Err(crate::PyError::runtime_error(
             "FileIO instance has no state dictionary",
@@ -10386,7 +10402,8 @@ pub(crate) fn fileio_init(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
         .and_then(|fd| crate::host_seam::ops::fstat(fd).ok())
         .map(|st| if st.blksize > 1 { st.blksize } else { 8192 })
         .unwrap_or(8192);
-    if !crate::baseobjspace::setdictvalue(self_obj, "__file_blksize__", w_int_new(blksize as i64)) {
+    if !crate::baseobjspace::setdictvalue(self_obj, "__file_blksize__", w_int_new(blksize as i64))?
+    {
         return Err(crate::PyError::runtime_error(
             "FileIO instance has no state dictionary",
         ));
@@ -10423,7 +10440,7 @@ fn file_is_closed(self_obj: PyObjectRef) -> bool {
 
 fn file_set_closed(self_obj: PyObjectRef, closed: bool) -> Result<(), crate::PyError> {
     if crate::baseobjspace::getattr_str(self_obj, "__file_closed__").is_ok() {
-        if crate::baseobjspace::setdictvalue(self_obj, "__file_closed__", w_bool_from(closed)) {
+        if crate::baseobjspace::setdictvalue(self_obj, "__file_closed__", w_bool_from(closed))? {
             return Ok(());
         }
     }
@@ -10782,7 +10799,7 @@ fn file_set_pos(self_obj: PyObjectRef, pos: usize) {
     // `__setattr__`, `__file_pos__` is not a descriptor), so the write is
     // the infallible instance-dict store `W_Root.setdictvalue`
     // (baseobjspace.py) that `setattr_str` would itself reach.
-    crate::baseobjspace::setdictvalue(self_obj, "__file_pos__", w_int_new(pos as i64));
+    crate::baseobjspace::setdictvalue_native(self_obj, "__file_pos__", w_int_new(pos as i64));
 }
 
 /// The raw file descriptor for an fd-backed file object (`open(fd, ...)`),

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -2548,12 +2548,15 @@ pub fn call_function_impl_result(
         pyre_object::gc_roots::pin_root(arg);
     }
 
-    // rpython/rlib/rstack.py:42 stack_check(): every interpreter call
-    // boundary checks the native stack synchronously, so deep recursion
-    // raises RecursionError instead of letting the OS abort on a
-    // guard-page hit. Also drain any JIT-prologue pending overflow.
+    // A JIT prologue may have published an overflow before entering this
+    // residual dispatcher, so preserve that pending exception.  Do not run a
+    // fresh stack check here: RPython's insert_ll_stackcheck places checks on
+    // recursive graph entries (PyPy marks PyFrame.execute_frame), not in front
+    // of every ObjSpace call.  In particular, CheckSignalAction must still be
+    // able to invoke the non-recursive default_int_handler while the current
+    // Python frame is handling a RecursionError.  Python frame call paths carry
+    // their stack check in funccall_valuestack / the JIT callee prologue.
     crate::stack_check::drain_jit_pending_exception()?;
-    crate::stack_check::stack_check()?;
 
     let callable = pyre_object::gc_roots::shadow_stack_get(root_base);
     let mut rooted_args: Vec<PyObjectRef> = Vec::with_capacity(args.len());

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -1024,6 +1024,11 @@ fn walk_global_prebuilt_roots(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
         // interp_posix.ApplevelForkCallbacks is another object-space cache.
         #[cfg(not(target_arch = "wasm32"))]
         crate::module::posix::interp_posix::walk_fork_callback_roots(&mut forward);
+        // `space.sys.modules` and its authoritative dictionary belong to the
+        // process/interpreter import state.  Keep them in the global
+        // non-stack-root walk so incminimark's end-of-marking rescan sees
+        // modules and bindings installed after the initial root snapshot.
+        crate::importing::walk_process_import_roots(&mut forward);
     }
     if is_minor {
         pyre_object::gc_roots::clear_prebuilt_roots_dirty();
@@ -1548,7 +1553,7 @@ pub fn handle_exception(frame: &mut PyFrame, err: &mut PyError, next_instr: &mut
 /// `EVAL_OVERRIDE.unwrap_or(eval_frame_plain)` fallback (call.rs:328 etc.)
 /// continues to reference it directly.
 pub(crate) fn eval_frame_plain(frame: &mut PyFrame) -> PyResult {
-    eval_frame_plain_with_resume(frame, None, None, None)
+    frame.execute_frame(None, None)
 }
 
 /// pyframe.py:270-299 execute_frame body — enter/call_trace/eval_loop/
@@ -1556,7 +1561,7 @@ pub(crate) fn eval_frame_plain(frame: &mut PyFrame) -> PyResult {
 /// throw() path routes it through handle_operation_error and sets
 /// last_instr = next_instr - 1 before resuming (pyframe.py:273-277).
 pub(crate) fn eval_frame_plain_with_operr(frame: &mut PyFrame, operr: Option<PyError>) -> PyResult {
-    eval_frame_plain_with_resume(frame, None, operr, None)
+    frame.execute_frame(None, operr)
 }
 
 enum FrameResume {

--- a/pyre/pyre-interpreter/src/function.rs
+++ b/pyre/pyre-interpreter/src/function.rs
@@ -2527,15 +2527,11 @@ pub fn funccall_valuestack(
     dropvalues: usize,
     methodcall: bool,
 ) -> PyObjectRef {
-    // rpython/rlib/rstack.py:42 stack_check(): every interpreter call
-    // boundary checks the native stack synchronously, so deep recursion
-    // raises RecursionError instead of letting the OS abort on a
-    // guard-page hit. funccall_valuestack is the bytecode CALL fast
-    // path that bypasses dispatch_callable, so it carries its own
-    // probe. Also drain any JIT-prologue pending overflow.
-    if let Err(e) = crate::stack_check::drain_jit_pending_exception()
-        .and_then(|_| crate::stack_check::stack_check())
-    {
+    // A compiled callee prologue can publish an overflow before control
+    // returns to this dispatcher.  The fresh stack check belongs to the
+    // Python frame entry (`PyFrame.execute_frame.insert_stack_check_here`),
+    // not to every CALL: builtin calls do not create a recursive frame.
+    if let Err(e) = crate::stack_check::drain_jit_pending_exception() {
         crate::call::set_call_error(e);
         return pyre_object::PY_NULL;
     }

--- a/pyre/pyre-interpreter/src/gateway.rs
+++ b/pyre/pyre-interpreter/src/gateway.rs
@@ -727,32 +727,50 @@ pub unsafe fn builtin_code_call(
     unsafe { ((*code).func)(args) }
 }
 
-/// The `_match_signature` wording (argument.py:283-297) for a call whose
-/// positional count does not match the implementation's.  The qualified name
-/// follows `func.qualname`: a method descriptor reports `type.name`, a
-/// module-level builtin its bare name.
+/// The TypeError raised for a call whose positional count does not match the
+/// implementation's.  Python 3.14 words this from the entry point's calling
+/// convention rather than from a signature, so a builtin registered by arity
+/// alone can reproduce it exactly:
 ///
-/// The too-few form omits the `: 'name'` tail upstream appends, because a
-/// builtin registered by arity alone carries no parameter names.
+/// - one argument (`METH_O`) — `range.count() takes exactly one argument (0 given)`
+/// - no arguments (`METH_NOARGS`) — `object.__dir__() takes no arguments (1 given)`
+/// - a fixed count — `insert expected 2 arguments, got 1`
+/// - a slot wrapper — `expected 1 argument, got 0`, with no qualified name,
+///   except the two-argument wrappers (`__setitem__`, `__setattr__`, `__set__`)
+///   which keep the bare method name.
+///
+/// A descriptor's receiver is not part of the reported count, so the declared
+/// arity and the supplied count both drop it.  The qualified name follows
+/// `func.__qualname__`: a method descriptor reports `type.name`, a
+/// module-level builtin its bare name.
 #[cold]
 #[inline(never)]
 fn arity_mismatch(code: &BuiltinCode, expected: usize, given: usize) -> crate::PyError {
-    let qualname = match unsafe { code.owner.as_ref() } {
-        Some(owner) => format!("{}.{}", owner.type_name, code.name),
-        None => code.name.to_string(),
+    let name = code.name;
+    let owner = unsafe { code.owner.as_ref() };
+    let (qualname, wanted, got) = match owner {
+        Some(owner) => (
+            format!("{}.{}", owner.type_name, name),
+            expected.saturating_sub(1),
+            given.saturating_sub(1),
+        ),
+        None => (name.to_string(), expected, given),
     };
-    let message = if given > expected {
-        format!(
-            "{qualname}() takes {expected} positional argument{} but {given} {} given",
-            if expected == 1 { "" } else { "s" },
-            if given == 1 { "was" } else { "were" },
-        )
+    let message = if owner.is_some_and(|owner| is_slot_wrapper(owner.type_name, name)) {
+        if wanted == 2 {
+            format!("{name} expected 2 arguments, got {got}")
+        } else {
+            format!(
+                "expected {wanted} argument{}, got {got}",
+                if wanted == 1 { "" } else { "s" },
+            )
+        }
     } else {
-        let missing = expected - given;
-        format!(
-            "{qualname}() missing {missing} required positional argument{}",
-            if missing == 1 { "" } else { "s" },
-        )
+        match wanted {
+            0 => format!("{qualname}() takes no arguments ({got} given)"),
+            1 => format!("{qualname}() takes exactly one argument ({got} given)"),
+            _ => format!("{name} expected {wanted} arguments, got {got}"),
+        }
     };
     crate::PyError::type_error(message)
 }

--- a/pyre/pyre-interpreter/src/gateway.rs
+++ b/pyre/pyre-interpreter/src/gateway.rs
@@ -510,8 +510,11 @@ pub type BuiltinCodeFn = fn(&[PyObjectRef]) -> Result<PyObjectRef, crate::PyErro
 pub struct MethodOwner {
     /// The owning type's name as it appears in the mismatch message.
     pub type_name: &'static str,
-    /// Layout membership, true for instances of subclasses as well.
-    pub is_instance: fn(PyObjectRef) -> bool,
+    /// Layout membership, true for instances of subclasses as well.  `None`
+    /// for a type with no layout test written yet: the receiver still has to
+    /// be *present*, and the owner still names the descriptor in every error
+    /// it raises, but a foreign object of the right shape is not rejected.
+    pub is_instance: Option<fn(PyObjectRef) -> bool>,
 }
 
 /// A built-in function object.
@@ -700,7 +703,8 @@ pub unsafe fn builtin_code_call(
     let owner = unsafe { (*code).owner };
     if !owner.is_null() {
         let owner = unsafe { &*owner };
-        let accepted = matches!(args.first(), Some(&receiver) if (owner.is_instance)(receiver));
+        let accepted = matches!(args.first(), Some(&receiver)
+            if owner.is_instance.is_none_or(|is_instance| is_instance(receiver)));
         if !accepted {
             return Err(receiver_mismatch(owner, unsafe { (*code).name }, args));
         }

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -1554,6 +1554,20 @@ pub(crate) unsafe fn walk_import_roots_area(
     visitor: &mut dyn FnMut(&mut PyObjectRef),
 ) {
     let area = unsafe { &*(data as *const ImportRootArea) };
+    let argv_pending = unsafe { &*area.argv_pending };
+    let mut argv = argv_pending.get();
+    if !argv.is_null() {
+        visitor(&mut argv);
+        argv_pending.set(argv);
+    }
+}
+
+/// Walk the import state owned by PyPy's process/interpreter object space.
+///
+/// Unlike `SYS_ARGV_PENDING`, these slots are not thread-local.  Keeping this
+/// walk separate lets the collector's `collect_nonstack_roots` parity rescan
+/// them exactly once at the end of incremental marking.
+pub(crate) unsafe fn walk_process_import_roots(visitor: &mut dyn FnMut(&mut PyObjectRef)) {
     // `space.sys.modules` is process-owned in PyPy.  STW has quiesced every
     // mutator, so the process-global cache cannot be semantically mutated
     // while this walk holds its native lock.
@@ -1573,12 +1587,6 @@ pub(crate) unsafe fn walk_import_roots_area(
     if !dict.is_null() {
         visitor(&mut dict);
         SYS_MODULES_DICT.store(dict as usize, Ordering::Release);
-    }
-    let argv_pending = unsafe { &*area.argv_pending };
-    let mut argv = argv_pending.get();
-    if !argv.is_null() {
-        visitor(&mut argv);
-        argv_pending.set(argv);
     }
 }
 

--- a/pyre/pyre-interpreter/src/module/_ctypes/cdata.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/cdata.rs
@@ -122,7 +122,7 @@ pub(super) fn cdata_in_dll(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::P
 }
 
 fn cdata_objects_get(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    let d = crate::baseobjspace::getdict(args[1]);
+    let d = crate::baseobjspace::getdict_native(args[1]);
     Ok(if d.is_null() {
         pyre_object::w_none()
     } else {
@@ -132,7 +132,7 @@ fn cdata_objects_get(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
 }
 
 fn cdata_base_get(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    let d = crate::baseobjspace::getdict(args[1]);
+    let d = crate::baseobjspace::getdict_native(args[1]);
     Ok(if d.is_null() {
         pyre_object::w_none()
     } else {
@@ -391,7 +391,7 @@ pub(super) fn new_simplecdata_obj(
             pyre_object::w_bytearray_data_mut(ba)[..n].copy_from_slice(&bytes[..n]);
         }
         if matches!(tc, "z" | "Z" | "O") {
-            let d = crate::baseobjspace::getdict(obj);
+            let d = crate::baseobjspace::getdict_native(obj);
             unsafe { pyre_object::w_dict_setitem_str(d, OBJECTS_KEY, v) };
         }
     }
@@ -405,7 +405,7 @@ pub(super) fn new_cdata_obj_from_bytes(
 ) -> Result<PyObjectRef, crate::PyError> {
     let ba = pyre_object::w_bytearray_new(size);
     let obj = pyre_object::w_instance_new(cls);
-    let d = crate::baseobjspace::getdict(obj);
+    let d = crate::baseobjspace::getdict_native(obj);
     if d.is_null() {
         return Err(crate::PyError::type_error(
             "ctypes instance has no instance dict",
@@ -472,7 +472,7 @@ fn value_setter(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     }
     cdata_write(obj, 0, &bytes);
     if matches!(tc.as_str(), "z" | "Z" | "O") {
-        let d = crate::baseobjspace::getdict(obj);
+        let d = crate::baseobjspace::getdict_native(obj);
         unsafe { pyre_object::w_dict_setitem_str(d, OBJECTS_KEY, value) };
     }
     Ok(pyre_object::w_none())
@@ -482,7 +482,7 @@ fn value_setter(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
 
 /// Read a `usize`-valued reserved key off the instance dict.
 fn dict_usize(obj: PyObjectRef, key: &str) -> Option<usize> {
-    let d = crate::baseobjspace::getdict(obj);
+    let d = crate::baseobjspace::getdict_native(obj);
     if d.is_null() {
         return None;
     }
@@ -511,7 +511,7 @@ fn baddr(obj: PyObjectRef) -> Option<usize> {
 
 /// The backing `bytearray` stored under `"_b_"` (the root's, for a sub-view).
 pub(super) fn cdata_buffer(obj: PyObjectRef) -> Option<PyObjectRef> {
-    let d = crate::baseobjspace::getdict(obj);
+    let d = crate::baseobjspace::getdict_native(obj);
     if d.is_null() {
         return None;
     }
@@ -703,7 +703,7 @@ fn struct_pep3118_format(cls: PyObjectRef) -> String {
         let Some(descr) = (unsafe { crate::baseobjspace::lookup_in_type(cls, name) }) else {
             continue;
         };
-        let dd = crate::baseobjspace::getdict(descr);
+        let dd = crate::baseobjspace::getdict_native(descr);
         let integer = |key: &str| {
             unsafe { pyre_object::w_dict_getitem_str(dd, key) }
                 .filter(|value| unsafe { pyre_object::is_int(*value) })
@@ -779,7 +779,7 @@ pub(super) fn cdata_write(obj: PyObjectRef, off: usize, bytes: &[u8]) {
 /// Whether `obj` owns its buffer (a root object, not a sub-view or external
 /// view) — the precondition for `resize`.
 pub(super) fn owns_buffer(obj: PyObjectRef) -> bool {
-    let d = crate::baseobjspace::getdict(obj);
+    let d = crate::baseobjspace::getdict_native(obj);
     if d.is_null() {
         return false;
     }
@@ -803,7 +803,7 @@ pub(super) fn make_subview(
     size: usize,
 ) -> PyObjectRef {
     let inst = pyre_object::w_instance_new(proto);
-    let d = crate::baseobjspace::getdict(inst);
+    let d = crate::baseobjspace::getdict_native(inst);
     if d.is_null() {
         return inst;
     }
@@ -836,7 +836,7 @@ pub(super) fn make_indexed_subview(
     index: usize,
 ) -> PyObjectRef {
     let view = make_subview(proto, parent, field_offset, size);
-    let d = crate::baseobjspace::getdict(view);
+    let d = crate::baseobjspace::getdict_native(view);
     if !d.is_null() {
         unsafe {
             pyre_object::w_dict_setitem_str(d, BINDEX_KEY, pyre_object::w_int_new(index as i64));
@@ -856,7 +856,7 @@ pub(super) fn make_at_address(
     base: PyObjectRef,
 ) -> PyObjectRef {
     let inst = pyre_object::w_instance_new(proto);
-    let d = crate::baseobjspace::getdict(inst);
+    let d = crate::baseobjspace::getdict_native(inst);
     if !d.is_null() {
         unsafe {
             pyre_object::w_dict_setitem_str(d, BADDR_KEY, pyre_object::w_int_new(address as i64));
@@ -882,7 +882,7 @@ pub(super) fn keep_ref(anchor: PyObjectRef, key: &str, obj: PyObjectRef) {
     let mut composite_key = key.to_string();
     loop {
         root = pyre_object::gc_roots::shadow_stack_get(root_slot);
-        let d = crate::baseobjspace::getdict(root);
+        let d = crate::baseobjspace::getdict_native(root);
         if d.is_null() {
             return;
         }
@@ -902,7 +902,7 @@ pub(super) fn keep_ref(anchor: PyObjectRef, key: &str, obj: PyObjectRef) {
         }
     }
     root = pyre_object::gc_roots::shadow_stack_get(root_slot);
-    let mut d = crate::baseobjspace::getdict(root);
+    let mut d = crate::baseobjspace::getdict_native(root);
     let objs = match unsafe { pyre_object::w_dict_getitem_str(d, OBJECTS_KEY) } {
         Some(o) if !o.is_null() && unsafe { pyre_object::is_dict(o) } => o,
         Some(previous) if !previous.is_null() && !unsafe { pyre_object::is_none(previous) } => {
@@ -911,14 +911,14 @@ pub(super) fn keep_ref(anchor: PyObjectRef, key: &str, obj: PyObjectRef) {
             }
             let nd = pyre_object::w_dict_new();
             root = pyre_object::gc_roots::shadow_stack_get(root_slot);
-            d = crate::baseobjspace::getdict(root);
+            d = crate::baseobjspace::getdict_native(root);
             unsafe { pyre_object::w_dict_setitem_str(d, OBJECTS_KEY, nd) };
             nd
         }
         _ => {
             let nd = pyre_object::w_dict_new();
             root = pyre_object::gc_roots::shadow_stack_get(root_slot);
-            d = crate::baseobjspace::getdict(root);
+            d = crate::baseobjspace::getdict_native(root);
             unsafe { pyre_object::w_dict_setitem_str(d, OBJECTS_KEY, nd) };
             nd
         }
@@ -947,7 +947,7 @@ pub(super) fn objects_for_keep(value: PyObjectRef) -> PyObjectRef {
     let _roots = pyre_object::gc_roots::push_roots();
     pyre_object::gc_roots::pin_root(value);
     let value_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-    let mut d = crate::baseobjspace::getdict(value);
+    let mut d = crate::baseobjspace::getdict_native(value);
     if d.is_null() {
         return value;
     }
@@ -956,7 +956,7 @@ pub(super) fn objects_for_keep(value: PyObjectRef) -> PyObjectRef {
         _ => {
             let objects = pyre_object::w_dict_new();
             let value = pyre_object::gc_roots::shadow_stack_get(value_slot);
-            d = crate::baseobjspace::getdict(value);
+            d = crate::baseobjspace::getdict_native(value);
             unsafe { pyre_object::w_dict_setitem_str(d, OBJECTS_KEY, objects) };
             objects
         }
@@ -977,7 +977,7 @@ fn keep_alive(anchor: PyObjectRef, key: &str, obj: PyObjectRef) {
     let mut root_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     loop {
         root = pyre_object::gc_roots::shadow_stack_get(root_slot);
-        let d = crate::baseobjspace::getdict(root);
+        let d = crate::baseobjspace::getdict_native(root);
         if d.is_null() {
             return;
         }
@@ -992,7 +992,7 @@ fn keep_alive(anchor: PyObjectRef, key: &str, obj: PyObjectRef) {
     }
     root = pyre_object::gc_roots::shadow_stack_get(root_slot);
     let obj = pyre_object::gc_roots::shadow_stack_get(obj_slot);
-    let d = crate::baseobjspace::getdict(root);
+    let d = crate::baseobjspace::getdict_native(root);
     if !d.is_null() {
         unsafe { pyre_object::w_dict_setitem_str(d, &format!("_keep_{key}"), obj) };
     }
@@ -1015,7 +1015,7 @@ pub(super) fn share_objects_for_cast(result: PyObjectRef, source: PyObjectRef) {
     let mut root_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     loop {
         root = pyre_object::gc_roots::shadow_stack_get(root_slot);
-        let d = crate::baseobjspace::getdict(root);
+        let d = crate::baseobjspace::getdict_native(root);
         if d.is_null() {
             return;
         }
@@ -1029,7 +1029,7 @@ pub(super) fn share_objects_for_cast(result: PyObjectRef, source: PyObjectRef) {
         }
     }
     root = pyre_object::gc_roots::shadow_stack_get(root_slot);
-    let mut source_dict = crate::baseobjspace::getdict(root);
+    let mut source_dict = crate::baseobjspace::getdict_native(root);
     if source_dict.is_null() {
         return;
     }
@@ -1040,7 +1040,7 @@ pub(super) fn share_objects_for_cast(result: PyObjectRef, source: PyObjectRef) {
             && !unsafe { pyre_object::is_dict(objects) }
     }) {
         let result = pyre_object::gc_roots::shadow_stack_get(result_slot);
-        let result_dict = crate::baseobjspace::getdict(result);
+        let result_dict = crate::baseobjspace::getdict_native(result);
         if !result_dict.is_null() {
             unsafe { pyre_object::w_dict_setitem_str(result_dict, OBJECTS_KEY, objects) };
         }
@@ -1051,7 +1051,7 @@ pub(super) fn share_objects_for_cast(result: PyObjectRef, source: PyObjectRef) {
         _ => {
             let objects = pyre_object::w_dict_new();
             root = pyre_object::gc_roots::shadow_stack_get(root_slot);
-            source_dict = crate::baseobjspace::getdict(root);
+            source_dict = crate::baseobjspace::getdict_native(root);
             unsafe { pyre_object::w_dict_setitem_str(source_dict, OBJECTS_KEY, objects) };
             objects
         }
@@ -1068,7 +1068,7 @@ pub(super) fn share_objects_for_cast(result: PyObjectRef, source: PyObjectRef) {
     unsafe { pyre_object::w_dict_store(objects, identity_key, source) };
     let result = pyre_object::gc_roots::shadow_stack_get(result_slot);
     let objects = pyre_object::gc_roots::shadow_stack_get(objects_slot);
-    let result_dict = crate::baseobjspace::getdict(result);
+    let result_dict = crate::baseobjspace::getdict_native(result);
     if !result_dict.is_null() {
         unsafe { pyre_object::w_dict_setitem_str(result_dict, OBJECTS_KEY, objects) };
     }

--- a/pyre/pyre-interpreter/src/module/_ctypes/funcptr.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/funcptr.rs
@@ -122,7 +122,7 @@ fn cfuncptr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         }
     };
     let obj = cdata::new_cdata_obj_from_bytes(cls, host_ctypes::pointer_size(), &[])?;
-    let d = crate::baseobjspace::getdict(obj);
+    let d = crate::baseobjspace::getdict_native(obj);
     if d.is_null() {
         return Err(crate::PyError::type_error(
             "CFuncPtr instance has no instance dict",
@@ -179,7 +179,7 @@ fn resolve_from_tuple(t: PyObjectRef) -> Result<usize, crate::PyError> {
 // ── restype / argtypes descriptors ────────────────────────────────────
 
 fn instance_get(obj: PyObjectRef, key: &str) -> Option<PyObjectRef> {
-    let d = crate::baseobjspace::getdict(obj);
+    let d = crate::baseobjspace::getdict_native(obj);
     if d.is_null() {
         return None;
     }
@@ -187,7 +187,7 @@ fn instance_get(obj: PyObjectRef, key: &str) -> Option<PyObjectRef> {
 }
 
 fn instance_set(obj: PyObjectRef, key: &str, value: PyObjectRef) {
-    let d = crate::baseobjspace::getdict(obj);
+    let d = crate::baseobjspace::getdict_native(obj);
     if !d.is_null() {
         unsafe { pyre_object::w_dict_setitem_str(d, key, value) };
     }
@@ -295,7 +295,7 @@ fn resolve_restype(obj: PyObjectRef) -> Result<Ret, crate::PyError> {
 /// Wrap a returned pointer value `p` in a fresh instance of pointer type `rt`.
 fn wrap_pointer_result(rt: PyObjectRef, p: usize) -> Result<PyObjectRef, crate::PyError> {
     let obj = pyre_object::w_instance_new(rt);
-    let d = crate::baseobjspace::getdict(obj);
+    let d = crate::baseobjspace::getdict_native(obj);
     if d.is_null() {
         return Err(crate::PyError::type_error("pointer instance has no dict"));
     }
@@ -934,7 +934,7 @@ fn make_aggregate_instance(ty: PyObjectRef, bytes: &[u8]) -> Result<PyObjectRef,
         pyre_object::w_bytearray_data_mut(ba)[..n].copy_from_slice(&bytes[..n]);
     }
     let obj = pyre_object::w_instance_new(ty);
-    let d = crate::baseobjspace::getdict(obj);
+    let d = crate::baseobjspace::getdict_native(obj);
     if d.is_null() {
         return Err(crate::PyError::type_error(
             "aggregate instance has no instance dict",

--- a/pyre/pyre-interpreter/src/module/_ctypes/interp_ctypes.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/interp_ctypes.rs
@@ -528,7 +528,7 @@ fn carg_type() -> pyre_object::PyObjectRef {
                 ns,
                 "__repr__",
                 crate::make_builtin_function("__repr__", |args| {
-                    let d = crate::baseobjspace::getdict(args[0]);
+                    let d = crate::baseobjspace::getdict_native(args[0]);
                     let value = unsafe { pyre_object::w_dict_getitem_str(d, "_obj") }
                         .unwrap_or_else(pyre_object::w_none);
                     let rendered = unsafe { crate::display::py_repr(value) }?;
@@ -545,7 +545,7 @@ fn carg_type() -> pyre_object::PyObjectRef {
 #[cfg(all(unix, feature = "host_env"))]
 pub(super) fn make_carg(addr: usize, obj: pyre_object::PyObjectRef) -> pyre_object::PyObjectRef {
     let carg = pyre_object::w_instance_new(carg_type());
-    let d = crate::baseobjspace::getdict(carg);
+    let d = crate::baseobjspace::getdict_native(carg);
     if !d.is_null() {
         unsafe {
             pyre_object::w_dict_setitem_str(d, "_ptr", pyre_object::w_int_new(addr as i64));
@@ -564,7 +564,7 @@ pub(super) fn is_carg(obj: pyre_object::PyObjectRef) -> bool {
 /// The address a `byref()` carrier points at.
 #[cfg(all(unix, feature = "host_env"))]
 pub(super) fn carg_ptr(carg: pyre_object::PyObjectRef) -> usize {
-    let d = crate::baseobjspace::getdict(carg);
+    let d = crate::baseobjspace::getdict_native(carg);
     if d.is_null() {
         return 0;
     }

--- a/pyre/pyre-interpreter/src/module/_ctypes/metaclass.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/metaclass.rs
@@ -591,12 +591,13 @@ fn promote_anonymous_fields(
                 cf_usize(child, "byte_size"),
                 cf_usize(child, "index"),
             );
-            let d = crate::baseobjspace::getdict(promoted);
+            let d = crate::baseobjspace::getdict_native(promoted);
             unsafe {
                 for key in ["size", "bit_size", "bit_offset", "is_bitfield"] {
-                    if let Some(value) =
-                        pyre_object::w_dict_getitem_str(crate::baseobjspace::getdict(child), key)
-                    {
+                    if let Some(value) = pyre_object::w_dict_getitem_str(
+                        crate::baseobjspace::getdict_native(child),
+                        key,
+                    ) {
                         pyre_object::w_dict_setitem_str(d, key, value);
                     }
                 }
@@ -900,7 +901,7 @@ fn process_fields(cls: PyObjectRef, fields: PyObjectRef, is_union: bool) -> PyRe
         let (field_offset, size, align, bitfield) = pending[index];
         mark_type_final(entry.ty, size, align);
         let cf = cfield_new(&entry.name, entry.ty, field_offset, size, index);
-        let d = crate::baseobjspace::getdict(cf);
+        let d = crate::baseobjspace::getdict_native(cf);
         if let Some((bits, bit_offset)) = bitfield {
             unsafe {
                 pyre_object::w_dict_setitem_str(
@@ -1061,7 +1062,7 @@ fn cfield_new(
     index: usize,
 ) -> PyObjectRef {
     let inst = pyre_object::w_instance_new(cfield_type());
-    let d = crate::baseobjspace::getdict(inst);
+    let d = crate::baseobjspace::getdict_native(inst);
     unsafe {
         pyre_object::w_dict_setitem_str(d, "name", pyre_object::w_str_new(name));
         pyre_object::w_dict_setitem_str(d, "proto", proto);
@@ -1085,7 +1086,7 @@ fn cfield_new(
 }
 
 fn cf_obj(cfield: PyObjectRef, key: &str) -> PyObjectRef {
-    unsafe { pyre_object::w_dict_getitem_str(crate::baseobjspace::getdict(cfield), key) }
+    unsafe { pyre_object::w_dict_getitem_str(crate::baseobjspace::getdict_native(cfield), key) }
         .unwrap_or(pyre_object::PY_NULL)
 }
 
@@ -1482,7 +1483,7 @@ fn cfield_new_internal(args: &[PyObjectRef]) -> PyResult {
                 byte_size * 8,
             )));
         }
-        let d = crate::baseobjspace::getdict(field);
+        let d = crate::baseobjspace::getdict_native(field);
         unsafe {
             pyre_object::w_dict_setitem_str(d, "bit_size", pyre_object::w_int_new(bits));
             pyre_object::w_dict_setitem_str(d, "bit_offset", pyre_object::w_int_new(bit_offset));
@@ -1509,7 +1510,7 @@ fn structure_new(args: &[PyObjectRef]) -> PyResult {
     let size = stginfo::stginfo_size(info);
     stginfo::stginfo_mark_final(info);
     let obj = pyre_object::w_instance_new(cls);
-    let d = crate::baseobjspace::getdict(obj);
+    let d = crate::baseobjspace::getdict_native(obj);
     if d.is_null() {
         return Err(crate::PyError::type_error("ctypes instance has no dict"));
     }
@@ -1755,7 +1756,7 @@ fn array_new(args: &[PyObjectRef]) -> PyResult {
         .ok_or_else(|| crate::PyError::type_error("abstract class"))?;
     let size = stginfo::stginfo_size(info);
     let obj = pyre_object::w_instance_new(cls);
-    let d = crate::baseobjspace::getdict(obj);
+    let d = crate::baseobjspace::getdict_native(obj);
     if d.is_null() {
         return Err(crate::PyError::type_error("ctypes instance has no dict"));
     }
@@ -2183,7 +2184,7 @@ fn pointer_new(args: &[PyObjectRef]) -> PyResult {
         ));
     }
     let obj = pyre_object::w_instance_new(cls);
-    let d = crate::baseobjspace::getdict(obj);
+    let d = crate::baseobjspace::getdict_native(obj);
     if d.is_null() {
         return Err(crate::PyError::type_error("ctypes instance has no dict"));
     }

--- a/pyre/pyre-interpreter/src/module/_ctypes/stginfo.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/stginfo.rs
@@ -74,7 +74,7 @@ impl StgInfoData {
 }
 
 fn dict_of(info: PyObjectRef) -> PyObjectRef {
-    crate::baseobjspace::getdict(info)
+    crate::baseobjspace::getdict_native(info)
 }
 
 fn set_int(info: PyObjectRef, key: &str, v: i64) {

--- a/pyre/pyre-interpreter/src/module/_io/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_io/mod.rs
@@ -55,7 +55,7 @@ fn iobase_internal_closed(obj: PyObjectRef) -> bool {
 }
 
 fn iobase_set_internal_closed(obj: PyObjectRef, closed: bool) -> Result<(), crate::PyError> {
-    if crate::baseobjspace::setdictvalue(obj, "__iobase_closed__", w_bool_from(closed)) {
+    if crate::baseobjspace::setdictvalue(obj, "__iobase_closed__", w_bool_from(closed))? {
         Ok(())
     } else {
         Err(crate::PyError::runtime_error(

--- a/pyre/pyre-interpreter/src/module/_io/textio.rs
+++ b/pyre/pyre-interpreter/src/module/_io/textio.rs
@@ -829,7 +829,7 @@ impl W_TextIOWrapper {
             encoding_start_of_stream: false,
             ..Self::default()
         });
-        crate::baseobjspace::setdictvalue(obj, "name", w_str_new(name));
+        crate::baseobjspace::setdictvalue_native(obj, "name", w_str_new(name));
         obj
     }
 }

--- a/pyre/pyre-interpreter/src/module/_multiprocessing/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_multiprocessing/mod.rs
@@ -12,7 +12,7 @@ use pyre_object::*;
 
 #[cfg(all(unix, feature = "host_env"))]
 fn semlock_get_handle(obj: PyObjectRef) -> *mut libc::sem_t {
-    let d = crate::baseobjspace::getdict(obj);
+    let d = crate::baseobjspace::getdict_native(obj);
     if d.is_null() {
         return core::ptr::null_mut();
     }
@@ -172,7 +172,7 @@ crate::py_module! {
                     // calls sem_close on instance death.
                     core::mem::forget(handle);
                     let obj = w_instance_new(type_object());
-                    let d = crate::baseobjspace::getdict(obj);
+                    let d = crate::baseobjspace::getdict_native(obj);
                     if !d.is_null() {
                         unsafe {
                             w_dict_setitem_str(

--- a/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
+++ b/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
@@ -1872,7 +1872,7 @@ fn socket_io_err(e: std::io::Error) -> crate::PyError {
 
 #[cfg(unix)]
 fn socket_get_attr_i64(obj: pyre_object::PyObjectRef, key: &str) -> i64 {
-    let d = crate::baseobjspace::getdict(obj);
+    let d = crate::baseobjspace::getdict_native(obj);
     if d.is_null() {
         return -1;
     }
@@ -1886,7 +1886,7 @@ fn socket_get_attr_i64(obj: pyre_object::PyObjectRef, key: &str) -> i64 {
 
 #[cfg(unix)]
 fn socket_set_attr(obj: pyre_object::PyObjectRef, key: &str, v: pyre_object::PyObjectRef) {
-    let d = crate::baseobjspace::getdict(obj);
+    let d = crate::baseobjspace::getdict_native(obj);
     if d.is_null() {
         return;
     }
@@ -2477,7 +2477,7 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
             crate::make_builtin_function_with_arity(
                 "timeout",
                 |args| {
-                    let d = crate::baseobjspace::getdict(args[1]);
+                    let d = crate::baseobjspace::getdict_native(args[1]);
                     if d.is_null() {
                         return Ok(pyre_object::w_none());
                     }
@@ -3910,7 +3910,7 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
             "gettimeout",
             |args| {
                 let obj = args.first().copied().unwrap_or(pyre_object::PY_NULL);
-                let d = crate::baseobjspace::getdict(obj);
+                let d = crate::baseobjspace::getdict_native(obj);
                 if d.is_null() {
                     return Ok(pyre_object::w_none());
                 }

--- a/pyre/pyre-interpreter/src/module/_weakref/interp__weakref.rs
+++ b/pyre/pyre-interpreter/src/module/_weakref/interp__weakref.rs
@@ -47,7 +47,8 @@ fn read_attr(obj: PyObjectRef, name: &str) -> PyObjectRef {
     let _roots = pyre_object::gc_roots::push_roots();
     let root_base = pyre_object::gc_roots::shadow_stack_len();
     pyre_object::gc_roots::pin_root(obj);
-    let w_dict = crate::baseobjspace::getdict(pyre_object::gc_roots::shadow_stack_get(root_base));
+    let w_dict =
+        crate::baseobjspace::getdict_native(pyre_object::gc_roots::shadow_stack_get(root_base));
     if w_dict.is_null() {
         return PY_NULL;
     }
@@ -72,7 +73,8 @@ fn write_attr(obj: PyObjectRef, name: &str, value: PyObjectRef) {
     let root_base = pyre_object::gc_roots::shadow_stack_len();
     pyre_object::gc_roots::pin_root(obj);
     pyre_object::gc_roots::pin_root(value);
-    let w_dict = crate::baseobjspace::getdict(pyre_object::gc_roots::shadow_stack_get(root_base));
+    let w_dict =
+        crate::baseobjspace::getdict_native(pyre_object::gc_roots::shadow_stack_get(root_base));
     if !w_dict.is_null() {
         pyre_object::gc_roots::pin_root(w_dict);
         unsafe {

--- a/pyre/pyre-interpreter/src/module/mmap/interp_mmap.rs
+++ b/pyre/pyre-interpreter/src/module/mmap/interp_mmap.rs
@@ -102,7 +102,7 @@ fn mmap_type() -> pyre_object::PyObjectRef {
 
 #[cfg(unix)]
 fn mmap_get_attr_i64(obj: pyre_object::PyObjectRef, key: &str) -> i64 {
-    let d = crate::baseobjspace::getdict(obj);
+    let d = crate::baseobjspace::getdict_native(obj);
     if d.is_null() {
         return 0;
     }
@@ -116,7 +116,7 @@ fn mmap_get_attr_i64(obj: pyre_object::PyObjectRef, key: &str) -> i64 {
 
 #[cfg(unix)]
 fn mmap_set_attr(obj: pyre_object::PyObjectRef, key: &str, v: pyre_object::PyObjectRef) {
-    let d = crate::baseobjspace::getdict(obj);
+    let d = crate::baseobjspace::getdict_native(obj);
     if d.is_null() {
         return;
     }
@@ -190,7 +190,7 @@ pub(crate) fn mmap_buffer_view(
 
 #[cfg(unix)]
 fn mmap_get_attr_obj(obj: pyre_object::PyObjectRef, key: &str) -> pyre_object::PyObjectRef {
-    let d = crate::baseobjspace::getdict(obj);
+    let d = crate::baseobjspace::getdict_native(obj);
     if d.is_null() {
         return pyre_object::PY_NULL;
     }

--- a/pyre/pyre-interpreter/src/module/pyexpat/mod.rs
+++ b/pyre/pyre-interpreter/src/module/pyexpat/mod.rs
@@ -268,7 +268,7 @@ impl<'a> MiniXmlParser<'a> {
             &[w_str_new(&version), encoding, standalone],
         )?;
         if unsafe { is_int(standalone) && w_int_get_value(standalone) == 0 } {
-            crate::baseobjspace::setdictvalue(
+            crate::baseobjspace::setdictvalue_native(
                 self.parser,
                 "_pyre_not_standalone_pending",
                 w_bool_from(true),
@@ -369,7 +369,7 @@ impl<'a> MiniXmlParser<'a> {
             .unwrap_or(false)
         {
             self.call_not_standalone()?;
-            crate::baseobjspace::setdictvalue(
+            crate::baseobjspace::setdictvalue_native(
                 self.parser,
                 "_pyre_not_standalone_pending",
                 w_bool_from(false),
@@ -765,7 +765,7 @@ impl<'a> MiniXmlParser<'a> {
                 return self.call_handler_raw("CharacterDataHandler", &[w_str_new(text)]);
             }
             self.char_buffer.push_str(text);
-            crate::baseobjspace::setdictvalue(
+            crate::baseobjspace::setdictvalue_native(
                 self.parser,
                 "buffer_used",
                 w_int_new(self.char_buffer.len() as i64),
@@ -803,7 +803,7 @@ impl<'a> MiniXmlParser<'a> {
             return Ok(());
         }
         let text = std::mem::take(&mut self.char_buffer);
-        crate::baseobjspace::setdictvalue(self.parser, "buffer_used", w_int_new(0));
+        crate::baseobjspace::setdictvalue_native(self.parser, "buffer_used", w_int_new(0));
         self.call_handler_raw("CharacterDataHandler", &[w_str_new(&text)])
     }
 
@@ -857,17 +857,17 @@ impl<'a> MiniXmlParser<'a> {
 
     fn set_event_position(&mut self, pos: XmlPos) {
         self.suppress_current = pos.index < self.suppress_until;
-        crate::baseobjspace::setdictvalue(
+        crate::baseobjspace::setdictvalue_native(
             self.parser,
             "CurrentLineNumber",
             w_int_new(pos.line as i64),
         );
-        crate::baseobjspace::setdictvalue(
+        crate::baseobjspace::setdictvalue_native(
             self.parser,
             "CurrentColumnNumber",
             w_int_new(pos.col as i64),
         );
-        crate::baseobjspace::setdictvalue(
+        crate::baseobjspace::setdictvalue_native(
             self.parser,
             "CurrentByteIndex",
             w_int_new(pos.index as i64),
@@ -1120,22 +1120,22 @@ impl<'a> MiniXmlParser<'a> {
 
     fn make_error(&self, msg: &str) -> crate::PyError {
         let code = error_code_for_message(msg);
-        crate::baseobjspace::setdictvalue(
+        crate::baseobjspace::setdictvalue_native(
             self.parser,
             "ErrorLineNumber",
             w_int_new(self.pos.line as i64),
         );
-        crate::baseobjspace::setdictvalue(
+        crate::baseobjspace::setdictvalue_native(
             self.parser,
             "ErrorColumnNumber",
             w_int_new(self.pos.col as i64),
         );
-        crate::baseobjspace::setdictvalue(
+        crate::baseobjspace::setdictvalue_native(
             self.parser,
             "ErrorByteIndex",
             w_int_new(self.pos.index as i64),
         );
-        crate::baseobjspace::setdictvalue(self.parser, "ErrorCode", w_int_new(code));
+        crate::baseobjspace::setdictvalue_native(self.parser, "ErrorCode", w_int_new(code));
         pyexpat_error(
             format!("{msg}: line {}, column {}", self.pos.line, self.pos.col),
             code,
@@ -1145,17 +1145,17 @@ impl<'a> MiniXmlParser<'a> {
     }
 
     fn update_position_slots(&self) {
-        crate::baseobjspace::setdictvalue(
+        crate::baseobjspace::setdictvalue_native(
             self.parser,
             "CurrentLineNumber",
             w_int_new(self.pos.line as i64),
         );
-        crate::baseobjspace::setdictvalue(
+        crate::baseobjspace::setdictvalue_native(
             self.parser,
             "CurrentColumnNumber",
             w_int_new(self.pos.col as i64),
         );
-        crate::baseobjspace::setdictvalue(
+        crate::baseobjspace::setdictvalue_native(
             self.parser,
             "CurrentByteIndex",
             w_int_new(self.pos.index as i64),
@@ -1180,7 +1180,11 @@ fn object_to_xml_string(parser: PyObjectRef, obj: PyObjectRef) -> Result<String,
 fn decode_xml_bytes(parser: PyObjectRef, data: &[u8]) -> Result<String, crate::PyError> {
     let enc = declared_or_forced_encoding(parser, data)?;
     let normalized = normalize_encoding(&enc);
-    crate::baseobjspace::setdictvalue(parser, "_pyre_forced_encoding", w_str_new(&normalized));
+    crate::baseobjspace::setdictvalue_native(
+        parser,
+        "_pyre_forced_encoding",
+        w_str_new(&normalized),
+    );
     match normalized.as_str() {
         "utf-8" | "us-ascii" => {
             let data = data.strip_prefix(&[0xef, 0xbb, 0xbf]).unwrap_or(data);
@@ -1344,7 +1348,7 @@ fn parser_pending(parser: PyObjectRef) -> String {
 }
 
 fn set_parser_pending(parser: PyObjectRef, pending: &str) {
-    crate::baseobjspace::setdictvalue(parser, "_pyre_pending_xml", w_str_new(pending));
+    crate::baseobjspace::setdictvalue_native(parser, "_pyre_pending_xml", w_str_new(pending));
 }
 
 fn get_parser_int(parser: PyObjectRef, name: &str, default: i64) -> i64 {
@@ -1359,7 +1363,7 @@ fn get_emit_upto(parser: PyObjectRef) -> usize {
 }
 
 fn set_emit_upto(parser: PyObjectRef, value: usize) {
-    crate::baseobjspace::setdictvalue(parser, "_pyre_emit_upto", w_int_new(value as i64));
+    crate::baseobjspace::setdictvalue_native(parser, "_pyre_emit_upto", w_int_new(value as i64));
 }
 
 fn parse_impl(
@@ -1402,7 +1406,11 @@ fn parse_impl(
         }
     } else {
         set_parser_pending(parser, &input);
-        crate::baseobjspace::setdictvalue(parser, "_pyre_deferred_incomplete", w_bool_from(true));
+        crate::baseobjspace::setdictvalue_native(
+            parser,
+            "_pyre_deferred_incomplete",
+            w_bool_from(true),
+        );
         return Ok(w_int_new(1));
     };
     if crate::baseobjspace::getattr_str(parser, "_pyre_use_foreign_dtd")
@@ -1415,11 +1423,19 @@ fn parse_impl(
     let suppress_until = get_emit_upto(parser);
     let parsed = MiniXmlParser::new(parser, &parse_input, final_flag, suppress_until).parse()?;
     if final_flag {
-        crate::baseobjspace::setdictvalue(parser, "_pyre_finished", w_bool_from(true));
-        crate::baseobjspace::setdictvalue(parser, "_pyre_deferred_incomplete", w_bool_from(false));
+        crate::baseobjspace::setdictvalue_native(parser, "_pyre_finished", w_bool_from(true));
+        crate::baseobjspace::setdictvalue_native(
+            parser,
+            "_pyre_deferred_incomplete",
+            w_bool_from(false),
+        );
         set_parser_pending(parser, "");
     } else {
-        crate::baseobjspace::setdictvalue(parser, "_pyre_deferred_incomplete", w_bool_from(false));
+        crate::baseobjspace::setdictvalue_native(
+            parser,
+            "_pyre_deferred_incomplete",
+            w_bool_from(false),
+        );
         set_parser_pending(parser, &input);
     }
     set_emit_upto(parser, parsed);
@@ -1475,9 +1491,9 @@ fn pyexpat_error(msg: String, code: i64, lineno: i64, offset: i64) -> crate::PyE
     if let Some(cls) = crate::builtins::lookup_exc_class("pyexpat.error") {
         let args = [cls, w_str_new(&msg)];
         if let Ok(exc) = crate::builtins::exc_exception_new(&args) {
-            crate::baseobjspace::setdictvalue(exc, "code", w_int_new(code));
-            crate::baseobjspace::setdictvalue(exc, "lineno", w_int_new(lineno));
-            crate::baseobjspace::setdictvalue(exc, "offset", w_int_new(offset));
+            crate::baseobjspace::setdictvalue_native(exc, "code", w_int_new(code));
+            crate::baseobjspace::setdictvalue_native(exc, "lineno", w_int_new(lineno));
+            crate::baseobjspace::setdictvalue_native(exc, "offset", w_int_new(offset));
             err.exc_object = exc;
         }
     }
@@ -1504,12 +1520,12 @@ fn copy_parser_config(src: PyObjectRef, dst: PyObjectRef) {
         "_pyre_base",
     ] {
         if let Ok(value) = crate::baseobjspace::getattr_str(src, name) {
-            crate::baseobjspace::setdictvalue(dst, name, value);
+            crate::baseobjspace::setdictvalue_native(dst, name, value);
         }
     }
     for h in HANDLER_NAMES {
         if let Ok(value) = crate::baseobjspace::getattr_str(src, h) {
-            crate::baseobjspace::setdictvalue(dst, h, value);
+            crate::baseobjspace::setdictvalue_native(dst, h, value);
         }
     }
 }
@@ -1552,7 +1568,7 @@ mod xmlparser_class {
                 if unsafe { !is_str(base) } {
                     return Err(crate::PyError::type_error("SetBase() argument must be str"));
                 }
-                crate::baseobjspace::setdictvalue(self_obj, "_pyre_base", base);
+                crate::baseobjspace::setdictvalue_native(self_obj, "_pyre_base", base);
                 Ok(w_none())
             }
             fn GetBase(self_obj: PyObjectRef) -> PyObjectRef {
@@ -1568,7 +1584,7 @@ mod xmlparser_class {
                 } else {
                     is_true_obj(flag)
                 };
-                crate::baseobjspace::setdictvalue(
+                crate::baseobjspace::setdictvalue_native(
                     self_obj,
                     "_pyre_param_entity_parsing",
                     w_int_new(if enabled { 1 } else { 0 }),
@@ -1579,14 +1595,14 @@ mod xmlparser_class {
                 self_obj: PyObjectRef,
                 #[default(w_bool_from(true))] flag: PyObjectRef,
             ) -> PyObjectRef {
-                crate::baseobjspace::setdictvalue(self_obj, "_pyre_use_foreign_dtd", w_bool_from(is_true_obj(flag)));
+                crate::baseobjspace::setdictvalue_native(self_obj, "_pyre_use_foreign_dtd", w_bool_from(is_true_obj(flag)));
                 w_none()
             }
             fn GetReparseDeferralEnabled(self_obj: PyObjectRef) -> PyObjectRef {
                 crate::baseobjspace::getattr_str(self_obj, "_pyre_reparse_deferral").unwrap_or_else(|_| w_bool_from(true))
             }
             fn SetReparseDeferralEnabled(self_obj: PyObjectRef, flag: PyObjectRef) -> PyObjectRef {
-                crate::baseobjspace::setdictvalue(self_obj, "_pyre_reparse_deferral", w_bool_from(is_true_obj(flag)));
+                crate::baseobjspace::setdictvalue_native(self_obj, "_pyre_reparse_deferral", w_bool_from(is_true_obj(flag)));
                 w_none()
             }
             fn SetBillionLaughsAttackProtectionActivationThreshold(self_obj: PyObjectRef, threshold: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
@@ -1599,7 +1615,7 @@ mod xmlparser_class {
                 if unsafe { w_int_get_value(threshold) } < 0 {
                     return Err(crate::PyError::value_error("threshold must be non-negative"));
                 }
-                crate::baseobjspace::setdictvalue(self_obj, "_pyre_billion_threshold", threshold);
+                crate::baseobjspace::setdictvalue_native(self_obj, "_pyre_billion_threshold", threshold);
                 Ok(w_none())
             }
             fn SetBillionLaughsAttackProtectionMaximumAmplification(self_obj: PyObjectRef, max_factor: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
@@ -1624,7 +1640,7 @@ mod xmlparser_class {
                         0,
                     ));
                 }
-                crate::baseobjspace::setdictvalue(self_obj, "_pyre_billion_max_is_one", w_bool_from(value <= 1.0));
+                crate::baseobjspace::setdictvalue_native(self_obj, "_pyre_billion_max_is_one", w_bool_from(value <= 1.0));
                 Ok(w_none())
             }
             fn ExternalEntityParserCreate(
@@ -1635,11 +1651,11 @@ mod xmlparser_class {
                 let parser = w_instance_new(xmlparser_class::type_object());
                 init_parser_slots(parser);
                 copy_parser_config(self_obj, parser);
-                crate::baseobjspace::setdictvalue(parser, "_pyre_is_subparser", w_bool_from(true));
+                crate::baseobjspace::setdictvalue_native(parser, "_pyre_is_subparser", w_bool_from(true));
                 if unsafe { is_str(encoding) } {
-                    crate::baseobjspace::setdictvalue(parser, "_pyre_forced_encoding", encoding);
+                    crate::baseobjspace::setdictvalue_native(parser, "_pyre_forced_encoding", encoding);
                 }
-                crate::baseobjspace::setdictvalue(parser, "_pyre_external_context", context);
+                crate::baseobjspace::setdictvalue_native(parser, "_pyre_external_context", context);
                 parser
             }
             fn __setattr__(self_obj: PyObjectRef, name: PyObjectRef, value: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
@@ -1651,7 +1667,7 @@ mod xmlparser_class {
                     return Err(crate::PyError::attribute_error("returns_unicode"));
                 }
                 if bool_slot_name(name_s) {
-                    crate::baseobjspace::setdictvalue(self_obj, name_s, w_bool_from(is_true_obj(value)));
+                    crate::baseobjspace::setdictvalue_native(self_obj, name_s, w_bool_from(is_true_obj(value)));
                     return Ok(w_none());
                 }
                 if name_s == "buffer_size" {
@@ -1662,10 +1678,10 @@ mod xmlparser_class {
                     if size <= 0 {
                         return Err(crate::PyError::value_error("buffer_size must be greater than zero"));
                     }
-                    crate::baseobjspace::setdictvalue(self_obj, "buffer_size", value);
+                    crate::baseobjspace::setdictvalue_native(self_obj, "buffer_size", value);
                     return Ok(w_none());
                 }
-                crate::baseobjspace::setdictvalue(self_obj, name_s, value);
+                crate::baseobjspace::setdictvalue_native(self_obj, name_s, value);
                 Ok(w_none())
             }
         }
@@ -1674,13 +1690,13 @@ mod xmlparser_class {
 
 fn init_parser_slots(parser: PyObjectRef) {
     for h in HANDLER_NAMES {
-        crate::baseobjspace::setdictvalue(parser, h, w_none());
+        crate::baseobjspace::setdictvalue_native(parser, h, w_none());
     }
     let set_int = |name: &str, v: i64| {
-        crate::baseobjspace::setdictvalue(parser, name, w_int_new(v));
+        crate::baseobjspace::setdictvalue_native(parser, name, w_int_new(v));
     };
     let set_bool = |name: &str, v: bool| {
-        crate::baseobjspace::setdictvalue(parser, name, w_bool_from(v));
+        crate::baseobjspace::setdictvalue_native(parser, name, w_bool_from(v));
     };
     set_bool("buffer_text", false);
     set_int("buffer_size", 8192);
@@ -1695,19 +1711,35 @@ fn init_parser_slots(parser: PyObjectRef) {
     set_int("CurrentLineNumber", 0);
     set_int("CurrentColumnNumber", 0);
     set_int("CurrentByteIndex", 0);
-    crate::baseobjspace::setdictvalue(parser, "intern", w_dict_new());
-    crate::baseobjspace::setdictvalue(parser, "_pyre_pending_xml", w_str_new(""));
-    crate::baseobjspace::setdictvalue(parser, "_pyre_emit_upto", w_int_new(0));
-    crate::baseobjspace::setdictvalue(parser, "_pyre_finished", w_bool_from(false));
-    crate::baseobjspace::setdictvalue(parser, "_pyre_base", w_none());
-    crate::baseobjspace::setdictvalue(parser, "_pyre_use_foreign_dtd", w_bool_from(false));
-    crate::baseobjspace::setdictvalue(parser, "_pyre_reparse_deferral", w_bool_from(true));
-    crate::baseobjspace::setdictvalue(parser, "_pyre_is_subparser", w_bool_from(false));
-    crate::baseobjspace::setdictvalue(parser, "_pyre_deferred_incomplete", w_bool_from(false));
-    crate::baseobjspace::setdictvalue(parser, "_pyre_param_entity_parsing", w_int_new(0));
-    crate::baseobjspace::setdictvalue(parser, "_pyre_billion_threshold", w_int_new(i64::MAX));
-    crate::baseobjspace::setdictvalue(parser, "_pyre_billion_max_is_one", w_bool_from(false));
-    crate::baseobjspace::setdictvalue(parser, "_pyre_not_standalone_pending", w_bool_from(false));
+    crate::baseobjspace::setdictvalue_native(parser, "intern", w_dict_new());
+    crate::baseobjspace::setdictvalue_native(parser, "_pyre_pending_xml", w_str_new(""));
+    crate::baseobjspace::setdictvalue_native(parser, "_pyre_emit_upto", w_int_new(0));
+    crate::baseobjspace::setdictvalue_native(parser, "_pyre_finished", w_bool_from(false));
+    crate::baseobjspace::setdictvalue_native(parser, "_pyre_base", w_none());
+    crate::baseobjspace::setdictvalue_native(parser, "_pyre_use_foreign_dtd", w_bool_from(false));
+    crate::baseobjspace::setdictvalue_native(parser, "_pyre_reparse_deferral", w_bool_from(true));
+    crate::baseobjspace::setdictvalue_native(parser, "_pyre_is_subparser", w_bool_from(false));
+    crate::baseobjspace::setdictvalue_native(
+        parser,
+        "_pyre_deferred_incomplete",
+        w_bool_from(false),
+    );
+    crate::baseobjspace::setdictvalue_native(parser, "_pyre_param_entity_parsing", w_int_new(0));
+    crate::baseobjspace::setdictvalue_native(
+        parser,
+        "_pyre_billion_threshold",
+        w_int_new(i64::MAX),
+    );
+    crate::baseobjspace::setdictvalue_native(
+        parser,
+        "_pyre_billion_max_is_one",
+        w_bool_from(false),
+    );
+    crate::baseobjspace::setdictvalue_native(
+        parser,
+        "_pyre_not_standalone_pending",
+        w_bool_from(false),
+    );
 }
 
 /// `ParserCreate(encoding=None, namespace_separator=None, intern=None)`.
@@ -1724,7 +1756,7 @@ fn parser_create3(
                 "ParserCreate() argument 'encoding' must be str or None",
             ));
         }
-        crate::baseobjspace::setdictvalue(parser, "_pyre_forced_encoding", encoding);
+        crate::baseobjspace::setdictvalue_native(parser, "_pyre_forced_encoding", encoding);
     }
     if unsafe { is_none(namespace_separator) } {
     } else if unsafe { is_str(namespace_separator) } {
@@ -1734,14 +1766,18 @@ fn parser_create3(
                 "namespace_separator must be at most one character, omitted, or None",
             ));
         }
-        crate::baseobjspace::setdictvalue(parser, "_pyre_namespace_separator", w_str_new(value));
+        crate::baseobjspace::setdictvalue_native(
+            parser,
+            "_pyre_namespace_separator",
+            w_str_new(value),
+        );
     } else {
         return Err(crate::PyError::type_error(
             "ParserCreate() argument 'namespace_separator' must be str or None, not int",
         ));
     }
     if unsafe { !is_none(intern) } {
-        crate::baseobjspace::setdictvalue(parser, "intern", intern);
+        crate::baseobjspace::setdictvalue_native(parser, "intern", intern);
     }
     Ok(parser)
 }
@@ -1872,7 +1908,7 @@ fn make_namespace(name: &'static str) -> PyObjectRef {
     let tp = crate::typedef::make_builtin_type(name, |_| {});
     unsafe { typeobject::w_type_set_hasdict(tp, true) };
     let obj = w_instance_new(tp);
-    crate::baseobjspace::setdictvalue(obj, "__name__", w_str_new(name));
+    crate::baseobjspace::setdictvalue_native(obj, "__name__", w_str_new(name));
     obj
 }
 
@@ -1912,7 +1948,7 @@ crate::py_module! {
         // model — content-model integer constants.
         let model = make_namespace("pyexpat.model");
         for (name, value) in MODEL_CONSTANTS {
-            crate::baseobjspace::setdictvalue(model, name, w_int_new(*value));
+            crate::baseobjspace::setdictvalue_native(model, name, w_int_new(*value));
         }
         crate::module_ns_store(ns, "model", model);
 
@@ -1928,14 +1964,14 @@ crate::py_module! {
             }
             let (msg, code) = ERROR_TABLE[idx - 1];
             let w_msg = w_str_new(msg);
-            crate::baseobjspace::setdictvalue(errors, name, w_msg);
+            crate::baseobjspace::setdictvalue_native(errors, name, w_msg);
             unsafe {
                 w_dict_setitem_str(codes, msg, w_int_new(code));
                 w_dict_store(messages, w_int_new(code), w_msg);
             }
         }
-        crate::baseobjspace::setdictvalue(errors, "codes", codes);
-        crate::baseobjspace::setdictvalue(errors, "messages", messages);
+        crate::baseobjspace::setdictvalue_native(errors, "codes", codes);
+        crate::baseobjspace::setdictvalue_native(errors, "messages", messages);
         crate::module_ns_store(ns, "errors", errors);
 
         // features — list of (name, value) capability tuples.

--- a/pyre/pyre-interpreter/src/module/sys/vm.rs
+++ b/pyre/pyre-interpreter/src/module/sys/vm.rs
@@ -73,7 +73,7 @@ fn namespace_apply_kwargs(self_obj: PyObjectRef, kwargs: Option<PyObjectRef>) ->
                         if name == "__pyre_kw__" {
                             continue;
                         }
-                        crate::baseobjspace::setdictvalue(self_obj, name, value);
+                        crate::baseobjspace::setdictvalue_native(self_obj, name, value);
                         continue;
                     }
                 }
@@ -1126,8 +1126,8 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     // sys.implementation — structseq-like namespace with name, version, ...
     {
         let impl_obj = w_instance_new(simple_namespace_type());
-        crate::baseobjspace::setdictvalue(impl_obj, "name", w_str_new("pyre"));
-        crate::baseobjspace::setdictvalue(
+        crate::baseobjspace::setdictvalue_native(impl_obj, "name", w_str_new("pyre"));
+        crate::baseobjspace::setdictvalue_native(
             impl_obj,
             "version",
             w_tuple_new(vec![
@@ -1138,41 +1138,41 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 w_int_new(0),
             ]),
         );
-        crate::baseobjspace::setdictvalue(impl_obj, "hexversion", w_int_new(0x030e06f0));
-        crate::baseobjspace::setdictvalue(impl_obj, "cache_tag", w_str_new("pyre-314"));
-        crate::baseobjspace::setdictvalue(impl_obj, "_multiarch", w_str_new(""));
+        crate::baseobjspace::setdictvalue_native(impl_obj, "hexversion", w_int_new(0x030e06f0));
+        crate::baseobjspace::setdictvalue_native(impl_obj, "cache_tag", w_str_new("pyre-314"));
+        crate::baseobjspace::setdictvalue_native(impl_obj, "_multiarch", w_str_new(""));
         module_ns_store(ns, "implementation", impl_obj);
     }
     // sys.hash_info — structseq with width/modulus/... fields.
     // PyPy: pypy/module/sys/system.py hash_info.
     {
         let hash_info = make_sys_namespace_instance();
-        crate::baseobjspace::setdictvalue(hash_info, "width", w_int_new(64));
-        crate::baseobjspace::setdictvalue(hash_info, "modulus", w_int_new((1i64 << 61) - 1));
-        crate::baseobjspace::setdictvalue(hash_info, "inf", w_int_new(314159));
-        crate::baseobjspace::setdictvalue(hash_info, "nan", w_int_new(0));
-        crate::baseobjspace::setdictvalue(hash_info, "imag", w_int_new(1000003));
-        crate::baseobjspace::setdictvalue(hash_info, "algorithm", w_str_new("siphash13"));
-        crate::baseobjspace::setdictvalue(hash_info, "hash_bits", w_int_new(64));
-        crate::baseobjspace::setdictvalue(hash_info, "seed_bits", w_int_new(128));
-        crate::baseobjspace::setdictvalue(hash_info, "cutoff", w_int_new(0));
+        crate::baseobjspace::setdictvalue_native(hash_info, "width", w_int_new(64));
+        crate::baseobjspace::setdictvalue_native(hash_info, "modulus", w_int_new((1i64 << 61) - 1));
+        crate::baseobjspace::setdictvalue_native(hash_info, "inf", w_int_new(314159));
+        crate::baseobjspace::setdictvalue_native(hash_info, "nan", w_int_new(0));
+        crate::baseobjspace::setdictvalue_native(hash_info, "imag", w_int_new(1000003));
+        crate::baseobjspace::setdictvalue_native(hash_info, "algorithm", w_str_new("siphash13"));
+        crate::baseobjspace::setdictvalue_native(hash_info, "hash_bits", w_int_new(64));
+        crate::baseobjspace::setdictvalue_native(hash_info, "seed_bits", w_int_new(128));
+        crate::baseobjspace::setdictvalue_native(hash_info, "cutoff", w_int_new(0));
         module_ns_store(ns, "hash_info", hash_info);
     }
     // sys.float_info — structseq with IEEE 754 double metadata.
     // PyPy: pypy/module/sys/system.py float_info.
     {
         let fi = make_sys_namespace_instance();
-        crate::baseobjspace::setdictvalue(fi, "max", w_float_new(f64::MAX));
-        crate::baseobjspace::setdictvalue(fi, "max_exp", w_int_new(1024));
-        crate::baseobjspace::setdictvalue(fi, "max_10_exp", w_int_new(308));
-        crate::baseobjspace::setdictvalue(fi, "min", w_float_new(f64::MIN_POSITIVE));
-        crate::baseobjspace::setdictvalue(fi, "min_exp", w_int_new(-1021));
-        crate::baseobjspace::setdictvalue(fi, "min_10_exp", w_int_new(-307));
-        crate::baseobjspace::setdictvalue(fi, "dig", w_int_new(15));
-        crate::baseobjspace::setdictvalue(fi, "mant_dig", w_int_new(53));
-        crate::baseobjspace::setdictvalue(fi, "epsilon", w_float_new(f64::EPSILON));
-        crate::baseobjspace::setdictvalue(fi, "radix", w_int_new(2));
-        crate::baseobjspace::setdictvalue(fi, "rounds", w_int_new(1));
+        crate::baseobjspace::setdictvalue_native(fi, "max", w_float_new(f64::MAX));
+        crate::baseobjspace::setdictvalue_native(fi, "max_exp", w_int_new(1024));
+        crate::baseobjspace::setdictvalue_native(fi, "max_10_exp", w_int_new(308));
+        crate::baseobjspace::setdictvalue_native(fi, "min", w_float_new(f64::MIN_POSITIVE));
+        crate::baseobjspace::setdictvalue_native(fi, "min_exp", w_int_new(-1021));
+        crate::baseobjspace::setdictvalue_native(fi, "min_10_exp", w_int_new(-307));
+        crate::baseobjspace::setdictvalue_native(fi, "dig", w_int_new(15));
+        crate::baseobjspace::setdictvalue_native(fi, "mant_dig", w_int_new(53));
+        crate::baseobjspace::setdictvalue_native(fi, "epsilon", w_float_new(f64::EPSILON));
+        crate::baseobjspace::setdictvalue_native(fi, "radix", w_int_new(2));
+        crate::baseobjspace::setdictvalue_native(fi, "rounds", w_int_new(1));
         module_ns_store(ns, "float_info", fi);
     }
     // sysmodule.c — `sys.float_repr_style` is "short" wherever float repr
@@ -1181,18 +1181,18 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     // sys.thread_info — structseq(name, lock, version).
     {
         let ti = make_sys_namespace_instance();
-        crate::baseobjspace::setdictvalue(ti, "name", w_str_new("pthread"));
-        crate::baseobjspace::setdictvalue(ti, "lock", w_str_new("semaphore"));
-        crate::baseobjspace::setdictvalue(ti, "version", w_none());
+        crate::baseobjspace::setdictvalue_native(ti, "name", w_str_new("pthread"));
+        crate::baseobjspace::setdictvalue_native(ti, "lock", w_str_new("semaphore"));
+        crate::baseobjspace::setdictvalue_native(ti, "version", w_none());
         module_ns_store(ns, "thread_info", ti);
     }
     // sys.int_info — structseq with int implementation details.
     {
         let ii = make_sys_namespace_instance();
-        crate::baseobjspace::setdictvalue(ii, "bits_per_digit", w_int_new(30));
-        crate::baseobjspace::setdictvalue(ii, "sizeof_digit", w_int_new(4));
-        crate::baseobjspace::setdictvalue(ii, "default_max_str_digits", w_int_new(4300));
-        crate::baseobjspace::setdictvalue(ii, "str_digits_check_threshold", w_int_new(640));
+        crate::baseobjspace::setdictvalue_native(ii, "bits_per_digit", w_int_new(30));
+        crate::baseobjspace::setdictvalue_native(ii, "sizeof_digit", w_int_new(4));
+        crate::baseobjspace::setdictvalue_native(ii, "default_max_str_digits", w_int_new(4300));
+        crate::baseobjspace::setdictvalue_native(ii, "str_digits_check_threshold", w_int_new(640));
         module_ns_store(ns, "int_info", ii);
     }
     module_ns_store(ns, "hexversion", w_int_new(0x030e06f0));
@@ -1228,12 +1228,12 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     // Python 3.14+ introduced sys._jit for CPython tier-2 JIT support checks.
     {
         let jit = make_sys_namespace_instance();
-        crate::baseobjspace::setdictvalue(
+        crate::baseobjspace::setdictvalue_native(
             jit,
             "is_enabled",
             make_builtin_function_with_arity("is_enabled", |_| Ok(w_bool_from(false)), 0),
         );
-        crate::baseobjspace::setdictvalue(
+        crate::baseobjspace::setdictvalue_native(
             jit,
             "is_available",
             make_builtin_function_with_arity("is_available", |_| Ok(w_bool_from(false)), 0),
@@ -1254,16 +1254,16 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             ("PROFILER_ID", 2),
             ("OPTIMIZER_ID", 5),
         ] {
-            crate::baseobjspace::setdictvalue(mon, name, w_int_new(id));
+            crate::baseobjspace::setdictvalue_native(mon, name, w_int_new(id));
         }
         // DISABLE / MISSING sentinels — distinct singleton objects compared
         // by identity (`callback() == DISABLE`, `assertIs(x, MISSING)`).
-        crate::baseobjspace::setdictvalue(mon, "DISABLE", make_sys_namespace_instance());
-        crate::baseobjspace::setdictvalue(mon, "MISSING", make_sys_namespace_instance());
+        crate::baseobjspace::setdictvalue_native(mon, "DISABLE", make_sys_namespace_instance());
+        crate::baseobjspace::setdictvalue_native(mon, "MISSING", make_sys_namespace_instance());
         // events namespace — `1 << event_id` flags that OR together.
         {
             let events = make_sys_namespace_instance();
-            crate::baseobjspace::setdictvalue(events, "NO_EVENTS", w_int_new(0));
+            crate::baseobjspace::setdictvalue_native(events, "NO_EVENTS", w_int_new(0));
             for (i, name) in [
                 "PY_START",
                 "PY_RESUME",
@@ -1287,16 +1287,16 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             .iter()
             .enumerate()
             {
-                crate::baseobjspace::setdictvalue(events, name, w_int_new(1i64 << i));
+                crate::baseobjspace::setdictvalue_native(events, name, w_int_new(1i64 << i));
             }
             // BRANCH retained as an alias of BRANCH_LEFT for callers predating
             // the 3.14 left/right split.
-            crate::baseobjspace::setdictvalue(events, "BRANCH", w_int_new(1i64 << 8));
-            crate::baseobjspace::setdictvalue(mon, "events", events);
+            crate::baseobjspace::setdictvalue_native(events, "BRANCH", w_int_new(1i64 << 8));
+            crate::baseobjspace::setdictvalue_native(mon, "events", events);
         }
         // Runtime hooks — no-op stubs returning sensible defaults.
         let store_fn = |obj, name: &'static str, f: crate::gateway::BuiltinCodeFn, arity: u16| {
-            crate::baseobjspace::setdictvalue(
+            crate::baseobjspace::setdictvalue_native(
                 obj,
                 name,
                 make_builtin_function_with_arity(name, f, arity),
@@ -1745,12 +1745,12 @@ fn make_std_stream(name: &'static str, fd: i32) -> PyObjectRef {
             "strict"
         },
     );
-    crate::baseobjspace::setdictvalue(stream, "name", w_str_new(name));
-    crate::baseobjspace::setdictvalue(stream, "encoding", w_str_new("utf-8"));
+    crate::baseobjspace::setdictvalue_native(stream, "name", w_str_new(name));
+    crate::baseobjspace::setdictvalue_native(stream, "encoding", w_str_new("utf-8"));
     // `pylifecycle.c init_set_builtins_open`/`init_sys_streams`: stderr uses the
     // `backslashreplace` handler so traceback printing never fails on a lone
     // surrogate; stdout/stdin default to `strict`.
-    crate::baseobjspace::setdictvalue(
+    crate::baseobjspace::setdictvalue_native(
         stream,
         "errors",
         w_str_new(if to_stderr {
@@ -1759,9 +1759,9 @@ fn make_std_stream(name: &'static str, fd: i32) -> PyObjectRef {
             "strict"
         }),
     );
-    crate::baseobjspace::setdictvalue(stream, "mode", w_str_new(if writable { "w" } else { "r" }));
-    crate::baseobjspace::setdictvalue(stream, "closed", w_bool_from(false));
-    crate::baseobjspace::setdictvalue(stream, "buffer", w_none());
+    crate::baseobjspace::setdictvalue_native(stream, "mode", w_str_new(if writable { "w" } else { "r" }));
+    crate::baseobjspace::setdictvalue_native(stream, "closed", w_bool_from(false));
+    crate::baseobjspace::setdictvalue_native(stream, "buffer", w_none());
     // Instance-stored builtin methods do not get `self` prepended (see
     // pyopcode load_method dispatch), so the first arg may be the string
     // directly. Pick whichever element is a real str.
@@ -1812,8 +1812,8 @@ fn make_std_stream(name: &'static str, fd: i32) -> PyObjectRef {
             Ok(w_int_new(0))
         })
     };
-    crate::baseobjspace::setdictvalue(stream, "write", write_fn);
-    crate::baseobjspace::setdictvalue(
+    crate::baseobjspace::setdictvalue_native(stream, "write", write_fn);
+    crate::baseobjspace::setdictvalue_native(
         stream,
         "flush",
         crate::make_builtin_function("flush", |_| {
@@ -1828,7 +1828,7 @@ fn make_std_stream(name: &'static str, fd: i32) -> PyObjectRef {
             Ok(w_none())
         }),
     );
-    crate::baseobjspace::setdictvalue(
+    crate::baseobjspace::setdictvalue_native(
         stream,
         "isatty",
         crate::make_builtin_function("isatty", |_| Ok(w_bool_from(false))),
@@ -1836,7 +1836,7 @@ fn make_std_stream(name: &'static str, fd: i32) -> PyObjectRef {
     // `TextIOWrapper.reconfigure(*, encoding=None, errors=None, ...)` only
     // adjusts codec/newline policy; pyre's streams are fixed UTF-8, so accept
     // and ignore the request.
-    crate::baseobjspace::setdictvalue(
+    crate::baseobjspace::setdictvalue_native(
         stream,
         "reconfigure",
         crate::make_builtin_function("reconfigure", |_| Ok(w_none())),
@@ -1848,7 +1848,7 @@ fn make_std_stream(name: &'static str, fd: i32) -> PyObjectRef {
         2 => crate::make_builtin_function("fileno", |_| Ok(w_int_new(2))),
         _ => crate::make_builtin_function("fileno", |_| Ok(w_int_new(1))),
     };
-    crate::baseobjspace::setdictvalue(stream, "fileno", fileno_fn);
+    crate::baseobjspace::setdictvalue_native(stream, "fileno", fileno_fn);
     let (writable_fn, readable_fn) = if writable {
         (
             crate::make_builtin_function("writable", |_| Ok(w_bool_from(true))),
@@ -1860,7 +1860,7 @@ fn make_std_stream(name: &'static str, fd: i32) -> PyObjectRef {
             crate::make_builtin_function("readable", |_| Ok(w_bool_from(true))),
         )
     };
-    crate::baseobjspace::setdictvalue(stream, "writable", writable_fn);
-    crate::baseobjspace::setdictvalue(stream, "readable", readable_fn);
+    crate::baseobjspace::setdictvalue_native(stream, "writable", writable_fn);
+    crate::baseobjspace::setdictvalue_native(stream, "readable", readable_fn);
     stream
 }

--- a/pyre/pyre-interpreter/src/module/thread/mod.rs
+++ b/pyre/pyre-interpreter/src/module/thread/mod.rs
@@ -322,10 +322,27 @@ pub(crate) fn after_fork_child() {
     majit_gc::gc_sync::after_fork_child();
 }
 
+// os_lock.py:20 `RPY_LOCK_FAILURE, RPY_LOCK_ACQUIRED, RPY_LOCK_INTR`.
+const RPY_LOCK_FAILURE: i64 = 0;
+const RPY_LOCK_ACQUIRED: i64 = 1;
+const RPY_LOCK_INTR: i64 = 2;
+
+/// A `pthread_mutex_t` has no poison state — `thread_pthread.c` inspects only
+/// the status code — so a panic taken while lock bookkeeping was held must not
+/// turn every later acquire into an error.
+fn lock_state<T>(mutex: &std::sync::Mutex<T>) -> std::sync::MutexGuard<'_, T> {
+    mutex
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+/// `os_lock.py:23-40 parse_acquire_args`.  The result is the `microseconds`
+/// argument of the `RPyThreadAcquireLockTimed` ABI: negative blocks forever,
+/// zero polls once.
 fn parse_acquire_args(
     blocking: i64,
     w_timeout: Option<PyObjectRef>,
-) -> Result<Option<Duration>, crate::PyError> {
+) -> Result<i64, crate::PyError> {
     // os_lock.py `@unwrap_spec(blocking=int, timeout=float)`: unlike the
     // macro's concrete `f64` receiver, `space.float_w` performs Python's
     // numeric coercion first, so integer timeout arguments retain their
@@ -345,18 +362,74 @@ fn parse_acquire_args(
             "timeout value must be strictly positive",
         ));
     }
-    if timeout > TIMEOUT_MAX {
-        return Err(crate::PyError::overflow_error("timeout value is too large"));
-    }
-    Ok(if blocking && timeout >= 0.0 {
-        Some(Duration::from_secs_f64(timeout))
+    if !blocking {
+        Ok(0)
+    } else if timeout == -1.0 {
+        Ok(-1)
+    } else if timeout > TIMEOUT_MAX {
+        // `ovfcheck_float_to_longlong(timeout * 1e6)`.
+        Err(crate::PyError::overflow_error("timeout value is too large"))
     } else {
-        None
-    })
+        Ok((timeout * 1e6) as i64)
+    }
+}
+
+/// `os_lock.py:49 space.getexecutioncontext().checksignals()`.  The signal
+/// module is not built for wasm32 (`module/mod.rs:94`), where no handler can
+/// be pending, so there the check has nothing to run.
+fn checksignals() -> Result<(), crate::PyError> {
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        crate::module::signal::interp_signal::checksignals_now()
+    }
+    #[cfg(target_arch = "wasm32")]
+    {
+        Ok(())
+    }
+}
+
+/// `os_lock.py:43-60 acquire_timed` — "Helper to acquire an interruptible lock
+/// with a timeout."  `RPY_LOCK_INTR` reports a wait that a signal handler cut
+/// short: deliver the signal, then retry with whatever time is left.
+///
+/// `acquire` is the `RPyThreadAcquireLockTimed` primitive of the lock being
+/// taken; upstream reaches it as `lock.acquire_timed`
+/// (`rthread.py:192-197 Lock.acquire_timed`, `intr_flag=1`).
+fn acquire_timed(
+    mut microseconds: i64,
+    mut acquire: impl FnMut(i64) -> i64,
+) -> Result<i64, crate::PyError> {
+    // os_lock.py:45 `endtime`, measured here on the monotonic clock the
+    // `time_sleep` retry loop already uses for its deadline.
+    let start = Instant::now();
+    let endtime = microseconds;
+    loop {
+        let mut result = acquire(microseconds);
+        if result == RPY_LOCK_INTR {
+            // Run signal handlers if we were interrupted
+            checksignals()?;
+            if microseconds >= 0 {
+                microseconds = endtime - start.elapsed().as_micros() as i64;
+                // Check for negative values, since those mean block forever
+                if microseconds <= 0 {
+                    result = RPY_LOCK_FAILURE;
+                }
+            }
+        }
+        if result != RPY_LOCK_INTR {
+            return Ok(result);
+        }
+    }
 }
 
 mod lock_class {
     use super::*;
+    // `pthread_cond_wait` returning without the lock is how
+    // `RPyThreadAcquireLockTimed` detects a signal (thread_pthread.c:466-471),
+    // so the wait must be the bare one-shot call that propagates spurious
+    // wakeups.  `parking_lot`'s condition variable retries internally and
+    // would swallow exactly the wakeup that carries the interrupt.
+    use std::sync::{Condvar, Mutex};
 
     #[crate::pyre_class("_thread.lock")]
     #[derive(Default)]
@@ -380,51 +453,74 @@ mod lock_class {
             Ok(obj)
         }
 
+        /// `thread_pthread.c:427-485 RPyThreadAcquireLockTimed`, the mutex and
+        /// condition-variable build — the shape this lock has — with
+        /// `intr_flag=1`, which is what `rthread.py:195` passes.
+        fn acquire_timed(&self, microseconds: i64) -> i64 {
+            // A potentially blocking native lock wait leaves the collector's
+            // RUNNING census.  This does not serialize Python execution.  The
+            // guard ends with the primitive, so the signal handlers the caller
+            // runs on `RPY_LOCK_INTR` execute back inside the census.
+            let _blocked = before_external_block();
+            let mut locked = lock_state(&self.locked);
+            let mut success;
+            if !*locked {
+                success = RPY_LOCK_ACQUIRED;
+            } else if microseconds == 0 {
+                success = RPY_LOCK_FAILURE;
+            } else {
+                let deadline = (microseconds > 0)
+                    .then(|| Instant::now() + Duration::from_micros(microseconds as u64));
+                success = RPY_LOCK_FAILURE;
+                while success == RPY_LOCK_FAILURE {
+                    if let Some(deadline) = deadline {
+                        let now = Instant::now();
+                        if now >= deadline {
+                            break;
+                        }
+                        let (guard, timeout) = self
+                            .ready
+                            .wait_timeout(locked, deadline - now)
+                            .unwrap_or_else(std::sync::PoisonError::into_inner);
+                        locked = guard;
+                        if timeout.timed_out() {
+                            break;
+                        }
+                    } else {
+                        locked = self
+                            .ready
+                            .wait(locked)
+                            .unwrap_or_else(std::sync::PoisonError::into_inner);
+                    }
+                    if *locked {
+                        // We were woken up, but didn't get the lock.  We
+                        // probably received a signal.  Return RPY_LOCK_INTR to
+                        // allow the caller to handle it and retry.
+                        success = RPY_LOCK_INTR;
+                    } else {
+                        success = RPY_LOCK_ACQUIRED;
+                    }
+                }
+            }
+            if success == RPY_LOCK_ACQUIRED {
+                *locked = true;
+            }
+            success
+        }
+
+        /// `os_lock.py:75-85 descr_lock_acquire`.
         fn acquire(
             &self,
             #[default(1)] blocking: i64,
             timeout: Option<PyObjectRef>,
         ) -> Result<bool, crate::PyError> {
-            let timeout = parse_acquire_args(blocking, timeout)?;
-            let blocking = blocking != 0;
-            // A potentially blocking native lock wait leaves the collector's
-            // RUNNING census.  This does not serialize Python execution.
-            let _blocked = before_external_block();
-            let mut locked = self.locked.lock();
-            if !*locked {
-                *locked = true;
-                return Ok(true);
-            }
-            if !blocking {
-                return Ok(false);
-            }
-            match timeout {
-                None => {
-                    while *locked {
-                        self.ready.wait(&mut locked);
-                    }
-                    *locked = true;
-                    Ok(true)
-                }
-                Some(duration) => {
-                    let deadline = Instant::now() + duration;
-                    while *locked {
-                        let now = Instant::now();
-                        if now >= deadline {
-                            return Ok(false);
-                        }
-                        if self.ready.wait_for(&mut locked, deadline - now).timed_out() && *locked {
-                            return Ok(false);
-                        }
-                    }
-                    *locked = true;
-                    Ok(true)
-                }
-            }
+            let microseconds = parse_acquire_args(blocking, timeout)?;
+            let result = super::acquire_timed(microseconds, |us| self.acquire_timed(us))?;
+            Ok(result == RPY_LOCK_ACQUIRED)
         }
 
         fn release(&self) -> Result<(), crate::PyError> {
-            let mut locked = self.locked.lock();
+            let mut locked = lock_state(&self.locked);
             if !*locked {
                 return Err(crate::PyError::runtime_error("release unlocked lock"));
             }
@@ -434,7 +530,7 @@ mod lock_class {
         }
 
         fn locked(&self) -> bool {
-            *self.locked.lock()
+            *lock_state(&self.locked)
         }
 
         fn __enter__(&self) -> Result<PyObjectRef, crate::PyError> {
@@ -468,6 +564,8 @@ use lock_class::W_Lock;
 
 mod rlock_class {
     use super::*;
+    // Same interrupt-detection requirement as `lock_class`.
+    use std::sync::{Condvar, Mutex};
 
     #[derive(Default)]
     struct RLockState {
@@ -501,59 +599,96 @@ mod rlock_class {
             Ok(obj)
         }
 
+        /// The native-lock half of `os_lock.py:206-241 acquire_w`, shaped to
+        /// the `RPyThreadAcquireLockTimed` ABI (thread_pthread.c:427-485) so
+        /// `acquire_timed` can deliver signals between attempts.
+        ///
+        /// Upstream keeps `rlock_count`/`rlock_owner` outside the native lock
+        /// because the GIL serializes them; free-threaded pyre has no such
+        /// serialization, so ownership is claimed under the same mutex the
+        /// wait releases — the place `thread_pthread.c:479` sets `locked`.
+        fn acquire_timed(&self, microseconds: i64, ident: i64) -> i64 {
+            let _blocked = before_external_block();
+            let mut state = lock_state(&self.state);
+            let mut success;
+            if state.count == 0 {
+                success = RPY_LOCK_ACQUIRED;
+            } else if microseconds == 0 {
+                success = RPY_LOCK_FAILURE;
+            } else {
+                let deadline = (microseconds > 0)
+                    .then(|| Instant::now() + Duration::from_micros(microseconds as u64));
+                success = RPY_LOCK_FAILURE;
+                while success == RPY_LOCK_FAILURE {
+                    if let Some(deadline) = deadline {
+                        let now = Instant::now();
+                        if now >= deadline {
+                            break;
+                        }
+                        let (guard, timeout) = self
+                            .ready
+                            .wait_timeout(state, deadline - now)
+                            .unwrap_or_else(std::sync::PoisonError::into_inner);
+                        state = guard;
+                        if timeout.timed_out() {
+                            break;
+                        }
+                    } else {
+                        state = self
+                            .ready
+                            .wait(state)
+                            .unwrap_or_else(std::sync::PoisonError::into_inner);
+                    }
+                    if state.count != 0 {
+                        // Woken without the lock — probably a signal.
+                        success = RPY_LOCK_INTR;
+                    } else {
+                        success = RPY_LOCK_ACQUIRED;
+                    }
+                }
+            }
+            if success == RPY_LOCK_ACQUIRED {
+                state.owner = ident;
+                state.count = 1;
+            }
+            success
+        }
+
+        /// `os_lock.py:206-241 acquire_w`.
         fn acquire(
             &self,
             #[default(1)] blocking: i64,
             timeout: Option<PyObjectRef>,
         ) -> Result<bool, crate::PyError> {
-            let timeout = parse_acquire_args(blocking, timeout)?;
-            let blocking = blocking != 0;
-            let ident = current_ident();
-            let _blocked = before_external_block();
-            let mut state = self.state.lock();
-            if state.count > 0 && state.owner == ident {
-                state.count = state.count.checked_add(1).ok_or_else(|| {
-                    crate::PyError::overflow_error("internal lock count overflowed")
-                })?;
-                return Ok(true);
-            }
-            if state.count == 0 {
-                state.owner = ident;
-                state.count = 1;
-                return Ok(true);
-            }
-            if !blocking {
-                return Ok(false);
-            }
-            match timeout {
-                None => {
-                    while state.count != 0 {
-                        self.ready.wait(&mut state);
-                    }
-                }
-                Some(duration) => {
-                    let deadline = Instant::now() + duration;
-                    while state.count != 0 {
-                        let now = Instant::now();
-                        if now >= deadline {
-                            return Ok(false);
-                        }
-                        if self.ready.wait_for(&mut state, deadline - now).timed_out()
-                            && state.count != 0
-                        {
-                            return Ok(false);
-                        }
-                    }
+            let microseconds = parse_acquire_args(blocking, timeout)?;
+            let tid = current_ident();
+            {
+                let mut state = lock_state(&self.state);
+                if state.count > 0 && state.owner == tid {
+                    state.count = state.count.checked_add(1).ok_or_else(|| {
+                        crate::PyError::overflow_error("internal lock count overflowed")
+                    })?;
+                    return Ok(true);
                 }
             }
-            state.owner = ident;
-            state.count = 1;
-            Ok(true)
+            // os_lock.py:231-235 — `self.lock.acquire(False)` first; only a
+            // failed poll waits, and only when `blocking`.  The count check
+            // upstream pairs it with is the same predicate the poll tests,
+            // because here the count is the lock.
+            let mut r = self.acquire_timed(0, tid) == RPY_LOCK_ACQUIRED;
+            if !r {
+                if blocking == 0 {
+                    return Ok(false);
+                }
+                r = super::acquire_timed(microseconds, |us| self.acquire_timed(us, tid))?
+                    == RPY_LOCK_ACQUIRED;
+            }
+            Ok(r)
         }
 
         fn release(&self) -> Result<(), crate::PyError> {
             let ident = current_ident();
-            let mut state = self.state.lock();
+            let mut state = lock_state(&self.state);
             if state.count == 0 || state.owner != ident {
                 return Err(crate::PyError::runtime_error(
                     "cannot release un-acquired lock",
@@ -568,16 +703,16 @@ mod rlock_class {
         }
 
         fn locked(&self) -> bool {
-            self.state.lock().count != 0
+            lock_state(&self.state).count != 0
         }
 
         fn _is_owned(&self) -> bool {
-            let state = self.state.lock();
+            let state = lock_state(&self.state);
             state.count > 0 && state.owner == current_ident()
         }
 
         fn _recursion_count(&self) -> i64 {
-            let state = self.state.lock();
+            let state = lock_state(&self.state);
             if state.owner == current_ident() {
                 state.count
             } else {
@@ -586,7 +721,7 @@ mod rlock_class {
         }
 
         fn _release_save(&self) -> Result<PyObjectRef, crate::PyError> {
-            let mut state = self.state.lock();
+            let mut state = lock_state(&self.state);
             if state.count == 0 {
                 return Err(crate::PyError::runtime_error(
                     "cannot release un-acquired lock",
@@ -611,15 +746,13 @@ mod rlock_class {
             }
             let count = unsafe { w_int_get_value(items[0]) };
             let owner = unsafe { w_int_get_value(items[1]) };
-            let _blocked = before_external_block();
-            let mut state = self.state.lock();
-            if state.count != 0 {
-                while state.count != 0 {
-                    self.ready.wait(&mut state);
-                }
-            }
-            state.count = count;
-            state.owner = owner;
+            // os_lock.py:286-287 `self.lock.acquire(True)` reaches
+            // `RPyThreadAcquireLockTimed` with `intr_flag=0`
+            // (rthread.py:169-174), so an interrupted wait is retried rather
+            // than reported: restoring a saved state is not a place where a
+            // signal may be delivered.
+            while self.acquire_timed(-1, owner) != RPY_LOCK_ACQUIRED {}
+            lock_state(&self.state).count = count;
             Ok(())
         }
 
@@ -634,7 +767,7 @@ mod rlock_class {
         }
 
         fn __repr__(&self) -> String {
-            let state = self.state.lock();
+            let state = lock_state(&self.state);
             let locked = if state.count == 0 {
                 "unlocked"
             } else {

--- a/pyre/pyre-interpreter/src/module/thread/mod.rs
+++ b/pyre/pyre-interpreter/src/module/thread/mod.rs
@@ -395,7 +395,12 @@ fn parse_acquire_args(
     } else if timeout == -1.0 {
         Ok(-1)
     } else {
-        Ok((timeout * 1e6) as i64)
+        // `_PyTime_ROUND_TIMEOUT` rounds away from zero, both in
+        // `lock_acquire_parse_args`' seconds→ns step and in
+        // `_PyTime_AsMicroseconds`.  Truncating instead would collapse any
+        // positive sub-microsecond timeout to 0, which `acquire_timed` reads
+        // as a non-blocking poll rather than a timed wait.
+        Ok((timeout * 1e6).ceil() as i64)
     }
 }
 
@@ -1090,9 +1095,16 @@ mod local_class {
                     return Ok(self.last_dict);
                 }
             }
-            // `create_new_dict` runs app-level `__init__`, which reenters this
-            // method, so the cache lock is not held across the lookup.
-            let w_dict = match unsafe { pyre_object::w_dict_getitem(self.dicts, ident) } {
+            // `dicts` is mutated under `state_lock` by `create_new_dict` and
+            // `thread_is_stopping`, so the probe takes it too rather than
+            // reading the native dict beside a concurrent write.  The lock is
+            // released before `create_new_dict`, which runs app-level
+            // `__init__` and reenters this method.
+            let existing = {
+                let _guard = self.state_lock.lock();
+                unsafe { pyre_object::w_dict_getitem(self.dicts, ident) }
+            };
+            let w_dict = match existing {
                 Some(w_dict) => w_dict,
                 None => self.create_new_dict(ident)?,
             };

--- a/pyre/pyre-interpreter/src/module/thread/mod.rs
+++ b/pyre/pyre-interpreter/src/module/thread/mod.rs
@@ -980,6 +980,10 @@ mod local_class {
         initkwargs: PyObjectRef,
         last_dict: PyObjectRef,
         last_ident: i64,
+        /// Guards `dicts` and the `last_dict`/`last_ident` pair.  Upstream
+        /// keeps both unsynchronized — `os_local.py:36` "cache the last seen
+        /// dict, works because we are protected by the GIL" — which
+        /// free-threaded pyre cannot rely on.
         state_lock: Mutex<()>,
     }
 

--- a/pyre/pyre-interpreter/src/module/thread/mod.rs
+++ b/pyre/pyre-interpreter/src/module/thread/mod.rs
@@ -11,7 +11,11 @@ use std::sync::atomic::{AtomicBool, AtomicI64, AtomicUsize, Ordering};
 use std::sync::{LazyLock, OnceLock};
 use std::time::{Duration, Instant};
 
-const TIMEOUT_MAX: f64 = i64::MAX as f64 / 1_000_000.0;
+/// `_thread.TIMEOUT_MAX` — the whole-second bound of the nanosecond timestamp
+/// an acquire timeout is converted to.  PyPy exposes the microsecond bound
+/// instead (`moduledef.py:27` `float(os_lock.TIMEOUT_MAX // 1000000)`), which
+/// is a thousand times larger and is its 3.11-era surface.
+const TIMEOUT_MAX: f64 = (i64::MAX / 1_000_000_000) as f64;
 static THREAD_COUNT: AtomicI64 = AtomicI64::new(0);
 static STACK_SIZE: AtomicUsize = AtomicUsize::new(0);
 static FINALIZING: AtomicBool = AtomicBool::new(false);
@@ -339,6 +343,13 @@ fn lock_state<T>(mutex: &std::sync::Mutex<T>) -> std::sync::MutexGuard<'_, T> {
 /// `os_lock.py:23-40 parse_acquire_args`.  The result is the `microseconds`
 /// argument of the `RPyThreadAcquireLockTimed` ABI: negative blocks forever,
 /// zero polls once.
+///
+/// The argument is rejected the way `lock_acquire_parse_args` does in 3.14,
+/// which is stricter than `os_lock.py`: upstream converts the seconds straight
+/// to microseconds, while 3.14 first builds a nanosecond timestamp, so NaN and
+/// anything outside the nanosecond range are rejected before the microsecond
+/// bound is ever reached — and that bound, being a thousand times wider than
+/// the nanosecond one, is then unreachable and is not tested here.
 fn parse_acquire_args(
     blocking: i64,
     w_timeout: Option<PyObjectRef>,
@@ -352,6 +363,23 @@ fn parse_acquire_args(
         Some(w_timeout) => crate::baseobjspace::float_w(w_timeout)?,
         None => -1.0,
     };
+    // `_PyTime_FromSecondsObject(&timeout, timeout_obj, _PyTime_ROUND_TIMEOUT)`
+    // runs before either check below, so a value it cannot represent is
+    // reported even for a non-blocking call.
+    if timeout.is_nan() {
+        return Err(crate::PyError::value_error(
+            "Invalid value NaN (not a number)",
+        ));
+    }
+    // `rarithmetic.ovfcheck_float_to_longlong` bounds, the ones `time.sleep`
+    // converts its own argument against (`interp_time.rs:122-126`).
+    const NS_MIN: f64 = -9223372036854776832.0;
+    const NS_MAX: f64 = 9223372036854775296.0;
+    if !(NS_MIN..NS_MAX).contains(&(timeout * 1e9).ceil()) {
+        return Err(crate::PyError::overflow_error(
+            "timestamp out of range for platform time_t",
+        ));
+    }
     if !blocking && timeout != -1.0 {
         return Err(crate::PyError::value_error(
             "can't specify a timeout for a non-blocking call",
@@ -359,16 +387,13 @@ fn parse_acquire_args(
     }
     if timeout < 0.0 && timeout != -1.0 {
         return Err(crate::PyError::value_error(
-            "timeout value must be strictly positive",
+            "timeout value must be a non-negative number",
         ));
     }
     if !blocking {
         Ok(0)
     } else if timeout == -1.0 {
         Ok(-1)
-    } else if timeout > TIMEOUT_MAX {
-        // `ovfcheck_float_to_longlong(timeout * 1e6)`.
-        Err(crate::PyError::overflow_error("timeout value is too large"))
     } else {
         Ok((timeout * 1e6) as i64)
     }

--- a/pyre/pyre-interpreter/src/module/thread/mod.rs
+++ b/pyre/pyre-interpreter/src/module/thread/mod.rs
@@ -1017,17 +1017,33 @@ mod local_class {
                     call_args.extend(unsafe { w_tuple_items_copy_as_vec(self.initargs) });
                     self.call_init(w_init, &call_args)
                 });
-            let w_dict = pyre_object::gc_roots::shadow_stack_get(dict_slot);
-            drop(roots);
             if let Err(err) = result {
                 // failed, forget w_dict and propagate the exception
                 let key = w_int_new(ident);
                 let _guard = self.state_lock.lock();
                 unsafe { pyre_object::w_dict_delitem(self.dicts, key) };
+                // The initializer reached `current_dict` before it raised —
+                // assigning an instance attribute is what publishes the dict —
+                // so this thread's cache now names the entry just removed.
+                // Leaving it makes the next access return a half-initialized
+                // dict instead of rerunning `__init__`; `thread_is_stopping`
+                // drops the same pair alongside the same removal.
+                unsafe {
+                    if (*this).last_ident == ident {
+                        (*this).last_ident = 0;
+                        (*this).last_dict = PY_NULL;
+                    }
+                }
                 return Err(err);
             }
-            // ready
+            // ready.  `register_local_in_current_ec` allocates a weakref, so
+            // the dict stays rooted across it and is reloaded afterwards: it is
+            // still reachable through `self.dicts`, and a moving collection
+            // would relocate it there while this frame's copy kept the pre-move
+            // address for `current_dict` to cache and return.
             register_local_in_current_ec(obj);
+            let w_dict = pyre_object::gc_roots::shadow_stack_get(dict_slot);
+            drop(roots);
             Ok(w_dict)
         }
 
@@ -1137,12 +1153,9 @@ mod local_class {
             // os_local.py:23-38 `Local.__init__` installs the first dictionary
             // before app-level __init__ is entered, preventing recursive
             // initialization.
-            let initargs = w_tuple_new(positional.get(1..).unwrap_or(&[]).to_vec());
             let roots = pyre_object::gc_roots::push_roots();
             let cls_slot = pyre_object::gc_roots::shadow_stack_len();
             pyre_object::gc_roots::pin_root(cls);
-            let initargs_slot = pyre_object::gc_roots::shadow_stack_len();
-            pyre_object::gc_roots::pin_root(initargs);
             // A plain `_local()` has no keyword mapping, and a null takes no
             // shadow-stack slot.
             let initkwargs_slot = kwargs.map(|w_kwargs| {
@@ -1150,6 +1163,14 @@ mod local_class {
                 pyre_object::gc_roots::pin_root(w_kwargs);
                 slot
             });
+            // Pinned BEFORE the tuple is built: `w_tuple_new` allocates, and
+            // while it roots the elements it is given, `cls` and the keyword
+            // mapping are raw locals of this frame that a moving collection
+            // cannot update.  Pinning them afterwards would record evacuated
+            // addresses, so both are read back from their slots below.
+            let initargs = w_tuple_new(positional.get(1..).unwrap_or(&[]).to_vec());
+            let initargs_slot = pyre_object::gc_roots::shadow_stack_len();
+            pyre_object::gc_roots::pin_root(initargs);
             let dicts_slot = pyre_object::gc_roots::shadow_stack_len();
             let dicts = pyre_object::w_dict_new();
             pyre_object::gc_roots::pin_root(dicts);

--- a/pyre/pyre-interpreter/src/module/thread/mod.rs
+++ b/pyre/pyre-interpreter/src/module/thread/mod.rs
@@ -942,35 +942,123 @@ mod local_class {
     /// `self.dicts = {}` and keeping every per-ExecutionContext dictionary on the
     /// object's ordinary GC graph.  The integer key is pyre's stable identity for
     /// the current OS-thread ExecutionContext.
+    ///
+    /// `initargs` and `initkwargs` are `Local.__init__`'s `self.initargs`
+    /// (os_local.py:25).  Upstream keeps one `Arguments`; pyre's call surface
+    /// takes the positional and keyword halves separately, so they are stored as
+    /// the positional tuple and the construction call's keyword mapping (null
+    /// when it had none), and `create_new_dict` replays the call from both.
     #[crate::pyre_class("_thread._local")]
     pub struct W_Local {
         dicts: PyObjectRef,
+        initargs: PyObjectRef,
+        initkwargs: PyObjectRef,
         last_dict: PyObjectRef,
         last_ident: i64,
         state_lock: Mutex<()>,
     }
 
     impl W_Local {
-        pub(super) fn current_dict(&self) -> PyObjectRef {
-            let _guard = self.state_lock.lock();
+        /// `os_local.py:47-64 create_new_dict`.
+        fn create_new_dict(&self, ident: i64) -> Result<PyObjectRef, crate::PyError> {
             let this = self as *const Self as *mut Self;
-            let ident = current_ident();
-            if self.last_ident == ident && !self.last_dict.is_null() {
-                return self.last_dict;
+            let obj = this as PyObjectRef;
+            // create a new dict for this thread
+            let w_dict = pyre_object::w_dict_new();
+            let roots = pyre_object::gc_roots::push_roots();
+            pyre_object::gc_roots::pin_root(w_dict);
+            let dict_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+            // Published before the initializer runs: the `__init__` about to be
+            // entered reaches `getdict` again, and finding this entry is what
+            // stops it recursing back into `create_new_dict` (os_local.py:28-31).
+            {
+                let _guard = self.state_lock.lock();
+                unsafe { pyre_object::w_dict_setitem(self.dicts, ident, w_dict) };
             }
-            let w_dict =
-                unsafe { pyre_object::w_dict_getitem(self.dicts, ident) }.unwrap_or_else(|| {
-                    let w_dict = pyre_object::w_dict_new();
-                    unsafe { pyre_object::w_dict_setitem(self.dicts, ident, w_dict) };
-                    register_local_in_current_ec(self as *const Self as PyObjectRef);
-                    w_dict
+            // call __init__ — `space.call_obj_args(w_init, self, self.initargs)`.
+            // The argument pointers are copied out of the tuple only after the
+            // lookup, which can itself run Python: nothing between the copy and
+            // the callee rooting them allocates, so a collection cannot leave
+            // the copies naming pre-move addresses.
+            let result = crate::typedef::r#type(obj)
+                .ok_or_else(|| crate::PyError::type_error("_local instance has no type"))
+                .and_then(|w_type| crate::baseobjspace::getattr_str(w_type.as_ptr(), "__init__"))
+                .and_then(|w_init| {
+                    let mut call_args = vec![obj];
+                    call_args.extend(unsafe { w_tuple_items_copy_as_vec(self.initargs) });
+                    self.call_init(w_init, &call_args)
                 });
+            let w_dict = pyre_object::gc_roots::shadow_stack_get(dict_slot);
+            drop(roots);
+            if let Err(err) = result {
+                // failed, forget w_dict and propagate the exception
+                let key = w_int_new(ident);
+                let _guard = self.state_lock.lock();
+                unsafe { pyre_object::w_dict_delitem(self.dicts, key) };
+                return Err(err);
+            }
+            // ready
+            register_local_in_current_ec(obj);
+            Ok(w_dict)
+        }
+
+        /// The call itself of `os_local.py:57 space.call_obj_args(w_init, self,
+        /// self.initargs)`.  `args` is the instance followed by the stored
+        /// positional arguments; the stored keywords are bound by name.
+        ///
+        /// Upstream passes a single `Arguments` to `space.call_args`, which
+        /// binds keywords whatever the caller is.  Pyre splits that surface:
+        /// `call::call_with_kwargs` binds keywords but needs the running frame,
+        /// while the frame-less `call_function_impl_result` is positional only.
+        /// Reaching the frame through the execution context is the same
+        /// resolution `call::call_metaclass_with_kwargs` uses, down to falling
+        /// back to the positional call when there is no frame — a receiver only
+        /// reaches here from Python code, which always has one.
+        fn call_init(
+            &self,
+            w_init: PyObjectRef,
+            args: &[PyObjectRef],
+        ) -> Result<PyObjectRef, crate::PyError> {
+            let kwds = crate::builtins::builtin_kwarg_entries(
+                (!self.initkwargs.is_null()).then_some(self.initkwargs),
+            );
+            let frame = {
+                let ec = crate::call::getexecutioncontext() as *mut crate::PyExecutionContext;
+                if ec.is_null() {
+                    std::ptr::null_mut()
+                } else {
+                    unsafe { (*ec).gettopframe_raw() }
+                }
+            };
+            if kwds.is_empty() || frame.is_null() {
+                return crate::call::call_function_impl_result(w_init, args);
+            }
+            crate::call::call_with_kwargs(unsafe { &mut *frame }, w_init, args, &kwds)
+        }
+
+        /// `os_local.py:66-76 getdict`.
+        pub(super) fn current_dict(&self) -> Result<PyObjectRef, crate::PyError> {
+            let ident = current_ident();
+            {
+                let _guard = self.state_lock.lock();
+                if self.last_ident == ident && !self.last_dict.is_null() {
+                    return Ok(self.last_dict);
+                }
+            }
+            // `create_new_dict` runs app-level `__init__`, which reenters this
+            // method, so the cache lock is not held across the lookup.
+            let w_dict = match unsafe { pyre_object::w_dict_getitem(self.dicts, ident) } {
+                Some(w_dict) => w_dict,
+                None => self.create_new_dict(ident)?,
+            };
+            let this = self as *const Self as *mut Self;
+            let _guard = self.state_lock.lock();
             unsafe {
                 (*this).last_ident = ident;
                 (*this).last_dict = w_dict;
             }
             pyre_object::gc_hook::try_gc_write_barrier(this as *mut u8);
-            w_dict
+            Ok(w_dict)
         }
 
         pub(super) fn thread_is_stopping(&self, ident: i64) {
@@ -996,41 +1084,87 @@ mod local_class {
 
     #[crate::pyre_methods(doc = "Thread-local data", weakrefable)]
     impl W_Local {
+        /// `os_local.py:78-88 descr_local__new__`.
         #[staticmethod]
         fn __new__(cls: PyObjectRef, args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
             crate::typedef::check_user_subclass(type_object(), cls)?;
-            // os_local.py:81 rejects construction arguments before
-            // `allocate_instance`, and does so for every subtype that inherits
-            // `object.__init__` — not just for the exact type — so a refused
-            // construction never reaches `_register_in_ec` (os_local.py:40).
-            if args.len() > 1
-                && unsafe { crate::baseobjspace::lookup_where_class_uncached(cls, "__init__") }
-                    == Some(crate::typedef::w_object())
-            {
-                return Err(crate::PyError::type_error(
-                    "Initialization arguments are not supported",
-                ));
+            let (positional, kwargs) = crate::builtins::split_builtin_kwargs(args);
+            if positional.len() > 1 || crate::builtins::has_real_kwargs(kwargs) {
+                // Construction arguments are rejected by the initializer the
+                // subtype inherits, not by the requested type: a subclass that
+                // defines its own `__init__` consumes them, and
+                // `create_new_dict` replays that call on every further thread.
+                // os_local.py:81 runs this ahead of `allocate_instance`, so a
+                // refused construction never reaches `_register_in_ec`
+                // (os_local.py:40).
+                let w_parent_init = unsafe { crate::baseobjspace::lookup_where(cls, "__init__") }
+                    .map(|(w_where, _)| w_where);
+                if w_parent_init == Some(crate::typedef::w_object()) {
+                    return Err(crate::PyError::type_error(
+                        "Initialization arguments are not supported",
+                    ));
+                }
             }
-            // os_local.py installs the first dictionary before app-level
-            // __init__ is entered, preventing recursive initialization.
+            // os_local.py:23-38 `Local.__init__` installs the first dictionary
+            // before app-level __init__ is entered, preventing recursive
+            // initialization.
+            let initargs = w_tuple_new(positional.get(1..).unwrap_or(&[]).to_vec());
+            let roots = pyre_object::gc_roots::push_roots();
+            let cls_slot = pyre_object::gc_roots::shadow_stack_len();
+            pyre_object::gc_roots::pin_root(cls);
+            let initargs_slot = pyre_object::gc_roots::shadow_stack_len();
+            pyre_object::gc_roots::pin_root(initargs);
+            // A plain `_local()` has no keyword mapping, and a null takes no
+            // shadow-stack slot.
+            let initkwargs_slot = kwargs.map(|w_kwargs| {
+                let slot = pyre_object::gc_roots::shadow_stack_len();
+                pyre_object::gc_roots::pin_root(w_kwargs);
+                slot
+            });
+            let dicts_slot = pyre_object::gc_roots::shadow_stack_len();
             let dicts = pyre_object::w_dict_new();
+            pyre_object::gc_roots::pin_root(dicts);
+            let dict_slot = pyre_object::gc_roots::shadow_stack_len();
             let w_dict = pyre_object::w_dict_new();
+            pyre_object::gc_roots::pin_root(w_dict);
             let ident = current_ident();
-            unsafe { pyre_object::w_dict_setitem(dicts, ident, w_dict) };
+            unsafe {
+                pyre_object::w_dict_setitem(
+                    pyre_object::gc_roots::shadow_stack_get(dicts_slot),
+                    ident,
+                    pyre_object::gc_roots::shadow_stack_get(dict_slot),
+                )
+            };
+            // The object slots are filled after the allocation, from the
+            // shadow stack, so a collection triggered by `allocate_stable`
+            // cannot leave the fresh instance holding pre-move addresses.
             let obj = Self::allocate_stable(Self {
                 ob: PyObject::default(),
-                dicts,
-                last_dict: w_dict,
+                dicts: PY_NULL,
+                initargs: PY_NULL,
+                initkwargs: PY_NULL,
+                last_dict: PY_NULL,
                 last_ident: ident,
                 state_lock: parking_lot::const_mutex(()),
             });
-            unsafe { (*obj).w_class = cls };
+            unsafe {
+                let this = obj as *mut Self;
+                (*obj).w_class = pyre_object::gc_roots::shadow_stack_get(cls_slot);
+                (*this).dicts = pyre_object::gc_roots::shadow_stack_get(dicts_slot);
+                (*this).initargs = pyre_object::gc_roots::shadow_stack_get(initargs_slot);
+                (*this).initkwargs = initkwargs_slot
+                    .map(pyre_object::gc_roots::shadow_stack_get)
+                    .unwrap_or(PY_NULL);
+                (*this).last_dict = pyre_object::gc_roots::shadow_stack_get(dict_slot);
+            }
+            pyre_object::gc_hook::try_gc_write_barrier(obj as *mut u8);
+            drop(roots);
             register_local_in_current_ec(obj);
             Ok(obj)
         }
 
         #[getter]
-        fn __dict__(&self) -> PyObjectRef {
+        fn __dict__(&self) -> Result<PyObjectRef, crate::PyError> {
             self.current_dict()
         }
     }
@@ -1041,10 +1175,18 @@ fn local_type() -> PyObjectRef {
     local_class::type_object()
 }
 
-/// W_Root.getdict dispatch for `os_local.Local.getdict`.
-pub(crate) fn local_getdict(obj: PyObjectRef) -> Option<PyObjectRef> {
+/// W_Root.getdict dispatch for `os_local.Local.getdict`.  `None` means the
+/// receiver is not a `_local`; `Some(Err(..))` is the app-level `__init__` the
+/// first access from a thread runs (`os_local.py:73 create_new_dict`) raising.
+pub(crate) fn local_getdict(obj: PyObjectRef) -> Option<Result<PyObjectRef, crate::PyError>> {
     let local = W_Local::from_obj(obj)?;
     Some(local.current_dict())
+}
+
+/// True when `obj` is a `_thread._local`, the one receiver whose `getdict`
+/// runs app-level code.
+pub(crate) fn is_local(obj: PyObjectRef) -> bool {
+    W_Local::from_obj(obj).is_some()
 }
 
 /// `os_local.py:Local._register_in_ec`.

--- a/pyre/pyre-interpreter/src/module/unicodedata/mod.rs
+++ b/pyre/pyre-interpreter/src/module/unicodedata/mod.rs
@@ -327,7 +327,7 @@ crate::py_module! {
         let ucd_ty = crate::typedef::make_builtin_type("UCD", |_| {});
         unsafe { typeobject::w_type_set_hasdict(ucd_ty, true) };
         let ucd = w_instance_new(ucd_ty);
-        let d = crate::baseobjspace::getdict(ucd);
+        let d = crate::baseobjspace::getdict_native(ucd);
         let bind = |name: &'static str, func: crate::gateway::BuiltinCodeFn| {
             let f = crate::gateway::make_module_builtin_function(name, func);
             unsafe { w_dict_setitem_str(d, name, f) };

--- a/pyre/pyre-interpreter/src/module/winreg/mod.rs
+++ b/pyre/pyre-interpreter/src/module/winreg/mod.rs
@@ -139,7 +139,7 @@ mod imp {
     }
 
     fn store_handle(obj: PyObjectRef, raw: HKEY) {
-        let d = crate::baseobjspace::getdict(obj);
+        let d = crate::baseobjspace::getdict_native(obj);
         if !d.is_null() {
             unsafe { w_dict_setitem_str(d, "_handle", int_from_ptr(raw)) };
         }
@@ -165,7 +165,7 @@ mod imp {
     /// The stored `_handle` value, if `obj` is a `PyHKEY`.  `uint_w` reads both
     /// the small-int and long forms a handle pointer may take.
     fn stored_handle(obj: PyObjectRef) -> Option<HKEY> {
-        let d = crate::baseobjspace::getdict(obj);
+        let d = crate::baseobjspace::getdict_native(obj);
         if d.is_null() {
             return None;
         }

--- a/pyre/pyre-interpreter/src/module/zlib/mod.rs
+++ b/pyre/pyre-interpreter/src/module/zlib/mod.rs
@@ -31,7 +31,7 @@ fn next_id() -> u64 {
 }
 
 fn get_id(obj: PyObjectRef) -> u64 {
-    let d = crate::baseobjspace::getdict(obj);
+    let d = crate::baseobjspace::getdict_native(obj);
     if d.is_null() {
         return 0;
     }
@@ -42,7 +42,7 @@ fn get_id(obj: PyObjectRef) -> u64 {
 }
 
 fn set_id(obj: PyObjectRef, id: u64) {
-    let d = crate::baseobjspace::getdict(obj);
+    let d = crate::baseobjspace::getdict_native(obj);
     if !d.is_null() {
         unsafe { w_dict_setitem_str(d, "_id", w_int_new(id as i64)) };
     }

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -584,6 +584,14 @@ impl FrameBox {
             std::mem::size_of::<PyFrame>(),
         );
         if !raw.is_null() {
+            // RPython allocation results stay live in the translated shadow
+            // stack while the caller initializes their fields.  Free-threaded
+            // pyre must expose the same root before entering the write-barrier
+            // GC operation: a contended barrier is an entry safepoint, so an
+            // unrooted fresh frame could otherwise be swept by another
+            // collector between this allocation and the barrier below.
+            let frame_root = pyre_object::gc_roots::push_roots();
+            pyre_object::gc_roots::pin_root(raw as pyre_object::PyObjectRef);
             debug_assert!(pyre_object::gc_hook::try_gc_owns_object(
                 frame.locals_cells_stack_w as *mut u8
             ));
@@ -597,6 +605,7 @@ impl FrameBox {
             // tracer, exactly as `generator.rs:72` does for a stable
             // generator wrapping young frame contents.
             pyre_object::gc_hook::try_gc_write_barrier(raw);
+            drop(frame_root);
             return FrameBox { ptr };
         }
         debug_assert!(!pyre_object::gc_hook::try_gc_owns_object(
@@ -684,11 +693,12 @@ impl FrameBox {
         let frame_ptr = self.into_raw();
         // `w_generator_new` allocates and may trigger a collection. Until the
         // generator owns `frame_ptr` (and its custom trace greys the frame
-        // block), the frame's locals/args live only in its
-        // `locals_cells_stack_w` — the caller has already dropped them from
-        // its own stack — so root that slot across the allocation. The frame
-        // block is non-moving (old-gen when GC-managed, `std::alloc`
-        // otherwise), so only the locals array needs protecting.
+        // block), the frame is an RPython allocation result still live in the
+        // translated caller.  Publish both the managed frame itself and the
+        // locals slot (the latter also covers the std::alloc fallback frame)
+        // across that allocation.
+        let _frame_roots = pyre_object::gc_roots::push_roots();
+        pyre_object::gc_roots::pin_root(frame_ptr as pyre_object::PyObjectRef);
         let _root = FrameLocalsRoot::new(frame_ptr);
         // generator.py:21 `self.pycode = frame.pycode`: preserve the exact
         // code object independently of the frame, which is cleared when the
@@ -2746,6 +2756,13 @@ impl PyFrame {
         w_inputvalue: Option<PyObjectRef>,
         operr: Option<crate::PyError>,
     ) -> crate::PyResult {
+        // pyframe.py:360 `execute_frame.insert_stack_check_here = True`.
+        // RPython's transform inserts the check at this graph entry, so
+        // builtin/object-space calls remain usable while an existing frame is
+        // handling RecursionError and every newly entered Python frame is
+        // still guarded.
+        crate::stack_check::drain_jit_pending_exception()?;
+        crate::stack_check::stack_check()?;
         crate::eval::eval_frame_plain_with_resume(self, w_inputvalue, operr, None)
     }
 
@@ -2760,6 +2777,8 @@ impl PyFrame {
         operr: Option<crate::PyError>,
         throw_args: Option<([PyObjectRef; 3], usize)>,
     ) -> crate::PyResult {
+        crate::stack_check::drain_jit_pending_exception()?;
+        crate::stack_check::stack_check()?;
         crate::eval::eval_frame_plain_with_resume(self, w_inputvalue, operr, throw_args)
     }
 
@@ -4007,6 +4026,12 @@ pub fn createframe_obj(
     // cells) and stores the cells into `locals_cells_stack_w`; root the slot so
     // a collection mid-init can't drop the cells already written there.
     {
+        // The owned Rust `FrameBox` is not itself visible to the collector.
+        // RPython keeps the freshly allocated frame as a livevar across these
+        // initialization allocations, so expose the frame object alongside
+        // the separately registered locals-array field.
+        let _frame_roots = pyre_object::gc_roots::push_roots();
+        pyre_object::gc_roots::pin_root(frame.as_mut_ptr() as pyre_object::PyObjectRef);
         let _root = FrameLocalsRoot::new(frame.as_mut_ptr());
         frame.initialize_frame_scopes(outer_ref, code)?;
     }

--- a/pyre/pyre-interpreter/src/runtime_ops.rs
+++ b/pyre/pyre-interpreter/src/runtime_ops.rs
@@ -414,18 +414,12 @@ where
     FBuiltin: FnOnce(PyObjectRef) -> Result<R, PyError>,
     FUser: FnOnce(PyObjectRef) -> Result<R, PyError>,
 {
-    // Drain any pending JIT-prologue overflow first so a backend
-    // probe that already detected an overflow surfaces here as the
-    // user-visible RecursionError. The pending-exception slot is
-    // populated by the backend slowpath wrapper when the JIT
-    // prologue probe trips — backend raises, glue propagates
-    // (rpython/rlib/rstack.py:68-73 stack_check_slowpath parity).
+    // Drain any pending JIT-prologue overflow first so a backend probe that
+    // already detected an overflow surfaces here as the user-visible
+    // RecursionError.  A fresh check is performed only when a Python frame is
+    // entered (`PyFrame.execute_frame.insert_stack_check_here` in PyPy);
+    // builtin dispatch itself is not a recursive frame entry.
     crate::stack_check::drain_jit_pending_exception()?;
-    // rpython/rlib/rstack.py:42 stack_check(): every interpreter call
-    // boundary also checks the native stack synchronously, so deep
-    // interpreter recursion (no JIT involved) raises RecursionError
-    // instead of letting the OS abort on a guard-page hit.
-    crate::stack_check::stack_check()?;
     unsafe {
         if crate::is_function_carrier(callable) {
             // All callables are Function objects. Check code type to distinguish

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -1489,6 +1489,14 @@ pub fn w_object() -> PyObjectRef {
 /// `object`'s predicate accepts everything, since every receiver really is an
 /// `object`; listing it still rejects a *missing* receiver, which its methods
 /// would otherwise index straight off an empty argument slice.
+///
+/// Every builtin type gets an owner, whether or not a layout test is written
+/// for it: `d_type` is what names the descriptor in `descriptor 'x' of 'T'
+/// object needs an argument` and in the qualified name its arity errors
+/// report, and it is set for every entry of every `tp_methods` table.  A type
+/// missing from the table below takes an owner with no layout test — the
+/// receiver must be present, but a foreign one still reaches the
+/// implementation.
 fn method_owner(type_name: &str) -> Option<&'static crate::gateway::MethodOwner> {
     macro_rules! owners {
         ($($name:literal => $pred:path),+ $(,)?) => {
@@ -1496,11 +1504,11 @@ fn method_owner(type_name: &str) -> Option<&'static crate::gateway::MethodOwner>
                 $($name => {
                     static OWNER: crate::gateway::MethodOwner = crate::gateway::MethodOwner {
                         type_name: $name,
-                        is_instance: |obj| unsafe { $pred(obj) },
+                        is_instance: Some(|obj| unsafe { $pred(obj) }),
                     };
-                    Some(&OWNER)
+                    return Some(&OWNER);
                 })+
-                _ => None,
+                _ => {}
             }
         };
     }
@@ -1522,12 +1530,81 @@ fn method_owner(type_name: &str) -> Option<&'static crate::gateway::MethodOwner>
         "tuple" => pyre_object::is_tuple,
         "set" => pyre_object::is_set,
         "frozenset" => pyre_object::is_frozenset,
+        "set_iterator" => pyre_object::is_set_iterator,
         "range" => pyre_object::functional::is_w_range,
         "slice" => pyre_object::is_slice,
         "memoryview" => pyre_object::memoryview::is_w_memoryview,
         "type" => pyre_object::is_type,
         "object" => is_any_object,
         "BaseException" => pyre_object::interp_exceptions::is_exception,
+        // The `iter()` / `reversed()` products and the functional wrappers.
+        // Each reads its receiver's payload at its own layout, so an unchecked
+        // receiver reaches those accessors as type confusion — reproducibly a
+        // SIGSEGV for `type(iter(())).__length_hint__(None)`.
+        "iterator" => pyre_object::is_seq_iter,
+        "list_iterator" => pyre_object::is_list_iter,
+        "list_reverseiterator" => pyre_object::is_list_reverse_iter,
+        "tuple_iterator" => pyre_object::is_tuple_iter,
+        "range_iterator" => pyre_object::functional::is_range_iter,
+        "longrange_iterator" => pyre_object::is_long_range_iter,
+        "callable_iterator" => pyre_object::operation::is_callable_iterator,
+        "enumerate" => pyre_object::functional::is_enumerate,
+        "reversed" => pyre_object::functional::is_reversed,
+        "map" => pyre_object::functional::is_map,
+        "filter" => pyre_object::functional::is_filter,
+        "zip" => pyre_object::functional::is_zip,
+        "property" => pyre_object::descriptor::is_property,
+        "super" => pyre_object::descriptor::is_super,
+    }
+    Some(untested_method_owner(type_name))
+}
+
+/// The `MethodOwner` for a builtin type with no entry in the table above.
+/// Built once per type while the type is, and leaked: a `MethodOwner` lives as
+/// long as the interpreter, like the `PyMethodDef` tables it stands in for.
+fn untested_method_owner(type_name: &str) -> &'static crate::gateway::MethodOwner {
+    leaked_method_owner(type_name, None)
+}
+
+fn leaked_method_owner(
+    type_name: &str,
+    is_instance: Option<fn(PyObjectRef) -> bool>,
+) -> &'static crate::gateway::MethodOwner {
+    // Keyed by the layout test as well as the name: a type reached first
+    // through the shared constructors takes an owner with no test, and a
+    // later caller that does know the test must not be handed that one back.
+    static LEAKED: std::sync::Mutex<
+        Option<std::collections::HashMap<(String, bool), &'static crate::gateway::MethodOwner>>,
+    > = std::sync::Mutex::new(None);
+    let mut guard = LEAKED.lock().unwrap_or_else(|err| err.into_inner());
+    let table = guard.get_or_insert_with(std::collections::HashMap::new);
+    let key = (type_name.to_owned(), is_instance.is_some());
+    if let Some(owner) = table.get(&key) {
+        return owner;
+    }
+    let owner: &'static crate::gateway::MethodOwner =
+        Box::leak(Box::new(crate::gateway::MethodOwner {
+            type_name: Box::leak(type_name.to_owned().into_boxed_str()),
+            is_instance,
+        }));
+    table.insert(key, owner);
+    owner
+}
+
+/// Bind a builtin exception class's own methods to it.  The exception classes
+/// are built by their own factories rather than through the shared type
+/// constructors, and every one of them shares `BaseException`'s instance
+/// layout, so each takes that layout test under its own name — without it
+/// `ImportError.__reduce__(None)` reaches an accessor that reads a `NoneType`
+/// at the exception layout.
+pub(crate) fn stamp_exception_method_owners(cls: PyObjectRef, name: &str) {
+    let owner = leaked_method_owner(
+        name,
+        Some(|obj| unsafe { pyre_object::interp_exceptions::is_exception(obj) }),
+    );
+    let ns = unsafe { pyre_object::w_type_get_dict_ptr(cls) } as PyObjectRef;
+    if !ns.is_null() {
+        unsafe { stamp_method_owners(ns, owner) };
     }
 }
 
@@ -1578,6 +1655,25 @@ unsafe fn stamp_method_owners(ns: PyObjectRef, owner: &'static crate::gateway::M
             continue;
         }
         crate::gateway::builtin_code_set_owner(code, owner);
+    }
+}
+
+/// Bind one freshly built method descriptor to the type that defines it, for
+/// the bound methods `getattr` assembles outside a type namespace.  Without
+/// it those carry no owner and report their errors under the bare method name,
+/// where the namespace entry for the same method reports `type.name`.
+///
+/// # Safety
+/// `func` must be a valid, live function object.
+pub(crate) unsafe fn stamp_builtin_owner(func: PyObjectRef, type_name: &str) {
+    let Some(owner) = method_owner(type_name) else {
+        return;
+    };
+    unsafe {
+        let code = crate::function::getcode(func) as PyObjectRef;
+        if !code.is_null() && crate::gateway::is_builtin_code(code) {
+            crate::gateway::builtin_code_set_owner(code, owner);
+        }
     }
 }
 
@@ -1652,6 +1748,14 @@ fn new_root_typeobject(name: &str, init: fn(PyObjectRef)) -> PyObjectRef {
     let ns = pyre_object::w_dict_new();
     pyre_object::gc_roots::pin_root(ns);
     init(ns);
+    // `object`'s own methods are descriptors of `object` just like every other
+    // builtin type's, so they are bound here too: their receiver test accepts
+    // any instance, but the binding is what supplies the qualified name their
+    // receiver and arity errors report.
+    if let Some(owner) = method_owner(name) {
+        let ns = pyre_object::gc_roots::shadow_stack_get(ns_slot);
+        unsafe { stamp_method_owners(ns, owner) };
+    }
     let ns = pyre_object::gc_roots::shadow_stack_get(ns_slot);
     let type_obj = w_type_new_builtin(
         name,

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -11573,7 +11573,7 @@ fn init_member_descriptor_type(ns: PyObjectRef) {
                 let found = if unsafe { pyre_object::is_instance(obj) } {
                     unsafe { crate::objspace::std::mapdict::getslotvalue(obj, index) }
                 } else {
-                    crate::baseobjspace::native_slot_get(obj, slot_name, index)
+                    crate::baseobjspace::native_slot_get(obj, slot_name, index)?
                 };
                 match found {
                     Some(v) => Ok(v),
@@ -11626,7 +11626,7 @@ fn init_member_descriptor_type(ns: PyObjectRef) {
                     unsafe { crate::objspace::std::mapdict::setslotvalue(obj, index, value) };
                 } else {
                     let slot_name = unsafe { pyre_object::w_member_get_name(descr) };
-                    if !crate::baseobjspace::native_slot_set(obj, slot_name, index, value) {
+                    if !crate::baseobjspace::native_slot_set(obj, slot_name, index, value)? {
                         return Err(crate::PyError::new(
                             crate::PyErrorKind::AttributeError,
                             format!(
@@ -11677,7 +11677,7 @@ fn init_member_descriptor_type(ns: PyObjectRef) {
                 let removed = if unsafe { pyre_object::is_instance(obj) } {
                     unsafe { crate::objspace::std::mapdict::delslotvalue(obj, index) }
                 } else {
-                    crate::baseobjspace::native_slot_del(obj, slot_name, index)
+                    crate::baseobjspace::native_slot_del(obj, slot_name, index)?
                 };
                 if !removed {
                     return Err(crate::PyError::new(
@@ -23406,7 +23406,7 @@ fn descr_get_dict(
 ) -> Result<pyre_object::PyObjectRef, crate::PyError> {
     let _closure = args[0];
     let w_obj = args[1];
-    let w_dict = crate::baseobjspace::getdict(w_obj);
+    let w_dict = crate::baseobjspace::getdict(w_obj)?;
     if w_dict.is_null() {
         let tp_name = unsafe { pyre_object::type_name_of(w_obj) };
         return Err(crate::PyError::type_error(format!(

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -1682,6 +1682,17 @@ fn try_adopt_single_frame_blackhole(ctx: &mut TraceCtx, cf_addr: usize) -> bool 
 }
 
 fn try_adopt_multi_frame_blackhole(ctx: &mut TraceCtx, cf_addr: usize) -> bool {
+    // Every arm below returns to the legacy escape/replay path.  Name each one
+    // under `PYRE_FBW_DEBUG_ABORT`, the way `build_multi_frame_miframe`'s
+    // `s2dbg!` names its own: a silent decline is indistinguishable from the
+    // adopt never being reached, and the two want different fixes.
+    macro_rules! mfdbg {
+        ($($a:tt)*) => {
+            if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
+                eprintln!("[s2-adopt-decline] {}", format!($($a)*));
+            }
+        };
+    }
     let Some(mut latched) = crate::jitcode_dispatch::take_multi_frame_blackhole() else {
         return false;
     };
@@ -1691,9 +1702,11 @@ fn try_adopt_multi_frame_blackhole(ctx: &mut TraceCtx, cf_addr: usize) -> bool {
         .map(std::sync::Arc::as_ptr)
         .unwrap_or(std::ptr::null());
     if virtualizable_info.is_null() {
+        mfdbg!("no virtualizable_info");
         return false;
     }
     let Some(stack_base) = crate::state::concrete_nlocals(cf_addr) else {
+        mfdbg!("cf_addr {cf_addr:#x} has no concrete nlocals");
         return false;
     };
     // Recover each level's concrete PyFrame ptr and its own fastlocals base.
@@ -1704,21 +1717,29 @@ fn try_adopt_multi_frame_blackhole(ctx: &mut TraceCtx, cf_addr: usize) -> bool {
     // into — that intermediate frame.  Any level whose frame register is not
     // a concrete PyFrame declines the adopt (legacy replay handles it).
     let mut per_frame: Vec<(i64, usize)> = Vec::with_capacity(latched.framestack.frames.len());
-    for frame in &latched.framestack.frames {
+    for (index, frame) in latched.framestack.frames.iter().enumerate() {
         let Ok(jitcode_index) = i32::try_from(frame.jitcode.index()) else {
+            mfdbg!(
+                "frame {index}: jitcode index {} out of range",
+                frame.jitcode.index()
+            );
             return false;
         };
         let frame_reg = crate::state::portal_red_regs_at(jitcode_index).0;
         if frame_reg == u16::MAX {
+            mfdbg!("frame {index}: jitcode {jitcode_index} has no portal frame reg");
             return false;
         }
         let Some(frame_ptr) = frame.ref_values.get(frame_reg as usize).copied().flatten() else {
+            mfdbg!("frame {index}: reg {frame_reg} unstamped");
             return false;
         };
         if frame_ptr == 0 {
+            mfdbg!("frame {index}: reg {frame_reg} is null");
             return false;
         }
         let Some(frame_stack_base) = crate::state::concrete_nlocals(frame_ptr as usize) else {
+            mfdbg!("frame {index}: {frame_ptr:#x} has no concrete nlocals");
             return false;
         };
         per_frame.push((frame_ptr, frame_stack_base));
@@ -1737,6 +1758,11 @@ fn try_adopt_multi_frame_blackhole(ctx: &mut TraceCtx, cf_addr: usize) -> bool {
     // the `jit.virtual_ref` emit at the inline push, so decline to legacy
     // replay until then.
     if per_frame.first().map(|&(frame_ptr, _)| frame_ptr) != Some(cf_addr as i64) {
+        mfdbg!(
+            "chain rooted at {:#x}, not the walked frame {cf_addr:#x} (needs the \
+             virtual_ref emit at the inline push)",
+            per_frame.first().map(|&(p, _)| p).unwrap_or(0),
+        );
         return false;
     }
     // `ExecutionContext::enter` parity for the resumed chain:
@@ -1806,10 +1832,12 @@ fn try_adopt_multi_frame_blackhole(ctx: &mut TraceCtx, cf_addr: usize) -> bool {
             ref green_int, ..
         } => {
             let Some(&resume_py_pc) = green_int.first() else {
+                mfdbg!("ContinueRunningNormally with no green int");
                 return false;
             };
             let resume_py_pc = resume_py_pc as usize;
             if cf_addr == 0 || resume_py_pc == 0 {
+                mfdbg!("cf_addr {cf_addr:#x} / resume_py_pc {resume_py_pc} is zero");
                 return false;
             }
             // The terminal frame's own `setfield_vable` operations committed
@@ -1818,9 +1846,14 @@ fn try_adopt_multi_frame_blackhole(ctx: &mut TraceCtx, cf_addr: usize) -> bool {
             // the same live-slot materialization the single-frame path
             // performs.
             let Some(terminal) = mf_terminal.as_mut() else {
+                mfdbg!("no terminal image for the ContinueRunningNormally handoff");
                 return false;
             };
             let Ok(terminal_jitcode_index) = i32::try_from(terminal.jitcode_index) else {
+                mfdbg!(
+                    "terminal jitcode index {} out of range",
+                    terminal.jitcode_index
+                );
                 return false;
             };
             if !apply_blackhole_crn(
@@ -1833,6 +1866,7 @@ fn try_adopt_multi_frame_blackhole(ctx: &mut TraceCtx, cf_addr: usize) -> bool {
                 &terminal.registers_f,
                 resume_py_pc,
             ) {
+                mfdbg!("apply_blackhole_crn rejected the terminal image");
                 return false;
             }
             WALK_END_RESTART_PC.with(|slot| slot.set(Some(resume_py_pc)));

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -1757,6 +1757,21 @@ fn try_adopt_multi_frame_blackhole(ctx: &mut TraceCtx, cf_addr: usize) -> bool {
     // one and shifts every `_getframe` result up a level.  Closing this needs
     // the `jit.virtual_ref` emit at the inline push, so decline to legacy
     // replay until then.
+    //
+    // Measured by driving the chain with this check lifted, over the
+    // `getframe_inline_subwalk_multiframe` shape: the shift is exactly one
+    // level and it is silent.  A `sys._getframe(2)` meant for the walked frame
+    // lands on the module frame instead, so the same run returns a wrong
+    // integer rather than failing — `f_locals["base"]` raises `KeyError`,
+    // `f_locals.get("base", -1)` scores -1 for 7, `len(f_locals)` scores the
+    // module globals' 12 for the walked frame's 3, and
+    // `len(f_code.co_name)` scores `<module>`'s 8 for `main_loop`'s 9.  The
+    // check is therefore load-bearing for EVERY outcome arm, not only the
+    // `ContinueRunningNormally` one that consumes a `cf_addr` coordinate:
+    // `DoneWithThisFrame*` and `ExitFrameWithExceptionRef` hand back a value
+    // the chain computed off the wrong frame.  It also has to stay AHEAD of
+    // the drive — declining afterwards returns to a legacy replay that
+    // re-executes what the chain already committed.
     mfdbg!(
         "chain cf_addr={cf_addr:#x} levels=[{}]",
         per_frame

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -1859,8 +1859,15 @@ fn try_adopt_multi_frame_blackhole(ctx: &mut TraceCtx, cf_addr: usize) -> bool {
                 return false;
             };
             let resume_py_pc = resume_py_pc as usize;
-            if cf_addr == 0 || resume_py_pc == 0 {
-                mfdbg!("cf_addr {cf_addr:#x} / resume_py_pc {resume_py_pc} is zero");
+            // Only the frame address is checked.  `resume_py_pc` is a
+            // `depth_at_py_pc` index written through to
+            // `frame.last_instr = resume_py_pc - 1`, so 0 is an ordinary
+            // coordinate — the single-frame arm hands it to
+            // `apply_blackhole_crn` unfiltered.  Rejecting it here would also
+            // decline *after* the chain has been driven, returning to a legacy
+            // replay that re-executes what the chain already committed.
+            if cf_addr == 0 {
+                mfdbg!("cf_addr {cf_addr:#x} is zero");
                 return false;
             }
             // The terminal frame's own `setfield_vable` operations committed

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -1757,6 +1757,14 @@ fn try_adopt_multi_frame_blackhole(ctx: &mut TraceCtx, cf_addr: usize) -> bool {
     // one and shifts every `_getframe` result up a level.  Closing this needs
     // the `jit.virtual_ref` emit at the inline push, so decline to legacy
     // replay until then.
+    mfdbg!(
+        "chain cf_addr={cf_addr:#x} levels=[{}]",
+        per_frame
+            .iter()
+            .map(|&(p, b)| format!("{p:#x}/nl{b}"))
+            .collect::<Vec<_>>()
+            .join(", "),
+    );
     if per_frame.first().map(|&(frame_ptr, _)| frame_ptr) != Some(cf_addr as i64) {
         mfdbg!(
             "chain rooted at {:#x}, not the walked frame {cf_addr:#x} (needs the \

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -4835,6 +4835,12 @@ fn stack_almost_full() -> bool {
 ///
 /// This is the main entry point for pyre-jit.
 pub fn eval_with_jit(frame: &mut PyFrame) -> PyResult {
+    // pypy/interpreter/pyframe.py:360 marks execute_frame as a stack-check
+    // entry.  The portal runner is pyre's JIT-aware execution entry for the
+    // same frame and must perform the interpreter-side check before compiled
+    // code exists; compiled callees additionally carry the backend prologue.
+    pyre_interpreter::stack_check::drain_jit_pending_exception()?;
+    pyre_interpreter::stack_check::stack_check()?;
     eval_with_jit_inner(frame)
 }
 

--- a/pyre/pyre-object/src/gc_roots.rs
+++ b/pyre/pyre-object/src/gc_roots.rs
@@ -129,13 +129,25 @@ pub fn push_roots() -> RootScope {
 /// it (`@dont_look_inside`, `rlib/jit.py:139`), the `shadow_stack_len` twin.
 #[majit_macros::dont_look_inside]
 pub fn pin_root(root: PyObjectRef) {
+    // Publish the raw value first.  `try_gc_current_object_address` is itself
+    // a GC operation and may wait behind another thread's collection; the
+    // fresh allocation must already be visible to that collector before we
+    // enter the query safepoint.  RPython's push_roots writes the livevar to
+    // the shadow stack before calling the allocation/GC slow path for the
+    // same reason.
+    let index = SHADOW_STACK.with(|s| {
+        let mut stack = s.borrow_mut();
+        let index = stack.len();
+        stack.push(root);
+        index
+    });
     // A foreign mutator may have completed a nursery collection after the
     // caller copied this GCREF but before it entered this explicit root
     // bracket.  RPython's `_trace_drag_out` always rewrites a root that names
     // an already-forwarded nursery object; normalize the host-side copy at
     // the same boundary so the shadow stack never gains a forwarding stub.
     let root = crate::gc_hook::try_gc_current_object_address(root as *mut u8) as PyObjectRef;
-    SHADOW_STACK.with(|s| s.borrow_mut().push(root));
+    SHADOW_STACK.with(|s| s.borrow_mut()[index] = root);
 }
 
 /// Current length of the thread-local shadow stack. Used by

--- a/pyre/pyre-object/src/memoryview.rs
+++ b/pyre/pyre-object/src/memoryview.rs
@@ -244,19 +244,34 @@ pub unsafe fn w_memoryview_owns_export(obj: PyObjectRef) -> bool {
     unsafe { (*(obj as *const W_MemoryView)).owns_export }
 }
 
-/// Release the view: drop the off-heap `BufferView` box (reclaiming any
-/// nested `Buffer::Sub` boxes through `Box`'s recursive drop glue) and null
-/// `view`, then flip `released`.  Mirrors `descr_release` clearing
-/// `self.view = None` (`memoryobject.py`) so the backing / view graph is
-/// dropped eagerly on release rather than lingering until the header is
-/// GC-collected.  Idempotent: a second call finds `view` already null.  The
-/// `released` flag is an inline scalar, so no write barrier is needed (a
-/// barrier guards `PyObjectRef` stores only).
+/// Flip `released` without touching the view box, so a re-entrant `release()`
+/// is already a no-op while the view is still readable.  The exporter's
+/// `__release_buffer__` runs in exactly that window: it is handed this
+/// memoryview and reads its backing to identify the export it is undoing.
+/// The flag is an inline scalar, so no write barrier is needed (a barrier
+/// guards `PyObjectRef` stores only).
 ///
 /// # Safety
 /// `obj` must point to a valid `W_MemoryView`.
 #[inline]
-pub unsafe fn w_memoryview_set_released(obj: PyObjectRef) {
+pub unsafe fn w_memoryview_mark_released(obj: PyObjectRef) {
+    unsafe {
+        (*(obj as *mut W_MemoryView)).released = true;
+    }
+}
+
+/// Drop the off-heap `BufferView` box (reclaiming any nested `Buffer::Sub`
+/// boxes through `Box`'s recursive drop glue) and null `view`.  Mirrors
+/// `descr_release` clearing `self.view = None` (`memoryobject.py`) so the
+/// backing / view graph is dropped eagerly on release rather than lingering
+/// until the header is GC-collected.  Idempotent: a second call finds `view`
+/// already null.
+///
+/// # Safety
+/// `obj` must point to a valid `W_MemoryView`, and no borrow handed out by
+/// [`w_memoryview_view`] may outlive this call.
+#[inline]
+pub unsafe fn w_memoryview_drop_view(obj: PyObjectRef) {
     unsafe {
         let mv = obj as *mut W_MemoryView;
         let view_ptr = (*mv).view as *mut BufferView;
@@ -264,7 +279,19 @@ pub unsafe fn w_memoryview_set_released(obj: PyObjectRef) {
             drop(Box::from_raw(view_ptr));
             (*mv).view = std::ptr::null();
         }
-        (*mv).released = true;
+    }
+}
+
+/// Release the view: flip `released` and drop the view box together, for the
+/// paths that run no exporter callback in between.
+///
+/// # Safety
+/// `obj` must point to a valid `W_MemoryView`.
+#[inline]
+pub unsafe fn w_memoryview_set_released(obj: PyObjectRef) {
+    unsafe {
+        w_memoryview_mark_released(obj);
+        w_memoryview_drop_view(obj);
     }
 }
 

--- a/pyre/pyre-object/src/specialisedtupleobject.rs
+++ b/pyre/pyre-object/src/specialisedtupleobject.rs
@@ -176,6 +176,7 @@ pub fn w_specialised_tuple_oo_new(value0: PyObjectRef, value1: PyObjectRef) -> P
     // potential collection inside `try_gc_alloc_stable`. The ii/ff
     // variants take unboxed i64/f64 and need no bracket here.
     let _roots = crate::gc_roots::push_roots();
+    let save_point = crate::gc_roots::shadow_stack_len();
     crate::gc_roots::pin_root(value0);
     crate::gc_roots::pin_root(value1);
 
@@ -187,6 +188,11 @@ pub fn w_specialised_tuple_oo_new(value0: PyObjectRef, value1: PyObjectRef) -> P
         SPECIALISED_TUPLE_OO_GC_TYPE_ID,
         SPECIALISED_TUPLE_OO_OBJECT_SIZE,
     );
+    // pop_roots: the parameters still name the pre-collection addresses, so
+    // the values stored into the tuple are read back out of the shadow stack,
+    // as `w_tuple_new_array_backed` does before filling its items block.
+    let value0 = crate::gc_roots::shadow_stack_get(save_point);
+    let value1 = crate::gc_roots::shadow_stack_get(save_point + 1);
     if !raw.is_null() {
         unsafe {
             std::ptr::write(

--- a/pyre/pyrex/src/lib.rs
+++ b/pyre/pyrex/src/lib.rs
@@ -496,14 +496,6 @@ fn real_main(binary_name: &str) {
     }
 
     if !is_interact {
-        // pypy/interpreter/app_main.py:824-825 parity for the standalone
-        // launcher: untranslated hosts need a higher startup recursion limit
-        // than translated PyPy's default 1000 because each host-language
-        // frame is larger. Pyre is likewise running on Rust frames here, so
-        // raise the startup budget before executing user code.
-        pyre_interpreter::stack_check::set_recursion_limit(5000)
-            .expect("startup recursion limit must be applicable");
-
         // Eagerly install pyre-jit's hooks into pyre-interpreter so that
         // sys.settrace / set_jit_param routing is live from the very first
         // user statement, not only after the first JIT-traced bytecode.


### PR DESCRIPTION
Closes the two remaining items of the Codex parity review §2 on #784.

## `_thread._local` creation semantics (`os_local.py:47-88`)

`W_Local.current_dict` created and returned a new per-thread dict directly.
`create_new_dict` instead re-calls the local subclass's `__init__` with the
original construction arguments and removes the dict again if the initializer
raises.

The object now stores those arguments. Upstream keeps one `Arguments`; pyre's
call surface takes the positional and keyword halves separately, so they are
held as the positional tuple and the keyword mapping and the call is replayed
from both. Keyword binding goes through `call::call_with_kwargs` with the frame
taken from the execution context, as `call::call_metaclass_with_kwargs` does —
the frame-less call entry is positional only and would bind the `__pyre_kw__`
marker dict as a value.

Because the initializer can raise, `getdict` becomes fallible, along with
`getdict_backing`, `native_slot_get/set/del` and `setdictvalue`. Call sites
whose receiver is structurally never a `_local` — native payload objects,
exceptions, structseq — go through `getdict_native` / `getdict_backing_native`
/ `setdictvalue_native`, which assert that in debug builds. The JIT dict-fold
precondition declines a `_local` receiver outright rather than run app-level
code.

`__new__` rejects construction arguments based on the initializer the subtype
inherits (`os_local.py:78-88`) rather than on the requested type.

## Signal handling in a blocking lock acquire (`os_lock.py:23-60`)

`Lock.acquire` and `RLock.acquire` waited on a `parking_lot` condition
variable until release or timeout. That wait retries internally on spurious
wakeups, so the wakeup a signal handler produces never surfaced and a blocking
acquire could not be interrupted.

`parse_acquire_args` and `acquire_timed` are ported, and both locks' native
wait is shaped after `thread_pthread.c:427-485 RPyThreadAcquireLockTimed` in
its mutex and condition-variable build with `intr_flag=1`
(`rthread.py:192-197`): a wait that returns with the lock still held reports
`RPY_LOCK_INTR`, and the caller then runs pending signal handlers and retries
with the time that is left. Both lock classes move to `std::sync::Condvar`,
whose `wait` is the single `pthread_cond_wait` that propagates such a wakeup.

RLock claims ownership under the mutex the wait releases, because pyre has no
GIL serializing `rlock_count`/`rlock_owner`. `_acquire_restore` keeps the
non-interruptible retry that `rthread.py:169-174` gives `lock.acquire(True)`.
The `before_external_block()` guard ends with the native primitive, so the
signal handlers run back inside the collector's RUNNING census.
## Acquire timeout validation against Python 3.14

`_thread.TIMEOUT_MAX` was the microsecond bound PyPy exposes
(`moduledef.py:27` `float(os_lock.TIMEOUT_MAX // 1000000)`), a thousand times
wider than 3.14's, and `parse_acquire_args` carried `os_lock.py`'s wording for a
rejected timeout.

3.14's `lock_acquire_parse_args` converts the argument to a nanosecond timestamp
before either the blocking or the sign check, so NaN and anything outside the
nanosecond range are reported first, and for a non-blocking call too.
`TIMEOUT_MAX` becomes the whole-second bound of a nanosecond timestamp, the
conversion is checked against the `ovfcheck_float_to_longlong` bounds
`time.sleep` already converts against, and the messages become the 3.14 ones.

The microsecond bound `os_lock.py:36-39` tests is unreachable behind the
nanosecond one and is dropped rather than kept as a check that would reject the
accepted fractional tail between 9223372036.0 and 9223372036.854.

A NaN timeout was accepted and polled once, the float converting to zero
microseconds; it now raises.

`extra_tests/snippets/builtin_thread.py` has asserted the 3.14 `TIMEOUT_MAX`
since 547175e2de7 and had been failing on pyre ever since; it passes again.
## Rooting fresh allocations across the GC operations that can block

A contended `gc_op` takes the mutator out of the RUNNING census before it
acquires `gc_mutex`, so that wait is an entry safepoint: another thread's
collector runs there and a moving minor can forward or sweep an object held only
by a Rust local. `gc_op_with_root` publishes the argument on the per-mutator
shadow stack first and reloads the possibly forwarded value once the operation
owns the GC; `write_barrier`, `jit_remember_young_pointer_from_array` and
`remember_young_pointer_from_array2` go through it, as do the cranelift and
dynasm barrier trampolines.

`pin_root` had the same hole in the other direction — it queried
`try_gc_current_object_address`, itself a GC operation, *before* publishing the
raw value. `push_roots` writes the livevar to the shadow stack before entering
the allocation slow path; frame allocation gets the same treatment, so the fresh
frame is rooted across its initialization allocations and the barrier.

Major collection rescans non-stack roots before finalizers, weakrefs and sweep
(`incminimark.py:2478-2481`), because those roots can grow after the cycle's
initial snapshot while marking is incremental. Thread frame and shadow-stack
roots are deliberately not repeated — upstream repeats only
`collect_nonstack_roots`, not `collect_roots`.

The recursion check moves from the launcher's startup `set_recursion_limit(5000)`
to frame entry, per `pyframe.py:360 execute_frame.insert_stack_check_here`.

## `winreg`: read the handle dict through the infallible accessor

The fallible-`getdict` cascade above reached one windows-only call site.
`store_handle`/`stored_handle` hold a `_handle` on a native payload object whose
receiver is structurally never a `_local`, so they take `getdict_native`. This is
what broke `prepare Charon/LLBC (windows-latest)` — the only windows-gated module
in the tree is `winreg` (`module/mod.rs:109-110`), and it was the only place the
new `Result` reached uncovered.

## `bench`: two synth workloads sized above PyPy's startup

Unrelated to the above; it rides here because it is what makes this PR's own CI
readable.

`check.py` gates on execution-only time, so the ratio's denominator is PyPy's run
time minus its *measured* empty-program startup (`check.py:713-725`, floored at
`EXEC_TIME_FLOOR_S = 0.005`). Both `synth/inlined_helper_arith_hot` and
`synth/residual_raise_except_resume` finished near that startup — PyPy's whole
`residual_raise_except_resume` run was shorter than its own startup — so the
denominator was the residue of two similar measurements and the gate silently
degenerated into an absolute wall-clock wall that tracks runner speed. The same
unchanged code reported 6.3x/8.9x locally against 19.8x/21.8x on a CI runner.

Raising N to 4000000 and 20000000 puts PyPy's execution-only time at 43ms and
38ms against a 10ms startup. The ratios become 2.5x/2.8x and 2.1x/2.1x against
gates of 12 and 10, and they agree between a standalone harness and `check.py`.
Output stays byte-identical across CPython 3.14, PyPy, dynasm and cranelift at
the new N.

## `jit(fbw)`: the multi-frame adopt declines are now named

Unrelated to the `_thread` work above; it rides here because the branch is
shared.

`try_adopt_multi_frame_blackhole` returned false from seven places without
recording which, so a decline read the same as the adopt never being reached.
Each now reports under `PYRE_FBW_DEBUG_ABORT` as `[s2-adopt-decline]`, the way
`build_multi_frame_miframe` already reports its own.

What that measured, under `PYRE_FBW_MULTIFRAME=1`: the image builds
(`BUILT multi-frame depth=2`) and every adopt is then declined at
`per_frame.first() != cf_addr`, the arm whose comment names the missing
`jit.virtual_ref` emit at the inline push (`executioncontext.py:89`). The
frames are not missing — the `per_frame` loop requires a concrete `PyFrame`
for every level and passes. A level entered through a residual call has one
because the interpreter's call sequence ran; an inlined level has none; the
chain that mixes them roots at the intermediate residual frame.

`bench/synth/getframe_inline_subwalk_multiframe.py` is the first fixture that
reaches the build. Sweeping the other 310 synth fixtures reaches it zero times
and #763 added none. One `sys._getframe(1)` level does not suffice: the chain
needs a residual level under the walked frame and an inlined level under that.
It carries no `max-pypy-ratio` header, so it is an output check only, and its
output matches CPython 3.14.

No behaviour changes: the new reporting is debug-gated and the fixture is new.
## Verification

Run on this branch's current base (`origin/main` at `3add72aff7`), after
re-extracting LLBC for all three crates — the peer rebase moved
`pyre-interpreter` and `pyre-jit`, so the previous artefacts were stale:

- `cargo fmt --all -- --check` — clean
- `python3 pyre/scripts/extract-llbc.py` — all three crates plus the
  `wasm32-unknown-unknown` layout artefacts, before the build
- `python3 pyre/check.py` — dynasm 330/330, cranelift 330/330, wasm 327/327
- `pyre/extra_tests/parity_tests/run.py` with `PYRE_CHECK_PYTHON3` pointed at
  CPython 3.14 — `thread_local_and_lock_acquire.py` is `OK` on CPython 3.14,
  pyre-dynasm and pyre-cranelift

`cargo test` is left to CI rather than quoted from an earlier base.

Interruptibility was measured against CPython 3.14: a `lock.acquire()` and an
`RLock.acquire()` blocked on another thread both raise `KeyboardInterrupt` after
the signal, which this branch now matches. That measurement is macOS-only — see
the open item below.

## CI

Three failures were reported on the previous head. Their causes are distinct:

- **`prepare Charon/LLBC (windows-latest)`** — a real break introduced here, from
  the fallible-`getdict` cascade reaching `winreg`. Fixed; the job passes.
- **wasm `fib_loop` and `synth/binary_int_overflow_local_resume` wrong output** —
  pre-existing, not from this branch: a `main` run at the same base carried the
  identical two. Resolved by `a527e14dcb` (#813), which the current base
  includes.
- **`cranelift int_loop`, `synth/inlined_helper_arith_hot`** — perf gates. The
  second is the denominator artifact fixed above.

`cranelift int_loop` is left alone deliberately. It is not a flake in the ratio;
the ratio is stable and the gate value simply coincides with it:

| run | dynasm | cranelift | verdict |
|---|---|---|---|
| `main` @ `3add72aff7` | 1.1x | 2.0x | passed (gate is 2x) |
| `main` @ `1dd5b4c36e` | 1.1x | 2.3x | failed |
| `main` @ `a527e14dcb` | — | 2.1x | failed |
| this PR @ `4be25562b6` | — | 2.1x | failed |
| local aarch64 | 1.3x | 1.1x | passed |

So dynasm-x64 and cranelift-aarch64 both sit at 1.1x while cranelift-x64 is a
steady 2.0-2.3x — an x86_64-only backend gap that is present on `main` and is not
attributable to this branch. Compiling this trace's CLIF offline for both ISAs
with the backend's own flags does not explain it (x86_64 is +10% code size and
+18% reg-to-reg moves, with an identical 34 pinned-register copies and no spills),
so the register-pressure reading of the `preserve_frame_pointers` +
`enable_pinned_reg` pair is refuted; that flag also cannot simply be dropped,
because cranelift 0.132.3 asserts it inside `emit_return_call_common_sequence`
(`isa/x64/inst/emit.rs:1874`) and every trace body reaches that path through
`return_call_indirect`. Root-causing it needs profiling on an x86_64 host.

## Open

The blocking-acquire signal delivery is verified on Darwin only. On Linux glibc
retries the futex inside `pthread_cond_wait`, so `std::sync::Condvar` does not
propagate the interrupt there either; converging needs a different wait primitive
(the `sem_timedwait` shape CPython uses on Linux). No Linux host was available to
measure a fix or to add a test that would not redden Linux CI, so both are left
out rather than guessed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `_thread._local` behavior across threads, including correct per-thread initialization and surfacing per-thread initialization failures.
  * Refined `_thread` lock acquisition for timeouts, invalid arguments, and interruptible/reentrant locking.
  * Improved attribute/dictionary access consistency and error propagation across multiple built-in modules (e.g., structseq, ctypes, socket, I/O, sys, mmap, weakref, unicodedata, zlib).
* **Tests**
  * Added parity tests for `_thread._local` initialization semantics and lock/timeout validation (including `RLock`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
