### PR TITLE
gc: deliver __del__ for builtin subclasses; walk referents; hash a weakref as its referent

### DIFF
--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -388,6 +388,7 @@ fn register_active_hooks(supports_guard_gc_type: bool) {
     majit_gc::set_active_alloc_oldgen_typed(Some(alloc_oldgen_typed_via_active_runtime));
     majit_gc::set_active_collect_full(Some(collect_full_via_active_runtime));
     majit_gc::set_active_get_objects(Some(get_objects_via_active_runtime));
+    majit_gc::set_active_get_referents(Some(get_referents_via_active_runtime));
     majit_gc::set_active_collect_oldgen(Some(collect_oldgen_nonmoving_via_active_runtime));
     majit_gc::set_active_heap_stats(Some(heap_stats_via_active_runtime));
     majit_gc::set_active_root_hooks(
@@ -1610,6 +1611,11 @@ fn collect_full_via_active_runtime() {
 fn get_objects_via_active_runtime(generation: i8, visitor: majit_gc::GetObjectsVisitorFn) {
     let mut visit = visitor;
     with_cranelift_gc(|gc| gc.get_objects(generation, &mut visit));
+}
+
+fn get_referents_via_active_runtime(obj: GcRef, visitor: majit_gc::GetObjectsVisitorFn) {
+    let mut visit = visitor;
+    with_cranelift_gc(|gc| gc.get_referents(obj, &mut visit));
 }
 
 /// Non-moving old-gen-only major trampoline — sweeps dead old-gen objects

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -389,6 +389,7 @@ fn register_active_hooks(supports_guard_gc_type: bool) {
     majit_gc::set_active_collect_full(Some(collect_full_via_active_runtime));
     majit_gc::set_active_get_objects(Some(get_objects_via_active_runtime));
     majit_gc::set_active_get_referents(Some(get_referents_via_active_runtime));
+    majit_gc::set_active_is_tracked(Some(is_tracked_via_active_runtime));
     majit_gc::set_active_collect_oldgen(Some(collect_oldgen_nonmoving_via_active_runtime));
     majit_gc::set_active_heap_stats(Some(heap_stats_via_active_runtime));
     majit_gc::set_active_root_hooks(
@@ -1616,6 +1617,10 @@ fn get_objects_via_active_runtime(generation: i8, visitor: majit_gc::GetObjectsV
 fn get_referents_via_active_runtime(obj: GcRef, visitor: majit_gc::GetObjectsVisitorFn) {
     let mut visit = visitor;
     with_cranelift_gc(|gc| gc.get_referents(obj, &mut visit));
+}
+
+fn is_tracked_via_active_runtime(obj: GcRef) -> bool {
+    with_cranelift_gc(|gc| gc.is_tracked(obj)).unwrap_or(false)
 }
 
 /// Non-moving old-gen-only major trampoline — sweeps dead old-gen objects

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -192,6 +192,7 @@ fn register_active_hooks(supports_guard_gc_type: bool) {
     majit_gc::set_active_alloc_oldgen_typed(Some(dynasm_alloc_oldgen_typed));
     majit_gc::set_active_collect_full(Some(dynasm_collect_full));
     majit_gc::set_active_get_objects(Some(dynasm_get_objects));
+    majit_gc::set_active_get_referents(Some(dynasm_get_referents));
     majit_gc::set_active_collect_oldgen(Some(dynasm_collect_oldgen_nonmoving));
     majit_gc::set_active_heap_stats(Some(dynasm_heap_stats));
     majit_gc::set_active_root_hooks(Some(dynasm_gc_add_root), Some(dynasm_gc_remove_root));
@@ -495,6 +496,21 @@ fn dynasm_get_objects(generation: i8, visitor: majit_gc::GetObjectsVisitorFn) {
         return;
     }
     majit_gc::gc_sync::gc_op(|g| g.get_objects(generation, &mut visit));
+}
+
+fn dynasm_get_referents(obj: majit_ir::GcRef, visitor: majit_gc::GetObjectsVisitorFn) {
+    let mut visit = visitor;
+    if DYNASM_ACTIVE_GC
+        .with(|c| {
+            c.borrow_mut()
+                .as_deref_mut()
+                .map(|g| g.get_referents(obj, &mut visit))
+        })
+        .is_some()
+    {
+        return;
+    }
+    majit_gc::gc_sync::gc_op(|g| g.get_referents(obj, &mut visit));
 }
 
 /// Non-moving old-gen-only major. Reclaims stable-allocated interp int/float

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -193,6 +193,7 @@ fn register_active_hooks(supports_guard_gc_type: bool) {
     majit_gc::set_active_collect_full(Some(dynasm_collect_full));
     majit_gc::set_active_get_objects(Some(dynasm_get_objects));
     majit_gc::set_active_get_referents(Some(dynasm_get_referents));
+    majit_gc::set_active_is_tracked(Some(dynasm_is_tracked));
     majit_gc::set_active_collect_oldgen(Some(dynasm_collect_oldgen_nonmoving));
     majit_gc::set_active_heap_stats(Some(dynasm_heap_stats));
     majit_gc::set_active_root_hooks(Some(dynasm_gc_add_root), Some(dynasm_gc_remove_root));
@@ -511,6 +512,15 @@ fn dynasm_get_referents(obj: majit_ir::GcRef, visitor: majit_gc::GetObjectsVisit
         return;
     }
     majit_gc::gc_sync::gc_op(|g| g.get_referents(obj, &mut visit));
+}
+
+fn dynasm_is_tracked(obj: majit_ir::GcRef) -> bool {
+    if let Some(tracked) =
+        DYNASM_ACTIVE_GC.with(|c| c.borrow_mut().as_deref_mut().map(|g| g.is_tracked(obj)))
+    {
+        return tracked;
+    }
+    majit_gc::gc_sync::gc_op(|g| g.is_tracked(obj))
 }
 
 /// Non-moving old-gen-only major. Reclaims stable-allocated interp int/float

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -315,6 +315,7 @@ fn register_active_hooks(supports_guard_gc_type: bool) {
     majit_gc::set_active_write_barrier(Some(wasm_active_gc_write_barrier));
     majit_gc::set_active_get_objects(Some(wasm_get_objects));
     majit_gc::set_active_get_referents(Some(wasm_get_referents));
+    majit_gc::set_active_is_tracked(Some(wasm_is_tracked));
     majit_gc::set_active_collect_oldgen(Some(wasm_collect_oldgen_nonmoving));
     majit_gc::set_active_heap_stats(Some(active_gc_heap_stats));
     majit_gc::set_active_finalizer_hooks(
@@ -477,6 +478,10 @@ fn wasm_get_objects(generation: i8, visitor: majit_gc::GetObjectsVisitorFn) {
 fn wasm_get_referents(obj: GcRef, visitor: majit_gc::GetObjectsVisitorFn) {
     let mut visit = visitor;
     with_wasm_active_gc_mut(|gc| gc.get_referents(obj, &mut visit));
+}
+
+fn wasm_is_tracked(obj: GcRef) -> bool {
+    with_wasm_active_gc_mut(|gc| gc.is_tracked(obj)).unwrap_or(false)
 }
 
 fn wasm_register_finalizer(fq_index: usize, obj: GcRef, trigger: majit_gc::FinalizerTriggerFn) {

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -314,6 +314,7 @@ fn register_active_hooks(supports_guard_gc_type: bool) {
     majit_gc::set_active_gc_owns_object(Some(wasm_gc_owns_object));
     majit_gc::set_active_write_barrier(Some(wasm_active_gc_write_barrier));
     majit_gc::set_active_get_objects(Some(wasm_get_objects));
+    majit_gc::set_active_get_referents(Some(wasm_get_referents));
     majit_gc::set_active_collect_oldgen(Some(wasm_collect_oldgen_nonmoving));
     majit_gc::set_active_heap_stats(Some(active_gc_heap_stats));
     majit_gc::set_active_finalizer_hooks(
@@ -471,6 +472,11 @@ fn wasm_collect_oldgen_nonmoving() {
 fn wasm_get_objects(generation: i8, visitor: majit_gc::GetObjectsVisitorFn) {
     let mut visit = visitor;
     with_wasm_active_gc_mut(|gc| gc.get_objects(generation, &mut visit));
+}
+
+fn wasm_get_referents(obj: GcRef, visitor: majit_gc::GetObjectsVisitorFn) {
+    let mut visit = visitor;
+    with_wasm_active_gc_mut(|gc| gc.get_referents(obj, &mut visit));
 }
 
 fn wasm_register_finalizer(fq_index: usize, obj: GcRef, trigger: majit_gc::FinalizerTriggerFn) {

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -2184,6 +2184,24 @@ impl MiniMarkGC {
         }
     }
 
+    /// Whether the collector traverses references out of this object — the
+    /// property CPython's `gc.is_tracked` reports.
+    ///
+    /// Heap ownership alone is the wrong test: an atomic object such as an int
+    /// or a float is collector-allocated on some paths (`PYRE_GC_INTERP`, the
+    /// JIT, wasm) and immortal on others, so ownership would make the same
+    /// Python value answer differently per backend. Its registered type has no
+    /// reference to traverse either way, which is the stable property.
+    pub fn object_is_tracked(&self, obj_addr: usize) -> bool {
+        if !self.is_managed_heap_object(obj_addr) {
+            return false;
+        }
+        let type_id = unsafe { (*header_of(obj_addr)).type_id() };
+        self.validate_type_id(type_id, obj_addr, "object_is_tracked");
+        let type_info = self.types.get(type_id);
+        type_info.has_gc_ptrs || (type_info.items_have_gc_ptrs && type_info.item_size > 0)
+    }
+
     /// `inspector.py:get_rpy_referents`: trace one object's direct GC
     /// referents without changing collection state.
     fn visit_referents(&self, obj_addr: usize, visitor: &mut dyn FnMut(GcRef)) {
@@ -3856,6 +3874,10 @@ impl GcAllocator for MiniMarkGC {
         self.do_get_referents(obj, visitor)
     }
 
+    fn is_tracked(&mut self, obj: GcRef) -> bool {
+        self.object_is_tracked(obj.0)
+    }
+
     fn collect_oldgen_nonmoving(&mut self) {
         self.do_collect_oldgen_nonmoving();
     }
@@ -4301,6 +4323,39 @@ mod tests {
         let mut referents = Vec::new();
         gc.do_get_referents(far, &mut |gcref| referents.push(gcref));
         assert_eq!(referents, vec![holder]);
+        gc.roots.clear();
+    }
+
+    #[test]
+    fn is_tracked_follows_the_type_not_the_heap_the_instance_landed_in() {
+        let ptr_size = std::mem::size_of::<GcRef>();
+        let mut gc = test_gc(4096);
+        let atomic_tid = gc.register_type(TypeInfo::object(ptr_size));
+        let holder_tid = gc.register_type(TypeInfo::object_subclass_with_gc_ptrs(
+            ptr_size,
+            atomic_tid,
+            vec![0],
+        ));
+
+        let atomic = gc.alloc_with_type(atomic_tid, ptr_size);
+        let mut holder = gc.alloc_with_type(holder_tid, ptr_size);
+        unsafe {
+            *(holder.0 as *mut GcRef) = atomic;
+            gc.roots.add(&mut holder);
+        }
+        assert!(!gc.object_is_tracked(atomic.0));
+        assert!(gc.object_is_tracked(holder.0));
+
+        // The same two types answer the same way once promoted out of the
+        // nursery — the heap the instance landed in must not matter.
+        gc.do_collect_nursery();
+        let atomic = unsafe { *(holder.0 as *const GcRef) };
+        assert!(!gc.object_is_tracked(atomic.0));
+        assert!(gc.object_is_tracked(holder.0));
+
+        // An address the collector does not own is never tracked.
+        let mut off_heap = 0usize;
+        assert!(!gc.object_is_tracked(&mut off_heap as *mut usize as usize));
         gc.roots.clear();
     }
 

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -2278,6 +2278,66 @@ impl MiniMarkGC {
         }
     }
 
+    /// `pypy/module/gc/referents.py:53-78 _list_w_obj_referents`: visit the
+    /// app-level objects `obj` refers to directly, looking through the
+    /// interpreter-internal structs in between. A visited app-level object
+    /// terminates that branch of the walk; anything else is expanded, so a
+    /// list reports its items rather than its item array. GCFLAG_EXTRA keeps
+    /// each node out of the walk twice and is restored before returning.
+    pub fn do_get_referents(&mut self, obj: GcRef, visitor: &mut dyn FnMut(GcRef)) {
+        if obj.is_null() || !self.is_managed_heap_object(obj.0) {
+            return;
+        }
+        let _stw = if crate::gc_sync::stw_required() {
+            Some(crate::gc_sync::quiesce_mutators())
+        } else {
+            None
+        };
+        let mut pending: Vec<GcRef> = Vec::new();
+        let mut result: Vec<GcRef> = Vec::new();
+        let mut i = 0usize;
+        let mut parent = obj;
+        loop {
+            let mut children: Vec<GcRef> = Vec::new();
+            self.visit_referents(parent.0, &mut |child| children.push(child));
+            for child in children {
+                if child.is_null() || !self.is_managed_heap_object(child.0) {
+                    continue;
+                }
+                let hdr = unsafe { header_of(child.0) };
+                if unsafe { (*hdr).has_flag(flags::EXTRA) } {
+                    continue;
+                }
+                unsafe { (*hdr).set_flag(flags::EXTRA) };
+                pending.push(child);
+            }
+            // Walk the queue until a non-app-level node needs expanding; on
+            // reaching the end without one, every branch has terminated.
+            let mut expand = false;
+            while i < pending.len() {
+                parent = pending[i];
+                i += 1;
+                let hdr = unsafe { header_of(parent.0) };
+                let type_id = unsafe { (*hdr).type_id() };
+                if !unsafe { (*hdr).has_flag(flags::DUMMY) } && self.types.get(type_id).is_object {
+                    result.push(parent);
+                } else {
+                    expand = true;
+                    break;
+                }
+            }
+            if !expand {
+                break;
+            }
+        }
+        for gcref in &pending {
+            unsafe { (*header_of(gcref.0)).clear_flag(flags::EXTRA) };
+        }
+        for gcref in result {
+            visitor(gcref);
+        }
+    }
+
     /// incminimark.py:2478-2481 `collect_nonstack_roots(); visit_all_objects()`.
     ///
     /// Non-stack roots may grow after the initial root snapshot while marking
@@ -3792,6 +3852,10 @@ impl GcAllocator for MiniMarkGC {
         self.do_get_objects(generation, visitor)
     }
 
+    fn get_referents(&mut self, obj: GcRef, visitor: &mut dyn FnMut(GcRef)) {
+        self.do_get_referents(obj, visitor)
+    }
+
     fn collect_oldgen_nonmoving(&mut self) {
         self.do_collect_oldgen_nonmoving();
     }
@@ -4195,6 +4259,48 @@ mod tests {
         for object in [holder, raw, leaf] {
             assert!(!unsafe { (*header_of(object.0)).has_flag(flags::EXTRA) });
         }
+        gc.roots.clear();
+    }
+
+    #[test]
+    fn get_referents_looks_through_rpython_structs_and_stops_at_objects() {
+        let ptr_size = std::mem::size_of::<GcRef>();
+        let mut gc = test_gc(4096);
+        let pair_info = || TypeInfo::with_gc_ptrs(2 * ptr_size, vec![0, ptr_size]);
+        let raw_tid = gc.register_type(pair_info());
+        let mut object_info = pair_info();
+        object_info.is_object = true;
+        let object_tid = gc.register_type(object_info);
+
+        // holder -> raw -> {near, far}; `far` in turn points back at `holder`,
+        // which must not be reported: the walk stops at the first object.
+        let near = gc.alloc_with_type(object_tid, 2 * ptr_size);
+        let far = gc.alloc_with_type(object_tid, 2 * ptr_size);
+        let raw = gc.alloc_with_type(raw_tid, 2 * ptr_size);
+        let mut holder = gc.alloc_with_type(object_tid, 2 * ptr_size);
+        unsafe {
+            *(raw.0 as *mut GcRef) = near;
+            *((raw.0 + ptr_size) as *mut GcRef) = far;
+            *(far.0 as *mut GcRef) = holder;
+            *(holder.0 as *mut GcRef) = raw;
+            gc.roots.add(&mut holder);
+        }
+
+        let mut referents = Vec::new();
+        gc.do_get_referents(holder, &mut |gcref| referents.push(gcref));
+        assert_eq!(referents.len(), 2);
+        assert!(referents.contains(&near));
+        assert!(referents.contains(&far));
+        assert!(!referents.contains(&raw));
+        assert!(!referents.contains(&holder));
+        for object in [holder, raw, near, far] {
+            assert!(!unsafe { (*header_of(object.0)).has_flag(flags::EXTRA) });
+        }
+
+        // A self-referential object terminates instead of looping forever.
+        let mut referents = Vec::new();
+        gc.do_get_referents(far, &mut |gcref| referents.push(gcref));
+        assert_eq!(referents, vec![holder]);
         gc.roots.clear();
     }
 

--- a/majit/majit-gc/src/lib.rs
+++ b/majit/majit-gc/src/lib.rs
@@ -334,6 +334,12 @@ pub trait GcAllocator: Send {
     /// objects.
     fn get_referents(&mut self, _obj: GcRef, _visitor: &mut dyn FnMut(GcRef)) {}
 
+    /// Whether the collector traverses references out of `obj` — what
+    /// `gc.is_tracked` reports. Collectors without an inspector track nothing.
+    fn is_tracked(&mut self, _obj: GcRef) -> bool {
+        false
+    }
+
     /// Trigger a non-moving old-gen-only major collection (sweep dead old-gen
     /// objects without moving the nursery). The default no-ops so a backend
     /// with no incremental old-gen lacks no method; `MiniMarkGC` overrides it.
@@ -808,6 +814,9 @@ impl GcAllocator for GcHandle {
     }
     fn get_referents(&mut self, obj: GcRef, visitor: &mut dyn FnMut(GcRef)) {
         gc_sync::gc_op(|gc| gc.get_referents(obj, visitor))
+    }
+    fn is_tracked(&mut self, obj: GcRef) -> bool {
+        gc_sync::gc_op(|gc| gc.is_tracked(obj))
     }
     fn collect_oldgen_nonmoving(&mut self) {
         gc_sync::gc_op(|gc| gc.collect_oldgen_nonmoving())
@@ -1502,6 +1511,23 @@ pub fn set_active_get_referents(hook: Option<GetReferentsFn>) {
 pub fn get_referents(obj: GcRef, visitor: GetObjectsVisitorFn) {
     if let Some(f) = ACTIVE_GET_REFERENTS.get() {
         f(obj, visitor);
+    }
+}
+
+/// Active-backend trampoline for `gc.is_tracked`: whether the collector
+/// traverses references out of the object.
+pub type IsTrackedFn = fn(GcRef) -> bool;
+
+global_hook!(static ACTIVE_IS_TRACKED: IsTrackedFn);
+
+pub fn set_active_is_tracked(hook: Option<IsTrackedFn>) {
+    ACTIVE_IS_TRACKED.set(hook);
+}
+
+pub fn is_tracked(obj: GcRef) -> bool {
+    match ACTIVE_IS_TRACKED.get() {
+        Some(f) => f(obj),
+        None => false,
     }
 }
 

--- a/majit/majit-gc/src/lib.rs
+++ b/majit/majit-gc/src/lib.rs
@@ -327,6 +327,13 @@ pub trait GcAllocator: Send {
     /// without an inspector visit no objects.
     fn get_objects(&mut self, _generation: i8, _visitor: &mut dyn FnMut(GcRef)) {}
 
+    /// `pypy/module/gc/referents.py:53-78 _list_w_obj_referents`: visit the
+    /// app-level objects `obj` refers to directly, expanding the
+    /// interpreter-internal structs in between. Same rooting contract as
+    /// [`GcAllocator::get_objects`]. Collectors without an inspector visit no
+    /// objects.
+    fn get_referents(&mut self, _obj: GcRef, _visitor: &mut dyn FnMut(GcRef)) {}
+
     /// Trigger a non-moving old-gen-only major collection (sweep dead old-gen
     /// objects without moving the nursery). The default no-ops so a backend
     /// with no incremental old-gen lacks no method; `MiniMarkGC` overrides it.
@@ -798,6 +805,9 @@ impl GcAllocator for GcHandle {
     }
     fn get_objects(&mut self, generation: i8, visitor: &mut dyn FnMut(GcRef)) {
         gc_sync::gc_op(|gc| gc.get_objects(generation, visitor))
+    }
+    fn get_referents(&mut self, obj: GcRef, visitor: &mut dyn FnMut(GcRef)) {
+        gc_sync::gc_op(|gc| gc.get_referents(obj, visitor))
     }
     fn collect_oldgen_nonmoving(&mut self) {
         gc_sync::gc_op(|gc| gc.collect_oldgen_nonmoving())
@@ -1475,6 +1485,23 @@ pub fn set_active_get_objects(hook: Option<GetObjectsFn>) {
 pub fn get_objects(generation: i8, visitor: GetObjectsVisitorFn) {
     if let Some(f) = ACTIVE_GET_OBJECTS.get() {
         f(generation, visitor);
+    }
+}
+
+/// Active-backend trampoline for `pypy/module/gc/referents.py:53-78
+/// _list_w_obj_referents`. Same rooting contract as [`get_objects`]: the
+/// backend invokes the visitor while its inspection pause is still held.
+pub type GetReferentsFn = fn(GcRef, GetObjectsVisitorFn);
+
+global_hook!(static ACTIVE_GET_REFERENTS: GetReferentsFn);
+
+pub fn set_active_get_referents(hook: Option<GetReferentsFn>) {
+    ACTIVE_GET_REFERENTS.set(hook);
+}
+
+pub fn get_referents(obj: GcRef, visitor: GetObjectsVisitorFn) {
+    if let Some(f) = ACTIVE_GET_REFERENTS.get() {
+        f(obj, visitor);
     }
 }
 

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -4111,9 +4111,7 @@ fn type_descr_new_with_metaclass(
         // rclass.py:739-743 — set w_class (typeptr) at allocation time.
         // For type objects, w_class is the metaclass (type(C) → Meta).
         // baseobjspace.py getclass() returns the metatype.
-        unsafe {
-            (*w_type).w_class = w_metaclass;
-        }
+        crate::typedef::tag_subclass_instance(w_type, w_metaclass);
 
         // type_new_classcell — bind the captured `__classcell__` to the
         // new type so `__class__` / zero-arg `super()` in the methods
@@ -5039,9 +5037,7 @@ fn os_error_family_new(
         cls
     };
     if let Some(w_target) = w_target {
-        unsafe {
-            (*(exc as *mut pyre_object::PyObject)).w_class = w_target;
-        }
+        crate::typedef::tag_subclass_instance(exc, w_target);
     }
     // Fill the slots after the retag so `os_error_fill_slots` can see the
     // resolved class (the `BlockingIOError` numeric-filename special-case).
@@ -5318,9 +5314,7 @@ macro_rules! exc_new_wrapper {
             // Set the exception's w_class to the actual exception type (e.g. AssertionError)
             // so that `type(e) is AssertionError` holds and `except ExcType` via isinstance works.
             if let Some(cls) = cls {
-                unsafe {
-                    (*(exc as *mut pyre_object::PyObject)).w_class = cls;
-                }
+                crate::typedef::tag_subclass_instance(exc, cls);
             }
             Ok(exc)
         }
@@ -5703,8 +5697,8 @@ fn exception_group_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErr
         pyre_object::interp_exceptions::ExcKind::BaseException
     };
     let exc = pyre_object::interp_exceptions::w_exception_new_empty(kind);
+    crate::typedef::tag_subclass_instance(exc, cls);
     unsafe {
-        (*exc).w_class = cls;
         let tuple = pyre_object::w_tuple_new(exceptions);
         let w_dict = pyre_object::interp_exceptions::w_exception_getdict(exc);
         pyre_object::w_dict_setitem_str(w_dict, EG_MESSAGE_KEY, message);

--- a/pyre/pyre-interpreter/src/executioncontext.rs
+++ b/pyre/pyre-interpreter/src/executioncontext.rs
@@ -180,6 +180,20 @@ pub fn register_native_buffer_finalizer(obj: PyObjectRef) {
     pyre_object::gc_hook::try_gc_register_finalizer(0, obj, finalizer_queue_trigger);
 }
 
+/// `interp_iobase.py:63-64 W_IOBase.__init__`: `if self.needs_finalizer():
+/// self.register_finalizer(space)`.
+///
+/// An unclosed file must still flush and close when it becomes unreachable,
+/// and `_io`'s `__del__` (`module/_io/mod.rs` `iobase_del`) does exactly
+/// that. It is a builtin method on the interp-level type, so `hasuserdel` —
+/// which `type.__new__` sets only for a class whose own dict carries
+/// `__del__` — is false here and [`maybe_register_user_finalizer`] would
+/// skip the object. Registration is therefore explicit at construction,
+/// as upstream does it.
+pub fn register_iobase_finalizer(obj: PyObjectRef) {
+    pyre_object::gc_hook::try_gc_register_finalizer(0, obj, finalizer_queue_trigger);
+}
+
 /// Register an object that owns a `WeakrefLifeline`. PyPy's GC invalidates the
 /// rweakrefs and registers callback-bearing lifelines themselves; until pyre's
 /// mapdict weakref SPECIAL slot is inline, the address-keyed slot keeps that

--- a/pyre/pyre-interpreter/src/module/_io/buffered.rs
+++ b/pyre/pyre-interpreter/src/module/_io/buffered.rs
@@ -547,8 +547,9 @@ impl W_BufferedReader {
 )]
 impl W_BufferedReader {
     #[staticmethod]
-    fn __new__(_cls: PyObjectRef, _args: &[PyObjectRef]) -> PyObjectRef {
-        W_BufferedReader::allocate_stable(W_BufferedReader::default())
+    fn __new__(cls: PyObjectRef, _args: &[PyObjectRef]) -> PyObjectRef {
+        let obj = W_BufferedReader::allocate_stable(W_BufferedReader::default());
+        super::tag_io_instance(obj, cls)
     }
 
     fn __init__(

--- a/pyre/pyre-interpreter/src/module/_io/buffered_random.rs
+++ b/pyre/pyre-interpreter/src/module/_io/buffered_random.rs
@@ -655,7 +655,7 @@ impl W_BufferedRandom {
 )]
 impl W_BufferedRandom {
     #[staticmethod]
-    fn __new__(_cls: PyObjectRef, args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    fn __new__(cls: PyObjectRef, args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         let (params, kwargs) = crate::builtins::split_builtin_kwargs(args);
         let given = params.len().saturating_sub(1) + crate::builtins::real_kwarg_count(kwargs);
         if given > 2 {
@@ -664,9 +664,8 @@ impl W_BufferedRandom {
                 given
             )));
         }
-        Ok(W_BufferedRandom::allocate_stable(
-            W_BufferedRandom::default(),
-        ))
+        let obj = W_BufferedRandom::allocate_stable(W_BufferedRandom::default());
+        Ok(super::tag_io_instance(obj, cls))
     }
 
     fn __init__(

--- a/pyre/pyre-interpreter/src/module/_io/buffered_rwpair.rs
+++ b/pyre/pyre-interpreter/src/module/_io/buffered_rwpair.rs
@@ -57,8 +57,9 @@ impl W_BufferedRWPair {
 )]
 impl W_BufferedRWPair {
     #[staticmethod]
-    fn __new__(_cls: PyObjectRef, _args: &[PyObjectRef]) -> PyObjectRef {
-        W_BufferedRWPair::allocate_stable(W_BufferedRWPair::default())
+    fn __new__(cls: PyObjectRef, _args: &[PyObjectRef]) -> PyObjectRef {
+        let obj = W_BufferedRWPair::allocate_stable(W_BufferedRWPair::default());
+        super::tag_io_instance(obj, cls)
     }
 
     fn __init__(

--- a/pyre/pyre-interpreter/src/module/_io/buffered_writer.rs
+++ b/pyre/pyre-interpreter/src/module/_io/buffered_writer.rs
@@ -322,8 +322,9 @@ impl W_BufferedWriter {
 )]
 impl W_BufferedWriter {
     #[staticmethod]
-    fn __new__(_cls: PyObjectRef, _args: &[PyObjectRef]) -> PyObjectRef {
-        W_BufferedWriter::allocate_stable(W_BufferedWriter::default())
+    fn __new__(cls: PyObjectRef, _args: &[PyObjectRef]) -> PyObjectRef {
+        let obj = W_BufferedWriter::allocate_stable(W_BufferedWriter::default());
+        super::tag_io_instance(obj, cls)
     }
 
     fn __init__(

--- a/pyre/pyre-interpreter/src/module/_io/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_io/mod.rs
@@ -208,6 +208,24 @@ fn iobase_next(args: &[PyObjectRef]) -> crate::PyResult {
     }
 }
 
+/// Tag a freshly allocated `_io` object with the class being constructed and
+/// put it on the finalizer queue, `interp_iobase.py:63-64`.
+///
+/// Exactly one registration per object: `iobase_del` is inherited by every
+/// subclass, and `_call_finalizer` resolves `__del__` on the instance's own
+/// type, so an app-level override is reached through this same registration.
+/// Routing through `typedef::tag_subclass_instance` instead would register a
+/// second time for a subclass that defines `__del__`, and run it twice.
+pub(crate) fn tag_io_instance(obj: PyObjectRef, cls: PyObjectRef) -> PyObjectRef {
+    if !cls.is_null() {
+        unsafe {
+            (*obj).w_class = cls;
+        }
+    }
+    crate::executioncontext::register_iobase_finalizer(obj);
+    obj
+}
+
 fn iobase_del(args: &[PyObjectRef]) -> crate::PyResult {
     let Some(&self_obj) = args.first() else {
         return Ok(w_none());

--- a/pyre/pyre-interpreter/src/module/_io/textio.rs
+++ b/pyre/pyre-interpreter/src/module/_io/textio.rs
@@ -845,8 +845,7 @@ impl W_TextIOWrapper {
         let obj = Self::allocate_stable(Self::default());
         // A subclass still uses this concrete storage layout, while its
         // Python-visible class remains `cls`.
-        unsafe { (*obj).w_class = cls };
-        obj
+        super::tag_io_instance(obj, cls)
     }
 
     fn __init__(

--- a/pyre/pyre-interpreter/src/module/_random/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_random/mod.rs
@@ -151,9 +151,9 @@ impl W_Random {
         let cls_slot = pyre_object::gc_roots::shadow_stack_len() - 2;
         let seed_slot = cls_slot + 1;
         let obj = W_Random::allocate_stable(W_Random::default());
-        unsafe {
-            (*obj).w_class = pyre_object::gc_roots::shadow_stack_get(cls_slot);
-        }
+        crate::typedef::tag_subclass_instance(obj, unsafe {
+            pyre_object::gc_roots::shadow_stack_get(cls_slot)
+        });
         let random = W_Random::from_obj(obj)
             .expect("a freshly allocated _random.Random has the Random layout");
         random.seed(pyre_object::gc_roots::shadow_stack_get(seed_slot))?;

--- a/pyre/pyre-interpreter/src/module/_weakref/interp__weakref.rs
+++ b/pyre/pyre-interpreter/src/module/_weakref/interp__weakref.rs
@@ -730,7 +730,7 @@ pub fn descr__init__weakref(args: &[PyObjectRef]) -> Result<PyObjectRef, PyError
     Ok(pyre_object::w_none())
 }
 
-/// pypy/module/_weakref/interp__weakref.py:216-223 descr_hash
+/// pypy/module/_weakref/interp__weakref.py:212-219 descr_hash
 ///
 /// ```python
 /// def descr_hash(self):
@@ -755,8 +755,16 @@ pub fn descr_hash(args: &[PyObjectRef]) -> Result<PyObjectRef, PyError> {
     if w_obj.is_null() || unsafe { pyre_object::is_none(w_obj) } {
         return Err(PyError::type_error("weak object has gone away".to_string()));
     }
-    // pyre's hash: identity-based for non-int/non-str. Mirrors space.hash(w_obj).
-    let h = pyre_object::w_int_new(w_obj as i64);
+    // `self.w_hash = self.space.hash(w_obj)`: the reference hashes as its
+    // referent, so a ref and the object it points at land in the same bucket.
+    // `hash_w_strict` can run a user-defined `__hash__`, which allocates, so
+    // the referent is rooted across the call and `current_self` re-reads the
+    // reference afterwards.
+    pyre_object::gc_roots::pin_root(w_obj);
+    let obj_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+    let h = pyre_object::w_int_new(crate::baseobjspace::hash_w_strict(
+        pyre_object::gc_roots::shadow_stack_get(obj_slot),
+    )?);
     write_attr(current_self(), ATTR_W_HASH, h);
     Ok(h)
 }

--- a/pyre/pyre-interpreter/src/module/array/mod.rs
+++ b/pyre/pyre-interpreter/src/module/array/mod.rs
@@ -259,9 +259,7 @@ fn array_descr_new(args: &[PyObjectRef]) -> PyResult {
         if let Some(canonical) = crate::typedef::gettypefor(&pyre_object::interp_array::ARRAY_TYPE)
         {
             if !std::ptr::eq(cls, canonical.as_ptr()) {
-                unsafe {
-                    (*obj).w_class = cls;
-                }
+                crate::typedef::tag_subclass_instance(obj, cls);
             }
         }
     }

--- a/pyre/pyre-interpreter/src/module/gc/mod.rs
+++ b/pyre/pyre-interpreter/src/module/gc/mod.rs
@@ -247,10 +247,17 @@ crate::py_module! {
             w_int_new(0), w_int_new(0), w_int_new(0),
         ])),
         "is_tracked"    / 1 = |args| {
-            // CPython 3.14 `gc.is_tracked(obj)`: whether the collector visits
-            // the object. pyre's immortal allocations live outside the managed
-            // heap, so they are never traced and never reclaimed.
-            Ok(w_bool_from(majit_gc::gc_owns_object(args[0] as usize)))
+            // CPython 3.14 `gc.is_tracked(obj)`: whether the collector
+            // traverses references out of the object. Asked of the registered
+            // type rather than of the heap the instance landed in, so an int
+            // answers the same under `PYRE_GC_INTERP`, under the JIT and on
+            // wasm as it does on the immortal path.
+            //
+            // `bytes` and `int` answer True where CPython answers False: their
+            // pyre structs carry `w_dict` and `w_weakreflifeline` slots that
+            // the collector really does follow, which the CPython objects have
+            // no equivalent of.
+            Ok(w_bool_from(majit_gc::is_tracked(majit_ir::GcRef(args[0] as usize))))
         },
         "is_finalized"  / 1 = |_| Ok(w_bool_from(false)),
         // CPython 3.14 `gc.freeze()` moves the surviving objects into a

--- a/pyre/pyre-interpreter/src/module/gc/mod.rs
+++ b/pyre/pyre-interpreter/src/module/gc/mod.rs
@@ -4,13 +4,38 @@
 //! RPython collection, then drains the finalizer queue synchronously.
 
 use pyre_object::*;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicI64, Ordering};
 
 /// `interp_gc.py` tracks a process-wide `enabled` flag on the GC
 /// frontend; pyre has no generational threshold knob, but
 /// `gc.isenabled()` should reflect the most recent `enable`/`disable`
 /// call so callers that toggle and re-read the state stay consistent.
 static GC_ENABLED: AtomicBool = AtomicBool::new(true);
+
+/// The three thresholds `gc.set_threshold` writes and `gc.get_threshold`
+/// reads back, seeded with CPython 3.14's defaults. The collector runs off a
+/// nursery size rather than per-generation allocation counters, so the values
+/// round-trip but do not decide when a collection happens.
+static GC_THRESHOLD: [AtomicI64; 3] =
+    [AtomicI64::new(2000), AtomicI64::new(10), AtomicI64::new(10)];
+
+fn pin_object(object: majit_ir::GcRef) {
+    pyre_object::gc_roots::pin_root(object.0 as PyObjectRef);
+}
+
+/// `referents.py:53-78 _list_w_obj_referents`: push the app-level objects
+/// `w_obj` refers to directly onto the shadow stack. The walk looks through
+/// the interpreter-internal structs in between, so a list reports its items
+/// and not the array holding them.
+///
+/// Only managed-heap referents are reported, the same boundary `gc.get_objects`
+/// and `gc.is_tracked` draw. An immortal referent carries a GC header but sits
+/// outside the collector's ranges, and a slot such as `ob_type` can hold a
+/// static that has no header at all, so there is no address the walk could
+/// safely widen to.
+fn pin_referents(w_obj: PyObjectRef) {
+    majit_gc::get_referents(majit_ir::GcRef(w_obj as usize), pin_object);
+}
 
 fn user_del_action() -> Option<&'static mut crate::executioncontext::UserDelAction> {
     let ec = crate::call::getexecutioncontext() as *mut crate::PyExecutionContext;
@@ -115,9 +140,6 @@ crate::py_module! {
             }
             let _roots = pyre_object::gc_roots::push_roots();
             let first = pyre_object::gc_roots::shadow_stack_len();
-            fn pin_object(object: majit_ir::GcRef) {
-                pyre_object::gc_roots::pin_root(object.0 as PyObjectRef);
-            }
             majit_gc::get_objects(generation as i8, pin_object);
             let objects = (first..pyre_object::gc_roots::shadow_stack_len())
                 .map(pyre_object::gc_roots::shadow_stack_get)
@@ -155,17 +177,89 @@ crate::py_module! {
             };
             Ok(w_bool_from(enabled))
         },
-        "get_referrers" / * = |_| Ok(w_list_new(vec![])),
-        "get_referents" / * = |_| Ok(w_list_new(vec![])),
-        "set_threshold" / 0 = |_| Ok(w_none()),
-        "get_threshold" / 0 = |_| Ok(w_tuple_new(vec![
-            w_int_new(700), w_int_new(10), w_int_new(10),
-        ])),
+        "get_referrers" / * = |args| {
+            // referents.py:147-169 get_referrers: list every app-level object,
+            // then keep the ones whose direct referents include an argument.
+            // An object referring to the same argument twice is reported once,
+            // but one passed the same argument twice is reported twice.
+            let _roots = pyre_object::gc_roots::push_roots();
+            let all_first = pyre_object::gc_roots::shadow_stack_len();
+            majit_gc::get_objects(-1, pin_object);
+            let all_last = pyre_object::gc_roots::shadow_stack_len();
+            let mut result = Vec::new();
+            for slot in all_first..all_last {
+                let w_obj = pyre_object::gc_roots::shadow_stack_get(slot);
+                let _refs = pyre_object::gc_roots::push_roots();
+                let refs_first = pyre_object::gc_roots::shadow_stack_len();
+                pin_referents(w_obj);
+                let refs_last = pyre_object::gc_roots::shadow_stack_len();
+                for &w_arg in args {
+                    if (refs_first..refs_last)
+                        .any(|s| pyre_object::gc_roots::shadow_stack_get(s) == w_arg)
+                    {
+                        result.push(w_obj);
+                    }
+                }
+            }
+            // Every entry is also pinned in `all_first..all_last`, so the list
+            // allocation below cannot leave one unrooted.
+            Ok(w_list_new_object(result))
+        },
+        "get_referents" / * = |args| {
+            // referents.py:128-145 get_referents.
+            let _roots = pyre_object::gc_roots::push_roots();
+            let first = pyre_object::gc_roots::shadow_stack_len();
+            for &w_obj in args {
+                pin_referents(w_obj);
+            }
+            let result = (first..pyre_object::gc_roots::shadow_stack_len())
+                .map(pyre_object::gc_roots::shadow_stack_get)
+                .collect();
+            Ok(w_list_new_object(result))
+        },
+        "set_threshold" / * = |args| {
+            // CPython 3.14 `gc.set_threshold(threshold0[, threshold1[,
+            // threshold2]])` writes only the positions it was given, and
+            // parses every argument before writing any of them.
+            if args.is_empty() || args.len() > 3 {
+                return Err(crate::PyError::type_error(
+                    "gc.set_threshold requires 1 to 3 arguments",
+                ));
+            }
+            let mut parsed = [0i64; 3];
+            for (i, &arg) in args.iter().enumerate() {
+                parsed[i] = crate::baseobjspace::int_w(
+                    crate::baseobjspace::space_index(arg)?,
+                )?;
+            }
+            for (i, &value) in parsed[..args.len()].iter().enumerate() {
+                GC_THRESHOLD[i].store(value, Ordering::Relaxed);
+            }
+            Ok(w_none())
+        },
+        "get_threshold" / 0 = |_| Ok(w_tuple_new(
+            GC_THRESHOLD
+                .iter()
+                .map(|slot| w_int_new(slot.load(Ordering::Relaxed)))
+                .collect(),
+        )),
         "get_count"     / 0 = |_| Ok(w_tuple_new(vec![
             w_int_new(0), w_int_new(0), w_int_new(0),
         ])),
-        "is_tracked"    / 1 = |_| Ok(w_bool_from(false)),
+        "is_tracked"    / 1 = |args| {
+            // CPython 3.14 `gc.is_tracked(obj)`: whether the collector visits
+            // the object. pyre's immortal allocations live outside the managed
+            // heap, so they are never traced and never reclaimed.
+            Ok(w_bool_from(majit_gc::gc_owns_object(args[0] as usize)))
+        },
         "is_finalized"  / 1 = |_| Ok(w_bool_from(false)),
-        "freeze"        / 0 = |_| Ok(w_none()),
+        // CPython 3.14 `gc.freeze()` moves the surviving objects into a
+        // permanent generation that later collections skip; it is a pre-fork
+        // hint, not a semantic guarantee. The collector has no permanent
+        // generation, so freezing and unfreezing are no-ops and the frozen
+        // count is always the truthful zero.
+        "freeze"           / 0 = |_| Ok(w_none()),
+        "unfreeze"         / 0 = |_| Ok(w_none()),
+        "get_freeze_count" / 0 = |_| Ok(w_int_new(0)),
     },
 }

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -2122,7 +2122,7 @@ fn module_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
     let w_module = pyre_object::w_module_new_managed("");
     if let Some(cls) = args.first().copied() {
         if !cls.is_null() {
-            unsafe { (*w_module).w_class = cls };
+            tag_subclass_instance(w_module, cls);
         }
     }
     Ok(w_module)
@@ -3003,7 +3003,7 @@ fn bool_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
 /// `hasuserdel`, so tagging must precede registration. Registering an
 /// instance whose type has no `__del__` is a no-op, the hook gates on
 /// `hasuserdel` exactly as upstream does.
-fn tag_subclass_instance(obj: PyObjectRef, sub: PyObjectRef) -> PyObjectRef {
+pub(crate) fn tag_subclass_instance(obj: PyObjectRef, sub: PyObjectRef) -> PyObjectRef {
     unsafe {
         (*obj).w_class = sub;
     }
@@ -12219,7 +12219,7 @@ fn staticmethod_descr_new(args: &[PyObjectRef]) -> crate::PyResult {
     check_user_subclass(staticmethod_type, cls)?;
     let sm = pyre_object::function::w_staticmethod_new(w_none());
     if !std::ptr::eq(cls, staticmethod_type) {
-        unsafe { (*sm).w_class = cls };
+        tag_subclass_instance(sm, cls);
     }
     Ok(sm)
 }
@@ -12505,7 +12505,7 @@ fn classmethod_descr_new(args: &[PyObjectRef]) -> crate::PyResult {
     check_user_subclass(classmethod_type, cls)?;
     let cm = pyre_object::function::w_classmethod_new(w_none());
     if !std::ptr::eq(cls, classmethod_type) {
-        unsafe { (*cm).w_class = cls };
+        tag_subclass_instance(cm, cls);
     }
     Ok(cm)
 }
@@ -12833,7 +12833,7 @@ fn property_descr_new(args: &[PyObjectRef]) -> crate::PyResult {
     check_user_subclass(property_type, cls)?;
     let prop = pyre_object::w_property_new(PY_NULL, PY_NULL, PY_NULL);
     if !std::ptr::eq(cls, property_type) {
-        unsafe { (*prop).w_class = cls };
+        tag_subclass_instance(prop, cls);
     }
     Ok(prop)
 }
@@ -22848,7 +22848,7 @@ fn itertools_alloc_for_class(
     // freshly allocated interpreter object.
     check_user_subclass(exact_type, cls)?;
     if !std::ptr::eq(cls, exact_type) {
-        unsafe { (*obj).w_class = cls };
+        tag_subclass_instance(obj, cls);
     }
     Ok(obj)
 }

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -2013,12 +2013,9 @@ fn int_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         pyre_object::w_long_new(big)
     } else {
         let int_val = unsafe { pyre_object::w_int_get_value(value) };
-        pyre_object::w_int_new_unique(int_val)
+        pyre_object::intobject::w_int_subclass_new(int_val)
     };
-    unsafe {
-        (*obj).w_class = cls;
-    }
-    Ok(obj)
+    Ok(tag_subclass_instance(obj, cls))
 }
 
 /// `float.__new__(cls, *args)` — PyPy: floatobject.py descr__new__.
@@ -2052,11 +2049,8 @@ fn float_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
         None => return Ok(value),
     };
     let float_val = unsafe { pyre_object::w_float_get_value(value) };
-    let obj = pyre_object::w_float_new(float_val);
-    unsafe {
-        (*obj).w_class = sub;
-    }
-    Ok(obj)
+    let obj = pyre_object::floatobject::w_float_subclass_new(float_val);
+    Ok(tag_subclass_instance(obj, sub))
 }
 
 fn complex_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
@@ -2076,11 +2070,8 @@ fn complex_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
             pyre_object::w_complex_get_imag(value),
         )
     };
-    let obj = pyre_object::w_complex_new(re, im);
-    unsafe {
-        (*obj).w_class = cls;
-    }
-    Ok(obj)
+    let obj = pyre_object::complexobject::w_complex_subclass_new(re, im);
+    Ok(tag_subclass_instance(obj, cls))
 }
 
 /// Wrap a `__new__` builtin function in a staticmethod descriptor.
@@ -3001,6 +2992,25 @@ fn bool_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         w_obj,
     )?))
 }
+/// Tag a freshly allocated builtin-layout instance with the user subclass
+/// it is being constructed for, then enqueue it on the user-finalizer
+/// queue when that subclass defines `__del__`.
+///
+/// `objspace.py:485-487 allocate_instance` performs both steps together —
+/// `instance.user_setup(self, w_subtype)` followed by
+/// `if w_subtype.hasuserdel: self.finalizer_queue.register_finalizer(instance)`.
+/// Order is load-bearing: the hook reads the object's `w_class` to find
+/// `hasuserdel`, so tagging must precede registration. Registering an
+/// instance whose type has no `__del__` is a no-op, the hook gates on
+/// `hasuserdel` exactly as upstream does.
+fn tag_subclass_instance(obj: PyObjectRef, sub: PyObjectRef) -> PyObjectRef {
+    unsafe {
+        (*obj).w_class = sub;
+    }
+    pyre_object::gc_hook::maybe_register_finalizer(obj);
+    obj
+}
+
 /// When `cls` is a user subclass of the builtin `base` (not `base`
 /// itself, not null/non-type), return it so `__new__` can tag the fresh
 /// builtin instance's `w_class`; otherwise `None`.  Mirrors the
@@ -3145,9 +3155,7 @@ fn enumerate_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErr
     let cls = args.first().copied().unwrap_or(pyre_object::PY_NULL);
     let value = crate::builtins::builtin_enumerate(args.get(1..).unwrap_or(&[]))?;
     if let Some(sub) = subclass_to_tag(cls, &pyre_object::functional::ENUMERATE_TYPE)? {
-        unsafe {
-            (*value).w_class = sub;
-        }
+        tag_subclass_instance(value, sub);
     }
     Ok(value)
 }
@@ -3165,9 +3173,7 @@ fn map_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let value = unsafe { pyre_object::gc_roots::shadow_stack_get(value_slot) };
     let cls = unsafe { pyre_object::gc_roots::shadow_stack_get(cls_slot) };
     if let Some(sub) = subclass_to_tag(cls, &pyre_object::functional::MAP_TYPE)? {
-        unsafe {
-            (*value).w_class = sub;
-        }
+        tag_subclass_instance(value, sub);
     }
     Ok(value)
 }
@@ -3229,9 +3235,7 @@ fn filter_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
     let value = unsafe { pyre_object::gc_roots::shadow_stack_get(value_slot) };
     let cls = unsafe { pyre_object::gc_roots::shadow_stack_get(cls_slot) };
     if let Some(sub) = subclass_to_tag(cls, &pyre_object::functional::FILTER_TYPE)? {
-        unsafe {
-            (*value).w_class = sub;
-        }
+        tag_subclass_instance(value, sub);
     }
     Ok(value)
 }
@@ -3249,9 +3253,7 @@ fn zip_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let value = unsafe { pyre_object::gc_roots::shadow_stack_get(value_slot) };
     let cls = unsafe { pyre_object::gc_roots::shadow_stack_get(cls_slot) };
     if let Some(sub) = subclass_to_tag(cls, &pyre_object::functional::ZIP_TYPE)? {
-        unsafe {
-            (*value).w_class = sub;
-        }
+        tag_subclass_instance(value, sub);
     }
     Ok(value)
 }

--- a/pyre/pyre-object/src/bytearrayobject.rs
+++ b/pyre/pyre-object/src/bytearrayobject.rs
@@ -118,12 +118,17 @@ pub fn w_bytearray_subclass_from_bytes(bytes: &[u8], w_class: PyObjectRef) -> Py
         w_dict: PY_NULL,
         w_weakreflifeline: PY_NULL,
     };
-    if raw.is_null() {
+    let obj = if raw.is_null() {
         crate::lltype::malloc_typed(payload) as PyObjectRef
     } else {
         unsafe { std::ptr::write(raw as *mut W_BytearrayObject, payload) };
         raw as PyObjectRef
-    }
+    };
+    // `allocate_instance` registers the fresh instance on the finalizer queue
+    // when its subtype has `__del__`; the `w_class` is already stamped above,
+    // so the hook resolves the subclass rather than the canonical bytearray type.
+    crate::gc_hook::maybe_register_finalizer(obj);
+    obj
 }
 
 #[inline]

--- a/pyre/pyre-object/src/bytesobject.rs
+++ b/pyre/pyre-object/src/bytesobject.rs
@@ -138,12 +138,17 @@ pub fn w_bytes_subclass_from_bytes(bytes: &[u8], w_class: PyObjectRef) -> PyObje
         w_dict: PY_NULL,
         w_weakreflifeline: PY_NULL,
     };
-    if raw.is_null() {
+    let obj = if raw.is_null() {
         crate::lltype::malloc_typed(payload) as PyObjectRef
     } else {
         unsafe { std::ptr::write(raw as *mut W_BytesObject, payload) };
         raw as PyObjectRef
-    }
+    };
+    // `allocate_instance` registers the fresh instance on the finalizer queue
+    // when its subtype has `__del__`; the `w_class` is already stamped above,
+    // so the hook resolves the subclass rather than the canonical bytes type.
+    crate::gc_hook::maybe_register_finalizer(obj);
+    obj
 }
 
 #[inline]

--- a/pyre/pyre-object/src/complexobject.rs
+++ b/pyre/pyre-object/src/complexobject.rs
@@ -51,6 +51,29 @@ pub fn w_complex_new(real: f64, imag: f64) -> PyObjectRef {
     }) as PyObjectRef
 }
 
+/// Allocate a `W_ComplexObject` for a `complex` subclass instance, on the
+/// managed heap so it can be reclaimed. See [`crate::intobject::w_int_subclass_new`]
+/// for why the shared constructor cannot be used.
+pub fn w_complex_subclass_new(real: f64, imag: f64) -> PyObjectRef {
+    let obj = W_ComplexObject {
+        ob_header: PyObject {
+            ob_type: &COMPLEX_TYPE as *const PyType,
+            w_class: get_instantiate(&COMPLEX_TYPE),
+        },
+        real,
+        imag,
+    };
+    let raw = crate::gc_hook::try_gc_alloc_stable_raw(W_COMPLEX_GC_TYPE_ID, W_COMPLEX_OBJECT_SIZE);
+    if raw.is_null() {
+        crate::lltype::malloc_typed(obj) as PyObjectRef
+    } else {
+        unsafe {
+            std::ptr::write(raw as *mut W_ComplexObject, obj);
+            raw as PyObjectRef
+        }
+    }
+}
+
 /// Extract the real component from a known W_ComplexObject pointer.
 ///
 /// # Safety

--- a/pyre/pyre-object/src/floatobject.rs
+++ b/pyre/pyre-object/src/floatobject.rs
@@ -71,6 +71,34 @@ pub fn w_float_new(value: f64) -> PyObjectRef {
     crate::lltype::malloc_typed(obj) as PyObjectRef
 }
 
+/// Allocate a `W_FloatObject` for a `float` subclass instance, on the
+/// managed heap so it can be reclaimed.
+///
+/// [`w_float_new`] gates its managed allocation on
+/// [`crate::gc_interp::enabled`], which is off unless `PYRE_GC_INTERP` is
+/// set, so it falls back to an unreclaimable `malloc_typed` box. A subclass
+/// instance cannot: `register_finalizer` drops anything outside the managed
+/// heap, so such an instance would never die and its `__del__` would never
+/// run. See [`crate::intobject::w_int_subclass_new`].
+pub fn w_float_subclass_new(value: f64) -> PyObjectRef {
+    let obj = W_FloatObject {
+        ob_header: PyObject {
+            ob_type: &FLOAT_TYPE as *const PyType,
+            w_class: get_instantiate(&FLOAT_TYPE),
+        },
+        floatval: value,
+    };
+    let raw = crate::gc_hook::try_gc_alloc_stable_raw(W_FLOAT_GC_TYPE_ID, W_FLOAT_OBJECT_SIZE);
+    if raw.is_null() {
+        crate::lltype::malloc_typed(obj) as PyObjectRef
+    } else {
+        unsafe {
+            std::ptr::write(raw as *mut W_FloatObject, obj);
+            raw as PyObjectRef
+        }
+    }
+}
+
 /// Box a float constant into a heap Python float object.
 pub fn box_float_constant(value: f64) -> PyObjectRef {
     w_float_new(value)

--- a/pyre/pyre-object/src/intobject.rs
+++ b/pyre/pyre-object/src/intobject.rs
@@ -138,6 +138,36 @@ pub fn w_int_new_unique(value: i64) -> PyObjectRef {
     }) as PyObjectRef
 }
 
+/// Allocate a `W_IntObject` for an `int` subclass instance, on the managed
+/// heap so it can be reclaimed.
+///
+/// [`w_int_new_unique`] is shared with the JIT's tagged-int unboxing paths
+/// and keeps their `malloc_typed` allocation; a subclass instance cannot
+/// use it, because `register_finalizer` drops anything outside the managed
+/// heap, so a boxed instance would never die and its `__del__` would never
+/// run. Allocation is unconditional rather than gated on
+/// [`crate::gc_interp::enabled`], matching the other subclass allocators
+/// ([`crate::bytesobject::w_bytes_subclass_from_bytes`],
+/// `w_str_subclass_from_wtf8`).
+pub fn w_int_subclass_new(value: i64) -> PyObjectRef {
+    let obj = W_IntObject {
+        ob_header: PyObject {
+            ob_type: &INT_TYPE as *const PyType,
+            w_class: get_instantiate(&INT_TYPE),
+        },
+        intval: value,
+    };
+    let raw = crate::gc_hook::try_gc_alloc_stable_raw(W_INT_GC_TYPE_ID, W_INT_OBJECT_SIZE);
+    if raw.is_null() {
+        crate::lltype::malloc_typed(obj) as PyObjectRef
+    } else {
+        unsafe {
+            std::ptr::write(raw as *mut W_IntObject, obj);
+            raw as PyObjectRef
+        }
+    }
+}
+
 /// Return the address of INT_TYPE for JIT type-id validation.
 #[inline]
 pub fn w_int_type_id() -> usize {


### PR DESCRIPTION
Three-way differential work against `python3.14` (3.14.5) and `pypy3` (7.3.22).
Classification used throughout: `pyre==pypy!=cpython` is left alone,
`pyre!=pypy==cpython` is fixed, `pyre!=pypy!=cpython` is a pyre-only invention.

## `__del__` was never called for a subclass of most builtins

`objspace.py:485-487 allocate_instance` ends with `user_setup` and then
`if w_subtype.hasuserdel: register_finalizer(instance)`. pyre has that tail
scattered across per-allocation-site code, and most sites tagged `w_class`
without registering. `class D(int)` with a `__del__` never ran it.

Two commits complete the pattern:

- int, float, complex, bytes, bytearray, enumerate, map, filter, zip.
  int/float/complex needed a collectable allocator (`w_int_subclass_new` and
  friends) — the existing `w_int_new_unique` serves four JIT hot-path call
  sites and stays immortal.
- the exception constructors (`exc_new_wrapper!`, the OSError family,
  ExceptionGroup), type objects and their metaclass, staticmethod,
  classmethod, property, ModuleType, the itertools allocator, `array`,
  `_random.Random`, and the `_io` types.

`_io` registers through its own helper rather than the shared one.
`iobase_del` is a builtin method on the interp-level type, so `hasuserdel` —
which `type.__new__` sets only for a class whose own dict carries `__del__` —
is false and the gated hook skips the object; `interp_iobase.py:63-64`
registers explicitly for the same reason. Using both paths would run a
subclass's `__del__` twice. One consequence is that a file dropped without
`close()` now flushes: `open(p,'w')`, `write`, `del`, collect left the file
empty and now leaves the bytes on disk.

`BufferedWriter.__new__` and its three siblings ignored their `cls` argument
entirely; they now tag with it.

`array` instances stay unreclaimable: `W_Array::allocate` is `malloc_typed`,
so their registration is inert until that moves to the managed heap.

## weakref hashed its own address

`interp__weakref.py:218` is `self.w_hash = self.space.hash(w_obj)`. `descr_hash`
returned the referent's address instead, so `hash(ref) != hash(obj)` and a
weakref could not be used to look up its referent in a dict. It now delegates
to `hash_w_strict`, which also supplies the unhashable-referent TypeError, the
-1 to -2 fold and propagation of a raising `__hash__`. The lazy cache that
keeps the hash stable after the referent dies is unchanged. The referent is
rooted across the call because a user `__hash__` can allocate.

## gc module

`gc.get_referents` and `gc.get_referrers` returned an empty list. PyPy
implements both, so `referents.py:53-78 _list_w_obj_referents` is ported as
`MiniMarkGC::do_get_referents`, reached through a `get_referents` hook next to
the existing `get_objects` one with a trampoline in each of the three
backends. The walk stops at the first app-level object on a branch and expands
anything else, so a list reports its items rather than the array holding them;
GCFLAG_EXTRA is restored on every visited header before returning.
`get_referrers` composes the two the way `referents.py:147-169` does.

- `gc.is_tracked` answered False for everything, including lists and
  instances. It now reports whether the collector owns the object.
- `gc.set_threshold` took no arguments, so `gc.set_threshold(*gc.get_threshold())`
  raised TypeError. It now accepts one to three, parses them all before
  writing any, and writes only the positions given. `gc.get_threshold` reads
  the stored values back and starts at 3.14's `(2000, 10, 10)` rather than
  `(700, 10, 10)`.
- `gc.unfreeze` and `gc.get_freeze_count` join the `gc.freeze` no-op that was
  already there. The collector has no permanent generation, so nothing is ever
  frozen and the count is zero.

### Deliberately still absent

`get_stats` (PyPy's `W_GcStats` has 13 fields; `active_heap_stats()` supplies
two), `set_debug`/`get_debug` (storing the flag without honoring DEBUG_SAVEALL
would silently drop uncollectables the caller asked to retain),
`gc.callbacks` invocation (firing only on explicit `collect()` reads as "no
collections happened"), and `is_finalized` (`GCFLAG_IGNORE_FINALIZER` is a
*don't-run* marker, `incminimark.py:3043`, not a *has-run* record). A fake
would be worse than the AttributeError.

### Known divergences, verified as correct

- `gc.get_referents([1,2,3])` is `[]`, matching PyPy exactly (its list
  strategies unbox small ints); CPython reports 3.
- `gc.get_referents({'a': 1})` is `[]` where PyPy gives 2 and CPython 1.
  pyre's exact str and small int are immortal and the walk stops at the
  managed-heap boundary — the same boundary `gc.get_objects` already drew.
  Widening it has no safe address test: an immortal object carries a GC
  header, but a slot such as `ob_type` can hold a static that has none.
- `gc.get_referrers(a, a)` reports the referrer twice, as PyPy does (the
  append sits inside the per-argument loop); CPython reports it once.
- `gc.is_tracked((1, 2))` is True; CPython untracks tuples of untracked items.

## Verification

- `check.py --backend dynasm,cranelift,wasm`: dynasm 326/326, cranelift
  326/326, wasm 323/323, after re-extracting LLBC. Re-run after the rebase
  onto current main.
- `cargo test`: majit-gc 205, pyre-object 275, pyre-interpreter 401.
- Every builtin base in a 16-base subclass matrix and all seven weakref-hash
  cases now agree with CPython 3.14.