### PR TITLE
jit: deliver the exception a jd1 trace finishes with; clear the drain's loop-exit StopIteration

### DIFF
--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -8413,6 +8413,12 @@ impl CraneliftBackend {
             trace_id
         });
         let header_pc = self.next_header_pc.take().unwrap_or(0);
+        // One-shot like `next_trace_id` / `next_header_pc`: a compile entry that
+        // installs no override (`compile_tmp_callback`) must fall back to the
+        // process-global callback rather than inherit the previous driver's
+        // build-time store, which decodes the same `-live-` marker to a
+        // different — and silently plausible — count.
+        let frame_value_count_fn = self.next_frame_value_count_fn.take();
         let ptr_type = self.module.target_config().pointer_type();
         let call_conv = self.module.target_config().default_call_conv;
         // The body uses CallConv::Tail so it can `return_call_indirect` to
@@ -8491,7 +8497,7 @@ impl CraneliftBackend {
             caller_layout,
             &constants_i64,
             attached_descrs,
-            self.next_frame_value_count_fn,
+            frame_value_count_fn,
         )?;
         // RPython jitframe layout parity: ref_root slots start AFTER all
         // output slots. max_output_slots must be >= inputs.len() so that

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -407,27 +407,6 @@ fn no_bridge_enabled() -> bool {
     static FLAG: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     *FLAG.get_or_init(|| std::env::var_os("MAJIT_NO_BRIDGE").is_some())
 }
