### PR TITLE
jit: stop the frame-chain walkers from forcing; keep last_instr current across residual calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,6 @@ aheui/
 CLAUDE.md
 
 # Personal planning docs (not committed)
+
+# Scratch probes, profiles and baseline binaries (not committed)
+/scratchpad/

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -352,6 +352,9 @@ fn ensure_jitframe_type_registered(gc: &mut dyn GcAllocator) -> Option<u32> {
 /// Install a GC box into TLS and register all `set_active_*` hooks.
 /// Shared by `install_gc_standalone` (production) and `set_gc_allocator` (tests).
 fn install_gc_box(mut gc: Box<dyn GcAllocator>) {
+    // Per-thread allocator: its nursery is not the singleton's, so the
+    // process-wide published range can no longer answer `is_nursery_object`.
+    majit_gc::disarm_published_nursery();
     let jitframe_type_id = ensure_jitframe_type_registered(gc.as_mut());
     gc.freeze_types();
     let supports_guard_gc_type = gc.supports_guard_gc_type();

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -211,6 +211,10 @@ fn register_active_hooks(supports_guard_gc_type: bool) {
 /// [`install_gc_standalone`], which registers the same hooks WITHOUT a
 /// box so the trampolines fall through to `gc_sync`.
 fn install_gc_box(gc: Box<dyn majit_gc::GcAllocator>) {
+    // This thread now answers heap queries from its own allocator, whose
+    // nursery is not the singleton's, so the process-wide published range can
+    // no longer stand in for `is_nursery_object`.
+    majit_gc::disarm_published_nursery();
     let supports_guard_gc_type = gc.supports_guard_gc_type();
     DYNASM_ACTIVE_GC.with(|cell| {
         let mut guard = cell.borrow_mut();

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -331,6 +331,9 @@ fn register_active_hooks(supports_guard_gc_type: bool) {
 /// registers the same hooks WITHOUT a box so the trampolines fall through
 /// to `gc_sync`.
 fn install_gc_box(gc: Box<dyn majit_gc::GcAllocator>) {
+    // Per-thread allocator: its nursery is not the singleton's, so the
+    // process-wide published range can no longer answer `is_nursery_object`.
+    majit_gc::disarm_published_nursery();
     let supports_guard_gc_type = gc.supports_guard_gc_type();
     WASM_ACTIVE_GC.with(|cell| {
         let mut guard = cell.borrow_mut();

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -3763,6 +3763,15 @@ impl GcAllocator for MiniMarkGC {
         self.is_nursery_object_start(addr)
     }
 
+    fn nursery_bounds(&self) -> Option<(usize, usize)> {
+        let start = self.nursery.start_ptr() as usize;
+        Some((start, start + self.nursery.size()))
+    }
+
+    fn taggedpointers(&self) -> bool {
+        self.config.taggedpointers
+    }
+
     fn write_barrier(&mut self, obj: GcRef) {
         self.do_write_barrier(obj);
     }

--- a/majit/majit-gc/src/gc_sync.rs
+++ b/majit/majit-gc/src/gc_sync.rs
@@ -93,6 +93,7 @@ pub fn store_singleton(gc: Box<dyn GcAllocator>) {
     // SAFETY: gc_mutex held, no concurrent access.
     unsafe {
         *GC_STORE.0.get() = Some(gc);
+        crate::publish_singleton_nursery(&**(*GC_STORE.0.get()).as_ref().unwrap());
     }
     GC_INITIALIZED.store(true, Ordering::Release);
 }
@@ -115,6 +116,7 @@ pub fn replace_singleton_leaking_old(gc: Box<dyn GcAllocator>) {
             std::mem::forget(old);
         }
         *GC_STORE.0.get() = Some(gc);
+        crate::publish_singleton_nursery(&**(*GC_STORE.0.get()).as_ref().unwrap());
     }
     GC_INITIALIZED.store(true, Ordering::Release);
 }

--- a/majit/majit-gc/src/lib.rs
+++ b/majit/majit-gc/src/lib.rs
@@ -398,6 +398,19 @@ pub trait GcAllocator: Send {
         false
     }
 
+    /// The nursery's `[start, end)`, when it is a fixed range for the life of
+    /// this allocator.  `None` (the default) keeps callers on the full
+    /// `is_nursery_object` query.
+    fn nursery_bounds(&self) -> Option<(usize, usize)> {
+        None
+    }
+
+    /// `gc/base.py:380-383 is_valid_gc_object`'s tagged-immediate setting
+    /// (`translationoption.py:185 taggedpointers`, default off).
+    fn taggedpointers(&self) -> bool {
+        false
+    }
+
     /// Current nursery free pointer.
     fn nursery_free(&self) -> *mut u8;
 
@@ -1588,8 +1601,75 @@ pub fn gc_owns_object(addr: usize) -> bool {
     }
 }
 
+/// Published `[start, end)` of the `gc_sync` singleton's nursery, plus the
+/// tagged-pointer setting `is_valid_gc_object` consults.
+///
+/// `is_nursery_object_start` is `addr != 0 && !tagged && nursery.contains(addr)`
+/// — three loads and two compares against fields that never move for the life
+/// of the GC instance (`reset` rewinds `free`, never `start`/`size`).  Reaching
+/// them through the hook chain instead costs a thread-local lookup, a `RefCell`
+/// borrow and a trait-object dispatch on every root pin and every root reload,
+/// which is where the query is actually hot.  Publishing them lets the common
+/// process shape — one singleton, no per-thread allocator box — answer inline.
+///
+/// Armed only for the singleton.  `install_gc_box` gives a thread its own
+/// allocator with its own nursery, which a single published pair cannot
+/// describe, so that path disarms this permanently
+/// ([`disarm_published_nursery`]).
+static PUBLISHED_NURSERY_START: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+static PUBLISHED_NURSERY_END: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+static PUBLISHED_NURSERY_TAGGED: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+static PUBLISHED_NURSERY_ARMED: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+static PUBLISHED_NURSERY_REFUSED: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
+/// Publish the singleton's nursery bounds.  A `None` from `nursery_bounds`
+/// (a stub allocator, or one whose nursery is not a fixed range) leaves the
+/// fast path disarmed.
+///
+/// The disarm-store-rearm here is not atomic against a concurrent query, so a
+/// reader can pair a stale "armed" with the incoming bounds.  Both writers are
+/// the singleton installers, which run before the GC has a mutator to answer
+/// for; the hook path they replace is no more synchronized, since the swap
+/// behind it is not atomic against a query either.
+pub fn publish_singleton_nursery(gc: &dyn GcAllocator) {
+    PUBLISHED_NURSERY_ARMED.store(false, std::sync::atomic::Ordering::Release);
+    if PUBLISHED_NURSERY_REFUSED.load(std::sync::atomic::Ordering::Acquire) {
+        return;
+    }
+    let Some((start, end)) = gc.nursery_bounds() else {
+        return;
+    };
+    PUBLISHED_NURSERY_START.store(start, std::sync::atomic::Ordering::Relaxed);
+    PUBLISHED_NURSERY_END.store(end, std::sync::atomic::Ordering::Relaxed);
+    PUBLISHED_NURSERY_TAGGED.store(gc.taggedpointers(), std::sync::atomic::Ordering::Relaxed);
+    PUBLISHED_NURSERY_ARMED.store(true, std::sync::atomic::Ordering::Release);
+}
+
+/// Permanently retire the published fast path: a per-thread allocator box is
+/// in play, so "the nursery" is no longer a single process-wide range.
+pub fn disarm_published_nursery() {
+    PUBLISHED_NURSERY_REFUSED.store(true, std::sync::atomic::Ordering::Release);
+    PUBLISHED_NURSERY_ARMED.store(false, std::sync::atomic::Ordering::Release);
+}
+
 /// Whether `addr` is a live object in the active backend's nursery.
 pub fn gc_is_nursery_object(addr: usize) -> bool {
+    if PUBLISHED_NURSERY_ARMED.load(std::sync::atomic::Ordering::Acquire) {
+        // `is_nursery_object_start` = `is_valid_gc_object && is_in_nursery`.
+        if addr == 0
+            || (PUBLISHED_NURSERY_TAGGED.load(std::sync::atomic::Ordering::Relaxed)
+                && addr & 1 == 1)
+        {
+            return false;
+        }
+        return addr >= PUBLISHED_NURSERY_START.load(std::sync::atomic::Ordering::Relaxed)
+            && addr < PUBLISHED_NURSERY_END.load(std::sync::atomic::Ordering::Relaxed);
+    }
     match ACTIVE_GC_IS_NURSERY_OBJECT.get() {
         Some(f) => f(addr),
         None if gc_sync::is_initialized() => {

--- a/majit/majit-gc/src/lib.rs
+++ b/majit/majit-gc/src/lib.rs
@@ -1603,7 +1603,13 @@ pub fn gc_is_nursery_object(addr: usize) -> bool {
 /// root. During a minor collection this follows an already-installed nursery
 /// forwarding pointer; otherwise it returns `addr` unchanged.
 pub fn gc_current_object_address(addr: usize) -> usize {
-    if addr == 0 || !gc_owns_object(addr) {
+    // Only a nursery address can carry a forwarding stub: `_trace_drag_out`
+    // installs one at the young object's old address, and the major collection
+    // is mark-and-sweep, so nothing outside the nursery ever moves.  The
+    // nursery test is a two-word range compare, where the full ownership query
+    // also walks the old-generation arena index and the rawmalloc set — and
+    // every root pin and every root reload asks this question.
+    if addr == 0 || !gc_is_nursery_object(addr) {
         return addr;
     }
     let hdr = unsafe { header::header_of(addr) };

--- a/majit/majit-translate/src/front/checked_arith.rs
+++ b/majit/majit-translate/src/front/checked_arith.rs
@@ -341,8 +341,11 @@ fn rewire_one_checked_arith_site(graph: &mut FunctionGraph, opt: &Variable) -> R
 
     // The Some target reads the payload via `opt.__pos_0`; with the `_ovf`
     // result flowing directly, that read collapses to the carried value.
+    // The `checked_*()` residual is replaced below by an `Int`-stamped
+    // `_ovf` BinOp, so the value flowing into the collapsed payload slot
+    // already declares the payload's type.
     for pos in payload_positions {
-        collapse_pos0_read(graph, some_target, pos, &name)?;
+        let _ = collapse_pos0_read(graph, some_target, pos, &name)?;
     }
 
     // Replace A's residual `checked_*()` call with the native `_ovf`

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -12783,10 +12783,24 @@ fn tyref_fieldless_enum_class_root(ty: &TyRef, llbc: &Llbc) -> Option<String> {
 /// `Unknown` results (whose legacy concrete is also Unknown — the
 /// dead-var backfill family, not a genuine kind mismatch).
 fn dont_look_inside_return_token(output: &TyRef, llbc: &Llbc) -> Option<String> {
-    if is_unit_type(output, llbc) {
+    // A `Result<T, PyError>` callee is reached through the residual-call
+    // ABI, which hands back the `Ok` payload and routes the error through
+    // `BH_LAST_EXC_VALUE`, so `FUNC.RESULT` is `T`.  Reading the kind off
+    // the `Result` ADT instead reports `ref` whatever `T` is, and the
+    // caller — whose call result is the unwrapped payload — then disagrees
+    // with the token for every non-reference `T` (`getcalldescr`'s
+    // `RESULT == FUNC.RESULT` check).  `Result<(), PyError>` reaches the
+    // unit arm the same way its callee reaches `widen_unit_return_to_void`.
+    //
+    // The `OBJECTPTR` carve-out below deliberately keeps reading the
+    // declared `output`: it decides the pointer's lowering, not its bank,
+    // and a `Result`-typed output has never taken it.
+    let payload = crate::front::result_exc::tyref_result_ok(output, llbc);
+    let kind_src = payload.as_ref().unwrap_or(output);
+    if is_unit_type(kind_src, llbc) {
         return None;
     }
-    let token = match tyref_to_value_type(output, llbc) {
+    let token = match tyref_to_value_type(kind_src, llbc) {
         ValueType::Bool => "bool",
         ValueType::Int => "i64",
         ValueType::Unsigned => "u64",

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -4523,10 +4523,22 @@ impl<'a> Lowering<'a> {
                 // shape (`flowspace_adapter.rs::is_str_const_define`).
                 result_ty: ValueType::Ref(None),
             },
+            // A function item's value is its address.  Upstream materialises
+            // it as `Constant(funcptr)` of lltype `Ptr(FuncType)`
+            // (`rtyper.getcallable`, and `sub_helper_funcptr_constant` for the
+            // sub-helper twins), whose `getkind` is `r` — the same reason the
+            // `Str` arm above declares a Ref.  The synthetic define reuses the
+            // callee's real path so a value threaded into a call site still
+            // resolves, which also puts it in front of `getcalldescr`'s
+            // `RESULT == FUNC.RESULT` check (`call.py`): an `Int` here read as
+            // a 0-arg call to that function and hard-failed against any callee
+            // whose graph carries a `FUNC.RESULT` token — `w_dict_new`
+            // (`dont_look_inside`) threaded through `Option::unwrap_or_else` is
+            // the shape that surfaces it.
             DecodedConst::FnPath(segments) => OpKind::Call {
                 target: CallTarget::FunctionPath { segments },
                 args: vec![],
-                result_ty: ValueType::Int,
+                result_ty: ValueType::Ref(None),
             },
         };
         let var = self

--- a/majit/majit-translate/src/front/result_exc.rs
+++ b/majit/majit-translate/src/front/result_exc.rs
@@ -237,26 +237,37 @@ pub(crate) fn tyref_result_instantiation_suffix(ty: &TyRef, llbc: &Llbc) -> Opti
 /// widened to a genuine void return rather than forwarding the unit
 /// `()` value as a `Ref`-typed shell — see [`widen_unit_return_to_void`].
 pub(crate) fn tyref_result_ok_is_unit(ty: &TyRef, llbc: &Llbc) -> bool {
+    result_ok_slot(ty, llbc).is_some_and(|slot| {
+        crate::front::mir::charon_type_value_to_ast_string(slot, llbc, 0) == "()"
+    })
+}
+
+/// The `Ok` payload slot of a `Result<T, E>` type value, or `None` when
+/// `ty` is not a `Result`.
+fn result_ok_slot<'l>(ty: &'l TyRef, llbc: &'l Llbc) -> Option<&'l serde_json::Value> {
     let body = match ty {
         TyRef::Inline { value: (_, v) } => v,
         TyRef::Other(v) => v,
-        TyRef::Dedup { id } => match llbc.dedup_body(*id) {
-            Some(v) => v,
-            None => return false,
-        },
+        TyRef::Dedup { id } => llbc.dedup_body(*id)?,
     };
     if adt_path_of(body, llbc).as_deref() != Some("core::result::Result") {
-        return false;
+        return None;
     }
-    let Some(ok_slot) = body
-        .get("Adt")
+    body.get("Adt")
         .and_then(|a| a.get("generics"))
         .and_then(|g| g.get("types"))
         .and_then(|t| t.get(0))
-    else {
-        return false;
-    };
-    crate::front::mir::charon_type_value_to_ast_string(ok_slot, llbc, 0) == "()"
+}
+
+/// The `Ok` payload of a `Result<T, PyError>` as its own [`TyRef`], or
+/// `None` when `ty` is not a `Result`.
+///
+/// A scoped callee's `Result` never survives the exception-link lowering:
+/// the graph returns `T` and the residual-call ABI returns `T` with the
+/// error routed through `BH_LAST_EXC_VALUE`.  Consumers that describe the
+/// callee's result therefore have to read `T`, not the `Result` ADT.
+pub(crate) fn tyref_result_ok(ty: &TyRef, llbc: &Llbc) -> Option<TyRef> {
+    result_ok_slot(ty, llbc).and_then(|slot| serde_json::from_value(slot.clone()).ok())
 }
 
 /// Collapse a scoped callee's returnblock to a genuine void return.
@@ -1178,7 +1189,9 @@ fn rewire_one_call_site(
     // value itself.
     let continue_target = continue_link.target;
     for pos in payload_positions {
-        collapse_pos0_read(graph, continue_target, pos, &name)?;
+        if let Some(payload_ty) = collapse_pos0_read(graph, continue_target, pos, &name)? {
+            narrow_call_result_ty(graph, a, r, payload_ty);
+        }
     }
 
     // Rewire A: LastException exits — normal → continue arm,
@@ -2166,9 +2179,11 @@ fn try_fuse_drain_match(graph: &mut FunctionGraph, a: usize, r: &Variable) -> Re
     );
 
     // The Ok arm reads the payload via `r.__pos_0[Result::Ok]`; with the native
-    // call result flowing directly, that read collapses to `r`.
+    // call result flowing directly, that read collapses to `r`.  The fused
+    // native call is stamped from the guest value it returns, not from the
+    // `Result` shell, so its declared type already is the payload's.
     for pos in payload_positions {
-        collapse_pos0_read(graph, ok_link.target, pos, &name)?;
+        let _ = collapse_pos0_read(graph, ok_link.target, pos, &name)?;
     }
 
     Ok(())
@@ -2564,15 +2579,57 @@ fn verify_break_arm_is_reraise(
     verify_forwards_to_returnblock_general(graph, e_block, &residual_result)
 }
 
+/// Narrow the declared result type of the operation producing `r` in
+/// `block` to `payload_ty`.
+///
+/// The call was stamped from its Rust `dest.ty` — `Result<T, PyError>`,
+/// an ADT, hence `Ref` (`front::mir` `Rvalue::Call`).  Once the diamond
+/// rewrite lets the call result flow into the continue arm's payload slot
+/// and [`collapse_pos0_read`] folds the `__pos_0` read away, `r` IS the
+/// `T` the arm reads, so the stale `Ref` stamp contradicts the value's
+/// kind.  A `Ref` payload hides that — `Result<PyObjectRef, PyError>`
+/// projects to the same `Ref` — but a scalar `T` leaves the carrier
+/// column unioning `Bool`/`Int` against `Ref` at every merge that also
+/// receives the value from a non-`?` path.  The union has no answer
+/// (`legacy_annotator::union_type`), the empty binding is defaulted to
+/// `GcRef`, and the register banks only disagree at the assembler.
+///
+/// `checked_arith` keeps the same invariant by replacing its residual
+/// `checked_*()` call outright with an `Int`-stamped `BinOp`, and
+/// [`widen_unit_return_to_void`] is the `T = ()` case of the same rule.
+fn narrow_call_result_ty(
+    graph: &mut FunctionGraph,
+    block: usize,
+    r: &Variable,
+    payload_ty: ValueType,
+) {
+    let Some(op) = graph.blocks[block]
+        .operations
+        .iter_mut()
+        .find(|op| op.result.as_ref() == Some(r))
+    else {
+        return;
+    };
+    if let OpKind::Call { result_ty, .. } = &mut op.kind {
+        *result_ty = payload_ty;
+    }
+}
+
 /// In the continue-arm target, the `__pos_0` read off the inputarg at
 /// `pos` collapses: the inherited value already *is* the payload.
 /// Deletes the read and renames its result to the inputarg.
+///
+/// Returns the collapsed read's type, or `None` when the arm discarded
+/// the payload and there was no read to collapse.  The carrier inputarg
+/// carries the payload from here on, so a caller whose substituted value
+/// still declares the enclosing `Result` / `Option` type must narrow that
+/// declaration to the returned type — see [`narrow_call_result_ty`].
 pub(crate) fn collapse_pos0_read(
     graph: &mut FunctionGraph,
     target: crate::model::BlockId,
     pos: usize,
     name: &str,
-) -> Result<(), String> {
+) -> Result<Option<ValueType>, String> {
     let ti = target.0;
     let carrier = graph.blocks[ti]
         .inputargs
@@ -2602,12 +2659,16 @@ pub(crate) fn collapse_pos0_read(
                  carrier outside a __pos_0 read — unsupported shape"
             ));
         }
-        return Ok(());
+        return Ok(None);
     };
     let read_result = graph.blocks[ti].operations[read_idx]
         .result
         .clone()
         .ok_or_else(|| format!("{name}: __pos_0 read without result"))?;
+    let payload_ty = match &graph.blocks[ti].operations[read_idx].kind {
+        OpKind::FieldRead { ty, .. } => ty.clone(),
+        _ => unreachable!("read_idx was selected by matching FieldRead"),
+    };
     graph.blocks[ti].operations.remove(read_idx);
     // Rename the read's result to the carrier across the block's
     // remaining ops, exitswitch, and exits.
@@ -2630,5 +2691,5 @@ pub(crate) fn collapse_pos0_read(
     );
     block.exitswitch = sw;
     block.exits = exits;
-    Ok(())
+    Ok(Some(payload_ty))
 }

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -10409,7 +10409,7 @@ pub(crate) fn fileio_init(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
         .unwrap_or_else(|| w_bool_from(true));
     let closefd = crate::baseobjspace::is_true(closefd_obj)?;
     if unsafe { pyre_object::is_bool(file) } {
-        crate::warn::warn_category("bool is used as a file descriptor", "RuntimeWarning", 1)?;
+        crate::warn::warn_category("bool is used as a file descriptor", "RuntimeWarning", 2)?;
     }
     if !unsafe { pyre_object::is_int(file) } && !closefd {
         return Err(crate::PyError::value_error(

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -6230,11 +6230,16 @@ fn register_exc_class(name: &'static str, cls: PyObjectRef) -> PyObjectRef {
 /// Look up a builtin exception class by its `ExcKind` name. Returns
 /// `None` if the registry hasn't been populated yet (e.g. before
 /// install_default_builtins).
-/// Reads the runtime-populated `EXC_CLASS_REGISTRY` `OnceLock`, not a
-/// build-time constant, so the JIT residualizes the call instead of tracing
-/// into it (`@dont_look_inside`). The scalar-`Option<PyObjectRef>` result is
-/// the same residual boundary shape as
-/// `baseobjspace::lookup_in_type_where_uncached`.
+///
+/// `dont_look_inside` because the body reads `EXC_CLASS_REGISTRY`, a
+/// runtime-populated `static` of a host type rather than a build-time constant,
+/// so the front-end cannot lift it. Reaching it from a lifted body fails that
+/// callee's lift and, transitively, every caller's — which is how
+/// `warn::warn_category_w` lost its jitcode and made every interpreter-level
+/// warning an opaque residual. Hiding the registry behind the opaque call keeps
+/// the callers liftable, exactly as `w_dict_new` does for its host `IndexMap`,
+/// and the scalar `Option<PyObjectRef>` result is the same residual boundary
+/// shape as `baseobjspace::lookup_in_type_where_uncached`.
 #[majit_macros::dont_look_inside]
 pub fn lookup_exc_class(name: &str) -> Option<PyObjectRef> {
     let registry = EXC_CLASS_REGISTRY.get()?;

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -9061,12 +9061,7 @@ fn _hash_tuple_xx_iter(items: impl Iterator<Item = i64>) -> i64 {
 /// instead of panicking on the `&str` view.
 fn _hash_str(bytes: &[u8]) -> i64 {
     use core::hash::Hasher;
-    // Empty input hashes to 0 (`""` and `b""`), short-circuiting the
-    // siphash digest.
-    if bytes.is_empty() {
-        return 0;
-    }
-    // `rpython/rlib/rsiphash.py:60-62 _build_key_from_seed` — when
+    // `rpython/rlib/rsiphash.py _build_key_from_seed` — when
     // `PYTHONHASHSEED=0` the key is the 16-byte all-zero buffer.
     // Pyre runs with the deterministic seed for reproducibility,
     // matching PyPy's `PYTHONHASHSEED=0` byte-for-byte.  Wiring a
@@ -9083,7 +9078,15 @@ fn _hash_str(bytes: &[u8]) -> i64 {
     let mut hasher = siphasher::sip::SipHasher24::new_with_key(&SECRET);
     hasher.write(bytes);
     let raw = hasher.finish() as i64;
-    raw - ((raw == -1) as i64)
+    let raw = raw - ((raw == -1) as i64);
+    // `rstr.py _ll_strhash` — a string caches its digest in a slot that
+    // `malloc` zeroed, so zero doubles as "not computed yet" and a digest that
+    // lands on it is replaced by this fixed substitute.  Applied here rather
+    // than at the caching str caller so every digest consumer (bytes,
+    // memoryview) agrees with the cached one on the same bytes.  Empty input
+    // is NOT special-cased: `ll_strhash`'s `return 0` arm is a null-pointer
+    // check, and upstream digests `b""` like any other value.
+    if raw == 0 { 29872897 } else { raw }
 }
 
 /// `space.hash_w` digest for a `str` computed directly from its WTF-8 bytes
@@ -9176,20 +9179,17 @@ pub fn hash_value(obj: PyObjectRef) -> i64 {
             );
         }
         if is_str(obj) {
-            // `unicodeobject.py:339-343 hash_w` digests `self._utf8`, and
+            // `unicodeobject.py hash_w` digests `self._utf8`, and
             // `compute_hash` on an RPython string is `ll_strhash`, which keeps
             // the result in the string and recomputes only while the slot
-            // still reads zero.  Zero doubles as "not computed", so a digest
-            // that lands on it is stored as the same substitute every time
-            // (`rstr.py:409-410`) and stays a consistent hash for the value.
+            // still reads zero.  `_hash_str` already substitutes a zero
+            // digest, so the value cached here is never the "not computed"
+            // sentinel.
             let cached = pyre_object::w_str_get_hash(obj);
             if cached != 0 {
                 return cached;
             }
-            let mut hash = _hash_str(pyre_object::w_str_get_wtf8(obj).as_bytes());
-            if hash == 0 {
-                hash = 29742;
-            }
+            let hash = _hash_str(pyre_object::w_str_get_wtf8(obj).as_bytes());
             pyre_object::w_str_set_hash(obj, hash);
             return hash;
         }
@@ -12749,12 +12749,14 @@ mod tests {
         }
     }
 
-    /// Empty `str`/`bytes` hash to 0; non-empty inputs take the siphash
-    /// digest.
+    /// Empty input is digested like any other: SipHash-2-4 under the all-zero
+    /// key gives `0x1e924b9d737700d7`, which is what PyPy reports for
+    /// `hash("")` under `PYTHONHASHSEED=0`.  A digest never reads back as the
+    /// zero "not computed yet" sentinel.
     #[test]
-    fn empty_str_and_bytes_hash_to_zero() {
-        assert_eq!(_hash_str(b""), 0);
-        assert_eq!(hash_str_bytes(b""), 0);
+    fn empty_str_and_bytes_digest_like_pypy() {
+        assert_eq!(_hash_str(b""), 0x1e92_4b9d_7377_00d7);
+        assert_eq!(hash_str_bytes(b""), 0x1e92_4b9d_7377_00d7);
         assert_ne!(_hash_str(b"a"), 0);
     }
 

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -8994,7 +8994,12 @@ pub(crate) fn _hash_float(v: f64) -> i64 {
 /// it.
 #[inline]
 fn _hash_tuple_xx(items: &[i64]) -> i64 {
-    rustpython_common::hash::hash_tuple(items.iter().map(|&h| Ok::<i64, ()>(h)))
+    _hash_tuple_xx_iter(items.iter().copied())
+}
+
+/// `_hash_tuple_xx` over element digests produced on the fly.
+fn _hash_tuple_xx_iter(items: impl Iterator<Item = i64>) -> i64 {
+    rustpython_common::hash::hash_tuple(items.map(Ok::<i64, ()>))
         .expect("element hashes are precomputed, so the fold cannot fail")
 }
 
@@ -9139,7 +9144,22 @@ pub fn hash_value(obj: PyObjectRef) -> i64 {
             );
         }
         if is_str(obj) {
-            return _hash_str(pyre_object::w_str_get_wtf8(obj).as_bytes());
+            // `unicodeobject.py:339-343 hash_w` digests `self._utf8`, and
+            // `compute_hash` on an RPython string is `ll_strhash`, which keeps
+            // the result in the string and recomputes only while the slot
+            // still reads zero.  Zero doubles as "not computed", so a digest
+            // that lands on it is stored as the same substitute every time
+            // (`rstr.py:409-410`) and stays a consistent hash for the value.
+            let cached = pyre_object::w_str_get_hash(obj);
+            if cached != 0 {
+                return cached;
+            }
+            let mut hash = _hash_str(pyre_object::w_str_get_wtf8(obj).as_bytes());
+            if hash == 0 {
+                hash = 29742;
+            }
+            pyre_object::w_str_set_hash(obj, hash);
+            return hash;
         }
         // `bytesobject.py descr_hash` — `compute_hash(self._value)`, the same
         // byte-string digest str uses (bytearray is mutable / unhashable).
@@ -9166,14 +9186,13 @@ pub fn hash_value(obj: PyObjectRef) -> i64 {
             return 0xFCA8_6420;
         }
         if is_tuple(obj) {
-            let n = w_tuple_len(obj);
-            let mut hashes = Vec::with_capacity(n);
-            for i in 0..(n as i64) {
-                if let Some(item) = w_tuple_getitem(obj, i) {
-                    hashes.push(hash_value(item));
-                }
-            }
-            return _hash_tuple_xx(&hashes);
+            // `tupleobject.py:409-420 _descr_hash_unroll` folds the element
+            // digests straight into the accumulator; collecting them into a
+            // list first would allocate one per hashed tuple.
+            let n = w_tuple_len(obj) as i64;
+            return _hash_tuple_xx_iter(
+                (0..n).filter_map(|i| w_tuple_getitem(obj, i).map(hash_value)),
+            );
         }
         if pyre_object::is_frozenset(obj) {
             return frozenset_hash_from_storage(obj);

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -4410,9 +4410,36 @@ fn exc_base_exception_init(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::P
             )));
         }
     }
-    let args_list = pyre_object::w_list_new(positional.to_vec());
-    unsafe { pyre_object::interp_exceptions::w_exception_set_args(w_self, args_list) };
+    // `interp_exceptions.py:123-124 descr_init` and `:277-282
+    // descr_new_base_exception` both store the `args_w` list their own
+    // signature was bound to, so `type.__call__` reaches here holding a list
+    // that already contains exactly these objects.  Keep it rather than build
+    // a second one over the same elements: `args` is read out as a fresh
+    // tuple and the storage is never handed out, so its identity is not
+    // observable.
+    if !exception_args_already(w_self, positional) {
+        let args_list = pyre_object::w_list_new(positional.to_vec());
+        unsafe { pyre_object::interp_exceptions::w_exception_set_args(w_self, args_list) };
+    }
     Ok(pyre_object::w_none())
+}
+
+/// Whether `w_self`'s `args_w` storage already holds exactly `positional`,
+/// element for element by identity.
+fn exception_args_already(w_self: PyObjectRef, positional: &[PyObjectRef]) -> bool {
+    unsafe {
+        let stored = pyre_object::interp_exceptions::w_exception_get_args_storage(w_self);
+        if stored.is_null() || !pyre_object::is_list(stored) {
+            return false;
+        }
+        if pyre_object::w_list_len(stored) != positional.len() {
+            return false;
+        }
+        positional.iter().enumerate().all(|(i, &item)| {
+            pyre_object::w_list_getitem(stored, i as i64)
+                .is_some_and(|held| std::ptr::eq(held, item))
+        })
+    }
 }
 
 /// `interp_exceptions.py:551-652 W_OSError._parse_init_args` + `_init_error`.

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -8682,6 +8682,27 @@ pub fn try_hash_value(obj: PyObjectRef) -> Result<i64, crate::PyError> {
     if obj.is_null() {
         return Err(crate::PyError::type_error("hash() argument is null"));
     }
+    // The scalar builtins are not subclassable in place: an *exact* instance
+    // can only ever reach the `__hash__` these arms of `hash_value` already
+    // compute, so the slot lookup and the call protocol below would just
+    // route back here.  This is the digest every interpreter-level dict probe
+    // needs, and it is on the path of every module / `sys.modules` /
+    // namespace lookup — `UnicodeDictStrategy`'s upstream storage hashes its
+    // unwrapped key the same way, without an app-level call.
+    unsafe {
+        for tp in [
+            &pyre_object::STR_TYPE,
+            &pyre_object::INT_TYPE,
+            &pyre_object::BOOL_TYPE,
+            &pyre_object::LONG_TYPE,
+            &pyre_object::FLOAT_TYPE,
+            &pyre_object::bytesobject::BYTES_TYPE,
+        ] {
+            if is_exact_type(obj, tp) {
+                return Ok(hash_value(obj));
+            }
+        }
+    }
     unsafe {
         let kind = if pyre_object::is_dict(obj) {
             Some("dict")
@@ -8762,6 +8783,11 @@ pub fn try_hash_value(obj: PyObjectRef) -> Result<i64, crate::PyError> {
             }
         }
         if is_tuple(obj) {
+            // The element walk is the one recursive step here, and the scalar
+            // fast path above no longer reaches the call protocol's own
+            // guard, so a nest deep enough to exhaust the C stack has to be
+            // caught on the way down.
+            crate::stack_check::stack_check()?;
             let n = w_tuple_len(obj);
             let mut hashes = Vec::with_capacity(n);
             for i in 0..(n as i64) {

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -2752,10 +2752,13 @@ fn type_descr_call_impl(w_type: PyObjectRef, args: &[PyObjectRef]) -> PyObjectRe
         pyre_object::gc_roots::pin_root(arg);
     }
     let current_type = || pyre_object::gc_roots::shadow_stack_get(root_base);
-    let current_args = || {
-        (0..args.len())
-            .map(|i| pyre_object::gc_roots::shadow_stack_get(root_base + 1 + i))
-            .collect::<Vec<_>>()
+    // `Arguments.prepend` builds one list per call, so both call sites below
+    // fill their argument vector straight from the pinned slots — reloading
+    // into a throwaway `Vec` first would allocate a second one per call.
+    let extend_current_args = |dst: &mut Vec<PyObjectRef>| {
+        for i in 0..args.len() {
+            dst.push(pyre_object::gc_roots::shadow_stack_get(root_base + 1 + i));
+        }
     };
 
     if let Err(e) = check_type_instantiable(current_type()) {
@@ -2768,7 +2771,7 @@ fn type_descr_call_impl(w_type: PyObjectRef, args: &[PyObjectRef]) -> PyObjectRe
     {
         let mut new_args = Vec::with_capacity(1 + args.len());
         new_args.push(current_type());
-        new_args.extend(current_args());
+        extend_current_args(&mut new_args);
         call_function_impl(new_fn, &new_args)
     } else {
         pyre_object::w_instance_new(current_type())
@@ -2789,7 +2792,7 @@ fn type_descr_call_impl(w_type: PyObjectRef, args: &[PyObjectRef]) -> PyObjectRe
         {
             let mut init_args = Vec::with_capacity(1 + args.len());
             init_args.push(pyre_object::gc_roots::shadow_stack_get(instance_slot));
-            init_args.extend(current_args());
+            extend_current_args(&mut init_args);
             let res = call_function_impl(init_fn, &init_args);
             if res.is_null() {
                 // `__init__` raised — error already stashed; propagate it.

--- a/pyre/pyre-interpreter/src/executioncontext.rs
+++ b/pyre/pyre-interpreter/src/executioncontext.rs
@@ -10,8 +10,22 @@ pub fn register_force_frame_hook(f: ForceFrameFn) {
     let _ = FORCE_FRAME_HOOK.set(f);
 }
 
+/// `rvirtualizable.py hook_access_field` → `jit_force_virtualizable`:
+/// materialize a frame's virtualizable fields before something outside the JIT
+/// reads them.
+///
+/// Upstream emits this per redirected FIELD ACCESS, and
+/// `jtransform.rewrite_op_jit_force_virtualizable` deletes it again in every
+/// graph the codewriter looks inside — only the graphs the JIT cannot see keep
+/// the call (`rvirtualizable.replace_force_virtualizable_with_call`).  So the
+/// frame-chain walk itself never forces upstream; the consumer that reads a
+/// field does.  Call sites here are therefore the consumers, not the walkers:
+/// a walk that only follows `f_backref` and tests `hide()` reads nothing the
+/// JIT keeps virtual, and forcing there escapes the traced virtualizable for
+/// every frame-walking helper — `pyjitpl.vable_after_residual_call` then
+/// aborts the whole trace with `ABORT_ESCAPE`.
 #[inline]
-fn force_frame(frame: *mut PyFrame) {
+pub fn force_frame(frame: *mut PyFrame) {
     if let Some(f) = FORCE_FRAME_HOOK.get() {
         unsafe { f(frame) };
     }
@@ -406,10 +420,14 @@ impl ExecutionContext {
         self.topframeref
     }
 
+    /// `executioncontext.py gettopframe_nohidden` — follow `f_backref` past every
+    /// `hidden_applevel` frame.  No force: the walk reads only the vref links
+    /// and `hide()`, and `hide()` goes through `pyframe_get_pycode`, a plain
+    /// field read.  Consumers that hand the frame to app code call
+    /// [`force_frame`] themselves.
     pub fn gettopframe_nohidden(&self) -> *mut PyFrame {
         let mut frame = force_vref(self.topframeref);
         while !frame.is_null() {
-            force_frame(frame);
             // SAFETY: frame pointers are owned by interpreter call stack and can be
             // null-checked before dereference.
             unsafe {
@@ -423,9 +441,11 @@ impl ExecutionContext {
         frame
     }
 
+    /// `executioncontext.py getnextframe_nohidden` — the same walk from an
+    /// arbitrary frame.
+    /// Force-free for the reason given on [`gettopframe_nohidden`].
     pub fn getnextframe_nohidden(mut frame: *mut PyFrame) -> *mut PyFrame {
         while !frame.is_null() {
-            force_frame(frame);
             // SAFETY: caller provides a valid frame chain or null.
             unsafe {
                 let current = &*frame;
@@ -433,7 +453,6 @@ impl ExecutionContext {
                 if next.is_null() {
                     return std::ptr::null_mut();
                 }
-                force_frame(next);
                 if !(&*next).hide() {
                     return next;
                 }

--- a/pyre/pyre-interpreter/src/host_seam.rs
+++ b/pyre/pyre-interpreter/src/host_seam.rs
@@ -422,6 +422,12 @@ declare_seam! {
 // Best-effort — a failed relay is dropped, matching a closed real stream.
 
 /// Emit bytes to the interpreter's stdout (fd 1).
+///
+/// `dont_look_inside` for the same reason `ll_os_write` is an external: the
+/// non-sandbox arm reaches `std::io::stdout()`, a host handle with no lifted
+/// form, so a caller that can reach it loses its own jitcode and so does every
+/// caller above it.
+#[majit_macros::dont_look_inside]
 pub fn emit_stdout(bytes: &[u8]) {
     #[cfg(not(feature = "sandbox"))]
     {
@@ -435,6 +441,12 @@ pub fn emit_stdout(bytes: &[u8]) {
 }
 
 /// Emit bytes to the interpreter's stderr (fd 2).
+///
+/// `dont_look_inside` — see [`emit_stdout`].  This one is on the warning path:
+/// `warn::warn` is the pre-`_warnings` fallback reachable from
+/// `warn::warn_category_w`, so an opaque body here is what keeps
+/// `warn_category_w` liftable.
+#[majit_macros::dont_look_inside]
 pub fn emit_stderr(bytes: &[u8]) {
     #[cfg(not(feature = "sandbox"))]
     {

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -3286,7 +3286,7 @@ fn resolve_package_name(w_globals: PyObjectRef) -> Result<Option<String>, crate:
     crate::warn::warn_category(
         "can't resolve package from __spec__ or __package__, falling back on __name__ and __path__",
         "ImportWarning",
-        3,
+        2,
     )?;
 
     // Fallback: __name__ (for modules inside packages)

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -688,6 +688,56 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         w_dict_new as *const (),
     );
     push_fnaddr(&mut entries, "w_dict_new", w_dict_new as *const ());
+    // `bool_invert_deprecation_text` is `#[dont_look_inside]` (it hides a
+    // `static` prebuilt cell the front-end cannot lift); bind its zero-arg
+    // `fn() -> PyObjectRef` so `invert`'s residual call to it resolves.
+    let bool_invert_deprecation_text: fn() -> pyre_object::PyObjectRef =
+        crate::objspace::descroperation::bool_invert_deprecation_text;
+    push_alias_pair(
+        &mut entries,
+        "pyre_interpreter::objspace::descroperation::bool_invert_deprecation_text",
+        "pyre_interpreter::bool_invert_deprecation_text",
+        bool_invert_deprecation_text as *const (),
+    );
+    push_fnaddr(
+        &mut entries,
+        "bool_invert_deprecation_text",
+        bool_invert_deprecation_text as *const (),
+    );
+    // `lookup_exc_class` is `#[dont_look_inside]` (it hides the
+    // `EXC_CLASS_REGISTRY` static); bind it so the residual call from
+    // `warn::warn_category_w` and the `_warnings` category helpers resolves.
+    let lookup_exc_class: fn(&str) -> Option<pyre_object::PyObjectRef> =
+        crate::builtins::lookup_exc_class;
+    push_alias_pair(
+        &mut entries,
+        "pyre_interpreter::builtins::lookup_exc_class",
+        "pyre_interpreter::lookup_exc_class",
+        lookup_exc_class as *const (),
+    );
+    push_fnaddr(
+        &mut entries,
+        "lookup_exc_class",
+        lookup_exc_class as *const (),
+    );
+    // `emit_stdout` / `emit_stderr` are `#[dont_look_inside]` (host stdio
+    // handles); bind them so the residual calls resolve.
+    let emit_stdout: fn(&[u8]) = crate::host_seam::emit_stdout;
+    push_alias_pair(
+        &mut entries,
+        "pyre_interpreter::host_seam::emit_stdout",
+        "pyre_interpreter::emit_stdout",
+        emit_stdout as *const (),
+    );
+    push_fnaddr(&mut entries, "emit_stdout", emit_stdout as *const ());
+    let emit_stderr: fn(&[u8]) = crate::host_seam::emit_stderr;
+    push_alias_pair(
+        &mut entries,
+        "pyre_interpreter::host_seam::emit_stderr",
+        "pyre_interpreter::emit_stderr",
+        emit_stderr as *const (),
+    );
+    push_fnaddr(&mut entries, "emit_stderr", emit_stderr as *const ());
     // `w_set_new` / `w_frozenset_new` are `#[dont_look_inside]` for the same
     // host `IndexMap::new` storage-box reason; bind their zero-arg
     // `fn() -> PyObjectRef` so the residual calls resolve.

--- a/pyre/pyre-interpreter/src/module/_warnings/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_warnings/mod.rs
@@ -38,9 +38,26 @@ fn import_module(name: &str) -> Result<PyObjectRef, PyError> {
     })
 }
 
+/// The `State` fields, which this module keeps in its own namespace instead
+/// of a space cache.  Read straight out of the namespace dict when the name
+/// still holds the module: upstream reaches them as plain attributes of a
+/// translated-away `State` instance, so routing a read as hot as the filters
+/// version through the attribute protocol would be pure overhead.  Anything
+/// else bound under the name goes back through `space.getattr`, which is the
+/// only form that copes with an arbitrary object.
 fn native_attr(name: &str) -> Result<PyObjectRef, PyError> {
-    module_attr("_warnings", name)
-        .ok_or_else(|| PyError::runtime_error(format!("_warnings.{name} is not initialized")))
+    let module = crate::importing::get_sys_module("_warnings")
+        .ok_or_else(|| PyError::runtime_error("_warnings is not initialized"))?;
+    if unsafe { pyre_object::module::is_module(module) } {
+        let w_dict = unsafe { w_module_get_w_dict(module) };
+        if !w_dict.is_null()
+            && let Some(value) = unsafe { w_dict_getitem_str(w_dict, name) }
+        {
+            return Ok(value);
+        }
+    }
+    crate::baseobjspace::getattr_str(module, name)
+        .map_err(|_| PyError::runtime_error(format!("_warnings.{name} is not initialized")))
 }
 
 fn native_store(name: &str, value: PyObjectRef) -> Result<(), PyError> {
@@ -98,7 +115,9 @@ fn filters_mutated_impl() -> Result<(), PyError> {
 
 fn get_category(message: PyObjectRef, category: PyObjectRef) -> Result<PyObjectRef, PyError> {
     let warning = warning_class("Warning");
-    if crate::baseobjspace::isinstance(message, warning)? {
+    // `space.isinstance_w` — the type-only test, not the `__instancecheck__`
+    // protocol the `isinstance()` builtin runs.
+    if unsafe { crate::baseobjspace::isinstance_w(message, warning) } {
         return crate::typedef::r#type(message)
             .map(|p| p.as_ptr())
             .ok_or_else(|| PyError::type_error("warning instance has no type"));
@@ -597,7 +616,9 @@ fn do_warn_explicit(
     let warning = warning_class("Warning");
     let input_message = pyre_object::gc_roots::shadow_stack_get(input_message_slot);
     let category = pyre_object::gc_roots::shadow_stack_get(category_slot);
-    let (text, message, category) = if crate::baseobjspace::isinstance(input_message, warning)? {
+    let (text, message, category) = if unsafe {
+        crate::baseobjspace::isinstance_w(input_message, warning)
+    } {
         (
             crate::builtins::builtin_str(&[pyre_object::gc_roots::shadow_stack_get(
                 input_message_slot,
@@ -705,6 +726,52 @@ fn do_warn_explicit(
     Ok(())
 }
 
+/// Whether the `State` this module keeps in its own namespace is readable.
+///
+/// Upstream holds it on a `space.fromcache(State)` instance that no Python
+/// code can reach, so `space.warn` can always match a warning.  pyre's lives
+/// under `sys.modules['_warnings']`, which app code can rebind to anything;
+/// an interpreter warning has to survive that rather than raise out of the
+/// operator that issued it.
+pub fn state_is_readable() -> bool {
+    native_attr(VERSION_ATTR).is_ok()
+}
+
+/// `interp_warnings.do_warn` — the interpreter-level entry point.
+///
+/// `category` must already be a `Warning` subclass; `_warnings.warn` runs
+/// `get_category` first, and `space.warn` names the class outright.
+/// `skip_file_prefixes` reaches `setup_context`'s frame walk; a caller with
+/// no prefix to skip passes an empty slice.
+///
+/// Reachable without `warnings` being imported: the filters, the default
+/// action and the once-registry all live on the native module, so an
+/// interpreter warning is matched and deduplicated whether or not the Python
+/// wrapper has been loaded.
+pub fn do_warn(
+    message: PyObjectRef,
+    category: PyObjectRef,
+    stacklevel: i64,
+    source: PyObjectRef,
+    skip_file_prefixes: &[String],
+) -> Result<(), PyError> {
+    let _roots = pyre_object::gc_roots::push_roots();
+    let message_slot = pin_root_slot(message);
+    let category_slot = pin_root_slot(category);
+    let source_slot = pin_root_slot(source);
+    let (filename, lineno, module, registry) = setup_context(stacklevel, skip_file_prefixes);
+    do_warn_explicit(
+        pyre_object::gc_roots::shadow_stack_get(category_slot),
+        pyre_object::gc_roots::shadow_stack_get(message_slot),
+        filename,
+        lineno,
+        module,
+        registry,
+        PY_NULL,
+        pyre_object::gc_roots::shadow_stack_get(source_slot),
+    )
+}
+
 fn filters_mutated(_: &[PyObjectRef]) -> Result<PyObjectRef, PyError> {
     filters_mutated_impl()?;
     Ok(w_none())
@@ -762,12 +829,19 @@ crate::py_module! {
             } else {
                 stacklevel.max(2)
             };
-            let category = get_category(message, category)?;
-            let (filename, lineno, module, registry) =
-                setup_context(stacklevel, &skip_file_prefixes);
-            do_warn_explicit(
-                category, message, filename, lineno, module, registry,
-                pyre_object::PY_NULL, source,
+            let _roots = pyre_object::gc_roots::push_roots();
+            let message_slot = pin_root_slot(message);
+            let source_slot = pin_root_slot(source);
+            let category = get_category(
+                pyre_object::gc_roots::shadow_stack_get(message_slot),
+                category,
+            )?;
+            do_warn(
+                pyre_object::gc_roots::shadow_stack_get(message_slot),
+                category,
+                stacklevel,
+                pyre_object::gc_roots::shadow_stack_get(source_slot),
+                &skip_file_prefixes,
             )?;
             Ok(w_none())
         }

--- a/pyre/pyre-interpreter/src/module/_warnings/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_warnings/mod.rs
@@ -38,32 +38,42 @@ fn import_module(name: &str) -> Result<PyObjectRef, PyError> {
     })
 }
 
-/// The `State` fields, which this module keeps in its own namespace instead
-/// of a space cache.  Read straight out of the namespace dict when the name
-/// still holds the module: upstream reaches them as plain attributes of a
-/// translated-away `State` instance, so routing a read as hot as the filters
-/// version through the attribute protocol would be pure overhead.  Anything
-/// else bound under the name goes back through `space.getattr`, which is the
-/// only form that copes with an arbitrary object.
+/// The namespace holding the `State` fields, captured when the module is
+/// built.  Upstream reaches them as plain attributes of a translated-away
+/// `State` instance that `space.fromcache` hands out and that no Python name
+/// can reach.  pyre keeps them in the module's own namespace, so holding the
+/// dict itself is what gives the same reachability: resolving
+/// `sys.modules['_warnings']` per access would put a lookup on the path of
+/// every warning and would lose the state the moment app code rebinds the
+/// name.  Module namespaces are Box-immortal, so the captured pointer stays
+/// valid and unmoved.
+static STATE_NS: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+
+fn state_ns() -> PyObjectRef {
+    STATE_NS.load(std::sync::atomic::Ordering::Acquire) as PyObjectRef
+}
+
+/// One `State` field.  Errs only before the module is built, which
+/// `state_is_readable` screens for.
 fn native_attr(name: &str) -> Result<PyObjectRef, PyError> {
-    let module = crate::importing::get_sys_module("_warnings")
-        .ok_or_else(|| PyError::runtime_error("_warnings is not initialized"))?;
-    if unsafe { pyre_object::module::is_module(module) } {
-        let w_dict = unsafe { w_module_get_w_dict(module) };
-        if !w_dict.is_null()
-            && let Some(value) = unsafe { w_dict_getitem_str(w_dict, name) }
-        {
-            return Ok(value);
-        }
+    let ns = state_ns();
+    if !ns.is_null()
+        && let Some(value) = unsafe { w_dict_getitem_str(ns, name) }
+    {
+        return Ok(value);
     }
-    crate::baseobjspace::getattr_str(module, name)
-        .map_err(|_| PyError::runtime_error(format!("_warnings.{name} is not initialized")))
+    Err(PyError::runtime_error(format!(
+        "_warnings.{name} is not initialized"
+    )))
 }
 
 fn native_store(name: &str, value: PyObjectRef) -> Result<(), PyError> {
-    let module = crate::importing::get_sys_module("_warnings")
-        .ok_or_else(|| PyError::runtime_error("_warnings is not initialized"))?;
-    crate::baseobjspace::setattr_str(module, name, value).map(|_| ())
+    let ns = state_ns();
+    if ns.is_null() {
+        return Err(PyError::runtime_error("_warnings is not initialized"));
+    }
+    crate::module_ns_store(ns, name, value);
+    Ok(())
 }
 
 fn get_default_action() -> Result<PyObjectRef, PyError> {
@@ -616,33 +626,32 @@ fn do_warn_explicit(
     let warning = warning_class("Warning");
     let input_message = pyre_object::gc_roots::shadow_stack_get(input_message_slot);
     let category = pyre_object::gc_roots::shadow_stack_get(category_slot);
-    let (text, message, category) = if unsafe {
-        crate::baseobjspace::isinstance_w(input_message, warning)
-    } {
-        (
-            crate::builtins::builtin_str(&[pyre_object::gc_roots::shadow_stack_get(
-                input_message_slot,
-            )])?,
-            pyre_object::gc_roots::shadow_stack_get(input_message_slot),
-            crate::typedef::r#type(pyre_object::gc_roots::shadow_stack_get(input_message_slot))
-                .map(|p| p.as_ptr())
-                .unwrap_or(category),
-        )
-    } else {
-        let input_message = pyre_object::gc_roots::shadow_stack_get(input_message_slot);
-        let text = if unsafe { is_str(input_message) || is_bytes(input_message) } {
-            input_message
+    let (text, message, category) =
+        if unsafe { crate::baseobjspace::isinstance_w(input_message, warning) } {
+            (
+                crate::builtins::builtin_str(&[pyre_object::gc_roots::shadow_stack_get(
+                    input_message_slot,
+                )])?,
+                pyre_object::gc_roots::shadow_stack_get(input_message_slot),
+                crate::typedef::r#type(pyre_object::gc_roots::shadow_stack_get(input_message_slot))
+                    .map(|p| p.as_ptr())
+                    .unwrap_or(category),
+            )
         } else {
-            crate::builtins::builtin_str(&[input_message])?
+            let input_message = pyre_object::gc_roots::shadow_stack_get(input_message_slot);
+            let text = if unsafe { is_str(input_message) || is_bytes(input_message) } {
+                input_message
+            } else {
+                crate::builtins::builtin_str(&[input_message])?
+            };
+            let text_slot = pin_root_slot(text);
+            let instance = crate::call::call_function_impl_result(
+                pyre_object::gc_roots::shadow_stack_get(category_slot),
+                &[pyre_object::gc_roots::shadow_stack_get(input_message_slot)],
+            )?;
+            let text = pyre_object::gc_roots::shadow_stack_get(text_slot);
+            (text, instance, category)
         };
-        let text_slot = pin_root_slot(text);
-        let instance = crate::call::call_function_impl_result(
-            pyre_object::gc_roots::shadow_stack_get(category_slot),
-            &[pyre_object::gc_roots::shadow_stack_get(input_message_slot)],
-        )?;
-        let text = pyre_object::gc_roots::shadow_stack_get(text_slot);
-        (text, instance, category)
-    };
     let text_slot = pin_root_slot(text);
     let message_slot = pin_root_slot(message);
     let category_slot = pin_root_slot(category);
@@ -726,15 +735,14 @@ fn do_warn_explicit(
     Ok(())
 }
 
-/// Whether the `State` this module keeps in its own namespace is readable.
+/// Whether the `State` has been installed yet.
 ///
-/// Upstream holds it on a `space.fromcache(State)` instance that no Python
-/// code can reach, so `space.warn` can always match a warning.  pyre's lives
-/// under `sys.modules['_warnings']`, which app code can rebind to anything;
-/// an interpreter warning has to survive that rather than raise out of the
-/// operator that issued it.
+/// Upstream builds `space.fromcache(State)` during space construction, so
+/// `space.warn` can always match a warning.  pyre builds it with the module,
+/// and a warning issued before that point still has to reach stderr rather
+/// than raise out of the operator that issued it.
 pub fn state_is_readable() -> bool {
-    native_attr(VERSION_ATTR).is_ok()
+    !state_ns().is_null()
 }
 
 /// `interp_warnings.do_warn` — the interpreter-level entry point.
@@ -881,9 +889,14 @@ crate::py_module! {
             create_filter(warning_class("ImportWarning"), "ignore", None),
             create_filter(warning_class("ResourceWarning"), "ignore", None),
         ]);
+        // `moduledef.py:18-22 setup_after_space_initialization` publishes the
+        // State fields into the module dict.  Capture the namespace only once
+        // every field is in place, so `state_is_readable` never reports a
+        // half-filled State to a warning raised in between.
         crate::module_ns_store(ns, "filters", filters);
         crate::module_ns_store(ns, "_onceregistry", w_dict_new());
         crate::module_ns_store(ns, "_defaultaction", w_str_new("default"));
         crate::module_ns_store(ns, VERSION_ATTR, new_version());
+        STATE_NS.store(ns as usize, std::sync::atomic::Ordering::Release);
     },
 }

--- a/pyre/pyre-interpreter/src/module/sys/vm.rs
+++ b/pyre/pyre-interpreter/src/module/sys/vm.rs
@@ -737,7 +737,17 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             let mut current = if ec.is_null() {
                 std::ptr::null_mut()
             } else {
-                unsafe { (*ec).gettopframe_nohidden() }
+                // Force the frame `topframeref` names BEFORE deciding which
+                // frame to hand out.  A JIT-inlined callee has no frame of its
+                // own until that force materialises one, so a walk started on
+                // the unforced chain would skip straight to the caller and
+                // then read `f_back` off a frame that never existed.
+                // `gettopframe` is the forcing accessor; the `_nohidden` walk
+                // is force-free by design (see `force_frame`).
+                unsafe {
+                    (*ec).gettopframe();
+                    (*ec).gettopframe_nohidden()
+                }
             };
             let mut remaining = depth_signed as usize;
             loop {
@@ -754,9 +764,12 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             // Return the live `PyFrame` itself as the user-visible `frame`
             // object (`FRAME_TYPE` typedef); `f_back` chains lazily through
             // the getset.  Mark it escaped so the JIT keeps the frame
-            // materialised for the exposed reference (pyframe.py:176
-            // `mark_as_escaped`).
+            // materialised for the exposed reference (`pyframe.py`
+            // `mark_as_escaped`), and force it now: app code is about to read
+            // `f_lineno` / `f_locals` off a frame whose virtualizable fields
+            // the JIT may still be holding.
             unsafe { (*current).mark_as_escaped() };
+            crate::executioncontext::force_frame(current);
             Ok(current as pyre_object::PyObjectRef)
         }),
     );

--- a/pyre/pyre-interpreter/src/module/thread/mod.rs
+++ b/pyre/pyre-interpreter/src/module/thread/mod.rs
@@ -272,6 +272,9 @@ pub(crate) fn current_frames() -> PyObjectRef {
                 unsafe { (*(ec as *const crate::PyExecutionContext)).gettopframe_nohidden() };
             if !frame.is_null() {
                 unsafe { (*frame).mark_as_escaped() };
+                // The frame becomes a user-visible value; materialize the
+                // virtualizable fields the JIT may still be holding.
+                crate::executioncontext::force_frame(frame);
                 pyre_object::gc_roots::pin_root(frame as PyObjectRef);
                 entries.push(ident);
             }

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -4388,7 +4388,20 @@ the bitwise inversion of the underlying int.";
 /// The wrapped form of [`BOOL_INVERT_DEPRECATION_TEXT`]: `~True` in a loop
 /// issues the same message on every iteration, and the registry lookup that
 /// deduplicates it hashes and compares the message each time.
-static BOOL_INVERT_DEPRECATION: crate::warn::PrebuiltText = crate::warn::PrebuiltText::new();
+///
+/// `dont_look_inside` because the cell is a `static` of a host type, which
+/// the front-end cannot lift: reaching it from a lifted body fails the
+/// callee's own lift and, transitively, every caller's — [`invert`] then has
+/// no jitcode, the tracer has to residualise the whole `~` opcode, and a
+/// virtualizable forced inside that residual aborts the trace
+/// (`ABORT_ESCAPE`), so a `~bool` in a hot loop stops the loop compiling at
+/// all.  Hiding the static behind an opaque accessor keeps the body out of
+/// the lift, exactly as `w_dict_new` does for its host `IndexMap`.
+#[majit_macros::dont_look_inside]
+pub(crate) fn bool_invert_deprecation_text() -> PyObjectRef {
+    static CELL: crate::warn::PrebuiltText = crate::warn::PrebuiltText::new();
+    CELL.get(BOOL_INVERT_DEPRECATION_TEXT)
+}
 
 /// Unary bitwise inversion.
 
@@ -4401,11 +4414,7 @@ pub fn invert(a: PyObjectRef) -> PyResult {
             // CPython 3.14 `Objects/boolobject.c:bool_invert`.  The bundled
             // PyPy source inherits `W_IntObject.descr_invert`; 3.14 inserts
             // this warning-bearing bool slot before the integer inversion.
-            crate::warn::warn_category_w(
-                BOOL_INVERT_DEPRECATION.get(BOOL_INVERT_DEPRECATION_TEXT),
-                "DeprecationWarning",
-                2,
-            )?;
+            crate::warn::warn_category_w(bool_invert_deprecation_text(), "DeprecationWarning", 2)?;
             return Ok(w_int_new(!int_value(a)));
         }
         if is_int(a) {

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -4379,6 +4379,17 @@ pub fn neg(a: PyObjectRef) -> PyResult {
     }
 }
 
+const BOOL_INVERT_DEPRECATION_TEXT: &str = "Bitwise inversion '~' on bool is deprecated and will be removed in \
+Python 3.16. This returns the bitwise inversion of the underlying int \
+object and is usually not what you expect from negating a bool. \
+Use the 'not' operator for boolean negation or ~int(x) if you really want \
+the bitwise inversion of the underlying int.";
+
+/// The wrapped form of [`BOOL_INVERT_DEPRECATION_TEXT`]: `~True` in a loop
+/// issues the same message on every iteration, and the registry lookup that
+/// deduplicates it hashes and compares the message each time.
+static BOOL_INVERT_DEPRECATION: crate::warn::PrebuiltText = crate::warn::PrebuiltText::new();
+
 /// Unary bitwise inversion.
 
 pub fn invert(a: PyObjectRef) -> PyResult {
@@ -4390,12 +4401,10 @@ pub fn invert(a: PyObjectRef) -> PyResult {
             // CPython 3.14 `Objects/boolobject.c:bool_invert`.  The bundled
             // PyPy source inherits `W_IntObject.descr_invert`; 3.14 inserts
             // this warning-bearing bool slot before the integer inversion.
-            crate::warn::warn_deprecation(
-                "Bitwise inversion '~' on bool is deprecated and will be removed in \
-Python 3.16. This returns the bitwise inversion of the underlying int \
-object and is usually not what you expect from negating a bool. \
-Use the 'not' operator for boolean negation or ~int(x) if you really want \
-the bitwise inversion of the underlying int.",
+            crate::warn::warn_category_w(
+                BOOL_INVERT_DEPRECATION.get(BOOL_INVERT_DEPRECATION_TEXT),
+                "DeprecationWarning",
+                2,
             )?;
             return Ok(w_int_new(!int_value(a)));
         }

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -773,6 +773,8 @@ fn capture_coroutine_origin(ec: *const PyExecutionContext) -> PyObjectRef {
         if frame.is_null() {
             break;
         }
+        // `fget_f_lineno` below reads `last_instr`, a virtualizable field.
+        crate::executioncontext::force_frame(frame);
         let code = unsafe { (*frame).code() };
         let filename_slot = pyre_object::gc_roots::shadow_stack_len();
         pyre_object::gc_roots::pin_root(w_str_new(&code.source_path));
@@ -2896,9 +2898,18 @@ impl PyFrame {
     /// nohidden walker itself) returns the raw `f_backref` link.
     #[inline]
     pub fn fget_f_back(&self) -> *mut PyFrame {
-        crate::executioncontext::ExecutionContext::getnextframe_nohidden(
-            self as *const PyFrame as *mut PyFrame,
-        )
+        // `f_back` is read from app code, which goes on to read frame fields;
+        // the walk itself no longer forces, so force both ends here.  `self`
+        // matters as much as the result: an inline-published callee frame is
+        // materialised only by a force, and `f_backref` off an unforced one
+        // names the wrong caller.
+        let this = self as *const PyFrame as *mut PyFrame;
+        crate::executioncontext::force_frame(this);
+        let back = crate::executioncontext::ExecutionContext::getnextframe_nohidden(this);
+        if !back.is_null() {
+            crate::executioncontext::force_frame(back);
+        }
+        back
     }
 
     /// pyframe.py:641-642 fget_code → self.getcode().  Returns the `PyCode`

--- a/pyre/pyre-interpreter/src/warn.rs
+++ b/pyre/pyre-interpreter/src/warn.rs
@@ -1,38 +1,76 @@
 //! `space.warn` — interpreter-level warnings.
 
+use pyre_object::PyObjectRef;
+
+/// A `space.newtext(...)` applied to an interpreter-level string literal.
+///
+/// RPython builds the string for a literal once, at translation time, and
+/// `ll_strhash` memoizes its digest in that prebuilt, so `space.newtext` on a
+/// constant costs neither a copy nor a rehash however often it runs.  pyre
+/// reaches the same place with a cell per literal: `w_str_new` is immortal
+/// (`malloc_typed` header over a `malloc_raw` buffer), so the box is never
+/// swept and never relocated and needs no root.
+pub struct PrebuiltText(std::sync::OnceLock<usize>);
+
+impl PrebuiltText {
+    pub const fn new() -> Self {
+        Self(std::sync::OnceLock::new())
+    }
+
+    /// The wrapped constant.  `text` must be the same literal on every call.
+    pub fn get(&self, text: &str) -> PyObjectRef {
+        *self.0.get_or_init(|| pyre_object::w_str_new(text) as usize) as PyObjectRef
+    }
+}
+
+impl Default for PrebuiltText {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// `space.warn(space.newtext(msg), space.w_DeprecationWarning)`
 pub fn warn_deprecation(msg: &str) -> Result<(), crate::PyError> {
     warn_category(msg, "DeprecationWarning", 2)
+}
+
+/// `space.warn(w_msg, w_warningcls, stacklevel)` for a message that is built
+/// per call.
+pub fn warn_category(
+    msg: &str,
+    category_name: &str,
+    stacklevel: i64,
+) -> Result<(), crate::PyError> {
+    warn_category_w(pyre_object::w_str_new(msg), category_name, stacklevel)
 }
 
 /// `space.warn(w_msg, w_warningcls, stacklevel)` — hands the message to
 /// `_warnings.do_warn` with `stacklevel - 1`, so the filters, the module
 /// `__warningregistry__` and `warnings.catch_warnings(record=True)` all
 /// observe the event whether or not the `warnings` wrapper is imported.
-pub fn warn_category(
-    msg: &str,
+pub fn warn_category_w(
+    w_msg: PyObjectRef,
     category_name: &str,
     stacklevel: i64,
 ) -> Result<(), crate::PyError> {
     // Upstream reaches the filters and the once-registry through
     // `space.fromcache(State)`, which exists from space construction and which
-    // app code cannot reach.  pyre keeps them on the `_warnings` module, so a
-    // warning raised before that module is installed — or after the name has
-    // been rebound — has nowhere to be matched.  Report it unfiltered rather
-    // than turn a warning into an error out of the operator that issued it.
+    // app code cannot reach.  pyre's equivalent is installed with the
+    // `_warnings` module, so a warning raised before that point has nowhere to
+    // be matched.  Report it unfiltered rather than turn a warning into an
+    // error out of the operator that issued it.
     let Some(category) = crate::builtins::lookup_exc_class(category_name)
         .filter(|_| crate::module::_warnings::state_is_readable())
     else {
-        warn(msg, category_name);
+        let _roots = pyre_object::gc_roots::push_roots();
+        pyre_object::gc_roots::pin_root(w_msg);
+        let text = crate::baseobjspace::text_w(w_msg)
+            .map(|text| text.to_string())
+            .unwrap_or_default();
+        warn(&text, category_name);
         return Ok(());
     };
-    crate::module::_warnings::do_warn(
-        pyre_object::w_str_new(msg),
-        category,
-        stacklevel - 1,
-        pyre_object::PY_NULL,
-        &[],
-    )
+    crate::module::_warnings::do_warn(w_msg, category, stacklevel - 1, pyre_object::PY_NULL, &[])
 }
 
 /// `do_warn_explicit`'s stderr format without the location prefix, for

--- a/pyre/pyre-interpreter/src/warn.rs
+++ b/pyre/pyre-interpreter/src/warn.rs
@@ -1,49 +1,42 @@
-/// baseobjspace.py:2087-2093 space.warn(w_msg, w_warningcls, stacklevel)
-///
-/// _warnings/interp_warnings.py:263-290 do_warn → do_warn_explicit.
-///
-/// Routes through Python's `warnings.warn()` when available, otherwise
-/// falls back to stderr in the standard format.
-/// Currently uses stderr-only path; Python-level routing requires the
-/// _warnings C-extension module (not yet ported).
+//! `space.warn` — interpreter-level warnings.
 
-/// baseobjspace.py:2087: space.warn(space.newtext(msg), space.w_DeprecationWarning)
+/// `space.warn(space.newtext(msg), space.w_DeprecationWarning)`
 pub fn warn_deprecation(msg: &str) -> Result<(), crate::PyError> {
     warn_category(msg, "DeprecationWarning", 2)
 }
 
-/// Route an interpreter warning through Python's warnings machinery so
-/// filters and `warnings.catch_warnings(record=True)` observe it.
+/// `space.warn(w_msg, w_warningcls, stacklevel)` — hands the message to
+/// `_warnings.do_warn` with `stacklevel - 1`, so the filters, the module
+/// `__warningregistry__` and `warnings.catch_warnings(record=True)` all
+/// observe the event whether or not the `warnings` wrapper is imported.
 pub fn warn_category(
     msg: &str,
     category_name: &str,
     stacklevel: i64,
 ) -> Result<(), crate::PyError> {
-    if let (Some(warnings), Some(category)) = (
-        crate::importing::get_sys_module("warnings"),
-        crate::builtins::lookup_exc_class(category_name),
-    ) {
-        if let Ok(warn_fn) = crate::baseobjspace::getattr_str(warnings, "warn") {
-            crate::call::call_function_impl_result(
-                warn_fn,
-                &[
-                    pyre_object::w_str_new(msg),
-                    category,
-                    pyre_object::w_int_new(stacklevel),
-                ],
-            )
-            .map(|_| ())?;
-            return Ok(());
-        }
-    }
-    warn(msg, category_name);
-    Ok(())
+    // Upstream reaches the filters and the once-registry through
+    // `space.fromcache(State)`, which exists from space construction and which
+    // app code cannot reach.  pyre keeps them on the `_warnings` module, so a
+    // warning raised before that module is installed — or after the name has
+    // been rebound — has nowhere to be matched.  Report it unfiltered rather
+    // than turn a warning into an error out of the operator that issued it.
+    let Some(category) = crate::builtins::lookup_exc_class(category_name)
+        .filter(|_| crate::module::_warnings::state_is_readable())
+    else {
+        warn(msg, category_name);
+        return Ok(());
+    };
+    crate::module::_warnings::do_warn(
+        pyre_object::w_str_new(msg),
+        category,
+        stacklevel - 1,
+        pyre_object::PY_NULL,
+        &[],
+    )
 }
 
-/// baseobjspace.py:2087-2093
-///
-/// _warnings/interp_warnings.py:263: do_warn(space, w_message, w_category, stacklevel-1)
-/// do_warn_explicit formats: "{filename}:{lineno}: {category}: {message}"
+/// `do_warn_explicit`'s stderr format without the location prefix, for
+/// reporting before the warnings machinery is usable.
 pub fn warn(msg: &str, category: &str) {
     crate::host_seam::emit_stderr(format!("{category}: {msg}\n").as_bytes());
 }

--- a/pyre/pyre-jit-trace/src/helpers.rs
+++ b/pyre/pyre-jit-trace/src/helpers.rs
@@ -657,6 +657,44 @@ pub fn emit_empty_list_inline(ctx: &mut TraceCtx) -> OpRef {
     list
 }
 
+/// Trace-visible `W_SpecialisedTupleObject_oo` construction from two boxed
+/// items — the shape `makespecialisedtuple2` builds for an arity-2 tuple whose
+/// elements are not both plain ints or both plain floats.
+///
+/// `newtuple` picks the representation, so a fold that reproduces a `newtuple`
+/// must pick the same one: emitting the array-backed shape for an arity the
+/// runtime specialises leaves the trace disagreeing with its own record-time
+/// concrete, and a consumer that dispatches on the concrete's layout (the
+/// `except <tuple>:` match fold) then guards for a shape the trace never
+/// builds.
+///
+/// `ob_type` is the JIT vtable and differs per variant so `GuardClass` can
+/// dispatch on the inline-field layout; Python-level `type()` reads `w_class`,
+/// which every variant shares at the public `tuple` typedef.
+pub fn emit_specialised_tuple_oo_inline(ctx: &mut TraceCtx, value0: OpRef, value1: OpRef) -> OpRef {
+    let tuple = ctx.record_op_with_descr(
+        OpCode::NewWithVtable,
+        &[],
+        crate::descr::specialised_tuple_oo_size_descr(),
+    );
+    ctx.heap_cache_mut().new_object(tuple);
+    let w_class = pyre_object::get_instantiate(&pyre_object::TUPLE_TYPE);
+    if !w_class.is_null() {
+        let w_class = ctx.const_ref(w_class as i64);
+        let class_descr = crate::descr::specialised_tuple_oo_w_class_descr();
+        ctx.record_op_with_descr(OpCode::SetfieldGc, &[tuple, w_class], class_descr.clone());
+        ctx.heapcache_setfield_cached(tuple, class_descr.index(), w_class);
+    }
+    for (value, descr) in [
+        (value0, crate::descr::specialised_tuple_oo_value0_descr()),
+        (value1, crate::descr::specialised_tuple_oo_value1_descr()),
+    ] {
+        ctx.record_op_with_descr(OpCode::SetfieldGc, &[tuple, value], descr.clone());
+        ctx.heapcache_setfield_cached(tuple, descr.index(), value);
+    }
+    tuple
+}
+
 /// Trace-visible canonical `W_TupleObject` construction from boxed items.
 /// This is the allocation half of `W_BaseException.descr_getargs`: the raw
 /// `args_w` list is copied into a fresh tuple on every public attribute read.

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
@@ -1464,6 +1464,12 @@ fn body_branch_targets(body_code: &[u8]) -> Option<std::collections::HashSet<usi
     let mut pc = 0usize;
     while pc < body_code.len() {
         let d = crate::jitcode_runtime::decode_op_at(body_code, pc)?;
+        // `switch/id` carries its case targets in the descr, not in an operand,
+        // so this decode cannot name the joins it creates.  Give up on the
+        // whole body rather than return a target set that is missing them.
+        if d.opname.starts_with("switch") {
+            return None;
+        }
         if d.argcodes.contains('L') {
             // Operand widths follow `decode_op_at`; only the fixed-width forms
             // can precede the label, so anything else gives up.
@@ -1733,8 +1739,16 @@ pub(crate) fn fbw_callee_body_replay_safety(
                 }
             }
         } else if d.opname.starts_with("setfield_gc") {
-            // Canonical setfield shapes are `r<value>d`: the target ref is
-            // operand 0 and the field descr is operand 2.
+            // Only the `r<value>d` shapes name their target in a ref register
+            // (operand 0), with the field descr at operand 2.  The `i…` forms
+            // (`setfield_gc_i/iid`, `setfield_gc_r/ird`, `setfield_gc_v/iid`,
+            // `setfield_gc_v/ird`) address the target by raw int instead, so
+            // there is no ref register whose freshness could be proven — and
+            // reading operand 0 as one would index the freshness set with an
+            // int register number.
+            if !d.argcodes.starts_with('r') {
+                return CalleeReplaySafety::Dirty;
+            }
             let Some(&target_reg) = body_code.get(d.pc + 1) else {
                 return CalleeReplaySafety::Dirty;
             };

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -1243,6 +1243,26 @@ pub(crate) fn reconstructed_all_ref_call_stack<Sym: WalkSym>(
 ///
 /// # Safety
 /// `w_code` must be the live code object pointer for the resolved callable.
+/// Whether every local of `w_code` that a call must bind lives in
+/// `registers_r[0..co_argcount]`, which is all the inline seeding fills.
+///
+/// `*args` and `**kwargs` own locals the seeding never packs, and a
+/// keyword-only parameter owns one it never reaches — and none of the three is
+/// counted by `co_argcount`, so an arity check alone lets them through.
+fn fbw_callee_scope_is_positional_only(w_code: *const ()) -> bool {
+    let raw = unsafe {
+        pyre_interpreter::w_code_get_ptr(w_code as pyre_object::PyObjectRef)
+            as *const pyre_interpreter::CodeObject
+    };
+    if raw.is_null() {
+        return false;
+    }
+    let flags = unsafe { (*raw).flags };
+    !flags.contains(pyre_interpreter::CodeFlags::VARARGS)
+        && !flags.contains(pyre_interpreter::CodeFlags::VARKEYWORDS)
+        && unsafe { (*raw).kwonlyarg_count } == 0
+}
+
 unsafe fn fbw_reorder_call_kw_args(
     r_args: &[OpRef],
     arg_concretes: &[ConcreteValue],
@@ -1278,11 +1298,7 @@ unsafe fn fbw_reorder_call_kw_args(
     if raw.is_null() {
         return None;
     }
-    let flags = unsafe { (*raw).flags };
-    if flags.contains(pyre_interpreter::CodeFlags::VARARGS)
-        || flags.contains(pyre_interpreter::CodeFlags::VARKEYWORDS)
-        || unsafe { (*raw).kwonlyarg_count } != 0
-    {
+    if !fbw_callee_scope_is_positional_only(w_code) {
         return None;
     }
     let varnames = unsafe { &(*raw).varnames };
@@ -1309,8 +1325,11 @@ unsafe fn fbw_reorder_call_kw_args(
             .position(|v| v.as_str() == name)?;
         // A keyword may only bind a parameter past the positional fill, and each
         // parameter at most once (else Python raises "multiple values for
-        // argument").
-        if pi < n_pos || slot_args[pi].is_some() {
+        // argument").  A name in the positional-only range is not bindable by
+        // keyword at all — `def f(x, /)` called as `f(x=1)` is a TypeError, so
+        // binding slot 0 here would inline a call the interpreter rejects.
+        if pi < n_pos || pi < unsafe { (*raw).posonlyarg_count } as usize || slot_args[pi].is_some()
+        {
             return None;
         }
         slot_args[pi] = Some(args[n_pos + j]);
@@ -1351,6 +1370,17 @@ fn fbw_unpack_call_function_ex_args<Sym: WalkSym>(
     match arg_concretes[3] {
         ConcreteValue::Null => {}
         ConcreteValue::Ref(kwargs) if kwargs.is_null() || kwargs == pyre_object::PY_NULL => {}
+        _ => return None,
+    }
+    // `wrappeditems` resolves to a structural field index (offset / size /
+    // type), so an object whose slot 0 happens to match — a list's backing
+    // store, say — would hit the same cache entry and be unpacked as if its
+    // slots were tuple element refs.  `f(*some_list)` is ordinary Python, so
+    // pin the concrete to a real tuple the way the `kwnames` path does before
+    // reading the field.
+    match arg_concretes[2] {
+        ConcreteValue::Ref(starargs)
+            if !starargs.is_null() && unsafe { pyre_object::is_tuple(starargs) } => {}
         _ => return None,
     }
     let starargs = r_args[2];
@@ -1489,7 +1519,13 @@ pub(crate) fn try_walker_inline_user_call<Sym: WalkSym>(
         // a trace-time reorder whenever the tuple is the one this trace just
         // built: its element boxes are still in the heap cache, so the callee
         // seeds from them and the tuple keeps no consumer.
-        if method_form {
+        //
+        // The seeding fills `registers_r[0..nparams]` and nothing else, so a
+        // callee owning a local the arity check cannot see must stay residual:
+        // `co_argcount` counts neither `*args` nor `**kwargs` nor keyword-only
+        // params, so `def f(a, *, b=5)` accepts a 1-tuple here while `b` is
+        // never bound.  Same decline the keyword fold applies.
+        if method_form || !fbw_callee_scope_is_positional_only(w_code) {
             return Ok(None);
         }
         let Some(unpacked) = fbw_unpack_call_function_ex_args(ctx, r_args, &arg_concretes, nparams)

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -1757,6 +1757,27 @@ pub(crate) fn try_execute_residual_call_via_executor<Sym: WalkSym>(
             last_instr,
             majit_ir::Value::Int(ctx.vstack_cur_pypc as i64),
         );
+        // …and the heap half of the same `_opimpl_setfield_vable` shape
+        // (`virtualizable_boxes[index] = valuebox; synchronize_virtualizable()`
+        // — the mirror above is only the box half, and writes the trace's
+        // shadow, never the frame).  The same constant feeds both so the
+        // shadow and the heap cannot disagree.
+        //
+        // Upstream needs neither at a residual call: its frame readers are
+        // traced in and read `last_instr` off the virtual frame.  pyre
+        // residualizes them and reads the heap, and the frame-chain walk no
+        // longer forces (`ExecutionContext::force_frame`), so without this
+        // store nothing keeps the field current in compiled code: left at the
+        // last resume point, `_warnings::setup_context` keys its registry on
+        // the wrong line and re-issues a warning the interpreted run already
+        // deduplicated.
+        if let Some(vable_ref) = ctx.trace_ctx.standard_virtualizable_box()
+            && let Some(idx) = info.static_field_index_by_name("last_instr")
+        {
+            let descr = info.static_field_descr(idx);
+            ctx.trace_ctx
+                .vable_setfield_descr(vable_ref, last_instr, descr);
+        }
         unsafe {
             majit_gc::shadow_stack::push_resume_ref_roots(std::slice::from_mut(&mut **obj));
             info.tracing_before_residual_call(**obj as usize as *mut u8);
@@ -1998,6 +2019,31 @@ pub(crate) fn try_execute_residual_call_via_executor<Sym: WalkSym>(
             // leg must not assume walk-end shadow state after a cancelled
             // commit.
             ctx.trace_ctx.refresh_virtualizable_shadow_from_heap();
+            if fbw_debug_abort_enabled() {
+                // `vable_after_residual_call`'s
+                // `debug_print('vable escaped during a call in %s')`: name the
+                // callee through `get_name_from_address`, falling back to the
+                // raw address.  Which helper forced the virtualizable is the
+                // only thing that distinguishes one ABORT_ESCAPE from another,
+                // and the trace is gone by the time the abort surfaces.
+                let addr = match ctx.trace_ctx.box_value(allboxes[0]) {
+                    Some(majit_ir::Value::Int(a)) => a,
+                    _ => 0,
+                };
+                match pyre_interpreter::jit_trace_fnaddrs()
+                    .into_iter()
+                    .find(|(_, a)| *a == addr)
+                {
+                    Some((name, _)) => eprintln!(
+                        "[fbw-escape] pc={op_pc} vable escaped during a call in ConstClass({name})"
+                    ),
+                    None => {
+                        eprintln!(
+                            "[fbw-escape] pc={op_pc} vable escaped during a call in {addr:#x}"
+                        )
+                    }
+                }
+            }
             return Err(DispatchError::VableEscapedDuringResidualCall { pc: op_pc });
         }
     }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -342,6 +342,70 @@ thread_local! {
     /// [`INLINE_CONCRETE_FRAME`], which stays set across the whole sub-walk.
     static PUBLISHED_INLINE_FRAME: std::cell::Cell<*mut pyre_interpreter::PyFrame> =
         const { std::cell::Cell::new(std::ptr::null_mut()) };
+
+    /// The frame a live [`LiveLastInstrGuard`] published the executing pc onto,
+    /// with the resume coordinate it displaced.
+    static PUBLISHED_LAST_INSTR: std::cell::Cell<Option<(usize, isize)>> =
+        const { std::cell::Cell::new(None) };
+}
+
+/// `_opimpl_setfield_vable`'s heap half for the recording walk.  While a
+/// residual runs concretely the live frame must name the EXECUTING opcode, so
+/// that a frame reader inside the callee reports the line the opcode is on —
+/// what `eval.rs` `frame.last_instr = pc` gives an interpreted opcode.  The
+/// walk dispatches opcodes itself instead of through `execute_opcode_step`, so
+/// nothing else advances the field and the frame still carries the pc of the
+/// last resume point; `_warnings::setup_context` then keys its registry on
+/// that line and re-issues a warning the interpreted run already deduplicated.
+///
+/// Restored on the way out, because `last_instr` doubles as the resume
+/// coordinate: `flush_walk_end_state_to_frame_inner` writes `resume_py_pc - 1`
+/// and the escape guard's resume pc is this same pc, so the two meanings
+/// differ by exactly one and may only coexist for the residual's duration.
+/// Leaving the executing value behind makes an abort replay one opcode late.
+struct LiveLastInstrGuard {
+    frame: *mut pyre_interpreter::PyFrame,
+    saved: isize,
+}
+
+impl LiveLastInstrGuard {
+    /// Publishes onto the frame `py_pc` indexes.  Inside an inline sub-walk
+    /// that is the callee's concrete frame, NOT the walk's virtualizable: a
+    /// sub-walk's pc is in the callee's code (the same reason `escape_stack`
+    /// declines to latch a sub-walk's mirror), and writing it onto the outer
+    /// frame strands that frame's replay on a stack depth it never had.
+    fn enter(live_frame: usize, py_pc: u32) -> Option<Self> {
+        let inline = INLINE_CONCRETE_FRAME.with(|slot| slot.get());
+        let frame = if inline.is_null() {
+            live_frame as *mut pyre_interpreter::PyFrame
+        } else {
+            inline
+        };
+        if frame.is_null() {
+            return None;
+        }
+        let saved = unsafe { (*frame).last_instr };
+        unsafe { (*frame).last_instr = py_pc as isize };
+        PUBLISHED_LAST_INSTR.with(|slot| slot.set(Some((frame as usize, saved))));
+        Some(Self { frame, saved })
+    }
+}
+
+impl Drop for LiveLastInstrGuard {
+    fn drop(&mut self) {
+        PUBLISHED_LAST_INSTR.with(|slot| slot.set(None));
+        // A flush that committed onto this frame wrote the resume coordinate
+        // itself and is authoritative.  Its undo capture holds the value this
+        // guard displaced (see [`capture_escape_flush_undo`]), so a later
+        // commit withdrawal still restores the resume pc rather than the
+        // executing one.
+        let flushed = ESCAPE_FLUSH_UNDO
+            .with(|slot| slot.borrow().as_ref().map(|undo| undo.frame))
+            == Some(self.frame as usize);
+        if !flushed {
+            unsafe { (*self.frame).last_instr = self.saved };
+        }
+    }
 }
 
 /// Names the frame an inline sub-walk executes concretely for the duration of
@@ -559,9 +623,17 @@ fn capture_escape_flush_undo(frame: usize) {
             None => {}
         }
         let pf = unsafe { &*(frame as *const pyre_interpreter::PyFrame) };
+        // With a [`LiveLastInstrGuard`] live on this frame the field holds the
+        // EXECUTING pc, not the resume coordinate.  The undo exists to hand a
+        // legacy replay a pristine pre-flush frame, and a replay needs the
+        // resume pc — so capture the value the guard displaced.
+        let last_instr = PUBLISHED_LAST_INSTR
+            .with(|slot| slot.get())
+            .filter(|(published, _)| *published == frame)
+            .map_or(pf.last_instr, |(_, saved)| saved);
         *slot = Some(EscapeFlushUndo {
             frame,
-            last_instr: pf.last_instr,
+            last_instr,
             valuestackdepth: pf.valuestackdepth,
             slots: pf.locals_w().as_slice().to_vec(),
         });
@@ -1887,6 +1959,7 @@ pub(crate) fn try_execute_residual_call_via_executor<Sym: WalkSym>(
         // `executioncontext.py:85 enter` for the inlined callee this residual
         // runs inside of.
         let _frame_chain = ResidualFrameChainGuard::enter();
+        let _last_instr = LiveLastInstrGuard::enter(live_frame, ctx.vstack_cur_pypc);
         let _suspend = majit_metainterp::TraceContinuationSuspendGuard::enter();
         majit_metainterp::executor::execute_residual_call(call_descr, func_ptr, &args)
     };

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -1829,33 +1829,43 @@ pub(crate) fn try_execute_residual_call_via_executor<Sym: WalkSym>(
         // Publish the current Python pc so a force inside the callee reports
         // the executing line rather than the one the last resume point left
         // behind.
-        let last_instr = ctx.trace_ctx.const_int(ctx.vstack_cur_pypc as i64);
-        crate::trace_opcode::mirror_vable_static_to_boxes(
-            ctx.trace_ctx,
-            "last_instr",
-            last_instr,
-            majit_ir::Value::Int(ctx.vstack_cur_pypc as i64),
-        );
-        // …and the heap half of the same `_opimpl_setfield_vable` shape
-        // (`virtualizable_boxes[index] = valuebox; synchronize_virtualizable()`
-        // — the mirror above is only the box half, and writes the trace's
-        // shadow, never the frame).  The same constant feeds both so the
-        // shadow and the heap cannot disagree.
         //
-        // Upstream needs neither at a residual call: its frame readers are
-        // traced in and read `last_instr` off the virtual frame.  pyre
-        // residualizes them and reads the heap, and the frame-chain walk no
-        // longer forces (`ExecutionContext::force_frame`), so without this
-        // store nothing keeps the field current in compiled code: left at the
-        // last resume point, `_warnings::setup_context` keys its registry on
-        // the wrong line and re-issues a warning the interpreted run already
-        // deduplicated.
-        if let Some(vable_ref) = ctx.trace_ctx.standard_virtualizable_box()
-            && let Some(idx) = info.static_field_index_by_name("last_instr")
-        {
-            let descr = info.static_field_descr(idx);
-            ctx.trace_ctx
-                .vable_setfield_descr(vable_ref, last_instr, descr);
+        // Only while the pc indexes the walk's own virtualizable.  Inside an
+        // inline sub-walk `vstack_cur_pypc` is in the CALLEE's code, and both
+        // halves below name the outer frame, so publishing there stamps a
+        // foreign pc onto it — `offset2lineno` then resolves it against the
+        // outer code object and reports whatever line that byte happens to sit
+        // on.  [`LiveLastInstrGuard`] makes the matching retarget for the
+        // concrete store, publishing onto the callee's own frame instead.
+        if INLINE_CONCRETE_FRAME.with(|slot| slot.get()).is_null() {
+            let last_instr = ctx.trace_ctx.const_int(ctx.vstack_cur_pypc as i64);
+            crate::trace_opcode::mirror_vable_static_to_boxes(
+                ctx.trace_ctx,
+                "last_instr",
+                last_instr,
+                majit_ir::Value::Int(ctx.vstack_cur_pypc as i64),
+            );
+            // …and the heap half of the same `_opimpl_setfield_vable` shape
+            // (`virtualizable_boxes[index] = valuebox; synchronize_virtualizable()`
+            // — the mirror above is only the box half, and writes the trace's
+            // shadow, never the frame).  The same constant feeds both so the
+            // shadow and the heap cannot disagree.
+            //
+            // Upstream needs neither at a residual call: its frame readers are
+            // traced in and read `last_instr` off the virtual frame.  pyre
+            // residualizes them and reads the heap, and the frame-chain walk no
+            // longer forces (`ExecutionContext::force_frame`), so without this
+            // store nothing keeps the field current in compiled code: left at
+            // the last resume point, `_warnings::setup_context` keys its
+            // registry on the wrong line and re-issues a warning the
+            // interpreted run already deduplicated.
+            if let Some(vable_ref) = ctx.trace_ctx.standard_virtualizable_box()
+                && let Some(idx) = info.static_field_index_by_name("last_instr")
+            {
+                let descr = info.static_field_descr(idx);
+                ctx.trace_ctx
+                    .vable_setfield_descr(vable_ref, last_instr, descr);
+            }
         }
         unsafe {
             majit_gc::shadow_stack::push_resume_ref_roots(std::slice::from_mut(&mut **obj));

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -399,8 +399,7 @@ impl Drop for LiveLastInstrGuard {
         // guard displaced (see [`capture_escape_flush_undo`]), so a later
         // commit withdrawal still restores the resume pc rather than the
         // executing one.
-        let flushed = ESCAPE_FLUSH_UNDO
-            .with(|slot| slot.borrow().as_ref().map(|undo| undo.frame))
+        let flushed = ESCAPE_FLUSH_UNDO.with(|slot| slot.borrow().as_ref().map(|undo| undo.frame))
             == Some(self.frame as usize);
         if !flushed {
             unsafe { (*self.frame).last_instr = self.saved };

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -366,6 +366,7 @@ thread_local! {
 struct LiveLastInstrGuard {
     frame: *mut pyre_interpreter::PyFrame,
     saved: isize,
+    prev: Option<(usize, isize)>,
 }
 
 impl LiveLastInstrGuard {
@@ -386,14 +387,21 @@ impl LiveLastInstrGuard {
         }
         let saved = unsafe { (*frame).last_instr };
         unsafe { (*frame).last_instr = py_pc as isize };
-        PUBLISHED_LAST_INSTR.with(|slot| slot.set(Some((frame as usize, saved))));
-        Some(Self { frame, saved })
+        // Save/restore rather than set/clear: a residual can run user code that
+        // records a nested walk whose own residual enters a second guard, and
+        // clearing on the inner drop would leave the still-live outer
+        // publication invisible — `capture_escape_flush_undo` would then snapshot
+        // the executing pc as if it were the outer frame's resume coordinate.
+        // Same discipline as [`InlineConcreteFrameGuard`] and
+        // [`ResidualFrameChainGuard`].
+        let prev = PUBLISHED_LAST_INSTR.with(|slot| slot.replace(Some((frame as usize, saved))));
+        Some(Self { frame, saved, prev })
     }
 }
 
 impl Drop for LiveLastInstrGuard {
     fn drop(&mut self) {
-        PUBLISHED_LAST_INSTR.with(|slot| slot.set(None));
+        PUBLISHED_LAST_INSTR.with(|slot| slot.set(self.prev));
         // A flush that committed onto this frame wrote the resume coordinate
         // itself and is authoritative.  Its undo capture holds the value this
         // guard displaced (see [`capture_escape_flush_undo`]), so a later

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -1325,6 +1325,20 @@ pub(crate) fn try_walker_specialize_unpack<Sym: WalkSym>(
     }
 }
 
+/// The tuple `descr_getargs` would build from an exception's `args_w` list.
+/// Built only to read the representation `newtuple` picks off it, so the caller
+/// keeps the shape and drops the tuple.
+unsafe fn args_tuple_shape_probe(stored: pyre_object::PyObjectRef) -> pyre_object::PyObjectRef {
+    let len = unsafe { pyre_object::w_list_len(stored) };
+    let items = (0..len)
+        .map(|index| {
+            unsafe { pyre_object::w_list_getitem(stored, index as i64) }
+                .unwrap_or(pyre_object::PY_NULL)
+        })
+        .collect();
+    pyre_object::w_tuple_new(items)
+}
+
 /// `mapdict.py LOAD_ATTR_caching` full-body-walker fast path for a
 /// plain (non-method) instance attribute.  When the concrete receiver is a
 /// monomorphic instance whose attribute resolves to a boxed plain storage slot
@@ -1408,6 +1422,35 @@ pub(crate) fn try_walker_specialize_load_attr<Sym: WalkSym>(
         {
             return Ok(None);
         }
+        // `descr_getargs` copies `args_w` through `newtuple`, which picks the
+        // tuple representation from the arity and the element types.  Ask
+        // `newtuple` itself which shape this read produces, rather than second-
+        // guessing its dispatch, and settle it here — before any guard is
+        // recorded, so a decline stays clean (a bail-out after the class pin
+        // would leave the caller reading this attribute as already guarded).
+        //
+        // Only the shape crosses into the emit below; the probe tuple is
+        // dropped rather than held, since nothing roots it across the guards.
+        let args_specialised_oo = if slot == pyre_interpreter::baseobjspace::ExceptionAttrSlot::Args
+        {
+            let ob_type = unsafe { (*args_tuple_shape_probe(stored)).ob_type };
+            if std::ptr::eq(
+                ob_type,
+                &pyre_object::specialisedtupleobject::SPECIALISED_TUPLE_OO_TYPE,
+            ) {
+                true
+            } else if std::ptr::eq(ob_type, &pyre_object::TUPLE_TYPE) {
+                false
+            } else {
+                // The unboxed arity-2 specialisations (`Cls_ii` / `Cls_ff`)
+                // hold machine values in their inline fields, which this copy
+                // has no unboxed operand for.  Only an Object-strategy `args_w`
+                // holding exactly two plain ints or two plain floats gets here.
+                return Ok(None);
+            }
+        } else {
+            false
+        };
         walker_guard_exception_attr_slot(ctx, op_pc, obj, concrete_obj, w_type, version_tag)?;
         let raw_value = crate::state::opimpl_getfield_gc_r(
             ctx.trace_ctx,
@@ -1502,7 +1545,17 @@ pub(crate) fn try_walker_specialize_load_attr<Sym: WalkSym>(
                         .unwrap_or(pyre_object::PY_NULL),
                 );
             }
-            let tuple = crate::helpers::emit_object_tuple_inline(ctx.trace_ctx, &items);
+            // Emit the representation `newtuple` picks, settled above.  Emitting
+            // the array-backed shape for an arity the runtime specialises leaves
+            // the trace disagreeing with its own record-time concrete, and the
+            // `except <tuple>:` match fold — which dispatches on that concrete's
+            // layout — then guards for a shape this trace never builds, so the
+            // loop aborts instead of compiling.
+            let tuple = if args_specialised_oo {
+                crate::helpers::emit_specialised_tuple_oo_inline(ctx.trace_ctx, items[0], items[1])
+            } else {
+                crate::helpers::emit_object_tuple_inline(ctx.trace_ctx, &items)
+            };
             let concrete_tuple = pyre_object::w_tuple_new(concrete_items);
             ctx.trace_ctx.set_opref_concrete(
                 tuple,

--- a/pyre/pyre-object/src/unicodeobject.rs
+++ b/pyre/pyre-object/src/unicodeobject.rs
@@ -22,7 +22,7 @@ use crate::pyobject::*;
 /// Python string object.
 ///
 /// Layout:
-/// `[ob_type | w_class | value:*mut Wtf8Buf | byte_len | len | w_slots]`
+/// `[ob_type | w_class | value:*mut Wtf8Buf | byte_len | len | w_slots | hash]`
 /// `byte_len` is the WTF-8 byte count (RPython STR `rstr.py:1226
 /// Array(Char)` parity — `llmodel.py:667 bh_strlen` reads this).
 /// `len` is the codepoint count (RPython UNICODE parity —
@@ -51,6 +51,12 @@ pub struct W_UnicodeObject {
     /// walker's `is_managed_heap_object` edge guard skips, the same split its
     /// `value` buffer already makes.
     pub index_storage: *mut crate::rutf8::Utf8IndexStorage,
+    /// Memoized digest, `rstr.py:395-412 LLHelpers.ll_strhash`.  RPython
+    /// keeps the hash in the string itself and recomputes only while the
+    /// slot still reads zero (`jit.conditional_call_elidable(s.hash, ...)`);
+    /// `W_UnicodeObject.hash_w` reaches it through `compute_hash(self._utf8)`,
+    /// so a wrapped string digests its bytes at most once.
+    pub hash: i64,
 }
 
 /// Field offset of `value` within `W_UnicodeObject`, for JIT field access.
@@ -154,6 +160,7 @@ pub fn w_str_new(s: &str) -> PyObjectRef {
         len: char_len,
         w_slots: PY_NULL,
         index_storage: std::ptr::null_mut(),
+        hash: 0,
     }) as PyObjectRef
 }
 
@@ -191,6 +198,7 @@ pub fn w_str_from_wtf8(value: Wtf8Buf) -> PyObjectRef {
         len: char_len,
         w_slots: PY_NULL,
         index_storage: std::ptr::null_mut(),
+        hash: 0,
     }) as PyObjectRef
 }
 
@@ -223,6 +231,7 @@ pub fn w_str_from_wtf8_managed(value: Wtf8Buf) -> PyObjectRef {
         len: char_len,
         w_slots: PY_NULL,
         index_storage: std::ptr::null_mut(),
+        hash: 0,
     };
     let raw = crate::gc_hook::try_gc_alloc_stable_raw(W_UNICODE_GC_TYPE_ID, W_UNICODE_OBJECT_SIZE);
     if raw.is_null() {
@@ -305,6 +314,7 @@ pub fn w_str_from_wtf8_immortal(value: Wtf8Buf) -> PyObjectRef {
         len: char_len,
         w_slots: PY_NULL,
         index_storage: std::ptr::null_mut(),
+        hash: 0,
     }) as PyObjectRef
 }
 
@@ -330,6 +340,7 @@ pub fn w_str_subclass_from_wtf8(value: Wtf8Buf, w_class: PyObjectRef) -> PyObjec
         len: char_len,
         w_slots: PY_NULL,
         index_storage: std::ptr::null_mut(),
+        hash: 0,
     };
     let raw = crate::gc_hook::try_gc_alloc_stable_raw(W_UNICODE_GC_TYPE_ID, W_UNICODE_OBJECT_SIZE);
     let obj = if raw.is_null() {
@@ -459,6 +470,29 @@ pub unsafe fn w_str_get_wtf8(obj: PyObjectRef) -> &'static Wtf8 {
         let str_obj = obj as *const W_UnicodeObject;
         &*(*str_obj).value
     }
+}
+
+/// `rstr.py:395-400 ll_strhash` — the memoized digest, or zero while it has
+/// not been computed yet ("our malloc initializes the memory to zero, so we
+/// use zero as the value of a string whose hash is not computed yet").
+///
+/// # Safety
+/// `obj` must be a `W_UnicodeObject`.
+#[inline]
+pub unsafe fn w_str_get_hash(obj: PyObjectRef) -> i64 {
+    unsafe { (*(obj as *const W_UnicodeObject)).hash }
+}
+
+/// Publish a computed digest into the memo slot, `rstr.py:411-412`.  Racing
+/// writers store the same value, so no ordering is required; upstream
+/// reaches the field through `conditional_call_elidable`, which likewise
+/// tolerates a repeated computation.
+///
+/// # Safety
+/// `obj` must be a `W_UnicodeObject`.
+#[inline]
+pub unsafe fn w_str_set_hash(obj: PyObjectRef, hash: i64) {
+    unsafe { (*(obj as *mut W_UnicodeObject)).hash = hash }
 }
 
 /// Borrow a known W_UnicodeObject as `&str`, or `None` when it carries a lone


### PR DESCRIPTION
## What

`ExecutionContext::gettopframe_nohidden` and `getnextframe_nohidden` called `force_frame` on every frame they walked. `executioncontext.py` has no force in either walk — upstream emits `jit_force_virtualizable` per redirected **field access** (`rvirtualizable.hook_access_field`) and `jtransform` deletes it again in every graph the codewriter looks inside, so only graphs the JIT cannot see keep the call.

Forcing inside the walk escaped the traced virtualizable for every frame-walking helper, so any residual call that reached one raised `VableEscapedDuringResidualCall`. Concretely: `~bool` emits a DeprecationWarning, `_warnings::setup_context` walks the frame chain, and that walk aborted the trace — so a loop containing `~bool` never compiled at all.

Both walks are now force-free and the **consumers** force instead: `sys._getframe`, `sys._current_frames`, `PyFrame::fget_f_back`, and the coroutine-origin walk.

## Follow-on: `last_instr`

Nothing else kept the live frame's `last_instr` current once the walk stopped forcing, and that field has two incompatible required values at a residual-call site:

| meaning | value | written by |
|---|---|---|
| executing opcode (line reporting) | `vstack_cur_pypc` | `eval.rs frame.last_instr = pc`; the existing `mirror_vable_static_to_boxes` box half |
| resume coordinate (replay) | `resume_py_pc - 1` | `flush_walk_end_state_to_frame_inner`, with `ActiveFrameEscapeGuard` passing that same pc |

Exactly off by one, always. The old code never hit the conflict because forcing during the walk always ended in `ABORT_ESCAPE`, so the resume coordinate never had to survive the residual.

- **Compiled code**: a `SetfieldGc` of `last_instr` recorded from the *same constant* as the box mirror, so shadow and heap cannot disagree.
- **Recording walk**: `LiveLastInstrGuard` publishes the executing pc for the residual's duration and restores it afterwards. It targets `INLINE_CONCRETE_FRAME` when one is set — inside an inline sub-walk `vstack_cur_pypc` is in the *callee's* code, and writing it onto the walk's virtualizable strands that frame's replay on a stack depth it never had.

Without this, `~bool` in a traced loop reported **two** DeprecationWarnings (one at the `~` statement, one at the loop-entry line) where CPython reports one.

## Lift fixes

Four interpreter functions are marked `dont_look_inside` with their addresses registered in `jit_fnaddr`: `builtins::lookup_exc_class` (reads the `EXC_CLASS_REGISTRY` static), `host_seam::emit_stdout` / `emit_stderr` (host stdio handles), and a new `descroperation::bool_invert_deprecation_text` accessor wrapping a `PrebuiltText` static. Each static failed the front-end lift and, transitively, the lift of every caller — which is how `warn::warn_category_w` and `descroperation::invert` lost their jitcode.

Also ports `vable_after_residual_call`'s `debug_print` under `PYRE_FBW_DEBUG_ABORT`, naming the callee that forced the virtualizable.

## Review follow-ups

Two fixes from the review of this branch:

- `LiveLastInstrGuard` now **saves and restores** the previous publication instead of clearing it on drop. The guards in `residual_call.rs` nest — a residual runs user code that records a nested walk whose own residual enters the guard again — so clearing on the inner drop hid a still-live outer publication. Every sibling (`InlineConcreteFrameGuard.previous`, `ResidualFrameChainGuard.previous_published`, `ActiveFrameEscapeGuard.prev`) already saved-and-restored; being the odd one out was the tell. The corpus does not cover the nesting, so this was latent rather than reproducible.
- The executing-pc publish is now **skipped inside an inline sub-walk**. `mirror_vable_static_to_boxes` and `vable_setfield_descr` both named `standard_virtualizable_box()` — the walk's virtualizable — while using `vstack_cur_pypc`, which inside a sub-walk indexes the *callee's* code. Compiled code therefore stamped a foreign pc onto the caller's frame and `offset2lineno` resolved it against the caller's code object. `LiveLastInstrGuard` already retargeted the *concrete* store to `INLINE_CONCRETE_FRAME`; the IR emission did not. Both halves are now gated on the same predicate.

Verifying this area needs care — two natural-looking instruments are unsound. The warning dedup registry keys on lineno, so 99 999 compiled iterations that all report the same wrong line show up as **one** extra histogram entry, indistinguishable from a single stray recording event; and `warnings.simplefilter("always")` makes `show_warning` do stderr I/O every iteration, which stops the loop compiling (`Total # of loops: 0`) so the measurement is of the interpreter. The instrument that works is a counting `showwarning` with no I/O, plus confirming `Total # of loops > 0`.

## Numbers

`synth/arith_int_bool`: **11.6s → 2.65s** dynasm, 2.77s cranelift (cpython 1.00s, pypy 0.03s — PyPy has no `~bool` deprecation at all, so this bench's pypy ratio is structurally unwinnable; CPython is the honest comparison).

Warning attribution matches CPython exactly in the **flat** shape on both backends (`[(19, 100000)]`). It does **not** match when the warning is raised from a JIT-inlined callee: the frame chain has no callee frame, so the warning is attributed to the caller. This divergence is known and deliberately left here.

Closing it is not a matter of forcing in the consumer. That was built and measured: correct (`[(14,5),(15,100005)]` vs CPython `[(15,100000)]`) but 15.97/17.17/15.24 s against 4.61/6.81/7.05 s without — i.e. straight back to the regression this PR removes, because the force lands as a live may-force residual inside the (still lifted) `setup_context`, escapes the virtualizable and aborts every trace. It is "correct" only because nothing compiles. Upstream's `setup_context` jitcode carries **zero** force ops; forcing there is a property of the call boundary, not of the consumer.

The orthodox fix is to wire the vref producer — emit `enter`/`leave` (`f_backref` + `topframeref = virtual_ref(callee)`) at the inline push/pop, as upstream gets for free by tracing `executioncontext.enter`. Forcing a **vref** is a graceful `VIRTUAL_REF_FINISH`, not the `ABORT_ESCAPE` that forcing the **virtualizable** causes. That work is an epic with its own prerequisites (walker-path `_do_jit_force_virtual`, the vref residual-call bracket, `ResidualFrameChainGuard` vref-awareness, `EC_DESCR_GROUP` extension, scoped callee `last_instr`) and a blast radius covering the whole inline-call corpus, so it is deliberately out of scope for this PR.

check.py: **328/328 on both backends** (dynasm and cranelift), measured at `769da5c8` on base `2580479628` with the box quiet (load 13.1). The branch has since been rebased onto `512e5cb32b`; the files this PR touches are byte-identical across that rebase, but the base moved, so CI is the authority for the current head.

— *commented by Claude*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved garbage-collection object detection and forwarding behavior across supported backends.
  * Fixed frame inspection and traceback behavior when execution is optimized or inlined.
  * Corrected function-call and exception-result handling in translated code.
  * Improved warning attribution and initialization reliability.
  * Fixed hashing behavior, including cached string hashes and empty-value compatibility.

* **Performance**
  * Reduced temporary allocations during object creation, hashing, and warning processing.
  * Improved optimized handling of tuples, exception arguments, and residual calls.

* **Compatibility**
  * Strengthened inline handling for positional-only and star-argument calls.
  * Improved specialized tuple construction for exception arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
