### PR TITLE
jit: virtualize math.sqrt / float() in hot loops (builtin-call + module-attr folds)

### DIFF
--- a/pyre/bench/synth/float_builtin_hot.py
+++ b/pyre/bench/synth/float_builtin_hot.py
@@ -1,0 +1,19 @@
+# A hot `float(x)` builtin-call loop over int and float arguments.  The walker
+# specializes the call (`try_walker_specialize_float_call`) to an inline
+# conversion — `CastIntToFloat` + `wrapfloat` for an int/bool argument, or the
+# `float(f) is f` identity for an exact float — instead of the opaque
+# `bh_call_fn(float_type, NULL, x)` residual, so the result virtualizes.  A
+# rebound `float` name or a float subclass (which reboxes) falls through to the
+# residual.
+N = 300000
+
+
+def run():
+    total = 0.0
+    for i in range(N):
+        f = float(i)             # int -> CastIntToFloat
+        total += float(f) * 0.5  # exact float -> identity forward, then halve
+    return total
+
+
+print(round(run(), 6))

--- a/pyre/bench/synth/math_sqrt_hot.py
+++ b/pyre/bench/synth/math_sqrt_hot.py
@@ -1,0 +1,21 @@
+# A hot `math.sqrt(x)` loop.  The walker specializes the call
+# (`try_walker_specialize_math_sqrt`) to a domain-guarded pure
+# `CALL_F(sqrt_nonneg_jit)` (ll_math.rs `ll_math_sqrt` -> `sqrt_nonneg`,
+# EF_ELIDABLE_CANNOT_RAISE) plus inline `wrapfloat`, instead of the opaque
+# `bh_call_fn(sqrt_builtin, NULL, x)` residual.  Two guards pin the
+# `ll_math_sqrt` branches — `x >= 0` (the ValueError direction) and
+# `isfinite(x)` — so the result `W_FloatObject` virtualizes.  A negative /
+# non-finite argument or a rebound `math.sqrt` falls through to the residual.
+import math
+
+N = 300000
+
+
+def run():
+    total = 0.0
+    for i in range(N):
+        total += math.sqrt(float(i))
+    return total
+
+
+print(round(run(), 6))

--- a/pyre/pyre-interpreter/src/module/math/interp_math.rs
+++ b/pyre/pyre-interpreter/src/module/math/interp_math.rs
@@ -218,6 +218,26 @@ pm1_edom!(atanh, "expected a number between -1 and 1");
 
 // Exponential / logarithmic
 pm1_edom!(sqrt, "expected a nonnegative input");
+
+/// True iff `callable` is the canonical builtin `math.sqrt` function object.
+/// The JIT walker uses the builtin-code native fn-pointer identity to
+/// distinguish it from a value rebound under the same `math.sqrt` name, so a
+/// monkeypatched `math.sqrt` correctly declines the pure-inline specialization.
+pub fn is_math_sqrt_function(callable: PyObjectRef) -> bool {
+    unsafe {
+        if callable.is_null() || !crate::is_function(callable) {
+            return false;
+        }
+        let code = crate::function_get_code(callable) as PyObjectRef;
+        if code.is_null() || !crate::gateway::is_builtin_code(code) {
+            return false;
+        }
+        std::ptr::fn_addr_eq(
+            crate::gateway::builtin_code_get(code),
+            sqrt as crate::gateway::BuiltinCodeFn,
+        )
+    }
+}
 pm1!(cbrt);
 pm1!(exp);
 pm1!(exp2);

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -2953,6 +2953,27 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
         return Ok((DispatchOutcome::Continue, op.next_pc));
     }
 
