### PR TITLE
jit(fbw): resume a blackhole ContinueRunningNormally on the frame the drive wrote

### DIFF
--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -2280,6 +2280,12 @@ impl BlackholeInterpBuilder {
         interp.virtualizable_ptr = 0;
         interp.virtualizable_info = std::ptr::null();
         interp.virtualizable_stack_base = 0;
+        // Same footing: the layout describes the register file of the machine
+        // this run resumed, so it must not outlive it.  A stale one does not
+        // fail loudly — `StateFieldLayout::default()` is all-zero and the
+        // `scalar_slot`/`array_elem_slot` range checks are `debug_assert!`, so
+        // a release build reads whatever slot the arithmetic lands on.
+        interp.state_field_layout = StateFieldLayout::default();
         self.pool.push(interp);
     }
 
@@ -3895,6 +3901,30 @@ mod tests {
             assert!(
                 builder.acquire_interp().jitdrivers_sd.is_empty(),
                 "a pooled interp must not carry the previous run's table",
+            );
+        }
+
+        /// `state_field_layout` describes the register file of the machine one
+        /// resume belongs to, so it must not survive into the pool.  The
+        /// range checks in `scalar_slot`/`ref_scalar_slot`/`array_elem_slot`
+        /// are `debug_assert!`, so a release build given the all-zero default
+        /// silently returns `0 + field_idx` — aliasing the dispatch JitCode's
+        /// own argument registers rather than the identity slots
+        /// `ref_scalar_base` exists to keep clear of them.
+        #[test]
+        fn released_interp_does_not_leak_its_state_field_layout_to_the_next_user() {
+            let mut builder = super::build_inline_call_only_bh_builder();
+            let mut bh = builder.acquire_interp();
+            bh.state_field_layout =
+                super::StateFieldLayout::with_ref_scalars(1, vec![4], 0, 2, 8, 0);
+            assert_eq!(bh.state_field_layout.ref_scalar_slot(0), 8);
+
+            builder.release_interp(bh);
+            let reused = builder.acquire_interp();
+            assert_eq!(
+                reused.state_field_layout,
+                super::StateFieldLayout::default(),
+                "a pooled interp must not carry the previous resume's layout",
             );
         }
 

--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -716,6 +716,17 @@ impl BlackholeInterpreter {
                 self.registers_r[i] = 0;
             }
         }
+        // `tmpreg_r` is a reference slot on the same footing as `registers_r`:
+        // `run()` hands both to `push_bh_regs`, and `walk_bh_regs` visits the
+        // tmpreg word as a `GcRef` root.  Its live window is one opcode — the
+        // gap between a call helper returning and the `registers_r[dst]` store
+        // — but nothing resets it, so a released interp carries the last ref
+        // return value into the pool.  Nothing roots it there, so the object
+        // can be collected; the next `run()` on that pooled interp then pushes
+        // the dead address as a root and the collector reads a header off it.
+        // Upstream's `cleanup_registers` (`blackhole.py:385`) has no such slot
+        // to clear: RPython's tmpreg is a traced field of a GC object.
+        self.tmpreg_r = 0;
         self.exception_last_value = 0;
     }
 
@@ -3583,6 +3594,36 @@ mod tests {
             assert_eq!(reused.virtualizable_ptr, 0);
             assert!(reused.virtualizable_info.is_null());
             assert_eq!(reused.virtualizable_stack_base, 0);
+        }
+
+        /// A pooled interp must expose no reference word as a GC root.
+        ///
+        /// `run()` roots `registers_r` AND `tmpreg_r` through
+        /// `push_bh_regs`, and `walk_bh_regs` visits the tmpreg word as a
+        /// `GcRef`.  `cleanup_registers` cleared the bank but not the tmpreg,
+        /// so a released interp carried the last ref return value into the
+        /// pool, where nothing roots it — and the next `run()` on that interp
+        /// pushed the by-then-collectable address back as a root.
+        #[test]
+        fn released_interp_exposes_no_reference_word_to_the_root_walker() {
+            let mut builder = BlackholeInterpBuilder::new();
+            let mut bh = builder.acquire_interp();
+            bh.tmpreg_r = 0x7f00_0000_5678;
+
+            builder.release_interp(bh);
+            let mut reused = builder.acquire_interp();
+            assert_eq!(reused.tmpreg_r, 0);
+
+            let depth = unsafe {
+                majit_gc::shadow_stack::push_bh_regs(&mut reused.registers_r, &mut reused.tmpreg_r)
+            };
+            let mut roots: Vec<usize> = Vec::new();
+            majit_gc::shadow_stack::walk_bh_regs(|slot| roots.push(slot.0));
+            majit_gc::shadow_stack::pop_bh_regs_to(depth);
+            assert!(
+                roots.iter().all(|&word| word == 0),
+                "pooled interp handed the root walker stale references: {roots:x?}",
+            );
         }
 
         #[test]

--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -2222,6 +2222,20 @@ impl BlackholeInterpBuilder {
         interp.nextblackholeinterp = None;
         interp.aborted = false;
         interp.got_exception = false;
+        // The virtualizable handle is frame identity, not builder state, and
+        // `acquire_interp` refreshes only the six builder-shared fields.  A
+        // pooled interp that kept `virtualizable_ptr` would hand the next user
+        // a pointer to the frame this run just finished with:
+        // `blackhole_from_resumedata` never assigns either field, so
+        // `call_jit.rs`'s "a novable resume runs no vable opcodes, so leave
+        // both the pointer and the vinfo handle unset (null)" only holds for
+        // an interp that comes back from the pool clean.  `run()` dereferences
+        // `virtualizable_ptr` for every chain frame whose `virtualizable_info`
+        // is non-null (`push_resume_ref_roots`), so a stale pair reads a dead
+        // frame and roots its slots.  Reset with `virtualizable_stack_base`,
+        // which is the same frame-scoped triple.
+        interp.virtualizable_ptr = 0;
+        interp.virtualizable_info = std::ptr::null();
         interp.virtualizable_stack_base = 0;
         self.pool.push(interp);
     }
@@ -3537,6 +3551,38 @@ mod tests {
             let bh2 = builder.acquire_interp();
             // Reused from pool
             assert!(bh2.registers_i.is_empty());
+        }
+
+        /// A pooled interp must not carry the previous run's frame identity.
+        ///
+        /// `acquire_interp` refreshes only the six builder-shared fields
+        /// (`blackhole.py:284-289`), and `blackhole_from_resumedata` assigns
+        /// neither `virtualizable_ptr` nor `virtualizable_info` — the guard
+        /// path sets them afterwards, and deliberately does not for a
+        /// `novable` resume ("leave both the pointer and the vinfo handle
+        /// unset (null)", `pyre-jit/src/call_jit.rs`).  That contract is only
+        /// true if the pool hands back a cleared interp: `run()` dereferences
+        /// `virtualizable_ptr` for every chain frame with a non-null
+        /// `virtualizable_info` to push its GC roots, so a leaked pair reads
+        /// the frame the previous blackhole finished with.
+        ///
+        /// The handle here is never dereferenced — the assertion is on the
+        /// pointer word, so a dangling non-null stand-in is enough.
+        #[test]
+        fn released_interp_does_not_leak_its_virtualizable_handle_to_the_next_user() {
+            let mut builder = BlackholeInterpBuilder::new();
+            let mut bh = builder.acquire_interp();
+            bh.virtualizable_ptr = 0x7f00_0000_1234;
+            bh.virtualizable_info =
+                std::ptr::NonNull::<crate::virtualizable::VirtualizableInfo>::dangling().as_ptr();
+            bh.virtualizable_stack_base = 9;
+
+            builder.release_interp(bh);
+            let reused = builder.acquire_interp();
+
+            assert_eq!(reused.virtualizable_ptr, 0);
+            assert!(reused.virtualizable_info.is_null());
+            assert_eq!(reused.virtualizable_stack_base, 0);
         }
 
         #[test]

--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -278,6 +278,15 @@ pub struct BlackholeInterpreter {
     /// Replaces the prior single-driver flat fields
     /// (`portal_runner_ptr`/`mainjitcode_calldescr`) so multi-driver
     /// dispatch matches upstream line-by-line.
+    ///
+    /// Upstream reads the table through `self.builder.metainterp_sd`
+    /// (blackhole.py:60 `self.metainterp_sd = metainterp_sd`), so it is
+    /// builder-shared and every interpreter in a chain sees it by
+    /// construction.  A pool-owned Rust interpreter cannot hold a `&builder`
+    /// back-reference, so this is the builder's snapshot, copied in by
+    /// `acquire_interp` the same way `descrs` is (blackhole.py:288).  Set it
+    /// via [`BlackholeInterpBuilder::setup_jitdrivers_sd`] before acquiring,
+    /// not on individual frames.
     pub jitdrivers_sd: Vec<BhJitDriverSd>,
     /// Pyre: absolute start index of the operand stack in
     /// PyFrame.locals_cells_stack_w. RPython does not need this because
@@ -1855,6 +1864,12 @@ pub struct BlackholeInterpBuilder {
     /// wiring is done before the first `acquire_interp`, the inner Vec
     /// is uniquely owned and `make_mut` is cheap.
     pub(crate) dispatch_table: std::sync::Arc<Vec<BhOpcodeHandler>>,
+    /// RPython `blackhole.py:60` `self.metainterp_sd = metainterp_sd`.
+    /// Every interpreter resolves `jitdrivers_sd[jdindex]` through its
+    /// builder (blackhole.py:1079 `sd = self.builder.metainterp_sd`,
+    /// :1096 `self.builder.metainterp_sd.jitdrivers_sd[jdindex]`), so the
+    /// table belongs here and `acquire_interp` hands each frame a copy.
+    pub jitdrivers_sd: Vec<BhJitDriverSd>,
 }
 
 impl Default for BlackholeInterpBuilder {
@@ -1874,6 +1889,7 @@ impl BlackholeInterpBuilder {
             op_rvmprof_code: u8::MAX,
             descrs: Vec::new(),
             dispatch_table: std::sync::Arc::new(Vec::new()),
+            jitdrivers_sd: Vec::new(),
         }
     }
 
@@ -2015,6 +2031,17 @@ impl BlackholeInterpBuilder {
     /// RPython `blackhole.py:102-103` `setup_descrs(descrs)`.
     pub fn setup_descrs(&mut self, descrs: Vec<BhDescr>) {
         self.descrs = descrs;
+    }
+
+    /// Publish the jitdriver table every interpreter this builder hands out
+    /// will resolve `jdindex` against — the builder-side half of
+    /// `blackhole.py:60` `self.metainterp_sd = metainterp_sd` (read back at
+    /// :1079 / :1096).  Call before `acquire_interp`: a chain built from a
+    /// builder whose table is still empty gives every frame an empty table,
+    /// and `bhimpl_jit_merge_point`'s recursive-portal branch indexes it
+    /// directly.
+    pub fn setup_jitdrivers_sd(&mut self, jitdrivers_sd: Vec<BhJitDriverSd>) {
+        self.jitdrivers_sd = jitdrivers_sd;
     }
 
     /// Resolve JitCode fnaddr values from a mapping function.
@@ -2222,6 +2249,11 @@ impl BlackholeInterpBuilder {
         bh.op_live = self.op_live;
         // RPython blackhole.py:287: self.dispatch_loop = builder.dispatch_loop
         bh.dispatch_table = std::sync::Arc::clone(&self.dispatch_table);
+        // blackhole.py:250 `self.builder = builder` — upstream keeps the
+        // back-reference and reads `self.builder.metainterp_sd.jitdrivers_sd`
+        // on demand (:1079, :1096).  The pool owns the interpreters here, so
+        // hand each one the builder's snapshot instead.
+        bh.jitdrivers_sd = self.jitdrivers_sd.clone();
         bh
     }
 
@@ -2523,7 +2555,6 @@ pub struct PyjitplBlackholeFrameConfig<'a> {
     pub virtualizable_info: *const crate::virtualizable::VirtualizableInfo,
     pub virtualizable_ptr: i64,
     pub virtualizable_stack_base: usize,
-    pub jitdrivers_sd: &'a [BhJitDriverSd],
     /// Per-frame concrete frame ptr + its own stack_base, aligned to
     /// `framestack.frames` (outermost-first).  When present, each blackhole
     /// level uses ITS OWN frame as the virtualizable instead of sharing the
@@ -2562,7 +2593,6 @@ pub fn convert_and_run_from_pyjitpl(
                 cur_bh.virtualizable_ptr = frame_ptr;
                 cur_bh.virtualizable_stack_base = frame_stack_base;
             }
-            cur_bh.jitdrivers_sd = config.jitdrivers_sd.to_vec();
         }
         // Keep every completed interpreter bank rooted while later frames are
         // acquired and throughout `run_forever`.  The chain is consumed and
@@ -3814,6 +3844,57 @@ mod tests {
                     crate::jitexc::JitException::DoneWithThisFrameInt(999)
                 ),
                 "the caller must return the portal runner's result, got {outcome:?}",
+            );
+        }
+
+        /// `bhimpl_jit_merge_point`'s recursive-portal branch
+        /// (`blackhole.py:1079-1093`) and `get_portal_runner`
+        /// (`blackhole.py:1096`) both index `jitdrivers_sd[jdindex]`
+        /// unchecked.  Upstream can, because the table hangs off
+        /// `self.builder.metainterp_sd`: one table, reached by every frame of
+        /// a chain through its builder back-reference.  A pool-owned Rust
+        /// interpreter holds a snapshot instead, so the guarantee has to come
+        /// from `acquire_interp` — `blackhole_from_resumedata` builds a chain
+        /// by acquiring one interpreter per resumed frame and never touches
+        /// the table, and every frame above the bottom one takes the
+        /// recursive-portal branch.
+        #[test]
+        fn every_interp_a_builder_hands_out_carries_the_jitdriver_table() {
+            let mut builder = super::build_inline_call_only_bh_builder();
+            builder.setup_jitdrivers_sd(vec![super::BhJitDriverSd {
+                result_type: super::BhReturnType::Int,
+                ..Default::default()
+            }]);
+
+            // The shape `blackhole_from_resumedata` produces: one acquire per
+            // resumed frame, linked caller-ward through `nextblackholeinterp`.
+            let caller = builder.acquire_interp();
+            let mut inner = builder.acquire_interp();
+            inner.nextblackholeinterp = Some(Box::new(caller));
+
+            let mut frame = Some(&inner);
+            let mut depth = 0;
+            while let Some(f) = frame {
+                assert_eq!(
+                    f.jitdrivers_sd.len(),
+                    1,
+                    "chain frame {depth} cannot resolve jdindex 0",
+                );
+                assert_eq!(f.get_portal_runner(0).0, 0);
+                depth += 1;
+                frame = f.nextblackholeinterp.as_deref();
+            }
+            assert_eq!(depth, 2, "expected a two-frame chain");
+
+            // `release_interp` leaves the table on the pooled interpreter, so
+            // the refresh must overwrite it.  Otherwise a builder whose table
+            // is empty still hands out the previous run's entries, which is
+            // what let an unseeded resume path look like it worked.
+            builder.release_interp(inner);
+            builder.setup_jitdrivers_sd(Vec::new());
+            assert!(
+                builder.acquire_interp().jitdrivers_sd.is_empty(),
+                "a pooled interp must not carry the previous run's table",
             );
         }
 