-/// TEMP DIAGNOSTIC (remove before commit): `MAJIT_BRIDGE_ONLY=a,b,c` restricts
-/// bridge formation to the listed guard `fail_index` values, so a miscompiling
-/// bridge can be bisected out of a run. Unset = allow all.
-fn bridge_only_allows(fail_index: u32) -> bool {
-    static LIST: std::sync::OnceLock<Option<Vec<u32>>> = std::sync::OnceLock::new();
-    let list = LIST.get_or_init(|| {
-        std::env::var("MAJIT_BRIDGE_ONLY").ok().map(|v| {
-            v.split(',')
-                .filter_map(|t| t.trim().parse::<u32>().ok())
-                .collect()
-        })
-    });
-    let ok = match list {
-        None => true,
-        Some(allowed) => allowed.contains(&fail_index),
-    };
-    if crate::bridge_debug_enabled() {
-        eprintln!("[bridgeONLY] fail_index={fail_index} allowed={ok}");
-    }
-    ok
-}
 fn guardlog_enabled() -> bool {
     static FLAG: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     *FLAG.get_or_init(|| std::env::var_os("MAJIT_GUARDLOG").is_some())
@@ -3525,8 +3504,7 @@ impl<S: JitState> JitDriver<S> {
             // pending-field prologue (resume.py:993-1007).
             let should_bridge = must_compile
                 && !majit_metainterp::MetaInterp::<S::Meta>::stack_almost_full()
-                && !no_bridge_enabled()
-                && bridge_only_allows(fail_index);
+                && !no_bridge_enabled();
 
             // compile.py:710 recovery_layout header_pc parity:
             // guard resume_pc comes from the guard's recovery metadata.
@@ -5887,8 +5865,7 @@ impl<S: JitState> JitDriver<S> {
             // resume defects from the blackhole path.
             let should_bridge = must_compile
                 && !majit_metainterp::MetaInterp::<S::Meta>::stack_almost_full()
-                && !no_bridge_enabled()
-                && bridge_only_allows(fail_index);
+                && !no_bridge_enabled();
 
             // compile.py:710 recovery_layout header_pc parity:
             // guard resume_pc comes from the guard's recovery metadata.

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -2796,10 +2796,7 @@ impl<S: JitState> JitDriver<S> {
                 finish_args,
                 finish_arg_types,
                 exit_with_exception,
-                // The full-body walk delivers the `raise` half of
-                // `pyjitpl.py:2558-2562` itself (`WALK_END_PROPAGATED_EXCEPTION`),
-                // so this consumer only runs the compile half.
-                exc_value: _,
+                exc_value,
             } => {
                 // A terminal dispatch return is also a valid single-pass
                 // handoff: the interpreted function has returned, so native
@@ -2827,6 +2824,26 @@ impl<S: JitState> JitDriver<S> {
                     .and_then(|ctx| ctx.collect_virtualizable_element_values());
                 if let Some(elems) = virt_elems {
                     self.meta.single_pass_virt_array_values = Some(elems);
+                }
+                // The `raise` half of `pyjitpl.py:2558-2562`.  This arm is the
+                // consumer for `#[jit_interp]`-generated tracers, which reach
+                // it through `merge_point` and whose walk carries an escaping
+                // exception in `BH_LAST_EXC_VALUE` — the only channel a
+                // macro-front-end client has.  The producer
+                // (`dispatch.rs unwind_to_exception_handler`) closes that
+                // channel and hands the value over on the action, so re-open
+                // it here; dropping it would let the portal finish as if the
+                // frame had returned normally.
+                //
+                // Published *before* the compile: upstream snapshots
+                // `excvalue` into a local at :2531 and that local keeps the
+                // ref alive as a GC root across
+                // `compile_exit_frame_with_exception` (:2558).  A raw `i64`
+                // is no root, and `compile_finish_from_active_session`
+                // allocates, so the walked TLS cell has to hold the value
+                // across it.
+                if exit_with_exception && exc_value != 0 {
+                    crate::blackhole::BH_LAST_EXC_VALUE.with(|c| c.set(exc_value));
                 }
                 // pyjitpl.py:3198-3220 + 3238-3245 parity — upstream's
                 // `compile_done_with_this_frame` and
@@ -6654,6 +6671,59 @@ mod tests {
             state.writeback_applied,
             Some(vec![9]),
             "write-back must run with the walk-final captured values, not be a no-op",
+        );
+    }
+
+    /// Regression: an exception that drains the walk's frame stack must still
+    /// be delivered after the FINISH is compiled.
+    ///
+    /// `dispatch.rs unwind_to_exception_handler` closes the
+    /// `BH_LAST_EXC_VALUE` channel when it builds the exception-carrying
+    /// FINISH (leaving it set makes an interpreter re-surface the trace's
+    /// exception at its next residual-call boundary), and hands the concrete
+    /// value over on the action instead.  `#[jit_interp]` clients reach that
+    /// action through `merge_point` and have no second carrier, so this arm
+    /// re-publishes it — without that, the portal finishes as if the frame had
+    /// returned normally and the exception is silently dropped.
+    #[test]
+    fn finish_with_exception_republishes_the_escaping_exception() {
+        const ESCAPING_EXC: i64 = 0xc0ff_ee00;
+
+        let mut driver = JitDriver::<ScalarWalkState>::new(1);
+        driver.meta.finish_setup_descrs_for_jitdrivers();
+
+        let mut state = ScalarWalkState {
+            selected: 3,
+            writeback_applied: None,
+        };
+        let target_pc = 7usize;
+        driver.force_start_tracing(target_pc as u64, target_pc, &mut state, &());
+        assert!(
+            driver.is_tracing(),
+            "force_start_tracing must start a trace"
+        );
+
+        // The producer cleared the channel; only the action carries the value.
+        crate::blackhole::BH_LAST_EXC_VALUE.with(|c| c.set(0));
+
+        driver.merge_point(|meta, _sym| {
+            let exc_box = meta
+                .trace_ctx()
+                .expect("tracing ⇒ trace ctx")
+                .const_ref(ESCAPING_EXC);
+            TraceAction::Finish {
+                finish_args: vec![exc_box],
+                finish_arg_types: vec![majit_ir::Type::Ref],
+                exit_with_exception: true,
+                exc_value: ESCAPING_EXC,
+            }
+        });
+
+        let delivered = crate::blackhole::BH_LAST_EXC_VALUE.with(|c| c.get());
+        crate::blackhole::BH_LAST_EXC_VALUE.with(|c| c.set(0));
+        assert_eq!(
+            delivered, ESCAPING_EXC,
+            "the exception the trace finished with must survive the compile half",
         );
     }
 

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -2796,6 +2796,10 @@ impl<S: JitState> JitDriver<S> {
                 finish_args,
                 finish_arg_types,
                 exit_with_exception,
+                // The full-body walk delivers the `raise` half of
+                // `pyjitpl.py:2558-2562` itself (`WALK_END_PROPAGATED_EXCEPTION`),
+                // so this consumer only runs the compile half.
+                exc_value: _,
             } => {
                 // A terminal dispatch return is also a valid single-pass
                 // handoff: the interpreted function has returned, so native

--- a/majit/majit-metainterp/src/lib.rs
+++ b/majit/majit-metainterp/src/lib.rs
@@ -368,6 +368,17 @@ pub enum TraceAction {
         finish_args: Vec<OpRef>,
         finish_arg_types: Vec<Type>,
         exit_with_exception: bool,
+        /// The concrete exception object this finish escapes with, as a raw
+        /// GC-ref word (`0` when `exit_with_exception` is false).
+        ///
+        /// `pyjitpl.py:2530-2562 finishframe_exception` snapshots
+        /// `excvalue = self.last_exc_value` *before* calling
+        /// `compile_exit_frame_with_exception(self.last_exc_box)` and then
+        /// raises `jitexc.ExitFrameWithExceptionRef(excvalue)`, which
+        /// `warmspot.py:998-1005` re-raises out of `ll_portal_runner`.  The
+        /// compile half consumes only the symbolic `finish_args`; the raise
+        /// half needs the value, so it travels alongside them.
+        exc_value: i64,
     },
     /// Close and compile a segmented loop (force_finish_trace).
     /// pyjitpl.py:1622 _create_segmented_trace_and_blackhole parity.

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -3599,6 +3599,21 @@ where
                     _ => self.read_int_reg(value_reg),
                 };
                 let descr_index = descr.index();
+                // `execute_setarrayitem_gc` (pyjitpl.py:2742) records through
+                // `execute_and_record` → `_record_helper` (pyjitpl.py:2694),
+                // which runs `heapcache.invalidate_caches` → `mark_escaped` →
+                // `_escape_from_write` (heapcache.py:217-241) *before* the op is
+                // appended: a ref written into an already-escaped array escapes
+                // too, or `invalidate_unescaped` keeps its cached fields alive
+                // across the next residual call while the callee can reach and
+                // mutate it through the array.  `clear_caches_not_necessary`
+                // (heapcache.py:314) lists SETARRAYITEM_GC, so only the
+                // mark-escaped half runs.  Same shape as BC_RAW_STORE_I above.
+                ctx.heapcache_invalidate_caches_varargs(
+                    OpCode::SetarrayitemGc,
+                    None,
+                    &[array_opref, index_opref, value_opref],
+                );
                 ctx.record_op_with_descr(
                     OpCode::SetarrayitemGc,
                     &[array_opref, index_opref, value_opref],

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -1783,10 +1783,24 @@ where
         // shortcuts to Abort for that case, so here the exception slot
         // is guaranteed non-zero).
         if let Some(exc_box) = self.last_exception_box {
+            // `pyjitpl.py:2531 excvalue = self.last_exc_value`, snapshotted
+            // next to `last_exc_box` so the consumer can raise it after the
+            // compile (`pyjitpl.py:2558-2562`).
+            let exc_value = self.last_exception_value;
+            // Upstream's `last_exc_value` dies with the MetaInterp the moment
+            // `finishframe_exception` raises out of it.  Pyre's half of that
+            // state is the `BH_LAST_EXC_VALUE` TLS shared with the blackhole,
+            // and every *other* way out of a frame clears it (`clear_exception`
+            // at each `BC_*_RETURN`).  This exit hands the value to the caller
+            // on the action instead, so the channel closes here too — leaving it
+            // set makes the interpreter re-surface the trace's exception at its
+            // next residual-call boundary.
+            self.clear_exception();
             TraceAction::Finish {
                 finish_args: vec![exc_box],
                 finish_arg_types: vec![majit_ir::Type::Ref],
                 exit_with_exception: true,
+                exc_value,
             }
         } else {
             TraceAction::Abort
@@ -5168,6 +5182,7 @@ where
                         finish_args: vec![opref],
                         finish_arg_types: vec![majit_ir::Type::Int],
                         exit_with_exception: false,
+                        exc_value: 0,
                     };
                 }
             }
@@ -5202,6 +5217,7 @@ where
                         finish_args: vec![opref],
                         finish_arg_types: vec![majit_ir::Type::Int],
                         exit_with_exception: false,
+                        exc_value: 0,
                     };
                 }
             }
