### PR TITLE
bench: size int_loop above startup and the timer quantum

### DIFF
--- a/pyre/bench/int_loop.py
+++ b/pyre/bench/int_loop.py
@@ -1,7 +1,7 @@
 def main():
     s = 0
     i = 0
-    while i < 200000000:
+    while i < 500000000:
         s = s + i
         i = i + 1
     print(s)


### PR DESCRIPTION
`int_loop` ran 200M iterations, finishing in ~90–200ms user-CPU — on the order of the cranelift backend's empty-program startup and a few Windows 15.6ms scheduler ticks. `check.py` gates on **startup-subtracted** user-CPU, so subtracting a startup estimate of that magnitude left the cranelift exec-time ratio swinging between **0.7x and 3.0x** run to run (a single-run CI gate can then spuriously fail, the same class of measurement fragility fixed for the two synth workloads in the preceding commit).

Raising N to 500M puts each run at ~0.2–0.3s, so startup and the timer quantum drop below the run time; the ratio settles at **dynasm ~1.00x / cranelift ~1.46x**. The printed sum (`124999999750000000`) stays under `i64::MAX`, so it remains a small-int loop with no allocation.

Verified locally: `check.py --backend dynasm,cranelift` int_loop PASS (dynasm 0.9x / cranelift 1.2x on that run), full suite **330/330** on both backends; a 15-trial single-run+median-retry simulation shows the first-run ratio range tightening from 0.71–3.00x (200M) to 1.33–1.82x (500M).

🤖 Generated with [Claude Code](https://claude.com/claude-code)