### PR TITLE
jit: residualize foreign-container constructors + close niche-Option bool-exitcase (gh#346)

### DIFF
--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -2236,6 +2236,17 @@ struct Lowering<'a> {
     /// `front::option_closure_select` post-pass synthesizes (see
     /// [`crate::front::option_closure_select::ClosureSelectSite`]).
     closure_select_sites: Vec<crate::front::option_closure_select::ClosureSelectSite>,
+    /// Result-var ids of niche `Option<NonNull>` discriminant reads folded to
+    /// a pointer null-test (`ne(base, null_mut())`, `build_rvalue`
+    /// `Rvalue::Discriminant` niche arm).  Such a discriminant is a `SomeBool`
+    /// (the `ne` result), so a `SwitchInt` terminator on it must close with
+    /// `ExitCase::Bool` — not `ExitCase::Const(Int)` — or the bool exitswitch
+    /// disagrees with its exitcases at rtype (`BoolRepr::convert_const(Int)`
+    /// → "not a bool").  `lower_switch` consults this set to route the
+    /// terminator through the `If` (`set_branch`) bool path; genuine
+    /// two-variant enum tag switches (real `__discriminant` reads) are absent
+    /// and keep the `Int`-exitcase path.
+    niche_disc_vars: std::collections::HashSet<u64>,
 }
 
 impl<'a> Lowering<'a> {
@@ -2413,6 +2424,7 @@ impl<'a> Lowering<'a> {
             map_or_sites: Vec::new(),
             is_none_sites: Vec::new(),
             closure_select_sites: Vec::new(),
+            niche_disc_vars: std::collections::HashSet::new(),
         })
     }
 
