### PR TITLE
build: cut the pyre-jit-trace prepass cost — 13m46s → 5m24s, 15.5 GB → 8.95 GB

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2258,6 +2258,7 @@ dependencies = [
  "majit-metainterp",
  "majit-trace",
  "majit-translate",
+ "mimalloc",
  "pyre-interpreter",
  "pyre-object",
  "rustpython-wtf8",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,3 +184,13 @@ insta = "1"
 [profile.dist]
 inherits = "release"
 lto = "thin"
+
+# The `pyre-jit-trace` build script runs the whole RPython-style translation
+# pipeline (flowspace → annotator → rtyper → codewriter) over the interpreter.
+# Cargo's default build-override profile compiles it at `opt-level = 0`, so that
+# analysis — the single longest and most memory-hungry step of a cold build —
+# runs unoptimized.
+[profile.release.build-override]
+opt-level = 1
+[profile.dev.build-override]
+opt-level = 1

--- a/majit/majit-translate/src/codewriter/call.rs
+++ b/majit/majit-translate/src/codewriter/call.rs
@@ -3188,6 +3188,13 @@ impl CallControl {
         self.candidate_graphs.contains(path)
     }
 
+    /// Size of the post-`find_all_graphs` candidate set — the graphs the
+    /// portal closure actually reaches, against which the registered graph
+    /// count is the eagerly-lowered universe.
+    pub fn candidate_graph_count(&self) -> usize {
+        self.candidate_graphs.len()
+    }
+
     /// RPython: `CallControl.get_jitcode(graph, called_from)`.
     ///
     /// Retrieve or create the `Arc<JitCode>` shell for the given graph.

--- a/majit/majit-translate/src/lib.rs
+++ b/majit/majit-translate/src/lib.rs
@@ -121,6 +121,7 @@ fn build_semantic_program_via_active_frontend(
     module_paths: &[&str],
     static_addrs: HostStaticAddrs<'_>,
     explicit_llbc_paths: Option<&[&str]>,
+    prof: &mut PhaseProfiler,
 ) -> front::SemanticProgram {
     #[cfg(feature = "mir-frontend")]
     {
@@ -155,8 +156,10 @@ fn build_semantic_program_via_active_frontend(
             let llbcs: Vec<majit_charon_reader::Llbc> = paths
                 .iter()
                 .map(|p| {
-                    majit_charon_reader::Llbc::load(p)
-                        .unwrap_or_else(|e| panic!("Step 4.4 cutover: load {p}: {e}"))
+                    let llbc = majit_charon_reader::Llbc::load(p)
+                        .unwrap_or_else(|e| panic!("Step 4.4 cutover: load {p}: {e}"));
+                    prof.mark(&format!("    load {p}"));
+                    llbc
                 })
                 .collect();
             // Seed the local-crate alias roots from the loaded set so
@@ -174,6 +177,7 @@ fn build_semantic_program_via_active_frontend(
                     module_paths,
                 )
                 .unwrap_or_else(|e| panic!("Step 4.4 cutover: lower llbcs {paths:?}: {e}"));
+            prof.mark("    build_semantic_program_from_llbcs");
             // JIT-hint pass.  pyre's proc-macro attributes
             // (`#[majit_macros::elidable*]` / `dont_look_inside` /
             // `loop_invariant` / `unroll_safe`) are consumed by the
@@ -517,12 +521,20 @@ pub fn analyze_multiple_pipeline_from_llbc_with_modules(
 /// the parity guard against silent cross-crate name-tail collisions.
 /// Same-name re-registration (e.g. a function reachable through more
 /// than one well-known crate alias) is treated as idempotent.
+/// `graph` is shared, not copied, across the ~`4 + 2 * local_crate_roots`
+/// spellings [`free_function_alias_paths`] produces for one funcobj —
+/// `bookkeeper.getdesc` binds every alias to the same graph object, and a
+/// per-alias deep copy of `FunctionGraph.blocks` multiplied the whole
+/// free-function graph set by the alias count.
 fn register_function_graph_alias(
-    graphs: &mut std::collections::HashMap<crate::parse::CallPath, crate::model::FunctionGraph>,
+    graphs: &mut std::collections::HashMap<
+        crate::parse::CallPath,
+        std::sync::Arc<crate::model::FunctionGraph>,
+    >,
     sources: &mut std::collections::HashMap<crate::parse::CallPath, String>,
     path: crate::parse::CallPath,
     source_name: &str,
-    graph: &crate::model::FunctionGraph,
+    graph: &std::sync::Arc<crate::model::FunctionGraph>,
 ) {
     if let Some(prev) = sources.get(&path) {
         assert!(
@@ -534,7 +546,7 @@ fn register_function_graph_alias(
         return;
     }
     sources.insert(path.clone(), source_name.to_string());
-    graphs.insert(path, graph.clone());
+    graphs.insert(path, std::sync::Arc::clone(graph));
 }
 
 /// Compute the full alias spelling set for a free function lifted
@@ -606,6 +618,103 @@ fn free_function_alias_paths(name: &str, source_module: &str) -> Vec<crate::pars
     paths
 }
 
+/// `PYRE_PROFILE_PIPELINE=1` phase profiler: elapsed wall time plus the
+/// process high-water RSS at each mark, so a phase's contribution to the
+/// translation prepass's peak footprint is visible next to its cost in time.
+pub struct PhaseProfiler {
+    enabled: bool,
+    start: std::time::Instant,
+    last: std::time::Instant,
+}
+
+impl PhaseProfiler {
+    pub fn new() -> Self {
+        let now = std::time::Instant::now();
+        Self {
+            enabled: std::env::var_os("PYRE_PROFILE_PIPELINE").is_some(),
+            start: now,
+            last: now,
+        }
+    }
+
+    pub fn mark(&mut self, name: &str) {
+        if !self.enabled {
+            return;
+        }
+        let now = std::time::Instant::now();
+        const GB: f64 = (1u64 << 30) as f64;
+        eprintln!(
+            "[PYRE_PROFILE_PIPELINE] {:>9.3}s  {:>9.3}s  live {:>6.2}GB  peak {:>6.2}GB  {name}",
+            (now - self.start).as_secs_f64(),
+            (now - self.last).as_secs_f64(),
+            live_rss_bytes() as f64 / GB,
+            peak_rss_bytes() as f64 / GB,
+        );
+        self.last = now;
+    }
+
+    /// Emit a free-form line under the same gate as [`Self::mark`], for
+    /// per-phase input sizes that explain a phase's cost. Takes a closure so
+    /// counting the sizes costs nothing when the profiler is off.
+    pub fn note(&self, message: impl FnOnce() -> String) {
+        if self.enabled {
+            eprintln!("[PYRE_PROFILE_PIPELINE] {}", message());
+        }
+    }
+}
+
+impl Default for PhaseProfiler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// `getrusage(RUSAGE_SELF).ru_maxrss` — the process high-water RSS. Monotonic,
+/// so the difference between two marks is what the span between them added to
+/// the peak. macOS reports bytes, Linux kilobytes.
+#[cfg(unix)]
+fn peak_rss_bytes() -> u64 {
+    let mut usage: libc::rusage = unsafe { std::mem::zeroed() };
+    if unsafe { libc::getrusage(libc::RUSAGE_SELF, &mut usage) } != 0 {
+        return 0;
+    }
+    let raw = usage.ru_maxrss as u64;
+    if cfg!(target_os = "macos") {
+        raw
+    } else {
+        raw * 1024
+    }
+}
+
+#[cfg(not(unix))]
+fn peak_rss_bytes() -> u64 {
+    0
+}
+
+/// Current resident set size. Unlike [`peak_rss_bytes`] this falls back when a
+/// phase releases memory, so the pair separates "this phase allocated N" from
+/// "this phase retains N". Shells out to `ps` because the in-process query is
+/// per-platform (`proc_pidinfo` on macOS, `/proc/self/statm` on Linux) and the
+/// profiler samples fewer than a dozen times per run.
+#[cfg(unix)]
+fn live_rss_bytes() -> u64 {
+    let output = std::process::Command::new("ps")
+        .args(["-o", "rss=", "-p"])
+        .arg(std::process::id().to_string())
+        .output();
+    let Ok(output) = output else { return 0 };
+    String::from_utf8_lossy(&output.stdout)
+        .trim()
+        .parse::<u64>()
+        .map(|kb| kb * 1024)
+        .unwrap_or(0)
+}
+
+#[cfg(not(unix))]
+fn live_rss_bytes() -> u64 {
+    0
+}
+
 fn analyze_pipeline_from_module_paths(
     module_paths: &[&str],
     explicit_llbc_paths: Option<&[&str]>,
@@ -616,23 +725,11 @@ fn analyze_pipeline_from_module_paths(
     impl_fnaddr_bindings: &ImplFnAddrBindings<'_>,
     static_addrs: HostStaticAddrs<'_>,
 ) -> pipeline::ProgramPipelineResult {
-    let profile = std::env::var_os("PYRE_PROFILE_PIPELINE").is_some();
-    let phase_start = std::time::Instant::now();
-    let mut last = phase_start;
+    let mut prof = PhaseProfiler::new();
     macro_rules! mark_phase {
-        ($name:literal) => {{
-            #[allow(unused_assignments)]
-            if profile {
-                let now = std::time::Instant::now();
-                eprintln!(
-                    "[PYRE_PROFILE_PIPELINE] {:>9.3}s  {:>9.3}s  {}",
-                    (now - phase_start).as_secs_f64(),
-                    (now - last).as_secs_f64(),
-                    $name,
-                );
-                last = now;
-            }
-        }};
+        ($name:literal) => {
+            prof.mark($name)
+        };
     }
     mark_phase!("entry");
     // `FORCE_ATTRIBUTES_INTO_CLASSES` is seeded from the LLBC-sourced
@@ -652,8 +749,12 @@ fn analyze_pipeline_from_module_paths(
     // `scripts/extract-llbc.py`), located via `PYRE_MIR_FRONTEND_LLBC`
     // or workspace auto-discovery.
     mark_phase!("known_statics + struct_field_attrs populated");
-    let program =
-        build_semantic_program_via_active_frontend(module_paths, static_addrs, explicit_llbc_paths);
+    let program = build_semantic_program_via_active_frontend(
+        module_paths,
+        static_addrs,
+        explicit_llbc_paths,
+        &mut prof,
+    );
     // Publish the `(bare struct leaf → defining crate-relative module
     // path)` map into the process-global `STRUCT_ORIGIN_REGISTRY` so the
     // later `codewriter` `canonical_struct_name` `path_hash` sites
@@ -691,6 +792,25 @@ fn analyze_pipeline_from_module_paths(
         }
     }
     mark_phase!("build_semantic_program_from_parsed_files");
+    prof.note(|| {
+        format!(
+            "  program: {} functions, {} blocks, {} ops, {} struct_fields, {} type layouts",
+            program.functions.len(),
+            program
+                .functions
+                .iter()
+                .map(|f| f.graph.blocks.len())
+                .sum::<usize>(),
+            program
+                .functions
+                .iter()
+                .flat_map(|f| f.graph.blocks.iter())
+                .map(|b| b.operations.len())
+                .sum::<usize>(),
+            program.struct_fields.fields.len(),
+            program.exact_layouts.len(),
+        )
+    });
     let mut canonical_trait_impls = Vec::new();
     let mut canonical_inherent_methods = Vec::new();
     // `(trait_leaf, trait_qualified, method_name, owner, return_type,
@@ -849,6 +969,7 @@ fn analyze_pipeline_from_module_paths(
             (None, None) => {}
         }
     }
+    prof.mark("  classify methods into side tables");
     // RPython: use the rtyped graphs (with concretetype info) for all analysis.
     // Use program.functions' graphs which were built with full struct_fields
     // context, NOT re-parsed graphs (which lose array_type_id etc.).
@@ -858,10 +979,10 @@ fn analyze_pipeline_from_module_paths(
             // codewriter signature validator reads `FUNC.RESULT`
             // directly off the callee graph (RPython
             // `funcptr._obj.TO.RESULT`).
-            let graph = match &func.return_type {
+            let graph = std::sync::Arc::new(match &func.return_type {
                 Some(rt) => func.graph.clone().with_return_type(rt),
                 None => func.graph.clone(),
-            };
+            });
             // Free function: register under every canonical alias
             // spelling computed by `free_function_alias_paths` — bare
             // segments, `crate::` prefix, three pyre-crate prefixes,
@@ -881,6 +1002,7 @@ fn analyze_pipeline_from_module_paths(
             }
         }
     }
+    prof.mark("  free-fn graph aliases");
 
     // ── Build CallControl (RPython call.py) ──
     // Populate with all discovered function graphs and trait impl methods.
@@ -941,6 +1063,7 @@ fn analyze_pipeline_from_module_paths(
     // so the variant payload resolves at its real position. Per-field type
     // classification, immutability rank, and size stay as the provider
     // computed them; only the byte offsets and the struct size are corrected.
+    prof.mark("  call_control setup");
     for struct_name in program.struct_fields.fields.keys() {
         // Resolve the (possibly multi-spelled) field-registry key to its
         // identity token; an unresolved / ambiguous bare leaf has no
@@ -960,9 +1083,15 @@ fn analyze_pipeline_from_module_paths(
     }
     // Register graphs collected above (free functions only — trait
     // methods are handled separately via register_trait_method).
+    prof.mark("  struct layouts");
     for (path, graph) in &canonical_function_graphs {
-        call_control.register_function_graph(path.clone(), graph.clone());
+        // Each alias re-presents the shared graph so
+        // `insert_function_graph_indexed` can fold that spelling's pending
+        // external-funcobj effects onto the one stored graph; `GraphStore`
+        // keys on the funcobj, so the copy is transient.
+        call_control.register_function_graph(path.clone(), graph.as_ref().clone());
     }
+    prof.mark("  register_function_graph (free fns)");
     // Re-register free functions with their RPython-equivalent hints
     // (`elidable`, `loop_invariant`, `unroll_safe`, `jit_look_inside`)
     // so `JitPolicy::look_inside_graph` sees the same metadata RPython
@@ -1186,6 +1315,7 @@ fn analyze_pipeline_from_module_paths(
             }
         }
     }
+    prof.mark("  trait-impl registration");
     // Single-impl devirtualization for REQUIRED trait methods.  A call
     // site `<Trait>::<method>(receiver, …)` lowers to
     // `CallTarget::FunctionPath { segments: [<Trait>, <method>] }`
@@ -1478,6 +1608,7 @@ fn analyze_pipeline_from_module_paths(
             }
         }
     }
+    prof.mark("  concrete-trait + inherent method registration");
     for &(full_path, fnaddr) in fnaddr_bindings {
         call_control.register_macro_helper_trace_fnaddr(full_path, fnaddr);
     }
@@ -1600,6 +1731,14 @@ fn analyze_pipeline_from_module_paths(
     }
     let mut policy = policy::DefaultJitPolicy::new();
     call_control.find_all_graphs(&mut policy);
+    prof.mark("  find_all_graphs");
+    prof.note(|| {
+        format!(
+            "  portal closure: {} candidate graphs out of {} lowered functions",
+            call_control.candidate_graph_count(),
+            program.functions.len(),
+        )
+    });
 
     // The canonical jitcode emitter below is the production analysis
     // path; `ProgramPipelineResult.functions` / `total_*` remain diagnostic fields.
@@ -1618,7 +1757,7 @@ fn analyze_pipeline_from_module_paths(
 
     mark_phase!("call_control + canonical_trait_impls + register graphs");
     let (jitcodes, insns, descrs, all_liveness) =
-        make_jitcodes(&config.pipeline, &mut call_control);
+        make_jitcodes(&config.pipeline, &mut call_control, &mut prof);
     mark_phase!("make_jitcodes");
     pipeline.jit_drivers = call_control
         .jitdrivers_sd()
@@ -1717,6 +1856,7 @@ fn register_configured_jitdrivers(
 fn make_jitcodes(
     pipeline_config: &pipeline::PipelineConfig,
     call_control: &mut call::CallControl,
+    prof: &mut PhaseProfiler,
 ) -> (
     Vec<std::sync::Arc<jitcode::JitCode>>,
     indexmap::IndexMap<String, u8>,
@@ -1751,17 +1891,21 @@ fn make_jitcodes(
     // RPython grab_initial_jitcodes + drain portals and their callees.
     // RPython call.py:145-148.
     call_control.grab_initial_jitcodes();
+    prof.mark("  grab_initial_jitcodes");
     // Two-phase rtyper prepass (production default; `PYRE_TWO_PHASE_RTYPE=0`
     // opts out): annotate-all → rtype-all over the portal closure before the
     // drain publishes any covered graph, so a shared callee (e.g. `type_error`)
     // is unioned across all its callers before being rtyped.
     codewriter.run_two_phase_prepass_if_enabled(call_control);
+    prof.mark("  run_two_phase_prepass");
     codewriter.drain_pending_graphs(call_control, &pipeline_config.transform);
+    prof.mark("  drain_pending_graphs");
 
     // RPython codewriter.py:85: self.assembler.finished(callinfocollection).
     codewriter
         .assembler
         .finished(&call_control.callinfocollection);
+    prof.mark("  assembler.finished");
 
     // Materialise `all_jitcodes[]` from the completed jitcodes. Each
     // jitcode receives its dense index when appended, matching RPython
@@ -1870,7 +2014,8 @@ mod portal_driver_tests {
         let mut policy = policy::DefaultJitPolicy::new();
         call_control.find_all_graphs(&mut policy);
 
-        let (jitcodes, _, _, _) = make_jitcodes(&config, &mut call_control);
+        let (jitcodes, _, _, _) =
+            make_jitcodes(&config, &mut call_control, &mut PhaseProfiler::new());
         assert_eq!(jitcodes.len(), 1);
         assert_eq!(jitcodes[0].index(), 0);
         assert!(call_control.jitcodes().contains_key(&portal));
@@ -1938,7 +2083,8 @@ mod portal_driver_tests {
         let mut policy = policy::DefaultJitPolicy::new();
         call_control.find_all_graphs(&mut policy);
 
-        let (jitcodes, _, _, _) = make_jitcodes(&config, &mut call_control);
+        let (jitcodes, _, _, _) =
+            make_jitcodes(&config, &mut call_control, &mut PhaseProfiler::new());
         let merge = jitcodes[0]
             .body()
             ._ssarepr

--- a/pyre/pyre-jit-trace/Cargo.toml
+++ b/pyre/pyre-jit-trace/Cargo.toml
@@ -41,6 +41,7 @@ majit-backend-wasm = { path = "../../majit/majit-backend-wasm", version = "0.0.2
 
 [build-dependencies]
 majit-translate = { workspace = true }
+mimalloc = { version = "0.1" }
 pyre-interpreter = { workspace = true, features = ["dynasm"] }
 serde = { workspace = true, features = ["rc"] }
 serde_json = { workspace = true }

--- a/pyre/pyre-jit-trace/build.rs
+++ b/pyre/pyre-jit-trace/build.rs
@@ -12,6 +12,11 @@ use walkdir::WalkDir;
 static ALLOC: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 const CODEGEN_CACHE_VERSION: &str = "pyre-jit-trace-codegen-cache-v2";
+/// Retained cache entries. Each is ~6 MB, and a handful covers the
+/// configurations one checkout switches between (native/wasm × release/dev).
+const CODEGEN_CACHE_MAX_ENTRIES: usize = 8;
+/// Rewritten on every cache hit; its mtime is the entry's last-use stamp.
+const CODEGEN_CACHE_USED_MARKER: &str = ".last-used";
 const CODEGEN_OUTPUTS: &[&str] = &[
     "jit_trace_gen.rs",
     "jit_metadata.json",
@@ -464,6 +469,8 @@ fn real_main() {
             "[pyre-jit-trace build.rs] restored generated JIT trace artifacts from cache {}",
             cache_key
         );
+        touch_codegen_cache_entry(&cache_dir);
+        prune_codegen_cache(&repo_root, &cache_dir);
         return;
     }
 
@@ -612,7 +619,10 @@ fn real_main() {
             "[pyre-jit-trace build.rs] warning: could not store generated JIT trace cache {}: {e}",
             cache_key
         );
+        return;
     }
+    touch_codegen_cache_entry(&cache_dir);
+    prune_codegen_cache(&repo_root, &cache_dir);
 }
 
 fn build_call_effect_overrides() -> Vec<majit_translate::CallEffectOverride> {
@@ -692,14 +702,71 @@ fn llbc_layout_sidecars() -> Vec<String> {
         .collect()
 }
 
+/// The cache sits under `build/` rather than the Cargo target directory so
+/// `cargo clean`, a fresh `CARGO_TARGET_DIR`, or a profile switch does not
+/// re-pay the translation prepass — the same reason the prepass's own inputs
+/// (`build/llbc/*.ullbc`) live there. `codegen_cache_key` already folds
+/// HOST/TARGET/PROFILE/OPT_LEVEL, the feature set, the build-script binary's
+/// own bytes and the LLBC content, so an entry is only ever served back to the
+/// configuration that produced it.
+fn codegen_cache_base(repo_root: &str) -> std::path::PathBuf {
+    std::path::Path::new(repo_root).join("build/pyre-jit-trace-cache")
+}
+
 fn codegen_cache_dir(repo_root: &str, cache_key: &str) -> std::path::PathBuf {
-    let target_dir = std::env::var_os("CARGO_TARGET_DIR")
-        .map(std::path::PathBuf::from)
-        .unwrap_or_else(|| std::path::Path::new(repo_root).join("target"));
-    target_dir
-        .join("pyre-jit-trace-cache")
+    codegen_cache_base(repo_root)
         .join(CODEGEN_CACHE_VERSION)
         .join(cache_key)
+}
+
+/// Record that `cache_dir` was used, so [`prune_codegen_cache`] evicts by last
+/// use rather than by creation: a configuration built daily but keyed long ago
+/// would otherwise be dropped ahead of one-off keys minted by a source edit.
+fn touch_codegen_cache_entry(cache_dir: &std::path::Path) {
+    let _ = std::fs::write(cache_dir.join(CODEGEN_CACHE_USED_MARKER), b"");
+}
+
+/// Drop entries beyond [`CODEGEN_CACHE_MAX_ENTRIES`], least recently used
+/// first, along with any directory left by an earlier `CODEGEN_CACHE_VERSION`.
+/// Every distinct (target, profile, feature set, build-script binary, LLBC
+/// content) combination mints a key and nothing removed them before, so the
+/// directory grew without bound — 110 entries / 682 MB in one worktree.
+///
+/// Best effort throughout: a concurrent build whose entry is removed
+/// mid-restore re-runs the prepass, because `restore_codegen_cache` copies
+/// every output or reports failure — it never serves a partial set.
+fn prune_codegen_cache(repo_root: &str, keep: &std::path::Path) {
+    let base = codegen_cache_base(repo_root);
+    if let Ok(versions) = std::fs::read_dir(&base) {
+        for version in versions.flatten() {
+            if version.file_name() != std::ffi::OsStr::new(CODEGEN_CACHE_VERSION) {
+                let _ = std::fs::remove_dir_all(version.path());
+            }
+        }
+    }
+    let Ok(entries) = std::fs::read_dir(base.join(CODEGEN_CACHE_VERSION)) else {
+        return;
+    };
+    let mut by_last_use: Vec<(std::time::SystemTime, std::path::PathBuf)> = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        // `store_codegen_cache` stages into a dot-prefixed sibling before its
+        // rename; leaving those alone keeps a concurrent store intact.
+        if path == keep || !path.is_dir() || entry.file_name().to_string_lossy().starts_with('.') {
+            continue;
+        }
+        let last_use = std::fs::metadata(path.join(CODEGEN_CACHE_USED_MARKER))
+            .or_else(|_| std::fs::metadata(&path))
+            .and_then(|meta| meta.modified())
+            .unwrap_or(std::time::UNIX_EPOCH);
+        by_last_use.push((last_use, path));
+    }
+    by_last_use.sort_by(|a, b| b.0.cmp(&a.0));
+    // `keep` is excluded above and occupies one of the retained slots.
+    let retained = CODEGEN_CACHE_MAX_ENTRIES.saturating_sub(1);
+    for (_, path) in by_last_use.into_iter().skip(retained) {
+        let _ = std::fs::remove_dir_all(path);
+    }
 }
 
 fn restore_codegen_cache(cache_dir: &std::path::Path, out_dir: &str) -> bool {
@@ -787,18 +854,34 @@ fn codegen_cache_key(manifest_dir: &str, repo_root: &str, source_paths: &[String
     // The codegen output also depends on every crate linked into this
     // build-script binary — `majit-translate`'s own dependencies
     // (`majit-ir`, `majit-charon-reader`, `rustpython-compiler-core`, …)
-    // and their serde wire formats — whose sources are not hashed below
-    // (only `majit-translate/src` and `resoperation.rs` are). Cargo
-    // recompiles and reruns the build script whenever any of them changes,
-    // but the content key would otherwise stay identical and restore a
-    // stale snapshot (e.g. `*.bin` written under an older `majit-ir`
-    // bincode layout). Folding the build-script executable's own bytes into
-    // the key rekeys the cache on any transitive code change.
-    match std::env::current_exe() {
-        Ok(exe) => hash_file_content(&mut h, &exe),
-        Err(e) => {
-            h.write_str("current-exe-error");
-            h.write_str(&e.to_string());
+    // and their serde wire formats — whose sources `majit-translate/src`
+    // below does not cover. Without them the key would stay identical across
+    // such a change and restore a stale snapshot (e.g. `*.bin` written under
+    // an older `majit-ir` bincode layout).
+    //
+    // Hash their *sources* rather than the build-script executable's bytes.
+    // The binary is not reproducible: recompiling it from unchanged sources —
+    // which `cargo clean`, a fresh `CARGO_TARGET_DIR`, or a touched `build.rs`
+    // all force — yields different bytes, so keying on them rekeyed the cache
+    // on almost every build and made it serve only reruns that skipped the
+    // recompile. Workspace sources plus `Cargo.lock` (external crate
+    // versions) and the compiler's version string cover the same change
+    // surface and are stable across recompiles.
+    hash_file_content(&mut h, &std::path::Path::new(repo_root).join("Cargo.lock"));
+    h.write_str(&rustc_version_string());
+    for workspace_dir in ["majit", "pyre"] {
+        let root = std::path::Path::new(repo_root).join(workspace_dir);
+        let Ok(crates) = std::fs::read_dir(&root) else {
+            continue;
+        };
+        let mut src_dirs: Vec<std::path::PathBuf> = crates
+            .flatten()
+            .map(|entry| entry.path().join("src"))
+            .filter(|src| src.is_dir())
+            .collect();
+        src_dirs.sort();
+        for src in src_dirs {
+            hash_rs_dir_content(&mut h, &src);
         }
     }
 
@@ -824,6 +907,21 @@ fn codegen_cache_key(manifest_dir: &str, repo_root: &str, source_paths: &[String
     format!("{:016x}", h.finish())
 }
 
+/// `rustc -vV`, so a toolchain upgrade that changes codegen or a type layout
+/// rekeys the cache. Falls back to a marker when the compiler cannot be run —
+/// a missing string only makes the key coarser, never staler, because every
+/// other input is still hashed.
+fn rustc_version_string() -> String {
+    let rustc = std::env::var_os("RUSTC").unwrap_or_else(|| "rustc".into());
+    std::process::Command::new(rustc)
+        .arg("-vV")
+        .output()
+        .ok()
+        .filter(|out| out.status.success())
+        .map(|out| String::from_utf8_lossy(&out.stdout).into_owned())
+        .unwrap_or_else(|| "rustc-version-unavailable".to_string())
+}
+
 fn hash_llbc_inputs(h: &mut CacheHasher, repo_root: &str) {
     // Hash the LLBC by content, not by (len, mtime) signature. The
     // analysis (`analyze_multiple_pipeline_with_modules`) derives every
@@ -831,8 +929,9 @@ fn hash_llbc_inputs(h: &mut CacheHasher, repo_root: &str) {
     // happens to preserve size and mtime — `git checkout`, a cache restore
     // that keeps timestamps, an in-place rewrite of equal length — must
     // still rekey the cache. A signature would let `restore_codegen_cache`
-    // serve stale output and skip re-analysis. The `.ullbc` set is a few
-    // MB; the read is negligible next to the analysis it gates.
+    // serve stale output and skip re-analysis. The `.ullbc` set is ~660 MB
+    // (89 % of it `fun_decls`), so the read costs under a second — still
+    // negligible next to the tens of seconds of analysis it gates.
     if let Some(paths) = std::env::var_os("PYRE_MIR_FRONTEND_LLBC") {
         for path in std::env::split_paths(&paths) {
             if !path.as_os_str().is_empty() {

--- a/pyre/pyre-jit-trace/build.rs
+++ b/pyre/pyre-jit-trace/build.rs
@@ -5,6 +5,12 @@ mod virtualizable_spec;
 
 use walkdir::WalkDir;
 
+/// The translation prepass churns the whole graph universe through short-lived
+/// allocations; the system allocator keeps the freed spans and the process's
+/// peak RSS tracks the churn rather than the live set.
+#[global_allocator]
+static ALLOC: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 const CODEGEN_CACHE_VERSION: &str = "pyre-jit-trace-codegen-cache-v2";
 const CODEGEN_OUTPUTS: &[&str] = &[
     "jit_trace_gen.rs",


### PR DESCRIPTION
A cold `cargo build --release -p pyrex --features dynasm` took 13m 46s and
peaked at 15.5 GB. Both numbers come from a single unit: the `pyre-jit-trace`
build script, which runs the whole RPython-style translation pipeline
(flowspace → annotator → rtyper → codewriter) over the interpreter. From
`--timings` on the baseline, dependency compilation ran 0–199 s, the build
script ran **199–786 s single-threaded**, and only 41 s of work followed it —
71 % of wall in one serial unit.

| | before | after |
|---|---|---|
| cold build | 13m 46s | 5m 24s |
| prepass run | 586.8 s | ~50–80 s |
| build-script peak RSS | 15.51 GB | **8.95 GB** |
| process peak RSS | 15.77 GB | **9.61 GB** |
| codegen cache | ~never hit, 110 entries / 682 MB | hits across `cargo clean`, 8-entry cap |

Every commit leaves the generated artifacts byte-identical:
`819 all_jitcodes (555669 bytes bincode), generated 25254 bytes`.

## The four changes

**1. The prepass ran unoptimized.** Cargo's default `build-override` profile is
`opt-level = 0`, so the longest and most memory-hungry step of a cold build had
no optimization. `opt-level = 1` (not 2 — same prepass speed, far less codegen
for the build-dependency graph) takes the prepass from 586.8 s to 82.4 s.

**2. Free-function graphs were deep-copied once per alias spelling.**
`free_function_alias_paths` yields `4 + 2 * local_crate_roots` = ~10 spellings
per free function, and `register_function_graph_alias` stored a full
`FunctionGraph.blocks` copy under each while `program.functions` still held the
original. `canonical_function_graphs` now holds `Arc<FunctionGraph>`, matching
what `CallControl`'s `GraphStore` already did (one funcobj, many names) and what
`bookkeeper.getdesc` does upstream. That phase drops from +4.42 GB to +0.43 GB.

**3. Peak RSS was tracking allocator churn, not live data.** One full copy of
every free-function graph is only ~0.43 GB, so the multi-GB phase deltas could
not all be retained data. With mimalloc as the build script's global allocator,
every phase after the LLBC front-end adds 0.03 GB in total where the system
allocator added 1.80 GB. `cc` was already required by `stacker`/`psm` in the
same build-dependency graph, so this adds no toolchain requirement.

**4. The codegen cache was almost never hit.** `codegen_cache_key` hashed the
build-script executable's own bytes as a hedge against a transitive dependency
changing a serde wire format. That binary is not reproducible — recompiling it
from unchanged sources yields different bytes — so `cargo clean`, a fresh
`CARGO_TARGET_DIR`, a profile switch, or a touched `build.rs` each minted a new
key and re-ran the whole prepass, which also explains the unbounded growth. The
hedge now hashes `Cargo.lock`, `rustc -vV`, and every `{majit,pyre}/*/src` tree:
same change surface, stable across recompiles. The cache also moved under
`build/` (beside its own `build/llbc/` inputs, already gitignored) and is pruned
to the 8 most recently used entries.

## Diagnostics added

`PYRE_PROFILE_PIPELINE=1` now reports live and peak RSS alongside each phase
mark, with marks pushed down into the LLBC front-end and `make_jitcodes`. This
is what located every finding above, and it is what shows the remaining cost:

```
   0.65s  live  0.42GB   load pyre-object.ullbc        (65 MB json)
   2.01s  live  2.85GB   load pyre-interpreter.ullbc  (501 MB json)
   2.48s  live  3.27GB   load pyre-jit.ullbc          (112 MB json)
  44.60s  live  8.92GB   build_semantic_program_from_llbcs
          program: 14998 functions, 390802 blocks, 326985 ops
          portal closure: 819 candidate graphs out of 14998 lowered functions
  54.12s  live  8.95GB   run_two_phase_prepass   (annotator + rtyper)
  57.12s  live  8.95GB   drain_pending_graphs    (codewriter)
```

## What remains

99.7 % of the peak is now the Charon LLBC front-end alone. `build/llbc/*.ullbc`
is 658 MB of JSON, 88 % of it `fun_decls`, and the pipeline lowers all 14,998
functions to use 819 of them. The orthodox fix is on-demand graph construction
(RPython's `bookkeeper.getdesc(func).get_graph()` builds flow graphs lazily from
the entry point); that is a `front::mir` redesign and is left for its own change.

## Verification

`python3 ./pyre/check.py --backend dynasm,cranelift,wasm` on the final rebased
tree: **dynasm 329/329, cranelift 329/329, wasm 326/326, 3/3 backend runs**.

Cache behaviour verified directly rather than by wall-clock (a cache-miss build
measured *faster* than a warm one when machine load doubled — the decisive check
is whether a new entry directory appears, since a restore never creates one):
touching `build.rs` so the binary is recompiled, and building under a different
`CARGO_TARGET_DIR`, both restore the same key instead of re-analysing. Pruning
verified by seeding 12 entries with staggered mtimes plus a stale version
directory: 13 → 8 (live key + 7 newest), stale version removed.

## Two things for the reviewer to decide

- **CI cache.** `pyre-ci.yml` caches `build/llbc/*` by explicit path and leaves
  `target/` to `Swatinem/rust-cache`. Whether rust-cache's target cleanup
  preserved the old `target/pyre-jit-trace-cache` is unverified; if it did, CI
  loses those prepass hits until `build/pyre-jit-trace-cache` is added to a
  cache step in the ~6 build jobs. Such a step is safe by construction — the
  directory name *is* the content key, so a stale restore simply misses. Not
  included here since it is a workflow change across 6 jobs.
- **Legacy cache.** `target/pyre-jit-trace-cache` (750 MB) is now orphaned and
  was deliberately not deleted: `rm -rf target/pyre-jit-trace-cache`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
