### PR TITLE
jit: two codewriter parity fixes — constant-pool operand bound, effectinfo readonly subtraction order

### DIFF
--- a/majit/majit-translate/src/codewriter/assembler.rs
+++ b/majit/majit-translate/src/codewriter/assembler.rs
@@ -539,6 +539,15 @@ impl Assembler {
             });
         }
 
+        // RPython assembler.py:46 `self.check_result()`, :265-269 —
+        // the single-byte operand encoding addresses registers and
+        // constants of one kind in one space, so their sum is what the
+        // byte has to hold.
+        check_result(
+            (num_regs_i, state.constants_i.len()),
+            (num_regs_r, state.constants_r.len()),
+            (num_regs_f, state.constants_f.len()),
+        );
         // RPython assembler.py:271-281: jitcode.setup(code, ...)
         // Build the body that the codewriter will commit into the
         // pre-allocated `Arc<JitCode>` shell via `set_body`.
@@ -2787,12 +2796,12 @@ impl Assembler {
         // Check if already in pool
         for (i, &existing) in state.constants_i.iter().enumerate() {
             if existing == value {
-                return (state.num_regs_i + i) as u8;
+                return const_pool_slot(state.num_regs_i, i);
             }
         }
         // Add to pool: index = num_regs + pool_position
         state.constants_i.push(value);
-        (state.num_regs_i + state.constants_i.len() - 1) as u8
+        const_pool_slot(state.num_regs_i, state.constants_i.len() - 1)
     }
 
     /// `assembler.py:99-107` — the `allow_short` branch of `emit_const`.
@@ -2886,10 +2895,10 @@ impl Assembler {
             .iter()
             .position(|&existing| existing == bits)
         {
-            return (state.num_regs_r + index) as u8;
+            return const_pool_slot(state.num_regs_r, index);
         }
         state.constants_r.push(bits);
-        (state.num_regs_r + state.constants_r.len() - 1) as u8
+        const_pool_slot(state.num_regs_r, state.constants_r.len() - 1)
     }
 
     fn emit_const_f(&mut self, value: &ConstValue, state: &mut AssemblyState) -> u8 {
@@ -2902,10 +2911,35 @@ impl Assembler {
             .iter()
             .position(|&existing| existing == bits)
         {
-            return (state.num_regs_f + index) as u8;
+            return const_pool_slot(state.num_regs_f, index);
         }
         state.constants_f.push(bits);
-        (state.num_regs_f + state.constants_f.len() - 1) as u8
+        const_pool_slot(state.num_regs_f, state.constants_f.len() - 1)
+    }
+}
+
+/// Operand byte of a constant-pool entry: `count_regs[kind] +
+/// pool_index` (`assembler.py:132`).  Registers and constants of one
+/// kind share a single byte-wide address space, so the slot is bounded
+/// by `assembler.py:133 assert 0 <= val < 256, "too many constants"`.
+/// Without the bound a wider pool wraps modulo 256 and silently aliases
+/// a live register or an earlier constant.
+fn const_pool_slot(num_regs: usize, pool_index: usize) -> u8 {
+    let val = num_regs + pool_index;
+    assert!(val < 256, "too many constants");
+    val as u8
+}
+
+/// `assembler.py:265-269 check_result()` — "Limitation of the number of
+/// registers, from the single-byte encoding".  Each pair is
+/// `(count_regs[kind], len(constants_kind))`.
+fn check_result(int: (usize, usize), reference: (usize, usize), float: (usize, usize)) {
+    for (kind, (num_regs, num_consts)) in [("int", int), ("ref", reference), ("float", float)] {
+        assert!(
+            num_regs + num_consts <= 256,
+            "too many {kind} registers and constants \
+             ({num_regs} + {num_consts} > 256)"
+        );
     }
 }
 

