### PR TITLE
jit: stop a permanent abort re-firing from a bridge guard; close the production blackhole's dispatch gap

### DIFF
--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -2469,7 +2469,7 @@ pub fn run_forever_with_portal(
     }
 }
 
-/// blackhole.py:1798 convert_and_run_from_pyjitpl
+/// blackhole.py:1799 convert_and_run_from_pyjitpl
 ///
 /// Get a chain of blackhole interpreters and fill them by copying
 /// 'metainterp.framestack'.
@@ -3300,6 +3300,51 @@ mod tests {
             builder.setup_insns(&entries);
             wire_bhimpl_handlers(&mut builder);
             builder
+        }
+
+        /// `test_blackhole.py:115-143 test_convert_and_run_from_pyjitpl`.
+        ///
+        /// The fixture puts an illegal instruction at pc 0 and gives the
+        /// MIFrame `pc = 1`, so the chain must start at exactly `frame.pc`
+        /// and can never reach anything before it.  pyre's assembler emits
+        /// only real opcodes, so the illegal instruction is an `int_mul`
+        /// left out of the dispatch table: its slot holds
+        /// `unwired_handler_placeholder`, which panics the same way
+        /// `\xFF` does upstream.  It also writes `r0`, so a chain that
+        /// started at 0 would return 1602 rather than panicking silently.
+        #[test]
+        fn test_convert_and_run_from_pyjitpl_starts_at_frame_pc() {
+            use crate::pyjitpl::{MIFrame, MIFrameStack};
+            use majit_translate::insns;
+
+            let mut b = JitCodeBuilder::default();
+            // pc 0 — never executed.
+            b.record_binop_i(0, OpCode::IntMul, 0, 0);
+            let second = b.current_pos();
+            b.record_binop_i(2, OpCode::IntAdd, 0, 1);
+            b.int_return(2);
+            let jitcode = std::sync::Arc::new(b.finish());
+
+            // test_blackhole.py:124-125 `pc = 1`, `registers_i = [40, 2, None]`.
+            let mut frame = MIFrame::new(jitcode, second);
+            frame.int_values[0] = Some(40);
+            frame.int_values[1] = Some(2);
+            let framestack = MIFrameStack::new(frame);
+
+            let mut builder = BlackholeInterpBuilder::new();
+            let mut entries: indexmap::IndexMap<String, u8> = indexmap::IndexMap::new();
+            entries.insert("int_add/ii>i".to_string(), insns::BC_INT_ADD);
+            entries.insert("int_return/i".to_string(), insns::BC_INT_RETURN);
+            builder.setup_insns(&entries);
+            wire_bhimpl_handlers(&mut builder);
+
+            // test_blackhole.py:141-143 `DoneWithThisFrameInt`, `result == 42`.
+            let outcome =
+                convert_and_run_from_pyjitpl(&mut builder, &framestack, 0, false, None, None);
+            assert_eq!(
+                outcome,
+                crate::jitexc::JitException::DoneWithThisFrameInt(42)
+            );
         }
 
         #[test]

--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -7848,6 +7848,33 @@ pub fn build_inline_call_only_bh_builder() -> BlackholeInterpBuilder {
         "int_mul_jump_if_ovf/Lii>i".to_string(),
         majit_translate::insns::BC_INT_MUL_JUMP_IF_OVF,
     );
