### PR TITLE
descr: gate struct identity on the serialized raw-set universe, and fix the two ordering defects it exposes

### DIFF
--- a/majit/majit-ir/src/descr.rs
+++ b/majit/majit-ir/src/descr.rs
@@ -1240,7 +1240,10 @@ impl GcCache {
         //
         // The vtable is the reliable discriminator between the two: only the
         // runtime publish has one, because a build-time spec has no runtime
-        // type object to point at. Losing it is separately fatal —
+        // type object to point at. It decides in both directions, so the
+        // surviving descr is the same whichever producer registers first —
+        // the closest this can get to upstream's single owner per STRUCT.
+        // Losing the vtable is separately fatal —
         // `new_with_vtable` skips its typeptr store (`majit-gc/src/rewrite.rs`
         // gates `gen_initialize_vtable` on `vtable != 0`) over zeroed nursery
         // memory, so the fresh object reads back with a null `ob_type`.
@@ -1267,10 +1270,17 @@ impl GcCache {
                     .unwrap_or(0);
                 let existing_vtable = existing.as_size_descr().map_or(0, |sd| sd.vtable());
                 let new_vtable = descr.as_size_descr().map_or(0, |sd| sd.vtable());
-                if existing_vtable != 0 && new_vtable == 0 {
-                    false
-                } else {
-                    new_count > existing_count
+                // Both directions, so the surviving descr does not depend on
+                // which producer happened to register first. The 18
+                // module-scope groups are published before the build-time
+                // specs, but the per-exception-class groups behind
+                // `W_BASE_EXCEPTION_DESCR_CACHE` are not — they arrive after,
+                // and a one-sided rule would reject their vtable exactly the
+                // way the other order loses it.
+                match (existing_vtable != 0, new_vtable != 0) {
+                    (true, false) => false,
+                    (false, true) => true,
+                    _ => new_count > existing_count,
                 }
             }
         };
@@ -5443,6 +5453,46 @@ mod register_keyed_size_authority_tests {
                 .collect::<Vec<_>>(),
             vec![16, 24, 32],
             "the header words must not enter the positional list",
+        );
+    }
+
+    /// The mirror order. The 18 module-scope groups publish before the
+    /// build-time specs, but the per-exception-class groups do not — they
+    /// arrive after a `vtable: 0` spec is already cached, and a one-sided rule
+    /// would reject their vtable, losing it exactly the way the other order
+    /// does.
+    #[test]
+    fn a_vtable_bearing_publish_still_wins_when_it_arrives_second() {
+        let mut gc = GcCache::new();
+        let key = LLType::Struct(0x8463ec159694d229);
+        gc.register_keyed_size(
+            key.clone(),
+            size_descr_at(0x9694d229, 0, &[0, 8, 16, 24, 32]),
+        );
+        gc.register_keyed_size(key.clone(), size_descr_at(7, 0x1000, &[16, 24, 32]));
+        let cached = gc._cache_size.get(&key).unwrap().as_size_descr().unwrap();
+        assert_eq!(cached.type_id(), 7);
+        assert_ne!(cached.vtable(), 0, "the vtable must win from either side");
+    }
+
+    /// The two orders above must agree; upstream has one owner per `STRUCT`
+    /// and never arbitrates, so an order-dependent answer is a defect by
+    /// itself.
+    #[test]
+    fn the_surviving_descr_does_not_depend_on_registration_order() {
+        let runtime = || size_descr_at(7, 0x1000, &[16, 24, 32]);
+        let analyzer = || size_descr_at(0x9694d229, 0, &[0, 8, 16, 24, 32]);
+        let survivor = |first: DescrRef, second: DescrRef| {
+            let mut gc = GcCache::new();
+            let key = LLType::Struct(3);
+            gc.register_keyed_size(key.clone(), first);
+            gc.register_keyed_size(key.clone(), second);
+            let sd = gc._cache_size.get(&key).unwrap().as_size_descr().unwrap();
+            (sd.type_id(), sd.vtable(), sd.all_fielddescrs().len())
+        };
+        assert_eq!(
+            survivor(runtime(), analyzer()),
+            survivor(analyzer(), runtime())
         );
     }
 

