### PR TITLE
interp/jit: resolve module attributes dict-first (LOAD_ATTR_MODULE precedence)

### DIFF
--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -4944,13 +4944,18 @@ fn getattr_str_impl(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyResul
         }
     }
 
-    // Module objects use `object_getattribute` first (`module.py:130-134`),
-    // so their class descriptors and namespace follow the normal descriptor
-    // precedence.  This matters for a ModuleType subclass that shadows the
-    // base `__dict__` member: `class M(ModuleType): __dict__ = 8` must expose
-    // 8, and `module.__dir__` then rejects it as a non-dict.  Only after the
-    // complete normal lookup misses does module.py consult PEP 562
-    // `__getattr__` (the tail below).
+    // Module attribute lookup resolves the namespace dict before the module
+    // type's data descriptors (`LOAD_ATTR_MODULE` precedence): a name present
+    // in the module dict wins even over a same-named data descriptor on the
+    // module type.  This deliberately departs from the generic
+    // descriptor-first protocol so a hot `m.attr` and its compiled fold agree
+    // — e.g. after `m.__dict__["__dict__"] = x`, reading `m.__dict__` yields
+    // `x`.  A retagged module's replacement `__getattribute__`
+    // (importlib.util._LazyModule) still runs first.  A dict miss resumes the
+    // descriptor protocol, so a `ModuleType` subclass shadowing the base
+    // `__dict__` member with a plain value (`class M(ModuleType): __dict__ =
+    // 8`) still exposes 8.  Only after the whole lookup misses does module.py
+    // consult PEP 562 `__getattr__` (the tail below).
     unsafe {
         if is_module(obj) {
             let w_type = crate::typedef::r#type(obj).map_or(PY_NULL, |p| p.as_ptr());
@@ -4977,6 +4982,14 @@ fn getattr_str_impl(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyResul
                     }
                 }
             }
+            let w_dict = pyre_object::w_module_get_w_dict(obj);
+            if !w_dict.is_null() {
+                if let Some(value) = finditem_str(w_dict, name)? {
+                    if !value.is_null() {
+                        return Ok(value);
+                    }
+                }
+            }
             let w_descr = if w_type.is_null() {
                 None
             } else {
@@ -4988,16 +5001,6 @@ fn getattr_str_impl(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyResul
                         return Ok(value);
                     }
                 }
-            }
-            let w_dict = pyre_object::w_module_get_w_dict(obj);
-            if !w_dict.is_null() {
-                if let Some(value) = finditem_str(w_dict, name)? {
-                    if !value.is_null() {
-                        return Ok(value);
-                    }
-                }
-            }
-            if let Some(descr) = w_descr {
                 return Ok(get(descr, obj, w_type)?.unwrap_or(descr));
             }
         }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -1528,6 +1528,10 @@ pub(crate) fn try_walker_specialize_load_attr<Sym: WalkSym>(
     // `module` `w_class` excludes a module subclass with a custom
     // `__getattribute__`; a module-level PEP 562 `__getattr__` is irrelevant
     // because the name is present (the dict lookup wins before `__getattr__`).
+    // Module getattr resolves the namespace dict before the module type's
+    // data descriptors (`LOAD_ATTR_MODULE` precedence, mirrored in the
+    // interpreter), so folding the cell is faithful even for a name that also
+    // names a data descriptor on the module type (e.g. `__dict__`).
     if unsafe { pyre_object::is_module(concrete_obj) }
         && std::ptr::eq(
             unsafe { (*concrete_obj).w_class },


### PR DESCRIPTION
## What

Module attribute lookup now consults the module **namespace dict before the module type's data descriptors**, so a name present in the module dict wins over a same-named data descriptor on the module type — the `LOAD_ATTR_MODULE` precedence. After `m.__dict__["__dict__"] = x`, reading `m.__dict__` yields `x`.

A dict miss resumes the normal descriptor protocol, so a `ModuleType` subclass shadowing the base `__dict__` member with a plain value (`class M(ModuleType): __dict__ = 8`) still exposes it, and PEP 562 `__getattr__` still runs only after the whole lookup misses.

## Why

Follow-up to the Codex P2 on #827. The JIT module-attr fold in `try_walker_specialize_load_attr` folds the namespace-dict cell directly, while the interpreter's module getattr checked type data descriptors first — so a hot `m.__dict__` (with `__dict__` injected into the namespace) returned the injected value under the JIT but the real dict under the interpreter (**jit ≠ nojit**).

Investigating the fix surfaced a genuine **CPython 3.14 ↔ PyPy divergence** on this case:

| | cold / nojit | hot |
|---|---|---|
| CPython 3.14 | real dict | **injected value** (`LOAD_ATTR_MODULE` specialization bypasses the `__dict__` data descriptor) |
| PyPy 3.11 | real dict | real dict |

pyre's compat target is CPython 3.14, so this reorders the **interpreter** module getattr to dict-first and reverts the JIT fold to its original cell read, making both agree with CPython 3.14's specialized behavior (`jit == nojit == injected value`). This deliberately departs from PyPy's generic descriptor-first `module.py`; the rationale is documented at both sites.

## Verification

- `m.__dict__` shadow (hot loop): pyre jit = nojit = injected value, matching python3.14 (pyre is consistent from iteration 0; python3.14 has one cold warmup iteration).
- Normal module attributes (`math.sqrt`, `math.__dict__`, non-shadowed modules): unchanged across pyre and python3.14.
- `pyre/check.py`: **ALL PASSED** — dynasm 334/334, cranelift 334/334, wasm 331/331.

No synthetic regression bench is included: the observable behavior is exactly the case where CPython 3.14 and PyPy disagree, which the oracle-baselined synth harness rejects as an inconsistent baseline (BASEFAIL). The behavior is guarded by the code comments at the interpreter and fold sites instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)