### PR TITLE
build: cut the prepass peak RSS 7.71 GB → 4.25 GB; make on-demand body lowering possible

### DIFF
--- a/majit/majit-translate/src/codewriter/call.rs
+++ b/majit/majit-translate/src/codewriter/call.rs
@@ -12,6 +12,7 @@ use majit_ir::descr::{DescrRef, EffectInfo, ExtraEffect, OopSpecIndex};
 use majit_ir::value::Type;
 use serde::{Deserialize, Serialize};
 
+use crate::flowspace::argument::Signature;
 use crate::front::semantic::SemanticFunction;
 use crate::jitcode::{BhCallDescr, CallResultErasedKey};
 use crate::model::{CallTarget, FunctionGraph, LinkArg, OpKind, SpaceOperation};
@@ -500,7 +501,23 @@ type GraphKey = (Option<String>, String);
 #[derive(Default)]
 pub(crate) struct GraphStore {
     path_to_key: HashMap<CallPath, GraphKey>,
-    graphs: HashMap<GraphKey, FunctionGraph>,
+    graphs: HashMap<GraphKey, GraphSlot>,
+}
+
+/// One source funcobj's stored graph plus the metadata derived from it at
+/// registration time.
+///
+/// `signature` is the funcobj's formal parameter list.  `pygraph.py:16`
+/// names the initial-block locals straight from `code.co_varnames` and
+/// stores `code.signature` on the `PyGraph` wrapper, so upstream reads a
+/// callee's signature off the *code object* and never walks the built
+/// graph.  Pyre's lifted callees carry no `PyGraph` wrapper, so the
+/// signature is recovered from the startblock's `Input` ops
+/// ([`crate::model::FunctionGraph::value_name_for`]) — but once, here,
+/// while the body is in hand, rather than on every registry consumer.
+struct GraphSlot {
+    graph: FunctionGraph,
+    signature: Signature,
 }
 
 impl GraphStore {
@@ -508,38 +525,70 @@ impl GraphStore {
         Self::default()
     }
 
+    /// Derive a funcobj's parameter [`Signature`] from its startblock
+    /// inputargs.  `varargname` / `kwargname` are `None`: a Rust-source
+    /// funcobj has no `*args` / `**kwargs` formal.
+    fn signature_from_graph(graph: &FunctionGraph) -> Signature {
+        let startblock = graph.block(graph.startblock);
+        let argnames: Vec<String> = startblock
+            .inputargs
+            .iter()
+            .enumerate()
+            .map(|(idx, var)| {
+                graph
+                    .value_name_for(var)
+                    .unwrap_or_else(|| format!("arg{idx}"))
+            })
+            .collect();
+        Signature::new(argnames, None, None)
+    }
+
     /// Register `graph` under `path`.  When another alias of the same
     /// source funcobj (same `GraphKey`) is already stored, keep the one
     /// shared graph object and fold this registration's attributes onto it
     /// monotonically — accumulate effects, adopt hints / return type if the
     /// stored graph lacks them — so neither registration order nor a
-    /// hint-less first insert drops metadata a later alias carried.
+    /// hint-less first insert drops metadata a later alias carried.  The
+    /// signature stays that of the shared graph, which the aliases resolve
+    /// to anyway.
     pub(crate) fn insert(&mut self, path: CallPath, graph: FunctionGraph) {
         let key = (graph.owner_root.clone(), graph.name.clone());
         match self.graphs.get_mut(&key) {
             Some(existing) => {
-                existing.func.merge_from(&graph.func);
+                existing.graph.func.merge_from(&graph.func);
                 if !graph.hints.is_empty() {
-                    existing.hints = graph.hints;
+                    existing.graph.hints = graph.hints;
                 }
-                if existing.return_type.is_none() {
-                    existing.return_type = graph.return_type;
+                if existing.graph.return_type.is_none() {
+                    existing.graph.return_type = graph.return_type;
                 }
             }
             None => {
-                self.graphs.insert(key.clone(), graph);
+                let signature = Self::signature_from_graph(&graph);
+                self.graphs
+                    .insert(key.clone(), GraphSlot { graph, signature });
             }
         }
         self.path_to_key.insert(path, key);
     }
 
     pub(crate) fn get(&self, path: &CallPath) -> Option<&FunctionGraph> {
-        self.graphs.get(self.path_to_key.get(path)?)
+        self.graphs
+            .get(self.path_to_key.get(path)?)
+            .map(|s| &s.graph)
     }
 
     pub(crate) fn get_mut(&mut self, path: &CallPath) -> Option<&mut FunctionGraph> {
         let key = self.path_to_key.get(path)?.clone();
-        self.graphs.get_mut(&key)
+        self.graphs.get_mut(&key).map(|s| &mut s.graph)
+    }
+
+    /// The formal parameter [`Signature`] of the funcobj `path` names —
+    /// the `FunctionDesc` signature upstream takes from `code.signature`.
+    pub(crate) fn signature(&self, path: &CallPath) -> Option<&Signature> {
+        self.graphs
+            .get(self.path_to_key.get(path)?)
+            .map(|s| &s.signature)
     }
 
     pub(crate) fn contains_key(&self, path: &CallPath) -> bool {
@@ -558,7 +607,7 @@ impl GraphStore {
     pub(crate) fn iter(&self) -> impl Iterator<Item = (&CallPath, &FunctionGraph)> {
         self.path_to_key
             .iter()
-            .filter_map(move |(p, k)| self.graphs.get(k).map(|g| (p, g)))
+            .filter_map(move |(p, k)| self.graphs.get(k).map(|s| (p, &s.graph)))
     }
 
     /// Number of registered alias spellings (path count), matching the old

--- a/majit/majit-translate/src/front/graph_body.rs
+++ b/majit/majit-translate/src/front/graph_body.rs
@@ -1,0 +1,218 @@
+//! On-demand construction of a funcobj's lowered body.
+//!
+//! `translator.py:55 buildflowgraph(func)` builds a function's flow graph
+//! from the function object when a consumer first asks for it, and
+//! `description.py:1037 FunctionDesc.cachedgraph` is that consumer: a
+//! cache miss builds, a hit returns.  Nothing in upstream builds every
+//! reachable function's graph up front — `translator.graphs` *is* the set
+//! that demand has already reached.
+//!
+//! Pyre's funcobjs are Charon-extracted `FunDecl`s rather than Python
+//! function objects, so the analogue of "build the flow graph from the
+//! function object" is "lower the `FunDecl` from the LLBC it came from".
+//! That requires the LLBC set to stay alive past the whole-program build,
+//! which is what a [`GraphBodyProvider`] owns.
+
+use std::collections::HashMap;
+use std::sync::OnceLock;
+
+use majit_charon_reader::Llbc;
+
+use crate::front::mir::{self, LowerError};
+use crate::model::{FunctionGraph, ValueType};
+
+/// Where a funcobj's body comes from: the LLBC that carries it and the
+/// Charon `def_id` that indexes it there (`Llbc::fn_by_id`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) struct GraphBodySource {
+    pub llbc_index: u32,
+    pub def_id: u64,
+}
+
+/// Owns the extracted LLBC set and everything else the lowering reads, so
+/// a funcobj's body can be built after the whole-program pass has run.
+///
+/// The three `HostStaticAddrs` tables are held owned because
+/// [`crate::HostStaticAddrs`] borrows its slices from the caller's frame;
+/// the borrowed view is rebuilt per [`GraphBodyProvider::build`] call,
+/// which only a demanded body pays for.
+pub(crate) struct GraphBodyProvider {
+    llbcs: Vec<Llbc>,
+    /// Per-LLBC struct field-attribute map, the same one the whole-program
+    /// loop lowered that LLBC's decls with.  `derive_program_metadata` is a
+    /// pure function of the LLBC, so recovering it here reproduces the
+    /// map exactly; it is computed on the first body demanded from each
+    /// LLBC rather than for every LLBC up front.
+    struct_field_attrs: Vec<OnceLock<HashMap<String, Vec<(String, ValueType)>>>>,
+    pytypes: Vec<(String, i64)>,
+    refs: Vec<(String, i64)>,
+    int_values: Vec<(String, i64)>,
+}
+
+impl GraphBodyProvider {
+    pub(crate) fn new(llbcs: Vec<Llbc>, static_addrs: crate::HostStaticAddrs<'_>) -> Self {
+        let own = |rows: &[(&str, i64)]| -> Vec<(String, i64)> {
+            rows.iter().map(|(k, v)| ((*k).to_string(), *v)).collect()
+        };
+        let struct_field_attrs = llbcs.iter().map(|_| OnceLock::new()).collect();
+        Self {
+            llbcs,
+            struct_field_attrs,
+            pytypes: own(static_addrs.pytypes),
+            refs: own(static_addrs.refs),
+            int_values: own(static_addrs.int_values),
+        }
+    }
+
+    /// Locate the funcobj whose Charon `name_path()` is `name_path`.
+    ///
+    /// Linear over the corpus, so it is a registration-time helper (and
+    /// the test seam), not a per-demand lookup: the demand path carries
+    /// the [`GraphBodySource`] recorded when the funcobj was registered.
+    pub(crate) fn source_for_name_path(&self, name_path: &str) -> Option<GraphBodySource> {
+        for (i, llbc) in self.llbcs.iter().enumerate() {
+            for fd in llbc.iter_local_fns() {
+                if fd.item_meta.name_path() == name_path {
+                    return Some(GraphBodySource {
+                        llbc_index: i as u32,
+                        def_id: fd.def_id,
+                    });
+                }
+            }
+        }
+        None
+    }
+
+    /// Lower the funcobj `src` names, reproducing what the whole-program
+    /// loop produced for it.
+    pub(crate) fn build(&self, src: GraphBodySource) -> Result<FunctionGraph, LowerError> {
+        let idx = src.llbc_index as usize;
+        let llbc = self
+            .llbcs
+            .get(idx)
+            .ok_or_else(|| LowerError::Unsupported(format!("llbc index {idx} out of range")))?;
+        let fd = llbc.fn_by_id(src.def_id).ok_or_else(|| {
+            LowerError::Unsupported(format!("no FunDecl for def_id {}", src.def_id))
+        })?;
+        let attrs = self.struct_field_attrs[idx].get_or_init(|| mir::struct_field_attrs_of(llbc));
+        let pytypes = borrowed(&self.pytypes);
+        let refs = borrowed(&self.refs);
+        let int_values = borrowed(&self.int_values);
+        mir::lower_fun_decl_with_static_addrs_and_attrs(
+            llbc,
+            fd,
+            crate::HostStaticAddrs {
+                pytypes: &pytypes,
+                refs: &refs,
+                int_values: &int_values,
+            },
+            attrs,
+        )
+    }
+}
+
+fn borrowed(rows: &[(String, i64)]) -> Vec<(&str, i64)> {
+    rows.iter().map(|(k, v)| (k.as_str(), *v)).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const CORPUS: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../charon-corpus/corpus.ullbc");
+
+    /// Rewrite every `id: N` in `s` to the position at which that id was
+    /// first seen across the graph, so two lowerings that differ only in
+    /// which range of the process-global `NEXT_VAR_ID` they drew from
+    /// render the same.  Aliasing is preserved: one id maps to one slot,
+    /// so "these two operands are the same variable" still shows up.
+    fn normalize_ids(s: &str, seen: &mut HashMap<u64, usize>) -> String {
+        const KEY: &str = "id: ";
+        let mut out = String::with_capacity(s.len());
+        let mut rest = s;
+        while let Some(at) = rest.find(KEY) {
+            let (before, after) = rest.split_at(at + KEY.len());
+            out.push_str(before);
+            let digits: String = after.chars().take_while(char::is_ascii_digit).collect();
+            match digits.parse::<u64>() {
+                Ok(id) => {
+                    let next = seen.len();
+                    let slot = *seen.entry(id).or_insert(next);
+                    out.push_str(&format!("#{slot}"));
+                    rest = &after[digits.len()..];
+                }
+                Err(_) => rest = after,
+            }
+        }
+        out.push_str(rest);
+        out
+    }
+
+    /// An id-independent shape of a lowered graph.  Variables carry ids
+    /// from process-global counters, so two lowerings of one funcobj are
+    /// never `==`; what must match is the structure the codewriter reads.
+    fn shape(
+        g: &FunctionGraph,
+    ) -> (
+        String,
+        Option<String>,
+        usize,
+        Vec<(usize, usize)>,
+        Vec<String>,
+    ) {
+        let mut seen: HashMap<u64, usize> = HashMap::new();
+        let mut ops = Vec::new();
+        let mut blocks = Vec::new();
+        for b in &g.blocks {
+            blocks.push((b.inputargs.len(), b.operations.len()));
+            for arg in &b.inputargs {
+                ops.push(normalize_ids(&format!("inputarg {arg:?}"), &mut seen));
+            }
+            for op in &b.operations {
+                ops.push(normalize_ids(&format!("{:?}", op.kind), &mut seen));
+            }
+        }
+        (
+            g.name.clone(),
+            g.return_type.clone(),
+            g.blocks.len(),
+            blocks,
+            ops,
+        )
+    }
+
+    /// A body built through the provider is the body the whole-program
+    /// loop built: same graph shape, from the same `FunDecl`, for every
+    /// funcobj in the corpus that lowers at all.
+    #[test]
+    fn provider_reproduces_the_eagerly_lowered_body() {
+        let llbc = Llbc::load(CORPUS).expect("load corpus.ullbc");
+        let attrs = mir::struct_field_attrs_of(&llbc);
+        let mut eager: Vec<(String, _)> = Vec::new();
+        for fd in llbc.iter_local_fns() {
+            if fd.unstructured().is_none() || fd.is_global_initializer.is_some() {
+                continue;
+            }
+            if let Ok(g) = mir::lower_fun_decl_with_static_addrs_and_attrs(
+                &llbc,
+                fd,
+                crate::HostStaticAddrs::default(),
+                &attrs,
+            ) {
+                eager.push((fd.item_meta.name_path(), shape(&g)));
+            }
+        }
+        assert!(!eager.is_empty(), "corpus fixture lowered no bodies at all");
+
+        let provider = GraphBodyProvider::new(vec![llbc], crate::HostStaticAddrs::default());
+        for (name_path, want) in &eager {
+            let src = provider
+                .source_for_name_path(name_path)
+                .unwrap_or_else(|| panic!("no GraphBodySource for {name_path}"));
+            let got = provider
+                .build(src)
+                .unwrap_or_else(|e| panic!("provider failed to build {name_path}: {e}"));
+            assert_eq!(&shape(&got), want, "{name_path}");
+        }
+    }
+}

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -745,9 +745,13 @@ fn build_semantic_program_from_llbc_with_static_addrs_filtered(
     let mut functions = Vec::new();
     let mut skipped: Vec<(String, String)> = Vec::new();
     for fd in llbc.iter_local_fns() {
-        if fd.unstructured().is_none() {
+        // `FunDecl::body` is raw JSON and `unstructured()` re-parses it on
+        // every call, so hold the one projection this iteration needs: it
+        // is both the "has a lowerable body" gate and the input the
+        // lowering below reads.
+        let Some(body) = fd.unstructured() else {
             continue;
-        }
+        };
         // Charon emits static / const initialiser bodies (e.g. the
         // body that builds `static NONE_SINGLETON`) as ordinary
         // `FunDecl` entries with `is_global_initializer` set to the
@@ -789,9 +793,10 @@ fn build_semantic_program_from_llbc_with_static_addrs_filtered(
         // production keeps going with a degraded SemanticProgram —
         // failing-loud on the single broken function rather than
         // erroring out at program-build time.
-        let graph = match lower_fun_decl_with_static_addrs_and_attrs(
+        let graph = match lower_unstructured_with_static_addrs_and_attrs(
             llbc,
             fd,
+            &body,
             static_addrs,
             &struct_field_attrs,
         ) {
@@ -1585,6 +1590,23 @@ fn lower_fun_decl_with_static_addrs_and_attrs(
             fd.item_meta.name_path()
         ))
     })?;
+    lower_unstructured_with_static_addrs_and_attrs(llbc, fd, &u, static_addrs, struct_field_attrs)
+}
+
+/// Lower `fd` from an already-projected `Unstructured` body.
+///
+/// `FunDecl::body` is retained as raw JSON and `FunDecl::unstructured`
+/// re-parses it on every call, so a caller that has already projected the
+/// body — the whole-program loop, which needs the projection to decide
+/// whether the decl has one at all — passes it in here rather than paying
+/// the parse a second time.
+fn lower_unstructured_with_static_addrs_and_attrs(
+    llbc: &Llbc,
+    fd: &FunDecl,
+    u: &Unstructured,
+    static_addrs: crate::HostStaticAddrs<'_>,
+    struct_field_attrs: &std::collections::HashMap<String, Vec<(String, ValueType)>>,
+) -> Result<FunctionGraph, LowerError> {
     let name = fd.item_meta.name_path();
     // The Result-of-PyError exception-link lowering's callee rule
     // applies when this body is a scoped callee (see
@@ -1883,7 +1905,7 @@ fn lower_fun_decl_with_static_addrs_and_attrs(
     // the monotonic one — unless `PYRE_MIR_FRAMESTATE_STRICT` is set,
     // which propagates the error for debugging.
     if framestate_enabled() {
-        let mut lo = Lowering::new(llbc, name.clone(), &u, static_addrs, fd.generics.as_ref())?;
+        let mut lo = Lowering::new(llbc, name.clone(), u, static_addrs, fd.generics.as_ref())?;
         // Back-edge targets (loop headers); empty for an acyclic body, in
         // which case `lower_framestate` reduces exactly to the two-pass
         // RPO walk.  Treat the threaded lowering and its shared
@@ -1915,7 +1937,7 @@ fn lower_fun_decl_with_static_addrs_and_attrs(
             }
         }
     }
-    let mut lo = Lowering::new(llbc, name.clone(), &u, static_addrs, fd.generics.as_ref())?;
+    let mut lo = Lowering::new(llbc, name.clone(), u, static_addrs, fd.generics.as_ref())?;
     match lo.lower(BlockOrder::Linear) {
         Ok(()) => {
             finish(&mut lo)?;
@@ -1933,7 +1955,7 @@ fn lower_fun_decl_with_static_addrs_and_attrs(
         // inputargs), which is order-independent.  RPO only resolves the
         // acyclic forward-reference case above.
         Err(LowerError::Unsupported(msg)) if is_known_lowering_gap(&msg) => {
-            let mut lo = Lowering::new(llbc, name, &u, static_addrs, fd.generics.as_ref())?;
+            let mut lo = Lowering::new(llbc, name, u, static_addrs, fd.generics.as_ref())?;
             lo.lower(BlockOrder::ReversePostorder)?;
             finish(&mut lo)?;
             Ok(lo.graph)

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -1578,7 +1578,16 @@ pub fn lower_fun_decl_with_static_addrs(
     lower_fun_decl_with_static_addrs_and_attrs(llbc, fd, static_addrs, &struct_field_attrs)
 }
 
-fn lower_fun_decl_with_static_addrs_and_attrs(
+/// The `struct_field_attrs` projection of [`derive_program_metadata`] —
+/// the map the whole-program loop lowers this LLBC's decls with.
+pub(crate) fn struct_field_attrs_of(
+    llbc: &Llbc,
+) -> std::collections::HashMap<String, Vec<(String, ValueType)>> {
+    let (_, _, _, _, _, struct_field_attrs, _, _) = derive_program_metadata(llbc);
+    struct_field_attrs
+}
+
+pub(crate) fn lower_fun_decl_with_static_addrs_and_attrs(
     llbc: &Llbc,
     fd: &FunDecl,
     static_addrs: crate::HostStaticAddrs<'_>,

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -635,6 +635,103 @@ pub fn build_semantic_program_from_llbc_with_static_addrs(
     build_semantic_program_from_llbc_with_static_addrs_filtered(llbc, static_addrs, None)
 }
 
+/// One block's slot-indexed `Option<Variable>` row, stored by bound slot.
+///
+/// Same reasoning as [`PackedFrameState`]: the row is sized by the body's
+/// local count but holds a live-in handful, and one row per block makes
+/// the table `blocks * locals`.
+#[derive(Clone, Default)]
+struct PackedLocalRow {
+    len: usize,
+    bound: Vec<(u32, crate::flowspace::model::Variable)>,
+}
+
+impl PackedLocalRow {
+    fn pack(row: &[Option<crate::flowspace::model::Variable>]) -> Self {
+        Self {
+            len: row.len(),
+            bound: row
+                .iter()
+                .enumerate()
+                .filter_map(|(i, v)| v.clone().map(|v| (i as u32, v)))
+                .collect(),
+        }
+    }
+
+    fn unpack(&self) -> Vec<Option<crate::flowspace::model::Variable>> {
+        let mut row = vec![None; self.len];
+        for (i, v) in &self.bound {
+            row[*i as usize] = Some(v.clone());
+        }
+        row
+    }
+
+    fn set(&mut self, slot: usize, var: crate::flowspace::model::Variable) {
+        match self.bound.binary_search_by_key(&(slot as u32), |(i, _)| *i) {
+            Ok(at) => self.bound[at].1 = var,
+            Err(at) => self.bound.insert(at, (slot as u32, var)),
+        }
+    }
+}
+
+/// A [`FrameState`] held in a per-block table with its two slot-indexed
+/// rows compressed to the slots that are actually bound.
+///
+/// `entries` / `locals_w` are sized by the body's local count and read
+/// positionally, so a table holding one per block costs
+/// `blocks * locals` cells.  On a large body that product dominates the
+/// whole front end — `transform_graph_to_jitcode` has 15 335 MIR blocks
+/// and 14 215 locals, yet averages ~33 bound slots per block, so the
+/// dense rows are 0.2% occupied.  Packing keeps the same values and the
+/// same row lengths; a row is rebuilt dense at each use, one at a time.
+#[derive(Clone)]
+struct PackedFrameState {
+    /// The other `FrameState` fields, verbatim; its `entries` /
+    /// `locals_w` are left empty and carried in the two sparse rows.
+    rest: FrameState,
+    entries_len: usize,
+    entries: Vec<(u32, crate::flowspace::model::Variable)>,
+    locals_w_len: usize,
+    locals_w: Vec<(u32, crate::flowspace::model::Hlvalue)>,
+}
+
+impl PackedFrameState {
+    fn pack(mut fs: FrameState) -> Self {
+        let entries_len = fs.entries.len();
+        let locals_w_len = fs.locals_w.len();
+        let entries = std::mem::take(&mut fs.entries)
+            .into_iter()
+            .enumerate()
+            .filter_map(|(i, v)| v.map(|v| (i as u32, v)))
+            .collect();
+        let locals_w = std::mem::take(&mut fs.locals_w)
+            .into_iter()
+            .enumerate()
+            .filter_map(|(i, v)| v.map(|v| (i as u32, v)))
+            .collect();
+        Self {
+            rest: fs,
+            entries_len,
+            entries,
+            locals_w_len,
+            locals_w,
+        }
+    }
+
+    fn unpack(&self) -> FrameState {
+        let mut fs = self.rest.clone();
+        fs.entries = vec![None; self.entries_len];
+        for (i, v) in &self.entries {
+            fs.entries[*i as usize] = Some(v.clone());
+        }
+        fs.locals_w = vec![None; self.locals_w_len];
+        for (i, v) in &self.locals_w {
+            fs.locals_w[*i as usize] = Some(v.clone());
+        }
+        fs
+    }
+}
+
 fn build_semantic_program_from_llbc_with_static_addrs_filtered(
     llbc: &Llbc,
     static_addrs: crate::HostStaticAddrs<'_>,
@@ -2134,7 +2231,7 @@ struct Lowering<'a> {
     /// blocks receive these through `Block.inputargs`, and predecessor
     /// edges pass the matching current Variables via `Link.args`.
     block_live_in: Vec<bit_set::BitSet>,
-    block_entry_local_var: Vec<Vec<Option<Variable>>>,
+    block_entry_local_var: Vec<PackedLocalRow>,
     block_entry_positional_aggregate_locals: Vec<std::collections::HashMap<usize, String>>,
     block_positional_seen: Vec<bit_set::BitSet>,
     block_positional_conflict: Vec<bit_set::BitSet>,
@@ -2401,11 +2498,17 @@ impl<'a> Lowering<'a> {
         }
         let index_write_extra_live = compute_index_write_extra_live(body, llbc);
         let block_live_in = compute_mir_liveness(body, &index_write_extra_live);
-        let mut block_entry_local_var = vec![vec![None; n_locals]; body.body.len()];
+        let mut block_entry_local_var = vec![
+            PackedLocalRow {
+                len: n_locals,
+                bound: Vec::new()
+            };
+            body.body.len()
+        ];
         let block_entry_positional_aggregate_locals =
             vec![std::collections::HashMap::new(); body.body.len()];
         if !block_entry_local_var.is_empty() {
-            block_entry_local_var[0] = local_var.clone();
+            block_entry_local_var[0] = PackedLocalRow::pack(&local_var);
         }
         for mir_bb in 1..body.body.len() {
             for local_idx in 0..n_locals {
@@ -2417,7 +2520,7 @@ impl<'a> Lowering<'a> {
                 }
                 let var = graph.alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
                 graph.push_inputarg_var(block_id[mir_bb], var.clone());
-                block_entry_local_var[mir_bb][local_idx] = Some(var);
+                block_entry_local_var[mir_bb].set(local_idx, var);
             }
         }
 
@@ -2830,10 +2933,10 @@ impl<'a> Lowering<'a> {
             block_to_mir[bid.0] = mir;
         }
 
-        let mut entry_state: Vec<Option<FrameState>> = vec![None; n];
-        let mut exit_state: Vec<Option<FrameState>> = vec![None; n];
+        let mut entry_state: Vec<Option<PackedFrameState>> = vec![None; n];
+        let mut exit_state: Vec<Option<PackedFrameState>> = vec![None; n];
         // bb0 enters with the parameter bindings established in `new`.
-        entry_state[0] = Some(self.getstate());
+        entry_state[0] = Some(PackedFrameState::pack(self.getstate()));
 
         // Pass 0 (cyclic only) — pre-seed each loop header's entry
         // framestate with the live-in phis `new` pre-bound for it
@@ -2847,16 +2950,16 @@ impl<'a> Lowering<'a> {
         // set), so its parameter inputargs / `Input` ops stay intact.
         for (h, &is_header) in loop_headers.iter().enumerate().take(n) {
             if is_header && h != 0 {
-                entry_state[h] = Some(FrameState {
-                    entries: self.block_entry_local_var[h].clone(),
+                entry_state[h] = Some(PackedFrameState::pack(FrameState {
+                    entries: self.block_entry_local_var[h].unpack(),
                     ..Default::default()
-                });
+                }));
             }
         }
 
         // Pass 1 — RPO walk: setstate, inputargs, lower, snapshot, union.
         for &bb in &rpo {
-            let st = match entry_state[bb].clone() {
+            let st = match entry_state[bb].as_ref().map(PackedFrameState::unpack) {
                 Some(st) => st,
                 None => {
                     // No live predecessor edge reached this block.  RPO
@@ -2902,7 +3005,7 @@ impl<'a> Lowering<'a> {
                 // positional projection of the framestate entries, whose
                 // Variable cells are the same identities `getvariables`
                 // threaded into `inputargs`.
-                self.block_entry_local_var[bb] = self.local_var.clone();
+                self.block_entry_local_var[bb] = PackedLocalRow::pack(&self.local_var);
             }
             self.lower_block(bb)?;
             let mut ex = self.getstate();
@@ -2929,7 +3032,7 @@ impl<'a> Lowering<'a> {
                     *slot = None;
                 }
             }
-            exit_state[bb] = Some(ex.clone());
+            exit_state[bb] = Some(PackedFrameState::pack(ex.clone()));
             // Union this exit into each model successor's entry state.
             // Successors are read off the just-closed exits (the model
             // edges), skipping the return / except sinks and any
@@ -2957,7 +3060,11 @@ impl<'a> Lowering<'a> {
                 if loop_headers.get(tmir).copied().unwrap_or(false) {
                     continue;
                 }
-                let merged = match entry_state[tmir].take() {
+                let merged = match entry_state[tmir]
+                    .take()
+                    .as_ref()
+                    .map(PackedFrameState::unpack)
+                {
                     None => ex.clone(),
                     Some(prev) => prev.union(&ex, &mut self.graph).ok_or_else(|| {
                         LowerError::Unsupported(format!(
@@ -2965,7 +3072,7 @@ impl<'a> Lowering<'a> {
                         ))
                     })?,
                 };
-                entry_state[tmir] = Some(merged);
+                entry_state[tmir] = Some(PackedFrameState::pack(merged));
             }
         }
 
@@ -2999,9 +3106,14 @@ impl<'a> Lowering<'a> {
             if self.graph.block(bb_id).dead {
                 continue;
             }
-            let ex = exit_state[bb].clone().ok_or_else(|| {
-                LowerError::Unsupported(format!("framestate: bb{bb} missing exit state in pass 2"))
-            })?;
+            let ex = exit_state[bb]
+                .as_ref()
+                .map(PackedFrameState::unpack)
+                .ok_or_else(|| {
+                    LowerError::Unsupported(format!(
+                        "framestate: bb{bb} missing exit state in pass 2"
+                    ))
+                })?;
             let exits_meta: Vec<(usize, BlockId)> = self
                 .graph
                 .block(bb_id)
@@ -3018,11 +3130,14 @@ impl<'a> Lowering<'a> {
                 if tmir == usize::MAX {
                     continue;
                 }
-                let tgt_state = entry_state[tmir].clone().ok_or_else(|| {
-                    LowerError::Unsupported(format!(
-                        "framestate: bb{tmir} missing entry state in pass 2"
-                    ))
-                })?;
+                let tgt_state = entry_state[tmir]
+                    .as_ref()
+                    .map(PackedFrameState::unpack)
+                    .ok_or_else(|| {
+                        LowerError::Unsupported(format!(
+                            "framestate: bb{tmir} missing entry state in pass 2"
+                        ))
+                    })?;
                 // `try_getoutputargs` (not the panicking `getoutputargs`):
                 // a loop header pre-seeded with live-in phis bypasses the
                 // union's None-kill, so a phantom slot scrubbed to `None`
@@ -3169,7 +3284,7 @@ impl<'a> Lowering<'a> {
 
     fn lower_block(&mut self, mir_bb: usize) -> Result<(), LowerError> {
         let bb: &BasicBlock = &self.body.body[mir_bb];
-        self.local_var = self.block_entry_local_var[mir_bb].clone();
+        self.local_var = self.block_entry_local_var[mir_bb].unpack();
         self.positional_aggregate_locals =
             self.block_entry_positional_aggregate_locals[mir_bb].clone();
 

--- a/majit/majit-translate/src/front/mod.rs
+++ b/majit/majit-translate/src/front/mod.rs
@@ -67,6 +67,7 @@
 pub(crate) mod bigint_binop;
 pub(crate) mod bool_then;
 pub(crate) mod checked_arith;
+pub(crate) mod graph_body;
 pub(crate) mod iter_next;
 pub mod llbc_hints;
 pub mod mir;

--- a/majit/majit-translate/src/model.rs
+++ b/majit/majit-translate/src/model.rs
@@ -5406,16 +5406,16 @@ impl FunctionGraph {
     /// formal parameters the recovery is exact 1:1 — the param-binding
     /// loop (`lower_expr_into_graph_with_signature` / `build_function_
     /// graph`) emits a named `Input` op for every inputarg — so the
-    /// `arg{N}` fallback in `signature_for_graph` is unreachable for
-    /// well-formed graphs. `pygraph.py:16` instead names the initial-
-    /// block locals straight from `code.co_varnames` and stores
-    /// `code.signature` on the `PyGraph` wrapper; pyre's lifted callee
-    /// graphs carry no such wrapper, so the raw name is recovered from
-    /// the `Input` op until a `PyGraph`-equivalent signature store
-    /// lands. Orthodox reader for callers that already hold the
-    /// `Variable` (e.g. `signature_for_graph` walking
-    /// `startblock.inputargs`); RPython reads the source name off the
-    /// Variable / `co_varnames`, never via an integer value index.
+    /// `arg{N}` fallback in `GraphStore::signature_from_graph` is
+    /// unreachable for well-formed graphs. `pygraph.py:16` instead names
+    /// the initial-block locals straight from `code.co_varnames` and
+    /// stores `code.signature` on the `PyGraph` wrapper; pyre's lifted
+    /// callee graphs carry no such wrapper, so the raw name is recovered
+    /// from the `Input` op once at registration and kept on the
+    /// `GraphStore` slot thereafter. Orthodox reader for callers that
+    /// already hold the `Variable` (e.g. `GraphStore::signature_from_graph`
+    /// walking `startblock.inputargs`); RPython reads the source name off
+    /// the Variable / `co_varnames`, never via an integer value index.
     pub fn value_name_for(&self, var: &crate::flowspace::model::Variable) -> Option<String> {
         // Unnamed values (arithmetic temporaries, constants) carry no
         // source name; `Variable.renamed` is the O(1) gate that keeps

--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -444,12 +444,13 @@ fn unpoison_failed_subject_callees(
             .keys_for_entry(&key)
             .iter()
             .find_map(|k| {
-                lift_sources.get(&crate::parse::CallPath::from_segments(
-                    k.segments().iter().cloned(),
-                ))
+                let path = crate::parse::CallPath::from_segments(k.segments().iter().cloned());
+                let source = lift_sources.get(&path)?;
+                let signature = lift_sources.signature(&path)?;
+                Some((source, signature))
             })
-            .and_then(|source| {
-                lift_callee_to_pygraph(source, signature_for_graph(source), call_registry).ok()
+            .and_then(|(source, signature)| {
+                lift_callee_to_pygraph(source, signature.clone(), call_registry).ok()
             });
         match fresh {
             Some(fresh) => {
@@ -1521,8 +1522,12 @@ pub(crate) fn populate_call_registry_from_call_graphs(
         }
         segs
     }
-    let mut pending: Vec<(FunctionPathKey, &LegacyGraph, Rc<PyreFunctionEntry>)> =
-        Vec::with_capacity(function_graphs.len());
+    let mut pending: Vec<(
+        FunctionPathKey,
+        &LegacyGraph,
+        Rc<PyreFunctionEntry>,
+        &Signature,
+    )> = Vec::with_capacity(function_graphs.len());
     // `by_canonical_path` tracks the canonical `FunctionPathKey` of
     // the first-encountered alias for each canonical-stripped key.
     // Subsequent aliases of the same callable register an alias row
@@ -1601,6 +1606,9 @@ pub(crate) fn populate_call_registry_from_call_graphs(
         {
             continue;
         }
+        let signature = function_graphs
+            .signature(path)
+            .expect("iter() path resolves to a stored slot");
         let entry = if let Some(canonical_key) = by_canonical_path.get(&canonical_strip) {
             if canonical_key != &key {
                 registry.alias(key.clone(), canonical_key);
@@ -1609,12 +1617,11 @@ pub(crate) fn populate_call_registry_from_call_graphs(
                 .lookup(canonical_key)
                 .expect("canonical entry registered")
         } else {
-            let signature = signature_for_graph(graph);
-            let entry = registry.get_or_register(key.clone(), signature);
+            let entry = registry.get_or_register(key.clone(), signature.clone());
             by_canonical_path.insert(canonical_strip, key.clone());
             entry
         };
-        pending.push((key, graph, entry));
+        pending.push((key, graph, entry, signature));
     }
     // Lift `pending` in a deterministic order.  `function_graphs.iter()`
     // (`GraphStore` over `path_to_key: HashMap<CallPath, _>`) yields entries
@@ -1698,7 +1705,7 @@ pub(crate) fn populate_call_registry_from_call_graphs(
     // `RPythonAnnotator` (`bookkeeper.annotator()` panics with
     // "backlink absent or dropped") only pay the lookup on the
     // failure path; success paths remain unaffected.
-    for (_key, graph, entry) in &pending {
+    for (_key, graph, entry, signature) in &pending {
         let entry_ptr = Rc::as_ptr(entry);
         if !lifted.insert(entry_ptr) {
             continue;
@@ -1774,14 +1781,14 @@ pub(crate) fn populate_call_registry_from_call_graphs(
             if let Some(result_shell) = result_shell {
                 let stub = build_stub_pygraph_with_result_shell(
                     graph.name.clone(),
-                    signature_for_graph(graph),
+                    (*signature).clone(),
                     result_shell,
                 );
                 entry.prefill_default_cache(stub);
                 continue;
             }
         }
-        match lift_callee_to_pygraph(graph, signature_for_graph(graph), registry) {
+        match lift_callee_to_pygraph(graph, (*signature).clone(), registry) {
             Ok(pygraph) => entry.prefill_default_cache(pygraph),
             Err(e) => {
                 let message = format!("{e}");
@@ -1815,7 +1822,7 @@ pub(crate) fn populate_call_registry_from_call_graphs(
     // same-named instance field wins — a function source for a field
     // attribute would union-conflict in `generalize_attr`.
     let bk = registry.bookkeeper();
-    for (key, _graph, entry) in &pending {
+    for (key, _graph, entry, _signature) in &pending {
         // `CallPath::for_impl_method` splits the module-qualified owner
         // ("pyframe::PyFrame" → [pyframe, PyFrame, method]), so the
         // owner is the second-to-last segment.  Free-function paths
@@ -1847,26 +1854,6 @@ pub(crate) fn populate_call_registry_from_call_graphs(
 // orthodox flow directly: lift subject graph -> seed subject blocks
 // -> compute_at_fixpoint (drives pycall->recursivecall to discover
 // callees) -> RPythonTyper::specialize.
-
-/// Derive a parameter `Signature` directly from a `FunctionGraph`'s
-/// startblock inputargs.  Same shape as
-/// [`signature_for`] but takes a graph rather than a
-/// `SemanticFunction`, since `CallControl::function_graphs()`
-/// carries graphs without their lowered SemanticFunction wrapper.
-fn signature_for_graph(graph: &LegacyGraph) -> Signature {
-    let startblock = graph.block(graph.startblock);
-    let argnames: Vec<String> = startblock
-        .inputargs
-        .iter()
-        .enumerate()
-        .map(|(idx, var)| {
-            graph
-                .value_name_for(var)
-                .unwrap_or_else(|| format!("arg{idx}"))
-        })
-        .collect();
-    Signature::new(argnames, None, None)
-}
 
 /// Lift a pyre `model::FunctionGraph` (a callee that may appear on a
 /// `OpKind::Call::FunctionPath` callsite of some other graph) into a


### PR DESCRIPTION
## What this does

Four commits on the `pyre-jit-trace` build prepass. The headline is the last
one: **pipeline peak RSS 7.71 GB → 4.25 GB**, total prepass time unchanged
(63.63s → 63.68s).

### `front/mir: store the per-block local rows by bound slot`

`Lowering` kept three tables holding one slot-indexed row per MIR block —
`block_entry_local_var`, and the RPO walk's `entry_state` / `exit_state`, whose
`FrameState` carries `entries` and `locals_w` sized by the body's local count.
Each costs `blocks * locals` cells no matter how many slots are bound.

`pyre_jit::jit::codewriter::<Impl>::transform_graph_to_jitcode` has 15335 MIR
blocks and 14215 locals, and lowering it accounted for **4.05 GB of the prepass
RSS on its own**. The next-largest body,
`pyre_interpreter::module::_pickle::unpickler::dispatch` (3061 blocks, 2121
locals), accounted for 0.15 GB — a fifth the size, a twenty-seventh the memory.

Its lowered graph carries 509162 block inputargs across 15403 blocks: ~33 bound
slots per 14215-slot row, so the dense rows are **0.2% occupied**.

`PackedLocalRow` / `PackedFrameState` store the bound slots plus the row length,
and a row is rebuilt dense at each use, one at a time. `Lowering::local_var` and
every `FrameState` reaching `union` / `getvariables` / `getoutputargs` keep the
shape they have today, and `crate::model::FrameState` is untouched — same
values, same algorithm, different storage.

RPython's flowspace also gives every block its inputargs from the frame state
(`framestate.py:19 locals_w`), so the algorithm is unchanged here. What does not
carry over is the input scale: a Python frame has tens of `co_varnames`, this
Rust MIR body has 14215 locals.

### `front: add a GraphBodyProvider that lowers a FunDecl on demand`

`translator.py:55 buildflowgraph(func)` builds a function's flow graph when a
consumer first asks; pyre's funcobjs are Charon `FunDecl`s, so the analogue is
lowering the decl from its LLBC. That needs the LLBC set to outlive the
whole-program build, which nothing kept alive.

The provider owns the `Vec<Llbc>`, an owned copy of the three `HostStaticAddrs`
tables, and a per-LLBC `struct_field_attrs` map recovered lazily through the new
`mir::struct_field_attrs_of`. A `GraphBodySource` is `(llbc index, Charon
def_id)`, resolved via `Llbc::fn_by_id`.

The test lowers every body in `charon-corpus/corpus.ullbc` through both the
whole-program entry point and the provider and compares graph shapes, with
variable ids renumbered in first-seen order — `NEXT_VAR_ID` is process-global,
so two lowerings of one funcobj never carry equal ids, while the aliasing the
renumbering preserves is what the codewriter reads. No production call site yet.

### `front/mir: lower the whole-program loop from the body it already projected`

`FunDecl::body` is raw JSON and `unstructured()` re-parses it per call. The loop
called it twice per decl: once as a "has a lowerable body" gate, discarding the
projection, then again inside the lowering. One full-corpus `unstructured()`
pass over the three artefacts (23137 bodies, 406388 blocks) measures **4.20s** at
the build script's `opt-level = 1`.

### `majit-translate: keep the funcobj Signature on the GraphStore slot`

`GraphStore` now stores `GraphSlot { graph, signature }`, the signature derived
from the startblock inputargs when the key is first inserted.
`signature_for_graph` is removed and its four callers read the slot, so
registration no longer walks a graph body for parameter names.

## Verification

Every commit holds `819 all_jitcodes (555669 bytes bincode), generated 25254
bytes` and passes `check.py --backend dynasm,cranelift,wasm` (333/333, 333/333,
330/330 at the tip).

`majit-translate`'s suite is green except
`test_rbigint_mir::dependent_crate_rbigint_identity_retargets_opaque_llbc_declaration`,
which is red on the base too: it asserts `harvest_hints_from_llbcs` reports
`elidable_or_memerror` for `jit_bigint_div` / `jit_bigint_rem`, but
`build/llbc/pyre-interpreter.ullbc` was extracted 2026-07-25 21:43 and the
attribute landed in 7b70e1ebff at 22:02 — a stale fixture, not a regression from
this branch.

## Note on scope

This branch started out building toward demand-driven body lowering (the first
three commits are that plumbing). Measuring the premise first would have been
the better order: an env-gated probe that drops every lowered body immediately
moves the phase from 7.67 GB to 6.34 GB, so **retaining all 14998 graphs is worth
only 1.33 GB** — the whole ceiling of that axis. Skipping lowering entirely lands
at 2.10 GB, and `mi_collect(true)` before each reading changes nothing, which is
what pointed at the dense tables above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)