### PR TITLE
jit: lower the empty dict literal, drop unlowered loop-header trace entries, decline frameless traceback nodes

### DIFF
--- a/pyre/bench/synth/exception_raise_caught_same_frame_tb.py
+++ b/pyre/bench/synth/exception_raise_caught_same_frame_tb.py
@@ -1,0 +1,67 @@
+# A frame that raises and catches in one body contributes EXACTLY ONE
+# traceback node, and it keeps that count once the loop is compiled.
+#
+# The raise routes through walk()'s SubRaise arm, which scans the raising
+# frame for its own `catch_exception/L` and jumps into the handler.  Both the
+# `raise/r` arm and that walk-catch arm can record a node for the same frame,
+# so the two have to divide the work: the raise arm emits the node the
+# compiled trace runs, the walk-catch arm applies the node for the recording
+# pass.  Either one taking both halves gives the frame two nodes; either one
+# taking neither drops the frame from the chain.
+#
+# Surveying over N iterations is what catches it — the pre-compile iterations
+# are correct, so a single sample sees nothing and a miscount shows up only as
+# a SECOND tuple in the shape set.
+#
+# `reraise` covers the bare-`raise` spelling, which must preserve the node the
+# original raise attached rather than adding one of its own, and the callee
+# case pins the two-frame chain the same run has to keep producing.
+N = 4000
+
+
+def chain(traceback):
+    out = []
+    while traceback is not None:
+        out.append((traceback.tb_frame.f_code.co_name, traceback.tb_lineno))
+        traceback = traceback.tb_next
+    return tuple(out)
+
+
+def raise_here(i):
+    try:
+        raise ValueError(i)
+    except ValueError as e:
+        return chain(e.__traceback__)
+
+
+def reraise_here(i):
+    try:
+        try:
+            raise KeyError(i)
+        except KeyError:
+            raise
+    except KeyError as e:
+        return chain(e.__traceback__)
+
+
+def callee_raise(i):
+    raise TypeError(i)
+
+
+def caught_from_callee(i):
+    try:
+        callee_raise(i)
+    except TypeError as e:
+        return chain(e.__traceback__)
+
+
+def survey(name, fn):
+    seen = set()
+    for i in range(N):
+        seen.add(fn(i))
+    print(name, sorted(seen))
+
+
+survey("raise_here   ", raise_here)
+survey("reraise_here ", reraise_here)
+survey("from_callee  ", caught_from_callee)

