### PR TITLE
jit(fbw): type the walk-end commit contract and make the callee rebuild the preferred abort leg

### DIFF
--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -4457,68 +4457,10 @@ impl<M: Clone> MetaInterp<M> {
             None => return,
         };
         let vable_ptr = self.vable_ptr;
-        if vable_ptr.is_null() {
-            return;
-        }
-        let (vable_box, array_lengths) = match self.tracing.as_ref() {
-            Some(ctx) => {
-                let Some(vable_box) = ctx.standard_virtualizable_box() else {
-                    return;
-                };
-                let array_lengths = ctx
-                    .virtualizable_array_lengths()
-                    .map(|lengths| lengths.to_vec())
-                    .unwrap_or_default();
-                (vable_box, array_lengths)
-            }
-            None => return,
-        };
-        let (static_boxes, array_boxes) = unsafe { info.read_all_boxes(vable_ptr, &array_lengths) };
         let Some(ctx) = self.tracing.as_mut() else {
             return;
         };
-        let cap = static_boxes.len() + array_boxes.iter().map(Vec::len).sum::<usize>() + 1;
-        let mut boxes = Vec::with_capacity(cap);
-        let mut values = Vec::with_capacity(cap);
-        for (index, value) in static_boxes.into_iter().enumerate() {
-            let (opref, concrete) = match info.static_fields[index].field_type {
-                majit_ir::Type::Int => (ctx.const_int(value), Value::Int(value)),
-                majit_ir::Type::Ref => (
-                    ctx.const_ref(value),
-                    Value::Ref(majit_ir::GcRef(value as usize)),
-                ),
-                majit_ir::Type::Float => (
-                    ctx.const_float(value),
-                    Value::Float(f64::from_bits(value as u64)),
-                ),
-                majit_ir::Type::Void => continue,
-            };
-            boxes.push(opref);
-            values.push(concrete);
-        }
-        for (array_index, items) in array_boxes.into_iter().enumerate() {
-            let item_type = info.array_fields[array_index].item_type;
-            for value in items {
-                let (opref, concrete) = match item_type {
-                    majit_ir::Type::Int => (ctx.const_int(value), Value::Int(value)),
-                    majit_ir::Type::Ref => (
-                        ctx.const_ref(value),
-                        Value::Ref(majit_ir::GcRef(value as usize)),
-                    ),
-                    majit_ir::Type::Float => (
-                        ctx.const_float(value),
-                        Value::Float(f64::from_bits(value as u64)),
-                    ),
-                    majit_ir::Type::Void => continue,
-                };
-                boxes.push(opref);
-                values.push(concrete);
-            }
-        }
-        boxes.push(vable_box);
-        // The vable identity's concrete value is the heap pointer itself.
-        values.push(Value::Ref(majit_ir::GcRef(vable_ptr as usize)));
-        ctx.set_virtualizable_boxes_with_info(boxes, values, &info, &array_lengths);
+        ctx.load_fields_from_virtualizable(&info, vable_ptr);
     }
 
     /// pyjitpl.py:1167-1172 `opimpl_getfield_vable_i(box, fielddescr, pc)`.

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -1030,13 +1030,15 @@ where
         Some(active)
     }
 