+    // The three remaining opnames the build-time `pipeline.insns` records as
+    // actually emitted (`build_emitted_insns()`) that this curated set did not
+    // cover.  Upstream never has this gap: `setup_insns(asm.insns)`
+    // (`blackhole.py:58-59`) registers exactly what the assembler emitted, so
+    // its table spans the reachable bytecode universe by construction.  Here a
+    // missing entry is a live `dispatch_step` unwired-opcode panic that fires
+    // only once a forward resume happens to land on the byte.
+    //
+    // All three emit canonical operands matching their wired decoders — a
+    // 1-byte register per `r`/`i`, a 2-byte little-endian descr index per `d`
+    // (`assembler.rs` `OpKind::{ArrayLen, NewWithVtable}` and the generic
+    // `UnaryOp` path vs `handler_arraylen_gc`, `handler_new_with_vtable`,
+    // `bhhandler_r_i!`) — and `arraylen_gc` / `new_with_vtable` read
+    // `bh.cpu`, which this builder sets above.
+    for (key, byte) in [
+        ("arraylen_gc/rd>i", majit_translate::insns::BC_ARRAYLEN_GC),
+        (
+            "cast_ptr_to_int/r>i",
+            majit_translate::insns::BC_CAST_PTR_TO_INT,
+        ),
+        (
+            "new_with_vtable/d>r",
+            majit_translate::insns::BC_NEW_WITH_VTABLE,
+        ),
+    ] {
+        insns.insert(key.to_string(), byte);
+    }
     builder.setup_insns(&insns);
     // `setup_insns` already derives `op_live` and `op_catch_exception`
     // from the registered canonical subset above.  `rvmprof_code/ii` is

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -2977,8 +2977,8 @@ impl<S: JitState> JitDriver<S> {
                 // call's eventual exception is preserved
                 // (`pyjitpl.py:3391-3393` comment).  Pyre wires only
                 // the accounting half here; the `convert_and_run_from_pyjitpl`
-                // helper exists at `blackhole.rs:3011` (port of
-                // `blackhole.py:1798`) but is not yet invoked from
+                // helper exists in `blackhole.rs` (port of
+                // `blackhole.py:1799`) but is not yet invoked from
                 // this consumer, so `stb.raising_exception` is
                 // currently a no-op and the helper-side exception is
                 // dropped at the abort boundary.  Full cancel-tracing

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -473,7 +473,7 @@ pub struct TraceCtx {
     /// the consumer mirrors only `pyjitpl.py:2491` `aborted_tracing(reason)`
     /// accounting.  `stb.raising_exception` is preserved on this struct
     /// but the `convert_and_run_from_pyjitpl` invocation
-    /// (`blackhole.rs:3011`, ported from `blackhole.py:1798`) is NOT yet
+    /// (in `blackhole.rs`, ported from `blackhole.py:1799`) is NOT yet
     /// wired through this path; the helper-side exception raised during
     /// the residual call is therefore silently dropped at the abort
     /// boundary rather than re-raised via blackhole as RPython does.

--- a/pyre/bench/spectral_norm.py
+++ b/pyre/bench/spectral_norm.py
@@ -36,7 +36,12 @@ v = [0.0] * n
 tmp = [0.0] * n
 
 i = 0
-while i < 10:
+# 30 rather than the reference 10: check.py gates on execution-only time
+# (run minus the measured empty-program startup), and at 10 the pypy run is
+# 0.026s against a 0.011s startup, so the denominator is the residue of two
+# similar measurements and the ratio stops tracking pyre. 30 puts pypy at
+# 0.077s, ~7x its startup.
+while i < 30:
     multiply_AtAv(n, u, v, tmp)
     multiply_AtAv(n, v, u, tmp)
     i = i + 1

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -1747,17 +1747,26 @@ def main():
         # we run them so the wasm leak/perf work can be driven down one bench
         # at a time, accepting the timeout state until each is fixed.
 
+        # Gate values are set from the gate's OWN metric — user-CPU minus the
+        # measured empty-program startup, min-of-5 interleaved — at ~2.5x the
+        # measured ratio, so a runner 2.5x slower than an idle local box still
+        # passes. A gate is only tightened when its baseline is healthy
+        # (baseline exec >= ~5x that runtime's startup); where it is not, the
+        # workload is sized up instead (see spectral_norm.py). Benches with
+        # under ~3x headroom are deliberately left alone: nested_loop,
+        # raise_catch, int_loop and fib_recursive-vs-cpython are the known
+        # slow-runner flakes.
         #             name              script                          timeout  d_vs_cp  d_vs_py  c_vs_cp  c_vs_py
         chk.run_bench("int_loop",       f"{B}/int_loop.py",             5,       None,    2,       None,    2)
         chk.run_bench("float_loop",     f"{B}/float_loop.py",           5,       None,    1.5,     None,    1.5)
         chk.run_bench("fib_loop",       f"{B}/fib_loop.py",             5,       2,       3,       2,       3)
         chk.run_bench("inline_helper",  f"{B}/inline_helper.py",        5,       None,    1.5,     None,    1.5)
-        chk.run_bench("fib_recursive",  f"{B}/fib_recursive.py",        5,       2,       13,      2,       13)
+        chk.run_bench("fib_recursive",  f"{B}/fib_recursive.py",        5,       2,       6,       2,       8)
         chk.run_bench("nested_loop",    f"{B}/nested_loop.py",          5,       None,    2,       None,    3)
         chk.run_bench("raise_catch",    f"{B}/raise_catch_loop.py",     5,       None,    1.5,     None,    2.5)
-        chk.run_bench("spectral_norm",  f"{B}/spectral_norm.py",        5,       2,       7,       2,       7)
-        chk.run_bench("nbody",          f"{B}/nbody.py",               10,       1,       5,       1,       5,    wasm_float_tol=True)
-        chk.run_bench("fannkuch",       f"{B}/fannkuch.py",            30,       1,       5,       2,       None)
+        chk.run_bench("spectral_norm",  f"{B}/spectral_norm.py",       15,       1,       5,       1,       5)
+        chk.run_bench("nbody",          f"{B}/nbody.py",               10,       0.5,     5,       1,       5,    wasm_float_tol=True)
+        chk.run_bench("fannkuch",       f"{B}/fannkuch.py",            30,       1,       5,       2,       15)
         # Skipped on wasm: the guard times calls with `time.perf_counter()`, and
         # the wasm guest has no `time` module (import fails before any output),
         # so the guard is native-JIT-backend only.

--- a/pyre/gate-triage.md
+++ b/pyre/gate-triage.md
@@ -428,6 +428,16 @@ nested inside `single_frame_blackhole_resume_enabled()`, so it also requires
 `_BLACKHOLE_RESUME` to stay ON.  The pre-existing `[s2-gate]` eprintln (under
 `PYRE_FBW_DEBUG_ABORT`) already reports `inline_subwalk` at that site.
 
+**A second coverage benchmark, 2026-07-27.**
+`synth/getframe_inline_subwalk_multiframe` (#798) reaches the latch with
+`inline_subwalk=true` and drives `build_multi_frame_miframe` — under
+`PYRE_FBW_MULTIFRAME=1 PYRE_FBW_DEBUG_ABORT=1` it prints 5 `[s2-gate]
+inline_subwalk` lines each followed by `[s2-build-decline] BUILT multi-frame
+depth=2`.  One `sys._getframe(1)` level does not get there; the chain needs a
+residual level under the walked frame and an inlined level under that, so the
+force has to reach two frames up.  Per-frame vable binding, outer-locals
+materialization, and the `jit.virtual_ref` emit are therefore validatable now.
+
 ## §2 — Not gates (11): Rust identifiers, not env vars
 
 The audit regex matched non-env identifiers. These are real code; **do not

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -4638,10 +4638,10 @@ struct InlineParentBlackhole {
     /// return value through `call_result_reg()` before this caller runs.
     resume_pc: usize,
     int_values: Vec<(usize, i64)>,
-    /// `(register color, semantic slot, value)`.  Keeping both indices makes
-    /// the semantic Ref shadow's source explicit while the MIFrame consumer
-    /// restores the color-indexed bank.
-    ref_values: Vec<(usize, usize, pyre_object::PyObjectRef)>,
+    /// `(register color, value)`, read out of the color-indexed
+    /// `concrete_registers_r` shadow and restored into the MIFrame's
+    /// color-indexed Ref bank.
+    ref_values: Vec<(usize, pyre_object::PyObjectRef)>,
     /// Float values have no concrete shadow bank; retain their OpRefs and
     /// resolve them at force time while the trace context is still live.
     float_values: Vec<(usize, OpRef)>,
@@ -5347,7 +5347,7 @@ pub unsafe fn fbw_store_journal_root_walker_area(
                     visitor(unsafe { &mut *(value as *mut pyre_object::PyObjectRef).cast() });
                 }
                 if let Some(blackhole) = parent.blackhole.as_mut() {
-                    for (_color, _semantic_slot, value) in blackhole.ref_values.iter_mut() {
+                    for (_color, value) in blackhole.ref_values.iter_mut() {
                         visitor(unsafe { &mut *(value as *mut pyre_object::PyObjectRef).cast() });
                     }
                 }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -5932,10 +5932,18 @@ pub(crate) unsafe fn resolve_inlinable_callee(
         if raw.is_null() {
             return None;
         }
-        // Calling a generator / coroutine / async-generator function does NOT
-        // run its body — it builds the iterator and returns.  Inlining the
-        // body at the call site walks code the call never reaches, so the
-        // attempt can only end in an abort that discards the whole trace.
+        // Calling a generator / coroutine / async-generator function does not
+        // run its body — it builds a suspended frame object and returns it.
+        // Its jitcode therefore starts at `RETURN_GENERATOR`, which the
+        // codewriter lowers to an `abort_permanent` marker: inlining the body
+        // at the call site walks code the call never reaches, so the attempt
+        // can only end in an abort that discards the whole trace.  Decline to
+        // the residual call instead — the creation is an ordinary allocating
+        // call the walk steps over, and the body's suspension never enters the
+        // trace.  `generator.py:614-634` `should_not_inline` (consumed at
+        // `:63`) is upstream's decision point for the same boundary; it governs
+        // the *body* at `send_ex`, which is a separate question from the
+        // creation call.
         if pyre_interpreter::pyframe::code_flags_make_generator((*raw).flags) {
             return None;
         }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -171,10 +171,16 @@ fn build_single_frame_miframe<Sym: WalkSym>(
     resume_pc: usize,
     lastop_result: Option<(char, usize, i64)>,
 ) -> Option<majit_metainterp::MIFrame> {
-    let live = crate::state::frame_liveness_reg_indices_by_bank_at(
+    // An MIFrame is only representable at a `-live-` anchored startpoint: the
+    // blackhole reads its registers straight out of the copied banks, so a
+    // coordinate whose live set cannot be decoded must decline here rather
+    // than yield a frame with every register unset.  All callers pass a
+    // post-call `next_pc` today, which always resolves; the precondition is
+    // what keeps that true as the pc domain widens.
+    let live = crate::state::try_frame_liveness_reg_indices_by_bank_at_with_jitcode_pc(
         i32::try_from(jitcode.index()).ok()?,
         i32::try_from(resume_pc).ok()?,
-    );
+    )?;
     let mut miframe = majit_metainterp::MIFrame::new(jitcode.clone(), resume_pc);
 
     // pyjitpl.py make_result_of_lastop: the residual returned before its
@@ -272,7 +278,7 @@ fn build_multi_frame_miframe<Sym: WalkSym>(
         for &(color, value) in &concrete.int_values {
             *miframe.int_values.get_mut(color)? = Some(value);
         }
-        for &(color, _semantic_slot, value) in &concrete.ref_values {
+        for &(color, value) in &concrete.ref_values {
             *miframe.ref_values.get_mut(color)? = Some(value as i64);
         }
         for &(color, opref) in &concrete.float_values {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/resume_snapshot.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/resume_snapshot.rs
@@ -1250,19 +1250,6 @@ fn capture_inline_parent_blackhole<Sym: WalkSym>(
         jitcode_index as i32,
         i32::try_from(call.next_pc).ok()?,
     );
-    let depth = pjc
-        .depth_trivia_for_jitcode_pc(call.next_pc)
-        .or_else(|| pjc.depth_for_jitcode_pc_pred(call.next_pc))
-        .unwrap_or(0) as usize;
-    let nlocals = (!pjc.code_ptr.is_null())
-        .then(|| unsafe { &*pjc.code_ptr }.varnames.len())
-        .unwrap_or(0);
-    let pcdep = pjc
-        .pcdep_trivia_for_jitcode_pc(call.next_pc)
-        .map(ToOwned::to_owned)
-        .or_else(|| pjc.pcdep_for_jitcode_pc(call.next_pc))
-        .unwrap_or_default();
-
     let mut int_values = Vec::with_capacity(live.int.len());
     for &color in &live.int {
         let color = color as usize;
@@ -1281,18 +1268,19 @@ fn capture_inline_parent_blackhole<Sym: WalkSym>(
         if result_bank == 'r' && result_color == Some(color) {
             continue;
         }
-        let semantic_slot =
-            crate::state::semantic_ref_slot_for_reg_color(nlocals, depth, &pcdep, color)
-                .unwrap_or(color);
-        let ConcreteValue::Ref(value) = ctx
-            .concrete_registers_r
-            .get(semantic_slot)
-            .copied()
-            .or_else(|| ctx.concrete_registers_r.get(color).copied())?
-        else {
+        // `concrete_registers_r` is the color-indexed shadow of `registers_r`:
+        // it is allocated to `num_regs_r + constants_r.len()` and every walker
+        // handler writes `concrete_registers_r[dst]` in lock-step with
+        // `registers_r[dst]`.  `semantic_ref_slot_for_reg_color` maps a color
+        // to a `locals_cells_stack_w` slot, which is what
+        // `restore_guard_failure_values` needs to call `set_local_at` /
+        // `set_stack_at` on a concrete PyFrame — a different index space.
+        // Reading the shadow through it stamped whatever register happened to
+        // live at the slot's number.
+        let ConcreteValue::Ref(value) = ctx.concrete_registers_r.get(color).copied()? else {
             return None;
         };
-        ref_values.push((color, semantic_slot, value));
+        ref_values.push((color, value));
     }
 
     let mut float_values = Vec::with_capacity(live.float.len());

--- a/pyre/pyre-jit-trace/src/jitcode_runtime.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_runtime.rs
@@ -1384,6 +1384,94 @@ mod tests {
         }
     }
 
+    /// Coverage of the *production* builder, which is not the default one.
+    ///
+    /// `build_pyre_production_bh_builder` delegates to
+    /// `build_inline_call_only_bh_builder`, which registers only the shapes
+    /// with an explicit handler contract, so an emitted byte outside that
+    /// surface reaches `dispatch_step`'s unwired-opcode panic.  Upstream has
+    /// no analogue: `setup_insns` (blackhole.py:66) resolves every opname in
+    /// `asm.insns` eagerly, so its dispatch table covers the whole emitted
+    /// bytecode universe by construction.
+    ///
+    /// This publishes the gap so it is a reviewable number rather than a
+    /// runtime surprise: every opname the codewriter can emit that the
+    /// production blackhole cannot execute.
+    #[test]
+    fn production_bh_builder_coverage_gap_snapshot() {
+        let builder = build_pyre_production_bh_builder();
+        let mut gap: Vec<String> = insns_opname_to_byte()
+            .iter()
+            .filter(|(_key, byte)| {
+                builder
+                    ._insns
+                    .get(**byte as usize)
+                    .is_none_or(|name| name.is_empty())
+            })
+            .map(|(key, _)| key.clone())
+            .collect();
+        gap.sort();
+        let mut unwired: Vec<String> = builder
+            .unwired_opnames()
+            .into_iter()
+            .map(|s| s.to_string())
+            .collect();
+        unwired.sort();
+        assert_eq!(
+            unwired,
+            Vec::<String>::new(),
+            "production builder registered an opname without a handler",
+        );
+        // Every entry below has a `bhimpl_*` handler — `build_default_bh_builder`
+        // wires all 208 opnames and its unwired set is empty (see the snapshot
+        // test right after this one).  The gap is registration, not
+        // implementation: `build_inline_call_only_bh_builder` opts each family
+        // in by hand.  Note `rvmprof_code/ii`, one of the three well-known
+        // opcodes `setup_insns` resolves (blackhole.py:72-74), so the
+        // production builder's `op_rvmprof_code` stays `u8::MAX`.
+        let expected = [
+            "abort/>r",
+            "arraylen_gc/rd>i",
+            "assert_not_none/r",
+            "cast_float_to_int/f>i",
+            "cast_int_to_float/i>f",
+            "cast_int_to_ptr/i>r",
+            "cast_ptr_to_int/r>i",
+            "check_neg_index/rid>i",
+            "conditional_call_ir_v/iiIRd",
+            "conditional_call_value_ir_i/iiIRd>i",
+            "conditional_call_value_ir_r/riIRd>r",
+            "convert_float_bytes_to_longlong/f>i",
+            "convert_longlong_bytes_to_float/i>f",
+            "gc_load_indexed_f/riiii>f",
+            "gc_load_indexed_i/riiii>i",
+            "getinteriorfield_gc_f/rid>f",
+            "getinteriorfield_gc_i/rid>i",
+            "getinteriorfield_gc_r/rid>r",
+            "getlistitem_gc_f/ridd>f",
+            "getlistitem_gc_i/ridd>i",
+            "getlistitem_gc_r/ridd>r",
+            "int_between/iii>i",
+            "new/d>r",
+            "new_array/id>r",
+            "new_with_vtable/d>r",
+            "newlist/idddd>r",
+            "newlist_clear/idddd>r",
+            "newlist_hint/idddd>r",
+            "record_exact_class/ri",
+            "record_known_result_i_ir_v/iiIRd",
+            "record_known_result_r_ir_v/riIRd",
+            "record_quasiimmut_field/rdd",
+            "rvmprof_code/ii",
+            "vtable_method_ptr/rd>i",
+        ];
+        assert_eq!(
+            gap, expected,
+            "production blackhole coverage gap drifted; a jitcode emitting any \
+             opname in this set reaches `dispatch_step`'s unwired-opcode panic",
+        );
+    }
+
     #[test]
     fn default_bh_builder_unwired_set_matches_task_85_snapshot() {
         // Lock-in: every generated opname must be wired by

--- a/pyre/pyre-jit-trace/src/jitcode_runtime.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_runtime.rs
@@ -276,16 +276,35 @@ pub fn list_append_jitcode() -> Option<Arc<JitCode>> {
 /// the equivalent `Assembler.insns` object on the translated staticdata /
 /// blackhole-builder path; pyre's `LazyLock` is the binary-embedded form
 /// of that same single translated table.
-static INSNS_OPNAME_TO_BYTE: LazyLock<indexmap::IndexMap<String, u8>> = LazyLock::new(|| {
+/// Build-time `pipeline.insns` exactly as the assembler serialised it —
+/// the opnames `make_jitcodes` actually emitted into this binary's
+/// jitcodes, with no canonical-universe overlay.
+///
+/// This is the direct analogue of upstream's `asm.insns`, which is what
+/// `BlackholeInterpBuilder.__init__` hands to `setup_insns`
+/// (`blackhole.py:58-59`): upstream registers exactly what was emitted,
+/// so its dispatch table covers the whole reachable bytecode universe by
+/// construction.  Any byte in this map that the production blackhole
+/// builder leaves unregistered is a byte a real jitcode can carry and the
+/// blackhole cannot execute — see
+/// `production_bh_builder_covers_every_build_emitted_opname`.
+static BUILD_EMITTED_INSNS: LazyLock<indexmap::IndexMap<String, u8>> = LazyLock::new(|| {
     const BYTES: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/insns.bin"));
-    let mut table: indexmap::IndexMap<String, u8> =
-        bincode::deserialize(BYTES).unwrap_or_else(|e| {
-            panic!(
-                "pyre-jit-trace: failed to deserialize insns.bin \
-                     ({} bytes): {e}",
-                BYTES.len(),
-            )
-        });
+    bincode::deserialize(BYTES).unwrap_or_else(|e| {
+        panic!(
+            "pyre-jit-trace: failed to deserialize insns.bin ({} bytes): {e}",
+            BYTES.len(),
+        )
+    })
+});
+
+/// The build-emitted opname → byte table (upstream `asm.insns`).
+pub fn build_emitted_insns() -> &'static indexmap::IndexMap<String, u8> {
+    &BUILD_EMITTED_INSNS
+}
+
+static INSNS_OPNAME_TO_BYTE: LazyLock<indexmap::IndexMap<String, u8>> = LazyLock::new(|| {
+    let mut table = BUILD_EMITTED_INSNS.clone();
     // Overlay the canonical `wellknown_bh_insns` and pyre-only
     // `pyre_extension_insns` keys so the runtime table covers every
     // opname a `BlackholeInterpBuilder` could be asked to dispatch.
@@ -1387,20 +1406,28 @@ mod tests {
     /// Coverage of the *production* builder, which is not the default one.
     ///
     /// `build_pyre_production_bh_builder` delegates to
-    /// `build_inline_call_only_bh_builder`, which registers only the shapes
-    /// with an explicit handler contract, so an emitted byte outside that
-    /// surface reaches `dispatch_step`'s unwired-opcode panic.  Upstream has
-    /// no analogue: `setup_insns` (blackhole.py:66) resolves every opname in
-    /// `asm.insns` eagerly, so its dispatch table covers the whole emitted
+    /// `build_inline_call_only_bh_builder`, which hand-curates its registered
+    /// set family by family, so an emitted byte outside that surface reaches
+    /// `dispatch_step`'s unwired-opcode panic — and only once a forward resume
+    /// happens to land on it.  Upstream cannot have this failure mode:
+    /// `setup_insns(asm.insns)` (`blackhole.py:58-59`, :66) resolves every
+    /// opname the assembler emitted, so its dispatch table spans the reachable
     /// bytecode universe by construction.
     ///
-    /// This publishes the gap so it is a reviewable number rather than a
-    /// runtime surprise: every opname the codewriter can emit that the
-    /// production blackhole cannot execute.
+    /// This is the structural form of that guarantee: `build_emitted_insns()`
+    /// IS pyre's `asm.insns` — the serialised build-time `pipeline.insns`,
+    /// before the canonical-universe overlay — so every key in it names a byte
+    /// a real jitcode in this binary can carry.  Each must be dispatchable.
+    ///
+    /// Deliberately NOT asserted over `insns_opname_to_byte()`: that map
+    /// additionally carries the `wellknown_bh_insns` / `pyre_extension_insns`
+    /// overlay, i.e. canonical opnames this build never emitted. Their bytes
+    /// cannot appear in any jitcode here, so leaving them unregistered is the
+    /// same state upstream is in — its `asm.insns` would not list them either.
     #[test]
-    fn production_bh_builder_coverage_gap_snapshot() {
+    fn production_bh_builder_covers_every_build_emitted_opname() {
         let builder = build_pyre_production_bh_builder();
-        let mut gap: Vec<String> = insns_opname_to_byte()
+        let mut unregistered: Vec<String> = build_emitted_insns()
             .iter()
             .filter(|(_key, byte)| {
                 builder
@@ -1410,7 +1437,16 @@ mod tests {
             })
             .map(|(key, _)| key.clone())
             .collect();
-        gap.sort();
+        unregistered.sort();
+        assert_eq!(
+            unregistered,
+            Vec::<String>::new(),
+            "the production blackhole cannot dispatch an opname this build's \
+             jitcodes actually contain; register it in \
+             `build_inline_call_only_bh_builder` (and confirm the emit-side \
+             operand shape matches the wired handler's decoder) rather than \
+             widening this assertion",
+        );
         let mut unwired: Vec<String> = builder
             .unwired_opnames()
             .into_iter()
@@ -1422,21 +1458,66 @@ mod tests {
             Vec::<String>::new(),
             "production builder registered an opname without a handler",
         );
-        // Every entry below has a `bhimpl_*` handler — `build_default_bh_builder`
-        // wires all 208 opnames and its unwired set is empty (see the snapshot
-        // test right after this one).  The gap is registration, not
-        // implementation: `build_inline_call_only_bh_builder` opts each family
-        // in by hand.  Note `rvmprof_code/ii`, one of the three well-known
-        // opcodes `setup_insns` resolves (blackhole.py:72-74), so the
-        // production builder's `op_rvmprof_code` stays `u8::MAX`.
+        // The curated list spells each byte as a `BC_*` constant by hand, so it
+        // can also drift the other way: a key bound to a byte the canonical
+        // table gives to a different opname would decode every occurrence as
+        // the wrong instruction.  `setup_insns` only rejects two keys claiming
+        // one byte *within* this builder, so nothing else catches it.
+        let mut mismatched: Vec<String> = Vec::new();
+        for (byte, key) in builder._insns.iter().enumerate() {
+            if key.is_empty() {
+                continue;
+            }
+            match insns_opname_to_byte().get(key) {
+                Some(&canonical) if canonical as usize == byte => {}
+                Some(&canonical) => mismatched.push(format!(
+                    "{key:?} registered at byte {byte}, canonical byte is {canonical}"
+                )),
+                None => mismatched.push(format!(
+                    "{key:?} registered at byte {byte} but is not a canonical opname"
+                )),
+            }
+        }
+        mismatched.sort();
+        assert_eq!(
+            mismatched,
+            Vec::<String>::new(),
+            "production builder's hand-spelled bytes disagree with the canonical \
+             opname table",
+        );
+    }
+
+    /// The overlay-only remainder: canonical opnames that exist in the
+    /// blackhole's key universe but that this build never emitted.
+    ///
+    /// Every entry has a `bhimpl_*` handler — `build_default_bh_builder` wires
+    /// all of them and its unwired set is empty (see the snapshot test below)
+    /// — so this is a registration gap, not an implementation gap, and it is
+    /// unreachable: no jitcode in this binary carries these bytes.  It is
+    /// pinned so that an opname MOVING out of this list (because the codewriter
+    /// started emitting it) shows up as a test failure to be classified,
+    /// instead of silently becoming a live `dispatch_step` panic.
+    #[test]
+    fn production_bh_builder_overlay_only_gap_snapshot() {
+        let builder = build_pyre_production_bh_builder();
+        let mut gap: Vec<String> = insns_opname_to_byte()
+            .iter()
+            .filter(|(key, byte)| {
+                !build_emitted_insns().contains_key(*key)
+                    && builder
+                        ._insns
+                        .get(**byte as usize)
+                        .is_none_or(|name| name.is_empty())
+            })
+            .map(|(key, _)| key.clone())
+            .collect();
+        gap.sort();
         let expected = [
             "abort/>r",
-            "arraylen_gc/rd>i",
             "assert_not_none/r",
             "cast_float_to_int/f>i",
             "cast_int_to_float/i>f",
             "cast_int_to_ptr/i>r",
-            "cast_ptr_to_int/r>i",
             "check_neg_index/rid>i",
             "conditional_call_ir_v/iiIRd",
             "conditional_call_value_ir_i/iiIRd>i",
@@ -1454,7 +1535,6 @@ mod tests {
             "int_between/iii>i",
             "new/d>r",
             "new_array/id>r",
-            "new_with_vtable/d>r",
             "newlist/idddd>r",
             "newlist_clear/idddd>r",
             "newlist_hint/idddd>r",
@@ -1467,8 +1547,9 @@ mod tests {
         ];
         assert_eq!(
             gap, expected,
-            "production blackhole coverage gap drifted; a jitcode emitting any \
-             opname in this set reaches `dispatch_step`'s unwired-opcode panic",
+            "the unreachable production-blackhole registration gap drifted; if \
+             an opname LEFT this list the codewriter now emits it, so it must \
+             be registered in `build_inline_call_only_bh_builder`",
         );
     }
 

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -1371,25 +1371,38 @@ pub fn frame_liveness_reg_indices_by_bank_at_with_jitcode_pc(
     jitcode_index: i32,
     carried_jitcode_pc: i32,
 ) -> FrameLivenessRegIndices {
+    try_frame_liveness_reg_indices_by_bank_at_with_jitcode_pc(jitcode_index, carried_jitcode_pc)
+        .unwrap_or_default()
+}
+
+/// The decline-reporting form of
+/// [`frame_liveness_reg_indices_by_bank_at_with_jitcode_pc`].
+///
+/// The three ways the decode can fail — unknown jitcode index, a coordinate
+/// that is not a `-live-` anchored startpoint, and a liveness offset past the
+/// end of the table — are indistinguishable from a genuinely empty live set in
+/// the `FrameLivenessRegIndices` return. A caller that materializes registers
+/// from the result (rather than merely reading them) needs to tell the two
+/// apart, or it builds a frame whose every register is unset and hands it on as
+/// if it were complete.
+pub fn try_frame_liveness_reg_indices_by_bank_at_with_jitcode_pc(
+    jitcode_index: i32,
+    carried_jitcode_pc: i32,
+) -> Option<FrameLivenessRegIndices> {
     ensure_finish_setup();
     METAINTERP_SD.with(|r| {
         let sd = r.borrow();
         let idx = jitcode_index as usize;
-        let Some(jc) = sd.jitcodes.get(idx) else {
-            return FrameLivenessRegIndices::default();
-        };
+        let jc = sd.jitcodes.get(idx)?;
         let payload = &jc.payload;
         // No Python-pc reconstruction is available here: an absent carried
-        // coordinate returns the empty result to its decline-aware caller.
-        let resolved_jit_pc: Option<usize> =
-            payload.resolve_resume_pc_with_jitcode_pc(carried_jitcode_pc, sd.op_live);
-        let Some(jit_pc) = resolved_jit_pc else {
-            return FrameLivenessRegIndices::default();
-        };
+        // coordinate declines.
+        let jit_pc: usize =
+            payload.resolve_resume_pc_with_jitcode_pc(carried_jitcode_pc, sd.op_live)?;
         let off = payload.jitcode.get_live_vars_info(jit_pc, sd.op_live);
         let all_liveness = &sd.liveness_info;
         if off + 2 >= all_liveness.len() {
-            return FrameLivenessRegIndices::default();
+            return None;
         }
         let length_i = all_liveness[off] as u32;
         let length_r = all_liveness[off + 1] as u32;
@@ -1414,7 +1427,7 @@ pub fn frame_liveness_reg_indices_by_bank_at_with_jitcode_pc(
         let int = read_bank(&mut cursor, length_i, all_liveness);
         let ref_ = read_bank(&mut cursor, length_r, all_liveness);
         let float = read_bank(&mut cursor, length_f, all_liveness);
-        FrameLivenessRegIndices { int, ref_, float }
+        Some(FrameLivenessRegIndices { int, ref_, float })
     })
 }
 

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -4324,7 +4324,7 @@ fn full_body_walk_trace<Sym: WalkSym>(
     if ctx.is_bridge_trace && std::env::var_os("PYRE_P2_DIAG").is_some() {
         ctx.dump_trace_ops_diag("carrier-root-walk-end");
     }
-    match walk_result {
+    let action = match walk_result {
         Some((_entry, _code_len, Ok((outcome, _end_pc)))) => match outcome {
             crate::jitcode_dispatch::DispatchOutcome::CloseLoop {
                 jump_args,
@@ -4482,7 +4482,20 @@ fn full_body_walk_trace<Sym: WalkSym>(
                 TraceAction::Abort
             }
         }
+    };
+    // A permanent abort is a property of the walked jitcode body, not of the
+    // guard's runtime values: the same `(jitcode, resume_pc)` reaches the same
+    // marker on every retrace.  The loop-header entry stops re-entering because
+    // `abort_trace(true)` flips its cell to `DONT_TRACE_HERE`, but a bridge
+    // entry is keyed on the guard descr, which that cell never gates — so
+    // without this the guard keeps re-firing `must_compile` every
+    // `trace_eagerness` failures and each retry walks the whole body, executing
+    // its residual calls concretely, before failing again.  Record the decline
+    // through the same channel the pre-walk structural declines use.
+    if matches!(action, TraceAction::AbortPermanent) {
+        fbw_bridge_decline(ctx);
     }
+    action
 }
 
 /// Walker-as-tracer diagnostic dump.


### PR DESCRIPTION
Rebased onto `main` @ 5191484d5f. Six commits: a measured JIT defect found by
following the `abort_permanent` census down, a blackhole dispatch-coverage
closure, two rank-5 groundwork slices, and a bench/gate tightening.

## ⚠️ Scope change on rebase

This PR originally also carried the generator-callee residualization. **#837
landed the identical `code_flags_make_generator` decline independently**, so
after the rebase `9cb3934acf` contains only the comment: the mechanism behind
the decline (the callee's jitcode starts at `RETURN_GENERATOR`, which the
codewriter lowers to an `abort_permanent` marker) and the upstream boundary it
corresponds to, `generator.py:614-634` `should_not_inline`, consumed at
`generator.py:63`. The measured generator speedup this PR previously reported
is therefore already realized on `main` and is **not** attributable to this
PR anymore.

## A bridge guard could re-fire a permanent abort without bound

`bench/synth/calls_closures` showed `loops_aborted=149`, all 149 the identical
`AbortPermanentMarkerReached { pc: 8 }` at `start_pc=55`.

The loop-header entry was correct — it gates on
`warm_state.is_dont_trace_here(green_key)`, and instrumenting both
`compile_and_run_once` call sites proved only **one** trace-start for that key.
The other 148 walks were **bridge** traces, and bridge entry is keyed on
`declined_bridge_guards: HashSet<(trace_id, fail_index)>` — the green cell's
`DONT_TRACE_HERE` never reaches it.

`full_body_walk_trace` set `FBW_BRIDGE_DECLINED` only for pre-walk structural
declines, never for `TraceAction::AbortPermanent`. A permanent abort is a
property of the walked jitcode body, not of the guard's runtime values, so it
is the most deterministic decline there is. Setting the bit routes it through
the launcher's existing `take_fbw_bridge_declined` →
`record_declined_bridge_guard` plumbing.

The retry count tracked `guard_failures / trace_eagerness`, i.e. **linear in
workload** — at 10x iterations `guard_failures` goes 29827 → 299827 — and each
retry walked the whole body, executing its residual calls concretely. Now
constant at 1.

Post-rebase check: #837 reworked this same region (`commit_walk_end` now takes
a `WalkEndResume` and returns `bool`). All three `TraceAction::AbortPermanent`
producers — `BranchGuardUnrestorableKeptStackPermanent`,
`InplaceContainerMutationUnsupported`, `AbortPermanentMarkerReached` — are
still match-arm expressions with no early `return`, so the tail check catches
every one.

⚠️ Note for future work: upstream `warmstate.py:178-181` `JC_DONT_TRACE_HERE`
means "don't **inline** this callee; trace from here ASAP" — a *retry hint*,
set only on `ABORT_TOO_LONG`. pyre overloads the same flag as a permanent
blacklist in `abort_tracing`, while `should_start_dont_trace_here_trace` and
`should_trace_function_entry` still implement the upstream retry meaning. That
overload did not cause this case (`TRACING_OCCURRED` throttles them) but it is
live.

## The production blackhole could not dispatch three opnames it emits

`build_inline_call_only_bh_builder` — what `build_pyre_production_bh_builder`
delegates to, i.e. what guard-failure resume actually runs — **hand-curates**
its registered opname set. Any emitted byte outside it hits `dispatch_step`'s
unwired-opcode panic, and only when a forward resume happens to land on that
byte. Upstream cannot reach this state: `setup_insns(asm.insns)`
(`blackhole.py:58-59`) registers exactly what the assembler emitted.

The previously-pinned "34-opname gap" had the wrong denominator.
`insns_opname_to_byte()` is *build-emitted ∪ canonical overlay*, most of which
this build never emits. This adds `build_emitted_insns()` — the raw build-time
`pipeline.insns`, i.e. pyre's `asm.insns` — and the 34 split cleanly:

- **3 build-emitted**, real latent panics, now registered: `arraylen_gc/rd>i`,
  `cast_ptr_to_int/r>i`, `new_with_vtable/d>r`. All three emit canonical
  operands matching their wired decoders, and the two that read `bh.cpu` get it
  from the builder.
- **31 overlay-only**, unreachable — upstream's `asm.insns` would not list them
  either, so leaving them unregistered is correct.

The hand-maintained 34-entry snapshot is replaced by two structural gates:

- `production_bh_builder_covers_every_build_emitted_opname` — every emitted
  opname dispatchable, no unwired handler, and **no registered key sitting at a
  byte the canonical table gives to another opname**. That last clause is new
  coverage: the curated list spells each byte as a `BC_*` by hand, and
  `setup_insns` only rejects two keys claiming one byte *within* this builder.
- `production_bh_builder_overlay_only_gap_snapshot` — pinned so an opname
  *leaving* the 31 (because the codewriter started emitting it) fails the build
  instead of silently becoming a live panic.

Negative-tested: removing the `arraylen_gc` registration fails the first gate
naming it exactly.

## Rank-5 groundwork

- **`4abc26c18a`** pins the `convert_and_run_from_pyjitpl` start-at-frame-pc
  contract with a test ported from `test_blackhole.py:124-125`.
- **`76057fa0a3`** makes `build_single_frame_miframe` decline on an undecodable
  resume pc instead of silently defaulting the liveness banks, and reads the
  Ref shadow by register **color** in `capture_inline_parent_blackhole`. The
  semantic-slot detour it replaces was a silent wrong-object hazard;
  `concrete_registers_r` is color-indexed, a different index space from
  `locals_cells_stack_w`.

## Bench and gate tightening

- **`558de844c4`** tightens six perf gates to ~2.5x their measured ratio and
  documents the rule. `spectral_norm`'s workload is sized up 10 → 30 rather
  than its gate tightened: check.py gates on execution-only time (run minus the
  measured empty-program startup), and at 10 the pypy run was 0.026s against a
  0.011s startup, so the denominator was the residue of two similar
  measurements and the ratio stopped tracking pyre. Benches with under ~3x
  headroom are deliberately left alone — `nested_loop`, `raise_catch`,
  `int_loop` and `fib_recursive`-vs-cpython are the known slow-runner flakes.

## A lever this PR deliberately does **not** pull

The general form of the generator decline would be "residualize any callee
whose jitcode body carries an `abort_permanent` marker anywhere", retiring
`loop_inlines_abort_permanent_callee`. Censused across all 377 benches: that
up-front whole-loop decline fires **3 times in 2 benches** before the generator
decline and **1 time in 1 bench** after it. Generalizing would buy ~nothing
while retiring a defense, so it is refuted rather than deferred.

## Verification

Re-run after the rebase, with `build/llbc/*.ullbc` re-extracted (the rebase
pulled a `pyre-object/src/setobject.rs` change under a Jul-26 snapshot):
`python3 ./pyre/check.py` — dynasm 326/326, cranelift 326/326, wasm 323/323.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
