### PR TITLE
gc: validate generations and enumerate reachable objects

### DIFF
--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -1607,8 +1607,9 @@ fn collect_full_via_active_runtime() {
     with_cranelift_gc(|gc| gc.collect_full());
 }
 
-fn get_objects_via_active_runtime(generation: i8) -> Vec<GcRef> {
-    with_cranelift_gc(|gc| gc.get_objects(generation)).unwrap_or_default()
+fn get_objects_via_active_runtime(generation: i8, visitor: majit_gc::GetObjectsVisitorFn) {
+    let mut visit = visitor;
+    with_cranelift_gc(|gc| gc.get_objects(generation, &mut visit));
 }
 
 /// Non-moving old-gen-only major trampoline — sweeps dead old-gen objects

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -387,6 +387,7 @@ fn register_active_hooks(supports_guard_gc_type: bool) {
     ));
     majit_gc::set_active_alloc_oldgen_typed(Some(alloc_oldgen_typed_via_active_runtime));
     majit_gc::set_active_collect_full(Some(collect_full_via_active_runtime));
+    majit_gc::set_active_get_objects(Some(get_objects_via_active_runtime));
     majit_gc::set_active_collect_oldgen(Some(collect_oldgen_nonmoving_via_active_runtime));
     majit_gc::set_active_heap_stats(Some(heap_stats_via_active_runtime));
     majit_gc::set_active_root_hooks(
@@ -1604,6 +1605,10 @@ fn alloc_oldgen_typed_via_active_runtime(type_id: u32, size: usize) -> GcRef {
 /// dangle after the embedded minor cycle).
 fn collect_full_via_active_runtime() {
     with_cranelift_gc(|gc| gc.collect_full());
+}
+
+fn get_objects_via_active_runtime(generation: i8) -> Vec<GcRef> {
+    with_cranelift_gc(|gc| gc.get_objects(generation)).unwrap_or_default()
 }
 
 /// Non-moving old-gen-only major trampoline — sweeps dead old-gen objects

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -191,6 +191,7 @@ fn register_active_hooks(supports_guard_gc_type: bool) {
     ));
     majit_gc::set_active_alloc_oldgen_typed(Some(dynasm_alloc_oldgen_typed));
     majit_gc::set_active_collect_full(Some(dynasm_collect_full));
+    majit_gc::set_active_get_objects(Some(dynasm_get_objects));
     majit_gc::set_active_collect_oldgen(Some(dynasm_collect_oldgen_nonmoving));
     majit_gc::set_active_heap_stats(Some(dynasm_heap_stats));
     majit_gc::set_active_root_hooks(Some(dynasm_gc_add_root), Some(dynasm_gc_remove_root));
@@ -479,6 +480,17 @@ fn dynasm_collect_full() {
         return;
     }
     majit_gc::gc_sync::gc_op(|g| g.collect_full());
+}
+
+fn dynasm_get_objects(generation: i8) -> Vec<GcRef> {
+    if let Some(result) = DYNASM_ACTIVE_GC.with(|c| {
+        c.borrow_mut()
+            .as_deref_mut()
+            .map(|g| g.get_objects(generation))
+    }) {
+        return result;
+    }
+    majit_gc::gc_sync::gc_op(|g| g.get_objects(generation))
 }
 
 /// Non-moving old-gen-only major. Reclaims stable-allocated interp int/float

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -482,15 +482,19 @@ fn dynasm_collect_full() {
     majit_gc::gc_sync::gc_op(|g| g.collect_full());
 }
 
