### PR TITLE
jit(gh#346): retire the set copy-storage and symmetric-difference IndexMap census heads

### DIFF
--- a/pyre/extra_tests/snippets/set_symdiff_raising_eq.py
+++ b/pyre/extra_tests/snippets/set_symdiff_raising_eq.py
@@ -1,0 +1,71 @@
+# symmetric_difference / ^ with a user __eq__/__hash__ that raises mid-probe.
+# Exercises the JIT-residualised per-key contains/insert boundary: the parked
+# exception must surface identically whether the merge loop runs interpreted or
+# jitted.  Run under both the interpreter and the JIT (the harness warms the
+# loop past the trace threshold).
+
+
+class Boom:
+    """Hashes into one bucket so every pair collides and __eq__ is forced."""
+
+    def __init__(self, key, explode=False):
+        self.key = key
+        self.explode = explode
+
+    def __hash__(self):
+        return 7  # single bucket -> __eq__ runs on every probe
+
+    def __eq__(self, other):
+        if self.explode or getattr(other, "explode", False):
+            raise ValueError("boom in __eq__")
+        return self.key == other.key
+
+
+def run_symdiff(a, b):
+    return a ^ b
+
+
+# --- baseline: no raise, plain-int fast path stays bit-exact ---------------
+for _ in range(1000):
+    assert {1, 2, 3} ^ {2, 3, 4} == {1, 4}
+    assert {1, 2, 3}.symmetric_difference({2, 3, 4}) == {1, 4}
+    assert set() ^ {1} == {1}
+    assert {1} ^ set() == {1}
+
+
+# --- object elements, no raise: hash collision forces __eq__ but succeeds ---
+for _ in range(1000):
+    left = {Boom(1), Boom(2), Boom(3)}
+    right = {Boom(3), Boom(4)}
+    result = run_symdiff(left, right)
+    keys = sorted(e.key for e in result)
+    assert keys == [1, 2, 4], keys
+
+
+# --- raising __eq__ mid-probe: the ValueError must propagate identically ----
+for _ in range(1000):
+    left = {Boom(1), Boom(2)}
+    right = {Boom(1, explode=True)}
+    raised = False
+    try:
+        run_symdiff(left, right)
+    except ValueError as exc:
+        raised = True
+        assert str(exc) == "boom in __eq__"
+    assert raised, "symmetric_difference swallowed a raising __eq__"
+
+
+# --- raising __eq__ on the second pass (walk this side) ---------------------
+for _ in range(1000):
+    left = {Boom(9, explode=True)}
+    right = {Boom(5)}
+    raised = False
+    try:
+        run_symdiff(left, right)
+    except ValueError as exc:
+        raised = True
+        assert str(exc) == "boom in __eq__"
+    assert raised, "symmetric_difference swallowed a raising __eq__ on the second pass"
+
+
+print("set_symdiff_raising_eq OK")

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -711,6 +711,17 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         "w_frozenset_new",
         w_frozenset_new as *const (),
     );
