### PR TITLE
interp/jit: revert dict-first module getattr (#836); decline the JIT fold for data-descriptor names

### DIFF
--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -4944,18 +4944,13 @@ fn getattr_str_impl(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyResul
         }
     }
 
-    // Module attribute lookup resolves the namespace dict before the module
-    // type's data descriptors (`LOAD_ATTR_MODULE` precedence): a name present
-    // in the module dict wins even over a same-named data descriptor on the
-    // module type.  This deliberately departs from the generic
-    // descriptor-first protocol so a hot `m.attr` and its compiled fold agree
-    // — e.g. after `m.__dict__["__dict__"] = x`, reading `m.__dict__` yields
-    // `x`.  A retagged module's replacement `__getattribute__`
-    // (importlib.util._LazyModule) still runs first.  A dict miss resumes the
-    // descriptor protocol, so a `ModuleType` subclass shadowing the base
-    // `__dict__` member with a plain value (`class M(ModuleType): __dict__ =
-    // 8`) still exposes 8.  Only after the whole lookup misses does module.py
-    // consult PEP 562 `__getattr__` (the tail below).
+    // Module objects use `object_getattribute` first (`module.py:130-134`),
+    // so their class descriptors and namespace follow the normal descriptor
+    // precedence.  This matters for a ModuleType subclass that shadows the
+    // base `__dict__` member: `class M(ModuleType): __dict__ = 8` must expose
+    // 8, and `module.__dir__` then rejects it as a non-dict.  Only after the
+    // complete normal lookup misses does module.py consult PEP 562
+    // `__getattr__` (the tail below).
     unsafe {
         if is_module(obj) {
             let w_type = crate::typedef::r#type(obj).map_or(PY_NULL, |p| p.as_ptr());
@@ -4982,14 +4977,6 @@ fn getattr_str_impl(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyResul
                     }
                 }
             }
-            let w_dict = pyre_object::w_module_get_w_dict(obj);
-            if !w_dict.is_null() {
-                if let Some(value) = finditem_str(w_dict, name)? {
-                    if !value.is_null() {
-                        return Ok(value);
-                    }
-                }
-            }
             let w_descr = if w_type.is_null() {
                 None
             } else {
@@ -5001,6 +4988,16 @@ fn getattr_str_impl(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyResul
                         return Ok(value);
                     }
                 }
+            }
+            let w_dict = pyre_object::w_module_get_w_dict(obj);
+            if !w_dict.is_null() {
+                if let Some(value) = finditem_str(w_dict, name)? {
+                    if !value.is_null() {
+                        return Ok(value);
+                    }
+                }
+            }
+            if let Some(descr) = w_descr {
                 return Ok(get(descr, obj, w_type)?.unwrap_or(descr));
             }
         }
