### PR TITLE
thread: add CPython 3.14 ExceptHookArgs

### DIFF
--- a/pyre/cpython_tests/baseline.json
+++ b/pyre/cpython_tests/baseline.json
@@ -843,7 +843,7 @@
       "dynasm": "IMPORTERROR"
     },
     "test.test_property": {
-      "dynasm": "FAIL"
+      "dynasm": "PASS"
     },
     "test.test_pstats": {
       "dynasm": "IMPORTERROR"

--- a/pyre/extra_tests/snippets/builtin_bytearray.py
+++ b/pyre/extra_tests/snippets/builtin_bytearray.py
@@ -1,3 +1,4 @@
+import array
 import pickle
 import sys
 
@@ -163,8 +164,63 @@ assert bytearray.fromhex(b"B9 01EF") == b"\xb9\x01\xef"
 # fromhex with bytearray (bytes-like object)
 assert bytearray.fromhex(bytearray(b"4142")) == b"AB"
 
+# fromhex with array.array (bytes-like object)
+assert bytearray.fromhex(array.array("B", b"4142")) == b"AB"
+
 # fromhex with memoryview (bytes-like object)
 assert bytearray.fromhex(memoryview(b"4142")) == b"AB"
+
+
+class FromHexExporter:
+    def __init__(self, data):
+        self.data = bytearray(data)
+        self.flags = []
+        self.released = []
+
+    def __buffer__(self, flags):
+        self.flags.append(flags)
+        return memoryview(self.data)
+
+    def __release_buffer__(self, view):
+        self.released.append(view)
+        view.release()
+
+
+# Python 3.14 `_PyBytes_FromHex`: acquire PyBUF_SIMPLE and release the
+# temporary export after both successful and failed parses.
+exporter = FromHexExporter(b"4142")
+assert bytearray.fromhex(exporter) == b"AB"
+assert exporter.flags == [0]
+assert len(exporter.released) == 1
+exporter.data.append(0)
+
+exporter = FromHexExporter(b"4Z")
+assert_raises(ValueError, bytearray.fromhex, exporter)
+assert exporter.flags == [0]
+assert len(exporter.released) == 1
+exporter.data.append(0)
+
+
+class RaisingFromHexExporter(FromHexExporter):
+    def __release_buffer__(self, view):
+        self.released.append(view)
+        raise RuntimeError("release boom")
+
+
+unraisable = []
+old_unraisablehook = sys.unraisablehook
+sys.unraisablehook = unraisable.append
+try:
+    exporter = RaisingFromHexExporter(b"4142")
+    assert bytes.fromhex(exporter) == b"AB"
+    exporter = RaisingFromHexExporter(b"4Z")
+    assert_raises(ValueError, bytes.fromhex, exporter)
+finally:
+    sys.unraisablehook = old_unraisablehook
+assert len(unraisable) == 2
+assert all(isinstance(event.exc_value, RuntimeError) for event in unraisable)
+
+assert_raises(BufferError, bytearray.fromhex, memoryview(b"4142")[::2])
 
 # fromhex error: non-hexadecimal character
 try:

--- a/pyre/extra_tests/snippets/builtin_bytearray.py
+++ b/pyre/extra_tests/snippets/builtin_bytearray.py
@@ -420,6 +420,89 @@ assert bytearray(b"abcdabcda").rfind(b"a", 2, None) == 8
 assert bytearray(b"abcdabcda").index(b"a") == 0
 assert bytearray(b"abcdabcda").rindex(b"a") == 8
 
+search_buffer = FromHexExporter(b"bc")
+assert bytearray(b"abcd").find(search_buffer) == 1
+assert bytearray(b"abcbc").count(search_buffer) == 2
+assert search_buffer in bytearray(b"abcd")
+assert len(search_buffer.released) == 3
+
+split_buffer = FromHexExporter(b",")
+assert bytearray(b"a,b").split(split_buffer) == [bytearray(b"a"), bytearray(b"b")]
+assert bytearray(b"a,b").rsplit(split_buffer) == [bytearray(b"a"), bytearray(b"b")]
+assert len(split_buffer.released) == 2
+
+
+# CPython 3.14 gh-142560: search methods acquire the bytearray receiver
+# before converting a buffer/index argument.  Re-entrant conversion therefore
+# cannot resize the receiver out from under the borrowed search window.
+class SearchResize:
+    def __init__(self, receiver):
+        self.receiver = receiver
+
+    def __buffer__(self, flags):
+        self.receiver.clear()
+        return memoryview(self.receiver)
+
+    def __release_buffer__(self, view):
+        view.release()
+
+    def __index__(self):
+        self.receiver.clear()
+        return ord("A")
+
+
+for method_name in (
+    "find",
+    "count",
+    "index",
+    "rindex",
+    "rfind",
+    "startswith",
+    "endswith",
+):
+    receiver = bytearray(b"A")
+    assert_raises(BufferError, getattr(receiver, method_name), SearchResize(receiver))
+
+receiver = bytearray(b"A")
+argument = SearchResize(receiver)
+assert_raises(BufferError, lambda: argument in receiver)
+
+for method_name in ("split", "rsplit"):
+    receiver = bytearray(b"A")
+    assert_raises(BufferError, getattr(receiver, method_name), SearchResize(receiver))
+
+
+class SearchBound:
+    def __init__(self, receiver, value):
+        self.receiver = receiver
+        self.value = value
+
+    def __index__(self):
+        self.receiver.clear()
+        return self.value
+
+
+# Argument-clinic converts slice bounds/maxsplit before the implementation
+# acquires the receiver export, so these mutations remain legal.
+for method_name, expected in (("find", -1), ("count", 0), ("rfind", -1)):
+    receiver = bytearray(b"A")
+    assert getattr(receiver, method_name)(b"A", SearchBound(receiver, 0)) == expected
+
+for method_name in ("index", "rindex"):
+    receiver = bytearray(b"A")
+    assert_raises(
+        ValueError,
+        getattr(receiver, method_name),
+        b"A",
+        SearchBound(receiver, 0),
+    )
+
+for method_name in ("split", "rsplit"):
+    receiver = bytearray(b"A,A")
+    assert getattr(receiver, method_name)(
+        b",", SearchBound(receiver, 1)
+    ) == [bytearray()]
+
 
 # make trans
 # fmt: off

--- a/pyre/extra_tests/snippets/builtin_bytearray.py
+++ b/pyre/extra_tests/snippets/builtin_bytearray.py
@@ -882,3 +882,24 @@ for i in range(-1, 2, 1):
     assert_raises(
         IndexError, lambda: a[-sys.maxsize - i], _msg="bytearray index out of range"
     )
+
+
+# CPython 3.14 `ByteArrayTest.test_resize` /
+# `ByteArrayTest.test_resize_forbidden`.
+a = bytearray(b"abcdef")
+assert a.resize(3) is None
+assert a == bytearray(b"abc")
+assert a.resize(10) is None
+assert a == bytearray(b"abc\0\0\0\0\0\0\0")
+assert a.resize(0) is None
+assert a == bytearray()
+
+a = bytearray(10)
+view = memoryview(a)
+# The same-size fast path is not a resize and remains legal while exported.
+assert a.resize(10) is None
+assert_raises(BufferError, a.resize, 11)
+assert_raises(BufferError, a.resize, 9)
+assert len(a) == 10
+view.release()
+assert a.resize(9) is None

--- a/pyre/extra_tests/snippets/builtin_compile.py
+++ b/pyre/extra_tests/snippets/builtin_compile.py
@@ -7,6 +7,12 @@ assert isinstance(
 assert compile("1 + 1", "<test>", "eval") is not None
 assert compile("1", "<test>", "single") is not None
 
+# `source_as_str` accepts every readable contiguous buffer, not only bytes and
+# bytearray.  This is exercised directly by CPython's test_builtin suite.
+namespace = {}
+exec(compile(memoryview(b"answer = 42"), "<buffer>", "exec"), namespace)
+assert namespace["answer"] == 42
+
 # `optimize` accepts -1 (use config default), 0, 1, 2 only.
 # Anything else raises ValueError with CPython's exact wording.
 for ok in (-1, 0, 1, 2):

--- a/pyre/extra_tests/snippets/builtin_eval.py
+++ b/pyre/extra_tests/snippets/builtin_eval.py
@@ -1,4 +1,6 @@
 assert 3 == eval("1+2")
+assert 2 == eval(" \t 1+1\n")
+assert 42 == eval(memoryview(b"40+2"))
 
 code = compile("5+3", "x.py", "eval")
 assert eval(code) == 8

--- a/pyre/extra_tests/snippets/builtin_property.py
+++ b/pyre/extra_tests/snippets/builtin_property.py
@@ -110,5 +110,12 @@ assert SlottedProperty(doc="slot doc").__doc__ == "slot doc"
 assert SlottedProperty(documented_getter_2).__doc__ == "doc 2"
 
 for count in (0, 1, 3):
-    with assert_raises(TypeError):
+    with assert_raises(TypeError) as caught:
         property().__set_name__(*([0] * count))
+    assert str(caught.exception) == (
+        "__set_name__() takes 2 positional arguments but {} were given".format(count)
+    )
+
+with assert_raises(TypeError) as caught:
+    property().__set_name__(owner=object, name="value")
+assert str(caught.exception) == "property.__set_name__() takes no keyword arguments"

--- a/pyre/extra_tests/snippets/builtin_thread.py
+++ b/pyre/extra_tests/snippets/builtin_thread.py
@@ -1,3 +1,94 @@
 import _thread
+import sys
 
 assert _thread.TIMEOUT_MAX in [9223372036.0, 4294967.0]
+
+
+ExceptHookArgs = _thread._ExceptHookArgs
+assert ExceptHookArgs.__module__ == "_thread"
+assert ExceptHookArgs.__name__ == "_ExceptHookArgs"
+assert ExceptHookArgs.n_fields == 4
+assert ExceptHookArgs.n_sequence_fields == 4
+assert ExceptHookArgs.n_unnamed_fields == 0
+assert ExceptHookArgs.__match_args__ == (
+    "exc_type",
+    "exc_value",
+    "exc_traceback",
+    "thread",
+)
+assert "Type used to pass arguments to threading.excepthook." in ExceptHookArgs.__doc__
+
+try:
+    class DerivedExceptHookArgs(ExceptHookArgs):
+        pass
+except TypeError:
+    pass
+else:
+    raise AssertionError("_ExceptHookArgs unexpectedly accepted a subclass")
+
+hook_args = ExceptHookArgs([ValueError, ValueError("thread boom"), None, None])
+assert tuple(hook_args) == (ValueError, hook_args.exc_value, None, None)
+assert repr(hook_args).startswith(
+    "_thread._ExceptHookArgs(exc_type=<class 'ValueError'>, "
+)
+
+try:
+    _thread._excepthook(())
+except TypeError as exc:
+    assert str(exc) == "_thread.excepthook argument type must be ExceptHookArgs"
+else:
+    raise AssertionError("_excepthook accepted a plain tuple")
+
+
+class Sink:
+    def __init__(self):
+        self.parts = []
+        self.flushed = False
+
+    def write(self, text):
+        self.parts.append(text)
+
+    def flush(self):
+        self.flushed = True
+
+
+sink = Sink()
+old_stderr = sys.stderr
+try:
+    sys.stderr = sink
+    assert _thread._excepthook(hook_args) is None
+    assert _thread._excepthook(
+        ExceptHookArgs([SystemExit, SystemExit(1), None, None])
+    ) is None
+finally:
+    sys.stderr = old_stderr
+
+output = "".join(sink.parts)
+assert output.startswith(f"Exception in thread {_thread.get_ident()}:\n")
+assert output.endswith("ValueError: thread boom\n")
+assert "SystemExit" not in output
+assert sink.flushed
+
+sink.parts.clear()
+sink.flushed = False
+try:
+    raise LookupError("traceback boom")
+except LookupError:
+    traced_args = ExceptHookArgs([*sys.exc_info(), None])
+    try:
+        sys.stderr = sink
+        assert _thread._excepthook(traced_args) is None
+    finally:
+        sys.stderr = old_stderr
+        traced_args = None
+
+output = "".join(sink.parts)
+assert "Traceback (most recent call last):\n" in output
+assert 'raise LookupError("traceback boom")' in output
+assert output.endswith("LookupError: traceback boom\n")
+assert sink.flushed
+
+import threading
+
+assert threading.ExceptHookArgs is ExceptHookArgs
+assert threading.excepthook is _thread._excepthook

--- a/pyre/extra_tests/snippets/builtin_thread.py
+++ b/pyre/extra_tests/snippets/builtin_thread.py
@@ -99,6 +99,11 @@ class BrokenStrError(Exception):
         raise RuntimeError("str failed")
 
 
+class SurrogateStrError(Exception):
+    def __str__(self):
+        return "bad\ud800value"
+
+
 def capture_error(exc):
     try:
         raise exc
@@ -145,6 +150,24 @@ assert "[Errno 2] missing: 'file.txt'" in hook_output(
 assert hook_output(BrokenStrError("raw")).endswith(
     "BrokenStrError: <exception str() failed>\n"
 )
+assert hook_output(SurrogateStrError()).endswith(
+    "SurrogateStrError: bad\ud800value\n"
+)
+
+# CPython's invalid-value printer intentionally retains its historical
+# `NoneType: None` special case while other non-exceptions use the diagnostic.
+assert hook_output(None).endswith("NoneType: None\n")
+assert hook_output(42).endswith(
+    "TypeError: print_exception(): Exception expected for value, int found\n"
+)
+
+located_syntax_error = SyntaxError(
+    "bad syntax", ("thread_syntax.py", 3, 4, "abc\n", 3, 5)
+)
+syntax_output = hook_output(located_syntax_error)
+assert 'File "thread_syntax.py", line 3\n' in syntax_output
+assert "SyntaxError: bad syntax\n" in syntax_output
+assert "(thread_syntax.py, line 3)" not in syntax_output
 
 
 class BrokenThreadName:
@@ -195,6 +218,43 @@ finally:
     sys.modules["sys"] = original_sys_entry
 assert "ValueError: real stderr\n" in "".join(real_sink.parts)
 assert wrong_sink.parts == []
+
+
+class FakeThread:
+    def __init__(self, name, stderr):
+        self.name = name
+        self._stderr = stderr
+
+
+named_thread = FakeThread("worker-1", Sink())
+assert hook_output(ValueError("named"), thread=named_thread).startswith(
+    "Exception in thread worker-1:\n"
+)
+
+# Exercise the saved `_stderr` fallback.  CPython 3.14's stdlib traceback
+# fast path writes the exception body through `sys.__stderr__`, while its
+# C fallback (and pyre) writes it to the explicit file; the named banner and
+# flush prove that `_thread` selected the thread-owned stream in both cases.
+fallback_sink = Sink()
+backup_sink = Sink()
+fallback_thread = FakeThread("worker-fallback", fallback_sink)
+old_stderr = sys.stderr
+old_dunder_stderr = sys.__stderr__
+try:
+    sys.stderr = None
+    sys.__stderr__ = backup_sink
+    _thread._excepthook(
+        ExceptHookArgs(
+            [ValueError, ValueError("fallback"), None, fallback_thread]
+        )
+    )
+finally:
+    sys.stderr = old_stderr
+    sys.__stderr__ = old_dunder_stderr
+assert "".join(fallback_sink.parts).startswith(
+    "Exception in thread worker-fallback:\n"
+)
+assert fallback_sink.flushed
 
 import threading
 

--- a/pyre/extra_tests/snippets/builtin_thread.py
+++ b/pyre/extra_tests/snippets/builtin_thread.py
@@ -114,6 +114,12 @@ class CollectingStrError(Exception):
         return "collected safely"
 
 
+class BrokenNotesError(Exception):
+    @property
+    def __notes__(self):
+        raise RuntimeError("notes failed")
+
+
 class ErrorNamespace:
     class NestedError(Exception):
         pass
@@ -191,6 +197,52 @@ scalar_notes = ValueError("scalar notes")
 scalar_notes.__notes__ = "detail"
 scalar_notes_output = hook_output(scalar_notes)
 assert scalar_notes_output.endswith("'detail'\n")
+
+broken_notes_output = hook_output(BrokenNotesError("broken notes"))
+assert broken_notes_output.endswith(
+    "BrokenNotesError: broken notes\n"
+    "Ignored error getting __notes__: RuntimeError('notes failed')\n"
+)
+
+
+def raise_name_suggestion():
+    available_name = 1
+    return availabl_name
+
+
+try:
+    raise_name_suggestion()
+except NameError as suggested_name_error:
+    name_suggestion_output = hook_output(suggested_name_error)
+assert name_suggestion_output.endswith(
+    "NameError: name 'availabl_name' is not defined. "
+    "Did you mean: 'available_name'?\n"
+)
+
+
+class SuggestionTarget:
+    available_attribute = 1
+
+
+attribute_suggestion = AttributeError(
+    "'SuggestionTarget' object has no attribute 'availabl_attribute'",
+    name="availabl_attribute",
+    obj=SuggestionTarget(),
+)
+assert hook_output(attribute_suggestion).endswith(
+    "AttributeError: 'SuggestionTarget' object has no attribute "
+    "'availabl_attribute'. Did you mean: 'available_attribute'?\n"
+)
+
+import_suggestion = ImportError(
+    "cannot import name 'sqr' from 'math'",
+    name="math",
+    name_from="sqr",
+)
+import_suggestion_output = hook_output(import_suggestion)
+assert import_suggestion_output.endswith(
+    "ImportError: cannot import name 'sqr' from 'math'. Did you mean: 'sqrt'?\n"
+), repr(import_suggestion_output)
 
 # CPython's invalid-value printer intentionally retains its historical
 # `NoneType: None` special case while other non-exceptions use the diagnostic.

--- a/pyre/extra_tests/snippets/builtin_thread.py
+++ b/pyre/extra_tests/snippets/builtin_thread.py
@@ -88,6 +88,114 @@ assert 'raise LookupError("traceback boom")' in output
 assert output.endswith("LookupError: traceback boom\n")
 assert sink.flushed
 
+
+class CustomStrError(Exception):
+    def __str__(self):
+        return "custom thread formatting"
+
+
+class BrokenStrError(Exception):
+    def __str__(self):
+        raise RuntimeError("str failed")
+
+
+def capture_error(exc):
+    try:
+        raise exc
+    except Exception as caught:
+        return caught
+
+
+def hook_output(exc, traceback=None, thread=None):
+    target = Sink()
+    previous = sys.stderr
+    try:
+        sys.stderr = target
+        _thread._excepthook(
+            ExceptHookArgs([type(exc), exc, traceback, thread])
+        )
+    finally:
+        sys.stderr = previous
+    assert target.flushed
+    return "".join(target.parts)
+
+
+# `_PyErr_Display` installs a supplied traceback only when the exception has
+# none.  An exception-resident traceback wins and remains unchanged.
+supplied_error = capture_error(LookupError("supplied traceback"))
+supplied_tb = supplied_error.__traceback__
+fresh_error = CustomStrError("raw constructor argument")
+fresh_output = hook_output(fresh_error, supplied_tb)
+assert fresh_error.__traceback__ is supplied_tb
+assert "capture_error" in fresh_output
+assert fresh_output.endswith("CustomStrError: custom thread formatting\n")
+
+own_error = capture_error(CustomStrError("own traceback"))
+own_tb = own_error.__traceback__
+own_output = hook_output(own_error, supplied_tb)
+assert own_error.__traceback__ is own_tb
+assert own_error.__traceback__ is not supplied_tb
+assert own_output.endswith("CustomStrError: custom thread formatting\n")
+
+# Exception-only formatting calls the exception object's real `__str__`.
+assert hook_output(KeyError("key")).endswith("KeyError: 'key'\n")
+assert "[Errno 2] missing: 'file.txt'" in hook_output(
+    OSError(2, "missing", "file.txt")
+)
+assert hook_output(BrokenStrError("raw")).endswith(
+    "BrokenStrError: <exception str() failed>\n"
+)
+
+
+class BrokenThreadName:
+    @property
+    def name(self):
+        raise NameError("thread name failed")
+
+
+# `PyObject_GetOptionalAttr` suppresses AttributeError only; NameError from a
+# descriptor must reach `threading`'s outer failure reporting path.
+sink = Sink()
+old_stderr = sys.stderr
+try:
+    sys.stderr = sink
+    try:
+        _thread._excepthook(
+            ExceptHookArgs(
+                [ValueError, ValueError("name"), None, BrokenThreadName()]
+            )
+        )
+    except NameError as exc:
+        assert str(exc) == "thread name failed"
+    else:
+        raise AssertionError("_excepthook swallowed a thread-name NameError")
+finally:
+    sys.stderr = old_stderr
+
+# `_PySys_GetOptionalAttr` reads the interpreter-owned sys dictionary even
+# when user code replaces the `sys.modules["sys"]` import-cache entry.
+class ReplacementSys:
+    pass
+
+
+replacement = ReplacementSys()
+wrong_sink = Sink()
+replacement.stderr = wrong_sink
+real_sink = Sink()
+original_sys_entry = sys.modules["sys"]
+old_stderr = sys.stderr
+try:
+    sys.modules["sys"] = replacement
+    sys.stderr = real_sink
+    _thread._excepthook(
+        ExceptHookArgs([ValueError, ValueError("real stderr"), None, None])
+    )
+finally:
+    sys.stderr = old_stderr
+    sys.modules["sys"] = original_sys_entry
+assert "ValueError: real stderr\n" in "".join(real_sink.parts)
+assert wrong_sink.parts == []
+
 import threading
 
 assert threading.ExceptHookArgs is ExceptHookArgs

--- a/pyre/extra_tests/snippets/builtin_thread.py
+++ b/pyre/extra_tests/snippets/builtin_thread.py
@@ -104,6 +104,16 @@ class SurrogateStrError(Exception):
         return "bad\ud800value"
 
 
+class CollectingStrError(Exception):
+    def __str__(self):
+        import gc
+
+        garbage = [[index] for index in range(4096)]
+        gc.collect()
+        assert len(garbage) == 4096
+        return "collected safely"
+
+
 def capture_error(exc):
     try:
         raise exc
@@ -153,6 +163,11 @@ assert hook_output(BrokenStrError("raw")).endswith(
 assert hook_output(SurrogateStrError()).endswith(
     "SurrogateStrError: bad\ud800value\n"
 )
+collecting_error = CollectingStrError()
+collecting_error.add_note("note after collection")
+collecting_output = hook_output(collecting_error)
+assert "CollectingStrError: collected safely\n" in collecting_output
+assert collecting_output.endswith("note after collection\n")
 
 # CPython's invalid-value printer intentionally retains its historical
 # `NoneType: None` special case while other non-exceptions use the diagnostic.
@@ -173,13 +188,13 @@ group_output = hook_output(
     ExceptionGroup(
         "outer",
         [
-            ValueError("first leaf"),
+            CollectingStrError(),
             ExceptionGroup("inner", [TypeError("nested leaf")]),
         ],
     )
 )
 assert "ExceptionGroup: outer (2 sub-exceptions)\n" in group_output
-assert "ValueError: first leaf\n" in group_output
+assert "CollectingStrError: collected safely\n" in group_output
 assert "ExceptionGroup: inner (1 sub-exception)\n" in group_output
 assert "TypeError: nested leaf\n" in group_output
 assert "+---------------- 1 ----------------\n" in group_output
@@ -199,6 +214,16 @@ context_cycle_output = hook_output(cycle_first)
 assert context_cycle_output.count("ValueError: cycle first\n") == 1
 assert context_cycle_output.count("TypeError: cycle second\n") == 1
 assert context_cycle_output.count("During handling") == 1
+
+deep_chain = ValueError("chain 0")
+for chain_index in range(1, 1200):
+    next_error = ValueError(f"chain {chain_index}")
+    next_error.__context__ = deep_chain
+    deep_chain = next_error
+deep_chain_output = hook_output(deep_chain)
+assert deep_chain_output.count("During handling") == 1199
+assert "ValueError: chain 0\n" in deep_chain_output
+assert "ValueError: chain 1199\n" in deep_chain_output
 
 
 class BrokenThreadName:

--- a/pyre/extra_tests/snippets/builtin_thread.py
+++ b/pyre/extra_tests/snippets/builtin_thread.py
@@ -198,6 +198,11 @@ range_notes.__notes__ = range(2)
 range_notes_output = hook_output(range_notes)
 assert range_notes_output.endswith("0\n1\n")
 
+surrogate_note = ValueError("surrogate note")
+surrogate_note.add_note("bad\ud800note")
+surrogate_note_output = hook_output(surrogate_note)
+assert surrogate_note_output.endswith("bad\ud800note\n")
+
 scalar_notes = ValueError("scalar notes")
 scalar_notes.__notes__ = "detail"
 scalar_notes_output = hook_output(scalar_notes)
@@ -242,6 +247,14 @@ assert hook_output(attribute_suggestion).endswith(
 
 class PrivateSuggestionTarget:
     _public = 1
+
+    def __dir__(self):
+        import gc
+
+        garbage = [[index] for index in range(4096)]
+        gc.collect()
+        assert len(garbage) == 4096
+        return ["_public"]
 
     def fail(self):
         return self.public
@@ -296,6 +309,15 @@ assert "ExceptionGroup: inner (1 sub-exception)\n" in group_output
 assert "TypeError: nested leaf\n" in group_output
 assert "+---------------- 1 ----------------\n" in group_output
 assert "+------------------------------------\n" in group_output
+
+later_group_child = TypeError("later child")
+first_group_child = ValueError("first child")
+first_group_child.__cause__ = later_group_child
+sibling_chain_group_output = hook_output(
+    ExceptionGroup("sibling chain", [first_group_child, later_group_child])
+)
+assert sibling_chain_group_output.count("TypeError: later child\n") == 1
+assert "direct cause" not in sibling_chain_group_output
 
 self_cause = ValueError("self cycle")
 self_cause.__cause__ = self_cause

--- a/pyre/extra_tests/snippets/builtin_thread.py
+++ b/pyre/extra_tests/snippets/builtin_thread.py
@@ -169,6 +169,37 @@ assert 'File "thread_syntax.py", line 3\n' in syntax_output
 assert "SyntaxError: bad syntax\n" in syntax_output
 assert "(thread_syntax.py, line 3)" not in syntax_output
 
+group_output = hook_output(
+    ExceptionGroup(
+        "outer",
+        [
+            ValueError("first leaf"),
+            ExceptionGroup("inner", [TypeError("nested leaf")]),
+        ],
+    )
+)
+assert "ExceptionGroup: outer (2 sub-exceptions)\n" in group_output
+assert "ValueError: first leaf\n" in group_output
+assert "ExceptionGroup: inner (1 sub-exception)\n" in group_output
+assert "TypeError: nested leaf\n" in group_output
+assert "+---------------- 1 ----------------\n" in group_output
+assert "+------------------------------------\n" in group_output
+
+self_cause = ValueError("self cycle")
+self_cause.__cause__ = self_cause
+self_cause_output = hook_output(self_cause)
+assert self_cause_output.count("ValueError: self cycle\n") == 1
+assert "direct cause" not in self_cause_output
+
+cycle_first = ValueError("cycle first")
+cycle_second = TypeError("cycle second")
+cycle_first.__context__ = cycle_second
+cycle_second.__context__ = cycle_first
+context_cycle_output = hook_output(cycle_first)
+assert context_cycle_output.count("ValueError: cycle first\n") == 1
+assert context_cycle_output.count("TypeError: cycle second\n") == 1
+assert context_cycle_output.count("During handling") == 1
+
 
 class BrokenThreadName:
     @property

--- a/pyre/extra_tests/snippets/builtin_thread.py
+++ b/pyre/extra_tests/snippets/builtin_thread.py
@@ -193,6 +193,11 @@ tuple_notes.__notes__ = ("first detail", 42)
 tuple_notes_output = hook_output(tuple_notes)
 assert tuple_notes_output.endswith("first detail\n42\n")
 
+range_notes = ValueError("range notes")
+range_notes.__notes__ = range(2)
+range_notes_output = hook_output(range_notes)
+assert range_notes_output.endswith("0\n1\n")
+
 scalar_notes = ValueError("scalar notes")
 scalar_notes.__notes__ = "detail"
 scalar_notes_output = hook_output(scalar_notes)
@@ -232,6 +237,23 @@ attribute_suggestion = AttributeError(
 assert hook_output(attribute_suggestion).endswith(
     "AttributeError: 'SuggestionTarget' object has no attribute "
     "'availabl_attribute'. Did you mean: 'available_attribute'?\n"
+)
+
+
+class PrivateSuggestionTarget:
+    _public = 1
+
+    def fail(self):
+        return self.public
+
+
+try:
+    PrivateSuggestionTarget().fail()
+except AttributeError as private_suggestion:
+    private_suggestion_output = hook_output(private_suggestion)
+assert private_suggestion_output.endswith(
+    "AttributeError: 'PrivateSuggestionTarget' object has no attribute "
+    "'public'. Did you mean: '_public'?\n"
 )
 
 import_suggestion = ImportError(

--- a/pyre/extra_tests/snippets/builtin_thread.py
+++ b/pyre/extra_tests/snippets/builtin_thread.py
@@ -114,6 +114,11 @@ class CollectingStrError(Exception):
         return "collected safely"
 
 
+class ErrorNamespace:
+    class NestedError(Exception):
+        pass
+
+
 def capture_error(exc):
     try:
         raise exc
@@ -168,6 +173,24 @@ collecting_error.add_note("note after collection")
 collecting_output = hook_output(collecting_error)
 assert "CollectingStrError: collected safely\n" in collecting_output
 assert collecting_output.endswith("note after collection\n")
+
+nested_output = hook_output(ErrorNamespace.NestedError("nested"))
+assert nested_output.endswith("ErrorNamespace.NestedError: nested\n")
+ErrorNamespace.NestedError.__module__ = "pkg.mod"
+qualified_output = hook_output(ErrorNamespace.NestedError("qualified"))
+assert qualified_output.endswith(
+    "pkg.mod.ErrorNamespace.NestedError: qualified\n"
+)
+
+tuple_notes = ValueError("tuple notes")
+tuple_notes.__notes__ = ("first detail", 42)
+tuple_notes_output = hook_output(tuple_notes)
+assert tuple_notes_output.endswith("first detail\n42\n")
+
+scalar_notes = ValueError("scalar notes")
+scalar_notes.__notes__ = "detail"
+scalar_notes_output = hook_output(scalar_notes)
+assert scalar_notes_output.endswith("'detail'\n")
 
 # CPython's invalid-value printer intentionally retains its historical
 # `NoneType: None` special case while other non-exceptions use the diagnostic.

--- a/pyre/extra_tests/snippets/bytes_fromhex_hex_sep.py
+++ b/pyre/extra_tests/snippets/bytes_fromhex_hex_sep.py
@@ -5,6 +5,7 @@
 assert b''.fromhex('aa') == b'\xaa'
 assert b'x'.fromhex('B9 01EF') == b'\xb9\x01\xef'
 assert bytes.fromhex('aabb') == b'\xaa\xbb'
+assert bytes.fromhex(memoryview(b'aabb')) == b'\xaa\xbb'
 assert bytearray().fromhex('aa') == bytearray(b'\xaa')
 assert bytearray.fromhex('aabb') == bytearray(b'\xaa\xbb')
 

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -7466,6 +7466,180 @@ pub fn charbuf_w(obj: PyObjectRef) -> Result<&'static [u8], PyError> {
     Ok(unsafe { pyre_object::bytesobject::bytes_like_data(obj) })
 }
 
+/// One copied `PyBUF_SIMPLE` export whose owner remains rooted and acquired
+/// until [`SimpleBufferBytes::release`].
+pub(crate) struct SimpleBufferBytes {
+    _roots: pyre_object::gc_roots::RootScope,
+    data: Vec<u8>,
+    native_owner_slot: Option<usize>,
+    native_export_active: bool,
+    release_exporter_slot: Option<usize>,
+    release_view_slot: Option<usize>,
+}
+
+impl SimpleBufferBytes {
+    pub(crate) fn as_bytes(&self) -> &[u8] {
+        &self.data
+    }
+
+    /// `PyBuffer_Release`: release errors are unraisable and must not replace
+    /// the operation's success or parsing exception.
+    pub(crate) fn release(mut self) {
+        if self.native_export_active {
+            self.native_export_active = false;
+            let owner = pyre_object::gc_roots::shadow_stack_get(
+                self.native_owner_slot
+                    .expect("active native export has an owner"),
+            );
+            unsafe { crate::builtins::buffer_export_decref(owner) };
+        }
+        let (Some(exporter_slot), Some(view_slot)) = (
+            self.release_exporter_slot.take(),
+            self.release_view_slot.take(),
+        ) else {
+            return;
+        };
+        let exporter = pyre_object::gc_roots::shadow_stack_get(exporter_slot);
+        let view = pyre_object::gc_roots::shadow_stack_get(view_slot);
+        unsafe {
+            if let Some(w_release) = lookup(exporter, "__release_buffer__") {
+                let w_type = crate::typedef::r#type(exporter).map_or(exporter, |p| p.as_ptr());
+                if let Err(mut error) = get_and_call_function(w_release, exporter, w_type, &[view])
+                {
+                    let exporter = pyre_object::gc_roots::shadow_stack_get(exporter_slot);
+                    error.write_unraisable(
+                        pyre_object::w_none(),
+                        &format!(
+                            "Exception ignored in __release_buffer__ of {}:",
+                            object_functionstr_type_name(exporter)
+                        ),
+                        exporter,
+                    );
+                }
+            }
+        }
+        let view = pyre_object::gc_roots::shadow_stack_get(view_slot);
+        if let Err(mut error) = crate::builtins::memoryview_release(&[view]) {
+            error.write_unraisable(
+                pyre_object::w_none(),
+                "Exception ignored in __release_buffer__:",
+                pyre_object::gc_roots::shadow_stack_get(exporter_slot),
+            );
+        }
+    }
+}
+
+/// `ObjSpace.acquire_readbuf`: acquire and copy one `PyBUF_SIMPLE` export.
+///
+/// PyPy: `W_Root.buffer_w` → `__buffer_w`; CPython:
+/// `PyObject_GetBuffer(..., PyBUF_SIMPLE)` / `PyBuffer_Release`.
+/// `Ok(None)` is the `BufferInterfaceNotFound` path, so callers can spell
+/// their own operation-specific TypeError.
+pub(crate) fn simple_buffer_bytes(obj: PyObjectRef) -> Result<Option<SimpleBufferBytes>, PyError> {
+    if let Some(target) = crate::module::__pypy__::interp_buffer::forwarded_exporter(obj) {
+        return simple_buffer_bytes(target?);
+    }
+    let roots = pyre_object::gc_roots::push_roots();
+    pyre_object::gc_roots::pin_root(obj);
+    let obj_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+    let r_obj = pyre_object::gc_roots::shadow_stack_get(obj_slot);
+    unsafe {
+        if pyre_object::memoryview::is_w_memoryview(r_obj) {
+            crate::builtins::memoryview_check_released(r_obj)?;
+            if !crate::builtins::memoryview_contiguity(r_obj).0 {
+                return Err(PyError::new(
+                    PyErrorKind::BufferError,
+                    "memoryview: underlying buffer is not C-contiguous",
+                ));
+            }
+            return Ok(Some(SimpleBufferBytes {
+                _roots: roots,
+                data: crate::builtins::memoryview_gather_bytes(r_obj),
+                native_owner_slot: None,
+                native_export_active: false,
+                release_exporter_slot: None,
+                release_view_slot: None,
+            }));
+        }
+    }
+    let native_export_active = unsafe { crate::builtins::buffer_export_incref(r_obj) };
+    match crate::typedef::buffer_as_bytes_like(r_obj) {
+        Ok(Some(w_bytes)) => {
+            return Ok(Some(SimpleBufferBytes {
+                _roots: roots,
+                data: unsafe { pyre_object::bytesobject::bytes_like_data(w_bytes) }.to_vec(),
+                native_owner_slot: native_export_active.then_some(obj_slot),
+                native_export_active,
+                release_exporter_slot: None,
+                release_view_slot: None,
+            }));
+        }
+        Ok(None) => {
+            debug_assert!(!native_export_active);
+        }
+        Err(error) => {
+            if native_export_active {
+                unsafe { crate::builtins::buffer_export_decref(r_obj) };
+            }
+            return Err(error);
+        }
+    }
+
+    // W_Root.__buffer_w: descriptor-bind `__buffer__`, pass PyBUF_SIMPLE,
+    // and require the Python implementation to return a memoryview.
+    unsafe {
+        let r_obj = pyre_object::gc_roots::shadow_stack_get(obj_slot);
+        let Some(w_impl) = lookup(r_obj, "__buffer__") else {
+            return Ok(None);
+        };
+        const BUF_SIMPLE: i64 = 0;
+        pyre_object::gc_roots::pin_root(pyre_object::w_int_new(BUF_SIMPLE));
+        let flags_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+        pyre_object::gc_roots::pin_root(w_impl);
+        let impl_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+        let r_obj = pyre_object::gc_roots::shadow_stack_get(obj_slot);
+        let w_type = crate::typedef::r#type(r_obj).map_or(r_obj, |p| p.as_ptr());
+        let w_view = get_and_call_function(
+            pyre_object::gc_roots::shadow_stack_get(impl_slot),
+            r_obj,
+            w_type,
+            &[pyre_object::gc_roots::shadow_stack_get(flags_slot)],
+        )?;
+        if !pyre_object::memoryview::is_w_memoryview(w_view) {
+            return Err(PyError::type_error(
+                "__buffer__ returned non-memoryview object",
+            ));
+        }
+        pyre_object::gc_roots::pin_root(w_view);
+        let view_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+        let r_view = pyre_object::gc_roots::shadow_stack_get(view_slot);
+        crate::builtins::memoryview_check_released(r_view)?;
+        if !crate::builtins::memoryview_contiguity(r_view).0 {
+            let buffer = SimpleBufferBytes {
+                _roots: roots,
+                data: Vec::new(),
+                native_owner_slot: None,
+                native_export_active: false,
+                release_exporter_slot: Some(obj_slot),
+                release_view_slot: Some(view_slot),
+            };
+            buffer.release();
+            return Err(PyError::new(
+                PyErrorKind::BufferError,
+                "memoryview: underlying buffer is not C-contiguous",
+            ));
+        }
+        Ok(Some(SimpleBufferBytes {
+            _roots: roots,
+            data: crate::builtins::memoryview_gather_bytes(r_view),
+            native_owner_slot: None,
+            native_export_active: false,
+            release_exporter_slot: Some(obj_slot),
+            release_view_slot: Some(view_slot),
+        }))
+    }
+}
+
 /// Look up a descriptor on an object's type.
 ///
 /// PyPy equivalent: `space.lookup(w_obj, name)`.

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -15328,8 +15328,9 @@ pub(crate) fn contains_slot(haystack: PyObjectRef, needle: PyObjectRef) -> Resul
         // `_op_val` falls back to `buffer_w(BUF_SIMPLE)`, so any buffer-protocol
         // object (e.g. a memoryview) is also accepted as the needle.
         if pyre_object::bytesobject::is_bytes_like(haystack) {
-            let hay = pyre_object::bytesobject::bytes_like_data(haystack);
-            if is_int(needle) || is_long(needle) {
+            let receiver = simple_buffer_bytes(haystack)?
+                .expect("bytes/bytearray receiver always exports a buffer");
+            let result = if is_int(needle) || is_long(needle) {
                 // `_single_char`: `int_w` then `0 <= c < 256`; a bignum is
                 // necessarily out of range (its `int_w` overflows upstream).
                 let v = if is_int(needle) {
@@ -15338,21 +15339,35 @@ pub(crate) fn contains_slot(haystack: PyObjectRef, needle: PyObjectRef) -> Resul
                     -1
                 };
                 if !(0..=255).contains(&v) {
-                    return Err(PyError::value_error("byte must be in range(0, 256)"));
+                    Err(PyError::value_error("byte must be in range(0, 256)"))
+                } else {
+                    Ok(receiver.as_bytes().contains(&(v as u8)))
                 }
-                return Ok(hay.contains(&(v as u8)));
-            }
-            if let Some(src) = crate::typedef::buffer_as_bytes_like(needle)? {
-                let sub = pyre_object::bytesobject::bytes_like_data(src);
-                return Ok(sub.is_empty() || hay.windows(sub.len()).any(|w| w == sub));
-            }
-            let tname = match crate::typedef::r#type(needle) {
-                Some(tp) => pyre_object::w_type_get_name(tp.as_ptr()).to_string(),
-                None => "object".to_string(),
+            } else {
+                match simple_buffer_bytes(needle) {
+                    Ok(Some(sub)) => {
+                        let value = sub.as_bytes().is_empty()
+                            || receiver
+                                .as_bytes()
+                                .windows(sub.as_bytes().len())
+                                .any(|window| window == sub.as_bytes());
+                        sub.release();
+                        Ok(value)
+                    }
+                    Ok(None) => {
+                        let tname = match crate::typedef::r#type(needle) {
+                            Some(tp) => pyre_object::w_type_get_name(tp.as_ptr()).to_string(),
+                            None => "object".to_string(),
+                        };
+                        Err(PyError::type_error(format!(
+                            "a bytes-like object is required, not '{tname}'"
+                        )))
+                    }
+                    Err(error) => Err(error),
+                }
             };
-            return Err(PyError::type_error(format!(
-                "a bytes-like object is required, not '{tname}'"
-            )));
+            receiver.release();
+            return result;
         }
         // dict: key containment (dictmultiobject.py __contains__)
         if is_dict(haystack) {

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -13621,15 +13621,27 @@ unsafe fn property_no_accessor(
 
 pub(crate) fn property_set_name_impl(args: &[PyObjectRef]) -> PyResult {
     // descriptor.py:274-276 `set_name(self, w_type, w_name)` — the bound
-    // method receives `[property, owner, name]`.
-    if args.len() != 3 {
+    // method receives `[property, owner, name]`.  CPython 3.14 exposes this
+    // method through a positional-only clinic wrapper.  Keep the PyPy body
+    // shape, but parse pyre's temporary keyword marker here so the 3.14
+    // public error surface excludes the bound receiver from its count.
+    let (positional, kwargs) = crate::builtins::split_builtin_kwargs(args);
+    if crate::builtins::has_real_kwargs(kwargs) {
+        return Err(crate::PyError::type_error(
+            "property.__set_name__() takes no keyword arguments",
+        ));
+    }
+    if positional.len() != 3 {
         return Err(crate::PyError::type_error(format!(
             "__set_name__() takes 2 positional arguments but {} were given",
-            args.len().saturating_sub(1),
+            positional.len().saturating_sub(1),
         )));
     }
-    let prop = property_require_obj(args.first().copied().unwrap_or(PY_NULL), "__set_name__")?;
-    let w_name = args[2];
+    let prop = property_require_obj(
+        positional.first().copied().unwrap_or(PY_NULL),
+        "__set_name__",
+    )?;
+    let w_name = positional[2];
     unsafe { pyre_object::descriptor::w_property_set_name(prop, w_name) };
     Ok(pyre_object::w_none())
 }

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -7681,6 +7681,52 @@ const PYCF_ACCEPT_NULL_BYTES: i64 = 0x1000_0000;
 /// i.e. the flags `getcodeflags` masks out of a caller's `co_flags`.
 const COMPILER_FLAGS: i64 = 0x01FE_0000;
 
+/// `pyopcode.py:source_as_str` — turn text or one readable `PyBUF_SIMPLE`
+/// export into compiler input.  The export remains acquired while its bytes
+/// are copied and is released before decoding can raise.
+fn source_as_str(
+    source: PyObjectRef,
+    funcname: &str,
+    what: &str,
+    filename: &str,
+    flags: &mut i64,
+) -> Result<String, crate::PyError> {
+    unsafe {
+        if pyre_object::is_str(source) {
+            // A text source is encoded strictly and coding-cookie detection is
+            // disabled, matching PyPy's unicode branch.
+            let bytes = crate::type_methods::encode_object(source, "utf-8", "strict")?;
+            *flags |= PYCF_IGNORE_COOKIE;
+            return Ok(String::from_utf8(bytes).expect("strict utf-8 encode yields valid utf-8"));
+        }
+        if pyre_object::bytesobject::is_bytes(source) {
+            return crate::compile::decode_source_bytes(
+                pyre_object::bytesobject::bytes_like_data(source),
+                filename,
+                *flags & PYCF_IGNORE_COOKIE != 0,
+            );
+        }
+    }
+
+    let buffer = match crate::baseobjspace::simple_buffer_bytes(source) {
+        Ok(Some(buffer)) => buffer,
+        Ok(None) => {
+            return Err(crate::PyError::type_error(format!(
+                "{funcname}() arg 1 must be a {what} object"
+            )));
+        }
+        Err(error) if error.kind == crate::PyErrorKind::TypeError => {
+            return Err(crate::PyError::type_error(format!(
+                "{funcname}() arg 1 must be a {what} object"
+            )));
+        }
+        Err(error) => return Err(error),
+    };
+    let bytes = buffer.as_bytes().to_vec();
+    buffer.release();
+    crate::compile::decode_source_bytes(&bytes, filename, *flags & PYCF_IGNORE_COOKIE != 0)
+}
+
 fn builtin_compile(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     // `compile(source, filename, mode, flags=0, dont_inherit=False,
     // optimize=-1, *, _feature_version=-1)`: the three required parameters and
@@ -7792,44 +7838,29 @@ fn builtin_compile(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
         optimize = i64::from(crate::importing::optimize_flag());
     }
 
-    let source_str = unsafe {
-        if pyre_object::is_str(source) {
-            // The source is decoded to UTF-8 for the tokenizer; a lone
-            // surrogate raises `UnicodeEncodeError` (strict) rather than
-            // panicking in `w_str_get_value`.
-            let bytes = crate::type_methods::encode_object(source, "utf-8", "strict")?;
-            Some(String::from_utf8(bytes).expect("strict utf-8 encode yields valid utf-8"))
-        } else if pyre_object::bytesobject::is_bytes_like(source) {
-            // A bytes-like source honours the PEP 263 coding cookie and raises
-            // SyntaxError on undecodable bytes rather than lossily replacing.
-            Some(crate::compile::decode_source_bytes(
-                pyre_object::bytesobject::bytes_like_data(source),
-                &filename,
-                false,
-            )?)
-        } else {
-            // PyPy returns an AST input unchanged when ONLY_AST is requested.
-            // Keep this check at the public `_ast.AST` boundary so subclasses
-            // behave the same way as native nodes.
-            let ast_module = crate::importing::importhook(
-                "_ast",
-                PY_NULL,
-                PY_NULL,
-                0,
-                crate::call::take_last_exec_ctx(),
-            )?;
-            let ast_type = crate::baseobjspace::getattr_str(ast_module, "AST")?;
-            if crate::baseobjspace::isinstance_w(source, ast_type) {
-                if flags & PYCF_ONLY_AST != 0 {
-                    return Ok(source);
-                }
-                None
-            } else {
-                return Err(crate::PyError::type_error(
-                    "compile() arg 1 must be a string, bytes or AST object",
-                ));
-            }
+    // PyPy checks the public AST boundary before source_as_str so AST
+    // subclasses are compiled as trees rather than probed for a buffer.
+    let ast_module = crate::importing::importhook(
+        "_ast",
+        PY_NULL,
+        PY_NULL,
+        0,
+        crate::call::take_last_exec_ctx(),
+    )?;
+    let ast_type = crate::baseobjspace::getattr_str(ast_module, "AST")?;
+    let source_str = if unsafe { crate::baseobjspace::isinstance_w(source, ast_type) } {
+        if flags & PYCF_ONLY_AST != 0 {
+            return Ok(source);
         }
+        None
+    } else {
+        Some(source_as_str(
+            source,
+            "compile",
+            "string, bytes or AST",
+            &filename,
+            &mut flags,
+        )?)
     };
 
     // Assemble CompileOpts: the __future__ feature bits, the two PyCF_*
@@ -7927,38 +7958,30 @@ fn exec_or_eval(
     // original argument was already a code object (vs a compiled str /
     // bytes) — the closure validation below branches on it.
     let (code_obj_ref, source_is_code) = unsafe {
-        // `compiling.py:103 source_as_str` — accepts a str or a bytes-like
-        // source (decoded), or an already-compiled code object.
-        let source_str = if pyre_object::is_str(source) {
-            Some(pyre_object::w_str_get_value(source).to_string())
-        } else if pyre_object::bytesobject::is_bytes_like(source) {
-            // A bytes-like source honours the PEP 263 coding cookie and raises
-            // SyntaxError on undecodable bytes rather than lossily replacing.
-            Some(crate::compile::decode_source_bytes(
-                pyre_object::bytesobject::bytes_like_data(source),
-                "<string>",
-                false,
-            )?)
+        if !source.is_null() && crate::is_code(source) {
+            (source, true)
         } else {
-            None
-        };
-        if let Some(s) = source_str {
+            let mut flags = PYCF_SOURCE_IS_UTF8;
+            let mut source = source_as_str(
+                source,
+                if is_eval { "eval" } else { "exec" },
+                "string, bytes or code",
+                "<string>",
+                &mut flags,
+            )?;
+            if is_eval {
+                // compiling.py:eval compiles `source.lstrip(' \t')`.
+                source = source.trim_start_matches([' ', '\t']).to_owned();
+            }
             let mode = if is_eval {
                 crate::compile::Mode::Eval
             } else {
                 crate::compile::Mode::Exec
             };
-            let code = crate::compile::compile_source(&s, mode)
-                .map_err(|e| compile_err_to_syntax_error(e, &s))?;
+            let code = crate::compile::compile_source(&source, mode)
+                .map_err(|e| compile_err_to_syntax_error(e, &source))?;
             let code_ptr = Box::into_raw(Box::new(code)) as *const ();
             (crate::w_code_new(code_ptr), false)
-        } else if !source.is_null() && crate::is_code(source) {
-            (source, true)
-        } else {
-            return Err(crate::PyError::type_error(format!(
-                "{}() arg 1 must be a string, bytes or code object",
-                if is_eval { "eval" } else { "exec" }
-            )));
         }
     };
     let raw_code = unsafe {

--- a/pyre/pyre-interpreter/src/error.rs
+++ b/pyre/pyre-interpreter/src/error.rs
@@ -1538,7 +1538,13 @@ pub fn write_syntax_error<W: Write>(writer: &mut W, err: &PyError) -> std::io::R
 }
 
 fn write_syntax_error_object<W: Write>(writer: &mut W, exc: PyObjectRef) -> std::io::Result<()> {
-    let attr = |name: &str| crate::baseobjspace::syntax_error_attr(exc, name);
+    let _roots = pyre_object::gc_roots::push_roots();
+    let exc_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(exc);
+    let attr = |name: &str| {
+        let exc = pyre_object::gc_roots::shadow_stack_get(exc_slot);
+        crate::baseobjspace::syntax_error_attr(exc, name)
+    };
     let str_of = |w: PyObjectRef| -> Option<String> {
         (!w.is_null() && unsafe { pyre_object::is_str(w) })
             .then(|| unsafe { pyre_object::w_str_get_value(w) }.to_string())
@@ -1570,6 +1576,7 @@ fn write_syntax_error_object<W: Write>(writer: &mut W, exc: PyObjectRef) -> std:
             writeln!(writer, "{caret}")?;
         }
     }
+    let exc = pyre_object::gc_roots::shadow_stack_get(exc_slot);
     let name = exc_object_class_name(exc).unwrap_or_else(|| "SyntaxError".to_string());
     match str_of(attr("msg")) {
         Some(msg) if !msg.is_empty() => writeln!(writer, "{name}: {msg}"),
@@ -1597,7 +1604,7 @@ struct ExceptionPrintContext {
 impl ExceptionPrintContext {
     fn new(exc: PyObjectRef) -> Self {
         let mut seen = HashSet::new();
-        seen.insert(exc as usize);
+        seen.insert(pyre_object::gc_hook::gc_identity_hash(exc as usize));
         Self {
             seen,
             exception_group_depth: 0,
@@ -1611,82 +1618,136 @@ fn write_exception_object_recursive<W: Write>(
     exc: PyObjectRef,
     context: &mut ExceptionPrintContext,
 ) -> std::io::Result<()> {
-    let cause = unsafe { pyre_object::interp_exceptions::w_exception_get_cause(exc) };
-    let chained = if !cause.is_null()
-        && !unsafe { pyre_object::is_none(cause) }
-        && context.seen.insert(cause as usize)
-    {
-        Some((
-            cause,
-            "\nThe above exception was the direct cause of the following exception:\n\n",
-        ))
-    } else {
-        let previous = unsafe { pyre_object::interp_exceptions::w_exception_get_context(exc) };
-        let suppress =
-            unsafe { pyre_object::interp_exceptions::w_exception_get_suppress_context(exc) };
-        if !suppress
-            && !previous.is_null()
-            && !unsafe { pyre_object::is_none(previous) }
-            && context.seen.insert(previous as usize)
-        {
-            Some((
-                previous,
-                "\nDuring handling of the above exception, another exception occurred:\n\n",
-            ))
+    // `TracebackException.__init__` uses an explicit queue for chain capture.
+    // Keep the same non-recursive shape so an application-created chain cannot
+    // consume the native Rust stack.  Store shadow-stack slot indices, not raw
+    // GC pointers: formatting calls arbitrary `__str__` / attribute code.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let first_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(exc);
+    let mut chain: Vec<(usize, Option<&'static str>)> = Vec::new();
+    let mut current_slot = first_slot;
+    loop {
+        let current = pyre_object::gc_roots::shadow_stack_get(current_slot);
+        let cause = unsafe { pyre_object::interp_exceptions::w_exception_get_cause(current) };
+        let cause_slot = pin_unseen_exception(cause, context);
+        let (older_slot, banner) = if let Some(cause_slot) = cause_slot {
+            (
+                Some(cause_slot),
+                Some("\nThe above exception was the direct cause of the following exception:\n\n"),
+            )
         } else {
-            None
+            let current = pyre_object::gc_roots::shadow_stack_get(current_slot);
+            let suppress = unsafe {
+                pyre_object::interp_exceptions::w_exception_get_suppress_context(current)
+            };
+            let previous =
+                unsafe { pyre_object::interp_exceptions::w_exception_get_context(current) };
+            if !suppress {
+                if let Some(previous_slot) = pin_unseen_exception(previous, context) {
+                    (
+                        Some(previous_slot),
+                        Some(
+                            "\nDuring handling of the above exception, another exception occurred:\n\n",
+                        ),
+                    )
+                } else {
+                    (None, None)
+                }
+            } else {
+                (None, None)
+            }
+        };
+        chain.push((current_slot, banner));
+        match older_slot {
+            Some(slot) => current_slot = slot,
+            None => break,
         }
-    };
-    if let Some((older, banner)) = chained {
-        write_exception_object_recursive(writer, older, context)?;
-        emit_exception_text(writer, banner.as_bytes(), context, b'|')?;
     }
 
-    if exception_group_items(exc).is_some() {
-        write_exception_group(writer, exc, context)
-    } else {
-        write_plain_exception_object(writer, exc, context)
+    for (slot, banner) in chain.into_iter().rev() {
+        if let Some(banner) = banner {
+            emit_exception_text(writer, banner.as_bytes(), context, b'|')?;
+        }
+        if let Some(exceptions) = exception_group_item_slots(slot) {
+            write_exception_group(writer, slot, exceptions, context)?;
+        } else {
+            write_plain_exception_object(writer, slot, context)?;
+        }
     }
+    Ok(())
+}
+
+fn pin_unseen_exception(
+    candidate: PyObjectRef,
+    context: &mut ExceptionPrintContext,
+) -> Option<usize> {
+    if candidate.is_null() || unsafe { pyre_object::is_none(candidate) } {
+        return None;
+    }
+    let slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(candidate);
+    let candidate = pyre_object::gc_roots::shadow_stack_get(slot);
+    let identity = pyre_object::gc_hook::gc_identity_hash(candidate as usize);
+    context.seen.insert(identity).then_some(slot)
 }
 
 fn write_plain_exception_object<W: Write>(
     writer: &mut W,
-    exc: PyObjectRef,
+    exc_slot: usize,
     context: &ExceptionPrintContext,
 ) -> std::io::Result<()> {
     let mut rendered = Vec::new();
+    let exc = pyre_object::gc_roots::shadow_stack_get(exc_slot);
     let tb = unsafe { pyre_object::interp_exceptions::w_exception_get_traceback(exc) };
     if !tb.is_null() {
         writeln!(rendered, "Traceback (most recent call last):")?;
         write_traceback_chain_from_tb(&mut rendered, tb)?;
     }
+    let exc = pyre_object::gc_roots::shadow_stack_get(exc_slot);
     if unsafe { pyre_object::interp_exceptions::w_exception_get_kind(exc) } == ExcKind::SyntaxError
     {
         write_syntax_error_object(&mut rendered, exc)?;
     } else {
-        let header = render_exc_object_wtf8(exc);
+        let header = render_rooted_exc_object_wtf8(exc_slot);
         rendered.write_all(header.as_bytes())?;
         rendered.write_all(b"\n")?;
     }
+    let exc = pyre_object::gc_roots::shadow_stack_get(exc_slot);
     write_exception_notes(&mut rendered, exc)?;
     emit_exception_text(writer, &rendered, context, b'|')
 }
 
-fn exception_group_items(exc: PyObjectRef) -> Option<Vec<PyObjectRef>> {
+fn exception_group_item_slots(exc_slot: usize) -> Option<Vec<usize>> {
     let base_group = crate::builtins::lookup_exc_class("BaseExceptionGroup")?;
+    let exc = pyre_object::gc_roots::shadow_stack_get(exc_slot);
     if !crate::baseobjspace::isinstance(exc, base_group).ok()? {
         return None;
     }
+    let exc = pyre_object::gc_roots::shadow_stack_get(exc_slot);
     let exceptions = crate::baseobjspace::getattr_str(exc, "exceptions").ok()?;
+    let tuple_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(exceptions);
+    let exceptions = pyre_object::gc_roots::shadow_stack_get(tuple_slot);
     if !unsafe { pyre_object::is_tuple(exceptions) } {
         return None;
     }
-    Some(unsafe { pyre_object::w_tuple_items_copy_as_vec(exceptions) })
+    let len = unsafe { pyre_object::w_tuple_len(exceptions) };
+    let mut slots = Vec::with_capacity(len);
+    for index in 0..len {
+        let exceptions = pyre_object::gc_roots::shadow_stack_get(tuple_slot);
+        let child = unsafe { pyre_object::w_tuple_getitem(exceptions, index as i64) }?;
+        let child_slot = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(child);
+        slots.push(child_slot);
+    }
+    Some(slots)
 }
 
 fn write_exception_group<W: Write>(
     writer: &mut W,
-    exc: PyObjectRef,
+    exc_slot: usize,
+    exceptions: Vec<usize>,
     context: &mut ExceptionPrintContext,
 ) -> std::io::Result<()> {
     const MAX_GROUP_WIDTH: usize = 15;
@@ -1695,15 +1756,12 @@ fn write_exception_group<W: Write>(
     if context.exception_group_depth > MAX_GROUP_DEPTH {
         return emit_exception_text(writer, b"... (max_group_depth is 10)\n", context, b'|');
     }
-    let exceptions = match exception_group_items(exc) {
-        Some(exceptions) => exceptions,
-        None => return write_plain_exception_object(writer, exc, context),
-    };
     let is_toplevel = context.exception_group_depth == 0;
     if is_toplevel {
         context.exception_group_depth += 1;
     }
 
+    let exc = pyre_object::gc_roots::shadow_stack_get(exc_slot);
     let tb = unsafe { pyre_object::interp_exceptions::w_exception_get_traceback(exc) };
     if !tb.is_null() {
         emit_exception_text(
@@ -1718,9 +1776,10 @@ fn write_exception_group<W: Write>(
     }
 
     let mut header = Vec::new();
-    let group_header = render_exc_object_wtf8(exc);
+    let group_header = render_rooted_exc_object_wtf8(exc_slot);
     header.write_all(group_header.as_bytes())?;
     header.write_all(b"\n")?;
+    let exc = pyre_object::gc_roots::shadow_stack_get(exc_slot);
     write_exception_notes(&mut header, exc)?;
     emit_exception_text(writer, &header, context, b'|')?;
 
@@ -1759,8 +1818,10 @@ fn write_exception_group<W: Write>(
                 b'|',
             )?;
         } else {
-            let child = exceptions[index];
-            context.seen.insert(child as usize);
+            let child = pyre_object::gc_roots::shadow_stack_get(exceptions[index]);
+            context
+                .seen
+                .insert(pyre_object::gc_hook::gc_identity_hash(child as usize));
             write_exception_object_recursive(writer, child, context)?;
         }
         if last && context.need_close {
@@ -1869,19 +1930,30 @@ fn write_exception_notes<W: Write>(writer: &mut W, exc: PyObjectRef) -> std::io:
     if exc.is_null() || !unsafe { pyre_object::is_exception(exc) } {
         return Ok(());
     }
+    let _roots = pyre_object::gc_roots::push_roots();
+    let exc_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(exc);
+    let exc = pyre_object::gc_roots::shadow_stack_get(exc_slot);
     let notes = match crate::baseobjspace::getattr_str(exc, "__notes__") {
         Ok(v) if !v.is_null() => v,
         _ => return Ok(()),
     };
+    let notes_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(notes);
+    let notes = pyre_object::gc_roots::shadow_stack_get(notes_slot);
     if !unsafe { pyre_object::is_list(notes) } {
         return Ok(());
     }
     let len = unsafe { pyre_object::w_list_len(notes) } as i64;
     for i in 0..len {
+        let notes = pyre_object::gc_roots::shadow_stack_get(notes_slot);
         let item = unsafe { pyre_object::w_list_getitem(notes, i) }.unwrap_or(pyre_object::PY_NULL);
         if item.is_null() {
             continue;
         }
+        let item_slot = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(item);
+        let item = pyre_object::gc_roots::shadow_stack_get(item_slot);
         let s = unsafe { crate::display::py_str(item) }
             .unwrap_or_else(|_| "<unprintable note>".to_string());
         for line in s.lines() {
@@ -1903,6 +1975,29 @@ fn render_exc_object(exc: PyObjectRef) -> String {
         .ok()
         .and_then(|b| String::from_utf8(b).ok())
         .unwrap_or_else(|| "<exception str() failed>".to_string())
+}
+
+fn render_rooted_exc_object_wtf8(exc_slot: usize) -> Wtf8Buf {
+    let exc = pyre_object::gc_roots::shadow_stack_get(exc_slot);
+    if exc.is_null() || !unsafe { pyre_object::is_exception(exc) } {
+        return Wtf8Buf::from_string("<no exception>".to_string());
+    }
+    let name = exc_object_class_name(exc).unwrap_or_else(|| {
+        let exc = pyre_object::gc_roots::shadow_stack_get(exc_slot);
+        let kind = unsafe { pyre_object::interp_exceptions::w_exception_get_kind(exc) };
+        exc_kind_name(kind).to_string()
+    });
+    let exc = pyre_object::gc_roots::shadow_stack_get(exc_slot);
+    let msg = unsafe {
+        crate::display::py_str_wtf8(exc)
+            .unwrap_or_else(|_| Wtf8Buf::from_string("<exception str() failed>".to_string()))
+    };
+    let mut rendered = Wtf8Buf::from_string(name);
+    if !msg.as_bytes().is_empty() {
+        rendered.push_str(": ");
+        rendered.push_wtf8(&msg);
+    }
+    rendered
 }
 
 fn render_exc_object_wtf8(exc: PyObjectRef) -> Wtf8Buf {

--- a/pyre/pyre-interpreter/src/error.rs
+++ b/pyre/pyre-interpreter/src/error.rs
@@ -1950,7 +1950,21 @@ fn write_exception_notes<W: Write>(writer: &mut W, exc: PyObjectRef) -> std::io:
     let exc = pyre_object::gc_roots::shadow_stack_get(exc_slot);
     let notes = match crate::baseobjspace::getattr_str(exc, "__notes__") {
         Ok(v) if !v.is_null() => v,
-        _ => return Ok(()),
+        Ok(_) => return Ok(()),
+        Err(err) if err.kind == PyErrorKind::AttributeError => return Ok(()),
+        Err(mut err) => {
+            // `traceback.py:1068-1072 TracebackException.__init__` preserves
+            // failures raised by a custom `__notes__` descriptor as a
+            // synthetic note instead of silently discarding the diagnostic.
+            let err_obj = err.to_exc_object();
+            pyre_object::gc_roots::pin_root(err_obj);
+            let err_obj = pyre_object::gc_roots::shadow_stack_get(
+                pyre_object::gc_roots::shadow_stack_len() - 1,
+            );
+            let rendered = unsafe { crate::display::py_repr(err_obj) }
+                .unwrap_or_else(|_| "<exception repr() failed>".to_string());
+            return writeln!(writer, "Ignored error getting __notes__: {rendered}");
+        }
     };
     let notes_slot = pyre_object::gc_roots::shadow_stack_len();
     pyre_object::gc_roots::pin_root(notes);
@@ -2030,6 +2044,9 @@ fn render_rooted_exc_object_wtf8(exc_slot: usize) -> Wtf8Buf {
         rendered.push_str(": ");
         rendered.push_wtf8(&msg);
     }
+    if let Some(suffix) = exception_suggestion(exc_slot) {
+        rendered.push_str(&suffix);
+    }
     rendered
 }
 
@@ -2037,25 +2054,258 @@ fn render_exc_object_wtf8(exc: PyObjectRef) -> Wtf8Buf {
     if exc.is_null() || !unsafe { pyre_object::is_exception(exc) } {
         return Wtf8Buf::from_string("<no exception>".to_string());
     }
-    let name = exc_object_class_name(exc).unwrap_or_else(|| {
-        let kind = unsafe { pyre_object::interp_exceptions::w_exception_get_kind(exc) };
-        exc_kind_name(kind).to_string()
-    });
-    // `Python/pythonrun.c:print_exception_message` calls
-    // `PyObject_Str(value)`, so specialized builtin formatting
-    // (KeyError/OSError/Unicode errors) and a user `__str__` override all win
-    // over reconstructing a message from `args`.  A raising `__str__` is
-    // cleared and rendered with CPython's diagnostic placeholder.
-    let msg = unsafe {
-        crate::display::py_str_wtf8(exc)
-            .unwrap_or_else(|_| Wtf8Buf::from_string("<exception str() failed>".to_string()))
-    };
-    let mut rendered = Wtf8Buf::from_string(name);
-    if !msg.as_bytes().is_empty() {
-        rendered.push_str(": ");
-        rendered.push_wtf8(&msg);
+    let _roots = pyre_object::gc_roots::push_roots();
+    let exc_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(exc);
+    render_rooted_exc_object_wtf8(exc_slot)
+}
+
+const MAX_SUGGESTION_CANDIDATES: usize = 750;
+const MAX_SUGGESTION_STRING_SIZE: usize = 40;
+const SUGGESTION_MOVE_COST: usize = 2;
+
+fn dict_string_keys(dict: PyObjectRef, names: &mut Vec<String>) {
+    if dict.is_null() || !unsafe { pyre_object::is_dict(dict) } {
+        return;
     }
-    rendered
+    for (key, _) in unsafe { pyre_object::w_dict_items(dict) } {
+        if unsafe { pyre_object::is_str(key) } {
+            names.push(unsafe { pyre_object::w_str_get_value(key) }.to_string());
+        }
+    }
+}
+
+fn suggestion_distance(a: &str, b: &str, max_cost: usize) -> usize {
+    let mut a: Vec<char> = a.chars().collect();
+    let mut b: Vec<char> = b.chars().collect();
+    if a == b {
+        return 0;
+    }
+    while a.first() == b.first() && !a.is_empty() {
+        a.remove(0);
+        b.remove(0);
+    }
+    while a.last() == b.last() && !a.is_empty() {
+        a.pop();
+        b.pop();
+    }
+    if a.is_empty() || b.is_empty() {
+        return SUGGESTION_MOVE_COST * (a.len() + b.len());
+    }
+    if a.len() > MAX_SUGGESTION_STRING_SIZE || b.len() > MAX_SUGGESTION_STRING_SIZE {
+        return max_cost + 1;
+    }
+    if b.len() < a.len() {
+        std::mem::swap(&mut a, &mut b);
+    }
+    if (b.len() - a.len()) * SUGGESTION_MOVE_COST > max_cost {
+        return max_cost + 1;
+    }
+    let mut row: Vec<usize> = (1..=a.len())
+        .map(|index| index * SUGGESTION_MOVE_COST)
+        .collect();
+    let mut result = 0;
+    for (bindex, bchar) in b.iter().enumerate() {
+        let mut distance = bindex * SUGGESTION_MOVE_COST;
+        result = distance;
+        let mut minimum = usize::MAX;
+        for (index, achar) in a.iter().enumerate() {
+            let case_equal = achar.to_lowercase().eq(bchar.to_lowercase());
+            let substitute = distance
+                + if achar == bchar {
+                    0
+                } else if case_equal {
+                    1
+                } else {
+                    SUGGESTION_MOVE_COST
+                };
+            distance = row[index];
+            result = (result.min(distance) + SUGGESTION_MOVE_COST).min(substitute);
+            row[index] = result;
+            minimum = minimum.min(result);
+        }
+        if minimum > max_cost {
+            return max_cost + 1;
+        }
+    }
+    result
+}
+
+fn best_suggestion(candidates: &[String], wrong_name: &str) -> Option<String> {
+    if candidates.len() > MAX_SUGGESTION_CANDIDATES
+        || wrong_name.chars().count() > MAX_SUGGESTION_STRING_SIZE
+    {
+        return None;
+    }
+    let wrong_len = wrong_name.chars().count();
+    let mut best_distance = wrong_len;
+    let mut suggestion = None;
+    for candidate in candidates {
+        if candidate == wrong_name {
+            continue;
+        }
+        let candidate_len = candidate.chars().count();
+        let mut max_distance = (candidate_len + wrong_len + 3) * SUGGESTION_MOVE_COST / 6;
+        max_distance = max_distance.min(best_distance.saturating_sub(1));
+        let distance = suggestion_distance(wrong_name, candidate, max_distance);
+        if distance <= max_distance && (suggestion.is_none() || distance < best_distance) {
+            suggestion = Some(candidate.clone());
+            best_distance = distance;
+        }
+    }
+    suggestion
+}
+
+fn traceback_last_frame(tb: PyObjectRef) -> Option<*mut crate::pyframe::PyFrame> {
+    if tb.is_null() {
+        return None;
+    }
+    let mut current = tb;
+    let mut last_slot = None;
+    while !current.is_null() && unsafe { crate::pytraceback::is_pytraceback(current) } {
+        let slot = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(current);
+        last_slot = Some(slot);
+        let rooted_current = pyre_object::gc_roots::shadow_stack_get(slot);
+        current = unsafe { crate::pytraceback::w_pytraceback_get_w_next(rooted_current) };
+    }
+    let tb = pyre_object::gc_roots::shadow_stack_get(last_slot?);
+    let frame = unsafe { crate::pytraceback::w_pytraceback_get_frame(tb) };
+    (!frame.is_null()).then_some(frame)
+}
+
+fn object_dir_strings(obj: PyObjectRef) -> Option<Vec<String>> {
+    if obj.is_null() || unsafe { pyre_object::is_none(obj) } {
+        return None;
+    }
+    let slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(obj);
+    let obj = pyre_object::gc_roots::shadow_stack_get(slot);
+    let names = crate::builtins::builtin_dir(&[obj]).ok()?;
+    let names_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(names);
+    let names = pyre_object::gc_roots::shadow_stack_get(names_slot);
+    let items = crate::builtins::collect_iterable(names).ok()?;
+    Some(
+        items
+            .into_iter()
+            .filter(|item| unsafe { pyre_object::is_str(*item) })
+            .filter_map(|item| {
+                unsafe { pyre_object::w_str_get_wtf8(item).as_str() }
+                    .ok()
+                    .map(str::to_owned)
+            })
+            .collect(),
+    )
+}
+
+fn stdlib_module_name(name: &str) -> bool {
+    let Some(sys) = crate::importing::get_interpreter_sys_module() else {
+        return false;
+    };
+    let Ok(names) = crate::baseobjspace::getattr_str(sys, "stdlib_module_names") else {
+        return false;
+    };
+    if !unsafe { pyre_object::is_set_or_frozenset(names) } {
+        return false;
+    }
+    let names_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(names);
+    let name = pyre_object::w_str_new(name);
+    let name_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(name);
+    let names = pyre_object::gc_roots::shadow_stack_get(names_slot);
+    let name = pyre_object::gc_roots::shadow_stack_get(name_slot);
+    crate::baseobjspace::contains(names, name).unwrap_or(false)
+}
+
+/// `traceback.py:1096-1114,1601-1684` enhanced error messages.
+fn exception_suggestion(exc_slot: usize) -> Option<String> {
+    let exc = pyre_object::gc_roots::shadow_stack_get(exc_slot);
+    let kind = unsafe { pyre_object::interp_exceptions::w_exception_get_kind(exc) };
+    let wrong = match kind {
+        ExcKind::ImportError => unsafe {
+            pyre_object::interp_exceptions::w_exception_get_import_name_from(exc)
+        },
+        ExcKind::NameError | ExcKind::AttributeError => unsafe {
+            pyre_object::interp_exceptions::w_exception_get_name(exc)
+        },
+        _ => return None,
+    };
+    if wrong.is_null()
+        || unsafe { pyre_object::is_none(wrong) }
+        || !unsafe { pyre_object::is_str(wrong) }
+    {
+        return None;
+    }
+    let wrong_name = unsafe { pyre_object::w_str_get_value(wrong) }.to_string();
+    let exc = pyre_object::gc_roots::shadow_stack_get(exc_slot);
+    let tb = unsafe { pyre_object::interp_exceptions::w_exception_get_traceback(exc) };
+    let suggestion = match kind {
+        ExcKind::AttributeError => {
+            let exc = pyre_object::gc_roots::shadow_stack_get(exc_slot);
+            let obj = unsafe { pyre_object::interp_exceptions::w_exception_get_attr_obj(exc) };
+            object_dir_strings(obj).and_then(|mut names| {
+                if !wrong_name.starts_with('_') {
+                    names.retain(|name| !name.starts_with('_'));
+                }
+                best_suggestion(&names, &wrong_name)
+            })
+        }
+        ExcKind::ImportError => {
+            let exc = pyre_object::gc_roots::shadow_stack_get(exc_slot);
+            let module_name = unsafe { pyre_object::interp_exceptions::w_exception_get_name(exc) };
+            if module_name.is_null() || !unsafe { pyre_object::is_str(module_name) } {
+                None
+            } else {
+                let module_name = unsafe { pyre_object::w_str_get_value(module_name) }.to_string();
+                crate::importing::get_sys_module(&module_name)
+                    .or_else(|| {
+                        crate::importing::importhook(
+                            &module_name,
+                            pyre_object::w_none(),
+                            pyre_object::w_none(),
+                            0,
+                            crate::call::take_last_exec_ctx(),
+                        )
+                        .ok()
+                    })
+                    .and_then(object_dir_strings)
+                    .and_then(|mut names| {
+                        if !wrong_name.starts_with('_') {
+                            names.retain(|name| !name.starts_with('_'));
+                        }
+                        best_suggestion(&names, &wrong_name)
+                    })
+            }
+        }
+        ExcKind::NameError => {
+            let frame = traceback_last_frame(tb)?;
+            let frame = unsafe { &mut *frame };
+            let mut names = Vec::new();
+            if let Ok(locals) = frame.getdictscope() {
+                dict_string_keys(locals, &mut names);
+                if let Some(self_obj) = unsafe { pyre_object::w_dict_getitem_str(locals, "self") } {
+                    if crate::baseobjspace::getattr_str(self_obj, &wrong_name).is_ok() {
+                        return Some(format!(". Did you mean: 'self.{wrong_name}'?"));
+                    }
+                }
+            }
+            dict_string_keys(frame.get_w_globals(), &mut names);
+            dict_string_keys(frame.fget_f_builtins(), &mut names);
+            best_suggestion(&names, &wrong_name)
+        }
+        _ => None,
+    };
+    let mut suffix = suggestion.map(|value| format!(". Did you mean: '{value}'?"));
+    if kind == ExcKind::NameError && stdlib_module_name(&wrong_name) {
+        let import = format!("Did you forget to import '{wrong_name}'?");
+        match suffix.as_mut() {
+            Some(text) => text.push_str(&format!(" Or {import}")),
+            None => suffix = Some(format!(". {import}")),
+        }
+    }
+    suffix
 }
 
 /// `pypy/interpreter/error.py:125-158 print_app_tb_only` parity —
@@ -2085,13 +2335,17 @@ fn write_traceback_chain_from_tb<W: Write>(
     writer: &mut W,
     mut tb: PyObjectRef,
 ) -> std::io::Result<()> {
+    let _roots = pyre_object::gc_roots::push_roots();
     while !tb.is_null() {
-        if !unsafe { crate::pytraceback::is_pytraceback(tb) } {
+        let tb_slot = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(tb);
+        let current_tb = pyre_object::gc_roots::shadow_stack_get(tb_slot);
+        if !unsafe { crate::pytraceback::is_pytraceback(current_tb) } {
             break;
         }
-        let w_code = unsafe { crate::pytraceback::w_pytraceback_get_w_code(tb) };
-        let lineno = unsafe { crate::pytraceback::w_pytraceback_get_lineno(tb) };
-        let lasti = unsafe { crate::pytraceback::w_pytraceback_get_lasti(tb) };
+        let w_code = unsafe { crate::pytraceback::w_pytraceback_get_w_code(current_tb) };
+        let lineno = unsafe { crate::pytraceback::w_pytraceback_get_lineno(current_tb) };
+        let lasti = unsafe { crate::pytraceback::w_pytraceback_get_lasti(current_tb) };
         let (filename, funcname, location) = if w_code.is_null() {
             (String::from("<unknown>"), String::from("<unknown>"), None)
         } else {
@@ -2174,7 +2428,8 @@ fn write_traceback_chain_from_tb<W: Write>(
                 }
             }
         }
-        tb = unsafe { crate::pytraceback::w_pytraceback_get_w_next(tb) };
+        let current_tb = pyre_object::gc_roots::shadow_stack_get(tb_slot);
+        tb = unsafe { crate::pytraceback::w_pytraceback_get_w_next(current_tb) };
     }
     Ok(())
 }

--- a/pyre/pyre-interpreter/src/error.rs
+++ b/pyre/pyre-interpreter/src/error.rs
@@ -2,6 +2,7 @@ use pyre_object::PyObjectRef;
 use pyre_object::interp_exceptions::{ExcKind, exc_kind_name, w_exception_new};
 use ruff_text_size::Ranged;
 use rustpython_compiler::{ast, parser};
+use rustpython_wtf8::Wtf8Buf;
 use std::io::Write;
 use std::sync::OnceLock;
 
@@ -1523,7 +1524,15 @@ pub fn write_exception_from_parts<W: Write>(
         write_traceback_chain_from_tb(writer, current_tb)?;
     }
     let exc_value = pyre_object::gc_roots::shadow_stack_get(exc_value_slot);
-    writeln!(writer, "{}", render_exc_object(exc_value))?;
+    if unsafe { pyre_object::interp_exceptions::w_exception_get_kind(exc_value) }
+        == ExcKind::SyntaxError
+    {
+        write_syntax_error_object(writer, exc_value)?;
+    } else {
+        let rendered = render_exc_object_wtf8(exc_value);
+        writer.write_all(rendered.as_bytes())?;
+        writer.write_all(b"\n")?;
+    }
     write_exception_notes(
         writer,
         pyre_object::gc_roots::shadow_stack_get(exc_value_slot),
@@ -1543,6 +1552,10 @@ pub fn write_syntax_error<W: Write>(writer: &mut W, err: &PyError) -> std::io::R
     if exc.is_null() || !unsafe { pyre_object::is_exception(exc) } {
         return writeln!(writer, "{}", err.render_exception());
     }
+    write_syntax_error_object(writer, exc)
+}
+
+fn write_syntax_error_object<W: Write>(writer: &mut W, exc: PyObjectRef) -> std::io::Result<()> {
     let attr = |name: &str| crate::baseobjspace::syntax_error_attr(exc, name);
     let str_of = |w: PyObjectRef| -> Option<String> {
         (!w.is_null() && unsafe { pyre_object::is_str(w) })
@@ -1575,8 +1588,7 @@ pub fn write_syntax_error<W: Write>(writer: &mut W, err: &PyError) -> std::io::R
             writeln!(writer, "{caret}")?;
         }
     }
-    let name =
-        exc_object_class_name(exc).unwrap_or_else(|| exc_kind_name(err.to_exc_kind()).to_string());
+    let name = exc_object_class_name(exc).unwrap_or_else(|| "SyntaxError".to_string());
     match str_of(attr("msg")) {
         Some(msg) if !msg.is_empty() => writeln!(writer, "{name}: {msg}"),
         _ => writeln!(writer, "{name}"),
@@ -1670,8 +1682,20 @@ fn write_exception_notes<W: Write>(writer: &mut W, exc: PyObjectRef) -> std::io:
 /// Compose the `ExcName: msg` header for a W_BaseException —
 /// equivalent to `traceback.format_exception_only`'s last line.
 fn render_exc_object(exc: PyObjectRef) -> String {
+    let rendered = render_exc_object_wtf8(exc);
+    if let Ok(s) = rendered.as_str() {
+        return s.to_owned();
+    }
+    let s_obj = pyre_object::w_str_from_wtf8(rendered);
+    crate::type_methods::encode_object(s_obj, "utf-8", "backslashreplace")
+        .ok()
+        .and_then(|b| String::from_utf8(b).ok())
+        .unwrap_or_else(|| "<exception str() failed>".to_string())
+}
+
+fn render_exc_object_wtf8(exc: PyObjectRef) -> Wtf8Buf {
     if exc.is_null() || !unsafe { pyre_object::is_exception(exc) } {
-        return String::from("<no exception>");
+        return Wtf8Buf::from_string("<no exception>".to_string());
     }
     let name = exc_object_class_name(exc).unwrap_or_else(|| {
         let kind = unsafe { pyre_object::interp_exceptions::w_exception_get_kind(exc) };
@@ -1683,26 +1707,15 @@ fn render_exc_object(exc: PyObjectRef) -> String {
     // over reconstructing a message from `args`.  A raising `__str__` is
     // cleared and rendered with CPython's diagnostic placeholder.
     let msg = unsafe {
-        match crate::display::py_str_wtf8(exc) {
-            Ok(w) => {
-                if let Ok(s) = w.as_str() {
-                    s.to_owned()
-                } else {
-                    let s_obj = pyre_object::w_str_from_wtf8(w);
-                    crate::type_methods::encode_object(s_obj, "utf-8", "backslashreplace")
-                        .ok()
-                        .and_then(|b| String::from_utf8(b).ok())
-                        .unwrap_or_else(|| "<exception str() failed>".to_string())
-                }
-            }
-            Err(_) => "<exception str() failed>".to_string(),
-        }
+        crate::display::py_str_wtf8(exc)
+            .unwrap_or_else(|_| Wtf8Buf::from_string("<exception str() failed>".to_string()))
     };
-    if msg.is_empty() {
-        name
-    } else {
-        format!("{name}: {msg}")
+    let mut rendered = Wtf8Buf::from_string(name);
+    if !msg.as_bytes().is_empty() {
+        rendered.push_str(": ");
+        rendered.push_wtf8(&msg);
     }
+    rendered
 }
 
 /// `pypy/interpreter/error.py:125-158 print_app_tb_only` parity —

--- a/pyre/pyre-interpreter/src/error.rs
+++ b/pyre/pyre-interpreter/src/error.rs
@@ -1468,6 +1468,46 @@ pub fn write_exception<W: Write>(
     }
 }
 
+/// CPython `_PyErr_Display(file, exc_type, exc_value, exc_tb)` shape used by
+/// `_thread._excepthook`.
+///
+/// The exception hook receives the traceback as a separate structseq field;
+/// it must display that live value rather than reading (or mutating)
+/// `exc_value.__traceback__`.  PyPy's `OperationError.print_application_traceback`
+/// likewise carries its traceback independently from the wrapped value.
+pub fn write_exception_from_parts<W: Write>(
+    writer: &mut W,
+    exc_value: PyObjectRef,
+    exc_tb: PyObjectRef,
+) -> std::io::Result<()> {
+    if exc_value.is_null() || !unsafe { pyre_object::is_exception(exc_value) } {
+        if !exc_value.is_null() && unsafe { pyre_object::is_none(exc_value) } {
+            return writeln!(writer, "NoneType: None");
+        }
+        let value_type = crate::typedef::r#type(exc_value)
+            .map(|tp| unsafe { pyre_object::w_type_get_name(tp.as_ptr()).to_string() })
+            .unwrap_or_else(|| "NULL".to_string());
+        return writeln!(
+            writer,
+            "TypeError: print_exception(): Exception expected for value, {value_type} found"
+        );
+    }
+
+    // `PyErr_DisplayException`: older explicit cause/context entries precede
+    // the current value, while the current traceback comes from the argument
+    // supplied by ExceptHookArgs.
+    write_chained_context(writer, exc_value)?;
+    if !exc_tb.is_null()
+        && !unsafe { pyre_object::is_none(exc_tb) }
+        && unsafe { crate::pytraceback::is_pytraceback(exc_tb) }
+    {
+        writeln!(writer, "Traceback (most recent call last):")?;
+        write_traceback_chain_from_tb(writer, exc_tb)?;
+    }
+    writeln!(writer, "{}", render_exc_object(exc_value))?;
+    write_exception_notes(writer, exc_value)
+}
+
 /// Render an uncaught compile-time SyntaxError as the top-level banner
 /// (`print_error_text`): the `File "…", line N` header, the offending
 /// source line, a caret under the offending column span, and
@@ -1672,7 +1712,14 @@ fn write_traceback_chain_from_exc<W: Write>(
     if exc.is_null() || !unsafe { pyre_object::is_exception(exc) } {
         return Ok(());
     }
-    let mut tb = unsafe { pyre_object::interp_exceptions::w_exception_get_traceback(exc) };
+    let tb = unsafe { pyre_object::interp_exceptions::w_exception_get_traceback(exc) };
+    write_traceback_chain_from_tb(writer, tb)
+}
+
+fn write_traceback_chain_from_tb<W: Write>(
+    writer: &mut W,
+    mut tb: PyObjectRef,
+) -> std::io::Result<()> {
     while !tb.is_null() {
         if !unsafe { crate::pytraceback::is_pytraceback(tb) } {
             break;

--- a/pyre/pyre-interpreter/src/error.rs
+++ b/pyre/pyre-interpreter/src/error.rs
@@ -1468,18 +1468,24 @@ pub fn write_exception<W: Write>(
     }
 }
 
-/// CPython `_PyErr_Display(file, exc_type, exc_value, exc_tb)` shape used by
-/// `_thread._excepthook`.
+/// CPython 3.14 `_PyErr_Display(file, exc_type, exc_value, exc_tb)` shape used
+/// by `_thread._excepthook`.
 ///
-/// The exception hook receives the traceback as a separate structseq field;
-/// it must display that live value rather than reading (or mutating)
-/// `exc_value.__traceback__`.  PyPy's `OperationError.print_application_traceback`
-/// likewise carries its traceback independently from the wrapped value.
+/// `Python/pythonrun.c:_PyErr_Display` installs a supplied traceback only when
+/// the exception has none, then displays the traceback resident on the
+/// exception.  An existing traceback therefore wins and the one-time
+/// installation remains observable through `exc_value.__traceback__`.
 pub fn write_exception_from_parts<W: Write>(
     writer: &mut W,
     exc_value: PyObjectRef,
     exc_tb: PyObjectRef,
 ) -> std::io::Result<()> {
+    let _roots = pyre_object::gc_roots::push_roots();
+    let exc_value_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(exc_value);
+    let exc_tb_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(exc_tb);
+    let exc_value = pyre_object::gc_roots::shadow_stack_get(exc_value_slot);
     if exc_value.is_null() || !unsafe { pyre_object::is_exception(exc_value) } {
         if !exc_value.is_null() && unsafe { pyre_object::is_none(exc_value) } {
             return writeln!(writer, "NoneType: None");
@@ -1493,19 +1499,35 @@ pub fn write_exception_from_parts<W: Write>(
         );
     }
 
-    // `PyErr_DisplayException`: older explicit cause/context entries precede
-    // the current value, while the current traceback comes from the argument
-    // supplied by ExceptHookArgs.
-    write_chained_context(writer, exc_value)?;
+    let exc_tb = pyre_object::gc_roots::shadow_stack_get(exc_tb_slot);
     if !exc_tb.is_null()
         && !unsafe { pyre_object::is_none(exc_tb) }
         && unsafe { crate::pytraceback::is_pytraceback(exc_tb) }
+        && unsafe { pyre_object::interp_exceptions::w_exception_get_traceback(exc_value).is_null() }
     {
-        writeln!(writer, "Traceback (most recent call last):")?;
-        write_traceback_chain_from_tb(writer, exc_tb)?;
+        unsafe {
+            pyre_object::interp_exceptions::w_exception_set_traceback(exc_value, exc_tb);
+        }
     }
+
+    // Older explicit cause/context entries precede the current value.  The
+    // current traceback is the exception-resident value after the conditional
+    // installation above, exactly as `print_exception_recursive` observes it.
+    let exc_value = pyre_object::gc_roots::shadow_stack_get(exc_value_slot);
+    write_chained_context(writer, exc_value)?;
+    let exc_value = pyre_object::gc_roots::shadow_stack_get(exc_value_slot);
+    let current_tb =
+        unsafe { pyre_object::interp_exceptions::w_exception_get_traceback(exc_value) };
+    if !current_tb.is_null() {
+        writeln!(writer, "Traceback (most recent call last):")?;
+        write_traceback_chain_from_tb(writer, current_tb)?;
+    }
+    let exc_value = pyre_object::gc_roots::shadow_stack_get(exc_value_slot);
     writeln!(writer, "{}", render_exc_object(exc_value))?;
-    write_exception_notes(writer, exc_value)
+    write_exception_notes(
+        writer,
+        pyre_object::gc_roots::shadow_stack_get(exc_value_slot),
+    )
 }
 
 /// Render an uncaught compile-time SyntaxError as the top-level banner
@@ -1655,35 +1677,25 @@ fn render_exc_object(exc: PyObjectRef) -> String {
         let kind = unsafe { pyre_object::interp_exceptions::w_exception_get_kind(exc) };
         exc_kind_name(kind).to_string()
     });
-    // `str(e)` semantically — pyre stores args as a list; the
-    // first arg's str repr is the message.  Empty args produces
-    // bare `ExcName` per `traceback.format_exception_only`.
-    let args = unsafe { pyre_object::interp_exceptions::w_exception_get_args(exc) };
+    // `Python/pythonrun.c:print_exception_message` calls
+    // `PyObject_Str(value)`, so specialized builtin formatting
+    // (KeyError/OSError/Unicode errors) and a user `__str__` override all win
+    // over reconstructing a message from `args`.  A raising `__str__` is
+    // cleared and rendered with CPython's diagnostic placeholder.
     let msg = unsafe {
-        if args.is_null() || !pyre_object::is_tuple(args) {
-            String::new()
-        } else {
-            let len = pyre_object::w_tuple_len(args);
-            if len == 0 {
-                String::new()
-            } else if len == 1 {
-                let first = pyre_object::w_tuple_getitem(args, 0).unwrap_or(pyre_object::PY_NULL);
-                if first.is_null() {
-                    String::new()
+        match crate::display::py_str_wtf8(exc) {
+            Ok(w) => {
+                if let Ok(s) = w.as_str() {
+                    s.to_owned()
                 } else {
-                    crate::display::py_str_display(first)
+                    let s_obj = pyre_object::w_str_from_wtf8(w);
+                    crate::type_methods::encode_object(s_obj, "utf-8", "backslashreplace")
+                        .ok()
+                        .and_then(|b| String::from_utf8(b).ok())
+                        .unwrap_or_else(|| "<exception str() failed>".to_string())
                 }
-            } else {
-                // Multi-arg exceptions render as tuple repr — matches
-                // BaseException.__str__ (`interp_exceptions.py:142`).
-                let items: Vec<String> = (0..len as i64)
-                    .filter_map(|i| pyre_object::w_tuple_getitem(args, i))
-                    .map(|w| {
-                        crate::display::py_repr(w).unwrap_or_else(|_| "<unprintable>".to_string())
-                    })
-                    .collect();
-                format!("({})", items.join(", "))
             }
+            Err(_) => "<exception str() failed>".to_string(),
         }
     };
     if msg.is_empty() {

--- a/pyre/pyre-interpreter/src/error.rs
+++ b/pyre/pyre-interpreter/src/error.rs
@@ -2146,7 +2146,7 @@ fn best_suggestion(candidates: &[String], wrong_name: &str) -> Option<String> {
         }
         let candidate_len = candidate.chars().count();
         let mut max_distance = (candidate_len + wrong_len + 3) * SUGGESTION_MOVE_COST / 6;
-        max_distance = max_distance.min(best_distance.saturating_sub(1));
+        max_distance = max_distance.min(best_distance);
         let distance = suggestion_distance(wrong_name, candidate, max_distance);
         if distance <= max_distance && (suggestion.is_none() || distance < best_distance) {
             suggestion = Some(candidate.clone());
@@ -2160,17 +2160,18 @@ fn traceback_last_frame(tb: PyObjectRef) -> Option<*mut crate::pyframe::PyFrame>
     if tb.is_null() {
         return None;
     }
-    let mut current = tb;
-    let mut last_slot = None;
+    let tb_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(tb);
+    let mut current = pyre_object::gc_roots::shadow_stack_get(tb_slot);
+    let mut last = pyre_object::PY_NULL;
     while !current.is_null() && unsafe { crate::pytraceback::is_pytraceback(current) } {
-        let slot = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(current);
-        last_slot = Some(slot);
-        let rooted_current = pyre_object::gc_roots::shadow_stack_get(slot);
-        current = unsafe { crate::pytraceback::w_pytraceback_get_w_next(rooted_current) };
+        last = current;
+        current = unsafe { crate::pytraceback::w_pytraceback_get_w_next(current) };
     }
-    let tb = pyre_object::gc_roots::shadow_stack_get(last_slot?);
-    let frame = unsafe { crate::pytraceback::w_pytraceback_get_frame(tb) };
+    if last.is_null() {
+        return None;
+    }
+    let frame = unsafe { crate::pytraceback::w_pytraceback_get_frame(last) };
     (!frame.is_null()).then_some(frame)
 }
 
@@ -2281,17 +2282,25 @@ fn exception_suggestion(exc_slot: usize) -> Option<String> {
         }
         ExcKind::NameError => {
             let frame = traceback_last_frame(tb)?;
-            let frame = unsafe { &mut *frame };
+            let anchor = crate::eval::FrameAnchor::new(unsafe { &mut *frame });
             let mut names = Vec::new();
-            if let Ok(locals) = frame.getdictscope() {
+            if let Ok(locals) = unsafe { &mut *anchor.live() }.getdictscope() {
+                let locals_slot = pyre_object::gc_roots::shadow_stack_len();
+                pyre_object::gc_roots::pin_root(locals);
+                let locals = pyre_object::gc_roots::shadow_stack_get(locals_slot);
                 dict_string_keys(locals, &mut names);
                 if let Some(self_obj) = unsafe { pyre_object::w_dict_getitem_str(locals, "self") } {
+                    let self_slot = pyre_object::gc_roots::shadow_stack_len();
+                    pyre_object::gc_roots::pin_root(self_obj);
+                    let self_obj = pyre_object::gc_roots::shadow_stack_get(self_slot);
                     if crate::baseobjspace::getattr_str(self_obj, &wrong_name).is_ok() {
                         return Some(format!(". Did you mean: 'self.{wrong_name}'?"));
                     }
                 }
             }
+            let frame = unsafe { &*anchor.live() };
             dict_string_keys(frame.get_w_globals(), &mut names);
+            let frame = unsafe { &*anchor.live() };
             dict_string_keys(frame.fget_f_builtins(), &mut names);
             best_suggestion(&names, &wrong_name)
         }

--- a/pyre/pyre-interpreter/src/error.rs
+++ b/pyre/pyre-interpreter/src/error.rs
@@ -3,6 +3,7 @@ use pyre_object::interp_exceptions::{ExcKind, exc_kind_name, w_exception_new};
 use ruff_text_size::Ranged;
 use rustpython_compiler::{ast, parser};
 use rustpython_wtf8::Wtf8Buf;
+use std::collections::HashSet;
 use std::io::Write;
 use std::sync::OnceLock;
 
@@ -1511,32 +1512,13 @@ pub fn write_exception_from_parts<W: Write>(
         }
     }
 
-    // Older explicit cause/context entries precede the current value.  The
-    // current traceback is the exception-resident value after the conditional
-    // installation above, exactly as `print_exception_recursive` observes it.
+    // `lib-python/3/traceback.py:1047-1188 TracebackException.__init__`
+    // records every visited exception before following cause/context edges.
+    // Keep the same set for the complete structured render so cycles terminate
+    // and ExceptionGroup leaves share the chain census.
     let exc_value = pyre_object::gc_roots::shadow_stack_get(exc_value_slot);
-    write_chained_context(writer, exc_value)?;
-    let exc_value = pyre_object::gc_roots::shadow_stack_get(exc_value_slot);
-    let current_tb =
-        unsafe { pyre_object::interp_exceptions::w_exception_get_traceback(exc_value) };
-    if !current_tb.is_null() {
-        writeln!(writer, "Traceback (most recent call last):")?;
-        write_traceback_chain_from_tb(writer, current_tb)?;
-    }
-    let exc_value = pyre_object::gc_roots::shadow_stack_get(exc_value_slot);
-    if unsafe { pyre_object::interp_exceptions::w_exception_get_kind(exc_value) }
-        == ExcKind::SyntaxError
-    {
-        write_syntax_error_object(writer, exc_value)?;
-    } else {
-        let rendered = render_exc_object_wtf8(exc_value);
-        writer.write_all(rendered.as_bytes())?;
-        writer.write_all(b"\n")?;
-    }
-    write_exception_notes(
-        writer,
-        pyre_object::gc_roots::shadow_stack_get(exc_value_slot),
-    )
+    let mut context = ExceptionPrintContext::new(exc_value);
+    write_exception_object_recursive(writer, exc_value, &mut context)
 }
 
 /// Render an uncaught compile-time SyntaxError as the top-level banner
@@ -1603,11 +1585,234 @@ pub fn eprint_syntax_error(err: &PyError) {
     crate::host_seam::emit_stderr(&buf);
 }
 
+/// `lib-python/3/traceback.py:980-1000 _ExceptionPrintContext` and
+/// `:1468-1565 TracebackException.format` state.  CPython shares one visited
+/// set across the complete cause/context/ExceptionGroup tree.
+struct ExceptionPrintContext {
+    seen: HashSet<usize>,
+    exception_group_depth: usize,
+    need_close: bool,
+}
+
+impl ExceptionPrintContext {
+    fn new(exc: PyObjectRef) -> Self {
+        let mut seen = HashSet::new();
+        seen.insert(exc as usize);
+        Self {
+            seen,
+            exception_group_depth: 0,
+            need_close: false,
+        }
+    }
+}
+
+fn write_exception_object_recursive<W: Write>(
+    writer: &mut W,
+    exc: PyObjectRef,
+    context: &mut ExceptionPrintContext,
+) -> std::io::Result<()> {
+    let cause = unsafe { pyre_object::interp_exceptions::w_exception_get_cause(exc) };
+    let chained = if !cause.is_null()
+        && !unsafe { pyre_object::is_none(cause) }
+        && context.seen.insert(cause as usize)
+    {
+        Some((
+            cause,
+            "\nThe above exception was the direct cause of the following exception:\n\n",
+        ))
+    } else {
+        let previous = unsafe { pyre_object::interp_exceptions::w_exception_get_context(exc) };
+        let suppress =
+            unsafe { pyre_object::interp_exceptions::w_exception_get_suppress_context(exc) };
+        if !suppress
+            && !previous.is_null()
+            && !unsafe { pyre_object::is_none(previous) }
+            && context.seen.insert(previous as usize)
+        {
+            Some((
+                previous,
+                "\nDuring handling of the above exception, another exception occurred:\n\n",
+            ))
+        } else {
+            None
+        }
+    };
+    if let Some((older, banner)) = chained {
+        write_exception_object_recursive(writer, older, context)?;
+        emit_exception_text(writer, banner.as_bytes(), context, b'|')?;
+    }
+
+    if exception_group_items(exc).is_some() {
+        write_exception_group(writer, exc, context)
+    } else {
+        write_plain_exception_object(writer, exc, context)
+    }
+}
+
+fn write_plain_exception_object<W: Write>(
+    writer: &mut W,
+    exc: PyObjectRef,
+    context: &ExceptionPrintContext,
+) -> std::io::Result<()> {
+    let mut rendered = Vec::new();
+    let tb = unsafe { pyre_object::interp_exceptions::w_exception_get_traceback(exc) };
+    if !tb.is_null() {
+        writeln!(rendered, "Traceback (most recent call last):")?;
+        write_traceback_chain_from_tb(&mut rendered, tb)?;
+    }
+    if unsafe { pyre_object::interp_exceptions::w_exception_get_kind(exc) } == ExcKind::SyntaxError
+    {
+        write_syntax_error_object(&mut rendered, exc)?;
+    } else {
+        let header = render_exc_object_wtf8(exc);
+        rendered.write_all(header.as_bytes())?;
+        rendered.write_all(b"\n")?;
+    }
+    write_exception_notes(&mut rendered, exc)?;
+    emit_exception_text(writer, &rendered, context, b'|')
+}
+
+fn exception_group_items(exc: PyObjectRef) -> Option<Vec<PyObjectRef>> {
+    let base_group = crate::builtins::lookup_exc_class("BaseExceptionGroup")?;
+    if !crate::baseobjspace::isinstance(exc, base_group).ok()? {
+        return None;
+    }
+    let exceptions = crate::baseobjspace::getattr_str(exc, "exceptions").ok()?;
+    if !unsafe { pyre_object::is_tuple(exceptions) } {
+        return None;
+    }
+    Some(unsafe { pyre_object::w_tuple_items_copy_as_vec(exceptions) })
+}
+
+fn write_exception_group<W: Write>(
+    writer: &mut W,
+    exc: PyObjectRef,
+    context: &mut ExceptionPrintContext,
+) -> std::io::Result<()> {
+    const MAX_GROUP_WIDTH: usize = 15;
+    const MAX_GROUP_DEPTH: usize = 10;
+
+    if context.exception_group_depth > MAX_GROUP_DEPTH {
+        return emit_exception_text(writer, b"... (max_group_depth is 10)\n", context, b'|');
+    }
+    let exceptions = match exception_group_items(exc) {
+        Some(exceptions) => exceptions,
+        None => return write_plain_exception_object(writer, exc, context),
+    };
+    let is_toplevel = context.exception_group_depth == 0;
+    if is_toplevel {
+        context.exception_group_depth += 1;
+    }
+
+    let tb = unsafe { pyre_object::interp_exceptions::w_exception_get_traceback(exc) };
+    if !tb.is_null() {
+        emit_exception_text(
+            writer,
+            b"Exception Group Traceback (most recent call last):\n",
+            context,
+            if is_toplevel { b'+' } else { b'|' },
+        )?;
+        let mut traceback = Vec::new();
+        write_traceback_chain_from_tb(&mut traceback, tb)?;
+        emit_exception_text(writer, &traceback, context, b'|')?;
+    }
+
+    let mut header = Vec::new();
+    let group_header = render_exc_object_wtf8(exc);
+    header.write_all(group_header.as_bytes())?;
+    header.write_all(b"\n")?;
+    write_exception_notes(&mut header, exc)?;
+    emit_exception_text(writer, &header, context, b'|')?;
+
+    let shown = exceptions.len().min(MAX_GROUP_WIDTH);
+    let count = if exceptions.len() > MAX_GROUP_WIDTH {
+        shown + 1
+    } else {
+        shown
+    };
+    context.need_close = false;
+    for index in 0..count {
+        let last = index + 1 == count;
+        if last {
+            context.need_close = true;
+        }
+        let truncated = index >= MAX_GROUP_WIDTH;
+        let title = if truncated {
+            "...".to_string()
+        } else {
+            (index + 1).to_string()
+        };
+        write!(
+            writer,
+            "{}{}+---------------- {title} ----------------\n",
+            " ".repeat(2 * context.exception_group_depth),
+            if index == 0 { "+-" } else { "  " },
+        )?;
+        context.exception_group_depth += 1;
+        if truncated {
+            let remaining = exceptions.len() - MAX_GROUP_WIDTH;
+            let suffix = if remaining == 1 { "" } else { "s" };
+            emit_exception_text(
+                writer,
+                format!("and {remaining} more exception{suffix}\n").as_bytes(),
+                context,
+                b'|',
+            )?;
+        } else {
+            let child = exceptions[index];
+            context.seen.insert(child as usize);
+            write_exception_object_recursive(writer, child, context)?;
+        }
+        if last && context.need_close {
+            writeln!(
+                writer,
+                "{}+------------------------------------",
+                " ".repeat(2 * context.exception_group_depth)
+            )?;
+            context.need_close = false;
+        }
+        context.exception_group_depth -= 1;
+    }
+
+    if is_toplevel {
+        debug_assert_eq!(context.exception_group_depth, 1);
+        context.exception_group_depth = 0;
+    }
+    Ok(())
+}
+
+fn emit_exception_text<W: Write>(
+    writer: &mut W,
+    bytes: &[u8],
+    context: &ExceptionPrintContext,
+    margin: u8,
+) -> std::io::Result<()> {
+    let mut prefix = vec![b' '; 2 * context.exception_group_depth];
+    if context.exception_group_depth != 0 {
+        prefix.extend_from_slice(&[margin, b' ']);
+    }
+    for line in bytes.split_inclusive(|byte| *byte == b'\n') {
+        writer.write_all(&prefix)?;
+        writer.write_all(line)?;
+    }
+    Ok(())
+}
+
 /// `Lib/traceback.py:171-200 TracebackException._format_*` parity —
 /// walk `__cause__` (or `__context__` when `__suppress_context__` is
 /// False) chains and emit each older exception with the appropriate
 /// bridging banner before the current one.
 fn write_chained_context<W: Write>(writer: &mut W, exc: PyObjectRef) -> std::io::Result<()> {
+    let mut seen = HashSet::new();
+    seen.insert(exc as usize);
+    write_chained_context_inner(writer, exc, &mut seen)
+}
+
+fn write_chained_context_inner<W: Write>(
+    writer: &mut W,
+    exc: PyObjectRef,
+    seen: &mut HashSet<usize>,
+) -> std::io::Result<()> {
     if exc.is_null() || !unsafe { pyre_object::is_exception(exc) } {
         return Ok(());
     }
@@ -1618,12 +1823,19 @@ fn write_chained_context<W: Write>(writer: &mut W, exc: PyObjectRef) -> std::io:
     // `traceback.py:184-191` — `__cause__` wins over `__context__`;
     // `__suppress_context__` (set by `raise X from None`) hides
     // `__context__` only when no explicit cause was attached.
-    let (older, banner) = if !cause.is_null() && !unsafe { pyre_object::is_none(cause) } {
+    let (older, banner) = if !cause.is_null()
+        && !unsafe { pyre_object::is_none(cause) }
+        && seen.insert(cause as usize)
+    {
         (
             cause,
             "\nThe above exception was the direct cause of the following exception:\n",
         )
-    } else if !suppress && !context.is_null() && !unsafe { pyre_object::is_none(context) } {
+    } else if !suppress
+        && !context.is_null()
+        && !unsafe { pyre_object::is_none(context) }
+        && seen.insert(context as usize)
+    {
         (
             context,
             "\nDuring handling of the above exception, another exception occurred:\n",
@@ -1632,7 +1844,7 @@ fn write_chained_context<W: Write>(writer: &mut W, exc: PyObjectRef) -> std::io:
         return Ok(());
     };
 
-    write_chained_context(writer, older)?;
+    write_chained_context_inner(writer, older, seen)?;
     write_single_exception(writer, older)?;
     writeln!(writer, "{}", banner)?;
     Ok(())

--- a/pyre/pyre-interpreter/src/error.rs
+++ b/pyre/pyre-interpreter/src/error.rs
@@ -1803,6 +1803,12 @@ fn write_exception_group<W: Write>(
     } else {
         shown
     };
+    for child_slot in exceptions.iter().take(shown) {
+        let child = pyre_object::gc_roots::shadow_stack_get(*child_slot);
+        context
+            .seen
+            .insert(pyre_object::gc_hook::gc_identity_hash(child as usize));
+    }
     context.need_close = false;
     for index in 0..count {
         let last = index + 1 == count;
@@ -1833,9 +1839,6 @@ fn write_exception_group<W: Write>(
             )?;
         } else {
             let child = pyre_object::gc_roots::shadow_stack_get(exceptions[index]);
-            context
-                .seen
-                .insert(pyre_object::gc_hook::gc_identity_hash(child as usize));
             write_exception_object_recursive(writer, child, context)?;
         }
         if last && context.need_close {
@@ -2014,10 +2017,11 @@ fn write_exception_notes<W: Write>(writer: &mut W, exc: PyObjectRef) -> std::io:
         }
         for item_slot in item_slots {
             let item = pyre_object::gc_roots::shadow_stack_get(item_slot);
-            let s = unsafe { crate::display::py_str(item) }
-                .unwrap_or_else(|_| "<unprintable note>".to_string());
-            for line in s.split('\n') {
-                writeln!(writer, "{}", line)?;
+            let s = unsafe { crate::display::py_str_wtf8(item) }
+                .unwrap_or_else(|_| Wtf8Buf::from_string("<unprintable note>".to_string()));
+            for line in s.as_bytes().split(|byte| *byte == b'\n') {
+                writer.write_all(line)?;
+                writer.write_all(b"\n")?;
             }
         }
         return Ok(());
@@ -2308,6 +2312,13 @@ fn exception_suggestion(exc_slot: usize) -> Option<String> {
     let wrong_name = unsafe { pyre_object::w_str_get_value(wrong) }.to_string();
     let exc = pyre_object::gc_roots::shadow_stack_get(exc_slot);
     let tb = unsafe { pyre_object::interp_exceptions::w_exception_get_traceback(exc) };
+    let tb_slot = if tb.is_null() {
+        None
+    } else {
+        let slot = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(tb);
+        Some(slot)
+    };
     let suggestion = match kind {
         ExcKind::AttributeError => {
             let exc = pyre_object::gc_roots::shadow_stack_get(exc_slot);
@@ -2317,6 +2328,9 @@ fn exception_suggestion(exc_slot: usize) -> Option<String> {
             let obj = pyre_object::gc_roots::shadow_stack_get(obj_slot);
             object_dir_strings(obj).and_then(|mut names| {
                 let obj = pyre_object::gc_roots::shadow_stack_get(obj_slot);
+                let tb = tb_slot
+                    .map(pyre_object::gc_roots::shadow_stack_get)
+                    .unwrap_or(pyre_object::PY_NULL);
                 if !wrong_name.starts_with('_') && !traceback_self_is(tb, obj) {
                     names.retain(|name| !name.starts_with('_'));
                 }

--- a/pyre/pyre-interpreter/src/error.rs
+++ b/pyre/pyre-interpreter/src/error.rs
@@ -1976,25 +1976,43 @@ fn write_exception_notes<W: Write>(writer: &mut W, exc: PyObjectRef) -> std::io:
                 crate::baseobjspace::isinstance_w(notes, tuple_type.as_ptr())
             })
     };
-    if is_list || is_tuple {
-        let len = if is_list {
-            unsafe { pyre_object::w_list_len(notes) }
-        } else {
-            unsafe { pyre_object::w_tuple_len(notes) }
-        } as i64;
-        for i in 0..len {
-            let notes = pyre_object::gc_roots::shadow_stack_get(notes_slot);
-            let item = if is_list {
-                unsafe { pyre_object::w_list_getitem(notes, i) }
+    let is_sequence = is_list || is_tuple || notes_is_abc_sequence(notes_slot);
+    if is_sequence
+        && !unsafe { crate::baseobjspace::isinstance_str_w(notes) }
+        && !unsafe { crate::baseobjspace::isinstance_bytes_w(notes) }
+    {
+        let mut item_slots = Vec::new();
+        if is_list || is_tuple {
+            let len = if is_list {
+                unsafe { pyre_object::w_list_len(notes) }
             } else {
-                unsafe { pyre_object::w_tuple_getitem(notes, i) }
+                unsafe { pyre_object::w_tuple_len(notes) }
+            } as i64;
+            for i in 0..len {
+                let notes = pyre_object::gc_roots::shadow_stack_get(notes_slot);
+                let item = if is_list {
+                    unsafe { pyre_object::w_list_getitem(notes, i) }
+                } else {
+                    unsafe { pyre_object::w_tuple_getitem(notes, i) }
+                }
+                .unwrap_or(pyre_object::PY_NULL);
+                if !item.is_null() {
+                    let item_slot = pyre_object::gc_roots::shadow_stack_len();
+                    pyre_object::gc_roots::pin_root(item);
+                    item_slots.push(item_slot);
+                }
             }
-            .unwrap_or(pyre_object::PY_NULL);
-            if item.is_null() {
-                continue;
+        } else {
+            let notes = pyre_object::gc_roots::shadow_stack_get(notes_slot);
+            if let Ok(items) = crate::builtins::collect_iterable(notes) {
+                for item in items {
+                    let item_slot = pyre_object::gc_roots::shadow_stack_len();
+                    pyre_object::gc_roots::pin_root(item);
+                    item_slots.push(item_slot);
+                }
             }
-            let item_slot = pyre_object::gc_roots::shadow_stack_len();
-            pyre_object::gc_roots::pin_root(item);
+        }
+        for item_slot in item_slots {
             let item = pyre_object::gc_roots::shadow_stack_get(item_slot);
             let s = unsafe { crate::display::py_str(item) }
                 .unwrap_or_else(|_| "<unprintable note>".to_string());
@@ -2008,6 +2026,31 @@ fn write_exception_notes<W: Write>(writer: &mut W, exc: PyObjectRef) -> std::io:
     let rendered = unsafe { crate::display::py_repr(notes) }
         .unwrap_or_else(|_| "<exception repr() failed>".to_string());
     writeln!(writer, "{rendered}")
+}
+
+fn notes_is_abc_sequence(notes_slot: usize) -> bool {
+    let module = crate::importing::get_sys_module("collections.abc").or_else(|| {
+        crate::importing::importhook(
+            "collections.abc",
+            pyre_object::w_none(),
+            pyre_object::w_none(),
+            0,
+            crate::call::take_last_exec_ctx(),
+        )
+        .ok()?;
+        crate::importing::get_sys_module("collections.abc")
+    });
+    let Some(module) = module else {
+        return false;
+    };
+    let Ok(sequence) = crate::baseobjspace::getattr_str(module, "Sequence") else {
+        return false;
+    };
+    let sequence_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(sequence);
+    let notes = pyre_object::gc_roots::shadow_stack_get(notes_slot);
+    let sequence = pyre_object::gc_roots::shadow_stack_get(sequence_slot);
+    crate::baseobjspace::isinstance(notes, sequence).unwrap_or(false)
 }
 
 /// Compose the `ExcName: msg` header for a W_BaseException —
@@ -2175,6 +2218,29 @@ fn traceback_last_frame(tb: PyObjectRef) -> Option<*mut crate::pyframe::PyFrame>
     (!frame.is_null()).then_some(frame)
 }
 
+fn traceback_self_is(tb: PyObjectRef, obj: PyObjectRef) -> bool {
+    if obj.is_null() {
+        return false;
+    }
+    let obj_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(obj);
+    let Some(frame) = traceback_last_frame(tb) else {
+        return false;
+    };
+    let anchor = crate::eval::FrameAnchor::new(unsafe { &mut *frame });
+    let Ok(locals) = unsafe { &mut *anchor.live() }.getdictscope() else {
+        return false;
+    };
+    let locals_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(locals);
+    let locals = pyre_object::gc_roots::shadow_stack_get(locals_slot);
+    let Some(self_obj) = (unsafe { pyre_object::w_dict_getitem_str(locals, "self") }) else {
+        return false;
+    };
+    let obj = pyre_object::gc_roots::shadow_stack_get(obj_slot);
+    std::ptr::eq(self_obj, obj)
+}
+
 fn object_dir_strings(obj: PyObjectRef) -> Option<Vec<String>> {
     if obj.is_null() || unsafe { pyre_object::is_none(obj) } {
         return None;
@@ -2246,8 +2312,12 @@ fn exception_suggestion(exc_slot: usize) -> Option<String> {
         ExcKind::AttributeError => {
             let exc = pyre_object::gc_roots::shadow_stack_get(exc_slot);
             let obj = unsafe { pyre_object::interp_exceptions::w_exception_get_attr_obj(exc) };
+            let obj_slot = pyre_object::gc_roots::shadow_stack_len();
+            pyre_object::gc_roots::pin_root(obj);
+            let obj = pyre_object::gc_roots::shadow_stack_get(obj_slot);
             object_dir_strings(obj).and_then(|mut names| {
-                if !wrong_name.starts_with('_') {
+                let obj = pyre_object::gc_roots::shadow_stack_get(obj_slot);
+                if !wrong_name.starts_with('_') && !traceback_self_is(tb, obj) {
                     names.retain(|name| !name.starts_with('_'));
                 }
                 best_suggestion(&names, &wrong_name)

--- a/pyre/pyre-interpreter/src/error.rs
+++ b/pyre/pyre-interpreter/src/error.rs
@@ -1439,8 +1439,22 @@ fn exc_object_class_name(exc: PyObjectRef) -> Option<String> {
     if exc.is_null() || !unsafe { pyre_object::is_exception(exc) } {
         return None;
     }
-    crate::typedef::r#type(exc)
-        .map(|tp| unsafe { pyre_object::w_type_get_name(tp.as_ptr()).to_string() })
+    crate::typedef::r#type(exc).map(|tp| unsafe {
+        let w_type = tp.as_ptr();
+        if !pyre_object::w_type_is_heaptype(w_type) {
+            return pyre_object::w_type_get_name(w_type).to_string();
+        }
+        let qualname = pyre_object::w_type_get_qualname(w_type).to_string();
+        let module = crate::baseobjspace::lookup_in_type(w_type, "__module__")
+            .filter(|value| pyre_object::is_str(*value))
+            .map(|value| pyre_object::w_str_get_value(value).to_string());
+        match module.as_deref() {
+            Some(module) if module != "builtins" && module != "__main__" => {
+                format!("{module}.{qualname}")
+            }
+            _ => qualname,
+        }
+    })
 }
 
 impl std::fmt::Display for PyError {
@@ -1941,26 +1955,45 @@ fn write_exception_notes<W: Write>(writer: &mut W, exc: PyObjectRef) -> std::io:
     let notes_slot = pyre_object::gc_roots::shadow_stack_len();
     pyre_object::gc_roots::pin_root(notes);
     let notes = pyre_object::gc_roots::shadow_stack_get(notes_slot);
-    if !unsafe { pyre_object::is_list(notes) } {
+    let is_list = unsafe { crate::baseobjspace::isinstance_list_w(notes) };
+    let is_tuple = unsafe {
+        pyre_object::is_tuple(notes)
+            || crate::typedef::gettypefor(&pyre_object::TUPLE_TYPE).is_some_and(|tuple_type| {
+                crate::baseobjspace::isinstance_w(notes, tuple_type.as_ptr())
+            })
+    };
+    if is_list || is_tuple {
+        let len = if is_list {
+            unsafe { pyre_object::w_list_len(notes) }
+        } else {
+            unsafe { pyre_object::w_tuple_len(notes) }
+        } as i64;
+        for i in 0..len {
+            let notes = pyre_object::gc_roots::shadow_stack_get(notes_slot);
+            let item = if is_list {
+                unsafe { pyre_object::w_list_getitem(notes, i) }
+            } else {
+                unsafe { pyre_object::w_tuple_getitem(notes, i) }
+            }
+            .unwrap_or(pyre_object::PY_NULL);
+            if item.is_null() {
+                continue;
+            }
+            let item_slot = pyre_object::gc_roots::shadow_stack_len();
+            pyre_object::gc_roots::pin_root(item);
+            let item = pyre_object::gc_roots::shadow_stack_get(item_slot);
+            let s = unsafe { crate::display::py_str(item) }
+                .unwrap_or_else(|_| "<unprintable note>".to_string());
+            for line in s.split('\n') {
+                writeln!(writer, "{}", line)?;
+            }
+        }
         return Ok(());
     }
-    let len = unsafe { pyre_object::w_list_len(notes) } as i64;
-    for i in 0..len {
-        let notes = pyre_object::gc_roots::shadow_stack_get(notes_slot);
-        let item = unsafe { pyre_object::w_list_getitem(notes, i) }.unwrap_or(pyre_object::PY_NULL);
-        if item.is_null() {
-            continue;
-        }
-        let item_slot = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(item);
-        let item = pyre_object::gc_roots::shadow_stack_get(item_slot);
-        let s = unsafe { crate::display::py_str(item) }
-            .unwrap_or_else(|_| "<unprintable note>".to_string());
-        for line in s.lines() {
-            writeln!(writer, "{}", line)?;
-        }
-    }
-    Ok(())
+    let notes = pyre_object::gc_roots::shadow_stack_get(notes_slot);
+    let rendered = unsafe { crate::display::py_repr(notes) }
+        .unwrap_or_else(|_| "<exception repr() failed>".to_string());
+    writeln!(writer, "{rendered}")
 }
 
 /// Compose the `ExcName: msg` header for a W_BaseException —

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -1444,6 +1444,23 @@ pub fn get_sys_module(name: &str) -> Option<PyObjectRef> {
     check_sys_modules(name)
 }
 
+/// Return the interpreter-owned `sys` module, bypassing the Python-visible
+/// `sys.modules` mapping.
+///
+/// CPython's `_PySys_GetOptionalAttr*` reads `PyInterpreterState.sysdict`
+/// directly, and PyPy reads `space.sys`; neither follows a replacement
+/// `sys.modules["sys"]`.  `SYS_MODULES` is pyre's process/interpreter-owned
+/// module registry and is independently walked as a GC root, so its original
+/// `sys` entry is the corresponding owner.
+pub fn get_interpreter_sys_module() -> Option<PyObjectRef> {
+    SYS_MODULES
+        .lock()
+        .unwrap()
+        .get("sys")
+        .copied()
+        .map(|module| module as PyObjectRef)
+}
+
 /// The Python-visible `sys.modules` dict, or `PY_NULL` before it is
 /// installed. Used by callers that need to iterate every loaded module
 /// (e.g. pickle's `whichmodule` scan).

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -1455,7 +1455,7 @@ pub fn get_sys_module(name: &str) -> Option<PyObjectRef> {
 pub fn get_interpreter_sys_module() -> Option<PyObjectRef> {
     SYS_MODULES
         .lock()
-        .unwrap()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
         .get("sys")
         .copied()
         .map(|module| module as PyObjectRef)

--- a/pyre/pyre-interpreter/src/module/thread/mod.rs
+++ b/pyre/pyre-interpreter/src/module/thread/mod.rs
@@ -1670,6 +1670,201 @@ fn interrupt_main(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     Ok(w_none())
 }
 
+/// CPython 3.14 `ExceptHookArgs_desc`: the immutable, non-baseable
+/// `_thread._ExceptHookArgs` struct sequence passed to
+/// `threading.excepthook`.  The storage and descriptors come from pyre's
+/// line-by-line port of PyPy `lib_pypy/_structseq.py`.
+fn except_hook_args_type() -> PyObjectRef {
+    static TYPE: OnceLock<usize> = OnceLock::new();
+    *TYPE.get_or_init(|| {
+        let _roots = pyre_object::gc_roots::push_roots();
+        let ty = crate::_structseq::make_struct_seq(
+            "_thread._ExceptHookArgs",
+            &["exc_type", "exc_value", "exc_traceback", "thread"],
+        );
+        let ty_slot = pin_root_slot(ty);
+        unsafe {
+            let ty = pyre_object::gc_roots::shadow_stack_get(ty_slot);
+            pyre_object::w_type_set_acceptable_as_base_class(ty, false);
+            let doc =
+                w_str_new("ExceptHookArgs\n\nType used to pass arguments to threading.excepthook.");
+            let doc_slot = pin_root_slot(doc);
+            let ty = pyre_object::gc_roots::shadow_stack_get(ty_slot);
+            let ns = pyre_object::w_type_get_dict_ptr(ty) as PyObjectRef;
+            pyre_object::w_dict_setitem_str_no_proxy(
+                ns,
+                "__doc__",
+                pyre_object::gc_roots::shadow_stack_get(doc_slot),
+            );
+        }
+        pyre_object::gc_roots::shadow_stack_get(ty_slot) as usize
+    }) as PyObjectRef
+}
+
+#[inline]
+fn pin_root_slot(value: PyObjectRef) -> usize {
+    pyre_object::gc_roots::pin_root(value);
+    pyre_object::gc_roots::shadow_stack_len() - 1
+}
+
+fn call_method_result(
+    obj: PyObjectRef,
+    name: &str,
+    args: &[PyObjectRef],
+) -> Result<PyObjectRef, crate::PyError> {
+    let result = crate::baseobjspace::call_method(obj, name, args);
+    if result.is_null() {
+        Err(crate::call::take_call_error()
+            .unwrap_or_else(|| crate::PyError::runtime_error(format!("{name} failed"))))
+    } else {
+        Ok(result)
+    }
+}
+
+/// `thread_excepthook_file`: write one string to the live file root.
+fn thread_excepthook_write(file_slot: usize, text: PyObjectRef) -> Result<(), crate::PyError> {
+    let text_slot = pin_root_slot(text);
+    call_method_result(
+        pyre_object::gc_roots::shadow_stack_get(file_slot),
+        "write",
+        &[pyre_object::gc_roots::shadow_stack_get(text_slot)],
+    )?;
+    Ok(())
+}
+
+/// CPython 3.14 `thread_excepthook_file`.
+fn thread_excepthook_file(
+    file: PyObjectRef,
+    exc_value: PyObjectRef,
+    exc_traceback: PyObjectRef,
+    thread: PyObjectRef,
+) -> Result<(), crate::PyError> {
+    let _roots = pyre_object::gc_roots::push_roots();
+    let file_slot = pin_root_slot(file);
+    let exc_value_slot = pin_root_slot(exc_value);
+    let exc_traceback_slot = pin_root_slot(exc_traceback);
+    let thread_slot = pin_root_slot(thread);
+
+    // `PyFile_WriteString("Exception in thread ", file)`.
+    thread_excepthook_write(file_slot, w_str_new("Exception in thread "))?;
+
+    // `PyObject_GetOptionalAttr(thread, "name")`; a missing name falls back
+    // to the native thread identifier, while a raising descriptor propagates.
+    let thread = pyre_object::gc_roots::shadow_stack_get(thread_slot);
+    let name = if !unsafe { is_none(thread) } {
+        crate::baseobjspace::findattr_result(thread, "name")?
+    } else {
+        None
+    };
+    if let Some(name) = name {
+        let name_slot = pin_root_slot(name);
+        let rendered = unsafe {
+            crate::display::py_str_wtf8(pyre_object::gc_roots::shadow_stack_get(name_slot))?
+        };
+        thread_excepthook_write(file_slot, w_str_from_wtf8(rendered))?;
+    } else {
+        thread_excepthook_write(file_slot, w_str_new(&current_ident().to_string()))?;
+    }
+    thread_excepthook_write(file_slot, w_str_new(":\n"))?;
+
+    // `_PyErr_Display(file, exc_type, exc_value, exc_traceback)`.  The
+    // renderer consumes the explicit traceback field and never rewrites the
+    // exception object's own `__traceback__`.
+    let mut rendered = Vec::new();
+    crate::error::write_exception_from_parts(
+        &mut rendered,
+        pyre_object::gc_roots::shadow_stack_get(exc_value_slot),
+        pyre_object::gc_roots::shadow_stack_get(exc_traceback_slot),
+    )
+    .map_err(|err| crate::PyError::runtime_error(format!("failed to display exception: {err}")))?;
+    let rendered = String::from_utf8(rendered).map_err(|err| {
+        crate::PyError::new(crate::PyErrorKind::UnicodeEncodeError, err.to_string())
+    })?;
+    thread_excepthook_write(file_slot, w_str_new(&rendered))?;
+
+    // `_PyFile_Flush(file)`.
+    call_method_result(
+        pyre_object::gc_roots::shadow_stack_get(file_slot),
+        "flush",
+        &[],
+    )?;
+    Ok(())
+}
+
+/// CPython 3.14 `thread_excepthook`.
+fn thread_excepthook(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let hook_args = args
+        .first()
+        .copied()
+        .ok_or_else(|| crate::PyError::type_error("_excepthook() missing argument"))?;
+    let _roots = pyre_object::gc_roots::push_roots();
+    let hook_args_slot = pin_root_slot(hook_args);
+    let hook_args = pyre_object::gc_roots::shadow_stack_get(hook_args_slot);
+    let actual_type = crate::typedef::r#type(hook_args)
+        .map(|tp| tp.as_ptr())
+        .unwrap_or(PY_NULL);
+    if !std::ptr::eq(actual_type, except_hook_args_type()) {
+        return Err(crate::PyError::type_error(
+            "_thread.excepthook argument type must be ExceptHookArgs",
+        ));
+    }
+
+    let exc_type = unsafe {
+        w_tuple_getitem(pyre_object::gc_roots::shadow_stack_get(hook_args_slot), 0)
+            .expect("ExceptHookArgs has four sequence fields")
+    };
+    let exc_type_slot = pin_root_slot(exc_type);
+    if crate::builtins::lookup_exc_class("SystemExit").is_some_and(|system_exit| {
+        crate::baseobjspace::is_w(
+            pyre_object::gc_roots::shadow_stack_get(exc_type_slot),
+            system_exit,
+        )
+    }) {
+        return Ok(w_none());
+    }
+
+    let exc_value = unsafe {
+        w_tuple_getitem(pyre_object::gc_roots::shadow_stack_get(hook_args_slot), 1)
+            .expect("ExceptHookArgs has four sequence fields")
+    };
+    let exc_traceback = unsafe {
+        w_tuple_getitem(pyre_object::gc_roots::shadow_stack_get(hook_args_slot), 2)
+            .expect("ExceptHookArgs has four sequence fields")
+    };
+    let thread = unsafe {
+        w_tuple_getitem(pyre_object::gc_roots::shadow_stack_get(hook_args_slot), 3)
+            .expect("ExceptHookArgs has four sequence fields")
+    };
+    let exc_value_slot = pin_root_slot(exc_value);
+    let exc_traceback_slot = pin_root_slot(exc_traceback);
+    let thread_slot = pin_root_slot(thread);
+
+    // `_PySys_GetOptionalAttr("stderr")`; when it is absent/None, use the
+    // Thread object's saved `_stderr`, unless both the stream and thread are
+    // None.
+    let sys = crate::importing::get_sys_module("sys")
+        .ok_or_else(|| crate::PyError::runtime_error("sys module is unavailable"))?;
+    let mut file = crate::baseobjspace::findattr_result(sys, "stderr")?.unwrap_or(PY_NULL);
+    if file.is_null() || unsafe { is_none(file) } {
+        let thread = pyre_object::gc_roots::shadow_stack_get(thread_slot);
+        if unsafe { is_none(thread) } {
+            return Ok(w_none());
+        }
+        file = crate::baseobjspace::getattr_str(thread, "_stderr")?;
+        if unsafe { is_none(file) } {
+            return Ok(w_none());
+        }
+    }
+    let file_slot = pin_root_slot(file);
+    thread_excepthook_file(
+        pyre_object::gc_roots::shadow_stack_get(file_slot),
+        pyre_object::gc_roots::shadow_stack_get(exc_value_slot),
+        pyre_object::gc_roots::shadow_stack_get(exc_traceback_slot),
+        pyre_object::gc_roots::shadow_stack_get(thread_slot),
+    )?;
+    Ok(w_none())
+}
+
 crate::py_module! {
     "_thread",
     interpleveldefs: {
@@ -1681,6 +1876,7 @@ crate::py_module! {
         "RLock"         => rlock_class::type_object(),
         "_ThreadHandle" => handle_class::type_object(),
         "_local"        => local_type(),
+        "_ExceptHookArgs" => except_hook_args_type(),
         "TIMEOUT_MAX"   => w_float_new(TIMEOUT_MAX),
         "error"         => crate::builtins::lookup_exc_class("RuntimeError")
                                .unwrap_or_else(crate::typedef::w_object),
@@ -1699,7 +1895,7 @@ crate::py_module! {
         "stack_size"             / * = stack_size,
         "interrupt_main"         / * = interrupt_main,
         "set_name"               / 1 = |_| Ok(w_none()),
-        "_excepthook"            / 1 = |_| Ok(w_none()),
+        "_excepthook"            / 1 = thread_excepthook,
         "_get_main_thread_ident" / 0 = |_| Ok(w_int_new(current_ident())),
         "start_joinable_thread"  / * = start_joinable_thread,
         "start_new_thread"       / * = start_new_thread,

--- a/pyre/pyre-interpreter/src/module/thread/mod.rs
+++ b/pyre/pyre-interpreter/src/module/thread/mod.rs
@@ -1721,6 +1721,17 @@ fn call_method_result(
     }
 }
 
+/// CPython `PyObject_GetOptionalAttr`: only `AttributeError` denotes a missing
+/// attribute.  In particular, a `NameError` raised by a descriptor propagates.
+fn optional_attr(obj: PyObjectRef, name: &str) -> Result<Option<PyObjectRef>, crate::PyError> {
+    match crate::baseobjspace::getattr_str(obj, name) {
+        Ok(value) if value.is_null() => Ok(None),
+        Ok(value) => Ok(Some(value)),
+        Err(err) if err.kind == crate::PyErrorKind::AttributeError => Ok(None),
+        Err(err) => Err(err),
+    }
+}
+
 /// `thread_excepthook_file`: write one string to the live file root.
 fn thread_excepthook_write(file_slot: usize, text: PyObjectRef) -> Result<(), crate::PyError> {
     let text_slot = pin_root_slot(text);
@@ -1752,7 +1763,7 @@ fn thread_excepthook_file(
     // to the native thread identifier, while a raising descriptor propagates.
     let thread = pyre_object::gc_roots::shadow_stack_get(thread_slot);
     let name = if !unsafe { is_none(thread) } {
-        crate::baseobjspace::findattr_result(thread, "name")?
+        optional_attr(thread, "name")?
     } else {
         None
     };
@@ -1839,12 +1850,15 @@ fn thread_excepthook(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
     let exc_traceback_slot = pin_root_slot(exc_traceback);
     let thread_slot = pin_root_slot(thread);
 
-    // `_PySys_GetOptionalAttr("stderr")`; when it is absent/None, use the
-    // Thread object's saved `_stderr`, unless both the stream and thread are
-    // None.
-    let sys = crate::importing::get_sys_module("sys")
+    // `_PySys_GetOptionalAttr("stderr")` reads the interpreter-owned sys dict,
+    // not the replaceable `sys.modules["sys"]` entry.  When stderr is
+    // absent/None, use the Thread object's saved `_stderr`, unless both the
+    // stream and thread are None.
+    let sys = crate::importing::get_interpreter_sys_module()
         .ok_or_else(|| crate::PyError::runtime_error("sys module is unavailable"))?;
-    let mut file = crate::baseobjspace::findattr_result(sys, "stderr")?.unwrap_or(PY_NULL);
+    let sys_dict = unsafe { pyre_object::w_module_get_w_dict(sys) };
+    let mut file =
+        unsafe { pyre_object::w_module_dict_getitem_str(sys_dict, "stderr") }.unwrap_or(PY_NULL);
     if file.is_null() || unsafe { is_none(file) } {
         let thread = pyre_object::gc_roots::shadow_stack_get(thread_slot);
         if unsafe { is_none(thread) } {

--- a/pyre/pyre-interpreter/src/module/thread/mod.rs
+++ b/pyre/pyre-interpreter/src/module/thread/mod.rs
@@ -1788,10 +1788,9 @@ fn thread_excepthook_file(
         pyre_object::gc_roots::shadow_stack_get(exc_traceback_slot),
     )
     .map_err(|err| crate::PyError::runtime_error(format!("failed to display exception: {err}")))?;
-    let rendered = String::from_utf8(rendered).map_err(|err| {
-        crate::PyError::new(crate::PyErrorKind::UnicodeEncodeError, err.to_string())
-    })?;
-    thread_excepthook_write(file_slot, w_str_new(&rendered))?;
+    let rendered = rustpython_wtf8::Wtf8Buf::from_bytes(rendered)
+        .map_err(|_| crate::PyError::runtime_error("invalid WTF-8 exception display"))?;
+    thread_excepthook_write(file_slot, pyre_object::w_str_from_wtf8(rendered))?;
 
     // `_PyFile_Flush(file)`.
     call_method_result(

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -16598,54 +16598,89 @@ fn bytes_descr_repeat(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErro
 /// `stringmethods.py:_op_val(space, w_sub, allow_char=True)` — the
 /// `sub` argument of a bytes search/count method is either a bytes-like
 /// object or a single integer in `range(0, 256)` standing for one byte.
-fn bytes_sub_arg(w_sub: PyObjectRef) -> Result<Vec<u8>, crate::PyError> {
-    unsafe {
-        if let Some(src) = buffer_as_bytes_like(w_sub)? {
-            Ok(pyre_object::bytesobject::bytes_like_data(src).to_vec())
-        } else if pyre_object::is_int(w_sub) {
-            let v = pyre_object::w_int_get_value(w_sub);
-            if !(0..=255).contains(&v) {
-                return Err(crate::PyError::value_error("byte must be in range(0, 256)"));
-            }
-            Ok(vec![v as u8])
-        } else {
-            Err(crate::PyError::type_error(format!(
-                "argument should be integer or bytes-like object, not '{}'",
-                type_name_of(w_sub)
-            )))
+enum BytesSubArg {
+    Buffer(crate::baseobjspace::SimpleBufferBytes),
+    Char([u8; 1]),
+}
+
+impl BytesSubArg {
+    fn as_bytes(&self) -> &[u8] {
+        match self {
+            Self::Buffer(buffer) => buffer.as_bytes(),
+            Self::Char(value) => value,
+        }
+    }
+
+    fn release(self) {
+        if let Self::Buffer(buffer) = self {
+            buffer.release();
         }
     }
 }
 
-/// `stringmethods.py:_convert_idx_params` — resolve the optional `start`
-/// / `end` search args (PyPy slice semantics) into a byte-offset window
-/// `[start, end)` into a bytes-like of length `len`.  Returns `None`
-/// when the window is empty because `start` is past the end or past
-/// `end` (the search-miss case shared by find / index / count).
-fn bytes_idx_window(
-    len: usize,
-    args: &[PyObjectRef],
-) -> Result<Option<(usize, usize)>, crate::PyError> {
+fn bytes_sub_arg(w_sub: PyObjectRef) -> Result<BytesSubArg, crate::PyError> {
+    unsafe {
+        // bytesobject.py / bytearrayobject.py `_op_val`: integer subclasses
+        // take the allow_char path before the general buffer protocol.
+        if crate::baseobjspace::isinstance_int_w(w_sub) {
+            let v = match crate::baseobjspace::int_w(w_sub) {
+                Ok(value) => value,
+                Err(error) if error.kind == crate::PyErrorKind::OverflowError => 256,
+                Err(error) => return Err(error),
+            };
+            if !(0..=255).contains(&v) {
+                return Err(crate::PyError::value_error("byte must be in range(0, 256)"));
+            }
+            return Ok(BytesSubArg::Char([v as u8]));
+        }
+    }
+    match crate::baseobjspace::simple_buffer_bytes(w_sub)? {
+        Some(buffer) => Ok(BytesSubArg::Buffer(buffer)),
+        None => Err(crate::PyError::type_error(format!(
+            "argument should be integer or bytes-like object, not '{}'",
+            type_name_of(w_sub)
+        ))),
+    }
+}
+
+/// Argument-clinic `slice_index` conversion for bytes/bytearray search
+/// methods.  Conversion precedes the bytearray implementation's receiver
+/// export, so a re-entrant `__index__` may resize the receiver.
+fn bytes_idx_args(args: &[PyObjectRef]) -> Result<(Option<i64>, Option<i64>), crate::PyError> {
+    let convert = |index: usize| {
+        let Some(&value) = args.get(index) else {
+            return Ok(None);
+        };
+        if unsafe { pyre_object::is_none(value) } {
+            Ok(None)
+        } else {
+            crate::sliceobject::eval_slice_index(value).map(Some)
+        }
+    };
+    Ok((convert(2)?, convert(3)?))
+}
+
+/// Normalize already-converted `start` / `end` against the receiver length
+/// observed after argument conversion.
+fn bytes_idx_window(len: usize, bounds: (Option<i64>, Option<i64>)) -> Option<(usize, usize)> {
     let len_i = len as i64;
-    let w_start = if args.len() >= 3 {
-        args[2]
-    } else {
-        pyre_object::w_none()
+    let adapt = |value: i64| {
+        if value < 0 {
+            value.saturating_add(len_i).max(0)
+        } else {
+            value
+        }
     };
-    let w_end = if args.len() >= 4 {
-        args[3]
-    } else {
-        pyre_object::w_none()
-    };
-    let (start, end) = crate::sliceobject::unwrap_start_stop(len_i, w_start, w_end)?;
+    let start = bounds.0.map(adapt).unwrap_or(0);
+    let end = bounds.1.map(adapt).unwrap_or(len_i);
     if start > len_i {
-        return Ok(None);
+        return None;
     }
     let end = end.min(len_i);
     if start > end {
-        return Ok(None);
+        return None;
     }
-    Ok(Some((start as usize, end as usize)))
+    Some((start as usize, end as usize))
 }
 
 /// First index of `needle` within `hay`; empty needle matches at 0.
@@ -16693,18 +16728,36 @@ fn bytes_count_subslices(hay: &[u8], needle: &[u8]) -> usize {
 /// `stringmethods.py:descr_find` / `descr_rfind` — search a bytes-like
 /// over the codepoint-irrelevant byte window selected by start / end.
 fn bytes_search(args: &[PyObjectRef], forward: bool) -> Result<i64, crate::PyError> {
-    let data = unsafe { pyre_object::bytesobject::bytes_like_data(args[0]) };
-    let sub = bytes_sub_arg(args[1])?;
-    let Some((start, end)) = bytes_idx_window(data.len(), args)? else {
-        return Ok(-1);
+    let bounds = bytes_idx_args(args)?;
+    // CPython 3.14 bytearray search methods acquire the receiver before
+    // converting `sub` (gh-142560), so re-entrant buffer conversion cannot
+    // resize the storage under a borrowed slice.  Argument-clinic converted
+    // start/end above, before the implementation acquires that export.
+    let receiver = crate::baseobjspace::simple_buffer_bytes(args[0])?
+        .expect("bytes/bytearray receiver always exports a buffer");
+    let sub = match bytes_sub_arg(args[1]) {
+        Ok(sub) => sub,
+        Err(error) => {
+            receiver.release();
+            return Err(error);
+        }
     };
-    let window = &data[start..end];
-    let pos = if forward {
-        bytes_find_subslice(window, &sub)
-    } else {
-        bytes_rfind_subslice(window, &sub)
-    };
-    Ok(pos.map(|p| (start + p) as i64).unwrap_or(-1))
+    let result = (|| {
+        let data = receiver.as_bytes();
+        let Some((start, end)) = bytes_idx_window(data.len(), bounds) else {
+            return Ok(-1);
+        };
+        let window = &data[start..end];
+        let pos = if forward {
+            bytes_find_subslice(window, sub.as_bytes())
+        } else {
+            bytes_rfind_subslice(window, sub.as_bytes())
+        };
+        Ok(pos.map(|p| (start + p) as i64).unwrap_or(-1))
+    })();
+    sub.release();
+    receiver.release();
+    result
 }
 
 fn bytes_method_find(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
@@ -16737,14 +16790,28 @@ fn bytes_method_rindex(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErr
 
 fn bytes_method_count(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     crate::type_methods::arity_at_least(args, "count", 1)?;
-    let data = unsafe { pyre_object::bytesobject::bytes_like_data(args[0]) };
-    let sub = bytes_sub_arg(args[1])?;
-    let Some((start, end)) = bytes_idx_window(data.len(), args)? else {
-        return Ok(pyre_object::w_int_new(0));
+    let bounds = bytes_idx_args(args)?;
+    let receiver = crate::baseobjspace::simple_buffer_bytes(args[0])?
+        .expect("bytes/bytearray receiver always exports a buffer");
+    let sub = match bytes_sub_arg(args[1]) {
+        Ok(sub) => sub,
+        Err(error) => {
+            receiver.release();
+            return Err(error);
+        }
     };
-    Ok(pyre_object::w_int_new(
-        bytes_count_subslices(&data[start..end], &sub) as i64,
-    ))
+    let result = (|| {
+        let data = receiver.as_bytes();
+        let Some((start, end)) = bytes_idx_window(data.len(), bounds) else {
+            return Ok(pyre_object::w_int_new(0));
+        };
+        Ok(pyre_object::w_int_new(
+            bytes_count_subslices(&data[start..end], sub.as_bytes()) as i64,
+        ))
+    })();
+    sub.release();
+    receiver.release();
+    result
 }
 
 /// `stringmethods.py:descr_startswith` / `descr_endswith` — test the
@@ -16755,45 +16822,56 @@ fn bytes_prefix_match(
     method: &str,
     forward: bool,
 ) -> Result<bool, crate::PyError> {
-    let data = unsafe { pyre_object::bytesobject::bytes_like_data(args[0]) };
-    // `start > len(value)` collapses the window to None → no match.
-    let Some((start, end)) = bytes_idx_window(data.len(), args)? else {
-        return Ok(false);
-    };
-    let window = &data[start..end];
-    let test = |p: &[u8]| {
-        if forward {
-            window.starts_with(p)
-        } else {
-            window.ends_with(p)
-        }
-    };
-    let needle = args[1];
-    unsafe {
-        if let Some(src) = buffer_as_bytes_like(needle)? {
-            return Ok(test(pyre_object::bytesobject::bytes_like_data(src)));
-        }
-        if pyre_object::is_tuple(needle) {
-            let n = pyre_object::w_tuple_len(needle) as i64;
-            for i in 0..n {
-                let item = pyre_object::w_tuple_getitem(needle, i).expect("index is in range");
-                let Some(src) = buffer_as_bytes_like(item)? else {
-                    return Err(crate::PyError::type_error(format!(
-                        "a bytes-like object is required, not '{}'",
-                        type_name_of(item)
-                    )));
-                };
-                if test(pyre_object::bytesobject::bytes_like_data(src)) {
-                    return Ok(true);
-                }
-            }
+    let bounds = bytes_idx_args(args)?;
+    let receiver = crate::baseobjspace::simple_buffer_bytes(args[0])?
+        .expect("bytes/bytearray receiver always exports a buffer");
+    let result = (|| {
+        let data = receiver.as_bytes();
+        // `start > len(value)` collapses the window to None → no match.
+        let Some((start, end)) = bytes_idx_window(data.len(), bounds) else {
             return Ok(false);
+        };
+        let window = &data[start..end];
+        let test = |prefix: &[u8]| {
+            if forward {
+                window.starts_with(prefix)
+            } else {
+                window.ends_with(prefix)
+            }
+        };
+        let needle = args[1];
+        unsafe {
+            if pyre_object::is_tuple(needle) {
+                let n = pyre_object::w_tuple_len(needle) as i64;
+                for i in 0..n {
+                    let item = pyre_object::w_tuple_getitem(needle, i).expect("index is in range");
+                    let Some(buffer) = crate::baseobjspace::simple_buffer_bytes(item)? else {
+                        return Err(crate::PyError::type_error(format!(
+                            "a bytes-like object is required, not '{}'",
+                            type_name_of(item)
+                        )));
+                    };
+                    let matches = test(buffer.as_bytes());
+                    buffer.release();
+                    if matches {
+                        return Ok(true);
+                    }
+                }
+                return Ok(false);
+            }
+            let Some(buffer) = crate::baseobjspace::simple_buffer_bytes(needle)? else {
+                return Err(crate::PyError::type_error(format!(
+                    "{method} first arg must be bytes or a tuple of bytes, not {}",
+                    type_name_of(needle)
+                )));
+            };
+            let matches = test(buffer.as_bytes());
+            buffer.release();
+            Ok(matches)
         }
-        Err(crate::PyError::type_error(format!(
-            "{method} first arg must be bytes or a tuple of bytes, not {}",
-            type_name_of(needle)
-        )))
-    }
+    })();
+    receiver.release();
+    result
 }
 
 fn bytes_method_startswith(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
@@ -17154,7 +17232,8 @@ fn bytes_split(args: &[PyObjectRef], forward: bool) -> Result<PyObjectRef, crate
     crate::builtins::kwarg_reject_unknown(kwargs, &["sep", "maxsplit"], fn_name)?;
     crate::builtins::kwarg_reject_duplicate(kwargs, fn_name, "sep", pos.get(1).is_some())?;
     crate::builtins::kwarg_reject_duplicate(kwargs, fn_name, "maxsplit", pos.get(2).is_some())?;
-    let data = unsafe { pyre_object::bytesobject::bytes_like_data(pos[0]) };
+    // Argument clinic converts maxsplit before bytearray_split_impl acquires
+    // the receiver export; a re-entrant __index__ may therefore resize it.
     let maxsplit = match pos
         .get(2)
         .copied()
@@ -17163,44 +17242,56 @@ fn bytes_split(args: &[PyObjectRef], forward: bool) -> Result<PyObjectRef, crate
         Some(m) if !m.is_null() => crate::builtins::space_index_w(m)?,
         _ => -1,
     };
-    let sep_arg = pos
-        .get(1)
-        .copied()
-        .or_else(|| crate::builtins::kwarg_get(kwargs, "sep"));
-    let sep: Option<Vec<u8>> = match sep_arg {
-        Some(o) if !o.is_null() && unsafe { !pyre_object::is_none(o) } => {
-            if let Some(src) = buffer_as_bytes_like(o)? {
-                Some(unsafe { pyre_object::bytesobject::bytes_like_data(src) }.to_vec())
-            } else {
-                return Err(crate::PyError::type_error(format!(
-                    "a bytes-like object is required, not '{}'",
-                    type_name_of(o)
-                )));
-            }
+    // CPython 3.14 bytearray split keeps the receiver export across separator
+    // buffer acquisition (gh-142560).
+    let receiver = crate::baseobjspace::simple_buffer_bytes(pos[0])?
+        .expect("bytes/bytearray receiver always exports a buffer");
+    let mut sep_buffer = None;
+    let result = (|| {
+        let sep_arg = pos
+            .get(1)
+            .copied()
+            .or_else(|| crate::builtins::kwarg_get(kwargs, "sep"));
+        if let Some(o) = sep_arg.filter(|o| !o.is_null() && unsafe { !pyre_object::is_none(*o) }) {
+            sep_buffer = match crate::baseobjspace::simple_buffer_bytes(o)? {
+                Some(buffer) => Some(buffer),
+                None => {
+                    return Err(crate::PyError::type_error(format!(
+                        "a bytes-like object is required, not '{}'",
+                        type_name_of(o)
+                    )));
+                }
+            };
         }
-        _ => None,
-    };
-    let parts = match sep {
-        Some(s) => {
-            if s.is_empty() {
-                return Err(crate::PyError::value_error("empty separator"));
+        let data = receiver.as_bytes();
+        let parts = match sep_buffer.as_ref() {
+            Some(buffer) => {
+                let sep = buffer.as_bytes();
+                if sep.is_empty() {
+                    return Err(crate::PyError::value_error("empty separator"));
+                }
+                if forward {
+                    split_bytes_sep(data, sep, maxsplit)
+                } else {
+                    rsplit_bytes_sep(data, sep, maxsplit)
+                }
             }
-            if forward {
-                split_bytes_sep(data, &s, maxsplit)
-            } else {
-                rsplit_bytes_sep(data, &s, maxsplit)
+            None => {
+                if forward {
+                    split_bytes_ws(data, maxsplit)
+                } else {
+                    rsplit_bytes_ws(data, maxsplit)
+                }
             }
-        }
-        None => {
-            if forward {
-                split_bytes_ws(data, maxsplit)
-            } else {
-                rsplit_bytes_ws(data, maxsplit)
-            }
-        }
-    };
-    let items: Vec<PyObjectRef> = parts.iter().map(|p| cut_bytes_like(pos[0], p)).collect();
-    Ok(pyre_object::w_list_new(items))
+        };
+        let items: Vec<PyObjectRef> = parts.iter().map(|p| cut_bytes_like(pos[0], p)).collect();
+        Ok(pyre_object::w_list_new(items))
+    })();
+    if let Some(buffer) = sep_buffer {
+        buffer.release();
+    }
+    receiver.release();
+    result
 }
 
 fn bytes_method_split(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
@@ -18037,12 +18128,15 @@ fn bytes_fromhex(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
 fn bytearray_fromhex(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let cls = args.first().copied().unwrap_or(pyre_object::PY_NULL);
     let out = parse_hex_string(&args[1..])?;
-    let w_bytearray = pyre_object::bytearrayobject::w_bytearray_from_bytes(&out);
     let base = crate::typedef::gettypeobject(&pyre_object::bytearrayobject::BYTEARRAY_TYPE);
     if cls.is_null() || crate::baseobjspace::is_w(cls, base) {
-        Ok(w_bytearray)
+        // CPython 3.14 `_PyBytes_FromHex(string, type == &PyByteArray_Type)`.
+        Ok(pyre_object::bytearrayobject::w_bytearray_from_bytes(&out))
     } else {
-        crate::call::call_function_impl_result(cls, &[w_bytearray])
+        // A subclass receives the base bytes result through `cls(result)`,
+        // not an already-materialised bytearray.
+        let w_bytes = pyre_object::bytesobject::w_bytes_from_bytes(&out);
+        crate::call::call_function_impl_result(cls, &[w_bytes])
     }
 }
 

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -19316,7 +19316,12 @@ fn bytearray_descr_resize(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
         )));
     }
     unsafe {
-        crate::builtins::bytearray_check_exports(args[0])?;
+        // CPython 3.14 `bytearray_resize_impl` delegates to
+        // `PyByteArray_Resize`, whose same-size fast path returns before the
+        // export check.  A live buffer only forbids an actual size change.
+        if pyre_object::bytearrayobject::w_bytearray_len(args[0]) != size as usize {
+            crate::builtins::bytearray_check_exports(args[0])?;
+        }
         pyre_object::bytearrayobject::w_bytearray_vec_mut(args[0]).resize(size as usize, 0);
     }
     Ok(w_none())

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -13122,11 +13122,11 @@ fn init_property_type(ns: PyObjectRef) {
         ),
         (
             "__set_name__",
-            make_builtin_function_with_arity(
-                "__set_name__",
-                crate::baseobjspace::property_set_name_impl,
-                3,
-            ),
+            // CPython 3.14's positional-only clinic wrapper reports the
+            // user-visible count without the bound receiver.  Let the
+            // implementation parse the call so its exact 3.14 diagnostics
+            // are not pre-empted by gateway's generic fixed-arity wording.
+            make_builtin_function("__set_name__", crate::baseobjspace::property_set_name_impl),
         ),
     ];
     for (name, value) in entries {

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -17858,25 +17858,24 @@ fn parse_hex_string(args: &[PyObjectRef]) -> Result<Vec<u8>, crate::PyError> {
             "fromhex() takes exactly one argument",
         ));
     }
-    let bytes: &[u8] = match args.first() {
-        Some(&a) if unsafe { pyre_object::is_str(a) } => {
-            unsafe { pyre_object::w_str_get_value(a) }.as_bytes()
-        }
-        Some(&a) if unsafe { pyre_object::bytesobject::is_bytes_like(a) } => unsafe {
-            pyre_object::bytesobject::bytes_like_data(a)
-        },
-        Some(&a) => {
-            return Err(crate::PyError::type_error(format!(
-                "fromhex() argument must be str or bytes-like, not {}",
-                unsafe { pyre_object::type_name_of(a) }
-            )));
-        }
-        None => {
-            return Err(crate::PyError::type_error(
-                "fromhex() takes exactly one argument",
-            ));
-        }
+    let a = args[0];
+    if unsafe { pyre_object::is_str(a) } {
+        return parse_hex_bytes(unsafe { pyre_object::w_str_get_value(a) }.as_bytes());
+    }
+    let Some(buffer) = crate::baseobjspace::simple_buffer_bytes(a)? else {
+        return Err(crate::PyError::type_error(format!(
+            "fromhex() argument must be str or bytes-like, not {}",
+            unsafe { pyre_object::type_name_of(a) }
+        )));
     };
+    let result = parse_hex_bytes(buffer.as_bytes());
+    // `_PyBytes_FromHex`'s `release_buffer` label runs on both success and
+    // every parsing/allocation error.
+    buffer.release();
+    result
+}
+
+fn parse_hex_bytes(bytes: &[u8]) -> Result<Vec<u8>, crate::PyError> {
     let nibble = |b: u8| -> Option<u8> {
         match b {
             b'0'..=b'9' => Some(b - b'0'),


### PR DESCRIPTION
`_thread._excepthook` existed as a no-op stub while `_thread._ExceptHookArgs` did not exist
at all. `threading.py` imports the two together:

```python
from _thread import _excepthook as excepthook, _ExceptHookArgs as ExceptHookArgs
```

so the missing name raised `ImportError` and `threading` fell back to its pure-Python
implementation for both: `threading.ExceptHookArgs` was a function wrapping a namedtuple
rather than a type, and calling `_thread._excepthook` directly returned `None` and wrote
nothing. Measured against both oracles — CPython 3.14 has both names natively, PyPy has
neither and uses the fallback throughout. pyre was the only one carrying a stub that claims
the entry point and then does nothing with it.

- `_thread._ExceptHookArgs`: the immutable, non-baseable struct sequence with fields
  `exc_type` / `exc_value` / `exc_traceback` / `thread`, built on the existing `_structseq`
  port with `acceptable_as_base_class` cleared.
- `_thread._excepthook`: ports `thread_excepthook` — rejects a non-`ExceptHookArgs`
  argument, returns silently for `SystemExit`, resolves the stream from `sys.stderr` and
  falls back to the thread's saved `_stderr`, writes the `Exception in thread <name>:`
  banner (the native ident when the args carry no thread), and flushes.
- `error::write_exception_from_parts`: the `_PyErr_Display(file, exc_type, exc_value,
  exc_tb)` shape. The hook receives the traceback as a separate structseq field, so it has
  to render that value rather than reading `exc_value.__traceback__`; the existing walk is
  split into `write_traceback_chain_from_tb`, which takes a traceback directly.

With both names present `threading.py` takes the native path, so
`threading.ExceptHookArgs is _thread._ExceptHookArgs` and
`threading.excepthook is _thread._excepthook`.

## Validation

- `python3 scripts/extract-llbc.py` + `cargo build --release --features dynasm`
- `python3 pyre/extra_tests/run.py --dynasm-only --filter builtin_thread -v` — 1/1
- the new `builtin_thread.py` snippet also passes unmodified under CPython 3.14
- `python3 pyre/check.py --synthetic-only --backend dynasm target/release/pyre-dynasm` —
  311 passed, `synth/inline_chain_depth_typeflip` reported a >20s timeout. That timeout is
  machine contention, not this change: the bench passes on its own at 5.60s against a 20s
  budget, and a binary built from `34596313f5` (the commit that added the bench) spends the
  same 5.7s of user CPU on it under the same load.

## Pre-existing on this base, not from this branch

`test.test_threading` segfaults part-way through (rc=139) on base `0f2775fd94` with freshly
extracted LLBC. Reverting this branch's two source files and rebuilding on the same base
reproduces the crash at the same point, so it is not caused by this change. A binary built
from `34596313f5` completes the suite (`Ran 228 tests`, one failure,
`test_stop_the_world_during_finalization`), which puts the change between `34596313f5` and
`0f2775fd94` — either `9c808f9e2d` / `0f2775fd94` themselves or the re-extracted LLBC that
those commits' prepass rework produces.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CPython 3.14-compatible uncaught thread exception handling via `threading.excepthook`/`_thread._excepthook`, including strict `_ExceptHookArgs` validation and automatic flushing to the chosen stderr.
  * Thread excepthook now emits CPython-style “Exception in thread …” headers with full exception text.
* **Bug Fixes**
  * Improved structured exception rendering: better cause/context handling, `ExceptionGroup` truncation, `SyntaxError` formatting, and more robust `__notes__`/traceback output.
* **Tests**
  * Expanded runtime coverage for `_thread` argument behavior, formatting edge cases, and stderr/sys fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->