+    // `math.sqrt(x)` / `float(x)` on an exact numeric argument: inline the
+    // domain-guarded pure `CALL_F(sqrt_nonneg_jit)` (ll_math.rs) resp. the
+    // `CastIntToFloat` / identity conversion instead of the opaque
+    // `bh_call_fn` residual, so the result `W_FloatObject` virtualizes.  Any
+    // non-matching shape (rebound name, subclass, non-numeric arg, negative /
+    // non-finite sqrt) falls through to the generic residual (SAFE).
+    if ctx.is_authoritative_executor
+        && dst_bank == 'r'
+        && ei.pyre_helper == majit_ir::PyreHelperKind::CallFn
+        && try_walker_specialize_math_sqrt(ctx, code, op, &r_args, dst)?.is_some()
+    {
+        return Ok((DispatchOutcome::Continue, op.next_pc));
+    }
+    if ctx.is_authoritative_executor
+        && dst_bank == 'r'
+        && ei.pyre_helper == majit_ir::PyreHelperKind::CallFn
+        && try_walker_specialize_float_call(ctx, code, op, &r_args, dst)?.is_some()
+    {
+        return Ok((DispatchOutcome::Continue, op.next_pc));
+    }
+
     // B3: a `raise Type(args)` of a canonical
     // builtin exception class arrives as two residuals — a `CallFn` that
     // constructs the exception, and a `RaiseVarargs`

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -3924,6 +3924,216 @@ pub(crate) fn try_walker_specialize_builtin_len<Sym: WalkSym>(
     Ok(Some(()))
 }
 
