### PR TITLE
jit: audit the exception-slot barriers, forward the off-GC singleton children, drop the dead LivenessInfo table

### DIFF
--- a/majit/majit-backend-dynasm/src/lib.rs
+++ b/majit/majit-backend-dynasm/src/lib.rs
@@ -108,7 +108,9 @@ pub fn jit_exc_class_raw() -> i64 {
     JIT_EXC_TYPE.load(Ordering::Relaxed)
 }
 
-/// cpu.grab_exc_value parity: read and clear exception value.
+/// `_store_and_reset_exception` (x86/assembler.py:1838, 1847-1848) parity:
+/// read `pos_exc_value` and zero the global.  Not `grab_exc_value`, which
+/// reads `jf_guard_exc` off the deadframe and does not write.
 pub fn jit_exc_value_raw() -> i64 {
     JIT_EXC_VALUE.swap(0, Ordering::Relaxed)
 }
@@ -201,10 +203,12 @@ use std::sync::OnceLock;
 /// the descr is the sole identity carrier.  No surrogate triple
 /// crosses the C-ABI.
 ///
-/// `guard_exc` is `cpu.grab_exc_value(deadframe)` (`llmodel.py:240`):
+/// `guard_exc` is `cpu.grab_exc_value(deadframe)` (`llmodel.py:240-242`):
 /// the pending exception the `must_save_exception` failure-recovery
-/// stub staged into `jf_guard_exc`, grabbed (read + clear) off the
-/// jitframe before it is freed.  `blackhole.py:1794
+/// stub staged into `jf_guard_exc`, read off the jitframe before it is
+/// freed.  The grab itself does not write the slot upstream — clearing
+/// `jf_guard_exc` is emitted code's job (`_restore_exception`,
+/// x86/assembler.py:1855-1857).  `blackhole.py:1794
 /// _prepare_resume_from_failure` hands it to the resumed frame so an
 /// exception guard unwinds into its handler instead of resuming the
 /// no-exception continuation.  `0` = no pending exception.
@@ -664,11 +668,16 @@ fn handle_fail_resume_guard(
     // `debug_assert_eq!(source_jct.green_key, green_key)` (pyjitpl.rs:8297-8301).
     let owning_jct = majit_backend::descr_owning_jct(descr);
 
-    // llmodel.py:240 `grab_exc_value(deadframe)`: read + clear
-    // `jf_guard_exc` while the jitframe is still alive.  The
-    // `must_save_exception` failure-recovery stub (GUARD_EXCEPTION /
-    // GUARD_NO_EXCEPTION / GUARD_NOT_FORCED) staged `pos_exc_value`
-    // here; non-exception guards leave it null.
+    // llmodel.py:240-242 `grab_exc_value(deadframe)`: read `jf_guard_exc`
+    // while the jitframe is still alive.  The `must_save_exception`
+    // failure-recovery stub (GUARD_EXCEPTION / GUARD_NO_EXCEPTION /
+    // GUARD_NOT_FORCED) staged `pos_exc_value` here; non-exception guards
+    // leave it null.
+    //
+    // The grab is read-only upstream; the additional clear below is pyre's,
+    // so the rooted local is the sole carrier for the rest of this function
+    // (the value is read back from `guard_exc_root`, never re-read from the
+    // slot).
     //
     // Clearing the slot drops the only GC root for the exception object
     // (`jf_guard_exc` is a GCREF visited by `jitframe_trace`).  The bridge

--- a/majit/majit-backend-dynasm/src/lib.rs
+++ b/majit/majit-backend-dynasm/src/lib.rs
@@ -694,6 +694,13 @@ fn handle_fail_resume_guard(
         *slot = 0;
         v
     });
