### PR TITLE
jit: retire the (false,false) walker catch-link arm in flatten_graph

### DIFF
--- a/pyre/pyre-jit/src/jit/flatten.rs
+++ b/pyre/pyre-jit/src/jit/flatten.rs
@@ -1874,37 +1874,13 @@ impl<'a> GraphFlattener<'a> {
             self.emitline(normal_label);
             let mut captured_all = false;
             for link in &catch_links {
-                let payload_shape = {
-                    let link_borrow = link.borrow();
-                    (
-                        link_borrow.last_exception.is_some(),
-                        link_borrow.last_exc_value.is_some(),
-                    )
-                };
-                match payload_shape {
-                    (false, false) => {
-                        // Structural adaptation for pyre's bytecode-level
-                        // graph builder.  RPython `flowcontext.py:130-156
-                        // guessexception` closes a canraise block with
-                        // `exits[0]` as the sole normal link and all
-                        // following links seeded via `Link.extravars`.
-                        // Pyre's PC-sequential walker can leave an
-                        // additional normal/explicit-raise edge after
-                        // the first slot.  Such a link is not an
-                        // exception match arm; flatten it with ordinary
-                        // `make_link` so final exceptblock targets still
-                        // lower through `make_return`, and keep
-                        // `make_exception_link` reserved for seeded
-                        // exception links as upstream expects.
-                        self.make_link(link, false);
-                        continue;
-                    }
-                    (true, true) => {}
-                    (last_exception, last_exc_value) => panic!(
-                        "canraise catch link payload partially seeded: \
-                         last_exception={last_exception}, last_exc_value={last_exc_value}",
-                    ),
-                }
+                // `flatten.py:223-233 insert_exits` lowers every catch link
+                // (`block.exits[1:]`) through `make_exception_link`, which
+                // asserts both `last_exception` and `last_exc_value` are seeded
+                // (`flatten.py:161-162`).  There is no ordinary-`make_link` arm
+                // for a catch link: one that is not a fully seeded exception
+                // link is a graph-construction bug and fails loud inside
+                // `make_exception_link`.
                 let llexitcase = link.borrow().llexitcase.clone();
                 if let Some(case) = llexitcase {
                     let case_operand = self.getcolor(&case);


### PR DESCRIPTION
Retires the last walker-specific exception-CFG adaptation #371 targeted — the follow-up tail to PR #800 (which retired the pcdep regalloc + B1/B2 exception-CFG adaptations and closed #371).

## What changed

`GraphFlattener::flatten_graph`'s canraise catch-link loop matched on `(last_exception.is_some(), last_exc_value.is_some())` and, for `(false, false)`, flattened the link with the ordinary `make_link` instead of `make_exception_link` — a repair for an extra normal/explicit-raise edge the PC-sequential walker could leave after the first slot.

`flatten.py:223-233 insert_exits` has no such arm: every `block.exits[1:]` link is lowered through `make_exception_link`, which already asserts both `last_exception` and `last_exc_value` are seeded (`flatten.py:161-162`; pyre mirrors this assertion in `make_exception_link`). The `payload_shape` match is deleted so catch links lower straight through `make_exception_link`, and an unseeded catch link now fails loud there instead of being silently repaired.

## Why it's safe

The arm was unreachable — **0 hits across the full 334-bench synth+top corpus** on dynasm (probe-armed build). The 4 benches that previously could not be evaluated (`except_star`, `exception_group_type`, `exception_subclass_attrs`, `slots_class_var_conflict` — SIGBUS on a stale-LLBC base) all match python3.14 on freshly re-extracted LLBC.

## Verification

`check.py` green on all backends: dynasm 329/329, cranelift 329/329, wasm 326/326.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
