### PR TITLE
_ast: read the required fields an object carries, and narrow the literal-pattern shapes

### DIFF
--- a/pyre/bench/synth/ast_compile_roundtrip.py
+++ b/pyre/bench/synth/ast_compile_roundtrip.py
@@ -147,6 +147,12 @@ def handbuilt():
         kw_defaults=kw.get("kd", []), defaults=kw.get("d", []))
     pat = lambda p: ast.Match(subject=ast.Constant(1),
                               cases=[ast.match_case(pattern=p, body=[ast.Pass()])])
+    RANGE = {"lineno": 1, "col_offset": 0, "end_lineno": 1, "end_col_offset": 1}
+
+    class Index:
+        # An integer field is not asked for `__index__`.
+        def __index__(self):
+            return 1
 
     for label, node in (
         ("missing-conversion", ast.JoinedStr(values=[
@@ -214,11 +220,51 @@ def handbuilt():
         ("match-mapping-store-key", ast.Module(body=[pat(ast.MatchMapping(
             keys=[ast.Attribute(value=ast.Name("o", S), attr="a", ctx=ast.Load())],
             patterns=[ast.MatchAs(pattern=None, name="v")], rest=None))], type_ignores=[])),
+        ("type-ignores-not-a-list", ast.Module(body=[ast.Pass()], type_ignores=42)),
+        ("type-ignores-bad-element", ast.Module(body=[ast.Pass()], type_ignores=[1])),
+        ("lineno-not-an-int", ast.Module(body=[ast.Pass(lineno=Index(), col_offset=0)],
+                                         type_ignores=[])),
+        ("constant-kind-not-str", ast.Constant(value="a", kind=1)),
+        ("expr-context-not-a-node", ast.Name("x", 1)),
+        ("boolop-not-a-node", ast.BoolOp(op=1, values=[ast.Constant(1), ast.Constant(2)])),
+        ("operator-not-a-node", ast.BinOp(left=ast.Constant(1), op=1, right=ast.Constant(2))),
+        ("unaryop-not-a-node", ast.UnaryOp(op=1, operand=ast.Constant(1))),
+        ("cmpop-not-a-node", ast.Compare(left=ast.Constant(1), ops=[1],
+                                         comparators=[ast.Constant(2)])),
     ):
         tree = node if isinstance(node, ast.Module) else ast.Expression(body=node)
         try:
             ast.fix_missing_locations(tree)
             compile(tree, "<s>", "exec" if isinstance(node, ast.Module) else "eval")
+            out.append("reject " + label + " none")
+        except BaseException as e:
+            out.append("reject " + label + " " + type(e).__name__)
+    # A source range is required on the node kinds below, so these trees are
+    # the ones `fix_missing_locations` would have repaired.
+    for label, node in (
+        ("stmt-no-range", ast.Module(body=[ast.Pass()], type_ignores=[])),
+        ("expr-no-range", ast.Module(body=[ast.Expr(value=ast.Name("x", L), **RANGE)],
+                                     type_ignores=[])),
+        ("pattern-no-range", ast.Module(body=[ast.Match(
+            subject=ast.Constant(1, **RANGE),
+            cases=[ast.match_case(pattern=ast.MatchAs(pattern=None, name="v"),
+                                  body=[ast.Pass(**RANGE)])], **RANGE)], type_ignores=[])),
+        ("excepthandler-no-range", ast.Module(body=[ast.Try(
+            body=[ast.Pass(**RANGE)],
+            handlers=[ast.ExceptHandler(type=None, name=None, body=[ast.Pass(**RANGE)])],
+            orelse=[], finalbody=[], **RANGE)], type_ignores=[])),
+        ("alias-no-range", ast.Module(body=[ast.Import(names=[ast.alias(name="os")], **RANGE)],
+                                      type_ignores=[])),
+        ("arg-no-range", ast.Module(body=[ast.FunctionDef(
+            name="f", args=args(a=[ast.arg(arg="a")]), body=[ast.Pass(**RANGE)],
+            decorator_list=[], type_params=[], **RANGE)], type_ignores=[])),
+        ("keyword-no-range", ast.Module(body=[ast.Expr(value=ast.Call(
+            func=ast.Name("f", L, **RANGE), args=[],
+            keywords=[ast.keyword(arg="k", value=ast.Constant(1, **RANGE))], **RANGE), **RANGE)],
+            type_ignores=[])),
+    ):
+        try:
+            compile(node, "<s>", "exec")
             out.append("reject " + label + " none")
         except BaseException as e:
             out.append("reject " + label + " " + type(e).__name__)

--- a/pyre/pyre-interpreter/src/astcompiler/validate.rs
+++ b/pyre/pyre-interpreter/src/astcompiler/validate.rs
@@ -85,6 +85,37 @@ fn validate_constant(value: &ast::ConstantValue) -> ValidateResult {
     }
 }
 
+/// The operand a literal pattern is allowed to negate.
+fn is_number(expr: &ast::Expr) -> bool {
+    matches!(expr, ast::Expr::Constant(constant) if matches!(
+        constant.value,
+        ast::ConstantValue::Integer(_)
+            | ast::ConstantValue::Float(_)
+            | ast::ConstantValue::Complex { .. }
+    ))
+}
+
+/// The real half of the complex literal a pattern may spell out, which is
+/// written either on its own or negated.
+fn is_signed_real(expr: &ast::Expr) -> bool {
+    let expr = match expr {
+        ast::Expr::UnaryOp(unary) if unary.op == ast::UnaryOp::USub => &unary.operand,
+        _ => expr,
+    };
+    matches!(expr, ast::Expr::Constant(constant) if matches!(
+        constant.value,
+        ast::ConstantValue::Integer(_) | ast::ConstantValue::Float(_)
+    ))
+}
+
+/// The imaginary half of that literal, which carries its own sign.
+fn is_imaginary(expr: &ast::Expr) -> bool {
+    matches!(
+        expr,
+        ast::Expr::Constant(constant) if matches!(constant.value, ast::ConstantValue::Complex { .. })
+    )
+}
+
 struct AstValidator;
 
 impl AstValidator {
@@ -433,10 +464,24 @@ impl AstValidator {
                             ))
                         }
                     }
