### PR TITLE
front: resolve an ambiguous name path to None in GraphBodyProvider

### DIFF
--- a/majit/majit-translate/src/front/graph_body.rs
+++ b/majit/majit-translate/src/front/graph_body.rs
@@ -64,23 +64,37 @@ impl GraphBodyProvider {
         }
     }
 
-    /// Locate the funcobj whose Charon `name_path()` is `name_path`.
+    /// Locate the funcobj whose Charon `name_path()` is `name_path`, if
+    /// exactly one carries it.
+    ///
+    /// `bookkeeper.py:361 getdesc(pyobj)` keys a descriptor by the function
+    /// object itself, so two distinct functions are never conflated even
+    /// when they render the same name.  A name path carries no such
+    /// identity, and nothing stops two extracted `FunDecl`s from sharing
+    /// one, so an ambiguous name resolves to nothing rather than to an
+    /// arbitrary one of the candidates: binding the wrong body is silent,
+    /// while a miss is not.  Identity on the demand path is
+    /// [`GraphBodySource`], recorded when the funcobj was registered.
     ///
     /// Linear over the corpus, so it is a registration-time helper (and
-    /// the test seam), not a per-demand lookup: the demand path carries
-    /// the [`GraphBodySource`] recorded when the funcobj was registered.
+    /// the test seam), not a per-demand lookup.
     pub(crate) fn source_for_name_path(&self, name_path: &str) -> Option<GraphBodySource> {
+        let mut found = None;
         for (i, llbc) in self.llbcs.iter().enumerate() {
             for fd in llbc.iter_local_fns() {
-                if fd.item_meta.name_path() == name_path {
-                    return Some(GraphBodySource {
-                        llbc_index: i as u32,
-                        def_id: fd.def_id,
-                    });
+                if fd.item_meta.name_path() != name_path {
+                    continue;
                 }
+                if found.is_some() {
+                    return None;
+                }
+                found = Some(GraphBodySource {
+                    llbc_index: i as u32,
+                    def_id: fd.def_id,
+                });
             }
         }
-        None
+        found
     }
 
     /// Lower the funcobj `src` names, reproducing what the whole-program
@@ -184,6 +198,10 @@ mod tests {
     /// A body built through the provider is the body the whole-program
     /// loop built: same graph shape, from the same `FunDecl`, for every
     /// funcobj in the corpus that lowers at all.
+    ///
+    /// Also asserts every lowerable funcobj's name path is unique in the
+    /// corpus: `source_for_name_path` resolves an ambiguous name to
+    /// `None`, so a duplicate surfaces here as a lookup miss.
     #[test]
     fn provider_reproduces_the_eagerly_lowered_body() {
         let llbc = Llbc::load(CORPUS).expect("load corpus.ullbc");
@@ -208,7 +226,7 @@ mod tests {
         for (name_path, want) in &eager {
             let src = provider
                 .source_for_name_path(name_path)
-                .unwrap_or_else(|| panic!("no GraphBodySource for {name_path}"));
+                .unwrap_or_else(|| panic!("no unique GraphBodySource for {name_path}"));
             let got = provider
                 .build(src)
                 .unwrap_or_else(|e| panic!("provider failed to build {name_path}: {e}"));


### PR DESCRIPTION
Follow-up to #835, from its Codex parity review (section 2).

`GraphBodyProvider::source_for_name_path` returned the first `FunDecl` whose
`name_path()` matched. Two extracted `FunDecl`s can render the same name path,
and in that case the first match binds a body that belongs to a different
funcobj — silently, because the caller sees a perfectly ordinary hit.

`bookkeeper.py:361 getdesc(pyobj)` keys a descriptor by the function object
itself, so upstream never conflates two functions that happen to share a name.
A Charon name path carries no such identity. `GraphBodySource` — the
`(llbc_index, def_id)` pair recorded at registration — is what does, and it is
already what the demand path resolves against; the name lookup is only the
registration-time/test seam.

So the helper now scans the whole corpus and returns `None` when more than one
`FunDecl` carries the name. A miss is visible where a wrong body is not.

`provider_reproduces_the_eagerly_lowered_body` gains a second job for free: it
looks every lowerable funcobj up by name, so a duplicate name path anywhere in
the corpus fixture now fails the test as a lookup miss.

No production behaviour changes — the provider still has no production call
site, as noted in #835.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved function lookup reliability by rejecting ambiguous matches instead of selecting one arbitrarily.
  * Updated error reporting to clearly distinguish missing functions from non-unique matches.

* **Tests**
  * Strengthened coverage to verify that lowerable functions have unique name paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->