+    // The blackhole receiver parks this same value in the metainterp's raw
+    // guard-exception carrier as soon as it is entered, so across the
+    // `blackhole` call below the value is rooted twice over. Collapsing the
+    // pair onto the park alone is not reachable from here: this crate does not
+    // depend on `majit-metainterp`, and `BridgeFn` does not carry the
+    // exception, so the bridge hook cannot park a value it never receives.
+    // Either fix costs more machinery than the root pair it would delete.
     let guard_exc_rooted = guard_exc_root.0 != 0;
     if guard_exc_rooted {
         unsafe { majit_gc::gc_add_root(&mut guard_exc_root as *mut majit_ir::GcRef) };

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -1678,8 +1678,9 @@ impl DynasmBackend {
     ///
     /// `frame_ptr` is required so the `propagate_exception_descr` arm
     /// can run the equivalent of `compile.py:1092-1098`'s
-    /// `cpu.grab_exc_value(deadframe)` — read+clear `jf_guard_exc` and
-    /// stage the value into `jf_frame[0]` before synthesizing the
+    /// `cpu.grab_exc_value(deadframe)` — read `jf_guard_exc` (the grab is
+    /// read-only, `llmodel.py:240-242`; the clear alongside it is pyre's)
+    /// and stage the value into `jf_frame[0]` before synthesizing the
     /// exit-frame-with-exception descr the toplevel consumer expects.
     fn find_descr_by_ptr(
         &self,
@@ -1748,7 +1749,9 @@ impl DynasmBackend {
         // _store_and_reset_exception, x86/assembler.rs:2304-...) into
         // `jf_frame[0]` so the existing slot-0 Ref reader picks it up.
         if ptr != 0 && ptr == attached.propagate_exception_descr {
-            // grab_exc_value: read+clear jf_guard_exc.
+            // grab_exc_value reads jf_guard_exc (llmodel.py:240-242); the
+            // clear is pyre's — the value moves into jf_frame[0] below and
+            // the slot must not hand a second copy to a later grab.
             let exc_val = unsafe {
                 let slot = &mut (*frame_ptr).jf_guard_exc;
                 let v = *slot;

--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -319,7 +319,10 @@ thread_local! {
     /// reachable only through it — live behind a bare `i64`. RPython's
     /// `grab_exc_value` result is a shadowstack-rooted local across the same
     /// span; pyre has no GC transform, so the frontend registers a root walker
-    /// over this cell instead.
+    /// over this cell instead, and carries the cell's address in the
+    /// per-mutator root area next to `BH_LAST_EXC_VALUE` so a collection
+    /// started by another thread still reaches a stopped mutator's parked
+    /// exception.
     pub static GUARD_EXC_VALUE: std::cell::Cell<i64> = const { std::cell::Cell::new(0) };
 }
 

--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -323,6 +323,14 @@ thread_local! {
     /// per-mutator root area next to `BH_LAST_EXC_VALUE` so a collection
     /// started by another thread still reaches a stopped mutator's parked
     /// exception.
+    ///
+    /// Thread-local is the faithful shape rather than a concession: upstream
+    /// keeps one shadow stack per thread and switches between them on GIL
+    /// hand-off (`shadowstack.py:140-215`, a `{tid: SHADOWSTACKREF}` map), and
+    /// enumerates every thread's block at collection time instead of resolving
+    /// the thread local on whichever thread started collecting
+    /// (`rthread.py:429-437 _trace_tlref`). This cell plus the per-mutator area
+    /// is that pair, hand-materialized for one live value.
     pub static GUARD_EXC_VALUE: std::cell::Cell<i64> = const { std::cell::Cell::new(0) };
 }
 

--- a/majit/majit-metainterp/src/jitcode/assembler.rs
+++ b/majit/majit-metainterp/src/jitcode/assembler.rs
@@ -3057,8 +3057,8 @@ impl JitCodeBuilder {
         );
     }
 
-    /// of: emit canonical
-    /// `residual_call_{r,ir,irf}_v` opname/argcodes byte layout.
+    /// Emit the canonical `residual_call_{r,ir,irf}_v` opname/argcodes byte
+    /// layout.
     ///
     /// Policy-specific void calls use this same bytecode family; their
     /// behaviour is carried by `calldescr.extra_info`, matching RPython
@@ -3341,9 +3341,8 @@ impl JitCodeBuilder {
     /// `handler_residual_call_*_{i,r,f}` at `blackhole.rs:6611-6660` via
     /// `code[p]`).
     ///
-    /// of:
-    /// foundation. (`residual_call_*_canonical_*`
-    /// wrappers below) is the first non-dormant caller.
+    /// The `residual_call_*_canonical_*` wrappers below are its first
+    /// non-dormant callers.
     fn emit_canonical_call_typed(
         &mut self,
         opcodes: (u8, u8, u8),
@@ -3430,8 +3429,8 @@ impl JitCodeBuilder {
         self.call_descr_to_call_target.insert(calldescr_idx, target);
     }
 
-    /// of: int-result
-    /// sibling of [`Self::residual_call_void_canonical_via_target`].
+    /// Int-result sibling of
+    /// [`Self::residual_call_void_canonical_via_target`].
     /// `bhimpl_residual_call_{r,ir,irf}_i` (`blackhole.py:1225-1247`)
     /// dispatches via `cpu.bh_call_i` and writes the result into
     /// `bh.registers_i[dst]`.
@@ -4720,9 +4719,6 @@ impl JitCodeBuilder {
     /// pool and return its index. Used by canonical `residual_call_*` /
     /// `call_*` emit paths that need a `d` argcode descriptor (RPython
     /// `assembler.py:197-207` `_encode_descr(calldescr)`).
-    ///
-    /// of: helper only.
-    /// emits via this from the migrated emit sites.
     ///
     /// TODO: dedup is intentionally NOT done for the
     /// `Call` variant. RPython's `descr.py:660-668 _key_for_caching`

--- a/majit/majit-metainterp/src/jitcode/mod.rs
+++ b/majit/majit-metainterp/src/jitcode/mod.rs
@@ -27,32 +27,6 @@ pub(crate) use majit_translate::insns::insn_byte;
 
 pub use majit_translate::insns::{pyre_extension_insns, wellknown_bh_insns};
 
-/// GC liveness metadata at a specific bytecode PC.
-///
-/// RPython liveness.py: `[len_i][len_r][len_f][bitset_i][bitset_r][bitset_f]`.
-/// Tracks which registers of each type (int/ref/float) are live at a given PC.
-///
-/// TODO: pyre currently keeps this per-entry form alongside the packed
-/// Temporary pyre-side liveness shape used before the codewriter emits
-/// RPython `-live-` opcodes directly. Canonical JitCode does not store this.
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
-pub struct LivenessInfo {
-    pub pc: u16,
-    /// Live integer register indices at this PC.
-    pub live_i_regs: Vec<u16>,
-    /// Live reference register indices at this PC.
-    pub live_r_regs: Vec<u16>,
-    /// Live float register indices at this PC.
-    pub live_f_regs: Vec<u16>,
-}
-
-impl LivenessInfo {
-    /// Total number of live registers across all typed banks.
-    pub fn total_live(&self) -> usize {
-        self.live_i_regs.len() + self.live_r_regs.len() + self.live_f_regs.len()
-    }
-}
-
 /// Re-export of the canonical `enumerate_vars` function so existing
 /// metainterp callers can keep using `crate::jitcode::enumerate_vars`.
 ///

--- a/majit/majit-metainterp/src/lib.rs
+++ b/majit/majit-metainterp/src/lib.rs
@@ -124,7 +124,7 @@ pub use jit_state::{
     bridge_decode_red,
 };
 pub use jitcode::{
-    BC_GOTO, JitArgKind, JitCallArg, JitCode, JitCodeBuilder, LivenessInfo, RuntimeBhDescr, insns,
+    BC_GOTO, JitArgKind, JitCallArg, JitCode, JitCodeBuilder, RuntimeBhDescr, insns,
     live_slots_for_state_field_jit, set_global_build_descr_pool,
 };
 pub use jitdriver::{

--- a/pyre/gate-triage.md
+++ b/pyre/gate-triage.md
@@ -478,7 +478,7 @@ OFF path is a needed safety net. Retire at the listed trigger (A7).
 
 | var | subsystem | retire when |
 |---|---|---|
-| PYRE_FBW_BLACKHOLE_RESUME | single-frame resume-past-escape (#754) | flipped default-ON 2026-07-25; retirement was conditioned on the multi-frame twin (`_MULTIFRAME`) landing, but §1 now measures that twin as having zero corpus coverage, so the condition is unevaluable — keep the gate and re-open the question once the multi-frame adopt's root-mismatch decline (§1d) is resolved |
+| PYRE_FBW_BLACKHOLE_RESUME | single-frame resume-past-escape (#754) | flipped default-ON 2026-07-25; retirement is conditioned on the multi-frame twin (`_MULTIFRAME`) flipping, and the multi-frame latch is nested inside `single_frame_blackhole_resume_enabled()`, so this gate has to stay ON while that one is in play. Both earlier premises are spent: the root-mismatch decline is resolved (§1d) and the twin's corpus coverage is no longer zero (20 adopts, 10 pinned declines). What blocks the twin now is the escaping `sys._getframe` identity answer, not this gate |
 | PYRE_TWO_PHASE_RTYPE, PYRE_TUPLE_PER_SHAPE_CLASSDEF | rtyper prepass / per-shape tuple classdef | WS2 / #346 rtyper epic |
 | PYRE_ORIGINAL_BOXES | greens++reds original_boxes index shape | box-identity #202 / resume F1 |
 | PYRE_MIR_FRAMESTATE | framestate-threaded MIR lowering | MIR front-end #176/#181/#346 |

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -278,16 +278,19 @@ pub unsafe fn walk_raw_code_roots(
     }
 }
 
-/// Mark the GC-managed children of an immortal `W_BaseException`.
+/// Mark the GC-managed children of a `W_BaseException`.
 ///
-/// Exceptions are `malloc_typed`-immortal (`interp_exceptions.rs` `new_exception`
-/// / "lives forever"), so the collector never traces them — the root visitor's
-/// `is_managed_heap_object` guard short-circuits on the immortal exception, and
-/// `mark_object` is never reached for it (it is not an old-gen object). Its
+/// Exception allocation is split: an ordinary exception goes to the non-moving
+/// oldgen via `try_gc_alloc_stable_raw`, while the immortal singletons and the
+/// GC-allocation-failure fallback use `malloc_typed` (`interp_exceptions.rs`
+/// `new_exception`). For the `malloc_typed` family the collector never traces
+/// the exception at all — the root visitor's `is_managed_heap_object` guard
+/// short-circuits and `mark_object` is never reached — and for the oldgen
+/// family a minor reaches the children only through the remembered set. Its
 /// `args_w` tuple, `w_errno` / `w_strerror` / `w_filename` ints/strings,
 /// `w_traceback` / `w_context` / `w_cause`, `w_dict`, … are ordinary GC-managed
 /// objects, so when an exception is the only holder of those children (a caught
-/// `except X as e` bound to a frame local) a major collection sweeps them and a
+/// `except X as e` bound to a frame local) a collection sweeps them and a
 /// later `e.args` / `e.errno` reads freed memory. Visit every
 /// `W_BASE_EXCEPTION_GC_PTR_OFFSETS` slot in place, the same shape
 /// `walk_raw_function_roots` / `walk_raw_getset_roots` use for Box/`malloc_typed`

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -51,6 +51,8 @@ thread_local! {
         in_flight_exception: IN_FLIGHT_EXCEPTION.with(|cell| cell as *const _),
         bh_last_exception: majit_metainterp::blackhole::BH_LAST_EXC_VALUE
             .with(|cell| cell as *const _),
+        guard_exception: majit_metainterp::blackhole::GUARD_EXC_VALUE
+            .with(|cell| cell as *const _),
         jit_pending_exception: crate::stack_check::capture_jit_pending_exception_area(),
         pending_call_error: crate::call::capture_pending_call_error_area(),
         pending_hash_error: crate::baseobjspace::capture_pending_hash_error_area(),
@@ -64,6 +66,7 @@ struct PyFrameRootArea {
     mapdict_method_cache: *const (),
     in_flight_exception: *const Cell<PyObjectRef>,
     bh_last_exception: *const Cell<i64>,
+    guard_exception: *const Cell<i64>,
     jit_pending_exception: *const Cell<i64>,
     pending_call_error: *const (),
     pending_hash_error: *const (),
@@ -592,6 +595,7 @@ pub unsafe fn walk_pyframe_roots_area(
     unsafe {
         walk_in_flight_exception_area(area.in_flight_exception, visitor);
         walk_raw_exception_cell_area(area.bh_last_exception, visitor);
+        walk_raw_exception_cell_area(area.guard_exception, visitor);
         walk_raw_exception_cell_area(area.jit_pending_exception, visitor);
         crate::call::walk_pending_call_error_area(area.pending_call_error, visitor);
         crate::baseobjspace::walk_pending_hash_error_area(area.pending_hash_error, visitor);
@@ -982,7 +986,8 @@ fn walk_bh_last_exception(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
 
 /// Forward one raw `i64` exception carrier cell and trace the exception's
 /// GC-managed children. Shared by every such carrier
-/// (`BH_LAST_EXC_VALUE`, `TL_JIT_PENDING_EXCEPTION`) so they cannot drift.
+/// (`BH_LAST_EXC_VALUE`, `GUARD_EXC_VALUE`, `TL_JIT_PENDING_EXCEPTION`) so they
+/// cannot drift.
 pub(crate) unsafe fn walk_raw_exception_cell_area(
     c: *const Cell<i64>,
     visitor: &mut dyn FnMut(&mut majit_ir::GcRef),

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -3297,9 +3297,9 @@ fn walk_jit_exc_value(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
     if exc == 0 {
         return;
     }
-    // A GC-managed exception (post-#18) marked here has its registered child
-    // offsets traced by the collector; the exception is oldgen-stable so a
-    // bare mark suffices.
+    // A GC-managed exception marked here has its registered child offsets
+    // traced by the collector; the exception is oldgen-stable so a bare mark
+    // suffices.
     let mut gcref = majit_ir::GcRef(exc as usize);
     visitor(&mut gcref);
     // The carrier is non-moving (oldgen-stable / malloc_typed), so a minor
@@ -3308,6 +3308,24 @@ fn walk_jit_exc_value(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
     // tracebacks appended by the raise in flight, args — would be left
     // dangling inside the exception across the minor. Forward the raw child
     // slots explicitly, as the EC root walk does for `sys_exc_value`.
+    //
+    // For a *managed* exception the explicit walk is belt-and-braces: minor is
+    // already covered by the remembered set, since every reference setter goes
+    // through `exception_write_barrier`, and major marking traces the type's
+    // registered pointer offsets. It is load-bearing only for exceptions that
+    // live outside the GC heap — the `malloc_typed` immortals such as the
+    // MemoryError singleton — where the write barrier and major seeding both
+    // ignore a non-managed holder, leaving this walker as the sole traversal
+    // of their children.
+    //
+    // That asymmetry is why the carrier cannot be demoted to a plain
+    // shadow-stack entry (the direct analogue of the GC transform's rooted
+    // local, `shadowstack.py:31-39`): a generic root reaches an off-GC
+    // exception's fields through neither collection. Pushing the children
+    // individually does not substitute either — forwarding would rewrite the
+    // pushed copies, not the slots inside the exception. A walker with
+    // mutable access to the real slots is the only shape that works while the
+    // heap admits off-GC exception holders.
     unsafe {
         pyre_interpreter::eval::walk_raw_exception_roots(
             gcref.0 as pyre_object::PyObjectRef,

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -3341,6 +3341,12 @@ fn walk_bh_last_exc_value(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
 /// handle on it, and the bridge / blackhole handoff reconstructs resume state
 /// through the blackhole allocator before re-rooting the value. Same
 /// carrier/children split as [`walk_jit_exc_value`].
+///
+/// This slot reaches only the *collecting* thread's cell; every other mutator's
+/// cell is reached through the per-mutator `PyFrameRootArea`, which carries the
+/// same TLS address alongside `BH_LAST_EXC_VALUE`. `rthread.py:429-437
+/// _trace_tlref` enumerates every thread's block rather than resolving the
+/// thread local on whichever thread started the collection.
 fn walk_guard_exc_value(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
     let exc = majit_metainterp::blackhole::GUARD_EXC_VALUE.with(|c| c.get());
     if exc == 0 {

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -3309,23 +3309,29 @@ fn walk_jit_exc_value(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
     // dangling inside the exception across the minor. Forward the raw child
     // slots explicitly, as the EC root walk does for `sys_exc_value`.
     //
-    // For a *managed* exception the explicit walk is belt-and-braces: minor is
-    // already covered by the remembered set, since every reference setter goes
-    // through `exception_write_barrier`, and major marking traces the type's
-    // registered pointer offsets. It is load-bearing only for exceptions that
-    // live outside the GC heap — the `malloc_typed` immortals such as the
-    // MemoryError singleton — where the write barrier and major seeding both
-    // ignore a non-managed holder, leaving this walker as the sole traversal
-    // of their children.
+    // For an off-GC exception — the `malloc_typed` immortals such as the
+    // MemoryError singleton, and the fallback taken when the GC allocation
+    // fails — this walk is the sole traversal of the children: both the write
+    // barrier and major seeding ignore a non-managed holder.
     //
-    // That asymmetry is why the carrier cannot be demoted to a plain
-    // shadow-stack entry (the direct analogue of the GC transform's rooted
-    // local, `shadowstack.py:31-39`): a generic root reaches an off-GC
-    // exception's fields through neither collection. Pushing the children
-    // individually does not substitute either — forwarding would rewrite the
-    // pushed copies, not the slots inside the exception. A walker with
-    // mutable access to the real slots is the only shape that works while the
-    // heap admits off-GC exception holders.
+    // For a GC-managed exception the picture is narrower but not empty. A
+    // major reaches the children on its own, through the type's registered
+    // pointer offsets. A minor reaches them only through the remembered set,
+    // which is exactly as complete as the barrier discipline over the twenty
+    // reference slots — and the sibling carriers keep this same explicit
+    // forwarding precisely because children built while tracing are not
+    // covered by it. Treat the walk as load-bearing for both populations
+    // until every store into a `W_BaseException` reference slot has been
+    // audited for a barrier; narrowing it to the off-GC family on the
+    // strength of the setters alone would reintroduce swept children.
+    //
+    // Either way the carrier cannot be demoted to a plain shadow-stack entry
+    // (the direct analogue of the GC transform's rooted local,
+    // `shadowstack.py:31-39`): a generic root reaches an off-GC exception's
+    // fields through neither collection, and pushing the children
+    // individually does not substitute — forwarding would rewrite the pushed
+    // copies, not the slots inside the exception. A walker with mutable
+    // access to the real slots is the only shape that works.
     unsafe {
         pyre_interpreter::eval::walk_raw_exception_roots(
             gcref.0 as pyre_object::PyObjectRef,

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -3318,12 +3318,20 @@ fn walk_jit_exc_value(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
     // major reaches the children on its own, through the type's registered
     // pointer offsets. A minor reaches them only through the remembered set,
     // which is exactly as complete as the barrier discipline over the twenty
-    // reference slots — and the sibling carriers keep this same explicit
-    // forwarding precisely because children built while tracing are not
-    // covered by it. Treat the walk as load-bearing for both populations
-    // until every store into a `W_BaseException` reference slot has been
-    // audited for a barrier; narrowing it to the off-GC family on the
-    // strength of the setters alone would reintroduce swept children.
+    // reference slots. That discipline has been audited and is not yet
+    // complete: the interpreter's slot writers all barrier
+    // (`exception_write_barrier` on every one), and a compiled SETFIELD_GC
+    // into a pointer field picks up a `COND_CALL_GC_WB` from the rewrite pass
+    // (`rewrite.py:930-931`, `:948-953`), but the blackhole's
+    // `bh_setfield_gc_r` / `bh_setinteriorfield_gc_r` store a reference with
+    // no barrier at all, where upstream's `write_ref_at_mem`
+    // (`llmodel.py:495-497`) gets one implicitly from the GC transform. A
+    // `w_context` or `w_traceback` written during a blackhole resume is
+    // therefore exactly the old-to-young edge the remembered set misses, so
+    // the walk stays load-bearing for both populations. Even once that gap
+    // closes, the coverage is a maintained invariant rather than a structural
+    // one — narrowing this walk to the off-GC family would make every future
+    // unbarriered exception-slot store a use-after-free instead of a leak.
     //
     // Either way the carrier cannot be demoted to a plain shadow-stack entry
     // (the direct analogue of the GC transform's rooted local,
@@ -3386,6 +3394,33 @@ fn walk_guard_exc_value(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
     };
 }
 
+/// Forward the GC-managed children of the immortal exception singletons.
+///
+/// `memory_error_singleton` and the per-kind `standard_exc_instance` reusable
+/// instances are `malloc_typed`, so `is_managed_heap_object` is false for them:
+/// a store into one of their reference slots takes no write barrier, and major
+/// seeding skips them, leaving the collector no path to the `args_w` /
+/// `w_traceback` a raise attaches. Upstream has no such hole — its
+/// `memory_error` (`compile.py:1090`) and the reusable prebuilt instances
+/// (`exceptiondata.py:34-38`) are ordinary prebuilt GC objects, which
+/// incminimark keeps in `prebuilt_root_objects` (`incminimark.py:355`) and
+/// traces on every major.
+///
+/// Forwarding per object rather than per carrier means the children stay live
+/// even when no raw carrier happens to be parked on the singleton.
+///
+/// This is presently latent rather than a live fix: the per-kind instances are
+/// materialized lazily by the `_ovf` direct-raise resolver, which the current
+/// walker-driven pipeline never reaches, and the MemoryError singleton is
+/// created only on an allocation failure. The enumeration reports only
+/// initialized slots, so with none created the walk costs a handful of
+/// `OnceLock` reads and visits nothing.
+fn walk_immortal_exception_singleton_roots(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
+    pyre_object::interp_exceptions::for_each_immortal_exception_singleton(|exc| unsafe {
+        pyre_interpreter::eval::walk_raw_exception_roots(exc, visitor)
+    });
+}
+
 /// Root PyPy's process-global `rbigint._parts_cache`. The object crate exposes
 /// its raw `_digits` slots without depending on majit-ir; this adapter performs
 /// the `GcRef` conversion and writes back a forwarded address.
@@ -3406,6 +3441,9 @@ fn install_gc_root_walkers() {
     majit_gc::shadow_stack::register_extra_root_walker(walk_bh_last_exc_value);
     majit_gc::shadow_stack::register_extra_root_walker(walk_guard_exc_value);
     majit_gc::shadow_stack::register_extra_root_walker(walk_rbigint_parts_cache);
+    // Children of the off-GC exception singletons, which no carrier and no
+    // collection phase reaches on its own.
+    majit_gc::shadow_stack::register_extra_root_walker(walk_immortal_exception_singleton_roots);
     // Stored `PyError` carriers whose GC refs the precise collector cannot
     // reach through their raw TLS cells: the call-assembler FFI stash and the
     // no-handler trace→portal stash. Mirrors `walk_pending_call_error`.

--- a/pyre/pyre-object/src/interp_exceptions.rs
+++ b/pyre/pyre-object/src/interp_exceptions.rs
@@ -1286,10 +1286,36 @@ pub unsafe fn w_exception_set_import_msg(obj: PyObjectRef, value: PyObjectRef) {
 /// GC-invisible `OnceLock` and baked into JIT constant pools, so it must
 /// stay immortal (`w_exception_new_empty_immortal`), never GC-swept.
 pub fn memory_error_singleton() -> PyObjectRef {
-    static MEMORY_ERROR_SINGLETON: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
     *MEMORY_ERROR_SINGLETON
         .get_or_init(|| w_exception_new_empty_immortal(ExcKind::MemoryError) as usize)
         as PyObjectRef
+}
+
+static MEMORY_ERROR_SINGLETON: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+
+static STANDARD_EXC_INSTANCES: [std::sync::OnceLock<usize>; EXC_KIND_COUNT] =
+    [const { std::sync::OnceLock::new() }; EXC_KIND_COUNT];
+
+/// Visit every immortal exception singleton that has actually been created.
+///
+/// The singletons themselves are `malloc_typed` and outlive every collection,
+/// but the `args_w` / `w_traceback` / `w_context` a raise attaches to them are
+/// ordinary GC-managed objects. Because the holder is not managed, neither the
+/// write barrier nor major seeding reaches those children, so they survive only
+/// while some raw carrier happens to be parked on the singleton. Enumerating
+/// them here lets a root walker forward the children per object instead.
+///
+/// Only initialized slots are reported — reading through `get()` never forces
+/// an allocation, which must not happen from inside a collection.
+pub fn for_each_immortal_exception_singleton(mut visit: impl FnMut(PyObjectRef)) {
+    if let Some(&raw) = MEMORY_ERROR_SINGLETON.get() {
+        visit(raw as PyObjectRef);
+    }
+    for slot in STANDARD_EXC_INSTANCES.iter() {
+        if let Some(&raw) = slot.get() {
+            visit(raw as PyObjectRef);
+        }
+    }
 }
 
 /// `rpython/rtyper/exceptiondata.py:34-38 get_standard_ll_exc_instance`
@@ -1305,9 +1331,7 @@ pub fn memory_error_singleton() -> PyObjectRef {
 /// Same `OnceLock<usize>` escape hatch as `memory_error_singleton`
 /// because `PyObjectRef` is neither `Send` nor `Sync`.
 pub fn standard_exc_instance(kind: ExcKind) -> PyObjectRef {
-    static INSTANCES: [std::sync::OnceLock<usize>; EXC_KIND_COUNT] =
-        [const { std::sync::OnceLock::new() }; EXC_KIND_COUNT];
-    let slot = &INSTANCES[kind as u8 as usize];
+    let slot = &STANDARD_EXC_INSTANCES[kind as u8 as usize];
     *slot.get_or_init(|| w_exception_new_empty_immortal(kind) as usize) as PyObjectRef
 }
 
@@ -1652,6 +1676,39 @@ mod tests {
             assert!(is_exception(overflow_a));
             assert_eq!(w_exception_get_kind(overflow_a), ExcKind::OverflowError);
             assert_eq!(w_exception_get_kind(zerodiv), ExcKind::ZeroDivisionError);
+        }
+    }
+
+    #[test]
+    fn immortal_singleton_enumeration_reports_created_and_forces_none() {
+        // The root walker forwards each reported singleton's reference slots,
+        // so the enumeration must cover every singleton that exists — and must
+        // never itself create one, since it runs from inside a collection.
+        let mem = memory_error_singleton();
+        let key = standard_exc_instance(ExcKind::KeyError);
+
+        let mut seen = Vec::new();
+        for_each_immortal_exception_singleton(|exc| seen.push(exc as usize));
+        assert!(
+            seen.contains(&(mem as usize)),
+            "MemoryError singleton must be reported once created"
+        );
+        assert!(
+            seen.contains(&(key as usize)),
+            "per-kind singleton must be reported once created"
+        );
+        assert!(
+            seen.len() <= EXC_KIND_COUNT + 1,
+            "enumeration is bounded by the per-kind slots plus MemoryError"
+        );
+
+        // Enumerating must not initialize a slot: a second pass reports the
+        // same set, and every reported pointer is a real exception object.
+        let mut again = Vec::new();
+        for_each_immortal_exception_singleton(|exc| again.push(exc as usize));
+        assert_eq!(seen, again, "enumeration must not create singletons");
+        for &raw in &again {
+            assert!(unsafe { is_exception(raw as PyObjectRef) });
         }
     }
 


### PR DESCRIPTION
Follow-ups to the guard-exception rooting work, plus one jitcode-layer deletion.

## Consultation outcome: the TLS carrier is the right port

Three independent reviews (one `codex`, two advisors) were asked whether
`GuardExcRoot`'s thread-local carrier could be replaced by something more
orthodox at no performance cost. All three returned the same verdict: **no**,
and the current design is the correct port.

Upstream roots this value with two mechanisms pyre structurally cannot have —
a GC-object jitframe (`jitframe_trace` traces `jf_guard_exc`) and a
transform-rooted local (`shadowstack.py:31-40`). Of the two hand-rolled
emulations available, only the custom-traced TLS cell can also express pyre's
off-GC exception population. Thread-local storage is not a concession either:
upstream keeps one shadow stack *per thread* (`shadowstack.py:140-216`, a
`{tid: SHADOWSTACKREF}` map) and enumerates every thread's block at collection
time (`rthread.py:428-444 _trace_tlref`) — which is exactly this cell plus the
per-mutator root area.

A `shadow_stack::push` swap was rejected on coverage, not taste: pushing the
twenty children individually cannot substitute for the walker, because
forwarding rewrites the *pushed copies* rather than the slots inside the
exception.

## The barrier audit, and its result

The walker's child forwarding was claimed here to be redundant for GC-managed
exceptions. That claim was wrong and is retracted in this branch. Auditing
every store into a `W_BaseException` reference slot found three paths, one of
them unbarriered:

| path | barriered |
|---|---|
| interpreter slot writers (all twenty) | yes — `exception_write_barrier` on every store |
| compiled `SETFIELD_GC` into a pointer field | yes — `COND_CALL_GC_WB` from the rewrite pass (`rewrite.py:930-931`, `:948-953`) |
| blackhole `bh_setfield_gc_r` / `bh_setinteriorfield_gc_r` | **no** — a raw store, where upstream's `write_ref_at_mem` (`llmodel.py:495-497`) takes one implicitly from the GC transform |

A `w_context` or `w_traceback` written during a blackhole resume is therefore
exactly the old-to-young edge the remembered set misses, so the walk stays
load-bearing for both populations. **That gap is not fixed here** — #796
already carries the fix for both sites, and duplicating it would only conflict.

## Off-GC singleton children

`memory_error_singleton` and the per-kind `standard_exc_instance` instances are
`malloc_typed`, so no barrier records a store into them and major seeding skips
them: their `args_w` / `w_traceback` survive only while some raw carrier is
parked on the singleton. Upstream has no equivalent hole — `memory_error`
(`compile.py:1090`) and the reusable prebuilt instances
(`exceptiondata.py:34-38`) are prebuilt GC objects traced from
`prebuilt_root_objects` (`incminimark.py:355`) on every major.

The two `OnceLock` stores move to module scope, an enumerator reports only the
*initialized* ones, and a root walker forwards each singleton's slots per
object rather than per carrier.

**This is latent as landed.** The per-kind instances are materialized by the
`_ovf` direct-raise resolver, which the current walker-driven pipeline never
reaches, and the MemoryError singleton appears only on an allocation failure.
With no slot initialized the walk reads a handful of `OnceLock`s and visits
nothing. Because end-to-end runs therefore cannot discriminate, the added unit
test is the real check: a created singleton is reported, the enumeration is
bounded, and enumerating never initializes a slot — which would allocate
inside a collection.

## Also here

- **`grab_exc_value` attribution.** Five comments described it as read+clear.
  Upstream is a pure read (`llmodel.py:240-242`); clearing `jf_guard_exc`
  belongs to emitted code (`_restore_exception`, x86/`assembler.py:1855-1857`)
  and zeroing the exception globals to `_store_and_reset_exception`
  (`:1838`, `:1847-1848`). Each pyre clear now names the upstream site it
  actually corresponds to, and the two pyre-only clears are marked as such.
- **`LivenessInfo` deleted.** A per-PC `(live_i, live_r, live_f)` side table
  documented as a temporary shape kept alongside the packed form, with no
  readers: the type, its `total_live()`, and one re-export were its only three
  references in the workspace. Liveness already flows through the canonical
  packed `MetaInterpStaticData.liveness_info` (`pyjitpl.py:2264`), and the
  canonical `JitCode` stores no liveness field. Four doc comments left as
  `of:` sentence fragments are repaired in the same commit.
- **CA guard-failure root pair.** `handle_fail_resume_guard` roots the grabbed
  exception with `gc_add_root`/`gc_remove_root` while the blackhole receiver
  parks the same value, so it is rooted twice in sequence. Collapsing the pair
  is unreachable from that crate — it does not depend on `majit-metainterp`,
  and `BridgeFn` does not carry the exception — so both blockers are noted at
  the site rather than worked around.

## Verification

- workspace `cargo check` and `cargo fmt --check` clean
- pyre-object + majit-metainterp: 1774 tests pass
- release dynasm binary, exception-heavy script reading `args` / `__context__`
  / `__traceback__` across collections: clean under the default configuration,
  under `PYRE_GC_INTERP_COLLECT`, and under `MAJIT_GC_STRESS`
- LLBC re-extracted after the rebase onto current `main`

The corpus gate (`check.py`) has not been run locally; CI covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
