### PR TITLE
fix: collect all positional-only-as-keyword violations before raising

### DIFF
--- a/pyre/pyre-interpreter/src/argument.rs
+++ b/pyre/pyre-interpreter/src/argument.rs
@@ -1671,17 +1671,13 @@ impl ArgErr {
                 }
             }
             ArgErr::PosonlyAsKwds { posonly_kwds } => {
-                if posonly_kwds.len() == 1 {
-                    format!(
-                        "got a positional-only argument passed as keyword argument: '{}'",
-                        posonly_kwds[0],
-                    )
-                } else {
-                    format!(
-                        "got some positional-only arguments passed as keyword arguments: '{}'",
-                        posonly_kwds.join(", "),
-                    )
-                }
+                // argument.py:635-637 — always the plural wording, even for
+                // a single name; CPython (`positional_only_passed_as_keyword`
+                // in Python/ceval.c) matches this, there is no singular form.
+                format!(
+                    "got some positional-only arguments passed as keyword arguments: '{}'",
+                    posonly_kwds.join(", "),
+                )
             }
         }
     }
@@ -1809,16 +1805,18 @@ mod tests {
         assert_eq!(many.getmsg(), "got 3 unexpected keyword arguments");
     }
 
-    /// pypy/interpreter/argument.py:635-640 `ArgErrPosonlyAsKwds`
-    /// — single vs multi-name plural branches.
+    /// pypy/interpreter/argument.py:635-637 `ArgErrPosonlyAsKwds.getmsg` —
+    /// always the plural wording, regardless of `posonly_kwds` length.
+    /// CPython's `positional_only_passed_as_keyword` (Python/ceval.c) has
+    /// no singular form either.
     #[test]