-                    // An attribute lookup is always permitted, and a complex
-                    // literal reaches here as the operation that builds it,
-                    // whose shape the code generator checks.
-                    ast::Expr::Attribute(_) | ast::Expr::BinOp(_) | ast::Expr::UnaryOp(_) => Ok(()),
+                    // An attribute lookup is always permitted.
+                    ast::Expr::Attribute(_) => Ok(()),
+                    // A negated number and a complex literal reach here as the
+                    // operations that build them, and only in those shapes.
+                    ast::Expr::UnaryOp(unary)
+                        if unary.op == ast::UnaryOp::USub && is_number(&unary.operand) =>
+                    {
+                        Ok(())
+                    }
+                    ast::Expr::BinOp(binop)
+                        if matches!(binop.op, ast::Operator::Add | ast::Operator::Sub)
+                            && is_signed_real(&binop.left)
+                            && is_imaginary(&binop.right) =>
+                    {
+                        Ok(())
+                    }
+                    // An f-string is left for the code generator to report.
+                    ast::Expr::FString(_) => Ok(()),
                     // Upstream stops at the constant check and lets everything
                     // else through; 3.14 rejects it here, before the code
                     // generator reports the same thing as a SyntaxError.
@@ -740,6 +785,43 @@ mod tests {
         })
     }
 
+    fn literal(value: ast::ConstantValue) -> ast::Expr {
+        ast::Expr::Constant(ast::ExprConstant {
+            node_index: Default::default(),
+            range: Default::default(),
+            value,
+            kind: None,
+            invalid_type: None,
+        })
+    }
+
+    fn unary(op: ast::UnaryOp, operand: ast::Expr) -> ast::Expr {
+        ast::Expr::UnaryOp(ast::ExprUnaryOp {
+            node_index: Default::default(),
+            range: Default::default(),
+            op,
+            operand: Box::new(operand),
+        })
+    }
+
+    fn binop(left: ast::Expr, op: ast::Operator, right: ast::Expr) -> ast::Expr {
+        ast::Expr::BinOp(ast::ExprBinOp {
+            node_index: Default::default(),
+            range: Default::default(),
+            left: Box::new(left),
+            op,
+            right: Box::new(right),
+        })
+    }
+
+    fn value(expr: ast::Expr) -> ast::Pattern {
+        ast::Pattern::MatchValue(ast::PatternMatchValue {
+            node_index: Default::default(),
+            range: Default::default(),
+            value: Box::new(expr),
+        })
+    }
+
     fn message(result: ValidateResult) -> String {
         result.unwrap_err().message
     }
