### PR TITLE
gc, _io: register a finalizer at most once, and close the _io registration, needs_finalizer and autoflusher gaps behind it

### DIFF
--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -3914,6 +3914,17 @@ impl GcAllocator for MiniMarkGC {
                 trigger,
             });
         }
+        // `register_finalizer` is contracted to run at most once per object
+        // (`rgc.py:648-649`). A second deque entry survives the first
+        // `deal_with_objects_with_finalizers` pass through `new_with_finalizer`
+        // (incminimark.py:2944-2946) and delivers the object a second time on
+        // the next major collection, so honour the contract here rather than
+        // leaving it to every caller.
+        let hdr = unsafe { header_of(obj.0) };
+        if unsafe { (*hdr).has_flag(flags::FINALIZER_REGISTERED) } {
+            return;
+        }
+        unsafe { (*hdr).set_flag(flags::FINALIZER_REGISTERED) };
         if self.oldgen.contains(obj.0) {
             // Pyre's host allocations can be born directly in old-gen and an
             // explicit non-moving major intentionally skips the leading minor.
@@ -7735,5 +7746,45 @@ mod tests {
         // can stay true for a freed block while the current arena is retained.
         // The allocator's exact live count verifies reclamation here.
         assert_eq!(gc.oldgen.object_count(), 0);
+    }
+
+    /// `rgc.py:648-649` contracts `register_finalizer` to run at most once per
+    /// object. Registering twice used to leave two deque entries: the first
+    /// major delivers the object and re-appends the survivor through
+    /// `new_with_finalizer` (incminimark.py:2944-2946), so the next major
+    /// delivers it again and the app-level `__del__` runs a second time.
+    #[test]
+    fn register_finalizer_delivers_an_object_once_however_often_it_is_registered() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        static TRIGGERS: AtomicUsize = AtomicUsize::new(0);
+        fn trigger() {
+            TRIGGERS.fetch_add(1, Ordering::Relaxed);
+        }
+
+        TRIGGERS.store(0, Ordering::Relaxed);
+        let mut gc = test_gc(4096);
+        let tid = gc.register_type(TypeInfo::simple(16));
+        let obj = gc.alloc_in_oldgen(tid, GcHeader::SIZE + 16);
+        let mut root = obj;
+        unsafe { gc.roots.add(&mut root) };
+
+        // The construction site registers, then a later out-of-band caller
+        // asks again without knowing that.
+        GcAllocator::register_finalizer(&mut gc, 0, obj, trigger);
+        GcAllocator::register_finalizer(&mut gc, 0, obj, trigger);
+        assert_eq!(gc.old_objects_with_finalizers.len(), 1);
+
+        gc.roots.remove(&mut root);
+        gc.do_collect_oldgen_nonmoving();
+        assert_eq!(TRIGGERS.load(Ordering::Relaxed), 1);
+        assert_eq!(GcAllocator::finalizer_next_dead(&mut gc, 0), Some(obj));
+        assert_eq!(GcAllocator::finalizer_next_dead(&mut gc, 0), None);
+
+        // No survivor was carried into the next cycle, so the object is not
+        // delivered a second time.
+        gc.do_collect_oldgen_nonmoving();
+        assert_eq!(TRIGGERS.load(Ordering::Relaxed), 1);
+        assert_eq!(GcAllocator::finalizer_next_dead(&mut gc, 0), None);
     }
 }

--- a/majit/majit-gc/src/lib.rs
+++ b/majit/majit-gc/src/lib.rs
@@ -59,6 +59,20 @@ pub mod flags {
     pub const SHADOW_INITIALIZED: u64 = 1 << 11;
     /// GCFLAG_DUMMY (bit 12)
     pub const DUMMY: u64 = 1 << 12;
+    /// The object is already on a finalizer queue (bit 13).
+    ///
+    /// Not an incminimark flag — bit 13 is `_GCFLAG_FIRST_UNUSED`
+    /// (incminimark.py:169) there, so this claims the first free bit and
+    /// disturbs no RPython position. incminimark keeps the registered set
+    /// purely in its two deques and never asks the question, because
+    /// `register_finalizer` is contracted to be called at most once per
+    /// object. That contract is checked only untranslated (`rgc.py:648-649`
+    /// `assert not self._already_registered(obj)`); translated, a second
+    /// registration silently appends a second deque entry and the finalizer
+    /// runs again on the following major collection. This flag lets the
+    /// queue enforce the contract for callers that cannot establish single
+    /// registration statically.
+    pub const FINALIZER_REGISTERED: u64 = 1 << 13;
 }
 
 /// Low-level trigger stored in an RPython finalizer handler.  It must only

--- a/pyre/pyre-interpreter/src/executioncontext.rs
+++ b/pyre/pyre-interpreter/src/executioncontext.rs
@@ -166,62 +166,30 @@ fn finalizer_queue_trigger() {
     }
 }
 
