### PR TITLE
jit: close a top-level trace at any matching merge point, and restore the check.py regression floor

### DIFF
--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -9845,23 +9845,18 @@ impl<M: Clone> MetaInterp<M> {
             .expect("must_compile_with_values: descr_arc must be a FailDescr");
         let trace_id = descr_fd.trace_id();
         let fail_index = descr_fd.fail_index_per_trace();
-        // quasiimmut.py:97-100 `QuasiImmut.invalidate()` marks the owning
-        // JitCellToken invalid before `cpu.invalidate_loop()` patches every
-        // GUARD_NOT_INVALIDATED.  The failed guard remains usable only as
-        // resume data; warmstate.py:191-196 no longer returns that token as a
-        // procedure token, and PyPy never traces a bridge onto it.  Preserve
-        // that object ownership here: a stale machine-code activation may
-        // still report the descr, but it must go straight to blackhole
-        // resume instead of ticking the bridge counter and repeatedly
-        // attaching bridges to the permanently invalidated loop.
-        let owning_jct = majit_backend::descr_owning_jct(descr_fd);
-        let owning_key = owning_jct
-            .as_ref()
+        // `must_compile` ticks the counter for every reported guard failure,
+        // including one whose owning JitCellToken has since been invalidated by
+        // `QuasiImmut.invalidate()` (quasiimmut.py:97-100).  That tick is the
+        // recovery path, not a leak: warmstate.py:191-196 stops returning the
+        // dead token as a procedure token, so once the counter fires, the walk
+        // reaches `reached_loop_header` (pyjitpl.py:3005-3007) with no compiled
+        // target, falls through to `compile_loop` and installs a live
+        // replacement for the key.  Suppressing the tick strands every later
+        // activation of the dead trace in blackhole resume forever.
+        let owning_key = majit_backend::descr_owning_jct(descr_fd)
             .map(|jct| jct.green_key())
             .unwrap_or(fallback_green_key);
-        if owning_jct.as_ref().is_some_and(|jct| jct.is_invalidated()) {
-            return (false, owning_key);
-        }
         // A guard whose bridge was refused by a terminal-declining backend
         // (`bridge_decline_is_terminal()`, currently wasm) or by a structural
         // full-body-walk decline must not re-fire: re-tracing rebuilds the same

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -1176,9 +1176,8 @@ impl TraceCtx {
 
     /// Like [`for_test_types`] but seeds the trace green key (and thus
     /// `root_green_key`).  A unit test that drives a loop-closing
-    /// `jit_merge_point` must model the trace as having STARTED at that
-    /// loop header: the close fires only when the arriving green key
-    /// matches `root_green_key` (the primary loop).
+    /// `jit_merge_point` uses this to model the trace as having STARTED at
+    /// that loop header.
     pub fn for_test_types_with_green_key(types: &[majit_ir::Type], green_key: u64) -> Self {
         let mut recorder = Trace::new();
         for &tp in types {

--- a/pyre/bench/fannkuch.cranelift.jitstats
+++ b/pyre/bench/fannkuch.cranelift.jitstats
@@ -1,5 +1,5 @@
-bridges_compiled=40
-guard_failures=8203
+bridges_compiled=26
+guard_failures=5628
 internal_compile_panics=0
 loops_aborted=0
-loops_compiled=6
+loops_compiled=5

--- a/pyre/bench/fannkuch.dynasm.jitstats
+++ b/pyre/bench/fannkuch.dynasm.jitstats
@@ -1,5 +1,5 @@
-bridges_compiled=40
-guard_failures=8203
+bridges_compiled=26
+guard_failures=5628
 internal_compile_panics=0
 loops_aborted=0
-loops_compiled=6
+loops_compiled=5

--- a/pyre/bench/fib_loop.cranelift.jitstats
+++ b/pyre/bench/fib_loop.cranelift.jitstats
@@ -2,4 +2,4 @@ bridges_compiled=0
 guard_failures=190
 internal_compile_panics=0
 loops_aborted=0
-loops_compiled=2
+loops_compiled=1

--- a/pyre/bench/fib_loop.dynasm.jitstats
+++ b/pyre/bench/fib_loop.dynasm.jitstats
@@ -2,4 +2,4 @@ bridges_compiled=0
 guard_failures=190
 internal_compile_panics=0
 loops_aborted=0
-loops_compiled=2
+loops_compiled=1

--- a/pyre/bench/fib_recursive.cranelift.jitstats
+++ b/pyre/bench/fib_recursive.cranelift.jitstats
@@ -1,5 +1,5 @@
 bridges_compiled=3
-guard_failures=407
+guard_failures=406
 internal_compile_panics=0
 loops_aborted=0
-loops_compiled=2
+loops_compiled=1

--- a/pyre/bench/fib_recursive.dynasm.jitstats
+++ b/pyre/bench/fib_recursive.dynasm.jitstats
@@ -1,5 +1,5 @@
 bridges_compiled=3
-guard_failures=407
+guard_failures=406
 internal_compile_panics=0
 loops_aborted=0
-loops_compiled=2
+loops_compiled=1

--- a/pyre/bench/float_loop.cranelift.jitstats
+++ b/pyre/bench/float_loop.cranelift.jitstats
@@ -1,5 +1,5 @@
 bridges_compiled=0
-guard_failures=2
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
-loops_compiled=2
+loops_compiled=1

--- a/pyre/bench/float_loop.dynasm.jitstats
+++ b/pyre/bench/float_loop.dynasm.jitstats
@@ -1,5 +1,5 @@
 bridges_compiled=0
-guard_failures=2
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
-loops_compiled=2
+loops_compiled=1

--- a/pyre/bench/inline_helper.cranelift.jitstats
+++ b/pyre/bench/inline_helper.cranelift.jitstats
@@ -1,5 +1,5 @@
 bridges_compiled=0
-guard_failures=2
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
 loops_compiled=2

--- a/pyre/bench/inline_helper.dynasm.jitstats
+++ b/pyre/bench/inline_helper.dynasm.jitstats
@@ -1,5 +1,5 @@
 bridges_compiled=0
-guard_failures=2
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
 loops_compiled=2

--- a/pyre/bench/int_loop.cranelift.jitstats
+++ b/pyre/bench/int_loop.cranelift.jitstats
@@ -1,5 +1,5 @@
 bridges_compiled=0
-guard_failures=2
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
-loops_compiled=2
+loops_compiled=1

--- a/pyre/bench/int_loop.dynasm.jitstats
+++ b/pyre/bench/int_loop.dynasm.jitstats
@@ -1,5 +1,5 @@
 bridges_compiled=0
-guard_failures=2
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
-loops_compiled=2
+loops_compiled=1

--- a/pyre/bench/nbody.cranelift.jitstats
+++ b/pyre/bench/nbody.cranelift.jitstats
@@ -1,5 +1,5 @@
-bridges_compiled=5
-guard_failures=1287
+bridges_compiled=7
+guard_failures=1949
 internal_compile_panics=0
 loops_aborted=0
-loops_compiled=6
+loops_compiled=5

--- a/pyre/bench/nbody.dynasm.jitstats
+++ b/pyre/bench/nbody.dynasm.jitstats
@@ -1,5 +1,5 @@
-bridges_compiled=5
-guard_failures=1287
+bridges_compiled=6
+guard_failures=1580
 internal_compile_panics=0
 loops_aborted=0
-loops_compiled=6
+loops_compiled=5

--- a/pyre/bench/nested_loop.cranelift.jitstats
+++ b/pyre/bench/nested_loop.cranelift.jitstats
@@ -1,5 +1,5 @@
 bridges_compiled=1
-guard_failures=202
+guard_failures=201
 internal_compile_panics=0
 loops_aborted=0
-loops_compiled=2
+loops_compiled=1

--- a/pyre/bench/nested_loop.dynasm.jitstats
+++ b/pyre/bench/nested_loop.dynasm.jitstats
@@ -1,5 +1,5 @@
 bridges_compiled=1
-guard_failures=202
+guard_failures=201
 internal_compile_panics=0
 loops_aborted=0
-loops_compiled=2
+loops_compiled=1

--- a/pyre/bench/raise_catch_loop.cranelift.jitstats
+++ b/pyre/bench/raise_catch_loop.cranelift.jitstats
@@ -1,5 +1,5 @@
 bridges_compiled=1
-guard_failures=202
+guard_failures=201
 internal_compile_panics=0
 loops_aborted=0
-loops_compiled=2
+loops_compiled=1

--- a/pyre/bench/raise_catch_loop.dynasm.jitstats
+++ b/pyre/bench/raise_catch_loop.dynasm.jitstats
@@ -1,5 +1,5 @@
 bridges_compiled=1
-guard_failures=202
+guard_failures=201
 internal_compile_panics=0
 loops_aborted=0
-loops_compiled=2
+loops_compiled=1

--- a/pyre/bench/spectral_norm.cranelift.jitstats
+++ b/pyre/bench/spectral_norm.cranelift.jitstats
@@ -1,5 +1,5 @@
 bridges_compiled=2
-guard_failures=442
+guard_failures=520
 internal_compile_panics=0
 loops_aborted=0
-loops_compiled=4
+loops_compiled=2

--- a/pyre/bench/spectral_norm.dynasm.jitstats
+++ b/pyre/bench/spectral_norm.dynasm.jitstats
@@ -1,5 +1,5 @@
 bridges_compiled=2
-guard_failures=442
+guard_failures=520
 internal_compile_panics=0
 loops_aborted=0
-loops_compiled=4
+loops_compiled=2

--- a/pyre/bench/synth/comprehension_object_append_hot.cranelift.jitstats
+++ b/pyre/bench/synth/comprehension_object_append_hot.cranelift.jitstats
@@ -1,5 +1,5 @@
 bridges_compiled=18
-guard_failures=3700
+guard_failures=3611
 internal_compile_panics=0
-loops_aborted=2
-loops_compiled=7
+loops_aborted=0
+loops_compiled=6

--- a/pyre/bench/synth/comprehension_object_append_hot.dynasm.jitstats
+++ b/pyre/bench/synth/comprehension_object_append_hot.dynasm.jitstats
@@ -1,5 +1,5 @@
 bridges_compiled=18
-guard_failures=3700
+guard_failures=3611
 internal_compile_panics=0
-loops_aborted=2
-loops_compiled=7
+loops_aborted=0
+loops_compiled=6

--- a/pyre/bench/synth/const_arg_call_resume.cranelift.jitstats
+++ b/pyre/bench/synth/const_arg_call_resume.cranelift.jitstats
@@ -1,5 +1,5 @@
 bridges_compiled=9
-guard_failures=1846
+guard_failures=1804
 internal_compile_panics=0
-loops_aborted=1
-loops_compiled=5
+loops_aborted=0
+loops_compiled=3

--- a/pyre/bench/synth/const_arg_call_resume.dynasm.jitstats
+++ b/pyre/bench/synth/const_arg_call_resume.dynasm.jitstats
@@ -1,5 +1,5 @@
 bridges_compiled=9
-guard_failures=1846
+guard_failures=1804
 internal_compile_panics=0
-loops_aborted=1
-loops_compiled=5
+loops_aborted=0
+loops_compiled=3

--- a/pyre/bench/synth/nested_list_comprehension_hot.cranelift.jitstats
+++ b/pyre/bench/synth/nested_list_comprehension_hot.cranelift.jitstats
@@ -1,5 +1,5 @@
 bridges_compiled=6
-guard_failures=1228
+guard_failures=1203
 internal_compile_panics=0
-loops_aborted=2
-loops_compiled=3
+loops_aborted=0
+loops_compiled=2

--- a/pyre/bench/synth/nested_list_comprehension_hot.dynasm.jitstats
+++ b/pyre/bench/synth/nested_list_comprehension_hot.dynasm.jitstats
@@ -1,5 +1,5 @@
 bridges_compiled=6
-guard_failures=1228
+guard_failures=1203
 internal_compile_panics=0
-loops_aborted=2
-loops_compiled=3
+loops_aborted=0
+loops_compiled=2

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -397,11 +397,22 @@ def _jit_panic_reason(stderr):
 # ── Helpers ──────────────────────────────────────────────────────────
 
 def _jit_stats_snapshot(stderr):
-    """Return the last jit-stats line as normalized key/value text."""
+    """Return the last structural jit-stats line as normalized key/value text.
+
+    The diagnostic lines (mc_diag, heap_buckets, bridge_diag, fbw_diag,
+    exec_hist) share the `[jit-stats]` prefix but name themselves in a bare
+    first token; only the structural summary starts straight into key=value.
+    Reading one of those instead leaves loops_aborted and
+    internal_compile_panics missing, which the regression floor below reads as
+    0 — the gate would then never fire again, silently."""
     stats_line = None
     for line in stderr.splitlines():
-        if line.startswith("[jit-stats]"):
-            stats_line = line
+        if not line.startswith("[jit-stats]"):
+            continue
+        head = line[len("[jit-stats]") :].split()
+        if head and "=" not in head[0]:
+            continue
+        stats_line = line
     if stats_line is None:
         return None
 

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -10097,6 +10097,27 @@ fn handle<Sym: WalkSym>(
                             op.next_pc,
                         ));
                     }
+                    // The jump did not take. Closing here anyway lands on
+                    // `compile_loop`'s own `has_compiled_targets` check
+                    // (pyjitpl.py:3185-3189), which gives the whole trace up
+                    // with SwitchToBlackhole; and the cut would store the loop
+                    // under `cut_inner_green_key`, replacing reachable code
+                    // with code stored where nothing enters. Keep tracing
+                    // instead, so the trace closes at its own header with this
+                    // loop's body inlined — the interpreter front end declines
+                    // the same case for the same reason. Only a cross-loop cut
+                    // is declined: a trace that started at these greens still
+                    // closes on its own back-edge below.
+                    if key != ctx.trace_ctx.root_green_key() {
+                        if majit_metainterp::majit_log_enabled() {
+                            eprintln!(
+                                "[jit][walker-reached-loop-header] merge point pc={} already \
+                                 has a compiled loop key={} — declining the cross-loop cut",
+                                next_instr, key
+                            );
+                        }
+                        return Ok((DispatchOutcome::Continue, op.next_pc));
+                    }
                 }
             }
 