@@ -7472,6 +7469,17 @@ pub unsafe fn lookup_special(
 /// PyPy equivalent: `space.lookup_in_type(w_type, name)`.
 pub unsafe fn lookup_in_type(w_type: PyObjectRef, name: &str) -> Option<PyObjectRef> {
     lookup_in_type_where(w_type, name)
+}
+
+/// True if `name` resolves to a data descriptor on `w_type`'s MRO.  Generic
+/// getattr consults a data descriptor before the object's own dict, so a
+/// same-named dict entry is shadowed; a JIT fold that reads the dict directly
+/// must decline for such a name.
+pub unsafe fn type_lookup_is_data_descr(w_type: PyObjectRef, name: &str) -> bool {
+    match lookup_in_type(w_type, name) {
+        Some(descr) => is_data_descr(descr),
+        None => false,
+    }
 }
 
 /// `typeobject.py:353-371 W_TypeObject.compares_by_identity` — walk

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -1528,15 +1528,21 @@ pub(crate) fn try_walker_specialize_load_attr<Sym: WalkSym>(
     // `module` `w_class` excludes a module subclass with a custom
     // `__getattribute__`; a module-level PEP 562 `__getattr__` is irrelevant
     // because the name is present (the dict lookup wins before `__getattr__`).
-    // Module getattr resolves the namespace dict before the module type's
-    // data descriptors (`LOAD_ATTR_MODULE` precedence, mirrored in the
-    // interpreter), so folding the cell is faithful even for a name that also
-    // names a data descriptor on the module type (e.g. `__dict__`).
+    // A data descriptor on the module type (e.g. `__dict__`) outranks a
+    // same-named dict entry in generic getattr, so decline when the name
+    // resolves to one — the descriptor result, not the dict cell, is what a
+    // read returns.
     if unsafe { pyre_object::is_module(concrete_obj) }
         && std::ptr::eq(
             unsafe { (*concrete_obj).w_class },
             pyre_object::pyobject::get_instantiate(&pyre_object::pyobject::MODULE_TYPE),
         )
+        && !unsafe {
+            pyre_interpreter::baseobjspace::type_lookup_is_data_descr(
+                (*concrete_obj).w_class,
+                &name,
+            )
+        }
     {
         let w_dict = unsafe { pyre_object::w_module_get_w_dict(concrete_obj) };
         if !w_dict.is_null() && !majit_gc::can_move(majit_ir::GcRef(w_dict as usize)) {


### PR DESCRIPTION
Reverts the interpreter change from #836 and takes the descriptor-first approach instead (Codex's recommendation on #836).

## Background

The JIT module-attr fold in `try_walker_specialize_load_attr` folds a module namespace-dict cell directly. For a name that is both a data descriptor on `ModuleType` (essentially `__dict__`) and injected into the namespace (`m.__dict__["__dict__"] = x`), a hot `m.__dict__` read returned `x` under the JIT but the real dict under the interpreter (**jit ≠ nojit**).

#836 resolved this by reordering the **interpreter** module getattr to dict-first (matching CPython 3.14's specialized `LOAD_ATTR_MODULE`). But that over-applied — CPython 3.14 is dict-first **only** in the compiled hot opcode; its cold, explicit `type(m).__getattribute__`, and `getattr` paths stay descriptor-first:

| access mode | CPython 3.14 |
|---|---|
| hot opcode `for: m.__dict__` | injected value (dict-first) |
| explicit `type(m).__getattribute__(m,'__dict__')` | real dict (descriptor-first) |
| `getattr(m,'__dict__')` / cold | real dict (descriptor-first) |

Since pyre has one interpreter path (no per-opcode adaptive specialization), making it dict-first also changed cold/explicit/getattr/subclass lookups, diverging from CPython 3.14 there. Codex flagged exactly this on #836.

## This change (option 1)

- **Restore descriptor-first module getattr** in `baseobjspace.rs` (revert #836's reorder).
- **Make the JIT fold decline** when the name resolves to a data descriptor on the module type, via a new `type_lookup_is_data_descr` helper (`lookup_in_type` + `is_data_descr`).

Result: `jit == nojit == descriptor result`, matching CPython 3.14's cold / explicit / `getattr` paths and PyPy. It diverges only from CPython 3.14's hot `LOAD_ATTR_MODULE` opcode — unavoidable without either breaking jit==nojit or reproducing CPython's per-opcode specializer. The sqrt/float folds from #827 are unaffected (those names are not descriptors, so the fold still fires).

## Verification

- `m.__dict__` shadow: pyre jit = nojit = real dict (`is sentinel` → 0), matching python3.14's explicit `__getattribute__` / `getattr`.
- `math.sqrt` hot loop unchanged.
- `pyre/check.py`: **ALL PASSED** — dynasm 326/326, cranelift 326/326, wasm 323/323.

No synthetic regression bench: the observable behavior is the case where CPython 3.14 and PyPy disagree, which the oracle-baselined synth harness rejects (BASEFAIL). Guarded by code comments at the interpreter and fold sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)