--- a/majit/majit-ir/src/descr.rs
+++ b/majit/majit-ir/src/descr.rs
@@ -1227,20 +1227,33 @@ impl GcCache {
         // report partial layouts, so the cached owner is upgraded when the
         // incoming frozen list has more fields.
         //
-        // Field count alone is not authority. The analyzer-side producer
-        // (`majit-translate` `bh_size_spec_from_callcontrol`) reports
-        // `vtable: 0` because a build-time spec has no runtime type object to
-        // point at, and it reports the inherited header fields the runtime
-        // groups deliberately keep out of their positional list — so it
-        // outranks the runtime publish on count while carrying strictly less
-        // information. Letting it displace a vtable-bearing descr loses the
-        // only copy of that vtable, and `new_with_vtable` then skips its
-        // typeptr store (`majit-gc/src/rewrite.rs` gates
-        // `gen_initialize_vtable` on `vtable != 0`) over zeroed nursery
+        // Field count alone is not authority, and "more fields" is not
+        // "closer to upstream". Where the two producers collide today, the
+        // analyzer-side one (`majit-translate`
+        // `bh_size_spec_from_callcontrol`) is longer by exactly the header
+        // words at offsets 0 and 8 — and `heaptracker.py:60-71
+        // all_fielddescrs`, the list `descr.py:125-126` assigns onto the
+        // cached descr, skips `typeptr` and `c__pad*` outright while the GC
+        // header is not part of the lltype STRUCT at all. Upstream's
+        // positional list is therefore the header-free one, which is what the
+        // runtime groups build.
+        //
+        // The vtable is the reliable discriminator between the two: only the
+        // runtime publish has one, because a build-time spec has no runtime
+        // type object to point at. Losing it is separately fatal —
+        // `new_with_vtable` skips its typeptr store (`majit-gc/src/rewrite.rs`
+        // gates `gen_initialize_vtable` on `vtable != 0`) over zeroed nursery
         // memory, so the fresh object reads back with a null `ob_type`.
-        // Upstream has no upgrade rule to begin with: `descr.py:104-126
-        // get_size_descr` mints once per STRUCT and caches, and `gc.py:536-542
-        // init_size_descr` stamps the tid on that one owner.
+        //
+        // Upstream has no upgrade rule to arbitrate at all: `descr.py:105-127
+        // get_size_descr` takes the vtable as a parameter, mints once per
+        // STRUCT, and assigns `all_fielddescrs` onto that one owner;
+        // `gc.py:536-542 init_size_descr` stamps the tid on it. Two producers
+        // for one key is pyre's own condition. Where their specs describe
+        // genuinely different layouts — disagreeing on field offsets and
+        // sizes rather than one being a subset of the other — neither side is
+        // right and the key itself is the defect; that is the struct-identity
+        // spelling collision, tracked separately.
         let should_insert = match self._cache_size.get(&key) {
             None => true,
             Some(existing) => {
@@ -5377,19 +5390,21 @@ impl FailDescr for SimpleFailDescr {
 mod register_keyed_size_authority_tests {
     use super::*;
 
-    fn size_descr(type_id: u32, vtable: usize, nfields: usize) -> DescrRef {
+    fn size_descr_at(type_id: u32, vtable: usize, offsets: &[usize]) -> DescrRef {
         let mut sd = SimpleSizeDescr::with_vtable(u32::MAX, 32, type_id, vtable);
-        let fields: Vec<Arc<dyn FieldDescr>> = (0..nfields)
-            .map(|i| {
+        let fields: Vec<Arc<dyn FieldDescr>> = offsets
+            .iter()
+            .enumerate()
+            .map(|(i, &offset)| {
                 Arc::new(SimpleFieldDescr::new_with_name(
                     i as u32,
-                    i * 8,
+                    offset,
                     8,
                     Type::Int,
                     false,
                     ArrayFlag::Signed,
-                    format!("f{i}"),
-                    format!("f{i}"),
+                    format!("f{offset}"),
+                    format!("f{offset}"),
                 )) as Arc<dyn FieldDescr>
             })
             .collect();
@@ -5397,19 +5412,38 @@ mod register_keyed_size_authority_tests {
         Arc::new(sd) as DescrRef
     }
 
-    /// The analyzer-side producer reports MORE fields (it includes the
-    /// inherited header) and NO vtable. Field count alone would let it evict
-    /// the runtime publish, which holds the only copy of the vtable
-    /// `new_with_vtable`'s typeptr store needs.
+    fn size_descr(type_id: u32, vtable: usize, nfields: usize) -> DescrRef {
+        let offsets: Vec<usize> = (0..nfields).map(|i| i * 8).collect();
+        size_descr_at(type_id, vtable, &offsets)
+    }
+
+    /// The analyzer-side producer reports MORE fields and NO vtable, and the
+    /// extra entries are the two header words at offsets 0 and 8 — exactly
+    /// what `heaptracker.py:64-67 all_fielddescrs` skips. Field count alone
+    /// would let that list evict the runtime publish, which holds both the
+    /// header-free positional list upstream builds and the only copy of the
+    /// vtable `new_with_vtable`'s typeptr store needs.
     #[test]
-    fn a_vtable_less_producer_never_displaces_a_vtable_bearing_one() {
+    fn a_vtable_less_header_bearing_producer_never_displaces_the_runtime_publish() {
         let mut gc = GcCache::new();
         let key = LLType::Struct(0x8463ec159694d229);
-        gc.register_keyed_size(key.clone(), size_descr(7, 0x1000, 1));
-        gc.register_keyed_size(key.clone(), size_descr(0x9694d229, 0, 3));
+        gc.register_keyed_size(key.clone(), size_descr_at(7, 0x1000, &[16, 24, 32]));
+        gc.register_keyed_size(
+            key.clone(),
+            size_descr_at(0x9694d229, 0, &[0, 8, 16, 24, 32]),
+        );
         let cached = gc._cache_size.get(&key).unwrap().as_size_descr().unwrap();
         assert_eq!(cached.type_id(), 7, "the real gc tid must survive");
         assert_ne!(cached.vtable(), 0, "the vtable must survive");
+        assert_eq!(
+            cached
+                .all_fielddescrs()
+                .iter()
+                .map(|f| f.offset())
+                .collect::<Vec<_>>(),
+            vec![16, 24, 32],
+            "the header words must not enter the positional list",
+        );
     }
 
     /// The upgrade rule itself is unchanged when both sides carry a vtable.

--- a/majit/majit-ir/src/descr.rs
+++ b/majit/majit-ir/src/descr.rs
@@ -1226,6 +1226,21 @@ impl GcCache {
         // descr.py:108-118 caches the SizeDescr. Multiple pyre producers may
         // report partial layouts, so the cached owner is upgraded when the
         // incoming frozen list has more fields.
+        //
+        // Field count alone is not authority. The analyzer-side producer
+        // (`majit-translate` `bh_size_spec_from_callcontrol`) reports
+        // `vtable: 0` because a build-time spec has no runtime type object to
+        // point at, and it reports the inherited header fields the runtime
+        // groups deliberately keep out of their positional list — so it
+        // outranks the runtime publish on count while carrying strictly less
+        // information. Letting it displace a vtable-bearing descr loses the
+        // only copy of that vtable, and `new_with_vtable` then skips its
+        // typeptr store (`majit-gc/src/rewrite.rs` gates
+        // `gen_initialize_vtable` on `vtable != 0`) over zeroed nursery
+        // memory, so the fresh object reads back with a null `ob_type`.
+        // Upstream has no upgrade rule to begin with: `descr.py:104-126
+        // get_size_descr` mints once per STRUCT and caches, and `gc.py:536-542
+        // init_size_descr` stamps the tid on that one owner.
         let should_insert = match self._cache_size.get(&key) {
             None => true,
             Some(existing) => {
@@ -1237,7 +1252,13 @@ impl GcCache {
                     .as_size_descr()
                     .map(|sd| sd.all_fielddescrs().len())
                     .unwrap_or(0);
-                new_count > existing_count
+                let existing_vtable = existing.as_size_descr().map_or(0, |sd| sd.vtable());
+                let new_vtable = descr.as_size_descr().map_or(0, |sd| sd.vtable());
+                if existing_vtable != 0 && new_vtable == 0 {
+                    false
+                } else {
+                    new_count > existing_count
+                }
             }
         };
         if should_insert {
@@ -5349,6 +5370,58 @@ impl FailDescr for SimpleFailDescr {
     }
     fn vector_info(&self) -> Vec<AccumInfo> {
         flatten_vector_info(unsafe { (&*self.vector_info.get()).as_deref() })
+    }
+}
+
+#[cfg(test)]
+mod register_keyed_size_authority_tests {
+    use super::*;
+
+    fn size_descr(type_id: u32, vtable: usize, nfields: usize) -> DescrRef {
+        let mut sd = SimpleSizeDescr::with_vtable(u32::MAX, 32, type_id, vtable);
+        let fields: Vec<Arc<dyn FieldDescr>> = (0..nfields)
+            .map(|i| {
+                Arc::new(SimpleFieldDescr::new_with_name(
+                    i as u32,
+                    i * 8,
+                    8,
+                    Type::Int,
+                    false,
+                    ArrayFlag::Signed,
+                    format!("f{i}"),
+                    format!("f{i}"),
+                )) as Arc<dyn FieldDescr>
+            })
+            .collect();
+        sd = sd.with_all_fielddescrs(fields);
+        Arc::new(sd) as DescrRef
+    }
+
+    /// The analyzer-side producer reports MORE fields (it includes the
+    /// inherited header) and NO vtable. Field count alone would let it evict
+    /// the runtime publish, which holds the only copy of the vtable
+    /// `new_with_vtable`'s typeptr store needs.
+    #[test]
+    fn a_vtable_less_producer_never_displaces_a_vtable_bearing_one() {
+        let mut gc = GcCache::new();
+        let key = LLType::Struct(0x8463ec159694d229);
+        gc.register_keyed_size(key.clone(), size_descr(7, 0x1000, 1));
+        gc.register_keyed_size(key.clone(), size_descr(0x9694d229, 0, 3));
+        let cached = gc._cache_size.get(&key).unwrap().as_size_descr().unwrap();
+        assert_eq!(cached.type_id(), 7, "the real gc tid must survive");
+        assert_ne!(cached.vtable(), 0, "the vtable must survive");
+    }
+
+    /// The upgrade rule itself is unchanged when both sides carry a vtable.
+    #[test]
+    fn a_fuller_layout_still_upgrades_when_both_carry_a_vtable() {
+        let mut gc = GcCache::new();
+        let key = LLType::Struct(11);
+        gc.register_keyed_size(key.clone(), size_descr(7, 0x1000, 1));
+        gc.register_keyed_size(key.clone(), size_descr(9, 0x2000, 3));
+        let cached = gc._cache_size.get(&key).unwrap().as_size_descr().unwrap();
+        assert_eq!(cached.type_id(), 9);
+        assert_eq!(cached.all_fielddescrs().len(), 3);
     }
 }
 

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -4398,6 +4398,9 @@ pub struct SetMemberLedger {
     /// exactly like a container this process never traced.
     pub absent: std::collections::BTreeSet<String>,
     pub ambiguous: std::collections::BTreeSet<String>,
+    /// The dropped members themselves, so
+    /// [`stale_absent_containers`] can ask the question again later.
+    absent_members: Vec<majit_ir::effectinfo::DescrSetMember>,
 }
 
 static SET_MEMBER_LEDGER: LazyLock<Mutex<SetMemberLedger>> =
@@ -4423,7 +4426,9 @@ fn record_set_member_lookup(m: &majit_ir::effectinfo::DescrSetMember, out: &SetM
         SetMemberLookup::Resolved(_) => ledger.resolved += 1,
         SetMemberLookup::AbsentContainer => {
             let label = set_member_label(m);
-            ledger.absent.insert(label);
+            if ledger.absent.insert(label) {
+                ledger.absent_members.push(m.clone());
+            }
         }
         SetMemberLookup::Ambiguous => {
             let label = set_member_label(m);
@@ -4439,7 +4444,31 @@ pub fn set_member_ledger() -> SetMemberLedger {
         resolved: ledger.resolved,
         absent: ledger.absent.clone(),
         ambiguous: ledger.ambiguous.clone(),
+        absent_members: Vec::new(),
     }
+}
+
+/// Re-ask the [`SetMemberLookup::AbsentContainer`] question against the
+/// universe as it stands *now*, and return the members that have since become
+/// reachable.
+///
+/// Every entry is a live instance of the gap documented on that variant: the
+/// member was dropped from its raw set when the `BhCallDescr` was
+/// materialised, the container was registered afterwards, and the frozen
+/// `EffectInfo` still claims the callee does not touch it. Upstream cannot
+/// reach this state — `effectinfo.py` builds its sets through
+/// `cpu.fielddescrof` / `cpu.arraydescrof` in the same process that owns the
+/// descr cache, so the container is always registered by construction.
+///
+/// An empty result is the evidence that the gap is not being hit; a non-empty
+/// one names exactly which containers to publish eagerly next.
+pub fn stale_absent_containers() -> Vec<String> {
+    let members = SET_MEMBER_LEDGER.lock().unwrap().absent_members.clone();
+    members
+        .iter()
+        .filter(|m| !matches!(descr_from_set_member(m), SetMemberLookup::AbsentContainer))
+        .map(set_member_label)
+        .collect()
 }
 
 fn descr_from_set_member(m: &majit_ir::effectinfo::DescrSetMember) -> SetMemberLookup {

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -4279,8 +4279,14 @@ enum SetMemberLookup {
     /// runtime universe keeps growing after that.  A container registered
     /// later — under the same `path_hash` key — leaves this EI permanently
     /// claiming "not written" for a field the callee does write, so the
-    /// heapcache would not invalidate a read across the call.  No corpus
-    /// fixture reproduces it today.
+    /// heapcache would not invalidate a read across the call.
+    ///
+    /// `publish_runtime_descr_groups` closes the gap for the module-scope
+    /// groups by forcing all of them before the first lookup;
+    /// `W_IntObject.intval` was landing here until it did.  What is still
+    /// published on demand, and so can still fall into this arm: the
+    /// per-exception-class groups behind `W_BASE_EXCEPTION_DESCR_CACHE`, and
+    /// the `ARRAY_DESCR_REGISTRY` entries minted per element layout.
     ///
     /// The conservative repair (treat this like [`Self::Ambiguous`] and
     /// degrade the EI to `EF_RANDOM_EFFECTS`) is not taken here: a probe over
@@ -4314,6 +4320,128 @@ enum SetMemberLookup {
 /// objects — breaking the positional invariant `heaptracker.py:76-101
 /// get_fielddescr_index_in` establishes and `optimizeopt/info.rs force_box`
 /// asserts.
+/// Ledger of every serialized raw-set member that came back
+/// [`SetMemberLookup::Ambiguous`] — its container *is* published in this
+/// process's descr universe, just not under the key the analyzer minted
+/// through.
+///
+/// `Ambiguous` is the two-spellings defect by construction, and it is the only
+/// one of the three outcomes that is never a legitimate projection:
+/// `Resolved` joined, `AbsentContainer` means the runtime never named the
+/// container at all (the analyzer walks the whole translated program, the
+/// runtime only registers what it actually traces), but `Ambiguous` means both
+/// sides named the same container and disagreed on how to spell it.  Its
+/// consumer degrades the whole `EffectInfo` to `EF_RANDOM_EFFECTS`, so every
+/// entry below is a residual call that stopped invalidating precisely and
+/// became a whole-heap barrier.
+///
+/// This is the gate for struct-identity work; a converged-field-descr count is
+/// not.  A field-descr census only counts the descrs a particular run happens
+/// to mint, so deleting a call site greens it without joining anything,
+/// whereas the members here are fixed by `descrs.bin` and stay `Ambiguous`
+/// until the two spellings actually collapse onto one key.
+/// Force every module-scope runtime descr group into the gccache.
+///
+/// `descr.py:25-47 setup_descrs` publishes the whole descr universe before
+/// anything consumes it, and upstream gets that for free: `cpu.*descrof` runs
+/// during codewriting, so by the time `compute_bitstrings`
+/// (`effectinfo.py:484-489`) walks the raw sets, every `STRUCT` the program
+/// mentions already has its slot.  Pyre splits those two phases across a
+/// build-time analyzer and a runtime process, and the runtime groups are
+/// `LazyLock`s that publish only when a trace first touches the type — so the
+/// raw-set members were being resolved against a universe that was still
+/// mostly empty, and answered [`SetMemberLookup::AbsentContainer`] for
+/// containers this process does register, just later.
+///
+/// Publishing here restores the upstream order.  It must run *before* the
+/// build-time `make_descr_from_bh` loop: those specs carry `vtable: 0` and the
+/// inherited header fields, so on a shared key they would otherwise displace
+/// the runtime publish that owns the only copy of the vtable (see the
+/// authority rule in `majit-ir` `register_keyed_size`).
+pub(crate) fn publish_runtime_descr_groups() {
+    // `PyreObjectDescrGroup`'s constructor is what registers into the
+    // gccache, so dereferencing the `LazyLock` is the publish.
+    let _published = [
+        &*W_INT_DESCR_GROUP,
+        &*W_FLOAT_DESCR_GROUP,
+        &*W_LONG_DESCR_GROUP,
+        &*W_BOOL_DESCR_GROUP,
+        &*RANGE_ITER_DESCR_GROUP,
+        &*RANGE_DESCR_GROUP,
+        &*W_METHOD_DESCR_GROUP,
+        &*W_OBJECT_MUTABLE_CELL_DESCR_GROUP,
+        &*W_LIST_DESCR_GROUP,
+        &*W_TUPLE_DESCR_GROUP,
+        &*SPECIALISED_TUPLE_II_DESCR_GROUP,
+        &*SPECIALISED_TUPLE_FF_DESCR_GROUP,
+        &*SPECIALISED_TUPLE_OO_DESCR_GROUP,
+        &*ITEMS_BLOCK_DESCR_GROUP,
+        &*W_SLICE_DESCR_GROUP,
+        &*PYFRAME_DESCR_GROUP,
+        &*W_OBJECT_OBJECT_DESCR_GROUP,
+        &*PYTRACEBACK_DESCR_GROUP,
+    ];
+}
+
+/// `ambiguous` empty alone is not enough to call the gate green: a member
+/// whose container is not registered *yet* answers `AbsentContainer`, which
+/// looks identical to the legitimate projection.  So the ledger carries all
+/// three outcomes — a run where `absent` dwarfs `resolved` has an empty
+/// `ambiguous` set vacuously, because nothing was ever joined.
+#[derive(Default)]
+pub struct SetMemberLedger {
+    pub resolved: usize,
+    /// Container keys no lookup could reach, by name.  Kept as a set rather
+    /// than a count because a spelling miss hides here too: a container the
+    /// runtime *did* publish, under a different key, is absent from both
+    /// `_cache_field` and `_cache_size` at the analyzer's key and so reads
+    /// exactly like a container this process never traced.
+    pub absent: std::collections::BTreeSet<String>,
+    pub ambiguous: std::collections::BTreeSet<String>,
+}
+
+static SET_MEMBER_LEDGER: LazyLock<Mutex<SetMemberLedger>> =
+    LazyLock::new(|| Mutex::new(SetMemberLedger::default()));
+
+fn set_member_label(m: &majit_ir::effectinfo::DescrSetMember) -> String {
+    use majit_ir::effectinfo::DescrSetMember;
+    match m {
+        DescrSetMember::Field {
+            struct_id,
+            field_name,
+        } => format!("Struct({struct_id:#018x}).{field_name}"),
+        DescrSetMember::Array { array_id } => format!("Array({array_id:#018x})"),
+        DescrSetMember::InteriorField { array_id, name } => {
+            format!("Array({array_id:#018x}).{name}")
+        }
+    }
+}
+
+fn record_set_member_lookup(m: &majit_ir::effectinfo::DescrSetMember, out: &SetMemberLookup) {
+    let mut ledger = SET_MEMBER_LEDGER.lock().unwrap();
+    match out {
+        SetMemberLookup::Resolved(_) => ledger.resolved += 1,
+        SetMemberLookup::AbsentContainer => {
+            let label = set_member_label(m);
+            ledger.absent.insert(label);
+        }
+        SetMemberLookup::Ambiguous => {
+            let label = set_member_label(m);
+            ledger.ambiguous.insert(label);
+        }
+    }
+}
+
+/// Snapshot of the [`SET_MEMBER_LEDGER`].
+pub fn set_member_ledger() -> SetMemberLedger {
+    let ledger = SET_MEMBER_LEDGER.lock().unwrap();
+    SetMemberLedger {
+        resolved: ledger.resolved,
+        absent: ledger.absent.clone(),
+        ambiguous: ledger.ambiguous.clone(),
+    }
+}
+
 fn descr_from_set_member(m: &majit_ir::effectinfo::DescrSetMember) -> SetMemberLookup {
     use majit_ir::descr::{LLType, gc_cache};
 
@@ -4415,7 +4543,9 @@ pub fn rehydrate_effect_info(ei: &mut majit_ir::EffectInfo) {
     let resolve = |members: &[majit_ir::effectinfo::DescrSetMember]| {
         let mut out = Vec::with_capacity(members.len());
         for m in members {
-            match descr_from_set_member(m) {
+            let looked_up = descr_from_set_member(m);
+            record_set_member_lookup(m, &looked_up);
+            match looked_up {
                 SetMemberLookup::Resolved(d) => out.push(d),
                 SetMemberLookup::AbsentContainer => {}
                 SetMemberLookup::Ambiguous => return None,

--- a/pyre/pyre-jit-trace/src/jitcode_runtime.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_runtime.rs
@@ -474,6 +474,11 @@ fn rehydrated_call_descr_ref(bh: &majit_translate::jitcode::BhCallDescr) -> maji
 pub fn rehydrate_build_descr_raw_sets() {
     static ONCE: Once = Once::new();
     ONCE.call_once(|| {
+        // The runtime's own groups first: `descr_from_set_member` is
+        // lookup-only, so a container that has not been published yet reads
+        // as `AbsentContainer` and its member is dropped from the raw set for
+        // the life of the process.
+        crate::descr::publish_runtime_descr_groups();
         let all = all_descrs();
         // `descr.py:25-47 setup_descrs` group order — every non-call slot
         // first.  Each `Size` / `Field` entry publishes its parent's FULL
@@ -496,7 +501,34 @@ pub fn rehydrate_build_descr_raw_sets() {
             refs[i] = Some(rehydrated_call_descr_ref(calldescr));
         }
         *REHYDRATED_CALL_DESCR_REFS.lock().unwrap() = refs;
+        report_descr_spelling_gate();
     });
+}
+
+/// Print the [`crate::descr::set_member_ledger`] under
+/// `PYRE_DESCR_SPELLING_GATE=1`.
+///
+/// The whole serialized raw-set universe is resolved inside the `Once` above
+/// and nowhere else, so this runs exactly once with the ledger complete.
+/// Green is `ambiguous=0` **with** a `resolved` count that shows the join
+/// actually happened; `ambiguous=0, resolved=0` is vacuous.
+fn report_descr_spelling_gate() {
+    if std::env::var_os("PYRE_DESCR_SPELLING_GATE").is_none() {
+        return;
+    }
+    let ledger = crate::descr::set_member_ledger();
+    eprintln!(
+        "[descr-spelling-gate] resolved={} absent={} ambiguous={}",
+        ledger.resolved,
+        ledger.absent.len(),
+        ledger.ambiguous.len()
+    );
+    for label in &ledger.ambiguous {
+        eprintln!("[descr-spelling-gate] ambiguous {label}");
+    }
+    for label in &ledger.absent {
+        eprintln!("[descr-spelling-gate] absent {label}");
+    }
 }
 
 /// Pool of `DescrRef`s indexed alongside [`all_descrs`] so the

--- a/pyre/pyre-jit-trace/src/jitcode_runtime.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_runtime.rs
@@ -531,6 +531,23 @@ fn report_descr_spelling_gate() {
     }
 }
 
+/// Re-ask the `AbsentContainer` question once the run is over, and report
+/// every member whose container has since been registered.
+///
+/// Called from the same post-`real_main` hook as
+/// [`field_descr_identity_census_now`], so it sees the fully grown universe
+/// rather than the one the `Once` above resolved against. Each entry is a live
+/// instance of the gap documented on `SetMemberLookup::AbsentContainer`: an
+/// `EffectInfo` frozen while its container was unregistered still claims the
+/// callee does not touch it.
+pub fn descr_spelling_gate_recheck_now() {
+    let stale = crate::descr::stale_absent_containers();
+    eprintln!("[descr-spelling-gate] stale_absent={}", stale.len());
+    for label in &stale {
+        eprintln!("[descr-spelling-gate] stale_absent {label}");
+    }
+}
+
 /// Pool of `DescrRef`s indexed alongside [`all_descrs`] so the
 /// trace-side jitcode walker
 /// ([`crate::jitcode_dispatch::dispatch_via_miframe`]) can resolve each

--- a/pyre/pyre-jit/src/lib.rs
+++ b/pyre/pyre-jit/src/lib.rs
@@ -54,7 +54,9 @@ pub mod jit;
 mod trace_verify;
 
 // Re-export auto-generated trace functions from pyre-jit-trace
-pub use pyre_jit_trace::jitcode_runtime::field_descr_identity_census_now;
+pub use pyre_jit_trace::jitcode_runtime::{
+    descr_spelling_gate_recheck_now, field_descr_identity_census_now,
+};
 pub use pyre_jit_trace::{
     trace_box_float, trace_box_int, trace_float_binop, trace_float_compare, trace_int_binop,
     trace_int_binop_ovf, trace_int_compare, trace_unbox_float, trace_unbox_int,

--- a/pyre/pyrex/src/lib.rs
+++ b/pyre/pyrex/src/lib.rs
@@ -519,6 +519,9 @@ pub fn main_entry(binary_name: &'static str) {
                 if std::env::var_os("PYRE_FIELD_IDENTITY_CENSUS").is_some() {
                     pyre_jit::field_descr_identity_census_now();
                 }
+                if std::env::var_os("PYRE_DESCR_SPELLING_GATE").is_some() {
+                    pyre_jit::descr_spelling_gate_recheck_now();
+                }
             })
             .expect("spawn main thread")
             .join()


### PR DESCRIPTION
## The gate

Struct-identity work needs a gate that cannot be greened without actually
joining two spellings. The field-descr identity census is not one: it counts
only the descrs a particular run happens to mint, so deleting a call site
greens it while nothing converges.

The serialized raw-set universe is. `descr_from_set_member` looks every member
of `descrs.bin`'s `DescrSetKeys` back up in the runtime gccache, and its three
outcomes are exactly the three states of the identity question:

| outcome | meaning |
|---|---|
| `Resolved` | the analyzer's key and the runtime's publish agree |
| `Ambiguous` | container published, **not** under this member's key — the two-spellings defect by construction |
| `AbsentContainer` | nothing in this process ever named the container |

`Ambiguous` degrades the whole `EffectInfo` to `EF_RANDOM_EFFECTS`, so each one
is a residual call that stopped invalidating precisely.

**`ambiguous == 0` alone is not the gate.** A container the runtime publishes
under a *different* key is missing from both `_cache_field` and `_cache_size`
at the analyzer's key, so it reads exactly like a container this process never
traced — the defect hides in `AbsentContainer`. So the ledger reports all
three, `absent` by name, and the gate is: `ambiguous == 0` **and** no `absent`
container key is a spelling of a group the runtime does publish.

`PYRE_DESCR_SPELLING_GATE=1` prints it.

## Reading on this base

```
[descr-spelling-gate] resolved=88 absent=58 ambiguous=0
```

Identical on `int_loop`, `fannkuch`, `nbody`.

Intersecting the 58 `absent` container keys against `path_hash` of all three
spellings (simple / crate-relative / crate-qualified) of the 18 published
groups: **empty**. The same intersection against the `resolved` container keys
is non-empty — `intobject::W_IntObject`, `listobject::W_ListObject`,
`pyframe::PyFrame` — so the join is real, not vacuous, and the analyzer and
the runtime already agree on the crate-relative spelling for the containers
that carry raw-set members. The 58 absent are containers the runtime has no
group for at all: `W_TypeObject` (`mro_w`, `version_tag`), `PyCode`
(`arg_count`, `varnames`, `cellvars`), the dict/map storages, the rclass
`OBJECT_VTABLE` (`instantiate`, `subclassrange_min/max`), thread state.

**The gate is green.** The 9 field-descr identity misses on `W_ListObject`
that opened this task are therefore latent: they cost no `EffectInfo`
precision today.

## What landed

**`majit-ir`: authority in `register_keyed_size`.** The cached `SizeDescr` was
upgraded whenever the incoming frozen field list was longer. Measuring the
colliding keys shows the analyzer-side list is longer by exactly the header
words at offsets 0 and 8 — and `heaptracker.py:60-71 all_fielddescrs`, the list
`descr.py:125-126` assigns onto the cached descr, skips `typeptr` and `c__pad*`
outright while the GC header is not part of the lltype STRUCT at all. Upstream's
positional list is the header-free one, which is what the runtime groups build,
so "more fields" is not "closer to upstream". The vtable is the reliable
discriminator — only the runtime publish has one, and losing it is separately
fatal, since `new_with_vtable` skips its typeptr store when `vtable == 0` and
the fresh object reads back with a null `ob_type` over zeroed nursery memory.
Now a `vtable == 0` descr never displaces a vtable-bearing one; among descrs
that both carry one, the longer list still wins. Two tests, built at the
measured offsets.

**`pyre-jit-trace`: publish the runtime groups before resolving raw-set
members.** The 18 module-scope `PyreObjectDescrGroup` statics published lazily,
on first trace touch — after the `Once` that resolves the raw sets. Anything
not yet published answered `AbsentContainer` and was dropped from its set for
the life of the process; that is the KNOWN GAP already documented on the
variant. Forcing all 18 first restores the order upstream gets for free
(`cpu.*descrof` during codewriting, universe complete before
`compute_bitstrings`). On the current `descrs.bin` it recovers exactly one
member: `intobject::W_IntObject.intval` in `readonly_descrs_fields`. This is
also why the vtable guard has to land with it — publishing runtime-first puts
the `vtable: 0` analyzer specs on the displacing side.

**`pyre-jit-trace`: measure the `AbsentContainer` staleness gap.** The variant's
doc said a container registered after the `BhCallDescr` is materialised leaves
the frozen `EffectInfo` claiming the callee does not touch it, "no corpus
fixture reproduces it today" — an assertion, never a measurement. The ledger now
retains the dropped members and re-asks the lookup against the grown universe at
the post-`real_main` hook. Over `pyre/bench` + `pyre/bench/synth`, 337 scripts,
dynasm: 330 reach the hook and every one reports `stale_absent=0`.

## What did not land

The identity rewrite behind task #12 (`assembler.rs:3208`
`type_id: path_hash(owner)` → a canonicalized struct key). Both one-site
variants segfault identically — `EXC_BAD_ACCESS address=0x0` in
`py_str_wtf8`, all 5 JIT benches — and with the gate green there is no live
defect motivating it. It stays open as a latent-identity cleanup, now with a
gate that will show when it starts costing something.

## Verification

- `check.py --backend dynasm,cranelift`: **6 failed / 326 passed** per backend.
  Same 6 test names as the pre-change baseline at this base (`except_star`,
  `exception_group_type`, `exception_subclass_attrs`,
  `getframe_force_cancel_journal`, `slots_class_var_conflict`,
  `unpack_drain_star_raise`) — all pre-existing, `jd1 drain body must contain a
  jit_merge_point` / wrong output, unrelated to descr registration.
  One cranelift run additionally reported `synth/const_arg_call_resume  exec
  0.16s > pypy 0.01s  ratio 31.3x > gate 30x`; the same binary passes it on
  re-run and the script's own user CPU is 0.19s across 5 rounds, so that is the
  known perf-gate boundary flake.
- `cargo test -p majit-ir register_keyed_size_authority`: 2 passed.
- `cargo fmt --check`: clean.
- Codex parity review §1 verified then reclassified, §3 measured rather than
  deferred — see the adjudication comment.