-fn dynasm_get_objects(generation: i8) -> Vec<GcRef> {
-    if let Some(result) = DYNASM_ACTIVE_GC.with(|c| {
-        c.borrow_mut()
-            .as_deref_mut()
-            .map(|g| g.get_objects(generation))
-    }) {
-        return result;
+fn dynasm_get_objects(generation: i8, visitor: majit_gc::GetObjectsVisitorFn) {
+    let mut visit = visitor;
+    if DYNASM_ACTIVE_GC
+        .with(|c| {
+            c.borrow_mut()
+                .as_deref_mut()
+                .map(|g| g.get_objects(generation, &mut visit))
+        })
+        .is_some()
+    {
+        return;
     }
-    majit_gc::gc_sync::gc_op(|g| g.get_objects(generation))
+    majit_gc::gc_sync::gc_op(|g| g.get_objects(generation, &mut visit));
 }
 
 /// Non-moving old-gen-only major. Reclaims stable-allocated interp int/float

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -313,6 +313,7 @@ fn register_active_hooks(supports_guard_gc_type: bool) {
     majit_gc::set_active_root_hooks(Some(wasm_gc_add_root), Some(wasm_gc_remove_root));
     majit_gc::set_active_gc_owns_object(Some(wasm_gc_owns_object));
     majit_gc::set_active_write_barrier(Some(wasm_active_gc_write_barrier));
+    majit_gc::set_active_get_objects(Some(wasm_get_objects));
     majit_gc::set_active_collect_oldgen(Some(wasm_collect_oldgen_nonmoving));
     majit_gc::set_active_heap_stats(Some(active_gc_heap_stats));
     majit_gc::set_active_finalizer_hooks(
@@ -465,6 +466,10 @@ fn jf_top_addr() -> Option<u32> {
 /// and cranelift's `collect_oldgen_nonmoving_via_active_runtime`.
 fn wasm_collect_oldgen_nonmoving() {
     with_wasm_active_gc_mut(|gc| gc.collect_oldgen_nonmoving());
+}
+
+fn wasm_get_objects(generation: i8) -> Vec<GcRef> {
+    with_wasm_active_gc_mut(|gc| gc.get_objects(generation)).unwrap_or_default()
 }
 
 fn wasm_register_finalizer(fq_index: usize, obj: GcRef, trigger: majit_gc::FinalizerTriggerFn) {

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -468,8 +468,9 @@ fn wasm_collect_oldgen_nonmoving() {
     with_wasm_active_gc_mut(|gc| gc.collect_oldgen_nonmoving());
 }
 
-fn wasm_get_objects(generation: i8) -> Vec<GcRef> {
-    with_wasm_active_gc_mut(|gc| gc.get_objects(generation)).unwrap_or_default()
+fn wasm_get_objects(generation: i8, visitor: majit_gc::GetObjectsVisitorFn) {
+    let mut visit = visitor;
+    with_wasm_active_gc_mut(|gc| gc.get_objects(generation, &mut visit));
 }
 
 fn wasm_register_finalizer(fq_index: usize, obj: GcRef, trigger: majit_gc::FinalizerTriggerFn) {

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -2047,20 +2047,23 @@ impl MiniMarkGC {
         }
     }
 
-    fn seed_major_roots(&mut self) {
+    /// `inspector.py:get_rpy_roots` / `gc.enumerate_all_roots`: snapshot the
+    /// same complete root set used by major marking. The returned Vec is raw
+    /// (system-allocator) storage, matching inspector.py's preallocated raw
+    /// root list rather than creating a GC-visible side table.
+    fn enumerate_all_root_values(&self) -> Vec<GcRef> {
         // incminimark.py:2717 collect_roots: root_walker.walk_roots()
-        // seeds stack roots for a major marking cycle. Mirror the same
-        // root sets as minor collection, but mark old objects instead of
-        // copying nursery objects.
+        // walks the same root sets as minor collection.
+        let mut result = Vec::new();
         let roots: Vec<*mut GcRef> = self.roots.roots.iter().copied().collect();
         for root_ptr in roots {
             let gcref = unsafe { *root_ptr };
-            self.seed_major_root(gcref);
+            result.push(gcref);
         }
 
         let walk_all_mutators = crate::gc_sync::mutators_quiesced();
         let mut visit_shadow_root = |gcref: &mut GcRef| {
-            self.seed_major_root(*gcref);
+            result.push(*gcref);
         };
         if walk_all_mutators {
             crate::shadow_stack::walk_all_roots(&mut visit_shadow_root);
@@ -2068,17 +2071,16 @@ impl MiniMarkGC {
             crate::shadow_stack::walk_roots(&mut visit_shadow_root);
         }
 
-        let mut libc_jf_refs: Vec<GcRef> = Vec::new();
         let mut visit_jf_root = |gcref: &mut GcRef| {
             if !gcref.is_null() && crate::shadow_stack::is_libc_jitframe(gcref.0) {
                 crate::shadow_stack::trace_libc_jitframe(gcref.0, &mut |slot_ptr| {
                     let field_ref = unsafe { *slot_ptr };
                     if !field_ref.is_null() {
-                        libc_jf_refs.push(field_ref);
+                        result.push(field_ref);
                     }
                 });
             } else {
-                self.seed_major_root(*gcref);
+                result.push(*gcref);
             }
         };
         if walk_all_mutators {
@@ -2086,12 +2088,9 @@ impl MiniMarkGC {
         } else {
             crate::shadow_stack::walk_jf_roots(&mut visit_jf_root);
         }
-        for gcref in libc_jf_refs {
-            self.seed_major_root(gcref);
-        }
 
         let mut visit_bh_root = |gcref: &mut GcRef| {
-            self.seed_major_root(*gcref);
+            result.push(*gcref);
         };
         if walk_all_mutators {
             crate::shadow_stack::walk_all_bh_regs(&mut visit_bh_root);
@@ -2103,7 +2102,7 @@ impl MiniMarkGC {
         // minor-collection path for why the in-flight virtuals_cache /
         // registers_r slices must be seeded as roots.
         let mut visit_resume_root = |gcref: &mut GcRef| {
-            self.seed_major_root(*gcref);
+            result.push(*gcref);
         };
         if walk_all_mutators {
             crate::shadow_stack::walk_all_resume_ref_roots(&mut visit_resume_root);
@@ -2112,7 +2111,7 @@ impl MiniMarkGC {
         }
 
         let mut visit_extra_area = |gcref: &mut GcRef| {
-            self.seed_major_root(*gcref);
+            result.push(*gcref);
         };
         if walk_all_mutators {
             crate::shadow_stack::walk_all_extra_areas(&mut visit_extra_area);
@@ -2121,11 +2120,11 @@ impl MiniMarkGC {
         }
 
         crate::walk_active_extra_roots(&mut |gcref| {
-            self.seed_major_root(*gcref);
+            result.push(*gcref);
         });
 
         crate::shadow_stack::walk_extra_roots(|gcref| {
-            self.seed_major_root(*gcref);
+            result.push(*gcref);
         });
 
         // gc/base.py `enum_pending_finalizers`: objects already moved to a
@@ -2136,8 +2135,111 @@ impl MiniMarkGC {
             .flat_map(|handler| handler.deque.iter().copied())
             .collect();
         for addr in pending {
-            self.seed_major_root(GcRef(addr));
+            result.push(GcRef(addr));
         }
+        result
+    }
+
+    fn seed_major_roots(&mut self) {
+        // incminimark.py:2717 collect_roots: root_walker.walk_roots()
+        // seeds stack roots for a major marking cycle. Mirror the same
+        // root sets as minor collection, but mark old objects instead of
+        // copying nursery objects.
+        for gcref in self.enumerate_all_root_values() {
+            self.seed_major_root(gcref);
+        }
+    }
+
+    /// `inspector.py:get_rpy_referents`: trace one object's direct GC
+    /// referents without changing collection state.
+    fn visit_referents(&self, obj_addr: usize, visitor: &mut dyn FnMut(GcRef)) {
+        let type_id = unsafe { (*header_of(obj_addr)).type_id() };
+        self.validate_type_id(type_id, obj_addr, "visit_referents");
+        let type_info = self.types.get(type_id);
+        if let Some(trace_fn) = type_info.custom_trace {
+            unsafe {
+                trace_fn(obj_addr, &mut |slot_ptr: *mut GcRef| {
+                    let field_ref = *slot_ptr;
+                    if !field_ref.is_null() {
+                        visitor(field_ref);
+                    }
+                });
+            }
+            return;
+        }
+        for &offset in &type_info.gc_ptr_offsets {
+            let field_ref = unsafe { *((obj_addr + offset) as *const GcRef) };
+            if !field_ref.is_null() {
+                visitor(field_ref);
+            }
+        }
+        if type_info.items_have_gc_ptrs && type_info.item_size > 0 {
+            let length = unsafe { *((obj_addr + type_info.length_offset) as *const usize) };
+            let items_start = obj_addr + type_info.size;
+            for i in 0..length {
+                let field_ref =
+                    unsafe { *((items_start + i * type_info.item_size) as *const GcRef) };
+                if !field_ref.is_null() {
+                    visitor(field_ref);
+                }
+            }
+        }
+    }
+
+    /// `rpython/rlib/rgc.py:1224 do_get_objects`, using MiniMark's
+    /// GCFLAG_EXTRA exactly as the translated RPython path does.
+    pub fn do_get_objects(&mut self, generation: i8) -> Vec<GcRef> {
+        if generation == 1 {
+            return Vec::new();
+        }
+        let _stw = if crate::gc_sync::stw_required() {
+            Some(crate::gc_sync::quiesce_mutators())
+        } else {
+            None
+        };
+        let roots = self.enumerate_all_root_values();
+        let mut pending = roots.clone();
+        let mut result = Vec::new();
+        while let Some(gcref) = pending.pop() {
+            if gcref.is_null() || !self.is_managed_heap_object(gcref.0) {
+                continue;
+            }
+            let hdr = unsafe { header_of(gcref.0) };
+            if unsafe { (*hdr).has_flag(flags::EXTRA) } {
+                continue;
+            }
+            unsafe { (*hdr).set_flag(flags::EXTRA) };
+            let is_requested_generation = match generation {
+                -1 => true,
+                0 => self.is_in_nursery(gcref.0),
+                2 => !self.is_in_nursery(gcref.0),
+                _ => false,
+            };
+            let type_id = unsafe { (*hdr).type_id() };
+            if is_requested_generation
+                && !unsafe { (*hdr).has_flag(flags::DUMMY) }
+                && self.types.get(type_id).is_object
+            {
+                result.push(gcref);
+            }
+            self.visit_referents(gcref.0, &mut |child| pending.push(child));
+        }
+
+        // rgc.clear_gcflag_extra(roots): repeat the root traversal and restore
+        // every toggled header before returning to app-level code.
+        let mut pending = roots;
+        while let Some(gcref) = pending.pop() {
+            if gcref.is_null() || !self.is_managed_heap_object(gcref.0) {
+                continue;
+            }
+            let hdr = unsafe { header_of(gcref.0) };
+            if unsafe { !(*hdr).has_flag(flags::EXTRA) } {
+                continue;
+            }
+            unsafe { (*hdr).clear_flag(flags::EXTRA) };
+            self.visit_referents(gcref.0, &mut |child| pending.push(child));
+        }
+        result
     }
 
     /// Drive incremental major-collection progress after a minor collection.
@@ -3621,6 +3723,10 @@ impl GcAllocator for MiniMarkGC {
         self.do_collect_full();
     }
 
+    fn get_objects(&mut self, generation: i8) -> Vec<GcRef> {
+        self.do_get_objects(generation)
+    }
+
     fn collect_oldgen_nonmoving(&mut self) {
         self.do_collect_oldgen_nonmoving();
     }
@@ -3975,6 +4081,51 @@ mod tests {
             large_object_threshold: nursery_size / 2,
             ..GcConfig::default()
         })
+    }
+
+    #[test]
+    fn get_objects_walks_referents_filters_rpython_structs_and_generations() {
+        let ptr_size = std::mem::size_of::<GcRef>();
+        let mut gc = test_gc(4096);
+        let mut holder_info = TypeInfo::object(ptr_size);
+        holder_info.has_gc_ptrs = true;
+        holder_info.gc_ptr_offsets = vec![0];
+        let holder_tid = gc.register_type(holder_info);
+        let raw_tid = gc.register_type(TypeInfo::with_gc_ptrs(ptr_size, vec![0]));
+        let leaf_tid = gc.register_type(TypeInfo::object(ptr_size));
+
+        let leaf = gc.alloc_with_type(leaf_tid, ptr_size);
+        let raw = gc.alloc_with_type(raw_tid, ptr_size);
+        let mut holder = gc.alloc_with_type(holder_tid, ptr_size);
+        unsafe {
+            *(raw.0 as *mut GcRef) = leaf;
+            *(holder.0 as *mut GcRef) = raw;
+            gc.roots.add(&mut holder);
+        }
+
+        let all = gc.do_get_objects(-1);
+        assert_eq!(all.len(), 2);
+        assert!(all.contains(&holder));
+        assert!(all.contains(&leaf));
+        assert_eq!(gc.do_get_objects(0).len(), 2);
+        assert!(gc.do_get_objects(1).is_empty());
+        assert!(gc.do_get_objects(2).is_empty());
+        for object in [holder, raw, leaf] {
+            assert!(!unsafe { (*header_of(object.0)).has_flag(flags::EXTRA) });
+        }
+
+        gc.do_collect_nursery();
+        let raw = unsafe { *(holder.0 as *const GcRef) };
+        let leaf = unsafe { *(raw.0 as *const GcRef) };
+        assert!(gc.do_get_objects(0).is_empty());
+        let old = gc.do_get_objects(2);
+        assert_eq!(old.len(), 2);
+        assert!(old.contains(&holder));
+        assert!(old.contains(&leaf));
+        for object in [holder, raw, leaf] {
+            assert!(!unsafe { (*header_of(object.0)).has_flag(flags::EXTRA) });
+        }
+        gc.roots.clear();
     }
 
     #[test]

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -2047,11 +2047,11 @@ impl MiniMarkGC {
         }
     }
 
-    /// `inspector.py:get_rpy_roots` / `gc.enumerate_all_roots`: snapshot the
-    /// same complete root set used by major marking. The returned Vec is raw
-    /// (system-allocator) storage, matching inspector.py's preallocated raw
-    /// root list rather than creating a GC-visible side table.
-    fn enumerate_all_root_values(&self) -> Vec<GcRef> {
+    /// Snapshot the root walk shared by inspection and major marking. The
+    /// finalizer lists are appended by the caller because
+    /// `gc.enumerate_all_roots` includes live registered finalizers, whereas
+    /// major marking must leave those objects to the finalization-order pass.
+    fn enumerate_root_walker_values(&self) -> Vec<GcRef> {
         // incminimark.py:2717 collect_roots: root_walker.walk_roots()
         // walks the same root sets as minor collection.
         let mut result = Vec::new();
@@ -2126,6 +2126,29 @@ impl MiniMarkGC {
         crate::shadow_stack::walk_extra_roots(|gcref| {
             result.push(*gcref);
         });
+        result
+    }
+
+    /// `inspector.py:get_rpy_roots` / `gc.enumerate_all_roots`: snapshot all
+    /// inspection roots in the order from `gc/base.py:enumerate_all_roots`.
+    /// The returned Vec is raw system-allocator storage, matching
+    /// inspector.py's preallocated raw root list.
+    fn enumerate_all_root_values(&self) -> Vec<GcRef> {
+        let mut result = self.enumerate_root_walker_values();
+        // incminimark.py:2734-2736 `enum_live_with_finalizers`: registered
+        // finalizer objects remain roots even before they become unreachable
+        // and move to an app-visible death queue. AddressDeque.foreach(..., 2)
+        // visits every object address while skipping each paired queue index.
+        result.extend(
+            self.probably_young_objects_with_finalizers
+                .iter()
+                .map(|&(addr, _)| GcRef(addr)),
+        );
+        result.extend(
+            self.old_objects_with_finalizers
+                .iter()
+                .map(|&(addr, _)| GcRef(addr)),
+        );
 
         // gc/base.py `enum_pending_finalizers`: objects already moved to a
         // death queue remain GC roots until app-level code pops them.
@@ -2145,7 +2168,18 @@ impl MiniMarkGC {
         // seeds stack roots for a major marking cycle. Mirror the same
         // root sets as minor collection, but mark old objects instead of
         // copying nursery objects.
-        for gcref in self.enumerate_all_root_values() {
+        let mut roots = self.enumerate_root_walker_values();
+        // Objects already moved to a death queue remain ordinary roots until
+        // app-level code pops them. Registered live finalizers are deliberately
+        // absent here; incminimark's finalization-order pass decides whether
+        // they survive or move to the death queue.
+        roots.extend(
+            self.finalizer_handlers
+                .iter()
+                .flat_map(|handler| handler.deque.iter().copied())
+                .map(GcRef),
+        );
+        for gcref in roots {
             self.seed_major_root(gcref);
         }
     }
@@ -2188,9 +2222,9 @@ impl MiniMarkGC {
 
     /// `rpython/rlib/rgc.py:1224 do_get_objects`, using MiniMark's
     /// GCFLAG_EXTRA exactly as the translated RPython path does.
-    pub fn do_get_objects(&mut self, generation: i8) -> Vec<GcRef> {
+    pub fn do_get_objects(&mut self, generation: i8, visitor: &mut dyn FnMut(GcRef)) {
         if generation == 1 {
-            return Vec::new();
+            return;
         }
         let _stw = if crate::gc_sync::stw_required() {
             Some(crate::gc_sync::quiesce_mutators())
@@ -2239,7 +2273,9 @@ impl MiniMarkGC {
             unsafe { (*hdr).clear_flag(flags::EXTRA) };
             self.visit_referents(gcref.0, &mut |child| pending.push(child));
         }
-        result
+        for gcref in result {
+            visitor(gcref);
+        }
     }
 
     /// Drive incremental major-collection progress after a minor collection.
@@ -3723,8 +3759,8 @@ impl GcAllocator for MiniMarkGC {
         self.do_collect_full();
     }
 
-    fn get_objects(&mut self, generation: i8) -> Vec<GcRef> {
-        self.do_get_objects(generation)
+    fn get_objects(&mut self, generation: i8, visitor: &mut dyn FnMut(GcRef)) {
+        self.do_get_objects(generation, visitor)
     }
 
     fn collect_oldgen_nonmoving(&mut self) {
@@ -4103,13 +4139,18 @@ mod tests {
             gc.roots.add(&mut holder);
         }
 
-        let all = gc.do_get_objects(-1);
+        let get_objects = |gc: &mut MiniMarkGC, generation| {
+            let mut result = Vec::new();
+            gc.do_get_objects(generation, &mut |gcref| result.push(gcref));
+            result
+        };
+        let all = get_objects(&mut gc, -1);
         assert_eq!(all.len(), 2);
         assert!(all.contains(&holder));
         assert!(all.contains(&leaf));
-        assert_eq!(gc.do_get_objects(0).len(), 2);
-        assert!(gc.do_get_objects(1).is_empty());
-        assert!(gc.do_get_objects(2).is_empty());
+        assert_eq!(get_objects(&mut gc, 0).len(), 2);
+        assert!(get_objects(&mut gc, 1).is_empty());
+        assert!(get_objects(&mut gc, 2).is_empty());
         for object in [holder, raw, leaf] {
             assert!(!unsafe { (*header_of(object.0)).has_flag(flags::EXTRA) });
         }
@@ -4117,8 +4158,8 @@ mod tests {
         gc.do_collect_nursery();
         let raw = unsafe { *(holder.0 as *const GcRef) };
         let leaf = unsafe { *(raw.0 as *const GcRef) };
-        assert!(gc.do_get_objects(0).is_empty());
-        let old = gc.do_get_objects(2);
+        assert!(get_objects(&mut gc, 0).is_empty());
+        let old = get_objects(&mut gc, 2);
         assert_eq!(old.len(), 2);
         assert!(old.contains(&holder));
         assert!(old.contains(&leaf));
@@ -4126,6 +4167,21 @@ mod tests {
             assert!(!unsafe { (*header_of(object.0)).has_flag(flags::EXTRA) });
         }
         gc.roots.clear();
+    }
+
+    #[test]
+    fn get_objects_includes_live_objects_registered_with_finalizers() {
+        fn trigger() {}
+
+        let ptr_size = std::mem::size_of::<GcRef>();
+        let mut gc = test_gc(4096);
+        let object_tid = gc.register_type(TypeInfo::object(ptr_size));
+        let object = gc.alloc_with_type(object_tid, ptr_size);
+        gc.register_finalizer(0, object, trigger);
+
+        let mut objects = Vec::new();
+        gc.do_get_objects(-1, &mut |gcref| objects.push(gcref));
+        assert!(objects.contains(&object));
     }
 
     #[test]

--- a/majit/majit-gc/src/lib.rs
+++ b/majit/majit-gc/src/lib.rs
@@ -319,6 +319,14 @@ pub trait GcAllocator: Send {
     /// Trigger a full collection.
     fn collect_full(&mut self);
 
+    /// `rpython/rlib/rgc.py:1224 do_get_objects`: walk every object reachable
+    /// from the GC roots and return the `rclass.OBJECT` instances selected by
+    /// CPython 3.14's generation argument (`-1` all, `0` nursery, `1` empty,
+    /// `2` old generation). Collectors without an inspector return no objects.
+    fn get_objects(&mut self, _generation: i8) -> Vec<GcRef> {
+        Vec::new()
+    }
+
     /// Trigger a non-moving old-gen-only major collection (sweep dead old-gen
     /// objects without moving the nursery). The default no-ops so a backend
     /// with no incremental old-gen lacks no method; `MiniMarkGC` overrides it.
@@ -785,6 +793,9 @@ impl GcAllocator for GcHandle {
     }
     fn collect_full(&mut self) {
         gc_sync::gc_op(|gc| gc.collect_full())
+    }
+    fn get_objects(&mut self, generation: i8) -> Vec<GcRef> {
+        gc_sync::gc_op(|gc| gc.get_objects(generation))
     }
     fn collect_oldgen_nonmoving(&mut self) {
         gc_sync::gc_op(|gc| gc.collect_oldgen_nonmoving())
@@ -1444,6 +1455,23 @@ pub fn collect_full() {
     if let Some(f) = ACTIVE_COLLECT_FULL.get() {
         f();
     }
+}
+
+/// Active-backend trampoline for `rpython/rlib/rgc.py:1224
+/// do_get_objects`. The generation values are CPython 3.14's public
+/// `gc.get_objects` convention.
+pub type GetObjectsFn = fn(i8) -> Vec<GcRef>;
+
+global_hook!(static ACTIVE_GET_OBJECTS: GetObjectsFn);
+
+pub fn set_active_get_objects(hook: Option<GetObjectsFn>) {
+    ACTIVE_GET_OBJECTS.set(hook);
+}
+
+pub fn get_objects(generation: i8) -> Vec<GcRef> {
+    ACTIVE_GET_OBJECTS
+        .get()
+        .map_or_else(Vec::new, |f| f(generation))
 }
 
 /// Process-global callback running a non-moving old-gen-only major collection

--- a/majit/majit-gc/src/lib.rs
+++ b/majit/majit-gc/src/lib.rs
@@ -320,12 +320,12 @@ pub trait GcAllocator: Send {
     fn collect_full(&mut self);
 
     /// `rpython/rlib/rgc.py:1224 do_get_objects`: walk every object reachable
-    /// from the GC roots and return the `rclass.OBJECT` instances selected by
-    /// CPython 3.14's generation argument (`-1` all, `0` nursery, `1` empty,
-    /// `2` old generation). Collectors without an inspector return no objects.
-    fn get_objects(&mut self, _generation: i8) -> Vec<GcRef> {
-        Vec::new()
-    }
+    /// from the GC roots and visit the `rclass.OBJECT` instances selected by
+    /// the generation argument. The visitor runs before the collector releases
+    /// its inspection pause, so callers can root every returned object without
+    /// exposing unrooted raw addresses to another collection. Collectors
+    /// without an inspector visit no objects.
+    fn get_objects(&mut self, _generation: i8, _visitor: &mut dyn FnMut(GcRef)) {}
 
     /// Trigger a non-moving old-gen-only major collection (sweep dead old-gen
     /// objects without moving the nursery). The default no-ops so a backend
@@ -794,8 +794,8 @@ impl GcAllocator for GcHandle {
     fn collect_full(&mut self) {
         gc_sync::gc_op(|gc| gc.collect_full())
     }
-    fn get_objects(&mut self, generation: i8) -> Vec<GcRef> {
-        gc_sync::gc_op(|gc| gc.get_objects(generation))
+    fn get_objects(&mut self, generation: i8, visitor: &mut dyn FnMut(GcRef)) {
+        gc_sync::gc_op(|gc| gc.get_objects(generation, visitor))
     }
     fn collect_oldgen_nonmoving(&mut self) {
         gc_sync::gc_op(|gc| gc.collect_oldgen_nonmoving())
@@ -1459,8 +1459,10 @@ pub fn collect_full() {
 
 /// Active-backend trampoline for `rpython/rlib/rgc.py:1224
 /// do_get_objects`. The generation values are CPython 3.14's public
-/// `gc.get_objects` convention.
-pub type GetObjectsFn = fn(i8) -> Vec<GcRef>;
+/// `gc.get_objects` convention. The backend must invoke the visitor while its
+/// inspection pause is still held.
+pub type GetObjectsVisitorFn = fn(GcRef);
+pub type GetObjectsFn = fn(i8, GetObjectsVisitorFn);
 
 global_hook!(static ACTIVE_GET_OBJECTS: GetObjectsFn);
 
@@ -1468,10 +1470,10 @@ pub fn set_active_get_objects(hook: Option<GetObjectsFn>) {
     ACTIVE_GET_OBJECTS.set(hook);
 }
 
-pub fn get_objects(generation: i8) -> Vec<GcRef> {
-    ACTIVE_GET_OBJECTS
-        .get()
-        .map_or_else(Vec::new, |f| f(generation))
+pub fn get_objects(generation: i8, visitor: GetObjectsVisitorFn) {
+    if let Some(f) = ACTIVE_GET_OBJECTS.get() {
+        f(generation, visitor);
+    }
 }
 
 /// Process-global callback running a non-moving old-gen-only major collection

--- a/pyre/extra_tests/snippets/stdlib_gc.py
+++ b/pyre/extra_tests/snippets/stdlib_gc.py
@@ -1,0 +1,48 @@
+import gc
+
+from testutils import assert_raises
+
+
+assert isinstance(gc.collect(), int)
+assert isinstance(gc.collect(0), int)
+assert isinstance(gc.collect(1), int)
+assert isinstance(gc.collect(2), int)
+assert isinstance(gc.collect(generation=2), int)
+
+
+class Index:
+    def __index__(self):
+        return 0
+
+
+assert isinstance(gc.collect(Index()), int)
+
+for generation in (-1, 3):
+    with assert_raises(ValueError):
+        gc.collect(generation)
+
+with assert_raises(TypeError):
+    gc.collect("0")
+
+with assert_raises(TypeError):
+    gc.collect(0, 1)
+
+assert isinstance(gc.get_objects(), list)
+assert isinstance(gc.get_objects(None), list)
+assert isinstance(gc.get_objects(generation=None), list)
+assert isinstance(gc.get_objects(-1), list)
+assert isinstance(gc.get_objects(0), list)
+assert gc.get_objects(1) == []
+assert isinstance(gc.get_objects(2), list)
+assert isinstance(gc.get_objects(Index()), list)
+
+for generation in (-2, 3):
+    with assert_raises(ValueError):
+        gc.get_objects(generation)
+
+for generation in ("0", 1.25):
+    with assert_raises(TypeError):
+        gc.get_objects(generation)
+
+with assert_raises(TypeError):
+    gc.get_objects(None, None)

--- a/pyre/extra_tests/snippets/stdlib_gc.py
+++ b/pyre/extra_tests/snippets/stdlib_gc.py
@@ -11,7 +11,7 @@ assert isinstance(gc.collect(generation=2), int)
 
 
 class Index:
-    def __index__(self):
+    def __index__(self) -> int:
         return 0
 
 
@@ -32,7 +32,7 @@ assert isinstance(gc.get_objects(None), list)
 assert isinstance(gc.get_objects(generation=None), list)
 assert isinstance(gc.get_objects(-1), list)
 assert isinstance(gc.get_objects(0), list)
-assert gc.get_objects(1) == []
+assert isinstance(gc.get_objects(1), list)
 assert isinstance(gc.get_objects(2), list)
 assert isinstance(gc.get_objects(Index()), list)
 

--- a/pyre/extra_tests/snippets/stdlib_gc.py
+++ b/pyre/extra_tests/snippets/stdlib_gc.py
@@ -36,6 +36,13 @@ assert gc.get_objects(1) == []
 assert isinstance(gc.get_objects(2), list)
 assert isinstance(gc.get_objects(Index()), list)
 
+marker = []
+assert any(obj is marker for obj in gc.get_objects())
+assert any(
+    obj is marker
+    for obj in gc.get_objects(0) + gc.get_objects(2)
+)
+
 for generation in (-2, 3):
     with assert_raises(ValueError):
         gc.get_objects(generation)

--- a/pyre/extra_tests/snippets/stdlib_sys.py
+++ b/pyre/extra_tests/snippets/stdlib_sys.py
@@ -150,6 +150,21 @@ assert proc.returncode == 0, proc
 
 assert sys._getframemodulename() == "__main__", sys._getframemodulename()
 
+# PyPy's `vm.getsizeof(space, w_object, w_default=None)` accepts one or two
+# positional arguments.  Python 3.14 likewise rejects every excess argument,
+# including when the object has a working `__sizeof__`.
+with assert_raises(TypeError):
+    sys.getsizeof()
+
+with assert_raises(TypeError):
+    sys.getsizeof(object(), 1, 2)
+
+with assert_raises(TypeError):
+    sys.getsizeof("x", 1, 2)
+
+default = object()
+assert sys.getsizeof(object(), default) is default
+
 
 def test_getframemodulename():
     return sys._getframemodulename()

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -773,7 +773,13 @@ fn call_builtin_code_positional(code: PyObjectRef, args: &[PyObjectRef]) -> PyRe
     };
 
     if let Some(sig) = unsafe { crate::builtin_code_get_signature(current_code()) } {
-        if sig.has_vararg() || sig.has_kwarg() || sig.num_kwonlyargnames() > 0 {
+        // Every HOPELESS signature needs `_match_signature`, not only
+        // *args/**kwargs/kw-only shapes.  A plain optional positional
+        // parameter also has HOPELESS fast arity; bypassing the binder let
+        // excess positionals reach the typed wrapper, which consumes its
+        // declared prefix and silently ignores the rest.
+        if unsafe { crate::builtin_code_get_fast_natural_arity(current_code()) } == crate::HOPELESS
+        {
             let fname = unsafe { crate::builtin_code_name(current_code()) };
             let args = current_args();
             let bound = bind_kwargs_to_signature(sig, fname, &args, &[])?;

--- a/pyre/pyre-interpreter/src/module/gc/mod.rs
+++ b/pyre/pyre-interpreter/src/module/gc/mod.rs
@@ -98,9 +98,7 @@ crate::py_module! {
         ) -> Result<PyObjectRef, crate::PyError> {
             // CPython 3.14 `gc.get_objects(generation=None)`: -1/None means
             // every generation, generation 1 is empty after its removal, and
-            // 0/2 select the young/old generations.  Heap enumeration itself
-            // remains the same empty-list fallback until majit-gc exposes the
-            // RPython `rgc.do_get_objects` walk.
+            // 0/2 select the young/old generations.
             let generation = if unsafe { is_none(generation) } {
                 -1
             } else {
@@ -116,7 +114,16 @@ crate::py_module! {
                     "generation parameter must be less than the number of available generations (3)",
                 ));
             }
-            Ok(w_list_new(vec![]))
+            let _roots = pyre_object::gc_roots::push_roots();
+            let objects = majit_gc::get_objects(generation as i8);
+            for &object in &objects {
+                pyre_object::gc_roots::pin_root(object.0 as PyObjectRef);
+            }
+            let first = pyre_object::gc_roots::shadow_stack_len() - objects.len();
+            let objects = (0..objects.len())
+                .map(|index| pyre_object::gc_roots::shadow_stack_get(first + index))
+                .collect();
+            Ok(w_list_new_object(objects))
         }
     },
     functions: {

--- a/pyre/pyre-interpreter/src/module/gc/mod.rs
+++ b/pyre/pyre-interpreter/src/module/gc/mod.rs
@@ -64,10 +64,19 @@ crate::py_module! {
         "DEBUG_SAVEALL"       => w_int_new(32),
         "DEBUG_LEAK"          => w_int_new(38),
     },
-    functions: {
-        // `interp_gc.py:7-26 collect` — the optional `generation` argument is
-        // ignored per upstream.
-        "collect"       / * = |_| {
+    inline_functions: {
+        fn collect(
+            #[default(w_int_new(2))] generation: PyObjectRef,
+        ) -> Result<PyObjectRef, crate::PyError> {
+            // PyPy `interp_gc.py:7-26 collect` unwraps the optional generation
+            // as an int before entering the body.  CPython 3.14 gives it the
+            // default 2 and validates the three surviving generations.
+            let generation = crate::baseobjspace::int_w(
+                crate::baseobjspace::space_index(generation)?,
+            )?;
+            if !(0..=2).contains(&generation) {
+                return Err(crate::PyError::value_error("invalid generation"));
+            }
             crate::baseobjspace::clear_method_cache();
             crate::objspace::std::mapdict::clear_map_attr_cache();
             pyre_object::gc_hook::try_gc_collect();
@@ -82,7 +91,35 @@ crate::py_module! {
                 }
             }
             Ok(w_int_new(0))
-        },
+        }
+
+        fn get_objects(
+            #[default(w_none())] generation: PyObjectRef,
+        ) -> Result<PyObjectRef, crate::PyError> {
+            // CPython 3.14 `gc.get_objects(generation=None)`: -1/None means
+            // every generation, generation 1 is empty after its removal, and
+            // 0/2 select the young/old generations.  Heap enumeration itself
+            // remains the same empty-list fallback until majit-gc exposes the
+            // RPython `rgc.do_get_objects` walk.
+            let generation = if unsafe { is_none(generation) } {
+                -1
+            } else {
+                crate::baseobjspace::int_w(crate::baseobjspace::space_index(generation)?)?
+            };
+            if generation < -1 {
+                return Err(crate::PyError::value_error(
+                    "generation parameter cannot be negative",
+                ));
+            }
+            if generation > 2 {
+                return Err(crate::PyError::value_error(
+                    "generation parameter must be less than the number of available generations (3)",
+                ));
+            }
+            Ok(w_list_new(vec![]))
+        }
+    },
+    functions: {
         "disable"       / 0 = |_| {
             pyre_object::gc_hook::try_gc_set_enabled(false);
             GC_ENABLED.store(false, Ordering::Relaxed);
@@ -112,8 +149,6 @@ crate::py_module! {
             };
             Ok(w_bool_from(enabled))
         },
-        // `generation` is optional.
-        "get_objects"   / * = |_| Ok(w_list_new(vec![])),
         "get_referrers" / * = |_| Ok(w_list_new(vec![])),
         "get_referents" / * = |_| Ok(w_list_new(vec![])),
         "set_threshold" / 0 = |_| Ok(w_none()),

--- a/pyre/pyre-interpreter/src/module/gc/mod.rs
+++ b/pyre/pyre-interpreter/src/module/gc/mod.rs
@@ -97,8 +97,7 @@ crate::py_module! {
             #[default(w_none())] generation: PyObjectRef,
         ) -> Result<PyObjectRef, crate::PyError> {
             // CPython 3.14 `gc.get_objects(generation=None)`: -1/None means
-            // every generation, generation 1 is empty after its removal, and
-            // 0/2 select the young/old generations.
+            // every generation; 0 through 2 select a generation.
             let generation = if unsafe { is_none(generation) } {
                 -1
             } else {
@@ -115,13 +114,13 @@ crate::py_module! {
                 ));
             }
             let _roots = pyre_object::gc_roots::push_roots();
-            let objects = majit_gc::get_objects(generation as i8);
-            for &object in &objects {
+            let first = pyre_object::gc_roots::shadow_stack_len();
+            fn pin_object(object: majit_ir::GcRef) {
                 pyre_object::gc_roots::pin_root(object.0 as PyObjectRef);
             }
-            let first = pyre_object::gc_roots::shadow_stack_len() - objects.len();
-            let objects = (0..objects.len())
-                .map(|index| pyre_object::gc_roots::shadow_stack_get(first + index))
+            majit_gc::get_objects(generation as i8, pin_object);
+            let objects = (first..pyre_object::gc_roots::shadow_stack_len())
+                .map(pyre_object::gc_roots::shadow_stack_get)
                 .collect();
             Ok(w_list_new_object(objects))
         }

--- a/pyre/pyre-interpreter/src/module/sys/vm.rs
+++ b/pyre/pyre-interpreter/src/module/sys/vm.rs
@@ -1499,6 +1499,12 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         make_builtin_function(
             "getsizeof",
             |args| {
+                if args.len() > 2 {
+                    return Err(crate::PyError::type_error(format!(
+                        "getsizeof() takes at most 2 arguments ({} given)",
+                        args.len()
+                    )));
+                }
                 let Some(&w_obj) = args.first() else {
                     return Err(crate::PyError::type_error(
                         "getsizeof() takes at least 1 argument (0 given)",


### PR DESCRIPTION
Follow-up to #735 that finishes the current builtin/GC chunk.

- reject excess `sys.getsizeof` positional arguments
- implement Python 3.14 generation validation for `gc.collect` and `gc.get_objects`
- port RPython `do_get_objects` root/referent traversal using `GCFLAG_EXTRA`
- filter app-level objects and support the 3.14 young/removed/old generation view
- keep enumerated objects rooted while constructing the Python list

Validation:
- `cargo check --features dynasm`
- `cargo test --features dynasm`
- `cargo test --all --no-default-features --features dynasm`
- `python3 pyre/extra_tests/run.py --dynasm-only --filter stdlib_gc -v`
- `python3 pyre/cpython_tests/run.py --backend dynasm --baseline pyre/cpython_tests/baseline.json --jobs 4 --timeout 120`
- `python3 pyre/check.py --backend dynasm --no-synthetic` (14/14)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Implemented `gc.get_objects(generation)` with support for querying generations (including “all generations”).
  * Added backend-backed object retrieval so reachable objects can be enumerated consistently.
  * Enhanced `gc.collect(generation)` to accept a `generation` argument with proper conversion and range validation.
  * Improved builtin calling to use signature binding in more cases for stricter compatibility.

* **Bug Fixes**
  * `sys.getsizeof` now raises `TypeError` for excessive arguments and honors provided defaults.

* **Tests**
  * Added regression tests for `gc.collect`, `gc.get_objects`, generation validation, and `sys.getsizeof` argument behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->