### PR TITLE
majit(census): bind static PyTypes from the #[pyre_class] registry; raw-ident path normalization

### DIFF
--- a/majit/majit-ir/src/descr.rs
+++ b/majit/majit-ir/src/descr.rs
@@ -290,11 +290,36 @@ pub fn path_hash_stripped_crate(module_path: &str, struct_name: &str) -> u64 {
         Some((_crate, rest)) => rest,
         None => "",
     };
+    // `module_path!()` and `stringify!` spell a raw identifier with its
+    // sigil (`module::r#struct`, `r#type`), while
+    // `module_path_from_source_file` and the Charon-side idents the analyzer
+    // hashes never carry one.  Strip it from every segment of both halves, so
+    // a type declared with — or inside — a keyword-named ident lands in one
+    // `path_hash` namespace instead of two.
+    let struct_name = strip_raw_ident_sigils(struct_name);
     if stripped_module.is_empty() {
-        path_hash(struct_name)
+        path_hash(&struct_name)
     } else {
-        path_hash(&format!("{}::{}", stripped_module, struct_name))
+        path_hash(&format!(
+            "{}::{struct_name}",
+            strip_raw_ident_sigils(stripped_module)
+        ))
     }
+}
+
+/// Every `::`-separated segment of `path` with its raw-identifier sigil
+/// removed, borrowing when there is none to remove.  `#` cannot occur inside
+/// an identifier, so an `r#` in the path is always the sigil.
+fn strip_raw_ident_sigils(path: &str) -> std::borrow::Cow<'_, str> {
+    if !path.contains("r#") {
+        return std::borrow::Cow::Borrowed(path);
+    }
+    std::borrow::Cow::Owned(
+        path.split("::")
+            .map(|seg| seg.strip_prefix("r#").unwrap_or(seg))
+            .collect::<Vec<_>>()
+            .join("::"),
+    )
 }
 
 /// Object-identity token for a STRUCT / enum-variant type definition —

--- a/majit/majit-translate/src/codewriter/call.rs
+++ b/majit/majit-translate/src/codewriter/call.rs
@@ -2344,6 +2344,7 @@ impl CallControl {
         let segments: Vec<&str> = full_path
             .split("::")
             .filter(|segment| !segment.is_empty())
+            .map(Self::strip_raw_ident_sigil)
             .collect();
         if segments.is_empty() {
             return;
@@ -2428,7 +2429,22 @@ impl CallControl {
         } else {
             format!("{module_prefix}::{impl_type_as_written}")
         };
+        let impl_type_joined = impl_type_joined
+            .split("::")
+            .map(Self::strip_raw_ident_sigil)
+            .collect::<Vec<_>>()
+            .join("::");
         self.register_function_fnaddr(CallPath::for_impl_method(&impl_type_joined, method), fnaddr);
+    }
+
+    /// Drop the `r#` sigil from one path segment.  A registry key spelled
+    /// by `module_path!()` keeps it (`module::r#struct`), while the
+    /// canonical [`CallPath`]s these registrations bind against are derived
+    /// from Charon, which records rustc's `DefPath` ident bare.  The sigil
+    /// is surface syntax, not identity, so a helper declared inside such a
+    /// module would otherwise register under a path nothing resolves to.
+    fn strip_raw_ident_sigil(segment: &str) -> &str {
+        segment.strip_prefix("r#").unwrap_or(segment)
     }
 
     /// Register a trait impl method graph.

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -14275,15 +14275,51 @@ fn graph_is_items_block_base_accessor(name: &str) -> bool {
         || name.ends_with("object_array::items_block_items_ptr")
 }
 
+/// One path segment, with a raw-identifier prefix removed.  `r#struct` and
+/// `struct` name the same module: rustc's canonical `DefPath` ident (what
+/// Charon records, and therefore what a `name_path()` carries) drops the
+/// `r#`, while a path spelled by `module_path!()` on the host side keeps it.
+fn path_segment_ident(seg: &str) -> &str {
+    seg.strip_prefix("r#").unwrap_or(seg)
+}
+
+/// Whole-path equality, segment by segment, ignoring raw-identifier
+/// prefixes on either side.
+fn path_eq_ignoring_raw(a: &str, b: &str) -> bool {
+    let mut a = a.split("::");
+    let mut b = b.split("::");
+    loop {
+        match (a.next(), b.next()) {
+            (None, None) => return true,
+            (Some(x), Some(y)) if path_segment_ident(x) == path_segment_ident(y) => {}
+            _ => return false,
+        }
+    }
+}
+
+/// `key` is a proper `::`-boundary suffix of `path`, compared the same way.
+fn path_has_suffix_ignoring_raw(path: &str, key: &str) -> bool {
+    let mut path = path.rsplit("::");
+    let mut key = key.rsplit("::");
+    loop {
+        let Some(k) = key.next() else {
+            // Key exhausted at a segment boundary; require at least one
+            // more segment so this stays a *proper* suffix (whole-path
+            // equality is the caller's other arm).
+            return path.next().is_some();
+        };
+        match path.next() {
+            Some(p) if path_segment_ident(p) == path_segment_ident(k) => {}
+            _ => return false,
+        }
+    }
+}
+
 fn static_key_matches(full: &str, stripped: &str, key: &str) -> bool {
-    full == key
-        || stripped == key
-        || full
-            .strip_suffix(key)
-            .is_some_and(|prefix| prefix.ends_with("::"))
-        || stripped
-            .strip_suffix(key)
-            .is_some_and(|prefix| prefix.ends_with("::"))
+    path_eq_ignoring_raw(full, key)
+        || path_eq_ignoring_raw(stripped, key)
+        || path_has_suffix_ignoring_raw(full, key)
+        || path_has_suffix_ignoring_raw(stripped, key)
 }
 
 /// Supply the value of a primitive `f64` associated constant whose

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -8066,30 +8066,6 @@ impl<'a> Lowering<'a> {
         )
     }
 
