### PR TITLE
jit: trace the PEP 634 match opcodes as residual calls; majit: six O(n) per-op scans made O(1)

### DIFF
--- a/majit/majit-backend-dynasm/src/aarch64/assembler.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/assembler.rs
@@ -3853,9 +3853,17 @@ impl<'a> AssemblerARM64<'a> {
         let fail_label = self.mc.new_dynamic_label();
         if self.invalidated_flag_addr != 0 {
             self.emit_mov_imm64(16, self.invalidated_flag_addr as i64);
+            // `CBNZ` reaches +-32KB, but this guard sits at the head of the
+            // peeled loop body while its recovery stub is emitted after the
+            // whole trace, so a long body puts the stub out of range and
+            // dynasm rejects the relocation at commit. Branch over an
+            // unconditional `B` (+-128MB) instead, the standard veneer.
+            let continue_label = self.mc.new_dynamic_label();
             dynasm!(self.mc ; .arch aarch64
                 ; ldrb w17, [x16]
-                ; cbnz w17, =>fail_label
+                ; cbz w17, =>continue_label
+                ; b =>fail_label
+                ; =>continue_label
             );
         }
         self.append_guard_token_with_faillocs(op, op_index, fail_index, fail_label, faillocs);

--- a/majit/majit-backend-dynasm/src/aarch64/assembler.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/assembler.rs
@@ -343,14 +343,18 @@ pub struct AssemblerARM64<'a> {
     /// references no reference constants. Set before `assemble_loop` /
     /// `assemble_bridge` via [`set_gc_table_base`](Self::set_gc_table_base).
     gc_table_base: usize,
-    /// Address of the owning `JitCellToken.invalidated` `AtomicBool`.
-    /// `GUARD_NOT_INVALIDATED` bakes it as a 64-bit immediate and loads
-    /// the byte at runtime, branching to its recovery stub when set.
-    /// PyPy instead emits no runtime code and patches the guard site
-    /// (`invalidate_positions`) when the quasi-immutable field mutates;
-    /// pyre reads the flag live so re-entry through any path (warm entry,
-    /// CALL_ASSEMBLER, resume) observes the invalidation. 0 leaves the
-    /// guard as a no-op (bridges / tests with no owning token).
+    /// Address of the owning `JitCellToken.invalidated` `AtomicBool`
+    /// (`history.py:443`). `GUARD_NOT_INVALIDATED` bakes it as a 64-bit
+    /// immediate and loads the byte at runtime, branching to its recovery
+    /// stub when set — the shape `llgraph/runner.py:375` uses, where
+    /// `invalidate_loop` sets a per-trace `invalid` flag that the guard
+    /// reads live at execution. The machine backends instead emit no
+    /// runtime code and patch the recorded guard sites
+    /// (`clt.invalidate_positions`) on invalidation; reading the flag live
+    /// makes re-entry through any path (warm entry, CALL_ASSEMBLER,
+    /// resume) observe it without a second code-patching channel, and is
+    /// the only formulation cranelift and wasm can express at all. 0
+    /// leaves the guard a no-op (bridges / tests with no owning token).
     invalidated_flag_addr: usize,
 }
 

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -2838,7 +2838,11 @@ impl Backend for DynasmBackend {
     }
 
     fn invalidate_loop(&self, token: &JitCellToken) {
-        token.invalidated.store(true, Ordering::Release);
+        // `model.py:145` activates the guards in the loop AND in its attached
+        // bridges. Each bridge's GUARD_NOT_INVALIDATED reads its own
+        // generation flag, so storing to the root flag alone would leave every
+        // bridge guard a no-op; `invalidate` walks both.
+        token.invalidate();
     }
 
     // assembler.py:1138 redirect_call_assembler

--- a/majit/majit-backend-dynasm/src/x86/assembler.rs
+++ b/majit/majit-backend-dynasm/src/x86/assembler.rs
@@ -890,23 +890,24 @@ pub struct Assembler386<'a> {
     /// references no reference constants. Set before `assemble_loop` /
     /// `assemble_bridge` via [`set_gc_table_base`](Self::set_gc_table_base).
     gc_table_base: usize,