@@ -5232,6 +5248,7 @@ where
                         finish_args: vec![opref],
                         finish_arg_types: vec![majit_ir::Type::Ref],
                         exit_with_exception: false,
+                        exc_value: 0,
                     };
                 }
             }
@@ -5262,6 +5279,7 @@ where
                         finish_args: vec![opref],
                         finish_arg_types: vec![majit_ir::Type::Float],
                         exit_with_exception: false,
+                        exc_value: 0,
                     };
                 }
             }
@@ -5279,6 +5297,7 @@ where
                         finish_args: vec![],
                         finish_arg_types: vec![],
                         exit_with_exception: false,
+                        exc_value: 0,
                     };
                 }
                 // Sub-frame void return: caller resumes; nothing to write.
@@ -8633,6 +8652,7 @@ mod tests {
                 finish_args,
                 finish_arg_types,
                 exit_with_exception: false,
+                ..
             } => (finish_args, finish_arg_types),
             other => panic!("expected Finish[Int] from recursive-call portal, got {other:?}"),
         };
@@ -8847,6 +8867,7 @@ mod tests {
                 finish_args,
                 finish_arg_types,
                 exit_with_exception: false,
+                ..
             } => {
                 assert_eq!(finish_arg_types, vec![majit_ir::Type::Int]);
                 finish_args
@@ -8931,6 +8952,7 @@ mod tests {
                 finish_args,
                 finish_arg_types,
                 exit_with_exception: false,
+                ..
             } => {
                 assert_eq!(finish_arg_types, vec![majit_ir::Type::Ref]);
                 finish_args
@@ -8995,6 +9017,7 @@ mod tests {
                 finish_args,
                 finish_arg_types,
                 exit_with_exception: false,
+                ..
             } => {
                 assert_eq!(finish_arg_types, vec![majit_ir::Type::Float]);
                 finish_args
@@ -9059,6 +9082,7 @@ mod tests {
                 finish_args,
                 finish_arg_types,
                 exit_with_exception: false,
+                ..
             } => {
                 assert!(finish_args.is_empty(), "void return has no finish args");
                 assert!(
@@ -9206,6 +9230,7 @@ mod tests {
                 finish_args,
                 finish_arg_types,
                 exit_with_exception: false,
+                ..
             } => {
                 assert_eq!(finish_arg_types, vec![majit_ir::Type::Int]);
                 finish_args
@@ -10399,6 +10424,7 @@ mod tests {
                 finish_args,
                 finish_arg_types,
                 exit_with_exception,
+                ..
             } => (finish_args, finish_arg_types, exit_with_exception),
             other => panic!(
                 "expected TraceAction::Finish for handler-less raise, got {:?}",

--- a/pyre/bench/synth/unpack_drain_star_raise.py
+++ b/pyre/bench/synth/unpack_drain_star_raise.py
@@ -4,7 +4,7 @@
 # it — the exact-arity form has its own `unpack_sequence_exact` loop — so this
 # is the shape that exercises the second jit driver end to end.
 #
-# Three cases, each driven past the jd1 trace threshold:
+# Five cases, each driven past the jd1 trace threshold:
 #   1. plain drain to exhaustion,
 #   2. an iterator that raises a non-StopIteration exception mid-drain and
 #      re-raises it on every later `next()`,
@@ -14,8 +14,25 @@
 #      into a silent early return, so the case pins the exception actually
 #      travelling out of the compiled drain / blackhole resume rather than
 #      being re-discovered.
+#
+# Cases 1-3 all raise long after the drain has been compiled, so they only
+# exercise the live-enter/blackhole exits. The two below raise *while the
+# trace is being recorded*, which is a different exit (the walk drains its
+# framestack and returns an exception-carrying finish):
+#   4. raises at EARLY_AT, chosen to land inside the very first traced drain,
+#   5. `exc.args = <list>` from inside a hot loop — an unknown-length drain
+#      that ends on its own loop-exit StopIteration while being traced. That
+#      StopIteration is the loop's normal terminator and must not reach the
+#      interpreter. The store is off the hot path (`i % ARGS_EVERY`) so the
+#      enclosing loop compiles without it and the drain is traced from a guard
+#      exit, which is where the leak shows.
 N = 4000
 ROUNDS = 12
+# One less than the jd1 trace threshold, so the raise happens on the crossing
+# that starts the trace rather than after the loop is already compiled.
+EARLY_AT = 99
+ARGS_ITERS = 40000
+ARGS_EVERY = 997
 
 
 class Counting:
@@ -75,6 +92,30 @@ class RaisingOnce:
         return self.i
 
 
+class RaisingEarly:
+    """Raises once at `at`, then reports exhausted — same shape as
+    `RaisingOnce` but on its own type so it gets its own jd1 green key and
+    its raise lands on the trace-recording crossing."""
+
+    def __init__(self, n, at):
+        self.i = 0
+        self.n = n
+        self.at = at
+        self.fired = False
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self.i == self.at and not self.fired:
+            self.fired = True
+            raise ValueError("raising-early")
+        if self.fired or self.i >= self.n:
+            raise StopIteration
+        self.i += 1
+        return self.i
+
+
 def count(*args):
     return len(args)
 
@@ -83,6 +124,7 @@ def main():
     drained = 0
     stable = 0
     once = 0
+    early = 0
     for _ in range(ROUNDS):
         drained += count(*Counting(N))
         try:
@@ -93,7 +135,29 @@ def main():
             count(*RaisingOnce(N, N // 2))
         except ValueError as e:
             once += len(str(e))
-    print(drained, stable, once)
+        try:
+            count(*RaisingEarly(N, EARLY_AT))
+        except ValueError as e:
+            early += len(str(e))
+
+    print(drained, stable, once, early)
 
 
+def args_drain():
+    """`exc.args = <iterable>` is the other unknown-length drain consumer
+    (`coerce_to_list_for_args`). The list is short, so the drain always ends on
+    its own StopIteration — including on the crossing that records the trace."""
+    exc = ValueError("x")
+    items = [1, 2, 3]
+    n = 0
+    for i in range(ARGS_ITERS):
+        if i % ARGS_EVERY == ARGS_EVERY - 1:
+            exc.args = items
+        n += 1
+    print(n, exc.args)
+
+
+# `args_drain` runs first: measured, the StopIteration leak is only
+# observable on a cold JIT, so reordering these two hides case 5.
+args_drain()
 main()

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -10608,19 +10608,29 @@ fn _unpackiterable_unknown_length(
 /// jitcode. `#[dont_look_inside]` keeps the host plumbing opaque should a
 /// caller ever be traced.
 ///
-/// Pins `items` across the readback: an Integer/Float-strategy `getitem`
-/// boxes each element through the moving collector (`w_int_new` /
-/// `w_float_new`), which can relocate `items`.
+/// Pins `items` and every element read back. This is a liveness bracket, not
+/// a relocation read-back: the `W_ListObject` header is old-gen and non-moving.
+/// The caller's `RootScope` is already gone, so the drained list lives only on
+/// the Rust stack, and an Integer/Float-strategy `getitem` boxes through
+/// `w_int_new` / `w_float_new`, whose allocator slow path parks this mutator at
+/// a `gc_op` — a foreign thread's stop-the-world collection can mark and sweep
+/// while it is parked. The boxes read back so far are reachable from no root at
+/// that moment, so they get the same per-element pins
+/// `alloc_list_items_block_gc` uses.
 #[majit_macros::dont_look_inside]
 pub(crate) fn drain_collect_items(items: PyObjectRef) -> Vec<PyObjectRef> {
     let _roots = pyre_object::gc_roots::push_roots();
     pyre_object::gc_roots::pin_root(items);
     let n = unsafe { pyre_object::listobject::w_list_len(items) };
-    let mut out: Vec<PyObjectRef> = Vec::with_capacity(n);
+    let save = pyre_object::gc_roots::shadow_stack_len();
     for i in 0..n as i64 {
-        out.push(unsafe { pyre_object::listobject::w_list_getitem(items, i).unwrap() });
+        pyre_object::gc_roots::pin_root(unsafe {
+            pyre_object::listobject::w_list_getitem(items, i).unwrap()
+        });
     }
-    out
+    (0..n)
+        .map(|i| pyre_object::gc_roots::shadow_stack_get(save + i))
+        .collect()
 }
 
 /// pypy/interpreter/baseobjspace.py:1080-1108 `length_hint`.

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -51,6 +51,7 @@ thread_local! {
         in_flight_exception: IN_FLIGHT_EXCEPTION.with(|cell| cell as *const _),
         bh_last_exception: majit_metainterp::blackhole::BH_LAST_EXC_VALUE
             .with(|cell| cell as *const _),
+        jit_pending_exception: crate::stack_check::capture_jit_pending_exception_area(),
         pending_call_error: crate::call::capture_pending_call_error_area(),
         pending_hash_error: crate::baseobjspace::capture_pending_hash_error_area(),
     };
@@ -63,6 +64,7 @@ struct PyFrameRootArea {
     mapdict_method_cache: *const (),
     in_flight_exception: *const Cell<PyObjectRef>,
     bh_last_exception: *const Cell<i64>,
+    jit_pending_exception: *const Cell<i64>,
     pending_call_error: *const (),
     pending_hash_error: *const (),
 }
@@ -589,7 +591,8 @@ pub unsafe fn walk_pyframe_roots_area(
     // which happened to initiate collection.
     unsafe {
         walk_in_flight_exception_area(area.in_flight_exception, visitor);
-        walk_bh_last_exception_area(area.bh_last_exception, visitor);
+        walk_raw_exception_cell_area(area.bh_last_exception, visitor);
+        walk_raw_exception_cell_area(area.jit_pending_exception, visitor);
         crate::call::walk_pending_call_error_area(area.pending_call_error, visitor);
         crate::baseobjspace::walk_pending_hash_error_area(area.pending_hash_error, visitor);
     }
@@ -967,11 +970,14 @@ unsafe fn walk_in_flight_exception_area(
 /// `0xDEAD` sentinel exists solely in a blackhole unit-test helper).
 fn walk_bh_last_exception(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
     majit_metainterp::blackhole::BH_LAST_EXC_VALUE.with(|c| {
-        unsafe { walk_bh_last_exception_area(c as *const _, visitor) };
+        unsafe { walk_raw_exception_cell_area(c as *const _, visitor) };
     });
 }
 
-unsafe fn walk_bh_last_exception_area(
+/// Forward one raw `i64` exception carrier cell and trace the exception's
+/// GC-managed children. Shared by every such carrier
+/// (`BH_LAST_EXC_VALUE`, `TL_JIT_PENDING_EXCEPTION`) so they cannot drift.
+pub(crate) unsafe fn walk_raw_exception_cell_area(
     c: *const Cell<i64>,
     visitor: &mut dyn FnMut(&mut majit_ir::GcRef),
 ) {

--- a/pyre/pyre-interpreter/src/stack_check.rs
+++ b/pyre/pyre-interpreter/src/stack_check.rs
@@ -455,16 +455,25 @@ pub fn park_jit_pending_error(mut err: PyError) {
 /// `W_BaseException` is reachable from nothing else until the next call
 /// boundary drains it, and the drain crosses collecting code
 /// (`next()`/`__next__`). Registered once at JIT init next to the other
-/// `register_extra_root_walker` slots.
+/// `register_extra_root_walker` slots, which reach only the *collecting*
+/// thread's cell — every other mutator's cell is reached through the
+/// per-mutator root area built from
+/// [`capture_jit_pending_exception_area`].
 pub fn walk_jit_pending_exception(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
-    TL_JIT_PENDING_EXCEPTION.with(|slot| {
-        let obj = slot.get();
-        if obj != 0 {
-            let mut r = majit_ir::GcRef(obj as usize);
-            visitor(&mut r);
-            slot.set(r.0 as i64);
-        }
+    TL_JIT_PENDING_EXCEPTION.with(|slot| unsafe {
+        crate::eval::walk_raw_exception_cell_area(slot as *const _, visitor)
     });
+}
+
+/// Address of this thread's pending-exception cell, for registration in the
+/// per-mutator `PyFrameRootArea` alongside the other thread-local exception
+/// carriers. `rthread.py:429-437 _trace_tlref` traces a GC-pointer thread
+/// local by enumerating *every* thread's block
+/// (`threadlocal.c:86-93 _RPython_ThreadLocals_Enum`); resolving the TLS on
+/// whichever thread happened to start the collection would miss a stopped
+/// mutator's parked exception.
+pub(crate) fn capture_jit_pending_exception_area() -> *const std::cell::Cell<i64> {
+    TL_JIT_PENDING_EXCEPTION.with(|slot| slot as *const _)
 }
 
 /// rpython/translator/c/src/stack.h:42 `LL_stack_criticalcode_start`.

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -652,6 +652,15 @@ pub fn install_jitcode_for(
 /// import-time `_get_exports_list` at slot 0 is dead by the time user code
 /// drives jd1).  Reconciling the two index spaces into one absolute table is
 /// the standing follow-up.
+///
+/// Dropping the install is NOT an available shortcut, measured: without it the
+/// jd1 live-enter blackhole resume resolves slot 0 to the user jitcode that
+/// happens to own it and decodes garbage —
+/// `synth/slots_class_var_conflict` SIGSEGVs in
+/// `blackhole_resume_via_rd_numb` on dynasm and cranelift, and passes again
+/// under `PYRE_NO_JD1=1` / `PYRE_JD1_NO_ENTER=1`.  The resume path does not
+/// reach the build-time store on its own; only the index-space unification
+/// removes the collision.
 pub fn install_build_time_jitcode_at(index: usize, payload: std::sync::Arc<crate::PyJitCode>) {
     ensure_finish_setup();
     METAINTERP_SD.with(|r| {

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -3733,6 +3733,7 @@ fn full_body_walk_trace<Sym: WalkSym>(
                         finish_args: vec![],
                         finish_arg_types: vec![],
                         exit_with_exception: false,
+                        exc_value: 0,
                     },
                     // A top-level uncaught raise stashes the exception box as an
                     // `is_exception` payload (`fbw_terminate_with_raise`): build
@@ -3745,11 +3746,17 @@ fn full_body_walk_trace<Sym: WalkSym>(
                         finish_args: vec![exc],
                         finish_arg_types: vec![majit_ir::Type::Ref],
                         exit_with_exception: true,
+                        // The full-body walk delivers its own uncaught raise
+                        // through `WALK_END_PROPAGATED_EXCEPTION` (:557), so the
+                        // `raise` half of `finishframe_exception` is already
+                        // covered and no value needs to ride the action.
+                        exc_value: 0,
                     },
                     Some((finish_value, finish_type)) => TraceAction::Finish {
                         finish_args: vec![finish_value],
                         finish_arg_types: vec![finish_type],
                         exit_with_exception: false,
+                        exc_value: 0,
                     },
                     None => {
                         crate::jitcode_dispatch::census_record("Terminate::NoFinishPayload");

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -4963,6 +4963,24 @@ fn unpack_merge_point_jit(
     drive_unpack_iterable_trace(green_key, greenkey, w_iterator, items);
 }
 
+/// The exception a jd1 drain exit escapes with, as a `PyError`, unless it is the
+/// drain's own loop-exit `StopIteration` (which the caller `ln` loop re-derives
+/// on its next `next()`) or the slot is empty.
+///
+/// `compile.py:658-662 ExitFrameWithExceptionDescrRef.handle_fail` reads the
+/// value out of the deadframe and raises `jitexc.ExitFrameWithExceptionRef`;
+/// every jd1 exit that carries one funnels through here so the three call sites
+/// cannot drift apart.
+fn drain_error_from_exc_ref(exc: i64) -> Option<pyre_interpreter::error::PyError> {
+    if exc == 0 {
+        return None;
+    }
+    let err = unsafe {
+        pyre_interpreter::error::PyError::from_exc_object(exc as pyre_object::PyObjectRef)
+    };
+    (err.kind != pyre_interpreter::PyErrorKind::StopIteration).then_some(err)
+}
+
 /// Drive one jd1 trace of `_unpackiterable_unknown_length`. The tracer executes
 /// each residual (`self.next`, `items.append`) concretely on the shared reds,
 /// so this advances the live iterator and grows the live list in place; the
@@ -5085,9 +5103,10 @@ fn drive_unpack_iterable_trace(
     // is novable with raw `(w_iterator, items)` reds, not a PyFrame the
     // frame-projecting `execute_assembler`/`handle_fail` path expects.
     if matches!(action, BackEdgeAction::RunCompiled) && jd1_enter_enabled() {
-        // Root the shared reds across the compiled run (it may collect).
-        // `items` is already pinned by `ln`; re-pinning is a harmless dup that
-        // pops with `ln`'s root scope. `w_iterator` is a bare `ln` local.
+        // Root the shared reds across the compiled run (it may collect). The
+        // scope guard truncates both entries on the way out; `pin_root` without
+        // one grows `ln`'s shadow stack by two per jd1 crossing.
+        let _enter_roots = pyre_object::gc_roots::push_roots();
         pyre_object::gc_roots::pin_root(w_iterator);
         pyre_object::gc_roots::pin_root(items);
         let before = unsafe { pyre_object::listobject::w_list_len(items) };
@@ -5123,6 +5142,14 @@ fn drive_unpack_iterable_trace(
                 break;
             };
             if is_finish {
+                // A finish exit can be the compiled drain's own
+                // `exit_frame_with_exception` (`finish_and_compile` publishes an
+                // `ExitFrameWithExceptionRef` trace as the loop for this green
+                // key, so the next crossing lands here). `compile.py:658-662`
+                // takes the value from result slot 0, not from `jf_guard_exc`.
+                if exit_layout.is_exception_exit {
+                    pending_err = drain_error_from_exc_ref(values.first().copied().unwrap_or(0));
+                }
                 break;
             }
             // A normal back-edge JUMP (`fail_index == u32::MAX`) or a guard exit
@@ -5135,16 +5162,9 @@ fn drive_unpack_iterable_trace(
             // the drain's `return Err(e)` arm. Resuming it would only walk the
             // drain's re-raise tail to re-derive the same error, so take it
             // here; the iteration is over either way.
-            if guard_exc != 0 {
-                let err = unsafe {
-                    pyre_interpreter::error::PyError::from_exc_object(
-                        guard_exc as pyre_object::PyObjectRef,
-                    )
-                };
-                if err.kind != pyre_interpreter::PyErrorKind::StopIteration {
-                    pending_err = Some(err);
-                    break;
-                }
+            if let Some(err) = drain_error_from_exc_ref(guard_exc) {
+                pending_err = Some(err);
+                break;
             }
             // compile.py:710-716 resume_in_blackhole: complete the in-flight
             // `next()`/`append` and run forward to the next merge point.
@@ -5177,10 +5197,21 @@ fn drive_unpack_iterable_trace(
                 after
             );
         }
-        // Discard any pending compiled-side StopIteration; `ln` re-derives its
-        // own loop exit.
-        let _ = pyre_interpreter::stack_check::drain_jit_pending_exception();
-        let _ = crate::call_jit::take_ca_exception();
+        // Clear the compiled-side slots so `ln` re-derives its own loop-exit
+        // StopIteration rather than seeing the drain's. Anything else left in
+        // them is a real error (a prologue-overflow `RecursionError` is the only
+        // producer today) and is promoted instead of discarded; an exit that
+        // already picked one keeps it, since that one is the earlier failure.
+        if let Err(err) = pyre_interpreter::stack_check::drain_jit_pending_exception()
+            && err.kind != pyre_interpreter::PyErrorKind::StopIteration
+        {
+            pending_err.get_or_insert(err);
+        }
+        if let Some(err) = crate::call_jit::take_ca_exception()
+            && err.kind != pyre_interpreter::PyErrorKind::StopIteration
+        {
+            pending_err.get_or_insert(err);
+        }
         // Parked last, so the clears above cannot swallow it.
         if let Some(err) = pending_err {
             pyre_interpreter::stack_check::park_jit_pending_error(err);
@@ -5291,12 +5322,28 @@ fn drive_unpack_iterable_trace(
         finish_args,
         finish_arg_types,
         exit_with_exception,
+        exc_value,
     }) = drove
     {
         // A straight-line trace that closes by finishing rather than
         // back-edging (the unpack loop's `StopIteration` exit reached before a
         // full body + back-edge): route through the same finish-compile path
         // jd0 uses so P1 still proves the recorded trace is assemblable.
+        //
+        // `pyjitpl.py:2558-2562 finishframe_exception` compiles the FINISH and
+        // then raises `ExitFrameWithExceptionRef(excvalue)`, which
+        // `warmspot.py:998-1005` propagates out of `ll_portal_runner`. The
+        // tracer ran the raising `next()` for real, so the error exists only
+        // here; without this the unpack silently returns a truncated list. jd1
+        // is entered from a merge-point hook with no return value, so the
+        // pending-exception slot carries it, exactly as the live-enter path
+        // above does. Parked *before* the compile — that is the one deliberate
+        // reordering against upstream — because the compile allocates and the
+        // slot is the only place the raw value is a GC root
+        // (`walk_jit_pending_exception`).
+        if exit_with_exception && let Some(err) = drain_error_from_exc_ref(exc_value) {
+            pyre_interpreter::stack_check::park_jit_pending_error(err);
+        }
         match meta.compile_finish_from_active_session(
             &finish_args,
             finish_arg_types,


### PR DESCRIPTION
Follow-up to #751: applies its review findings. Two of them were live
default-settings wrong answers.

## Fixed: an exception raised while the jd1 drain is being traced was dropped

`TraceAction::Finish` carried only the symbolic `finish_args`, so
`eval.rs drive_unpack_iterable_trace`'s Finish arm compiled the FINISH and
returned — nothing raised. `count(*it)` where `__next__` raises on the
trace-recording crossing returned a truncated list:

```
cpython: lost 0    dynasm: lost 1    PYRE_NO_JD1=1: lost 0
```

`pyjitpl.py:2530-2562 finishframe_exception` snapshots
`excvalue = self.last_exc_value` *before* calling
`compile_exit_frame_with_exception(self.last_exc_box)` and then raises
`jitexc.ExitFrameWithExceptionRef(excvalue)`, which `warmspot.py:998-1005`
re-raises out of `ll_portal_runner`. The compile half consumes only the
symbolic args; the raise half needs the value. So the value now travels on
the action as `TraceAction::Finish { exc_value }`, and jd1 parks it **before**
the compile — the compile allocates, and the pending-exception slot is the
only root for the raw ref.

## Fixed: the drain's own loop-exit `StopIteration` leaked to the interpreter

`unwind_to_exception_handler`'s drained-framestack terminal never called
`clear_exception()`, so `BH_LAST_EXC_VALUE` stayed set after the walk and the
interpreter re-surfaced it at its next residual-call boundary. Every other
frame exit (`BC_*_RETURN`) clears it; that asymmetry was the bug. Repro shape
(needs a cold JIT and the store off the hot path):

```python
e = ValueError("x"); it = [1, 2, 3]
for i in range(40000):
    if i % 997 == 996:
        e.args = it          # bogus StopIteration traceback here
```

Both bugs are now covered by `synth/unpack_drain_star_raise`, verified to fail
on a build with the fixes reverted.

## Fixed: `merge_point`'s finish arm dropped that same exception

Follow-up to the two above, found in review of this PR. Closing the
`BH_LAST_EXC_VALUE` channel at the producer left the *other* consumer without
one. `JitDriver::merge_point` is reached only from the
`#[jit_interp]`-generated tracer (`majit-macros/src/jit_interp/mod.rs:1346`),
and a macro-front-end client has no second carrier for an escaping exception,
so its Finish arm silently dropped the value and the portal finished as if the
frame had returned normally.

Latent today — every non-zero writer of `BH_LAST_EXC_VALUE` outside tests is in
`pyre/`, and pyre does not use `#[jit_interp]` — but it is a wrong-answer shape
this PR introduced, so it is closed here rather than left standing.
`BH_LAST_EXC_VALUE` is now set from `exc_value` *before*
`compile_finish_from_active_session`, for the same rooting reason as the jd1
side. The comment that previously justified discarding the value claimed this
arm was reached by the full-body walk (which raises via
`WALK_END_PROPAGATED_EXCEPTION`); that thread-local lives in `pyre-jit-trace`
and pyre does not route through `merge_point`, so the comment was wrong.

Covered by `finish_with_exception_republishes_the_escaping_exception`, verified
to fail (`left: 0`) with the republish disabled.

## Rest of the review

- **root scope** — `push_roots()` around the jd1 live-enter block.
- **per-element pins** — `drain_collect_items` pins each element it reads back
  instead of relying on the container pin, and its doc comment is corrected.
- **cranelift one-shot** — `next_frame_value_count_fn` is `.take()`n once per
  `do_compile`, next to its two siblings, instead of leaking into the next
  compile.
- **`SETARRAYITEM_GC` `mark_escaped`** — `heapcache_invalidate_caches_varargs`
  before `record_op_with_descr`, matching `pyjitpl.py:2742` →
  `_record_helper` (:2694) → `heapcache.py:217-241`.
- **per-mutator GC root area** — the JIT pending-exception cell is walked from
  `PyFrameRootArea` like `BH_LAST_EXC_VALUE`, so it is a root for every mutator
  rather than only the collecting thread (`rthread.py:429-437 _trace_tlref`).
- **`MAJIT_BRIDGE_ONLY`** — temporary diagnostic removed.

### Refuted by measurement

One finding claimed `install_build_time_jitcode_at` became vestigial once
every jd1 coordinate consumer moved to the build-time store, so the slot-0
install could be deleted. Measured false: without it
`synth/slots_class_var_conflict` SIGSEGVs in
`pyre_jit::call_jit::blackhole_resume_via_rd_numb` on dynasm *and* cranelift,
and passes under `PYRE_NO_JD1=1` / `PYRE_JD1_NO_ENTER=1`. The jd1 **live-enter**
blackhole resume still resolves `sd.jitcodes[0]`, so without the install it
decodes whichever user jitcode owns slot 0. Kept, with the measurement recorded
in its doc comment. The real fix stays the build-time↔runtime index-space
unification (`codewriter.py:74-88`, `warmspot.py:281-282`).

### Not in this PR

A `#[dont_look_inside]` callee returning `Vec<T>` is erased to a one-word
`"ref"` by `dont_look_inside_return_token`
(`majit/majit-translate/src/front/mir.rs`), so `drain_collect_items`,
`compute_mro` and `memoryview_gather_bytes` would residualize with a broken
sret ABI. Measured latent — no runtime path dispatches those residuals today.
The orthodox fix is to make `unpackiterable`/`fixedview` return the `W_List`
ref, which touches ~50 call sites; filed separately rather than ballooning
this diff.

## Gate

`python3 pyre/check.py --backend dynasm,cranelift,wasm` →
dynasm 2 failed / 319 passed, cranelift 2 failed / 319 passed,
wasm 1 failed / 317 passed.

Every remaining failure was reproduced with a binary built from unmodified
`main`, i.e. they are red on `main` already and are not caused by this branch:

- `synth/getframe_force_cancel_journal` wrong output (`19995` vs `20000`), all
  three backends.
- `synth/const_arg_call_resume` cranelift 33.8–34.4x over the 30x gate.
- `cargo test`: `majit-translate/test_rbigint_mir` and
  `pyre-jit-trace --lib::{sub_jitcode_body_by_index_builds_w_list_append,
  list_append_jitcode_resolves_charon_body}` — the stale feature-flavoured LLBC
  extract artifact.

`synth/unpack_drain_star_raise` passes on all three backends.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed exception propagation during compiled iterator draining, including preservation of non-`StopIteration` errors.
  - Improved reliability when exceptions escape compiled execution paths.
  - Prevented stale or missing exception values during trace completion.
  - Improved garbage-collection safety for list elements, array updates, and pending exceptions.
  - Corrected bridge recording behavior after guard failures.
- **Tests**
  - Added regression coverage for exception preservation and expanded iterator-draining scenarios.
- **Documentation**
  - Added diagnostic context for a rare compiled-code resume failure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->