+/// `math.sqrt(x)` on an exact int/float argument: inline the domain-guarded
+/// pure `CALL_F(sqrt_nonneg_jit)` (ll_math.rs `ll_math_sqrt` → `sqrt_nonneg`,
+/// EF_ELIDABLE_CANNOT_RAISE) instead of the opaque
+/// `bh_call_fn(sqrt_builtin, NULL, x)` residual, so the result `W_FloatObject`
+/// virtualizes.  Two guards pin the branches of `ll_math_sqrt`: `x >= 0` (the
+/// ValueError direction) and `isfinite(x)` (NaN/±inf take the residual).  A
+/// negative argument raises in the concrete pre-exec below and declines to the
+/// generic residual (which records the raise).  Any non-matching shape falls
+/// through to the generic residual (SAFE).
+pub(crate) fn try_walker_specialize_math_sqrt<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    code: &[u8],
+    op: &DecodedOp,
+    r_args: &[OpRef],
+    dst: usize,
+) -> Result<Option<()>, DispatchError> {
+    // Plain `bh_call_fn(callable, PY_NULL, arg)` shape only.
+    if r_args.len() != 3 {
+        return Ok(None);
+    }
+    let arg_concretes = read_ref_var_list_concrete(code, op, 1, ctx);
+    let (
+        ConcreteValue::Ref(concrete_callable),
+        ConcreteValue::Ref(null_or_self),
+        ConcreteValue::Ref(arg_obj),
+    ) = (arg_concretes[0], arg_concretes[1], arg_concretes[2])
+    else {
+        return Ok(None);
+    };
+    // A non-null `null_or_self` is a bound receiver `bh_call_fn_impl` prepends
+    // as arg0 — not a plain `sqrt(x)` call.
+    if concrete_callable.is_null() || !null_or_self.is_null() || arg_obj.is_null() {
+        return Ok(None);
+    }
+    if !pyre_interpreter::module::math::interp_math::is_math_sqrt_function(concrete_callable) {
+        return Ok(None);
+    }
+    // Exact int/bool/float argument only — a numeric subclass keeps the builtin
+    // `ob_type` layout but a Python-visible `w_class`, and the `guard_class`
+    // the coercion emits reads `ob_type`, so it would not catch the subclass.
+    let (is_int, val) = unsafe {
+        if !pyre_object::is_exact_builtin_instance(arg_obj) {
+            return Ok(None);
+        }
+        // `bool` shares `W_IntObject`'s `intval`; it coerces through the int arm
+        // via its own `&BOOL_TYPE` guard inside `walker_coerce_operand_to_float`.
+        if pyre_object::is_int(arg_obj) {
+            (true, pyre_object::w_int_get_value(arg_obj) as f64)
+        } else if pyre_object::is_float(arg_obj) {
+            (false, pyre_object::w_float_get_value(arg_obj))
+        } else {
+            return Ok(None);
+        }
+    };
+    // Cold domain: NaN/±inf and negatives take the opaque residual (the
+    // negative direction also raises in the concrete pre-exec below).
+    if !(val.is_finite() && val >= 0.0) {
+        return Ok(None);
+    }
+    // Authentic boxed result, produced on the plain eval loop exactly as the
+    // skipped residual would.  Declines on any raise (defensive; the cold
+    // domain is already excluded above).
+    let boxed_result = {
+        let _plain_guard = pyre_interpreter::call::force_plain_eval();
+        pyre_interpreter::call::call_function_impl_result(concrete_callable, &[arg_obj])
+    };
+    let Ok(boxed_result) = boxed_result else {
+        return Ok(None);
+    };
+
+    // --- emit the specialized IR (walker-native) ---
+    // Pin the callable identity (the module-attr fold usually makes it a
+    // constant already; guard only when it is not).
+    let callable_op = r_args[0];
+    if !callable_op.is_constant() {
+        let expected = ctx.trace_ctx.const_ref(concrete_callable as i64);
+        ctx.trace_ctx
+            .record_guard(OpCode::GuardValue, &[callable_op, expected], 0);
+        walker_capture_snapshot_for_last_guard(ctx, op.pc)?;
+        ctx.trace_ctx.heap_cache_mut().replace_box(callable_op, expected);
+    }
+    // Coerce the argument to a raw float (int → guard_class + unbox +
+    // CastIntToFloat; float → guard_class + unbox).
+    let x = walker_coerce_operand_to_float(ctx, op.pc, r_args[2], arg_obj, is_int, val, false)?;
+    // `ll_math_sqrt` domain guards: `if x < 0.0` (FloatLt pinned false) and
+    // `if isfinite(x)` (FloatSub(x,x) == 0 pinned true — excludes NaN/±inf).
+    let zero = ctx.trace_ctx.const_float(0.0f64.to_bits() as i64);
+    walker_float_cmp_guard(ctx, op.pc, OpCode::FloatLt, &[x, zero], false)?;
+    let diff = ctx.trace_ctx.record_op(OpCode::FloatSub, &[x, x]);
+    ctx.trace_ctx
+        .set_opref_concrete(diff, majit_ir::Value::Float(0.0));
+    walker_float_cmp_guard(ctx, op.pc, OpCode::FloatEq, &[diff, zero], true)?;
+    // The pure elidable libm sqrt: EF_ELIDABLE_CANNOT_RAISE → CALL_F, no
+    // trailing guard, foldable/hoistable.
+    let raw = ctx.trace_ctx.call_float_typed_with_effect(
+        crate::trace_opcode::sqrt_nonneg_jit as *const (),
+        &[x],
+        &[majit_ir::Type::Float],
+        majit_metainterp::CANNOT_RAISE_NO_HEAP_EFFECT_INFO,
+    );
+    let result_val = unsafe { pyre_object::w_float_get_value(boxed_result) };
+    ctx.trace_ctx
+        .set_opref_concrete(raw, majit_ir::Value::Float(result_val));
+    let boxed = crate::state::wrapfloat(ctx.trace_ctx, raw);
+    ctx.trace_ctx.set_opref_concrete(
+        boxed,
+        majit_ir::Value::Ref(majit_ir::GcRef(boxed_result as usize)),
+    );
+    write_residual_call_result_to_dst(ctx, op.pc, dst, 'r', boxed)?;
+    Ok(Some(()))
+}
+
+/// `float(x)` on an exact int/float argument: inline the conversion
+/// (`W_IntObject.descr_float` → `space.newfloat`, or the identity
+/// `float(f) is f` for an exact float) instead of the opaque
+/// `bh_call_fn(float_type, NULL, x)` residual, so the result virtualizes.  The
+/// callable must be the exact `float` type object; a rebound name or a float
+/// subclass (which reboxes rather than returning the argument) declines.  Any
+/// non-matching shape falls through to the generic residual (SAFE).
+pub(crate) fn try_walker_specialize_float_call<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    code: &[u8],
+    op: &DecodedOp,
+    r_args: &[OpRef],
+    dst: usize,
+) -> Result<Option<()>, DispatchError> {
+    if r_args.len() != 3 {
+        return Ok(None);
+    }
+    let arg_concretes = read_ref_var_list_concrete(code, op, 1, ctx);
+    let (
+        ConcreteValue::Ref(concrete_callable),
+        ConcreteValue::Ref(null_or_self),
+        ConcreteValue::Ref(arg_obj),
+    ) = (arg_concretes[0], arg_concretes[1], arg_concretes[2])
+    else {
+        return Ok(None);
+    };
+    if concrete_callable.is_null() || !null_or_self.is_null() || arg_obj.is_null() {
+        return Ok(None);
+    }
+    // The callable must be the canonical `float` type object.
+    let float_type_obj =
+        pyre_object::pyobject::get_instantiate(&pyre_object::pyobject::FLOAT_TYPE);
+    if !std::ptr::eq(concrete_callable, float_type_obj) {
+        return Ok(None);
+    }
+    let (is_int, val) = unsafe {
+        if !pyre_object::is_exact_builtin_instance(arg_obj) {
+            return Ok(None);
+        }
+        if pyre_object::is_int(arg_obj) {
+            (true, pyre_object::w_int_get_value(arg_obj) as f64)
+        } else if pyre_object::is_float(arg_obj) {
+            (false, pyre_object::w_float_get_value(arg_obj))
+        } else {
+            return Ok(None);
+        }
+    };
+    // Authentic boxed result (float() is side-effect-free on int/float).
+    let boxed_result = {
+        let _plain_guard = pyre_interpreter::call::force_plain_eval();
+        pyre_interpreter::call::call_function_impl_result(concrete_callable, &[arg_obj])
+    };
+    let Ok(boxed_result) = boxed_result else {
+        return Ok(None);
+    };
+
+    // --- emit the specialized IR (walker-native) ---
+    let callable_op = r_args[0];
+    if !callable_op.is_constant() {
+        let expected = ctx.trace_ctx.const_ref(concrete_callable as i64);
+        ctx.trace_ctx
+            .record_guard(OpCode::GuardValue, &[callable_op, expected], 0);
+        walker_capture_snapshot_for_last_guard(ctx, op.pc)?;
+        ctx.trace_ctx.heap_cache_mut().replace_box(callable_op, expected);
+    }
+    let arg_op = r_args[2];
+    if is_int {
+        // int/bool → CastIntToFloat + inline wrapfloat (no residual call).
+        let raw = walker_coerce_operand_to_float(ctx, op.pc, arg_op, arg_obj, true, val, false)?;
+        let boxed = crate::state::wrapfloat(ctx.trace_ctx, raw);
+        ctx.trace_ctx.set_opref_concrete(
+            boxed,
+            majit_ir::Value::Ref(majit_ir::GcRef(boxed_result as usize)),
+        );
+        write_residual_call_result_to_dst(ctx, op.pc, dst, 'r', boxed)?;
+    } else {
+        // exact float → `float(f) is f`: forward the argument unchanged.  Only
+        // sound when the constructor actually returned the same object; a
+        // divergence (should not happen for an exact float) declines.
+        if !std::ptr::eq(boxed_result, arg_obj) {
+            return Ok(None);
+        }
+        let float_type_addr = &pyre_object::pyobject::FLOAT_TYPE as *const _ as i64;
+        if !arg_op.is_constant() && !ctx.trace_ctx.heap_cache().is_class_known(arg_op) {
+            let type_const = ctx.trace_ctx.const_int(float_type_addr);
+            ctx.trace_ctx
+                .record_guard(OpCode::GuardClass, &[arg_op, type_const], 0);
+            walker_capture_snapshot_for_last_guard(ctx, op.pc)?;
+        }
+        ctx.trace_ctx
+            .heap_cache_mut()
+            .class_now_known(arg_op, float_type_addr);
+        walker_guard_exact_w_class(ctx, op.pc, arg_op, float_type_obj)?;
+        write_residual_call_result_to_dst(ctx, op.pc, dst, 'r', arg_op)?;
+    }
+    Ok(Some(()))
+}
+
 /// #171 ORTHODOX descent of the real `w_list_append` charon body (WIP).
 ///
 /// Instead of hand-rolling the int-storage append IR (the fold below), walk

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -1516,6 +1516,53 @@ pub(crate) fn try_walker_specialize_load_attr<Sym: WalkSym>(
         return Ok(Some(()));
     }
 