@@ -768,6 +850,57 @@ mod tests {
             })),
         });
         assert!(validate(matched(value)).is_ok());
+    }
+
+    #[test]
+    fn match_value_takes_a_negated_number_and_a_complex_literal() {
+        let float = || literal(ast::ConstantValue::Float(1.5));
+        let imaginary = || {
+            literal(ast::ConstantValue::Complex {
+                real: 0.0,
+                imag: 2.0,
+            })
+        };
+        let text = || literal(ast::ConstantValue::Str("a".into()));
+        let accepted = [
+            unary(ast::UnaryOp::USub, constant(1)),
+            unary(ast::UnaryOp::USub, float()),
+            unary(ast::UnaryOp::USub, imaginary()),
+            binop(constant(1), ast::Operator::Add, imaginary()),
+            binop(float(), ast::Operator::Sub, imaginary()),
+            binop(
+                unary(ast::UnaryOp::USub, constant(1)),
+                ast::Operator::Add,
+                imaginary(),
+            ),
+        ];
+        for expr in accepted {
+            assert!(validate(matched(value(expr))).is_ok());
+        }
+
+        let rejected = [
+            // Only a negation, and only over a number.
+            unary(ast::UnaryOp::USub, text()),
+            unary(ast::UnaryOp::UAdd, constant(1)),
+            unary(ast::UnaryOp::Invert, constant(1)),
+            unary(ast::UnaryOp::USub, unary(ast::UnaryOp::USub, constant(1))),
+            // A real half and then an imaginary one, added or subtracted.
+            binop(imaginary(), ast::Operator::Add, constant(1)),
+            binop(constant(1), ast::Operator::Add, constant(2)),
+            binop(text(), ast::Operator::Add, imaginary()),
+            binop(constant(1), ast::Operator::Mult, imaginary()),
+            binop(
+                constant(1),
+                ast::Operator::Add,
+                unary(ast::UnaryOp::USub, imaginary()),
+            ),
+        ];
+        for expr in rejected {
+            assert_eq!(
+                message(validate(matched(value(expr)))),
+                "patterns may only match literals and attribute lookups"
+            );
+        }
     }
 
     #[test]

--- a/pyre/pyre-interpreter/src/module/_ast/convert.rs
+++ b/pyre/pyre-interpreter/src/module/_ast/convert.rs
@@ -99,8 +99,71 @@ impl ObjectConverter {
         Ok(unsafe { pyre_object::w_str_get_value(value).to_string() })
     }
 