-/// objspace.py:486 `allocate_instance` finalizer registration callback.
+/// `baseobjspace.py:173-193 W_Root.register_finalizer` — the single entry
+/// point through which a construction site asks for `_finalize_` to run once
+/// `obj` becomes unreachable.
+///
+/// Upstream's contract is "call this at most once"; it holds structurally
+/// there, because every requester sits in the object's own constructor. pyre
+/// has one requester that does not: `getlifeline`
+/// (`interp__weakref.py:252-257`) asks at weakref-creation time and cannot
+/// know what the constructor already did. So the guard upstream writes as
+/// `if self.user_overridden_class and self.getclass(space).hasuserdel` —
+/// "`allocate_instance` got here first" — is enforced by the queue instead,
+/// which answers for every requester rather than one of them.
+pub fn register_finalizer(obj: PyObjectRef) {
+    pyre_object::gc_hook::try_gc_register_finalizer(0, obj, finalizer_queue_trigger);
+}
+
+/// objspace.py:486-487 `allocate_instance`:
+/// `if w_subtype.hasuserdel: self.finalizer_queue.register_finalizer(instance)`.
 pub fn maybe_register_user_finalizer(obj: PyObjectRef) {
     let Some(w_type) = crate::typedef::r#type(obj) else {
         return;
     };
     if unsafe { pyre_object::w_type_get_hasuserdel(w_type.as_ptr()) } {
-        pyre_object::gc_hook::try_gc_register_finalizer(0, obj, finalizer_queue_trigger);
-    }
-}
-
-/// Register a suspended-generator finalizer so its `finally`/`with` cleanup runs if the
-/// generator is collected while suspended inside a handler range. PyPy
-/// (generator.py:27) gates registration on `co_flags & CO_YIELD_INSIDE_TRY`; that
-/// compile-time flag is unavailable here (external compiler), so the caller gates on a
-/// non-empty code exception table — a sound necessary condition for any reachable
-/// `finally`/`except`/`with`.
-pub fn register_generator_finalizer(obj: PyObjectRef) {
-    pyre_object::gc_hook::try_gc_register_finalizer(0, obj, finalizer_queue_trigger);
-}
-
-/// Register an interp-level object whose PyPy counterpart implements
-/// `_finalize_` solely to release an acquired buffer.  The ownership bit
-/// lives on the object itself; this queue supplies the unreachable-object
-/// callback corresponding to `register_finalizer(space)`.
-pub fn register_native_buffer_finalizer(obj: PyObjectRef) {
-    pyre_object::gc_hook::try_gc_register_finalizer(0, obj, finalizer_queue_trigger);
-}
-
-/// `interp_iobase.py:63-64 W_IOBase.__init__`: `if self.needs_finalizer():
-/// self.register_finalizer(space)`.
-///
-/// An unclosed file must still flush and close when it becomes unreachable,
-/// and `_io`'s `__del__` (`module/_io/mod.rs` `iobase_del`) does exactly
-/// that. It is a builtin method on the interp-level type, so `hasuserdel` —
-/// which `type.__new__` sets only for a class whose own dict carries
-/// `__del__` — is false here and [`maybe_register_user_finalizer`] would
-/// skip the object. Registration is therefore explicit at construction,
-/// as upstream does it.
-pub fn register_iobase_finalizer(obj: PyObjectRef) {
-    pyre_object::gc_hook::try_gc_register_finalizer(0, obj, finalizer_queue_trigger);
-}
-
-/// Register an object that owns a `WeakrefLifeline`. PyPy's GC invalidates the
-/// rweakrefs and registers callback-bearing lifelines themselves; until pyre's
-/// mapdict weakref SPECIAL slot is inline, the address-keyed slot keeps that
-/// lifeline rooted, so the equivalent death notification is registered on its
-/// owner. Objects with `__del__` are already in this queue and must not be
-/// registered twice.
-pub fn register_weakref_finalizer(obj: PyObjectRef) {
-    let already_registered = crate::typedef::r#type(obj)
-        .map(|w_type| unsafe { pyre_object::w_type_get_hasuserdel(w_type.as_ptr()) })
-        .unwrap_or(false);
-    let native_buffer_finalizer = crate::module::__pypy__::W_PickleBuffer::from_obj(obj).is_some()
-        || crate::module::r#struct::unpack_iter::W_UnpackIter::from_obj(obj).is_some();
-    if !already_registered && !native_buffer_finalizer {
-        pyre_object::gc_hook::try_gc_register_finalizer(0, obj, finalizer_queue_trigger);
+        register_finalizer(obj);
     }
 }
 

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -2169,10 +2169,29 @@ impl AppleveldefNamespace for PyObjectRef {
 }
 
 pub fn appleveldef_install(
+    ns: impl AppleveldefNamespace,
+    source: &str,
+    filename: &str,
+    names: &[&str],
+) {
+    appleveldef_install_seeded(ns, source, filename, names, &[]);
+}
+
+/// [`appleveldef_install`] with `seed` bound into the app namespace before the
+/// source runs.
+///
+/// `mixedmodule.py:135 MixedModule.get` executes the sibling app file lazily, on
+/// the first access to a name it defines, so by then the module is importable
+/// and the file can reach its own interp-level types through a plain
+/// `import _io` (`app_io.py:1`).  pyre installs app files eagerly from the
+/// module initializer, before the module object exists, so a name the source
+/// needs from its own module is bound up front instead.
+pub fn appleveldef_install_seeded(
     mut ns: impl AppleveldefNamespace,
     source: &str,
     filename: &str,
     names: &[&str],
+    seed: &[(&str, PyObjectRef)],
 ) {
     let code = compile_source_with_filename(source, Mode::Exec, filename)
         .unwrap_or_else(|e| panic!("appleveldef `{filename}`: compile failed — {e}"));
@@ -2183,6 +2202,9 @@ pub fn appleveldef_install(
     let w_app_globals = unsafe { (*ctx).fresh_module_globals() };
     let _root = pyre_object::gc_roots::push_roots();
     pyre_object::gc_roots::pin_root(w_app_globals);
+    for &(name, value) in seed {
+        unsafe { pyre_object::w_dict_setitem_str(w_app_globals, name, value) };
+    }
     let code_ptr = Box::into_raw(Box::new(code));
     let w_code = crate::w_code_new(code_ptr as *const ());
     let mut frame = crate::pyframe::createframe_obj(w_code as *const (), w_app_globals, ctx, None)

--- a/pyre/pyre-interpreter/src/module/__pypy__/interp_buffer.rs
+++ b/pyre/pyre-interpreter/src/module/__pypy__/interp_buffer.rs
@@ -60,11 +60,12 @@ impl W_PickleBuffer {
             release_memoryview,
             w_release_exporter: pyre_object::gc_roots::shadow_stack_get(sp + 1),
         });
-        // Pyre also routes weakref invalidation through this finalizer queue,
-        // so register immutable-buffer wrappers too: PyPy's collector handles
-        // their weakrefs independently even when `buf.needs_release()` is
-        // false.  The idempotent release body is a no-op for that export.
-        crate::executioncontext::register_native_buffer_finalizer(w_pickle_buffer);
+        // `_finalize_` releases the acquired export. Pyre also routes weakref
+        // invalidation through this queue, so register immutable-buffer
+        // wrappers too: PyPy's collector handles their weakrefs independently
+        // even when `buf.needs_release()` is false. The idempotent release
+        // body is a no-op for that export.
+        crate::executioncontext::register_finalizer(w_pickle_buffer);
         Ok(w_pickle_buffer)
     }
 