+    // Module attribute (`math.sqrt`): the receiver is an exact module and the
+    // name is present in its dict.  Fold the module-dict read to a
+    // `QUASIIMMUT_FIELD(dict, slot)` version guard + elidable cell lookup —
+    // celldict.py `_getdictvalue_no_unwrapping_pure` (`@jit.elidable_promote`) —
+    // so a hot `math.sqrt(x)` loop drops its per-iteration LOAD_ATTR may-force
+    // residual and the `math.sqrt` callable becomes a trace constant.  A rebind
+    // of the attribute bumps the module dict `version` and fails the guard.
+    // All resolution below is read-only; a missing / movable / non-canonical
+    // shape falls through to the residual with no IR emitted.  An exact
+    // `module` `w_class` excludes a module subclass with a custom
+    // `__getattribute__`; a module-level PEP 562 `__getattr__` is irrelevant
+    // because the name is present (the dict lookup wins before `__getattr__`).
+    if unsafe { pyre_object::is_module(concrete_obj) }
+        && std::ptr::eq(
+            unsafe { (*concrete_obj).w_class },
+            pyre_object::pyobject::get_instantiate(&pyre_object::pyobject::MODULE_TYPE),
+        )
+    {
+        let w_dict = unsafe { pyre_object::w_module_get_w_dict(concrete_obj) };
+        if !w_dict.is_null() && !majit_gc::can_move(majit_ir::GcRef(w_dict as usize)) {
+            if let Some(slot) = crate::state::module_dict_cell_slot_direct(w_dict, &name) {
+                if let Some(stored) = crate::state::module_dict_cell_value_direct(w_dict, slot) {
+                    if !stored.is_null()
+                        && !majit_gc::can_move(majit_ir::GcRef(stored as usize))
+                    {
+                        // Pin the receiver to THIS module so the baked dict
+                        // address is correct: a constant receiver is already
+                        // pinned; a non-constant one gets a `guard_value`.
+                        if !obj.is_constant() {
+                            let expected = ctx.trace_ctx.const_ref(concrete_obj as i64);
+                            ctx.trace_ctx
+                                .record_guard(OpCode::GuardValue, &[obj, expected], 0);
+                            walker_capture_snapshot_for_last_guard(ctx, op_pc)?;
+                            ctx.trace_ctx.heap_cache_mut().replace_box(obj, expected);
+                        }
+                        // `guard_frame_globals=false`: the receiver pin above
+                        // (not a frame-globals-identity guard) proves the dict.
+                        emit_namespace_cell_fold(
+                            ctx, op_pc, dst, dst_bank, w_dict, slot, stored, false,
+                        )?;
+                        return Ok(Some(()));
+                    }
+                }
+            }
+        }
+    }
+
     let Some((w_type, version_tag, map, storageindex, listindex, unbox_type)) = (unsafe {
         pyre_interpreter::objspace::std::mapdict::load_attr_unboxed_fast_path(concrete_obj, &name)
     }) else {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -1538,9 +1538,7 @@ pub(crate) fn try_walker_specialize_load_attr<Sym: WalkSym>(
         if !w_dict.is_null() && !majit_gc::can_move(majit_ir::GcRef(w_dict as usize)) {
             if let Some(slot) = crate::state::module_dict_cell_slot_direct(w_dict, &name) {
                 if let Some(stored) = crate::state::module_dict_cell_value_direct(w_dict, slot) {
-                    if !stored.is_null()
-                        && !majit_gc::can_move(majit_ir::GcRef(stored as usize))
-                    {
+                    if !stored.is_null() && !majit_gc::can_move(majit_ir::GcRef(stored as usize)) {
                         // Pin the receiver to THIS module so the baked dict
                         // address is correct: a constant receiver is already
                         // pinned; a non-constant one gets a `guard_value`.
@@ -4050,7 +4048,9 @@ pub(crate) fn try_walker_specialize_math_sqrt<Sym: WalkSym>(
         ctx.trace_ctx
             .record_guard(OpCode::GuardValue, &[callable_op, expected], 0);
         walker_capture_snapshot_for_last_guard(ctx, op.pc)?;
-        ctx.trace_ctx.heap_cache_mut().replace_box(callable_op, expected);
+        ctx.trace_ctx
+            .heap_cache_mut()
+            .replace_box(callable_op, expected);
     }
     // Coerce the argument to a raw float (int → guard_class + unbox +
     // CastIntToFloat; float → guard_class + unbox).
@@ -4113,8 +4113,7 @@ pub(crate) fn try_walker_specialize_float_call<Sym: WalkSym>(
         return Ok(None);
     }
     // The callable must be the canonical `float` type object.
-    let float_type_obj =
-        pyre_object::pyobject::get_instantiate(&pyre_object::pyobject::FLOAT_TYPE);
+    let float_type_obj = pyre_object::pyobject::get_instantiate(&pyre_object::pyobject::FLOAT_TYPE);
     if !std::ptr::eq(concrete_callable, float_type_obj) {
         return Ok(None);
     }
@@ -4146,7 +4145,9 @@ pub(crate) fn try_walker_specialize_float_call<Sym: WalkSym>(
         ctx.trace_ctx
             .record_guard(OpCode::GuardValue, &[callable_op, expected], 0);
         walker_capture_snapshot_for_last_guard(ctx, op.pc)?;
-        ctx.trace_ctx.heap_cache_mut().replace_box(callable_op, expected);
+        ctx.trace_ctx
+            .heap_cache_mut()
+            .replace_box(callable_op, expected);
     }
     let arg_op = r_args[2];
     if is_int {

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -89,6 +89,18 @@ pub(crate) extern "C" fn ccall_pow(x: f64, y: f64) -> f64 {
     x.powf(y)
 }
 
+/// `sqrt_nonneg` (ll_math.rs:91) — `@jit.elidable`, `oopspec
+/// "math.sqrt_nonneg(x)"` (ll_math.py:72-75).  The trace records this as a
+/// pure `CALL_F(sqrt_nonneg_jit, x)` (EF_ELIDABLE_CANNOT_RAISE, no trailing
+/// guard) behind the domain-pinning guards emitted by
+/// `try_walker_specialize_math_sqrt`: `x >= 0` (excludes the ValueError
+/// direction) and `isfinite(x)` (excludes NaN/±inf).  Reached only with a
+/// finite, non-negative operand, so `x.sqrt()` cannot raise and matches
+/// `ll_math_sqrt`'s finite-nonneg branch bit-for-bit.
+pub(crate) extern "C" fn sqrt_nonneg_jit(x: f64) -> f64 {
+    x.sqrt()
+}
+
 pub(crate) extern "C" fn float_pow_jit(x: f64, y: f64) -> f64 {
     match pyre_interpreter::float_pow_raw(x, y) {
         Ok(z) => z,

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -3251,36 +3251,24 @@ fn restore_canraise_exit_order(block: &super::flow::BlockRef) {
     let Some(first_normal) = first_normal else {
         return;
     };
+    if first_normal == 0 {
+        return;
+    }
 
+    // `flatten.rs` lowers a canraise block's `exits[0]` as the normal edge and
+    // `exits[1:]` as seeded exception edges (`flatten.py:220-233 insert_exits`).
+    // Pyre's PC-sequential walker can emit the normal edge past index 0, so
+    // move it back to the front; the exception edges keep their relative order.
+    // A non-seeded exit left in the `exits[1:]` position is a graph-construction
+    // bug that fails loud in `make_exception_link`, not something to drop here.
     let mut ordered = Vec::with_capacity(block_mut.exits.len());
     ordered.push(block_mut.exits[first_normal].clone());
     for (index, link) in block_mut.exits.iter().enumerate() {
-        if index == first_normal {
-            continue;
-        }
-        let is_exception_edge = {
-            let link = link.borrow();
-            link.last_exception.is_some() || link.last_exc_value.is_some()
-        };
-        if is_exception_edge {
+        if index != first_normal {
             ordered.push(link.clone());
         }
     }
-
-    // Structural adaptation for pyre's PC-sequential walker:
-    // RPython `flowcontext.py:130-156 guessexception` closes a
-    // canraise block with exactly one normal edge followed by
-    // exception edges.  Pyre may transiently append an extra normal
-    // fallthrough while forcing the next-PC boundary after
-    // `emit_catch_exception!`.  That duplicate has no
-    // `Link.extravars`, so `flatten.py:223-238` would treat it as an
-    // exception link and trip `make_exception_link`'s
-    // `last_exception` assertion.  Keep the upstream shape at the
-    // graph boundary: first normal edge, then only seeded exception
-    // edges.
-    if ordered.len() >= 2 {
-        block_mut.exits = ordered;
-    }
+    block_mut.exits = ordered;
 }
 
 // `PyJitCode` and `PyJitCodeMetadata` live in `pyre_jit_trace::pyjitcode`


### PR DESCRIPTION
Builtin CALLs in hot loops (`math.sqrt(x)`, `float(x)`) compiled to opaque `CallMayForce` residuals that forced the virtualizable and materialized a `W_FloatObject` every iteration, blocking float-box virtualization. (Float boxes themselves already virtualize — the *call* was the cost; arithmetic like `j*1.0` has a walker-native specialization, these builtins did not.)

## Commits

- **`aa008dac4b` — specialize `math.sqrt` / `float()` builtin calls.** Two walker-native specializers in `dispatch_residual_call_iRd_kind`:
  - `try_walker_specialize_math_sqrt`: behind `x >= 0` and `isfinite(x)` guards (the `ll_math_sqrt` branches), emit a pure `CALL_F(sqrt_nonneg_jit)` (EF_ELIDABLE_CANNOT_RAISE) + inline `wrapfloat`. Orthodox: `ll_math.rs sqrt_nonneg` `@jit.elidable` + oopspec.
  - `try_walker_specialize_float_call`: for the exact `float` type callable, `CastIntToFloat` + `wrapfloat` for int/bool, or the `float(f) is f` identity for an exact float.
  - Callee identity via the builtin-code native fn pointer / the `float` type object. Both take the authentic boxed result from a `force_plain_eval` pre-exec and decline on any raise/subclass/non-numeric/rebound-name/non-finite (fall through to the residual). Adds `math_sqrt_hot` / `float_builtin_hot` synth benches.

- **`8060e4b422` — fold module attribute reads to a version-guarded cell lookup.** Extends `try_walker_specialize_load_attr` with a module-receiver arm: an exact `module` whose attribute is present in its dict folds to `QUASIIMMUT_FIELD(dict, slot)` + the elidable cell lookup (celldict `_getdictvalue_no_unwrapping_pure`, `@jit.elidable_promote`). Removes the per-iteration `math.sqrt` LOAD_ATTR residual; applies to any `module.attr` in a hot loop. Rebind-safe: an in-place `write_cell` is caught by the consumer's `guard_value` (the cell is read live), a new-cell rebind by the version guard.

- **`2ef30add0b` — drop the dead extra-edge filter from `restore_canraise_exit_order`.** Small pre-existing JIT cleanup already on this branch (retires a dead filter, keeps the load-bearing reorder). Included here as it was the branch base; can be split out if preferred.

## Results (dynasm, aarch64, min-of-3 user-time)

| bench | before | after |
|---|---|---|
| `math.sqrt(x)` hot loop | 0.74s | **0.04s** (~18.5x) |
| `float(j)` hot loop | 4.74s | **0.04s** |

Both reach pure-float-loop parity with `call_may_force = 0` — fully virtualized.

## Verification

- `pyre/check.py` **green on all backends: dynasm 331/331, cranelift 331/331, wasm 328/328**.
- Correctness bit-exact `jit == no-jit`, including: negative `sqrt` raises `ValueError`, `float`/`int` subclasses rebox (not identity), bool/int args, and a **mid-loop `math.sqrt` rebind deopt** test (the QUASIIMMUT + guard_value composition).
- module/globals parity tests and math/sys attribute stress: `jit == no-jit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)