### PR TITLE
jit: target-correct descr widths; residualize the unsafe-fn result shell and five global reads

### DIFF
--- a/majit/majit-metainterp/src/jitcode/assembler.rs
+++ b/majit/majit-metainterp/src/jitcode/assembler.rs
@@ -20,19 +20,30 @@ use super::{
 };
 
 /// Byte width of one scalar of `ty` in memory — a struct field or an array
-/// item.  Integers and pointers are one target word (`symbolic.py:12 WORD =
-/// sizeof(lltype.Signed)`) — 4 on wasm32, where an 8 would make the backend
-/// pick its load width (`majit-backend-wasm codegen.rs emit_sized_int_load`)
-/// wide enough to fold in the following field's bytes.  A float is its own
-/// 8-byte storage on every target, so it does not follow the word.
+/// item.
+///
+/// Only `Ref` follows the target word: its storage IS a pointer, so on
+/// wasm32 it is 4 and a literal 8 would make the backend pick a load width
+/// (`majit-backend-wasm codegen.rs emit_sized_int_load`) wide enough to fold
+/// in the following slot's bytes.
+///
+/// `Int` does NOT follow the word.  It names the interpreter's integer
+/// *bank*, whose values are `i64` (`majit_ir::value::Type` doc), and the
+/// storage a descr describes is the source declaration, not the bank: a
+/// `jit_interp` `[int; virt]` array is backed by the caller's `Vec<i64>`
+/// (`majit/examples/spcount/src/main.rs:96`) and an `int` struct field by an
+/// `i64` (`majit-metainterp/tests/jit_interp_inline_helper_typed_return.rs:57`).
+/// Narrowing those to 4 on wasm32 strides past half of every item and
+/// truncates the value.  `Float` is `f64` on every target for the same
+/// reason.
 ///
 /// This crate is compiled into the wasm guest, so `size_of::<usize>()` is
 /// the target word here; build-time host code in `majit-translate` must use
 /// `layout::target_word_size()` instead.
