### PR TITLE
jit: barrier the blackhole's ref setfield stores

### DIFF
--- a/majit/majit-backend-dynasm/src/lib.rs
+++ b/majit/majit-backend-dynasm/src/lib.rs
@@ -681,13 +681,13 @@ fn handle_fail_resume_guard(
     //
     // Clearing the slot drops the only GC root for the exception object
     // (`jf_guard_exc` is a GCREF visited by `jitframe_trace`).  The bridge
-    // hook below can allocate and trigger a moving nursery collection,
-    // which would relocate the object and leave a bare `usize` copy stale.
-    // RPython keeps the `grab_exc_value` result alive across
-    // `_trace_and_compile_from_bridge` automatically (shadowstack-rooted
-    // local); pyre has no GC-transform pass, so root the value explicitly
-    // via `gc_add_root` for the duration of the bridge hook — the collector
-    // rewrites `guard_exc_root` in place if it moves the object.
+    // hook below can allocate and trigger a collection, and an exception is
+    // allocated non-moving, so what is at stake is liveness rather than a
+    // stale address: with no root left, a major sweeps the object out from
+    // under the bare `usize` copy.  RPython keeps the `grab_exc_value` result
+    // alive across `_trace_and_compile_from_bridge` automatically
+    // (shadowstack-rooted local); pyre has no GC-transform pass, so root the
+    // value explicitly for the duration of the bridge hook.
     let mut guard_exc_root = majit_ir::GcRef(unsafe {
         let slot = &mut (*frame_ptr).jf_guard_exc;
         let v = *slot;
@@ -716,9 +716,9 @@ fn handle_fail_resume_guard(
     // compile.py:710-716 `resume_in_blackhole(descr, deadframe)`: the
     // descr is the sole identity carrier; the receiver derives green_key /
     // trace_id / fail_index from it via `fail_descr_arc_from_addr` and
-    // `descr_owning_jct`.  Read the (possibly relocated) exception pointer
-    // back from the rooted slot before handing it off, then drop the root —
-    // the blackhole receiver re-roots it through the resumed interpreter.
+    // `descr_owning_jct`.  Read the exception pointer back from the rooted
+    // slot before handing it off, then drop the root — the blackhole receiver
+    // re-roots it through the resumed interpreter.
     // The value is seeded as the resume exception (`blackhole.py:1647`
     // `_prepare_resume_from_failure`, consumed at `blackhole.py:1794`);
     // re-reading `jf_guard_exc` here would observe the post-`grab_exc_value`

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -3318,20 +3318,20 @@ fn walk_jit_exc_value(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
     // major reaches the children on its own, through the type's registered
     // pointer offsets. A minor reaches them only through the remembered set,
     // which is exactly as complete as the barrier discipline over the twenty
-    // reference slots. That discipline has been audited and is not yet
-    // complete: the interpreter's slot writers all barrier
-    // (`exception_write_barrier` on every one), and a compiled SETFIELD_GC
-    // into a pointer field picks up a `COND_CALL_GC_WB` from the rewrite pass
-    // (`rewrite.py:930-931`, `:948-953`), but the blackhole's
-    // `bh_setfield_gc_r` / `bh_setinteriorfield_gc_r` store a reference with
-    // no barrier at all, where upstream's `write_ref_at_mem`
-    // (`llmodel.py:495-497`) gets one implicitly from the GC transform. A
-    // `w_context` or `w_traceback` written during a blackhole resume is
-    // therefore exactly the old-to-young edge the remembered set misses, so
-    // the walk stays load-bearing for both populations. Even once that gap
-    // closes, the coverage is a maintained invariant rather than a structural
-    // one — narrowing this walk to the off-GC family would make every future
-    // unbarriered exception-slot store a use-after-free instead of a leak.
+    // reference slots. All three store paths have been audited and all three
+    // now barrier: the interpreter's slot writers call
+    // `exception_write_barrier` on every one, a compiled SETFIELD_GC into a
+    // pointer field picks up a `COND_CALL_GC_WB` from the rewrite pass
+    // (`rewrite.py:930-931`, `:948-953`), and the blackhole's
+    // `bh_setfield_gc_r` / `bh_setinteriorfield_gc_r` barrier the destination
+    // the way upstream's `write_ref_at_mem` (`llmodel.py:495-497`) does
+    // implicitly through the GC transform.
+    //
+    // That still does not make the walk removable. The coverage is a
+    // maintained invariant rather than a structural one: pyre has no transform
+    // inserting these barriers, so each one is a hand-written call that a
+    // future store can omit. Narrowing this walk to the off-GC family would
+    // turn every such omission from a leak into a use-after-free.
     //
     // Either way the carrier cannot be demoted to a plain shadow-stack entry
     // (the direct analogue of the GC transform's rooted local,
@@ -10658,6 +10658,11 @@ impl majit_metainterp::resume::BlackholeAllocator for PyreBlackholeAllocator {
         unsafe {
             ((struct_ptr as *mut u8).add(descr_info.offset) as *mut usize).write(value as usize);
         }
+        // llmodel.py:723 `bh_setfield_gc_r` → :495 `write_ref_at_mem`: the
+        // ref store carries an implied write barrier on the destination struct.
+        if pyre_object::gc_hook::try_gc_owns_object(struct_ptr as *mut u8) {
+            pyre_object::gc_hook::try_gc_write_barrier(struct_ptr as *mut u8);
+        }
     }
 
     fn bh_setfield_gc_f(&self, struct_ptr: i64, value: i64, descr_info: &majit_ir::FieldDescrInfo) {
@@ -10722,6 +10727,12 @@ impl majit_metainterp::resume::BlackholeAllocator for PyreBlackholeAllocator {
         descr: &majit_ir::DescrRef,
     ) {
         self.bh_setinteriorfield_gc_i(array, index, value, descr);
+        // llmodel.py:659 `bh_setinteriorfield_gc_r` → :495
+        // `write_ref_at_mem`: the ref store carries an implied write barrier
+        // on the destination array.
+        if array != 0 && pyre_object::gc_hook::try_gc_owns_object(array as *mut u8) {
+            pyre_object::gc_hook::try_gc_write_barrier(array as *mut u8);
+        }
     }
 
     fn bh_setinteriorfield_gc_f(


### PR DESCRIPTION
Follow-up to #854, which audited the three store paths into a
`W_BaseException` reference slot and found one of them unbarriered. This
closes that gap.

## The gap

`bh_setfield_gc_r` and `bh_setinteriorfield_gc_r` wrote a GC pointer into a
heap object with no write barrier. Upstream reaches both through
`write_ref_at_mem` (`llmodel.py:495-497`), whose `raw_store` carries an implied
barrier from the GC transform — the comment there says so in as many words.
pyre has no transform, so the old-to-young edge went unrecorded and a minor
could sweep a young child reachable only through the written slot.

The sibling `bh_setarrayitem_gc_r` already barriers in both backends
(`runner.rs` via `dynasm_write_barrier_if_managed`, `majit-backend` via
`gc_write_barrier`), so these two were the outliers rather than the rule. The
fix matches that sibling's shape: barrier the destination when the GC owns it.

I swept the rest of the blackhole allocator for the same class — the `_i` and
`_f` variants store non-pointers and need none, `bh_setarrayitem_gc_r`
delegates to an already-barriered backend method, and
`majit-backend`'s `bh_setinteriorfield_gc_r` is an empty default stub. These
two were the only real gaps.

**Overlap with #796:** that branch carries the same fix for the same two
methods, in the same shape, so whichever lands second should conflict
trivially rather than divergently.

## Also here

With all three store paths barriered, the audit note on the raw-exception
walker is restated rather than dropped. The walk still cannot be narrowed to
the off-GC family: pyre has no transform inserting these barriers, so each one
is a hand-written call a future store can omit, and narrowing would turn such
an omission from a leak into a use-after-free.

Two comments in the CALL_ASSEMBLER guard-failure helper justified rooting the
grabbed exception by relocation ("would relocate the object", "possibly
relocated"). Exceptions are allocated non-moving, so the root is about liveness
across a major, not about a stale address.

## Verification

- workspace `cargo check`, `cargo fmt --check` clean; pyre-jit 335 tests pass
- exception-heavy script reading `args` / `__context__` / `__traceback__`
  across collections: clean by default, under `PYRE_GC_INTERP_COLLECT`, and
  under `MAJIT_GC_STRESS`
- corpus gate: **cranelift 328/328 and wasm 325/325 all passed**; dynasm was
  327/328 with `nested_loop` at 2.1x against its 2x gate

`nested_loop` sits at its gate and the box was under load average 42-55 from
sibling worktrees, so I discriminated it against a control binary built from
this same tree with only the two barrier hunks removed, interleaving the two
binaries so common-mode load cancels:

| binary | median exec | ratio vs pypy |
|---|---|---|
| with barrier | 0.567s | 1.82x |
| without barrier (control) | 0.558s | 1.79x |

A +1.5% median difference, with the control slower than the fix in 2 of 9
rounds, and **both well under the 2x gate**. The gate failure is the load, not
this change. (Same bench also failed the same way on this box before any of
this branch's commits, and #854's CI was green on all three platforms.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