@@ -4275,6 +4287,11 @@ impl<'a> Lowering<'a> {
                 if self.tyref_is_niche_option_ptr(&place.ty) {
                     let base = self.resolve_place(mir_bb, place)?;
                     let nullc = self.push_niche_null_ptr(mir_bb);
+                    // The `ne` result is a `SomeBool`; a `SwitchInt` terminator
+                    // on it must close with `ExitCase::Bool`.  Record the
+                    // result-var id so `lower_switch` routes it through the
+                    // `If` bool path instead of the `Int`-exitcase path.
+                    self.niche_disc_vars.insert(res.id());
                     return Ok((
                         Some(OpKind::BinOp {
                             op: "ne".to_string(),
@@ -10594,6 +10611,21 @@ impl<'a> Lowering<'a> {
                 Ok(())
             }
             SwitchTargets::SwitchInt(_int_ty, arms, default) => {
+                // A `SwitchInt` on a niche `Option<NonNull>` discriminant
+                // switches on the pointer null-test `ne(base, null)` — a
+                // `SomeBool`, not an `Int` tag.  RPython never switches on a
+                // bool: `None`/`Some` on a maybe-null `Ptr` is a True/False
+                // `If` (`ptr_nonzero`).  Route it through `set_branch` so the
+                // bool exitswitch closes with `ExitCase::Bool`, matching the
+                // `If` terminator path; a `SwitchInt` here would emit
+                // `ExitCase::Const(Int)`, which rtype rejects against the
+                // `BoolRepr` exitswitch (`BoolRepr::convert_const(Int)` → "not
+                // a bool").  Genuine two-variant enum tag switches (real
+                // `__discriminant` reads, `Int`/`IntegerRepr`) are not recorded
+                // in `niche_disc_vars` and keep the `Int`-exitcase path below.
+                if self.niche_disc_vars.contains(&discr_var.id()) {
+                    return self.lower_niche_option_switch(mir_bb, bb_id, discr_var, arms, default);
+                }
                 let mut links: Vec<Link> = Vec::new();
                 for (scalar, bb) in arms {
                     let case = scalar_to_const_value(&scalar).ok_or_else(|| {
@@ -10630,6 +10662,69 @@ impl<'a> Lowering<'a> {
                 Ok(())
             }
         }
+    }
+
+    /// Close a `SwitchInt` whose discriminant is a niche `Option<NonNull>`
+    /// null-test (`ne(base, null)`, a `SomeBool`) as a True/False `If` via
+    /// [`FunctionGraph::set_branch`], so the bool exitswitch closes with
+    /// `ExitCase::Bool` instead of `ExitCase::Const(Int)`.  `Some` = tag 1 =
+    /// non-null → the `if_true` arm; `None` = tag 0 = null → the `if_false`
+    /// arm.  A two-variant match lowers to one explicit `(scalar, bb)` arm
+    /// plus a `default` covering the complementary tag, so whichever of {0,1}
+    /// is absent from `arms` is taken from `default` (the same 0/1/default
+    /// triage as [`crate::front::result_exc::split_diamond_exits`]); a
+    /// both-explicit shape (`arms.len() == 2`, no live default) is tolerated.
+    fn lower_niche_option_switch(
+        &mut self,
+        mir_bb: usize,
+        bb_id: BlockId,
+        discr_var: Variable,
+        arms: Vec<(serde_json::Value, u64)>,
+        default: u64,
+    ) -> Result<(), LowerError> {
+        let mut some_bb: Option<u64> = None;
+        let mut none_bb: Option<u64> = None;
+        for (scalar, bb) in &arms {
+            let case = scalar_to_const_value(scalar).ok_or_else(|| {
+                LowerError::Unsupported(format!(
+                    "bb{mir_bb}: niche-Option SwitchInt case scalar shape not supported: {scalar}"
+                ))
+            })?;
+            match case {
+                ConstValue::Int(1) => some_bb = Some(*bb),
+                ConstValue::Int(0) => none_bb = Some(*bb),
+                other => {
+                    return Err(LowerError::Unsupported(format!(
+                        "bb{mir_bb}: niche-Option SwitchInt has non-0/1 case {other:?}"
+                    )));
+                }
+            }
+        }
+        // The tag absent from `arms` is the `default` target; if both are
+        // explicit there is no live default to place.
+        match (some_bb, none_bb) {
+            (Some(_), None) => none_bb = Some(default),
+            (None, Some(_)) => some_bb = Some(default),
+            (Some(_), Some(_)) => {}
+            (None, None) => {
+                return Err(LowerError::Unsupported(format!(
+                    "bb{mir_bb}: niche-Option SwitchInt lacks a 0/1 case"
+                )));
+            }
+        }
+        let some_bb = some_bb.expect("some arm resolved above");
+        let none_bb = none_bb.expect("none arm resolved above");
+        let true_args = self.edge_args(mir_bb, some_bb as usize)?;
+        let false_args = self.edge_args(mir_bb, none_bb as usize)?;
+        self.graph.set_branch(
+            bb_id,
+            discr_var,
+            self.block_id[some_bb as usize],
+            true_args,
+            self.block_id[none_bb as usize],
+            false_args,
+        );
+        Ok(())
     }
 
     fn edge_args(&mut self, from_bb: usize, target_bb: usize) -> Result<Vec<Variable>, LowerError> {
@@ -19666,7 +19761,7 @@ mod tests {
     #[test]
     #[ignore]
     fn option_try_recast_break_arm_real_lookup() {
-        use crate::model::{CallTarget, OpKind};
+        use crate::model::{CallTarget, ExitCase, ExitSwitch, OpKind};
         let path = concat!(
             env!("CARGO_MANIFEST_DIR"),
             "/../../build/llbc/pyre-interpreter.ullbc"
@@ -19688,6 +19783,36 @@ mod tests {
         assert_eq!(
             branch_calls, 0,
             "lookup: residual Try::branch Method-call after the recast-break-arm fold"
+        );
+        // `lookup`'s `r#type(obj)?` is a niche `Option<NonNull>` `?`, rewritten
+        // by `option_try` into a `ne` pointer null-test switch.  Because the
+        // switch value is a `SomeBool` (`ne`), the some/none exits MUST carry
+        // `ExitCase::Bool`, not `ExitCase::Const(Int)` — else rtype rejects the
+        // bool exitswitch against Int cases ("not a bool: Int(1)").
+        let mut niche_try_switches = 0usize;
+        for b in &graph.blocks {
+            let Some(ExitSwitch::Value(sw)) = &b.exitswitch else {
+                continue;
+            };
+            let switches_on_ne = b.operations.iter().any(|op| {
+                op.result.as_ref() == Some(sw)
+                    && matches!(&op.kind, OpKind::BinOp { op, .. } if op == "ne")
+            });
+            if !switches_on_ne {
+                continue;
+            }
+            for l in &b.exits {
+                assert!(
+                    matches!(&l.exitcase, Some(ExitCase::Bool(_))),
+                    "lookup: niche `?` null-test switch exit must be ExitCase::Bool, got {:?}",
+                    l.exitcase
+                );
+            }
+            niche_try_switches += 1;
+        }
+        assert!(
+            niche_try_switches >= 1,
+            "lookup: expected a niche `?` `ne` null-test switch block"
         );
     }
 
@@ -19853,6 +19978,79 @@ mod tests {
         assert_eq!(
             discriminant_reads, 0,
             "gettypeobject: niche Option must not read an aggregate __discriminant"
+        );
+    }
+
+    /// `object_functionstr_type_name` is a pure `match r#type(w_obj) { Some(tp)
+    /// => .., None => .. }` on the niche `Option<NonNull<PyObject>>`.  The
+    /// `match` lowers `Rvalue::Discriminant` to a `ne(base, null_mut())` bool
+    /// null-test and closes the block with a `SwitchInt` on that bool.  Because
+    /// the switch value is a `SomeBool` (`ne`), its exits MUST carry
+    /// `ExitCase::Bool` — not `ExitCase::Const(Int)` — or rtype rejects the
+    /// bool exitswitch against its Int exitcases (`BoolRepr::convert_const(Int)`
+    /// → "not a bool: Int(1)").  Guards the `lower_switch` niche bool-route.
+    /// Ignored by default (loads the real LLBC).
+    #[test]
+    #[ignore]
+    fn niche_option_match_switch_closes_with_bool_exitcase() {
+        use crate::model::{ExitCase, ExitSwitch, OpKind};
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../build/llbc/pyre-interpreter.ullbc"
+        );
+        let llbc = Llbc::load(path).expect("load real LLBC");
+        let graph = super::lower_function(&llbc, "object_functionstr_type_name")
+            .expect("lower object_functionstr_type_name");
+
+        // The niche match's discriminant is a `ne` pointer null-test.  It is
+        // routed through the `If` path (`set_branch`), which wraps the `ne` in
+        // an idempotent `bool` UnaryOp and switches on that wrapped var — so
+        // locate the block whose exitswitch is a `bool` UnaryOp over a `ne`.
+        let ne_result_ids: std::collections::HashSet<u64> = graph
+            .blocks
+            .iter()
+            .flat_map(|b| b.operations.iter())
+            .filter_map(|op| match &op.kind {
+                OpKind::BinOp { op: name, .. } if name == "ne" => {
+                    op.result.as_ref().map(|v| v.id())
+                }
+                _ => None,
+            })
+            .collect();
+        let mut checked = 0usize;
+        for b in &graph.blocks {
+            let Some(ExitSwitch::Value(sw)) = &b.exitswitch else {
+                continue;
+            };
+            // The exitswitch is a `bool(ne)` wrap (set_branch) or the raw `ne`.
+            let switches_on_nulltest = b.operations.iter().any(|op| {
+                op.result.as_ref() == Some(sw)
+                    && match &op.kind {
+                        OpKind::BinOp { op: name, .. } => name == "ne",
+                        OpKind::UnaryOp { op: name, operand, .. } => {
+                            name == "bool" && ne_result_ids.contains(&operand.id())
+                        }
+                        _ => false,
+                    }
+            });
+            if !switches_on_nulltest {
+                continue;
+            }
+            // Every exit of a niche null-test switch must be a bool case, never
+            // an Int const case.
+            for l in &b.exits {
+                assert!(
+                    matches!(&l.exitcase, Some(ExitCase::Bool(_))),
+                    "object_functionstr_type_name: niche null-test switch exit must be \
+                     ExitCase::Bool, got {:?}",
+                    l.exitcase
+                );
+            }
+            checked += 1;
+        }
+        assert!(
+            checked >= 1,
+            "object_functionstr_type_name: expected a niche `ne` null-test switch block"
         );
     }
 }

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -20027,9 +20027,9 @@ mod tests {
                 op.result.as_ref() == Some(sw)
                     && match &op.kind {
                         OpKind::BinOp { op: name, .. } => name == "ne",
-                        OpKind::UnaryOp { op: name, operand, .. } => {
-                            name == "bool" && ne_result_ids.contains(&operand.id())
-                        }
+                        OpKind::UnaryOp {
+                            op: name, operand, ..
+                        } => name == "bool" && ne_result_ids.contains(&operand.id()),
                         _ => false,
                     }
             });

--- a/majit/majit-translate/src/front/option_try.rs
+++ b/majit/majit-translate/src/front/option_try.rs
@@ -326,6 +326,20 @@ fn rewire_one_option_try_site(
             },
         });
     }
+    // The niche switch value is the `ne` pointer null-test — a `SomeBool`, so
+    // its exits must carry `ExitCase::Bool` (`Some` = non-null = true, `None` =
+    // null = false).  An `ExitCase::Const(Int)` here would disagree with the
+    // `BoolRepr` exitswitch at rtype (`BoolRepr::convert_const(Int)` → "not a
+    // bool").  The non-niche branch switches on a real `__discriminant`
+    // `FieldRead` (an `Int` tag / `IntegerRepr`), which keeps the `Int` cases.
+    let (some_case, none_case) = if site.niche {
+        (ExitCase::Bool(true), ExitCase::Bool(false))
+    } else {
+        (
+            ExitCase::Const(ConstValue::Int(1)),
+            ExitCase::Const(ConstValue::Int(0)),
+        )
+    };
     graph.set_control_flow_metadata(
         graph.blocks[a].id,
         Some(ExitSwitch::Value(opt_disc)),
@@ -333,13 +347,9 @@ fn rewire_one_option_try_site(
             Link::new_mixed(
                 some_sources.iter().cloned().map(LinkArg::Value).collect(),
                 some_bb,
-                Some(ExitCase::Const(ConstValue::Int(1))),
+                Some(some_case),
             ),
-            Link::new_mixed(
-                Vec::new(),
-                none_bb,
-                Some(ExitCase::Const(ConstValue::Int(0))),
-            ),
+            Link::new_mixed(Vec::new(), none_bb, Some(none_case)),
         ],
     );
     Ok(())

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -699,15 +699,18 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         w_set_new as *const (),
     );
     push_fnaddr(&mut entries, "w_set_new", w_set_new as *const ());
-    let w_frozenset_new: fn() -> pyre_object::PyObjectRef =
-        pyre_object::setobject::w_frozenset_new;
+    let w_frozenset_new: fn() -> pyre_object::PyObjectRef = pyre_object::setobject::w_frozenset_new;
     push_alias_pair(
         &mut entries,
         "pyre_object::setobject::w_frozenset_new",
         "pyre_object::w_frozenset_new",
         w_frozenset_new as *const (),
     );
-    push_fnaddr(&mut entries, "w_frozenset_new", w_frozenset_new as *const ());
+    push_fnaddr(
+        &mut entries,
+        "w_frozenset_new",
+        w_frozenset_new as *const (),
+    );
     push_alias_pair(
         &mut entries,
         "pyre_object::dictmultiobject::w_dict_len",

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -677,6 +677,17 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         "pyre_object::alloc_dict_object",
         pyre_object::dictmultiobject::alloc_dict_object as *const (),
     );
+    // `w_dict_new` is `#[dont_look_inside]` (residualised over the host
+    // `IndexMap::new` storage box); bind its zero-arg `fn() -> PyObjectRef`
+    // so the residual call resolves, mirroring `w_list_new_empty`.
+    let w_dict_new: fn() -> pyre_object::PyObjectRef = pyre_object::dictmultiobject::w_dict_new;
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::dictmultiobject::w_dict_new",
+        "pyre_object::w_dict_new",
+        w_dict_new as *const (),
+    );
+    push_fnaddr(&mut entries, "w_dict_new", w_dict_new as *const ());
     push_alias_pair(
         &mut entries,
         "pyre_object::dictmultiobject::w_dict_len",

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -688,6 +688,26 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         w_dict_new as *const (),
     );
     push_fnaddr(&mut entries, "w_dict_new", w_dict_new as *const ());
+    // `w_set_new` / `w_frozenset_new` are `#[dont_look_inside]` for the same
+    // host `IndexMap::new` storage-box reason; bind their zero-arg
+    // `fn() -> PyObjectRef` so the residual calls resolve.
+    let w_set_new: fn() -> pyre_object::PyObjectRef = pyre_object::setobject::w_set_new;
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::setobject::w_set_new",
+        "pyre_object::w_set_new",
+        w_set_new as *const (),
+    );
+    push_fnaddr(&mut entries, "w_set_new", w_set_new as *const ());
+    let w_frozenset_new: fn() -> pyre_object::PyObjectRef =
+        pyre_object::setobject::w_frozenset_new;
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::setobject::w_frozenset_new",
+        "pyre_object::w_frozenset_new",
+        w_frozenset_new as *const (),
+    );
+    push_fnaddr(&mut entries, "w_frozenset_new", w_frozenset_new as *const ());
     push_alias_pair(
         &mut entries,
         "pyre_object::dictmultiobject::w_dict_len",

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -2487,6 +2487,11 @@ unsafe fn needs_numeric_binop_dispatch(
 /// paths below are valid for exact builtins, but a heap subclass must enter
 /// `_call_binop_impl` so its forward/reflected override and the reflected-
 /// subclass priority are observed before inherited set semantics.
+///
+/// `dont_look_inside`: `is_exact_type` loads the builtin `SET_TYPE`/
+/// `FROZENSET_TYPE` statics here, so keep that load in this residual helper
+/// off the traced graph — mirrors `needs_seq`/`needs_bytes`/`needs_numeric`.
+#[majit_macros::dont_look_inside]
 unsafe fn needs_set_binop_dispatch(a: PyObjectRef, b: PyObjectRef) -> bool {
     let is_exact_setlike = |obj| {
         pyre_object::is_exact_type(obj, &pyre_object::setobject::SET_TYPE)

--- a/pyre/pyre-object/src/dictmultiobject.rs
+++ b/pyre/pyre-object/src/dictmultiobject.rs
@@ -882,6 +882,15 @@ pub unsafe fn module_dict_register_version_watcher(
 /// helpers reading the Vec directly still see an empty container;
 /// when EmptyDictStrategy is active the Vec is observationally
 /// empty (the trait readers return empty without touching the slot).
+///
+/// `#[dont_look_inside]` (`@jit.dont_look_inside`, `rlib/jit.py:139`), the
+/// `alloc_dict_object` / `w_str_new` twin: the body builds the host
+/// `IndexMap` storage box (`gc_alloc_storage_box(IndexMap::new())`) before
+/// `alloc_dict_object` runs, so the foreign `IndexMap::new` construction sits
+/// outside `alloc_dict_object`'s own residual boundary.  Tracing into it
+/// carries the unported host container op into the caller; residualising the
+/// whole constructor models it by signature — a plain `PyObjectRef` GCREF.
+#[majit_macros::dont_look_inside]
 pub fn w_dict_new() -> PyObjectRef {
     let entries: *mut ObjectDictStorage = crate::gc_storage::gc_alloc_storage_box(
         indexmap::IndexMap::new(),

--- a/pyre/pyre-object/src/setobject.rs
+++ b/pyre/pyre-object/src/setobject.rs
@@ -154,6 +154,14 @@ fn set_write_barrier(obj: PyObjectRef) {
 }
 
 /// Allocate an empty `set`.
+///
+/// `#[dont_look_inside]` (`@jit.dont_look_inside`, `rlib/jit.py:139`), the
+/// `w_dict_new` twin: the body builds the host `SetItemsStorage`
+/// (`IndexMap<ObjectKey, ()>`) box before the object is allocated, so the
+/// foreign `IndexMap::new` construction is an unported host container op.
+/// Tracing into it carries that op into the caller; residualising the whole
+/// constructor models it by signature — a plain `PyObjectRef` GCREF.
+#[majit_macros::dont_look_inside]
 pub fn w_set_new() -> PyObjectRef {
     let items =
         crate::gc_storage::gc_alloc_storage_box(SetItemsStorage::new(), set_items_gc_type_id());
@@ -197,6 +205,9 @@ pub fn w_set_new() -> PyObjectRef {
 ///
 /// Same body as [`w_set_new`] with the constant `&FROZENSET_TYPE` baked
 /// into `ob_type`; see that constructor for the GC old-gen rationale.
+/// `#[dont_look_inside]` for the same `IndexMap::new` storage-box reason as
+/// [`w_set_new`].
+#[majit_macros::dont_look_inside]
 pub fn w_frozenset_new() -> PyObjectRef {
     let items =
         crate::gc_storage::gc_alloc_storage_box(SetItemsStorage::new(), set_items_gc_type_id());


### PR DESCRIPTION
gh#346 (JIT rtyper-legacy retirement) frontier reduction. All three commits retire two-phase-rtyper `[PREPASS phaseB fail]` census heads in a PyPy-orthodox way.

## Commits

1. **`jit: close niche-Option null-test switches with ExitCase::Bool, not Int`**
   A niche `Option<NonNull>` discriminant fold (`ne(base, null_mut())`, result_ty Int) is typed `SomeBool` by the annotator, so the exitswitch rtypes to `BoolRepr` — but the two terminator paths emitted `ExitCase::Const(Int(0|1))`, causing `BoolRepr::convert_const(Int(1))` → `"not a bool: Int(1)"` rtype failure. Record each niche-discriminant fold result var and route its `SwitchInt` arm through `ExitCase::Bool`; genuine two-variant enum tag switches keep the Int-exitcase path.
   - Retires phaseB heads: `descr_has_delete`, `isinstance_str_w`, `object_functionstr_type_name`, `is_w_abstract_proxy`, `arg_type_name`, `lookup`, `subclass_special_override`, `type_call_init_type`.

2. **`jit: residualize w_dict_new over its foreign IndexMap storage box`**
   Add `#[dont_look_inside]` + `jit_fnaddr` registration to `w_dict_new`. Its body builds the host `IndexMap` storage box (`gc_alloc_storage_box(IndexMap::new())`) before `alloc_dict_object` runs, so the foreign `IndexMap::new` op sits outside `alloc_dict_object`'s residual boundary. Model it by signature (a plain `PyObjectRef` GCREF), matching the `w_long_new`/`w_str_new`/`alloc_dict_object` twins.
   - census phaseB 28→24 (retires `w_dict_new` + the transitive getdict cluster).

3. **`jit: residualize w_set_new/w_frozenset_new over their IndexMap storage box`**
   Same root cause — `SetItemsStorage = IndexMap<ObjectKey, ()>`. Add `#[dont_look_inside]` + `jit_fnaddr` registration to `w_set_new`/`w_frozenset_new`. Also add the marker to `needs_set_binop_dispatch` (the only one of the four dispatch siblings missing it; it loads the `SET_TYPE`/`FROZENSET_TYPE` statics via `is_exact_type`).
   - census phaseB 24→22 (retires the set/frozenset constructors, 0 added).

## Verification

- **check.py**: dynasm 324/324 + cranelift 324/324 ALL PASSED, bit-exact vs python3.14.
- `cargo test -p majit-translate`: 3024 passed, 0 failed.
- set/frozenset synth repro (empty constructors + exact binops + subclass dispatch): JIT == naive == python3.14, bit-exact.
- `--no-default-features --features dynasm` clean build.
- Applied the LLBC fingerprint-check discipline (guards against stale-LLBC ghosts).

## Remaining phaseB frontier (22 heads, follow-up slices)

The numeric-binop cluster (int/float/complex_add etc.) + `gc_alloc_storage_box` (survives via non-set/dict callers) + Cluster-B (`is_exception`, `current_sp`, `range_length_big`, error kind). The numeric constructors have a separate perf-sensitive `jit_w_*_new` C-ABI residual variant, so a `dont_look_inside` extension there is not clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed control-flow handling for nullable pointer-based options, including `?` propagation and pattern matching.
  * Corrected true/false branch behavior for null and non-null option values.
* **Performance**
  * Improved JIT-compiled creation of dictionaries, sets, and frozen sets by ensuring native construction paths are used reliably.
* **Tests**
  * Expanded coverage for nullable option branching and added additional object type-name coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->