### PR TITLE
jit: fold the immutable-type STORE_ATTR/DELETE_ATTR raise to a traced inline exception

### DIFF
--- a/majit/majit-ir/src/effectinfo.rs
+++ b/majit/majit-ir/src/effectinfo.rs
@@ -712,6 +712,14 @@ pub enum PyreHelperKind {
     /// inserting a helper in the middle changes existing discriminants consumed
     /// by serialized/stable helper metadata.
     LoadMethodSelf,
+    /// `bh_delete_attr_fn(obj, code, name_idx)` — the plain DELETE_ATTR
+    /// residual (`lower_delete_attr_hlop_to_insn` → `space.delattr`), the
+    /// deletion counterpart of [`StoreAttr`](PyreHelperKind::StoreAttr).
+    /// The full-body walker recognises this tag to fold the deterministic
+    /// immutable-type raise (`del int.x` → TypeError before any dict
+    /// access) to a traced inline exception construction the optimizer
+    /// can virtualize; every other shape keeps the generic residual.
+    DeleteAttr,
 }
 
 impl EffectInfo {

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -9105,6 +9105,69 @@ pub fn setattr_str(obj: PyObjectRef, name: &str, value: PyObjectRef) -> PyResult
     object_setattr(obj, name, value)
 }
 
+/// Trace-time stability predicate for the walker's immutable-type
+/// STORE_ATTR / DELETE_ATTR raise fold: whether `setattr_str` /
+/// `delattr_str` on `obj` with `name` is *guaranteed* to take the
+/// terminal `object_setattr` / `object_delattr` non-heaptype raise —
+/// not just this call, but on every later call with the same `(obj,
+/// name)` pair.
+///
+/// The raise-path decision consults, in order: the weakref-proxy
+/// `force` (identity for a type receiver), the metaclass
+/// `__setattr__` / `__delattr__` resolution, the metaclass-MRO data
+/// descriptor walk for `name`, and finally `is_heaptype`.  Each input
+/// is frozen once the conditions below hold:
+///
+///   * `obj` is a non-heaptype type object — its dict rejects every
+///     mutation (that IS the raise being folded) and its `__class__`
+///     cannot be reassigned, so `is_heaptype` and the metaclass
+///     identity are permanent.
+///   * The metaclass is the canonical `type`, whose MRO is
+///     `(type, object)` — both non-heap, so both dicts are frozen
+///     after interpreter init and the two lookups are constant.
+///
+/// Returns `false` for any other shape (heap type, custom metaclass,
+/// a metaclass `__setattr__`/`__delattr__` override, or a `name` that
+/// resolves to a metaclass descriptor such as `type.__name__`, whose
+/// setter has its own value-dependent behaviour).
+pub fn type_immutable_attr_raise_is_stable(obj: PyObjectRef, name: &str, is_delete: bool) -> bool {
+    unsafe {
+        if obj.is_null()
+            || !pyre_object::typeobject::is_type(obj)
+            || pyre_object::w_type_is_heaptype(obj)
+        {
+            return false;
+        }
+        let Some(metaclass) = crate::typedef::r#type(obj) else {
+            return false;
+        };
+        let metaclass = metaclass.as_ptr();
+        if !std::ptr::eq(
+            metaclass,
+            pyre_object::get_instantiate(&pyre_object::pyobject::TYPE_TYPE),
+        ) {
+            return false;
+        }
+        if is_delete {
+            // `delattr_str`'s type-receiver branch: a non-default metaclass
+            // `__delattr__` routes to a descriptor call instead of the
+            // terminal raise.
+            if let Some(da) = lookup_in_type(metaclass, "__delattr__") {
+                let is_default = lookup_in_type(crate::typedef::w_object(), "__delattr__")
+                    .is_some_and(|d| std::ptr::eq(da, d));
+                if !is_default {
+                    return false;
+                }
+            }
+        } else if setattr_if_not_from_object(metaclass).is_some() {
+            return false;
+        }
+        // The terminal's metaclass-MRO descriptor walk runs before the
+        // heaptype guard; any hit (`__name__`, `__dict__`, …) diverts.
+        lookup_in_type_where(metaclass, name).is_none()
+    }
+}
+
 /// `objectobject.py descr__setattr__` — the terminal implementation
 /// that bypasses user `__setattr__` overrides and writes directly
 /// through the descriptor / instance-dict path.  Called by

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -3326,6 +3326,11 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
                 descr_index,
             })?;
     let descr_key = descr.index();