--- a/majit/majit-translate/src/codewriter/call.rs
+++ b/majit/majit-translate/src/codewriter/call.rs
@@ -5939,6 +5939,28 @@ pub fn effectinfo_from_writeanalyze(
     write_descrs_interiorfields.sort_unstable();
     write_descrs_interiorfields.dedup();
 
+    // The `read \ write` exclusion sets are captured HERE, before the
+    // elidable/loop-invariant write blanking below, because
+    // `effectinfo_from_writeanalyze` runs its `tupw not in effects`
+    // subtraction against the full effects tuple (effectinfo.py:345-360)
+    // and only afterwards does `EffectInfo.__new__` blank the write sets
+    // (effectinfo.py:169-181).  Reading them after the blanking would
+    // make the subtraction a no-op and route a descr that is both read
+    // and written into `_readonly_descrs_*`, where upstream puts it in
+    // neither set.
+    let field_write_ptr_set: std::collections::HashSet<*const ()> = field_write_descrs
+        .iter()
+        .map(|d| std::sync::Arc::as_ptr(&d.0).cast::<()>())
+        .collect();
+    let interior_write_ptr_set: std::collections::HashSet<*const ()> = interior_write_descrs
+        .iter()
+        .map(|d| std::sync::Arc::as_ptr(&d.0).cast::<()>())
+        .collect();
+    let array_write_ptr_set: std::collections::HashSet<*const ()> = array_write_descrs
+        .iter()
+        .map(|d| std::sync::Arc::as_ptr(&d.0).cast::<()>())
+        .collect();
+
     // effectinfo.py:169-181: for elidable/loopinvariant, ignore writes.
     if matches!(
         extraeffect,
@@ -6034,26 +6056,14 @@ pub fn effectinfo_from_writeanalyze(
     // sharing a `descr.index()` due to side-table collisions remain
     // distinct under pointer equality, matching PyPy's tuple-identity
     // membership test.
-    let field_write_ptr_set: std::collections::HashSet<*const ()> = field_write_descrs
-        .iter()
-        .map(|d| std::sync::Arc::as_ptr(&d.0).cast::<()>())
-        .collect();
     let read_fields_canon =
         canonicalize_keyed_descrs(field_read_descrs_raw, Some(&field_write_ptr_set));
     let write_fields_canon = canonicalize_keyed_descrs(field_write_descrs, None);
     // Same `read \ write` subtract for interiorfield + array (PyPy
     // `effectinfo.py:351-360`), again by Arc identity.
-    let interior_write_ptr_set: std::collections::HashSet<*const ()> = interior_write_descrs
-        .iter()
-        .map(|d| std::sync::Arc::as_ptr(&d.0).cast::<()>())
-        .collect();
     let read_interior_canon =
         canonicalize_keyed_descrs(interior_read_descrs_raw, Some(&interior_write_ptr_set));
     let write_interior_canon = canonicalize_keyed_descrs(interior_write_descrs, None);
-    let array_write_ptr_set: std::collections::HashSet<*const ()> = array_write_descrs_snapshot
-        .iter()
-        .map(|d| std::sync::Arc::as_ptr(&d.0).cast::<()>())
-        .collect();
     let read_arrays_canon =
         canonicalize_keyed_descrs(array_read_descrs_raw, Some(&array_write_ptr_set));
     let write_arrays_canon = canonicalize_keyed_descrs(array_write_descrs_snapshot, None);
@@ -8646,6 +8656,88 @@ mod tests {
             .as_ref()
             .expect("elidable getcalldescr populates write_descrs_fields");
         assert!(writes.is_empty());
+    }
+
+    #[test]
+    fn elidable_read_and_written_field_lands_in_neither_descr_set() {
+        // `effectinfo_from_writeanalyze` subtracts `read \ write` against
+        // the full effects tuple (effectinfo.py:345-360) and only then does
+        // `EffectInfo.__new__` blank the writes (effectinfo.py:169-181), so a
+        // field that is both read and written by an elidable graph ends up in
+        // NEITHER `_readonly_descrs_fields` nor `_write_descrs_fields`.
+        let mut cc = CallControl::new();
+        // `fielddescrof_concrete` returns None for an unregistered struct,
+        // which would leave the descr sets empty and make the assertions
+        // below vacuous.
+        cc.struct_fields.fields.insert(
+            "Cache".to_string(),
+            vec![("slot".to_string(), "i64".to_string())],
+        );
+        let mut graph = FunctionGraph::new("pure_cache");
+        let base_var = graph.alloc_value_var();
+        graph.push_op_var(
+            graph.startblock,
+            OpKind::FieldRead {
+                base: base_var.clone(),
+                field: crate::model::FieldDescriptor::new("slot", Some("Cache".into())),
+                ty: ValueType::Int,
+                pure: false,
+            },
+            true,
+        );
+        graph.push_op_var(
+            graph.startblock,
+            OpKind::FieldWrite {
+                base: base_var.clone(),
+                field: crate::model::FieldDescriptor::new("slot", Some("Cache".into())),
+                value: crate::model::LinkArg::Value(base_var),
+                ty: ValueType::Int,
+            },
+            false,
+        );
+        graph.set_return(graph.startblock, None);
+        let path = CallPath::from_segments(["pure_cache"]);
+        register_int_result_graph(&mut cc, path.clone(), graph);
+        cc.mark_elidable(path);
+        cc.find_all_graphs_for_tests();
+
+        let mut cache = AnalysisCache::default();
+        let descriptor = cc.getcalldescr(
+            &direct_call_op(CallTarget::function_path(["pure_cache"])),
+            Vec::new(),
+            Type::Int,
+            OopSpecIndex::None,
+            None,
+            &mut cache,
+            None,
+        );
+        assert_eq!(
+            descriptor.extra_info.extraeffect,
+            ExtraEffect::ElidableCannotRaise
+        );
+        // The write blanking must not resurrect the descr as read-only:
+        // reading the exclusion set after the blanking would make the
+        // subtraction a no-op and leave `slot` in `_readonly_descrs_fields`.
+        assert_eq!(
+            descriptor
+                .extra_info
+                ._readonly_descrs_fields
+                .as_deref()
+                .unwrap_or_default()
+                .len(),
+            0,
+            "a read-and-written field must not become read-only when the \
+             elidable write blanking runs",
+        );
+        assert_eq!(
+            descriptor
+                .extra_info
+                ._write_descrs_fields
+                .as_deref()
+                .unwrap_or_default()
+                .len(),
+            0,
+        );
     }
 
     #[test]


### PR DESCRIPTION
Two independent parity defects found by an exhaustive sweep of the codewriter port (`majit-translate/src/codewriter/*.rs` vs `rpython/jit/codewriter/*.py`). 17 candidates were adversarially verified; these are the two that survived and are safe to land.

## 1. Constant-pool operand byte had no 256 bound

`emit_const_i` / `emit_const_r_bits` / `emit_const_f` computed the operand byte as `num_regs + pool_index` and narrowed it with `as u8`, which wraps silently. Registers and constants of one kind share a single byte-wide address space, so a wrapped slot aliases a live register — `MIFrame::copy_constants` and the blackhole both place constants at flat slot `num_regs + i`, so an operand byte of 0 reads register 0 instead of the constant.

Upstream bounds this twice and neither was ported:

- `assembler.py:133` — `assert 0 <= val < 256, "too many constants"` at each pool insertion
- `assembler.py:265-269` `check_result()`, called from `:46`

The `num_regs_* < 256` assert that was already present is `jitcode.py:36` — a strictly weaker invariant on a different quantity.

Both runtime builders already carry the bound (`JitCodeBuilder::patch_const_u8_refs`, `pyre-jit`'s own `check_result`); only the build-time port dropped it, so this is drift between the duplicated encoders rather than a design choice.

Peak in the current corpus is 96 (`object_setattr`, 33 regs + 63 int constants), so no jitcode trips the bound today. What this restores is the upstream translation-time abort — previously the failure mode would have been a silently mis-encoded operand instead of a loud failure.

## 2. effectinfo: elidable write blanking ran before the readonly subtraction

`effectinfo_from_writeanalyze` built the three `read \ write` exclusion sets from `field_write_descrs` / `interior_write_descrs` / `array_write_descrs` **after** the elidable/loop-invariant branch had cleared them, so the subtraction was a no-op and a descr that is both read and written landed in `_readonly_descrs_fields`.

Upstream runs the `tupw not in effects` subtraction against the full effects tuple (`effectinfo.py:345-360`) and blanks the write sets only afterwards, in `EffectInfo.__new__` (`effectinfo.py:169-181`), so such a descr ends up in **neither** set. Fix is to hoist the three exclusion sets above the clear.

The function was internally inconsistent about this: the index-based `readonly_descrs_fields` computed at the top of the function was already correct (pre-clear), and disagreed with the Arc-keyed set built later. `compute_bitstrings` recomputes the bitstring from the Arc set, so the wrong one won.

Direction is conservative (an extra `SETFIELD_GC` force, lost store sinking), so no wrong results — but it is a real divergence in the emitted trace.

### Test

`elidable_read_and_written_field_lands_in_neither_descr_set` fails without the hoist and passes with it. Note it must register the struct layout in `cc.struct_fields`: `fielddescrof_concrete` returns `None` for an unregistered struct, which leaves the descr sets empty and makes the assertions vacuous.

## Verification

- `cargo test -p majit-translate --lib` — 3028 passed, 0 failed
- `cargo check -p majit-metainterp -p pyre-jit` clean
- release `pyre-dynasm` builds and smoke-tests clean; the new assert does not fire on the corpus
- The corpus perf gate was **not** run locally: the box was at load 99–179 with sibling worktree builds, and `check.py`'s own rebuild was SIGTERMed twice. Relying on CI for it.

## Note on the current CI red

`pyre/check.py (ubuntu-24.04)` is already failing on `main` itself (run 30378431710, `b8a00beb9`) on `int_loop` / cranelift at 2.0x against the 2x gate. pyre's absolute time there is unchanged across recent runs (0.71s / 0.80s / 0.72s / 0.79s, all previously passing) — the ratio crossed because pypy got faster on that runner. dynasm passes the same bench comfortably (1.38x locally), so this is the standing cranelift backend codegen gap sitting on the gate boundary, not something introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)