-fn scalar_size(ty: majit_ir::value::Type) -> usize {
+pub(crate) fn scalar_size(ty: majit_ir::value::Type) -> usize {
     match ty {
-        majit_ir::value::Type::Float => std::mem::size_of::<f64>(),
-        _ => std::mem::size_of::<usize>(),
+        majit_ir::value::Type::Ref => std::mem::size_of::<usize>(),
+        _ => std::mem::size_of::<i64>(),
     }
 }
 
@@ -4680,11 +4691,12 @@ impl JitCodeBuilder {
     ) -> u16 {
         self.add_bh_descr(CanonicalBhDescr::Array {
             base_size: std::mem::size_of::<usize>(),
-            // The runtime twin of this descr reads its item size from
+            // A `[ref; virt]` array's runtime twin reads its item size from
             // `pyre_object::ITEMS_BLOCK_TOKEN`
             // (`pyre-jit-trace virtualizable_gen.rs`), which is
             // `size_of::<PyObjectRef>()`; a literal 8 makes the two descr
-            // universes disagree on wasm32.
+            // universes disagree on wasm32.  A `[int; virt]` array keeps 8 —
+            // it is backed by the caller's `Vec<i64>`, not by words.
             itemsize: scalar_size(item_type),
             len_offset: Some(0),
             type_id: 0,

--- a/majit/majit-metainterp/src/jitcode/assembler.rs
+++ b/majit/majit-metainterp/src/jitcode/assembler.rs
@@ -19,6 +19,23 @@ use super::{
     RuntimeBhDescr,
 };
 
+/// Byte width of one scalar of `ty` in memory — a struct field or an array
+/// item.  Integers and pointers are one target word (`symbolic.py:12 WORD =
+/// sizeof(lltype.Signed)`) — 4 on wasm32, where an 8 would make the backend
+/// pick its load width (`majit-backend-wasm codegen.rs emit_sized_int_load`)
+/// wide enough to fold in the following field's bytes.  A float is its own
+/// 8-byte storage on every target, so it does not follow the word.
+///
+/// This crate is compiled into the wasm guest, so `size_of::<usize>()` is
+/// the target word here; build-time host code in `majit-translate` must use
+/// `layout::target_word_size()` instead.
+fn scalar_size(ty: majit_ir::value::Type) -> usize {
+    match ty {
+        majit_ir::value::Type::Float => std::mem::size_of::<f64>(),
+        _ => std::mem::size_of::<usize>(),
+    }
+}
+
 #[derive(Default)]
 pub struct JitCodeBuilder {
     /// RPython `jitcode.py:15` `self.name = name`. Propagated to the
@@ -592,8 +609,9 @@ impl JitCodeBuilder {
     /// Build `Vec<BhFieldSpec>` from a `(offset, is_ref, name)` layout,
     /// mirroring `descr.py:230-231 FieldDescr(name, offset, size, flag,
     /// index_in_parent, is_pure)` for each field.  Scalar fields are one
-    /// machine word (`field_size = 8`); the flag/sign follow the field
-    /// kind (pointer vs signed int).
+    /// machine word (`symbolic.py:12 WORD = sizeof(lltype.Signed)`, so 4
+    /// on wasm32); the flag/sign follow the field kind (pointer vs signed
+    /// int).
     ///
     /// `index_in_parent` is the field's rank by byte offset, not its order
     /// in the incoming slice.  `heaptracker.get_fielddescr_index_in`
@@ -631,7 +649,7 @@ impl JitCodeBuilder {
                     index: u32::MAX,
                     name: name.to_string(),
                     offset,
-                    field_size: 8,
+                    field_size: scalar_size(field_type),
                     field_type,
                     field_flag,
                     is_field_signed,
@@ -655,7 +673,7 @@ impl JitCodeBuilder {
         };
         self.add_bh_descr(CanonicalBhDescr::Field {
             offset,
-            field_size: 8,
+            field_size: scalar_size(field_type),
             field_type,
             field_flag,
             is_field_signed,
@@ -705,7 +723,7 @@ impl JitCodeBuilder {
             .unwrap_or((0, String::new()));
         self.add_bh_descr(CanonicalBhDescr::Field {
             offset,
-            field_size: 8,
+            field_size: scalar_size(field_type),
             field_type,
             field_flag,
             is_field_signed,
@@ -1486,7 +1504,9 @@ impl JitCodeBuilder {
     pub fn add_raw_float_array_descr(&mut self) -> u16 {
         self.add_bh_descr(CanonicalBhDescr::Array {
             base_size: 0,
-            itemsize: 8,
+            // f64 items are 8 bytes on every target — the one scalar width
+            // that does not follow the word.
+            itemsize: std::mem::size_of::<f64>(),
             len_offset: None,
             type_id: 0,
             item_type: majit_ir::value::Type::Float,
@@ -1588,7 +1608,7 @@ impl JitCodeBuilder {
         })
     }
 
-    /// Add a GC-array descriptor for a raw-pointer-element array (8-byte
+    /// Add a GC-array descriptor for a raw-pointer-element array (one-word
     /// `*mut T` items) to the descrs pool; returns the descr index for
     /// `getarrayitem_gc_r`.  Models a length-prefixed `{ len: usize,
     /// items: [*mut T; N] }` whose base pointer points at the `len` word:
@@ -1603,7 +1623,7 @@ impl JitCodeBuilder {
     pub fn add_ptr_array_descr(&mut self) -> u16 {
         self.add_array_descr(CanonicalBhDescr::Array {
             base_size: std::mem::size_of::<usize>(),
-            itemsize: 8,
+            itemsize: scalar_size(majit_ir::value::Type::Ref),
             len_offset: Some(0),
             type_id: 0,
             item_type: majit_ir::value::Type::Ref,
@@ -4660,7 +4680,12 @@ impl JitCodeBuilder {
     ) -> u16 {
         self.add_bh_descr(CanonicalBhDescr::Array {
             base_size: std::mem::size_of::<usize>(),
-            itemsize: 8,
+            // The runtime twin of this descr reads its item size from
+            // `pyre_object::ITEMS_BLOCK_TOKEN`
+            // (`pyre-jit-trace virtualizable_gen.rs`), which is
+            // `size_of::<PyObjectRef>()`; a literal 8 makes the two descr
+            // universes disagree on wasm32.
+            itemsize: scalar_size(item_type),
             len_offset: Some(0),
             type_id: 0,
             item_type,

--- a/majit/majit-metainterp/src/jitcode/mod.rs
+++ b/majit/majit-metainterp/src/jitcode/mod.rs
@@ -1,5 +1,6 @@
 mod assembler;
 
+pub(crate) use assembler::scalar_size;
 pub use assembler::{JitCodeBuilder, live_slots_for_state_field_jit};
 pub use majit_translate::jitcode::{
     BhCallDescr as CanonicalBhCallDescr, BhDescr as CanonicalBhDescr, BhInteriorFieldSpec,

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -1368,7 +1368,12 @@ impl crate::walkvirtual::VirtualVisitor for RdVirtualInfoBuilder {
                     index: descr.index(),
                     offset: fd.map(|f| f.offset()).unwrap_or(0),
                     field_type: fd.map(|f| f.field_type()).unwrap_or(majit_ir::Type::Int),
-                    field_size: fd.map(|f| f.field_size()).unwrap_or(8),
+                    // The fallback pairs with the `Type::Int` above: one
+                    // target word (`symbolic.py:12 WORD =
+                    // sizeof(lltype.Signed)`), 4 on wasm32.
+                    field_size: fd
+                        .map(|f| f.field_size())
+                        .unwrap_or(std::mem::size_of::<usize>()),
                 }
             })
             .collect();
@@ -1403,7 +1408,12 @@ impl crate::walkvirtual::VirtualVisitor for RdVirtualInfoBuilder {
                     index: descr.index(),
                     offset: fd.map(|f| f.offset()).unwrap_or(0),
                     field_type: fd.map(|f| f.field_type()).unwrap_or(majit_ir::Type::Int),
-                    field_size: fd.map(|f| f.field_size()).unwrap_or(8),
+                    // The fallback pairs with the `Type::Int` above: one
+                    // target word (`symbolic.py:12 WORD =
+                    // sizeof(lltype.Signed)`), 4 on wasm32.
+                    field_size: fd
+                        .map(|f| f.field_size())
+                        .unwrap_or(std::mem::size_of::<usize>()),
                 }
             })
             .collect();

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -1368,12 +1368,12 @@ impl crate::walkvirtual::VirtualVisitor for RdVirtualInfoBuilder {
                     index: descr.index(),
                     offset: fd.map(|f| f.offset()).unwrap_or(0),
                     field_type: fd.map(|f| f.field_type()).unwrap_or(majit_ir::Type::Int),
-                    // The fallback pairs with the `Type::Int` above: one
-                    // target word (`symbolic.py:12 WORD =
-                    // sizeof(lltype.Signed)`), 4 on wasm32.
+                    // The fallback pairs with the `Type::Int` above, whose
+                    // storage is `i64` on every target — only a `Ref` field
+                    // follows the target word.
                     field_size: fd
                         .map(|f| f.field_size())
-                        .unwrap_or(std::mem::size_of::<usize>()),
+                        .unwrap_or_else(|| crate::jitcode::scalar_size(majit_ir::Type::Int)),
                 }
             })
             .collect();
@@ -1408,12 +1408,12 @@ impl crate::walkvirtual::VirtualVisitor for RdVirtualInfoBuilder {
                     index: descr.index(),
                     offset: fd.map(|f| f.offset()).unwrap_or(0),
                     field_type: fd.map(|f| f.field_type()).unwrap_or(majit_ir::Type::Int),
-                    // The fallback pairs with the `Type::Int` above: one
-                    // target word (`symbolic.py:12 WORD =
-                    // sizeof(lltype.Signed)`), 4 on wasm32.
+                    // The fallback pairs with the `Type::Int` above, whose
+                    // storage is `i64` on every target — only a `Ref` field
+                    // follows the target word.
                     field_size: fd
                         .map(|f| f.field_size())
-                        .unwrap_or(std::mem::size_of::<usize>()),
+                        .unwrap_or_else(|| crate::jitcode::scalar_size(majit_ir::Type::Int)),
                 }
             })
             .collect();

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -265,7 +265,10 @@ pub fn struct_fields_write_effect_info(
                     index: u32::MAX,
                     name: name.to_string(),
                     offset,
-                    field_size: 8,
+                    // One target word (`symbolic.py:12 WORD =
+                    // sizeof(lltype.Signed)`), matching the Ref/Int split
+                    // above; 4 on wasm32.
+                    field_size: std::mem::size_of::<usize>(),
                     field_type,
                     is_immutable: false,
                     is_quasi_immutable: false,

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -265,10 +265,10 @@ pub fn struct_fields_write_effect_info(
                     index: u32::MAX,
                     name: name.to_string(),
                     offset,
-                    // One target word (`symbolic.py:12 WORD =
-                    // sizeof(lltype.Signed)`), matching the Ref/Int split
-                    // above; 4 on wasm32.
-                    field_size: std::mem::size_of::<usize>(),
+                    // Same width rule as the `field_specs_from_layout` twin
+                    // this mirrors: a `Ref` field is one target word (4 on
+                    // wasm32), an `Int` field is its `i64` storage.
+                    field_size: jitcode::scalar_size(field_type),
                     field_type,
                     is_immutable: false,
                     is_quasi_immutable: false,

--- a/majit/majit-translate/src/codewriter/assembler.rs
+++ b/majit/majit-translate/src/codewriter/assembler.rs
@@ -2920,6 +2920,11 @@ fn value_type_to_itemsize(ty: &crate::model::ValueType) -> usize {
         // (`symbolic.py:12 WORD = sizeof(lltype.Signed)`).  The sibling
         // fallback in `arraydescrof` already reads it this way.
         ValueType::Ref(_) => crate::layout::target_word_size(),
+        // `lltype.Bool` is one byte (`descr.py:223` takes the field's real
+        // size from `symbolic.get_field_token`), and so is a Rust `bool` —
+        // the spelling-keyed twin already answers 1 for it
+        // (`type_flag_from_str` `"u8" | "bool"`).
+        ValueType::Bool => 1,
         // `Int`/`Unsigned` deliberately keep 8.  They are `lltype.Signed` /
         // `lltype.Unsigned` on paper, but the MIR front-end folds narrower
         // *and* 64-bit Rust integers into them (see `model.rs ValueType`),
@@ -2927,9 +2932,30 @@ fn value_type_to_itemsize(ty: &crate::model::ValueType) -> usize {
         // struct is recoverable; narrowing an `i64`/`u64` field to the
         // wasm32 word would truncate it.  Resolving this needs the
         // front-end to carry the source width, not a guess at this seam.
-        ValueType::Int => 8,
+        ValueType::Int | ValueType::Unsigned => 8,
         ValueType::Float => 8,
         _ => 8,
+    }
+}
+
+/// `descr.py:241-254 get_type_flag` over a `ValueType`, for the no-layout
+/// fallback.
+///
+/// Cannot go through `ArrayFlag::from_field_type`: that reads the descriptor
+/// IR type, which collapses `Bool` / `Unsigned` onto `Type::Int` to track the
+/// register class (`value_type_to_ir_type_for_descr`), and would then report
+/// every unsigned field as `Signed`.  The signedness has to come from the
+/// `ValueType` itself, the way the spelling-keyed `type_flag_from_str` reads
+/// it off `u*` vs `i*`.
+fn value_type_to_field_flag(ty: &crate::model::ValueType) -> majit_ir::descr::ArrayFlag {
+    use crate::model::ValueType;
+    use majit_ir::descr::ArrayFlag;
+    match ty {
+        ValueType::Ref(_) => ArrayFlag::Pointer,
+        ValueType::Float => ArrayFlag::Float,
+        ValueType::Bool | ValueType::Unsigned | ValueType::UInt128 => ArrayFlag::Unsigned,
+        ValueType::Void => ArrayFlag::Void,
+        _ => ArrayFlag::Signed,
     }
 }
 
@@ -3009,7 +3035,7 @@ fn fallback_field_layout(
 ) {
     let field_type = value_type_to_ir_type_for_descr(ty);
     let field_size = value_type_to_itemsize(ty);
-    let field_flag = majit_ir::descr::ArrayFlag::from_field_type(field_type);
+    let field_flag = value_type_to_field_flag(ty);
     let is_signed = field_flag == majit_ir::descr::ArrayFlag::Signed;
     (field_size, field_type, field_flag, is_signed)
 }

--- a/majit/majit-translate/src/codewriter/assembler.rs
+++ b/majit/majit-translate/src/codewriter/assembler.rs
@@ -2901,11 +2901,33 @@ fn kind_char_to_name(c: char) -> &'static str {
     }
 }
 
+/// Alignment of a scalar of `field_size` bytes, for the textual struct-layout
+/// walkers below.
+///
+/// The cap is the target's *maximum scalar alignment*, not its word:
+/// `u64`/`f64` align to 8 on wasm32 even though a pointer there is 4 bytes,
+/// so this must NOT be rewritten to `layout::target_word_size()` — that would
+/// under-align every 8-byte field on a 32-bit target and shift the offsets
+/// this walker derives.
+fn scalar_align(field_size: usize) -> usize {
+    field_size.min(8)
+}
+
 fn value_type_to_itemsize(ty: &crate::model::ValueType) -> usize {
     use crate::model::ValueType;
     match ty {
+        // A pointer strides by the target word, not the build host's
+        // (`symbolic.py:12 WORD = sizeof(lltype.Signed)`).  The sibling
+        // fallback in `arraydescrof` already reads it this way.
+        ValueType::Ref(_) => crate::layout::target_word_size(),
+        // `Int`/`Unsigned` deliberately keep 8.  They are `lltype.Signed` /
+        // `lltype.Unsigned` on paper, but the MIR front-end folds narrower
+        // *and* 64-bit Rust integers into them (see `model.rs ValueType`),
+        // so the width is genuinely unknown here.  Over-reading inside the
+        // struct is recoverable; narrowing an `i64`/`u64` field to the
+        // wasm32 word would truncate it.  Resolving this needs the
+        // front-end to carry the source width, not a guess at this seam.
         ValueType::Int => 8,
-        ValueType::Ref(_) => 8,
         ValueType::Float => 8,
         _ => 8,
     }
@@ -2926,10 +2948,27 @@ fn value_type_to_ir_type_for_descr(ty: &crate::model::ValueType) -> majit_ir::va
     }
 }
 
+/// `descr.py:241-254 get_type_flag`, over a Rust type spelling.
+///
+/// The authoritative copy is [`super::call::get_type_flag`]; this one serves
+/// the layout walkers below.  Word-sized spellings must resolve through
+/// `layout::target_word_size()` in both: this crate is the build-time host
+/// prepass, so `size_of::<usize>()` here would bake the *host's* 8 into a
+/// wasm32 descr.
+///
+/// The two deliberately still differ on `f32`.  `get_type_flag` follows
+/// `descr.py:254` and lands SingleFloat int-banked
+/// (`ArrayFlag::Unsigned` / `Type::Int`), then restores the `'f'` width
+/// marker via `concrete_type` on the ArrayDescr it builds
+/// (`call.rs` `elem_ref == Some("f32")`).  `BhDescr::Array` carries no
+/// `concrete_type` field to restore it with, so adopting the int-banked
+/// answer here would lose the f32-ness outright.  Merging the two is
+/// blocked on `BhDescr::Array` gaining that marker.
 fn type_flag_from_str(
     type_str: &str,
 ) -> (majit_ir::descr::ArrayFlag, majit_ir::value::Type, usize) {
     use majit_ir::descr::ArrayFlag;
+    let word = crate::layout::target_word_size();
     match type_str {
         s if s.starts_with('&')
             || s.starts_with("Box<")
@@ -2939,20 +2978,24 @@ fn type_flag_from_str(
             || s.starts_with("Option<")
             || s == "String" =>
         {
-            (ArrayFlag::Pointer, majit_ir::value::Type::Ref, 8)
+            (ArrayFlag::Pointer, majit_ir::value::Type::Ref, word)
         }
         "f64" => (ArrayFlag::Float, majit_ir::value::Type::Float, 8),
         "f32" => (ArrayFlag::Float, majit_ir::value::Type::Float, 4),
-        "i64" | "isize" => (ArrayFlag::Signed, majit_ir::value::Type::Int, 8),
+        "i64" => (ArrayFlag::Signed, majit_ir::value::Type::Int, 8),
+        "isize" => (ArrayFlag::Signed, majit_ir::value::Type::Int, word),
         "i32" => (ArrayFlag::Signed, majit_ir::value::Type::Int, 4),
         "i16" => (ArrayFlag::Signed, majit_ir::value::Type::Int, 2),
         "i8" => (ArrayFlag::Signed, majit_ir::value::Type::Int, 1),
-        "u64" | "usize" => (ArrayFlag::Unsigned, majit_ir::value::Type::Int, 8),
+        "u64" => (ArrayFlag::Unsigned, majit_ir::value::Type::Int, 8),
+        "usize" => (ArrayFlag::Unsigned, majit_ir::value::Type::Int, word),
         "u32" => (ArrayFlag::Unsigned, majit_ir::value::Type::Int, 4),
         "u16" => (ArrayFlag::Unsigned, majit_ir::value::Type::Int, 2),
         "u8" | "bool" => (ArrayFlag::Unsigned, majit_ir::value::Type::Int, 1),
         "()" => (ArrayFlag::Void, majit_ir::value::Type::Void, 0),
-        _ => (ArrayFlag::Pointer, majit_ir::value::Type::Ref, 8),
+        // Unknown type — treat as GC pointer (conservative), matching
+        // `get_type_flag`'s wildcard.
+        _ => (ArrayFlag::Pointer, majit_ir::value::Type::Ref, word),
     }
 }
 
@@ -3145,7 +3188,7 @@ fn bh_all_field_specs_for_struct_into(
         if field_type == majit_ir::value::Type::Void || field_size == 0 {
             continue;
         }
-        let align = field_size.min(std::mem::size_of::<usize>());
+        let align = scalar_align(field_size);
         offset = (offset + align - 1) & !(align - 1);
         let is_skipped_field = field_name == "typeptr" || field_name.starts_with("c__pad");
         if !is_skipped_field {
@@ -3198,7 +3241,7 @@ fn heuristic_struct_size_for_bh(cc: &CallControl, owner: &str) -> Option<usize> 
         if field_size == 0 {
             continue;
         }
-        let align = field_size.min(std::mem::size_of::<usize>());
+        let align = scalar_align(field_size);
         max_align = max_align.max(align);
         offset = (offset + align - 1) & !(align - 1);
         offset += field_size;
@@ -3318,7 +3361,7 @@ fn heuristic_field_layout(
         if field_type == majit_ir::value::Type::Void || field_size == 0 {
             continue;
         }
-        let align = field_size.min(std::mem::size_of::<usize>());
+        let align = scalar_align(field_size);
         offset = (offset + align - 1) & !(align - 1);
         if name == field_name {
             return Some((

--- a/majit/majit-translate/src/codewriter/call.rs
+++ b/majit/majit-translate/src/codewriter/call.rs
@@ -933,7 +933,7 @@ pub struct CallControl {
     pub unsafe_fn_stubs: Vec<(
         Vec<String>,
         crate::flowspace::argument::Signature,
-        crate::translator::rtyper::lltypesystem::lltype::LowLevelType,
+        Option<String>,
     )>,
     /// `(path-segments, Signature, result ValueType)` for every method on
     /// a foreign **opaque** ADT owner (`malachite_bigint::bigint::BigInt`,

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -11889,13 +11889,23 @@ fn deref_impl_owner_leaf(llbc: &Llbc, fd: &FunDecl) -> Option<String> {
 }
 
 /// Collect, from the lowered MIR,
-/// `(path-segments, Signature, return-lltype)` for every local `unsafe
-/// fn` / unsafe impl-method whose return type projects to `Void` (unit)
-/// or `Bool`.  These callees cannot lower their bodies (raw-pointer
-/// access the flowspace adapter does not model), but downstream
+/// `(path-segments, Signature, FUNC.RESULT token)` for every local `unsafe
+/// fn` / unsafe impl-method whose return type projects to a token
+/// [`crate::translator::rtyper::cutover::residual_return_shell`] can model.
+/// These callees cannot lower their bodies (raw-pointer access the
+/// flowspace adapter does not model), but downstream
 /// `OpKind::Call::FunctionPath` sites still need their signature
 /// registered so the dual gate does not Skip with "not registered in
 /// PyreCallRegistry".
+///
+/// An `unsafe fn` is never lowered, so it never enters
+/// `CallControl::function_graphs` and its call sites already residualize
+/// whether or not it is registered here — registration changes only
+/// whether the *caller* can annotate past the call.  That is why the
+/// result token is projected through the same
+/// [`dont_look_inside_return_token`] the `@jit.dont_look_inside` residual
+/// path uses: both describe one residual boundary's declared result, and
+/// keeping one projection keeps the two in step.
 ///
 /// The single registration key must equal the call-site lookup. A free
 /// fn keys as the crate-included `name_path()` split on every `::`
@@ -11914,18 +11924,16 @@ fn deref_impl_owner_leaf(llbc: &Llbc, fd: &FunDecl) -> Option<String> {
 /// through an `FnDef` constant fall back to `CallTarget::FunctionPath {
 /// name_path }`, whose lookup is served only by this registry.  Argument
 /// names come from the Charon body locals, falling back to `arg{N}`.
-/// Return types other than unit / bool surface no entry, preserving the
-/// original "not registered" Skip for those fns — matches
-/// `simple_return_type_to_lltype`'s Void/Bool-only projection.
+/// A return type `residual_return_shell` declines surfaces no entry,
+/// preserving the original "not registered" Skip for that fn.
 pub(crate) fn collect_unsafe_fn_stubs_from_llbc(
     llbc: &Llbc,
 ) -> Vec<(
     Vec<String>,
     crate::flowspace::argument::Signature,
-    crate::translator::rtyper::lltypesystem::lltype::LowLevelType,
+    Option<String>,
 )> {
     use crate::flowspace::argument::Signature;
-    use crate::translator::rtyper::lltypesystem::lltype::LowLevelType;
     let mut out = Vec::new();
     for fd in llbc.iter_local_fns() {
         if !fd.signature.is_unsafe {
@@ -11936,19 +11944,22 @@ pub(crate) fn collect_unsafe_fn_stubs_from_llbc(
         if fd.is_global_initializer.is_some() {
             continue;
         }
-        // Reference returns (`&bool`, `&()`, …) are not plain unit/bool
-        // stubs: `tyref_to_ast_string` strips the reference to its
-        // referent, which would misclassify `&bool` as `bool`.  The syn
-        // extractor's `simple_return_type_to_lltype` rejects
-        // `syn::Type::Reference`, so skip references here to match it.
+        // Reference returns (`&bool`, `&()`, …) stay out.  The projection
+        // below would give them the `ref` token, which is defensible — a
+        // reference is one pointer word — but widening the collector's
+        // return types and its reference policy at once would make an A/B
+        // unattributable.  Held for its own slice.
         if output_type_is_ref(&fd.signature.output, llbc) {
             continue;
         }
-        let lltype = match tyref_to_ast_string(&fd.signature.output, llbc).as_str() {
-            "()" => LowLevelType::Void,
-            "bool" => LowLevelType::Bool,
-            _ => continue,
-        };
+        // `None` here means unit, which `residual_return_shell` maps to
+        // `Void`; a return type it cannot model still reaches this arm as
+        // a token it declines, and the fn then keeps its original "not
+        // registered" Skip.
+        let token = dont_look_inside_return_token(&fd.signature.output, llbc);
+        if crate::translator::rtyper::cutover::residual_return_shell(token.as_deref()).is_none() {
+            continue;
+        }
         // Both free functions and impl-owned functions are collected,
         // keyed on `name_path()` — the segment vector
         // `call_target_segments` emits for a `CallKind::Fun(Regular)`
@@ -11978,7 +11989,7 @@ pub(crate) fn collect_unsafe_fn_stubs_from_llbc(
                     .unwrap_or_else(|| format!("arg{i}"))
             })
             .collect();
-        out.push((segments, Signature::new(argnames, None, None), lltype));
+        out.push((segments, Signature::new(argnames, None, None), token));
     }
     out
 }

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -11960,6 +11960,21 @@ pub(crate) fn collect_unsafe_fn_stubs_from_llbc(
         if crate::translator::rtyper::cutover::residual_return_shell(token.as_deref()).is_none() {
             continue;
         }
+        // The `ref` token collapses every non-`*mut PyObject` ADT onto one
+        // GC-reference word, so on its own it would also admit a by-value
+        // aggregate — `w_tuple_items_copy_as_vec` returns
+        // `Vec<PyObjectRef>`, three words returned through `sret`.  The
+        // hand-written residuals that do return a `Vec` (`compute_mro`,
+        // `memoryview_gather_bytes`) work because each carries an explicit
+        // `jit_fnaddr` `push_alias_pair` row arranging that ABI; a stub
+        // this collector mints has no such row, so a caller would annotate
+        // the one-word shell against a multiword ABI.  Admit `ref` only
+        // for returns that genuinely are one word.
+        if token.as_deref() == Some("ref")
+            && !ref_return_is_single_word(&tyref_to_ast_string(&fd.signature.output, llbc))
+        {
+            continue;
+        }
         // Both free functions and impl-owned functions are collected,
         // keyed on `name_path()` — the segment vector
         // `call_target_segments` emits for a `CallKind::Fun(Regular)`
@@ -13583,6 +13598,41 @@ fn output_type_is_ref(ty: &TyRef, llbc: &Llbc) -> bool {
 /// `dont_look_inside` residual prefill (`cutover.rs`): without a
 /// `return_type` marker an object-pointer-returning opaque callee maps
 /// `None`→`Void`, residualizing to a void result the caller cannot use.
+/// True when a `ref`-tokened return is genuinely one machine word, so the
+/// token's one-word `SomeInstance` shell matches the callee's return ABI.
+///
+/// Reads the `tyref_to_ast_string` spelling because the `ref` token itself
+/// has already erased the distinction: `tyref_to_value_type` maps every
+/// non-primitive ADT to `ValueType::Ref`, a `Vec<T>` (three words, `sret`)
+/// exactly like a `*mut T`.
+///
+/// Admitted:
+/// - a raw pointer (`*mut T` / `*const T`), one word by construction;
+/// - `Result<T, PyError>` whose `Ok` payload is itself one word.  That is
+///   the shape the exception bridge already gives a one-word ABI — the `Ok`
+///   payload is returned in the result register and the `Err` rides
+///   `BH_LAST_EXC_VALUE` + `jit_publish_exception` — and it is what
+///   `PyResult` spells.
+///
+/// Everything else — `Vec<T>`, `String`, tuples, `Option<T>`, a named ADT by
+/// value — is declined, and its callers keep their "not registered" Skip.
+fn ref_return_is_single_word(ast: &str) -> bool {
+    let ast = ast.trim();
+    if ast.starts_with("*mut ") || ast.starts_with("*const ") {
+        return true;
+    }
+    // `Result<T,PyError>` — `tyref_to_ast_string` comma-joins type args
+    // without spaces, so split the payload off the trailing `,PyError>`.
+    if let Some(args) = ast
+        .strip_prefix("Result<")
+        .and_then(|s| s.strip_suffix(">"))
+        && let Some(ok) = args.strip_suffix(",PyError")
+    {
+        return ok == "()" || ref_return_is_single_word(ok);
+    }
+    false
+}
+
 fn output_type_is_objectptr(ty: &TyRef, llbc: &Llbc) -> bool {
     tyref_node(ty, llbc)
         .and_then(|n| strip_ty_wrappers(n, llbc))

--- a/majit/majit-translate/src/front/semantic.rs
+++ b/majit/majit-translate/src/front/semantic.rs
@@ -307,7 +307,7 @@ pub struct SemanticProgram {
     pub unsafe_fn_stubs: Vec<(
         Vec<String>,
         crate::flowspace::argument::Signature,
-        crate::translator::rtyper::lltypesystem::lltype::LowLevelType,
+        Option<String>,
     )>,
     /// `(path-segments, Signature, result ValueType)` for every method on
     /// a foreign **opaque** ADT owner (`malachite_bigint::bigint::BigInt`,

--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -1477,7 +1477,7 @@ pub(crate) fn is_known_unported(msg: &str) -> bool {
 ///    rtyper's `direct_call`.
 pub(crate) fn populate_call_registry_from_call_graphs(
     function_graphs: &crate::codewriter::call::GraphStore,
-    unsafe_fn_stubs: &[(Vec<String>, Signature, LowLevelType)],
+    unsafe_fn_stubs: &[(Vec<String>, Signature, Option<String>)],
     foreign_opaque_method_externals: &[(Vec<String>, Signature, crate::model::ValueType)],
     registry: &PyreCallRegistry,
 ) -> Result<(), TyperError> {
@@ -1723,61 +1723,15 @@ pub(crate) fn populate_call_registry_from_call_graphs(
         // (the `ExtRegistryEntry.compute_result_annotation` shape) so
         // callers annotate the declared result and the codewriter emits
         // the residual call via the fn's registered C ABI address
-        // (`pyre/jit_fnaddr.rs`).  The FUNC.RESULT token is the
-        // canonical spelling `front::mir::dont_look_inside_return_token`
-        // stamps from the callee's return `ValueType`.  Scalar tokens
-        // decode to their primitive lltype (`getkind` equals the legacy
-        // walker's `valuetype_to_concrete(result_ty)`).
-        //
-        // The `ref` token (a non-`*mut PyObject` heap result — e.g. a
-        // `*mut BigInt`) carries a classdef-less `SomeInstance` result
-        // shell (`valuetype_to_someshell(Ref(None))`), NOT a
-        // `SomePtr(GCREF)`.  A residual result is an annotation-stage
-        // value; the annotation-stage projection of every `Ref` is the
-        // classdef-less `SomeInstance` (`annotation_state.rs` doc-table),
-        // with `SomePtr` reserved for a producer writing
-        // `Variable.annotation` at the rtyper stage.  Emitting a
-        // `SomePtr(GCREF)` here made the result collide with the
-        // `SomeInstance(None)` an ordinary `Ref` merge partner carries
-        // (`_ptr ∪ <other>` UnionError in `mergeinputargs`, the union
-        // has no `SomePtr ∪ SomeInstance` arm).  The `SomeInstance(None)`
-        // shell unions cleanly (the classdef-less widen arm) and is the
-        // same shell the sibling `register_foreign_opaque_method_externals`
-        // path already gives a `BigInt`-returning method residual.  Both
-        // spellings rtype to `getkind = GcRef`, so the emitted
-        // `residual_call_*_r` opcode and C ABI are byte-identical.
-        //
-        // The object-pointer marker (`OBJECTPTR_RETURN_TYPE`, stamped by
-        // `merge_hints_from_llbcs` for a `*mut PyObject`-returning opaque
-        // callee the front-end left untokened) keeps the typed `OBJECTPTR`
-        // lltype so a caller reading the returned object's fields rtypes
-        // against the real struct.  An unrecognized token (none currently
-        // emitted) falls through to the normal lift.
+        // (`pyre/jit_fnaddr.rs`).  The FUNC.RESULT token is the canonical
+        // spelling `front::mir::dont_look_inside_return_token` stamps from
+        // the callee's return `ValueType`; [`residual_return_shell`]
+        // decodes it.  A token it declines falls through to the normal
+        // lift.
         let residualize = graph.hints.iter().any(|h| h == "dont_look_inside")
             || graph.hints.iter().any(|h| h == "elidable");
         if residualize {
-            let result_shell = match graph.return_type.as_deref() {
-                Some("ref") => Some(
-                    crate::codewriter::annotation_state::valuetype_to_someshell(
-                        &crate::model::ValueType::Ref(None),
-                    )
-                    .expect("Ref(None) shells to a definite SomeInstance"),
-                ),
-                token => {
-                    let return_lltype = match token {
-                        None | Some("()") => Some(LowLevelType::Void),
-                        Some("bool") => Some(LowLevelType::Bool),
-                        Some("i64") => Some(LowLevelType::Signed),
-                        Some("u64") => Some(LowLevelType::Unsigned),
-                        Some("f64") => Some(LowLevelType::Float),
-                        Some(s) if s == OBJECTPTR_RETURN_TYPE => {
-                            Some(crate::translator::rtyper::rclass::OBJECTPTR.clone())
-                        }
-                        _ => None,
-                    };
-                    return_lltype.and_then(|ll| default_someshell_for_lltype(&ll))
-                }
-            };
+            let result_shell = residual_return_shell(graph.return_type.as_deref());
             if let Some(result_shell) = result_shell {
                 let stub = build_stub_pygraph_with_result_shell(
                     graph.name.clone(),
@@ -1937,12 +1891,12 @@ pub(crate) fn lift_callee_to_pygraph(
 }
 
 /// Synthesize a minimal flowed `PyGraph` for a
-/// callee whose real body cannot be lowered through the adapter
-/// (`unsafe fn` in `pyre-object` / `pyre-interpreter`).  The stub has
-/// a single Link from `startblock` to `returnblock` carrying a
-/// pre-annotated `Variable` so the annotator's `flowin` projects the
-/// callsite result to the declared return type without touching the
-/// (non-modellable) body.
+/// callee declared by a `LowLevelType` result rather than a
+/// `SomeValue` shell — the static [`FOREIGN_STDLIB_EXTERNALS`] table.
+/// The stub has a single Link from `startblock` to `returnblock`
+/// carrying a pre-annotated `Variable` so the annotator's `flowin`
+/// projects the callsite result to the declared return type without
+/// touching the (non-modellable) body.
 ///
 /// `name` becomes the synthetic graph's `FunctionGraph.name`.
 /// `signature.argnames` are turned into named `Variable`s on the
@@ -1974,7 +1928,7 @@ pub(crate) fn lift_callee_to_pygraph(
 /// where `pygraph` is hand-constructed without going through
 /// `build_flow`.  Pure constructor — no annotator / rtyper side
 /// effects.
-pub(crate) fn build_stub_pygraph_for_unsafe_fn(
+pub(crate) fn build_stub_pygraph_for_lltype(
     name: String,
     signature: Signature,
     return_lltype: LowLevelType,
@@ -1989,13 +1943,14 @@ pub(crate) fn build_stub_pygraph_for_unsafe_fn(
 
 /// Build an annotator-only stub PyGraph whose return Variable carries
 /// `return_someval` directly.  Shared core of
-/// [`build_stub_pygraph_for_unsafe_fn`] (which projects an lltype through
-/// [`default_someshell_for_lltype`]) and the foreign-opaque-method
-/// registration (which carries a `SomeValue` shell built from the
-/// method's faithful result `ValueType` — including the classdef-less
-/// `SomeInstance` that an lltype cannot express).  See
-/// [`build_stub_pygraph_for_unsafe_fn`] for the annotator-only carrier
-/// contract.
+/// [`build_stub_pygraph_for_lltype`] (which projects an lltype through
+/// [`default_someshell_for_lltype`]) and the two shell-carrying paths —
+/// the unsafe-fn / `dont_look_inside` residuals via
+/// [`residual_return_shell`], and the foreign-opaque-method
+/// registration built from the method's faithful result `ValueType`.
+/// Both carry the classdef-less `SomeInstance` that an lltype cannot
+/// express.  See [`build_stub_pygraph_for_lltype`] for the
+/// annotator-only carrier contract.
 fn build_stub_pygraph_with_result_shell(
     name: String,
     signature: Signature,
@@ -2033,7 +1988,7 @@ fn build_stub_pygraph_with_result_shell(
 
 /// Project a `LowLevelType` to a `SomeValue` shell suitable for
 /// pre-annotating the stub-graph return Variable
-/// ([`build_stub_pygraph_for_unsafe_fn`]).
+/// ([`build_stub_pygraph_for_lltype`]).
 ///
 /// Delegates to
 /// [`crate::translator::rtyper::llannotation::lltype_to_annotation`]
@@ -2065,9 +2020,70 @@ pub(crate) fn default_someshell_for_lltype(
     }
 }
 
+/// Decode a residual callee's FUNC.RESULT token into the `SomeValue` shell
+/// its stub graph returns, or `None` when the token is one this path cannot
+/// model faithfully.
+///
+/// The token is the canonical spelling
+/// [`crate::front::mir::dont_look_inside_return_token`] stamps from the
+/// callee's return `ValueType`.  Scalar tokens decode to their primitive
+/// lltype (`getkind` equals the legacy walker's
+/// `valuetype_to_concrete(result_ty)`).
+///
+/// The `ref` token (a non-`*mut PyObject` heap result — e.g. a `*mut BigInt`,
+/// or the one-word success payload of a `Result<_, PyError>`) carries a
+/// classdef-less `SomeInstance` shell (`valuetype_to_someshell(Ref(None))`),
+/// NOT a `SomePtr(GCREF)`.  A residual result is an annotation-stage value;
+/// the annotation-stage projection of every `Ref` is the classdef-less
+/// `SomeInstance` (`annotation_state.rs` doc-table), with `SomePtr` reserved
+/// for a producer writing `Variable.annotation` at the rtyper stage.
+/// Emitting a `SomePtr(GCREF)` here made the result collide with the
+/// `SomeInstance(None)` an ordinary `Ref` merge partner carries (`_ptr ∪
+/// <other>` UnionError in `mergeinputargs`, the union has no `SomePtr ∪
+/// SomeInstance` arm).  The `SomeInstance(None)` shell unions cleanly (the
+/// classdef-less widen arm) and is the same shell the sibling
+/// [`register_foreign_opaque_method_externals`] path already gives a
+/// `BigInt`-returning method residual.  Both spellings rtype to `getkind =
+/// GcRef`, so the emitted `residual_call_*_r` opcode and C ABI are
+/// byte-identical.
+///
+/// The object-pointer marker (`OBJECTPTR_RETURN_TYPE`, stamped by
+/// `merge_hints_from_llbcs` for a `*mut PyObject`-returning opaque callee the
+/// front-end left untokened) keeps the typed `OBJECTPTR` lltype so a caller
+/// reading the returned object's fields rtypes against the real struct.
+///
+/// `i128` / `u128` are deliberately declined: they have no `getkind` at the
+/// codewriter boundary (`history.getkind` rejects `SignedLongLongLong`, 16
+/// bytes), so a caller annotating one would only reach a deeper wall.
+pub(crate) fn residual_return_shell(
+    token: Option<&str>,
+) -> Option<crate::annotator::model::SomeValue> {
+    if token == Some("ref") {
+        return Some(
+            crate::codewriter::annotation_state::valuetype_to_someshell(
+                &crate::model::ValueType::Ref(None),
+            )
+            .expect("Ref(None) shells to a definite SomeInstance"),
+        );
+    }
+    let return_lltype = match token {
+        None | Some("()") => Some(LowLevelType::Void),
+        Some("bool") => Some(LowLevelType::Bool),
+        Some("i64") => Some(LowLevelType::Signed),
+        Some("u64") => Some(LowLevelType::Unsigned),
+        Some("f64") => Some(LowLevelType::Float),
+        Some(s) if s == OBJECTPTR_RETURN_TYPE => {
+            Some(crate::translator::rtyper::rclass::OBJECTPTR.clone())
+        }
+        _ => None,
+    };
+    return_lltype.and_then(|ll| default_someshell_for_lltype(&ll))
+}
+
 /// Register a batch of unsafe-fn stub
-/// `(segments, signature, return_lltype)` specs into `registry`.
-/// Each entry is wrapped through [`build_stub_pygraph_for_unsafe_fn`]
+/// `(segments, signature, FUNC.RESULT token)` specs into `registry`.
+/// Each entry is wrapped through [`residual_return_shell`] +
+/// [`build_stub_pygraph_with_result_shell`]
 /// + [`PyreCallRegistry::register_callee`], so subsequent
 /// `flowspace_adapter::translate_op` lookups via
 /// `call_registry.lookup_with_leaf_match` find a registered entry and
@@ -2076,8 +2092,8 @@ pub(crate) fn default_someshell_for_lltype(
 ///
 /// `specs` is typically the output of
 /// `front::mir::collect_unsafe_fn_stubs_from_llbc` (the Charon/LLBC-
-/// sourced stub-spec list).  Per-fn failures (stub-pygraph builder returns
-/// `None` for compound lltypes, or registry already has the same key
+/// sourced stub-spec list).  Per-fn failures ([`residual_return_shell`]
+/// declines the token, or registry already has the same key
 /// at a conflicting signature) propagate as silent skips — the
 /// upstream "not registered" Skip path then absorbs that specific fn
 /// while the rest of the batch lands.
@@ -2090,8 +2106,8 @@ pub(crate) fn default_someshell_for_lltype(
 /// unsafe fns by validate_signature rejection).
 ///
 /// **Annotator-only carrier — never reaches the codewriter.**
-/// The stub graph carries a single default-Constant return link
-/// suitable for `RPythonAnnotator` return-type inference via
+/// The stub graph carries a single return link holding a pre-annotated
+/// Variable, suitable for `RPythonAnnotator` return-type inference via
 /// `cachedgraph` (see `pyre_call_registry::prefill_default_cache`).
 /// Because `CallControl::function_graphs` is populated exclusively
 /// by lowered safe-fn bodies (unsafe fns never produce a flow graph —
@@ -2106,21 +2122,22 @@ pub(crate) fn default_someshell_for_lltype(
 /// into executable JITCode.  The actual unsafe-fn body executes
 /// through the residual-call / direct-call fnaddr lowering that
 /// the codewriter emits for the call op whose target resolves
-/// to the host-evaluator entry point.  The default-Constant return is
+/// to the host-evaluator entry point.  The synthetic return shell is
 /// safe by virtue of the `function_graphs` gate, not by any
 /// `look_inside_graph` policy on the stub itself.
 pub(crate) fn register_unsafe_fn_stubs(
     registry: &PyreCallRegistry,
-    specs: &[(Vec<String>, Signature, LowLevelType)],
+    specs: &[(Vec<String>, Signature, Option<String>)],
 ) {
-    for (segments, signature, return_lltype) in specs {
-        let Some(stub_pygraph) = build_stub_pygraph_for_unsafe_fn(
-            segments.last().cloned().unwrap_or_default(),
-            signature.clone(),
-            return_lltype.clone(),
-        ) else {
+    for (segments, signature, return_token) in specs {
+        let Some(result_shell) = residual_return_shell(return_token.as_deref()) else {
             continue;
         };
+        let stub_pygraph = build_stub_pygraph_with_result_shell(
+            segments.last().cloned().unwrap_or_default(),
+            signature.clone(),
+            result_shell,
+        );
         let key = FunctionPathKey::from_segments(segments.iter().cloned());
         if registry.lookup(&key).is_some() {
             // Already registered via the function_graphs pass (e.g. a
@@ -2247,7 +2264,7 @@ pub(crate) fn register_foreign_stdlib_externals(registry: &PyreCallRegistry) {
             None,
             None,
         );
-        let Some(stub_pygraph) = build_stub_pygraph_for_unsafe_fn(
+        let Some(stub_pygraph) = build_stub_pygraph_for_lltype(
             segments.last().copied().unwrap_or_default().to_string(),
             signature.clone(),
             return_lltype.clone(),
@@ -4632,12 +4649,9 @@ mod tests {
     fn build_stub_pygraph_carries_signature_and_links_to_returnblock() {
         use crate::annotator::model::SomeValue;
         let sig = Signature::new(vec!["obj".to_string()], None, None);
-        let pygraph = build_stub_pygraph_for_unsafe_fn(
-            "is_none".to_string(),
-            sig.clone(),
-            LowLevelType::Bool,
-        )
-        .expect("Bool return must produce a stub pygraph");
+        let pygraph =
+            build_stub_pygraph_for_lltype("is_none".to_string(), sig.clone(), LowLevelType::Bool)
+                .expect("Bool return must produce a stub pygraph");
         assert_eq!(*pygraph.signature.borrow(), sig);
         let graph = pygraph.graph.borrow();
         assert_eq!(graph.name, "is_none");
@@ -4695,28 +4709,27 @@ mod tests {
             (
                 vec!["pyobject".to_string(), "is_none".to_string()],
                 Signature::new(vec!["obj".to_string()], None, None),
-                LowLevelType::Bool,
+                Some("bool".to_string()),
             ),
             (
                 vec!["pyobject".to_string(), "is_int".to_string()],
                 Signature::new(vec!["obj".to_string()], None, None),
-                LowLevelType::Bool,
+                Some("bool".to_string()),
             ),
-            // Compound lltype — the stub-pygraph builder returns None
-            // and register_unsafe_fn_stubs must skip.
+            // A token `residual_return_shell` declines — 128-bit has no
+            // `getkind` at the codewriter boundary — so
+            // register_unsafe_fn_stubs must skip.
             (
                 vec!["pyobject".to_string(), "unsupported".to_string()],
                 Signature::new(vec!["x".to_string()], None, None),
-                LowLevelType::Struct(Box::new(
-                    crate::translator::rtyper::lltypesystem::lltype::Struct::new("S", vec![]),
-                )),
+                Some("i128".to_string()),
             ),
         ];
         register_unsafe_fn_stubs(&registry, &specs);
         assert_eq!(
             registry.len(),
             2,
-            "compound-return spec must be skipped, others registered"
+            "undecodable-return spec must be skipped, others registered"
         );
         assert!(
             registry
@@ -4756,7 +4769,7 @@ mod tests {
         callcontrol.unsafe_fn_stubs = vec![(
             vec!["pyobject".to_string(), "is_none".to_string()],
             Signature::new(vec!["obj".to_string()], None, None),
-            LowLevelType::Bool,
+            Some("bool".to_string()),
         )];
         let bk = std::rc::Rc::new(Bookkeeper::new());
         let registry = PyreCallRegistry::new(bk);
@@ -4797,7 +4810,7 @@ mod tests {
         let specs = vec![(
             vec!["pyobject".to_string(), "shared".to_string()],
             signature,
-            LowLevelType::Bool,
+            Some("bool".to_string()),
         )];
         register_unsafe_fn_stubs(&registry, &specs);
         assert_eq!(registry.len(), 1, "no new entry expected");
@@ -4820,7 +4833,7 @@ mod tests {
                 result: LowLevelType::Void,
             },
         ));
-        let result = build_stub_pygraph_for_unsafe_fn("synth".to_string(), sig, func_ll);
+        let result = build_stub_pygraph_for_lltype("synth".to_string(), sig, func_ll);
         assert!(result.is_none(), "Func lltype must surface as None");
     }
 }

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -6203,6 +6203,12 @@ fn register_exc_class(name: &'static str, cls: PyObjectRef) -> PyObjectRef {
 /// Look up a builtin exception class by its `ExcKind` name. Returns
 /// `None` if the registry hasn't been populated yet (e.g. before
 /// install_default_builtins).
+/// Reads the runtime-populated `EXC_CLASS_REGISTRY` `OnceLock`, not a
+/// build-time constant, so the JIT residualizes the call instead of tracing
+/// into it (`@dont_look_inside`). The scalar-`Option<PyObjectRef>` result is
+/// the same residual boundary shape as
+/// `baseobjspace::lookup_in_type_where_uncached`.
+#[majit_macros::dont_look_inside]
 pub fn lookup_exc_class(name: &str) -> Option<PyObjectRef> {
     let registry = EXC_CLASS_REGISTRY.get()?;
     let registry = registry

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -929,6 +929,12 @@ thread_local! {
 /// keeps it (and its traceback chain) alive across a collection. Called from
 /// `record_application_traceback`, the single chokepoint every raising frame
 /// passes through.
+///
+/// Writes the runtime-mutable `IN_FLIGHT_EXCEPTION` thread-local, not a
+/// build-time constant, so the JIT residualizes the call instead of tracing
+/// into it (`@dont_look_inside`, the `gc_interp::at_outermost_activation`
+/// shape). One single-word argument, `()` result, and it cannot raise.
+#[majit_macros::dont_look_inside]
 pub fn set_in_flight_exception(exc: PyObjectRef) {
     IN_FLIGHT_EXCEPTION.with(|c| c.set(exc));
 }

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -1399,7 +1399,7 @@ pub(crate) fn check_sys_modules(name: &str) -> Option<PyObjectRef> {
     // writing `sys.modules['foo'] = mod` is immediately visible to imports.
     // PyPy: importing.py check_sys_modules reads space.sys.get('modules').
     let key = pyre_object::w_str_new(name);
-    let dict = SYS_MODULES_DICT.load(Ordering::Acquire) as PyObjectRef;
+    let dict = sys_modules_dict();
     if !dict.is_null() {
         if let Some(m) = unsafe { pyre_object::w_dict_lookup(dict, key) } {
             if !m.is_null() && !unsafe { pyre_object::is_none(m) } {
@@ -1428,7 +1428,7 @@ fn sys_modules_blocks(name: &str) -> bool {
     // uses: reading the thread-local last keeps the borrow off the stack
     // across the allocation.
     let key = pyre_object::w_str_new(name);
-    let dict = SYS_MODULES_DICT.load(Ordering::Acquire) as PyObjectRef;
+    let dict = sys_modules_dict();
     if dict.is_null() {
         return false;
     }
@@ -1446,7 +1446,14 @@ pub fn get_sys_module(name: &str) -> Option<PyObjectRef> {
 
 /// The Python-visible `sys.modules` dict, or `PY_NULL` before it is
 /// installed. Used by callers that need to iterate every loaded module
-/// (e.g. pickle's `whichmodule` scan).
+/// (e.g. pickle's `whichmodule` scan), and the single read seam every
+/// traced reader of `SYS_MODULES_DICT` goes through.
+///
+/// The pointer is stamped at runtime by `set_sys_modules_dict`, so it is not
+/// a build-time constant and the JIT residualizes the read instead of
+/// tracing into it (`@dont_look_inside`, the `gc_interp::enabled` shape).
+/// The `-> PyObjectRef` return fits a single word and it cannot raise.
+#[majit_macros::dont_look_inside]
 pub fn sys_modules_dict() -> PyObjectRef {
     SYS_MODULES_DICT.load(Ordering::Acquire) as PyObjectRef
 }
@@ -1460,7 +1467,7 @@ pub fn set_sys_module(name: &str, module: PyObjectRef) {
         .unwrap()
         .insert(name.to_string(), module as usize);
     // Keep the Python-visible sys.modules dict in sync.
-    let dict = SYS_MODULES_DICT.load(Ordering::Acquire) as PyObjectRef;
+    let dict = sys_modules_dict();
     if !dict.is_null() {
         unsafe {
             pyre_object::w_dict_store(dict, pyre_object::w_str_new(name), module);
@@ -1477,7 +1484,7 @@ pub fn set_sys_module(name: &str, module: PyObjectRef) {
 /// the next `import ssl` succeeds with no `SSLWantReadError`, etc.
 pub fn remove_sys_module(name: &str) {
     SYS_MODULES.lock().unwrap().remove(name);
-    let dict = SYS_MODULES_DICT.load(Ordering::Acquire) as PyObjectRef;
+    let dict = sys_modules_dict();
     if !dict.is_null() {
         unsafe {
             pyre_object::w_dict_delitem_str(dict, name);

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -935,7 +935,11 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         "pyre_interpreter::lookup_exc_class",
         lookup_exc_class as *const (),
     );
-    #[cfg(unix)]
+    // `mmap_type` is `#[cfg(unix)]` inside `interp_mmap`, and the `mmap`
+    // module itself is gated at `module/mod.rs:80`; the row has to carry
+    // both or a sandbox build on Linux satisfies `unix` with the module
+    // configured out.
+    #[cfg(all(unix, not(target_arch = "wasm32"), not(feature = "sandbox")))]
     {
         let mmap_type: fn() -> pyre_object::PyObjectRef =
             crate::module::mmap::interp_mmap::mmap_type;

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -902,6 +902,62 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         "pyre_object::dict_view_iterator_gc_type_id",
         pyre_object::dictmultiobject::dict_view_iterator_gc_type_id as *const (),
     );
+    // The same shape over the object space's remaining runtime-mutable
+    // globals: `sys_modules_dict` reads the `SYS_MODULES_DICT` pointer
+    // `set_sys_modules_dict` stamps, `set_in_flight_exception` writes the
+    // `IN_FLIGHT_EXCEPTION` thread-local, `lookup_exc_class` reads the
+    // `EXC_CLASS_REGISTRY` `OnceLock`, `mmap_type` the lazily-installed
+    // `mmap` type object, and the two `note_eval_activation_*` twins move the
+    // `EVAL_NESTING` thread-local `at_outermost_activation` already reads.
+    // None is a build-time constant, so each carries `#[dont_look_inside]`
+    // and binds its Rust `fn` directly by qualified path rather than taking a
+    // `jit_static_*_addrs` address row.
+    let sys_modules_dict: fn() -> pyre_object::PyObjectRef = crate::importing::sys_modules_dict;
+    push_alias_pair(
+        &mut entries,
+        "pyre_interpreter::importing::sys_modules_dict",
+        "pyre_interpreter::sys_modules_dict",
+        sys_modules_dict as *const (),
+    );
+    let set_in_flight_exception: fn(pyre_object::PyObjectRef) =
+        crate::eval::set_in_flight_exception;
+    push_alias_pair(
+        &mut entries,
+        "pyre_interpreter::eval::set_in_flight_exception",
+        "pyre_interpreter::set_in_flight_exception",
+        set_in_flight_exception as *const (),
+    );
+    let lookup_exc_class: fn(&str) -> Option<pyre_object::PyObjectRef> =
+        crate::builtins::lookup_exc_class;
+    push_alias_pair(
+        &mut entries,
+        "pyre_interpreter::builtins::lookup_exc_class",
+        "pyre_interpreter::lookup_exc_class",
+        lookup_exc_class as *const (),
+    );
+    #[cfg(unix)]
+    {
+        let mmap_type: fn() -> pyre_object::PyObjectRef =
+            crate::module::mmap::interp_mmap::mmap_type;
+        push_alias_pair(
+            &mut entries,
+            "pyre_interpreter::module::mmap::interp_mmap::mmap_type",
+            "pyre_interpreter::mmap_type",
+            mmap_type as *const (),
+        );
+    }
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::gc_interp::note_eval_activation_enter",
+        "pyre_object::note_eval_activation_enter",
+        pyre_object::gc_interp::note_eval_activation_enter as *const (),
+    );
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::gc_interp::note_eval_activation_exit",
+        "pyre_object::note_eval_activation_exit",
+        pyre_object::gc_interp::note_eval_activation_exit as *const (),
+    );
     // The dispatch-loop safepoint's four toucher residuals plus the frame-entry
     // odometer bump and the items-block strategy gate: each reads a
     // runtime-mutable global (`COLLECT_STATE` / `EVAL_NESTING` atomics, the two

--- a/pyre/pyre-interpreter/src/module/mmap/interp_mmap.rs
+++ b/pyre/pyre-interpreter/src/module/mmap/interp_mmap.rs
@@ -88,8 +88,13 @@ fn mmap_io_err(e: std::io::Error, ctx: &str) -> crate::PyError {
 #[cfg(unix)]
 static MMAP_TYPE_OBJ: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
 
+/// Reads (and lazily installs) the runtime-assigned `mmap` type object, not a
+/// build-time constant, so the JIT residualizes the call instead of tracing
+/// into it (`@dont_look_inside`, the `gc_interp::enabled` shape). The
+/// `-> PyObjectRef` return fits a single word and it cannot raise.
 #[cfg(unix)]
-fn mmap_type() -> pyre_object::PyObjectRef {
+#[majit_macros::dont_look_inside]
+pub(crate) fn mmap_type() -> pyre_object::PyObjectRef {
     *MMAP_TYPE_OBJ.get_or_init(|| {
         let tp = crate::typedef::make_builtin_type("mmap", init_mmap_type);
         unsafe { pyre_object::typeobject::w_type_set_hasdict(tp, true) };

--- a/pyre/pyre-object/src/gc_interp.rs
+++ b/pyre/pyre-object/src/gc_interp.rs
@@ -53,12 +53,30 @@ pub struct EvalActivationGuard {
     armed: bool,
 }
 
+/// Count one eval-loop activation on this thread.
+///
+/// Writes the runtime-mutable `EVAL_NESTING` thread-local, not a build-time
+/// constant, so the JIT residualizes the call instead of tracing into it
+/// (`@dont_look_inside`, the [`at_outermost_activation`] sibling). No
+/// arguments, `()` result, and it cannot raise.
+#[majit_macros::dont_look_inside]
+pub fn note_eval_activation_enter() {
+    EVAL_NESTING.with(|d| d.set(d.get() + 1));
+}
+
+/// Rewind one eval-loop activation. The [`note_eval_activation_enter`] twin;
+/// same residual contract.
+#[majit_macros::dont_look_inside]
+pub fn note_eval_activation_exit() {
+    EVAL_NESTING.with(|d| d.set(d.get().saturating_sub(1)));
+}
+
 impl EvalActivationGuard {
     #[inline]
     pub fn enter() -> Self {
         let armed = enabled();
         if armed {
-            EVAL_NESTING.with(|d| d.set(d.get() + 1));
+            note_eval_activation_enter();
         }
         Self { armed }
     }
@@ -68,7 +86,7 @@ impl Drop for EvalActivationGuard {
     #[inline]
     fn drop(&mut self) {
         if self.armed {
-            EVAL_NESTING.with(|d| d.set(d.get().saturating_sub(1)));
+            note_eval_activation_exit();
         }
     }
 }


### PR DESCRIPTION
Six commits: three on descr widths (a sweep, the regression it introduced,
and a pre-existing gap the review surfaced next to it), two census slices, and
the ABI gate the review caught on the first of those slices.

## 1. `aef5265234` — take the remaining descr widths from the target

Completeness pass over the class #817 opened: a target-dependent width spelled
as the literal `8`. A no-op on the 64-bit backends; wrong on wasm32, where
`usize` and every pointer are 4 bytes. This classifies every remaining
`field_size: 8` / `itemsize: 8` / `unwrap_or(8)` literal in the tree against
its file's first top-level `#[cfg(test)]` and derives the eight that turned
out to be production code.

| crate | runs | word source |
| --- | --- | --- |
| `majit-metainterp` | compiled into the wasm guest | `size_of::<usize>()` |
| `majit-translate` | build-time prepass **on the host** | `layout::target_word_size()` (`CARGO_CFG_TARGET_POINTER_WIDTH`) |

Getting this backwards silently bakes the host's 8. The dynasm x86/aarch64
assemblers keep their `unwrap_or(8)` — those backends are 64-bit by
construction.

## 2. `a4e057499b` — ⚠️ and the part of that sweep which was wrong

**Codex flagged this as a P1 and was right.** The sweep's `scalar_size` mapped
every non-float `majit_ir::value::Type` to the target word, so on wasm32 an
integer field or array item got width 4.

`Type::Int` names the interpreter's integer **bank**, not a word-sized storage
class. The storage a descr describes is the *source declaration*:

- a `jit_interp` `[int; virt]` array is backed by the caller's `Vec<i64>`
  (`majit/examples/spcount/src/main.rs:96`)
- an `int` struct field by an `i64`
  (`majit-metainterp/tests/jit_interp_inline_helper_typed_return.rs:57`)

The wasm backend picks its load width from that size
(`majit-backend-wasm codegen.rs emit_sized_int_load`), so it would stride 4
bytes through 8-byte items and truncate. Invisible on x86-64/aarch64, where
the word *is* 8 — which is why check.py stayed green.

Only `Ref` is provably a pointer, and the `ITEMS_BLOCK_TOKEN` argument written
to justify `add_vable_array_descr` only ever covered the `[ref; virt]` case.
`scalar_size` now answers `size_of::<usize>()` for `Ref` and
`size_of::<i64>()` otherwise; it becomes `pub(crate)` so the two sibling sites
the sweep converted (`optimizeopt/mod.rs`'s `visit_virtual` / `visit_vstruct`
fallbacks and `pyjitpl/dispatch.rs`'s `struct_fields_write_effect_info`) use
the one rule rather than a second copy of it.

**The discriminator for the next sweep:** a width may follow the target word
only where the seam can see that the source type is a pointer or an
`isize`/`usize`. `majit-translate`'s `type_flag_from_str` /
`value_type_to_itemsize` are unaffected because they key on the source *type
spelling*; `majit-metainterp`'s `scalar_size` was wrong because a bank `Type`
carries no spelling.

## 3. `84c2688814` — the no-layout field fallback

Surfaced by the Codex parity review's section 3, adjacent to the above.
`fallback_field_layout` seeds `fielddescrof` before a `BhSizeSpec` or
`StructLayout` overrides it, and disagreed with its spelling-keyed twin
`type_flag_from_str` on two points:

- `ValueType::Bool` fell through the wildcard to 8 bytes. `lltype.Bool` is one
  byte (`descr.py:223` reads the real size from `symbolic.get_field_token`)
  and so is a Rust `bool`; the twin already answers 1 for `"u8" | "bool"`.
- the flag came from `ArrayFlag::from_field_type`, which reads the descriptor
  IR type — and that type collapses `Bool` / `Unsigned` onto `Type::Int` to
  track the register class, so every unsigned field was described as `Signed`.
  A new `value_type_to_field_flag` reads signedness off the `ValueType`.

## 4. `2d7ccb4d16` — one residual result-shell decoder

`collect_unsafe_fn_stubs_from_llbc` projected an `unsafe fn`'s return through
a local `match { "()" => Void, "bool" => Bool, _ => continue }`, so every
other return type was dropped, the fn never reached `PyreCallRegistry`, and
its callers' lifts failed with *"not registered"*.

`residual_return_shell` is extracted out of the `dont_look_inside` /
`elidable` path and shared with the collector, which now projects through
`dont_look_inside_return_token`. An `unsafe fn` is never lowered
(`build_flow.rs:215` rejects `sig.unsafety`), so it is already residual and
registration only changes whether the *caller* can annotate past the call — a
test pins that the stub never enters `CallControl::function_graphs`.

Census A/B, freshly re-extracted corpus: the root
`baseobjspace::generator_invoke_execute_frame` goes 25 → **0**, distinct roots
56 → 53. Records are near-neutral (phaseA 324 → 323, phaseB 25 → 26): 23 of
the 25 freed graphs re-root one wall deeper at
`core::num::<Impl>::saturating_sub`. Budget these slices at *roots cleared*,
not records.

## 5. `886e543e52` — residualize five runtime-mutable global reads

Each static is stamped at runtime, so it is not a build-time constant and the
front-end must not trace into the read. Each reader now carries
`#[majit_macros::dont_look_inside]` and binds its `fn` by qualified path via
`jit_fnaddr`'s `push_alias_pair` — the `gc_interp::enabled` /
`bigint_gc_type_id` / `dict_view_iterator_gc_type_id` shape. None takes a
`jit_static_*_addrs` address row: those carry an address fixed at build time.

- `importing::sys_modules_dict` — the four pure `SYS_MODULES_DICT` reads go
  through it instead of loading the atomic inline, making it the single read
  seam. The read-modify-write walkers keep the atomic.
- `eval::set_in_flight_exception` — writes the `IN_FLIGHT_EXCEPTION` TLS
- `builtins::lookup_exc_class` — reads the `EXC_CLASS_REGISTRY` `OnceLock`
- `module::mmap::interp_mmap::mmap_type`
- `gc_interp::note_eval_activation_{enter,exit}` — new leaf twins holding the
  `EVAL_NESTING` bump `EvalActivationGuard::enter` / `drop` did inline

| root | before | after |
| --- | --- | --- |
| `SYS_MODULES_DICT` | 12 | **0** |
| `IN_FLIGHT_EXCEPTION` | 3 | **0** |
| `EVAL_NESTING` | 2 | **0** |
| `EXC_CLASS_REGISTRY` | 2 | **0** |
| `MMAP_TYPE_OBJ` | 2 | **0** |
| `__dyn_call` (absorber) | 39 | 52 |

phaseA 323 → 317, phaseB 26 → 24, distinct roots 53 → 49. Thirteen of the
freed graphs re-root at `__dyn_call`, the wall that is sequencing-locked on
Vec/IndexMap, so the record gain is again much smaller than the roots cleared.
One new root appears — `module::thread::FINALIZING`, a member of the same
class that was invisible until these walls came down.

Left alone on purpose: `call::CALL_DEPTH` (13) and
`sys::state::RECURSION_LIMIT` (2) are both read inside `stack_check()`'s
per-call recursion test (`stack_check.rs:545`), so they need a perf A/B of
their own; `module::thread::TRACE_ALL_GENERATION` (2) because
`apply_all_thread_hooks` reads `PROFILE_ALL_GENERATION` and two
`Mutex<usize>` hooks in the same body, so the wall regenerates one line later.

## 6. `82ffc28489` — and the second thing the review caught

`dont_look_inside_return_token` maps every non-`*mut PyObject` ADT to the
`ref` token (`tyref_to_value_type` falls a non-primitive shape back to
`ValueType::Ref(None)`, `front/mir.rs:12642`), and `residual_return_shell`
gives that token a **one-word** `SomeInstance` shell. So routing the collector
through the same projection also admitted by-value aggregates:
`pyre_object::tupleobject::w_tuple_items_copy_as_vec:345` returns
`Vec<PyObjectRef>` — three words through `sret` — and is called from traced
`opcode_ops.rs match_keys_value`.

The hand-written `Vec`-returning residuals (`compute_mro`,
`memoryview_gather_bytes`) work because each carries an explicit `jit_fnaddr`
`push_alias_pair` row arranging that ABI. A stub the collector mints has no
row, so the caller would annotate a one-word shell against a multiword return.

`ref_return_is_single_word` now gates the `ref` token on the
`tyref_to_ast_string` spelling that the token itself has erased: a raw pointer
passes, and so does `Result<T, PyError>` whose `Ok` payload is one word — the
shape the exception bridge already gives a one-word ABI, and what `PyResult`
spells. `Vec<T>`, `String`, tuples, `Option<T>` and named ADTs by value are
declined and keep their "not registered" Skip.

⚠️ **A census A/B would not have caught this.** phaseA 317 / phaseB 24 and an
identical root ranking before and after, with
`generator_invoke_execute_frame` still at 0 so commit 4's win survives — and
neither the callee nor its caller appears in the census at all. The bad
registration *passed* annotation, which is exactly why it left no failure
record.

## Divergences deliberately left, with the reason at the site

**`type_flag_from_str` cannot be merged into `call.rs get_type_flag`.** It is a
near-duplicate of that authoritative table, but the two answer differently for
`f32`: `get_type_flag` follows `descr.py:254` and lands SingleFloat int-banked,
then restores the `'f'` width marker through `concrete_type` on the ArrayDescr
it builds — and `BhDescr::Array` has no `concrete_type` field to restore it
with. Merging is blocked on that field.

**`value_type_to_itemsize` keeps 8 for `Int` / `Unsigned`.** The MIR front-end
folds narrower *and* 64-bit Rust integers into both, so the width is genuinely
unknown at that seam. Over-reading inside a struct is recoverable; narrowing
an `i64` would truncate. Resolving it needs the front-end to carry the source
width.

**`scalar_align` is `field_size.min(8)`, not the target word.** That cap is the
target's *maximum scalar alignment*: `u64` / `f64` align to 8 on wasm32 even
though a pointer there is 4 bytes. Rewriting it to `target_word_size()` would
under-align every 8-byte field and shift the offsets the walker derives. It is
only the fallback — the exact `StructLayout` path overrides it whenever one is
available.

## Verification

`python3 pyre/check.py --backend dynasm,cranelift,wasm` — dynasm 326/326,
cranelift 326/326, wasm 323/323, all green; `cargo fmt --check`,
`cargo check --all --tests`, and the `wasm32-unknown-unknown` target check
clean.