--- a/pyre/pyre-interpreter/src/module/_io/_io_app.py
+++ b/pyre/pyre-interpreter/src/module/_io/_io_app.py
@@ -3,10 +3,25 @@
 BytesIO is an in-memory binary stream backed by a bytearray plus an
 integer position, sufficient for pickle's pure-Python Pickler/Unpickler
 (write/getvalue on dump, read/readline on load).
+
+`_BufferedIOBase` and `_TextIOBase` are bound by the module initializer
+before this source runs.
 """
 
 
-class BytesIO:
+class BytesIO(_BufferedIOBase):
+    def __new__(cls, *args, **kwargs):
+        # interp_bytesio.py:196-198 `needs_finalizer`: `self.close()` is not
+        # necessary when the object goes away, so the exact class stays off the
+        # finalizer queue.  A subclass, whose `close` may do anything, goes on
+        # it through the base `__new__`.  That base is also the one entry into
+        # the autoflusher, which interp_bytesio.py:70 opts out of
+        # (`add_to_autoflusher=False`) — an in-memory buffer has nothing to
+        # write out at exit.
+        if cls is BytesIO:
+            return object.__new__(cls)
+        return _BufferedIOBase.__new__(cls)
+
     def __init__(self, initial_bytes=b""):
         self._buffer = bytearray(initial_bytes)
         self._pos = 0
@@ -190,11 +205,22 @@ class BytesIO:
         return False
 
 
-class StringIO:
+class StringIO(_TextIOBase):
     """In-memory text stream backed by a str buffer plus an integer
     position.  Covers the common producers/consumers (logging /
     traceback / csv / json) without the C `_io.StringIO` accelerator.
     """
+
+    def __new__(cls, *args, **kwargs):
+        # interp_stringio.py:465-467 `needs_finalizer`: `self.buf = None` is not
+        # necessary when the object goes away, so the exact class stays off the
+        # finalizer queue; a subclass goes on it through the base `__new__`.
+        # That base also enters the stream into the autoflusher, which
+        # interp_stringio.py inherits (`add_to_autoflusher` defaults to True);
+        # for the exact class the flush it would run has no effect either.
+        if cls is StringIO:
+            return object.__new__(cls)
+        return _TextIOBase.__new__(cls)
 
     def __init__(self, initial_value="", newline="\n"):
         if newline is not None and not isinstance(newline, str):

--- a/pyre/pyre-interpreter/src/module/_io/buffered_rwpair.rs
+++ b/pyre/pyre-interpreter/src/module/_io/buffered_rwpair.rs
@@ -59,7 +59,11 @@ impl W_BufferedRWPair {
     #[staticmethod]
     fn __new__(cls: PyObjectRef, _args: &[PyObjectRef]) -> PyObjectRef {
         let obj = W_BufferedRWPair::allocate_stable(W_BufferedRWPair::default());
-        super::tag_io_instance(obj, cls)
+        // interp_bufferedio.py:1175-1177 `needs_finalizer`: `self.w_writer` and
+        // `self.w_reader` have their own finalizer, so the pair itself needs
+        // none. A subclass keeps one — its `close` may do anything.
+        let needs_finalizer = !cls.is_null() && !std::ptr::eq(cls, type_object());
+        super::tag_io_instance_with_finalizer(obj, cls, needs_finalizer)
     }
 
     fn __init__(

--- a/pyre/pyre-interpreter/src/module/_io/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_io/mod.rs
@@ -564,6 +564,41 @@ fn init_iobase_type(ns: PyObjectRef) {
         "__getstate__",
         crate::make_builtin_function_with_arity("__getstate__", iobase_getstate, 1),
     );
+    unsafe {
+        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+            ns,
+            "__new__",
+            crate::typedef::make_new_descr(iobase_new),
+        )
+    };
+}
+
+/// `interp_iobase.py:335 __new__ = generic_new_descr(W_IOBase)`.
+///
+/// `typedef.py:558-564 generic_new_descr` allocates the instance and then runs
+/// the interp-level `W_IOBase.__init__`, whose only effect is
+/// `interp_iobase.py:63-64` — put the stream on the finalizer queue, so an
+/// unclosed one still flushes and closes once it becomes unreachable. Because
+/// it sits in `__new__` rather than in the app-level `__init__`, a subclass
+/// that overrides `__init__` without calling up is registered all the same.
+///
+/// Every `_io` type keeping the generic instance layout inherits this through
+/// the MRO: `FileIO`, the `_RawIOBase`/`_BufferedIOBase`/`_TextIOBase` bases,
+/// and app-level subclasses of any of them. The typed payloads override
+/// `__new__` and reach the same queue through [`tag_io_instance`].
+///
+/// The extra arguments go to `__init__`; `generic_new_descr` ignores its
+/// `__args__` in the same way.
+fn iobase_new(args: &[PyObjectRef]) -> crate::PyResult {
+    let (positional, _) = crate::builtins::split_builtin_kwargs(args);
+    let Some(&cls) = positional.first() else {
+        return Err(crate::PyError::type_error(
+            "_IOBase.__new__(): not enough arguments",
+        ));
+    };
+    let obj = crate::typedef::object_descr_new(&[cls])?;
+    crate::executioncontext::register_finalizer(obj);
+    Ok(obj)
 }
 
 /// `interp_iobase.py:rawiobase_read_w` — the default raw `read` is a

--- a/pyre/pyre-interpreter/src/module/_io/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_io/mod.rs
@@ -208,6 +208,136 @@ fn iobase_next(args: &[PyObjectRef]) -> crate::PyResult {
     }
 }
 
+// ── AutoFlusher ──────────────────────────────────────────────────────
+//
+// `interp_iobase.py:444-476` keeps one `AutoFlusher` per space, weakly holding
+// every stream ever constructed, and `moduledef.py:37-40 Module.shutdown`
+// flushes whatever is still alive.  Without it an unclosed buffered stream
+// loses its writes whenever it outlives the only teardown pyre performs — the
+// `__main__` globals — which is every stream reachable from another module,
+// from `sys.modules`, or from a container.
+//
+// `rweaklist.py:52 store_handle` holds each stream through `weakref.ref`; the
+// `GcWeakrefBox` is pyre's rweakref, so the handle list is a `Vec` of boxes.
+// Those are immortal, so their addresses stay valid across collections, but
+// their inner rweakref is walked by the boxing thread alone
+// (`weakref.rs WEAKREF_BOXES`) — hence the list lives with them, per thread, and
+// shutdown flushes the streams of the thread it runs on.
+
+/// `rweaklist.py:4 INITIAL_SIZE`.
+const AUTOFLUSHER_INITIAL_SIZE: usize = 4;
+
+#[derive(Default)]
+struct AutoFlusher {
+    /// `rweaklist.py:18 self.handles` — index → `GcWeakrefBox`. A null slot is
+    /// the `dead_ref` placeholder RPython pre-fills the list with.
+    handles: Vec<PyObjectRef>,
+    /// `rweaklist.py:19 self.free_list`.
+    free_list: Vec<usize>,
+}
+
+impl AutoFlusher {
+    /// `rweaklist.py:17-20 initialize`.
+    fn initialize(&mut self) {
+        self.handles = vec![std::ptr::null_mut(); AUTOFLUSHER_INITIAL_SIZE];
+        self.free_list = (0..AUTOFLUSHER_INITIAL_SIZE).collect();
+    }
+
+    /// `rweaklist.py:23-42 reserve_next_handle_index`.
+    fn reserve_next_handle_index(&mut self) -> usize {
+        if self.handles.is_empty() {
+            self.initialize();
+        }
+        if let Some(index) = self.free_list.pop() {
+            return index;
+        }
+        for (index, &handle) in self.handles.iter().enumerate() {
+            if unsafe { pyre_object::weakref::w_gc_weakref_box_deref(handle) }.is_null() {
+                self.free_list.push(index);
+            }
+        }
+        if self.free_list.len() * 3 < self.handles.len() * 2 {
+            let length = self.handles.len();
+            self.free_list.extend(length..length * 2);
+            self.handles.resize(length * 2, std::ptr::null_mut());
+        }
+        self.free_list
+            .pop()
+            .expect("the doubling above always frees an index")
+    }
+}
+
+thread_local! {
+    /// `interp_iobase.py:475-476 get_autoflusher` — `space.fromcache(AutoFlusher)`.
+    static AUTOFLUSHER: std::cell::RefCell<AutoFlusher> =
+        std::cell::RefCell::new(AutoFlusher::default());
+}
+
+/// `interp_iobase.py:447-453 AutoFlusher.add`, reached from
+/// `interp_iobase.py:61-62 W_IOBase.__init__` for every stream that does not
+/// opt out.
+///
+/// Returns `w_iobase`, which the rweakref allocation may have relocated.
+fn autoflusher_add(w_iobase: PyObjectRef) -> PyObjectRef {
+    if w_iobase.is_null() {
+        return w_iobase;
+    }
+    let index = AUTOFLUSHER.with(|flusher| flusher.borrow_mut().reserve_next_handle_index());
+    let _roots = pyre_object::gc_roots::push_roots();
+    let target_root = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(w_iobase);
+    // `rweaklist.py:51-52 store_handle` — reuse the slot's box when it already
+    // holds one, so a long-lived process bounds the immortal boxes by its peak
+    // number of open streams.
+    let handle = AUTOFLUSHER.with(|flusher| flusher.borrow().handles[index]);
+    let stored = unsafe { pyre_object::weakref::w_gc_weakref_box_retarget(handle, w_iobase) };
+    if !stored {
+        let boxed = pyre_object::weakref::w_gc_weakref_box_new(
+            pyre_object::gc_roots::shadow_stack_get(target_root),
+        );
+        AUTOFLUSHER.with(|flusher| flusher.borrow_mut().handles[index] = boxed);
+    }
+    pyre_object::gc_roots::shadow_stack_get(target_root)
+}
+
+/// `interp_iobase.py:455-472 AutoFlusher.flush_all`, run from
+/// `moduledef.py:37-40 Module.shutdown` — "at shutdown, flush all open streams.
+/// Ignore I/O errors."
+pub fn flush_all_streams() {
+    loop {
+        let handles = AUTOFLUSHER.with(|flusher| {
+            let mut flusher = flusher.borrow_mut();
+            flusher.free_list.clear();
+            // `self.initialize()` — reset the state here, so a stream created
+            // while flushing is picked up by the next round instead of being
+            // flushed twice.
+            std::mem::take(&mut flusher.handles)
+        });
+        let mut progress = false;
+        for handle in handles {
+            let _roots = pyre_object::gc_roots::push_roots();
+            let stream_root = pyre_object::gc_roots::shadow_stack_len();
+            let stream = unsafe { pyre_object::weakref::w_gc_weakref_box_deref(handle) };
+            if stream.is_null() {
+                continue;
+            }
+            pyre_object::gc_roots::pin_root(stream);
+            progress = true;
+            // "Silencing all errors is bad, but getting randomly interrupted
+            // here is equally as bad, and potentially more frequent (because of
+            // shutdown issues)."
+            let _ = call_method_result(
+                pyre_object::gc_roots::shadow_stack_get(stream_root),
+                "flush",
+                &[],
+            );
+        }
+        if !progress {
+            break;
+        }
+    }
+}
+
 /// Tag a freshly allocated `_io` object with the class being constructed, then
 /// put it on the finalizer queue — `objspace.py:485-487 allocate_instance`
 /// followed by `interp_iobase.py:63-64 W_IOBase.__init__`:
@@ -237,6 +367,7 @@ pub(crate) fn tag_io_instance_with_finalizer(
     if !cls.is_null() {
         crate::typedef::tag_subclass_instance(obj, cls);
     }
+    let obj = autoflusher_add(obj);
     if needs_finalizer {
         crate::executioncontext::register_finalizer(obj);
     }
@@ -591,9 +722,10 @@ fn init_iobase_type(ns: PyObjectRef) {
 /// `interp_iobase.py:335 __new__ = generic_new_descr(W_IOBase)`.
 ///
 /// `typedef.py:558-564 generic_new_descr` allocates the instance and then runs
-/// the interp-level `W_IOBase.__init__`, whose only effect is
-/// `interp_iobase.py:63-64` — put the stream on the finalizer queue, so an
-/// unclosed one still flushes and closes once it becomes unreachable. Because
+/// the interp-level `W_IOBase.__init__`, whose only effects are
+/// `interp_iobase.py:61-64` — hand the stream to the autoflusher, and put it on
+/// the finalizer queue so an unclosed one still flushes and closes once it
+/// becomes unreachable. Because
 /// it sits in `__new__` rather than in the app-level `__init__`, a subclass
 /// that overrides `__init__` without calling up is registered all the same.
 ///
@@ -611,7 +743,7 @@ fn iobase_new(args: &[PyObjectRef]) -> crate::PyResult {
             "_IOBase.__new__(): not enough arguments",
         ));
     };
-    let obj = crate::typedef::object_descr_new(&[cls])?;
+    let obj = autoflusher_add(crate::typedef::object_descr_new(&[cls])?);
     crate::executioncontext::register_finalizer(obj);
     Ok(obj)
 }

--- a/pyre/pyre-interpreter/src/module/_io/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_io/mod.rs
@@ -221,10 +221,25 @@ fn iobase_next(args: &[PyObjectRef]) -> crate::PyResult {
 /// this call too — the case `baseobjspace.py:185-188` returns early on; here
 /// the queue drops the repeat.
 pub(crate) fn tag_io_instance(obj: PyObjectRef, cls: PyObjectRef) -> PyObjectRef {
+    tag_io_instance_with_finalizer(obj, cls, true)
+}
+
+/// [`tag_io_instance`] for a type that overrides
+/// `interp_iobase.py:157-159 W_IOBase.needs_finalizer` — "can return False if we
+/// know that the precise close() method of this class will have no effect".
+/// Every override reads `type(self) is not <that class>`, so a subclass, whose
+/// `close` may do anything, keeps the default answer.
+pub(crate) fn tag_io_instance_with_finalizer(
+    obj: PyObjectRef,
+    cls: PyObjectRef,
+    needs_finalizer: bool,
+) -> PyObjectRef {
     if !cls.is_null() {
         crate::typedef::tag_subclass_instance(obj, cls);
     }
-    crate::executioncontext::register_finalizer(obj);
+    if needs_finalizer {
+        crate::executioncontext::register_finalizer(obj);
+    }
     obj
 }
 

--- a/pyre/pyre-interpreter/src/module/_io/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_io/mod.rs
@@ -990,11 +990,6 @@ crate::py_module! {
     interpleveldefs: {
         "DEFAULT_BUFFER_SIZE" => w_int_new(DEFAULT_BUFFER_SIZE),
     },
-    // BytesIO / StringIO are the pure-Python in-memory streams: pickle's
-    // Pickler/Unpickler use BytesIO; logging / traceback / csv use StringIO.
-    appleveldefs: {
-        "_io_app.py" => ["BytesIO", "StringIO", "IncrementalNewlineDecoder"],
-    },
     functions: {
         "open"            / * = crate::builtins::builtin_open,
         // `io.open_code(path)` — `_PyIO_open_code` opens the path in binary
@@ -1085,5 +1080,23 @@ crate::py_module! {
             pyre_object::w_type_set_acceptable_as_base_class(text_io_wrapper, true);
         }
         crate::module_ns_store(ns, "TextIOWrapper", text_io_wrapper);
+
+        // The pure-Python in-memory streams: pickle's Pickler/Unpickler use
+        // BytesIO; logging / traceback / csv use StringIO.  `W_BytesIO` derives
+        // `W_BufferedIOBase` (interp_bytesio.py:65) and `W_StringIO`
+        // `W_TextIOBase` (interp_stringio.py:390), so both bases have to be
+        // bound before the source runs; that is what puts this install here
+        // rather than in the `appleveldefs:` table, which the macro expands
+        // ahead of `extra_init`.
+        crate::importing::appleveldef_install_seeded(
+            ns,
+            include_str!("_io_app.py"),
+            "_io_app.py",
+            &["BytesIO", "StringIO", "IncrementalNewlineDecoder"],
+            &[
+                ("_BufferedIOBase", buffered_base),
+                ("_TextIOBase", text_base),
+            ],
+        );
     }
 }

--- a/pyre/pyre-interpreter/src/module/_io/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_io/mod.rs
@@ -208,21 +208,23 @@ fn iobase_next(args: &[PyObjectRef]) -> crate::PyResult {
     }
 }
 
-/// Tag a freshly allocated `_io` object with the class being constructed and
-/// put it on the finalizer queue, `interp_iobase.py:63-64`.
+/// Tag a freshly allocated `_io` object with the class being constructed, then
+/// put it on the finalizer queue — `objspace.py:485-487 allocate_instance`
+/// followed by `interp_iobase.py:63-64 W_IOBase.__init__`:
+/// `if self.needs_finalizer(): self.register_finalizer(space)`.
 ///
-/// Exactly one registration per object: `iobase_del` is inherited by every
-/// subclass, and `_call_finalizer` resolves `__del__` on the instance's own
-/// type, so an app-level override is reached through this same registration.
-/// Routing through `typedef::tag_subclass_instance` instead would register a
-/// second time for a subclass that defines `__del__`, and run it twice.
+/// An unclosed stream still has to flush and close once it is unreachable, and
+/// `iobase_del` does that. It is a builtin method on the interp-level type, so
+/// `hasuserdel` — set only for a class whose own dict carries `__del__` — is
+/// false for the plain types and the allocation hook would skip them. A
+/// subclass that does define `__del__` is registered by the hook and reaches
+/// this call too — the case `baseobjspace.py:185-188` returns early on; here
+/// the queue drops the repeat.
 pub(crate) fn tag_io_instance(obj: PyObjectRef, cls: PyObjectRef) -> PyObjectRef {
     if !cls.is_null() {
-        unsafe {
-            (*obj).w_class = cls;
-        }
+        crate::typedef::tag_subclass_instance(obj, cls);
     }
-    crate::executioncontext::register_iobase_finalizer(obj);
+    crate::executioncontext::register_finalizer(obj);
     obj
 }
 

--- a/pyre/pyre-interpreter/src/module/_weakref/interp__weakref.rs
+++ b/pyre/pyre-interpreter/src/module/_weakref/interp__weakref.rs
@@ -935,8 +935,11 @@ pub fn getlifeline(w_obj: PyObjectRef) -> Result<PyObjectRef, PyError> {
     crate::baseobjspace::setweakref(w_obj, lifeline)?;
     // RPython's collector invalidates every rweakref when its target dies.
     // pyre routes the equivalent lifeline clear through the shared finalizer
-    // queue, including for refs/proxies without callbacks.
-    crate::executioncontext::register_weakref_finalizer(w_obj);
+    // queue, including for refs/proxies without callbacks. This is the one
+    // registration that does not sit in the target's constructor, so it can
+    // land on an object some constructor already registered; the queue drops
+    // the repeat.
+    crate::executioncontext::register_finalizer(w_obj);
     Ok(lifeline)
 }
 

--- a/pyre/pyre-interpreter/src/module/struct/mod.rs
+++ b/pyre/pyre-interpreter/src/module/struct/mod.rs
@@ -1374,8 +1374,10 @@ pub mod unpack_iter {
             index: 0,
             export_active,
         });
+        // `_finalize_` releases the acquired export; nothing to release when
+        // the buffer was never acquired.
         if export_active {
-            crate::executioncontext::register_native_buffer_finalizer(w_iter);
+            crate::executioncontext::register_finalizer(w_iter);
         }
         Ok(w_iter)
     }

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -744,8 +744,14 @@ impl FrameBox {
         unsafe {
             (*frame_ptr).f_generator_nowref = generator;
         }
+        // generator.py:27 registers the generator so a `finally`/`with` body
+        // still unwinds when it is collected while suspended inside a handler
+        // range. Upstream gates on `co_flags & CO_YIELD_INSIDE_TRY`; that
+        // compile-time flag is unavailable here (external compiler), so
+        // `register_final` gates on a non-empty code exception table — a sound
+        // necessary condition for any reachable `finally`/`except`/`with`.
         if register_final {
-            crate::executioncontext::register_generator_finalizer(generator);
+            crate::executioncontext::register_finalizer(generator);
         }
         Ok(generator)
     }

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -15341,7 +15341,7 @@ fn same_inherited_slot(a: Option<PyObjectRef>, b: Option<PyObjectRef>) -> bool {
     }
 }
 
-fn object_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+pub(crate) fn object_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let w_object = w_object();
     let (positional, kwargs) = crate::builtins::split_builtin_kwargs(args);
     let Some(&w_type_arg) = positional.first() else {

--- a/pyre/pyre-object/src/weakref.rs
+++ b/pyre/pyre-object/src/weakref.rs
@@ -230,6 +230,37 @@ pub unsafe fn w_gc_weakref_box_deref(obj: PyObjectRef) -> PyObjectRef {
     unsafe { w_weakref_deref(wref) }
 }
 
+/// Point an existing box at `target` by installing a fresh rweakref.
+///
+/// `rweaklist.py:44-52 add_handle` reuses the slot of a handle whose referent
+/// died rather than appending a new one; reusing the box with it keeps the
+/// immortal-box count at the peak number of simultaneously live handles instead
+/// of the number of registrations. The previous inner Weakref becomes
+/// unreachable and is collected — it is the *new* one that
+/// [`w_weakref_new`] registers with the collector, which is what keeps the weak
+/// semantics. Storing it into the immortal box needs the prebuilt-family write
+/// barrier, since the `inner` slot is reached only by
+/// [`walk_gc_weakref_box_inner_roots`].
+///
+/// Returns false for a null target or a slot that is not a box.
+///
+/// # Safety
+///
+/// `obj` must be null or a live `GcWeakrefBox`, and `target` must be rooted by
+/// the caller: allocating the replacement rweakref can collect.
+pub unsafe fn w_gc_weakref_box_retarget(obj: PyObjectRef, target: PyObjectRef) -> bool {
+    if target.is_null() || !unsafe { is_gc_weakref_box(obj) } {
+        return false;
+    }
+    let inner = unsafe { w_weakref_new(target) };
+    if inner.is_null() {
+        return false;
+    }
+    unsafe { (*(obj as *mut GcWeakrefBox)).inner = inner };
+    crate::gc_roots::mark_prebuilt_roots_dirty();
+    true
+}
+
 /// Clear the wrapped rweakref, mirroring
 /// `W_WeakrefBase.clear(): self.w_obj_weak = dead_ref`.
 ///

--- a/pyre/pyrex/src/lib.rs
+++ b/pyre/pyrex/src/lib.rs
@@ -1007,6 +1007,12 @@ fn collect_and_run_finalizers(ec_ptr: *const PyExecutionContext) {
 /// methods may reference are still present.
 fn finalize_runtime(canonical: pyre_object::PyObjectRef, ec_ptr: *const PyExecutionContext) {
     run_threading_shutdown();
+    // baseobjspace.py:498-501 `finish()` runs every started module's shutdown
+    // hook; `_io`'s (moduledef.py:37-40) flushes the streams that are still
+    // alive.  The per-global teardown below reaches only the ones `__main__`
+    // itself holds, so without this a stream owned by any other module loses
+    // its buffered writes.
+    pyre_interpreter::module::_io::flush_all_streams();
     collect_and_run_finalizers(ec_ptr);
     let mut entries = unsafe { pyre_object::w_dict_str_entries(canonical) };
     entries.reverse();


### PR DESCRIPTION
Five commits closing the `register_finalizer` contract break Codex flagged on #850 (finding ②), and the `_io` registration gaps that only became fixable once the contract held.

## `register_finalizer` is at-most-once, and pyre broke it

`incminimark.py:1755` appends without dedup. A duplicate is **not** absorbed — inside one major collection `GCFLAG_VISITED` (`incminimark.py:2944`) serialises the two entries, but the second is re-appended through `new_with_finalizer` (:2945-2946) and becomes the next `old_objects_with_finalizers`, so the **next** major delivers the object again and the app-level `__del__` runs twice. Upstream tolerates this only because `rgc.py:648-649` contracts `register_finalizer` to at-most-once — asserted untranslated, silently double-firing when translated.

Every RPython requester sits in the object's own constructor. pyre had one that does not: `getlifeline` (`interp__weakref.py:252-257`) registers at weakref-creation time and cannot know what the constructor did, so it carried a hand-written skip list (`hasuserdel` + `PickleBuffer` + `unpack_iterator`) that missed the `_io` and generator constructors.

Earlier probes missed this because the finalizer *action* is idempotent (`iobase_del` early-returns on `io_closed`; a closed generator no-ops). Break that and it shows:

```python
class Leaky(io.BufferedWriter):
    def close(self): calls.append(1)   # never actually closes
x = Leaky(io.BytesIO()); weakref.ref(x); del x
```

pyre reported 2; CPython 3.14 and PyPy 1. Without the `weakref.ref`, 1.

`MiniMarkGC::register_finalizer` now records the registration in `flags::FINALIZER_REGISTERED` — bit 13, `_GCFLAG_FIRST_UNUSED` upstream, so no RPython bit position moves — and drops a repeat. Every allocation writes a fresh `GcHeader`, so the bit cannot survive address reuse. pyre's five entry points collapse to one `executioncontext::register_finalizer` (`baseobjspace.py:173-193`) and the skip list is gone.

## The `_io` gaps behind it

**Registration lived in the wrong place.** It was reached only from the five `#[pyre_class]` payload `__new__`s, so `FileIO`, the `_IOBase`/`_RawIOBase`/`_BufferedIOBase`/`_TextIOBase` bases, and app-level subclasses never reached the queue: 200 `io.FileIO` opens left **200 live fds**. `interp_iobase.py:335` is `__new__ = generic_new_descr(W_IOBase)` and `typedef.py:558-564` runs the interp-level `W_IOBase.__init__` *inside* `__new__` — verified by measurement, a subclass whose `__init__` never calls up is still registered on PyPy. `_IOBase` gained that `__new__`; every `_io` type keeping the generic layout inherits it.

**`needs_finalizer` was unported.** `interp_iobase.py:157-159` — "can return False if we know that the precise close() method of this class will have no effect" — with three overrides that all read `type(self) is not <that class>`: `W_BufferedRWPair` (:1175-1177), `W_BytesIO` (:196-198), `W_StringIO` (:465-467).

**`BytesIO`/`StringIO` derived `object`.** Upstream they are `W_BufferedIOBase` / `W_TextIOBase` subclasses, so `io.BytesIO.__mro__` read `[BytesIO, object]` against `[BytesIO, _BufferedIOBase, _IOBase, object]` and a subclass's `close()` never ran at collection. `detach()` and `fileno()` now raise `UnsupportedOperation` instead of `AttributeError`.

**No autoflusher.** `interp_iobase.py:444-476` weakly holds every stream `W_IOBase.__init__` constructs (:61-62) and `moduledef.py:37-40 Module.shutdown` flushes whatever is still alive. The only teardown `finalize_runtime` performs is `__main__`'s globals, so a stream held by another module, by `sys.modules`, or by a container lost its buffered writes at exit. The handles are `GcWeakrefBox`es — pyre's rweakref — and `reserve_next_handle_index` (`rweaklist.py:23-42`) reuses a dead handle's slot, with `w_gc_weakref_box_retarget` reusing its box so the immortal boxes stay bounded by the peak number of open streams.

## Measured, three-way against CPython 3.14 and PyPy 7.3.22

| probe | before | after | CPython / PyPy |
|---|---|---|---|
| `leaky_close_with_weakref` | 2 | 1 | 1 |
| `live_fds_after_200_fileio` | 200 | 0 | 0 |
| `iobase_subclass_close` / `rawiobase_close` | 0 | 1 | 1 |
| `iobase_no_super_init_close` | 0 | 1 | 1 |
| `bytesio_sub_close` / `stringio_sub_close` | 0 | 1 | 1 |
| `io.BytesIO.__mro__` | `[BytesIO, object]` | `[BytesIO, _BufferedIOBase, _IOBase, object]` | same |
| unclosed stream held off `__main__`, at exit | *empty file* | flushed | flushed |
| PickleBuffer / unpack_iter / generator `finally` | 1 | 1 | 1 |

Also checked line-for-line against CPython: read/readline/readlines/write/writelines/seek/tell/truncate/getvalue/getbuffer/iteration/context-manager on both in-memory streams, plus pickle, json, csv and traceback round-trips.

## Verification

`pyre/check.py --backend dynasm,cranelift,wasm` — dynasm 332/332, cranelift 332/332, wasm 329/329, 3/3 runs. `cargo test`: majit-gc 209 (one new regression test for the double delivery), pyre-interpreter 407, pyre-object 279.

## Refuted while verifying

The "`Cls.__del__ = f` after construction, then `weakref.ref` → object in no queue" hole is not a pyre defect — PyPy gives the same 0 there and the weakref still clears. Untouched.

## Still open

`W_BytesIO` / `W_StringIO` remain app-level stand-ins rather than interp-level classes with `RStringIO` and the buffer exports; `interp_iobase.py:61-62,444-455`'s per-space `AutoFlusher` is per-thread here, because the `GcWeakrefBox` rweakrefs it indexes are walked by the boxing thread alone.

— *authored by Claude*
