### PR TITLE
jit: walk indirect_call families and skip close_stack callees in find_all_graphs

### DIFF
--- a/majit/majit-translate/src/codewriter/call.rs
+++ b/majit/majit-translate/src/codewriter/call.rs
@@ -3241,64 +3241,115 @@ impl CallControl {
             // is_candidate that treats "has graph" as candidate).
             for block in &graph.blocks {
                 for op in &block.operations {
-                    let target = match &op.kind {
-                        OpKind::Call { target, .. } => target,
+                    // `call.py:76-77` — only `direct_call` and
+                    // `indirect_call` ops are walked; everything else is
+                    // skipped.  The op-shape dispatch produces the callee
+                    // set `call.py:83 graphs_from(op, is_candidate)` would
+                    // yield: one path for a direct call, the whole family
+                    // for an indirect one.
+                    let callees: Vec<CallPath> = match &op.kind {
+                        // `call.py:103-112` indirect_call — the attached
+                        // `c_graphs` family, `None` meaning "unknown
+                        // family" and classifying the site as residual.
+                        OpKind::IndirectCall { graphs, .. } => match graphs {
+                            Some(graphs) => graphs.clone(),
+                            None => continue,
+                        },
+                        // Same indirect_call site, spelled the way it
+                        // exists *before* `rpbc::lower_indirect_calls`
+                        // rewrites it into `VtableMethodPtr` +
+                        // `IndirectCall`.  That lowering runs inside
+                        // `transform_graph_to_jitcode`, i.e. strictly
+                        // after `find_all_graphs`, so this is the shape
+                        // the BFS actually sees.  The family is the same
+                        // one the lowering stamps into `graphs`
+                        // (`rpbc.py:216 c_graphs = row_of_graphs.values()`),
+                        // so resolving it here keeps the walk equivalent
+                        // to walking the lowered op.
+                        OpKind::Call {
+                            target:
+                                CallTarget::Indirect {
+                                    trait_root,
+                                    method_name,
+                                },
+                            ..
+                        } => self.all_impls_for_indirect(trait_root, method_name),
+                        // `call.py:117-136` direct_call.  These three
+                        // classifications are attached to the single
+                        // `funcobj` and so apply to the direct branch
+                        // only; an indirect family is instead validated
+                        // as a whole in `getcalldescr`.
+                        OpKind::Call { target, .. } => {
+                            let callee_path = match self.target_to_path(target) {
+                                Some(path) => path,
+                                None => continue,
+                            };
+                            // `call.py:119-120`
+                            // jitdriver_sd_from_portal_runner_ptr → recursive.
+                            if self
+                                .jitdrivers_sd
+                                .iter()
+                                .any(|jd| jd.portal_graph == callee_path)
+                            {
+                                continue;
+                            }
+                            // `call.py:129-134`
+                            // `_gctransformer_hint_close_stack_` → residual.
+                            // `get_jitcode` asserts such a graph never
+                            // reaches it, so following one here would turn
+                            // a residual classification into a panic.
+                            if self
+                                .func_effects(&callee_path)
+                                .is_some_and(|f| f.close_stack)
+                            {
+                                continue;
+                            }
+                            // `call.py:135-136`
+                            // `hasattr(targetgraph.func, 'oopspec')` → builtin.
+                            if self
+                                .func_effects(&callee_path)
+                                .is_some_and(|f| f.oopspec.is_some())
+                            {
+                                continue;
+                            }
+                            vec![callee_path]
+                        }
                         _ => continue,
                     };
-                    // `call.py:97` direct_call → `funcobj.graph` — co-fetch
-                    // path + graph through the single Box-identity helper.
-                    // A missing graph (unregistered target) and a missing
-                    // path collapse into the same "skip" decision: the
-                    // earlier path-then-Some(graph) two-step never built a
-                    // SemanticFunction either when the graph wasn't in
-                    // `function_graphs`.
-                    let (callee_path, graph_ref) = match self.target_to_path_and_graph(target) {
-                        Some(pair) => pair,
-                        None => continue,
-                    };
-                    // RPython call.py:80: kind = self.guess_call_kind(op, is_candidate)
-                    // Skip recursive (portal) and builtin calls — these are NOT
-                    // followed during BFS. Only "regular" calls are followed.
-                    if self
-                        .jitdrivers_sd
-                        .iter()
-                        .any(|jd| jd.portal_graph == callee_path)
-                    {
-                        continue; // recursive — don't follow
-                    }
-                    // call.py:135 — `hasattr(targetgraph.func, 'oopspec')`
-                    // ⇒ builtin; builtins are not followed during BFS.
-                    if self
-                        .func_effects(&callee_path)
-                        .is_some_and(|f| f.oopspec.is_some())
-                    {
-                        continue; // builtin — don't follow
-                    }
-                    if self.candidate_graphs.contains(&callee_path) {
-                        continue; // already discovered
-                    }
-                    // RPython call.py:84,87: callee must satisfy
-                    // policy.look_inside_graph(graph). Synthesize a
-                    // SemanticFunction from the stored graph + hints so
-                    // the policy's `_jit_*_` / `_elidable_function_`
-                    // checks fire identically to upstream.
-                    let hints = graph_ref.hints.clone();
-                    let graph = graph_ref.clone();
-                    let func = SemanticFunction {
-                        name: callee_path.last_segment().unwrap_or_default().to_string(),
-                        graph,
-                        return_type: None,
-                        self_ty_root: None,
-                        hints,
-                        module_path: String::new(),
-                        access_directly: false,
-                        trait_root: None,
-                        trait_qualified: None,
-                        returns_objectptr: false,
-                    };
-                    if policy.look_inside_graph(&func) {
-                        self.candidate_graphs.insert(callee_path.clone());
-                        todo.push(callee_path);
+                    for callee_path in callees {
+                        // `call.py:81-82` — already discovered.
+                        if self.candidate_graphs.contains(&callee_path) {
+                            continue;
+                        }
+                        // A target with no registered graph is upstream's
+                        // `funcobj.graph is None` → residual (call.py:127).
+                        let graph_ref = match self.function_graphs.get(&callee_path) {
+                            Some(g) => g,
+                            None => continue,
+                        };
+                        // RPython call.py:84,87: callee must satisfy
+                        // policy.look_inside_graph(graph). Synthesize a
+                        // SemanticFunction from the stored graph + hints so
+                        // the policy's `_jit_*_` / `_elidable_function_`
+                        // checks fire identically to upstream.
+                        let hints = graph_ref.hints.clone();
+                        let graph = graph_ref.clone();
+                        let func = SemanticFunction {
+                            name: callee_path.last_segment().unwrap_or_default().to_string(),
+                            graph,
+                            return_type: None,
+                            self_ty_root: None,
+                            hints,
+                            module_path: String::new(),
+                            access_directly: false,
+                            trait_root: None,
+                            trait_qualified: None,
+                            returns_objectptr: false,
+                        };
+                        if policy.look_inside_graph(&func) {
+                            self.candidate_graphs.insert(callee_path.clone());
+                            todo.push(callee_path);
+                        }
                     }
                 }
             }

--- a/majit/majit-translate/tests/test_phase_d_find_all_graphs_parity.rs
+++ b/majit/majit-translate/tests/test_phase_d_find_all_graphs_parity.rs
@@ -143,6 +143,100 @@ fn find_all_graphs_does_not_follow_portal_recursive_edges() {
     assert!(cc.is_candidate(&portal_path));
 }
 
+/// Same as `build_caller_graph` but the single call is an `indirect_call`
+/// site — a `dyn Trait` method call, before `rpbc::lower_indirect_calls`
+/// rewrites it into `VtableMethodPtr` + `OpKind::IndirectCall`.  That
+/// lowering runs inside `transform_graph_to_jitcode`, i.e. after
+/// `find_all_graphs`, so this is the shape the BFS sees.
+fn build_indirect_caller_graph(name: &str, trait_root: &str, method_name: &str) -> FunctionGraph {
+    use majit_translate::model::{CallTarget, OpKind, SpaceOperation, ValueType};
+
+    let mut graph = FunctionGraph::new(name);
+    let receiver = graph.alloc_value_var();
+    let result_var = graph.alloc_value_var();
+    graph
+        .block_mut(graph.startblock)
+        .operations
+        .push(SpaceOperation {
+            result: Some(result_var.clone()),
+            kind: OpKind::Call {
+                target: CallTarget::indirect(trait_root, method_name),
+                args: vec![receiver],
+                result_ty: ValueType::Int,
+            },
+        });
+    graph.set_return(graph.startblock, Some(result_var));
+    graph
+}
+
+#[test]
+fn find_all_graphs_follows_every_member_of_an_indirect_call_family() {
+    // RPython call.py:76 walks `("direct_call", "indirect_call")`, and
+    // call.py:103-112 `graphs_from` returns the whole attached family for
+    // an indirect_call, so every candidate member enters the closure.
+    // Skipping the indirect branch leaves the family out of
+    // `candidate_graphs`, which makes `graphs_from` return None at
+    // jtransform time and downgrades the site to a bare residual call —
+    // no `Live` prologue, no `GuardValue`.
+    let portal_path = CallPath::from_segments(["portal"]);
+    let alpha_path = CallPath::for_impl_method("Alpha", "step");
+    let beta_path = CallPath::for_impl_method("Beta", "step");
+
+    let mut cc = CallControl::new();
+    cc.register_function_graph(
+        portal_path.clone(),
+        build_indirect_caller_graph("portal", "Stepper", "step"),
+    );
+    cc.register_trait_method("step", Some("Stepper"), "Alpha", FunctionGraph::new("step"));
+    cc.register_trait_method("step", Some("Stepper"), "Beta", FunctionGraph::new("step"));
+    cc.mark_portal(portal_path.clone());
+
+    let mut policy = DefaultJitPolicy::new();
+    cc.find_all_graphs(&mut policy);
+
+    assert!(
+        cc.is_candidate(&alpha_path),
+        "call.py:103-112 — every candidate member of the indirect_call \
+         family must enter the closure, not just the first"
+    );
+    assert!(
+        cc.is_candidate(&beta_path),
+        "call.py:103-112 — every candidate member of the indirect_call \
+         family must enter the closure, not just the first"
+    );
+}
+
+#[test]
+fn find_all_graphs_does_not_follow_close_stack_targets() {
+    // RPython call.py:129-134 `_gctransformer_hint_close_stack_` →
+    // 'residual', skipped by call.py:82. `get_jitcode` asserts a
+    // close_stack graph never reaches it, so following the edge here
+    // turns a residual classification into a panic later.
+    let portal_path = CallPath::from_segments(["portal"]);
+    let close_stack_path = CallPath::from_segments(["ll_close_stack"]);
+
+    let mut cc = CallControl::new();
+    cc.register_function_graph(
+        portal_path.clone(),
+        build_caller_graph("portal", &close_stack_path),
+    );
+    cc.register_function_graph(
+        close_stack_path.clone(),
+        FunctionGraph::new("ll_close_stack"),
+    );
+    cc.mark_close_stack(close_stack_path.clone());
+    cc.mark_portal(portal_path.clone());
+
+    let mut policy = DefaultJitPolicy::new();
+    cc.find_all_graphs(&mut policy);
+
+    assert!(
+        !cc.is_candidate(&close_stack_path),
+        "call.py:129-134 — a close_stack callee is residual and must not \
+         enter the candidate closure"
+    );
+}
+
 #[test]
 fn find_all_graphs_leaves_unregistered_targets_as_residual() {
     // Phase D.2 parity contract: upstream `PyPyJitPolicy.look_inside_function`


### PR DESCRIPTION
Follow-up to #866 — two more `rpython/jit/codewriter/call.py` parity gaps in `find_all_graphs`.

## 1. The BFS never walked `indirect_call`

`find_all_graphs_bfs` matched only `OpKind::Call` and resolved it through `target_to_path`, which returns `None` for `CallTarget::Indirect` unconditionally. Upstream `call.py:76` walks **both** `direct_call` and `indirect_call`, and `call.py:103-112 graphs_from` returns the whole family attached to the op.

Both indirect spellings now enter the op dispatch:

- **`OpKind::IndirectCall { graphs }`** — the post-`lower_indirect_calls` shape. `graphs: None` is upstream's `graphs is None` residual.
- **`OpKind::Call { target: CallTarget::Indirect { .. } }`** — the same site *before* `rpbc::lower_indirect_calls` rewrites it into `VtableMethodPtr` + `IndirectCall`. That pass runs inside `transform_graph_to_jitcode`, i.e. strictly **after** `find_all_graphs`, so this is the shape the BFS actually sees. The family is resolved through `all_impls_for_indirect`, which is the same set the lowering stamps into `graphs` (`rpbc.py:216 c_graphs = row_of_graphs.values()`).

Without this the `(trait_root, method_name)` family never entered `candidate_graphs`, so `graphs_from` returned `None` at jtransform time, `guess_call_kind` said `Residual`, and the site was emitted as a bare `CallResidual { indirect_targets: None }` — no `Live` prologue, no `GuardValue` — instead of the Regular arm's guarded indirect call.

## 2. The direct arm was missing the `close_stack` gate

`call.py:129-134` classifies a `_gctransformer_hint_close_stack_` callee as `'residual'`, which `call.py:82` then skips. That check was absent from the BFS. `get_jitcode` asserts a close_stack graph never reaches it, so following the edge converted a residual classification into a **panic**. Latent today — no pyre source marks `close_stack`.

The recursive / close_stack / oopspec classifications stay on the **direct arm only**, matching `guess_call_kind`: they are read off a single `funcobj`. An indirect family is instead validated as a whole in `getcalldescr` (`call.py:259-280`).

## Impact on the default configuration: none, provably

- `CallTarget::Indirect` is only produced behind `PYRE_DYN_INDIRECT`, which is **default-off** (`front/mir.rs dyn_indirect_enabled`).
- Every non-test producer of `OpKind::IndirectCall` is `rpbc::lower_indirect_calls`, which runs after `find_all_graphs`. (The other construction sites are test fixtures in `flowspace_adapter.rs`, `support.rs`, `jtransform.rs`, `call.rs`, plus the `inline.rs` op-remap clone.)
- No pyre source carries a `close_stack` hint.

So both new arms are unreachable in the default build; this is a dropped classification restored, not a behaviour change.

## Verification

- **Two regression tests, both proven discriminating** — reverting `call.rs` makes both **FAIL**, restoring it makes both **PASS**. They live in `tests/test_phase_d_find_all_graphs_parity.rs`, which drives the portal-seeded production `find_all_graphs`. This matters: `find_all_graphs_for_tests()` bulk-inserts every registered graph into `candidate_graphs`, so no test using it can observe a BFS-reachability gap at all.
- `cargo test -p majit-translate` — green (lib + all integration targets).
- `cargo build --release -p pyrex --bin pyre-dynasm --no-default-features --features dynasm` — clean, and the built binary smoke-tests fine.
- `cargo fmt --all --check` — exit 0.

Corpus perf gate not run locally: the box was saturated by sibling worktree builds. Left to CI.

— *authored by Claude*