--- a/pyre/bench/synth/loop_exit_empty_dict_local_clobber.py
+++ b/pyre/bench/synth/loop_exit_empty_dict_local_clobber.py
@@ -1,0 +1,40 @@
+# A local must not read back as the `for` loop's iterator after the loop.
+#
+# An empty dict literal used to decline in the codewriter, and the decline
+# emitted `abort_permanent`, which closes its block: everything after it -
+# the whole loop - stopped being lowered. The loop header still resolved to a
+# walk entry, because the resume-marker tables carry an unlowered PC forward
+# onto the last marker that WAS emitted, so the walk entered the prologue
+# instead. Entry seeding fills a region's registers from the live frame by
+# SLOT, and the frame is parked at the loop header, so the prologue's
+# registers received the header's operand stack - the iterator - and replaying
+# the prologue's STORE_FAST published it into a local.
+#
+# `seen` printed `range_iterator` instead of `set` once the loop crossed the
+# compile threshold. The pre-compile iterations were correct and the local
+# still read correctly from inside the loop body, so only the loop-exit path
+# showed it.
+#
+# Discriminators, each verified against pypy3:
+#   * only the EMPTY dict literal tripped it - `dict()`, `{1: 2}`, `[]`,
+#     `set()`, `()` in the same position all lower normally;
+#   * a `while` loop was clean, saved only by the walk-entry stack-depth check
+#     that a `for` header's live stack of 1 happens to satisfy;
+#   * assigning the dict inside the loop or under an `if` was clean, and so
+#     was module scope - the function's own frame is what went wrong;
+#   * any iterator reproduced it (`list_iterator` and `enumerate` landed in the
+#     slot just as `range_iterator` did).
+#
+# Expected output: ('set', 'dict').
+N = 4000
+
+
+def driver(n):
+    seen = set()
+    acc = {}
+    for i in range(n):
+        pass
+    return type(seen).__name__, type(acc).__name__
+
+
+print(driver(N))

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -635,7 +635,8 @@ struct TracebackNodeSite {
     /// `PyTraceback.frame`.  `OpRef::NONE` when the walk has no materialized
     /// frame for this level — a branchless leaf inlined without one leaves
     /// the color unseeded.  Recording NONE as a `SetfieldGc` operand would
-    /// put a bogus box in the trace, so every caller has to resolve it.
+    /// put a bogus box in the trace, so every caller has to DECLINE on it and
+    /// leave the node to the frame-fabricating hook.
     frame: OpRef,
     w_code: usize,
     last_instruction: i32,
@@ -764,10 +765,11 @@ fn emit_traceback_node<Sym: WalkSym>(
 ///
 /// Every op is optimizer-visible, so escape analysis deletes the node when
 /// the exception never escapes.  The opaque
-/// `record_{,inline_,top_level_}application_traceback` hooks cannot be:
-/// they are `CanRaise` `call_void_typed_with_effect`s that force all lazy
-/// sets and materialize the exception, and the top-level one additionally
-/// passes the virtualizable frame box, forcing the vable.
+/// `record_{,inline_,top_level_}application_traceback` hooks cannot be: they
+/// carry `default_effect_info()` — `EffectInfo::MOST_GENERAL`, i.e. random
+/// effects — so the optimizer escapes every argument, forces all lazy sets
+/// and drops the whole heapcache, and the top-level one additionally passes
+/// the virtualizable frame box, forcing the vable.
 ///
 /// Returns `false` when nothing was emitted; the caller then keeps the
 /// opaque hook.
@@ -815,30 +817,37 @@ fn record_prepend_application_traceback<Sym: WalkSym>(
 /// exception's current traceback.  Sound only where the caller has proven
 /// the exception carries no prior node (`fbw_built_exc_take`); the general
 /// case is [`record_prepend_application_traceback`].
+///
+/// Returns `false` when nothing was emitted; the caller then keeps the
+/// opaque hook.
 fn record_fresh_application_traceback<Sym: WalkSym>(
     ctx: &mut WalkContext<'_, '_, Sym>,
     exc: OpRef,
     exc_concrete: ConcreteValue,
     opcode_position: usize,
-) {
+) -> bool {
     let ConcreteValue::Ref(exc_ptr) = exc_concrete else {
-        return;
+        return false;
     };
     if exc_ptr.is_null() || unsafe { !pyre_object::is_exception(exc_ptr) } {
-        return;
+        return false;
     }
-    let Some(mut site) = traceback_node_site(ctx, opcode_position) else {
-        return;
+    let Some(site) = traceback_node_site(ctx, opcode_position) else {
+        return false;
     };
     if site.frame.is_none() {
-        // No hook fallback on this route — the exception is one this walk
-        // built, so a frameless node still beats dropping it.  `tb_frame`
-        // answers None and the GC custom trace skips the null edge.
-        site.frame = ctx.trace_ctx.const_ref(0);
+        // No materialized frame for this level.  The opaque inline hook
+        // fabricates one from the promoted callee metadata
+        // (`record_inline_traceback_for_recording`), so `tb_frame` keeps
+        // answering a real frame; a null one answers None and breaks every
+        // consumer that follows `tb_frame.f_code` — `traceback.print_exc`
+        // among them.
+        return false;
     }
     let kind = unsafe { pyre_object::interp_exceptions::w_exception_get_kind(exc_ptr) };
     let w_next = ctx.trace_ctx.const_ref(0);
     emit_traceback_node(ctx, exc, kind, &site, w_next);
+    true
 }
 
 /// Compile-time-constant frame fields of an inlined callee.
@@ -9313,31 +9322,32 @@ fn handle<Sym: WalkSym>(
             if !recording_instruction_is_bare_reraise(ctx, op.pc) {
                 let caught_in_frame = try_catch_exception_at(code, op.next_pc).is_some();
                 if caught_in_frame {
-                    if freshly_normalized {
-                        record_fresh_application_traceback(ctx, exc, concrete_exc, op.pc);
+                    // Unless this walk built the exception it may already
+                    // carry callee nodes, so the general case prepends onto
+                    // its chain rather than starting a fresh one.  Either
+                    // recorder declining leaves the node to the opaque hook,
+                    // which fabricates the frame the walk has no box for.
+                    let emit_runtime = if freshly_normalized {
+                        !record_fresh_application_traceback(ctx, exc, concrete_exc, op.pc)
                     } else {
-                        // The exception may already carry callee nodes, so
-                        // the node prepends onto its chain rather than
-                        // starting a fresh one.
-                        let emit_runtime =
-                            !record_prepend_application_traceback(ctx, exc, concrete_exc, op.pc);
-                        record_inline_application_traceback(
-                            ctx,
-                            exc,
-                            concrete_exc,
-                            op.pc,
-                            false,
-                            emit_runtime,
-                        );
-                        record_top_level_application_traceback(
-                            ctx,
-                            exc,
-                            concrete_exc,
-                            op.pc,
-                            false,
-                            emit_runtime,
-                        );
-                    }
+                        !record_prepend_application_traceback(ctx, exc, concrete_exc, op.pc)
+                    };
+                    record_inline_application_traceback(
+                        ctx,
+                        exc,
+                        concrete_exc,
+                        op.pc,
+                        false,
+                        emit_runtime,
+                    );
+                    record_top_level_application_traceback(
+                        ctx,
+                        exc,
+                        concrete_exc,
+                        op.pc,
+                        false,
+                        emit_runtime,
+                    );
                 }
             }
             // Route the top-level raise through `SubRaise` so walk()'s

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -801,6 +801,15 @@ fn record_prepend_application_traceback<Sym: WalkSym>(
         // fabricates one from the promoted callee metadata
         // (`record_inline_traceback_for_recording`), so `tb_frame` keeps
         // answering a real frame there; a null here would lose it.
+        //
+        // Top level has no such hook fallback: `record_top_level_application_
+        // traceback` resolves its frame operand from the same unseeded color
+        // and declines too, so that level contributes no node at all.  A
+        // shorter traceback than `record_application_traceback` would build is
+        // the deliberate trade — the frame box a node needs is exactly what
+        // this walk lacks, and the vable box is not a substitute (a traceback
+        // outlives the frame, so storing it demands the escape marking this
+        // path does not perform).
         return false;
     }
     let kind = unsafe { pyre_object::interp_exceptions::w_exception_get_kind(exc_ptr) };
@@ -836,12 +845,10 @@ fn record_fresh_application_traceback<Sym: WalkSym>(
         return false;
     };
     if site.frame.is_none() {
-        // No materialized frame for this level.  The opaque inline hook
-        // fabricates one from the promoted callee metadata
-        // (`record_inline_traceback_for_recording`), so `tb_frame` keeps
-        // answering a real frame; a null one answers None and breaks every
-        // consumer that follows `tb_frame.f_code` — `traceback.print_exc`
-        // among them.
+        // Same disposition as the prepend sibling, for the same reason: the
+        // opaque inline hook fabricates a frame from the promoted callee
+        // metadata, while a null one answers None and breaks every consumer
+        // that follows `tb_frame.f_code` — `traceback.print_exc` among them.
         return false;
     }
     let kind = unsafe { pyre_object::interp_exceptions::w_exception_get_kind(exc_ptr) };
@@ -9326,7 +9333,11 @@ fn handle<Sym: WalkSym>(
                     // carry callee nodes, so the general case prepends onto
                     // its chain rather than starting a fresh one.  Either
                     // recorder declining leaves the node to the opaque hook,
-                    // which fabricates the frame the walk has no box for.
+                    // which builds a frame from the callee's code + globals
+                    // for the level the walk has no box for.  That frame
+                    // carries no locals and its own identity, so it is a
+                    // weaker node than the live one — still a node whose
+                    // `tb_frame.f_code` answers the right code object.
                     let emit_runtime = if freshly_normalized {
                         !record_fresh_application_traceback(ctx, exc, concrete_exc, op.pc)
                     } else {

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -7573,8 +7573,12 @@ fn compile_and_run_once(
     }
     let pjc = pyre_jit_trace::state::pyjitcode_for_code(frame_root.frame().pycode)
         .expect("registered portal must have a drained PyJitCode");
-    pjc.merge_entry_for(target_pc)
-        .expect("registered portal must have a static merge entry for the hot green");
+    // A body that stopped lowering at an `abort_permanent` carries no entry for
+    // the greens behind the abort, so the hot loop header has none.  There is
+    // no coordinate to start the walk from; interpret instead.
+    if pjc.merge_entry_for(target_pc).is_none() {
+        return None;
+    }
 
     let mut jit_state = build_jit_state(frame_root.frame(), info);
     let had_compiled = driver.has_compiled_loop(green_key);

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -7906,12 +7906,15 @@ impl CodeWriter {
                     // dispatch after `attach_catch_exception_edge` — the
                     // canraise op attaches its exception edge but the walker
                     // is expected to continue processing the canraise op's
-                    // normal-flow result and subsequent ops.  `emit_abort_
-                    // permanent!` is excluded by checking `exits.is_empty()`
-                    // — it inserts a runtime abort marker without closing
-                    // the block, so subsequent ops still need dispatch for
-                    // stack-depth parity (e.g. `Instruction::LoadName` +
-                    // `Instruction::StoreName` patterns at module scope).
+                    // normal-flow result and subsequent ops.
+                    //
+                    // `emit_abort_permanent!` is NOT excluded: it appends a
+                    // returnblock link, so `exits` is non-empty and every
+                    // later PC lands here and skips dispatch.  A body that
+                    // aborts therefore stops emitting at that opcode — which
+                    // is why `merge_entry_by_green` drops the loop headers
+                    // behind it instead of taking every header a bytecode
+                    // scan finds.
                     //
                     // Reuses `block_closed_by_terminator` computed above the
                     // loop-header `jit_merge_point` gate: the merge emission
@@ -13600,7 +13603,33 @@ impl CodeWriter {
         // otherwise the derivable resume marker. This is deliberately only
         // the set of trace-entry greens (function entry and loop headers), not
         // a general coordinate inverse.
-        let mut trace_entry_pcs: Vec<usize> = find_loop_header_pcs(code).iter().copied().collect();
+        //
+        // A header this body never lowered does NOT qualify.  `abort_permanent`
+        // closes its block, so every later PC is skipped as dead code and
+        // nothing at-or-after such a header emitted an op — exactly the case
+        // `derive_resume_marker` answers `None` for.  The dense carry-forward
+        // still has a value for it (the last `-live-` that WAS emitted, in the
+        // prologue), so the disagreement lands in `carryfwd_resume_pc` and
+        // `resolve_marker` would publish that unrelated offset as the header's
+        // walk entry.  `run_perfn_walk` seeds an entry marker's abstract
+        // registers from the live frame BY SLOT, so entering the prologue with
+        // the frame parked at the loop header fills the prologue's registers
+        // with the header's operand stack (for a `for` header, the iterator)
+        // and the replayed prologue stores them into locals.  Publishing no
+        // entry makes `merge_entry_for` answer `None`, which both the walk and
+        // `compile_and_run_once` read as "interpret this green".
+        let mut trace_entry_pcs: Vec<usize> = find_loop_header_pcs(code)
+            .iter()
+            .copied()
+            .filter(|&py_pc| {
+                pyre_jit_trace::pyjitcode::derive_resume_marker(
+                    &first_jit_pc_by_py_pc,
+                    &block_head_py_by_jit_pc,
+                    py_pc,
+                )
+                .is_some()
+            })
+            .collect();
         trace_entry_pcs.push(0);
         trace_entry_pcs.sort_unstable();
         trace_entry_pcs.dedup();

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -10468,21 +10468,11 @@ impl CodeWriter {
                         // `setarrayitem_gc_r` array build (`pyframe.py:408-419`),
                         // then a single `build_map_from_array` residual consuming
                         // the forced `[k0, v0, k1, v1, ...]` array. No arity cap:
-                        // the length travels in the array.
+                        // the length travels in the array.  count 0 (`{}`) takes
+                        // the same path as every other count, exactly like
+                        // BuildSet: an empty array yields an empty dict.
                         Instruction::BuildMap { count } => {
                             let nitems = count.get(op_arg) as usize * 2;
-                            // Empty `{}` (count 0) declines: the only corpus
-                            // site is `type(name, (), {})`, whose raise
-                            // (UnicodeEncodeError) exercises the unsupported
-                            // exception-resume-through-call path (#68/#51c).
-                            // Non-empty dict literals lower to the array
-                            // residual below.
-                            if nitems == 0 {
-                                push_fresh_ref(&mut current_state, &mut graph);
-                                current_depth += 1;
-                                emit_abort_permanent!(py_pc);
-                                continue;
-                            }
                             let mut item_values_rev = Vec::with_capacity(nitems);
                             for _ in 0..nitems {
                                 let _item_reg = emit_popvalue_ref!(current_depth, py_pc);
@@ -10620,9 +10610,7 @@ impl CodeWriter {
                         // `setarrayitem_gc_r` array build, then a single
                         // `build_set_from_array` residual consuming the forced
                         // element array.  No arity cap: the length travels in
-                        // the array.  Unlike BuildMap, no count==0 decline —
-                        // BuildSet has no raising corpus site (`{}` is a dict),
-                        // and an empty array yields an empty set.
+                        // the array.
                         Instruction::BuildSet { count } => {
                             let n = count.get(op_arg) as usize;
                             let mut item_values_rev = Vec::with_capacity(n);


### PR DESCRIPTION
Three defects plus the documentation follow-up from the #790 review.

## A local read back as the `for` loop's iterator (pre-existing, both backends)

```python
def driver(n):
    seen = set()
    acc = {}
    for i in range(n):
        pass
    return type(seen).__name__   # pypy3: set / pyre: range_iterator
```

Silent wrong answer once the loop crosses the compile threshold; `PYRE_JIT=0` is clean. The chain:

1. `BuildMap` declined `count == 0` and the decline emitted `abort_permanent`.
2. `emit_abort_permanent!` appends a returnblock link, so `block_closed_by_terminator` holds for every later PC and the rest of the function is never lowered — 127 bytes of jitcode versus 915 for the `dict()` twin, and no `jit_merge_point` at all.
3. `trace_entry_pcs` was a pure bytecode scan, so the unlowered loop header was still published as a walk entry. `derive_resume_marker` answers `None` past the truncation, so the dense carry-forward pointed that header at the prologue's last `-live-`.
4. `run_perfn_walk` accepted the entry (its only sanity check compares operand-stack depth, and a `for` header's live stack of 1 matches the prologue marker's), then seeded the prologue's registers from the live frame BY SLOT while the frame was parked at the header. The iterator landed in a register and the replayed prologue `STORE_FAST` published it into a local.

Two commits, because either alone is insufficient:

- `347c27db23` lowers `{}` through the same `new_array_clear` + `build_map_from_array` path as every other count, exactly like `BuildSet`.
- `cbddf590e4` filters `trace_entry_pcs` on `derive_resume_marker(..).is_some()` and makes `compile_and_run_once` interpret instead of `expect`ing a merge entry. Any other `abort_permanent` ahead of a hot `for` loop reproduces the identical corruption — confirmed with `match seq: case [_, _]:`.

Bench: `pyre/bench/synth/loop_exit_empty_dict_local_clobber.py`.

## A traceback node with a null `tb_frame` (#790 review, P2)

`d9dd30cda5`. `record_fresh_application_traceback` filled an unseeded frame color with `const_ref(0)`. `traceback.print_exc`, `format_exception` and `extract_tb` all read `tb.tb_frame.f_code`, so such a node raises `AttributeError`; meanwhile the recording pass attached a node with a real frame, so recording and compiled runs diverged. It now returns `bool` and declines, matching its `record_prepend_application_traceback` sibling, and the caller keeps the opaque hook — which fabricates a frame from the callee's code and globals. Only the missing frame box falls back; the `w_code` sentinel / non-code declines stay silent (the hook dereferences `w_code` through `createframe_obj`) and so does `hidden_applevel`.

The two other findings in that review were verified and rejected: the "walk-catch arm double-records a concrete node" reading is inverted — the base guard `matches!(op.opname, "raise/r" | …)` is dead code because `DecodedOp.opname` holds only the part before the slash, so base ran both calls too, and `record_fresh_application_traceback` performs no concrete record at all. Reinstating that guard would delete the recording iteration's only node for a same-frame raise. `hidden_applevel` is honoured one layer down in `record_application_traceback` for both hooks. `pyre/bench/synth/exception_raise_caught_same_frame_tb.py` locks the node count.

`5347220a00` records what the decline costs, from the parity review of this branch: at top level the sibling hook resolves its frame operand from the same unseeded color and declines too, so that level contributes no node, and the fabricated frame carries no locals and its own identity.

## Verification

- `check.py` dynasm 323/323, cranelift 323/323 (run sequentially)
- `cargo test --workspace --features dynasm` — 7082 passed, 0 failed
- `cargo fmt --check` clean
- the 28 exception benches byte-identical to pypy3

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved exception traceback reporting when stack frames are not materialized.
  * Prevented JIT execution failures by safely falling back to interpretation when required merge information is unavailable.
  * Improved handling of empty dictionary literals in compiled code.
  * Refined loop trace entry selection for more reliable execution.

* **Tests**
  * Added regression benchmarks covering exception traceback shapes, loop exits, and empty dictionary handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->