### PR TITLE
long, jit: rbigint follow-ups — write-barrier and 3.14 surface fixes, and walker specializations for long/int div, mod, pow and divmod

### DIFF
--- a/.github/workflows/pyre-ci.yml
+++ b/.github/workflows/pyre-ci.yml
@@ -383,6 +383,15 @@ jobs:
         PYRE_CHECK_PYTHON3: ${{ steps.cpython.outputs.python-path }}
         PYRE_CHECK_PYPY3: ${{ steps.pypy.outputs.python-path }}
       run: ${{ steps.cpython.outputs.python-path }} pyre/check.py
+    - name: Run pyre/extra_tests/parity_tests
+      # Every script must exit 0 and print "OK" as its last line under CPython
+      # AND under each pyre backend, so a divergence from CPython observable
+      # semantics fails here. check.py has just built the release pyre-dynasm
+      # and pyre-cranelift binaries the runner drives, so this costs only the
+      # per-script process spawns.
+      env:
+        PYRE_CHECK_PYTHON3: ${{ steps.cpython.outputs.python-path }}
+      run: ${{ steps.cpython.outputs.python-path }} pyre/extra_tests/parity_tests/run.py
     - name: JIT structural stats vs committed baseline (Linux, informational)
       # Diff each benchmark's [jit-stats] counters against the committed
       # pyre/bench/<name>.<backend>.jitstats baselines. The counters are decided

--- a/majit/majit-backend-dynasm/src/aarch64/assembler.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/assembler.rs
@@ -5891,9 +5891,9 @@ impl<'a> AssemblerARM64<'a> {
         is_array: bool,
         loc_index: Option<crate::regloc::RegLoc>,
     ) {
-        let wb = match crate::runner::with_dynasm_active_gc(|gc| gc.get_write_barrier_descr()) {
-            Some(Some(wb)) => wb,
-            _ => return,
+        let wb = match crate::runner::dynasm_write_barrier_descr() {
+            Some(wb) => wb,
+            None => return,
         };
         let card_marking = is_array && wb.jit_wb_cards_set != 0;
 

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -128,6 +128,20 @@ pub(crate) fn with_dynasm_active_gc<R>(f: impl Fn(&dyn majit_gc::GcAllocator) ->
     None
 }
 
+/// GC write-barrier descriptor for machine-code generation.
+///
+/// Compilation may run outside the mutator thread that owns
+/// `DYNASM_ACTIVE_GC`. PyPy keeps this descriptor on `cpu.gc_ll_descr`; use
+/// the current MiniMark layout in that case instead of silently omitting every
+/// barrier. If an active collector explicitly reports no descriptor, preserve
+/// that choice.
+pub(crate) fn dynasm_write_barrier_descr() -> Option<majit_gc::WriteBarrierDescr> {
+    match with_dynasm_active_gc(|gc| gc.get_write_barrier_descr()) {
+        Some(descr) => descr,
+        None => Some(majit_gc::WriteBarrierDescr::for_current_gc()),
+    }
+}
+
 /// `&mut` counterpart of [`with_dynasm_active_gc`] for GC mutations
 /// (allocation, write barriers). Same three-way routing: test box →
 /// box; production (no box, `gc_sync` initialized) → `gc_sync::gc_op`;

--- a/majit/majit-backend-dynasm/src/x86/assembler.rs
+++ b/majit/majit-backend-dynasm/src/x86/assembler.rs
@@ -516,8 +516,7 @@ fn build_malloc_slowpath_body(asm: &mut Assembler, slowpath_fn: i64, propagate_p
     // share): non-array write barrier on the reloaded jf so subsequent
     // Ref writes into frame slots are tracked by minor GC.  The barrier
     // body is conditional on the GC exposing a write-barrier descr.
-    let wb_descr =
-        crate::runner::with_dynasm_active_gc(|gc| gc.get_write_barrier_descr()).flatten();
+    let wb_descr = crate::runner::dynasm_write_barrier_descr();
     if let Some(wb) = wb_descr {
         let byteofs = wb.jit_wb_if_flag_byteofs;
         let mask = wb.jit_wb_if_flag_singlebyte as i8;
@@ -2456,10 +2455,7 @@ impl<'a> Assembler386<'a> {
         // (assembler.py:2401 `if array and jit_wb_cards_set` gate); the
         // `helper_num=4` XMM-skip optimization is a perf adaptation not
         // a correctness gap and is not yet implemented.
-        if crate::runner::with_dynasm_active_gc(|gc| gc.get_write_barrier_descr())
-            .flatten()
-            .is_some()
-        {
+        if crate::runner::dynasm_write_barrier_descr().is_some() {
             let rbp_loc = Loc::Reg(crate::regloc::EBP);
             self.emit_write_barrier_fastpath_kind(&[rbp_loc], false);
         }
@@ -7581,9 +7577,7 @@ impl<'a> Assembler386<'a> {
     /// write barrier.
     fn emit_setarrayitem_gc_write_barrier(&mut self, arglocs: &[Loc]) {
         let use_array_barrier =
-            crate::runner::with_dynasm_active_gc(|gc| gc.get_write_barrier_descr())
-                .flatten()
-                .is_some_and(|wb| wb.jit_wb_cards_set != 0);
+            crate::runner::dynasm_write_barrier_descr().is_some_and(|wb| wb.jit_wb_cards_set != 0);
         self.emit_write_barrier_fastpath_kind(arglocs, use_array_barrier);
     }
 
@@ -7594,9 +7588,9 @@ impl<'a> Assembler386<'a> {
     }
 
     fn emit_write_barrier_fastpath_kind(&mut self, arglocs: &[Loc], is_array: bool) {
-        let wb = match crate::runner::with_dynasm_active_gc(|gc| gc.get_write_barrier_descr()) {
-            Some(Some(wb)) => wb,
-            _ => return,
+        let wb = match crate::runner::dynasm_write_barrier_descr() {
+            Some(wb) => wb,
+            None => return,
         };
         let loc_base = match arglocs.first() {
             Some(Loc::Reg(r)) => *r,

--- a/majit/majit-backend-dynasm/src/x86/assembler.rs
+++ b/majit/majit-backend-dynasm/src/x86/assembler.rs
@@ -7711,49 +7711,57 @@ impl<'a> Assembler386<'a> {
             ; push rax ; push rcx ; push rdx ; push rsi ; push rdi
             ; push r8 ; push r9 ; push r10 ; push r11
         );
-        // Save XMM caller-saved (xmm0-xmm15, 16 × 16 bytes = 256 bytes)
+        // Save XMM caller-saved (xmm0-xmm15, 16 × 16 bytes = 256 bytes).
+        //
+        // The nine GPR pushes above leave `rsp` at 8-mod-16 (the body is
+        // 0-mod-16), and `SUB rsp, 256` preserves that, so these stores land
+        // on an odd 8-byte boundary.  They must therefore be the unaligned
+        // form: `MOVAPS` faults with #GP on a non-16-byte-aligned address.
+        // `_build_wb_slowpath` saves the XMM registers with `MOVSD_bx`, which
+        // has no alignment requirement either; only the save area differs
+        // (jitframe there, stack here).
         dynasm!(self.mc ; .arch x64
             ; sub rsp, 256
-            ; movaps [rsp], xmm0
-            ; movaps [rsp + 16], xmm1
-            ; movaps [rsp + 32], xmm2
-            ; movaps [rsp + 48], xmm3
-            ; movaps [rsp + 64], xmm4
-            ; movaps [rsp + 80], xmm5
-            ; movaps [rsp + 96], xmm6
-            ; movaps [rsp + 112], xmm7
-            ; movaps [rsp + 128], xmm8
-            ; movaps [rsp + 144], xmm9
-            ; movaps [rsp + 160], xmm10
-            ; movaps [rsp + 176], xmm11
-            ; movaps [rsp + 192], xmm12
-            ; movaps [rsp + 208], xmm13
-            ; movaps [rsp + 224], xmm14
-            ; movaps [rsp + 240], xmm15
+            ; movups [rsp], xmm0
+            ; movups [rsp + 16], xmm1
+            ; movups [rsp + 32], xmm2
+            ; movups [rsp + 48], xmm3
+            ; movups [rsp + 64], xmm4
+            ; movups [rsp + 80], xmm5
+            ; movups [rsp + 96], xmm6
+            ; movups [rsp + 112], xmm7
+            ; movups [rsp + 128], xmm8
+            ; movups [rsp + 144], xmm9
+            ; movups [rsp + 160], xmm10
+            ; movups [rsp + 176], xmm11
+            ; movups [rsp + 192], xmm12
+            ; movups [rsp + 208], xmm13
+            ; movups [rsp + 224], xmm14
+            ; movups [rsp + 240], xmm15
         );
         self.emit_abi_int_arg_from_reg(0, loc_base.value as u8);
         dynasm!(self.mc ; .arch x64
             ; mov rax, QWORD helper
         );
         self.emit_abi_call_rax_after_one_push();
-        // Restore XMM
+        // Restore XMM (same 8-mod-16 `rsp` as the save side above).
         dynasm!(self.mc ; .arch x64
-            ; movaps xmm0, [rsp]
-            ; movaps xmm1, [rsp + 16]
-            ; movaps xmm2, [rsp + 32]
-            ; movaps xmm3, [rsp + 48]
-            ; movaps xmm4, [rsp + 64]
-            ; movaps xmm5, [rsp + 80]
-            ; movaps xmm6, [rsp + 96]
-            ; movaps xmm7, [rsp + 112]
-            ; movaps xmm8, [rsp + 128]
-            ; movaps xmm9, [rsp + 144]
-            ; movaps xmm10, [rsp + 160]
-            ; movaps xmm11, [rsp + 176]
-            ; movaps xmm12, [rsp + 192]
-            ; movaps xmm13, [rsp + 208]
-            ; movaps xmm14, [rsp + 224]
-            ; movaps xmm15, [rsp + 240]
+            ; movups xmm0, [rsp]
+            ; movups xmm1, [rsp + 16]
+            ; movups xmm2, [rsp + 32]
+            ; movups xmm3, [rsp + 48]
+            ; movups xmm4, [rsp + 64]
+            ; movups xmm5, [rsp + 80]
+            ; movups xmm6, [rsp + 96]
+            ; movups xmm7, [rsp + 112]
+            ; movups xmm8, [rsp + 128]
+            ; movups xmm9, [rsp + 144]
+            ; movups xmm10, [rsp + 160]
+            ; movups xmm11, [rsp + 176]
+            ; movups xmm12, [rsp + 192]
+            ; movups xmm13, [rsp + 208]
+            ; movups xmm14, [rsp + 224]
+            ; movups xmm15, [rsp + 240]
             ; add rsp, 256
         );
         // Restore GPRs

--- a/majit/majit-backend/src/rd_payload.rs
+++ b/majit/majit-backend/src/rd_payload.rs
@@ -9,7 +9,7 @@ use std::cell::UnsafeCell;
 use std::rc::Rc;
 use std::sync::Arc;
 
-use majit_ir::{Const, GuardPendingFieldEntry, RdVirtualInfo};
+use majit_ir::{Const, GuardPendingFieldEntry, RdVirtualInfo, SharedConstPool};
 
 /// Resume-payload backing store for ResumeGuardDescr (`compile.py:855`).
 ///
@@ -29,7 +29,7 @@ use majit_ir::{Const, GuardPendingFieldEntry, RdVirtualInfo};
 #[derive(Debug)]
 pub struct RdPayload {
     rd_numb: UnsafeCell<Option<Arc<[u8]>>>,
-    rd_consts: UnsafeCell<Option<Arc<[Const]>>>,
+    rd_consts: UnsafeCell<Option<Arc<SharedConstPool>>>,
     rd_virtuals: UnsafeCell<Option<Arc<[Rc<RdVirtualInfo>]>>>,
     rd_pendingfields: UnsafeCell<Option<Arc<[GuardPendingFieldEntry]>>>,
 }
@@ -56,7 +56,7 @@ impl RdPayload {
     /// donor descr, matching RPython's reference-share semantics.
     pub fn from_arcs(
         rd_numb: Option<Arc<[u8]>>,
-        rd_consts: Option<Arc<[Const]>>,
+        rd_consts: Option<Arc<SharedConstPool>>,
         rd_virtuals: Option<Arc<[Rc<RdVirtualInfo>]>>,
         rd_pendingfields: Option<Arc<[GuardPendingFieldEntry]>>,
     ) -> Self {
@@ -100,15 +100,19 @@ impl RdPayload {
     }
 
     pub fn rd_consts(&self) -> Option<&[Const]> {
-        unsafe { (*self.rd_consts.get()).as_deref() }
+        unsafe {
+            (*self.rd_consts.get())
+                .as_deref()
+                .map(SharedConstPool::as_slice)
+        }
     }
-    pub fn rd_consts_arc(&self) -> Option<Arc<[Const]>> {
+    pub fn rd_consts_arc(&self) -> Option<Arc<SharedConstPool>> {
         unsafe { (*self.rd_consts.get()).clone() }
     }
     pub fn set_rd_consts(&self, value: Option<Vec<Const>>) {
-        unsafe { *self.rd_consts.get() = value.map(Arc::from) }
+        unsafe { *self.rd_consts.get() = value.map(SharedConstPool::new) }
     }
-    pub fn set_rd_consts_arc(&self, value: Option<Arc<[Const]>>) {
+    pub fn set_rd_consts_arc(&self, value: Option<Arc<SharedConstPool>>) {
         unsafe { *self.rd_consts.get() = value }
     }
 

--- a/majit/majit-backend/src/resume_guard_descr.rs
+++ b/majit/majit-backend/src/resume_guard_descr.rs
@@ -369,13 +369,13 @@ impl FailDescr for ResumeGuardDescr {
     fn rd_consts(&self) -> Option<&[Const]> {
         self.payload.rd_consts()
     }
-    fn rd_consts_arc(&self) -> Option<Arc<[Const]>> {
+    fn rd_consts_arc(&self) -> Option<Arc<majit_ir::SharedConstPool>> {
         self.payload.rd_consts_arc()
     }
     fn set_rd_consts(&self, value: Option<Vec<Const>>) {
         self.payload.set_rd_consts(value)
     }
-    fn set_rd_consts_arc(&self, value: Option<Arc<[Const]>>) {
+    fn set_rd_consts_arc(&self, value: Option<Arc<majit_ir::SharedConstPool>>) {
         self.payload.set_rd_consts_arc(value)
     }
     fn rd_virtuals(&self) -> Option<&[Rc<RdVirtualInfo>]> {

--- a/majit/majit-backend/src/resume_value.rs
+++ b/majit/majit-backend/src/resume_value.rs
@@ -32,6 +32,14 @@ pub enum ResumeValueSource {
     Constant(Const),
     /// Value is a virtual object that must be materialized on resume.
     Virtual(usize),
+    /// Raw resume.py field number, retained until the direct reader decodes
+    /// it. RPython stores `AbstractVirtualInfo.fieldnums` in this form and
+    /// resolves TAGCONST through the live `rd_consts` list only after any
+    /// allocation-triggered collection has forwarded that list.
+    ///
+    /// This variant is runtime-only: layout/export paths construct the
+    /// structured variants above.
+    Tagged(i16),
     /// Value exists conceptually but is still uninitialized.
     ///
     /// Mirrors RPython's `UNINITIALIZED` tag used for string/unicode content.
@@ -46,6 +54,9 @@ impl ResumeValueSource {
             ResumeValueSource::FailArg(_) => ResumeValueKind::FailArg,
             ResumeValueSource::Constant(_) => ResumeValueKind::Constant,
             ResumeValueSource::Virtual(_) => ResumeValueKind::Virtual,
+            ResumeValueSource::Tagged(_) => {
+                panic!("runtime tagged resume source has no exported ResumeValueKind")
+            }
             ResumeValueSource::Uninitialized => ResumeValueKind::Uninitialized,
             ResumeValueSource::Unavailable => ResumeValueKind::Unavailable,
         }
@@ -77,6 +88,9 @@ impl ResumeValueSource {
                 constant_type: None,
                 virtual_index: Some(*index),
             },
+            ResumeValueSource::Tagged(_) => {
+                panic!("runtime tagged resume source cannot be exported as a layout summary")
+            }
             ResumeValueSource::Uninitialized => ResumeValueLayoutSummary {
                 kind: ResumeValueKind::Uninitialized,
                 fail_arg_index: 0,

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -1707,7 +1707,13 @@ impl MiniMarkGC {
         }
     }
 
-    fn copy_nursery_object(&mut self, obj_addr: usize) -> GcRef {
+    fn copy_nursery_object(
+        &mut self,
+        obj_addr: usize,
+        site: &str,
+        holder_addr: usize,
+        slot_addr: usize,
+    ) -> GcRef {
         // Pinned objects must stay in the nursery.
         if self.pinned_objects.contains(&obj_addr) {
             return GcRef(obj_addr);
@@ -1727,7 +1733,36 @@ impl MiniMarkGC {
         }
 
         let type_id = unsafe { (*hdr_ptr).type_id() };
-        self.validate_type_id(type_id, obj_addr, "copy_nursery_object");
+        if type_id as usize >= self.types.len() {
+            let holder_type_id = if holder_addr == 0 {
+                None
+            } else {
+                Some(unsafe { (*header_of(holder_addr)).type_id() })
+            };
+            let mut holder_words = [0usize; 8];
+            if holder_addr != 0 {
+                for (index, word) in holder_words.iter_mut().enumerate() {
+                    *word = unsafe { *((holder_addr as *const usize).add(index)) };
+                }
+            }
+            panic!(
+                "GC BUG: invalid type_id={} at obj_addr={:#x} \
+                 (header_addr={:#x}, nursery_start={:#x}, site={}, \
+                 nursery_free={:#x}, nursery_top={:#x}, holder_addr={:#x}, \
+                 holder_type_id={:?}, holder_offset={:?}, holder_words={:#x?})",
+                type_id,
+                obj_addr,
+                obj_addr - GcHeader::SIZE,
+                self.nursery.start_ptr() as usize,
+                site,
+                self.nursery.free_ptr() as usize,
+                self.nursery.top_ptr() as usize,
+                holder_addr,
+                holder_type_id,
+                slot_addr.checked_sub(holder_addr),
+                holder_words,
+            );
+        }
         let type_info = self.types.get(type_id);
 
         // Compute the actual payload size (for varsize objects, read the length).
@@ -1854,7 +1889,8 @@ impl MiniMarkGC {
         if !self.is_nursery_object_start(gcref.0) || self.pinned_objects.contains(&gcref.0) {
             return;
         }
-        let new_ref = self.copy_nursery_object(gcref.0);
+        let slot_addr = gcref as *mut GcRef as usize;
+        let new_ref = self.copy_nursery_object(gcref.0, "minor_root_target", 0, slot_addr);
         *gcref = new_ref;
         // incminimark.py:2140-2143: append iff (VISITED | PINNED) == 0. pyre's
         // marking convention sets VISITED at push time (see `seed_major_root`
@@ -1888,7 +1924,12 @@ impl MiniMarkGC {
                         "minor_custom_trace",
                     );
                     if self.is_nursery_object_start(field_ref.0) {
-                        let new_ref = self.copy_nursery_object(field_ref.0);
+                        let new_ref = self.copy_nursery_object(
+                            field_ref.0,
+                            "minor_custom_trace_target",
+                            obj_addr,
+                            slot_ptr as usize,
+                        );
                         *slot_ptr = new_ref;
                     }
                 });
@@ -1914,7 +1955,12 @@ impl MiniMarkGC {
                 "minor_fixed_field",
             );
             if self.is_nursery_object_start(field_ref.0) {
-                let new_ref = self.copy_nursery_object(field_ref.0);
+                let new_ref = self.copy_nursery_object(
+                    field_ref.0,
+                    "minor_fixed_field_target",
+                    obj_addr,
+                    slot as usize,
+                );
                 unsafe {
                     *slot = new_ref;
                 }
@@ -1935,7 +1981,12 @@ impl MiniMarkGC {
                     "minor_varsize_item",
                 );
                 if self.is_nursery_object_start(field_ref.0) {
-                    let new_ref = self.copy_nursery_object(field_ref.0);
+                    let new_ref = self.copy_nursery_object(
+                        field_ref.0,
+                        "minor_varsize_item_target",
+                        obj_addr,
+                        slot as usize,
+                    );
                     unsafe {
                         *slot = new_ref;
                     }
@@ -2500,9 +2551,23 @@ impl MiniMarkGC {
     /// (incminimark.py:2739-2752) does not need this guard because RPython's
     /// type system guarantees every `Ptr(GcStruct)` is GC-managed; it converges
     /// away once every `gc_ptr_offsets` target is a real GC allocation.
-    fn grey_child(&mut self, addr: usize) {
+    fn grey_child(&mut self, addr: usize, holder_addr: usize, slot_addr: usize, site: &str) {
         if self.is_managed_heap_object(addr) {
             let hdr = unsafe { header_of(addr) };
+            let type_id = unsafe { (*hdr).type_id() };
+            if type_id as usize >= self.types.len() {
+                let holder_type_id = unsafe { (*header_of(holder_addr)).type_id() };
+                panic!(
+                    "GC BUG: invalid major child type_id={} at child_addr={:#x} \
+                     holder_addr={:#x} holder_type_id={} holder_offset={:?} site={}",
+                    type_id,
+                    addr,
+                    holder_addr,
+                    holder_type_id,
+                    slot_addr.checked_sub(holder_addr),
+                    site,
+                );
+            }
             if unsafe { !(*hdr).has_flag(flags::VISITED) } {
                 unsafe { (*hdr).set_flag(flags::VISITED) };
                 self.incr_state.gray_stack.push(addr);
@@ -2560,7 +2625,12 @@ impl MiniMarkGC {
                 trace_fn(obj_addr, &mut |slot_ptr: *mut GcRef| {
                     let field_ref = *slot_ptr;
                     if !field_ref.is_null() {
-                        self.grey_child(field_ref.0);
+                        self.grey_child(
+                            field_ref.0,
+                            obj_addr,
+                            slot_ptr as usize,
+                            "major_custom_trace",
+                        );
                     }
                 });
             }
@@ -2569,7 +2639,12 @@ impl MiniMarkGC {
             for &offset in &offsets {
                 let field_ref = unsafe { *((obj_addr + offset) as *const GcRef) };
                 if !field_ref.is_null() {
-                    self.grey_child(field_ref.0);
+                    self.grey_child(
+                        field_ref.0,
+                        obj_addr,
+                        obj_addr + offset,
+                        "major_fixed_field",
+                    );
                 }
             }
             // Variable-part items: streamed one at a time, never buffered, so a
@@ -2581,7 +2656,12 @@ impl MiniMarkGC {
                 for i in 0..length {
                     let field_ref = unsafe { *((items_start + i * item_size) as *const GcRef) };
                     if !field_ref.is_null() {
-                        self.grey_child(field_ref.0);
+                        self.grey_child(
+                            field_ref.0,
+                            obj_addr,
+                            items_start + i * item_size,
+                            "major_varsize_item",
+                        );
                     }
                 }
             }
@@ -3357,7 +3437,12 @@ impl MiniMarkGC {
                                     "minor_dirty_card_item",
                                 );
                                 if self.is_nursery_object_start(field_ref.0) {
-                                    let new_ref = self.copy_nursery_object(field_ref.0);
+                                    let new_ref = self.copy_nursery_object(
+                                        field_ref.0,
+                                        "minor_dirty_card_item_target",
+                                        obj,
+                                        slot as usize,
+                                    );
                                     unsafe {
                                         *slot = new_ref;
                                     }
@@ -3824,6 +3909,19 @@ impl GcAllocator for MiniMarkGC {
 
     fn collection_counts(&self) -> (usize, usize) {
         (self.minor_collections, self.major_collections)
+    }
+
+    fn get_write_barrier_descr(&self) -> Option<crate::WriteBarrierDescr> {
+        let mut descr = crate::WriteBarrierDescr::for_current_gc();
+        if self.card_page_shift == 0 {
+            descr.jit_wb_cards_set = 0;
+            descr.jit_wb_card_page_shift = 0;
+            descr.jit_wb_cards_set_byteofs = 0;
+            descr.jit_wb_cards_set_singlebyte = 0;
+        } else {
+            descr.jit_wb_card_page_shift = self.card_page_shift;
+        }
+        Some(descr)
     }
 
     fn type_alloc_is_plain(&self, type_id: u32) -> bool {
@@ -4381,6 +4479,33 @@ mod tests {
         let mut objects = Vec::new();
         gc.do_get_objects(-1, &mut |gcref| objects.push(gcref));
         assert!(objects.contains(&object));
+    }
+
+    #[test]
+    fn write_barrier_descr_exposes_minimark_card_geometry() {
+        let gc = test_gc(4096);
+        let descr = gc
+            .get_write_barrier_descr()
+            .expect("MiniMark must expose its write-barrier descriptor");
+        assert_eq!(descr.jit_wb_if_flag, flags::TRACK_YOUNG_PTRS);
+        assert_eq!(descr.jit_wb_cards_set, flags::CARDS_SET);
+        assert_eq!(descr.jit_wb_card_page_shift, gc.card_page_shift);
+    }
+
+    #[test]
+    fn write_barrier_descr_disables_cards_with_collector_config() {
+        let gc = MiniMarkGC::with_config(GcConfig {
+            nursery_size: 4096,
+            large_object_threshold: 2048,
+            card_page_indices: 0,
+            ..GcConfig::default()
+        });
+        let descr = gc
+            .get_write_barrier_descr()
+            .expect("MiniMark must retain its generic write barrier");
+        assert_eq!(descr.jit_wb_if_flag, flags::TRACK_YOUNG_PTRS);
+        assert_eq!(descr.jit_wb_cards_set, 0);
+        assert_eq!(descr.jit_wb_card_page_shift, 0);
     }
 
     #[test]

--- a/majit/majit-gc/src/header.rs
+++ b/majit/majit-gc/src/header.rs
@@ -29,6 +29,11 @@ pub struct GcHeader {
 impl GcHeader {
     /// Size of the header in bytes.
     pub const SIZE: usize = std::mem::size_of::<GcHeader>();
+    /// Alignment required by the fixed-width header word.
+    ///
+    /// This is wider than a native pointer on wasm32. Old-generation size
+    /// classes must therefore use this alignment rather than pointer width.
+    pub const ALIGN: usize = std::mem::align_of::<GcHeader>();
 
     /// Minimum object size in the nursery: header + one pointer (for forwarding).
     pub const MIN_NURSERY_OBJ_SIZE: usize = Self::SIZE + std::mem::size_of::<usize>();

--- a/majit/majit-gc/src/lib.rs
+++ b/majit/majit-gc/src/lib.rs
@@ -1412,7 +1412,12 @@ pub unsafe fn alloc_nursery_typed_with_placement(
 ) -> GcRef {
     match ACTIVE_ALLOC_NURSERY_TYPED_WITH_PLACEMENT.get() {
         Some(f) => unsafe { f(type_id, payload_size, needs_write_barrier) },
-        None => GcRef(0),
+        None => {
+            // No backend installed placement reporting, so keep the
+            // conservative creation barrier the sibling fallbacks report.
+            unsafe { *needs_write_barrier = true };
+            GcRef(0)
+        }
     }
 }
 
@@ -1504,7 +1509,12 @@ pub unsafe fn alloc_nursery_collecting_typed_rooted(
 ) -> GcRef {
     match ACTIVE_ALLOC_NURSERY_COLLECTING_TYPED_ROOTED.get() {
         Some(f) => unsafe { f(type_id, payload_size, root, needs_write_barrier) },
-        None => GcRef(0),
+        None => {
+            // No backend installed placement reporting, so keep the
+            // conservative creation barrier the sibling fallbacks report.
+            unsafe { *needs_write_barrier = true };
+            GcRef(0)
+        }
     }
 }
 

--- a/majit/majit-gc/src/minimarkpage.rs
+++ b/majit/majit-gc/src/minimarkpage.rs
@@ -9,6 +9,11 @@ use std::alloc::{self, Layout};
 use std::ptr;
 
 const WORD: usize = std::mem::size_of::<usize>();
+const ARENA_ALIGN: usize = if crate::header::GcHeader::ALIGN > WORD {
+    crate::header::GcHeader::ALIGN
+} else {
+    WORD
+};
 
 #[repr(C)]
 struct ArenaReference {
@@ -209,7 +214,11 @@ impl ArenaCollection {
         if self._pick_next_arena() {
             return;
         }
-        let layout = Layout::from_size_align(self.arena_size, WORD).expect("invalid arena layout");
+        // The arena stores GcHeader at the beginning of each old-generation
+        // block. On wasm32 the header remains u64-aligned even though WORD is
+        // four bytes, so pointer-width alignment is insufficient.
+        let layout =
+            Layout::from_size_align(self.arena_size, ARENA_ALIGN).expect("invalid arena layout");
         let arena_base = unsafe { alloc::alloc(layout) };
         if arena_base.is_null() {
             alloc::handle_alloc_error(layout);

--- a/majit/majit-gc/src/minimarkpage.rs
+++ b/majit/majit-gc/src/minimarkpage.rs
@@ -72,6 +72,11 @@ impl ArenaCollection {
     pub fn new(arena_size: usize, page_size: usize, small_request_threshold: usize) -> Self {
         assert_eq!(arena_size % WORD, 0);
         assert_eq!(page_size % WORD, 0);
+        assert_eq!(
+            page_size % ARENA_ALIGN,
+            0,
+            "page size must preserve the GC object alignment"
+        );
         assert_eq!(small_request_threshold % WORD, 0);
         let length = small_request_threshold / WORD + 1;
         let hdrsize = std::mem::size_of::<PageHeader>();

--- a/majit/majit-gc/src/minimarkpage.rs
+++ b/majit/majit-gc/src/minimarkpage.rs
@@ -75,6 +75,11 @@ impl ArenaCollection {
         assert_eq!(small_request_threshold % WORD, 0);
         let length = small_request_threshold / WORD + 1;
         let hdrsize = std::mem::size_of::<PageHeader>();
+        assert_eq!(
+            hdrsize % ARENA_ALIGN,
+            0,
+            "PageHeader must preserve the GC object alignment"
+        );
         assert!(page_size > hdrsize);
         let mut nblocks_for_size = vec![0; length];
         for (i, nblocks) in nblocks_for_size.iter_mut().enumerate().skip(1) {

--- a/majit/majit-gc/src/oldgen.rs
+++ b/majit/majit-gc/src/oldgen.rs
@@ -9,6 +9,11 @@ use crate::header::{GcHeader, header_of};
 use crate::minimarkpage::ArenaCollection;
 
 const WORD: usize = std::mem::size_of::<usize>();
+const OBJECT_ALIGN: usize = if GcHeader::ALIGN > WORD {
+    GcHeader::ALIGN
+} else {
+    WORD
+};
 const DEFAULT_PAGE_SIZE: usize = 1024 * WORD;
 const DEFAULT_ARENA_SIZE: usize = 65536 * WORD;
 const SMALL_REQUEST_THRESHOLD: usize = 35 * WORD;
@@ -102,10 +107,11 @@ impl OldGen {
     ) -> Option<*mut u8> {
         let obj_size = try_round_up(total_size.max(GcHeader::MIN_NURSERY_OBJ_SIZE))?;
         let alloc_size = try_round_up(card_header_bytes.checked_add(obj_size)?)?;
+        debug_assert_eq!(card_header_bytes % OBJECT_ALIGN, 0);
         let header_ptr = if card_header_bytes == 0 && alloc_size <= SMALL_REQUEST_THRESHOLD {
             self.ac.malloc(alloc_size)
         } else {
-            let layout = Layout::from_size_align(alloc_size, WORD).ok()?;
+            let layout = Layout::from_size_align(alloc_size, OBJECT_ALIGN).ok()?;
             let raw = unsafe { alloc::alloc(layout) };
             if raw.is_null() {
                 return None;
@@ -259,7 +265,7 @@ fn round_up(size: usize) -> usize {
 }
 
 fn try_round_up(size: usize) -> Option<usize> {
-    Some(size.checked_add(WORD - 1)? & !(WORD - 1))
+    Some(size.checked_add(OBJECT_ALIGN - 1)? & !(OBJECT_ALIGN - 1))
 }
 
 impl Default for OldGen {
@@ -296,6 +302,19 @@ mod tests {
     fn fallible_allocation_reports_size_overflow() {
         let mut oldgen = OldGen::new();
         assert!(oldgen.try_alloc(usize::MAX).is_none());
+    }
+
+    #[test]
+    fn allocations_preserve_gc_header_alignment() {
+        let mut oldgen = OldGen::new();
+        for payload_size in 1..=4 * OBJECT_ALIGN {
+            let ptr = oldgen.alloc(GcHeader::SIZE + payload_size);
+            assert_eq!(
+                ptr as usize % GcHeader::ALIGN,
+                0,
+                "payload size {payload_size} produced a misaligned GC header"
+            );
+        }
     }
 
     #[test]

--- a/majit/majit-ir/src/descr.rs
+++ b/majit/majit-ir/src/descr.rs
@@ -2168,7 +2168,7 @@ pub trait FailDescr: Descr {
         None
     }
 
-    fn rd_consts_arc(&self) -> Option<std::sync::Arc<[Const]>> {
+    fn rd_consts_arc(&self) -> Option<std::sync::Arc<crate::SharedConstPool>> {
         None
     }
 
@@ -2180,7 +2180,7 @@ pub trait FailDescr: Descr {
         );
     }
 
-    fn set_rd_consts_arc(&self, _value: Option<std::sync::Arc<[Const]>>) {
+    fn set_rd_consts_arc(&self, _value: Option<std::sync::Arc<crate::SharedConstPool>>) {
         panic!(
             "set_rd_consts_arc invoked on a FailDescr that does not \
              carry rd_consts (compile.py:855 `_attrs_` only on \

--- a/majit/majit-ir/src/lib.rs
+++ b/majit/majit-ir/src/lib.rs
@@ -44,6 +44,6 @@ pub use resoperation::{
 };
 pub use value::{
     Const, FAILARGS_LIMIT, GcRef, GreenAsI64, GreenKey, GreenType, InputArg, InputArgRc,
-    JitDriverVar, StrEqFn, StrHashFn, Type, Value, VarKind, green_type_to_ir, make_str_slot,
-    pypyjit_greenkey_uhash, set_str_resolver, set_unicode_resolver,
+    JitDriverVar, SharedConstPool, StrEqFn, StrHashFn, Type, Value, VarKind, green_type_to_ir,
+    make_str_slot, pypyjit_greenkey_uhash, set_str_resolver, set_unicode_resolver,
 };

--- a/majit/majit-ir/src/op_descr.rs
+++ b/majit/majit-ir/src/op_descr.rs
@@ -18,7 +18,6 @@ use crate::descr::{
     LoopTargetDescr, LoopTokenDescr, SizeDescr,
 };
 use crate::resoperation::{GuardPendingFieldEntry, Op, RdVirtualInfo};
-use crate::value::Const;
 
 impl Op {
     /// `resoperation.py:244 AbstractResOpOrInputArg.getdescr` + `:462
@@ -140,7 +139,7 @@ impl Op {
     }
 
     /// Same as `resolved_rd_numb` but for the `rd_consts` const pool.
-    pub fn resolved_rd_consts(&self) -> Option<Arc<[Const]>> {
+    pub fn resolved_rd_consts(&self) -> Option<Arc<crate::SharedConstPool>> {
         self.descr
             .borrow()
             .as_ref()?

--- a/majit/majit-ir/src/value.rs
+++ b/majit/majit-ir/src/value.rs
@@ -193,6 +193,59 @@ impl PartialEq for Const {
 
 impl Eq for Const {}
 
+/// Shared, GC-forwardable `ResumeGuardDescr.rd_consts` list.
+///
+/// RPython stores one mutable list object on the guard and reference-shares it
+/// with copied descriptors and every resume-data reader.  Rust needs interior
+/// mutability because the stop-the-world GC root walker forwards `Const::Ref`
+/// entries after the pool has been shared.  The JIT and collector run under
+/// the same single-threaded/GIL contract; mutator access resumes only after
+/// collection has finished.
+pub struct SharedConstPool {
+    values: std::cell::UnsafeCell<Vec<Const>>,
+}
+
+unsafe impl Send for SharedConstPool {}
+unsafe impl Sync for SharedConstPool {}
+
+impl SharedConstPool {
+    pub fn new(values: Vec<Const>) -> std::sync::Arc<Self> {
+        std::sync::Arc::new(Self {
+            values: std::cell::UnsafeCell::new(values),
+        })
+    }
+
+    pub fn as_slice(&self) -> &[Const] {
+        unsafe { &*self.values.get() }
+    }
+
+    pub fn snapshot(&self) -> Vec<Const> {
+        self.as_slice().to_vec()
+    }
+
+    /// # Safety
+    ///
+    /// The caller must be the exclusive GC root walker; no resume-data reader
+    /// may run concurrently.
+    pub unsafe fn as_mut_vec_for_gc(&self) -> &mut Vec<Const> {
+        unsafe { &mut *self.values.get() }
+    }
+}
+
+impl std::ops::Deref for SharedConstPool {
+    type Target = [Const];
+
+    fn deref(&self) -> &Self::Target {
+        self.as_slice()
+    }
+}
+
+impl std::fmt::Debug for SharedConstPool {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_list().entries(self.as_slice()).finish()
+    }
+}
+
 impl Const {
     pub fn get_type(&self) -> Type {
         match self {

--- a/majit/majit-metainterp/src/compile.rs
+++ b/majit/majit-metainterp/src/compile.rs
@@ -625,12 +625,10 @@ pub(crate) fn build_guard_metadata<T: AsRef<majit_ir::Op>>(
             // byte stream the donor was built from (RPython compile.py:832
             // ResumeGuardCopiedDescr).
             let storage_for_guard = if let Some(numb) = op.resolved_rd_numb() {
-                Some(crate::resume::ResumeStorage::new(
+                Some(crate::resume::ResumeStorage::with_shared_consts(
                     numb.to_vec(),
                     op.resolved_rd_consts()
-                        .as_deref()
-                        .map(<[Const]>::to_vec)
-                        .unwrap_or_default(),
+                        .unwrap_or_else(|| majit_ir::SharedConstPool::new(Vec::new())),
                     op.resolved_rd_virtuals()
                         .as_deref()
                         .map(<[std::rc::Rc<majit_ir::RdVirtualInfo>]>::to_vec)
@@ -723,7 +721,8 @@ pub(crate) fn build_guard_metadata<T: AsRef<majit_ir::Op>>(
             // Follow `descr.prev` so sharing-path guards see the donor's
             // const pool (compile.py:849 get_resumestorage).
             let rd_consts_arc = op.resolved_rd_consts();
-            let rd_consts_ref: &[Const] = rd_consts_arc.as_deref().unwrap_or(&[]);
+            let rd_consts_ref: &[Const] =
+                rd_consts_arc.as_deref().map_or(&[], |pool| pool.as_slice());
             let num_virtuals = op.resolved_rd_virtuals().map_or(0, |v| v.len()) as i32;
             let resolve_tagged_source = |tagged: i16| -> ExitValueSourceLayout {
                 let (val, tagbits) = majit_ir::resumedata::untag(tagged);
@@ -3212,13 +3211,13 @@ impl FailDescr for ResumeAtPositionDescr {
     fn rd_consts(&self) -> Option<&[Const]> {
         self.inner.payload.rd_consts()
     }
-    fn rd_consts_arc(&self) -> Option<Arc<[Const]>> {
+    fn rd_consts_arc(&self) -> Option<Arc<majit_ir::SharedConstPool>> {
         self.inner.payload.rd_consts_arc()
     }
     fn set_rd_consts(&self, value: Option<Vec<Const>>) {
         self.inner.payload.set_rd_consts(value)
     }
-    fn set_rd_consts_arc(&self, value: Option<Arc<[Const]>>) {
+    fn set_rd_consts_arc(&self, value: Option<Arc<majit_ir::SharedConstPool>>) {
         self.inner.payload.set_rd_consts_arc(value)
     }
     fn rd_virtuals(&self) -> Option<&[Rc<RdVirtualInfo>]> {
@@ -3479,13 +3478,13 @@ impl FailDescr for ResumeGuardForcedDescr {
     fn rd_consts(&self) -> Option<&[Const]> {
         self.inner.payload.rd_consts()
     }
-    fn rd_consts_arc(&self) -> Option<Arc<[Const]>> {
+    fn rd_consts_arc(&self) -> Option<Arc<majit_ir::SharedConstPool>> {
         self.inner.payload.rd_consts_arc()
     }
     fn set_rd_consts(&self, value: Option<Vec<Const>>) {
         self.inner.payload.set_rd_consts(value)
     }
-    fn set_rd_consts_arc(&self, value: Option<Arc<[Const]>>) {
+    fn set_rd_consts_arc(&self, value: Option<Arc<majit_ir::SharedConstPool>>) {
         self.inner.payload.set_rd_consts_arc(value)
     }
     fn rd_virtuals(&self) -> Option<&[Rc<RdVirtualInfo>]> {
@@ -3730,13 +3729,13 @@ impl FailDescr for ResumeGuardExcDescr {
     fn rd_consts(&self) -> Option<&[Const]> {
         self.inner.payload.rd_consts()
     }
-    fn rd_consts_arc(&self) -> Option<Arc<[Const]>> {
+    fn rd_consts_arc(&self) -> Option<Arc<majit_ir::SharedConstPool>> {
         self.inner.payload.rd_consts_arc()
     }
     fn set_rd_consts(&self, value: Option<Vec<Const>>) {
         self.inner.payload.set_rd_consts(value)
     }
-    fn set_rd_consts_arc(&self, value: Option<Arc<[Const]>>) {
+    fn set_rd_consts_arc(&self, value: Option<Arc<majit_ir::SharedConstPool>>) {
         self.inner.payload.set_rd_consts_arc(value)
     }
     fn rd_virtuals(&self) -> Option<&[Rc<RdVirtualInfo>]> {
@@ -4204,7 +4203,7 @@ impl FailDescr for ResumeGuardCopiedDescr {
     fn rd_consts(&self) -> Option<&[Const]> {
         self.prev().as_fail_descr().and_then(|fd| fd.rd_consts())
     }
-    fn rd_consts_arc(&self) -> Option<Arc<[Const]>> {
+    fn rd_consts_arc(&self) -> Option<Arc<majit_ir::SharedConstPool>> {
         self.prev()
             .as_fail_descr()
             .and_then(|fd| fd.rd_consts_arc())
@@ -4491,7 +4490,7 @@ impl FailDescr for ResumeGuardCopiedExcDescr {
     fn rd_consts(&self) -> Option<&[Const]> {
         self.inner.rd_consts()
     }
-    fn rd_consts_arc(&self) -> Option<Arc<[Const]>> {
+    fn rd_consts_arc(&self) -> Option<Arc<majit_ir::SharedConstPool>> {
         self.inner.rd_consts_arc()
     }
     fn set_rd_consts(&self, value: Option<Vec<Const>>) {
@@ -4912,13 +4911,13 @@ impl FailDescr for CompileLoopVersionDescr {
     fn rd_consts(&self) -> Option<&[Const]> {
         self.inner.payload.rd_consts()
     }
-    fn rd_consts_arc(&self) -> Option<Arc<[Const]>> {
+    fn rd_consts_arc(&self) -> Option<Arc<majit_ir::SharedConstPool>> {
         self.inner.payload.rd_consts_arc()
     }
     fn set_rd_consts(&self, value: Option<Vec<Const>>) {
         self.inner.payload.set_rd_consts(value)
     }
-    fn set_rd_consts_arc(&self, value: Option<Arc<[Const]>>) {
+    fn set_rd_consts_arc(&self, value: Option<Arc<majit_ir::SharedConstPool>>) {
         self.inner.payload.set_rd_consts_arc(value)
     }
     fn rd_virtuals(&self) -> Option<&[Rc<RdVirtualInfo>]> {

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -1666,15 +1666,21 @@ impl<M: Clone> MetaInterp<M> {
     /// `terminal_exit_layouts` storage slots once updates the pool for
     /// every observer.
     pub fn walk_rd_consts_refs(&mut self, mut visitor: impl FnMut(&mut GcRef)) {
-        fn visit_storage(
-            storage: Option<&Arc<ResumeStorage>>,
+        fn visit_pool(
+            pool: Option<&Arc<majit_ir::SharedConstPool>>,
+            visited: &mut Vec<usize>,
             visitor: &mut dyn FnMut(&mut GcRef),
         ) {
-            let Some(s) = storage else { return };
+            let Some(pool) = pool else { return };
+            let identity = Arc::as_ptr(pool) as usize;
+            if visited.contains(&identity) {
+                return;
+            }
+            visited.push(identity);
             // SAFETY: pyre is single-threaded and the minor-collection
             // walker is the only writer; concurrent readers run outside
             // GC cycles.
-            let consts = unsafe { s.rd_consts_mut_for_gc() };
+            let consts = unsafe { pool.as_mut_vec_for_gc() };
             for c in consts.iter_mut() {
                 if let Const::Ref(slot) = c {
                     visitor(slot);
@@ -1682,13 +1688,34 @@ impl<M: Clone> MetaInterp<M> {
             }
         }
 
+        let mut visited = Vec::new();
         for entry in self.compiled_loops.values_mut() {
             for trace in entry.traces.values_mut() {
                 for layout in trace.exit_layouts.values_mut() {
-                    visit_storage(layout.storage.as_ref(), &mut visitor);
+                    visit_pool(
+                        layout.storage.as_ref().map(|storage| &storage.rd_consts),
+                        &mut visited,
+                        &mut visitor,
+                    );
+                    let descr_pool = layout
+                        .descr
+                        .as_ref()
+                        .and_then(|descr| descr.as_fail_descr())
+                        .and_then(|fd| fd.rd_consts_arc());
+                    visit_pool(descr_pool.as_ref(), &mut visited, &mut visitor);
                 }
                 for layout in trace.terminal_exit_layouts.values_mut() {
-                    visit_storage(layout.storage.as_ref(), &mut visitor);
+                    visit_pool(
+                        layout.storage.as_ref().map(|storage| &storage.rd_consts),
+                        &mut visited,
+                        &mut visitor,
+                    );
+                    let descr_pool = layout
+                        .descr
+                        .as_ref()
+                        .and_then(|descr| descr.as_fail_descr())
+                        .and_then(|fd| fd.rd_consts_arc());
+                    visit_pool(descr_pool.as_ref(), &mut visited, &mut visitor);
                 }
             }
             for tt in entry.front_target_tokens.iter_mut() {
@@ -20183,10 +20210,7 @@ mod tests {
             .get_resume_storage(green_key, trace_id, fail_index)
             .expect("storage should be present");
         assert_eq!(storage.rd_numb, vec![7, 8, 9]);
-        assert_eq!(
-            unsafe { (*storage.rd_consts.get()).clone() },
-            vec![majit_ir::Const::Int(11)]
-        );
+        assert_eq!(storage.rd_consts_snapshot(), vec![majit_ir::Const::Int(11)]);
         assert_eq!(
             meta.get_recovery_slot_types(green_key, trace_id, fail_index),
             Some(vec![Type::Ref])
@@ -20859,7 +20883,7 @@ mod tests {
             .as_ref()
             .expect("retrace storage should be present");
         assert_eq!(storage.rd_numb, expected_rd_numb);
-        assert!(unsafe { (*storage.rd_consts.get()).is_empty() });
+        assert!(storage.rd_consts().is_empty());
         assert!(storage.rd_virtuals.is_empty());
     }
 

--- a/majit/majit-metainterp/src/resume.rs
+++ b/majit/majit-metainterp/src/resume.rs
@@ -537,7 +537,7 @@ pub struct ResumeStorage {
     /// must remain mutable after the `Arc` is shared. `UnsafeCell`
     /// is sound here because pyre is single-threaded and the walker
     /// holds exclusive access for the duration of each GC cycle.
-    pub rd_consts: UnsafeCell<Vec<Const>>,
+    pub rd_consts: Arc<majit_ir::SharedConstPool>,
     /// compile.py:858 `storage.rd_virtuals` — live `RdVirtualInfo`
     /// entries describing virtual objects to materialize on resume.
     pub rd_virtuals: Vec<std::rc::Rc<majit_ir::RdVirtualInfo>>,
@@ -554,7 +554,7 @@ unsafe impl Sync for ResumeStorage {}
 
 impl std::fmt::Debug for ResumeStorage {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let consts_len = unsafe { (*self.rd_consts.get()).len() };
+        let consts_len = self.rd_consts.len();
         f.debug_struct("ResumeStorage")
             .field("rd_numb_len", &self.rd_numb.len())
             .field("rd_consts_len", &consts_len)
@@ -573,7 +573,7 @@ impl ResumeStorage {
     ) -> Arc<Self> {
         Arc::new(ResumeStorage {
             rd_numb,
-            rd_consts: UnsafeCell::new(rd_consts),
+            rd_consts: majit_ir::SharedConstPool::new(rd_consts),
             rd_virtuals,
             rd_pendingfields,
         })
@@ -588,20 +588,34 @@ impl ResumeStorage {
     /// copy — e.g. legacy `Vec<Const>`-typed APIs before their
     /// migration to the shared storage handle).
     pub fn rd_consts_snapshot(&self) -> Vec<Const> {
-        unsafe { (*self.rd_consts.get()).clone() }
+        self.rd_consts.snapshot()
     }
 
     /// Borrow `rd_consts` for reading. Safety: the root walker holds
     /// the only writer and runs during GC, outside of reader scope.
     pub fn rd_consts(&self) -> &[Const] {
-        unsafe { &*self.rd_consts.get() }
+        self.rd_consts.as_slice()
     }
 
     /// Internal accessor for the GC root walker. SAFETY: caller must
     /// ensure exclusive access — only the minor-collection walker in
     /// `MetaInterp::walk_rd_consts_refs` uses this.
     pub(crate) unsafe fn rd_consts_mut_for_gc(&self) -> &mut Vec<Const> {
-        unsafe { &mut *self.rd_consts.get() }
+        unsafe { self.rd_consts.as_mut_vec_for_gc() }
+    }
+
+    pub fn with_shared_consts(
+        rd_numb: Vec<u8>,
+        rd_consts: Arc<majit_ir::SharedConstPool>,
+        rd_virtuals: Vec<std::rc::Rc<majit_ir::RdVirtualInfo>>,
+        rd_pendingfields: Vec<majit_ir::GuardPendingFieldEntry>,
+    ) -> Arc<Self> {
+        Arc::new(ResumeStorage {
+            rd_numb,
+            rd_consts,
+            rd_virtuals,
+            rd_pendingfields,
+        })
     }
 }
 
@@ -1371,13 +1385,29 @@ pub fn tagged_to_source(
 /// Convert an `RdVirtualInfo` (IR-level, from compile.rs/pyjitpl.rs)
 /// to a `VirtualInfo` (resume-level, used by ResumeDataDirectReader).
 ///
-/// `consts`, `count` and `num_virtuals` are needed to decode tagged
-/// fieldnums (see [`tagged_to_source`]).
+/// Keep `fieldnums` tagged until `ResumeDataDirectReader` consumes them.
+/// RPython's `AbstractVirtualInfo.fieldnums` has exactly this shape: a
+/// TAGCONST is resolved through the live `rd_consts` list only after any
+/// allocation-triggered collection has forwarded that list.
+///
+/// The numbering sentinels are not values and must remain semantic markers:
+/// RPython tests `UNINITIALIZED` before decoding string fields, while pyre's
+/// `VirtualInfo` also uses `Unavailable` for an unassigned field.
+fn rd_virtual_field_source(tagged: i16) -> VirtualFieldSource {
+    if tagged_eq(tagged, UNINITIALIZED_TAG) {
+        ResumeValueSource::Uninitialized
+    } else if tagged_eq(tagged, UNASSIGNED) || tagged_eq(tagged, UNASSIGNEDVIRTUAL) {
+        ResumeValueSource::Unavailable
+    } else {
+        ResumeValueSource::Tagged(tagged)
+    }
+}
+
 pub fn rd_virtual_to_virtual_info(
     rd: &majit_ir::RdVirtualInfo,
-    consts: &[majit_ir::Const],
-    count: i32,
-    num_virtuals: usize,
+    _consts: &[majit_ir::Const],
+    _count: i32,
+    _num_virtuals: usize,
 ) -> VirtualInfo {
     match rd {
         majit_ir::RdVirtualInfo::VirtualInfo {
@@ -1391,12 +1421,7 @@ pub fn rd_virtual_to_virtual_info(
             let fields = fielddescrs
                 .iter()
                 .zip(fieldnums.iter())
-                .map(|(fd, &tagged)| {
-                    (
-                        fd.index,
-                        tagged_to_source(tagged, consts, count, num_virtuals),
-                    )
-                })
+                .map(|(fd, &tagged)| (fd.index, rd_virtual_field_source(tagged)))
                 .collect();
             VirtualInfo::VirtualObj {
                 descr: descr.clone(),
@@ -1417,12 +1442,7 @@ pub fn rd_virtual_to_virtual_info(
             let fields = fielddescrs
                 .iter()
                 .zip(fieldnums.iter())
-                .map(|(fd, &tagged)| {
-                    (
-                        fd.index,
-                        tagged_to_source(tagged, consts, count, num_virtuals),
-                    )
-                })
+                .map(|(fd, &tagged)| (fd.index, rd_virtual_field_source(tagged)))
                 .collect();
             VirtualInfo::VStruct {
                 typedescr: typedescr.clone(),
@@ -1439,7 +1459,7 @@ pub fn rd_virtual_to_virtual_info(
         } => {
             let items = fieldnums
                 .iter()
-                .map(|&tagged| tagged_to_source(tagged, consts, count, num_virtuals))
+                .map(|&tagged| rd_virtual_field_source(tagged))
                 .collect();
             VirtualInfo::VArray {
                 arraydescr: arraydescr.clone(),
@@ -1454,7 +1474,7 @@ pub fn rd_virtual_to_virtual_info(
         } => {
             let items = fieldnums
                 .iter()
-                .map(|&tagged| tagged_to_source(tagged, consts, count, num_virtuals))
+                .map(|&tagged| rd_virtual_field_source(tagged))
                 .collect();
             VirtualInfo::VArray {
                 arraydescr: arraydescr.clone(),
@@ -1478,12 +1498,7 @@ pub fn rd_virtual_to_virtual_info(
                 let elem: Vec<(u32, VirtualFieldSource)> = chunk
                     .iter()
                     .enumerate()
-                    .map(|(j, &tagged)| {
-                        (
-                            j as u32,
-                            tagged_to_source(tagged, consts, count, num_virtuals),
-                        )
-                    })
+                    .map(|(j, &tagged)| (j as u32, rd_virtual_field_source(tagged)))
                     .collect();
                 element_fields.push(elem);
             }
@@ -1507,7 +1522,7 @@ pub fn rd_virtual_to_virtual_info(
             assert_eq!(offsets.len(), fieldnums.len());
             let values = fieldnums
                 .iter()
-                .map(|&tagged| tagged_to_source(tagged, consts, count, num_virtuals))
+                .map(|&tagged| rd_virtual_field_source(tagged))
                 .collect();
             VirtualInfo::VRawBuffer {
                 func: *func,
@@ -1520,7 +1535,7 @@ pub fn rd_virtual_to_virtual_info(
         majit_ir::RdVirtualInfo::VRawSliceInfo { offset, fieldnums } => {
             let parent = fieldnums
                 .first()
-                .map(|&tagged| tagged_to_source(tagged, consts, count, num_virtuals))
+                .map(|&tagged| rd_virtual_field_source(tagged))
                 .unwrap_or(ResumeValueSource::Unavailable);
             VirtualInfo::VRawSlice {
                 offset: *offset as i64,
@@ -1530,19 +1545,19 @@ pub fn rd_virtual_to_virtual_info(
         majit_ir::RdVirtualInfo::VStrPlainInfo { fieldnums } => {
             let chars = fieldnums
                 .iter()
-                .map(|&tagged| tagged_to_source(tagged, consts, count, num_virtuals))
+                .map(|&tagged| rd_virtual_field_source(tagged))
                 .collect();
             VirtualInfo::VStrPlain { chars }
         }
         majit_ir::RdVirtualInfo::VStrConcatInfo { fieldnums } => {
-            let left = Box::new(tagged_to_source(fieldnums[0], consts, count, num_virtuals));
-            let right = Box::new(tagged_to_source(fieldnums[1], consts, count, num_virtuals));
+            let left = Box::new(rd_virtual_field_source(fieldnums[0]));
+            let right = Box::new(rd_virtual_field_source(fieldnums[1]));
             VirtualInfo::VStrConcat { left, right }
         }
         majit_ir::RdVirtualInfo::VStrSliceInfo { fieldnums } => {
-            let source = Box::new(tagged_to_source(fieldnums[0], consts, count, num_virtuals));
-            let start = Box::new(tagged_to_source(fieldnums[1], consts, count, num_virtuals));
-            let length = Box::new(tagged_to_source(fieldnums[2], consts, count, num_virtuals));
+            let source = Box::new(rd_virtual_field_source(fieldnums[0]));
+            let start = Box::new(rd_virtual_field_source(fieldnums[1]));
+            let length = Box::new(rd_virtual_field_source(fieldnums[2]));
             VirtualInfo::VStrSlice {
                 source,
                 start,
@@ -1552,19 +1567,19 @@ pub fn rd_virtual_to_virtual_info(
         majit_ir::RdVirtualInfo::VUniPlainInfo { fieldnums } => {
             let chars = fieldnums
                 .iter()
-                .map(|&tagged| tagged_to_source(tagged, consts, count, num_virtuals))
+                .map(|&tagged| rd_virtual_field_source(tagged))
                 .collect();
             VirtualInfo::VUniPlain { chars }
         }
         majit_ir::RdVirtualInfo::VUniConcatInfo { fieldnums } => {
-            let left = Box::new(tagged_to_source(fieldnums[0], consts, count, num_virtuals));
-            let right = Box::new(tagged_to_source(fieldnums[1], consts, count, num_virtuals));
+            let left = Box::new(rd_virtual_field_source(fieldnums[0]));
+            let right = Box::new(rd_virtual_field_source(fieldnums[1]));
             VirtualInfo::VUniConcat { left, right }
         }
         majit_ir::RdVirtualInfo::VUniSliceInfo { fieldnums } => {
-            let source = Box::new(tagged_to_source(fieldnums[0], consts, count, num_virtuals));
-            let start = Box::new(tagged_to_source(fieldnums[1], consts, count, num_virtuals));
-            let length = Box::new(tagged_to_source(fieldnums[2], consts, count, num_virtuals));
+            let source = Box::new(rd_virtual_field_source(fieldnums[0]));
+            let start = Box::new(rd_virtual_field_source(fieldnums[1]));
+            let length = Box::new(rd_virtual_field_source(fieldnums[2]));
             VirtualInfo::VUniSlice {
                 source,
                 start,
@@ -1698,6 +1713,7 @@ impl EncodedResumeData {
                 ResumeValueSource::Virtual(index) => {
                     tag(*index as i32, TAGVIRTUAL).unwrap_or(UNASSIGNEDVIRTUAL)
                 }
+                ResumeValueSource::Tagged(tagged) => *tagged,
                 ResumeValueSource::Uninitialized => UNINITIALIZED_TAG,
                 ResumeValueSource::Unavailable => UNASSIGNED,
             }
@@ -2479,6 +2495,9 @@ impl ResumeDataExt for ResumeData {
             }
             ResumeValueSource::Constant(c) => MaterializedValue::Value(c.as_raw_i64()),
             ResumeValueSource::Virtual(idx) => MaterializedValue::VirtualRef(*idx),
+            ResumeValueSource::Tagged(_) => {
+                panic!("runtime tagged source requires ResumeDataDirectReader")
+            }
             ResumeValueSource::Uninitialized | ResumeValueSource::Unavailable => {
                 MaterializedValue::Value(0)
             }
@@ -2495,6 +2514,9 @@ impl ResumeDataExt for ResumeData {
             }
             ResumeValueSource::Constant(c) => ReconstructedValue::Value(c.as_raw_i64()),
             ResumeValueSource::Virtual(idx) => ReconstructedValue::Virtual(*idx),
+            ResumeValueSource::Tagged(_) => {
+                panic!("runtime tagged source requires ResumeDataDirectReader")
+            }
             ResumeValueSource::Uninitialized => ReconstructedValue::Uninitialized,
             ResumeValueSource::Unavailable => ReconstructedValue::Unavailable,
         }
@@ -3194,6 +3216,9 @@ impl ResumeDataLoopMemo {
             ResumeValueSource::Constant(c) => self.getconst_i64(c),
             // resume.py:219-221: virtual → tag(num_virtuals, TAGVIRTUAL)
             ResumeValueSource::Virtual(index) => tag_i64(encode_len(*index), TAGVIRTUAL),
+            ResumeValueSource::Tagged(_) => {
+                panic!("runtime tagged source cannot be encoded into a new resume stream")
+            }
             ResumeValueSource::Uninitialized => tag_i64(ENCODED_UNINITIALIZED, TAGCONST),
             ResumeValueSource::Unavailable => tag_i64(ENCODED_UNAVAILABLE, TAGCONST),
         }
@@ -4380,6 +4405,9 @@ impl<'a> ResumeDataReader<'a> {
             ResumeValueSource::Virtual(vidx) => {
                 self.virtuals.get(*vidx).copied().flatten().unwrap_or(0)
             }
+            ResumeValueSource::Tagged(_) => {
+                panic!("runtime tagged source requires ResumeDataDirectReader")
+            }
             ResumeValueSource::Uninitialized | ResumeValueSource::Unavailable => 0,
         }
     }
@@ -5210,6 +5238,48 @@ mod tests {
             ResumeDataDirectReader::new(&[0, 0], &[], &[], &[], None, None, &NullAllocator);
         let _ = reader.next_value_of_type(majit_ir::Type::Void);
     }
+
+    #[test]
+    fn rd_virtual_keeps_const_tag_until_direct_reader_decode() {
+        // resume.py:596-602 keeps AbstractVirtualInfo.fieldnums tagged and
+        // calls decoder.setfield(..., num, ...). In particular it does not
+        // copy ConstPtr.value out of rd_consts before allocate(), because that
+        // allocation may collect and forward rd_consts.
+        let tagged = tag(TAG_CONST_OFFSET, TAGCONST).unwrap();
+        let rd = majit_ir::RdVirtualInfo::VRawSliceInfo {
+            offset: 0,
+            fieldnums: vec![tagged],
+        };
+        let mut consts = vec![majit_ir::Const::Ref(majit_ir::GcRef(0x1000))];
+        let virtual_info = rd_virtual_to_virtual_info(&rd, &consts, 0, 1);
+        let VirtualInfo::VRawSlice { parent, .. } = virtual_info else {
+            panic!("expected VRawSlice");
+        };
+        assert_eq!(parent, ResumeValueSource::Tagged(tagged));
+
+        // Model the root walker forwarding rd_consts during the allocation
+        // window. The later field decode must observe the new pointer.
+        consts[0] = majit_ir::Const::Ref(majit_ir::GcRef(0x2000));
+        let mut reader =
+            ResumeDataDirectReader::new(&[0, 0], &consts, &[], &[], None, None, &NullAllocator);
+        assert_eq!(reader.decode_field_source(&parent), 0x2000);
+    }
+
+    #[test]
+    fn rd_virtual_normalizes_numbering_sentinels_before_decode() {
+        assert_eq!(
+            rd_virtual_field_source(UNINITIALIZED_TAG),
+            ResumeValueSource::Uninitialized
+        );
+        assert_eq!(
+            rd_virtual_field_source(UNASSIGNED),
+            ResumeValueSource::Unavailable
+        );
+        assert_eq!(
+            rd_virtual_field_source(UNASSIGNEDVIRTUAL),
+            ResumeValueSource::Unavailable
+        );
+    }
 }
 
 // ═══════════════════════════════════════════════════════════════
@@ -5654,6 +5724,15 @@ pub trait VirtualInfoBlackholeExt {
     ) -> i64;
 }
 
+#[inline]
+fn virtual_source_is_uninitialized(source: &VirtualFieldSource) -> bool {
+    match source {
+        ResumeValueSource::Uninitialized => true,
+        ResumeValueSource::Tagged(tagged) => tagged_eq(*tagged, UNINITIALIZED_TAG),
+        _ => false,
+    }
+}
+
 /// `resume.py:766-775 VStrPlainInfo.allocate` and `resume.py:821-830
 /// VUniPlainInfo.allocate` share the same loop body — the only
 /// difference is `decoder.allocate_string` vs `allocate_unicode` and
@@ -5680,7 +5759,7 @@ fn vstr_plain_info_allocate(
     decoder.virtuals_cache.set_ptr(index, string);
     for (i, char_source) in chars.iter().enumerate() {
         // resume.py:773 / 828 if not tagged_eq(charnum, UNINITIALIZED)
-        if matches!(char_source, VirtualFieldSource::Uninitialized) {
+        if virtual_source_is_uninitialized(char_source) {
             continue;
         }
         // resume.py:774 / 829 decoder.{string,unicode}_setitem(string, i, charnum)
@@ -5713,7 +5792,7 @@ fn abstract_virtual_struct_info_setfields(
             continue;
         };
         // resume.py:601 if not tagged_eq(num, UNINITIALIZED)
-        if matches!(source, VirtualFieldSource::Uninitialized) {
+        if virtual_source_is_uninitialized(source) {
             continue;
         }
         // resume.py:602 decoder.setfield(struct, num, descr)
@@ -5912,7 +5991,7 @@ impl VirtualInfoBlackholeExt for VirtualInfo {
                         fielddescrs.len()
                     );
                     for (j, &(_, ref source)) in fields.iter().enumerate() {
-                        if matches!(source, VirtualFieldSource::Uninitialized) {
+                        if virtual_source_is_uninitialized(source) {
                             continue;
                         }
                         // resume.py:757: decoder.setinteriorfield(i, array, num, self.fielddescrs[j])
@@ -6001,7 +6080,7 @@ impl VirtualInfoBlackholeExt for VirtualInfo {
                 for i in 0..offsets.len() {
                     let descr = &descrs[i];
                     let source = &values[i];
-                    if matches!(source, VirtualFieldSource::Uninitialized) {
+                    if virtual_source_is_uninitialized(source) {
                         continue;
                     }
                     // pyre extracts the per-entry value from the virtual
@@ -7020,6 +7099,7 @@ impl<'a> ResumeDataDirectReader<'a> {
             // resume.py:1568 ConstPtr.getref_base() — the Const carries its type.
             ResumeValueSource::Constant(c) => c.getref_base().as_usize() as i64,
             ResumeValueSource::Virtual(index) => self.getvirtual_ptr(*index),
+            ResumeValueSource::Tagged(tagged) => self.decode_ref(*tagged),
             ResumeValueSource::Uninitialized => 0,
             ResumeValueSource::Unavailable => 0,
         }
@@ -7034,6 +7114,7 @@ impl<'a> ResumeDataDirectReader<'a> {
             // resume.py:1555 ConstInt.getint().
             ResumeValueSource::Constant(c) => c.getint(),
             ResumeValueSource::Virtual(index) => self.getvirtual_int(*index),
+            ResumeValueSource::Tagged(tagged) => self.decode_int(*tagged),
             ResumeValueSource::Uninitialized => 0,
             ResumeValueSource::Unavailable => 0,
         }
@@ -7052,6 +7133,7 @@ impl<'a> ResumeDataDirectReader<'a> {
             ResumeValueSource::Virtual(_) => {
                 panic!("decode_field_source_float: TAGVIRTUAL not valid for float field")
             }
+            ResumeValueSource::Tagged(tagged) => self.decode_float(*tagged),
             ResumeValueSource::Uninitialized => 0,
             ResumeValueSource::Unavailable => 0,
         }

--- a/majit/majit-translate/docs/design-346-generic-adt-classdef-consistency.md
+++ b/majit/majit-translate/docs/design-346-generic-adt-classdef-consistency.md
@@ -33,7 +33,8 @@ predicate:
 
 - `adt_head_instantiation_suffix` (mir.rs:12384) returns `Some("<…>")` **iff** the head is an
   `TypeDeclKind::Enum` (mir.rs:12390 — **structs always collapse**) AND every rendered type-arg passes
-- `type_arg_splits_per_instantiation` (mir.rs:12361): `false` for `DEFERRED = ["f32","f64","()",""]`.
+- `type_arg_splits_per_instantiation` (mir.rs:12361): `false` for
+  `DEFERRED = ["f32","()",""]` (`SingleFloat` is int-banked; `f64` splits).
 
 ClassDef identity is the canonical name STRING (`classdesc.rs:2198` — `struct ClassDef` carries
 `name: String`, **no generic-args field**; dedup by `canonical_struct_name`, descr.rs:429). So bare

--- a/majit/majit-translate/src/annotator/annrpython.rs
+++ b/majit/majit-translate/src/annotator/annrpython.rs
@@ -81,6 +81,13 @@ pub struct RPythonAnnotator {
     /// identity-keyed blocks; the value side is `()` (we only use it
     /// as a set).
     pub added_blocks: RefCell<Option<IndexMap<BlockKey, BlockRef>>>,
+    /// Pyre's per-subject dual-gate continues after annotation failures,
+    /// unlike upstream's single fatal Translator run. While an
+    /// `added_blocks` scope is active, this transaction log captures only
+    /// previously-seen blocks before their input bindings are widened or
+    /// reflowed, so an uncommitted scope can restore them without cloning the
+    /// entire monotonically-growing annotator session for every subject.
+    subject_annotation_snapshots: RefCell<Option<IndexMap<BlockKey, BlockAnnotationSnapshot>>>,
     /// RPython `self.links_followed = {}` (annrpython.py:39).
     pub links_followed: RefCell<HashSet<LinkKey>>,
     /// RPython `self.notify = {}` (annrpython.py:40).
@@ -314,6 +321,12 @@ fn clear_block_bindings(block: &BlockRef) {
     }
 }
 
+struct BlockAnnotationSnapshot {
+    block: BlockRef,
+    graph: Option<GraphRef>,
+    definitions: Vec<(Variable, Option<Rc<SomeValue>>)>,
+}
+
 /// RAII guard for `self.added_blocks = {}; ...; finally:
 /// self.added_blocks = saved` in `complete_helpers()`.
 ///
@@ -334,6 +347,7 @@ fn clear_block_bindings(block: &BlockRef) {
 pub(crate) struct AddedBlocksGuard<'a> {
     ann: &'a RPythonAnnotator,
     saved: Option<Option<IndexMap<BlockKey, BlockRef>>>,
+    saved_annotation_snapshots: Option<Option<IndexMap<BlockKey, BlockAnnotationSnapshot>>>,
     annotated_at_entry: std::collections::HashSet<BlockKey>,
     committed: std::cell::Cell<bool>,
 }
@@ -352,6 +366,30 @@ impl<'a> AddedBlocksGuard<'a> {
 impl<'a> Drop for AddedBlocksGuard<'a> {
     fn drop(&mut self) {
         if !self.committed.get() {
+            // Restore only previously-seen blocks that this subject actually
+            // touched. `snapshot_block_if_tracking` records the cells before
+            // mergeinputargs/reflow mutates them.
+            if let Some(snapshots) = self.ann.subject_annotation_snapshots.borrow().as_ref() {
+                for (bkey, saved) in snapshots {
+                    self.ann
+                        .annotated
+                        .borrow_mut()
+                        .insert(bkey.clone(), saved.graph.clone());
+                    self.ann
+                        .all_blocks
+                        .borrow_mut()
+                        .insert(bkey.clone(), saved.block.clone());
+                    self.ann.blocked_blocks.borrow_mut().shift_remove(bkey);
+                    for (var, annotation) in &saved.definitions {
+                        *var.annotation.borrow_mut() = annotation.clone();
+                    }
+                }
+                if !snapshots.is_empty() {
+                    for generation in self.ann.genpendingblocks.borrow_mut().iter_mut() {
+                        generation.retain(|bkey, _| !snapshots.contains_key(bkey));
+                    }
+                }
+            }
             // Best-effort eviction under `try_borrow_mut`: a panic that
             // unwinds while one of these maps is borrowed degrades to a
             // leak rather than an abort-during-unwind double-borrow.
@@ -414,6 +452,9 @@ impl<'a> Drop for AddedBlocksGuard<'a> {
         }
         if let Some(saved) = self.saved.take() {
             *self.ann.added_blocks.borrow_mut() = saved;
+        }
+        if let Some(saved) = self.saved_annotation_snapshots.take() {
+            *self.ann.subject_annotation_snapshots.borrow_mut() = saved;
         }
     }
 }
@@ -480,6 +521,7 @@ impl RPythonAnnotator {
                 annotated: RefCell::new(IndexMap::new()),
                 all_blocks: RefCell::new(IndexMap::new()),
                 added_blocks: RefCell::new(None),
+                subject_annotation_snapshots: RefCell::new(None),
                 links_followed: RefCell::new(HashSet::new()),
                 notify: RefCell::new(IndexMap::new()),
                 fixed_graphs: RefCell::new(IndexMap::new()),
@@ -835,6 +877,10 @@ impl RPythonAnnotator {
     /// ```
     pub fn complete_helpers(&self) -> Result<(), crate::annotator::model::AnnotatorError> {
         let saved = self.added_blocks.borrow_mut().replace(IndexMap::new());
+        let saved_annotation_snapshots = self
+            .subject_annotation_snapshots
+            .borrow_mut()
+            .replace(IndexMap::new());
         // `complete_helpers` is the RPython helper-graph drive: its
         // `finally` only restores `added_blocks` (annrpython.py:113-119),
         // never evicting blocks.  Pre-commit so the guard's
@@ -843,6 +889,7 @@ impl RPythonAnnotator {
         let _guard = AddedBlocksGuard {
             ann: self,
             saved: Some(saved),
+            saved_annotation_snapshots: Some(saved_annotation_snapshots),
             annotated_at_entry: std::collections::HashSet::new(),
             committed: std::cell::Cell::new(true),
         };
@@ -1405,13 +1452,59 @@ impl RPythonAnnotator {
     /// (annrpython.py:113-114) for callers — e.g. the dual-gate
     /// per-subject driver — that drain via `complete_pending_blocks`
     /// directly rather than through `complete()`.
+    fn snapshot_block_if_tracking(&self, bkey: &BlockKey, block: &BlockRef) {
+        {
+            let snapshots = self.subject_annotation_snapshots.borrow();
+            let Some(snapshots) = snapshots.as_ref() else {
+                return;
+            };
+            if snapshots.contains_key(bkey) {
+                return;
+            }
+        }
+        let Some(graph) = self.annotated.borrow().get(bkey).cloned() else {
+            // A block first discovered in this scope is evicted by the
+            // ordinary added-block rollback and has no prior state to save.
+            return;
+        };
+        let definitions = {
+            let block = block.borrow();
+            block
+                .inputargs
+                .iter()
+                .chain(block.operations.iter().map(|op| &op.result))
+                .filter_map(|value| match value {
+                    Hlvalue::Variable(var) => Some((var.clone(), var.annotation.borrow().clone())),
+                    _ => None,
+                })
+                .collect()
+        };
+        self.subject_annotation_snapshots
+            .borrow_mut()
+            .as_mut()
+            .expect("annotation snapshot scope disappeared")
+            .insert(
+                bkey.clone(),
+                BlockAnnotationSnapshot {
+                    block: block.clone(),
+                    graph,
+                    definitions,
+                },
+            );
+    }
+
     pub(crate) fn enter_added_blocks_scope(&self) -> AddedBlocksGuard<'_> {
         let saved = self.added_blocks.borrow_mut().replace(IndexMap::new());
+        let saved_annotation_snapshots = self
+            .subject_annotation_snapshots
+            .borrow_mut()
+            .replace(IndexMap::new());
         let annotated_at_entry: std::collections::HashSet<BlockKey> =
             self.annotated.borrow().keys().cloned().collect();
         AddedBlocksGuard {
             ann: self,
             saved: Some(saved),
+            saved_annotation_snapshots: Some(saved_annotation_snapshots),
             annotated_at_entry,
             committed: std::cell::Cell::new(false),
         }
@@ -1583,6 +1676,9 @@ impl RPythonAnnotator {
 
         let bkey = BlockKey::of(block);
         let seen_before = self.annotated.borrow().contains_key(&bkey);
+        if seen_before {
+            self.snapshot_block_if_tracking(&bkey, block);
+        }
         if !seen_before {
             self.bindinputargs(graph, block, cells);
         } else {
@@ -1679,8 +1775,9 @@ impl RPythonAnnotator {
                 .contains_key(&GraphKey::of(graph)),
             "reflowpendingblock: graph is fixed"
         );
-        self.schedulependingblock(graph, block);
         let bkey = BlockKey::of(block);
+        self.snapshot_block_if_tracking(&bkey, block);
+        self.schedulependingblock(graph, block);
         assert!(
             self.annotated.borrow().contains_key(&bkey),
             "reflowpendingblock: block not yet annotated"

--- a/majit/majit-translate/src/annotator/bookkeeper.rs
+++ b/majit/majit-translate/src/annotator/bookkeeper.rs
@@ -1919,6 +1919,19 @@ impl Bookkeeper {
         let canon_root = majit_ir::descr::canonical_struct_name(enum_root);
         let variant_path = format!("{canon_root}::{variant_name}");
         self.project_struct_rows(&variant_path)?;
+        // A variant payload can be the first place a dependency struct is
+        // reached (`ConstantData::Complex.value: Complex<f64>`).  The payload
+        // projector queues that struct to avoid recursively borrowing the
+        // registry, just like an ordinary struct row does.  Drain it before
+        // publishing the variant classdef; otherwise the variant's `value`
+        // attr may be classed while `value.re` / `value.im` still see the
+        // FORCE shell.  This is the variant counterpart of the pending drain
+        // in `getuniqueclassdef_for_struct_root`.
+        loop {
+            let next = self.pending_struct_row_projection.borrow_mut().pop();
+            let Some(n) = next else { break };
+            self.project_struct_rows(&n)?;
+        }
         self.getuniqueclassdef(&variant_host)
     }
 
@@ -2467,7 +2480,28 @@ impl Bookkeeper {
             // meet the same `SomeString` — projecting `s_unicode0` here
             // raised `str ∪ unicode` where a literal merged into a
             // String-typed attr cell.
-            "String" | "str" => return super::model::s_str0(),
+            // RustPython's compiler constants store strings in the
+            // dependency-owned `Wtf8Buf` newtype.  The MIR front already
+            // erases `Wtf8`/`Wtf8Buf` to the same immutable byte-string
+            // value as `String`/`str` (their methods are view adapters over
+            // that value), so a struct payload row must project to that
+            // exact annotation too.  Leaving the dependency-opaque name to
+            // the registered-struct arm below produces `Impossible` and
+            // blocks `ConstantData::Str.value`.
+            "String" | "str" | "Wtf8" | "Wtf8Buf" => return super::model::s_str0(),
+            // `malachite_bigint::BigInt` is deliberately foreign and opaque
+            // to translation.  Its sanctioned conversion seam is a residual
+            // call, but the value occupying `ConstantData::Integer.value`
+            // still has RPython's one-GC-reference shape.  Match the
+            // `BigInt.from` builtin analyzer and foreign-method cutover:
+            // retain a classdef-less `SomeInstance`, never lattice bottom.
+            "BigInt" => {
+                return SomeValue::Instance(super::model::SomeInstance::new(
+                    None,
+                    false,
+                    std::collections::BTreeMap::new(),
+                ));
+            }
             "char" => return SomeValue::Char(super::model::SomeChar::new(false)),
             "()" => return super::model::s_none(),
             _ => {}
@@ -2590,11 +2624,35 @@ impl Bookkeeper {
                 return self.project_pyre_field_type(&items_ty);
             }
         }
+        // Named generic structs in Charon's registry are stored under their
+        // declaration template (`CodeObject`), while a concrete field row can
+        // spell the use-site instantiation (`CodeObject<ConstantData>`).
+        // RPython has no generic class instantiations: both spellings denote
+        // the same classdef.  This is distinct from Option/Result and
+        // container wrappers handled above, and from per-shape tuple/enum
+        // classes whose dedicated paths never reach this arm.
+        let named_root = if strip_generic_one(stripped, "Complex<").is_some()
+            && self
+                .pyre_struct_fields
+                .borrow()
+                .as_ref()
+                .is_some_and(|r| r.fields.contains_key("num_complex::Complex"))
+        {
+            // Charon renders compiler-core's `Complex64` alias payload as
+            // the unqualified `Complex<f64>`, while the opaque dependency
+            // declaration is registered under `num_complex::Complex`.
+            // Resolve that exact generic spelling to its declaration
+            // identity; an unrelated local `Complex` is untouched unless
+            // the real dependency root is present in this program.
+            std::borrow::Cow::Borrowed("num_complex::Complex")
+        } else {
+            majit_ir::descr::strip_generic_args(stripped)
+        };
         let registered = {
             let guard = self.pyre_struct_fields.borrow();
             guard
                 .as_ref()
-                .map(|r| r.fields.contains_key(stripped))
+                .map(|r| r.fields.contains_key(named_root.as_ref()))
                 .unwrap_or(false)
         };
         if !registered {
@@ -2613,14 +2671,14 @@ impl Bookkeeper {
         // pending drain projects its rows before any subject flow can
         // read the class's untyped FORCE shells.
         {
-            let canonical = majit_ir::descr::canonical_struct_name(stripped);
+            let canonical = majit_ir::descr::canonical_struct_name(named_root.as_ref());
             if !self.projected_struct_rows.borrow().contains(&canonical) {
                 self.pending_struct_row_projection
                     .borrow_mut()
-                    .push(stripped.to_string());
+                    .push(named_root.to_string());
             }
         }
-        let host = self.intern_class_by_qualname(stripped);
+        let host = self.intern_class_by_qualname(named_root.as_ref());
         match self.getuniqueclassdef(&host) {
             Ok(classdef) => SomeValue::Instance(super::model::SomeInstance::new(
                 Some(classdef),
@@ -4182,6 +4240,75 @@ mod tests {
                 .as_ref()
                 .is_some_and(|c| Rc::ptr_eq(c, &inner)),
             "PyFrame.pycode inner classdef must be the same Rc as the standalone PyCode lookup"
+        );
+    }
+
+    #[test]
+    fn compiler_constant_payload_types_project_without_lattice_bottom() {
+        use crate::annotator::model::SomeValue;
+        use crate::front::StructFieldRegistry;
+
+        let bk = bk();
+        let mut reg = StructFieldRegistry::default();
+        reg.fields.insert(
+            "CodeObject".to_string(),
+            vec![("max_stackdepth".to_string(), "u32".to_string())],
+        );
+        reg.fields.insert(
+            "num_complex::Complex".to_string(),
+            vec![
+                ("re".to_string(), "f64".to_string()),
+                ("im".to_string(), "f64".to_string()),
+            ],
+        );
+        reg.fields.insert(
+            "Complex".to_string(),
+            reg.fields["num_complex::Complex"].clone(),
+        );
+        bk.set_pyre_struct_fields(Rc::new(reg));
+
+        assert!(
+            matches!(bk.project_pyre_field_type("BigInt"), SomeValue::Instance(ref s) if s.classdef.is_none()),
+            "dependency-opaque compiler BigInt remains one GC reference"
+        );
+        assert!(
+            matches!(bk.project_pyre_field_type("Wtf8Buf"), SomeValue::String(_)),
+            "Wtf8Buf shares the immutable string annotation"
+        );
+
+        let SomeValue::Instance(complex) = bk.project_pyre_field_type("Complex<f64>") else {
+            panic!("Complex<f64> must project to its registered struct class")
+        };
+        let complex_cd = complex.classdef.expect("Complex classdef");
+        let projected_complex = bk
+            .getuniqueclassdef_for_struct_root("num_complex::Complex")
+            .expect("Complex rows project");
+        assert!(Rc::ptr_eq(&complex_cd, &projected_complex));
+        let complex_attrs = &complex_cd.borrow().attrs;
+        assert!(matches!(
+            complex_attrs.get("re").map(|a| &a.s_value),
+            Some(SomeValue::Float(_))
+        ));
+        assert!(matches!(
+            complex_attrs.get("im").map(|a| &a.s_value),
+            Some(SomeValue::Float(_))
+        ));
+
+        let SomeValue::Instance(code) = bk.project_pyre_field_type("Box<CodeObject<ConstantData>>")
+        else {
+            panic!("concrete CodeObject instantiation must use the template class")
+        };
+        let code_cd = code.classdef.expect("CodeObject classdef");
+        let template = bk
+            .getuniqueclassdef_for_struct_root("CodeObject")
+            .expect("CodeObject template classdef");
+        assert!(
+            code_cd.borrow().attrs.contains_key("max_stackdepth"),
+            "template rows must be projected onto the concrete generic use"
+        );
+        assert!(
+            Rc::ptr_eq(&code_cd, &template),
+            "RPython has one CodeObject class, not per-generic classdefs"
         );
     }
 

--- a/majit/majit-translate/src/front/bigint_binop.rs
+++ b/majit/majit-translate/src/front/bigint_binop.rs
@@ -106,6 +106,7 @@ pub(crate) fn bigint_unop_residual_path(segments: &[String]) -> Option<Vec<Strin
 pub(crate) fn bigint_unop_residual_for_method(leaf: &str) -> Option<Vec<String>> {
     let residual_leaf = match leaf {
         "neg" => "jit_bigint_neg",
+        "invert" | "not" => "jit_bigint_invert",
         _ => return None,
     };
     Some(residual_path(residual_leaf))
@@ -207,10 +208,18 @@ mod tests {
     }
 
     #[test]
-    fn maps_unary_neg_to_its_residual() {
+    fn maps_unary_operations_to_their_residuals() {
         let path = bigint_unop_residual_path(&segs(&["pyre_object", "rbigint", "<Impl>", "neg"]))
             .expect("neg must map");
         assert_eq!(path, desc("jit_bigint_neg"));
+        assert_eq!(
+            bigint_unop_residual_path(&segs(&["rbigint", "RBigInt", "invert"])),
+            Some(desc("jit_bigint_invert"))
+        );
+        assert_eq!(
+            bigint_unop_residual_path(&segs(&["pyre_object", "rbigint", "<Impl>", "not"])),
+            Some(desc("jit_bigint_invert"))
+        );
         // Binary operators / shifts are not in the unary map.
         assert!(
             bigint_unop_residual_path(&segs(&["pyre_object", "rbigint", "<Impl>", "add"]))

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -1477,15 +1477,22 @@ fn derive_program_metadata(
         .any(|td| td.item_meta.name_path() == compiler_constants_path)
     {
         let rows = vec![("__pos_0".to_string(), "Box<[ConstantData]>".to_string())];
-        for key in [compiler_constants_path, "bytecode::Constants", "Constants"] {
+        for key in [compiler_constants_path, "bytecode::Constants"] {
             struct_fields.fields.insert(key.to_string(), rows.clone());
             known_struct_names.insert(key.to_string());
         }
+        struct_fields
+            .fields
+            .entry("Constants".to_string())
+            .or_insert_with(|| rows.clone());
+        known_struct_names.insert("Constants".to_string());
         let sid = majit_ir::descr::StructId::from_canonical("bytecode::Constants");
         for key in [compiler_constants_path, "bytecode::Constants", "Constants"] {
             record_struct_id(&mut struct_ids, key.to_string(), sid);
         }
-        struct_origins.insert("Constants".to_string(), "bytecode".to_string());
+        struct_origins
+            .entry("Constants".to_string())
+            .or_insert_with(|| "bytecode".to_string());
         struct_field_attrs.insert(
             "bytecode::Constants".to_string(),
             vec![("__pos_0".to_string(), ValueType::Ref(None))],
@@ -1502,6 +1509,7 @@ fn derive_program_metadata(
     // declaration so an unrelated same-named local type cannot acquire this
     // shape.
     let num_complex_path = "num_complex::Complex";
+    let num_complex_canon = strip_crate_prefix(num_complex_path);
     if llbc
         .iter_type_decls()
         .any(|td| td.item_meta.name_path() == num_complex_path)
@@ -1514,13 +1522,13 @@ fn derive_program_metadata(
             struct_fields.fields.insert(key.to_string(), rows.clone());
             known_struct_names.insert(key.to_string());
         }
-        let sid = majit_ir::descr::StructId::from_canonical(num_complex_path);
+        let sid = majit_ir::descr::StructId::from_canonical(&num_complex_canon);
         for key in [num_complex_path, "Complex"] {
             record_struct_id(&mut struct_ids, key.to_string(), sid);
         }
         struct_origins.insert("Complex".to_string(), "num_complex".to_string());
         struct_field_attrs.insert(
-            num_complex_path.to_string(),
+            num_complex_canon,
             vec![
                 ("re".to_string(), ValueType::Float),
                 ("im".to_string(), ValueType::Float),
@@ -7747,6 +7755,25 @@ impl<'a> Lowering<'a> {
             ..
         } = &op_kind
             && args.len() == 2
+            && match segments.last().map(String::as_str) {
+                Some("bigint_lshift_count") => {
+                    first_arg_ty
+                        .as_ref()
+                        .is_some_and(|ty| tyref_is_rbigint(ty, self.llbc))
+                        && second_arg_ty
+                            .as_ref()
+                            .is_some_and(|ty| tyref_to_value_type(ty, self.llbc) == ValueType::Int)
+                }
+                Some("bigint_lshift_int_int_result") => {
+                    first_arg_ty
+                        .as_ref()
+                        .is_some_and(|ty| tyref_to_value_type(ty, self.llbc) == ValueType::Int)
+                        && second_arg_ty
+                            .as_ref()
+                            .is_some_and(|ty| tyref_to_value_type(ty, self.llbc) == ValueType::Int)
+                }
+                _ => false,
+            }
             && let Some(residual) = crate::front::rbigint_call::lshift_count_residual_path(segments)
         {
             OpKind::Call {

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -1159,12 +1159,27 @@ fn derive_program_metadata(
                 // so downstream lookups (`canonical_call_target`'s
                 // bare-leaf fallback) resolve either spelling.
                 let leaf = name.rsplit("::").next().unwrap_or(&name).to_string();
+                let is_rbigint = name == "rbigint::RBigInt" || name.ends_with("::rbigint::RBigInt");
                 let rows: Vec<(String, String)> = fields
                     .iter()
                     .enumerate()
                     .map(|(i, f)| {
                         let fname = f.name.clone().unwrap_or_else(|| format!("__pos_{i}"));
-                        (fname, tyref_to_ast_string(&f.ty, llbc))
+                        // RPython rbigint.py stores `_digits` as
+                        // `GcArray(Signed)`.  Rust stores the same translated
+                        // array behind a `*mut TypedItemsBlock`; exposing that
+                        // implementation pointer to the annotator loses the
+                        // list annotation and makes the always-inline
+                        // `digit()` projection classdef-less.  Preserve the
+                        // source-level RPython field shape here.  Exact Charon
+                        // layout still supplies the physical pointer-sized
+                        // field offset/size to the backend.
+                        let field_ty = if is_rbigint && fname == "_digits" {
+                            "[i64]".to_string()
+                        } else {
+                            tyref_to_ast_string(&f.ty, llbc)
+                        };
+                        (fname, field_ty)
                     })
                     .collect();
                 struct_fields.fields.insert(name.clone(), rows.clone());
@@ -1445,6 +1460,72 @@ fn derive_program_metadata(
             }
             TypeDeclKind::Alias(_) | TypeDeclKind::Opaque | TypeDeclKind::Unknown => {}
         }
+    }
+
+    // RustPython compiler-core declares this exact source type as
+    // `pub struct Constants<C: Constant>(Box<[C]>)`.  It is a dependency
+    // `Opaque` declaration in `pyre-interpreter.ullbc`, so Charon cannot
+    // provide the field row even though MIR contains the statically resolved
+    // `Deref`/`Index` impl calls.  Supply the literal upstream row for the one
+    // concrete interpreter instantiation (`C = ConstantData`) so the typed
+    // `Constants.__pos_0` FieldRead annotates as a list.  State remains on the
+    // wrapper object itself; this is metadata for its real field, not a side
+    // table or replacement container.
+    let compiler_constants_path = "rustpython_compiler_core::bytecode::Constants";
+    if llbc
+        .iter_type_decls()
+        .any(|td| td.item_meta.name_path() == compiler_constants_path)
+    {
+        let rows = vec![("__pos_0".to_string(), "Box<[ConstantData]>".to_string())];
+        for key in [compiler_constants_path, "bytecode::Constants", "Constants"] {
+            struct_fields.fields.insert(key.to_string(), rows.clone());
+            known_struct_names.insert(key.to_string());
+        }
+        let sid = majit_ir::descr::StructId::from_canonical("bytecode::Constants");
+        for key in [compiler_constants_path, "bytecode::Constants", "Constants"] {
+            record_struct_id(&mut struct_ids, key.to_string(), sid);
+        }
+        struct_origins.insert("Constants".to_string(), "bytecode".to_string());
+        struct_field_attrs.insert(
+            "bytecode::Constants".to_string(),
+            vec![("__pos_0".to_string(), ValueType::Ref(None))],
+        );
+    }
+
+    // `num_complex::Complex<T>` is dependency-opaque in the interpreter
+    // snapshot, but compiler-core's `ConstantData::Complex` payload stores
+    // the concrete `Complex<f64>` and `load_const_value` reads its public
+    // `re`/`im` fields.  Restore the literal upstream `#[repr(C)] struct
+    // Complex<T> { pub re: T, pub im: T }` rows for that one instantiation.
+    // As with `Constants` above, this describes fields on the real value; it
+    // introduces no parallel storage.  Gate it on the exact dependency type
+    // declaration so an unrelated same-named local type cannot acquire this
+    // shape.
+    let num_complex_path = "num_complex::Complex";
+    if llbc
+        .iter_type_decls()
+        .any(|td| td.item_meta.name_path() == num_complex_path)
+    {
+        let rows = vec![
+            ("re".to_string(), "f64".to_string()),
+            ("im".to_string(), "f64".to_string()),
+        ];
+        for key in [num_complex_path, "Complex"] {
+            struct_fields.fields.insert(key.to_string(), rows.clone());
+            known_struct_names.insert(key.to_string());
+        }
+        let sid = majit_ir::descr::StructId::from_canonical(num_complex_path);
+        for key in [num_complex_path, "Complex"] {
+            record_struct_id(&mut struct_ids, key.to_string(), sid);
+        }
+        struct_origins.insert("Complex".to_string(), "num_complex".to_string());
+        struct_field_attrs.insert(
+            num_complex_path.to_string(),
+            vec![
+                ("re".to_string(), ValueType::Float),
+                ("im".to_string(), ValueType::Float),
+            ],
+        );
     }
 
     for td in llbc.iter_trait_decls() {
@@ -6019,7 +6100,8 @@ impl<'a> Lowering<'a> {
                         || self.is_noop_ptr_cast(&reg)
                         || self.is_reflexive_into_iter(&reg)
                         || self.is_hint_must_use(&reg)
-                        || self.is_arguments_from_str(&reg))
+                        || self.is_arguments_from_str(&reg)
+                        || self.is_rbigint_translated_alias(&reg, first_arg_ty.as_ref()))
                 {
                     self.local_var[dest_local] = Some(args[0].clone());
                     let target_bb = self.block_id[target];
@@ -6087,6 +6169,25 @@ impl<'a> Lowering<'a> {
                 // the rtyper cannot route on the classdef-less receiver.
                 if args.len() == 1 && self.is_container_identity_deref(&reg) {
                     self.local_var[dest_local] = Some(args[0].clone());
+                    let target_bb = self.block_id[target];
+                    let link_args = self.edge_args(mir_bb, target)?;
+                    self.graph.set_goto(bb_id, target_bb, link_args);
+                    return Ok(());
+                }
+                // RustPython compiler-core's `Constants<C>` is exactly
+                // `struct Constants<C>(Box<[C]>)`; its `Deref<Target=[C]>`
+                // returns `&self.0`.  Preserve that upstream owner/storage
+                // shape by reading the tuple field, not by pretending the
+                // wrapper itself is a list or introducing a parallel store.
+                //
+                // `Box<[C]>` and `[C]` share the lifted list representation,
+                // so the field value is already the dereferenced slice value.
+                // This is deliberately separate from the generic
+                // String/Vec identity arm above: `Constants` has a real
+                // wrapper field which must remain visible to layout and GC.
+                if args.len() == 1 && constants_call_leaf(&reg, self.llbc) == Some("deref") {
+                    let constants = self.emit_constants_items_read(bb_id, args[0].clone());
+                    self.local_var[dest_local] = Some(constants);
                     let target_bb = self.block_id[target];
                     let link_args = self.edge_args(mir_bb, target)?;
                     self.graph.set_goto(bb_id, target_bb, link_args);
@@ -6200,6 +6301,34 @@ impl<'a> Lowering<'a> {
                             index_var: args[1].clone(),
                         },
                     );
+                    self.local_var[dest_local] = Some(res);
+                    let target_bb = self.block_id[target];
+                    let link_args = self.edge_args(mir_bb, target)?;
+                    self.graph.set_goto(bb_id, target_bb, link_args);
+                    return Ok(());
+                }
+                // `impl Index<ConstIdx> for Constants<C>` is the literal
+                // upstream operation `&self.0[consti.as_usize()]`.
+                // `ConstIdx` is one of compiler-core's exact
+                // `#[repr(transparent)] u32` oparg wrappers and therefore
+                // already occupies RPython's integer register bank; only the
+                // real `Constants.0` field projection is needed here.
+                if args.len() == 2 && constants_call_leaf(&reg, self.llbc) == Some("index") {
+                    let items = self.emit_constants_items_read(bb_id, args[0].clone());
+                    let res = self
+                        .graph
+                        .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
+                    self.graph.block_mut(bb_id).operations.push(SpaceOperation {
+                        result: Some(res.clone()),
+                        kind: OpKind::ArrayRead {
+                            base: items,
+                            index: args[1].clone(),
+                            item_ty: tyref_to_value_type(&call.dest.ty, self.llbc),
+                            array_type_id: None,
+                            nolength: false,
+                            pure: false,
+                        },
+                    });
                     self.local_var[dest_local] = Some(res);
                     let target_bb = self.block_id[target];
                     let link_args = self.edge_args(mir_bb, target)?;
@@ -6396,6 +6525,21 @@ impl<'a> Lowering<'a> {
                 // ([`is_items_block_base_ptr_add`] keys on the enclosing
                 // accessor so a dereferenced `.add` elsewhere is untouched).
                 if args.len() == 2 && self.is_items_block_base_ptr_add(&reg) {
+                    self.local_var[dest_local] = Some(args[0].clone());
+                    let target_bb = self.block_id[target];
+                    let link_args = self.edge_args(mir_bb, target)?;
+                    self.graph.set_goto(bb_id, target_bb, link_args);
+                    return Ok(());
+                }
+                // `RBigInt::digits{,_mut}` is Rust's view adapter around the
+                // RPython `_digits` GcArray:
+                // `slice::from_raw_parts(typed_items_base(_digits), capacity)`.
+                // The typed-items base call above already aliases the header
+                // pointer so the gcarray descr re-applies `base_size`; the
+                // resulting slice is therefore the same array value in the
+                // translated model. Fold only these two enclosing accessors,
+                // not arbitrary raw slices.
+                if args.len() == 2 && self.is_rbigint_digits_from_raw_parts(&reg) {
                     self.local_var[dest_local] = Some(args[0].clone());
                     let target_bb = self.block_id[target];
                     let link_args = self.edge_args(mir_bb, target)?;
@@ -6698,6 +6842,17 @@ impl<'a> Lowering<'a> {
                     return Ok(());
                 }
                 if self.try_lower_num_from(
+                    mir_bb,
+                    &reg.kind,
+                    &segments,
+                    &args,
+                    dest_local,
+                    &call.dest.ty,
+                    target,
+                )? {
+                    return Ok(());
+                }
+                if self.try_lower_rbigint_toint(
                     mir_bb,
                     &reg.kind,
                     &segments,
@@ -7130,6 +7285,32 @@ impl<'a> Lowering<'a> {
             op_kind
         };
 
+        // A translated RBigInt value is already its one-GC-reference payload.
+        // Rust's host-only `w_long_new(RBigInt)` / constant-boxing functions
+        // accept the two-word by-value handle and allocate that payload first;
+        // keeping that call in JIT IR would therefore use the wrong ABI and
+        // duplicate the translated object. Wrap the existing payload pointer
+        // directly, matching `W_LongObject(value)` in PyPy.
+        let op_kind = if let OpKind::Call {
+            target: CallTarget::FunctionPath { segments },
+            args,
+            ..
+        } = &op_kind
+            && args.len() == 1
+            && first_arg_ty
+                .as_ref()
+                .is_some_and(|ty| tyref_is_rbigint(ty, self.llbc))
+            && let Some(residual) = crate::front::rbigint_call::long_box_residual_path(segments)
+        {
+            OpKind::Call {
+                target: CallTarget::FunctionPath { segments: residual },
+                args: args.clone(),
+                result_ty: ValueType::Ref(None),
+            }
+        } else {
+            op_kind
+        };
+
         // Retarget an RBigInt Rust trait-operator call (`<RBigInt as
         // BitAnd>::bitand`, …) to its elidable `jit_bigint_*`
         // residual. The trait shell obscures the RPython method, and both operands
@@ -7289,6 +7470,90 @@ impl<'a> Lowering<'a> {
                 target: CallTarget::FunctionPath { segments: residual },
                 args: args.clone(),
                 result_ty: ValueType::Ref(None),
+            }
+        } else {
+            op_kind
+        };
+
+        // `RBigInt::digits{,_mut}` is only the Rust view adapter for
+        // RPython's direct `self._digits` GcArray field.  Project the field
+        // itself so the annotator receives the `[Signed]` SomeList registered
+        // above instead of following `slice::from_raw_parts` and manufacturing
+        // a classdef-less slice instance.  This is the literal rbigint.py
+        // storage shape; `digits_mut` differs only in Rust borrow mutability,
+        // which does not exist in the translated graph.
+        let op_kind = if let OpKind::Call { target, args, .. } = &op_kind
+            && args.len() == 1
+            && first_arg_ty
+                .as_ref()
+                .is_some_and(|ty| tyref_is_rbigint(ty, self.llbc))
+            && match target {
+                CallTarget::FunctionPath { segments } => matches!(
+                    segments.last().map(String::as_str),
+                    Some("digits" | "digits_mut")
+                ),
+                CallTarget::Method { name, .. } => {
+                    matches!(name.as_str(), "digits" | "digits_mut")
+                }
+                _ => false,
+            } {
+            OpKind::FieldRead {
+                base: args[0].clone(),
+                field: FieldDescriptor::new("_digits", Some("RBigInt".to_string())).with_owner_id(
+                    Some(majit_ir::descr::StructId::from_canonical(
+                        "rbigint::RBigInt",
+                    )),
+                ),
+                ty: ValueType::Ref(None),
+                pure: true,
+            }
+        } else {
+            op_kind
+        };
+
+        // rbigint.py marks its raw digit projections `_always_inline_ = True`.
+        // A dependent-crate LLBC sees `RBigInt` as opaque and therefore drops
+        // the ordinary impl-owner method hint, even though the combined
+        // pyre-object LLBC owns the concrete classdef and method graph. Restore
+        // that Method target after proving the exact nominal receiver so
+        // MethodDesc seeds a classdef-bound `self`; otherwise `digit(0)` in
+        // longobject.py's `-1 ** exponent` shortcut enters the concrete method
+        // with `SomeInstance(classdef=None)` and fails on `_digits`.
+        let op_kind = if let OpKind::Call {
+            target,
+            args,
+            result_ty,
+        } = &op_kind
+            && first_arg_ty
+                .as_ref()
+                .is_some_and(|ty| tyref_is_rbigint(ty, self.llbc))
+            && let Some(leaf) = match target {
+                CallTarget::FunctionPath { segments } => segments.last(),
+                _ => None,
+            }
+            && matches!(
+                leaf.as_str(),
+                "digit" | "widedigit" | "uwidedigit" | "udigit" | "numdigits"
+            ) {
+            let narrowed_receiver = self
+                .graph
+                .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
+            self.graph.block_mut(bb_id).operations.push(SpaceOperation {
+                result: Some(narrowed_receiver.clone()),
+                kind: OpKind::Call {
+                    target: CallTarget::FunctionPath {
+                        segments: vec!["__pyre_cast_instance".to_string(), "RBigInt".to_string()],
+                    },
+                    args: vec![args[0].clone()],
+                    result_ty: ValueType::Ref(Some("RBigInt".to_string())),
+                },
+            });
+            let mut narrowed_args = args.clone();
+            narrowed_args[0] = narrowed_receiver;
+            OpKind::Call {
+                target: CallTarget::method(leaf.clone(), Some("RBigInt".to_string())),
+                args: narrowed_args,
+                result_ty: result_ty.clone(),
             }
         } else {
             op_kind
@@ -7482,9 +7747,6 @@ impl<'a> Lowering<'a> {
             ..
         } = &op_kind
             && args.len() == 2
-            && first_arg_ty
-                .as_ref()
-                .is_some_and(|ty| tyref_is_rbigint(ty, self.llbc))
             && let Some(residual) = crate::front::rbigint_call::lshift_count_residual_path(segments)
         {
             OpKind::Call {
@@ -8075,6 +8337,52 @@ impl<'a> Lowering<'a> {
         Some((owner_leaf, leaf))
     }
 
+    /// Read the sole upstream field of
+    /// `rustpython_compiler_core::bytecode::Constants<C>`.
+    ///
+    /// The wrapper is a tuple struct around `Box<[C]>`; the anonymous field
+    /// is therefore `__pos_0` in the same ADT field model used by ordinary
+    /// MIR projections.  Keep the collision-free layout identity alongside
+    /// the bare `Constants` annotation owner, exactly as
+    /// [`Self::resolve_adt_field`] does for a source-level `.0` read.
+    fn emit_constants_items_read(&mut self, bb_id: BlockId, base: Variable) -> Variable {
+        // `CodeObject<C>` is generic, so its `constants: Constants<C>` field
+        // arrives at a dependent trait-default graph as classdef-less `Ref`.
+        // The nominal owner is nevertheless fixed by the statically resolved
+        // `Constants::{deref,index}` impl.  Restore that class identity before
+        // reading the real wrapper field, exactly like the typed raw-pointer
+        // projection path narrows to its declared field owner.
+        let narrowed = self
+            .graph
+            .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
+        self.graph.block_mut(bb_id).operations.push(SpaceOperation {
+            result: Some(narrowed.clone()),
+            kind: OpKind::Call {
+                target: CallTarget::FunctionPath {
+                    segments: vec!["__pyre_cast_instance".to_string(), "Constants".to_string()],
+                },
+                args: vec![base],
+                result_ty: ValueType::Ref(Some("Constants".to_string())),
+            },
+        });
+        let result = self
+            .graph
+            .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
+        self.graph.block_mut(bb_id).operations.push(SpaceOperation {
+            result: Some(result.clone()),
+            kind: OpKind::FieldRead {
+                base: narrowed,
+                field: FieldDescriptor::new("__pos_0", Some("Constants".to_string()))
+                    .with_owner_id(Some(majit_ir::descr::StructId::from_canonical(
+                        "bytecode::Constants",
+                    ))),
+                ty: ValueType::Ref(None),
+                pure: false,
+            },
+        });
+        result
+    }
+
     /// `arr[i]` / `arr[i] = v` on a workspace fixed-array type —
     /// resolves to its `Index::index` / `IndexMut::index_mut` impl,
     /// whose body bottoms out at raw-slice construction
@@ -8180,11 +8488,11 @@ impl<'a> Lowering<'a> {
         })
     }
 
-    /// `<*mut T>::add` / `<*const T>::add` inside an `ItemsBlock`
-    /// items-base accessor (`items_block_items_base` /
-    /// `items_block_items_ptr`), whose whole body is
-    /// `(block as *mut u8).add(ITEMS_BLOCK_ITEMS_OFFSET)` — the items
-    /// pointer of a list's backing block.
+    /// `<*mut T>::add` / `<*const T>::add` inside an `ItemsBlock` or
+    /// `TypedItemsBlock` items-base accessor (`items_block_items_base` /
+    /// `items_block_items_ptr` / `typed_items_block_items_base`), whose
+    /// whole body is `(block as *mut u8).add(*_ITEMS_OFFSET)` — the items
+    /// pointer of a GC array backing a list or rbigint digit array.
     ///
     /// The runtime reads list items through a `gcarray` descr whose
     /// `base_size` already folds in the header offset
@@ -8204,6 +8512,26 @@ impl<'a> Lowering<'a> {
     fn is_items_block_base_ptr_add(&self, reg: &RegularCall) -> bool {
         graph_is_items_block_base_accessor(&self.graph.name)
             && regular_call_is_ptr_add(reg, self.llbc)
+    }
+
+    /// `slice::from_raw_parts{,_mut}` in `RBigInt::digits{,_mut}` only.
+    /// RPython stores `_digits` as the array itself; the Rust slice is a
+    /// zero-copy source adapter and aliases that same translated GcArray.
+    fn is_rbigint_digits_from_raw_parts(&self, reg: &RegularCall) -> bool {
+        if !(self.graph.name.ends_with("rbigint::<Impl>::digits")
+            || self.graph.name.ends_with("rbigint::<Impl>::digits_mut"))
+        {
+            return false;
+        }
+        let CallKind::Fun(FunId::Regular { id }) = &reg.kind else {
+            return false;
+        };
+        self.llbc.fn_by_id(*id).is_some_and(|fd| {
+            matches!(
+                fd.item_meta.name_path().as_str(),
+                "core::slice::raw::from_raw_parts" | "core::slice::raw::from_raw_parts_mut"
+            )
+        })
     }
 
     /// `*items_block_items_base(block).add(idx)` — a list / tuple
@@ -8645,6 +8973,33 @@ impl<'a> Lowering<'a> {
         self.llbc
             .fn_by_id(*id)
             .is_some_and(|fd| fd.item_meta.name_path() == "core::hint::must_use")
+    }
+
+    /// `RBigInt::translated_alias(self)` is the Rust ownership spelling of an
+    /// RPython reference assignment. The host shallow-clones the two-word
+    /// handle, while the translated representation is already one GC
+    /// reference and must reuse that exact reference (`x + 0`, `x << 0`,
+    /// nonnegative `abs`, and the other upstream `return self` fast paths).
+    ///
+    /// Keep this separate from ordinary `Clone::clone`: `rbigint.neg` uses
+    /// that operation to construct a fresh handle before changing `_size`.
+    fn is_rbigint_translated_alias(&self, reg: &RegularCall, receiver_ty: Option<&TyRef>) -> bool {
+        let CallKind::Fun(FunId::Regular { id }) = &reg.kind else {
+            return false;
+        };
+        self.llbc.fn_by_id(*id).is_some_and(|fd| {
+            let path = fd.item_meta.name_path();
+            // Charon spells an inherent impl method owned by another crate
+            // either `rbigint::RBigInt::translated_alias` or
+            // `rbigint::<Impl>::translated_alias`, depending on which LLBC
+            // contains the callsite.  The receiver's exact nominal type is
+            // the stable identity across both forms.  Do not use the output:
+            // dependent-crate LLBC represents that foreign return as an
+            // opaque projection, which is precisely why the marker used to
+            // escape as a classdef-less method call.
+            path.ends_with("::translated_alias")
+                && receiver_ty.is_some_and(|ty| tyref_is_rbigint(ty, self.llbc))
+        })
     }
 
     /// A callsite of the reflexive `impl<T> From<T> for T`
@@ -10001,15 +10356,6 @@ impl<'a> Lowering<'a> {
         if !tyref_is_rbigint(src, self.llbc) {
             return Ok(false);
         }
-        // Resolve the destination `Result` decl so the FieldWrite owner
-        // matches what `resolve_aggregate_adt` would record for a real
-        // `Ok(..)` construction site of the same type.
-        let Some(def_id) = self.tyref_adt_def_id(dest_ty) else {
-            return Ok(false);
-        };
-        let Some(td) = self.llbc.type_by_id(def_id) else {
-            return Ok(false);
-        };
         // The synthesized fits test and payload are specifically the signed
         // machine-word conversion.  Other BigInt TryFrom impls (notably
         // `u32::try_from(&value)` in formatting.rs::char_arg) have different
@@ -10027,6 +10373,84 @@ impl<'a> Lowering<'a> {
         ) {
             return Ok(false);
         }
+        self.emit_fallible_rbigint_to_i64(mir_bb, arg.clone(), dest_local, dest_ty, target)
+    }
+
+    /// Lower the exact local `RBigInt::toint() -> Result<i64,
+    /// RBigIntError>` method to the same decomposed Result shape as
+    /// [`Self::try_lower_bigint_i64_try_from`].
+    ///
+    /// RPython's `rbigint.toint` is an elidable, overflow-raising scalar
+    /// operation (`rpython/rlib/rbigint.py:465-485`). Rust carries that
+    /// exceptional edge as `Result`; a dependent LLBC cannot translate into
+    /// the pyre-object method body and otherwise leaves a classdef-less
+    /// residual Result. Its subsequent discriminant/`Ok.__pos_0` reads then
+    /// have no enum class to narrow. Preserve the source control flow by
+    /// materializing the runtime Result tag and payload, using the shared
+    /// non-trapping payload rule below.
+    fn try_lower_rbigint_toint(
+        &mut self,
+        mir_bb: usize,
+        kind: &CallKind,
+        segments: &[String],
+        args: &[Variable],
+        dest_local: usize,
+        dest_ty: &TyRef,
+        target: usize,
+    ) -> Result<bool, LowerError> {
+        if segments.last().map(String::as_str) != Some("toint") {
+            return Ok(false);
+        }
+        let [arg] = args else {
+            return Ok(false);
+        };
+        let CallKind::Fun(FunId::Regular { id }) = kind else {
+            return Ok(false);
+        };
+        let Some(fd) = self.llbc.fn_by_id(*id) else {
+            return Ok(false);
+        };
+        if !fd
+            .signature
+            .inputs
+            .first()
+            .is_some_and(|src| tyref_is_rbigint(src, self.llbc))
+        {
+            return Ok(false);
+        }
+        let Some(success_ty) = self.tyref_adt_type_arg(dest_ty, 0) else {
+            return Ok(false);
+        };
+        if !matches!(
+            self.tyref_literal_int_atom(&success_ty),
+            Some("I64" | "Isize")
+        ) {
+            return Ok(false);
+        }
+        self.emit_fallible_rbigint_to_i64(mir_bb, arg.clone(), dest_local, dest_ty, target)
+    }
+
+    /// Emit the translated Result for a fallible signed-word RBigInt
+    /// conversion. Shared by Rust's direct `RBigInt::toint` spelling and the
+    /// `i64::try_from(&RBigInt)` trait spelling so their tags, class identity,
+    /// eager-payload safety, and residual ABI cannot drift apart.
+    fn emit_fallible_rbigint_to_i64(
+        &mut self,
+        mir_bb: usize,
+        arg: Variable,
+        dest_local: usize,
+        dest_ty: &TyRef,
+        target: usize,
+    ) -> Result<bool, LowerError> {
+        // Resolve the destination `Result` decl so the FieldWrite owner
+        // matches what `resolve_aggregate_adt` records for a real `Ok(..)`
+        // construction site of the same type.
+        let Some(def_id) = self.tyref_adt_def_id(dest_ty) else {
+            return Ok(false);
+        };
+        let Some(td) = self.llbc.type_by_id(def_id) else {
+            return Ok(false);
+        };
         // Route the runtime-discriminant tagged-pair ctor to the SAME
         // per-instantiation enum root a static `Ok(..)`/`Err(..)` mints,
         // by suffixing the bare template name with the `<X>` the
@@ -10037,7 +10461,6 @@ impl<'a> Lowering<'a> {
             td.item_meta.name_path(),
             tyref_enum_instantiation_suffix(dest_ty, self.llbc)
         );
-        let arg = arg.clone();
         let bb_id = self.block_id[mir_bb];
 
         let push_op = |graph: &mut FunctionGraph, kind: OpKind| {
@@ -11115,6 +11538,29 @@ fn is_workspace_index_regular(reg: &RegularCall, llbc: &Llbc) -> bool {
     (leaf == "index" || leaf == "index_mut") && path.starts_with("pyre_")
 }
 
+/// The supported operation on RustPython compiler-core's
+/// `bytecode::Constants<C>` wrapper.
+///
+/// Upstream defines only the relevant `Deref<Target=[C]>::deref` and
+/// `Index<ConstIdx>::index` accessors over its sole `Box<[C]>` field.  Match
+/// through Charon's resolved impl owner rather than a leaf-only test so an
+/// unrelated `index`/`deref` implementation can never acquire this layout.
+fn constants_call_leaf(reg: &RegularCall, llbc: &Llbc) -> Option<&'static str> {
+    let CallKind::Fun(FunId::Regular { id }) = &reg.kind else {
+        return None;
+    };
+    let fd = llbc.fn_by_id(*id)?;
+    let (owner, leaf) = impl_method_owner_for_fundecl(llbc, fd)?;
+    if owner != "bytecode::Constants" {
+        return None;
+    }
+    match leaf.as_str() {
+        "deref" => Some("deref"),
+        "index" => Some("index"),
+        _ => None,
+    }
+}
+
 /// The `Vec<T>` index leaf a statically-resolved [`RegularCall`] resolves
 /// to — `"index"` (`<Vec<T> as Index>::index`, read) or `"index_mut"`
 /// (`<Vec<T> as IndexMut>::index_mut`, write) — restricted to the
@@ -11125,8 +11571,10 @@ fn is_workspace_index_regular(reg: &RegularCall, llbc: &Llbc) -> bool {
 /// so the signature keeps the generic index param `I` (a `TypeVar` typing
 /// as `Ref`); the concrete index type is the callsite substitution
 /// `types[1]` of the impl generics `[T, I, A]`.  `Index<usize>` types as
-/// `Int`; `Index<Range<…>>` resolves to a `Range*` Adt (`Ref`) and returns
-/// `None`.  Owner/leaf are derived the same way [`call_target_segments`]
+/// `Unsigned` and signed integer indices as `Int`; both occupy RPython's
+/// integer register bank. `Index<Range<…>>` resolves to a `Range*` Adt
+/// (`Ref`) and returns `None`. Owner/leaf are derived the same way
+/// [`call_target_segments`]
 /// derives the call key (`impl_method_owner_for_fundecl`).  Free so the
 /// same gate is shared by the call-lowering intercept and the deferred-write
 /// liveness pre-pass.
@@ -11152,7 +11600,12 @@ fn vec_index_regular_leaf(reg: &RegularCall, llbc: &Llbc) -> Option<&'static str
         .and_then(serde_json::Value::as_array)
         .and_then(|tys| tys.get(1))
         .and_then(|t| serde_json::from_value::<TyRef>(t.clone()).ok())
-        .is_some_and(|t| matches!(tyref_to_value_type(&t, llbc), ValueType::Int));
+        .is_some_and(|t| {
+            matches!(
+                tyref_to_value_type(&t, llbc),
+                ValueType::Int | ValueType::Unsigned
+            )
+        });
     int_indexed.then_some(leaf)
 }
 
@@ -12735,10 +13188,10 @@ fn tyref_to_value_type(ty: &TyRef, llbc: &Llbc) -> ValueType {
     if let Some(inner) = tyref_atomic_inner_value_type(ty, llbc) {
         return inner;
     }
-    // `OpArg` is the transparent `struct OpArg(u32)` raw-operand wrapper;
-    // its external decl is `Opaque`, so it would otherwise fall to
-    // `Ref(None)` and shell to a classdef-less instance.  Model it as the
-    // bare integer operand it carries (`tyref_is_oparg`).
+    // `OpArg` and compiler-core's `newtype_oparg!` wrappers are transparent
+    // u32 bytecode operands.  Their dependency declarations are opaque in
+    // interpreter LLBC, so model the exact upstream family as bare integers
+    // (`tyref_is_oparg`).
     if tyref_is_oparg(ty, llbc) {
         return ValueType::Int;
     }
@@ -13189,15 +13642,15 @@ fn tyref_is_bytecode_arg_marker(ty: &TyRef, llbc: &Llbc) -> bool {
         .is_some_and(|p| p == "rustpython_compiler_core::bytecode::instruction::Arg")
 }
 
-/// Whether a `TyRef` resolves (behind reference wrappers) to the
-/// `rustpython_compiler_core::bytecode::oparg::OpArg` newtype.  `OpArg`
-/// is the transparent `struct OpArg(u32)` raw-operand wrapper; its
-/// external decl is `Opaque` in the LLBC, so a payload row spelled
-/// through it would project to an attr the annotator cannot type.  The
-/// value is only ever the raw u32 operand (constructed from a `u32`,
-/// consumed by `Arg::get` / `u32::from`), so the lifted model carries it
-/// as a plain integer wherever it appears — matching upstream, where the
-/// bytecode operand is a bare int with no wrapper type.
+/// Whether a `TyRef` resolves (behind reference wrappers) to an exact
+/// RustPython compiler-core transparent bytecode-oparg integer wrapper.
+///
+/// `OpArg` and every type emitted by upstream's `newtype_oparg!` macro are
+/// `#[repr(transparent)] struct Name(u32)`.  They are opaque dependency
+/// declarations in `pyre-interpreter.ullbc`, so their source shape cannot be
+/// rediscovered structurally there; keep the literal upstream macro product
+/// list instead.  Multi-field oparg records and fieldless oparg enums are not
+/// included (the latter take the separate discriminant-int path).
 fn tyref_is_oparg(ty: &TyRef, llbc: &Llbc) -> bool {
     let Some(node) = tyref_node(ty, llbc).and_then(|n| strip_ty_wrappers(n, llbc)) else {
         return false;
@@ -13208,13 +13661,21 @@ fn tyref_is_oparg(ty: &TyRef, llbc: &Llbc) -> bool {
     let Some(td) = llbc.type_by_id(id) else {
         return false;
     };
-    // Cheap leaf check before the full path-string comparison: bail
-    // unless the type's last segment is the `OpArg` ident.
-    let leaf_is_oparg = matches!(
-        td.item_meta.name.last(),
-        Some(NameSeg::Ident { ident: (s, _) }) if s == "OpArg"
-    );
-    leaf_is_oparg && td.item_meta.name_path().ends_with("oparg::OpArg")
+    let path = td.item_meta.name_path();
+    let Some(leaf) = path.strip_prefix("rustpython_compiler_core::bytecode::oparg::") else {
+        return false;
+    };
+    matches!(
+        leaf,
+        "OpArg"
+            | "ConstIdx"
+            | "VarNum"
+            | "VarNums"
+            | "LoadAttr"
+            | "LoadSuperAttr"
+            | "Label"
+            | "ResumeContext"
+    )
 }
 
 /// The ADT def_id of an (already wrapper-stripped) type node, or
@@ -14260,16 +14721,16 @@ fn option_payload_tuple_suffix(recv_ty: &TyRef, llbc: &Llbc) -> String {
 /// generic enum `Option<…>`, a tuple of references) are one word-sized GC
 /// pointer; the scalar integer/bool/char primitives are unboxed but each
 /// carries a well-defined int-banked repr, so all of these split.
-/// Excluded:
-///   - `f32`/`f64` — float bank; deferred until the codewriter field-descr
-///     carries the concrete bank (a suffixed-owner `setfield_gc_f`
-///     otherwise falls back to a GC-word descr).
+/// Float payloads split too: the per-instantiation row records `f32`/`f64`,
+/// and the codewriter's `get_type_flag`/`type_flag_from_str` selects the
+/// float bank, producing `setfield_gc_f`/`getfield_gc_f` rather than the
+/// generic GC-word fallback.  Excluded:
 ///   - `()` — the unit-`Ok` return widens to a genuine void return
 ///     (`widen_unit_return_to_void`) and never materialises a payload field.
 ///   - `""` — a degenerate/absent type-arg that would render a malformed
 ///     `<>` suffix.
 fn type_arg_splits_per_instantiation(arg: &str) -> bool {
-    const DEFERRED: &[&str] = &["f32", "f64", "()", ""];
+    const DEFERRED: &[&str] = &["()", ""];
     !DEFERRED.contains(&arg)
 }
 
@@ -14525,8 +14986,8 @@ fn strip_crate_prefix(path: &str) -> String {
     }
 }
 
-/// True for the `ItemsBlock` items-base accessor bodies whose
-/// `.add(ITEMS_BLOCK_ITEMS_OFFSET)` the front-end collapses to the
+/// True for the `ItemsBlock` / `TypedItemsBlock` items-base accessor bodies
+/// whose `.add(*_ITEMS_OFFSET)` the front-end collapses to the
 /// receiver (see [`Lowering::is_items_block_base_ptr_add`]).  Matched on
 /// the module-qualified path so a leaf collision in another module
 /// cannot widen the gate, and crate-prefix-independent so the same
@@ -14535,6 +14996,7 @@ fn strip_crate_prefix(path: &str) -> String {
 fn graph_is_items_block_base_accessor(name: &str) -> bool {
     name.ends_with("object_array::items_block_items_base")
         || name.ends_with("object_array::items_block_items_ptr")
+        || name.ends_with("object_array::typed_items_block_items_base")
 }
 
 /// One path segment, with a raw-identifier prefix removed.  `r#struct` and
@@ -17536,7 +17998,7 @@ mod tests {
     }
 
     #[test]
-    fn type_arg_splits_per_instantiation_defers_only_float_unit_empty() {
+    fn type_arg_splits_per_instantiation_defers_only_unit_and_empty() {
         use super::type_arg_splits_per_instantiation;
         // Bare named heap classes split (1-word GC pointer in the
         // erased model).
@@ -17555,9 +18017,12 @@ mod tests {
         ] {
             assert!(type_arg_splits_per_instantiation(p), "{p} must split");
         }
-        // Deferred: floats (float bank, codewriter descr not yet bank-aware)
-        // and the unit/degenerate atoms (no materialised payload field).
-        for p in ["f32", "f64", "()", ""] {
+        // Float payloads carry a concrete float-bank field descriptor.
+        for p in ["f32", "f64"] {
+            assert!(type_arg_splits_per_instantiation(p), "{p} must split");
+        }
+        // Deferred: unit/degenerate atoms have no materialised payload field.
+        for p in ["()", ""] {
             assert!(!type_arg_splits_per_instantiation(p), "{p} must not split");
         }
     }
@@ -17769,9 +18234,9 @@ mod tests {
     fn items_block_base_accessor_gate_excludes_deref_in_place() {
         use super::graph_is_items_block_base_accessor;
 
-        // The two accessors whose `.add(ITEMS_BLOCK_ITEMS_OFFSET)` body
-        // returns the interior items pointer for descr-based consumption —
-        // safe to collapse to the receiver, regardless of crate prefix.
+        // The object and typed-array accessors whose `.add(*_ITEMS_OFFSET)`
+        // body returns the interior items pointer for descr-based consumption
+        // are safe to collapse to the receiver, regardless of crate prefix.
         assert!(graph_is_items_block_base_accessor(
             "pyre_object::object_array::items_block_items_base"
         ));
@@ -17780,6 +18245,9 @@ mod tests {
         ));
         assert!(graph_is_items_block_base_accessor(
             "pyre_jit::object_array::items_block_items_base"
+        ));
+        assert!(graph_is_items_block_base_accessor(
+            "pyre_object::object_array::typed_items_block_items_base"
         ));
 
         // Bodies that dereference a `.add(NAMED_OFFSET)` interior pointer
@@ -19188,6 +19656,244 @@ mod tests {
         );
         assert_eq!(chain.args.len(), 1);
         assert_eq!(chain.args[0].kind, FmtArgKind::Display);
+    }
+
+    /// Anchor compiler-core's exact
+    /// `Constants(Box<[C]>)::{deref,index}` storage shape to the real
+    /// interpreter LLBC.  `constant_at` must project the wrapper's sole field
+    /// and index that list; `code_getdocstring` must project the same field
+    /// for its slice view.  Neither accessor may survive as a residual call.
+    #[test]
+    #[ignore]
+    fn constants_wrapper_access_matches_real_interpreter_llbc() {
+        use crate::model::{CallTarget, OpKind, ValueType};
+
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../build/llbc/pyre-interpreter.ullbc"
+        );
+        let llbc = Llbc::load(path).expect("load real LLBC");
+        let (_, _, fields, _, _, attrs, _, _) = super::derive_program_metadata(&llbc);
+        assert_eq!(
+            fields.fields.get("Constants"),
+            Some(&vec![(
+                "__pos_0".to_string(),
+                "Box<[ConstantData]>".to_string()
+            )])
+        );
+        assert_eq!(
+            attrs.get("bytecode::Constants"),
+            Some(&vec![("__pos_0".to_string(), ValueType::Ref(None))])
+        );
+        assert_eq!(
+            fields.fields.get("ConstantData::Integer"),
+            Some(&vec![("value".to_string(), "BigInt".to_string())])
+        );
+        assert_eq!(
+            fields.fields.get("ConstantData::Complex"),
+            Some(&vec![("value".to_string(), "Complex<f64>".to_string())])
+        );
+        assert_eq!(
+            fields.fields.get("ConstantData::Str"),
+            Some(&vec![("value".to_string(), "Wtf8Buf".to_string())])
+        );
+        assert_eq!(
+            fields.fields.get("ConstantData::Code"),
+            Some(&vec![(
+                "code".to_string(),
+                "Box<CodeObject<ConstantData>>".to_string()
+            )])
+        );
+        assert_eq!(
+            fields.fields.get("Complex"),
+            Some(&vec![
+                ("re".to_string(), "f64".to_string()),
+                ("im".to_string(), "f64".to_string()),
+            ])
+        );
+        assert_eq!(
+            attrs.get("num_complex::Complex"),
+            Some(&vec![
+                ("re".to_string(), ValueType::Float),
+                ("im".to_string(), ValueType::Float),
+            ])
+        );
+
+        let constant_at = super::lower_function(&llbc, "constant_at")
+            .expect("lower ConstantOpcodeHandler::constant_at");
+        let constant_ops: Vec<_> = constant_at
+            .blocks
+            .iter()
+            .flat_map(|block| block.operations.iter())
+            .collect();
+        assert!(
+            constant_ops.iter().any(|op| {
+                matches!(
+                    op.kind,
+                    OpKind::Input {
+                        ty: ValueType::Int,
+                        ..
+                    }
+                )
+            }),
+            "ConstIdx input must use RPython's integer oparg representation"
+        );
+        assert!(constant_ops.iter().any(|op| {
+            matches!(
+                &op.kind,
+                OpKind::FieldRead { field, .. }
+                    if field.name == "__pos_0"
+                        && field.owner_root.as_deref() == Some("Constants")
+            )
+        }));
+        assert!(
+            constant_ops
+                .iter()
+                .any(|op| matches!(op.kind, OpKind::ArrayRead { .. }))
+        );
+        assert!(!constant_ops.iter().any(|op| {
+            matches!(
+                &op.kind,
+                OpKind::Call {
+                    target: CallTarget::FunctionPath { segments },
+                    ..
+                } if segments.ends_with(&["Constants".to_string(), "index".to_string()])
+            )
+        }));
+
+        let getdocstring =
+            super::lower_function(&llbc, "code_getdocstring").expect("lower code_getdocstring");
+        let doc_ops: Vec<_> = getdocstring
+            .blocks
+            .iter()
+            .flat_map(|block| block.operations.iter())
+            .collect();
+        assert!(doc_ops.iter().any(|op| {
+            matches!(
+                &op.kind,
+                OpKind::FieldRead { field, .. }
+                    if field.name == "__pos_0"
+                        && field.owner_root.as_deref() == Some("Constants")
+            )
+        }));
+        assert!(!doc_ops.iter().any(|op| {
+            matches!(
+                &op.kind,
+                OpKind::Call {
+                    target: CallTarget::FunctionPath { segments },
+                    ..
+                } if segments.ends_with(&["Constants".to_string(), "deref".to_string()])
+            )
+        }));
+
+        let load_const = super::lower_function(&llbc, "load_const_value")
+            .expect("lower rbigint-consuming load_const_value");
+        let load_ops: Vec<_> = load_const
+            .blocks
+            .iter()
+            .flat_map(|block| block.operations.iter())
+            .collect();
+        assert!(load_ops.iter().any(|op| {
+            matches!(
+                &op.kind,
+                OpKind::Input {
+                    name,
+                    class_root: Some(root),
+                    ..
+                } if name == "constant" && root == "ConstantData"
+            )
+        }));
+
+        // `PyFrame::bigint_constant(&RBigInt)` is the LOAD_CONST consumer
+        // that boxes the already-translated payload. Anchor its ABI rewrite
+        // to the real interpreter LLBC: no by-value `w_long_new` call may
+        // survive, and the existing GC reference must flow to
+        // `w_long_from_raw`.
+        let mut boxed_handlers = 0usize;
+        for fd in llbc.iter_local_fns().filter(|fd| {
+            fd.item_meta.name_path().ends_with("::bigint_constant") && fd.unstructured().is_some()
+        }) {
+            let graph = super::lower_fun_decl(&llbc, fd)
+                .unwrap_or_else(|e| panic!("lower {}: {e:?}", fd.item_meta.name_path()));
+            let calls: Vec<&[String]> = graph
+                .blocks
+                .iter()
+                .flat_map(|block| block.operations.iter())
+                .filter_map(|op| match &op.kind {
+                    OpKind::Call {
+                        target: CallTarget::FunctionPath { segments },
+                        ..
+                    } => Some(segments.as_slice()),
+                    _ => None,
+                })
+                .collect();
+            if calls
+                .iter()
+                .any(|segments| segments.last().map(String::as_str) == Some("w_long_from_raw"))
+            {
+                boxed_handlers += 1;
+                assert!(!calls.iter().any(|segments| {
+                    matches!(
+                        segments.last().map(String::as_str),
+                        Some(
+                            "w_long_new"
+                                | "w_long_new_fresh_rbigint_handle"
+                                | "box_bigint_constant"
+                        )
+                    )
+                }));
+            }
+        }
+        assert!(
+            boxed_handlers >= 1,
+            "real LOAD_CONST bigint handler must use the RBigInt pointer boxing ABI"
+        );
+        assert!(
+            load_ops
+                .iter()
+                .any(|op| matches!(op.kind, OpKind::ArrayRead { .. }))
+        );
+        assert!(!load_ops.iter().any(|op| {
+            matches!(
+                &op.kind,
+                OpKind::Call {
+                    target: CallTarget::FunctionPath { segments },
+                    ..
+                } if segments.ends_with(&[
+                    "vec".to_string(),
+                    "Vec".to_string(),
+                    "index".to_string()
+                ])
+            )
+        }));
+        assert!(!load_ops.iter().any(|op| {
+            matches!(
+                &op.kind,
+                OpKind::Call {
+                    target: CallTarget::FunctionPath { segments },
+                    ..
+                } if segments.last().map(String::as_str) == Some("toint")
+            )
+        }));
+        for residual in ["jit_bigint_to_i64_value_or_zero", "jit_bigint_to_i64_fits"] {
+            assert!(load_ops.iter().any(|op| {
+                matches!(
+                    &op.kind,
+                    OpKind::Call {
+                        target: CallTarget::FunctionPath { segments },
+                        ..
+                    } if segments.last().map(String::as_str) == Some(residual)
+                )
+            }));
+        }
+        assert!(load_ops.iter().any(|op| {
+            matches!(
+                &op.kind,
+                OpKind::FieldWrite { field, .. }
+                    if field.name == "__discriminant"
+                        && field.owner_root.as_deref().is_some_and(|root| root.contains("Result<i64,RBigIntError>"))
+            )
+        }));
     }
 
     #[test]

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -14670,7 +14670,7 @@ fn tyref_tuple_suffix(ty: &TyRef, llbc: &Llbc) -> String {
 /// payload — the spelling a static `Some(..)`/`Ok(..)` construction already
 /// mints.  Extracts `ty`'s `{"Adt": …}` node (as [`tyref_tuple_suffix`]
 /// does) and defers to [`adt_head_instantiation_suffix`], already RC2-gated
-/// (an `f32`/`f64`/`()`/`""` argument yields `None`).  Fail-closed: a
+/// (an `f32`/`()`/`""` argument yields `None`).  Fail-closed: a
 /// missing `Adt` node, a non-enum type, or a deferred argument yields `""` —
 /// the bare owner, unchanged.
 fn tyref_enum_instantiation_suffix(ty: &TyRef, llbc: &Llbc) -> String {
@@ -14748,16 +14748,19 @@ fn option_payload_tuple_suffix(recv_ty: &TyRef, llbc: &Llbc) -> String {
 /// generic enum `Option<…>`, a tuple of references) are one word-sized GC
 /// pointer; the scalar integer/bool/char primitives are unboxed but each
 /// carries a well-defined int-banked repr, so all of these split.
-/// Float payloads split too: the per-instantiation row records `f32`/`f64`,
-/// and the codewriter's `get_type_flag`/`type_flag_from_str` selects the
-/// float bank, producing `setfield_gc_f`/`getfield_gc_f` rather than the
-/// generic GC-word fallback.  Excluded:
+/// An `f64` payload splits too: the per-instantiation row records `f64`, and
+/// the codewriter's `get_type_flag`/`type_flag_from_str` selects the float
+/// bank, producing `setfield_gc_f`/`getfield_gc_f` rather than the generic
+/// GC-word fallback.  Excluded:
+///   - `f32` — RPython's `SingleFloat` is int-banked (`getkind(...) == "int"`),
+///     while the textual field-descriptor path still classifies float atoms
+///     as float-banked. Defer the split until both paths agree.
 ///   - `()` — the unit-`Ok` return widens to a genuine void return
 ///     (`widen_unit_return_to_void`) and never materialises a payload field.
 ///   - `""` — a degenerate/absent type-arg that would render a malformed
 ///     `<>` suffix.
 fn type_arg_splits_per_instantiation(arg: &str) -> bool {
-    const DEFERRED: &[&str] = &["()", ""];
+    const DEFERRED: &[&str] = &["f32", "()", ""];
     !DEFERRED.contains(&arg)
 }
 
@@ -18025,7 +18028,7 @@ mod tests {
     }
 
     #[test]
-    fn type_arg_splits_per_instantiation_defers_only_unit_and_empty() {
+    fn type_arg_splits_per_instantiation_defers_singlefloat_unit_and_empty() {
         use super::type_arg_splits_per_instantiation;
         // Bare named heap classes split (1-word GC pointer in the
         // erased model).
@@ -18044,12 +18047,11 @@ mod tests {
         ] {
             assert!(type_arg_splits_per_instantiation(p), "{p} must split");
         }
-        // Float payloads carry a concrete float-bank field descriptor.
-        for p in ["f32", "f64"] {
-            assert!(type_arg_splits_per_instantiation(p), "{p} must split");
-        }
-        // Deferred: unit/degenerate atoms have no materialised payload field.
-        for p in ["()", ""] {
+        // DoubleFloat is float-banked. SingleFloat is int-banked in RPython,
+        // so it remains deferred until the textual descriptor path agrees.
+        assert!(type_arg_splits_per_instantiation("f64"));
+        // Unit/degenerate atoms have no materialised payload field.
+        for p in ["f32", "()", ""] {
             assert!(!type_arg_splits_per_instantiation(p), "{p} must not split");
         }
     }

--- a/majit/majit-translate/src/front/rbigint_call.rs
+++ b/majit/majit-translate/src/front/rbigint_call.rs
@@ -180,23 +180,27 @@ pub(crate) fn int_comparison_residual_for_method(leaf: &str) -> Option<Vec<Strin
 /// rule in `result_exc` removes the `Result` diamond; this target swap supplies
 /// the matching one-GC-reference result ABI.
 pub(crate) fn pow_nomod_residual_path(segments: &[String]) -> Option<Vec<String>> {
-    if !segments.ends_with(&[
-        "objspace".to_string(),
-        "descroperation".to_string(),
-        "bigint_pow_nomod".to_string(),
-    ]) {
+    // `bigint_int_pow_nomod` is the machine-int-exponent leg `descr_pow` takes
+    // for a `W_IntObject` exponent; its carrier and pointer result ABI match.
+    let residual = match segments.last().map(String::as_str) {
+        Some("bigint_pow_nomod") => "jit_bigint_pow_nomod",
+        Some("bigint_int_pow_nomod") => "jit_bigint_int_pow_nomod",
+        _ => return None,
+    };
+    if !segments
+        .iter()
+        .rev()
+        .skip(1)
+        .take(2)
+        .eq(["descroperation", "objspace"])
+    {
         return None;
     }
     Some(
-        [
-            "pyre_interpreter",
-            "objspace",
-            "descroperation",
-            "jit_bigint_pow_nomod",
-        ]
-        .into_iter()
-        .map(str::to_string)
-        .collect(),
+        ["pyre_interpreter", "objspace", "descroperation", residual]
+            .into_iter()
+            .map(str::to_string)
+            .collect(),
     )
 }
 
@@ -250,6 +254,11 @@ pub(crate) fn divmod_projection_residual_path(segments: &[String]) -> Option<Vec
     let residual = match segments.last().map(String::as_str) {
         Some("bigint_floordiv_nonzero") => "jit_bigint_div_floor",
         Some("bigint_modulo_nonzero") => "jit_bigint_mod_floor",
+        // Machine-int-divisor quotient leg (`_int_floordiv`): the divisor is
+        // already a bare word, so this swap stays ABI-identical. The `_int_mod`
+        // leg has no entry — `int_mod_int_result` yields a machine int, while
+        // every result in this map is modeled as a GC reference.
+        Some("bigint_int_floordiv_nonzero") => "jit_bigint_int_div_floor",
         _ => return None,
     };
     if !segments

--- a/majit/majit-translate/src/front/rbigint_call.rs
+++ b/majit/majit-translate/src/front/rbigint_call.rs
@@ -466,6 +466,20 @@ mod tests {
             pow_nomod_residual_path(&segs(&["pyre_object", "rbigint", "RBigInt", "pow",]))
                 .is_none()
         );
+        assert_eq!(
+            pow_nomod_residual_path(&segs(&[
+                "pyre_interpreter",
+                "objspace",
+                "descroperation",
+                "bigint_int_pow_nomod",
+            ])),
+            Some(segs(&[
+                "pyre_interpreter",
+                "objspace",
+                "descroperation",
+                "jit_bigint_int_pow_nomod",
+            ]))
+        );
     }
 
     #[test]
@@ -527,6 +541,7 @@ mod tests {
         for (source, residual) in [
             ("bigint_floordiv_nonzero", "jit_bigint_div_floor"),
             ("bigint_modulo_nonzero", "jit_bigint_mod_floor"),
+            ("bigint_int_floordiv_nonzero", "jit_bigint_int_div_floor"),
         ] {
             assert_eq!(
                 divmod_projection_residual_path(&segs(&[

--- a/majit/majit-translate/src/front/rbigint_call.rs
+++ b/majit/majit-translate/src/front/rbigint_call.rs
@@ -75,6 +75,32 @@ pub(crate) fn clone_residual_for_method(leaf: &str) -> Option<Vec<String>> {
     )
 }
 
+/// Retarget the Rust ownership spelling `w_long_new(RBigInt)` to the pointer
+/// ABI used by translated rbigints.
+///
+/// At source level an `RBigInt` is a by-value two-word Rust handle and
+/// `w_long_new` first allocates its GC payload. After translation that same
+/// value is already the one-GC-reference rbigint object, exactly as in
+/// RPython. Re-boxing it as a by-value Rust argument would both use the wrong
+/// residual ABI and allocate a redundant payload. The caller proves the sole
+/// argument is the exact local RBigInt ADT before applying this target swap.
+pub(crate) fn long_box_residual_path(segments: &[String]) -> Option<Vec<String>> {
+    let leaf = segments.last().map(String::as_str)?;
+    if !matches!(
+        leaf,
+        "w_long_new" | "w_long_new_fresh_rbigint_handle" | "box_bigint_constant"
+    ) || segments.iter().rev().nth(1).map(String::as_str) != Some("longobject")
+    {
+        return None;
+    }
+    Some(
+        ["pyre_object", "longobject", "w_long_from_raw"]
+            .into_iter()
+            .map(str::to_string)
+            .collect(),
+    )
+}
+
 /// Bare-payload residual for scalar RBigInt queries. The caller has already
 /// proved exact RBigInt receiver identity.
 pub(crate) fn scalar_residual_for_method(leaf: &str) -> Option<(Vec<String>, ScalarResult)> {
@@ -209,23 +235,25 @@ pub(crate) fn pow_nomod_residual_path(segments: &[String]) -> Option<Vec<String>
 /// MemoryError through Rust source. `result_exc` removes that carrier after
 /// this target swap supplies the one-GC-reference residual result.
 pub(crate) fn lshift_count_residual_path(segments: &[String]) -> Option<Vec<String>> {
-    if !segments.ends_with(&[
-        "objspace".to_string(),
-        "descroperation".to_string(),
-        "bigint_lshift_count".to_string(),
-    ]) {
+    let residual = match segments.last().map(String::as_str) {
+        Some("bigint_lshift_count") => "jit_bigint_lshift_count",
+        Some("bigint_lshift_int_int_result") => "jit_bigint_lshift_int_int_result",
+        _ => return None,
+    };
+    if !segments
+        .iter()
+        .rev()
+        .skip(1)
+        .take(2)
+        .eq(["descroperation", "objspace"])
+    {
         return None;
     }
     Some(
-        [
-            "pyre_interpreter",
-            "objspace",
-            "descroperation",
-            "jit_bigint_lshift_count",
-        ]
-        .into_iter()
-        .map(str::to_string)
-        .collect(),
+        ["pyre_interpreter", "objspace", "descroperation", residual]
+            .into_iter()
+            .map(str::to_string)
+            .collect(),
     )
 }
 
@@ -317,6 +345,26 @@ mod tests {
             Some(segs(&["pyre_object", "longobject", "jit_bigint_clone"]))
         );
         assert!(clone_residual_for_method("clone_from").is_none());
+    }
+
+    #[test]
+    fn maps_translated_long_boxing_to_pointer_abi() {
+        let expected = segs(&["pyre_object", "longobject", "w_long_from_raw"]);
+        for leaf in [
+            "w_long_new",
+            "w_long_new_fresh_rbigint_handle",
+            "box_bigint_constant",
+        ] {
+            assert_eq!(
+                long_box_residual_path(&segs(&["pyre_object", "longobject", leaf])),
+                Some(expected.clone())
+            );
+        }
+        assert!(
+            long_box_residual_path(&segs(&["other", "longobject", "w_long_new"])).is_some(),
+            "crate prefix is intentionally irrelevant; module/leaf and exact argument type identify the call"
+        );
+        assert!(long_box_residual_path(&segs(&["pyre_object", "other", "w_long_new"])).is_none());
     }
 
     #[test]
@@ -434,6 +482,20 @@ mod tests {
                 "objspace",
                 "descroperation",
                 "jit_bigint_lshift_count",
+            ]))
+        );
+        assert_eq!(
+            lshift_count_residual_path(&segs(&[
+                "pyre_interpreter",
+                "objspace",
+                "descroperation",
+                "bigint_lshift_int_int_result",
+            ])),
+            Some(segs(&[
+                "pyre_interpreter",
+                "objspace",
+                "descroperation",
+                "jit_bigint_lshift_int_int_result",
             ]))
         );
         assert!(

--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -62,7 +62,9 @@ use crate::flowspace::model::{
 use crate::flowspace::pygraph::PyGraph;
 use crate::model::FunctionGraph as LegacyGraph;
 use crate::translator::rtyper::error::TyperError;
-use crate::translator::rtyper::flowspace_adapter::{FlowspaceAdapterOutput, LegacyToTyped};
+use crate::translator::rtyper::flowspace_adapter::{
+    FlowspaceAdapterOutput, LegacyToTyped, LegacyToTypedCandidates,
+};
 use crate::translator::rtyper::lltypesystem::lltype::LowLevelType;
 use crate::translator::rtyper::pyre_call_registry::{
     FunctionPathKey, PyreCallRegistry, PyreFunctionEntry,
@@ -308,21 +310,18 @@ pub(crate) fn dual_gate_check_with_registry(
     // stringified error so the env-flag wrapper can decide whether
     // to panic, log, or skip.
     //
-    // Snapshot the session's `fixed_graphs` keys so the failure arms
-    // below can identify the shared callee graphs this subject fixed
-    // (and partially LL-rewrote) before it failed — see
+    // Snapshot the session so the failure arms below can identify both
+    // shared callees this subject newly fixed and previously-annotated
+    // callees whose bindings it evicted while reflowing them — see
     // `unpoison_failed_subject_callees`.
-    let fixed_at_entry: HashSet<crate::flowspace::model::GraphKey> = call_registry
-        .session_if_started()
-        .map(|(ann, _)| ann.fixed_graphs.borrow().keys().cloned().collect())
-        .unwrap_or_default();
+    let session_at_entry = SubjectSessionSnapshot::capture(call_registry);
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         specialize_legacy_graph_with_registry_returning_value_to_var(legacy_graph, call_registry)
     }));
     let (real_value_to_var, real_constants) = match result {
         Ok(Ok(pair)) => pair,
         Ok(Err(e)) => {
-            unpoison_failed_subject_callees(call_registry, &fixed_at_entry, lift_sources);
+            unpoison_failed_subject_callees(call_registry, &session_at_entry, lift_sources);
             let msg = format!("{e}");
             if is_known_unported(&msg) {
                 return Ok(DualGateOutcome::Skip(msg));
@@ -330,7 +329,7 @@ pub(crate) fn dual_gate_check_with_registry(
             return Err(format!("real path failed: {msg}"));
         }
         Err(payload) => {
-            unpoison_failed_subject_callees(call_registry, &fixed_at_entry, lift_sources);
+            unpoison_failed_subject_callees(call_registry, &session_at_entry, lift_sources);
             let msg = if let Some(s) = payload.downcast_ref::<&'static str>() {
                 (*s).to_string()
             } else if let Some(s) = payload.downcast_ref::<String>() {
@@ -403,32 +402,153 @@ pub(crate) fn dual_gate_check_with_registry(
 ///   so `total_calltable_size` and `get_concrete_calltable`'s size
 ///   invariant hold; the family's cached concrete calltable is
 ///   dropped so it rebuilds against the fresh graph)
+#[derive(Default)]
+struct SubjectSessionSnapshot {
+    fixed_graphs: HashSet<crate::flowspace::model::GraphKey>,
+    annotated_blocks: Vec<AnnotatedBlockSnapshot>,
+}
+
+struct AnnotatedBlockSnapshot {
+    key: crate::flowspace::model::BlockKey,
+    block: crate::flowspace::model::BlockRef,
+    graph: crate::flowspace::model::GraphRef,
+    definitions: Vec<(
+        crate::flowspace::model::Variable,
+        Option<Rc<crate::annotator::model::SomeValue>>,
+    )>,
+}
+
+impl SubjectSessionSnapshot {
+    fn capture(call_registry: &PyreCallRegistry) -> Self {
+        Self::capture_inner(call_registry, true)
+    }
+
+    fn capture_fixed_only(call_registry: &PyreCallRegistry) -> Self {
+        Self::capture_inner(call_registry, false)
+    }
+
+    fn capture_inner(call_registry: &PyreCallRegistry, include_annotations: bool) -> Self {
+        let Some((annotator, _)) = call_registry.session_if_started() else {
+            return Self::default();
+        };
+        let fixed_graphs = annotator.fixed_graphs.borrow().keys().cloned().collect();
+        if !include_annotations {
+            return Self {
+                fixed_graphs,
+                annotated_blocks: Vec::new(),
+            };
+        }
+        let annotated = annotator.annotated.borrow();
+        let all_blocks = annotator.all_blocks.borrow();
+        let mut annotated_blocks = Vec::new();
+        for (bkey, graph) in annotated.iter() {
+            let Some(graph) = graph else {
+                continue;
+            };
+            let Some(block) = all_blocks.get(bkey) else {
+                continue;
+            };
+            let definitions = {
+                let block = block.borrow();
+                block
+                    .inputargs
+                    .iter()
+                    .chain(block.operations.iter().map(|op| &op.result))
+                    .filter_map(|value| match value {
+                        Hlvalue::Variable(var) => {
+                            Some((var.clone(), var.annotation.borrow().clone()))
+                        }
+                        _ => None,
+                    })
+                    .collect()
+            };
+            annotated_blocks.push(AnnotatedBlockSnapshot {
+                key: bkey.clone(),
+                block: block.clone(),
+                graph: graph.clone(),
+                definitions,
+            });
+        }
+        Self {
+            fixed_graphs,
+            annotated_blocks,
+        }
+    }
+}
+
 fn unpoison_failed_subject_callees(
     call_registry: &PyreCallRegistry,
-    fixed_at_entry: &HashSet<crate::flowspace::model::GraphKey>,
+    session_at_entry: &SubjectSessionSnapshot,
     lift_sources: &crate::codewriter::call::GraphStore,
 ) {
     let Some((annotator, rtyper)) = call_registry.session_if_started() else {
         return;
     };
-    let newly_fixed: Vec<(
+    // `AddedBlocksGuard` can remove a block that was already healthy at
+    // subject entry because RPython's `added_blocks` records every
+    // reprocessed block, not only newly discovered ones. Restore the
+    // exact pre-subject annotation cells and ownership rows before
+    // repairing any graph that advanced into LL form. This is the
+    // transaction rollback required only by pyre's continue-after-Skip
+    // driver; upstream aborts the single Translator on the same error.
+    for saved in &session_at_entry.annotated_blocks {
+        annotator
+            .annotated
+            .borrow_mut()
+            .insert(saved.key.clone(), Some(saved.graph.clone()));
+        annotator
+            .all_blocks
+            .borrow_mut()
+            .insert(saved.key.clone(), saved.block.clone());
+        annotator
+            .blocked_blocks
+            .borrow_mut()
+            .shift_remove(&saved.key);
+        for (var, annotation) in &saved.definitions {
+            *var.annotation.borrow_mut() = annotation.clone();
+        }
+    }
+    if !session_at_entry.annotated_blocks.is_empty() {
+        let restored_keys: HashSet<_> = session_at_entry
+            .annotated_blocks
+            .iter()
+            .map(|saved| saved.key.clone())
+            .collect();
+        for generation in annotator.genpendingblocks.borrow_mut().iter_mut() {
+            generation.retain(|bkey, _| !restored_keys.contains(bkey));
+        }
+    }
+
+    let stale_graphs: HashMap<
         crate::flowspace::model::GraphKey,
         crate::flowspace::model::GraphRef,
-    )> = annotator
+    > = annotator
         .fixed_graphs
         .borrow()
         .iter()
-        .filter(|(k, _)| !fixed_at_entry.contains(*k))
+        .filter(|(k, _)| !session_at_entry.fixed_graphs.contains(*k))
         .map(|(k, g)| (k.clone(), g.clone()))
         .collect();
-    for (gkey, stale) in newly_fixed {
+
+    for (gkey, stale) in stale_graphs {
         annotator.fixed_graphs.borrow_mut().shift_remove(&gkey);
-        for block in stale.borrow().iterblocks() {
-            rtyper
-                .already_seen
-                .borrow_mut()
-                .remove(&crate::flowspace::model::BlockKey::of(&block));
+        let stale_blocks = stale.borrow().iterblocks();
+        let stale_block_keys: HashSet<crate::flowspace::model::BlockKey> = stale_blocks
+            .iter()
+            .map(crate::flowspace::model::BlockKey::of)
+            .collect();
+        for block in &stale_blocks {
+            let bkey = crate::flowspace::model::BlockKey::of(block);
+            annotator.annotated.borrow_mut().shift_remove(&bkey);
+            annotator.all_blocks.borrow_mut().shift_remove(&bkey);
+            annotator.blocked_blocks.borrow_mut().shift_remove(&bkey);
+            annotator.failed_blocks.borrow_mut().shift_remove(&bkey);
+            rtyper.already_seen.borrow_mut().remove(&bkey);
         }
+        for generation in annotator.genpendingblocks.borrow_mut().iter_mut() {
+            generation.retain(|bkey, _| !stale_block_keys.contains(bkey));
+        }
+        annotator.blocked_graphs.borrow_mut().shift_remove(&gkey);
         annotator
             .translator
             .graphs
@@ -528,6 +648,51 @@ fn project_value_to_var(
         }
     }
     real_state
+}
+
+/// Select the typed block-local representative of each legacy MIR Variable.
+///
+/// RPython flowspace gives every block inputarg its own Variable definition,
+/// while pyre's pre-adapter MIR can reuse one Variable identity for an op
+/// result and the phi columns of several successor blocks. The adapter
+/// therefore creates several orthodox typed Variables for one legacy key.
+/// Simplification can remove the initially preferred producer while leaving a
+/// successor representative live and rtyped. Repoint the projection map to a
+/// live representative after Phase B; this is identity reconciliation, not a
+/// kind backfill—the rtyper must have positively assigned the lltype.
+fn select_rtyped_representatives(
+    value_to_var: &mut LegacyToTyped,
+    candidates: &LegacyToTypedCandidates,
+) -> Result<(), TyperError> {
+    for (legacy, vars) in candidates {
+        if value_to_var
+            .get(legacy)
+            .is_some_and(|var| var.concretetype.borrow().is_some())
+        {
+            continue;
+        }
+        let mut selected: Option<(Variable, ConcreteType)> = None;
+        for candidate in vars {
+            let Some(lltype) = candidate.concretetype.borrow().clone() else {
+                continue;
+            };
+            let kind = lowleveltype_to_concrete(&lltype)?;
+            if let Some((_, selected_kind)) = &selected {
+                if *selected_kind != kind {
+                    return Err(TyperError::message(format!(
+                        "block-local representatives of one legacy Variable disagree: \
+                         {selected_kind:?} vs {kind:?} for {legacy:?}"
+                    )));
+                }
+            } else {
+                selected = Some((candidate.clone(), kind));
+            }
+        }
+        if let Some((selected, _)) = selected {
+            value_to_var.insert(legacy.clone(), selected);
+        }
+    }
+    Ok(())
 }
 
 /// Variables defined (inputarg or op result) in the reachable block
@@ -720,49 +885,164 @@ fn duplicate_inputarg_vars(graph: &LegacyGraph) -> std::collections::HashSet<Var
 /// excluded here) and the exitswitch (Value / fused compare).  `Link.args`
 /// forwarding is deliberately NOT counted, matching `reachable_defined_vars`.
 fn dead_op_result_vars(graph: &LegacyGraph) -> std::collections::HashSet<Variable> {
-    let mut op_read: std::collections::HashSet<Variable> = std::collections::HashSet::new();
-    for block in &graph.blocks {
-        for op in &block.operations {
-            for v in crate::front::result_exc::op_operand_vars(&op.kind) {
-                op_read.insert(v);
-            }
+    use crate::model::{BlockId, ExitSwitch, LinkArg};
+
+    // The legacy MIR can reuse one Variable identity as the producer and as
+    // inputargs in multiple successor blocks. RPython flowspace cannot:
+    // checkgraph requires each block inputarg to be a distinct definition.
+    // Reproduce simplify.py:428-518 over block-local definition nodes rather
+    // than collapsing those definitions into one global Variable key.
+    let by_id: HashMap<BlockId, &crate::model::Block> =
+        graph.blocks.iter().map(|block| (block.id, block)).collect();
+    let mut reachable = HashSet::new();
+    let mut pending = vec![graph.startblock];
+    while let Some(id) = pending.pop() {
+        if !reachable.insert(id) {
+            continue;
         }
-        match &block.exitswitch {
-            Some(crate::model::ExitSwitch::Value(v)) => {
-                op_read.insert(v.clone());
-            }
-            Some(crate::model::ExitSwitch::Fused { args, .. }) => {
-                for v in args {
-                    op_read.insert(v.clone());
-                }
-            }
-            _ => {}
+        if let Some(block) = by_id.get(&id) {
+            pending.extend(block.exits.iter().map(|link| link.target));
         }
     }
-    let mut dead = std::collections::HashSet::new();
-    for block in &graph.blocks {
-        // `canremove(op, block)` (`simplify.py:441`) also excludes the
-        // block's `raising_op` — `block.operations[-1]` whenever the block
-        // raises (`block.canraise()`, exitswitch is `c_last_exception`).  A
-        // `canremove`-classified op parked there as an overflow / bounds /
-        // zero-divide check must keep its result: the raise side effect is
-        // observable, so the real path does NOT drop it either.
+
+    let mut next_node = 0usize;
+    let mut input_nodes: HashMap<(BlockId, usize), usize> = HashMap::new();
+    let mut entry_defs: HashMap<BlockId, HashMap<Variable, usize>> = HashMap::new();
+    for block in graph
+        .blocks
+        .iter()
+        .filter(|block| reachable.contains(&block.id) && !block.dead)
+    {
+        let mut defs = HashMap::new();
+        for (column, var) in block.inputargs.iter().enumerate() {
+            let node = next_node;
+            next_node += 1;
+            input_nodes.insert((block.id, column), node);
+            // remove_identical_vars_SSA runs before the dead-var pass; keeping
+            // the first identity-equivalent column models its representative.
+            defs.entry(var.clone()).or_insert(node);
+        }
+        entry_defs.insert(block.id, defs);
+    }
+
+    let mut dependencies: HashMap<usize, HashSet<usize>> = HashMap::new();
+    let mut read_nodes = HashSet::new();
+    let mut exit_defs: HashMap<BlockId, HashMap<Variable, usize>> = HashMap::new();
+    let mut removable_results: HashMap<Variable, Vec<usize>> = HashMap::new();
+
+    for block in graph
+        .blocks
+        .iter()
+        .filter(|block| reachable.contains(&block.id) && !block.dead)
+    {
+        let mut defs = entry_defs.get(&block.id).cloned().unwrap_or_default();
+        if block.id == graph.startblock
+            || block.id == graph.returnblock
+            || block.id == graph.exceptblock
+        {
+            read_nodes.extend(defs.values().copied());
+        }
         let raising_op_idx = if block.canraise() && !block.operations.is_empty() {
             Some(block.operations.len() - 1)
         } else {
             None
         };
-        for (i, op) in block.operations.iter().enumerate() {
-            if let Some(r) = &op.result
-                && !op_read.contains(r)
-                && op_result_can_remove(&op.kind)
-                && Some(i) != raising_op_idx
-            {
-                dead.insert(r.clone());
+        for (index, op) in block.operations.iter().enumerate() {
+            let operands: Vec<usize> = crate::front::result_exc::op_operand_vars(&op.kind)
+                .into_iter()
+                .filter_map(|var| defs.get(&var).copied())
+                .collect();
+            let removable = op_result_can_remove(&op.kind) && Some(index) != raising_op_idx;
+            if !removable {
+                read_nodes.extend(operands.iter().copied());
+            }
+            if let Some(result) = &op.result {
+                let node = next_node;
+                next_node += 1;
+                if removable {
+                    dependencies
+                        .entry(node)
+                        .or_default()
+                        .extend(operands.iter().copied());
+                    removable_results
+                        .entry(result.clone())
+                        .or_default()
+                        .push(node);
+                }
+                defs.insert(result.clone(), node);
+            }
+        }
+        match &block.exitswitch {
+            Some(ExitSwitch::Value(var)) => {
+                if let Some(node) = defs.get(var) {
+                    read_nodes.insert(*node);
+                }
+            }
+            Some(ExitSwitch::Fused { args, .. }) => {
+                for var in args {
+                    if let Some(node) = defs.get(var) {
+                        read_nodes.insert(*node);
+                    }
+                }
+            }
+            Some(ExitSwitch::LastException) | None => {}
+        }
+        exit_defs.insert(block.id, defs);
+    }
+
+    // simplify.py:461-469: target inputargs depend on corresponding source
+    // link args. Backward liveness through this relation keeps a producer iff
+    // some live successor column ultimately consumes it.
+    for block in graph
+        .blocks
+        .iter()
+        .filter(|block| reachable.contains(&block.id) && !block.dead)
+    {
+        let Some(source_defs) = exit_defs.get(&block.id) else {
+            continue;
+        };
+        for link in &block.exits {
+            for (column, arg) in link.args.iter().enumerate() {
+                let LinkArg::Value(source_var) = arg else {
+                    continue;
+                };
+                let Some(source_node) = source_defs.get(source_var).copied() else {
+                    continue;
+                };
+                if let Some(target_node) = input_nodes.get(&(link.target, column)).copied() {
+                    dependencies
+                        .entry(target_node)
+                        .or_default()
+                        .insert(source_node);
+                } else {
+                    // Link leaves the analyzed closure: upstream marks both
+                    // ends read rather than pruning an externally-used value.
+                    read_nodes.insert(source_node);
+                }
             }
         }
     }
-    dead
+
+    let mut work: Vec<usize> = read_nodes.iter().copied().collect();
+    while let Some(node) = work.pop() {
+        if let Some(previous) = dependencies.get(&node) {
+            for &dependency in previous {
+                if read_nodes.insert(dependency) {
+                    work.push(dependency);
+                }
+            }
+        }
+    }
+
+    removable_results
+        .into_iter()
+        .filter_map(|(var, nodes)| {
+            nodes
+                .iter()
+                .all(|node| !read_nodes.contains(node))
+                .then_some(var)
+        })
+        .collect()
 }
 
 /// Results of a synthetic `FieldRead("__discriminant")` that feed a block
@@ -1021,6 +1301,14 @@ fn collect_divergences(
         // coloring consistent, and the crash does not recur.
         let real_refines_gcref_to_signed =
             legacy_kind == ConcreteType::GcRef && real_kind == ConcreteType::Signed;
+        // Same conservative-legacy refinement for a genuine floating-point
+        // value. `long_pow`'s negative-exponent arm extracts `f64` payloads
+        // from generic Result shells; Charon's erased legacy walk falls back
+        // Unknown→GcRef while the annotator/rtyper positively assigns Float.
+        // Like the Signed case, publish commits the real kind before
+        // jtransform partitions registers, so the float bank is authoritative.
+        let real_refines_gcref_to_float =
+            legacy_kind == ConcreteType::GcRef && real_kind == ConcreteType::Float;
         // A duplicate phi inputarg the real path's `remove_duplicate_inputargs`
         // merged away is untyped in the real graph (its column no longer
         // exists) while the legacy walker types the retained identity.  The
@@ -1068,6 +1356,7 @@ fn collect_divergences(
             real_present.is_none() && repack_payload_reads.contains(var);
         let diverges = if real_refines_gcref_to_void
             || real_refines_gcref_to_signed
+            || real_refines_gcref_to_float
             || real_dropped_duplicate_inputarg
             || real_dropped_dead_op_result
             || real_rebuilt_switch_discriminant
@@ -2370,7 +2659,7 @@ pub fn specialize_legacy_graph_with_registry_returning_value_to_var(
     legacy: &LegacyGraph,
     call_registry: &crate::translator::rtyper::pyre_call_registry::PyreCallRegistry,
 ) -> Result<(LegacyToTyped, HashMap<Variable, LowLevelType>), TyperError> {
-    let (_graph, value_to_var, constant_concretetypes) =
+    let (_graph, value_to_var, _value_to_var_candidates, constant_concretetypes) =
         drive_subject(legacy, call_registry, true)?;
     Ok((value_to_var, constant_concretetypes))
 }
@@ -2397,6 +2686,7 @@ fn drive_subject(
     (
         crate::flowspace::model::GraphRef,
         LegacyToTyped,
+        LegacyToTypedCandidates,
         HashMap<Variable, LowLevelType>,
     ),
     TyperError,
@@ -2417,7 +2707,8 @@ fn drive_subject(
     // ── Step 1 — adapter ─────────────────────────────────────────────
     let FlowspaceAdapterOutput {
         graph,
-        value_to_var,
+        mut value_to_var,
+        value_to_var_candidates,
         constant_concretetypes,
         ..
     } = crate::translator::rtyper::flowspace_adapter::function_graph_to_flowspace(
@@ -2659,7 +2950,15 @@ fn drive_subject(
         crate::codewriter::jtransform_shadow::report_if_enabled(&graph.borrow());
     }
 
-    Ok((graph, value_to_var, constant_concretetypes))
+    if do_rtype {
+        select_rtyped_representatives(&mut value_to_var, &value_to_var_candidates)?;
+    }
+    Ok((
+        graph,
+        value_to_var,
+        value_to_var_candidates,
+        constant_concretetypes,
+    ))
 }
 
 /// Whole-program two-phase rtyper prepass (`PYRE_TWO_PHASE_RTYPE`).
@@ -2882,21 +3181,19 @@ fn run_two_phase_prepass_inner(
         let Some(legacy) = function_graphs.get(path) else {
             continue;
         };
-        let fixed_at_entry: HashSet<crate::flowspace::model::GraphKey> = call_registry
-            .session_if_started()
-            .map(|(ann, _)| ann.fixed_graphs.borrow().keys().cloned().collect())
-            .unwrap_or_default();
+        let session_at_entry = SubjectSessionSnapshot::capture(call_registry);
         let attempt = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             drive_subject(legacy, call_registry, /* do_rtype = */ false)
         }));
         match attempt {
-            Ok(Ok((graph, value_to_var, constant_concretetypes))) => {
+            Ok(Ok((graph, value_to_var, value_to_var_candidates, constant_concretetypes))) => {
                 let key = path.canonical_key();
                 call_registry.two_phase().subjects.insert(
                     key,
                     crate::translator::rtyper::pyre_call_registry::TwoPhaseSubject {
                         graph_key: crate::flowspace::model::GraphKey::of(&graph),
                         value_to_var,
+                        value_to_var_candidates,
                         constant_concretetypes,
                     },
                 );
@@ -2929,7 +3226,7 @@ fn run_two_phase_prepass_inner(
                 let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                     unpoison_failed_subject_callees(
                         call_registry,
-                        &fixed_at_entry,
+                        &session_at_entry,
                         function_graphs,
                     );
                 }));
@@ -3122,8 +3419,7 @@ fn run_phase_b_rtype_isolated(
                     continue;
                 }
             }
-            let fixed_at_entry: HashSet<GraphKey> =
-                annotator.fixed_graphs.borrow().keys().cloned().collect();
+            let session_at_entry = SubjectSessionSnapshot::capture_fixed_only(call_registry);
             let res = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                 rtyper.specialize_block(&block)
             }));
@@ -3151,6 +3447,21 @@ fn run_phase_b_rtype_isolated(
                             "[PREPASS phaseB fail] {:?} {gname}: {reason}",
                             gopt.as_ref().map(GraphKey::of)
                         );
+                        // A panic from `bindingrepr` carries only the
+                        // unbound Variable identity, unlike ordinary
+                        // `TyperError::where_info`, which includes the
+                        // current operation.  Emit this block's shallow
+                        // contents in the explicitly verbose census so the
+                        // producer/consumer edge can be located without a
+                        // second instrumented build.
+                        let failed_block = block.borrow();
+                        eprintln!(
+                            "[PREPASS phaseB block] {gname}: inputargs={:?} exitswitch={:?}",
+                            failed_block.inputargs, failed_block.exitswitch
+                        );
+                        for op in &failed_block.operations {
+                            eprintln!("[PREPASS phaseB op] {gname}: {op:?}");
+                        }
                         phase_b_reasons.push(reason);
                     }
                     match &gopt {
@@ -3174,7 +3485,7 @@ fn run_phase_b_rtype_isolated(
                     let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                         unpoison_failed_subject_callees(
                             call_registry,
-                            &fixed_at_entry,
+                            &session_at_entry,
                             lift_sources,
                         );
                     }));
@@ -3269,16 +3580,19 @@ pub(crate) fn dual_gate_outcome_from_cache(
         match tp.subjects.get(diag_key) {
             Some(subj) if !tp.rtype_skipped.contains(&subj.graph_key) => Some((
                 subj.value_to_var.clone(),
+                subj.value_to_var_candidates.clone(),
                 subj.constant_concretetypes.clone(),
             )),
             _ => None,
         }
     };
-    let Some((value_to_var, constants)) = cached else {
+    let Some((mut value_to_var, value_to_var_candidates, constants)) = cached else {
         return Ok(DualGateOutcome::Skip(
             "two-phase: subject not annotated/rtyped in prepass".to_string(),
         ));
     };
+    select_rtyped_representatives(&mut value_to_var, &value_to_var_candidates)
+        .map_err(|e| e.to_string())?;
 
     // Validate the cached lltypes project to concrete kinds (the Step-4 check
     // deferred from `drive_subject`, which did not rtype in Phase A).
@@ -3719,10 +4033,13 @@ mod tests {
         collect_divergences(&real_state, &graph)
     }
 
-    /// Build start → mid → return where `mid` defines an `ArrayRead` result
-    /// (`vars[2]`) that no op or exitswitch reads — it is only forwarded on
-    /// the link into the returnblock (a dead phi-thread).  `dead_op_result_vars`
-    /// classifies it; the real path leaves it untyped (`real=None`).
+    /// Build start → mid → sink → return where `mid` defines an `ArrayRead`
+    /// result (`vars[2]`) that no op or exitswitch reads — it is only
+    /// forwarded into an unused `sink` inputarg (a dead phi-thread).
+    /// `dead_op_result_vars` classifies it; the real path leaves it untyped
+    /// (`real=None`). The returnblock itself has no such input: upstream
+    /// `transform_dead_op_vars` treats return/except inputargs as implicit
+    /// reads because they are observable function results.
     fn diff_dead_op_result(legacy_kind: ConcreteType) -> Vec<String> {
         let mut graph = LegacyGraph::new("diff_dead_op_result");
         let vars = mint_vars(&mut graph, 3);
@@ -3730,6 +4047,7 @@ mod tests {
         let index = vars[1].clone();
         let dead = vars[2].clone();
         let mid_id = crate::model::BlockId(7);
+        let sink_id = crate::model::BlockId(8);
         let startblock = Block {
             id: graph.startblock,
             inputargs: block_inputargs(&vars, &[0, 1]),
@@ -3760,23 +4078,33 @@ mod tests {
                 },
             }],
             exitswitch: None,
-            exits: vec![link_to_returnblock(
+            exits: vec![crate::model::Link::new_mixed(
                 vec![LinkArg::Value(dead.clone())],
-                graph.returnblock,
+                sink_id,
+                None,
             )],
+            framestate: None,
+            dead: false,
+        };
+        let sinkblock = Block {
+            id: sink_id,
+            inputargs: block_inputargs(&vars, &[2]),
+            operations: vec![],
+            exitswitch: None,
+            exits: vec![link_to_returnblock(vec![], graph.returnblock)],
             framestate: None,
             dead: false,
         };
         let returnblock = Block {
             id: graph.returnblock,
-            inputargs: block_inputargs(&vars, &[2]),
+            inputargs: vec![],
             operations: vec![],
             exitswitch: None,
             exits: vec![],
             framestate: None,
             dead: false,
         };
-        graph.blocks = vec![startblock, midblock, returnblock];
+        graph.blocks = vec![startblock, midblock, sinkblock, returnblock];
         crate::model::FunctionGraph::set_concretetype_of_inline(&dead, legacy_kind);
         // Real path dropped the dead op result → `dead` untyped.
         let real_state = HashMap::new();
@@ -3795,6 +4123,7 @@ mod tests {
         let index = vars[1].clone();
         let dead = vars[2].clone();
         let mid_id = crate::model::BlockId(7);
+        let sink_id = crate::model::BlockId(8);
         let startblock = Block {
             id: graph.startblock,
             inputargs: block_inputargs(&vars, &[0, 1]),
@@ -3822,23 +4151,33 @@ mod tests {
                 },
             }],
             exitswitch: None,
-            exits: vec![link_to_returnblock(
+            exits: vec![crate::model::Link::new_mixed(
                 vec![LinkArg::Value(dead.clone())],
-                graph.returnblock,
+                sink_id,
+                None,
             )],
+            framestate: None,
+            dead: false,
+        };
+        let sinkblock = Block {
+            id: sink_id,
+            inputargs: block_inputargs(&vars, &[2]),
+            operations: vec![],
+            exitswitch: None,
+            exits: vec![link_to_returnblock(vec![], graph.returnblock)],
             framestate: None,
             dead: false,
         };
         let returnblock = Block {
             id: graph.returnblock,
-            inputargs: block_inputargs(&vars, &[2]),
+            inputargs: vec![],
             operations: vec![],
             exitswitch: None,
             exits: vec![],
             framestate: None,
             dead: false,
         };
-        graph.blocks = vec![startblock, midblock, returnblock];
+        graph.blocks = vec![startblock, midblock, sinkblock, returnblock];
         crate::model::FunctionGraph::set_concretetype_of_inline(&dead, legacy_kind);
         let real_state = HashMap::new();
         collect_divergences(&real_state, &graph)
@@ -4199,6 +4538,87 @@ mod tests {
     }
 
     #[test]
+    fn dead_op_result_vars_propagates_liveness_through_block_local_phi_nodes() {
+        let build = |consume_in_successor: bool| {
+            let mut graph = LegacyGraph::new("phi_liveness_probe");
+            let vars = mint_vars(&mut graph, 4);
+            let input = vars[0].clone();
+            let threaded = vars[1].clone();
+            let call_result = vars[2].clone();
+            let middle_id = BlockId(7);
+            let producer = crate::model::SpaceOperation {
+                result: Some(threaded.clone()),
+                kind: crate::model::OpKind::BinOp {
+                    op: "eq".to_string(),
+                    lhs: input.clone(),
+                    rhs: input.clone(),
+                    result_ty: ValueType::Int,
+                },
+            };
+            let start = Block {
+                id: graph.startblock,
+                inputargs: vec![input],
+                operations: vec![producer],
+                exitswitch: None,
+                exits: vec![crate::model::Link::new_mixed(
+                    vec![LinkArg::Value(threaded.clone())],
+                    middle_id,
+                    None,
+                )],
+                framestate: None,
+                dead: false,
+            };
+            let operations = if consume_in_successor {
+                vec![crate::model::SpaceOperation {
+                    result: Some(call_result),
+                    kind: crate::model::OpKind::Call {
+                        target: crate::model::CallTarget::FunctionPath {
+                            segments: vec!["consume".into()],
+                        },
+                        args: vec![threaded.clone()],
+                        result_ty: ValueType::Int,
+                    },
+                }]
+            } else {
+                vec![]
+            };
+            let middle = Block {
+                id: middle_id,
+                // Deliberately reuse the legacy identity. The adapter turns
+                // this into a distinct orthodox flowspace input Variable.
+                inputargs: vec![threaded.clone()],
+                operations,
+                exitswitch: None,
+                exits: vec![link_to_returnblock(vec![], graph.returnblock)],
+                framestate: None,
+                dead: false,
+            };
+            let returnblock = Block {
+                id: graph.returnblock,
+                inputargs: vec![],
+                operations: vec![],
+                exitswitch: None,
+                exits: vec![],
+                framestate: None,
+                dead: false,
+            };
+            graph.blocks = vec![start, middle, returnblock];
+            (graph, threaded)
+        };
+
+        let (dead_graph, dead) = build(false);
+        assert!(
+            dead_op_result_vars(&dead_graph).contains(&dead),
+            "a pure producer forwarded only into an unused phi column is dead"
+        );
+        let (live_graph, live) = build(true);
+        assert!(
+            !dead_op_result_vars(&live_graph).contains(&live),
+            "successor consumption must flow backward across the link and keep the producer live"
+        );
+    }
+
+    #[test]
     fn collect_divergences_accepts_gcref_duplicate_inputarg_dropped() {
         // A `legacy=GcRef` duplicate phi inputarg the real path's
         // `remove_duplicate_inputargs` merged away reads `real=Unknown`, but
@@ -4248,6 +4668,32 @@ mod tests {
         assert!(
             diff_single_var(ConcreteType::GcRef, ConcreteType::Signed).is_empty(),
             "legacy=GcRef, real=Signed is an accepted real refinement"
+        );
+    }
+
+    #[test]
+    fn collect_divergences_accepts_gcref_refined_to_float() {
+        assert!(
+            diff_single_var(ConcreteType::GcRef, ConcreteType::Float).is_empty(),
+            "legacy=GcRef, real=Float is an accepted real refinement"
+        );
+    }
+
+    #[test]
+    fn select_rtyped_representatives_uses_live_block_local_peer() {
+        let legacy = Variable::named("legacy");
+        let removed_producer = Variable::named("producer");
+        let live_phi = Variable::named("phi");
+        live_phi.set_concretetype(Some(LowLevelType::Signed));
+        let mut preferred = HashMap::from([(legacy.clone(), removed_producer.clone())]);
+        let candidates =
+            HashMap::from([(legacy.clone(), vec![removed_producer, live_phi.clone()])]);
+
+        select_rtyped_representatives(&mut preferred, &candidates)
+            .expect("same legacy value's live peer must reconcile");
+        assert_eq!(
+            preferred[&legacy], live_phi,
+            "projection must point at the positively-rtyped block-local representative"
         );
     }
 
@@ -4570,6 +5016,130 @@ mod tests {
              translator.graphs instead of falling to top_result()"
         );
     }
+
+    #[test]
+    fn failed_subject_restores_previously_annotated_callee_that_lost_bindings() {
+        let _lock = anchor_lock();
+        use crate::annotator::bookkeeper::Bookkeeper;
+        use crate::codewriter::call::GraphStore;
+        use crate::flowspace::model::{BlockKey, GraphKey};
+        use crate::parse::CallPath;
+        use crate::translator::rtyper::pyre_call_registry::{FunctionPathKey, PyreCallRegistry};
+
+        let mut source = LegacyGraph::new("shared_int_value");
+        let vars = mint_vars(&mut source, 2);
+        let value = vars[1].clone();
+        source.blocks = vec![
+            Block {
+                id: source.startblock,
+                inputargs: block_inputargs(&vars, &[1]),
+                operations: vec![],
+                exitswitch: None,
+                exits: vec![link_to_returnblock(
+                    vec![LinkArg::Value(value.clone())],
+                    source.returnblock,
+                )],
+                framestate: None,
+                dead: false,
+            },
+            Block {
+                id: source.returnblock,
+                inputargs: block_inputargs(&vars, &[1]),
+                operations: vec![],
+                exitswitch: None,
+                exits: vec![],
+                framestate: None,
+                dead: false,
+            },
+        ];
+        setbinding(&value, ValueType::Int);
+
+        let registry = PyreCallRegistry::new(Rc::new(Bookkeeper::new()));
+        // `mint_vars` allocates unnamed value vars, so the startblock's single
+        // inputarg has no source name and takes the positional `arg0`.
+        let signature =
+            crate::flowspace::argument::Signature::new(vec!["arg0".to_string()], None, None);
+        let lifted = lift_callee_to_pygraph(&source, signature.clone(), &registry)
+            .expect("shared callee must lift");
+        let stale = lifted.graph.clone();
+        let entry_key = FunctionPathKey::from_segments(["shared_int_value"]);
+        registry.register_callee(entry_key.clone(), signature, lifted);
+        let (annotator, _) = registry.ensure_session().expect("session must initialize");
+        let stale_blocks = stale.borrow().iterblocks();
+        for block in &stale_blocks {
+            let bkey = BlockKey::of(block);
+            annotator
+                .annotated
+                .borrow_mut()
+                .insert(bkey.clone(), Some(stale.clone()));
+            annotator
+                .all_blocks
+                .borrow_mut()
+                .insert(bkey, block.clone());
+        }
+        let snapshot = SubjectSessionSnapshot::capture(&registry);
+
+        // Model raise_if_subject_blocked's destructive reflow rollback:
+        // one block that was healthy at subject entry is removed and all
+        // definitions lose their annotations. No graph became fixed, so
+        // the old fixed-only repair could not see this damage.
+        let damaged = stale_blocks
+            .first()
+            .expect("identity graph has a start block")
+            .clone();
+        let damaged_key = BlockKey::of(&damaged);
+        annotator.annotated.borrow_mut().shift_remove(&damaged_key);
+        annotator.all_blocks.borrow_mut().shift_remove(&damaged_key);
+        {
+            let block = damaged.borrow();
+            for value in block
+                .inputargs
+                .iter()
+                .chain(block.operations.iter().map(|op| &op.result))
+            {
+                if let Hlvalue::Variable(var) = value {
+                    *var.annotation.borrow_mut() = None;
+                }
+            }
+        }
+
+        let mut sources = GraphStore::default();
+        sources.insert(CallPath::from_segments(["shared_int_value"]), source);
+        unpoison_failed_subject_callees(&registry, &snapshot, &sources);
+
+        assert!(
+            registry.find_entry_with_cached_graph(&stale).is_some(),
+            "an annotation-only rollback must retain the original FunctionDesc.cache graph"
+        );
+        assert!(
+            stale_blocks.iter().all(|block| {
+                let bkey = BlockKey::of(block);
+                matches!(
+                    annotator.annotated.borrow().get(&bkey),
+                    Some(Some(graph)) if Rc::ptr_eq(graph, &stale)
+                ) && matches!(
+                    annotator.all_blocks.borrow().get(&bkey),
+                    Some(current) if Rc::ptr_eq(current, block)
+                )
+            }),
+            "all pre-existing annotator rows must be restored"
+        );
+        assert!(
+            damaged.borrow().inputargs.iter().all(|value| match value {
+                Hlvalue::Variable(var) => var.annotation.borrow().is_some(),
+                _ => true,
+            }),
+            "the pre-subject Variable annotations must be restored"
+        );
+        assert!(
+            !annotator
+                .blocked_graphs
+                .borrow()
+                .contains_key(&GraphKey::of(&stale)),
+            "discarded graph must not remain in blocked_graphs"
+        );
+    }
+
     // There is no program-wide annotator pre-pass to test: per-session
     // annotator construction inside
     // `specialize_legacy_graph_with_registry_returning_value_to_var`

--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -310,10 +310,9 @@ pub(crate) fn dual_gate_check_with_registry(
     // stringified error so the env-flag wrapper can decide whether
     // to panic, log, or skip.
     //
-    // Snapshot the session so the failure arms below can identify both
-    // shared callees this subject newly fixed and previously-annotated
-    // callees whose bindings it evicted while reflowing them — see
-    // `unpoison_failed_subject_callees`.
+    // Snapshot the fixed-graph keyset so failure repair can identify shared
+    // callees newly fixed by this subject. Previously-annotated block cells
+    // are journaled lazily by AddedBlocksGuard only when actually touched.
     let session_at_entry = SubjectSessionSnapshot::capture(call_registry);
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         specialize_legacy_graph_with_registry_returning_value_to_var(legacy_graph, call_registry)
@@ -405,74 +404,19 @@ pub(crate) fn dual_gate_check_with_registry(
 #[derive(Default)]
 struct SubjectSessionSnapshot {
     fixed_graphs: HashSet<crate::flowspace::model::GraphKey>,
-    annotated_blocks: Vec<AnnotatedBlockSnapshot>,
-}
-
-struct AnnotatedBlockSnapshot {
-    key: crate::flowspace::model::BlockKey,
-    block: crate::flowspace::model::BlockRef,
-    graph: crate::flowspace::model::GraphRef,
-    definitions: Vec<(
-        crate::flowspace::model::Variable,
-        Option<Rc<crate::annotator::model::SomeValue>>,
-    )>,
 }
 
 impl SubjectSessionSnapshot {
     fn capture(call_registry: &PyreCallRegistry) -> Self {
-        Self::capture_inner(call_registry, true)
+        Self::capture_fixed_only(call_registry)
     }
 
     fn capture_fixed_only(call_registry: &PyreCallRegistry) -> Self {
-        Self::capture_inner(call_registry, false)
-    }
-
-    fn capture_inner(call_registry: &PyreCallRegistry, include_annotations: bool) -> Self {
         let Some((annotator, _)) = call_registry.session_if_started() else {
             return Self::default();
         };
         let fixed_graphs = annotator.fixed_graphs.borrow().keys().cloned().collect();
-        if !include_annotations {
-            return Self {
-                fixed_graphs,
-                annotated_blocks: Vec::new(),
-            };
-        }
-        let annotated = annotator.annotated.borrow();
-        let all_blocks = annotator.all_blocks.borrow();
-        let mut annotated_blocks = Vec::new();
-        for (bkey, graph) in annotated.iter() {
-            let Some(graph) = graph else {
-                continue;
-            };
-            let Some(block) = all_blocks.get(bkey) else {
-                continue;
-            };
-            let definitions = {
-                let block = block.borrow();
-                block
-                    .inputargs
-                    .iter()
-                    .chain(block.operations.iter().map(|op| &op.result))
-                    .filter_map(|value| match value {
-                        Hlvalue::Variable(var) => {
-                            Some((var.clone(), var.annotation.borrow().clone()))
-                        }
-                        _ => None,
-                    })
-                    .collect()
-            };
-            annotated_blocks.push(AnnotatedBlockSnapshot {
-                key: bkey.clone(),
-                block: block.clone(),
-                graph: graph.clone(),
-                definitions,
-            });
-        }
-        Self {
-            fixed_graphs,
-            annotated_blocks,
-        }
+        Self { fixed_graphs }
     }
 }
 
@@ -484,41 +428,6 @@ fn unpoison_failed_subject_callees(
     let Some((annotator, rtyper)) = call_registry.session_if_started() else {
         return;
     };
-    // `AddedBlocksGuard` can remove a block that was already healthy at
-    // subject entry because RPython's `added_blocks` records every
-    // reprocessed block, not only newly discovered ones. Restore the
-    // exact pre-subject annotation cells and ownership rows before
-    // repairing any graph that advanced into LL form. This is the
-    // transaction rollback required only by pyre's continue-after-Skip
-    // driver; upstream aborts the single Translator on the same error.
-    for saved in &session_at_entry.annotated_blocks {
-        annotator
-            .annotated
-            .borrow_mut()
-            .insert(saved.key.clone(), Some(saved.graph.clone()));
-        annotator
-            .all_blocks
-            .borrow_mut()
-            .insert(saved.key.clone(), saved.block.clone());
-        annotator
-            .blocked_blocks
-            .borrow_mut()
-            .shift_remove(&saved.key);
-        for (var, annotation) in &saved.definitions {
-            *var.annotation.borrow_mut() = annotation.clone();
-        }
-    }
-    if !session_at_entry.annotated_blocks.is_empty() {
-        let restored_keys: HashSet<_> = session_at_entry
-            .annotated_blocks
-            .iter()
-            .map(|saved| saved.key.clone())
-            .collect();
-        for generation in annotator.genpendingblocks.borrow_mut().iter_mut() {
-            generation.retain(|bkey, _| !restored_keys.contains(bkey));
-        }
-    }
-
     let stale_graphs: HashMap<
         crate::flowspace::model::GraphKey,
         crate::flowspace::model::GraphRef,
@@ -940,7 +849,17 @@ fn dead_op_result_vars(graph: &LegacyGraph) -> std::collections::HashSet<Variabl
             || block.id == graph.returnblock
             || block.id == graph.exceptblock
         {
-            read_nodes.extend(defs.values().copied());
+            // Every terminal input column is observable. The legacy graph can
+            // repeat one Variable identity in multiple columns (notably the
+            // exceptblock's etype/evalue pair), while RPython SSA gives each
+            // column its own definition node.
+            read_nodes.extend(
+                block
+                    .inputargs
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(column, _)| input_nodes.get(&(block.id, column)).copied()),
+            );
         }
         let raising_op_idx = if block.canraise() && !block.operations.is_empty() {
             Some(block.operations.len() - 1)
@@ -5021,9 +4940,7 @@ mod tests {
     fn failed_subject_restores_previously_annotated_callee_that_lost_bindings() {
         let _lock = anchor_lock();
         use crate::annotator::bookkeeper::Bookkeeper;
-        use crate::codewriter::call::GraphStore;
         use crate::flowspace::model::{BlockKey, GraphKey};
-        use crate::parse::CallPath;
         use crate::translator::rtyper::pyre_call_registry::{FunctionPathKey, PyreCallRegistry};
 
         let mut source = LegacyGraph::new("shared_int_value");
@@ -5077,17 +4994,31 @@ mod tests {
                 .borrow_mut()
                 .insert(bkey, block.clone());
         }
-        let snapshot = SubjectSessionSnapshot::capture(&registry);
-
         // Model raise_if_subject_blocked's destructive reflow rollback:
         // one block that was healthy at subject entry is removed and all
         // definitions lose their annotations. No graph became fixed, so
-        // the old fixed-only repair could not see this damage.
+        // the transaction log must restore the touched block without scanning
+        // every annotated block in the session.
         let damaged = stale_blocks
             .first()
             .expect("identity graph has a start block")
             .clone();
         let damaged_key = BlockKey::of(&damaged);
+        let inputcells: Vec<Option<crate::annotator::model::SomeValue>> = damaged
+            .borrow()
+            .inputargs
+            .iter()
+            .map(|value| match value {
+                Hlvalue::Variable(var) => var
+                    .annotation
+                    .borrow()
+                    .as_ref()
+                    .map(|annotation| (**annotation).clone()),
+                _ => None,
+            })
+            .collect();
+        let scope = annotator.enter_added_blocks_scope();
+        annotator.addpendingblock(&stale, &damaged, &inputcells);
         annotator.annotated.borrow_mut().shift_remove(&damaged_key);
         annotator.all_blocks.borrow_mut().shift_remove(&damaged_key);
         {
@@ -5102,10 +5033,7 @@ mod tests {
                 }
             }
         }
-
-        let mut sources = GraphStore::default();
-        sources.insert(CallPath::from_segments(["shared_int_value"]), source);
-        unpoison_failed_subject_callees(&registry, &snapshot, &sources);
+        drop(scope);
 
         assert!(
             registry.find_entry_with_cached_graph(&stale).is_some(),

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -83,6 +83,14 @@ use crate::translator::rtyper::lltypesystem::lltype::LowLevelType;
 /// lets consumers read `typed_var.concretetype` / `.annotation` back onto
 /// the legacy Variable they already hold, with no slot-index round-trip.
 pub type LegacyToTyped = HashMap<Variable, Variable>;
+/// Every block-local flowspace Variable derived from one legacy MIR
+/// Variable. The legacy MIR can reuse one Variable identity as an op result
+/// and as inputargs of several successor blocks; orthodox RPython flowspace
+/// requires each block inputarg to be a distinct definition. `LegacyToTyped`
+/// retains the preferred projection representative, while this multimap lets
+/// the cutover replace an untyped representative removed by simplify with a
+/// typed block-local peer after rtyping.
+pub type LegacyToTypedCandidates = HashMap<Variable, Vec<Variable>>;
 
 pub use crate::codewriter::annotation_state::valuetype_to_someshell;
 
@@ -607,6 +615,52 @@ fn is_elided_unit_variant_ctor(kind: &OpKind) -> bool {
     false
 }
 
+/// A fixed-size Rust array aggregate emitted by `front::mir`.
+///
+/// The semantic/legacy graph keeps the exact `Array` transparent-ctor plus
+/// `__pos_i` field writes required by legacy code generation and format-array
+/// recognizers.  The RPython annotator has no distinct Rust array class:
+/// arrays, slices, and Vec values are list-shaped.  The block adapter therefore
+/// reconstructs this source aggregate as one `newlist(items...)` operation
+/// while leaving the original model graph untouched.
+fn is_array_aggregate_ctor(kind: &OpKind) -> bool {
+    matches!(
+        kind,
+        OpKind::Call {
+            target: crate::model::CallTarget::SyntheticTransparentCtor {
+                name,
+                owner_path,
+            },
+            ..
+        } if owner_path.is_empty()
+            && majit_ir::descr::strip_instantiation_suffix(name) == "Array"
+    )
+}
+
+fn array_aggregate_elements(
+    operations: &[SpaceOperation],
+    array: &Variable,
+) -> Option<Vec<Variable>> {
+    let mut by_index = Vec::new();
+    for op in operations {
+        if let OpKind::FieldWrite {
+            base, field, value, ..
+        } = &op.kind
+            && base.id() == array.id()
+        {
+            let index = field.name.strip_prefix("__pos_")?.parse::<usize>().ok()?;
+            by_index.push((index, value.as_variable()?.clone()));
+        }
+    }
+    by_index.sort_by_key(|(index, _)| *index);
+    for (expected, (actual, _)) in by_index.iter().enumerate() {
+        if *actual != expected {
+            return None;
+        }
+    }
+    Some(by_index.into_iter().map(|(_, value)| value).collect())
+}
+
 /// `true` iff `kind` is `front::mir`'s synthetic string-literal
 /// define-op (`Call(["__str_const", <text>])`, `mir.rs:1576`).
 /// Upstream flowspace carries a string literal as a bare
@@ -817,10 +871,10 @@ pub(crate) fn op_canraise(kind: &OpKind) -> bool {
         // the 0-arg unit-variant ctor, which `translate_op` pre-folds to a
         // `Constant` and emits no op — `op_canraise` is false exactly when
         // that happens.  Matched before the general `Call` arm.
-        OpKind::Call {
+        kind @ OpKind::Call {
             target: crate::model::CallTarget::SyntheticTransparentCtor { .. },
             ..
-        } => !is_elided_unit_variant_ctor(kind),
+        } => !is_elided_unit_variant_ctor(kind) && !is_array_aggregate_ctor(kind),
         // A string-literal define-op pre-folds to `Constant('text')`
         // and emits no op — a Constant raises nothing.  Matched before
         // the general `Call` arm, same as the unit-variant elision.
@@ -2551,6 +2605,9 @@ pub struct FlowspaceAdapterOutput {
     /// Legacy graph `Variable` → typed flowspace `Variable`; each typed
     /// Variable's `concretetype` is read after `specialize` returns.
     pub value_to_var: LegacyToTyped,
+    /// All block-local typed representatives for each legacy Variable.
+    /// See [`LegacyToTypedCandidates`].
+    pub value_to_var_candidates: LegacyToTypedCandidates,
     /// Const-define result `Variable` -> `Constant.concretetype`.
     /// Materialised at lift time from `OpKind::ConstInt` / `ConstFloat`
     /// via `Constant::with_concretetype` (`flowspace_adapter.rs:518-527`),
@@ -3173,6 +3230,7 @@ pub fn function_graph_to_flowspace(
     call_registry: &crate::translator::rtyper::pyre_call_registry::PyreCallRegistry,
 ) -> Result<FlowspaceAdapterOutput, TyperError> {
     let mut value_to_var: LegacyToTyped = HashMap::new();
+    let mut value_to_var_candidates: LegacyToTypedCandidates = HashMap::new();
     let mut constant_hlvalues: HashMap<Variable, Hlvalue> = HashMap::new();
     let mut constant_concretetypes: HashMap<Variable, LowLevelType> = HashMap::new();
 
@@ -3282,6 +3340,10 @@ pub fn function_graph_to_flowspace(
         let mut inputargs: Vec<Hlvalue> = Vec::with_capacity(legacy_block.inputargs.len());
         for legacy_var in legacy_block.inputargs.iter() {
             let var = seed_variable(legacy_var);
+            value_to_var_candidates
+                .entry(legacy_var.clone())
+                .or_default()
+                .push(var.clone());
             value_to_var
                 .entry(legacy_var.clone())
                 .or_insert_with(|| var.clone());
@@ -3323,6 +3385,10 @@ pub fn function_graph_to_flowspace(
         })
         .map(|legacy_var| {
             let var = seed_variable(&legacy_var);
+            value_to_var_candidates
+                .entry(legacy_var.clone())
+                .or_default()
+                .push(var.clone());
             value_to_var
                 .entry(legacy_var)
                 .or_insert_with(|| var.clone());
@@ -3350,6 +3416,10 @@ pub fn function_graph_to_flowspace(
             let mut except_inputargs = Vec::with_capacity(2);
             for legacy_var in legacy_exceptblock.inputargs.iter() {
                 let var = seed_variable(legacy_var);
+                value_to_var_candidates
+                    .entry(legacy_var.clone())
+                    .or_default()
+                    .push(var.clone());
                 value_to_var
                     .entry(legacy_var.clone())
                     .or_insert_with(|| var.clone());
@@ -3418,6 +3488,18 @@ pub fn function_graph_to_flowspace(
 
         // Translate operations.
         let mut translated_ops: Vec<FlowspaceOp> = Vec::new();
+        let array_list_elements: HashMap<Variable, Vec<Variable>> = legacy_block
+            .operations
+            .iter()
+            .filter_map(|op| {
+                if !is_array_aggregate_ctor(&op.kind) {
+                    return None;
+                }
+                let result = op.result.as_ref()?.clone();
+                let elements = array_aggregate_elements(&legacy_block.operations, &result)?;
+                Some((result, elements))
+            })
+            .collect();
         for legacy_op in &legacy_block.operations {
             if let Some(hlvalue) = legacy_const_define_hlvalue(legacy_op, Some(call_registry))? {
                 if let Some(result_var) = legacy_op.result.as_ref() {
@@ -3523,8 +3605,38 @@ pub fn function_graph_to_flowspace(
                 // local to the defining block; only the legacy→typed map is
                 // repointed to the definition.
                 let var = seed_variable(result_var);
+                value_to_var_candidates
+                    .entry(result_var.clone())
+                    .or_default()
+                    .push(var.clone());
                 value_to_var.insert(result_var.clone(), var.clone());
                 value_map.insert(result_var.clone(), Hlvalue::Variable(var));
+            }
+            // RPython has one list model for Rust fixed arrays, slices, and
+            // Vec values.  Rebuild the front-end's exact Array ctor +
+            // positional writes as `newlist(items...)` only in this
+            // flowspace view; the semantic graph stays intact for legacy
+            // fallback/code generation.
+            if let Some(result_var) = legacy_op.result.as_ref()
+                && let Some(elements) = array_list_elements.get(result_var)
+            {
+                let mut args = Vec::with_capacity(elements.len());
+                for (index, element) in elements.iter().enumerate() {
+                    args.push(lookup_operand(
+                        &value_map,
+                        element,
+                        legacy_op,
+                        &format!("array_item_{index}"),
+                    )?);
+                }
+                let result = resolve_result_hlvalue(legacy_op, &value_map)?;
+                translated_ops.push(FlowspaceOp::new("newlist", args, result));
+                continue;
+            }
+            if let OpKind::FieldWrite { base, .. } = &legacy_op.kind
+                && array_list_elements.contains_key(base)
+            {
+                continue;
             }
             translated_ops.extend(translate_op(legacy_op, &value_map, call_registry)?);
             if let Some(result_var) = legacy_op.result.as_ref() {
@@ -3628,6 +3740,7 @@ pub fn function_graph_to_flowspace(
     Ok(FlowspaceAdapterOutput {
         graph: graph_ref,
         value_to_var,
+        value_to_var_candidates,
         constant_concretetypes,
         #[cfg(test)]
         block_map,
@@ -5317,6 +5430,84 @@ mod tests {
             exit.target.as_ref().expect("link must have target"),
             &graph.returnblock,
         ));
+    }
+
+    #[test]
+    fn function_graph_to_flowspace_rebuilds_array_aggregate_as_rpython_list() {
+        let mut graph = LegacyGraph::new("array_to_list");
+        let vars = mint_vars(&mut graph, 6);
+        let startblock = Block {
+            id: graph.startblock,
+            inputargs: block_inputargs(&vars, &[1]),
+            operations: vec![
+                SpaceOperation {
+                    result: Some(vars[2].clone()),
+                    kind: OpKind::ConstInt(10),
+                },
+                SpaceOperation {
+                    result: Some(vars[3].clone()),
+                    kind: OpKind::ConstInt(20),
+                },
+                SpaceOperation {
+                    result: Some(vars[4].clone()),
+                    kind: OpKind::Call {
+                        target: crate::model::CallTarget::synthetic_transparent_ctor("Array"),
+                        args: vec![],
+                        result_ty: ValueType::Ref(Some("Array".to_string())),
+                    },
+                },
+                SpaceOperation {
+                    result: None,
+                    kind: OpKind::FieldWrite {
+                        base: vars[4].clone(),
+                        field: crate::model::FieldDescriptor::new(
+                            "__pos_0",
+                            Some("Array".to_string()),
+                        ),
+                        value: LinkArg::Value(vars[2].clone()),
+                        ty: ValueType::Int,
+                    },
+                },
+                SpaceOperation {
+                    result: None,
+                    kind: OpKind::FieldWrite {
+                        base: vars[4].clone(),
+                        field: crate::model::FieldDescriptor::new(
+                            "__pos_1",
+                            Some("Array".to_string()),
+                        ),
+                        value: LinkArg::Value(vars[3].clone()),
+                        ty: ValueType::Int,
+                    },
+                },
+            ],
+            exitswitch: None,
+            exits: vec![link_to_returnblock(
+                vec![LinkArg::Value(vars[4].clone())],
+                graph.returnblock,
+            )],
+            framestate: None,
+            dead: false,
+        };
+        let returnblock = Block {
+            id: graph.returnblock,
+            inputargs: block_inputargs(&vars, &[5]),
+            operations: vec![],
+            exitswitch: None,
+            exits: vec![],
+            framestate: None,
+            dead: false,
+        };
+        graph.blocks = vec![startblock, returnblock];
+
+        let output = function_graph_to_flowspace(&graph, &empty_call_registry())
+            .expect("array aggregate must adapt");
+        let graph = output.graph.borrow();
+        let startblock = graph.startblock.borrow();
+        assert_eq!(startblock.operations.len(), 1);
+        let op = &startblock.operations[0];
+        assert_eq!(op.opname, "newlist");
+        assert_eq!(op.args.len(), 2);
     }
 
     #[test]

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -874,7 +874,7 @@ pub(crate) fn op_canraise(kind: &OpKind) -> bool {
         kind @ OpKind::Call {
             target: crate::model::CallTarget::SyntheticTransparentCtor { .. },
             ..
-        } => !is_elided_unit_variant_ctor(kind) && !is_array_aggregate_ctor(kind),
+        } => !is_elided_unit_variant_ctor(kind),
         // A string-literal define-op pre-folds to `Constant('text')`
         // and emits no op — a Constant raises nothing.  Matched before
         // the general `Call` arm, same as the unit-variant elision.

--- a/majit/majit-translate/src/translator/rtyper/pyre_call_registry.rs
+++ b/majit/majit-translate/src/translator/rtyper/pyre_call_registry.rs
@@ -172,6 +172,8 @@ impl PyreFunctionEntry {
 pub struct TwoPhaseSubject {
     pub graph_key: crate::flowspace::model::GraphKey,
     pub value_to_var: crate::translator::rtyper::flowspace_adapter::LegacyToTyped,
+    pub value_to_var_candidates:
+        crate::translator::rtyper::flowspace_adapter::LegacyToTypedCandidates,
     pub constant_concretetypes: HashMap<
         crate::flowspace::model::Variable,
         crate::translator::rtyper::lltypesystem::lltype::LowLevelType,

--- a/majit/majit-translate/tests/test_rbigint_mir.rs
+++ b/majit/majit-translate/tests/test_rbigint_mir.rs
@@ -1220,7 +1220,15 @@ fn dependent_crate_rbigint_identity_retargets_opaque_llbc_declaration() {
     let program = build_semantic_program_from_llbcs_with_static_addrs_and_module_paths(
         &[llbc],
         HostStaticAddrs::default(),
-        &["objspace::descroperation", "module::math::interp_math"],
+        &[
+            "objspace::descroperation",
+            "module::math::interp_math",
+            "baseobjspace",
+            "builtins",
+            "typedef",
+            "type_methods",
+            "objspace::std::formatting",
+        ],
     )
     .expect("lower descroperation module");
     let helper = program

--- a/majit/majit-translate/tests/test_rbigint_mir.rs
+++ b/majit/majit-translate/tests/test_rbigint_mir.rs
@@ -537,6 +537,12 @@ fn rbigint_inherent_constructors_keep_their_owner_and_graph() {
     )
     .expect("lower rbigint module");
 
+    assert_eq!(
+        program.struct_fields.field_type("RBigInt", "_digits"),
+        Some("[i64]"),
+        "RBigInt._digits must retain rbigint.py's GcArray(Signed) annotation"
+    );
+
     for name in [
         "new",
         "setdigit",
@@ -665,11 +671,227 @@ fn rbigint_inherent_constructors_keep_their_owner_and_graph() {
             "RPython digit index must remain Signed for RBigInt::{name}"
         );
     }
+    let digit_graph = program
+        .functions
+        .iter()
+        .find(|function| {
+            function.name == "digit" && function.self_ty_root.as_deref() == Some("rbigint::RBigInt")
+        })
+        .expect("rbigint::RBigInt::digit graph");
+    assert!(
+        digit_graph.graph.blocks.iter().any(|block| {
+            block.operations.iter().any(|operation| {
+                matches!(
+                    &operation.kind,
+                    OpKind::FieldRead { field, .. } if field.name == "_digits"
+                )
+            })
+        }),
+        "RBigInt::digit must project the upstream _digits field directly"
+    );
+    assert!(
+        !digit_graph.graph.blocks.iter().any(|block| {
+            block
+                .operations
+                .iter()
+                .any(|operation| match &operation.kind {
+                    OpKind::Call {
+                        target: CallTarget::Method { name, .. },
+                        ..
+                    } => matches!(name.as_str(), "digits" | "digits_mut"),
+                    OpKind::Call {
+                        target: CallTarget::FunctionPath { segments },
+                        ..
+                    } => matches!(
+                        segments.last().map(String::as_str),
+                        Some("digits" | "digits_mut")
+                    ),
+                    _ => false,
+                })
+        }),
+        "RBigInt::digit must not retain Rust's slice-view adapter"
+    );
     for name in ["lqshift", "rqshift"] {
         assert_eq!(
             input_types(name, Some("rbigint::RBigInt")).last(),
             Some(&ValueType::Int),
             "RPython quick-shift count must remain Signed for RBigInt::{name}"
+        );
+    }
+
+    for name in [
+        "add",
+        "int_add",
+        "sub",
+        "int_sub",
+        "int_mul",
+        "int_floordiv",
+        "pow",
+        "int_pow",
+        "abs",
+        "lshift",
+        "rshift",
+    ] {
+        let function = program
+            .functions
+            .iter()
+            .find(|function| {
+                function.name == name
+                    && function.self_ty_root.as_deref() == Some("rbigint::RBigInt")
+            })
+            .unwrap_or_else(|| panic!("missing rbigint::RBigInt::{name} graph"));
+        assert!(
+            !function
+                .graph
+                .blocks
+                .iter()
+                .flat_map(|block| &block.operations)
+                .any(|operation| matches!(
+                    &operation.kind,
+                    OpKind::Call {
+                        target: CallTarget::FunctionPath { segments },
+                        ..
+                    } if segments.last().is_some_and(|leaf| leaf == "jit_bigint_clone")
+                )),
+            "RBigInt::{name} must preserve upstream `return self/other` as a GC-reference alias"
+        );
+    }
+    for name in [
+        "prebuilt",
+        "zero",
+        "one",
+        "negative_one",
+        "five",
+        "frombool",
+    ] {
+        let candidates: Vec<_> = program
+            .functions
+            .iter()
+            .filter(|function| {
+                function.name == name
+                    && function.self_ty_root.as_deref() == Some("rbigint::RBigInt")
+            })
+            .collect();
+        assert!(
+            !candidates.is_empty(),
+            "missing rbigint::RBigInt::{name} graph"
+        );
+        assert!(
+            candidates.iter().all(|function| {
+                function
+                    .graph
+                    .blocks
+                    .iter()
+                    .flat_map(|block| &block.operations)
+                    .all(|operation| {
+                        !matches!(
+                            &operation.kind,
+                            OpKind::Call {
+                                target: CallTarget::FunctionPath { segments },
+                                ..
+                            } if segments.last().is_some_and(|leaf| leaf == "jit_bigint_clone")
+                        )
+                    })
+            }),
+            "RBigInt::{name} must return the process-global prebuilt payload, not a clone"
+        );
+    }
+
+    let neg_candidates: Vec<_> = program
+        .functions
+        .iter()
+        .filter(|function| {
+            function.name == "neg" && function.self_ty_root.as_deref() == Some("rbigint::RBigInt")
+        })
+        .collect();
+    let neg = neg_candidates
+        .iter()
+        .copied()
+        .find(|function| {
+            function
+                .graph
+                .blocks
+                .iter()
+                .flat_map(|block| &block.operations)
+                .all(|operation| {
+                    !matches!(
+                        &operation.kind,
+                        OpKind::Call {
+                            target: CallTarget::FunctionPath { segments },
+                            ..
+                        } if segments.last().is_some_and(|leaf| leaf == "jit_bigint_neg")
+                    )
+                })
+        })
+        .expect("inherent rbigint::RBigInt::neg graph, distinct from the Neg trait adapter");
+    let neg_calls: Vec<Vec<String>> = neg
+        .graph
+        .blocks
+        .iter()
+        .flat_map(|block| &block.operations)
+        .filter_map(|operation| match &operation.kind {
+            OpKind::Call {
+                target: CallTarget::FunctionPath { segments },
+                ..
+            } => Some(segments.clone()),
+            _ => None,
+        })
+        .collect();
+    assert!(
+        neg_calls.iter().any(|segments| segments
+            .last()
+            .is_some_and(|leaf| leaf == "jit_bigint_clone")),
+        "RBigInt::neg must retain the fresh shallow-copy handle upstream constructs: {neg_calls:?}"
+    );
+    let range_obj_to_bigint = program
+        .functions
+        .iter()
+        .find(|function| {
+            function.name == "range_obj_to_bigint" && function.module_path.ends_with("functional")
+        })
+        .expect("functional::range_obj_to_bigint graph");
+    let range_bigint_calls: Vec<_> = range_obj_to_bigint
+        .graph
+        .blocks
+        .iter()
+        .flat_map(|block| &block.operations)
+        .filter_map(|operation| match &operation.kind {
+            OpKind::Call { target, .. } => Some(target),
+            _ => None,
+        })
+        .collect();
+    assert!(
+        !range_bigint_calls.iter().any(|target| {
+            matches!(
+                target,
+                CallTarget::FunctionPath { segments }
+                    if segments.last().is_some_and(|leaf| leaf == "jit_bigint_clone")
+            ) || matches!(
+                target,
+                CallTarget::Method { name, .. } if name == "translated_alias"
+            )
+        }),
+        "range_obj_to_bigint must preserve bigint_w's borrowed rbigint payload without a \
+         residual ownership marker: {range_bigint_calls:?}"
+    );
+    for function in &program.functions {
+        assert!(
+            !function
+                .graph
+                .blocks
+                .iter()
+                .flat_map(|block| &block.operations)
+                .any(|operation| matches!(
+                    &operation.kind,
+                    OpKind::Call {
+                        target: CallTarget::Method { name, .. },
+                        ..
+                    } if name == "translated_alias"
+                )),
+            "Rust's translated_alias ownership marker must be erased in every translated \
+             RBigInt consumer, but survived in {}::{}",
+            function.module_path,
+            function.name
         );
     }
     let from_list_types = input_types("from_list_n_bits", Some("rbigint::RBigInt"));
@@ -941,6 +1163,7 @@ fn dependent_crate_rbigint_identity_retargets_opaque_llbc_declaration() {
         "objspace::descroperation::jit_bigint_int_xor",
         "objspace::descroperation::jit_bigint_shl",
         "objspace::descroperation::jit_bigint_pow_nomod",
+        "objspace::descroperation::jit_bigint_lshift_int_int_result",
         "objspace::descroperation::jit_bigint_div",
         "objspace::descroperation::jit_bigint_rem",
         "objspace::descroperation::jit_bigint_div_floor",
@@ -957,7 +1180,7 @@ fn dependent_crate_rbigint_identity_retargets_opaque_llbc_declaration() {
         );
     }
     // rbigint.py `_make_int_comparison` only reads existing digits and
-    // returns a bool.  These wrappers are plain @jit.elidable, not the
+    // returns a bool.  These wrappers are elidable and cannot raise, not the
     // allocation-only arithmetic contract above.
     for path in [
         "objspace::descroperation::jit_bigint_int_eq",
@@ -966,11 +1189,16 @@ fn dependent_crate_rbigint_identity_retargets_opaque_llbc_declaration() {
         "objspace::descroperation::jit_bigint_int_le",
         "objspace::descroperation::jit_bigint_int_gt",
         "objspace::descroperation::jit_bigint_int_ge",
+        "objspace::descroperation::jit_bigint_divrem_returns_lhs_remainder",
     ] {
         let values = hints
             .get(path)
             .unwrap_or_else(|| panic!("missing pointer-ABI wrapper hints for {path}"));
         assert!(values.iter().any(|hint| hint == "elidable"));
+        assert!(
+            values.iter().any(|hint| hint == "elidable_cannot_raise"),
+            "{path} comparison must not retain an exception edge: {values:?}"
+        );
         assert!(
             !values.iter().any(|hint| hint == "elidable_or_memerror"),
             "{path} comparison must not advertise an allocation edge: {values:?}"
@@ -992,7 +1220,7 @@ fn dependent_crate_rbigint_identity_retargets_opaque_llbc_declaration() {
     let program = build_semantic_program_from_llbcs_with_static_addrs_and_module_paths(
         &[llbc],
         HostStaticAddrs::default(),
-        &["objspace::descroperation"],
+        &["objspace::descroperation", "module::math::interp_math"],
     )
     .expect("lower descroperation module");
     let helper = program
@@ -1098,6 +1326,15 @@ fn dependent_crate_rbigint_identity_retargets_opaque_llbc_declaration() {
             }),
             "{caller_name} retained an untranslated RBigInt::int_* call: {calls:?}"
         );
+        assert!(
+            !calls.iter().any(|segments| {
+                segments
+                    .last()
+                    .is_some_and(|leaf| leaf == "jit_bigint_clone")
+            }),
+            "{caller_name} must borrow W_LongObject.num like PyPy's asbigint(), \
+             not allocate cloned rbigint payloads: {calls:?}"
+        );
     }
 
     let mixed_compare = program
@@ -1187,6 +1424,60 @@ fn dependent_crate_rbigint_identity_retargets_opaque_llbc_declaration() {
         "the host Result wrapper must not survive in the translated graph: {pow_calls:?}"
     );
 
+    for (module_suffix, caller_name) in [
+        ("objspace::descroperation", "long_pow"),
+        ("objspace::descroperation", "try_int_long_pow_with_modulo"),
+        ("objspace::descroperation", "long_lshift"),
+        ("objspace::descroperation", "long_rshift"),
+        ("objspace::descroperation", "long_floordiv"),
+        ("objspace::descroperation", "long_mod"),
+        ("objspace::descroperation", "integer_divmod_pair"),
+        ("objspace::descroperation", "bigint_mod_inverse"),
+        ("objspace::descroperation", "complex_richcompare"),
+        ("objspace::descroperation", "compare_slot"),
+        ("baseobjspace", "compute_slice_indices3_big"),
+        ("baseobjspace", "uint_w"),
+        ("baseobjspace", "truncatedint_w"),
+        ("baseobjspace", "getindex_w"),
+        ("baseobjspace", "index_int_w_preserve_negative"),
+        ("baseobjspace", "space_index"),
+        ("builtins", "builtin_abs"),
+        ("builtins", "ensure_baseint_result"),
+        ("builtins", "int_to_decimal_string"),
+        ("typedef", "int_descr_new"),
+        ("typedef", "slice_method_indices"),
+        ("builtins", "format_index_radix"),
+        ("type_methods", "format_with_spec"),
+        ("builtins", "obj_to_bigint"),
+        ("objspace::std::formatting", "arg_to_bigint"),
+        ("module::math::interp_math", "comb"),
+        ("module::math::interp_math", "perm"),
+    ] {
+        let caller = program
+            .functions
+            .iter()
+            .find(|function| {
+                function.name == caller_name && function.module_path.ends_with(module_suffix)
+            })
+            .unwrap_or_else(|| panic!("{module_suffix}::{caller_name} graph"));
+        assert!(
+            !caller
+                .graph
+                .blocks
+                .iter()
+                .flat_map(|block| &block.operations)
+                .any(|operation| matches!(
+                    &operation.kind,
+                    OpKind::Call {
+                        target: CallTarget::FunctionPath { segments },
+                        ..
+                    } if segments.last().is_some_and(|leaf| leaf == "jit_bigint_clone")
+                )),
+            "{caller_name} must borrow long operand payloads rather than allocate \
+             translated rbigint clones"
+        );
+    }
+
     let long_lshift = program
         .functions
         .iter()
@@ -1225,6 +1516,45 @@ fn dependent_crate_rbigint_identity_retargets_opaque_llbc_declaration() {
         "the host Result wrapper must not survive in the translated graph: {lshift_calls:?}"
     );
 
+    let int_lshift = program
+        .functions
+        .iter()
+        .find(|function| {
+            function.name == "int_lshift"
+                && function.module_path.ends_with("objspace::descroperation")
+        })
+        .expect("descroperation::int_lshift graph");
+    let int_lshift_calls: Vec<Vec<String>> = int_lshift
+        .graph
+        .blocks
+        .iter()
+        .flat_map(|block| &block.operations)
+        .filter_map(|operation| match &operation.kind {
+            OpKind::Call {
+                target: CallTarget::FunctionPath { segments },
+                ..
+            } => Some(segments.clone()),
+            _ => None,
+        })
+        .collect();
+    assert!(
+        int_lshift_calls.iter().any(|segments| segments
+            == &[
+                "pyre_interpreter",
+                "objspace",
+                "descroperation",
+                "jit_bigint_lshift_int_int_result",
+            ]),
+        "int_lshift must retain rbigint's Signed×Signed specialized residual: \
+         {int_lshift_calls:?}"
+    );
+    assert!(
+        !int_lshift_calls.iter().any(|segments| segments
+            .last()
+            .is_some_and(|leaf| leaf == "bigint_lshift_int_int_result")),
+        "the specialized host Result wrapper must not survive: {int_lshift_calls:?}"
+    );
+
     for (caller_name, residual_name) in [
         ("long_floordiv", "jit_bigint_div_floor"),
         ("long_mod", "jit_bigint_mod_floor"),
@@ -1255,6 +1585,45 @@ fn dependent_crate_rbigint_identity_retargets_opaque_llbc_declaration() {
                 .iter()
                 .any(|segments| { segments.last().is_some_and(|leaf| leaf == residual_name) }),
             "{caller_name} must target {residual_name}: {calls:?}"
+        );
+    }
+
+    for (caller_name, residual_name) in [
+        ("bigint_neg", "jit_bigint_neg"),
+        ("bigint_invert", "jit_bigint_invert"),
+    ] {
+        let caller = program
+            .functions
+            .iter()
+            .find(|function| {
+                function.name == caller_name
+                    && function.module_path.ends_with("objspace::descroperation")
+            })
+            .unwrap_or_else(|| panic!("descroperation::{caller_name} graph"));
+        let calls: Vec<Vec<String>> = caller
+            .graph
+            .blocks
+            .iter()
+            .flat_map(|block| &block.operations)
+            .filter_map(|operation| match &operation.kind {
+                OpKind::Call {
+                    target: CallTarget::FunctionPath { segments },
+                    ..
+                } => Some(segments.clone()),
+                _ => None,
+            })
+            .collect();
+        assert!(
+            calls
+                .iter()
+                .any(|segments| segments.last().is_some_and(|leaf| leaf == residual_name)),
+            "{caller_name} must target {residual_name}: {calls:?}"
+        );
+        assert!(
+            !calls.iter().any(|segments| segments
+                .last()
+                .is_some_and(|leaf| leaf == "jit_bigint_clone")),
+            "{caller_name} must borrow its input and allocate only the unary result: {calls:?}"
         );
     }
 }

--- a/pyre/extra_tests/parity_tests/bool_python314.py
+++ b/pyre/extra_tests/parity_tests/bool_python314.py
@@ -29,3 +29,5 @@ assert str(True) == "True"
 assert str(False) == "False"
 assert bool.__doc__.startswith("Returns True when the argument is true")
 print("bool 3.14 surface: ok")
+
+print("OK")

--- a/pyre/extra_tests/parity_tests/builtin_function_python314.py
+++ b/pyre/extra_tests/parity_tests/builtin_function_python314.py
@@ -99,3 +99,5 @@ assert len.__module__ is None
 len.__module__ = "builtins"
 
 print("builtin_function_or_method Python 3.14 parity: ok")
+
+print("OK")

--- a/pyre/extra_tests/parity_tests/bytearray_python314.py
+++ b/pyre/extra_tests/parity_tests/bytearray_python314.py
@@ -77,3 +77,5 @@ assert repr(child) == "Child(b'x')"
 assert child.__reduce__() == (Child, ("x", "latin-1"), {"attr": 1})
 assert bytearray.__doc__.startswith("bytearray(iterable_of_ints)")
 print("bytearray 3.14 surface: ok")
+
+print("OK")

--- a/pyre/extra_tests/parity_tests/bytes_surface_python314.py
+++ b/pyre/extra_tests/parity_tests/bytes_surface_python314.py
@@ -19,3 +19,5 @@ else:
     raise AssertionError("bytes buffer must be read-only")
 
 print("bytes surface: ok")
+
+print("OK")

--- a/pyre/extra_tests/parity_tests/code_python314.py
+++ b/pyre/extra_tests/parity_tests/code_python314.py
@@ -153,6 +153,30 @@ constants_code = constants_sample.__code__
 assert constants_code.replace(co_consts=constants_code.co_consts) == constants_code
 
 
+def huge_constant():
+    return 123456789012345678901234567890123456789012345678901234567890
+
+
+huge_code = huge_constant.__code__
+huge_index = next(
+    index
+    for index, value in enumerate(huge_code.co_consts)
+    if isinstance(value, int) and value.bit_length() > 63
+)
+wrapped_huge = huge_code.co_consts[huge_index]
+assert huge_constant() is wrapped_huge
+assert huge_code.replace().co_consts[huge_index] is wrapped_huge
+
+replacement_huge = int(
+    "987654321098765432109876543210987654321098765432109876543210"
+)
+replacement_consts = list(huge_code.co_consts)
+replacement_consts[huge_index] = replacement_huge
+replaced_huge_code = huge_code.replace(co_consts=tuple(replacement_consts))
+assert replaced_huge_code.co_consts[huge_index] is replacement_huge
+assert types.FunctionType(replaced_huge_code, globals())() is replacement_huge
+
+
 def outer(captured):
     def inner():
         return captured

--- a/pyre/extra_tests/parity_tests/dict_surface_python314.py
+++ b/pyre/extra_tests/parity_tests/dict_surface_python314.py
@@ -59,3 +59,5 @@ assert {}.__sizeof__() > 0
 assert {"x": 1}.__sizeof__() > {}.__sizeof__()
 assert dict.__doc__.startswith("dict() -> new empty dictionary")
 print("dict surface: ok")
+
+print("OK")

--- a/pyre/extra_tests/parity_tests/divmod_int_jit.py
+++ b/pyre/extra_tests/parity_tests/divmod_int_jit.py
@@ -1,0 +1,152 @@
+"""`divmod(a, b)` on two exact ints under a JIT-hot loop.
+
+The walker recognises the `divmod` builtin and emits the guarded
+`int_py_div` / `int_py_mod` pair straight into a virtual `Cls_ii` specialised
+tuple, so a `q, r = divmod(...)` site keeps no tuple at all.  Everything the
+recognition declines — a zero divisor, `INT_MIN // -1`, a bool / long / float
+operand, an `int` subclass, a shadowed `divmod` name — has to keep producing
+the interpreted answer at a site that has already been traced.
+"""
+
+ROUNDS = 3000
+INT_MIN = -(1 << 63)
+
+
+def floored_pairs():
+    """All four sign combinations must follow Python's floored division."""
+    out = []
+    for _ in range(ROUNDS):
+        out = []
+        for a in (98765, -98765):
+            for d in (60, -60, 1, -1):
+                q, r = divmod(a, d)
+                out.append((q, r, q * d + r == a, type(q) is int, type(r) is int))
+    return out
+
+
+def remainder_hits_zero():
+    """The `r == 0` iterations must not diverge from the nonzero ones."""
+    acc = []
+    for i in range(ROUNDS):
+        q, r = divmod(i, 60)
+        acc.append(q * 60 + r == i)
+    return all(acc), divmod(ROUNDS - 1, 60)
+
+
+def tuple_is_a_real_tuple():
+    """A result that is not unpacked still has to materialise correctly."""
+    out = None
+    for i in range(ROUNDS):
+        t = divmod(i + 7, 5)
+        out = (t, len(t), t[0], t[1], type(t) is tuple, t == (t[0], t[1]))
+    return out
+
+
+def zero_divisor_after_warmup():
+    """The trace is built with a nonzero divisor, then replayed with 0."""
+    acc = 0
+    for i in range(ROUNDS):
+        d = 3 if i < ROUNDS - 1 else 0
+        try:
+            q, r = divmod(i, d)
+            acc += r
+        except ZeroDivisionError:
+            acc = -1
+    return acc
+
+
+def int_min_overflow():
+    """`divmod(INT_MIN, -1)` leaves the machine-int domain."""
+    out = None
+    for i in range(ROUNDS):
+        d = -1 if i == ROUNDS - 1 else 7
+        out = divmod(INT_MIN, d)
+    return out, INT_MIN // -1 == -INT_MIN
+
+
+def bool_operands():
+    """Bools are not exact ints; the divisor `False` is a zero."""
+    out = None
+    for _ in range(ROUNDS):
+        out = (divmod(True, 2), divmod(7, True), divmod(True, True))
+    try:
+        divmod(5, False)
+    except ZeroDivisionError:
+        caught = "ZeroDivisionError"
+    else:
+        caught = "no raise"
+    return out, caught
+
+
+def mixed_operand_kinds():
+    """long / float operands take other interpreter legs at the same site."""
+    big = (1 << 200) + 12345
+    out = None
+    for _ in range(ROUNDS):
+        out = (divmod(big, 97)[1], divmod(7.5, 2.0), divmod(-7.5, 2.0), divmod(big, big))
+    return out
+
+
+class MyInt(int):
+    pass
+
+
+def int_subclass_operands():
+    """An int subclass must not take the exact-builtin fast path."""
+    out = None
+    a = MyInt(98765)
+    for _ in range(ROUNDS):
+        out = (divmod(a, 60), divmod(98765, MyInt(60)), type(divmod(a, 60)[0]) is int)
+    return out
+
+
+def subclass_overrides_divmod():
+    """`__divmod__` on a subclass wins over the int leg."""
+
+    class Weird(int):
+        def __divmod__(self, other):
+            return ("weird", int(self), other)
+
+    out = None
+    w = Weird(9)
+    for _ in range(ROUNDS):
+        out = divmod(w, 4)
+    return out
+
+
+def alternating_divisor_sign():
+    """One site alternating between a positive and a negative divisor."""
+    acc = 0
+    for i in range(ROUNDS):
+        d = 7 if (i & 1) else -7
+        q, r = divmod(i, d)
+        acc += q * d + r - i
+        acc ^= r & 0xFF
+    return acc
+
+
+def shadowed_divmod():
+    """A rebound global `divmod` must not keep the builtin's trace."""
+    global divmod
+    builtin_divmod = divmod
+    out = []
+    for i in range(ROUNDS):
+        if i == ROUNDS - 1:
+            divmod = lambda a, b: ("shadowed", a, b)  # noqa: E731
+        out = divmod(i, 60)
+    divmod = builtin_divmod
+    return out
+
+
+print(floored_pairs())
+print(remainder_hits_zero())
+print(tuple_is_a_real_tuple())
+print(zero_divisor_after_warmup())
+print(int_min_overflow())
+print(bool_operands())
+print(mixed_operand_kinds())
+print(int_subclass_operands())
+print(subclass_overrides_divmod())
+print(alternating_divisor_sign())
+print(shadowed_divmod())
+print("OK")

--- a/pyre/extra_tests/parity_tests/divmod_long_int_jit.py
+++ b/pyre/extra_tests/parity_tests/divmod_long_int_jit.py
@@ -1,0 +1,143 @@
+"""`divmod(long, int)` under a JIT-hot loop.
+
+`_int_divmod` keeps a `W_IntObject` divisor unwrapped and calls
+`rbigint.int_divmod`, whose rtyped return is a two-item `GcStruct`.  The
+walker emits that as one elidable call plus two `getfield_gc_r`, and boxes
+both halves and the result pair itself, so this exercises three fresh GC
+allocations per call as well as the arithmetic.  Run it under
+`MAJIT_GC_NURSERY_POISON=1` (`run.py --gc-poison`) — a missing root around
+those allocations shows up as a wrong digit, not a crash.
+
+`makespecialisedtuple2` only reaches the object pair when the two halves are
+not both machine-word sized, so the small-quotient cases below have to leave
+the specialised arm and still come out exact.
+"""
+
+ROUNDS = 3000
+BIG = (1 << 200) + 12345
+NEG = -BIG
+
+
+def floored_pairs():
+    """All four sign combinations must follow Python's floored division."""
+    out = []
+    for _ in range(ROUNDS):
+        out = []
+        for a in (BIG, NEG):
+            for d in (97, -97, 1, -1):
+                q, r = divmod(a, d)
+                out.append((q == a // d, r == a % d, q * d + r == a, 0 <= abs(r) < abs(d)))
+    return out
+
+
+def exact_values():
+    q = r = None
+    for _ in range(ROUNDS):
+        q, r = divmod(BIG, 97)
+    return q, r, type(q) is int, type(r) is int, q * 97 + r == BIG
+
+
+def churn_keeps_earlier_results():
+    """Hold both halves live across later allocations of the same shape.
+
+    A quotient reclaimed while a subsequent `int_divmod` allocates would only
+    be visible as a wrong sum at the end.
+    """
+    held = []
+    total = 0
+    for i in range(ROUNDS):
+        q, r = divmod(BIG + i, 97)
+        held.append(q)
+        total += r
+        if len(held) > 16:
+            head = held.pop(0)
+            total += head % 1000003
+    return total, len(held), sum(x % 7 for x in held)
+
+
+def small_quotient():
+    """A quotient that fits a machine word leaves the specialised arm."""
+    out = None
+    small = (1 << 70) >> 70
+    for _ in range(ROUNDS):
+        out = (divmod(small, 3), divmod(small * 5, 7), divmod(-small, 3))
+    return out
+
+
+def zero_divisor_after_warmup():
+    """The trace is built with a nonzero divisor, then replayed with 0."""
+    acc = 0
+    for i in range(ROUNDS):
+        d = 3 if i < ROUNDS - 1 else 0
+        try:
+            q, r = divmod(BIG, d)
+            acc += r
+        except ZeroDivisionError:
+            acc = -1
+    return acc
+
+
+def bool_divisor():
+    out = None
+    for _ in range(ROUNDS):
+        out = divmod(BIG, True)
+    try:
+        divmod(BIG, False)
+    except ZeroDivisionError:
+        caught = "ZeroDivisionError"
+    else:
+        caught = "no raise"
+    return out[0] == BIG, out[1], caught
+
+
+def alternating_divisor():
+    """One site alternating between a huge and a machine-sized quotient."""
+    acc = 0
+    tiny = (1 << 70) >> 70
+    for i in range(ROUNDS):
+        a = BIG if (i & 1) else tiny
+        q, r = divmod(a, 5)
+        acc += r
+        acc ^= q & 0xFF
+    return acc
+
+
+def reflected_and_long_long():
+    """`int // long` and `long // long` take other legs at the same site."""
+    out = None
+    for _ in range(ROUNDS):
+        out = (divmod(12345, BIG), divmod(BIG, BIG), divmod(BIG, BIG // 7))
+    return out
+
+
+class MyInt(int):
+    pass
+
+
+def int_subclass_divisor():
+    out = None
+    d = MyInt(97)
+    for _ in range(ROUNDS):
+        out = divmod(BIG, d)
+    return out[0] * 97 + out[1] == BIG, out[1]
+
+
+def tuple_is_a_real_tuple():
+    out = None
+    for _ in range(ROUNDS):
+        t = divmod(BIG, 97)
+        out = (len(t), t[0] * 97 + t[1] == BIG, type(t) is tuple, t == (t[0], t[1]))
+    return out
+
+
+print(floored_pairs())
+print(exact_values())
+print(churn_keeps_earlier_results())
+print(small_quotient())
+print(zero_divisor_after_warmup())
+print(bool_divisor())
+print(alternating_divisor())
+print(reflected_and_long_long())
+print(int_subclass_divisor())
+print(tuple_is_a_real_tuple())
+print("OK")

--- a/pyre/extra_tests/parity_tests/float_complex_python314.py
+++ b/pyre/extra_tests/parity_tests/float_complex_python314.py
@@ -254,3 +254,5 @@ assert format(x, "021_._f") == "0_000_123_456.123_456"
 assert format(x, "023_.10_f") == "0_123_456.123_456_000_0"
 
 print("float/complex 3.14 surface: ok")
+
+print("OK")

--- a/pyre/extra_tests/parity_tests/function_python314.py
+++ b/pyre/extra_tests/parity_tests/function_python314.py
@@ -144,3 +144,5 @@ for method_name, args in (
         pass
     else:
         raise AssertionError(f"function {method_name} accepted a foreign receiver")
+
+print("OK")

--- a/pyre/extra_tests/parity_tests/int_python314.py
+++ b/pyre/extra_tests/parity_tests/int_python314.py
@@ -13,3 +13,5 @@ for value in (0, 1, -1, 2**30 - 1, 2**30, 2**60, -(2**60)):
 
 assert int.__doc__.startswith("int([x]) -> integer")
 print("int 3.14 surface: ok")
+
+print("OK")

--- a/pyre/extra_tests/parity_tests/int_to_bytes_zero_length.py
+++ b/pyre/extra_tests/parity_tests/int_to_bytes_zero_length.py
@@ -1,0 +1,39 @@
+"""`int.to_bytes(0, ...)` only accepts zero, including in signed mode."""
+
+
+def raises_overflow(operation):
+    try:
+        operation()
+    except OverflowError as exc:
+        assert "too big to convert" in str(exc), str(exc)
+    else:
+        raise AssertionError("zero-length to_bytes accepted a nonzero value")
+
+
+assert (0).to_bytes(0, "big") == b""
+assert (0).to_bytes(0, "little") == b""
+assert (0).to_bytes(0, "big", signed=True) == b""
+assert (0).to_bytes(0, "little", signed=True) == b""
+
+# -1 is the one negative whose two's complement emits no bytes at all, so it
+# reaches the end of the conversion with an empty buffer instead of tripping
+# the per-byte width check.
+raises_overflow(lambda: (-1).to_bytes(0, "big", signed=True))
+raises_overflow(lambda: (-1).to_bytes(0, "little", signed=True))
+raises_overflow(lambda: (1).to_bytes(0, "big", signed=True))
+raises_overflow(lambda: (-2).to_bytes(0, "big", signed=True))
+raises_overflow(lambda: (-(2**70)).to_bytes(0, "big", signed=True))
+
+# Unsigned negatives keep reporting the signedness error, not the width one.
+try:
+    (-1).to_bytes(0, "big")
+except OverflowError as exc:
+    assert "negative int to unsigned" in str(exc), str(exc)
+else:
+    raise AssertionError("unsigned to_bytes accepted a negative value")
+
+# The smallest width that does fit still round-trips.
+assert (-1).to_bytes(1, "big", signed=True) == b"\xff"
+assert int.from_bytes((-1).to_bytes(1, "big", signed=True), "big", signed=True) == -1
+
+print("OK")

--- a/pyre/extra_tests/parity_tests/itertools_compress_python314.py
+++ b/pyre/extra_tests/parity_tests/itertools_compress_python314.py
@@ -6,10 +6,14 @@ import itertools
 assert isinstance(itertools.compress, type)
 assert itertools.compress.__module__ == "itertools"
 assert itertools.compress.__name__ == "compress"
-assert itertools.compress.__doc__ == (
-    "Return data elements corresponding to true selector elements.\n\n"
-    "Forms a shorter iterator from selected data elements using the selectors to\n"
-    "choose the data elements."
+# The paragraph text is the parity property, not where the lines break:
+# 3.14.5 wraps after "the selectors", 3.14.6 after "using the selectors",
+# so pinning one of them makes the reference interpreter fail this test on
+# the other.  Compare with the line breaks collapsed.
+assert " ".join(itertools.compress.__doc__.split()) == (
+    "Return data elements corresponding to true selector elements. "
+    "Forms a shorter iterator from selected data elements using the selectors "
+    "to choose the data elements."
 )
 assert {"__new__", "__iter__", "__next__", "__doc__"} <= set(
     itertools.compress.__dict__

--- a/pyre/extra_tests/parity_tests/itertools_compress_python314.py
+++ b/pyre/extra_tests/parity_tests/itertools_compress_python314.py
@@ -106,3 +106,5 @@ else:
     raise AssertionError("Python 3.14 compress unexpectedly became picklable")
 
 print("itertools.compress Python 3.14 parity ok")
+
+print("OK")

--- a/pyre/extra_tests/parity_tests/itertools_count_repeat_python314.py
+++ b/pyre/extra_tests/parity_tests/itertools_count_repeat_python314.py
@@ -121,3 +121,5 @@ for obj in (itertools.count(), itertools.repeat(None)):
         raise AssertionError("Python 3.14 non-picklable iterator became picklable")
 
 print("itertools count/repeat Python 3.14 parity ok")
+
+print("OK")

--- a/pyre/extra_tests/parity_tests/itertools_predicate_types_python314.py
+++ b/pyre/extra_tests/parity_tests/itertools_predicate_types_python314.py
@@ -93,3 +93,5 @@ else:
 assert events == [1, 2]
 
 print("itertools predicate type Python 3.14 parity ok")
+
+print("OK")

--- a/pyre/extra_tests/parity_tests/itertools_starmap_python314.py
+++ b/pyre/extra_tests/parity_tests/itertools_starmap_python314.py
@@ -89,3 +89,5 @@ assert type(sub) is StarMapSubclass
 assert list(sub) == [16]
 
 print("itertools.starmap Python 3.14 parity ok")
+
+print("OK")

--- a/pyre/extra_tests/parity_tests/list_iterator_surface.py
+++ b/pyre/extra_tests/parity_tests/list_iterator_surface.py
@@ -57,6 +57,20 @@ check(reduced[0] is iter and reduced[1][0] is values and reduced[2] == 1,
       "forward reduce state")
 it.__setstate__(-5)
 check(next(it, "STOP") == "STOP", "forward negative setstate exhausts in 3.14")
+check(it.__length_hint__() == 0, "exhausted-by-setstate forward hint")
+check(it.__reduce__() == (iter, ([],)), "exhausted-by-setstate forward reduce")
+# The sentinel keeps the source list, so an in-range state revives the cursor.
+it.__setstate__(1)
+check(next(it, "STOP") == 20, "forward revives from the exhausted sentinel")
+it.__setstate__(99)
+check(it.__reduce__()[2] == len(values), "forward setstate upper clamp")
+check(next(it, "STOP") == "STOP", "forward upper clamp exhausts")
+
+# Running off the end drops the source list, and no state revives that.
+it = iter([7])
+check(list(it) == [7], "forward drain")
+it.__setstate__(0)
+check(next(it, "STOP") == "STOP", "drained forward iterator stays exhausted")
 
 values = [1, 2, 3]
 rit = reversed(values)
@@ -72,5 +86,17 @@ check(reduced[0] is reversed and reduced[1][0] is values and reduced[2] == 0,
       "reverse reduce state")
 rit.__setstate__(999)
 check(next(rit) == 4, "reverse setstate upper clamp")
+rit.__setstate__(-5)
+check(next(rit, "STOP") == "STOP", "reverse negative setstate exhausts")
+check(rit.__length_hint__() == 0, "exhausted-by-setstate reverse hint")
+check(rit.__reduce__() == (reversed, ([],)), "exhausted-by-setstate reverse reduce")
+rit.__setstate__(1)
+check(next(rit, "STOP") == 2, "reverse revives from the exhausted sentinel")
+# A drained reverse iterator keeps its source list and is revivable too.
+rit2 = reversed([5, 6])
+check(list(rit2) == [6, 5], "reverse drain")
+check(rit2.__reduce__() == (reversed, ([],)), "drained reverse reduce")
+rit2.__setstate__(0)
+check(next(rit2, "STOP") == 5, "drained reverse iterator revives")
 
 print("OK")

--- a/pyre/extra_tests/parity_tests/long_int_div_mod_jit.py
+++ b/pyre/extra_tests/parity_tests/long_int_div_mod_jit.py
@@ -1,0 +1,128 @@
+"""`long // int` and `long % int` under a JIT-hot loop.
+
+The walker specialises this operand pair apart from the bigint/bigint leg:
+`_int_floordiv` keeps a long quotient while `_int_mod` returns a machine int
+(`space.newint`), and the zero-divisor branch is traced as a guard rather than
+raised inside the trace. Each function runs long enough to be traced, so a
+divergence between the traced and interpreted shapes shows up as a wrong value,
+a wrong result type, or a missing exception.
+"""
+
+ROUNDS = 3000
+BIG = (1 << 200) + 12345
+
+
+def floored_pairs():
+    """All four sign combinations must follow Python's floored division."""
+    out = []
+    for _ in range(ROUNDS):
+        out = []
+        for a in (BIG, -BIG):
+            for d in (97, -97, 1, -1):
+                q = a // d
+                r = a % d
+                out.append((q, r, q * d + r == a, type(r) is int))
+    return out
+
+
+def result_types():
+    """`%` yields a plain int; `//` keeps the long value exactly."""
+    q = r = None
+    for _ in range(ROUNDS):
+        q = BIG // 7
+        r = BIG % 7
+    return q, r, type(q) is int, type(r) is int, q * 7 + r == BIG
+
+
+def bool_operand():
+    """A bool divisor unboxes through the same int path; False is a zero."""
+    total = 0
+    for _ in range(ROUNDS):
+        total += BIG % True
+        total += BIG // True & 1
+    caught = []
+    for expr in (lambda: BIG // False, lambda: BIG % False):
+        try:
+            expr()
+        except ZeroDivisionError:
+            caught.append("ZeroDivisionError")
+        else:
+            caught.append("no raise")
+    return total, caught
+
+
+def zero_divisor_after_warmup():
+    """The trace is built with a nonzero divisor, then replayed with 0."""
+    acc = 0
+    for i in range(ROUNDS):
+        d = 3 if i < ROUNDS - 1 else 0
+        try:
+            acc += BIG % d
+            acc += BIG // d & 1
+        except ZeroDivisionError:
+            acc = -1
+    return acc
+
+
+def inplace_forms():
+    a = b = None
+    for _ in range(ROUNDS):
+        a = BIG
+        a //= 31
+        b = BIG
+        b %= 31
+    return a, b, type(b) is int
+
+
+def reflected_order():
+    """`int // long` / `int % long` are `descr_rfloordiv` / `descr_rmod`."""
+    out = None
+    for _ in range(ROUNDS):
+        out = (12345 // BIG, 12345 % BIG, (-12345) // BIG, (-12345) % BIG)
+    return out
+
+
+def quotient_fits_machine_int():
+    """A quotient that fits a machine int still has to come out exact."""
+    out = None
+    for _ in range(ROUNDS):
+        out = (BIG // BIG, BIG % BIG, (1 << 64) // 3, (1 << 64) % 3)
+    return out
+
+
+def alternating_divisor():
+    """Alternate between a huge and a tiny quotient at one call site."""
+    acc = 0
+    for i in range(ROUNDS):
+        d = 3 if (i & 1) else 5
+        acc += BIG % d
+        acc ^= (BIG // d) & 0xFF
+        small = 1 << 62
+        acc += small % d
+        acc ^= (small // d) & 0xFF
+    return acc
+
+
+class MyInt(int):
+    pass
+
+
+def int_subclass_divisor():
+    """An int subclass must not take the exact-builtin fast path."""
+    out = None
+    d = MyInt(97)
+    for _ in range(ROUNDS):
+        out = (BIG // d, BIG % d, type(BIG % d) is int)
+    return out
+
+
+print(floored_pairs())
+print(result_types())
+print(bool_operand())
+print(zero_divisor_after_warmup())
+print(inplace_forms())
+print(reflected_order())
+print(quotient_fits_machine_int())
+print(alternating_divisor())
+print(int_subclass_divisor())
+print("OK")

--- a/pyre/extra_tests/parity_tests/long_int_pow_jit.py
+++ b/pyre/extra_tests/parity_tests/long_int_pow_jit.py
@@ -1,0 +1,78 @@
+"""`long ** int` under a JIT-hot loop.
+
+`descr_pow` keeps a `W_IntObject` exponent unwrapped and calls
+`rbigint.int_pow`, but only after four short-circuits: a negative exponent
+goes to the float path, a zero exponent returns 1, and a base of 0 / 1 / -1
+returns a constant. The walker specialises the remaining case, so each of the
+short-circuits has to keep working at a site that has already been traced.
+"""
+
+ROUNDS = 3000
+BIG = (1 << 200) + 12345
+NEG = -BIG
+
+
+def positive_exponents():
+    out = None
+    for _ in range(ROUNDS):
+        out = (BIG**1, BIG**2, BIG**3, NEG**2, NEG**3)
+    return [x % (10**30) for x in out]
+
+
+def zero_and_negative():
+    out = None
+    for _ in range(ROUNDS):
+        out = (BIG**0, NEG**0, type(BIG**0) is int)
+    neg = BIG**-1
+    return out, type(neg) is float, round(neg, 70) == 0.0
+
+
+def small_bases():
+    """A long whose payload fits a machine word must not take the fast arm."""
+    out = None
+    tiny = (1 << 70) >> 70
+    for _ in range(ROUNDS):
+        out = (tiny**5, (tiny - 1) ** 7, (-tiny) ** 3, (-tiny) ** 4)
+    return out
+
+
+def bool_exponent():
+    out = None
+    for _ in range(ROUNDS):
+        out = (BIG**True, BIG**False)
+    return [x % (10**20) for x in out]
+
+
+def alternating_exponent():
+    """One site alternating between the fast arm and the zero short-circuit."""
+    acc = 0
+    for i in range(ROUNDS):
+        e = 2 if (i & 1) else 0
+        acc ^= (BIG**e) & 0xFFFF
+    return acc
+
+
+def inplace_pow():
+    a = None
+    for _ in range(ROUNDS):
+        a = BIG
+        a **= 2
+    return a % (10**25)
+
+
+def three_arg():
+    """`pow(a, b, m)` is not a BINARY_OP and must keep its modulus."""
+    out = None
+    for _ in range(ROUNDS):
+        out = pow(BIG, 3, 1000003)
+    return out
+
+
+print(positive_exponents())
+print(zero_and_negative())
+print(small_bases())
+print(bool_exponent())
+print(alternating_exponent())
+print(inplace_pow())
+print(three_arg())
+print("OK")

--- a/pyre/extra_tests/parity_tests/long_int_pow_jit.py
+++ b/pyre/extra_tests/parity_tests/long_int_pow_jit.py
@@ -24,7 +24,7 @@ def zero_and_negative():
     for _ in range(ROUNDS):
         out = (BIG**0, NEG**0, type(BIG**0) is int)
     neg = BIG**-1
-    return out, type(neg) is float, round(neg, 70) == 0.0
+    return out, type(neg) is float, 0.0 < neg < 1e-50
 
 
 def small_bases():

--- a/pyre/extra_tests/parity_tests/math_lcm_argument_validation.py
+++ b/pyre/extra_tests/parity_tests/math_lcm_argument_validation.py
@@ -1,0 +1,56 @@
+"""`math.lcm` converts every argument even after the result reaches zero."""
+
+import math
+
+
+def raises_type_error(operation):
+    try:
+        operation()
+    except TypeError as exc:
+        assert "cannot be interpreted as an integer" in str(exc), str(exc)
+    else:
+        raise AssertionError("lcm skipped an argument conversion")
+
+
+assert math.lcm() == 1
+assert math.lcm(-5) == 5
+assert math.lcm(6, 10) == 30
+assert math.lcm(6, 10, 14) == 210
+assert math.lcm(0, 0) == 0
+assert math.lcm(0, 3) == 0
+assert math.lcm(3, 0) == 0
+assert math.lcm(0, 2**70) == 0
+assert math.lcm(2**70, 0, 5) == 0
+
+# A zero short-circuits the arithmetic only; the remaining arguments still go
+# through __index__, so a non-integer after a zero is still a TypeError.
+raises_type_error(lambda: math.lcm(0, 1.5))
+raises_type_error(lambda: math.lcm(4, 0, 1.5))
+raises_type_error(lambda: math.lcm(0, 0, "a"))
+raises_type_error(lambda: math.lcm(0, object()))
+
+
+class Index:
+    def __init__(self, value):
+        self.value = value
+
+    def __index__(self):
+        return self.value
+
+
+assert math.lcm(0, Index(4)) == 0
+assert math.lcm(Index(6), Index(10)) == 30
+
+calls = []
+
+
+class Counting:
+    def __index__(self):
+        calls.append(1)
+        return 0
+
+
+assert math.lcm(0, Counting(), Counting()) == 0
+assert len(calls) == 2, calls
+
+print("OK")

--- a/pyre/extra_tests/parity_tests/object_surface_python314.py
+++ b/pyre/extra_tests/parity_tests/object_surface_python314.py
@@ -82,3 +82,5 @@ else:
 
 assert object.__doc__.startswith("The base class of the class hierarchy.")
 print("object surface: ok")
+
+print("OK")

--- a/pyre/extra_tests/parity_tests/rbigint_mixed_int_jit.py
+++ b/pyre/extra_tests/parity_tests/rbigint_mixed_int_jit.py
@@ -1,5 +1,7 @@
 """Mixed machine-int/rbigint paths used by PyPy's longobject descriptors."""
 
+import gc
+
 
 BIG = (1 << 4095) + (1 << 2001) + 0x123456789
 MASK = (1 << 127) - 1
@@ -54,6 +56,23 @@ def comparisons(rounds):
 
 
 assert comparisons(20_000) == 120_000
+
+
+def clone_prebuilt_zero(rounds):
+    checksum = 0
+    for i in range(rounds):
+        # The long-long subtraction stays on the rbigint path even though its
+        # numeric result is the translated prebuilt zero. Unary negation then
+        # exercises RBigInt::clone's fresh-handle residual. Collections make a
+        # stale alias or an unrooted shared digit edge fail deterministically.
+        zero = BIG - BIG
+        checksum += -zero
+        if i & 255 == 0:
+            gc.collect()
+    return checksum
+
+
+assert clone_prebuilt_zero(20_000) == 0
 
 
 def shift_guards(rounds):

--- a/pyre/extra_tests/parity_tests/rbigint_mixed_int_jit.py
+++ b/pyre/extra_tests/parity_tests/rbigint_mixed_int_jit.py
@@ -80,3 +80,5 @@ def shift_guards(rounds):
 
 
 assert shift_guards(20_000) == (True, -1)
+
+print("OK")

--- a/pyre/extra_tests/parity_tests/run.py
+++ b/pyre/extra_tests/parity_tests/run.py
@@ -16,7 +16,12 @@ semantics.
 
 Usage:
     python3 pyre/extra_tests/parity_tests/run.py
-        [--dynasm-only|--cranelift-only]
+        [--dynasm-only|--cranelift-only] [--gc-poison]
+
+`--gc-poison` fills reclaimed nursery bytes with a poison pattern for the
+pyre backends. A dangling reference into reclaimed nursery memory usually
+still decodes as a plausible object, so without poison that whole class of
+GC defect passes silently; with it the run aborts at the first stale read.
 
 Exit code is 0 iff every (script, backend) pair passed.
 """
@@ -45,7 +50,7 @@ def _scripts() -> list[Path]:
     return out
 
 
-def _run(cmd: list[str], script: Path) -> tuple[bool, str]:
+def _run(cmd: list[str], script: Path, env: dict[str, str] | None) -> tuple[bool, str]:
     try:
         proc = subprocess.run(
             cmd + [str(script)],
@@ -54,6 +59,7 @@ def _run(cmd: list[str], script: Path) -> tuple[bool, str]:
             encoding="utf-8",
             errors="replace",
             timeout=30,
+            env=None if env is None else {**os.environ, **env},
         )
     except subprocess.TimeoutExpired:
         return False, "timeout"
@@ -66,16 +72,19 @@ def _run(cmd: list[str], script: Path) -> tuple[bool, str]:
     return ok, detail
 
 
-def _runners(only_dynasm: bool, only_cranelift: bool) -> list[tuple[str, list[str]]]:
-    runners: list[tuple[str, list[str]]] = []
+def _runners(
+    only_dynasm: bool, only_cranelift: bool, gc_poison: bool
+) -> list[tuple[str, list[str], dict[str, str] | None]]:
+    runners: list[tuple[str, list[str], dict[str, str] | None]] = []
     cpython = os.environ.get("PYRE_CHECK_PYTHON3") or "python3"
-    runners.append(("cpython", [cpython]))
+    runners.append(("cpython", [cpython], None))
+    pyre_env = {"MAJIT_GC_NURSERY_POISON": "1"} if gc_poison else None
     dynasm = TARGET_RELEASE / f"pyre-dynasm{EXE}"
     cranelift = TARGET_RELEASE / f"pyre-cranelift{EXE}"
     if not only_cranelift and dynasm.exists():
-        runners.append(("dynasm", [str(dynasm)]))
+        runners.append(("dynasm", [str(dynasm)], pyre_env))
     if not only_dynasm and cranelift.exists():
-        runners.append(("cranelift", [str(cranelift)]))
+        runners.append(("cranelift", [str(cranelift)], pyre_env))
     return runners
 
 
@@ -83,15 +92,16 @@ def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--dynasm-only", action="store_true")
     parser.add_argument("--cranelift-only", action="store_true")
+    parser.add_argument("--gc-poison", action="store_true")
     args = parser.parse_args()
 
-    runners = _runners(args.dynasm_only, args.cranelift_only)
+    runners = _runners(args.dynasm_only, args.cranelift_only, args.gc_poison)
     scripts = _scripts()
     if not scripts:
         print("no parity test scripts found", file=sys.stderr)
         return 1
 
-    print(f"runners: {[name for name, _ in runners]}")
+    print(f"runners: {[name for name, _, _ in runners]}")
     print(f"scripts: {len(scripts)}")
     print()
 
@@ -99,8 +109,8 @@ def main() -> int:
     for script in scripts:
         name = script.name
         row: list[str] = [f"  {name:<36s}"]
-        for backend, cmd in runners:
-            ok, detail = _run(cmd, script)
+        for backend, cmd, env in runners:
+            ok, detail = _run(cmd, script, env)
             mark = "OK" if ok else "FAIL"
             row.append(f"{backend}={mark}")
             if not ok:

--- a/pyre/extra_tests/parity_tests/str_surface.py
+++ b/pyre/extra_tests/parity_tests/str_surface.py
@@ -16,3 +16,5 @@ class Index:
 
 assert str.__rmul__("xy", Index()) == "xyxy"
 print("str surface: ok")
+
+print("OK")

--- a/pyre/extra_tests/parity_tests/thread_local_and_lock_acquire.py
+++ b/pyre/extra_tests/parity_tests/thread_local_and_lock_acquire.py
@@ -159,11 +159,19 @@ assert rlock.acquire() is True
 rlock.release()
 rlock.release()
 
-# `TIMEOUT_MAX` is the whole-second bound of the nanosecond timestamp the
-# argument is converted to, and that conversion runs before either the
-# blocking or the sign check.
-assert _thread.TIMEOUT_MAX == 9223372036.0
+# `TIMEOUT_MAX` is the largest timeout `acquire` accepts, floored to whole
+# seconds.  The bound is platform-dependent — each implementation clamps it to
+# what its own wait API takes, and on Windows that is far below the nanosecond
+# timestamp bound — so pin the relationships to it rather than one platform's
+# constant.
+timeout_max = _thread.TIMEOUT_MAX
+assert isinstance(timeout_max, float)
+assert timeout_max > 0.0
+assert timeout_max == float(int(timeout_max))
 
+# The timestamp conversion runs before either the blocking or the sign check,
+# so a value past the nanosecond range raises from that conversion on every
+# platform, whatever `TIMEOUT_MAX` happens to be.
 for timeout, exc_type, message in [
     (float("nan"), ValueError, "Invalid value NaN (not a number)"),
     (9223372036.9, OverflowError, "timestamp out of range for platform time_t"),
@@ -185,7 +193,7 @@ except ValueError as exc:
 else:
     raise AssertionError("non-blocking acquire accepted a timeout")
 
-# The fractional tail below the nanosecond bound is still in range.
-assert _thread.allocate_lock().acquire(True, 9223372036.854) is True
+# The bound is inclusive.
+assert _thread.allocate_lock().acquire(True, timeout_max) is True
 
 print("OK")

--- a/pyre/extra_tests/parity_tests/unpack_specialised_pair_shapes.py
+++ b/pyre/extra_tests/parity_tests/unpack_specialised_pair_shapes.py
@@ -1,0 +1,86 @@
+# Arity-2 unpacks across every makespecialisedtuple2 arm, plus the shapes the
+# fold must decline.
+BIG = (1 << 4095) + (1 << 2001) + 0x123456789
+
+
+def oo_longs(rounds):
+    acc = 0
+    for i in range(rounds):
+        q, r = divmod(BIG + i, (1 << 755) + 0xABCDEF)
+        acc ^= (q ^ r) & 0xFFFF
+    return acc
+
+
+def oo_strings(rounds):
+    acc = 0
+    for i in range(rounds):
+        a, b = ("left", "right")
+        acc += len(a) + len(b) + (i & 1)
+    return acc
+
+
+def oo_mixed(rounds):
+    acc = 0
+    for i in range(rounds):
+        a, b = (i, BIG)
+        acc ^= (a ^ (b & 0xFF))
+    return acc
+
+
+def ii_ints(rounds):
+    acc = 0
+    for i in range(rounds):
+        q, r = divmod(i + 7919, 97)
+        acc ^= q ^ r
+    return acc
+
+
+def ff_floats(rounds):
+    acc = 0.0
+    for i in range(rounds):
+        a, b = (1.5, 2.5)
+        acc += a * b + i
+    return acc
+
+
+def arity3(rounds):
+    acc = 0
+    for i in range(rounds):
+        a, b, c = (i, i + 1, BIG)
+        acc ^= a ^ b ^ (c & 0xFF)
+    return acc
+
+
+def from_list(rounds):
+    acc = 0
+    for i in range(rounds):
+        a, b = [i, BIG]
+        acc ^= a ^ (b & 0xFF)
+    return acc
+
+
+def wrong_arity_raises(rounds):
+    seen = 0
+    for i in range(rounds):
+        try:
+            a, b = (1, 2, 3)
+        except ValueError:
+            seen += 1
+    return seen
+
+
+def alternating(rounds):
+    # The same UNPACK_SEQUENCE site sees ii then oo, so the class guard must
+    # deopt rather than read oo fields off an ii layout.
+    acc = 0
+    for i in range(rounds):
+        pair = (i, i + 1) if i % 2 else (BIG, "s")
+        a, b = pair
+        acc ^= (a & 0xFF) if isinstance(a, int) else 0
+    return acc
+
+
+for fn in (oo_longs, oo_strings, oo_mixed, ii_ints, ff_floats, arity3,
+           from_list, wrong_arity_raises, alternating):
+    print(fn.__name__, fn(3000))
+print("OK")

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -2136,7 +2136,10 @@ fn iterator_reduce_tuple(
     let _roots = pyre_object::gc_roots::push_roots();
     let sp = pyre_object::gc_roots::shadow_stack_len();
     pyre_object::gc_roots::pin_root(callable);
-    if seq.is_null() {
+    // A negative cursor is the exhausted sentinel the list iterators store,
+    // and `listiter_reduce`/`listreviter_reduce` report the empty producer for
+    // it even while the source list is still referenced.
+    if seq.is_null() || index < 0 {
         // CPython 3.14 retains the concrete producer shape for the
         // specialized string/list iterators; generic sequence, bytes and
         // tuple iterators use the canonical empty tuple.
@@ -2312,12 +2315,16 @@ pub(crate) fn list_iter_setstate_method(args: &[PyObjectRef]) -> PyResult {
         if seq.is_null() {
             return Ok(w_none());
         }
-        if index < 0 {
-            pyre_object::w_list_iter_set_seq(args[0], PY_NULL);
-            return Ok(w_none());
-        }
+        // `listiter_setstate`: a negative cursor becomes the -1 exhausted
+        // sentinel rather than being clamped to zero, and an over-long one
+        // stops at the current length.  The source list stays referenced, so a
+        // later in-range `__setstate__` revives the iterator.  PyPy's
+        // `W_AbstractSeqIterObject.descr_setstate` clamps negatives to zero
+        // instead, which resumes iteration from the front.
         let length = pyre_object::w_list_len(seq) as i64;
-        if index > length {
+        if index < 0 {
+            index = -1;
+        } else if index > length {
             index = length;
         }
         pyre_object::w_list_iter_set_index(args[0], index);
@@ -2328,11 +2335,12 @@ pub(crate) fn list_iter_setstate_method(args: &[PyObjectRef]) -> PyResult {
 pub(crate) fn list_iter_length_hint_method(args: &[PyObjectRef]) -> PyResult {
     unsafe {
         let seq = pyre_object::w_list_iter_seq(args[0]);
-        if seq.is_null() {
+        let index = pyre_object::w_list_iter_index(args[0]);
+        if seq.is_null() || index < 0 {
             return Ok(w_int_new(0));
         }
         Ok(w_int_new(
-            (pyre_object::w_list_len(seq) as i64 - pyre_object::w_list_iter_index(args[0])).max(0),
+            (pyre_object::w_list_len(seq) as i64 - index).max(0),
         ))
     }
 }
@@ -2426,6 +2434,10 @@ pub(crate) fn list_reverse_iter_setstate_method(args: &[PyObjectRef]) -> PyResul
             index = -1;
         } else if index >= length {
             index = length - 1;
+        } else if index < 0 {
+            // `listreviter_setstate` keeps -1 as the single exhausted
+            // sentinel, so every negative cursor normalizes to it.
+            index = -1;
         }
         pyre_object::w_list_reverse_iter_set_index(args[0], index);
     }
@@ -12576,6 +12588,12 @@ pub fn next(obj: PyObjectRef) -> PyResult {
                 return Err(PyError::stop_iteration());
             }
             let index = pyre_object::w_list_iter_index(obj);
+            // A negative cursor is the `__setstate__` exhausted sentinel; it
+            // keeps the source list so an in-range `__setstate__` can revive
+            // the iterator, unlike running off the end.
+            if index < 0 {
+                return Err(PyError::stop_iteration());
+            }
             if let Some(item) = pyre_object::w_list_getitem(seq, index) {
                 pyre_object::w_list_iter_set_index(obj, index + 1);
                 return Ok(item);
@@ -12595,8 +12613,8 @@ pub fn next(obj: PyObjectRef) -> PyResult {
                     return Ok(item);
                 }
             }
-            // The descending cursor alone marks exhaustion; the list stays
-            // referenced so `__setstate__` can put the cursor back on it.
+            // `listreviter_next` only parks the -1 sentinel; the source list
+            // stays referenced so `__setstate__` can restart the descent.
             pyre_object::w_list_reverse_iter_set_index(obj, -1);
             return Err(PyError::stop_iteration());
         }

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -13,7 +13,7 @@
 // additional unsafe block adds noise without safety benefit.
 #![allow(unsafe_op_in_unsafe_fn)]
 
-use pyre_object::rbigint::{RBigInt as BigInt, RBigIntSign};
+use pyre_object::rbigint::{RBigInt as BigInt, RBigIntGcRoot};
 
 use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
@@ -1027,7 +1027,11 @@ pub(crate) fn is_true_slot(obj: PyObjectRef) -> Result<bool, PyError> {
             return Ok(w_int_get_value(obj) != 0);
         }
         if is_long(obj) {
-            return Ok(w_long_get_value(obj).clone() != BigInt::from(0));
+            // longobject.py W_LongObject.descr_bool delegates to the rbigint
+            // sign.  Cloning the Rust handle here becomes a fresh translated
+            // GC payload (`jit_bigint_clone`) and comparing against a newly
+            // materialized zero, neither of which exists in the RPython path.
+            return Ok(w_long_get_value(obj).get_sign() != 0);
         }
         if is_float(obj) {
             return Ok(w_float_get_value(obj) != 0.0);
@@ -1878,8 +1882,10 @@ unsafe fn compute_slice_indices3_big(
     let zero = BigInt::zero();
     let one = BigInt::one();
     let w_step = w_slice_get_step(slice);
-    let step = if is_none(w_step) {
-        one.clone()
+    // RPython's stack map roots each of these unboxed rbigint values while
+    // the following slice component's `space.index()` can call Python.
+    let step = RBigIntGcRoot::new(if is_none(w_step) {
+        one.translated_alias()
     } else {
         let s = pyre_object::range_obj_to_bigint(space_index(w_step)?);
         if s.is_zero() {
@@ -1889,14 +1895,14 @@ unsafe fn compute_slice_indices3_big(
             ));
         }
         s
-    };
-    let negative_step = step < zero;
+    });
+    let negative_step = *step < zero;
     let w_start = w_slice_get_start(slice);
-    let start = if is_none(w_start) {
+    let start = RBigIntGcRoot::new(if is_none(w_start) {
         if negative_step {
             length - &one
         } else {
-            zero.clone()
+            zero.translated_alias()
         }
     } else {
         let st = pyre_object::range_obj_to_bigint(space_index(w_start)?);
@@ -1904,9 +1910,9 @@ unsafe fn compute_slice_indices3_big(
             let st = st + length;
             if st < zero {
                 if negative_step {
-                    -one.clone()
+                    one.neg()
                 } else {
-                    zero.clone()
+                    zero.translated_alias()
                 }
             } else {
                 st
@@ -1915,18 +1921,18 @@ unsafe fn compute_slice_indices3_big(
             if negative_step {
                 length - &one
             } else {
-                length.clone()
+                length.translated_alias()
             }
         } else {
             st
         }
-    };
+    });
     let w_stop = w_slice_get_stop(slice);
-    let stop = if is_none(w_stop) {
+    let stop = RBigIntGcRoot::new(if is_none(w_stop) {
         if negative_step {
-            -one.clone()
+            one.neg()
         } else {
-            length.clone()
+            length.translated_alias()
         }
     } else {
         let sp = pyre_object::range_obj_to_bigint(space_index(w_stop)?);
@@ -1934,9 +1940,9 @@ unsafe fn compute_slice_indices3_big(
             let sp = sp + length;
             if sp < zero {
                 if negative_step {
-                    -one.clone()
+                    one.neg()
                 } else {
-                    zero.clone()
+                    zero.translated_alias()
                 }
             } else {
                 sp
@@ -1945,13 +1951,17 @@ unsafe fn compute_slice_indices3_big(
             if negative_step {
                 length - &one
             } else {
-                length.clone()
+                length.translated_alias()
             }
         } else {
             sp
         }
-    };
-    Ok((start, stop, step))
+    });
+    Ok((
+        start.translated_alias(),
+        stop.translated_alias(),
+        step.translated_alias(),
+    ))
 }
 
 /// `functional.py W_Range._compute_slice` — build the NEW `range`
@@ -1959,22 +1969,27 @@ unsafe fn compute_slice_indices3_big(
 unsafe fn range_compute_slice(obj: PyObjectRef, slice: PyObjectRef) -> PyResult {
     let len_b = pyre_object::range_obj_to_bigint(pyre_object::w_range_length(obj));
     let (sl_start, sl_stop, sl_step) = compute_slice_indices3_big(slice, &len_b)?;
+    let sl_start = RBigIntGcRoot::new(sl_start);
+    let sl_stop = RBigIntGcRoot::new(sl_stop);
+    let sl_step = RBigIntGcRoot::new(sl_step);
     let (rstart, _rstop, rstep) = pyre_object::w_range_fields(obj);
     let rstart_b = pyre_object::range_obj_to_bigint(rstart);
     let rstep_b = pyre_object::range_obj_to_bigint(rstep);
-    let substart = &rstart_b + &sl_start * &rstep_b;
-    let substep = &rstep_b * &sl_step;
+    let substart = RBigIntGcRoot::new(&rstart_b + &*sl_start * &rstep_b);
+    let substep = RBigIntGcRoot::new(&rstep_b * &*sl_step);
+    // Compute and root every unboxed output before the first wrapping
+    // allocation, which may collect.
+    let substop = RBigIntGcRoot::new(&rstart_b + &*sl_stop * &rstep_b);
     let _roots = pyre_object::gc_roots::push_roots();
-    let w_substart = pyre_object::range_bigint_to_obj(substart);
+    let w_substart = pyre_object::range_bigint_to_obj(substart.translated_alias());
     pyre_object::gc_roots::pin_root(w_substart);
-    let w_substep = pyre_object::range_bigint_to_obj(substep);
+    let w_substep = pyre_object::range_bigint_to_obj(substep.translated_alias());
     pyre_object::gc_roots::pin_root(w_substep);
     // functional.py:523-526 tests `if w_stop`, i.e. whether the wrapped
     // pointer exists, not whether its integer payload is zero.  The wrapped
     // result of compute_slice_indices3 is always present, so compute the stop
     // lane even when its value is 0 (notably for `r[-1:-3:-1]`).
-    let substop = &rstart_b + &sl_stop * &rstep_b;
-    let w_substop = pyre_object::range_bigint_to_obj(substop);
+    let w_substop = pyre_object::range_bigint_to_obj(substop.translated_alias());
     pyre_object::gc_roots::pin_root(w_substop);
     Ok(pyre_object::w_range_new(w_substart, w_substop, w_substep))
 }
@@ -2009,19 +2024,21 @@ pub(crate) fn range_count_method(args: &[PyObjectRef]) -> PyResult {
     // merely until the first match.  Keep the counter unbounded like PyPy's
     // wrapped integer accumulator.
     let it = iter(obj)?;
-    let mut count = BigInt::from(0);
+    // The iterator and equality operation can execute Python between
+    // increments; RPython keeps the bigint accumulator in its root map.
+    let mut count = RBigIntGcRoot::new(BigInt::from(0));
     loop {
         match next(it) {
             Ok(item) => {
                 if is_true(compare(item, needle, CompareOp::Eq)?)? {
-                    count = count.int_add(1);
+                    *count = count.int_add(1);
                 }
             }
             Err(e) if e.kind == PyErrorKind::StopIteration => break,
             Err(e) => return Err(e),
         }
     }
-    Ok(pyre_object::range_bigint_to_obj(count))
+    Ok(pyre_object::range_bigint_to_obj(count.translated_alias()))
 }
 
 /// `range.index(value)` — `functional.py W_Range.descr_index`.
@@ -2467,10 +2484,12 @@ pub(crate) fn list_reverse_iter_length_hint_method(args: &[PyObjectRef]) -> PyRe
 pub(crate) fn range_iter_reduce_method(args: &[PyObjectRef]) -> PyResult {
     unsafe {
         let (current, remaining, step) = pyre_object::w_range_iter_fields(args[0]);
-        let stop = BigInt::from(current) + BigInt::from(remaining) * step;
+        // `w_int_new(current)` may collect before the computed stop is
+        // wrapped, so preserve the RPython stack-map root explicitly.
+        let stop = RBigIntGcRoot::new(BigInt::from(current) + BigInt::from(remaining) * step);
         let w_range = pyre_object::w_range_new(
             w_int_new(current),
-            pyre_object::range_bigint_to_obj(stop),
+            pyre_object::range_bigint_to_obj(stop.translated_alias()),
             w_int_new(step),
         );
         let state = w_tuple_new(vec![w_range]);
@@ -2493,11 +2512,11 @@ pub(crate) fn long_range_iter_reduce_method(args: &[PyObjectRef]) -> PyResult {
         let step_b = pyre_object::range_obj_to_bigint(step);
         let len_b = pyre_object::range_obj_to_bigint(len);
         let index_b = pyre_object::range_obj_to_bigint(index);
-        let current = &start_b + &index_b * &step_b;
-        let stop = &start_b + &len_b * &step_b;
+        let current = RBigIntGcRoot::new(&start_b + &index_b * &step_b);
+        let stop = RBigIntGcRoot::new(&start_b + &len_b * &step_b);
         let w_range = pyre_object::w_range_new(
-            pyre_object::range_bigint_to_obj(current),
-            pyre_object::range_bigint_to_obj(stop),
+            pyre_object::range_bigint_to_obj(current.translated_alias()),
+            pyre_object::range_bigint_to_obj(stop.translated_alias()),
             pyre_object::range_bigint_to_obj(step_b),
         );
         let state = w_tuple_new(vec![w_range]);
@@ -7340,7 +7359,6 @@ pub fn gateway_nonnegint_w(obj: PyObjectRef) -> Result<i64, PyError> {
 /// apply __int__/__index__ conversion: a non-int object raises TypeError
 /// (W_Root.uint_w → _typed_unwrap_error).
 pub fn uint_w(obj: PyObjectRef) -> Result<u64, PyError> {
-    use num_traits::ToPrimitive;
     if obj.is_null() {
         return Err(PyError::type_error("uint_w: null object"));
     }
@@ -7356,15 +7374,18 @@ pub fn uint_w(obj: PyObjectRef) -> Result<u64, PyError> {
     }
     // W_LongObject.uint_w — num.touint().
     if unsafe { pyre_object::pyobject::is_long(obj) } {
-        let big = unsafe { crate::builtins::obj_to_bigint(obj) };
-        if big.sign() == RBigIntSign::Minus {
+        let big = unsafe { pyre_object::w_long_get_value(obj) };
+        if big.get_sign() < 0 {
             return Err(PyError::value_error(
                 "cannot convert negative integer to unsigned int",
             ));
         }
-        return big
-            .to_u64()
-            .ok_or_else(|| PyError::overflow_error("int too large to convert to unsigned int"));
+        if pyre_object::longobject::jit_bigint_to_u64_fits(big) != 0 {
+            return Ok(pyre_object::longobject::jit_bigint_to_u64_value(big));
+        }
+        return Err(PyError::overflow_error(
+            "int too large to convert to unsigned int",
+        ));
     }
     // W_Root.uint_w → _typed_unwrap_error(space, "integer").
     let tp_name = unsafe { (*(*obj).ob_type).name };
@@ -7482,7 +7503,6 @@ pub fn truncatedint_w(obj: PyObjectRef) -> Result<i64, PyError> {
     match int_w(obj) {
         Ok(value) => Ok(value),
         Err(e) if e.kind == PyErrorKind::OverflowError => {
-            use num_traits::ToPrimitive;
             // intmask(self.bigint_w(w_obj).uintmask()): bigint_w applies
             // __int__/__index__ conversion, so read the bigint from the
             // converted int object rather than the raw argument.
@@ -7491,9 +7511,16 @@ pub fn truncatedint_w(obj: PyObjectRef) -> Result<i64, PyError> {
             } else {
                 space_int(obj)?
             };
-            let big = unsafe { crate::builtins::obj_to_bigint(w_int_obj) };
-            let low = (&big & BigInt::from(u64::MAX)).to_u64().unwrap_or(0);
-            Ok(low as i64)
+            let owned;
+            let big = unsafe {
+                if pyre_object::is_long(w_int_obj) {
+                    pyre_object::w_long_get_value(w_int_obj)
+                } else {
+                    owned = BigInt::from(pyre_object::w_int_get_value(w_int_obj));
+                    &owned
+                }
+            };
+            Ok(big.uintmask() as i64)
         }
         Err(e) => Err(e),
     }
@@ -11426,8 +11453,10 @@ pub fn space_index(obj: PyObjectRef) -> Result<PyObjectRef, PyError> {
                     w_result,
                 )));
             }
-            return Ok(pyre_object::w_long_new(
-                pyre_object::w_long_get_value(w_result).clone(),
+            // W_LongObject.int/newlong strips the strict subclass by creating
+            // a base wrapper around the same immutable rbigint payload.
+            return Ok(pyre_object::longobject::w_long_from_raw(
+                pyre_object::longobject::w_long_get_raw_value(w_result),
             ));
         }
     }
@@ -11499,8 +11528,8 @@ pub fn getindex_w(obj: PyObjectRef) -> Result<i64, PyError> {
     match int_w(w_index) {
         Ok(index) => Ok(index),
         Err(e) if e.kind == PyErrorKind::OverflowError => {
-            let big = unsafe { crate::builtins::obj_to_bigint(w_index) };
-            if big.sign() == RBigIntSign::Minus {
+            let big = unsafe { pyre_object::w_long_get_value(w_index) };
+            if big.get_sign() < 0 {
                 Ok(i64::MIN)
             } else {
                 Ok(i64::MAX)
@@ -11521,8 +11550,8 @@ pub fn index_int_w_preserve_negative(obj: PyObjectRef) -> Result<i64, PyError> {
     match int_w(w_index) {
         Ok(index) => Ok(index),
         Err(error) if error.kind == PyErrorKind::OverflowError => {
-            let big = unsafe { crate::builtins::obj_to_bigint(w_index) };
-            if big.sign() == RBigIntSign::Minus {
+            let big = unsafe { pyre_object::w_long_get_value(w_index) };
+            if big.get_sign() < 0 {
                 Ok(i64::MIN)
             } else {
                 Err(error)
@@ -15035,6 +15064,27 @@ pub fn generator_finalize(gen_obj: PyObjectRef) -> PyResult {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn uint_and_truncatedint_use_rbigint_word_conversions() {
+        let unsigned_max = pyre_object::longobject::w_long_new(BigInt::from_u128(u64::MAX as u128));
+        assert_eq!(uint_w(unsigned_max).unwrap(), u64::MAX);
+
+        let overflow =
+            pyre_object::longobject::w_long_new(BigInt::one().lshift(130).expect("fixed shift"));
+        assert_eq!(
+            uint_w(overflow).unwrap_err().kind,
+            PyErrorKind::OverflowError
+        );
+
+        let low_word = 0x0123_4567_89ab_cdef_u64;
+        let value = BigInt::one()
+            .lshift(200)
+            .expect("fixed shift")
+            .int_add(low_word as i64);
+        let wrapped = pyre_object::longobject::w_long_new(value);
+        assert_eq!(truncatedint_w(wrapped).unwrap(), low_word as i64);
+    }
 
     #[test]
     fn test_setattr_getattr_and_overwrite() {

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -1879,9 +1879,16 @@ unsafe fn compute_slice_indices3_big(
     length: &BigInt,
 ) -> Result<(BigInt, BigInt, BigInt), PyError> {
     use num_traits::{One, Zero};
+    let _roots = pyre_object::gc_roots::push_roots();
+    pyre_object::gc_roots::pin_root(slice);
+    let slice_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+    // `space.index` below can invoke arbitrary Python. RPython's GC transform
+    // keeps both the slice object and incoming rbigint live across every
+    // callback.
+    let length = RBigIntGcRoot::new(length.translated_alias());
     let zero = BigInt::zero();
     let one = BigInt::one();
-    let w_step = w_slice_get_step(slice);
+    let w_step = w_slice_get_step(pyre_object::gc_roots::shadow_stack_get(slice_slot));
     // RPython's stack map roots each of these unboxed rbigint values while
     // the following slice component's `space.index()` can call Python.
     let step = RBigIntGcRoot::new(if is_none(w_step) {
@@ -1897,17 +1904,17 @@ unsafe fn compute_slice_indices3_big(
         s
     });
     let negative_step = *step < zero;
-    let w_start = w_slice_get_start(slice);
+    let w_start = w_slice_get_start(pyre_object::gc_roots::shadow_stack_get(slice_slot));
     let start = RBigIntGcRoot::new(if is_none(w_start) {
         if negative_step {
-            length - &one
+            &*length - &one
         } else {
             zero.translated_alias()
         }
     } else {
         let st = pyre_object::range_obj_to_bigint(space_index(w_start)?);
         if st < zero {
-            let st = st + length;
+            let st = st + &*length;
             if st < zero {
                 if negative_step {
                     one.neg()
@@ -1919,7 +1926,7 @@ unsafe fn compute_slice_indices3_big(
             }
         } else if st >= *length {
             if negative_step {
-                length - &one
+                &*length - &one
             } else {
                 length.translated_alias()
             }
@@ -1927,7 +1934,7 @@ unsafe fn compute_slice_indices3_big(
             st
         }
     });
-    let w_stop = w_slice_get_stop(slice);
+    let w_stop = w_slice_get_stop(pyre_object::gc_roots::shadow_stack_get(slice_slot));
     let stop = RBigIntGcRoot::new(if is_none(w_stop) {
         if negative_step {
             one.neg()
@@ -1937,7 +1944,7 @@ unsafe fn compute_slice_indices3_big(
     } else {
         let sp = pyre_object::range_obj_to_bigint(space_index(w_stop)?);
         if sp < zero {
-            let sp = sp + length;
+            let sp = sp + &*length;
             if sp < zero {
                 if negative_step {
                     one.neg()
@@ -1949,7 +1956,7 @@ unsafe fn compute_slice_indices3_big(
             }
         } else if sp >= *length {
             if negative_step {
-                length - &one
+                &*length - &one
             } else {
                 length.translated_alias()
             }
@@ -1967,19 +1974,23 @@ unsafe fn compute_slice_indices3_big(
 /// `functional.py W_Range._compute_slice` — build the NEW `range`
 /// a slice of `obj` denotes.
 unsafe fn range_compute_slice(obj: PyObjectRef, slice: PyObjectRef) -> PyResult {
+    let _roots = pyre_object::gc_roots::push_roots();
+    pyre_object::gc_roots::pin_root(obj);
+    let obj_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let len_b = pyre_object::range_obj_to_bigint(pyre_object::w_range_length(obj));
     let (sl_start, sl_stop, sl_step) = compute_slice_indices3_big(slice, &len_b)?;
     let sl_start = RBigIntGcRoot::new(sl_start);
     let sl_stop = RBigIntGcRoot::new(sl_stop);
     let sl_step = RBigIntGcRoot::new(sl_step);
-    let (rstart, _rstop, rstep) = pyre_object::w_range_fields(obj);
-    let rstart_b = pyre_object::range_obj_to_bigint(rstart);
-    let rstep_b = pyre_object::range_obj_to_bigint(rstep);
-    let substart = RBigIntGcRoot::new(&rstart_b + &*sl_start * &rstep_b);
-    let substep = RBigIntGcRoot::new(&rstep_b * &*sl_step);
+    let (rstart, _rstop, rstep) =
+        pyre_object::w_range_fields(pyre_object::gc_roots::shadow_stack_get(obj_slot));
+    let rstart_b = RBigIntGcRoot::new(pyre_object::range_obj_to_bigint(rstart));
+    let rstep_b = RBigIntGcRoot::new(pyre_object::range_obj_to_bigint(rstep));
+    let substart = RBigIntGcRoot::new(&*rstart_b + &*sl_start * &*rstep_b);
+    let substep = RBigIntGcRoot::new(&*rstep_b * &*sl_step);
     // Compute and root every unboxed output before the first wrapping
     // allocation, which may collect.
-    let substop = RBigIntGcRoot::new(&rstart_b + &*sl_stop * &rstep_b);
+    let substop = RBigIntGcRoot::new(&*rstart_b + &*sl_stop * &*rstep_b);
     let _roots = pyre_object::gc_roots::push_roots();
     let w_substart = pyre_object::range_bigint_to_obj(substart.translated_alias());
     pyre_object::gc_roots::pin_root(w_substart);
@@ -2484,15 +2495,28 @@ pub(crate) fn list_reverse_iter_length_hint_method(args: &[PyObjectRef]) -> PyRe
 pub(crate) fn range_iter_reduce_method(args: &[PyObjectRef]) -> PyResult {
     unsafe {
         let (current, remaining, step) = pyre_object::w_range_iter_fields(args[0]);
-        // `w_int_new(current)` may collect before the computed stop is
-        // wrapped, so preserve the RPython stack-map root explicitly.
         let stop = RBigIntGcRoot::new(BigInt::from(current) + BigInt::from(remaining) * step);
+        // Python evaluates and keeps all three wrapped arguments before
+        // W_Range construction. Mirror the GC transform's root slots between
+        // those allocating expressions.
+        let _roots = pyre_object::gc_roots::push_roots();
+        let w_current = w_int_new(current);
+        pyre_object::gc_roots::pin_root(w_current);
+        let current_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+        let w_stop = pyre_object::range_bigint_to_obj(stop.translated_alias());
+        pyre_object::gc_roots::pin_root(w_stop);
+        let stop_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+        let w_step = w_int_new(step);
+        pyre_object::gc_roots::pin_root(w_step);
+        let step_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let w_range = pyre_object::w_range_new(
-            w_int_new(current),
-            pyre_object::range_bigint_to_obj(stop.translated_alias()),
-            w_int_new(step),
+            pyre_object::gc_roots::shadow_stack_get(current_slot),
+            pyre_object::gc_roots::shadow_stack_get(stop_slot),
+            pyre_object::gc_roots::shadow_stack_get(step_slot),
         );
+        pyre_object::gc_roots::pin_root(w_range);
         let state = w_tuple_new(vec![w_range]);
+        pyre_object::gc_roots::pin_root(state);
         Ok(w_tuple_new(vec![builtin_callable("iter"), state, w_none()]))
     }
 }
@@ -2508,18 +2532,30 @@ pub(crate) fn range_iter_length_hint_method(args: &[PyObjectRef]) -> PyResult {
 pub(crate) fn long_range_iter_reduce_method(args: &[PyObjectRef]) -> PyResult {
     unsafe {
         let (start, step, len, index) = pyre_object::w_long_range_iter_fields(args[0]);
-        let start_b = pyre_object::range_obj_to_bigint(start);
-        let step_b = pyre_object::range_obj_to_bigint(step);
-        let len_b = pyre_object::range_obj_to_bigint(len);
-        let index_b = pyre_object::range_obj_to_bigint(index);
-        let current = RBigIntGcRoot::new(&start_b + &index_b * &step_b);
-        let stop = RBigIntGcRoot::new(&start_b + &len_b * &step_b);
+        let start_b = RBigIntGcRoot::new(pyre_object::range_obj_to_bigint(start));
+        let step_b = RBigIntGcRoot::new(pyre_object::range_obj_to_bigint(step));
+        let len_b = RBigIntGcRoot::new(pyre_object::range_obj_to_bigint(len));
+        let index_b = RBigIntGcRoot::new(pyre_object::range_obj_to_bigint(index));
+        let current = RBigIntGcRoot::new(&*start_b + &*index_b * &*step_b);
+        let stop = RBigIntGcRoot::new(&*start_b + &*len_b * &*step_b);
+        let _roots = pyre_object::gc_roots::push_roots();
+        let w_current = pyre_object::range_bigint_to_obj(current.translated_alias());
+        pyre_object::gc_roots::pin_root(w_current);
+        let current_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+        let w_stop = pyre_object::range_bigint_to_obj(stop.translated_alias());
+        pyre_object::gc_roots::pin_root(w_stop);
+        let stop_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+        let w_step = pyre_object::range_bigint_to_obj(step_b.translated_alias());
+        pyre_object::gc_roots::pin_root(w_step);
+        let step_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let w_range = pyre_object::w_range_new(
-            pyre_object::range_bigint_to_obj(current.translated_alias()),
-            pyre_object::range_bigint_to_obj(stop.translated_alias()),
-            pyre_object::range_bigint_to_obj(step_b),
+            pyre_object::gc_roots::shadow_stack_get(current_slot),
+            pyre_object::gc_roots::shadow_stack_get(stop_slot),
+            pyre_object::gc_roots::shadow_stack_get(step_slot),
         );
+        pyre_object::gc_roots::pin_root(w_range);
         let state = w_tuple_new(vec![w_range]);
+        pyre_object::gc_roots::pin_root(state);
         Ok(w_tuple_new(vec![builtin_callable("iter"), state, w_none()]))
     }
 }

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -3166,8 +3166,17 @@ pub fn builtin_abs(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
             });
         }
         if is_long(obj) {
-            let val = w_long_get_value(obj).clone();
-            return Ok(w_long_new(if val < BigInt::from(0) { -val } else { val }));
+            let val = w_long_get_value(obj);
+            // rbigint.py:1303-1308 returns `self` for nonnegative values;
+            // longobject.py:272-277 then allocates a fresh W_LongObject around
+            // that same rbigint. Preserve both wrapper identity and payload
+            // sharing instead of translating `Clone` into another GC payload.
+            if val.get_sign() != -1 {
+                return Ok(pyre_object::longobject::w_long_from_raw(
+                    pyre_object::longobject::w_long_get_raw_value(obj),
+                ));
+            }
+            return Ok(w_long_new(val.neg()));
         }
         if is_float(obj) {
             return Ok(w_float_new(w_float_get_value(obj).abs()));
@@ -3550,10 +3559,16 @@ pub(crate) fn space_index_w(obj: PyObjectRef) -> Result<i64, crate::PyError> {
 /// Convert an int or long object to BigInt for comparison.
 pub(crate) unsafe fn obj_to_bigint(obj: PyObjectRef) -> BigInt {
     unsafe {
-        if is_int(obj) {
+        // PyPy's W_BoolObject subclasses W_IntObject and shares `intval`;
+        // pyre uses a distinct layout, so preserve that upstream semantic arm
+        // with the correct storage projection before testing `is_int`.
+        if is_bool(obj) {
+            BigInt::from(w_bool_get_value(obj) as i64)
+        } else if is_int(obj) {
             BigInt::from(w_int_get_value(obj))
         } else {
-            w_long_get_value(obj).clone()
+            // PyPy's bigint_w/asbigint returns W_LongObject.num itself.
+            w_long_get_value(obj).translated_alias()
         }
     }
 }
@@ -6630,8 +6645,8 @@ fn ensure_baseint_result(
         }
         if pyre_object::pyobject::is_long(obj) {
             // intobject.py:1100-1102: W_AbstractLongObject → newlong
-            return Ok(pyre_object::longobject::w_long_new(
-                pyre_object::longobject::w_long_get_value(obj).clone(),
+            return Ok(pyre_object::longobject::w_long_from_raw(
+                pyre_object::longobject::w_long_get_raw_value(obj),
             ));
         }
     }
@@ -6774,122 +6789,97 @@ fn invalid_int_literal(w_source: PyObjectRef, base: u32) -> crate::PyError {
 }
 
 /// Parse an integer from a string with the given base.
-fn parse_int_from_str(
+pub(crate) fn parse_int_from_str(
     w_source: PyObjectRef,
     s: &str,
     base: u32,
 ) -> Result<PyObjectRef, crate::PyError> {
-    let s = s.trim();
-    let (sign, rest) = if let Some(r) = s.strip_prefix('-') {
-        (-1i64, r)
-    } else if let Some(r) = s.strip_prefix('+') {
-        (1i64, r)
-    } else {
-        (1i64, s)
-    };
-    // intobject.py passes `disallow_whitespace_after_sign=True` to
-    // NumberStringParser.  Its sign branch advances `start` without calling
-    // `_strip_spaces`, so whitespace immediately after either sign remains
-    // part of the digit stream and makes the literal invalid.
-    if rest
-        .as_bytes()
-        .first()
-        .is_some_and(|c| matches!(c, b' ' | b'\x0c' | b'\n' | b'\r' | b'\t' | b'\x0b'))
-    {
-        return Err(invalid_int_literal(w_source, base));
-    }
-    let (radix, digits, had_base_prefix, implicit_zero_only) = if base == 0 {
-        if let Some(r) = rest.strip_prefix("0x").or(rest.strip_prefix("0X")) {
-            (16u32, r, true, false)
-        } else if let Some(r) = rest.strip_prefix("0b").or(rest.strip_prefix("0B")) {
-            (2u32, r, true, false)
-        } else if let Some(r) = rest.strip_prefix("0o").or(rest.strip_prefix("0O")) {
-            (8u32, r, true, false)
-        } else if rest.starts_with('0') {
-            // `NumberStringParser(..., no_implicit_octal=True)`: base 0
-            // plus an unprefixed leading zero selects pseudo-base 1, which
-            // makes only digit zero valid. Keep radix 10 for BigInt parsing
-            // after enforcing that digit rule below.
-            (10u32, rest, false, true)
-        } else {
-            (10u32, rest, false, false)
-        }
-    } else {
-        let (stripped, had_base_prefix) = match base {
-            16 => match rest.strip_prefix("0x").or(rest.strip_prefix("0X")) {
-                Some(r) => (r, true),
-                None => (rest, false),
-            },
-            2 => match rest.strip_prefix("0b").or(rest.strip_prefix("0B")) {
-                Some(r) => (r, true),
-                None => (rest, false),
-            },
-            8 => match rest.strip_prefix("0o").or(rest.strip_prefix("0O")) {
-                Some(r) => (r, true),
-                None => (rest, false),
-            },
-            _ => (rest, false),
+    // rarithmetic.py:936-957 `string_to_int` first handles short, plain
+    // decimal strings without constructing a NumberStringParser.
+    const OVF_DIGITS: usize = 19; // len(str(sys.maxint)) on pyre's i64 target
+    if base == 10 && !s.is_empty() && s.len() < OVF_DIGITS {
+        let bytes = s.as_bytes();
+        let (start, sign) = match bytes[0] {
+            b'-' => (1, -1_i64),
+            b'+' => (1, 1_i64),
+            _ => (0, 1_i64),
         };
-        (base, stripped, had_base_prefix, false)
-    };
-    let is_digit = |c: char| {
-        if implicit_zero_only {
-            c == '0'
-        } else {
-            c.to_digit(radix).is_some()
-        }
-    };
-
-    // RPython `NumberStringParser.__init__` checks the configured digit
-    // limit immediately after whitespace/sign/base-prefix handling and
-    // before it allocates or parses the digit stream.  Preserve that order:
-    // malformed underscore placement is diagnosed later by `next_digit`,
-    // except for an empty input or a leading underscore before a base prefix,
-    // which the parser rejects ahead of the limit check.
-    if digits.is_empty() || (!had_base_prefix && digits.starts_with('_')) {
-        return Err(invalid_int_literal(w_source, base));
-    }
-    if radix & (radix - 1) != 0 {
-        let maxdigits = crate::module::sys::state::int_max_str_digits();
-        if maxdigits != 0 {
-            let digit_count = digits.chars().filter(|&c| c != '_').count();
-            if digit_count > maxdigits as usize {
-                return Err(crate::PyError::new(
-                    crate::PyErrorKind::ValueError,
-                    format!(
-                        "Exceeds the limit ({maxdigits} digits) for integer string conversion: value has {digit_count} digits; use sys.set_int_max_str_digits() to increase the limit"
-                    ),
-                ));
+        if start != bytes.len() {
+            let mut result = 0_i64;
+            let mut all_decimal = true;
+            for &byte in &bytes[start..] {
+                if !byte.is_ascii_digit() {
+                    all_decimal = false;
+                    break;
+                }
+                result = result * 10 + (byte - b'0') as i64;
+            }
+            if all_decimal {
+                return Ok(w_int_new(result * sign));
             }
         }
     }
 
-    let digit_chars: Vec<char> = digits.chars().collect();
-    let mut cleaned = String::with_capacity(digits.len());
-    for (i, &c) in digit_chars.iter().enumerate() {
-        if c == '_' {
-            let after_prefix = had_base_prefix && i == 0;
-            let prev_is_digit = i > 0 && is_digit(digit_chars[i - 1]);
-            let next_is_digit = i + 1 < digit_chars.len() && is_digit(digit_chars[i + 1]);
-            if next_is_digit && (prev_is_digit || after_prefix) {
-                continue;
-            }
-            return Err(invalid_int_literal(w_source, base));
+    // intobject.py:955-982 `_string_to_int_or_long` constructs the one
+    // NumberStringParser used by both the machine-int attempt and the
+    // rbigint overflow retry.  Do not maintain a second parser here: it
+    // diverges on prefix/underscore ordering and erases rbigint allocation
+    // failures into an "invalid literal" error.
+    let maxdigits = if base == 0 || base.is_power_of_two() {
+        0
+    } else {
+        crate::module::sys::state::int_max_str_digits()
+    };
+    let mut parser =
+        pyre_object::rbigint::NumberStringParser::new(s, base as i64, true, true, 0, None, 0, true)
+            .map_err(|error| match error {
+                pyre_object::rbigint::RBigIntError::Memory => crate::PyError::memory_error(""),
+                _ => invalid_int_literal(w_source, base),
+            })?;
+
+    // NumberStringParser performs this check immediately after its structural
+    // initialization.  Constructing it with a zero limit lets us retain
+    // PyPy's `MaxDigitsError.digits` value in the application-level message.
+    if maxdigits != 0 {
+        let digit_count =
+            parser.end - parser.start - s.bytes().filter(|&c| c == b'_').count() as i64;
+        if digit_count > maxdigits as i64 {
+            return Err(crate::PyError::value_error(format!(
+                "Exceeds the limit ({maxdigits} digits) for integer string conversion: value has {digit_count} digits; use sys.set_int_max_str_digits() to increase the limit"
+            )));
         }
-        if implicit_zero_only && c != '0' {
-            return Err(invalid_int_literal(w_source, base));
+    }
+
+    // rarithmetic.py:962-977 accumulates a signed machine word and hands the
+    // same rewound parser to rbigint only after `ovfcheck` fails.
+    let parsed_base = parser.base;
+    let parsed_sign = parser.sign;
+    let mut machine_value = 0_i64;
+    loop {
+        let digit = parser.next_digit().map_err(|error| match error {
+            pyre_object::rbigint::RBigIntError::Memory => crate::PyError::memory_error(""),
+            _ => invalid_int_literal(w_source, base),
+        })?;
+        if digit < 0 {
+            return Ok(w_int_new(machine_value));
         }
-        cleaned.push(c);
+        let signed_digit = if parsed_sign < 0 { -digit } else { digit };
+        let Some(value) = machine_value
+            .checked_mul(parsed_base)
+            .and_then(|value| value.checked_add(signed_digit))
+        else {
+            parser.rewind();
+            break;
+        };
+        machine_value = value;
     }
-    if let Ok(v) = i64::from_str_radix(&cleaned, radix) {
-        return Ok(w_int_new(sign * v));
-    }
-    // Values outside the machine-int range parse as arbitrary precision.
-    if let Some(big) = BigInt::parse_bytes(cleaned.as_bytes(), radix) {
-        let signed = if sign < 0 { -big } else { big };
-        return Ok(w_long_new(signed));
-    }
-    Err(invalid_int_literal(w_source, base))
+
+    let value = BigInt::_from_numberstring_parser(&mut parser).map_err(|error| match error {
+        pyre_object::rbigint::RBigIntError::Memory => crate::PyError::memory_error(""),
+        pyre_object::rbigint::RBigIntError::MaxStrDigits => unreachable!("limit checked above"),
+        _ => invalid_int_literal(w_source, base),
+    })?;
+    Ok(w_long_new(value))
 }
 
 /// PyPy `W_AbstractLongObject.descr_str` / Python 3.14 integer-to-decimal
@@ -6897,7 +6887,17 @@ fn parse_int_from_str(
 /// before the quadratic decimal conversion; the resulting string supplies
 /// the exact boundary check.
 pub(crate) unsafe fn int_to_decimal_string(obj: PyObjectRef) -> Result<String, crate::PyError> {
-    let value = obj_to_bigint(obj);
+    let owned;
+    let value = if pyre_object::is_bool(obj) {
+        owned = BigInt::from(pyre_object::w_bool_get_value(obj) as i64);
+        &owned
+    } else if pyre_object::is_int(obj) {
+        owned = BigInt::from(pyre_object::w_int_get_value(obj));
+        &owned
+    } else {
+        debug_assert!(pyre_object::is_long(obj));
+        pyre_object::w_long_get_value(obj)
+    };
     let maxdigits = crate::module::sys::state::int_max_str_digits();
     if maxdigits != 0 {
         let bits = value.bits();
@@ -6912,13 +6912,17 @@ pub(crate) unsafe fn int_to_decimal_string(obj: PyObjectRef) -> Result<String, c
             )));
         }
     }
-    let text = value.to_string();
-    if maxdigits != 0 && text.trim_start_matches('-').len() > maxdigits as usize {
-        return Err(crate::PyError::value_error(format!(
+    // longobject.py:109 calls `self.asbigint().str(max_str_digits=...)`.
+    // Going through Rust's Display/ToString adapter erases rbigint's
+    // MaxIntError and MemoryError edges (and can turn either into a formatting
+    // panic), so preserve the direct consumer contract.
+    value.str(maxdigits as i64).map_err(|error| match error {
+        pyre_object::rbigint::RBigIntError::MaxStrDigits => crate::PyError::value_error(format!(
             "Exceeds the limit ({maxdigits}) for integer string conversion; use sys.set_int_max_str_digits() to increase the limit"
-        )));
-    }
-    Ok(text)
+        )),
+        pyre_object::rbigint::RBigIntError::Memory => crate::PyError::memory_error(""),
+        _ => unreachable!("rbigint.str returned an unrelated error"),
+    })
 }
 
 /// Remove PEP 515 underscore digit separators, rejecting any underscore
@@ -12150,30 +12154,29 @@ pub(crate) fn builtin_round(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::
             };
         }
         if is_int(obj) || is_long(obj) {
-            // `intobject.py:144 descr_round` — single-arg round and any
-            // ndigits >= 0 leave an int unchanged; ndigits < 0 rounds to
-            // the nearest multiple of 10**(-ndigits), ties to even.  `ndigits`
-            // is coerced through `space.index`, so a non-index one raises.
+            // intobject.py:144-175 `descr_round`: keep ndigits as an rbigint
+            // obtained through `space.index`, then compute
+            // `10 ** -ndigits` and divmod-near.  Converting ndigits to an
+            // index-sized Rust word or formatting the operand merely to count
+            // decimal digits both diverge from that consumer shape.
             let nd = match ndigits {
-                Some(nd) if !pyre_object::is_none(*nd) => crate::baseobjspace::getindex_w(*nd)?,
+                Some(nd) if !pyre_object::is_none(*nd) => index_to_bigint(*nd)?,
                 _ => return Ok(obj),
             };
-            if nd >= 0 {
+            if nd.get_sign() >= 0 {
                 return Ok(obj);
             }
-            let a = obj_to_bigint(obj);
-            // 10**(-ndigits) beyond the magnitude of `a` rounds every digit
-            // away, giving 0; short-circuit so a clamped huge-negative ndigits
-            // neither overflows `-nd` nor builds an astronomical power of ten.
-            let magnitude_digits = a.to_str_radix(10).trim_start_matches('-').len() as u64;
-            if nd.unsigned_abs() > magnitude_digits {
-                return Ok(w_int_new(0));
-            }
-            let mut b = BigInt::from(1);
-            let ten = BigInt::from(10);
-            for _ in 0..(-nd) {
-                b = &b * &ten;
-            }
+            let owned_a;
+            let a = if is_long(obj) {
+                w_long_get_value(obj)
+            } else {
+                owned_a = BigInt::from(w_int_get_value(obj));
+                &owned_a
+            };
+            let exponent = nd.neg();
+            let b = BigInt::from(10)
+                .pow(&exponent, None)
+                .map_err(|_| crate::PyError::memory_error("exponent too large"))?;
             // `_PyLong_DivmodNear`: q = round(a / b) ties-to-even,
             // result = q * b.  Floor division gives 0 <= r < b.
             let (q, r) = a
@@ -12301,11 +12304,43 @@ fn index_to_bigint(obj: PyObjectRef) -> Result<BigInt, crate::PyError> {
 
 /// Format a `BigInt` in `radix` with the given `0x`/`0o`/`0b` prefix, keeping
 /// the sign ahead of the prefix (`-0xff`).
-fn format_int_radix(value: &BigInt, radix: u32, prefix: &str) -> String {
-    let digits = value.to_str_radix(radix);
-    match digits.strip_prefix('-') {
-        Some(magnitude) => format!("-{prefix}{magnitude}"),
-        None => format!("{prefix}{digits}"),
+fn format_int_radix(value: &BigInt, radix: u32, prefix: &str) -> Result<String, crate::PyError> {
+    let digits = match radix {
+        2 => "01",
+        8 => pyre_object::rbigint::BASE8,
+        16 => pyre_object::rbigint::BASE16,
+        _ => unreachable!("hex/oct/bin use only power-of-two radices"),
+    };
+    value
+        .format(digits, prefix, "", 0)
+        .map_err(|error| match error {
+            pyre_object::rbigint::RBigIntError::Memory => crate::PyError::memory_error(""),
+            _ => unreachable!("validated radix formatting returned an unrelated error"),
+        })
+}
+
+/// `space.index(obj).asbigint().format(...)` without cloning a W_LongObject's
+/// immutable payload. PyPy's `W_LongObject.asbigint()` returns `self.num`;
+/// only compact int/bool results need a temporary rbigint materialisation.
+fn format_index_radix(
+    obj: PyObjectRef,
+    radix: u32,
+    prefix: &str,
+) -> Result<String, crate::PyError> {
+    let w_index = crate::baseobjspace::space_index(obj)?;
+    unsafe {
+        let owned;
+        let value = if pyre_object::is_bool(w_index) {
+            owned = BigInt::from(pyre_object::w_bool_get_value(w_index) as i64);
+            &owned
+        } else if pyre_object::is_int(w_index) {
+            owned = BigInt::from(pyre_object::w_int_get_value(w_index));
+            &owned
+        } else {
+            debug_assert!(pyre_object::is_long(w_index));
+            pyre_object::w_long_get_value(w_index)
+        };
+        format_int_radix(value, radix, prefix)
     }
 }
 
@@ -12323,7 +12358,7 @@ fn builtin_hex(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
             args.len()
         )));
     }
-    let s = format_int_radix(&index_to_bigint(args[0])?, 16, "0x");
+    let s = format_index_radix(args[0], 16, "0x")?;
     Ok(w_str_new(&s))
 }
 
@@ -12341,7 +12376,7 @@ fn builtin_oct(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
             args.len()
         )));
     }
-    let s = format_int_radix(&index_to_bigint(args[0])?, 8, "0o");
+    let s = format_index_radix(args[0], 8, "0o")?;
     Ok(w_str_new(&s))
 }
 
@@ -12359,7 +12394,7 @@ fn builtin_bin(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
             args.len()
         )));
     }
-    let s = format_int_radix(&index_to_bigint(args[0])?, 2, "0b");
+    let s = format_index_radix(args[0], 2, "0b")?;
     Ok(w_str_new(&s))
 }
 
@@ -12676,6 +12711,50 @@ fn builtin_dunder_import(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyE
 mod tests {
     use super::*;
 
+    #[test]
+    fn long_abs_reuses_nonnegative_rbigint_payload() {
+        let value = BigInt::one().lshift(80).unwrap();
+        let input = w_long_new(value);
+        let result = builtin_abs(&[input]).unwrap();
+
+        assert_ne!(result, input, "int.__abs__ returns a fresh long wrapper");
+        unsafe {
+            assert!(
+                std::ptr::eq(w_long_get_value(result), w_long_get_value(input)),
+                "nonnegative rbigint.abs returns its original payload"
+            );
+        }
+    }
+
+    #[test]
+    fn long_abs_negates_negative_rbigint_payload() {
+        let value = BigInt::one().lshift(80).unwrap().neg();
+        let input = w_long_new(value);
+        let result = builtin_abs(&[input]).unwrap();
+
+        unsafe {
+            assert!(!std::ptr::eq(
+                w_long_get_value(result),
+                w_long_get_value(input)
+            ));
+            assert_eq!(w_long_get_value(result).get_sign(), 1);
+        }
+    }
+
+    #[test]
+    fn ensure_baseint_long_rewraps_without_cloning_payload() {
+        let input = w_long_new(BigInt::one().lshift(80).unwrap());
+        let result = ensure_baseint_result(input, input).unwrap();
+
+        assert_ne!(result, input);
+        unsafe {
+            assert!(std::ptr::eq(
+                w_long_get_value(result),
+                w_long_get_value(input)
+            ));
+        }
+    }
+
     /// RPython rbigint and the small-int path must implement the same
     /// Mersenne reduction across the machine-word range.
     #[test]
@@ -12866,6 +12945,61 @@ mod tests {
         }
     }
 
+    #[test]
+    fn int_string_uses_rbigint_number_parser_for_prefixes_and_overflow() {
+        crate::typedef::init_typeobjects();
+        for (text, base, expected) in [
+            ("0x_10", 0, BigInt::from(16)),
+            ("0x_10", 16, BigInt::from(16)),
+            ("00_0", 0, BigInt::from(0)),
+            ("9223372036854775808", 10, BigInt::from(i64::MAX).int_add(1)),
+            (
+                "-9223372036854775809",
+                10,
+                BigInt::from(i64::MIN).int_sub(1),
+            ),
+        ] {
+            let result = parse_int_from_str(w_str_new(text), text, base).unwrap();
+            if let Ok(expected_int) = expected.toint() {
+                assert!(unsafe { is_int(result) });
+                assert_eq!(unsafe { w_int_get_value(result) }, expected_int);
+            } else {
+                assert!(unsafe { is_long(result) });
+                assert!(unsafe { w_long_get_value(result).eq(&expected) });
+            }
+        }
+
+        for text in ["012", "0x__1", "1__0", "1_"] {
+            let error = parse_int_from_str(w_str_new(text), text, 0).unwrap_err();
+            assert_eq!(error.kind, crate::PyErrorKind::ValueError);
+        }
+    }
+
+    #[test]
+    fn integer_round_keeps_rbigint_ndigits_and_ties_to_even() {
+        crate::typedef::init_typeobjects();
+        for (value, expected) in [(2500, 2000), (3500, 4000), (-2500, -2000), (-3500, -4000)] {
+            let rounded = builtin_round(&[w_int_new(value), w_long_new(BigInt::from(-3))]).unwrap();
+            assert_eq!(unsafe { w_int_get_value(rounded) }, expected);
+        }
+
+        let value = BigInt::fromdecimalstr("1234567890123456789012345");
+        let rounded = builtin_round(&[w_long_new(value.clone()), w_int_new(-5)]).unwrap();
+        let divisor = BigInt::from(10).int_pow(5, None).unwrap();
+        let expected = value
+            .divmod(&divisor)
+            .expect("positive divisor")
+            .0
+            .mul(&divisor);
+        assert!(unsafe { w_long_get_value(rounded).eq(&expected) });
+
+        let original = w_long_new(value);
+        assert_eq!(
+            builtin_round(&[original, w_long_new(BigInt::one().lshift(70).unwrap())]).unwrap(),
+            original
+        );
+    }
+
     /// PyPy `interp_io._open` constructs `W_FileIO`, and
     /// `W_FileIO.descr_init` calls `_open_fd` before returning.  A writable
     /// pathname must therefore be created/truncated while the stream is still
@@ -13002,6 +13136,36 @@ mod tests {
         // pow(3, -3, 7) == pow(pow(3, -1, 7), 3, 7) == 5^3 % 7 == 6.
         let cubed = builtin_pow(&[w_int_new(3), w_int_new(-3), w_int_new(7)]).unwrap();
         assert_eq!(unsafe { w_int_get_value(cubed) }, 6);
+
+        let negative_modulus = builtin_pow(&[
+            w_long_new(BigInt::from(5)),
+            w_long_new(BigInt::from(-1)),
+            w_long_new(BigInt::from(-13)),
+        ])
+        .unwrap();
+        assert!(unsafe { is_long(negative_modulus) });
+        assert!(unsafe { w_long_get_value(negative_modulus).int_eq(-5) });
+    }
+
+    #[test]
+    fn test_builtin_pow_three_arg_borrows_long_operands() {
+        crate::typedef::init_typeobjects();
+        let base = BigInt::one().lshift(100).unwrap().int_add(3);
+        let exponent = BigInt::from(5);
+        let modulus = BigInt::one().lshift(70).unwrap().int_add(33);
+        let expected = base.pow(&exponent, Some(&modulus)).unwrap();
+        let result =
+            builtin_pow(&[w_long_new(base), w_long_new(exponent), w_long_new(modulus)]).unwrap();
+        assert!(unsafe { is_long(result) });
+        assert!(unsafe { w_long_get_value(result).eq(&expected) });
+
+        let zero_exp = builtin_pow(&[
+            w_long_new(BigInt::from(2)),
+            w_long_new(BigInt::zero()),
+            w_long_new(BigInt::from(-13)),
+        ])
+        .unwrap();
+        assert!(unsafe { w_long_get_value(zero_exp).int_eq(-12) });
     }
 
     #[test]

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -12223,6 +12223,26 @@ pub(crate) fn builtin_round(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::
     )))
 }
 
+/// True iff `callable` is the canonical builtin `divmod` function object.
+/// The JIT walker uses the builtin-code identity to recognize a `divmod(a, b)`
+/// residual it can lower to the inline pair shape, and to distinguish it from
+/// an arbitrary replacement stored under the same global name.
+pub fn is_builtin_divmod_function(callable: PyObjectRef) -> bool {
+    unsafe {
+        if callable.is_null() || !crate::is_function(callable) {
+            return false;
+        }
+        let code = crate::function_get_code(callable) as PyObjectRef;
+        if code.is_null() || !crate::gateway::is_builtin_code(code) {
+            return false;
+        }
+        std::ptr::fn_addr_eq(
+            crate::gateway::builtin_code_get(code),
+            builtin_divmod as crate::gateway::BuiltinCodeFn,
+        )
+    }
+}
+
 /// `divmod(a, b)` — pypy/interpreter/baseobjspace.py divmod row.
 fn builtin_divmod(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let (args, kwargs) = split_builtin_kwargs(args);

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -1057,6 +1057,10 @@ fn walk_global_prebuilt_roots(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
     if !scan_prebuilt {
         return;
     }
+    // PyPy's GC reaches standalone code objects through the ordinary object
+    // graph. Pyre's Box-immortal wrappers need the equivalent process-global
+    // owner before walking module/type caches below.
+    crate::pycode::walk_prebuilt_code_roots(visitor);
     unsafe {
         let mut forward = |slot: &mut PyObjectRef| {
             visitor(&mut *(slot as *mut PyObjectRef as *mut majit_ir::GcRef));

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -269,17 +269,48 @@ pub unsafe fn walk_raw_code_roots(
     value: PyObjectRef,
     visitor: &mut dyn FnMut(&mut majit_ir::GcRef),
 ) {
+    unsafe fn walk(
+        value: PyObjectRef,
+        visitor: &mut dyn FnMut(&mut majit_ir::GcRef),
+        visited: &mut Vec<usize>,
+    ) {
+        unsafe {
+            if value.is_null() || !crate::pycode::is_code(value) {
+                return;
+            }
+            let identity = value as usize;
+            // PyPy's GC traces the PyCode constant list transitively and its
+            // mark state prevents revisiting shared/cyclic nodes. PyCode
+            // wrappers are outside pyre's collector, so mirror that small
+            // identity set directly while walking their constant graph.
+            if visited.contains(&identity) {
+                return;
+            }
+            visited.push(identity);
+            let code = &mut *(value as *mut crate::pycode::PyCode);
+            visitor(&mut *(&mut code.w_globals as *mut PyObjectRef as *mut majit_ir::GcRef));
+            if !code.co_consts_w.is_null() {
+                for slot in (&*code.co_consts_w).iter() {
+                    let mut child = slot.load(std::sync::atomic::Ordering::Acquire);
+                    if child.is_null() {
+                        continue;
+                    }
+                    visitor(&mut *(&mut child as *mut PyObjectRef as *mut majit_ir::GcRef));
+                    slot.store(child, std::sync::atomic::Ordering::Release);
+                    // A code wrapper is Box-immortal and therefore not traced
+                    // by the collector. Recurse through nested co_consts_w,
+                    // matching PyPy's transitively traced PyCode list.
+                    walk(child, visitor, visited);
+                }
+            }
+        }
+    }
+
     unsafe {
         if value.is_null() || !crate::pycode::is_code(value) {
             return;
         }
-        let code = &mut *(value as *mut crate::pycode::PyCode);
-        visitor(&mut *(&mut code.w_globals as *mut PyObjectRef as *mut majit_ir::GcRef));
-        if !code.co_consts_w.is_null() {
-            for slot in (&mut *code.co_consts_w).iter_mut() {
-                visitor(&mut *(slot as *mut PyObjectRef as *mut majit_ir::GcRef));
-            }
-        }
+        walk(value, visitor, &mut Vec::new());
     }
 }
 

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -257,8 +257,8 @@ unsafe fn walk_raw_function_roots(
     }
 }
 
-/// Forward a Box-immortal `PyCode`'s cached globals dict object
-/// (`pycode.py:105 "w_globals?"`).  Module globals are `malloc_typed`-immortal,
+/// Forward a Box-immortal `PyCode`'s cached globals dict object and realized
+/// `co_consts_w` entries. Module globals are `malloc_typed`-immortal,
 /// but `exec`/`eval` with a plain dict (or a function built with custom
 /// globals) caches a `try_gc_alloc` movable dict here, which a minor collection
 /// relocates.  The code object itself is Box-immortal, so the standard tracer
@@ -275,6 +275,11 @@ pub unsafe fn walk_raw_code_roots(
         }
         let code = &mut *(value as *mut crate::pycode::PyCode);
         visitor(&mut *(&mut code.w_globals as *mut PyObjectRef as *mut majit_ir::GcRef));
+        if !code.co_consts_w.is_null() {
+            for slot in (&mut *code.co_consts_w).iter_mut() {
+                visitor(&mut *(slot as *mut PyObjectRef as *mut majit_ir::GcRef));
+            }
+        }
     }
 }
 
@@ -2717,19 +2722,19 @@ impl ConstantOpcodeHandler for PyFrame {
         // Reached only for a code constant nested inside a container constant
         // (e.g. a tuple element), which has no top-level `co_consts_w` slot;
         // realize a wrapper directly.  Top-level `LOAD_CONST` of a code constant
-        // goes through `code_constant_at` below.
+        // goes through `constant_at` below.
         Ok(crate::pycode::box_code_constant(code))
     }
 
-    fn code_constant_at(
+    fn constant_at(
         &mut self,
-        index: usize,
+        index: crate::bytecode::oparg::ConstIdx,
         _enclosing: &crate::bytecode::CodeObject,
     ) -> Result<Self::Value, PyError> {
         // `pyopcode.py:498-499 getconstant_w(index) -> co_consts_w[index]`:
-        // return the one wrapper `self.pycode` holds at `index`.
+        // return the one object `self.pycode` holds at `index`.
         Ok(unsafe {
-            crate::pycode::w_code_co_const(self.pycode as pyre_object::PyObjectRef, index)
+            crate::pycode::w_code_const(self.pycode as pyre_object::PyObjectRef, usize::from(index))
         })
     }
 

--- a/pyre/pyre-interpreter/src/function.rs
+++ b/pyre/pyre-interpreter/src/function.rs
@@ -1135,7 +1135,7 @@ fn code_getdocstring(obj: PyObjectRef) -> PyObjectRef {
             if code_ref.flags.contains(crate::CodeFlags::HAS_DOCSTRING)
                 && !code_ref.constants.is_empty()
             {
-                let first = crate::pyframe::load_const_from_code(code_ref, 0);
+                let first = unsafe { crate::pycode::w_code_const(code, 0) };
                 if !first.is_null() && unsafe { pyre_object::is_str(first) } {
                     return first;
                 }

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -1098,6 +1098,17 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         "pyre_interpreter::objspace::descroperation::jit_bigint_mod_floor",
         crate::objspace::descroperation::jit_bigint_mod_floor as *const (),
     );
+    // Machine-int-divisor legs of the same seams (`_int_floordiv` / `_int_mod`).
+    push_fnaddr(
+        &mut entries,
+        "pyre_interpreter::objspace::descroperation::jit_bigint_int_div_floor",
+        crate::objspace::descroperation::jit_bigint_int_div_floor as *const (),
+    );
+    push_fnaddr(
+        &mut entries,
+        "pyre_interpreter::objspace::descroperation::jit_bigint_int_mod_int_result",
+        crate::objspace::descroperation::jit_bigint_int_mod_int_result as *const (),
+    );
     // `jit_bigint_{and,or,xor,sub,mul}` residualize the Rust RBigInt binary
     // operators (`<BigInt as BitAnd>::bitand`, …) the `front::mir` retarget
     // (`front::bigint_binop`) redirects when both operands are the opaque
@@ -1197,6 +1208,11 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         &mut entries,
         "pyre_interpreter::objspace::descroperation::jit_bigint_pow_nomod",
         crate::objspace::descroperation::jit_bigint_pow_nomod as *const (),
+    );
+    push_fnaddr(
+        &mut entries,
+        "pyre_interpreter::objspace::descroperation::jit_bigint_int_pow_nomod",
+        crate::objspace::descroperation::jit_bigint_int_pow_nomod as *const (),
     );
     // `bigint_lshift_count(...)?` carries the same implicit MemoryError shape
     // for RPython's lshift allocation.

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -637,6 +637,12 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
     );
     push_alias_pair(
         &mut entries,
+        "pyre_object::longobject::w_long_new_fresh_rbigint_handle",
+        "pyre_object::w_long_new_fresh_rbigint_handle",
+        pyre_object::longobject::w_long_new_fresh_rbigint_handle as *const (),
+    );
+    push_alias_pair(
+        &mut entries,
         "pyre_object::gc_hook::try_gc_add_root",
         "pyre_object::try_gc_add_root",
         pyre_object::gc_hook::try_gc_add_root as *const (),
@@ -1076,6 +1082,15 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         "pyre_interpreter::jit_compiler_bigint_to_rbigint",
         crate::jit_compiler_bigint_to_rbigint as *const (),
     );
+    // PyPy's getconstant_w is a pre-wrapped list read. Pyre's compiler stores
+    // ConstantData, so the first read realizes and atomically publishes that
+    // wrapped object. Keep this temporary compiler-boundary machinery opaque
+    // to source translation; all later reads return the same co_consts_w slot.
+    push_fnaddr(
+        &mut entries,
+        "pyre_interpreter::pycode::w_code_const",
+        crate::pycode::w_code_const as *const (),
+    );
     // Truncated `_divrem` projections used by Rust operator shims.
     push_fnaddr(
         &mut entries,
@@ -1086,6 +1101,11 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         &mut entries,
         "pyre_interpreter::objspace::descroperation::jit_bigint_rem",
         crate::objspace::descroperation::jit_bigint_rem as *const (),
+    );
+    push_fnaddr(
+        &mut entries,
+        "pyre_interpreter::objspace::descroperation::jit_bigint_divrem_returns_lhs_remainder",
+        crate::objspace::descroperation::jit_bigint_divrem_returns_lhs_remainder as *const (),
     );
     // Floored `divmod` projections used by the zero-checked interpreter seams.
     push_fnaddr(
@@ -1221,12 +1241,21 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         "pyre_interpreter::objspace::descroperation::jit_bigint_lshift_count",
         crate::objspace::descroperation::jit_bigint_lshift_count as *const (),
     );
-    // `jit_bigint_neg` residualizes the unary `<BigInt as Neg>::neg` operator;
-    // a single operand pointer.
+    push_fnaddr(
+        &mut entries,
+        "pyre_interpreter::objspace::descroperation::jit_bigint_lshift_int_int_result",
+        crate::objspace::descroperation::jit_bigint_lshift_int_int_result as *const (),
+    );
+    // Unary rbigint operations each take one payload pointer.
     push_fnaddr(
         &mut entries,
         "pyre_interpreter::objspace::descroperation::jit_bigint_neg",
         crate::objspace::descroperation::jit_bigint_neg as *const (),
+    );
+    push_fnaddr(
+        &mut entries,
+        "pyre_interpreter::objspace::descroperation::jit_bigint_invert",
+        crate::objspace::descroperation::jit_bigint_invert as *const (),
     );
     // `jit_bigint_{shl,shr}` residualize the BigInt shift-by-`usize` operators
     // (`<BigInt as Shl<usize>>::shl`, …); `b` is the machine shift count.
@@ -2991,6 +3020,29 @@ mod tests {
             tuple2
         );
         assert_eq!(bindings["pyre_interpreter::jit_build_tuple_2"], tuple2);
+    }
+
+    /// `front::rbigint_call::lshift_count_residual_path` retargets both the
+    /// long-count and Signed×Signed-overflow forms.  Keep both exact paths
+    /// resolvable: otherwise the latter silently falls back to a symbolic
+    /// fnaddr when an overflowing machine-int left shift promotes to rbigint.
+    #[test]
+    fn jit_trace_fnaddrs_covers_both_rbigint_lshift_residuals() {
+        let bindings: HashMap<&'static str, i64> = jit_trace_fnaddrs().into_iter().collect();
+
+        let count =
+            crate::objspace::descroperation::jit_bigint_lshift_count as *const () as usize as i64;
+        assert_eq!(
+            bindings["pyre_interpreter::objspace::descroperation::jit_bigint_lshift_count"],
+            count
+        );
+
+        let int_int = crate::objspace::descroperation::jit_bigint_lshift_int_int_result as *const ()
+            as usize as i64;
+        assert_eq!(
+            bindings["pyre_interpreter::objspace::descroperation::jit_bigint_lshift_int_int_result"],
+            int_int
+        );
     }
 
     #[test]

--- a/pyre/pyre-interpreter/src/module/_ctypes/metaclass.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/metaclass.rs
@@ -18,7 +18,7 @@ use super::cdata;
 use super::stginfo::{self, StgInfoData};
 use super::type_ns_store;
 use pyre_object::PyObjectRef;
-use pyre_object::rbigint::{RBigInt as BigInt, RBigIntSign};
+use pyre_object::rbigint::RBigInt as BigInt;
 use rustpython_host_env::ctypes as host_ctypes;
 use std::sync::OnceLock;
 
@@ -977,7 +977,7 @@ fn meta_mul(args: &[PyObjectRef]) -> PyResult {
     }
     if unsafe { pyre_object::is_long(count) } {
         let big = unsafe { pyre_object::longobject::w_long_get_value(count) };
-        if big.sign() == RBigIntSign::Minus {
+        if big.get_sign() < 0 {
             return Err(crate::PyError::value_error(
                 "array length must not be negative",
             ));
@@ -1622,7 +1622,7 @@ fn array_init_stginfo(cls: PyObjectRef) -> PyResult {
             }
             let n = if unsafe { pyre_object::is_long(v) } {
                 let big = unsafe { pyre_object::longobject::w_long_get_value(v) };
-                if big.sign() == RBigIntSign::Minus {
+                if big.get_sign() < 0 {
                     return Err(crate::PyError::value_error(
                         "The '_length_' attribute must not be negative",
                     ));

--- a/pyre/pyre-interpreter/src/module/_io/textio.rs
+++ b/pyre/pyre-interpreter/src/module/_io/textio.rs
@@ -1146,7 +1146,12 @@ impl W_TextIOWrapper {
         let snapshot = self.snapshot.as_ref().expect("checked above");
         let input = snapshot.input.clone();
         cookie.dec_flags = snapshot.flags;
-        cookie.start_pos = cookie.start_pos.wrapping_sub(input.len() as u64);
+        if input.len() as u64 > cookie.start_pos {
+            // interp_textio.py:tell_w, CPython GH-95782: devices may report
+            // zero even though the decoder snapshot still contains input.
+            return Ok(pyre_object::w_int_new(0));
+        }
+        cookie.start_pos -= input.len() as u64;
         if self.decoded.pos == 0 {
             return Ok(cookie.to_object());
         }

--- a/pyre/pyre-interpreter/src/module/_io/textio.rs
+++ b/pyre/pyre-interpreter/src/module/_io/textio.rs
@@ -29,21 +29,26 @@ impl PositionCookie {
         if value.int_lt(0) {
             return Err(crate::PyError::value_error("negative seek position"));
         }
-        let mask = RBigInt::one()
-            .lshift(Self::BITS as i64)
-            .expect("native-word shift")
-            .int_sub(1);
-        let mut take = || {
-            let field = value.and_(&mask).to_u64().unwrap_or(0);
-            value = value
-                .rshift(Self::BITS as i64, false)
-                .expect("native-word shift");
-            field
-        };
-        let start_pos = take();
-        let dec_flags = take();
-        let bytes_to_feed = take();
-        let chars_to_skip = take();
+        // interp_textio.py:253-269 `PositionCookie.__init__`: extract each
+        // native word with rbigint's mask conversion, then shift the source.
+        // In particular, do not call `to_u64()` on the whole cookie — valid
+        // packed cookies intentionally occupy several machine words.
+        let start_pos = value.ulonglongmask();
+        value = value
+            .rshift(Self::BITS as i64, false)
+            .expect("native-word shift");
+        let dec_flags = value.uintmask();
+        value = value
+            .rshift(Self::BITS as i64, false)
+            .expect("native-word shift");
+        let bytes_to_feed = value.uintmask();
+        value = value
+            .rshift(Self::BITS as i64, false)
+            .expect("native-word shift");
+        let chars_to_skip = value.uintmask();
+        value = value
+            .rshift(Self::BITS as i64, false)
+            .expect("native-word shift");
         let need_eof = value.tobool();
         Ok(Self {
             start_pos,
@@ -1137,21 +1142,11 @@ impl W_TextIOWrapper {
 
         let w_index = crate::baseobjspace::space_index(w_pos)?;
         let raw_pos = unsafe { crate::builtins::obj_to_bigint(w_index) };
-        let Some(raw_pos) = raw_pos.to_u64() else {
-            return Err(crate::PyError::overflow_error(
-                "Python int too large to convert to C unsigned long",
-            ));
-        };
+        let mut cookie = PositionCookie::unpack(raw_pos)?;
         let snapshot = self.snapshot.as_ref().expect("checked above");
-        if snapshot.input.len() as u64 > raw_pos {
-            return Ok(w_int_new(0));
-        }
         let input = snapshot.input.clone();
-        let mut cookie = PositionCookie {
-            start_pos: raw_pos - input.len() as u64,
-            dec_flags: snapshot.flags,
-            ..PositionCookie::default()
-        };
+        cookie.dec_flags = snapshot.flags;
+        cookie.start_pos = cookie.start_pos.wrapping_sub(input.len() as u64);
         if self.decoded.pos == 0 {
             return Ok(cookie.to_object());
         }
@@ -1643,5 +1638,33 @@ impl W_TextIOWrapper {
         fields.push_str(" encoding=");
         fields.push_str(&unsafe { crate::display::py_repr(self.w_encoding)? });
         Ok(format!("<{typename}{fields}>"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn position_cookie_round_trips_all_native_words() {
+        let original = PositionCookie {
+            start_pos: 0xfedc_ba98_7654_3210,
+            dec_flags: 0x0123_4567_89ab_cdef,
+            bytes_to_feed: 0x8877_6655_4433_2211,
+            chars_to_skip: 0x1020_3040_5060_7080,
+            need_eof: true,
+        };
+        let packed = original.pack();
+        assert!(
+            packed.bits() > u64::BITS as u64,
+            "a packed cookie must not be narrowed through to_u64"
+        );
+
+        let decoded = PositionCookie::unpack(packed).expect("packed cookie");
+        assert_eq!(decoded.start_pos, original.start_pos);
+        assert_eq!(decoded.dec_flags, original.dec_flags);
+        assert_eq!(decoded.bytes_to_feed, original.bytes_to_feed);
+        assert_eq!(decoded.chars_to_skip, original.chars_to_skip);
+        assert_eq!(decoded.need_eof, original.need_eof);
     }
 }

--- a/pyre/pyre-interpreter/src/module/_pickle/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_pickle/mod.rs
@@ -397,10 +397,10 @@ pub(crate) fn int_from_bigint(value: BigInt) -> PyObjectRef {
 
 /// Parse a decimal integer literal (INT / LONG text opcodes) into an int.
 pub(crate) fn parse_int_text(s: &str) -> Result<PyObjectRef, PyError> {
-    match BigInt::parse_bytes(s.trim().as_bytes(), 10) {
-        Some(big) => Ok(int_from_bigint(big)),
-        None => Err(unpickling_error("could not convert string to int")),
-    }
+    // interp_pickle.py:2201 calls the ordinary `int` constructor.  Reuse its
+    // NumberStringParser consumer so the digit limit, MemoryError edge, and
+    // literal diagnostics do not diverge for protocol-0 INT/LONG opcodes.
+    crate::builtins::parse_int_from_str(pyre_object::w_str_new(s), s, 10)
 }
 
 pub(crate) fn read_int_le(data: &[u8]) -> i64 {

--- a/pyre/pyre-interpreter/src/module/_random/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_random/mod.rs
@@ -187,7 +187,7 @@ impl W_Random {
             if is_int_or_long(w_n) {
                 // space.abs(w_n)
                 let v = crate::builtins::obj_to_bigint(w_n);
-                if v.sign() == Sign::Minus { -v } else { v }
+                if v.get_sign() < 0 { -v } else { v }
             } else {
                 // n = space.hash_w(w_n); w_n = space.newint(r_uint(n))
                 BigInt::from(crate::baseobjspace::hash_w_strict(w_n)? as u64)
@@ -223,11 +223,11 @@ impl W_Random {
                     crate::bail_type_error!("state vector must contain ints");
                 }
                 let mut v = crate::builtins::obj_to_bigint(item);
-                if v.sign() == Sign::Minus {
+                if v.get_sign() < 0 {
                     v += BigInt::from(1u64 << 32);
                 }
                 // space.uint_w: every word must fit an unsigned 32-bit int.
-                if v.sign() == Sign::Minus {
+                if v.get_sign() < 0 {
                     crate::bail_overflow_error!("cannot convert negative integer to unsigned int");
                 }
                 if v >= BigInt::from(1u64 << 32) {

--- a/pyre/pyre-interpreter/src/module/math/interp_math.rs
+++ b/pyre/pyre-interpreter/src/module/math/interp_math.rs
@@ -4,7 +4,7 @@
 //!
 //! All functions delegate to `pymath::math` for CPython-exact results.
 
-use pyre_object::rbigint::{RBigInt as BigInt, RBigIntError};
+use pyre_object::rbigint::{RBigInt as BigInt, RBigIntError, RBigIntGcRoot};
 use pyre_object::*;
 
 /// Infallible f64 extraction with a `0.0` fallback for a non-convertible
@@ -631,7 +631,7 @@ pub fn factorial(args: &[PyObjectRef]) -> PyResult {
         let (result, _, shift) = fac1(n, gap);
         result.lshift(shift).map_err(map_rbigint_err)?
     };
-    Ok(bigint_to_pyint(result))
+    Ok(bigint_to_pyint(&result))
 }
 
 /// Convert any int/long/bool to a BigInt for math.gcd/lcm/factorial
@@ -642,7 +642,7 @@ pub fn factorial(args: &[PyObjectRef]) -> PyResult {
 fn get_bigint(obj: PyObjectRef) -> Result<BigInt, crate::PyError> {
     unsafe {
         if pyre_object::is_long(obj) {
-            return Ok(pyre_object::w_long_get_value(obj).clone());
+            return Ok(pyre_object::w_long_get_value(obj).translated_alias());
         }
         if pyre_object::is_int(obj) {
             return Ok(BigInt::from(pyre_object::w_int_get_value(obj)));
@@ -671,7 +671,7 @@ fn get_bigint(obj: PyObjectRef) -> Result<BigInt, crate::PyError> {
                     return Ok(BigInt::from(pyre_object::w_int_get_value(result)));
                 }
                 if pyre_object::is_long(result) {
-                    return Ok(pyre_object::w_long_get_value(result).clone());
+                    return Ok(pyre_object::w_long_get_value(result).translated_alias());
                 }
             }
             // descroperation.py:612 — __index__ returned non-int (type %T)
@@ -689,18 +689,22 @@ fn get_bigint(obj: PyObjectRef) -> Result<BigInt, crate::PyError> {
 }
 
 pub fn gcd(args: &[PyObjectRef]) -> PyResult {
-    let mut result = BigInt::zero();
+    // RPython's GC transform roots this running rbigint across the next
+    // argument's potentially user-defined `__index__` call.
+    let mut result = RBigIntGcRoot::new(BigInt::zero());
     for &arg in args {
-        result = result.gcd(&get_bigint(arg)?).map_err(map_rbigint_err)?;
+        *result = result.gcd(&get_bigint(arg)?).map_err(map_rbigint_err)?;
     }
-    Ok(bigint_to_pyint(result))
+    Ok(bigint_to_pyint(&result))
 }
 
 pub fn lcm(args: &[PyObjectRef]) -> PyResult {
     if args.is_empty() {
         return Ok(w_int_new(1));
     }
-    let mut result = get_bigint(args[0])?;
+    // app_math.py keeps `res` live while each later `index()` can execute
+    // arbitrary Python and collect.
+    let mut result = RBigIntGcRoot::new(get_bigint(args[0])?);
     for &arg in &args[1..] {
         // Every argument goes through `__index__` even once the running result
         // is zero: `math_lcm_impl` only short-circuits the arithmetic, so
@@ -711,24 +715,26 @@ pub fn lcm(args: &[PyObjectRef]) -> PyResult {
             continue;
         }
         if value.is_zero() {
-            result = BigInt::zero();
+            *result = BigInt::zero();
             continue;
         }
         let divisor = result.gcd(&value).map_err(map_rbigint_err)?;
-        result = result
+        *result = result
             .floordiv(&divisor)
             .map_err(map_rbigint_err)?
             .mul(&value)
             .abs();
     }
-    Ok(bigint_to_pyint(result.abs()))
+    let result = result.abs();
+    Ok(bigint_to_pyint(&result))
 }
 
 /// `w_int_new` when the value fits an i64, else `w_long_new`.
-fn bigint_to_pyint(b: BigInt) -> PyObjectRef {
-    match b.to_i64() {
-        Some(i) => w_int_new(i),
-        None => w_long_new(b),
+fn bigint_to_pyint(b: &BigInt) -> PyObjectRef {
+    if jit_bigint_to_i64_fits(b) != 0 {
+        w_int_new(jit_bigint_to_i64_value(b))
+    } else {
+        w_long_new(b.translated_alias())
     }
 }
 
@@ -738,7 +744,9 @@ pub fn comb(args: &[PyObjectRef]) -> PyResult {
             "comb() takes exactly two arguments",
         ));
     }
-    let n_big = get_bigint(args[0])?;
+    // `n` is an unboxed rbigint local across `index(k)`, exactly the kind of
+    // local rooted automatically by RPython's GC transform.
+    let n_big = RBigIntGcRoot::new(get_bigint(args[0])?);
     let k_big = get_bigint(args[1])?;
 
     if n_big.int_lt(0) {
@@ -756,7 +764,7 @@ pub fn comb(args: &[PyObjectRef]) -> PyResult {
         return Ok(w_int_new(0));
     }
 
-    let n_minus_k = &n_big - &k_big;
+    let n_minus_k = &*n_big - &k_big;
     let k = if n_minus_k.lt(&k_big) {
         n_minus_k
     } else {
@@ -768,7 +776,7 @@ pub fn comb(args: &[PyObjectRef]) -> PyResult {
 
     // pypy/module/math/app_math.py:comb — preserve its occasional fraction
     // reduction, including a bigint loop index.
-    let mut numerator = n_big.clone();
+    let mut numerator = n_big.translated_alias();
     let mut denominator = BigInt::one();
     let mut i = BigInt::one();
     while i.lt(&k) {
@@ -781,7 +789,7 @@ pub fn comb(args: &[PyObjectRef]) -> PyResult {
         i = i.int_add(1);
     }
     Ok(bigint_to_pyint(
-        numerator.floordiv(&denominator).map_err(map_rbigint_err)?,
+        &numerator.floordiv(&denominator).map_err(map_rbigint_err)?,
     ))
 }
 
@@ -796,7 +804,8 @@ pub fn perm(args: &[PyObjectRef]) -> PyResult {
             "perm() takes at most 2 arguments",
         ));
     }
-    let n_big = get_bigint(args[0])?;
+    // Keep `n` rooted while a non-None `k` invokes its `__index__`.
+    let n_big = RBigIntGcRoot::new(get_bigint(args[0])?);
     if n_big.int_lt(0) {
         return Err(crate::PyError::value_error(
             "n must be a non-negative integer",
@@ -818,12 +827,12 @@ pub fn perm(args: &[PyObjectRef]) -> PyResult {
             return Ok(w_int_new(0));
         }
     }
-    let k = k_big.unwrap_or_else(|| n_big.clone());
+    let k = k_big.unwrap_or_else(|| n_big.translated_alias());
 
     fn product_range(low: &BigInt, high: &BigInt, gap: &BigInt) -> Result<BigInt, RBigIntError> {
         if low.add(gap).ge(high) {
             let mut result = BigInt::one();
-            let mut i = low.clone();
+            let mut i = low.translated_alias();
             while i.lt(high) {
                 result = result.mul(&i);
                 i = i.int_add(1);
@@ -848,7 +857,7 @@ pub fn perm(args: &[PyObjectRef]) -> PyResult {
         product_range(&low, &high, &gap)
     }
     .map_err(map_rbigint_err)?;
-    Ok(bigint_to_pyint(result))
+    Ok(bigint_to_pyint(&result))
 }
 
 pub fn isqrt(args: &[PyObjectRef]) -> PyResult {
@@ -861,7 +870,7 @@ pub fn isqrt(args: &[PyObjectRef]) -> PyResult {
     let value = n
         .isqrt()
         .map_err(|_| crate::PyError::value_error("isqrt() argument must be nonnegative"))?;
-    Ok(bigint_to_pyint(value))
+    Ok(bigint_to_pyint(&value))
 }
 
 pub fn fsum(args: &[PyObjectRef]) -> PyResult {
@@ -974,7 +983,6 @@ pub fn frexp(args: &[PyObjectRef]) -> PyResult {
 }
 
 pub fn ldexp(args: &[PyObjectRef]) -> PyResult {
-    use num_traits::ToPrimitive;
     if args.len() < 2 {
         return Err(crate::PyError::type_error(
             "ldexp() takes exactly 2 arguments",
@@ -982,8 +990,11 @@ pub fn ldexp(args: &[PyObjectRef]) -> PyResult {
     }
     // PyPy: pypy/module/math/interp_math.py::ldexp — second argument
     // must be an integer (via `__index__`), not a float.
-    let exp_big = get_bigint(args[1])?;
+    // interp_math.py::ldexp evaluates x before converting the exponent.
+    // Besides preserving callback order, this avoids retaining an unboxed
+    // exponent rbigint across x.__float__.
     let x = try_get_double(args[0])?;
+    let exp_big = get_bigint(args[1])?;
     // Short-circuit special cases so an overflowing exponent doesn't
     // mask inf/nan propagation.
     if x.is_nan() {
@@ -994,16 +1005,18 @@ pub fn ldexp(args: &[PyObjectRef]) -> PyResult {
     }
     // Clamp the exponent to i32 range. Out-of-range exponents either
     // underflow to 0 (negative, finite x) or overflow to OverflowError.
-    let exp = match exp_big.to_i32() {
-        Some(v) => v,
-        None => {
-            // Sign of the exponent decides the result shape.
-            if exp_big.int_lt(0) {
-                let signed = if x.is_sign_positive() { 0.0 } else { -0.0 };
-                return Ok(floatobject::w_float_new(signed));
-            }
-            return Err(crate::PyError::overflow_error("math range error"));
+    let exp = if jit_bigint_to_i64_fits(&exp_big) != 0 {
+        i32::try_from(jit_bigint_to_i64_value(&exp_big)).ok()
+    } else {
+        None
+    };
+    let Some(exp) = exp else {
+        // Sign of the exponent decides the result shape.
+        if exp_big.int_lt(0) {
+            let signed = if x.is_sign_positive() { 0.0 } else { -0.0 };
+            return Ok(floatobject::w_float_new(signed));
         }
+        return Err(crate::PyError::overflow_error("math range error"));
     };
     map_err(pymath::math::ldexp(x, exp))
 }
@@ -1049,7 +1062,11 @@ pub fn nextafter(args: &[PyObjectRef]) -> PyResult {
                     "steps must be a non-negative integer",
                 ));
             }
-            Some(b.to_u64().unwrap_or(u64::MAX))
+            Some(if jit_bigint_to_u64_fits(&b) != 0 {
+                jit_bigint_to_u64_value(&b)
+            } else {
+                u64::MAX
+            })
         }
         None => None,
     };

--- a/pyre/pyre-interpreter/src/module/math/interp_math.rs
+++ b/pyre/pyre-interpreter/src/module/math/interp_math.rs
@@ -702,9 +702,17 @@ pub fn lcm(args: &[PyObjectRef]) -> PyResult {
     }
     let mut result = get_bigint(args[0])?;
     for &arg in &args[1..] {
+        // Every argument goes through `__index__` even once the running result
+        // is zero: `math_lcm_impl` only short-circuits the arithmetic, so
+        // `math.lcm(0, 1.5)` still raises TypeError.  `app_math.lcm` returns
+        // early instead and skips the remaining conversions.
         let value = get_bigint(arg)?;
-        if result.is_zero() || value.is_zero() {
-            return Ok(w_int_new(0));
+        if result.is_zero() {
+            continue;
+        }
+        if value.is_zero() {
+            result = BigInt::zero();
+            continue;
         }
         let divisor = result.gcd(&value).map_err(map_rbigint_err)?;
         result = result

--- a/pyre/pyre-interpreter/src/module/struct/mod.rs
+++ b/pyre/pyre-interpreter/src/module/struct/mod.rs
@@ -440,9 +440,10 @@ unsafe fn pack_int(
             return Err(range_error(fmtchar, size, signed));
         }
     } else {
-        match value.to_u64() {
-            Some(u) => u.to_le_bytes(),
-            None => return Err(range_error(fmtchar, size, signed)),
+        if longobject::jit_bigint_to_u64_fits(&value) != 0 {
+            longobject::jit_bigint_to_u64_value(&value).to_le_bytes()
+        } else {
+            return Err(range_error(fmtchar, size, signed));
         }
     };
 

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -1035,11 +1035,6 @@ unsafe fn long_floordiv(a: PyObjectRef, b: PyObjectRef) -> PyResult {
         owned_a = BigInt::from(int_value(a));
         &owned_a
     };
-    if is_long(a) && va.get_sign() == 1 && vb.int_eq(1) {
-        return Ok(pyre_object::longobject::w_long_from_raw(
-            w_long_get_raw_value(a),
-        ));
-    }
     // rbigint.floordiv → _divmod, returning the quotient half (rbigint.py:1001).
     // `_floordiv`/`_int_floordiv` both `newlong` the quotient, keeping a long.
     Ok(w_long_new(bigint_floordiv_nonzero(va, vb)))
@@ -1120,8 +1115,6 @@ unsafe fn integer_divmod_pair(a: PyObjectRef, b: PyObjectRef) -> PyResult {
 
     // longobject.py `_make_descr_binop(_divmod, _int_divmod)` preserves a
     // dedicated long/int residual; reflected int/long follows `_divmod`.
-    let quotient_aliases_a =
-        is_long(a) && is_int_like(b) && int_value(b) == 1 && w_long_get_value(a).get_sign() == 1;
     let remainder_aliases_a = if is_long(a) && is_long(b) {
         let va = w_long_get_value(a);
         let vb = w_long_get_value(b);
@@ -1154,11 +1147,7 @@ unsafe fn integer_divmod_pair(a: PyObjectRef, b: PyObjectRef) -> PyResult {
     let q = RBigIntGcRoot::new(q);
     let r = RBigIntGcRoot::new(r);
     if is_long(a) || is_long(b) {
-        let w_q = if quotient_aliases_a {
-            pyre_object::longobject::w_long_from_raw(w_long_get_raw_value(a))
-        } else {
-            w_long_new(q.translated_alias())
-        };
+        let w_q = w_long_new(q.translated_alias());
         let w_r = if remainder_aliases_a {
             pyre_object::longobject::w_long_from_raw(w_long_get_raw_value(a))
         } else {
@@ -5251,6 +5240,16 @@ mod tests {
     }
 
     #[test]
+    fn test_machine_int_host_seams_use_dedicated_rbigint_legs() {
+        let value = BigInt::one().lshift(130).unwrap().int_add(17);
+        let quotient = bigint_int_floordiv_nonzero(&value, 3);
+        assert!(quotient.eq(&value.int_floordiv(3).unwrap()));
+
+        let power = bigint_int_pow_nomod(&value, 3).expect("small exponent");
+        assert!(power.eq(&value.int_pow(3, None).unwrap()));
+    }
+
+    #[test]
     fn test_bigint_truediv_exponent() {
         // Regression: the exponent assembly carried a spurious `+ 1` that
         // doubled every quotient (equal operands gave 2.0, not 1.0).
@@ -5402,12 +5401,18 @@ mod tests {
                 long_mul(value, w_int_new(1)).unwrap(),
                 long_mul(w_bool_from(true), value).unwrap(),
                 long_floordiv(value, w_int_new(1)).unwrap(),
-                long_floordiv(value, w_long_new(BigInt::one())).unwrap(),
                 long_pow(value, w_int_new(1)).unwrap(),
             ] {
                 assert_ne!(result, value);
                 assert_eq!(w_long_get_raw_value(result), payload);
             }
+
+            // `rbigint.int_floordiv(1)` returns `self`, but the long-divisor
+            // path goes through `rbigint.divmod` -> `int_divmod`, whose
+            // quotient is freshly constructed.
+            let long_divisor_result = long_floordiv(value, w_long_new(BigInt::one())).unwrap();
+            assert_ne!(w_long_get_raw_value(long_divisor_result), payload);
+            assert!(w_long_get_value(long_divisor_result).eq(w_long_get_value(value)));
 
             // These upstream methods check zero before their alias shortcut
             // and return canonical NULLRBIGINT, not a fresh zero operand.
@@ -5430,7 +5435,8 @@ mod tests {
 
             let pair = integer_divmod_pair(value, w_int_new(1)).unwrap();
             let pair_quotient = w_tuple_getitem(pair, 0).expect("quotient");
-            assert_eq!(w_long_get_raw_value(pair_quotient), payload);
+            assert_ne!(w_long_get_raw_value(pair_quotient), payload);
+            assert!(w_long_get_value(pair_quotient).eq(w_long_get_value(value)));
         }
     }
 

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -8,7 +8,7 @@
 #![allow(unsafe_op_in_unsafe_fn)]
 
 use num_traits::ToPrimitive;
-use pyre_object::rbigint::RBigInt as BigInt;
+use pyre_object::rbigint::{RBigInt as BigInt, RBigIntGcRoot};
 
 use pyre_object::unicodeobject::is_str;
 use pyre_object::*;
@@ -21,20 +21,6 @@ use crate::baseobjspace::{
 pub use crate::{PyError, PyErrorKind, PyResult};
 
 // ── BigInt helpers ──────────────────────────────────────────────────
-
-/// Extract a BigInt from an int or long object.
-
-unsafe fn as_bigint(obj: PyObjectRef) -> BigInt {
-    // `is_int` is true for a bool (`BOOL_TYPE`), so test `is_bool` first; a bool
-    // reads through `w_bool_get_value`, not the int accessor.
-    if is_bool(obj) {
-        BigInt::from(w_bool_get_value(obj) as i64)
-    } else if is_int(obj) {
-        BigInt::from(w_int_get_value(obj))
-    } else {
-        w_long_get_value(obj).clone()
-    }
-}
 
 /// Box a BigInt result, demoting to W_IntObject if it fits in i64.
 
@@ -54,7 +40,7 @@ fn bigint_mod_inverse(base: &BigInt, modulus: &BigInt) -> Result<BigInt, PyError
     let mut old_r = base
         .r#mod(modulus)
         .map_err(|_| PyError::value_error("pow() 3rd argument cannot be 0"))?;
-    let mut r = modulus.clone();
+    let mut r = modulus.translated_alias();
     let mut old_s = BigInt::one();
     let mut s = BigInt::zero();
     while !r.is_zero() {
@@ -98,14 +84,14 @@ fn bigint_mul(a: BigInt, b: BigInt) -> BigInt {
 /// `jit_bigint_div_floor`, restoring RPython's one-GCREF CALL_PURE result
 /// instead of exposing Rust's `Result<(RBigInt, RBigInt), RBigIntError>`.
 #[majit_macros::jit_elidable]
-fn bigint_floordiv_nonzero(a: BigInt, b: BigInt) -> BigInt {
-    a.divmod(&b).expect("divisor was checked nonzero").0
+fn bigint_floordiv_nonzero(a: &BigInt, b: &BigInt) -> BigInt {
+    a.divmod(b).expect("divisor was checked nonzero").0
 }
 
 /// Remainder companion of [`bigint_floordiv_nonzero`].
 #[majit_macros::jit_elidable]
-fn bigint_modulo_nonzero(a: BigInt, b: BigInt) -> BigInt {
-    a.divmod(&b).expect("divisor was checked nonzero").1
+fn bigint_modulo_nonzero(a: &BigInt, b: &BigInt) -> BigInt {
+    a.divmod(b).expect("divisor was checked nonzero").1
 }
 
 /// Machine-int-divisor form of [`bigint_floordiv_nonzero`]
@@ -113,7 +99,7 @@ fn bigint_modulo_nonzero(a: BigInt, b: BigInt) -> BigInt {
 /// leg divides by a single digit instead of first materializing an rbigint for
 /// the `W_IntObject`.
 #[majit_macros::jit_elidable]
-fn bigint_int_floordiv_nonzero(a: BigInt, b: i64) -> BigInt {
+fn bigint_int_floordiv_nonzero(a: &BigInt, b: i64) -> BigInt {
     a.int_floordiv(b).expect("divisor was checked nonzero")
 }
 
@@ -122,7 +108,7 @@ fn bigint_int_floordiv_nonzero(a: BigInt, b: i64) -> BigInt {
 /// of a long by a machine int always fits a machine int, so the descriptor
 /// returns `space.newint` and this leg allocates no result bigint.
 #[majit_macros::jit_elidable]
-fn bigint_int_modulo_int_result_nonzero(a: BigInt, b: i64) -> i64 {
+fn bigint_int_modulo_int_result_nonzero(a: &BigInt, b: i64) -> i64 {
     a.int_mod_int_result(b)
         .expect("divisor was checked nonzero")
 }
@@ -143,16 +129,31 @@ fn bigint_xor(a: BigInt, b: BigInt) -> BigInt {
 }
 
 #[majit_macros::elidable]
-fn bigint_lshift(a: BigInt, shift: usize) -> Result<BigInt, pyre_object::rbigint::RBigIntError> {
-    // `rbigint.lshift` takes a signed machine int. Every caller has already
-    // performed longobject.py's negative/overflow checks.
-    let shift = i64::try_from(shift).map_err(|_| pyre_object::rbigint::RBigIntError::Memory)?;
+fn bigint_lshift(a: &BigInt, shift: i64) -> Result<BigInt, pyre_object::rbigint::RBigIntError> {
+    // longobject.py passes the result of rbigint.toint(), an RPython Signed.
+    // Keep that word signed and pointer-width independent all the way to
+    // rbigint.lshift; narrowing through usize truncates valid counts on wasm32.
     a.lshift(shift)
 }
 
 #[majit_macros::elidable]
-fn bigint_rshift(a: BigInt, shift: usize) -> BigInt {
-    a >> shift
+fn bigint_rshift(a: &BigInt, shift: i64) -> BigInt {
+    // Same Signed count shape as bigint_lshift.  The caller has rejected a
+    // negative value, so rshift cannot fail here.
+    a.rshift(shift, false).expect("nonnegative shift")
+}
+
+/// Exact `rbigint._divrem` early-return predicate (`rbigint.py:2406-2411`).
+///
+/// Upstream deliberately tests only the digit count and most-significant
+/// digit here. When it succeeds, the remainder is the input object `a`
+/// itself, so pointer-ABI residuals must not allocate a shallow copy.
+#[inline]
+fn divrem_returns_input_as_remainder(a: &BigInt, b: &BigInt) -> bool {
+    let size_a = a.numdigits();
+    let size_b = b.numdigits();
+    size_a < size_b
+        || (size_a == size_b && a.digit((size_a - 1).abs()) < b.digit((size_b - 1).abs()))
 }
 
 /// Host form of `rbigint.pow(a, b, None)` used by `long_pow`.
@@ -186,6 +187,21 @@ fn bigint_int_pow_nomod(a: &BigInt, b: i64) -> Result<BigInt, PyError> {
 #[majit_macros::dont_look_inside]
 fn bigint_lshift_count(a: &BigInt, shift: i64) -> Result<BigInt, PyError> {
     a.lshift(shift).map_err(|error| match error {
+        pyre_object::rbigint::RBigIntError::Memory => PyError::memory_error(""),
+        _ => PyError::value_error("negative shift count"),
+    })
+}
+
+/// Machine-int-specialized counterpart of [`bigint_lshift_count`].
+///
+/// intobject.py:861-868 calls
+/// `rbigint.lshift_int_int_bigint_result(a, b)` directly on two Signed words.
+/// Rust exposes its implicit MemoryError as `Result`; the MIR front retargets
+/// this exact carrier to `jit_bigint_lshift_int_int_result`, preserving the
+/// specialized no-input-rbigint-allocation shape.
+#[majit_macros::dont_look_inside]
+fn bigint_lshift_int_int_result(iself: i64, shift: i64) -> Result<BigInt, PyError> {
+    BigInt::lshift_int_int_bigint_result(iself, shift).map_err(|error| match error {
         pyre_object::rbigint::RBigIntError::Memory => PyError::memory_error(""),
         _ => PyError::value_error("negative shift count"),
     })
@@ -257,6 +273,9 @@ pub extern "C" fn jit_bigint_div(a: i64, b: i64) -> pyre_object::longobject::Jit
 pub extern "C" fn jit_bigint_rem(a: i64, b: i64) -> pyre_object::longobject::JitBigIntResult {
     let (a, b) = (a as *const BigInt, b as *const BigInt);
     unsafe {
+        if (&*b).get_sign() != 0 && divrem_returns_input_as_remainder(&*a, &*b) {
+            return pyre_object::longobject::encode_jit_bigint_result(a as *mut BigInt);
+        }
         pyre_object::longobject::encode_jit_bigint_result(
             pyre_object::longobject::alloc_bigint_nursery_collecting(
                 pyre_object::rbigint::_divrem(&*a, &*b)
@@ -293,6 +312,11 @@ pub extern "C" fn jit_bigint_int_div_floor(
 ) -> pyre_object::longobject::JitBigIntResult {
     let a = a as *const BigInt;
     unsafe {
+        // rbigint.int_floordiv: a positive bigint divided by +1 returns
+        // `self`, i.e. the identical translated GC reference.
+        if b == 1 && (&*a).get_sign() == 1 {
+            return pyre_object::longobject::encode_jit_bigint_result(a as *mut BigInt);
+        }
         pyre_object::longobject::encode_jit_bigint_result(
             pyre_object::longobject::alloc_bigint_nursery_collecting(
                 (&*a).int_floordiv(b).expect("division by zero"),
@@ -316,6 +340,19 @@ pub extern "C" fn jit_bigint_int_mod_int_result(a: i64, b: i64) -> i64 {
 pub extern "C" fn jit_bigint_mod_floor(a: i64, b: i64) -> pyre_object::longobject::JitBigIntResult {
     let (a, b) = (a as *const BigInt, b as *const BigInt);
     unsafe {
+        let selfsign = (&*a).get_sign();
+        let othersign = (&*b).get_sign();
+        // `divmod` routes one-digit divisors through `int_divmod`, which
+        // constructs its remainder. Otherwise `_divmod_small` preserves
+        // `_divrem`'s `a` remainder when no opposite-sign correction occurs.
+        if selfsign != 0
+            && othersign != 0
+            && selfsign == othersign
+            && (&*b).numdigits() != 1
+            && divrem_returns_input_as_remainder(&*a, &*b)
+        {
+            return pyre_object::longobject::encode_jit_bigint_result(a as *mut BigInt);
+        }
         pyre_object::longobject::encode_jit_bigint_result(
             pyre_object::longobject::alloc_bigint_nursery_collecting(
                 (&*a).divmod(&*b).expect("division by zero").1,
@@ -376,6 +413,9 @@ pub extern "C" fn jit_bigint_xor(a: i64, b: i64) -> pyre_object::longobject::Jit
 pub extern "C" fn jit_bigint_sub(a: i64, b: i64) -> pyre_object::longobject::JitBigIntResult {
     let (a, b) = (a as *const BigInt, b as *const BigInt);
     unsafe {
+        if (&*b).get_sign() == 0 {
+            return pyre_object::longobject::encode_jit_bigint_result(a as *mut BigInt);
+        }
         pyre_object::longobject::encode_jit_bigint_result(
             pyre_object::longobject::alloc_bigint_nursery_collecting(&*a - &*b),
         )
@@ -398,6 +438,12 @@ pub extern "C" fn jit_bigint_mul(a: i64, b: i64) -> pyre_object::longobject::Jit
 pub extern "C" fn jit_bigint_add(a: i64, b: i64) -> pyre_object::longobject::JitBigIntResult {
     let (a, b) = (a as *const BigInt, b as *const BigInt);
     unsafe {
+        if (&*a).get_sign() == 0 {
+            return pyre_object::longobject::encode_jit_bigint_result(b as *mut BigInt);
+        }
+        if (&*b).get_sign() == 0 {
+            return pyre_object::longobject::encode_jit_bigint_result(a as *mut BigInt);
+        }
         pyre_object::longobject::encode_jit_bigint_result(
             pyre_object::longobject::alloc_bigint_nursery_collecting(&*a + &*b),
         )
@@ -428,9 +474,45 @@ macro_rules! bigint_int_residual {
     };
 }
 
-bigint_int_residual!(jit_bigint_int_add, int_add);
-bigint_int_residual!(jit_bigint_int_sub, int_sub);
-bigint_int_residual!(jit_bigint_int_mul, int_mul);
+#[majit_macros::elidable_or_memerror]
+pub extern "C" fn jit_bigint_int_add(a: i64, b: i64) -> pyre_object::longobject::JitBigIntResult {
+    let a = a as *const BigInt;
+    unsafe {
+        if b == 0 && (&*a).get_sign() != 0 {
+            return pyre_object::longobject::encode_jit_bigint_result(a as *mut BigInt);
+        }
+        pyre_object::longobject::encode_jit_bigint_result(
+            pyre_object::longobject::alloc_bigint_nursery_collecting((&*a).int_add(b)),
+        )
+    }
+}
+
+#[majit_macros::elidable_or_memerror]
+pub extern "C" fn jit_bigint_int_sub(a: i64, b: i64) -> pyre_object::longobject::JitBigIntResult {
+    let a = a as *const BigInt;
+    unsafe {
+        if b == 0 {
+            return pyre_object::longobject::encode_jit_bigint_result(a as *mut BigInt);
+        }
+        pyre_object::longobject::encode_jit_bigint_result(
+            pyre_object::longobject::alloc_bigint_nursery_collecting((&*a).int_sub(b)),
+        )
+    }
+}
+
+#[majit_macros::elidable_or_memerror]
+pub extern "C" fn jit_bigint_int_mul(a: i64, b: i64) -> pyre_object::longobject::JitBigIntResult {
+    let a = a as *const BigInt;
+    unsafe {
+        if b == 1 && (&*a).get_sign() != 0 {
+            return pyre_object::longobject::encode_jit_bigint_result(a as *mut BigInt);
+        }
+        pyre_object::longobject::encode_jit_bigint_result(
+            pyre_object::longobject::alloc_bigint_nursery_collecting((&*a).int_mul(b)),
+        )
+    }
+}
+
 bigint_int_residual!(jit_bigint_int_and, int_and_);
 bigint_int_residual!(jit_bigint_int_or, int_or_);
 bigint_int_residual!(jit_bigint_int_xor, int_xor);
@@ -441,7 +523,7 @@ macro_rules! bigint_int_comparison_residual {
         // rbigint.py `_make_int_comparison`: these helpers only inspect the
         // existing digits and return a bool; unlike the arithmetic int_*
         // family above, they allocate nothing and cannot raise.
-        #[majit_macros::elidable]
+        #[majit_macros::elidable_cannot_raise]
         pub extern "C" fn $name(a: i64, b: i64) -> i64 {
             let a = a as *const BigInt;
             unsafe { (&*a).$method(b) as i64 }
@@ -464,6 +546,10 @@ bigint_int_comparison_residual!(jit_bigint_int_ge, int_ge);
 #[majit_macros::elidable_or_memerror]
 pub extern "C" fn jit_bigint_pow_nomod(a: i64, b: i64) -> pyre_object::longobject::JitBigIntResult {
     let (a, b) = (a as *const BigInt, b as *const BigInt);
+    // rbigint.pow(..., modulus=None): exponent +1 returns `self`.
+    if unsafe { (&*a).get_sign() != 0 && (&*b).int_eq(1) } {
+        return pyre_object::longobject::encode_jit_bigint_result(a as *mut BigInt);
+    }
     match unsafe { (&*a).pow(&*b, None) } {
         Ok(value) => pyre_object::longobject::encode_jit_bigint_result(
             pyre_object::longobject::alloc_bigint_nursery_collecting(value),
@@ -485,6 +571,10 @@ pub extern "C" fn jit_bigint_int_pow_nomod(
     b: i64,
 ) -> pyre_object::longobject::JitBigIntResult {
     let a = a as *const BigInt;
+    // rbigint.int_pow(..., modulus=None): exponent 1 returns `self`.
+    if b == 1 && unsafe { (&*a).get_sign() != 0 } {
+        return pyre_object::longobject::encode_jit_bigint_result(a as *mut BigInt);
+    }
     match unsafe { (&*a).int_pow(b, None) } {
         Ok(value) => pyre_object::longobject::encode_jit_bigint_result(
             pyre_object::longobject::alloc_bigint_nursery_collecting(value),
@@ -506,7 +596,31 @@ pub extern "C" fn jit_bigint_lshift_count(
     shift: i64,
 ) -> pyre_object::longobject::JitBigIntResult {
     let a = a as *const BigInt;
+    // rbigint.lshift returns `self` for both a zero count and a zero base.
+    if shift == 0 || unsafe { (&*a).get_sign() == 0 } {
+        return pyre_object::longobject::encode_jit_bigint_result(a as *mut BigInt);
+    }
     match unsafe { (&*a).lshift(shift) } {
+        Ok(value) => pyre_object::longobject::encode_jit_bigint_result(
+            pyre_object::longobject::alloc_bigint_nursery_collecting(value),
+        ),
+        Err(_) => {
+            crate::runtime_ops::jit_publish_exception(
+                pyre_object::interp_exceptions::memory_error_singleton(),
+            );
+            pyre_object::longobject::encode_jit_bigint_result(std::ptr::null_mut())
+        }
+    }
+}
+
+/// intobject.py's Signed×Signed specialized overflow leg. This is the direct
+/// pointer-ABI form of [`bigint_lshift_int_int_result`].
+#[majit_macros::elidable_or_memerror]
+pub extern "C" fn jit_bigint_lshift_int_int_result(
+    iself: i64,
+    shift: i64,
+) -> pyre_object::longobject::JitBigIntResult {
+    match BigInt::lshift_int_int_bigint_result(iself, shift) {
         Ok(value) => pyre_object::longobject::encode_jit_bigint_result(
             pyre_object::longobject::alloc_bigint_nursery_collecting(value),
         ),
@@ -526,7 +640,44 @@ pub extern "C" fn jit_bigint_neg(a: i64) -> pyre_object::longobject::JitBigIntRe
     let a = a as *const BigInt;
     unsafe {
         pyre_object::longobject::encode_jit_bigint_result(
-            pyre_object::longobject::alloc_bigint_nursery_collecting(-&*a),
+            // rbigint.py:1299-1301 always constructs a fresh rbigint handle,
+            // including for zero; only its immutable digits are shared.
+            pyre_object::rbigint::alloc_rbigint_clone_nursery_collecting((&*a).neg()),
+        )
+    }
+}
+
+/// Whether `rbigint.divmod(a, b)` reaches `_divrem`'s literal
+/// `(NULLRBIGINT, a)` return without a floored-sign adjustment.
+///
+/// This pointer-only predicate is a translation seam for W_LongObject
+/// consumers that must put the returned operand payload into a fresh wrapper.
+/// Keeping it residual avoids rebuilding the opaque RBigInt field graph in
+/// `long_mod` while retaining an elidable/cannot-raise operation.
+#[majit_macros::elidable_cannot_raise]
+pub extern "C" fn jit_bigint_divrem_returns_lhs_remainder(a: i64, b: i64) -> i64 {
+    let (a, b) = (a as *const BigInt, b as *const BigInt);
+    unsafe {
+        let a = &*a;
+        let b = &*b;
+        let a_size = a.numdigits();
+        let b_size = b.numdigits();
+        (a.get_sign() != 0
+            && a.get_sign() == b.get_sign()
+            && b_size != 1
+            && (a_size < b_size || (a_size == b_size && a.digit(a_size - 1) < b.digit(b_size - 1))))
+            as i64
+    }
+}
+
+/// `rbigint.invert` payload. Zero returns the canonical -1 prebuilt; every
+/// other input follows `int_add(1)` and sign inversion.
+#[majit_macros::elidable_or_memerror]
+pub extern "C" fn jit_bigint_invert(a: i64) -> pyre_object::longobject::JitBigIntResult {
+    let a = a as *const BigInt;
+    unsafe {
+        pyre_object::longobject::encode_jit_bigint_result(
+            pyre_object::longobject::alloc_bigint_nursery_collecting((&*a).invert()),
         )
     }
 }
@@ -543,6 +694,9 @@ pub extern "C" fn jit_bigint_neg(a: i64) -> pyre_object::longobject::JitBigIntRe
 pub extern "C" fn jit_bigint_shl(a: i64, b: i64) -> pyre_object::longobject::JitBigIntResult {
     let a = a as *const BigInt;
     unsafe {
+        if b == 0 || (&*a).get_sign() == 0 {
+            return pyre_object::longobject::encode_jit_bigint_result(a as *mut BigInt);
+        }
         pyre_object::longobject::encode_jit_bigint_result(
             pyre_object::longobject::alloc_bigint_nursery_collecting(&*a << (b as usize)),
         )
@@ -554,6 +708,9 @@ pub extern "C" fn jit_bigint_shl(a: i64, b: i64) -> pyre_object::longobject::Jit
 pub extern "C" fn jit_bigint_shr(a: i64, b: i64) -> pyre_object::longobject::JitBigIntResult {
     let a = a as *const BigInt;
     unsafe {
+        if b == 0 {
+            return pyre_object::longobject::encode_jit_bigint_result(a as *mut BigInt);
+        }
         pyre_object::longobject::encode_jit_bigint_result(
             pyre_object::longobject::alloc_bigint_nursery_collecting(&*a >> (b as usize)),
         )
@@ -570,13 +727,13 @@ fn float_copysign(mag: f64, sign: f64) -> f64 {
 }
 
 #[majit_macros::elidable]
-fn bigint_neg(a: BigInt) -> BigInt {
-    -a
+fn bigint_neg(a: &BigInt) -> BigInt {
+    a.neg()
 }
 
 #[majit_macros::elidable]
-fn bigint_invert(a: BigInt) -> BigInt {
-    !a
+fn bigint_invert(a: &BigInt) -> BigInt {
+    a.invert()
 }
 
 #[majit_macros::elidable]
@@ -599,114 +756,20 @@ fn bigint_mod(a: BigInt, b: BigInt) -> BigInt {
     a % b
 }
 
-/// `m * 2^exp`, splitting the power-of-two factor so neither side over- nor
-/// under-flows before a single correctly-rounded final multiply. A lone
-/// `2f64.powi(exp)` would flush to zero in the subnormal range and lose the
-/// result; this matches `math.ldexp` without raising on overflow.
-fn ldexp_pow2(m: f64, mut exp: i64) -> f64 {
-    let mut x = m;
-    while exp > 1023 {
-        x *= 2.0_f64.powi(1023);
-        exp -= 1023;
-    }
-    while exp < -1022 {
-        x *= 2.0_f64.powi(-1022);
-        exp += 1022;
-    }
-    x * 2.0_f64.powi(exp as i32)
-}
-
-/// longobject.py:62-70 `_truediv` → rbigint.truediv parity.
-/// Produces the correctly-rounded IEEE 754 double for a/b.
-/// Port of CPython `Objects/longobject.c long_true_divide`.
+/// longobject.py:62-70 `_truediv` delegates directly to rbigint.truediv and
+/// only translates its application-level exceptions.
 #[majit_macros::elidable]
-fn bigint_truediv(a: BigInt, b: BigInt) -> Result<f64, PyError> {
-    let a_sign = pyre_object::longobject::jit_bigint_sign_i64(&a);
-    let b_sign = pyre_object::longobject::jit_bigint_sign_i64(&b);
-    if b_sign == 0 {
-        return Err(PyError::zero_division("division by zero"));
-    }
-    if a_sign == 0 {
-        return Ok(0.0);
-    }
-
-    let negate = (a_sign < 0) != (b_sign < 0);
-    let a_abs = if a_sign < 0 { -a } else { a };
-    let b_abs = if b_sign < 0 { -b } else { b };
-
-    let a_bits = a_abs.bits() as i64;
-    let b_bits = b_abs.bits() as i64;
-
-    // f64 exponent range: [-1022, 1023]. If a/b would exceed 2^1024, overflow.
-    if a_bits - b_bits > 1024 {
-        return Err(PyError::new(
-            PyErrorKind::OverflowError,
-            "integer division result too large for a float",
-        ));
-    }
-    // If a/b would underflow to 0 (ratio < 2^-1075 where 1075 = 1022+53):
-    if b_bits - a_bits > 1075 {
-        return Ok(if negate { -0.0 } else { 0.0 });
-    }
-
-    // Scale so the integer quotient `q` carries DBL_MANT_DIG + 2 extra bits, then
-    // round it down to DBL_MANT_DIG significant bits. The remainder `r` is the
-    // sticky bit: scaling the DENOMINATOR up (never shifting `a` down) keeps it
-    // exact, so it captures every low bit of `a`. Folding that sticky into the
-    // round-to-53 decision — rather than letting an `f64` multiply re-round a
-    // 54-bit mantissa — avoids the double-rounding that drops the sticky on a tie.
-    // The `DBL_MIN_EXP` clamps keep the subnormal range correct: there the
-    // quotient is rounded to fewer than DBL_MANT_DIG bits and `ldexp` lands it.
-    const DBL_MANT_DIG: i64 = 53;
-    const DBL_MIN_EXP: i64 = -1021;
-    let shift = (a_bits - b_bits).max(DBL_MIN_EXP) - DBL_MANT_DIG - 2;
-    let (num, den) = if shift <= 0 {
-        (a_abs << ((-shift) as usize), b_abs)
-    } else {
-        (a_abs, b_abs << (shift as usize))
-    };
-
-    let (q, r) =
-        pyre_object::rbigint::_divrem(&num, &den).expect("absolute truediv denominator is nonzero");
-    let inexact = pyre_object::longobject::jit_bigint_sign_i64(&r) != 0;
-
-    // Drop the low `extra` bits of `q`, rounding half-to-even with `inexact` as
-    // the sticky bit. `extra` is 2 or 3; in the subnormal range the second term
-    // forces more bits off so the mantissa keeps only subnormal precision.
-    let extra = (q.bits() as i64).max(DBL_MIN_EXP - shift) - DBL_MANT_DIG;
-    let extra_u = extra.max(1) as usize;
-    let half = BigInt::from(1) << (extra_u - 1);
-    let low = &q & ((BigInt::from(1) << extra_u) - BigInt::from(1));
-    let dropped = &q >> extra_u;
-    let round_up =
-        low > half || (low == half && (inexact || (&dropped & BigInt::from(1)) != BigInt::from(0)));
-    let mantissa_big = if round_up {
-        dropped + BigInt::from(1)
-    } else {
-        dropped
-    };
-
-    if pyre_object::longobject::jit_bigint_to_u64_fits(&mantissa_big) == 0 {
-        return Err(PyError::new(
-            PyErrorKind::OverflowError,
-            "integer division result too large for a float",
-        ));
-    }
-    let mantissa = pyre_object::longobject::jit_bigint_to_u64_value(&mantissa_big);
-
-    // `mantissa` has at most DBL_MANT_DIG bits, so it is exact in `f64`; scale it
-    // by 2^exponent with a non-raising ldexp that preserves subnormal results.
-    let exponent = shift + extra_u as i64;
-    let result = ldexp_pow2(mantissa as f64, exponent);
-
-    if result.is_infinite() {
-        return Err(PyError::new(
-            PyErrorKind::OverflowError,
-            "integer division result too large for a float",
-        ));
-    }
-
-    Ok(if negate { -result } else { result })
+fn bigint_truediv(a: &BigInt, b: &BigInt) -> Result<f64, PyError> {
+    a.truediv(b).map_err(|error| match error {
+        pyre_object::rbigint::RBigIntError::DivisionByZero => {
+            PyError::zero_division("division by zero")
+        }
+        pyre_object::rbigint::RBigIntError::FloatDivisionOverflow => {
+            PyError::overflow_error("integer division result too large for a float")
+        }
+        pyre_object::rbigint::RBigIntError::Memory => PyError::memory_error(""),
+        _ => unreachable!("rbigint.truediv has no other exception edge"),
+    })
 }
 
 // ── Arithmetic operations ─────────────────────────────────────────────
@@ -757,10 +820,9 @@ unsafe fn int_floordiv(a: PyObjectRef, b: PyObjectRef) -> PyResult {
     // intobject.py `_floordiv`: `ovfcheck(x // y)` has exactly one
     // non-zero-divisor overflow on a signed machine word.
     if va == -9_223_372_036_854_775_808_i64 && vb == -1 {
-        return Ok(bigint_result(bigint_floordiv_nonzero(
-            BigInt::from(va),
-            BigInt::from(vb),
-        )));
+        let va = BigInt::from(va);
+        let vb = BigInt::from(vb);
+        return Ok(bigint_result(bigint_floordiv_nonzero(&va, &vb)));
     }
     let q = va / vb;
     let r = va % vb;
@@ -780,10 +842,9 @@ unsafe fn int_mod(a: PyObjectRef, b: PyObjectRef) -> PyResult {
     // intobject.py `_mod`: the matching machine-word overflow is
     // `MIN % -1`; bounce that one case to rbigint like `ovfcheck`.
     if va == -9_223_372_036_854_775_808_i64 && vb == -1 {
-        return Ok(bigint_result(bigint_modulo_nonzero(
-            BigInt::from(va),
-            BigInt::from(vb),
-        )));
+        let va = BigInt::from(va);
+        let vb = BigInt::from(vb);
+        return Ok(bigint_result(bigint_modulo_nonzero(&va, &vb)));
     }
     let r = va % vb;
     let r = if r != 0 && (r ^ vb) < 0 { r + vb } else { r };
@@ -799,57 +860,133 @@ unsafe fn long_add(a: PyObjectRef, b: PyObjectRef) -> PyResult {
     // bool separately, so the one upstream W_IntObject arm has two storage
     // projections here.
     if is_long(a) && is_bool(b) {
+        if !w_long_get_value(a).is_zero() && !w_bool_get_value(b) {
+            return Ok(pyre_object::longobject::w_long_from_raw(
+                w_long_get_raw_value(a),
+            ));
+        }
         return Ok(w_long_new(
             w_long_get_value(a).int_add(w_bool_get_value(b) as i64),
         ));
     }
     if is_long(a) && is_int(b) {
+        if !w_long_get_value(a).is_zero() && w_int_get_value(b) == 0 {
+            return Ok(pyre_object::longobject::w_long_from_raw(
+                w_long_get_raw_value(a),
+            ));
+        }
         return Ok(w_long_new(w_long_get_value(a).int_add(w_int_get_value(b))));
     }
     if is_bool(a) && is_long(b) {
+        if !w_long_get_value(b).is_zero() && !w_bool_get_value(a) {
+            return Ok(pyre_object::longobject::w_long_from_raw(
+                w_long_get_raw_value(b),
+            ));
+        }
         return Ok(w_long_new(
             w_long_get_value(b).int_add(w_bool_get_value(a) as i64),
         ));
     }
     if is_int(a) && is_long(b) {
+        if !w_long_get_value(b).is_zero() && w_int_get_value(a) == 0 {
+            return Ok(pyre_object::longobject::w_long_from_raw(
+                w_long_get_raw_value(b),
+            ));
+        }
         return Ok(w_long_new(w_long_get_value(b).int_add(w_int_get_value(a))));
     }
-    Ok(w_long_new(bigint_add(as_bigint(a), as_bigint(b))))
+    debug_assert!(is_long(a) && is_long(b));
+    if w_long_get_value(a).is_zero() {
+        return Ok(pyre_object::longobject::w_long_from_raw(
+            w_long_get_raw_value(b),
+        ));
+    }
+    if w_long_get_value(b).is_zero() {
+        return Ok(pyre_object::longobject::w_long_from_raw(
+            w_long_get_raw_value(a),
+        ));
+    }
+    Ok(w_long_new(w_long_get_value(a).add(w_long_get_value(b))))
 }
 
 unsafe fn long_sub(a: PyObjectRef, b: PyObjectRef) -> PyResult {
     // longobject.py:descr_sub specializes only `long - int`; descr_rsub keeps
     // `int - long` on the ordinary two-rbigint subtraction path.
     if is_long(a) && is_bool(b) {
+        if !w_bool_get_value(b) {
+            return Ok(pyre_object::longobject::w_long_from_raw(
+                w_long_get_raw_value(a),
+            ));
+        }
         return Ok(w_long_new(
             w_long_get_value(a).int_sub(w_bool_get_value(b) as i64),
         ));
     }
     if is_long(a) && is_int(b) {
+        if w_int_get_value(b) == 0 {
+            return Ok(pyre_object::longobject::w_long_from_raw(
+                w_long_get_raw_value(a),
+            ));
+        }
         return Ok(w_long_new(w_long_get_value(a).int_sub(w_int_get_value(b))));
     }
-    Ok(w_long_new(bigint_sub(as_bigint(a), as_bigint(b))))
+    if is_long(a) {
+        debug_assert!(is_long(b));
+        if w_long_get_value(b).is_zero() {
+            return Ok(pyre_object::longobject::w_long_from_raw(
+                w_long_get_raw_value(a),
+            ));
+        }
+        return Ok(w_long_new(w_long_get_value(a).sub(w_long_get_value(b))));
+    }
+    // Reflected int/bool - long follows descr_rsub's ordinary rbigint path:
+    // only the machine-word left operand needs materialising.
+    debug_assert!(is_long(b));
+    Ok(w_long_new(
+        BigInt::from(int_value(a)).sub(w_long_get_value(b)),
+    ))
 }
 
 unsafe fn long_mul(a: PyObjectRef, b: PyObjectRef) -> PyResult {
     // longobject.py:_make_generic_descr_binop('mul'): commutative int_mul.
     if is_long(a) && is_bool(b) {
+        if !w_long_get_value(a).is_zero() && w_bool_get_value(b) {
+            return Ok(pyre_object::longobject::w_long_from_raw(
+                w_long_get_raw_value(a),
+            ));
+        }
         return Ok(w_long_new(
             w_long_get_value(a).int_mul(w_bool_get_value(b) as i64),
         ));
     }
     if is_long(a) && is_int(b) {
+        if !w_long_get_value(a).is_zero() && w_int_get_value(b) == 1 {
+            return Ok(pyre_object::longobject::w_long_from_raw(
+                w_long_get_raw_value(a),
+            ));
+        }
         return Ok(w_long_new(w_long_get_value(a).int_mul(w_int_get_value(b))));
     }
     if is_bool(a) && is_long(b) {
+        if !w_long_get_value(b).is_zero() && w_bool_get_value(a) {
+            return Ok(pyre_object::longobject::w_long_from_raw(
+                w_long_get_raw_value(b),
+            ));
+        }
         return Ok(w_long_new(
             w_long_get_value(b).int_mul(w_bool_get_value(a) as i64),
         ));
     }
     if is_int(a) && is_long(b) {
+        if !w_long_get_value(b).is_zero() && w_int_get_value(a) == 1 {
+            return Ok(pyre_object::longobject::w_long_from_raw(
+                w_long_get_raw_value(b),
+            ));
+        }
         return Ok(w_long_new(w_long_get_value(b).int_mul(w_int_get_value(a))));
     }
-    Ok(w_long_new(bigint_mul(as_bigint(a), as_bigint(b))))
+    debug_assert!(is_long(a) && is_long(b));
+    Ok(w_long_new(w_long_get_value(a).mul(w_long_get_value(b))))
 }
 
 unsafe fn long_floordiv(a: PyObjectRef, b: PyObjectRef) -> PyResult {
@@ -863,15 +1000,37 @@ unsafe fn long_floordiv(a: PyObjectRef, b: PyObjectRef) -> PyResult {
         if vb == 0 {
             return Err(PyError::zero_division("integer division or modulo by zero"));
         }
-        return Ok(w_long_new(bigint_int_floordiv_nonzero(as_bigint(a), vb)));
+        debug_assert!(is_long(a));
+        if w_long_get_value(a).get_sign() == 1 && vb == 1 {
+            return Ok(pyre_object::longobject::w_long_from_raw(
+                w_long_get_raw_value(a),
+            ));
+        }
+        return Ok(w_long_new(bigint_int_floordiv_nonzero(
+            w_long_get_value(a),
+            vb,
+        )));
     }
-    let vb = as_bigint(b);
-    if bigint_eq(vb.clone(), BigInt::from(0)) {
+    debug_assert!(is_long(b));
+    let vb = w_long_get_value(b);
+    if !vb.tobool() {
         return Err(PyError::zero_division("integer division or modulo by zero"));
+    }
+    let owned_a;
+    let va = if is_long(a) {
+        w_long_get_value(a)
+    } else {
+        owned_a = BigInt::from(int_value(a));
+        &owned_a
+    };
+    if is_long(a) && va.get_sign() == 1 && vb.int_eq(1) {
+        return Ok(pyre_object::longobject::w_long_from_raw(
+            w_long_get_raw_value(a),
+        ));
     }
     // rbigint.floordiv → _divmod, returning the quotient half (rbigint.py:1001).
     // `_floordiv`/`_int_floordiv` both `newlong` the quotient, keeping a long.
-    Ok(w_long_new(bigint_floordiv_nonzero(as_bigint(a), vb)))
+    Ok(w_long_new(bigint_floordiv_nonzero(va, vb)))
 }
 
 unsafe fn long_mod(a: PyObjectRef, b: PyObjectRef) -> PyResult {
@@ -886,17 +1045,37 @@ unsafe fn long_mod(a: PyObjectRef, b: PyObjectRef) -> PyResult {
         if vb == 0 {
             return Err(PyError::zero_division("integer modulo by zero"));
         }
+        debug_assert!(is_long(a));
         return Ok(w_int_new(bigint_int_modulo_int_result_nonzero(
-            as_bigint(a),
+            w_long_get_value(a),
             vb,
         )));
     }
-    let vb = as_bigint(b);
-    if bigint_eq(vb.clone(), BigInt::from(0)) {
+    debug_assert!(is_long(b));
+    let vb = w_long_get_value(b);
+    if !vb.tobool() {
         return Err(PyError::zero_division("integer modulo by zero"));
     }
+    let owned_a;
+    let va = if is_long(a) {
+        w_long_get_value(a)
+    } else {
+        owned_a = BigInt::from(int_value(a));
+        &owned_a
+    };
+    if is_long(a) {
+        if jit_bigint_divrem_returns_lhs_remainder(
+            va as *const BigInt as i64,
+            vb as *const BigInt as i64,
+        ) != 0
+        {
+            return Ok(pyre_object::longobject::w_long_from_raw(
+                w_long_get_raw_value(a),
+            ));
+        }
+    }
     // rbigint.mod → _divmod, returning the remainder half (rbigint.py:1001).
-    Ok(w_long_new(bigint_modulo_nonzero(as_bigint(a), vb)))
+    Ok(w_long_new(bigint_modulo_nonzero(va, vb)))
 }
 
 /// PyPy longobject.py `_divmod` / `_int_divmod`: compute both halves with one
@@ -911,7 +1090,12 @@ unsafe fn integer_divmod_pair(a: PyObjectRef, b: PyObjectRef) -> PyResult {
             let (q, r) = BigInt::from(va)
                 .int_divmod(vb)
                 .expect("divisor was checked nonzero");
-            return Ok(w_tuple_new(vec![bigint_result(q), bigint_result(r)]));
+            let q = RBigIntGcRoot::new(q);
+            let r = RBigIntGcRoot::new(r);
+            return Ok(w_tuple_new(vec![
+                bigint_result(q.translated_alias()),
+                bigint_result(r.translated_alias()),
+            ]));
         }
         let mut q = va / vb;
         let mut r = va % vb;
@@ -924,19 +1108,56 @@ unsafe fn integer_divmod_pair(a: PyObjectRef, b: PyObjectRef) -> PyResult {
 
     // longobject.py `_make_descr_binop(_divmod, _int_divmod)` preserves a
     // dedicated long/int residual; reflected int/long follows `_divmod`.
+    let quotient_aliases_a =
+        is_long(a) && is_int_like(b) && int_value(b) == 1 && w_long_get_value(a).get_sign() == 1;
+    let remainder_aliases_a = if is_long(a) && is_long(b) {
+        let va = w_long_get_value(a);
+        let vb = w_long_get_value(b);
+        jit_bigint_divrem_returns_lhs_remainder(
+            va as *const BigInt as i64,
+            vb as *const BigInt as i64,
+        ) != 0
+    } else {
+        false
+    };
     let (q, r) = if is_long(a) && is_int_like(b) {
         w_long_get_value(a)
             .int_divmod(int_value(b))
             .expect("divisor was checked nonzero")
     } else {
-        as_bigint(a)
-            .divmod(&as_bigint(b))
+        debug_assert!(is_long(b));
+        let owned_a;
+        let va = if is_long(a) {
+            w_long_get_value(a)
+        } else {
+            owned_a = BigInt::from(int_value(a));
+            &owned_a
+        };
+        va.divmod(w_long_get_value(b))
             .expect("divisor was checked nonzero")
     };
+    // `_divmod` produces two live rbigints before either wrapper is
+    // allocated. RPython's GC transform roots both across those collecting
+    // allocations.
+    let q = RBigIntGcRoot::new(q);
+    let r = RBigIntGcRoot::new(r);
     if is_long(a) || is_long(b) {
-        Ok(w_tuple_new(vec![w_long_new(q), w_long_new(r)]))
+        let w_q = if quotient_aliases_a {
+            pyre_object::longobject::w_long_from_raw(w_long_get_raw_value(a))
+        } else {
+            w_long_new(q.translated_alias())
+        };
+        let w_r = if remainder_aliases_a {
+            pyre_object::longobject::w_long_from_raw(w_long_get_raw_value(a))
+        } else {
+            w_long_new(r.translated_alias())
+        };
+        Ok(w_tuple_new(vec![w_q, w_r]))
     } else {
-        Ok(w_tuple_new(vec![bigint_result(q), bigint_result(r)]))
+        Ok(w_tuple_new(vec![
+            bigint_result(q.translated_alias()),
+            bigint_result(r.translated_alias()),
+        ]))
     }
 }
 
@@ -1040,7 +1261,17 @@ fn bigint_mod_core(a: &BigInt, b: &BigInt, collecting: bool) -> i64 {
         );
         return 0;
     }
-    // rbigint.mod → _divmod, returning the remainder half (rbigint.py:1001).
+    let selfsign = pyre_object::longobject::jit_bigint_sign_i64(a);
+    let othersign = pyre_object::longobject::jit_bigint_sign_i64(b);
+    if selfsign != 0
+        && selfsign == othersign
+        && b.numdigits() != 1
+        && divrem_returns_input_as_remainder(a, b)
+    {
+        // `_divmod_small` leaves `_divrem`'s literal `a` remainder unchanged.
+        return a as *const BigInt as i64;
+    }
+    // rbigint.mod → divmod, returning the remainder half.
     alloc_result_bigint(
         a.divmod(b).expect("divisor was checked nonzero").1,
         collecting,
@@ -1057,17 +1288,20 @@ fn bigint_lshift_core(a: &BigInt, b: &BigInt, collecting: bool) -> i64 {
     // `rbigint.toint()` is a *signed* machine int (i64), so a count above
     // i64::MAX overflows here — not at usize::MAX — matching `_lshift`.
     let shift = if jit_bigint_to_i64_fits(b) != 0 {
-        jit_bigint_to_i64_value(b) as usize
+        jit_bigint_to_i64_value(b)
     } else {
         if pyre_object::longobject::jit_bigint_sign_i64(a) == 0 {
-            return alloc_result_bigint(BigInt::from(0), collecting);
+            return a as *const BigInt as i64;
         }
         crate::runtime_ops::jit_publish_exception(
             PyError::overflow_error("shift count too large").to_exc_object(),
         );
         return 0;
     };
-    match bigint_lshift(a.clone(), shift) {
+    if shift == 0 || pyre_object::longobject::jit_bigint_sign_i64(a) == 0 {
+        return a as *const BigInt as i64;
+    }
+    match bigint_lshift(a, shift) {
         Ok(value) => alloc_result_bigint(value, collecting),
         Err(pyre_object::rbigint::RBigIntError::Memory) => {
             crate::runtime_ops::jit_publish_exception(PyError::memory_error("").to_exc_object());
@@ -1087,7 +1321,7 @@ fn bigint_rshift_core(a: &BigInt, b: &BigInt, collecting: bool) -> i64 {
     // `toint()` overflow (count > i64::MAX) takes this branch like `_rshift`;
     // for rshift the result (0 / -1) is the same as an actual huge shift.
     let shift = if jit_bigint_to_i64_fits(b) != 0 {
-        jit_bigint_to_i64_value(b) as usize
+        jit_bigint_to_i64_value(b)
     } else {
         let val = if pyre_object::longobject::jit_bigint_sign_i64(a) < 0 {
             -1
@@ -1096,7 +1330,11 @@ fn bigint_rshift_core(a: &BigInt, b: &BigInt, collecting: bool) -> i64 {
         };
         return alloc_result_bigint(BigInt::from(val), collecting);
     };
-    alloc_result_bigint(bigint_rshift(a.clone(), shift), collecting)
+    if shift == 0 {
+        // rbigint.rshift(..., 0) returns `self`.
+        return a as *const BigInt as i64;
+    }
+    alloc_result_bigint(bigint_rshift(a, shift), collecting)
 }
 
 /// `rbigint.floordiv`/`mod`/`lshift`/`rshift` payload halves on bare
@@ -1151,7 +1389,7 @@ pub extern "C" fn jit_w_long_truediv_raw(a: i64, b: i64) -> f64 {
     let a = a as PyObjectRef;
     let b = b as PyObjectRef;
     unsafe {
-        match bigint_truediv(w_long_get_value(a).clone(), w_long_get_value(b).clone()) {
+        match bigint_truediv(w_long_get_value(a), w_long_get_value(b)) {
             Ok(f) => f,
             Err(mut e) => {
                 crate::runtime_ops::jit_publish_exception(e.to_exc_object());
@@ -1266,7 +1504,7 @@ unsafe fn float_mod(a: PyObjectRef, b: PyObjectRef) -> PyResult {
         // floatobject.py:526
         return Err(PyError::zero_division("float modulo"));
     }
-    let mut m = x % y; // fmod
+    let mut m = jit_float_fmod(x, y);
     if m != 0.0 {
         // floatobject.py:529-531: ensure remainder has same sign as denominator
         if (y < 0.0) != (m < 0.0) {
@@ -1285,7 +1523,7 @@ fn float_divmod_w(x: f64, y: f64) -> Result<(f64, f64), PyError> {
         // floatobject.py:761
         return Err(PyError::zero_division("float modulo"));
     }
-    let mut m = x % y; // fmod
+    let mut m = jit_float_fmod(x, y);
     // floatobject.py:767: div = (x - mod) / y
     let mut div = (x - m) / y;
     if m != 0.0 {
@@ -1370,8 +1608,19 @@ unsafe fn int_pow(a: PyObjectRef, b: PyObjectRef) -> PyResult {
 }
 
 unsafe fn long_pow(a: PyObjectRef, b: PyObjectRef) -> PyResult {
-    let vb = as_bigint(b);
-    if bigint_lt(vb.clone(), BigInt::from(0)) {
+    let vb_owned;
+    let vb = if is_long(b) {
+        w_long_get_value(b)
+    } else {
+        vb_owned = BigInt::from(int_value(b));
+        &vb_owned
+    };
+    if vb.get_sign() < 0 {
+        // longobject.py:219-222 calls descr_float on both integer operands
+        // before float pow.  RBigInt::tofloat raises on an out-of-range value;
+        // do not silently pass the infinity sentinel from as_float onward.
+        reject_pow_operand_overflow(a)?;
+        reject_pow_operand_overflow(b)?;
         let fa = as_float(a);
         let fb = as_float(b);
         return Ok(w_float_new(float_pow_raw(fa, fb)?));
@@ -1379,28 +1628,41 @@ unsafe fn long_pow(a: PyObjectRef, b: PyObjectRef) -> PyResult {
     // longobject.py:229: `if not exp_bigint: return int_pow(0)` → 1. `descr_pow`
     // wraps every branch as `W_LongObject`, so a long base keeps the long
     // representation across these trivial-base short-circuits too.
-    if pyre_object::longobject::jit_bigint_sign_i64(&vb) == 0 {
+    if vb.get_sign() == 0 {
         return Ok(w_long_new(BigInt::from(1)));
     }
     // longobject.py:224-231: rbigint.pow handles arbitrary exponents.
-    let va = as_bigint(a);
-    if pyre_object::longobject::jit_bigint_sign_i64(&va) == 0 {
+    let va_owned;
+    let va = if is_long(a) {
+        w_long_get_value(a)
+    } else {
+        va_owned = BigInt::from(int_value(a));
+        &va_owned
+    };
+    // Both rbigint.int_pow(1) and rbigint.pow(ONERBIGINT) return the base
+    // reference after the zero-base check. W_LongObject adds only a wrapper.
+    if is_long(a) && va.get_sign() != 0 && vb.int_eq(1) {
+        return Ok(pyre_object::longobject::w_long_from_raw(
+            w_long_get_raw_value(a),
+        ));
+    }
+    if va.get_sign() == 0 {
         return Ok(w_long_new(BigInt::from(0)));
     }
-    if va == BigInt::from(1) {
+    if va.int_eq(1) {
         return Ok(w_long_new(BigInt::from(1)));
     }
-    if va == BigInt::from(-1) {
-        let even = vb.clone() % BigInt::from(2) == BigInt::from(0);
+    if va.int_eq(-1) {
+        let even = vb.digit(0) & 1 == 0;
         return Ok(w_long_new(BigInt::from(if even { 1 } else { -1 })));
     }
     // longobject.py:229-231: `descr_pow` keeps a `W_IntObject` exponent
     // unwrapped (`exp_bigint` stays None) and calls `rbigint.int_pow`; only a
     // long exponent reaches `rbigint.pow`.
     if is_int_like(b) {
-        return Ok(w_long_new(bigint_int_pow_nomod(&va, int_value(b))?));
+        return Ok(w_long_new(bigint_int_pow_nomod(va, int_value(b))?));
     }
-    Ok(w_long_new(bigint_pow_nomod(&va, &vb)?))
+    Ok(w_long_new(bigint_pow_nomod(va, vb)?))
 }
 
 // ── Shift operations ─────────────────────────────────────────────────
@@ -1427,13 +1689,7 @@ unsafe fn int_lshift(a: PyObjectRef, b: PyObjectRef) -> PyResult {
     if va == 0 {
         return Ok(w_int_new(0));
     }
-    let big = match BigInt::lshift_int_int_bigint_result(va, vb) {
-        Ok(value) => value,
-        Err(pyre_object::rbigint::RBigIntError::Memory) => {
-            return Err(PyError::memory_error(""));
-        }
-        Err(_) => return Err(PyError::value_error("negative shift count")),
-    };
+    let big = bigint_lshift_int_int_result(va, vb)?;
     Ok(bigint_result(big))
 }
 
@@ -1457,49 +1713,97 @@ unsafe fn int_rshift(a: PyObjectRef, b: PyObjectRef) -> PyResult {
 }
 
 unsafe fn long_lshift(a: PyObjectRef, b: PyObjectRef) -> PyResult {
-    let vb = as_bigint(b);
-    if bigint_lt(vb.clone(), BigInt::from(0)) {
+    let vb_owned;
+    let vb = if is_long(b) {
+        w_long_get_value(b)
+    } else {
+        vb_owned = BigInt::from(int_value(b));
+        &vb_owned
+    };
+    if vb.get_sign() < 0 {
         return Err(PyError::value_error("negative shift count"));
     }
     // longobject.py:375-380: `toint()` (signed machine int / i64) overflows
     // when the count exceeds i64::MAX → 0 if base is zero, OverflowError
     // otherwise.
-    let shift = if jit_bigint_to_i64_fits(&vb) != 0 {
-        jit_bigint_to_i64_value(&vb) as u64
+    let shift = if jit_bigint_to_i64_fits(vb) != 0 {
+        jit_bigint_to_i64_value(vb)
     } else {
-        let va = as_bigint(a);
-        if pyre_object::longobject::jit_bigint_sign_i64(&va) == 0 {
+        let base_is_zero = if is_long(a) {
+            w_long_get_value(a).get_sign() == 0
+        } else {
+            int_value(a) == 0
+        };
+        if base_is_zero {
             // `_lshift` returns `self` (a W_LongObject) for a zero base.
-            return Ok(w_long_new(BigInt::from(0)));
+            return Ok(if is_long(a) {
+                a
+            } else {
+                // A reflected compact-int operand is first coerced to the
+                // W_LongObject receiver in PyPy's `_make_descr_binop`.
+                w_long_new(BigInt::from(0))
+            });
         }
         return Err(PyError::overflow_error("shift count too large"));
     };
-    let va = as_bigint(a);
-    let shifted = bigint_lshift_count(&va, shift as i64)?;
+    // rbigint.lshift returns `self` for a zero count or zero receiver.
+    // `W_LongObject._lshift` then puts that same payload into a fresh long
+    // wrapper (except for the huge-count zero case above, which returns the
+    // receiver wrapper itself).
+    if is_long(a) && (shift == 0 || w_long_get_value(a).get_sign() == 0) {
+        return Ok(pyre_object::longobject::w_long_from_raw(
+            w_long_get_raw_value(a),
+        ));
+    }
+    let va_owned;
+    let va = if is_long(a) {
+        w_long_get_value(a)
+    } else {
+        va_owned = BigInt::from(int_value(a));
+        &va_owned
+    };
+    let shifted = bigint_lshift_count(va, shift)?;
     Ok(w_long_new(shifted))
 }
 
 unsafe fn long_rshift(a: PyObjectRef, b: PyObjectRef) -> PyResult {
-    let vb = as_bigint(b);
-    if bigint_lt(vb.clone(), BigInt::from(0)) {
+    let vb_owned;
+    let vb = if is_long(b) {
+        w_long_get_value(b)
+    } else {
+        vb_owned = BigInt::from(int_value(b));
+        &vb_owned
+    };
+    if vb.get_sign() < 0 {
         return Err(PyError::value_error("negative shift count"));
     }
     // longobject.py:393-397: `toint()` overflow (count > i64::MAX) → positive
     // yields 0, negative yields -1 (all bits shifted out).
-    let shift = if jit_bigint_to_i64_fits(&vb) != 0 {
-        jit_bigint_to_i64_value(&vb) as usize
+    let shift = if jit_bigint_to_i64_fits(vb) != 0 {
+        jit_bigint_to_i64_value(vb)
     } else {
-        let va = as_bigint(a);
-        return Ok(w_int_new(
-            if pyre_object::longobject::jit_bigint_sign_i64(&va) < 0 {
-                -1
-            } else {
-                0
-            },
-        ));
+        let negative = if is_long(a) {
+            w_long_get_value(a).get_sign() < 0
+        } else {
+            int_value(a) < 0
+        };
+        return Ok(w_int_new(if negative { -1 } else { 0 }));
     };
+    // rbigint.rshift(0) returns `self`; `newlong` adds only a fresh wrapper.
+    if is_long(a) && shift == 0 {
+        return Ok(pyre_object::longobject::w_long_from_raw(
+            w_long_get_raw_value(a),
+        ));
+    }
     // `_rshift`/`_int_rshift` `newlong` the normal-count result, keeping a long.
-    Ok(w_long_new(bigint_rshift(as_bigint(a), shift)))
+    let va_owned;
+    let va = if is_long(a) {
+        w_long_get_value(a)
+    } else {
+        va_owned = BigInt::from(int_value(a));
+        &va_owned
+    };
+    Ok(w_long_new(bigint_rshift(va, shift)))
 }
 
 // ── bool-as-int helpers ──────────────────────────────────────────────
@@ -1553,7 +1857,8 @@ unsafe fn long_bitand(a: PyObjectRef, b: PyObjectRef) -> PyResult {
     if is_int(a) && is_long(b) {
         return Ok(w_long_new(w_long_get_value(b).int_and_(w_int_get_value(a))));
     }
-    Ok(w_long_new(bigint_and(as_bigint(a), as_bigint(b))))
+    debug_assert!(is_long(a) && is_long(b));
+    Ok(w_long_new(w_long_get_value(a).and_(w_long_get_value(b))))
 }
 
 unsafe fn long_bitor(a: PyObjectRef, b: PyObjectRef) -> PyResult {
@@ -1573,7 +1878,8 @@ unsafe fn long_bitor(a: PyObjectRef, b: PyObjectRef) -> PyResult {
     if is_int(a) && is_long(b) {
         return Ok(w_long_new(w_long_get_value(b).int_or_(w_int_get_value(a))));
     }
-    Ok(w_long_new(bigint_or(as_bigint(a), as_bigint(b))))
+    debug_assert!(is_long(a) && is_long(b));
+    Ok(w_long_new(w_long_get_value(a).or_(w_long_get_value(b))))
 }
 
 unsafe fn long_bitxor(a: PyObjectRef, b: PyObjectRef) -> PyResult {
@@ -1593,7 +1899,8 @@ unsafe fn long_bitxor(a: PyObjectRef, b: PyObjectRef) -> PyResult {
     if is_int(a) && is_long(b) {
         return Ok(w_long_new(w_long_get_value(b).int_xor(w_int_get_value(a))));
     }
-    Ok(w_long_new(bigint_xor(as_bigint(a), as_bigint(b))))
+    debug_assert!(is_long(a) && is_long(b));
+    Ok(w_long_new(w_long_get_value(a).xor(w_long_get_value(b))))
 }
 
 // ── String operations ────────────────────────────────────────────────
@@ -1617,14 +1924,14 @@ pub(crate) unsafe fn str_concat(a: PyObjectRef, b: PyObjectRef) -> PyResult {
 /// Extract a non-negative repeat count from an int or long.
 unsafe fn repeat_count(n: PyObjectRef) -> Result<usize, PyError> {
     if is_long(n) {
-        let big = as_bigint(n);
+        let big = w_long_get_value(n);
         // The count coerces to a signed machine word (an index-sized integer):
         // a non-negative value exceeding `isize::MAX` overflows rather than
         // wrapping to a huge `usize` count, matching `getindex_w`. Negative
         // counts clamp to 0.
         match big.to_isize() {
             Some(v) => Ok(if v < 0 { 0 } else { v as usize }),
-            None if bigint_lt(big, BigInt::from(0)) => Ok(0),
+            None if big.get_sign() < 0 => Ok(0),
             None => Err(PyError::new(
                 PyErrorKind::OverflowError,
                 "cannot fit 'int' into an index-sized integer",
@@ -2314,7 +2621,13 @@ unsafe fn complex_richcompare(a: PyObjectRef, b: PyObjectRef, op: CompareOp) -> 
         } else if is_int(other) || is_long(other) || is_bool(other) {
             real.is_finite()
                 && real.fract() == 0.0
-                && BigInt::from_f64(real).is_some_and(|value| value == as_bigint(other))
+                && BigInt::from_f64(real).is_some_and(|value| {
+                    if is_long(other) {
+                        value.eq(w_long_get_value(other))
+                    } else {
+                        value.int_eq(int_value(other))
+                    }
+                })
         } else {
             return Ok(w_not_implemented());
         }
@@ -3025,7 +3338,21 @@ pub fn truediv(a: PyObjectRef, b: PyObjectRef) -> PyResult {
                 return Err(PyError::zero_division("division by zero"));
             }
             if is_long(a) || is_long(b) {
-                let r = bigint_truediv(as_bigint(a), as_bigint(b))?;
+                let a_owned;
+                let va = if is_long(a) {
+                    w_long_get_value(a)
+                } else {
+                    a_owned = BigInt::from(int_value(a));
+                    &a_owned
+                };
+                let b_owned;
+                let vb = if is_long(b) {
+                    w_long_get_value(b)
+                } else {
+                    b_owned = BigInt::from(int_value(b));
+                    &b_owned
+                };
+                let r = bigint_truediv(va, vb)?;
                 return Ok(w_float_new(r));
             }
             return Ok(w_float_new(as_float(a) / as_float(b)));
@@ -3160,7 +3487,21 @@ pub(crate) fn truediv_builtin(a: PyObjectRef, b: PyObjectRef) -> PyResult {
                 return Err(PyError::zero_division("division by zero"));
             }
             if is_long(a) || is_long(b) {
-                let r = bigint_truediv(as_bigint(a), as_bigint(b))?;
+                let a_owned;
+                let va = if is_long(a) {
+                    w_long_get_value(a)
+                } else {
+                    a_owned = BigInt::from(int_value(a));
+                    &a_owned
+                };
+                let b_owned;
+                let vb = if is_long(b) {
+                    w_long_get_value(b)
+                } else {
+                    b_owned = BigInt::from(int_value(b));
+                    &b_owned
+                };
+                let r = bigint_truediv(va, vb)?;
                 return Ok(w_float_new(r));
             }
             return Ok(w_float_new(as_float(a) / as_float(b)));
@@ -3482,54 +3823,78 @@ pub(crate) fn try_int_long_pow_with_modulo(
         // machine ints, in which case `space.newint` demotes it.
         let all_int_like = is_int_like(base) && is_int_like(exp) && is_int_like(modulus);
 
-        let base = crate::builtins::obj_to_bigint(base);
-        let exp = crate::builtins::obj_to_bigint(exp);
-        let modulus = crate::builtins::obj_to_bigint(modulus);
+        let base_owned;
+        let base = if is_long(base) {
+            w_long_get_value(base)
+        } else {
+            base_owned = BigInt::from(int_value(base));
+            &base_owned
+        };
+        let exp_owned;
+        let exp = if is_long(exp) {
+            w_long_get_value(exp)
+        } else {
+            exp_owned = BigInt::from(int_value(exp));
+            &exp_owned
+        };
+        let modulus_owned;
+        let modulus = if is_long(modulus) {
+            w_long_get_value(modulus)
+        } else {
+            modulus_owned = BigInt::from(int_value(modulus));
+            &modulus_owned
+        };
 
-        if bigint_eq(modulus.clone(), BigInt::from(0)) {
+        if modulus.get_sign() == 0 {
             return Err(PyError::value_error("pow() 3rd argument cannot be 0"));
         }
-        if bigint_lt(exp.clone(), BigInt::from(0)) {
+        if exp.get_sign() < 0 {
             // 3-arg pow with a negative exponent: raise the modular
             // inverse of `base` to `-exp` (longobject.c long_pow →
             // long_invmod).  The inverse exists only when `base` is
             // coprime to the modulus.
-            let negative_modulus = bigint_lt(modulus.clone(), BigInt::from(0));
+            let negative_modulus = modulus.get_sign() < 0;
+            let abs_modulus_owned;
             let abs_modulus = if negative_modulus {
-                bigint_neg(modulus.clone())
+                abs_modulus_owned = modulus.neg();
+                &abs_modulus_owned
             } else {
-                modulus.clone()
+                modulus
             };
-            let inverse = bigint_mod_inverse(&base, &abs_modulus)?;
-            let pos_exp = bigint_neg(exp.clone());
+            let inverse = bigint_mod_inverse(base, abs_modulus)?;
+            let pos_exp = exp.neg();
             let mut result = inverse
-                .pow(&pos_exp, Some(&abs_modulus))
+                .pow(&pos_exp, Some(abs_modulus))
                 .map_err(|_| PyError::memory_error("exponent too large"))?;
-            if negative_modulus && bigint_gt(result.clone(), BigInt::from(0)) {
-                result = bigint_sub(result, abs_modulus);
+            if negative_modulus && result.get_sign() > 0 {
+                result = result.sub(abs_modulus);
             }
             return Ok(Some(pow_mod_result(result, all_int_like)));
         }
-        if bigint_eq(exp.clone(), BigInt::from(0)) {
+        if exp.get_sign() == 0 {
             // `x ** 0 % m` is `1 % m` under floor semantics, so a negative
             // modulus yields a negative residue (`pow(2, 0, -13) == -12`).
             return Ok(Some(pow_mod_result(
-                bigint_modulo_nonzero(BigInt::from(1), modulus),
+                BigInt::one()
+                    .r#mod(modulus)
+                    .expect("modulus was checked nonzero"),
                 all_int_like,
             )));
         }
 
-        let negative_modulus = bigint_lt(modulus.clone(), BigInt::from(0));
+        let negative_modulus = modulus.get_sign() < 0;
+        let abs_modulus_owned;
         let abs_modulus = if negative_modulus {
-            bigint_neg(modulus.clone())
+            abs_modulus_owned = modulus.neg();
+            &abs_modulus_owned
         } else {
-            modulus.clone()
+            modulus
         };
         let mut result = base
-            .pow(&exp, Some(&abs_modulus))
+            .pow(exp, Some(abs_modulus))
             .map_err(|_| PyError::memory_error("exponent too large"))?;
-        if negative_modulus && bigint_gt(result.clone(), BigInt::from(0)) {
-            result = bigint_sub(result, abs_modulus);
+        if negative_modulus && result.get_sign() > 0 {
+            result = result.sub(abs_modulus);
         }
         Ok(Some(pow_mod_result(result, all_int_like)))
     }
@@ -3649,7 +4014,8 @@ pub fn divmod(a: PyObjectRef, b: PyObjectRef) -> PyResult {
 /// a fractional power, which `descr_pow` promotes to a complex result.
 enum FloatPowError {
     Domain,
-    Py(PyError),
+    ZeroDivision,
+    Overflow,
 }
 
 /// Float scalar helper for the rtyper residual surface. Mirrors RPython's
@@ -3659,6 +4025,15 @@ enum FloatPowError {
 #[majit_macros::dont_look_inside]
 pub fn jit_float_abs(v: f64) -> f64 {
     v.abs()
+}
+
+/// `rpython.rlib.rfloat.rfloat` / `math.fmod` scalar residual.  PyPy's float
+/// modulo, divmod, and power code call `math_fmod` directly; Rust's `%`
+/// spelling would instead expose a `mod(SomeFloat, SomeFloat)` operation that
+/// RPython's annotator intentionally does not define.
+#[majit_macros::dont_look_inside]
+pub fn jit_float_fmod(x: f64, y: f64) -> f64 {
+    x % y
 }
 
 /// floatobject.py:865 `_pow`.
@@ -3693,7 +4068,7 @@ fn float_pow_inner(x: f64, y: f64) -> Result<f64, FloatPowError> {
     }
     // floatobject.py:828-842
     if x.is_infinite() {
-        let y_is_odd = jit_float_abs(y) % 2.0 == 1.0;
+        let y_is_odd = jit_float_fmod(jit_float_abs(y), 2.0) == 1.0;
         return Ok(if y > 0.0 {
             if y_is_odd { x } else { jit_float_abs(x) }
         } else if y_is_odd {
@@ -3704,9 +4079,7 @@ fn float_pow_inner(x: f64, y: f64) -> Result<f64, FloatPowError> {
     }
     // floatobject.py:844-847
     if x == 0.0 && y < 0.0 {
-        return Err(FloatPowError::Py(PyError::zero_division(
-            "zero to a negative power",
-        )));
+        return Err(FloatPowError::ZeroDivision);
     }
     // floatobject.py:849-862
     let mut negate_result = false;
@@ -3716,7 +4089,7 @@ fn float_pow_inner(x: f64, y: f64) -> Result<f64, FloatPowError> {
             return Err(FloatPowError::Domain);
         }
         bx = -bx;
-        negate_result = jit_float_abs(y) % 2.0 == 1.0;
+        negate_result = jit_float_fmod(jit_float_abs(y), 2.0) == 1.0;
     }
     // floatobject.py:864-869
     if bx == 1.0 {
@@ -3725,7 +4098,7 @@ fn float_pow_inner(x: f64, y: f64) -> Result<f64, FloatPowError> {
     // floatobject.py:871-877
     let z = bx.powf(y);
     if z.is_infinite() && !bx.is_infinite() {
-        return Err(FloatPowError::Py(PyError::overflow_error("float power")));
+        return Err(FloatPowError::Overflow);
     }
     // floatobject.py:879-881
     Ok(if negate_result { -z } else { z })
@@ -3735,12 +4108,14 @@ fn float_pow_inner(x: f64, y: f64) -> Result<f64, FloatPowError> {
 /// negative-base fractional case cannot arise with an integral exponent, but is
 /// mapped back to the ValueError that `_pow` raises via `PowDomainError`.
 pub fn float_pow_raw(x: f64, y: f64) -> Result<f64, PyError> {
-    float_pow_inner(x, y).map_err(|e| match e {
-        FloatPowError::Domain => {
-            PyError::value_error("negative number cannot be raised to a fractional power")
-        }
-        FloatPowError::Py(e) => e,
-    })
+    match float_pow_inner(x, y) {
+        Ok(z) => Ok(z),
+        Err(FloatPowError::Domain) => Err(PyError::value_error(
+            "negative number cannot be raised to a fractional power",
+        )),
+        Err(FloatPowError::ZeroDivision) => Err(PyError::zero_division("zero to a negative power")),
+        Err(FloatPowError::Overflow) => Err(PyError::overflow_error("float power")),
+    }
 }
 
 /// floatobject.py:584 `W_FloatObject.descr_pow`.
@@ -3751,7 +4126,8 @@ fn float_pow_impl(x: f64, y: f64) -> PyResult {
         Err(FloatPowError::Domain) => unsafe {
             complex_pow(w_complex_new(x, 0.0), w_complex_new(y, 0.0))
         },
-        Err(FloatPowError::Py(e)) => Err(e),
+        Err(FloatPowError::ZeroDivision) => Err(PyError::zero_division("zero to a negative power")),
+        Err(FloatPowError::Overflow) => Err(PyError::overflow_error("float power")),
     }
 }
 
@@ -4074,15 +4450,20 @@ pub fn compare_slot(a: PyObjectRef, b: PyObjectRef, op: CompareOp) -> PyResult {
             )));
         }
         if is_int_or_long(a) && is_int_or_long(b) {
-            let va = as_bigint(a);
-            let vb = as_bigint(b);
+            // All machine/mixed integer pairs returned above, so this is the
+            // longobject.py `_make_descr_cmp` long/long arm. `asbigint()`
+            // returns each W_LongObject's immutable payload upstream; borrow
+            // those payloads rather than allocating two translated clones.
+            debug_assert!(is_long(a) && is_long(b));
+            let va = w_long_get_value(a);
+            let vb = w_long_get_value(b);
             return Ok(w_bool_from(match op {
-                CompareOp::Lt => va < vb,
-                CompareOp::Le => va <= vb,
-                CompareOp::Gt => va > vb,
-                CompareOp::Ge => va >= vb,
-                CompareOp::Eq => va == vb,
-                CompareOp::Ne => va != vb,
+                CompareOp::Lt => va.lt(vb),
+                CompareOp::Le => va.le(vb),
+                CompareOp::Gt => va.gt(vb),
+                CompareOp::Ge => va.ge(vb),
+                CompareOp::Eq => va.eq(vb),
+                CompareOp::Ne => va.ne(vb),
             }));
         }
         if is_float_pair(a, b) {
@@ -4418,7 +4799,11 @@ pub fn pos(a: PyObjectRef) -> PyResult {
             return Ok(w_int_new(int_value(a)));
         }
         if is_long(a) {
-            return Ok(w_long_new(w_long_get_value(a).clone()));
+            // intobject.py:182-191 `_self_unaryop('pos')` delegates to
+            // `self.int(space)`, and W_LongObject.int returns `self` for the
+            // exact builtin representation.  Do not allocate another wrapper
+            // or shallow-cloned rbigint payload for unary plus.
+            return Ok(a);
         }
         if is_float(a) {
             return Ok(w_float_new(w_float_get_value(a)));
@@ -4453,11 +4838,15 @@ pub fn neg(a: PyObjectRef) -> PyResult {
             let v = int_value(a);
             return match v.checked_neg() {
                 Some(r) => Ok(w_int_new(r)),
-                None => Ok(w_long_new(bigint_neg(BigInt::from(v)))),
+                None => Ok(pyre_object::longobject::w_long_new_fresh_rbigint_handle(
+                    bigint_neg(&BigInt::from(v)),
+                )),
             };
         }
         if is_long(a) {
-            return Ok(w_long_new(bigint_neg(w_long_get_value(a).clone())));
+            return Ok(pyre_object::longobject::w_long_new_fresh_rbigint_handle(
+                bigint_neg(w_long_get_value(a)),
+            ));
         }
         if is_float(a) {
             return Ok(w_float_new(-w_float_get_value(a)));
@@ -4523,7 +4912,7 @@ pub fn invert(a: PyObjectRef) -> PyResult {
             return Ok(w_int_new(!int_value(a)));
         }
         if is_long(a) {
-            return Ok(w_long_new(bigint_invert(w_long_get_value(a).clone())));
+            return Ok(w_long_new(bigint_invert(w_long_get_value(a))));
         }
         if let Some(result) = try_instance_unaryop(a, "__invert__")? {
             return Ok(result);
@@ -4539,6 +4928,28 @@ pub fn invert(a: PyObjectRef) -> PyResult {
 mod tests {
     use super::*;
 
+    #[cfg(target_pointer_width = "64")]
+    fn decoded_bigint_result(value: pyre_object::longobject::JitBigIntResult) -> *mut BigInt {
+        value
+    }
+
+    #[cfg(target_pointer_width = "32")]
+    fn decoded_bigint_result(value: pyre_object::longobject::JitBigIntResult) -> *mut BigInt {
+        value as usize as *mut BigInt
+    }
+
+    /// Test projection for assertions that accept either compact or long
+    /// integer results. Production consumers borrow W_LongObject payloads.
+    unsafe fn as_bigint(obj: PyObjectRef) -> BigInt {
+        if is_bool(obj) {
+            BigInt::from(w_bool_get_value(obj) as i64)
+        } else if is_int(obj) {
+            BigInt::from(w_int_get_value(obj))
+        } else {
+            w_long_get_value(obj).clone()
+        }
+    }
+
     #[test]
     fn test_int_add() {
         let a = w_int_new(3);
@@ -4553,6 +4964,14 @@ mod tests {
         let b = w_int_new(10);
         let result = compare(a, b, CompareOp::Lt).unwrap();
         unsafe { assert!(w_bool_get_value(result)) };
+    }
+
+    #[test]
+    fn test_long_pos_preserves_exact_object_identity() {
+        let value = BigInt::from(1).lshift(80).unwrap();
+        let a = w_long_new(value);
+        let result = pos(a).unwrap();
+        assert_eq!(result, a);
     }
 
     #[test]
@@ -4762,17 +5181,76 @@ mod tests {
     }
 
     #[test]
+    fn test_rbigint_residuals_preserve_upstream_reference_fast_paths() {
+        let magnitude = BigInt::one().lshift(130).unwrap().int_add(17);
+        let larger = magnitude.lshift(70).unwrap();
+        let one = pyre_object::longobject::alloc_bigint_nursery(BigInt::one());
+        let zero = pyre_object::longobject::alloc_bigint_nursery(BigInt::zero());
+        let a = pyre_object::longobject::alloc_bigint_nursery(magnitude);
+        let b = pyre_object::longobject::alloc_bigint_nursery(larger);
+
+        assert_eq!(
+            decoded_bigint_result(jit_bigint_add(a as i64, zero as i64)),
+            a
+        );
+        assert_eq!(
+            decoded_bigint_result(jit_bigint_sub(a as i64, zero as i64)),
+            a
+        );
+        assert_eq!(decoded_bigint_result(jit_bigint_int_add(a as i64, 0)), a);
+        assert_eq!(decoded_bigint_result(jit_bigint_int_sub(a as i64, 0)), a);
+        assert_eq!(decoded_bigint_result(jit_bigint_int_mul(a as i64, 1)), a);
+        assert_eq!(
+            decoded_bigint_result(jit_bigint_int_div_floor(a as i64, 1)),
+            a
+        );
+        assert_eq!(
+            decoded_bigint_result(jit_bigint_pow_nomod(a as i64, one as i64)),
+            a
+        );
+        assert_eq!(
+            decoded_bigint_result(jit_bigint_int_pow_nomod(a as i64, 1)),
+            a
+        );
+        assert_eq!(
+            decoded_bigint_result(jit_bigint_lshift_count(a as i64, 0)),
+            a
+        );
+        assert_eq!(decoded_bigint_result(jit_bigint_shl(a as i64, 0)), a);
+        assert_eq!(decoded_bigint_result(jit_bigint_shr(a as i64, 0)), a);
+
+        // `_divrem` returns its literal input remainder when its early
+        // magnitude test succeeds. Floored modulo retains it for equal signs
+        // and a non-one-digit divisor.
+        assert_eq!(decoded_bigint_result(jit_bigint_rem(a as i64, b as i64)), a);
+        assert_eq!(
+            decoded_bigint_result(jit_bigint_mod_floor(a as i64, b as i64)),
+            a
+        );
+
+        // `lshift` returns even a non-canonical zero handle unchanged.
+        let fresh_zero = pyre_object::rbigint::alloc_rbigint_clone_nursery_collecting(unsafe {
+            (&*zero).clone()
+        });
+        assert_ne!(fresh_zero, zero);
+        assert_eq!(
+            decoded_bigint_result(jit_bigint_lshift_count(fresh_zero as i64, 37)),
+            fresh_zero
+        );
+    }
+
+    #[test]
     fn test_bigint_truediv_exponent() {
         // Regression: the exponent assembly carried a spurious `+ 1` that
         // doubled every quotient (equal operands gave 2.0, not 1.0).
         let big = BigInt::from(10u64).int_pow(40, None).unwrap();
-        assert_eq!(bigint_truediv(big.clone(), big.clone()).unwrap(), 1.0);
+        assert_eq!(bigint_truediv(&big, &big).unwrap(), 1.0);
         let a = BigInt::from(10u64).int_pow(60, None).unwrap();
         let b = BigInt::from(2) * BigInt::from(10u64).int_pow(59, None).unwrap();
-        assert_eq!(bigint_truediv(a.clone(), b.clone()).unwrap(), 5.0);
-        assert_eq!(bigint_truediv(-a.clone(), b.clone()).unwrap(), -5.0);
-        assert_eq!(bigint_truediv(a.clone(), -b.clone()).unwrap(), -5.0);
-        assert!(bigint_truediv(a, BigInt::from(0)).is_err());
+        assert_eq!(bigint_truediv(&a, &b).unwrap(), 5.0);
+        assert_eq!(bigint_truediv(&a.neg(), &b).unwrap(), -5.0);
+        assert_eq!(bigint_truediv(&a, &b.neg()).unwrap(), -5.0);
+        assert!(bigint_truediv(&a, &BigInt::from(0)).is_err());
     }
 
     #[test]
@@ -4787,17 +5265,14 @@ mod tests {
         let a_exact = (BigInt::from(2u64).int_pow(53, None).unwrap() + BigInt::from(1))
             * BigInt::from(4)
             * &b;
-        assert_eq!(bigint_truediv(a_exact.clone(), b.clone()).unwrap(), two55);
+        assert_eq!(bigint_truediv(&a_exact, &b).unwrap(), two55);
         // +1 makes the true quotient exceed the tie → sticky → round up to 2^55+8.
         assert_eq!(
-            bigint_truediv(&a_exact + BigInt::from(1), b.clone()).unwrap(),
+            bigint_truediv(&a_exact.int_add(1), &b).unwrap(),
             two55 + 8.0
         );
         // -1 drops it just below the tie → round down to 2^55.
-        assert_eq!(
-            bigint_truediv(&a_exact - BigInt::from(1), b.clone()).unwrap(),
-            two55
-        );
+        assert_eq!(bigint_truediv(&a_exact.int_sub(1), &b).unwrap(), two55);
     }
 
     #[test]
@@ -4808,22 +5283,22 @@ mod tests {
         let p = |e: u32| BigInt::from(2u64).int_pow(e as i64, None).unwrap();
         // 1 / 2^1030 == 2^-1030 (exact subnormal)
         assert_eq!(
-            bigint_truediv(BigInt::from(1), p(1030)).unwrap(),
+            bigint_truediv(&BigInt::from(1), &p(1030)).unwrap(),
             f64::from_bits(0x0000_1000_0000_0000)
         );
         // 7 / 2^1074 == 7 * 2^-1074 (seven smallest subnormals)
         assert_eq!(
-            bigint_truediv(BigInt::from(7), p(1074)).unwrap(),
+            bigint_truediv(&BigInt::from(7), &p(1074)).unwrap(),
             f64::from_bits(0x0000_0000_0000_0007)
         );
         // (2^53+1) / (2^1075+7) rounds across the subnormal/normal boundary to 2^-1022
         assert_eq!(
-            bigint_truediv(p(53) + BigInt::from(1), p(1075) + BigInt::from(7)).unwrap(),
+            bigint_truediv(&p(53).int_add(1), &p(1075).int_add(7)).unwrap(),
             f64::from_bits(0x0010_0000_0000_0000)
         );
         // sign preserved
         assert_eq!(
-            bigint_truediv(BigInt::from(-1), p(1030)).unwrap(),
+            bigint_truediv(&BigInt::from(-1), &p(1030)).unwrap(),
             -f64::from_bits(0x0000_1000_0000_0000)
         );
     }
@@ -4837,12 +5312,12 @@ mod tests {
         let b = w_long_new(y.clone());
         unsafe {
             let l = jit_w_long_lshift_raw(a as i64, two as i64) as *mut BigInt;
-            assert_eq!(*l, bigint_lshift(x.clone(), 2).unwrap());
+            assert_eq!(*l, bigint_lshift(&x, 2).unwrap());
             let r = jit_w_long_rshift_raw(a as i64, two as i64) as *mut BigInt;
-            assert_eq!(*r, bigint_rshift(x.clone(), 2));
+            assert_eq!(*r, bigint_rshift(&x, 2));
             // true-divide returns the f64 quotient directly (CallPureF).
             let f = jit_w_long_truediv_raw(a as i64, b as i64);
-            assert_eq!(f, bigint_truediv(x, y).unwrap());
+            assert_eq!(f, bigint_truediv(&x, &y).unwrap());
         }
     }
 
@@ -4853,6 +5328,98 @@ mod tests {
         unsafe {
             assert!(is_long(result));
             assert_eq!(*w_long_get_value(result), -BigInt::from(i64::MIN));
+        }
+    }
+
+    #[test]
+    fn test_long_neg_and_zero_count_shifts_preserve_rpython_payload_identity() {
+        unsafe {
+            // rbigint.neg always constructs a fresh handle, including zero.
+            let zero = w_long_new(BigInt::zero());
+            let negated = neg(zero).unwrap();
+            assert_ne!(negated, zero);
+            assert_ne!(w_long_get_raw_value(negated), w_long_get_raw_value(zero));
+            assert!(w_long_get_value(negated).is_zero());
+
+            let magnitude = BigInt::one().lshift(130).unwrap().int_add(17);
+            let value = w_long_new(magnitude);
+            let count_zero = w_int_new(0);
+
+            // rbigint returns `self`; newlong creates a fresh W_LongObject
+            // around that exact translated payload.
+            let shifted_left = long_lshift(value, count_zero).unwrap();
+            assert_ne!(shifted_left, value);
+            assert_eq!(
+                w_long_get_raw_value(shifted_left),
+                w_long_get_raw_value(value)
+            );
+            let shifted_right = long_rshift(value, count_zero).unwrap();
+            assert_ne!(shifted_right, value);
+            assert_eq!(
+                w_long_get_raw_value(shifted_right),
+                w_long_get_raw_value(value)
+            );
+
+            let zero_shifted = long_lshift(zero, w_int_new(5)).unwrap();
+            assert_ne!(zero_shifted, zero);
+            assert_eq!(
+                w_long_get_raw_value(zero_shifted),
+                w_long_get_raw_value(zero)
+            );
+
+            // Overflowing count is the W_LongObject-level early return.
+            let huge_count = w_long_new(BigInt::one().lshift(100).unwrap());
+            assert_eq!(long_lshift(zero, huge_count).unwrap(), zero);
+        }
+    }
+
+    #[test]
+    fn test_long_arithmetic_rewraps_rbigint_operand_fast_paths() {
+        unsafe {
+            let magnitude = BigInt::one().lshift(130).unwrap().int_add(17);
+            let value = w_long_new(magnitude.translated_alias());
+            let zero = w_long_new(BigInt::zero());
+            let payload = w_long_get_raw_value(value);
+
+            for result in [
+                long_add(value, w_int_new(0)).unwrap(),
+                long_add(w_int_new(0), value).unwrap(),
+                long_add(value, zero).unwrap(),
+                long_add(zero, value).unwrap(),
+                long_sub(value, w_int_new(0)).unwrap(),
+                long_sub(value, zero).unwrap(),
+                long_mul(value, w_int_new(1)).unwrap(),
+                long_mul(w_bool_from(true), value).unwrap(),
+                long_floordiv(value, w_int_new(1)).unwrap(),
+                long_floordiv(value, w_long_new(BigInt::one())).unwrap(),
+                long_pow(value, w_int_new(1)).unwrap(),
+            ] {
+                assert_ne!(result, value);
+                assert_eq!(w_long_get_raw_value(result), payload);
+            }
+
+            // These upstream methods check zero before their alias shortcut
+            // and return canonical NULLRBIGINT, not a fresh zero operand.
+            let fresh_zero = neg(zero).unwrap();
+            assert_ne!(w_long_get_raw_value(fresh_zero), w_long_get_raw_value(zero));
+            for result in [
+                long_add(fresh_zero, w_int_new(0)).unwrap(),
+                long_mul(fresh_zero, w_int_new(1)).unwrap(),
+                long_pow(fresh_zero, w_int_new(1)).unwrap(),
+            ] {
+                assert_eq!(w_long_get_raw_value(result), w_long_get_raw_value(zero));
+            }
+
+            let larger = w_long_new(magnitude.lshift(70).unwrap());
+            let remainder = long_mod(value, larger).unwrap();
+            assert_eq!(w_long_get_raw_value(remainder), payload);
+            let pair = integer_divmod_pair(value, larger).unwrap();
+            let pair_remainder = w_tuple_getitem(pair, 1).expect("remainder");
+            assert_eq!(w_long_get_raw_value(pair_remainder), payload);
+
+            let pair = integer_divmod_pair(value, w_int_new(1)).unwrap();
+            let pair_quotient = w_tuple_getitem(pair, 0).expect("quotient");
+            assert_eq!(w_long_get_raw_value(pair_quotient), payload);
         }
     }
 
@@ -4871,6 +5438,32 @@ mod tests {
         let b = w_int_new(i64::MAX);
         let result = compare(a, b, CompareOp::Gt).unwrap();
         unsafe { assert!(w_bool_get_value(result)) };
+
+        let magnitude = BigInt::one().lshift(190).unwrap();
+        let a = w_long_new(magnitude.int_add(1));
+        let b = w_long_new(magnitude.int_add(2));
+        for (op, expected) in [
+            (CompareOp::Lt, true),
+            (CompareOp::Le, true),
+            (CompareOp::Gt, false),
+            (CompareOp::Ge, false),
+            (CompareOp::Eq, false),
+            (CompareOp::Ne, true),
+        ] {
+            let result = compare(a, b, op).unwrap();
+            assert_eq!(unsafe { w_bool_get_value(result) }, expected);
+        }
+    }
+
+    #[test]
+    fn test_complex_long_comparison_is_exact() {
+        let magnitude = BigInt::one().lshift(100).unwrap();
+        let complex = w_complex_new(2_f64.powi(100), 0.0);
+        let equal = compare(complex, w_long_new(magnitude.clone()), CompareOp::Eq).unwrap();
+        assert!(unsafe { w_bool_get_value(equal) });
+
+        let unequal = compare(complex, w_long_new(magnitude.int_add(1)), CompareOp::Eq).unwrap();
+        assert!(!unsafe { w_bool_get_value(unequal) });
     }
 
     #[test]
@@ -4988,6 +5581,19 @@ mod tests {
     }
 
     #[test]
+    fn test_long_pow_negative_exponent_rejects_float_overflow() {
+        let huge = BigInt::one().lshift(2000).unwrap();
+        let error = pow(w_long_new(huge), w_int_new(-1)).unwrap_err();
+        assert_eq!(error.kind, PyErrorKind::OverflowError);
+        assert_eq!(error.message, "int too large to convert to float");
+
+        let huge_negative_exponent = BigInt::one().lshift(2000).unwrap().neg();
+        let error = pow(w_int_new(1), w_long_new(huge_negative_exponent)).unwrap_err();
+        assert_eq!(error.kind, PyErrorKind::OverflowError);
+        assert_eq!(error.message, "int too large to convert to float");
+    }
+
+    #[test]
     fn test_int_lshift() {
         let result = lshift(w_int_new(1), w_int_new(10)).unwrap();
         unsafe { assert_eq!(w_int_get_value(result), 1024) };
@@ -5018,9 +5624,54 @@ mod tests {
     }
 
     #[test]
+    fn test_long_shift_mixed_operands_and_large_counts() {
+        unsafe {
+            let base = BigInt::one().lshift(70).unwrap();
+            let shifted = lshift(w_long_new(base.clone()), w_long_new(BigInt::from(5))).unwrap();
+            assert!(is_long(shifted));
+            assert_eq!(*w_long_get_value(shifted), base.lshift(5).unwrap());
+
+            let mixed = lshift(w_int_new(3), w_long_new(BigInt::from(65))).unwrap();
+            assert!(is_long(mixed));
+            assert_eq!(
+                *w_long_get_value(mixed),
+                BigInt::from(3).lshift(65).unwrap()
+            );
+
+            let negative = BigInt::from(-3).lshift(70).unwrap();
+            let right = rshift(w_long_new(negative.clone()), w_int_new(69)).unwrap();
+            assert!(is_long(right));
+            assert_eq!(
+                *w_long_get_value(right),
+                negative.rshift(69, false).unwrap()
+            );
+
+            let enormous_count = BigInt::one().lshift(70).unwrap();
+            let saturated =
+                rshift(w_long_new(negative), w_long_new(enormous_count.clone())).unwrap();
+            assert_eq!(w_int_get_value(saturated), -1);
+            let zero = lshift(w_long_new(BigInt::zero()), w_long_new(enormous_count)).unwrap();
+            assert!(is_long(zero));
+            assert_eq!(w_long_get_value(zero).get_sign(), 0);
+        }
+    }
+
+    #[test]
     fn test_negative_shift_count() {
         assert!(lshift(w_int_new(1), w_int_new(-1)).is_err());
         assert!(rshift(w_int_new(1), w_int_new(-1)).is_err());
+        assert!(lshift(w_long_new(BigInt::from(1)), w_long_new(BigInt::from(-1))).is_err());
+        assert!(rshift(w_long_new(BigInt::from(1)), w_long_new(BigInt::from(-1))).is_err());
+    }
+
+    #[test]
+    fn test_long_repeat_count_bounds() {
+        unsafe {
+            let huge = BigInt::one().lshift(100).unwrap();
+            assert_eq!(repeat_count(w_long_new(huge.neg())).unwrap(), 0);
+            let error = repeat_count(w_long_new(huge)).unwrap_err();
+            assert_eq!(error.kind, PyErrorKind::OverflowError);
+        }
     }
 
     #[test]

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -165,7 +165,12 @@ fn divrem_returns_input_as_remainder(a: &BigInt, b: &BigInt) -> bool {
 /// callers.
 #[majit_macros::dont_look_inside]
 fn bigint_pow_nomod(a: &BigInt, b: &BigInt) -> Result<BigInt, PyError> {
-    a.pow(b, None)
+    // `rbigint.pow` performs several collecting digit-array allocations while
+    // both operands remain live. RPython's GC transform roots those incoming
+    // handles for the whole call.
+    let a = RBigIntGcRoot::new(a.translated_alias());
+    let b = RBigIntGcRoot::new(b.translated_alias());
+    a.pow(&b, None)
         .map_err(|_| PyError::memory_error("exponent too large"))
 }
 
@@ -174,6 +179,8 @@ fn bigint_pow_nomod(a: &BigInt, b: &BigInt) -> Result<BigInt, PyError> {
 /// (`longobject.py:230`); only a long exponent reaches `rbigint.pow`.
 #[majit_macros::dont_look_inside]
 fn bigint_int_pow_nomod(a: &BigInt, b: i64) -> Result<BigInt, PyError> {
+    // `int_pow` also keeps the base live across its intermediate allocations.
+    let a = RBigIntGcRoot::new(a.translated_alias());
     a.int_pow(b, None)
         .map_err(|_| PyError::memory_error("exponent too large"))
 }
@@ -550,7 +557,12 @@ pub extern "C" fn jit_bigint_pow_nomod(a: i64, b: i64) -> pyre_object::longobjec
     if unsafe { (&*a).get_sign() != 0 && (&*b).int_eq(1) } {
         return pyre_object::longobject::encode_jit_bigint_result(a as *mut BigInt);
     }
-    match unsafe { (&*a).pow(&*b, None) } {
+    // The residual call can collect inside `rbigint.pow`; mirror the roots
+    // inserted for both arguments by RPython's GC transform instead of
+    // depending on a backend-specific native call map.
+    let a = RBigIntGcRoot::new(unsafe { (&*a).translated_alias() });
+    let b = RBigIntGcRoot::new(unsafe { (&*b).translated_alias() });
+    match a.pow(&b, None) {
         Ok(value) => pyre_object::longobject::encode_jit_bigint_result(
             pyre_object::longobject::alloc_bigint_nursery_collecting(value),
         ),
@@ -575,7 +587,9 @@ pub extern "C" fn jit_bigint_int_pow_nomod(
     if b == 1 && unsafe { (&*a).get_sign() != 0 } {
         return pyre_object::longobject::encode_jit_bigint_result(a as *mut BigInt);
     }
-    match unsafe { (&*a).int_pow(b, None) } {
+    // `int_pow` retains the base across intermediate collecting allocations.
+    let a = RBigIntGcRoot::new(unsafe { (&*a).translated_alias() });
+    match a.int_pow(b, None) {
         Ok(value) => pyre_object::longobject::encode_jit_bigint_result(
             pyre_object::longobject::alloc_bigint_nursery_collecting(value),
         ),
@@ -660,13 +674,11 @@ pub extern "C" fn jit_bigint_divrem_returns_lhs_remainder(a: i64, b: i64) -> i64
     unsafe {
         let a = &*a;
         let b = &*b;
-        let a_size = a.numdigits();
         let b_size = b.numdigits();
         (a.get_sign() != 0
             && a.get_sign() == b.get_sign()
             && b_size != 1
-            && (a_size < b_size || (a_size == b_size && a.digit(a_size - 1) < b.digit(b_size - 1))))
-            as i64
+            && divrem_returns_input_as_remainder(a, b)) as i64
     }
 }
 
@@ -1928,10 +1940,9 @@ unsafe fn repeat_count(n: PyObjectRef) -> Result<usize, PyError> {
         // The count coerces to a signed machine word (an index-sized integer):
         // a non-negative value exceeding `isize::MAX` overflows rather than
         // wrapping to a huge `usize` count, matching `getindex_w`. Negative
-        // counts clamp to 0.
+        // counts clamp to 0 only after they fit the index-sized word.
         match big.to_isize() {
             Some(v) => Ok(if v < 0 { 0 } else { v as usize }),
-            None if big.get_sign() < 0 => Ok(0),
             None => Err(PyError::new(
                 PyErrorKind::OverflowError,
                 "cannot fit 'int' into an index-sized integer",
@@ -5668,7 +5679,8 @@ mod tests {
     fn test_long_repeat_count_bounds() {
         unsafe {
             let huge = BigInt::one().lshift(100).unwrap();
-            assert_eq!(repeat_count(w_long_new(huge.neg())).unwrap(), 0);
+            let negative_error = repeat_count(w_long_new(huge.neg())).unwrap_err();
+            assert_eq!(negative_error.kind, PyErrorKind::OverflowError);
             let error = repeat_count(w_long_new(huge)).unwrap_err();
             assert_eq!(error.kind, PyErrorKind::OverflowError);
         }

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -3615,6 +3615,11 @@ pub fn pow3(base: PyObjectRef, exp: PyObjectRef, modulus: PyObjectRef) -> PyResu
 /// standard NotImplemented fallback.
 pub fn divmod(a: PyObjectRef, b: PyObjectRef) -> PyResult {
     unsafe {
+        if needs_numeric_binop_dispatch(a, b, "__divmod__", "__rdivmod__") {
+            if let Some(result) = try_dispatch_binary_special(a, b, "__divmod__", "__rdivmod__")? {
+                return Ok(result);
+            }
+        }
         let lhs_num = is_int(a) || is_long(a) || is_float(a);
         let rhs_num = is_int(b) || is_long(b) || is_float(b);
         if lhs_num && rhs_num {

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -108,6 +108,25 @@ fn bigint_modulo_nonzero(a: BigInt, b: BigInt) -> BigInt {
     a.divmod(&b).expect("divisor was checked nonzero").1
 }
 
+/// Machine-int-divisor form of [`bigint_floordiv_nonzero`]
+/// (`longobject.py:418 _int_floordiv` → `rbigint.int_floordiv`). The dedicated
+/// leg divides by a single digit instead of first materializing an rbigint for
+/// the `W_IntObject`.
+#[majit_macros::jit_elidable]
+fn bigint_int_floordiv_nonzero(a: BigInt, b: i64) -> BigInt {
+    a.int_floordiv(b).expect("divisor was checked nonzero")
+}
+
+/// Machine-int-divisor form of [`bigint_modulo_nonzero`]
+/// (`longobject.py:435 _int_mod` → `rbigint.int_mod_int_result`). The remainder
+/// of a long by a machine int always fits a machine int, so the descriptor
+/// returns `space.newint` and this leg allocates no result bigint.
+#[majit_macros::jit_elidable]
+fn bigint_int_modulo_int_result_nonzero(a: BigInt, b: i64) -> i64 {
+    a.int_mod_int_result(b)
+        .expect("divisor was checked nonzero")
+}
+
 #[majit_macros::elidable]
 fn bigint_and(a: BigInt, b: BigInt) -> BigInt {
     a & b
@@ -146,6 +165,15 @@ fn bigint_rshift(a: BigInt, shift: usize) -> BigInt {
 #[majit_macros::dont_look_inside]
 fn bigint_pow_nomod(a: &BigInt, b: &BigInt) -> Result<BigInt, PyError> {
     a.pow(b, None)
+        .map_err(|_| PyError::memory_error("exponent too large"))
+}
+
+/// Machine-int-exponent form of [`bigint_pow_nomod`]. `descr_pow` keeps a
+/// `W_IntObject` exponent unwrapped and calls `rbigint.int_pow`
+/// (`longobject.py:230`); only a long exponent reaches `rbigint.pow`.
+#[majit_macros::dont_look_inside]
+fn bigint_int_pow_nomod(a: &BigInt, b: i64) -> Result<BigInt, PyError> {
+    a.int_pow(b, None)
         .map_err(|_| PyError::memory_error("exponent too large"))
 }
 
@@ -254,6 +282,33 @@ pub extern "C" fn jit_bigint_div_floor(a: i64, b: i64) -> pyre_object::longobjec
             ),
         )
     }
+}
+
+/// Machine-int-divisor quotient (`longobject.py:418 _int_floordiv` →
+/// `rbigint.int_floordiv`). `b` is a bare machine word, not a payload pointer.
+#[majit_macros::elidable_or_memerror]
+pub extern "C" fn jit_bigint_int_div_floor(
+    a: i64,
+    b: i64,
+) -> pyre_object::longobject::JitBigIntResult {
+    let a = a as *const BigInt;
+    unsafe {
+        pyre_object::longobject::encode_jit_bigint_result(
+            pyre_object::longobject::alloc_bigint_nursery_collecting(
+                (&*a).int_floordiv(b).expect("division by zero"),
+            ),
+        )
+    }
+}
+
+/// Machine-int-divisor remainder (`longobject.py:435 _int_mod` →
+/// `rbigint.int_mod_int_result`). The remainder of a long by a machine int
+/// always fits a machine int, so this residual returns the value itself and
+/// allocates nothing.
+#[majit_macros::elidable]
+pub extern "C" fn jit_bigint_int_mod_int_result(a: i64, b: i64) -> i64 {
+    let a = a as *const BigInt;
+    unsafe { (&*a).int_mod_int_result(b).expect("division by zero") }
 }
 
 /// `rbigint.divmod`'s floored modulus projection.
@@ -410,6 +465,27 @@ bigint_int_comparison_residual!(jit_bigint_int_ge, int_ge);
 pub extern "C" fn jit_bigint_pow_nomod(a: i64, b: i64) -> pyre_object::longobject::JitBigIntResult {
     let (a, b) = (a as *const BigInt, b as *const BigInt);
     match unsafe { (&*a).pow(&*b, None) } {
+        Ok(value) => pyre_object::longobject::encode_jit_bigint_result(
+            pyre_object::longobject::alloc_bigint_nursery_collecting(value),
+        ),
+        Err(_) => {
+            crate::runtime_ops::jit_publish_exception(
+                pyre_object::interp_exceptions::memory_error_singleton(),
+            );
+            pyre_object::longobject::encode_jit_bigint_result(std::ptr::null_mut())
+        }
+    }
+}
+
+/// Machine-int-exponent form of [`jit_bigint_pow_nomod`]
+/// (`longobject.py:230` → `rbigint.int_pow`). `b` is a bare machine word.
+#[majit_macros::elidable_or_memerror]
+pub extern "C" fn jit_bigint_int_pow_nomod(
+    a: i64,
+    b: i64,
+) -> pyre_object::longobject::JitBigIntResult {
+    let a = a as *const BigInt;
+    match unsafe { (&*a).int_pow(b, None) } {
         Ok(value) => pyre_object::longobject::encode_jit_bigint_result(
             pyre_object::longobject::alloc_bigint_nursery_collecting(value),
         ),
@@ -777,11 +853,20 @@ unsafe fn long_mul(a: PyObjectRef, b: PyObjectRef) -> PyResult {
 }
 
 unsafe fn long_floordiv(a: PyObjectRef, b: PyObjectRef) -> PyResult {
+    // longobject.py:424 `_make_descr_binop(_floordiv, _int_floordiv)`: a
+    // machine-int divisor takes the dedicated `rbigint.int_floordiv` leg.
+    // 3.x reports "integer division or modulo by zero" for every int; the
+    // int path raises the same. PyPy's `_floordiv` still carries the 2.x
+    // "long ..." wording (longobject.py:409), which a 3.x runtime does not.
+    if is_int_like(b) {
+        let vb = int_value(b);
+        if vb == 0 {
+            return Err(PyError::zero_division("integer division or modulo by zero"));
+        }
+        return Ok(w_long_new(bigint_int_floordiv_nonzero(as_bigint(a), vb)));
+    }
     let vb = as_bigint(b);
     if bigint_eq(vb.clone(), BigInt::from(0)) {
-        // 3.x reports "integer division or modulo by zero" for every int; the
-        // int path raises the same. PyPy's `_floordiv` still carries the 2.x
-        // "long ..." wording (longobject.py:409), which a 3.x runtime does not.
         return Err(PyError::zero_division("integer division or modulo by zero"));
     }
     // rbigint.floordiv → _divmod, returning the quotient half (rbigint.py:1001).
@@ -790,22 +875,28 @@ unsafe fn long_floordiv(a: PyObjectRef, b: PyObjectRef) -> PyResult {
 }
 
 unsafe fn long_mod(a: PyObjectRef, b: PyObjectRef) -> PyResult {
+    // longobject.py:441 `_make_descr_binop(_mod, _int_mod)`. `_int_mod`
+    // (machine-int RHS) computes through `rbigint.int_mod_int_result` and
+    // returns `space.newint` — the remainder of a long by a machine int always
+    // fits — while `_mod` (long RHS) returns `newlong`.
+    // `%` alone reports "integer modulo by zero" (not the floordiv/divmod
+    // "division or modulo" wording).
+    if is_int_like(b) {
+        let vb = int_value(b);
+        if vb == 0 {
+            return Err(PyError::zero_division("integer modulo by zero"));
+        }
+        return Ok(w_int_new(bigint_int_modulo_int_result_nonzero(
+            as_bigint(a),
+            vb,
+        )));
+    }
     let vb = as_bigint(b);
     if bigint_eq(vb.clone(), BigInt::from(0)) {
-        // `%` alone reports "integer modulo by zero" (not the floordiv/divmod
-        // "division or modulo" wording).
         return Err(PyError::zero_division("integer modulo by zero"));
     }
     // rbigint.mod → _divmod, returning the remainder half (rbigint.py:1001).
-    // `_int_mod` (machine-int RHS) returns `space.newint` — the remainder of a
-    // long by a machine int always fits — while `_mod` (long RHS) returns
-    // `newlong`. `a` is a long here, so the RHS kind decides.
-    let r = bigint_modulo_nonzero(as_bigint(a), vb);
-    if is_int_like(b) {
-        Ok(w_int_new(jit_bigint_to_i64_value(&r)))
-    } else {
-        Ok(w_long_new(r))
-    }
+    Ok(w_long_new(bigint_modulo_nonzero(as_bigint(a), vb)))
 }
 
 /// PyPy longobject.py `_divmod` / `_int_divmod`: compute both halves with one
@@ -1302,6 +1393,12 @@ unsafe fn long_pow(a: PyObjectRef, b: PyObjectRef) -> PyResult {
     if va == BigInt::from(-1) {
         let even = vb.clone() % BigInt::from(2) == BigInt::from(0);
         return Ok(w_long_new(BigInt::from(if even { 1 } else { -1 })));
+    }
+    // longobject.py:229-231: `descr_pow` keeps a `W_IntObject` exponent
+    // unwrapped (`exp_bigint` stays None) and calls `rbigint.int_pow`; only a
+    // long exponent reaches `rbigint.pow`.
+    if is_int_like(b) {
+        return Ok(w_long_new(bigint_int_pow_nomod(&va, int_value(b))?));
     }
     Ok(w_long_new(bigint_pow_nomod(&va, &vb)?))
 }

--- a/pyre/pyre-interpreter/src/objspace/std/formatting.rs
+++ b/pyre/pyre-interpreter/src/objspace/std/formatting.rs
@@ -253,8 +253,12 @@ fn cformat_rbigint(spec: &CFormatSpec, num: &BigInt) -> Result<String, PyError> 
         _ => unreachable!("validated radix formatting returned an unrelated error"),
     })?;
     if negative {
-        debug_assert!(magnitude.starts_with('-'));
-        magnitude.remove(0);
+        let Some(unsigned) = magnitude.strip_prefix('-') else {
+            return Err(PyError::system_error(
+                "rbigint formatting omitted the negative sign",
+            ));
+        };
+        magnitude = unsigned.to_owned();
     }
     if upper {
         magnitude.make_ascii_uppercase();

--- a/pyre/pyre-interpreter/src/objspace/std/formatting.rs
+++ b/pyre/pyre-interpreter/src/objspace/std/formatting.rs
@@ -207,7 +207,7 @@ unsafe fn bytes_format_is_mapping(obj: PyObjectRef) -> bool {
 }
 
 /// `CFormatSpec::format_number` over RPython rbigint.
-fn cformat_rbigint(spec: &CFormatSpec, num: &BigInt) -> String {
+fn cformat_rbigint(spec: &CFormatSpec, num: &BigInt) -> Result<String, PyError> {
     let CFormatType::Number(number_type) = spec.format_type else {
         unreachable!()
     };
@@ -241,7 +241,21 @@ fn cformat_rbigint(spec: &CFormatSpec, num: &BigInt) -> String {
             },
         ),
     };
-    let mut magnitude = num.abs().to_str_radix(radix);
+    let digits = match radix {
+        8 => pyre_object::rbigint::BASE8,
+        10 => pyre_object::rbigint::BASE10,
+        16 => pyre_object::rbigint::BASE16,
+        _ => unreachable!("percent integer formats use radix 8, 10, or 16"),
+    };
+    let negative = num.int_lt(0);
+    let mut magnitude = num.format(digits, "", "", 0).map_err(|error| match error {
+        pyre_object::rbigint::RBigIntError::Memory => PyError::memory_error(""),
+        _ => unreachable!("validated radix formatting returned an unrelated error"),
+    })?;
+    if negative {
+        debug_assert!(magnitude.starts_with('-'));
+        magnitude.remove(0);
+    }
     if upper {
         magnitude.make_ascii_uppercase();
     }
@@ -250,7 +264,7 @@ fn cformat_rbigint(spec: &CFormatSpec, num: &BigInt) -> String {
     {
         magnitude = format!("{}{magnitude}", "0".repeat(precision - magnitude.len()));
     }
-    let sign = if num.int_lt(0) {
+    let sign = if negative {
         "-"
     } else {
         spec.flags.sign_string()
@@ -268,23 +282,23 @@ fn cformat_rbigint(spec: &CFormatSpec, num: &BigInt) -> String {
         };
         let needed = width.saturating_sub(signed_prefix.len() + magnitude.len());
         if spec.flags.contains(CConversionFlags::LEFT_ADJUST) {
-            format!(
+            Ok(format!(
                 "{signed_prefix}{magnitude}{}",
                 fill.to_string().repeat(needed)
-            )
+            ))
         } else {
-            format!(
+            Ok(format!(
                 "{signed_prefix}{}{magnitude}",
                 fill.to_string().repeat(needed)
-            )
+            ))
         }
     } else {
         let body = format!("{signed_prefix}{magnitude}");
         let needed = width.saturating_sub(body.len());
         if spec.flags.contains(CConversionFlags::LEFT_ADJUST) {
-            format!("{body}{}", " ".repeat(needed))
+            Ok(format!("{body}{}", " ".repeat(needed)))
         } else {
-            format!("{}{body}", " ".repeat(needed))
+            Ok(format!("{}{body}", " ".repeat(needed)))
         }
     }
 }
@@ -322,7 +336,7 @@ unsafe fn spec_format_bytes(spec: &CFormatSpec, obj: PyObjectRef) -> Result<Vec<
                 }
                 _ => number_arg_integer(spec, obj)?,
             };
-            Ok(cformat_rbigint(spec, &value).into_bytes())
+            Ok(cformat_rbigint(spec, &value)?.into_bytes())
         }
         CFormatType::Float(_) => {
             let value = crate::baseobjspace::float_w(obj).map_err(|e| {
@@ -370,9 +384,10 @@ unsafe fn bytes_char_arg(obj: PyObjectRef) -> Result<u8, PyError> {
         )));
     };
     let overflow = || PyError::new(PyErrorKind::OverflowError, "%c arg not in range(256)");
-    let Some(n) = value.to_i64() else {
+    if pyre_object::jit_bigint_to_i64_fits(&value) == 0 {
         return Err(overflow());
-    };
+    }
+    let n = pyre_object::jit_bigint_to_i64_value(&value);
     if !(0..=255).contains(&n) {
         return Err(overflow());
     }
@@ -421,7 +436,7 @@ unsafe fn spec_format_string(
                 }
                 _ => number_arg_integer(spec, obj)?,
             };
-            Ok(Wtf8Buf::from_string(cformat_rbigint(spec, &value)))
+            Ok(Wtf8Buf::from_string(cformat_rbigint(spec, &value)?))
         }
         CFormatType::Float(_) => {
             let value = crate::baseobjspace::float_w(obj)?;
@@ -438,7 +453,8 @@ unsafe fn arg_to_bigint(obj: PyObjectRef) -> BigInt {
     } else if is_int(obj) {
         BigInt::from(w_int_get_value(obj))
     } else {
-        w_long_get_value(obj).clone()
+        // bigint_w returns the immutable payload reference, not a copy.
+        w_long_get_value(obj).translated_alias()
     }
 }
 
@@ -606,14 +622,26 @@ unsafe fn star_int(arg: Option<PyObjectRef>, field: StarField) -> Result<i64, Py
         return Err(PyError::type_error("* wants int"));
     }
     let big = crate::builtins::obj_to_bigint(arg);
-    use num_traits::ToPrimitive;
     match field {
-        StarField::Width => big
-            .to_i64()
-            .ok_or_else(|| PyError::overflow_error("Python int too large to convert to C ssize_t")),
-        StarField::Precision => big
-            .to_i32()
-            .map(|v| v as i64)
-            .ok_or_else(|| PyError::overflow_error("Python int too large to convert to C int")),
+        StarField::Width => {
+            if pyre_object::jit_bigint_to_i64_fits(&big) != 0 {
+                Ok(pyre_object::jit_bigint_to_i64_value(&big))
+            } else {
+                Err(PyError::overflow_error(
+                    "Python int too large to convert to C ssize_t",
+                ))
+            }
+        }
+        StarField::Precision => {
+            if pyre_object::jit_bigint_to_i64_fits(&big) != 0 {
+                let value = pyre_object::jit_bigint_to_i64_value(&big);
+                if i32::try_from(value).is_ok() {
+                    return Ok(value);
+                }
+            }
+            Err(PyError::overflow_error(
+                "Python int too large to convert to C int",
+            ))
+        }
     }
 }

--- a/pyre/pyre-interpreter/src/pycode.rs
+++ b/pyre/pyre-interpreter/src/pycode.rs
@@ -227,7 +227,7 @@ pub struct PyCode {
     /// Owned via `Box::into_raw`, sized to `code.constants.len()` at construction,
     /// never resized; a `null` slot is unrealized.  The whole pointer is `null`
     /// when `code_ptr` is null or unaligned (test fixtures, gateway builtins).
-    pub co_consts_w: *mut Vec<PyObjectRef>,
+    pub co_consts_w: *mut Vec<std::sync::atomic::AtomicPtr<PyObject>>,
 }
 
 /// Field offset of `code_ptr` within `PyCode`.
@@ -372,8 +372,10 @@ pub fn w_code_new_with_hidden_applevel(code_ptr: *const (), hidden_applevel: boo
     } else {
         let code_ref = unsafe { &*(code_ptr as *const crate::CodeObject) };
         let consts_len = code_ref.constants.len();
-        let mut v: Vec<PyObjectRef> = Vec::with_capacity(consts_len);
-        v.resize(consts_len, std::ptr::null_mut());
+        let mut v: Vec<std::sync::atomic::AtomicPtr<PyObject>> = Vec::with_capacity(consts_len);
+        v.resize_with(consts_len, || {
+            std::sync::atomic::AtomicPtr::new(std::ptr::null_mut())
+        });
         Box::into_raw(Box::new(v))
     };
     let npure_cellvars = if !code_ptr_aligned {
@@ -454,15 +456,15 @@ fn box_code_constant_with_firstlineno(code: &crate::CodeObject, firstlineno: i32
 /// `ConstantData` for bytecode decoding, but that representation must not
 /// replace the interpreter-level owner.
 unsafe fn w_code_fill_consts_from_tuple(obj: PyObjectRef, constants: PyObjectRef) {
-    let code = unsafe { &mut *(obj as *mut PyCode) };
+    let code = unsafe { &*(obj as *const PyCode) };
     if code.co_consts_w.is_null() {
         return;
     }
-    let slots = unsafe { &mut *code.co_consts_w };
+    let slots = unsafe { &*code.co_consts_w };
     let count = slots.len().min(pyre_object::w_tuple_len(constants));
-    for (index, slot) in slots.iter_mut().take(count).enumerate() {
+    for (index, slot) in slots.iter().take(count).enumerate() {
         if let Some(value) = unsafe { pyre_object::w_tuple_getitem(constants, index as i64) } {
-            *slot = value;
+            slot.store(value, std::sync::atomic::Ordering::Release);
         }
     }
     pyre_object::gc_roots::mark_prebuilt_roots_dirty();
@@ -471,15 +473,15 @@ unsafe fn w_code_fill_consts_from_tuple(obj: PyObjectRef, constants: PyObjectRef
 /// Preserve the existing wrapped constant array when `code.replace()` changes
 /// fields other than `co_consts`.
 unsafe fn w_code_copy_const_slots(dst: PyObjectRef, src: PyObjectRef) {
-    let dst_code = unsafe { &mut *(dst as *mut PyCode) };
+    let dst_code = unsafe { &*(dst as *const PyCode) };
     if dst_code.co_consts_w.is_null() {
         return;
     }
-    let slots = unsafe { &mut *dst_code.co_consts_w };
-    for (index, slot) in slots.iter_mut().enumerate() {
+    let slots = unsafe { &*dst_code.co_consts_w };
+    for (index, slot) in slots.iter().enumerate() {
         let value = unsafe { w_code_const(src, index) };
         if !value.is_null() {
-            *slot = value;
+            slot.store(value, std::sync::atomic::Ordering::Release);
         }
     }
     pyre_object::gc_roots::mark_prebuilt_roots_dirty();
@@ -531,11 +533,13 @@ fn names_tuple(names: &[String]) -> PyObjectRef {
 
 fn constants_tuple(obj: PyObjectRef, code: &crate::CodeObject) -> PyObjectRef {
     let mut constants = Vec::with_capacity(code.constants.len());
-    for index in 0..code.constants.len() {
+    for (index, constant) in crate::pyframe::code_constants(code).iter().enumerate() {
         let value = unsafe { w_code_const(obj, index) };
-        if !value.is_null() {
-            constants.push(value);
-        }
+        constants.push(if value.is_null() {
+            crate::pyframe::pyobject_from_constant(constant)
+        } else {
+            value
+        });
     }
     w_tuple_new(constants)
 }
@@ -1421,12 +1425,9 @@ pub unsafe fn w_code_const(w_code_obj: PyObjectRef, idx: usize) -> PyObjectRef {
         return pyre_object::pyobject::PY_NULL;
     };
     // PyPy's GIL serializes first access to its already-wrapped list. Pyre is
-    // free-threaded and realizes this compiler-boundary slot lazily, so publish
-    // with a pointer CAS. State still lives in the literal co_consts_w array;
-    // the atomic operation is synchronization only, not a side table.
-    let atomic_slot =
-        unsafe { &*(slot as *const PyObjectRef as *const std::sync::atomic::AtomicUsize) };
-    let existing = atomic_slot.load(std::sync::atomic::Ordering::Acquire) as PyObjectRef;
+    // free-threaded and realizes this compiler-boundary slot lazily, so every
+    // reader and writer uses the AtomicPtr element stored in co_consts_w.
+    let existing = slot.load(std::sync::atomic::Ordering::Acquire);
     if !existing.is_null() {
         return existing;
     }
@@ -1436,9 +1437,9 @@ pub unsafe fn w_code_const(w_code_obj: PyObjectRef, idx: usize) -> PyObjectRef {
     // published it or selected the concurrently-published canonical object.
     let candidate_root = &mut realized as *mut PyObjectRef as *mut *mut u8;
     let registered = unsafe { pyre_object::gc_hook::try_gc_add_root(candidate_root) };
-    let published = match atomic_slot.compare_exchange(
-        0,
-        realized as usize,
+    let published = match slot.compare_exchange(
+        std::ptr::null_mut(),
+        realized,
         std::sync::atomic::Ordering::AcqRel,
         std::sync::atomic::Ordering::Acquire,
     ) {
@@ -1446,7 +1447,7 @@ pub unsafe fn w_code_const(w_code_obj: PyObjectRef, idx: usize) -> PyObjectRef {
             pyre_object::gc_roots::mark_prebuilt_roots_dirty();
             realized
         }
-        Err(winner) => winner as PyObjectRef,
+        Err(winner) => winner,
     };
     if registered {
         pyre_object::gc_hook::try_gc_remove_root(candidate_root);
@@ -2140,6 +2141,63 @@ mod tests {
         assert!(
             visited,
             "Box-immortal PyCode must expose managed co_consts_w values as roots"
+        );
+    }
+
+    #[test]
+    fn raw_code_root_walker_recurses_through_nested_code_constants() {
+        let code = compile_exec(
+            "def outer():\n\
+             \x20   def inner():\n\
+             \x20       return 12345678901234567890123456789012345678901234567890\n\
+             \x20   return inner\n",
+        )
+        .expect("compile failed");
+        let (outer_idx, outer_code) = code
+            .constants
+            .iter()
+            .enumerate()
+            .find_map(|(index, constant)| match constant {
+                crate::bytecode::ConstantData::Code { code } => Some((index, code.as_ref())),
+                _ => None,
+            })
+            .expect("outer code constant");
+        let (inner_idx, inner_code) = outer_code
+            .constants
+            .iter()
+            .enumerate()
+            .find_map(|(index, constant)| match constant {
+                crate::bytecode::ConstantData::Code { code } => Some((index, code.as_ref())),
+                _ => None,
+            })
+            .expect("inner code constant");
+        let bigint_idx = inner_code
+            .constants
+            .iter()
+            .position(|constant| {
+                matches!(
+                    constant,
+                    crate::bytecode::ConstantData::Integer { value }
+                        if num_traits::ToPrimitive::to_i64(value).is_none()
+                )
+            })
+            .expect("nested large integer");
+
+        let w_top = box_code_constant(&code);
+        let w_outer = unsafe { w_code_const(w_top, outer_idx) };
+        let w_inner = unsafe { w_code_const(w_outer, inner_idx) };
+        let w_bigint = unsafe { w_code_const(w_inner, bigint_idx) };
+        let mut visited = false;
+        unsafe {
+            crate::eval::walk_raw_code_roots(w_top, &mut |root| {
+                if root.0 == w_bigint as usize {
+                    visited = true;
+                }
+            });
+        }
+        assert!(
+            visited,
+            "an outer PyCode root must trace realized constants in nested PyCode wrappers"
         );
     }
 

--- a/pyre/pyre-interpreter/src/pycode.rs
+++ b/pyre/pyre-interpreter/src/pycode.rs
@@ -235,6 +235,44 @@ pub const CODE_PTR_OFFSET: usize = std::mem::offset_of!(PyCode, code_ptr);
 /// Field offset of `w_globals` within `PyCode`.
 pub const CODE_W_GLOBALS_OFFSET: usize = std::mem::offset_of!(PyCode, w_globals);
 
+/// Box-immortal `PyCode` wrappers that own off-GC `w_globals` and
+/// `co_consts_w` slots.
+///
+/// PyPy's `PyCode` is GC-managed, so ordinary graph tracing reaches these
+/// fields even when a code object is stored directly in a module/container
+/// without first becoming a function or frame. Pyre's wrappers are
+/// `Box::into_raw`-immortal; retain their exact process-global lifetime and
+/// expose every wrapper through one small insertion-ordered registry instead
+/// of a TLS or per-value side table.
+static PREBUILT_CODE_ROOTS: std::sync::OnceLock<std::sync::Mutex<Vec<usize>>> =
+    std::sync::OnceLock::new();
+
+fn register_prebuilt_code_root(code: PyObjectRef) {
+    let roots = PREBUILT_CODE_ROOTS.get_or_init(|| std::sync::Mutex::new(Vec::new()));
+    let mut roots = roots
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let identity = code as usize;
+    if !roots.contains(&identity) {
+        roots.push(identity);
+    }
+}
+
+/// Trace every Box-immortal code wrapper exactly as PyPy traces every live
+/// GC-managed `PyCode`. Nested code constants are handled by the raw walker's
+/// own mark-state analogue.
+pub(crate) fn walk_prebuilt_code_roots(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
+    let Some(roots) = PREBUILT_CODE_ROOTS.get() else {
+        return;
+    };
+    let roots = roots
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    for &code in roots.iter() {
+        unsafe { crate::eval::walk_raw_code_roots(code as PyObjectRef, visitor) };
+    }
+}
+
 /// GC type id assigned to `PyCode`.
 ///
 /// `PyCode` is a normal interpreter-level code object in PyPy
@@ -406,7 +444,9 @@ pub fn w_code_new_with_hidden_applevel(code_ptr: *const (), hidden_applevel: boo
         mapdict_caches,
         co_consts_w,
     });
-    Box::into_raw(obj) as PyObjectRef
+    let obj = Box::into_raw(obj) as PyObjectRef;
+    register_prebuilt_code_root(obj);
+    obj
 }
 
 /// pypy/interpreter/pycode.py:107-147 `PyCode.__init__` shorthand —
@@ -462,29 +502,41 @@ unsafe fn w_code_fill_consts_from_tuple(obj: PyObjectRef, constants: PyObjectRef
     }
     let slots = unsafe { &*code.co_consts_w };
     let count = slots.len().min(pyre_object::w_tuple_len(constants));
+    let mut filled = false;
     for (index, slot) in slots.iter().take(count).enumerate() {
         if let Some(value) = unsafe { pyre_object::w_tuple_getitem(constants, index as i64) } {
             slot.store(value, std::sync::atomic::Ordering::Release);
+            filled = true;
         }
     }
-    pyre_object::gc_roots::mark_prebuilt_roots_dirty();
+    if filled {
+        pyre_object::gc_roots::mark_prebuilt_roots_dirty();
+    }
 }
 
 /// Preserve the existing wrapped constant array when `code.replace()` changes
-/// fields other than `co_consts`.
+/// fields other than `co_consts`. PyPy copies an already-wrapped list; pyre
+/// must therefore copy only source slots that have already been realized,
+/// without turning `code.replace()` into an eager realization boundary.
 unsafe fn w_code_copy_const_slots(dst: PyObjectRef, src: PyObjectRef) {
     let dst_code = unsafe { &*(dst as *const PyCode) };
-    if dst_code.co_consts_w.is_null() {
+    let src_code = unsafe { &*(src as *const PyCode) };
+    if dst_code.co_consts_w.is_null() || src_code.co_consts_w.is_null() {
         return;
     }
-    let slots = unsafe { &*dst_code.co_consts_w };
-    for (index, slot) in slots.iter().enumerate() {
-        let value = unsafe { w_code_const(src, index) };
+    let dst_slots = unsafe { &*dst_code.co_consts_w };
+    let src_slots = unsafe { &*src_code.co_consts_w };
+    let mut copied = false;
+    for (dst_slot, src_slot) in dst_slots.iter().zip(src_slots.iter()) {
+        let value = src_slot.load(std::sync::atomic::Ordering::Acquire);
         if !value.is_null() {
-            slot.store(value, std::sync::atomic::Ordering::Release);
+            dst_slot.store(value, std::sync::atomic::Ordering::Release);
+            copied = true;
         }
     }
-    pyre_object::gc_roots::mark_prebuilt_roots_dirty();
+    if copied {
+        pyre_object::gc_roots::mark_prebuilt_roots_dirty();
+    }
 }
 
 /// The keyword-only fields `code.replace` accepts, in the order
@@ -2142,6 +2194,60 @@ mod tests {
             visited,
             "Box-immortal PyCode must expose managed co_consts_w values as roots"
         );
+
+        let mut globally_visited = false;
+        walk_prebuilt_code_roots(&mut |root| {
+            if root.0 == first as usize {
+                globally_visited = true;
+            }
+        });
+        assert!(
+            globally_visited,
+            "a standalone PyCode must remain a root without a function/frame owner"
+        );
+    }
+
+    #[test]
+    fn copy_const_slots_preserves_unrealized_source_slots() {
+        let code = compile_exec(
+            "x = 12345678901234567890123456789012345678901234567890\n\
+             y = 98765432109876543210987654321098765432109876543210\n",
+        )
+        .expect("compile failed");
+        let integer_indices: Vec<usize> = code
+            .constants
+            .iter()
+            .enumerate()
+            .filter_map(|(index, constant)| {
+                matches!(
+                    constant,
+                    crate::bytecode::ConstantData::Integer { value }
+                        if num_traits::ToPrimitive::to_i64(value).is_none()
+                )
+                .then_some(index)
+            })
+            .collect();
+        assert!(integer_indices.len() >= 2);
+        let realized_idx = integer_indices[0];
+        let unrealized_idx = integer_indices[1];
+        let src = box_code_constant(&code);
+        let dst = box_code_constant(&code);
+        let realized = unsafe { w_code_const(src, realized_idx) };
+
+        unsafe {
+            w_code_copy_const_slots(dst, src);
+            let dst_slots = &*(*(dst as *const PyCode)).co_consts_w;
+            assert_eq!(
+                dst_slots[realized_idx].load(std::sync::atomic::Ordering::Acquire),
+                realized
+            );
+            assert!(
+                dst_slots[unrealized_idx]
+                    .load(std::sync::atomic::Ordering::Acquire)
+                    .is_null(),
+                "code.replace must not eagerly realize a missing source constant"
+            );
+        }
     }
 
     #[test]

--- a/pyre/pyre-interpreter/src/pycode.rs
+++ b/pyre/pyre-interpreter/src/pycode.rs
@@ -215,16 +215,14 @@ pub struct PyCode {
     /// `pycode.py:126 self.co_consts_w = consts` (`_immutable_fields_
     /// co_consts_w[*]`, pycode.py:97).  The realized constant objects indexed by
     /// constant index.  `getconstant_w(index)` (`pyopcode.py:498-499`) returns
-    /// `co_consts_w[index]`, so a `LOAD_CONST` of a code constant yields the one
-    /// shared `PyCode` stored here — repeated loads (and the blackhole
-    /// resume reading the same `pycode` off the virtualizable) get identical
-    /// `__code__` identity and a stable JIT green key, with no side table.
+    /// `co_consts_w[index]`, so every `LOAD_CONST` yields the one shared object
+    /// stored here — repeated loads (including blackhole resume through the
+    /// same virtualizable `pycode`) preserve object identity.
     ///
-    /// Only the reference-typed code-constant slots are realized into this list
-    /// (lazily, once per index); value constants realize through
-    /// `load_const_value` as before.  The stored code wrappers are `Box`-immortal
-    /// (`w_code_new` → `Box::into_raw`), so the slots never dangle and need no GC
-    /// walking (the rationale that retired `CODE_CONSTANT_INTERN`).
+    /// PyPy receives this list already wrapped from the compiler. Pyre's
+    /// compiler keeps `ConstantData` unwrapped, so slots are realized lazily at
+    /// the equivalent boundary. `eval::walk_raw_code_roots` traces every filled
+    /// slot because value constants (notably `W_LongObject`) are GC-managed.
     ///
     /// Owned via `Box::into_raw`, sized to `code.constants.len()` at construction,
     /// never resized; a `null` slot is unrealized.  The whole pointer is `null`
@@ -367,8 +365,8 @@ pub fn w_code_new_with_hidden_applevel(code_ptr: *const (), hidden_applevel: boo
         Box::into_raw(Box::new(v))
     };
     // `pycode.py:126 self.co_consts_w = consts` — the realized-constant table
-    // sized to the constant count, with code-constant slots filled lazily by
-    // `w_code_co_const`.
+    // sized to the constant count, with slots filled lazily by `w_code_const`
+    // at pyre's wrapped/unwrapped compiler boundary.
     let co_consts_w = if !code_ptr_aligned {
         std::ptr::null_mut()
     } else {
@@ -423,6 +421,17 @@ pub fn w_code_new(code_ptr: *const ()) -> PyObjectRef {
 }
 
 /// Box a cloned compiler code object into a heap Python code wrapper.
+///
+/// PyPy's compiler constructs `PyCode` directly (`pycode.py:115-126`) and
+/// therefore has no foreign compiler-object clone in the translated graph.
+/// Pyre's compiler-core `CodeObject` is a dependency ADT whose derived `Clone`
+/// recursively owns boxed slices and nested constants; it is solely the
+/// serialization/API seam used to reach the interpreter-level `PyCode`.
+/// Residualize that foreign seam so the translated graph retains PyPy's direct
+/// `PyCode` value shape instead of inventing an RPython layout for the opaque
+/// Rust clone. Keep clone, Box ownership transfer, and wrapper publication in
+/// the one boundary.
+#[majit_macros::dont_look_inside]
 pub fn box_code_constant(code: &crate::CodeObject) -> PyObjectRef {
     let code_ptr = Box::into_raw(Box::new(code.clone())) as *const ();
     w_code_new(code_ptr)
@@ -434,6 +443,46 @@ fn box_code_constant_with_firstlineno(code: &crate::CodeObject, firstlineno: i32
         (*(obj as *mut PyCode)).co_firstlineno_raw = firstlineno;
     }
     obj
+}
+
+/// Fill a newly-created code object's `co_consts_w` from the wrapped tuple
+/// supplied to `CodeType.__new__` / `code.replace`.
+///
+/// PyPy passes this list straight into `PyCode.__init__`
+/// (`pycode.py:126 self.co_consts_w = consts`), preserving every wrapper's
+/// identity. Pyre additionally serializes the values into compiler
+/// `ConstantData` for bytecode decoding, but that representation must not
+/// replace the interpreter-level owner.
+unsafe fn w_code_fill_consts_from_tuple(obj: PyObjectRef, constants: PyObjectRef) {
+    let code = unsafe { &mut *(obj as *mut PyCode) };
+    if code.co_consts_w.is_null() {
+        return;
+    }
+    let slots = unsafe { &mut *code.co_consts_w };
+    let count = slots.len().min(pyre_object::w_tuple_len(constants));
+    for (index, slot) in slots.iter_mut().take(count).enumerate() {
+        if let Some(value) = unsafe { pyre_object::w_tuple_getitem(constants, index as i64) } {
+            *slot = value;
+        }
+    }
+    pyre_object::gc_roots::mark_prebuilt_roots_dirty();
+}
+
+/// Preserve the existing wrapped constant array when `code.replace()` changes
+/// fields other than `co_consts`.
+unsafe fn w_code_copy_const_slots(dst: PyObjectRef, src: PyObjectRef) {
+    let dst_code = unsafe { &mut *(dst as *mut PyCode) };
+    if dst_code.co_consts_w.is_null() {
+        return;
+    }
+    let slots = unsafe { &mut *dst_code.co_consts_w };
+    for (index, slot) in slots.iter_mut().enumerate() {
+        let value = unsafe { w_code_const(src, index) };
+        if !value.is_null() {
+            *slot = value;
+        }
+    }
+    pyre_object::gc_roots::mark_prebuilt_roots_dirty();
 }
 
 /// The keyword-only fields `code.replace` accepts, in the order
@@ -480,13 +529,15 @@ fn names_tuple(names: &[String]) -> PyObjectRef {
     w_tuple_new(names.iter().map(|name| w_str_new(name)).collect())
 }
 
-fn constants_tuple(code: &crate::CodeObject) -> PyObjectRef {
-    w_tuple_new(
-        crate::pyframe::code_constants(code)
-            .iter()
-            .map(crate::pyframe::pyobject_from_constant)
-            .collect(),
-    )
+fn constants_tuple(obj: PyObjectRef, code: &crate::CodeObject) -> PyObjectRef {
+    let mut constants = Vec::with_capacity(code.constants.len());
+    for index in 0..code.constants.len() {
+        let value = unsafe { w_code_const(obj, index) };
+        if !value.is_null() {
+            constants.push(value);
+        }
+    }
+    w_tuple_new(constants)
 }
 
 fn legacy_lnotab(code: &crate::CodeObject, firstlineno: i64) -> Vec<u8> {
@@ -538,7 +589,7 @@ pub unsafe fn code_get_field(obj: PyObjectRef, name: &str) -> Result<PyObjectRef
         "co_code" | "_co_code_adaptive" => {
             pyre_object::bytesobject::w_bytes_from_bytes(&code.instructions.original_bytes())
         }
-        "co_consts" => constants_tuple(code),
+        "co_consts" => constants_tuple(obj, code),
         "co_names" => names_tuple(&code.names),
         "co_varnames" => names_tuple(&code.varnames),
         "co_freevars" => names_tuple(&code.freevars),
@@ -662,10 +713,12 @@ pub unsafe fn code_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErr
         linetable,
         exceptiontable,
     };
-    Ok(box_code_constant_with_firstlineno(
+    let result = box_code_constant_with_firstlineno(
         &code,
         first_line.clamp(i32::MIN as i64, i32::MAX as i64) as i32,
-    ))
+    );
+    unsafe { w_code_fill_consts_from_tuple(result, args[8]) };
+    Ok(result)
 }
 
 fn code_data_equal(a: &crate::CodeObject, b: &crate::CodeObject) -> bool {
@@ -800,11 +853,14 @@ pub unsafe fn code_hash(obj: PyObjectRef) -> Result<i64, crate::PyError> {
             add_obj(&mut result, w_str_new(name))?;
         }
     }
-    for constant in crate::pyframe::code_constants(code) {
-        add_obj(
-            &mut result,
-            crate::pyframe::pyobject_from_constant(constant),
-        )?;
+    for (index, constant) in crate::pyframe::code_constants(code).iter().enumerate() {
+        let w_constant = unsafe { w_code_const(obj, index) };
+        let w_constant = if w_constant.is_null() {
+            crate::pyframe::pyobject_from_constant(constant)
+        } else {
+            w_constant
+        };
+        add_obj(&mut result, w_constant)?;
     }
     Ok(if result == -1 { -2 } else { result })
 }
@@ -1128,7 +1184,13 @@ pub unsafe fn code_replace(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::P
         code.instructions.len(),
     );
 
-    Ok(box_code_constant_with_firstlineno(&code, firstlineno_raw))
+    let result = box_code_constant_with_firstlineno(&code, firstlineno_raw);
+    if let Some(constants) = get("co_consts") {
+        unsafe { w_code_fill_consts_from_tuple(result, constants) };
+    } else {
+        unsafe { w_code_copy_const_slots(result, w_self) };
+    }
+    Ok(result)
 }
 
 /// A non-negative `co_*` count argument as `u32`.
@@ -1319,31 +1381,22 @@ pub(crate) unsafe fn obj_to_constant_data(
     }
 }
 
-/// `pyopcode.py:498-499 getconstant_w(index) -> co_consts_w[index]` for a code
-/// constant: return the one shared `PyCode` the enclosing code holds at
-/// `index`, realizing it into the slot on first access (`pycode.py:126` builds
-/// `co_consts_w` eagerly; pyre fills the reference-typed slots lazily).
+/// `pyopcode.py:498-499 getconstant_w(index) -> co_consts_w[index]`: return the
+/// one shared constant object the enclosing code holds at `index`, realizing
+/// it into the slot on first access (`pycode.py:126` builds `co_consts_w`
+/// eagerly; pyre's compiler representation is unwrapped).
 ///
-/// `w_code_obj` is the enclosing `PyCode` (`frame.pycode` for the
-/// interpreter, the virtualizable `pycode` field for the blackhole — the same
-/// object for a given running code), and `idx` is the constant index.  Repeated
-/// `LOAD_CONST` of the same code constant returns the same wrapper, giving stable
-/// `__code__` identity and a stable JIT green key (`greens = [..., 'pycode']`);
-/// without it a closure defined in a hot-loop-called function gets a fresh wrapper
-/// each iteration and the trace give-up counter never accumulates.
+/// `w_code_obj` is the enclosing `PyCode` (`frame.pycode` for the interpreter,
+/// the virtualizable `pycode` field for the blackhole), and `idx` is the
+/// constant index. No side table is involved: the owner and storage shape are
+/// the literal port of `PyCode.co_consts_w`.
 ///
-/// The stored wrapper is `Box`-immortal, so the slot never dangles and needs no
-/// GC walking.  An absent slot table (null `co_consts_w`) still realizes a fresh
-/// wrapper from the nested code.
-///
-/// Returns `PY_NULL` (the empty pointer) when the constant cannot be resolved as
-/// a code wrapper — a null/misaligned `code_ptr` (the nested code is
-/// unreadable), `idx` out of range, or `constants[idx]` not a code constant — so
-/// callers fall back to their value-constant realization path.
+/// Returns `PY_NULL` only when the enclosing code/slot cannot be resolved.
 ///
 /// # Safety
 /// `w_code_obj` must point to a valid `PyCode`.
-pub unsafe fn w_code_co_const(w_code_obj: PyObjectRef, idx: usize) -> PyObjectRef {
+#[majit_macros::dont_look_inside]
+pub unsafe fn w_code_const(w_code_obj: PyObjectRef, idx: usize) -> PyObjectRef {
     let w_code = unsafe { &*(w_code_obj as *const PyCode) };
     // Guard `code_ptr` before dereferencing it — the same null/alignment check
     // the lazy-cache initializers use. A null/misaligned pointer means the
@@ -1360,22 +1413,45 @@ pub unsafe fn w_code_co_const(w_code_obj: PyObjectRef, idx: usize) -> PyObjectRe
     if idx >= constants.len() {
         return pyre_object::pyobject::PY_NULL;
     }
-    let crate::bytecode::ConstantData::Code { code: nested } = &constants[idx] else {
+    if w_code.co_consts_w.is_null() {
+        return crate::pyframe::pyobject_from_constant(&constants[idx]);
+    }
+    let slot_table = unsafe { &*w_code.co_consts_w };
+    let Some(slot) = slot_table.get(idx) else {
         return pyre_object::pyobject::PY_NULL;
     };
-    if w_code.co_consts_w.is_null() {
-        return box_code_constant(nested);
+    // PyPy's GIL serializes first access to its already-wrapped list. Pyre is
+    // free-threaded and realizes this compiler-boundary slot lazily, so publish
+    // with a pointer CAS. State still lives in the literal co_consts_w array;
+    // the atomic operation is synchronization only, not a side table.
+    let atomic_slot =
+        unsafe { &*(slot as *const PyObjectRef as *const std::sync::atomic::AtomicUsize) };
+    let existing = atomic_slot.load(std::sync::atomic::Ordering::Acquire) as PyObjectRef;
+    if !existing.is_null() {
+        return existing;
     }
-    let slot_table = unsafe { &mut *w_code.co_consts_w };
-    match slot_table.get_mut(idx) {
-        Some(slot) if !slot.is_null() => *slot,
-        Some(slot) => {
-            let realized = box_code_constant(nested);
-            *slot = realized;
+
+    let mut realized = crate::pyframe::pyobject_from_constant(&constants[idx]);
+    // Keep the losing or winning candidate live until the CAS has either
+    // published it or selected the concurrently-published canonical object.
+    let candidate_root = &mut realized as *mut PyObjectRef as *mut *mut u8;
+    let registered = unsafe { pyre_object::gc_hook::try_gc_add_root(candidate_root) };
+    let published = match atomic_slot.compare_exchange(
+        0,
+        realized as usize,
+        std::sync::atomic::Ordering::AcqRel,
+        std::sync::atomic::Ordering::Acquire,
+    ) {
+        Ok(_) => {
+            pyre_object::gc_roots::mark_prebuilt_roots_dirty();
             realized
         }
-        None => box_code_constant(nested),
+        Err(winner) => winner as PyObjectRef,
+    };
+    if registered {
+        pyre_object::gc_hook::try_gc_remove_root(candidate_root);
     }
+    published
 }
 
 /// pypy/module/__pypy__/interp_magic.py:79
@@ -1899,6 +1975,7 @@ pub unsafe fn is_code(obj: PyObjectRef) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::compile_exec;
 
     /// Build a minimal varint-encoded exception table from `(start, length,
     /// target, depth, lasti)` tuples, mirroring the encoding produced by
@@ -2011,12 +2088,95 @@ mod tests {
     }
 
     #[test]
-    fn w_code_co_const_null_code_ptr_returns_py_null() {
+    fn w_code_const_null_code_ptr_returns_py_null() {
         // A `PyCode` built from a null `code_ptr` must not be
         // dereferenced; the guard returns PY_NULL so the caller falls back to
         // its own constant realization.
         let w_code = w_code_new(std::ptr::null());
-        let result = unsafe { w_code_co_const(w_code, 0) };
+        let result = unsafe { w_code_const(w_code, 0) };
         assert_eq!(result, pyre_object::pyobject::PY_NULL);
+    }
+
+    #[test]
+    fn w_code_const_shares_large_integer_and_root_walker_visits_slot() {
+        let code =
+            compile_exec("x = 123456789012345678901234567890123456789012345678901234567890\n")
+                .expect("compile failed");
+        let idx = code
+            .constants
+            .iter()
+            .position(|constant| {
+                matches!(
+                    constant,
+                    crate::bytecode::ConstantData::Integer { value }
+                        if num_traits::ToPrimitive::to_i64(value).is_none()
+                )
+            })
+            .expect("large integer constant");
+        let w_code = box_code_constant(&code);
+
+        let first = unsafe { w_code_const(w_code, idx) };
+        let second = unsafe { w_code_const(w_code, idx) };
+        assert_eq!(
+            first, second,
+            "getconstant_w must return the co_consts_w slot identity"
+        );
+        assert!(unsafe { pyre_object::is_long(first) });
+        let exposed = unsafe { code_get_field(w_code, "co_consts") }.expect("co_consts descriptor");
+        assert_eq!(
+            unsafe { pyre_object::w_tuple_getitem(exposed, idx as i64) },
+            Some(first),
+            "code.co_consts must expose the same wrapped slot object"
+        );
+
+        let mut visited = false;
+        unsafe {
+            crate::eval::walk_raw_code_roots(w_code, &mut |root| {
+                if root.0 == first as usize {
+                    visited = true;
+                }
+            });
+        }
+        assert!(
+            visited,
+            "Box-immortal PyCode must expose managed co_consts_w values as roots"
+        );
+    }
+
+    #[test]
+    fn w_code_const_first_publication_is_free_threaded_identity_safe() {
+        let code =
+            compile_exec("x = 314159265358979323846264338327950288419716939937510582097494\n")
+                .expect("compile failed");
+        let idx = code
+            .constants
+            .iter()
+            .position(|constant| {
+                matches!(
+                    constant,
+                    crate::bytecode::ConstantData::Integer { value }
+                        if num_traits::ToPrimitive::to_i64(value).is_none()
+                )
+            })
+            .expect("large integer constant");
+        let w_code = box_code_constant(&code) as usize;
+        let barrier = std::sync::Arc::new(std::sync::Barrier::new(8));
+        let mut workers = Vec::new();
+        for _ in 0..8 {
+            let barrier = barrier.clone();
+            workers.push(std::thread::spawn(move || {
+                barrier.wait();
+                unsafe { w_code_const(w_code as PyObjectRef, idx) as usize }
+            }));
+        }
+        let values: Vec<usize> = workers
+            .into_iter()
+            .map(|worker| worker.join().expect("constant worker panicked"))
+            .collect();
+        assert!(values[0] != 0);
+        assert!(
+            values.iter().all(|value| *value == values[0]),
+            "the co_consts_w CAS must select one canonical wrapper"
+        );
     }
 }

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -3864,15 +3864,14 @@ pub(crate) fn code_constants(code: &CodeObject) -> &[crate::bytecode::ConstantDa
 /// `pyopcode.rs::load_const_value` so future additions stay in sync.
 pub fn pyobject_from_constant(constant: &crate::bytecode::ConstantData) -> PyObjectRef {
     use crate::bytecode::ConstantData;
-    use num_traits::ToPrimitive;
     match constant {
         // `pyopcode.rs:347-353` — promote bigints to W_LongObject just
         // like `load_const_value` does before invoking the trait.
         ConstantData::Integer { value } => {
-            if let Some(value) = ToPrimitive::to_i64(value) {
-                pyre_object::intobject::w_int_new(value)
-            } else {
-                pyre_object::longobject::w_long_new(crate::compiler_bigint_to_rbigint(value))
+            let value = crate::compiler_bigint_to_rbigint(value);
+            match value.toint() {
+                Ok(value) => pyre_object::intobject::w_int_new(value),
+                Err(_) => pyre_object::longobject::w_long_new(value),
             }
         }
         // `eval.rs:1309-1311 float_constant`.

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -3810,14 +3810,13 @@ impl PyFrame {
     /// Load a constant from the code object by raw index.
     /// Used by the blackhole interpreter's bh_load_const_fn.
     pub fn load_const_pyobj(&self, idx: usize) -> PyObjectRef {
-        let code = self.code();
-        // RPython: constants are in JitCode.constants_r. In pyre, we resolve
-        // from the CodeObject's constant table at runtime.
-        let constants = code_constants(code);
-        if idx >= constants.len() {
-            return pyre_object::w_none();
+        let value =
+            unsafe { crate::pycode::w_code_const(self.pycode as pyre_object::PyObjectRef, idx) };
+        if value.is_null() {
+            pyre_object::w_none()
+        } else {
+            value
         }
-        pyobject_from_constant(&constants[idx])
     }
 }
 
@@ -3863,20 +3862,17 @@ pub(crate) fn code_constants(code: &CodeObject) -> &[crate::bytecode::ConstantDa
 /// `&mut PyFrame` to dispatch through the trait, so this free function
 /// mirrors each `*_constant` body directly. Variant order matches
 /// `pyopcode.rs::load_const_value` so future additions stay in sync.
-pub(crate) fn pyobject_from_constant(constant: &crate::bytecode::ConstantData) -> PyObjectRef {
+pub fn pyobject_from_constant(constant: &crate::bytecode::ConstantData) -> PyObjectRef {
     use crate::bytecode::ConstantData;
     use num_traits::ToPrimitive;
     match constant {
         // `pyopcode.rs:347-353` — promote bigints to W_LongObject just
         // like `load_const_value` does before invoking the trait.
         ConstantData::Integer { value } => {
-            let value = crate::compiler_bigint_to_rbigint(value);
-            if pyre_object::longobject::jit_bigint_to_i64_fits(&value) != 0 {
-                pyre_object::intobject::w_int_new(pyre_object::longobject::jit_bigint_to_i64_value(
-                    &value,
-                ))
+            if let Some(value) = ToPrimitive::to_i64(value) {
+                pyre_object::intobject::w_int_new(value)
             } else {
-                pyre_object::longobject::w_long_new(value)
+                pyre_object::longobject::w_long_new(crate::compiler_bigint_to_rbigint(value))
             }
         }
         // `eval.rs:1309-1311 float_constant`.

--- a/pyre/pyre-interpreter/src/pyopcode.rs
+++ b/pyre/pyre-interpreter/src/pyopcode.rs
@@ -476,21 +476,15 @@ pub trait ConstantOpcodeHandler: SharedOpcodeHandler {
     /// on call sites that need true immutability to make a copy.
     fn bytes_constant(&mut self, value: &[u8]) -> Result<Self::Value, PyError>;
     fn code_constant(&mut self, code: &CodeObject) -> Result<Self::Value, PyError>;
-    /// `getconstant_w(index) -> co_consts_w[index]` (`pyopcode.py:498-499`) for a
-    /// code constant: return the one wrapper the enclosing code holds at `index`.
-    /// `enclosing` is the running code (whose `constants[index]` is the
-    /// `ConstantData::Code`).  The default realizes a fresh wrapper; `PyFrame`
-    /// overrides it to return `self.pycode.co_consts_w[index]` so repeated loads
-    /// share one `PyCode`.
-    fn code_constant_at(
+    /// `getconstant_w(index) -> co_consts_w[index]` (`pyopcode.py:498-499`).
+    /// The default realizes from the compiler constant; `PyFrame` overrides it
+    /// to return the object owned by `self.pycode.co_consts_w[index]`.
+    fn constant_at(
         &mut self,
-        index: usize,
+        index: crate::bytecode::oparg::ConstIdx,
         enclosing: &CodeObject,
     ) -> Result<Self::Value, PyError> {
-        match &crate::pyframe::code_constants(enclosing)[index] {
-            ConstantData::Code { code } => self.code_constant(code),
-            _ => unreachable!("code_constant_at on a non-code constant at index {index}"),
-        }
+        load_const_value(self, &enclosing.constants[index])
     }
     fn none_constant(&mut self) -> Result<Self::Value, PyError>;
     fn ellipsis_constant(&mut self) -> Result<Self::Value, PyError>;
@@ -515,11 +509,18 @@ fn load_const_value<H: ConstantOpcodeHandler + ?Sized>(
 ) -> Result<H::Value, PyError> {
     match constant {
         ConstantData::Integer { value } => {
-            if let Some(value) = num_traits::ToPrimitive::to_i64(value) {
-                handler.int_constant(value)
-            } else {
-                let value = crate::compiler_bigint_to_rbigint(value);
-                handler.bigint_constant(&value)
+            // The compiler's Malachite integer is a serialization/API seam,
+            // never the interpreter arithmetic representation.  Convert once
+            // to RPython's rbigint, then make the same machine-int decision
+            // through `rbigint.toint()` that PyPy's integer consumers use.
+            // This also keeps the generated JIT graph entirely on the
+            // sanctioned compiler-bigint conversion residual instead of
+            // pulling a foreign `BigInt::to_i64 -> Option<i64>` method into
+            // translated code.
+            let value = crate::compiler_bigint_to_rbigint(value);
+            match value.toint() {
+                Ok(value) => handler.int_constant(value),
+                Err(_) => handler.bigint_constant(&value),
             }
         }
         ConstantData::Float { value } => handler.float_constant(*value),
@@ -3135,15 +3136,10 @@ where
     };
     let const_idx = consti.get(op_arg);
     // `pyopcode.py:533 LOAD_CONST` reads `getconstant_w(index)`
-    // (`pyopcode.py:498-499 co_consts_w[index]`); a code constant must resolve to
-    // the enclosing code's one shared wrapper, so route it through
-    // `code_constant_at` instead of realizing afresh in `load_const`.
-    if matches!(&code.constants[const_idx], ConstantData::Code { .. }) {
-        let value = executor.code_constant_at(usize::from(const_idx), code)?;
-        executor.push_value(value)?;
-        return Ok(StepResult::Continue);
-    }
-    executor.load_const(&code.constants[const_idx])?;
+    // (`pyopcode.py:498-499 co_consts_w[index]`): every constant, not just a
+    // nested code object, comes from the enclosing PyCode's shared slot.
+    let value = executor.constant_at(const_idx, code)?;
+    executor.push_value(value)?;
     Ok(StepResult::Continue)
 }
 

--- a/pyre/pyre-interpreter/src/runtime_ops.rs
+++ b/pyre/pyre-interpreter/src/runtime_ops.rs
@@ -1409,7 +1409,8 @@ pub fn range_iter_continues(iter: PyObjectRef) -> Result<bool, PyError> {
         }
         if is_list_iter(iter) {
             let si = &*(iter as *const W_ListIterObject);
-            return Ok(!si.seq.is_null() && si.index < w_list_len(si.seq) as i64);
+            // A negative cursor is the `__setstate__` exhausted sentinel.
+            return Ok(!si.seq.is_null() && si.index >= 0 && si.index < w_list_len(si.seq) as i64);
         }
         if is_tuple_iter(iter) {
             let si = &*(iter as *const W_TupleIterObject);
@@ -1493,7 +1494,10 @@ pub fn range_iter_next_or_null(iter: PyObjectRef) -> Result<PyObjectRef, PyError
         }
         if is_list_iter(iter) {
             let si = &mut *(iter as *mut W_ListIterObject);
-            if si.seq.is_null() {
+            // The `__setstate__` sentinel keeps the sequence so a later
+            // in-range state can revive the iterator (mirrors
+            // `baseobjspace::next`).
+            if si.seq.is_null() || si.index < 0 {
                 return Ok(PY_NULL);
             }
             if let Some(item) = w_list_getitem(si.seq, si.index) {

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -2150,11 +2150,26 @@ fn format_rbigint(num: &BigInt, spec: &Wtf8, type_name: &str) -> Result<Wtf8Buf,
     // Keep the parsed value live so syntax validation cannot be optimized
     // away independently from rendering.
     let _ = parsed;
-    let mut magnitude = num.abs().to_str_radix(radix);
+    let digits = match radix {
+        2 => "01",
+        8 => pyre_object::rbigint::BASE8,
+        10 => pyre_object::rbigint::BASE10,
+        16 => pyre_object::rbigint::BASE16,
+        _ => unreachable!("integer format uses radix 2, 8, 10, or 16"),
+    };
+    let negative = num.int_lt(0);
+    let mut magnitude = num.format(digits, "", "", 0).map_err(|error| match error {
+        pyre_object::rbigint::RBigIntError::Memory => crate::PyError::memory_error(""),
+        _ => unreachable!("validated radix formatting returned an unrelated error"),
+    })?;
+    if negative {
+        debug_assert!(magnitude.starts_with('-'));
+        magnitude.remove(0);
+    }
     if upper {
         magnitude.make_ascii_uppercase();
     }
-    let sign = if num.int_lt(0) {
+    let sign = if negative {
         "-"
     } else {
         match p.sign {
@@ -2447,10 +2462,16 @@ fn format_with_spec(val: PyObjectRef, spec: &Wtf8) -> Result<Wtf8Buf, crate::PyE
         // codes (`e`/`f`/`g`/`%`) format the `f64` conversion of the value.
         if pyre_object::is_int(val) || pyre_object::is_bool(val) || pyre_object::is_long(val) {
             let type_name = arg_type_name(val);
+            let owned;
             let big = if pyre_object::is_bool(val) {
-                BigInt::from(pyre_object::w_bool_get_value(val) as i64)
+                owned = BigInt::from(pyre_object::w_bool_get_value(val) as i64);
+                &owned
+            } else if pyre_object::is_int(val) {
+                owned = BigInt::from(pyre_object::w_int_get_value(val));
+                &owned
             } else {
-                crate::builtins::obj_to_bigint(val)
+                // newformat.py's `w_num.asbigint()` borrows `W_LongObject.num`.
+                pyre_object::w_long_get_value(val)
             };
             let parsed = FormatSpec::parse(spec);
             let p = parse_spec(spec);
@@ -2463,12 +2484,12 @@ fn format_with_spec(val: PyObjectRef, spec: &Wtf8) -> Result<Wtf8Buf, crate::PyE
                 ));
             }
             if spec.ends_with("c") && parsed.is_ok() {
-                return format_char(&big, spec);
+                return format_char(big, spec);
             }
             // A float presentation code formats the `f64` conversion (`n` and
             // the integer bases keep full integer precision instead).
             if matches!(p.ty, 'e' | 'E' | 'f' | 'F' | 'g' | 'G' | '%') {
-                let f = big.to_f64().unwrap_or(f64::INFINITY);
+                let f = pyre_object::jit_bigint_to_f64_or_inf(big);
                 if f.is_infinite() {
                     return Err(crate::PyError::overflow_error(
                         "int too large to convert to float",
@@ -2477,7 +2498,7 @@ fn format_with_spec(val: PyObjectRef, spec: &Wtf8) -> Result<Wtf8Buf, crate::PyE
                 return format_finite_float(f, spec);
             }
             parsed.map_err(|e| format_spec_err(e, spec, &type_name, true))?;
-            return format_rbigint(&big, spec, &type_name);
+            return format_rbigint(big, spec, &type_name);
         }
         if pyre_object::is_float(val) {
             let v = pyre_object::floatobject::w_float_get_value(val);
@@ -2734,20 +2755,21 @@ fn format_char(num: &BigInt, spec: &Wtf8) -> Result<Wtf8Buf, crate::PyError> {
             "Alternate form (#) not allowed with integer format specifier 'c'",
         ));
     }
-    let cp = match num.to_i64() {
+    if pyre_object::jit_bigint_to_i64_fits(num) == 0 {
+        return Err(crate::PyError::overflow_error(
+            "Python int too large to convert to C long",
+        ));
+    }
+    let cp = match u32::try_from(pyre_object::jit_bigint_to_i64_value(num))
+        .ok()
+        .and_then(CodePoint::from_u32)
+    {
+        Some(cp) => cp,
         None => {
             return Err(crate::PyError::overflow_error(
-                "Python int too large to convert to C long",
+                "%c arg not in range(0x110000)",
             ));
         }
-        Some(n) => match u32::try_from(n).ok().and_then(CodePoint::from_u32) {
-            Some(cp) => cp,
-            None => {
-                return Err(crate::PyError::overflow_error(
-                    "%c arg not in range(0x110000)",
-                ));
-            }
-        },
     };
     let mut body = Wtf8Buf::new();
     body.push(cp);

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -2006,11 +2006,14 @@ fn int_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     // small-int cache so each has its own identity). Set w_class = cls so
     // type()/isinstance() see the subclass while preserving the underlying
     // int/long storage layout for arithmetic. A magnitude that overflows
-    // i64 is a W_LongObject; cloning its BigInt keeps the value intact
-    // (w_int_get_value would truncate it to a garbage machine word).
+    // i64 is a W_LongObject; like PyPy's `W_LongObject(w_value.asbigint())`,
+    // the subtype wrapper shares the immutable rbigint payload.
     let obj = if unsafe { pyre_object::is_long(value) } {
-        let big = unsafe { pyre_object::w_long_get_value(value) }.clone();
-        pyre_object::w_long_new(big)
+        unsafe {
+            pyre_object::longobject::w_long_from_raw(pyre_object::longobject::w_long_get_raw_value(
+                value,
+            ))
+        }
     } else {
         let int_val = unsafe { pyre_object::w_int_get_value(value) };
         pyre_object::intobject::w_int_subclass_new(int_val)
@@ -8097,7 +8100,7 @@ fn slice_method_indices(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyEr
         pyre_object::sliceobject::w_slice_get_step(pyre_object::gc_roots::shadow_stack_get(roots))
     };
     let step = if unsafe { pyre_object::is_none(w_step) } {
-        one.clone()
+        one.translated_alias()
     } else {
         let step = slice_eval_index_big(w_step)?;
         if step == zero {
@@ -8107,14 +8110,14 @@ fn slice_method_indices(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyEr
     };
     let negative_step = step < zero;
     let lower = if negative_step {
-        -one.clone()
+        one.neg()
     } else {
-        zero.clone()
+        zero.translated_alias()
     };
     let upper = if negative_step {
         &length - &one
     } else {
-        length.clone()
+        length.translated_alias()
     };
 
     let w_start = unsafe {
@@ -8122,19 +8125,19 @@ fn slice_method_indices(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyEr
     };
     let start = if unsafe { pyre_object::is_none(w_start) } {
         if negative_step {
-            upper.clone()
+            upper.translated_alias()
         } else {
-            lower.clone()
+            lower.translated_alias()
         }
     } else {
         let mut start = slice_eval_index_big(w_start)?;
         if start < zero {
             start += &length;
             if start < lower {
-                start = lower.clone();
+                start = lower.translated_alias();
             }
         } else if start > upper {
-            start = upper.clone();
+            start = upper.translated_alias();
         }
         start
     };
@@ -13755,7 +13758,20 @@ fn init_int_type(ns: PyObjectRef) {
             make_builtin_function_with_arity(
                 "__sizeof__",
                 |args| {
-                    let bits = unsafe { crate::builtins::obj_to_bigint(args[0]).bits() } as usize;
+                    let bits = unsafe {
+                        if pyre_object::is_bool(args[0]) {
+                            pyre_object::rbigint::bit_length_int(pyre_object::w_bool_get_value(
+                                args[0],
+                            )
+                                as i64) as usize
+                        } else if pyre_object::is_int(args[0]) {
+                            pyre_object::rbigint::bit_length_int(pyre_object::w_int_get_value(
+                                args[0],
+                            )) as usize
+                        } else {
+                            pyre_object::w_long_get_value(args[0]).bits() as usize
+                        }
+                    };
                     // CPython 3.14's compact PyLong layout: three pointer-sized
                     // header words and at least one 30-bit, four-byte digit.
                     let digits = std::cmp::max(1, (bits + 29) / 30);
@@ -13789,12 +13805,16 @@ fn init_int_type(ns: PyObjectRef) {
                     // absolute value, so long/bigint operands must route
                     // through their magnitude rather than the i64 fast path
                     // (which leaves out-of-range values at 0).
-                    let bits = if !args.is_empty() && unsafe { pyre_object::is_int(args[0]) } {
+                    let bits = if !args.is_empty() && unsafe { pyre_object::is_bool(args[0]) } {
+                        pyre_object::rbigint::bit_length_int(unsafe {
+                            pyre_object::w_bool_get_value(args[0]) as i64
+                        }) as u64
+                    } else if !args.is_empty() && unsafe { pyre_object::is_int(args[0]) } {
                         pyre_object::rbigint::bit_length_int(unsafe {
                             pyre_object::w_int_get_value(args[0])
                         }) as u64
                     } else if !args.is_empty() && unsafe { pyre_object::is_long(args[0]) } {
-                        match unsafe { crate::builtins::obj_to_bigint(args[0]).bit_length() } {
+                        match unsafe { pyre_object::w_long_get_value(args[0]).bit_length() } {
                             Ok(bits) => bits as u64,
                             Err(pyre_object::rbigint::RBigIntError::Overflow) => {
                                 return Err(crate::PyError::overflow_error(
@@ -13828,11 +13848,15 @@ fn init_int_type(ns: PyObjectRef) {
                 |args| {
                     let count = if args.is_empty() {
                         0
+                    } else if unsafe { pyre_object::is_bool(args[0]) } {
+                        pyre_object::int_bit_count(unsafe {
+                            pyre_object::w_bool_get_value(args[0]) as i64
+                        })
                     } else if unsafe { pyre_object::is_int(args[0]) } {
                         // Small-int fast path — `@jit.elidable` `_bit_count`.
                         pyre_object::int_bit_count(unsafe { pyre_object::w_int_get_value(args[0]) })
                     } else if unsafe { pyre_object::pyobject::is_int_or_long(args[0]) } {
-                        match unsafe { crate::builtins::obj_to_bigint(args[0]).bit_count() } {
+                        match unsafe { pyre_object::w_long_get_value(args[0]).bit_count() } {
                             Ok(count) => count,
                             Err(pyre_object::rbigint::RBigIntError::Overflow) => {
                                 return Err(crate::PyError::overflow_error(
@@ -13883,12 +13907,19 @@ fn init_int_type(ns: PyObjectRef) {
                         pos.len() - 1
                     )));
                 }
-                let val = if !pos.is_empty()
-                    && unsafe { pyre_object::pyobject::is_int_or_long(pos[0]) }
-                {
-                    unsafe { crate::builtins::obj_to_bigint(pos[0]) }
+                let owned_val;
+                let val = if !pos.is_empty() && unsafe { pyre_object::is_bool(pos[0]) } {
+                    owned_val =
+                        BigInt::from(unsafe { pyre_object::w_bool_get_value(pos[0]) as i64 });
+                    &owned_val
+                } else if !pos.is_empty() && unsafe { pyre_object::is_int(pos[0]) } {
+                    owned_val = BigInt::from(unsafe { pyre_object::w_int_get_value(pos[0]) });
+                    &owned_val
+                } else if !pos.is_empty() && unsafe { pyre_object::is_long(pos[0]) } {
+                    unsafe { pyre_object::w_long_get_value(pos[0]) }
                 } else {
-                    BigInt::from(0)
+                    owned_val = BigInt::from(0);
+                    &owned_val
                 };
                 let length_obj = pos
                     .get(1)
@@ -13959,6 +13990,9 @@ fn init_int_type(ns: PyObjectRef) {
                             }
                             pyre_object::rbigint::RBigIntError::Overflow => {
                                 crate::PyError::overflow_error("int too big to convert")
+                            }
+                            pyre_object::rbigint::RBigIntError::Memory => {
+                                crate::PyError::memory_error("")
                             }
                             _ => unreachable!("rbigint.tobytes returned an unrelated error"),
                         })?;
@@ -18106,6 +18140,7 @@ fn int_from_bytes(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
                     pyre_object::rbigint::RBigIntError::InvalidEndianness => {
                         crate::PyError::value_error("byteorder must be either 'little' or 'big'")
                     }
+                    pyre_object::rbigint::RBigIntError::Memory => crate::PyError::memory_error(""),
                     _ => unreachable!("validated rbigint.frombytes returned an unrelated error"),
                 })?;
             pyre_object::w_long_new(value)

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -13931,6 +13931,14 @@ fn init_int_type(ns: PyObjectRef) {
                     .map(crate::baseobjspace::is_true)
                     .transpose()?
                     .unwrap_or(false);
+                // `rbigint.tobytes` skips its final sign-fit check when
+                // `nbytes == 0` (rbigint.py:450), and `-1` is the one value
+                // whose two's complement emits no bytes at all, so it falls
+                // through as `b''`.  `_PyLong_AsByteArray` rejects every
+                // nonzero value that does not fit the requested width.
+                if length_i == 0 && signed && val.get_sign() == -1 {
+                    return Err(crate::PyError::overflow_error("int too big to convert"));
+                }
                 // intobject.py:129-141 `descr_to_bytes`: route directly through
                 // rbigint.tobytes.  Besides preserving its exact exception
                 // contract, this is linear in the output length; shifting the

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -23410,7 +23410,7 @@ fn init_compress_type(ns: PyObjectRef) {
         (
             "__doc__",
             w_str_new(
-                "Return data elements corresponding to true selector elements.\n\nForms a shorter iterator from selected data elements using the selectors to\nchoose the data elements.",
+                "Return data elements corresponding to true selector elements.\n\nForms a shorter iterator from selected data elements using the selectors\nto choose the data elements.",
             ),
         ),
     ];

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -1765,6 +1765,10 @@ pub enum DispatchError {
     /// walker surfaces it as a typed abort that the production driver
     /// maps to `TraceAction::Abort` (recoverable — may retry later).
     AbortMarkerReached { pc: usize },
+    /// Record-time construction of a concrete shadow object failed after the
+    /// specialization had emitted IR. Falling through to the generic residual
+    /// would retain that partial prologue, so abort the whole walk.
+    ConcreteShadowAllocationFailed { pc: usize },
     /// `abort_permanent/` (BC_ABORT_PERMANENT) reached. pyre's codegen
     /// emits this for fail-paths that must always terminate the frame
     /// (e.g. BigInt-overflow / unported-op fallbacks). Blackhole
@@ -1975,6 +1979,7 @@ impl DispatchError {
             Self::VableArrayIndexOutOfRange { .. } => "VableArrayIndexOutOfRange",
             Self::VableArrayIndexNotConcrete { .. } => "VableArrayIndexNotConcrete",
             Self::AbortMarkerReached { .. } => "AbortMarkerReached",
+            Self::ConcreteShadowAllocationFailed { .. } => "ConcreteShadowAllocationFailed",
             Self::AbortPermanentMarkerReached { .. } => "AbortPermanentMarkerReached",
             Self::MayForceNullRefArgUnsupported { .. } => "MayForceNullRefArgUnsupported",
             Self::VableEscapedDuringResidualCall { .. } => "VableEscapedDuringResidualCall",
@@ -7132,6 +7137,37 @@ fn next_op_is_load_method_self_for_attr<Sym: WalkSym>(
 enum WalkerStoreAttrSpecialization {
     Residual(DescrRef, Vec<OpRef>),
     Direct,
+}
+
+/// The canonical Python class of an exact builtin operand, or `None` when it
+/// is a subclass instance or carries no `w_class` to pin.
+///
+/// A specialization that bypasses special-method lookup needs this at RECORD
+/// time to pick the class object its replay guard compares against.  PyPy has
+/// no equivalent step: `space.allocate_instance` gives an `int` subclass its
+/// own RPython class, so one `guard_class` already separates it from
+/// `W_IntObject`.  pyre shares the `ob_type` layout between the two and carries
+/// the Python-visible class in `w_class`, so `GuardClass` alone leaves a
+/// subclass free to reuse the trace and skip its `__floordiv__` / `__pow__` /
+/// `__lt__` override.
+///
+/// `is_exact_builtin_instance` also accepts a NULL `w_class`; that operand
+/// cannot be pinned by [`walker_guard_exact_w_class`], so it declines here
+/// rather than emitting a guard that would fail on its own recorded operand.
+///
+/// # Safety
+/// `obj` must be a non-null, untagged heap object.
+unsafe fn walker_exact_builtin_class(
+    obj: pyre_object::PyObjectRef,
+) -> Option<pyre_object::PyObjectRef> {
+    unsafe {
+        let w_class = (*obj).w_class;
+        if w_class.is_null() {
+            return None;
+        }
+        let canonical = pyre_object::pyobject::get_instantiate(&*(*obj).ob_type);
+        std::ptr::eq(w_class, canonical).then_some(canonical)
+    }
 }
 
 /// Walker-native mirror of the trait `trace_guard_exact_w_class`

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -890,8 +890,9 @@ pub struct FbwWalkMode<Sym: WalkSym> {
     /// jitcode in `walker_capture_snapshot_for_last_guard`.
     pub inline_subwalk: bool,
     /// The enclosing `w_list_append` fold took the Object strategy's in-place
-    /// arm, so the appended ref lands in a `SetarrayitemGc` the backend GC
-    /// rewrite already covers with `COND_CALL_GC_WB_ARRAY`
+    /// arm on a block that existed before this append, so the appended ref
+    /// lands in a `SetarrayitemGc` the backend GC rewrite already covers with
+    /// `COND_CALL_GC_WB_ARRAY`
     /// (`rewrite.py:936-944` `handle_write_barrier_setarrayitem`). The list's
     /// own `items` pointer is unchanged on that arm, so remembering the
     /// `W_ListObject` adds nothing the array barrier does not already do.
@@ -906,6 +907,10 @@ pub struct FbwWalkMode<Sym: WalkSym> {
     /// Carries the receiver address rather than a flag so only that list's
     /// barrier is dropped — a barrier reached for any other list inside the
     /// sub-walk is recorded normally.
+    ///
+    /// Never set for Empty->Object promotion: that transition also installs
+    /// the new block in `W_ListObject.items`, so the owner barrier is
+    /// load-bearing even though the subsequent element store is in-place.
     ///
     /// Only set while the items block is GC-managed. With
     /// `PYRE_GC_ITEMSBLOCK=0` the block is `std::alloc` memory with no GC

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -4142,6 +4142,15 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
                             )?;
                         }
                         if specialized.is_none() {
+                            // `_int_floordiv` / `_int_mod` are the same family:
+                            // an Int divisor keeps its machine word instead of
+                            // being widened to a bigint, and `_int_mod`'s
+                            // result is a machine int rather than a long.
+                            specialized = try_walker_specialize_binary_op_long_int_div(
+                                ctx, op.pc, op_tag, &r_args, &allboxes, call_descr, dst, dst_bank,
+                            )?;
+                        }
+                        if specialized.is_none() {
                             // W_LongObject operands take the long fast path
                             // before float so bigint arithmetic retains its
                             // payload representation.

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -3221,6 +3221,20 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
         return Ok((DispatchOutcome::Continue, op.next_pc));
     }
 
+    // `divmod(a, b)` on two exact ints: inline the guarded
+    // `OS_INT_PY_DIV` / `OS_INT_PY_MOD` pair into a virtual `Cls_ii`
+    // specialised tuple (intobject.py `_divmod` → `newtuple2`) instead of the
+    // opaque `bh_call_fn(divmod_builtin, NULL, a, b)` residual.  Pure like the
+    // `len` fold, so no sub-walk restriction; any non-matching shape falls
+    // through to the generic residual (SAFE).
+    if ctx.is_authoritative_executor
+        && dst_bank == 'r'
+        && ei.pyre_helper == majit_ir::PyreHelperKind::CallFn
+        && try_walker_specialize_builtin_divmod(ctx, code, op, &r_args, dst)?.is_some()
+    {
+        return Ok((DispatchOutcome::Continue, op.next_pc));
+    }
+
     // B3: a `raise Type(args)` of a canonical
     // builtin exception class arrives as two residuals — a `CallFn` that
     // constructs the exception, and a `RaiseVarargs`

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -3791,24 +3791,14 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
                 ctx.trace_ctx.box_value(idx_opref),
                 ctx.trace_ctx.box_value(code_opref),
             ) {
-                // Materialize the constant identically to the runtime
-                // `bh_load_const_fn` helper (call_jit.rs): a code constant reads
-                // the one shared wrapper off the virtualizable `pycode`'s
-                // `co_consts_w[index]`, other constants realize directly.
+                // Read the constant identically to the runtime
+                // `bh_load_const_fn`: every constant is the shared
+                // `pycode.co_consts_w[index]` object.
                 let w_const = unsafe {
-                    let w_code = pyre_interpreter::pycode::w_code_co_const(
+                    pyre_interpreter::pycode::w_code_const(
                         w_code_ptr as pyre_object::PyObjectRef,
                         consti as usize,
-                    );
-                    if !w_code.is_null() {
-                        w_code
-                    } else {
-                        let code = &*(pyre_interpreter::w_code_get_ptr(
-                            w_code_ptr as pyre_object::PyObjectRef,
-                        )
-                            as *const pyre_interpreter::CodeObject);
-                        pyre_interpreter::pyframe::load_const_from_code(code, consti as usize)
-                    }
+                    )
                 };
                 let const_box = ctx.trace_ctx.const_ref(w_const as i64);
                 write_residual_call_result_to_dst(ctx, op.pc, dst, dst_bank, const_box)?;

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -4151,6 +4151,14 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
                             )?;
                         }
                         if specialized.is_none() {
+                            // `descr_pow` keeps a `W_IntObject` exponent
+                            // unwrapped and calls `rbigint.int_pow`; only a
+                            // long exponent reaches `rbigint.pow`.
+                            specialized = try_walker_specialize_binary_op_long_int_pow(
+                                ctx, op.pc, op_tag, &r_args, &allboxes, call_descr, dst, dst_bank,
+                            )?;
+                        }
+                        if specialized.is_none() {
                             // W_LongObject operands take the long fast path
                             // before float so bigint arithmetic retains its
                             // payload representation.

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -740,6 +740,12 @@ pub(crate) fn try_walker_specialize_binary_op_long_int<Sym: WalkSym>(
         (Some(lhs), Some(rhs)) => (lhs, rhs),
         _ => return Ok(None),
     };
+    if pyre_object::tagged_int::CAN_BE_TAGGED
+        && (pyre_object::tagged_int::is_tagged_int(lhs_obj)
+            || pyre_object::tagged_int::is_tagged_int(rhs_obj))
+    {
+        return Ok(None);
+    }
     let (long, int, long_obj, int_obj) = unsafe {
         if pyre_object::is_long(lhs_obj) && pyre_object::is_int(rhs_obj) {
             (r_args[0], r_args[1], lhs_obj, rhs_obj)
@@ -749,12 +755,14 @@ pub(crate) fn try_walker_specialize_binary_op_long_int<Sym: WalkSym>(
             return Ok(None);
         }
     };
-    if unsafe {
-        !pyre_object::is_exact_builtin_instance(long_obj)
-            || !pyre_object::is_exact_builtin_instance(int_obj)
-    } {
+    let (Some(long_class), Some(int_class)) = (unsafe {
+        (
+            walker_exact_builtin_class(long_obj),
+            walker_exact_builtin_class(int_obj),
+        )
+    }) else {
         return Ok(None);
-    }
+    };
     let int_value = unsafe { pyre_object::w_int_get_value(int_obj) };
 
     let Some(boxed_result_i64) = walker_execute_may_force_boxed(ctx, allboxes, call_descr) else {
@@ -779,8 +787,10 @@ pub(crate) fn try_walker_specialize_binary_op_long_int<Sym: WalkSym>(
 
     let long_type_addr = &pyre_object::pyobject::LONG_TYPE as *const _ as i64;
     walker_guard_class(ctx, op_pc, long, long_type_addr)?;
+    walker_guard_exact_w_class(ctx, op_pc, long, long_class)?;
     let (int_type, int_descr) = crate::state::int_or_bool_unbox_type_descr(int_obj);
     let int_raw = walker_unbox_int_typed(ctx, op_pc, int, int_type, int_descr)?;
+    walker_guard_exact_w_class(ctx, op_pc, int, int_class)?;
     let off = pyre_object::longobject::LONG_VALUE_OFFSET;
     let long_payload = unsafe { *((long_obj as *const u8).add(off) as *const i64) };
     let long_pl = ctx.trace_ctx.record_op_with_descr(
@@ -895,15 +905,23 @@ pub(crate) fn try_walker_specialize_binary_op_long_int_div<Sym: WalkSym>(
     ) else {
         return Ok(None);
     };
-    let int_value = unsafe {
-        if !pyre_object::is_long(long_obj)
-            || !pyre_object::is_int(int_obj)
-            || !pyre_object::is_exact_builtin_instance(long_obj)
-            || !pyre_object::is_exact_builtin_instance(int_obj)
-        {
+    if pyre_object::tagged_int::CAN_BE_TAGGED
+        && (pyre_object::tagged_int::is_tagged_int(long_obj)
+            || pyre_object::tagged_int::is_tagged_int(int_obj))
+    {
+        return Ok(None);
+    }
+    let (long_class, int_class, int_value) = unsafe {
+        if !pyre_object::is_long(long_obj) || !pyre_object::is_int(int_obj) {
             return Ok(None);
         }
-        pyre_object::w_int_get_value(int_obj)
+        let (Some(long_class), Some(int_class)) = (
+            walker_exact_builtin_class(long_obj),
+            walker_exact_builtin_class(int_obj),
+        ) else {
+            return Ok(None);
+        };
+        (long_class, int_class, pyre_object::w_int_get_value(int_obj))
     };
     // The zero-divisor arm raises before calling rbigint. Record it through the
     // generic helper so no partial specialization is emitted.
@@ -947,8 +965,10 @@ pub(crate) fn try_walker_specialize_binary_op_long_int_div<Sym: WalkSym>(
 
     let long_type_addr = &pyre_object::pyobject::LONG_TYPE as *const _ as i64;
     walker_guard_class(ctx, op_pc, long, long_type_addr)?;
+    walker_guard_exact_w_class(ctx, op_pc, long, long_class)?;
     let (int_type, int_descr) = crate::state::int_or_bool_unbox_type_descr(int_obj);
     let int_raw = walker_unbox_int_typed(ctx, op_pc, int, int_type, int_descr)?;
+    walker_guard_exact_w_class(ctx, op_pc, int, int_class)?;
     let zero = ctx.trace_ctx.const_int(0);
     let nonzero = ctx.trace_ctx.record_op(OpCode::IntNe, &[int_raw, zero]);
     ctx.trace_ctx
@@ -1107,15 +1127,23 @@ pub(crate) fn try_walker_specialize_binary_op_long_int_pow<Sym: WalkSym>(
     ) else {
         return Ok(None);
     };
-    let exp_value = unsafe {
-        if !pyre_object::is_long(long_obj)
-            || !pyre_object::is_int(int_obj)
-            || !pyre_object::is_exact_builtin_instance(long_obj)
-            || !pyre_object::is_exact_builtin_instance(int_obj)
-        {
+    if pyre_object::tagged_int::CAN_BE_TAGGED
+        && (pyre_object::tagged_int::is_tagged_int(long_obj)
+            || pyre_object::tagged_int::is_tagged_int(int_obj))
+    {
+        return Ok(None);
+    }
+    let (long_class, int_class, exp_value) = unsafe {
+        if !pyre_object::is_long(long_obj) || !pyre_object::is_int(int_obj) {
             return Ok(None);
         }
-        pyre_object::w_int_get_value(int_obj)
+        let (Some(long_class), Some(int_class)) = (
+            walker_exact_builtin_class(long_obj),
+            walker_exact_builtin_class(int_obj),
+        ) else {
+            return Ok(None);
+        };
+        (long_class, int_class, pyre_object::w_int_get_value(int_obj))
     };
     // A non-positive exponent leaves through one of the short-circuits above
     // the `rbigint.int_pow` call; record those through the generic helper.
@@ -1146,8 +1174,10 @@ pub(crate) fn try_walker_specialize_binary_op_long_int_pow<Sym: WalkSym>(
 
     let long_type_addr = &pyre_object::pyobject::LONG_TYPE as *const _ as i64;
     walker_guard_class(ctx, op_pc, long, long_type_addr)?;
+    walker_guard_exact_w_class(ctx, op_pc, long, long_class)?;
     let (int_type, int_descr) = crate::state::int_or_bool_unbox_type_descr(int_obj);
     let exp_raw = walker_unbox_int_typed(ctx, op_pc, int, int_type, int_descr)?;
+    walker_guard_exact_w_class(ctx, op_pc, int, int_class)?;
     let zero = ctx.trace_ctx.const_int(0);
     let positive = ctx.trace_ctx.record_op(OpCode::IntGt, &[exp_raw, zero]);
     ctx.trace_ctx
@@ -3171,9 +3201,7 @@ pub(crate) fn try_walker_specialize_newtuple<Sym: WalkSym>(
         )?
     };
 
-    let Some(tuple) = walker_emit_specialised_tuple_ii(ctx, raw0, raw1, v0, v1) else {
-        return Ok(None);
-    };
+    let tuple = walker_emit_specialised_tuple_ii(ctx, op_pc, raw0, raw1, v0, v1)?;
     write_residual_call_result_to_dst(ctx, op_pc, dst, dst_bank, tuple)?;
     Ok(Some(()))
 }
@@ -3186,15 +3214,17 @@ pub(crate) fn try_walker_specialize_newtuple<Sym: WalkSym>(
 /// partner unpack fold reads back (`walker_concrete_ref_object` +
 /// `unpack_item_fn`).  The shadow is constructed LAST so the construct→root
 /// window holds no intervening runtime allocation: stamping `tuple`'s concrete
-/// roots the fresh spec_ii via the trace's concrete-shadow set.  Returns
-/// `None` only when that allocation fails.
+/// roots the fresh spec_ii via the trace's concrete-shadow set. A concrete
+/// allocation failure aborts the whole walk because the virtual allocation
+/// and stores have already been recorded.
 fn walker_emit_specialised_tuple_ii<Sym: WalkSym>(
     ctx: &mut WalkContext<'_, '_, Sym>,
+    op_pc: usize,
     raw0: OpRef,
     raw1: OpRef,
     v0: i64,
     v1: i64,
-) -> Option<OpRef> {
+) -> Result<OpRef, DispatchError> {
     let tuple = ctx.trace_ctx.record_op_with_descr(
         OpCode::NewWithVtable,
         &[],
@@ -3230,13 +3260,13 @@ fn walker_emit_specialised_tuple_ii<Sym: WalkSym>(
     }
     let tuple_ptr = pyre_object::specialisedtupleobject::w_specialised_tuple_ii_new(v0, v1);
     if tuple_ptr.is_null() {
-        return None;
+        return Err(DispatchError::ConcreteShadowAllocationFailed { pc: op_pc });
     }
     ctx.trace_ctx.set_opref_concrete(
         tuple,
         majit_ir::Value::Ref(majit_ir::GcRef(tuple_ptr as usize)),
     );
-    Some(tuple)
+    Ok(tuple)
 }
 
 /// #57 SLICE 3b: walker-native speculative int specialization for the
@@ -4835,10 +4865,8 @@ pub(crate) fn try_walker_specialize_builtin_divmod<Sym: WalkSym>(
     walker_emit_int_div_domain_guards(ctx, op.pc, lhs_raw, rhs_raw, la, rb)?;
     let (div_raw, div_value) = walker_emit_int_py_div_or_mod(ctx, lhs_raw, rhs_raw, la, rb, true);
     let (mod_raw, mod_value) = walker_emit_int_py_div_or_mod(ctx, lhs_raw, rhs_raw, la, rb, false);
-    let Some(tuple) = walker_emit_specialised_tuple_ii(ctx, div_raw, mod_raw, div_value, mod_value)
-    else {
-        return Ok(None);
-    };
+    let tuple =
+        walker_emit_specialised_tuple_ii(ctx, op.pc, div_raw, mod_raw, div_value, mod_value)?;
     write_residual_call_result_to_dst(ctx, op.pc, dst, 'r', tuple)?;
     Ok(Some(()))
 }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -1287,15 +1287,17 @@ pub(crate) fn try_walker_specialize_binary_op_long_int_shift<Sym: WalkSym>(
     ) else {
         return Ok(None);
     };
-    let rhs_value = unsafe {
-        if !pyre_object::is_long(lhs_obj)
-            || !pyre_object::is_int(rhs_obj)
-            || !pyre_object::is_exact_builtin_instance(lhs_obj)
-            || !pyre_object::is_exact_builtin_instance(rhs_obj)
-        {
+    let (lhs_class, rhs_class, rhs_value) = unsafe {
+        if !pyre_object::is_long(lhs_obj) || !pyre_object::is_int(rhs_obj) {
             return Ok(None);
         }
-        pyre_object::w_int_get_value(rhs_obj)
+        let (Some(lhs_class), Some(rhs_class)) = (
+            walker_exact_builtin_class(lhs_obj),
+            walker_exact_builtin_class(rhs_obj),
+        ) else {
+            return Ok(None);
+        };
+        (lhs_class, rhs_class, pyre_object::w_int_get_value(rhs_obj))
     };
     // The negative-count arm raises before calling rbigint.  Record it through
     // the generic helper so no partial specialization is emitted.
@@ -1328,8 +1330,10 @@ pub(crate) fn try_walker_specialize_binary_op_long_int_shift<Sym: WalkSym>(
 
     let long_type_addr = &pyre_object::pyobject::LONG_TYPE as *const _ as i64;
     walker_guard_class(ctx, op_pc, lhs, long_type_addr)?;
+    walker_guard_exact_w_class(ctx, op_pc, lhs, lhs_class)?;
     let (rhs_type, rhs_descr) = crate::state::int_or_bool_unbox_type_descr(rhs_obj);
     let rhs_raw = walker_unbox_int_typed(ctx, op_pc, rhs, rhs_type, rhs_descr)?;
+    walker_guard_exact_w_class(ctx, op_pc, rhs, rhs_class)?;
     let zero = ctx.trace_ctx.const_int(0);
     let nonnegative = ctx.trace_ctx.record_op(OpCode::IntGe, &[rhs_raw, zero]);
     ctx.trace_ctx
@@ -1452,6 +1456,14 @@ pub(crate) fn try_walker_specialize_binary_op_long<Sym: WalkSym>(
     if !unsafe { pyre_object::is_long(lhs_obj) && pyre_object::is_long(rhs_obj) } {
         return Ok(None);
     }
+    let (Some(lhs_class), Some(rhs_class)) = (unsafe {
+        (
+            walker_exact_builtin_class(lhs_obj),
+            walker_exact_builtin_class(rhs_obj),
+        )
+    }) else {
+        return Ok(None);
+    };
     // Authentic boxed result via the same execute path the int leg uses; a
     // NULL / raised result defers to the generic record.
     let Some(boxed_result_i64) = walker_execute_may_force_boxed(ctx, allboxes, call_descr) else {
@@ -1480,6 +1492,8 @@ pub(crate) fn try_walker_specialize_binary_op_long<Sym: WalkSym>(
     let long_type_addr = &pyre_object::pyobject::LONG_TYPE as *const _ as i64;
     walker_guard_class(ctx, op_pc, lhs, long_type_addr)?;
     walker_guard_class(ctx, op_pc, rhs, long_type_addr)?;
+    walker_guard_exact_w_class(ctx, op_pc, lhs, lhs_class)?;
+    walker_guard_exact_w_class(ctx, op_pc, rhs, rhs_class)?;
     // Read each operand's immutable `value` payload, then call the
     // elidable `rbigint` op on the bare `*const BigInt` payloads. Passing
     // the payloads (not the wrappers) keeps the call pure on the immutable
@@ -1620,6 +1634,14 @@ pub(crate) fn try_walker_specialize_truediv_op_long<Sym: WalkSym>(
     if !unsafe { pyre_object::is_long(lhs_obj) && pyre_object::is_long(rhs_obj) } {
         return Ok(None);
     }
+    let (Some(lhs_class), Some(rhs_class)) = (unsafe {
+        (
+            walker_exact_builtin_class(lhs_obj),
+            walker_exact_builtin_class(rhs_obj),
+        )
+    }) else {
+        return Ok(None);
+    };
     // Authentic boxed float via the generic execute path; a NULL / raised result
     // (zero divisor, float overflow) defers to the generic record.
     let Some(boxed_result_i64) = walker_execute_may_force_boxed(ctx, allboxes, call_descr) else {
@@ -1628,6 +1650,8 @@ pub(crate) fn try_walker_specialize_truediv_op_long<Sym: WalkSym>(
     let long_type_addr = &pyre_object::pyobject::LONG_TYPE as *const _ as i64;
     walker_guard_class(ctx, op_pc, lhs, long_type_addr)?;
     walker_guard_class(ctx, op_pc, rhs, long_type_addr)?;
+    walker_guard_exact_w_class(ctx, op_pc, lhs, lhs_class)?;
+    walker_guard_exact_w_class(ctx, op_pc, rhs, rhs_class)?;
     // Pure `rbigint.truediv` → correctly-rounded f64 (CallPureF). The op already
     // ran authentically above, so the divisor is nonzero / non-overflowing here;
     // the trailing GuardNoException covers a divide-by-zero / overflow on replay.
@@ -3631,12 +3655,14 @@ pub(crate) fn try_walker_specialize_compare_op_long_int<Sym: WalkSym>(
     } else {
         return Ok(None);
     };
-    if unsafe {
-        !pyre_object::is_exact_builtin_instance(long_obj)
-            || !pyre_object::is_exact_builtin_instance(int_obj)
-    } {
+    let (Some(long_class), Some(int_class)) = (unsafe {
+        (
+            walker_exact_builtin_class(long_obj),
+            walker_exact_builtin_class(int_obj),
+        )
+    }) else {
         return Ok(None);
-    }
+    };
     let effective_cmp = if reflected {
         match cmp_op {
             ComparisonOperator::Less => ComparisonOperator::Greater,
@@ -3672,8 +3698,10 @@ pub(crate) fn try_walker_specialize_compare_op_long_int<Sym: WalkSym>(
 
     let long_type_addr = &pyre_object::pyobject::LONG_TYPE as *const _ as i64;
     walker_guard_class(ctx, op_pc, long, long_type_addr)?;
+    walker_guard_exact_w_class(ctx, op_pc, long, long_class)?;
     let (int_type, int_descr) = crate::state::int_or_bool_unbox_type_descr(int_obj);
     let int_raw = walker_unbox_int_typed(ctx, op_pc, int, int_type, int_descr)?;
+    walker_guard_exact_w_class(ctx, op_pc, int, int_class)?;
     let off = pyre_object::longobject::LONG_VALUE_OFFSET;
     let long_payload = unsafe { *((long_obj as *const u8).add(off) as *const i64) };
     let long_pl = ctx.trace_ctx.record_op_with_descr(
@@ -3763,6 +3791,14 @@ pub(crate) fn try_walker_specialize_compare_op_long<Sym: WalkSym>(
     if !unsafe { pyre_object::is_long(lhs_obj) && pyre_object::is_long(rhs_obj) } {
         return Ok(None);
     }
+    let (Some(lhs_class), Some(rhs_class)) = (unsafe {
+        (
+            walker_exact_builtin_class(lhs_obj),
+            walker_exact_builtin_class(rhs_obj),
+        )
+    }) else {
+        return Ok(None);
+    };
     // Authentic boxed W_Bool via the same execute path the int leg uses; also
     // advances the concrete VM state the downstream ops read.
     let Some(boxed_result_i64) = walker_execute_may_force_boxed(ctx, allboxes, call_descr) else {
@@ -3771,6 +3807,8 @@ pub(crate) fn try_walker_specialize_compare_op_long<Sym: WalkSym>(
     let long_type_addr = &pyre_object::pyobject::LONG_TYPE as *const _ as i64;
     walker_guard_class(ctx, op_pc, lhs, long_type_addr)?;
     walker_guard_class(ctx, op_pc, rhs, long_type_addr)?;
+    walker_guard_exact_w_class(ctx, op_pc, lhs, lhs_class)?;
+    walker_guard_exact_w_class(ctx, op_pc, rhs, rhs_class)?;
     // Pure `rbigint` comparison → sign in {-1,0,1}. Dead after the `int_<cmp>`
     // below and never spans a guard, so it needs no blackhole reconstruction.
     let cmp_fn = pyre_object::longobject::jit_w_long_cmp as *const ();

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -5356,10 +5356,15 @@ pub(crate) fn orthodox_list_append_commit<Sym: WalkSym>(
     let saved_fbw_mode = ctx.fbw_mode;
     ctx.fbw_mode.inline_subwalk = true;
     // Read the arm AFTER any empty-strategy promotion above, so the predicate
-    // sees the storage the sub-walk will actually append into.
-    ctx.fbw_mode.append_inplace_wb_covered_receiver =
-        unsafe { pyre_object::w_list_append_stores_into_gc_block_in_place(inner_self) }
-            .then_some(inner_self as usize);
+    // sees the storage the sub-walk will actually append into.  An
+    // Empty->Object promotion is not the pre-existing-block in-place case:
+    // it has just installed a young `items` block into the (possibly old)
+    // list wrapper.  Keep the body's `list_write_barrier` for that transition;
+    // only an append whose Object block predated this append is covered solely
+    // by the SetarrayitemGc array barrier.
+    ctx.fbw_mode.append_inplace_wb_covered_receiver = (!promote_empty
+        && unsafe { pyre_object::w_list_append_stores_into_gc_block_in_place(inner_self) })
+    .then_some(inner_self as usize);
     let walk_result = run_sub_jitcode_walk(
         ctx,
         op.pc,

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -563,53 +563,15 @@ pub(crate) fn try_walker_specialize_binary_op_int<Sym: WalkSym>(
     }
     let (raw_result, concrete_value) = match op_code {
         OpCode::IntFloorDiv | OpCode::IntMod => {
-            // rint.py _ovf_zer guards: int_eq(rhs,0)→guard_false +
-            // (lhs==INT_MIN)&(rhs==-1)→guard_false ahead of the elidable
-            // helper call (so a re-used trace bails before the helper's
-            // wrapping_div / wrapping_rem returns a wrap value).
-            let rhs_zero = walker_int_eq_const(ctx, rhs_raw, 0, (rb == 0) as i64);
-            walker_emit_guard_with_snapshot(ctx, op_pc, OpCode::GuardFalse, &[rhs_zero])?;
-            let lhs_is_min = walker_int_eq_const(ctx, lhs_raw, i64::MIN, (la == i64::MIN) as i64);
-            let rhs_is_neg_one = walker_int_eq_const(ctx, rhs_raw, -1, (rb == -1) as i64);
-            let ovf_both = ctx
-                .trace_ctx
-                .record_op(OpCode::IntAnd, &[lhs_is_min, rhs_is_neg_one]);
-            ctx.trace_ctx.set_opref_concrete(
-                ovf_both,
-                majit_ir::Value::Int(((la == i64::MIN) as i64) & ((rb == -1) as i64)),
-            );
-            walker_emit_guard_with_snapshot(ctx, op_pc, OpCode::GuardFalse, &[ovf_both])?;
-            // jtransform.py OS_INT_PY_DIV / OS_INT_PY_MOD elidable
-            // residual call (call_typed_with_effect_pure → CallI patched via
-            // record_result_of_call_pure).
-            let (func_ptr, effect_info, concrete_result) = if op_code == OpCode::IntFloorDiv {
-                (
-                    majit_metainterp::blackhole::ll_int_py_div as *const (),
-                    majit_metainterp::INT_PY_DIV_EFFECT_INFO,
-                    majit_metainterp::blackhole::ll_int_py_div(la, rb),
-                )
-            } else {
-                (
-                    majit_metainterp::blackhole::ll_int_py_mod as *const (),
-                    majit_metainterp::INT_PY_MOD_EFFECT_INFO,
-                    majit_metainterp::blackhole::ll_int_py_mod(la, rb),
-                )
-            };
-            let r = ctx.trace_ctx.call_typed_with_effect_pure(
-                OpCode::CallI,
-                func_ptr,
-                &[lhs_raw, rhs_raw],
-                &[majit_ir::Type::Int, majit_ir::Type::Int],
-                majit_ir::Type::Int,
-                effect_info,
-                &[
-                    majit_ir::Value::Int(func_ptr as usize as i64),
-                    majit_ir::Value::Int(la),
-                    majit_ir::Value::Int(rb),
-                ],
-                majit_ir::Value::Int(concrete_result),
-            );
-            (r, concrete_result)
+            walker_emit_int_div_domain_guards(ctx, op_pc, lhs_raw, rhs_raw, la, rb)?;
+            walker_emit_int_py_div_or_mod(
+                ctx,
+                lhs_raw,
+                rhs_raw,
+                la,
+                rb,
+                op_code == OpCode::IntFloorDiv,
+            )
         }
         OpCode::IntRshift => {
             // The machine SAR masks the count mod 64, so guard the count into
@@ -650,6 +612,78 @@ pub(crate) fn try_walker_specialize_binary_op_int<Sym: WalkSym>(
     ctx.trace_ctx.set_opref_concrete(boxed, boxed_concrete);
     write_residual_call_result_to_dst(ctx, op_pc, dst, dst_bank, boxed)?;
     Ok(Some(()))
+}
+
+/// rint.py `_ovf_zer` guards for a machine-int division: `int_eq(rhs,0)` →
+/// `guard_false` plus `(lhs==INT_MIN)&(rhs==-1)` → `guard_false`.  Both must
+/// precede the elidable `ll_int_py_div` / `ll_int_py_mod` call so a re-used
+/// trace bails before the helper's `wrapping_div` / `wrapping_rem` returns a
+/// wrap value.  A `divmod` site shares one guard pair across both halves.
+fn walker_emit_int_div_domain_guards<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    op_pc: usize,
+    lhs_raw: OpRef,
+    rhs_raw: OpRef,
+    la: i64,
+    rb: i64,
+) -> Result<(), DispatchError> {
+    let rhs_zero = walker_int_eq_const(ctx, rhs_raw, 0, (rb == 0) as i64);
+    walker_emit_guard_with_snapshot(ctx, op_pc, OpCode::GuardFalse, &[rhs_zero])?;
+    let lhs_is_min = walker_int_eq_const(ctx, lhs_raw, i64::MIN, (la == i64::MIN) as i64);
+    let rhs_is_neg_one = walker_int_eq_const(ctx, rhs_raw, -1, (rb == -1) as i64);
+    let ovf_both = ctx
+        .trace_ctx
+        .record_op(OpCode::IntAnd, &[lhs_is_min, rhs_is_neg_one]);
+    ctx.trace_ctx.set_opref_concrete(
+        ovf_both,
+        majit_ir::Value::Int(((la == i64::MIN) as i64) & ((rb == -1) as i64)),
+    );
+    walker_emit_guard_with_snapshot(ctx, op_pc, OpCode::GuardFalse, &[ovf_both])
+}
+
+/// jtransform.py `OS_INT_PY_DIV` / `OS_INT_PY_MOD` elidable residual call
+/// (`call_typed_with_effect_pure` → `CallI` patched via
+/// `record_result_of_call_pure`), returning the result op and its recorded
+/// value.  The caller must have emitted
+/// [`walker_emit_int_div_domain_guards`] over the same operand pair first.
+fn walker_emit_int_py_div_or_mod<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    lhs_raw: OpRef,
+    rhs_raw: OpRef,
+    la: i64,
+    rb: i64,
+    is_div: bool,
+) -> (OpRef, i64) {
+    let (func_ptr, effect_info, concrete_result) = if is_div {
+        (
+            majit_metainterp::blackhole::ll_int_py_div as *const (),
+            majit_metainterp::INT_PY_DIV_EFFECT_INFO,
+            majit_metainterp::blackhole::ll_int_py_div(la, rb),
+        )
+    } else {
+        (
+            majit_metainterp::blackhole::ll_int_py_mod as *const (),
+            majit_metainterp::INT_PY_MOD_EFFECT_INFO,
+            majit_metainterp::blackhole::ll_int_py_mod(la, rb),
+        )
+    };
+    let r = ctx.trace_ctx.call_typed_with_effect_pure(
+        OpCode::CallI,
+        func_ptr,
+        &[lhs_raw, rhs_raw],
+        &[majit_ir::Type::Int, majit_ir::Type::Int],
+        majit_ir::Type::Int,
+        effect_info,
+        &[
+            majit_ir::Value::Int(func_ptr as usize as i64),
+            majit_ir::Value::Int(la),
+            majit_ir::Value::Int(rb),
+        ],
+        majit_ir::Value::Int(concrete_result),
+    );
+    ctx.trace_ctx
+        .set_opref_concrete(r, majit_ir::Value::Int(concrete_result));
+    (r, concrete_result)
 }
 
 /// Walker-native mixed `W_LongObject` / `W_IntObject` arithmetic
@@ -3137,6 +3171,30 @@ pub(crate) fn try_walker_specialize_newtuple<Sym: WalkSym>(
         )?
     };
 
+    let Some(tuple) = walker_emit_specialised_tuple_ii(ctx, raw0, raw1, v0, v1) else {
+        return Ok(None);
+    };
+    write_residual_call_result_to_dst(ctx, op_pc, dst, dst_bank, tuple)?;
+    Ok(Some(()))
+}
+
+/// Emit the virtual `Cls_ii` arity-2 int tuple (`makespecialisedtuple2`,
+/// specialisedtupleobject.py) walker-native: `new_with_vtable` + the `w_class`
+/// / `value0` / `value1` `setfield_gc`s over the two raw int payloads.
+///
+/// `v0` / `v1` are the recorded payloads; they build the concrete shadow the
+/// partner unpack fold reads back (`walker_concrete_ref_object` +
+/// `unpack_item_fn`).  The shadow is constructed LAST so the construct→root
+/// window holds no intervening runtime allocation: stamping `tuple`'s concrete
+/// roots the fresh spec_ii via the trace's concrete-shadow set.  Returns
+/// `None` only when that allocation fails.
+fn walker_emit_specialised_tuple_ii<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    raw0: OpRef,
+    raw1: OpRef,
+    v0: i64,
+    v1: i64,
+) -> Option<OpRef> {
     let tuple = ctx.trace_ctx.record_op_with_descr(
         OpCode::NewWithVtable,
         &[],
@@ -3160,43 +3218,25 @@ pub(crate) fn try_walker_specialize_newtuple<Sym: WalkSym>(
             wc,
         );
     }
-    ctx.trace_ctx.record_op_with_descr(
-        OpCode::SetfieldGc,
-        &[tuple, raw0],
-        crate::descr::specialised_tuple_ii_value0_descr(),
-    );
-    ctx.trace_ctx.heapcache_setfield_cached(
-        tuple,
-        crate::descr::specialised_tuple_ii_value0_descr().index(),
-        raw0,
-    );
-    ctx.trace_ctx.record_op_with_descr(
-        OpCode::SetfieldGc,
-        &[tuple, raw1],
-        crate::descr::specialised_tuple_ii_value1_descr(),
-    );
-    ctx.trace_ctx.heapcache_setfield_cached(
-        tuple,
-        crate::descr::specialised_tuple_ii_value1_descr().index(),
-        raw1,
-    );
-    // Concrete spec_ii shadow for the dst (read by the partner unpack fold's
-    // `walker_concrete_ref_object` + `unpack_item_fn` execution).  Built
-    // directly from the element payloads — `newtuple_from_array(arr)` cannot
-    // be executed concretely (the virtual array `arr` has no concrete
-    // shadow).  Constructed last so the construct→root window holds no
-    // intervening runtime allocation: stamping `tuple`'s concrete roots the
-    // fresh spec_ii via the trace's concrete-shadow set.
+    for (raw, descr) in [
+        (raw0, crate::descr::specialised_tuple_ii_value0_descr()),
+        (raw1, crate::descr::specialised_tuple_ii_value1_descr()),
+    ] {
+        let descr_index = descr.index();
+        ctx.trace_ctx
+            .record_op_with_descr(OpCode::SetfieldGc, &[tuple, raw], descr);
+        ctx.trace_ctx
+            .heapcache_setfield_cached(tuple, descr_index, raw);
+    }
     let tuple_ptr = pyre_object::specialisedtupleobject::w_specialised_tuple_ii_new(v0, v1);
     if tuple_ptr.is_null() {
-        return Ok(None);
+        return None;
     }
     ctx.trace_ctx.set_opref_concrete(
         tuple,
         majit_ir::Value::Ref(majit_ir::GcRef(tuple_ptr as usize)),
     );
-    write_residual_call_result_to_dst(ctx, op_pc, dst, dst_bank, tuple)?;
-    Ok(Some(()))
+    Some(tuple)
 }
 
 /// #57 SLICE 3b: walker-native speculative int specialization for the
@@ -4664,6 +4704,142 @@ pub(crate) fn try_walker_specialize_float_call<Sym: WalkSym>(
         walker_guard_exact_w_class(ctx, op.pc, arg_op, float_type_obj)?;
         write_residual_call_result_to_dst(ctx, op.pc, dst, 'r', arg_op)?;
     }
+    Ok(Some(()))
+}
+
+/// `divmod(a, b)` on two exact `W_IntObject` operands: emit the inline pair
+/// shape the meta-tracer produces upstream (intobject.py `_divmod` →
+/// `space.newtuple2(space.newint(z), space.newint(m))`) instead of the opaque
+/// `bh_call_fn(divmod_builtin, NULL, a, b)` residual.
+///
+/// The divmod row rejects a zero divisor before dispatching, so the trace
+/// carries the same domain guards the `//` / `%` specialization emits, then
+/// runs the two `OS_INT_PY_DIV` / `OS_INT_PY_MOD` elidable calls over one
+/// guarded operand pair.  The result is the virtual `Cls_ii` specialised
+/// tuple, so a `q, r = divmod(...)` site pairs with
+/// [`try_walker_specialize_unpack`] and the tuple never materializes.
+///
+/// The exact `w_class` guard is required because an `int` SUBCLASS shares
+/// `ob_type == &INT_TYPE` but may override `__divmod__`; it side-exits to the
+/// generic residual.
+///
+/// Returns `None` (fall through to the generic residual, SAFE) for any other
+/// shape: wrong arity, a bound receiver, a non-`divmod` callable, an operand
+/// that is not an exact `int` (long / float / bool / subclass), a tagged
+/// immediate, a zero divisor, or the `INT_MIN // -1` pair that escapes to a
+/// bigint result.
+pub(crate) fn try_walker_specialize_builtin_divmod<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    code: &[u8],
+    op: &DecodedOp,
+    r_args: &[OpRef],
+    dst: usize,
+) -> Result<Option<()>, DispatchError> {
+    // Plain `bh_call_fn(callable, PY_NULL, a, b)` shape only.
+    if r_args.len() != 4 {
+        return Ok(None);
+    }
+    let arg_concretes = read_ref_var_list_concrete(code, op, 1, ctx);
+    let (
+        ConcreteValue::Ref(concrete_callable),
+        ConcreteValue::Ref(null_or_self),
+        ConcreteValue::Ref(lhs_obj),
+        ConcreteValue::Ref(rhs_obj),
+    ) = (
+        arg_concretes[0],
+        arg_concretes[1],
+        arg_concretes[2],
+        arg_concretes[3],
+    )
+    else {
+        return Ok(None);
+    };
+    // A non-null `null_or_self` is a bound receiver `bh_call_fn_impl`
+    // prepends as arg0 — not a plain `divmod(a, b)` call.
+    if concrete_callable.is_null()
+        || !null_or_self.is_null()
+        || lhs_obj.is_null()
+        || rhs_obj.is_null()
+    {
+        return Ok(None);
+    }
+    if !pyre_interpreter::builtins::is_builtin_divmod_function(concrete_callable) {
+        return Ok(None);
+    }
+    // A tagged immediate has no real header for the `w_class` / unbox guards
+    // and this emit is not tag-aware, so decline it to the residual.
+    if pyre_object::tagged_int::CAN_BE_TAGGED
+        && (pyre_object::tagged_int::is_tagged_int(lhs_obj)
+            || pyre_object::tagged_int::is_tagged_int(rhs_obj))
+    {
+        return Ok(None);
+    }
+    let int_typeobj = pyre_object::pyobject::get_instantiate(&pyre_object::pyobject::INT_TYPE);
+    let (la, rb) = unsafe {
+        let is_exact_int = |o: pyre_object::PyObjectRef| {
+            std::ptr::eq((*o).ob_type, &pyre_object::pyobject::INT_TYPE)
+                && std::ptr::eq((*o).w_class, int_typeobj)
+        };
+        if !is_exact_int(lhs_obj) || !is_exact_int(rhs_obj) {
+            return Ok(None);
+        }
+        (
+            pyre_object::w_int_get_value(lhs_obj),
+            pyre_object::w_int_get_value(rhs_obj),
+        )
+    };
+    // A zero divisor raises ZeroDivisionError and `INT_MIN // -1` escapes to
+    // the bigint pair; both are outside the guarded domain the emit below
+    // covers, so decline rather than record a guard the recorded operands
+    // already fail.
+    if rb == 0 || (la == i64::MIN && rb == -1) {
+        return Ok(None);
+    }
+
+    // --- emit the specialized IR (walker-native) ---
+    // Pin the callable identity (LOAD_GLOBAL `divmod` is usually already a
+    // constant via the namespace cell fold).
+    let callable_op = r_args[0];
+    if !callable_op.is_constant() {
+        let expected = ctx.trace_ctx.const_ref(concrete_callable as i64);
+        ctx.trace_ctx
+            .record_guard(OpCode::GuardValue, &[callable_op, expected], 0);
+        walker_capture_snapshot_for_last_guard(ctx, op.pc)?;
+        ctx.trace_ctx
+            .heap_cache_mut()
+            .replace_box(callable_op, expected);
+    }
+    let (lhs_op, rhs_op) = (r_args[2], r_args[3]);
+    let int_type_addr = &pyre_object::pyobject::INT_TYPE as *const _ as i64;
+    // `GuardClass` before the `w_class` read: it is the guard that proves the
+    // operand is a real heap header rather than a tagged immediate, so it has
+    // to precede any `getfield` off that header.
+    walker_guard_class(ctx, op.pc, lhs_op, int_type_addr)?;
+    walker_guard_class(ctx, op.pc, rhs_op, int_type_addr)?;
+    walker_guard_exact_w_class(ctx, op.pc, lhs_op, int_typeobj)?;
+    walker_guard_exact_w_class(ctx, op.pc, rhs_op, int_typeobj)?;
+    let lhs_raw = walker_unbox_int_typed(
+        ctx,
+        op.pc,
+        lhs_op,
+        int_type_addr,
+        crate::descr::int_intval_descr(),
+    )?;
+    let rhs_raw = walker_unbox_int_typed(
+        ctx,
+        op.pc,
+        rhs_op,
+        int_type_addr,
+        crate::descr::int_intval_descr(),
+    )?;
+    walker_emit_int_div_domain_guards(ctx, op.pc, lhs_raw, rhs_raw, la, rb)?;
+    let (div_raw, div_value) = walker_emit_int_py_div_or_mod(ctx, lhs_raw, rhs_raw, la, rb, true);
+    let (mod_raw, mod_value) = walker_emit_int_py_div_or_mod(ctx, lhs_raw, rhs_raw, la, rb, false);
+    let Some(tuple) = walker_emit_specialised_tuple_ii(ctx, div_raw, mod_raw, div_value, mod_value)
+    else {
+        return Ok(None);
+    };
+    write_residual_call_result_to_dst(ctx, op.pc, dst, 'r', tuple)?;
     Ok(Some(()))
 }
 

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -808,6 +808,217 @@ pub(crate) fn try_walker_specialize_binary_op_long_int<Sym: WalkSym>(
     Ok(Some(()))
 }
 
+/// Walker-native `W_LongObject // W_IntObject` / `%` specialization for the
+/// `BINARY_OP` helper residual_call.
+///
+/// `pypy/objspace/std/longobject.py:424,441 _make_descr_binop` selects
+/// `_int_floordiv` / `_int_mod` when the right operand is a `W_IntObject`.
+/// The two legs differ in their *result* representation, and that difference
+/// is the whole point of specialising them apart:
+///   * `_int_floordiv` (`longobject.py:417-423`) → `rbigint.int_floordiv` →
+///     a bigint quotient, boxed as a `W_LongObject` — the same shape
+///     [`try_walker_specialize_binary_op_long_int_shift`] emits.
+///   * `_int_mod` (`longobject.py:434-440`) → `rbigint.int_mod_int_result` →
+///     `space.newint`: the remainder of a long by a machine int always fits a
+///     machine int, so this leg allocates **no** result bigint and boxes a
+///     plain `W_IntObject`.
+///
+/// `long_floordiv` / `long_mod` (`descroperation.rs`) raise
+/// `ZeroDivisionError` before reaching the `_nonzero` rbigint seam, so the
+/// divisor test is traced as a `GUARD_TRUE(int_ne(divisor, 0))` — the guard a
+/// meta-tracer records for that interpreter branch. A replay with a zero
+/// divisor therefore bails to the interpreter, which raises the authentic
+/// error rather than re-deriving its wording here.
+///
+/// `int // long` and `int % long` are `descr_rfloordiv` / `descr_rmod`, which
+/// coerce the left operand to a long and take the bigint/bigint path; they are
+/// deliberately left to [`try_walker_specialize_binary_op_long`].
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn try_walker_specialize_binary_op_long_int_div<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    op_pc: usize,
+    op_tag: i64,
+    r_args: &[OpRef],
+    allboxes: &[OpRef],
+    call_descr: &dyn majit_ir::descr::CallDescr,
+    dst: usize,
+    dst_bank: char,
+) -> Result<Option<()>, DispatchError> {
+    if !ctx.is_authoritative_executor || r_args.len() != 2 || dst_bank != 'r' {
+        return Ok(None);
+    }
+    use pyre_interpreter::bytecode::BinaryOperator;
+    let is_floordiv = match pyre_interpreter::runtime_ops::binary_op_from_tag(op_tag) {
+        Some(BinaryOperator::FloorDivide | BinaryOperator::InplaceFloorDivide) => true,
+        Some(BinaryOperator::Remainder | BinaryOperator::InplaceRemainder) => false,
+        _ => return Ok(None),
+    };
+    let long = r_args[0];
+    let int = r_args[1];
+    let (Some(long_obj), Some(int_obj)) = (
+        walker_concrete_ref_object(ctx, long),
+        walker_concrete_ref_object(ctx, int),
+    ) else {
+        return Ok(None);
+    };
+    let int_value = unsafe {
+        if !pyre_object::is_long(long_obj)
+            || !pyre_object::is_int(int_obj)
+            || !pyre_object::is_exact_builtin_instance(long_obj)
+            || !pyre_object::is_exact_builtin_instance(int_obj)
+        {
+            return Ok(None);
+        }
+        pyre_object::w_int_get_value(int_obj)
+    };
+    // The zero-divisor arm raises before calling rbigint. Record it through the
+    // generic helper so no partial specialization is emitted.
+    if int_value == 0 {
+        return Ok(None);
+    }
+
+    // Execute the authentic Python operation first: it supplies both the
+    // observable result and the concrete payload for the pure call, without
+    // running an allocating rbigint helper twice at record time.
+    let Some(boxed_result_i64) = walker_execute_may_force_boxed(ctx, allboxes, call_descr) else {
+        return Ok(None);
+    };
+    let boxed_result_obj = boxed_result_i64 as usize as pyre_object::PyObjectRef;
+    if boxed_result_obj == pyre_object::PY_NULL {
+        return Ok(None);
+    }
+    // Everything that can decline must do so before the first guard is
+    // recorded — a later bail-out would leave the operand's class pinned in
+    // the heap cache with no matching guard in the trace.
+    let quotient_concrete = if is_floordiv {
+        if unsafe {
+            pyre_object::is_int(boxed_result_obj) || !pyre_object::is_long(boxed_result_obj)
+        } {
+            return Ok(None);
+        }
+        let raw_concrete = unsafe {
+            *((boxed_result_obj as *const u8).add(pyre_object::longobject::LONG_VALUE_OFFSET)
+                as *const i64)
+        };
+        if pyre_object::longobject::jit_bigint_fits_int(raw_concrete) != 0 {
+            return Ok(None);
+        }
+        Some(raw_concrete)
+    } else {
+        if unsafe { !pyre_object::is_int(boxed_result_obj) } {
+            return Ok(None);
+        }
+        None
+    };
+
+    let long_type_addr = &pyre_object::pyobject::LONG_TYPE as *const _ as i64;
+    walker_guard_class(ctx, op_pc, long, long_type_addr)?;
+    let (int_type, int_descr) = crate::state::int_or_bool_unbox_type_descr(int_obj);
+    let int_raw = walker_unbox_int_typed(ctx, op_pc, int, int_type, int_descr)?;
+    let zero = ctx.trace_ctx.const_int(0);
+    let nonzero = ctx.trace_ctx.record_op(OpCode::IntNe, &[int_raw, zero]);
+    ctx.trace_ctx
+        .set_opref_concrete(nonzero, majit_ir::Value::Int(1));
+    walker_emit_guard_with_snapshot(ctx, op_pc, OpCode::GuardTrue, &[nonzero])?;
+
+    let off = pyre_object::longobject::LONG_VALUE_OFFSET;
+    let long_payload = unsafe { *((long_obj as *const u8).add(off) as *const i64) };
+    let long_pl = ctx.trace_ctx.record_op_with_descr(
+        OpCode::GetfieldGcR,
+        &[long],
+        crate::descr::long_value_descr(),
+    );
+    ctx.trace_ctx.set_opref_concrete(
+        long_pl,
+        majit_ir::Value::Ref(majit_ir::GcRef(long_payload as usize)),
+    );
+
+    let result = match quotient_concrete {
+        Some(raw_concrete) => {
+            let helper =
+                pyre_interpreter::objspace::descroperation::jit_bigint_int_div_floor as *const ();
+            let raw = ctx.trace_ctx.call_typed_with_effect_pure_can_raise(
+                OpCode::CallR,
+                helper,
+                &[long_pl, int_raw],
+                &[majit_ir::Type::Ref, majit_ir::Type::Int],
+                majit_ir::Type::Ref,
+                majit_metainterp::ELIDABLE_OR_MEMERROR_EFFECT_INFO,
+                &[
+                    majit_ir::Value::Int(helper as usize as i64),
+                    majit_ir::Value::Ref(majit_ir::GcRef(long_payload as usize)),
+                    majit_ir::Value::Int(int_value),
+                ],
+                majit_ir::Value::Ref(majit_ir::GcRef(raw_concrete as usize)),
+            );
+            ctx.trace_ctx.set_opref_concrete(
+                raw,
+                majit_ir::Value::Ref(majit_ir::GcRef(raw_concrete as usize)),
+            );
+            if raw.inline_const_to_value().is_none() {
+                walker_emit_guard_with_snapshot(ctx, op_pc, OpCode::GuardNoException, &[])?;
+            }
+            // `w_long_new` keeps the quotient a `W_LongObject`, so this guard is
+            // not a demotion test: it pins the trace to the payload shape the
+            // inline box was recorded for, exactly as the shift leg does.
+            let fits_fn = pyre_object::longobject::jit_bigint_fits_int as *const ();
+            let fits = ctx.trace_ctx.call_typed_with_effect(
+                OpCode::CallI,
+                fits_fn,
+                &[raw],
+                &[majit_ir::Type::Ref],
+                majit_ir::Type::Int,
+                majit_metainterp::cannot_raise_effect_info(),
+            );
+            ctx.trace_ctx
+                .set_opref_concrete(fits, majit_ir::Value::Int(0));
+            walker_emit_guard_with_snapshot(ctx, op_pc, OpCode::GuardFalse, &[fits])?;
+
+            let boxed = crate::helpers::emit_box_long_inline(
+                ctx.trace_ctx,
+                raw,
+                crate::descr::w_long_size_descr(),
+                crate::descr::long_value_descr(),
+            );
+            ctx.trace_ctx.set_opref_concrete(
+                boxed,
+                majit_ir::Value::Ref(majit_ir::GcRef(boxed_result_i64 as usize)),
+            );
+            boxed
+        }
+        None => {
+            let mod_concrete = unsafe { pyre_object::w_int_get_value(boxed_result_obj) };
+            let helper = pyre_interpreter::objspace::descroperation::jit_bigint_int_mod_int_result
+                as *const ();
+            let raw = ctx.trace_ctx.call_typed_with_effect_pure_can_raise(
+                OpCode::CallI,
+                helper,
+                &[long_pl, int_raw],
+                &[majit_ir::Type::Ref, majit_ir::Type::Int],
+                majit_ir::Type::Int,
+                majit_metainterp::ELIDABLE_EFFECT_INFO,
+                &[
+                    majit_ir::Value::Int(helper as usize as i64),
+                    majit_ir::Value::Ref(majit_ir::GcRef(long_payload as usize)),
+                    majit_ir::Value::Int(int_value),
+                ],
+                majit_ir::Value::Int(mod_concrete),
+            );
+            ctx.trace_ctx
+                .set_opref_concrete(raw, majit_ir::Value::Int(mod_concrete));
+            if raw.inline_const_to_value().is_none() {
+                walker_emit_guard_with_snapshot(ctx, op_pc, OpCode::GuardNoException, &[])?;
+            }
+            let boxed = walker_box_int(ctx, op_pc, raw, mod_concrete)?;
+            ctx.trace_ctx
+                .set_opref_concrete(boxed, box_int_concrete(mod_concrete, boxed_result_i64));
+            boxed
+        }
+    };
+    write_residual_call_result_to_dst(ctx, op_pc, dst, dst_bank, result)?;
+    Ok(Some(()))
+}
+
 /// Walker-native `W_LongObject << W_IntObject` / `>>` specialization for the
 /// `BINARY_OP` helper residual_call.
 ///

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -1236,14 +1236,28 @@ pub(crate) fn try_walker_specialize_truediv_op_long<Sym: WalkSym>(
 
 /// FBW fold of the UNPACK_SEQUENCE two-residual lowering (`unpack_sequence_fn`
 /// validator + per-index `unpack_item_fn` reader emitted by the codewriter
-/// UNPACK_SEQUENCE arm) for an arity-2 specialised int tuple: guard the
-/// `spec_ii` class once, then read `value0` / `value1` directly
-/// (`getfield_gc_pure_i` + `wrapint`) so the unpacked items stay unboxed ints
-/// through the downstream BINARY_OP int fold — the walker analogue of the
-/// retired MIFrame `W_SpecialisedTupleObject_ii` value0/value1 reads. Returns
-/// `Ok(Some(()))` when folded (the caller returns `Continue`); `Ok(None)` to
-/// fall through to the opaque residual record, which stays correct for any
-/// other shape — so a non-foldable sequence is not declined.
+/// UNPACK_SEQUENCE arm) for an arity-2 specialised tuple: guard the
+/// specialisation's class once, then read `value0` / `value1` directly instead
+/// of leaving three opaque `CALL_MAY_FORCE` residuals in the loop.
+///
+/// `objspace.py:519-523 fixedview` reaches `tolist()` for every
+/// `W_AbstractTupleObject`, and `specialisedtupleobject.py:32,58-64 tolist`
+/// unrolls over `_immutable_fields_` value slots, so upstream traces the whole
+/// unpack inline and the optimizer virtualizes the pair away. Both arity-2
+/// layouts are covered here because `makespecialisedtuple2`
+/// (`specialisedtupleobject.py:169-179`) never falls back to a plain tuple:
+///   * `ii` — `value0`/`value1` are inline machine ints, so the read is
+///     `getfield_gc_pure_i` + `wrapint` and the items stay unboxed through the
+///     downstream BINARY_OP int fold (the walker analogue of the retired
+///     MIFrame `W_SpecialisedTupleObject_ii` reads);
+///   * `oo` — `wraps[i]` for an object slot is the identity
+///     (`specialisedtupleobject.py:26-27`), so the `getfield_gc_r` result is
+///     already the item. This is the layout a `divmod(long, long)` result pair
+///     takes, since neither half satisfies `is_plain_int1`.
+///
+/// Returns `Ok(Some(()))` when folded (the caller returns `Continue`);
+/// `Ok(None)` to fall through to the opaque residual record, which stays
+/// correct for any other shape — so a non-foldable sequence is not declined.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn try_walker_specialize_unpack<Sym: WalkSym>(
     ctx: &mut WalkContext<'_, '_, Sym>,
@@ -1268,29 +1282,27 @@ pub(crate) fn try_walker_specialize_unpack<Sym: WalkSym>(
     let Some(concrete_seq) = walker_concrete_ref_object(ctx, seq) else {
         return Ok(None);
     };
-    // Only the arity-2 int specialised tuple is folded today; any other shape
-    // falls through to the opaque residual (correct, slower).
+    // Both arity-2 specialisations fold; any other shape (a plain tuple, a
+    // longer unpack, a list) falls through to the opaque residual (correct,
+    // slower).
     let spec_ii = &pyre_object::specialisedtupleobject::SPECIALISED_TUPLE_II_TYPE
         as *const pyre_object::pyobject::PyType;
-    if !std::ptr::eq(unsafe { (*concrete_seq).ob_type }, spec_ii) {
+    let spec_oo = &pyre_object::specialisedtupleobject::SPECIALISED_TUPLE_OO_TYPE
+        as *const pyre_object::pyobject::PyType;
+    let seq_type = unsafe { (*concrete_seq).ob_type };
+    let is_oo = std::ptr::eq(seq_type, spec_oo);
+    if !is_oo && !std::ptr::eq(seq_type, spec_ii) {
         return Ok(None);
     }
+    let spec_type = if is_oo { spec_oo } else { spec_ii };
     match helper {
         majit_ir::PyreHelperKind::UnpackSequence => {
-            // `spec_ii` is always arity 2, so the class guard subsumes the
-            // exact-length check `unpack_sequence_fn` performs.
+            // Either specialisation is always arity 2, so the class guard
+            // subsumes the exact-length check `unpack_sequence_fn` performs.
             if int_val != 2 {
                 return Ok(None);
             }
-            if !ctx.trace_ctx.heap_cache().is_class_known(seq) {
-                let type_const = ctx.trace_ctx.const_int(spec_ii as i64);
-                ctx.trace_ctx
-                    .record_guard(OpCode::GuardClass, &[seq, type_const], 0);
-                walker_capture_snapshot_for_last_guard(ctx, op_pc)?;
-                ctx.trace_ctx
-                    .heap_cache_mut()
-                    .class_now_known(seq, spec_ii as i64);
-            }
+            walker_guard_specialised_pair_class(ctx, op_pc, seq, spec_type)?;
             // Pass `seq` through as the validated tuple; the per-index
             // `unpack_item_fn` reads below fold off it.
             write_residual_call_result_to_dst(ctx, op_pc, dst, dst_bank, seq)?;
@@ -1300,13 +1312,29 @@ pub(crate) fn try_walker_specialize_unpack<Sym: WalkSym>(
             if !(0..2).contains(&int_val) {
                 return Ok(None);
             }
+            // Normally the partner `unpack_sequence_fn` fold already guarded
+            // the class (its validated-tuple passthrough reg == `seq`), in
+            // which case this is a no-op; guard here too so a fold that only
+            // catches the item reads still proves the layout it loads from.
+            walker_guard_specialised_pair_class(ctx, op_pc, seq, spec_type)?;
+            if is_oo {
+                let descr = if int_val == 0 {
+                    crate::descr::specialised_tuple_oo_value0_descr()
+                } else {
+                    crate::descr::specialised_tuple_oo_value1_descr()
+                };
+                // `wraps[i]` is the identity for an object slot, so the field
+                // read is the whole item — no re-boxing, and no `may_force`
+                // execution needed to recover a box identity.
+                let item = crate::state::opimpl_getfield_gc_r(ctx.trace_ctx, seq, descr);
+                write_residual_call_result_to_dst(ctx, op_pc, dst, dst_bank, item)?;
+                return Ok(Some(()));
+            }
             // Authentic boxed element (small-int caching / identity); fall
             // through to the opaque residual if it cannot be executed.
             let Some(elem_ptr) = walker_execute_may_force_boxed(ctx, allboxes, call_descr) else {
                 return Ok(None);
             };
-            // The class was already guarded by the partner `unpack_sequence_fn`
-            // fold (its validated-tuple passthrough reg == `seq`).
             let descr = if int_val == 0 {
                 crate::descr::specialised_tuple_ii_value0_descr()
             } else {
@@ -1337,6 +1365,29 @@ unsafe fn args_tuple_shape_probe(stored: pyre_object::PyObjectRef) -> pyre_objec
         })
         .collect();
     pyre_object::w_tuple_new(items)
+}
+
+/// `guard_class(seq, spec)` for one of the arity-2 tuple specialisations,
+/// emitted once per traced `seq` — the heap cache turns every later fold on the
+/// same register into a no-op, the way upstream's optimizer keeps a single
+/// class guard for a value it already proved.
+fn walker_guard_specialised_pair_class<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    op_pc: usize,
+    seq: OpRef,
+    spec_type: *const pyre_object::pyobject::PyType,
+) -> Result<(), DispatchError> {
+    if ctx.trace_ctx.heap_cache().is_class_known(seq) {
+        return Ok(());
+    }
+    let type_const = ctx.trace_ctx.const_int(spec_type as i64);
+    ctx.trace_ctx
+        .record_guard(OpCode::GuardClass, &[seq, type_const], 0);
+    walker_capture_snapshot_for_last_guard(ctx, op_pc)?;
+    ctx.trace_ctx
+        .heap_cache_mut()
+        .class_now_known(seq, spec_type as i64);
+    Ok(())
 }
 
 /// `mapdict.py LOAD_ATTR_caching` full-body-walker fast path for a

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -1019,6 +1019,166 @@ pub(crate) fn try_walker_specialize_binary_op_long_int_div<Sym: WalkSym>(
     Ok(Some(()))
 }
 
+/// Walker-native `W_LongObject ** W_IntObject` specialization for the
+/// `BINARY_OP` helper residual_call.
+///
+/// `longobject.py:206-231 descr_pow` keeps a `W_IntObject` exponent unwrapped
+/// (`exp_bigint` stays `None`) and calls `rbigint.int_pow`; only a long
+/// exponent reaches `rbigint.pow`. `long_pow` (`descroperation.rs`) reaches
+/// that call past four short-circuits — a negative exponent goes to the float
+/// path, a zero exponent returns 1, and a base of 0 / 1 / -1 returns a
+/// constant. The exponent tests unbox to a machine word, so they record as a
+/// single `GUARD_TRUE(int_gt(exp, 0))`.
+///
+/// The three base tests collapse into one guard: a base whose payload does not
+/// fit a machine word has magnitude at least `2**63`, so it can be none of
+/// 0 / 1 / -1. That is strictly stronger than the interpreter's three
+/// comparisons — it can only bail more often, never take a different path —
+/// and it costs one `jit_bigint_fits_int` call instead of three bigint
+/// comparisons against baked constants. It also makes the usual trailing
+/// result-fits guard redundant: `|base| >= 2**63` with `exp >= 1` cannot
+/// produce a result that fits a machine word, so unlike the floordiv and shift
+/// legs this one emits no guard on the result payload.
+///
+/// `descr_pow` wraps every branch as `W_LongObject` (no `newlong` demotion),
+/// so the result boxes inline exactly like the other long legs.
+/// The three-argument `pow(a, b, m)` is not a `BINARY_OP` and never reaches
+/// here.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn try_walker_specialize_binary_op_long_int_pow<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    op_pc: usize,
+    op_tag: i64,
+    r_args: &[OpRef],
+    allboxes: &[OpRef],
+    call_descr: &dyn majit_ir::descr::CallDescr,
+    dst: usize,
+    dst_bank: char,
+) -> Result<Option<()>, DispatchError> {
+    if !ctx.is_authoritative_executor || r_args.len() != 2 || dst_bank != 'r' {
+        return Ok(None);
+    }
+    use pyre_interpreter::bytecode::BinaryOperator;
+    if !matches!(
+        pyre_interpreter::runtime_ops::binary_op_from_tag(op_tag),
+        Some(BinaryOperator::Power | BinaryOperator::InplacePower)
+    ) {
+        return Ok(None);
+    }
+    let long = r_args[0];
+    let int = r_args[1];
+    let (Some(long_obj), Some(int_obj)) = (
+        walker_concrete_ref_object(ctx, long),
+        walker_concrete_ref_object(ctx, int),
+    ) else {
+        return Ok(None);
+    };
+    let exp_value = unsafe {
+        if !pyre_object::is_long(long_obj)
+            || !pyre_object::is_int(int_obj)
+            || !pyre_object::is_exact_builtin_instance(long_obj)
+            || !pyre_object::is_exact_builtin_instance(int_obj)
+        {
+            return Ok(None);
+        }
+        pyre_object::w_int_get_value(int_obj)
+    };
+    // A non-positive exponent leaves through one of the short-circuits above
+    // the `rbigint.int_pow` call; record those through the generic helper.
+    if exp_value <= 0 {
+        return Ok(None);
+    }
+    let off = pyre_object::longobject::LONG_VALUE_OFFSET;
+    let base_payload = unsafe { *((long_obj as *const u8).add(off) as *const i64) };
+    if pyre_object::longobject::jit_bigint_fits_int(base_payload) != 0 {
+        return Ok(None);
+    }
+
+    let Some(boxed_result_i64) = walker_execute_may_force_boxed(ctx, allboxes, call_descr) else {
+        return Ok(None);
+    };
+    let boxed_result_obj = boxed_result_i64 as usize as pyre_object::PyObjectRef;
+    if boxed_result_obj == pyre_object::PY_NULL
+        || unsafe {
+            pyre_object::is_int(boxed_result_obj) || !pyre_object::is_long(boxed_result_obj)
+        }
+    {
+        return Ok(None);
+    }
+    let raw_concrete = unsafe {
+        *((boxed_result_obj as *const u8).add(pyre_object::longobject::LONG_VALUE_OFFSET)
+            as *const i64)
+    };
+
+    let long_type_addr = &pyre_object::pyobject::LONG_TYPE as *const _ as i64;
+    walker_guard_class(ctx, op_pc, long, long_type_addr)?;
+    let (int_type, int_descr) = crate::state::int_or_bool_unbox_type_descr(int_obj);
+    let exp_raw = walker_unbox_int_typed(ctx, op_pc, int, int_type, int_descr)?;
+    let zero = ctx.trace_ctx.const_int(0);
+    let positive = ctx.trace_ctx.record_op(OpCode::IntGt, &[exp_raw, zero]);
+    ctx.trace_ctx
+        .set_opref_concrete(positive, majit_ir::Value::Int(1));
+    walker_emit_guard_with_snapshot(ctx, op_pc, OpCode::GuardTrue, &[positive])?;
+
+    let base_pl = ctx.trace_ctx.record_op_with_descr(
+        OpCode::GetfieldGcR,
+        &[long],
+        crate::descr::long_value_descr(),
+    );
+    ctx.trace_ctx.set_opref_concrete(
+        base_pl,
+        majit_ir::Value::Ref(majit_ir::GcRef(base_payload as usize)),
+    );
+    let fits_fn = pyre_object::longobject::jit_bigint_fits_int as *const ();
+    let base_fits = ctx.trace_ctx.call_typed_with_effect(
+        OpCode::CallI,
+        fits_fn,
+        &[base_pl],
+        &[majit_ir::Type::Ref],
+        majit_ir::Type::Int,
+        majit_metainterp::cannot_raise_effect_info(),
+    );
+    ctx.trace_ctx
+        .set_opref_concrete(base_fits, majit_ir::Value::Int(0));
+    walker_emit_guard_with_snapshot(ctx, op_pc, OpCode::GuardFalse, &[base_fits])?;
+
+    let helper = pyre_interpreter::objspace::descroperation::jit_bigint_int_pow_nomod as *const ();
+    let raw = ctx.trace_ctx.call_typed_with_effect_pure_can_raise(
+        OpCode::CallR,
+        helper,
+        &[base_pl, exp_raw],
+        &[majit_ir::Type::Ref, majit_ir::Type::Int],
+        majit_ir::Type::Ref,
+        majit_metainterp::ELIDABLE_OR_MEMERROR_EFFECT_INFO,
+        &[
+            majit_ir::Value::Int(helper as usize as i64),
+            majit_ir::Value::Ref(majit_ir::GcRef(base_payload as usize)),
+            majit_ir::Value::Int(exp_value),
+        ],
+        majit_ir::Value::Ref(majit_ir::GcRef(raw_concrete as usize)),
+    );
+    ctx.trace_ctx.set_opref_concrete(
+        raw,
+        majit_ir::Value::Ref(majit_ir::GcRef(raw_concrete as usize)),
+    );
+    if raw.inline_const_to_value().is_none() {
+        walker_emit_guard_with_snapshot(ctx, op_pc, OpCode::GuardNoException, &[])?;
+    }
+
+    let result = crate::helpers::emit_box_long_inline(
+        ctx.trace_ctx,
+        raw,
+        crate::descr::w_long_size_descr(),
+        crate::descr::long_value_descr(),
+    );
+    ctx.trace_ctx.set_opref_concrete(
+        result,
+        majit_ir::Value::Ref(majit_ir::GcRef(boxed_result_i64 as usize)),
+    );
+    write_residual_call_result_to_dst(ctx, op_pc, dst, dst_bank, result)?;
+    Ok(Some(()))
+}
+
 /// Walker-native `W_LongObject << W_IntObject` / `>>` specialization for the
 /// `BINARY_OP` helper residual_call.
 ///

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/vstack_mirror.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/vstack_mirror.rs
@@ -260,7 +260,25 @@ fn loadconst_operand_ref<Sym: WalkSym>(
         return OpRef::NONE;
     };
     let idx = usize::from(consti.get(op_arg));
-    let w_const = pyre_interpreter::pyframe::load_const_from_code(code, idx);
+    let w_code = if ctx.is_top_level {
+        let session = ctx.session.borrow();
+        let frame = session.recording_frame_ptr as *const pyre_interpreter::PyFrame;
+        if frame.is_null() {
+            0
+        } else {
+            unsafe { (*frame).pycode as usize }
+        }
+    } else {
+        ctx.inline_callee_consts.map_or(0, |consts| consts.w_code)
+    };
+    let w_const = if w_code == 0 || w_code == usize::MAX {
+        // Malformed/test-only walks have no enclosing PyCode. Keep the
+        // historical materializer fallback; production LOAD_CONST always has
+        // the per-frame red `pycode` owner.
+        pyre_interpreter::pyframe::load_const_from_code(code, idx)
+    } else {
+        unsafe { pyre_interpreter::pycode::w_code_const(w_code as pyre_object::PyObjectRef, idx) }
+    };
     if w_const.is_null() {
         return OpRef::NONE;
     }

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -5382,13 +5382,13 @@ pub extern "C" fn bh_store_global_fn(frame_ptr: i64, w_name: i64, value: i64) ->
 pub extern "C" fn bh_load_const_fn(w_code_ptr: i64, consti: i64) -> i64 {
     // `getconstant_w(index) -> co_consts_w[index]`: read the one shared object
     // off the virtualizable `pycode`, exactly as the interpreter does.
-    let w_code = unsafe {
+    let w_const = unsafe {
         pyre_interpreter::pycode::w_code_const(
             w_code_ptr as pyre_object::PyObjectRef,
             consti as usize,
         )
     };
-    w_code as i64
+    w_const as i64
 }
 
 /// Box a raw integer into a PyObject (w_int_new wrapper).

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -5380,24 +5380,15 @@ pub extern "C" fn bh_store_global_fn(frame_ptr: i64, w_name: i64, value: i64) ->
 /// Load a constant from the code object.
 /// jtransform.py parity: code comes from getfield_vable_r(frame, pycode).
 pub extern "C" fn bh_load_const_fn(w_code_ptr: i64, consti: i64) -> i64 {
-    // `getconstant_w(index) -> co_consts_w[index]` for a code constant: read the
-    // one wrapper off the virtualizable `pycode` (the same `PyCode` the
-    // interpreter loads), so deopt resume keeps `__code__` identity.  Non-code
-    // constants return `PY_NULL` here and fall through to value realization.
+    // `getconstant_w(index) -> co_consts_w[index]`: read the one shared object
+    // off the virtualizable `pycode`, exactly as the interpreter does.
     let w_code = unsafe {
-        pyre_interpreter::pycode::w_code_co_const(
+        pyre_interpreter::pycode::w_code_const(
             w_code_ptr as pyre_object::PyObjectRef,
             consti as usize,
         )
     };
-    if !w_code.is_null() {
-        return w_code as i64;
-    }
-    let code = unsafe {
-        &*(pyre_interpreter::w_code_get_ptr(w_code_ptr as pyre_object::PyObjectRef)
-            as *const pyre_interpreter::CodeObject)
-    };
-    pyre_interpreter::pyframe::load_const_from_code(code, consti as usize) as i64
+    w_code as i64
 }
 
 /// Box a raw integer into a PyObject (w_int_new wrapper).

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -10661,6 +10661,17 @@ impl majit_metainterp::resume::BlackholeAllocator for PyreBlackholeAllocator {
         if struct_ptr == 0 {
             return;
         }
+        // `resume.py:1512` dispatches to `cpu.bh_setfield_gc_r`, whose
+        // `write_ref_at_mem` (llmodel.py:495) carries the framework GC
+        // transformer's write barrier around the ref store. This override
+        // shadows the backend's `bh_setfield_gc_r`, so it must reproduce the
+        // barrier itself: `allocate_with_vtable` materializes a virtual
+        // straight into the non-moving old generation, so a young `value`
+        // stored here is an `old -> young` edge. Without the barrier the store
+        // never reaches `old_objects_pointing_to_young`, the next minor
+        // collection reclaims the payload while the materialized struct still
+        // points at it, and the following major mark reads a dangling header.
+        majit_gc::gc_write_barrier(majit_ir::GcRef(struct_ptr as usize));
         unsafe {
             ((struct_ptr as *mut u8).add(descr_info.offset) as *mut usize).write(value as usize);
         }
@@ -10732,6 +10743,12 @@ impl majit_metainterp::resume::BlackholeAllocator for PyreBlackholeAllocator {
         value: i64,
         descr: &majit_ir::DescrRef,
     ) {
+        // Same barrier obligation as `bh_setfield_gc_r` above: the `_i`
+        // helper is a bare store, and the blackhole has no inline
+        // `TRACK_YOUNG_PTRS` test in front of it.
+        if array != 0 {
+            majit_gc::gc_write_barrier(majit_ir::GcRef(array as usize));
+        }
         self.bh_setinteriorfield_gc_i(array, index, value, descr);
         // llmodel.py:659 `bh_setinteriorfield_gc_r` → :495
         // `write_ref_at_mem`: the ref store carries an implied write barrier

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -3025,16 +3025,12 @@ fn frontend_load_const_flow_value(
     idx: usize,
 ) -> super::flow::FlowValue {
     // `flowcontext.py:841-843 LOAD_CONST`: fetch the pre-wrapped constant
-    // and push that value.  A top-level code constant resolves through the
-    // enclosing code's `co_consts_w` (same as `bh_load_const_fn`) so the
-    // graph shadow carries the interpreter's `PyCode` wrapper rather
-    // than a freshly boxed one — keeping `__code__` identity and the nested
-    // function's JIT green key stable. `w_code_co_const` returns null for
-    // non-code constants, which fall through to the `ConstantData`
-    // materializer (the same one the blackhole helper uses).
+    // and push that value. Every top-level constant resolves through the
+    // enclosing code's `co_consts_w`, the same object `bh_load_const_fn`
+    // returns.
     let w_code = w_code as pyre_object::PyObjectRef;
     if !w_code.is_null() {
-        let w_const = unsafe { pyre_interpreter::pycode::w_code_co_const(w_code, idx) };
+        let w_const = unsafe { pyre_interpreter::pycode::w_code_const(w_code, idx) };
         if !w_const.is_null() {
             return pyobject_const_ref_value(w_const);
         }
@@ -3491,14 +3487,12 @@ struct FnPtrIndices {
 /// * `load_global_fn` / `build_slice_fn`: namespace dict lookup +
 ///   slice allocation; can raise (`NameError` / `MemoryError`) but do
 ///   not force virtuals — `EF_CAN_RAISE` → `Plain`.
-/// * `box_int_fn` / `load_const_fn`: kept on `Plain` until the
-///   upstream `@jit.elidable_promote` decorator is wired
-///   (`rpython/rlib/jit.py:180`) and pyre's constant storage shape
-///   matches PyPy's pre-wrapped `co_consts_w`
-///   (`pypy/interpreter/pyopcode.py:516` vs
-///   `pyre-interpreter/src/pyframe.rs:1748-1768`).  Hand-pure
-///   classification without those prerequisites would be a
-///   TODO.
+/// * `box_int_fn`: kept on `Plain` until the upstream
+///   `@jit.elidable_promote` decorator is wired (`rpython/rlib/jit.py:180`).
+/// * `load_const_fn`: reads the shared `co_consts_w` slot, but pyre lazily
+///   realizes the compiler's unwrapped constant on the first read. That first
+///   call allocates and mutates the slot, so it remains `Plain` until the
+///   compiler boundary supplies PyPy-style pre-wrapped constants eagerly.
 fn register_helper_fn_pointers(
     assembler: &mut SSAReprEmitter,
     cpu: &super::cpu::Cpu,
@@ -3566,14 +3560,10 @@ fn register_helper_fn_pointers(
     // Matches `EF_FORCES_VIRTUAL_OR_VIRTUALIZABLE`
     // (`effectinfo.py:23`) → `MayForce` per Slice α-2.
     let truth_fn = bind(assembler, cpu.truth_fn as *const (), CallFlavor::MayForce);
-    // PyPy's `LOAD_CONST` reads pre-wrapped `co_consts_w`
-    // (`pypy/interpreter/pyopcode.py:516`); pyre's
-    // `pyre_interpreter::pyframe::load_const_from_code`
-    // (`pyre-interpreter/src/pyframe.rs:1748-1768`)
-    // re-materializes int / float / str / bool constants on every
-    // call, so the helper is NOT observably idempotent. Stay on
-    // `Plain` until the constant-storage shape converges to the
-    // PyPy pre-wrapped representation.
+    // PyPy's `LOAD_CONST` is a pure pre-wrapped list read. Pyre now preserves
+    // that slot identity, but the first read is still the unwrapped compiler
+    // boundary: it allocates and publishes the object. Stay on `Plain` until
+    // construction itself supplies an eagerly wrapped `co_consts_w`.
     let load_const_fn = bind(assembler, cpu.load_const_fn as *const (), CallFlavor::Plain);
     let store_subscr_fn = bind(
         assembler,
@@ -15294,7 +15284,7 @@ mod tests {
             .position(|constant| matches!(constant, ConstantData::Code { .. }))
             .expect("code constant");
 
-        let expected = unsafe { pyre_interpreter::pycode::w_code_co_const(w_code, idx) };
+        let expected = unsafe { pyre_interpreter::pycode::w_code_const(w_code, idx) };
         assert!(
             !expected.is_null(),
             "co_consts_w must resolve the code wrapper"
@@ -15310,6 +15300,36 @@ mod tests {
                     "graph LOAD_CONST must carry the co_consts_w wrapper, not a fresh box",
                 );
             }
+            other => panic!("expected Ref constant, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn frontend_load_const_flow_value_shares_co_consts_w_large_integer() {
+        let code =
+            compile_exec("x = 123456789012345678901234567890123456789012345678901234567890\n")
+                .expect("compile failed");
+        let w_code = pyre_interpreter::box_code_constant(&code);
+        let idx = code
+            .constants
+            .iter()
+            .position(|constant| {
+                matches!(
+                    constant,
+                    ConstantData::Integer { value }
+                        if num_traits::ToPrimitive::to_i64(value).is_none()
+                )
+            })
+            .expect("large integer constant");
+
+        let expected = unsafe { pyre_interpreter::pycode::w_code_const(w_code, idx) };
+        let value = frontend_load_const_flow_value(w_code as *const (), &code, idx);
+        match value {
+            FlowValue::Constant(c) => assert_eq!(
+                c.value,
+                super::super::flow::ConstantValue::Signed(expected as i64),
+                "graph LOAD_CONST must carry the shared W_LongObject",
+            ),
             other => panic!("expected Ref constant, got {other:?}"),
         }
     }

--- a/pyre/pyre-jit/tests/gc_stress.rs
+++ b/pyre/pyre-jit/tests/gc_stress.rs
@@ -866,3 +866,110 @@ assert result == 3002, result
         "rbigint formatter cache gc stress program failed",
     );
 }
+
+/// Long consumers keep only the Python wrapper as the GC root while rbigint
+/// arithmetic borrows its immutable digit payload.  Repeatedly move those
+/// wrappers and digit arrays between operations to catch stale borrowed
+/// payloads, missing W_LongObject write barriers, and result digit edges that
+/// were not rooted when the payload was boxed.
+#[test]
+fn rbigint_consumers_survive_moving_collection_between_operations() {
+    const PROGRAM: &str = r#"
+import gc
+
+def run():
+    a = (1 << 300) + 123456789
+    b = (1 << 190) + 98765
+
+    # rbigint.abs returns the original payload for a nonnegative value while
+    # W_LongObject.descr_abs creates a new old-gen wrapper. Drop the original
+    # wrapper so the creation barrier on that shared-payload edge is the only
+    # thing keeping the young rbigint alive.
+    positive = abs((1 << 333) + 13579)
+    gc.collect()
+    assert positive == (1 << 333) + 13579
+    assert +positive is positive
+
+    class HugeInt(int):
+        pass
+    subclassed = HugeInt((1 << 345) + 24680)
+    base = int(subclassed)
+    subclassed = None
+    gc.collect()
+    assert type(base) is int
+    assert base == (1 << 345) + 24680
+
+    i = 0
+    while i < 60:
+        shifted = a << ((i % 31) + 1)
+        gc.collect()
+        assert shifted >> ((i % 31) + 1) == a
+
+        product = a * b
+        gc.collect()
+        q, r = divmod(product, b)
+        assert q == a
+        assert r == 0
+        gc.collect()
+        assert product // b == a
+        assert product % b == 0
+
+        modular = pow(a, 5, b)
+        gc.collect()
+        assert modular == (a * a * a * a * a) % b
+        negative_modular = pow(a, 3, -b)
+        gc.collect()
+        assert -b < negative_modular <= 0
+        assert negative_modular == (a * a * a) % -b
+
+        mixed = (product ^ shifted) + i
+        gc.collect()
+        assert (mixed - i) ^ shifted == product
+
+        # Keep producing fresh long payloads; both operands have survived a
+        # moving collection before the next borrowed rbigint operation.
+        a = a + (1 << (70 + i))
+        b = b | (1 << (80 + i))
+        i = i + 1
+    return a.bit_length() + b.bit_length()
+
+result = run()
+assert result > 490, result
+"#;
+    run_on_worker(
+        PROGRAM,
+        "<rbigint_consumer_gc_stress>",
+        "rbigint consumer survival checks",
+        "rbigint consumer gc stress program failed",
+    );
+}
+
+/// `PyCode.co_consts_w` owns the one wrapped object for each constant index
+/// (`pycode.py:126`, `pyopcode.py:498-499`). A large integer constant is a
+/// managed `W_LongObject`; the Box-immortal PyCode therefore has to expose the
+/// filled slot to the raw-root walker across both interpreter and JIT loads.
+#[test]
+fn rbigint_code_constant_identity_survives_full_collection() {
+    run_on_worker(
+        r#"
+import gc
+
+def load_big():
+    return 123456789012345678901234567890123456789012345678901234567890
+
+i = 0
+first = load_big()
+while i < 80:
+    if i % 7 == 0:
+        gc.collect()
+    assert load_big() is first
+    i += 1
+
+gc.collect()
+assert load_big() is first
+"#,
+        "<rbigint_code_constant_gc_stress>",
+        "rbigint code constant identity and survival checks",
+        "rbigint code constant gc stress program failed",
+    );
+}

--- a/pyre/pyre-jit/tests/gc_stress.rs
+++ b/pyre/pyre-jit/tests/gc_stress.rs
@@ -944,6 +944,49 @@ assert result > 490, result
     );
 }
 
+/// RPython's GC transform roots a by-value `rbigint` local when a later
+/// `space.index`, comparison, or wrapping allocation can collect. The Rust
+/// interpreter needs the equivalent explicit stable slot: these callbacks
+/// force a collection while an earlier machine-int conversion exists only as
+/// an unboxed `RBigInt`.
+#[test]
+fn unboxed_rbigint_consumers_survive_python_callbacks() {
+    run_on_worker(
+        r#"
+import gc
+import math
+
+class Index:
+    def __init__(self, value):
+        self.value = value
+
+    def __index__(self):
+        gc.collect()
+        return self.value
+
+class Even:
+    def __eq__(self, other):
+        gc.collect()
+        return other % 2 == 0
+
+i = 0
+while i < 40:
+    assert math.gcd(123456789, Index(3)) == 3
+    assert math.lcm(123456789, Index(3)) == 123456789
+    assert math.comb(50, Index(3)) == 19600
+    assert math.perm(20, Index(3)) == 6840
+
+    sliced = range(20)[slice(Index(1), Index(12), Index(2))]
+    assert list(sliced) == [1, 3, 5, 7, 9, 11]
+    assert range(20).count(Even()) == 10
+    i += 1
+"#,
+        "<unboxed_rbigint_callback_gc_stress>",
+        "unboxed rbigint callback-root checks",
+        "unboxed rbigint callback GC stress program failed",
+    );
+}
+
 /// `PyCode.co_consts_w` owns the one wrapped object for each constant index
 /// (`pycode.py:126`, `pyopcode.py:498-499`). A large integer constant is a
 /// managed `W_LongObject`; the Box-immortal PyCode therefore has to expose the

--- a/pyre/pyre-object/src/functional.rs
+++ b/pyre/pyre-object/src/functional.rs
@@ -771,7 +771,10 @@ pub unsafe fn range_obj_to_bigint(obj: PyObjectRef) -> BigInt {
         } else if is_int(obj) {
             BigInt::from(crate::intobject::w_int_get_value(obj))
         } else {
-            crate::longobject::w_long_get_value(obj).clone()
+            // `space.bigint_w(W_LongObject)` returns the stored rbigint
+            // reference. The host ownership adapter is a shallow clone, but
+            // source translation aliases the existing GC payload.
+            crate::longobject::w_long_get_value(obj).translated_alias()
         }
     }
 }
@@ -927,7 +930,7 @@ pub unsafe fn w_range_compute_item(obj: PyObjectRef, index: &BigInt) -> Option<P
     unsafe {
         let (start, _stop, step) = w_range_fields(obj);
         let len_b = range_obj_to_bigint(w_range_length(obj));
-        let mut idx = index.clone();
+        let mut idx = index.translated_alias();
         if idx < BigInt::zero() {
             idx = &idx + &len_b;
         }
@@ -1156,7 +1159,7 @@ pub unsafe fn w_long_range_iter_next(obj: PyObjectRef) -> Option<PyObjectRef> {
         let step = range_obj_to_bigint((*it).step);
         // `w_result = self.w_index * self.w_step + self.w_start`, then
         // `self.w_index = self.w_index + 1` (wrapped, arbitrary precision).
-        let value = start + index.clone() * step;
+        let value = start + index.translated_alias() * step;
         let _roots = crate::gc_roots::push_roots();
         crate::gc_roots::pin_root(obj);
         let iter_slot = crate::gc_roots::shadow_stack_len() - 1;

--- a/pyre/pyre-object/src/functional.rs
+++ b/pyre/pyre-object/src/functional.rs
@@ -1,7 +1,7 @@
 //! `pypy/module/__builtin__/functional.py` line-by-line ports for built-in iterator functionals.
 
 use crate::pyobject::*;
-use crate::rbigint::RBigInt as BigInt;
+use crate::rbigint::{RBigInt as BigInt, RBigIntGcRoot};
 use pyre_macros::pyre_class;
 
 // ── functional.rs ─────────────────────────────────────────────
@@ -1159,7 +1159,10 @@ pub unsafe fn w_long_range_iter_next(obj: PyObjectRef) -> Option<PyObjectRef> {
         let step = range_obj_to_bigint((*it).step);
         // `w_result = self.w_index * self.w_step + self.w_start`, then
         // `self.w_index = self.w_index + 1` (wrapped, arbitrary precision).
-        let value = start + index.translated_alias() * step;
+        // `next_index` is wrapped before `value`; that first allocation may
+        // collect while the computed item exists only as an unboxed rbigint.
+        // RPython's GC transform roots this local automatically.
+        let value = RBigIntGcRoot::new(start + index.translated_alias() * step);
         let _roots = crate::gc_roots::push_roots();
         crate::gc_roots::pin_root(obj);
         let iter_slot = crate::gc_roots::shadow_stack_len() - 1;
@@ -1168,7 +1171,7 @@ pub unsafe fn w_long_range_iter_next(obj: PyObjectRef) -> Option<PyObjectRef> {
         let it = crate::gc_roots::shadow_stack_get(iter_slot) as *mut W_LongRangeIterator;
         (*it).index = next_index;
         crate::gc_hook::try_gc_write_barrier(it as *mut u8);
-        Some(range_bigint_to_obj(value))
+        Some(range_bigint_to_obj(value.translated_alias()))
     }
 }
 

--- a/pyre/pyre-object/src/listobject.rs
+++ b/pyre/pyre-object/src/listobject.rs
@@ -168,6 +168,14 @@ impl W_ListObject {
         // block's live items across that allocation. Callers that hold an
         // incoming `value` across this call root it themselves before grow.
         self.items = grow_list_items_block_gc(self.items, target_cap, self.length);
+        // framework.py's GC transform places the owner write barrier directly
+        // after `_ll_list_resize_really` installs the fresh GcArray pointer.
+        // `object_grow` runs inside the residualized
+        // `w_list_grow_items_block` boundary, so an outer append barrier is
+        // too late to represent this field store in the compiled trace: the
+        // helper itself must leave the old-gen list remembered before it
+        // returns its new nursery-backed `items`.
+        list_write_barrier(self as *mut W_ListObject as PyObjectRef);
     }
 
     /// Upstream list.append equivalent for the object strategy.

--- a/pyre/pyre-object/src/longobject.rs
+++ b/pyre/pyre-object/src/longobject.rs
@@ -230,7 +230,11 @@ pub extern "C" fn jit_bigint_from_u64(value: u64) -> JitBigIntResult {
 #[majit_macros::elidable_or_memerror]
 pub extern "C" fn jit_bigint_clone(value: i64) -> JitBigIntResult {
     let value = value as *const BigInt;
-    unsafe { encode_jit_bigint_result(alloc_bigint_nursery_collecting((*value).clone())) }
+    unsafe {
+        encode_jit_bigint_result(crate::rbigint::alloc_rbigint_clone_nursery_collecting(
+            (*value).clone(),
+        ))
+    }
 }
 
 macro_rules! bigint_comparison_residual {
@@ -730,11 +734,15 @@ mod tests {
         let a = jit_bigint_from_i64(-42);
         let b = jit_bigint_from_u64(42);
         let cloned = jit_bigint_clone(a as i64);
+        let prebuilt_zero = jit_bigint_from_i64(0);
+        let cloned_zero = jit_bigint_clone(prebuilt_zero as i64);
         unsafe {
             assert_eq!(&*a, &BigInt::from(-42));
             assert_eq!(&*b, &BigInt::from(42));
             assert_eq!(&*cloned, &*a);
             assert_ne!(cloned, a);
+            assert_eq!(&*cloned_zero, &*prebuilt_zero);
+            assert_ne!(cloned_zero, prebuilt_zero);
         }
         assert_eq!(jit_bigint_eq(a as i64, b as i64), 0);
         assert_eq!(jit_bigint_lt(a as i64, b as i64), 1);

--- a/pyre/pyre-object/src/longobject.rs
+++ b/pyre/pyre-object/src/longobject.rs
@@ -5,7 +5,7 @@
 //! payloads, calling pure raw-payload helpers, and boxing the resulting payload
 //! with the same `W_LongObject` layout.
 
-use crate::rbigint::{RBigInt as BigInt, RBigIntSign};
+use crate::rbigint::RBigInt as BigInt;
 
 use crate::pyobject::*;
 
@@ -191,6 +191,15 @@ pub fn w_long_new(value: BigInt) -> PyObjectRef {
     w_long_from_raw(alloc_bigint_nursery(value))
 }
 
+/// Wrap a fresh rbigint handle without canonicalizing a shallow copy whose
+/// digit array happens to belong to a prebuilt value.
+#[majit_macros::dont_look_inside]
+pub fn w_long_new_fresh_rbigint_handle(value: BigInt) -> PyObjectRef {
+    // No-collect host counterpart of `jit_bigint_clone`: rbigint.neg always
+    // constructs a new handle, including for the prebuilt zero digit array.
+    w_long_from_raw(crate::rbigint::alloc_rbigint_nursery_impl(value, false))
+}
+
 /// Create a W_LongObject from an i64 value.
 pub fn w_long_from_i64(v: i64) -> PyObjectRef {
     w_long_new(BigInt::from(v))
@@ -293,7 +302,7 @@ pub unsafe fn w_long_fits_int(obj: PyObjectRef) -> bool {
 /// `obj` must point to a valid `W_LongObject`.
 #[inline]
 pub unsafe fn w_long_is_zero(obj: PyObjectRef) -> bool {
-    unsafe { w_long_get_value(obj).sign() == RBigIntSign::NoSign }
+    unsafe { w_long_get_value(obj).get_sign() == 0 }
 }
 
 /// Extract a reference to the BigInt value from a known W_LongObject pointer.
@@ -306,6 +315,17 @@ pub unsafe fn w_long_get_value(obj: PyObjectRef) -> &'static BigInt {
         let long_obj = obj as *const W_LongObject;
         &*(*long_obj).value
     }
+}
+
+/// Return the translated rbigint GC reference stored in a long wrapper.
+///
+/// PyPy's `rbigint.abs` returns `self` for a nonnegative value and
+/// `W_LongObject.descr_abs` then constructs only a new Python wrapper around
+/// that same payload. Consumers implementing that path need the stored
+/// reference itself, not a Rust `Clone` that translates to a fresh GC payload.
+#[inline]
+pub unsafe fn w_long_get_raw_value(obj: PyObjectRef) -> *mut BigInt {
+    unsafe { (*(obj as *const W_LongObject)).value }
 }
 
 /// `rbigint.fits_int()` (`rpython/rlib/rbigint.py:490`) — JIT-callable
@@ -341,7 +361,7 @@ pub extern "C" fn jit_bigint_fits_int(num: i64) -> i64 {
 /// the two-phase rtyper so it never has to model an `Option<i64>` ABI.
 #[majit_macros::dont_look_inside]
 pub fn jit_bigint_to_i64_fits(num: &BigInt) -> i64 {
-    i64::try_from(num).is_ok() as i64
+    num.fits_int() as i64
 }
 
 /// `rbigint.toint()` (`rpython/rlib/rbigint.py:465`, `@jit.elidable`) on a
@@ -349,7 +369,7 @@ pub fn jit_bigint_to_i64_fits(num: &BigInt) -> i64 {
 /// [`jit_bigint_to_i64_fits`]; overflow means that guard was violated.
 #[majit_macros::dont_look_inside]
 pub fn jit_bigint_to_i64_value(num: &BigInt) -> i64 {
-    i64::try_from(num).unwrap_or_else(|_| {
+    num.toint().unwrap_or_else(|_| {
         panic!("jit_bigint_to_i64_value: BigInt out of i64 range - fits guard violated")
     })
 }
@@ -360,22 +380,22 @@ pub fn jit_bigint_to_i64_value(num: &BigInt) -> i64 {
 /// the Err path. Companion of [`jit_bigint_to_i64_fits`].
 #[majit_macros::dont_look_inside]
 pub fn jit_bigint_to_i64_value_or_zero(num: &BigInt) -> i64 {
-    i64::try_from(num).unwrap_or(0)
+    num.toint().unwrap_or(0)
 }
 
-/// `BigInt::to_u64().is_some()` on a borrowed BigInt payload. Scalar half of
-/// the `BigInt::to_u64()` split so the two-phase rtyper never has to model an
-/// `Option<u64>` ABI. Companion of [`jit_bigint_to_u64_value`].
+/// `rbigint.touint()` on a borrowed BigInt payload. Scalar half of the
+/// fallible conversion so the two-phase rtyper never has to model a
+/// `Result<u64, RBigIntError>` ABI. Companion of [`jit_bigint_to_u64_value`].
 #[majit_macros::dont_look_inside]
 pub fn jit_bigint_to_u64_fits(num: &BigInt) -> i64 {
-    num.to_u64().is_some() as i64
+    num.touint().is_ok() as i64
 }
 
-/// `BigInt::to_u64()` on a borrowed BigInt payload. Callers must first check
-/// [`jit_bigint_to_u64_fits`]; a `None` here means that guard was violated.
+/// `rbigint.touint()` on a borrowed BigInt payload. Callers must first check
+/// [`jit_bigint_to_u64_fits`]; an error here means that guard was violated.
 #[majit_macros::dont_look_inside]
 pub fn jit_bigint_to_u64_value(num: &BigInt) -> u64 {
-    num.to_u64().unwrap_or_else(|| {
+    num.touint().unwrap_or_else(|_| {
         panic!("jit_bigint_to_u64_value: BigInt exceeds u64 range - fits guard violated")
     })
 }
@@ -385,11 +405,7 @@ pub fn jit_bigint_to_u64_value(num: &BigInt) -> u64 {
 /// rtyper does not need a synthetic Rust enum ABI at this boundary.
 #[majit_macros::elidable_cannot_raise]
 pub fn jit_bigint_sign_i64(num: &BigInt) -> i64 {
-    match num.sign() {
-        RBigIntSign::Minus => -1,
-        RBigIntSign::NoSign => 0,
-        RBigIntSign::Plus => 1,
-    }
+    num.get_sign()
 }
 
 /// `rbigint.tofloat()` (`rpython/rlib/rbigint.py:503`) on a borrowed BigInt
@@ -397,14 +413,14 @@ pub fn jit_bigint_sign_i64(num: &BigInt) -> i64 {
 /// scalar return.
 #[majit_macros::elidable_cannot_raise]
 pub fn jit_bigint_to_f64_or_inf(num: &BigInt) -> f64 {
-    num.to_f64().unwrap_or(f64::INFINITY)
+    num.tofloat().unwrap_or(f64::INFINITY)
 }
 
 /// `rbigint.tofloat()` (`rpython/rlib/rbigint.py:503`) on a borrowed BigInt
 /// payload, preserving callers that intentionally collapse overflow to NaN.
 #[majit_macros::elidable_cannot_raise]
 pub fn jit_bigint_to_f64_or_nan(num: &BigInt) -> f64 {
-    num.to_f64().unwrap_or(f64::NAN)
+    num.tofloat().unwrap_or(f64::NAN)
 }
 
 /// `W_LongObject.toint()` (`pypy/objspace/std/longobject.py:138`) →
@@ -447,14 +463,28 @@ pub extern "C" fn jit_w_long_toint(obj: i64) -> i64 {
 #[majit_macros::elidable_or_memerror]
 pub extern "C" fn jit_w_long_add_raw(a: i64, b: i64) -> i64 {
     let (a, b) = (a as PyObjectRef, b as PyObjectRef);
-    unsafe { alloc_bigint_nursery(w_long_get_value(a) + w_long_get_value(b)) as i64 }
+    unsafe {
+        let (av, bv) = (w_long_get_value(a), w_long_get_value(b));
+        if av.get_sign() == 0 {
+            return w_long_get_raw_value(b) as i64;
+        }
+        if bv.get_sign() == 0 {
+            return w_long_get_raw_value(a) as i64;
+        }
+        alloc_bigint_nursery(av + bv) as i64
+    }
 }
 
 /// `rbigint.sub` over `W_LongObject` operands (no-collect). See [`jit_w_long_add_raw`].
 #[majit_macros::elidable_or_memerror]
 pub extern "C" fn jit_w_long_sub_raw(a: i64, b: i64) -> i64 {
     let (a, b) = (a as PyObjectRef, b as PyObjectRef);
-    unsafe { alloc_bigint_nursery(w_long_get_value(a) - w_long_get_value(b)) as i64 }
+    unsafe {
+        if w_long_get_value(b).get_sign() == 0 {
+            return w_long_get_raw_value(a) as i64;
+        }
+        alloc_bigint_nursery(w_long_get_value(a) - w_long_get_value(b)) as i64
+    }
 }
 
 /// `rbigint.mul` over `W_LongObject` operands (no-collect). See [`jit_w_long_add_raw`].
@@ -505,6 +535,12 @@ pub extern "C" fn jit_bigint_add(a: i64, b: i64) -> i64 {
     // Two-limb fast path: when both operands and the sum fit i128 the result
     // is exact without the general limb machinery.
     unsafe {
+        if (&*a).get_sign() == 0 {
+            return b as i64;
+        }
+        if (&*b).get_sign() == 0 {
+            return a as i64;
+        }
         if let (Ok(x), Ok(y)) = (i128::try_from(&*a), i128::try_from(&*b)) {
             if let Some(z) = x.checked_add(y) {
                 return alloc_bigint_nursery_collecting(BigInt::from(z)) as i64;
@@ -530,6 +566,9 @@ pub extern "C" fn jit_bigint_sub(a: i64, b: i64) -> i64 {
     let (a, b) = (a as *const BigInt, b as *const BigInt);
     // Two-limb fast path mirroring `jit_bigint_add`.
     unsafe {
+        if (&*b).get_sign() == 0 {
+            return a as i64;
+        }
         if let (Ok(x), Ok(y)) = (i128::try_from(&*a), i128::try_from(&*b)) {
             if let Some(z) = x.checked_sub(y) {
                 return alloc_bigint_nursery_collecting(BigInt::from(z)) as i64;

--- a/pyre/pyre-object/src/longobject.rs
+++ b/pyre/pyre-object/src/longobject.rs
@@ -769,6 +769,38 @@ mod tests {
     }
 
     #[test]
+    fn test_bigint_add_zero_shortcuts_preserve_payload_identity() {
+        let zero_obj = w_long_new(BigInt::from(0));
+        let value_obj = w_long_new(BigInt::from(i64::MAX) + BigInt::from(17));
+        let zero_payload = unsafe { w_long_get_raw_value(zero_obj) };
+        let value_payload = unsafe { w_long_get_raw_value(value_obj) };
+
+        assert_eq!(
+            jit_w_long_add_raw(zero_obj as i64, value_obj as i64) as *mut BigInt,
+            value_payload
+        );
+        assert_eq!(
+            jit_w_long_add_raw(value_obj as i64, zero_obj as i64) as *mut BigInt,
+            value_payload
+        );
+        assert_eq!(
+            jit_bigint_add(zero_payload as i64, value_payload as i64) as *mut BigInt,
+            value_payload
+        );
+        assert_eq!(
+            jit_bigint_add(value_payload as i64, zero_payload as i64) as *mut BigInt,
+            value_payload
+        );
+        unsafe {
+            assert_eq!(&*zero_payload, &BigInt::from(0));
+            assert_eq!(
+                &*value_payload,
+                &(BigInt::from(i64::MAX) + BigInt::from(17))
+            );
+        }
+    }
+
+    #[test]
     fn test_bare_bigint_constructor_comparison_and_scalar_residuals() {
         let a = jit_bigint_from_i64(-42);
         let b = jit_bigint_from_u64(42);

--- a/pyre/pyre-object/src/rbigint.rs
+++ b/pyre/pyre-object/src/rbigint.rs
@@ -454,8 +454,8 @@ fn prebuilt_payload_pointer(value: &RBigInt) -> Option<*mut RBigInt> {
 }
 
 #[inline]
-pub fn alloc_rbigint_nursery(value: RBigInt) -> *mut RBigInt {
-    if let Some(prebuilt) = prebuilt_payload_pointer(&value) {
+fn alloc_rbigint_nursery_impl(value: RBigInt, canonicalize_prebuilt: bool) -> *mut RBigInt {
+    if canonicalize_prebuilt && let Some(prebuilt) = prebuilt_payload_pointer(&value) {
         return prebuilt;
     }
     let tid = rbigint_gc_type_id();
@@ -484,8 +484,16 @@ pub fn alloc_rbigint_nursery(value: RBigInt) -> *mut RBigInt {
 }
 
 #[inline]
-pub fn alloc_rbigint_nursery_collecting(mut value: RBigInt) -> *mut RBigInt {
-    if let Some(prebuilt) = prebuilt_payload_pointer(&value) {
+pub fn alloc_rbigint_nursery(value: RBigInt) -> *mut RBigInt {
+    alloc_rbigint_nursery_impl(value, true)
+}
+
+#[inline]
+fn alloc_rbigint_nursery_collecting_impl(
+    mut value: RBigInt,
+    canonicalize_prebuilt: bool,
+) -> *mut RBigInt {
+    if canonicalize_prebuilt && let Some(prebuilt) = prebuilt_payload_pointer(&value) {
         return prebuilt;
     }
     let tid = rbigint_gc_type_id();
@@ -520,7 +528,23 @@ pub fn alloc_rbigint_nursery_collecting(mut value: RBigInt) -> *mut RBigInt {
             return raw as *mut RBigInt;
         }
     }
-    alloc_rbigint_nursery(value)
+    alloc_rbigint_nursery_impl(value, canonicalize_prebuilt)
+}
+
+#[inline]
+pub fn alloc_rbigint_nursery_collecting(value: RBigInt) -> *mut RBigInt {
+    alloc_rbigint_nursery_collecting_impl(value, true)
+}
+
+/// Allocate the fresh translated GC handle required by `RBigInt::clone`.
+///
+/// RPython's `rbigint.neg`/`abs` shallow-copy the immutable digit list and
+/// then update the new rbigint object's sign. Rust represents that intermediate
+/// object as a by-value handle, so the clone residual must preserve the shared
+/// digit array while bypassing the ordinary prebuilt-payload canonicalization.
+#[inline]
+pub fn alloc_rbigint_clone_nursery_collecting(value: RBigInt) -> *mut RBigInt {
+    alloc_rbigint_nursery_collecting_impl(value, false)
 }
 
 #[inline]
@@ -5682,6 +5706,49 @@ mod tests {
         let raw_zero_c = alloc_rbigint_stable(RBigInt::fromint(0));
         assert_eq!(raw_zero_a, raw_zero_b);
         assert_eq!(raw_zero_a, raw_zero_c);
+    }
+
+    #[test]
+    fn test_clone_allocation_bypasses_prebuilt_payload_canonicalization() {
+        let prebuilts = [
+            RBigInt::zero(),
+            RBigInt::one(),
+            RBigInt::negative_one(),
+            RBigInt::five(),
+        ];
+
+        for value in prebuilts {
+            let prebuilt = prebuilt_payload_pointer(&value).expect("prebuilt payload");
+            let original_sign = unsafe { (*prebuilt).get_sign() };
+            let original_digits = unsafe { (*prebuilt)._digits };
+            let cloned = alloc_rbigint_clone_nursery_collecting(value.clone());
+
+            assert_ne!(
+                cloned, prebuilt,
+                "the clone residual must allocate a fresh rbigint handle"
+            );
+            assert_eq!(
+                unsafe { (*cloned)._digits },
+                original_digits,
+                "the fresh handle must retain rbigint's shallow digit sharing"
+            );
+
+            // Generated neg/abs code mutates the cloned handle's `_size`.
+            // Exercise the same write directly, including zero where changing
+            // the raw size makes aliasing observable despite `_set_sign(0)`.
+            unsafe {
+                if original_sign == 0 {
+                    (*cloned)._size = 1;
+                } else {
+                    (*cloned)._set_sign(-original_sign);
+                }
+                assert_eq!(
+                    (*prebuilt).get_sign(),
+                    original_sign,
+                    "mutating the fresh handle must not corrupt the immortal prebuilt"
+                );
+            }
+        }
     }
 
     #[test]

--- a/pyre/pyre-object/src/rbigint.rs
+++ b/pyre/pyre-object/src/rbigint.rs
@@ -193,6 +193,55 @@ pub struct RBigInt {
     _size: i64,
 }
 
+/// Address-stable GC root for a host-side, by-value `RBigInt`.
+///
+/// RPython's GC transform puts an `rbigint` local's `_digits` edge in the
+/// shadow stack whenever that local is live across a call that can collect.
+/// Rust locals have no generated stack map, so interpreter-level consumers
+/// that retain an unboxed `RBigInt` across a Python callback use this exact
+/// analogue.  The `Box` is required: moving this guard must not move the slot
+/// registered with MiniMark.
+pub struct RBigIntGcRoot {
+    value: Box<RBigInt>,
+    slot: *mut *mut u8,
+    registered: bool,
+}
+
+impl RBigIntGcRoot {
+    pub fn new(value: RBigInt) -> Self {
+        let mut value = Box::new(value);
+        let slot = (&mut value._digits as *mut *mut TypedItemsBlock).cast::<*mut u8>();
+        let registered = unsafe { crate::gc_hook::try_gc_add_root(slot) };
+        Self {
+            value,
+            slot,
+            registered,
+        }
+    }
+}
+
+impl std::ops::Deref for RBigIntGcRoot {
+    type Target = RBigInt;
+
+    fn deref(&self) -> &Self::Target {
+        &self.value
+    }
+}
+
+impl std::ops::DerefMut for RBigIntGcRoot {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.value
+    }
+}
+
+impl Drop for RBigIntGcRoot {
+    fn drop(&mut self) {
+        if self.registered {
+            crate::gc_hook::try_gc_remove_root(self.slot);
+        }
+    }
+}
+
 /// `rpython.rlib.rstring.NumberStringParser`.
 ///
 /// This deliberately remains an iterator-like parser over the original
@@ -368,7 +417,11 @@ impl<'a> NumberStringParser<'a> {
         }
 
         debug_assert!(self.allow_underscores);
-        let mut builder = String::with_capacity((self.end - self.start) as usize);
+        let capacity = usize::try_from(self.end - self.start).map_err(|_| RBigIntError::Memory)?;
+        let mut builder = String::new();
+        builder
+            .try_reserve_exact(capacity)
+            .map_err(|_| RBigIntError::Memory)?;
         loop {
             let digit = self.next_digit()?;
             if digit < 0 {
@@ -454,7 +507,10 @@ fn prebuilt_payload_pointer(value: &RBigInt) -> Option<*mut RBigInt> {
 }
 
 #[inline]
-fn alloc_rbigint_nursery_impl(value: RBigInt, canonicalize_prebuilt: bool) -> *mut RBigInt {
+pub(crate) fn alloc_rbigint_nursery_impl(
+    value: RBigInt,
+    canonicalize_prebuilt: bool,
+) -> *mut RBigInt {
     if canonicalize_prebuilt && let Some(prebuilt) = prebuilt_payload_pointer(&value) {
         return prebuilt;
     }
@@ -618,6 +674,18 @@ pub enum RBigIntSign {
 }
 
 impl RBigInt {
+    /// Rust ownership spelling for an RPython reference assignment.
+    ///
+    /// The host needs a shallow value clone, but source translation aliases
+    /// this exact method's input and output so upstream fast paths that return
+    /// `self`/`other` do not allocate a new GC payload. Do not use this for
+    /// `rbigint.neg`, which deliberately constructs a fresh handle.
+    #[doc(hidden)]
+    #[inline]
+    pub fn translated_alias(&self) -> Self {
+        self.clone()
+    }
+
     #[inline]
     fn prebuilt(slot: &'static std::sync::OnceLock<usize>, digit: Digit, sign: i64) -> Self {
         let raw = *slot.get_or_init(|| {
@@ -631,10 +699,10 @@ impl RBigInt {
             };
             Box::into_raw(Box::new(value)) as usize
         }) as *const Self;
-        // RPython assignment shares the immutable prebuilt rbigint.  A Rust
-        // RBigInt value is the translated handle, so its shallow clone carries
-        // the same `_digits` GC reference without exposing object identity.
-        unsafe { (&*raw).clone() }
+        // RPython assignment returns the process-global rbigint itself. The
+        // host needs a shallow owned handle; source translation aliases the
+        // exact immortal payload address instead of allocating a clone.
+        unsafe { (&*raw).translated_alias() }
     }
 
     #[inline]
@@ -674,6 +742,38 @@ impl RBigInt {
             _digits: block,
             _size: logical_len * sign,
         }
+    }
+
+    /// Fallible form of [`RBigInt::new`] for upstream paths whose translated
+    /// allocation has an explicit MemoryError edge.
+    fn try_new(digits: &[Digit], sign: i64, size: i64) -> Result<Self, RBigIntError> {
+        debug_assert!(size >= 0);
+        let logical_len = if size == 0 {
+            i64::try_from(digits.len()).map_err(|_| RBigIntError::Memory)?
+        } else {
+            size
+        };
+        let allocation_size = digits.len().max(1);
+        let block = unsafe {
+            try_alloc_typed_items_block_nursery(allocation_size, GC_INT_ARRAY_GC_TYPE_ID)
+        }
+        .ok_or(RBigIntError::Memory)?;
+        unsafe {
+            let base = typed_items_block_items_base(block) as *mut Digit;
+            if digits.is_empty() {
+                *base = NULLDIGIT;
+            } else {
+                let mut i = 0;
+                while i < digits.len() {
+                    *base.add(i) = digits[i];
+                    i += 1;
+                }
+            }
+        }
+        Ok(Self {
+            _digits: block,
+            _size: logical_len.checked_mul(sign).ok_or(RBigIntError::Memory)?,
+        })
     }
 
     /// Allocate the translated equivalent of `[NULLDIGIT] * size`.
@@ -975,8 +1075,14 @@ impl RBigInt {
         // `len(s) * 8 // LONG_BIT + 1`) and then passes `digits[:]` to the
         // rbigint constructor.  Reserve enough fixed-width slots for that
         // append phase here; below we make the same exact-length final copy.
-        let max_digits = (bytes.len() as i64 * 8 + SHIFT - 1) / SHIFT;
-        let mut result = Self::with_size(max_digits, sign);
+        let max_digits = bytes
+            .len()
+            .checked_mul(8)
+            .and_then(|value| value.checked_add(SHIFT as usize - 1))
+            .map(|value| value / SHIFT as usize)
+            .and_then(|value| i64::try_from(value).ok())
+            .ok_or(RBigIntError::Memory)?;
+        let mut result = Self::try_with_size(max_digits, sign)?;
         let mut accum = 0_u128;
         let mut accumbits = 0_i64;
         let mut out = 0;
@@ -1012,7 +1118,7 @@ impl RBigInt {
         // `digits[:]` in rbigint.py:386 discards the temporary list's spare
         // capacity.  Keeping `max_digits` as the final GcArray capacity makes
         // the translated storage shape depend on a reservation detail.
-        result = Self::new(&result.digits()[..out as usize], sign, out);
+        result = Self::try_new(&result.digits()[..out as usize], sign, out)?;
         result._normalize();
         Ok(result)
     }
@@ -1035,7 +1141,14 @@ impl RBigInt {
         let imax = self.numdigits();
         let mut accum = 0_i128;
         let mut accumbits = 0_i64;
-        let mut result = Vec::with_capacity(nbytes as usize);
+        // StringBuilder(nbytes) in rbigint.py carries the translated
+        // gc_malloc/MemoryError edge.  Preserve it explicitly instead of
+        // truncating i64 to usize on wasm32 or panicking on capacity overflow.
+        let capacity = usize::try_from(nbytes).map_err(|_| RBigIntError::Memory)?;
+        let mut result = Vec::new();
+        result
+            .try_reserve_exact(capacity)
+            .map_err(|_| RBigIntError::Memory)?;
         let mut carry = 1_i128;
         let mut i = 0;
         while i < imax {
@@ -1365,10 +1478,10 @@ impl RBigInt {
         let selfsign = self.get_sign();
         let othersign = other.get_sign();
         if selfsign == 0 {
-            return other.clone();
+            return other.translated_alias();
         }
         if othersign == 0 {
-            return self.clone();
+            return self.translated_alias();
         }
         let mut result = if selfsign == othersign {
             _x_add(self, other)
@@ -1386,7 +1499,7 @@ impl RBigInt {
             return Self::fromint(iother);
         }
         if iother == 0 {
-            return self.clone();
+            return self.translated_alias();
         }
         if !int_in_valid_range(iother) {
             return self.add(&Self::fromint(iother));
@@ -1453,7 +1566,7 @@ impl RBigInt {
         let selfsign = self.get_sign();
         let othersign = other.get_sign();
         if othersign == 0 {
-            return self.clone();
+            return self.translated_alias();
         }
         if selfsign == 0 {
             return Self::new(
@@ -1478,7 +1591,7 @@ impl RBigInt {
             return self.sub(&Self::fromint(iother));
         }
         if iother == 0 {
-            return self.clone();
+            return self.translated_alias();
         }
         if selfsign == 0 {
             return Self::fromint(-iother);
@@ -1577,7 +1690,7 @@ impl RBigInt {
         let othersign = intsign(iother);
         if digit == 1 {
             if othersign == 1 {
-                return self.clone();
+                return self.translated_alias();
             }
             return Self::new(
                 &self.digits()[..asize as usize],
@@ -1670,7 +1783,7 @@ impl RBigInt {
         let selfsign = self.get_sign();
         if selfsign == 1 && iother > 0 {
             if digit == 1 {
-                return Ok(self.clone());
+                return Ok(self.translated_alias());
             } else if digit & (digit - 1) == 0 {
                 return Ok(self.rqshift(PTWOTABLE[digit.trailing_zeros() as usize]));
             }
@@ -1894,7 +2007,7 @@ impl RBigInt {
         if modulus.is_none() && size_b == 1 {
             let digit = other.digit(0);
             if digit == ONEDIGIT {
-                return Ok(base.clone());
+                return Ok(base.translated_alias());
             } else if base.numdigits() == 1 {
                 let adigit = base.udigit(0);
                 if adigit == 1 {
@@ -2014,7 +2127,7 @@ impl RBigInt {
         } else if selfsign == 0 {
             return Ok(Self::zero());
         } else if iother == 1 {
-            return Ok(self.clone());
+            return Ok(self.translated_alias());
         } else if self.numdigits() == 1 {
             let adigit = self.udigit(0);
             if adigit == 1 {
@@ -2077,7 +2190,7 @@ impl RBigInt {
     #[majit_macros::jit_elidable]
     pub fn abs(&self) -> Self {
         if self.get_sign() != -1 {
-            self.clone()
+            self.translated_alias()
         } else {
             self.neg()
         }
@@ -2101,7 +2214,7 @@ impl RBigInt {
         if int_other < 0 {
             return Err(RBigIntError::NegativeShift);
         } else if int_other == 0 || selfsign == 0 {
-            return Ok(self.clone());
+            return Ok(self.translated_alias());
         }
         let mut wordshift = int_other / SHIFT as i64;
         let remshift = int_other % SHIFT;
@@ -2213,7 +2326,7 @@ impl RBigInt {
         if int_other < 0 {
             return Err(RBigIntError::NegativeShift);
         } else if int_other == 0 {
-            return Ok(self.clone());
+            return Ok(self.translated_alias());
         }
         let selfsign = self.get_sign();
         if selfsign == -1 && !dont_invert {
@@ -3639,7 +3752,10 @@ pub(crate) fn _x_divrem(v1: &RBigInt, w1: &RBigInt) -> (RBigInt, RBigInt) {
         let carry = _v_rshift(&mut w, &v, size_w, d);
         debug_assert_eq!(carry, 0);
         w._normalize();
-        return (RBigInt::zero(), w);
+        // rbigint.py:2322 deliberately does not return NULLRBIGINT here:
+        // callers of this internal division helper may modify the result.
+        // Keep both the rbigint value and its digit array fresh.
+        return (RBigInt::new(&[NULLDIGIT], 0, 0), w);
     }
     let mut a = RBigInt::with_size(k, 1);
     let wm1 = w.widedigit(size_w - 1);
@@ -3700,7 +3816,7 @@ pub fn _divrem(a: &RBigInt, b: &RBigInt) -> Result<(RBigInt, RBigInt), RBigIntEr
         return Err(RBigIntError::DivisionByZero);
     }
     if size_a < size_b || (size_a == size_b && a.digit(size_a - 1) < b.digit(size_b - 1)) {
-        return Ok((RBigInt::zero(), a.clone()));
+        return Ok((RBigInt::zero(), a.translated_alias()));
     }
     let (mut z, mut rem) = if size_b == 1 {
         let (z, urem) = _divrem1(a, b.digit(0));
@@ -3767,7 +3883,7 @@ fn div2n1n(
         half_n_s,
     )?;
     let (q2, r) = div3n2n(&r1, 0, a_container, a_startindex, b, &b1, &b2, half_n_s)?;
-    Ok((_full_digits_lshift_then_or(&q1, half_n_s, &q2), r))
+    Ok((_full_digits_lshift_then_or(&q1, half_n_s, &q2)?, r))
 }
 
 /// rbigint.py:2497 `div3n2n`.
@@ -3787,7 +3903,8 @@ fn div3n2n(
         r = _extract_digits(a3_container, a3_startindex, n_s);
     } else {
         let r_size = r.numdigits();
-        let mut combined = RBigInt::with_size(n_s + r_size, 1);
+        let combined_size = n_s.checked_add(r_size).ok_or(RBigIntError::Memory)?;
+        let mut combined = RBigInt::try_with_size(combined_size, 1)?;
         let stop = (a3_startindex + n_s).min(a3_container.numdigits());
         let mut source = a3_startindex;
         let mut index = 0;
@@ -3818,13 +3935,14 @@ fn div3n2n(
 }
 
 /// rbigint.py:2525 `_full_digits_lshift_then_or`.
-fn _full_digits_lshift_then_or(a: &RBigInt, n: i64, b: &RBigInt) -> RBigInt {
+fn _full_digits_lshift_then_or(a: &RBigInt, n: i64, b: &RBigInt) -> Result<RBigInt, RBigIntError> {
     if a.get_sign() == 0 {
-        return b.clone();
+        return Ok(b.translated_alias());
     }
     let bdigits = b.numdigits();
     debug_assert!(bdigits <= n);
-    let mut result = RBigInt::with_size(a.numdigits() + n, 1);
+    let result_size = a.numdigits().checked_add(n).ok_or(RBigIntError::Memory)?;
+    let mut result = RBigInt::try_with_size(result_size, 1)?;
     let mut i = 0;
     while i < bdigits {
         result.setdigit(i, b.digit(i));
@@ -3835,7 +3953,7 @@ fn _full_digits_lshift_then_or(a: &RBigInt, n: i64, b: &RBigInt) -> RBigInt {
         result.setdigit(n + i, a.digit(i));
         i += 1;
     }
-    result
+    Ok(result)
 }
 
 /// rbigint.py:2545 `_divmod_fast_pos`.
@@ -3843,7 +3961,7 @@ fn _divmod_fast_pos(a: &RBigInt, b: &RBigInt) -> Result<(RBigInt, RBigInt), RBig
     let n = b.bit_length()?;
     let m = a.bit_length()?;
     if m < n {
-        return Ok((RBigInt::zero(), a.clone()));
+        return Ok((RBigInt::zero(), a.translated_alias()));
     }
     let mut new_n = SHIFT as i64 * holder_limit(&HOLDER.DIV_LIMIT);
     while new_n < n {
@@ -3862,8 +3980,16 @@ fn _divmod_fast_pos(a: &RBigInt, b: &RBigInt) -> Result<(RBigInt, RBigInt), RBig
     };
     let n_s = new_n / SHIFT as i64;
 
-    let chunk_count = (a.numdigits() + n_s - 1) / n_s;
-    let mut a_digits_base_two_pow_n = Vec::with_capacity(chunk_count as usize);
+    let chunk_count = a
+        .numdigits()
+        .checked_add(n_s - 1)
+        .ok_or(RBigIntError::Memory)?
+        / n_s;
+    let chunk_capacity = usize::try_from(chunk_count).map_err(|_| RBigIntError::Memory)?;
+    let mut a_digits_base_two_pow_n = Vec::new();
+    a_digits_base_two_pow_n
+        .try_reserve_exact(chunk_capacity)
+        .map_err(|_| RBigIntError::Memory)?;
     let mut start = 0;
     while start < a.numdigits() {
         // rbigint.py:2570-2577 constructs these chunks directly from
@@ -3873,7 +3999,8 @@ fn _divmod_fast_pos(a: &RBigInt, b: &RBigInt) -> Result<(RBigInt, RBigInt), RBig
         // machine digits) for the recursive Burnikel-Ziegler slice offsets.
         let stop = (start + n_s).min(a.numdigits());
         let digits = &a.digits()[start as usize..stop as usize];
-        a_digits_base_two_pow_n.push(RBigInt::new(digits, 1, digits.len() as i64));
+        let digits_len = i64::try_from(digits.len()).map_err(|_| RBigIntError::Memory)?;
+        a_digits_base_two_pow_n.push(RBigInt::try_new(digits, 1, digits_len)?);
         start = stop;
     }
     let mut a_digits_index = a_digits_base_two_pow_n.len() as i64 - 1;
@@ -3882,20 +4009,25 @@ fn _divmod_fast_pos(a: &RBigInt, b: &RBigInt) -> Result<(RBigInt, RBigInt), RBig
     if a_digits_base_two_pow_n[a_digits_index as usize].ge(b) {
         r = RBigInt::zero();
     } else {
-        r = a_digits_base_two_pow_n[a_digits_index as usize].clone();
+        r = a_digits_base_two_pow_n[a_digits_index as usize].translated_alias();
         a_digits_index -= 1;
     }
 
     let mut q_digits: Option<RBigInt> = None;
     let mut q_index_start = a_digits_index * n_s;
     while a_digits_index >= 0 {
-        let arg1 =
-            _full_digits_lshift_then_or(&r, n_s, &a_digits_base_two_pow_n[a_digits_index as usize]);
+        let arg1 = _full_digits_lshift_then_or(
+            &r,
+            n_s,
+            &a_digits_base_two_pow_n[a_digits_index as usize],
+        )?;
         let (q_digit, next_r) = div2n1n(&arg1, 0, b, n_s)?;
         r = next_r;
         if q_digits.is_none() {
-            let q_size = q_index_start + q_digit.numdigits();
-            q_digits = Some(RBigInt::with_size(q_size, 1));
+            let q_size = q_index_start
+                .checked_add(q_digit.numdigits())
+                .ok_or(RBigIntError::Memory)?;
+            q_digits = Some(RBigInt::try_with_size(q_size, 1)?);
         }
         if let Some(q_digits) = &mut q_digits {
             let mut i = 0;
@@ -4025,7 +4157,7 @@ fn _AsDouble(value: &RBigInt) -> Result<f64, RBigIntError> {
         return Err(RBigIntError::Overflow);
     }
 
-    let mut result = (q as f64) * 2_f64.powi((exp - DBL_MANT_DIG) as i32);
+    let mut result = _float_ldexp(q as f64, exp - DBL_MANT_DIG);
     if sign < 0 {
         result = -result;
     }
@@ -4136,6 +4268,23 @@ fn _truediv_overflow<T>() -> Result<T, RBigIntError> {
     Err(RBigIntError::FloatDivisionOverflow)
 }
 
+/// RPython's `math.ldexp(value, exponent)` spelling used by `_AsDouble` and
+/// `_bigint_true_divide`.  Computing `value * 2.0.powi(exponent)` directly is
+/// not equivalent: for a subnormal result the power-of-two factor can become
+/// zero before it is multiplied by the exactly-representable mantissa.
+#[inline]
+fn _float_ldexp(mut value: f64, mut exponent: i64) -> f64 {
+    while exponent > 1023 {
+        value *= 2.0_f64.powi(1023);
+        exponent -= 1023;
+    }
+    while exponent < -1022 {
+        value *= 2.0_f64.powi(-1022);
+        exponent += 1022;
+    }
+    value * 2.0_f64.powi(exponent as i32)
+}
+
 /// rbigint.py:2844 `_bigint_true_divide`.
 fn _bigint_true_divide(a: &RBigInt, b: &RBigInt) -> Result<f64, RBigIntError> {
     const DBL_MANT_DIG: i64 = 53;
@@ -4220,7 +4369,7 @@ fn _bigint_true_divide(a: &RBigInt, b: &RBigInt) -> Result<f64, RBigIntError> {
     {
         return _truediv_overflow();
     }
-    Ok(_truediv_result(dx * 2_f64.powi(shift as i32), negate))
+    Ok(_truediv_result(_float_ldexp(dx, shift), negate))
 }
 
 pub const BASE8: &str = "01234567";
@@ -4234,7 +4383,7 @@ fn _format_base2_notzero(
     prefix: &str,
     suffix: &str,
     _max_str_digits: i64,
-) -> String {
+) -> Result<String, RBigIntError> {
     let digit_bytes = digits.as_bytes();
     let base = digit_bytes.len() as i64;
     let mut accum = 0_u128;
@@ -4246,11 +4395,25 @@ fn _format_base2_notzero(
         i >>= 1;
     }
     let size_a = a.numdigits();
-    let capacity =
-        (5 + prefix.len() as i64
-            + suffix.len() as i64
-            + (size_a * SHIFT as i64 + basebits as i64 - 1) / basebits as i64) as usize;
-    let mut result = vec![0_u8; capacity];
+    // rbigint.py allocates `[chr(0)] * i`; its translated allocation can
+    // raise MemoryError.  Keep that edge instead of allowing Rust sizing
+    // arithmetic to wrap or an infallible allocation to abort the process.
+    let payload_bits = size_a
+        .checked_mul(SHIFT as i64)
+        .and_then(|value| value.checked_add(basebits as i64 - 1))
+        .ok_or(RBigIntError::Memory)?;
+    let encoded_digits = payload_bits / basebits as i64;
+    let capacity = 5_i64
+        .checked_add(i64::try_from(prefix.len()).map_err(|_| RBigIntError::Memory)?)
+        .and_then(|value| value.checked_add(suffix.len() as i64))
+        .and_then(|value| value.checked_add(encoded_digits))
+        .and_then(|value| usize::try_from(value).ok())
+        .ok_or(RBigIntError::Memory)?;
+    let mut result = Vec::new();
+    result
+        .try_reserve_exact(capacity)
+        .map_err(|_| RBigIntError::Memory)?;
+    result.resize(capacity, 0_u8);
     let mut next_char_index = capacity;
     let mut j = suffix.len();
     while j > 0 {
@@ -4289,8 +4452,9 @@ fn _format_base2_notzero(
         next_char_index -= 1;
         result[next_char_index] = b'-';
     }
-    String::from_utf8(result[next_char_index..].to_vec())
-        .expect("rbigint format digit alphabets are ASCII")
+    result.copy_within(next_char_index.., 0);
+    result.truncate(capacity - next_char_index);
+    Ok(String::from_utf8(result).expect("rbigint format digit alphabets are ASCII"))
 }
 
 struct PartsCacheBase {
@@ -4306,6 +4470,38 @@ struct PartsCacheBase {
     // complete list on every formatting call, and never retain this lock
     // across a bigint allocation/GC safepoint.
     parts_cache: std::sync::Mutex<std::sync::Arc<Vec<std::sync::Arc<RBigInt>>>>,
+}
+
+/// Explicit root for a cached rbigint that has been computed but is not yet
+/// reachable from the translated module-global `_parts_cache` graph.
+///
+/// RPython's GC transform roots this local automatically across publication.
+/// In pyre another mutator may collect while this thread is allocating the
+/// host-side snapshot vector, so the cached value's movable GcArray(Signed)
+/// slot must be registered until either the shared list owns it or it is
+/// discarded after losing a concurrent append race.
+struct PendingPartsCacheDigitRoot {
+    slot: *mut *mut u8,
+    registered: bool,
+}
+
+impl PendingPartsCacheDigitRoot {
+    /// `value`'s Arc allocation keeps the slot address stable for this
+    /// guard's lifetime.
+    unsafe fn new(value: &std::sync::Arc<RBigInt>) -> Self {
+        let value = std::sync::Arc::as_ptr(value) as *mut RBigInt;
+        let slot = unsafe { &mut (*value)._digits as *mut *mut TypedItemsBlock as *mut *mut u8 };
+        let registered = unsafe { crate::gc_hook::try_gc_add_root(slot) };
+        Self { slot, registered }
+    }
+}
+
+impl Drop for PendingPartsCacheDigitRoot {
+    fn drop(&mut self) {
+        if self.registered {
+            crate::gc_hook::try_gc_remove_root(self.slot);
+        }
+    }
 }
 
 impl PartsCacheBase {
@@ -4365,7 +4561,7 @@ impl PartsCacheBase {
     fn parts_snapshot(&self) -> std::sync::Arc<Vec<std::sync::Arc<RBigInt>>> {
         self.parts_cache
             .lock()
-            .expect("rbigint parts list lock poisoned")
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
             .clone()
     }
 
@@ -4381,7 +4577,12 @@ impl PartsCacheBase {
         // Do every bigint/GC allocation outside the list lock.  MiniMark's
         // STW root walker locks this same shared list to forward `_digits`.
         let next = std::sync::Arc::new(last.int_pow(2, None)?);
-        let mut extended = Vec::with_capacity(expected.len() + 1);
+        let _next_root = unsafe { PendingPartsCacheDigitRoot::new(&next) };
+        let extended_len = expected.len().checked_add(1).ok_or(RBigIntError::Memory)?;
+        let mut extended = Vec::new();
+        extended
+            .try_reserve_exact(extended_len)
+            .map_err(|_| RBigIntError::Memory)?;
         extended.extend(expected.iter().cloned());
         extended.push(next);
         let extended = std::sync::Arc::new(extended);
@@ -4389,7 +4590,7 @@ impl PartsCacheBase {
         let mut shared = self
             .parts_cache
             .lock()
-            .expect("rbigint parts list lock poisoned");
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         if std::sync::Arc::ptr_eq(&shared, expected) {
             *shared = extended;
         }
@@ -4434,12 +4635,12 @@ pub fn walk_rbigint_cache_digit_slots(mut visitor: impl FnMut(&mut *mut u8)) {
 
     let all = PARTS_CACHE
         .lock()
-        .expect("rbigint process-global parts cache lock poisoned");
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
     for cache in all.iter().flatten() {
         let parts = cache
             .parts_cache
             .lock()
-            .expect("rbigint parts list lock poisoned");
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         for value in parts.iter() {
             // Every published snapshot is a monotonic extension and shares
             // these exact Arc<RBigInt> objects with older reader snapshots.
@@ -4464,7 +4665,7 @@ fn get_cached_parts(base: i64) -> PartsCacheRef {
     {
         let all = PARTS_CACHE
             .lock()
-            .expect("rbigint process-global parts cache lock poisoned");
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         if let Some(cache) = &all[index as usize] {
             return cache.clone();
         }
@@ -4473,9 +4674,17 @@ fn get_cached_parts(base: i64) -> PartsCacheRef {
     // Construct outside the owner lock: `fromint` allocates a digit array and
     // the collector walks this same process-global owner.
     let initial = std::sync::Arc::new(PartsCacheBase::new(base));
+    let initial_part = {
+        let parts = initial
+            .parts_cache
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        parts[0].clone()
+    };
+    let _initial_root = unsafe { PendingPartsCacheDigitRoot::new(&initial_part) };
     let mut all = PARTS_CACHE
         .lock()
-        .expect("rbigint process-global parts cache lock poisoned");
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
     all[index as usize].get_or_insert(initial).clone()
 }
 
@@ -4715,20 +4924,26 @@ fn _format(
     max_str_digits: i64,
 ) -> Result<String, RBigIntError> {
     if x.get_sign() == 0 {
-        return Ok(format!("{prefix}0{suffix}"));
+        let capacity = prefix
+            .len()
+            .checked_add(1)
+            .and_then(|value| value.checked_add(suffix.len()))
+            .ok_or(RBigIntError::Memory)?;
+        let mut output = String::new();
+        output
+            .try_reserve_exact(capacity)
+            .map_err(|_| RBigIntError::Memory)?;
+        output.push_str(prefix);
+        output.push('0');
+        output.push_str(suffix);
+        return Ok(output);
     }
     let base = digits.len() as i64;
     if !(2..=36).contains(&base) {
         return Err(RBigIntError::InvalidBase);
     }
     if base & (base - 1) == 0 {
-        return Ok(_format_base2_notzero(
-            x,
-            digits,
-            prefix,
-            suffix,
-            max_str_digits,
-        ));
+        return _format_base2_notzero(x, digits, prefix, suffix, max_str_digits);
     }
     let negative = x.get_sign() < 0;
     let x_owned;
@@ -4758,12 +4973,20 @@ fn _format(
 
     let mut startindex = 0;
     while startindex < pts.len() as i64 && pts[startindex as usize].as_ref().lt(x) {
-        stringsize *= 2;
+        stringsize = stringsize.checked_mul(2).ok_or(RBigIntError::Memory)?;
         startindex += 1;
     }
     startindex -= 1;
-    stringsize += prefix.len() as i64 + suffix.len() as i64 + negative as i64;
-    let mut output = String::with_capacity(stringsize as usize);
+    stringsize = stringsize
+        .checked_add(i64::try_from(prefix.len()).map_err(|_| RBigIntError::Memory)?)
+        .and_then(|value| value.checked_add(suffix.len() as i64))
+        .and_then(|value| value.checked_add(negative as i64))
+        .ok_or(RBigIntError::Memory)?;
+    let capacity = usize::try_from(stringsize).map_err(|_| RBigIntError::Memory)?;
+    let mut output = String::new();
+    output
+        .try_reserve_exact(capacity)
+        .map_err(|_| RBigIntError::Memory)?;
     if negative {
         output.push('-');
     }
@@ -4779,7 +5002,7 @@ fn _format(
         let size_prefix = output.len() as i64;
         if digits == BASE10 {
             _format_recursive_decimal(
-                x.clone(),
+                x.translated_alias(),
                 startindex,
                 &mut output,
                 &pcb,
@@ -4790,7 +5013,7 @@ fn _format(
             )?;
         } else {
             _format_recursive_general(
-                x.clone(),
+                x.translated_alias(),
                 startindex,
                 &mut output,
                 &pcb,
@@ -5331,7 +5554,7 @@ impl FivePowCache {
         self.entries
             .iter()
             .find(|(candidate, _)| *candidate == key)
-            .map(|(_, value)| value.clone())
+            .map(|(_, value)| value.translated_alias())
     }
 
     fn contains(&self, key: i64) -> bool {
@@ -5365,7 +5588,7 @@ fn _str_to_int_big_w5pow(
         let larger = _str_to_int_big_w5pow(w - w2, mem, limit)?;
         smaller.mul(&larger)
     };
-    mem.insert(w, result.clone());
+    mem.insert(w, result.translated_alias());
     Ok(result)
 }
 
@@ -5616,7 +5839,14 @@ pub fn tobytes_int(
     if !signed && intval < 0 {
         return Err(RBigIntError::InvalidSignedness);
     }
-    let mut result = Vec::with_capacity(nbytes as usize);
+    // Keep the same allocation edge as rbigint.py's StringBuilder(nbytes).
+    // In particular, a signed-to-unsigned cast must not turn a negative
+    // length into an enormous allocation request.
+    let capacity = usize::try_from(nbytes).map_err(|_| RBigIntError::Memory)?;
+    let mut result = Vec::new();
+    result
+        .try_reserve_exact(capacity)
+        .map_err(|_| RBigIntError::Memory)?;
     let mut currval = intval;
     let mut byte = 0_u8;
     for _ in 0..nbytes {
@@ -5901,6 +6131,11 @@ mod tests {
         assert_eq!(
             tobytes_int(-1, 1, "big", false),
             Err(RBigIntError::InvalidSignedness)
+        );
+        assert_eq!(tobytes_int(0, -1, "big", false), Err(RBigIntError::Memory));
+        assert_eq!(
+            RBigInt::zero().tobytes(-1, "big", false),
+            Err(RBigIntError::Memory)
         );
         assert_eq!(
             frombytes_int(&[0x80, 0, 0, 0, 0, 0, 0, 0], "big", false),
@@ -6432,6 +6667,22 @@ mod tests {
         assert!(q.eq(&expected_q));
         assert!(r.eq(&expected_r));
         assert!(q.mul(&divisor).add(&r).eq(&dividend));
+    }
+
+    #[test]
+    fn test_x_divrem_zero_quotient_is_fresh() {
+        // rbigint.py:2322 cannot return NULLRBIGINT because callers may
+        // modify this internal result.  Equal-sized, two-digit operands with
+        // dividend < divisor take the otherwise uncommon k == 0 branch.
+        let dividend = RBigInt::new(&[1, 1], 1, 2);
+        let divisor = RBigInt::new(&[2, 1], 1, 2);
+        let (mut quotient, remainder) = _x_divrem(&dividend, &divisor);
+        assert_eq!(quotient.get_sign(), 0);
+        assert!(remainder.eq(&dividend));
+        assert_ne!(quotient._digits, RBigInt::zero()._digits);
+
+        quotient.setdigit(0, 1);
+        assert_eq!(RBigInt::zero().digit(0), 0);
     }
 
     #[test]
@@ -6975,6 +7226,26 @@ mod tests {
         assert_eq!(
             twice_just_below.truediv(&RBigInt::fromint(-2)).unwrap(),
             -f64::MAX
+        );
+
+        // `math.ldexp` parity at the subnormal boundary.  A direct
+        // `dx * 2.0.powi(shift)` loses these values when the scale factor
+        // underflows before multiplication.
+        let power_of_two = |exponent| RBigInt::one().lshift(exponent).unwrap();
+        assert_eq!(
+            RBigInt::one().truediv(&power_of_two(1030)).unwrap(),
+            f64::from_bits(0x0000_1000_0000_0000)
+        );
+        assert_eq!(
+            RBigInt::fromint(7).truediv(&power_of_two(1074)).unwrap(),
+            f64::from_bits(0x0000_0000_0000_0007)
+        );
+        assert_eq!(
+            power_of_two(53)
+                .int_add(1)
+                .truediv(&power_of_two(1075).int_add(7))
+                .unwrap(),
+            f64::from_bits(0x0010_0000_0000_0000)
         );
     }
 

--- a/pyre/pyre-object/src/rbigint.rs
+++ b/pyre/pyre-object/src/rbigint.rs
@@ -4490,7 +4490,7 @@ impl PendingPartsCacheDigitRoot {
     /// guard's lifetime.
     unsafe fn new(value: &std::sync::Arc<RBigInt>) -> Self {
         let value = std::sync::Arc::as_ptr(value) as *mut RBigInt;
-        let slot = unsafe { &mut (*value)._digits as *mut *mut TypedItemsBlock as *mut *mut u8 };
+        let slot = unsafe { std::ptr::addr_of_mut!((*value)._digits).cast::<*mut u8>() };
         let registered = unsafe { crate::gc_hook::try_gc_add_root(slot) };
         Self { slot, registered }
     }

--- a/pyre/pyre-object/tests/rbigint_differential.rs
+++ b/pyre/pyre-object/tests/rbigint_differential.rs
@@ -69,6 +69,24 @@ fn oracle_floor_divmod(a: &Oracle, b: &Oracle) -> (Oracle, Oracle) {
     (q, r)
 }
 
+/// Machine-word operand stream for the `int_*` legs: mostly random words, but
+/// weighted towards the boundaries those legs special-case — zero, ±1, powers
+/// of two, and the ends of the signed range where the single-digit fast path
+/// gives way to a `fromint` fallback.
+fn machine_word(state: &mut u64) -> i64 {
+    let raw = next_u64(state);
+    match raw % 8 {
+        0 => 0,
+        1 => 1,
+        2 => -1,
+        3 => 1_i64 << (raw >> 32) % 62,
+        4 => -(1_i64 << (raw >> 32) % 62),
+        5 => i64::MAX,
+        6 => i64::MIN,
+        _ => raw as i64,
+    }
+}
+
 fn oracle_abs(value: &Oracle) -> Oracle {
     if value.sign() == OracleSign::Minus {
         -value
@@ -228,6 +246,72 @@ fn deterministic_arbitrary_size_arithmetic_matches_independent_oracle() {
             let (oq, or) = oracle_floor_divmod(&oa, &ob);
             assert_eq!(to_oracle(&q), oq, "floordiv, iteration {iteration}");
             assert_eq!(to_oracle(&r), or, "mod, iteration {iteration}");
+        }
+
+        // Machine-word legs (`rbigint.int_*`), the ones `W_LongObject`'s
+        // descriptors take for a `W_IntObject` operand. The divisor stream
+        // deliberately spans ±1, powers of two, and magnitudes outside the
+        // single-digit range so `int_floordiv`/`int_mod_int_result` exercise
+        // their `fromint` fallbacks too.
+        let word = machine_word(&mut state);
+        let oword = Oracle::from(word);
+        assert_eq!(
+            to_oracle(&a.int_add(word)),
+            &oa + &oword,
+            "int_add, iteration {iteration}"
+        );
+        assert_eq!(
+            to_oracle(&a.int_sub(word)),
+            &oa - &oword,
+            "int_sub, iteration {iteration}"
+        );
+        assert_eq!(
+            to_oracle(&a.int_mul(word)),
+            &oa * &oword,
+            "int_mul, iteration {iteration}"
+        );
+        assert_eq!(
+            to_oracle(&a.int_and_(word)),
+            &oa & &oword,
+            "int_and_, iteration {iteration}"
+        );
+        assert_eq!(
+            to_oracle(&a.int_or_(word)),
+            &oa | &oword,
+            "int_or_, iteration {iteration}"
+        );
+        assert_eq!(
+            to_oracle(&a.int_xor(word)),
+            &oa ^ &oword,
+            "int_xor, iteration {iteration}"
+        );
+        if word != 0 {
+            let (oq, or) = oracle_floor_divmod(&oa, &oword);
+            assert_eq!(
+                to_oracle(&a.int_floordiv(word).unwrap()),
+                oq,
+                "int_floordiv, iteration {iteration}"
+            );
+            assert_eq!(
+                to_oracle(&a.int_mod(word).unwrap()),
+                or,
+                "int_mod, iteration {iteration}"
+            );
+            // The remainder of a long by a machine int always fits a machine
+            // int — that invariant is what lets `_int_mod` return `newint`.
+            assert_eq!(
+                Oracle::from(a.int_mod_int_result(word).unwrap()),
+                or,
+                "int_mod_int_result, iteration {iteration}"
+            );
+            let (iq, ir) = a.int_divmod(word).unwrap();
+            assert_eq!(to_oracle(&iq), oq, "int_divmod q, iteration {iteration}");
+            assert_eq!(to_oracle(&ir), or, "int_divmod r, iteration {iteration}");
+        } else {
+            assert!(a.int_floordiv(word).is_err());
+            assert!(a.int_mod(word).is_err());
+            assert!(a.int_mod_int_result(word).is_err());
+            assert!(a.int_divmod(word).is_err());
         }
 
         let exponent = (next_u64(&mut state) % 13) as i64;

--- a/pyre/pyre-object/tests/rbigint_differential.rs
+++ b/pyre/pyre-object/tests/rbigint_differential.rs
@@ -69,18 +69,18 @@ fn oracle_floor_divmod(a: &Oracle, b: &Oracle) -> (Oracle, Oracle) {
     (q, r)
 }
 
-/// Machine-word operand stream for the `int_*` legs: mostly random words, but
-/// weighted towards the boundaries those legs special-case — zero, ±1, powers
-/// of two, and the ends of the signed range where the single-digit fast path
-/// gives way to a `fromint` fallback.
+/// Machine-word operand stream for the `int_*` legs: seven boundary-focused
+/// arms and one random arm. The boundaries cover zero, ±1, powers of two, and
+/// the ends of the signed range where the single-digit fast path gives way to
+/// a `fromint` fallback.
 fn machine_word(state: &mut u64) -> i64 {
     let raw = next_u64(state);
     match raw % 8 {
         0 => 0,
         1 => 1,
         2 => -1,
-        3 => 1_i64 << (raw >> 32) % 62,
-        4 => -(1_i64 << (raw >> 32) % 62),
+        3 => 1_i64 << ((raw >> 32) % 62),
+        4 => -(1_i64 << ((raw >> 32) % 62)),
         5 => i64::MAX,
         6 => i64::MIN,
         _ => raw as i64,
@@ -308,10 +308,22 @@ fn deterministic_arbitrary_size_arithmetic_matches_independent_oracle() {
             assert_eq!(to_oracle(&iq), oq, "int_divmod q, iteration {iteration}");
             assert_eq!(to_oracle(&ir), or, "int_divmod r, iteration {iteration}");
         } else {
-            assert!(a.int_floordiv(word).is_err());
-            assert!(a.int_mod(word).is_err());
-            assert!(a.int_mod_int_result(word).is_err());
-            assert!(a.int_divmod(word).is_err());
+            assert!(
+                a.int_floordiv(word).is_err(),
+                "int_floordiv zero divisor, iteration {iteration}"
+            );
+            assert!(
+                a.int_mod(word).is_err(),
+                "int_mod zero divisor, iteration {iteration}"
+            );
+            assert!(
+                a.int_mod_int_result(word).is_err(),
+                "int_mod_int_result zero divisor, iteration {iteration}"
+            );
+            assert!(
+                a.int_divmod(word).is_err(),
+                "int_divmod zero divisor, iteration {iteration}"
+            );
         }
 
         let exponent = (next_u64(&mut state) % 13) as i64;


### PR DESCRIPTION
Follow-up work on the ported `rbigint`, stacked on the end-to-end port (#761) and the first review round (#781).

## Correctness

- **`long`/`math`/`gc`** — zero-length signed `int.to_bytes`, `math.lcm` argument validation, and the placement write-barrier fallbacks.
- **`listobject`** — adopt the 3.14 negative-cursor exhausted sentinel for list iterators.
- **`gc`** — apply the write barrier in the blackhole allocator's ref setters. Previously a ref stored through the blackhole path could leave an old-gen object pointing into the nursery without recording the edge.
- **`long`/`gc`** — keep `rbigint` clones fresh and align the wasm old-gen path.
- **`descroperation`** — `divmod` was the only numeric binop missing the
  `needs_numeric_binop_dispatch` override gate, so a subclass overriding
  `__divmod__`/`__rdivmod__` was skipped. This is interpreter-level and
  reproduces with `PYRE_NO_JIT=1`.

## Walker specializations

- `long op int` now takes the `rbigint` `int_*` machine-word legs instead of
  wrapping the `W_IntObject` operand into a bigint first.
- New walker arms for `long // int`, `long % int`, and `long ** int`.
- `UNPACK_SEQUENCE` folds for the object-pair specialised tuple.
- `divmod(int, int)` is specialized on two exact ints. It was previously an
  opaque `bh_call_fn` may-force for *every* operand type: `divmod(a, b)` ran
  3.4x slower than CPython 3.14 while pyre's own `a // b` + `a % b` was 81x
  faster. The arm emits the `makespecialisedtuple2` `Cls_ii` shape directly
  (`specialisedtupleobject.py:169-179`) plus the `ll_int_py_div` /
  `ll_int_py_mod` legs with the `rint.py` `_ovf_zer` domain guards.

  Measured on the int/int loop: **0.405s → 0.004s (101x)**, i.e. from 3.4x
  slower than CPython 3.14 to 29x faster. The optimized loop contains no
  `CallMayForce`, `ForceToken`, or `NewWithVtable`.

## Tests

- `ci` — run `pyre/extra_tests/parity_tests` in the `pyre/check.py` jobs; they
  were not previously gated.
- New parity tests: `long_int_div_mod_jit.py`, `long_int_pow_jit.py`,
  `rbigint_mixed_int_jit.py`, `unpack_specialised_pair_shapes.py`,
  `list_iterator_surface.py`, `math_lcm_argument_validation.py`, plus
  `divmod_int_jit.py`.
- `rbigint_differential.rs` gains the `int_*` family.

## Verification

Measured at this branch tip with a freshly extracted `build/llbc` census and
**both** backend binaries rebuilt against it, using `python3.14` as the oracle
(`PYRE_CHECK_PYTHON3=python3.14`):

| test | dynasm | cranelift | without JIT | pre-existing? |
|---|---|---|---|---|
| `long_int_div_mod_jit.py` | FAIL | OK | OK | **no — added by this branch** |
| `bytearray_python314.py` | FAIL | FAIL | FAIL (139) | yes (#560) |
| `memoryview_python314.py` | FAIL | FAIL | FAIL (139) | yes (#560) |
| `range_python314.py` | FAIL | FAIL | FAIL (1) | yes (#560) |
| `slice_python314.py` | FAIL | FAIL | FAIL (1) | yes (#560) |
| `set_iterator_python314.py` | FAIL | FAIL | FAIL (1) | yes (#629) |

Everything else in the parity suite is green on both backends.

An earlier `check.py --backend dynasm,cranelift` → 326/326 run **should be
disregarded**: it was measured against a stale `build/llbc/*.ullbc`. `cargo build`
does not re-extract LLBC, so that run validated traces built from a census
extracted hours earlier from older sources.

### The five pre-existing failures

These are not regressions from this branch. All five fail identically on both
backends *and* under `PYRE_NO_JIT=1`, so they are interpreter-level, and the
tests were added in #560/#629 long before this work. They surface here only
because this branch's `ci: run pyre/extra_tests/parity_tests in the
pyre/check.py jobs` commit gates them for the first time.

`range`/`slice`/`set_iterator` are the same shape — calling an unbound method
descriptor with no argument reports `TypeError: count() missing 1 required
positional argument` instead of CPython's `unbound method ... needs an
argument`. `bytearray`/`memoryview` segfault (139).

They need fixing (or the gate needs to land separately), but they are
independent of the rbigint work.

## Branch defect — blocks merge

`long_int_div_mod_jit.py`, added by this branch, aborts under `pyre-dynasm`:

```
GC BUG: invalid type_id=... at obj_addr=... site=copy_nursery_object
  MiniMarkGC::copy_nursery_object <- trace_and_update_object
  <- do_collect_nursery <- alloc_with_type <- dynasm_nursery_slowpath
```

**Confirmed present at this branch tip** by a control run (committed tip, clean
working tree, LLBC re-extracted so the census matches the sources): 6/6. It was
masked earlier only by the stale census.

### Characterisation

- **dynasm only** — cranelift passes, consistent with `dynasm_nursery_slowpath`
  on the stack. (Note cranelift's shim never collects at allocation sites, so it
  simply never exercises this path; dynasm is the orthodox one here.)
- **JIT-only** — passes under `PYRE_NO_JIT=1`.
- **Cumulative and geometry-dependent** — the failing function passes in
  isolation; it needs ~5 earlier allocation-heavy functions. Shrinking the
  nursery (`PYPY_GC_NURSERY` 128K–512K) does **not** reproduce it; it depends on
  the default 4 MB fill geometry.

### Root-cause analysis so far

An instrumented collector (probe naming the *referrer*, skipping forwarded
headers) gives:

```
bad child via varsize_item  parent_type_id=9 (PY_OBJECT_ARRAY) parent=OLD-GEN
capacity=8, item[0]=<nursery addr>  BAD-TID
item[1..7]=<low nursery addrs>      valid
child FORWARDED_EARLIER_TO=None
```

The parent is an old-gen `ItemsBlock`; only `item[0]` is corrupt. It holds the
*pre-collection* address of an object that a forwarding-history probe shows was
**never forwarded by any collection in the whole run** — i.e. the object was
unreachable from every GC root when its collection ran, yet compiled code kept
using its address afterwards and stored it into a freshly allocated block.

**So this is a missing-GC-root defect, not a write-barrier or zeroing defect.**
Some holder keeps a `PyObjectRef` across a collection without the GC knowing.

### Hypotheses refuted with evidence (recorded so they are not re-tried)

| hypothesis | how it was refuted |
|---|---|
| `malloc_zero_filled` misconfigured | both backends set it `false`, citing incminimark.py:211. Only the doc comment at `rewrite.rs:140-150` is stale (it claims `Nursery::reset()` zeroes; the real `reset()` zeroes on wasm32 only) |
| uninitialized capacity tail | allocation helpers NULL-fill `len..cap`; poison mode would raise the dedicated poison panic instead |
| `wb_covered` drops a needed barrier | dumped compiled code: `CondCallGcWbArray` is emitted before every `GcStoreIndexed` on the append arm |
| born-old-gen block missing TRACK_YOUNG_PTRS | `finish_alloc_in_oldgen` sets it; and the block is 72 bytes, far below `large_object_threshold` |
| card marking incoherent | `HAS_CARDS` is only ever set by tests, so production degenerates to whole-object remembering (correct) |
| **old-gen spill from `alloc_with_type` (`collector.rs:868-871`) breaking the rewrite's WB elision** | **instrumented: ZERO spills in a failing run.** This was the leading hypothesis; it is empirically dead for this crash |
| malloc slow-path register handling | x2–x13/x19–x22 are spilled and reloaded from GC-updated slots; regalloc matches aarch64/regalloc.py:958 (pyre spills *more*) |
| baked Ref constants unpinned | constants resolve through a traced `GcTable` (`gcreftracer.rs`, the RPython GCREFTRACER shape) |

### Still open

Identifying the specific unrooted holder. The diagnostic patch used above is
kept out of tree.

Separately, two genuine latent divergences were found and are **not** the cause
here, but should be fixed on their own:

1. `alloc_with_type` can return old-gen memory where incminimark's
   `collect_and_reserve` (incminimark.py:865-930) loops minor collections and
   never does. The rewrite's write-barrier elision for fresh mallocs
   (rewrite.py:911) depends on that young-result guarantee.
2. `emit_write_barrier_fastpath_kind` silently emits nothing when the WB descr
   is unavailable (`_ => return`, both arches), and the aarch64 inline card
   write silently skips non-register indices. Upstream asserts in both cases.

— *authored by Claude*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CI parity step running extra parity tests under the same CPython interpreter.
  * Expanded parity coverage (JIT divmod, long div/mod, long pow, unpacking, conversions/edge cases) and added clear completion output.
* **Bug Fixes**
  * Improved write-barrier descriptor handling, blackhole write barriers, and GC/object alignment.
  * Strengthened constant loading/identity and integer parsing/formatting behaviors.
  * Enhanced iterator exhaustion/restoration and range/list cursor handling.
* **Tests**
  * Added GC-poison option and broadened JIT/GC/translation/numeric differential assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->