### PR TITLE
jit: fix two abort-replay wrong-answer classes in the single walker; propagate a raising dict probe out of finditem_str

### DIFF
--- a/pyre/bench/synth/module_body_truncated_jitcode_replay.py
+++ b/pyre/bench/synth/module_body_truncated_jitcode_replay.py
@@ -1,0 +1,31 @@
+# A module body whose JitCode lowering stops early must not let a later loop
+# header borrow the truncation's resume marker. `class` compiles to
+# LOAD_BUILD_CLASS, which has no JitCode lowering, so the body ends there with
+# an `abort_permanent` block; every py_pc after it is unlowered, and the
+# marker table forward-carries the loop header onto that block. Walking from
+# there aborts at the marker and back-translates it to the unported
+# instruction's own py_pc — before the loop — rewinding the frame so the whole
+# span between them runs twice.
+#
+# The counters below sit in that span. `steps` is the loop's own work, so the
+# body stays hot enough to reach the trace threshold on every backend; `runs`
+# and the list length report the span's execution count, which is 1.
+
+runs = 0
+seen = []
+
+
+class Marker:
+    pass
+
+
+runs = runs + 1
+seen.append("once")
+
+i = 0
+steps = 0
+while i < 20000:
+    steps = steps + i
+    i = i + 1
+
+print(runs, len(seen), seen, steps)

--- a/pyre/bench/synth/trace_too_long_effect_replay.py
+++ b/pyre/bench/synth/trace_too_long_effect_replay.py
@@ -1,0 +1,66 @@
+# A trace that outgrows `trace_limit` must not re-apply effects the walk has
+# already executed. The walker's length check fires at an arbitrary opcode,
+# unlike every other abort, which declines before executing an effect it
+# cannot roll back; an abort resumes by re-interpreting the iteration from the
+# trace entry, so an executed-but-unrollbackable effect would land twice.
+#
+# `pypyjit.set_param` lowers `trace_limit` far enough that the check binds on
+# every backend (the param hook reaches the wasm guest, which sees no
+# environment). CPython, the oracle, has no `pypyjit`; guarding the import
+# keeps the output identical across all three while the limit only binds where
+# a JIT exists.
+try:
+    import pypyjit
+except ImportError:
+    pypyjit = None
+
+
+def set_trace_limit(n):
+    if pypyjit is not None:
+        pypyjit.set_param("trace_limit=%d,threshold=1,function_threshold=1" % n)
+
+
+N = 200
+
+# Phase A — an effect-free body under a limit small enough to trip it. The
+# committed `.jitstats` baseline records the resulting abort, so the length
+# check itself cannot silently stop firing.
+set_trace_limit(8)
+
+i = 0
+free_total = 0
+while i < N:
+    x = i
+    x = x + 1
+    x = x + 2
+    x = x + 3
+    x = x + 4
+    x = x + 5
+    free_total = free_total + x
+    i = i + 1
+
+# Phase B — the same shape with the limit raised past the body's own length,
+# so the check lands mid-body, and with one effect per rollback class: a list
+# slot store is journaled, a dict store and a list append historically were
+# not. Each counter must read exactly N; a replayed iteration shows up as
+# N + 1.
+set_trace_limit(100)
+
+box = [0]
+d = {"k": 0}
+obj = []
+
+i = 0
+total = 0
+while i < N:
+    x = i
+    x = x + 1
+    x = x + 2
+    x = x + 3
+    box[0] += 1
+    d["k"] = d["k"] + 1
+    obj.append(x)
+    total = total + x
+    i = i + 1
+
+print(free_total, total, box[0], d["k"], len(obj), sum(obj) % 1000003)

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -3662,9 +3662,15 @@ unsafe fn setitem_instance(obj: PyObjectRef, index: PyObjectRef, value: PyObject
 /// `&str`, so a miss allocates neither the wrapped key nor the exception.
 /// Every other receiver falls through to `baseobjspace.py:868-871`, which
 /// wraps the key and defers to the generic `finditem`.
+///
+/// The probe still compares against whatever the bucket holds, so a stored
+/// non-string key whose hash collides can reach a user `__eq__` that raises.
+/// Take the `_checked` variant so that surfaces as an error rather than a
+/// miss; only that path wraps the key, to name it in a 3.14 hash-error.
 pub fn finditem_str(obj: PyObjectRef, key: &str) -> Result<Option<PyObjectRef>, PyError> {
     if is_shortcut_dict(obj) {
-        return Ok(unsafe { pyre_object::dictmultiobject::w_dict_getitem_str(obj, key) });
+        return unsafe { pyre_object::dictmultiobject::w_dict_getitem_str_checked(obj, key) }
+            .map_err(|_| take_pending_dict_key_error(w_str_new(key)));
     }
     finditem(obj, w_str_new(key))
 }
@@ -4285,6 +4291,29 @@ fn getdict_backing(obj: PyObjectRef) -> PyObjectRef {
         return w_dict;
     }
     crate::type_methods::resolve_dict_backing(w_dict)
+}
+
+/// `baseobjspace.py:46-50 W_Root.getdictvalue`.
+///
+/// ```python
+/// def getdictvalue(self, space, attr):
+///     w_dict = self.getdict(space)
+///     if w_dict is not None:
+///         return space.finditem_str(w_dict, attr)
+///     return None
+/// ```
+///
+/// Going through `finditem_str` rather than the raw layout accessor is what
+/// makes a dict probe that raises reach the caller: a borrowed-`&str` key is
+/// still compared against whatever the bucket holds, so a stored non-string
+/// key whose hash collides can run a user `__eq__`, and the raw accessor
+/// reports that as an ordinary miss — the attribute would look absent.
+fn getdictvalue(obj: PyObjectRef, name: &str) -> Result<Option<PyObjectRef>, PyError> {
+    let w_dict = getdict_backing(obj);
+    if w_dict.is_null() {
+        return Ok(None);
+    }
+    finditem_str(w_dict, name)
 }
 
 /// interpreter/baseobjspace.py:142-143 W_Root.getweakref().
