### PR TITLE
str: route code point index and byte offset conversions

### DIFF
--- a/pyre/bench/synth/str_search_index_bounds.py
+++ b/pyre/bench/synth/str_search_index_bounds.py
@@ -1,0 +1,90 @@
+# Every str surface that converts between a code point index and a byte offset:
+# find/rfind/index/rindex and count take code point bounds and report a code
+# point result, startswith/endswith slice by them, and the width methods read
+# the string's own length. Each is folded over payloads whose code points are
+# 1-4 bytes wide and over strings long enough to span several index-table
+# groups, so an off-by-one in either direction changes the number.
+# `warm_find` searches a long wide payload repeatedly: resolving those bounds
+# by walking, or by materialising the whole offset table per call, costs orders
+# of magnitude rather than staying flat. Output verified against CPython/PyPy.
+SAMPLES = (
+    ("empty", ""),
+    ("ascii", "abcabcabc"),
+    ("latin1", "\xe9\xe8\xe9\xe8\xe9"),
+    ("wide", "一二一二一"),
+    ("astral", "\U0001f600\U0001f601\U0001f600\U0001f601"),
+    ("mixed", "a一b\U0001f600c一a"),
+    ("long_wide", "一二三四" * 40),
+    ("long_mixed", ("a\xe9一\U0001f600" * 40) + "zz"),
+)
+NEEDLES = ("", "a", "一", "\U0001f600", "ab", "一二", "zz")
+BOUNDS = (None, 0, 1, 3, -1, -3, -100, 100, 63, 64, 65, 160)
+
+
+def warm_find(reps):
+    s = "一二三四" * 2048 + "zq"
+    acc = 0
+    for _ in range(reps):
+        acc += s.find("zq") + s.rfind("一") + s.count("二", 7, -7)
+    return acc
+
+
+def fold(acc, value):
+    for ch in str(value):
+        acc = (acc * 31 + ord(ch)) & 0xFFFFFFFF
+    return acc
+
+
+def searches(s):
+    acc = 0
+    for sub in NEEDLES:
+        for a in BOUNDS:
+            for b in BOUNDS:
+                acc = fold(acc, s.find(sub, a, b))
+                acc = fold(acc, s.rfind(sub, a, b))
+                # An empty needle is excluded from count: PyPy answers the
+                # byte length plus one on a non-ASCII payload where 3.14
+                # answers the code point length plus one, so the corpus
+                # cannot compare it. Every other needle agrees.
+                if sub:
+                    acc = fold(acc, s.count(sub, a, b))
+                acc = fold(acc, s.startswith(sub, a, b))
+                acc = fold(acc, s.endswith(sub, a, b))
+                for meth in (s.index, s.rindex):
+                    # Only the raised type, not its text: the "substring not
+                    # found" message is worded differently across runtimes.
+                    try:
+                        acc = fold(acc, meth(sub, a, b))
+                    except ValueError:
+                        acc = fold(acc, "ValueError")
+    # index/rindex must agree with find/rfind wherever the latter hit.
+    for sub in NEEDLES:
+        assert (s.index(sub) if s.find(sub) >= 0 else -1) == s.find(sub)
+        assert (s.rindex(sub) if s.rfind(sub) >= 0 else -1) == s.rfind(sub)
+    return acc
+
+
+def widths(s):
+    acc = 0
+    for width in (0, 1, 5, 12, 200):
+        acc = fold(acc, s.center(width, "一"))
+        acc = fold(acc, s.ljust(width, "\U0001f600"))
+        acc = fold(acc, s.rjust(width, "\xe9"))
+        acc = fold(acc, s.zfill(width))
+        # A padded result is exactly `width` code points once it is wider.
+        assert len(s.center(width, "一")) == max(width, len(s))
+    return acc
+
+
+def main():
+    print("warm_find", warm_find(2000))
+    for name, s in SAMPLES:
+        print(name, "search", searches(s), "width", widths(s))
+    for x, y in (("", ""), ("ab", "一二"), ("一二", "ab"), ("abc", "ab")):
+        try:
+            print("maketrans", ascii(x), ascii(y), sorted(str.maketrans(x, y).items()))
+        except ValueError as e:
+            print("maketrans", ascii(x), ascii(y), "!!", ascii(str(e)))
+
+
+main()

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -1097,8 +1097,7 @@ pub fn str_method_rstrip(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyE
 pub fn str_method_startswith(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     arity_at_least(args, "startswith", 1)?;
     arity_at_most(args, "startswith", 3)?;
-    let s = unsafe { pyre_object::w_str_get_wtf8(args[0]) };
-    let Some(slice) = str_slice_args(s, args)? else {
+    let Some(slice) = str_slice_args(args[0], args)? else {
         return validate_prefix_arg(args[1], "startswith").map(|()| w_bool_from(false));
     };
     str_prefix_match(slice, args[1], "startswith", true).map(w_bool_from)
@@ -1107,8 +1106,7 @@ pub fn str_method_startswith(args: &[PyObjectRef]) -> Result<PyObjectRef, crate:
 pub fn str_method_endswith(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     arity_at_least(args, "endswith", 1)?;
     arity_at_most(args, "endswith", 3)?;
-    let s = unsafe { pyre_object::w_str_get_wtf8(args[0]) };
-    let Some(slice) = str_slice_args(s, args)? else {
+    let Some(slice) = str_slice_args(args[0], args)? else {
         return validate_prefix_arg(args[1], "endswith").map(|()| w_bool_from(false));
     };
     str_prefix_match(slice, args[1], "endswith", false).map(w_bool_from)
@@ -1126,11 +1124,12 @@ pub fn str_method_endswith(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::P
 /// it is short of the end. `None` signals the resulting window is inverted,
 /// for which the match is always `False` — even for an empty needle, which is
 /// why `'abc'.startswith('', 5, 10)` and `''.endswith('', 1, 0)` are `False`.
-fn str_slice_args<'a>(
-    s: &'a Wtf8,
+fn str_slice_args(
+    obj: pyre_object::PyObjectRef,
     args: &[pyre_object::PyObjectRef],
-) -> Result<Option<&'a Wtf8>, crate::PyError> {
-    let char_len = s.code_points().count() as i64;
+) -> Result<Option<&'static Wtf8>, crate::PyError> {
+    let s = unsafe { pyre_object::w_str_get_wtf8(obj) };
+    let char_len = unsafe { pyre_object::w_str_len(obj) } as i64;
     // `None` bounds mean "not provided" (start -> 0, end -> len).
     let start = if args.len() >= 3 && !unsafe { pyre_object::is_none(args[2]) } {
         crate::sliceobject::adapt_lower_bound(char_len, args[2])?
@@ -1143,21 +1142,16 @@ fn str_slice_args<'a>(
         char_len
     };
     let bytes = s.as_bytes();
-    let index_to_byte = |cp: i64| {
-        s.code_point_indices()
-            .nth(cp as usize)
-            .map_or(bytes.len(), |(i, _)| i)
-    };
     let mut end_index = bytes.len();
     if end < char_len {
-        end_index = index_to_byte(end);
+        end_index = unsafe { pyre_object::w_str_index_to_byte(obj, end as usize) };
     }
     let mut start_index = 0usize;
     if start > 0 {
         start_index = if start > char_len {
             end_index + 1
         } else {
-            index_to_byte(start)
+            unsafe { pyre_object::w_str_index_to_byte(obj, start as usize) }
         };
     }
     if start_index > end_index {
@@ -1290,10 +1284,10 @@ pub fn str_method_replace(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
 /// `None` when the codepoint window is empty because `start` is past the end
 /// or past `end` (the search-miss case shared by count).
 fn wtf8_idx_window(
-    s: &Wtf8,
+    obj: PyObjectRef,
     args: &[PyObjectRef],
 ) -> Result<Option<(usize, usize)>, crate::PyError> {
-    let cp_len = s.code_points().count() as i64;
+    let cp_len = unsafe { pyre_object::w_str_len(obj) } as i64;
     let w_start = if args.len() >= 3 { args[2] } else { w_none() };
     let w_end = if args.len() >= 4 { args[3] } else { w_none() };
     let (start, end) = crate::sliceobject::unwrap_start_stop(cp_len, w_start, w_end)?;
@@ -1304,14 +1298,8 @@ fn wtf8_idx_window(
     if start > end {
         return Ok(None);
     }
-    let byte_start = s
-        .code_point_indices()
-        .nth(start as usize)
-        .map_or(s.len(), |(i, _)| i);
-    let byte_end = s
-        .code_point_indices()
-        .nth(end as usize)
-        .map_or(s.len(), |(i, _)| i);
+    let byte_start = unsafe { pyre_object::w_str_index_to_byte(obj, start as usize) };
+    let byte_end = unsafe { pyre_object::w_str_index_to_byte(obj, end as usize) };
     Ok(Some((byte_start, byte_end)))
 }
 
@@ -4104,7 +4092,7 @@ pub fn str_method_zfill(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyEr
     arity_exact(args, "str.zfill", 1)?;
     let s = unsafe { w_str_get_wtf8(args[0]) };
     let width = crate::builtins::space_index_w(args[1])?.max(0) as usize;
-    let len = s.code_points().count();
+    let len = unsafe { pyre_object::w_str_len(args[0]) };
     if len >= width {
         return Ok(str_result_unchanged(args[0]));
     }
@@ -4674,9 +4662,21 @@ fn rstring_search_normal(
 /// scanning over the WTF-8 bytes. PyPy's `unicodeobject.py:1116` delegates
 /// to `_utf8.count`; the RPython translation path for non-host strings is
 /// `rstring.py:_search_normal(..., SEARCH_COUNT)`.
+///
+/// The empty needle is answered here rather than through that path. Any
+/// other needle is a whole encoded sequence, so counting matches over bytes
+/// and counting them over code points give the same number; the empty
+/// needle alone degenerates to `end - start + 1` (`rstring.py:836`), which
+/// is a length, and the bounds `descr_count` hands down are byte offsets
+/// (`unicodeobject.py:1322` says so). PyPy therefore reports the byte
+/// length plus one for a non-ASCII receiver: `"\xe9\xe8\xe9\xe8\xe9"
+/// .count("")` is 11 there against 6 in 3.14. `descr_find` and its
+/// siblings escape this because `_unwrap_and_search` maps the byte result
+/// back with `_byte_to_index`, a step a count has nowhere to put. 3.14
+/// counts code points, so that is what this counts.
 fn wtf8_count(haystack: &Wtf8, needle: &Wtf8) -> usize {
     if needle.is_empty() {
-        return haystack.code_points().count() + 1;
+        return pyre_object::rutf8::codepoints_in_utf8(haystack, 0, haystack.len()) + 1;
     }
     rstring_search_normal(
         haystack.as_bytes(),
@@ -4719,31 +4719,30 @@ fn str_unwrap_and_search(
     args: &[PyObjectRef],
     forward: bool,
 ) -> Result<Option<i64>, crate::PyError> {
-    let s = unsafe { pyre_object::w_str_get_wtf8(args[0]) };
+    let obj = args[0];
+    let s = unsafe { pyre_object::w_str_get_wtf8(obj) };
     let sub = unsafe { pyre_object::w_str_get_wtf8(args[1]) }.as_bytes();
     let h = s.as_bytes();
-    // Byte offset of each codepoint, with the trailing length appended,
-    // so `cp_offsets[i]` is `_index_to_byte(i)` and a byte offset maps
-    // back via its position.
-    let mut cp_offsets: Vec<usize> = s.code_point_indices().map(|(i, _)| i).collect();
-    cp_offsets.push(h.len());
-    let length = (cp_offsets.len() - 1) as i64;
+    let length = unsafe { pyre_object::w_str_len(obj) } as i64;
 
     let w_start = if args.len() >= 3 { args[2] } else { w_none() };
     let w_end = if args.len() >= 4 { args[3] } else { w_none() };
     let (start, end) = crate::sliceobject::unwrap_start_stop(length, w_start, w_end)?;
 
+    // `_search` (`unicodeobject.py:1290`): the two code point bounds become
+    // byte offsets through `_index_to_byte`, and the byte offset the search
+    // lands on comes back through `_byte_to_index`.
     let start_index = if start == 0 {
         0
     } else if start > length {
         return Ok(None);
     } else {
-        cp_offsets[start as usize]
+        unsafe { pyre_object::w_str_index_to_byte(obj, start as usize) }
     };
     let end_index = if end >= length {
         h.len()
     } else {
-        cp_offsets[end as usize]
+        unsafe { pyre_object::w_str_index_to_byte(obj, end as usize) }
     };
     if start_index > end_index {
         return Ok(None);
@@ -4754,7 +4753,7 @@ fn str_unwrap_and_search(
     } else {
         wtf8_rfind_bounded(h, sub, start_index, end_index)
     };
-    Ok(res_index.and_then(|ri| cp_offsets.iter().position(|&o| o == ri).map(|i| i as i64)))
+    Ok(res_index.map(|ri| unsafe { pyre_object::w_str_byte_to_index(obj, ri) } as i64))
 }
 
 /// PyPy: unicodeobject.py descr_count
@@ -4766,7 +4765,7 @@ pub fn str_method_count(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyEr
     // start / end arguments bound the count window over the code points.
     let s = unsafe { pyre_object::w_str_get_wtf8(args[0]) };
     let sub = unsafe { pyre_object::w_str_get_wtf8(args[1]) };
-    let Some((byte_start, byte_end)) = wtf8_idx_window(s, args)? else {
+    let Some((byte_start, byte_end)) = wtf8_idx_window(args[0], args)? else {
         return Ok(w_int_new(0));
     };
     let window = rustpython_wtf8::Wtf8::from_bytes(&s.as_bytes()[byte_start..byte_end])
@@ -4870,7 +4869,7 @@ pub fn str_method_center(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyE
     let s = unsafe { w_str_get_wtf8(args[0]) };
     let width = crate::builtins::space_index_w(args[1])?.max(0) as usize;
     let fillchar = pad_fillchar(args, "center")?;
-    let s_len = s.code_points().count();
+    let s_len = unsafe { pyre_object::w_str_len(args[0]) };
     if s_len >= width {
         return Ok(str_result_unchanged(args[0]));
     }
@@ -4891,7 +4890,7 @@ pub fn str_method_ljust(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyEr
     let s = unsafe { w_str_get_wtf8(args[0]) };
     let width = crate::builtins::space_index_w(args[1])?.max(0) as usize;
     let fillchar = pad_fillchar(args, "ljust")?;
-    let s_len = s.code_points().count();
+    let s_len = unsafe { pyre_object::w_str_len(args[0]) };
     if s_len >= width {
         return Ok(str_result_unchanged(args[0]));
     }
@@ -4907,7 +4906,7 @@ pub fn str_method_rjust(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyEr
     let s = unsafe { w_str_get_wtf8(args[0]) };
     let width = crate::builtins::space_index_w(args[1])?.max(0) as usize;
     let fillchar = pad_fillchar(args, "rjust")?;
-    let s_len = s.code_points().count();
+    let s_len = unsafe { pyre_object::w_str_len(args[0]) };
     if s_len >= width {
         return Ok(str_result_unchanged(args[0]));
     }

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -5356,7 +5356,8 @@ fn init_str_type(ns: PyObjectRef) {
 
                     let x = unsafe { pyre_object::w_str_get_wtf8(args[0]) };
                     let y = unsafe { pyre_object::w_str_get_wtf8(args[1]) };
-                    if x.code_points().count() != y.code_points().count() {
+                    if unsafe { pyre_object::w_str_len(args[0]) != pyre_object::w_str_len(args[1]) }
+                    {
                         return Err(crate::PyError::value_error(
                             "the first two maketrans arguments must have equal length",
                         ));

--- a/pyre/pyre-object/src/rutf8.rs
+++ b/pyre/pyre-object/src/rutf8.rs
@@ -1,22 +1,55 @@
-//! RPython's `rpython.rlib.rutf8` code point index storage, ported
-//! structurally to Rust.
+//! RPython's `rpython.rlib.rutf8`, ported structurally to Rust.
 //!
-//! A UTF-8 (here WTF-8) buffer addresses code points by byte offset, so
-//! resolving the n-th code point means walking from the start.  The index
-//! storage turns that walk into a table lookup: one entry per 64 code points
-//! holding the byte offset the group starts at, plus a one-byte delta for every
-//! fourth code point inside it.  A lookup reads the entry, adds the delta, and
-//! steps at most two code points — `codepoint_position_at_index`.
+//! # Relationship to `rustpython-wtf8`
 //!
-//! The table costs 24 bytes per 64 code points and is built once per string,
-//! on the first non-ASCII index; an ASCII payload never needs one because its
-//! code point index is already its byte offset (`W_UnicodeObject.is_ascii`).
+//! RPython has no string *type*: `W_UnicodeObject._utf8` is a plain `str`
+//! (immutable bytes) and every operation on it is a free function in `rutf8`
+//! taking `(code, pos)`.  pyre stores the same buffer as a `Wtf8Buf`, a type
+//! that already carries the well-formedness invariant, so the two overlap and
+//! the split has to be deliberate:
+//!
+//! * **`rustpython-wtf8` owns the representation and sequential access.** An
+//!   `rutf8` function whose whole content is "encode, decode or validate,
+//!   scanning forward" has a checked counterpart there and is *not* re-ported:
+//!   a second, unchecked implementation beside a checked one would be two
+//!   sources of truth for one invariant.  `unichr_as_utf8*` (:40) is
+//!   `CodePoint::encode_wtf8` / `Wtf8Buf::push`; `check_utf8` (:351),
+//!   `_check_utf8` (:373) and `get_utf8_length` (:364) are `Wtf8::from_bytes`;
+//!   `check_ascii` (:242) and `first_non_ascii_char` (:249) are
+//!   `Wtf8::is_ascii` and a byte scan; `has_surrogates` (:439) and
+//!   `surrogate_in_utf8` (:489) are `Wtf8::as_str().is_err()`; `islinebreak`
+//!   (:255), `isspace` (:272) and `utf8_in_chars` (:307) are predicates over a
+//!   decoded `CodePoint`; `char_escape_helper` (:647),
+//!   `make_utf8_escape_function` (:660) and `decode_latin_1` (:867) belong to
+//!   `repr` and `_codecs`.
+//!
+//! * **This module owns random access**, which the crate deliberately has no
+//!   counterpart for — its iterators are sequential, so resolving the n-th code
+//!   point through them costs O(n).  `UTF8_INDEX_STORAGE` is PyPy's index over
+//!   an *already valid* buffer, and everything written against it lives here:
+//!   the table and its build, the three lookups that read it, and the byte
+//!   offset stepping (`next_codepoint_pos`, `prev_codepoint_pos`) they are
+//!   defined in terms of, which is pure arithmetic the crate exposes no
+//!   equivalent for.
+//!
+//! That is why the `utf8` parameter is `&Wtf8` rather than `&[u8]`: `&Wtf8` is
+//! what RPython's `str` payload becomes once the invariant lives in the type,
+//! and holding it lets `codepoint_at_pos` decode through the crate instead of
+//! carrying a second copy of its decoder.
+//!
+//! Two members of the family are deliberately absent.  `null_storage` (:513)
+//! has no counterpart: an absent table is a null pointer in the
+//! `W_UnicodeObject` slot.  `_pos_at_index` (:568), the "Slow!" linear
+//! fallback, has no pyre caller — upstream reaches it from `unicodehelper` and
+//! `formatting`, neither of which pyre routes this way.
 //!
 //! Names, entry layout, group sizes and the build loop follow
-//! `rpython/rlib/rutf8.py:131-566`.  The `_is_64bit` branch of
+//! `rpython/rlib/rutf8.py:131-644`.  The `_is_64bit` branch of
 //! `next_codepoint_pos` (a hand-tuned x86-64 sequence guarded by
 //! `not jit.we_are_jitted()`) is left out: it computes the same value as the
 //! comparison ladder it sits in front of.
+
+use rustpython_wtf8::{CodePoint, Wtf8};
 
 /// `UTF8_INDEX_STORAGE`'s element (`rutf8.py:508-511`) — `baseindex` is the
 /// byte offset the 64-code-point group starts at, and `ofs[i]` the byte delta
@@ -36,8 +69,8 @@ pub type Utf8IndexStorage = Vec<Utf8LocElem>;
 /// `next_codepoint_pos` (`rutf8.py:131`) — the position of the code point after
 /// `pos`.  Assumes valid WTF-8 and `pos` before the end.
 #[inline]
-pub fn next_codepoint_pos(code: &[u8], pos: usize) -> usize {
-    let chr1 = code[pos];
+pub fn next_codepoint_pos(code: &Wtf8, pos: usize) -> usize {
+    let chr1 = code.as_bytes()[pos];
     if chr1 <= 0x7F {
         return pos + 1;
     }
@@ -54,7 +87,8 @@ pub fn next_codepoint_pos(code: &[u8], pos: usize) -> usize {
 /// before `pos`, which must not be zero.  A `pos` one past the end reads as the
 /// extra `'\x00'` the build loop pretends is there.
 #[inline]
-pub fn prev_codepoint_pos(code: &[u8], pos: usize) -> usize {
+pub fn prev_codepoint_pos(code: &Wtf8, pos: usize) -> usize {
+    let code = code.as_bytes();
     let mut pos = pos - 1;
     if pos >= code.len() {
         return pos;
@@ -73,9 +107,49 @@ pub fn prev_codepoint_pos(code: &[u8], pos: usize) -> usize {
     pos - 1
 }
 
+/// `codepoint_at_pos` (`rutf8.py:175`) — the code point starting at byte `pos`.
+///
+/// Assumes valid WTF-8 with `pos` on a boundary before the end, as upstream
+/// does ("no checking!").  The decode itself goes through the crate rather than
+/// a second copy of its bit arithmetic.
+#[inline]
+pub fn codepoint_at_pos(code: &Wtf8, pos: usize) -> CodePoint {
+    let end = next_codepoint_pos(code, pos);
+    code.get(pos..end)
+        .and_then(|one| one.code_points().next())
+        .expect("codepoint_at_pos: pos is not a code point boundary")
+}
+
+/// `codepoint_before_pos` (`rutf8.py:201`) — the code point immediately before
+/// `pos`, which must not be zero.
+///
+/// Upstream walks the continuation bytes backwards inline; composing the
+/// already-ported `prev_codepoint_pos` with `codepoint_at_pos` yields the same
+/// code point by construction, and inherits `prev_codepoint_pos`'s handling of
+/// a `pos` one past the end.
+#[inline]
+pub fn codepoint_before_pos(code: &Wtf8, pos: usize) -> CodePoint {
+    codepoint_at_pos(code, prev_codepoint_pos(code, pos))
+}
+
+/// `codepoints_in_utf8` (`rutf8.py:471`) — the number of code points in
+/// `value[start..end]`.
+///
+/// Counts the bytes that are *not* continuation bytes, which upstream spells as
+/// a signed-char comparison against `-0x40`.
+pub fn codepoints_in_utf8(value: &Wtf8, start: usize, end: usize) -> usize {
+    let value = value.as_bytes();
+    let end = end.min(value.len());
+    debug_assert!(start <= end);
+    value[start..end]
+        .iter()
+        .filter(|&&ch| (ch as i8) >= -0x40)
+        .count()
+}
+
 /// `create_utf8_index_storage` (`rutf8.py:516`) — the table for `utf8`, whose
 /// code point count is `utf8len`.
-pub fn create_utf8_index_storage(utf8: &[u8], utf8len: usize) -> Utf8IndexStorage {
+pub fn create_utf8_index_storage(utf8: &Wtf8, utf8len: usize) -> Utf8IndexStorage {
     let arraysize = utf8len / 64 + 1;
     let mut storage = vec![
         Utf8LocElem {
@@ -123,7 +197,7 @@ pub fn create_utf8_index_storage(utf8: &[u8], utf8len: usize) -> Utf8IndexStorag
 /// `codepoint_position_at_index` (`rutf8.py:548`) — the byte offset of code
 /// point `index`, which must not exceed the string's code point count.
 #[inline]
-pub fn codepoint_position_at_index(utf8: &[u8], storage: &[Utf8LocElem], index: usize) -> usize {
+pub fn codepoint_position_at_index(utf8: &Wtf8, storage: &[Utf8LocElem], index: usize) -> usize {
     let elem = &storage[index >> 6];
     let bytepos = elem.baseindex as usize + elem.ofs[(index >> 2) & 0x0F] as usize;
     match index & 0x3 {
@@ -134,10 +208,91 @@ pub fn codepoint_position_at_index(utf8: &[u8], storage: &[Utf8LocElem], index: 
     }
 }
 
+/// `codepoint_at_index` (`rutf8.py:576`) — the code point at code point
+/// `index`, which must be below the string's code point count.
+///
+/// Upstream fuses the position lookup with the decode so the JIT sees one
+/// elidable call; both spellings walk to the same byte offset, so this is the
+/// composition of the two.
+#[inline]
+pub fn codepoint_at_index(utf8: &Wtf8, storage: &[Utf8LocElem], index: usize) -> CodePoint {
+    codepoint_at_pos(utf8, codepoint_position_at_index(utf8, storage, index))
+}
+
+/// `codepoint_index_at_byte_position` (`rutf8.py:594`) — the code point index
+/// for which `codepoint_position_at_index` is `bytepos`.
+///
+/// Logarithmic in the string length, plus a constant that is not tiny either.
+/// Upstream's leading `if bytepos < 0: return bytepos` guard carries `str.find`
+/// misses through; pyre's search returns `Option`, so the caller handles a miss
+/// and this takes an offset that is always real.
+pub fn codepoint_index_at_byte_position(
+    utf8: &Wtf8,
+    storage: &[Utf8LocElem],
+    bytepos: usize,
+    num_codepoints: usize,
+) -> usize {
+    let bytes = utf8.as_bytes();
+    // binary search on elements of storage
+    let bytes_remaining = bytes.len() - bytepos;
+    // the fact that one codepoint is encoded in 1-4 bytes constrains the
+    // result. pick good min and max indexes based on this observation. saves a
+    // few bisection steps.  Both `max` candidates are clamped at zero, which
+    // the `max`/`min` against a non-negative bound would have discarded anyway.
+    let mut index_min = std::cmp::max(
+        bytepos / 4,
+        num_codepoints.saturating_sub(bytes_remaining + 1),
+    ) >> 6;
+    let mut index_max =
+        std::cmp::min(bytepos, num_codepoints.saturating_sub(bytes_remaining / 4)) >> 6;
+    while index_min < index_max {
+        // this addition can't overflow because storage has a length that is
+        // 1/64 of the length of a string
+        let index_middle = (index_min + index_max + 1) / 2;
+        let base_bytepos = storage[index_middle].baseindex as usize;
+        if bytepos < base_bytepos {
+            index_max = index_middle - 1;
+        } else {
+            index_min = index_middle;
+        }
+    }
+
+    let baseindex = storage[index_min].baseindex as usize;
+    if baseindex == bytepos {
+        return index_min << 6;
+    }
+
+    // use ofs to get closer to the correct character index.  Reaching here
+    // means `bytepos` is past a group start, so the string is not empty and
+    // `num_codepoints - 1` cannot underflow.
+    let mut result = index_min << 6;
+    let mut bytepos1 = baseindex;
+    let maxindex = if index_min == storage.len() - 1 {
+        ((num_codepoints - 1) >> 2) & 0x0F
+    } else {
+        16
+    };
+    for i in 0..maxindex {
+        let x = baseindex + storage[index_min].ofs[i] as usize;
+        if x >= bytepos {
+            break;
+        }
+        bytepos1 = x;
+        result = (index_min << 6) + (i << 2) + 1;
+    }
+
+    // this loop should run at most four times
+    while bytepos1 < bytepos {
+        bytepos1 = next_codepoint_pos(utf8, bytepos1);
+        result += 1;
+    }
+    result
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rustpython_wtf8::{CodePoint, Wtf8Buf};
+    use rustpython_wtf8::Wtf8Buf;
 
     fn sample(kind: &str, repeat: usize) -> Wtf8Buf {
         let mut buf = Wtf8Buf::new();
@@ -160,28 +315,39 @@ mod tests {
         buf
     }
 
+    const KINDS: [&str; 6] = ["ascii", "latin1", "wide", "astral", "mixed", "surrogate"];
+    // Lengths straddling the 4-code-point delta stride and the 64-code point
+    // group, in both directions.
+    const REPEATS: [usize; 11] = [0, 1, 2, 15, 16, 17, 32, 63, 64, 65, 100];
+
     /// The table must answer exactly what a walk from the start would.
     fn assert_matches_walk(buf: &Wtf8Buf) {
-        let utf8 = buf.as_bytes();
         let positions: Vec<usize> = buf.code_point_indices().map(|(pos, _)| pos).collect();
-        let storage = create_utf8_index_storage(utf8, positions.len());
+        let storage = create_utf8_index_storage(buf, positions.len());
         for (index, &expected) in positions.iter().enumerate() {
             assert_eq!(
-                codepoint_position_at_index(utf8, &storage, index),
+                codepoint_position_at_index(buf, &storage, index),
                 expected,
                 "index {index} of a {} byte / {} code point payload",
-                utf8.len(),
+                buf.len(),
                 positions.len(),
             );
         }
+        // "smaller than or equal to the utf8 length" — the build loop's
+        // padding slot exists so the count itself resolves to the end, which
+        // is what a `start`/`end` bound equal to the length asks for.
+        assert_eq!(
+            codepoint_position_at_index(buf, &storage, positions.len()),
+            buf.len(),
+            "the code point count of a {} byte payload",
+            buf.len(),
+        );
     }
 
     #[test]
     fn test_index_storage_matches_a_walk() {
-        // Lengths straddling the 4-code-point delta stride and the 64-code
-        // point group, in both directions.
-        for repeat in [0, 1, 2, 15, 16, 17, 32, 63, 64, 65, 100] {
-            for kind in ["ascii", "latin1", "wide", "astral", "mixed", "surrogate"] {
+        for repeat in REPEATS {
+            for kind in KINDS {
                 assert_matches_walk(&sample(kind, repeat));
             }
         }
@@ -199,9 +365,84 @@ mod tests {
 
     #[test]
     fn test_index_storage_size_is_one_entry_per_64_code_points() {
-        assert_eq!(create_utf8_index_storage(b"", 0).len(), 1);
-        assert_eq!(create_utf8_index_storage(&[b'a'; 64], 64).len(), 2);
-        assert_eq!(create_utf8_index_storage(&[b'a'; 127], 127).len(), 2);
-        assert_eq!(create_utf8_index_storage(&[b'a'; 128], 128).len(), 3);
+        assert_eq!(create_utf8_index_storage(Wtf8::new(""), 0).len(), 1);
+        let ascii = "a".repeat(128);
+        assert_eq!(
+            create_utf8_index_storage(Wtf8::new(&ascii[..64]), 64).len(),
+            2
+        );
+        assert_eq!(
+            create_utf8_index_storage(Wtf8::new(&ascii[..127]), 127).len(),
+            2
+        );
+        assert_eq!(
+            create_utf8_index_storage(Wtf8::new(&ascii[..]), 128).len(),
+            3
+        );
+    }
+
+    /// `codepoint_at_index` must yield what iteration yields, at every index.
+    #[test]
+    fn test_codepoint_at_index_matches_iteration() {
+        for repeat in REPEATS {
+            for kind in KINDS {
+                let buf = sample(kind, repeat);
+                let expected: Vec<CodePoint> = buf.code_points().collect();
+                let storage = create_utf8_index_storage(&buf, expected.len());
+                for (index, &cp) in expected.iter().enumerate() {
+                    assert_eq!(
+                        codepoint_at_index(&buf, &storage, index).to_u32(),
+                        cp.to_u32(),
+                        "{kind} * {repeat}, index {index}",
+                    );
+                }
+            }
+        }
+    }
+
+    /// `codepoint_index_at_byte_position` must invert
+    /// `codepoint_position_at_index` at every code point boundary.
+    #[test]
+    fn test_byte_position_inverts_index_lookup() {
+        for repeat in REPEATS {
+            for kind in KINDS {
+                let buf = sample(kind, repeat);
+                let positions: Vec<usize> = buf.code_point_indices().map(|(pos, _)| pos).collect();
+                let n = positions.len();
+                let storage = create_utf8_index_storage(&buf, n);
+                for (index, &bytepos) in positions.iter().enumerate() {
+                    assert_eq!(
+                        codepoint_index_at_byte_position(&buf, &storage, bytepos, n),
+                        index,
+                        "{kind} * {repeat}, byte {bytepos}",
+                    );
+                }
+                // The end of the string maps to the code point count.
+                assert_eq!(
+                    codepoint_index_at_byte_position(&buf, &storage, buf.len(), n),
+                    n,
+                    "{kind} * {repeat}, end",
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_codepoints_in_utf8_counts_a_byte_window() {
+        for repeat in REPEATS {
+            for kind in KINDS {
+                let buf = sample(kind, repeat);
+                let positions: Vec<usize> = buf.code_point_indices().map(|(pos, _)| pos).collect();
+                let n = positions.len();
+                assert_eq!(codepoints_in_utf8(&buf, 0, buf.len()), n);
+                // Every code point-aligned window counts its own span, and an
+                // `end` past the buffer clamps.
+                for (index, &start) in positions.iter().enumerate() {
+                    assert_eq!(codepoints_in_utf8(&buf, start, buf.len()), n - index);
+                    assert_eq!(codepoints_in_utf8(&buf, 0, start), index);
+                }
+                assert_eq!(codepoints_in_utf8(&buf, 0, buf.len() + 10), n);
+            }
+        }
     }
 }

--- a/pyre/pyre-object/src/unicodeobject.rs
+++ b/pyre/pyre-object/src/unicodeobject.rs
@@ -478,8 +478,7 @@ pub unsafe fn w_str_is_ascii(obj: PyObjectRef) -> bool {
 unsafe fn w_str_compute_index_storage(obj: PyObjectRef) -> *mut crate::rutf8::Utf8IndexStorage {
     unsafe {
         let str_obj = obj as *mut W_UnicodeObject;
-        let storage =
-            crate::rutf8::create_utf8_index_storage((*(*str_obj).value).as_bytes(), (*str_obj).len);
+        let storage = crate::rutf8::create_utf8_index_storage(&*(*str_obj).value, (*str_obj).len);
         let tid = if crate::gc_hook::try_gc_owns_object(obj as *mut u8) {
             utf8_index_gc_type_id()
         } else {
@@ -509,7 +508,9 @@ unsafe fn w_str_get_index_storage(obj: PyObjectRef) -> *mut crate::rutf8::Utf8In
 }
 
 /// `W_UnicodeObject._index_to_byte` (`unicodeobject.py:1251`) — the byte offset
-/// of code point `index`, which must be below the code point count.
+/// of code point `index`, which must not exceed the code point count.  The
+/// count itself resolves to the end of the buffer, which is what a `start` or
+/// `end` bound equal to the length asks for.
 ///
 /// # Safety
 /// `obj` must point to a valid `W_UnicodeObject` and `index` must be in range.
@@ -520,16 +521,57 @@ pub unsafe fn w_str_index_to_byte(obj: PyObjectRef, index: usize) -> usize {
         }
         let storage = w_str_get_index_storage(obj);
         crate::rutf8::codepoint_position_at_index(
-            (*(*(obj as *const W_UnicodeObject)).value).as_bytes(),
+            &*(*(obj as *const W_UnicodeObject)).value,
             &*storage,
             index,
         )
     }
 }
 
-/// The code point at `index`, or `None` past the end — the read behind
-/// `_getitem_result` (`unicodeobject.py:1205`): resolve the position through
-/// `_index_to_byte`, then take the one code point that starts there.
+/// `W_UnicodeObject._byte_to_index` (`unicodeobject.py:1263`) — the code point
+/// index whose [`w_str_index_to_byte`] is `bytepos`.
+///
+/// Logarithmic in the string length, with a constant that is not tiny either,
+/// so callers resolve a byte offset once rather than per code point.
+///
+/// # Safety
+/// `obj` must point to a valid `W_UnicodeObject` and `bytepos` must be a code
+/// point boundary within it.
+pub unsafe fn w_str_byte_to_index(obj: PyObjectRef, bytepos: usize) -> usize {
+    unsafe {
+        if w_str_is_ascii(obj) {
+            return bytepos;
+        }
+        let storage = w_str_get_index_storage(obj);
+        crate::rutf8::codepoint_index_at_byte_position(
+            &*(*(obj as *const W_UnicodeObject)).value,
+            &*storage,
+            bytepos,
+            w_str_len(obj),
+        )
+    }
+}
+
+/// `W_UnicodeObject._codepoints_in_utf8` (`unicodeobject.py:1257`) — the number
+/// of code points in the byte window `start..end`.
+///
+/// # Safety
+/// `obj` must point to a valid `W_UnicodeObject` and `start <= end` must hold.
+pub unsafe fn w_str_codepoints_in_utf8(obj: PyObjectRef, start: usize, end: usize) -> usize {
+    unsafe {
+        if w_str_is_ascii(obj) {
+            return end - start;
+        }
+        crate::rutf8::codepoints_in_utf8(&*(*(obj as *const W_UnicodeObject)).value, start, end)
+    }
+}
+
+/// The code point at `index`, or `None` past the end.
+///
+/// `rutf8.codepoint_at_index` (`rutf8.py:576`) is the read for a non-ASCII
+/// payload; an ASCII one takes `_index_to_byte`'s direct branch
+/// (`unicodeobject.py:1251`), where the code point index is already the byte
+/// offset, and never builds a table.
 ///
 /// # Safety
 /// `obj` must point to a valid `W_UnicodeObject`.
@@ -538,12 +580,14 @@ pub unsafe fn w_str_codepoint_at(obj: PyObjectRef, index: usize) -> Option<CodeP
         if index >= w_str_len(obj) {
             return None;
         }
-        let start = w_str_index_to_byte(obj, index);
         let value = &*(*(obj as *const W_UnicodeObject)).value;
-        let end = crate::rutf8::next_codepoint_pos(value.as_bytes(), start);
-        value
-            .get(start..end)
-            .and_then(|one| one.code_points().next())
+        if w_str_is_ascii(obj) {
+            return value
+                .get(index..index + 1)
+                .and_then(|one| one.code_points().next());
+        }
+        let storage = w_str_get_index_storage(obj);
+        Some(crate::rutf8::codepoint_at_index(value, &*storage, index))
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary


## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 will be run automatically when this is ready for review.
The prompt is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
-->

- [ ] I fully resolved all reasonable code review comments from Codex and CodeRabbit.
  - [ ] Auto-review section 1 is clear. This check is mandatory.
  - [ ] Auto-review section 2 is clear. If this is not checked, please add a comment explaining why.
- [ ] I did not use AI to write the code of this patch.
  - If this is not checked, commits must include `Assisted-by`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Unicode-aware string indexing and slicing, including text containing non-ASCII and astral characters.
  - Corrected behavior for substring searches, counts, prefixes, suffixes, padding, alignment, and zero-filling.
  - Ensured translation-table validation consistently handles Unicode string lengths.
  - Improved consistency between character positions and underlying text representation.

- **Tests**
  - Added comprehensive coverage for Unicode search, indexing, width, and translation edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->