### PR TITLE
interp: complete module __getattr__ routing (descriptor __get__ errors + surrogate-name misses)

### DIFF
--- a/pyre/bench/synth/module_getattr_descr_error.py
+++ b/pyre/bench/synth/module_getattr_descr_error.py
@@ -1,0 +1,63 @@
+# module.py Module.descr_getattribute (PEP 562): an AttributeError raised by
+# the normal module lookup — including a module-type data / non-data
+# descriptor's __get__ (objspace.py:694-699) — is caught and routed to the
+# module-level __getattr__, the same as a plain attribute miss.  Without a
+# module __getattr__ the error propagates.  The descriptors live on a
+# ModuleType subclass so the base module slot stays intact.
+
+import types
+
+
+class DataDesc:
+    def __get__(self, obj, objtype=None):
+        raise AttributeError("data descr")
+
+    def __set__(self, obj, value):
+        pass  # __set__ makes it a *data* descriptor
+
+
+class NonDataDesc:
+    def __get__(self, obj, objtype=None):
+        raise AttributeError("non-data descr")
+
+
+class M(types.ModuleType):
+    ddesc = DataDesc()
+    ndesc = NonDataDesc()
+
+
+def with_hook():
+    m = M("m")
+
+    def modgetattr(attr):
+        return "hook:" + attr
+
+    m.__getattr__ = modgetattr
+    return m
+
+
+def main():
+    m = with_hook()
+    # a data descriptor whose __get__ raises AttributeError routes to the hook
+    print("data", getattr(m, "ddesc"))
+    # a non-data descriptor whose __get__ raises AttributeError routes too
+    print("nondata", getattr(m, "ndesc"))
+    # a plain miss routes to the hook as well
+    print("miss", getattr(m, "nope"))
+
+    # no module __getattr__: the descriptor AttributeError propagates unchanged
+    bare = M("bare")
+    try:
+        getattr(bare, "ddesc")
+        print("bare", "NO-RAISE")
+    except AttributeError:
+        print("bare", "AttributeError")
+
+    # a hot loop keeps the routed result stable once the access is compiled
+    seen = set()
+    for _ in range(30000):
+        seen.add(getattr(m, "ddesc"))
+    print("hot", sorted(seen))
+
+
+main()

--- a/pyre/bench/synth/module_getattr_surrogate_cls.py
+++ b/pyre/bench/synth/module_getattr_surrogate_cls.py
@@ -29,11 +29,34 @@ def main():
     print("ident2", getattr(m, "again") == ("dict", "again"))
     print("surr2", getattr(m, SUR) == ("dict", SUR))
 
+    # a module-dict hook that itself raises AttributeError also falls through
+    # to the class-level __getattr__
+    def raising(name):
+        raise AttributeError("hook raised")
+
+    m2 = M("m2")
+    m2.__getattr__ = raising
+    print("ident3", getattr(m2, "x") == ("cls", "x"))
+    print("surr3", getattr(m2, SUR) == ("cls", SUR))
+
     # no hook anywhere: AttributeError for both name kinds
     bare = types.ModuleType("bare")
-    for label, nm in (("ident3", "gone"), ("surr3", SUR)):
+    for label, nm in (("ident4", "gone"), ("surr4", SUR)):
         try:
             getattr(bare, nm)
+            print(label, "NO-RAISE")
+        except AttributeError:
+            print(label, "AttributeError")
+
+    # a raising module-dict hook with NO class-level fallback propagates
+    class Plain(types.ModuleType):
+        pass
+
+    p = Plain("p")
+    p.__getattr__ = raising
+    for label, nm in (("ident5", "gone"), ("surr5", SUR)):
+        try:
+            getattr(p, nm)
             print(label, "NO-RAISE")
         except AttributeError:
             print(label, "AttributeError")

