### PR TITLE
jit: three guard→bridge fixes, and a native MC_DIAG readout to find them

### DIFF
--- a/majit/majit-metainterp/src/compile.rs
+++ b/majit/majit-metainterp/src/compile.rs
@@ -5282,11 +5282,17 @@ impl TraceCtx {
     /// `header_pc` identifies the header on its own here: a merge point's
     /// `green_key` is derived from `(code, header_pc)`, so the reverse scan's
     /// first hit is the same entry [`get_merge_point_at`] would return.
+    /// Only entries recorded during the walk (`position > 0`) answer here.
+    /// The entry at position 0 is the synthetic trace-start seed, whose boxes
+    /// were built from the trace's own `inputarg_types()`; leaving it out lets
+    /// callers keep their existing fallback for a head close and reserves this
+    /// lookup for the case it is meant to fix — closing at a header the walk
+    /// reached later.
     pub fn merge_point_arg_types_at_header(&self, header_pc: usize) -> Option<Vec<majit_ir::Type>> {
         self.current_merge_points
             .iter()
             .rev()
-            .find(|mp| mp.header_pc == header_pc)
+            .find(|mp| mp.header_pc == header_pc && mp.position._pos > 0)
             .map(|mp| mp.green_boxes.iter().map(|green| green.ty).collect())
     }
 

--- a/majit/majit-metainterp/src/compile.rs
+++ b/majit/majit-metainterp/src/compile.rs
@@ -5271,6 +5271,25 @@ impl TraceCtx {
 
     /// pyjitpl.py:2988 + header identity: find merge point by (key, header_pc),
     /// searching in reverse order (most recent first).
+    /// pyjitpl.py:3039-3041 `compile_loop(original_boxes, live_arg_boxes,
+    /// start)`: the closing JUMP's args belong to the label of the loop being
+    /// CLOSED — `original_boxes`, taken from the merge point that matched —
+    /// not to the trace's own inputargs. The two name the same list only when
+    /// the trace closes at its own head; a close at a later-registered header
+    /// (the cross-loop cut, compile.py:269) re-labels the loop from that
+    /// merge point instead.
+    ///
+    /// `header_pc` identifies the header on its own here: a merge point's
+    /// `green_key` is derived from `(code, header_pc)`, so the reverse scan's
+    /// first hit is the same entry [`get_merge_point_at`] would return.
+    pub fn merge_point_arg_types_at_header(&self, header_pc: usize) -> Option<Vec<majit_ir::Type>> {
+        self.current_merge_points
+            .iter()
+            .rev()
+            .find(|mp| mp.header_pc == header_pc)
+            .map(|mp| mp.green_boxes.iter().map(|green| green.ty).collect())
+    }
+
     pub fn get_merge_point_at(&self, key: u64, header_pc: usize) -> Option<&MergePoint> {
         self.current_merge_points
             .iter()

--- a/majit/majit-metainterp/src/lib.rs
+++ b/majit/majit-metainterp/src/lib.rs
@@ -597,17 +597,19 @@ pub fn register_stack_almost_full_hook(f: fn() -> bool) {
 /// compile_and_run_once early-out: tracing did not start, 23 =
 /// should_trace_function_entry declined (cell compiled or tracing), 24 =
 /// should_trace_function_entry declined (dead procedure token cleanup), 25 =
-/// should_trace_function_entry answered from the counter tick.
-pub static MC_DIAG: [std::sync::atomic::AtomicU64; 26] = {
+/// should_trace_function_entry answered from the counter tick, 26 = walk steps
+/// recorded past `trace_limit` whose abort was suppressed because the walk had
+/// already executed an unrollbackable effect.
+pub static MC_DIAG: [std::sync::atomic::AtomicU64; 27] = {
     const Z: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
     [
-        Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z,
+        Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z,
     ]
 };
 
 /// Short label per [`MC_DIAG`] slot, in index order, so a tally cannot be added
 /// without naming it. Readers join these with the counter values.
-pub const MC_DIAG_LABELS: [&str; 26] = [
+pub const MC_DIAG_LABELS: [&str; 27] = [
     "mc_entered",
     "decl_shortcircuit",
     "descr0_skip",
@@ -634,6 +636,7 @@ pub const MC_DIAG_LABELS: [&str; 26] = [
     "stfe_cell_busy",
     "stfe_dead_token",
     "stfe_tick",
+    "toolong_suppressed",
 ];
 
 /// Render every [`MC_DIAG`] tally as space-separated `label=count` pairs.

--- a/majit/majit-metainterp/src/lib.rs
+++ b/majit/majit-metainterp/src/lib.rs
@@ -590,11 +590,61 @@ pub fn register_stack_almost_full_hook(f: fn() -> bool) {
 /// return (JUMP args != target LABEL args), 12 = start_bridge_tracing entered,
 /// 13 = sbt early: descr not FailDescr, 14 = sbt early: no owning jct, 15 = sbt
 /// early: no compiled_meta, 16 = sbt early: !can_trace, 17 = sbt early:
-/// fail_values too short.
-pub static MC_DIAG: [std::sync::atomic::AtomicU64; 18] = {
+/// fail_values too short, 18 = compile_and_run_once entered from a back edge,
+/// 19 = compile_and_run_once entered from a function entry, 20 =
+/// compile_and_run_once early-out: portal jitcode unavailable, 21 =
+/// compile_and_run_once early-out: no merge entry at the target pc, 22 =
+/// compile_and_run_once early-out: tracing did not start, 23 =
+/// should_trace_function_entry declined (cell compiled or tracing), 24 =
+/// should_trace_function_entry declined (dead procedure token cleanup), 25 =
+/// should_trace_function_entry answered from the counter tick.
+pub static MC_DIAG: [std::sync::atomic::AtomicU64; 26] = {
     const Z: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
-    [Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z]
+    [
+        Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z,
+    ]
 };
+
+/// Short label per [`MC_DIAG`] slot, in index order, so a tally cannot be added
+/// without naming it. Readers join these with the counter values.
+pub const MC_DIAG_LABELS: [&str; 26] = [
+    "mc_entered",
+    "decl_shortcircuit",
+    "descr0_skip",
+    "busy_skip",
+    "FIRED",
+    "stack_full",
+    "retrace_entered",
+    "retrace_bailed",
+    "cb_entered",
+    "cb_invalidloop",
+    "cb_retrace_req",
+    "cb_arity_giveup",
+    "sbt_entered",
+    "sbt_not_faildescr",
+    "sbt_no_jct",
+    "sbt_no_meta",
+    "sbt_cant_trace",
+    "sbt_short_vals",
+    "caro_backedge",
+    "caro_funcentry",
+    "caro_no_portal",
+    "caro_no_merge_entry",
+    "caro_not_tracing",
+    "stfe_cell_busy",
+    "stfe_dead_token",
+    "stfe_tick",
+];
+
+/// Render every [`MC_DIAG`] tally as space-separated `label=count` pairs.
+pub fn mc_diag_summary() -> String {
+    MC_DIAG_LABELS
+        .iter()
+        .enumerate()
+        .map(|(i, label)| format!("{label}={}", mc_diag(i)))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
 
 /// Read an `MC_DIAG` tally (saturating). Surfaced via `pyre_jit_mc_diag`.
 pub fn mc_diag(i: usize) -> u64 {

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -10385,6 +10385,11 @@ impl<M: Clone> MetaInterp<M> {
                 bridge_inputarg_base,
             )
         };
+        // Restore before any exit below, for the reason given in
+        // `compile_bridge`: the optimizer is the last reader of the descrs, and
+        // an early return that skipped this would leave `staticdata.all_descrs`
+        // empty for every later trace.
+        self.take_back_all_descrs(std::mem::take(&mut optimizer.all_descrs));
         let (optimized_ops, retrace_requested) = match bridge_optimize_result {
             Ok(result) => result,
             // unroll.py:119-123 `except (InvalidLoop, SpeculativeError)`: a
@@ -10547,7 +10552,6 @@ impl<M: Clone> MetaInterp<M> {
                     trace_id,
                     &mut terminal_exit_layouts,
                 );
-                self.take_back_all_descrs(std::mem::take(&mut optimizer.all_descrs));
                 let mut next_global_opref =
                     compute_next_global_opref(bridge_inputargs, &optimized_ops);
                 let mut traces = indexmap::IndexMap::new();
@@ -11048,6 +11052,15 @@ impl<M: Clone> MetaInterp<M> {
                 compiled.front_target_tokens = tokens;
             }
         }
+        // Hand the descrs back as soon as the optimizer is done with them,
+        // before any of the paths below can leave the function. `optimize_bridge`
+        // is the last reader; everything after it touches `optimizer` only for
+        // counters, exported state and quasi-immutable deps. Restoring here
+        // rather than on the success path keeps the InvalidLoop, retrace and
+        // giveup exits from leaving `staticdata.all_descrs` empty, which would
+        // make the next trace resolve `descr_index` against a zero-length table
+        // (`opencoder.rs` `all_descr_len`).
+        self.take_back_all_descrs(std::mem::take(&mut optimizer.all_descrs));
         let (optimized_ops, retrace_requested) = match bridge_optimize_result {
             Ok(result) => result,
             // compile.py:1077-1078 + unroll.py:119-123 `except (InvalidLoop,
@@ -11374,7 +11387,6 @@ impl<M: Clone> MetaInterp<M> {
                         },
                     );
                 }
-                self.take_back_all_descrs(std::mem::take(&mut optimizer.all_descrs));
                 self.warm_state.log_bridge_compile(fail_index);
                 self.stats.bridges_compiled += 1;
                 // `cpu.tracker.total_compiled_bridges` is bumped inside

--- a/majit/majit-metainterp/src/warmstate.rs
+++ b/majit/majit-metainterp/src/warmstate.rs
@@ -1408,6 +1408,7 @@ impl WarmEnterState {
         let mut cleanup_dead_token_cell = false;
         if let Some(cell) = self.cells.get(&green_key_hash) {
             if cell.is_compiled() || cell.is_tracing() {
+                crate::mc_diag_bump(23);
                 return false;
             }
             if cell.flags & jc_flags::DONT_TRACE_HERE != 0 {
@@ -1430,9 +1431,11 @@ impl WarmEnterState {
         if cleanup_dead_token_cell {
             // warmstate.py:483-500 — function-entry warmup must see an
             // invalidated token as a removed cell and re-count from cold.
+            crate::mc_diag_bump(24);
             self.cleanup_chain(green_key_hash);
             return false;
         }
+        crate::mc_diag_bump(25);
         self.counter
             .tick(green_key_hash, self.increment_function_threshold)
     }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -2223,17 +2223,23 @@ pub fn walk<Sym: WalkSym>(
         // the odometer itself. `fbw_executed_effect_count` is reset per walk, so
         // zero means nothing the replay would redo has run yet. A walk that is
         // already past that point keeps recording — the pre-existing unbounded
-        // behaviour — rather than corrupt the heap.
-        if ctx.trace_ctx.is_too_long() && fbw_executed_effect_count() == 0 {
-            let ops = ctx.trace_ctx.num_recorded_ops();
-            crate::state::note_root_trace_too_long(
-                ctx.trace_ctx.current_merge_points_first_greenkey(),
-                ctx.trace_ctx.resumekey_original_loop_token().cloned(),
-            );
-            return Err(DispatchError::TraceTooLong {
-                pc: opcode_position,
-                ops,
-            });
+        // behaviour — rather than corrupt the heap. That overshoot is otherwise
+        // silent, so it is tallied: it is what turns a walk which never reaches
+        // a close into unbounded recording.
+        if ctx.trace_ctx.is_too_long() {
+            if fbw_executed_effect_count() != 0 {
+                majit_metainterp::mc_diag_bump(26);
+            } else {
+                let ops = ctx.trace_ctx.num_recorded_ops();
+                crate::state::note_root_trace_too_long(
+                    ctx.trace_ctx.current_merge_points_first_greenkey(),
+                    ctx.trace_ctx.resumekey_original_loop_token().cloned(),
+                );
+                return Err(DispatchError::TraceTooLong {
+                    pc: opcode_position,
+                    ops,
+                });
+            }
         }
         match outcome {
             DispatchOutcome::Continue => {}

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -2196,6 +2196,15 @@ impl MIFrame {
         // inputargs types via `front_target_inputarg_types` (peeled-entry
         // LABEL when unrolled, root TreeLoop.inputargs otherwise — see
         // `MetaInterp::front_target_inputarg_types` doc).
+        //
+        // For a main trace the target label is the merge point being closed at
+        // (`original_boxes`, pyjitpl.py:3039-3041), which is the trace's own
+        // inputargs only when the trace closes at its own head. Resolving it
+        // through the merge point keeps the JUMP typed against the label it
+        // actually targets, the same correction `front_target_inputarg_types`
+        // makes on the bridge arm. A head close resolves to the trace-start
+        // seed, whose boxes were registered from `inputarg_types` — so that
+        // case stays byte-identical.
         let inputarg_types = {
             let (driver, _) = crate::driver::driver_pair();
             if driver.is_bridge_tracing() {
@@ -2207,7 +2216,9 @@ impl MIFrame {
                     ctx.inputarg_types()
                 }
             } else {
-                ctx.inputarg_types()
+                target_pc
+                    .and_then(|pc| ctx.merge_point_arg_types_at_header(pc))
+                    .unwrap_or_else(|| ctx.inputarg_types())
             }
         };
         let num_scalars = crate::virtualizable_gen::NUM_SCALAR_INPUTARGS;

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -2197,30 +2197,27 @@ impl MIFrame {
         // LABEL when unrolled, root TreeLoop.inputargs otherwise — see
         // `MetaInterp::front_target_inputarg_types` doc).
         //
-        // For a main trace the target label is the merge point being closed at
-        // (`original_boxes`, pyjitpl.py:3039-3041), which is the trace's own
-        // inputargs only when the trace closes at its own head. Resolving it
-        // through the merge point keeps the JUMP typed against the label it
-        // actually targets, the same correction `front_target_inputarg_types`
-        // makes on the bridge arm. A head close resolves to the trace-start
-        // seed, whose boxes were registered from `inputarg_types` — so that
-        // case stays byte-identical.
-        let inputarg_types = {
-            let (driver, _) = crate::driver::driver_pair();
-            if driver.is_bridge_tracing() {
-                if let Some(gk) = driver.current_trace_green_key() {
-                    driver
-                        .front_target_inputarg_types(gk)
-                        .unwrap_or_else(|| ctx.inputarg_types())
-                } else {
-                    ctx.inputarg_types()
-                }
-            } else {
-                target_pc
-                    .and_then(|pc| ctx.merge_point_arg_types_at_header(pc))
-                    .unwrap_or_else(|| ctx.inputarg_types())
-            }
-        };
+        // A close reached through the walk targets the merge point that matched
+        // (`original_boxes`, pyjitpl.py:3039-3041), whichever kind of trace is
+        // recording: `reached_loop_header` scans `current_merge_points` first
+        // and only falls through to the previously compiled loop when nothing
+        // matched. So the merge point recorded at the closing header answers
+        // ahead of the bridge's front target; a bridge that walked into a loop
+        // header it had itself passed closes at THAT label, not at the loop its
+        // guard came from. With no such merge point the close targets the root
+        // loop's LABEL/inputargs, which `front_target_inputarg_types` resolves
+        // (a bridge's own `inputarg_types()` are its guard fail_arg types).
+        let inputarg_types = target_pc
+            .and_then(|pc| ctx.merge_point_arg_types_at_header(pc))
+            .or_else(|| {
+                let (driver, _) = crate::driver::driver_pair();
+                driver
+                    .is_bridge_tracing()
+                    .then(|| driver.current_trace_green_key())
+                    .flatten()
+                    .and_then(|gk| driver.front_target_inputarg_types(gk))
+            })
+            .unwrap_or_else(|| ctx.inputarg_types());
         let num_scalars = crate::virtualizable_gen::NUM_SCALAR_INPUTARGS;
         // `extra_reds` reflects the canonical ec/red layout (NUM_EXTRA_REDS).
         // Drives the conditional ec push at args[1] and the dedup-side

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -7181,13 +7181,28 @@ fn handle_fail(
     // resuming, so the next back-edge warms and compiles against the new
     // quasi-immutable value instead of re-entering the stale containing
     // machine trace on every iteration.
-    if descr_arc
+    //
+    // Only when the guard's owning token IS the one currently installed.  A
+    // retired token's descrs stay reachable through the loop's side tables
+    // long after the key has been recompiled, and `invalidate_loop` resolves
+    // the key through `get_procedure_token`, which skips invalidated tokens —
+    // so an unscoped revoke kills the *replacement* loop instead, on every
+    // guard failure that still reports through the old trace.  `QuasiImmut.
+    // invalidate` (quasiimmut.py:84-109) marks only the looptokens registered
+    // on that instance and then drops the list, so a retired token never
+    // revokes a later compile upstream.
+    if let Some(owner) = descr_arc
         .as_fail_descr()
         .and_then(majit_backend::descr_owning_jct)
-        .is_some_and(|token| token.is_invalidated())
+        .filter(|token| token.is_invalidated())
     {
         let (driver, _) = driver_pair();
-        driver.invalidate_loop(green_key);
+        if driver
+            .get_loop_token_arc(green_key)
+            .is_some_and(|installed| std::sync::Arc::ptr_eq(&installed, &owner))
+        {
+            driver.invalidate_loop(green_key);
+        }
     }
 
     // The range FOR_ITER `GuardClass(RANGE_ITER)` proves its own site

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -7709,12 +7709,17 @@ fn compile_and_run_once(
 ) -> Option<LoopResult> {
     let mut frame_root = FrameRoot::new(frame);
     let code = unsafe { &*pyre_interpreter::pyframe_get_pycode(frame_root.frame()) };
+    majit_metainterp::mc_diag_bump(match start {
+        CompileOnceStart::BackEdge => 18,
+        CompileOnceStart::FunctionEntry => 19,
+    });
 
     // warmspot/codewriter ordering: the portal and all drained JitCodes are
     // installed before the marker-driven metainterpreter starts.  Resolve the
     // per-green static entry here; `trace_bytecode` consumes the same sidecar
     // when it constructs the root MIFrame.
     if !crate::jit::codewriter::register_portal_jitdriver(code) {
+        majit_metainterp::mc_diag_bump(20);
         return None;
     }
     let pjc = pyre_jit_trace::state::pyjitcode_for_code(frame_root.frame().pycode)
@@ -7723,6 +7728,7 @@ fn compile_and_run_once(
     // the greens behind the abort, so the hot loop header has none.  There is
     // no coordinate to start the walk from; interpret instead.
     if pjc.merge_entry_for(target_pc).is_none() {
+        majit_metainterp::mc_diag_bump(21);
         return None;
     }
 
@@ -7738,6 +7744,7 @@ fn compile_and_run_once(
         }
     }
     if !driver.is_tracing() {
+        majit_metainterp::mc_diag_bump(22);
         return None;
     }
 

--- a/pyre/pyre-wasm-runner/src/main.rs
+++ b/pyre/pyre-wasm-runner/src/main.rs
@@ -562,6 +562,7 @@ fn run(module_path: &PathBuf, source: &str) -> Result<i32> {
                 "stfe_cell_busy",
                 "stfe_dead_token",
                 "stfe_tick",
+                "toolong_suppressed",
             ];
             let mut parts = Vec::new();
             for (i, lbl) in labels.iter().enumerate() {

--- a/pyre/pyre-wasm-runner/src/main.rs
+++ b/pyre/pyre-wasm-runner/src/main.rs
@@ -554,6 +554,14 @@ fn run(module_path: &PathBuf, source: &str) -> Result<i32> {
                 "sbt_no_meta",
                 "sbt_cant_trace",
                 "sbt_short_vals",
+                "caro_backedge",
+                "caro_funcentry",
+                "caro_no_portal",
+                "caro_no_merge_entry",
+                "caro_not_tracing",
+                "stfe_cell_busy",
+                "stfe_dead_token",
+                "stfe_tick",
             ];
             let mut parts = Vec::new();
             for (i, lbl) in labels.iter().enumerate() {

--- a/pyre/pyrex/src/lib.rs
+++ b/pyre/pyrex/src/lib.rs
@@ -861,8 +861,20 @@ fn maybe_print_jit_stats() {
     // Gate tallies for the trace-entry and guard→bridge paths. These were
     // reachable only through the wasm runner's `pyre_jit_mc_diag` export, so a
     // native run had no way to see which gate declined a trace.
+    //
+    // `all_descrs` rides along because it is the one table the optimizer grows
+    // per trace while `descr.py:47` asserts it stays under 2**15 — upstream
+    // fills it once at translation time, so only pyre can run into that bound.
+    let all_descrs_len = pyre_jit::eval::driver_pair()
+        .0
+        .meta_interp()
+        .staticdata
+        .all_descrs
+        .lock()
+        .map(|d| d.len())
+        .unwrap_or(0);
     eprintln!(
-        "[jit-stats] mc_diag {}",
+        "[jit-stats] mc_diag {} all_descrs={all_descrs_len}",
         majit_metainterp::mc_diag_summary()
     );
 }

--- a/pyre/pyrex/src/lib.rs
+++ b/pyre/pyrex/src/lib.rs
@@ -869,7 +869,7 @@ fn maybe_print_jit_stats() {
         .0
         .meta_interp()
         .staticdata
-        .all_descrs
+        .all_descrs()
         .lock()
         .map(|d| d.len())
         .unwrap_or(0);

--- a/pyre/pyrex/src/lib.rs
+++ b/pyre/pyrex/src/lib.rs
@@ -858,6 +858,13 @@ fn maybe_print_jit_stats() {
         stats.guard_failures,
         stats.internal_compile_panics,
     );
+    // Gate tallies for the trace-entry and guard→bridge paths. These were
+    // reachable only through the wasm runner's `pyre_jit_mc_diag` export, so a
+    // native run had no way to see which gate declined a trace.
+    eprintln!(
+        "[jit-stats] mc_diag {}",
+        majit_metainterp::mc_diag_summary()
+    );
 }
 
 /// Shared top-level launcher bootstrap for `run_source` and `run_module`:


### PR DESCRIPTION
Guard → bridge fixes, plus the native `MC_DIAG` readout that found them.

Rebased onto `b8a00beb94`. One commit from the original series — *take a bridge's
candidate target tokens from its closing JUMP's loop* — is **dropped**: #834
landed the same correction upstream in a better form (a named
`bridge_cell_token_key` helper plus a clone/store-back, where this branch took a
second `&mut` on `compiled_loops`). Its `cb_crossloop_jump` tally is dropped with
it, since #834 measured that case as byte-identical and shipped it untallied.

## Fixes

**A closing JUMP was typed against the wrong loop's label.** `close_loop_args_at`
picked the target label's arg types by asking `driver.is_bridge_tracing()`
first, so any trace that had *started* as a bridge typed its closing JUMP against
`front_target_inputarg_types(gk)` — the loop the failed guard came from. But a
bridge-originated full-body walk that reaches a merge point closes a **loop**,
and `reached_loop_header` (`pyjitpl.py:3003-3021`) scans `current_merge_points`
first, falling through to the already-compiled loop only when nothing matched.
The backtrace is the giveaway: `handle_fail → trace_and_compile_from_bridge →
compile_loop`. Typing against the guard's loop left a raw `Int` in a `Ref`-typed
virtualizable slot and panicked in `OptUnroll::import_state` (`make_equal_to:
cross-type forward`). `merge_point_arg_types_at_header` now answers first; the
position-0 trace-start seed is excluded because its boxes are built from the
trace's own `inputarg_types()`, which is exactly what the existing fallback
already yields.

**A guard from a retired trace revoked the replacement loop.** `handle_fail`
revoked the entry token for the green key whenever the failed guard's owning
`JitCellToken` was invalidated. A retired token's descrs stay reachable through
the loop side tables long after the key has been recompiled, and
`invalidate_loop` resolves the key through `get_procedure_token`, which skips
invalidated tokens — so the revoke landed on the **replacement** loop, on every
guard failure still reporting through the old trace. `should_remove_jitcell` then
returned true, the cell was dropped, the counter re-armed, and the key recompiled
from cold. `QuasiImmut.invalidate` (`quasiimmut.py:84-109`) marks only the
looptokens registered on that instance and then clears the list, so a retired
token never revokes a later compile upstream. The revoke is now scoped by
`Arc::ptr_eq` to the token actually installed.

**`compile_bridge` / `compile_entry_bridge` left `staticdata.all_descrs` empty on
every early exit.** Both moved the vector into the optimizer with `mem::take` and
handed it back only on the success path, so the `InvalidLoop`, retrace-requested
and arity-giveup returns left the staticdata vector empty and the next trace
resolved `descr_index` against a zero-length table in `opencoder`'s
`all_descr_len`. The restore now happens right after `optimize_bridge`, which is
the last reader — everything after it touches the optimizer only for counters,
exported state and quasi-immutable deps.

**`MC_DIAG` was readable only from wasm.** The gate tallies were exported through
`pyre_jit_mc_diag` for the wasm runner, so a native run had no way to see which
gate declined a trace. Labels and a summary now live next to the counters and
print under `MAJIT_STATS`, together with the `all_descrs` length — the optimizer
grows that table per trace via `ensure_descr_index` while `descr.py:47` asserts
it stays under 2**15, a bound only pyre can reach at runtime.

## New tallies

`compile_and_run_once`'s entry kind and its three early exits,
`should_trace_function_entry`'s three outcomes, and `toolong_suppressed` — the
walk steps recorded past `trace_limit` whose abort was skipped because the walk
had already executed an unrollbackable effect. The last one sits inside the
existing `is_too_long()` branch, so a walk under the limit does no extra work.

## What the readout showed

`function_threshold=1`, N=2400, dynasm release:

| | time | loops | bridges | guard failures |
|---|---|---|---|---|
| default | 0.08s | 1 | 2 | 401 |
| `function_threshold=1` | 10.30s | 1 | 0 | 0 |

`caro_funcentry=1 caro_backedge=0` — `compile_and_run_once` is entered **once**,
from the function entry, and a `sample` profile puts 3288/3295 samples inside
that single call. So the 130x is one unbounded trace, not repeated tracing:
`jitcode_dispatch::walk` closes a top-level trace only when the merge point's key
equals the trace-start key, while `pyjitpl.py:3018-3022` searches all of
`current_merge_points`. A function-entry trace starts at a pc that is not a loop
header, so its root key is never re-reached and the walk records the whole
program. `toolong_suppressed` puts a number on the overshoot: 12,097 / 75,697 /
160,497 steps past `trace_limit` for outer = 10 / 40 / 80 — the same linear shape
as the RSS curve, against **0** at default parameters.

Three synth benches set `function_threshold=1`
(`exception_reraise_tb_depth_jitstress`, `exception_metadata_jitstress`,
`trace_too_long_effect_replay`) and none carries a `.jitstats` baseline, so none
of this was visible.

## Not fixed here: the `root_green_key` close gate

The gate above is still in place, and this PR does not remove it. Lifting it
behind a throwaway env flag on `global_quasiimmut_invalidation` (dynasm release,
`MAJIT_STATS=1`) isolates the one remaining blocker:

| | gate ON | gate LIFTED |
|---|---|---|
| wall | 0.64s | 28.99s |
| loops / bridges | 2 / 2 | 2 / 3 |
| `mc_entered` (= guard_failures) | 402 | 995258 |
| `FIRED` | 2 | **3** |
| every decline tally | 0 | 0 |

Output is `99505000` in both arms, so this is a perf residual, not a divergence.
The gate-ON column calibrates the counter: 402 failures → 2 firings is exactly
`trace_eagerness=200`. Under the lift, 995258 failures give **3** firings, not
the ~4976 a healthy counter would produce, while every decline tally reads 0 and
every bridge attempted was built (`cb_entered=3` → `bridges_compiled=3`). The
failures are therefore neither declined nor counted — they leave
`must_compile_with_values` before the tick, through its one untallied early exit:

```rust
if owning_jct.as_ref().is_some_and(|jct| jct.is_invalidated()) {
    return (false, owning_key);
}
```

`compile.py:738-784 must_compile` has no invalidated-owner gate. Upstream ticks
regardless; at `trace_eagerness` the bridge walk reaches `reached_loop_header` →
`get_procedure_token` → `None` → `compile_loop` → `attach_procedure_to_interp`,
installing a live replacement token and bounding the damage. Removing that gate
is the precondition for retiring the close gate, and it needs its own
verification pass on both backends.

## Verification

`cargo fmt --check` clean. `pyre/check.py --backend dynasm`: **331 passed, 1
failed**. The one failure is `synth/ast_compile_roundtrip`, a `BASEFAIL` from
this base — the harness's own oracle pair disagrees and pyre never runs:

```
< hand reject named-target-not-name TypeError     # CPython 3.14.2
> hand reject named-target-not-name ValueError    # PyPy 3.11.13
```

That bench arrived with `a510d58a73` (#856) and fails identically on a clean
`origin/main`. Two earlier passes on a loaded box also flapped
`attr_instance_shadows_class` (timeout >20s; 4.41s in isolation) and
`raise_catch` (1.8x vs a 1.5x gate; 5-run medians in isolation put it at ~1.4x)
— different benches each run from the same binary, i.e. box noise.
