### PR TITLE
majit: land the cel-jit tracing fixes — merge-point cut, bridge virtualizable, single vable identity

### DIFF
--- a/majit/examples/tl/src/jit_interp.rs
+++ b/majit/examples/tl/src/jit_interp.rs
@@ -518,9 +518,12 @@ mod tests {
 
     /// #184 recursive CALL_ASSEMBLER portal entry: the macro-generated
     /// `JitCodeSym::recursive_fresh_entry_reds` yields fresh-frame reds in
-    /// `extract_live` order — stackpos zeroed, a fresh vable identity Ref
-    /// distinct from the caller, and the stack re-allocated at the caller's
-    /// captured capacity (read from the sym's `stack_len_value` cache).
+    /// `extract_live` order — stackpos zeroed, then a fresh vable identity Ref
+    /// distinct from the caller's. The stack is re-allocated at the caller's
+    /// captured capacity (read from the sym's `stack_len_value` cache), but
+    /// that capacity is NOT a red: a virtualizable is named once, and its array
+    /// lengths are read off the live object (`virtualizable.py:150-153`). It is
+    /// checked here on the returned owner instead.
     #[test]
     fn recursive_fresh_entry_reds_layout() {
         use majit_metainterp::{JitCodeSym as _, JitState as _};
@@ -533,11 +536,11 @@ mod tests {
         let mut sym = <TlState as majit_metainterp::JitState>::create_sym(&meta, 0);
         // Seeds `sym.stack_len_value` from the caller's live capacity.
         caller.initialize_sym(&mut sym, &meta);
-        let (values, _owner) = sym
+        let (values, owner) = sym
             .recursive_fresh_entry_reds()
             .expect("ref-scalar-free state-field interp must support portal entry");
-        // tl extract_live order: [stackpos (Int), &state (Ref), stack.len() (Int)].
-        assert_eq!(values.len(), 3, "stackpos + vable ptr + stack len");
+        // tl extract_live order: [stackpos (Int), &state (Ref)].
+        assert_eq!(values.len(), 2, "stackpos + the one vable identity");
         assert_eq!(values[0], majit_ir::Value::Int(0), "fresh stackpos zeroed");
         match values[1] {
             majit_ir::Value::Ref(majit_ir::GcRef(p)) => {
@@ -549,11 +552,15 @@ mod tests {
             }
             ref other => panic!("slot 1 must be the vable identity Ref, got {other:?}"),
         }
+        let fresh = owner
+            .downcast_ref::<TlState>()
+            .expect("the owner is the fresh state the reds name");
         assert_eq!(
-            values[2],
-            majit_ir::Value::Int(caller.stack.len() as i64),
+            fresh.stack.len(),
+            caller.stack.len(),
             "fresh stack re-allocated at the caller's captured capacity",
         );
+        assert_eq!(fresh.stackpos, 0, "fresh frame starts empty");
     }
 
     /// #184 S3f-1: the host alloc/free targets the recursive dispatcher records

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -7904,6 +7904,22 @@ impl CraneliftBackend {
     pub fn new() -> Self {
         let mut flag_builder = settings::builder();
         flag_builder.set("opt_level", "speed").unwrap();
+        // Cranelift's IR verifier defaults to on and re-checks every function we
+        // hand it, which is 25% of this backend's compile time (measured on the
+        // cel nested-loop shape: 3719 -> 2783 us, steady-state unchanged).
+        // compile.py:242-244 runs the equivalent trace consistency checks under
+        // `if not we_are_translated()`, i.e. only in the untranslated
+        // interpreter; `debug_assertions` is that same distinction here.
+        flag_builder
+            .set(
+                "enable_verifier",
+                if cfg!(debug_assertions) {
+                    "true"
+                } else {
+                    "false"
+                },
+            )
+            .unwrap();
         // cranelift 0.132 x86_64 `emit_return_call_common_sequence` panics
         // when `preserve_frame_pointers=false`:
         //   "frame pointers aren't fundamentally required for tail calls,

--- a/majit/majit-macros/src/jit_interp/codegen_state.rs
+++ b/majit/majit-macros/src/jit_interp/codegen_state.rs
@@ -133,6 +133,15 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
 
     let num_scalars = scalars.len();
     let num_virt_arrays = virt_arrays.len();
+    // `pyjitpl.py:2984-2989 reached_loop_header` carries the virtualizable
+    // exactly ONCE: it is a single red (`warmspot.py:529-538
+    // jd.index_of_virtualizable = jitdriver.reds.index(vname)`), and
+    // `virtualizable.py:150-153` reads every `[.. ; virt]` array's length off
+    // the live object instead of boxing it.  So a state contributes one
+    // identity slot however many virt arrays it declares — a presence flag,
+    // not a per-array count.
+    let has_vable_identity = num_virt_arrays > 0;
+    let num_vable_identity_slots = usize::from(has_vable_identity);
     let num_ref_scalars = ref_scalars.len();
     let num_float_scalars = float_scalars.len();
     // First ref-bank register available for ref-scalar identity slots.
@@ -172,7 +181,8 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
     };
 
     // ── __JitMeta fields: one `{name}_len: usize` per flattened array ──
-    // Virt arrays do NOT store length in meta (it's dynamic, tracked as inputarg).
+    // Virt arrays do NOT store length in meta: `virtualizable.py:150-153` reads
+    // each one off the live object, so it is neither a meta field nor a box.
     let meta_fields: Vec<TokenStream> = arrays
         .iter()
         .map(|(_, f)| {
@@ -213,24 +223,29 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
             quote! { #value_name: Vec<i64>, }
         })
         .collect();
+    // Per virt array only a plain `i64` length mirror survives: it feeds the
+    // fresh-callee capacity and the debug dumps, and is NEVER an inputarg
+    // (`virtualizable.py:150-153` reads the length off the live object).
     let sym_virt_array_fields: Vec<TokenStream> = virt_arrays
         .iter()
         .map(|(_, f)| {
-            let ptr_name = quote::format_ident!("{}_ptr", f.name);
-            let len_name = quote::format_ident!("{}_len", f.name);
-            let ptr_value_name = quote::format_ident!("{}_ptr_value", f.name);
             let len_value_name = quote::format_ident!("{}_len_value", f.name);
-            quote! {
-                #ptr_name: majit_ir::OpRef,
-                #len_name: majit_ir::OpRef,
-                #ptr_value_name: i64,
-                #len_value_name: i64,
-            }
+            quote! { #len_value_name: i64, }
         })
         .collect();
+    // `virtualizable.py:139-144` names the virtualizable once, so one OpRef
+    // slot serves every `[.. ; virt]` array on the state.
+    let sym_vable_identity_fields: TokenStream = if has_vable_identity {
+        quote! {
+            __vable_identity: majit_ir::OpRef,
+            __vable_identity_value: i64,
+        }
+    } else {
+        quote! {}
+    };
 
     // ── JitCodeSym: total_slots ──
-    // num_scalars + sum(flattened array lengths) + 2 * num_virt_arrays
+    // num_scalars + sum(flattened array lengths) + num_vable_identity_slots
     let total_slots_array_parts: Vec<TokenStream> = arrays
         .iter()
         .map(|(_, f)| {
@@ -325,7 +340,7 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
         })
         .collect();
 
-    // ── collect_jump_args: scalars, then flattened arrays, then virt array ptr+len ──
+    // ── collect_jump_args: scalars, then flattened arrays, then the vable identity ──
     let collect_scalar_parts: Vec<TokenStream> = scalars
         .iter()
         .map(|(_, f)| {
@@ -340,17 +355,11 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
             quote! { args.extend_from_slice(&sym.#fname); }
         })
         .collect();
-    let collect_virt_array_parts: Vec<TokenStream> = virt_arrays
-        .iter()
-        .map(|(_, f)| {
-            let ptr_name = quote::format_ident!("{}_ptr", f.name);
-            let len_name = quote::format_ident!("{}_len", f.name);
-            quote! {
-                args.push(sym.#ptr_name);
-                args.push(sym.#len_name);
-            }
-        })
-        .collect();
+    let collect_vable_identity_part: TokenStream = if has_vable_identity {
+        quote! { args.push(sym.__vable_identity); }
+    } else {
+        quote! {}
+    };
     // ── populate_frame_int_regs: scalars + flattened arrays ──
     // Matches `live_slots_for_state_field_jit` slot order so a
     // `MIFrame::get_list_of_active_boxes` walk against the canonical
@@ -388,43 +397,24 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
             }
         })
         .collect();
-    // Virt-array populate: two consecutive slots per
-    // varray — `<varr>_ptr` (data pointer OpRef) at offset N, then
-    // `<varr>_len` at N+1.  Value mirrors come from
-    // `<varr>_ptr_value` / `<varr>_len_value` cached at
-    // `JitState::initialize_sym` from the user state's
-    // `<varr>.as_ptr() as i64` / `<varr>.len() as i64`.
-    let populate_virt_array_parts: Vec<TokenStream> = virt_arrays
-        .iter()
-        .map(|(_, f)| {
-            let ptr_name = quote::format_ident!("{}_ptr", f.name);
-            let len_name = quote::format_ident!("{}_len", f.name);
-            let ptr_value_name = quote::format_ident!("{}_ptr_value", f.name);
-            let len_value_name = quote::format_ident!("{}_len_value", f.name);
-            quote! {
-                // `<varr>_ptr` is the backing storage's raw data pointer (a
-                // raw address, not a GC ref) and `<varr>_len` its length: both
-                // occupy int slots, matching `live_slots_for_state_field_jit`
-                // (which counts `2 * num_virt_arrays` into `live_i`), the
-                // `StateFieldLayout::total_slots` decode, and the int-stream
-                // resume reader. The vable identity, when the state has one,
-                // is a separate `ref(<T>)` scalar in the ref bank — NOT this
-                // pointer. Writing the ptr to the ref bank desyncs it from the
-                // int `live_i` index the resume reader decodes, leaving
-                // `int_regs[slot]` unset when the guard snapshot is collected.
-                if __slot < frame.int_regs.len() {
-                    frame.int_regs[__slot] = Some(self.#ptr_name);
-                    frame.int_values[__slot] = Some(self.#ptr_value_name);
-                }
-                __slot += 1;
-                if __slot < frame.int_regs.len() {
-                    frame.int_regs[__slot] = Some(self.#len_name);
-                    frame.int_values[__slot] = Some(self.#len_value_name);
-                }
-                __slot += 1;
+    // Virtualizable populate: ONE slot holding the `&state` identity, past the
+    // scalars and fixed-array elements, matching
+    // `live_slots_for_state_field_jit` and `StateFieldLayout::total_slots`.
+    // It occupies an INT slot even though it carries a Ref: the resume reader
+    // decodes this bank by the int `live_i` index, and writing the identity to
+    // the ref bank instead would desync it, leaving `int_regs[slot]` unset when
+    // the guard snapshot is collected.
+    let populate_vable_identity_part: TokenStream = if has_vable_identity {
+        quote! {
+            if __slot < frame.int_regs.len() {
+                frame.int_regs[__slot] = Some(self.__vable_identity);
+                frame.int_values[__slot] = Some(self.__vable_identity_value);
             }
-        })
-        .collect();
+            __slot += 1;
+        }
+    } else {
+        quote! {}
+    };
 
     // ── seed_recursive_fresh_frame: fresh state as CONSTANTS ──
     // Same slot layout as `populate_frame_int_regs`, but writes const OpRefs
@@ -459,25 +449,21 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
             }
         })
         .collect();
-    let seed_virt_array_parts: Vec<TokenStream> = virt_arrays
-        .iter()
-        .map(|(_, f)| {
-            let len_value_name = quote::format_ident!("{}_len_value", f.name);
-            quote! {
-                if __slot < frame.int_regs.len() {
-                    frame.int_regs[__slot] = Some(majit_ir::OpRef::const_int(0));
-                    frame.int_values[__slot] = Some(0);
-                }
-                __slot += 1;
-                let __cap = self.#len_value_name;
-                if __slot < frame.int_regs.len() {
-                    frame.int_regs[__slot] = Some(majit_ir::OpRef::const_int(__cap));
-                    frame.int_values[__slot] = Some(__cap);
-                }
-                __slot += 1;
+    // The fresh callee's identity is not known at the call site (it allocates
+    // its own state), so seed the one identity slot as const 0; the array
+    // capacities it re-allocates at come from the caller's `<arr>_len_value`
+    // mirrors in `recursive_fresh_entry_reds`, not from a boxed length.
+    let seed_vable_identity_part: TokenStream = if has_vable_identity {
+        quote! {
+            if __slot < frame.int_regs.len() {
+                frame.int_regs[__slot] = Some(majit_ir::OpRef::const_int(0));
+                frame.int_values[__slot] = Some(0);
             }
-        })
-        .collect();
+            __slot += 1;
+        }
+    } else {
+        quote! {}
+    };
 
     // ── snapshot/reset/restore inline scalar+fixed-array sym state ──
     // The sym holds the WORKING scalar (and fixed-array) state read/written by
@@ -574,17 +560,11 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
             quote! { args.extend_from_slice(&self.#fname); }
         })
         .collect();
-    let fail_virt_array_parts: Vec<TokenStream> = virt_arrays
-        .iter()
-        .map(|(_, f)| {
-            let ptr_name = quote::format_ident!("{}_ptr", f.name);
-            let len_name = quote::format_ident!("{}_len", f.name);
-            quote! {
-                args.push(self.#ptr_name);
-                args.push(self.#len_name);
-            }
-        })
-        .collect();
+    let fail_vable_identity_part: TokenStream = if has_vable_identity {
+        quote! { args.push(self.__vable_identity); }
+    } else {
+        quote! {}
+    };
 
     // ── build_meta: capture flattened array lengths ──
     let build_meta_fields: Vec<TokenStream> = arrays
@@ -611,7 +591,7 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
         })
         .collect();
 
-    // ── extract_live: scalars, then flattened array elements, then virt array ptr+len ──
+    // ── extract_live: scalars, then flattened array elements, then the vable identity ──
     let extract_scalar_parts: Vec<TokenStream> = scalars
         .iter()
         .map(|(_, f)| {
@@ -630,20 +610,17 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
             }
         })
         .collect();
-    let extract_virt_array_parts: Vec<TokenStream> = virt_arrays
-        .iter()
-        .map(|(_, f)| {
-            let fname = &f.name;
-            quote! {
-                // The vable base is the virtualizable identity (`&state` ==
-                // `virtualizable_heap_ptr`), NOT the array's data pointer:
-                // `vable_getarrayitem_*` reaches the element through the
-                // RustVec storage from this base. Every virt array shares it.
-                values.push(self as *const Self as i64);
-                values.push(self.#fname.len() as i64);
-            }
-        })
-        .collect();
+    // One value: the virtualizable identity (`&state` ==
+    // `virtualizable_heap_ptr`), NOT any array's data pointer —
+    // `vable_getarrayitem_*` reaches every element through the RustVec storage
+    // from this base, and all `[.. ; virt]` arrays share it.  Emitting it once
+    // is `virtualizable.py:139-144`; the lengths stay off the red vector
+    // (`virtualizable.py:150-153` reads them off the live object).
+    let extract_vable_identity_part: TokenStream = if has_vable_identity {
+        quote! { values.push(self as *const Self as i64); }
+    } else {
+        quote! {}
+    };
     let debug_scalar_state_parts: Vec<TokenStream> = scalars
         .iter()
         .map(|(_, f)| {
@@ -732,16 +709,11 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
             }
         })
         .collect();
-    let debug_virt_array_label_parts: Vec<TokenStream> = virt_arrays
-        .iter()
-        .map(|(_, f)| {
-            let label = f.name.to_string();
-            quote! {
-                labels.push(::std::format!("{}.<vable>", #label));
-                labels.push(::std::format!("{}.len", #label));
-            }
-        })
-        .collect();
+    let debug_vable_identity_label_part: TokenStream = if has_vable_identity {
+        quote! { labels.push(::std::string::String::from("<vable>")); }
+    } else {
+        quote! {}
+    };
     let debug_ref_scalar_label_parts: Vec<TokenStream> = ref_scalars
         .iter()
         .map(|(_, f)| {
@@ -787,9 +759,9 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
         })
         .collect();
     // Reds in `extract_live` order: int scalars, then flattened fixed-array
-    // elements, then per virt array the `&state` identity (Ref) + length
-    // (Int).  Mirrors `extract_scalar_parts` / `extract_array_parts` /
-    // `extract_virt_array_parts` so the fresh reds match the callee loop's
+    // elements, then the single `&state` identity (Ref) when the state has a
+    // virtualizable.  Mirrors `extract_scalar_parts` / `extract_array_parts` /
+    // `extract_vable_identity_part` so the fresh reds match the callee loop's
     // input-arg layout and `live_value_types` routing.
     let fresh_entry_scalar_value_pushes: Vec<TokenStream> = scalars
         .iter()
@@ -806,20 +778,17 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
             }
         })
         .collect();
-    let fresh_entry_virt_array_value_pushes: Vec<TokenStream> = virt_arrays
-        .iter()
-        .map(|(_, f)| {
-            let len_value_name = quote::format_ident!("{}_len_value", f.name);
-            quote! {
-                __values.push(majit_ir::Value::Ref(majit_ir::GcRef(__base as usize)));
-                __values.push(majit_ir::Value::Int(self.#len_value_name));
-            }
-        })
-        .collect();
-    // The freshly-boxed `&state` identity feeds the virt-array Ref slots; only
+    let fresh_entry_vable_identity_push: TokenStream = if has_vable_identity {
+        quote! {
+            __values.push(majit_ir::Value::Ref(majit_ir::GcRef(__base as usize)));
+        }
+    } else {
+        quote! {}
+    };
+    // The freshly-boxed `&state` identity feeds the one vable Ref slot; only
     // bound when there is at least one virt array (fixed-array-only reds carry
     // no pointer).
-    let fresh_entry_base_let: TokenStream = if num_virt_arrays > 0 {
+    let fresh_entry_base_let: TokenStream = if has_vable_identity {
         quote! { let __base = &*__fresh as *const #state_type as i64; }
     } else {
         quote! {}
@@ -844,7 +813,7 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
                     let mut __values: Vec<majit_ir::Value> = Vec::new();
                     #(#fresh_entry_scalar_value_pushes)*
                     #(#fresh_entry_array_value_pushes)*
-                    #(#fresh_entry_virt_array_value_pushes)*
+                    #fresh_entry_vable_identity_push
                     Some((__values, __fresh as Box<dyn ::core::any::Any>))
                 }
             }
@@ -953,20 +922,25 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
     let create_sym_virt_array_inits: Vec<TokenStream> = virt_arrays
         .iter()
         .map(|(_, f)| {
-            let ptr_name = quote::format_ident!("{}_ptr", f.name);
-            let len_name = quote::format_ident!("{}_len", f.name);
-            let ptr_value_name = quote::format_ident!("{}_ptr_value", f.name);
             let len_value_name = quote::format_ident!("{}_len_value", f.name);
-            quote! {
-                let #ptr_name = majit_ir::OpRef::input_arg_ref(__offset as u32);
-                __offset += 1;
-                let #len_name = majit_ir::OpRef::input_arg_int(__offset as u32);
-                __offset += 1;
-                let #ptr_value_name = 0i64;
-                let #len_value_name = 0i64;
-            }
+            quote! { let #len_value_name = 0i64; }
         })
         .collect();
+    // One inputarg for the whole virtualizable, in the same flat offset space
+    // as every other inputarg.  The array elements that follow are carried by
+    // `virtualizable_boxes`, so this is the last header slot — which makes the
+    // loop's entry contract the same shape as a guard's vable section
+    // (`resume.py:1404` + `virtualizable.py:139-144`) and therefore the same
+    // shape a bridge entering that loop presents.
+    let create_sym_vable_identity_init: TokenStream = if has_vable_identity {
+        quote! {
+            let __vable_identity = majit_ir::OpRef::input_arg_ref(__offset as u32);
+            __offset += 1;
+            let __vable_identity_value = 0i64;
+        }
+    } else {
+        quote! {}
+    };
     let create_sym_scalar_names: Vec<&syn::Ident> = scalars.iter().map(|(_, f)| &f.name).collect();
     let create_sym_array_names: Vec<&syn::Ident> = arrays.iter().map(|(_, f)| &f.name).collect();
     let create_sym_scalar_value_names: Vec<syn::Ident> = scalars
@@ -977,25 +951,21 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
         .iter()
         .map(|(_, f)| quote::format_ident!("{}_values", f.name))
         .collect();
-    let create_sym_virt_array_ptr_names: Vec<syn::Ident> = virt_arrays
-        .iter()
-        .map(|(_, f)| quote::format_ident!("{}_ptr", f.name))
-        .collect();
-    let create_sym_virt_array_len_names: Vec<syn::Ident> = virt_arrays
-        .iter()
-        .map(|(_, f)| quote::format_ident!("{}_len", f.name))
-        .collect();
-    let create_sym_virt_array_ptr_value_names: Vec<syn::Ident> = virt_arrays
-        .iter()
-        .map(|(_, f)| quote::format_ident!("{}_ptr_value", f.name))
-        .collect();
+    let create_sym_vable_identity_field_names: TokenStream = if has_vable_identity {
+        quote! {
+            __vable_identity,
+            __vable_identity_value,
+        }
+    } else {
+        quote! {}
+    };
     let create_sym_virt_array_len_value_names: Vec<syn::Ident> = virt_arrays
         .iter()
         .map(|(_, f)| quote::format_ident!("{}_len_value", f.name))
         .collect();
 
     // ── is_compatible: check flattened array lengths match meta ──
-    // Virt arrays always compatible (ptr+len are inputargs, not fixed).
+    // Virt arrays always compatible (their length is read off the live object).
     let compat_checks: Vec<TokenStream> = arrays
         .iter()
         .map(|(_, f)| {
@@ -1006,7 +976,8 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
         .collect();
 
     // ── restore: write values back to state fields ──
-    // Virt arrays: restore ptr (ignored, Vec owns it) and skip len.
+    // The virtualizable identity slot is skipped (the Vec owns its storage and
+    // compiled code already mutated the elements in place).
     // The compiled code writes directly to the heap backing the Vec, so
     // no element-level restore is needed.
     let restore_scalar_parts: Vec<TokenStream> = scalars
@@ -1073,16 +1044,13 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
             }
         })
         .collect();
-    let restore_virt_array_parts: Vec<TokenStream> = virt_arrays
-        .iter()
-        .map(|_| {
-            // Skip the 2 slots (ptr + len) — virt array data lives on heap,
-            // already modified in-place by compiled code.
-            quote! {
-                __offset += 2;
-            }
-        })
-        .collect();
+    // Skip the one identity slot — the virt-array data lives on the heap and
+    // was already modified in place by compiled code.
+    let restore_vable_identity_part: TokenStream = if has_vable_identity {
+        quote! { __offset += 1; }
+    } else {
+        quote! {}
+    };
     // Single-pass close: write the walk-final virt-array element values
     // (captured off the trace-ctx shadow) into native state, one array at a
     // time in declaration order. Mirrors `restore_array_parts`'s per-element
@@ -1135,10 +1103,10 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
             }
         })
         .collect();
-    // Virt-array `<varr>_ptr_value` / `<varr>_len_value` mirror the
-    // current `<state>.<varr>` ptr/len so `populate_frame_int_regs`
-    // can fill the corresponding `MIFrame.int_values` slots without
-    // re-reading the live state at guard time
+    // `<varr>_len_value` mirrors the current `<state>.<varr>` length for the
+    // fresh-callee capacity, and `__vable_identity_value` the `&state` identity
+    // so `populate_frame_int_regs` can fill the corresponding
+    // `MIFrame.int_values` slot without re-reading the live state at guard time
     // TODO:
     // accurate iff the user's varray Vec does not reallocate during
     // tracing — true for the 6 macro examples
@@ -1148,20 +1116,21 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
         .iter()
         .map(|(_, f)| {
             let fname = &f.name;
-            let ptr_value_name = quote::format_ident!("{}_ptr_value", f.name);
             let len_value_name = quote::format_ident!("{}_len_value", f.name);
-            quote! {
-                // Vable base identity (`&state`), matching `extract_live` and
-                // `standard_virtualizable_concrete` so the traced vable box is
-                // recognized as the standard virtualizable (no force).
-                sym.#ptr_value_name = self as *const Self as i64;
-                sym.#len_value_name = self.#fname.len() as i64;
-            }
+            quote! { sym.#len_value_name = self.#fname.len() as i64; }
         })
         .collect();
+    // Vable base identity (`&state`), matching `extract_live` and
+    // `standard_virtualizable_concrete` so the traced vable box is recognized
+    // as the standard virtualizable (no force).
+    let initialize_sym_vable_identity_part: TokenStream = if has_vable_identity {
+        quote! { sym.__vable_identity_value = self as *const Self as i64; }
+    } else {
+        quote! {}
+    };
 
     // ── validate_close: flattened array lengths in sym match meta ──
-    // Virt arrays always validate (ptr+len are just OpRefs, not sized).
+    // Virt arrays always validate (their length is read off the live object).
     let validate_array_checks: Vec<TokenStream> = arrays
         .iter()
         .map(|(_, f)| {
@@ -1229,12 +1198,12 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
         .enumerate()
         .map(|(ref_idx, (_, f))| {
             let fname = &f.name;
-            // `live_value_types` routes one `Ref` per virt array (the shared
-            // `&state` identity) into the ref bank ahead of the ref scalars, so
-            // ref scalar `j` lives at `ref_values[num_virt_arrays + j]`, not
-            // `ref_values[j]`.  Mirrors `populate_ref_scalar_parts`, which skips
-            // the same prefix in the register bank via `ref_identity_base`.
-            let slot = num_virt_arrays + ref_idx;
+            // `live_value_types` routes the single vable identity `Ref` into
+            // the ref bank ahead of the ref scalars, so ref scalar `j` lives at
+            // `ref_values[num_vable_identity_slots + j]`, not `ref_values[j]`.
+            // Mirrors `populate_ref_scalar_parts`, which skips the same prefix
+            // in the register bank via `ref_identity_base`.
+            let slot = num_vable_identity_slots + ref_idx;
             quote! { self.#fname = ref_values[#slot] as usize; }
         })
         .collect();
@@ -1325,17 +1294,11 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
             }
         })
         .collect();
-    let typed_virt_array_parts: Vec<TokenStream> = virt_arrays
-        .iter()
-        .map(|(_, f)| {
-            let ptr_name = quote::format_ident!("{}_ptr", f.name);
-            let len_name = quote::format_ident!("{}_len", f.name);
-            quote! {
-                args.push((sym.#ptr_name, majit_ir::Type::Ref));
-                args.push((sym.#len_name, majit_ir::Type::Int));
-            }
-        })
-        .collect();
+    let typed_vable_identity_part: TokenStream = if has_vable_identity {
+        quote! { args.push((sym.__vable_identity, majit_ir::Type::Ref)); }
+    } else {
+        quote! {}
+    };
     let typed_ref_scalar_parts: Vec<TokenStream> = ref_scalars
         .iter()
         .map(|(_, f)| {
@@ -1369,7 +1332,7 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
             let mut args: Vec<(majit_ir::OpRef, majit_ir::Type)> = Vec::new();
             #(#typed_scalar_parts)*
             #(#typed_array_parts)*
-            #(#typed_virt_array_parts)*
+            #typed_vable_identity_part
             #typed_element_splice
             #(#typed_ref_scalar_parts)*
             #(#typed_float_scalar_parts)*
@@ -1628,17 +1591,13 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
     // Optional method overrides — emitted ONLY when ref scalars exist, so
     // interps with none generate a byte-identical token stream (the trait
     // defaults from `JitState` / `JitCodeSym` apply).
-    // Per-virt-array value-routing types: the identity pointer slot is Ref,
-    // the length slot is Int (in `extract_live` ptr-then-len order).
-    let virt_array_type_parts: Vec<TokenStream> = virt_arrays
-        .iter()
-        .map(|_| {
-            quote! {
-                types.push(majit_ir::Type::Ref);
-                types.push(majit_ir::Type::Int);
-            }
-        })
-        .collect();
+    // The virtualizable's value-routing type: one Ref for the identity,
+    // whatever the number of `[.. ; virt]` arrays.
+    let vable_identity_type_part: TokenStream = if has_vable_identity {
+        quote! { types.push(majit_ir::Type::Ref); }
+    } else {
+        quote! {}
+    };
     // Per-array value-routing types: one Int per element.
     let array_type_parts: Vec<TokenStream> = arrays
         .iter()
@@ -1656,11 +1615,11 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
             quote! {
                 fn live_value_types(&self, _meta: &__JitMeta) -> Vec<majit_ir::Type> {
                     // Value-routing types in `extract_live` order: int scalars,
-                    // int array elements, then per virt-array the identity ptr
-                    // (Ref) + length (Int), then appended ref scalars (Ref), then
-                    // appended float scalars (Float).
-                    // The ptr slot MUST be Ref so the live `&state` identity is a
-                    // Ref failarg (TAGBOX), which the resume reader decodes through
+                    // int array elements, then the ONE virtualizable identity
+                    // (Ref), then appended ref scalars (Ref), then appended float
+                    // scalars (Float).
+                    // The identity slot MUST be Ref so the live `&state` is a Ref
+                    // failarg (TAGBOX), which the resume reader decodes through
                     // `decode_ref` in both the vable section and the frame
                     // ref-liveness.
                     let mut types: Vec<majit_ir::Type> = Vec::new();
@@ -1668,7 +1627,7 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
                         types.push(majit_ir::Type::Int);
                     }
                     #(#array_type_parts)*
-                    #(#virt_array_type_parts)*
+                    #vable_identity_type_part
                     for _ in 0..#num_ref_scalars {
                         types.push(majit_ir::Type::Ref);
                     }
@@ -1789,7 +1748,7 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
             majit_metainterp::blackhole::StateFieldLayout::with_ref_scalars(
                 #num_scalars,
                 ::std::vec![#(self.#create_sym_array_names.len()),*],
-                #num_virt_arrays,
+                #num_vable_identity_slots,
                 #num_ref_scalars,
                 #ref_identity_base,
                 #int_identity_base,
@@ -1800,7 +1759,7 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
             majit_metainterp::blackhole::StateFieldLayout::new(
                 #num_scalars,
                 ::std::vec![#(self.#create_sym_array_names.len()),*],
-                #num_virt_arrays,
+                #num_vable_identity_slots,
                 #int_identity_base,
             ).with_float_scalars(#num_float_scalars, #float_identity_base)
         }
@@ -2011,7 +1970,7 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
                 majit_metainterp::live_slots_for_state_field_jit(
                     #num_scalars,
                     __array_lens,
-                    #num_virt_arrays,
+                    #num_vable_identity_slots,
                     #num_ref_scalars,
                     #ref_identity_base,
                     #num_float_scalars,
@@ -2223,6 +2182,7 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
             #(#sym_array_fields)*
             #(#sym_array_value_fields)*
             #(#sym_virt_array_fields)*
+            #sym_vable_identity_fields
             #(#sym_ref_scalar_fields)*
             #(#sym_ref_scalar_value_fields)*
             #(#sym_float_scalar_fields)*
@@ -2235,7 +2195,7 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
 
         impl majit_metainterp::JitCodeSym for __JitSym {
             fn total_slots(&self) -> usize {
-                #num_scalars #(#total_slots_array_parts)* + #num_virt_arrays * 2
+                #num_scalars #(#total_slots_array_parts)* + #num_vable_identity_slots
             }
 
             fn loop_carried_boxes(
@@ -2320,7 +2280,7 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
                 let mut args = Vec::new();
                 #(#fail_scalar_parts)*
                 #(#fail_array_parts)*
-                #(#fail_virt_array_parts)*
+                #fail_vable_identity_part
                 #(#fail_ref_scalar_parts)*
                 #(#fail_float_scalar_parts)*
                 Some(args)
@@ -2345,7 +2305,7 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
                 let mut __slot: usize = #int_identity_base;
                 #(#populate_scalar_parts)*
                 #(#populate_array_parts)*
-                #(#populate_virt_array_parts)*
+                #populate_vable_identity_part
                 let _ = __slot;
                 #(#populate_ref_scalar_parts)*
                 #(#populate_float_scalar_parts)*
@@ -2359,7 +2319,7 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
                 let mut __slot: usize = #int_identity_base;
                 #(#seed_scalar_parts)*
                 #(#seed_array_parts)*
-                #(#seed_virt_array_parts)*
+                #seed_vable_identity_part
                 let _ = __slot;
             }
 
@@ -2406,7 +2366,7 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
                 let mut values = Vec::new();
                 #(#extract_scalar_parts)*
                 #(#extract_array_parts)*
-                #(#extract_virt_array_parts)*
+                #extract_vable_identity_part
                 #(#extract_ref_scalar_parts)*
                 #(#extract_float_scalar_parts)*
                 values
@@ -2419,6 +2379,7 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
                 #(#create_sym_scalar_inits)*
                 #(#create_sym_array_inits)*
                 #(#create_sym_virt_array_inits)*
+                #create_sym_vable_identity_init
                 #(#create_sym_ref_scalar_inits)*
                 #(#create_sym_float_scalar_inits)*
                 __JitSym {
@@ -2426,10 +2387,8 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
                     #(#create_sym_scalar_value_names,)*
                     #(#create_sym_array_names,)*
                     #(#create_sym_array_value_names,)*
-                    #(#create_sym_virt_array_ptr_names,)*
-                    #(#create_sym_virt_array_len_names,)*
-                    #(#create_sym_virt_array_ptr_value_names,)*
                     #(#create_sym_virt_array_len_value_names,)*
+                    #create_sym_vable_identity_field_names
                     #(#create_sym_ref_scalar_names,)*
                     #(#create_sym_ref_scalar_value_names,)*
                     #(#create_sym_float_scalar_names,)*
@@ -2443,6 +2402,7 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
                 #(#initialize_sym_scalar_parts)*
                 #(#initialize_sym_array_parts)*
                 #(#initialize_sym_virt_array_parts)*
+                #initialize_sym_vable_identity_part
                 #(#initialize_sym_ref_scalar_parts)*
                 #(#initialize_sym_float_scalar_parts)*
             }
@@ -2787,7 +2747,7 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
                 let mut __offset: usize = 0;
                 #(#restore_scalar_parts)*
                 #(#restore_array_parts)*
-                #(#restore_virt_array_parts)*
+                #restore_vable_identity_part
             }
 
             #restore_banked_override
@@ -2810,7 +2770,7 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
                 let mut labels: ::std::vec::Vec<::std::string::String> = ::std::vec::Vec::new();
                 #(#debug_scalar_label_parts)*
                 #(#debug_array_label_parts)*
-                #(#debug_virt_array_label_parts)*
+                #debug_vable_identity_label_part
                 #(#debug_ref_scalar_label_parts)*
                 #(#debug_float_scalar_label_parts)*
                 Some(labels)
@@ -2865,7 +2825,7 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
                 let mut args = Vec::new();
                 #(#collect_scalar_parts)*
                 #(#collect_array_parts)*
-                #(#collect_virt_array_parts)*
+                #collect_vable_identity_part
                 #(#collect_ref_scalar_parts)*
                 #(#collect_float_scalar_parts)*
                 args

--- a/majit/majit-macros/src/jit_interp/codegen_state.rs
+++ b/majit/majit-macros/src/jit_interp/codegen_state.rs
@@ -1806,6 +1806,40 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
         }
     };
 
+    // pyjitpl.py:3449 `rebuild_state_after_failure`:
+    //     if vinfo is not None:
+    //         self.virtualizable_boxes = virtualizable_boxes
+    // The guard's vable section is decoded by `rebuild_from_resumedata` above;
+    // rebuild the shadow from it so the bridge traces with the same
+    // virtualizable the parent loop had.  Without it `virtualizable_boxes`
+    // stays None for the whole bridge and `__trace_*` aborts at its first
+    // statement (`standard_virtualizable_jitcode_argbox` has nothing to
+    // resolve), so a state with `[.. ; virt]` arrays never forms a bridge at
+    // all — every guard exit deopts through the blackhole instead.
+    let seed_bridge_vable: TokenStream = if num_virt_arrays > 0 {
+        quote! {
+            if let Some(__vinfo) = Self::__build_virtualizable_info() {
+                let __seeded = majit_metainterp::seed_bridge_virtualizable_boxes(
+                    ctx,
+                    &__vinfo,
+                    rd_virtuals,
+                    resume_data,
+                    &mut __bridge_cache,
+                    fail_values,
+                );
+                if std::env::var("MAJIT_BRIDGE_DEBUG").is_ok() {
+                    eprintln!(
+                        "[bridgeB] vable seed={} stream={}",
+                        __seeded,
+                        resume_data.virtualizable_values.len(),
+                    );
+                }
+            }
+        }
+    } else {
+        quote! {}
+    };
+
     // ── VirtualizableInfo / heap-ptr overrides for `[int; virt]` arrays ──
     // Each virt array becomes a standard-virtualizable RustVec array field on
     // a zero-static-field vinfo, so `state.<arr>[i]` lowers through the
@@ -2568,6 +2602,7 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
                     rd_virtuals,
                     &mut __bridge_cache,
                 );
+                #seed_bridge_vable
                 let frame = match resume_data.frames.first() {
                     Some(f) => f,
                     None => return,

--- a/majit/majit-macros/src/jit_interp/codegen_state.rs
+++ b/majit/majit-macros/src/jit_interp/codegen_state.rs
@@ -1867,6 +1867,20 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
                 }
             })
             .collect();
+        // `extract_live` pushes int scalars, then every fixed array's items,
+        // then the one identity slot. With no fixed arrays that position is a
+        // constant — `num_scalars` — so the identity can be DECLARED the way
+        // `warmspot.py:529-538` declares `index_of_virtualizable`, and
+        // `initialize_virtualizable` can look it up instead of searching the
+        // reds for a matching pointer. A fixed `[int]` array alongside a
+        // `[int; virt]` one would make the position depend on that array's
+        // runtime length; no front-end declares both, and the lookup falls
+        // back to the pointer match when it happens.
+        let identity_live_index_stmt: TokenStream = if arrays.is_empty() {
+            quote! { __info.identity_live_index = Some(#num_scalars); }
+        } else {
+            quote! {}
+        };
         quote! {
             #[allow(non_snake_case)]
             fn __build_virtualizable_info()
@@ -1889,6 +1903,7 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
                 // `num_green_args + index_of_virtualizable` ordinal would
                 // resolve to 0, the slot the green ref occupies).
                 __info.identity_ref_bank_index = Some(1);
+                #identity_live_index_stmt
                 #(#virt_array_field_parts)*
                 Some(__info.finalize_arc(
                     majit_ir::descr::make_size_descr(::std::mem::size_of::<#state_type>()),

--- a/majit/majit-macros/src/jit_interp/codegen_state.rs
+++ b/majit/majit-macros/src/jit_interp/codegen_state.rs
@@ -1273,51 +1273,119 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
             }
         })
         .collect();
-    let collect_float_scalar_parts_for_jump: Vec<TokenStream> = float_scalars
-        .iter()
-        .map(|(_, f)| {
-            let fname = &f.name;
-            quote! { args.push(sym.#fname); }
-        })
-        .collect();
-    // Override `JitState::collect_jump_args_with_boxes` when the state has any
-    // `[int; virt]` array (tl/tlc/tla/braininterp + multi-array interps). With
-    // 0 virt arrays (tlr/tinyframe) the defaulted trait method (scalars + fixed
-    // arrays) is already correct, so the `else` is the 0-array case.
+    // pyjitpl.py:2981-2989 `live_arg_boxes` — THE loop-carried box list, built
+    // in exactly one place because it has two consumers that must agree:
+    // `JitState::collect_jump_args_with_boxes` (the closing JUMP) and
+    // `JitCodeSym::loop_carried_boxes` (the merge-point registration, i.e. a
+    // later cross-loop cut's LABEL). RPython gets that agreement for free —
+    // `reached_loop_header` builds one list and passes it to both — and
+    // asserts it at pyjitpl.py:3020. Two independent constructions here is
+    // what made every purely-virt-array interpreter's nested loop decline on
+    // `jump.numargs() != label.numargs()` (compile.py:334).
     //
-    // The JUMP must be slot-for-slot identical to the trace-entry Label, whose
-    // virt-array inputargs are all the `<arr>_ptr`/`<arr>_len` headers (minted
-    // by `create_sym` advancing `__offset`, declaration order) followed by the
-    // element boxes (minted by `initialize_virtualizable` at
-    // `num_reds..num_reds+total`). `__boxes` =
-    // `TraceCtx::collect_virtualizable_boxes()` =
+    // The list must be slot-for-slot identical to the trace-entry Label, whose
+    // inputargs are minted by `create_sym` advancing `__offset` in declaration
+    // order — int scalars (Int), each fixed `[int]` array's cells (Int), then
+    // per virt array the `<arr>_ptr` (Ref, `input_arg_ref`) + `<arr>_len`
+    // (Int) header, then ref scalars (Ref), then float scalars (Float) — with
+    // the element boxes minted by `initialize_virtualizable` at
+    // `num_reds..num_reds+total`. `__boxes` =
+    // `TraceCtx::collect_virtualizable_typed_boxes()` =
     // `[arr0_elem0.., arr1_elem0.., .., identity]` (`num_static_extra_boxes==0`
     // for state-field; `initialize_virtualizable` concatenates the arrays in
     // declaration order; identity LAST). So push every header first (loop-
     // invariant identity bases + lengths), then the whole element shadow once,
-    // dropping the trailing identity (pyjitpl.py:2982-2989 `live_arg_boxes +=
+    // dropping the trailing identity (pyjitpl.py:2988-2989 `live_arg_boxes +=
     // virtualizable_boxes; live_arg_boxes.pop()`). The element block is already
     // in per-array order, so a single contiguous splice reproduces the Label
     // for any number of arrays; pushing it once-per-array (or putting elements
     // before a later array's header) would shift every later slot and break the
     // unroll's Label↔Jump virtual-state match.
+    //
+    // With 0 virt arrays (tlr/tinyframe) there is no element shadow to splice,
+    // so the body degenerates to `collect_jump_args` and `__boxes` is unused —
+    // which is why the `collect_jump_args_with_boxes` override below stays
+    // gated on `num_virt_arrays >= 1` (the trait default already delegates to
+    // `collect_jump_args` there).
+    let typed_scalar_parts: Vec<TokenStream> = scalars
+        .iter()
+        .map(|(_, f)| {
+            let fname = &f.name;
+            quote! { args.push((sym.#fname, majit_ir::Type::Int)); }
+        })
+        .collect();
+    let typed_array_parts: Vec<TokenStream> = arrays
+        .iter()
+        .map(|(_, f)| {
+            let fname = &f.name;
+            quote! {
+                for &__cell in sym.#fname.iter() {
+                    args.push((__cell, majit_ir::Type::Int));
+                }
+            }
+        })
+        .collect();
+    let typed_virt_array_parts: Vec<TokenStream> = virt_arrays
+        .iter()
+        .map(|(_, f)| {
+            let ptr_name = quote::format_ident!("{}_ptr", f.name);
+            let len_name = quote::format_ident!("{}_len", f.name);
+            quote! {
+                args.push((sym.#ptr_name, majit_ir::Type::Ref));
+                args.push((sym.#len_name, majit_ir::Type::Int));
+            }
+        })
+        .collect();
+    let typed_ref_scalar_parts: Vec<TokenStream> = ref_scalars
+        .iter()
+        .map(|(_, f)| {
+            let fname = &f.name;
+            quote! { args.push((sym.#fname, majit_ir::Type::Ref)); }
+        })
+        .collect();
+    let typed_float_scalar_parts: Vec<TokenStream> = float_scalars
+        .iter()
+        .map(|(_, f)| {
+            let fname = &f.name;
+            quote! { args.push((sym.#fname, majit_ir::Type::Float)); }
+        })
+        .collect();
+    let typed_element_splice: TokenStream = if num_virt_arrays >= 1 {
+        quote! {
+            let __elem_count = __boxes.len().saturating_sub(1);
+            args.extend_from_slice(&__boxes[..__elem_count]);
+        }
+    } else {
+        quote! {}
+    };
+    let loop_carried_boxes_fn: TokenStream = quote! {
+        /// pyjitpl.py:2981-2989 `live_arg_boxes`, typed. See the emit-site
+        /// comment in `majit-macros/src/jit_interp/codegen_state.rs`.
+        #[allow(unused_variables)]
+        fn __jit_loop_carried_boxes(
+            sym: &__JitSym,
+            __boxes: &[(majit_ir::OpRef, majit_ir::Type)],
+        ) -> Vec<(majit_ir::OpRef, majit_ir::Type)> {
+            let mut args: Vec<(majit_ir::OpRef, majit_ir::Type)> = Vec::new();
+            #(#typed_scalar_parts)*
+            #(#typed_array_parts)*
+            #(#typed_virt_array_parts)*
+            #typed_element_splice
+            #(#typed_ref_scalar_parts)*
+            #(#typed_float_scalar_parts)*
+            args
+        }
+    };
     let collect_jump_args_with_boxes_method: TokenStream = if num_virt_arrays >= 1 {
         quote! {
             fn collect_jump_args_with_boxes(
                 sym: &__JitSym,
-                __boxes: &[majit_ir::OpRef],
+                __boxes: &[(majit_ir::OpRef, majit_ir::Type)],
             ) -> Vec<majit_ir::OpRef> {
-                let mut args = Vec::new();
-                #(#collect_scalar_parts)*
-                #(#collect_array_parts)*
-                #(#collect_virt_array_parts)*
-                let __elem_count = __boxes.len().saturating_sub(1);
-                for __i in 0..__elem_count {
-                    args.push(__boxes[__i]);
-                }
-                #(#collect_ref_scalar_parts)*
-                #(#collect_float_scalar_parts_for_jump)*
-                args
+                __jit_loop_carried_boxes(sym, __boxes)
+                    .into_iter()
+                    .map(|(__opref, _)| __opref)
+                    .collect()
             }
         }
     } else {
@@ -2129,9 +2197,18 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
             trace_started: bool,
         }
 
+        #loop_carried_boxes_fn
+
         impl majit_metainterp::JitCodeSym for __JitSym {
             fn total_slots(&self) -> usize {
                 #num_scalars #(#total_slots_array_parts)* + #num_virt_arrays * 2
+            }
+
+            fn loop_carried_boxes(
+                &self,
+                __boxes: &[(majit_ir::OpRef, majit_ir::Type)],
+            ) -> Option<Vec<(majit_ir::OpRef, majit_ir::Type)>> {
+                Some(__jit_loop_carried_boxes(self, __boxes))
             }
 
             fn int_identity_slots_end(&self) -> usize {

--- a/majit/majit-macros/src/jit_interp/codegen_state.rs
+++ b/majit/majit-macros/src/jit_interp/codegen_state.rs
@@ -1613,6 +1613,11 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
     let live_value_types_override: TokenStream =
         if num_ref_scalars > 0 || num_virt_arrays > 0 || num_float_scalars > 0 {
             quote! {
+                // A bank with no scalars emits `0..0`, which is data, not the
+                // `for i in 10..0` typo `reversed_empty_ranges` is aimed at —
+                // and that lint is deny-by-default in every consumer of this
+                // macro, so a state of arrays only would not compile there.
+                #[allow(clippy::reversed_empty_ranges)]
                 fn live_value_types(&self, _meta: &__JitMeta) -> Vec<majit_ir::Type> {
                     // Value-routing types in `extract_live` order: int scalars,
                     // int array elements, then the ONE virtualizable identity
@@ -2527,6 +2532,7 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
             // fields like `selected` to `Const`, so only the identity register
             // reliably names the field).  Box → `input_arg(n)` + `fail_values[n]`;
             // Const → a folded pool constant.  MAJIT_BRIDGE_DEBUG dumps it.
+            #[allow(clippy::reversed_empty_ranges)]
             fn setup_bridge_sym(
                 sym: &mut __JitSym,
                 ctx: &mut majit_metainterp::TraceCtx,

--- a/majit/majit-macros/src/jit_interp/codegen_state.rs
+++ b/majit/majit-macros/src/jit_interp/codegen_state.rs
@@ -144,38 +144,6 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
     let num_vable_identity_slots = usize::from(has_vable_identity);
     let num_ref_scalars = ref_scalars.len();
     let num_float_scalars = float_scalars.len();
-    // The virtualizable's element boxes are a strict SUFFIX of the loop-carried
-    // list upstream — `live_arg_boxes = greenboxes + redboxes` then
-    // `live_arg_boxes += self.virtualizable_boxes; live_arg_boxes.pop()`
-    // (pyjitpl.py:2981-2989), and `+=` cannot put an element before a red.
-    //
-    // Pyre's two sides disagree once a state has BOTH a `[.. ; virt]` array and
-    // a ref or float scalar:
-    //   entry (`JitDriver::extend_compiled_live_values`, jitdriver.rs)
-    //     `live_values.extend(extra_values)`
-    //     -> [ints, fixed arrays, identity, refs, floats] ++ [elements]
-    //   close (`__jit_loop_carried_boxes` below)
-    //     -> [ints, fixed arrays, identity, elements, refs, floats]
-    // Same arity, so `jump.numargs() == label.numargs()` (compile.py:334) still
-    // holds and nothing catches it — the JUMP just binds the ref/float scalars
-    // and the trailing elements to each other's LABEL slots.
-    //
-    // No interpreter in tree declares that combination (cel's `VmStateF` is
-    // arrays only; `tl` is one int scalar plus one virt array), so this refuses
-    // the shape rather than miscompiling it silently. Lifting the refusal means
-    // moving the element splice to the end of every vector that enumerates the
-    // reds, not relaxing this check.
-    if num_virt_arrays > 0 && (num_ref_scalars > 0 || num_float_scalars > 0) {
-        return quote! {
-            compile_error!(
-                "state_fields cannot yet combine a `[.. ; virt]` array with a ref or \
-                 float scalar: the closing JUMP splices the virtualizable's element \
-                 boxes ahead of those scalars while the entry contract appends them \
-                 after every red (pyjitpl.py:2981-2989 makes the elements a strict \
-                 suffix), so the two orders disagree at equal arity"
-            );
-        };
-    }
     // First ref-bank register available for ref-scalar identity slots.
     // `MIFrame::setup_call` packs the dispatch JitCode's ref args densely
     // from r0 (`program` at r0, the virtualizable identity at r1 when
@@ -1286,22 +1254,27 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
     //
     // The list must be slot-for-slot identical to the trace-entry Label, whose
     // inputargs are minted by `create_sym` advancing `__offset` in declaration
-    // order — int scalars (Int), each fixed `[int]` array's cells (Int), then
-    // per virt array the `<arr>_ptr` (Ref, `input_arg_ref`) + `<arr>_len`
-    // (Int) header, then ref scalars (Ref), then float scalars (Float) — with
-    // the element boxes minted by `initialize_virtualizable` at
-    // `num_reds..num_reds+total`. `__boxes` =
-    // `TraceCtx::collect_virtualizable_typed_boxes()` =
+    // order — int scalars (Int), each fixed `[int]` array's cells (Int), the
+    // one `__vable_identity` (Ref), then ref scalars (Ref), then float scalars
+    // (Float) — after which `JitDriver::extend_compiled_live_values` appends
+    // the element block with `live_values.extend(extra_values)`.
+    //
+    // So the element block is a strict SUFFIX of the reds, exactly as upstream
+    // builds it: `live_arg_boxes = greenboxes + redboxes` and then
+    // `live_arg_boxes += self.virtualizable_boxes; live_arg_boxes.pop()`
+    // (pyjitpl.py:2981-2989) — `+=` appends, so no element can precede a red.
+    // ⚠️Splicing the elements before the ref/float scalars (as this did until
+    // the order was unified) leaves the JUMP and the Label at the SAME arity
+    // with different slot meanings, so `jump.numargs() == label.numargs()`
+    // (compile.py:334) still passes and nothing downstream catches it.
+    //
+    // `__boxes` = `TraceCtx::collect_virtualizable_typed_boxes()` =
     // `[arr0_elem0.., arr1_elem0.., .., identity]` (`num_static_extra_boxes==0`
     // for state-field; `initialize_virtualizable` concatenates the arrays in
-    // declaration order; identity LAST). So push every header first (loop-
-    // invariant identity bases + lengths), then the whole element shadow once,
-    // dropping the trailing identity (pyjitpl.py:2988-2989 `live_arg_boxes +=
-    // virtualizable_boxes; live_arg_boxes.pop()`). The element block is already
-    // in per-array order, so a single contiguous splice reproduces the Label
-    // for any number of arrays; pushing it once-per-array (or putting elements
-    // before a later array's header) would shift every later slot and break the
-    // unroll's Label↔Jump virtual-state match.
+    // declaration order; identity LAST), so one contiguous splice of
+    // `__boxes[..len-1]` reproduces the Label's element tail for any number of
+    // arrays. Pushing it once-per-array would interleave the arrays and shift
+    // every later slot.
     //
     // With 0 virt arrays (tlr/tinyframe) there is no element shadow to splice,
     // so the body degenerates to `collect_jump_args` and `__boxes` is unused —
@@ -1362,12 +1335,18 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
             __boxes: &[(majit_ir::OpRef, majit_ir::Type)],
         ) -> Vec<(majit_ir::OpRef, majit_ir::Type)> {
             let mut args: Vec<(majit_ir::OpRef, majit_ir::Type)> = Vec::new();
+            // The reds, in `extract_live` / `live_value_types` order …
             #(#typed_scalar_parts)*
             #(#typed_array_parts)*
             #typed_vable_identity_part
-            #typed_element_splice
             #(#typed_ref_scalar_parts)*
             #(#typed_float_scalar_parts)*
+            // … then the element block as a strict SUFFIX, which is what
+            // `live_arg_boxes += self.virtualizable_boxes; live_arg_boxes.pop()`
+            // (pyjitpl.py:2988-2989) makes it, and what the entry contract
+            // builds with `live_values.extend(extra_values)`
+            // (`JitDriver::extend_compiled_live_values`).
+            #typed_element_splice
             args
         }
     };

--- a/majit/majit-macros/src/jit_interp/codegen_state.rs
+++ b/majit/majit-macros/src/jit_interp/codegen_state.rs
@@ -144,6 +144,38 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
     let num_vable_identity_slots = usize::from(has_vable_identity);
     let num_ref_scalars = ref_scalars.len();
     let num_float_scalars = float_scalars.len();
+    // The virtualizable's element boxes are a strict SUFFIX of the loop-carried
+    // list upstream — `live_arg_boxes = greenboxes + redboxes` then
+    // `live_arg_boxes += self.virtualizable_boxes; live_arg_boxes.pop()`
+    // (pyjitpl.py:2981-2989), and `+=` cannot put an element before a red.
+    //
+    // Pyre's two sides disagree once a state has BOTH a `[.. ; virt]` array and
+    // a ref or float scalar:
+    //   entry (`JitDriver::extend_compiled_live_values`, jitdriver.rs)
+    //     `live_values.extend(extra_values)`
+    //     -> [ints, fixed arrays, identity, refs, floats] ++ [elements]
+    //   close (`__jit_loop_carried_boxes` below)
+    //     -> [ints, fixed arrays, identity, elements, refs, floats]
+    // Same arity, so `jump.numargs() == label.numargs()` (compile.py:334) still
+    // holds and nothing catches it — the JUMP just binds the ref/float scalars
+    // and the trailing elements to each other's LABEL slots.
+    //
+    // No interpreter in tree declares that combination (cel's `VmStateF` is
+    // arrays only; `tl` is one int scalar plus one virt array), so this refuses
+    // the shape rather than miscompiling it silently. Lifting the refusal means
+    // moving the element splice to the end of every vector that enumerates the
+    // reds, not relaxing this check.
+    if num_virt_arrays > 0 && (num_ref_scalars > 0 || num_float_scalars > 0) {
+        return quote! {
+            compile_error!(
+                "state_fields cannot yet combine a `[.. ; virt]` array with a ref or \
+                 float scalar: the closing JUMP splices the virtualizable's element \
+                 boxes ahead of those scalars while the entry contract appends them \
+                 after every red (pyjitpl.py:2981-2989 makes the elements a strict \
+                 suffix), so the two orders disagree at equal arity"
+            );
+        };
+    }
     // First ref-bank register available for ref-scalar identity slots.
     // `MIFrame::setup_call` packs the dispatch JitCode's ref args densely
     // from r0 (`program` at r0, the virtualizable identity at r1 when

--- a/majit/majit-macros/src/jit_interp/codegen_state.rs
+++ b/majit/majit-macros/src/jit_interp/codegen_state.rs
@@ -1770,7 +1770,7 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
         }
     };
 
-    // pyjitpl.py:3449 `rebuild_state_after_failure`:
+    // pyjitpl.py:3443-3444 `rebuild_state_after_failure`:
     //     if vinfo is not None:
     //         self.virtualizable_boxes = virtualizable_boxes
     // The guard's vable section is decoded by `rebuild_from_resumedata` above;
@@ -1795,6 +1795,23 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
                     eprintln!(
                         "[bridgeB] vable seed={} stream={}",
                         __seeded,
+                        resume_data.virtualizable_values.len(),
+                    );
+                }
+                // A declined seed is not recoverable here and must not pass
+                // silently: `virtualizable_boxes` stays unset, so the first
+                // vable-shaped op in `__trace_*` has nothing to resolve and the
+                // bridge trace aborts — the guard keeps deopting through the
+                // blackhole, which is `compile.giveup()`'s outcome
+                // (compile.py:27) reached one step later. Surface it on the
+                // ordinary log channel so a bridge that never forms is
+                // attributable to the seed rather than looking like an
+                // unexplained abort.
+                if !__seeded && majit_metainterp::majit_log_enabled() {
+                    eprintln!(
+                        "[jit][bridgeB] virtualizable seed declined \
+                         (vable stream {} entries) — bridge will abort and \
+                         the guard deopts through the blackhole",
                         resume_data.virtualizable_values.len(),
                     );
                 }

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/dispatch.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/dispatch.rs
@@ -3307,18 +3307,20 @@ pub(crate) fn lower_dispatch_body(
     } else {
         config.ref_identity_base() + config.state_ref_scalars.len() as u16
     };
-    // After the scalars the dispatch frame seeds two int slots per virt array
-    // (`<arr>_ptr`, `<arr>_len`); `populate_frame_int_regs` / `total_slots`
-    // count `2 * num_virt_arrays`.  Reserve them in the working-register floor:
-    // a working register landing on a seeded `ptr`/`len` slot is overwritten by
-    // the guard-failure resume seeder, corrupting the live state the snapshot
-    // captures.  Fixed `[int]` arrays seed one slot per live element, but their
+    // After the scalars the dispatch frame seeds ONE int slot for the
+    // virtualizable identity, however many `[.. ; virt]` arrays the state
+    // declares (`pyjitpl.py:2984-2989` carries the virtualizable once;
+    // `virtualizable.py:150-153` reads each array length off the live object).
+    // `populate_frame_int_regs` / `total_slots` count it the same way.  Reserve
+    // it in the working-register floor: a working register landing on the
+    // seeded identity slot is overwritten by the guard-failure resume seeder,
+    // corrupting the live state the snapshot captures.  Fixed `[int]` arrays seed one slot per live element, but their
     // length is only known at runtime (tlr reassigns `regs = vec![0; n]`), so
     // this compile-time floor cannot reserve those element slots; that residual
     // affects only fixed-array consumers (none of which also carry a virt array).
     let int_identity_end = config.int_identity_base()
         + config.state_scalars.len() as u16
-        + 2 * config.state_virt_arrays.len() as u16;
+        + u16::from(!config.state_virt_arrays.is_empty());
     // Float scalars seed their own reserved prefix at
     // `float_regs[float_identity_base()..float_identity_end())`, restored by
     // the guard-failure resume seeder just like the int/ref banks. `alloc_reg`

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/mod.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/mod.rs
@@ -272,7 +272,10 @@ impl LowererConfig {
     /// `[int_identity_base, int_end)` / `[ref_identity_base, ref_end)`.
     ///
     /// Mirrors the dispatch JitCode's identity reservation: int identity =
-    /// the scalar slots plus two words (ptr+len) per virtualizable array;
+    /// the scalar slots plus the ONE virtualizable identity word (present
+    /// whenever the state declares any `[.. ; virt]` array — the
+    /// virtualizable is one red, `warmspot.py:538`, and array lengths are
+    /// read off the live object, `virtualizable.py:150-153`);
     /// ref identity = the ref scalars. A split sub-JitCode must reserve the
     /// SAME prefix so its register file spans the identity slots that the
     /// arm body's `load/store_state_field` ops address and that the resume
@@ -281,7 +284,7 @@ impl LowererConfig {
     pub(super) fn split_identity_reg_ends(&self) -> (u16, u16) {
         let int_end = self.int_identity_base()
             + self.state_scalars.len() as u16
-            + 2 * self.state_virt_arrays.len() as u16;
+            + u16::from(!self.state_virt_arrays.is_empty());
         let ref_end = if self.state_ref_scalars.is_empty() {
             0
         } else {

--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -4694,7 +4694,7 @@ fn handler_abort_result_marker_i(
 /// Mirrors `live_slots_for_state_field_jit` (`jitcode/assembler.rs:4476`): the
 /// blackhole int register file holds, in flat order,
 /// `[scalars 0..num_scalars | flattened fixed-array elements |
-/// virt-array (ptr,len) pairs]`, seeded by the resume reader via `setarg_i`
+/// the virtualizable identity]`, seeded by the resume reader via `setarg_i`
 /// (`resume.rs _prepare_next_section` → `blackhole.py:339 setarg_i`).
 ///
 /// majit's `state_field` opcodes carry a section-relative logical index
@@ -4702,15 +4702,21 @@ fn handler_abort_result_marker_i(
 /// slot. RPython's codewriter assigns register indices directly, so this
 /// mapping is the majit-port adaptation recovering the flat slot a handler
 /// must read/write. `array_lens` are per-instance (a fixed `[int]` array's
-/// length comes from the live state, e.g. tlr's `regs`); virt arrays
-/// contribute exactly two slots each (data pointer + length) regardless of
-/// element count — those slots are threaded as loop inputargs / live values
-/// alongside the element boxes the virtualizable machinery carries.
+/// length comes from the live state, e.g. tlr's `regs`); the virtualizable,
+/// when the state has one, contributes exactly ONE slot — its identity —
+/// however many `[.. ; virt]` arrays it declares. `virtualizable.py:150-153`
+/// reads each array's length off the live object, so a length is never a box,
+/// and `virtualizable.py:139-144` names the virtualizable once.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct StateFieldLayout {
     pub num_scalars: usize,
     pub array_lens: Vec<usize>,
-    pub num_virt_arrays: usize,
+    /// `1` when the state declares any `[.. ; virt]` array (or an explicit
+    /// virtualizable), else `0`. `pyjitpl.py:2984-2989` carries the
+    /// virtualizable exactly once — it is one red, `warmspot.py:538
+    /// jd.index_of_virtualizable = jitdriver.reds.index(vname)` — so this is
+    /// a presence flag, not a per-array count.
+    pub num_vable_identity_slots: usize,
     /// Ref-typed scalar state fields. They live in the SEPARATE ref
     /// register bank at `registers_r[ref_scalar_base ..
     /// ref_scalar_base + num_ref_scalars]`, seeded by the resume reader
@@ -4743,13 +4749,13 @@ impl StateFieldLayout {
     pub fn new(
         num_scalars: usize,
         array_lens: Vec<usize>,
-        num_virt_arrays: usize,
+        num_vable_identity_slots: usize,
         int_scalar_base: usize,
     ) -> Self {
         Self {
             num_scalars,
             array_lens,
-            num_virt_arrays,
+            num_vable_identity_slots,
             num_ref_scalars: 0,
             ref_scalar_base: 0,
             num_float_scalars: 0,
@@ -4763,7 +4769,7 @@ impl StateFieldLayout {
     pub fn with_ref_scalars(
         num_scalars: usize,
         array_lens: Vec<usize>,
-        num_virt_arrays: usize,
+        num_vable_identity_slots: usize,
         num_ref_scalars: usize,
         ref_scalar_base: usize,
         int_scalar_base: usize,
@@ -4771,7 +4777,7 @@ impl StateFieldLayout {
         Self {
             num_scalars,
             array_lens,
-            num_virt_arrays,
+            num_vable_identity_slots,
             num_ref_scalars,
             ref_scalar_base,
             num_float_scalars: 0,
@@ -4794,9 +4800,9 @@ impl StateFieldLayout {
     }
 
     /// Total int register slots — equals the `live_slots_for_state_field_jit`
-    /// slot count `num_scalars + Σ array_lens + 2·num_virt_arrays`.
+    /// slot count `num_scalars + Σ array_lens + num_vable_identity_slots`.
     pub fn total_slots(&self) -> usize {
-        self.num_scalars + self.array_lens.iter().sum::<usize>() + 2 * self.num_virt_arrays
+        self.num_scalars + self.array_lens.iter().sum::<usize>() + self.num_vable_identity_slots
     }
 
     /// Total live values `extract_live_values` produces: the int register

--- a/majit/majit-metainterp/src/jit_state.rs
+++ b/majit/majit-metainterp/src/jit_state.rs
@@ -607,12 +607,18 @@ pub trait JitState: Sized {
     /// JUMP in place of the `<arr>_ptr`/`<arr>_len` placeholders that the
     /// no-ctx `collect_jump_args` emits.
     ///
-    /// `boxes` is `TraceCtx::collect_virtualizable_boxes()` extracted by the
-    /// caller (owned clone, so the trace-ctx borrow is released before the
+    /// `boxes` is `TraceCtx::collect_virtualizable_typed_boxes()` extracted by
+    /// the caller (owned clone, so the trace-ctx borrow is released before the
     /// subsequent `compile_loop`). Default delegates to `collect_jump_args`,
     /// so PyFrame (which closes via `CloseLoopWithArgs`, never this path) and
     /// non-virtualizable state-field JITs (e.g. `regs: [int]`) are unaffected.
-    fn collect_jump_args_with_boxes(sym: &Self::Sym, _boxes: &[OpRef]) -> Vec<OpRef> {
+    ///
+    /// The boxes are typed because the same construction also builds the
+    /// merge-point registration's `original_boxes`
+    /// (`JitCodeSym::loop_carried_boxes`), and those become a cut trace's
+    /// typed LABEL inputargs. RPython gets that for free — one
+    /// `live_arg_boxes` list of `Box`es, each already carrying its type.
+    fn collect_jump_args_with_boxes(sym: &Self::Sym, _boxes: &[(OpRef, Type)]) -> Vec<OpRef> {
         Self::collect_jump_args(sym)
     }
 

--- a/majit/majit-metainterp/src/jitcode/assembler.rs
+++ b/majit/majit-metainterp/src/jitcode/assembler.rs
@@ -5570,7 +5570,11 @@ fn canonical_bh_descr_eq(lhs: &CanonicalBhDescr, rhs: &CanonicalBhDescr) -> bool
 /// state-field JIT enforces `Type::Int` on every slot at macro
 /// expansion (`codegen_state.rs:30-43`), so `live_r` and `live_f` are
 /// empty.  `total_slots` matches `JitCodeSym::total_slots`:
-/// `num_scalars + sum(array_lens) + 2 * num_virt_arrays`.
+/// `num_scalars + sum(array_lens) + num_vable_identity_slots`, where the last
+/// term is 1 when the state has a virtualizable and 0 otherwise —
+/// `pyjitpl.py:2984-2989` carries the virtualizable once regardless of how
+/// many `[.. ; virt]` arrays it holds, and `virtualizable.py:150-153` reads
+/// every array length off the live object rather than boxing it.
 ///
 /// The returned `Vec<u8>`s are caller-owned and can be passed directly
 /// into `JitCodeBuilder::live` / `Assembler::_encode_liveness`.
@@ -5585,14 +5589,15 @@ fn canonical_bh_descr_eq(lhs: &CanonicalBhDescr, rhs: &CanonicalBhDescr) -> bool
 pub fn live_slots_for_state_field_jit(
     num_scalars: usize,
     array_lens: &[usize],
-    num_virt_arrays: usize,
+    num_vable_identity_slots: usize,
     num_ref_scalars: usize,
     ref_scalar_base: usize,
     num_float_scalars: usize,
     float_scalar_base: usize,
     int_scalar_base: usize,
 ) -> (Vec<u8>, Vec<u8>, Vec<u8>) {
-    let total_slots: usize = num_scalars + array_lens.iter().sum::<usize>() + 2 * num_virt_arrays;
+    let total_slots: usize =
+        num_scalars + array_lens.iter().sum::<usize>() + num_vable_identity_slots;
     // Int identity slots start past the dispatch JitCode's int-bank
     // argument registers (`pc` at i0), mirroring the ref-bank base
     // below: the guard-time canonical materialization writes the
@@ -6241,13 +6246,15 @@ mod tests {
 
     #[test]
     fn state_field_canonical_slots_mixed_layout() {
-        // Mirrors the `tlc` example shape: 1 scalar (`stackpos`) + 1
-        // virt array (`stack`, ptr+len) plus a synthetic 3-element
-        // flattened array.  total_slots = 1 + 3 + 2 = 6, so
-        // live_i = [0, 1, 2, 3, 4, 5] and ref/float banks are empty.
+        // Mirrors the `tlc` example shape: 1 scalar (`stackpos`) + a
+        // virtualizable (`stack`) plus a synthetic 3-element flattened
+        // array.  The virtualizable contributes ONE slot — its identity —
+        // however many `[.. ; virt]` arrays it declares, so
+        // total_slots = 1 + 3 + 1 = 5 and live_i = [0, 1, 2, 3, 4] with
+        // the ref/float banks empty.
         let (live_i, live_r, live_f) =
             super::live_slots_for_state_field_jit(1, &[3], 1, 0, 0, 0, 0, 0);
-        assert_eq!(live_i, vec![0u8, 1, 2, 3, 4, 5]);
+        assert_eq!(live_i, vec![0u8, 1, 2, 3, 4]);
         assert!(live_r.is_empty());
         assert!(live_f.is_empty());
     }

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -1473,6 +1473,32 @@ impl<S: JitState> JitDriver<S> {
         self.meta.mainjitcode_of(self.portal_jd_index?)
     }
 
+    /// Point the per-thread state-field store back at this driver, reusing what
+    /// [`Self::register_dispatch_jitcode`] already built.
+    ///
+    /// That store is a SINGLE slot per thread and is written only when a driver
+    /// registers its dispatch jitcode, so a consumer holding more than one
+    /// driver alive on a thread must call this for the driver it is about to
+    /// run. Leaving another driver's store in place is not a benign miss:
+    /// [`JitDriverStaticData::frame_value_count_fn`] records that the wrong
+    /// store frequently *succeeds*, decoding an unrelated jitcode at the same pc
+    /// and silently returning a mistyped frame count.
+    ///
+    /// A driver that has not registered a dispatch jitcode has nothing to
+    /// publish and is left alone.
+    ///
+    /// The upstream arrangement is one process-wide `metainterp_sd.jitcodes`
+    /// table rather than a registry per driver; until majit has that, the store
+    /// has to be aimed at the right driver by hand.
+    pub fn republish_state_field_fvc(&self) {
+        if self.dispatch_jitcode.is_none() {
+            return;
+        }
+        let all_liveness = self.meta_interp().staticdata.liveness_info.clone();
+        let op_live = self.meta_interp().staticdata.op_live as u8;
+        install_state_field_fvc(self.jitcode_registry.clone(), all_liveness, op_live);
+    }
+
     /// Register a BlackholeAllocator for virtual materialization during
     /// guard failure blackhole resume. Without this, virtual objects
     /// and raw buffers are allocated as null/zero.

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -2513,7 +2513,7 @@ impl<S: JitState> JitDriver<S> {
                             let vable_boxes = self
                                 .meta
                                 .trace_ctx()
-                                .and_then(|ctx| ctx.collect_virtualizable_boxes());
+                                .and_then(|ctx| ctx.collect_virtualizable_typed_boxes());
                             let finish_args = match vable_boxes {
                                 Some(ref boxes) => S::collect_jump_args_with_boxes(sym, boxes),
                                 None => S::collect_jump_args(sym),
@@ -2598,7 +2598,7 @@ impl<S: JitState> JitDriver<S> {
                     let vable_boxes = self
                         .meta
                         .trace_ctx()
-                        .and_then(|ctx| ctx.collect_virtualizable_boxes());
+                        .and_then(|ctx| ctx.collect_virtualizable_typed_boxes());
                     let jump_args = match vable_boxes {
                         Some(ref boxes) => S::collect_jump_args_with_boxes(sym, boxes),
                         None => S::collect_jump_args(sym),

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -5533,6 +5533,12 @@ impl<S: JitState> JitDriver<S> {
             let meta = unsafe { &*(meta_ptr as *const crate::pyjitpl::MetaInterp<S::Meta>) };
             meta.has_compiled_targets(gk)
         }));
+        ctx.compiled_key_for_greens_fn = Some(Box::new(
+            move |greens: &(Vec<i64>, Vec<i64>, Vec<i64>)| -> Option<u64> {
+                let meta = unsafe { &*(meta_ptr as *const crate::pyjitpl::MetaInterp<S::Meta>) };
+                meta.compiled_key_for_greens(greens)
+            },
+        ));
         // pyjitpl.py:1551 first-iteration auto loop-header
         // `if self.metainterp.portal_call_depth: return` parity —
         // sample the live counter through the same self.meta

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -5504,6 +5504,17 @@ impl<S: JitState> JitDriver<S> {
         // at this header pc; the bridge closes by JUMPing into it there, not at
         // its own `resume_pc`. Resolve before the `ctx` mutable borrow below.
         let parent_header_pc = self.meta.loop_header_pc_for(green_key);
+        // pyjitpl.py:3446-3450 `rebuild_state_after_failure` ends with
+        // `synchronize_virtualizable()` / `check_synchronized_virtualizable()`,
+        // both of which read the LIVE virtualizable.  Resolve it here (the same
+        // `virtualizable_heap_ptr` hook the trace-entry `sync_before` uses) so
+        // the bridge's vable seeding has an authority to check the guard's
+        // decoded identity against.
+        let live_vable_ptr = self.meta.virtualizable_info().cloned().and_then(|info| {
+            state
+                .virtualizable_heap_ptr(&trace_meta, &info.name.clone(), &info)
+                .map(|ptr| ptr.cast_const())
+        });
         // `start_retrace_from_guard` above sets `self.meta.tracing = Some(..)`
         // on success (pyjitpl.py:9415). Fail loud rather than skipping bridge
         // header_pc / is_bridge_trace / has_compiled_targets_fn wiring
@@ -5522,6 +5533,9 @@ impl<S: JitState> JitDriver<S> {
         // can apply bridge-only behavior without overloading
         // `has_compiled_targets_fn` presence.
         ctx.is_bridge_trace = true;
+        if let Some(ptr) = live_vable_ptr {
+            ctx.set_virtualizable_heap_ptr(ptr);
+        }
         ctx.set_bridge_source_is_exception_guard(retrace.is_exception_guard);
         // pyjitpl.py:3125 `_prepare_exception_resumption` grabs the exception
         // BEFORE frame reconstruction; thread it onto the ctx so the pyre

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -4303,7 +4303,7 @@ impl<S: JitState> JitDriver<S> {
 
         // Refresh the trace-entry vable heap pointer so `initialize_virtualizable`
         // reads array lengths directly from the concrete virtualizable object
-        // (pyjitpl.py:3302 `vinfo.read_boxes(cpu, virtualizable, startindex)`).
+        // (pyjitpl.py:3326 `vinfo.read_boxes(cpu, virtualizable, startindex)`).
         // `VirtualizableInfo.name` is the canonical identifier declared via
         // `virtualizable!(name = "...")`, so we can feed it straight to the
         // interpreter hooks without going through the descriptor.

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -1195,6 +1195,9 @@ pub struct JitDriver<S: JitState> {
     /// JitCode itself, so this driver stores only the slot; `None` until
     /// `register_dispatch_jitcode` runs.
     portal_jd_index: Option<usize>,
+    /// This driver's payload for the per-thread `frame_value_count` store,
+    /// built once by `register_dispatch_jitcode`. `None` until then.
+    state_field_fvc: Option<StateFieldFvcData>,
 }
 
 thread_local! {
@@ -1206,9 +1209,20 @@ thread_local! {
         const { std::cell::RefCell::new(None) };
 }
 
+/// Identity stamped on each driver's publication so a thread can tell whose
+/// store it is currently holding. Non-zero; `0` is never handed out.
+static STATE_FIELD_FVC_EPOCH: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
+
+/// One driver's contribution to the per-thread store, assembled once at
+/// `register_dispatch_jitcode` so re-publishing costs three refcount bumps
+/// rather than cloning the registry and the liveness buffer.
+#[derive(Clone)]
 struct StateFieldFvcData {
-    jitcodes: Vec<std::sync::Arc<crate::jitcode::JitCode>>,
-    all_liveness: Vec<u8>,
+    /// Which driver built this. Compared against the thread's current store to
+    /// skip a redundant install.
+    epoch: u64,
+    jitcodes: std::sync::Arc<Vec<std::sync::Arc<crate::jitcode::JitCode>>>,
+    all_liveness: std::sync::Arc<Vec<u8>>,
     op_live: u8,
 }
 
@@ -1240,27 +1254,33 @@ fn state_field_frame_value_count(jitcode_index: i32, pc: i32) -> usize {
     })
 }
 
+/// Epoch of the state-field store this thread is currently holding, or `0`
+/// when no driver has published on it yet. Diagnostic for the single-slot
+/// store described on [`JitDriver::republish_state_field_fvc`].
+#[doc(hidden)]
+pub fn current_state_field_fvc_epoch() -> u64 {
+    STATE_FIELD_FVC.with(|cell| cell.borrow().as_ref().map_or(0, |data| data.epoch))
+}
+
 /// Publish the driver's flat jitcode registry + packed liveness for the
 /// stateless global `frame_value_count` decode. Both compile-time decoders
 /// (`compile.rs` build_guard_metadata and the cranelift backend) read the
 /// callback via `get_frame_value_count_fn`, so this single registration
 /// serves both. Registers the callback once (process-global slot), then
-/// refreshes the thread-local payload for the installing driver.
-fn install_state_field_fvc(
-    jitcodes: Vec<std::sync::Arc<crate::jitcode::JitCode>>,
-    all_liveness: Vec<u8>,
-    op_live: u8,
-) {
+/// refreshes the thread-local payload for the installing driver — but only
+/// when the thread is not already holding that driver's store, so the
+/// trace-entry calls that keep it honest cost one `u64` compare.
+fn install_state_field_fvc(data: &StateFieldFvcData) {
     static INIT: std::sync::Once = std::sync::Once::new();
     INIT.call_once(|| {
         majit_ir::resumedata::set_frame_value_count_fn(state_field_frame_value_count);
     });
     STATE_FIELD_FVC.with(|cell| {
-        *cell.borrow_mut() = Some(StateFieldFvcData {
-            jitcodes,
-            all_liveness,
-            op_live,
-        });
+        let mut slot = cell.borrow_mut();
+        if slot.as_ref().is_some_and(|held| held.epoch == data.epoch) {
+            return;
+        }
+        *slot = Some(data.clone());
     });
 }
 
@@ -1325,6 +1345,7 @@ impl<S: JitState> JitDriver<S> {
             blackhole_allocator: None,
             portal_runner: None,
             portal_jd_index: None,
+            state_field_fvc: None,
             shared_asm: std::sync::Arc::new(std::sync::Mutex::new(
                 majit_translate::codewriter::assembler::Assembler::new(),
             )),
@@ -1462,7 +1483,14 @@ impl<S: JitState> JitDriver<S> {
         // before this call, so staticdata carries the final liveness buffer.
         let all_liveness = self.meta_interp().staticdata.liveness_info.clone();
         let op_live = self.meta_interp().staticdata.op_live as u8;
-        install_state_field_fvc(registry, all_liveness, op_live);
+        let data = StateFieldFvcData {
+            epoch: STATE_FIELD_FVC_EPOCH.fetch_add(1, std::sync::atomic::Ordering::Relaxed),
+            jitcodes: std::sync::Arc::new(registry),
+            all_liveness: std::sync::Arc::new(all_liveness),
+            op_live,
+        };
+        install_state_field_fvc(&data);
+        self.state_field_fvc = Some(data);
     }
 
     /// pyjitpl.py:3294 `self.jitdriver_sd.mainjitcode` — this driver's portal
@@ -1477,26 +1505,38 @@ impl<S: JitState> JitDriver<S> {
     /// [`Self::register_dispatch_jitcode`] already built.
     ///
     /// That store is a SINGLE slot per thread and is written only when a driver
-    /// registers its dispatch jitcode, so a consumer holding more than one
-    /// driver alive on a thread must call this for the driver it is about to
-    /// run. Leaving another driver's store in place is not a benign miss:
+    /// publishes, so a thread holding more than one driver alive can otherwise
+    /// decode against whichever published last. That is not a benign miss:
     /// [`JitDriverStaticData::frame_value_count_fn`] records that the wrong
     /// store frequently *succeeds*, decoding an unrelated jitcode at the same pc
     /// and silently returning a mistyped frame count.
     ///
+    /// The store is now re-aimed automatically at both trace entries
+    /// ([`Self::force_start_tracing`] and [`Self::start_bridge_tracing`]), which
+    /// is what every compile is reached through, so calling this by hand is no
+    /// longer required — it stays for consumers that already do, and to let a
+    /// pool aim the store at checkout rather than at trace start.
+    ///
     /// A driver that has not registered a dispatch jitcode has nothing to
     /// publish and is left alone.
     ///
-    /// The upstream arrangement is one process-wide `metainterp_sd.jitcodes`
-    /// table rather than a registry per driver; until majit has that, the store
-    /// has to be aimed at the right driver by hand.
+    /// `warmspot.py:281-282 metainterp_sd.jitcodes` now owns the table
+    /// (`MetaInterp::install_jitcodes`), but one `MetaInterpStaticData` per
+    /// driver is still not upstream's ONE table, and this store is a separate
+    /// per-thread copy of it besides. Re-aiming on entry only removes the
+    /// window in which the wrong one is read.
     pub fn republish_state_field_fvc(&self) {
-        if self.dispatch_jitcode.is_none() {
-            return;
+        if let Some(data) = self.state_field_fvc.as_ref() {
+            install_state_field_fvc(data);
         }
-        let all_liveness = self.meta_interp().staticdata.liveness_info.clone();
-        let op_live = self.meta_interp().staticdata.op_live as u8;
-        install_state_field_fvc(self.jitcode_registry.clone(), all_liveness, op_live);
+    }
+
+    /// This driver's store epoch, or `0` before it registered a dispatch
+    /// jitcode. Compare against [`current_state_field_fvc_epoch`] to see whose
+    /// store the thread is holding.
+    #[doc(hidden)]
+    pub fn state_field_fvc_epoch(&self) -> u64 {
+        self.state_field_fvc.as_ref().map_or(0, |data| data.epoch)
     }
 
     /// Register a BlackholeAllocator for virtual materialization during
@@ -4032,6 +4072,11 @@ impl<S: JitState> JitDriver<S> {
     ) {
         // Note: no is_hot_or_tracing check here — the caller (try_function_entry_jit)
         // already verified the threshold. force_start_tracing must unconditionally start.
+        //
+        // Every compile this trace can reach decodes frame value counts through
+        // the per-thread store, so aim it at this driver before recording a
+        // single op. Free when it already points here (one `u64` compare).
+        self.republish_state_field_fvc();
         let meta = state.build_meta(target_pc, env);
         let descriptor = self.driver_descriptor_for(state, &meta);
         if !self.sync_before(state, &meta, descriptor.as_ref()) {
@@ -5361,6 +5406,9 @@ impl<S: JitState> JitDriver<S> {
         guard_exc: i64,
     ) -> bool {
         majit_metainterp::mc_diag_bump(12); // start_bridge_tracing entered
+        // Same reason as the primary trace entry: the bridge compile decodes
+        // frame value counts through the per-thread store, so aim it here.
+        self.republish_state_field_fvc();
         self.bridge_body_start_op_count = None;
         // compile.py:725-729 `_trace_and_compile_from_bridge` raises
         // `compile.giveup()` when the descr's owning JitCellToken weakref

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -2540,10 +2540,17 @@ impl<S: JitState> JitDriver<S> {
                                 .meta
                                 .trace_ctx()
                                 .and_then(|ctx| ctx.collect_virtualizable_typed_boxes());
-                            let finish_args = match vable_boxes {
+                            let mut finish_args = match vable_boxes {
                                 Some(ref boxes) => S::collect_jump_args_with_boxes(sym, boxes),
                                 None => S::collect_jump_args(sym),
                             };
+                            // pyjitpl.py:2978-2987: the same normalization the
+                            // loop close applies — the bridge JUMP is built from
+                            // the same `live_arg_boxes`.
+                            if let Some(ctx) = self.meta.trace_ctx() {
+                                ctx.remove_consts_and_duplicates_untyped(&mut finish_args);
+                            }
+                            let finish_args = finish_args;
                             let continue_running_normally_values = {
                                 let trace_meta = self.meta.trace_meta().cloned();
                                 match (trace_meta, self.sym.as_ref()) {
@@ -2625,10 +2632,17 @@ impl<S: JitState> JitDriver<S> {
                         .meta
                         .trace_ctx()
                         .and_then(|ctx| ctx.collect_virtualizable_typed_boxes());
-                    let jump_args = match vable_boxes {
+                    let mut jump_args = match vable_boxes {
                         Some(ref boxes) => S::collect_jump_args_with_boxes(sym, boxes),
                         None => S::collect_jump_args(sym),
                     };
+                    // pyjitpl.py:2978-2987 `remove_consts_and_duplicates` runs
+                    // over this list before anything consumes it, so the JUMP
+                    // never passes a constant or the same box twice.
+                    if let Some(ctx) = self.meta.trace_ctx() {
+                        ctx.remove_consts_and_duplicates_untyped(&mut jump_args);
+                    }
+                    let jump_args = jump_args;
                     // pyjitpl.py:2993-3036 parity: compile_loop borrows the
                     // frontend meta the same way `self.history` is a shared
                     // mutable object on the RPython MetaInterp — the caller

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -3807,7 +3807,7 @@ impl<S: JitState> JitDriver<S> {
                                     eprintln!("[callee-rca][crn-state-before]\n{dump}");
                                 }
                             }
-                            if layout.num_virt_arrays == 0 {
+                            if layout.num_vable_identity_slots == 0 {
                                 let float_base = layout.float_scalar_base.min(bh.registers_f.len());
                                 state.restore_banked3(
                                     &compiled_meta,

--- a/majit/majit-metainterp/src/lib.rs
+++ b/majit/majit-metainterp/src/lib.rs
@@ -129,8 +129,8 @@ pub use jitcode::{
 };
 pub use jitdriver::{
     DeclarativeJitDriver, JitDriver, JitDriverStaticData, MultiFrameBlackholeResult,
-    SingleFrameBlackholeResult, TraceContinuationSuspendGuard, drive_multi_frame_blackhole,
-    drive_single_frame_blackhole, trace_continuation_suspended,
+    SingleFrameBlackholeResult, TraceContinuationSuspendGuard, current_state_field_fvc_epoch,
+    drive_multi_frame_blackhole, drive_single_frame_blackhole, trace_continuation_suspended,
 };
 pub use majit_backend::CompiledTraceInfo;
 pub use pyjitpl::{eval_binop_f, eval_binop_i, eval_float_cmp, eval_unary_f, eval_unary_i};

--- a/majit/majit-metainterp/src/lib.rs
+++ b/majit/majit-metainterp/src/lib.rs
@@ -163,6 +163,7 @@ pub use quasiimmut::QuasiImmut;
 pub use resume_box_reader::{
     BridgeVirtualCache, decode_fieldnum, default_bridge_array_descr, emit_pending_field_op,
     materialize_bridge_virtual, rebuilt_value_to_opref, replay_pending_fields,
+    seed_bridge_virtualizable_boxes,
 };
 pub use trace_ctx::BridgeInlineCarrier;
 pub use trace_ctx::GreenBox;

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -4042,10 +4042,10 @@ impl Optimizer {
         // through the full pass chain. No explicit flush()/force_box() needed.
         if !inline_short_preamble || front_target_tokens.len() <= 1 {
             // unroll.py:196 `cell_token = jump_op.getdescr()`: the jump-to
-            // jitcell is the one the recorded close JUMP points to, not the
-            // caller-passed `front_target_tokens` (which is the bridge's
-            // ORIGIN loop and may differ from the loop the trace closed
-            // into). `assert cell_token.target_tokens` ⇒ require a target.
+            // jitcell is the one the recorded close JUMP points to, which is
+            // also where `front_target_tokens` comes from (`compile_bridge`
+            // resolves it off the JUMP target, not the bridge origin).
+            // `assert cell_token.target_tokens` ⇒ require a target.
             if !front_target_tokens.is_empty() {
                 let mut ctx = self.final_ctx.take().unwrap_or_else(|| {
                     // opencoder.py:259 inputarg_from_tp parity — seed inputarg
@@ -4163,9 +4163,8 @@ impl Optimizer {
                     ctx.rebuild_new_operations_index();
                     // unroll.py:196,238-242 jump_to_preamble parity: the jump-to
                     // jitcell is `jump_op.getdescr()` = terminal_jump's own
-                    // recorded descr (the preamble of the loop the trace closed
-                    // into), not the ORIGIN `front_target_tokens`. Keep both
-                    // jump_op's forced args AND its descr.
+                    // recorded descr, the preamble of the loop the trace closed
+                    // into. Keep both jump_op's forced args AND its descr.
                     let jump_op = terminal_jump.copy_and_change(OpCode::Jump, None, None);
                     self.send_extra_operation(&jump_op, &mut ctx)?;
                     let mut result = optimized_ops;
@@ -4254,11 +4253,9 @@ impl Optimizer {
             // (forced) args so send_extra_operation's Virtualize pass forces the
             // still-virtual ref args, AND keep its recorded descr. That descr is
             // `cell_token.target_tokens[0]` (cell_token = jump_op.getdescr()) —
-            // the preamble of the jitcell the trace closed into. The caller's
-            // `front_target_tokens` belongs to the bridge's ORIGIN loop, whose
-            // preamble can be a different (reordered-arglocs) token when the
-            // bridge crosses loops, so redirecting to it delivers args to the
-            // wrong frame slots.
+            // the preamble of the jitcell the trace closed into. Redirecting to
+            // a token picked here instead would deliver args to the wrong frame
+            // slots whenever that jitcell's preamble has different arglocs.
             let jump_op = terminal_jump.copy_and_change(OpCode::Jump, None, None);
             self.send_extra_operation(&jump_op, &mut ctx)?;
             let mut result = optimized_ops;

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -3218,7 +3218,30 @@ impl<M: Clone> MetaInterp<M> {
         let box_ref_index = info
             .identity_ref_bank_index
             .unwrap_or(index_of_virtualizable);
-        let virtualizable_box = OpRef::input_arg_ref(box_ref_index as u32);
+        // `identity_ref_bank_index` names a JitCode ref REGISTER, while trace
+        // inputargs are numbered flat across banks — `OpRef::input_arg_ref(1)`
+        // is inputarg #1, which for the state-field front-end is an int, not
+        // the `&state` identity.  The alias is invisible while the identity is
+        // only read through `virtualizable_values[-1]`, but it is what
+        // `capture_resumedata` writes into every guard's vable section, so a
+        // bridge decoding that section resolves the identity to the wrong
+        // deadframe slot.  `pyjitpl.py:3295 virtualizable_box =
+        // original_boxes[index]` is a lookup of the red that HOLDS the
+        // virtualizable; recover the same box by matching the live pointer
+        // against `live_values`, which is `original_boxes` here.
+        let identity_index = if info.identity_ref_bank_index.is_some() && !self.vable_ptr.is_null()
+        {
+            let vable_bits = self.vable_ptr as usize;
+            original_boxes
+                .iter()
+                .position(|value| matches!(value, Value::Ref(r) if r.as_usize() == vable_bits))
+        } else {
+            None
+        };
+        let virtualizable_box = match identity_index {
+            Some(idx) => OpRef::input_arg_typed(idx as u32, Type::Ref),
+            None => OpRef::input_arg_ref(box_ref_index as u32),
+        };
         // The identity's concrete VALUE is the live virtualizable pointer.
         // For PyFrame `original_boxes[index]` already IS the frame pointer
         // (== `vable_ptr`), so this is a no-op there. For the state-field

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -3059,6 +3059,36 @@ impl<M: Clone> MetaInterp<M> {
     /// `index_of_virtualizable`; the resolved virtualizable pointer and its
     /// ref-bank index are unchanged either way (the gate is a structural-parity
     /// no-op).
+    /// Position of the virtualizable identity inside `live_values`, the
+    /// state-field counterpart of `pyjitpl.py:3295 original_boxes[index]`.
+    ///
+    /// The host declares it (`identity_live_index`); this checks the declared
+    /// position actually holds `vable_ptr` before taking it, because
+    /// `live_values` also arrives from bridge entry, where the reds are rebuilt
+    /// from a deadframe rather than emitted by the state's `extract_live`. A
+    /// host that declares nothing, or whose reds disagree with the declaration,
+    /// falls back to matching the live pointer.
+    ///
+    /// `None` when the pointer is not in the reds at all — the caller then
+    /// mints the box at the declared ref-bank index instead.
+    fn identity_live_position(
+        info: &VirtualizableInfo,
+        live_values: &[Value],
+        vable_ptr: *const u8,
+    ) -> Option<usize> {
+        if vable_ptr.is_null() {
+            return None;
+        }
+        let vable_bits = vable_ptr as usize;
+        let holds_identity = |idx: usize| match live_values.get(idx) {
+            Some(Value::Ref(r)) => r.as_usize() == vable_bits,
+            _ => false,
+        };
+        info.identity_live_index
+            .filter(|idx| holds_identity(*idx))
+            .or_else(|| (0..live_values.len()).find(|idx| holds_identity(*idx)))
+    }
+
     fn initialize_virtualizable(&self, ctx: &mut TraceCtx, live_values: &[Value]) {
         // pyjitpl.py:3291: vinfo = self.jitdriver_sd.virtualizable_info
         // Prefer the trace-bound `active_jitdriver_sd` (RPython
@@ -3227,19 +3257,23 @@ impl<M: Clone> MetaInterp<M> {
         // bridge decoding that section resolves the identity to the wrong
         // deadframe slot.  `pyjitpl.py:3295 virtualizable_box =
         // original_boxes[index]` is a lookup of the red that HOLDS the
-        // virtualizable; recover the same box by matching the live pointer.
+        // virtualizable, so take the same lookup: `identity_live_index` is the
+        // host's declared position for it, the state-field counterpart of
+        // `warmspot.py:529-538 jd.index_of_virtualizable`.
         //
-        // The scan runs over `live_values`, NOT `original_boxes`: the latter is
-        // `[Void; num_green_args] ++ live_values` (the greens are positional
+        // The position indexes `live_values`, NOT `original_boxes`: the latter
+        // is `[Void; num_green_args] ++ live_values` (the greens are positional
         // placeholders so the `num_green_args + index_of_virtualizable` read
         // above lands), while trace inputargs are reds-only.  A position taken
         // in the `original_boxes` space would be `num_green_args` too high.
-        let identity_index = if info.identity_ref_bank_index.is_some() && !self.vable_ptr.is_null()
-        {
-            let vable_bits = self.vable_ptr as usize;
-            live_values
-                .iter()
-                .position(|value| matches!(value, Value::Ref(r) if r.as_usize() == vable_bits))
+        //
+        // The declared position is checked against the live pointer rather than
+        // trusted blind, because `live_values` also arrives from bridge entry,
+        // where the reds are rebuilt from a deadframe rather than emitted by
+        // `extract_live`.  A host that declares no position, or whose reds do
+        // not agree with it, falls back to matching the pointer.
+        let identity_index = if info.identity_ref_bank_index.is_some() {
+            Self::identity_live_position(info, live_values, self.vable_ptr)
         } else {
             None
         };
@@ -19907,6 +19941,69 @@ mod tests {
                 Some(&recovery_layout),
             ),
             vec![Type::Ref, Type::Int, Type::Float, Type::Ref]
+        );
+    }
+
+    /// `pyjitpl.py:3295` reads the virtualizable out of a DECLARED red
+    /// position; it never searches the reds for it. A red that happens to hold
+    /// the same pointer earlier in the vector — another name for the same
+    /// object — must not take the identity's place.
+    #[test]
+    fn test_declared_identity_position_wins_over_an_earlier_alias() {
+        let vable = 0x4000usize;
+        let mut info = VirtualizableInfo::without_vable_token();
+        info.identity_ref_bank_index = Some(1);
+        info.identity_live_index = Some(2);
+        // reds: [alias (Ref), stackpos (Int), &state (Ref)].
+        let live_values = [
+            Value::Ref(majit_ir::GcRef(vable)),
+            Value::Int(7),
+            Value::Ref(majit_ir::GcRef(vable)),
+        ];
+
+        assert_eq!(
+            MetaInterp::<()>::identity_live_position(&info, &live_values, vable as *const u8),
+            Some(2),
+            "the declared position, not the first pointer match",
+        );
+    }
+
+    /// Bridge entry rebuilds the reds from a deadframe instead of the state's
+    /// `extract_live`, and a host with a fixed array alongside a virtualizable
+    /// one declares no position at all. Both fall back to the pointer match.
+    #[test]
+    fn test_identity_position_falls_back_when_the_declaration_does_not_hold() {
+        let vable = 0x4000usize;
+        let live_values = [Value::Int(7), Value::Ref(majit_ir::GcRef(vable))];
+
+        let mut declared_elsewhere = VirtualizableInfo::without_vable_token();
+        declared_elsewhere.identity_ref_bank_index = Some(1);
+        declared_elsewhere.identity_live_index = Some(5);
+        assert_eq!(
+            MetaInterp::<()>::identity_live_position(
+                &declared_elsewhere,
+                &live_values,
+                vable as *const u8,
+            ),
+            Some(1),
+            "a declaration the reds do not honour falls back to the pointer",
+        );
+
+        let mut undeclared = VirtualizableInfo::without_vable_token();
+        undeclared.identity_ref_bank_index = Some(1);
+        assert_eq!(
+            MetaInterp::<()>::identity_live_position(&undeclared, &live_values, vable as *const u8),
+            Some(1),
+        );
+
+        assert_eq!(
+            MetaInterp::<()>::identity_live_position(
+                &undeclared,
+                &live_values,
+                std::ptr::null::<u8>(),
+            ),
+            None,
+            "no live pointer means no red holds the identity",
         );
     }
 

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -3944,6 +3944,12 @@ impl<M: Clone> MetaInterp<M> {
                         let meta = unsafe { &*(self_ptr as *const Self) };
                         meta.has_compiled_targets(gk)
                     }));
+                    ctx.compiled_key_for_greens_fn = Some(Box::new(
+                        move |greens: &(Vec<i64>, Vec<i64>, Vec<i64>)| -> Option<u64> {
+                            let meta = unsafe { &*(self_ptr as *const Self) };
+                            meta.compiled_key_for_greens(greens)
+                        },
+                    ));
                     ctx.portal_call_depth_fn = Some(Box::new(move || -> i32 {
                         let meta = unsafe { &*(self_ptr as *const Self) };
                         meta.portal_call_depth
@@ -4224,6 +4230,12 @@ impl<M: Clone> MetaInterp<M> {
                 let meta = unsafe { &*(self_ptr as *const Self) };
                 meta.has_compiled_targets(gk)
             }));
+            ctx.compiled_key_for_greens_fn = Some(Box::new(
+                move |greens: &(Vec<i64>, Vec<i64>, Vec<i64>)| -> Option<u64> {
+                    let meta = unsafe { &*(self_ptr as *const Self) };
+                    meta.compiled_key_for_greens(greens)
+                },
+            ));
             ctx.portal_call_depth_fn = Some(Box::new(move || -> i32 {
                 let meta = unsafe { &*(self_ptr as *const Self) };
                 meta.portal_call_depth

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -3227,12 +3227,17 @@ impl<M: Clone> MetaInterp<M> {
         // bridge decoding that section resolves the identity to the wrong
         // deadframe slot.  `pyjitpl.py:3295 virtualizable_box =
         // original_boxes[index]` is a lookup of the red that HOLDS the
-        // virtualizable; recover the same box by matching the live pointer
-        // against `live_values`, which is `original_boxes` here.
+        // virtualizable; recover the same box by matching the live pointer.
+        //
+        // The scan runs over `live_values`, NOT `original_boxes`: the latter is
+        // `[Void; num_green_args] ++ live_values` (the greens are positional
+        // placeholders so the `num_green_args + index_of_virtualizable` read
+        // above lands), while trace inputargs are reds-only.  A position taken
+        // in the `original_boxes` space would be `num_green_args` too high.
         let identity_index = if info.identity_ref_bank_index.is_some() && !self.vable_ptr.is_null()
         {
             let vable_bits = self.vable_ptr as usize;
-            original_boxes
+            live_values
                 .iter()
                 .position(|value| matches!(value, Value::Ref(r) if r.as_usize() == vable_bits))
         } else {

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -1349,7 +1349,7 @@ pub struct MetaInterp<M: Clone> {
     /// reads it to fire the trace-too-long hook.
     pub aborted_tracing_jitdriver: Option<usize>,
 
-    /// pyjitpl.py:3291 `self.jitdriver_sd` parity — index into
+    /// pyjitpl.py:2411 `self.jitdriver_sd` parity — index into
     /// `staticdata.jitdrivers_sd` of the driver that owns the
     /// in-flight trace.
     ///
@@ -1769,7 +1769,7 @@ impl<M: Clone> MetaInterp<M> {
                 ia.set_value(Value::Ref(r));
             }
         }
-        // pyjitpl.py:3290-3306 — `initialize_virtualizable` /
+        // pyjitpl.py:3314-3330 — `initialize_virtualizable` /
         // `force_start_tracing` / `setup_tracing` snapshot inputarg
         // constants into `initial_inputarg_consts`. Each is an inline-const
         // `OpRef`; a `ConstPtr` entry's inline gcref is forwarded in place —
@@ -3006,7 +3006,7 @@ impl<M: Clone> MetaInterp<M> {
     }
 
     fn trace_entry_vable_lengths(&self, info: &VirtualizableInfo) -> Vec<usize> {
-        // pyjitpl.py:3302 `vinfo.read_boxes(self.cpu, virtualizable, startindex)`
+        // pyjitpl.py:3326 `vinfo.read_boxes(self.cpu, virtualizable, startindex)`
         // reads field/array values directly from the concrete virtualizable
         // heap object; RPython does not consult any interpreter-supplied
         // "trace-entry cache" for lengths. Match that here when the layout
@@ -3026,7 +3026,7 @@ impl<M: Clone> MetaInterp<M> {
     }
 
     /// Position of the virtualizable identity inside `live_values`, the
-    /// state-field counterpart of `pyjitpl.py:3295 original_boxes[index]`.
+    /// state-field counterpart of `pyjitpl.py:3319 original_boxes[index]`.
     ///
     /// The host declares it (`identity_live_index`); this checks the declared
     /// position actually holds `vable_ptr` before taking it, because
@@ -3055,7 +3055,7 @@ impl<M: Clone> MetaInterp<M> {
             .or_else(|| (0..live_values.len()).find(|idx| holds_identity(*idx)))
     }
 
-    /// pyjitpl.py:3290 `initialize_virtualizable(self, original_boxes)`.
+    /// pyjitpl.py:3314 `initialize_virtualizable(self, original_boxes)`.
     ///
     /// RPython:
     ///     vinfo = self.jitdriver_sd.virtualizable_info
@@ -3078,7 +3078,7 @@ impl<M: Clone> MetaInterp<M> {
     /// `TraceCtx::init_virtualizable_boxes` helper which performs the
     /// actual `virtualizable_boxes = [..., vable_ref]` push (matching
     /// the `read_boxes(...) ; append(virtualizable_box)` shape from
-    /// pyjitpl.py:3302-3306).
+    /// pyjitpl.py:3326-3330).
     ///
     /// `live_values` is reds-only (greens fold to consts in the `green_key`
     /// side channel, matching the compiled loop's reds-only entry contract).
@@ -3090,7 +3090,7 @@ impl<M: Clone> MetaInterp<M> {
     /// ref-bank index are unchanged either way (the gate is a structural-parity
     /// no-op).
     fn initialize_virtualizable(&self, ctx: &mut TraceCtx, live_values: &[Value]) {
-        // pyjitpl.py:3291: vinfo = self.jitdriver_sd.virtualizable_info
+        // pyjitpl.py:3315: vinfo = self.jitdriver_sd.virtualizable_info
         // Prefer the trace-bound `active_jitdriver_sd` (RPython
         // `self.jitdriver_sd`); fall back to scanning when an
         // init-time / test caller has not yet elected one.
@@ -3102,7 +3102,7 @@ impl<M: Clone> MetaInterp<M> {
             .virtualizable_info
             .as_ref()
             .expect("resolve_active_jitdriver_sd_with_vinfo returned a slot without vinfo");
-        // pyjitpl.py:3293-3295:
+        // pyjitpl.py:3317-3319:
         //     index = (self.jitdriver_sd.num_green_args +
         //              self.jitdriver_sd.index_of_virtualizable)
         //     virtualizable_box = original_boxes[index]
@@ -3114,7 +3114,7 @@ impl<M: Clone> MetaInterp<M> {
         // driver (empty reds + named virtualizable), matching the
         // portal convention, so the strict RPython read works for
         // every driver.
-        // pyjitpl.py:3293 reads `original_boxes[num_green_args +
+        // pyjitpl.py:3317 reads `original_boxes[num_green_args +
         // index_of_virtualizable]`. pyre keeps `live_values` reds-only — the
         // compiled loop's reds-only entry contract (`live_values_match_descriptor`,
         // warmstate.py:387 execute_assembler). By default this restores RPython's
@@ -3138,11 +3138,11 @@ impl<M: Clone> MetaInterp<M> {
         };
         debug_assert!(
             use_original_boxes || num_green_args == 0,
-            "pyre green args live in green_key, not in live_values (pyjitpl.py:3293)"
+            "pyre green args live in green_key, not in live_values (pyjitpl.py:3317)"
         );
         assert!(
             jd_sd.index_of_virtualizable >= 0,
-            "pyjitpl.py:3293: jitdriver with virtualizable_info must have \
+            "pyjitpl.py:3317: jitdriver with virtualizable_info must have \
              index_of_virtualizable set (got {})",
             jd_sd.index_of_virtualizable,
         );
@@ -3189,7 +3189,7 @@ impl<M: Clone> MetaInterp<M> {
         };
         let num_array_elems: usize = array_lengths.iter().sum();
         let total_vable = num_static + num_array_elems;
-        // pyjitpl.py:3293-3302 parity:
+        // pyjitpl.py:3317-3326 parity:
         //     index = num_green_args + index_of_virtualizable
         //     virtualizable_box = original_boxes[index]
         //     startindex = len(original_boxes) - num_green_args  # == num_red_args
@@ -3209,7 +3209,7 @@ impl<M: Clone> MetaInterp<M> {
             .driver_descriptor()
             .map(|driver| driver.num_reds())
             .unwrap_or(1);
-        // pyjitpl.py:3290-3307 `initialize_virtualizable` only gates on
+        // pyjitpl.py:3314-3331 `initialize_virtualizable` only gates on
         // `vinfo is not None` and unconditionally calls
         // `vinfo.read_boxes(cpu, virtualizable, startindex)`. Callers
         // without a driver descriptor supply `live_values` already in the
@@ -3231,7 +3231,7 @@ impl<M: Clone> MetaInterp<M> {
         if !_has_expanded_tail_outer && self.vable_ptr.is_null() {
             return;
         }
-        // pyjitpl.py:3293-3295: index = num_green_args + index_of_virtualizable.
+        // pyjitpl.py:3317-3319: index = num_green_args + index_of_virtualizable.
         // The caller derives `index` above from jitdriver_sd so the bootstrap
         // path and the regular JitDriver registry agree. The virtualizable
         // is a Ref-typed inputarg (resoperation.py:739 InputArgRef).
@@ -3255,7 +3255,7 @@ impl<M: Clone> MetaInterp<M> {
         // only read through `virtualizable_values[-1]`, but it is what
         // `capture_resumedata` writes into every guard's vable section, so a
         // bridge decoding that section resolves the identity to the wrong
-        // deadframe slot.  `pyjitpl.py:3295 virtualizable_box =
+        // deadframe slot.  `pyjitpl.py:3319 virtualizable_box =
         // original_boxes[index]` is a lookup of the red that HOLDS the
         // virtualizable, so take the same lookup: `identity_live_index` is the
         // host's declared position for it, the state-field counterpart of
@@ -3303,7 +3303,7 @@ impl<M: Clone> MetaInterp<M> {
         // inputargs from the live heap values.
         let has_expanded_tail =
             info.identity_ref_bank_index.is_none() && live_values.len() >= num_reds + total_vable;
-        // pyjitpl.py:3302: virtualizable_boxes = vinfo.read_boxes(...)
+        // pyjitpl.py:3326: virtualizable_boxes = vinfo.read_boxes(...)
         // pyjitpl.py appends these boxes to `original_boxes` before
         // create_empty_history() snapshots the trace inputargs. When the
         // caller already supplied an expanded tail we reuse those inputarg
@@ -3347,7 +3347,7 @@ impl<M: Clone> MetaInterp<M> {
                 })
                 .collect()
         };
-        // pyjitpl.py:3306: virtualizable_boxes.append(virtualizable_box)
+        // pyjitpl.py:3330: virtualizable_boxes.append(virtualizable_box)
         // is folded inside init_virtualizable_boxes (it pushes vable_ref
         // at the end of the list).
         ctx.init_virtualizable_boxes(
@@ -3375,7 +3375,7 @@ impl<M: Clone> MetaInterp<M> {
         // MetaInterp `vable_ptr` was cached before `tracing` existed, so
         // `set_vable_ptr` could not plumb it through.
         ctx.set_virtualizable_heap_ptr(self.vable_ptr);
-        // pyjitpl.py:3307: check_synchronized_virtualizable() — debug-only
+        // pyjitpl.py:3331: check_synchronized_virtualizable() — debug-only
         // assertion. pyre's analog is `check_synchronized_virtualizable`
         // on MetaInterp, but it requires &self which we don't have here.
         // Callers in setup_tracing / bound_reached perform the check
@@ -3510,7 +3510,7 @@ impl<M: Clone> MetaInterp<M> {
             // slot 0; encode that here so `initialize_virtualizable`
             // can use `jd.index_of_virtualizable` unconditionally,
             // matching RPython's `index = num_green_args +
-            // index_of_virtualizable` (pyjitpl.py:3293-3295) without a
+            // index_of_virtualizable` (pyjitpl.py:3317-3319) without a
             // `< 0` fallback at the read site.
             if jd.index_of_virtualizable < 0 && jd.reds().is_empty() {
                 jd.index_of_virtualizable = 0;
@@ -3527,7 +3527,7 @@ impl<M: Clone> MetaInterp<M> {
 
     /// Get the active virtualizable info.
     ///
-    /// pyjitpl.py:3291 `vinfo = self.jitdriver_sd.virtualizable_info`.
+    /// pyjitpl.py:3315 `vinfo = self.jitdriver_sd.virtualizable_info`.
     /// Prefers the trace-bound `active_jitdriver_sd`; falls back to
     /// scanning `jitdrivers_sd` for callers that read this before any
     /// trace has started (warmspot init, host-side queries).
@@ -3545,7 +3545,7 @@ impl<M: Clone> MetaInterp<M> {
             .find_map(|jd| jd.virtualizable_info.as_ref())
     }
 
-    /// pyjitpl.py:3291 `self.jitdriver_sd = jitdriver_sd` parity —
+    /// pyjitpl.py:2411 `self.jitdriver_sd = jitdriver_sd` parity —
     /// pick the slot inside `staticdata.jitdrivers_sd` that owns the
     /// next trace.
     ///
@@ -3585,10 +3585,10 @@ impl<M: Clone> MetaInterp<M> {
     }
 
     /// Resolve the slot index of the JitDriver that should be treated
-    /// as `self.jitdriver_sd` (pyjitpl.py:3291) for callers that need
+    /// as `self.jitdriver_sd` (pyjitpl.py:2411) for callers that need
     /// `virtualizable_info` and the related metadata together.
     ///
-    /// pyjitpl.py:3291 `vinfo = self.jitdriver_sd.virtualizable_info` — the
+    /// pyjitpl.py:3315 `vinfo = self.jitdriver_sd.virtualizable_info` — the
     /// vinfo is STRICTLY that of the elected active driver, so a novable
     /// active driver (jd1 `unpackiterable_driver`, `virtualizable_info=None`)
     /// never borrows a sibling driver's vinfo; borrowing would capture a
@@ -3959,12 +3959,12 @@ impl<M: Clone> MetaInterp<M> {
                 if let Some(ref descriptor) = driver_descriptor {
                     ctx.set_driver_descriptor(descriptor.clone());
                 }
-                // pyjitpl.py:3291 `self.jitdriver_sd = jitdriver_sd`: see
+                // pyjitpl.py:2411 `self.jitdriver_sd = jitdriver_sd`: see
                 // `setup_tracing` for the rationale; `force_start_tracing`
                 // is the parallel trace-start entry point and must keep the
                 // same invariant.
                 self.active_jitdriver_sd = self.elect_active_jitdriver_sd(ctx.driver_descriptor());
-                // pyjitpl.py:3290 initialize_virtualizable parity.
+                // pyjitpl.py:3314 initialize_virtualizable parity.
                 self.initialize_virtualizable(&mut ctx, live_values);
                 // warmstate.py:439 `force_finish_trace=bool(cell.flags &
                 // JC_FORCE_FINISH)`.  Read-only — JC_FORCE_FINISH is sticky
@@ -4239,13 +4239,13 @@ impl<M: Clone> MetaInterp<M> {
         if let Some(ref descriptor) = driver_descriptor {
             ctx.set_driver_descriptor(descriptor.clone());
         }
-        // pyjitpl.py:3291 `self.jitdriver_sd = jitdriver_sd`: bind the
+        // pyjitpl.py:2411 `self.jitdriver_sd = jitdriver_sd`: bind the
         // active driver before reads (`initialize_virtualizable`) consult
         // it. `elect_active_jitdriver_sd` mirrors RPython by picking the
         // driver matching the descriptor; with the single-portal pyre
         // shell driver this collapses to slot 0.
         self.active_jitdriver_sd = self.elect_active_jitdriver_sd(ctx.driver_descriptor());
-        // pyjitpl.py:3290 initialize_virtualizable parity.
+        // pyjitpl.py:3314 initialize_virtualizable parity.
         self.initialize_virtualizable(&mut ctx, live_values);
 
         // warmstate.py:439 `force_finish_trace=bool(cell.flags &
@@ -11462,7 +11462,7 @@ impl<M: Clone> MetaInterp<M> {
         ctx.set_trace_limit(self.warm_state.trace_limit() as usize);
         ctx.callinfocollection = self.callinfocollection.clone();
         self.tracing = Some(ctx);
-        // pyjitpl.py:3291 `self.jitdriver_sd = jitdriver_sd`: bridges
+        // pyjitpl.py:2411 `self.jitdriver_sd = jitdriver_sd`: bridges
         // inherit the parent's driver. The bridge entry path does not
         // thread `driver_descriptor`, so fall back to scanning for the
         // vinfo-bearing slot — a no-op for single-portal pyre and the
@@ -19944,7 +19944,7 @@ mod tests {
         );
     }
 
-    /// `pyjitpl.py:3295` reads the virtualizable out of a DECLARED red
+    /// `pyjitpl.py:3319` reads the virtualizable out of a DECLARED red
     /// position; it never searches the reds for it. A red that happens to hold
     /// the same pointer earlier in the vector — another name for the same
     /// object — must not take the identity's place.
@@ -20956,7 +20956,7 @@ mod tests {
 
     #[test]
     fn trace_entry_vable_lengths_reads_from_heap_first() {
-        // pyjitpl.py:3302 `vinfo.read_boxes(...)` always reads from the
+        // pyjitpl.py:3326 `vinfo.read_boxes(...)` always reads from the
         // concrete heap object. The interpreter-supplied cache is a pyre
         // fallback used only when `info.can_read_all_array_lengths_from_heap`
         // is false; otherwise the heap-read wins.

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -6832,6 +6832,7 @@ impl<M: Clone> MetaInterp<M> {
                     .expect("bridge source op.descr must implement FailDescr");
                 let success = self.compile_bridge(
                     origin_key,
+                    green_key,
                     fail_index,
                     fail_descr,
                     &bridge_ops,
@@ -10683,9 +10684,35 @@ impl<M: Clone> MetaInterp<M> {
     /// `fail_descr` is the FailDescr from the guard that failed.
     /// `bridge_ops` are the recorded bridge trace operations.
     /// `bridge_inputargs` are the input arguments for the bridge.
+    /// `unroll.py:196-197 cell_token = jump_op.getdescr()` and
+    /// `unroll.py:321-322 jitcelltoken = jump_op.getdescr()`: the jitcell whose
+    /// `target_tokens` `optimize_bridge` scans, and whose `retraced_count` it
+    /// reads and charges, is the one the closing JUMP *enters* — never the loop
+    /// the bridge hangs from.  A JUMP target with no compiled loop has no
+    /// `target_tokens` to scan, so it degrades to the origin.
+    pub(crate) fn bridge_cell_token_key(&self, origin_key: u64, jump_target_key: u64) -> u64 {
+        if jump_target_key != origin_key && self.compiled_loops.contains_key(&jump_target_key) {
+            jump_target_key
+        } else {
+            origin_key
+        }
+    }
+
     pub fn compile_bridge(
         &mut self,
         green_key: u64,
+        // The jitcell the closing JUMP enters (`bridge_cell_token_key`).
+        // `green_key` stays the origin — it selects the guard's trace, its
+        // OpRef namespace base and the loop the bridge is attached to.
+        //
+        // Measured over `pyre/bench` (336 scripts, dynasm): 50 of 403 bridge
+        // closes cross loops, but 44 of those enter a jitcell holding a single
+        // target token, where `optimize_bridge` takes the `len() <= 1`
+        // jump_to_preamble path off the JUMP's own descr either way.  Only 6
+        // reach the target-token scan, and they converge — outputs and all
+        // five jit-stats counters are byte-identical across the corpus with
+        // and without this parameter.  It is a parity correction, not a lever.
+        jump_target_key: u64,
         fail_index: u32,
         fail_descr: &dyn majit_ir::FailDescr,
         bridge_ops: &[majit_ir::Op],
@@ -10703,6 +10730,7 @@ impl<M: Clone> MetaInterp<M> {
         if !self.compiled_loops.contains_key(&green_key) {
             return false;
         }
+        let cell_token_key = self.bridge_cell_token_key(green_key, jump_target_key);
 
         // `pyjitpl.py:2897-2899` parity:
         //   self.resumekey_original_loop_token =
@@ -10748,8 +10776,16 @@ impl<M: Clone> MetaInterp<M> {
         // bridgeopt.py:124-185 deserialize_optimizer_knowledge:
         // Retrieve guard's rd_numb + frontend_boxes for deserialization.
         use crate::optimizeopt::optimizer::PendingBridgeRd;
-        let (retraced_count, loop_num_inputs, parent_next_global_opref, pending_bridge_rd): (
-            u32,
+        // `unroll.py:213-215 if cell_token.retraced_count < limit:
+        // cell_token.retraced_count += 1` — the retrace budget is charged to
+        // the jitcell being entered, so a cross-loop close reads (and below,
+        // bumps) the target's counter rather than the origin's.
+        let retraced_count = self
+            .compiled_loops
+            .get(&cell_token_key)
+            .and_then(|compiled| compiled.live_token())
+            .map_or(0, |tok| tok.get_retraced_count());
+        let (loop_num_inputs, parent_next_global_opref, pending_bridge_rd): (
             usize,
             u32,
             Option<PendingBridgeRd>,
@@ -10831,7 +10867,6 @@ impl<M: Clone> MetaInterp<M> {
                 return false;
             };
             (
-                tok.get_retraced_count(),
                 tok.inputarg_types().len(),
                 compiled.next_global_opref,
                 pending,
@@ -10966,18 +11001,39 @@ impl<M: Clone> MetaInterp<M> {
             eprint!("{}", majit_ir::format_trace(bridge_ops, &constants));
         }
         let _compiled = self.compiled_loops.get_mut(&green_key).unwrap();
+        // `unroll.py:325 for target_token in jitcelltoken.target_tokens` scans
+        // the tokens of the loop the JUMP enters.  `compiled_loops` cannot
+        // hand out a second `&mut` alongside the origin entry, so a cross-loop
+        // close runs against a clone of the target's vector and stores it back
+        // below; a same-loop close keeps borrowing the entry in place.
+        let mut crossed_target_tokens = if cell_token_key != green_key {
+            self.compiled_loops
+                .get(&cell_token_key)
+                .map(|compiled| compiled.front_target_tokens.clone())
+        } else {
+            None
+        };
         // compile.py:1077-1078 parity: optimize_bridge may raise InvalidLoop
         // (e.g. rewrite.py:404-407 GUARD_CLASS proven to always fail).
         // RPython catches it via the abstract jitexc handler and discards
         // the bridge. Mirror that here so the trace abort doesn't unwind
         // past compile_bridge.
         let bridge_optimize_result = {
-            let compiled = self.compiled_loops.get_mut(&green_key).unwrap();
+            let front_target_tokens = match crossed_target_tokens.as_mut() {
+                Some(tokens) => tokens,
+                None => {
+                    &mut self
+                        .compiled_loops
+                        .get_mut(&green_key)
+                        .unwrap()
+                        .front_target_tokens
+                }
+            };
             optimizer.optimize_bridge(
                 bridge_ops,
                 &mut constants,
                 bridge_inputargs.len(),
-                &mut compiled.front_target_tokens,
+                front_target_tokens,
                 bridge_runtime_boxes,
                 bridge_inline_short_preamble,
                 retraced_count,
@@ -10987,6 +11043,11 @@ impl<M: Clone> MetaInterp<M> {
                 bridge_inputarg_base,
             )
         };
+        if let Some(tokens) = crossed_target_tokens {
+            if let Some(compiled) = self.compiled_loops.get_mut(&cell_token_key) {
+                compiled.front_target_tokens = tokens;
+            }
+        }
         let (optimized_ops, retrace_requested) = match bridge_optimize_result {
             Ok(result) => result,
             // compile.py:1077-1078 + unroll.py:119-123 `except (InvalidLoop,
@@ -11015,9 +11076,11 @@ impl<M: Clone> MetaInterp<M> {
             // compile.py:1079: metainterp.retrace_needed(new_trace, info)
             // Save partial trace + exported state so the next loop-header's
             // compile_loop → compile_retrace can produce a new specialization.
+            // unroll.py:214 `cell_token.retraced_count += 1` — charged to the
+            // jitcell the JUMP enters, which is where the count was read from.
             if let Some(tok) = self
                 .compiled_loops
-                .get(&green_key)
+                .get(&cell_token_key)
                 .and_then(|compiled| compiled.live_token())
             {
                 tok.set_retraced_count(tok.get_retraced_count() + 1);
@@ -22051,6 +22114,60 @@ mod tests {
         assert!(hooks.on_trace_start.is_none());
         assert!(hooks.on_trace_abort.is_none());
         assert!(hooks.on_compile_error.is_none());
+    }
+}
+
+/// `unroll.py:196-197` / `:321-322` route every target-token decision in
+/// `optimize_bridge` through `jump_op.getdescr()`, the jitcell the closing JUMP
+/// enters.  These pin which loop `compile_bridge` resolves that to.
+#[cfg(test)]
+mod bridge_cell_token_tests {
+    use super::*;
+
+    fn record_loop(meta: &mut MetaInterp<()>, green_key: u64) {
+        meta.compiled_loops.insert(
+            green_key,
+            CompiledEntry {
+                token: std::sync::Weak::new(),
+                meta: (),
+                front_target_tokens: Vec::new(),
+                front_target_source_positions: None,
+                root_trace_id: green_key,
+                traces: indexmap::IndexMap::new(),
+                previous_tokens: Vec::new(),
+                next_global_opref: 0,
+            },
+        );
+    }
+
+    #[test]
+    fn a_same_loop_close_keeps_the_origin() {
+        let mut meta = MetaInterp::<()>::new(1);
+        record_loop(&mut meta, 7);
+        assert_eq!(meta.bridge_cell_token_key(7, 7), 7);
+    }
+
+    #[test]
+    fn a_cross_loop_close_reaches_the_jump_target() {
+        let mut meta = MetaInterp::<()>::new(1);
+        record_loop(&mut meta, 7);
+        record_loop(&mut meta, 9);
+        assert_eq!(
+            meta.bridge_cell_token_key(7, 9),
+            9,
+            "unroll.py:321-322 scans the target_tokens of the jitcell the JUMP enters"
+        );
+    }
+
+    #[test]
+    fn an_uncompiled_jump_target_degrades_to_the_origin() {
+        let mut meta = MetaInterp::<()>::new(1);
+        record_loop(&mut meta, 7);
+        assert_eq!(
+            meta.bridge_cell_token_key(7, 9),
+            7,
+            "a target with no compiled loop has no target_tokens to scan"
+        );
     }
 }
 

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -3025,6 +3025,36 @@ impl<M: Clone> MetaInterp<M> {
         self.vable_array_lengths.clone()
     }
 
+    /// Position of the virtualizable identity inside `live_values`, the
+    /// state-field counterpart of `pyjitpl.py:3295 original_boxes[index]`.
+    ///
+    /// The host declares it (`identity_live_index`); this checks the declared
+    /// position actually holds `vable_ptr` before taking it, because
+    /// `live_values` also arrives from bridge entry, where the reds are rebuilt
+    /// from a deadframe rather than emitted by the state's `extract_live`. A
+    /// host that declares nothing, or whose reds disagree with the declaration,
+    /// falls back to matching the live pointer.
+    ///
+    /// `None` when the pointer is not in the reds at all — the caller then
+    /// mints the box at the declared ref-bank index instead.
+    fn identity_live_position(
+        info: &VirtualizableInfo,
+        live_values: &[Value],
+        vable_ptr: *const u8,
+    ) -> Option<usize> {
+        if vable_ptr.is_null() {
+            return None;
+        }
+        let vable_bits = vable_ptr as usize;
+        let holds_identity = |idx: usize| match live_values.get(idx) {
+            Some(Value::Ref(r)) => r.as_usize() == vable_bits,
+            _ => false,
+        };
+        info.identity_live_index
+            .filter(|idx| holds_identity(*idx))
+            .or_else(|| (0..live_values.len()).find(|idx| holds_identity(*idx)))
+    }
+
     /// pyjitpl.py:3290 `initialize_virtualizable(self, original_boxes)`.
     ///
     /// RPython:
@@ -3059,36 +3089,6 @@ impl<M: Clone> MetaInterp<M> {
     /// `index_of_virtualizable`; the resolved virtualizable pointer and its
     /// ref-bank index are unchanged either way (the gate is a structural-parity
     /// no-op).
-    /// Position of the virtualizable identity inside `live_values`, the
-    /// state-field counterpart of `pyjitpl.py:3295 original_boxes[index]`.
-    ///
-    /// The host declares it (`identity_live_index`); this checks the declared
-    /// position actually holds `vable_ptr` before taking it, because
-    /// `live_values` also arrives from bridge entry, where the reds are rebuilt
-    /// from a deadframe rather than emitted by the state's `extract_live`. A
-    /// host that declares nothing, or whose reds disagree with the declaration,
-    /// falls back to matching the live pointer.
-    ///
-    /// `None` when the pointer is not in the reds at all — the caller then
-    /// mints the box at the declared ref-bank index instead.
-    fn identity_live_position(
-        info: &VirtualizableInfo,
-        live_values: &[Value],
-        vable_ptr: *const u8,
-    ) -> Option<usize> {
-        if vable_ptr.is_null() {
-            return None;
-        }
-        let vable_bits = vable_ptr as usize;
-        let holds_identity = |idx: usize| match live_values.get(idx) {
-            Some(Value::Ref(r)) => r.as_usize() == vable_bits,
-            _ => false,
-        };
-        info.identity_live_index
-            .filter(|idx| holds_identity(*idx))
-            .or_else(|| (0..live_values.len()).find(|idx| holds_identity(*idx)))
-    }
-
     fn initialize_virtualizable(&self, ctx: &mut TraceCtx, live_values: &[Value]) {
         // pyjitpl.py:3291: vinfo = self.jitdriver_sd.virtualizable_info
         // Prefer the trace-bound `active_jitdriver_sd` (RPython

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -5011,11 +5011,30 @@ where
                             // counts too low to reach the merge point twice.
                             //
                             // The JUMP-into-ptoken half of :3001-3007 is not
-                            // implemented — see `compile_trace_entry_data`, which
-                            // declines an entry-bridge close for `header_pc != 0`.
+                            // implemented here.  It is not blocked on missing
+                            // machinery — that was tried and measured:
+                            // publishing the token key plus `close_greens` and
+                            // returning `CloseLoop` reaches `close_bridge` for a
+                            // guard origin and `compile_trace_from_interp`
+                            // (through `compile_trace_entry_data`, which needs
+                            // `header_pc == 0`) for an interp origin, and both
+                            // land.  cel's `nested_list_loop_varying_trip_count`
+                            // then keeps its results and loses its 4 aborts, but
+                            // its `spread 0..32` deopts go 959 → 1763 over 4000
+                            // rows and 1275 → 2601 over 16000: the residual
+                            // per-row tail worsens ~2.6x.  Jumping in ends the
+                            // trace at the inner loop, where the ordinary close
+                            // covered the whole outer iteration, and the exit
+                            // guards that shape leaves behind do not converge.
+                            // Routing the closing JUMP's target tokens off the
+                            // token it enters instead of off the bridge origin
+                            // (`unroll.py:196-197 cell_token = jump_op.getdescr()`
+                            // — pyre's `compile_bridge` hands `optimize_bridge`
+                            // the ORIGIN loop's `front_target_tokens`) recovers
+                            // only 7% of that, so the gap is elsewhere.
                             //
                             // Two consequences of declining, both narrower than
-                            // upstream, both waiting on that half:
+                            // upstream:
                             //   * upstream reaches the `current_merge_points`
                             //     scan whenever `compile_trace` does NOT raise;
                             //     this arm returns to neither the scan nor the
@@ -5025,15 +5044,18 @@ where
                             //   * upstream's is a JUMP into reachable code; ours
                             //     re-traces that loop's body inline.
                             //
-                            // Upstream's `if not self.partial_trace:` (:3003) is
-                            // NOT ported and must not be spelled `is_bridge_trace`:
-                            // `partial_trace` is set only by `retrace_needed`
-                            // (pyjitpl.py:2438-2439), so it means "this is a
-                            // RETRACE", and a bridge from a guard failure runs the
-                            // ptoken consult upstream just like a primary entry.
-                            // Pyre has no retrace at this site, so the consult is
-                            // unconditional — which is the upstream behaviour for
-                            // every trace pyre can actually produce here.
+                            // The token lookup below is unconditional, where
+                            // upstream guards it with `if not self.partial_trace:`
+                            // (:3002).  That gate must not be spelled
+                            // `is_bridge_trace`: `partial_trace` is set only by
+                            // `retrace_needed` (pyjitpl.py:2438-2439), so it means
+                            // "this is a RETRACE", and a bridge from a guard
+                            // failure runs the consult upstream just like a
+                            // primary entry.  Its live reading is
+                            // `MetaInterp::partial_trace()`, which this loop
+                            // cannot reach while it holds the TraceCtx borrow —
+                            // harmless while the lookup only decides a log line,
+                            // and part of what the JUMP half has to carry.
                             let mp_greens = (
                                 mp_green_ints.clone(),
                                 mp_green_refs.clone(),

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -4982,7 +4982,55 @@ where
                             let header_pc = ctx.header_pc;
                             let inner_key =
                                 crate::green_key_from_code_ptr(ctx.green_key_raw.0, pc as usize);
-                            if ctx.has_merge_point_at(inner_key, header_pc) {
+                            // pyjitpl.py:3001-3007, which runs BEFORE the
+                            // `current_merge_points` scan:
+                            //
+                            //     ptoken = self.get_procedure_token(greenboxes)
+                            //     if has_compiled_targets(ptoken):
+                            //         self.compile_trace(live_arg_boxes, ptoken)
+                            //
+                            // `greenboxes` is the merge point just reached, so a
+                            // loop that ALREADY has compiled code is jumped into,
+                            // never re-derived by cutting this trace at it. The
+                            // cut (compile.py:269) is for the other case: an
+                            // inner loop nobody has compiled yet, which
+                            // `compile_loop` then attaches to
+                            // `original_boxes[:num_green_args]` — the INNER
+                            // greenkey (pyjitpl.py:3183-3187).
+                            //
+                            // Pyre's cut cannot do that attach: it stores under
+                            // `cut_inner_green_key`, and the only key derivable
+                            // here is `green_key_from_code_ptr(green_key_raw.0,
+                            // pc)` with `JitState::code_ptr()` defaulting to 0 —
+                            // not the driver's `GreenKey::hash_u64`. So cutting
+                            // at a merge point that already holds a compiled loop
+                            // would replace reachable code with code stored where
+                            // nothing enters. Decline the cut and keep tracing;
+                            // the trace then closes at its own header with this
+                            // loop's body inlined, which is what it does at trip
+                            // counts too low to reach the merge point twice.
+                            //
+                            // The JUMP-into-ptoken half of :3001-3007 is not
+                            // implemented — see `compile_trace_entry_data`, which
+                            // declines an entry-bridge close for `header_pc != 0`.
+                            let mp_greens = (
+                                mp_green_ints.clone(),
+                                mp_green_refs.clone(),
+                                mp_green_floats.clone(),
+                            );
+                            let already_compiled_here = ctx
+                                .compiled_key_for_greens_fn
+                                .as_ref()
+                                .and_then(|f| f(&mp_greens));
+                            if let Some(ptoken_key) = already_compiled_here {
+                                if crate::majit_log_enabled() {
+                                    eprintln!(
+                                        "[jit] merge point pc={pc} already has compiled loop \
+                                         key={ptoken_key} — declining the cross-loop cut \
+                                         (pyjitpl.py:3005)"
+                                    );
+                                }
+                            } else if ctx.has_merge_point_at(inner_key, header_pc) {
                                 if crate::jitdriver::spdiag_enabled() {
                                     eprintln!(
                                         "@@@SPDIAG INNER-CUT-CLOSE pc={pc} header_pc={header_pc} inner_key={inner_key} walk_reds={walk_reds:?}"
@@ -5029,46 +5077,47 @@ where
                                 // unconditionally at the reached_loop_header entry
                                 // above (pyjitpl.py:2993).
                                 return TraceAction::CloseLoop;
+                            } else {
+                                // first visit → append and keep tracing
+                                // (pyjitpl.py:3058-3060). For the state-field dispatch
+                                // model the merge point's loop-carried values are the
+                                // RED state fields (the closing JUMP = collect_jump_args),
+                                // NOT the green operands captured in `live_arg_boxes`
+                                // (those are promoted constants folded inline in the cut
+                                // body). Register the SAME construction the close uses
+                                // — `JitState::collect_jump_args_with_boxes` reached
+                                // through `JitCodeSym::loop_carried_boxes` — so the cut
+                                // label's inputarg arity matches the JUMP's
+                                // (compile.py:334 jump.numargs()==label.numargs()), the
+                                // way RPython's single `live_arg_boxes` list does by
+                                // construction (pyjitpl.py:2981-2989). Falls back to the
+                                // operand-captured boxes for interpreters with no state
+                                // fields at all.
+                                //
+                                // Building this from the scalar state fields alone (as
+                                // this site used to) silently omits the virtualizable's
+                                // element boxes, so an interpreter whose state is purely
+                                // `[int; virt]` / `[float; virt]` arrays registered just
+                                // the greens plus one unexpanded vable ref while its
+                                // close expanded to one box per element — the arity
+                                // mismatch that made every nested loop decline.
+                                let vable_boxes =
+                                    ctx.collect_virtualizable_typed_boxes().unwrap_or_default();
+                                let original_boxes = match sym.loop_carried_boxes(&vable_boxes) {
+                                    Some(boxes) => boxes
+                                        .into_iter()
+                                        .map(|(o, ty)| crate::trace_ctx::GreenBox::new(o, ty))
+                                        .collect(),
+                                    None => live_arg_boxes,
+                                };
+                                if crate::mptrace_enabled() {
+                                    eprintln!(
+                                        "@@@MPTRACE add-mp pc={pc} header_pc={header_pc} inner_key={inner_key} num_ops={}",
+                                        ctx.num_ops(),
+                                    );
+                                }
+                                ctx.add_merge_point(inner_key, original_boxes, header_pc);
                             }
-                            // first visit → append and keep tracing
-                            // (pyjitpl.py:3058-3060). For the state-field dispatch
-                            // model the merge point's loop-carried values are the
-                            // RED state fields (the closing JUMP = collect_jump_args),
-                            // NOT the green operands captured in `live_arg_boxes`
-                            // (those are promoted constants folded inline in the cut
-                            // body). Register the SAME construction the close uses
-                            // — `JitState::collect_jump_args_with_boxes` reached
-                            // through `JitCodeSym::loop_carried_boxes` — so the cut
-                            // label's inputarg arity matches the JUMP's
-                            // (compile.py:334 jump.numargs()==label.numargs()), the
-                            // way RPython's single `live_arg_boxes` list does by
-                            // construction (pyjitpl.py:2981-2989). Falls back to the
-                            // operand-captured boxes for interpreters with no state
-                            // fields at all.
-                            //
-                            // Building this from the scalar state fields alone (as
-                            // this site used to) silently omits the virtualizable's
-                            // element boxes, so an interpreter whose state is purely
-                            // `[int; virt]` / `[float; virt]` arrays registered just
-                            // the greens plus one unexpanded vable ref while its
-                            // close expanded to one box per element — the arity
-                            // mismatch that made every nested loop decline.
-                            let vable_boxes =
-                                ctx.collect_virtualizable_typed_boxes().unwrap_or_default();
-                            let original_boxes = match sym.loop_carried_boxes(&vable_boxes) {
-                                Some(boxes) => boxes
-                                    .into_iter()
-                                    .map(|(o, ty)| crate::trace_ctx::GreenBox::new(o, ty))
-                                    .collect(),
-                                None => live_arg_boxes,
-                            };
-                            if crate::mptrace_enabled() {
-                                eprintln!(
-                                    "@@@MPTRACE add-mp pc={pc} header_pc={header_pc} inner_key={inner_key} num_ops={}",
-                                    ctx.num_ops(),
-                                );
-                            }
-                            ctx.add_merge_point(inner_key, original_boxes, header_pc);
                         }
                     }
                 }

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -335,6 +335,31 @@ pub trait JitCodeSym {
         None
     }
 
+    /// pyjitpl.py:2981-2989 `live_arg_boxes` — this merge point's
+    /// loop-carried boxes, in the exact order the closing JUMP emits them.
+    ///
+    /// RPython builds `live_arg_boxes` ONCE per `reached_loop_header` and
+    /// hands the same list to `current_merge_points.append` (the
+    /// registration), to `compile_loop`'s LABEL and to `compile_trace`'s
+    /// JUMP; `assert len(original_boxes) == len(live_arg_boxes)`
+    /// (pyjitpl.py:3020) is free there because there is only one list. The
+    /// dispatch loop reaches a merge point with only `JitCodeSym` in scope,
+    /// so this hook is how it gets at the construction that
+    /// `JitState::collect_jump_args_with_boxes` uses for the close — the two
+    /// MUST agree or the cut label's arity will not match the JUMP's
+    /// (`compile.py:334 jump.numargs() == label.numargs()`).
+    ///
+    /// `vable_boxes` is `TraceCtx::collect_virtualizable_typed_boxes()`,
+    /// identity last (this hook drops it, mirroring the `.pop()`).
+    /// `None` = "no state-field construction" — the caller keeps its own
+    /// fallback.
+    fn loop_carried_boxes(
+        &self,
+        _vable_boxes: &[(OpRef, majit_ir::Type)],
+    ) -> Option<Vec<(OpRef, majit_ir::Type)>> {
+        None
+    }
+
     // -- State field support (register/tape machines) -----
     //
     // When state_fields is configured, scalar and array fields on the
@@ -5011,30 +5036,31 @@ where
                             // RED state fields (the closing JUMP = collect_jump_args),
                             // NOT the green operands captured in `live_arg_boxes`
                             // (those are promoted constants folded inline in the cut
-                            // body). Use the red state-field oprefs in
-                            // collect_jump_args order (int scalars then ref scalars)
-                            // as the cut's `original_boxes` so the inner loop's LABEL
-                            // inputarg arity matches the JUMP (compile.py:334
-                            // jump.numargs()==label.numargs()). Falls back to the
-                            // operand-captured boxes for interpreters with no
-                            // int/ref state fields.
-                            let mut red_boxes: Vec<crate::trace_ctx::GreenBox> = Vec::new();
-                            let mut sfi = 0;
-                            while let Some(o) = sym.state_field_ref(sfi) {
-                                red_boxes
-                                    .push(crate::trace_ctx::GreenBox::new(o, majit_ir::Type::Int));
-                                sfi += 1;
-                            }
-                            let mut sfr = 0;
-                            while let Some(o) = sym.state_ref_field_ref(sfr) {
-                                red_boxes
-                                    .push(crate::trace_ctx::GreenBox::new(o, majit_ir::Type::Ref));
-                                sfr += 1;
-                            }
-                            let original_boxes = if red_boxes.is_empty() {
-                                live_arg_boxes
-                            } else {
-                                red_boxes
+                            // body). Register the SAME construction the close uses
+                            // — `JitState::collect_jump_args_with_boxes` reached
+                            // through `JitCodeSym::loop_carried_boxes` — so the cut
+                            // label's inputarg arity matches the JUMP's
+                            // (compile.py:334 jump.numargs()==label.numargs()), the
+                            // way RPython's single `live_arg_boxes` list does by
+                            // construction (pyjitpl.py:2981-2989). Falls back to the
+                            // operand-captured boxes for interpreters with no state
+                            // fields at all.
+                            //
+                            // Building this from the scalar state fields alone (as
+                            // this site used to) silently omits the virtualizable's
+                            // element boxes, so an interpreter whose state is purely
+                            // `[int; virt]` / `[float; virt]` arrays registered just
+                            // the greens plus one unexpanded vable ref while its
+                            // close expanded to one box per element — the arity
+                            // mismatch that made every nested loop decline.
+                            let vable_boxes =
+                                ctx.collect_virtualizable_typed_boxes().unwrap_or_default();
+                            let original_boxes = match sym.loop_carried_boxes(&vable_boxes) {
+                                Some(boxes) => boxes
+                                    .into_iter()
+                                    .map(|(o, ty)| crate::trace_ctx::GreenBox::new(o, ty))
+                                    .collect(),
+                                None => live_arg_boxes,
                             };
                             if crate::mptrace_enabled() {
                                 eprintln!(

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -5013,6 +5013,27 @@ where
                             // The JUMP-into-ptoken half of :3001-3007 is not
                             // implemented — see `compile_trace_entry_data`, which
                             // declines an entry-bridge close for `header_pc != 0`.
+                            //
+                            // Two consequences of declining, both narrower than
+                            // upstream, both waiting on that half:
+                            //   * upstream reaches the `current_merge_points`
+                            //     scan whenever `compile_trace` does NOT raise;
+                            //     this arm returns to neither the scan nor the
+                            //     `append` (:3058-3060), so the merge point is
+                            //     never registered at all while a compiled loop
+                            //     sits at those greens.
+                            //   * upstream's is a JUMP into reachable code; ours
+                            //     re-traces that loop's body inline.
+                            //
+                            // Upstream's `if not self.partial_trace:` (:3003) is
+                            // NOT ported and must not be spelled `is_bridge_trace`:
+                            // `partial_trace` is set only by `retrace_needed`
+                            // (pyjitpl.py:2438-2439), so it means "this is a
+                            // RETRACE", and a bridge from a guard failure runs the
+                            // ptoken consult upstream just like a primary entry.
+                            // Pyre has no retrace at this site, so the consult is
+                            // unconditional — which is the upstream behaviour for
+                            // every trace pyre can actually produce here.
                             let mp_greens = (
                                 mp_green_ints.clone(),
                                 mp_green_refs.clone(),

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -5125,10 +5125,17 @@ where
                                 let vable_boxes =
                                     ctx.collect_virtualizable_typed_boxes().unwrap_or_default();
                                 let original_boxes = match sym.loop_carried_boxes(&vable_boxes) {
-                                    Some(boxes) => boxes
-                                        .into_iter()
-                                        .map(|(o, ty)| crate::trace_ctx::GreenBox::new(o, ty))
-                                        .collect(),
+                                    Some(mut boxes) => {
+                                        // pyjitpl.py:2978-2987 normalizes the list
+                                        // before it becomes anything — the LABEL
+                                        // this registration turns into cannot carry
+                                        // a constant or a repeated box.
+                                        ctx.remove_consts_and_duplicates(&mut boxes);
+                                        boxes
+                                            .into_iter()
+                                            .map(|(o, ty)| crate::trace_ctx::GreenBox::new(o, ty))
+                                            .collect()
+                                    }
                                     None => live_arg_boxes,
                                 };
                                 if crate::mptrace_enabled() {

--- a/majit/majit-metainterp/src/resume.rs
+++ b/majit/majit-metainterp/src/resume.rs
@@ -3909,11 +3909,17 @@ impl ResumeDataLoopMemo {
 
         // resume.py:240-241 virtualizable array.
         //
-        // Upstream shape is `virtualizable_boxes = read_boxes(...);`
-        // `virtualizable_boxes.append(virtualizable_box)` (pyjitpl.py:3302-3306),
-        // i.e. payload first, identity last. The snapshot already carries the
-        // tracing-time Box identities in that order, so line-by-line parity is
-        // to run the whole array through `_number_boxes()` unchanged.
+        // `metainterp.virtualizable_boxes` is payload-first, identity-last
+        // (`read_boxes(...)` then `append(virtualizable_box)`,
+        // pyjitpl.py:3302-3306) — but that is NOT the order arriving here. The
+        // snapshot writer already reordered it: `_list_of_boxes_virtualizable`
+        // (opencoder.py:718-726, `build_vable_snapshot_boxes` for the
+        // state-field path) moves `boxes[-1]` to slot 0, so `vable_array` is
+        // identity-FIRST and the readers pull the virtualizable out before its
+        // payload (`resume.py:1404 virtualizable = self.next_ref()`;
+        // `consume_vable_info`; `seed_bridge_virtualizable_boxes`'s
+        // `split_first`). Numbering must not reorder it again — running the
+        // whole array through `_number_boxes()` unchanged is the parity.
         numb_state.append_int(snapshot.vable_array.len() as i64);
         self._number_boxes(&snapshot.vable_array, &mut numb_state, env)?;
 

--- a/majit/majit-metainterp/src/resume.rs
+++ b/majit/majit-metainterp/src/resume.rs
@@ -3911,7 +3911,7 @@ impl ResumeDataLoopMemo {
         //
         // `metainterp.virtualizable_boxes` is payload-first, identity-last
         // (`read_boxes(...)` then `append(virtualizable_box)`,
-        // pyjitpl.py:3302-3306) — but that is NOT the order arriving here. The
+        // pyjitpl.py:3326-3330) — but that is NOT the order arriving here. The
         // snapshot writer already reordered it: `_list_of_boxes_virtualizable`
         // (opencoder.py:718-726, `build_vable_snapshot_boxes` for the
         // state-field path) moves `boxes[-1]` to slot 0, so `vable_array` is
@@ -5071,7 +5071,7 @@ mod tests {
         env.types.insert(1, majit_ir::Type::Int);
 
         let snapshot = Snapshot {
-            // pyjitpl.py:3302-3306 parity: payload slots first,
+            // pyjitpl.py:3326-3330 parity: payload slots first,
             // virtualizable identity (`virtualizable_boxes[-1]`) last.
             vable_array: vec![OpRef::int_op(1).into(), OpRef::ref_op(7).into()],
             vref_array: vec![],

--- a/majit/majit-metainterp/src/resume_box_reader.rs
+++ b/majit/majit-metainterp/src/resume_box_reader.rs
@@ -991,7 +991,7 @@ pub fn replay_pending_fields(
 ///     self.virtualizable_boxes = virtualizable_boxes
 /// ```
 ///
-/// `virtualizable_boxes` is what `resume.py:1370 consume_virtualizable_boxes`
+/// `virtualizable_boxes` is what `resume.py:1083 consume_virtualizable_boxes`
 /// built out of the guard's vable section: the virtualizable itself comes
 /// first (`resume.py:1404 virtualizable = self.next_ref()`), then
 /// `virtualizable.py:139 load_list_of_boxes` reads one box per static field
@@ -1044,7 +1044,7 @@ pub fn seed_bridge_virtualizable_boxes(
     // replaced, folded, or never made it into the guard's fail args), and
     // dereferencing whatever value sits there would be a wild read; decline
     // the seed instead, which leaves the guard deopting through the blackhole
-    // exactly as it did before — `compile.py:725-729 compile.giveup()`.
+    // exactly as it did before — `compile.py:27 compile.giveup()`.
     let Some(identity_value @ Value::Ref(vable_ref)) = concrete(identity, fail_values) else {
         return false;
     };
@@ -1058,12 +1058,27 @@ pub fn seed_bridge_virtualizable_boxes(
     if !info.can_read_all_array_lengths_from_heap() {
         return false;
     }
-    // `pyjitpl.py:3450 rebuild_state_after_failure` pairs the assignment with
-    // `self.check_synchronized_virtualizable()`, which asserts the box just
-    // decoded IS the live virtualizable.  Pyre cannot assert: the guard's vable
-    // section is only as good as the numbering that produced it, and a decoded
-    // identity that is not the live object would be dereferenced below.  Treat
-    // the mismatch as `compile.py:725-729 compile.giveup()` instead.
+    // Upstream never validates the decoded identity here: `rebuild_state_after
+    // _failure` takes `virtualizable_boxes[-1]` and goes straight on to
+    // `reset_token_gcref` + `synchronize_virtualizable()` (pyjitpl.py:3449-3454),
+    // because the box came out of ITS OWN numbering and cannot name anything
+    // else.  Pyre's does not carry that guarantee — the state-field vable
+    // section is only as good as the numbering that produced it — and the
+    // pointer is dereferenced below, so an identity that is not the live object
+    // would be a wild read.  Check it and decline instead (`compile.giveup()`,
+    // compile.py:27), which is strictly more conservative than upstream: the
+    // guard keeps deopting through the blackhole exactly as it did before.
+    //
+    // The two writes upstream pairs with the assignment are both inert for this
+    // seed's only consumer, so neither is ported:
+    //   * `reset_token_gcref` — the state-field vinfo is built by
+    //     `VirtualizableInfo::without_vable_token()`, whose token protocol
+    //     no-ops (`codegen_state.rs` `__build_virtualizable_info`).
+    //   * `synchronize_virtualizable()` — `TraceCtx::synchronize_virtualizable`
+    //     deliberately skips the write-back for `RustVec` array storage, which
+    //     is what every `[.. ; virt]` state field is: the macro-generated
+    //     mainloop owns that struct and writes it on every opcode, so the heap
+    //     is authoritative and flushing the shadow back would clobber it.
     match ctx.virtualizable_heap_ptr() {
         Some(live) if live == vable_ptr => {}
         Some(_) | None => return false,

--- a/majit/majit-metainterp/src/resume_box_reader.rs
+++ b/majit/majit-metainterp/src/resume_box_reader.rs
@@ -983,3 +983,123 @@ pub fn replay_pending_fields(
         emit_pending_field_op(ctx, target_op, value_op, pending.item_index, descr);
     }
 }
+
+/// `pyjitpl.py:3449 rebuild_state_after_failure`:
+///
+/// ```python
+/// if vinfo is not None:
+///     self.virtualizable_boxes = virtualizable_boxes
+/// ```
+///
+/// `virtualizable_boxes` is what `resume.py:1370 consume_virtualizable_boxes`
+/// built out of the guard's vable section: the virtualizable itself comes
+/// first (`resume.py:1404 virtualizable = self.next_ref()`), then
+/// `virtualizable.py:139 load_list_of_boxes` reads one box per static field
+/// and one per array element — off the LIVE object, which is where the array
+/// lengths come from — and returns the list with the virtualizable appended,
+/// so `boxes[-1]` is the identity every consumer indexes.
+///
+/// Without this a bridge traces with no virtualizable bound at all, and the
+/// first vable-shaped op it reaches has nothing to resolve against.
+///
+/// Returns `false` (leaving the ctx untouched) when the stream cannot be
+/// turned into a complete shadow: no vable section, a null identity, a
+/// length that disagrees with the live object's layout, or an entry whose
+/// concrete value the guard did not carry.
+pub fn seed_bridge_virtualizable_boxes(
+    ctx: &mut crate::TraceCtx,
+    info: &crate::virtualizable::VirtualizableInfo,
+    rd_virtuals: Option<&[std::rc::Rc<majit_ir::RdVirtualInfo>]>,
+    resume_data: &crate::jit_state::ResumeDataResult,
+    cache: &mut BridgeVirtualCache,
+    fail_values: &[i64],
+) -> bool {
+    use majit_ir::resumedata::RebuiltValue;
+    use majit_ir::{Const, GcRef, Type, Value};
+
+    fn concrete(v: &RebuiltValue, fail_values: &[i64]) -> Option<Value> {
+        let typed = |ty: Type, bits: i64| match ty {
+            Type::Int => Value::Int(bits),
+            Type::Float => Value::Float(f64::from_bits(bits as u64)),
+            Type::Ref => Value::Ref(GcRef(bits as usize)),
+            Type::Void => Value::Void,
+        };
+        match v {
+            RebuiltValue::Box(n, ty) => fail_values.get(*n).map(|&bits| typed(*ty, bits)),
+            RebuiltValue::Const(Const::Int(i)) => Some(Value::Int(*i)),
+            RebuiltValue::Const(Const::Float(f)) => Some(Value::Float(*f)),
+            RebuiltValue::Const(Const::Ref(r)) => Some(Value::Ref(*r)),
+            // A virtualized vable slot has no deadframe concrete; the shadow
+            // would be a guess, so decline the whole seed instead.
+            RebuiltValue::Virtual(_) | RebuiltValue::Unassigned => None,
+        }
+    }
+
+    let Some((identity, slots)) = resume_data.virtualizable_values.split_first() else {
+        return false;
+    };
+    // `resume.py:1404 virtualizable = self.next_ref()` — the first entry is a
+    // ref box holding the virtualizable itself.  Anything else means this
+    // guard's vable section does not name the virtualizable (the box was
+    // replaced, folded, or never made it into the guard's fail args), and
+    // dereferencing whatever value sits there would be a wild read; decline
+    // the seed instead, which leaves the guard deopting through the blackhole
+    // exactly as it did before — `compile.py:725-729 compile.giveup()`.
+    let Some(identity_value @ Value::Ref(vable_ref)) = concrete(identity, fail_values) else {
+        return false;
+    };
+    let vable_ptr = vable_ref.as_usize() as *const u8;
+    if vable_ptr.is_null() {
+        return false;
+    }
+    // virtualizable.py:150-153 `lst = getattr(virtualizable, fieldname); for j
+    // in range(len(lst))` — the live object is the authority on how many array
+    // boxes the stream carries.
+    if !info.can_read_all_array_lengths_from_heap() {
+        return false;
+    }
+    // `pyjitpl.py:3450 rebuild_state_after_failure` pairs the assignment with
+    // `self.check_synchronized_virtualizable()`, which asserts the box just
+    // decoded IS the live virtualizable.  Pyre cannot assert: the guard's vable
+    // section is only as good as the numbering that produced it, and a decoded
+    // identity that is not the live object would be dereferenced below.  Treat
+    // the mismatch as `compile.py:725-729 compile.giveup()` instead.
+    match ctx.virtualizable_heap_ptr() {
+        Some(live) if live == vable_ptr => {}
+        Some(_) | None => return false,
+    }
+    let array_lengths = unsafe { info.read_array_lengths_from_heap(vable_ptr) };
+    let expected = info.num_static_extra_boxes + array_lengths.iter().sum::<usize>();
+    if slots.len() != expected {
+        return false;
+    }
+    let mut values = Vec::with_capacity(expected + 1);
+    for slot in slots {
+        match concrete(slot, fail_values) {
+            Some(value) => values.push(value),
+            None => return false,
+        }
+    }
+    let mut boxes: Vec<OpRef> = Vec::with_capacity(expected + 1);
+    for slot in slots {
+        boxes.push(rebuilt_value_to_opref(
+            ctx,
+            slot,
+            rd_virtuals,
+            resume_data,
+            cache,
+        ));
+    }
+    // virtualizable.py:143-144 "the returned list is in the format expected of
+    // virtualizable_boxes, so it ends in the virtualizable itself".
+    boxes.push(rebuilt_value_to_opref(
+        ctx,
+        identity,
+        rd_virtuals,
+        resume_data,
+        cache,
+    ));
+    values.push(identity_value);
+    ctx.set_virtualizable_boxes_with_info(boxes, values, info, &array_lengths);
+    true
+}

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -1859,6 +1859,26 @@ impl TraceCtx {
         self.virtualizable_boxes.clone()
     }
 
+    /// [`collect_virtualizable_boxes`] with each slot paired with its declared
+    /// [`Type`] (`virtualizable_slot_type`); identity LAST, as always.
+    ///
+    /// pyjitpl.py:2981-2989 builds ONE `live_arg_boxes` and hands it to both
+    /// the merge-point registration and the closing JUMP. The registration
+    /// side becomes a cut trace's LABEL inputargs, and those are *typed*
+    /// (`TreeLoop::cut_trace_from_with_consts` → `OpRef::input_arg_typed`), so
+    /// the type tag has to travel with the box for a registration to be able
+    /// to reproduce the close's shape.
+    pub fn collect_virtualizable_typed_boxes(&self) -> Option<Vec<(OpRef, Type)>> {
+        let boxes = self.virtualizable_boxes.as_ref()?;
+        Some(
+            boxes
+                .iter()
+                .enumerate()
+                .map(|(i, &opref)| (opref, self.virtualizable_slot_type(i).unwrap_or(Type::Int)))
+                .collect(),
+        )
+    }
+
     /// The walk-final concrete values of the virtualizable's array elements, in
     /// the flat `[arr0_elem0.., arr1_elem0.., ..]` layout — the array portion of
     /// `virtualizable_values`, excluding the `num_static_extra_boxes` leading

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -1883,6 +1883,69 @@ impl TraceCtx {
         self.virtualizable_boxes.clone()
     }
 
+    /// pyjitpl.py:2958-2964 `remove_consts_and_duplicates`:
+    ///
+    /// ```python
+    /// for i in range(endindex):
+    ///     box = boxes[i]
+    ///     if isinstance(box, Const) or box in duplicates:
+    ///         boxes[i] = self.history.record_same_as(box)
+    ///     else:
+    ///         duplicates[box] = None
+    /// ```
+    ///
+    /// `reached_loop_header` runs this over the reds and, sharing ONE
+    /// `duplicates` set, over `virtualizable_boxes[:-1]` (pyjitpl.py:2978-2987)
+    /// — i.e. over exactly what the loop-carried list is about to become — so
+    /// no entry of that list is a constant and none appears twice. Both
+    /// properties are assumed downstream and neither is checked:
+    /// `TreeLoop::cut_trace_from_with_consts` keys its remap on the `OpRef`, so
+    /// a repeat overwrites the earlier slot's mapping, and its `remap_ref`
+    /// short-circuits on `!is_runtime_opref`, so a constant is never rewritten
+    /// to the inputarg the LABEL declares for it.
+    ///
+    /// The `SameAs` variant follows the box's OWN type, never the slot's
+    /// declared one: a cross-type `SameAs` absorbed by `make_equal_to` breaks
+    /// the type invariant in the optimizer's replace path. An entry whose
+    /// `OpRef` carries no type is left alone rather than guessed at.
+    ///
+    /// Upstream normalizes per `reached_loop_header` visit, so the registration
+    /// and the closing JUMP are normalized by separate invocations; this is
+    /// called at each of those sites rather than once for both.
+    pub fn remove_consts_and_duplicates(&mut self, boxes: &mut [(OpRef, Type)]) {
+        let mut duplicates: indexmap::IndexSet<OpRef> = indexmap::IndexSet::new();
+        for slot in boxes.iter_mut() {
+            let (opref, declared) = *slot;
+            if !opref.is_constant() && duplicates.insert(opref) {
+                continue;
+            }
+            let Some(tp) = opref.ty() else {
+                continue;
+            };
+            debug_assert!(
+                tp == declared || opref.is_constant(),
+                "loop-carried slot declared {declared:?} but its box is {tp:?}",
+            );
+            let same_as = self.record_op(majit_ir::OpCode::same_as_for_type(tp), &[opref]);
+            *slot = (same_as, declared);
+        }
+    }
+
+    /// [`Self::remove_consts_and_duplicates`] for the JUMP side, which carries
+    /// no separate type tag — the LABEL it targets already declares the types,
+    /// so each slot's own `OpRef` is the only type source and the only one
+    /// upstream uses (`record_same_as` reads `box.type`).
+    pub fn remove_consts_and_duplicates_untyped(&mut self, boxes: &mut [OpRef]) {
+        let mut typed: Vec<(OpRef, Type)> = boxes
+            .iter()
+            .map(|&opref| (opref, opref.ty().unwrap_or(Type::Int)))
+            .collect();
+        self.remove_consts_and_duplicates(&mut typed);
+        for (slot, (opref, _)) in boxes.iter_mut().zip(typed) {
+            *slot = opref;
+        }
+    }
+
     /// [`collect_virtualizable_boxes`] with each slot paired with its declared
     /// [`Type`] (`virtualizable_slot_type`); identity LAST, as always.
     ///
@@ -4442,6 +4505,57 @@ mod tests {
         let field_index = fd.index();
         ctx.heapcache_getfield_now_known(vable, field_index, cached);
         ctx.vable_getfield_int(0, vable, 0xCAFE_BABE, fd);
+    }
+
+    /// `test_pyjitpl.py:74-95 test_remove_consts_and_duplicates` — the upstream
+    /// vector, verbatim: `[b1, b2, b1, c3]` leaves the first sighting of each
+    /// box alone and replaces the repeat AND the constant with fresh `SAME_AS`
+    /// results, recording one `SAME_AS` op per replacement.
+    #[test]
+    fn remove_consts_and_duplicates_matches_the_upstream_vector() {
+        let mut recorder = Trace::new();
+        let b1 = recorder.record_input_arg(Type::Int);
+        let b2 = recorder.record_input_arg(Type::Int);
+        let mut ctx = TraceCtx::new(
+            recorder,
+            0,
+            std::sync::Arc::new(crate::MetaInterpStaticData::new()),
+        );
+        let c3 = ctx.const_int(3);
+        let ops_before = ctx.num_ops();
+
+        let mut boxes = [
+            (b1, Type::Int),
+            (b2, Type::Int),
+            (b1, Type::Int),
+            (c3, Type::Int),
+        ];
+        ctx.remove_consts_and_duplicates(&mut boxes);
+
+        assert_eq!(boxes[0].0, b1, "first sighting is left alone");
+        assert_eq!(boxes[1].0, b2, "first sighting is left alone");
+        assert_ne!(boxes[2].0, b1, "the repeat must become a fresh SAME_AS");
+        assert_ne!(boxes[3].0, c3, "the constant must become a fresh SAME_AS");
+        assert_ne!(boxes[2].0, boxes[3].0, "each replacement is its own op");
+        assert!(
+            !boxes[3].0.is_constant(),
+            "a SAME_AS result is a runtime box, which is the point: \
+             `TreeLoop::cut_trace_from_with_consts`'s `remap_ref` skips \
+             non-runtime oprefs, so a constant would never be rewritten to \
+             the inputarg the LABEL declares for it"
+        );
+        assert_eq!(
+            ctx.num_ops(),
+            ops_before + 2,
+            "exactly one SAME_AS recorded per replaced slot"
+        );
+
+        // Idempotent: a normalized list has no constant and no repeat left.
+        let ops_after = ctx.num_ops();
+        let mut again = boxes;
+        ctx.remove_consts_and_duplicates(&mut again);
+        assert_eq!(again, boxes, "a normalized list is unchanged");
+        assert_eq!(ctx.num_ops(), ops_after, "and records nothing");
     }
 
     /// vable_getfield_ref cache-hit (pyjitpl.py:939

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -320,13 +320,21 @@ pub struct TraceCtx {
     /// `GreenKey::hash_u64` over the declared green tuple.
     pub compiled_key_for_greens_fn:
         Option<Box<dyn Fn(&(Vec<i64>, Vec<i64>, Vec<i64>)) -> Option<u64>>>,
-    /// pyjitpl.py:2978 `if not self.partial_trace:` parity at
-    /// `reached_loop_header` — explicit "this trace started from a
-    /// guard failure" flag.  RPython distinguishes via
-    /// `self.resumekey` typing (`ResumeGuardDescr` vs
+    /// Explicit "this trace started from a guard failure" flag. RPython
+    /// distinguishes via `self.resumekey` typing (`ResumeGuardDescr` vs
     /// `ResumeFromInterpDescr`); pyre sets this to `true` at
     /// `start_bridge_tracing` and leaves the default `false` for
-    /// primary entries.  Consumers that need bridge-only behavior
+    /// primary entries.
+    ///
+    /// ⚠️This is NOT `self.partial_trace`. That flag is set only by
+    /// `retrace_needed` (pyjitpl.py:2438-2439) and means "this is a
+    /// RETRACE"; a bridge from a guard failure has `partial_trace = None`
+    /// and takes every `if not self.partial_trace:` branch. Pyre has no
+    /// retrace counterpart, so those branches are unconditional here —
+    /// gating one of them on this flag would be a new behaviour, not
+    /// parity.
+    ///
+    /// Consumers that need bridge-only behavior
     /// (e.g. `pyre-jit-trace::pyjitpl::run_to_end`'s close-loop
     /// skip when no compiled targets exist for the current
     /// greenkey) gate on this flag instead of fn presence.

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -306,6 +306,20 @@ pub struct TraceCtx {
     /// skip loop headers without compiled targets. Live lookup (not snapshot)
     /// matches RPython's get_procedure_token(greenboxes) + has_compiled_targets.
     pub has_compiled_targets_fn: Option<Box<dyn Fn(u64) -> bool>>,
+    /// pyjitpl.py:3005 `ptoken = self.get_procedure_token(greenboxes)` for the
+    /// greens of the merge point just reached, in the same `(ints, refs,
+    /// floats)` slot grouping as [`Self::close_greens`]. `Some(key)` iff a
+    /// compiled loop with jumpable targets already lives at those greens
+    /// (`MetaInterp::compiled_key_for_greens`, which folds in
+    /// `has_compiled_targets`).
+    ///
+    /// [`Self::has_compiled_targets_fn`] cannot answer this: it is keyed on the
+    /// u64 green key, and the dispatch loop cannot derive a foreign merge
+    /// point's key. `green_key_from_code_ptr(green_key_raw.0, pc)` is not it —
+    /// `JitState::code_ptr()` defaults to 0, and the driver's key is
+    /// `GreenKey::hash_u64` over the declared green tuple.
+    pub compiled_key_for_greens_fn:
+        Option<Box<dyn Fn(&(Vec<i64>, Vec<i64>, Vec<i64>)) -> Option<u64>>>,
     /// pyjitpl.py:2978 `if not self.partial_trace:` parity at
     /// `reached_loop_header` — explicit "this trace started from a
     /// guard failure" flag.  RPython distinguishes via
@@ -1228,6 +1242,7 @@ impl TraceCtx {
             pending_guard_not_invalidated_pc: None,
             forced_virtualizable: None,
             has_compiled_targets_fn: None,
+            compiled_key_for_greens_fn: None,
             is_bridge_trace: false,
             reads_module_global: false,
             bridge_target_header_pc: None,
@@ -1306,6 +1321,7 @@ impl TraceCtx {
             pending_guard_not_invalidated_pc: None,
             forced_virtualizable: None,
             has_compiled_targets_fn: None,
+            compiled_key_for_greens_fn: None,
             is_bridge_trace: false,
             reads_module_global: false,
             bridge_target_header_pc: None,

--- a/majit/majit-metainterp/src/virtualizable.rs
+++ b/majit/majit-metainterp/src/virtualizable.rs
@@ -233,7 +233,7 @@ pub struct VirtualizableInfo {
     /// Flat position of the virtualizable identity inside the reds the host
     /// hands `initialize_virtualizable` as `live_values`.
     ///
-    /// `pyjitpl.py:3295 virtualizable_box = original_boxes[index]` is a lookup
+    /// `pyjitpl.py:3319 virtualizable_box = original_boxes[index]` is a lookup
     /// at a DECLARED position — `warmspot.py:529-538` fixes
     /// `index_of_virtualizable` when the driver is registered, and nothing at
     /// snapshot time searches for the box. Hosts whose reds are not the

--- a/majit/majit-metainterp/src/virtualizable.rs
+++ b/majit/majit-metainterp/src/virtualizable.rs
@@ -230,6 +230,20 @@ pub struct VirtualizableInfo {
     /// box's ref-bank index so it matches the lowering's `vable_input_ref_reg`.
     /// `None` (PyFrame and tests) leaves the flat formula unchanged.
     pub identity_ref_bank_index: Option<usize>,
+    /// Flat position of the virtualizable identity inside the reds the host
+    /// hands `initialize_virtualizable` as `live_values`.
+    ///
+    /// `pyjitpl.py:3295 virtualizable_box = original_boxes[index]` is a lookup
+    /// at a DECLARED position — `warmspot.py:529-538` fixes
+    /// `index_of_virtualizable` when the driver is registered, and nothing at
+    /// snapshot time searches for the box. Hosts whose reds are not the
+    /// jitdriver's `reds` list (the state-field JIT expands its state fields
+    /// into the red vector) publish the identity's position here so pyre can
+    /// take the same lookup instead of matching on the live pointer.
+    ///
+    /// `None` (PyFrame and tests) means the flat `num_green_args +
+    /// index_of_virtualizable` formula already names the box.
+    pub identity_live_index: Option<usize>,
 }
 
 impl Clone for VirtualizableInfo {
@@ -253,6 +267,7 @@ impl Clone for VirtualizableInfo {
             clear_vable_ptr: self.clear_vable_ptr,
             clear_vable_descr: self.clear_vable_descr.clone(),
             identity_ref_bank_index: self.identity_ref_bank_index,
+            identity_live_index: self.identity_live_index,
         }
     }
 }
@@ -315,6 +330,7 @@ impl VirtualizableInfo {
             clear_vable_ptr: None,
             clear_vable_descr: None,
             identity_ref_bank_index: None,
+            identity_live_index: None,
         }
     }
 

--- a/majit/majit-metainterp/tests/jit_interp_dispatch_ir_shape.rs
+++ b/majit/majit-metainterp/tests/jit_interp_dispatch_ir_shape.rs
@@ -646,6 +646,51 @@ fn register_dispatch_jitcode_stores_singleton() {
     let _arc: &Arc<JitCode> = stored.unwrap();
 }
 
+/// A thread that keeps two drivers alive holds ONE state-field store, and it
+/// belongs to whichever driver published last. Every compile is reached through
+/// a trace entry, so `force_start_tracing` re-aims the store: the guard metadata
+/// that trace produces decodes frame value counts against its OWN jitcodes.
+///
+/// Without that re-aim the second registration owned the slot for good, and
+/// `JitDriverStaticData::frame_value_count_fn` records that the wrong store
+/// frequently *succeeds* — it decodes an unrelated jitcode at the same pc and
+/// returns a mistyped frame count rather than failing.
+#[test]
+fn a_trace_entry_takes_the_state_field_store_back_from_a_second_driver() {
+    let mut first: JitDriver<DispatchTestState> = JitDriver::new(100);
+    __declare_jit_schema_dispatch_minimal(&mut first);
+    first.register_dispatch_jitcode(build_dispatch_minimal());
+    assert_eq!(
+        majit_metainterp::current_state_field_fvc_epoch(),
+        first.state_field_fvc_epoch(),
+        "registering a dispatch jitcode publishes the registering driver's store",
+    );
+
+    let mut second: JitDriver<DispatchTestState> = JitDriver::new(100);
+    __declare_jit_schema_dispatch_minimal(&mut second);
+    second.register_dispatch_jitcode(build_dispatch_minimal());
+    assert_ne!(
+        first.state_field_fvc_epoch(),
+        second.state_field_fvc_epoch(),
+        "each driver's registry is published under its own identity",
+    );
+    assert_eq!(
+        majit_metainterp::current_state_field_fvc_epoch(),
+        second.state_field_fvc_epoch(),
+        "the later registration takes the single slot",
+    );
+
+    let program = [OP_INC_A, OP_END];
+    let mut state = DispatchTestState { a: 0 };
+    first.meta_interp_mut().finish_setup_descrs_for_jitdrivers();
+    first.force_start_tracing(0, 0, &mut state, &program[..]);
+    assert_eq!(
+        majit_metainterp::current_state_field_fvc_epoch(),
+        first.state_field_fvc_epoch(),
+        "force_start_tracing must aim the store at the driver about to trace",
+    );
+}
+
 /// A.2.1 fixture: minimal `#[jit_interp]` dispatch loop carrying both the
 /// `state.last_instr = pc as i64` store (`pyopcode.py:172`) AND the two-byte
 /// `[opcode][oparg]` fetch with `pc += 2` (`pyopcode.py:179-181`).

--- a/majit/majit-metainterp/tests/jit_interp_float_state_field.rs
+++ b/majit/majit-metainterp/tests/jit_interp_float_state_field.rs
@@ -377,3 +377,149 @@ mod scalar_float_slot_reserve {
         );
     }
 }
+
+// The virtualizable's element boxes are a strict SUFFIX of the loop-carried
+// list upstream: `live_arg_boxes = greenboxes + redboxes` and then
+// `live_arg_boxes += self.virtualizable_boxes; live_arg_boxes.pop()`
+// (pyjitpl.py:2981-2989). `+=` appends, so no element can precede a red.
+//
+// The entry contract is built the same way — `JitDriver::extend_compiled_live_values`
+// does `live_values.extend(extra_values)` after every red. The closing JUMP
+// spliced the elements between the vable identity and the ref/float scalars, so
+// for a state declaring BOTH a `[.. ; virt]` array and a ref or float scalar the
+// two sides carried the same arity with different slot meanings —
+// `jump.numargs() == label.numargs()` (compile.py:334) passes and nothing
+// downstream catches it. Pin the suffix relation directly.
+mod virt_array_with_float_scalar {
+    use super::Bytecode;
+    use majit_metainterp::{JitDriver, JitState};
+
+    struct MixedState {
+        sp: i64,
+        cells: Vec<i64>,
+        acc: f64,
+        stack: Vec<i64>,
+    }
+
+    const OP_NOP: u8 = 0;
+    const OP_STEP: u8 = 1;
+
+    #[majit_macros::jit_interp(
+        state = MixedState,
+        env = Bytecode,
+        // The fixed `[int]` array is what makes this shape reachable: a state
+        // that is exactly one virt array plus a float scalar is already refused
+        // by the recursive-portal fresh-allocation gate, so the ordering bug
+        // could only be hit alongside a fixed array or a ref scalar.
+        state_fields = { sp: int, cells: [int], acc: float, stack: [int; virt] },
+    )]
+    #[allow(unused_assignments, unused_variables)]
+    fn mixed_virt_and_float(program: &Bytecode, threshold: u32) -> i64 {
+        let mut driver: JitDriver<MixedState> = JitDriver::new(threshold);
+        let mut pc: usize = 0;
+        let mut state = MixedState {
+            sp: 0,
+            cells: vec![0; 2],
+            acc: 0.0,
+            stack: vec![0; 2],
+        };
+        {
+            use majit_metainterp::JitState as _;
+            state
+                .build_meta(0, program)
+                .install_canonical_liveness(&mut driver);
+        }
+        while pc < program.len() {
+            jit_merge_point!();
+            let opcode = program[pc];
+            pc += 1;
+            match opcode {
+                OP_NOP => {}
+                OP_STEP => {
+                    state.stack[0] = state.stack[0] + 1;
+                    state.acc = state.acc + 1.5;
+                    // Read-only: a MUTATED plain `[int]` is refused outright
+                    // (it is not restored on deopt), so the fixed array is
+                    // loop-carried but never written.
+                    state.sp = state.sp + 1 + state.cells[0];
+                }
+                _ => break,
+            }
+        }
+        state.sp
+    }
+
+    #[test]
+    fn element_boxes_are_a_strict_suffix_of_the_reds() {
+        let state = MixedState {
+            sp: 0,
+            cells: vec![0; 2],
+            acc: 0.0,
+            stack: vec![0; 2],
+        };
+        let program: &Bytecode = &[OP_NOP, OP_STEP];
+        let meta = state.build_meta(0, program);
+        let sym = <MixedState as JitState>::create_sym(&meta, 0);
+
+        // `TraceCtx::collect_virtualizable_typed_boxes()` shape: the element
+        // block in per-array order, identity LAST.
+        let e0 = majit_ir::OpRef::input_arg_typed(90, majit_ir::Type::Int);
+        let e1 = majit_ir::OpRef::input_arg_typed(91, majit_ir::Type::Int);
+        let identity = majit_ir::OpRef::input_arg_typed(92, majit_ir::Type::Ref);
+        let boxes = [
+            (e0, majit_ir::Type::Int),
+            (e1, majit_ir::Type::Int),
+            (identity, majit_ir::Type::Ref),
+        ];
+
+        let reds = <MixedState as JitState>::collect_jump_args(&sym);
+        let close = <MixedState as JitState>::collect_jump_args_with_boxes(&sym, &boxes);
+
+        assert_eq!(
+            close.len(),
+            reds.len() + 2,
+            "the close carries every red plus one box per element, minus the \
+             trailing identity (pyjitpl.py:2988-2989)"
+        );
+        assert_eq!(
+            &close[..reds.len()],
+            &reds[..],
+            "the reds must lead, in `collect_jump_args` order and unshifted — a \
+             float scalar displaced by an element box binds the JUMP to the wrong \
+             LABEL slot at equal arity"
+        );
+        assert_eq!(
+            &close[reds.len()..],
+            &[e0, e1],
+            "the element block must be the strict suffix `live_arg_boxes += \
+             virtualizable_boxes; live_arg_boxes.pop()` produces"
+        );
+    }
+
+    /// The entry contract this suffix has to match: `live_value_types` is the
+    /// reds only, and `JitDriver::extend_compiled_live_values` appends the
+    /// elements after all of them.
+    #[test]
+    fn the_entry_contract_carries_no_element_in_its_red_block() {
+        let state = MixedState {
+            sp: 0,
+            cells: vec![0; 2],
+            acc: 0.0,
+            stack: vec![0; 2],
+        };
+        let program: &Bytecode = &[OP_NOP, OP_STEP];
+        let meta = state.build_meta(0, program);
+        assert_eq!(
+            state.live_value_types(&meta),
+            vec![
+                majit_ir::Type::Int,   // sp
+                majit_ir::Type::Int,   // cells[0]
+                majit_ir::Type::Int,   // cells[1]
+                majit_ir::Type::Ref,   // __vable_identity
+                majit_ir::Type::Float, // acc
+            ],
+            "no `stack` element belongs in the red block",
+        );
+        assert_eq!(state.extract_live(&meta).len(), 5);
+    }
+}


### PR DESCRIPTION
Six commits from driving majit's `#[jit_interp]` front end through cel-jit's
columnar batch tier. Every one is a defect the cel nested-loop shape
(`items.all(i, i.price > 10)` over a runtime-length list column) surfaced;
`majit-metainterp`, `majit-macros` and `majit-ir` are green (20 test binaries,
0 failures, `--features majit-metainterp/cranelift`).

### The trace never closed a loop with the right boxes

- **`371bd3d66e` build the merge-point registration from the same construction
  as the loop close.** `BC_JIT_MERGE_POINT` built `original_boxes` from the
  scalar state fields only, while the closing JUMP goes through
  `collect_jump_args_with_boxes`, which expands the whole virtualizable. A state
  that is purely `[int; virt]` arrays registered one unexpanded ref and closed
  with one box per element.
- **`f0aaa825bf` do not cut a trace at a merge point that already holds a
  compiled loop.** The `has_compiled_targets` half of `pyjitpl.py:3001-3007`.
  Cutting there stored the result under a key nothing enters, replacing
  reachable code with unreachable code. Measured: at 8 elements/row `guard_fails`
  3999 → 9, aborts 1 → 0; 100k rows goes from a net loss against the clean
  bytecode VM to 1.68x. The JUMP-into-ptoken half is deliberately not
  implemented.
- **`44b0bce3c5` rebuild `virtualizable_boxes` at bridge entry.**
  `initialize_virtualizable` minted the identity as
  `OpRef::input_arg_ref(identity_ref_bank_index)` — a JitCode ref-register index
  used where inputargs are numbered flat across banks — so on a `#[jit_interp]`
  state it aliased an int inputarg. Adds `seed_bridge_virtualizable_boxes`
  (`pyjitpl.py:3449 rebuild_state_after_failure`); before it, those states left
  `virtualizable_boxes` unset for the whole bridge and no guard-exit bridge ever
  formed.

### One virtualizable, named once

- **`c91c01481e` carry the `#[jit_interp]` virtualizable as one identity slot.**
  Each `[.. ; virt]` array synthesized `<arr>_ptr` + `<arr>_len`, and
  `extract_live` filled every `<arr>_ptr` with the same `&state`, so an N-array
  state named its virtualizable N times. Upstream names it once
  (`warmspot.py:529-538`, `virtualizable.py:139-144`). Entry contract goes 29
  args → 26 with the identity at 0; census counts unchanged.

### Two smaller ones

- **`e000696e12` run Cranelift's IR verifier only under `debug_assertions`.**
  It re-checked every function in release builds; backend phase 3719 → 2783 us,
  steady state unchanged. `compile.py:242-244` runs the equivalent checks under
  `if not we_are_translated()`.
- **`2fc3d72bf2` let a driver re-publish its state-field store.**
  `STATE_FIELD_FVC` is one slot per thread, written once when a driver registers
  its dispatch jitcode, so a consumer keeping more than one driver alive on a
  thread runs against whichever installed last — and
  `frame_value_count_fn` documents that the wrong store *succeeds*, returning a
  mistyped frame count. `republish_state_field_fvc` re-runs only the
  publication. Verified structurally; not reproduced as a wrong answer.

Opened so cel-jit can depend on these crates by git rev instead of a
cross-workspace path.

— *commented by Claude*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JIT handling of virtualizable state, including array layouts and identity tracking.
  * Fixed bridge and nested-loop resume behavior to avoid state mismatches and merge-point arity issues.
  * Improved restoration and live-state writeback during compiled-code resumes.
* **Reliability**
  * Enabled IR verification in debug builds to catch invalid generated code earlier.
  * Added additional validation and seeding when rebuilding virtualizable values during bridge tracing.
* **New Features**
  * Added support for re-publishing per-thread dispatch metadata after installation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->