+    // Copy the recognition tag out of the descr borrow now: the DELETE_ATTR
+    // fold gate below runs after the StoreAttr arm's `descr = specialized_
+    // descr` reassignment, which the live `original_call_descr` borrow would
+    // otherwise forbid (E0506).
+    let pyre_helper_kind = original_call_descr.get_extra_info().pyre_helper;
     // Void shape `_ir_v/iIRd` (`pyjitpl.py opimpl_residual_call_ir_v =
     // _opimpl_residual_call2`) has no `>X` dst byte; see
     // `dispatch_residual_call_iRd_kind` for the void operand-layout note.
@@ -3370,6 +3375,20 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
                 ctx.trace_ctx.box_value(code_opref),
                 ctx.trace_ctx.box_value(namei_opref),
             ) {
+                // Deterministic immutable-type raise (`int.x = v`) folds to a
+                // traced inline exception construction the optimizer can
+                // virtualize — tried before the unboxed-slot store fold; the
+                // two shapes are disjoint (type receiver vs instance receiver).
+                if let Some(outcome) = try_walker_trace_immutable_type_attr_raise(
+                    ctx,
+                    op,
+                    obj_opref,
+                    Some(value_opref),
+                    w_code_ptr,
+                    namei as usize,
+                )? {
+                    return Ok(outcome);
+                }
                 if let Some(specialization) = try_walker_specialize_store_attr(
                     ctx,
                     op.pc,
@@ -3391,6 +3410,34 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
                             return Ok((DispatchOutcome::Continue, op.next_pc));
                         }
                     }