-    fn arg_err_posonly_as_kwds_branches() {
+    fn arg_err_posonly_as_kwds_always_plural() {
         let one = ArgErr::PosonlyAsKwds {
             posonly_kwds: vec!["a".to_string()],
         };
         assert_eq!(
             one.getmsg(),
-            "got a positional-only argument passed as keyword argument: 'a'",
+            "got some positional-only arguments passed as keyword arguments: 'a'",
         );
         let many = ArgErr::PosonlyAsKwds {
             posonly_kwds: vec!["x".to_string(), "y".to_string()],

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -1808,7 +1808,8 @@ pub(crate) fn bind_kwargs_to_signature(
                     if has_varkw {
                         break;
                     }
-                    // argument.py:481-484 — collect and keep scanning.
+                    // argument.py:481-484 — collect and keep scanning
+                    // remaining keywords instead of raising immediately.
                     posonly_kwds.push(key.to_string());
                     matched = true;
                     break;
@@ -2125,7 +2126,8 @@ pub fn call_with_kwargs(
                             if has_varkw {
                                 break;
                             }
-                            // argument.py:481-484 — collect and keep scanning.
+                            // argument.py:481-484 — collect and keep scanning
+                            // remaining keywords instead of raising immediately.
                             posonly_kwds.push(key.to_string());
                             matched = true;
                             break;

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -1506,6 +1506,10 @@ pub(crate) fn resolve_kwargs(
     // varnames[skip_cls..total_params] are the effective param names
     let mut extra_kwargs: Vec<(PyObjectRef, PyObjectRef)> = Vec::new();
     let mut unmatched_kw_names: Vec<Wtf8Buf> = Vec::new();
+    // argument.py:469,481-484 — `wrong_posonly` accumulator: every
+    // posonly-as-keyword violation is collected across the whole loop and
+    // reported together, instead of raising on the first one found.
+    let mut posonly_kwds: Vec<String> = Vec::new();
     for ki in 0..nkw {
         let kw_name = unsafe { pyre_object::w_tuple_getitem(kwarg_names, ki as i64) };
         let Some(kw_name_obj) = kw_name else { continue };
@@ -1532,10 +1536,11 @@ pub(crate) fn resolve_kwargs(
                     if has_varkw {
                         break; // fall through to !matched → extra_kwargs
                     }
-                    return Err(crate::PyError::type_error(format!(
-                        "{}() got some positional-only arguments passed as keyword arguments: '{}'",
-                        fname, param_name
-                    )));
+                    // argument.py:481-484 — collect and keep scanning
+                    // remaining keywords instead of raising immediately.
+                    posonly_kwds.push(param_name.to_string());
+                    matched = true;
+                    break;
                 }
                 // argument.py:410 — duplicate keyword argument
                 if !result[pi].is_null() {
@@ -1557,6 +1562,17 @@ pub(crate) fn resolve_kwargs(
                     .push(unsafe { pyre_object::w_str_get_wtf8(kw_name_obj).to_owned() });
             }
         }
+    }
+
+    // argument.py:499-500 — ArgErrPosonlyAsKwds, raised after the full
+    // keyword scan (and before ArgErrUnknownKwds, since `_match_keywords`
+    // raises this before its caller ever checks unmatched kwds).
+    if !posonly_kwds.is_empty() {
+        return Err(crate::PyError::type_error(format!(
+            "{}() got some positional-only arguments passed as keyword arguments: '{}'",
+            fname,
+            posonly_kwds.join(", ")
+        )));
     }
 
     // `argument.py:270-271` ArgErrUnknownKwds — unmatched kwargs and no
@@ -1775,6 +1791,9 @@ pub(crate) fn bind_kwargs_to_signature(
     // _match_keywords — match each keyword to a param name by index.
     let mut extra_kwargs: Vec<(PyObjectRef, PyObjectRef)> = Vec::new();
     let mut unmatched_kw_names: Vec<Wtf8Buf> = Vec::new();
+    // argument.py:469,481-484 — collected across the whole loop, reported
+    // together instead of raising on the first violation found.
+    let mut posonly_kwds: Vec<String> = Vec::new();
     for (key, value) in kwargs {
         // A lone-surrogate keyword name (not valid UTF-8) never equals a
         // source-level parameter name, so it falls straight to **kwargs or
@@ -1789,10 +1808,10 @@ pub(crate) fn bind_kwargs_to_signature(
                     if has_varkw {
                         break;
                     }
-                    return Err(crate::PyError::type_error(format!(
-                        "{}() got some positional-only arguments passed as keyword arguments: '{}'",
-                        fname, key
-                    )));
+                    // argument.py:481-484 — collect and keep scanning.
+                    posonly_kwds.push(key.to_string());
+                    matched = true;
+                    break;
                 }
                 if !result[pi].is_null() {
                     return Err(crate::PyError::type_error(format!(
@@ -1812,6 +1831,16 @@ pub(crate) fn bind_kwargs_to_signature(
                 unmatched_kw_names.push(key.clone());
             }
         }
+    }
+
+    // argument.py:499-500 — ArgErrPosonlyAsKwds, raised after the full
+    // keyword scan and before ArgErrUnknownKwds.
+    if !posonly_kwds.is_empty() {
+        return Err(crate::PyError::type_error(format!(
+            "{}() got some positional-only arguments passed as keyword arguments: '{}'",
+            fname,
+            posonly_kwds.join(", ")
+        )));
     }
 
     if !unmatched_kw_names.is_empty() {
@@ -2080,6 +2109,9 @@ pub fn call_with_kwargs(
             let posonly = code.posonlyarg_count as usize;
             let mut extra_kwargs: Vec<(Wtf8Buf, PyObjectRef)> = Vec::new();
             let mut unmatched_kw_names: Vec<Wtf8Buf> = Vec::new();
+            // argument.py:469,481-484 — collected across the whole loop,
+            // reported together instead of raising on the first violation.
+            let mut posonly_kwds: Vec<String> = Vec::new();
             for (key, value) in kwargs {
                 // A lone-surrogate keyword name never equals a source-level
                 // parameter name; it falls to **kwargs or the error below.
@@ -2093,10 +2125,10 @@ pub fn call_with_kwargs(
                             if has_varkw {
                                 break;
                             }
-                            return Err(crate::PyError::type_error(format!(
-                                "{}() got some positional-only arguments passed as keyword arguments: '{}'",
-                                fname, key
-                            )));
+                            // argument.py:481-484 — collect and keep scanning.
+                            posonly_kwds.push(key.to_string());
+                            matched = true;
+                            break;
                         }
                         // argument.py:495 — ArgErrMultipleValues: keyword
                         // duplicates an already-bound positional argument.
@@ -2118,6 +2150,16 @@ pub fn call_with_kwargs(
                         unmatched_kw_names.push(key.clone());
                     }
                 }
+            }
+
+            // argument.py:499-500 — ArgErrPosonlyAsKwds, raised after the
+            // full keyword scan and before ArgErrUnknownKwds.
+            if !posonly_kwds.is_empty() {
+                return Err(crate::PyError::type_error(format!(
+                    "{}() got some positional-only arguments passed as keyword arguments: '{}'",
+                    fname,
+                    posonly_kwds.join(", ")
+                )));
             }
 
             // `argument.py:270-271` ArgErrUnknownKwds.


### PR DESCRIPTION
## Summary

`resolve_kwargs`, `bind_kwargs_to_signature`, and `call_with_kwargs` each raised on the first keyword naming a positional-only parameter instead of scanning the rest first, unlike PyPy's `_match_keywords` (`argument.py:464-501`) and CPython's `positional_only_passed_as_keyword` (`Python/ceval.c`), both of which collect every violator and report them together.

`f(a=1, b=2)` against `def f(a, b, /)` reported only `'a'` instead of `'a, b'`. Fixes `test_positional_only_arg`.

`ArgErr::PosonlyAsKwds::getmsg` also had a singular-vs-plural branch that used "got a positional-only argument passed as keyword argument" for a single name. Neither PyPy (`argument.py:635-637`) https://github.com/youknowone/pyre/blob/a527e14dcb51f446744430c251bad01e303702b7/pypy/interpreter/argument.py#L635-L637 nor CPython special-case a single violation — both always use the plural wording. Dropped the singular branch.

## Self-review

- [x] I fully resolved all reasonable code review comments from Codex and CodeRabbit.
  - [ ] Auto-review section 1 is clear. This check is mandatory.
  - [ ] Auto-review section 2 is clear. If this is not checked, please add a comment explaining why.
- [ ] I did not use AI to write the code of this patch.
  - If this is not checked, commits must include `Assisted-by`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting when positional-only parameters are provided as keyword arguments.
  * Error messages now list all affected parameter names together instead of stopping at the first one.
  * Standardized wording for single and multiple invalid arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->