### PR TITLE
gc: drive the interpreter safepoint from the collector, and root the __main__ frame across the bootstrap

### DIFF
--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -398,6 +398,7 @@ fn register_active_hooks(supports_guard_gc_type: bool) {
     majit_gc::set_active_is_tracked(Some(is_tracked_via_active_runtime));
     majit_gc::set_active_collect_oldgen(Some(collect_oldgen_nonmoving_via_active_runtime));
     majit_gc::set_active_heap_stats(Some(heap_stats_via_active_runtime));
+    majit_gc::set_active_major_threshold_reached(Some(major_threshold_reached_via_active_runtime));
     majit_gc::set_active_root_hooks(
         Some(gc_add_root_via_active_runtime),
         Some(gc_remove_root_via_active_runtime),
@@ -1662,6 +1663,12 @@ fn finalizer_next_dead_via_active_runtime(fq_index: usize) -> Option<GcRef> {
 /// Report `(oldgen_total, nursery_used)` for the interpreter GC safepoint.
 fn heap_stats_via_active_runtime() -> (usize, usize) {
     with_cranelift_gc(|gc| gc.heap_byte_stats()).unwrap_or((0, 0))
+}
+
+/// Report whether the GC wants a major collection, for the interpreter GC
+/// safepoint (incminimark.py:1288-1290 `threshold_reached`).
+fn major_threshold_reached_via_active_runtime() -> bool {
+    with_cranelift_gc(|gc| gc.major_threshold_reached()).unwrap_or(false)
 }
 
 /// Host-side root-register trampoline. Bridges

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -199,6 +199,7 @@ fn register_active_hooks(supports_guard_gc_type: bool) {
     majit_gc::set_active_is_tracked(Some(dynasm_is_tracked));
     majit_gc::set_active_collect_oldgen(Some(dynasm_collect_oldgen_nonmoving));
     majit_gc::set_active_heap_stats(Some(dynasm_heap_stats));
+    majit_gc::set_active_major_threshold_reached(Some(dynasm_major_threshold_reached));
     majit_gc::set_active_root_hooks(Some(dynasm_gc_add_root), Some(dynasm_gc_remove_root));
     majit_gc::set_active_gc_owns_object(Some(dynasm_gc_owns_object));
     majit_gc::set_active_gc_is_nursery_object(Some(dynasm_gc_is_nursery_object));
@@ -627,6 +628,19 @@ fn dynasm_heap_stats() -> (usize, usize) {
         return r;
     }
     majit_gc::gc_sync::gc_op(|g| g.heap_byte_stats())
+}
+
+/// Report whether the GC wants a major collection, for the interpreter GC
+/// safepoint (incminimark.py:1288-1290 `threshold_reached`).
+fn dynasm_major_threshold_reached() -> bool {
+    if let Some(r) = DYNASM_ACTIVE_GC.with(|c| {
+        c.borrow_mut()
+            .as_deref_mut()
+            .map(|g| g.major_threshold_reached())
+    }) {
+        return r;
+    }
+    majit_gc::gc_sync::gc_op(|g| g.major_threshold_reached())
 }
 
 /// Host-side root-register trampoline. Bridges

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -321,6 +321,7 @@ fn register_active_hooks(supports_guard_gc_type: bool) {
     majit_gc::set_active_is_tracked(Some(wasm_is_tracked));
     majit_gc::set_active_collect_oldgen(Some(wasm_collect_oldgen_nonmoving));
     majit_gc::set_active_heap_stats(Some(active_gc_heap_stats));
+    majit_gc::set_active_major_threshold_reached(Some(active_gc_major_threshold_reached));
     majit_gc::set_active_finalizer_hooks(
         Some(wasm_register_finalizer),
         Some(wasm_finalizer_next_dead),
@@ -364,6 +365,13 @@ pub fn install_gc_standalone() {
 /// runner split GC-retained memory from host-heap growth.
 pub fn active_gc_heap_stats() -> (usize, usize) {
     with_wasm_active_gc(|gc| gc.heap_byte_stats()).unwrap_or((0, 0))
+}
+
+/// Whether the GC owned by this thread's wasm backend wants a major collection
+/// (incminimark.py:1288-1290 `threshold_reached`). Drives the interpreter GC
+/// safepoint, which is on by default on wasm.
+pub fn active_gc_major_threshold_reached() -> bool {
+    with_wasm_active_gc(|gc| gc.major_threshold_reached()).unwrap_or(false)
 }
 
 /// Diagnostic: `(minor_collections, major_collections)` of the active GC, or

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -4015,6 +4015,10 @@ impl GcAllocator for MiniMarkGC {
         (self.get_total_memory_used(), self.nursery.used())
     }
 
+    fn major_threshold_reached(&self) -> bool {
+        self.threshold_reached(0)
+    }
+
     fn type_size(&self, type_id: u32) -> Option<usize> {
         if (type_id as usize) < self.types.len() {
             Some(self.types.get(type_id).size)

--- a/majit/majit-gc/src/lib.rs
+++ b/majit/majit-gc/src/lib.rs
@@ -299,6 +299,17 @@ pub trait GcAllocator: Send {
     /// `alloc_nursery_no_collect_typed` so backends without a
     /// distinct old-gen still compile; backends with a real old-gen
     /// override to force placement there.
+    ///
+    /// Non-collecting, unlike its structural counterpart
+    /// `external_malloc` (incminimark.py:987-994), which tests
+    /// `threshold_reached(raw_malloc_usage(totalsize))` before allocating and
+    /// drives `minor_collection_with_major_progress` when it holds. That check
+    /// cannot be made here: an RPython caller's locals are shadow-stack roots,
+    /// so upstream may collect mid-allocation, while the callers this entry
+    /// exists for are holding the raw pointer on the Rust stack precisely
+    /// because it is not a root. Old-gen growth is instead answered by the
+    /// interpreter safepoint's `threshold_reached` poll, which runs where the
+    /// root set is known (`pyre-object`'s `gc_interp::safepoint`).
     fn alloc_oldgen_typed(&mut self, type_id: u32, size: usize) -> GcRef {
         self.alloc_nursery_no_collect_typed(type_id, size)
     }

--- a/majit/majit-gc/src/lib.rs
+++ b/majit/majit-gc/src/lib.rs
@@ -526,6 +526,18 @@ pub trait GcAllocator: Send {
         (0, 0)
     }
 
+    /// incminimark.py:1288-1290 `threshold_reached(0)`: whether the memory the
+    /// collector is responsible for has caught up to the threshold it set for
+    /// the next major collection. Everything that shapes that threshold — the
+    /// growth ratio, `growth_rate_max`, `max_delta`, `min_heap_size`,
+    /// `max_heap_size` — lives behind this answer, so a caller that cannot
+    /// drive collection from the allocator can ask here instead of modelling
+    /// heap growth itself. Default `false` for stub allocators with no
+    /// threshold accounting.
+    fn major_threshold_reached(&self) -> bool {
+        false
+    }
+
     /// Diagnostic only: `(minor_collections, major_collections)` run so far.
     /// Used to attribute run time to collection cadence (e.g. old-gen churn
     /// driving repeated majors). Default `(0, 0)` for stub allocators.
@@ -927,6 +939,9 @@ impl GcAllocator for GcHandle {
     }
     fn heap_byte_stats(&self) -> (usize, usize) {
         gc_sync::gc_query_reentrant(|gc| gc.heap_byte_stats())
+    }
+    fn major_threshold_reached(&self) -> bool {
+        gc_sync::gc_query_reentrant(|gc| gc.major_threshold_reached())
     }
     fn collection_counts(&self) -> (usize, usize) {
         gc_sync::gc_query_reentrant(|gc| gc.collection_counts())
@@ -1609,10 +1624,11 @@ pub fn collect_oldgen_nonmoving() {
 }
 
 /// Process-global callback reporting the active GC's `heap_byte_stats`
-/// (`(oldgen_total, nursery_used)`). Lets the interpreter safepoint
-/// (`pyre_object::gc_interp`) gate a collection on an empty nursery,
-/// where the embedded minor cycle moves nothing and is therefore safe
-/// even without a shadowstack pass over Rust-stack temporaries.
+/// (`(oldgen_total, nursery_used)`). Diagnostic: it lets a host runner split
+/// GC-retained memory from host-heap growth. Deciding when to collect is not
+/// among its uses — that question is [`active_major_threshold_reached`], which
+/// answers it from the collector's own threshold rather than from a number a
+/// caller would have to compare against a threshold of its own.
 pub type HeapStatsFn = fn() -> (usize, usize);
 
 global_hook!(static ACTIVE_HEAP_STATS: HeapStatsFn);
@@ -1628,6 +1644,30 @@ pub fn active_heap_stats() -> (usize, usize) {
     match ACTIVE_HEAP_STATS.get() {
         Some(f) => f(),
         None => (0, 0),
+    }
+}
+
+/// Process-global callback reporting the active GC's `major_threshold_reached`
+/// (incminimark.py:1288-1290). The interpreter GC safepoint
+/// (`pyre_object::gc_interp`) collects when this says the collector wants a
+/// major, instead of keeping a second, poorer model of heap growth beside the
+/// collector's own.
+pub type MajorThresholdReachedFn = fn() -> bool;
+
+global_hook!(static ACTIVE_MAJOR_THRESHOLD_REACHED: MajorThresholdReachedFn);
+
+/// Install the active backend's `major_threshold_reached` trampoline.
+pub fn set_active_major_threshold_reached(hook: Option<MajorThresholdReachedFn>) {
+    ACTIVE_MAJOR_THRESHOLD_REACHED.set(hook);
+}
+
+/// Whether the active backend's GC has reached its next-major threshold.
+/// `false` when no backend has installed a hook, so a caller with no collector
+/// behind it never collects.
+pub fn active_major_threshold_reached() -> bool {
+    match ACTIVE_MAJOR_THRESHOLD_REACHED.get() {
+        Some(f) => f(),
+        None => false,
     }
 }
 

--- a/majit/majit-gc/src/lib.rs
+++ b/majit/majit-gc/src/lib.rs
@@ -1671,17 +1671,6 @@ pub fn active_major_threshold_reached() -> bool {
     }
 }
 
-/// Whether the JIT-frame shadow stack is empty — i.e. no compiled trace
-/// is suspended on this thread. The interpreter GC safepoint only
-/// collects when this holds: a suspended jitframe's gcmap describes its
-/// own suspension PC, and a collection driven from the nested interpreter
-/// (not from compiled code at a real safepoint) can mis-root it. The
-/// JIT's own nursery-full collections are safe; this gate keeps the
-/// interpreter-driven one out of the trace-suspended window.
-pub fn jitframe_shadow_stack_empty() -> bool {
-    shadow_stack::jf_top_ptr().is_null()
-}
-
 /// Process-global callback that reports whether a raw address is owned
 /// by the active backend's GC heap. Used by host-side allocators
 /// (`pyre-object`'s `dealloc_items_block`) to discriminate

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -205,7 +205,7 @@ pub fn frame_entry_count() -> u64 {
 ///
 /// Touches the runtime-mutable `FRAME_ENTRY_COUNT` thread-local, not a
 /// build-time constant, so the JIT residualizes the call instead of tracing
-/// into it (`@dont_look_inside`, the `note_alloc` sibling). A `()` return has
+/// into it (`@dont_look_inside`, the `gc_interp::enabled` sibling). A `()` return has
 /// no discriminant to erase and it cannot raise.
 #[majit_macros::dont_look_inside]
 pub fn bump_frame_entry_count() {

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -838,20 +838,10 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         "pyre_object::try_gc_alloc_stable_raw",
         pyre_object::gc_hook::try_gc_alloc_stable_raw as *const (),
     );
-    // The interp-alloc boxing tail's GC-hook toucher residual: `note_alloc`
-    // bumps the runtime-mutable `ALLOC_SINCE_GC` atomic. It is not a build-time
-    // constant, so it carries `#[dont_look_inside]` and binds its `()`-returning
-    // function directly by qualified path.
-    push_alias_pair(
-        &mut entries,
-        "pyre_object::gc_interp::note_alloc",
-        "pyre_object::note_alloc",
-        pyre_object::gc_interp::note_alloc as *const (),
-    );
     // `w_type_set_abstract` stores the runtime-mutable `flag_abstract` atomic — a
     // side effect on per-type state, not a build-time constant, so it carries
     // `#[dont_look_inside]` and binds its `()`-returning `fn` directly by
-    // qualified path (sibling of `note_alloc`).
+    // qualified path (sibling of `gc_interp::enabled`).
     push_alias_pair(
         &mut entries,
         "pyre_object::typeobject::w_type_set_abstract",
@@ -1021,13 +1011,13 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         "pyre_object::note_eval_activation_exit",
         pyre_object::gc_interp::note_eval_activation_exit as *const (),
     );
-    // The dispatch-loop safepoint's four toucher residuals plus the frame-entry
+    // The dispatch-loop safepoint's six toucher residuals plus the frame-entry
     // odometer bump and the items-block strategy gate: each reads a
-    // runtime-mutable global (`COLLECT_STATE` / `EVAL_NESTING` atomics, the two
-    // GC hook fn-pointer cells, `FRAME_ENTRY_COUNT` TLS, the `PYRE_GC_ITEMSBLOCK`
-    // `OnceLock`) — none a build-time constant — so all carry
+    // runtime-mutable global (`COLLECT_STATE` atomic, `EVAL_NESTING` / `POLL_TICK`
+    // TLS, the three GC hook fn-pointer cells, `FRAME_ENTRY_COUNT` TLS, the
+    // `PYRE_GC_ITEMSBLOCK` `OnceLock`) — none a build-time constant — so all carry
     // `#[dont_look_inside]` and bind their `-> bool` / `()` Rust `fn` directly by
-    // qualified path (siblings of `gc_interp::enabled` / `note_alloc`).
+    // qualified path (siblings of `gc_interp::enabled`).
     push_alias_pair(
         &mut entries,
         "pyre_object::gc_interp::collect_enabled",
@@ -1036,9 +1026,21 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
     );
     push_alias_pair(
         &mut entries,
+        "pyre_object::gc_interp::poll_due",
+        "pyre_object::poll_due",
+        pyre_object::gc_interp::poll_due as *const (),
+    );
+    push_alias_pair(
+        &mut entries,
         "pyre_object::gc_interp::at_outermost_activation",
         "pyre_object::at_outermost_activation",
         pyre_object::gc_interp::at_outermost_activation as *const (),
+    );
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::gc_hook::try_gc_major_threshold_reached",
+        "pyre_object::try_gc_major_threshold_reached",
+        pyre_object::gc_hook::try_gc_major_threshold_reached as *const (),
     );
     push_alias_pair(
         &mut entries,
@@ -1063,8 +1065,8 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         "pyre_interpreter::call::bump_frame_entry_count",
         crate::call::bump_frame_entry_count as *const (),
     );
-    // The dispatch-loop safepoint entry itself reads `ALLOC_SINCE_GC` inline and
-    // dispatches to the collection hook.
+    // The dispatch-loop safepoint entry itself paces the poll inline and
+    // dispatches to the threshold and collection hooks.
     push_alias_pair(
         &mut entries,
         "pyre_object::gc_interp::safepoint",
@@ -3067,7 +3069,7 @@ mod tests {
     /// qualified path; a typo in either the module-qualified or root alias
     /// silently regresses the `#[dont_look_inside]` call to a symbolic hash,
     /// so pin both spellings against the live fnaddr (siblings of the
-    /// `gc_interp::enabled` / `note_alloc` registrations).
+    /// `gc_interp::enabled` registration).
     #[test]
     fn jit_trace_fnaddrs_covers_interp_gc_safepoint_readers() {
         let bindings: HashMap<&'static str, i64> = jit_trace_fnaddrs().into_iter().collect();

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -1011,10 +1011,10 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         "pyre_object::note_eval_activation_exit",
         pyre_object::gc_interp::note_eval_activation_exit as *const (),
     );
-    // The dispatch-loop safepoint's six toucher residuals plus the frame-entry
+    // The dispatch-loop safepoint's five toucher residuals plus the frame-entry
     // odometer bump and the items-block strategy gate: each reads a
     // runtime-mutable global (`COLLECT_STATE` atomic, `EVAL_NESTING` / `POLL_TICK`
-    // TLS, the three GC hook fn-pointer cells, `FRAME_ENTRY_COUNT` TLS, the
+    // TLS, the two GC hook fn-pointer cells, `FRAME_ENTRY_COUNT` TLS, the
     // `PYRE_GC_ITEMSBLOCK` `OnceLock`) — none a build-time constant — so all carry
     // `#[dont_look_inside]` and bind their `-> bool` / `()` Rust `fn` directly by
     // qualified path (siblings of `gc_interp::enabled`).
@@ -1047,12 +1047,6 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         "pyre_object::gc_hook::try_gc_collect_oldgen",
         "pyre_object::try_gc_collect_oldgen",
         pyre_object::gc_hook::try_gc_collect_oldgen as *const (),
-    );
-    push_alias_pair(
-        &mut entries,
-        "pyre_object::gc_hook::try_gc_jitframe_empty",
-        "pyre_object::try_gc_jitframe_empty",
-        pyre_object::gc_hook::try_gc_jitframe_empty as *const (),
     );
     push_alias_pair(
         &mut entries,
@@ -3101,17 +3095,6 @@ mod tests {
         assert_eq!(
             bindings["pyre_object::try_gc_collect_oldgen"],
             collect_oldgen
-        );
-
-        let jitframe_empty =
-            pyre_object::gc_hook::try_gc_jitframe_empty as *const () as usize as i64;
-        assert_eq!(
-            bindings["pyre_object::gc_hook::try_gc_jitframe_empty"],
-            jitframe_empty
-        );
-        assert_eq!(
-            bindings["pyre_object::try_gc_jitframe_empty"],
-            jitframe_empty
         );
 
         let itemsblock =

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -2375,6 +2375,44 @@ impl PyFrame {
         self.nlocals() + self.ncells()
     }
 
+    /// Name the frame a stack underflow was detected on. A bare depth
+    /// assertion says an opcode popped from an empty stack but not which
+    /// opcode of which code object, which is the whole question when the
+    /// underflow means the frame — or the code behind it — is no longer the
+    /// one the loop started with.
+    #[cold]
+    #[inline(never)]
+    fn report_stack_underflow(&self) -> ! {
+        let code = unsafe { &*pyframe_get_pycode(self) };
+        let window: Vec<String> = code
+            .instructions
+            .iter()
+            .copied()
+            .enumerate()
+            .skip(self.next_instr().saturating_sub(4))
+            .take(8)
+            .map(|(pc, unit)| format!("{pc}:{unit:?}"))
+            .collect();
+        panic!(
+            "value-stack underflow: depth={} base={} (nlocals={} ncells={}) \
+             pc={} last_instr={} ninstrs={} code={:?} file={:?} frame={:p} \
+             pycode={:p} back={:p} window=[{}]",
+            self.valuestackdepth,
+            self.stack_base(),
+            self.nlocals(),
+            self.ncells(),
+            self.next_instr(),
+            self.last_instr,
+            code.instructions.len(),
+            code.obj_name,
+            code.source_path,
+            self,
+            self.pycode,
+            self.f_backref,
+            window.join(" "),
+        );
+    }
+
     // ── Stack operations ──────────────────────────────────────────────
 
     #[inline]
@@ -2387,7 +2425,9 @@ impl PyFrame {
 
     #[inline]
     pub fn pop(&mut self) -> PyObjectRef {
-        assert!(self.valuestackdepth > self.stack_base());
+        if self.valuestackdepth <= self.stack_base() {
+            self.report_stack_underflow();
+        }
         let depth = self.valuestackdepth - 1;
         let value = self.locals_w()[depth];
         self.locals_w_mut()[depth] = PY_NULL;

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -595,7 +595,6 @@ impl FrameBox {
             debug_assert!(pyre_object::gc_hook::try_gc_owns_object(
                 frame.locals_cells_stack_w as *mut u8
             ));
-            pyre_object::gc_interp::note_alloc(std::mem::size_of::<PyFrame>());
             let ptr = raw as *mut PyFrame;
             unsafe {
                 std::ptr::write(ptr, frame);

--- a/pyre/pyre-interpreter/src/pytraceback.rs
+++ b/pyre/pyre-interpreter/src/pytraceback.rs
@@ -136,7 +136,6 @@ pub fn w_pytraceback_new(
         PYTRACEBACK_OBJECT_SIZE,
     );
     if !raw.is_null() {
-        pyre_object::gc_interp::note_alloc(PYTRACEBACK_OBJECT_SIZE);
         let ptr = raw as *mut PyTraceback;
         unsafe {
             std::ptr::write(ptr, value);

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -166,13 +166,6 @@ fn pyre_object_gc_finalizer_next_dead_trampoline(fq_index: usize) -> pyre_object
         .unwrap_or(pyre_object::PY_NULL)
 }
 
-/// Jitframe-empty trampoline for the interpreter GC safepoint. Bridges
-/// pyre-object's hook to `majit_gc::jitframe_shadow_stack_empty`, so the
-/// safepoint can skip collecting while a compiled trace is suspended.
-fn pyre_object_gc_jitframe_empty_trampoline() -> bool {
-    majit_gc::jitframe_shadow_stack_empty()
-}
-
 /// Trampoline: register a caller-owned slot as
 /// a GC root with the active backend. Bridges `*mut *mut u8` (the
 /// pyre-object-facing shape that does not depend on majit-gc) to
@@ -3546,7 +3539,6 @@ fn install_pyre_object_hooks() {
         pyre_object_gc_register_finalizer_trampoline,
         pyre_object_gc_finalizer_next_dead_trampoline,
     );
-    pyre_object::gc_hook::register_gc_jitframe_empty_hook(pyre_object_gc_jitframe_empty_trampoline);
     pyre_object::register_gc_root_hooks(
         pyre_object_gc_add_root_trampoline,
         pyre_object_gc_remove_root_trampoline,

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -141,11 +141,11 @@ fn pyre_object_gc_collect_oldgen_trampoline() {
     majit_gc::collect_oldgen_nonmoving();
 }
 
-/// Trampoline for the interpreter safepoint's `(oldgen_total, nursery_used)`
-/// read, used to re-derive its next-major threshold from what survived a
-/// collection (`set_major_threshold_from`, incminimark.py:575-594).
-fn pyre_object_gc_heap_stats_trampoline() -> (usize, usize) {
-    majit_gc::active_heap_stats()
+/// Trampoline for the interpreter safepoint's next-major-threshold question
+/// (`threshold_reached`, incminimark.py:1288-1290). The collector owns the
+/// threshold and every bound on it, so the safepoint asks rather than models.
+fn pyre_object_gc_major_threshold_reached_trampoline() -> bool {
+    majit_gc::active_major_threshold_reached()
 }
 
 fn pyre_object_gc_set_enabled_trampoline(enabled: bool) {
@@ -3538,7 +3538,9 @@ fn install_pyre_object_hooks() {
     );
     pyre_object::register_gc_collect_hook(pyre_object_gc_collect_trampoline);
     pyre_object::gc_hook::register_gc_collect_oldgen_hook(pyre_object_gc_collect_oldgen_trampoline);
-    pyre_object::gc_hook::register_gc_heap_stats_hook(pyre_object_gc_heap_stats_trampoline);
+    pyre_object::gc_hook::register_gc_major_threshold_reached_hook(
+        pyre_object_gc_major_threshold_reached_trampoline,
+    );
     pyre_object::gc_hook::register_gc_set_enabled_hook(pyre_object_gc_set_enabled_trampoline);
     pyre_object::gc_hook::register_gc_finalizer_hooks(
         pyre_object_gc_register_finalizer_trampoline,

--- a/pyre/pyre-object/src/floatobject.rs
+++ b/pyre/pyre-object/src/floatobject.rs
@@ -61,7 +61,6 @@ pub fn w_float_new(value: f64) -> PyObjectRef {
     if crate::gc_interp::enabled() {
         let raw = crate::gc_hook::try_gc_alloc_stable_raw(W_FLOAT_GC_TYPE_ID, W_FLOAT_OBJECT_SIZE);
         if !raw.is_null() {
-            crate::gc_interp::note_alloc(W_FLOAT_OBJECT_SIZE);
             unsafe {
                 std::ptr::write(raw as *mut W_FloatObject, obj);
                 return raw as PyObjectRef;

--- a/pyre/pyre-object/src/gc_hook.rs
+++ b/pyre/pyre-object/src/gc_hook.rs
@@ -386,40 +386,6 @@ pub extern "C" fn maybe_register_finalizer(obj: PyObjectRef) {
     }
 }
 
-/// Signature of the host-side "is the JIT-frame shadow stack empty"
-/// callback. Used by the interpreter GC safepoint to avoid collecting
-/// while a compiled trace is suspended (its jitframe roots can be
-/// mis-mapped from a nested interpreter collection).
-pub type GcJitframeEmptyHookFn = fn() -> bool;
-
-majit_gc::global_hook!(static GC_JITFRAME_EMPTY_HOOK: GcJitframeEmptyHookFn);
-
-/// Install the jitframe-shadow-stack-empty callback.
-pub fn register_gc_jitframe_empty_hook(hook: GcJitframeEmptyHookFn) {
-    GC_JITFRAME_EMPTY_HOOK.set(Some(hook));
-}
-
-/// Remove the jitframe-shadow-stack-empty callback.
-pub fn clear_gc_jitframe_empty_hook() {
-    GC_JITFRAME_EMPTY_HOOK.set(None);
-}
-
-/// Whether no compiled trace is suspended (jitframe shadow stack empty),
-/// via the installed hook. `true` when no hook is installed (no JIT →
-/// no jitframes).
-///
-/// Reads the runtime-mutable `GC_JITFRAME_EMPTY_HOOK` fn-pointer cell, not a
-/// build-time constant, so the JIT residualizes the call instead of tracing
-/// into it (`@dont_look_inside`, the [`try_gc_collect_oldgen`] twin). The
-/// `-> bool` return fits a single word and it cannot raise.
-#[majit_macros::dont_look_inside]
-pub fn try_gc_jitframe_empty() -> bool {
-    match GC_JITFRAME_EMPTY_HOOK.get() {
-        Some(f) => f(),
-        None => true,
-    }
-}
-
 /// Signature of the host-side `threshold_reached` callback
 /// (incminimark.py:1288-1290).
 pub type GcMajorThresholdReachedHookFn = fn() -> bool;
@@ -442,7 +408,7 @@ pub fn clear_gc_major_threshold_reached_hook() {
 ///
 /// Reads the runtime-mutable `GC_MAJOR_THRESHOLD_REACHED_HOOK` fn-pointer cell,
 /// not a build-time constant, so the JIT residualizes the call instead of
-/// tracing into it (`@dont_look_inside`, the [`try_gc_jitframe_empty`] twin).
+/// tracing into it (`@dont_look_inside`, the [`try_gc_collect_oldgen`] twin).
 /// The `-> bool` return fits a single word and it cannot raise.
 #[majit_macros::dont_look_inside]
 pub fn try_gc_major_threshold_reached() -> bool {

--- a/pyre/pyre-object/src/gc_hook.rs
+++ b/pyre/pyre-object/src/gc_hook.rs
@@ -420,36 +420,35 @@ pub fn try_gc_jitframe_empty() -> bool {
     }
 }
 
-/// Signature of the host-side `(oldgen_total, nursery_used)` byte-stats
-/// callback. `oldgen_total` is `get_total_memory_used`
-/// (incminimark.py:1264-1268).
-pub type GcHeapStatsHookFn = fn() -> (usize, usize);
+/// Signature of the host-side `threshold_reached` callback
+/// (incminimark.py:1288-1290).
+pub type GcMajorThresholdReachedHookFn = fn() -> bool;
 
-majit_gc::global_hook!(static GC_HEAP_STATS_HOOK: GcHeapStatsHookFn);
+majit_gc::global_hook!(static GC_MAJOR_THRESHOLD_REACHED_HOOK: GcMajorThresholdReachedHookFn);
 
-/// Install the heap-byte-stats callback.
-pub fn register_gc_heap_stats_hook(hook: GcHeapStatsHookFn) {
-    GC_HEAP_STATS_HOOK.set(Some(hook));
+/// Install the next-major-threshold callback.
+pub fn register_gc_major_threshold_reached_hook(hook: GcMajorThresholdReachedHookFn) {
+    GC_MAJOR_THRESHOLD_REACHED_HOOK.set(Some(hook));
 }
 
-/// Remove the heap-byte-stats callback.
-pub fn clear_gc_heap_stats_hook() {
-    GC_HEAP_STATS_HOOK.set(None);
+/// Remove the next-major-threshold callback.
+pub fn clear_gc_major_threshold_reached_hook() {
+    GC_MAJOR_THRESHOLD_REACHED_HOOK.set(None);
 }
 
-/// Report `(oldgen_total, nursery_used)` in bytes via the installed hook.
-/// `(0, 0)` when none is installed, which leaves the interpreter safepoint on
-/// its `min_heap_size` floor.
+/// Whether the collector has reached the threshold it set for its next major
+/// collection, via the installed hook. `false` when none is installed, so an
+/// interpreter with no collector behind it never asks for one.
 ///
-/// Reads the runtime-mutable `GC_HEAP_STATS_HOOK` fn-pointer cell, not a
-/// build-time constant, so the JIT residualizes the call instead of tracing
-/// into it (`@dont_look_inside`, the [`try_gc_jitframe_empty`] twin). It
-/// cannot raise.
+/// Reads the runtime-mutable `GC_MAJOR_THRESHOLD_REACHED_HOOK` fn-pointer cell,
+/// not a build-time constant, so the JIT residualizes the call instead of
+/// tracing into it (`@dont_look_inside`, the [`try_gc_jitframe_empty`] twin).
+/// The `-> bool` return fits a single word and it cannot raise.
 #[majit_macros::dont_look_inside]
-pub fn try_gc_heap_stats() -> (usize, usize) {
-    match GC_HEAP_STATS_HOOK.get() {
+pub fn try_gc_major_threshold_reached() -> bool {
+    match GC_MAJOR_THRESHOLD_REACHED_HOOK.get() {
         Some(f) => f(),
-        None => (0, 0),
+        None => false,
     }
 }
 

--- a/pyre/pyre-object/src/gc_interp.rs
+++ b/pyre/pyre-object/src/gc_interp.rs
@@ -215,13 +215,15 @@ pub fn enabled() -> bool {
 /// reclamation can now fire under an active JIT, exactly when the interp-path
 /// old-gen leak accumulates. Reachability stays exact: the marker walks through
 /// nursery objects (`old -> nursery -> old` edges are followed) so no live old
-/// object is freed. The `jitframe_empty` gate is kept conservatively: a
-/// suspended trace's gcmap roots are seeded by `seed_major_roots`, but until
-/// that path is independently re-validated the safepoint stays out of the
-/// trace-suspended window. It also fires only at the outermost eval activation
-/// ([`at_outermost_activation`]) so a Python callback nested inside native
-/// module code — whose Rust-stack roots the pyframe walker cannot see — never
-/// triggers it.
+/// object is freed. A suspended compiled trace is no obstacle either: a trace
+/// suspends by making a residual call into the interpreter, and a call site is
+/// where the backend emits a gcmap, so `enumerate_root_walker_values` reaches
+/// the suspended frame's live refs by expanding each jitframe on the JF shadow
+/// stack through `trace_libc_jitframe`. That is the same basis on which
+/// upstream collects with compiled frames on the stack. The safepoint fires
+/// only at the outermost eval activation ([`at_outermost_activation`]) so a
+/// Python callback nested inside native module code — whose Rust-stack roots
+/// the pyframe walker cannot see — never triggers it.
 ///
 /// Dispatches to the installed threshold and collection hooks, neither a
 /// build-time constant, so the JIT residualizes the call instead of tracing
@@ -238,7 +240,6 @@ pub fn safepoint() {
         && at_outermost_activation()
         && poll_due()
         && crate::gc_hook::try_gc_major_threshold_reached()
-        && crate::gc_hook::try_gc_jitframe_empty()
     {
         crate::gc_hook::try_gc_collect_oldgen();
     }

--- a/pyre/pyre-object/src/gc_interp.rs
+++ b/pyre/pyre-object/src/gc_interp.rs
@@ -20,10 +20,13 @@
 //! path dict/set/list/instances already use), so they become GC-tracked without
 //! the move hazard, and trigger a full mark-sweep at a bytecode-dispatch
 //! safepoint (loop top, where the only live refs are in the frame and reachable
-//! through the registered `pyframe` root walker). The collection is throttled
-//! the way `set_major_threshold_from` (incminimark.py:575-594) throttles a
-//! major: on bytes allocated since the last one, against a threshold re-derived
-//! from what survived it, so the cost is amortised against heap growth.
+//! through the registered `pyframe` root walker). When to collect is not
+//! decided here: the safepoint asks the collector's own `threshold_reached`
+//! (incminimark.py:1288-1290), which weighs everything the collector is
+//! responsible for against the threshold `set_major_threshold_from`
+//! (incminimark.py:575-594) derived from the last major's survivors. Upstream
+//! asks that question in the allocator; pyre asks it here because here is where
+//! it can act on the answer.
 //!
 //! Gated off by default on native; enabled with `PYRE_GC_INTERP=1`. On wasm it
 //! is on by default — the env read returns nothing there, and the interp-path
@@ -32,7 +35,7 @@
 //! turns it off where the env is readable.
 
 use std::cell::Cell;
-use std::sync::atomic::{AtomicU8, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicU8, Ordering};
 
 /// Tri-state: 0 = not yet read from env, 1 = disabled, 2 = enabled.
 static STATE: AtomicU8 = AtomicU8::new(0);
@@ -121,37 +124,47 @@ pub fn at_outermost_activation() -> bool {
 /// routing+collection while diagnosing root-completeness.
 static COLLECT_STATE: AtomicU8 = AtomicU8::new(0);
 
-/// Bytes of interpreter-routed object allocation since the last collection.
+/// Dispatches between two `threshold_reached` queries.
 ///
-/// The allocator accumulating a byte total is `nursery_free = result +
-/// totalsize` (minimark.py:556-557); a count of allocations has no upstream
-/// counterpart, and cannot bound anything because one allocation is not one
-/// size.
-static ALLOC_BYTES_SINCE_GC: AtomicUsize = AtomicUsize::new(0);
+/// This is a poll rate, not a collection policy: the safepoint holds no model
+/// of the heap, and this value cannot make a collection happen that the
+/// collector did not ask for. It exists only because reaching the collector
+/// costs a thread-local borrow — or, with no backend GC box installed, a
+/// `gc_op` compare-and-exchange — which is too much to spend on every bytecode
+/// dispatch. At a few tens of bytes allocated per dispatch the interval spans
+/// far less than `min_heap_size` (incminimark.py:307), the smallest threshold
+/// the collector will ever set, so no answer is reached late enough to matter.
+const POLL_INTERVAL: u32 = 1024;
 
-/// Bytes that must be allocated before the next safepoint collection.
+thread_local! {
+    /// Eligible dispatches since this thread last asked the collector; see
+    /// [`POLL_INTERVAL`]. Advanced only once the cheaper gates have passed, so
+    /// it paces the queries actually made rather than the dispatches seen.
+    /// Thread-local rather than atomic because the query it paces is itself
+    /// per-thread, and a `fetch_add` on every dispatch would cost about what it
+    /// is here to avoid.
+    static POLL_TICK: Cell<u32> = const { Cell::new(0) };
+}
+
+/// Whether this dispatch is the one that asks the collector.
 ///
-/// `set_major_threshold_from` (incminimark.py:575-594) schedules the next major
-/// at `get_total_memory_used() * major_collection_threshold`, so the major cost
-/// is amortised against how much the heap grew rather than paid on a fixed
-/// cadence. `threshold_reached` (incminimark.py:1288-1290) is the comparison.
-///
-/// Held here as the equivalent *delta*: having allocated `b` bytes since the
-/// last major, the total is `live + b`, so `live + b >= live * threshold` is
-/// just `b >= live * (threshold - 1)`. That keeps the safepoint's per-dispatch
-/// test a plain atomic compare and confines the heap-stats read to the far
-/// rarer post-collection update.
-static NEXT_MAJOR_BYTES: AtomicUsize = AtomicUsize::new(MIN_HEAP_BYTES);
-
-/// `major_collection_threshold - 1` in hundredths (incminimark.py:198's 1.82
-/// default, as the growth delta 0.82). Integer maths keeps the safepoint free
-/// of floating point.
-const MAJOR_GROWTH_DELTA_PCT: usize = 82;
-
-/// Floor for [`NEXT_MAJOR_BYTES`], mirroring `min_heap_size`
-/// (incminimark.py:307). Without it a small live heap would schedule the next
-/// major almost immediately and the collection cost would dominate again.
-const MIN_HEAP_BYTES: usize = 8 << 20;
+/// Reads the runtime-mutable `POLL_TICK` thread-local, not a build-time
+/// constant, so the JIT residualizes the call instead of tracing into it
+/// (`@dont_look_inside`, the [`at_outermost_activation`] sibling). The
+/// `-> bool` return fits a single word and it cannot raise.
+#[majit_macros::dont_look_inside]
+pub fn poll_due() -> bool {
+    POLL_TICK.with(|t| {
+        let n = t.get() + 1;
+        if n >= POLL_INTERVAL {
+            t.set(0);
+            true
+        } else {
+            t.set(n);
+            false
+        }
+    })
+}
 
 /// Whether `PYRE_GC_INTERP` routes int/float allocations through the GC and
 /// arms the dispatch-loop safepoint. Reads the env once, then caches.
@@ -174,27 +187,25 @@ pub fn enabled() -> bool {
     }
 }
 
-/// Account for `size` bytes of interpreter-routed allocation. Called after a
-/// successful `try_gc_alloc_stable` with the payload size that succeeded.
+/// Dispatch-loop safepoint: when the collector says it has reached the
+/// threshold it set for its next major, run a non-moving old-gen-only major.
+/// A no-op when the flag is off or no collection hook is installed.
 ///
-/// Takes the size because the safepoint's budget is a byte budget: the
-/// allocator's own accumulation is `nursery_free = result + totalsize`
-/// (minimark.py:556-557). Counting allocations instead lets a workload that
-/// boxes many small objects trigger a whole-heap major far more often than the
-/// bytes it reclaims justify.
+/// The decision is entirely the collector's. `threshold_reached`
+/// (incminimark.py:1288-1290) compares `get_total_memory_used()` — every byte
+/// the collector is responsible for, headers included, whatever allocated them
+/// — against the threshold `set_major_threshold_from` (incminimark.py:575-594)
+/// derived from the last major's survivors under `major_collection_threshold`,
+/// `growth_rate_max`, `max_delta`, `min_heap_size` and `max_heap_size`. Running
+/// the collection re-derives it, because `do_collect_oldgen_nonmoving` drives
+/// `major_collection_step` to the end of the cycle and `finish_incremental_cycle`
+/// sets the next threshold there.
 ///
-/// Touches the runtime-mutable `ALLOC_BYTES_SINCE_GC` atomic; the value is not
-/// a build-time constant, so the JIT residualises the call instead of tracing
-/// into it (`@dont_look_inside`, the [`enabled`] sibling). A `()` return has no
-/// discriminant to erase.
-#[majit_macros::dont_look_inside]
-pub fn note_alloc(size: usize) {
-    ALLOC_BYTES_SINCE_GC.fetch_add(size, Ordering::Relaxed);
-}
-
-/// Dispatch-loop safepoint: when enough interpreter objects have accumulated,
-/// run a non-moving old-gen-only major to reclaim the dead ones, then reset the
-/// counter. A no-op when the flag is off or no collection hook is installed.
+/// The safepoint deliberately keeps no counter of its own. Upstream asks this
+/// question in the allocator, where every allocation passes; a second tally
+/// kept beside the collector could only ever see the subset of allocations
+/// that remembered to report, and would answer for a heap that is not the one
+/// being collected.
 ///
 /// The collection is `try_gc_collect_oldgen` — it seeds roots, marks, and
 /// sweeps ONLY the old generation, never touching the nursery (not moved, not
@@ -212,13 +223,12 @@ pub fn note_alloc(size: usize) {
 /// module code — whose Rust-stack roots the pyframe walker cannot see — never
 /// triggers it.
 ///
-/// Reads the runtime-mutable `ALLOC_SINCE_GC` atomic and dispatches to the
-/// installed collection hook, neither a build-time constant, so the JIT
-/// residualizes the call instead of tracing into it (`@dont_look_inside`, the
-/// [`enabled`] sibling). A `()` return has no discriminant to erase and it
-/// cannot raise. On the cold interpreter dispatch loop its first act is
-/// already the non-inlined `enabled()` early-return; the residual adds no
-/// hot-path cost the un-residualized form did not already pay.
+/// Dispatches to the installed threshold and collection hooks, neither a
+/// build-time constant, so the JIT residualizes the call instead of tracing
+/// into it (`@dont_look_inside`, the [`enabled`] sibling). A `()` return has no
+/// discriminant to erase and it cannot raise. On the cold interpreter dispatch
+/// loop its first act is already the non-inlined `enabled()` early-return; the
+/// residual adds no hot-path cost the un-residualized form did not already pay.
 #[majit_macros::dont_look_inside]
 pub fn safepoint() {
     if !enabled() {
@@ -226,18 +236,11 @@ pub fn safepoint() {
     }
     if collect_enabled()
         && at_outermost_activation()
-        && ALLOC_BYTES_SINCE_GC.load(Ordering::Relaxed) >= NEXT_MAJOR_BYTES.load(Ordering::Relaxed)
+        && poll_due()
+        && crate::gc_hook::try_gc_major_threshold_reached()
         && crate::gc_hook::try_gc_jitframe_empty()
     {
         crate::gc_hook::try_gc_collect_oldgen();
-        // `set_major_threshold_from` (incminimark.py:575-594) re-derives the
-        // next threshold from what survived, so a heap that keeps growing pays
-        // proportionally more between majors and a steady-state one stops
-        // collecting altogether.
-        let (oldgen_live, _nursery_used) = crate::gc_hook::try_gc_heap_stats();
-        let next = (oldgen_live / 100).saturating_mul(MAJOR_GROWTH_DELTA_PCT);
-        NEXT_MAJOR_BYTES.store(next.max(MIN_HEAP_BYTES), Ordering::Relaxed);
-        ALLOC_BYTES_SINCE_GC.store(0, Ordering::Relaxed);
     }
 }
 

--- a/pyre/pyre-object/src/generator.rs
+++ b/pyre/pyre-object/src/generator.rs
@@ -160,7 +160,6 @@ fn w_generator_or_coroutine_new(
     let raw =
         crate::gc_hook::try_gc_alloc_stable_raw(W_GENERATOR_GC_TYPE_ID, W_GENERATOR_OBJECT_SIZE);
     if !raw.is_null() {
-        crate::gc_interp::note_alloc(W_GENERATOR_OBJECT_SIZE);
         unsafe {
             std::ptr::write(raw as *mut GeneratorIterator, value);
         }

--- a/pyre/pyre-object/src/interp_exceptions.rs
+++ b/pyre/pyre-object/src/interp_exceptions.rs
@@ -597,7 +597,6 @@ fn w_exception_new_empty_impl(kind: ExcKind, immortal: bool) -> PyObjectRef {
             unsafe {
                 std::ptr::write(raw as *mut W_BaseException, value);
             }
-            crate::gc_interp::note_alloc(W_BASE_EXCEPTION_SIZE);
             crate::gc_hook::try_gc_write_barrier(raw);
             return raw as PyObjectRef;
         }

--- a/pyre/pyre-object/src/intobject.rs
+++ b/pyre/pyre-object/src/intobject.rs
@@ -111,7 +111,6 @@ pub fn w_int_new(value: i64) -> PyObjectRef {
     if crate::gc_interp::enabled() {
         let raw = crate::gc_hook::try_gc_alloc_stable_raw(W_INT_GC_TYPE_ID, W_INT_OBJECT_SIZE);
         if !raw.is_null() {
-            crate::gc_interp::note_alloc(W_INT_OBJECT_SIZE);
             unsafe {
                 std::ptr::write(raw as *mut W_IntObject, obj);
                 return raw as PyObjectRef;

--- a/pyre/pyre-object/src/longobject.rs
+++ b/pyre/pyre-object/src/longobject.rs
@@ -149,11 +149,6 @@ pub fn w_long_from_raw(value: *mut BigInt) -> PyObjectRef {
         // until the wrapper is initialized and remembered below.
         let raw = crate::gc_hook::try_gc_alloc_stable_raw(W_LONG_GC_TYPE_ID, W_LONG_OBJECT_SIZE);
         if !raw.is_null() {
-            // Charge the dispatch-loop safepoint's byte budget, as w_int_new /
-            // w_float_new do for their stable allocs — otherwise a long-dominated
-            // interpreter workload never reaches the safepoint threshold and the
-            // dead old-gen long wrappers + their bigint payloads accumulate.
-            crate::gc_interp::note_alloc(W_LONG_OBJECT_SIZE);
             unsafe {
                 std::ptr::write(
                     raw as *mut W_LongObject,

--- a/pyre/pyre-object/src/unicodeobject.rs
+++ b/pyre/pyre-object/src/unicodeobject.rs
@@ -243,9 +243,6 @@ pub fn w_str_from_wtf8_managed(value: Wtf8Buf) -> PyObjectRef {
         let recovered = unsafe { (*value).clone() };
         return w_str_from_wtf8_immortal(recovered);
     }
-    // Both the header and the value box holding the WTF-8 bytes came from the
-    // collector, so the safepoint's byte budget accounts for both.
-    crate::gc_interp::note_alloc(W_UNICODE_OBJECT_SIZE + byte_len);
     unsafe {
         std::ptr::write(raw as *mut W_UnicodeObject, unicode);
         raw as PyObjectRef

--- a/pyre/pyre-wasm/src/lib.rs
+++ b/pyre/pyre-wasm/src/lib.rs
@@ -433,6 +433,14 @@ fn run_python_impl(source: &str) -> String {
             Ok(frame) => frame,
             Err(e) => return format!("Error: {e}"),
         };
+    // Nothing reaches a GC frame but the `CURRENT_FRAME` / `f_backref` chain,
+    // which this one joins only when `eval_with_jit` installs it; the module
+    // registration below allocates and can collect in between. Publish it for
+    // that span (pyrex `run_source` does the same).
+    let _main_frame_root = pyre_object::gc_roots::push_roots();
+    pyre_object::gc_roots::pin_root(
+        &*frame as *const pyre_interpreter::pyframe::PyFrame as pyre_object::PyObjectRef,
+    );
 
     // Register the `__main__` module in sys.modules (pyrex real_main does the
     // same), reusing the canonical globals dict so `__main__.__dict__`,

--- a/pyre/pyrex/src/lib.rs
+++ b/pyre/pyrex/src/lib.rs
@@ -1124,6 +1124,16 @@ fn run_source(source: &str, mode: Mode, filename: &str, no_site: bool) {
             std::process::exit(1);
         }
     };
+    // The frame is a GC object, and the only root that reaches one is the
+    // `CURRENT_FRAME` / `f_backref` chain the frame walker follows — which it
+    // joins when `eval_with_jit` below installs it.  Everything between here
+    // and that call runs Python (`sys`, the importlib bootstrap, `site`) and
+    // can therefore drive a collection that would reclaim the frame and hand
+    // its storage to the next frame allocation.  RPython keeps a local holding
+    // a GC object alive through the translated shadow stack; publish it
+    // explicitly for the same span.
+    let _main_frame_root = pyre_object::gc_roots::push_roots();
+    pyre_object::gc_roots::pin_root(&*frame as *const PyFrame as pyre_object::PyObjectRef);
 
     // Register __main__ module in sys.modules — PyPy: app_main sets
     // sys.modules['__main__'] before executing user code so that


### PR DESCRIPTION
Four commits on the interpreter GC safepoint. The first two replace the safepoint's hand-rolled heap model and its jitframe gate with the collector's own answers; in between sits the frame-lifetime bug that removing the gate exposes, and the diagnostic that found it.

## `gc: ask the collector when to run the interpreter safepoint's major`

The safepoint kept its own model of heap growth: bytes charged by `note_alloc` at eight allocation sites, compared against a threshold re-derived after each collection from `get_total_memory_used()` times a growth delta. Both halves described a different heap from the one being collected — the tally saw only the sites that remembered to report (dicts, lists, tuples, instances and every JIT promotion grow the old generation without charging it), the charges were payload-only while the collector's total counts each `GcHeader`, and the re-derived threshold dropped the `growth_rate_max` / `max_delta` caps and the `max_heap_size` bound that `set_major_threshold_from` (incminimark.py:575-594) applies.

All of that is already ported in `majit-gc`. `threshold_reached` (incminimark.py:1288-1290) weighs `get_total_memory_used()` against the threshold set from the last major's survivors, and `do_collect_oldgen_nonmoving` already runs `major_collection_step` through `finish_incremental_cycle`, which sets the next one. Exposed as `GcAllocator::major_threshold_reached`. What remains on the pyre side is a poll interval carrying no heap semantics.

Interleaved min-of-7 against the previous policy: every workload within 1% with `PYRE_GC_INTERP` off and on, completed majors per run unchanged (14/13, 34/33, 12/12), RSS over a `s.lower()` loop flat at 154 MB either way.

## `pyframe: name the code object and pc when the value stack underflows`

`pop`'s bare depth assertion said an opcode popped from an empty stack, but not which opcode of which code object — the whole question when the underflow means the frame is no longer the one the loop started with. Replaced with a `#[cold]` reporter carrying depth/base/nlocals/ncells, pc, `last_instr`, the code object's name and file, the frame/pycode/f_backref pointers, and an opcode window.

## `interp: root the __main__ frame across the bootstrap imports`

`run_source` built the `__main__` frame and then ran the `sys` importhook, the importlib bootstrap, `seed_main_loader` and `import_site` before handing it to `eval_with_jit`. The frame is a GC-managed `FrameBox`, and the only root that reaches one is the `CURRENT_FRAME` / `f_backref` chain `walk_pyframe_roots` follows — which it joins when `eval_with_jit` installs it. A collection driven by any bootstrap step therefore reclaimed a live frame and handed its block to the next stable frame allocation.

With min_heap_size near 1 MB the first major lands inside `import_site` and the block goes to importlib's `_get_module_lock` weakref callback, which leaves `last_instr` at its `ReturnValue` and a value stack at base; `eval_with_jit` then enters that block and `pop` underflows. Confirmed under lldb: the `FrameBox` pointer returned by `new_with_context` is the frame the panic names.

Pin the frame for the span, as `FrameBox::new`, `call_function_impl_result` and `finalize_weakrefs` already do for the same reason — an RPython local holding a GC object is a shadow-stack root, a Rust local is not. `pyre-wasm`'s `run_python_impl` has the same shape over a shorter window and gets the same pin.

## `gc: drop the jitframe-empty gate from the interpreter safepoint`

The safepoint only ran a major when no compiled trace was suspended on this thread. A trace suspends by making a residual call into the interpreter, and a call site is where the backend emits a gcmap, so `enumerate_root_walker_values` already reaches a suspended frame's live refs by expanding each jitframe on the JF shadow stack through `trace_libc_jitframe`. The gate has no upstream counterpart and suppressed most of the safepoint's collections.

Removed root and branch, along with its hook layer, trampoline and fn-addr aliases. On `p_calleeloop.py` this takes the safepoint from 12 majors to 23, against a JIT-off baseline of 26.

---

Verification is running locally (repro matrix, `check.py` on both backends × default and gated, `cargo test`, perf A/B); this PR will be updated if anything comes back red.

— *opened by Claude*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved garbage-collection scheduling by using the collector’s major-threshold status directly.
  * Reduced unnecessary allocation bookkeeping during object creation.
  * Improved frame lifetime handling during Python execution to prevent premature collection.
  * Added detailed diagnostics for interpreter stack underflow errors.
  * Improved compatibility across native, WebAssembly, and JIT execution backends.
* **Refactor**
  * Simplified garbage-collection safepoint and polling behavior for more consistent collection decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->