@@ -10107,54 +10128,41 @@ fn handle<Sym: WalkSym>(
                 .trace_ctx
                 .has_merge_point_with_shape_assert(key, live_args.len())
             {
-                // `reached_loop_header` closes the trace
-                // only at the loop whose green key MATCHES the one tracing
-                // started from. A top-level walk that re-arrives at a
-                // NON-primary header (an enclosing/sibling loop the recorded
-                // path crossed) must NOT close there: closing at a non-root
-                // header is the cross-loop cut (a pyre-only deviation) that
-                // retargets the green key and leaks the outer loop's
-                // exit-prediction guard into the cut inner-loop body
-                // (miscompiling a triangular nested loop). Continue the walk
-                // instead so it closes at the primary loop's own back-edge;
-                // an inner loop that is itself hot compiles as its OWN token
-                // and is reached via the compiled-target JUMP path above. Only
-                // the top-level walk is gated — a sub-walk keeps the prior
-                // close-on-match behaviour.
-                if !ctx.is_top_level || key == ctx.trace_ctx.root_green_key() {
-                    let loop_header_marker_jit_pc = {
-                        let sym_ptr = ctx.fbw_mode.snapshot_sym;
-                        if sym_ptr.is_null() {
+                // The matched merge point need not be the one tracing started
+                // from: `reached_loop_header` scans every registered merge
+                // point in reverse and closes at the first same_greenkey hit,
+                // whichever loop that is, and `compile_loop` re-derives the
+                // green key from the merge point it closed at.
+                let loop_header_marker_jit_pc = {
+                    let sym_ptr = ctx.fbw_mode.snapshot_sym;
+                    if sym_ptr.is_null() {
+                        None
+                    } else {
+                        let sym = unsafe { &*sym_ptr };
+                        if sym.jitcode().is_null() {
                             None
                         } else {
-                            let sym = unsafe { &*sym_ptr };
-                            if sym.jitcode().is_null() {
-                                None
-                            } else {
-                                unsafe {
-                                    (&*sym.jitcode())
-                                        .payload
-                                        .resume_marker_for_jitcode_pc(op.pc)
-                                }
+                            unsafe {
+                                (&*sym.jitcode())
+                                    .payload
+                                    .resume_marker_for_jitcode_pc(op.pc)
                             }
                         }
-                    };
-                    Ok((
-                        DispatchOutcome::CloseLoop {
-                            jump_args: live_args,
-                            loop_header_pc: next_instr,
-                            loop_header_marker_jit_pc,
-                        },
-                        op.next_pc,
-                    ))
-                } else {
-                    Ok((DispatchOutcome::Continue, op.next_pc))
-                }
+                    }
+                };
+                Ok((
+                    DispatchOutcome::CloseLoop {
+                        jump_args: live_args,
+                        loop_header_pc: next_instr,
+                        loop_header_marker_jit_pc,
+                    },
+                    op.next_pc,
+                ))
             } else {
-                // This merge point registers (does not close) — the walk
-                // crossed a loop-boundary that did not match the primary
-                // loop's green key, i.e. an enclosing or sibling loop whose
-                // header is `next_instr`.  The intermediate merge-point
+                // This merge point registers (does not close) — no already
+                // registered merge point carries this green key and red-bank
+                // shape, so this is the first arrival at the loop whose header
+                // is `next_instr`.  The intermediate merge-point
                 // vable→heap writeback (#62 / #67-remaining) already ran
                 // above, before the live-args build, mirroring
                 // `close_loop_args_at`'s ordering.

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
@@ -10385,11 +10385,10 @@ fn jit_merge_point_first_visit_continues_then_closes_loop() {
         0x02, 0x01, 0x02, // rr: len=2, [r1, r2]
         0x00, // rf: len=0
     ];
-    // Model the trace as having STARTED at this loop header: the close
-    // gate fires only when the arriving green key equals the primary
-    // `root_green_key` (a non-primary header re-arrival continues — the
-    // cross-loop-cut elimination).  The arriving key is
-    // `make_green_key(pycode, next_instr)` from the green concretes below.
+    // Model the trace as having STARTED at this loop header, so the second
+    // arrival closes on the merge point the first arrival registered.  The
+    // arriving key is `make_green_key(pycode, next_instr)` from the green
+    // concretes below.
     let mut tc = TraceCtx::for_test_types_with_green_key(
         &[Type::Ref],
         crate::driver::make_green_key(0x1_0000 as *const (), 42),

--- a/pyre/pyrex/src/lib.rs
+++ b/pyre/pyrex/src/lib.rs
@@ -848,16 +848,6 @@ fn maybe_print_jit_stats() {
     if std::env::var_os("MAJIT_STATS").is_none() {
         return;
     }
-    let stats = pyre_jit::eval::driver_pair().0.get_stats();
-    eprintln!(
-        "[jit-stats] loops_compiled={} bridges_compiled={} loops_aborted={} \
-         guard_failures={} internal_compile_panics={}",
-        stats.loops_compiled,
-        stats.bridges_compiled,
-        stats.loops_aborted,
-        stats.guard_failures,
-        stats.internal_compile_panics,
-    );
     // Gate tallies for the trace-entry and guard→bridge paths. These were
     // reachable only through the wasm runner's `pyre_jit_mc_diag` export, so a
     // native run had no way to see which gate declined a trace.
@@ -865,6 +855,12 @@ fn maybe_print_jit_stats() {
     // `all_descrs` rides along because it is the one table the optimizer grows
     // per trace while `descr.py:47` asserts it stays under 2**15 — upstream
     // fills it once at translation time, so only pyre can run into that bound.
+    //
+    // Printed BEFORE the structural summary: `check.py` `_jit_stats_snapshot`
+    // keeps the LAST `[jit-stats]` line, so the structural counters have to be
+    // last or the baseline compare reads these tallies instead and the
+    // loops_aborted / internal_compile_panics floor silently stops firing.
+    // The wasm runner orders its diag lines the same way.
     let all_descrs_len = pyre_jit::eval::driver_pair()
         .0
         .meta_interp()
@@ -876,6 +872,16 @@ fn maybe_print_jit_stats() {
     eprintln!(
         "[jit-stats] mc_diag {} all_descrs={all_descrs_len}",
         majit_metainterp::mc_diag_summary()
+    );
+    let stats = pyre_jit::eval::driver_pair().0.get_stats();
+    eprintln!(
+        "[jit-stats] loops_compiled={} bridges_compiled={} loops_aborted={} \
+         guard_failures={} internal_compile_panics={}",
+        stats.loops_compiled,
+        stats.bridges_compiled,
+        stats.loops_aborted,
+        stats.guard_failures,
+        stats.internal_compile_panics,
     );
 }
 


### PR DESCRIPTION
Removes the two pyre-only gates that stood between a guard failure and the
bridge/loop that should answer it, and repairs the `check.py` gate that #851
silently disabled.

## The close gate

`jitcode_dispatch::handle`'s `jit_merge_point` arm closed a **top-level** walk
only when the arriving green key equalled `root_green_key`:

```rust
if !ctx.is_top_level || key == ctx.trace_ctx.root_green_key() {
```

`reached_loop_header` has no such restriction. It scans **every** registered
merge point in reverse and closes at the first `same_greenkey` hit, whichever
loop that is (`pyjitpl.py:3018-3022`), appending a new merge point for each
non-matching arrival (`:3060`). `compile_loop` then attaches the procedure to
`original_boxes[:num_green_args]` — the greenkey of the merge point it closed
at, not the trace's start key (`pyjitpl.py:3182-3196`).

Pyre already carries that retarget on this exact outcome:
`full_body_walk_trace` sets the green key and `cut_inner_green_key` when
`loop_header_pc != start_pc`, which routes `compile_loop` through
`cross_loop_cut` (`compile.py:269-270`), and
`has_merge_point_with_shape_assert` is already the reverse-scan-any-match. The
gate was suppressing a fully wired path, not guarding an unimplemented one.

The disjunct only ever affected top-level walks — for a sub-walk `!is_top_level`
was already true, so sub-walk behaviour is unchanged.

## Declining the cut at a merge point that already has a compiled loop

Removing the gate on its own regressed `fannkuch` to `loops_aborted 0 -> 4`.
Root cause, from the walk log:

```
[jit] compile_trace(jump): key=3472069868542305897, ops=137, origin=None
[jit] compile_trace(jump): key=3472069868542305897, ops=183, origin=None
[jit] compile_loop → SwitchToBlackhole: has_compiled_targets key=3472069868542305897
```

The walker implements `pyjitpl.py:3002-3007` — when the arriving greens already
have compiled targets it closes the trace as a bridge jumping into them. When
that jump does **not** take, the walk used to fall through and close a loop
there anyway, landing on `compile_loop`'s own `has_compiled_targets` check
(`pyjitpl.py:3185-3189`, upstream's "XXX this path not tested, but shown to
occur on pypy-c") which gives the whole trace up. The comment above that
compile_trace attempt already describes this failure mode; what was missing was
the handling for the attempt failing.

The interpreter front end already declines exactly this case, because pyre's cut
stores the loop under `cut_inner_green_key` and would replace reachable code
with code stored where nothing enters. The walker now declines it the same way:
keep tracing, so the trace closes at its own header with this loop's body
inlined. Only a cross-loop cut is declined; a trace that started at those greens
still closes on its own back-edge.

## The untallied `must_compile` gate

`must_compile_with_values` returned **before** the jitcounter tick when the
failed guard's owning `JitCellToken` had been invalidated:

```rust
if owning_jct.as_ref().is_some_and(|jct| jct.is_invalidated()) {
    return (false, owning_key);
}
```

`ResumeGuardDescr.must_compile` (`compile.py:738-784`) has no invalidated-owner
gate — it ticks regardless, and that tick *is* the recovery: once it fires, the
bridge walk reaches `reached_loop_header`, `get_procedure_token` filters the
dead token and returns `None`, and `compile_loop` installs a live replacement
for the key. Suppressing the tick deletes that recovery path, so every later
activation of the dead trace goes to blackhole resume forever.

It was also the only early return in the function with no `mc_diag` tally, which
is why #851's readout could locate it only by elimination.

## The `[jit-stats]` line #851 broke

#851 added the `mc_diag` tally line **after** the structural summary, and both
carry the `[jit-stats]` prefix. `check.py` `_jit_stats_snapshot` keeps the LAST
such line, so every baseline compare read the tallies instead — leaving
`loops_aborted` and `internal_compile_panics` absent, which the regression floor
reads as 0. That floor runs on **every** `check.py` invocation, not just
`--snapshot-diff`, so it had silently stopped being able to fire.

Fixed on both sides: the structural summary is printed last again (the wasm
runner already orders its diag lines that way for this reason), and the parser
skips lines whose first token after the prefix is a bare name rather than
`key=value`. The fannkuch regression above is what the restored floor caught.

## Measurement

dynasm release, `OLD` = the pre-change binary, medians of 3–5 runs. Output is
byte-identical to `OLD` on every bench listed, and on all 12 `nested*` /
`*quasiimmut*` synth benches.

| bench | OLD wall | NEW wall | OLD loops/bridges/aborted/gf | NEW |
|---|---|---|---|---|
| `global_quasiimmut_invalidation` | 0.45s | **0.18s** | 2 / 2 / 0 / 402 | 2 / 5 / 0 / 1003 |
| `fannkuch` | 3.69s | **2.50s** | 5 / 65 / 0 / 14737 | 5 / 26 / 0 / 5628 |
| `nbody` | — | — | 6 / 10 / 0 / 2077 | 5 / 6 / 0 / 1580 |
| `nested_break_not_hot` | 0.98s | **0.64s** | 1 / 3 / 0 / 602 | 2 / 4 / 0 / 1001 |
| `nested_for_outer_local_postread` | 0.72s | **0.38s** | 4 / 10 / 0 / 2006 | 5 / 9 / 0 / 2141 |

1003 guard failures at `trace_eagerness=200` is ~5 firings, which is exactly the
5 bridges built — the counter ticks and the bridges land, where before the gate
it read 402/2 and under a diagnostic lift of the close gate alone (#851's
measurement) it read 995258 failures against **3** firings.

## Re-recorded `.jitstats` baselines

26 files (13 per backend). Attribution, measured against the pre-change binary:

* `fannkuch` and `nbody` move because of **this** change, both toward fewer
  bridges and fewer guard failures.
* The other eleven — including `loops_aborted` 2→0, 1→0 and 2→0 on
  `comprehension_object_append_hot`, `const_arg_call_resume` and
  `nested_list_comprehension_hot` — were **already** stale on `main`: the
  pre-change binary produces the new numbers too. The count-valued fields are
  documented as informational and are only compared under `--snapshot-diff`, so
  they drifted while the badness floor was disabled.

No `loops_aborted` value rises: every change to it is a fall (1→0 twice, 2→0
four times), and `internal_compile_panics` stays 0 everywhere.

## Verification

`cargo fmt --check` clean. `cargo test -p pyre-jit-trace --features dynasm`:
311 passed, 0 failed. `pyre/check.py --snapshot-diff` on dynasm and cranelift:
**331 passed, 1 failed** each. The one failure is `synth/ast_compile_roundtrip`,
a `BASEFAIL` from this base — the harness's own oracle pair disagrees and pyre
never runs:

```
< hand reject named-target-not-name TypeError     # CPython 3.14.2
> hand reject named-target-not-name ValueError    # PyPy 3.11.13
```

It arrived with `a510d58a73` (#856) and fails identically on a clean
`origin/main`.
