### PR TITLE
str: index a code point in O(1) via the rutf8 index storage; iterate bytes without unpacking

### DIFF
--- a/pyre/bench/synth/str_index_bytes_iter_surface.py
+++ b/pyre/bench/synth/str_index_bytes_iter_surface.py
@@ -2,17 +2,39 @@
 # payload width, and a slice keeps that indexing under negative and skipping
 # steps. bytes/bytearray iterate their live buffer as ordinals, so a bytearray
 # resized mid-loop is observed by the cursor rather than frozen at iter() time.
-# The warm loops run the ASCII subscript and the bytes cursor hot first so the
-# traced paths are the ones under test. Output verified against CPython/PyPy.
+# A non-ASCII payload resolves its subscript through a code point index table
+# built once per string, so `groups` walks strings long enough to span several
+# of its entries and folds every index, both signs, plus the stride and group
+# boundaries and slices crossing them, into one number per payload kind. A
+# wrong byte offset anywhere changes that number.
+# The warm loops run the ASCII and wide subscripts and the bytes cursor hot
+# first so the traced paths are the ones under test; `warm_wide` scatters its
+# reads over a long payload, so a regression to resolving each subscript by
+# walking the buffer costs orders of magnitude rather than staying flat.
+# Output verified against CPython/PyPy.
 ASCII = "abcdefghij"
 WIDE = "\xe9一\U0001f600ÿあ"
 MIXED = "a一b\U0001f600c"
+UNITS = ("\xe9\xe8\xea\xeb", "一二三四", "\U0001f600\U0001f601\U0001f602\U0001f603",
+         "a\xe9一\U0001f600")
 
 
 def warm_index(n):
     acc = 0
     for i in range(n):
         acc += ord(ASCII[i % 10])
+    return acc
+
+
+def warm_wide(n):
+    # Scattered reads over a payload far longer than one index-table entry
+    # covers, so resolving a subscript by walking the buffer costs thousands of
+    # steps apiece instead of a lookup.
+    s = UNITS[3] * 2048
+    m = len(s)
+    acc = 0
+    for i in range(n):
+        acc += ord(s[i * 7919 % m])
     return acc
 
 
@@ -25,6 +47,32 @@ def warm_bytes(n):
     return acc
 
 
+def fold(acc, s):
+    for ch in s:
+        acc = (acc * 31 + ord(ch)) & 0xFFFFFFFF
+    return acc
+
+
+def groups(unit):
+    acc = 0
+    for repeat in (16, 17, 64, 100):
+        s = unit * repeat
+        n = len(s)
+        for i in range(n):
+            acc = (acc * 31 + ord(s[i])) & 0xFFFFFFFF
+        for i in range(-n, 0):
+            acc = (acc * 31 + ord(s[i])) & 0xFFFFFFFF
+        # The 4-code-point delta stride and the 64-entry group edges, then
+        # slices that cross them in both directions.
+        for part in (s[0], s[63 % n], s[64 % n], s[n - 1],
+                     s[60:70], s[70:60:-1], s[::-3], s[1::7]):
+            acc = fold(acc, part)
+        # Iteration and reversal must agree with indexing.
+        assert [c for c in s] == [s[i] for i in range(n)]
+        assert list(reversed(s)) == [s[i] for i in range(n - 1, -1, -1)]
+    return acc
+
+
 def show(label, fn):
     try:
         print(label, "->", ascii(fn()))
@@ -34,6 +82,7 @@ def show(label, fn):
 
 def main():
     print("warm_index", warm_index(20000))
+    print("warm_wide", warm_wide(20000))
     print("warm_bytes", warm_bytes(400))
 
     for name, s in (("ascii", ASCII), ("wide", WIDE), ("mixed", MIXED)):
@@ -47,6 +96,9 @@ def main():
         show(f"{name}.iter", lambda s=s: list(iter(s)))
         show(f"{name}.for", lambda s=s: [c for c in s])
         show(f"{name}.rev", lambda s=s: list(reversed(s)))
+
+    for i, unit in enumerate(UNITS):
+        show(f"groups[{i}]", lambda u=unit: groups(u))
 
     show("bytes.iter", lambda: list(iter(b"abc")))
     show("bytes.for", lambda: [x for x in b"abc"])

--- a/pyre/bench/synth/str_index_bytes_iter_surface.py
+++ b/pyre/bench/synth/str_index_bytes_iter_surface.py
@@ -1,0 +1,78 @@
+# str subscripts resolve a code point index, not a byte offset, for every
+# payload width, and a slice keeps that indexing under negative and skipping
+# steps. bytes/bytearray iterate their live buffer as ordinals, so a bytearray
+# resized mid-loop is observed by the cursor rather than frozen at iter() time.
+# The warm loops run the ASCII subscript and the bytes cursor hot first so the
+# traced paths are the ones under test. Output verified against CPython/PyPy.
+ASCII = "abcdefghij"
+WIDE = "\xe9一\U0001f600ÿあ"
+MIXED = "a一b\U0001f600c"
+
+
+def warm_index(n):
+    acc = 0
+    for i in range(n):
+        acc += ord(ASCII[i % 10])
+    return acc
+
+
+def warm_bytes(n):
+    payload = bytes(range(64))
+    acc = 0
+    for _ in range(n):
+        for byte in payload:
+            acc += byte
+    return acc
+
+
+def show(label, fn):
+    try:
+        print(label, "->", ascii(fn()))
+    except BaseException as e:
+        print(label, "!!", type(e).__name__, ascii(str(e)))
+
+
+def main():
+    print("warm_index", warm_index(20000))
+    print("warm_bytes", warm_bytes(400))
+
+    for name, s in (("ascii", ASCII), ("wide", WIDE), ("mixed", MIXED)):
+        print(name, "len", len(s))
+        for i in range(-len(s), len(s)):
+            show(f"{name}[{i}]", lambda s=s, i=i: s[i])
+        show(f"{name}[oob]", lambda s=s: s[len(s)])
+        show(f"{name}[-oob]", lambda s=s: s[-len(s) - 1])
+        for sl in ((None, None, 2), (1, 4, None), (None, None, -1), (4, 0, -2), (-2, None, None)):
+            show(f"{name}[{sl}]", lambda s=s, sl=sl: s[slice(*sl)])
+        show(f"{name}.iter", lambda s=s: list(iter(s)))
+        show(f"{name}.for", lambda s=s: [c for c in s])
+        show(f"{name}.rev", lambda s=s: list(reversed(s)))
+
+    show("bytes.iter", lambda: list(iter(b"abc")))
+    show("bytes.for", lambda: [x for x in b"abc"])
+    show("bytearray.iter", lambda: list(iter(bytearray(b"abc"))))
+    show("bytes.empty", lambda: list(iter(b"")))
+
+    def grow():
+        buf = bytearray(b"abc")
+        seen = []
+        for x in buf:
+            seen.append(x)
+            if len(seen) == 1:
+                buf.append(100)
+        return seen
+
+    def shrink():
+        buf = bytearray(b"abcdef")
+        seen = []
+        for x in buf:
+            seen.append(x)
+            if len(seen) == 1:
+                del buf[2:]
+        return seen
+
+    show("bytearray.grow", grow)
+    show("bytearray.shrink", shrink)
+
+
+main()

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -2367,19 +2367,28 @@ pub(crate) fn list_reverse_iter_reduce_method(args: &[PyObjectRef]) -> PyResult 
     pyre_object::gc_roots::pin_root(callable);
     unsafe {
         let receiver = pyre_object::gc_roots::shadow_stack_get(sp);
+        // A spent cursor keeps its list so `__setstate__` can revive it, but
+        // still pickles as `reversed([])`, so the exhausted form is selected
+        // by the cursor rather than by a cleared sequence.
+        let index = pyre_object::w_list_reverse_iter_index(receiver);
+        let seq = if index < 0 {
+            PY_NULL
+        } else {
+            pyre_object::w_list_reverse_iter_seq(receiver)
+        };
         iterator_reduce_tuple(
             pyre_object::gc_roots::shadow_stack_get(sp + 1),
-            pyre_object::w_list_reverse_iter_seq(receiver),
-            pyre_object::w_list_reverse_iter_index(receiver),
+            seq,
+            index,
             2,
         )
     }
 }
 