+                }
+            }
+        }
+    }
+
+    // DELETE_ATTR immutable-type raise fold — the deletion twin of the
+    // STORE_ATTR fold above.  `bh_delete_attr_fn(obj, code, name_idx)`
+    // carries no value operand: r_args = [obj, code], i_args = [name_idx].
+    if ctx.is_authoritative_executor && pyre_helper_kind == majit_ir::PyreHelperKind::DeleteAttr {
+        if let (Some(&obj_opref), Some(&code_opref), Some(&namei_opref)) =
+            (r_args.first(), r_args.get(1), i_args.first())
+        {
+            if let (
+                Some(majit_ir::Value::Ref(majit_ir::GcRef(w_code_ptr))),
+                Some(majit_ir::Value::Int(namei)),
+            ) = (
+                ctx.trace_ctx.box_value(code_opref),
+                ctx.trace_ctx.box_value(namei_opref),
+            ) {
+                if let Some(outcome) = try_walker_trace_immutable_type_attr_raise(
+                    ctx,
+                    op,
+                    obj_opref,
+                    None,
+                    w_code_ptr,
+                    namei as usize,
+                )? {
+                    return Ok(outcome);
                 }
             }
         }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -5380,6 +5380,197 @@ pub(crate) fn try_walker_trace_raise_bare_class<Sym: WalkSym>(
     Ok(Some(()))
 }
 
+/// Walker-native fold for the deterministic immutable-type
+/// STORE_ATTR / DELETE_ATTR raise (`int.x = v` / `del str.x` →
+/// TypeError from the `object_setattr` / `object_delattr` non-heaptype
+/// guard, `typeobject.py:416/437`).
+///
+/// The generic path records the raise as an opaque
+/// `CallMayForceN(bh_store_attr_fn)` + `GuardNotForced` +
+/// `GuardException`, whose result box (the exception materialised
+/// *inside* the residual by `PyError::to_exc_object`) can never
+/// virtualize — every compiled iteration re-allocates the TypeError,
+/// its message string, and its args list through the runtime GC hooks.
+/// PyPy traces `space.setattr` itself, so the same raise shows up as
+/// `new_with_vtable` + `setfield_gc` ops its optimizer removes when the
+/// exception never escapes.
+///
+/// This fold restores that shape for the one attribute-store raise
+/// whose outcome is provably iteration-invariant: when
+/// `type_immutable_attr_raise_is_stable` holds (constant non-heaptype
+/// receiver, canonical `type` metaclass, no metaclass descriptor for
+/// `name` — every consulted dict frozen), the raise and its message
+/// depend only on trace-time constants.  Pin the receiver with
+/// `GuardValue` (when not already constant), run the authentic
+/// `setattr_str` / `delattr_str` concretely for the authoritative
+/// walk's exception, and emit the [`try_walker_trace_exception_new`]
+/// construction (`NewWithVtable` + args-list `SetfieldGc`s, message as
+/// a rooted trace constant) in place of the residual + guards.  The
+/// raise then routes through the ordinary `SubRaise` path with a
+/// virtualizable exception OpRef, and a locally-caught `except` DCEs
+/// the whole allocation exactly as the explicit-`raise` B3 fold does.
+///
+/// Returns `None` (fall through to the generic residual) for any
+/// non-matching or unprovable shape.
+pub(crate) fn try_walker_trace_immutable_type_attr_raise<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    op: &DecodedOp,
+    obj_op: OpRef,
+    store_value: Option<OpRef>,
+    w_code_ptr: usize,
+    name_idx: usize,
+) -> Result<Option<(DispatchOutcome, usize)>, DispatchError> {
+    if !ctx.is_authoritative_executor {
+        return Ok(None);
+    }
+    let Some(concrete_obj) = walker_concrete_ref_object(ctx, obj_op) else {
+        return Ok(None);
+    };
+    // STORE_ATTR needs the live value operand to run the authentic
+    // concrete `setattr_str` below (the value plays no role in the raise
+    // decision — the terminal raises before consulting it).
+    let concrete_value = match store_value {
+        Some(value_op) => match walker_concrete_ref_object(ctx, value_op) {
+            Some(v) => Some(v),
+            None => return Ok(None),
+        },
+        None => None,
+    };
+    let name = unsafe {
+        let code_ptr = pyre_interpreter::w_code_get_ptr(w_code_ptr as pyre_object::PyObjectRef);
+        if code_ptr.is_null() {
+            return Ok(None);
+        }
+        let code = &*(code_ptr as *const pyre_interpreter::CodeObject);
+        match pyre_interpreter::pyframe::load_name_from_code(code, name_idx) {
+            Some(n) => n.to_string(),
+            None => return Ok(None),
+        }
+    };
+    if !pyre_interpreter::baseobjspace::type_immutable_attr_raise_is_stable(
+        concrete_obj,
+        &name,
+        store_value.is_none(),
+    ) {
+        return Ok(None);
+    }
+
+    // --- commit: pin the receiver, run the authentic raise, emit inline ---
+    // The stability predicate makes the raise a pure function of `(obj,
+    // name)`; `GuardValue` pins the one live input (`name` is a co_names
+    // constant).
+    if !obj_op.is_constant() {
+        let expected = ctx.trace_ctx.const_ref(concrete_obj as i64);
+        ctx.trace_ctx
+            .record_guard(OpCode::GuardValue, &[obj_op, expected], 0);
+        walker_capture_snapshot_for_last_guard(ctx, op.pc)?;
+        ctx.trace_ctx.heap_cache_mut().replace_box(obj_op, expected);
+    }
+
+    // The authoritative walk's concrete execution — the same call the
+    // residual executor would have made, raising before any heap
+    // mutation.  Plain eval: the predicate excludes every user-code path.
+    let result = {
+        let _plain_guard = pyre_interpreter::call::force_plain_eval();
+        match concrete_value {
+            Some(value) => pyre_interpreter::baseobjspace::setattr_str(concrete_obj, &name, value),
+            None => pyre_interpreter::baseobjspace::delattr_str(concrete_obj, &name),
+        }
+    };
+    let Err(mut err) = result else {
+        // Unreachable under the predicate (a non-heaptype dict rejects
+        // every mutation).  Fail loud rather than falling through: the
+        // generic residual would re-run the (somehow) committed effect.
+        return Err(DispatchError::UnsupportedOpname {
+            pc: op.pc,
+            key: "immutable-type attr raise fold: stable raise unexpectedly succeeded",
+        });
+    };
+    let exc = err.to_exc_object();
+    let kind = unsafe {
+        if !pyre_object::is_exception(exc) {
+            return Ok(None);
+        }
+        pyre_object::interp_exceptions::w_exception_get_kind(exc)
+    };
+    // The folded raise is exactly the immutable-type TypeError; any other
+    // kind means the runtime path diverged from the predicate's model.
+    if kind != pyre_object::interp_exceptions::ExcKind::TypeError {
+        return Ok(None);
+    }
+    let exc_type_ptr = unsafe {
+        (*(exc as *const pyre_object::interp_exceptions::W_BaseException))
+            .ob_header
+            .ob_type
+    };
+    if !std::ptr::eq(
+        exc_type_ptr,
+        pyre_object::interp_exceptions::exc_kind_to_pytype(kind),
+    ) {
+        return Ok(None);
+    }
+
+    // Message as a trace constant: deterministic per `(obj, name)` under
+    // the predicate, so one shared immutable string is exact (the same
+    // sharing a `raise TypeError("...")` gets from co_consts).  Pin the
+    // fresh exception across the string allocation; the recorded ConstPtr
+    // slot is forwarded across minor collections by the op-graph walker
+    // and rooted by the compiled loop's gcref table thereafter.
+    let _roots = pyre_object::gc_roots::push_roots();
+    pyre_object::gc_roots::pin_root(exc);
+    let msg = pyre_object::w_str_new(&err.message);
+    let msg_const = ctx.trace_ctx.const_ref(msg as i64);
+    let args_list = crate::helpers::emit_object_list_inline(ctx.trace_ctx, &[msg_const]);
+    // Stamp the canonical list class exactly as `w_list_new` does (the
+    // `try_walker_trace_exception_new` args tail), so a materialised
+    // `args_w` still satisfies `space.type(args_w) is list`.
+    let list_w_class = pyre_object::get_instantiate(&pyre_object::pyobject::LIST_TYPE);
+    let list_w_class = ctx.trace_ctx.const_ref(list_w_class as i64);
+    let list_w_class_descr = crate::descr::list_w_class_descr();
+    let list_w_class_index = list_w_class_descr.index();
+    ctx.trace_ctx.record_op_with_descr(
+        OpCode::SetfieldGc,
+        &[args_list, list_w_class],
+        list_w_class_descr,
+    );
+    ctx.trace_ctx
+        .heapcache_setfield_cached(args_list, list_w_class_index, list_w_class);
+
+    let class_const = ctx
+        .trace_ctx
+        .const_ref(pyre_object::interp_exceptions::lookup_exc_class_for_kind(kind) as i64);
+    let new_op =
+        crate::helpers::emit_exception_new_inline(ctx.trace_ctx, kind, class_const, args_list);
+    ctx.trace_ctx
+        .heap_cache_mut()
+        .class_now_known(new_op, exc_type_ptr as usize as i64);
+    ctx.trace_ctx
+        .set_opref_concrete(new_op, majit_ir::Value::Ref(majit_ir::GcRef(exc as usize)));
+    // Inline-built marker: the downstream raise routing records the frame
+    // node via the virtual `record_fresh_application_traceback` instead of
+    // the forcing runtime hook (mirrors `try_walker_trace_raise_bare_class`).
+    fbw_built_exc_insert(new_op);
+
+    // The residual-executor Err-arm state, minus the call itself: seed the
+    // standing exception for the `SubRaise` routing (`execute_raised`
+    // analogue) and restore the blackhole cell so an aborting walk still
+    // delivers the pending raise to the live frame.  The class IS proven
+    // constant here — the `NewWithVtable` vtable pins it.
+    fbw_count_executed_residual(true, true);
+    ctx.last_exc_value = Some(new_op);
+    ctx.last_exc_value_concrete = ConcreteValue::Ref(exc);
+    ctx.fbw_mode.class_of_last_exc_is_const = true;
+    majit_metainterp::blackhole::BH_LAST_EXC_VALUE.with(|c| c.set(exc as i64));
+
+    Ok(Some((
+        DispatchOutcome::SubRaise {
+            exc: new_op,
+            exc_concrete: ConcreteValue::Ref(exc),
+        },
+        op.next_pc,
+    )))
+}
+
 /// B3 piece 3: lower the PUSH_EXC_INFO / POP_EXCEPT
 /// exc-info-stack residuals to GETFIELD_GC_R / SETFIELD_GC on the EC's
 /// `sys_exc_value` slot (`ec_sys_exc_value_descr`).