-    /// Address of the owning `JitCellToken.invalidated` `AtomicBool`.
-    /// `GUARD_NOT_INVALIDATED` bakes it as a 64-bit immediate and loads
-    /// the byte at runtime, branching to its recovery stub when set.
-    /// PyPy instead emits no runtime code and patches the guard site
-    /// (`invalidate_positions`) when the quasi-immutable field mutates;
-    /// pyre reads the flag live so re-entry through any path (warm entry,
-    /// CALL_ASSEMBLER, resume) observes the invalidation. 0 leaves the
-    /// guard as a no-op (bridges / tests with no owning token).
+    /// Address of the owning `JitCellToken.invalidated` `AtomicBool`
+    /// (`history.py:443`). `GUARD_NOT_INVALIDATED` bakes it as a 64-bit
+    /// immediate and loads the byte at runtime, branching to its recovery
+    /// stub when set — the shape `llgraph/runner.py:375` uses, where
+    /// `invalidate_loop` sets a per-trace `invalid` flag that the guard
+    /// reads live at execution. The machine backends instead emit no
+    /// runtime code and patch the recorded guard sites
+    /// (`clt.invalidate_positions`) on invalidation; reading the flag live
+    /// makes re-entry through any path (warm entry, CALL_ASSEMBLER,
+    /// resume) observe it without a second code-patching channel, and is
+    /// the only formulation cranelift and wasm can express at all. 0
+    /// leaves the guard a no-op (bridges / tests with no owning token).
     invalidated_flag_addr: usize,
 }
 
 /// assembler.py GuardToken — represents a pending guard needing
 /// a recovery stub to be written after the main loop body.
 struct GuardToken {
-    /// Offset in machine code where the guard's conditional jump
-    /// was emitted. We'll patch this to point to the recovery stub.
-    jump_offset: AssemblyOffset,
     /// Dynamic label that the guard's Jcc jumps to — bound in
     /// write_pending_failure_recoveries to the recovery stub.
     fail_label: DynamicLabel,
@@ -5323,7 +5324,6 @@ impl<'a> Assembler386<'a> {
             .take()
             .unwrap_or_else(|| majit_ir::FailDescrCell::wrap(descr.clone()));
         self.pending_guard_tokens.push(GuardToken {
-            jump_offset: self.mc.offset(),
             fail_label,
             fail_descr: cell.clone(),
             fail_args: op

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -2889,10 +2889,15 @@ impl majit_backend::Backend for WasmBackend {
     }
 
     fn invalidate_loop(&self, token: &JitCellToken) {
-        // x86/assembler.py:641-648 invalidate_loop parity. The wasm module is
-        // immutable, so GUARD_NOT_INVALIDATED loads this live flag instead of
-        // having its instruction bytes patched in place.
-        token.invalidated.store(true, Ordering::Release);
+        // A validated wasm module's code is immutable, so
+        // GUARD_NOT_INVALIDATED loads a live flag instead of having its
+        // instruction bytes patched in place — the same shape the llgraph
+        // backend uses (`llgraph/runner.py:375` sets `trace.invalid` across
+        // `_llgraph_alltraces`). `model.py:145` covers the loop AND its
+        // attached bridges, each of which reads its own generation flag, so
+        // this must go through `invalidate` rather than store to the root
+        // flag alone.
+        token.invalidate();
     }
 
     fn redirect_call_assembler(

--- a/majit/majit-backend/src/lib.rs
+++ b/majit/majit-backend/src/lib.rs
@@ -893,8 +893,6 @@ pub struct CompiledLoopToken {
     pub loop_token_wref: parking_lot::Mutex<std::sync::Weak<JitCellToken>>,
     /// `model.py:300` `self.bridges_count = 0`.
     pub bridges_count: parking_lot::Mutex<usize>,
-    /// `model.py:301` `self.invalidate_positions = []`.
-    pub invalidate_positions: parking_lot::Mutex<Vec<usize>>,
     /// `model.py:302-304` `self.looptokens_redirected_to = []` — weak
     /// references to `CompiledLoopToken` instances previously redirected
     /// to this one via `redirect_call_assembler`.
@@ -982,7 +980,6 @@ impl CompiledLoopToken {
             number,
             loop_token_wref: parking_lot::Mutex::new(std::sync::Weak::new()),
             bridges_count: parking_lot::Mutex::new(0),
-            invalidate_positions: parking_lot::Mutex::new(Vec::new()),
             looptokens_redirected_to: parking_lot::Mutex::new(Vec::new()),
             asmmemmgr_blocks: parking_lot::Mutex::new(Vec::new()),
             asmmemmgr_gcreftracers: parking_lot::Mutex::new(Vec::new()),
@@ -1202,7 +1199,7 @@ pub struct JitCellToken {
     /// Carries per-compilation metadata: `asmmemmgr_blocks` (owned bridge
     /// memory blocks — `model.py:293`), `asmmemmgr_gcreftracers`
     /// (`model.py:294`), `frame_info` (JIT frame layout —
-    /// `x86/assembler.py:514`), `bridges_count`, `invalidate_positions`,
+    /// `x86/assembler.py:514`), `bridges_count`,
     /// `looptokens_redirected_to`. Populated eagerly by `JitCellToken::new`
     /// so backends can update fields through `&JitCellToken`.
     ///

--- a/majit/majit-gc/src/rewrite.rs
+++ b/majit/majit-gc/src/rewrite.rs
@@ -327,6 +327,13 @@ struct RewriteState {
     /// live-track its producer instead of fabricating position-only
     /// boxes (#9 operand-union grind).
     out: Vec<majit_ir::OpRc>,
+    /// `pos -> emitted op` index over [`Self::out`], maintained by the two
+    /// `emit*` methods.  `emit_pending_zeros` resolves a delayed
+    /// zero-setfield's malloc base by position, and it is flushed at every
+    /// guard (rewrite.py:376-377), so scanning `out` for the producer made
+    /// the GC rewrite quadratic in trace length.  Void results share
+    /// `OpRef::NONE` and are not indexed.
+    out_by_pos: IndexMap<OpRef, majit_ir::OpRc>,
     /// Next position index for emitted result ops that do not have an
     /// explicit source position to preserve.
     next_pos: u32,
@@ -449,6 +456,7 @@ impl RewriteState {
     fn new(hint: usize, next_pos: u32) -> Self {
         RewriteState {
             out: Vec::with_capacity(hint + hint / 4),
+            out_by_pos: IndexMap::default(),
             next_pos,
             constants: ConstMap::new(),
             pending_malloc_idx: None,
@@ -604,6 +612,7 @@ impl RewriteState {
         if pos.is_none() {
             Operand::none()
         } else {
+            self.out_by_pos.insert(pos, rc.clone());
             Operand::from_bound_op(&rc)
         }
     }
@@ -626,6 +635,9 @@ impl RewriteState {
         op.pos.set(pos);
         let rc = std::rc::Rc::new(op);
         self.out.push(rc.clone());
+        if !pos.is_none() {
+            self.out_by_pos.insert(pos, rc.clone());
+        }
         Operand::from_bound_op(&rc)
     }
 
@@ -883,9 +895,8 @@ impl RewriteState {
             // panic, so resolve the producer here. `to_opref()` is unchanged
             // either way.
             let ptr_box = self
-                .out
-                .iter()
-                .find(|o| o.pos.get() == ptr)
+                .out_by_pos
+                .get(&ptr)
                 .map(Operand::from_bound_op)
                 .unwrap_or_else(|| Operand::from_opref(ptr));
             for ofs in entries.iter().copied() {

--- a/majit/majit-metainterp/src/opencoder.rs
+++ b/majit/majit-metainterp/src/opencoder.rs
@@ -1681,6 +1681,10 @@ impl Trace {
             _index: self._index,
             snapshot_data_len: self._snapshot_data.len(),
             snapshot_array_data_len: self._snapshot_array_data.len(),
+            // The byte-stream recorder keeps no guard counter; `None` makes
+            // `recorder::Trace::cut` recompute if such a position ever
+            // reaches it.
+            guard_count: None,
         }
     }
 

--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -24,6 +24,15 @@ fn sort_descr_entries_untranslated<T>(entries: &mut [(u32, DescrRef, T)]) {
     }
 }
 
+/// [`sort_descr_entries_untranslated`] for a caller that permutes an index
+/// list instead of the entries themselves.
+#[inline]
+fn sort_descr_entry_indices_untranslated<T>(entries: &[(u32, DescrRef, T)], order: &mut [usize]) {
+    if use_untranslated_heap_ordering() {
+        order.sort_by(|&a, &b| entries[b].1.repr().cmp(&entries[a].1.repr()));
+    }
+}
+
 #[inline]
 fn sort_descr_item_refs_untranslated<T>(entries: &mut [(&DescrRef, T)]) {
     if use_untranslated_heap_ordering() {
@@ -1434,17 +1443,19 @@ impl OptHeap {
     /// PtrInfo cleanup through `invalidate_with_ctx` so the per-pass
     /// "single source of truth" stays in sync after a clean.
     fn clean_caches(&mut self, ctx: &mut OptContext) {
-        let mut field_entries: Vec<_> = self
-            .cached_fields
-            .iter_mut()
-            .map(|(field_idx, descr, cf)| (*field_idx, descr.clone(), cf))
-            .collect();
-        sort_descr_entries_untranslated(&mut field_entries);
-        for (_field_idx, descr, cf) in field_entries {
+        // heap.py:380-381 `if not we_are_translated(): items.sort(key=str,
+        // reverse=True)` — the ordering exists only untranslated, so walk the
+        // cache in place through a permuted index list. Materializing the
+        // entries instead cost a `DescrRef` clone per cached field on every
+        // residual call, which is where clean_caches runs.
+        let mut order: Vec<usize> = (0..self.cached_fields.len()).collect();
+        sort_descr_entry_indices_untranslated(&self.cached_fields, &mut order);
+        for i in order {
+            let (_field_idx, descr, cf) = &mut self.cached_fields[i];
             // heap.py:384: `cf.invalidate(descr)` — purity self-gate
             // inside the method (heap.py:189-194). `_field_idx` unused
             // post-purity-lift; index now recomputed from `descr`.
-            cf.invalidate(&descr, ctx);
+            cf.invalidate(descr, ctx);
         }
         // heap.py:386-389:
         //   for descr, submap in self.cached_arrayitems.iteritems():

--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -1315,18 +1315,21 @@ impl OptHeap {
         // clear `_lazy_set`), so every later guard re-collects it into
         // pendingfields and a later call/flush boundary still emits it.
         // Only force_lazy_set — the non-virtual arm — clears it.
-        let mut ordered_entries: Vec<_> = self
+        // heap.py:611-612 `op = cf._lazy_set; if op is None: continue` — skip
+        // before touching the entry, so a guard costs one `Option` probe per
+        // cached field instead of a `DescrRef` clone per cached field. Filtering
+        // ahead of the sort is equivalent: the sort is stable and filtering
+        // preserves relative order.
+        let mut field_entries: Vec<(u32, DescrRef, Op)> = self
             .cached_fields
-            .iter_mut()
-            .map(|(field_idx, descr, cf)| (*field_idx, descr.clone(), cf))
-            .collect();
-        sort_descr_entries_untranslated(&mut ordered_entries);
-        let field_entries: Vec<(u32, DescrRef, Op)> = ordered_entries
-            .into_iter()
+            .iter()
             .filter_map(|(field_idx, descr, cf)| {
-                cf.lazy_set.clone().map(|op| (field_idx, descr, op))
+                cf.lazy_set
+                    .clone()
+                    .map(|op| (*field_idx, descr.clone(), op))
             })
             .collect();
+        sort_descr_entries_untranslated(&mut field_entries);
         for (field_idx, descr, mut op) in field_entries {
             // heap.py:617-618: val = op.getarg(1); if is_virtual(val)
             let is_virtual = ctx.is_virtual(&op.arg(1).get_box_replacement(false));
@@ -1783,9 +1786,13 @@ impl OptHeap {
         }
         let escaped_owners: &[OpRef] = &flush_owners;
 
+        // Same `_lazy_set is None` skip as force_lazy_sets_for_guard: only the
+        // entries that carry a lazy set can reach the arm below, so nothing
+        // else needs its `DescrRef` cloned.
         let mut field_entries: Vec<_> = self
             .cached_fields
             .iter_mut()
+            .filter(|(_field_idx, _descr, cf)| cf.lazy_set.is_some())
             .map(|(field_idx, descr, cf)| (*field_idx, descr.clone(), cf))
             .collect();
         sort_descr_entries_untranslated(&mut field_entries);

--- a/majit/majit-metainterp/src/optimizeopt/intbounds.rs
+++ b/majit/majit-metainterp/src/optimizeopt/intbounds.rs
@@ -854,25 +854,25 @@ impl OptIntBounds {
     /// `new_operations` / `emitted_operations` to operand identity, at which
     /// point this positional scan collapses to the `_emittedoperations`
     /// membership test on the box.
-    fn find_producing_op<'a>(&self, box_: &Operand, ctx: &'a OptContext) -> Option<&'a Op> {
+    ///
+    /// The lookup goes through `new_operations_index`, the O(1) mirror of
+    /// `new_operations` keyed by result position. `op in
+    /// self._emittedoperations` (optimizer.py:375) is a dict membership test,
+    /// so a hash lookup is the shape upstream has; scanning instead put an
+    /// O(len(new_operations)) walk on `propagate_bounds_backward`, which runs
+    /// once per emitted int op and recurses, making bound propagation
+    /// quadratic in trace length. Insert-overwrites gives the index
+    /// last-occurrence semantics, matching the `rfind` it replaces (a later
+    /// replacement at the same position wins).
+    fn find_producing_op(&self, box_: &Operand, ctx: &OptContext) -> Option<majit_ir::OpRc> {
         // optimizer.py:372 `isinstance(op, AbstractResOp)` — a `Const` is not
         // an AbstractResOp, so `as_operation` returns None for it. A constant
-        // operand has no producing op; bail before `raw()`, which panics on
-        // the inline-`Const` OpRef variants.
+        // operand has no producing op; bail before `to_opref()`, whose
+        // inline-`Const` variants have no producer.
         if box_.is_constant() {
             return None;
         }
-        let cond_ref = box_.to_opref();
-        // First try direct index (when OpRef matches new_operations index)
-        let idx = cond_ref.raw() as usize;
-        if idx < ctx.new_operations.len() && ctx.new_operations[idx].pos.get() == cond_ref {
-            return Some(ctx.new_operations[idx].as_ref());
-        }
-        // Otherwise search by pos field
-        ctx.new_operations
-            .iter()
-            .rfind(|op| op.pos.get() == cond_ref)
-            .map(|rc| rc.as_ref())
+        ctx.producer_in_new_operations(box_.to_opref())
     }
 
     // ── Bound narrowing helpers ──
@@ -1063,9 +1063,9 @@ impl OptIntBounds {
     /// to tighten its other arguments.
     /// Reads the operand bound box-native through `getintbound_arg`
     /// (→ `resolve_box_box`); the `as_operation` producer lookup
-    /// (`find_producing_op`) now takes the box directly, keeping only an
-    /// internal flat-OpRef positional scan over `new_operations` (the
-    /// legitimate `_emittedoperations` residual, #188-gated). The const-fold
+    /// (`find_producing_op`) now takes the box directly, resolving it through
+    /// the `new_operations` position index (the legitimate
+    /// `_emittedoperations` residual, #188-gated). The const-fold
     /// (`make_constant_int_ref`) stays OpRef-keyed pending #186.
     fn propagate_bounds_backward(&mut self, box_: &Operand, ctx: &mut OptContext) {
         let b = self.getintbound_arg(box_, ctx);
@@ -1073,7 +1073,7 @@ impl OptIntBounds {
             self.make_constant_int_ref(box_.to_opref(), b.get_constant_int(), ctx);
         }
         if let Some(producing_op) = self.find_producing_op(box_, ctx) {
-            let producing_op = producing_op.clone();
+            let producing_op = (*producing_op).clone();
             self.propagate_bounds_backward_op(&producing_op, ctx);
         }
     }

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -2653,9 +2653,25 @@ impl OptContext {
         // `resop_refs` is keyed by the full type-tagged `OpRef`; a raw `u32`
         // can host more than one entry (typed vs untyped). Any host at this
         // raw carrying `Forwarded::Const` claims the position.
-        let resop_const = self.resop_refs.values().any(|op| {
-            op.pos.get().raw() == raw && matches!(*op.forwarded.borrow(), Forwarded::Const(_))
-        });
+        //
+        // Every key is the value's own `op.pos` (`install_canonical_producer`,
+        // `materialize_operand_at`), so the hosts at `raw` are exactly the
+        // OpRef variants that carry it. Probing those keys keeps this O(1):
+        // scanning `resop_refs` made `allocate_next_pos_raw` linear in the
+        // trace, and it runs once per `reserve_pos_typed`, so the whole
+        // optimizer emit path was quadratic in trace length.
+        let resop_const = [
+            OpRef::IntOp(raw),
+            OpRef::FloatOp(raw),
+            OpRef::RefOp(raw),
+            OpRef::VoidOp(raw),
+            OpRef::InputArgInt(raw),
+            OpRef::InputArgFloat(raw),
+            OpRef::InputArgRef(raw),
+        ]
+        .iter()
+        .filter_map(|key| self.resop_refs.get(key))
+        .any(|op| matches!(*op.forwarded.borrow(), Forwarded::Const(_)));
         let inputarg_const = self
             .inputarg_refs
             .get(idx)

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -1890,6 +1890,27 @@ impl OptContext {
         self.new_operations.push(op);
     }
 
+    /// Overwrite an already-emitted op in place (the guard-strengthening
+    /// replacements of `optimizer.py:716-718` / `rewrite.py:343`) and mirror
+    /// the new op into `new_operations_index`, so the index keeps agreeing
+    /// with `new_operations` for the rest of the forward phase.
+    pub(crate) fn replace_new_operation(&mut self, idx: usize, op: majit_ir::OpRc) {
+        self.new_operations_index.insert(op.pos.get(), op.clone());
+        self.new_operations[idx] = op;
+    }
+
+    /// The producer of `opref` among the ops emitted so far by this optimizer
+    /// run, or `None` when nothing at that position has been emitted.
+    /// Unlike [`Self::find_producer_op`] this consults only `new_operations`,
+    /// which is what optimizer.py:369-377 `as_operation` tests
+    /// (`op in self._emittedoperations`).
+    pub(crate) fn producer_in_new_operations(&self, opref: OpRef) -> Option<majit_ir::OpRc> {
+        if opref.is_none() || opref.is_constant() {
+            return None;
+        }
+        self.new_operations_index.get(&opref).cloned()
+    }
+
     /// Rebuild `new_operations_index` from the current `new_operations`.
     /// Called after the rare structural mutations (tail truncate, jump
     /// reorder) that the incremental `push_new_operation` maintenance cannot

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -4698,7 +4698,7 @@ impl Optimizer {
                              replacement guard has no descr",
                         );
                         crate::compile::copy_all_attributes_from(&new_descr, &old_descr);
-                        ctx.new_operations[target_pos] = std::rc::Rc::new(op.clone());
+                        ctx.replace_new_operation(target_pos, std::rc::Rc::new(op.clone()));
                         ctx.in_final_emission = saved_in_final_emission;
                         return Ok(());
                     }

--- a/majit/majit-metainterp/src/optimizeopt/rewrite.rs
+++ b/majit/majit-metainterp/src/optimizeopt/rewrite.rs
@@ -843,7 +843,7 @@ impl OptRewrite {
                             Some(Some(new_descr)),
                         );
                         // rewrite.py:343: self.optimizer.replace_guard(op, info)
-                        ctx.new_operations[old_idx] = std::rc::Rc::new(replacement);
+                        ctx.replace_new_operation(old_idx, std::rc::Rc::new(replacement));
                         // rewrite.py:345-346: info.reset_last_guard_pos()
                         if let Some(b) = obj_box.as_ref() {
                             ctx.with_ptr_info_mut(b, |info_mut| info_mut.reset_last_guard_pos());
@@ -943,7 +943,7 @@ impl OptRewrite {
                         Some(&[old_guard.arg(0), op.arg(1)]),
                         Some(Some(new_descr)),
                     );
-                    ctx.new_operations[old_idx] = std::rc::Rc::new(combined);
+                    ctx.replace_new_operation(old_idx, std::rc::Rc::new(combined));
                     // rewrite.py:430-436 postprocess_GUARD_CLASS parity
                     // (invoked inline here because the replacement path
                     // rewrites `new_operations[old_idx]` directly instead

--- a/majit/majit-metainterp/src/recorder.rs
+++ b/majit/majit-metainterp/src/recorder.rs
@@ -40,6 +40,12 @@ pub struct TracePosition {
     pub snapshot_data_len: usize,
     /// opencoder.py:567 `len(self._snapshot_array_data)`.
     pub snapshot_array_data_len: usize,
+    /// pyre-only: `Trace::guard_count` at the cut point, so
+    /// [`Trace::cut`] restores it without rescanning `ops`.  RPython keeps
+    /// no guard counter, so this has no slot in opencoder.py's 5-tuple;
+    /// `None` marks a position minted by a producer that does not track
+    /// one (`TraceRecordBuffer::cut_point`) and makes `cut` recompute.
+    pub guard_count: Option<usize>,
 }
 
 /// opencoder.py Snapshot parity: per-guard snapshot of the interpreter
@@ -125,6 +131,14 @@ pub struct Trace {
     inputargs: Vec<InputArgRc>,
     /// Next OpRef index to assign.
     op_count: u32,
+    /// Running count of recorded guards, kept in sync by the two
+    /// `record_guard*` entry points (the only producers — `record_op` /
+    /// `record_op_with_descr` assert the opcode is not a guard) and
+    /// restored by [`Self::cut`] from `TracePosition::guard_count`.
+    /// `num_guards` is consulted once per traced vable op
+    /// (`walker_capture_inline_nonstandard_vable_guard`), so counting by
+    /// scanning `ops` made tracing quadratic in trace length.
+    guard_count: usize,
     /// opencoder.py parity: count of box-yielding positions
     /// (inputargs + non-void ops).
     box_count: u32,
@@ -141,6 +155,7 @@ impl Trace {
             ops: Vec::with_capacity(256),
             inputargs: Vec::new(),
             op_count: 0,
+            guard_count: 0,
             box_count: 0,
         }
     }
@@ -313,6 +328,7 @@ impl Trace {
     ) -> OpRef {
         assert!(opcode.is_guard(), "opcode {:?} is not a guard", opcode);
         let opref = OpRef::op_typed(self.op_count, opcode.result_type());
+        self.guard_count += 1;
         let op = match descr {
             Some(d) => Op::with_descr(opcode, &self.box_args(args), d),
             None => Op::new(opcode, &self.box_args(args)),
@@ -338,6 +354,7 @@ impl Trace {
     ) -> OpRef {
         assert!(opcode.is_guard(), "opcode {:?} is not a guard", opcode);
         let opref = OpRef::op_typed(self.op_count, opcode.result_type());
+        self.guard_count += 1;
         let op = match descr {
             Some(d) => Op::with_descr(opcode, &self.box_args(args), d),
             None => Op::new(opcode, &self.box_args(args)),
@@ -489,6 +506,7 @@ impl Trace {
             _index: self.box_count,
             snapshot_data_len: 0,
             snapshot_array_data_len: 0,
+            guard_count: Some(self.guard_count),
         }
     }
 
@@ -502,6 +520,12 @@ impl Trace {
         self.ops.truncate(pos._pos);
         self.op_count = pos._count;
         self.box_count = pos._index;
+        // `record_result_of_call_pure` cuts back after every speculative
+        // pure-call record, so this runs on a hot path — restore from the
+        // saved position instead of rescanning `ops`.
+        self.guard_count = pos
+            .guard_count
+            .unwrap_or_else(|| self.ops.iter().filter(|op| op.opcode.is_guard()).count());
     }
 
     /// history.py:725 `length`: number of non-inputarg ops recorded so far.
@@ -523,7 +547,7 @@ impl Trace {
 
     /// Number of guards recorded so far.
     pub fn num_guards(&self) -> usize {
-        self.ops.iter().filter(|op| op.opcode.is_guard()).count()
+        self.guard_count
     }
 
     /// Access the recorded operations.
@@ -537,6 +561,9 @@ impl Trace {
     /// without driving the full record path.
     #[cfg(test)]
     pub fn push_op_for_test(&mut self, op: Op) {
+        if op.opcode.is_guard() {
+            self.guard_count += 1;
+        }
         self.ops.push(OpRc::new(op));
     }
 

--- a/pyre/bench/synth/nested_list_comprehension_hot.py
+++ b/pyre/bench/synth/nested_list_comprehension_hot.py
@@ -4,12 +4,10 @@
 # jitcode-liveness color. Once the trace-time single-executor forks were retired
 # the append body no longer runs under a speculative-replay sub-walk, so the
 # backing block is bound at every guard-exit deopt without an extra resume-data
-# root; the shape is admitted by default (PYRE_NESTED_LIST_FOLD_VIRT, default-on).
+# root.
 #
 # Acceptance repro for that fold: it must print the same total on all three
-# backends (dynasm / cranelift / wasm). Set PYRE_NESTED_LIST_FOLD_VIRT=0 to fall
-# back to the `for_iter_bodies_all_jit_safe` interpreter decline (native only —
-# the wasm guest cannot read the env var).
+# backends (dynasm / cranelift / wasm).
 
 
 def single_comp(n):

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -3645,77 +3645,26 @@ impl OpcodeStepExecutor for PyFrame {
     }
 
     // ── Pattern matching (PEP 634) ──
-    // MATCH_MAPPING / MATCH_SEQUENCE peek the subject and push a bool from the
-    // type's PATMA flag (the raw mapping/sequence marker — no `__getitem__`
-    // fallback, which is the pattern-matching contract, unlike `ismapping_w`).
+    // Each opcode is the stack shuffle around an `opcode_ops` value-level
+    // helper; the JIT residuals (`bh_match_*_fn`) call the same helpers.
     fn match_mapping(&mut self) -> Result<(), PyError> {
         let subject = PyFrame::peek_at(self, 0);
-        let is_mapping = unsafe {
-            let ty = crate::typedef::r#type(subject).map_or(std::ptr::null_mut(), |p| p.as_ptr());
-            pyre_object::typeobject::w_type_get_flag_map_or_seq(ty) == b'M'
-        };
-        self.push(pyre_object::boolobject::w_bool_from(is_mapping));
+        self.push(crate::opcode_ops::match_mapping_value(subject));
         Ok(())
     }
 
     fn match_sequence(&mut self) -> Result<(), PyError> {
         let subject = PyFrame::peek_at(self, 0);
-        let is_sequence = unsafe {
-            let ty = crate::typedef::r#type(subject).map_or(std::ptr::null_mut(), |p| p.as_ptr());
-            pyre_object::typeobject::w_type_get_flag_map_or_seq(ty) == b'S'
-        };
-        self.push(pyre_object::boolobject::w_bool_from(is_sequence));
+        self.push(crate::opcode_ops::match_sequence_value(subject));
         Ok(())
     }
 
     // MATCH_KEYS: STACK[-1] = keys tuple, STACK[-2] = subject (neither popped).
-    // Push a tuple of the looked-up values when every key is present, else None.
     fn match_keys(&mut self) -> Result<(), PyError> {
         let keys = PyFrame::peek_at(self, 0);
         let subject = PyFrame::peek_at(self, 1);
-        // MATCH_MAPPING already proved the subject is a mapping, so match_keys
-        // looks the keys up directly without re-gating (Python/ceval.c
-        // match_keys).
-        let key_items = unsafe { pyre_object::tupleobject::w_tuple_items_copy_as_vec(keys) };
-        let mut values = Vec::with_capacity(key_items.len());
-        // pyopcode.py:1797-1818 — a key repeated in the pattern is rejected
-        // before it binds anything; track keys already looked up and raise on
-        // a duplicate. Each key is looked up with `map.get(key, sentinel)`
-        // rather than subscription so a mapping subclass that defines
-        // `__missing__` (defaultdict) neither creates entries nor raises; a
-        // sentinel result means the key is absent.  The sentinel is a fresh
-        // `object()` (match_keys `dummy = object()`), so a value present in the
-        // subject can never be mistaken for the absent marker.
-        let w_seen = pyre_object::w_set_new();
-        let w_sentinel = pyre_object::w_instance_new(crate::typedef::gettypeobject(
-            &pyre_object::pyobject::INSTANCE_TYPE,
-        ));
-        let mut all_match = true;
-        for key in key_items {
-            if crate::baseobjspace::contains(w_seen, key)? {
-                let key_repr = unsafe { crate::py_repr(key)? };
-                return Err(crate::PyError::value_error(format!(
-                    "mapping pattern checks duplicate key ({key_repr})"
-                )));
-            }
-            unsafe { pyre_object::w_set_add(w_seen, key) };
-            let w_value = crate::baseobjspace::call_method(subject, "get", &[key, w_sentinel]);
-            if w_value.is_null() {
-                return Err(crate::call::take_call_error().unwrap_or_else(|| {
-                    crate::PyError::type_error("mapping pattern lookup failed")
-                }));
-            }
-            if crate::baseobjspace::is_w(w_value, w_sentinel) {
-                all_match = false;
-                break;
-            }
-            values.push(w_value);
-        }
-        if all_match {
-            self.push(pyre_object::w_tuple_new(values));
-        } else {
-            self.push(pyre_object::w_none());
-        }
+        let result = crate::opcode_ops::match_keys_value(subject, keys)?;
+        self.push(result);
         Ok(())
     }
 
@@ -3726,145 +3675,8 @@ impl OpcodeStepExecutor for PyFrame {
         let kwd_attrs = self.pop();
         let cls = self.pop();
         let subject = self.pop();
-
-        if unsafe { !pyre_object::typeobject::is_type(cls) } {
-            return Err(crate::PyError::type_error(
-                "called match pattern must be a class",
-            ));
-        }
-        let type_name = unsafe { pyre_object::w_type_get_name(cls) };
-
-        if !crate::baseobjspace::isinstance(subject, cls)? {
-            self.push(pyre_object::w_none());
-            return Ok(());
-        }
-
-        let mut extracted: Vec<PyObjectRef> = Vec::new();
-        let mut seen: Vec<String> = Vec::new();
-
-        if count > 0 {
-            let match_args = match crate::baseobjspace::getattr_str(cls, "__match_args__") {
-                Ok(v) => Some(v),
-                Err(e) if e.kind == crate::PyErrorKind::AttributeError => None,
-                Err(e) => return Err(e),
-            };
-            if let Some(match_args) = match_args {
-                if unsafe { !pyre_object::is_tuple(match_args) } {
-                    let got = unsafe {
-                        pyre_object::w_type_get_name(
-                            crate::typedef::r#type(match_args)
-                                .map_or(std::ptr::null_mut(), |p| p.as_ptr()),
-                        )
-                    };
-                    return Err(crate::PyError::type_error(format!(
-                        "{type_name}.__match_args__ must be a tuple (got {got})"
-                    )));
-                }
-                let ma = unsafe { pyre_object::tupleobject::w_tuple_items_copy_as_vec(match_args) };
-                if ma.len() < count {
-                    let plural = if ma.len() == 1 { "" } else { "s" };
-                    return Err(crate::PyError::type_error(format!(
-                        "{type_name}() accepts {} positional sub-pattern{plural} ({count} given)",
-                        ma.len()
-                    )));
-                }
-                for attr_obj in ma.into_iter().take(count) {
-                    let attr_name = match unsafe { pyre_object::w_str_get_value_opt(attr_obj) } {
-                        Some(s) => s,
-                        None => {
-                            let got = unsafe {
-                                pyre_object::w_type_get_name(
-                                    crate::typedef::r#type(attr_obj)
-                                        .map_or(std::ptr::null_mut(), |p| p.as_ptr()),
-                                )
-                            };
-                            return Err(crate::PyError::type_error(format!(
-                                "__match_args__ elements must be strings (got {got})"
-                            )));
-                        }
-                    };
-                    if seen.iter().any(|s| s == attr_name) {
-                        return Err(crate::PyError::type_error(format!(
-                            "{type_name}() got multiple sub-patterns for attribute '{attr_name}'"
-                        )));
-                    }
-                    seen.push(attr_name.to_string());
-                    match crate::baseobjspace::getattr_str(subject, attr_name) {
-                        Ok(v) => extracted.push(v),
-                        Err(e) if e.kind == crate::PyErrorKind::AttributeError => {
-                            self.push(pyre_object::w_none());
-                            return Ok(());
-                        }
-                        Err(e) => return Err(e),
-                    }
-                }
-            } else {
-                // No `__match_args__`: the builtin "atomic" types (int, str,
-                // bytes, ...) match the subject itself as their single
-                // positional sub-pattern (Py_TPFLAGS_MATCH_SELF).
-                let is_self = {
-                    use pyre_object::pyobject::get_instantiate;
-                    let atomics: [PyObjectRef; 11] = [
-                        get_instantiate(&pyre_object::pyobject::INT_TYPE),
-                        get_instantiate(&pyre_object::pyobject::BOOL_TYPE),
-                        get_instantiate(&pyre_object::pyobject::FLOAT_TYPE),
-                        get_instantiate(&pyre_object::pyobject::STR_TYPE),
-                        get_instantiate(&pyre_object::pyobject::LIST_TYPE),
-                        get_instantiate(&pyre_object::pyobject::TUPLE_TYPE),
-                        get_instantiate(&pyre_object::pyobject::DICT_TYPE),
-                        get_instantiate(&pyre_object::bytesobject::BYTES_TYPE),
-                        get_instantiate(&pyre_object::bytearrayobject::BYTEARRAY_TYPE),
-                        get_instantiate(&pyre_object::setobject::SET_TYPE),
-                        get_instantiate(&pyre_object::setobject::FROZENSET_TYPE),
-                    ];
-                    let mut found = false;
-                    for ty_obj in atomics {
-                        if crate::baseobjspace::issubclass(cls, ty_obj)? {
-                            found = true;
-                            break;
-                        }
-                    }
-                    found
-                };
-                if is_self {
-                    if count == 1 {
-                        extracted.push(subject);
-                    } else {
-                        return Err(crate::PyError::type_error(format!(
-                            "{type_name}() accepts 1 positional sub-pattern ({count} given)"
-                        )));
-                    }
-                } else {
-                    return Err(crate::PyError::type_error(format!(
-                        "{type_name}() accepts 0 positional sub-patterns ({count} given)"
-                    )));
-                }
-            }
-        }
-
-        let kwd_items = unsafe { pyre_object::tupleobject::w_tuple_items_copy_as_vec(kwd_attrs) };
-        for name_obj in kwd_items {
-            let name = match unsafe { pyre_object::w_str_get_value_opt(name_obj) } {
-                Some(s) => s,
-                None => return Err(crate::PyError::type_error("Attribute name must be string")),
-            };
-            if seen.iter().any(|s| s == name) {
-                return Err(crate::PyError::type_error(format!(
-                    "{type_name}() got multiple sub-patterns for attribute '{name}'"
-                )));
-            }
-            seen.push(name.to_string());
-            match crate::baseobjspace::getattr_str(subject, name) {
-                Ok(v) => extracted.push(v),
-                Err(e) if e.kind == crate::PyErrorKind::AttributeError => {
-                    self.push(pyre_object::w_none());
-                    return Ok(());
-                }
-                Err(e) => return Err(e),
-            }
-        }
-
-        self.push(pyre_object::w_tuple_new(extracted));
+        let result = crate::opcode_ops::match_class_value(subject, cls, kwd_attrs, count)?;
+        self.push(result);
         Ok(())
     }
 

--- a/pyre/pyre-interpreter/src/opcode_ops.rs
+++ b/pyre/pyre-interpreter/src/opcode_ops.rs
@@ -186,6 +186,229 @@ pub fn list_to_tuple_value(value: PyObjectRef) -> Result<PyObjectRef, PyError> {
     }
     Err(PyError::type_error("expected list for list_to_tuple"))
 }
+
+// ── Pattern matching (PEP 634) ──
+//
+// The four value-level entry points below are shared by the interpreter's
+// stack-based opcode handlers (`eval.rs`) and the JIT residuals
+// (`bh_match_*_fn`), so a traced `match` statement and an interpreted one
+// run exactly the same code.
+
+/// `MATCH_MAPPING` — push whether the subject is a mapping.
+/// `pyopcode.py:1776` reads `flag_patma_collection` and only falls back to
+/// `ismapping_w` when the type declares neither marker; every pyre type
+/// carries the marker, so the flag read is the whole test.  This is the raw
+/// mapping marker, not `__getitem__` duck-typing — that is the
+/// pattern-matching contract.
+pub fn match_mapping_value(subject: PyObjectRef) -> PyObjectRef {
+    let is_mapping = unsafe {
+        let ty = crate::typedef::r#type(subject).map_or(std::ptr::null_mut(), |p| p.as_ptr());
+        pyre_object::typeobject::w_type_get_flag_map_or_seq(ty) == b'M'
+    };
+    w_bool_from(is_mapping)
+}
+
+/// `MATCH_SEQUENCE` — push whether the subject is a sequence.
+/// `pyopcode.py:1759`, mirroring [`match_mapping_value`].
+pub fn match_sequence_value(subject: PyObjectRef) -> PyObjectRef {
+    let is_sequence = unsafe {
+        let ty = crate::typedef::r#type(subject).map_or(std::ptr::null_mut(), |p| p.as_ptr());
+        pyre_object::typeobject::w_type_get_flag_map_or_seq(ty) == b'S'
+    };
+    w_bool_from(is_sequence)
+}
+
+/// `MATCH_KEYS` — look every key of the pattern up in the subject and
+/// return a tuple of the values, or `None` when any key is absent.
+/// MATCH_MAPPING already proved the subject is a mapping, so the keys are
+/// looked up directly without re-gating (`Python/ceval.c match_keys`).
+pub fn match_keys_value(subject: PyObjectRef, keys: PyObjectRef) -> Result<PyObjectRef, PyError> {
+    let key_items = unsafe { pyre_object::tupleobject::w_tuple_items_copy_as_vec(keys) };
+    let mut values = Vec::with_capacity(key_items.len());
+    // pyopcode.py:1797-1818 — a key repeated in the pattern is rejected
+    // before it binds anything; track keys already looked up and raise on
+    // a duplicate. Each key is looked up with `map.get(key, sentinel)`
+    // rather than subscription so a mapping subclass that defines
+    // `__missing__` (defaultdict) neither creates entries nor raises; a
+    // sentinel result means the key is absent.  The sentinel is a fresh
+    // `object()` (match_keys `dummy = object()`), so a value present in the
+    // subject can never be mistaken for the absent marker.
+    let w_seen = pyre_object::w_set_new();
+    let w_sentinel = pyre_object::w_instance_new(crate::typedef::gettypeobject(
+        &pyre_object::pyobject::INSTANCE_TYPE,
+    ));
+    let mut all_match = true;
+    for key in key_items {
+        if crate::baseobjspace::contains(w_seen, key)? {
+            let key_repr = unsafe { crate::py_repr(key)? };
+            return Err(PyError::value_error(format!(
+                "mapping pattern checks duplicate key ({key_repr})"
+            )));
+        }
+        unsafe { pyre_object::w_set_add(w_seen, key) };
+        let w_value = crate::baseobjspace::call_method(subject, "get", &[key, w_sentinel]);
+        if w_value.is_null() {
+            return Err(crate::call::take_call_error()
+                .unwrap_or_else(|| PyError::type_error("mapping pattern lookup failed")));
+        }
+        if crate::baseobjspace::is_w(w_value, w_sentinel) {
+            all_match = false;
+            break;
+        }
+        values.push(w_value);
+    }
+    Ok(if all_match {
+        pyre_object::w_tuple_new(values)
+    } else {
+        pyre_object::w_none()
+    })
+}
+
+/// `MATCH_CLASS count` — return the extracted-attribute tuple when the
+/// subject matches the class pattern, else `None`.  `count` is the number
+/// of positional sub-patterns; `kwd_attrs` is the keyword attribute-name
+/// tuple.
+pub fn match_class_value(
+    subject: PyObjectRef,
+    cls: PyObjectRef,
+    kwd_attrs: PyObjectRef,
+    count: usize,
+) -> Result<PyObjectRef, PyError> {
+    if unsafe { !pyre_object::typeobject::is_type(cls) } {
+        return Err(PyError::type_error("called match pattern must be a class"));
+    }
+    let type_name = unsafe { pyre_object::w_type_get_name(cls) };
+
+    if !crate::baseobjspace::isinstance(subject, cls)? {
+        return Ok(pyre_object::w_none());
+    }
+
+    let mut extracted: Vec<PyObjectRef> = Vec::new();
+    let mut seen: Vec<String> = Vec::new();
+
+    if count > 0 {
+        let match_args = match crate::baseobjspace::getattr_str(cls, "__match_args__") {
+            Ok(v) => Some(v),
+            Err(e) if e.kind == crate::PyErrorKind::AttributeError => None,
+            Err(e) => return Err(e),
+        };
+        if let Some(match_args) = match_args {
+            if unsafe { !pyre_object::is_tuple(match_args) } {
+                let got = unsafe {
+                    pyre_object::w_type_get_name(
+                        crate::typedef::r#type(match_args)
+                            .map_or(std::ptr::null_mut(), |p| p.as_ptr()),
+                    )
+                };
+                return Err(PyError::type_error(format!(
+                    "{type_name}.__match_args__ must be a tuple (got {got})"
+                )));
+            }
+            let ma = unsafe { pyre_object::tupleobject::w_tuple_items_copy_as_vec(match_args) };
+            if ma.len() < count {
+                let plural = if ma.len() == 1 { "" } else { "s" };
+                return Err(PyError::type_error(format!(
+                    "{type_name}() accepts {} positional sub-pattern{plural} ({count} given)",
+                    ma.len()
+                )));
+            }
+            for attr_obj in ma.into_iter().take(count) {
+                let attr_name = match unsafe { pyre_object::w_str_get_value_opt(attr_obj) } {
+                    Some(s) => s,
+                    None => {
+                        let got = unsafe {
+                            pyre_object::w_type_get_name(
+                                crate::typedef::r#type(attr_obj)
+                                    .map_or(std::ptr::null_mut(), |p| p.as_ptr()),
+                            )
+                        };
+                        return Err(PyError::type_error(format!(
+                            "__match_args__ elements must be strings (got {got})"
+                        )));
+                    }
+                };
+                if seen.iter().any(|s| s == attr_name) {
+                    return Err(PyError::type_error(format!(
+                        "{type_name}() got multiple sub-patterns for attribute '{attr_name}'"
+                    )));
+                }
+                seen.push(attr_name.to_string());
+                match crate::baseobjspace::getattr_str(subject, attr_name) {
+                    Ok(v) => extracted.push(v),
+                    Err(e) if e.kind == crate::PyErrorKind::AttributeError => {
+                        return Ok(pyre_object::w_none());
+                    }
+                    Err(e) => return Err(e),
+                }
+            }
+        } else {
+            // No `__match_args__`: the builtin "atomic" types (int, str,
+            // bytes, ...) match the subject itself as their single
+            // positional sub-pattern (Py_TPFLAGS_MATCH_SELF).
+            let is_self = {
+                use pyre_object::pyobject::get_instantiate;
+                let atomics: [PyObjectRef; 11] = [
+                    get_instantiate(&pyre_object::pyobject::INT_TYPE),
+                    get_instantiate(&pyre_object::pyobject::BOOL_TYPE),
+                    get_instantiate(&pyre_object::pyobject::FLOAT_TYPE),
+                    get_instantiate(&pyre_object::pyobject::STR_TYPE),
+                    get_instantiate(&pyre_object::pyobject::LIST_TYPE),
+                    get_instantiate(&pyre_object::pyobject::TUPLE_TYPE),
+                    get_instantiate(&pyre_object::pyobject::DICT_TYPE),
+                    get_instantiate(&pyre_object::bytesobject::BYTES_TYPE),
+                    get_instantiate(&pyre_object::bytearrayobject::BYTEARRAY_TYPE),
+                    get_instantiate(&pyre_object::setobject::SET_TYPE),
+                    get_instantiate(&pyre_object::setobject::FROZENSET_TYPE),
+                ];
+                let mut found = false;
+                for ty_obj in atomics {
+                    if crate::baseobjspace::issubclass(cls, ty_obj)? {
+                        found = true;
+                        break;
+                    }
+                }
+                found
+            };
+            if is_self {
+                if count == 1 {
+                    extracted.push(subject);
+                } else {
+                    return Err(PyError::type_error(format!(
+                        "{type_name}() accepts 1 positional sub-pattern ({count} given)"
+                    )));
+                }
+            } else {
+                return Err(PyError::type_error(format!(
+                    "{type_name}() accepts 0 positional sub-patterns ({count} given)"
+                )));
+            }
+        }
+    }
+
+    let kwd_items = unsafe { pyre_object::tupleobject::w_tuple_items_copy_as_vec(kwd_attrs) };
+    for name_obj in kwd_items {
+        let name = match unsafe { pyre_object::w_str_get_value_opt(name_obj) } {
+            Some(s) => s,
+            None => return Err(PyError::type_error("Attribute name must be string")),
+        };
+        if seen.iter().any(|s| s == name) {
+            return Err(PyError::type_error(format!(
+                "{type_name}() got multiple sub-patterns for attribute '{name}'"
+            )));
+        }
+        seen.push(name.to_string());
+        match crate::baseobjspace::getattr_str(subject, name) {
+            Ok(v) => extracted.push(v),
+            Err(e) if e.kind == crate::PyErrorKind::AttributeError => {
+                return Ok(pyre_object::w_none());
+            }
+            Err(e) => return Err(e),
+        }
+    }
+
+    Ok(pyre_object::w_tuple_new(extracted))
+}
+
 pub fn truth_value(value: PyObjectRef) -> Result<bool, PyError> {
     is_true(value)
 }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -2052,12 +2052,11 @@ thread_local! {
 }
 
 /// Record — once per distinct code object — the frame-shape decline of a frame
-/// that `unsupported_jit_shape` keeps out of the tracer entirely.  Two shapes
-/// reach here: a `CurrentFrameOnly` FOR_ITER frame (a body with a
-/// non-journalable mutator — the #57 gate — or a `finally`-duplicated loop),
-/// and a `StructuralRegion` frame (a `with` block whose `WITH_EXCEPT_START`
-/// exception-link lowering the codewriter still residualizes, which also keeps
-/// its nested callees interpreted).  The tracer never runs for such a frame, so
+/// that `unsupported_jit_shape` keeps out of the tracer entirely: a
+/// `CurrentFrameOnly` FOR_ITER frame (a body with a non-journalable mutator —
+/// the #57 gate — or a `finally`-duplicated loop), a `NestedBreakBridgeResume`
+/// frame, or a frame whose constant pool overruns the single-byte index
+/// encoding.  The tracer never runs for such a frame, so
 /// its decline would otherwise leave no census entry and read as a silent
 /// no-token gap; recording it here lets the `PYRE_FBW_DEBUG_ABORT` corpus
 /// attribute the pre-trace frame-shape decline alongside the traced declines.
@@ -7052,49 +7051,6 @@ fn walker_guard_exact_w_class<Sym: WalkSym>(
     let expected = ctx.trace_ctx.const_ref(expected_typeobj as i64);
     let eq = ctx.trace_ctx.record_op(OpCode::PtrEq, &[actual, expected]);
     walker_emit_guard_with_snapshot(ctx, op_pc, OpCode::GuardTrue, &[eq])
-}
-
-/// `PYRE_NEWLIST_VIRT` gate (read once) — routes the `newlist_from_array`
-/// residual through the virtualizable [`try_walker_specialize_newlist`]
-/// instead of recording the opaque CallR.  Default-on (the orthodox
-/// `opimpl_newlist` shape); set `PYRE_NEWLIST_VIRT=0` to fall back to the
-/// residual.
-fn newlist_virt_enabled() -> bool {
-    static ENABLED: std::sync::LazyLock<bool> =
-        std::sync::LazyLock::new(|| std::env::var("PYRE_NEWLIST_VIRT").map_or(true, |v| v != "0"));
-    *ENABLED
-}
-
-/// `PYRE_EMPTY_APPEND_VIRT` gate (read once) — admits the empty-list first
-/// append into the orthodox `w_list_append` fold by promoting the receiver
-/// Empty→typed (recording the strategy switch as inline IR) before the
-/// spare-capacity fold runs, instead of aborting with
-/// `UnfoldableListAppendResidualUnsupported`.  Default-on (the orthodox
-/// `EmptyListStrategy.append` → `switch_to_correct_strategy` shape); set
-/// `PYRE_EMPTY_APPEND_VIRT=0` to fall back to the residual abort.
-fn empty_append_virt_enabled() -> bool {
-    static ENABLED: std::sync::LazyLock<bool> = std::sync::LazyLock::new(|| {
-        std::env::var("PYRE_EMPTY_APPEND_VIRT").map_or(true, |v| v != "0")
-    });
-    *ENABLED
-}
-
-/// `PYRE_NESTED_LIST_FOLD_VIRT` gate (read once) — admits a non-empty nested
-/// `BUILD_LIST` element (`[[i] for i in range(n)]`) into the orthodox
-/// `w_list_append` fold. The appended value is a virtualized inner list whose
-/// separately allocated backing block (`NewArray` / `NewArrayClear`) carries no
-/// jitcode-liveness slot; once the trace-time single-executor forks were retired
-/// the append body no longer runs under a speculative-replay sub-walk, so the
-/// backing block is bound at every guard-exit deopt and the shape compiles
-/// bit-exact on dynasm / cranelift / wasm (comprehension-hot acceptance repro
-/// `bench/synth/nested_list_comprehension_hot.py`). Default-on; set
-/// `PYRE_NESTED_LIST_FOLD_VIRT=0` to fall back to the `for_iter_bodies_all_jit_safe`
-/// decline (native only — the wasm guest cannot read the env var).
-pub fn nested_list_fold_virt_enabled() -> bool {
-    static ENABLED: std::sync::LazyLock<bool> = std::sync::LazyLock::new(|| {
-        std::env::var("PYRE_NESTED_LIST_FOLD_VIRT").map_or(true, |v| v != "0")
-    });
-    *ENABLED
 }
 
 /// #62 dead-`box_bool` proof for [`try_walker_specialize_compare_op_int`] /

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -2779,10 +2779,9 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
         // same-length, step-1, Integer↔Integer slice — fold the assignment
         // into per-element getarrayitem/setarrayitem on the int_items blocks so
         // a virtualizable BUILD_LIST source temp is consumed without forcing.
-        // Gated on `PYRE_NEWLIST_VIRT`; declines to the opaque residual
-        // otherwise (SAFE — always byte-correct).
-        if newlist_virt_enabled() && try_walker_specialize_setslice(ctx, op.pc, &r_args)?.is_some()
-        {
+        // Declines to the opaque residual for any shape it cannot reproduce
+        // faithfully (SAFE — always byte-correct).
+        if try_walker_specialize_setslice(ctx, op.pc, &r_args)?.is_some() {
             return Ok((DispatchOutcome::Continue, op.next_pc));
         }
         if ctx.trace_ctx.is_bridge_trace && fbw_debug_abort_enabled() {
@@ -2850,14 +2849,13 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     // `new_with_vtable` + `new_array` + `setarrayitem_gc` + `setfield_gc` —
     // choosing the storage strategy from the concrete element shadows exactly
     // like `w_list_new` / `list_strategy_for`, so the traced object matches what
-    // the blackhole rebuilds on deopt.  Gated on `PYRE_NEWLIST_VIRT`
-    // (default-on).  Falls through to the opaque residual for any shape it
-    // cannot reproduce faithfully (empty list, non-const array length, an
-    // element without a concrete Ref shadow) — SAFE, never declined.
+    // the blackhole rebuilds on deopt.  Falls through to the opaque residual
+    // for any shape it cannot reproduce faithfully (empty list, non-const
+    // array length, an element without a concrete Ref shadow) — SAFE, never
+    // declined.
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
         && ei.pyre_helper == majit_ir::PyreHelperKind::NewlistFromArray
-        && newlist_virt_enabled()
         && try_walker_specialize_newlist(ctx, op.pc, &r_args, dst, dst_bank)?.is_some()
     {
         return Ok((DispatchOutcome::Continue, op.next_pc));

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -4016,8 +4016,7 @@ pub(crate) fn try_walker_orthodox_list_append<Sym: WalkSym>(
     // Mirror the commit's own promotion predicate exactly: a rollback must
     // undo a promotion only when one was performed, or it would pop another
     // list's journal entry.
-    let promoted_empty = empty_append_virt_enabled()
-        && unsafe { pyre_object::w_list_uses_empty_storage(inner_self) };
+    let promoted_empty = unsafe { pyre_object::w_list_uses_empty_storage(inner_self) };
 
     // ── tentative commit ──
     let callable_op = r_args[0];
@@ -4104,15 +4103,11 @@ unsafe fn orthodox_list_append_recognize(
     if !pyre_object::pyobject::is_list(inner_self) {
         return None;
     }
-    // Empty-strategy first-append promotion (gated). `w_list_can_append_without_realloc`
+    // Empty-strategy first-append promotion. `w_list_can_append_without_realloc`
     // is false for Empty (no backing block yet), so classify by the value's
     // type using switch_to_correct_strategy's int -> float -> object order
     // (listobject.py) and let the commit path install the typed storage.
     if pyre_object::w_list_uses_empty_storage(inner_self) {
-        if !empty_append_virt_enabled() {
-            // Gate off: preserve the prior behavior (Empty always declined).
-            return None;
-        }
         let int_ok = pyre_object::is_plain_int1(value)
             && !(pyre_object::tagged_int::CAN_BE_TAGGED
                 && pyre_object::tagged_int::is_tagged_int(value));
@@ -4241,8 +4236,7 @@ pub(crate) fn orthodox_list_append_commit<Sym: WalkSym>(
     // transition IR mutating the existing wrapper, promote the concrete list,
     // and journal the rewind to Empty.
     use pyre_object::listobject::ListStrategy;
-    let promote_empty = empty_append_virt_enabled()
-        && unsafe { pyre_object::w_list_uses_empty_storage(inner_self) };
+    let promote_empty = unsafe { pyre_object::w_list_uses_empty_storage(inner_self) };
     if promote_empty {
         let target = unsafe {
             let int_ok = pyre_object::is_plain_int1(value)
@@ -4546,8 +4540,7 @@ pub(crate) fn try_walker_orthodox_list_append_opcode<Sym: WalkSym>(
     // Mirror the commit's own promotion predicate exactly: a rollback must
     // undo a promotion only when one was performed, or it would pop another
     // list's journal entry.
-    let promoted_empty =
-        empty_append_virt_enabled() && unsafe { pyre_object::w_list_uses_empty_storage(list) };
+    let promoted_empty = unsafe { pyre_object::w_list_uses_empty_storage(list) };
 
     // ── tentative commit ──
     // The receiver list OpRef + value OpRef are the residual's Ref operands.

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -5916,6 +5916,66 @@ pub extern "C" fn bh_list_to_tuple_fn(value: i64) -> i64 {
     }
 }
 
+/// GET_LEN residual (`get_len` HLOp → `residual_call_r_r`).  Pushes
+/// `len(subject)` without consuming the subject.  Runs the type's
+/// `__len__` (`MayForce`).
+pub extern "C" fn bh_get_len_fn(subject: i64) -> i64 {
+    match pyre_interpreter::baseobjspace::len(subject as pyre_object::PyObjectRef) {
+        Ok(result) => result as i64,
+        Err(mut err) => {
+            publish_residual_call_exception(err.to_exc_object() as i64);
+            0
+        }
+    }
+}
+
+/// MATCH_SEQUENCE residual (`match_sequence` HLOp → `residual_call_r_r`).
+/// Reads the subject type's PATMA marker; runs no user code and never
+/// raises (`Plain`).
+pub extern "C" fn bh_match_sequence_fn(subject: i64) -> i64 {
+    pyre_interpreter::opcode_ops::match_sequence_value(subject as pyre_object::PyObjectRef) as i64
+}
+
+/// MATCH_MAPPING residual (`match_mapping` HLOp → `residual_call_r_r`).
+/// Mirrors [`bh_match_sequence_fn`].
+pub extern "C" fn bh_match_mapping_fn(subject: i64) -> i64 {
+    pyre_interpreter::opcode_ops::match_mapping_value(subject as pyre_object::PyObjectRef) as i64
+}
+
+/// MATCH_KEYS residual (`match_keys` HLOp → `residual_call_r_r`).  Looks
+/// each pattern key up in the subject via `get`, so it runs user code
+/// (`MayForce`) and can raise on a duplicate key.
+pub extern "C" fn bh_match_keys_fn(subject: i64, keys: i64) -> i64 {
+    match pyre_interpreter::opcode_ops::match_keys_value(
+        subject as pyre_object::PyObjectRef,
+        keys as pyre_object::PyObjectRef,
+    ) {
+        Ok(result) => result as i64,
+        Err(mut err) => {
+            publish_residual_call_exception(err.to_exc_object() as i64);
+            0
+        }
+    }
+}
+
+/// MATCH_CLASS residual (`match_class` HLOp → `residual_call_ir_r`).
+/// `count` is the number of positional sub-patterns.  Runs `isinstance`
+/// and attribute lookups, so user code (`MayForce`).
+pub extern "C" fn bh_match_class_fn(subject: i64, cls: i64, kwd_attrs: i64, count: i64) -> i64 {
+    match pyre_interpreter::opcode_ops::match_class_value(
+        subject as pyre_object::PyObjectRef,
+        cls as pyre_object::PyObjectRef,
+        kwd_attrs as pyre_object::PyObjectRef,
+        count as usize,
+    ) {
+        Ok(result) => result as i64,
+        Err(mut err) => {
+            publish_residual_call_exception(err.to_exc_object() as i64);
+            0
+        }
+    }
+}
+
 /// LOAD_COMMON_CONSTANT residual (`load_common_constant` HLOp →
 /// `residual_call_ir_r`).  `disc` is the `CommonConstant` discriminant
 /// (0-6).  Resolves the pushed object through the shared

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -5714,7 +5714,7 @@ fn for_iter_bodies_all_jit_safe(code: &pyre_interpreter::CodeObject) -> bool {
 }
 
 /// True when `code` holds more than one `FOR_ITER` and at least one of them
-/// sits inside an exception-table-covered range — the signature of a loop
+/// sits in the *exceptional copy* of a `finally` body — the signature of a loop
 /// DUPLICATED into a `finally` block's normal and exceptional copies (3.14
 /// emits the `finally` body twice). The JIT compiles only the normal copy; on
 /// loop exhaustion the side-exit resumes the live frame through the dense
@@ -5725,29 +5725,42 @@ fn for_iter_bodies_all_jit_safe(code: &pyre_interpreter::CodeObject) -> bool {
 /// emitted into the trace, so no inverse-map rule can recover it; the frame must
 /// run in the interpreter (#57).
 ///
-/// A single `FOR_ITER` inside a `try`/`except` (no duplication) keeps JITting
-/// because the count stays at one, and genuinely nested `FOR_ITER` frames are
-/// already declined by [`for_iter_bodies_all_jit_safe`].
+/// The exceptional copy is identified by the entry that protects it: 3.14 lays
+/// the copy at a handler landing and covers it with its own exception-table
+/// entry starting exactly there, so a duplicated loop is a `FOR_ITER` covered by
+/// an entry whose `start` is another entry's `target`. Merely being covered by
+/// *some* entry is far weaker and does not imply duplication — a PEP 709 inlined
+/// comprehension puts its `FOR_ITER` inside a range whose handler only restores
+/// the shadowed loop variable and reraises, and a `for` inside `try`/`except`
+/// puts it inside the protected body. Both keep their single copy, so declining
+/// on coverage alone took every function holding a comprehension plus any other
+/// loop out of the JIT entirely.
+///
+/// A single `FOR_ITER` keeps JITting because the count stays at one, and
+/// genuinely nested `FOR_ITER` frames are already declined by
+/// [`for_iter_bodies_all_jit_safe`].
 fn for_iter_frame_is_finally_duplicated(code: &pyre_interpreter::CodeObject) -> bool {
+    let entries: Vec<_> =
+        pyre_interpreter::pycode::decode_exceptiontable(&code.exceptiontable).collect();
     let mut arg_state = pyre_interpreter::OpArgState::default();
     let mut for_iter_count = 0usize;
-    let mut any_in_handler = false;
+    let mut any_in_duplicated_copy = false;
     for (pc, unit) in code.instructions.iter().copied().enumerate() {
         if let pyre_interpreter::Instruction::ForIter { .. } = arg_state.get(unit).0 {
             for_iter_count += 1;
             // The exception table is keyed by byte offset; pyre's `pc` is the
             // instruction-unit index (two bytes per unit).
-            if pyre_interpreter::pycode::lookup_exceptiontable(
-                &code.exceptiontable,
-                (pc * 2) as u32,
-            )
-            .is_some()
-            {
-                any_in_handler = true;
+            let byte_offset = (pc * 2) as u32;
+            if entries.iter().any(|entry| {
+                entry.start <= byte_offset
+                    && byte_offset < entry.end
+                    && entries.iter().any(|outer| outer.target == entry.start)
+            }) {
+                any_in_duplicated_copy = true;
             }
         }
     }
-    for_iter_count > 1 && any_in_handler
+    for_iter_count > 1 && any_in_duplicated_copy
 }
 
 /// True when `code` holds an `except ... as name:` handler whose own body can

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -5440,36 +5440,10 @@ pub fn init_jit_hooks() {
     );
 }
 
-thread_local! {
-    static JIT_SUPPRESSED_BY_UNSUPPORTED_FRAME: Cell<usize> = const { Cell::new(0) };
-}
-
-struct JitSuppressionGuard;
-
-impl JitSuppressionGuard {
-    fn new() -> Self {
-        JIT_SUPPRESSED_BY_UNSUPPORTED_FRAME.with(|depth| depth.set(depth.get() + 1));
-        Self
-    }
-}
-
-impl Drop for JitSuppressionGuard {
-    fn drop(&mut self) {
-        JIT_SUPPRESSED_BY_UNSUPPORTED_FRAME.with(|depth| depth.set(depth.get().saturating_sub(1)));
-    }
-}
-
-// dont_look_inside: reads JIT_SUPPRESSED_BY_UNSUPPORTED_FRAME TLS.
-#[majit_macros::dont_look_inside]
-fn jit_suppressed_by_unsupported_frame() -> bool {
-    JIT_SUPPRESSED_BY_UNSUPPORTED_FRAME.with(|depth| depth.get() != 0)
-}
-
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum UnsupportedJitShape {
     None,
     CurrentFrameOnly,
-    StructuralRegion,
     NestedBreakBridgeResume,
     /// The frame's constant pool plus register file would exceed the
     /// single-byte (`< 256`) register-or-constant index encoding
@@ -5648,41 +5622,33 @@ fn for_iter_bodies_all_jit_safe(code: &pyre_interpreter::CodeObject) -> bool {
             // effect, mirroring RPython's `COND_CALL_GC_WB`, which pyjitpl never
             // executes and the optimizer never treats as a side effect).
             //
-            // A non-empty nested `BUILD_LIST` element (`[[i] …]`) is the one
-            // value-producing shape: the fold virtualizes the inner list, whose
-            // separately allocated backing block (`NewArray` / `NewArrayClear`)
-            // carries no jitcode-liveness slot. With the trace-time single-executor
-            // forks retired the append body no longer runs under a speculative-replay
-            // sub-walk, so the backing block is bound at every guard-exit deopt and
-            // the shape compiles bit-exact on all backends; admitted by default
-            // (`PYRE_NESTED_LIST_FOLD_VIRT`). An empty `[]` element is Empty-strategy
-            // (no backing block) and unaffected; tuple / set / dict elements take
-            // non-list allocation paths.
-            let nested_list_fold_ok =
-                pyre_jit_trace::jitcode_dispatch::nested_list_fold_virt_enabled();
-            let (body_has_call, body_has_nonempty_list_build) = {
+            // A non-empty nested `BUILD_LIST` element (`[[i] …]`) is admitted
+            // too: the fold virtualizes the inner list, whose separately
+            // allocated backing block (`NewArray` / `NewArrayClear`) carries no
+            // jitcode-liveness slot, and with the trace-time single-executor
+            // forks retired the append body no longer runs under a
+            // speculative-replay sub-walk, so the block is bound at every
+            // guard-exit deopt and the shape compiles bit-exact on all backends
+            // (`bench/synth/nested_list_comprehension_hot.py`).
+            let body_has_call = {
                 let mut scan_state = pyre_interpreter::OpArgState::default();
                 let mut scan_pc = pc + 1;
                 let mut has_call = false;
-                let mut has_nonempty_list_build = false;
                 while scan_pc < exit && scan_pc < instructions.len() {
-                    let (scan_instr, scan_op_arg) = scan_state.get(instructions[scan_pc]);
-                    match scan_instr {
+                    let (scan_instr, _) = scan_state.get(instructions[scan_pc]);
+                    if matches!(
+                        scan_instr,
                         I::Call { .. }
-                        | I::CallKw { .. }
-                        | I::CallFunctionEx
-                        | I::CallIntrinsic1 { .. } => has_call = true,
-                        I::BuildList { count } if count.get(scan_op_arg) > 0 => {
-                            has_nonempty_list_build = true
-                        }
-                        _ => {}
-                    }
-                    if has_call && has_nonempty_list_build {
+                            | I::CallKw { .. }
+                            | I::CallFunctionEx
+                            | I::CallIntrinsic1 { .. }
+                    ) {
+                        has_call = true;
                         break;
                     }
                     scan_pc += 1;
                 }
-                (has_call, has_nonempty_list_build)
+                has_call
             };
             let mut body_state = pyre_interpreter::OpArgState::default();
             let mut body_pc = pc + 1;
@@ -5700,9 +5666,7 @@ fn for_iter_bodies_all_jit_safe(code: &pyre_interpreter::CodeObject) -> bool {
                             | I::DeleteAttr { .. }
                             | I::LoadName { .. }
                     )
-                    || (!body_has_call
-                        && (!body_has_nonempty_list_build || nested_list_fold_ok)
-                        && matches!(body_instr, I::ListAppend { .. }));
+                    || (!body_has_call && matches!(body_instr, I::ListAppend { .. }));
                 if !permitted {
                     return false;
                 }
@@ -5993,23 +5957,16 @@ fn const_pool_slot_upper_bound(c: &pyre_interpreter::ConstantData) -> usize {
 }
 
 fn unsupported_jit_shape(code: &pyre_interpreter::CodeObject) -> UnsupportedJitShape {
-    // Structural adaptation: RPython/PyPy traces these bytecodes with
-    // fully translated support. Pyre's codewriter still lowers
-    // `WITH_EXCEPT_START` through a pyre-local `abort_permanent`
-    // path. A frame containing this unsupported shape must run in the
-    // interpreter. While that frame is active, nested helper calls are
-    // also kept out of the JIT by `JitSuppressionGuard`; this mirrors
-    // the structural unsupported region instead of keying on a
-    // benchmark filename.
+    // RPython/PyPy has no counterpart to this function at all: `jit_merge_point`
+    // and `can_enter_jit` are unconditional (`pypy/module/pypyjit/interp_jit.py`),
+    // and `JitPolicy.look_inside_graph` (`rpython/jit/codewriter/policy.py:48`)
+    // decides inline-vs-residual for *interpreter helper graphs* at translation
+    // time, never whether a user frame may be traced. Every arm below is a pyre
+    // deviation kept only until the defect it names is closed; each records a
+    // census entry so the interpreted frame is visible rather than a silent
+    // no-token gap.
     //
-    // The gate cannot be dropped yet: removing it lets a `with` frame trace,
-    // which miscompiles (a raw SIGSEGV in the exception-link path plus
-    // guard-failure storms — test_strftime/test_shlex/test_textwrap, #389).
-    // The eventual fix is a real `WITH_EXCEPT_START` lowering; until then the
-    // decline is recorded in the census (see the `StructuralRegion` arm) so it
-    // is not a silent no-token gap.
-    //
-    // `FOR_ITER` is narrower: a FOR_ITER frame may enter the JIT only when
+    // `FOR_ITER`: a FOR_ITER frame may enter the JIT only when
     // every loop body contains exclusively allow-listed opcodes
     // (`for_iter_bodies_all_jit_safe`). The exclusion exists because a FBW walk
     // that aborts mid-loop while an inlined sub-walk has performed a direct
@@ -6103,9 +6060,6 @@ fn eval_with_jit_inner(frame: &mut PyFrame) -> PyResult {
     if *PYRE_JIT_DISABLED.get_or_init(|| std::env::var("PYRE_JIT").as_deref() == Ok("0")) {
         return frame.execute_frame(None, None);
     }
-    if jit_suppressed_by_unsupported_frame() {
-        return frame.execute_frame(None, None);
-    }
     let mut frame_root = FrameRoot::new(frame);
     let code = unsafe { &*pyre_interpreter::pyframe_get_pycode(frame_root.frame()) };
     pyre_interpreter::call::register_eval_override(eval_with_jit);
@@ -6137,21 +6091,6 @@ fn eval_with_jit_inner(frame: &mut PyFrame) -> PyResult {
             );
             return frame_root.frame().execute_frame(None, None);
         }
-        UnsupportedJitShape::StructuralRegion => {
-            // A `with` frame whose `WITH_EXCEPT_START` exception-link lowering
-            // the codewriter still residualizes: tracing it (or its callees)
-            // miscompiles — a raw SIGSEGV in the exception path and guard-failure
-            // storms (#389 gate-regression evidence).  Keep the frame AND its
-            // nested helper frames interpreted via `JitSuppressionGuard`, and
-            // record the census entry so the decline is visible, not a silent
-            // no-token gap.
-            pyre_jit_trace::jitcode_dispatch::census_record_frame_shape_decline(
-                code as *const _ as usize,
-                "FrameShape::StructuralRegion",
-            );
-            let _guard = JitSuppressionGuard::new();
-            return frame_root.frame().execute_frame(None, None);
-        }
         UnsupportedJitShape::NestedBreakBridgeResume => {
             pyre_jit_trace::jitcode_dispatch::census_record_frame_shape_decline(
                 code as *const _ as usize,
@@ -6164,9 +6103,8 @@ fn eval_with_jit_inner(frame: &mut PyFrame) -> PyResult {
             // single-byte register-or-constant index encoding, so no jitcode
             // can be assembled for it (`unsupported_jit_shape`).  Run this frame
             // in the plain interpreter; nested callees stay JIT-eligible (the
-            // overflow is per-frame), so no `JitSuppressionGuard`.  Record the
-            // decline in the census so the interpreted frame is visible, not a
-            // silent no-token gap.
+            // overflow is per-frame).  Record the decline in the census so the
+            // interpreted frame is visible, not a silent no-token gap.
             pyre_jit_trace::jitcode_dispatch::census_record_frame_shape_decline(
                 code as *const _ as usize,
                 "FrameShape::ConstEncodingOverflow",
@@ -6409,19 +6347,6 @@ pub(crate) fn portal_runner_result(frame: &mut PyFrame) -> PyResult {
     let mut frame_root = FrameRoot::new(frame);
     frame_root.frame().fix_array_ptrs();
     let _frame_guard = pyre_interpreter::eval::install_current_frame(frame_root.frame());
-    // Mirror `eval_with_jit_inner`'s structural-region suppression so a
-    // recursive portal entry whose code contains `WITH_EXCEPT_START`
-    // keeps nested helper Python frames out of the JIT too. The current
-    // frame is already kept out of trace by `try_function_entry_jit`; the
-    // guard extends that to callees.
-    let code = unsafe { &*pyre_interpreter::pyframe_get_pycode(frame_root.frame()) };
-    let _suppression = match unsupported_jit_shape(code) {
-        UnsupportedJitShape::StructuralRegion => Some(JitSuppressionGuard::new()),
-        UnsupportedJitShape::None
-        | UnsupportedJitShape::CurrentFrameOnly
-        | UnsupportedJitShape::NestedBreakBridgeResume
-        | UnsupportedJitShape::ConstEncodingOverflow => None,
-    };
     portal_runner_dispatch(frame_root.frame())
 }
 
@@ -6897,9 +6822,7 @@ fn maybe_compile_and_run(
         return None;
     }
     let code = unsafe { &*pyre_interpreter::pyframe_get_pycode(frame) };
-    if jit_suppressed_by_unsupported_frame()
-        || unsupported_jit_shape(code) != UnsupportedJitShape::None
-    {
+    if unsupported_jit_shape(code) != UnsupportedJitShape::None {
         return None;
     }
     if let Some(expected_vsd) =
@@ -7949,9 +7872,7 @@ pub fn try_function_entry_jit(frame: &mut PyFrame) -> Option<PyResult> {
         return None;
     }
     let code = unsafe { &*pyre_interpreter::pyframe_get_pycode(frame_root.frame()) };
-    if jit_suppressed_by_unsupported_frame()
-        || unsupported_jit_shape(code) != UnsupportedJitShape::None
-    {
+    if unsupported_jit_shape(code) != UnsupportedJitShape::None {
         return None;
     }
     if std::env::var_os("MAJIT_DUMP_BYTECODE").is_some() {
@@ -10860,7 +10781,7 @@ mod tests {
         // only residual is the idempotent `list_write_barrier`, exempt from the
         // FBW body-effect gate. An empty `[]` element is Empty-strategy (no
         // backing block). A non-empty nested `BUILD_LIST` element (`[[i] …]`) is
-        // also admitted (`nested_list_fold_virt_enabled`, default-on): with the
+        // also admitted: with the
         // trace-time single-executor forks retired the inner list's separately
         // allocated backing block is bound at every guard-exit deopt without an
         // extra resume-data root.

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -10946,10 +10946,11 @@ impl CodeWriter {
                             current_depth = current_depth.saturating_sub(1);
                             current_state.stack.push(result);
                             current_depth += 1;
-                            // Genuine trace boundary: flowspace rejects END_SEND
-                            // with `unsupported_rpython("async iteration is not
-                            // RPython")` — the generated JIT cannot trace it
-                            // either, so abort_permanent is parity-correct.
+                            // Genuine trace boundary: END_SEND terminates a
+                            // `yield from` / `await` delegation, whose partner
+                            // opcode SEND suspends the frame. A trace records one
+                            // continuous execution, so no residual can express the
+                            // resume; abort_permanent is the only correct choice.
                             emit_abort_permanent!(py_pc);
                         }
 
@@ -11255,10 +11256,10 @@ impl CodeWriter {
                             }
                             push_fresh_ref(&mut current_state, &mut graph);
                             current_depth += 1;
-                            // Genuine trace boundary: flowspace rejects
-                            // BUILD_INTERPOLATION with `unsupported_rpython(
-                            // "f-strings and template strings are not RPython")`
-                            // — abort is parity-correct.
+                            // Portable in principle (PEP 750 t-strings build an
+                            // Interpolation object — an ordinary call), but no
+                            // residual is written yet: t-strings appear in
+                            // formatting code, not in hot loop bodies.
                             emit_abort_permanent!(py_pc);
                         }
 
@@ -11269,10 +11270,8 @@ impl CodeWriter {
                             }
                             push_fresh_ref(&mut current_state, &mut graph);
                             current_depth += 1;
-                            // Genuine trace boundary: flowspace rejects
-                            // BUILD_TEMPLATE with `unsupported_rpython("f-strings
-                            // and template strings are not RPython")` — abort is
-                            // parity-correct.
+                            // Portable in principle, unported for the same
+                            // reason as BUILD_INTERPOLATION above.
                             emit_abort_permanent!(py_pc);
                         }
 
@@ -11284,11 +11283,11 @@ impl CodeWriter {
                         Instruction::CallIntrinsic1 { func } => {
                             use pyre_interpreter::bytecode::IntrinsicFunction1;
                             // UnaryPositive→`pos`, ListToTuple→`list_to_tuple`
-                            // are the two portable CALL_INTRINSIC_1 variants
-                            // (flowcontext.rs:2422-2431 record real ops); both
-                            // are single-Ref→Ref residuals.  Every other variant
-                            // is `unsupported_rpython` (flowcontext.rs:2435) —
-                            // abort_permanent is parity-correct there.
+                            // are the two CALL_INTRINSIC_1 variants with a
+                            // residual; both are single-Ref→Ref.  The remaining
+                            // variants (import-star, stopiteration-error, the PEP
+                            // 695 type-param helpers) are def-time or error-path
+                            // only, so no residual has been written for them.
                             let opname = match func.get(op_arg) {
                                 IntrinsicFunction1::UnaryPositive => Some("pos"),
                                 IntrinsicFunction1::ListToTuple => Some("list_to_tuple"),
@@ -11318,12 +11317,9 @@ impl CodeWriter {
                         // Other variants: general pop 2, push 1. Net: -1.
                         // pyopcode.rs:1302-1316.
                         //
-                        // Only SetTypeparamDefault is portable (flowspace
-                        // `set_typeparam_default` pure op); the rest are genuine
-                        // boundaries (`unsupported_rpython`).  The portable one is
-                        // deeply latent — a PEP 695 def-time intrinsic that
+                        // Every variant is a PEP 695 / def-time intrinsic that
                         // imports `_typing` and calls a Python helper, never a hot
-                        // loop body. No residual.
+                        // loop body, so none carries a residual.
                         Instruction::CallIntrinsic2 { func } => {
                             use pyre_interpreter::bytecode::IntrinsicFunction2;
                             match func.get(op_arg) {
@@ -11460,10 +11456,10 @@ impl CodeWriter {
                         Instruction::LoadFromDictOrDeref { .. } => {
                             let _ = current_state.stack.pop();
                             push_fresh_ref(&mut current_state, &mut graph);
-                            // Genuine trace boundary: flowspace rejects
-                            // LOAD_FROM_DICT_OR_DEREF with `unsupported_rpython(
-                            // "closure cell mutation is not RPython")` — abort is
-                            // parity-correct.
+                            // No residual is possible while the interpreter
+                            // itself raises here: the trait default
+                            // (pyopcode.rs:1247) never implements the opcode, so
+                            // there is no value-level function to call.
                             emit_abort_permanent!(py_pc);
                         }
 
@@ -11653,11 +11649,10 @@ impl CodeWriter {
                             push_and_bump!(result_value.into(), py_pc);
                         }
 
-                        // Genuine trace boundaries: flowspace rejects both —
-                        // LOAD_LOCALS with `unsupported_rpython("locals() is not
-                        // RPython")` and LOAD_BUILD_CLASS with `unsupported_rpython(
-                        // "defining classes inside functions is not RPython")`.
-                        // abort is parity-correct.
+                        // Both are portable (plain value-level reads), but both
+                        // occur only in a class body, which runs once per class
+                        // definition — never a hot loop body — so no residual has
+                        // been written.
                         Instruction::LoadLocals | Instruction::LoadBuildClass => {
                             push_fresh_ref(&mut current_state, &mut graph);
                             current_depth += 1;
@@ -11765,10 +11760,9 @@ impl CodeWriter {
                         Instruction::GetYieldFromIter => {
                             let _ = current_state.stack.pop();
                             push_fresh_ref(&mut current_state, &mut graph);
-                            // Genuine trace boundary: flowspace rejects
-                            // GET_YIELD_FROM_ITER with `unsupported_rpython(
-                            // "`yield from` is not supported by flowspace yet")`
-                            // — abort is parity-correct.
+                            // Genuine trace boundary: this only heads a
+                            // `yield from` delegation, whose SEND suspends the
+                            // frame — not expressible as a residual call.
                             emit_abort_permanent!(py_pc);
                         }
 
@@ -12138,16 +12132,14 @@ impl CodeWriter {
                             emit_abort_permanent!(py_pc);
                         }
 
-                        // ExitInitCheck: no-op in pyre (pyopcode.rs:2069). Net: 0.
+                        // ExitInitCheck: no-op in pyre. Net: 0.
                         // RustPython pops the __init__ return value, but pyre's
-                        // dispatch is a plain Ok(StepResult::Continue).
-                        // Genuine trace boundary: flowspace rejects
-                        // EXIT_INIT_CHECK with `unsupported_rpython("`__init__`
-                        // return-None check is not RPython")` — abort is
-                        // parity-correct.
-                        Instruction::ExitInitCheck => {
-                            emit_abort_permanent!(py_pc);
-                        }
+                        // dispatch is a plain `Ok(StepResult::Continue)`
+                        // (pyopcode.rs), and liveness.rs:579 models it as pop 0 /
+                        // push 0 to match. An opcode the interpreter executes as a
+                        // no-op has nothing to residualize and nothing to bail for,
+                        // so the trace just carries on.
+                        Instruction::ExitInitCheck => {}
 
                         // StoreName pops 1 value from the stack.
                         // (This is separate from the above because pyopcode.rs pops.)
@@ -12187,9 +12179,10 @@ impl CodeWriter {
                         Instruction::Send { .. } => {
                             let _ = current_state.stack.pop();
                             push_fresh_ref(&mut current_state, &mut graph);
-                            // Genuine trace boundary: flowspace rejects SEND with
-                            // `unsupported_rpython("async iteration is not
-                            // RPython")` — abort is parity-correct.
+                            // Genuine trace boundary: SEND suspends the frame
+                            // (StepResult::Yield) and resumes it in a different
+                            // stack context, which a residual call cannot express —
+                            // the same reason YIELD_VALUE aborts above.
                             emit_abort_permanent!(py_pc);
                         }
 
@@ -12209,10 +12202,9 @@ impl CodeWriter {
                         // on the StopAsyncIteration path (assemble.py:1578). Structural
                         // adaptation: pyre targets CPython opcode shape here.
                         //
-                        // Genuine trace boundary: flowspace rejects END_ASYNC_FOR
-                        // with `unsupported_rpython` (the async cluster —
-                        // GET_AITER/GET_AWAITABLE/GET_ANEXT/SEND/END_ASYNC_FOR —
-                        // `async for` is not RPython), so abort is parity-correct.
+                        // Genuine trace boundary: END_ASYNC_FOR closes an
+                        // `async for`, whose body suspends the frame through SEND
+                        // on every iteration — not expressible as a residual.
                         Instruction::EndAsyncFor => {
                             for _ in 0..2 {
                                 pop_and_decr_depth(&mut current_state, &mut current_depth);
@@ -12227,10 +12219,9 @@ impl CodeWriter {
                             }
                             push_fresh_ref(&mut current_state, &mut graph);
                             current_depth += 1;
-                            // Genuine trace boundary: flowspace rejects
-                            // CLEANUP_THROW with `unsupported_rpython("async
-                            // iteration is not RPython")` — abort is
-                            // parity-correct.
+                            // Genuine trace boundary: CLEANUP_THROW runs on the
+                            // throw() path of a suspended generator, which a trace
+                            // never records — the resume happens elsewhere.
                             emit_abort_permanent!(py_pc);
                         }
 

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -3446,6 +3446,11 @@ struct FnPtrIndices {
     unary_positive_fn: HelperHandle,
     load_common_constant_fn: HelperHandle,
     list_to_tuple_fn: HelperHandle,
+    get_len_fn: HelperHandle,
+    match_sequence_fn: HelperHandle,
+    match_mapping_fn: HelperHandle,
+    match_keys_fn: HelperHandle,
+    match_class_fn: HelperHandle,
     load_from_dict_or_globals_fn: HelperHandle,
     call_function_ex_fn: HelperHandle,
     unary_not_fn: HelperHandle,
@@ -4120,6 +4125,32 @@ fn register_helper_fn_pointers(
         cpu.unbound_local_error_fn as *const (),
         CallFlavor::PlainCannotRaise,
     );
+    // Pattern matching (PEP 634).  `bh_get_len_fn` runs `__len__`,
+    // `bh_match_keys_fn` runs the subject's `get`, `bh_match_class_fn` runs
+    // `isinstance` plus attribute lookups → `MayForce`.  MATCH_SEQUENCE /
+    // MATCH_MAPPING only read the subject type's PATMA marker → `Plain`.
+    // Appended last to preserve fn_ptr indices.
+    let get_len_fn = bind(assembler, cpu.get_len_fn as *const (), CallFlavor::MayForce);
+    let match_sequence_fn = bind(
+        assembler,
+        cpu.match_sequence_fn as *const (),
+        CallFlavor::Plain,
+    );
+    let match_mapping_fn = bind(
+        assembler,
+        cpu.match_mapping_fn as *const (),
+        CallFlavor::Plain,
+    );
+    let match_keys_fn = bind(
+        assembler,
+        cpu.match_keys_fn as *const (),
+        CallFlavor::MayForce,
+    );
+    let match_class_fn = bind(
+        assembler,
+        cpu.match_class_fn as *const (),
+        CallFlavor::MayForce,
+    );
     FnPtrIndices {
         call_fn,
         load_global_fn,
@@ -4195,6 +4226,11 @@ fn register_helper_fn_pointers(
         map_add_fn,
         dict_merge_fn,
         list_to_tuple_fn,
+        get_len_fn,
+        match_sequence_fn,
+        match_mapping_fn,
+        match_keys_fn,
+        match_class_fn,
         load_from_dict_or_globals_fn,
         call_function_ex_fn,
         call_kw_fn_0,
@@ -5664,6 +5700,31 @@ impl CodeWriter {
                     idx: list_to_tuple_fn_idx,
                     flavor: _list_to_tuple_fn_flavor,
                 },
+            get_len_fn:
+                HelperHandle {
+                    idx: get_len_fn_idx,
+                    flavor: _get_len_fn_flavor,
+                },
+            match_sequence_fn:
+                HelperHandle {
+                    idx: match_sequence_fn_idx,
+                    flavor: _match_sequence_fn_flavor,
+                },
+            match_mapping_fn:
+                HelperHandle {
+                    idx: match_mapping_fn_idx,
+                    flavor: _match_mapping_fn_flavor,
+                },
+            match_keys_fn:
+                HelperHandle {
+                    idx: match_keys_fn_idx,
+                    flavor: _match_keys_fn_flavor,
+                },
+            match_class_fn:
+                HelperHandle {
+                    idx: match_class_fn_idx,
+                    flavor: _match_class_fn_flavor,
+                },
             load_from_dict_or_globals_fn:
                 HelperHandle {
                     idx: load_from_dict_or_globals_fn_idx,
@@ -5922,6 +5983,11 @@ impl CodeWriter {
                 unary_positive_fn_idx,
                 load_common_constant_fn_idx,
                 list_to_tuple_fn_idx,
+                get_len_fn_idx,
+                match_sequence_fn_idx,
+                match_mapping_fn_idx,
+                match_keys_fn_idx,
+                match_class_fn_idx,
                 load_from_dict_or_globals_fn_idx,
                 call_function_ex_fn_idx,
                 unary_not_fn_idx,
@@ -11276,15 +11342,23 @@ impl CodeWriter {
                             emit_abort_permanent!(py_pc);
                         }
 
-                        // GetLen: peeks obj, pushes len. Net: +1.
+                        // GetLen: peeks obj (does NOT pop), pushes len. Net: +1.
+                        // `get_len(subject)` HLOp → `bh_get_len_fn` residual.
                         Instruction::GetLen => {
-                            push_fresh_ref(&mut current_state, &mut graph);
-                            current_depth += 1;
-                            // Genuine trace boundary: flowspace rejects GET_LEN
-                            // with `unsupported_rpython("GET_LEN is used by match
-                            // statements (not RPython)")` — abort is
-                            // parity-correct.
-                            emit_abort_permanent!(py_pc);
+                            let subject = current_state
+                                .stack
+                                .last()
+                                .cloned()
+                                .unwrap_or_else(|| fresh_ref_value(&mut graph));
+                            let result_value = emit_graph_op_with_result(
+                                &mut graph,
+                                &current_block.block(),
+                                "get_len",
+                                vec![subject.into()],
+                                Kind::Ref,
+                                py_pc as i64,
+                            );
+                            push_and_bump!(result_value.into(), py_pc);
                         }
 
                         // LoadSpecial: pops 1 (obj), pushes 2 (callable, self_or_null). Net: +1.
@@ -12161,47 +12235,78 @@ impl CodeWriter {
                         }
 
                         // MatchSequence: peeks TOS (subject), pushes bool. Net: +1.
-                        // assemble.py:1614, liveness.rs:601.
-                        Instruction::MatchSequence => {
-                            push_fresh_ref(&mut current_state, &mut graph);
-                            current_depth += 1;
-                            // Genuine trace boundary: flowspace rejects
-                            // MATCH_SEQUENCE with `unsupported_rpython("structural
-                            // pattern matching is not RPython")` — abort is
-                            // parity-correct.
-                            emit_abort_permanent!(py_pc);
-                        }
-
-                        // MatchMapping: peeks TOS (subject), pushes bool. Net: +1.
-                        Instruction::MatchMapping => {
-                            push_fresh_ref(&mut current_state, &mut graph);
-                            current_depth += 1;
-                            emit_abort_permanent!(py_pc);
+                        // assemble.py:1614, liveness.rs:601.  `match_sequence(
+                        // subject)` HLOp → `bh_match_sequence_fn` residual.
+                        Instruction::MatchSequence | Instruction::MatchMapping => {
+                            let opname = if matches!(instruction, Instruction::MatchSequence) {
+                                "match_sequence"
+                            } else {
+                                "match_mapping"
+                            };
+                            let subject = current_state
+                                .stack
+                                .last()
+                                .cloned()
+                                .unwrap_or_else(|| fresh_ref_value(&mut graph));
+                            let result_value = emit_graph_op_with_result(
+                                &mut graph,
+                                &current_block.block(),
+                                opname,
+                                vec![subject.into()],
+                                Kind::Ref,
+                                py_pc as i64,
+                            );
+                            push_and_bump!(result_value.into(), py_pc);
                         }
 
                         // MatchKeys: peeks subject + keys tuple (TOS), pushes a
-                        // values tuple or None. Net: +1.
+                        // values tuple or None. Net: +1.  `match_keys(subject,
+                        // keys)` HLOp → `bh_match_keys_fn` residual.
                         Instruction::MatchKeys => {
-                            push_fresh_ref(&mut current_state, &mut graph);
-                            current_depth += 1;
-                            emit_abort_permanent!(py_pc);
+                            let depth = current_state.stack.len();
+                            let keys = current_state
+                                .stack
+                                .last()
+                                .cloned()
+                                .unwrap_or_else(|| fresh_ref_value(&mut graph));
+                            let subject = depth
+                                .checked_sub(2)
+                                .and_then(|i| current_state.stack.get(i).cloned())
+                                .unwrap_or_else(|| fresh_ref_value(&mut graph));
+                            let result_value = emit_graph_op_with_result(
+                                &mut graph,
+                                &current_block.block(),
+                                "match_keys",
+                                vec![subject.into(), keys.into()],
+                                Kind::Ref,
+                                py_pc as i64,
+                            );
+                            push_and_bump!(result_value.into(), py_pc);
                         }
 
                         // MatchClass: pops subject, type and the keyword-names
                         // tuple (3), pushes the extracted-attrs tuple or None (1).
-                        // Net: -2. The stack effect MUST be modelled even though
-                        // the trace aborts: an unmodelled MATCH_CLASS (via the
-                        // catch-all below) left the operand-stack depth 2 too high,
-                        // so the enclosing block's return link carried stale pattern
-                        // temporaries and tripped `make_return`'s arity assert in
-                        // the flatten pass.
-                        Instruction::MatchClass { .. } => {
-                            pop_and_decr_depth(&mut current_state, &mut current_depth);
-                            pop_and_decr_depth(&mut current_state, &mut current_depth);
-                            pop_and_decr_depth(&mut current_state, &mut current_depth);
-                            push_fresh_ref(&mut current_state, &mut graph);
-                            current_depth += 1;
-                            emit_abort_permanent!(py_pc);
+                        // Net: -2.  `match_class(subject, cls, kwd_attrs, count)`
+                        // HLOp → `bh_match_class_fn` residual.
+                        Instruction::MatchClass { count } => {
+                            let count = count.get(op_arg) as i64;
+                            let _kwd_reg = emit_popvalue_ref!(current_depth, py_pc);
+                            let kwd_attrs = pop_ref_or_fresh(&mut current_state, &mut graph);
+                            let _cls_reg = emit_popvalue_ref!(current_depth, py_pc);
+                            let cls = pop_ref_or_fresh(&mut current_state, &mut graph);
+                            let _subject_reg = emit_popvalue_ref!(current_depth, py_pc);
+                            let subject = pop_ref_or_fresh(&mut current_state, &mut graph);
+                            let v_count: super::flow::FlowValue =
+                                super::flow::Constant::signed(count).into();
+                            let result_value = emit_graph_op_with_result(
+                                &mut graph,
+                                &current_block.block(),
+                                "match_class",
+                                vec![subject.into(), cls.into(), kwd_attrs.into(), v_count.into()],
+                                Kind::Ref,
+                                py_pc as i64,
+                            );
+                            push_and_bump!(result_value.into(), py_pc);
                         }
 
                         // Catch-all: unknown instruction.

--- a/pyre/pyre-jit/src/jit/cpu.rs
+++ b/pyre/pyre-jit/src/jit/cpu.rs
@@ -265,6 +265,21 @@ pub struct Cpu {
     /// `bh_list_to_tuple_fn(value)` — CALL_INTRINSIC_1 ListToTuple residual
     /// (`list_to_tuple`, allocates a fresh tuple; non-list → TypeError).
     pub list_to_tuple_fn: extern "C" fn(i64) -> i64,
+    /// `bh_get_len_fn(subject)` — GET_LEN residual; pushes `len(subject)`
+    /// without consuming it (runs `__len__`).
+    pub get_len_fn: extern "C" fn(i64) -> i64,
+    /// `bh_match_sequence_fn(subject)` — MATCH_SEQUENCE residual; reads the
+    /// subject type's PATMA marker (no user code).
+    pub match_sequence_fn: extern "C" fn(i64) -> i64,
+    /// `bh_match_mapping_fn(subject)` — MATCH_MAPPING residual, mirroring
+    /// `match_sequence_fn`.
+    pub match_mapping_fn: extern "C" fn(i64) -> i64,
+    /// `bh_match_keys_fn(subject, keys)` — MATCH_KEYS residual; looks each
+    /// pattern key up via `get` (user code; duplicate key → ValueError).
+    pub match_keys_fn: extern "C" fn(i64, i64) -> i64,
+    /// `bh_match_class_fn(subject, cls, kwd_attrs, count)` — MATCH_CLASS
+    /// residual; runs `isinstance` and attribute lookups.
+    pub match_class_fn: extern "C" fn(i64, i64, i64, i64) -> i64,
     /// `bh_unary_not_fn(value)` — UNARY_NOT `not value` residual returning a
     /// bool (a user `__bool__` / `__len__` may run Python; infallible).
     pub unary_not_fn: extern "C" fn(i64) -> i64,
@@ -478,6 +493,11 @@ impl Cpu {
             unary_positive_fn: crate::call_jit::bh_unary_positive_fn,
             load_common_constant_fn: crate::call_jit::bh_load_common_constant_fn,
             list_to_tuple_fn: crate::call_jit::bh_list_to_tuple_fn,
+            get_len_fn: crate::call_jit::bh_get_len_fn,
+            match_sequence_fn: crate::call_jit::bh_match_sequence_fn,
+            match_mapping_fn: crate::call_jit::bh_match_mapping_fn,
+            match_keys_fn: crate::call_jit::bh_match_keys_fn,
+            match_class_fn: crate::call_jit::bh_match_class_fn,
             unary_not_fn: crate::call_jit::bh_unary_not_fn,
             load_fast_check_fn: crate::call_jit::bh_load_fast_check_fn,
             unbound_local_error_fn: crate::call_jit::bh_unbound_local_error_fn,

--- a/pyre/pyre-jit/src/jit/flatten.rs
+++ b/pyre/pyre-jit/src/jit/flatten.rs
@@ -2591,6 +2591,11 @@ pub fn graph_op_can_raise(op: &super::flow::SpaceOperation) -> bool {
             | "invert"
             | "pos"
             | "list_to_tuple"
+            | "get_len"
+            | "match_sequence"
+            | "match_mapping"
+            | "match_keys"
+            | "match_class"
             | "not_"
             | "import_name"
             | "import_from"
@@ -3488,6 +3493,30 @@ pub struct LoweringContext {
     /// FORMAT_SIMPLE shape); `bh_list_to_tuple_fn` allocates a fresh tuple
     /// (non-list → TypeError → `MayForce`).
     pub list_to_tuple_fn_idx: u16,
+    /// `get_len_fn` descrs-pool index.  GET_LEN records `get_len(subject)`
+    /// lowered to `residual_call_r_r` by [`lower_get_len_hlop_to_insn`];
+    /// `bh_get_len_fn` runs the type's `__len__` → `MayForce`.
+    pub get_len_fn_idx: u16,
+    /// `match_sequence_fn` descrs-pool index.  MATCH_SEQUENCE records
+    /// `match_sequence(subject)` lowered to `residual_call_r_r` by
+    /// [`lower_match_sequence_hlop_to_insn`]; `bh_match_sequence_fn` reads
+    /// the subject type's PATMA marker, runs no user code → `Plain`.
+    pub match_sequence_fn_idx: u16,
+    /// `match_mapping_fn` descrs-pool index, mirroring
+    /// [`Self::match_sequence_fn_idx`].
+    pub match_mapping_fn_idx: u16,
+    /// `match_keys_fn` descrs-pool index.  MATCH_KEYS records
+    /// `match_keys(subject, keys)` lowered to `residual_call_r_r` (two-Ref)
+    /// by [`lower_match_keys_hlop_to_insn`]; `bh_match_keys_fn` looks each
+    /// key up via `get` → `MayForce`.
+    pub match_keys_fn_idx: u16,
+    /// `match_class_fn` descrs-pool index.  MATCH_CLASS records
+    /// `match_class(subject, cls, kwd_attrs, count)` lowered to
+    /// `residual_call_ir_r(ConstInt(fn_idx), ListI([count]), ListR([subject,
+    /// cls, kwd_attrs]), Descr) → reg` by [`lower_match_class_hlop_to_insn`];
+    /// `bh_match_class_fn` runs `isinstance` and attribute lookups →
+    /// `MayForce`.
+    pub match_class_fn_idx: u16,
     /// `load_from_dict_or_globals_fn` descrs-pool index.
     /// LOAD_FROM_DICT_OR_GLOBALS records `load_from_dict_or_globals(dict,
     /// code, frame, namei)` lowered to `residual_call_ir_r(ConstInt(fn_idx),
@@ -3748,6 +3777,39 @@ fn build_residual_call_ir_r_insn_from_operands(
             Operand::ConstInt(fn_idx as i64),
             Operand::ListOfKind(ListOfKind::new(Kind::Int, vec![Operand::ConstInt(op_val)])),
             Operand::ListOfKind(ListOfKind::new(Kind::Ref, vec![lhs_operand, rhs_operand])),
+            descr_operand,
+        ],
+        dst_reg,
+    )
+}
+
+/// `build_residual_call_ir_r_insn_from_operands` with a caller-supplied Ref
+/// list instead of the fixed `(lhs, rhs)` pair, for helpers that take more
+/// (or fewer) than two Refs alongside their single Int.  The ABI is Refs
+/// first then Ints, matching the two-Ref form.
+fn build_residual_call_ir_r_insn_from_ref_list(
+    fn_idx: u16,
+    op_val: i64,
+    ref_operands: Vec<Operand>,
+    flavor: CallFlavor,
+    pyre_helper: majit_ir::PyreHelperKind,
+    dst_reg: Register,
+) -> Insn {
+    let mut arg_kinds = vec![Kind::Ref; ref_operands.len()];
+    arg_kinds.push(Kind::Int);
+    let mut effect_info = effect_info_for_call_flavor(flavor);
+    effect_info.pyre_helper = pyre_helper;
+    let descr_operand = Operand::descr(DescrOperand::CallDescrStub(CallDescrStub {
+        effect_info,
+        arg_kinds,
+        result_kind: Some(Kind::Ref),
+    }));
+    Insn::op_with_result(
+        "residual_call_ir_r",
+        vec![
+            Operand::ConstInt(fn_idx as i64),
+            Operand::ListOfKind(ListOfKind::new(Kind::Int, vec![Operand::ConstInt(op_val)])),
+            Operand::ListOfKind(ListOfKind::new(Kind::Ref, ref_operands)),
             descr_operand,
         ],
         dst_reg,
@@ -5190,6 +5252,21 @@ where
     if let Some(insn) = lower_list_to_tuple_hlop_to_insn(op, ctx, get_register, lower_constant) {
         return Some(insn);
     }
+    if let Some(insn) = lower_get_len_hlop_to_insn(op, ctx, get_register, lower_constant) {
+        return Some(insn);
+    }
+    if let Some(insn) = lower_match_sequence_hlop_to_insn(op, ctx, get_register, lower_constant) {
+        return Some(insn);
+    }
+    if let Some(insn) = lower_match_mapping_hlop_to_insn(op, ctx, get_register, lower_constant) {
+        return Some(insn);
+    }
+    if let Some(insn) = lower_match_keys_hlop_to_insn(op, ctx, get_register, lower_constant) {
+        return Some(insn);
+    }
+    if let Some(insn) = lower_match_class_hlop_to_insn(op, ctx, get_register, lower_constant) {
+        return Some(insn);
+    }
     if let Some(insn) = lower_load_common_constant_hlop_to_insn(op, ctx, get_register) {
         return Some(insn);
     }
@@ -5985,6 +6062,177 @@ where
     Some(build_residual_call_r_r_insn_from_operands(
         ctx.list_to_tuple_fn_idx,
         vec![value],
+        CallFlavor::MayForce,
+        majit_ir::PyreHelperKind::None,
+        dst_reg,
+    ))
+}
+
+/// Lower a single-Ref pattern-matching HLOp to `residual_call_r_r`.
+/// GET_LEN / MATCH_SEQUENCE / MATCH_MAPPING all have the `op(subject) →
+/// Ref` shape, differing only in helper index and call flavor.
+fn lower_unary_patma_hlop_to_insn<F, LC>(
+    op: &super::flow::SpaceOperation,
+    opname: &str,
+    fn_idx: u16,
+    flavor: CallFlavor,
+    get_register: &mut F,
+    lower_constant: &mut LC,
+) -> Option<Insn>
+where
+    F: FnMut(super::flow::Variable) -> Register,
+    LC: FnMut(&Constant) -> Operand,
+{
+    if op.opname != opname || op.args.len() != 1 {
+        return None;
+    }
+    let subject = operand_for_value_arg(&op.args[0], get_register, lower_constant)?;
+    let dst_reg = match &op.result {
+        Some(super::flow::FlowValue::Variable(var)) => get_register(*var),
+        _ => return None,
+    };
+    Some(build_residual_call_r_r_insn_from_operands(
+        fn_idx,
+        vec![subject],
+        flavor,
+        majit_ir::PyreHelperKind::None,
+        dst_reg,
+    ))
+}
+
+/// Lower the GET_LEN HLOp `get_len(subject)` → `result: Ref`.
+/// `bh_get_len_fn` runs the type's `__len__` → `MayForce`.
+pub fn lower_get_len_hlop_to_insn<F, LC>(
+    op: &super::flow::SpaceOperation,
+    ctx: &LoweringContext,
+    get_register: &mut F,
+    lower_constant: &mut LC,
+) -> Option<Insn>
+where
+    F: FnMut(super::flow::Variable) -> Register,
+    LC: FnMut(&Constant) -> Operand,
+{
+    lower_unary_patma_hlop_to_insn(
+        op,
+        "get_len",
+        ctx.get_len_fn_idx,
+        CallFlavor::MayForce,
+        get_register,
+        lower_constant,
+    )
+}
+
+/// Lower the MATCH_SEQUENCE HLOp `match_sequence(subject)` → `result: Ref`.
+/// `bh_match_sequence_fn` reads the subject type's PATMA marker: no user
+/// code, no allocation beyond the interned bool → `Plain`.
+pub fn lower_match_sequence_hlop_to_insn<F, LC>(
+    op: &super::flow::SpaceOperation,
+    ctx: &LoweringContext,
+    get_register: &mut F,
+    lower_constant: &mut LC,
+) -> Option<Insn>
+where
+    F: FnMut(super::flow::Variable) -> Register,
+    LC: FnMut(&Constant) -> Operand,
+{
+    lower_unary_patma_hlop_to_insn(
+        op,
+        "match_sequence",
+        ctx.match_sequence_fn_idx,
+        CallFlavor::Plain,
+        get_register,
+        lower_constant,
+    )
+}
+
+/// Lower the MATCH_MAPPING HLOp `match_mapping(subject)` → `result: Ref`,
+/// mirroring [`lower_match_sequence_hlop_to_insn`].
+pub fn lower_match_mapping_hlop_to_insn<F, LC>(
+    op: &super::flow::SpaceOperation,
+    ctx: &LoweringContext,
+    get_register: &mut F,
+    lower_constant: &mut LC,
+) -> Option<Insn>
+where
+    F: FnMut(super::flow::Variable) -> Register,
+    LC: FnMut(&Constant) -> Operand,
+{
+    lower_unary_patma_hlop_to_insn(
+        op,
+        "match_mapping",
+        ctx.match_mapping_fn_idx,
+        CallFlavor::Plain,
+        get_register,
+        lower_constant,
+    )
+}
+
+/// Lower the MATCH_KEYS HLOp `match_keys(subject, keys)` → `result: Ref` to
+/// `residual_call_r_r(ConstInt(match_keys_fn_idx), ListR([subject, keys]),
+/// Descr) → reg`.  `bh_match_keys_fn` looks each pattern key up through the
+/// subject's `get` → `MayForce`.
+pub fn lower_match_keys_hlop_to_insn<F, LC>(
+    op: &super::flow::SpaceOperation,
+    ctx: &LoweringContext,
+    get_register: &mut F,
+    lower_constant: &mut LC,
+) -> Option<Insn>
+where
+    F: FnMut(super::flow::Variable) -> Register,
+    LC: FnMut(&Constant) -> Operand,
+{
+    if op.opname != "match_keys" || op.args.len() != 2 {
+        return None;
+    }
+    let subject = operand_for_value_arg(&op.args[0], get_register, lower_constant)?;
+    let keys = operand_for_value_arg(&op.args[1], get_register, lower_constant)?;
+    let dst_reg = match &op.result {
+        Some(super::flow::FlowValue::Variable(var)) => get_register(*var),
+        _ => return None,
+    };
+    Some(build_residual_call_r_r_insn_from_operands(
+        ctx.match_keys_fn_idx,
+        vec![subject, keys],
+        CallFlavor::MayForce,
+        majit_ir::PyreHelperKind::None,
+        dst_reg,
+    ))
+}
+
+/// Lower the MATCH_CLASS HLOp `match_class(subject, cls, kwd_attrs, count)`
+/// → `result: Ref` to `residual_call_ir_r(ConstInt(match_class_fn_idx),
+/// ListI([count]), ListR([subject, cls, kwd_attrs]), Descr) → reg` — the
+/// three-Ref-plus-one-Int shape of `lower_load_from_dict_or_globals_hlop_to_insn`.
+/// `bh_match_class_fn` runs `isinstance` and attribute lookups →
+/// `MayForce`.
+pub fn lower_match_class_hlop_to_insn<F, LC>(
+    op: &super::flow::SpaceOperation,
+    ctx: &LoweringContext,
+    get_register: &mut F,
+    lower_constant: &mut LC,
+) -> Option<Insn>
+where
+    F: FnMut(super::flow::Variable) -> Register,
+    LC: FnMut(&Constant) -> Operand,
+{
+    if op.opname != "match_class" || op.args.len() != 4 {
+        return None;
+    }
+    let subject = operand_for_value_arg(&op.args[0], get_register, lower_constant)?;
+    let cls = operand_for_value_arg(&op.args[1], get_register, lower_constant)?;
+    let kwd_attrs = operand_for_value_arg(&op.args[2], get_register, lower_constant)?;
+    let count = match flatten_arg_with_lowering(&op.args[3], get_register, lower_constant) {
+        Operand::ConstInt(v) => v,
+        _ => return None,
+    };
+    let dst_reg = match &op.result {
+        Some(super::flow::FlowValue::Variable(var)) => get_register(*var),
+        _ => return None,
+    };
+    Some(build_residual_call_ir_r_insn_from_ref_list(
+        ctx.match_class_fn_idx,
+        count,
+        vec![subject, cls, kwd_attrs],
         CallFlavor::MayForce,
         majit_ir::PyreHelperKind::None,
         dst_reg,

--- a/pyre/pyre-jit/src/jit/flatten.rs
+++ b/pyre/pyre-jit/src/jit/flatten.rs
@@ -4528,8 +4528,8 @@ where
             // shape (`pyjitpl.py:779 opimpl_newlist`) instead of recording the
             // opaque CallR.  Inert on the assembler/baseline path (it reads
             // fn_idx + args, not `pyre_helper`) and on the legacy trait path
-            // (which never emitted this residual); only the FBW intercept, gated
-            // on `PYRE_NEWLIST_VIRT`, keys on it.
+            // (which never emitted this residual); only the FBW intercept keys
+            // on it.
             Some(build_residual_call_r_r_insn_from_operands(
                 ctx.newlist_from_array_fn_idx,
                 vec![array_operand],


### PR DESCRIPTION
## What this does

Two independent threads that turned out to be entangled.

### 1. `unsupported_rpython` is pyre's own function, so the abort arms citing it were self-citations

`GET_LEN`, `MATCH_SEQUENCE`, `MATCH_MAPPING`, `MATCH_KEYS` and `MATCH_CLASS` emitted `abort_permanent`, each justified by a comment of the form *"flowspace rejects X with `unsupported_rpython("structural pattern matching is not RPython")` — abort is parity-correct"*.

`unsupported_rpython` lives at `majit/majit-translate/src/flowspace/flowcontext.rs:1824`. It is majit-translate's own flowspace port, and it constrains the **RPython source being translated**. It appears nowhere in `rpython/` or `pypy/`. It says nothing about whether the JIT may trace a *user's* `match` statement — and PyPy dispatches all five opcodes inside `dispatch_bytecode` itself (`pypy/interpreter/pyopcode.py:490-497`, implementations at `:1759-1830`).

More generally, **upstream has no runtime abort for an opcode without a jitcode lowering at all**. `jtransform.py:238 rewrite_operation` raises at *translation* time, and an op with no direct opcode becomes a residual call through `_do_builtin_call`. The six runtime abort reasons (`jitprof.py:150-157`) are all trace-level conditions.

So the five opcodes are now residual calls. The stack handlers moved out of `eval.rs` into value-level functions in `opcode_ops.rs`, which the interpreter and the `bh_*_fn` residuals both call, so a traced `match` and an interpreted one run the same code.

`MATCH_CLASS` keeps pyre's pop-3/push-1 shape: PyPy 3.11 pushes an attrs tuple plus a bool, CPython 3.12+ pushes one value, and pyre targets 3.14.

The remaining eleven arms keep their `abort_permanent` but no longer cite `unsupported_rpython`; each now states the reason that actually holds (frame suspension for the generator/coroutine cluster, an unimplemented interpreter opcode for `LOAD_FROM_DICT_OR_DEREF`, class-body/def-time-only for the rest). `EXIT_INIT_CHECK` is a plain `Ok(StepResult::Continue)` in `pyopcode.rs` and `liveness.rs:579` models it as pop 0 / push 0, so bailing out of a trace over an interpreter no-op was simply wrong; it now falls through.

### 2. Six O(n) scans on per-op paths, making compile time quadratic in trace length

Each of these does a full linear walk of a per-trace collection from a path that runs once per op:

| helper | scan | upstream shape |
|---|---|---|
| `Trace::num_guards` | every recorded op | counter |
| `Trace::cut` | recomputed the guard count | carried in the cut point |
| `OptContext::position_is_const_forwarded` | every `resop_refs` entry | keyed lookup |
| `RewriteState::emit_pending_zeros` | `out.iter().find(...)` per delayed zero-setfield | keyed lookup |
| `OptIntBounds::find_producing_op` | `new_operations.iter().rfind(...)` | `op in self._emittedoperations`, a dict membership test (`optimizer.py:375`) |
| `OptHeap::force_lazy_sets_for_guard` / `clean_caches` | materialized every cached field into a `Vec`, cloning each `DescrRef` | `heap.py:611` skips on `_lazy_set is None`; `heap.py:380` only sorts when untranslated |

`OptContext` already carried `new_operations_index`, the O(1) mirror added for `find_producer_op`; `find_producing_op` now goes through it via `producer_in_new_operations`, which keeps the `new_operations`-only scope it had. The three in-place `new_operations[i] = ...` guard-strengthening writes (`optimizer.py:716-718`, `rewrite.py:343`) now go through `replace_new_operation` so the mirror stays honest during the forward phase.

Also deletes two never-read fields: `CompiledLoopToken.invalidate_positions` (declared, initialized, never read, and the wrong shape — upstream records `(pos, target)` pairs) and x86 `GuardToken.jump_offset`. The `GUARD_NOT_INVALIDATED` doc now cites `llgraph/runner.py:375`, which implements pyre's exact live-flag shape, instead of presenting the flag as an unbacked deviation.

## Measurements

`match` at the **default** threshold, min of 5 interleaved rounds against the same tree without the patma commit:

| fixture | before | after |
|---|---|---|
| `match v: case [a, b]` × 200k | 0.37s | **0.23s** (1.61x) |
| 5-arm `match` (seq / map / class / str / `_`) × 50k | 0.94s | **0.73s** (1.29x) |

Both agree with `PYRE_NO_JIT=1` and with python3.14.

Compile time on a `threshold=1` fixture (where the full-body walk unrolls the outer loop, so trace length scales with the iteration count): a no-`match` control went from **>60s, unfinished** to single-digit seconds across the six fixes.

## Notes for review

- ⚠️ The `threshold=1` fixtures above are a full-body-walk artifact, not a real configuration. At the default threshold a 128000-iteration loop costs the same as a 2000-iteration one, because `trace_limit` (6000, `rlib/jit.py:592`) bounds the trace. I parked the patma port once on the strength of those numbers before re-measuring; they size the scan cost, not the feature.
- `abort_permanent` turns out to be **frame**-scoped, not pc-scoped: the full-body walk covers the whole body statically, so one unlowerable opcode anywhere in the reachable region kills the frame even if it never executes (census `FullBodyWalk::LoopBodyAbortPermanent`). That is most of why the patma port pays — it un-poisons every frame containing a `match`.
- I also tried removing the `except*` veto in `unsupported_jit_shape` (it looked like a redundant frame-level pre-inspection, since the codewriter already aborts at `CHECK_EG_MATCH`). `check.py` was green, but the frame still does not compile — the walk aborts on the handler's opcode — so removal only turned one cheap decline into five wasted trace attempts (0.20s → 0.25s, `loops_aborted` 0 → 5). Reverted; it is an abort-storm damper. `test.test_except_star` is 60/60 with and without the JIT either way, and the two `test.test_exception_group` failures are pre-existing (they reproduce under `PYRE_NO_JIT=1` and on the base binary).

## Test plan

- `pyre/check.py`: dynasm 329/329, cranelift 329/329, wasm 326/326 — re-run after each commit in this branch.
- `cargo test -p majit-metainterp --features dynasm` green in debug, which is the profile where `clean_caches`' untranslated-ordering branch actually runs.
- `test.test_except_star` 60/60 under the JIT and under `PYRE_NO_JIT=1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