-/// `list_reverseiterator.__setstate__(index)` — the descending cursor is
-/// clamped to the last valid index, and a negative cursor exhausts the
-/// iterator, which is the state `descr_next` leaves behind once it walks off
-/// the front.
+/// `list_reverseiterator.__setstate__(index)` — the cursor is clamped into
+/// `[-1, len - 1]`, where -1 is the exhausted state `descr_next` leaves behind
+/// once it walks off the front.  The list outlives exhaustion, so this restores
+/// a spent iterator to a live cursor as well.
 pub(crate) fn list_reverse_iter_setstate_method(args: &[PyObjectRef]) -> PyResult {
     let mut index = int_w(args[1])?;
     unsafe {
@@ -2387,13 +2396,10 @@ pub(crate) fn list_reverse_iter_setstate_method(args: &[PyObjectRef]) -> PyResul
         if seq.is_null() {
             return Ok(w_none());
         }
-        if index < 0 {
-            pyre_object::w_list_reverse_iter_set_index(args[0], -1);
-            pyre_object::w_list_reverse_iter_set_seq(args[0], PY_NULL);
-            return Ok(w_none());
-        }
         let length = pyre_object::w_list_len(seq) as i64;
-        if index >= length {
+        if index < -1 {
+            index = -1;
+        } else if index >= length {
             index = length - 1;
         }
         pyre_object::w_list_reverse_iter_set_index(args[0], index);
@@ -12230,8 +12236,9 @@ pub fn next(obj: PyObjectRef) -> PyResult {
                     return Ok(item);
                 }
             }
+            // The descending cursor alone marks exhaustion; the list stays
+            // referenced so `__setstate__` can put the cursor back on it.
             pyre_object::w_list_reverse_iter_set_index(obj, -1);
-            pyre_object::w_list_reverse_iter_set_seq(obj, PY_NULL);
             return Err(PyError::stop_iteration());
         }
         if pyre_object::is_tuple_iter(obj) {

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -1624,25 +1624,45 @@ unsafe fn getitem_str(obj: PyObjectRef, index: PyObjectRef) -> PyResult {
     // Index code points through the surrogate-aware WTF-8 view so a
     // surrogateescape / surrogatepass-decoded string can be sliced and
     // indexed without going through `w_str_get_value`.
-    let cps: Vec<CodePoint> = w_str_get_wtf8(obj).code_points().collect();
+    //
+    // `_index_to_byte` (`unicodeobject.py:1251`) reads an ASCII payload's byte
+    // at the code point index, so only a wide or surrogate-bearing string has
+    // to walk.  Upstream keeps that walk O(1) with a per-string
+    // `rutf8.create_utf8_index_storage` table; without one, walking it once
+    // per call beats walking it once per code point.
+    let ascii = pyre_object::w_str_is_ascii(obj);
+    let cps: Vec<CodePoint> = if ascii {
+        Vec::new()
+    } else {
+        w_str_get_wtf8(obj).code_points().collect()
+    };
+    let len = w_str_len(obj);
+    let at = |i: usize| -> Option<CodePoint> {
+        if ascii {
+            pyre_object::w_str_codepoint_at(obj, i)
+        } else {
+            cps.get(i).copied()
+        }
+    };
     if is_slice(index) {
         // `pypy/objspace/std/unicodeobject.py W_UnicodeObject._getitem_slice`
         // → `slice.indices(len)` (`pypy/objspace/std/sliceobject.py`).
         // Use the shared adjusted slice count so very large steps do not
         // overflow the index loop.
-        let len = cps.len() as i64;
         let (rs, rp, st) = crate::sliceobject::slice_unpack(
             w_slice_get_start(index),
             w_slice_get_stop(index),
             w_slice_get_step(index),
         )?;
         let (start, _stop, step, slicelength) =
-            crate::sliceobject::slice_adjust_indices(rs, rp, st, len);
+            crate::sliceobject::slice_adjust_indices(rs, rp, st, len as i64);
         let mut result = Wtf8Buf::new();
         let mut i = start;
         for n in 0..slicelength {
-            if i >= 0 && (i as usize) < cps.len() {
-                result.push(cps[i as usize]);
+            if i >= 0 {
+                if let Some(cp) = at(i as usize) {
+                    result.push(cp);
+                }
             }
             if n + 1 < slicelength {
                 i += step;
@@ -1678,11 +1698,13 @@ unsafe fn getitem_str(obj: PyObjectRef, index: PyObjectRef) -> PyResult {
     } else {
         return Err(string_index_type_error(index));
     };
-    let actual_idx = if idx < 0 { cps.len() as i64 + idx } else { idx } as usize;
-    if actual_idx < cps.len() {
-        let mut one = Wtf8Buf::new();
-        one.push(cps[actual_idx]);
-        return Ok(w_str_from_wtf8(one));
+    let actual_idx = if idx < 0 { len as i64 + idx } else { idx };
+    if actual_idx >= 0 {
+        if let Some(cp) = at(actual_idx as usize) {
+            let mut one = Wtf8Buf::new();
+            one.push(cp);
+            return Ok(w_str_from_wtf8(one));
+        }
     }
     Err(PyError::new(
         PyErrorKind::IndexError,
@@ -12246,19 +12268,11 @@ pub fn next(obj: PyObjectRef) -> PyResult {
                 // Box the idx-th code point as a one-character str,
                 // reading the WTF-8 view so a lone surrogate is yielded
                 // instead of panicking.
-                let s = w_str_get_wtf8(seq);
-                let mut found: Option<PyObjectRef> = None;
-                let mut n = 0i64;
-                for cp in s.code_points() {
-                    if n == idx {
-                        let mut one = Wtf8Buf::new();
-                        one.push(cp);
-                        found = Some(w_str_from_wtf8(one));
-                        break;
-                    }
-                    n += 1;
-                }
-                found
+                pyre_object::w_str_codepoint_at(seq, idx as usize).map(|cp| {
+                    let mut one = Wtf8Buf::new();
+                    one.push(cp);
+                    w_str_from_wtf8(one)
+                })
             } else if pyre_object::interp_array::is_array(seq) {
                 if (idx as usize) < pyre_object::interp_array::w_array_len(seq) {
                     Some(pyre_object::interp_array::w_array_unpack_item(

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -1626,24 +1626,11 @@ unsafe fn getitem_str(obj: PyObjectRef, index: PyObjectRef) -> PyResult {
     // indexed without going through `w_str_get_value`.
     //
     // `_index_to_byte` (`unicodeobject.py:1251`) reads an ASCII payload's byte
-    // at the code point index, so only a wide or surrogate-bearing string has
-    // to walk.  Upstream keeps that walk O(1) with a per-string
-    // `rutf8.create_utf8_index_storage` table; without one, walking it once
-    // per call beats walking it once per code point.
-    let ascii = pyre_object::w_str_is_ascii(obj);
-    let cps: Vec<CodePoint> = if ascii {
-        Vec::new()
-    } else {
-        w_str_get_wtf8(obj).code_points().collect()
-    };
+    // at the code point index; a wide or surrogate-bearing one resolves the
+    // position through the string's cached `rutf8` index table, so a read is
+    // O(1) either way and nothing here has to materialise the code points.
     let len = w_str_len(obj);
-    let at = |i: usize| -> Option<CodePoint> {
-        if ascii {
-            pyre_object::w_str_codepoint_at(obj, i)
-        } else {
-            cps.get(i).copied()
-        }
-    };
+    let at = |i: usize| -> Option<CodePoint> { pyre_object::w_str_codepoint_at(obj, i) };
     if is_slice(index) {
         // `pypy/objspace/std/unicodeobject.py W_UnicodeObject._getitem_slice`
         // → `slice.indices(len)` (`pypy/objspace/std/sliceobject.py`).

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -11947,15 +11947,15 @@ pub fn iter(obj: PyObjectRef) -> PyResult {
             return Ok(pyre_object::w_seq_iter_new(obj, len));
         }
         if pyre_object::bytesobject::is_bytes_like(obj) {
+            // The cursor holds the bytes object itself, as the str arm above
+            // does: `space.iter` builds a sequence iterator over the sequence
+            // (`iterobject.py W_SeqIterObject`), it does not unpack it.  A
+            // materialised int list would make `iter(b)` cost O(len) before a
+            // single item is consumed, freeze a bytearray against
+            // mid-iteration mutation, and report the list rather than the
+            // bytes in `__reduce__`.
             let len = pyre_object::bytesobject::bytes_like_len(obj);
-            let mut items = Vec::with_capacity(len);
-            for i in 0..len {
-                items.push(w_int_new(
-                    pyre_object::bytesobject::bytes_like_getitem(obj, i) as i64,
-                ));
-            }
-            let list = pyre_object::w_list_new(items);
-            return Ok(pyre_object::w_seq_iter_new(list, len));
+            return Ok(pyre_object::w_seq_iter_new(obj, len));
         }
         // dict → iterate over keys (`pypy/objspace/std/dictmultiobject.py
         // W_DictMultiObject.descr_iter` → `W_DictMultiIterKeysObject`).
@@ -12273,6 +12273,15 @@ pub fn next(obj: PyObjectRef) -> PyResult {
                     one.push(cp);
                     w_str_from_wtf8(one)
                 })
+            } else if pyre_object::bytesobject::is_bytes_like(seq) {
+                // Each item is the byte's ordinal, read from the live buffer.
+                if (idx as usize) < pyre_object::bytesobject::bytes_like_len(seq) {
+                    Some(w_int_new(
+                        pyre_object::bytesobject::bytes_like_getitem(seq, idx as usize) as i64,
+                    ))
+                } else {
+                    None
+                }
             } else if pyre_object::interp_array::is_array(seq) {
                 if (idx as usize) < pyre_object::interp_array::w_array_len(seq) {
                     Some(pyre_object::interp_array::w_array_unpack_item(

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -2241,14 +2241,22 @@ pub(crate) fn seq_iter_setstate_method(args: &[PyObjectRef]) -> PyResult {
 /// (iterobject.py:16-24): `len(seq) - index` recomputed from the LIVE sequence
 /// — `space.len(w_seq)`, so a subclass `__len__` override or a mutation made
 /// mid-iteration is reflected — clamped to 0.  An exhausted (cleared) sequence
-/// reports 0.  A missing or raising `__len__` propagates as a real error;
-/// `operator.length_hint` then maps a TypeError to its default, exactly as a
-/// direct `space.len` would.
+/// reports 0.
+///
+/// A sequence whose type has no `__len__` reports `NotImplemented` rather than
+/// raising: `iter_len` (`iterobject.c`) guards the length read with
+/// `_PyObject_HasLen`, and a `__getitem__`-only sequence is exactly the case
+/// that guard exists for.  A `__len__` that raises still propagates.  This
+/// intentionally differs from PyPy's `getlength`, which lets `space.len` raise;
+/// the observable behaviour target is 3.14.
 pub(crate) fn seq_iter_length_hint_method(args: &[PyObjectRef]) -> PyResult {
     unsafe {
         let seq = pyre_object::w_seq_iter_seq(args[0]);
         if seq.is_null() {
             return Ok(w_int_new(0));
+        }
+        if is_instance(seq) && lookup(seq, "__len__").is_none() {
+            return Ok(pyre_object::special::w_not_implemented());
         }
         let length = len_w(seq)?;
         let remaining = length - pyre_object::w_seq_iter_index(args[0]);

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -2440,17 +2440,12 @@ impl IterOpcodeHandler for PyFrame {
                 self.locals_w_mut()[tos] = seq_iter;
                 return Ok(());
             }
-            // bytes/bytearray → list of int → seq_iter
+            // bytes/bytearray → seq_iter cursor over the bytes themselves, so
+            // GET_ITER stays O(1) and a bytearray mutated mid-loop is observed
+            // (baseobjspace::iter takes the same shape).
             if pyre_object::bytesobject::is_bytes_like(iter) {
                 let len = pyre_object::bytesobject::bytes_like_len(iter);
-                let mut items = Vec::with_capacity(len);
-                for i in 0..len {
-                    items.push(pyre_object::w_int_new(
-                        pyre_object::bytesobject::bytes_like_getitem(iter, i) as i64,
-                    ));
-                }
-                let list = pyre_object::w_list_new(items);
-                let seq_iter = pyre_object::w_seq_iter_new(list, len);
+                let seq_iter = pyre_object::w_seq_iter_new(iter, len);
                 let tos = self.valuestackdepth - 1;
                 self.locals_w_mut()[tos] = seq_iter;
                 return Ok(());

--- a/pyre/pyre-interpreter/src/runtime_ops.rs
+++ b/pyre/pyre-interpreter/src/runtime_ops.rs
@@ -1367,6 +1367,8 @@ unsafe fn seq_iter_current_len(seq: PyObjectRef) -> Option<i64> {
             // Code-point count, not byte count (matches the str seq-iter
             // seed in baseobjspace::iter).
             Some(w_str_len(seq) as i64)
+        } else if pyre_object::bytesobject::is_bytes_like(seq) {
+            Some(pyre_object::bytesobject::bytes_like_len(seq) as i64)
         } else if pyre_object::interp_array::is_array(seq) {
             Some(pyre_object::interp_array::w_array_len(seq) as i64)
         } else {
@@ -1450,6 +1452,17 @@ pub fn range_iter_next_or_null(iter: PyObjectRef) -> Result<PyObjectRef, PyError
                     one.push(cp);
                     w_str_from_wtf8(one)
                 })
+            } else if pyre_object::bytesobject::is_bytes_like(si.seq) {
+                // Each item is the byte's ordinal, read from the live buffer so
+                // a bytearray resized mid-iteration is observed.
+                if (idx as usize) < pyre_object::bytesobject::bytes_like_len(si.seq) {
+                    Some(w_int_new(pyre_object::bytesobject::bytes_like_getitem(
+                        si.seq,
+                        idx as usize,
+                    ) as i64))
+                } else {
+                    None
+                }
             } else if pyre_object::interp_array::is_array(si.seq) {
                 if (idx as usize) < pyre_object::interp_array::w_array_len(si.seq) {
                     Some(pyre_object::interp_array::w_array_unpack_item(

--- a/pyre/pyre-interpreter/src/runtime_ops.rs
+++ b/pyre/pyre-interpreter/src/runtime_ops.rs
@@ -1173,11 +1173,9 @@ pub fn sequence_getitem(seq: PyObjectRef, index: usize) -> Result<PyObjectRef, P
                 .ok_or_else(|| PyError::type_error("list index out of range"));
         }
         if is_str(seq) {
-            // Walk code points through the WTF-8 view so a surrogate-bearing
+            // Read the code point through the WTF-8 view so a surrogate-bearing
             // string yields its lone surrogate instead of panicking.
-            return w_str_get_wtf8(seq)
-                .code_points()
-                .nth(index)
+            return pyre_object::w_str_codepoint_at(seq, index)
                 .map(|c| {
                     let mut one = Wtf8Buf::new();
                     one.push(c);
@@ -1447,19 +1445,11 @@ pub fn range_iter_next_or_null(iter: PyObjectRef) -> Result<PyObjectRef, PyError
                 // list); without this arm `seq_iter_current_len` would say
                 // "more" while this helper returned PY_NULL forever, hanging
                 // the loop. Mirrors baseobjspace::next.
-                let s = w_str_get_wtf8(si.seq);
-                let mut found: Option<PyObjectRef> = None;
-                let mut n = 0i64;
-                for cp in s.code_points() {
-                    if n == idx {
-                        let mut one = Wtf8Buf::new();
-                        one.push(cp);
-                        found = Some(w_str_from_wtf8(one));
-                        break;
-                    }
-                    n += 1;
-                }
-                found
+                pyre_object::w_str_codepoint_at(si.seq, idx as usize).map(|cp| {
+                    let mut one = Wtf8Buf::new();
+                    one.push(cp);
+                    w_str_from_wtf8(one)
+                })
             } else if pyre_object::interp_array::is_array(si.seq) {
                 if (idx as usize) < pyre_object::interp_array::w_array_len(si.seq) {
                     Some(pyre_object::interp_array::w_array_unpack_item(

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -1882,10 +1882,11 @@ fn build_gc() -> Box<dyn majit_gc::GcAllocator> {
     // W_ObjectObject's instance-class edge. A slots-bearing `str` subclass
     // also owns a normal list in `w_slots`; tracing that list edge gives the
     // list's custom tracer ownership of the individual slot values, matching
-    // PyPy's object-resident BaseUserClassMapdict storage. No
-    // `.with_destructor_fn`: the value-box tid's drop glue is the sole
-    // reclaimer (a holder destructor would double-free a box swept before its
-    // owner).
+    // PyPy's object-resident BaseUserClassMapdict storage. The lazily-built
+    // `index_storage` code point table splits the same way as `value` and is
+    // traced on the same terms. No `.with_destructor_fn`: the value-box tid's
+    // drop glue is the sole reclaimer (a holder destructor would double-free a
+    // box swept before its owner).
     let w_str_tid = gc.register_type(TypeInfo::object_subclass_with_gc_ptrs(
         std::mem::size_of::<pyre_object::unicodeobject::W_UnicodeObject>(),
         object_tid,
@@ -1893,6 +1894,7 @@ fn build_gc() -> Box<dyn majit_gc::GcAllocator> {
             pyre_object::pyobject::W_CLASS_OFFSET,
             pyre_object::unicodeobject::UNICODE_VALUE_OFFSET,
             pyre_object::unicodeobject::UNICODE_W_SLOTS_OFFSET,
+            pyre_object::unicodeobject::UNICODE_INDEX_STORAGE_OFFSET,
         ],
     ));
     debug_assert_eq!(w_str_tid, W_UNICODE_GC_TYPE_ID);
@@ -3166,6 +3168,17 @@ fn build_gc() -> Box<dyn majit_gc::GcAllocator> {
             pyre_object::unicodeobject::UnicodeValueStorage,
         >,
         pyre_object::unicodeobject::set_unicode_value_gc_type_id,
+    );
+    // Mortal `str` `rutf8` code point index table storage box. A leaf
+    // `Vec<Utf8LocElem>` (no inner refs) built on the first non-ASCII index; the
+    // W_UnicodeObject `index_storage` gc-pointer edge greys it and the box tid's
+    // drop glue reclaims it on sweep. Only a GC-owned string boxes its table; an
+    // immortal one keeps a `malloc_raw` table, as it does its value. Keep this id
+    // at the absolute registration tail.
+    register_leaf_storage_box::<pyre_object::rutf8::Utf8IndexStorage>(
+        &mut gc,
+        pyre_object::gc_storage::storage_box_destructor::<pyre_object::rutf8::Utf8IndexStorage>,
+        pyre_object::unicodeobject::set_utf8_index_gc_type_id,
     );
     // Mortal `name` string storage box shared by heap `W_TypeObject` and user
     // `Function` (off-GC storage). A leaf `String` (no inner refs); the

--- a/pyre/pyre-object/src/lib.rs
+++ b/pyre/pyre-object/src/lib.rs
@@ -51,6 +51,7 @@ pub mod objectobject;
 pub mod operation;
 pub mod pyobject;
 pub mod rbigint;
+pub mod rutf8;
 pub mod setobject;
 pub mod sliceobject;
 pub mod special;

--- a/pyre/pyre-object/src/rutf8.rs
+++ b/pyre/pyre-object/src/rutf8.rs
@@ -1,0 +1,207 @@
+//! RPython's `rpython.rlib.rutf8` code point index storage, ported
+//! structurally to Rust.
+//!
+//! A UTF-8 (here WTF-8) buffer addresses code points by byte offset, so
+//! resolving the n-th code point means walking from the start.  The index
+//! storage turns that walk into a table lookup: one entry per 64 code points
+//! holding the byte offset the group starts at, plus a one-byte delta for every
+//! fourth code point inside it.  A lookup reads the entry, adds the delta, and
+//! steps at most two code points — `codepoint_position_at_index`.
+//!
+//! The table costs 24 bytes per 64 code points and is built once per string,
+//! on the first non-ASCII index; an ASCII payload never needs one because its
+//! code point index is already its byte offset (`W_UnicodeObject.is_ascii`).
+//!
+//! Names, entry layout, group sizes and the build loop follow
+//! `rpython/rlib/rutf8.py:131-566`.  The `_is_64bit` branch of
+//! `next_codepoint_pos` (a hand-tuned x86-64 sequence guarded by
+//! `not jit.we_are_jitted()`) is left out: it computes the same value as the
+//! comparison ladder it sits in front of.
+
+/// `UTF8_INDEX_STORAGE`'s element (`rutf8.py:508-511`) — `baseindex` is the
+/// byte offset the 64-code-point group starts at, and `ofs[i]` the byte delta
+/// from it to the code point *after* the group's `4 * i`-th.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct Utf8LocElem {
+    pub baseindex: isize,
+    pub ofs: [u8; 16],
+}
+
+/// `UTF8_INDEX_STORAGE` (`rutf8.py:508`).  A leaf (no inner `PyObjectRef`), so
+/// a mortal string's table lives in a storage box whose drop glue reclaims it,
+/// as its WTF-8 buffer does.
+pub type Utf8IndexStorage = Vec<Utf8LocElem>;
+
+/// `next_codepoint_pos` (`rutf8.py:131`) — the position of the code point after
+/// `pos`.  Assumes valid WTF-8 and `pos` before the end.
+#[inline]
+pub fn next_codepoint_pos(code: &[u8], pos: usize) -> usize {
+    let chr1 = code[pos];
+    if chr1 <= 0x7F {
+        return pos + 1;
+    }
+    if chr1 <= 0xDF {
+        return pos + 2;
+    }
+    if chr1 <= 0xEF {
+        return pos + 3;
+    }
+    pos + 4
+}
+
+/// `prev_codepoint_pos` (`rutf8.py:152`) — the position of the code point
+/// before `pos`, which must not be zero.  A `pos` one past the end reads as the
+/// extra `'\x00'` the build loop pretends is there.
+#[inline]
+pub fn prev_codepoint_pos(code: &[u8], pos: usize) -> usize {
+    let mut pos = pos - 1;
+    if pos >= code.len() {
+        return pos;
+    }
+    if code[pos] <= 0x7F {
+        return pos;
+    }
+    pos -= 1;
+    if code[pos] >= 0xC0 {
+        return pos;
+    }
+    pos -= 1;
+    if code[pos] >= 0xC0 {
+        return pos;
+    }
+    pos - 1
+}
+
+/// `create_utf8_index_storage` (`rutf8.py:516`) — the table for `utf8`, whose
+/// code point count is `utf8len`.
+pub fn create_utf8_index_storage(utf8: &[u8], utf8len: usize) -> Utf8IndexStorage {
+    let arraysize = utf8len / 64 + 1;
+    let mut storage = vec![
+        Utf8LocElem {
+            baseindex: 0,
+            ofs: [0u8; 16],
+        };
+        arraysize
+    ];
+    // Signed: the count overshoots the last group by design and the loop stops
+    // on the first negative value.
+    let mut utf8len = utf8len as isize;
+    let mut baseindex = 0usize;
+    let mut current = 0usize;
+    loop {
+        storage[current].baseindex = baseindex as isize;
+        let mut next = baseindex;
+        // Stands in for the `for ... else` upstream breaks out of.
+        let mut group_filled = true;
+        for i in 0..16 {
+            if utf8len == 0 {
+                next += 1; // assume there is an extra '\x00' character
+            } else {
+                next = next_codepoint_pos(utf8, next);
+            }
+            storage[current].ofs[i] = (next - baseindex) as u8;
+            utf8len -= 4;
+            if utf8len < 0 {
+                debug_assert_eq!(current + 1, storage.len());
+                group_filled = false;
+                break;
+            }
+            next = next_codepoint_pos(utf8, next);
+            next = next_codepoint_pos(utf8, next);
+            next = next_codepoint_pos(utf8, next);
+        }
+        if !group_filled {
+            break;
+        }
+        current += 1;
+        baseindex = next;
+    }
+    storage
+}
+
+/// `codepoint_position_at_index` (`rutf8.py:548`) — the byte offset of code
+/// point `index`, which must not exceed the string's code point count.
+#[inline]
+pub fn codepoint_position_at_index(utf8: &[u8], storage: &[Utf8LocElem], index: usize) -> usize {
+    let elem = &storage[index >> 6];
+    let bytepos = elem.baseindex as usize + elem.ofs[(index >> 2) & 0x0F] as usize;
+    match index & 0x3 {
+        0 => prev_codepoint_pos(utf8, bytepos),
+        1 => bytepos,
+        2 => next_codepoint_pos(utf8, bytepos),
+        _ => next_codepoint_pos(utf8, next_codepoint_pos(utf8, bytepos)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rustpython_wtf8::{CodePoint, Wtf8Buf};
+
+    fn sample(kind: &str, repeat: usize) -> Wtf8Buf {
+        let mut buf = Wtf8Buf::new();
+        for i in 0..repeat {
+            match kind {
+                "ascii" => buf.push_str("abcd"),
+                "latin1" => buf.push_str("éèêë"),
+                "wide" => buf.push_str("一二三四"),
+                "astral" => buf.push_str("\u{1f600}\u{1f601}\u{1f602}\u{1f603}"),
+                "mixed" => buf.push_str("a\u{e9}\u{4e00}\u{1f600}"),
+                "surrogate" => {
+                    buf.push_str("a");
+                    buf.push(CodePoint::from_u32(0xD800 + (i % 0x400) as u32).unwrap());
+                    buf.push_str("\u{4e00}");
+                    buf.push(CodePoint::from_u32(0xDC80).unwrap());
+                }
+                other => panic!("unknown sample kind {other}"),
+            }
+        }
+        buf
+    }
+
+    /// The table must answer exactly what a walk from the start would.
+    fn assert_matches_walk(buf: &Wtf8Buf) {
+        let utf8 = buf.as_bytes();
+        let positions: Vec<usize> = buf.code_point_indices().map(|(pos, _)| pos).collect();
+        let storage = create_utf8_index_storage(utf8, positions.len());
+        for (index, &expected) in positions.iter().enumerate() {
+            assert_eq!(
+                codepoint_position_at_index(utf8, &storage, index),
+                expected,
+                "index {index} of a {} byte / {} code point payload",
+                utf8.len(),
+                positions.len(),
+            );
+        }
+    }
+
+    #[test]
+    fn test_index_storage_matches_a_walk() {
+        // Lengths straddling the 4-code-point delta stride and the 64-code
+        // point group, in both directions.
+        for repeat in [0, 1, 2, 15, 16, 17, 32, 63, 64, 65, 100] {
+            for kind in ["ascii", "latin1", "wide", "astral", "mixed", "surrogate"] {
+                assert_matches_walk(&sample(kind, repeat));
+            }
+        }
+    }
+
+    #[test]
+    fn test_index_storage_handles_a_partial_final_group() {
+        // A code point count that is neither a multiple of 4 nor of 64 leaves
+        // the last group half-written; every filled entry must still answer.
+        let mut buf = sample("mixed", 3);
+        buf.push_str("x\u{4e00}");
+        assert_eq!(buf.code_points().count(), 14);
+        assert_matches_walk(&buf);
+    }
+
+    #[test]
+    fn test_index_storage_size_is_one_entry_per_64_code_points() {
+        assert_eq!(create_utf8_index_storage(b"", 0).len(), 1);
+        assert_eq!(create_utf8_index_storage(&[b'a'; 64], 64).len(), 2);
+        assert_eq!(create_utf8_index_storage(&[b'a'; 127], 127).len(), 2);
+        assert_eq!(create_utf8_index_storage(&[b'a'; 128], 128).len(), 3);
+    }
+}

--- a/pyre/pyre-object/src/unicodeobject.rs
+++ b/pyre/pyre-object/src/unicodeobject.rs
@@ -41,6 +41,16 @@ pub struct W_UnicodeObject {
     /// `Member.index` from its layout. Keeping this on the object mirrors
     /// PyPy's `_mapdict_*storage` owner and avoids an address-keyed side table.
     pub w_slots: PyObjectRef,
+    /// `W_UnicodeObject._index_storage` (`unicodeobject.py:1196`) — the
+    /// `rutf8` code point index table, built on the first non-ASCII index and
+    /// null until then.  A pure cache: dropping it only costs the next lookup a
+    /// rebuild.
+    ///
+    /// A managed holder boxes it (`utf8_index_gc_type_id`) and is greyed
+    /// through this slot; an immortal holder keeps a `malloc_raw` table the
+    /// walker's `is_managed_heap_object` edge guard skips, the same split its
+    /// `value` buffer already makes.
+    pub index_storage: *mut crate::rutf8::Utf8IndexStorage,
 }
 
 /// Field offset of `value` within `W_UnicodeObject`, for JIT field access.
@@ -51,6 +61,9 @@ pub const UNICODE_BYTE_LEN_OFFSET: usize = std::mem::offset_of!(W_UnicodeObject,
 pub const UNICODE_LEN_OFFSET: usize = std::mem::offset_of!(W_UnicodeObject, len);
 /// Field offset of the subclass slot-storage list.
 pub const UNICODE_W_SLOTS_OFFSET: usize = std::mem::offset_of!(W_UnicodeObject, w_slots);
+/// Field offset of the `rutf8` code point index table.
+pub const UNICODE_INDEX_STORAGE_OFFSET: usize =
+    std::mem::offset_of!(W_UnicodeObject, index_storage);
 
 /// GC type id assigned to `W_UnicodeObject` at JitDriver init time.
 pub const W_UNICODE_GC_TYPE_ID: u32 = 34;
@@ -79,6 +92,22 @@ pub fn set_unicode_value_gc_type_id(id: u32) {
 #[majit_macros::dont_look_inside]
 pub fn unicode_value_gc_type_id() -> u32 {
     UNICODE_VALUE_GC_TYPE_ID.load(std::sync::atomic::Ordering::Relaxed)
+}
+
+/// Runtime-assigned GC type id for the `rutf8` index table of a *mortal*
+/// string, registered beside [`UnicodeValueStorage`] and published the same
+/// way.  A leaf; its box carries only drop glue.
+static UTF8_INDEX_GC_TYPE_ID: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
+
+/// Record the GC type id registered for the `rutf8` index table.
+pub fn set_utf8_index_gc_type_id(id: u32) {
+    UTF8_INDEX_GC_TYPE_ID.store(id, std::sync::atomic::Ordering::Relaxed);
+}
+
+/// Read the runtime-assigned GC type id for the `rutf8` index table.
+#[majit_macros::dont_look_inside]
+pub fn utf8_index_gc_type_id() -> u32 {
+    UTF8_INDEX_GC_TYPE_ID.load(std::sync::atomic::Ordering::Relaxed)
 }
 
 /// Fixed payload size (`framework.py:811`).
@@ -124,6 +153,7 @@ pub fn w_str_new(s: &str) -> PyObjectRef {
         byte_len,
         len: char_len,
         w_slots: PY_NULL,
+        index_storage: std::ptr::null_mut(),
     }) as PyObjectRef
 }
 
@@ -160,6 +190,7 @@ pub fn w_str_from_wtf8(value: Wtf8Buf) -> PyObjectRef {
         byte_len,
         len: char_len,
         w_slots: PY_NULL,
+        index_storage: std::ptr::null_mut(),
     }) as PyObjectRef
 }
 
@@ -191,6 +222,7 @@ pub fn w_str_from_wtf8_managed(value: Wtf8Buf) -> PyObjectRef {
         byte_len,
         len: char_len,
         w_slots: PY_NULL,
+        index_storage: std::ptr::null_mut(),
     };
     let raw = crate::gc_hook::try_gc_alloc_stable_raw(W_UNICODE_GC_TYPE_ID, W_UNICODE_OBJECT_SIZE);
     if raw.is_null() {
@@ -229,6 +261,7 @@ pub fn w_str_from_wtf8_immortal(value: Wtf8Buf) -> PyObjectRef {
         byte_len,
         len: char_len,
         w_slots: PY_NULL,
+        index_storage: std::ptr::null_mut(),
     }) as PyObjectRef
 }
 
@@ -253,6 +286,7 @@ pub fn w_str_subclass_from_wtf8(value: Wtf8Buf, w_class: PyObjectRef) -> PyObjec
         byte_len,
         len: char_len,
         w_slots: PY_NULL,
+        index_storage: std::ptr::null_mut(),
     };
     let raw = crate::gc_hook::try_gc_alloc_stable_raw(W_UNICODE_GC_TYPE_ID, W_UNICODE_OBJECT_SIZE);
     let obj = if raw.is_null() {
@@ -424,27 +458,92 @@ pub unsafe fn w_str_is_ascii(obj: PyObjectRef) -> bool {
     }
 }
 
-/// The code point at `index`, or `None` past the end — the read behind
-/// `_getitem_result` (`unicodeobject.py:1205`), which resolves the position
-/// through `_index_to_byte` (:1251).
+/// `W_UnicodeObject._compute_index_storage` (`unicodeobject.py:1200`) — build
+/// the `rutf8` code point index table and cache it in the `index_storage` slot.
 ///
-/// An ASCII payload takes the direct branch and is O(1).  Anything else walks,
-/// because pyre has no counterpart of the `rutf8.create_utf8_index_storage`
-/// table that turns the general case into an O(1) lookup upstream; a
-/// surrogate-bearing or wide string therefore still costs O(index) per read.
+/// The table's holder follows the string's own: a GC-managed string boxes it
+/// so the `index_storage` edge greys it and the sweep reclaims it, while an
+/// immortal one keeps a `malloc_raw` table like its `malloc_raw` value.
+/// `try_gc_owns_object` is the same discriminator every other mixed-allocation
+/// host path uses.
+///
+/// `#[dont_look_inside]` (`@jit.dont_look_inside`, `rlib/jit.py:139`) stands in
+/// for the `jit.conditional_call_elidable` that keeps this build off the trace
+/// upstream: [`w_str_get_index_storage`] traces the cached-pointer test and
+/// residualizes the build behind it.
+///
+/// # Safety
+/// `obj` must point to a valid `W_UnicodeObject`.
+#[majit_macros::dont_look_inside]
+unsafe fn w_str_compute_index_storage(obj: PyObjectRef) -> *mut crate::rutf8::Utf8IndexStorage {
+    unsafe {
+        let str_obj = obj as *mut W_UnicodeObject;
+        let storage =
+            crate::rutf8::create_utf8_index_storage((*(*str_obj).value).as_bytes(), (*str_obj).len);
+        let tid = if crate::gc_hook::try_gc_owns_object(obj as *mut u8) {
+            utf8_index_gc_type_id()
+        } else {
+            0
+        };
+        let storage = crate::gc_storage::gc_alloc_storage_box(storage, tid);
+        (*str_obj).index_storage = storage;
+        crate::gc_hook::try_gc_write_barrier(obj as *mut u8);
+        storage
+    }
+}
+
+/// `W_UnicodeObject._get_index_storage` (`unicodeobject.py:1196`) — the cached
+/// index table, computing it on first use.
+///
+/// # Safety
+/// `obj` must point to a valid `W_UnicodeObject`.
+#[inline]
+unsafe fn w_str_get_index_storage(obj: PyObjectRef) -> *mut crate::rutf8::Utf8IndexStorage {
+    unsafe {
+        let cached = (*(obj as *const W_UnicodeObject)).index_storage;
+        if cached.is_null() {
+            return w_str_compute_index_storage(obj);
+        }
+        cached
+    }
+}
+
+/// `W_UnicodeObject._index_to_byte` (`unicodeobject.py:1251`) — the byte offset
+/// of code point `index`, which must be below the code point count.
+///
+/// # Safety
+/// `obj` must point to a valid `W_UnicodeObject` and `index` must be in range.
+pub unsafe fn w_str_index_to_byte(obj: PyObjectRef, index: usize) -> usize {
+    unsafe {
+        if w_str_is_ascii(obj) {
+            return index;
+        }
+        let storage = w_str_get_index_storage(obj);
+        crate::rutf8::codepoint_position_at_index(
+            (*(*(obj as *const W_UnicodeObject)).value).as_bytes(),
+            &*storage,
+            index,
+        )
+    }
+}
+
+/// The code point at `index`, or `None` past the end — the read behind
+/// `_getitem_result` (`unicodeobject.py:1205`): resolve the position through
+/// `_index_to_byte`, then take the one code point that starts there.
 ///
 /// # Safety
 /// `obj` must point to a valid `W_UnicodeObject`.
 pub unsafe fn w_str_codepoint_at(obj: PyObjectRef, index: usize) -> Option<CodePoint> {
     unsafe {
-        let value = &*(*(obj as *const W_UnicodeObject)).value;
-        if w_str_is_ascii(obj) {
-            let end = index.checked_add(1)?;
-            return value
-                .get(index..end)
-                .and_then(|one| one.code_points().next());
+        if index >= w_str_len(obj) {
+            return None;
         }
-        value.code_points().nth(index)
+        let start = w_str_index_to_byte(obj, index);
+        let value = &*(*(obj as *const W_UnicodeObject)).value;
+        let end = crate::rutf8::next_codepoint_pos(value.as_bytes(), start);
+        value
+            .get(start..end)
+            .and_then(|one| one.code_points().next())
     }
 }
 
@@ -554,6 +653,7 @@ mod tests {
         assert_eq!(UNICODE_BYTE_LEN_OFFSET, 24);
         assert_eq!(UNICODE_LEN_OFFSET, 32);
         assert_eq!(UNICODE_W_SLOTS_OFFSET, 40);
+        assert_eq!(UNICODE_INDEX_STORAGE_OFFSET, 48);
     }
 
     #[test]
@@ -613,6 +713,57 @@ mod tests {
             assert_eq!(at(1), Some(0xD800));
             assert_eq!(at(2), Some(u32::from(b'b')));
             assert_eq!(at(3), None);
+        }
+    }
+
+    /// Every index of a multi-group non-ASCII string must answer what a walk
+    /// from the start would, and the table must be built once and reused.
+    #[test]
+    fn test_str_codepoint_at_uses_a_cached_index_table() {
+        let mut buf = Wtf8Buf::new();
+        for i in 0..200 {
+            buf.push_str("a\u{e9}\u{4e00}");
+            buf.push(CodePoint::from_u32(0xD800 + (i % 0x400) as u32).unwrap());
+        }
+        let expected: Vec<u32> = buf.code_points().map(CodePoint::to_u32).collect();
+        let obj = w_str_from_wtf8(buf);
+        unsafe {
+            let str_obj = obj as *const W_UnicodeObject;
+            assert!(!w_str_is_ascii(obj));
+            assert!((*str_obj).index_storage.is_null());
+
+            for (index, &code) in expected.iter().enumerate() {
+                assert_eq!(
+                    w_str_codepoint_at(obj, index).map(CodePoint::to_u32),
+                    Some(code),
+                    "index {index}",
+                );
+            }
+            assert_eq!(w_str_codepoint_at(obj, expected.len()), None);
+
+            let storage = (*str_obj).index_storage;
+            assert!(!storage.is_null());
+            // 800 code points -> ceil-style one entry per 64 plus the tail.
+            assert_eq!((*storage).len(), expected.len() / 64 + 1);
+            // A second pass reuses the table rather than rebuilding it.
+            assert_eq!(
+                w_str_codepoint_at(obj, 0).map(CodePoint::to_u32),
+                Some(expected[0])
+            );
+            assert_eq!((*str_obj).index_storage, storage);
+        }
+    }
+
+    /// An ASCII string never pays for a table: its index is already its byte
+    /// offset (`is_ascii`).
+    #[test]
+    fn test_ascii_str_never_builds_an_index_table() {
+        let obj = w_str_new("abcdefghij");
+        unsafe {
+            for index in 0..10 {
+                assert!(w_str_codepoint_at(obj, index).is_some());
+            }
+            assert!((*(obj as *const W_UnicodeObject)).index_storage.is_null());
         }
     }
 

--- a/pyre/pyre-object/src/unicodeobject.rs
+++ b/pyre/pyre-object/src/unicodeobject.rs
@@ -15,7 +15,7 @@
 use std::cell::RefCell;
 use std::collections::HashMap;
 
-use rustpython_wtf8::{Wtf8, Wtf8Buf};
+use rustpython_wtf8::{CodePoint, Wtf8, Wtf8Buf};
 
 use crate::pyobject::*;
 
@@ -410,6 +410,44 @@ pub unsafe fn w_str_len(obj: PyObjectRef) -> usize {
     unsafe { (*(obj as *const W_UnicodeObject)).len }
 }
 
+/// `unicodeobject.py:1245 W_UnicodeObject.is_ascii` — `self._length ==
+/// len(self._utf8)`.  One byte per code point means a code point index is
+/// already a byte offset.
+///
+/// # Safety
+/// `obj` must point to a valid `W_UnicodeObject`.
+#[inline]
+pub unsafe fn w_str_is_ascii(obj: PyObjectRef) -> bool {
+    unsafe {
+        let str_obj = obj as *const W_UnicodeObject;
+        (*str_obj).len == (*str_obj).byte_len
+    }
+}
+
+/// The code point at `index`, or `None` past the end — the read behind
+/// `_getitem_result` (`unicodeobject.py:1205`), which resolves the position
+/// through `_index_to_byte` (:1251).
+///
+/// An ASCII payload takes the direct branch and is O(1).  Anything else walks,
+/// because pyre has no counterpart of the `rutf8.create_utf8_index_storage`
+/// table that turns the general case into an O(1) lookup upstream; a
+/// surrogate-bearing or wide string therefore still costs O(index) per read.
+///
+/// # Safety
+/// `obj` must point to a valid `W_UnicodeObject`.
+pub unsafe fn w_str_codepoint_at(obj: PyObjectRef, index: usize) -> Option<CodePoint> {
+    unsafe {
+        let value = &*(*(obj as *const W_UnicodeObject)).value;
+        if w_str_is_ascii(obj) {
+            let end = index.checked_add(1)?;
+            return value
+                .get(index..end)
+                .and_then(|one| one.code_points().next());
+        }
+        value.code_points().nth(index)
+    }
+}
+
 /// Check if an object is a str.
 ///
 /// # Safety
@@ -534,6 +572,47 @@ mod tests {
             let str_obj = obj as *const W_UnicodeObject;
             assert_eq!((*str_obj).byte_len, 5); // UTF-8: c(1) a(1) f(1) é(2)
             assert_eq!((*str_obj).len, 4); // 4 codepoints
+        }
+    }
+
+    #[test]
+    fn test_str_codepoint_at_indexes_code_points_not_bytes() {
+        let ascii = w_str_new("hello");
+        let wide = w_str_new("café一");
+        let empty = w_str_new("");
+        unsafe {
+            assert!(w_str_is_ascii(ascii));
+            assert!(w_str_is_ascii(empty));
+            assert!(!w_str_is_ascii(wide));
+
+            let at = |obj, i| w_str_codepoint_at(obj, i).map(CodePoint::to_u32);
+            assert_eq!(at(ascii, 0), Some(u32::from(b'h')));
+            assert_eq!(at(ascii, 4), Some(u32::from(b'o')));
+            assert_eq!(at(ascii, 5), None);
+            assert_eq!(at(ascii, usize::MAX), None);
+            assert_eq!(at(empty, 0), None);
+
+            // 'é' is two bytes, so byte offset 3 would land mid-character.
+            assert_eq!(at(wide, 3), Some(u32::from('é')));
+            assert_eq!(at(wide, 4), Some(u32::from('一')));
+            assert_eq!(at(wide, 5), None);
+        }
+    }
+
+    #[test]
+    fn test_str_codepoint_at_yields_a_lone_surrogate() {
+        let mut buf = Wtf8Buf::new();
+        buf.push_str("a");
+        buf.push(CodePoint::from_u32(0xD800).unwrap());
+        buf.push_str("b");
+        let obj = w_str_from_wtf8(buf);
+        unsafe {
+            assert!(!w_str_is_ascii(obj));
+            let at = |i| w_str_codepoint_at(obj, i).map(CodePoint::to_u32);
+            assert_eq!(at(0), Some(u32::from(b'a')));
+            assert_eq!(at(1), Some(0xD800));
+            assert_eq!(at(2), Some(u32::from(b'b')));
+            assert_eq!(at(3), None);
         }
     }
 


### PR DESCRIPTION
Closes the quadratic in `str` indexing and iteration, and stops `iter(bytes)`
materialising its buffer.

## `str` indexing

`baseobjspace.rs::getitem_str` opened every subscript with
`w_str_get_wtf8(obj).code_points().collect()` — the **whole** string into a
`Vec<CodePoint>`, per read. An 80000-character index walk cost 2.36s against
CPython's 0.0010s, and `for c in s` had the same shape.

Upstream resolves a code point index through `_index_to_byte`
(`pypy/objspace/std/unicodeobject.py:1251`), which has two branches. Both are
ported here:

* **ASCII** — `is_ascii()` is `self._length == len(self._utf8)` (:1245), and one
  byte per code point means the index already *is* the byte offset. Free in
  pyre: `W_UnicodeObject` already caches both `len` and `byte_len`.
* **Everything else** — `rutf8.codepoint_position_at_index` over a per-string
  index table. `pyre/pyre-object/src/rutf8.rs` is the port of
  `rpython/rlib/rutf8.py:131-566`: the `UTF8_INDEX_STORAGE` entry layout (one
  `baseindex` per 64 code points plus a byte delta for every fourth),
  `next_codepoint_pos`, `prev_codepoint_pos`, `create_utf8_index_storage` and
  `codepoint_position_at_index`. The `_is_64bit` branch of `next_codepoint_pos`
  is left out: it computes the same value as the comparison ladder it fronts.

`W_UnicodeObject` gains `_index_storage` (:1196), built on first use by
`_compute_index_storage` (:1200). `_get_index_storage` stays inlineable so the
trace sees the cached-pointer test, and the build sits behind
`#[dont_look_inside]` — the stand-in for the `jit.conditional_call_elidable`
upstream wraps it in. Fusing them would drag a `Vec`-building loop into every
trace.

### Table lifetime

The table follows the string's own allocation, which is mixed: exact strings are
immortal (`malloc_typed` header + `malloc_raw` value), dynamic and subclass ones
are GC-managed. A field filled *lazily* cannot follow whichever constructor ran,
so the builder asks `gc_hook::try_gc_owns_object` — the discriminator that
already exists for mixed `try_gc_alloc_stable` / `std::alloc` paths.

A GC-owned string boxes the table in a leaf storage box, greyed through the new
`index_storage` gc-pointer edge on `w_str_tid` and reclaimed by the box tid's
drop glue. An immortal one keeps a `malloc_raw` table, which the walker's
`is_managed_heap_object` edge guard skips — the same split its `value` buffer
already makes. The one unsound pairing, immortal holder + GC box, cannot arise:
`owns_object == false` yields tid 0, which is `gc_alloc_storage_box`'s
`malloc_raw` fallback.

### Measured

macOS aarch64, dynasm, JIT on. `s[i]` over `"一" * n`, same script, HEAD binary
vs this branch:

| n | before | after |
|---|---|---|
| 20000 | 0.61s | 0.0069s |
| 40000 | 2.41s | 0.0067s |
| 80000 | 25.96s | 0.0126s |

ASCII, same ladder: 2.36s → 0.0048s at 80000. `for c in s` over 400000 wide
characters is 0.11s and linear; over 400000 ASCII, 38.34s → 0.0555s.

## `iter(bytes)`

`baseobjspace::iter` and `eval.rs` GET_ITER both built
`w_list_new(vec![w_int_new(byte); len])` *before* the first item. On a 4MB
`bytes` that is 77ms and 4M objects up front; it also froze a `bytearray`
against mid-iteration mutation and made `__reduce__` report the list rather than
the buffer. The cursor now holds the bytes object, exactly as the `str` arm
beside it already did, with `bytes` arms in `seq_iter_current_len` and both item
readers so it keeps the inline `FOR_ITER` leg. Construction 77ms → 9µs;
per-item cost unchanged (controlled same-process comparison: list 0.70s /
tuple 0.67s / bytes 0.71s / bytearray 0.71s per 2M items).

## Also here

* `list_reverseiterator` cleared its list on exhaustion, so `__setstate__` could
  not revive it; 3.14 keeps the list and uses cursor `-1`.
* `sequenceiterator.__length_hint__` raised `TypeError` for a
  `__getitem__`-only sequence where `iter_len`'s `_PyObject_HasLen` guard
  returns `NotImplemented`.

## Verification

* `check.py --backend dynasm,cranelift` — **dynasm 332/332, cranelift 332/332**,
  after a forced LLBC re-extract (this changes `W_UnicodeObject`'s layout) with
  all three fingerprints confirmed against the working tree.
* `cargo test`: pyre-object 275, pyre-interpreter 401, pyre-jit 322 + 13.
  `cargo fmt --all -- --check` clean.
* Differential vs CPython 3.14: a 1400-row probe over ASCII / latin1 / wide /
  astral / mixed / surrogate payloads — every index, both signs, out of range,
  slice combinations, `__index__` receivers — matches exactly. A second 511-row
  probe covers payloads spanning several index-table groups at six lengths.
  The only remaining divergence in the whole iterator surface is pre-existing
  and unrelated: pyre has one `sequenceiterator` where 3.14 has
  `str_ascii_iterator` / `bytes_iterator` / `bytearray_iterator` /
  `memory_iterator`.
* A GC-stress probe (churn of short-lived non-ASCII strings and `str`
  subclasses, indexed then collected, re-read after collection) matches CPython
  under `PYRE_NO_JIT=1`, `PYRE_GC_INTERP=1` and the default.
* `pyre/bench/synth/str_index_bytes_iter_surface.py` is the corpus guard:
  per-index output for three payload widths, folded whole-string hashes for four
  non-ASCII payload kinds at four lengths each (every index, both signs, the
  4-code-point stride and 64-entry group edges, slices crossing them, and
  iteration/reversal agreement), the bytes/bytearray iteration surface including
  mid-loop grow and shrink, and a `warm_wide` loop whose scattered reads over a
  long payload make a return to per-subscript walking cost orders of magnitude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
