### PR TITLE
stdlib: support string slots and socket file wrappers

### DIFF
--- a/pyre/extra_tests/snippets/stdlib_configparser.py
+++ b/pyre/extra_tests/snippets/stdlib_configparser.py
@@ -1,0 +1,27 @@
+import configparser
+import gc
+
+
+line = configparser._Line("value ; comment", configparser._CommentSpec(("#",), (";",)))
+assert line == "value ; comment"
+assert line.clean == "value"
+assert line.has_comments is True
+assert not hasattr(line, "__dict__")
+
+marker = []
+line.clean = marker
+gc.collect()
+assert line.clean is marker
+del line.clean
+try:
+    line.clean
+except AttributeError:
+    pass
+else:
+    raise AssertionError("deleted str-subclass slot remained bound")
+
+parser = configparser.ConfigParser()
+parser.read_string("[section]\nanswer = 42 ; comment\n")
+assert parser["section"]["answer"] == "42 ; comment"
+
+print("stdlib configparser ok")

--- a/pyre/extra_tests/snippets/stdlib_socket.py
+++ b/pyre/extra_tests/snippets/stdlib_socket.py
@@ -12,6 +12,9 @@ MESSAGE_B = b"bbbbb"
 # TCP
 
 listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+assert type(listener) is socket.socket
+assert isinstance(listener, _socket.socket)
+assert hasattr(listener, "makefile")
 listener.bind(("127.0.0.1", 0))
 listener.listen(1)
 
@@ -26,6 +29,11 @@ recv_a = connection.recv(len(MESSAGE_A))
 recv_b = connector.recv(len(MESSAGE_B))
 assert recv_a == MESSAGE_A
 assert recv_b == MESSAGE_B
+
+raw = connection.makefile("rb", buffering=0)
+connector.send(MESSAGE_A)
+assert raw.read(len(MESSAGE_A)) == MESSAGE_A
+raw.close()
 
 fd = open("README.md", "rb")
 connector.sendfile(fd)

--- a/pyre/extra_tests/snippets/stdlib_socket_makefile.py
+++ b/pyre/extra_tests/snippets/stdlib_socket_makefile.py
@@ -1,0 +1,25 @@
+import socket
+
+
+with socket.socket() as listener:
+    assert type(listener) is socket.socket
+    assert hasattr(listener, "makefile")
+    listener.bind(("127.0.0.1", 0))
+    listener.listen(1)
+
+    with socket.socket() as client:
+        client.connect(listener.getsockname())
+        server, _ = listener.accept()
+        with server:
+            assert type(server) is socket.socket
+            raw = server.makefile("rb", buffering=0)
+            client.sendall(b"ping")
+            assert raw.read(4) == b"ping"
+            raw.close()
+
+# Exercise pack_inet_addr's hostname path, which must use a re-entrant
+# resolver because socketserver and logging handlers call it from workers.
+with socket.socket() as sock:
+    assert isinstance(sock.connect_ex(("localhost", 9)), int)
+
+print("stdlib socket makefile ok")

--- a/pyre/extra_tests/snippets/stdlib_warnings.py
+++ b/pyre/extra_tests/snippets/stdlib_warnings.py
@@ -1,4 +1,5 @@
 import _warnings
+import os
 import sys
 import warnings
 
@@ -55,6 +56,33 @@ except TypeError:
     pass
 else:
     raise AssertionError("non-Warning category accepted")