-    fn finish_standard_virtualizable_after_residual_call(
+    /// The escaping half of `vable_after_residual_call` (pyjitpl.py:3372):
+    /// `Some` when `tracing_after_residual_call` reports the virtualizable
+    /// escaped during this CALL_MAY_FORCE.  Returns the still-rooted
+    /// [`ActiveStandardVirtualizable`] so the caller can read the heap object
+    /// before dropping the shadow-stack root.
+    fn escaped_standard_virtualizable(
         active: Option<ActiveStandardVirtualizable>,
-    ) -> bool {
-        let Some(active) = active else {
-            return false;
-        };
-        unsafe { active.info.tracing_after_residual_call(active.obj_ptr()) }
+    ) -> Option<ActiveStandardVirtualizable> {
+        active.filter(|active| unsafe { active.info.tracing_after_residual_call(active.obj_ptr()) })
     }
 
     fn finalize_standard_virtualizable_may_force(
@@ -1045,7 +1047,18 @@ where
         sym: &mut S,
         active: Option<ActiveStandardVirtualizable>,
     ) -> TraceAction {
-        if Self::finish_standard_virtualizable_after_residual_call(active) {
+        if let Some(active) = Self::escaped_standard_virtualizable(active) {
+            // pyjitpl.py:3377 `self.load_fields_from_virtualizable()` runs
+            // BEFORE the abort: the residual call forced the virtualizable and
+            // wrote its fields through the heap object, so the tracing-time
+            // box cache is stale.  Without this reload the blackhole rebuilds
+            // the resumed interpreter state from the pre-call boxes and the
+            // forced writes are lost.  The `MetaInterp` side already does this
+            // (`vable_after_residual_call`); this dispatcher holds no
+            // `MetaInterp`, so it calls the shared `TraceCtx` body directly.
+            // `active` stays alive across the read to keep the shadow-stack
+            // root for `obj_ptr` — its `Drop` pops that root.
+            ctx.load_fields_from_virtualizable(&active.info, active.obj_ptr());
             // pyjitpl.py:3373-3375 `raise SwitchToBlackhole(ABORT_ESCAPE,
             // raising_exception=True)` — stash the upstream-orthodox
             // abort reason + `raising_exception` flag on TraceCtx so
@@ -9760,6 +9773,74 @@ mod tests {
         assert_eq!(
             recorder.get_op_by_pos(OpRef::void_op(2)).unwrap().opcode,
             OpCode::CallMayForceN
+        );
+    }
+
+    #[repr(C)]
+    struct ForcingVable {
+        token: u64,
+        pc: i64,
+    }
+
+    /// Force the virtualizable (clear the token) and write a field through the
+    /// heap object, the way a real forced residual call does.
+    extern "C" fn residual_force_and_write(vable: i64) {
+        unsafe {
+            let vable = &mut *(vable as usize as *mut ForcingVable);
+            vable.pc = 99;
+            vable.token = 0;
+        }
+    }
+
+    /// pyjitpl.py:3377 `vable_after_residual_call` calls
+    /// `load_fields_from_virtualizable()` before raising
+    /// `SwitchToBlackhole(ABORT_ESCAPE)`, so the fields the forced callee wrote
+    /// through the heap become the resumed interpreter's state.  Without the
+    /// reload the box cache still holds the pre-call values.
+    #[test]
+    fn escaping_standard_virtualizable_reloads_fields_before_abort() {
+        let mut obj = ForcingVable { token: 0, pc: 1 };
+        let obj_ptr = (&mut obj as *mut ForcingVable) as usize as i64;
+
+        let mut builder = JitCodeBuilder::new();
+        let fn_idx = builder.add_fn_ptr(residual_force_and_write as *const ());
+        builder.call_may_force_void_canonical_via_target(fn_idx, &[JitCallArg::reference(0)]);
+        let jitcode = builder.finish();
+
+        let mut ctx = TraceCtx::for_test(0);
+        let mut info = VirtualizableInfo::new(0);
+        info.add_field("pc", Type::Int, 8);
+        info.set_parent_descr(majit_ir::descr::make_size_descr(64));
+        let vable_ref = ctx.const_ref(obj_ptr);
+        let stale_pc = ctx.const_int(1);
+        ctx.init_virtualizable_boxes(
+            &info,
+            vable_ref,
+            Value::Ref(majit_ir::GcRef(obj_ptr as usize)),
+            &[stale_pc],
+            &[Value::Int(1)],
+            &[],
+        );
+
+        let mut sym = DummySym::default();
+        let action = trace_jitcode_with_args(
+            &mut ctx,
+            &mut sym,
+            &jitcode,
+            0,
+            |_pc| 0,
+            &[(JitArgKind::Ref, vable_ref, obj_ptr)],
+        );
+        assert!(matches!(action, TraceAction::Abort));
+        assert_eq!(obj.pc, 99, "the forced residual call wrote the heap field");
+
+        let (_, reloaded) = ctx
+            .virtualizable_entry_at(0)
+            .expect("escape path must leave the virtualizable box cache populated");
+        assert_eq!(
+            reloaded,
+            Value::Int(99),
+            "load_fields_from_virtualizable must refresh the box cache from the heap",
         );
     }
 

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -2444,6 +2444,84 @@ impl TraceCtx {
         self.virtualizable_array_lengths = Some(array_lengths.to_vec());
     }
 
+    /// Reload the tracing-time `virtualizable_boxes` cache from the heap
+    /// object — the `TraceCtx`-level body of
+    /// `MetaInterp::load_fields_from_virtualizable` (pyjitpl.py:3452-3464).
+    ///
+    /// ```text
+    /// def load_fields_from_virtualizable(self):
+    ///     vinfo = self.jitdriver_sd.virtualizable_info
+    ///     if vinfo is not None:
+    ///         virtualizable_box = self.virtualizable_boxes[-1]
+    ///         virtualizable = vinfo.unwrap_virtualizable_box(virtualizable_box)
+    ///         self.virtualizable_boxes = vinfo.read_boxes(self.cpu, virtualizable, 0)
+    ///         self.virtualizable_boxes.append(virtualizable_box)
+    /// ```
+    ///
+    /// It lives here rather than only on `MetaInterp` because the second
+    /// upstream caller of this reload — the escape path of
+    /// `vable_after_residual_call` (pyjitpl.py:3377) — is reached from the
+    /// state-field dispatcher, which holds no `MetaInterp` reference.
+    pub fn load_fields_from_virtualizable(
+        &mut self,
+        info: &VirtualizableInfo,
+        vable_ptr: *const u8,
+    ) {
+        if vable_ptr.is_null() {
+            return;
+        }
+        let Some(vable_box) = self.standard_virtualizable_box() else {
+            return;
+        };
+        let array_lengths = self
+            .virtualizable_array_lengths()
+            .map(|lengths| lengths.to_vec())
+            .unwrap_or_default();
+        let (static_boxes, array_boxes) = unsafe { info.read_all_boxes(vable_ptr, &array_lengths) };
+        let cap = static_boxes.len() + array_boxes.iter().map(Vec::len).sum::<usize>() + 1;
+        let mut boxes = Vec::with_capacity(cap);
+        let mut values = Vec::with_capacity(cap);
+        for (index, value) in static_boxes.into_iter().enumerate() {
+            let (opref, concrete) = match info.static_fields[index].field_type {
+                majit_ir::Type::Int => (self.const_int(value), Value::Int(value)),
+                majit_ir::Type::Ref => (
+                    self.const_ref(value),
+                    Value::Ref(majit_ir::GcRef(value as usize)),
+                ),
+                majit_ir::Type::Float => (
+                    self.const_float(value),
+                    Value::Float(f64::from_bits(value as u64)),
+                ),
+                majit_ir::Type::Void => continue,
+            };
+            boxes.push(opref);
+            values.push(concrete);
+        }
+        for (array_index, items) in array_boxes.into_iter().enumerate() {
+            let item_type = info.array_fields[array_index].item_type;
+            for value in items {
+                let (opref, concrete) = match item_type {
+                    majit_ir::Type::Int => (self.const_int(value), Value::Int(value)),
+                    majit_ir::Type::Ref => (
+                        self.const_ref(value),
+                        Value::Ref(majit_ir::GcRef(value as usize)),
+                    ),
+                    majit_ir::Type::Float => (
+                        self.const_float(value),
+                        Value::Float(f64::from_bits(value as u64)),
+                    ),
+                    majit_ir::Type::Void => continue,
+                };
+                boxes.push(opref);
+                values.push(concrete);
+            }
+        }
+        boxes.push(vable_box);
+        // The vable identity's concrete value is the heap pointer itself.
+        values.push(Value::Ref(majit_ir::GcRef(vable_ptr as usize)));
+        self.set_virtualizable_boxes_with_info(boxes, values, info, &array_lengths);
+    }
+
     /// Canonical virtualizable metadata for the active standard virtualizable.
     pub fn virtualizable_info(&self) -> Option<&std::sync::Arc<VirtualizableInfo>> {
         self.virtualizable_info.as_ref()

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
@@ -913,6 +913,10 @@ pub(crate) fn fbw_set_abort_call_resume(
             outer_jitcode_index,
             call_jitcode_pc,
             call_stack: stack,
+            // The latch is only set at the CALL, and only under the caller's
+            // zero-delta gate, so the odometer read here IS the count at the
+            // pc this carrier resumes at.
+            entry_executed_effects: fbw_executed_effect_count(),
         })
     });
 }
@@ -1110,14 +1114,16 @@ pub(crate) fn fbw_abort_nested_unjournaled_residual<Sym: WalkSym>(
         }
         // The flush this latch feeds resumes the OUTERMOST caller at the CALL
         // that entered the inline region, re-executing that call from scratch,
-        // while the walk's store journal is committed.  So it is sound only
-        // while the inline region has executed nothing irreversible: an
-        // executed-effect delta means the call would apply its effects a
-        // second time on top of the committed ones.  Same zero-delta gate the
-        // entry carrier applies at its own CALL (`try_walker_inline_user_call`)
-        // and the contract `FBW_EXECUTED_EFFECT_COUNT` documents; declining
-        // here leaves the legacy path, whose journal rollback makes the replay
-        // exactly-once.
+        // while the walk's store journal is committed — a
+        // `WalkEndResume::Rewind` leg.  So it is sound only while the inline
+        // region has executed nothing irreversible: an executed-effect delta
+        // means the call would apply its effects a second time on top of the
+        // committed ones.  Same zero-delta gate the entry carrier applies at
+        // its own CALL (`try_walker_inline_user_call`) and the contract
+        // `FBW_EXECUTED_EFFECT_COUNT` documents; declining here leaves the
+        // legacy path, whose journal rollback makes the replay exactly-once.
+        // The snapshot travels with the latch so `commit_walk_end` re-checks
+        // it at the commit point, not just here.
         let (outer_resume, stack_overrides) = {
             let session = ctx.session.borrow();
             let outermost = session
@@ -1126,9 +1132,13 @@ pub(crate) fn fbw_abort_nested_unjournaled_residual<Sym: WalkSym>(
                 .filter(|f| fbw_executed_effect_count() == f.entry_executed_effects);
             match outermost.and_then(|f| f.parent.as_ref()) {
                 Some(frame) => (
-                    frame
-                        .call_jitcode_pc
-                        .map(|jit_pc| (frame.jitcode_index, jit_pc)),
+                    frame.call_jitcode_pc.map(|jit_pc| {
+                        (
+                            frame.jitcode_index,
+                            jit_pc,
+                            crate::jitcode_dispatch::fbw_executed_effect_count(),
+                        )
+                    }),
                     frame.call_stack_overrides.clone(),
                 ),
                 None => (None, Vec::new()),
@@ -1149,7 +1159,10 @@ pub(crate) fn fbw_abort_nested_unjournaled_residual<Sym: WalkSym>(
 /// `abort_overrides`) until [`fbw_abort_outer_stack_overrides_clear`]; the
 /// flush reads them in place from the rooted cell so a minor collection while
 /// boxing Int/Float locals forwards the very refs it writes.
-pub(crate) fn fbw_abort_outer_resume_take() -> Option<(u32, usize)> {
+///
+/// The third element is the executed-effect odometer at the outer CALL this
+/// resumes at — `WalkEndResume::Rewind`'s `effects_at_resume_point`.
+pub(crate) fn fbw_abort_outer_resume_take() -> Option<(u32, usize, usize)> {
     FBW_ABORT_OUTER_RESUME.with(|c| c.replace(None))
 }
 

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
@@ -902,14 +902,26 @@ pub(crate) fn fbw_bump_executed_effect() {
     FBW_EXECUTED_EFFECT_COUNT.with(|c| c.set(c.get() + 1));
 }
 
-/// gh#467 latch the inline-abort forward-flush carrier (see [`FBW_ABORT_CALL_RESUME`]).
+/// gh#467 latch the inline-abort forward-flush carrier (see
+/// [`FBW_ABORT_CALL_RESUME`]).
+///
+/// Declines when a `MidBody` carrier is already latched.  Rebuilding the callee
+/// at its own pc and resuming the caller past its call is what upstream does
+/// (`blackhole.py:1799-1821`, `:1653-1662`); rewinding the caller TO the call
+/// has no upstream counterpart, so it stands in only for a callee the rebuild
+/// could not describe.  Both sites are `is_top_inline` on an aborting sub-walk,
+/// which ends the walk, so at most one of each is latched per walk.
 pub(crate) fn fbw_set_abort_call_resume(
     outer_jitcode_index: u32,
     call_jitcode_pc: usize,
     stack: Vec<pyre_object::PyObjectRef>,
 ) {
     FBW_ABORT_CALL_RESUME.with(|c| {
-        *c.borrow_mut() = Some(InlineAbortCarrier::Entry {
+        let mut slot = c.borrow_mut();
+        if matches!(&*slot, Some(InlineAbortCarrier::MidBody(_))) {
+            return;
+        }
+        *slot = Some(InlineAbortCarrier::Entry {
             outer_jitcode_index,
             call_jitcode_pc,
             call_stack: stack,

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
@@ -905,12 +905,14 @@ pub(crate) fn fbw_bump_executed_effect() {
 /// gh#467 latch the inline-abort forward-flush carrier (see
 /// [`FBW_ABORT_CALL_RESUME`]).
 ///
-/// Declines when a `MidBody` carrier is already latched.  Rebuilding the callee
-/// at its own pc and resuming the caller past its call is what upstream does
+/// Does not displace an already-latched `MidBody` carrier — it is stored inside
+/// it as [`MidBodyPayload::entry_fallback`] instead.  Rebuilding the callee at
+/// its own pc and resuming the caller past its call is what upstream does
 /// (`blackhole.py:1799-1821`, `:1653-1662`); rewinding the caller TO the call
 /// has no upstream counterpart, so it stands in only for a callee the rebuild
-/// could not describe.  Both sites are `is_top_inline` on an aborting sub-walk,
-/// which ends the walk, so at most one of each is latched per walk.
+/// could not describe or could not flush.  Both sites are `is_top_inline` on an
+/// aborting sub-walk, which ends the walk, so at most one of each is latched
+/// per walk, and both read the same outer CALL coordinate.
 pub(crate) fn fbw_set_abort_call_resume(
     outer_jitcode_index: u32,
     call_jitcode_pc: usize,
@@ -918,7 +920,15 @@ pub(crate) fn fbw_set_abort_call_resume(
 ) {
     FBW_ABORT_CALL_RESUME.with(|c| {
         let mut slot = c.borrow_mut();
-        if matches!(&*slot, Some(InlineAbortCarrier::MidBody(_))) {
+        if let Some(InlineAbortCarrier::MidBody(payload)) = slot.as_mut() {
+            if payload.outer_jitcode_index == outer_jitcode_index
+                && payload.call_jitcode_pc == call_jitcode_pc
+            {
+                payload.entry_fallback = Some(crate::jitcode_dispatch::EntryFallback {
+                    call_stack: stack,
+                    entry_executed_effects: fbw_executed_effect_count(),
+                });
+            }
             return;
         }
         *slot = Some(InlineAbortCarrier::Entry {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -2726,10 +2726,6 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
                         }
                         *dst = Some(value);
                     }
-                    let Some(ConcreteValue::Ref(x_arg)) = callee_arg_concretes.first().copied()
-                    else {
-                        return Err("first callee argument is not a Ref");
-                    };
                     Ok(MidBodyPayload {
                         abort_kind,
                         outer_jitcode_index,
@@ -2740,7 +2736,6 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
                         callee_py_pc,
                         w_code: w_code as pyre_object::PyObjectRef,
                         w_globals: unsafe { pyre_interpreter::function_get_globals_obj(callable) },
-                        x_arg,
                         live_locals,
                         live_stack,
                         return_value: pyre_object::PY_NULL,

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -2680,18 +2680,19 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
                         let register_value =
                             crate::state::semantic_slot_color_for_ref_slot(&entries, semantic_slot)
                                 .and_then(|color| sub_wc.concrete_registers_r.get(color).copied());
-                        let value = register_value.or_else(|| {
-                            (metadata.built_as_portal && abort_kind == MidBodyAbortKind::Marker)
-                                .then(|| {
-                                    callee_vable_ref_at(
-                                        sub_wc.callee_shadow.as_ref(),
-                                        metadata.portal_frame_reg,
-                                        semantic_slot,
-                                    )
-                                })
-                                .flatten()
-                        })
-                        .ok_or("live stack slot has no concrete value")?;
+                        let value = register_value
+                            .or_else(|| {
+                                (metadata.built_as_portal && abort_kind == MidBodyAbortKind::Marker)
+                                    .then(|| {
+                                        callee_vable_ref_at(
+                                            sub_wc.callee_shadow.as_ref(),
+                                            metadata.portal_frame_reg,
+                                            semantic_slot,
+                                        )
+                                    })
+                                    .flatten()
+                            })
+                            .ok_or("live stack slot has no concrete value")?;
                         if !matches!(value, ConcreteValue::Ref(r) if !r.is_null()) {
                             return Err("live stack slot is not a non-null Ref");
                         }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -2625,22 +2625,28 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
                         crate::state::pyjitcode_for_code(w_code).ok_or("no callee pyjitcode")?;
                     let metadata = &callee_pjc.metadata;
                     let callee_py_pc = python_pc_for_jitcode_pc(metadata, abort_pc) as usize;
-                    let anchor_ok = match abort_kind {
-                        MidBodyAbortKind::Structural => {
-                            exact_floor_segment_anchor(metadata, callee_py_pc, abort_pc)
-                        }
-                        MidBodyAbortKind::Marker => portal_marker_first_jit_anchor(
-                            metadata,
-                            metadata.built_as_portal,
-                            metadata.portal_frame_reg,
-                            callee_perfn_descrs,
-                            body.code,
-                            callee_py_pc,
-                            abort_pc,
-                            |op_pc| python_pc_for_jitcode_pc(metadata, op_pc) as usize,
-                        ),
-                    };
+                    // Both abort kinds sit at the head of an opcode the walker
+                    // could not take, behind at most that opcode's own vable
+                    // spill; the marker kind is the narrower of the two.
+                    let anchor_ok = portal_vable_bookkeeping_anchor(
+                        metadata,
+                        metadata.built_as_portal,
+                        metadata.portal_frame_reg,
+                        callee_perfn_descrs,
+                        body.code,
+                        callee_py_pc,
+                        abort_pc,
+                        |op_pc| python_pc_for_jitcode_pc(metadata, op_pc) as usize,
+                    );
                     if !anchor_ok {
+                        if fbw_debug_abort_enabled() {
+                            eprintln!(
+                                "[fbw-abort-flush] gh#467 inexact anchor at abort_pc={abort_pc} \
+                                 callee_py_pc={callee_py_pc} kind={abort_kind:?} \
+                                 would re-run {:?}",
+                                floor_segment_ops_before(metadata, body.code, abort_pc),
+                            );
+                        }
                         return Err("abort pc is not an exact segment anchor");
                     }
                     let raw = unsafe {
@@ -2738,6 +2744,10 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
                         live_locals,
                         live_stack,
                         return_value: pyre_object::PY_NULL,
+                        // Attached later by `fbw_set_abort_call_resume`, which
+                        // runs in the Err arm below under the entry latch's own
+                        // zero-delta gate.
+                        entry_fallback: None,
                     })
                 })();
                 match payload {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -2604,13 +2604,25 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
             // is sampled before the sub-walk and cannot see such a mark; read
             // the flags again, as the loop-header, abort-pc and branch-guard
             // legs do.
-            if is_top_inline
-                && !fbw_has_unjournaled_effect()
-                && fbw_executed_effect_count() != executed_effects_before
-            {
+            //
+            // Attempted whether or not the callee executed anything.
+            // `convert_and_run_from_pyjitpl` (`blackhole.py:1799-1821`) rebuilds
+            // every framestack frame at its own pc unconditionally —
+            // `run_blackhole_interp_to_cancel_tracing` ends `assert False`
+            // (`pyjitpl.py:2956`) — and the caller is resumed PAST its call
+            // (`blackhole.py:1653-1662`), never rewound to it.  The entry
+            // carrier's rewind-to-the-CALL has no upstream counterpart, so it
+            // is the fallback for a callee this one cannot rebuild, not the
+            // preferred leg; `fbw_set_abort_call_resume` keeps that ordering.
+            if is_top_inline && !fbw_has_unjournaled_effect() {
+                // Each refusal names itself so the debug log can say WHICH
+                // narrowing keeps a callee off this leg — the entry carrier
+                // silently absorbs every one of them.
                 let payload = (|| {
-                    let (outer_jitcode_index, call_jitcode_pc) = abort_flush_call_jitcode_coord?;
-                    let callee_pjc = crate::state::pyjitcode_for_code(w_code)?;
+                    let (outer_jitcode_index, call_jitcode_pc) =
+                        abort_flush_call_jitcode_coord.ok_or("no call jitcode coord")?;
+                    let callee_pjc =
+                        crate::state::pyjitcode_for_code(w_code).ok_or("no callee pyjitcode")?;
                     let metadata = &callee_pjc.metadata;
                     let callee_py_pc = python_pc_for_jitcode_pc(metadata, abort_pc) as usize;
                     let anchor_ok = match abort_kind {
@@ -2629,33 +2641,33 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
                         ),
                     };
                     if !anchor_ok {
-                        return None;
+                        return Err("abort pc is not an exact segment anchor");
                     }
                     let raw = unsafe {
                         pyre_interpreter::w_code_get_ptr(w_code as pyre_object::PyObjectRef)
                             as *const pyre_interpreter::CodeObject
                     };
                     if raw.is_null() {
-                        return None;
+                        return Err("null callee code ptr");
                     }
                     let callee_code = unsafe { &*raw };
-                    if pyre_interpreter::pyframe::code_flags_make_generator(callee_code.flags)
-                        || !callee_code.cellvars.is_empty()
-                        || !callee_code.freevars.is_empty()
-                        || !unsafe { pyre_interpreter::function_get_closure(callable) }.is_null()
-                    {
-                        return None;
+                    if pyre_interpreter::pyframe::code_flags_make_generator(callee_code.flags) {
+                        return Err("callee is a generator");
                     }
-                    let depth_twin = callee_pjc.depth_for_jitcode_pc_pred(abort_pc);
-                    let Some(depth) = depth_twin else {
-                        return None;
-                    };
-                    let depth = depth as usize;
+                    if !callee_code.cellvars.is_empty() || !callee_code.freevars.is_empty() {
+                        return Err("callee has cellvars/freevars");
+                    }
+                    if !unsafe { pyre_interpreter::function_get_closure(callable) }.is_null() {
+                        return Err("callee has a closure");
+                    }
+                    let depth = callee_pjc
+                        .depth_for_jitcode_pc_pred(abort_pc)
+                        .ok_or("no stack depth for the abort pc")?
+                        as usize;
                     let nlocals = callee_code.varnames.len();
-                    let pcdep_twin = callee_pjc.pcdep_for_jitcode_pc(abort_pc);
-                    let Some(entries) = pcdep_twin else {
-                        return None;
-                    };
+                    let entries = callee_pjc
+                        .pcdep_for_jitcode_pc(abort_pc)
+                        .ok_or("no pcdep entries for the abort pc")?;
                     let mut live_stack = Vec::with_capacity(depth);
                     for rel in 0..depth {
                         let semantic_slot = nlocals + rel;
@@ -2672,14 +2684,15 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
                                     )
                                 })
                                 .flatten()
-                        })?;
+                        })
+                        .ok_or("live stack slot has no concrete value")?;
                         if !matches!(value, ConcreteValue::Ref(r) if !r.is_null()) {
-                            return None;
+                            return Err("live stack slot is not a non-null Ref");
                         }
                         live_stack.push(value);
                     }
                     if live_stack.len() != depth {
-                        return None;
+                        return Err("live stack depth mismatch");
                     }
                     let lv = crate::state::liveness_for(raw);
                     let mut live_locals = vec![None; nlocals];
@@ -2700,17 +2713,18 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
                                 Value::Float(v) => Some(ConcreteValue::Float(v)),
                                 Value::Void => None,
                             })
-                            .or_else(|| callee_arg_concretes.get(slot).copied())?;
+                            .or_else(|| callee_arg_concretes.get(slot).copied())
+                            .ok_or("live local has no concrete value")?;
                         if matches!(value, ConcreteValue::Null | ConcreteValue::Bool(_)) {
-                            return None;
+                            return Err("live local is Null/Bool");
                         }
                         *dst = Some(value);
                     }
                     let Some(ConcreteValue::Ref(x_arg)) = callee_arg_concretes.first().copied()
                     else {
-                        return None;
+                        return Err("first callee argument is not a Ref");
                     };
-                    Some(MidBodyPayload {
+                    Ok(MidBodyPayload {
                         abort_kind,
                         outer_jitcode_index,
                         call_jitcode_pc,
@@ -2726,8 +2740,16 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
                         return_value: pyre_object::PY_NULL,
                     })
                 })();
-                if let Some(payload) = payload {
-                    fbw_set_midbody_abort_resume(payload);
+                match payload {
+                    Ok(payload) => fbw_set_midbody_abort_resume(payload),
+                    Err(reason) => {
+                        if fbw_debug_abort_enabled() {
+                            eprintln!(
+                                "[fbw-abort-flush] gh#467 callee-rebuild NOT LATCHED at \
+                                 abort_pc={abort_pc} ({reason})"
+                            );
+                        }
+                    }
                 }
             }
         }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -4668,7 +4668,9 @@ thread_local! {
     /// [`fbw_abort_nested_unjournaled_residual`] at the nested-inline decline,
     /// read back by the trace loop after the walk unwinds
     /// ([`fbw_abort_outer_resume_take`]) to drive the abort-point flush.
-    static FBW_ABORT_OUTER_RESUME: std::cell::Cell<Option<(u32, usize)>> =
+    /// The trailing `usize` is the executed-effect odometer at that CALL, the
+    /// `WalkEndResume::Rewind` snapshot the flush re-checks before committing.
+    static FBW_ABORT_OUTER_RESUME: std::cell::Cell<Option<(u32, usize, usize)>> =
         const { std::cell::Cell::new(None) };
     static FBW_ABORT_OUTER_STACK_OVERRIDES: std::cell::RefCell<Vec<(usize, pyre_object::PyObjectRef)>> =
         const { std::cell::RefCell::new(Vec::new()) };
@@ -4998,6 +5000,12 @@ pub(crate) enum InlineAbortCarrier {
         outer_jitcode_index: u32,
         call_jitcode_pc: usize,
         call_stack: Vec<pyre_object::PyObjectRef>,
+        /// [`FBW_EXECUTED_EFFECT_COUNT`] at the CALL this carrier resumes at,
+        /// sampled when the latch was set.  The flush that consumes this
+        /// carrier re-executes that CALL, so it is
+        /// [`crate::trace::WalkEndResume::Rewind`] and must prove the odometer
+        /// has not moved since.
+        entry_executed_effects: usize,
     },
     MidBody(MidBodyPayload),
 }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -5034,7 +5034,6 @@ pub(crate) struct MidBodyPayload {
     pub callee_py_pc: usize,
     pub w_code: pyre_object::PyObjectRef,
     pub w_globals: pyre_object::PyObjectRef,
-    pub x_arg: pyre_object::PyObjectRef,
     pub live_locals: Vec<Option<ConcreteValue>>,
     pub live_stack: Vec<ConcreteValue>,
     pub return_value: pyre_object::PyObjectRef,
@@ -5446,9 +5445,6 @@ pub unsafe fn fbw_store_journal_root_walker_area(
                 });
                 visitor(unsafe {
                     &mut *(&mut payload.w_globals as *mut pyre_object::PyObjectRef).cast()
-                });
-                visitor(unsafe {
-                    &mut *(&mut payload.x_arg as *mut pyre_object::PyObjectRef).cast()
                 });
                 if !payload.return_value.is_null() {
                     visitor(unsafe {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -5038,6 +5038,20 @@ pub(crate) struct MidBodyPayload {
     pub live_locals: Vec<Option<ConcreteValue>>,
     pub live_stack: Vec<ConcreteValue>,
     pub return_value: pyre_object::PyObjectRef,
+    /// What [`InlineAbortCarrier::Entry`] would have carried for the same
+    /// abort.  The rebuild is preferred, but it can still decline at the flush
+    /// (an unsourceable outer local, a handler-bearing body); dropping to the
+    /// legacy replay there would re-open the double-apply this carrier family
+    /// exists to close, so the entry rewind stands behind it.  `None` when the
+    /// entry latch's own gate refused.
+    pub entry_fallback: Option<EntryFallback>,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct EntryFallback {
+    pub call_stack: Vec<pyre_object::PyObjectRef>,
+    /// See [`InlineAbortCarrier::Entry::entry_executed_effects`].
+    pub entry_executed_effects: usize,
 }
 
 struct FbwStoreJournalRootArea {
@@ -5103,14 +5117,57 @@ fn exact_floor_segment_anchor(
         .is_some_and(|(start, py)| start == jit_pc && py as usize == py_pc)
 }
 
-/// Admit a marker at the semantic head of a portal-shaped Python opcode.
-/// `serialize_op` keeps the first op for a Python pc, so the
-/// `setfield_vable_i(last_instr)` emitted immediately before
-/// `abort_permanent` owns the exact anchor slot. The write is entry
-/// bookkeeping: forward interpretation repeats it before executing the
-/// unsupported opcode. Anything except that same-pc write to this portal
-/// frame declines.
-fn portal_marker_first_jit_anchor(
+/// The jitcode ops the callee-rebuild leg would re-run if it resumed at the
+/// Python pc owning `jit_pc` — everything from that pc's floor-segment start up
+/// to `jit_pc`.  Empty exactly when [`exact_floor_segment_anchor`] holds, so a
+/// non-empty list names what makes the anchor inexact.
+pub(crate) fn floor_segment_ops_before(
+    metadata: &crate::PyJitCodeMetadata,
+    code: &[u8],
+    jit_pc: usize,
+) -> Vec<String> {
+    let Some((mut pc, _py)) =
+        crate::pyjitcode::floor_segment_for_jitcode_pc(&metadata.py_floor_by_jit_pc, jit_pc)
+    else {
+        return vec!["<no floor segment>".to_string()];
+    };
+    let mut keys = Vec::new();
+    while pc < jit_pc {
+        let Some(op) = crate::jitcode_runtime::decode_op_at(code, pc) else {
+            keys.push("<undecodable>".to_string());
+            break;
+        };
+        keys.push(format!(
+            "{}@f{}",
+            op.key,
+            code.get(op.pc + 1).copied().unwrap_or(u8::MAX)
+        ));
+        pc = op.next_pc;
+    }
+    keys
+}
+
+/// Admit an abort pc at the semantic head of a portal-shaped Python opcode —
+/// that is, one whose whole jitcode prefix inside its own floor segment writes
+/// nothing but THIS frame's own virtualizable: operand-stack slots
+/// (`setarrayitem_vable_r`) and the two int bookkeeping fields,
+/// `last_instr`/`valuestackdepth` (`setfield_vable_i`).
+///
+/// The callee-rebuild leg reconstructs the frame wholesale — a fresh `PyFrame`
+/// whose locals, stack area, `valuestackdepth` and `last_instr` all come from
+/// the carried payload — so every one of those writes is erased before the
+/// rebuilt frame runs, and the resume state at `py_pc` is unaffected by how far
+/// into the opcode's spill the walk got.  `live_stack`'s depth is
+/// `depth_at_py_pc[py_pc]` (`depth_for_jitcode_pc_pred` is keyed per Python pc),
+/// i.e. the depth BEFORE the opcode, which is what resuming at `py_pc` needs.
+///
+/// `getarrayitem_vable_r` is NOT admitted even though it too only reads the
+/// vable: it writes a jitcode REGISTER, and the payload sources `live_stack`
+/// and `live_locals` out of `concrete_registers_r` by color.  A clobbered color
+/// would be read back as a live value.
+///
+/// Anything else, or a write aimed at another frame, declines.
+fn portal_vable_bookkeeping_anchor(
     metadata: &crate::PyJitCodeMetadata,
     built_as_portal: bool,
     portal_frame_reg: u16,
@@ -5140,23 +5197,33 @@ fn portal_marker_first_jit_anchor(
         };
         if op.next_pc > jit_pc
             || python_pc_for_op(op.pc) != py_pc
-            || op.key != "setfield_vable_i/rid"
             || code.get(op.pc + 1).copied() != Some(portal_frame_reg as u8)
         {
             return false;
         }
-        // `rid`: opcode, frame reg, value reg, little-endian descr index.
-        let Some((&lo, &hi)) = code.get(op.pc + 3).zip(code.get(op.pc + 4)) else {
-            return false;
-        };
-        let descr_index = lo as usize | ((hi as usize) << 8);
-        if !matches!(
-            perfn_descrs.get(descr_index),
-            Some(majit_metainterp::jitcode::RuntimeBhDescr::Descr(
-                majit_translate::jitcode::BhDescr::VableField { index: 0 }
-            ))
-        ) {
-            return false;
+        match op.key {
+            // Which stack slot a spill addresses does not matter: the whole
+            // stack area is rewritten from `live_stack`.
+            "setarrayitem_vable_r/rirdd" => {}
+            // `rid`: opcode, frame reg, value reg, little-endian descr index.
+            // The int vable fields are `last_instr` (0) and `valuestackdepth`
+            // (2), both reassigned by the rebuild; a non-`VableField` descr is
+            // not frame bookkeeping.
+            "setfield_vable_i/rid" => {
+                let Some((&lo, &hi)) = code.get(op.pc + 3).zip(code.get(op.pc + 4)) else {
+                    return false;
+                };
+                let descr_index = lo as usize | ((hi as usize) << 8);
+                if !matches!(
+                    perfn_descrs.get(descr_index),
+                    Some(majit_metainterp::jitcode::RuntimeBhDescr::Descr(
+                        majit_translate::jitcode::BhDescr::VableField { .. }
+                    ))
+                ) {
+                    return false;
+                }
+            }
+            _ => return false,
         }
         pc = op.next_pc;
     }
@@ -5396,6 +5463,11 @@ pub unsafe fn fbw_store_journal_root_walker_area(
                 for slot in &mut payload.live_stack {
                     if let ConcreteValue::Ref(value) = slot {
                         visitor(unsafe { &mut *(value as *mut pyre_object::PyObjectRef).cast() });
+                    }
+                }
+                if let Some(fallback) = payload.entry_fallback.as_mut() {
+                    for slot in &mut fallback.call_stack {
+                        visitor(unsafe { &mut *(slot as *mut pyre_object::PyObjectRef).cast() });
                     }
                 }
             }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -5936,6 +5936,13 @@ pub(crate) unsafe fn resolve_inlinable_callee(
         if raw.is_null() {
             return None;
         }
+        // Calling a generator / coroutine / async-generator function does NOT
+        // run its body — it builds the iterator and returns.  Inlining the
+        // body at the call site walks code the call never reaches, so the
+        // attempt can only end in an abort that discards the whole trace.
+        if pyre_interpreter::pyframe::code_flags_make_generator((*raw).flags) {
+            return None;
+        }
         let closure = pyre_interpreter::function_get_closure(callable);
         Some((w_code, (*raw).arg_count as usize, !closure.is_null()))
     }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -46,16 +46,29 @@ thread_local! {
     /// adopt the committed resume pc must restore this first.
     static ESCAPE_FLUSH_UNDO: std::cell::RefCell<Option<EscapeFlushUndo>> =
         const { std::cell::RefCell::new(None) };
-    /// Opcode-scoped effect window: `(py_pc, frame_entry_count,
-    /// executed_effect_count)` sampled at the FIRST residual of the Python
-    /// opcode currently being walked.  Re-executing a committed escape re-runs
-    /// the WHOLE opcode, so the latch gate must know whether any EARLIER
-    /// residual of the same opcode ran user bytecode or committed an effect —
-    /// not just the escaping one (rich-compare fallback chains run two
-    /// residuals in one opcode).  Reset at walk start; concrete effects only
-    /// happen through residuals, so anchoring the window at the first residual
-    /// loses nothing.
-    static ESCAPE_OPCODE_WINDOW: std::cell::Cell<Option<(usize, u64, usize)>> =
+    /// Opcode-scoped purity window: `(py_pc, every_prior_residual_reentrant)`
+    /// for the Python opcode currently being walked.  Re-executing a committed
+    /// escape re-runs the WHOLE opcode, so the latch gate must know whether any
+    /// EARLIER residual of the same opcode could have done something — not just
+    /// the escaping one (rich-compare fallback chains run two residuals in one
+    /// opcode).
+    ///
+    /// The verdict comes from each residual's DECLARED effect class
+    /// ([`escape_opcode_window_note`], `EffectInfo::check_is_elidable` or
+    /// `LoopInvariant`), not from counting what happened.  That is the axis
+    /// upstream decides on: the licence to place a resume pc behind an executed
+    /// residual is the codewriter-time `EF_ELIDABLE_CANNOT_RAISE` registration
+    /// (`jtransform.py:620-630`), and upstream's only op counters are
+    /// profiling-only and gate nothing (`jitprof.py:43-44`, `count_ops` is
+    /// `pass`).
+    ///
+    /// Reset at walk start.  Residuals are the only executor that can put
+    /// something irreversible between two points of ONE opcode: the eager
+    /// journaled folds (`fbw_store_journal_push` / `fbw_append_journal_push` /
+    /// `fbw_cell_store_journal_push`) each terminate their own opcode
+    /// (STORE_SUBSCR, the `append` CALL, STORE_NAME/STORE_GLOBAL), so no
+    /// residual of the same opcode instance can follow one.
+    static ESCAPE_OPCODE_WINDOW: std::cell::Cell<Option<(usize, bool)>> =
         const { std::cell::Cell::new(None) };
     /// C3 S1 force-time image of the single live tracing frame.  The
     /// color-indexed concrete banks cease to exist when dispatch unwinds, so
@@ -578,23 +591,41 @@ pub(crate) fn discard_escape_flush_undo() {
 }
 
 /// Opcode-scoped effect window check (see [`ESCAPE_OPCODE_WINDOW`]): true iff
-/// no earlier residual of the CURRENT Python opcode entered a user frame or
-/// committed a concrete effect.  Opens the window on the first residual of
-/// each opcode.  Keyed on `py_pc` alone: an opcode revisited across walked
-/// inner-loop iterations compares against the FIRST visit's snapshot, so
-/// every revisit after any effect declines the latch — conservative (decline
-/// → legacy).  An unexplained latch-decline spike on nested-loop shapes is
-/// this; the refinement would reset the window on back-edge re-entry.
+/// every earlier residual of the CURRENT Python opcode is declared re-runnable.
+/// A pure query — the window is written only by [`escape_opcode_window_note`],
+/// so the residual asking the question never disqualifies itself.
+///
+/// Keyed on `py_pc` alone: an opcode revisited across walked inner-loop
+/// iterations still sees the FIRST visit's verdict, so every revisit after any
+/// non-re-runnable residual declines the latch — conservative (decline →
+/// legacy).  An unexplained latch-decline spike on nested-loop shapes is this;
+/// the refinement would reset the window on back-edge re-entry.
 fn escape_opcode_window_clean(py_pc: usize) -> bool {
-    let frames = pyre_interpreter::call::frame_entry_count();
-    let effects = fbw_executed_effect_count();
     ESCAPE_OPCODE_WINDOW.with(|slot| match slot.get() {
-        Some((pc, f, e)) if pc == py_pc => f == frames && e == effects,
-        _ => {
-            slot.set(Some((py_pc, frames, effects)));
-            true
-        }
+        Some((pc, clean)) if pc == py_pc => clean,
+        _ => true,
     })
+}
+
+/// Declare this residual's re-runnability into the opcode window (see
+/// [`ESCAPE_OPCODE_WINDOW`]).  Called for every residual that reaches
+/// execution, AFTER the latch gate has read the window.
+///
+/// `reentrant` is the declared effect class, `EF_ELIDABLE_*`
+/// (`check_is_elidable`) or `EF_LOOPINVARIANT`.  It is deliberately STRICTER
+/// than `provably_side_effect_free`, which additionally exempts
+/// [`majit_ir::PyreHelperKind::ForIterNext`]: that exemption answers a
+/// different question (the consume is the SOURCE of an in-flight item, not a
+/// body effect for it), and a user-defined `__next__` runs user bytecode that
+/// re-executing the opcode would re-run.
+fn escape_opcode_window_note(py_pc: usize, reentrant: bool) {
+    ESCAPE_OPCODE_WINDOW.with(|slot| {
+        let clean = match slot.get() {
+            Some((pc, clean)) if pc == py_pc => clean,
+            _ => true,
+        };
+        slot.set(Some((py_pc, clean && reentrant)));
+    });
 }
 
 /// Reset the opcode window at walk start so a prior trace's sample cannot
@@ -1627,9 +1658,14 @@ pub(crate) fn try_execute_residual_call_via_executor<Sym: WalkSym>(
     // consume.
     let ei = call_descr.get_extra_info();
     let helper = ei.pyre_helper;
-    let provably_side_effect_free = ei.check_is_elidable()
-        || ei.extraeffect == majit_ir::ExtraEffect::LoopInvariant
-        || helper == majit_ir::PyreHelperKind::ForIterNext;
+    // The declared re-runnability class, the axis `EffectInfo` is decided on at
+    // codewriter time (`jtransform.py:620-630`): re-executing the opcode that
+    // contains this residual re-executes the residual, which is harmless only
+    // for an elidable or loop-hoisted one.  Feeds [`ESCAPE_OPCODE_WINDOW`].
+    let reentrant_residual =
+        ei.check_is_elidable() || ei.extraeffect == majit_ir::ExtraEffect::LoopInvariant;
+    let provably_side_effect_free =
+        reentrant_residual || helper == majit_ir::PyreHelperKind::ForIterNext;
     let writes_live_heap = call_descr.result_type() == majit_ir::Type::Void
         || matches!(
             helper,
@@ -1786,6 +1822,11 @@ pub(crate) fn try_execute_residual_call_via_executor<Sym: WalkSym>(
         let _suspend = majit_metainterp::TraceContinuationSuspendGuard::enter();
         majit_metainterp::executor::execute_residual_call(call_descr, func_ptr, &args)
     };
+    // Declared only now, so this residual constrains the residuals that FOLLOW
+    // it inside the same opcode and never itself: the gate above read the
+    // window, and a force inside the callee reads it again from
+    // `flush_active_frame_escape` while it is still the gate's view.
+    escape_opcode_window_note(ctx.vstack_cur_pypc as usize, reentrant_residual);
     if !provably_side_effect_free && !is_idempotent_gc_barrier {
         fbw_mark_executed_nonpure_residual();
         // Count only a FOREIGN non-pure residual: a self-recursive call is the

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -662,6 +662,40 @@ fn flush_escape_state_with_latched_stack(ctx: &TraceCtx, frame: usize, py_pc: us
                 _ => return false,
             }
         }
+        // Why this latch exists, checkable at runtime.  `vable_setfield` and
+        // `vable_setarrayitem_indexed` both end in `synchronize_virtualizable`
+        // (`pyjitpl.py:1194`, `:1246`), so any slot a push actually stored IS
+        // current in the shadow.  Measured over pyre/bench/synth the only slot
+        // that ever disagrees is the in-progress opcode's TOS, and it always
+        // reads back NULL rather than a stale value — the store never happened.
+        //
+        // `pyframe.pushvalue` is two writes: `locals_cells_stack_w[depth] =
+        // w_object` and `valuestackdepth = depth + 1`, lowered by
+        // `jtransform.py:1898` `do_fixed_list_setitem` and `:844` respectively.
+        // `emit_load_fast_ref` emits both; the generic `push_and_bump!` that
+        // every residual-call and HLOp result goes through emits only the
+        // depth bump, so a value produced mid-opcode never reaches the array.
+        // That missing store is what this latch stands in for.
+        if fbw_debug_abort_enabled() {
+            let base = ctx
+                .virtualizable_info()
+                .map_or(usize::MAX, |info| info.num_static_extra_boxes);
+            let nlocals = crate::state::concrete_nlocals(frame).unwrap_or(usize::MAX);
+            for (rel, &obj) in stack.iter().enumerate() {
+                let shadow = ctx
+                    .virtualizable_entry_at(base.saturating_add(nlocals).saturating_add(rel))
+                    .map(|(_opref, value)| value);
+                let agrees =
+                    matches!(shadow, Some(majit_ir::Value::Ref(r)) if r.as_usize() == obj as usize);
+                if !agrees {
+                    eprintln!(
+                        "[r6-latch] slot {rel}/{} latched=0x{:x} shadow={shadow:?} (DISAGREES)",
+                        stack.len(),
+                        obj as usize,
+                    );
+                }
+            }
+        }
         // The flush's Int/Float local boxing can trigger a minor collection;
         // register the resolved refs as resume roots so they are forwarded in
         // place across it (the same discipline as the vable root above).

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -17,12 +17,27 @@
 
 use super::*;
 
+/// Which of [`flush_active_frame_escape`]'s two flushes committed the resume
+/// pc.  They differ in exactly the way the walk-end commit contract cares
+/// about, so the epilogue cannot classify the leg without being told.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum EscapeResumeKind {
+    /// The latched mid-expression operand stack resolved.  The resume pc still
+    /// re-runs the escaping opcode — both flushes take the same `py_pc` and the
+    /// same `last_instr = py_pc - 1` — but this path is gated:
+    /// [`escape_opcode_window_clean`] ran at the residual before the latch.
+    Exact,
+    /// The latch did not resolve and the flush fell back to the merge-point
+    /// state.  Same resume pc, but NO gate ran on this path at any point.
+    RerunsOpcode,
+}
+
 thread_local! {
     static ACTIVE_FRAME_ESCAPE: std::cell::Cell<Option<(usize, usize)>> =
         const { std::cell::Cell::new(None) };
     static ACTIVE_FRAME_ESCAPE_STACK: std::cell::RefCell<Option<Vec<OpRef>>> =
         const { std::cell::RefCell::new(None) };
-    static COMMITTED_FRAME_ESCAPE_PC: std::cell::Cell<Option<usize>> =
+    static COMMITTED_FRAME_ESCAPE_PC: std::cell::Cell<Option<(usize, EscapeResumeKind)>> =
         const { std::cell::Cell::new(None) };
     /// Pre-flush frame state captured by [`flush_active_frame_escape`] so a
     /// post-call commit withdrawal can put the live frame back.  The legacy
@@ -486,7 +501,12 @@ pub fn flush_active_frame_escape(ctx: &TraceCtx, frame: *mut pyre_interpreter::P
                 }
             }
             if flushed {
-                COMMITTED_FRAME_ESCAPE_PC.with(|committed| committed.set(Some(py_pc)));
+                let kind = if latched {
+                    EscapeResumeKind::Exact
+                } else {
+                    EscapeResumeKind::RerunsOpcode
+                };
+                COMMITTED_FRAME_ESCAPE_PC.with(|committed| committed.set(Some((py_pc, kind))));
             } else {
                 // All-or-nothing decline: nothing was written, nothing to undo.
                 discard_escape_flush_undo();
@@ -628,11 +648,13 @@ fn flush_escape_state_with_latched_stack(ctx: &TraceCtx, frame: usize, py_pc: us
     })
 }
 
-pub fn take_committed_frame_escape_pc() -> Option<usize> {
+/// Take the committed escape resume pc and which flush produced it (the
+/// walk-end commit contract turns on the difference — see [`EscapeResumeKind`]).
+pub(crate) fn take_committed_frame_escape_pc() -> Option<(usize, EscapeResumeKind)> {
     COMMITTED_FRAME_ESCAPE_PC.with(|slot| slot.take())
 }
 
-fn committed_frame_escape_pc() -> Option<usize> {
+fn committed_frame_escape_pc() -> Option<(usize, EscapeResumeKind)> {
     COMMITTED_FRAME_ESCAPE_PC.with(|slot| slot.get())
 }
 
@@ -1672,9 +1694,12 @@ pub(crate) fn try_execute_residual_call_via_executor<Sym: WalkSym>(
     // it is not a body effect: keep it out of the R1 in-flight-FOR_ITER
     // accounting so an escaping residual later in the same body does not
     // refuse-drop the whole iteration.
-    // `vstack_cur_pypc` points one past the executing op (next-instr
-    // convention), while `body_pc` is the store's own py_pc, so the loop-var
-    // store satisfies `vstack_cur_pypc == body_pc + 1`.
+    // `vstack_cur_pypc` is the pc the walk is ABOUT TO ENTER
+    // (`reconcile_vstack_at_boundary` sets it to `new_pypc` after reconciling
+    // the PREVIOUS opcode), so at this residual it names the opcode being
+    // walked.  The loop-var store is recognised by the FOR_ITER body's own
+    // relation `body_pc + 1 == vstack_cur_pypc`, i.e. the walk has advanced one
+    // opcode past the recorded body pc — not by a next-instr convention.
     let is_loop_var_binding_store = matches!(
         helper,
         majit_ir::PyreHelperKind::StoreName | majit_ir::PyreHelperKind::StoreGlobal

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -662,36 +662,43 @@ fn flush_escape_state_with_latched_stack(ctx: &TraceCtx, frame: usize, py_pc: us
                 _ => return false,
             }
         }
-        // Why this latch exists, checkable at runtime.  `vable_setfield` and
-        // `vable_setarrayitem_indexed` both end in `synchronize_virtualizable`
-        // (`pyjitpl.py:1194`, `:1246`), so any slot a push actually stored IS
-        // current in the shadow.  Measured over pyre/bench/synth the only slot
-        // that ever disagrees is the in-progress opcode's TOS, and it always
-        // reads back NULL rather than a stale value — the store never happened.
+        // Why this latch exists, checkable at runtime.  Measured over
+        // pyre/bench/synth, the only slot that ever disagrees with the vable
+        // shadow is the in-progress opcode's TOS, and it holds a compile-time
+        // NULL *constant* rather than a stale or absent value: exactly what
+        // `popvalue_maybe_none` writes (`pyframe.py:411-417` →
+        // `setarrayitem_vable_r(locals_cells_stack_w, depth, ConstPtr.NULL)`
+        // via `jtransform.py:1898`).  The opcode had already popped the slot
+        // before its residual forced.
         //
-        // `pyframe.pushvalue` is two writes: `locals_cells_stack_w[depth] =
-        // w_object` and `valuestackdepth = depth + 1`, lowered by
-        // `jtransform.py:1898` `do_fixed_list_setitem` and `:844` respectively.
-        // `emit_load_fast_ref` emits both; the generic `push_and_bump!` that
-        // every residual-call and HLOp result goes through emits only the
-        // depth bump, so a value produced mid-opcode never reaches the array.
-        // That missing store is what this latch stands in for.
+        // So the array is correct and upstream agrees — RPython's `popvalue`
+        // NULLs the slot the same way.  What this latch holds is the operand
+        // the in-flight opcode already consumed, which is what upstream keeps
+        // in `MIFrame.registers_r` and what `convert_and_run_from_pyjitpl`
+        // resumes a blackhole from.  Emitting more vable stores does not
+        // remove the need for it: `LOAD_ATTR` already emits the push mirror
+        // via `emit_pushvalue_ref!` and its slot still reads NULL, because the
+        // pop follows the push.
         if fbw_debug_abort_enabled() {
             let base = ctx
                 .virtualizable_info()
                 .map_or(usize::MAX, |info| info.num_static_extra_boxes);
             let nlocals = crate::state::concrete_nlocals(frame).unwrap_or(usize::MAX);
             for (rel, &obj) in stack.iter().enumerate() {
-                let shadow = ctx
-                    .virtualizable_entry_at(base.saturating_add(nlocals).saturating_add(rel))
-                    .map(|(_opref, value)| value);
+                let entry =
+                    ctx.virtualizable_entry_at(base.saturating_add(nlocals).saturating_add(rel));
+                let shadow = entry.map(|(_opref, value)| value);
                 let agrees =
                     matches!(shadow, Some(majit_ir::Value::Ref(r)) if r.as_usize() == obj as usize);
                 if !agrees {
+                    // Report the OpRef too: a live box with a NULL value means
+                    // the symbolic write landed and only the concrete mirror is
+                    // absent, which is a different defect from no write at all.
                     eprintln!(
-                        "[r6-latch] slot {rel}/{} latched=0x{:x} shadow={shadow:?} (DISAGREES)",
+                        "[r6-latch] slot {rel}/{} latched=0x{:x} shadow={shadow:?} box={:?} (DISAGREES)",
                         stack.len(),
                         obj as usize,
+                        entry.map(|(opref, _)| opref),
                     );
                 }
             }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
@@ -10669,7 +10669,7 @@ fn structural_midbody_anchor_requires_exact_floor_segment_start() {
 }
 
 #[test]
-fn portal_marker_anchor_accepts_only_same_pc_last_instr_bookkeeping() {
+fn portal_vable_bookkeeping_anchor_accepts_only_same_pc_same_frame_vable_writes() {
     use majit_metainterp::jitcode::RuntimeBhDescr;
     use majit_translate::jitcode::BhDescr;
 
@@ -10687,7 +10687,7 @@ fn portal_marker_anchor_accepts_only_same_pc_last_instr_bookkeeping() {
     pyjit.metadata.py_floor_by_jit_pc = vec![(0, 29)];
     let portal_gap = [setfield, 1, 7, 0, 0, abort];
 
-    assert!(super::portal_marker_first_jit_anchor(
+    assert!(super::portal_vable_bookkeeping_anchor(
         &pyjit.metadata,
         true,
         1,
@@ -10697,7 +10697,7 @@ fn portal_marker_anchor_accepts_only_same_pc_last_instr_bookkeeping() {
         5,
         |_| 29,
     ));
-    assert!(!super::portal_marker_first_jit_anchor(
+    assert!(!super::portal_vable_bookkeeping_anchor(
         &pyjit.metadata,
         true,
         1,
@@ -10709,7 +10709,7 @@ fn portal_marker_anchor_accepts_only_same_pc_last_instr_bookkeeping() {
     ));
 
     let computation_gap = [int_copy, 1, 7, abort];
-    assert!(!super::portal_marker_first_jit_anchor(
+    assert!(!super::portal_vable_bookkeeping_anchor(
         &pyjit.metadata,
         true,
         1,
@@ -10721,7 +10721,7 @@ fn portal_marker_anchor_accepts_only_same_pc_last_instr_bookkeeping() {
     ));
 
     pyjit.metadata.py_floor_by_jit_pc = vec![(0, 0), (5, 29)];
-    assert!(super::portal_marker_first_jit_anchor(
+    assert!(super::portal_vable_bookkeeping_anchor(
         &pyjit.metadata,
         false,
         u16::MAX,
@@ -10729,6 +10729,101 @@ fn portal_marker_anchor_accepts_only_same_pc_last_instr_bookkeeping() {
         &portal_gap,
         29,
         5,
+        |_| 29,
+    ));
+}
+
+/// The operand-stack spill the walker emits ahead of an unwalkable opcode is
+/// `setarrayitem_vable_r` + `setfield_vable_i(valuestackdepth)`, not the
+/// `last_instr` write alone; the rebuild rewrites both, so both are admitted.
+/// `getarrayitem_vable_r` is not — it writes a jitcode register the payload
+/// sources live values from.
+#[test]
+fn portal_vable_bookkeeping_anchor_admits_stack_spill_but_not_a_register_write() {
+    use majit_metainterp::jitcode::RuntimeBhDescr;
+    use majit_translate::jitcode::BhDescr;
+
+    let setarrayitem = *insns_opname_to_byte()
+        .get("setarrayitem_vable_r/rirdd")
+        .expect("setarrayitem_vable_r must exist");
+    let getarrayitem = *insns_opname_to_byte()
+        .get("getarrayitem_vable_r/ridd>r")
+        .expect("getarrayitem_vable_r must exist");
+    let setfield = *insns_opname_to_byte()
+        .get("setfield_vable_i/rid")
+        .expect("setfield_vable_i must exist");
+    let abort = *insns_opname_to_byte()
+        .get("abort_permanent/")
+        .expect("abort_permanent must exist");
+    // `valuestackdepth` is static field index 2, not 0.
+    let descrs = [RuntimeBhDescr::Descr(BhDescr::VableField { index: 2 })];
+    let mut pyjit = crate::PyJitCode::skeleton(std::ptr::null());
+    pyjit.metadata.py_floor_by_jit_pc = vec![(0, 29)];
+
+    let mut spill = vec![setarrayitem];
+    let setarrayitem_len =
+        super::super::jitcode_runtime::decode_op_at(&[setarrayitem, 1, 2, 3, 0, 0, 0, 0], 0)
+            .expect("setarrayitem_vable_r must decode")
+            .next_pc;
+    spill.extend(std::iter::repeat_n(1u8, setarrayitem_len - 1));
+    let spill_end = spill.len();
+    spill.extend_from_slice(&[setfield, 1, 7, 0, 0]);
+    let abort_pc = spill.len();
+    spill.push(abort);
+
+    assert!(super::portal_vable_bookkeeping_anchor(
+        &pyjit.metadata,
+        true,
+        1,
+        &descrs,
+        &spill,
+        29,
+        abort_pc,
+        |_| 29,
+    ));
+    // A `setfield_vable_i` whose descr is not a vable field is not bookkeeping.
+    let mut foreign_descr = spill.clone();
+    foreign_descr[spill_end + 3] = 1;
+    assert!(!super::portal_vable_bookkeeping_anchor(
+        &pyjit.metadata,
+        true,
+        1,
+        &descrs,
+        &foreign_descr,
+        29,
+        abort_pc,
+        |_| 29,
+    ));
+    // A spill aimed at another frame register is not this frame's bookkeeping.
+    let mut foreign_frame = spill.clone();
+    foreign_frame[1] = 2;
+    assert!(!super::portal_vable_bookkeeping_anchor(
+        &pyjit.metadata,
+        true,
+        1,
+        &descrs,
+        &foreign_frame,
+        29,
+        abort_pc,
+        |_| 29,
+    ));
+
+    let mut reload = vec![getarrayitem];
+    let getarrayitem_len =
+        super::super::jitcode_runtime::decode_op_at(&[getarrayitem, 1, 2, 0, 0, 0, 0, 3], 0)
+            .expect("getarrayitem_vable_r must decode")
+            .next_pc;
+    reload.extend(std::iter::repeat_n(1u8, getarrayitem_len - 1));
+    let reload_abort_pc = reload.len();
+    reload.push(abort);
+    assert!(!super::portal_vable_bookkeeping_anchor(
+        &pyjit.metadata,
+        true,
+        1,
+        &descrs,
+        &reload,
+        29,
+        reload_abort_pc,
         |_| 29,
     ));
 }

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -4562,15 +4562,54 @@ pub(crate) fn flush_walk_end_state_at_outer_call(
     true
 }
 
-/// Allocation-free preflight for the depth-1 post-CALL delivery. Every gate
-/// is checked before the rebuilt callee runs, so a later decline cannot replay
-/// effects the plain interpreter already committed.
+/// How many operands the CALL at `call_py_pc` sits on top of: the caller's
+/// static stack height there minus the call's own `[callable, null_or_self,
+/// args...]`.  Zero for a statement-position call, positive for an
+/// expression-position one (`total += f(x)` keeps `total` below the call).
+/// `None` when the two disagree, i.e. the residual's operand list does not
+/// model this call shape.
+pub(crate) fn outer_call_operands_below(
+    frame: usize,
+    call_py_pc: usize,
+    post_call_py_pc: usize,
+    call_stack_len: usize,
+) -> Option<usize> {
+    let frame_ptr = frame as *const u8;
+    let w_code =
+        unsafe { *(frame_ptr.add(crate::frame_layout::PYFRAME_PYCODE_OFFSET) as *const *const ()) };
+    if w_code.is_null() {
+        return None;
+    }
+    let raw_code = unsafe {
+        pyre_interpreter::w_code_get_ptr(w_code as PyObjectRef)
+            as *const pyre_interpreter::CodeObject
+    };
+    if raw_code.is_null() {
+        return None;
+    }
+    let depths = crate::liveness::liveness_for(raw_code).depth_at_py_pc();
+    let at_call = usize::from(depths.get(call_py_pc).copied()?);
+    let after_call = usize::from(depths.get(post_call_py_pc).copied()?);
+    let below = at_call.checked_sub(call_stack_len)?;
+    // The call leaves exactly one value where its operands were.
+    (after_call == below + 1).then_some(below)
+}
+
+/// Allocation-free preflight for the post-CALL delivery. Every gate is checked
+/// before the rebuilt callee runs, so a later decline cannot replay effects the
+/// plain interpreter already committed.
+///
+/// `below` is [`outer_call_operands_below`]'s slice of the caller's operand
+/// stack — empty for a statement-position call.  Leg 4's payload records only
+/// the call's own operand count, so an expression-position call sources the
+/// residue from the entry carrier's full-stack reconstruction.
 pub(crate) fn can_flush_walk_end_state_after_outer_call(
     ctx: &TraceCtx,
     frame: usize,
     call_py_pc: usize,
     post_call_py_pc: usize,
     call_stack_len: usize,
+    below: &[PyObjectRef],
 ) -> bool {
     if frame == 0 {
         return false;
@@ -4594,10 +4633,12 @@ pub(crate) fn can_flush_walk_end_state_after_outer_call(
     if raw_code.is_null() {
         return false;
     }
-    let depths = crate::liveness::liveness_for(raw_code).depth_at_py_pc();
-    if depths.get(call_py_pc).copied().map(usize::from) != Some(call_stack_len)
-        || depths.get(post_call_py_pc).copied() != Some(1)
-    {
+    let Some(want_below) =
+        outer_call_operands_below(frame, call_py_pc, post_call_py_pc, call_stack_len)
+    else {
+        return false;
+    };
+    if want_below != below.len() || below.iter().any(|slot| slot.is_null()) {
         return false;
     }
     let Some(lastblock_idx) = info
@@ -4616,14 +4657,17 @@ pub(crate) fn can_flush_walk_end_state_after_outer_call(
         return false;
     }
     let base = info.num_static_extra_boxes;
-    if (0..nlocals).any(|abs| ctx.virtualizable_entry_at(base + abs).is_none()) {
+    if let Some(abs) = (0..nlocals).find(|&abs| ctx.virtualizable_entry_at(base + abs).is_none()) {
+        if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
+            eprintln!("[after-call] outer local {abs} has no shadow entry");
+        }
         return false;
     }
     let arr_ptr = unsafe {
         *(frame_ptr.add(PYFRAME_LOCALS_CELLS_STACK_OFFSET)
             as *const *mut pyre_object::FixedObjectArray)
     };
-    !arr_ptr.is_null() && unsafe { &*arr_ptr }.as_slice().len() >= nlocals + 1
+    !arr_ptr.is_null() && unsafe { &*arr_ptr }.as_slice().len() >= nlocals + below.len() + 1
 }
 
 /// Materialize the outer frame's locals from the virtualizable shadow.
@@ -4673,6 +4717,7 @@ pub(crate) fn flush_walk_end_state_after_outer_call(
     call_py_pc: usize,
     post_call_py_pc: usize,
     call_stack_len: usize,
+    below: &[PyObjectRef],
     retval: PyObjectRef,
 ) -> bool {
     if !can_flush_walk_end_state_after_outer_call(
@@ -4681,6 +4726,7 @@ pub(crate) fn flush_walk_end_state_after_outer_call(
         call_py_pc,
         post_call_py_pc,
         call_stack_len,
+        below,
     ) {
         return false;
     }
@@ -4692,11 +4738,17 @@ pub(crate) fn flush_walk_end_state_after_outer_call(
         *(frame_ptr.add(PYFRAME_LOCALS_CELLS_STACK_OFFSET)
             as *const *mut pyre_object::FixedObjectArray)
     };
-    // Land the nursery-resident result, then arm the barrier before
+    // Restore the operands the CALL sat on top of, then land the
+    // nursery-resident result above them, arming the barrier before
     // `write_back_outer_locals` boxes locals (an allocation that can
-    // collect the just-stored result if the array is not remembered).
+    // collect the just-stored refs if the array is not remembered).
     unsafe {
-        (*arr_ptr).as_mut_slice()[nlocals] = retval;
+        let slots = (*arr_ptr).as_mut_slice();
+        if slots.len() < nlocals + below.len() + 1 {
+            return false;
+        }
+        slots[nlocals..nlocals + below.len()].copy_from_slice(below);
+        slots[nlocals + below.len()] = retval;
     }
     frame_array_write_barrier(frame as *mut u8, arr_ptr);
     if !write_back_outer_locals(ctx, frame) {
@@ -4704,7 +4756,7 @@ pub(crate) fn flush_walk_end_state_after_outer_call(
     }
     unsafe {
         let pf = &mut *(frame as *mut PyFrame);
-        pf.valuestackdepth = nlocals + 1;
+        pf.valuestackdepth = nlocals + below.len() + 1;
         pf.last_instr = post_call_py_pc as isize - 1;
     }
     frame_array_write_barrier(frame as *mut u8, arr_ptr);

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -3063,9 +3063,7 @@ fn run_perfn_walk<Sym: WalkSym>(
                                         "[fbw-abort-flush] gh#467 callee-rebuild COMMIT \
                                          abort_jit_pc={abort_jit_pc} callee_py_pc={} \
                                          call_py_pc={} post_call_py_pc={}",
-                                        words.callee_py_pc,
-                                        words.call_py_pc,
-                                        words.post_call_py_pc,
+                                        words.callee_py_pc, words.call_py_pc, words.post_call_py_pc,
                                     );
                                 } else {
                                     eprintln!(

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -92,6 +92,14 @@ pub(crate) enum WalkEndCommitLeg {
     NestedInlineOuterCall = 6,
     /// Kept-stack branch guard flush at the abort pc.
     BranchGuard = 7,
+    /// Not a flush leg: the portal/CALL_ASSEMBLER `Terminate` no-replay
+    /// shortcut.  It keeps the journal like the legs above, but by a different
+    /// caller protocol — the caller consumes the walk's concrete result
+    /// instead of adopting a resume pc — so it must NOT set
+    /// [`WALK_END_FLUSH_COMMITTED`].  Tagged anyway because the census
+    /// otherwise reports these walks as `committed=true leg=0`, which reads as
+    /// "no leg" when it means "a commit path outside the leg contract".
+    TerminateNoReplay = 8,
 }
 
 /// Where a committing leg puts the interpreter, relative to the effects the
@@ -191,13 +199,26 @@ pub(crate) fn walk_end_resume_provable(resume: WalkEndResume) -> bool {
     }
 }
 
+/// Name the path that kept this walk's journal, for the census only.  Every
+/// journal-keeping path goes through here so none stays anonymous; the flush
+/// legs additionally set [`WALK_END_FLUSH_COMMITTED`] via [`commit_walk_end`],
+/// which is what tells the portal the returned `FrameBox` carries adoptable end
+/// state.  A path with a different caller protocol must tag WITHOUT that flag.
 #[must_use]
-pub(crate) fn commit_walk_end(leg: WalkEndCommitLeg, resume: WalkEndResume) -> bool {
+pub(crate) fn record_walk_end_leg(leg: WalkEndCommitLeg, resume: WalkEndResume) -> bool {
     if !walk_end_resume_provable(resume) {
         return false;
     }
-    WALK_END_FLUSH_COMMITTED.with(|c| c.set(true));
     WALK_END_COMMIT_LEG.with(|c| c.set(leg as u8));
+    true
+}
+
+#[must_use]
+pub(crate) fn commit_walk_end(leg: WalkEndCommitLeg, resume: WalkEndResume) -> bool {
+    if !record_walk_end_leg(leg, resume) {
+        return false;
+    }
+    WALK_END_FLUSH_COMMITTED.with(|c| c.set(true));
     true
 }
 
@@ -3264,6 +3285,14 @@ fn run_perfn_walk<Sym: WalkSym>(
         && crate::jitcode_dispatch::fbw_finish_concrete_peek().is_some();
     if !terminate_no_replay && !blackhole_terminal_no_replay {
         crate::jitcode_dispatch::fbw_finish_concrete_reset();
+    }
+    // The one journal-keeping path outside the flush legs: it sets no flush
+    // flag (the caller consumes the concrete result instead of adopting a
+    // resume pc), so tag it here or the census reports it as `leg=0`.
+    // `blackhole_terminal_no_replay` needs no tag — it only refines a walk
+    // whose VableEscape leg already committed, and retagging would erase it.
+    if terminate_no_replay {
+        let _ = record_walk_end_leg(WalkEndCommitLeg::TerminateNoReplay, WalkEndResume::Terminal);
     }
 
     // Store-journal epilogue, on EVERY walk exit (commit, declined

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -174,8 +174,10 @@ pub(crate) enum WalkEndResume {
     /// The resume pc is AHEAD of what the walk applied — a rebuilt callee
     /// resumed at its own abort pc.  Nothing re-runs; committing is what
     /// *keeps* the applied effects, and rolling back would lose them (the
-    /// discarded trace was their only carrier).  Such a leg's own gate is the
-    /// mirror image of `Rewind`: it latches BECAUSE the odometer moved.
+    /// discarded trace was their only carrier).  Needs no effect gate at all,
+    /// which is why upstream's version of this leg is unconditional
+    /// (`run_blackhole_interp_to_cancel_tracing` ends `assert False`,
+    /// `pyjitpl.py:2956`).
     AfterApplied,
 }
 
@@ -2953,8 +2955,7 @@ fn run_perfn_walk<Sym: WalkSym>(
                             // This leg resumes INSIDE the rebuilt callee at its
                             // abort pc — ahead of what the callee applied, not
                             // behind it.  Nothing re-runs; committing is what
-                            // keeps those effects, which is why the leg's own
-                            // gate latches BECAUSE the odometer moved.
+                            // keeps those effects.
                             let _ = commit_walk_end(
                                 WalkEndCommitLeg::CalleeRebuild,
                                 WalkEndResume::AfterApplied,

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -94,10 +94,111 @@ pub(crate) enum WalkEndCommitLeg {
     BranchGuard = 7,
 }
 
+/// Where a committing leg puts the interpreter, relative to the effects the
+/// walk already applied.
+///
+/// Committing does two things at once: it keeps the store journal (instead of
+/// rolling it back) AND it hands the caller a resume pc.  Those two must agree,
+/// so every leg has to say which side of its applied effects the resume pc
+/// falls on.
+///
+/// Upstream's rule is not "never rewind".  `opimpl_str_guard_value`
+/// (`pyjitpl.py:1498-1511`) runs a real `do_residual_call` and then records its
+/// guard with `resumepc=orgpc`, an earlier pc; `capture_resumedata` stamps that
+/// pc into the frame (`pyjitpl.py:2617-2620`).  What upstream forbids is
+/// rewinding past an *effectful* residual, and it decides both the permission
+/// and the prohibition STATICALLY — the licence is the codewriter-time
+/// `EffectInfo.EF_ELIDABLE_CANNOT_RAISE` registration
+/// (`jtransform.py:620-630`), and the ban is by opnum: the four guards that can
+/// follow a residual take `after_residual_call`, which pins the resume pc to
+/// the POST-call `self.pc` (`pyjitpl.py:2599-2602` → `194-198`).  Upstream's
+/// only op counters are profiling-only and gate nothing
+/// (`jitprof.py:43-44 EmptyProfiler.count_ops` is `pass`).
+///
+/// So this enum discharges an obligation upstream also has, but in a form
+/// upstream does not use: a runtime odometer where upstream uses a declared
+/// effect class.  That is a tracked deviation, not the end state — the
+/// convergence is a static per-callee effect classification.  Separately, the
+/// legs that resume the OUTER frame at a CALL (gh#467, gated by #126/#215's
+/// missing inner-frame rebuild) have no upstream counterpart at all;
+/// `convert_and_run_from_pyjitpl` (`blackhole.py:1799-1821`) gives every frame
+/// its own current pc and splices the callee result in PAST the caller's call
+/// (`blackhole.py:1653-1662`), which is the [`WalkEndResume::AfterApplied`]
+/// shape.
+#[derive(Clone, Copy)]
+pub(crate) enum WalkEndResume {
+    /// The resume pc is the walk terminal: nothing already applied lies ahead
+    /// of it, and nothing behind it re-runs.  "Anywhere in the walk" and
+    /// "behind the resume point" coincide here, which is why the sticky
+    /// unjournaled flags a terminal leg consults are a sufficient gate.
+    Terminal,
+    /// The resume pc REWINDS — the interpreter re-runs a region the walk
+    /// already ran, while the journal stays committed.  Sound only while the
+    /// executed-effect odometer has not moved since `effects_at_resume_point`,
+    /// which is sampled AT that pc; otherwise every effect applied since it
+    /// runs a second time on top of the committed ones.  [`commit_walk_end`]
+    /// enforces this and declines the leg, leaving the legacy path whose
+    /// journal rollback makes the replay exactly-once.
+    Rewind { effects_at_resume_point: usize },
+    /// The resume pc rewinds and the leg has no sample to prove the odometer
+    /// stayed put since it.  [`commit_walk_end`] always declines: an unproven
+    /// rewind is exactly the shape that double-executes silently.  A leg that
+    /// reaches this either has to start sampling its resume point or should
+    /// not be committing at all.
+    RewindUnproven,
+    /// A rewind whose only proof is taken ELSEWHERE and EARLIER: the escape
+    /// latch's `escape_opcode_window_clean` runs at the residual
+    /// (`residual_call.rs`), not at this commit.  Named rather than spelled
+    /// `Terminal` because the resume pc genuinely re-runs its opcode —
+    /// `vstack_cur_pypc` is the pc the walk is ABOUT TO ENTER
+    /// (`reconcile_vstack_at_boundary` sets it to `new_pypc` after reconciling
+    /// the PREVIOUS opcode), and the flush sets `last_instr = pc - 1`
+    /// (`state.rs`), so `next_instr()` re-executes that opcode.
+    ///
+    /// Re-founding it on a commit-time sample would flip which walks commit
+    /// (the forcing residual bumps the odometer after the window is sampled),
+    /// so that is a measured change of its own and not part of introducing
+    /// this contract.
+    RewindProvenAtLatch,
+    /// The resume pc is AHEAD of what the walk applied — a rebuilt callee
+    /// resumed at its own abort pc.  Nothing re-runs; committing is what
+    /// *keeps* the applied effects, and rolling back would lose them (the
+    /// discarded trace was their only carrier).  Such a leg's own gate is the
+    /// mirror image of `Rewind`: it latches BECAUSE the odometer moved.
+    AfterApplied,
+}
+
 /// Set [`WALK_END_FLUSH_COMMITTED`] and record which leg did it.
-pub(crate) fn commit_walk_end(leg: WalkEndCommitLeg) {
+///
+/// Returns whether the commit was taken.  A [`WalkEndResume::Rewind`] leg whose
+/// odometer moved since its resume point is declined here rather than
+/// committed — the one gate that cannot be left to each leg, because a leg that
+/// forgets it produces a silent double-execution rather than a crash.
+/// Whether `resume` may be committed — the predicate [`commit_walk_end`]
+/// applies.  Exposed separately because a leg whose flush mutates the live
+/// frame before it can commit has to consult it FIRST: those flushes have no
+/// undo, so declining after one would leave the frame half-adopted.
+#[must_use]
+pub(crate) fn walk_end_resume_provable(resume: WalkEndResume) -> bool {
+    match resume {
+        WalkEndResume::Terminal
+        | WalkEndResume::AfterApplied
+        | WalkEndResume::RewindProvenAtLatch => true,
+        WalkEndResume::Rewind {
+            effects_at_resume_point,
+        } => crate::jitcode_dispatch::fbw_executed_effect_count() == effects_at_resume_point,
+        WalkEndResume::RewindUnproven => false,
+    }
+}
+
+#[must_use]
+pub(crate) fn commit_walk_end(leg: WalkEndCommitLeg, resume: WalkEndResume) -> bool {
+    if !walk_end_resume_provable(resume) {
+        return false;
+    }
     WALK_END_FLUSH_COMMITTED.with(|c| c.set(true));
     WALK_END_COMMIT_LEG.with(|c| c.set(leg as u8));
+    true
 }
 
 pub fn take_walk_end_propagated_exception() -> Option<pyre_interpreter::PyError> {
@@ -1669,7 +1770,9 @@ fn try_adopt_single_frame_blackhole(ctx: &mut TraceCtx, cf_addr: usize) -> bool 
         let _ = crate::jitcode_dispatch::take_committed_frame_escape_pc();
         crate::jitcode_dispatch::discard_escape_flush_undo();
         crate::jitcode_dispatch::fbw_foriter_inflight_clear();
-        commit_walk_end(WalkEndCommitLeg::VableEscape);
+        // The blackhole ran the region to a frame terminal, so the resume is
+        // the frame's RESULT, not a pc that re-runs anything.
+        let _ = commit_walk_end(WalkEndCommitLeg::VableEscape, WalkEndResume::Terminal);
         if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
             eprintln!(
                 "[fbw-blackhole] adopted single-frame terminal at jitcode_index={} \
@@ -1935,7 +2038,8 @@ fn try_adopt_multi_frame_blackhole(ctx: &mut TraceCtx, cf_addr: usize) -> bool {
         let _ = crate::jitcode_dispatch::take_committed_frame_escape_pc();
         crate::jitcode_dispatch::discard_escape_flush_undo();
         crate::jitcode_dispatch::fbw_foriter_inflight_clear();
-        commit_walk_end(WalkEndCommitLeg::VableEscape);
+        // Same as the single-frame adoption: a frame terminal, not a resume pc.
+        let _ = commit_walk_end(WalkEndCommitLeg::VableEscape, WalkEndResume::Terminal);
         if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
             eprintln!("[fbw-blackhole] adopted multi-frame terminal depth={depth}");
         }
@@ -2632,7 +2736,9 @@ fn run_perfn_walk<Sym: WalkSym>(
                             crate::jitcode_dispatch::fbw_store_journal_len(),
                         );
                     }
-                    commit_walk_end(WalkEndCommitLeg::LoopHeader);
+                    // The loop header IS where this walk ended; the sticky
+                    // unjournaled check above is the whole gate.
+                    let _ = commit_walk_end(WalkEndCommitLeg::LoopHeader, WalkEndResume::Terminal);
                 } else if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
                     eprintln!(
                         "[fbw-end-flush] declined at header_pc={header_pc} (shadow slot \
@@ -2667,27 +2773,58 @@ fn run_perfn_walk<Sym: WalkSym>(
                 &walk_result,
                 Err(crate::jitcode_dispatch::DispatchError::VableEscapedDuringResidualCall { .. })
             )
-            && let Some(resume_py_pc) = crate::jitcode_dispatch::take_committed_frame_escape_pc()
+            && let Some((resume_py_pc, escape_kind)) =
+                crate::jitcode_dispatch::take_committed_frame_escape_pc()
         {
-            crate::jitcode_dispatch::discard_escape_flush_undo();
-            // The force-time escape flush wrote the resume state into the
-            // LIVE frame (the frame the callee inspected).  The portal
-            // epilogue propagates `executed_frame` → live on a committed
-            // flush, so mirror the live frame's resume state into the walk
-            // snapshot to make that copy the identity.
-            let live = sym.live_vable_frame_addr();
-            if live != 0 && cf_addr != 0 && live != cf_addr {
-                unsafe {
-                    (*(cf_addr as *mut pyre_interpreter::PyFrame))
-                        .restore_resume_state_from(&*(live as *const pyre_interpreter::PyFrame));
+            // BOTH flushes inside `flush_active_frame_escape` rewind: they take
+            // the same `py_pc` and the same `last_instr = pc - 1`, so the
+            // escaping opcode re-runs either way.  They differ in whether the
+            // mid-expression operand stack was reconstructed, and — the part
+            // that matters here — in whether any gate ran at all.  The latched
+            // path is gated by `escape_opcode_window_clean` back at the
+            // residual; the merge-point fallback had no gate anywhere, so it
+            // has nothing to offer this contract and is refused.
+            let resume = match escape_kind {
+                crate::jitcode_dispatch::EscapeResumeKind::Exact => {
+                    WalkEndResume::RewindProvenAtLatch
+                }
+                crate::jitcode_dispatch::EscapeResumeKind::RerunsOpcode => {
+                    WalkEndResume::RewindUnproven
+                }
+            };
+            if commit_walk_end(WalkEndCommitLeg::VableEscape, resume) {
+                crate::jitcode_dispatch::discard_escape_flush_undo();
+                // The force-time escape flush wrote the resume state into the
+                // LIVE frame (the frame the callee inspected).  The portal
+                // epilogue propagates `executed_frame` → live on a committed
+                // flush, so mirror the live frame's resume state into the walk
+                // snapshot to make that copy the identity.
+                let live = sym.live_vable_frame_addr();
+                if live != 0 && cf_addr != 0 && live != cf_addr {
+                    unsafe {
+                        (*(cf_addr as *mut pyre_interpreter::PyFrame)).restore_resume_state_from(
+                            &*(live as *const pyre_interpreter::PyFrame),
+                        );
+                    }
+                }
+                // The committed flush owns the iteration count (the resume pc
+                // is PAST the FOR_ITER consume); drop any in-flight item so
+                // the legacy deliver cannot re-apply one.
+                crate::jitcode_dispatch::fbw_foriter_inflight_clear();
+                WALK_END_RESTART_PC.with(|c| c.set(Some(resume_py_pc)));
+            } else {
+                // Put the live frame back to its pre-flush state: the legacy
+                // replay's contract is that the frame still holds pre-walk
+                // state, and its journal rollback makes the replay exactly-once.
+                crate::jitcode_dispatch::restore_escape_flush_undo();
+                if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
+                    eprintln!(
+                        "[fbw-abort-flush] escape flush declined at \
+                         resume_py_pc={resume_py_pc} (merge-point fallback re-runs the \
+                         escaping opcode) — legacy replay kept"
+                    );
                 }
             }
-            // The committed flush owns the iteration count (the resume pc
-            // is PAST the FOR_ITER consume); drop any in-flight item so
-            // the legacy deliver cannot re-apply one.
-            crate::jitcode_dispatch::fbw_foriter_inflight_clear();
-            WALK_END_RESTART_PC.with(|c| c.set(Some(resume_py_pc)));
-            commit_walk_end(WalkEndCommitLeg::VableEscape);
         }
         let call_forward_abort = match &walk_result {
             Err(crate::jitcode_dispatch::DispatchError::AbortPermanentMarkerReached { pc }) => {
@@ -2720,8 +2857,24 @@ fn run_perfn_walk<Sym: WalkSym>(
                     outer_jitcode_index,
                     call_jitcode_pc,
                     call_stack,
+                    entry_executed_effects,
                 }) => {
-                    if let Some(call_py_pc) =
+                    // This resume re-executes the outer CALL from scratch, so
+                    // it is only sound while nothing has been applied since
+                    // that CALL.  The latch was set under the same gate; check
+                    // it again here, before the flush mutates the live frame.
+                    let resume = WalkEndResume::Rewind {
+                        effects_at_resume_point: *entry_executed_effects,
+                    };
+                    if !walk_end_resume_provable(resume) {
+                        if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
+                            eprintln!(
+                                "[fbw-abort-flush] gh#467 CALL-forward declined at \
+                                     abort_jit_pc={abort_jit_pc} (executed-effect delta since the \
+                                     outer CALL) — legacy replay kept"
+                            );
+                        }
+                    } else if let Some(call_py_pc) =
                         resolve_entry_carrier_call_py_pc(*outer_jitcode_index, *call_jitcode_pc)
                     {
                         if crate::state::flush_walk_end_state_at_outer_call(
@@ -2736,7 +2889,9 @@ fn run_perfn_walk<Sym: WalkSym>(
                                     call_stack.len()
                                 );
                             }
-                            commit_walk_end(WalkEndCommitLeg::EntryCarrierCall);
+                            let committed =
+                                commit_walk_end(WalkEndCommitLeg::EntryCarrierCall, resume);
+                            debug_assert!(committed, "provability re-checked after a pure flush");
                         } else if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
                             eprintln!(
                                 "[fbw-abort-flush] gh#467 CALL-forward declined at \
@@ -2771,7 +2926,15 @@ fn run_perfn_walk<Sym: WalkSym>(
                                     words.callee_py_pc, words.call_py_pc, words.post_call_py_pc,
                                 );
                             }
-                            commit_walk_end(WalkEndCommitLeg::CalleeRebuild);
+                            // This leg resumes INSIDE the rebuilt callee at its
+                            // abort pc — ahead of what the callee applied, not
+                            // behind it.  Nothing re-runs; committing is what
+                            // keeps those effects, which is why the leg's own
+                            // gate latches BECAUSE the odometer moved.
+                            let _ = commit_walk_end(
+                                WalkEndCommitLeg::CalleeRebuild,
+                                WalkEndResume::AfterApplied,
+                            );
                         } else if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
                             eprintln!(
                                 "[fbw-abort-flush] gh#467 callee-rebuild declined at \
@@ -2807,7 +2970,10 @@ fn run_perfn_walk<Sym: WalkSym>(
                                          resume_py_pc={resume_py_pc}"
                                 );
                             }
-                            commit_walk_end(WalkEndCommitLeg::AbortPc);
+                            // The abort pc IS where the walk stopped; the
+                            // unjournaled/sub-walk check above is the gate.
+                            let _ =
+                                commit_walk_end(WalkEndCommitLeg::AbortPc, WalkEndResume::Terminal);
                         } else if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
                             eprintln!(
                                 "[fbw-abort-flush] declined at resume_py_pc={resume_py_pc} \
@@ -2847,11 +3013,25 @@ fn run_perfn_walk<Sym: WalkSym>(
                              (unjournaled effect) — legacy replay kept"
                     );
                 }
-            } else if let Some((jitcode_index, call_jitcode_pc)) =
+            } else if let Some((jitcode_index, call_jitcode_pc, effects_at_resume_point)) =
                 crate::jitcode_dispatch::fbw_abort_outer_resume_take()
             {
+                // Like the entry carrier, this resume re-executes the outer
+                // CALL, so it needs the same zero-delta proof — the one the
+                // latch sampled at that CALL.
+                let resume = WalkEndResume::Rewind {
+                    effects_at_resume_point,
+                };
                 let pjc = crate::state::pyjitcode_for_jitcode_index(jitcode_index as i32);
-                if let Some(pjc) = pjc {
+                if !walk_end_resume_provable(resume) {
+                    crate::jitcode_dispatch::fbw_abort_outer_stack_overrides_clear();
+                    if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
+                        eprintln!(
+                            "[fbw-abort-flush] declined at abort_jit_pc={abort_jit_pc} \
+                                 (executed-effect delta since the outer CALL) — legacy replay kept"
+                        );
+                    }
+                } else if let Some(pjc) = pjc {
                     let resume_py_pc = crate::jitcode_dispatch::python_pc_for_jitcode_pc(
                         &pjc.metadata,
                         call_jitcode_pc,
@@ -2889,7 +3069,9 @@ fn run_perfn_walk<Sym: WalkSym>(
                                          resume_py_pc={resume_py_pc} (nested inline decline)"
                                 );
                             }
-                            commit_walk_end(WalkEndCommitLeg::NestedInlineOuterCall);
+                            let committed =
+                                commit_walk_end(WalkEndCommitLeg::NestedInlineOuterCall, resume);
+                            debug_assert!(committed, "provability re-checked after a pure flush");
                         } else if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
                             eprintln!(
                                 "[fbw-abort-flush] declined at resume_py_pc={resume_py_pc} \
@@ -3012,7 +3194,9 @@ fn run_perfn_walk<Sym: WalkSym>(
                     // in-flight items so the legacy deliver cannot re-apply
                     // one (exactly-once).
                     crate::jitcode_dispatch::fbw_foriter_inflight_clear();
-                    commit_walk_end(WalkEndCommitLeg::BranchGuard);
+                    // The abort pc is where the walk stopped, and the in-flight
+                    // item is delivered exactly once by the flush above.
+                    let _ = commit_walk_end(WalkEndCommitLeg::BranchGuard, WalkEndResume::Terminal);
                     if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
                         eprintln!(
                             "[fbw-branch-flush] COMMIT abort_jit_pc={abort_jit_pc} \
@@ -4068,6 +4252,30 @@ mod tests {
     use pyre_interpreter::bytecode::Instruction;
     use pyre_interpreter::compile_exec;
     use pyre_interpreter::decode_instruction_at;
+
+    /// The walk-end commit contract: only a resume pc that does not precede
+    /// something the walk already applied may keep the store journal.
+    #[test]
+    fn walk_end_commit_refuses_an_unproven_or_stale_rewind() {
+        use super::{WalkEndResume, walk_end_resume_provable};
+        let live = crate::jitcode_dispatch::fbw_executed_effect_count();
+
+        assert!(walk_end_resume_provable(WalkEndResume::Terminal));
+        assert!(walk_end_resume_provable(WalkEndResume::AfterApplied));
+        assert!(walk_end_resume_provable(WalkEndResume::Rewind {
+            effects_at_resume_point: live,
+        }));
+        assert!(
+            !walk_end_resume_provable(WalkEndResume::Rewind {
+                effects_at_resume_point: live.wrapping_sub(1),
+            }),
+            "an odometer delta since the resume point means the region re-runs its effects",
+        );
+        assert!(
+            !walk_end_resume_provable(WalkEndResume::RewindUnproven),
+            "a rewind with no resume-point sample cannot be proven and must decline",
+        );
+    }
 
     #[test]
     fn static_marker_entry_recovers_ref_green_register_color() {

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -604,26 +604,75 @@ fn try_commit_entry_carrier_call(
     Some(call_py_pc)
 }
 
+/// Wrapper that names which narrowing kept a rebuild off leg 4; the reason
+/// otherwise vanishes into the entry-carrier fallback.
 fn try_commit_midbody_abort(
     ctx: &TraceCtx,
     cf_addr: usize,
     payload: &crate::jitcode_dispatch::MidBodyPayload,
     words: MidBodyFlushWords,
 ) -> bool {
+    match try_commit_midbody_abort_inner(ctx, cf_addr, payload, words) {
+        Ok(()) => true,
+        Err(reason) => {
+            if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
+                eprintln!(
+                    "[fbw-abort-flush] gh#467 callee-rebuild NOT COMMITTED at \
+                     callee_py_pc={} ({reason})",
+                    words.callee_py_pc,
+                );
+            }
+            false
+        }
+    }
+}
+
+fn try_commit_midbody_abort_inner(
+    ctx: &TraceCtx,
+    cf_addr: usize,
+    payload: &crate::jitcode_dispatch::MidBodyPayload,
+    words: MidBodyFlushWords,
+) -> Result<(), &'static str> {
+    // An expression-position call sits on top of operands the payload does not
+    // record — it counts only the call's own `[callable, null_or_self, args…]`.
+    // The entry fallback's `reconstructed_all_ref_call_stack` is the caller's
+    // WHOLE operand stack at that pc, slot-ordered from the stack base, so its
+    // prefix is exactly that residue.
+    let below = match crate::state::outer_call_operands_below(
+        cf_addr,
+        words.call_py_pc,
+        words.post_call_py_pc,
+        payload.call_stack_len,
+    ) {
+        Some(0) => &[][..],
+        Some(n) => {
+            let Some(full) = payload
+                .entry_fallback
+                .as_ref()
+                .map(|fallback| fallback.call_stack.as_slice())
+                .filter(|full| full.len() == n + payload.call_stack_len)
+            else {
+                return Err("expression-position call with no reconstructed stack below it");
+            };
+            &full[..n]
+        }
+        None => return Err("caller stack depth does not model this call shape"),
+    };
     if !crate::state::can_flush_walk_end_state_after_outer_call(
         ctx,
         cf_addr,
         words.call_py_pc,
         words.post_call_py_pc,
         payload.call_stack_len,
+        below,
     ) {
-        return false;
+        return Err("outer call boundary not flushable");
     }
     let raw = unsafe {
         pyre_interpreter::w_code_get_ptr(payload.w_code) as *const pyre_interpreter::CodeObject
     };
     if raw.is_null() {
-        return false;
+        return Err("null callee code ptr");
     }
     let code = unsafe { &*raw };
     // Only portal trace sites currently carry `_exit_frame_with_exception`
@@ -634,15 +683,15 @@ fn try_commit_midbody_abort(
         && (!code.exceptiontable.is_empty()
             || !midbody_post_marker_is_effect_free(code, words.callee_py_pc))
     {
-        return false;
+        return Err("no propagate licence and callee body can raise");
     }
     if cf_addr == 0 {
-        return false;
+        return Err("no live caller frame");
     }
     let ec = unsafe { (*(cf_addr as *const pyre_interpreter::PyFrame)).execution_context }
         as *mut pyre_interpreter::PyExecutionContext;
     if ec.is_null() {
-        return false;
+        return Err("null execution context");
     }
     let propagate_allowed = WALK_END_PROPAGATE_ALLOWED.with(|c| c.get());
     let outer = unsafe { &mut *(cf_addr as *mut pyre_interpreter::PyFrame) };
@@ -662,14 +711,14 @@ fn try_commit_midbody_abort(
                 outer.locals_w().as_slice().len(),
                 outer_stack_base,
             ) {
-                return false;
+                return Err("caller handler keeps an operand below the call");
             }
         }
         // G7: materialize every outer local before the rebuilt callee can run.
         // `can_flush_walk_end_state_after_outer_call` already proved all
         // shadow entries sourceable, so no post-effect decline remains.
         if !crate::state::write_back_outer_locals(ctx, cf_addr) {
-            return false;
+            return Err("an outer local is not sourceable");
         }
     }
     let mut w_code = payload.w_code;
@@ -687,7 +736,7 @@ fn try_commit_midbody_abort(
         pyre_interpreter::pyframe::FrameLocalsArrayAllocation::OldGenGc,
     ) {
         Ok(frame) => frame,
-        Err(_) => return false,
+        Err(_) => return Err("callee frame allocation failed"),
     };
     let mut frame = pyre_interpreter::pyframe::FrameBox::new(frame);
     frame.fix_array_ptrs();
@@ -696,10 +745,10 @@ fn try_commit_midbody_abort(
     let Some(crate::jitcode_dispatch::InlineAbortCarrier::MidBody(current)) =
         crate::jitcode_dispatch::fbw_abort_carrier_clone()
     else {
-        return false;
+        return Err("carrier is no longer a MidBody");
     };
     if current.live_locals.len() != code.varnames.len() {
-        return false;
+        return Err("live_locals length does not match varnames");
     }
     for slot in &mut frame.locals_w_mut().as_mut_slice()[..code.varnames.len()] {
         *slot = pyre_object::PY_NULL;
@@ -714,7 +763,7 @@ fn try_commit_midbody_abort(
     let stack_base = code.varnames.len() + pyre_interpreter::pyframe::ncells(code);
     for (rel, value) in current.live_stack.iter().enumerate() {
         let crate::state::ConcreteValue::Ref(value) = value else {
-            return false;
+            return Err("live stack slot is not a Ref");
         };
         frame.locals_w_mut().as_mut_slice()[stack_base + rel] = *value;
     }
@@ -740,7 +789,7 @@ fn try_commit_midbody_abort(
                 pyre_object::floatobject::w_float_new(*value)
             }
             Some(crate::state::ConcreteValue::Null | crate::state::ConcreteValue::Bool(_)) => {
-                return false;
+                return Err("live local is Null/Bool");
             }
         };
     }
@@ -755,14 +804,38 @@ fn try_commit_midbody_abort(
         Ok(mut retval) => {
             crate::jitcode_dispatch::fbw_abort_carrier_set_return(retval);
             let _retval_root = ObjectSlotRoot::new(&mut retval);
-            crate::state::flush_walk_end_state_after_outer_call(
+            // `below` came from a clone taken BEFORE the callee ran; a minor
+            // collection inside it can have moved those objects.  Re-read them
+            // from the live carrier, which the abort-resume GC root area keeps
+            // forwarded.
+            let fresh = crate::jitcode_dispatch::fbw_abort_carrier_clone();
+            let below_now = match (below.len(), fresh.as_ref()) {
+                (0, _) => &[][..],
+                (
+                    n,
+                    Some(crate::jitcode_dispatch::InlineAbortCarrier::MidBody(fresh)),
+                ) => match fresh.entry_fallback.as_ref() {
+                    Some(fallback) if fallback.call_stack.len() >= n => &fallback.call_stack[..n],
+                    _ => return Err("entry fallback vanished while the callee ran"),
+                },
+                _ => return Err("carrier is no longer a MidBody after the callee ran"),
+            };
+            // The callee has already RUN.  A false here is not a plain
+            // decline: it drops to the legacy replay with the callee's
+            // effects applied.
+            if crate::state::flush_walk_end_state_after_outer_call(
                 ctx,
                 cf_addr,
                 words.call_py_pc,
                 words.post_call_py_pc,
                 current.call_stack_len,
+                below_now,
                 retval,
-            )
+            ) {
+                Ok(())
+            } else {
+                Err("post-call caller flush declined AFTER the callee ran")
+            }
         }
         Err(mut operr) => {
             // `_resume_mainloop(current_exc)` returns the exception to the
@@ -771,7 +844,7 @@ fn try_commit_midbody_abort(
             // selected handler onward.
             unsafe { (*ec).sys_exc_value = sys_exc_value_pre };
             if !propagate_allowed {
-                return false;
+                return Err("callee raised and this site has no propagate licence");
             }
             let outer = unsafe { &mut *(cf_addr as *mut pyre_interpreter::PyFrame) };
             outer.last_instr = words.call_py_pc as isize;
@@ -782,7 +855,7 @@ fn try_commit_midbody_abort(
             } else {
                 WALK_END_PROPAGATED_EXCEPTION.with(|c| *c.borrow_mut() = Some(operr));
             }
-            true
+            Ok(())
         }
     }
 }

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -541,6 +541,69 @@ fn exception_delivery_stack_is_sourceable(
     handler_depth == 0 && array_len >= stack_base + 1
 }
 
+/// Flush the OUTER frame at the CALL that entered the aborting callee and let
+/// the interpreter re-execute that whole call.  Returns the committed
+/// `call_py_pc`, or `None` when any step declined and the legacy replay stands.
+///
+/// This resume REWINDS to the CALL, which is sound only while nothing has been
+/// applied since it — the latch was set under that gate, and it is re-checked
+/// here before the flush mutates the live frame.  Reached either as the carrier
+/// in its own right or as the callee-rebuild leg's fallback.
+fn try_commit_entry_carrier_call(
+    ctx: &TraceCtx,
+    cf_addr: usize,
+    abort_jit_pc: usize,
+    outer_jitcode_index: u32,
+    call_jitcode_pc: usize,
+    call_stack: &[pyre_object::PyObjectRef],
+    entry_executed_effects: usize,
+) -> Option<usize> {
+    let resume = WalkEndResume::Rewind {
+        effects_at_resume_point: entry_executed_effects,
+    };
+    if !walk_end_resume_provable(resume) {
+        if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
+            eprintln!(
+                "[fbw-abort-flush] gh#467 CALL-forward declined at \
+                 abort_jit_pc={abort_jit_pc} (executed-effect delta since the \
+                 outer CALL) — legacy replay kept"
+            );
+        }
+        return None;
+    }
+    let Some(call_py_pc) = resolve_entry_carrier_call_py_pc(outer_jitcode_index, call_jitcode_pc)
+    else {
+        if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
+            eprintln!(
+                "[fbw-abort-flush] gh#467 CALL-forward declined at \
+                 abort_jit_pc={abort_jit_pc} (unresolved outer \
+                 jitcode_index={outer_jitcode_index} or null code ptr) — legacy replay kept"
+            );
+        }
+        return None;
+    };
+    if !crate::state::flush_walk_end_state_at_outer_call(ctx, cf_addr, call_py_pc, call_stack) {
+        if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
+            eprintln!(
+                "[fbw-abort-flush] gh#467 CALL-forward declined at \
+                 call_py_pc={call_py_pc} (depth mismatch / unresolved local / \
+                 lastblock) — legacy replay kept"
+            );
+        }
+        return None;
+    }
+    if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
+        eprintln!(
+            "[fbw-abort-flush] gh#467 CALL-forward COMMIT abort_jit_pc={abort_jit_pc} \
+             call_py_pc={call_py_pc} stack_depth={}",
+            call_stack.len()
+        );
+    }
+    let committed = commit_walk_end(WalkEndCommitLeg::EntryCarrierCall, resume);
+    debug_assert!(committed, "provability re-checked after a pure flush");
+    Some(call_py_pc)
+}
+
 fn try_commit_midbody_abort(
     ctx: &TraceCtx,
     cf_addr: usize,
@@ -2885,54 +2948,15 @@ fn run_perfn_walk<Sym: WalkSym>(
                     call_stack,
                     entry_executed_effects,
                 }) => {
-                    // This resume re-executes the outer CALL from scratch, so
-                    // it is only sound while nothing has been applied since
-                    // that CALL.  The latch was set under the same gate; check
-                    // it again here, before the flush mutates the live frame.
-                    let resume = WalkEndResume::Rewind {
-                        effects_at_resume_point: *entry_executed_effects,
-                    };
-                    if !walk_end_resume_provable(resume) {
-                        if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
-                            eprintln!(
-                                "[fbw-abort-flush] gh#467 CALL-forward declined at \
-                                     abort_jit_pc={abort_jit_pc} (executed-effect delta since the \
-                                     outer CALL) — legacy replay kept"
-                            );
-                        }
-                    } else if let Some(call_py_pc) =
-                        resolve_entry_carrier_call_py_pc(*outer_jitcode_index, *call_jitcode_pc)
-                    {
-                        if crate::state::flush_walk_end_state_at_outer_call(
-                            ctx, cf_addr, call_py_pc, call_stack,
-                        ) {
-                            committed_entry_carrier_call_py_pc = Some(call_py_pc);
-                            if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
-                                eprintln!(
-                                    "[fbw-abort-flush] gh#467 CALL-forward COMMIT \
-                                         abort_jit_pc={abort_jit_pc} call_py_pc={call_py_pc} \
-                                         stack_depth={}",
-                                    call_stack.len()
-                                );
-                            }
-                            let committed =
-                                commit_walk_end(WalkEndCommitLeg::EntryCarrierCall, resume);
-                            debug_assert!(committed, "provability re-checked after a pure flush");
-                        } else if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
-                            eprintln!(
-                                "[fbw-abort-flush] gh#467 CALL-forward declined at \
-                                     call_py_pc={call_py_pc} (depth mismatch / unresolved local / \
-                                     lastblock) — legacy replay kept"
-                            );
-                        }
-                    } else if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
-                        eprintln!(
-                            "[fbw-abort-flush] gh#467 CALL-forward declined at \
-                                 abort_jit_pc={abort_jit_pc} (unresolved outer jitcode_index={} \
-                                 or null code ptr) — legacy replay kept",
-                            outer_jitcode_index,
-                        );
-                    }
+                    committed_entry_carrier_call_py_pc = try_commit_entry_carrier_call(
+                        ctx,
+                        cf_addr,
+                        abort_jit_pc,
+                        *outer_jitcode_index,
+                        *call_jitcode_pc,
+                        call_stack,
+                        *entry_executed_effects,
+                    );
                 }
                 Some(crate::jitcode_dispatch::InlineAbortCarrier::MidBody(payload))
                     if (is_marker_abort
@@ -2942,36 +2966,62 @@ fn run_perfn_walk<Sym: WalkSym>(
                             && payload.abort_kind
                                 == crate::jitcode_dispatch::MidBodyAbortKind::Structural) =>
                 {
-                    if let Some(words) = resolve_midbody_flush_words(payload) {
-                        if try_commit_midbody_abort(ctx, cf_addr, payload, words) {
+                    let rebuilt = match resolve_midbody_flush_words(payload) {
+                        Some(words) => {
+                            let ok = try_commit_midbody_abort(ctx, cf_addr, payload, words);
                             if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
-                                eprintln!(
-                                    "[fbw-abort-flush] gh#467 callee-rebuild COMMIT \
+                                if ok {
+                                    eprintln!(
+                                        "[fbw-abort-flush] gh#467 callee-rebuild COMMIT \
                                          abort_jit_pc={abort_jit_pc} callee_py_pc={} \
                                          call_py_pc={} post_call_py_pc={}",
-                                    words.callee_py_pc, words.call_py_pc, words.post_call_py_pc,
+                                        words.callee_py_pc,
+                                        words.call_py_pc,
+                                        words.post_call_py_pc,
+                                    );
+                                } else {
+                                    eprintln!(
+                                        "[fbw-abort-flush] gh#467 callee-rebuild declined at \
+                                         callee_py_pc={}",
+                                        words.callee_py_pc,
+                                    );
+                                }
+                            }
+                            ok
+                        }
+                        None => {
+                            if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
+                                eprintln!(
+                                    "[fbw-abort-flush] gh#467 callee-rebuild declined at \
+                                     abort_jit_pc={abort_jit_pc} (unresolved carried jitcode \
+                                     identity or null code ptr)",
                                 );
                             }
-                            // This leg resumes INSIDE the rebuilt callee at its
-                            // abort pc — ahead of what the callee applied, not
-                            // behind it.  Nothing re-runs; committing is what
-                            // keeps those effects.
-                            let _ = commit_walk_end(
-                                WalkEndCommitLeg::CalleeRebuild,
-                                WalkEndResume::AfterApplied,
-                            );
-                        } else if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
-                            eprintln!(
-                                "[fbw-abort-flush] gh#467 callee-rebuild declined at \
-                                     callee_py_pc={} — legacy replay kept",
-                                words.callee_py_pc,
-                            );
+                            false
                         }
-                    } else if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
-                        eprintln!(
-                            "[fbw-abort-flush] gh#467 callee-rebuild declined at \
-                                 abort_jit_pc={abort_jit_pc} (unresolved carried jitcode identity \
-                                 or null code ptr) — legacy replay kept",
+                    };
+                    if rebuilt {
+                        // This leg resumes INSIDE the rebuilt callee at its
+                        // abort pc — ahead of what the callee applied, not
+                        // behind it.  Nothing re-runs; committing is what
+                        // keeps those effects.
+                        let _ = commit_walk_end(
+                            WalkEndCommitLeg::CalleeRebuild,
+                            WalkEndResume::AfterApplied,
+                        );
+                    } else if let Some(fallback) = payload.entry_fallback.as_ref() {
+                        // The rebuild declined but the entry latch's gate had
+                        // held, so rewinding to the outer CALL is still open.
+                        // Falling through to the legacy replay instead would
+                        // re-apply the non-journaled pre-CALL stores.
+                        committed_entry_carrier_call_py_pc = try_commit_entry_carrier_call(
+                            ctx,
+                            cf_addr,
+                            abort_jit_pc,
+                            payload.outer_jitcode_index,
+                            payload.call_jitcode_pc,
+                            &fallback.call_stack,
+                            fallback.entry_executed_effects,
                         );
                     }
                 }

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -163,10 +163,13 @@ pub(crate) enum WalkEndResume {
     /// the PREVIOUS opcode), and the flush sets `last_instr = pc - 1`
     /// (`state.rs`), so `next_instr()` re-executes that opcode.
     ///
-    /// Re-founding it on a commit-time sample would flip which walks commit
-    /// (the forcing residual bumps the odometer after the window is sampled),
-    /// so that is a measured change of its own and not part of introducing
-    /// this contract.
+    /// The proof is DECLARED, not measured: the window records each residual's
+    /// `EffectInfo` re-runnability class (`EF_ELIDABLE_*` / `EF_LOOPINVARIANT`),
+    /// the same axis upstream licenses `resumepc=orgpc` on
+    /// (`jtransform.py:620-630`).  A commit-time counter sample would answer a
+    /// different question — the forcing residual itself moves the odometer
+    /// after the window is read — and upstream's op counters gate nothing
+    /// (`jitprof.py:43-44`).
     RewindProvenAtLatch,
     /// The resume pc is AHEAD of what the walk applied — a rebuilt callee
     /// resumed at its own abort pc.  Nothing re-runs; committing is what

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -533,12 +533,19 @@ fn resolve_midbody_flush_words(
     })
 }
 
+/// Whether the caller's handler for the aborting CALL can be entered from the
+/// operand stack this leg can reconstruct.
+///
+/// `handle_exception` only ever POPS down to the handler's recorded depth
+/// (`eval.rs`, `pyopcode.py:151-173`), so restoring the `below` operands the
+/// CALL sat on is enough for any handler that wants at most that many.
 fn exception_delivery_stack_is_sourceable(
     handler_depth: u32,
+    below_len: usize,
     array_len: usize,
     stack_base: usize,
 ) -> bool {
-    handler_depth == 0 && array_len >= stack_base + 1
+    handler_depth as usize <= below_len && array_len >= stack_base + below_len + 1
 }
 
 /// Flush the OUTER frame at the CALL that entered the aborting callee and let
@@ -708,10 +715,11 @@ fn try_commit_midbody_abort_inner(
         if let Some((_target, depth, _lasti)) = outer_handler {
             if !exception_delivery_stack_is_sourceable(
                 depth,
+                below.len(),
                 outer.locals_w().as_slice().len(),
                 outer_stack_base,
             ) {
-                return Err("caller handler keeps an operand below the call");
+                return Err("caller handler wants more operands than the call sat on");
             }
         }
         // G7: materialize every outer local before the rebuilt callee can run.
@@ -723,13 +731,14 @@ fn try_commit_midbody_abort_inner(
     }
     let mut w_code = payload.w_code;
     let mut w_globals = payload.w_globals;
-    let mut x_arg = payload.x_arg;
     let _w_code_root = ObjectSlotRoot::new(&mut w_code);
     let _w_globals_root = ObjectSlotRoot::new(&mut w_globals);
-    let _x_arg_root = ObjectSlotRoot::new(&mut x_arg);
+    // No positional seed: `finish_for_call_with_globals_obj` only binds
+    // `args` into the first `varnames` slots, and every one of them is
+    // cleared to PY_NULL and rewritten from `live_locals` just below.
     let frame = match pyre_interpreter::PyFrame::try_new_for_call_with_closure_and_globals_obj(
         w_code as *const (),
-        &[x_arg],
+        &[],
         w_globals,
         ec,
         pyre_object::PY_NULL,
@@ -800,26 +809,25 @@ fn try_commit_midbody_abort_inner(
     frame.valuestackdepth = stack_base + current.live_stack.len();
     frame.last_instr = words.callee_py_pc as isize - 1;
     let sys_exc_value_pre = unsafe { (*ec).sys_exc_value };
-    match frame.execute_frame(None, None) {
+    let ran = frame.execute_frame(None, None);
+    // `below` came from a clone taken BEFORE the callee ran; a minor collection
+    // inside it can have moved those objects.  Re-read them from the live
+    // carrier, which the abort-resume GC root area keeps forwarded.
+    let fresh = crate::jitcode_dispatch::fbw_abort_carrier_clone();
+    let below_now = match (below.len(), fresh.as_ref()) {
+        (0, _) => &[][..],
+        (n, Some(crate::jitcode_dispatch::InlineAbortCarrier::MidBody(fresh))) => {
+            match fresh.entry_fallback.as_ref() {
+                Some(fallback) if fallback.call_stack.len() >= n => &fallback.call_stack[..n],
+                _ => return Err("entry fallback vanished while the callee ran"),
+            }
+        }
+        _ => return Err("carrier is no longer a MidBody after the callee ran"),
+    };
+    match ran {
         Ok(mut retval) => {
             crate::jitcode_dispatch::fbw_abort_carrier_set_return(retval);
             let _retval_root = ObjectSlotRoot::new(&mut retval);
-            // `below` came from a clone taken BEFORE the callee ran; a minor
-            // collection inside it can have moved those objects.  Re-read them
-            // from the live carrier, which the abort-resume GC root area keeps
-            // forwarded.
-            let fresh = crate::jitcode_dispatch::fbw_abort_carrier_clone();
-            let below_now = match (below.len(), fresh.as_ref()) {
-                (0, _) => &[][..],
-                (
-                    n,
-                    Some(crate::jitcode_dispatch::InlineAbortCarrier::MidBody(fresh)),
-                ) => match fresh.entry_fallback.as_ref() {
-                    Some(fallback) if fallback.call_stack.len() >= n => &fallback.call_stack[..n],
-                    _ => return Err("entry fallback vanished while the callee ran"),
-                },
-                _ => return Err("carrier is no longer a MidBody after the callee ran"),
-            };
             // The callee has already RUN.  A false here is not a plain
             // decline: it drops to the legacy replay with the callee's
             // effects applied.
@@ -847,8 +855,15 @@ fn try_commit_midbody_abort_inner(
                 return Err("callee raised and this site has no propagate licence");
             }
             let outer = unsafe { &mut *(cf_addr as *mut pyre_interpreter::PyFrame) };
+            // The handler unwinds from the operand level the CALL raised at,
+            // which for an expression-position call is not the empty one.
+            let arr_ptr = outer.locals_w_mut() as *mut _;
+            outer.locals_w_mut().as_mut_slice()
+                [outer_stack_base..outer_stack_base + below_now.len()]
+                .copy_from_slice(below_now);
+            crate::state::frame_array_write_barrier(cf_addr as *mut u8, arr_ptr);
             outer.last_instr = words.call_py_pc as isize;
-            outer.valuestackdepth = outer_stack_base;
+            outer.valuestackdepth = outer_stack_base + below_now.len();
             let mut next_instr = words.call_py_pc;
             if pyre_interpreter::eval::handle_exception(outer, &mut operr, &mut next_instr) {
                 outer.last_instr = next_instr as isize - 1;
@@ -4591,10 +4606,17 @@ mod tests {
     }
 
     #[test]
-    fn forward_exception_delivery_requires_exact_empty_handler_stack() {
-        assert!(super::exception_delivery_stack_is_sourceable(0, 8, 7));
-        assert!(!super::exception_delivery_stack_is_sourceable(1, 9, 7));
-        assert!(!super::exception_delivery_stack_is_sourceable(0, 7, 7));
+    fn forward_exception_delivery_needs_a_handler_the_call_operands_can_fill() {
+        // Statement position: nothing below the call, empty-stack handler.
+        assert!(super::exception_delivery_stack_is_sourceable(0, 0, 8, 7));
+        assert!(!super::exception_delivery_stack_is_sourceable(1, 0, 9, 7));
+        // Expression position: one operand below, handler wanting 0 or 1.
+        assert!(super::exception_delivery_stack_is_sourceable(1, 1, 9, 7));
+        assert!(super::exception_delivery_stack_is_sourceable(0, 1, 9, 7));
+        assert!(!super::exception_delivery_stack_is_sourceable(2, 1, 9, 7));
+        // The array must hold the restored operands plus the pushed exception.
+        assert!(!super::exception_delivery_stack_is_sourceable(0, 0, 7, 7));
+        assert!(!super::exception_delivery_stack_is_sourceable(1, 1, 8, 7));
     }
 }
 

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -611,6 +611,32 @@ fn try_commit_entry_carrier_call(
     Some(call_py_pc)
 }
 
+/// Why a callee rebuild did not commit — and whether the callee body had
+/// already executed when that was decided.
+///
+/// The distinction is load-bearing, not diagnostic.  The caller's fallback is
+/// `EntryCarrierCall`, which rewinds the outer frame to its CALL; taking that
+/// after `frame.execute_frame` has run the callee runs the callee a SECOND
+/// time.  `walk_end_resume_provable` cannot catch it, because the odometer it
+/// samples (`FBW_EXECUTED_EFFECT_COUNT`) is walker-side and the plain
+/// interpretation inside `execute_frame` never bumps it.
+enum MidBodyDecline {
+    /// Refused before the callee ran; none of its effects are applied, so
+    /// rewinding the caller to its CALL is still sound.
+    BeforeRun(&'static str),
+    /// The callee body already ran.  Its effects are applied and there is no
+    /// journal undo for them, so no rewinding leg may be selected.
+    AfterRun(&'static str),
+}
+
+impl MidBodyDecline {
+    fn reason(&self) -> &'static str {
+        match self {
+            Self::BeforeRun(reason) | Self::AfterRun(reason) => reason,
+        }
+    }
+}
+
 /// Wrapper that names which narrowing kept a rebuild off leg 4; the reason
 /// otherwise vanishes into the entry-carrier fallback.
 fn try_commit_midbody_abort(
@@ -618,20 +644,22 @@ fn try_commit_midbody_abort(
     cf_addr: usize,
     payload: &crate::jitcode_dispatch::MidBodyPayload,
     words: MidBodyFlushWords,
-) -> bool {
-    match try_commit_midbody_abort_inner(ctx, cf_addr, payload, words) {
-        Ok(()) => true,
-        Err(reason) => {
-            if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
-                eprintln!(
-                    "[fbw-abort-flush] gh#467 callee-rebuild NOT COMMITTED at \
-                     callee_py_pc={} ({reason})",
-                    words.callee_py_pc,
-                );
-            }
-            false
-        }
+) -> Result<(), MidBodyDecline> {
+    let outcome = try_commit_midbody_abort_inner(ctx, cf_addr, payload, words);
+    if let Err(decline) = &outcome
+        && crate::jitcode_dispatch::fbw_debug_abort_enabled()
+    {
+        eprintln!(
+            "[fbw-abort-flush] gh#467 callee-rebuild NOT COMMITTED at callee_py_pc={} ({}){}",
+            words.callee_py_pc,
+            decline.reason(),
+            match decline {
+                MidBodyDecline::AfterRun(_) => " — callee already ran, no rewinding leg eligible",
+                MidBodyDecline::BeforeRun(_) => "",
+            },
+        );
     }
+    outcome
 }
 
 fn try_commit_midbody_abort_inner(
@@ -639,7 +667,7 @@ fn try_commit_midbody_abort_inner(
     cf_addr: usize,
     payload: &crate::jitcode_dispatch::MidBodyPayload,
     words: MidBodyFlushWords,
-) -> Result<(), &'static str> {
+) -> Result<(), MidBodyDecline> {
     // An expression-position call sits on top of operands the payload does not
     // record — it counts only the call's own `[callable, null_or_self, args…]`.
     // The entry fallback's `reconstructed_all_ref_call_stack` is the caller's
@@ -659,11 +687,17 @@ fn try_commit_midbody_abort_inner(
                 .map(|fallback| fallback.call_stack.as_slice())
                 .filter(|full| full.len() == n + payload.call_stack_len)
             else {
-                return Err("expression-position call with no reconstructed stack below it");
+                return Err(MidBodyDecline::BeforeRun(
+                    "expression-position call with no reconstructed stack below it",
+                ));
             };
             &full[..n]
         }
-        None => return Err("caller stack depth does not model this call shape"),
+        None => {
+            return Err(MidBodyDecline::BeforeRun(
+                "caller stack depth does not model this call shape",
+            ));
+        }
     };
     if !crate::state::can_flush_walk_end_state_after_outer_call(
         ctx,
@@ -673,13 +707,15 @@ fn try_commit_midbody_abort_inner(
         payload.call_stack_len,
         below,
     ) {
-        return Err("outer call boundary not flushable");
+        return Err(MidBodyDecline::BeforeRun(
+            "outer call boundary not flushable",
+        ));
     }
     let raw = unsafe {
         pyre_interpreter::w_code_get_ptr(payload.w_code) as *const pyre_interpreter::CodeObject
     };
     if raw.is_null() {
-        return Err("null callee code ptr");
+        return Err(MidBodyDecline::BeforeRun("null callee code ptr"));
     }
     let code = unsafe { &*raw };
     // Only portal trace sites currently carry `_exit_frame_with_exception`
@@ -690,15 +726,17 @@ fn try_commit_midbody_abort_inner(
         && (!code.exceptiontable.is_empty()
             || !midbody_post_marker_is_effect_free(code, words.callee_py_pc))
     {
-        return Err("no propagate licence and callee body can raise");
+        return Err(MidBodyDecline::BeforeRun(
+            "no propagate licence and callee body can raise",
+        ));
     }
     if cf_addr == 0 {
-        return Err("no live caller frame");
+        return Err(MidBodyDecline::BeforeRun("no live caller frame"));
     }
     let ec = unsafe { (*(cf_addr as *const pyre_interpreter::PyFrame)).execution_context }
         as *mut pyre_interpreter::PyExecutionContext;
     if ec.is_null() {
-        return Err("null execution context");
+        return Err(MidBodyDecline::BeforeRun("null execution context"));
     }
     let propagate_allowed = WALK_END_PROPAGATE_ALLOWED.with(|c| c.get());
     let outer = unsafe { &mut *(cf_addr as *mut pyre_interpreter::PyFrame) };
@@ -719,14 +757,18 @@ fn try_commit_midbody_abort_inner(
                 outer.locals_w().as_slice().len(),
                 outer_stack_base,
             ) {
-                return Err("caller handler wants more operands than the call sat on");
+                return Err(MidBodyDecline::BeforeRun(
+                    "caller handler wants more operands than the call sat on",
+                ));
             }
         }
         // G7: materialize every outer local before the rebuilt callee can run.
         // `can_flush_walk_end_state_after_outer_call` already proved all
         // shadow entries sourceable, so no post-effect decline remains.
         if !crate::state::write_back_outer_locals(ctx, cf_addr) {
-            return Err("an outer local is not sourceable");
+            return Err(MidBodyDecline::BeforeRun(
+                "an outer local is not sourceable",
+            ));
         }
     }
     let mut w_code = payload.w_code;
@@ -745,7 +787,7 @@ fn try_commit_midbody_abort_inner(
         pyre_interpreter::pyframe::FrameLocalsArrayAllocation::OldGenGc,
     ) {
         Ok(frame) => frame,
-        Err(_) => return Err("callee frame allocation failed"),
+        Err(_) => return Err(MidBodyDecline::BeforeRun("callee frame allocation failed")),
     };
     let mut frame = pyre_interpreter::pyframe::FrameBox::new(frame);
     frame.fix_array_ptrs();
@@ -754,10 +796,12 @@ fn try_commit_midbody_abort_inner(
     let Some(crate::jitcode_dispatch::InlineAbortCarrier::MidBody(current)) =
         crate::jitcode_dispatch::fbw_abort_carrier_clone()
     else {
-        return Err("carrier is no longer a MidBody");
+        return Err(MidBodyDecline::BeforeRun("carrier is no longer a MidBody"));
     };
     if current.live_locals.len() != code.varnames.len() {
-        return Err("live_locals length does not match varnames");
+        return Err(MidBodyDecline::BeforeRun(
+            "live_locals length does not match varnames",
+        ));
     }
     for slot in &mut frame.locals_w_mut().as_mut_slice()[..code.varnames.len()] {
         *slot = pyre_object::PY_NULL;
@@ -772,7 +816,7 @@ fn try_commit_midbody_abort_inner(
     let stack_base = code.varnames.len() + pyre_interpreter::pyframe::ncells(code);
     for (rel, value) in current.live_stack.iter().enumerate() {
         let crate::state::ConcreteValue::Ref(value) = value else {
-            return Err("live stack slot is not a Ref");
+            return Err(MidBodyDecline::BeforeRun("live stack slot is not a Ref"));
         };
         frame.locals_w_mut().as_mut_slice()[stack_base + rel] = *value;
     }
@@ -798,7 +842,7 @@ fn try_commit_midbody_abort_inner(
                 pyre_object::floatobject::w_float_new(*value)
             }
             Some(crate::state::ConcreteValue::Null | crate::state::ConcreteValue::Bool(_)) => {
-                return Err("live local is Null/Bool");
+                return Err(MidBodyDecline::BeforeRun("live local is Null/Bool"));
             }
         };
     }
@@ -819,10 +863,18 @@ fn try_commit_midbody_abort_inner(
         (n, Some(crate::jitcode_dispatch::InlineAbortCarrier::MidBody(fresh))) => {
             match fresh.entry_fallback.as_ref() {
                 Some(fallback) if fallback.call_stack.len() >= n => &fallback.call_stack[..n],
-                _ => return Err("entry fallback vanished while the callee ran"),
+                _ => {
+                    return Err(MidBodyDecline::AfterRun(
+                        "entry fallback vanished while the callee ran",
+                    ));
+                }
             }
         }
-        _ => return Err("carrier is no longer a MidBody after the callee ran"),
+        _ => {
+            return Err(MidBodyDecline::AfterRun(
+                "carrier is no longer a MidBody after the callee ran",
+            ));
+        }
     };
     match ran {
         Ok(mut retval) => {
@@ -842,7 +894,9 @@ fn try_commit_midbody_abort_inner(
             ) {
                 Ok(())
             } else {
-                Err("post-call caller flush declined AFTER the callee ran")
+                Err(MidBodyDecline::AfterRun(
+                    "post-call caller flush declined AFTER the callee ran",
+                ))
             }
         }
         Err(mut operr) => {
@@ -852,7 +906,9 @@ fn try_commit_midbody_abort_inner(
             // selected handler onward.
             unsafe { (*ec).sys_exc_value = sys_exc_value_pre };
             if !propagate_allowed {
-                return Err("callee raised and this site has no propagate licence");
+                return Err(MidBodyDecline::AfterRun(
+                    "callee raised and this site has no propagate licence",
+                ));
             }
             let outer = unsafe { &mut *(cf_addr as *mut pyre_interpreter::PyFrame) };
             // The handler unwinds from the operand level the CALL raised at,
@@ -3056,24 +3112,17 @@ fn run_perfn_walk<Sym: WalkSym>(
                 {
                     let rebuilt = match resolve_midbody_flush_words(payload) {
                         Some(words) => {
-                            let ok = try_commit_midbody_abort(ctx, cf_addr, payload, words);
-                            if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
-                                if ok {
-                                    eprintln!(
-                                        "[fbw-abort-flush] gh#467 callee-rebuild COMMIT \
-                                         abort_jit_pc={abort_jit_pc} callee_py_pc={} \
-                                         call_py_pc={} post_call_py_pc={}",
-                                        words.callee_py_pc, words.call_py_pc, words.post_call_py_pc,
-                                    );
-                                } else {
-                                    eprintln!(
-                                        "[fbw-abort-flush] gh#467 callee-rebuild declined at \
-                                         callee_py_pc={}",
-                                        words.callee_py_pc,
-                                    );
-                                }
+                            let outcome = try_commit_midbody_abort(ctx, cf_addr, payload, words);
+                            if outcome.is_ok() && crate::jitcode_dispatch::fbw_debug_abort_enabled()
+                            {
+                                eprintln!(
+                                    "[fbw-abort-flush] gh#467 callee-rebuild COMMIT \
+                                     abort_jit_pc={abort_jit_pc} callee_py_pc={} \
+                                     call_py_pc={} post_call_py_pc={}",
+                                    words.callee_py_pc, words.call_py_pc, words.post_call_py_pc,
+                                );
                             }
-                            ok
+                            outcome
                         }
                         None => {
                             if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
@@ -3083,32 +3132,61 @@ fn run_perfn_walk<Sym: WalkSym>(
                                      identity or null code ptr)",
                                 );
                             }
-                            false
+                            // Nothing was rebuilt, so nothing of the callee ran.
+                            Err(MidBodyDecline::BeforeRun("unresolved jitcode identity"))
                         }
                     };
-                    if rebuilt {
-                        // This leg resumes INSIDE the rebuilt callee at its
-                        // abort pc — ahead of what the callee applied, not
-                        // behind it.  Nothing re-runs; committing is what
-                        // keeps those effects.
-                        let _ = commit_walk_end(
-                            WalkEndCommitLeg::CalleeRebuild,
-                            WalkEndResume::AfterApplied,
-                        );
-                    } else if let Some(fallback) = payload.entry_fallback.as_ref() {
-                        // The rebuild declined but the entry latch's gate had
-                        // held, so rewinding to the outer CALL is still open.
-                        // Falling through to the legacy replay instead would
-                        // re-apply the non-journaled pre-CALL stores.
-                        committed_entry_carrier_call_py_pc = try_commit_entry_carrier_call(
-                            ctx,
-                            cf_addr,
-                            abort_jit_pc,
-                            payload.outer_jitcode_index,
-                            payload.call_jitcode_pc,
-                            &fallback.call_stack,
-                            fallback.entry_executed_effects,
-                        );
+                    match rebuilt {
+                        Ok(()) => {
+                            // This leg resumes INSIDE the rebuilt callee at its
+                            // abort pc — ahead of what the callee applied, not
+                            // behind it.  Nothing re-runs; committing is what
+                            // keeps those effects.
+                            let _ = commit_walk_end(
+                                WalkEndCommitLeg::CalleeRebuild,
+                                WalkEndResume::AfterApplied,
+                            );
+                        }
+                        Err(MidBodyDecline::BeforeRun(_)) => {
+                            if let Some(fallback) = payload.entry_fallback.as_ref() {
+                                // The rebuild declined before running anything
+                                // and the entry latch's gate had held, so
+                                // rewinding to the outer CALL is still open.
+                                // Falling through to the legacy replay instead
+                                // would re-apply the non-journaled pre-CALL
+                                // stores.
+                                committed_entry_carrier_call_py_pc = try_commit_entry_carrier_call(
+                                    ctx,
+                                    cf_addr,
+                                    abort_jit_pc,
+                                    payload.outer_jitcode_index,
+                                    payload.call_jitcode_pc,
+                                    &fallback.call_stack,
+                                    fallback.entry_executed_effects,
+                                );
+                            }
+                        }
+                        Err(MidBodyDecline::AfterRun(_)) => {
+                            // The callee body already executed.  `EntryCarrierCall`
+                            // rewinds the outer frame to its CALL, which would run
+                            // that body a SECOND time — the gh#467 double-apply.
+                            // Its `walk_end_resume_provable` re-check does not stop
+                            // it: that samples `FBW_EXECUTED_EFFECT_COUNT`, which is
+                            // walker-side, and the plain interpretation inside
+                            // `execute_frame` never bumps it.  So take no leg.
+                            //
+                            // ⚠️This NARROWS the hazard, it does not close it: the
+                            // legacy replay this falls through to re-enters the
+                            // outer frame at its entry and re-runs the CALL too.
+                            // The callee's effects are user code and the store
+                            // journal does not cover them, so neither branch can
+                            // undo them.  Closing it means making the post-run path
+                            // infallible — every one of these declines already has a
+                            // pre-run counterpart (`can_flush_walk_end_state_after_
+                            // outer_call`, the propagate licence), so reaching here
+                            // means a pre-check was too weak, not that a new
+                            // fallback is needed.
+                        }
                     }
                 }
                 None if is_marker_abort => {

--- a/walk-end-commit.plan.md
+++ b/walk-end-commit.plan.md
@@ -1,6 +1,6 @@
 # Walk-end commit contract — convergence roadmap
 
-Status: **R1–R3 landed; R4–R6 open.** This is the authoritative plan for
+Status: **R1–R4 landed; R5–R6 open.** This is the authoritative plan for
 retiring the walk-end commit gates in `run_perfn_walk`'s epilogue. It supersedes
 the reasoning in the comments those gates carry, and it records two claims that
 were in the tree and are **false**.
@@ -92,25 +92,31 @@ way. They differ in operand-stack sourcing and in whether any gate ran.
   (`residual_call.rs`, `flush_active_frame_escape`).
 - Naming the one journal-keeping path that sat outside the contract
   (`TerminateNoReplay`), so no commit path is anonymous in the census.
+- **R4** — the escape gate is now founded on a declared effect class.
+  `ESCAPE_OPCODE_WINDOW` holds `(py_pc, every_prior_residual_reentrant)`;
+  `escape_opcode_window_clean` is a pure query; `escape_opcode_window_note`
+  records each residual's `EffectInfo` class (`check_is_elidable` /
+  `LoopInvariant`) after the call returns, so the gate and a force inside the
+  callee both see the window as it stood *before* that residual. The ordering
+  hazard below was respected — this is a reclassification, not a resample, and
+  the CA-bench census is unchanged.
+
+  `reentrant_residual` is deliberately stricter than `provably_side_effect_free`
+  (it drops the `ForIterNext` exemption, which answers the in-flight FOR_ITER
+  question, not the opcode-re-execution one), so it covers both runtime signals
+  it replaced: advancing `frame_entry_count` or bumping the odometer both
+  require a non-elidable, non-loop-invariant residual. The three journaled folds
+  that also bump the odometer each terminate their own opcode, so no residual of
+  the same opcode instance can follow one.
+
+  Not addressed, and unchanged from before: the window is still keyed on `py_pc`
+  alone, so an opcode revisited across walked inner-loop iterations still sees
+  the first visit's verdict. That is conservative (decline → legacy); the
+  refinement is a back-edge reset, and it belongs with R6.
 
 ---
 
 ## Open
-
-### R4 — re-found the escape gate on a static effect class
-
-Replace the runtime window comparison in `escape_opcode_window_clean`
-(`residual_call.rs`; compares `frame_entry_count` and
-`fbw_executed_effect_count` sampled at the first residual of the opcode) with a
-per-callee effect classification decided once, the way `EffectInfo` is decided
-at codewriter time (`jtransform.py:620-630`).
-
-This is the item that makes `RewindProvenAtLatch` collapse into a real proof
-rather than a named gap. Note the ordering hazard: re-founding the *existing*
-gate on a commit-time sample instead (the obvious-looking move) would flip which
-walks commit — the forcing residual bumps the odometer *after* the window is
-sampled — and per TL;DR §3 the branch it would flip into is not safe either. So
-this must be a static reclassification, not a resampling.
 
 ### R5 — generalize leg 4, then let legs 3 and 6 become unreachable
 
@@ -128,6 +134,22 @@ drop the `fbw_executed_effect_count() != executed_effects_before` conjunct,
 which is a routing filter rather than a safety gate and currently makes the
 orthodox path the exception. Legs 3 and 6 then retire by becoming
 **unreachable**, not by deletion.
+
+The eligibility set to lift is `inline_call.rs`, the `midbody_abort` payload
+builder — in the order they refuse:
+
+| # | refusal | upstream counterpart |
+|---|---|---|
+| 1 | `is_top_inline` (depth-1 only) | none — upstream loops over the whole `framestack` (`blackhole.py:1799-1821`) |
+| 2 | `fbw_executed_effect_count() != executed_effects_before` | none — routing filter, drop it |
+| 3 | `!fbw_has_unjournaled_effect()` | ⚠️KEEP — see below |
+| 4 | generator / `cellvars` / `freevars` / non-null closure | none — upstream rebuilds any frame |
+| 5 | `callee_arg_concretes.first()` must be a `Ref` (`x_arg`) | none — single-argument residue |
+| 6 | every live stack slot a non-null `Ref`; every live local resolvable and not `Null`/`Bool` | partial — upstream reads typed registers per frame |
+| 7 | `anchor_ok` / `abort_flush_call_jitcode_coord` / `depth`+`pcdep` resolvable | pyre's jitcode↔py_pc mapping, orthogonal |
+
+Rows 1, 4 and 5 are the ones the per-level `PyFrame` materialization blocks;
+rows 2 and 6 are independent of it and can move first.
 
 ⚠️Do **not** drop the other conjunct, `!fbw_has_unjournaled_effect()`. Upstream's
 `execute_and_record` executes *then* records (`pyjitpl.py:2647-2662`), so

--- a/walk-end-commit.plan.md
+++ b/walk-end-commit.plan.md
@@ -141,15 +141,56 @@ builder — in the order they refuse:
 | # | refusal | upstream counterpart |
 |---|---|---|
 | 1 | `is_top_inline` (depth-1 only) | none — upstream loops over the whole `framestack` (`blackhole.py:1799-1821`) |
-| 2 | `fbw_executed_effect_count() != executed_effects_before` | none — routing filter, drop it |
+| 2 | ~~`fbw_executed_effect_count() != executed_effects_before`~~ | dropped (slice A) |
 | 3 | `!fbw_has_unjournaled_effect()` | ⚠️KEEP — see below |
-| 4 | generator / `cellvars` / `freevars` / non-null closure | none — upstream rebuilds any frame |
+| 4a | callee is a generator / coroutine | ✅CORRECT, keep — see below |
+| 4b | `cellvars` / `freevars` / non-null closure | none — upstream rebuilds any frame |
 | 5 | `callee_arg_concretes.first()` must be a `Ref` (`x_arg`) | none — single-argument residue |
 | 6 | every live stack slot a non-null `Ref`; every live local resolvable and not `Null`/`Bool` | partial — upstream reads typed registers per frame |
-| 7 | `anchor_ok` / `abort_flush_call_jitcode_coord` / `depth`+`pcdep` resolvable | pyre's jitcode↔py_pc mapping, orthogonal |
+| 7 | `anchor_ok` / `abort_flush_call_jitcode_coord` / `depth`+`pcdep` resolvable | pyre's jitcode↔py_pc mapping, the F1 charter deviation |
 
-Rows 1, 4 and 5 are the ones the per-level `PyFrame` materialization blocks;
-rows 2 and 6 are independent of it and can move first.
+#### ⛔The assumed blocker is not the measured one
+
+The blocker recorded here before slice A — per-level `PyFrame` materialization,
+i.e. rows 1/4/5 — **is refuted by measurement**. Slice A dropped row 2 and made
+leg 4 preferred; the conversion was **zero**. Census over `pyre/bench/synth`
+(315 files, `PYRE_FBW_DEBUG_ABORT=1`):
+
+| | count |
+|---|---|
+| leg 3 `EntryCarrierCall` commits | 169 |
+| leg 4 `CalleeRebuild` commits | 1 |
+| refusal: callee is a generator | 151 |
+| refusal: abort pc is not an exact segment anchor | 18 |
+| refusal: first callee argument is not a `Ref` | 1 |
+
+Row 1 never fired. Rows 4b and 6 never fired. Print the denominator: 149 of the
+151 generator refusals come from one loop in `calls_closures.py`, and the 18
+anchor refusals are spread over 5 files (`foriter_exempt_nested_foriter`,
+`foriter_exempt_shared_generator`, `inline_subwalk_user_iterator`,
+`selfrec_tail_exception_unwind`, `bridge_recursion_overflow`).
+
+#### Row 4a is correct and must stay
+
+Rebuilding a generator callee would run its body eagerly instead of producing a
+generator object, so leg 4 refusing it is right. What is *not* right is that the
+call was inlined at all: `resolve_inlinable_callee` (`jitcode_dispatch/mod.rs`)
+has no `code_flags_make_generator` guard, so the walker inlines `gen(6)` and
+starts walking the generator body, escaping only via an abort. Verified **not** a
+miscompile (jit / `PYRE_NO_JIT=1` / CPython agree on a `yield`-per-`next` probe)
+— it is wasted tracing, and a separate defect from this plan.
+
+⇒ the honest denominator for R5 is **19**, not 170, and row 7's anchor is the
+dominant real blocker.
+
+#### Next slice: row 7 (the segment anchor)
+
+`exact_floor_segment_anchor` (`jitcode_dispatch/mod.rs`) demands the abort
+jitcode pc be the exact FIRST jitcode op of its Python pc's floor segment,
+because leg 4 rebuilds a **Python** frame at a **Python** pc. Upstream needs no
+such mapping: `_copy_data_from_miframe` (`blackhole.py:1711-1712`) resumes each
+blackhole at its **jitcode** position. This is the F1 charter deviation
+(py_pc ↔ jitcode), so the slice is scoped by it rather than by frame layout.
 
 ⚠️Do **not** drop the other conjunct, `!fbw_has_unjournaled_effect()`. Upstream's
 `execute_and_record` executes *then* records (`pyjitpl.py:2647-2662`), so
@@ -157,10 +198,12 @@ rows 2 and 6 are independent of it and can move first.
 can record without executing, so that state is real and the conjunct is
 load-bearing. It dies with the two-executor split, not with the odometer.
 
-Blocker: per-level `PyFrame` materialization (`fbw_strict_fold_frame_reg`,
-`vable_ops.rs`). Upstream avoids it only because `_nonstandard_virtualizable`
-already degraded callee frames to heap fields (`pyjitpl.py:1120-1146`).
-Tracked upstream of this as the inner-frame rebuild (gh#126/#215).
+Per-level `PyFrame` materialization (`fbw_strict_fold_frame_reg`,
+`vable_ops.rs`; the inner-frame rebuild, gh#126/#215) is still the blocker for
+row 1 *in principle* — upstream avoids it only because
+`_nonstandard_virtualizable` already degraded callee frames to heap fields
+(`pyjitpl.py:1120-1146`) — but no corpus case reaches it yet, so it is not what
+gates progress today.
 
 ### R6 — vable write-through parity
 

--- a/walk-end-commit.plan.md
+++ b/walk-end-commit.plan.md
@@ -1,0 +1,183 @@
+# Walk-end commit contract — convergence roadmap
+
+Status: **R1–R3 landed; R4–R6 open.** This is the authoritative plan for
+retiring the walk-end commit gates in `run_perfn_walk`'s epilogue. It supersedes
+the reasoning in the comments those gates carry, and it records two claims that
+were in the tree and are **false**.
+
+The contract itself (`WalkEndResume` in `pyre/pyre-jit-trace/src/trace.rs`) is
+scaffolding that makes the deviation visible and typed. It is **not** the end
+state. The end state is that most of it does not exist.
+
+---
+
+## TL;DR / disposition
+
+1. **"Upstream never rewinds" is false.** `opimpl_str_guard_value`
+   (`rpython/jit/metainterp/pyjitpl.py:1498-1511`) runs a real
+   `do_residual_call` and then records `generate_guard(GUARD_VALUE,
+   resumepc=orgpc)` — an *earlier* pc, which `capture_resumedata` stamps into
+   the frame (`pyjitpl.py:2617-2620`). The sentence was in `trace.rs` and is now
+   corrected there.
+
+2. **The real upstream rule is static, not dynamic.** Upstream may rewind to an
+   opcode start; it forbids rewinding past an *effectful* residual; and it
+   decides **both** at codewriter time, never by measuring at runtime:
+   - permission — `EffectInfo.EF_ELIDABLE_CANNOT_RAISE`
+     (`rpython/jit/codewriter/jtransform.py:620-630`)
+   - prohibition — per-opnum: the four guards that can follow a residual take
+     `after_residual_call`, pinning the resume pc to the POST-call `self.pc`
+     (`pyjitpl.py:2599-2602` → `194-198`)
+   - upstream's only op counters are profiling-only and gate nothing
+     (`rpython/jit/metainterp/jitprof.py:43-44`, `count_ops` is `pass`)
+
+   So `FBW_EXECUTED_EFFECT_COUNT` discharges an obligation upstream **also
+   has**, in a form upstream **does not use**. The convergence target is a
+   static effect classification (R4), not deletion of the obligation.
+
+3. **"Declining falls back to a safe replay" is false.** The store journal
+   covers five folded classes only — list `STORE_SUBSCR`, `append`,
+   append-promote, `IntMutableCell`, `sys_exc_value`
+   (`pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs:4797-4874`) — and
+   `FBW_FORITER_INFLIGHT` states outright that "the advance is an irreversible
+   side effect with no journal undo" (`:4878-4880`). **Both branches of a
+   decline can be unsound.** No new refusal may be justified by "the legacy
+   replay is exactly-once", and this is why R7 is rejected.
+
+4. **Leg 4 (`CalleeRebuild`) is the only orthodox leg**, and upstream's version
+   of it is unconditional. Everything else converges toward it.
+
+---
+
+## The commit paths today
+
+`pyre/pyre-jit-trace/src/trace.rs`, `WalkEndCommitLeg` / `WalkEndResume`.
+
+| leg | resumes at | class | note |
+|---|---|---|---|
+| 1 `LoopHeader` | walk terminal | `Terminal` | |
+| 2 `VableEscape` ×2 (blackhole adopts) | a frame RESULT | `Terminal` | |
+| 2 `VableEscape` (epilogue, latched) | the escaping OPCODE | `RewindProvenAtLatch` | proof taken earlier, at the residual |
+| 2 `VableEscape` (epilogue, merge-point fallback) | same pc, **no gate anywhere** | `RewindUnproven` → always declined | |
+| 3 `EntryCarrierCall` | outer frame AT the CALL | `Rewind` | snapshot on `InlineAbortCarrier::Entry` |
+| 4 `CalleeRebuild` | INSIDE rebuilt callee at abort pc | `AfterApplied` | latches BECAUSE the odometer moved |
+| 5 `AbortPc` | the marker opcode | `Terminal` | |
+| 6 `NestedInlineOuterCall` | outermost inline CALL | `Rewind` | snapshot on `FBW_ABORT_OUTER_RESUME` |
+| 7 `BranchGuard` | abort pc + inflight LIFO | `Terminal` | |
+| 8 `TerminateNoReplay` | no resume pc at all | `Terminal` | **not a flush leg**; keeps the journal by a different caller protocol and must not set `WALK_END_FLUSH_COMMITTED` |
+
+`vstack_cur_pypc` is the pc the walk is **about to enter**:
+`reconcile_vstack_at_boundary` reconciles the PREVIOUS opcode and then assigns
+`new_pypc` (`jitcode_dispatch/vstack_mirror.rs:272-281`, `:518`). Both escape
+flushes therefore take the same resume pc and both set
+`last_instr = pc - 1` (`state.rs:4404`), so the escaping opcode re-runs either
+way. They differ in operand-stack sourcing and in whether any gate ran.
+
+---
+
+## Landed
+
+- **R1** — corrected the false "upstream never rewinds" claim in `trace.rs`, and
+  the false "`vstack_cur_pypc` points one past the executing op" comment in
+  `residual_call.rs`.
+- **R2 (first half)** — settled `vstack_cur_pypc`; reclassified the latched
+  escape flush from `Terminal` (which short-circuits the check) to
+  `RewindProvenAtLatch`; deleted the dead `escape_opcode_window_effects`.
+- **R3** — no deletion was performed, deliberately. The merge-point fallback's
+  commit branch is already **unreachable at the code level** (`commit_walk_end`
+  declines `RewindUnproven` unconditionally). Deleting more would break the
+  escape-token force signal: the plain flush is what makes the live frame
+  heap-authoritative for the escaping callee, and its undo can only run in the
+  epilogue, after the callee has returned
+  (`residual_call.rs`, `flush_active_frame_escape`).
+- Naming the one journal-keeping path that sat outside the contract
+  (`TerminateNoReplay`), so no commit path is anonymous in the census.
+
+---
+
+## Open
+
+### R4 — re-found the escape gate on a static effect class
+
+Replace the runtime window comparison in `escape_opcode_window_clean`
+(`residual_call.rs`; compares `frame_entry_count` and
+`fbw_executed_effect_count` sampled at the first residual of the opcode) with a
+per-callee effect classification decided once, the way `EffectInfo` is decided
+at codewriter time (`jtransform.py:620-630`).
+
+This is the item that makes `RewindProvenAtLatch` collapse into a real proof
+rather than a named gap. Note the ordering hazard: re-founding the *existing*
+gate on a commit-time sample instead (the obvious-looking move) would flip which
+walks commit — the forcing residual bumps the odometer *after* the window is
+sampled — and per TL;DR §3 the branch it would flip into is not safe either. So
+this must be a static reclassification, not a resampling.
+
+### R5 — generalize leg 4, then let legs 3 and 6 become unreachable
+
+Upstream builds one blackhole per framestack frame, each at its own current pc
+(`rpython/jit/metainterp/blackhole.py:1799-1821`, `:1711-1712`), and splices the
+callee result into the caller **past** its call (`:1653-1662`). That is exactly
+`AfterApplied`, and it is unconditional —
+`run_blackhole_interp_to_cancel_tracing` ends `assert False  # ^^^ must raise`
+(`pyjitpl.py:2956`). Upstream's answer to "give up inside an inlined callee" is
+pop-callee, keep what ran, continue forward (`pyjitpl.py:1580-1600`); it never
+rewinds the caller to its CALL.
+
+Work: lift leg 4 from depth-1 / single-argument / no-closure to N frames, and
+drop the `fbw_executed_effect_count() != executed_effects_before` conjunct,
+which is a routing filter rather than a safety gate and currently makes the
+orthodox path the exception. Legs 3 and 6 then retire by becoming
+**unreachable**, not by deletion.
+
+⚠️Do **not** drop the other conjunct, `!fbw_has_unjournaled_effect()`. Upstream's
+`execute_and_record` executes *then* records (`pyjitpl.py:2647-2662`), so
+"recorded symbolically but not yet executed" cannot arise there. pyre's walker
+can record without executing, so that state is real and the conjunct is
+load-bearing. It dies with the two-executor split, not with the odometer.
+
+Blocker: per-level `PyFrame` materialization (`fbw_strict_fold_frame_reg`,
+`vable_ops.rs`). Upstream avoids it only because `_nonstandard_virtualizable`
+already degraded callee frames to heap fields (`pyjitpl.py:1120-1146`).
+Tracked upstream of this as the inner-frame rebuild (gh#126/#215).
+
+### R6 — vable write-through parity
+
+Upstream's virtualizable is write-through: `_opimpl_setfield_vable` and
+`_opimpl_setarrayitem_vable` both call `synchronize_virtualizable()`
+(`pyjitpl.py:1194`, `:1246`). That is why `force_now` on `TOKEN_TRACING_RESCALL`
+is a bare token store, commented "The values in the virtualizable are always
+correct during tracing" (`rpython/jit/metainterp/virtualizable.py:248-255`).
+
+pyre's shadow is explicitly lazy — "only generally valid at a merge point"
+(`state.rs:4343-4357`) — and that laziness is the entire reason a mid-expression
+operand-stack latch had to be invented. With write-through parity the live frame
+is continuously authoritative, there is nothing to reconstruct at force time,
+and the whole latch machinery retires: `flush_escape_state_with_latched_stack`,
+`ESCAPE_OPCODE_WINDOW`, `EscapeFlushUndo`, `EscapeResumeKind`, and both
+`RewindProvenAtLatch` and `RewindUnproven` with them.
+
+### R7 — REJECTED: do not delete legs 3/6 or the journals now
+
+Re-opens the gh#467 double-apply for callees that cannot be resolved up front,
+and the fallback they would retreat to is unsound for the effect classes the
+journal does not cover (TL;DR §3).
+
+---
+
+## Evidence rules for this area
+
+- **"Zero corpus reaches" is evidence about the corpus, not the path.** The
+  merge-point fallback measured 0/334 on both backends, but it fires only when
+  the latch *fails* (non-`Ref`/null slot, `vstack_valid == false`, a bridge
+  trace, an inline sub-walk), and the corpus structurally cannot produce those.
+  The defensible licence for refusing it is the code-level one: `commit_walk_end`
+  declines `RewindUnproven` unconditionally. State it that way.
+- `ESCAPE_PLAIN_FALLBACK` bumps only under `!latched && flushed`, so a flush
+  that *declines* is never counted; the counter says nothing about decline
+  frequency.
+- Always print a reachability denominator next to a hazard count.
+- `timeout(1)` does not exist on this macOS; use `perl -e 'alarm N; exec @ARGV'`.
+  A corpus loop using `timeout` runs zero benches and every probe reads 0.
+- Walk-level observability is `fbw_diag` (`trace.rs`) plus the `pyre_fbw_diag`
+  **export** and the runner decoder. It must stay an export: adding a host
+  *import* shifts wasm function indices and breaks JIT-baked ones.

--- a/walk-end-commit.plan.md
+++ b/walk-end-commit.plan.md
@@ -296,33 +296,21 @@ row 1 *in principle* — upstream avoids it only because
 (`pyjitpl.py:1120-1146`) — but no corpus case reaches it yet, so it is not what
 gates progress today.
 
-### R6 — vable write-through parity
+### R6 — CLOSED: the latch is orthodox; nothing is missing on this path
 
-⛔**The premise recorded here before was wrong, and this section is now the
-scoping note rather than a work item.** It said "pyre's shadow is explicitly
-lazy … that laziness is the entire reason a mid-expression operand-stack latch
-had to be invented". Verified false:
+⛔**R6 is not a work item. Two successive premises were recorded here and both
+are refuted by measurement.** Keep this section so the theory is not re-derived.
 
-- `TraceCtx::vable_setfield` ends in `self.synchronize_virtualizable()`
-  (`majit-metainterp/src/trace_ctx.rs`), and so does
-  `vable_setarrayitem_indexed`. Both mirror `pyjitpl.py:1194` / `:1246`.
-- `synchronize_virtualizable` → `write_boxes` parity is already implemented
-  (`trace_ctx.rs`).
-- The strict fresh-frame fold that writes nothing through
-  (`vable_ops.rs`, `setfield_vable_via_metainterp` / `setarrayitem_vable_via_metainterp`)
-  is gated on `fbw_strict_fold_frame_reg`, which reads
-  `callee_shadow.fold_frame_reg` — set only for an inline **callee** sub-walk.
-  The escape latch is gated on `!inline_subwalk`, so it is not that path.
+**Premise 1 (refuted): "pyre's shadow is lazy where upstream writes through."**
+`TraceCtx::vable_setfield` and `vable_setarrayitem_indexed` both end in
+`self.synchronize_virtualizable()` (`trace_ctx.rs`), mirroring `pyjitpl.py:1194`
+/ `:1246`, and `write_boxes` parity exists. The fold path that writes nothing
+(`vable_ops.rs`) is gated on `fbw_strict_fold_frame_reg` =
+`callee_shadow.fold_frame_reg`, set only for an inline **callee** sub-walk,
+while the escape latch is gated on `!inline_subwalk` — a different path.
 
-So write-through is present on exactly the path the latch serves. What is
-actually incomplete is *which* pushes reach a vable store at all: `state.rs`
-(the "only generally valid at a merge point" comment) names the shape — "a
-MAKE_FUNCTION whose LOAD_CONST'd code object the walk tracked symbolically,
-never writing it to the shadow". A slot no `setarrayitem_vable_r` ever wrote is
-not made current by synchronizing.
-
-✅**Verified — R6 is a frontend task, and the missing write is named.** The
-latch was instrumented to compare every resolved slot against the vable shadow
+**Premise 2 (refuted): "the missing write is the `pushvalue` array store."**
+The latch was instrumented to compare every resolved slot against the shadow
 (`residual_call.rs`, `[r6-latch]`, gated on `PYRE_FBW_DEBUG_ABORT`) and censused
 over `pyre/bench/synth`:
 
@@ -331,47 +319,48 @@ over `pyre/bench/synth`:
 | disagreements | **10**, in 2 files (`getframe_stored_fback_walk.py` 5, `getframe_force_cancel_journal.py` 5) |
 | slot index | **`rel == len-1` in 10/10** — always the in-progress opcode's TOS |
 | shadow value | **`Ref(GcRef(0))` (NULL) in 10/10** — never a stale non-null |
+| shadow **box** | **`ConstPtr(GcRef(0))` in 10/10** — a compile-time NULL *constant* |
 
-Two things follow. The shadow is never *wrong*, only *absent*, so this is a
-missing store and not a synchronization race. And every slot **below** the TOS
-agrees, so the completed pushes did write through — it is specifically the value
-produced mid-opcode that never lands.
+That last row is what settles it. The slot does not hold *no* write; it holds a
+**deliberate NULL constant**, which is exactly what `emit_popvalue_ref!` emits:
+`pyframe.py:411-417 popvalue_maybe_none` → `setarrayitem_vable_r(
+locals_cells_stack_w, depth, ConstPtr.NULL)` via `jtransform.py:1898`. The
+in-flight opcode had already **popped** that slot before its residual forced.
 
-The store that is missing: `pyframe.pushvalue` is two writes —
-`locals_cells_stack_w[depth] = w_object` and `valuestackdepth = depth + 1` —
-lowered by `jtransform.py:1898` `do_fixed_list_setitem` and `:844`. In
-`codewriter.rs`:
+So the vable array is *correct*, and upstream agrees with it — RPython's
+`popvalue` NULLs `locals_cells_stack_w[depth]` the same way. What the latch
+holds is the operand the in-flight opcode already consumed, which is precisely
+what upstream keeps in `MIFrame.registers_r` and what
+`convert_and_run_from_pyjitpl` resumes a blackhole from. **The latch is the
+orthodox register-level mirror, not a workaround.** It does not retire, and
+neither do `ESCAPE_OPCODE_WINDOW`, `EscapeFlushUndo`, `EscapeResumeKind`,
+`RewindProvenAtLatch` or `RewindUnproven` on this argument.
 
-- `emit_load_fast_ref` emits **both** (and cites `:1898`), as do the ad-hoc
-  mirrors at `STORE_FAST` and `SWAP` — the `SWAP` arm even states the invariant:
-  "a guard-failure resume walk reconstructs the live frame from those slots, so
-  emit the `setarrayitem_vable_r` writes that keep the mirror consistent".
-- the generic `push_and_bump!` — the single path taken by **every** residual-call
-  and HLOp result, 38 call sites — emits only `emit_vsd!`, the depth bump.
+Directly disproving premise 2: `LOAD_ATTR` — the escaping opcode in both witness
+files — *already* emits the push mirror via `emit_pushvalue_ref!`
+(`codewriter.rs`), and the slot still reads NULL. Emitting the store is
+demonstrably not sufficient, because the pop follows it.
 
-So the TOS at an escaping residual is a value pushed with the depth bumped and
-the array never written, which is exactly the NULL the census reports. In both
-witness files the disagreeing TOS is a residual result awaiting its next
-attribute read (`box[0].f_back` before `.f_locals`; `sys._getframe(1)` before
-`.f_locals`).
+#### Witness-less residue: `push_and_bump!` omits the `:1898` half
 
-⚠️The earlier framing in this section — that the latch is the orthodox
-register-level mirror, upstream's `MIFrame.registers_r` — is **also wrong**.
-Upstream emits both halves of `pushvalue` and can afford to because
-`OptVirtualize` removes them from the compiled trace while the tracer still sees
-them. The latch is standing in for a store pyre never made.
+Genuine and separate from the above. `pyframe.pushvalue` is two writes —
+`locals_cells_stack_w[depth] = w_object` (`jtransform.py:1898`
+`do_fixed_list_setitem`) and `valuestackdepth = depth + 1` (`:844`).
+`emit_pushvalue_ref!` and `emit_load_fast_ref` emit both; the generic
+`push_and_bump!`, taken by every residual-call and HLOp result (38 sites),
+emits only `emit_vsd!`. A guard-failure resume at an opcode **boundary** just
+after such a push would therefore read a NULL stack slot.
 
-**R6 = make `push_and_bump!` emit the `jtransform.py:1898` half.** Only then do
-`flush_escape_state_with_latched_stack`, `ESCAPE_OPCODE_WINDOW`,
-`EscapeFlushUndo`, `EscapeResumeKind`, `RewindProvenAtLatch` and
-`RewindUnproven` retire. Two things to settle while implementing:
+Measured cost of closing it (prototyped, then reverted): adding the store to
+`push_and_bump!` under a `Kind::Ref` gate takes
+`getframe_stored_fback_walk.py` from **140 to 175** emitted
+`setarrayitem_vable_r`, ~25% more vable stores, and **changes none of the 10
+disagreements** — it is not a fix for anything observed.
 
-- **Kind.** The vable array holds `W_Root`, so the mirror is `setarrayitem_vable_r`
-  and only a Ref-kind push may take it. Audit the 38 sites for Int/Float pushes
-  before emitting unconditionally.
-- **Perf.** This adds a vable store to every pushing opcode and leans on the
-  optimizer to remove them, so it needs the A/B discipline for this repo: size
-  ladder, min-of-rounds, base measured from a worktree at committed `HEAD`.
+⛔**Do not land it without a corpus witness.** Per this file's own evidence
+rules, a row with no witness is not worked. To get one, look for a guard that
+fails at an opcode boundary immediately after a residual-call push and observe
+whether the resumed frame sees NULL at that slot.
 
 ### R7 — REJECTED: do not delete legs 3/6 or the journals now
 

--- a/walk-end-commit.plan.md
+++ b/walk-end-commit.plan.md
@@ -156,32 +156,34 @@ i.e. rows 1/4/5 — **is refuted by measurement**. Slice A dropped row 2 and mad
 leg 4 preferred; the conversion was **zero**. Census over `pyre/bench/synth`
 (315 files, `PYRE_FBW_DEBUG_ABORT=1`):
 
-| | count |
-|---|---|
-| leg 3 `EntryCarrierCall` commits | 169 |
-| leg 4 `CalleeRebuild` commits | 1 |
-| refusal: callee is a generator | 151 |
-| refusal: abort pc is not an exact segment anchor | 18 |
-| refusal: first callee argument is not a `Ref` | 1 |
+| | base | after slices A–C |
+|---|---|---|
+| leg 3 `EntryCarrierCall` commits | 169 | **9** |
+| leg 4 `CalleeRebuild` commits | 1 | **11** |
+| refusal: callee is a generator | 151 | 0 |
+| refusal: abort pc is not an exact segment anchor | 18 | 3 |
+| refusal: first callee argument is not a `Ref` | 1 | 1 |
 
 Row 1 never fired. Rows 4b and 6 never fired. Print the denominator: 149 of the
-151 generator refusals come from one loop in `calls_closures.py`, and the 18
-anchor refusals are spread over 5 files (`foriter_exempt_nested_foriter`,
+151 generator refusals came from one loop in `calls_closures.py`, and the 18
+anchor refusals were spread over 5 files (`foriter_exempt_nested_foriter`,
 `foriter_exempt_shared_generator`, `inline_subwalk_user_iterator`,
 `selfrec_tail_exception_unwind`, `bridge_recursion_overflow`).
 
-#### Row 4a is correct and must stay
+The orthodox leg is now the majority one.
+
+#### ✅Row 4a is correct and must stay — the defect was upstream of it
 
 Rebuilding a generator callee would run its body eagerly instead of producing a
-generator object, so leg 4 refusing it is right. What is *not* right is that the
+generator object, so leg 4 refusing it is right. What was *not* right is that the
 call was inlined at all: `resolve_inlinable_callee` (`jitcode_dispatch/mod.rs`)
-has no `code_flags_make_generator` guard, so the walker inlines `gen(6)` and
-starts walking the generator body, escaping only via an abort. Verified **not** a
+had no `code_flags_make_generator` guard, so the walker inlined `gen(6)` and
+started walking the generator body, escaping only via an abort. Verified **not** a
 miscompile (jit / `PYRE_NO_JIT=1` / CPython agree on a `yield`-per-`next` probe)
-— it is wasted tracing, and a separate defect from this plan.
+— it was wasted tracing that discarded the whole trace 149 times.
 
-⇒ the honest denominator for R5 is **19**, not 170, and row 7's anchor is the
-dominant real blocker.
+Adding the guard (slice C) took leg 3 from 169 to **9** commits on its own, and
+is what actually makes legs 3/6 rare rather than dominant.
 
 #### ✅Slice B landed: row 7 (the segment anchor)
 
@@ -232,9 +234,12 @@ the walk-end MidBody arm retries through the extracted
 
 #### Next slice
 
-The remaining refusals are 3 `getarrayitem_vable_r` anchors and 1 non-`Ref`
-first argument (row 5). Row 1 (depth-1) and rows 4b/6 still have no corpus
-witness — do not work them without one.
+Leg 3's remaining 9 commits are the ceiling to attack next; 5 of them are the
+rebuild's fallback (a rebuild that latched but declined at
+`try_commit_midbody_abort`), so that decline is where the leverage is, not the
+latch. The remaining latch refusals are 3 `getarrayitem_vable_r` anchors and 1
+non-`Ref` first argument (row 5). Row 1 (depth-1) and rows 4b/6 still have no
+corpus witness — do not work them without one.
 
 ⚠️Do **not** drop the other conjunct, `!fbw_has_unjournaled_effect()`. Upstream's
 `execute_and_record` executes *then* records (`pyjitpl.py:2647-2662`), so

--- a/walk-end-commit.plan.md
+++ b/walk-end-commit.plan.md
@@ -183,14 +183,58 @@ miscompile (jit / `PYRE_NO_JIT=1` / CPython agree on a `yield`-per-`next` probe)
 ⇒ the honest denominator for R5 is **19**, not 170, and row 7's anchor is the
 dominant real blocker.
 
-#### Next slice: row 7 (the segment anchor)
+#### ✅Slice B landed: row 7 (the segment anchor)
 
-`exact_floor_segment_anchor` (`jitcode_dispatch/mod.rs`) demands the abort
+`exact_floor_segment_anchor` (`jitcode_dispatch/mod.rs`) demanded the abort
 jitcode pc be the exact FIRST jitcode op of its Python pc's floor segment,
 because leg 4 rebuilds a **Python** frame at a **Python** pc. Upstream needs no
 such mapping: `_copy_data_from_miframe` (`blackhole.py:1711-1712`) resumes each
-blackhole at its **jitcode** position. This is the F1 charter deviation
-(py_pc ↔ jitcode), so the slice is scoped by it rather than by frame layout.
+blackhole at its **jitcode** position — the F1 charter deviation (py_pc ↔
+jitcode).
+
+What the 18 refusals actually were, measured: the prefix between the segment
+start and the abort pc is **only** `setarrayitem_vable_r` +
+`setfield_vable_i` + `getarrayitem_vable_r`, every one of them aimed at the
+callee's own `portal_frame_reg`. `portal_marker_first_jit_anchor` already
+admitted a subset of exactly this (the `setfield_vable_i(VableField{index:0})`
+prefix); it was generalized to `portal_vable_bookkeeping_anchor` and now serves
+both abort kinds. Result: anchor refusals 18 → 3, leg 4 commits 1 → **11**,
+leg 3 commits 169 → 159.
+
+⚠️Two traps this slice walked into, both worth remembering:
+
+- **`depth_for_jitcode_pc_pred` is keyed per Python pc**, not per jitcode pc
+  ("Equals `depth_at_py_pc[python_pc_for_jitcode_pc(jit_pc)]`",
+  `pyjitcode.rs`). Comparing it at the segment start and at the abort pc
+  therefore *always* agrees and proves nothing. The real licence is that the
+  rebuild rewrites locals, stack area, `valuestackdepth` and `last_instr`
+  wholesale, so every vable write in the prefix is erased.
+- The `setfield_vable_i` in the prefix writes `VableField{index:2}` =
+  **`valuestackdepth`**, not `last_instr` (static field order is
+  `last_instr, pycode, valuestackdepth, debugdata, lastblock, w_globals` —
+  `virtualizable_gen.rs`). The pattern is `push_and_bump!`: store the slot,
+  then bump the depth.
+
+`getarrayitem_vable_r` is deliberately still refused (the remaining 3): it
+writes a jitcode REGISTER, and the payload sources `live_stack`/`live_locals`
+out of `concrete_registers_r` by color, so a clobbered color would be read back
+as a live value. Lifting it needs a color-liveness argument, not a wider op set.
+
+#### ✅Slice B also: the rebuild's fallback
+
+Newly-latched rebuilds can still decline at the flush (5 of the 15 did), and
+that decline used to land on the legacy replay — the unsound fallback of
+TL;DR §3, and precisely the double-apply the entry carrier was built to close.
+`MidBodyPayload` now carries `entry_fallback`, attached by
+`fbw_set_abort_call_resume` under the entry latch's own zero-delta gate, and
+the walk-end MidBody arm retries through the extracted
+`try_commit_entry_carrier_call`. Commit totals are conserved: 169+1 → 159+11.
+
+#### Next slice
+
+The remaining refusals are 3 `getarrayitem_vable_r` anchors and 1 non-`Ref`
+first argument (row 5). Row 1 (depth-1) and rows 4b/6 still have no corpus
+witness — do not work them without one.
 
 ⚠️Do **not** drop the other conjunct, `!fbw_has_unjournaled_effect()`. Upstream's
 `execute_and_record` executes *then* records (`pyjitpl.py:2647-2662`), so

--- a/walk-end-commit.plan.md
+++ b/walk-end-commit.plan.md
@@ -1,6 +1,8 @@
 # Walk-end commit contract — convergence roadmap
 
-Status: **R1–R4 landed; R5–R6 open.** This is the authoritative plan for
+Status: **R1–R5 landed; R6 closed as refuted; R7 rejected.** The only
+remaining rows carry named, measured causes and no corpus witness — see
+"Residue" below. This is the authoritative plan for
 retiring the walk-end commit gates in `run_perfn_walk`'s epilogue. It supersedes
 the reasoning in the comments those gates carry, and it records two claims that
 were in the tree and are **false**.
@@ -116,7 +118,18 @@ way. They differ in operand-stack sourcing and in whether any gate ran.
 
 ---
 
-## Open
+## Residue
+
+Nothing here is blocking. R5 landed, R6 is closed as refuted, R7 is rejected.
+What is left is recorded so it is not re-derived, and each row states why it is
+not being worked:
+
+| row | state | why not worked |
+|---|---|---|
+| 3 `getarrayitem_vable_r` anchors | still refused | needs a color-liveness argument, not a measurement |
+| depth-1 / N-frame (old assumed R5 blocker) | never fired | **no corpus witness** — refuted by census |
+| `push_and_bump!` omits `jtransform.py:1898` | real gap | **no corpus witness**; prototyped, costs ~25% more vable stores, fixes nothing observed |
+| legs 3/6 + store journals | keep | deleting them re-opens gh#467 double-apply (TL;DR §3) |
 
 ### R5 — generalize leg 4, then let legs 3 and 6 become unreachable
 

--- a/walk-end-commit.plan.md
+++ b/walk-end-commit.plan.md
@@ -156,14 +156,16 @@ i.e. rows 1/4/5 — **is refuted by measurement**. Slice A dropped row 2 and mad
 leg 4 preferred; the conversion was **zero**. Census over `pyre/bench/synth`
 (315 files, `PYRE_FBW_DEBUG_ABORT=1`):
 
-| | base | after slices A–D |
+| | base | after slices A–E |
 |---|---|---|
-| leg 3 `EntryCarrierCall` commits | 169 | **4** |
-| leg 4 `CalleeRebuild` commits | 1 | **16** |
+| leg 3 `EntryCarrierCall` commits | 169 | **3** |
+| leg 4 `CalleeRebuild` commits | 1 | **17** |
 | refusal: callee is a generator | 151 | 0 |
 | refusal: abort pc is not an exact segment anchor | 18 | 3 |
-| refusal: first callee argument is not a `Ref` | 1 | 1 |
+| refusal: first callee argument is not a `Ref` | 1 | 0 |
 | rebuild latched but declined at the flush | 0 | 0 |
+
+Every remaining leg-3 commit is one of the 3 `getarrayitem_vable_r` anchors.
 
 Row 1 never fired. Rows 4b and 6 never fired. Print the denominator: 149 of the
 151 generator refusals came from one loop in `calls_closures.py`, and the 18
@@ -254,12 +256,32 @@ pc, slot-ordered from the stack base, so its prefix is exactly the residue.
 Python, so they are re-read from the live carrier (kept forwarded by the
 abort-resume root area), never from the pre-execute clone.
 
+#### ✅Slice E landed: the single-argument residue and the raising caller
+
+Row 5 (`callee_arg_concretes.first()` must be a `Ref`) was **dead weight**.
+`finish_for_call_with_globals_obj` binds `args` into the first `varnames` slots
+and validates no arity; `try_commit_midbody_abort` then clears every one of
+those slots to `PY_NULL` and rewrites them from `live_locals`. The seed never
+survived, so `x_arg` is gone from `MidBodyPayload`, from its GC root visit, and
+from the refusal list.
+
+Removing it exposed the next one: `exception_delivery_stack_is_sourceable`
+required `handler_depth == 0` — the same statement-position assumption slice D
+removed from the return path, now on the raise path. `handle_exception` only
+ever POPS down to the handler's recorded depth (`eval.rs`,
+`pyopcode.py:151-173`), so restoring the `below` operands and setting
+`valuestackdepth` from them serves any handler wanting at most that many. The
+re-read of `below` from the live carrier is hoisted above the `execute_frame`
+match so both arms use it.
+
 #### Next slice
 
-Leg 3 is down to 4 commits, each of them a rebuild that could not latch:
-3 `getarrayitem_vable_r` anchors and 1 non-`Ref` first argument (row 5).
-No rebuild declines at the flush any more. Row 1 (depth-1) and rows 4b/6 still
-have no corpus witness — do not work them without one.
+Leg 3 is down to 3 commits, all of them the `getarrayitem_vable_r` anchor.
+Lifting it needs a color-liveness argument: the op writes a jitcode register and
+the payload sources `live_stack`/`live_locals` out of `concrete_registers_r` by
+color, so the case to prove is that the clobbered color is not one the payload
+reads — not that the op is harmless. Row 1 (depth-1) and rows 4b/6 still have no
+corpus witness; do not work them without one.
 
 ⚠️Do **not** drop the other conjunct, `!fbw_has_unjournaled_effect()`. Upstream's
 `execute_and_record` executes *then* records (`pyjitpl.py:2647-2662`), so

--- a/walk-end-commit.plan.md
+++ b/walk-end-commit.plan.md
@@ -130,6 +130,51 @@ not being worked:
 | depth-1 / N-frame (old assumed R5 blocker) | **unobserved, not refuted** | its gate is outside the named-refusal path, so the census cannot see it — no witness either way |
 | `push_and_bump!` omits `jtransform.py:1898` | real gap | **no corpus witness**; prototyped, costs ~25% more vable stores, fixes nothing observed |
 | legs 3/6 + store journals | keep | deleting them re-opens gh#467 double-apply (TL;DR §3) |
+| post-run rebuild decline is still unsound | **narrowed, not closed** | see R8 |
+| the escaping residual does not constrain itself | open question | see R9 |
+
+### R8 — a rebuild that fails AFTER the callee ran (found by Codex parity review, PR #837)
+
+⚠️**This was a live double-apply introduced by R5 and is now narrowed.** The
+call site took `EntryCarrierCall` — which rewinds the outer frame to its CALL —
+whenever `try_commit_midbody_abort` returned false, and "false" included the
+failures that happen *after* `frame.execute_frame` has already run the callee.
+Rewinding then runs the callee body a **second** time.
+`try_commit_entry_carrier_call`'s `walk_end_resume_provable` re-check cannot
+catch it: it samples `FBW_EXECUTED_EFFECT_COUNT`, which is walker-side, and the
+plain interpretation inside `execute_frame` never bumps it.
+
+Fixed by making the decline say which side of `execute_frame` it came from
+(`MidBodyDecline::{BeforeRun, AfterRun}`) and taking the rewinding leg only on
+`BeforeRun`.
+
+⛔**Still open.** `AfterRun` now takes no leg, which drops through to the legacy
+replay — and that re-enters the outer frame at its entry and re-runs the CALL as
+well. The callee's effects are user code, which the store journal does not
+cover, so **neither branch can undo them**. The real close is to make the
+post-run path infallible: each `AfterRun` decline already has a pre-run
+counterpart (`can_flush_walk_end_state_after_outer_call`, the propagate
+licence), so reaching one means a pre-check is too weak, not that another
+fallback is needed. Upstream has no post-execution decline at all —
+`convert_and_run_from_pyjitpl` copies every frame and continues
+(`blackhole.py:1799-1820`). No corpus witness: the census row "rebuild latched
+but declined at the flush" measured 0.
+
+### R9 — the escaping residual is not in its own purity window
+
+Raised as pre-existing by the same review (`residual_call.rs` ↔
+`pyjitpl.py:3373-3390`). `escape_opcode_window_note` is called *after*
+`execute_residual_call` returns, so a residual constrains only the ones that
+FOLLOW it inside the opcode, never itself. The escape resume pc is the escaping
+opcode, so that residual re-runs. Upstream's licence for `resumepc=orgpc` is
+`EF_ELIDABLE_CANNOT_RAISE` on the residual being rewound over
+(`jtransform.py:620-630`) — which is the residual itself, not its predecessors.
+
+Unresolved, deliberately: folding the current residual into its own window would
+turn latches into declines on a path with no measured decline today, and R6
+established the latch itself is orthodox. Needs a witness first — a forcing
+residual that is neither elidable nor loop-invariant and whose re-execution is
+observable.
 
 ### R5 — generalize leg 4, then let legs 3 and 6 become unreachable
 

--- a/walk-end-commit.plan.md
+++ b/walk-end-commit.plan.md
@@ -127,7 +127,7 @@ not being worked:
 | row | state | why not worked |
 |---|---|---|
 | 3 `getarrayitem_vable_r` anchors | still refused | needs a color-liveness argument, not a measurement |
-| depth-1 / N-frame (old assumed R5 blocker) | never fired | **no corpus witness** — refuted by census |
+| depth-1 / N-frame (old assumed R5 blocker) | **unobserved, not refuted** | its gate is outside the named-refusal path, so the census cannot see it — no witness either way |
 | `push_and_bump!` omits `jtransform.py:1898` | real gap | **no corpus witness**; prototyped, costs ~25% more vable stores, fixes nothing observed |
 | legs 3/6 + store journals | keep | deleting them re-opens gh#467 double-apply (TL;DR §3) |
 
@@ -180,7 +180,15 @@ leg 4 preferred; the conversion was **zero**. Census over `pyre/bench/synth`
 
 Every remaining leg-3 commit is one of the 3 `getarrayitem_vable_r` anchors.
 
-Row 1 never fired. Rows 4b and 6 never fired. Print the denominator: 149 of the
+⚠️**Row 1 is NOT instrumented — do not read its silence as "never fired".** The
+`is_top_inline && !fbw_has_unjournaled_effect()` gate (`inline_call.rs:2617`)
+sits *outside* the closure whose `Err(&'static str)` arms are what print under
+`PYRE_FBW_DEBUG_ABORT`, so a depth≥2 inline sub-walk abort (row 1) or an
+unjournaled-effect abort (row 3) emits no line at all. Zero observations is
+indistinguishable from not-measured. The only support is indirect and weaker
+than it looks: the 3 surviving leg-3 commits are accounted for by the 3 anchor
+refusals, which is *consistent* with row 1 not firing but does not establish it.
+Rows 4b and 6 are likewise unobserved. Print the denominator: 149 of the
 151 generator refusals came from one loop in `calls_closures.py`, and the 18
 anchor refusals were spread over 5 files (`foriter_exempt_nested_foriter`,
 `foriter_exempt_shared_generator`, `inline_subwalk_user_iterator`,

--- a/walk-end-commit.plan.md
+++ b/walk-end-commit.plan.md
@@ -298,19 +298,80 @@ gates progress today.
 
 ### R6 — vable write-through parity
 
-Upstream's virtualizable is write-through: `_opimpl_setfield_vable` and
-`_opimpl_setarrayitem_vable` both call `synchronize_virtualizable()`
-(`pyjitpl.py:1194`, `:1246`). That is why `force_now` on `TOKEN_TRACING_RESCALL`
-is a bare token store, commented "The values in the virtualizable are always
-correct during tracing" (`rpython/jit/metainterp/virtualizable.py:248-255`).
+⛔**The premise recorded here before was wrong, and this section is now the
+scoping note rather than a work item.** It said "pyre's shadow is explicitly
+lazy … that laziness is the entire reason a mid-expression operand-stack latch
+had to be invented". Verified false:
 
-pyre's shadow is explicitly lazy — "only generally valid at a merge point"
-(`state.rs:4343-4357`) — and that laziness is the entire reason a mid-expression
-operand-stack latch had to be invented. With write-through parity the live frame
-is continuously authoritative, there is nothing to reconstruct at force time,
-and the whole latch machinery retires: `flush_escape_state_with_latched_stack`,
-`ESCAPE_OPCODE_WINDOW`, `EscapeFlushUndo`, `EscapeResumeKind`, and both
-`RewindProvenAtLatch` and `RewindUnproven` with them.
+- `TraceCtx::vable_setfield` ends in `self.synchronize_virtualizable()`
+  (`majit-metainterp/src/trace_ctx.rs`), and so does
+  `vable_setarrayitem_indexed`. Both mirror `pyjitpl.py:1194` / `:1246`.
+- `synchronize_virtualizable` → `write_boxes` parity is already implemented
+  (`trace_ctx.rs`).
+- The strict fresh-frame fold that writes nothing through
+  (`vable_ops.rs`, `setfield_vable_via_metainterp` / `setarrayitem_vable_via_metainterp`)
+  is gated on `fbw_strict_fold_frame_reg`, which reads
+  `callee_shadow.fold_frame_reg` — set only for an inline **callee** sub-walk.
+  The escape latch is gated on `!inline_subwalk`, so it is not that path.
+
+So write-through is present on exactly the path the latch serves. What is
+actually incomplete is *which* pushes reach a vable store at all: `state.rs`
+(the "only generally valid at a merge point" comment) names the shape — "a
+MAKE_FUNCTION whose LOAD_CONST'd code object the walk tracked symbolically,
+never writing it to the shadow". A slot no `setarrayitem_vable_r` ever wrote is
+not made current by synchronizing.
+
+✅**Verified — R6 is a frontend task, and the missing write is named.** The
+latch was instrumented to compare every resolved slot against the vable shadow
+(`residual_call.rs`, `[r6-latch]`, gated on `PYRE_FBW_DEBUG_ABORT`) and censused
+over `pyre/bench/synth`:
+
+| | |
+|---|---|
+| disagreements | **10**, in 2 files (`getframe_stored_fback_walk.py` 5, `getframe_force_cancel_journal.py` 5) |
+| slot index | **`rel == len-1` in 10/10** — always the in-progress opcode's TOS |
+| shadow value | **`Ref(GcRef(0))` (NULL) in 10/10** — never a stale non-null |
+
+Two things follow. The shadow is never *wrong*, only *absent*, so this is a
+missing store and not a synchronization race. And every slot **below** the TOS
+agrees, so the completed pushes did write through — it is specifically the value
+produced mid-opcode that never lands.
+
+The store that is missing: `pyframe.pushvalue` is two writes —
+`locals_cells_stack_w[depth] = w_object` and `valuestackdepth = depth + 1` —
+lowered by `jtransform.py:1898` `do_fixed_list_setitem` and `:844`. In
+`codewriter.rs`:
+
+- `emit_load_fast_ref` emits **both** (and cites `:1898`), as do the ad-hoc
+  mirrors at `STORE_FAST` and `SWAP` — the `SWAP` arm even states the invariant:
+  "a guard-failure resume walk reconstructs the live frame from those slots, so
+  emit the `setarrayitem_vable_r` writes that keep the mirror consistent".
+- the generic `push_and_bump!` — the single path taken by **every** residual-call
+  and HLOp result, 38 call sites — emits only `emit_vsd!`, the depth bump.
+
+So the TOS at an escaping residual is a value pushed with the depth bumped and
+the array never written, which is exactly the NULL the census reports. In both
+witness files the disagreeing TOS is a residual result awaiting its next
+attribute read (`box[0].f_back` before `.f_locals`; `sys._getframe(1)` before
+`.f_locals`).
+
+⚠️The earlier framing in this section — that the latch is the orthodox
+register-level mirror, upstream's `MIFrame.registers_r` — is **also wrong**.
+Upstream emits both halves of `pushvalue` and can afford to because
+`OptVirtualize` removes them from the compiled trace while the tracer still sees
+them. The latch is standing in for a store pyre never made.
+
+**R6 = make `push_and_bump!` emit the `jtransform.py:1898` half.** Only then do
+`flush_escape_state_with_latched_stack`, `ESCAPE_OPCODE_WINDOW`,
+`EscapeFlushUndo`, `EscapeResumeKind`, `RewindProvenAtLatch` and
+`RewindUnproven` retire. Two things to settle while implementing:
+
+- **Kind.** The vable array holds `W_Root`, so the mirror is `setarrayitem_vable_r`
+  and only a Ref-kind push may take it. Audit the 38 sites for Int/Float pushes
+  before emitting unconditionally.
+- **Perf.** This adds a vable store to every pushing opcode and leans on the
+  optimizer to remove them, so it needs the A/B discipline for this repo: size
+  ladder, min-of-rounds, base measured from a worktree at committed `HEAD`.
 
 ### R7 — REJECTED: do not delete legs 3/6 or the journals now
 

--- a/walk-end-commit.plan.md
+++ b/walk-end-commit.plan.md
@@ -156,13 +156,14 @@ i.e. rows 1/4/5 — **is refuted by measurement**. Slice A dropped row 2 and mad
 leg 4 preferred; the conversion was **zero**. Census over `pyre/bench/synth`
 (315 files, `PYRE_FBW_DEBUG_ABORT=1`):
 
-| | base | after slices A–C |
+| | base | after slices A–D |
 |---|---|---|
-| leg 3 `EntryCarrierCall` commits | 169 | **9** |
-| leg 4 `CalleeRebuild` commits | 1 | **11** |
+| leg 3 `EntryCarrierCall` commits | 169 | **4** |
+| leg 4 `CalleeRebuild` commits | 1 | **16** |
 | refusal: callee is a generator | 151 | 0 |
 | refusal: abort pc is not an exact segment anchor | 18 | 3 |
 | refusal: first callee argument is not a `Ref` | 1 | 1 |
+| rebuild latched but declined at the flush | 0 | 0 |
 
 Row 1 never fired. Rows 4b and 6 never fired. Print the denominator: 149 of the
 151 generator refusals came from one loop in `calls_closures.py`, and the 18
@@ -232,14 +233,33 @@ TL;DR §3, and precisely the double-apply the entry carrier was built to close.
 the walk-end MidBody arm retries through the extracted
 `try_commit_entry_carrier_call`. Commit totals are conserved: 169+1 → 159+11.
 
+#### ✅Slice D landed: expression-position calls
+
+All 5 rebuilds that latched and then declined failed one gate,
+`can_flush_walk_end_state_after_outer_call`, and all 5 for the same reason: the
+CALL was in **expression** position (static depth 7 at a 6-operand call, 2
+after), while the preflight demanded `depths[post_call_py_pc] == 1` — the
+statement-position specialization.
+
+`outer_call_operands_below` now computes the residue
+`depths[call_py_pc] - call_stack_len` and requires
+`depths[post_call_py_pc] == below + 1`; the flush restores those operands under
+the return value and sets `valuestackdepth` accordingly. `MidBodyPayload`
+records only the call's own operand count, so the residue is sourced from
+`entry_fallback.call_stack` — the entry carrier's
+`reconstructed_all_ref_call_stack` is the caller's WHOLE operand stack at that
+pc, slot-ordered from the stack base, so its prefix is exactly the residue.
+
+⚠️GC: those refs are written **after** `frame.execute_frame` has run arbitrary
+Python, so they are re-read from the live carrier (kept forwarded by the
+abort-resume root area), never from the pre-execute clone.
+
 #### Next slice
 
-Leg 3's remaining 9 commits are the ceiling to attack next; 5 of them are the
-rebuild's fallback (a rebuild that latched but declined at
-`try_commit_midbody_abort`), so that decline is where the leverage is, not the
-latch. The remaining latch refusals are 3 `getarrayitem_vable_r` anchors and 1
-non-`Ref` first argument (row 5). Row 1 (depth-1) and rows 4b/6 still have no
-corpus witness — do not work them without one.
+Leg 3 is down to 4 commits, each of them a rebuild that could not latch:
+3 `getarrayitem_vable_r` anchors and 1 non-`Ref` first argument (row 5).
+No rebuild declines at the flush any more. Row 1 (depth-1) and rows 4b/6 still
+have no corpus witness — do not work them without one.
 
 ⚠️Do **not** drop the other conjunct, `!fbw_has_unjournaled_effect()`. Upstream's
 `execute_and_record` executes *then* records (`pyjitpl.py:2647-2662`), so


### PR DESCRIPTION
17 commits: 10 code commits on the walk-end commit path in `pyre/pyre-jit-trace`, one majit parity fix, five plan-document updates and one rustfmt pass.

`run_perfn_walk`'s epilogue can keep the walk's eagerly-executed store journal instead of falling back to the legacy replay-from-entry. Whether a path's resume pc sits *behind* effects the walk already applied — a rewind, which re-executes them on top of committed ones — was decided ad hoc per leg across three files, and one path had no gate at all. This series types that obligation, then converges the abort-inside-an-inlined-callee case onto the leg the plan classes as orthodox.

Correctness/convergence only; **no performance claim is made**.

`walk-end-commit.plan.md` (new, tracked in-tree) is the authoritative record: R1, R2, R4 and R5 landed; **R3 deliberately landed no deletion**; R6 closed as refuted; R7 rejected.

## Walk-end commit contract (R1–R4)

- New `WalkEndResume { Terminal, Rewind{effects_at_resume_point}, RewindUnproven, RewindProvenAtLatch, AfterApplied }` in `trace.rs`. `commit_walk_end` takes it and is `#[must_use]`. Every call site is retagged (9 `commit_walk_end` sites across 7 pre-existing legs — `VableEscape` covers three of them).
- **This is a runtime change, not only a retag.** The escape flush's merge-point fallback — the path that had no gate — is now tagged `RewindUnproven`, always declines, and restores the live frame via `restore_escape_flush_undo()`. Legs 3 and 6 also re-check their odometer sample a second time at the commit point, so a path that previously committed after only the latch-time gate can now decline. The plan records the merge-point fallback as measured 0/334 on both backends, so this decline has no corpus witness either way.
- `WalkEndCommitLeg::TerminateNoReplay = 8` names the portal/CALL_ASSEMBLER no-replay shortcut. Of the eight tagged legs, seven hand the portal a resume pc; **this eighth hands none** — it keeps the journal under a different caller protocol. `record_walk_end_leg` (tag only) is split from `commit_walk_end` (tag + flush flag) so it stops reporting as `leg=0` in the census without setting `WALK_END_FLUSH_COMMITTED`.
- `ESCAPE_OPCODE_WINDOW` is re-keyed from a runtime `(frame_entry_count, executed_effect_count)` sample to the residual's declared `EffectInfo` class, matching the axis upstream licenses `resumepc=orgpc` on (`jtransform.py:620-630`). Note the new `reentrant_residual` is deliberately **stricter** than the `provably_side_effect_free` predicate it was split out of: it drops the `PyreHelperKind::ForIterNext` exemption, so a FOR_ITER's own next-residual now dirties the opcode window where the runtime-count gate left it clean.
- Two comments the sources contradict are corrected: upstream *does* rewind (`opimpl_str_guard_value`, `pyjitpl.py:1498-1511`), and the `vstack_cur_pypc` "one past the executing op" note was wrong.
- majit (`6de46f5ae4`): `finalize_standard_virtualizable_may_force` reloads the virtualizable fields from the heap before `TraceAction::Abort`, matching `vable_after_residual_call`. Without it the blackhole rebuilt from pre-call boxes.

## Leg 4 / R5

Leg 4 (`CalleeRebuild`) is the leg the plan classes as orthodox: `convert_and_run_from_pyjitpl` builds one blackhole per framestack frame at its own pc and splices the callee result into the caller *past* its call (`blackhole.py:1799-1821`, `:1653-1662`), and upstream's form is unconditional (`pyjitpl.py:2956`). Leg 3 (`EntryCarrierCall`) rewinds the caller to its CALL and has no upstream counterpart. The MidBody latch previously required the executed-effect odometer to have moved, which routed every zero-effect callee abort to leg 3.

This series drops that filter, then removes or widens each narrowing the resulting debug census named as a cause of leg-4 refusal:

- Drop the odometer conjunct; `fbw_set_abort_call_resume` no longer overwrites an already-latched MidBody carrier. Payload building becomes `Result<_, &'static str>` so every refusal **inside the builder** names itself under `PYRE_FBW_DEBUG_ABORT`. The outer `is_top_inline && !fbw_has_unjournaled_effect()` gate remains silent — see the residue table.
- **Widen** the abort anchor (`portal_vable_bookkeeping_anchor`) to admit a prefix of `setarrayitem_vable_r/rirdd` and `setfield_vable_i/rid` on any `VableField` aimed at this frame's `portal_frame_reg`. `getarrayitem_vable_r` stays refused, and 3 such refusals remain.
- Route a declining rebuild to the entry carrier rather than to the legacy replay — declining is **not** a safe fallback, since the store journal covers only five folded classes.
- Refuse to inline generator/coroutine/async-generator callees in `resolve_inlinable_callee`. That is the single shared resolve site, so the refusal also reaches the LOAD_METHOD specialization gate, the callee-candidate scan and the self-recursive-callee check.
- Deliver a rebuild into an expression-position caller. `outer_call_operands_below` computes the operand residue below the CALL; the return path's `depths[post_call_py_pc] == 1` gate becomes `== below + 1`, and the raise path's `handler_depth == 0` becomes `handler_depth <= below.len()`, restoring the operands the CALL sat on instead of resetting to the bare stack base.
- Delete the `x_arg` seed **and the refusal it carried** ("first callee argument is not a `Ref`") — the third refusal class the census named.

## R6 — refuted, not fixed

R6 claimed pyre's virtualizable shadow is lazy where upstream's is write-through, and that this is why the mid-expression operand-stack latch exists. If true it would retire `flush_escape_state_with_latched_stack`, `ESCAPE_OPCODE_WINDOW`, `EscapeFlushUndo`, `EscapeResumeKind`, `RewindProvenAtLatch` and `RewindUnproven`.

**The outcome is a refutation recorded in the plan, not a code fix.** A debug-gated `[r6-latch]` probe compares each latched slot against the vable shadow. Over `pyre/bench/synth`, every slot that disagreed (10 disagreements in 2 files) was the in-progress opcode's TOS, and in every one it held a compile-time NULL *constant* written by `popvalue_maybe_none` (`pyframe.py:411-417` → `setarrayitem_vable_r(_, depth, ConstPtr.NULL)` via `jtransform.py:1898`) — the in-flight opcode had already **popped** it. RPython's `popvalue` NULLs the slot the same way, so on this evidence the array is correct and matches upstream, and the latch is the orthodox register-level mirror of what upstream keeps in `MIFrame.registers_r`. It does not retire.

An intermediate commit's stated root cause ("the missing write is the `pushvalue` array store") is refuted by the next one: `LOAD_ATTR` — the escaping opcode in both witness files — already emits the push mirror via `emit_pushvalue_ref!` and its slot still reads NULL, because the pop follows the push.

The only executable change in this slice is the probe block, wholly inside `if fbw_debug_abort_enabled()` (`PYRE_FBW_DEBUG_ABORT`); it reads pure accessors and prints. The rest of R6 is documentation. (The rustfmt commit is separate and reformats R5 code that landed earlier on the branch.)

## Not done / residue

Recorded in the plan's `## Residue` table so it is not re-derived. Nothing here is blocking:

| row | why not worked |
|---|---|
| 3 remaining `getarrayitem_vable_r` anchors | needs a color-liveness argument, not a measurement |
| depth-1 / N-frame (the assumed R5 blocker) | **unobserved, not refuted** — its gate sits outside the named-refusal path, so the census cannot see it either way |
| `push_and_bump!` omits the `jtransform.py:1898` array store | real gap, no corpus witness; prototyped under a `Kind::Ref` gate and reverted — it took one bench from 140 to 175 emitted `setarrayitem_vable_r` and changed none of the 10 disagreements |
| legs 3/6 and the store journals | keep — deleting them re-opens the gh#467 double-apply |

## Verification

The series was verified **as a whole at HEAD**, after the branch was rebased onto current `main`:

- `cargo test --all --features dynasm` — 7083 passed, 0 failed
- `python3 ./pyre/check.py` — dynasm 334/334, cranelift 334/334, wasm 331/331
- `cargo fmt --all -- --check` — clean

Most individual commits also carry their own gate line, but five do not (`6de46f5ae4`, `9faf14afd9`, `f7ecad700b`, `0d6e137717`, `3928e1606e`); the per-commit numbers in those messages predate the rebase. Census figures quoted in commit messages come from debug-gated runs and are not re-derivable from the tree alone.

## Reviewer notes

- `try_commit_entry_carrier_call` has three decline points; only the first — `walk_end_resume_provable(Rewind{..})` on `FBW_EXECUTED_EFFECT_COUNT` — is a soundness re-check. That odometer is walker-side and plain interpretation does not bump it.
- Only `try_execute_residual_call_via_executor` calls `escape_opcode_window_note`, so residuals reaching the opcode by another path do not constrain the window.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JIT state recovery after aborted or interrupted calls.
  * Ensured virtualizable values reflect current heap state instead of stale cached values.
  * Improved operand-stack and exception-state restoration during complex tracing scenarios.
  * Strengthened validation for inline calls, resume points, and virtualizable bookkeeping.
  * Generators, coroutines, and async generators are now handled more safely during optimization.

* **Documentation**
  * Added a detailed walk-end commit contract and roadmap.

* **Tests**
  * Expanded coverage for virtualizable state refresh, stack restoration, and tracing safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->