### PR TITLE
jit: size the int/float GcArray tids from the TypedItemsBlock items offset; interpreter: skip the builtin-subclass dunder lookup for exact builtins

### DIFF
--- a/pyre/pyre-interpreter/src/display.rs
+++ b/pyre/pyre-interpreter/src/display.rs
@@ -358,6 +358,13 @@ pub(crate) unsafe fn builtin_subclass_dunder_obj(
         if !is_leaf {
             return Ok(None);
         }
+        // An exact builtin is not a subclass instance: its `w_class` is the
+        // canonical type object, so the MRO walk below would resolve the
+        // builtin's own dunder and re-dispatch it through a full call rather
+        // than the native formatting this function exists to defer to.
+        if pyre_object::is_exact_builtin_instance(obj) {
+            return Ok(None);
+        }
         let w_class = (*obj).w_class;
         if w_class.is_null() || !pyre_object::is_type(w_class) {
             return Ok(None);

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -2058,8 +2058,17 @@ fn build_gc() -> Box<dyn majit_gc::GcAllocator> {
     // GcLLDescr_framework.init_array_descr (gc.py:544-549).  These
     // two primitive GcArray lltypes have the same trace shape but are
     // distinct ARRAY identities, so register separate tids.
+    //
+    // The blocks carrying these two tids are `TypedItemsBlock`s
+    // (`rbigint._digits`, the Integer/Float list strategies), so the base size
+    // is that block's items offset, not `GcTypedArray`'s bare length word: the
+    // 8-byte items force 8-byte alignment, which pads a 4-byte length prefix on
+    // a 32-bit target. Sizing the instance from the length word would then
+    // compute four bytes too few and truncate the last item on every copy.
+    // `state.rs` builds the JIT array descrs for the same tids from the same
+    // offset.
     let gc_int_array_tid = gc.register_type(TypeInfo::varsize(
-        pyre_object::GC_TYPED_ARRAY_ITEMS_OFFSET,
+        pyre_object::TYPED_ITEMS_BLOCK_ITEMS_OFFSET,
         std::mem::size_of::<i64>(),
         pyre_object::GC_TYPED_ARRAY_LEN_OFFSET,
         false,
@@ -2067,7 +2076,7 @@ fn build_gc() -> Box<dyn majit_gc::GcAllocator> {
     ));
     debug_assert_eq!(gc_int_array_tid, GC_INT_ARRAY_GC_TYPE_ID);
     let gc_float_array_tid = gc.register_type(TypeInfo::varsize(
-        pyre_object::GC_TYPED_ARRAY_ITEMS_OFFSET,
+        pyre_object::TYPED_ITEMS_BLOCK_ITEMS_OFFSET,
         std::mem::size_of::<f64>(),
         pyre_object::GC_TYPED_ARRAY_LEN_OFFSET,
         false,


### PR DESCRIPTION
Two commits. The first fixes a wasm32-only GC sizing bug that silently corrupts
bignums; the second lands a `repr`/`str`/f-string fast path that the first one
unblocks.

## 1. `jit`: size the int/float GcArray tids from the `TypedItemsBlock` items offset

`GC_INT_ARRAY_GC_TYPE_ID` / `GC_FLOAT_ARRAY_GC_TYPE_ID` were registered in
`build_gc` with `GC_TYPED_ARRAY_ITEMS_OFFSET` as the varsize base. That constant
is `size_of::<usize>()` — the items offset of `GcTypedArray`, which is not GC
managed. Every block actually allocated with those two tids is a
`TypedItemsBlock` (`rbigint._digits`, the Integer/Float list strategies), whose
items sit at 8 because `[u64; 0]` forces 8-byte alignment over the `usize`
length prefix.

The two agree on 64-bit and differ by 4 on wasm32, where `total_instance_size`
then reported four bytes too few and `copy_nursery_object` truncated the high
half of a digits block's last item on every minor collection.

`state.rs` already builds the JIT array descrs for the same two tids from
`TYPED_ITEMS_BLOCK_ITEMS_OFFSET`; the GC registration was the lone outlier.

### Symptom

`bench/fib_loop.py` and `bench/synth/binary_int_overflow_local_resume.py`
printed wrong integers on the wasm backend. Two further phrasings of the same
fib program were already wrong on unmodified `main`, so `fib_loop` passing the
wasm gate was luck rather than correctness.

Minimal reproducer (wasm only, deterministic — it needs a preceding run in the
same process, a single `churn(20000)` standalone is always correct):

```python
V = 1 << 62
keep = V * 2
def churn(n):
    s = 0
    for i in range(n):
        s = (s + (V * (i % 5 + 2)) % 1000000007) % 1000000007
    return s
for k in range(4):
    churn(20000)
    print(k, keep)          # k >= 1 prints a corrupted, ever-growing value
```

Decomposing the corrupted bignums into base-2^63 digits and diffing against the
originals is what identified it — same mask, always the last digit, always its
high 32 bits, `digit[0]` untouched:

```
0x1        -> 0x2900000001    xor = 0x2900000000
0xa1bd45   -> 0x2900a1bd45    xor = 0x2900000000
0x42d80f16 -> 0x2942d80f16    xor = 0x2900000000
```

That is a short copy, not a dangling pointer and not a lost `old -> young` edge.
Hypotheses measured and refuted along the way are recorded in #808:
`JitBigIntResult = i64` breaking the payload's Ref-ness, the wasm-only
collecting nursery hooks, the old-gen major armed by `PYRE_GC_INTERP`, and
`MAJIT_GC_NURSERY_POISON` (inert on wasm — `Nursery::reset` always zero-fills
there).

## 2. `interpreter`: skip the builtin-subclass dunder lookup for exact builtins

`builtin_subclass_dunder_obj` guarded only on `w_class` being a type, but every
exact builtin carries `w_class = get_instantiate(&<TYPE>)`, so an exact `int`
also entered the lookup: two uncached MRO walks (`lookup_where_pair`) plus a
full `call_and_check` of the builtin's own `__repr__`/`__str__`, leaving the
native `builtin_leaf_repr_string` path below unreachable for it. Gate on
`pyre_object::is_exact_builtin_instance` before the `w_class` read.

Measured against CPython 3.14 (median-5, user CPU, startup subtracted):

| | before | after |
|---|---|---|
| `[f"{i}" for i in range(1000)]` | 13.75x | **2.13x** |
| `repr(i)` | 17.4x | 7.9x |
| `str(i)` | 42.7x | 25.2x |

This change was held back until now because it re-shaped the wasm traces enough
to land on defect 1 above.

## Note on #808

That issue conflated this wasm defect with a native poison-detector panic on the
same benchmark. They are independent; the body has been corrected. The native
half (blackhole ref setters dropping the write barrier) is fixed separately and
is not in this PR — this PR's fix does not stop the native panic, and that fix
does not change the wasm output.

## Verification

`python3 pyre/check.py` — dynasm 328/328, cranelift 328/328, wasm 325/325.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected subclass behavior for exact built-in instances, preventing incorrect override dispatch.
  * Fixed memory layout and sizing calculations for JIT-managed integer and floating-point arrays, improving allocation reliability across platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->