### PR TITLE
_ast: convert every node kind back from an ast object, and walk it through validate_ast before compiling

### DIFF
--- a/pyre/bench/synth/ast_compile_roundtrip.py
+++ b/pyre/bench/synth/ast_compile_roundtrip.py
@@ -147,6 +147,7 @@ def handbuilt():
         kw_defaults=kw.get("kd", []), defaults=kw.get("d", []))
     pat = lambda p: ast.Match(subject=ast.Constant(1),
                               cases=[ast.match_case(pattern=p, body=[ast.Pass()])])
+
     for label, node in (
         ("missing-conversion", ast.JoinedStr(values=[
             without(ast.FormattedValue(value=name, conversion=-1), "conversion")])),
@@ -207,6 +208,12 @@ def handbuilt():
                                            type_ignores=[])),
         ("match-value-bad-constant", ast.Module(body=[pat(ast.MatchValue(
             value=ast.Constant(value=None)))], type_ignores=[])),
+        # Only trees the two oracles agree on belong here: every backend's
+        # output is compared byte for byte against PyPy's. Where 3.14 and PyPy
+        # disagree the check lives in `astcompiler::validate`'s own tests.
+        ("match-mapping-store-key", ast.Module(body=[pat(ast.MatchMapping(
+            keys=[ast.Attribute(value=ast.Name("o", S), attr="a", ctx=ast.Load())],
+            patterns=[ast.MatchAs(pattern=None, name="v")], rest=None))], type_ignores=[])),
     ):
         tree = node if isinstance(node, ast.Module) else ast.Expression(body=node)
         try:

--- a/pyre/bench/synth/ast_compile_roundtrip.py
+++ b/pyre/bench/synth/ast_compile_roundtrip.py
@@ -1,0 +1,127 @@
+# compile() accepts an `ast` tree as well as source text, and the two must
+# produce the same code. Each source below is compiled both ways and executed,
+# and the outputs are folded together, so a statement or expression kind that
+# the tree path converts wrongly -- or silently drops, as a decorator list read
+# as empty would -- changes the number.
+# The tree path is also the only one that sees hand-built nodes, so the cases
+# cover the shapes a parser never emits: a missing optional field, a container
+# constant, and `orelse` chains that a parser would have written as `elif`.
+# Syntax is held to what every compared runtime parses. Output verified against
+# CPython/PyPy.
+import ast
+
+SOURCES = (
+    ("assign", "x = 1\ny = x + 1\nprint(x, y, x < y <= 2, x is not None)"),
+    ("augassign", "x = 1\nx += 4\nx *= 2\nx //= 3\nprint(x)"),
+    ("annassign", "x: int = 5\ndef f():\n    y: int\n    return x\nprint(x, f())"),
+    ("delete", "d = {'k': 1}\ndel d['k']\nprint(d)"),
+    ("ifchain", "for i in range(4):\n    if i == 0:\n        print('zero')\n    elif i == 1:\n        print('one')\n    elif i == 2:\n        print('two')\n    else:\n        print('many')"),
+    ("loops", "i = 0\nwhile i < 3:\n    i += 1\nelse:\n    print('while-else', i)\nfor j in range(5):\n    if j == 2:\n        break\nelse:\n    print('unreached')\nprint('j', j)\nfor k in range(2):\n    continue\nelse:\n    print('for-else', k)"),
+    ("try", "try:\n    raise ValueError('v')\nexcept KeyError:\n    print('no')\nexcept ValueError as e:\n    print('caught', e)\nelse:\n    print('no else')\nfinally:\n    print('finally')\ntry:\n    1 / 0\nexcept:\n    print('bare')"),
+    ("trystar", "try:\n    raise ExceptionGroup('g', [ValueError('a'), TypeError('b')])\nexcept* ValueError as e:\n    print('star-v', len(e.exceptions))\nexcept* TypeError as e:\n    print('star-t', len(e.exceptions))"),
+    ("raise_from", "try:\n    try:\n        raise KeyError('k')\n    except KeyError as e:\n        raise ValueError('v') from e\nexcept ValueError as e:\n    print('cause', type(e.__cause__).__name__)"),
+    ("assert", "assert 1 == 1\ntry:\n    assert 0, 'boom'\nexcept AssertionError as e:\n    print('assert', e)"),
+    ("with", "import io\nwith io.StringIO('a') as f, io.StringIO('b') as g:\n    print(f.read(), g.read())"),
+    ("imports", "import sys\nimport sys as alias\nfrom sys import path\nfrom sys import path as p\nprint(type(path) is list, p is path, alias is sys)"),
+    ("scopes", "g = 0\ndef setg():\n    global g\n    g = 7\nsetg()\ndef outer():\n    v = 1\n    def inner():\n        nonlocal v\n        v = 9\n    inner()\n    return v\nprint(g, outer())"),
+    ("funcargs", "def f(a, b, /, c, d=4, *rest, e, g=7, **kw):\n    return (a, b, c, d, rest, e, g, sorted(kw.items()))\nprint(f(1, 2, 3))\nprint(f(1, 2, 3, 4, 5, 6, e=7, h=8))"),
+    ("decorators", "def deco(tag):\n    def wrap(fn):\n        def call(*a):\n            return tag + ':' + str(fn(*a))\n        return call\n    return wrap\n@deco('x')\n@deco('y')\ndef f(v):\n    return v\nprint(f(3))"),
+    ("annotations", "def f(a: int, b: str = 'x') -> bool:\n    return True\nprint(f(1), sorted(f.__annotations__))"),
+    ("classes", "def tag(cls):\n    cls.t = 'T'\n    return cls\nclass A:\n    def m(self):\n        return 'A'\n@tag\nclass B(A):\n    def m(self):\n        return 'B' + super().m()\nprint(B().m(), B.t, B.__mro__[1].__name__)"),
+    ("lambdas", "f = lambda a, b=2, *r, k=3, **kw: (a, b, r, k, sorted(kw))\nprint(f(1), f(1, 5, 6, k=7, z=8))"),
+    ("boolops", "print(1 and 2, 0 or 3, 1 and 0 or 4, not 0, 'a' in 'abc', 'z' not in 'abc')"),
+    ("ifexp", "print(['no', 'yes'][1], 'yes' if 1 else 'no', (lambda v: 'p' if v > 0 else 'n')(-1))"),
+    ("namedexpr", "print([y := 3, y + 1], y)"),
+    ("containers", "a = {'x': 1}\nd = {**a, 'y': 2}\nprint(sorted(d.items()), sorted({3, 1, 2}), [1, 2][::-1], (1, 2, 3)[1:])"),
+    ("comprehensions", "print([i * i for i in range(5) if i % 2 == 0])\nprint(sorted({i % 3 for i in range(7)}))\nprint(sorted({i: i * 2 for i in range(3)}.items()))\nprint(sum(i for i in range(5) if i != 2))\nprint([(i, j) for i in range(2) for j in range(2) if i != j])"),
+    ("generators", "def g():\n    x = yield 1\n    yield x\ndef outer():\n    yield from g()\n    yield 'end'\nit = outer()\nprint(next(it))\nprint(it.send(5))\nprint(next(it))"),
+    ("subscripts", "s = list(range(10))\nprint(s[2], s[1:4], s[::2], s[::-1], s[1:8:3])\ns[0] = 99\ns[1:3] = [7, 8]\ndel s[9]\nprint(s)"),
+    ("starred", "a, *rest = [1, 2, 3]\n(b, (c, d)) = (1, (2, 3))\nargs = [1, 2]\nprint(a, rest, b, c, d, max(*args), [*args, 3])"),
+    ("match", "def f(v):\n    match v:\n        case 0:\n            return 'zero'\n        case [1, 2]:\n            return 'onetwo'\n        case [1, *tail]:\n            return 'head1 ' + str(tail)\n        case {'k': val, **extra}:\n            return 'map ' + str(val) + str(sorted(extra))\n        case str() as s if len(s) > 1:\n            return 'str ' + s\n        case (int() | float()) as n:\n            return 'num ' + str(n)\n        case None:\n            return 'none'\n        case _:\n            return 'other'\nfor v in (0, [1, 2], [1, 5, 6], {'k': 9, 'z': 1}, 'hi', 4.5, None, object):\n    print(f(v))"),
+    ("matchclass", "class P:\n    __match_args__ = ('x', 'y')\n    def __init__(self, x, y):\n        self.x, self.y = x, y\ndef f(p):\n    match p:\n        case P(0, y=b):\n            return 'originx ' + str(b)\n        case P(a, b):\n            return 'point ' + str(a + b)\nprint(f(P(0, 5)), f(P(2, 3)))"),
+    ("constants", "print(1, 1.5, 'a', b'b', True, False, None, ..., 3 + 4j, -0.0, 10 ** 30)"),
+)
+
+
+def fold(acc, value):
+    for ch in str(value):
+        acc = (acc * 31 + ord(ch)) & 0xFFFFFFFF
+    return acc
+
+
+def run(code, out):
+    ns = {"__name__": "__main__", "_out": out}
+    exec("def _p(*a):\n    _out.append(' '.join(str(x) for x in a))\n", ns)
+    ns["print"] = ns["_p"]
+    try:
+        exec(code, ns)
+    except BaseException as e:
+        out.append("!!" + type(e).__name__ + ":" + str(e))
+    return out
+
+
+def both_ways(src):
+    # Same source, two compile paths; the outputs have to match each other.
+    direct = run(compile(src, "<s>", "exec"), [])
+    viaast = run(compile(ast.parse(src), "<s>", "exec"), [])
+    assert direct == viaast, (direct, viaast)
+    return direct
+
+
+def handbuilt():
+    # Shapes the parser never produces, so only the tree path can reach them.
+    out = []
+    # An `If` whose alternative is a nested `If`: the parser would have written
+    # `elif`, and both have to compile to the same branch chain.
+    tree = ast.parse("if a == 1:\n    print('one')\nelse:\n    print('other')")
+    inner = ast.parse("if a == 2:\n    print('two')\nelse:\n    print('many')").body[0]
+    tree.body[0].orelse = [inner]
+    ast.fix_missing_locations(tree)
+    code = compile(tree, "<s>", "exec")
+    for a in (1, 2, 3):
+        ns = {"a": a, "_out": out}
+        exec("def _p(*x):\n    _out.append(' '.join(str(v) for v in x))\n", ns)
+        ns["print"] = ns["_p"]
+        exec(code, ns)
+    # Optional fields left off a hand-built node.
+    tree = ast.parse("def f():\n    return 1")
+    tree.body[0].body = [ast.Return()]
+    ast.fix_missing_locations(tree)
+    ns = {}
+    exec(compile(tree, "<s>", "exec"), ns)
+    out.append("bare-return " + str(ns["f"]()))
+    # Container and complex constants, which no parser emits.
+    for value in ((1, "a", 2.5), (1, (2, 3)), frozenset({1, 2}), 3 + 4j, ()):
+        tree = ast.parse("x = 0")
+        tree.body[0].value = ast.Constant(value=value)
+        ast.fix_missing_locations(tree)
+        ns = {}
+        exec(compile(tree, "<s>", "exec"), ns)
+        got = ns["x"]
+        shown = sorted(got) if isinstance(got, frozenset) else got
+        out.append("const " + type(got).__name__ + " " + str(shown) + " " + str(got == value))
+    return out
+
+
+def warm(reps):
+    # The conversion runs per compile, so keep the hot path the traced one.
+    src = "def f(a, b=2, *r, k=3):\n    if a > b:\n        return a - b\n    return sum(i for i in range(a) if i != b)"
+    acc = 0
+    for _ in range(reps):
+        acc += len(compile(ast.parse(src), "<s>", "exec").co_names)
+    return acc
+
+
+def main():
+    print("warm", warm(200))
+    acc = 0
+    for name, src in SOURCES:
+        lines = both_ways(src)
+        for line in lines:
+            acc = fold(acc, line)
+        print(name, len(lines), acc)
+    for line in handbuilt():
+        print("hand", line)
+
+
+main()

--- a/pyre/bench/synth/ast_compile_roundtrip.py
+++ b/pyre/bench/synth/ast_compile_roundtrip.py
@@ -40,6 +40,8 @@ SOURCES = (
     ("match", "def f(v):\n    match v:\n        case 0:\n            return 'zero'\n        case [1, 2]:\n            return 'onetwo'\n        case [1, *tail]:\n            return 'head1 ' + str(tail)\n        case {'k': val, **extra}:\n            return 'map ' + str(val) + str(sorted(extra))\n        case str() as s if len(s) > 1:\n            return 'str ' + s\n        case (int() | float()) as n:\n            return 'num ' + str(n)\n        case None:\n            return 'none'\n        case _:\n            return 'other'\nfor v in (0, [1, 2], [1, 5, 6], {'k': 9, 'z': 1}, 'hi', 4.5, None, object):\n    print(f(v))"),
     ("matchclass", "class P:\n    __match_args__ = ('x', 'y')\n    def __init__(self, x, y):\n        self.x, self.y = x, y\ndef f(p):\n    match p:\n        case P(0, y=b):\n            return 'originx ' + str(b)\n        case P(a, b):\n            return 'point ' + str(a + b)\nprint(f(P(0, 5)), f(P(2, 3)))"),
     ("constants", "print(1, 1.5, 'a', b'b', True, False, None, ..., 3 + 4j, -0.0, 10 ** 30)"),
+    ("fstrings", "x, w = 5, 8\nprint(f'', f'plain', f'a{x}b', f'{x}{x}')\nprint(f'{x!r} {x!s} {x!a}')\nprint(f'{x:05d}|{x:>8}|{x:+.3f}|{x:>{w}}|{x:0{w}d}')\nprint(f'{x!r:>10}', f'{{literal}} {x}')"),
+    ("fstring_nesting", "x = 3\nd = {'k': [1, 2]}\nprint(f'{f\"{x}\"}', f'{d[\"k\"][1] + 1}', f'{len(\"abc\")}')\nprint(f'a' 'b' f'{x}' 'c')\nprint(f'{x=}', f'{x = }', f'{x=:04d}', f'{x=!r}')\ndef g(v):\n    return f'<{v!r}>'\nprint(g(1), g('s'), [f'{i}:{i * i}' for i in range(3)])"),
 )
 
 
@@ -100,6 +102,59 @@ def handbuilt():
         got = ns["x"]
         shown = sorted(got) if isinstance(got, frozenset) else got
         out.append("const " + type(got).__name__ + " " + str(shown) + " " + str(got == value))
+    # An f-string reaches the tree path as the values it joins, not as the
+    # literal and interpolated parts the parser split it into, so the shapes
+    # below only exist here: no values at all, a lone `FormattedValue`, a
+    # nested `JoinedStr`, and a spec that is itself formatted.
+    name = ast.Name("x", ast.Load())
+    for label, node in (
+        ("empty", ast.JoinedStr(values=[])),
+        ("const", ast.JoinedStr(values=[ast.Constant("ab")])),
+        ("lone-fv", ast.FormattedValue(value=name, conversion=-1)),
+        ("fv-repr", ast.FormattedValue(value=name, conversion=114)),
+        ("fv-str", ast.FormattedValue(value=name, conversion=115)),
+        ("fv-ascii", ast.FormattedValue(value=ast.Constant("\xe9"), conversion=97)),
+        ("mixed", ast.JoinedStr(values=[
+            ast.Constant("a"), ast.FormattedValue(value=name, conversion=-1), ast.Constant("b")])),
+        ("spec", ast.JoinedStr(values=[ast.FormattedValue(
+            value=name, conversion=-1,
+            format_spec=ast.JoinedStr(values=[ast.Constant("07.2f")]))])),
+        ("spec-formatted", ast.JoinedStr(values=[ast.FormattedValue(
+            value=name, conversion=-1,
+            format_spec=ast.JoinedStr(values=[
+                ast.Constant(">"),
+                ast.FormattedValue(value=ast.Name("w", ast.Load()), conversion=-1)]))])),
+        ("nested", ast.JoinedStr(values=[
+            ast.JoinedStr(values=[ast.FormattedValue(value=name, conversion=-1)]),
+            ast.Constant("!")])),
+        ("non-str-const", ast.JoinedStr(values=[ast.Constant(1)])),
+    ):
+        tree = ast.Expression(body=node)
+        ast.fix_missing_locations(tree)
+        out.append("fstring " + label + " " + repr(eval(compile(tree, "<s>", "eval"),
+                                                       {"x": 42.5, "w": 9})))
+    # Only the class is compared: the wording differs between runtimes.
+    def without(node, field):
+        # Dropped after construction rather than left off it, which warns.
+        delattr(node, field)
+        return node
+
+    for label, node in (
+        ("missing-conversion", ast.JoinedStr(values=[
+            without(ast.FormattedValue(value=name, conversion=-1), "conversion")])),
+        ("missing-value", ast.JoinedStr(values=[
+            without(ast.FormattedValue(value=name, conversion=-1), "value")])),
+        ("values-not-a-list", ast.JoinedStr(values=ast.Constant("a"))),
+        ("none-in-values", ast.JoinedStr(values=[None])),
+        ("none-in-body", ast.Module(body=[None], type_ignores=[])),
+    ):
+        tree = node if isinstance(node, ast.Module) else ast.Expression(body=node)
+        try:
+            ast.fix_missing_locations(tree)
+            compile(tree, "<s>", "exec" if isinstance(node, ast.Module) else "eval")
+            out.append("reject " + label + " none")
+        except BaseException as e:
+            out.append("reject " + label + " " + type(e).__name__)
     return out
 
 