+    /// How `%R` names the value an error rejected.
+    fn repr(&self, object: PyObjectRef) -> AstResult<String> {
+        unsafe { crate::display::py_repr(object) }
+    }
+
+    /// `obj_to_int` (ast.py:36) — an integer field takes an `int`, or an
+    /// instance of a subclass of one.  Nothing else is asked for `__index__`.
+    fn obj_to_int(&self, value: PyObjectRef) -> AstResult<i64> {
+        if !unsafe { crate::baseobjspace::isinstance_int_w(value) } {
+            return Err(crate::PyError::value_error(format!(
+                "invalid integer value: {}",
+                self.repr(value)?
+            )));
+        }
+        crate::builtins::space_index_w(value)
+    }
+
+    /// The source range an object carries as attributes.  A tree compiled
+    /// from objects has no source to map a range back onto, so these are read
+    /// only for what the boundary owes them: `lineno` and `col_offset` are
+    /// required, and the two end fields are optional.
+    fn location(&self, object: PyObjectRef, node: &str) -> AstResult<()> {
+        self.int_field(object, "lineno", node)?;
+        self.int_field(object, "col_offset", node)?;
+        for field in ["end_lineno", "end_col_offset"] {
+            if let Some(value) = self.optional_field(object, field)? {
+                self.obj_to_int(value)?;
+            }
+        }
+        Ok(())
+    }
+
+    /// `Module.type_ignores` (ast.py:229) holds the `# type: ignore` comments
+    /// a `type_comments=True` parse collected.  The compiler AST has nowhere
+    /// to keep them and never reads them back, but the field is still walked
+    /// so that a list holding something else is reported here.
+    fn type_ignores(&self, object: PyObjectRef) -> AstResult<()> {
+        let value = match crate::baseobjspace::getattr_str(object, "type_ignores") {
+            Ok(value) => value,
+            // An unset field stands for the empty list a parse without type
+            // comments produces.
+            Err(error) if error.kind == crate::PyErrorKind::AttributeError => return Ok(()),
+            Err(error) => return Err(error),
+        };
+        if !unsafe { pyre_object::is_list(value) } {
+            return Err(crate::PyError::type_error(format!(
+                "Module field \"type_ignores\" must be a list, not a {}",
+                class_name(value)
+            )));
+        }
+        for item in unsafe { pyre_object::w_list_items_copy_as_vec(value) } {
+            if unsafe { pyre_object::is_none(item) } || self.is_node(item, "TypeIgnore")? {
+                continue;
+            }
+            return Err(crate::PyError::type_error(format!(
+                "expected some sort of type_ignore, but got {}",
+                self.repr(item)?
+            )));
+        }
+        Ok(())
+    }
+
     fn module(&mut self, object: PyObjectRef) -> AstResult<ast::Mod> {
         let node = if self.is_node(object, "Module")? {
+            self.type_ignores(object)?;
             "Module"
         } else if self.is_node(object, "Interactive")? {
             "Interactive"
@@ -114,7 +177,7 @@ impl ObjectConverter {
         } else {
             return Err(crate::PyError::type_error(format!(
                 "expected some sort of mod, but got {}",
-                unsafe { pyre_object::type_name_of(object) }
+                self.repr(object)?
             )));
         };
         Ok(ast::Mod::Module(ast::ModModule {
@@ -126,6 +189,7 @@ impl ObjectConverter {
     }
 
     fn stmt(&mut self, object: PyObjectRef) -> AstResult<ast::Stmt> {
+        self.location(object, "stmt")?;
         if self.is_node(object, "FunctionDef")? || self.is_node(object, "AsyncFunctionDef")? {
             let is_async = self.is_node(object, "AsyncFunctionDef")?;
             let node = if is_async {
@@ -428,7 +492,7 @@ impl ObjectConverter {
             let names = self.aliases(object, "ImportFrom")?;
             // `level` is optional on a hand-built node and defaults to absolute.
             let level = match self.optional_field(object, "level")? {
-                Some(value) => crate::builtins::space_index_w(value)?,
+                Some(value) => self.obj_to_int(value)?,
                 None => 0,
             };
             if level < 0 {
@@ -487,7 +551,7 @@ impl ObjectConverter {
         } else {
             Err(crate::PyError::type_error(format!(
                 "expected some sort of stmt, but got {}",
-                unsafe { pyre_object::type_name_of(object) }
+                self.repr(object)?
             )))
         }
     }
@@ -581,6 +645,7 @@ impl ObjectConverter {
     }
 
     fn parameter(&mut self, object: PyObjectRef) -> AstResult<ast::Parameter> {
+        self.location(object, "arg")?;
         Ok(ast::Parameter {
             range: Default::default(),
             node_index: Default::default(),
@@ -602,10 +667,11 @@ impl ObjectConverter {
     }
 
     fn handler(&mut self, object: PyObjectRef) -> AstResult<ast::ExceptHandler> {
+        self.location(object, "excepthandler")?;
         if !self.is_node(object, "ExceptHandler")? {
             return Err(crate::PyError::type_error(format!(
                 "expected some sort of excepthandler, but got {}",
-                unsafe { pyre_object::type_name_of(object) }
+                self.repr(object)?
             )));
         }
         Ok(ast::ExceptHandler::ExceptHandler(
@@ -652,6 +718,7 @@ impl ObjectConverter {
         self.list(object, "names", node)?
             .into_iter()
             .map(|value| {
+                self.location(value, "alias")?;
                 Ok(ast::Alias {
                     range: Default::default(),
                     node_index: Default::default(),
@@ -709,6 +776,7 @@ impl ObjectConverter {
     }
 
     fn type_param(&mut self, object: PyObjectRef) -> AstResult<ast::TypeParam> {
+        self.location(object, "type_param")?;
         if self.is_node(object, "TypeVar")? {
             let name = self.identifier(object, "name", "TypeVar")?;
             Ok(ast::TypeParam::TypeVar(ast::TypeParamTypeVar {
@@ -737,7 +805,7 @@ impl ObjectConverter {
         } else {
             Err(crate::PyError::type_error(format!(
                 "expected some sort of type_param, but got {}",
-                unsafe { pyre_object::type_name_of(object) }
+                self.repr(object)?
             )))
         }
     }
@@ -768,6 +836,7 @@ impl ObjectConverter {
     }
 
     fn pattern(&mut self, object: PyObjectRef) -> AstResult<ast::Pattern> {
+        self.location(object, "pattern")?;
         if self.is_node(object, "MatchValue")? {
             Ok(ast::Pattern::MatchValue(ast::PatternMatchValue {
                 node_index: Default::default(),
@@ -876,7 +945,7 @@ impl ObjectConverter {
         } else {
             Err(crate::PyError::type_error(format!(
                 "expected some sort of pattern, but got {}",
-                unsafe { pyre_object::type_name_of(object) }
+                self.repr(object)?
             )))
         }
     }
@@ -986,10 +1055,11 @@ impl ObjectConverter {
 
     fn int_field(&self, object: PyObjectRef, field: &str, node: &str) -> AstResult<i64> {
         let value = self.field(object, field, node)?;
-        crate::builtins::space_index_w(value)
+        self.obj_to_int(value)
     }
 
     fn expr(&mut self, object: PyObjectRef) -> AstResult<ast::Expr> {
+        self.location(object, "expr")?;
         if self.is_node(object, "UnaryOp")? {
             let operand = self.field(object, "operand", "UnaryOp")?;
             let op = self.field(object, "op", "UnaryOp")?;
@@ -1094,7 +1164,7 @@ impl ObjectConverter {
                 node_index: Default::default(),
                 range: Default::default(),
                 value: self.constant_value(value)?,
-                kind: None,
+                kind: self.constant_kind(object)?,
                 invalid_type: None,
             }))
         } else if self.is_node(object, "BoolOp")? {
@@ -1284,7 +1354,7 @@ impl ObjectConverter {
         } else {
             Err(crate::PyError::type_error(format!(
                 "expected some sort of expr, but got {}",
-                unsafe { pyre_object::type_name_of(object) }
+                self.repr(object)?
             )))
         }
     }
@@ -1334,7 +1404,10 @@ impl ObjectConverter {
                 return Ok(op);
             }
         }
-        Err(crate::PyError::type_error("expected some sort of boolop"))
+        Err(crate::PyError::type_error(format!(
+            "expected some sort of boolop, but got {}",
+            self.repr(object)?
+        )))
     }
 
     fn cmpop(&self, object: PyObjectRef) -> AstResult<ast::CmpOp> {
@@ -1354,10 +1427,14 @@ impl ObjectConverter {
                 return Ok(op);
             }
         }
-        Err(crate::PyError::type_error("expected some sort of cmpop"))
+        Err(crate::PyError::type_error(format!(
+            "expected some sort of cmpop, but got {}",
+            self.repr(object)?
+        )))
     }
 
     fn keyword(&mut self, object: PyObjectRef) -> AstResult<ast::Keyword> {
+        self.location(object, "keyword")?;
         let arg = self
             .optional_field(object, "arg")?
             .map(|value| {
@@ -1451,20 +1528,42 @@ impl ObjectConverter {
         }
     }
 
+    /// `Constant.kind` — the `u` a string literal may have been written with.
+    /// `check_string` (ast.py:18) takes bytes here as well, and the prefix is
+    /// only ever read back as text, so bytes leave the field unset.
+    fn constant_kind(&self, object: PyObjectRef) -> AstResult<Option<Box<str>>> {
+        let Some(value) = self.optional_field(object, "kind")? else {
+            return Ok(None);
+        };
+        if unsafe { crate::baseobjspace::isinstance_str_w(value) } {
+            return Ok(Some(
+                unsafe { pyre_object::w_str_get_value(value) }
+                    .to_string()
+                    .into_boxed_str(),
+            ));
+        }
+        if unsafe { crate::baseobjspace::isinstance_bytes_w(value) } {
+            return Ok(None);
+        }
+        Err(crate::PyError::type_error("AST string must be of type str"))
+    }
+
     fn context(&self, object: PyObjectRef) -> AstResult<ast::ExprContext> {
+        // The three the ASDL declares; `Invalid` is a compiler-AST state with
+        // no `_ast` class behind it, so no object can carry one.
         for (name, ctx) in [
             ("Load", ast::ExprContext::Load),
             ("Store", ast::ExprContext::Store),
             ("Del", ast::ExprContext::Del),
-            ("Invalid", ast::ExprContext::Invalid),
         ] {
             if self.is_node(object, name)? {
                 return Ok(ctx);
             }
         }
-        Err(crate::PyError::type_error(
-            "expected some sort of expr_context",
-        ))
+        Err(crate::PyError::type_error(format!(
+            "expected some sort of expr_context, but got {}",
+            self.repr(object)?
+        )))
     }
 
     fn unaryop(&self, object: PyObjectRef) -> AstResult<ast::UnaryOp> {
@@ -1478,7 +1577,10 @@ impl ObjectConverter {
                 return Ok(op);
             }
         }
-        Err(crate::PyError::type_error("expected some sort of unaryop"))
+        Err(crate::PyError::type_error(format!(
+            "expected some sort of unaryop, but got {}",
+            self.repr(object)?
+        )))
     }
 
     fn operator(&self, object: PyObjectRef) -> AstResult<ast::Operator> {
@@ -1501,7 +1603,10 @@ impl ObjectConverter {
                 return Ok(op);
             }
         }
-        Err(crate::PyError::type_error("expected some sort of operator"))
+        Err(crate::PyError::type_error(format!(
+            "expected some sort of operator, but got {}",
+            self.repr(object)?
+        )))
     }
 }
 


### PR DESCRIPTION
Follow-up to #856, from the review findings that outlived it.

## `astcompiler`: the expression shapes a literal pattern takes

`MatchValue` took any `UnaryOp` or `BinOp` and rejected an f-string. A negated
number is only `USub` over a numeric literal, and a complex literal is only a
real half added to or subtracted from an imaginary one; an f-string is left for
the code generator, which already reports it.

Measured over 27 shapes: **the set of trees that compile is unchanged**. What
moves is which stage rejects the rest, and with which exception — `-y`, `1*2`,
`2j+1`, `1+(-2j)` now stop at validation as a `ValueError`, and a `JoinedStr`
reaches the code generator and comes out as a `SyntaxError`.

## `_ast`: the fields an object is required to carry

Each of these is a shape both 3.14 and PyPy reject and pyre compiled:

- `lineno` and `col_offset` were not read on any node. They are required on
  `stmt`, `expr`, `pattern`, `excepthandler`, `alias`, `arg`, `keyword` and
  `type_param`; `end_lineno`/`end_col_offset` are optional.
- an integer field accepted anything with `__index__`. `obj_to_int`
  (`ast.py:36`) takes an `int` or an instance of a subclass of one.
- `Module.type_ignores` was never read: it must be a list, and holds
  `type_ignore` or `None`.
- `Constant.kind` was never read: it must be a string.
- `expr_context` looked up an `Invalid` class that `_ast` does not define, so a
  context that was not a node surfaced as
  `AttributeError: module '_ast' has no attribute 'Invalid'`. `Invalid` is a
  compiler-AST state no object can carry.
- the five operator kinds now name the value they rejected (`, but got %R`), as
  the rest of the conversion does.

## Verification

70 hand-built trees compared against CPython 3.14 — 69 identical, the one
difference being the `(<t>, line 1)` suffix a `SyntaxError` carries, which is
the residual already documented in #856 (a tree compiled from objects has no
source).

- 18 lines added to `bench/synth/ast_compile_roundtrip.py`, byte-identical
  across CPython 3.14 / PyPy 3.11 / pyre. 11 of them printed `none` before this
  change; the four operator ones pin only the exception class, which this
  change does not move.
- 6 unit tests in `astcompiler::validate`, the new one an accept-6 / reject-9
  ladder over the pattern shapes.
- `check.py` dynasm 332/332, cranelift 332/332; `cargo test --all --features
  dynasm` 7118 passed / 0 failed; `cargo fmt --all --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of abstract syntax trees, including source locations, constants, expression contexts, operators, and pattern matching.
  * Invalid or malformed syntax trees are now rejected more consistently with clearer error messages.
  * Added support for preserving constant metadata during AST processing.
  * Tightened handling of complex and negated literals in `match` patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->