--- a/pyre/bench/synth/module_getattr_surrogate_cls.py
+++ b/pyre/bench/synth/module_getattr_surrogate_cls.py
@@ -1,0 +1,49 @@
+# module.py Module.descr_getattribute for a lone-surrogate attribute name: a
+# module miss consults the module dict's PEP 562 __getattr__ first, then the
+# class-level __getattr__ on the module's type (descroperation.py:242-245),
+# just like an identifier name.  Results are compared, never printed, so the
+# surrogate never reaches the stdout codec.
+
+import types
+
+
+class M(types.ModuleType):
+    def __getattr__(self, name):
+        return ("cls", name)
+
+
+SUR = "\udc80"  # lone surrogate -> non-identifier attribute name
+
+
+def main():
+    m = M("m")
+    # class-level __getattr__ reached for both an identifier and a surrogate name
+    print("ident", getattr(m, "missing") == ("cls", "missing"))
+    print("surr", getattr(m, SUR) == ("cls", SUR))
+
+    # a module-dict PEP 562 hook wins over the class-level one, for both kinds
+    def modhook(name):
+        return ("dict", name)
+
+    m.__getattr__ = modhook
+    print("ident2", getattr(m, "again") == ("dict", "again"))
+    print("surr2", getattr(m, SUR) == ("dict", SUR))
+
+    # no hook anywhere: AttributeError for both name kinds
+    bare = types.ModuleType("bare")
+    for label, nm in (("ident3", "gone"), ("surr3", SUR)):
+        try:
+            getattr(bare, nm)
+            print(label, "NO-RAISE")
+        except AttributeError:
+            print(label, "AttributeError")
+
+    # a hot loop over the routed surrogate access stays stable once compiled
+    ok = 0
+    for _ in range(20000):
+        if getattr(m, SUR) == ("dict", SUR):
+            ok += 1
+    print("hot", ok)
+
+
+main()

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -5354,14 +5354,10 @@ unsafe fn getattr_surrogate(obj: PyObjectRef, w_name: PyObjectRef, name: &Wtf8) 
                     if !w_dict.is_null() {
                         if let Some(mod_getattr) = finditem_str(w_dict, "__getattr__")? {
                             if !mod_getattr.is_null() {
-                                match crate::call::call_function_impl_result(
-                                    mod_getattr,
-                                    &[w_name],
-                                ) {
+                                match crate::call::call_function_impl_result(mod_getattr, &[w_name])
+                                {
                                     Ok(v) => return Ok(v),
-                                    Err(e2)
-                                        if e2.kind == crate::PyErrorKind::AttributeError =>
-                                    {
+                                    Err(e2) if e2.kind == crate::PyErrorKind::AttributeError => {
                                         e = e2;
                                     }
                                     Err(e2) => return Err(e2),

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -5012,10 +5012,22 @@ fn getattr_str_impl(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyResul
             } else {
                 lookup_in_type_where(w_type, name)
             };
+            // module.py descr_getattribute runs the normal lookup, then catches
+            // an AttributeError from it (objspace.py:694-699) and routes it to
+            // the PEP 562 module `__getattr__`.  This inlined default slot must
+            // do the same rather than propagate a descriptor `__get__`'s
+            // AttributeError; the bare `object.__getattribute__` slot
+            // (`!call_getattr`) still propagates so `module_getattribute`'s own
+            // `try`/`except` performs the routing.
             if let Some(descr) = w_descr {
                 if is_data_descr(descr) {
-                    if let Some(value) = get(descr, obj, w_type)? {
-                        return Ok(value);
+                    match get(descr, obj, w_type) {
+                        Ok(Some(value)) => return Ok(value),
+                        Ok(None) => {}
+                        Err(e) if call_getattr && e.kind == PyErrorKind::AttributeError => {
+                            return module_getattr_fallback(obj, name, e);
+                        }
+                        Err(e) => return Err(e),
                     }
                 }
             }
@@ -5028,7 +5040,13 @@ fn getattr_str_impl(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyResul
                 }
             }
             if let Some(descr) = w_descr {
-                return Ok(get(descr, obj, w_type)?.unwrap_or(descr));
+                match get(descr, obj, w_type) {
+                    Ok(value) => return Ok(value.unwrap_or(descr)),
+                    Err(e) if call_getattr && e.kind == PyErrorKind::AttributeError => {
+                        return module_getattr_fallback(obj, name, e);
+                    }
+                    Err(e) => return Err(e),
+                }
             }
         }
     }
@@ -5247,13 +5265,7 @@ fn getattr_str_impl(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyResul
         if err.kind != PyErrorKind::AttributeError {
             return Err(err);
         }
-        let err = match unsafe { module_getattr_hook_or_err(obj, name, err, true) } {
-            Ok(value) => return Ok(value),
-            Err(e) if e.kind == PyErrorKind::AttributeError => e,
-            Err(e) => return Err(e),
-        };
-        let w_type = crate::typedef::r#type(obj).map_or(PY_NULL, |p| p.as_ptr());
-        return unsafe { instance_getattr_hook_or_err(w_type, obj, name, err) };
+        return unsafe { module_getattr_fallback(obj, name, err) };
     }
 
     let err = match object_getattr_miss(obj, name, call_getattr) {
@@ -5843,6 +5855,23 @@ unsafe fn module_getattr_hook_or_err(
         format!("module '{nm}' has no attribute '{name}'")
     };
     Err(PyError::new(PyErrorKind::AttributeError, msg))
+}
+
+/// module.py `Module.descr_getattribute` AttributeError tail for the inlined
+/// default slot: consult the module dict's PEP 562 `__getattr__`, then the
+/// receiver type's class-level `__getattr__` (descroperation.py:242-245),
+/// before propagating `err`.  Mirrors the `module_getattribute` slot's own
+/// `try`/`except` so a directly-served `getattr(module, name)` routes a
+/// descriptor `__get__`'s AttributeError the same way an explicit
+/// `ModuleType.__getattribute__` call would.
+unsafe fn module_getattr_fallback(obj: PyObjectRef, name: &str, err: PyError) -> PyResult {
+    let err = match module_getattr_hook_or_err(obj, name, err, true) {
+        Ok(value) => return Ok(value),
+        Err(e) if e.kind == PyErrorKind::AttributeError => e,
+        Err(e) => return Err(e),
+    };
+    let w_type = crate::typedef::r#type(obj).map_or(PY_NULL, |p| p.as_ptr());
+    instance_getattr_hook_or_err(w_type, obj, name, err)
 }
 
 /// `descroperation.py:242-245` `_handle_getattribute` tail: on an

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -5334,7 +5334,7 @@ unsafe fn getattr_surrogate(obj: PyObjectRef, w_name: PyObjectRef, name: &Wtf8) 
     unsafe {
         match object_getattribute_surrogate(obj, w_name, name) {
             Ok(v) => Ok(v),
-            Err(e) => {
+            Err(mut e) => {
                 // descroperation.py:243-252 `_handle_getattribute`: only an
                 // AttributeError from `__getattribute__` (here a descriptor
                 // `__get__` or the dict miss) triggers the `__getattr__`
@@ -5345,19 +5345,27 @@ unsafe fn getattr_surrogate(obj: PyObjectRef, w_name: PyObjectRef, name: &Wtf8) 
                 // module.py:139-162 PEP 562: a module-level `__getattr__` in the
                 // module's own dict is consulted first on miss, called unbound
                 // with just the name (a module hook is a dict value, not a type
-                // descriptor).  With no module hook, fall through to the
-                // class-level `__getattr__` on the module's type
-                // (descroperation.py:242-245), matching the non-surrogate path's
-                // `module_getattr_fallback`.
+                // descriptor).  A missing module hook — or one that itself raises
+                // AttributeError — falls through to the class-level `__getattr__`
+                // on the module's type (descroperation.py:242-245), matching the
+                // non-surrogate path's `module_getattr_fallback`.
                 if is_module(obj) {
                     let w_dict = pyre_object::w_module_get_w_dict(obj);
                     if !w_dict.is_null() {
                         if let Some(mod_getattr) = finditem_str(w_dict, "__getattr__")? {
                             if !mod_getattr.is_null() {
-                                return crate::call::call_function_impl_result(
+                                match crate::call::call_function_impl_result(
                                     mod_getattr,
                                     &[w_name],
-                                );
+                                ) {
+                                    Ok(v) => return Ok(v),
+                                    Err(e2)
+                                        if e2.kind == crate::PyErrorKind::AttributeError =>
+                                    {
+                                        e = e2;
+                                    }
+                                    Err(e2) => return Err(e2),
+                                }
                             }
                         }
                     }

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -5342,10 +5342,13 @@ unsafe fn getattr_surrogate(obj: PyObjectRef, w_name: PyObjectRef, name: &Wtf8) 
                 if e.kind != crate::PyErrorKind::AttributeError {
                     return Err(e);
                 }
-                // module.py:139-142 PEP 562: a module-level `__getattr__` in the
-                // module's own dict is consulted on miss, called unbound with
-                // just the name (a module hook is a dict value, not a type
-                // descriptor).
+                // module.py:139-162 PEP 562: a module-level `__getattr__` in the
+                // module's own dict is consulted first on miss, called unbound
+                // with just the name (a module hook is a dict value, not a type
+                // descriptor).  With no module hook, fall through to the
+                // class-level `__getattr__` on the module's type
+                // (descroperation.py:242-245), matching the non-surrogate path's
+                // `module_getattr_fallback`.
                 if is_module(obj) {
                     let w_dict = pyre_object::w_module_get_w_dict(obj);
                     if !w_dict.is_null() {
@@ -5358,7 +5361,6 @@ unsafe fn getattr_surrogate(obj: PyObjectRef, w_name: PyObjectRef, name: &Wtf8) 
                             }
                         }
                     }
-                    return Err(e);
                 }
                 // `space.lookup(w_obj, '__getattr__')` walks `type(w_obj)` —
                 // the metaclass for a type receiver, the class for an


### PR DESCRIPTION
Two related fixes closing gaps where a module attribute lookup failed to reach the module's `__getattr__` hooks. Both mirror `module.py Module.descr_getattribute` / `objspace.py:694-699` / `descroperation.py:242-245`, and both are oracle-agreed (python3.14 == pypy3).

## 1. Descriptor `__get__` AttributeError (flagged by Codex on #844)

`getattr_str_impl` inlines the default module `__getattribute__` for the hot path but propagated an `AttributeError` raised by a module-type data / non-data descriptor's `__get__` instead of routing it — unlike the `module_getattribute` slot's own `try`/`except`. So `getattr(module, name)` where a `ModuleType`(-subclass) descriptor's `__get__` raises `AttributeError` leaked the error rather than consulting the module's PEP 562 `__getattr__`.

- On the `space.getattr` path (`call_getattr`), catch that `AttributeError` and route it through the module dict's PEP 562 `__getattr__`, then the class-level `__getattr__`. The bare `object.__getattribute__` slot (`!call_getattr`) still propagates, so `module_getattribute`'s own `try`/`except` performs the routing.
- This makes the module fast-path consistent with the instance and type paths, which already route descriptor `__get__` `AttributeError`s.
- Extract the shared tail as `module_getattr_fallback` and reuse it in the module-miss tail.
- Test: `synth/module_getattr_descr_error`.

## 2. Surrogate-name module miss

`getattr_surrogate` consulted the module dict's PEP 562 `__getattr__` on a lone-surrogate attribute miss but returned the `AttributeError` instead of falling through to the class-level `__getattr__` on the module's type, unlike the non-surrogate `module_getattr_fallback`. `getattr(module, "\udc80")` on a `ModuleType` subclass with a class-level `__getattr__` raised instead of calling it.

- Drop the early return so a surrogate-name miss reaches the class-level `__getattr__` too.
- Test: `synth/module_getattr_surrogate_cls`.

## Verification

- Both fixes: `getattr` result identical across python3.14, pypy3, pyre-dynasm JIT, pyre-dynasm NOJIT.
- `check.py --backend dynasm`: ALL PASSED 328/328.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved module attribute lookup so `AttributeError` from descriptor `__get__` is routed consistently through module-level fallback behavior, with reliable class-level fallback when needed.
  * Updated lone-surrogate attribute name handling to consult module-level `__getattr__` first before falling back.

* **Tests**
  * Added benchmark coverage for descriptor failures and module attribute fallback behavior, including repeated surrogate-name lookups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->