-    /// Devirtualize a callsite of the blanket
-    /// `impl<T, U: From<T>> Into<U> for T` (`core::convert::<Impl>::into`).
-    ///
-    /// The callsite's `generics.trait_refs` carries the resolved
-    /// `U: From<T>` obligation as a trait ref whose `trait_decl_ref`
-    /// names `core::convert::From` and whose `kind` is
-    /// `TraitImpl { id }` — the def_id of the selected `impl From<T>
-    /// for U`.  Two outcomes:
-    ///
-    /// - The obligation's decl-ref type args are equal (`T == U`):
-    ///   the reflexive `impl<T> From<T> for T` was selected and the
-    ///   whole conversion is a `T -> T` identity —
-    ///   [`IntoDevirt::Identity`].
-    /// - Otherwise the impl's `methods` table binds the single `From`
-    ///   method to the concrete `from` FunDecl, whose path is the
-    ///   devirtualized call target — [`IntoDevirt::Target`].  `from`
-    ///   is an associated function (no `self` receiver), so the
-    ///   caller must keep the `FunctionPath` shape (a
-    ///   `CallTarget::Method` hint would bind the *argument* as a
-    ///   receiver).
-    ///
-    /// Returns `None` (caller keeps the blanket-into path) when the
-    /// obligation is unresolved (`kind` is a clause/builtin rather
-    /// than `TraitImpl`) or any table lookup misses.
     /// `<*const T>::cast_mut` / `<*mut T>::cast_const` — pointer casts that
     /// change only const/mut, never the pointee type.  The JIT does not
     /// model the mut/const distinction (`Ref` / `RawPtr` lower to a
@@ -8539,6 +8515,30 @@ impl<'a> Lowering<'a> {
         }
     }
 