--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -2454,10 +2454,19 @@ pub fn run_forever_with_portal(
                     terminal_out.as_deref_mut(),
                 ) {
                     Ok((new_bh, exc)) => {
-                        // Handled at recursive portal level — continue
+                        // Handled at a recursive portal level.  `new_bh` is
+                        // that portal frame (blackhole.py:1780 returns
+                        // `blackholeinterp`), and its caller already holds the
+                        // re-entered portal's result
+                        // (`_handle_jitexception_in_portal` →
+                        // warmspot.py:1041-1050), so the frame is finished.
+                        // Fall through to the shared release + step below —
+                        // blackhole.py:1759-1760 sit outside the `try`, so
+                        // they run on this arm too.  Re-entering `new_bh`
+                        // instead would execute its tail a second time and
+                        // overwrite the installed result.
                         bh = new_bh;
                         current_exc = exc;
-                        continue;
                     }
                     Err(propagated_exc) => {
                         // Bottommost or unhandled — propagate out
@@ -3635,6 +3644,90 @@ mod tests {
             let _ = bh.run();
 
             assert_eq!(bh.registers_i[1], 42);
+        }
+
+        /// `_run_forever` steps to `nextblackholeinterp` after the
+        /// iteration whose `JitException` was resolved at a recursive
+        /// portal level, not only after a plain return.
+        ///
+        /// `blackhole.py:1752-1760`:
+        ///
+        /// ```python
+        /// while True:
+        ///     try:
+        ///         current_exc = blackholeinterp._resume_mainloop(current_exc)
+        ///     except jitexc.JitException as e:
+        ///         blackholeinterp, current_exc = _handle_jitexception(
+        ///             blackholeinterp, e)
+        ///     blackholeinterp.builder.release_interp(blackholeinterp)
+        ///     blackholeinterp = blackholeinterp.nextblackholeinterp
+        /// ```
+        ///
+        /// The release + step sit BELOW the `try`, so they run on both
+        /// arms.  `_handle_jitexception` returns the portal frame
+        /// (`blackhole.py:1780`) after
+        /// `_handle_jitexception_in_portal` has already installed the
+        /// re-entered portal's result as the CALLER's return value
+        /// (`blackhole.py:1772` → `warmspot.py:1039-1050`), so that
+        /// frame is finished and the loop must continue in its caller.
+        ///
+        /// The chain here is `inner -> caller`.  `inner` carries the
+        /// portal `jitdriver_sd` and inline-calls a sub-jitcode whose
+        /// `jit_merge_point` is bottommost (the callee interpreter
+        /// `for_inline_callee` builds has no `nextblackholeinterp`), so
+        /// the `ContinueRunningNormally` reaches `_run_forever` from a
+        /// frame that DOES have a caller — the recursive-portal arm.
+        /// Re-entering `inner` instead would run its tail a second time
+        /// and overwrite the portal runner's result with `inner`'s own.
+        #[test]
+        fn run_forever_steps_past_the_portal_frame_after_handle_jitexception() {
+            let mut sub = JitCodeBuilder::default();
+            sub.jit_merge_point(0, &[], &[], &[], &[], &[], &[]);
+            let sub_jitcode = sub.finish();
+
+            let mut inner_b = JitCodeBuilder::default();
+            let sub_idx = inner_b.add_sub_jitcode(sub_jitcode);
+            inner_b.inline_call_ir_v(sub_idx, &[], &[], None);
+            // The tail the bug re-executes: it would hand the caller `7`.
+            inner_b.load_const_i_value(1, 7);
+            inner_b.int_return(1);
+            let inner_jitcode = inner_b.finish();
+            inner_jitcode.set_jitdriver_sd(0);
+
+            // `_setup_return_value_i` writes `registers_i[code[position-1]]`
+            // (`blackhole.py:1655`), so the caller resumes at an
+            // `int_return` whose preceding byte is the `int_copy`
+            // destination register 0.
+            let mut caller_b = JitCodeBuilder::default();
+            caller_b.load_const_i_value(0, 42);
+            let caller_resume = caller_b.current_pos();
+            caller_b.int_return(0);
+            let caller_jitcode = caller_b.finish();
+
+            let mut builder = super::build_inline_call_only_bh_builder();
+            let mut caller = builder.acquire_interp();
+            caller.setposition(std::sync::Arc::new(caller_jitcode), caller_resume);
+            let mut inner = builder.acquire_interp();
+            inner.setposition(std::sync::Arc::new(inner_jitcode), 0);
+            inner.nextblackholeinterp = Some(Box::new(caller));
+
+            let portal_runner =
+                |_exc: &crate::jitexc::JitException| Ok((super::BhReturnType::Int, 999));
+            let outcome = super::run_forever_with_portal(
+                &mut builder,
+                inner,
+                0,
+                Some(&portal_runner),
+                None,
+                None,
+            );
+            assert!(
+                matches!(
+                    outcome,
+                    crate::jitexc::JitException::DoneWithThisFrameInt(999)
+                ),
+                "the caller must return the portal runner's result, got {outcome:?}",
+            );
         }
 
         /// Tier 2.1: ref-typed return propagation through

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -3762,7 +3762,6 @@ impl<S: JitState> JitDriver<S> {
                     // and the loop's state load/store) does, so it must hold the
                     // layout before it runs.
                     let sf_layout = state.state_field_layout();
-                    bh.state_field_layout = sf_layout.clone();
                     // Seed the reconstructed blackhole chain with the registered
                     // virtualizable info + identity pointer so a mid-body
                     // vable-array opcode (`getarrayitem_vable_*` /
@@ -3781,9 +3780,16 @@ impl<S: JitState> JitDriver<S> {
                     // walk (`resume_mainloop`) dereferences `virtualizable_ptr`
                     // whenever `virtualizable_info` is non-null.
                     let seed_vinfo_ptr = seed_deopt_vinfo_ptr(self.meta.virtualizable_info());
-                    if !seed_vinfo_ptr.is_null() {
-                        bh.virtualizable_info = seed_vinfo_ptr;
-                        bh.virtualizable_ptr = vable_ptr;
+                    {
+                        let mut current = Some(&mut bh);
+                        while let Some(frame) = current {
+                            frame.state_field_layout = sf_layout.clone();
+                            if !seed_vinfo_ptr.is_null() {
+                                frame.virtualizable_info = seed_vinfo_ptr;
+                                frame.virtualizable_ptr = vable_ptr;
+                            }
+                            current = frame.nextblackholeinterp.as_deref_mut();
+                        }
                     }
                     let exc = crate::blackhole::BlackholeInterpreter::prepare_resume_from_failure(
                         guard_exc,
@@ -3807,12 +3813,9 @@ impl<S: JitState> JitDriver<S> {
                     let outcome = loop {
                         match bh.resume_mainloop(cur_exc) {
                             Ok(next_exc) => match bh.nextblackholeinterp.take() {
-                                Some(mut caller) => {
-                                    caller.state_field_layout = sf_layout.clone();
-                                    if !seed_vinfo_ptr.is_null() {
-                                        caller.virtualizable_info = seed_vinfo_ptr;
-                                        caller.virtualizable_ptr = vable_ptr;
-                                    }
+                                Some(caller) => {
+                                    // Layout + vinfo were seeded across the
+                                    // whole chain before the loop started.
                                     bh_builder.release_interp(bh);
                                     bh = *caller;
                                     cur_exc = next_exc;
@@ -6169,18 +6172,36 @@ impl<S: JitState> JitDriver<S> {
                     allocator,
                 );
                 if let Some((mut bh, vable_ptr)) = bh {
-                    // Thread the state-field register layout so the
-                    // `state_field` handlers map a logical scalar/array index
-                    // to the flat register slot the resume reader seeded.
-                    bh.state_field_layout = state.state_field_layout();
-                    // Seed vinfo + identity for a state-field machine so a
-                    // mid-body vable-array op resolves during resume (see the
-                    // chain-resume path above for the full rationale). Real heap
-                    // virtualizables (`token_offset > 0`) are left untouched.
+                    // Thread the state-field register layout onto every frame
+                    // so the `state_field` handlers map a logical scalar/array
+                    // index to the flat register slot the resume reader seeded.
+                    // The chain tail is the root dispatch frame — it owns the
+                    // merge point and the loop's state load/store — so it is
+                    // exactly the frame that needs the layout, and
+                    // `run_forever_with_portal` consumes the chain with no
+                    // per-frame hook to seed it later.  A missing layout does
+                    // not fail loudly: `StateFieldLayout::default()` is
+                    // all-zero, so `scalar_slot`/`ref_scalar_slot` return
+                    // `0 + field_idx` and silently address the dispatch
+                    // JitCode's own argument registers in a release build.
+                    //
+                    // Seed vinfo + identity on the same walk for a state-field
+                    // machine, so a mid-body vable-array op resolves during
+                    // resume (see the chain-resume path above for the full
+                    // rationale). Real heap virtualizables (`token_offset > 0`)
+                    // are left untouched.
+                    let sf_layout = state.state_field_layout();
                     let seed_vinfo_ptr = seed_deopt_vinfo_ptr(self.meta.virtualizable_info());
-                    if !seed_vinfo_ptr.is_null() {
-                        bh.virtualizable_info = seed_vinfo_ptr;
-                        bh.virtualizable_ptr = vable_ptr;
+                    {
+                        let mut current = Some(&mut bh);
+                        while let Some(frame) = current {
+                            frame.state_field_layout = sf_layout.clone();
+                            if !seed_vinfo_ptr.is_null() {
+                                frame.virtualizable_info = seed_vinfo_ptr;
+                                frame.virtualizable_ptr = vable_ptr;
+                            }
+                            current = frame.nextblackholeinterp.as_deref_mut();
+                        }
                     }
                     let exc = crate::blackhole::BlackholeInterpreter::prepare_resume_from_failure(
                         result_exc,

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -176,13 +176,14 @@ pub fn drive_single_frame_blackhole(
         miframe.ref_values[*index] = Some(*forwarded);
     }
 
+    builder.setup_jitdrivers_sd(bh_jitdrivers_sd(metainterp_sd));
+
     let mut bh = builder.acquire_interp();
     bh.copy_data_from_miframe(miframe);
     bh.state_field_layout = state_field_layout;
     bh.virtualizable_info = virtualizable_info;
     bh.virtualizable_ptr = virtualizable_ptr;
     bh.virtualizable_stack_base = virtualizable_stack_base;
-    bh.jitdrivers_sd = bh_jitdrivers_sd(metainterp_sd);
 
     // The blackhole may allocate/collect while executing.  Its Ref bank is the
     // authoritative live register file and must be forwarded in place.
@@ -284,7 +285,8 @@ pub fn drive_multi_frame_blackhole(
         last_exc_value = packed_ref_roots[index];
     }
 
-    let jitdrivers_sd = bh_jitdrivers_sd(metainterp_sd);
+    builder.setup_jitdrivers_sd(bh_jitdrivers_sd(metainterp_sd));
+
     let mut terminal = None;
     let outcome = crate::blackhole::convert_and_run_from_pyjitpl(
         builder,
@@ -296,7 +298,6 @@ pub fn drive_multi_frame_blackhole(
             virtualizable_info,
             virtualizable_ptr,
             virtualizable_stack_base,
-            jitdrivers_sd: &jitdrivers_sd,
             per_frame,
             on_enter_level,
         }),
@@ -3709,6 +3710,15 @@ impl<S: JitState> JitDriver<S> {
                     self.meta_interp().staticdata.op_catch_exception,
                     self.meta_interp().staticdata.op_rvmprof_code,
                 );
+                // `blackhole_from_resumedata` below acquires one interpreter
+                // per resumed frame, and every frame that still has a caller
+                // takes `bhimpl_jit_merge_point`'s recursive-portal branch
+                // (blackhole.py:1079-1093), which indexes `jitdrivers_sd`
+                // directly.  The lease is thread-local and carries whatever
+                // the previous resume left on it, so seed the table here
+                // instead of depending on that.
+                let jitdrivers_sd = bh_jitdrivers_sd(&self.meta_interp().staticdata);
+                bh_builder.setup_jitdrivers_sd(jitdrivers_sd);
                 let all_liveness = self.meta_interp().staticdata.liveness_info.as_slice();
                 // The state-field macro's `&state` is host-stack storage, so
                 // its identity may be folded out of the failing frame. Ask
@@ -6117,6 +6127,15 @@ impl<S: JitState> JitDriver<S> {
                     self.meta_interp().staticdata.op_catch_exception,
                     self.meta_interp().staticdata.op_rvmprof_code,
                 );
+                // `blackhole_from_resumedata` below acquires one interpreter
+                // per resumed frame, and every frame that still has a caller
+                // takes `bhimpl_jit_merge_point`'s recursive-portal branch
+                // (blackhole.py:1079-1093), which indexes `jitdrivers_sd`
+                // directly.  The lease is thread-local and carries whatever
+                // the previous resume left on it, so seed the table here
+                // instead of depending on that.
+                let jitdrivers_sd = bh_jitdrivers_sd(&self.meta_interp().staticdata);
+                bh_builder.setup_jitdrivers_sd(jitdrivers_sd);
                 let all_liveness = self.meta_interp().staticdata.liveness_info.as_slice();
                 // See `back_edge_internal`: only the macro state-field host
                 // opts in to this per-call host-stack identity source.

--- a/pyre/bench/synth/getframe_root_loop_force_blackhole_crn.py
+++ b/pyre/bench/synth/getframe_root_loop_force_blackhole_crn.py
@@ -18,6 +18,15 @@
 # post-drive decline discards a region the drive already executed and hands it
 # back to the replay, which turned 199990000 into 200005595. The gate has to be
 # taken before the drive.
+#
+# This shape is also the one that exposed the two defects behind that NULL. The
+# image seeded only the colors live at the build pc rather than the whole
+# concrete bank; and the walk synchronized the virtualizable into the
+# snapshot_for_tracing copy while the image's vable identity pointed at the live
+# frame, so the drive read locals one Python iteration stale and accumulated
+# total += 1039 where i was already 1040. Both are fixed. The loop-header gate
+# still refuses this drive, so what the fixture pins day to day is the
+# interpreter-equal answer; drop that gate locally to exercise the CRN arm.
 import sys
 
 

--- a/pyre/bench/synth/getframe_root_loop_force_blackhole_crn.py
+++ b/pyre/bench/synth/getframe_root_loop_force_blackhole_crn.py
@@ -1,0 +1,34 @@
+# Regression guard: SIGSEGV from a NULL operand-stack slot written by the
+# single-frame blackhole's ContinueRunningNormally handoff.
+#
+# The walk roots at `main`, which HAS a Python loop, so its portal jitcode
+# carries a jit_merge_point at the loop header. A sys._getframe force inside the
+# loop latched a blackhole image built at the resume pc just past the residual;
+# driving it ran to the loop back edge and raised ContinueRunningNormally at the
+# merge point. The MIFrame is seeded from the live colors at the BUILD pc, but
+# the merge point has its own live set, so a Ref color live at the merge but not
+# at the build read back NULL -- and apply_blackhole_crn had no NULL guard, so it
+# wrote a null into a live operand-stack slot. Resuming there faulted the
+# interpreter (EXC_BAD_ACCESS at 0x0 in baseobjspace::next), exit 139, JIT-only.
+#
+# The walk's own flush declines exactly this case ("NULL operand-stack shadow
+# slot (mid-expression)"); the blackhole path did not.
+#
+# Guarding it post-drive is NOT sufficient and this fixture also pins that: a
+# post-drive decline discards a region the drive already executed and hands it
+# back to the replay, which turned 199990000 into 200005595. The gate has to be
+# taken before the drive.
+import sys
+
+
+def main():
+    total = 0
+    names = set()
+    for i in range(20000):
+        fr = sys._getframe(0)
+        names.add(fr.f_code.co_name)
+        total += i
+    print(total, sorted(names))
+
+
+main()

--- a/pyre/bench/synth/getframe_root_loop_force_blackhole_crn.py
+++ b/pyre/bench/synth/getframe_root_loop_force_blackhole_crn.py
@@ -16,17 +16,21 @@
 #
 # Guarding it post-drive is NOT sufficient and this fixture also pins that: a
 # post-drive decline discards a region the drive already executed and hands it
-# back to the replay, which turned 199990000 into 200005595. The gate has to be
-# taken before the drive.
+# back to the replay, which turned 199990000 into 200005595.
 #
 # This shape is also the one that exposed the two defects behind that NULL. The
 # image seeded only the colors live at the build pc rather than the whole
 # concrete bank; and the walk synchronized the virtualizable into the
 # snapshot_for_tracing copy while the image's vable identity pointed at the live
 # frame, so the drive read locals one Python iteration stale and accumulated
-# total += 1039 where i was already 1040. Both are fixed. The loop-header gate
-# still refuses this drive, so what the fixture pins day to day is the
-# interpreter-equal answer; drop that gate locally to exercise the CRN arm.
+# total += 1039 where i was already 1040.
+#
+# All of it is now moot for the reason that matters: the CRN handoff no longer
+# rebuilds the frame from the terminal register banks at all, so there is no
+# NULL to write and nothing left to decline. The drive runs and this file
+# adopts it five times. Its effects are idempotent, though, which is exactly
+# what hid the residual heap half of a post-drive decline — see the
+# `_nonidempotent` sibling.
 import sys
 
 

--- a/pyre/bench/synth/getframe_root_loop_force_blackhole_crn_nonidempotent.py
+++ b/pyre/bench/synth/getframe_root_loop_force_blackhole_crn_nonidempotent.py
@@ -1,0 +1,35 @@
+# Regression guard: a blackhole drive that is declined after the fact must not
+# hand its already-executed region back to a replay.
+#
+# Same shape as `getframe_root_loop_force_blackhole_crn`: the walk roots at
+# `main`, whose portal jitcode carries a jit_merge_point at the loop header, and
+# a sys._getframe force inside the loop latches a blackhole image that drives to
+# the back edge and raises ContinueRunningNormally there.
+#
+# The difference is the effect in the driven region.  The sibling accumulates
+# into a local and adds an already-present element to a set, so BOTH halves of a
+# post-drive decline are invisible once the frame is restored: the local comes
+# back with the undo, and re-running `set.add` of the same string changes
+# nothing.  A list append does not have that property.  With the CRN arm forced
+# to decline, that sibling prints its correct 199990000 while this file prints
+# 20005 appends for 20000 iterations — one extra per declined drive.
+#
+# That is the measurement behind `adopt_blackhole_crn`: a decline taken after
+# the drive cannot be repaired by any frame-level undo, because the residual
+# calls the drive ran are heap effects and not frame state.  So the CRN handoff
+# resumes on the frame the blackhole already wrote instead of validating a
+# rebuilt register image that could reject it.
+import sys
+
+
+def main():
+    total = 0
+    seen = []
+    for i in range(20000):
+        fr = sys._getframe(0)
+        seen.append(fr.f_code.co_name)
+        total += i
+    print(total, len(seen))
+
+
+main()

--- a/pyre/bench/synth/getframe_root_loop_force_while_merge.py
+++ b/pyre/bench/synth/getframe_root_loop_force_while_merge.py
@@ -1,0 +1,25 @@
+# Reachability fixture: a force whose blackhole drive REACHES a jit_merge_point.
+#
+# Companion to getframe_root_loop_force_blackhole_crn. The walk roots at `main`,
+# whose `while` loop gives the portal jitcode a merge point, so driving the
+# latched image from just past the sys._getframe residual runs to the back edge
+# and hands back ContinueRunningNormally rather than a frame terminal.
+#
+# Every getframe_* fixture that predates this one forces inside a short leaf
+# callee whose jitcode has nothing after the residual but a return, so all of
+# them ended in DoneWithThisFrameRef and the CRN arm -- the only arm that can
+# reject the image -- was never exercised at all.
+import sys
+_gf = sys._getframe
+kept = None
+def main():
+    global kept
+    total = 0
+    i = 0
+    while i < 30000:
+        kept = _gf()
+        total = total + 1
+        i = i + 1
+    return total
+t = main()
+print(t, kept.f_code.co_name)

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -1081,6 +1081,12 @@ impl PyFrame {
     /// frame-invariant and `debugdata` is debug-only; none are written on the
     /// live frame during tracing (the walk writes only the symbolic `PyreSym`
     /// shadow), so restoring them would be dead.
+    ///
+    /// The slot copy moves Refs between two frames, so it ends on
+    /// [`remember_frame_locals_array`]: `locals_cells_stack_w` is its own GC
+    /// object, and an old destination array taking a young value has to join
+    /// the remembered set.  One arm covers the whole batch because nothing in
+    /// the loop can collect — `to_vec` has already allocated by then.
     pub fn restore_resume_state_from(&mut self, src: &PyFrame) {
         self.last_instr = src.last_instr;
         self.valuestackdepth = src.valuestackdepth;
@@ -1090,6 +1096,7 @@ impl PyFrame {
         for (i, &v) in src_vals.iter().take(n).enumerate() {
             dst[i] = v;
         }
+        remember_frame_locals_array(self.locals_cells_stack_w);
     }
 }
 

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -1958,6 +1958,27 @@ pub(crate) fn try_execute_residual_call_via_executor<Sym: WalkSym>(
         // gates is attribute/item READS of frame-family objects, which are
         // idempotently re-executable (re-execution reads the same flushed
         // values the first execution saw; a token re-force is a no-op).
+        //
+        // Why the licence is `!writes_live_heap` and not the effect class the
+        // rewound residual declares: BOTH upstream-shaped static licences are
+        // empty on this path.  `check_is_elidable()`/`EF_LOOPINVARIANT` is
+        // disjoint from forcing by construction — `pyjitpl.py:2007` takes the
+        // forcing arm iff `check_forces_virtual_or_virtualizable()`
+        // (`extraeffect >= EF_FORCES_VIRTUAL_OR_VIRTUALIZABLE`, effectinfo.py:250)
+        // and routes elidable/loop-invariant down the `else` arm at `:2084`.
+        // An empty declared write set is unavailable too: every residual that
+        // reaches this gate carries `EF_RANDOM_EFFECTS`, whose write-descr sets
+        // are `None` — top, not bottom — by upstream's own assertion
+        // (effectinfo.py:149-155).  So no `EffectInfo` predicate can license
+        // this rewind, and the licence has to come from the shape gates above.
+        // Measured over `pyre/bench/synth` (312 files, 115 forces): the only
+        // shape that commits an `EscapeResumeKind::Exact` is a `LoadAttr`/`Ref`
+        // frame-family read, 10 of them, from `getframe_stored_fback_walk` and
+        // `getframe_force_cancel_journal`; 5 enter a user frame and have the
+        // commit withdrawn below, 5 do not and are re-executed.  Every other
+        // force either commits nothing or takes the merge-point fallback, whose
+        // `RerunsOpcode` kind `commit_walk_end` refuses outright.
+        //
         // A sub-walk's mirror describes the callee frame, not the escape
         // frame, so it is never latched (the nested unjournaled-residual
         // decline above already aborts before this).
@@ -2015,6 +2036,31 @@ pub(crate) fn try_execute_residual_call_via_executor<Sym: WalkSym>(
             majit_gc::shadow_stack::pop_resume_ref_roots_to(depth);
         }
         if forced {
+            if fbw_debug_abort_enabled() {
+                eprintln!(
+                    "[force-shape] helper={helper:?} rtype={:?} writes_live={writes_live_heap} \
+                     reentrant={reentrant_residual} commit={} entered_frame={} bh={} \
+                     fs={} subwalk={} bridge={} wf={:?} wa={:?} wi={:?} rnd={} fn=0x{:x} \
+                     pc={op_pc}",
+                    call_descr.result_type(),
+                    match committed_frame_escape_pc() {
+                        None => "none",
+                        Some((_, EscapeResumeKind::Exact)) => "exact",
+                        Some((_, EscapeResumeKind::RerunsOpcode)) => "reruns",
+                    },
+                    heap_write_odometer_before
+                        .is_some_and(|before| pyre_interpreter::call::frame_entry_count() != before),
+                    blackhole_result.is_some(),
+                    ctx.session.borrow().framestack.len(),
+                    ctx.fbw_mode.inline_subwalk,
+                    ctx.trace_ctx.is_bridge_trace,
+                    ei._write_descrs_fields.as_ref().map(Vec::len),
+                    ei._write_descrs_arrays.as_ref().map(Vec::len),
+                    ei._write_descrs_interiorfields.as_ref().map(Vec::len),
+                    ei.has_random_effects(),
+                    func_ptr as usize,
+                );
+            }
             // The escaping residual also entered a user Python frame whose
             // body may have committed irreversible effects; a committed
             // escape resume would re-execute this opcode and re-run that

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -243,6 +243,45 @@ fn build_single_frame_miframe<Sym: WalkSym>(
         *miframe.float_values.get_mut(color)? = Some(value.to_bits() as i64);
     }
 
+    // Seed every REMAINING color the walk has a concrete value for, not just the
+    // ones live at `resume_pc`.
+    //
+    // `_copy_data_from_miframe` (blackhole.py:1711-1730) copies
+    // `range(num_regs_i/r/f())` — the WHOLE bank, filtering only on "the MIFrame
+    // has a box here", never on liveness.  Seeding a liveness-selected subset is
+    // the deviation, and it is unsound the moment the drive leaves the straight
+    // line: the blackhole runs on to a `jit_merge_point`, whose own live set is
+    // generally LARGER (a loop-carried value defined in the prologue and not
+    // rewritten in the body is dead at a mid-body pc but live at the header).
+    // Those colors then read back NULL, and a NULL written into a live
+    // operand-stack slot faults the interpreter.
+    //
+    // Measured on the `getframe_root_loop_force_*` fixtures: live at the build
+    // pc was ref [0, 1, 6] while the merge wanted [0, 1, 2, 3, 4], and 2/3/4 all
+    // had concrete values in the walk's own bank the whole time.
+    //
+    // Seeding cannot introduce a stale value: a color the drive rewrites is
+    // overwritten before any read, and a color it does not rewrite still holds
+    // what the walk observed at the force point, which is what a merge reached
+    // without an intervening definition expects.  Colors with no concrete value
+    // stay unset, exactly as an absent upstream box does.
+    for (color, slot) in miframe.int_values.iter_mut().enumerate() {
+        if slot.is_none()
+            && let Some(ConcreteValue::Int(value)) = ctx.concrete_registers_i.get(color).copied()
+        {
+            *slot = Some(value);
+        }
+    }
+    for (color, slot) in miframe.ref_values.iter_mut().enumerate() {
+        // `ConcreteValue::Null` is the walker's "unknown" sentinel, not a proven
+        // Python null, so it seeds nothing.
+        if slot.is_none()
+            && let Some(ConcreteValue::Ref(value)) = ctx.concrete_registers_r.get(color).copied()
+        {
+            *slot = Some(value as i64);
+        }
+    }
+
     Some(miframe)
 }
 

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -2083,6 +2083,59 @@ pub(crate) fn try_execute_residual_call_via_executor<Sym: WalkSym>(
             // failure leaves the pre-existing escape/replay path untouched.
             let odometer_unchanged = heap_write_odometer_before
                 .is_some_and(|before| pyre_interpreter::call::frame_entry_count() == before);
+            // Feasibility probe for retiring the rewind latch in favour of the
+            // orthodox resume-PAST-the-residual path (`blackhole.py:1653-1662`
+            // splices the callee result into the caller past its call, so no
+            // re-runnability licence is needed at all).  The latch shape is the
+            // exact complement of the C3 S1 gate: it is `!writes_live_heap` and
+            // has already committed an escape pc, so it can never reach the
+            // build below.  Measure whether it COULD: build the image and throw
+            // it away.  `build_single_frame_miframe` only reads liveness and the
+            // concrete register banks, so discarding it is free.
+            if fbw_debug_abort_enabled()
+                && !writes_live_heap
+                && odometer_unchanged
+                && matches!(
+                    committed_frame_escape_pc(),
+                    Some((_, EscapeResumeKind::Exact))
+                )
+                && !ctx.trace_ctx.is_bridge_trace
+                && !ctx.fbw_mode.inline_subwalk
+                && ctx.session.borrow().framestack.is_empty()
+                && !ctx.fbw_mode.snapshot_sym.is_null()
+            {
+                let built = blackhole_result.and_then(|(resume_pc, result_bank, result_color)| {
+                    let lastop_result = match exec_result {
+                        Ok(value) => {
+                            (result_bank != 'v').then_some((result_bank, result_color, value))
+                        }
+                        Err(_) => None,
+                    };
+                    let jitcode = unsafe {
+                        let sym = &*ctx.fbw_mode.snapshot_sym;
+                        (!sym.jitcode().is_null())
+                            .then(|| (&(*sym.jitcode()).payload).jitcode.clone())
+                    };
+                    jitcode.map(|jitcode| {
+                        (
+                            resume_pc,
+                            build_single_frame_miframe(ctx, jitcode, resume_pc, lastop_result)
+                                .is_some(),
+                        )
+                    })
+                });
+                match built {
+                    Some((resume_pc, true)) => eprintln!(
+                        "[latch-vs-bh] latch shape COULD build a resume-past image at \
+                         resume_pc={resume_pc}"
+                    ),
+                    Some((resume_pc, false)) => eprintln!(
+                        "[latch-vs-bh] latch shape could NOT build an image at \
+                         resume_pc={resume_pc}"
+                    ),
+                    None => eprintln!("[latch-vs-bh] latch shape has no blackhole_result/jitcode"),
+                }
+            }
             if fbw_debug_abort_enabled() && ctx.fbw_mode.inline_subwalk {
                 eprintln!(
                     "[s2-gate] inline_subwalk fs={} flag={} writes_live={} odo_unchanged={} \

--- a/pyre/pyre-jit-trace/src/pyjitcode.rs
+++ b/pyre/pyre-jit-trace/src/pyjitcode.rs
@@ -881,19 +881,6 @@ impl PyJitCode {
             || !self.metadata.depth_trivia_pred_by_jit_pc.is_empty()
     }
 
-    /// Whether the trivia-aware pcdep twin carries entries. `false` for a
-    /// skeleton / fixture install, where [`Self::pcdep_trivia_for_jitcode_pc`]
-    /// answers `None` for EVERY coordinate rather than for a particular one.
-    ///
-    /// That distinction is what makes the blackhole adopt path's pcdep
-    /// precondition decidable BEFORE `drive_*_blackhole` runs: the drive's stop
-    /// position is its own output, but "this jitcode has no pcdep trivia at
-    /// all" does not depend on it.
-    pub fn pcdep_trivia_populated(&self) -> bool {
-        !self.metadata.pcdep_trivia_marker_by_jit_pc.is_empty()
-            || !self.metadata.pcdep_trivia_pred_by_jit_pc.is_empty()
-    }
-
     /// Whether the trivia-aware result-color twin carries entries. `false`
     /// distinguishes a skeleton / fixture from an in-table `None` caused by a
     /// trailing-trivia overshoot.

--- a/pyre/pyre-jit-trace/src/pyjitcode.rs
+++ b/pyre/pyre-jit-trace/src/pyjitcode.rs
@@ -881,6 +881,19 @@ impl PyJitCode {
             || !self.metadata.depth_trivia_pred_by_jit_pc.is_empty()
     }
 
+    /// Whether the trivia-aware pcdep twin carries entries. `false` for a
+    /// skeleton / fixture install, where [`Self::pcdep_trivia_for_jitcode_pc`]
+    /// answers `None` for EVERY coordinate rather than for a particular one.
+    ///
+    /// That distinction is what makes the blackhole adopt path's pcdep
+    /// precondition decidable BEFORE `drive_*_blackhole` runs: the drive's stop
+    /// position is its own output, but "this jitcode has no pcdep trivia at
+    /// all" does not depend on it.
+    pub fn pcdep_trivia_populated(&self) -> bool {
+        !self.metadata.pcdep_trivia_marker_by_jit_pc.is_empty()
+            || !self.metadata.pcdep_trivia_pred_by_jit_pc.is_empty()
+    }
+
     /// Whether the trivia-aware result-color twin carries entries. `false`
     /// distinguishes a skeleton / fixture from an in-table `None` caused by a
     /// trailing-trivia overshoot.

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -1673,21 +1673,6 @@ pub fn pcdep_trivia_at(jitcode_index: i32, jit_pc: i32) -> Option<Vec<(u8, u16, 
     })
 }
 
-/// Whether `jitcode_index` carries any pcdep trivia at all — the
-/// position-INDEPENDENT half of [`pcdep_trivia_at`]'s answer, and the only half
-/// the blackhole adopt path can evaluate before driving. `false` for a missing
-/// index or a skeleton / fixture payload, i.e. exactly when every later
-/// `pcdep_trivia_at` on this jitcode is already doomed to `None`.
-pub fn pcdep_trivia_populated(jitcode_index: i32) -> bool {
-    ensure_finish_setup();
-    METAINTERP_SD.with(|r| {
-        let sd = r.borrow();
-        sd.jitcodes
-            .get(jitcode_index as usize)
-            .is_some_and(|jc| jc.payload.pcdep_trivia_populated())
-    })
-}
-
 /// Depth-based `valuestackdepth` for `w_code` at `py_pc`:
 /// `nlocals + ncells + depth_at_py_pc[py_pc]`.  Mirrors the encoder's
 /// published vsd (the `jitcode_dispatch` valuestackdepth publish).  The
@@ -4820,8 +4805,18 @@ pub(crate) fn can_flush_walk_end_state_after_outer_call(
 /// Take a copy of `frame`'s locals so a caller that publishes over them can put
 /// the frame back exactly as it found it.  Returned as raw words: boxing a slot
 /// during the publish can collect, so the copy has to be registered as resume
-/// roots (`push_resume_ref_roots`) for the duration, like the register image
-/// `apply_blackhole_crn` holds.
+/// roots (`push_resume_ref_roots`) for the duration.
+///
+/// ⚠️Restoring the FRAME is not the same as undoing the drive.  This and
+/// [`capture_frame_scalars`] together cover the whole mutable virtualizable
+/// surface — the only vable fields with a production emit site are `last_instr`
+/// (index 0) and `valuestackdepth` (2), plus this array; `setfield_vable_r`/`_f`
+/// have dispatch arms and no emitter.  A decline taken after
+/// `drive_single_frame_blackhole` still leaves every heap effect the region's
+/// residual calls made, and the replay repeats them — measured on
+/// `getframe_root_loop_force_blackhole_crn_nonidempotent` as one extra list
+/// entry per declined drive while the locals came back correct.  So this is an
+/// undo for PRE-drive failures; it does not license a post-drive one.
 ///
 /// Upstream needs no counterpart. `resume.py`'s virtualizable write-back
 /// (`VirtualizableInfo.write_from_resume_data`) runs on a per-call `MIFrame`

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -1673,6 +1673,21 @@ pub fn pcdep_trivia_at(jitcode_index: i32, jit_pc: i32) -> Option<Vec<(u8, u16, 
     })
 }
 
+/// Whether `jitcode_index` carries any pcdep trivia at all — the
+/// position-INDEPENDENT half of [`pcdep_trivia_at`]'s answer, and the only half
+/// the blackhole adopt path can evaluate before driving. `false` for a missing
+/// index or a skeleton / fixture payload, i.e. exactly when every later
+/// `pcdep_trivia_at` on this jitcode is already doomed to `None`.
+pub fn pcdep_trivia_populated(jitcode_index: i32) -> bool {
+    ensure_finish_setup();
+    METAINTERP_SD.with(|r| {
+        let sd = r.borrow();
+        sd.jitcodes
+            .get(jitcode_index as usize)
+            .is_some_and(|jc| jc.payload.pcdep_trivia_populated())
+    })
+}
+
 /// Depth-based `valuestackdepth` for `w_code` at `py_pc`:
 /// `nlocals + ncells + depth_at_py_pc[py_pc]`.  Mirrors the encoder's
 /// published vsd (the `jitcode_dispatch` valuestackdepth publish).  The

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -2108,6 +2108,23 @@ fn try_adopt_single_frame_blackhole(
         latched.raising_exception,
     );
 
+    sfdbg!(
+        "drive outcome = {}",
+        match terminal.outcome {
+            majit_metainterp::jitexc::JitException::ContinueRunningNormally { .. } =>
+                "ContinueRunningNormally",
+            majit_metainterp::jitexc::JitException::DoneWithThisFrameVoid =>
+                "DoneWithThisFrameVoid",
+            majit_metainterp::jitexc::JitException::DoneWithThisFrameInt(_) =>
+                "DoneWithThisFrameInt",
+            majit_metainterp::jitexc::JitException::DoneWithThisFrameRef(_) =>
+                "DoneWithThisFrameRef",
+            majit_metainterp::jitexc::JitException::DoneWithThisFrameFloat(_) =>
+                "DoneWithThisFrameFloat",
+            majit_metainterp::jitexc::JitException::ExitFrameWithExceptionRef(_) =>
+                "ExitFrameWithExceptionRef",
+        }
+    );
     let adopted = match terminal.outcome {
         majit_metainterp::jitexc::JitException::ContinueRunningNormally {
             ref green_int, ..

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -981,28 +981,6 @@ fn try_commit_midbody_abort_inner(
     }
 }
 
-/// True when `start_pc` is the target of a `JumpBackward` in `code` — i.e. a
-/// loop header, the origin of a loop-header trace rather than a function-entry
-/// trace.
-/// Whether `code` contains any backward jump, i.e. any Python loop header.
-///
-/// This is the same condition the codewriter emits `jit_merge_point` under —
-/// `loop_header_pcs` is built from the dominating `JUMP_BACKWARD` /
-/// `JUMP_BACKWARD_NO_INTERRUPT` targets (`codewriter.rs` `find_loop_header_pcs`,
-/// consumed at the `loop_header_pcs.contains(&py_pc) && is_true_portal` gate).
-/// So a code object without one produces a portal body with NO merge point, and
-/// a blackhole driven inside it can only ever leave through a frame terminal.
-fn code_has_loop_header(code: &pyre_interpreter::CodeObject) -> bool {
-    use pyre_interpreter::Instruction as I;
-    let mut arg_state = pyre_interpreter::OpArgState::default();
-    code.instructions.iter().copied().any(|unit| {
-        matches!(
-            arg_state.get(unit).0,
-            I::JumpBackward { .. } | I::JumpBackwardNoInterrupt { .. }
-        )
-    })
-}
-
 fn start_pc_is_loop_header(code: &pyre_interpreter::CodeObject, start_pc: usize) -> bool {
     use pyre_interpreter::Instruction as I;
     let mut arg_state = pyre_interpreter::OpArgState::default();
@@ -1887,139 +1865,56 @@ fn seed_loop_entry_ref_slots(
     }
 }
 
-/// Materialize a blackhole `ContinueRunningNormally` handoff into the live
-/// interpreter frame: write every live local / operand-stack slot from the
-/// terminal register banks, then move the frame to the resume coordinate.
+/// Hand a blackhole `ContinueRunningNormally` back the way upstream does:
+/// resume on the frame the blackhole has been writing, not on one rebuilt from
+/// the terminal register banks.
 ///
-/// Shared by the single-frame and multi-frame adopt paths — the multi-frame
-/// chain's terminal frame is the portal level, so it needs the exact same
-/// treatment (a chain whose inner levels committed through their own
-/// virtualizable still leaves the portal's `valuestackdepth` at the aborted
-/// mid-expression value).
-macro_rules! sfdbg_crn {
-    ($($a:tt)*) => {
-        if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
-            eprintln!("[crn-apply-decline] {}", format!($($a)*));
-        }
-    };
-}
-
-fn apply_blackhole_crn(
-    frame: usize,
-    jitcode_index: i32,
-    position: usize,
-    last_opcode_position: usize,
-    registers_i: &[i64],
-    registers_r: &mut [i64],
-    registers_f: &[i64],
-    resume_py_pc: usize,
-) -> bool {
-    if frame == 0 {
-        return false;
-    }
-    let Some(stack_base) = crate::state::concrete_nlocals(frame) else {
-        return false;
-    };
-    let pf = unsafe { &mut *(frame as *mut pyre_interpreter::PyFrame) };
-    let w_code = pf.pycode;
-    if w_code.is_null() {
-        return false;
-    }
-    let raw_code = unsafe {
-        pyre_interpreter::w_code_get_ptr(w_code as pyre_object::PyObjectRef)
-            as *const pyre_interpreter::CodeObject
-    };
-    let Some(stack_depth) = crate::liveness::liveness_for(raw_code)
-        .depth_at_py_pc()
-        .get(resume_py_pc)
-        .copied()
-    else {
-        return false;
-    };
-    let live_end = stack_base + stack_depth as usize;
-    if pf.locals_w().as_slice().len() < live_end {
-        return false;
-    }
-    let pcdep = crate::state::pcdep_trivia_at(jitcode_index, last_opcode_position as i32)
-        .or_else(|| crate::state::pcdep_trivia_at(jitcode_index, position as i32));
-    let Some(pcdep) = pcdep else {
-        return false;
-    };
-
-    // Validate every mapped color and every live operand-stack slot before
-    // writing anything.  Dead locals may retain their old heap value; each
-    // stack slot at the merge point must have an authoritative color.
-    let mut writes: Vec<(usize, u8, usize)> = Vec::new();
-    for &(bank, color, slot) in &pcdep {
-        let slot = slot as usize;
-        if slot >= live_end {
-            continue;
-        }
-        let color = color as usize;
-        let present = match bank {
-            0 => color < registers_i.len(),
-            1 => color < registers_r.len(),
-            2 => color < registers_f.len(),
-            _ => false,
-        };
-        if !present {
-            return false;
-        }
-        // A Ref color that reads back NULL is an UNPOPULATED register, not a
-        // live value.  Writing it into a live operand-STACK slot and resuming
-        // there faults the interpreter, which pops NULL where a real object is
-        // expected — the walk's own flush declines exactly this case and says
-        // so (`state.rs` "NULL operand-stack shadow slot (mid-expression)").
-        // The blackhole image gets there a different way: the CRN merge point
-        // is a different pc than the one the MIFrame was built at, and its live
-        // set is generally the larger of the two.  `build_single_frame_miframe`
-        // now seeds the whole concrete bank rather than the colors live at the
-        // build pc, so reaching here means the walk held no concrete for the
-        // color at all, not that a liveness filter dropped it.
-        // A LOCAL slot may legitimately be NULL (an unbound local), so this
-        // guards the stack region only, matching the sibling.
-        //
-        // ⚠️This must stay UNREACHABLE: it is a post-drive decline, and one was
-        // measured to turn a correct 199990000 into 200005595 by handing an
-        // already-executed region back to the replay.  The loop-header gate in
-        // `try_adopt_single_frame_blackhole` keeps the CRN arm out of reach; the
-        // check survives only so an incomplete gate degrades to a wrong answer
-        // instead of the SIGSEGV this class produced before it existed.  With
-        // that gate lifted the corpus reaches the CRN arm 10 times and fires
-        // this decline zero times — which is why the gate's own comment names
-        // discharging these declines, not lifting the gate, as the convergence.
-        if slot >= stack_base && bank == 1 && registers_r[color] == 0 {
-            sfdbg_crn!("NULL Ref color {color} for live stack slot {slot}");
-            return false;
-        }
-        if !writes.iter().any(|(existing, _, _)| *existing == slot) {
-            writes.push((slot, bank, color));
-        }
-    }
-    if (stack_base..live_end).any(|slot| !writes.iter().any(|(s, _, _)| *s == slot)) {
-        return false;
-    }
-
-    let root_depth = majit_gc::shadow_stack::resume_ref_roots_depth();
+/// `handle_jitexception` (`warmspot.py:970-982`) re-enters the portal with the
+/// greens and reds the exception carries; the frame is among the reds, and
+/// nothing reconstructs its contents.  It can afford that because the
+/// blackhole's virtualizable ops are write-through —
+/// `bhimpl_setarrayitem_vable_r` and `bhimpl_setfield_vable_i`
+/// (`blackhole.py:1390-1490`) fetch the array out of the virtualizable and
+/// store into it — so by the time `bhimpl_jit_merge_point` raises
+/// (`blackhole.py:1068-1069`) the frame already holds the driven region's
+/// result.  That raise only fires at the bottommost level, which is the portal
+/// frame: `convert_and_run_from_pyjitpl` links `framestack[0]` last, so
+/// `nextblackholeinterp is None` names the root and no other.
+///
+/// pyre's walked frame has two representations, so "the frame the blackhole was
+/// writing" has to be named.  The drive's vable ops address the frame held in
+/// the jitcode's own frame register, which the caller gates to be the LIVE
+/// root; the portal epilogue then publishes the SNAPSHOT
+/// (`eval.rs` `restore_resume_state_from(&executed_frame)`).  Mirroring live
+/// into the snapshot is what makes that epilogue hand over the drive's result
+/// instead of the walk's stale copy — the same move, for the same reason, that
+/// the escape leg makes.
+///
+/// `last_instr` is the one coordinate the drive does not leave resume-ready: it
+/// stops at the merge point having recorded the pc it is AT, and resuming there
+/// needs the pc before it.  Mirroring without this normalization resumes one
+/// opcode past the loop header — measured on
+/// `getframe_root_loop_force_blackhole_crn` and
+/// `getframe_root_loop_force_while_merge`, which then produce no output at all.
+///
+/// ⭐Infallible, and that is the whole point.  The register-image rebuild this
+/// replaces had to validate pcdep coverage, register-bank bounds and NULL Refs,
+/// and every one of those checks could only fail AFTER the drive had already
+/// executed the region — a decline that hands an executed region back to a
+/// replay that runs it again.  Upstream has no such path, and neither does
+/// this.
+///
+/// Both adopt arms come here.  The multi-frame one has already folded its live
+/// root into the snapshot by the time it does, so the mirror is a no-op there
+/// and only the coordinate lands; routing it through anyway keeps one
+/// definition of what adopting a CRN means.
+fn adopt_blackhole_crn(snapshot: usize, live_root: usize, resume_py_pc: usize) {
     unsafe {
-        majit_gc::shadow_stack::push_resume_ref_roots(registers_r);
+        let live = &*(live_root as *const pyre_interpreter::PyFrame);
+        let snap = &mut *(snapshot as *mut pyre_interpreter::PyFrame);
+        snap.restore_resume_state_from(live);
+        snap.last_instr = resume_py_pc as isize - 1;
     }
-    for (slot, bank, color) in writes {
-        let value = match bank {
-            0 => majit_ir::Value::Int(registers_i[color]),
-            1 => majit_ir::Value::Ref(majit_ir::GcRef(registers_r[color] as usize)),
-            2 => majit_ir::Value::Float(f64::from_bits(registers_f[color] as u64)),
-            _ => unreachable!("validated blackhole register bank"),
-        };
-        pf.locals_w_mut()[slot] = crate::state::boxed_slot_value_for_type(value.get_type(), &value);
-        // Per store, not once after the loop: boxing the next slot can collect,
-        // which re-arms the array's write barrier.
-        pyre_interpreter::remember_frame_locals_array(pf.locals_cells_stack_w);
-    }
-    majit_gc::shadow_stack::pop_resume_ref_roots_to(root_depth);
-    pf.valuestackdepth = live_end;
-    pf.last_instr = resume_py_pc as isize - 1;
-    true
 }
 
 /// ⚠️`drive_single_frame_blackhole` **executes** — `bh.resume_mainloop()`
@@ -2034,26 +1929,26 @@ fn apply_blackhole_crn(
 ///
 /// Declines therefore split at the drive:
 /// - BEFORE it are free — nothing has run.
-/// - AFTER it are the double-apply class.  `apply_blackhole_crn`'s frame-shape
-///   preconditions (`frame == 0`, null `pycode`, no `concrete_nlocals`) are
-///   already discharged by the pre-drive `concrete_nlocals(cf_addr)`, so what
-///   survives needs `resume_py_pc` — the drive's own output — and cannot be
-///   hoisted without validating the whole CRN resume-pc set up front.
-///   Named under `PYRE_FBW_DEBUG_ABORT` so they are countable rather than
-///   silent; a silent one is indistinguishable from the adopt never running.
+/// - AFTER it are the double-apply class, and worse than "a lost
+///   optimization": the undo the publish below carries restores the frame, but
+///   the region's residual calls already mutated the heap and no undo reaches
+///   that.  Measured with the CRN arm forced to decline on
+///   `getframe_root_loop_force_blackhole_crn_nonidempotent`: the accumulator
+///   comes back right at 199990000 and the list holds 20005 entries for 20000
+///   iterations, one extra per declined drive.
 ///
-/// ⭐The exposure is narrower than the decline count suggests: BOTH post-drive
-/// declines live in the `ContinueRunningNormally` arm, and every other arm
-/// (`DoneWithThisFrame*`, `ExitFrameWithExceptionRef`) is already infallible —
-/// it records a concrete frame result and adopts.  So the whole double-apply
-/// class here is "the CRN arm rejected the image".
+/// ⭐So this path now has NO post-drive decline, which is what makes it safe to
+/// drive loop-bearing bodies at all.  Every arm adopts: `DoneWithThisFrame*`
+/// and `ExitFrameWithExceptionRef` record a concrete frame result, and
+/// `ContinueRunningNormally` hands the frame over through
+/// [`adopt_blackhole_crn`], which validates nothing because it rebuilds
+/// nothing.  The one `false` left in the match is an empty green list, a
+/// codewriter contract violation with no upstream counterpart.
 ///
-/// ⚠️That arm is unreachable HERE, but only because the loop-header gate below
-/// keeps it so.  Under the gate all 50 single-frame adoptions over
-/// `pyre/bench/synth` take a frame-terminal arm; with the gate lifted the same
-/// corpus reaches it 10 times, from the two `getframe_root_loop_force_*`
-/// fixtures, and declines none of them.  The gate comment carries that
-/// measurement and why it is still not enough to lift.
+/// Over `pyre/bench/synth` that is 50 frame-terminal adoptions plus 15 CRN
+/// adoptions (five each from the three `getframe_root_loop_force_*` fixtures),
+/// zero declines, and no corpus file's output differing from the
+/// interpreter's.
 fn try_adopt_single_frame_blackhole(
     ctx: &mut TraceCtx,
     cf_addr: usize,
@@ -2062,7 +1957,7 @@ fn try_adopt_single_frame_blackhole(
     macro_rules! sfdbg {
         ($($a:tt)*) => {
             if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
-                eprintln!("[s1-adopt-decline] {}", format!($($a)*));
+                eprintln!("[s1-adopt] {}", format!($($a)*));
             }
         };
     }
@@ -2083,89 +1978,42 @@ fn try_adopt_single_frame_blackhole(
     let Some(stack_base) = crate::state::concrete_nlocals(cf_addr) else {
         return false;
     };
-    // `apply_blackhole_crn` cannot reconstruct the frame without pcdep trivia at
-    // the position the drive stops at.  That position is the drive's own output,
-    // but whether this jitcode carries ANY pcdep trivia is not — and when it
-    // carries none, the post-drive lookup is already doomed for every position.
-    // Deciding it here turns a decline that would have discarded an executed
-    // region into one taken before anything runs.  Taken ahead of the locals
-    // publish below, whose undo only covers declines that reach
-    // `restore_frame_locals`.
-    if !crate::state::pcdep_trivia_populated(jitcode_index) {
-        sfdbg!("jitcode {jitcode_index} carries no pcdep trivia (pre-drive)");
-        return false;
-    }
-    // ⭐Drive only bodies where EVERY outcome arm is infallible.
+    // Two gates used to sit here, and both were scaffolding around a decline
+    // that no longer exists.
     //
-    // The `DoneWithThisFrame*` / `ExitFrameWithExceptionRef` arms always adopt;
-    // only `ContinueRunningNormally` can reject the image, and rejecting it
-    // AFTER the drive discards an executed region and hands back to a replay —
-    // measured to produce a wrong answer, not merely a lost optimization
-    // (`root_loop_force.py`: 199990000 correct vs 200005595 after a post-drive
-    // decline).  A CRN can only arise at a `jit_merge_point`, which the
-    // codewriter emits solely at Python loop headers of the true portal, so a
-    // loop-free body cannot reach that arm at all.
+    // One refused to drive any body containing a loop header, so that no drive
+    // could reach a `jit_merge_point` and hence the `ContinueRunningNormally`
+    // arm — the only arm that could reject the image.  The other pre-checked
+    // pcdep trivia purely to pre-empt the pcdep lookup the register-image
+    // rebuild did, deciding before the drive what would otherwise have been
+    // decided after the region had already run.  The CRN arm rejects nothing now
+    // ([`adopt_blackhole_crn`]) and reads no pcdep, so all either gate could do
+    // is refuse an adopt that would have succeeded.
     //
-    // This is a RESTRICTION, not the convergence.  Both defects that made a
-    // driven loop body wrong are fixed: the image now carries the whole
-    // concrete bank rather than a liveness-selected subset, and the locals
-    // publish below writes the walk's locals into the frame the image's own
-    // register names, which is the live one and not the snapshot the walk
-    // stepped.  Without that publish the drive read pre-walk locals — on
-    // `getframe_root_loop_force_blackhole_crn` it accumulated `total += 1039`
-    // where the walk already had i=1040, and the total came out short by
-    // exactly the adoption count.  Lifting the gate was then measured over
-    // `pyre/bench/synth`:
-    // 10 CRN adoptions (both `getframe_root_loop_force_*` fixtures, 5 each),
-    // ZERO `apply_blackhole_crn` declines, no output differing from the
-    // interpreter on any corpus file, and check.py green on all three
-    // backends.
+    // Worth recording why gating was never the answer: a post-drive decline is
+    // unsound in a way no undo can repair.  The publish below carries an undo,
+    // and it restores the frame exactly — but the drive also ran the region's
+    // residual calls, and their heap effects are not frame state.  Measured
+    // with the CRN arm forced to decline on
+    // `getframe_root_loop_force_blackhole_crn_nonidempotent`: `total` comes
+    // back correct at 199990000 while the list holds 20005 entries for 20000
+    // iterations, one extra per declined drive.  The undo makes that failure
+    // QUIETER, not smaller — before it the accumulator was visibly wrong too.
+    // So the decline had to go, not be gated around.
     //
-    // It stays shut anyway, on two grounds.  The measurement is not a proof:
-    // `apply_blackhole_crn` can still decline post-drive on a shape the corpus
-    // does not contain (a NULL Ref for a live stack slot, an absent pcdep at
-    // the drive's own stop position, a live stack slot no color covers), and
-    // that decline's failure mode is a wrong answer rather than a crash.  And
-    // there is nothing on the other side of the trade: adoption fires once per
-    // trace attempt that meets a force, so the corpus's 10 adoptions bought no
-    // CPU time distinguishable from measurement floor (0.090s vs 0.080s and
-    // 0.050s vs 0.050s, min of 5 interleaved rounds), while the refused
-    // adoption's fallbacks — the committed escape or the legacy replay — are
-    // themselves correct.
-    //
-    // The convergence is to delete the decline instead of the gate.
-    // `convert_and_run_from_pyjitpl` (`blackhole.py:1799-1821`) has no path
-    // that rejects an image; it builds the interps and runs them.  Every
-    // decline in `apply_blackhole_crn` guards pyre's own resume metadata being
-    // incomplete at the merge point.  Once those are discharged, the CRN arm is
-    // infallible like the other three and this gate has nothing left to stand
-    // on.
-    let has_loop = {
-        let pf = unsafe { &*(cf_addr as *const pyre_interpreter::PyFrame) };
-        let w_code = pf.pycode;
-        !w_code.is_null() && {
-            let raw_code = unsafe {
-                pyre_interpreter::w_code_get_ptr(w_code as pyre_object::PyObjectRef)
-                    as *const pyre_interpreter::CodeObject
-            };
-            code_has_loop_header(unsafe { &*raw_code })
-        }
-    };
-    if has_loop {
-        sfdbg!("frame code has a loop header, so the drive could reach a merge point (pre-drive)");
-        return false;
-    }
     // The escape flush that ran ahead of the forcing residual is
     // all-or-nothing, and its decline is what this latch is gated on
     // (`committed_frame_escape_pc().is_none()`).  What it declines on is the
     // operand-stack half — the shadow's stack region reads NULL away from a
-    // merge point — and the register image below carries that half anyway.
+    // merge point — and the drive reconstructs that half itself, through the
+    // vable stores its own execution makes.
     // The LOCALS half is not optional: every LOAD_FAST lowers to
-    // `getarrayitem_vable_r` on the frame the register image names, so without
-    // it the replay reads whatever that frame held before the walk began, and
-    // a local the walk assigned comes back null.  Publish that half here and
-    // withdraw it if it cannot complete, so a decline still leaves the legacy
-    // replay pristine pre-walk state.
+    // `getarrayitem_vable_r` on the frame the latched image's register names,
+    // so without it the drive reads whatever that frame held before the walk
+    // began, and a local the walk assigned comes back null.  Publish that half
+    // here, and withdraw it if it cannot complete — the withdrawal is honest
+    // only because nothing has run at that point.
+    //
     // Which frame gets it is an identity question, and the walked frame has two
     // representations: `cf_addr` is the `snapshot_for_tracing` copy the walk
     // steps concretely, `live_root_addr` the frame the compiled loop runs on.
@@ -2211,7 +2059,7 @@ fn try_adopt_single_frame_blackhole(
     // slots it was taken from, so these words are the only remaining reference
     // to the pre-walk locals, and a collection inside the drive would both free
     // them and leave the withdrawal below writing back pre-move addresses.
-    let mut terminal = majit_metainterp::drive_single_frame_blackhole(
+    let terminal = majit_metainterp::drive_single_frame_blackhole(
         &mut latched.miframe,
         majit_metainterp::blackhole::StateFieldLayout::default(),
         virtualizable_info,
@@ -2249,30 +2097,19 @@ fn try_adopt_single_frame_blackhole(
         } => match green_int.first() {
             Some(&resume_py_pc) => {
                 let resume_py_pc = resume_py_pc as usize;
-                if apply_blackhole_crn(
-                    cf_addr,
-                    jitcode_index,
-                    terminal.position,
-                    terminal.last_opcode_position,
-                    &terminal.registers_i,
-                    terminal.registers_r.as_mut_slice(),
-                    &terminal.registers_f,
-                    resume_py_pc,
-                ) {
-                    // The green this CRN handed back.  Closing the remaining
-                    // post-drive declines means pre-validating
-                    // `apply_blackhole_crn` over the set of greens the drive can
-                    // produce, so what that set actually is is the next thing to
-                    // measure — report it per adoption.
-                    sfdbg!("adopted with green resume_py_pc={resume_py_pc}");
-                    WALK_END_RESTART_PC.with(|slot| slot.set(Some(resume_py_pc)));
-                    true
-                } else {
-                    sfdbg!("apply_blackhole_crn rejected the terminal image");
-                    false
-                }
+                adopt_blackhole_crn(cf_addr, vable_frame, resume_py_pc);
+                sfdbg!("adopted with green resume_py_pc={resume_py_pc}");
+                WALK_END_RESTART_PC.with(|slot| slot.set(Some(resume_py_pc)));
+                true
             }
             None => {
+                // The last post-drive decline in this arm, and a codewriter
+                // contract violation rather than a runtime condition: the
+                // portal's `jit_merge_point` carries `py_pc` as its first int
+                // green, so an empty list means the op was emitted without its
+                // greens.  Upstream indexes the greens unconditionally
+                // (`warmspot.py:973-976` `getattr(e, attrname)[count]`), so it
+                // has no decline for this to correspond to.
                 sfdbg!("ContinueRunningNormally with no green int");
                 false
             }
@@ -2321,15 +2158,21 @@ fn try_adopt_single_frame_blackhole(
             );
         }
     } else {
-        // The terminal was not adoptable, so this returns to the legacy
-        // escape/replay path, which resumes the frame from its pre-walk state —
-        // the state `restore_escape_flush_undo` puts back for the flush half.
-        // The publish above and the replay's own vable stores both landed here,
-        // so both have to come off.  The drive reached the frame's scalars
-        // through `setfield_vable_i`, for which no undo image exists anywhere
-        // else: the store journal covers heap effects and
+        // Only the empty-green-list arm gets here, and that is a codewriter
+        // contract violation rather than a runtime outcome.  This returns to the
+        // legacy escape/replay path, which resumes the frame from its pre-walk
+        // state — the state `restore_escape_flush_undo` puts back for the flush
+        // half.  The publish above and the drive's own vable stores both landed
+        // on this frame, so both have to come off.  The drive reached the
+        // frame's scalars through `setfield_vable_i`, for which no undo image
+        // exists anywhere else: the store journal covers heap effects and
         // `fbw_exit_last_instr_rollback` only arms on a return or void-return
         // exit, which an unadoptable terminal is not.
+        //
+        // ⚠️Putting the FRAME back is all this can do.  The drive already ran,
+        // so any heap effect in the region it executed stays, and the replay
+        // performs it a second time.  That is why no new post-drive decline may
+        // be added here: the withdrawal looks total and is not.
         crate::state::restore_frame_locals(vable_frame, &locals_undo);
         if let Some(scalars) = scalars_undo {
             crate::state::restore_frame_scalars(vable_frame, scalars);
@@ -2352,19 +2195,22 @@ fn try_adopt_multi_frame_blackhole(
     // ⚠️The declines are NOT interchangeable — see
     // [`try_adopt_single_frame_blackhole`].  Those before
     // `drive_multi_frame_blackhole` are free; those after it discard a chain
-    // that already ran and hand back to a caller that replays it.  Three
-    // post-drive ones survive here (empty `green_int`, no terminal image,
-    // terminal jitcode index out of i32 range); each depends on the drive's own
-    // output and so has no pre-drive counterpart to strengthen.
+    // that already ran and hand back to a caller that replays it, and no undo
+    // reaches the heap effects that chain committed.
     //
-    // In particular the single-frame path's pre-drive pcdep hoist does NOT
-    // transfer.  There the index handed to `apply_blackhole_crn` is the latched
-    // MIFrame's own, fixed before the drive; here it is
-    // `terminal.jitcode_index` = `bh.jitcode.index()` of whichever interpreter
-    // the chain ended in (`BlackholeTerminalImage::take_from`), and the run can
-    // enter jitcodes that are not levels of `latched.framestack`.  Pre-checking
-    // the levels would therefore add a decline without discharging the
-    // post-drive one.
+    // Exactly one post-drive decline survives here, the empty `green_int`, and
+    // it is a codewriter contract violation rather than a runtime outcome.  The
+    // three that used to sit beside it — no terminal image, terminal jitcode
+    // index out of i32 range, and the register-image rebuild's own rejection —
+    // all existed only to serve that rebuild, and went with it when the CRN
+    // handoff became [`adopt_blackhole_crn`].
+    //
+    // Note that they could not have been hoisted instead.  The rebuild's index
+    // here is `terminal.jitcode_index` = `bh.jitcode.index()` of whichever
+    // interpreter the chain ended in (`BlackholeTerminalImage::take_from`), and
+    // the run can enter jitcodes that are not levels of `latched.framestack`,
+    // so pre-checking the levels would have added a decline without discharging
+    // the post-drive one.  Retiring the rebuild is what discharged them.
     macro_rules! mfdbg {
         ($($a:tt)*) => {
             if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
@@ -2563,8 +2409,8 @@ fn try_adopt_multi_frame_blackhole(
     // that stores `e.__traceback__` and then reads an attribute off it faults
     // in `object_getattr_miss`, where the same shape through the single-frame
     // arm is correct.  Publishing them needs a per-level slot→value map — what
-    // `apply_blackhole_crn` builds from `pcdep_trivia_at` — run before the
-    // drive rather than after it.
+    // the retired register-image rebuild built from `pcdep_trivia_at` — run
+    // before the drive rather than after it.
     let Some(mut locals_undo) = crate::state::capture_frame_locals(root_addr) else {
         mfdbg!("frame 0: {root_addr:#x} locals not capturable");
         restore_links(&saved_links);
@@ -2600,7 +2446,7 @@ fn try_adopt_multi_frame_blackhole(
     mf_builder.cpu = Some(majit_metainterp::blackhole::pyre_production_cpu());
     let majit_metainterp::MultiFrameBlackholeResult {
         outcome,
-        terminal: mut mf_terminal,
+        terminal: _mf_terminal,
     } = majit_metainterp::drive_multi_frame_blackhole(
         &mut mf_builder,
         &mut latched.framestack,
@@ -2657,54 +2503,38 @@ fn try_adopt_multi_frame_blackhole(
             // `resume_py_pc` is deliberately NOT checked.  It is a
             // `depth_at_py_pc` index written through to
             // `frame.last_instr = resume_py_pc - 1`, so 0 is an ordinary
-            // coordinate — the single-frame arm hands it to
-            // `apply_blackhole_crn` unfiltered.  Rejecting it here would also
-            // decline *after* the chain has been driven, returning to a legacy
-            // replay that re-executes what the chain already committed.
+            // coordinate — the single-frame arm hands it to the CRN handoff
+            // unfiltered.  Rejecting it here would also decline *after* the
+            // chain has been driven, returning to a legacy replay that
+            // re-executes what the chain already committed.
             //
             // `cf_addr` needs no check either: the pre-drive
             // `concrete_nlocals(cf_addr)` above already returns `None` for a
-            // zero frame (`state.rs` `(frame != 0).then_some(..)?`), and
-            // `apply_blackhole_crn` re-checks it independently.  The decline
-            // that used to sit here was unreachable AND post-drive, i.e. it
-            // could only ever have been an instance of the hazard the comment
-            // above names.
+            // zero frame (`state.rs` `(frame != 0).then_some(..)?`).  The
+            // decline that used to sit here was unreachable AND post-drive,
+            // i.e. it could only ever have been an instance of the hazard the
+            // comment above names.
             debug_assert_ne!(
                 cf_addr, 0,
                 "pre-drive concrete_nlocals admitted a zero frame"
             );
-            // The terminal frame's own `setfield_vable` operations committed
-            // the frame fields they wrote, but the aborted mid-expression
-            // operand stack is still in place, so the resume coordinate needs
-            // the same live-slot materialization the single-frame path
-            // performs.
-            let Some(terminal) = mf_terminal.as_mut() else {
-                mfdbg!("no terminal image for the ContinueRunningNormally handoff");
-                break 'crn false;
-            };
-            let Ok(terminal_jitcode_index) = i32::try_from(terminal.jitcode_index) else {
-                mfdbg!(
-                    "terminal jitcode index {} out of range",
-                    terminal.jitcode_index
-                );
-                break 'crn false;
-            };
-            // Snapshot, not `root_addr`: with the fold above the match the
-            // snapshot is the committed image the epilogue propagates,
-            // matching the single-frame arm.
-            if !apply_blackhole_crn(
-                cf_addr,
-                terminal_jitcode_index,
-                terminal.position,
-                terminal.last_opcode_position,
-                &terminal.registers_i,
-                terminal.registers_r.as_mut_slice(),
-                &terminal.registers_f,
-                resume_py_pc,
-            ) {
-                mfdbg!("apply_blackhole_crn rejected the terminal image");
-                break 'crn false;
-            }
+            // Same handoff as the single-frame arm, for the same reason: the
+            // chain's levels wrote their frames through the blackhole's
+            // write-through vable ops, and a CRN is raised only at the
+            // bottommost level, which `convert_and_run_from_pyjitpl` makes the
+            // portal frame.  So the frame already holds the driven result and
+            // nothing has to be rebuilt from the terminal register banks.
+            //
+            // The fold above the match has already made the snapshot the
+            // committed image, so the mirror inside is a no-op here and only
+            // the resume coordinate is left to set.  Taking the same path
+            // anyway keeps one definition of what adopting a CRN means.
+            //
+            // This retires three post-drive declines at once — the absent
+            // terminal image, the out-of-range terminal jitcode index, and the
+            // register-image rebuild's own rejection — each of which handed a
+            // chain that had already run back to a replay.
+            adopt_blackhole_crn(cf_addr, root_addr, resume_py_pc);
             WALK_END_RESTART_PC.with(|slot| slot.set(Some(resume_py_pc)));
             true
         }

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -1968,11 +1968,37 @@ fn apply_blackhole_crn(
     true
 }
 
+/// ⚠️`drive_single_frame_blackhole` **executes** — `bh.resume_mainloop()`
+/// (`jitdriver.rs`) runs the region, allocating and calling.  So every decline
+/// AFTER the drive discards work that already happened and returns to a caller
+/// that replays it: `try_adopt_force_blackhole` reports `false`, and
+/// `run_perfn_walk`'s epilogue then takes the committed escape pc or the legacy
+/// replay, both of which re-enter the region.  The locals publish below carries
+/// its own undo for exactly that reason; the `mfdbg!` sibling names the same
+/// hazard at the multi-frame `resume_py_pc` check as the reason not to add a
+/// check there.
+///
+/// Declines therefore split at the drive:
+/// - BEFORE it are free — nothing has run.
+/// - AFTER it are the double-apply class.  `apply_blackhole_crn`'s frame-shape
+///   preconditions (`frame == 0`, null `pycode`, no `concrete_nlocals`) are
+///   already discharged by the pre-drive `concrete_nlocals(cf_addr)`, so what
+///   survives needs `resume_py_pc` — the drive's own output — and cannot be
+///   hoisted without validating the whole CRN resume-pc set up front.
+///   Named under `PYRE_FBW_DEBUG_ABORT` so they are countable rather than
+///   silent; a silent one is indistinguishable from the adopt never running.
 fn try_adopt_single_frame_blackhole(
     ctx: &mut TraceCtx,
     cf_addr: usize,
     live_root_addr: usize,
 ) -> bool {
+    macro_rules! sfdbg {
+        ($($a:tt)*) => {
+            if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
+                eprintln!("[s1-adopt-decline] {}", format!($($a)*));
+            }
+        };
+    }
     let Some(mut latched) = crate::jitcode_dispatch::take_single_frame_blackhole() else {
         return false;
     };
@@ -2076,10 +2102,14 @@ fn try_adopt_single_frame_blackhole(
                     WALK_END_RESTART_PC.with(|slot| slot.set(Some(resume_py_pc)));
                     true
                 } else {
+                    sfdbg!("apply_blackhole_crn rejected the terminal image");
                     false
                 }
             }
-            None => false,
+            None => {
+                sfdbg!("ContinueRunningNormally with no green int");
+                false
+            }
         },
         majit_metainterp::jitexc::JitException::DoneWithThisFrameVoid => {
             crate::jitcode_dispatch::fbw_finish_concrete_set(crate::state::ConcreteValue::Null);
@@ -2152,6 +2182,14 @@ fn try_adopt_multi_frame_blackhole(
     // under `PYRE_FBW_DEBUG_ABORT`, the way `build_multi_frame_miframe`'s
     // `s2dbg!` names its own: a silent decline is indistinguishable from the
     // adopt never being reached, and the two want different fixes.
+    //
+    // ⚠️The declines are NOT interchangeable — see
+    // [`try_adopt_single_frame_blackhole`].  Those before
+    // `drive_multi_frame_blackhole` are free; those after it discard a chain
+    // that already ran and hand back to a caller that replays it.  Three
+    // post-drive ones survive here (empty `green_int`, no terminal image,
+    // terminal jitcode index out of i32 range); each depends on the drive's own
+    // output and so has no pre-drive counterpart to strengthen.
     macro_rules! mfdbg {
         ($($a:tt)*) => {
             if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
@@ -2441,17 +2479,25 @@ fn try_adopt_multi_frame_blackhole(
                 break 'crn false;
             };
             let resume_py_pc = resume_py_pc as usize;
-            // Only the frame address is checked.  `resume_py_pc` is a
+            // `resume_py_pc` is deliberately NOT checked.  It is a
             // `depth_at_py_pc` index written through to
             // `frame.last_instr = resume_py_pc - 1`, so 0 is an ordinary
             // coordinate — the single-frame arm hands it to
             // `apply_blackhole_crn` unfiltered.  Rejecting it here would also
             // decline *after* the chain has been driven, returning to a legacy
             // replay that re-executes what the chain already committed.
-            if cf_addr == 0 {
-                mfdbg!("cf_addr {cf_addr:#x} is zero");
-                break 'crn false;
-            }
+            //
+            // `cf_addr` needs no check either: the pre-drive
+            // `concrete_nlocals(cf_addr)` above already returns `None` for a
+            // zero frame (`state.rs` `(frame != 0).then_some(..)?`), and
+            // `apply_blackhole_crn` re-checks it independently.  The decline
+            // that used to sit here was unreachable AND post-drive, i.e. it
+            // could only ever have been an instance of the hazard the comment
+            // above names.
+            debug_assert_ne!(
+                cf_addr, 0,
+                "pre-drive concrete_nlocals admitted a zero frame"
+            );
             // The terminal frame's own `setfield_vable` operations committed
             // the frame fields they wrote, but the aborted mid-expression
             // operand stack is still in place, so the resume coordinate needs

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -1971,8 +1971,11 @@ fn apply_blackhole_crn(
         // expected — the walk's own flush declines exactly this case and says
         // so (`state.rs` "NULL operand-stack shadow slot (mid-expression)").
         // The blackhole image gets there a different way: the CRN merge point
-        // is a different pc than the one the MIFrame was built at, so a color
-        // live at the merge need not have been populated at the build.
+        // is a different pc than the one the MIFrame was built at, and its live
+        // set is generally the larger of the two.  `build_single_frame_miframe`
+        // now seeds the whole concrete bank rather than the colors live at the
+        // build pc, so reaching here means the walk held no concrete for the
+        // color at all, not that a liveness filter dropped it.
         // A LOCAL slot may legitimately be NULL (an unbound local), so this
         // guards the stack region only, matching the sibling.
         //
@@ -1981,7 +1984,10 @@ fn apply_blackhole_crn(
         // already-executed region back to the replay.  The loop-header gate in
         // `try_adopt_single_frame_blackhole` keeps the CRN arm out of reach; the
         // check survives only so an incomplete gate degrades to a wrong answer
-        // instead of the SIGSEGV this class produced before it existed.
+        // instead of the SIGSEGV this class produced before it existed.  With
+        // that gate lifted the corpus reaches the CRN arm 10 times and fires
+        // this decline zero times — which is why the gate's own comment names
+        // discharging these declines, not lifting the gate, as the convergence.
         if slot >= stack_base && bank == 1 && registers_r[color] == 0 {
             sfdbg_crn!("NULL Ref color {color} for live stack slot {slot}");
             return false;
@@ -2042,12 +2048,12 @@ fn apply_blackhole_crn(
 /// it records a concrete frame result and adopts.  So the whole double-apply
 /// class here is "the CRN arm rejected the image".
 ///
-/// ⚠️And that arm is UNEXERCISED: over `pyre/bench/synth` (312 files) all 50
-/// single-frame adoptions took a frame-terminal arm and none reported a green,
-/// i.e. `apply_blackhole_crn` is never reached from here on this corpus.  Any
-/// work to make the CRN arm infallible therefore needs a shape that enters it
-/// first, or it cannot be tested — see the `[latch-vs-bh]` probe in
-/// `residual_call.rs`, which measures the most likely such shape.
+/// ⚠️That arm is unreachable HERE, but only because the loop-header gate below
+/// keeps it so.  Under the gate all 50 single-frame adoptions over
+/// `pyre/bench/synth` take a frame-terminal arm; with the gate lifted the same
+/// corpus reaches it 10 times, from the two `getframe_root_loop_force_*`
+/// fixtures, and declines none of them.  The gate comment carries that
+/// measurement and why it is still not enough to lift.
 fn try_adopt_single_frame_blackhole(
     ctx: &mut TraceCtx,
     cf_addr: usize,
@@ -2100,11 +2106,40 @@ fn try_adopt_single_frame_blackhole(
     // codewriter emits solely at Python loop headers of the true portal, so a
     // loop-free body cannot reach that arm at all.
     //
-    // This is a RESTRICTION, not the convergence.  The real fix is to make the
-    // CRN image complete by construction — the MIFrame is seeded from the live
-    // colors at the BUILD pc, while the merge point it stops at has its own
-    // live set, so a color live at the merge but not at the build reads back
-    // NULL.  Until that seeding is total, a loop body cannot be driven safely.
+    // This is a RESTRICTION, not the convergence.  Both defects that made a
+    // driven loop body wrong are fixed: the image now carries the whole
+    // concrete bank rather than a liveness-selected subset, and the locals
+    // publish below writes the walk's locals into the frame the image's own
+    // register names, which is the live one and not the snapshot the walk
+    // stepped.  Without that publish the drive read pre-walk locals — on
+    // `getframe_root_loop_force_blackhole_crn` it accumulated `total += 1039`
+    // where the walk already had i=1040, and the total came out short by
+    // exactly the adoption count.  Lifting the gate was then measured over
+    // `pyre/bench/synth`:
+    // 10 CRN adoptions (both `getframe_root_loop_force_*` fixtures, 5 each),
+    // ZERO `apply_blackhole_crn` declines, no output differing from the
+    // interpreter on any corpus file, and check.py green on all three
+    // backends.
+    //
+    // It stays shut anyway, on two grounds.  The measurement is not a proof:
+    // `apply_blackhole_crn` can still decline post-drive on a shape the corpus
+    // does not contain (a NULL Ref for a live stack slot, an absent pcdep at
+    // the drive's own stop position, a live stack slot no color covers), and
+    // that decline's failure mode is a wrong answer rather than a crash.  And
+    // there is nothing on the other side of the trade: adoption fires once per
+    // trace attempt that meets a force, so the corpus's 10 adoptions bought no
+    // CPU time distinguishable from measurement floor (0.090s vs 0.080s and
+    // 0.050s vs 0.050s, min of 5 interleaved rounds), while the refused
+    // adoption's fallbacks — the committed escape or the legacy replay — are
+    // themselves correct.
+    //
+    // The convergence is to delete the decline instead of the gate.
+    // `convert_and_run_from_pyjitpl` (`blackhole.py:1799-1821`) has no path
+    // that rejects an image; it builds the interps and runs them.  Every
+    // decline in `apply_blackhole_crn` guards pyre's own resume metadata being
+    // incomplete at the merge point.  Once those are discharged, the CRN arm is
+    // infallible like the other three and this gate has nothing left to stand
+    // on.
     let has_loop = {
         let pf = unsafe { &*(cf_addr as *const pyre_interpreter::PyFrame) };
         let w_code = pf.pycode;

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -984,6 +984,25 @@ fn try_commit_midbody_abort_inner(
 /// True when `start_pc` is the target of a `JumpBackward` in `code` — i.e. a
 /// loop header, the origin of a loop-header trace rather than a function-entry
 /// trace.
+/// Whether `code` contains any backward jump, i.e. any Python loop header.
+///
+/// This is the same condition the codewriter emits `jit_merge_point` under —
+/// `loop_header_pcs` is built from the dominating `JUMP_BACKWARD` /
+/// `JUMP_BACKWARD_NO_INTERRUPT` targets (`codewriter.rs` `find_loop_header_pcs`,
+/// consumed at the `loop_header_pcs.contains(&py_pc) && is_true_portal` gate).
+/// So a code object without one produces a portal body with NO merge point, and
+/// a blackhole driven inside it can only ever leave through a frame terminal.
+fn code_has_loop_header(code: &pyre_interpreter::CodeObject) -> bool {
+    use pyre_interpreter::Instruction as I;
+    let mut arg_state = pyre_interpreter::OpArgState::default();
+    code.instructions.iter().copied().any(|unit| {
+        matches!(
+            arg_state.get(unit).0,
+            I::JumpBackward { .. } | I::JumpBackwardNoInterrupt { .. }
+        )
+    })
+}
+
 fn start_pc_is_loop_header(code: &pyre_interpreter::CodeObject, start_pc: usize) -> bool {
     use pyre_interpreter::Instruction as I;
     let mut arg_state = pyre_interpreter::OpArgState::default();
@@ -1877,6 +1896,14 @@ fn seed_loop_entry_ref_slots(
 /// treatment (a chain whose inner levels committed through their own
 /// virtualizable still leaves the portal's `valuestackdepth` at the aborted
 /// mid-expression value).
+macro_rules! sfdbg_crn {
+    ($($a:tt)*) => {
+        if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
+            eprintln!("[crn-apply-decline] {}", format!($($a)*));
+        }
+    };
+}
+
 fn apply_blackhole_crn(
     frame: usize,
     jitcode_index: i32,
@@ -1936,6 +1963,27 @@ fn apply_blackhole_crn(
             _ => false,
         };
         if !present {
+            return false;
+        }
+        // A Ref color that reads back NULL is an UNPOPULATED register, not a
+        // live value.  Writing it into a live operand-STACK slot and resuming
+        // there faults the interpreter, which pops NULL where a real object is
+        // expected — the walk's own flush declines exactly this case and says
+        // so (`state.rs` "NULL operand-stack shadow slot (mid-expression)").
+        // The blackhole image gets there a different way: the CRN merge point
+        // is a different pc than the one the MIFrame was built at, so a color
+        // live at the merge need not have been populated at the build.
+        // A LOCAL slot may legitimately be NULL (an unbound local), so this
+        // guards the stack region only, matching the sibling.
+        //
+        // ⚠️This must stay UNREACHABLE: it is a post-drive decline, and one was
+        // measured to turn a correct 199990000 into 200005595 by handing an
+        // already-executed region back to the replay.  The loop-header gate in
+        // `try_adopt_single_frame_blackhole` keeps the CRN arm out of reach; the
+        // check survives only so an incomplete gate degrades to a wrong answer
+        // instead of the SIGSEGV this class produced before it existed.
+        if slot >= stack_base && bank == 1 && registers_r[color] == 0 {
+            sfdbg_crn!("NULL Ref color {color} for live stack slot {slot}");
             return false;
         }
         if !writes.iter().any(|(existing, _, _)| *existing == slot) {
@@ -2041,6 +2089,37 @@ fn try_adopt_single_frame_blackhole(
         sfdbg!("jitcode {jitcode_index} carries no pcdep trivia (pre-drive)");
         return false;
     }
+    // ⭐Drive only bodies where EVERY outcome arm is infallible.
+    //
+    // The `DoneWithThisFrame*` / `ExitFrameWithExceptionRef` arms always adopt;
+    // only `ContinueRunningNormally` can reject the image, and rejecting it
+    // AFTER the drive discards an executed region and hands back to a replay —
+    // measured to produce a wrong answer, not merely a lost optimization
+    // (`root_loop_force.py`: 199990000 correct vs 200005595 after a post-drive
+    // decline).  A CRN can only arise at a `jit_merge_point`, which the
+    // codewriter emits solely at Python loop headers of the true portal, so a
+    // loop-free body cannot reach that arm at all.
+    //
+    // This is a RESTRICTION, not the convergence.  The real fix is to make the
+    // CRN image complete by construction — the MIFrame is seeded from the live
+    // colors at the BUILD pc, while the merge point it stops at has its own
+    // live set, so a color live at the merge but not at the build reads back
+    // NULL.  Until that seeding is total, a loop body cannot be driven safely.
+    let has_loop = {
+        let pf = unsafe { &*(cf_addr as *const pyre_interpreter::PyFrame) };
+        let w_code = pf.pycode;
+        !w_code.is_null() && {
+            let raw_code = unsafe {
+                pyre_interpreter::w_code_get_ptr(w_code as pyre_object::PyObjectRef)
+                    as *const pyre_interpreter::CodeObject
+            };
+            code_has_loop_header(unsafe { &*raw_code })
+        }
+    };
+    if has_loop {
+        sfdbg!("frame code has a loop header, so the drive could reach a merge point (pre-drive)");
+        return false;
+    }
     // The escape flush that ran ahead of the forcing residual is
     // all-or-nothing, and its decline is what this latch is gated on
     // (`committed_frame_escape_pc().is_none()`).  What it declines on is the
@@ -2108,23 +2187,27 @@ fn try_adopt_single_frame_blackhole(
         latched.raising_exception,
     );
 
-    sfdbg!(
-        "drive outcome = {}",
-        match terminal.outcome {
-            majit_metainterp::jitexc::JitException::ContinueRunningNormally { .. } =>
-                "ContinueRunningNormally",
-            majit_metainterp::jitexc::JitException::DoneWithThisFrameVoid =>
-                "DoneWithThisFrameVoid",
-            majit_metainterp::jitexc::JitException::DoneWithThisFrameInt(_) =>
-                "DoneWithThisFrameInt",
-            majit_metainterp::jitexc::JitException::DoneWithThisFrameRef(_) =>
-                "DoneWithThisFrameRef",
-            majit_metainterp::jitexc::JitException::DoneWithThisFrameFloat(_) =>
-                "DoneWithThisFrameFloat",
-            majit_metainterp::jitexc::JitException::ExitFrameWithExceptionRef(_) =>
-                "ExitFrameWithExceptionRef",
-        }
-    );
+    // Its own prefix: this is not a decline, and reading it as one is exactly
+    // the confusion that made the CRN arm look unreachable.
+    if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
+        eprintln!(
+            "[s1-drive-outcome] {}",
+            match terminal.outcome {
+                majit_metainterp::jitexc::JitException::ContinueRunningNormally { .. } =>
+                    "ContinueRunningNormally",
+                majit_metainterp::jitexc::JitException::DoneWithThisFrameVoid =>
+                    "DoneWithThisFrameVoid",
+                majit_metainterp::jitexc::JitException::DoneWithThisFrameInt(_) =>
+                    "DoneWithThisFrameInt",
+                majit_metainterp::jitexc::JitException::DoneWithThisFrameRef(_) =>
+                    "DoneWithThisFrameRef",
+                majit_metainterp::jitexc::JitException::DoneWithThisFrameFloat(_) =>
+                    "DoneWithThisFrameFloat",
+                majit_metainterp::jitexc::JitException::ExitFrameWithExceptionRef(_) =>
+                    "ExitFrameWithExceptionRef",
+            }
+        );
+    }
     let adopted = match terminal.outcome {
         majit_metainterp::jitexc::JitException::ContinueRunningNormally {
             ref green_int, ..

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -1987,6 +1987,19 @@ fn apply_blackhole_crn(
 ///   hoisted without validating the whole CRN resume-pc set up front.
 ///   Named under `PYRE_FBW_DEBUG_ABORT` so they are countable rather than
 ///   silent; a silent one is indistinguishable from the adopt never running.
+///
+/// ⭐The exposure is narrower than the decline count suggests: BOTH post-drive
+/// declines live in the `ContinueRunningNormally` arm, and every other arm
+/// (`DoneWithThisFrame*`, `ExitFrameWithExceptionRef`) is already infallible —
+/// it records a concrete frame result and adopts.  So the whole double-apply
+/// class here is "the CRN arm rejected the image".
+///
+/// ⚠️And that arm is UNEXERCISED: over `pyre/bench/synth` (312 files) all 50
+/// single-frame adoptions took a frame-terminal arm and none reported a green,
+/// i.e. `apply_blackhole_crn` is never reached from here on this corpus.  Any
+/// work to make the CRN arm infallible therefore needs a shape that enters it
+/// first, or it cannot be tested — see the `[latch-vs-bh]` probe in
+/// `residual_call.rs`, which measures the most likely such shape.
 fn try_adopt_single_frame_blackhole(
     ctx: &mut TraceCtx,
     cf_addr: usize,
@@ -2016,6 +2029,18 @@ fn try_adopt_single_frame_blackhole(
     let Some(stack_base) = crate::state::concrete_nlocals(cf_addr) else {
         return false;
     };
+    // `apply_blackhole_crn` cannot reconstruct the frame without pcdep trivia at
+    // the position the drive stops at.  That position is the drive's own output,
+    // but whether this jitcode carries ANY pcdep trivia is not — and when it
+    // carries none, the post-drive lookup is already doomed for every position.
+    // Deciding it here turns a decline that would have discarded an executed
+    // region into one taken before anything runs.  Taken ahead of the locals
+    // publish below, whose undo only covers declines that reach
+    // `restore_frame_locals`.
+    if !crate::state::pcdep_trivia_populated(jitcode_index) {
+        sfdbg!("jitcode {jitcode_index} carries no pcdep trivia (pre-drive)");
+        return false;
+    }
     // The escape flush that ran ahead of the forcing residual is
     // all-or-nothing, and its decline is what this latch is gated on
     // (`committed_frame_escape_pc().is_none()`).  What it declines on is the
@@ -2099,6 +2124,12 @@ fn try_adopt_single_frame_blackhole(
                     &terminal.registers_f,
                     resume_py_pc,
                 ) {
+                    // The green this CRN handed back.  Closing the remaining
+                    // post-drive declines means pre-validating
+                    // `apply_blackhole_crn` over the set of greens the drive can
+                    // produce, so what that set actually is is the next thing to
+                    // measure — report it per adoption.
+                    sfdbg!("adopted with green resume_py_pc={resume_py_pc}");
                     WALK_END_RESTART_PC.with(|slot| slot.set(Some(resume_py_pc)));
                     true
                 } else {
@@ -2190,6 +2221,15 @@ fn try_adopt_multi_frame_blackhole(
     // post-drive ones survive here (empty `green_int`, no terminal image,
     // terminal jitcode index out of i32 range); each depends on the drive's own
     // output and so has no pre-drive counterpart to strengthen.
+    //
+    // In particular the single-frame path's pre-drive pcdep hoist does NOT
+    // transfer.  There the index handed to `apply_blackhole_crn` is the latched
+    // MIFrame's own, fixed before the drive; here it is
+    // `terminal.jitcode_index` = `bh.jitcode.index()` of whichever interpreter
+    // the chain ended in (`BlackholeTerminalImage::take_from`), and the run can
+    // enter jitcodes that are not levels of `latched.framestack`.  Pre-checking
+    // the levels would therefore add a decline without discharging the
+    // post-drive one.
     macro_rules! mfdbg {
         ($($a:tt)*) => {
             if crate::jitcode_dispatch::fbw_debug_abort_enabled() {

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -2082,20 +2082,11 @@ pub fn blackhole_resume_via_rd_numb(
     // down the whole chain, mirroring the forward-exec inheritance
     // `self.virtualizable_info = parent.virtualizable_info` performed when
     // a frame enters a callee.
-    {
-        let vinfo = bh.virtualizable_info;
-        let mut current = Some(&mut bh);
-        while let Some(frame) = current {
-            frame.virtualizable_info = vinfo;
-            frame.record_caught_exception = Some(record_caught_blackhole_traceback);
-            current = frame.nextblackholeinterp.as_deref_mut();
-        }
-    }
     // blackhole.py:1095-1099 get_portal_runner parity:
     //   jitdriver_sd = self.builder.metainterp_sd.jitdrivers_sd[jdindex]
     //   fnptr        = adr2int(jitdriver_sd.portal_runner_adr)
     //   calldescr    = jitdriver_sd.mainjitcode.calldescr
-    bh.jitdrivers_sd = vec![majit_metainterp::blackhole::BhJitDriverSd {
+    let jitdrivers_sd = vec![majit_metainterp::blackhole::BhJitDriverSd {
         result_type: majit_metainterp::blackhole::BhReturnType::Ref,
         portal_runner_ptr: Some(bh_portal_runner_c),
         mainjitcode_calldescr: {
@@ -2115,6 +2106,25 @@ pub fn blackhole_resume_via_rd_numb(
             d
         },
     }];
+    {
+        let vinfo = bh.virtualizable_info;
+        let mut current = Some(&mut bh);
+        while let Some(frame) = current {
+            frame.virtualizable_info = vinfo;
+            frame.record_caught_exception = Some(record_caught_blackhole_traceback);
+            // Upstream resolves `jitdrivers_sd[jdindex]` through
+            // `self.builder.metainterp_sd` (blackhole.py:1079, :1096), so every
+            // frame of a chain shares one table.  `BlackholeInterpBuilder`
+            // carries that snapshot and `acquire_interp` hands it out, but this
+            // path derives the entry from the innermost frame's own jitcode and
+            // so cannot seed the builder before `blackhole_from_resumedata`
+            // acquires the chain.  Publish it to every frame instead: any frame
+            // above the bottom one reaches `bhimpl_jit_merge_point`'s
+            // recursive-portal branch, which indexes the table directly.
+            frame.jitdrivers_sd = jitdrivers_sd.clone();
+            current = frame.nextblackholeinterp.as_deref_mut();
+        }
+    }
 
     // Portal red-arg registers (`pypy/module/pypyjit/interp_jit.py:67
     // reds = ['frame', 'ec']`) are filled per-frame by


### PR DESCRIPTION
## What this fixes

`try_adopt_single_frame_blackhole` drives a blackhole image and then decides whether to adopt the result. Every decline taken **after** `drive_single_frame_blackhole` hands an already-executed region back to a replay that runs it again.

The frame undo that guards this was recently widened to cover the resume coordinate, not just the locals. That closes the frame half completely — the only vable fields with a production emit site are `last_instr` (index 0) and `valuestackdepth` (2), plus the `locals_cells_stack_w` array; `setfield_vable_r`/`_f` have dispatch arms and no emitter. **It is still not sufficient**, because the drive also ran the region's residual calls, and those are heap effects rather than frame state.

The corpus fixture hid this. Its driven region re-adds an already-present element to a set, which is idempotent, so a replayed region leaves no trace in the output. With a list append instead, and `apply_blackhole_crn` forced to decline every time:

| driven-region effect | result |
|---|---|
| `set.add` of a present string (idempotent) | `199990000` — looks correct |
| `list.append` (non-idempotent) | `total` correct, **20005 appends for 20000 iterations** |

One extra per declined drive. So the widened undo made the failure *quieter*, not smaller — before it, the accumulator was visibly wrong too.

## The fix

Delete the decline rather than gate around it.

`apply_blackhole_crn` rebuilt the frame from the terminal register banks and validated pcdep coverage, register-bank bounds and NULL Refs — all post-drive, all fallible. Upstream does none of that:

- `bhimpl_setarrayitem_vable_r` / `bhimpl_setfield_vable_i` (`blackhole.py:1390-1490`) are **write-through**: they fetch the array out of the virtualizable and store into it. So when `bhimpl_jit_merge_point` raises (`blackhole.py:1068-1069`) the frame already holds the driven region's result.
- `handle_jitexception` (`warmspot.py:970-982`) re-enters the portal with the greens and reds the exception carries. The frame is among the reds; nothing reconstructs its contents.

`adopt_blackhole_crn` does the same thing. pyre's walked frame has two representations, so the mirror is what bridges them: the drive's vable ops address the frame in the jitcode's frame register (the live root), while the portal epilogue publishes the snapshot — the same move the escape leg already makes. `last_instr` is normalized to `resume_py_pc - 1` because the drive stops having recorded the pc it is *at*; skipping that normalization makes both loop fixtures produce no output at all.

With the arm unable to decline, the two pre-drive gates that existed only because it could — the loop-header refusal and the pcdep-trivia precondition — have nothing left to stand on and are removed, along with `code_has_loop_header` and both `pcdep_trivia_populated` bodies (`pub`, so no dead-code warning would have caught them).

## Scope

Both adopt arms take the new handoff. A CRN is raised only at the bottommost blackhole level, which `convert_and_run_from_pyjitpl` makes the portal frame, so the multi-frame chain is the same case — and that arm already folded its live root into the snapshot before the match, leaving only the coordinate to set. With no caller left, `apply_blackhole_crn` is deleted.

Five post-drive declines go: the register-image rejection in both arms, the absent terminal image, the out-of-range terminal jitcode index, and — with the arms no longer able to reject — the two pre-drive gates that existed only because they could. What survives is an empty green list, a codewriter contract violation with no upstream counterpart.

The multi-frame path has no `pyre/bench/synth` coverage (censused: 45 `s2-gate` lines, zero `s2-drive-outcome`), so its conversion rests on the argument above rather than on a measurement of that path. The corpus, test and `check.py` runs confirm nothing else regressed.

## Write barrier

`restore_resume_state_from` copies Ref slots between two frames with raw array writes and no write barrier. `apply_blackhole_crn` armed `remember_frame_locals_array` per store, so routing the handoff through that helper dropped the barrier — an old destination array taking a young reference could miss the remembered set. The barrier is armed in the helper, covering this handoff and its three pre-existing callers. One arm suffices per call: `to_vec` has already allocated by the time the copy loop runs, so nothing in it can collect.

This one was found by the Codex parity review, not by the verification below — it is a GC-timing defect, so the corpus, the test suite and `check.py` all passed with it present.

## Verification

- `pyre/bench/synth` (320 files): no output differs from the interpreter.
- Census: 15 CRN adoptions and 50 frame-terminal adoptions, **zero declines**. Only the three `getframe_root_loop_force_*` fixtures reach the CRN arm.
- `cargo test --all --features dynasm`: 7119 passed, 0 failed.
- `check.py`: dynasm 335/335, cranelift 335/335, wasm 332/332.
- CPU time on a 5000/20000/80000 trip ladder, min of 9 interleaved rounds, one binary with the old gate behind an env arm so both sides share a build: `0.060/0.090/0.200s` on both arms.

Loop-bearing bodies now drive where they previously declined before the drive, so the perf question is real rather than rhetorical; it measures neutral, and adoption fires once per trace attempt rather than per iteration, which is why the delta does not grow along the ladder.

## Note on the history

The branch introduces the loop-header gate (`0ca67ddefd`) and the pcdep precondition (`c7020f552e`), records what lifting the gate was measured to do (`3db91cc100`), and then removes both in the final commit. That is the actual order the investigation went in: the gates were the correct call while the CRN arm could still reject an image, and only became removable once it could not.

— *authored by Claude*