--- a/pyre/bench/synth/ast_compile_roundtrip.py
+++ b/pyre/bench/synth/ast_compile_roundtrip.py
@@ -139,6 +139,14 @@ def handbuilt():
         delattr(node, field)
         return node
 
+    # A tree the parser could never have produced. Only the class is compared:
+    # the wording differs between runtimes.
+    L, S, D = ast.Load(), ast.Store(), ast.Del()
+    args = lambda **kw: ast.arguments(
+        posonlyargs=kw.get("po", []), args=kw.get("a", []), kwonlyargs=kw.get("ko", []),
+        kw_defaults=kw.get("kd", []), defaults=kw.get("d", []))
+    pat = lambda p: ast.Match(subject=ast.Constant(1),
+                              cases=[ast.match_case(pattern=p, body=[ast.Pass()])])
     for label, node in (
         ("missing-conversion", ast.JoinedStr(values=[
             without(ast.FormattedValue(value=name, conversion=-1), "conversion")])),
@@ -147,6 +155,58 @@ def handbuilt():
         ("values-not-a-list", ast.JoinedStr(values=ast.Constant("a"))),
         ("none-in-values", ast.JoinedStr(values=[None])),
         ("none-in-body", ast.Module(body=[None], type_ignores=[])),
+        ("more-defaults-than-args", ast.Lambda(
+            args=args(d=[ast.Constant(1), ast.Constant(2)]), body=ast.Constant(1))),
+        ("kw-defaults-length", ast.Lambda(
+            args=args(ko=[ast.arg(arg="a"), ast.arg(arg="b")], kd=[ast.Constant(1)]),
+            body=ast.Constant(1))),
+        ("compare-no-comparators", ast.Compare(left=ast.Constant(1), ops=[], comparators=[])),
+        ("compare-ops-mismatch", ast.Compare(left=ast.Constant(1), ops=[ast.Lt()], comparators=[])),
+        ("boolop-one-value", ast.BoolOp(op=ast.And(), values=[ast.Constant(1)])),
+        ("boolop-no-values", ast.BoolOp(op=ast.And(), values=[])),
+        ("comprehension-no-generators", ast.ListComp(elt=ast.Constant(1), generators=[])),
+        ("named-target-not-name", ast.NamedExpr(target=ast.Constant(1), value=ast.Constant(1))),
+        ("name-is-a-constant", ast.Name("None", L)),
+        ("store-in-load-position", ast.Name("x", S)),
+        ("empty-body-functiondef", ast.Module(body=[ast.FunctionDef(
+            name="f", args=args(), body=[], decorator_list=[], type_params=[])], type_ignores=[])),
+        ("empty-body-classdef", ast.Module(body=[ast.ClassDef(
+            name="C", bases=[], keywords=[], body=[], decorator_list=[], type_params=[])],
+            type_ignores=[])),
+        ("empty-targets-assign", ast.Module(body=[ast.Assign(targets=[], value=ast.Constant(1))],
+                                            type_ignores=[])),
+        ("load-target-assign", ast.Module(body=[ast.Assign(targets=[ast.Name("x", L)],
+                                                           value=ast.Constant(1))],
+                                          type_ignores=[])),
+        ("load-target-delete", ast.Module(body=[ast.Delete(targets=[ast.Name("x", L)])],
+                                          type_ignores=[])),
+        ("empty-names-import", ast.Module(body=[ast.Import(names=[])], type_ignores=[])),
+        ("negative-import-level", ast.Module(body=[ast.ImportFrom(
+            module="x", names=[ast.alias(name="y")], level=-1)], type_ignores=[])),
+        ("raise-cause-no-exc", ast.Module(body=[ast.Raise(exc=None, cause=ast.Name("x", L))],
+                                          type_ignores=[])),
+        ("try-without-handlers", ast.Module(body=[ast.Try(
+            body=[ast.Pass()], handlers=[], orelse=[], finalbody=[])], type_ignores=[])),
+        ("empty-except-body", ast.Module(body=[ast.Try(body=[ast.Pass()], handlers=[
+            ast.ExceptHandler(type=None, name=None, body=[])], orelse=[], finalbody=[])],
+            type_ignores=[])),
+        ("empty-items-with", ast.Module(body=[ast.With(items=[], body=[ast.Pass()])],
+                                        type_ignores=[])),
+        ("empty-cases-match", ast.Module(body=[ast.Match(subject=ast.Constant(1), cases=[])],
+                                         type_ignores=[])),
+        ("match-or-one-pattern", ast.Module(body=[pat(ast.MatchOr(
+            patterns=[ast.MatchValue(value=ast.Constant(1))]))], type_ignores=[])),
+        ("match-star-alone", ast.Module(body=[pat(ast.MatchStar(name="a"))], type_ignores=[])),
+        ("match-as-no-name", ast.Module(body=[pat(ast.MatchAs(
+            pattern=ast.MatchValue(value=ast.Constant(1)), name=None))], type_ignores=[])),
+        ("match-capture-underscore", ast.Module(body=[pat(ast.MatchAs(
+            pattern=ast.MatchValue(value=ast.Constant(1)), name="_"))], type_ignores=[])),
+        ("match-class-bad-cls", ast.Module(body=[pat(ast.MatchClass(
+            cls=ast.Constant(1), patterns=[], kwd_attrs=[], kwd_patterns=[]))], type_ignores=[])),
+        ("match-singleton-bad", ast.Module(body=[pat(ast.MatchSingleton(value=42))],
+                                           type_ignores=[])),
+        ("match-value-bad-constant", ast.Module(body=[pat(ast.MatchValue(
+            value=ast.Constant(value=None)))], type_ignores=[])),
     ):
         tree = node if isinstance(node, ast.Module) else ast.Expression(body=node)
         try:

--- a/pyre/pyre-interpreter/src/astcompiler/mod.rs
+++ b/pyre/pyre-interpreter/src/astcompiler/mod.rs
@@ -1,0 +1,5 @@
+//! `pypy/interpreter/astcompiler/` — the passes that stand between an AST and
+//! a code object.  Parsing and code generation come from the RustPython
+//! compiler crates; what lives here is what has no counterpart there.
+
+pub mod validate;