@@ -6205,11 +6234,8 @@ fn object_getattr_miss(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyRe
                         }
                     }
                 }
-                let w_dict = getdict_backing(obj);
-                if !w_dict.is_null() {
-                    if let Some(value) = pyre_object::w_dict_getitem_str(w_dict, name) {
-                        return Ok(value);
-                    }
+                if let Some(value) = getdictvalue(obj, name)? {
+                    return Ok(value);
                 }
                 if let Some(descr) = w_descr {
                     if crate::is_function(descr) {
@@ -6258,11 +6284,8 @@ fn object_getattr_miss(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyRe
                     }
                 }
             }
-            let w_dict = getdict_backing(obj);
-            if !w_dict.is_null() {
-                if let Some(value) = unsafe { pyre_object::w_dict_getitem_str(w_dict, name) } {
-                    return Ok(value);
-                }
+            if let Some(value) = getdictvalue(obj, name)? {
+                return Ok(value);
             }
             if let Some(method) = w_descr {
                 match unsafe { get(method, obj, w_type.as_ptr()) } {
@@ -6307,13 +6330,10 @@ fn object_getattr_miss(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyRe
     // Function object attributes — PyPy: function.py Function
     // Check the live W_DictObject (functions are hasdict per typedef.py:735
     // __dict__ = getset_func_dict).
-    if unsafe { crate::is_function(obj) } {
-        let w_dict = getdict_backing(obj);
-        if !w_dict.is_null() {
-            if let Some(v) = unsafe { pyre_object::w_dict_getitem_str(w_dict, name) } {
-                return Ok(v);
-            }
-        }
+    if unsafe { crate::is_function(obj) }
+        && let Some(v) = getdictvalue(obj, name)?
+    {
+        return Ok(v);
     }
     unsafe {
         if crate::is_function(obj) {
@@ -6472,11 +6492,8 @@ fn object_getattr_miss(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyRe
     if name == "__doc__" || name == "__module__" || name == "__annotations__" {
         // baseobjspace.py:46-50 W_Root.getdictvalue — consult the
         // instance dict (exception `w_dict` slot, hasdict objects).
-        let w_dict = getdict_backing(obj);
-        if !w_dict.is_null() {
-            if let Some(value) = unsafe { pyre_object::w_dict_getitem_str(w_dict, name) } {
-                return Ok(value);
-            }
+        if let Some(value) = getdictvalue(obj, name)? {
+            return Ok(value);
         }
         // `__module__` is not a universal attribute: an object whose
         // type-MRO carries no `__module__` (e.g. a builtin instance like

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -2185,14 +2185,30 @@ pub fn walk<Sym: WalkSym>(
         //
         // The walker layer holds `&mut TraceCtx` and cannot reach
         // `MetaInterp::blackhole_if_trace_too_long` for the full bookkeeping;
-        // `note_root_trace_too_long` is the warm-state half the retired loop
-        // called (`trace_next_iteration` + `mark_force_finish_tracing`, so the
-        // next attempt cuts the trace instead of growing it again). The
-        // `find_biggest_function` → `disable_noninlinable_function` half
-        // (pyjitpl.py:2793) still only runs on the per-opcode path.
-        if ctx.trace_ctx.is_too_long() {
+        // `note_root_trace_too_long` carries the warm-state half, split into
+        // the loop and bridge arms `prepare_trace_segmenting` (pyjitpl.py:2833)
+        // keeps apart. The `find_biggest_function` →
+        // `disable_noninlinable_function` half (pyjitpl.py:2817) still only
+        // runs on the per-opcode path.
+        //
+        // DEVIATION from `SwitchToBlackhole(ABORT_TOO_LONG)`, which resumes in
+        // the blackhole from the traced state: a `DispatchError` resumes by
+        // re-interpreting the iteration from the trace entry, so an effect the
+        // walk already executed and cannot roll back would be applied twice.
+        // Every other walker abort upholds that invariant by declining BEFORE
+        // it executes such an effect (see `InplaceContainerMutationUnsupported`
+        // and the `FBW_STRUCTURAL_ABORT_OPCODE_EFFECTS` effect-free check); a
+        // length check fires at an arbitrary opcode instead, so it must consult
+        // the odometer itself. `fbw_executed_effect_count` is reset per walk, so
+        // zero means nothing the replay would redo has run yet. A walk that is
+        // already past that point keeps recording — the pre-existing unbounded
+        // behaviour — rather than corrupt the heap.
+        if ctx.trace_ctx.is_too_long() && fbw_executed_effect_count() == 0 {
             let ops = ctx.trace_ctx.num_recorded_ops();
-            crate::state::note_root_trace_too_long(ctx.trace_ctx.root_green_key());
+            crate::state::note_root_trace_too_long(
+                ctx.trace_ctx.current_merge_points_first_greenkey(),
+                ctx.trace_ctx.resumekey_original_loop_token().cloned(),
+            );
             return Err(DispatchError::TraceTooLong {
                 pc: opcode_position,
                 ops,

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -2904,15 +2904,43 @@ pub(crate) fn wrapint(ctx: &mut TraceCtx, value: OpRef) -> OpRef {
     boxed
 }
 
-pub(crate) fn note_root_trace_too_long(green_key: u64) {
-    let (driver, _) = crate::driver::driver_pair();
-    let warm_state = driver.meta_interp_mut().warm_state_mut();
-    warm_state.trace_next_iteration(green_key);
-    warm_state.mark_force_finish_tracing(green_key);
+/// The warm-state half of `prepare_trace_segmenting` (pyjitpl.py:2833),
+/// callable from the walker, which holds `&mut TraceCtx` and so cannot take
+/// `MetaInterp` to run the method itself.  The two arms are independent and
+/// upstream applies each on its own condition, so both arguments are read
+/// straight off the walk's `TraceCtx`:
+///
+/// * `merge_key` — `if self.current_merge_points:` (pyjitpl.py:2839). A loop's
+///   outermost green key; `None` while tracing a bridge, which has no merge
+///   point to boost.
+/// * `source_token` — `if not isinstance(self.resumekey, ResumeFromInterpDescr):`
+///   (pyjitpl.py:2849). A bridge has no room in its `ResumeGuardDescr` for the
+///   segmenting bit, so upstream sets it on the source `JitCellToken` instead,
+///   where it applies to every bridge off that token. Marking the root green key
+///   for a bridge would leave the real culprit untouched and let the same
+///   oversized bridge re-record on each failure of that guard.
+pub(crate) fn note_root_trace_too_long(
+    merge_key: Option<u64>,
+    source_token: Option<std::sync::Arc<majit_backend::JitCellToken>>,
+) {
+    if let Some(merge_key) = merge_key {
+        let (driver, _) = crate::driver::driver_pair();
+        let warm_state = driver.meta_interp_mut().warm_state_mut();
+        // pyjitpl.py:2843-2844.
+        warm_state.trace_next_iteration(merge_key);
+        warm_state.mark_force_finish_tracing(merge_key);
+    }
+    if let Some(source_jct) = source_token.as_ref() {
+        // pyjitpl.py:2857 `loop_token.retraced_count |= FORCE_BRIDGE_SEGMENTING`.
+        let cur = source_jct.retraced_count.get();
+        source_jct
+            .retraced_count
+            .set(cur | majit_backend::JitCellToken::FORCE_BRIDGE_SEGMENTING);
+    }
     if majit_metainterp::majit_log_enabled() {
         eprintln!(
-            "[jit][trace-too-long] trace_next_iteration + mark_force_finish_tracing key={}",
-            green_key
+            "[jit][trace-too-long] merge_key={merge_key:?} bridge_segmenting={}",
+            source_token.is_some()
         );
     }
 }

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -1874,7 +1874,23 @@ fn run_perfn_walk<Sym: WalkSym>(
         // the carried offset (override below).
         sym.bridge_walk_entry_pc()
     } else if uses_entry_sidecar {
-        sidecar_entry
+        // The resume-marker table forward-carries a py_pc that emitted no op of
+        // its own to the next py that did.  When lowering stopped early — an
+        // unported opcode ends the body with `abort_permanent` — every later py
+        // is unlowered, so that carry crosses the truncation and hands back the
+        // abort block.  The block's own coordinate is the unported instruction,
+        // far BEFORE `start_pc`: walking from it reaches the marker at once and
+        // `fbw_abort_resume_py_pc` back-translates to that earlier py, rewinding
+        // the live frame so every instruction between it and `start_pc` runs a
+        // second time.  Require the coordinate to round-trip forward instead —
+        // a trace-entry green heads its own block, so its marker back-translates
+        // to itself, and a genuine trivia carry lands on a LATER py.  Anything
+        // else is a body that does not encode `start_pc`, which is exactly the
+        // decline below.
+        sidecar_entry.filter(|&off| {
+            crate::jitcode_dispatch::python_pc_for_jitcode_pc(&pjc.metadata, off) as usize
+                >= start_pc
+        })
     } else {
         // Every non-entry resume carries its own JitCode coordinate. Without
         // one the site-specific decline below rejects the walk.

--- a/pyre/pyre-object/src/dictmultiobject.rs
+++ b/pyre/pyre-object/src/dictmultiobject.rs
@@ -2739,6 +2739,29 @@ pub unsafe fn w_dict_getitem_str(obj: PyObjectRef, key: &str) -> Option<PyObject
     w_dict_get_strategy(obj).getitem_str(obj, key)
 }
 
+/// Error-propagating sibling of [`w_dict_getitem_str`], the str-keyed
+/// counterpart of [`w_dict_lookup_checked`].
+///
+/// A borrowed-`&str` probe still runs `dict_keys_equal` against whatever the
+/// bucket holds, so a stored non-string key whose hash collides can reach a
+/// user `__eq__`.  When that raises, the callback pair records the error and
+/// reports "not equal", which `Option` alone renders as an ordinary miss —
+/// a name lookup would then continue as though the name were absent.  Drain
+/// the flag so the caller can surface the exception instead.
+///
+/// # Safety
+/// `obj` must point to a valid dict.
+pub unsafe fn w_dict_getitem_str_checked(
+    obj: PyObjectRef,
+    key: &str,
+) -> Result<Option<PyObjectRef>, DictKeyError> {
+    let hit = w_dict_getitem_str(obj, key);
+    if take_dict_key_error() {
+        return Err(DictKeyError);
+    }
+    Ok(hit)
+}
+
 /// Internal helper for `ObjectDictStrategy::getitem_str`. Kept as a free
 /// function so the strategy trait impl can share the borrowed-str lookup.
 ///

--- a/pyre/pyre-wasm-runner/src/main.rs
+++ b/pyre/pyre-wasm-runner/src/main.rs
@@ -126,8 +126,11 @@ struct Host {
 /// here; the prefix match needs no upkeep for new guest-side knobs.
 fn warn_inert_guest_env() {
     const HOST_HANDLED: &[&str] = &["PYRE_STDLIB", "MAJIT_STATS"];
+    // `to_string_lossy`, not `into_string().ok()`: a name the platform allows
+    // but UTF-8 does not is still a setting the guest silently ignores, and
+    // dropping it here would hide exactly the case worth reporting.
     let mut inert: Vec<String> = std::env::vars_os()
-        .filter_map(|(name, _)| name.into_string().ok())
+        .map(|(name, _)| name.to_string_lossy().into_owned())
         .filter(|name| name.starts_with("PYRE_") || name.starts_with("MAJIT_"))
         .filter(|name| {
             !name.starts_with("PYRE_WASM_")


### PR DESCRIPTION
Four fixes found by differential fuzzing against CPython 3.14, not by any existing bench.

## 1. A truncated JitCode let a later trace entry borrow the abort block's marker

Any module-level `class` statement followed by a hot module-level loop made the
whole span between them execute **twice** under JIT, on all three backends.
`del z` in that span raised `NameError`; a `with` block ran `__enter__`/`__exit__`
twice; loop accumulators were corrupted. Extremely pc-sensitive — adding one
statement made it vanish, which is why no bench caught it.

The codewriter stops lowering a body at the first unported opcode
(`LOAD_BUILD_CLASS` is one) and closes it with
`live; setfield_vable_i; abort_permanent; ref_return`. Every py_pc after the
truncation is unlowered, so the resume-marker table's forward-carry hands the
loop header that abort block's offset, while `python_pc_for_jitcode_pc` maps the
block back to the unported instruction's own py_pc. The forward and backward
maps disagree: the walk enters at the abort block, reaches the marker at once,
and the marker-abort arm commits a flush at that earlier coordinate — rewinding
the live frame.

`run_perfn_walk` now keeps a sidecar entry only when its coordinate maps back to
a py_pc at or after `start_pc`, and otherwise takes the pre-existing
"body does not encode `start_pc`; declining walk" path.

The existing pre-walk guard missed this because `loop_body_abort_permanent_pc`
anchors its scan on a `jit_merge_point` op, and a truncated body has none.

## 2. The walker `trace_limit` abort replayed effects it had already executed

The length check fires at an arbitrary opcode, unlike every other walker abort,
which declines *before* executing an effect it cannot roll back. A
`DispatchError` resumes by re-interpreting from the trace entry, so an
already-executed dict store or list append landed twice. It now also requires
`fbw_executed_effect_count() == 0`.

`note_root_trace_too_long` also took one green key and applied both halves of
`prepare_trace_segmenting` to it. `pyjitpl.py:2833-2857` applies them on
independent conditions — `trace_next_iteration` + `mark_force_finish_tracing` on
the outermost merge point, `FORCE_BRIDGE_SEGMENTING` on the source
`JitCellToken` when the resumekey is not a `ResumeFromInterpDescr` — so it now
takes both and applies each on its own.

## 3. `finditem_str` swallowed a dict probe that raised

The borrowed-`&str` shortcut still compares against whatever the bucket holds, so
a stored non-string key whose hash collides can reach a user `__eq__`.
`w_dict_getitem_str` reported that as an ordinary miss, making the name look
absent. Adds `w_dict_getitem_str_checked`, the str-keyed counterpart of
`w_dict_lookup_checked`. Also adds `getdictvalue`
(`baseobjspace.py:46-50 W_Root.getdictvalue`) and routes the four
`getdict_backing` + raw-accessor reads in the getattr paths through it.

## 4. wasm-runner inert-env warning dropped non-UTF-8 names

`into_string().ok()` dropped exactly the case the warning exists to report.

## Verification

| corpus | before | after |
|---|---|---|
| 30 module constructs x 4 loop placements (120 cases) | 13 diverge | **0** |
| same, cranelift / wasm | — | **0 / 0** |
| 20 loop bodies x 20 `trace_limit` values (400 runs) | 18/20 bodies diverge | **0** |

Two regression benches added: `module_body_truncated_jitcode_replay.py` and
`trace_too_long_effect_replay.py`.

`pyre/check.py` failure set is identical to a clean-`main` baseline built and run
side by side; both new benches pass on all three backends. The failures present
on `main` at the time of writing (`except_star`, `exception_group_type`,
`exception_subclass_attrs`, `unpack_drain_star_raise`,
`getframe_force_cancel_journal`) reproduce with these commits reverted and are
not touched here.