### PR TITLE
Windows: msvcrt, winreg follow-ups (os.utime, text-mode CRLF)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2213,6 +2213,7 @@ dependencies = [
  "rustpython-wtf8",
  "siphasher",
  "stacker",
+ "widestring",
  "windows-sys 0.61.2",
 ]
 

--- a/pyre/pyre-interpreter/Cargo.toml
+++ b/pyre/pyre-interpreter/Cargo.toml
@@ -78,7 +78,11 @@ windows-sys = { version = "0.61", features = [
     "Win32_Foundation",
     "Win32_Storage_FileSystem",
     "Win32_System_LibraryLoader",
+    "Win32_System_Threading",
 ] }
+# Builds the `WideCStr` key/value-name arguments the `rustpython_host_env::winreg`
+# Reg* wrappers take. Same 1.x line host_env resolves to.
+widestring = "1.2"
 
 [build-dependencies]
 # Compresses the embedded stdlib VFS blob at build time (only does work when the

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -525,6 +525,10 @@ pub fn install_builtin_modules() {
     // module must exist for the import machinery (and `import site`) to start.
     #[cfg(windows)]
     pyre_install_module!(winreg);
+    // `subprocess` picks its Windows implementation from the presence of
+    // `msvcrt`; `getpass` reads the console through it.
+    #[cfg(all(windows, feature = "host_env"))]
+    pyre_install_module!(msvcrt);
     pyre_install_module!(_abc);
     pyre_install_module!(_functools);
     pyre_install_module!("_thread"(thread));

--- a/pyre/pyre-interpreter/src/module/_io/textio.rs
+++ b/pyre/pyre-interpreter/src/module/_io/textio.rs
@@ -456,6 +456,29 @@ impl W_TextIOWrapper {
         self.readtranslate = newline.is_none();
     }
 
+    /// The string `write` substitutes for `'\n'`, or `None` for no
+    /// translation.  PyPy `W_TextIOWrapper` `writetranslate`/`writenl`: an
+    /// explicit `'\r'` or `'\r\n'` is honored on every platform; `newline=None`
+    /// writes the platform line separator (`'\r\n'` on Windows, untranslated
+    /// elsewhere); `''` and `'\n'` are written verbatim.
+    fn write_newline(&self) -> Option<&'static str> {
+        match self.configured_newline() {
+            None => {
+                #[cfg(windows)]
+                {
+                    Some("\r\n")
+                }
+                #[cfg(not(windows))]
+                {
+                    None
+                }
+            }
+            Some("\r") => Some("\r"),
+            Some("\r\n") => Some("\r\n"),
+            _ => None,
+        }
+    }
+
     fn size_limit(w_size: PyObjectRef) -> Result<Option<usize>, crate::PyError> {
         if unsafe { pyre_object::is_none(w_size) } {
             return Ok(None);
@@ -967,9 +990,7 @@ impl W_TextIOWrapper {
 
         let mut to_encode = text;
         if has_lf {
-            if let Some(writenl) = self.configured_newline()
-                && matches!(writenl, "\r" | "\r\n")
-            {
+            if let Some(writenl) = self.write_newline() {
                 to_encode = super::call_method_result(
                     text,
                     "replace",

--- a/pyre/pyre-interpreter/src/module/_winapi/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_winapi/mod.rs
@@ -16,11 +16,20 @@
 //! `lib_pypy/_winapi.py`, which predates the stdlib revision pyre ships, so
 //! both are defined against the Win32 headers instead.
 //!
-//! The process and handle half (`CreateProcess`, `DuplicateHandle`, the
-//! pipe calls) has no reachable caller: `subprocess` picks its Windows
-//! implementation on the presence of `msvcrt`, and `multiprocessing`'s
-//! spawn/reduction paths only touch `_winapi` once a Windows process
-//! launch is already underway.
+//! `subprocess` picks its Windows implementation on the presence of `msvcrt`
+//! (now installed), so its module body imports the process/priority constants
+//! and captures `CloseHandle`/`WaitForSingleObject`/`GetExitCodeProcess` as
+//! default arguments — those must exist here for `import subprocess` to
+//! succeed.  The `CreateProcess`/pipe/`DuplicateHandle` half a real launch
+//! needs is still absent, so an actual `Popen` spawn is a further follow-up.
+
+/// Map the current thread's last OS error to an `OSError`.
+fn last_os_error() -> crate::PyError {
+    crate::PyError::os_error_syscall(
+        crate::builtins::io_error_posix_errno(&std::io::Error::last_os_error(), 0),
+        pyre_object::PY_NULL,
+    )
+}
 
 crate::py_module! {
     "_winapi",
@@ -32,6 +41,37 @@ crate::py_module! {
         // `OSError.winerror` against to decide whether to retry.
         "ERROR_ACCESS_DENIED" => 5,
         "ERROR_PRIVILEGE_NOT_HELD" => 1314,
+        // `subprocess` imports these at module load (its Windows branch, taken
+        // once `msvcrt` exists) — GetStdHandle ids, ShowWindow/STARTUPINFO
+        // flags, and CreateProcess creation/priority flags (winbase.h,
+        // processthreadsapi.h).  Exposed as the unsigned DWORD values.
+        "STD_INPUT_HANDLE" => 0xFFFF_FFF6u32,
+        "STD_OUTPUT_HANDLE" => 0xFFFF_FFF5u32,
+        "STD_ERROR_HANDLE" => 0xFFFF_FFF4u32,
+        "SW_HIDE" => 0,
+        "STARTF_USESHOWWINDOW" => 0x0000_0001,
+        "STARTF_USESTDHANDLES" => 0x0000_0100,
+        "STARTF_FORCEONFEEDBACK" => 0x0000_0040,
+        "STARTF_FORCEOFFFEEDBACK" => 0x0000_0080,
+        "CREATE_NEW_CONSOLE" => 0x0000_0010,
+        "CREATE_NEW_PROCESS_GROUP" => 0x0000_0200,
+        "CREATE_NO_WINDOW" => 0x0800_0000,
+        "DETACHED_PROCESS" => 0x0000_0008,
+        "CREATE_DEFAULT_ERROR_MODE" => 0x0400_0000,
+        "CREATE_BREAKAWAY_FROM_JOB" => 0x0100_0000,
+        "ABOVE_NORMAL_PRIORITY_CLASS" => 0x0000_8000,
+        "BELOW_NORMAL_PRIORITY_CLASS" => 0x0000_4000,
+        "HIGH_PRIORITY_CLASS" => 0x0000_0080,
+        "IDLE_PRIORITY_CLASS" => 0x0000_0040,
+        "NORMAL_PRIORITY_CLASS" => 0x0000_0020,
+        "REALTIME_PRIORITY_CLASS" => 0x0000_0100,
+        // WaitForSingleObject results / GetExitCodeProcess sentinel that
+        // `subprocess.Popen._wait`/`poll` capture (winbase.h, ntstatus.h).
+        "WAIT_OBJECT_0" => 0,
+        "WAIT_ABANDONED_0" => 0x0000_0080,
+        "WAIT_TIMEOUT" => 0x0000_0102,
+        "INFINITE" => 0xFFFF_FFFFu32,
+        "STILL_ACTIVE" => 259,
     },
     inline_functions: {
         fn NeedCurrentDirectoryForExePath(exe_name: &str) -> bool {
@@ -41,6 +81,39 @@ crate::py_module! {
             let exe_name_w: Vec<u16> =
                 exe_name.encode_utf16().chain(std::iter::once(0)).collect();
             unsafe { NeedCurrentDirectoryForExePathW(exe_name_w.as_ptr()) != 0 }
+        }
+        // `subprocess.Handle.Close` captures `_winapi.CloseHandle` as a default
+        // argument at class-definition time, so the attribute must exist for
+        // `import subprocess` to succeed.
+        fn CloseHandle(handle: i64) -> Result<(), crate::PyError> {
+            let ok = unsafe {
+                windows_sys::Win32::Foundation::CloseHandle(handle as *mut _)
+            };
+            if ok == 0 {
+                return Err(last_os_error());
+            }
+            Ok(())
+        }
+        // `subprocess.Popen._wait`/`poll` also capture these as default
+        // arguments at import time (a process launch, needing the missing
+        // `CreateProcess`/pipe half, is what actually reaches them).
+        fn WaitForSingleObject(handle: i64, milliseconds: i64) -> i64 {
+            unsafe {
+                windows_sys::Win32::System::Threading::WaitForSingleObject(
+                    handle as *mut _,
+                    milliseconds as u32,
+                ) as i64
+            }
+        }
+        fn GetExitCodeProcess(handle: i64) -> Result<i64, crate::PyError> {
+            let mut code: u32 = 0;
+            let ok = unsafe {
+                windows_sys::Win32::System::Threading::GetExitCodeProcess(handle as *mut _, &mut code)
+            };
+            if ok == 0 {
+                return Err(last_os_error());
+            }
+            Ok(code as i64)
         }
     }
 }

--- a/pyre/pyre-interpreter/src/module/mod.rs
+++ b/pyre/pyre-interpreter/src/module/mod.rs
@@ -79,6 +79,8 @@ pub mod marshal;
 pub mod math;
 #[cfg(all(not(target_arch = "wasm32"), not(feature = "sandbox")))]
 pub mod mmap;
+#[cfg(all(windows, feature = "host_env"))]
+pub mod msvcrt;
 pub mod operator;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod posix;

--- a/pyre/pyre-interpreter/src/module/msvcrt/mod.rs
+++ b/pyre/pyre-interpreter/src/module/msvcrt/mod.rs
@@ -1,0 +1,99 @@
+//! msvcrt module — Windows Microsoft Visual C runtime services.
+//!
+//! `subprocess` selects its Windows implementation from the presence of this
+//! module (`try: import msvcrt` → `_mswindows = True`), and `getpass` uses the
+//! console read/write calls; the whole surface delegates to
+//! `rustpython_host_env::msvcrt`, which wraps the CRT `_getch`/`_setmode`/…
+//! family, plus `get_osfhandle` via `nt::handle_from_fd`.
+
+use rustpython_host_env::msvcrt as host_msvcrt;
+
+/// Convert a host `io::Error` into an `OSError` carrying its errno.
+fn msvcrt_err(error: std::io::Error) -> crate::PyError {
+    crate::PyError::os_error_with_errno(
+        crate::builtins::io_error_posix_errno(&error, 0),
+        format!("{error}"),
+    )
+}
+
+crate::py_module! {
+    "msvcrt",
+    int_constants: {
+        "LK_UNLCK" => host_msvcrt::LK_UNLCK,
+        "LK_LOCK" => host_msvcrt::LK_LOCK,
+        "LK_NBLCK" => host_msvcrt::LK_NBLCK,
+        "LK_RLCK" => host_msvcrt::LK_RLCK,
+        "LK_NBRLCK" => host_msvcrt::LK_NBRLCK,
+        "SEM_FAILCRITICALERRORS" => host_msvcrt::SEM_FAILCRITICALERRORS,
+        "SEM_NOALIGNMENTFAULTEXCEPT" => host_msvcrt::SEM_NOALIGNMENTFAULTEXCEPT,
+        "SEM_NOGPFAULTERRORBOX" => host_msvcrt::SEM_NOGPFAULTERRORBOX,
+        "SEM_NOOPENFILEERRORBOX" => host_msvcrt::SEM_NOOPENFILEERRORBOX,
+    },
+    inline_functions: {
+        fn getch() -> Vec<u8> {
+            host_msvcrt::getch()
+        }
+        fn getwch() -> String {
+            host_msvcrt::getwch()
+        }
+        fn getche() -> Vec<u8> {
+            host_msvcrt::getche()
+        }
+        fn getwche() -> String {
+            host_msvcrt::getwche()
+        }
+        fn putch(char_: &[u8]) -> Result<(), crate::PyError> {
+            let byte = *char_.first().ok_or_else(|| {
+                crate::PyError::type_error("putch() argument must be a byte string of length 1")
+            })?;
+            host_msvcrt::putch(byte);
+            Ok(())
+        }
+        fn putwch(unicode_char: &str) -> Result<(), crate::PyError> {
+            let ch = unicode_char.chars().next().ok_or_else(|| {
+                crate::PyError::type_error("putwch() argument must be a unicode character")
+            })?;
+            host_msvcrt::putwch(ch);
+            Ok(())
+        }
+        fn ungetch(char_: &[u8]) -> Result<(), crate::PyError> {
+            let byte = *char_.first().ok_or_else(|| {
+                crate::PyError::type_error("ungetch() argument must be a byte string of length 1")
+            })?;
+            host_msvcrt::ungetch(byte).map_err(msvcrt_err)
+        }
+        fn ungetwch(unicode_char: &str) -> Result<(), crate::PyError> {
+            let ch = unicode_char.chars().next().ok_or_else(|| {
+                crate::PyError::type_error("ungetwch() argument must be a unicode character")
+            })?;
+            host_msvcrt::ungetwch(ch).map_err(msvcrt_err)
+        }
+        fn kbhit() -> bool {
+            host_msvcrt::kbhit() != 0
+        }
+        fn locking(fd: i32, mode: i32, nbytes: i64) -> Result<(), crate::PyError> {
+            host_msvcrt::locking(fd, mode, nbytes).map_err(msvcrt_err)
+        }
+        fn setmode(fd: i32, flags: i32) -> Result<i32, crate::PyError> {
+            let borrowed = unsafe { rustpython_host_env::crt_fd::Borrowed::try_borrow_raw(fd) }
+                .map_err(msvcrt_err)?;
+            host_msvcrt::setmode(borrowed, flags).map_err(msvcrt_err)
+        }
+        fn open_osfhandle(handle: i64, flags: i32) -> Result<i32, crate::PyError> {
+            host_msvcrt::open_osfhandle(handle as isize, flags).map_err(msvcrt_err)
+        }
+        fn get_osfhandle(fd: i32) -> Result<i64, crate::PyError> {
+            let handle = rustpython_host_env::nt::handle_from_fd(fd);
+            if handle as isize == -1 {
+                return Err(crate::PyError::os_error_syscall(libc::EBADF, pyre_object::PY_NULL));
+            }
+            Ok(handle as isize as i64)
+        }
+        fn heapmin() -> Result<(), crate::PyError> {
+            host_msvcrt::heapmin().map_err(msvcrt_err)
+        }
+        fn SetErrorMode(mode: u32) -> u32 {
+            host_msvcrt::set_error_mode(mode)
+        }
+    }
+}

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -731,7 +731,6 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         "faccessat",
         "chflags",
         "lchflags",
-        "utime",
         "futimens",
         "futimes",
         "fdopendir",
@@ -1382,6 +1381,129 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         "replace",
         crate::make_builtin_function("replace", |args| rename_impl(args, "replace")),
     );
+
+    // os.utime(path, times=None, *, ns=None, dir_fd=None, follow_symlinks=True)
+    // PyPy `interp_posix.utime` → rposix `utimensat`/`SetFileTime`.  `times` is a
+    // `(atime, mtime)` pair in seconds; `ns` the same pair in integer
+    // nanoseconds; the two are mutually exclusive.  Both `None` means "now".
+    fn utime_impl(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+        let (pos, kwargs) = crate::builtins::split_builtin_kwargs(args);
+        if pos.is_empty() {
+            return Err(crate::PyError::type_error(
+                "utime() missing required argument 'path' (pos 1)",
+            ));
+        }
+        if pos.len() > 2 {
+            return Err(crate::PyError::type_error(format!(
+                "utime() takes from 1 to 2 positional arguments but {} were given",
+                pos.len()
+            )));
+        }
+        crate::builtins::kwarg_reject_unknown(kwargs, &["ns", "dir_fd", "follow_symlinks"], "utime")?;
+        let path = extract_path(pos[0])?;
+
+        let present = |v: PyObjectRef| (!unsafe { pyre_object::is_none(v) }).then_some(v);
+        let times = pos.get(1).copied().and_then(present);
+        let ns = crate::builtins::kwarg_get(kwargs, "ns").and_then(present);
+        let follow_symlinks = match crate::builtins::kwarg_get(kwargs, "follow_symlinks") {
+            Some(v) => crate::baseobjspace::is_true(v)?,
+            None => true,
+        };
+        let dir_fd = match crate::builtins::kwarg_get(kwargs, "dir_fd").and_then(present) {
+            Some(v) => {
+                if !unsafe { pyre_object::is_int(v) } {
+                    return Err(crate::PyError::type_error(
+                        "argument should be integer or None, not object",
+                    ));
+                }
+                Some(unsafe { pyre_object::w_int_get_value(v) } as i32)
+            }
+            None => None,
+        };
+
+        let unpack_two =
+            |obj: PyObjectRef, what: &str| -> Result<(PyObjectRef, PyObjectRef), crate::PyError> {
+                if !unsafe { pyre_object::is_tuple(obj) } || unsafe { pyre_object::w_tuple_len(obj) } != 2
+                {
+                    return Err(crate::PyError::type_error(format!(
+                        "utime: '{what}' must be a tuple of two ints"
+                    )));
+                }
+                Ok((
+                    unsafe { pyre_object::w_tuple_getitem(obj, 0) }.unwrap(),
+                    unsafe { pyre_object::w_tuple_getitem(obj, 1) }.unwrap(),
+                ))
+            };
+        let dur_from_secs = |v: PyObjectRef| -> Result<std::time::Duration, crate::PyError> {
+            let f = crate::builtins::builtin_float(&[v])?;
+            let secs = unsafe { pyre_object::w_float_get_value(f) };
+            std::time::Duration::try_from_secs_f64(secs)
+                .map_err(|_| crate::PyError::value_error("utime: timestamp out of range"))
+        };
+        let dur_from_ns = |v: PyObjectRef| -> Result<std::time::Duration, crate::PyError> {
+            let n = crate::builtins::space_index_w(v)?;
+            if n < 0 {
+                return Err(crate::PyError::value_error("utime: timestamp out of range"));
+            }
+            Ok(std::time::Duration::from_nanos(n as u64))
+        };
+
+        let (access, modified) = match (times, ns) {
+            (Some(_), Some(_)) => {
+                return Err(crate::PyError::value_error(
+                    "utime: you may specify either 'times' or 'ns' but not both",
+                ));
+            }
+            (Some(t), None) => {
+                let (a, m) = unpack_two(t, "times")?;
+                (dur_from_secs(a)?, dur_from_secs(m)?)
+            }
+            (None, Some(n)) => {
+                let (a, m) = unpack_two(n, "ns")?;
+                (dur_from_ns(a)?, dur_from_ns(m)?)
+            }
+            (None, None) => {
+                let now = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap_or(std::time::Duration::ZERO);
+                (now, now)
+            }
+        };
+
+        #[cfg(all(windows, feature = "host_env"))]
+        {
+            if dir_fd.is_some() || !follow_symlinks {
+                return Err(crate::PyError::not_implemented(
+                    "utime: dir_fd and follow_symlinks=False are unavailable on this platform",
+                ));
+            }
+            host_os::set_file_times(std::path::Path::new(&path), access, modified)
+                .map_err(|e| io_err(e, &path))?;
+            return Ok(pyre_object::w_none());
+        }
+        #[cfg(all(unix, not(feature = "sandbox")))]
+        {
+            let c_path = std::ffi::CString::new(path.as_bytes())
+                .map_err(|_| crate::PyError::value_error("embedded null character"))?;
+            rustpython_host_env::posix::set_file_times_at(
+                dir_fd.unwrap_or(libc::AT_FDCWD),
+                &c_path,
+                access,
+                modified,
+                follow_symlinks,
+            )
+            .map_err(|e| io_err(e, &path))?;
+            return Ok(pyre_object::w_none());
+        }
+        #[allow(unreachable_code)]
+        {
+            let _ = (access, modified, dir_fd, follow_symlinks, &path);
+            Err(crate::PyError::not_implemented(
+                "utime is unavailable on this platform",
+            ))
+        }
+    }
+    crate::module_ns_store(ns, "utime", crate::make_builtin_function("utime", utime_impl));
 
     // ── posix._path_splitroot(path) → (root, tail) ──
     // Registered only where `sys.platform` is `win32`, the same condition

--- a/pyre/pyre-interpreter/src/module/winreg/mod.rs
+++ b/pyre/pyre-interpreter/src/module/winreg/mod.rs
@@ -2,12 +2,11 @@
 //!
 //! `importlib._bootstrap_external` does an eager `import winreg` on every
 //! `sys.platform == "win32"` build, so the module must exist for the import
-//! machinery — and therefore `import site` — to come up.  Its one bootstrap
-//! consumer, `WindowsRegistryFinder`, is deprecated and never installed onto
-//! `sys.meta_path`, and touches `winreg.OpenKey`/`QueryValue` only inside its
-//! (unreached) methods, so the registry-access functions are not ported here;
-//! this exposes the integer constants a caller reads, leaving the RegOpenKeyEx
-//! family for a follow-up.
+//! machinery — and therefore `import site` — to come up.  The integer
+//! constants are always present; the `PyHKEY` handle object and the
+//! Open/Query/Enum/Set/Delete key & value functions are registered when the
+//! `host_env` feature is on (they delegate every Win32 `Reg*` call to
+//! `rustpython_host_env::winreg`).
 crate::py_module! {
     "winreg",
     int_constants: {
@@ -71,5 +70,571 @@ crate::py_module! {
         "REG_NOTIFY_CHANGE_SECURITY" => 8,
         "REG_LEGAL_CHANGE_FILTER" => 0x000F,
         "REG_LEGAL_OPTION" => 0x000F,
+    },
+    extra_init: |ns| {
+        #[cfg(feature = "host_env")]
+        imp::install(ns);
+    }
+}
+
+#[cfg(feature = "host_env")]
+mod imp {
+    use pyre_object::rbigint::RBigInt as BigInt;
+    use pyre_object::*;
+    use rustpython_host_env::winreg::{self as host_reg, HKEY};
+    use std::ffi::OsStr;
+    use widestring::WideCString;
+
+    /// A raw handle/pointer value → a Python int (`PyLong_FromVoidPtr`).  The
+    /// predefined roots sign-extend past `i64::MAX` on 64-bit, so route those
+    /// through a long.
+    fn int_from_ptr(raw: HKEY) -> PyObjectRef {
+        let value = raw as usize as u64;
+        if value <= i64::MAX as u64 {
+            w_int_new(value as i64)
+        } else {
+            pyre_object::longobject::w_long_new(BigInt::from(value))
+        }
+    }
+
+    // ── PyHKEY handle object ──
+    // The raw `HKEY` is stored on the instance dict under `_handle` as its
+    // pointer value; `int(key)` and passing a key where a handle is expected
+    // read it back.  A closed handle is left as 0.
+    crate::py_class! {
+        "PyHKEY",
+        methods: {
+            fn Close(self_obj: PyObjectRef) -> Result<(), crate::PyError> {
+                let raw = take_handle(self_obj);
+                if !raw.is_null() {
+                    host_reg::close_key(raw);
+                }
+                Ok(())
+            }
+            fn Detach(self_obj: PyObjectRef) -> PyObjectRef {
+                int_from_ptr(take_handle(self_obj))
+            }
+            fn __int__(self_obj: PyObjectRef) -> PyObjectRef {
+                int_from_ptr(get_handle(self_obj))
+            }
+            fn __bool__(self_obj: PyObjectRef) -> bool {
+                !get_handle(self_obj).is_null()
+            }
+            fn __enter__(self_obj: PyObjectRef) -> PyObjectRef {
+                self_obj
+            }
+            fn __exit__(
+                self_obj: PyObjectRef,
+                _exc_type: PyObjectRef,
+                _exc_value: PyObjectRef,
+                _traceback: PyObjectRef,
+            ) -> Result<bool, crate::PyError> {
+                let raw = take_handle(self_obj);
+                if !raw.is_null() {
+                    host_reg::close_key(raw);
+                }
+                Ok(false)
+            }
+        }
+    }
+
+    fn store_handle(obj: PyObjectRef, raw: HKEY) {
+        let d = crate::baseobjspace::getdict(obj);
+        if !d.is_null() {
+            unsafe { w_dict_setitem_str(d, "_handle", int_from_ptr(raw)) };
+        }
+    }
+
+    fn get_handle(obj: PyObjectRef) -> HKEY {
+        stored_handle(obj).unwrap_or(core::ptr::null_mut())
+    }
+
+    /// Read the stored handle and reset it to 0 (used by `Close`/`Detach`).
+    fn take_handle(obj: PyObjectRef) -> HKEY {
+        let raw = get_handle(obj);
+        store_handle(obj, core::ptr::null_mut());
+        raw
+    }
+
+    fn make_pyhkey(raw: HKEY) -> PyObjectRef {
+        let obj = w_instance_new(type_object());
+        store_handle(obj, raw);
+        obj
+    }
+
+    /// The stored `_handle` value, if `obj` is a `PyHKEY`.  `uint_w` reads both
+    /// the small-int and long forms a handle pointer may take.
+    fn stored_handle(obj: PyObjectRef) -> Option<HKEY> {
+        let d = crate::baseobjspace::getdict(obj);
+        if d.is_null() {
+            return None;
+        }
+        let value = unsafe { w_dict_getitem_str(d, "_handle") }?;
+        crate::baseobjspace::uint_w(value)
+            .ok()
+            .map(|u| u as usize as HKEY)
+    }
+
+    /// Resolve a key argument — a `PyHKEY` or an integer handle (the predefined
+    /// `HKEY_*` roots) — to a raw `HKEY`.
+    fn key_arg(args: &[PyObjectRef], idx: usize) -> Result<HKEY, crate::PyError> {
+        let obj = arg(args, idx)?;
+        if let Some(raw) = stored_handle(obj) {
+            return Ok(raw);
+        }
+        if unsafe { is_int_or_long(obj) } {
+            return Ok(crate::baseobjspace::uint_w(obj)? as usize as HKEY);
+        }
+        Err(crate::PyError::type_error(
+            "The object is not a PyHKEY object",
+        ))
+    }
+
+    fn arg(args: &[PyObjectRef], idx: usize) -> Result<PyObjectRef, crate::PyError> {
+        args.get(idx)
+            .copied()
+            .ok_or_else(|| crate::PyError::type_error("required argument missing"))
+    }
+
+    /// A `str` or `None` argument → owned `String` / `None`.
+    fn opt_str(args: &[PyObjectRef], idx: usize) -> Result<Option<String>, crate::PyError> {
+        match args.get(idx).copied() {
+            None => Ok(None),
+            Some(obj) if unsafe { is_none(obj) } => Ok(None),
+            Some(obj) if unsafe { is_str(obj) } => {
+                Ok(Some(unsafe { w_str_get_value(obj) }.to_string()))
+            }
+            Some(_) => Err(crate::PyError::type_error(
+                "argument must be a string or None",
+            )),
+        }
+    }
+
+    fn req_str(args: &[PyObjectRef], idx: usize) -> Result<String, crate::PyError> {
+        let obj = arg(args, idx)?;
+        if unsafe { is_str(obj) } {
+            Ok(unsafe { w_str_get_value(obj) }.to_string())
+        } else {
+            Err(crate::PyError::type_error("argument must be a string"))
+        }
+    }
+
+    fn req_int(args: &[PyObjectRef], idx: usize) -> Result<i64, crate::PyError> {
+        crate::baseobjspace::int_w(arg(args, idx)?)
+    }
+
+    /// Map a Win32 error code to an `OSError`.
+    fn win_err(code: u32) -> crate::PyError {
+        let error = std::io::Error::from_raw_os_error(code as i32);
+        crate::PyError::os_error_syscall(
+            crate::builtins::io_error_posix_errno(&error, 0),
+            pyre_object::PY_NULL,
+        )
+    }
+
+    fn check(code: u32) -> Result<PyObjectRef, crate::PyError> {
+        if code != 0 {
+            Err(win_err(code))
+        } else {
+            Ok(w_none())
+        }
+    }
+
+    fn utf16_units(data: &[u8]) -> Vec<u16> {
+        data.chunks_exact(2)
+            .map(|pair| u16::from_le_bytes([pair[0], pair[1]]))
+            .collect()
+    }
+
+    /// `Reg2Py` — registry bytes + type → a Python value.
+    fn reg2py(data: &[u8], typ: u32) -> PyObjectRef {
+        match typ {
+            host_reg::REG_DWORD => {
+                let value = if data.len() >= 4 {
+                    u32::from_le_bytes([data[0], data[1], data[2], data[3]])
+                } else {
+                    0
+                };
+                w_int_new(value as i64)
+            }
+            host_reg::REG_QWORD => {
+                let value = if data.len() >= 8 {
+                    u64::from_le_bytes(data[..8].try_into().unwrap())
+                } else {
+                    0
+                };
+                // Registry QWORDs above i64::MAX are vanishingly rare; the raw
+                // 64-bit pattern is preserved.
+                w_int_new(value as i64)
+            }
+            host_reg::REG_SZ | host_reg::REG_EXPAND_SZ | host_reg::REG_LINK => {
+                let units = utf16_units(data);
+                let end = units.iter().position(|&c| c == 0).unwrap_or(units.len());
+                w_str_new(&String::from_utf16_lossy(&units[..end]))
+            }
+            host_reg::REG_MULTI_SZ => {
+                let units = utf16_units(data);
+                let mut items = Vec::new();
+                for chunk in units.split(|&c| c == 0) {
+                    if chunk.is_empty() {
+                        break;
+                    }
+                    items.push(w_str_new(&String::from_utf16_lossy(chunk)));
+                }
+                w_list_new(items)
+            }
+            _ => {
+                if data.is_empty() {
+                    w_none()
+                } else {
+                    pyre_object::bytesobject::w_bytes_from_bytes(data)
+                }
+            }
+        }
+    }
+
+    fn encode_utf16z(s: &str) -> Vec<u8> {
+        let mut units: Vec<u16> = s.encode_utf16().collect();
+        units.push(0);
+        units.iter().flat_map(|u| u.to_le_bytes()).collect()
+    }
+
+    /// `Py2Reg` — a Python value + type → registry bytes.
+    fn py2reg(value: PyObjectRef, typ: u32) -> Result<Vec<u8>, crate::PyError> {
+        match typ {
+            host_reg::REG_DWORD => Ok((crate::baseobjspace::int_w(value)? as u32)
+                .to_le_bytes()
+                .to_vec()),
+            host_reg::REG_QWORD => Ok((crate::baseobjspace::int_w(value)? as u64)
+                .to_le_bytes()
+                .to_vec()),
+            host_reg::REG_SZ | host_reg::REG_EXPAND_SZ => {
+                if unsafe { !is_str(value) } {
+                    return Err(crate::PyError::type_error("value must be a string"));
+                }
+                Ok(encode_utf16z(unsafe { w_str_get_value(value) }))
+            }
+            host_reg::REG_MULTI_SZ => {
+                let len = unsafe { w_list_len(value) };
+                let mut out = Vec::new();
+                for i in 0..len {
+                    let item = unsafe { w_list_getitem(value, i as i64) };
+                    let Some(item) = item else { continue };
+                    if unsafe { !is_str(item) } {
+                        return Err(crate::PyError::type_error(
+                            "REG_MULTI_SZ value must be a list of strings",
+                        ));
+                    }
+                    let units: Vec<u16> = unsafe { w_str_get_value(item) }.encode_utf16().collect();
+                    out.extend(units.iter().flat_map(|u| u.to_le_bytes()));
+                    out.extend_from_slice(&[0, 0]);
+                }
+                out.extend_from_slice(&[0, 0]);
+                Ok(out)
+            }
+            _ => {
+                // REG_BINARY / REG_NONE and the rest — a bytes-like value, or
+                // `None` for an empty write.
+                if unsafe { is_none(value) } {
+                    return Ok(Vec::new());
+                }
+                if unsafe { pyre_object::bytesobject::is_bytes_like(value) } {
+                    Ok(unsafe { pyre_object::bytesobject::bytes_like_data(value) }.to_vec())
+                } else {
+                    Err(crate::PyError::type_error("value must be bytes"))
+                }
+            }
+        }
+    }
+
+    // ── module functions ──
+    fn open_key(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+        // (key, sub_key, reserved=0, access=KEY_READ)
+        let (pos, kwargs) = crate::builtins::split_builtin_kwargs(args);
+        let key = key_arg(pos, 0)?;
+        let sub_key = opt_str(pos, 1)?;
+        let access = match crate::builtins::kwarg_get(kwargs, "access") {
+            Some(v) => crate::baseobjspace::int_w(v)? as u32,
+            None => match pos.get(3) {
+                Some(&v) => crate::baseobjspace::int_w(v)? as u32,
+                None => host_reg::KEY_READ,
+            },
+        };
+        let wide = WideCString::from_str_truncate(sub_key.as_deref().unwrap_or(""));
+        let mut out: HKEY = core::ptr::null_mut();
+        let rc = unsafe { host_reg::open_key_ex(key, &wide, 0, access, &mut out) };
+        if rc != 0 {
+            return Err(win_err(rc));
+        }
+        Ok(make_pyhkey(out))
+    }
+
+    fn close_key(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+        let obj = arg(args, 0)?;
+        let raw = if unsafe { is_int(obj) } {
+            (unsafe { w_int_get_value(obj) } as usize) as HKEY
+        } else {
+            take_handle(obj)
+        };
+        if !raw.is_null() {
+            host_reg::close_key(raw);
+        }
+        Ok(w_none())
+    }
+
+    fn query_value(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+        use rustpython_host_env::winreg::QueryStringError;
+        let key = key_arg(args, 0)?;
+        let sub_key = opt_str(args, 1)?;
+        match host_reg::query_default_value(key, sub_key.as_deref().map(OsStr::new)) {
+            Ok(value) => Ok(w_str_new(&value)),
+            Err(QueryStringError::Code(code)) => Err(win_err(code)),
+            Err(QueryStringError::Utf16(_)) => Err(crate::PyError::value_error(
+                "registry value is not valid UTF-16",
+            )),
+        }
+    }
+
+    fn query_value_ex(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+        let key = key_arg(args, 0)?;
+        let name = opt_str(args, 1)?.unwrap_or_default();
+        match host_reg::query_value_bytes(key, OsStr::new(&name)) {
+            Ok((data, typ)) => Ok(w_tuple_new(vec![reg2py(&data, typ), w_int_new(typ as i64)])),
+            Err(code) => Err(win_err(code)),
+        }
+    }
+
+    fn enum_key(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+        let key = key_arg(args, 0)?;
+        let index = req_int(args, 1)? as u32;
+        // Registry key names are capped at 255 chars (winnt.h MAX_KEY_LENGTH).
+        let mut buffer = [0u16; 257];
+        let mut len = buffer.len() as u32;
+        let rc = unsafe { host_reg::enum_key_ex(key, index, buffer.as_mut_ptr(), &mut len) };
+        if rc != 0 {
+            return Err(win_err(rc));
+        }
+        Ok(w_str_new(&String::from_utf16_lossy(
+            &buffer[..len as usize],
+        )))
+    }
+
+    fn enum_value(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+        let key = key_arg(args, 0)?;
+        let index = req_int(args, 1)? as u32;
+        let mut max_name = 0u32;
+        let mut max_data = 0u32;
+        let rc = unsafe {
+            host_reg::query_info_key(
+                key,
+                core::ptr::null_mut(),
+                core::ptr::null_mut(),
+                &mut max_name,
+                &mut max_data,
+            )
+        };
+        if rc != 0 {
+            return Err(win_err(rc));
+        }
+        let mut name = vec![0u16; (max_name + 1) as usize];
+        let mut data = vec![0u8; max_data as usize];
+        let mut name_len = name.len() as u32;
+        let mut data_len = data.len() as u32;
+        let mut typ = 0u32;
+        let data_ptr = if data.is_empty() {
+            core::ptr::null_mut()
+        } else {
+            data.as_mut_ptr()
+        };
+        let rc = unsafe {
+            host_reg::enum_value(
+                key,
+                index,
+                name.as_mut_ptr(),
+                &mut name_len,
+                &mut typ,
+                data_ptr,
+                &mut data_len,
+            )
+        };
+        if rc != 0 {
+            return Err(win_err(rc));
+        }
+        let name_s = String::from_utf16_lossy(&name[..name_len as usize]);
+        Ok(w_tuple_new(vec![
+            w_str_new(&name_s),
+            reg2py(&data[..data_len as usize], typ),
+            w_int_new(typ as i64),
+        ]))
+    }
+
+    fn query_info_key(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+        let key = key_arg(args, 0)?;
+        match host_reg::query_info_key_full(key) {
+            Ok(info) => Ok(w_tuple_new(vec![
+                w_int_new(info.sub_keys as i64),
+                w_int_new(info.values as i64),
+                w_int_new(info.last_write_time as i64),
+            ])),
+            Err(code) => Err(win_err(code)),
+        }
+    }
+
+    fn flush_key(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+        check(host_reg::flush_key(key_arg(args, 0)?))
+    }
+
+    fn create_key(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+        let key = key_arg(args, 0)?;
+        let sub_key = opt_str(args, 1)?;
+        let wide = WideCString::from_str_truncate(sub_key.as_deref().unwrap_or(""));
+        let mut out: HKEY = core::ptr::null_mut();
+        let rc = unsafe { host_reg::create_key(key, &wide, &mut out) };
+        if rc != 0 {
+            return Err(win_err(rc));
+        }
+        Ok(make_pyhkey(out))
+    }
+
+    fn set_value(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+        // (key, sub_key, type, value) — SetValue only writes REG_SZ.
+        let key = key_arg(args, 0)?;
+        let sub_key = opt_str(args, 1)?.unwrap_or_default();
+        let typ = req_int(args, 2)? as u32;
+        if typ != host_reg::REG_SZ {
+            return Err(crate::PyError::type_error("Type must be winreg.REG_SZ"));
+        }
+        let value = req_str(args, 3)?;
+        check(host_reg::set_default_value(
+            key,
+            OsStr::new(&sub_key),
+            typ,
+            OsStr::new(&value),
+        ))
+    }
+
+    fn set_value_ex(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+        // (key, value_name, reserved, type, value)
+        let key = key_arg(args, 0)?;
+        let name = opt_str(args, 1)?;
+        let typ = req_int(args, 3)? as u32;
+        let data = py2reg(arg(args, 4)?, typ)?;
+        let wide_name = name.as_deref().map(WideCString::from_str_truncate);
+        let rc = unsafe {
+            host_reg::set_value_ex(
+                key,
+                wide_name.as_deref(),
+                typ,
+                data.as_ptr(),
+                data.len() as u32,
+            )
+        };
+        if rc != 0 {
+            return Err(win_err(rc));
+        }
+        Ok(w_none())
+    }
+
+    fn delete_key(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+        let key = key_arg(args, 0)?;
+        let sub_key = req_str(args, 1)?;
+        let wide = WideCString::from_str_truncate(&sub_key);
+        check(unsafe { host_reg::delete_key(key, &wide) })
+    }
+
+    fn delete_value(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+        let key = key_arg(args, 0)?;
+        let name = opt_str(args, 1)?;
+        let wide_name = name.as_deref().map(WideCString::from_str_truncate);
+        check(unsafe { host_reg::delete_value(key, wide_name.as_deref()) })
+    }
+
+    fn connect_registry(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+        // (computer_name, key)
+        let computer = opt_str(args, 0)?;
+        let key = key_arg(args, 1)?;
+        let wide = computer.as_deref().map(WideCString::from_str_truncate);
+        let mut out: HKEY = core::ptr::null_mut();
+        let rc = unsafe { host_reg::connect_registry(wide.as_deref(), key, &mut out) };
+        if rc != 0 {
+            return Err(win_err(rc));
+        }
+        Ok(make_pyhkey(out))
+    }
+
+    fn expand_environment_strings(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+        use rustpython_host_env::winreg::ExpandEnvironmentStringsError;
+        let input = req_str(args, 0)?;
+        match host_reg::expand_environment_strings(OsStr::new(&input)) {
+            Ok(value) => Ok(w_str_new(&value)),
+            Err(ExpandEnvironmentStringsError::Os) => Err(win_err(
+                std::io::Error::last_os_error().raw_os_error().unwrap_or(0) as u32,
+            )),
+            Err(ExpandEnvironmentStringsError::Utf16(_)) => Err(crate::PyError::value_error(
+                "expanded value is not valid UTF-16",
+            )),
+        }
+    }
+
+    fn disable_reflection_key(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+        check(host_reg::disable_reflection_key(key_arg(args, 0)?))
+    }
+
+    fn enable_reflection_key(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+        check(host_reg::enable_reflection_key(key_arg(args, 0)?))
+    }
+
+    fn query_reflection_key(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+        let key = key_arg(args, 0)?;
+        let mut disabled: i32 = 0;
+        let rc = unsafe { host_reg::query_reflection_key(key, &mut disabled) };
+        if rc != 0 {
+            return Err(win_err(rc));
+        }
+        Ok(w_bool_from(disabled != 0))
+    }
+
+    pub fn install(ns: PyObjectRef) {
+        crate::module_ns_store(ns, "PyHKEY", type_object());
+        // The predefined roots are exposed as their full (sign-extended)
+        // pointer value, matching `PyLong_FromVoidPtr` — this overrides the
+        // 32-bit fallbacks the always-present `int_constants` set.
+        for (name, root) in [
+            ("HKEY_CLASSES_ROOT", host_reg::HKEY_CLASSES_ROOT),
+            ("HKEY_CURRENT_USER", host_reg::HKEY_CURRENT_USER),
+            ("HKEY_LOCAL_MACHINE", host_reg::HKEY_LOCAL_MACHINE),
+            ("HKEY_USERS", host_reg::HKEY_USERS),
+            ("HKEY_PERFORMANCE_DATA", host_reg::HKEY_PERFORMANCE_DATA),
+            ("HKEY_CURRENT_CONFIG", host_reg::HKEY_CURRENT_CONFIG),
+            ("HKEY_DYN_DATA", host_reg::HKEY_DYN_DATA),
+        ] {
+            crate::module_ns_store(ns, name, int_from_ptr(root));
+        }
+        for (name, func) in [
+            (
+                "OpenKey",
+                open_key as fn(&[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>,
+            ),
+            ("OpenKeyEx", open_key),
+            ("CloseKey", close_key),
+            ("QueryValue", query_value),
+            ("QueryValueEx", query_value_ex),
+            ("EnumKey", enum_key),
+            ("EnumValue", enum_value),
+            ("QueryInfoKey", query_info_key),
+            ("FlushKey", flush_key),
+            ("CreateKey", create_key),
+            ("SetValue", set_value),
+            ("SetValueEx", set_value_ex),
+            ("DeleteKey", delete_key),
+            ("DeleteValue", delete_value),
+            ("ConnectRegistry", connect_registry),
+            ("ExpandEnvironmentStrings", expand_environment_strings),
+            ("DisableReflectionKey", disable_reflection_key),
+            ("EnableReflectionKey", enable_reflection_key),
+            ("QueryReflectionKey", query_reflection_key),
+        ] {
+            crate::module_ns_store(ns, name, crate::make_builtin_function(name, func));
+        }
     }
 }


### PR DESCRIPTION
Follow-ups to the nt module (#780).

- **posix:** implement `os.utime` (was a no-op stub) — parses `(path, times=None, *, ns=None, dir_fd=None, follow_symlinks=True)`, converts times/ns to a `Duration` (both `None` = now), and calls host_env `set_file_times` (Windows) / `set_file_times_at` (unix).
- **_io:** text-mode writes translate `\n` to the platform newline when `newline=None` (Windows `\r\n`), matching the writenl rule; explicit `\r`/`\r\n` were already handled, `''`/`\n` stay verbatim.
- **msvcrt:** new module over `host_env::msvcrt` (getch/getwch family, putch, ungetch, kbhit, locking, setmode, open_osfhandle, get_osfhandle, heapmin, SetErrorMode).
- **winreg:** real key operations over `host_env::winreg` behind a `PyHKEY` handle object; predefined `HKEY_*` roots expose the full sign-extended pointer values.
- **_winapi:** add the process/priority/GetStdHandle constants and `CloseHandle`/`WaitForSingleObject`/`GetExitCodeProcess` that `subprocess` captures as default args at import once `msvcrt` exists.

All OS bindings go through `rustpython_host_env`. Verified locally: `check.py --backend dynasm` 322/322, JIT on/off smoke test for all four features passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Windows support for `msvcrt`, including console, file-descriptor, locking, and error-mode operations.
  * Expanded Windows registry functionality with key management, value queries, enumeration, and updates.
  * Improved Windows subprocess compatibility and process-handle operations.
  * Added `os.utime` support for updating file timestamps.

* **Bug Fixes**
  * Corrected newline handling so platform line endings are applied consistently, including Windows defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->