+    /// Devirtualize a callsite of the blanket
+    /// `impl<T, U: From<T>> Into<U> for T` (`core::convert::<Impl>::into`).
+    ///
+    /// The callsite's `generics.trait_refs` carries the resolved
+    /// `U: From<T>` obligation as a trait ref whose `trait_decl_ref`
+    /// names `core::convert::From` and whose `kind` is
+    /// `TraitImpl { id }` — the def_id of the selected `impl From<T>
+    /// for U`.  Two outcomes:
+    ///
+    /// - The obligation's decl-ref type args are equal (`T == U`):
+    ///   the reflexive `impl<T> From<T> for T` was selected and the
+    ///   whole conversion is a `T -> T` identity —
+    ///   [`IntoDevirt::Identity`].
+    /// - Otherwise the impl's `methods` table binds the single `From`
+    ///   method to the concrete `from` FunDecl, whose path is the
+    ///   devirtualized call target — [`IntoDevirt::Target`].  `from`
+    ///   is an associated function (no `self` receiver), so the
+    ///   caller must keep the `FunctionPath` shape (a
+    ///   `CallTarget::Method` hint would bind the *argument* as a
+    ///   receiver).
+    ///
+    /// Returns `None` (caller keeps the blanket-into path) when the
+    /// obligation is unresolved (`kind` is a clause/builtin rather
+    /// than `TraitImpl`) or any table lookup misses.
     fn blanket_into_devirt(&self, reg: &RegularCall) -> Option<IntoDevirt> {
         let CallKind::Fun(FunId::Regular { id }) = &reg.kind else {
             return None;

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -5827,6 +5827,8 @@ impl<'a> Lowering<'a> {
                 // argument directly (same shape as a transparent
                 // ctor alias) instead of emitting a call to core's
                 // identity body, which is not a registered callee.
+                // `is_reflexive_from` takes the same path for the same
+                // impl reached through `From::from` directly.
                 //
                 // The clause-bound variant — `msg.into()` inside a
                 // generic body with `T: Into<String>` — has no
@@ -5837,6 +5839,7 @@ impl<'a> Lowering<'a> {
                 // it takes the same alias path.
                 if args.len() == 1
                     && (matches!(self.blanket_into_devirt(&reg), Some(IntoDevirt::Identity))
+                        || self.is_reflexive_from(&reg)
                         || self.trait_clause_into_string_identity(&reg, &call.dest.ty)
                         || self.is_noop_ptr_cast(&reg)
                         || self.is_reflexive_into_iter(&reg)
@@ -8367,6 +8370,12 @@ impl<'a> Lowering<'a> {
                     // the same element sequence — an identity on the list model.
                     | "core::array::<Impl>::into_iter"
                     | "core::array::iter::<Impl>::into_iter"
+                    // `alloc/src/boxed/iter.rs` — the `Box<[T]>` forms, by
+                    // value and by reference; the latter delegates to slice
+                    // iter. A boxed slice is the same element sequence as the
+                    // slice it owns (`project_pyre_field_type` strips the
+                    // `Box`), so both walk the receiver's list.
+                    | "alloc::boxed::iter::<Impl>::into_iter"
             )
         })
     }
@@ -8410,6 +8419,20 @@ impl<'a> Lowering<'a> {
     /// model and the callsite aliases its receiver instead of leaving the
     /// unregistered method callee.
     ///
+    /// The pyre length-prefixed containers `FixedObjectArray` / `IntArray`
+    /// / `FloatArray` expose the same pair of views, each spelled
+    /// `from_raw_parts(self.base(), self.len)` over their own backing
+    /// block (`object_array.rs:853-859`, `int_array.rs:120-125`,
+    /// `float_array.rs:120-125`).  Their receivers are already list-modelled
+    /// — [`Self::is_container_len`] carries the identical object/int/float
+    /// trio — so the same receiver-alias applies, and entering the body
+    /// instead dead-ends at the unregistered `core::slice::raw::from_raw_parts`.
+    ///
+    /// `as_mut_slice` is matched alongside `as_slice`: the mutable view
+    /// addresses the receiver's own storage, so a write through the alias
+    /// *is* a write to the receiver, which is exactly what the list model
+    /// wants.
+    ///
     /// `<[T]>::to_vec` is deliberately NOT matched: it allocates an
     /// independent list, so aliasing it to the receiver would let a later
     /// mutation of the copy (or of the original) be observed through the
@@ -8422,7 +8445,14 @@ impl<'a> Lowering<'a> {
         self.llbc.fn_by_id(*id).is_some_and(|fd| {
             matches!(
                 fd.item_meta.name_path().as_str(),
-                "core::slice::<Impl>::as_slice" | "alloc::vec::<Impl>::as_slice"
+                "core::slice::<Impl>::as_slice"
+                    | "alloc::vec::<Impl>::as_slice"
+                    | "pyre_object::object_array::<Impl>::as_slice"
+                    | "pyre_object::object_array::<Impl>::as_mut_slice"
+                    | "pyre_object::int_array::<Impl>::as_slice"
+                    | "pyre_object::int_array::<Impl>::as_mut_slice"
+                    | "pyre_object::float_array::<Impl>::as_slice"
+                    | "pyre_object::float_array::<Impl>::as_mut_slice"
             )
         })
     }
@@ -8440,6 +8470,45 @@ impl<'a> Lowering<'a> {
         self.llbc
             .fn_by_id(*id)
             .is_some_and(|fd| fd.item_meta.name_path() == "core::hint::must_use")
+    }
+
+    /// A callsite of the reflexive `impl<T> From<T> for T`
+    /// (`core::convert::<Impl>::from`), whose whole conversion is a
+    /// `T -> T` identity.  `core` carries no graph body, so without this
+    /// the callsite skips as an unregistered `FunctionPath`; aliasing the
+    /// destination to the argument is the `From` direction of the
+    /// identity [`Self::blanket_into_devirt`] already reports for `Into`
+    /// through [`IntoDevirt::Identity`].
+    ///
+    /// The gate is the *declared* signature rather than the instantiated
+    /// one: the reflexive impl declares `from(T) -> T`, so its input and
+    /// output resolve to the same type expression whatever `T` is bound
+    /// to at the callsite, and no generic substitution has to be walked.
+    /// A conversion between two distinct types declares two distinct
+    /// expressions and keeps the ordinary call — it has a body worth
+    /// entering, or crosses a repr boundary the carrier models.
+    ///
+    /// The live callsite is `pyopcode`'s `u32::from(format.get(op_arg))`:
+    /// [`Self::oparg_value_alias`] already binds `Arg::<T>::get` to its
+    /// `OpArg` argument, so the `From` sees a `u32` on both sides and
+    /// rustc selects the reflexive impl.
+    fn is_reflexive_from(&self, reg: &RegularCall) -> bool {
+        let CallKind::Fun(FunId::Regular { id }) = &reg.kind else {
+            return false;
+        };
+        let Some(fd) = self.llbc.fn_by_id(*id) else {
+            return false;
+        };
+        if fd.item_meta.name_path() != "core::convert::<Impl>::from" {
+            return false;
+        }
+        let Some(src) = fd.signature.inputs.first() else {
+            return false;
+        };
+        match (self.tyref_body(src), self.tyref_body(&fd.signature.output)) {
+            (Some(src_ty), Some(dst_ty)) => src_ty == dst_ty,
+            _ => false,
+        }
     }
 
     /// `f64::is_nan(self)` — `core` has no graph body (Opaque), so the

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -863,11 +863,16 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         "pyre_interpreter::lookup_in_type_where_uncached",
         lookup_in_type_where_uncached as *const (),
     );
-    // `gc_interp::enabled` reads (and lazily inits) the `STATE` atomic and
-    // `longobject::bigint_gc_type_id` reads the init-assigned `BIGINT_GC_TYPE_ID`
-    // atomic — neither is a build-time constant, so both carry
+    // `gc_interp::enabled` reads (and lazily inits) the `STATE` atomic, and
+    // `longobject::bigint_gc_type_id` /
+    // `dictmultiobject::dict_view_iterator_gc_type_id` read the
+    // init-assigned `BIGINT_GC_TYPE_ID` / `W_DICT_VIEW_ITERATOR_GC_TYPE_ID`
+    // cells — none is a build-time constant, so all three carry
     // `#[dont_look_inside]` and bind their `-> bool` / `-> u32` Rust `fn`
-    // directly by qualified path.
+    // directly by qualified path.  A type-id cell deliberately does NOT get
+    // a `jit_static_pytype_addrs` / `jit_static_ref_addrs` row: those carry
+    // the address of a value fixed at build time, and folding a
+    // runtime-stamped id that way would bake `TypeIdCell::UNASSIGNED`.
     push_alias_pair(
         &mut entries,
         "pyre_object::gc_interp::enabled",
@@ -879,6 +884,12 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         "pyre_object::longobject::bigint_gc_type_id",
         "pyre_object::bigint_gc_type_id",
         pyre_object::longobject::bigint_gc_type_id as *const (),
+    );
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::dictmultiobject::dict_view_iterator_gc_type_id",
+        "pyre_object::dict_view_iterator_gc_type_id",
+        pyre_object::dictmultiobject::dict_view_iterator_gc_type_id as *const (),
     );
     // The dispatch-loop safepoint's four toucher residuals plus the frame-entry
     // odometer bump and the items-block strategy gate: each reads a
@@ -2162,15 +2173,19 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
 /// addresses are identical to a direct `&pyre_object::X` read at the
 /// codewriter call site.
 ///
-/// Keys are the in-source `module::NAME` spelling the front-end
-/// `Expr::Path` arm looks up in `KnownStaticsCatalogue`.
+/// Keys name the static's path.  The front-end reaches them through
+/// `HostStaticAddrs::pytypes` and matches with `front::mir`'s
+/// `static_key_matches`, which accepts the full path, the crate-stripped
+/// path, or either with the key as a `::`-boundary suffix — so both the
+/// `module::NAME` spelling the rows below use and the fully-qualified
+/// spelling [`pyre_class_pytype_addrs`] carries resolve the same static.
 pub fn jit_static_pytype_addrs() -> Vec<(&'static str, i64)> {
     macro_rules! pytype_addr {
         ($key:literal, $($path:tt)::+) => {
             ($key, &pyre_object::$($path)::+ as *const _ as i64)
         };
     }
-    vec![
+    let mut rows = vec![
         pytype_addr!(
             "bytearrayobject::BYTEARRAY_TYPE",
             bytearrayobject::BYTEARRAY_TYPE
@@ -2258,6 +2273,10 @@ pub fn jit_static_pytype_addrs() -> Vec<(&'static str, i64)> {
             interp_exceptions::EXC_NAME_ERROR_TYPE
         ),
         pytype_addr!(
+            "interp_exceptions::EXC_UNBOUND_LOCAL_ERROR_TYPE",
+            interp_exceptions::EXC_UNBOUND_LOCAL_ERROR_TYPE
+        ),
+        pytype_addr!(
             "interp_exceptions::EXC_INDEX_ERROR_TYPE",
             interp_exceptions::EXC_INDEX_ERROR_TYPE
         ),
@@ -2332,6 +2351,10 @@ pub fn jit_static_pytype_addrs() -> Vec<(&'static str, i64)> {
         pytype_addr!(
             "interp_exceptions::EXC_SYSTEM_ERROR_TYPE",
             interp_exceptions::EXC_SYSTEM_ERROR_TYPE
+        ),
+        pytype_addr!(
+            "interp_exceptions::EXC_BUFFER_ERROR_TYPE",
+            interp_exceptions::EXC_BUFFER_ERROR_TYPE
         ),
         pytype_addr!(
             "interp_exceptions::EXC_LOOKUP_ERROR_TYPE",
@@ -2528,7 +2551,49 @@ pub fn jit_static_pytype_addrs() -> Vec<(&'static str, i64)> {
             "interp_buffer::PICKLEBUFFER_TYPE",
             &crate::module::__pypy__::interp_buffer::PICKLEBUFFER_TYPE as *const _ as i64,
         ),
-    ]
+    ];
+    // Fold in the `#[pyre_class]` registry.  A row above names one static
+    // by hand, so a `#[pyre_class]` that lands without someone adding its
+    // row leaves that type's address unbound and every graph reaching it
+    // walled off at translation — a drift the rows cannot prevent because
+    // the macro derives the static's identifier from the struct name and
+    // no source search finds it.  Deduplicated on the address, not the
+    // key: the two spellings differ (`module::NAME` above, fully-qualified
+    // below) and both satisfy the front-end's `static_key_matches`, so the
+    // hand-written row wins for the types that already have one.
+    let hand_written: std::collections::HashSet<i64> = rows.iter().map(|&(_, addr)| addr).collect();
+    rows.extend(
+        pyre_class_pytype_addrs()
+            .into_iter()
+            .filter(|(_, addr)| !hand_written.contains(addr)),
+    );
+    rows
+}
+
+/// The `PyType` static of every `#[pyre_class]` type, keyed by the
+/// fully-qualified Rust path the flowgraph names the global read with
+/// (`PyreClassDescriptor::pytype_path`).
+///
+/// Empty on `wasm32`, where the `PYRE_CLASS_DESCRIPTORS` registry does not
+/// exist (`linkme::distributed_slice` rejects the target).  That makes the
+/// binding set target-dependent, so `pyre-jit-trace`'s build script drops
+/// these rows when it is generating jitcodes *for* wasm: a name bound at
+/// build time but missing from the runtime pool keeps the build-process
+/// address baked in the constant pool, because
+/// `runtime_fnaddr_patch::patch_static_addr_constants` only re-pairs names
+/// present in both.
+pub fn pyre_class_pytype_addrs() -> Vec<(&'static str, i64)> {
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        pyre_object::lltype::PYRE_CLASS_DESCRIPTORS
+            .iter()
+            .map(|d| (d.pytype_path, d.pytype_ptr as usize as i64))
+            .collect()
+    }
+    #[cfg(target_arch = "wasm32")]
+    {
+        Vec::new()
+    }
 }
 
 /// Build-time addresses of the prebuilt dict-strategy singletons pyre

--- a/pyre/pyre-jit-trace/build.rs
+++ b/pyre/pyre-jit-trace/build.rs
@@ -395,7 +395,33 @@ fn real_main() {
     // build-script process the translator runs in, so the captured
     // addresses match a direct `&pyre_object::X` read at the codewriter
     // call site.
-    let static_pytype_addrs = pyre_interpreter::jit_static_pytype_addrs();
+    let mut static_pytype_addrs = pyre_interpreter::jit_static_pytype_addrs();
+    // This script is compiled for the host even when the crate it feeds is
+    // built for wasm, so the `#[pyre_class]` registry is populated here and
+    // empty there.  Binding a name the wasm runtime cannot re-pair would
+    // leave this process's address baked in the constant pool
+    // (`runtime_fnaddr_patch::patch_static_addr_constants` rewrites only
+    // names it finds in both pools), so drop the registry-derived rows when
+    // the target is wasm and let those statics stay unbound instead.
+    let registry_rows = pyre_interpreter::pyre_class_pytype_addrs();
+    let registry_keys: std::collections::HashSet<&str> =
+        registry_rows.iter().map(|&(key, _)| key).collect();
+    if std::env::var("CARGO_CFG_TARGET_ARCH").as_deref() == Ok("wasm32") {
+        static_pytype_addrs.retain(|(key, _)| !registry_keys.contains(key));
+    }
+    // Counts the rows that survived, not the registry's size: the table
+    // drops every registry row whose static a hand-written row already
+    // names, and all of them when the target is wasm.
+    let kept_from_registry = static_pytype_addrs
+        .iter()
+        .filter(|(key, _)| registry_keys.contains(key))
+        .count();
+    eprintln!(
+        "[PREPASS statics] pytype rows = {} ({kept_from_registry} of {} \
+         #[pyre_class] registry rows kept)",
+        static_pytype_addrs.len(),
+        registry_rows.len(),
+    );
     let static_ref_addrs = pyre_interpreter::jit_static_ref_addrs();
     let static_int_values = pyre_interpreter::jit_static_int_values();
     let static_addrs = majit_translate::HostStaticAddrs {

--- a/pyre/pyre-macros/src/lib.rs
+++ b/pyre/pyre-macros/src/lib.rs
@@ -1167,6 +1167,11 @@ fn expand_pyre_class(
                 object_size: #object_size_const,
                 ptr_offsets: &#ptr_offsets_const,
                 pyname: #name_lit,
+                pytype_path: ::core::concat!(
+                    ::core::module_path!(),
+                    "::",
+                    ::core::stringify!(#pytype_static),
+                ),
             };
 
         /// Link-time registration of this class's descriptor into the

--- a/pyre/pyre-object/src/dictmultiobject.rs
+++ b/pyre/pyre-object/src/dictmultiobject.rs
@@ -3821,9 +3821,18 @@ pub const W_DICT_VIEW_ITERATOR_OBJECT_SIZE: usize =
 
 pub const W_DICT_VIEW_ITERATOR_GC_PTR_OFFSETS: [usize; 1] = [DICT_VIEW_ITER_W_DICT_OFFSET];
 
+/// Reads the runtime-assigned dict-view iterator type id (stamped once at
+/// init by the JIT driver's GC registration); the value is not a build-time
+/// constant, so the JIT residualises the read instead of tracing into it
+/// (`@dont_look_inside`).
+#[majit_macros::dont_look_inside]
+pub fn dict_view_iterator_gc_type_id() -> u32 {
+    W_DICT_VIEW_ITERATOR_GC_TYPE_ID.get()
+}
+
 impl crate::lltype::GcType for W_BaseDictMultiIterObject {
     fn type_id() -> u32 {
-        W_DICT_VIEW_ITERATOR_GC_TYPE_ID.get()
+        dict_view_iterator_gc_type_id()
     }
     const SIZE: usize = W_DICT_VIEW_ITERATOR_OBJECT_SIZE;
 }
@@ -3886,7 +3895,7 @@ fn w_dict_view_iterator_new_direction(
         start_strategy_id,
     };
     let raw = crate::gc_hook::try_gc_alloc_stable_raw(
-        W_DICT_VIEW_ITERATOR_GC_TYPE_ID.get(),
+        dict_view_iterator_gc_type_id(),
         W_DICT_VIEW_ITERATOR_OBJECT_SIZE,
     );
     if raw.is_null() {

--- a/pyre/pyre-object/src/lltype.rs
+++ b/pyre/pyre-object/src/lltype.rs
@@ -152,6 +152,23 @@ pub struct PyreClassDescriptor {
     /// diagnostics — the GC-root registration guard reports it by name
     /// when a type with managed children was left unregistered.
     pub pyname: &'static str,
+    /// Fully-qualified Rust path of the `PyType` static
+    /// [`Self::pytype_ptr`] points at (`"pyre_interpreter::module::thread\
+    /// ::local_class::LOCAL_TYPE"`), spelled the way the flowgraph names
+    /// the global read.  `#[pyre_class]` derives the static's identifier
+    /// from the struct name, so the path exists only after macro
+    /// expansion and no source search finds it; carrying it here is what
+    /// lets the JIT bind the address without a hand-written table row per
+    /// type (`pyre-interpreter/src/jit_fnaddr.rs`
+    /// `jit_static_pytype_addrs`).
+    ///
+    /// Declare the type at module scope.  The path comes from
+    /// `module_path!()`, which names the enclosing *module*, so a
+    /// `#[pyre_class]` written inside a function body would carry a path
+    /// missing that function's segment and bind nothing — unlike the raw
+    /// identifier difference (`mod r#struct`), which the consumer side
+    /// normalizes away.
+    pub pytype_path: &'static str,
 }
 
 // Safety: every field is either a static-`'static` reference (PyType,


### PR DESCRIPTION
Continues the #73 census work. Three commits: the first two are the Slice B recognizers (reflexive `From`, `Box<[T]>` iteration, pyre container slice views) plus a doc-block relocation; the third is this slice.

## What was wrong

`jit_static_pytype_addrs()` named every prebuilt `PyType` singleton by hand. `#[pyre_class]` derives its type object's static identifier from the struct name (`W_Local` → `LOCAL_TYPE`), so the static exists only after macro expansion and no source search finds it — a class landing without someone adding its row left that address unbound, and every graph reaching it walled off at translation.

Measured: **25 of the 72 `#[pyre_class]` types had no row**, while **45 rows had been written by hand for statics the macro generated**. `local_class::LOCAL_TYPE` (added by #784) was simply the first one a traced graph reached.

Upstream has no such table — a prebuilt object enters the flow graph as a `Constant` automatically (`rpython/flowspace/flowcontext.py:845-858`) and the codewriter bakes it straight into the constant pool (`rpython/jit/codewriter/assembler.py:80-138`). pyre reads Charon LLBC, where a static is a symbolic path, so *some* host-address boundary is unavoidable and `HostStaticAddrs` is the documented analog of "`Constant(GCREF)` from the host". The boundary is parity; the hand-maintenance was not.

## What changed

The registry that fixes this already existed: `#[pyre_class]` emits a `PyreClassDescriptor` into the whole-program `linkme` slice `PYRE_CLASS_DESCRIPTORS`, documented there as "the Rust stand-in for RPython's translation-time walk". The only missing piece was a Rust-path key.

- `PyreClassDescriptor` gains `pytype_path`; `jit_static_pytype_addrs()` extends from the slice, deduplicated **on the address** so a hand-written row wins.
- The slice is absent on `wasm32`, so the build script drops the registry-derived rows when the target is wasm. Without that, a name bound at build time (the script is host-compiled) but missing from the wasm runtime pool keeps the build-process address in the constant pool, because `patch_static_addr_constants` re-pairs only names present in both. Cross-target cache reuse cannot defeat the filter — `codegen_cache_key` hashes `TARGET` and every `CARGO_CFG_TARGET_*`.
- Two hand-written statics were also missing: `EXC_BUFFER_ERROR_TYPE` and `EXC_UNBOUND_LOCAL_ERROR_TYPE`. An audit of `pub static X: PyType` across pyre-object now finds none unbound.
- `W_DICT_VIEW_ITERATOR_GC_TYPE_ID` gets a `#[dont_look_inside]` accessor bound through `push_alias_pair`, following `bigint_gc_type_id` — **not** a static-address row. The cell is stamped at runtime, so an address row would have folded `TypeIdCell::UNASSIGNED`.

### Raw-identifier paths

`module_path!()` spells a raw identifier with its `r#` sigil; Charon records rustc's `DefPath` ident bare. Paths crossing that boundary are now compared and hashed with the sigil stripped, at all three sites that cross it: `static_key_matches`, `path_hash_stripped_crate`, and the two `#[jit_module]` helper registrars. `mod r#struct` (which mirrors `pypy/module/struct`, so renaming it is not an option) is the only raw-ident module in the extracted crates and carries no jit attributes, so only the two `#[pyre_class]` types inside it were actually affected; the other two sites are hardening. The hash site cannot be fixed by a matcher — a `#[jit_struct]` there would have silently split descr identity between the macro side and the analyzer side.

## Verification

`cargo check --all --no-default-features --features dynasm` and `cargo test --all --no-default-features --features dynasm` are clean. The build script reports `pytype rows = 151 (25 of 72 #[pyre_class] registry rows kept)`.

**Census A/B**, base regenerated from this commit's parent so both runs share the same upstream base:

| | base | HEAD |
|---|---|---|
| phaseA | 307 | **304** |
| phaseB | 40 | 40 |
| newly failing graphs | — | **0** |

| root | base | HEAD |
|---|---|---|
| `local_class::LOCAL_TYPE` | 6 | **0** |
| `dictmultiobject::W_DICT_VIEW_ITERATOR_GC_TYPE_ID` | 4 | **0** |
| `interp_exceptions::EXC_BUFFER_ERROR_TYPE` | 4 | **0** |
| `call::CALL_DEPTH` | 14 | 11 |
| `host_env::thread::current_thread_id` | 0 | 4 |
| `builtins::EXC_CLASS_REGISTRY` | 2 | 3 |
| `interp_exceptions::w_exception_new_empty_impl` | 0 | 1 |

14 records of walls clear; the net is only −3 because most of those graphs re-block on their next unregistered callee — the census reports one wall per graph, so a slice is budgeted at roots-driven-to-zero, not records cleared. Three graphs clear entirely: `W_Local::from_obj`, `call::user_call_slot`, `exc_kind_to_pytype`. The next wall is itself a coherent class (10 roots / ~41 records of runtime-mutable-global accessors missing `#[dont_look_inside]`), addressable with the same mechanism this PR validates.

The Codex parity review reported no section-1/3 findings and one section-2 finding — that the `r#` normalization in `path_hash_stripped_crate` covered only the module segments, leaving `struct_name` and the crate-root branch unnormalized. Fixed in this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility with Rust raw identifiers, helping names and paths resolve consistently.
  - Improved handling of conversion, iterator, slice, and array operations during execution.
  - Fixed runtime type and function address resolution for dictionary views and generated classes.
  - Added missing exception type mappings for more reliable JIT execution.

- **Compatibility**
  - Improved WebAssembly builds by preventing host-specific type addresses from being embedded.
  - Expanded support for automatically registered runtime classes and their type information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->