--- a/pyre/pyre-jit/src/jit/flatten.rs
+++ b/pyre/pyre-jit/src/jit/flatten.rs
@@ -6591,7 +6591,12 @@ where
     let obj = operand_for_value_arg(&op.args[0], get_register, lower_constant)?;
     let code = operand_for_value_arg(&op.args[1], get_register, lower_constant)?;
     let name_idx = const_int_for_value_arg(&op.args[2])?;
-    let effect_info = effect_info_for_call_flavor(CallFlavor::MayForce);
+    let mut effect_info = effect_info_for_call_flavor(CallFlavor::MayForce);
+    // Tag the DELETE_ATTR helper calldescr so the full-body walker can fold
+    // the deterministic immutable-type raise to a traced inline exception
+    // construction.  A declined fold continues with this unchanged MayForce
+    // residual — the tag mirror of `lower_setattr_hlop_to_insn`.
+    effect_info.pyre_helper = majit_ir::PyreHelperKind::DeleteAttr;
     let descr_operand = Operand::descr(DescrOperand::CallDescrStub(CallDescrStub {
         effect_info,
         arg_kinds: vec![Kind::Ref, Kind::Ref, Kind::Int],


### PR DESCRIPTION
## Problem

`synth/type_immutable_reject` is ~133x slower than CPython (pyre 0.74s vs cpython 0.17s vs pypy 0.02s). Profiling (`sample`, 5s window) attributes ~65% of the loop time to the `bh_store_attr_fn` / `bh_delete_attr_fn` residuals, almost all of it inside `PyError::to_exc_object`: every compiled iteration re-materialises the TypeError instance, its message string, and its args list through the runtime GC hooks (`dynasm_gc_owns_object` → `OldGen::contains`, shadow-stack pins, write barriers).

The trace records the raising store as `CallMayForceN + GuardNotForced + GuardException`, so the exception is born *inside* the opaque residual and comes out as an unvirtualizable guard-result box — even though everything downstream (inline PyTraceback construction, `sys_exc_value` save/restore, handler matching) is already traced. By contrast, an explicit `raise TypeError("...")` loop already runs at PyPy-class speed (~0.05s loop time) because the B3 construct fold (`try_walker_trace_exception_new`) exposes the allocation to the optimizer, which virtualizes it away when the exception never escapes.

## Change

Extend the B3 treatment to the one attribute-store raise whose outcome is provably iteration-invariant: a STORE_ATTR / DELETE_ATTR on a non-heap (immutable) builtin type.

- **`pyre-interpreter`**: new stability predicate `type_immutable_attr_raise_is_stable(obj, name, is_delete)` — accepts only a non-heaptype type receiver whose metaclass is the canonical `type` (MRO `(type, object)`, both frozen) with no metaclass descriptor for `name`. Under these conditions every dict the `setattr_str`/`delattr_str` raise-path decision consults is frozen, so the raise and its message are a pure function of trace-time constants.
- **`pyre-jit-trace`**: new walker fold `try_walker_trace_immutable_type_attr_raise` — pins the receiver with `GuardValue` (when not already constant), runs the authentic `setattr_str`/`delattr_str` concretely for the authoritative walk's exception, and emits the inline construction (`emit_object_list_inline` + `emit_exception_new_inline`, message as a rooted trace constant shared across iterations like a co_consts string) in place of the residual + guards, then seeds the residual-executor Err-arm state (`last_exc_value`, `BH_LAST_EXC_VALUE`, `fbw_built_exc`) and routes through the ordinary `SubRaise` path.
- **`majit-ir` / `pyre-jit`**: `PyreHelperKind::DeleteAttr` calldescr tag (appended at the enum tail, existing discriminants preserved) + tagging in `lower_delete_attr_hlop_to_insn`, so the walker can recognise the DELETE_ATTR residual — mirroring the existing `StoreAttr` tag.

Python-visible semantics are unchanged: the same TypeError (same message, fresh instance per iteration, traceback attached) is raised; only how the compiled trace produces it changes. Any shape the predicate cannot prove (heap types, custom metaclasses, metaclass descriptors like `type.__name__`) declines to the unchanged residual path.

## Results (Apple Silicon)

- `synth/type_immutable_reject` (dynasm): **0.74s → 0.11s** — now faster than CPython (0.15s); 10x from PyPy (was ~37x). The optimized trace contains no `CallMayForceN` residuals; both the store and delete exceptions virtualize. cranelift: 0.16s.
- `check.py --synthetic-only`: dynasm **314/314**, cranelift **314/314** — ALL PASSED.
- Edge-case parity (JIT output == `PYRE_NO_JIT=1` interpreter output, 7 scenarios): escaping exception message/args/traceback, delete-variant message, `int.__name__ = x` (metaclass-descriptor decline), heap-type store success in the same loop shape, custom-metaclass `__setattr__` override, per-iteration fresh exception identity.

## Status

- [x] dynasm: full synth suite green (314/314), target fixture 0.11s vs cpython 0.15s.
- [x] cranelift: full synth suite green (314/314), target fixture 0.16s.
- [ ] wasm backend untested (no local wasm32 target run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved tracing for attribute assignments and deletions on immutable types.
  * Deterministic `TypeError` outcomes are now captured and replayed directly in optimized execution paths.

* **Bug Fixes**
  * Attribute deletion operations are now correctly recognized during optimization.
  * Unsupported or unstable attribute operations continue using the existing fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->