--- a/pyre/pyre-interpreter/src/astcompiler/validate.rs
+++ b/pyre/pyre-interpreter/src/astcompiler/validate.rs
@@ -180,6 +180,7 @@ impl AstValidator {
             }
             ast::Stmt::TypeAlias(node) => {
                 self.validate_expr(&node.name, ast::ExprContext::Store)?;
+                self.validate_type_params(node.type_params.as_deref())?;
                 self.validate_expr(&node.value, ast::ExprContext::Load)
             }
             ast::Stmt::For(node) => {
@@ -267,6 +268,7 @@ impl AstValidator {
             "FunctionDef"
         };
         self.validate_body(&node.body, owner)?;
+        self.validate_type_params(node.type_params.as_deref())?;
         self.visit_parameters(&node.parameters)?;
         self.validate_decorators(&node.decorator_list)?;
         match &node.returns {
@@ -277,6 +279,7 @@ impl AstValidator {
 
     fn visit_class_def(&self, node: &ast::StmtClassDef) -> ValidateResult {
         self.validate_body(&node.body, "ClassDef")?;
+        self.validate_type_params(node.type_params.as_deref())?;
         if let Some(arguments) = node.arguments.as_deref() {
             self.validate_exprs(&arguments.args, ast::ExprContext::Load)?;
             for keyword in &arguments.keywords {
@@ -284,6 +287,29 @@ impl AstValidator {
             }
         }
         self.validate_decorators(&node.decorator_list)
+    }
+
+    /// A type parameter carries a name, and everything else it holds is an
+    /// expression read in Load context. The checked-in tree predates PEP 695
+    /// and has no counterpart, so this answers to 3.14.
+    fn validate_type_params(&self, type_params: Option<&ast::TypeParams>) -> ValidateResult {
+        let Some(type_params) = type_params else {
+            return Ok(());
+        };
+        for type_param in &type_params.type_params {
+            let (name, bound, default) = match type_param {
+                ast::TypeParam::TypeVar(node) => {
+                    (&node.name, node.bound.as_deref(), node.default.as_deref())
+                }
+                ast::TypeParam::TypeVarTuple(node) => (&node.name, None, node.default.as_deref()),
+                ast::TypeParam::ParamSpec(node) => (&node.name, None, node.default.as_deref()),
+            };
+            self.validate_name(name)?;
+            for expr in [bound, default].into_iter().flatten() {
+                self.validate_expr(expr, ast::ExprContext::Load)?;
+            }
+        }
+        Ok(())
     }
 
     fn validate_decorators(&self, decorators: &[ast::Decorator]) -> ValidateResult {
@@ -388,34 +414,45 @@ impl AstValidator {
         match pattern {
             ast::Pattern::MatchValue(node) => {
                 self.validate_expr(&node.value, ast::ExprContext::Load)?;
-                let literal = match node.value.as_ref() {
-                    ast::Expr::Constant(constant) => matches!(
-                        constant.value,
-                        ast::ConstantValue::Integer(_)
-                            | ast::ConstantValue::Float(_)
-                            | ast::ConstantValue::Complex { .. }
-                            | ast::ConstantValue::Str(_)
-                            | ast::ConstantValue::Bytes(_)
-                    ),
-                    // Anything the parser produced is a literal or an
-                    // attribute lookup already.
-                    _ => true,
-                };
-                if literal {
-                    Ok(())
-                } else {
-                    Err(validation_error(
-                        "unexpected constant inside of a literal pattern",
-                    ))
+                match node.value.as_ref() {
+                    ast::Expr::Constant(constant) => {
+                        // Ellipsis and the immutable containers are out; True,
+                        // False and None belong to MatchSingleton.
+                        if matches!(
+                            constant.value,
+                            ast::ConstantValue::Integer(_)
+                                | ast::ConstantValue::Float(_)
+                                | ast::ConstantValue::Complex { .. }
+                                | ast::ConstantValue::Str(_)
+                                | ast::ConstantValue::Bytes(_)
+                        ) {
+                            Ok(())
+                        } else {
+                            Err(validation_error(
+                                "unexpected constant inside of a literal pattern",
+                            ))
+                        }
+                    }
+                    // An attribute lookup is always permitted, and a complex
+                    // literal reaches here as the operation that builds it,
+                    // whose shape the code generator checks.
+                    ast::Expr::Attribute(_) | ast::Expr::BinOp(_) | ast::Expr::UnaryOp(_) => Ok(()),
+                    // Upstream stops at the constant check and lets everything
+                    // else through; 3.14 rejects it here, before the code
+                    // generator reports the same thing as a SyntaxError.
+                    _ => Err(validation_error(
+                        "patterns may only match literals and attribute lookups",
+                    )),
                 }
             }
             ast::Pattern::MatchSingleton(_) => Ok(()),
             ast::Pattern::MatchSequence(node) => self.validate_patterns(&node.patterns, true),
             ast::Pattern::MatchMapping(node) => {
-                if !node.keys.is_empty()
-                    && !node.patterns.is_empty()
-                    && node.keys.len() != node.patterns.len()
-                {
+                // Upstream compares the two only when both are non-empty, so a
+                // node carrying keys and no patterns reaches the code
+                // generator, which zips them; 3.14 compares unconditionally.
+                // `{**rest}` leaves both empty and still passes.
+                if node.keys.len() != node.patterns.len() {
                     return Err(validation_error(
                         "MatchMapping doesn't have the same number of keys as patterns",
                     ));
@@ -429,9 +466,13 @@ impl AstValidator {
                         ));
                     }
                 }
+                self.validate_exprs(&node.keys, ast::ExprContext::Load)?;
                 if let Some(rest) = &node.rest {
                     self.validate_capture(rest)?;
                 }
+                // Upstream walks `keys` here, which are expressions, so a
+                // pattern nested in the mapping goes unchecked; 3.14 walks the
+                // patterns and this follows it.
                 self.validate_patterns(&node.patterns, false)
             }
             ast::Pattern::MatchClass(node) => {
@@ -627,5 +668,202 @@ impl AstValidator {
             self.validate_exprs(&comprehension.ifs, ast::ExprContext::Load)?;
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Where the walk and 3.14 disagree the shared roundtrip fixture cannot
+    /// carry the case: every backend's output there is compared against PyPy's.
+    fn validate(body: Vec<ast::Stmt>) -> ValidateResult {
+        validate_ast(&ast::Mod::Module(ast::ModModule {
+            node_index: Default::default(),
+            range: Default::default(),
+            body,
+            runtime_body: None,
+        }))
+    }
+
+    fn name(id: &str, ctx: ast::ExprContext) -> ast::Expr {
+        ast::Expr::Name(ast::ExprName {
+            node_index: Default::default(),
+            range: Default::default(),
+            id: id.into(),
+            ctx,
+        })
+    }
+
+    fn constant(value: i32) -> ast::Expr {
+        ast::Expr::Constant(ast::ExprConstant {
+            node_index: Default::default(),
+            range: Default::default(),
+            value: ast::ConstantValue::Integer(value.to_string().into_boxed_str()),
+            kind: None,
+            invalid_type: None,
+        })
+    }
+
+    fn pass() -> ast::Stmt {
+        ast::Stmt::Pass(ast::StmtPass {
+            node_index: Default::default(),
+            range: Default::default(),
+        })
+    }
+
+    fn matched(pattern: ast::Pattern) -> Vec<ast::Stmt> {
+        vec![ast::Stmt::Match(ast::StmtMatch {
+            node_index: Default::default(),
+            range: Default::default(),
+            subject: Box::new(constant(1)),
+            cases: vec![ast::MatchCase {
+                node_index: Default::default(),
+                range: Default::default(),
+                pattern,
+                guard: None,
+                body: vec![pass()],
+                runtime_body: None,
+            }],
+        })]
+    }
+
+    fn mapping(keys: Vec<ast::Expr>, patterns: Vec<ast::Pattern>) -> ast::Pattern {
+        ast::Pattern::MatchMapping(ast::PatternMatchMapping {
+            node_index: Default::default(),
+            range: Default::default(),
+            keys,
+            patterns,
+            rest: None,
+            runtime_keys: None,
+            runtime_patterns: None,
+        })
+    }
+
+    fn message(result: ValidateResult) -> String {
+        result.unwrap_err().message
+    }
+
+    #[test]
+    fn match_value_takes_only_a_literal_or_an_attribute() {
+        let value = ast::Pattern::MatchValue(ast::PatternMatchValue {
+            node_index: Default::default(),
+            range: Default::default(),
+            value: Box::new(name("foo", ast::ExprContext::Load)),
+        });
+        assert_eq!(
+            message(validate(matched(value))),
+            "patterns may only match literals and attribute lookups"
+        );
+
+        let value = ast::Pattern::MatchValue(ast::PatternMatchValue {
+            node_index: Default::default(),
+            range: Default::default(),
+            value: Box::new(ast::Expr::Attribute(ast::ExprAttribute {
+                node_index: Default::default(),
+                range: Default::default(),
+                value: Box::new(name("o", ast::ExprContext::Load)),
+                attr: ast::Identifier::new("a", Default::default()),
+                ctx: ast::ExprContext::Load,
+            })),
+        });
+        assert!(validate(matched(value)).is_ok());
+    }
+
+    #[test]
+    fn match_mapping_counts_keys_against_patterns() {
+        assert_eq!(
+            message(validate(matched(mapping(vec![constant(1)], Vec::new())))),
+            "MatchMapping doesn't have the same number of keys as patterns"
+        );
+        // `{**rest}` leaves both empty, which is not a mismatch.
+        assert!(validate(matched(mapping(Vec::new(), Vec::new()))).is_ok());
+    }
+
+    #[test]
+    fn match_mapping_reads_its_keys_in_load_context() {
+        let key = ast::Expr::Attribute(ast::ExprAttribute {
+            node_index: Default::default(),
+            range: Default::default(),
+            value: Box::new(name("o", ast::ExprContext::Store)),
+            attr: ast::Identifier::new("a", Default::default()),
+            ctx: ast::ExprContext::Load,
+        });
+        let pattern = ast::Pattern::MatchAs(ast::PatternMatchAs {
+            node_index: Default::default(),
+            range: Default::default(),
+            pattern: None,
+            name: Some(ast::Identifier::new("v", Default::default())),
+        });
+        assert_eq!(
+            message(validate(matched(mapping(vec![key], vec![pattern])))),
+            "expression must have Load context but has Store instead"
+        );
+    }
+
+    #[test]
+    fn match_mapping_walks_the_patterns_not_the_keys() {
+        // Upstream walks `keys`, so a star nested here goes unreported.
+        let star = ast::Pattern::MatchStar(ast::PatternMatchStar {
+            node_index: Default::default(),
+            range: Default::default(),
+            name: Some(ast::Identifier::new("a", Default::default())),
+        });
+        assert_eq!(
+            message(validate(matched(mapping(vec![constant(1)], vec![star])))),
+            "can't use MatchStar here"
+        );
+    }
+
+    #[test]
+    fn type_params_are_read_in_load_context() {
+        let type_params = |type_param| {
+            Some(Box::new(ast::TypeParams {
+                node_index: Default::default(),
+                range: Default::default(),
+                type_params: vec![type_param],
+                runtime_type_params: None,
+            }))
+        };
+        let function = |type_param| {
+            vec![ast::Stmt::FunctionDef(ast::StmtFunctionDef {
+                node_index: Default::default(),
+                range: Default::default(),
+                is_async: false,
+                decorator_list: Vec::new(),
+                name: ast::Identifier::new("f", Default::default()),
+                type_params: type_params(type_param),
+                parameters: Box::new(ast::Parameters::default()),
+                returns: None,
+                body: vec![pass()],
+                runtime_decorator_list: None,
+                runtime_type_comment: None,
+                runtime_type_comment_bytes: None,
+                runtime_body: None,
+            })]
+        };
+
+        let bound = ast::TypeParam::TypeVar(ast::TypeParamTypeVar {
+            node_index: Default::default(),
+            range: Default::default(),
+            name: ast::Identifier::new("T", Default::default()),
+            bound: Some(Box::new(name("x", ast::ExprContext::Store))),
+            default: None,
+        });
+        assert_eq!(
+            message(validate(function(bound))),
+            "expression must have Load context but has Store instead"
+        );
+
+        let named = ast::TypeParam::ParamSpec(ast::TypeParamParamSpec {
+            node_index: Default::default(),
+            range: Default::default(),
+            name: ast::Identifier::new("None", Default::default()),
+            default: None,
+        });
+        assert_eq!(
+            message(validate(function(named))),
+            "identifier field can't represent 'None' constant"
+        );
     }
 }

--- a/pyre/pyre-interpreter/src/astcompiler/validate.rs
+++ b/pyre/pyre-interpreter/src/astcompiler/validate.rs
@@ -1,0 +1,631 @@
+//! A visitor to validate an AST object.
+//!
+//! `compile()` given a tree of `_ast` objects converts it and then walks the
+//! result here before handing it to the code generator, so a tree the parser
+//! could never have produced is rejected with a message rather than compiled.
+//!
+//! The walk is over the compiler AST, which cannot hold every shape the
+//! objects can: a list element that is missing, a `Dict` whose keys and values
+//! have different lengths, defaults that outnumber their parameters. Those are
+//! rejected by the conversion in `module::_ast::convert`, which is the last
+//! place they are still visible; everything else is checked here.
+
+use rustpython_compiler::ast;
+
+use crate::PyError;
+
+type ValidateResult = Result<(), PyError>;
+
+/// Seen as a ValueError.
+fn validation_error(message: impl Into<String>) -> PyError {
+    PyError::value_error(message)
+}
+
+/// Seen as a TypeError.
+fn validation_type_error(message: impl Into<String>) -> PyError {
+    PyError::type_error(message)
+}
+
+pub fn validate_ast(node: &ast::Mod) -> ValidateResult {
+    let validator = AstValidator;
+    match node {
+        ast::Mod::Module(node) => validator.validate_stmts(&node.body),
+        ast::Mod::Expression(node) => validator.validate_expr(&node.body, ast::ExprContext::Load),
+    }
+}
+
+fn expr_context_name(ctx: ast::ExprContext) -> &'static str {
+    match ctx {
+        ast::ExprContext::Load => "Load",
+        ast::ExprContext::Store => "Store",
+        ast::ExprContext::Del => "Del",
+        ast::ExprContext::Invalid => "??",
+    }
+}
+
+fn check_context(expected_ctx: ast::ExprContext, actual_ctx: ast::ExprContext) -> ValidateResult {
+    if expected_ctx != actual_ctx {
+        return Err(validation_error(format!(
+            "expression must have {} context but has {} instead",
+            expr_context_name(expected_ctx),
+            expr_context_name(actual_ctx)
+        )));
+    }
+    Ok(())
+}
+
+/// The context an expression carries, for the ones that carry one.  The rest
+/// cannot be assigned to at all.
+fn context_of(expr: &ast::Expr) -> Option<ast::ExprContext> {
+    match expr {
+        ast::Expr::Name(node) => Some(node.ctx),
+        ast::Expr::List(node) => Some(node.ctx),
+        ast::Expr::Tuple(node) => Some(node.ctx),
+        ast::Expr::Starred(node) => Some(node.ctx),
+        ast::Expr::Subscript(node) => Some(node.ctx),
+        ast::Expr::Attribute(node) => Some(node.ctx),
+        _ => None,
+    }
+}
+
+/// Recursive function to validate a Constant value.
+fn validate_constant(value: &ast::ConstantValue) -> ValidateResult {
+    match value {
+        ast::ConstantValue::None
+        | ast::ConstantValue::Ellipsis
+        | ast::ConstantValue::Boolean(_)
+        | ast::ConstantValue::Integer(_)
+        | ast::ConstantValue::Float(_)
+        | ast::ConstantValue::Complex { .. }
+        | ast::ConstantValue::Str(_)
+        | ast::ConstantValue::Bytes(_) => Ok(()),
+        ast::ConstantValue::Tuple(items) | ast::ConstantValue::Frozenset(items) => {
+            items.iter().try_for_each(validate_constant)
+        }
+    }
+}
+
+struct AstValidator;
+
+impl AstValidator {
+    fn validate_stmts(&self, stmts: &[ast::Stmt]) -> ValidateResult {
+        stmts.iter().try_for_each(|stmt| self.visit_stmt(stmt))
+    }
+
+    fn validate_expr(&self, expr: &ast::Expr, ctx: ast::ExprContext) -> ValidateResult {
+        match context_of(expr) {
+            Some(actual) => check_context(ctx, actual)?,
+            None if ctx != ast::ExprContext::Load => {
+                return Err(validation_error(format!(
+                    "expression which can't be assigned to in {} context",
+                    expr_context_name(ctx)
+                )));
+            }
+            None => {}
+        }
+        self.walkabout_with_ctx(expr, ctx)
+    }
+
+    /// `List`, `Tuple` and `Starred` pass their context down to what they
+    /// hold; every other expression is entered in Load context.
+    fn walkabout_with_ctx(&self, expr: &ast::Expr, ctx: ast::ExprContext) -> ValidateResult {
+        match expr {
+            ast::Expr::List(node) => self.validate_exprs(&node.elts, ctx),
+            ast::Expr::Tuple(node) => self.validate_exprs(&node.elts, ctx),
+            ast::Expr::Starred(node) => self.validate_expr(&node.value, ctx),
+            _ => self.visit_expr(expr),
+        }
+    }
+
+    /// Upstream takes a `null_ok` for the two lists that may hold a missing
+    /// element -- `Dict` keys and `kw_defaults`.  Neither survives into the
+    /// compiler AST as a list with holes, so there is nothing here to allow.
+    fn validate_exprs(&self, exprs: &[ast::Expr], ctx: ast::ExprContext) -> ValidateResult {
+        exprs
+            .iter()
+            .try_for_each(|expr| self.validate_expr(expr, ctx))
+    }
+
+    fn validate_body(&self, body: &[ast::Stmt], owner: &str) -> ValidateResult {
+        self.validate_nonempty_seq(body.len(), "body", owner)?;
+        self.validate_stmts(body)
+    }
+
+    fn validate_nonempty_seq(&self, len: usize, what: &str, owner: &str) -> ValidateResult {
+        if len == 0 {
+            return Err(validation_error(format!("empty {what} on {owner}")));
+        }
+        Ok(())
+    }
+
+    fn validate_name(&self, name: &str) -> ValidateResult {
+        if matches!(name, "None" | "True" | "False") {
+            return Err(validation_error(format!(
+                "identifier field can't represent '{name}' constant"
+            )));
+        }
+        Ok(())
+    }
+
+    // Statements
+
+    fn visit_stmt(&self, stmt: &ast::Stmt) -> ValidateResult {
+        match stmt {
+            ast::Stmt::FunctionDef(node) => self.visit_function_def(node),
+            ast::Stmt::ClassDef(node) => self.visit_class_def(node),
+            ast::Stmt::Return(node) => match &node.value {
+                Some(value) => self.validate_expr(value, ast::ExprContext::Load),
+                None => Ok(()),
+            },
+            ast::Stmt::Delete(node) => {
+                self.validate_nonempty_seq(node.targets.len(), "targets", "Delete")?;
+                self.validate_exprs(&node.targets, ast::ExprContext::Del)
+            }
+            ast::Stmt::Assign(node) => {
+                self.validate_nonempty_seq(node.targets.len(), "targets", "Assign")?;
+                self.validate_exprs(&node.targets, ast::ExprContext::Store)?;
+                self.validate_expr(&node.value, ast::ExprContext::Load)
+            }
+            ast::Stmt::AugAssign(node) => {
+                self.validate_expr(&node.target, ast::ExprContext::Store)?;
+                self.validate_expr(&node.value, ast::ExprContext::Load)
+            }
+            ast::Stmt::AnnAssign(node) => {
+                self.validate_expr(&node.target, ast::ExprContext::Store)?;
+                self.validate_expr(&node.annotation, ast::ExprContext::Load)?;
+                match &node.value {
+                    Some(value) => self.validate_expr(value, ast::ExprContext::Load),
+                    None => Ok(()),
+                }
+            }
+            ast::Stmt::TypeAlias(node) => {
+                self.validate_expr(&node.name, ast::ExprContext::Store)?;
+                self.validate_expr(&node.value, ast::ExprContext::Load)
+            }
+            ast::Stmt::For(node) => {
+                let owner = if node.is_async { "AsyncFor" } else { "For" };
+                self.validate_expr(&node.target, ast::ExprContext::Store)?;
+                self.validate_expr(&node.iter, ast::ExprContext::Load)?;
+                self.validate_body(&node.body, owner)?;
+                self.validate_stmts(&node.orelse)
+            }
+            ast::Stmt::While(node) => {
+                self.validate_expr(&node.test, ast::ExprContext::Load)?;
+                self.validate_body(&node.body, "While")?;
+                self.validate_stmts(&node.orelse)
+            }
+            ast::Stmt::If(node) => {
+                self.validate_expr(&node.test, ast::ExprContext::Load)?;
+                self.validate_body(&node.body, "If")?;
+                // An `elif` is the `orelse` holding one more `If`, so its own
+                // body carries the same requirement; a plain `else` is only a
+                // statement list.
+                for clause in &node.elif_else_clauses {
+                    match &clause.test {
+                        Some(test) => {
+                            self.validate_expr(test, ast::ExprContext::Load)?;
+                            self.validate_body(&clause.body, "If")?;
+                        }
+                        None => self.validate_stmts(&clause.body)?,
+                    }
+                }
+                Ok(())
+            }
+            ast::Stmt::With(node) => {
+                let owner = if node.is_async { "AsyncWith" } else { "With" };
+                self.validate_nonempty_seq(node.items.len(), "items", owner)?;
+                for item in &node.items {
+                    self.validate_expr(&item.context_expr, ast::ExprContext::Load)?;
+                    if let Some(vars) = item.optional_vars.as_deref() {
+                        self.validate_expr(vars, ast::ExprContext::Store)?;
+                    }
+                }
+                self.validate_body(&node.body, owner)
+            }
+            ast::Stmt::Raise(node) => match (&node.exc, &node.cause) {
+                (Some(exc), cause) => {
+                    self.validate_expr(exc, ast::ExprContext::Load)?;
+                    match cause {
+                        Some(cause) => self.validate_expr(cause, ast::ExprContext::Load),
+                        None => Ok(()),
+                    }
+                }
+                (None, Some(_)) => Err(validation_error("Raise with cause but no exception")),
+                (None, None) => Ok(()),
+            },
+            ast::Stmt::Try(node) => self.visit_try(node),
+            ast::Stmt::Assert(node) => {
+                self.validate_expr(&node.test, ast::ExprContext::Load)?;
+                match &node.msg {
+                    Some(msg) => self.validate_expr(msg, ast::ExprContext::Load),
+                    None => Ok(()),
+                }
+            }
+            ast::Stmt::Import(node) => {
+                self.validate_nonempty_seq(node.names.len(), "names", "Import")
+            }
+            ast::Stmt::ImportFrom(node) => {
+                self.validate_nonempty_seq(node.names.len(), "names", "ImportFrom")
+            }
+            ast::Stmt::Global(node) => {
+                self.validate_nonempty_seq(node.names.len(), "names", "Global")
+            }
+            ast::Stmt::Nonlocal(node) => {
+                self.validate_nonempty_seq(node.names.len(), "names", "Nonlocal")
+            }
+            ast::Stmt::Expr(node) => self.validate_expr(&node.value, ast::ExprContext::Load),
+            ast::Stmt::Match(node) => self.visit_match(node),
+            ast::Stmt::Pass(_) | ast::Stmt::Break(_) | ast::Stmt::Continue(_) => Ok(()),
+            ast::Stmt::IpyEscapeCommand(_) => Ok(()),
+        }
+    }
+
+    fn visit_function_def(&self, node: &ast::StmtFunctionDef) -> ValidateResult {
+        let owner = if node.is_async {
+            "AsyncFunctionDef"
+        } else {
+            "FunctionDef"
+        };
+        self.validate_body(&node.body, owner)?;
+        self.visit_parameters(&node.parameters)?;
+        self.validate_decorators(&node.decorator_list)?;
+        match &node.returns {
+            Some(returns) => self.validate_expr(returns, ast::ExprContext::Load),
+            None => Ok(()),
+        }
+    }
+
+    fn visit_class_def(&self, node: &ast::StmtClassDef) -> ValidateResult {
+        self.validate_body(&node.body, "ClassDef")?;
+        if let Some(arguments) = node.arguments.as_deref() {
+            self.validate_exprs(&arguments.args, ast::ExprContext::Load)?;
+            for keyword in &arguments.keywords {
+                self.validate_expr(&keyword.value, ast::ExprContext::Load)?;
+            }
+        }
+        self.validate_decorators(&node.decorator_list)
+    }
+
+    fn validate_decorators(&self, decorators: &[ast::Decorator]) -> ValidateResult {
+        decorators.iter().try_for_each(|decorator| {
+            self.validate_expr(&decorator.expression, ast::ExprContext::Load)
+        })
+    }
+
+    fn visit_parameters(&self, node: &ast::Parameters) -> ValidateResult {
+        for parameter in node
+            .posonlyargs
+            .iter()
+            .chain(&node.args)
+            .chain(&node.kwonlyargs)
+        {
+            self.visit_parameter(&parameter.parameter)?;
+            if let Some(default) = parameter.default.as_deref() {
+                self.validate_expr(default, ast::ExprContext::Load)?;
+            }
+        }
+        for parameter in [node.vararg.as_deref(), node.kwarg.as_deref()]
+            .into_iter()
+            .flatten()
+        {
+            self.visit_parameter(parameter)?;
+        }
+        Ok(())
+    }
+
+    fn visit_parameter(&self, node: &ast::Parameter) -> ValidateResult {
+        match &node.annotation {
+            Some(annotation) => self.validate_expr(annotation, ast::ExprContext::Load),
+            None => Ok(()),
+        }
+    }
+
+    fn visit_try(&self, node: &ast::StmtTry) -> ValidateResult {
+        let owner = if node.is_star { "TryStar" } else { "Try" };
+        self.validate_body(&node.body, owner)?;
+        if node.handlers.is_empty() && node.finalbody.is_empty() {
+            return Err(validation_error(format!(
+                "{owner} has neither except handlers nor finalbody"
+            )));
+        }
+        if node.handlers.is_empty() && !node.orelse.is_empty() {
+            return Err(validation_error(format!(
+                "{owner} has orelse but no except handlers"
+            )));
+        }
+        for handler in &node.handlers {
+            let ast::ExceptHandler::ExceptHandler(handler) = handler;
+            if let Some(type_) = handler.type_.as_deref() {
+                self.validate_expr(type_, ast::ExprContext::Load)?;
+            }
+            self.validate_body(&handler.body, "ExceptHandler")?;
+        }
+        self.validate_stmts(&node.orelse)?;
+        self.validate_stmts(&node.finalbody)
+    }
+
+    // pattern matching
+
+    /// A second star in the same sequence is left to the code generator, which
+    /// reports it where 3.14 does, as a SyntaxError; upstream raises here and
+    /// so answers with a ValueError.
+    fn validate_patterns(&self, patterns: &[ast::Pattern], star_ok: bool) -> ValidateResult {
+        for pattern in patterns {
+            if let ast::Pattern::MatchStar(node) = pattern
+                && star_ok
+            {
+                if let Some(name) = &node.name {
+                    self.validate_capture(name)?;
+                }
+                continue;
+            }
+            self.visit_pattern(pattern)?;
+        }
+        Ok(())
+    }
+
+    fn validate_capture(&self, name: &str) -> ValidateResult {
+        if name == "_" {
+            return Err(validation_error("can't capture name '_' in patterns"));
+        }
+        self.validate_name(name)
+    }
+
+    fn visit_match(&self, node: &ast::StmtMatch) -> ValidateResult {
+        self.validate_nonempty_seq(node.cases.len(), "cases", "Match")?;
+        self.validate_expr(&node.subject, ast::ExprContext::Load)?;
+        for case in &node.cases {
+            if let Some(guard) = case.guard.as_deref() {
+                self.validate_expr(guard, ast::ExprContext::Load)?;
+            }
+            self.validate_stmts(&case.body)?;
+            self.visit_pattern(&case.pattern)?;
+        }
+        Ok(())
+    }
+
+    fn visit_pattern(&self, pattern: &ast::Pattern) -> ValidateResult {
+        match pattern {
+            ast::Pattern::MatchValue(node) => {
+                self.validate_expr(&node.value, ast::ExprContext::Load)?;
+                let literal = match node.value.as_ref() {
+                    ast::Expr::Constant(constant) => matches!(
+                        constant.value,
+                        ast::ConstantValue::Integer(_)
+                            | ast::ConstantValue::Float(_)
+                            | ast::ConstantValue::Complex { .. }
+                            | ast::ConstantValue::Str(_)
+                            | ast::ConstantValue::Bytes(_)
+                    ),
+                    // Anything the parser produced is a literal or an
+                    // attribute lookup already.
+                    _ => true,
+                };
+                if literal {
+                    Ok(())
+                } else {
+                    Err(validation_error(
+                        "unexpected constant inside of a literal pattern",
+                    ))
+                }
+            }
+            ast::Pattern::MatchSingleton(_) => Ok(()),
+            ast::Pattern::MatchSequence(node) => self.validate_patterns(&node.patterns, true),
+            ast::Pattern::MatchMapping(node) => {
+                if !node.keys.is_empty()
+                    && !node.patterns.is_empty()
+                    && node.keys.len() != node.patterns.len()
+                {
+                    return Err(validation_error(
+                        "MatchMapping doesn't have the same number of keys as patterns",
+                    ));
+                }
+                for key in &node.keys {
+                    if !matches!(key, ast::Expr::Constant(_) | ast::Expr::Attribute(_)) {
+                        // Upstream words this as "can only have Constant or
+                        // Attribute in the keys of a MatchMapping".
+                        return Err(validation_error(
+                            "patterns may only match literals and attribute lookups",
+                        ));
+                    }
+                }
+                if let Some(rest) = &node.rest {
+                    self.validate_capture(rest)?;
+                }
+                self.validate_patterns(&node.patterns, false)
+            }
+            ast::Pattern::MatchClass(node) => {
+                self.validate_expr(&node.cls, ast::ExprContext::Load)?;
+                let mut cls = node.cls.as_ref();
+                loop {
+                    match cls {
+                        ast::Expr::Name(_) => break,
+                        ast::Expr::Attribute(attribute) => cls = &attribute.value,
+                        _ => {
+                            return Err(validation_error(
+                                "MatchClass cls field can only contain Name or Attribute nodes.",
+                            ));
+                        }
+                    }
+                }
+                for keyword in &node.arguments.keywords {
+                    self.validate_name(&keyword.attr)?;
+                }
+                self.validate_patterns(&node.arguments.patterns, false)?;
+                for keyword in &node.arguments.keywords {
+                    self.visit_pattern(&keyword.pattern)?;
+                }
+                Ok(())
+            }
+            ast::Pattern::MatchStar(_) => Err(validation_error("can't use MatchStar here")),
+            ast::Pattern::MatchAs(node) => {
+                if let Some(name) = &node.name {
+                    self.validate_capture(name)?;
+                }
+                match (&node.pattern, &node.name) {
+                    (Some(_), None) => Err(validation_error(
+                        "MatchAs must specify a target name if a pattern is given",
+                    )),
+                    (Some(pattern), Some(_)) => self.visit_pattern(pattern),
+                    (None, _) => Ok(()),
+                }
+            }
+            ast::Pattern::MatchOr(node) => {
+                if node.patterns.len() < 2 {
+                    return Err(validation_error("MatchOr requires at least 2 patterns"));
+                }
+                self.validate_patterns(&node.patterns, false)
+            }
+        }
+    }
+
+    // Expressions
+
+    fn visit_expr(&self, expr: &ast::Expr) -> ValidateResult {
+        match expr {
+            ast::Expr::Name(node) => self.validate_name(&node.id),
+            ast::Expr::Constant(node) => validate_constant(&node.value),
+            ast::Expr::BoolOp(node) => {
+                if node.values.len() < 2 {
+                    return Err(validation_error("BoolOp with less than 2 values"));
+                }
+                self.validate_exprs(&node.values, ast::ExprContext::Load)
+            }
+            ast::Expr::UnaryOp(node) => self.validate_expr(&node.operand, ast::ExprContext::Load),
+            ast::Expr::BinOp(node) => {
+                self.validate_expr(&node.left, ast::ExprContext::Load)?;
+                self.validate_expr(&node.right, ast::ExprContext::Load)
+            }
+            ast::Expr::Lambda(node) => {
+                if let Some(parameters) = node.parameters.as_deref() {
+                    self.visit_parameters(parameters)?;
+                }
+                self.validate_expr(&node.body, ast::ExprContext::Load)
+            }
+            ast::Expr::If(node) => {
+                self.validate_expr(&node.test, ast::ExprContext::Load)?;
+                self.validate_expr(&node.body, ast::ExprContext::Load)?;
+                self.validate_expr(&node.orelse, ast::ExprContext::Load)
+            }
+            ast::Expr::Dict(node) => {
+                for item in &node.items {
+                    if let Some(key) = &item.key {
+                        self.validate_expr(key, ast::ExprContext::Load)?;
+                    }
+                    self.validate_expr(&item.value, ast::ExprContext::Load)?;
+                }
+                Ok(())
+            }
+            ast::Expr::Set(node) => self.validate_exprs(&node.elts, ast::ExprContext::Load),
+            ast::Expr::ListComp(node) => {
+                self.validate_comprehension(&node.generators)?;
+                self.validate_expr(&node.elt, ast::ExprContext::Load)
+            }
+            ast::Expr::SetComp(node) => {
+                self.validate_comprehension(&node.generators)?;
+                self.validate_expr(&node.elt, ast::ExprContext::Load)
+            }
+            ast::Expr::Generator(node) => {
+                self.validate_comprehension(&node.generators)?;
+                self.validate_expr(&node.elt, ast::ExprContext::Load)
+            }
+            ast::Expr::DictComp(node) => {
+                self.validate_comprehension(&node.generators)?;
+                self.validate_expr(&node.key, ast::ExprContext::Load)?;
+                self.validate_expr(&node.value, ast::ExprContext::Load)
+            }
+            ast::Expr::Await(node) => self.validate_expr(&node.value, ast::ExprContext::Load),
+            ast::Expr::Yield(node) => match &node.value {
+                Some(value) => self.validate_expr(value, ast::ExprContext::Load),
+                None => Ok(()),
+            },
+            ast::Expr::YieldFrom(node) => self.validate_expr(&node.value, ast::ExprContext::Load),
+            ast::Expr::Compare(node) => {
+                if node.comparators.is_empty() {
+                    return Err(validation_error("Compare with no comparators"));
+                }
+                if node.comparators.len() != node.ops.len() {
+                    return Err(validation_error(
+                        "Compare has a different number of comparators and operands",
+                    ));
+                }
+                self.validate_exprs(&node.comparators, ast::ExprContext::Load)?;
+                self.validate_expr(&node.left, ast::ExprContext::Load)
+            }
+            ast::Expr::Call(node) => {
+                self.validate_expr(&node.func, ast::ExprContext::Load)?;
+                self.validate_exprs(&node.arguments.args, ast::ExprContext::Load)?;
+                for keyword in &node.arguments.keywords {
+                    self.validate_expr(&keyword.value, ast::ExprContext::Load)?;
+                }
+                Ok(())
+            }
+            ast::Expr::Attribute(node) => self.validate_expr(&node.value, ast::ExprContext::Load),
+            ast::Expr::Subscript(node) => {
+                self.validate_expr(&node.value, ast::ExprContext::Load)?;
+                self.validate_expr(&node.slice, ast::ExprContext::Load)
+            }
+            ast::Expr::Slice(node) => {
+                for part in [
+                    node.lower.as_deref(),
+                    node.upper.as_deref(),
+                    node.step.as_deref(),
+                ]
+                .into_iter()
+                .flatten()
+                {
+                    self.validate_expr(part, ast::ExprContext::Load)?;
+                }
+                Ok(())
+            }
+            ast::Expr::FString(node) => self.visit_fstring(node),
+            ast::Expr::Named(node) => {
+                if !matches!(node.target.as_ref(), ast::Expr::Name(_)) {
+                    return Err(validation_type_error("NamedExpr target must be a Name"));
+                }
+                self.validate_expr(&node.value, ast::ExprContext::Load)
+            }
+            ast::Expr::Starred(node) => self.validate_expr(&node.value, ast::ExprContext::Load),
+            ast::Expr::List(node) => self.validate_exprs(&node.elts, ast::ExprContext::Load),
+            ast::Expr::Tuple(node) => self.validate_exprs(&node.elts, ast::ExprContext::Load),
+            // A literal the parser produced, or a node with nothing to check.
+            ast::Expr::StringLiteral(_)
+            | ast::Expr::BytesLiteral(_)
+            | ast::Expr::NumberLiteral(_)
+            | ast::Expr::BooleanLiteral(_)
+            | ast::Expr::NoneLiteral(_)
+            | ast::Expr::EllipsisLiteral(_)
+            | ast::Expr::TString(_)
+            | ast::Expr::IpyEscapeCommand(_) => Ok(()),
+        }
+    }
+
+    /// The values of a `JoinedStr` reach the compiler AST as the parts to
+    /// join, and a `FormattedValue` spec as the expression to format with.
+    fn visit_fstring(&self, node: &ast::ExprFString) -> ValidateResult {
+        if let Some(values) = node.runtime_joined_str.as_deref() {
+            return self.validate_exprs(values, ast::ExprContext::Load);
+        }
+        for element in node.value.elements() {
+            if let ast::InterpolatedStringElement::Interpolation(interpolation) = element {
+                self.validate_expr(&interpolation.expression, ast::ExprContext::Load)?;
+                if let Some(spec) = interpolation.runtime_formatted_value_format_spec.as_deref() {
+                    self.validate_expr(spec, ast::ExprContext::Load)?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn validate_comprehension(&self, generators: &[ast::Comprehension]) -> ValidateResult {
+        if generators.is_empty() {
+            return Err(validation_error("comprehension with no generators"));
+        }
+        for comprehension in generators {
+            self.validate_expr(&comprehension.target, ast::ExprContext::Store)?;
+            self.validate_expr(&comprehension.iter, ast::ExprContext::Load)?;
+            self.validate_exprs(&comprehension.ifs, ast::ExprContext::Load)?;
+        }
+        Ok(())
+    }
+}

--- a/pyre/pyre-interpreter/src/error.rs
+++ b/pyre/pyre-interpreter/src/error.rs
@@ -659,6 +659,10 @@ impl PyError {
         Self::new(PyErrorKind::NotImplementedError, msg)
     }
 
+    pub fn system_error(msg: impl Into<String>) -> Self {
+        Self::new(PyErrorKind::SystemError, msg)
+    }
+
     /// `_PyEval_FormatExcCheckArg` parity — a NameError carrying the
     /// undefined `name` so `e.name` reads back once the instance is
     /// materialised (Python 3.10+).

--- a/pyre/pyre-interpreter/src/lib.rs
+++ b/pyre/pyre-interpreter/src/lib.rs
@@ -29,6 +29,7 @@ pub use compile::*;
 pub mod _pypy_generic_alias;
 pub mod _structseq;
 pub mod argument;
+pub mod astcompiler;
 pub mod baseobjspace;
 pub mod builtins;
 pub mod display;

--- a/pyre/pyre-interpreter/src/module/_ast/convert.rs
+++ b/pyre/pyre-interpreter/src/module/_ast/convert.rs
@@ -80,8 +80,8 @@ impl ObjectConverter {
         let value = self.field(object, field, node)?;
         if !unsafe { pyre_object::is_list(value) } {
             return Err(crate::PyError::type_error(format!(
-                "AST list field must be a list, not {}",
-                unsafe { pyre_object::type_name_of(value) }
+                "{node} field {field:?} must be a list, not a {}",
+                class_name(value)
             )));
         }
         Ok(unsafe { pyre_object::w_list_items_copy_as_vec(value) })
@@ -98,43 +98,29 @@ impl ObjectConverter {
     }
 
     fn module(&mut self, object: PyObjectRef) -> AstResult<ast::Mod> {
-        if self.is_node(object, "Module")? {
-            let values = self.list(object, "body", "Module")?;
-            let body = values
-                .into_iter()
-                .map(|value| self.recurse(|this| this.stmt(value)))
-                .collect::<Result<Vec<_>, _>>()?;
-            Ok(ast::Mod::Module(ast::ModModule {
-                node_index: Default::default(),
-                range: Default::default(),
-                body,
-                runtime_body: None,
-            }))
+        let node = if self.is_node(object, "Module")? {
+            "Module"
         } else if self.is_node(object, "Interactive")? {
-            let values = self.list(object, "body", "Interactive")?;
-            let body = values
-                .into_iter()
-                .map(|value| self.recurse(|this| this.stmt(value)))
-                .collect::<Result<Vec<_>, _>>()?;
-            Ok(ast::Mod::Module(ast::ModModule {
-                node_index: Default::default(),
-                range: Default::default(),
-                body,
-                runtime_body: None,
-            }))
+            "Interactive"
         } else if self.is_node(object, "Expression")? {
             let body = self.field(object, "body", "Expression")?;
-            Ok(ast::Mod::Expression(ast::ModExpression {
+            return Ok(ast::Mod::Expression(ast::ModExpression {
                 node_index: Default::default(),
                 range: Default::default(),
                 body: Box::new(self.recurse(|this| this.expr(body))?),
-            }))
+            }));
         } else {
-            Err(crate::PyError::type_error(format!(
+            return Err(crate::PyError::type_error(format!(
                 "expected some sort of mod, but got {}",
                 unsafe { pyre_object::type_name_of(object) }
-            )))
-        }
+            )));
+        };
+        Ok(ast::Mod::Module(ast::ModModule {
+            node_index: Default::default(),
+            range: Default::default(),
+            body: self.body(object, "body", node)?,
+            runtime_body: None,
+        }))
     }
 
     fn stmt(&mut self, object: PyObjectRef) -> AstResult<ast::Stmt> {
@@ -877,17 +863,35 @@ impl ObjectConverter {
         }
     }
 
+    /// A missing element of a statement or expression list is rejected before
+    /// the node conversion, which would only report the type it did not
+    /// recognise.  Lists of the other ASDL nodes carry no such check.
+    fn require_node(&self, value: PyObjectRef, kind: &str) -> AstResult<()> {
+        if unsafe { pyre_object::is_none(value) } {
+            return Err(crate::PyError::value_error(format!(
+                "None disallowed in {kind} list"
+            )));
+        }
+        Ok(())
+    }
+
     fn body(&mut self, object: PyObjectRef, field: &str, node: &str) -> AstResult<Vec<ast::Stmt>> {
         self.list(object, field, node)?
             .into_iter()
-            .map(|value| self.recurse(|this| this.stmt(value)))
+            .map(|value| {
+                self.require_node(value, "statement")?;
+                self.recurse(|this| this.stmt(value))
+            })
             .collect()
     }
 
     fn exprs(&mut self, object: PyObjectRef, field: &str, node: &str) -> AstResult<Vec<ast::Expr>> {
         self.list(object, field, node)?
             .into_iter()
-            .map(|value| self.recurse(|this| this.expr(value)))
+            .map(|value| {
+                self.require_node(value, "expression")?;
+                self.recurse(|this| this.expr(value))
+            })
             .collect()
     }
 
@@ -1249,18 +1253,52 @@ impl ObjectConverter {
                 upper: self.opt_expr(object, "upper")?,
                 step: self.opt_expr(object, "step")?,
             }))
-        } else if self.is_node(object, "JoinedStr")? || self.is_node(object, "FormattedValue")? {
-            // The compiler AST keeps an f-string as its literal parts rather than
-            // as a concatenation node, so rebuilding one needs the part split
-            // that `JoinedStr` has already discarded.
-            Err(crate::PyError::not_implemented(
-                "compiling a JoinedStr AST node is not implemented",
-            ))
+        } else if self.is_node(object, "JoinedStr")? {
+            let values = self.exprs(object, "values", "JoinedStr")?;
+            Ok(fstring(Vec::new(), Some(values)))
+        } else if self.is_node(object, "FormattedValue")? {
+            let element = self.interpolation(object)?;
+            Ok(fstring(vec![element], None))
         } else {
             Err(crate::PyError::type_error(format!(
                 "expected some sort of expr, but got {}",
                 unsafe { pyre_object::type_name_of(object) }
             )))
+        }
+    }
+
+    fn interpolation(&mut self, object: PyObjectRef) -> AstResult<ast::InterpolatedStringElement> {
+        let expression = self.req_expr(object, "value", "FormattedValue")?;
+        let conversion = self.conversion(object)?;
+        let format_spec = self.opt_expr(object, "format_spec")?;
+        Ok(ast::InterpolatedStringElement::Interpolation(
+            ast::InterpolatedElement {
+                node_index: Default::default(),
+                range: Default::default(),
+                expression,
+                debug_text: None,
+                conversion,
+                // A parsed spec is the element list standing between the
+                // braces, while the object carries a `JoinedStr`; codegen
+                // formats with that expression whenever the field below is
+                // set, so the parsed shape has nothing to hold.
+                format_spec: None,
+                runtime_str: None,
+                runtime_interpolation_format_spec: None,
+                runtime_formatted_value_format_spec: format_spec,
+            },
+        ))
+    }
+
+    fn conversion(&self, object: PyObjectRef) -> AstResult<ast::ConversionFlag> {
+        match self.int_field(object, "conversion", "FormattedValue")? {
+            -1 => Ok(ast::ConversionFlag::None),
+            value if value == i64::from(b's') => Ok(ast::ConversionFlag::Str),
+            value if value == i64::from(b'r') => Ok(ast::ConversionFlag::Repr),
+            value if value == i64::from(b'a') => Ok(ast::ConversionFlag::Ascii),
+            value => Err(crate::PyError::system_error(format!(
+                "Unrecognized conversion character {value}"
+            ))),
         }
     }
 
@@ -1437,6 +1475,30 @@ impl ObjectConverter {
         }
         Err(crate::PyError::type_error("expected some sort of operator"))
     }
+}
+
+/// An f-string expression built from `_ast` objects.  The parser splits an
+/// f-string into the literal and interpolated parts the compiler AST holds,
+/// but a `JoinedStr` object carries only the values to join, so those go to
+/// codegen as the joined values and the part list stays empty.  A
+/// `FormattedValue` on its own is a single interpolated part, which does fit
+/// the part list.
+fn fstring(
+    elements: Vec<ast::InterpolatedStringElement>,
+    runtime_joined_str: Option<Vec<ast::Expr>>,
+) -> ast::Expr {
+    ast::Expr::FString(ast::ExprFString {
+        node_index: Default::default(),
+        range: Default::default(),
+        value: ast::FStringValue::single(ast::FString {
+            node_index: Default::default(),
+            range: Default::default(),
+            elements: elements.into(),
+            flags: ast::FStringFlags::empty(),
+        }),
+        runtime_joined_str,
+        runtime_values: None,
+    })
 }
 
 pub fn parse_to_object(source: &str, mode: crate::compile::Mode) -> crate::PyResult {
@@ -2175,19 +2237,18 @@ impl Converter<'_> {
             );
         }
 
-        let mut values = Vec::new();
+        let mut parts = Vec::new();
         for part in node.value.iter() {
             match part {
-                ast::FStringPart::Literal(literal) => values.push(self.constant(
-                    range(literal.range),
-                    self.string(&literal.value),
-                    pyre_object::w_none(),
-                )?),
+                ast::FStringPart::Literal(literal) => {
+                    push_literal(&mut parts, range(literal.range), &literal.value)
+                }
                 ast::FStringPart::FString(fstring) => {
-                    values.extend(self.interpolated_elements(&fstring.elements)?);
+                    self.interpolated_elements(&fstring.elements, &mut parts)?
                 }
             }
         }
+        let values = self.joined_values(parts)?;
         self.node(
             "JoinedStr",
             Some(range(node.range)),
@@ -2195,24 +2256,49 @@ impl Converter<'_> {
         )
     }
 
+    fn joined_values(&self, parts: Vec<JoinedPart>) -> Result<Vec<PyObjectRef>, crate::PyError> {
+        parts
+            .into_iter()
+            .map(|part| match part {
+                JoinedPart::Literal { start, end, value } => {
+                    self.constant((start, end), self.string(&value), pyre_object::w_none())
+                }
+                JoinedPart::Value(value) => Ok(value),
+            })
+            .collect()
+    }
+
     fn interpolated_elements(
         &self,
         elements: &[ast::InterpolatedStringElement],
-    ) -> Result<Vec<PyObjectRef>, crate::PyError> {
-        let mut values = Vec::new();
+        parts: &mut Vec<JoinedPart>,
+    ) -> Result<(), crate::PyError> {
         for element in elements {
             match element {
-                ast::InterpolatedStringElement::Literal(literal) => values.push(self.constant(
-                    range(literal.range),
-                    self.string(&literal.value),
-                    pyre_object::w_none(),
-                )?),
+                ast::InterpolatedStringElement::Literal(literal) => {
+                    push_literal(parts, range(literal.range), &literal.value)
+                }
                 ast::InterpolatedStringElement::Interpolation(interpolation) => {
+                    let mut conversion = interpolation.conversion;
+                    if let Some(debug_text) = interpolation.debug_text.as_ref() {
+                        self.push_debug_text(parts, interpolation, debug_text);
+                        // `=` echoes the expression text and then reprs the
+                        // value, unless a conversion or a format spec already
+                        // says how to render it.
+                        if matches!(
+                            (conversion, &interpolation.format_spec),
+                            (ast::ConversionFlag::None, None)
+                        ) {
+                            conversion = ast::ConversionFlag::Repr;
+                        }
+                    }
                     let format_spec = interpolation
                         .format_spec
                         .as_deref()
                         .map(|spec| {
-                            let values = self.interpolated_elements(&spec.elements)?;
+                            let mut spec_parts = Vec::new();
+                            self.interpolated_elements(&spec.elements, &mut spec_parts)?;
+                            let values = self.joined_values(spec_parts)?;
                             self.node(
                                 "JoinedStr",
                                 Some(range(spec.range)),
@@ -2220,22 +2306,46 @@ impl Converter<'_> {
                             )
                         })
                         .transpose()?;
-                    values.push(self.node(
+                    parts.push(JoinedPart::Value(self.node(
                         "FormattedValue",
                         Some(range(interpolation.range)),
                         &[
                             ("value", self.expr(&interpolation.expression)?),
                             (
                                 "conversion",
-                                pyre_object::w_int_new(interpolation.conversion as i8 as i64),
+                                pyre_object::w_int_new(conversion as i8 as i64),
                             ),
                             ("format_spec", self.optional(format_spec)),
                         ],
-                    )?);
+                    )?));
                 }
             }
         }
-        Ok(values)
+        Ok(())
+    }
+
+    /// The literal an `=` conversion echoes: the source text of the
+    /// expression, framed by whatever stood between the brace and the
+    /// expression and between the expression and the `!`, `:` or `}`.
+    fn push_debug_text(
+        &self,
+        parts: &mut Vec<JoinedPart>,
+        interpolation: &ast::InterpolatedElement,
+        debug_text: &ast::DebugText,
+    ) {
+        use ruff_text_size::Ranged;
+        let (start, end) = range(interpolation.expression.range());
+        let leading = strip_debug_comments(&debug_text.leading);
+        let trailing = strip_debug_comments(&debug_text.trailing);
+        let expression = &self.source[start as usize..end as usize];
+        push_literal(
+            parts,
+            (
+                start.saturating_sub(leading.len() as u32),
+                end + trailing.len() as u32,
+            ),
+            &[leading.as_str(), expression, trailing.as_str()].concat(),
+        );
     }
 
     fn match_case(&self, case: &ast::MatchCase) -> crate::PyResult {
@@ -2708,6 +2818,66 @@ impl Converter<'_> {
             .collect::<Result<Vec<_>, _>>()
             .map(|items| self.list(items))
     }
+}
+
+/// `%T`-style class name of an AST object.  The `_ast` node types are heap
+/// types, so the name sits on the class the instance points at rather than on
+/// the layout its `ob_type` names.
+fn class_name(object: PyObjectRef) -> &'static str {
+    match crate::typedef::r#type(object) {
+        Some(w_type) => unsafe { pyre_object::w_type_get_name(w_type.as_ptr()) },
+        None => unsafe { pyre_object::type_name_of(object) },
+    }
+}
+
+/// A value of a `JoinedStr` under construction.  Consecutive literal pieces
+/// are one `Constant`, so what the parser kept apart -- an implicit
+/// concatenation, the text an `=` conversion echoes -- is joined as it
+/// arrives instead of reaching the tree one node per piece.
+enum JoinedPart {
+    Literal { start: u32, end: u32, value: String },
+    Value(PyObjectRef),
+}
+
+fn push_literal(parts: &mut Vec<JoinedPart>, (start, end): (u32, u32), value: &str) {
+    if value.is_empty() {
+        return;
+    }
+    if let Some(JoinedPart::Literal {
+        end: last_end,
+        value: last,
+        ..
+    }) = parts.last_mut()
+    {
+        *last_end = end;
+        last.push_str(value);
+        return;
+    }
+    parts.push(JoinedPart::Literal {
+        start,
+        end,
+        value: value.to_string(),
+    });
+}
+
+/// A comment inside the braces runs to the end of the line and is no part of
+/// the text an `=` conversion echoes.
+fn strip_debug_comments(text: &str) -> String {
+    let mut result = String::with_capacity(text.len());
+    let mut in_comment = false;
+    for ch in text.chars() {
+        if in_comment {
+            if ch == '\n' {
+                in_comment = false;
+                result.push(ch);
+            }
+        } else if ch == '#' {
+            in_comment = true;
+        } else {
+            result.push(ch);
+        }
+    }
+    result
 }
 
 fn range(range: impl RangeParts) -> (u32, u32) {

--- a/pyre/pyre-interpreter/src/module/_ast/convert.rs
+++ b/pyre/pyre-interpreter/src/module/_ast/convert.rs
@@ -140,38 +140,27 @@ impl ObjectConverter {
     fn stmt(&mut self, object: PyObjectRef) -> AstResult<ast::Stmt> {
         if self.is_node(object, "FunctionDef")? || self.is_node(object, "AsyncFunctionDef")? {
             let is_async = self.is_node(object, "AsyncFunctionDef")?;
-            let name = ast::Identifier::new(
-                self.string(
-                    object,
-                    "name",
-                    if is_async {
-                        "AsyncFunctionDef"
-                    } else {
-                        "FunctionDef"
-                    },
-                )?,
-                Default::default(),
-            );
-            let args = self.field(object, "args", "FunctionDef")?;
+            let node = if is_async {
+                "AsyncFunctionDef"
+            } else {
+                "FunctionDef"
+            };
+            let name = self.identifier(object, "name", node)?;
+            let args = self.field(object, "args", node)?;
             let parameters = Box::new(self.recurse(|this| this.parameters(args))?);
-            let body = self
-                .list(object, "body", "FunctionDef")?
-                .into_iter()
-                .map(|value| self.recurse(|this| this.stmt(value)))
-                .collect::<Result<Vec<_>, _>>()?;
-            // `type_params` was added after the original positional
-            // FunctionDef constructor.  Like RustPython/PyPy, a missing field
-            // on a manually constructed legacy node means an empty list.
-            let _type_params = self.optional_field(object, "type_params")?;
+            let body = self.body(object, "body", node)?;
+            let decorator_list = self.decorators(object, node)?;
+            let returns = self.opt_expr(object, "returns")?;
+            let type_params = self.type_params(object)?;
             Ok(ast::Stmt::FunctionDef(ast::StmtFunctionDef {
                 node_index: Default::default(),
                 range: Default::default(),
                 is_async,
-                decorator_list: Vec::new(),
+                decorator_list,
                 name,
-                type_params: None,
+                type_params,
                 parameters,
-                returns: None,
+                returns,
                 body,
                 runtime_decorator_list: None,
                 runtime_type_comment: None,
@@ -215,6 +204,288 @@ impl ObjectConverter {
                 runtime_type_comment: None,
                 runtime_type_comment_bytes: None,
             }))
+        } else if self.is_node(object, "ClassDef")? {
+            let name = self.identifier(object, "name", "ClassDef")?;
+            let bases = self.exprs(object, "bases", "ClassDef")?;
+            let keywords = self
+                .list(object, "keywords", "ClassDef")?
+                .into_iter()
+                .map(|keyword| self.recurse(|this| this.keyword(keyword)))
+                .collect::<Result<Vec<_>, _>>()?;
+            let body = self.body(object, "body", "ClassDef")?;
+            let decorator_list = self.decorators(object, "ClassDef")?;
+            let type_params = self.type_params(object)?;
+            // An absent argument list and an empty one are different trees, and
+            // only the former elides the parentheses.
+            let arguments = if bases.is_empty() && keywords.is_empty() {
+                None
+            } else {
+                Some(Box::new(ast::Arguments {
+                    node_index: Default::default(),
+                    range: Default::default(),
+                    args: bases.into_boxed_slice(),
+                    keywords: keywords.into_boxed_slice(),
+                    runtime_args: None,
+                    runtime_bases: None,
+                }))
+            };
+            Ok(ast::Stmt::ClassDef(ast::StmtClassDef {
+                node_index: Default::default(),
+                range: Default::default(),
+                decorator_list,
+                name,
+                type_params,
+                arguments,
+                body,
+                runtime_decorator_list: None,
+                runtime_body: None,
+            }))
+        } else if self.is_node(object, "Delete")? {
+            Ok(ast::Stmt::Delete(ast::StmtDelete {
+                node_index: Default::default(),
+                range: Default::default(),
+                targets: self.exprs(object, "targets", "Delete")?,
+                runtime_targets: None,
+            }))
+        } else if self.is_node(object, "TypeAlias")? {
+            let name = self.req_expr(object, "name", "TypeAlias")?;
+            let type_params = self.type_params(object)?;
+            let value = self.req_expr(object, "value", "TypeAlias")?;
+            Ok(ast::Stmt::TypeAlias(ast::StmtTypeAlias {
+                node_index: Default::default(),
+                range: Default::default(),
+                name,
+                type_params,
+                value,
+            }))
+        } else if self.is_node(object, "AugAssign")? {
+            let target = self.req_expr(object, "target", "AugAssign")?;
+            let op = self.field(object, "op", "AugAssign")?;
+            let value = self.req_expr(object, "value", "AugAssign")?;
+            Ok(ast::Stmt::AugAssign(ast::StmtAugAssign {
+                node_index: Default::default(),
+                range: Default::default(),
+                target,
+                op: self.operator(op)?,
+                value,
+            }))
+        } else if self.is_node(object, "AnnAssign")? {
+            let target = self.req_expr(object, "target", "AnnAssign")?;
+            let annotation = self.req_expr(object, "annotation", "AnnAssign")?;
+            let value = self.opt_expr(object, "value")?;
+            let simple = self.int_field(object, "simple", "AnnAssign")?;
+            Ok(ast::Stmt::AnnAssign(ast::StmtAnnAssign {
+                node_index: Default::default(),
+                range: Default::default(),
+                target,
+                annotation,
+                value,
+                simple: simple != 0,
+                runtime_simple: None,
+            }))
+        } else if self.is_node(object, "For")? || self.is_node(object, "AsyncFor")? {
+            let is_async = self.is_node(object, "AsyncFor")?;
+            let node = if is_async { "AsyncFor" } else { "For" };
+            let target = self.req_expr(object, "target", node)?;
+            let iter = self.req_expr(object, "iter", node)?;
+            let body = self.body(object, "body", node)?;
+            let orelse = self.body(object, "orelse", node)?;
+            Ok(ast::Stmt::For(ast::StmtFor {
+                node_index: Default::default(),
+                range: Default::default(),
+                is_async,
+                target,
+                iter,
+                body,
+                orelse,
+                runtime_type_comment: None,
+                runtime_type_comment_bytes: None,
+                runtime_body: None,
+                runtime_orelse: None,
+            }))
+        } else if self.is_node(object, "While")? {
+            let test = self.req_expr(object, "test", "While")?;
+            let body = self.body(object, "body", "While")?;
+            let orelse = self.body(object, "orelse", "While")?;
+            Ok(ast::Stmt::While(ast::StmtWhile {
+                node_index: Default::default(),
+                range: Default::default(),
+                test,
+                body,
+                orelse,
+                runtime_body: None,
+                runtime_orelse: None,
+            }))
+        } else if self.is_node(object, "If")? {
+            let test = self.req_expr(object, "test", "If")?;
+            let body = self.body(object, "body", "If")?;
+            // `If` carries its alternatives as a nested `orelse`, while the
+            // compiler AST keeps them in one flat clause list.  An `elif` and an
+            // `else` holding a single `if` are indistinguishable here, exactly as
+            // they are to the parser, so both flatten the same way.
+            let mut elif_else_clauses = Vec::new();
+            let mut orelse = self.list(object, "orelse", "If")?;
+            while !orelse.is_empty() {
+                if orelse.len() == 1 && self.is_node(orelse[0], "If")? {
+                    let nested = orelse[0];
+                    let clause_test = self.req_expr(nested, "test", "If")?;
+                    let clause_body = self.body(nested, "body", "If")?;
+                    elif_else_clauses.push(ast::ElifElseClause {
+                        range: Default::default(),
+                        node_index: Default::default(),
+                        test: Some(*clause_test),
+                        body: clause_body,
+                        runtime_body: None,
+                        runtime_orelse: None,
+                    });
+                    orelse = self.list(nested, "orelse", "If")?;
+                } else {
+                    let values = std::mem::take(&mut orelse);
+                    let clause_body = values
+                        .into_iter()
+                        .map(|value| self.recurse(|this| this.stmt(value)))
+                        .collect::<Result<Vec<_>, _>>()?;
+                    elif_else_clauses.push(ast::ElifElseClause {
+                        range: Default::default(),
+                        node_index: Default::default(),
+                        test: None,
+                        body: clause_body,
+                        runtime_body: None,
+                        runtime_orelse: None,
+                    });
+                }
+            }
+            Ok(ast::Stmt::If(ast::StmtIf {
+                node_index: Default::default(),
+                range: Default::default(),
+                test,
+                body,
+                elif_else_clauses,
+                runtime_body: None,
+            }))
+        } else if self.is_node(object, "With")? || self.is_node(object, "AsyncWith")? {
+            let is_async = self.is_node(object, "AsyncWith")?;
+            let node = if is_async { "AsyncWith" } else { "With" };
+            let items = self
+                .list(object, "items", node)?
+                .into_iter()
+                .map(|item| self.recurse(|this| this.with_item(item)))
+                .collect::<Result<Vec<_>, _>>()?;
+            let body = self.body(object, "body", node)?;
+            Ok(ast::Stmt::With(ast::StmtWith {
+                node_index: Default::default(),
+                range: Default::default(),
+                is_async,
+                items,
+                body,
+                runtime_type_comment: None,
+                runtime_type_comment_bytes: None,
+                runtime_body: None,
+            }))
+        } else if self.is_node(object, "Raise")? {
+            Ok(ast::Stmt::Raise(ast::StmtRaise {
+                node_index: Default::default(),
+                range: Default::default(),
+                exc: self.opt_expr(object, "exc")?,
+                cause: self.opt_expr(object, "cause")?,
+            }))
+        } else if self.is_node(object, "Try")? || self.is_node(object, "TryStar")? {
+            let is_star = self.is_node(object, "TryStar")?;
+            let node = if is_star { "TryStar" } else { "Try" };
+            let body = self.body(object, "body", node)?;
+            let handlers = self
+                .list(object, "handlers", node)?
+                .into_iter()
+                .map(|handler| self.recurse(|this| this.handler(handler)))
+                .collect::<Result<Vec<_>, _>>()?;
+            let orelse = self.body(object, "orelse", node)?;
+            let finalbody = self.body(object, "finalbody", node)?;
+            Ok(ast::Stmt::Try(ast::StmtTry {
+                node_index: Default::default(),
+                range: Default::default(),
+                body,
+                handlers,
+                orelse,
+                finalbody,
+                is_star,
+                runtime_body: None,
+                runtime_handlers: None,
+                runtime_orelse: None,
+                runtime_finalbody: None,
+            }))
+        } else if self.is_node(object, "Assert")? {
+            let test = self.req_expr(object, "test", "Assert")?;
+            let msg = self.opt_expr(object, "msg")?;
+            Ok(ast::Stmt::Assert(ast::StmtAssert {
+                node_index: Default::default(),
+                range: Default::default(),
+                test,
+                msg,
+            }))
+        } else if self.is_node(object, "Import")? {
+            Ok(ast::Stmt::Import(ast::StmtImport {
+                node_index: Default::default(),
+                range: Default::default(),
+                names: self.aliases(object, "Import")?,
+                is_lazy: false,
+            }))
+        } else if self.is_node(object, "ImportFrom")? {
+            let module = self.opt_identifier(object, "module")?;
+            let names = self.aliases(object, "ImportFrom")?;
+            // `level` is optional on a hand-built node and defaults to absolute.
+            let level = match self.optional_field(object, "level")? {
+                Some(value) => crate::builtins::space_index_w(value)?,
+                None => 0,
+            };
+            if level < 0 {
+                return Err(crate::PyError::value_error(
+                    "ImportFrom level must be non-negative",
+                ));
+            }
+            Ok(ast::Stmt::ImportFrom(ast::StmtImportFrom {
+                node_index: Default::default(),
+                range: Default::default(),
+                module,
+                names,
+                level: level as u32,
+                is_lazy: false,
+                runtime_level: None,
+            }))
+        } else if self.is_node(object, "Global")? {
+            Ok(ast::Stmt::Global(ast::StmtGlobal {
+                node_index: Default::default(),
+                range: Default::default(),
+                names: self.identifiers(object, "names", "Global")?,
+            }))
+        } else if self.is_node(object, "Nonlocal")? {
+            Ok(ast::Stmt::Nonlocal(ast::StmtNonlocal {
+                node_index: Default::default(),
+                range: Default::default(),
+                names: self.identifiers(object, "names", "Nonlocal")?,
+            }))
+        } else if self.is_node(object, "Break")? {
+            Ok(ast::Stmt::Break(ast::StmtBreak {
+                node_index: Default::default(),
+                range: Default::default(),
+            }))
+        } else if self.is_node(object, "Continue")? {
+            Ok(ast::Stmt::Continue(ast::StmtContinue {
+                node_index: Default::default(),
+                range: Default::default(),
+            }))
+        } else if self.is_node(object, "Match")? {
+            let subject = self.req_expr(object, "subject", "Match")?;
+            let cases = self
+                .list(object, "cases", "Match")?
+                .into_iter()
+                .map(|case| self.recurse(|this| this.match_case(case)))
+                .collect::<Result<Vec<_>, _>>()?;
+            Ok(ast::Stmt::Match(ast::StmtMatch {
+                node_index: Default::default(),
+                range: Default::default(),
+                subject,
+                cases,
+            }))
         } else {
             Err(crate::PyError::type_error(format!(
                 "expected some sort of stmt, but got {}",
@@ -224,29 +495,474 @@ impl ObjectConverter {
     }
 
     fn parameters(&mut self, object: PyObjectRef) -> AstResult<ast::Parameters> {
-        // Preserve the ASDL field reads even for empty argument lists.  Defaults
-        // are paired with parameters in source order by the complete converter.
-        for field in [
-            "posonlyargs",
-            "args",
-            "kwonlyargs",
-            "kw_defaults",
-            "defaults",
-        ] {
-            if !self.list(object, field, "arguments")?.is_empty() {
-                return Err(crate::PyError::not_implemented(
-                    "compiling AST functions with parameters is not implemented",
-                ));
-            }
-        }
-        if self.optional_field(object, "vararg")?.is_some()
-            || self.optional_field(object, "kwarg")?.is_some()
-        {
-            return Err(crate::PyError::not_implemented(
-                "compiling AST functions with variadic parameters is not implemented",
+        let posonlyargs = self.parameter_list(object, "posonlyargs")?;
+        let args = self.parameter_list(object, "args")?;
+        let kwonlyargs = self.parameter_list(object, "kwonlyargs")?;
+        let vararg = self.opt_parameter(object, "vararg")?;
+        let kwarg = self.opt_parameter(object, "kwarg")?;
+        // `defaults` covers the tail of posonlyargs ++ args, while `kw_defaults`
+        // runs alongside kwonlyargs with a hole for every parameter that has
+        // none.  The compiler AST carries each default on its own parameter, so
+        // both lists are distributed here.
+        let defaults = self.exprs(object, "defaults", "arguments")?;
+        let kw_defaults = self.list(object, "kw_defaults", "arguments")?;
+        if kw_defaults.len() > kwonlyargs.len() {
+            return Err(crate::PyError::value_error(
+                "arguments has more kw_defaults than kwonlyargs",
             ));
         }
-        Ok(ast::Parameters::default())
+        let mut positional: Vec<ast::Parameter> = posonlyargs;
+        let posonly_count = positional.len();
+        positional.extend(args);
+        if defaults.len() > positional.len() {
+            return Err(crate::PyError::value_error(
+                "arguments has more defaults than args",
+            ));
+        }
+        let first_default = positional.len() - defaults.len();
+        let mut positional: Vec<ast::ParameterWithDefault> = positional
+            .into_iter()
+            .map(|parameter| ast::ParameterWithDefault {
+                range: Default::default(),
+                node_index: Default::default(),
+                parameter,
+                default: None,
+            })
+            .collect();
+        for (offset, default) in defaults.into_iter().enumerate() {
+            positional[first_default + offset].default = Some(Box::new(default));
+        }
+        let args = positional.split_off(posonly_count);
+        let posonlyargs = positional;
+        let mut kwonly: Vec<ast::ParameterWithDefault> = kwonlyargs
+            .into_iter()
+            .map(|parameter| ast::ParameterWithDefault {
+                range: Default::default(),
+                node_index: Default::default(),
+                parameter,
+                default: None,
+            })
+            .collect();
+        for (index, default) in kw_defaults.into_iter().enumerate() {
+            if unsafe { pyre_object::is_none(default) } {
+                continue;
+            }
+            kwonly[index].default = Some(Box::new(self.recurse(|this| this.expr(default))?));
+        }
+        Ok(ast::Parameters {
+            range: Default::default(),
+            node_index: Default::default(),
+            posonlyargs,
+            args,
+            vararg,
+            kwonlyargs: kwonly,
+            kwarg,
+            runtime_defaults: None,
+        })
+    }
+
+    fn parameter_list(
+        &mut self,
+        object: PyObjectRef,
+        field: &str,
+    ) -> AstResult<Vec<ast::Parameter>> {
+        self.list(object, field, "arguments")?
+            .into_iter()
+            .map(|value| self.recurse(|this| this.parameter(value)))
+            .collect()
+    }
+
+    fn opt_parameter(
+        &mut self,
+        object: PyObjectRef,
+        field: &str,
+    ) -> AstResult<Option<Box<ast::Parameter>>> {
+        self.optional_field(object, field)?
+            .map(|value| self.recurse(|this| this.parameter(value)).map(Box::new))
+            .transpose()
+    }
+
+    fn parameter(&mut self, object: PyObjectRef) -> AstResult<ast::Parameter> {
+        Ok(ast::Parameter {
+            range: Default::default(),
+            node_index: Default::default(),
+            name: self.identifier(object, "arg", "arg")?,
+            annotation: self.opt_expr(object, "annotation")?,
+            runtime_type_comment: None,
+            runtime_type_comment_bytes: None,
+        })
+    }
+
+    fn with_item(&mut self, object: PyObjectRef) -> AstResult<ast::WithItem> {
+        let context_expr = self.req_expr(object, "context_expr", "withitem")?;
+        Ok(ast::WithItem {
+            range: Default::default(),
+            node_index: Default::default(),
+            context_expr: *context_expr,
+            optional_vars: self.opt_expr(object, "optional_vars")?,
+        })
+    }
+
+    fn handler(&mut self, object: PyObjectRef) -> AstResult<ast::ExceptHandler> {
+        if !self.is_node(object, "ExceptHandler")? {
+            return Err(crate::PyError::type_error(format!(
+                "expected some sort of excepthandler, but got {}",
+                unsafe { pyre_object::type_name_of(object) }
+            )));
+        }
+        Ok(ast::ExceptHandler::ExceptHandler(
+            ast::ExceptHandlerExceptHandler {
+                range: Default::default(),
+                node_index: Default::default(),
+                type_: self.opt_expr(object, "type")?,
+                name: self.opt_identifier(object, "name")?,
+                body: self.body(object, "body", "ExceptHandler")?,
+                runtime_body: None,
+            },
+        ))
+    }
+
+    fn comprehension(&mut self, object: PyObjectRef) -> AstResult<ast::Comprehension> {
+        let target = self.req_expr(object, "target", "comprehension")?;
+        let iter = self.req_expr(object, "iter", "comprehension")?;
+        let ifs = self.exprs(object, "ifs", "comprehension")?;
+        let is_async = self.int_field(object, "is_async", "comprehension")?;
+        Ok(ast::Comprehension {
+            range: Default::default(),
+            node_index: Default::default(),
+            target: *target,
+            iter: *iter,
+            ifs,
+            is_async: is_async != 0,
+            runtime_ifs: None,
+            runtime_is_async: None,
+        })
+    }
+
+    fn comprehensions(
+        &mut self,
+        object: PyObjectRef,
+        node: &str,
+    ) -> AstResult<Vec<ast::Comprehension>> {
+        self.list(object, "generators", node)?
+            .into_iter()
+            .map(|value| self.recurse(|this| this.comprehension(value)))
+            .collect()
+    }
+
+    fn aliases(&mut self, object: PyObjectRef, node: &str) -> AstResult<Vec<ast::Alias>> {
+        self.list(object, "names", node)?
+            .into_iter()
+            .map(|value| {
+                Ok(ast::Alias {
+                    range: Default::default(),
+                    node_index: Default::default(),
+                    name: self.identifier(value, "name", "alias")?,
+                    asname: self.opt_identifier(value, "asname")?,
+                })
+            })
+            .collect()
+    }
+
+    fn decorators(&mut self, object: PyObjectRef, node: &str) -> AstResult<Vec<ast::Decorator>> {
+        self.list(object, "decorator_list", node)?
+            .into_iter()
+            .map(|value| {
+                Ok(ast::Decorator {
+                    range: Default::default(),
+                    node_index: Default::default(),
+                    expression: self.recurse(|this| this.expr(value))?,
+                })
+            })
+            .collect()
+    }
+
+    /// `type_params` postdates the original positional constructors, so a
+    /// manually built legacy node without the field means an empty list.
+    fn type_params(&mut self, object: PyObjectRef) -> AstResult<Option<Box<ast::TypeParams>>> {
+        let Some(field) = self.optional_field(object, "type_params")? else {
+            return Ok(None);
+        };
+        if !unsafe { pyre_object::is_list(field) } {
+            return Err(crate::PyError::type_error(
+                "AST list field must be a list, not object",
+            ));
+        }
+        let values = unsafe { pyre_object::w_list_items_copy_as_vec(field) };
+        if values.is_empty() {
+            return Ok(None);
+        }
+        let type_params = values
+            .into_iter()
+            .map(|value| self.recurse(|this| this.type_param(value)))
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Some(Box::new(ast::TypeParams {
+            range: Default::default(),
+            node_index: Default::default(),
+            type_params,
+            runtime_type_params: None,
+        })))
+    }
+
+    fn type_param(&mut self, object: PyObjectRef) -> AstResult<ast::TypeParam> {
+        if self.is_node(object, "TypeVar")? {
+            let name = self.identifier(object, "name", "TypeVar")?;
+            Ok(ast::TypeParam::TypeVar(ast::TypeParamTypeVar {
+                node_index: Default::default(),
+                range: Default::default(),
+                name,
+                bound: self.opt_expr(object, "bound")?,
+                default: self.opt_expr(object, "default_value")?,
+            }))
+        } else if self.is_node(object, "TypeVarTuple")? {
+            let name = self.identifier(object, "name", "TypeVarTuple")?;
+            Ok(ast::TypeParam::TypeVarTuple(ast::TypeParamTypeVarTuple {
+                node_index: Default::default(),
+                range: Default::default(),
+                name,
+                default: self.opt_expr(object, "default_value")?,
+            }))
+        } else if self.is_node(object, "ParamSpec")? {
+            let name = self.identifier(object, "name", "ParamSpec")?;
+            Ok(ast::TypeParam::ParamSpec(ast::TypeParamParamSpec {
+                node_index: Default::default(),
+                range: Default::default(),
+                name,
+                default: self.opt_expr(object, "default_value")?,
+            }))
+        } else {
+            Err(crate::PyError::type_error(format!(
+                "expected some sort of type_param, but got {}",
+                unsafe { pyre_object::type_name_of(object) }
+            )))
+        }
+    }
+
+    fn match_case(&mut self, object: PyObjectRef) -> AstResult<ast::MatchCase> {
+        let pattern = self.field(object, "pattern", "match_case")?;
+        let pattern = self.recurse(|this| this.pattern(pattern))?;
+        Ok(ast::MatchCase {
+            range: Default::default(),
+            node_index: Default::default(),
+            pattern,
+            guard: self.opt_expr(object, "guard")?,
+            body: self.body(object, "body", "match_case")?,
+            runtime_body: None,
+        })
+    }
+
+    fn patterns(
+        &mut self,
+        object: PyObjectRef,
+        field: &str,
+        node: &str,
+    ) -> AstResult<Vec<ast::Pattern>> {
+        self.list(object, field, node)?
+            .into_iter()
+            .map(|value| self.recurse(|this| this.pattern(value)))
+            .collect()
+    }
+
+    fn pattern(&mut self, object: PyObjectRef) -> AstResult<ast::Pattern> {
+        if self.is_node(object, "MatchValue")? {
+            Ok(ast::Pattern::MatchValue(ast::PatternMatchValue {
+                node_index: Default::default(),
+                range: Default::default(),
+                value: self.req_expr(object, "value", "MatchValue")?,
+            }))
+        } else if self.is_node(object, "MatchSingleton")? {
+            let value = self.field(object, "value", "MatchSingleton")?;
+            let value = unsafe {
+                if pyre_object::is_none(value) {
+                    ast::Singleton::None
+                } else if pyre_object::is_bool(value) {
+                    if pyre_object::w_bool_get_value(value) {
+                        ast::Singleton::True
+                    } else {
+                        ast::Singleton::False
+                    }
+                } else {
+                    return Err(crate::PyError::value_error(
+                        "MatchSingleton value must be True, False or None",
+                    ));
+                }
+            };
+            Ok(ast::Pattern::MatchSingleton(ast::PatternMatchSingleton {
+                node_index: Default::default(),
+                range: Default::default(),
+                value,
+            }))
+        } else if self.is_node(object, "MatchSequence")? {
+            Ok(ast::Pattern::MatchSequence(ast::PatternMatchSequence {
+                node_index: Default::default(),
+                range: Default::default(),
+                patterns: self.patterns(object, "patterns", "MatchSequence")?,
+                runtime_patterns: None,
+            }))
+        } else if self.is_node(object, "MatchMapping")? {
+            let keys = self.exprs(object, "keys", "MatchMapping")?;
+            let patterns = self.patterns(object, "patterns", "MatchMapping")?;
+            Ok(ast::Pattern::MatchMapping(ast::PatternMatchMapping {
+                node_index: Default::default(),
+                range: Default::default(),
+                keys,
+                patterns,
+                rest: self.opt_identifier(object, "rest")?,
+                runtime_keys: None,
+                runtime_patterns: None,
+            }))
+        } else if self.is_node(object, "MatchClass")? {
+            let cls = self.req_expr(object, "cls", "MatchClass")?;
+            let patterns = self.patterns(object, "patterns", "MatchClass")?;
+            let attrs = self.identifiers(object, "kwd_attrs", "MatchClass")?;
+            let kwd_patterns = self.patterns(object, "kwd_patterns", "MatchClass")?;
+            if attrs.len() != kwd_patterns.len() {
+                return Err(crate::PyError::value_error(
+                    "MatchClass doesn't have the same number of keyword attributes as patterns",
+                ));
+            }
+            let keywords = attrs
+                .into_iter()
+                .zip(kwd_patterns)
+                .map(|(attr, pattern)| ast::PatternKeyword {
+                    range: Default::default(),
+                    node_index: Default::default(),
+                    attr,
+                    pattern,
+                })
+                .collect();
+            Ok(ast::Pattern::MatchClass(ast::PatternMatchClass {
+                node_index: Default::default(),
+                range: Default::default(),
+                cls,
+                arguments: ast::PatternArguments {
+                    range: Default::default(),
+                    node_index: Default::default(),
+                    patterns,
+                    keywords,
+                },
+                runtime_patterns: None,
+                runtime_kwd_attrs: None,
+                runtime_kwd_patterns: None,
+            }))
+        } else if self.is_node(object, "MatchStar")? {
+            Ok(ast::Pattern::MatchStar(ast::PatternMatchStar {
+                node_index: Default::default(),
+                range: Default::default(),
+                name: self.opt_identifier(object, "name")?,
+            }))
+        } else if self.is_node(object, "MatchAs")? {
+            let pattern = self
+                .optional_field(object, "pattern")?
+                .map(|value| self.recurse(|this| this.pattern(value)).map(Box::new))
+                .transpose()?;
+            Ok(ast::Pattern::MatchAs(ast::PatternMatchAs {
+                node_index: Default::default(),
+                range: Default::default(),
+                pattern,
+                name: self.opt_identifier(object, "name")?,
+            }))
+        } else if self.is_node(object, "MatchOr")? {
+            Ok(ast::Pattern::MatchOr(ast::PatternMatchOr {
+                node_index: Default::default(),
+                range: Default::default(),
+                patterns: self.patterns(object, "patterns", "MatchOr")?,
+                runtime_patterns: None,
+            }))
+        } else {
+            Err(crate::PyError::type_error(format!(
+                "expected some sort of pattern, but got {}",
+                unsafe { pyre_object::type_name_of(object) }
+            )))
+        }
+    }
+
+    fn body(&mut self, object: PyObjectRef, field: &str, node: &str) -> AstResult<Vec<ast::Stmt>> {
+        self.list(object, field, node)?
+            .into_iter()
+            .map(|value| self.recurse(|this| this.stmt(value)))
+            .collect()
+    }
+
+    fn exprs(&mut self, object: PyObjectRef, field: &str, node: &str) -> AstResult<Vec<ast::Expr>> {
+        self.list(object, field, node)?
+            .into_iter()
+            .map(|value| self.recurse(|this| this.expr(value)))
+            .collect()
+    }
+
+    fn req_expr(
+        &mut self,
+        object: PyObjectRef,
+        field: &str,
+        node: &str,
+    ) -> AstResult<Box<ast::Expr>> {
+        let value = self.field(object, field, node)?;
+        Ok(Box::new(self.recurse(|this| this.expr(value))?))
+    }
+
+    fn opt_expr(&mut self, object: PyObjectRef, field: &str) -> AstResult<Option<Box<ast::Expr>>> {
+        self.optional_field(object, field)?
+            .map(|value| self.recurse(|this| this.expr(value)).map(Box::new))
+            .transpose()
+    }
+
+    fn identifier(
+        &self,
+        object: PyObjectRef,
+        field: &str,
+        node: &str,
+    ) -> AstResult<ast::Identifier> {
+        Ok(ast::Identifier::new(
+            self.string(object, field, node)?,
+            Default::default(),
+        ))
+    }
+
+    fn opt_identifier(
+        &self,
+        object: PyObjectRef,
+        field: &str,
+    ) -> AstResult<Option<ast::Identifier>> {
+        let Some(value) = self.optional_field(object, field)? else {
+            return Ok(None);
+        };
+        if !unsafe { pyre_object::is_str(value) } {
+            return Err(crate::PyError::type_error(
+                "AST identifier must be of type str",
+            ));
+        }
+        Ok(Some(ast::Identifier::new(
+            unsafe { pyre_object::w_str_get_value(value).to_string() },
+            Default::default(),
+        )))
+    }
+
+    fn identifiers(
+        &self,
+        object: PyObjectRef,
+        field: &str,
+        node: &str,
+    ) -> AstResult<Vec<ast::Identifier>> {
+        self.list(object, field, node)?
+            .into_iter()
+            .map(|value| {
+                if !unsafe { pyre_object::is_str(value) } {
+                    return Err(crate::PyError::type_error(
+                        "AST identifier must be of type str",
+                    ));
+                }
+                Ok(ast::Identifier::new(
+                    unsafe { pyre_object::w_str_get_value(value).to_string() },
+                    Default::default(),
+                ))
+            })
+            .collect()
+    }
+
+    fn int_field(&self, object: PyObjectRef, field: &str, node: &str) -> AstResult<i64> {
+        let value = self.field(object, field, node)?;
+        crate::builtins::space_index_w(value)
     }
 
     fn expr(&mut self, object: PyObjectRef) -> AstResult<ast::Expr> {
@@ -351,12 +1067,230 @@ impl ObjectConverter {
                 kind: None,
                 invalid_type: None,
             }))
+        } else if self.is_node(object, "BoolOp")? {
+            let op = self.field(object, "op", "BoolOp")?;
+            Ok(ast::Expr::BoolOp(ast::ExprBoolOp {
+                node_index: Default::default(),
+                range: Default::default(),
+                op: self.boolop(op)?,
+                values: self.exprs(object, "values", "BoolOp")?,
+                runtime_values: None,
+            }))
+        } else if self.is_node(object, "NamedExpr")? {
+            let target = self.req_expr(object, "target", "NamedExpr")?;
+            let value = self.req_expr(object, "value", "NamedExpr")?;
+            Ok(ast::Expr::Named(ast::ExprNamed {
+                node_index: Default::default(),
+                range: Default::default(),
+                target,
+                value,
+            }))
+        } else if self.is_node(object, "Lambda")? {
+            let args = self.field(object, "args", "Lambda")?;
+            let parameters = self.recurse(|this| this.parameters(args))?;
+            let body = self.req_expr(object, "body", "Lambda")?;
+            Ok(ast::Expr::Lambda(ast::ExprLambda {
+                node_index: Default::default(),
+                range: Default::default(),
+                parameters: Some(Box::new(parameters)),
+                body,
+            }))
+        } else if self.is_node(object, "IfExp")? {
+            let test = self.req_expr(object, "test", "IfExp")?;
+            let body = self.req_expr(object, "body", "IfExp")?;
+            let orelse = self.req_expr(object, "orelse", "IfExp")?;
+            Ok(ast::Expr::If(ast::ExprIf {
+                node_index: Default::default(),
+                range: Default::default(),
+                test,
+                body,
+                orelse,
+            }))
+        } else if self.is_node(object, "Dict")? {
+            let keys = self.list(object, "keys", "Dict")?;
+            let values = self.list(object, "values", "Dict")?;
+            if keys.len() != values.len() {
+                return Err(crate::PyError::value_error(
+                    "Dict doesn't have the same number of keys as values",
+                ));
+            }
+            // A `None` key is the `**mapping` spread, which has no key node.
+            let items = keys
+                .into_iter()
+                .zip(values)
+                .map(|(key, value)| {
+                    let key = if unsafe { pyre_object::is_none(key) } {
+                        None
+                    } else {
+                        Some(self.recurse(|this| this.expr(key))?)
+                    };
+                    Ok(ast::DictItem {
+                        key,
+                        value: self.recurse(|this| this.expr(value))?,
+                    })
+                })
+                .collect::<Result<Vec<_>, crate::PyError>>()?;
+            Ok(ast::Expr::Dict(ast::ExprDict {
+                node_index: Default::default(),
+                range: Default::default(),
+                items,
+                runtime_values: None,
+            }))
+        } else if self.is_node(object, "Set")? {
+            Ok(ast::Expr::Set(ast::ExprSet {
+                node_index: Default::default(),
+                range: Default::default(),
+                elts: self.exprs(object, "elts", "Set")?,
+                runtime_elts: None,
+            }))
+        } else if self.is_node(object, "ListComp")? {
+            let elt = self.req_expr(object, "elt", "ListComp")?;
+            let generators = self.comprehensions(object, "ListComp")?;
+            Ok(ast::Expr::ListComp(ast::ExprListComp {
+                node_index: Default::default(),
+                range: Default::default(),
+                elt,
+                generators,
+            }))
+        } else if self.is_node(object, "SetComp")? {
+            let elt = self.req_expr(object, "elt", "SetComp")?;
+            let generators = self.comprehensions(object, "SetComp")?;
+            Ok(ast::Expr::SetComp(ast::ExprSetComp {
+                node_index: Default::default(),
+                range: Default::default(),
+                elt,
+                generators,
+            }))
+        } else if self.is_node(object, "DictComp")? {
+            let key = self.req_expr(object, "key", "DictComp")?;
+            let value = self.req_expr(object, "value", "DictComp")?;
+            let generators = self.comprehensions(object, "DictComp")?;
+            Ok(ast::Expr::DictComp(ast::ExprDictComp {
+                node_index: Default::default(),
+                range: Default::default(),
+                key,
+                value,
+                generators,
+            }))
+        } else if self.is_node(object, "GeneratorExp")? {
+            let elt = self.req_expr(object, "elt", "GeneratorExp")?;
+            let generators = self.comprehensions(object, "GeneratorExp")?;
+            Ok(ast::Expr::Generator(ast::ExprGenerator {
+                node_index: Default::default(),
+                range: Default::default(),
+                elt,
+                generators,
+                parenthesized: true,
+            }))
+        } else if self.is_node(object, "Await")? {
+            Ok(ast::Expr::Await(ast::ExprAwait {
+                node_index: Default::default(),
+                range: Default::default(),
+                value: self.req_expr(object, "value", "Await")?,
+            }))
+        } else if self.is_node(object, "Yield")? {
+            Ok(ast::Expr::Yield(ast::ExprYield {
+                node_index: Default::default(),
+                range: Default::default(),
+                value: self.opt_expr(object, "value")?,
+            }))
+        } else if self.is_node(object, "YieldFrom")? {
+            Ok(ast::Expr::YieldFrom(ast::ExprYieldFrom {
+                node_index: Default::default(),
+                range: Default::default(),
+                value: self.req_expr(object, "value", "YieldFrom")?,
+            }))
+        } else if self.is_node(object, "Compare")? {
+            let left = self.req_expr(object, "left", "Compare")?;
+            let ops = self
+                .list(object, "ops", "Compare")?
+                .into_iter()
+                .map(|op| self.cmpop(op))
+                .collect::<Result<Vec<_>, _>>()?;
+            let comparators = self.exprs(object, "comparators", "Compare")?;
+            if ops.len() != comparators.len() {
+                return Err(crate::PyError::value_error(
+                    "Compare doesn't have the same number of ops as comparators",
+                ));
+            }
+            Ok(ast::Expr::Compare(ast::ExprCompare {
+                node_index: Default::default(),
+                range: Default::default(),
+                left,
+                ops: ops.into_boxed_slice(),
+                comparators: comparators.into_boxed_slice(),
+                runtime_comparators: None,
+            }))
+        } else if self.is_node(object, "Subscript")? {
+            let value = self.req_expr(object, "value", "Subscript")?;
+            let slice = self.req_expr(object, "slice", "Subscript")?;
+            let ctx = self.context(self.field(object, "ctx", "Subscript")?)?;
+            Ok(ast::Expr::Subscript(ast::ExprSubscript {
+                node_index: Default::default(),
+                range: Default::default(),
+                value,
+                slice,
+                ctx,
+            }))
+        } else if self.is_node(object, "Starred")? {
+            let value = self.req_expr(object, "value", "Starred")?;
+            let ctx = self.context(self.field(object, "ctx", "Starred")?)?;
+            Ok(ast::Expr::Starred(ast::ExprStarred {
+                node_index: Default::default(),
+                range: Default::default(),
+                value,
+                ctx,
+            }))
+        } else if self.is_node(object, "Slice")? {
+            Ok(ast::Expr::Slice(ast::ExprSlice {
+                node_index: Default::default(),
+                range: Default::default(),
+                lower: self.opt_expr(object, "lower")?,
+                upper: self.opt_expr(object, "upper")?,
+                step: self.opt_expr(object, "step")?,
+            }))
+        } else if self.is_node(object, "JoinedStr")? || self.is_node(object, "FormattedValue")? {
+            // The compiler AST keeps an f-string as its literal parts rather than
+            // as a concatenation node, so rebuilding one needs the part split
+            // that `JoinedStr` has already discarded.
+            Err(crate::PyError::not_implemented(
+                "compiling a JoinedStr AST node is not implemented",
+            ))
         } else {
             Err(crate::PyError::type_error(format!(
                 "expected some sort of expr, but got {}",
                 unsafe { pyre_object::type_name_of(object) }
             )))
         }
+    }
+
+    fn boolop(&self, object: PyObjectRef) -> AstResult<ast::BoolOp> {
+        for (name, op) in [("And", ast::BoolOp::And), ("Or", ast::BoolOp::Or)] {
+            if self.is_node(object, name)? {
+                return Ok(op);
+            }
+        }
+        Err(crate::PyError::type_error("expected some sort of boolop"))
+    }
+
+    fn cmpop(&self, object: PyObjectRef) -> AstResult<ast::CmpOp> {
+        for (name, op) in [
+            ("Eq", ast::CmpOp::Eq),
+            ("NotEq", ast::CmpOp::NotEq),
+            ("Lt", ast::CmpOp::Lt),
+            ("LtE", ast::CmpOp::LtE),
+            ("Gt", ast::CmpOp::Gt),
+            ("GtE", ast::CmpOp::GtE),
+            ("Is", ast::CmpOp::Is),
+            ("IsNot", ast::CmpOp::IsNot),
+            ("In", ast::CmpOp::In),
+            ("NotIn", ast::CmpOp::NotIn),
+        ] {
+            if self.is_node(object, name)? {
+                return Ok(op);
+            }
+        }
+        Err(crate::PyError::type_error("expected some sort of cmpop"))
     }
 
     fn keyword(&mut self, object: PyObjectRef) -> AstResult<ast::Keyword> {
@@ -419,8 +1353,29 @@ impl ObjectConverter {
                         .to_vec()
                         .into_boxed_slice(),
                 ))
+            } else if pyre_object::is_complex(object) {
+                Ok(ast::ConstantValue::Complex {
+                    real: pyre_object::w_complex_get_real(object),
+                    imag: pyre_object::w_complex_get_imag(object),
+                })
             } else if pyre_object::is_ellipsis(object) {
                 Ok(ast::ConstantValue::Ellipsis)
+            } else if pyre_object::is_tuple(object) {
+                // A container constant never comes out of the parser; it reaches
+                // here from a tree an optimizer folded, and it nests.
+                Ok(ast::ConstantValue::Tuple(
+                    pyre_object::w_tuple_items_copy_as_vec(object)
+                        .into_iter()
+                        .map(|item| self.constant_value(item))
+                        .collect::<Result<Vec<_>, _>>()?,
+                ))
+            } else if pyre_object::is_frozenset(object) {
+                Ok(ast::ConstantValue::Frozenset(
+                    pyre_object::w_set_items(object)
+                        .into_iter()
+                        .map(|item| self.constant_value(item))
+                        .collect::<Result<Vec<_>, _>>()?,
+                ))
             } else {
                 Err(crate::PyError::type_error(format!(
                     "got an invalid type in Constant: {}",

--- a/pyre/pyre-interpreter/src/module/_ast/convert.rs
+++ b/pyre/pyre-interpreter/src/module/_ast/convert.rs
@@ -139,7 +139,7 @@ impl ObjectConverter {
             let body = self.body(object, "body", node)?;
             let decorator_list = self.decorators(object, node)?;
             let returns = self.opt_expr(object, "returns")?;
-            let type_params = self.type_params(object)?;
+            let type_params = self.type_params(object, node)?;
             Ok(ast::Stmt::FunctionDef(ast::StmtFunctionDef {
                 node_index: Default::default(),
                 range: Default::default(),
@@ -202,7 +202,7 @@ impl ObjectConverter {
                 .collect::<Result<Vec<_>, _>>()?;
             let body = self.body(object, "body", "ClassDef")?;
             let decorator_list = self.decorators(object, "ClassDef")?;
-            let type_params = self.type_params(object)?;
+            let type_params = self.type_params(object, "ClassDef")?;
             // An absent argument list and an empty one are different trees, and
             // only the former elides the parentheses.
             let arguments = if bases.is_empty() && keywords.is_empty() {
@@ -237,7 +237,7 @@ impl ObjectConverter {
             }))
         } else if self.is_node(object, "TypeAlias")? {
             let name = self.req_expr(object, "name", "TypeAlias")?;
-            let type_params = self.type_params(object)?;
+            let type_params = self.type_params(object, "TypeAlias")?;
             let value = self.req_expr(object, "value", "TypeAlias")?;
             Ok(ast::Stmt::TypeAlias(ast::StmtTypeAlias {
                 node_index: Default::default(),
@@ -428,12 +428,18 @@ impl ObjectConverter {
             if level < 0 {
                 return Err(crate::PyError::value_error("Negative ImportFrom level"));
             }
+            // The field is read as a Python index, so a value past the range a
+            // level is stored in has to stop here rather than wrap and turn a
+            // relative import into an absolute one.
+            let level = u32::try_from(level).map_err(|_| {
+                crate::PyError::overflow_error("Python int too large to convert to C int")
+            })?;
             Ok(ast::Stmt::ImportFrom(ast::StmtImportFrom {
                 node_index: Default::default(),
                 range: Default::default(),
                 module,
                 names,
-                level: level as u32,
+                level,
                 is_lazy: false,
                 runtime_level: None,
             }))
@@ -665,14 +671,19 @@ impl ObjectConverter {
 
     /// `type_params` postdates the original positional constructors, so a
     /// manually built legacy node without the field means an empty list.
-    fn type_params(&mut self, object: PyObjectRef) -> AstResult<Option<Box<ast::TypeParams>>> {
+    fn type_params(
+        &mut self,
+        object: PyObjectRef,
+        node: &str,
+    ) -> AstResult<Option<Box<ast::TypeParams>>> {
         let Some(field) = self.optional_field(object, "type_params")? else {
             return Ok(None);
         };
         if !unsafe { pyre_object::is_list(field) } {
-            return Err(crate::PyError::type_error(
-                "AST list field must be a list, not object",
-            ));
+            return Err(crate::PyError::type_error(format!(
+                "{node} field \"type_params\" must be a list, not a {}",
+                class_name(field)
+            )));
         }
         let values = unsafe { pyre_object::w_list_items_copy_as_vec(field) };
         if values.is_empty() {

--- a/pyre/pyre-interpreter/src/module/_ast/convert.rs
+++ b/pyre/pyre-interpreter/src/module/_ast/convert.rs
@@ -30,6 +30,8 @@ pub fn compile_object(
         depth: 0,
     };
     let module = converter.module(object)?;
+    // compiling.py:73 — the tree is walked before it reaches the compiler.
+    crate::astcompiler::validate::validate_ast(&module)?;
     let source_file = rustpython_compiler::core::SourceFileBuilder::new(filename, "").finish();
     rustpython_compiler::codegen::compile::compile_top(module, source_file, mode, opts)
         .map_err(|error| crate::PyError::syntax_error(error.to_string()))
@@ -424,9 +426,7 @@ impl ObjectConverter {
                 None => 0,
             };
             if level < 0 {
-                return Err(crate::PyError::value_error(
-                    "ImportFrom level must be non-negative",
-                ));
+                return Err(crate::PyError::value_error("Negative ImportFrom level"));
             }
             Ok(ast::Stmt::ImportFrom(ast::StmtImportFrom {
                 node_index: Default::default(),
@@ -492,9 +492,9 @@ impl ObjectConverter {
         // both lists are distributed here.
         let defaults = self.exprs(object, "defaults", "arguments")?;
         let kw_defaults = self.list(object, "kw_defaults", "arguments")?;
-        if kw_defaults.len() > kwonlyargs.len() {
+        if kw_defaults.len() != kwonlyargs.len() {
             return Err(crate::PyError::value_error(
-                "arguments has more kw_defaults than kwonlyargs",
+                "length of kwonlyargs is not the same as kw_defaults on arguments",
             ));
         }
         let mut positional: Vec<ast::Parameter> = posonlyargs;
@@ -502,7 +502,7 @@ impl ObjectConverter {
         positional.extend(args);
         if defaults.len() > positional.len() {
             return Err(crate::PyError::value_error(
-                "arguments has more defaults than args",
+                "more positional defaults than args on arguments",
             ));
         }
         let first_default = positional.len() - defaults.len();
@@ -769,7 +769,7 @@ impl ObjectConverter {
                     }
                 } else {
                     return Err(crate::PyError::value_error(
-                        "MatchSingleton value must be True, False or None",
+                        "MatchSingleton can only contain True, False and None",
                     ));
                 }
             };
@@ -863,9 +863,11 @@ impl ObjectConverter {
         }
     }
 
-    /// A missing element of a statement or expression list is rejected before
-    /// the node conversion, which would only report the type it did not
-    /// recognise.  Lists of the other ASDL nodes carry no such check.
+    /// `_validate_stmts` / `_validate_exprs` (validate.py:132, :151) reject a
+    /// missing element of a statement or expression list.  The compiler AST
+    /// has nowhere to hold one, so unlike the rest of the validation this runs
+    /// during the conversion, where it is still visible.  Lists of the other
+    /// ASDL nodes carry no such check.
     fn require_node(&self, value: PyObjectRef, kind: &str) -> AstResult<()> {
         if unsafe { pyre_object::is_none(value) } {
             return Err(crate::PyError::value_error(format!(
@@ -1212,11 +1214,6 @@ impl ObjectConverter {
                 .map(|op| self.cmpop(op))
                 .collect::<Result<Vec<_>, _>>()?;
             let comparators = self.exprs(object, "comparators", "Compare")?;
-            if ops.len() != comparators.len() {
-                return Err(crate::PyError::value_error(
-                    "Compare doesn't have the same number of ops as comparators",
-                ));
-            }
             Ok(ast::Expr::Compare(ast::ExprCompare {
                 node_index: Default::default(),
                 range: Default::default(),
@@ -1278,10 +1275,11 @@ impl ObjectConverter {
                 expression,
                 debug_text: None,
                 conversion,
-                // A parsed spec is the element list standing between the
-                // braces, while the object carries a `JoinedStr`; codegen
-                // formats with that expression whenever the field below is
-                // set, so the parsed shape has nothing to hold.
+                // A spec is an expression that gets compiled like any other
+                // (`visit_FormattedValue`, codegen.py:2371). The compiler AST
+                // instead keeps the elements the parser found between the
+                // braces, which an object does not carry, so the spec rides
+                // the field below and the parsed shape stays empty.
                 format_spec: None,
                 runtime_str: None,
                 runtime_interpolation_format_spec: None,
@@ -1290,6 +1288,9 @@ impl ObjectConverter {
         ))
     }
 
+    /// `visit_FormattedValue` (codegen.py:2364) matches `s`, `r` and `a` and
+    /// leaves anything else at no conversion at all; 3.14 stops instead, so a
+    /// character it does not know is an error here.
     fn conversion(&self, object: PyObjectRef) -> AstResult<ast::ConversionFlag> {
         match self.int_field(object, "conversion", "FormattedValue")? {
             -1 => Ok(ast::ConversionFlag::None),
@@ -1477,10 +1478,11 @@ impl ObjectConverter {
     }
 }
 
-/// An f-string expression built from `_ast` objects.  The parser splits an
-/// f-string into the literal and interpolated parts the compiler AST holds,
-/// but a `JoinedStr` object carries only the values to join, so those go to
-/// codegen as the joined values and the part list stays empty.  A
+/// An f-string expression built from `_ast` objects.  `visit_JoinedStr`
+/// (codegen.py:2357) compiles the values one after another and joins them,
+/// which is the shape an object carries; the compiler AST instead holds the
+/// literal and interpolated parts the parser split, so the values are handed
+/// over as the parts to join and that part list stays empty.  A
 /// `FormattedValue` on its own is a single interpolated part, which does fit
 /// the part list.
 fn fstring(
@@ -2282,9 +2284,9 @@ impl Converter<'_> {
                     let mut conversion = interpolation.conversion;
                     if let Some(debug_text) = interpolation.debug_text.as_ref() {
                         self.push_debug_text(parts, interpolation, debug_text);
-                        // `=` echoes the expression text and then reprs the
-                        // value, unless a conversion or a format spec already
-                        // says how to render it.
+                        // fstring.py:315 — a debugging expression defaults to
+                        // `!r` when neither a conversion nor a format spec
+                        // says how to render the value.
                         if matches!(
                             (conversion, &interpolation.format_spec),
                             (ast::ConversionFlag::None, None)
@@ -2324,9 +2326,11 @@ impl Converter<'_> {
         Ok(())
     }
 
-    /// The literal an `=` conversion echoes: the source text of the
-    /// expression, framed by whatever stood between the brace and the
-    /// expression and between the expression and the `!`, `:` or `}`.
+    /// The literal an `=` conversion echoes.  `fstring_find_expr`
+    /// (fstring.py:279) takes it as one slice of the source, from the start of
+    /// the expression through the `=` and the whitespace after it; the parser
+    /// here hands over that frame as the text on either side of the
+    /// expression, so the slice is put back together from the two.
     fn push_debug_text(
         &self,
         parts: &mut Vec<JoinedPart>,
@@ -2830,10 +2834,12 @@ fn class_name(object: PyObjectRef) -> &'static str {
     }
 }
 
-/// A value of a `JoinedStr` under construction.  Consecutive literal pieces
-/// are one `Constant`, so what the parser kept apart -- an implicit
-/// concatenation, the text an `=` conversion echoes -- is joined as it
-/// arrives instead of reaching the tree one node per piece.
+/// A value of a `JoinedStr` under construction.  `add_constant_string`
+/// (fstring.py:23) folds a piece into the `Constant` before it, keeping that
+/// node's start and taking the new end, and an empty piece is dropped
+/// (`f_string_to_ast_node`, fstring.py:449); what the parser kept apart -- an
+/// implicit concatenation, the text an `=` conversion echoes -- therefore
+/// reaches the tree as one node, not one per piece.
 enum JoinedPart {
     Literal { start: u32, end: u32, value: String },
     Value(PyObjectRef),

--- a/pyre/pyre-interpreter/src/module/_ast/convert.rs
+++ b/pyre/pyre-interpreter/src/module/_ast/convert.rs
@@ -180,7 +180,10 @@ impl ObjectConverter {
             let targets = self
                 .list(object, "targets", "Assign")?
                 .into_iter()
-                .map(|value| self.recurse(|this| this.expr(value)))
+                .map(|value| {
+                    self.require_node(value, "expression")?;
+                    self.recurse(|this| this.expr(value))
+                })
                 .collect::<Result<Vec<_>, _>>()?;
             let value = self.field(object, "value", "Assign")?;
             Ok(ast::Stmt::Assign(ast::StmtAssign {
@@ -331,7 +334,10 @@ impl ObjectConverter {
                     let values = std::mem::take(&mut orelse);
                     let clause_body = values
                         .into_iter()
-                        .map(|value| self.recurse(|this| this.stmt(value)))
+                        .map(|value| {
+                            self.require_node(value, "statement")?;
+                            self.recurse(|this| this.stmt(value))
+                        })
                         .collect::<Result<Vec<_>, _>>()?;
                     elif_else_clauses.push(ast::ElifElseClause {
                         range: Default::default(),
@@ -660,6 +666,7 @@ impl ObjectConverter {
         self.list(object, "decorator_list", node)?
             .into_iter()
             .map(|value| {
+                self.require_node(value, "expression")?;
                 Ok(ast::Decorator {
                     range: Default::default(),
                     node_index: Default::default(),
@@ -1008,7 +1015,10 @@ impl ObjectConverter {
             let args = self
                 .list(object, "args", "Call")?
                 .into_iter()
-                .map(|arg| self.recurse(|this| this.expr(arg)))
+                .map(|arg| {
+                    self.require_node(arg, "expression")?;
+                    self.recurse(|this| this.expr(arg))
+                })
                 .collect::<Result<Vec<_>, _>>()?;
             let keywords = self
                 .list(object, "keywords", "Call")?
@@ -1046,7 +1056,10 @@ impl ObjectConverter {
             let elements = self
                 .list(object, "elts", if is_tuple { "Tuple" } else { "List" })?
                 .into_iter()
-                .map(|element| self.recurse(|this| this.expr(element)))
+                .map(|element| {
+                    self.require_node(element, "expression")?;
+                    self.recurse(|this| this.expr(element))
+                })
                 .collect::<Result<Vec<_>, _>>()?;
             let ctx = self.context(self.field(object, "ctx", "sequence")?)?;
             if is_tuple {
@@ -1141,6 +1154,7 @@ impl ObjectConverter {
                     } else {
                         Some(self.recurse(|this| this.expr(key))?)
                     };
+                    self.require_node(value, "expression")?;
                     Ok(ast::DictItem {
                         key,
                         value: self.recurse(|this| this.expr(value))?,
@@ -1412,7 +1426,9 @@ impl ObjectConverter {
                 Ok(ast::ConstantValue::Ellipsis)
             } else if pyre_object::is_tuple(object) {
                 // A container constant never comes out of the parser; it reaches
-                // here from a tree an optimizer folded, and it nests.
+                // here from a tree an optimizer folded, and it nests. The node
+                // depth guard does not apply: it counts AST nodes, and a
+                // constant nested past it still compiles where 3.14 compiles.
                 Ok(ast::ConstantValue::Tuple(
                     pyre_object::w_tuple_items_copy_as_vec(object)
                         .into_iter()


### PR DESCRIPTION
`compile()` accepts a tree of `_ast` objects. Converting one back into the
compiler AST covered 5 of the 22 statement kinds, and nothing walked the
result before it reached the code generator.

## Conversion

Port the remaining statement kinds — ClassDef, Delete, TypeAlias, AugAssign,
AnnAssign, For, AsyncFor, While, If, With, AsyncWith, Raise, Try, TryStar,
Assert, Import, ImportFrom, Global, Nonlocal, Break, Continue, Match — with
the expressions and helper nodes they refer to.

Three shapes do not survive a field-by-field copy:

- `arguments` distributes `defaults` over the tail of `posonlyargs ++ args`
  and `kw_defaults` positionally over `kwonlyargs`, since the compiler AST
  carries a default on the parameter it belongs to.
- `If` carries its alternatives as a nested `orelse` where the compiler AST
  keeps one flat clause list, so the chain is flattened on the way in.
- An f-string is stored as its literal parts, so `JoinedStr` hands its values
  to codegen as the parts to join and a lone `FormattedValue` becomes a single
  interpolated part.

`FunctionDef` read neither `decorator_list`, `returns` nor `type_params`, so a
decorated function compiled through a tree lost its decorators without an
error.

In the other direction, `f'{x=}'` dropped the text the `=` echoes and emitted
one `Constant` per literal piece. Consecutive literals now merge into one
node and the echoed text is rebuilt from the source span, which also makes the
conversion a repr when neither a conversion nor a format spec is given.

## Validation

`pypy/interpreter/astcompiler/validate.py` runs between `mod.from_object()`
and `compile_ast()` (`compiling.py:73`). pyre had no counterpart. Over 36
malformed trees where 3.14 and PyPy agree word for word:

| before | count |
|---|---|
| compiled with no complaint | 17 |
| **aborted the process** on an `unwrap()` in the code generator | 4 |
| SyntaxError from the compiler where both oracles raise ValueError | ~8 |
| already matching | 7 |

The four aborts: `Compare` with no comparators, `BoolOp` with none, `Match`
with no cases, a comprehension with no generators.

`astcompiler::validate` ports the walk and `compile_object` calls it where
upstream does. What the compiler AST cannot hold — a missing list element,
`Dict` keys against values, `kw_defaults` against kwonlyargs, defaults against
parameters — stays in the conversion, the last place it is visible.

Two checks answer to 3.14 where the two disagree: a second star in a sequence
pattern is left to the code generator, which reports it as a SyntaxError, and
a `MatchMapping` key that is neither a constant nor an attribute is worded as
3.14 words it.

35 of the 36 trees now give the same class and message as 3.14; the last
differs only in the location suffix on the SyntaxError.

## Fixture

`pyre/bench/synth/ast_compile_roundtrip.py` compiles each source both ways and
compares the executions, then builds the shapes no parser emits — an `If`
whose `orelse` is a nested `If`, an argument-less `Return`, container
constants, 11 f-string node shapes — and a 34-entry table of trees that must
be rejected. Byte-identical across CPython 3.14, PyPy 3.11, dynasm and
cranelift.

## Verification

- `pyre/check.py`: dynasm 330/330, cranelift 330/330
- `cargo test --all --features dynasm`: 7098 passed, 0 failed
- `cargo fmt --all --check`: clean

## Known gaps

- `BUILD_STRING` renders a non-str fragment instead of raising; the function is
  infallible by signature and its other caller is the JIT residual hook at
  `pyre/pyre-jit/src/call_jit.rs:5727`, which returns a raw `i64`.
- `_ast` node classes carry no class-level defaults for optional fields
  (affects `ast.dump` output only).
- `expected some sort of X, but got Y` prints a type name where both oracles
  print `%R`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Expanded support for compiling a wider range of Python AST constructs, including pattern matching, comprehensions, f-strings, type aliases, complex/tuple/frozenset constants, and more statement/expression forms.
  - Added upfront AST validation to catch malformed or unsupported structures before compilation.
- **Bug Fixes**
  - Improved invalid-AST error reporting with more precise mismatch details.
- **Tests**
  - Added comprehensive roundtrip/handbuilt validation coverage and a warm-up benchmark to exercise compilation behavior and output consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->