+    // `w_set_copy_storage_from` is `#[dont_look_inside]` (its body clones the
+    // host `SetItemsStorage` `IndexMap` and boxes it into `d.items`); bind its
+    // `unsafe fn(PyObjectRef, PyObjectRef)` so the residual call resolves. The
+    // void 2-arg fn registers exactly like the void `w_type_set_abstract`
+    // sibling below.
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::setobject::w_set_copy_storage_from",
+        "pyre_object::w_set_copy_storage_from",
+        pyre_object::setobject::w_set_copy_storage_from as *const (),
+    );
     push_alias_pair(
         &mut entries,
         "pyre_object::dictmultiobject::w_dict_len",

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -21185,13 +21185,36 @@ fn set_method_symmetric_difference_update(
 /// counts as present when it lands in the same bucket and compares equal; a
 /// bare `eq_w` scan over the elements would instead call two objects the same
 /// element on `__eq__` alone, and place them where their hashes never meet.
+///
+/// Walked one index at a time through `w_set_key_at` and probed with
+/// `w_set_contains_key_checked`, the same shape as `set_intersect_update`, so
+/// the merge loop stays traced and only the per-key table probe/insert cross a
+/// residual boundary. The two sets are old-gen allocations that keep their
+/// addresses across a collection, but their elements are young and move, so
+/// each key is re-read from the table the collector rewrites rather than
+/// carried across the `eq_w` a bucket probe can run.
 fn set_symmetric_difference_storage(
     w_set: pyre_object::PyObjectRef,
     w_other: pyre_object::PyObjectRef,
 ) -> Result<pyre_object::PyObjectRef, crate::PyError> {
     unsafe {
-        pyre_object::setobject::w_set_symmetric_difference_storage(w_set, w_other)
-            .map_err(crate::baseobjspace::map_set_update_error)
+        let d_new = pyre_object::w_set_new();
+        for (walk, probe) in [(w_other, w_set), (w_set, w_other)] {
+            let mut i = 0;
+            while let Some(key) = pyre_object::w_set_key_at(walk, i) {
+                if !pyre_object::w_set_contains_key_checked(probe, key)
+                    .map_err(|_| crate::baseobjspace::take_pending_hash_error())?
+                {
+                    let Some(key) = pyre_object::w_set_key_at(walk, i) else {
+                        break;
+                    };
+                    pyre_object::w_set_insert_key_checked(d_new, key)
+                        .map_err(crate::baseobjspace::map_set_update_error)?;
+                }
+                i += 1;
+            }
+        }
+        Ok(d_new)
     }
 }
 

--- a/pyre/pyre-object/src/setobject.rs
+++ b/pyre/pyre-object/src/setobject.rs
@@ -575,8 +575,17 @@ pub unsafe fn w_set_popitem(obj: PyObjectRef) -> Option<PyObjectRef> {
 /// non-collecting stable old-generation allocator, so there is no collection
 /// point between reading `src`'s table and installing the new field value.
 ///
+/// `#[dont_look_inside]` (`@jit.dont_look_inside`, `rlib/jit.py:139`), the
+/// `w_set_new` twin: cloning `src`'s `SetItemsStorage` (`IndexMap<ObjectKey,
+/// ()>`) and boxing it into `d.items` is a foreign `IndexMap::clone` +
+/// storage-box write. Tracing into it carries that host container op into the
+/// caller and unifies the `items` field as `Instance(IndexMap)`; residualising
+/// the whole assignment keeps the box off the trace, modelling it as a void
+/// effect on two GCREFs.
+///
 /// # Safety
 /// `dst` and `src` must point to valid `W_SetObject`s.
+#[majit_macros::dont_look_inside]
 pub unsafe fn w_set_copy_storage_from(dst: PyObjectRef, src: PyObjectRef) {
     let d = &mut *(dst as *mut W_SetObject);
     let copied = (*(*(src as *const W_SetObject)).items).clone();

--- a/pyre/pyre-object/src/setobject.rs
+++ b/pyre/pyre-object/src/setobject.rs
@@ -716,46 +716,6 @@ pub unsafe fn w_set_update_from_set(
     Ok(())
 }
 
-/// Build the elements on exactly one of the two sides as a fresh set.
-///
-/// `_symmetric_difference_unwrapped` (`setobject.py:1062-1074`) unerases both
-/// tables once — `d_this` and `d_other` — then walks the other side first and
-/// this side second, probing each stored `(key, hash)` pair against the
-/// *captured* opposite table and placing survivors into a fresh `d_new` under
-/// the digest they already carry.  Because both captures happen up front, an
-/// `eq_w` that clears either set mid-walk orphans that table without steering
-/// the walk or the membership probes onto the replacement storage; the caller
-/// then installs the result wholesale (`w_set.sstorage = storage`, `:1114`).
-///
-/// # Safety
-/// `w_set` and `w_other` must point to valid `W_SetObject`s.
-pub unsafe fn w_set_symmetric_difference_storage(
-    w_set: PyObjectRef,
-    w_other: PyObjectRef,
-) -> Result<PyObjectRef, SetUpdateError> {
-    let _roots = crate::gc_roots::push_roots();
-    let d_new = w_set_new();
-    // The fresh set is only reachable from this frame while the probes below
-    // run user code; pin it (set bodies are non-moving, so no reload).
-    crate::gc_roots::pin_root(d_new);
-    let d_this = capture_set_items(w_set);
-    let d_other = capture_set_items(w_other);
-    for (walk, probe) in [(d_other, d_this), (d_this, d_other)] {
-        let mut i = 0;
-        loop {
-            let Some((&key, _)) = (*walk).get_index(i) else {
-                break;
-            };
-            let (found, key) = scan_set_key_reentrant(probe, key).map_err(SetUpdateError::Key)?;
-            if found.is_none() {
-                w_set_insert_key_checked(d_new, key)?;
-            }
-            i += 1;
-        }
-    }
-    Ok(d_new)
-}
-
 /// Failure modes of the PyPy `ObjectSetStrategy.update` table merge.
 pub enum SetUpdateError {
     /// An equality callback raised; its concrete exception is parked in the


### PR DESCRIPTION
gh#346 "JIT rtyper-legacy retirement" — two more IndexMap-axis census heads
retired, PyPy-orthodox only. Stacks on `origin/main`; two independent slices.

## Slice 1 — `w_set_copy_storage_from` (`78e34fe8d7`)
Mark `pyre_object::setobject::w_set_copy_storage_from` `#[dont_look_inside]` and
register its runtime address in `jit_trace_fnaddrs()`, mirroring
`w_set_new`/`w_frozenset_new`. Its body clones the `SetItemsStorage`
(`IndexMap<ObjectKey, ()>`) into a boxed `d.items`, so the foreign
`IndexMap::clone` + storage-box write sat inside the traced graph and `items`
unified as `Instance(IndexMap)` — the phaseA `SomeInstance.setattr("items")
generalize_attr` union error. The fn returns `()`, so it registers with the
same `push_alias_pair` shape as the void `w_type_set_abstract` sibling.

Census **phaseA 303 → 301** (retires `typedef::set_copy_real` +
`setobject::w_set_copy_storage_from`); 0 heads added, phaseB unchanged.

## Slice 2 — `set_symmetric_difference_storage` (`d8efd385ea`)
Rewrite `typedef.rs` `set_symmetric_difference_storage` from a wrapper over the
pyre-object helper into the merge loop itself, walking each operand set one
index at a time through `w_set_key_at` and probing the other with
`w_set_contains_key_checked`, mirroring `set_intersect_update`. Remove the now
unused `pyre_object::setobject::w_set_symmetric_difference_storage`, whose loop
read the storage box through a raw `IndexMap::get_index` returning a reference
tuple the rtyper could not lift.

Orthodoxy: PyPy's `_symmetric_difference_unwrapped` (setobject.py:1062) has no
`dont_look_inside`/`jit_merge_point` — it traces the merge loop and lets the
per-key `contains_with_hash`/`setitem_with_hash` be the residual boundary. The
rewrite restores that objspace-level loop structure.

Census **phaseA 322 → 321** (the `typedef::set_symmetric_difference_storage`
head leaves phaseA), phaseB 25 unchanged, no head added.

Adds `extra_tests/snippets/set_symdiff_raising_eq.py` covering a raising
`__eq__`/`__hash__` mid-probe (plain-int fast path, object elements, raise on
first pass, raise on second pass) — bit-exact JIT vs `PYRE_NO_JIT=1` vs
python3.14.

## Verification
- check.py **dynasm + cranelift bit-exact**, full pass on both slices
- `cargo test -p pyre-object -p pyre-interpreter -p majit-translate` green
- No dead-code warnings after removing the unused helper


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved set symmetric-difference operations to correctly propagate errors raised during element comparisons.
  - Ensured symmetric-difference results are computed consistently across both operator and method forms.
  - Improved handling of sets containing custom objects with hash collisions or moving storage.

- **Tests**
  - Added coverage for error propagation and comparison edge cases in symmetric-difference operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->