+
+try:
+    _warnings.warn("bad prefixes", skip_file_prefixes=[])
+except TypeError:
+    pass
+else:
+    raise AssertionError("non-tuple skip_file_prefixes accepted")
+
+try:
+    _warnings.warn("bad prefix item", skip_file_prefixes=(1,))
+except TypeError:
+    pass
+else:
+    raise AssertionError("non-str skip_file_prefixes item accepted")
+
+
+def warning_from_skipped_helper():
+    _warnings.warn(
+        "skip helper",
+        skip_file_prefixes=(os.path.dirname(__file__),),
+    )
+
+
+with warnings.catch_warnings(record=True) as caught:
+    warnings.simplefilter("always")
+    warning_from_skipped_helper()
+    assert caught[-1].filename != __file__
 
 for kwargs in ({"module_globals": True}, {"registry": 42}):
     try:

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -4123,12 +4123,11 @@ pub fn getdict(obj: PyObjectRef) -> PyObjectRef {
 ///
 /// A `W_Member` slot normally reads/writes the receiver's mapdict slot
 /// storage (`MapdictSlotsSupport`), which only a `W_ObjectObject` carries.
-/// A subclass of a builtin type with a fixed Rust payload (e.g. a subclass
-/// of `array.array`) keeps that native layout and has no mapdict, so the
-/// slot is instead backed by the instance `__dict__` — the same side table
-/// (`mapdict::INSTANCE_DICT`) that already holds the subclass's regular
-/// attributes. `None`/`false` means the receiver has no writable dict.
-pub(crate) fn native_slot_get(obj: PyObjectRef, name: &str) -> Option<PyObjectRef> {
+/// Native `str` subclasses carry their PyPy-shaped indexed storage on the
+/// `W_UnicodeObject` itself. Other fixed Rust payloads still fall back to an
+/// exposed instance `__dict__` when their type has one. `None`/`false` means
+/// the receiver has no writable storage.
+pub(crate) fn native_slot_get(obj: PyObjectRef, name: &str, index: u32) -> Option<PyObjectRef> {
     // Python 3.14 permits a native-layout `property` subclass to declare an
     // explicit `__doc__` slot.  PyPy's extended instance layout stores that
     // slot on the object; pyre's equivalent object-resident location is the
@@ -4138,6 +4137,9 @@ pub(crate) fn native_slot_get(obj: PyObjectRef, name: &str) -> Option<PyObjectRe
         let value = unsafe { pyre_object::descriptor::w_property_get_doc(obj) };
         return (!value.is_null()).then_some(value);
     }
+    if unsafe { pyre_object::is_str(obj) } {
+        return unsafe { pyre_object::unicodeobject::w_str_slot_get(obj, index as usize) };
+    }
     let w_dict = getdict(obj);
     if w_dict.is_null() {
         return None;
@@ -4145,9 +4147,18 @@ pub(crate) fn native_slot_get(obj: PyObjectRef, name: &str) -> Option<PyObjectRe
     unsafe { pyre_object::dictmultiobject::w_dict_getitem_str(w_dict, name) }
 }
 
-pub(crate) fn native_slot_set(obj: PyObjectRef, name: &str, value: PyObjectRef) -> bool {
+pub(crate) fn native_slot_set(
+    obj: PyObjectRef,
+    name: &str,
+    index: u32,
+    value: PyObjectRef,
+) -> bool {
     if name == "__doc__" && unsafe { pyre_object::descriptor::is_property(obj) } {
         unsafe { pyre_object::descriptor::w_property_set_doc(obj, value) };
+        return true;
+    }
+    if unsafe { pyre_object::is_str(obj) } {
+        unsafe { pyre_object::unicodeobject::w_str_slot_set(obj, index as usize, value) };
         return true;
     }
     let w_dict = getdict(obj);
@@ -4158,7 +4169,7 @@ pub(crate) fn native_slot_set(obj: PyObjectRef, name: &str, value: PyObjectRef) 
     true
 }
 
-pub(crate) fn native_slot_del(obj: PyObjectRef, name: &str) -> bool {
+pub(crate) fn native_slot_del(obj: PyObjectRef, name: &str, index: u32) -> bool {
     if name == "__doc__" && unsafe { pyre_object::descriptor::is_property(obj) } {
         let value = unsafe { pyre_object::descriptor::w_property_get_doc(obj) };
         if value.is_null() {
@@ -4166,6 +4177,9 @@ pub(crate) fn native_slot_del(obj: PyObjectRef, name: &str) -> bool {
         }
         unsafe { pyre_object::descriptor::w_property_set_doc(obj, pyre_object::PY_NULL) };
         return true;
+    }
+    if unsafe { pyre_object::is_str(obj) } {
+        return unsafe { pyre_object::unicodeobject::w_str_slot_del(obj, index as usize) };
     }
     let w_dict = getdict(obj);
     if w_dict.is_null() {
@@ -8751,7 +8765,11 @@ pub(crate) unsafe fn get(
             crate::objspace::std::mapdict::getslotvalue(obj, index)
         } else {
             // Native-layout subclass instance — slot backed by __dict__.
-            native_slot_get(obj, pyre_object::w_member_get_name(descr))
+            native_slot_get(
+                obj,
+                pyre_object::w_member_get_name(descr),
+                pyre_object::w_member_get_index(descr),
+            )
         };
         // typedef.py:512-516: if w_result is None: raise
         // AttributeError("'%T' object has no attribute '%s'")
@@ -8841,7 +8859,7 @@ unsafe fn set(
         } else {
             // Native-layout subclass instance — slot backed by __dict__.
             let slot_name = pyre_object::w_member_get_name(descr);
-            if !native_slot_set(obj, slot_name, value) {
+            if !native_slot_set(obj, slot_name, index, value) {
                 return Err(crate::PyError::new(
                     crate::PyErrorKind::AttributeError,
                     format!(
@@ -8913,7 +8931,11 @@ unsafe fn delete(descr: PyObjectRef, obj: PyObjectRef) -> Result<(), crate::PyEr
             crate::objspace::std::mapdict::delslotvalue(obj, index)
         } else {
             // Native-layout subclass instance — slot backed by __dict__.
-            native_slot_del(obj, pyre_object::w_member_get_name(descr))
+            native_slot_del(
+                obj,
+                pyre_object::w_member_get_name(descr),
+                pyre_object::w_member_get_index(descr),
+            )
         };
         if !removed {
             let slot_name = pyre_object::w_member_get_name(descr);

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -4303,12 +4303,14 @@ pub unsafe fn create_all_slots(
             // typeobject.py:1178: string_sort(newslotnames)
             newslotnames.sort();
 
-            // CPython 3.14 rejects additional instance slots on variable-size
-            // builtin layouts (the Py_TPFLAGS_ITEMS_AT_END families).
+            // CPython 3.14 rejects additional instance slots on the remaining
+            // variable-size builtin layouts. `str` is deliberately excluded:
+            // current CPython permits them (configparser._Line relies on it),
+            // and PyPy stores them in BaseUserClassMapdict like every other
+            // app-level subclass slot.
             if !newslotnames.is_empty() && !base_layout.is_null() {
                 let typedef = (*base_layout).typedef;
                 if std::ptr::eq(typedef, &pyre_object::INT_TYPE)
-                    || std::ptr::eq(typedef, &pyre_object::STR_TYPE)
                     || std::ptr::eq(typedef, &pyre_object::TUPLE_TYPE)
                     || std::ptr::eq(typedef, &pyre_object::bytesobject::BYTES_TYPE)
                 {

--- a/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
+++ b/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
@@ -1973,7 +1973,34 @@ fn socket_from_fd(
     ty: libc::c_int,
     proto: libc::c_int,
 ) -> pyre_object::PyObjectRef {
-    let obj = pyre_object::w_instance_new(socket_type());
+    socket_from_fd_with_class(fd, family, ty, proto, socket_type())
+}
+
+#[cfg(unix)]
+fn socket_from_fd_with_class(
+    fd: libc::c_int,
+    family: libc::c_int,
+    ty: libc::c_int,
+    proto: libc::c_int,
+    cls: pyre_object::PyObjectRef,
+) -> pyre_object::PyObjectRef {
+    // PyPy's typeobject.py allocate_instance preserves the requested
+    // W_TypeObject when W_Socket.descr_init initialises a user subclass.
+    // The stdlib relies on this for `class socket(_socket.socket)`: losing
+    // `cls` here also loses its Python-level makefile() and lifecycle state.
+    let obj = pyre_object::w_instance_new(cls);
+    socket_init_state(obj, fd, family, ty, proto);
+    obj
+}
+
+#[cfg(unix)]
+fn socket_init_state(
+    obj: pyre_object::PyObjectRef,
+    fd: libc::c_int,
+    family: libc::c_int,
+    ty: libc::c_int,
+    proto: libc::c_int,
+) {
     socket_set_attr(obj, "_fd", pyre_object::w_int_new(fd as i64));
     socket_set_attr(obj, "_family", pyre_object::w_int_new(family as i64));
     socket_set_attr(obj, "_type", pyre_object::w_int_new(ty as i64));
@@ -1983,7 +2010,6 @@ fn socket_from_fd(
     // `_drop` followed by no `_reuse` closes the underlying fd exactly
     // once.
     socket_set_attr(obj, "_usecount", pyre_object::w_int_new(1));
-    obj
 }
 
 /// `rsocket.py:1694 get_socket_family` — the family of an existing fd,
@@ -2133,18 +2159,40 @@ fn pack_inet_addr(
             )
         };
         if r != 1 {
-            // Fall back to gethostbyname for hostnames.
-            let he = unsafe { gethostbyname(c_host.as_ptr()) };
-            if he.is_null() {
+            // `rsocket.makeipaddr` resolves names through getaddrinfo and
+            // copies the resulting address into its INETAddress.  Do the
+            // same here: gethostbyname's process-global result buffer is not
+            // re-entrant and was corrupted by socketserver worker threads.
+            let mut hints: libc::addrinfo = unsafe { std::mem::zeroed() };
+            hints.ai_family = libc::AF_INET;
+            let mut result: *mut libc::addrinfo = std::ptr::null_mut();
+            let rc = unsafe {
+                libc::getaddrinfo(c_host.as_ptr(), std::ptr::null(), &hints, &mut result)
+            };
+            if rc != 0 || result.is_null() {
                 return Err(crate::PyError::os_error(format!(
                     "name or service not known: {host}"
                 )));
             }
-            unsafe {
-                let h = &*he;
-                let addr_ptr = *h.h_addr_list;
-                sin.sin_addr.s_addr = *(addr_ptr as *const u32);
+            let mut current = result;
+            let mut resolved = None;
+            while !current.is_null() {
+                let info = unsafe { &*current };
+                if info.ai_family == libc::AF_INET
+                    && !info.ai_addr.is_null()
+                    && info.ai_addrlen as usize >= core::mem::size_of::<libc::sockaddr_in>()
+                {
+                    let resolved_addr =
+                        unsafe { &*(info.ai_addr as *const libc::sockaddr_in) };
+                    resolved = Some(resolved_addr.sin_addr);
+                    break;
+                }
+                current = info.ai_next;
             }
+            unsafe { libc::freeaddrinfo(result) };
+            sin.sin_addr = resolved.ok_or_else(|| {
+                crate::PyError::os_error(format!("name or service not known: {host}"))
+            })?;
         }
         Ok((
             storage,
@@ -2252,22 +2300,31 @@ fn unpack_inet_addr(storage: &libc::sockaddr_storage) -> pyre_object::PyObjectRe
 
 #[cfg(unix)]
 fn init_socket_type(ns: pyre_object::PyObjectRef) {
-    // The `socket` callable: socket(family=AF_INET, type=SOCK_STREAM, proto=0, fileno=None)
-    // CPython lets you pass a pre-existing fd via fileno=; we honor that
-    // by wrapping the fd directly instead of calling socket(2).
+    // `interp_socket.py:W_Socket.__init__` first creates an empty wrapper;
+    // `descr_init` below installs the RSocket state.  Keeping allocation and
+    // initialisation separate is required when socket.py's Python subclass
+    // explicitly calls `_socket.socket.__init__(self, ...)`.
     unsafe { pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
         ns,
         "__new__",
         crate::make_builtin_function("__new__", |args| {
-            // args = (cls, family, type, proto, fileno).  The cls slot is
-            // present when the type is invoked as `socket(...)`; keyword
-            // arguments arrive as a trailing `__pyre_kw__` dict.
-            let after_cls = if !args.is_empty() && !unsafe { pyre_object::is_int(args[0]) } {
-                &args[1..]
-            } else {
-                args
-            };
-            let (pos, kwargs) = crate::builtins::split_builtin_kwargs(after_cls);
+            let cls = args
+                .first()
+                .copied()
+                .filter(|w_cls| unsafe { pyre_object::is_type(*w_cls) })
+                .unwrap_or_else(socket_type);
+            Ok(pyre_object::w_instance_new(cls))
+        }),
+    ) };
+    unsafe { pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+        ns,
+        "__init__",
+        crate::make_builtin_function("__init__", |args| {
+            // `interp_socket.py:216 descr_init(family=-1, type=-1, proto=-1,
+            // w_fileno=None)`.
+            let obj = args.first().copied().unwrap_or(pyre_object::PY_NULL);
+            let after_self = if args.is_empty() { args } else { &args[1..] };
+            let (pos, kwargs) = crate::builtins::split_builtin_kwargs(after_self);
             // `descr_init`'s `@unwrap_spec` signature rejects unknown
             // keywords and a parameter supplied both by position and name.
             crate::builtins::kwarg_reject_unknown(
@@ -2338,7 +2395,8 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
                 unsafe {
                     libc::fcntl(fd, libc::F_SETFD, libc::FD_CLOEXEC);
                 }
-                return Ok(socket_from_fd(fd, family, ty, proto));
+                socket_init_state(obj, fd, family, ty, proto);
+                return Ok(pyre_object::w_none());
             }
             // `interp_socket.py:253-265` — wrap an existing fd.  A float
             // fileno is a TypeError, a negative fd a ValueError, and any
@@ -2365,7 +2423,8 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
             if proto == -1 {
                 proto = socket_get_so_protocol(fd)?;
             }
-            Ok(socket_from_fd(fd, family, ty, proto))
+            socket_init_state(obj, fd, family, ty, proto);
+            Ok(pyre_object::w_none())
         }),
     ) };
 

--- a/pyre/pyre-interpreter/src/module/_warnings/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_warnings/mod.rs
@@ -128,7 +128,19 @@ fn is_internal_frame(frame: *mut crate::PyFrame) -> bool {
     filename.contains("importlib") && filename.contains("_bootstrap")
 }
 
-fn get_frame(mut stacklevel: i64) -> *mut crate::PyFrame {
+fn filename_has_prefix(frame: *mut crate::PyFrame, skip_file_prefixes: &[String]) -> bool {
+    if frame.is_null() {
+        return false;
+    }
+    let filename = unsafe { &*crate::pyframe::pyframe_get_pycode(&*frame) }
+        .source_path
+        .as_str();
+    skip_file_prefixes
+        .iter()
+        .any(|prefix| filename.starts_with(prefix))
+}
+
+fn get_frame(mut stacklevel: i64, skip_file_prefixes: &[String]) -> *mut crate::PyFrame {
     let ec = crate::call::getexecutioncontext();
     if ec.is_null() {
         return std::ptr::null_mut();
@@ -143,7 +155,10 @@ fn get_frame(mut stacklevel: i64) -> *mut crate::PyFrame {
         while stacklevel > 1 && !frame.is_null() {
             loop {
                 frame = crate::executioncontext::ExecutionContext::getnextframe_nohidden(frame);
-                if frame.is_null() || !is_internal_frame(frame) {
+                if frame.is_null()
+                    || (!is_internal_frame(frame)
+                        && !filename_has_prefix(frame, skip_file_prefixes))
+                {
                     break;
                 }
             }
@@ -153,9 +168,12 @@ fn get_frame(mut stacklevel: i64) -> *mut crate::PyFrame {
     frame
 }
 
-fn setup_context(stacklevel: i64) -> (PyObjectRef, i64, PyObjectRef, PyObjectRef) {
+fn setup_context(
+    stacklevel: i64,
+    skip_file_prefixes: &[String],
+) -> (PyObjectRef, i64, PyObjectRef, PyObjectRef) {
     let _roots = pyre_object::gc_roots::push_roots();
-    let frame = get_frame(stacklevel);
+    let frame = get_frame(stacklevel, skip_file_prefixes);
     let (filename, lineno, globals) = if frame.is_null() {
         let globals = crate::importing::get_sys_module("sys")
             .map(|module| unsafe { w_module_get_w_dict(module) })
@@ -712,9 +730,41 @@ crate::py_module! {
             #[default(pyre_object::PY_NULL)] category: PyObjectRef,
             #[default(1i64)] stacklevel: i64,
             #[kwonly] #[default(pyre_object::PY_NULL)] source: PyObjectRef,
+            #[kwonly] #[default(pyre_object::PY_NULL)] skip_file_prefixes: PyObjectRef,
         ) -> Result<PyObjectRef, PyError> {
+            // CPython 3.14 `_warnings.warn`: `skip_file_prefixes` is a
+            // tuple-only fast-path argument.  Its frame walk is the current
+            // PyPy `get_frame` walk with matching filenames skipped alongside
+            // importlib-internal frames.
+            let skip_file_prefixes = if skip_file_prefixes.is_null() {
+                Vec::new()
+            } else {
+                if unsafe { !pyre_object::is_tuple(skip_file_prefixes) } {
+                    return Err(PyError::type_error(format!(
+                        "warn() argument 'skip_file_prefixes' must be tuple, not {}",
+                        crate::baseobjspace::object_functionstr_type_name(skip_file_prefixes),
+                    )));
+                }
+                let mut prefixes = Vec::new();
+                for prefix in crate::baseobjspace::fixedview(skip_file_prefixes, -1)? {
+                    if unsafe { !pyre_object::is_str(prefix) } {
+                        return Err(PyError::type_error(format!(
+                            "Found non-str '{}' in skip_file_prefixes.",
+                            crate::baseobjspace::object_functionstr_type_name(prefix),
+                        )));
+                    }
+                    prefixes.push(crate::baseobjspace::text_w(prefix)?.to_string());
+                }
+                prefixes
+            };
+            let stacklevel = if skip_file_prefixes.is_empty() {
+                stacklevel
+            } else {
+                stacklevel.max(2)
+            };
             let category = get_category(message, category)?;
-            let (filename, lineno, module, registry) = setup_context(stacklevel);
+            let (filename, lineno, module, registry) =
+                setup_context(stacklevel, &skip_file_prefixes);
             do_warn_explicit(
                 category, message, filename, lineno, module, registry,
                 pyre_object::PY_NULL, source,

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -11335,7 +11335,7 @@ fn init_member_descriptor_type(ns: PyObjectRef) {
                 let found = if unsafe { pyre_object::is_instance(obj) } {
                     unsafe { crate::objspace::std::mapdict::getslotvalue(obj, index) }
                 } else {
-                    crate::baseobjspace::native_slot_get(obj, slot_name)
+                    crate::baseobjspace::native_slot_get(obj, slot_name, index)
                 };
                 match found {
                     Some(v) => Ok(v),
@@ -11388,7 +11388,7 @@ fn init_member_descriptor_type(ns: PyObjectRef) {
                     unsafe { crate::objspace::std::mapdict::setslotvalue(obj, index, value) };
                 } else {
                     let slot_name = unsafe { pyre_object::w_member_get_name(descr) };
-                    if !crate::baseobjspace::native_slot_set(obj, slot_name, value) {
+                    if !crate::baseobjspace::native_slot_set(obj, slot_name, index, value) {
                         return Err(crate::PyError::new(
                             crate::PyErrorKind::AttributeError,
                             format!(
@@ -11439,7 +11439,7 @@ fn init_member_descriptor_type(ns: PyObjectRef) {
                 let removed = if unsafe { pyre_object::is_instance(obj) } {
                     unsafe { crate::objspace::std::mapdict::delslotvalue(obj, index) }
                 } else {
-                    crate::baseobjspace::native_slot_del(obj, slot_name)
+                    crate::baseobjspace::native_slot_del(obj, slot_name, index)
                 };
                 if !removed {
                     return Err(crate::PyError::new(

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -1869,15 +1869,20 @@ fn build_gc() -> Box<dyn majit_gc::GcAllocator> {
     // value (an immortal holder cannot grey an old-gen box), which the
     // `is_managed_heap_object` guard on the edge skips. Managed subclass
     // instances also need the header's `w_class` traced, matching
-    // W_ObjectObject's instance-class edge. No `.with_destructor_fn`: the box
-    // tid's drop glue is the sole reclaimer (a holder destructor would
-    // double-free a box swept before its owner).
+    // W_ObjectObject's instance-class edge. A slots-bearing `str` subclass
+    // also owns a normal list in `w_slots`; tracing that list edge gives the
+    // list's custom tracer ownership of the individual slot values, matching
+    // PyPy's object-resident BaseUserClassMapdict storage. No
+    // `.with_destructor_fn`: the value-box tid's drop glue is the sole
+    // reclaimer (a holder destructor would double-free a box swept before its
+    // owner).
     let w_str_tid = gc.register_type(TypeInfo::object_subclass_with_gc_ptrs(
         std::mem::size_of::<pyre_object::unicodeobject::W_UnicodeObject>(),
         object_tid,
         vec![
             pyre_object::pyobject::W_CLASS_OFFSET,
             pyre_object::unicodeobject::UNICODE_VALUE_OFFSET,
+            pyre_object::unicodeobject::UNICODE_W_SLOTS_OFFSET,
         ],
     ));
     debug_assert_eq!(w_str_tid, W_UNICODE_GC_TYPE_ID);

--- a/pyre/pyre-object/src/unicodeobject.rs
+++ b/pyre/pyre-object/src/unicodeobject.rs
@@ -21,7 +21,8 @@ use crate::pyobject::*;
 
 /// Python string object.
 ///
-/// Layout: `[ob_type | w_class | value:*mut Wtf8Buf | byte_len | len]`
+/// Layout:
+/// `[ob_type | w_class | value:*mut Wtf8Buf | byte_len | len | w_slots]`
 /// `byte_len` is the WTF-8 byte count (RPython STR `rstr.py:1226
 /// Array(Char)` parity — `llmodel.py:667 bh_strlen` reads this).
 /// `len` is the codepoint count (RPython UNICODE parity —
@@ -33,6 +34,13 @@ pub struct W_UnicodeObject {
     pub value: *mut Wtf8Buf,
     pub byte_len: usize,
     pub len: usize,
+    /// PyPy `BaseUserClassMapdict` slot storage for a `str` subclass.
+    ///
+    /// Exact strings and subclasses without populated slots keep `PY_NULL`.
+    /// A slots-bearing subclass owns an object-strategy list indexed by the
+    /// `Member.index` from its layout. Keeping this on the object mirrors
+    /// PyPy's `_mapdict_*storage` owner and avoids an address-keyed side table.
+    pub w_slots: PyObjectRef,
 }
 
 /// Field offset of `value` within `W_UnicodeObject`, for JIT field access.
@@ -41,6 +49,8 @@ pub const UNICODE_VALUE_OFFSET: usize = std::mem::offset_of!(W_UnicodeObject, va
 pub const UNICODE_BYTE_LEN_OFFSET: usize = std::mem::offset_of!(W_UnicodeObject, byte_len);
 /// Field offset of `len` (codepoint count) for UNICODE UNICODELEN parity.
 pub const UNICODE_LEN_OFFSET: usize = std::mem::offset_of!(W_UnicodeObject, len);
+/// Field offset of the subclass slot-storage list.
+pub const UNICODE_W_SLOTS_OFFSET: usize = std::mem::offset_of!(W_UnicodeObject, w_slots);
 
 /// GC type id assigned to `W_UnicodeObject` at JitDriver init time.
 pub const W_UNICODE_GC_TYPE_ID: u32 = 34;
@@ -113,6 +123,7 @@ pub fn w_str_new(s: &str) -> PyObjectRef {
         value,
         byte_len,
         len: char_len,
+        w_slots: PY_NULL,
     }) as PyObjectRef
 }
 
@@ -148,6 +159,7 @@ pub fn w_str_from_wtf8(value: Wtf8Buf) -> PyObjectRef {
         value,
         byte_len,
         len: char_len,
+        w_slots: PY_NULL,
     }) as PyObjectRef
 }
 
@@ -178,6 +190,7 @@ pub fn w_str_from_wtf8_managed(value: Wtf8Buf) -> PyObjectRef {
         value,
         byte_len,
         len: char_len,
+        w_slots: PY_NULL,
     };
     let raw = crate::gc_hook::try_gc_alloc_stable_raw(W_UNICODE_GC_TYPE_ID, W_UNICODE_OBJECT_SIZE);
     if raw.is_null() {
@@ -215,6 +228,7 @@ pub fn w_str_from_wtf8_immortal(value: Wtf8Buf) -> PyObjectRef {
         value,
         byte_len,
         len: char_len,
+        w_slots: PY_NULL,
     }) as PyObjectRef
 }
 
@@ -238,6 +252,7 @@ pub fn w_str_subclass_from_wtf8(value: Wtf8Buf, w_class: PyObjectRef) -> PyObjec
         value,
         byte_len,
         len: char_len,
+        w_slots: PY_NULL,
     };
     let raw = crate::gc_hook::try_gc_alloc_stable_raw(W_UNICODE_GC_TYPE_ID, W_UNICODE_OBJECT_SIZE);
     let obj = if raw.is_null() {
@@ -250,6 +265,60 @@ pub fn w_str_subclass_from_wtf8(value: Wtf8Buf, w_class: PyObjectRef) -> PyObjec
     };
     crate::gc_hook::maybe_register_finalizer(obj);
     obj
+}
+
+/// Read one app-level `__slots__` entry from a `str` subclass.
+///
+/// PyPy's `BaseUserClassMapdict.getslotvalue` indexes the instance-owned
+/// storage list by `Member.index`.  `PY_NULL` is the unbound-slot sentinel.
+pub unsafe fn w_str_slot_get(obj: PyObjectRef, index: usize) -> Option<PyObjectRef> {
+    let slots = unsafe { (*(obj as *const W_UnicodeObject)).w_slots };
+    if slots.is_null() {
+        return None;
+    }
+    unsafe { crate::listobject::w_list_getitem(slots, index as i64) }
+        .filter(|value| !value.is_null())
+}
+
+/// Write one app-level `__slots__` entry on a `str` subclass.
+pub unsafe fn w_str_slot_set(obj: PyObjectRef, index: usize, value: PyObjectRef) {
+    let _roots = crate::gc_roots::push_roots();
+    crate::gc_roots::pin_root(obj);
+    crate::gc_roots::pin_root(value);
+    let obj_slot = crate::gc_roots::shadow_stack_len() - 2;
+    let value_slot = crate::gc_roots::shadow_stack_len() - 1;
+
+    let mut rooted_obj = crate::gc_roots::shadow_stack_get(obj_slot);
+    let mut slots = unsafe { (*(rooted_obj as *const W_UnicodeObject)).w_slots };
+    if slots.is_null() {
+        slots = crate::listobject::w_list_new(vec![PY_NULL; index + 1]);
+        rooted_obj = crate::gc_roots::shadow_stack_get(obj_slot);
+        unsafe { (*(rooted_obj as *mut W_UnicodeObject)).w_slots = slots };
+        crate::gc_hook::try_gc_write_barrier(rooted_obj as *mut u8);
+    } else {
+        while unsafe { crate::listobject::w_list_len(slots) } <= index {
+            unsafe { crate::listobject::w_list_append(slots, PY_NULL) };
+        }
+    }
+    unsafe {
+        crate::listobject::w_list_setitem(
+            slots,
+            index as i64,
+            crate::gc_roots::shadow_stack_get(value_slot),
+        );
+    }
+}
+
+/// Clear one app-level `__slots__` entry on a `str` subclass.
+pub unsafe fn w_str_slot_del(obj: PyObjectRef, index: usize) -> bool {
+    let slots = unsafe { (*(obj as *const W_UnicodeObject)).w_slots };
+    if slots.is_null()
+        || unsafe { crate::listobject::w_list_getitem(slots, index as i64) }
+            .is_none_or(|value| value.is_null())
+    {
+        return false;
+    }
+    unsafe { crate::listobject::w_list_setitem(slots, index as i64, PY_NULL) }
 }
 
 thread_local! {
@@ -446,6 +515,7 @@ mod tests {
         assert_eq!(UNICODE_VALUE_OFFSET, 16);
         assert_eq!(UNICODE_BYTE_LEN_OFFSET, 24);
         assert_eq!(UNICODE_LEN_OFFSET, 32);
+        assert_eq!(UNICODE_W_SLOTS_OFFSET, 40);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add object-owned slot storage and GC tracing for `str` subclasses used by `configparser`
- implement `warnings.warn(skip_file_prefixes=...)` frame filtering
- preserve stdlib socket subclass identity, split socket allocation/initialization like PyPy, and enable `socket.makefile()`
- replace non-reentrant hostname resolution with `getaddrinfo()`

## Verification
- `cargo check --features dynasm`
- `cargo test --features dynasm`
- dynasm stdlib regressions: configparser, warnings, socket makefile, logging
- `python3 pyre/check.py --backend dynasm --no-synthetic target/release/pyre-dynasm` (14/14)

RustPython changes were not required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for `str` subclasses with instance slots.
  * Added `skip_file_prefixes` support to warnings for more accurate warning locations.
  * Improved socket subclass construction, hostname resolution, and file-like socket access.

* **Bug Fixes**
  * Improved garbage collection tracking for string subclass slots.
  * Preserved inline configuration comments during parsing.
  * Added validation for invalid warning prefix settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->