### PR TITLE
jit(gh#346): residualize importing::check_sys_modules via the runtime-mutable-global accessor

### DIFF
--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -1394,6 +1394,13 @@ pub fn add_sys_path_0() {
 // ── check_sys_modules ────────────────────────────────────────────────
 // PyPy equivalent: importing.py `check_sys_modules(space, w_modulename)`
 
+/// Reads the process-owned `SYS_MODULES` registry (and the runtime-stamped
+/// `sys.modules` dict through `sys_modules_dict`), neither a build-time
+/// constant, so the JIT residualizes the call rather than folding a stale
+/// `sys.modules` snapshot (`@dont_look_inside`, the `sys_modules_dict` /
+/// `lookup_exc_class` shape).  The `Option<PyObjectRef>` return fits one word
+/// and the `&str` argument matches `lookup_exc_class`.
+#[majit_macros::dont_look_inside]
 pub(crate) fn check_sys_modules(name: &str) -> Option<PyObjectRef> {
     // Consult the Python-visible sys.modules dict first so that user code
     // writing `sys.modules['foo'] = mod` is immediately visible to imports.

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -906,7 +906,8 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
     // globals: `sys_modules_dict` reads the `SYS_MODULES_DICT` pointer
     // `set_sys_modules_dict` stamps, `set_in_flight_exception` writes the
     // `IN_FLIGHT_EXCEPTION` thread-local, `lookup_exc_class` reads the
-    // `EXC_CLASS_REGISTRY` `OnceLock`, `mmap_type` the lazily-installed
+    // `EXC_CLASS_REGISTRY` `OnceLock`, `check_sys_modules` the process-owned
+    // `SYS_MODULES` registry, `mmap_type` the lazily-installed
     // `mmap` type object, and the two `note_eval_activation_*` twins move the
     // `EVAL_NESTING` thread-local `at_outermost_activation` already reads.
     // None is a build-time constant, so each carries `#[dont_look_inside]`
@@ -934,6 +935,14 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         "pyre_interpreter::builtins::lookup_exc_class",
         "pyre_interpreter::lookup_exc_class",
         lookup_exc_class as *const (),
+    );
+    let check_sys_modules: fn(&str) -> Option<pyre_object::PyObjectRef> =
+        crate::importing::check_sys_modules;
+    push_alias_pair(
+        &mut entries,
+        "pyre_interpreter::importing::check_sys_modules",
+        "pyre_interpreter::check_sys_modules",
+        check_sys_modules as *const (),
     );
     // `mmap_type` is `#[cfg(unix)]` inside `interp_mmap`, and the `mmap`
     // module itself is gated at `module/mod.rs:80`; the row has to carry


### PR DESCRIPTION
## gh#346 slice — runtime-mutable-global accessor axis

`check_sys_modules` reads two runtime-mutable globals — the process-owned
`SYS_MODULES` registry and the runtime-stamped `sys.modules` dict (through the
already-`#[dont_look_inside]` `sys_modules_dict`) — neither a build-time
constant. Left foldable, the two-phase rtyper prepass fails to annotate the
folded call and drops each referencing graph to the legacy walker.

This marks `check_sys_modules` `#[majit_macros::dont_look_inside]` and registers
its address in `jit_trace_fnaddrs` through `push_alias_pair` with the
`fn(&str) -> Option<PyObjectRef>` residual shape — the exact `lookup_exc_class`
row (single-word null-niche return, validated `&str` argument). The prepass
then emits a residual call instead of a failed fold.

### Census (A/B, base = 2580479628)

| `[PREPASS … fail]` | base | after | Δ |
|---|---|---|---|
| phaseA heads | 314 | **311** | −3 |
| phaseB heads | 24 | 24 | 0 (identical by function identity) |

Cleared, with no new/regenerated heads:
- `pyre_interpreter::importing::check_sys_modules` (direct)
- `pyre_interpreter::importing::get_sys_module` (delegates to it)
- `pyre_object::dictmultiobject::w_dict_lookup` (the dict lookup reached through the `sys.modules` fold)

### Orthodoxy

Same validated mechanism as the sibling global-read residuals already on this
branch's ancestry (`#832`): a runtime-mutable global read is not a build-time
constant, so the JIT residualizes the accessor rather than folding a stale
snapshot. No new mechanism, no perf lever.

### Gates

- check.py green on all three backends: **dynasm 328/328, cranelift 328/328, wasm 325/325** (vs python3.14 + pypy3.11 oracles).
- `cargo fmt` clean; extract + prepass build exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime handling of module state to ensure changes to loaded modules are recognized correctly.
  * Prevented stale module information from being reused during just-in-time execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->