### PR TITLE
jit(gh#346): pin the symmetric-difference result set across the merge loop

### DIFF
--- a/pyre/extra_tests/snippets/set_symdiff_raising_eq.py
+++ b/pyre/extra_tests/snippets/set_symdiff_raising_eq.py
@@ -12,13 +12,23 @@ class Boom:
         self.key = key
         self.explode = explode
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return 7  # single bucket -> __eq__ runs on every probe
 
     def __eq__(self, other):
         if self.explode or getattr(other, "explode", False):
             raise ValueError("boom in __eq__")
         return self.key == other.key
+
+
+class HashBoom:
+    """__hash__ raises: symmetric_difference must surface it before any probe."""
+
+    def __hash__(self) -> int:
+        raise ValueError("boom in __hash__")
+
+    def __eq__(self, other):
+        return self is other
 
 
 def run_symdiff(a, b):
@@ -66,6 +76,49 @@ for _ in range(1000):
         raised = True
         assert str(exc) == "boom in __eq__"
     assert raised, "symmetric_difference swallowed a raising __eq__ on the second pass"
+
+
+# --- raising __hash__: the ValueError must propagate before any probe -------
+for _ in range(1000):
+    left = {1, 2, 3}
+    raised = False
+    try:
+        left.symmetric_difference([HashBoom()])
+    except ValueError as exc:
+        raised = True
+        assert str(exc) == "boom in __hash__"
+    assert raised, "symmetric_difference swallowed a raising __hash__"
+
+
+# --- collecting __eq__: the in-progress result set must stay rooted ---------
+# Each probe runs a full collection; the fresh result set is reachable only
+# from the merge's Rust frame, so it must be pinned or a major collection
+# sweeps it mid-merge and the next insert / the return touches freed storage.
+# run_symdiff is already warmed past the trace threshold by the loops above, so
+# a couple of merges suffice to hit the jitted path; a full collection per probe
+# is O(heap) and quadratic in element count, so keep both counts small.
+import gc
+
+
+class Collect:
+    def __init__(self, v):
+        self.v = v
+
+    def __hash__(self) -> int:
+        return 7  # single bucket -> __eq__ runs on every probe
+
+    def __eq__(self, other):
+        gc.collect()
+        return self.v == getattr(other, "v", object())
+
+
+for _ in range(3):
+    left = {Collect(i) for i in range(6)}
+    right = {Collect(i) for i in range(3, 9)}
+    result = run_symdiff(left, right)
+    got = sorted(e.v for e in result)
+    exp = sorted(set(range(6)) ^ set(range(3, 9)))
+    assert got == exp, (got, exp)
 
 
 print("set_symdiff_raising_eq OK")

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -21287,7 +21287,10 @@ fn set_method_symmetric_difference_update(
 /// Walked one index at a time through `w_set_key_at` and probed with
 /// `w_set_contains_key_checked`, the same shape as `set_intersect_update`, so
 /// the merge loop stays traced and only the per-key table probe/insert cross a
-/// residual boundary. The two sets are old-gen allocations that keep their
+/// residual boundary. The two operands are reached from the frame and stay
+/// rooted, but `d_new` is only reachable from this frame's Rust locals; a probe
+/// `eq_w` that triggers a collection would sweep the unrooted body, so it is
+/// pinned for the whole merge. The set bodies are old-gen and keep their
 /// addresses across a collection, but their elements are young and move, so
 /// each key is re-read from the table the collector rewrites rather than
 /// carried across the `eq_w` a bucket probe can run.
@@ -21296,7 +21299,9 @@ fn set_symmetric_difference_storage(
     w_other: pyre_object::PyObjectRef,
 ) -> Result<pyre_object::PyObjectRef, crate::PyError> {
     unsafe {
+        let _roots = pyre_object::gc_roots::push_roots();
         let d_new = pyre_object::w_set_new();
+        pyre_object::gc_roots::pin_root(d_new);
         for (walk, probe) in [(w_other, w_set), (w_set, w_other)] {
             let mut i = 0;
             while let Some(key) = pyre_object::w_set_key_at(walk, i) {


### PR DESCRIPTION
## What

Follow-up to #846. That slice hoisted the symmetric-difference merge loop into `set_symmetric_difference_storage` and, in doing so, dropped the `push_roots()` + `pin_root(d_new)` that the removed `pyre_object::setobject` helper carried.

`d_new` (the fresh result set from `w_set_new()`) is reachable only from the merge's Rust frame. The GC sees roots via the shadow stack only — the two operands are rooted through the interpreter frame, but `d_new` is not. A probe `eq_w` that triggers a collection therefore sweeps the in-progress result body; the next insert or the return then touches freed storage.

- interpreter path: `GC BUG: invalid type_id` crash
- JIT path: `AttributeError` type-confusion (freed storage reused)

Both reproduced on the merged slice, then fixed here.

## Fix

Wrap the merge in `push_roots()` and `pin_root(d_new)`. The set body is old-gen (non-moving) so it keeps its address across a collection — the pin prevents the sweep and needs no reload. `+7/-2` in `typedef.rs`; the traced-loop shape (matching `set_intersect_update`) is unchanged, so the census head stays retired.

## Why not re-residualize the helper

Restoring the deleted `#[dont_look_inside]` + `jit_fnaddr` helper (the #846-slice-1 pattern) **revives** the census head: the helper returns `Result<PyObjectRef, SetUpdateError>`, and the annotator cannot decode the custom enum across the residual boundary (`map_set_update_error() takes exactly 1 argument (0 given)`), regressing phaseA 321→322. Void residuals and null-niche `Option<PyObjectRef>` residuals cross the boundary; custom-enum-`Result` residuals do not. So the pin-only path is the census-clean fix.

## Test

Extends `set_symdiff_raising_eq.py` with:
- a `HashBoom` raising-`__hash__` case (the error must surface before any probe),
- return-type annotations on the `__hash__` methods,
- a `Collect` class whose `__eq__` runs `gc.collect()` — this is the pin guard; without the pin it crashes as above. The collect loop is kept small because a full collection per single-bucket probe is O(heap).

## Verification

- census A/B: head-neutral (phaseA 321 before ≡ 321 after; `comm` diff empty both ways)
- `check.py --backend dynasm,cranelift`: dynasm 326/326, cranelift 326/326, bit-exact
- `cargo test` pyre-object / majit-translate / pyre-interpreter (dynasm,host_env): green
- snippet passes under JIT, interpreter, and CPython oracle

Note: `set_intersect_update` shares the same live-read shape (a pre-existing class deviation, PyPy `_intersect_unwrapped` / `_symmetric_difference_unwrapped` both unerase once); restoring capture-once for both jointly is a separate follow-up, out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)