### PR TITLE
_socket, sys, posix, mapdict, faulthandler, _warnings: parity fixes

### DIFF
--- a/pyre/extra_tests/snippets/stdlib_warnings.py
+++ b/pyre/extra_tests/snippets/stdlib_warnings.py
@@ -27,6 +27,19 @@ with warnings.catch_warnings(record=True) as caught:
     assert warning.line is None
 
 with warnings.catch_warnings(record=True) as caught:
+    warnings.simplefilter("always")
+    source = []
+    _warnings.warn("positional source", UserWarning, 1, source)
+    assert caught[-1].source is source
+
+try:
+    _warnings.warn("too many", UserWarning, 1, None, ())
+except TypeError:
+    pass
+else:
+    raise AssertionError("positional skip_file_prefixes accepted")
+
+with warnings.catch_warnings(record=True) as caught:
     warnings.simplefilter("ignore", UserWarning)
     registry = {}
     _warnings.warn_explicit(

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -2359,7 +2359,7 @@ pub fn install_default_builtins(ns: PyObjectRef) {
         crate::typedef::gettypeobject(&pyre_object::functional::FILTER_TYPE)
     });
     crate::module_ns_get_or_insert_with(ns, "input", || {
-        make_module_builtin_function("input", |_| Ok(pyre_object::w_str_new("")))
+        make_module_builtin_function("input", builtin_input)
     });
     crate::module_ns_get_or_insert_with(ns, "open", || {
         make_module_builtin_function("open", builtin_open)
@@ -2873,6 +2873,75 @@ fn resolve_default_print_target() -> Result<DefaultPrintTarget, crate::PyError> 
         }
     }
     Ok(DefaultPrintTarget::Rebound(stdout))
+}
+
+fn input_call_method(
+    object: PyObjectRef,
+    name: &str,
+    args: &[PyObjectRef],
+) -> Result<PyObjectRef, crate::PyError> {
+    let result = crate::baseobjspace::call_method(object, name, args);
+    if result.is_null() {
+        Err(crate::call::take_call_error()
+            .unwrap_or_else(|| crate::PyError::runtime_error(format!("{name} failed"))))
+    } else {
+        Ok(result)
+    }
+}
+
+/// PyPy `pypy/module/__builtin__/app_io.py:input`.
+///
+/// Resolve all three live sys streams, flush stderr, emit and flush the prompt
+/// through stdout, then consume one line from stdin. This preserves redirected
+/// StringIO streams as well as the interpreter-created standard streams.
+fn builtin_input(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    if args.len() > 1 {
+        return Err(crate::PyError::type_error(format!(
+            "input expected at most 1 argument, got {}",
+            args.len()
+        )));
+    }
+    let sys = crate::importing::get_sys_module("sys")
+        .ok_or_else(|| crate::PyError::runtime_error("input: lost sys.stdin"))?;
+    let stream = |name: &str| {
+        crate::baseobjspace::getattr_str(sys, name)
+            .map_err(|_| crate::PyError::runtime_error(format!("input: lost sys.{name}")))
+    };
+    let stdin = stream("stdin")?;
+    let stdout = stream("stdout")?;
+    let stderr = stream("stderr")?;
+    let _ = input_call_method(stderr, "flush", &[])?;
+
+    let prompt = match args.first().copied() {
+        Some(value) => builtin_str(&[value])?,
+        None => w_str_new(""),
+    };
+    let _roots = pyre_object::gc_roots::push_roots();
+    pyre_object::gc_roots::pin_root(prompt);
+    let prompt_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+    let _ = input_call_method(
+        stdout,
+        "write",
+        &[pyre_object::gc_roots::shadow_stack_get(prompt_slot)],
+    )?;
+    let _ = input_call_method(stdout, "flush", &[])?;
+
+    let line = input_call_method(stdin, "readline", &[])?;
+    if !unsafe { pyre_object::is_str(line) } {
+        return Err(crate::PyError::type_error("input() returned non-string"));
+    }
+    let value = crate::baseobjspace::str_utf8_w(line)?;
+    if value.is_empty() {
+        let message = "EOF when reading a line";
+        let mut error = crate::PyError::value_error(message);
+        if let Some(class) = lookup_exc_class("EOFError") {
+            if let Ok(exception) = exc_exception_new(&[class, w_str_new(message)]) {
+                error.exc_object = exception;
+            }
+        }
+        return Err(error);
+    }
+    Ok(w_str_new(value.strip_suffix('\n').unwrap_or(value)))
 }
 
 fn builtin_print(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {

--- a/pyre/pyre-interpreter/src/executioncontext.rs
+++ b/pyre/pyre-interpreter/src/executioncontext.rs
@@ -682,7 +682,11 @@ impl ExecutionContext {
     /// observes the unmodified instr_prev_plus_one and can fire its
     /// first `line` event correctly).
     pub fn bytecode_only_trace(&mut self, frame: *mut PyFrame) -> Result<(), crate::PyError> {
-        if self.space.is_null() || frame.is_null() {
+        // PyPy has no object-space-null guard here: `space` is the interpreter
+        // owner, not an optional tracing flag. Pyre represents that owner with
+        // PY_NULL in this runtime, so testing it suppressed every line event
+        // while still allowing call/return events through `_trace`.
+        if frame.is_null() {
             return Ok(());
         }
         let f_trace_is_none = unsafe { (*frame).get_w_f_trace().is_null() };
@@ -716,7 +720,7 @@ impl ExecutionContext {
     ///     d.instr_prev_plus_one = frame.last_instr + 1
     /// ```
     pub fn run_trace_func(&mut self, frame: *mut PyFrame) -> Result<(), crate::PyError> {
-        if self.space.is_null() || frame.is_null() {
+        if frame.is_null() {
             return Ok(());
         }
         // executioncontext.py:189-192:

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -1657,7 +1657,16 @@ static SYS_DEV_MODE: AtomicBool = AtomicBool::new(false);
 static SYS_UTF8_MODE: AtomicI64 = AtomicI64::new(0);
 static SYS_SAFE_PATH: AtomicBool = AtomicBool::new(false);
 static SYS_OPTIMIZE: AtomicI64 = AtomicI64::new(0);
+static SYS_BYTES_WARNING: AtomicI64 = AtomicI64::new(0);
 static SYS_DONT_WRITE_BYTECODE: AtomicBool = AtomicBool::new(false);
+static SYS_UNBUFFERED: AtomicBool = AtomicBool::new(false);
+// pypy/interpreter/app_main.py keeps the raw `-X` strings in
+// `options['_xoptions']` (a list) until sys initialization builds the public
+// dict.  Preserve that owner/storage shape rather than introducing a map here.
+static SYS_XOPTIONS: LazyLock<Mutex<Vec<String>>> = LazyLock::new(|| Mutex::new(Vec::new()));
+static SYS_WARNOPTIONS: LazyLock<Mutex<Vec<String>>> = LazyLock::new(|| Mutex::new(Vec::new()));
+static SYS_ORIG_ARGV: LazyLock<Mutex<Vec<String>>> = LazyLock::new(|| Mutex::new(Vec::new()));
+static SYS_STDIO_ENCODING: LazyLock<Mutex<Option<String>>> = LazyLock::new(|| Mutex::new(None));
 
 /// Record whether the launcher was given `-S` (no `site` import), so the
 /// `sys.flags.no_site` field built during sys module init reflects it. Set
@@ -1685,7 +1694,12 @@ pub fn set_runtime_flags(
     utf8_mode: i64,
     safe_path: bool,
     optimize: i64,
+    bytes_warning: i64,
     dont_write_bytecode: bool,
+    unbuffered: bool,
+    xoptions: Vec<String>,
+    warnoptions: Vec<String>,
+    stdio_encoding: Option<String>,
 ) {
     SYS_QUIET.store(quiet, Ordering::Relaxed);
     SYS_INSPECT.store(inspect, Ordering::Relaxed);
@@ -1696,7 +1710,41 @@ pub fn set_runtime_flags(
     SYS_UTF8_MODE.store(utf8_mode, Ordering::Relaxed);
     SYS_SAFE_PATH.store(safe_path, Ordering::Relaxed);
     SYS_OPTIMIZE.store(optimize, Ordering::Relaxed);
+    SYS_BYTES_WARNING.store(bytes_warning, Ordering::Relaxed);
     SYS_DONT_WRITE_BYTECODE.store(dont_write_bytecode, Ordering::Relaxed);
+    SYS_UNBUFFERED.store(unbuffered, Ordering::Relaxed);
+    *SYS_XOPTIONS.lock().unwrap() = xoptions;
+    *SYS_WARNOPTIONS.lock().unwrap() = warnoptions;
+    *SYS_STDIO_ENCODING.lock().unwrap() = stdio_encoding;
+}
+
+/// Raw `-X` values recorded by the launcher, in command-line order.
+pub fn xoptions() -> Vec<String> {
+    SYS_XOPTIONS.lock().unwrap().clone()
+}
+
+pub fn bytes_warning_flag() -> i64 {
+    SYS_BYTES_WARNING.load(Ordering::Relaxed)
+}
+
+pub fn unbuffered_flag() -> bool {
+    SYS_UNBUFFERED.load(Ordering::Relaxed)
+}
+
+pub fn warnoptions() -> Vec<String> {
+    SYS_WARNOPTIONS.lock().unwrap().clone()
+}
+
+pub fn stdio_encoding() -> Option<String> {
+    SYS_STDIO_ENCODING.lock().unwrap().clone()
+}
+
+pub fn set_sys_orig_argv(argv: Vec<String>) {
+    *SYS_ORIG_ARGV.lock().unwrap() = argv;
+}
+
+pub fn sys_orig_argv() -> Vec<String> {
+    SYS_ORIG_ARGV.lock().unwrap().clone()
 }
 
 pub fn quiet_flag() -> bool {

--- a/pyre/pyre-interpreter/src/module/_io/textio.rs
+++ b/pyre/pyre-interpreter/src/module/_io/textio.rs
@@ -800,21 +800,28 @@ impl W_TextIOWrapper {
     /// Allocate the typed payload used by the interpreter-created standard
     /// streams.  Their methods and metadata remain instance overrides until
     /// sys stream construction is ported to a real FileIO-backed pipeline.
-    pub(crate) fn allocate_stdio(name: &str, encoding: &str, errors: &str) -> PyObjectRef {
+    pub(crate) fn allocate_stdio(
+        name: &str,
+        buffer: PyObjectRef,
+        encoding: &str,
+        errors: &str,
+        line_buffering: bool,
+        write_through: bool,
+    ) -> PyObjectRef {
         // Establish the Python type and its mapdict layout before allocating
         // a payload whose stdio methods are installed in the instance dict.
         let _ = type_object();
         let obj = Self::allocate_stable(Self {
             state: STATE_OK,
-            w_buffer: w_none(),
+            w_buffer: buffer,
             w_encoding: w_str_new(encoding),
             w_errors: w_str_new(errors),
             w_newline: w_none(),
             w_stdio_name: w_str_new(name),
             w_encoder: PY_NULL,
             w_decoder: PY_NULL,
-            line_buffering: false,
-            write_through: false,
+            line_buffering,
+            write_through,
             decoded: DecodeBuffer::default(),
             snapshot: None,
             pending_bytes: None,

--- a/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
+++ b/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
@@ -92,7 +92,7 @@ struct ServentRaw {
 /// into a `Vec<u8>` suitable for passing to a DNS resolver.
 ///
 /// Accepts str / bytes / bytearray.  For str: tries ASCII first; on
-/// UnicodeEncodeError falls back to `.encode('idna')`.  Embedded null
+/// UnicodeEncodeError falls back to the `idna` codec.  Embedded null
 /// bytes raise TypeError (matching `:120-122`).  Other input types
 /// raise TypeError.
 #[cfg(unix)]
@@ -111,23 +111,12 @@ fn socket_idna_converter(w_host: pyre_object::PyObjectRef) -> Result<Vec<u8>, cr
             if s.as_bytes().is_ascii() {
                 s.as_bytes().to_vec()
             } else {
-                let method = crate::baseobjspace::getattr_str(w_host, "encode")?;
-                let codec = pyre_object::w_str_new("idna");
-                let encoded = crate::call_function(method, &[codec]);
-                if encoded.is_null() {
-                    // The codec's own error is what the caller sees — a host
-                    // the `idna` codec rejects raises that rejection, not a
-                    // substituted one.
-                    return Err(crate::call::take_call_error().unwrap_or_else(|| {
-                        crate::PyError::type_error("idna encoding failed")
-                    }));
-                }
-                if !pyre_object::bytesobject::is_bytes_like(encoded) {
-                    return Err(crate::PyError::type_error(
-                        "idna encode did not return bytes",
-                    ));
-                }
-                pyre_object::w_bytes_data(encoded).to_vec()
+                // `space.encode_unicode_object(w_host, 'idna', None)`: the
+                // codec runs on the string value itself rather than through
+                // an `encode` attribute lookup, so a `str` subclass cannot
+                // decide how its hostname reaches the resolver, and the
+                // error a caller sees is the codec's own rejection.
+                crate::type_methods::encode_object(w_host, "idna", "strict")?
             }
         } else if pyre_object::bytesobject::is_bytes_like(w_host) {
             pyre_object::w_bytes_data(w_host).to_vec()

--- a/pyre/pyre-interpreter/src/module/_warnings/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_warnings/mod.rs
@@ -813,7 +813,7 @@ crate::py_module! {
             message: PyObjectRef,
             #[default(pyre_object::PY_NULL)] category: PyObjectRef,
             #[default(1i64)] stacklevel: i64,
-            #[kwonly] #[default(pyre_object::PY_NULL)] source: PyObjectRef,
+            #[default(pyre_object::PY_NULL)] source: PyObjectRef,
             #[kwonly] #[default(pyre_object::PY_NULL)] skip_file_prefixes: PyObjectRef,
         ) -> Result<PyObjectRef, PyError> {
             // CPython 3.14 `_warnings.warn`: `skip_file_prefixes` is a

--- a/pyre/pyre-interpreter/src/module/faulthandler/handler.rs
+++ b/pyre/pyre-interpreter/src/module/faulthandler/handler.rs
@@ -4,7 +4,6 @@
 //! was renamed to `register_module`; the host_env signal handlers and the
 //! `faulthandler_extract_fd` helper stay private.
 
-
 // faulthandler module — PyPy: pypy/module/faulthandler/.
 //
 // CPython's faulthandler dumps the Python traceback on fatal signals.
@@ -60,27 +59,27 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         crate::make_builtin_function_with_signature(
             "enable",
             |args| {
-            // `handler.py:141-145 enable` — file=None, all_threads=True.
-            let _fd =
-                faulthandler_extract_fd(args.first().copied().unwrap_or(pyre_object::PY_NULL))?;
-            #[cfg(all(unix, feature = "host_env"))]
-            {
-                let ok = rustpython_host_env::faulthandler::enable_fatal_handlers(
-                    faulthandler_signal_handler,
-                    libc::SA_NODEFER | libc::SA_ONSTACK,
-                );
-                if ok {
-                    FAULTHANDLER_ENABLED.store(true, std::sync::atomic::Ordering::Relaxed);
-                    return Ok(pyre_object::w_none());
+                // `handler.py:141-145 enable` — file=None, all_threads=True.
+                let _fd =
+                    faulthandler_extract_fd(args.first().copied().unwrap_or(pyre_object::PY_NULL))?;
+                #[cfg(all(unix, feature = "host_env"))]
+                {
+                    let ok = rustpython_host_env::faulthandler::enable_fatal_handlers(
+                        faulthandler_signal_handler,
+                        libc::SA_NODEFER | libc::SA_ONSTACK,
+                    );
+                    if ok {
+                        FAULTHANDLER_ENABLED.store(true, std::sync::atomic::Ordering::Relaxed);
+                        return Ok(pyre_object::w_none());
+                    }
+                    return Err(crate::PyError::runtime_error(
+                        "faulthandler.enable: sigaction failed",
+                    ));
                 }
-                return Err(crate::PyError::runtime_error(
-                    "faulthandler.enable: sigaction failed",
-                ));
-            }
-            #[cfg(not(all(unix, feature = "host_env")))]
-            Err(crate::PyError::not_implemented(
-                "faulthandler.enable requires host_env feature",
-            ))
+                #[cfg(not(all(unix, feature = "host_env")))]
+                Err(crate::PyError::not_implemented(
+                    "faulthandler.enable requires host_env feature",
+                ))
             },
             // `enable(file=sys.stderr, all_threads=True, c_stack=True)` —
             // `c_stack` (3.14) selects C-stack dumping; accept and ignore it.
@@ -163,58 +162,59 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         crate::make_builtin_function_with_signature(
             "register",
             |args| {
-            let w_signum = args.first().copied().unwrap_or(pyre_object::PY_NULL);
-            if w_signum.is_null() {
-                return Err(crate::PyError::type_error("register() missing signal"));
-            }
-            let signum = (unsafe { pyre_object::w_int_get_value(w_signum) }) as libc::c_int;
-            let fd = faulthandler_extract_fd(args.get(1).copied().unwrap_or(pyre_object::PY_NULL))?;
-            // handler.py:174 `@unwrap_spec(all_threads=int, chain=int)`
-            // with defaults `all_threads=1, chain=0`: the arguments are
-            // coerced as integers (`gateway_int_w`, raising on a non-int),
-            // not by truthiness; `register` then tests `if all_threads:`.  An
-            // omitted keyword leaves a null slot from the signature binding, so
-            // treat null as the default.
-            let all_threads = args
-                .get(2)
-                .copied()
-                .filter(|a| !a.is_null())
-                .map(crate::baseobjspace::gateway_int_w)
-                .transpose()?
-                .unwrap_or(1)
-                != 0;
-            let chain = args
-                .get(3)
-                .copied()
-                .filter(|a| !a.is_null())
-                .map(crate::baseobjspace::gateway_int_w)
-                .transpose()?
-                .unwrap_or(0)
-                != 0;
-            #[cfg(all(unix, feature = "host_env"))]
-            {
-                rustpython_host_env::faulthandler::register_user_signal(
-                    signum,
-                    fd,
-                    all_threads,
-                    chain,
-                    faulthandler_user_handler,
-                )
-                .map_err(|e| {
-                    crate::PyError::os_error_with_errno(
-                        e.raw_os_error().unwrap_or(0),
-                        format!("register: {e}"),
+                let w_signum = args.first().copied().unwrap_or(pyre_object::PY_NULL);
+                if w_signum.is_null() {
+                    return Err(crate::PyError::type_error("register() missing signal"));
+                }
+                let signum = (unsafe { pyre_object::w_int_get_value(w_signum) }) as libc::c_int;
+                let fd =
+                    faulthandler_extract_fd(args.get(1).copied().unwrap_or(pyre_object::PY_NULL))?;
+                // handler.py:174 `@unwrap_spec(all_threads=int, chain=int)`
+                // with defaults `all_threads=1, chain=0`: the arguments are
+                // coerced as integers (`gateway_int_w`, raising on a non-int),
+                // not by truthiness; `register` then tests `if all_threads:`.  An
+                // omitted keyword leaves a null slot from the signature binding, so
+                // treat null as the default.
+                let all_threads = args
+                    .get(2)
+                    .copied()
+                    .filter(|a| !a.is_null())
+                    .map(crate::baseobjspace::gateway_int_w)
+                    .transpose()?
+                    .unwrap_or(1)
+                    != 0;
+                let chain = args
+                    .get(3)
+                    .copied()
+                    .filter(|a| !a.is_null())
+                    .map(crate::baseobjspace::gateway_int_w)
+                    .transpose()?
+                    .unwrap_or(0)
+                    != 0;
+                #[cfg(all(unix, feature = "host_env"))]
+                {
+                    rustpython_host_env::faulthandler::register_user_signal(
+                        signum,
+                        fd,
+                        all_threads,
+                        chain,
+                        faulthandler_user_handler,
                     )
-                })?;
-                return Ok(pyre_object::w_none());
-            }
-            #[cfg(not(all(unix, feature = "host_env")))]
-            {
-                let _ = (fd, all_threads, chain);
-                Err(crate::PyError::not_implemented(
-                    "faulthandler.register requires host_env feature",
-                ))
-            }
+                    .map_err(|e| {
+                        crate::PyError::os_error_with_errno(
+                            e.raw_os_error().unwrap_or(0),
+                            format!("register: {e}"),
+                        )
+                    })?;
+                    return Ok(pyre_object::w_none());
+                }
+                #[cfg(not(all(unix, feature = "host_env")))]
+                {
+                    let _ = (fd, all_threads, chain);
+                    Err(crate::PyError::not_implemented(
+                        "faulthandler.register requires host_env feature",
+                    ))
+                }
             },
             crate::Signature::new(
                 vec!["signum", "file", "all_threads", "chain"],
@@ -259,31 +259,41 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     crate::module_ns_store(
         ns,
         "_read_null",
-        crate::make_builtin_function_with_arity(
-            "_read_null",
-            |_| {
-                // `handler.py:225 read_null` — null-pointer deref.
-                let p: *const u8 = std::ptr::null();
-                let _ = unsafe { p.read_volatile() };
-                Ok(pyre_object::w_none())
-            },
-            0,
-        ),
+        crate::make_builtin_function("_read_null", |args| {
+            if args.len() > 1 {
+                return Err(crate::PyError::type_error(format!(
+                    "_read_null() takes at most 1 argument ({} given)",
+                    args.len()
+                )));
+            }
+            if let Some(&release_gil) = args.first() {
+                let _ = crate::baseobjspace::int_w(release_gil)?;
+            }
+            // `handler.py:225 read_null` — null-pointer deref.
+            let p: *const u8 = std::ptr::null();
+            let _ = unsafe { p.read_volatile() };
+            Ok(pyre_object::w_none())
+        }),
     );
     crate::module_ns_store(
         ns,
         "_sigsegv",
-        crate::make_builtin_function_with_arity(
-            "_sigsegv",
-            |_| {
-                #[cfg(unix)]
-                unsafe {
-                    libc::raise(libc::SIGSEGV);
-                }
-                Ok(pyre_object::w_none())
-            },
-            0,
-        ),
+        crate::make_builtin_function("_sigsegv", |args| {
+            if args.len() > 1 {
+                return Err(crate::PyError::type_error(format!(
+                    "_sigsegv() takes at most 1 argument ({} given)",
+                    args.len()
+                )));
+            }
+            if let Some(&release_gil) = args.first() {
+                let _ = crate::baseobjspace::int_w(release_gil)?;
+            }
+            #[cfg(unix)]
+            unsafe {
+                libc::raise(libc::SIGSEGV);
+            }
+            Ok(pyre_object::w_none())
+        }),
     );
     crate::module_ns_store(
         ns,

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -36,11 +36,7 @@ pub(crate) fn walk_fork_callback_roots(visitor: &mut dyn FnMut(&mut PyObjectRef)
         parent_w,
         child_w,
     } = &mut *callbacks;
-    for callbacks in [
-        before_w,
-        parent_w,
-        child_w,
-    ] {
+    for callbacks in [before_w, parent_w, child_w] {
         for callback in callbacks {
             visitor(unsafe { &mut *(callback as *mut usize as *mut PyObjectRef) });
         }
@@ -75,8 +71,7 @@ fn run_fork_callbacks(kind: &str) {
             .copied()
         };
         let Some(callback) = callback else { continue };
-        if let Err(mut error) =
-            crate::call::call_function_impl_result(callback as PyObjectRef, &[])
+        if let Err(mut error) = crate::call::call_function_impl_result(callback as PyObjectRef, &[])
         {
             error.write_unraisable(pyre_object::w_none(), "fork hook", callback as PyObjectRef);
         }
@@ -141,60 +136,60 @@ fn register_at_fork(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
 fn stat_result_seq_type() -> PyObjectRef {
     static STAT_RESULT_SEQ_TYPE: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
     *STAT_RESULT_SEQ_TYPE.get_or_init(|| {
-            crate::_structseq::make_struct_seq_with_extra(
-                // Dotted name → `__name__` "stat_result", repr "os.stat_result(...)".
-                "os.stat_result",
-                // `app_posix.py:20-37` — slots 7..10 are the hidden integer
-                // timestamps; the float `st_atime`/`st_mtime`/`st_ctime` are
-                // named-only extras, never indexable.
-                &[
-                    "st_mode",
-                    "st_ino",
-                    "st_dev",
-                    "st_nlink",
-                    "st_uid",
-                    "st_gid",
-                    "st_size",
-                    "_integer_atime",
-                    "_integer_mtime",
-                    "_integer_ctime",
-                ],
-                // `app_posix.py:38-69` — named-only extras ordered by their
-                // `structseqfield` index (11..13, 20..23, 40..42, 50..52).
-                // `structseq_descr_new` fills surplus sequence items into
-                // this list in order, so the list order must match PyPy's
-                // index sort, not the build-time population order.
-                &[
-                    // float times, indices 11..13.
-                    "st_atime",
-                    "st_mtime",
-                    "st_ctime",
-                    // `app_posix.py:45-52` — present where the platform's
-                    // `struct stat` carries them (every Unix target),
-                    // indices 20..23.
-                    #[cfg(unix)]
-                    "st_blksize",
-                    #[cfg(unix)]
-                    "st_blocks",
-                    #[cfg(unix)]
-                    "st_rdev",
-                    // `rposix_stat.py` exposes `st_flags` where the C
-                    // `struct stat` carries it (BSD family / macOS).
-                    #[cfg(target_os = "macos")]
-                    "st_flags",
-                    // `build_stat_result` (interp_posix.py:554-557) +
-                    // `rposix_stat.py STAT_FIELDS += ALL_STAT_FIELDS[-3:]`
-                    // — the sub-second nanosecond remainders, indices 40..42.
-                    "nsec_atime",
-                    "nsec_mtime",
-                    "nsec_ctime",
-                    // full nanosecond timestamps, indices 50..52.
-                    "st_atime_ns",
-                    "st_mtime_ns",
-                    "st_ctime_ns",
-                ],
-            ) as usize
-        }) as PyObjectRef
+        crate::_structseq::make_struct_seq_with_extra(
+            // Dotted name → `__name__` "stat_result", repr "os.stat_result(...)".
+            "os.stat_result",
+            // `app_posix.py:20-37` — slots 7..10 are the hidden integer
+            // timestamps; the float `st_atime`/`st_mtime`/`st_ctime` are
+            // named-only extras, never indexable.
+            &[
+                "st_mode",
+                "st_ino",
+                "st_dev",
+                "st_nlink",
+                "st_uid",
+                "st_gid",
+                "st_size",
+                "_integer_atime",
+                "_integer_mtime",
+                "_integer_ctime",
+            ],
+            // `app_posix.py:38-69` — named-only extras ordered by their
+            // `structseqfield` index (11..13, 20..23, 40..42, 50..52).
+            // `structseq_descr_new` fills surplus sequence items into
+            // this list in order, so the list order must match PyPy's
+            // index sort, not the build-time population order.
+            &[
+                // float times, indices 11..13.
+                "st_atime",
+                "st_mtime",
+                "st_ctime",
+                // `app_posix.py:45-52` — present where the platform's
+                // `struct stat` carries them (every Unix target),
+                // indices 20..23.
+                #[cfg(unix)]
+                "st_blksize",
+                #[cfg(unix)]
+                "st_blocks",
+                #[cfg(unix)]
+                "st_rdev",
+                // `rposix_stat.py` exposes `st_flags` where the C
+                // `struct stat` carries it (BSD family / macOS).
+                #[cfg(target_os = "macos")]
+                "st_flags",
+                // `build_stat_result` (interp_posix.py:554-557) +
+                // `rposix_stat.py STAT_FIELDS += ALL_STAT_FIELDS[-3:]`
+                // — the sub-second nanosecond remainders, indices 40..42.
+                "nsec_atime",
+                "nsec_mtime",
+                "nsec_ctime",
+                // full nanosecond timestamps, indices 50..52.
+                "st_atime_ns",
+                "st_mtime_ns",
+                "st_ctime_ns",
+            ],
+        ) as usize
+    }) as PyObjectRef
 }
 
 /// `os.terminal_size` structseq — `(columns, lines)`.
@@ -211,9 +206,9 @@ fn uname_result_seq_type() -> PyObjectRef {
     static T: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
     *T.get_or_init(|| {
         crate::_structseq::make_struct_seq(
-                "posix.uname_result",
-                &["sysname", "nodename", "release", "version", "machine"],
-            ) as usize
+            "posix.uname_result",
+            &["sysname", "nodename", "release", "version", "machine"],
+        ) as usize
     }) as PyObjectRef
 }
 
@@ -223,21 +218,21 @@ fn statvfs_result_seq_type() -> PyObjectRef {
     static T: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
     *T.get_or_init(|| {
         crate::_structseq::make_struct_seq_with_extra(
-                "os.statvfs_result",
-                &[
-                    "f_bsize",
-                    "f_frsize",
-                    "f_blocks",
-                    "f_bfree",
-                    "f_bavail",
-                    "f_files",
-                    "f_ffree",
-                    "f_favail",
-                    "f_flag",
-                    "f_namemax",
-                ],
-                &["f_fsid"],
-            ) as usize
+            "os.statvfs_result",
+            &[
+                "f_bsize",
+                "f_frsize",
+                "f_blocks",
+                "f_bfree",
+                "f_bavail",
+                "f_files",
+                "f_ffree",
+                "f_favail",
+                "f_flag",
+                "f_namemax",
+            ],
+            &["f_fsid"],
+        ) as usize
     }) as PyObjectRef
 }
 
@@ -247,15 +242,15 @@ fn times_result_seq_type() -> PyObjectRef {
     static T: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
     *T.get_or_init(|| {
         crate::_structseq::make_struct_seq(
-                "posix.times_result",
-                &[
-                    "user",
-                    "system",
-                    "children_user",
-                    "children_system",
-                    "elapsed",
-                ],
-            ) as usize
+            "posix.times_result",
+            &[
+                "user",
+                "system",
+                "children_user",
+                "children_system",
+                "elapsed",
+            ],
+        ) as usize
     }) as PyObjectRef
 }
 
@@ -492,7 +487,9 @@ mod win_nt {
 
     /// os._supports_virtual_terminal — whether stderr's console mode carries
     /// ENABLE_VIRTUAL_TERMINAL_PROCESSING.
-    pub fn _supports_virtual_terminal(_args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    pub fn _supports_virtual_terminal(
+        _args: &[PyObjectRef],
+    ) -> Result<PyObjectRef, crate::PyError> {
         Ok(pyre_object::w_bool_from(
             host_nt::supports_virtual_terminal(),
         ))
@@ -584,11 +581,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     crate::module_ns_store(
         ns,
         "_create_environ",
-        crate::make_builtin_function_with_arity(
-            "_create_environ",
-            |_args| Ok(create_environ()),
-            0,
-        ),
+        crate::make_builtin_function_with_arity("_create_environ", |_args| Ok(create_environ()), 0),
     );
 
     // ── posix.putenv(name, value) / posix.unsetenv(name) ──
@@ -676,8 +669,10 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         "HAVE_FCHMOD",
         #[cfg(not(feature = "sandbox"))]
         "HAVE_FCHOWN",
-        #[cfg(not(feature = "sandbox"))]
-        "HAVE_FEXECVE",
+        // Do not advertise HAVE_FEXECVE until execve() accepts an open file
+        // descriptor.  os.py uses this bit to add execve to supports_fd, and
+        // test_posix then runs a fork+fexecve path whose child must never
+        // return to the libregrtest worker.
         #[cfg(not(feature = "sandbox"))]
         "HAVE_FPATHCONF",
         #[cfg(not(feature = "sandbox"))]
@@ -1428,7 +1423,9 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 Some(v) if !unsafe { pyre_object::is_none(v) } => {
                     if !unsafe { pyre_object::is_int(v) } {
                         let type_name = crate::typedef::r#type(v)
-                            .map(|t| unsafe { pyre_object::typeobject::w_type_get_name(t.as_ptr()) })
+                            .map(|t| unsafe {
+                                pyre_object::typeobject::w_type_get_name(t.as_ptr())
+                            })
                             .unwrap_or("object");
                         return Err(crate::PyError::type_error(format!(
                             "argument should be integer or None, not {type_name}"
@@ -1501,7 +1498,11 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 pos.len()
             )));
         }
-        crate::builtins::kwarg_reject_unknown(kwargs, &["ns", "dir_fd", "follow_symlinks"], "utime")?;
+        crate::builtins::kwarg_reject_unknown(
+            kwargs,
+            &["ns", "dir_fd", "follow_symlinks"],
+            "utime",
+        )?;
         let path = extract_path(pos[0])?;
 
         let present = |v: PyObjectRef| (!unsafe { pyre_object::is_none(v) }).then_some(v);
@@ -1525,7 +1526,8 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
 
         let unpack_two =
             |obj: PyObjectRef, what: &str| -> Result<(PyObjectRef, PyObjectRef), crate::PyError> {
-                if !unsafe { pyre_object::is_tuple(obj) } || unsafe { pyre_object::w_tuple_len(obj) } != 2
+                if !unsafe { pyre_object::is_tuple(obj) }
+                    || unsafe { pyre_object::w_tuple_len(obj) } != 2
                 {
                     return Err(crate::PyError::type_error(format!(
                         "utime: '{what}' must be a tuple of two ints"
@@ -1605,7 +1607,11 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             ))
         }
     }
-    crate::module_ns_store(ns, "utime", crate::make_builtin_function("utime", utime_impl));
+    crate::module_ns_store(
+        ns,
+        "utime",
+        crate::make_builtin_function("utime", utime_impl),
+    );
 
     // ── posix._path_splitroot(path) → (root, tail) ──
     // Registered only where `sys.platform` is `win32`, the same condition
@@ -1774,28 +1780,25 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     crate::module_ns_store(
         ns,
         "get_terminal_size",
-        crate::make_builtin_function(
-            "get_terminal_size",
-            |_args| {
-                let (cols, rows) = {
-                    #[cfg(unix)]
-                    {
-                        let mut ws: libc::winsize = unsafe { std::mem::zeroed() };
-                        let ret = unsafe { libc::ioctl(1, libc::TIOCGWINSZ, &mut ws) };
-                        if ret == 0 && ws.ws_col > 0 {
-                            (ws.ws_col as i64, ws.ws_row as i64)
-                        } else {
-                            (80, 24)
-                        }
-                    }
-                    #[cfg(not(unix))]
-                    {
+        crate::make_builtin_function("get_terminal_size", |_args| {
+            let (cols, rows) = {
+                #[cfg(unix)]
+                {
+                    let mut ws: libc::winsize = unsafe { std::mem::zeroed() };
+                    let ret = unsafe { libc::ioctl(1, libc::TIOCGWINSZ, &mut ws) };
+                    if ret == 0 && ws.ws_col > 0 {
+                        (ws.ws_col as i64, ws.ws_row as i64)
+                    } else {
                         (80, 24)
                     }
-                };
-                Ok(make_terminal_size(cols, rows))
-            },
-        ),
+                }
+                #[cfg(not(unix))]
+                {
+                    (80, 24)
+                }
+            };
+            Ok(make_terminal_size(cols, rows))
+        }),
     );
     // os.fspath() — posixmodule.c posix_fspath / PyOS_FSPath.  str/bytes
     // pass through unchanged (the protocol's identity case); any other
@@ -2245,7 +2248,13 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     ("__fspath__", dir_entry_fspath),
                     ("__repr__", dir_entry_repr),
                 ] {
-                    unsafe { pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(ns, name, crate::make_builtin_function(name, f)) };
+                    unsafe {
+                        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+                            ns,
+                            name,
+                            crate::make_builtin_function(name, f),
+                        )
+                    };
                 }
             });
             unsafe { pyre_object::typeobject::w_type_set_hasdict(tp, true) };
@@ -2280,13 +2289,22 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         *CELL.get_or_init(|| {
             let tp = crate::typedef::make_builtin_type("ScandirIterator", |ns| {
                 for (name, f) in [
-                    ("__iter__", scandir_iter_self as crate::gateway::BuiltinCodeFn),
+                    (
+                        "__iter__",
+                        scandir_iter_self as crate::gateway::BuiltinCodeFn,
+                    ),
                     ("__next__", scandir_iter_next),
                     ("__enter__", scandir_iter_self),
                     ("__exit__", scandir_iter_close),
                     ("close", scandir_iter_close),
                 ] {
-                    unsafe { pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(ns, name, crate::make_builtin_function(name, f)) };
+                    unsafe {
+                        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+                            ns,
+                            name,
+                            crate::make_builtin_function(name, f),
+                        )
+                    };
                 }
             });
             unsafe { pyre_object::typeobject::w_type_set_hasdict(tp, true) };
@@ -2638,6 +2656,128 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     {
         use rustpython_host_env::posix as host_posix;
 
+        fn exec_argv(
+            w_argv: PyObjectRef,
+            function: &str,
+        ) -> Result<Vec<std::ffi::CString>, crate::PyError> {
+            // PyPy interp_posix.execv: `space.unpackiterable(w_argv)` followed
+            // by `space.fsencode_w` for every argument.
+            let items = crate::baseobjspace::unpackiterable(w_argv, -1).map_err(|error| {
+                if error.kind == crate::PyErrorKind::TypeError {
+                    crate::PyError::type_error(format!(
+                        "{function}() arg 2 must be an iterable of strings"
+                    ))
+                } else {
+                    error
+                }
+            })?;
+            if items.is_empty() {
+                return Err(crate::PyError::value_error(format!(
+                    "{function}() arg 2 must not be empty"
+                )));
+            }
+            let mut argv = Vec::with_capacity(items.len());
+            for item in items {
+                let value = extract_path(item)?;
+                argv.push(std::ffi::CString::new(value.as_bytes()).map_err(|_| {
+                    crate::PyError::value_error(format!(
+                        "{function}() arg 2 contains an embedded null byte"
+                    ))
+                })?);
+            }
+            if argv[0].as_bytes().is_empty() {
+                return Err(crate::PyError::value_error(format!(
+                    "{function}() arg 2 first element cannot be empty"
+                )));
+            }
+            Ok(argv)
+        }
+
+        fn exec_pointer_array(values: &[std::ffi::CString]) -> Vec<*const libc::c_char> {
+            let mut pointers: Vec<_> = values.iter().map(|value| value.as_ptr()).collect();
+            pointers.push(std::ptr::null());
+            pointers
+        }
+
+        // PyPy interp_posix.execv: this call replaces the current process and
+        // returns only to translate the host errno into OSError.
+        crate::module_ns_store(
+            ns,
+            "execv",
+            crate::make_builtin_function_with_arity(
+                "execv",
+                |args| {
+                    let command = extract_path(args[0])?;
+                    let command_c = std::ffi::CString::new(command.as_bytes()).map_err(|_| {
+                        crate::PyError::value_error("execv() path contains an embedded null byte")
+                    })?;
+                    let argv = exec_argv(args[1], "execv")?;
+                    let argv_ptrs = exec_pointer_array(&argv);
+                    let errno =
+                        host_posix::exec_replace(&[command_c], argv_ptrs.as_ptr(), None) as i32;
+                    Err(errno_err(errno, &command))
+                },
+                2,
+            ),
+        );
+
+        // PyPy interp_posix.execve/_env2interp: accept a mapping, fsencode
+        // names and values, reject illegal names, then replace the process.
+        crate::module_ns_store(
+            ns,
+            "execve",
+            crate::make_builtin_function_with_arity(
+                "execve",
+                |args| {
+                    let command = extract_path(args[0])?;
+                    let command_c = std::ffi::CString::new(command.as_bytes()).map_err(|_| {
+                        crate::PyError::value_error("execve() path contains an embedded null byte")
+                    })?;
+                    let argv = exec_argv(args[1], "execve")?;
+                    let argv_ptrs = exec_pointer_array(&argv);
+
+                    let keys_obj = crate::baseobjspace::call_method(args[2], "keys", &[]);
+                    if keys_obj.is_null() {
+                        return Err(crate::call::take_call_error().unwrap_or_else(|| {
+                            crate::PyError::type_error("execve: env must be a mapping")
+                        }));
+                    }
+                    let keys = crate::baseobjspace::unpackiterable(keys_obj, -1)?;
+                    let mut env = Vec::with_capacity(keys.len());
+                    for key_obj in keys {
+                        let value_obj = crate::baseobjspace::getitem(args[2], key_obj)?;
+                        let key = extract_path(key_obj)?;
+                        let value = extract_path(value_obj)?;
+                        if key.is_empty()
+                            || key
+                                .as_bytes()
+                                .get(1..)
+                                .is_some_and(|tail| tail.contains(&b'='))
+                        {
+                            return Err(crate::PyError::value_error(
+                                "illegal environment variable name",
+                            ));
+                        }
+                        env.push(std::ffi::CString::new(format!("{key}={value}")).map_err(
+                            |_| {
+                                crate::PyError::value_error(
+                                    "execve() environment contains an embedded null byte",
+                                )
+                            },
+                        )?);
+                    }
+                    let env_ptrs = exec_pointer_array(&env);
+                    let errno = host_posix::exec_replace(
+                        &[command_c],
+                        argv_ptrs.as_ptr(),
+                        Some(env_ptrs.as_ptr()),
+                    ) as i32;
+                    Err(errno_err(errno, &command))
+                },
+                3,
+            ),
+        );
+
         // os.strerror(code) -> str
         crate::module_ns_store(
             ns,
@@ -2937,6 +3077,30 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 "getppid",
                 |_| Ok(pyre_object::w_int_new(unsafe { libc::getppid() } as i64)),
                 0,
+            ),
+        );
+
+        // PyPy interp_posix.getsid(pid) -> rposix.getsid(pid).
+        #[cfg(not(feature = "sandbox"))]
+        crate::module_ns_store(
+            ns,
+            "getsid",
+            crate::make_builtin_function_with_arity(
+                "getsid",
+                |args| {
+                    let pid = match args.first() {
+                        Some(&obj) => (unsafe { pyre_object::w_int_get_value(obj) }) as libc::pid_t,
+                        None => {
+                            return Err(crate::PyError::type_error("getsid() requires 1 argument"));
+                        }
+                    };
+                    let sid = unsafe { libc::getsid(pid) };
+                    if sid == -1 {
+                        return Err(io_err(std::io::Error::last_os_error(), ""));
+                    }
+                    Ok(pyre_object::w_int_new(sid as i64))
+                },
+                1,
             ),
         );
 

--- a/pyre/pyre-interpreter/src/module/sys/vm.rs
+++ b/pyre/pyre-interpreter/src/module/sys/vm.rs
@@ -247,11 +247,7 @@ fn simple_namespace_ne(args: &[PyObjectRef]) -> crate::PyResult {
     simple_namespace_richcompare(args, "__ne__", true)
 }
 
-fn simple_namespace_richcompare(
-    args: &[PyObjectRef],
-    name: &str,
-    negate: bool,
-) -> crate::PyResult {
+fn simple_namespace_richcompare(args: &[PyObjectRef], name: &str, negate: bool) -> crate::PyResult {
     // `def __eq__(self, other)` — a missing argument is an arity error, not a
     // NotImplemented result.
     let (Some(&self_obj), Some(&other)) = (args.first(), args.get(1)) else {
@@ -617,6 +613,30 @@ pub fn exc_info_direct() -> PyObjectRef {
 pub fn register_module(ns: pyre_object::PyObjectRef) {
     module_ns_store(ns, "maxsize", w_int_new(i64::MAX));
     module_ns_store(ns, "maxunicode", w_int_new(0x10FFFF));
+    module_ns_store(
+        ns,
+        "orig_argv",
+        w_list_new(
+            crate::importing::sys_orig_argv()
+                .iter()
+                .map(|arg| w_str_new(arg))
+                .collect(),
+        ),
+    );
+    // pypy/interpreter/app_main.py:785-786:
+    //   sys._xoptions = dict(x.split('=', 1) if '=' in x else (x, True)
+    //                        for x in options['_xoptions'])
+    let xoptions = w_dict_new();
+    for option in crate::importing::xoptions() {
+        let (name, value) = match option.split_once('=') {
+            Some((name, value)) => (name, w_str_new(value)),
+            None => (option.as_str(), w_bool_from(true)),
+        };
+        unsafe {
+            pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(xoptions, name, value);
+        }
+    }
+    module_ns_store(ns, "_xoptions", xoptions);
     // Format matches `platform._sys_version`'s CPython parser:
     // `version (buildinfo) [compiler]`.
     module_ns_store(ns, "version", w_str_new("3.14.6 (pyre 0.0.1) [Rust]"));
@@ -835,7 +855,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 w_int_new(i64::from(crate::importing::no_site_flag())),
                 w_int_new(i64::from(crate::importing::ignore_environment_flag())),
                 w_int_new(0), // verbose
-                w_int_new(0), // bytes_warning
+                w_int_new(crate::importing::bytes_warning_flag()),
                 w_int_new(i64::from(crate::importing::quiet_flag())),
                 w_int_new(0), // hash_randomization
                 w_int_new(i64::from(crate::importing::isolated_flag())),
@@ -1299,7 +1319,16 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     };
     module_ns_store(ns, "argv", argv);
     // sys.warnoptions
-    module_ns_store(ns, "warnoptions", w_list_new(vec![]));
+    module_ns_store(
+        ns,
+        "warnoptions",
+        w_list_new(
+            crate::importing::warnoptions()
+                .iter()
+                .map(|option| w_str_new(option))
+                .collect(),
+        ),
+    );
     // sys.builtin_module_names — tuple of names of modules compiled into
     // the interpreter. PyPy: pypy/module/sys/state.py get_builtin_module_names,
     // which reads the same registry `import` resolves against, so the
@@ -1316,50 +1345,303 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     // by the module shadowing check for the stronger stdlib rename hint.  The
     // list is the full set regardless of platform, as upstream ships it.
     const STDLIB_MODULE_NAMES: &[&str] = &[
-        "__future__", "_abc", "_aix_support", "_android_support", "_apple_support", "_ast",
-        "_ast_unparse", "_asyncio", "_bisect", "_blake2", "_bz2", "_codecs", "_codecs_cn",
-        "_codecs_hk", "_codecs_iso2022", "_codecs_jp", "_codecs_kr", "_codecs_tw",
-        "_collections", "_collections_abc", "_colorize", "_compat_pickle", "_contextvars",
-        "_csv", "_ctypes", "_curses", "_curses_panel", "_datetime", "_dbm", "_decimal",
-        "_elementtree", "_frozen_importlib", "_frozen_importlib_external", "_functools",
-        "_gdbm", "_hashlib", "_heapq", "_hmac", "_imp", "_interpchannels", "_interpqueues",
-        "_interpreters", "_io", "_ios_support", "_json", "_locale", "_lsprof", "_lzma",
-        "_markupbase", "_md5", "_multibytecodec", "_multiprocessing", "_opcode",
-        "_opcode_metadata", "_operator", "_osx_support", "_overlapped", "_pickle",
-        "_posixshmem", "_posixsubprocess", "_py_abc", "_py_warnings", "_pydatetime",
-        "_pydecimal", "_pyio", "_pylong", "_pyrepl", "_queue", "_random",
-        "_remote_debugging", "_scproxy", "_sha1", "_sha2", "_sha3", "_signal",
-        "_sitebuiltins", "_socket", "_sqlite3", "_sre", "_ssl", "_stat", "_statistics",
-        "_string", "_strptime", "_struct", "_suggestions", "_symtable", "_sysconfig",
-        "_thread", "_threading_local", "_tkinter", "_tokenize", "_tracemalloc", "_types",
-        "_typing", "_uuid", "_warnings", "_weakref", "_weakrefset", "_winapi", "_wmi",
-        "_zoneinfo", "_zstd", "abc", "annotationlib", "antigravity", "argparse", "array",
-        "ast", "asyncio", "atexit", "base64", "bdb", "binascii", "bisect", "builtins",
-        "bz2", "cProfile", "calendar", "cmath", "cmd", "code", "codecs", "codeop",
-        "collections", "colorsys", "compileall", "compression", "concurrent",
-        "configparser", "contextlib", "contextvars", "copy", "copyreg", "csv", "ctypes",
-        "curses", "dataclasses", "datetime", "dbm", "decimal", "difflib", "dis", "doctest",
-        "email", "encodings", "ensurepip", "enum", "errno", "faulthandler", "fcntl",
-        "filecmp", "fileinput", "fnmatch", "fractions", "ftplib", "functools", "gc",
-        "genericpath", "getopt", "getpass", "gettext", "glob", "graphlib", "grp", "gzip",
-        "hashlib", "heapq", "hmac", "html", "http", "idlelib", "imaplib", "importlib",
-        "inspect", "io", "ipaddress", "itertools", "json", "keyword", "linecache", "locale",
-        "logging", "lzma", "mailbox", "marshal", "math", "mimetypes", "mmap",
-        "modulefinder", "msvcrt", "multiprocessing", "netrc", "nt", "ntpath", "nturl2path",
-        "numbers", "opcode", "operator", "optparse", "os", "pathlib", "pdb", "pickle",
-        "pickletools", "pkgutil", "platform", "plistlib", "poplib", "posix", "posixpath",
-        "pprint", "profile", "pstats", "pty", "pwd", "py_compile", "pyclbr", "pydoc",
-        "pydoc_data", "pyexpat", "queue", "quopri", "random", "re", "readline", "reprlib",
-        "resource", "rlcompleter", "runpy", "sched", "secrets", "select", "selectors",
-        "shelve", "shlex", "shutil", "signal", "site", "smtplib", "socket", "socketserver",
-        "sqlite3", "sre_compile", "sre_constants", "sre_parse", "ssl", "stat", "statistics",
-        "string", "stringprep", "struct", "subprocess", "symtable", "sys", "sysconfig",
-        "syslog", "tabnanny", "tarfile", "tempfile", "termios", "textwrap", "this",
-        "threading", "time", "timeit", "tkinter", "token", "tokenize", "tomllib", "trace",
-        "traceback", "tracemalloc", "tty", "turtle", "turtledemo", "types", "typing",
-        "unicodedata", "unittest", "urllib", "uuid", "venv", "warnings", "wave", "weakref",
-        "webbrowser", "winreg", "winsound", "wsgiref", "xml", "xmlrpc", "zipapp", "zipfile",
-        "zipimport", "zlib", "zoneinfo",
+        "__future__",
+        "_abc",
+        "_aix_support",
+        "_android_support",
+        "_apple_support",
+        "_ast",
+        "_ast_unparse",
+        "_asyncio",
+        "_bisect",
+        "_blake2",
+        "_bz2",
+        "_codecs",
+        "_codecs_cn",
+        "_codecs_hk",
+        "_codecs_iso2022",
+        "_codecs_jp",
+        "_codecs_kr",
+        "_codecs_tw",
+        "_collections",
+        "_collections_abc",
+        "_colorize",
+        "_compat_pickle",
+        "_contextvars",
+        "_csv",
+        "_ctypes",
+        "_curses",
+        "_curses_panel",
+        "_datetime",
+        "_dbm",
+        "_decimal",
+        "_elementtree",
+        "_frozen_importlib",
+        "_frozen_importlib_external",
+        "_functools",
+        "_gdbm",
+        "_hashlib",
+        "_heapq",
+        "_hmac",
+        "_imp",
+        "_interpchannels",
+        "_interpqueues",
+        "_interpreters",
+        "_io",
+        "_ios_support",
+        "_json",
+        "_locale",
+        "_lsprof",
+        "_lzma",
+        "_markupbase",
+        "_md5",
+        "_multibytecodec",
+        "_multiprocessing",
+        "_opcode",
+        "_opcode_metadata",
+        "_operator",
+        "_osx_support",
+        "_overlapped",
+        "_pickle",
+        "_posixshmem",
+        "_posixsubprocess",
+        "_py_abc",
+        "_py_warnings",
+        "_pydatetime",
+        "_pydecimal",
+        "_pyio",
+        "_pylong",
+        "_pyrepl",
+        "_queue",
+        "_random",
+        "_remote_debugging",
+        "_scproxy",
+        "_sha1",
+        "_sha2",
+        "_sha3",
+        "_signal",
+        "_sitebuiltins",
+        "_socket",
+        "_sqlite3",
+        "_sre",
+        "_ssl",
+        "_stat",
+        "_statistics",
+        "_string",
+        "_strptime",
+        "_struct",
+        "_suggestions",
+        "_symtable",
+        "_sysconfig",
+        "_thread",
+        "_threading_local",
+        "_tkinter",
+        "_tokenize",
+        "_tracemalloc",
+        "_types",
+        "_typing",
+        "_uuid",
+        "_warnings",
+        "_weakref",
+        "_weakrefset",
+        "_winapi",
+        "_wmi",
+        "_zoneinfo",
+        "_zstd",
+        "abc",
+        "annotationlib",
+        "antigravity",
+        "argparse",
+        "array",
+        "ast",
+        "asyncio",
+        "atexit",
+        "base64",
+        "bdb",
+        "binascii",
+        "bisect",
+        "builtins",
+        "bz2",
+        "cProfile",
+        "calendar",
+        "cmath",
+        "cmd",
+        "code",
+        "codecs",
+        "codeop",
+        "collections",
+        "colorsys",
+        "compileall",
+        "compression",
+        "concurrent",
+        "configparser",
+        "contextlib",
+        "contextvars",
+        "copy",
+        "copyreg",
+        "csv",
+        "ctypes",
+        "curses",
+        "dataclasses",
+        "datetime",
+        "dbm",
+        "decimal",
+        "difflib",
+        "dis",
+        "doctest",
+        "email",
+        "encodings",
+        "ensurepip",
+        "enum",
+        "errno",
+        "faulthandler",
+        "fcntl",
+        "filecmp",
+        "fileinput",
+        "fnmatch",
+        "fractions",
+        "ftplib",
+        "functools",
+        "gc",
+        "genericpath",
+        "getopt",
+        "getpass",
+        "gettext",
+        "glob",
+        "graphlib",
+        "grp",
+        "gzip",
+        "hashlib",
+        "heapq",
+        "hmac",
+        "html",
+        "http",
+        "idlelib",
+        "imaplib",
+        "importlib",
+        "inspect",
+        "io",
+        "ipaddress",
+        "itertools",
+        "json",
+        "keyword",
+        "linecache",
+        "locale",
+        "logging",
+        "lzma",
+        "mailbox",
+        "marshal",
+        "math",
+        "mimetypes",
+        "mmap",
+        "modulefinder",
+        "msvcrt",
+        "multiprocessing",
+        "netrc",
+        "nt",
+        "ntpath",
+        "nturl2path",
+        "numbers",
+        "opcode",
+        "operator",
+        "optparse",
+        "os",
+        "pathlib",
+        "pdb",
+        "pickle",
+        "pickletools",
+        "pkgutil",
+        "platform",
+        "plistlib",
+        "poplib",
+        "posix",
+        "posixpath",
+        "pprint",
+        "profile",
+        "pstats",
+        "pty",
+        "pwd",
+        "py_compile",
+        "pyclbr",
+        "pydoc",
+        "pydoc_data",
+        "pyexpat",
+        "queue",
+        "quopri",
+        "random",
+        "re",
+        "readline",
+        "reprlib",
+        "resource",
+        "rlcompleter",
+        "runpy",
+        "sched",
+        "secrets",
+        "select",
+        "selectors",
+        "shelve",
+        "shlex",
+        "shutil",
+        "signal",
+        "site",
+        "smtplib",
+        "socket",
+        "socketserver",
+        "sqlite3",
+        "sre_compile",
+        "sre_constants",
+        "sre_parse",
+        "ssl",
+        "stat",
+        "statistics",
+        "string",
+        "stringprep",
+        "struct",
+        "subprocess",
+        "symtable",
+        "sys",
+        "sysconfig",
+        "syslog",
+        "tabnanny",
+        "tarfile",
+        "tempfile",
+        "termios",
+        "textwrap",
+        "this",
+        "threading",
+        "time",
+        "timeit",
+        "tkinter",
+        "token",
+        "tokenize",
+        "tomllib",
+        "trace",
+        "traceback",
+        "tracemalloc",
+        "tty",
+        "turtle",
+        "turtledemo",
+        "types",
+        "typing",
+        "unicodedata",
+        "unittest",
+        "urllib",
+        "uuid",
+        "venv",
+        "warnings",
+        "wave",
+        "weakref",
+        "webbrowser",
+        "winreg",
+        "winsound",
+        "wsgiref",
+        "xml",
+        "xmlrpc",
+        "zipapp",
+        "zipfile",
+        "zipimport",
+        "zlib",
+        "zoneinfo",
     ];
     module_ns_store(
         ns,
@@ -1420,32 +1702,29 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     module_ns_store(
         ns,
         "getsizeof",
-        make_builtin_function(
-            "getsizeof",
-            |args| {
-                if args.len() > 2 {
-                    return Err(crate::PyError::type_error(format!(
-                        "getsizeof() takes at most 2 arguments ({} given)",
-                        args.len()
-                    )));
-                }
-                let Some(&w_obj) = args.first() else {
-                    return Err(crate::PyError::type_error(
-                        "getsizeof() takes at least 1 argument (0 given)",
-                    ));
-                };
-                if unsafe { pyre_object::is_str(w_obj) } {
-                    let method = crate::baseobjspace::getattr_str(w_obj, "__sizeof__")?;
-                    return crate::call::call_function_impl_result(method, &[]);
-                }
-                match args.get(1).copied() {
-                    Some(w_default) => Ok(w_default),
-                    None => Err(crate::PyError::type_error(
-                        "getsizeof(object, default) -> int: object size is not tracked; supply a default",
-                    )),
-                }
-            },
-        ),
+        make_builtin_function("getsizeof", |args| {
+            if args.len() > 2 {
+                return Err(crate::PyError::type_error(format!(
+                    "getsizeof() takes at most 2 arguments ({} given)",
+                    args.len()
+                )));
+            }
+            let Some(&w_obj) = args.first() else {
+                return Err(crate::PyError::type_error(
+                    "getsizeof() takes at least 1 argument (0 given)",
+                ));
+            };
+            if unsafe { pyre_object::is_str(w_obj) } {
+                let method = crate::baseobjspace::getattr_str(w_obj, "__sizeof__")?;
+                return crate::call::call_function_impl_result(method, &[]);
+            }
+            match args.get(1).copied() {
+                Some(w_default) => Ok(w_default),
+                None => Err(crate::PyError::type_error(
+                    "getsizeof(object, default) -> int: object size is not tracked; supply a default",
+                )),
+            }
+        }),
     );
     // PyPy normally omits CPython's raw refcount API.  The shared ctypes
     // tests only require the strong-reference delta created by a c_char_p
@@ -1493,20 +1772,12 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     module_ns_store(
         ns,
         "_settraceallthreads",
-        make_builtin_function_with_arity(
-            "_settraceallthreads",
-            sys_settraceallthreads_impl,
-            1,
-        ),
+        make_builtin_function_with_arity("_settraceallthreads", sys_settraceallthreads_impl, 1),
     );
     module_ns_store(
         ns,
         "_setprofileallthreads",
-        make_builtin_function_with_arity(
-            "_setprofileallthreads",
-            sys_setprofileallthreads_impl,
-            1,
-        ),
+        make_builtin_function_with_arity("_setprofileallthreads", sys_setprofileallthreads_impl, 1),
     );
     module_ns_store(
         ns,
@@ -1663,35 +1934,137 @@ fn sys_clear_type_descriptors(args: &[PyObjectRef]) -> crate::PyResult {
 /// real W_File-backed `TextIOWrapper`; pyre routes writes through Rust's
 /// stdout/stderr (the same sink as `print`) so output ordering is preserved,
 /// storing the read/write surface as instance attributes.
+fn stdio_encoding_and_errors() -> (String, String) {
+    // PyPy app_main.py `initstdio`: a non-empty encoding before ':' is
+    // explicit; an omitted encoding defaults to UTF-8 here, while a non-empty
+    // errors suffix overrides the normal strict policy. stderr replaces its
+    // error policy separately below.
+    let Some(raw) = crate::importing::stdio_encoding() else {
+        return ("utf-8".to_string(), "strict".to_string());
+    };
+    let (encoding, errors) = match raw.split_once(':') {
+        Some((encoding, errors)) => (
+            if encoding.is_empty() {
+                "utf-8"
+            } else {
+                encoding
+            },
+            if errors.is_empty() { "strict" } else { errors },
+        ),
+        None if raw.is_empty() => ("utf-8", "strict"),
+        None => (raw.as_str(), "strict"),
+    };
+    (encoding.to_string(), errors.to_string())
+}
+
+fn live_stdio_encoding_errors(stream_name: &str, default_errors: &str) -> (String, String) {
+    let defaults = stdio_encoding_and_errors();
+    let Some(sys) = crate::importing::get_sys_module("sys") else {
+        return (defaults.0, default_errors.to_string());
+    };
+    let Ok(stream) = crate::baseobjspace::getattr_str(sys, stream_name) else {
+        return (defaults.0, default_errors.to_string());
+    };
+    let text_attr = |name: &str, default: &str| {
+        crate::baseobjspace::getattr_str(stream, name)
+            .ok()
+            .filter(|value| unsafe { is_str(*value) })
+            .map(|value| unsafe { w_str_get_value(value) }.to_string())
+            .unwrap_or_else(|| default.to_string())
+    };
+    (
+        text_attr("encoding", &defaults.0),
+        text_attr("errors", default_errors),
+    )
+}
+
+fn stdio_stdin_readline(args: &[PyObjectRef]) -> crate::PyResult {
+    if args.len() > 1 {
+        return Err(crate::PyError::type_error(format!(
+            "readline() takes at most one argument ({} given)",
+            args.len()
+        )));
+    }
+    let sys = crate::importing::get_sys_module("sys")
+        .ok_or_else(|| crate::PyError::runtime_error("lost sys.stdin"))?;
+    let stdin = crate::baseobjspace::getattr_str(sys, "stdin")?;
+    let buffer = crate::baseobjspace::getattr_str(stdin, "buffer")?;
+    let bytes = crate::baseobjspace::call_method(buffer, "readline", args);
+    if bytes.is_null() {
+        return Err(crate::call::take_call_error()
+            .unwrap_or_else(|| crate::PyError::runtime_error("readline failed")));
+    }
+    if !unsafe { pyre_object::is_bytes(bytes) } {
+        return Err(crate::PyError::type_error(
+            "underlying readline() should have returned a bytes-like object",
+        ));
+    }
+    let _roots = pyre_object::gc_roots::push_roots();
+    pyre_object::gc_roots::pin_root(bytes);
+    let bytes_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+    let (encoding, errors) = live_stdio_encoding_errors("stdin", "strict");
+    crate::typedef::bytes_method_decode(&[
+        pyre_object::gc_roots::shadow_stack_get(bytes_slot),
+        w_str_new(&encoding),
+        w_str_new(&errors),
+    ])
+}
+
 fn make_std_stream(name: &'static str, fd: i32) -> PyObjectRef {
     let writable = fd != 0;
     let to_stderr = fd == 2;
+    let unbuffered = writable && crate::importing::unbuffered_flag();
+    // PyPy app_main.py `create_stdio`: retain the FileIO-backed binary layer
+    // as TextIOWrapper.buffer. libregrtest workers deliberately write invalid
+    // byte sequences through this exact owner.
+    //
+    // `create_stdio` also answers a descriptor `_io.open` rejects with no
+    // stream at all. These streams keep instance-override methods that reach
+    // the descriptor without going through the buffer, so a descriptor the
+    // host does not open — the sandbox controller mounts no real files —
+    // leaves the buffer absent instead of removing `sys.stdout` outright.
+    let buffer = crate::builtins::builtin_open(&[
+        w_int_new(i64::from(fd)),
+        w_str_new(if writable { "wb" } else { "rb" }),
+        w_int_new(if unbuffered { 0 } else { -1 }),
+        w_none(),
+        w_none(),
+        w_none(),
+        w_bool_from(false),
+    ])
+    .unwrap_or_else(|_| w_none());
+    let _roots = pyre_object::gc_roots::push_roots();
+    pyre_object::gc_roots::pin_root(buffer);
+    let buffer_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+    let (encoding, configured_errors) = stdio_encoding_and_errors();
+    let errors = if to_stderr {
+        "backslashreplace"
+    } else {
+        configured_errors.as_str()
+    };
     let stream = crate::module::_io::W_TextIOWrapper::allocate_stdio(
         name,
-        "utf-8",
-        if to_stderr {
-            "backslashreplace"
-        } else {
-            "strict"
-        },
+        pyre_object::gc_roots::shadow_stack_get(buffer_slot),
+        &encoding,
+        errors,
+        unbuffered || to_stderr,
+        unbuffered,
     );
     crate::baseobjspace::setdictvalue_native(stream, "name", w_str_new(name));
-    crate::baseobjspace::setdictvalue_native(stream, "encoding", w_str_new("utf-8"));
     // `pylifecycle.c init_set_builtins_open`/`init_sys_streams`: stderr uses the
     // `backslashreplace` handler so traceback printing never fails on a lone
     // surrogate; stdout/stdin default to `strict`.
     crate::baseobjspace::setdictvalue_native(
         stream,
-        "errors",
-        w_str_new(if to_stderr {
-            "backslashreplace"
-        } else {
-            "strict"
-        }),
+        "mode",
+        w_str_new(if writable { "w" } else { "r" }),
     );
-    crate::baseobjspace::setdictvalue_native(stream, "mode", w_str_new(if writable { "w" } else { "r" }));
     crate::baseobjspace::setdictvalue_native(stream, "closed", w_bool_from(false));
-    crate::baseobjspace::setdictvalue_native(stream, "buffer", w_none());
+    crate::baseobjspace::setdictvalue_native(
+        stream,
+        "buffer",
+        pyre_object::gc_roots::shadow_stack_get(buffer_slot),
+    );
     // Instance-stored builtin methods do not get `self` prepended (see
     // pyopcode load_method dispatch), so the first arg may be the string
     // directly. Pick whichever element is a real str.
@@ -1709,7 +2082,9 @@ fn make_std_stream(name: &'static str, fd: i32) -> PyObjectRef {
     let write_fn = if to_stderr {
         crate::make_builtin_function("write", |args| {
             if let Some(s_obj) = pick_str(args) {
-                let bytes = crate::type_methods::encode_object(s_obj, "utf-8", "backslashreplace")?;
+                let (encoding, _) = live_stdio_encoding_errors("stderr", "backslashreplace");
+                let bytes =
+                    crate::type_methods::encode_object(s_obj, &encoding, "backslashreplace")?;
                 // Under sandbox fd 1 is the marshalling pipe, so a raw write
                 // would corrupt the protocol: route through ll_os_write(2,…)
                 // and let the controller relay it to its own stderr.
@@ -1728,7 +2103,8 @@ fn make_std_stream(name: &'static str, fd: i32) -> PyObjectRef {
     } else {
         crate::make_builtin_function("write", |args| {
             if let Some(s_obj) = pick_str(args) {
-                let bytes = crate::type_methods::encode_object(s_obj, "utf-8", "strict")?;
+                let (encoding, errors) = live_stdio_encoding_errors("stdout", "strict");
+                let bytes = crate::type_methods::encode_object(s_obj, &encoding, &errors)?;
                 #[cfg(not(feature = "sandbox"))]
                 {
                     use std::io::Write;
@@ -1743,6 +2119,13 @@ fn make_std_stream(name: &'static str, fd: i32) -> PyObjectRef {
         })
     };
     crate::baseobjspace::setdictvalue_native(stream, "write", write_fn);
+    if fd == 0 {
+        crate::baseobjspace::setdictvalue_native(
+            stream,
+            "readline",
+            crate::make_builtin_function("readline", stdio_stdin_readline),
+        );
+    }
     crate::baseobjspace::setdictvalue_native(
         stream,
         "flush",
@@ -1762,14 +2145,6 @@ fn make_std_stream(name: &'static str, fd: i32) -> PyObjectRef {
         stream,
         "isatty",
         crate::make_builtin_function("isatty", |_| Ok(w_bool_from(false))),
-    );
-    // `TextIOWrapper.reconfigure(*, encoding=None, errors=None, ...)` only
-    // adjusts codec/newline policy; pyre's streams are fixed UTF-8, so accept
-    // and ignore the request.
-    crate::baseobjspace::setdictvalue_native(
-        stream,
-        "reconfigure",
-        crate::make_builtin_function("reconfigure", |_| Ok(w_none())),
     );
     // `BuiltinCodeFn` is a bare `fn` pointer (no captures), so select a
     // constant-returning function per descriptor rather than closing over `fd`.

--- a/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
+++ b/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
@@ -1111,6 +1111,7 @@ unsafe fn fill_cache(
     if !crate::baseobjspace::side_effects_ok() {
         return;
     }
+    let _code_cache_guard = code_cache_lock(pycode);
     let entry = MapdictCacheEntry {
         cached_map: map,
         cached_attr: attr,
@@ -1210,26 +1211,33 @@ pub unsafe fn load_attr_caching(
     nameindex: usize,
     name: &str,
 ) -> Result<PyObjectRef, PyError> {
-    // PyPy's GIL makes the per-instance map/storage pair and the per-code
-    // `_mapdict_caches` entry one atomic observation.  Preserve those exact
-    // owners under free threading with narrow synchronization around the
-    // upstream cache operation.
-    let _instance_guard = instance_lock(w_obj);
-    let _code_cache_guard = code_cache_lock(pycode);
-    let entry = unsafe { crate::pycode::w_code_mapdict_caches_get(pycode, nameindex) };
-    // mapdict.py:1482 `map = w_obj._get_mapdict_map()`.
-    let map = unsafe { mapdict_map_or_null(w_obj) };
-    if let Some(e) = entry {
-        // mapdict.py:1483 `if entry.is_valid_for_map(map) and entry.w_method is None`.
-        if !map.is_null() && unsafe { e.is_valid_for_map(map, false) } && e.w_method.is_null() {
-            // mapdict.py:1485-1487 `attr = entry.attr_wref(); if attr is not None`.
-            if !e.cached_attr.is_null() {
+    // Copy the immortal-node cache entry under its code-owned lock, then
+    // release that lock before touching an instance. Holding both locks
+    // across the slow path would extend them across arbitrary descriptor
+    // calls, unlike PyPy's single GIL critical section, and permits
+    // instance-A -> code -> instance-B / instance-B -> code cycles.
+    let entry = {
+        let _code_cache_guard = code_cache_lock(pycode);
+        unsafe { crate::pycode::w_code_mapdict_caches_get(pycode, nameindex) }
+    };
+    let map = {
+        let _instance_guard = instance_lock(w_obj);
+        // mapdict.py:1482 `map = w_obj._get_mapdict_map()`.
+        let map = unsafe { mapdict_map_or_null(w_obj) };
+        if let Some(e) = entry {
+            // mapdict.py:1483-1487 — valid cache entry with a live attr.
+            if !map.is_null()
+                && unsafe { e.is_valid_for_map(map, false) }
+                && e.w_method.is_null()
+                && !e.cached_attr.is_null()
+            {
                 let inst = unsafe { &mut *(w_obj as *mut pyre_object::W_ObjectObject) };
                 // mapdict.py:1487 `return attr._direct_read(w_obj)`.
                 return Ok(unsafe { direct_read(e.cached_attr, inst) });
             }
         }
-    }
+        map
+    };
     unsafe { load_attr_slowpath(pycode, w_obj, nameindex, name, map) }
 }
 
@@ -1270,8 +1278,26 @@ unsafe fn load_attr_slowpath(
             // mapdict.py:1526 `if attrkind != INVALID:`.
             if attrkind != INVALID {
                 let attrname = if is_slot { "slot" } else { name };
-                // mapdict.py:1527 `attr = map.find_map_attr(attrname, attrkind)`.
-                if let Some(attr) = unsafe { find_map_attr(map, Wtf8::new(attrname), attrkind) } {
+                // The type/descriptor lookup above can execute Python. Re-lock
+                // only for the direct map/storage observation and abandon the
+                // cache path if another thread changed the instance map.
+                let direct = {
+                    let _instance_guard = instance_lock(w_obj);
+                    let current_map = unsafe { mapdict_map_or_null(w_obj) };
+                    if std::ptr::eq(current_map, map) {
+                        unsafe { find_map_attr(current_map, Wtf8::new(attrname), attrkind) }.map(
+                            |attr| {
+                                let inst =
+                                    unsafe { &mut *(w_obj as *mut pyre_object::W_ObjectObject) };
+                                let value = unsafe { direct_read(attr, inst) };
+                                (current_map, attr, value)
+                            },
+                        )
+                    } else {
+                        None
+                    }
+                };
+                if let Some((current_map, attr, value)) = direct {
                     // mapdict.py:1531-1532 `_fill_cache(...,
                     // valid_for_store=w_type.setattr_if_not_from_object() is None)`.
                     let valid_for_store =
@@ -1281,7 +1307,7 @@ unsafe fn load_attr_slowpath(
                         fill_cache(
                             pycode,
                             nameindex,
-                            map,
+                            current_map,
                             version_tag,
                             attr,
                             std::ptr::null_mut(),
@@ -1289,8 +1315,7 @@ unsafe fn load_attr_slowpath(
                         );
                     }
                     // mapdict.py:1533 `return attr._direct_read(w_obj)`.
-                    let inst = unsafe { &mut *(w_obj as *mut pyre_object::W_ObjectObject) };
-                    return Ok(unsafe { direct_read(attr, inst) });
+                    return Ok(value);
                 }
             }
         }
@@ -1618,17 +1643,21 @@ pub unsafe fn store_attr_caching(
     name: &str,
     w_value: PyObjectRef,
 ) -> Result<(), PyError> {
-    let _instance_guard = instance_lock(w_obj);
-    let _code_cache_guard = code_cache_lock(pycode);
-    let entry = unsafe { crate::pycode::w_code_mapdict_caches_get(pycode, nameindex) };
-    // mapdict.py:1577 `map = w_obj._get_mapdict_map()`.
-    let map = unsafe { mapdict_map_or_null(w_obj) };
-    if let Some(e) = entry {
-        // mapdict.py:1578 `entry.is_valid_for_map(map, store=True) and
-        // entry.w_method is None`.
-        if !map.is_null() && unsafe { e.is_valid_for_map(map, true) } && e.w_method.is_null() {
-            // mapdict.py:1580-1585 `attr = entry.attr_wref(); if attr is not None`.
-            if !e.cached_attr.is_null() {
+    let entry = {
+        let _code_cache_guard = code_cache_lock(pycode);
+        unsafe { crate::pycode::w_code_mapdict_caches_get(pycode, nameindex) }
+    };
+    let map = {
+        let _instance_guard = instance_lock(w_obj);
+        // mapdict.py:1577 `map = w_obj._get_mapdict_map()`.
+        let map = unsafe { mapdict_map_or_null(w_obj) };
+        if let Some(e) = entry {
+            // mapdict.py:1578-1585 — valid cache entry with a live attr.
+            if !map.is_null()
+                && unsafe { e.is_valid_for_map(map, true) }
+                && e.w_method.is_null()
+                && !e.cached_attr.is_null()
+            {
                 let attr = e.cached_attr;
                 let p = unsafe { (*attr).as_plain() };
                 // mapdict.py:1582-1583 `if not attr.ever_mutated: attr.ever_mutated = True`.
@@ -1641,7 +1670,8 @@ pub unsafe fn store_attr_caching(
                 return Ok(());
             }
         }
-    }
+        map
+    };
     unsafe { store_attr_slowpath(pycode, w_obj, nameindex, name, map, w_value, entry) }
 }
 
@@ -1702,12 +1732,29 @@ unsafe fn store_attr_slowpath(
                         None => true,
                     };
                     if typsafe {
-                        // mapdict.py:1610 `_switch_map_and_write_increase_storage1`.
-                        let inst = unsafe { &mut *(w_obj as *mut pyre_object::W_ObjectObject) };
-                        unsafe {
-                            switch_map_and_write_increase_storage1(attr_to_add, inst, w_value)
+                        let switched = {
+                            let _instance_guard = instance_lock(w_obj);
+                            let current_map = unsafe { mapdict_map_or_null(w_obj) };
+                            if std::ptr::eq(current_map, map) {
+                                // mapdict.py:1610
+                                // `_switch_map_and_write_increase_storage1`.
+                                let inst =
+                                    unsafe { &mut *(w_obj as *mut pyre_object::W_ObjectObject) };
+                                unsafe {
+                                    switch_map_and_write_increase_storage1(
+                                        attr_to_add,
+                                        inst,
+                                        w_value,
+                                    )
+                                };
+                                true
+                            } else {
+                                false
+                            }
                         };
-                        return Ok(());
+                        if switched {
+                            return Ok(());
+                        }
                     }
                 }
             }
@@ -1729,6 +1776,34 @@ unsafe fn store_attr_slowpath(
                 // mapdict.py:1628 `attr = map.find_map_attr(attrname, attrkind)`.
                 match unsafe { find_map_attr(map, Wtf8::new(attrname), attrkind) } {
                     Some(attr) => {
+                        let written = {
+                            let _instance_guard = instance_lock(w_obj);
+                            let current_map = unsafe { mapdict_map_or_null(w_obj) };
+                            if !std::ptr::eq(current_map, map)
+                                || unsafe {
+                                    find_map_attr(current_map, Wtf8::new(attrname), attrkind)
+                                }
+                                .is_none()
+                            {
+                                false
+                            } else {
+                                let p = unsafe { (*attr).as_plain() };
+                                // mapdict.py:1632-1633
+                                // `if not attr.ever_mutated: ...`.
+                                if !p.ever_mutated.get() {
+                                    p.ever_mutated.set(true);
+                                }
+                                // mapdict.py:1634 `attr._direct_write(...)`.
+                                let inst =
+                                    unsafe { &mut *(w_obj as *mut pyre_object::W_ObjectObject) };
+                                unsafe { plain_direct_write(attr, inst, w_value) };
+                                true
+                            }
+                        };
+                        if !written {
+                            return crate::baseobjspace::setattr_str(w_obj, name, w_value)
+                                .map(|_| ());
+                        }
                         // mapdict.py:1630-1631 — fill only when there is no custom
                         // `__getattribute__` to upset the cache invariant.
                         if unsafe { crate::baseobjspace::getattribute_if_not_from_object(w_type) }
@@ -1746,14 +1821,6 @@ unsafe fn store_attr_slowpath(
                                 );
                             }
                         }
-                        let p = unsafe { (*attr).as_plain() };
-                        // mapdict.py:1632-1633 `if not attr.ever_mutated: ...`.
-                        if !p.ever_mutated.get() {
-                            p.ever_mutated.set(true);
-                        }
-                        // mapdict.py:1634 `attr._direct_write(w_obj, w_value)`.
-                        let inst = unsafe { &mut *(w_obj as *mut pyre_object::W_ObjectObject) };
-                        unsafe { plain_direct_write(attr, inst, w_value) };
                         return Ok(());
                     }
                     None => {
@@ -1765,13 +1832,35 @@ unsafe fn store_attr_slowpath(
                                 == TerminatorKind::Dict
                         {
                             let term = unsafe { (*map).terminator() };
-                            let inst = unsafe { &mut *(w_obj as *mut pyre_object::W_ObjectObject) };
-                            // mapdict.py:1639 `map.terminator._write_terminator(...)`.
-                            unsafe {
-                                write_terminator(term, inst, Wtf8::new(name), attrkind, w_value)
+                            let mapnew = {
+                                let _instance_guard = instance_lock(w_obj);
+                                let current_map = unsafe { mapdict_map_or_null(w_obj) };
+                                if !std::ptr::eq(current_map, map) {
+                                    std::ptr::null()
+                                } else {
+                                    let inst = unsafe {
+                                        &mut *(w_obj as *mut pyre_object::W_ObjectObject)
+                                    };
+                                    // mapdict.py:1639
+                                    // `map.terminator._write_terminator(...)`.
+                                    unsafe {
+                                        write_terminator(
+                                            term,
+                                            inst,
+                                            Wtf8::new(name),
+                                            attrkind,
+                                            w_value,
+                                        )
+                                    };
+                                    // mapdict.py:1640
+                                    // `mapnew = w_obj._get_mapdict_map()`.
+                                    inst._get_mapdict_map()
+                                }
                             };
-                            // mapdict.py:1640 `mapnew = w_obj._get_mapdict_map()`.
-                            let mapnew = inst._get_mapdict_map();
+                            if mapnew.is_null() {
+                                return crate::baseobjspace::setattr_str(w_obj, name, w_value)
+                                    .map(|_| ());
+                            }
                             // mapdict.py:1642-1648 — fill only when no attribute
                             // reordering happened (the new attr is the leaf whose
                             // `back` is the pre-write map).

--- a/pyre/pyre-macros/src/lib.rs
+++ b/pyre/pyre-macros/src/lib.rs
@@ -150,7 +150,14 @@ fn expand_pyre_function(func: ItemFn) -> syn::Result<proc_macro2::TokenStream> {
     // unwrap statements below index their slots directly, so the count is
     // checked here — a missing required slot would otherwise read past the
     // end of `args`.  A raw whole-args slice takes any count.
-    let count_preamble = if has_varargs {
+    // A signature with kw-only / **kwargs markers is matched by the gateway
+    // before this wrapper runs.  The resulting scope contains every
+    // positional and kw-only slot, so `args.len()` is no longer the number
+    // of positionals supplied by the caller.  PyPy's
+    // `BuiltinCode.funcrun_obj` likewise runs the activation directly after
+    // `args.parse_obj(...)`; do not perform a second positional-count check
+    // on that already-bound scope.
+    let count_preamble = if has_varargs || has_kw_markers {
         quote! {}
     } else {
         let total = param_positional

--- a/pyre/pyrex/src/lib.rs
+++ b/pyre/pyrex/src/lib.rs
@@ -43,7 +43,7 @@ enum RunMode {
     },
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 struct LaunchFlags {
     inspect: bool,
     quiet: bool,
@@ -56,7 +56,16 @@ struct LaunchFlags {
     safe_path: bool,
     // `-O` count on the command line; PYTHONOPTIMIZE folds in during finalize.
     optimize: i64,
+    bytes_warning: i64,
     dont_write_bytecode: bool,
+    unbuffered: bool,
+    warnoptions: Vec<String>,
+    // app_main.py passes the raw PYTHONIOENCODING value to initstdio after
+    // applying -E/-I. Keep it raw until stdio parses the optional errors part.
+    stdio_encoding: Option<String>,
+    // PyPy app_main.py keeps every raw `-X` value in a list until sys module
+    // initialization turns it into `sys._xoptions`.
+    xoptions: Vec<String>,
 }
 
 impl Default for LaunchFlags {
@@ -72,7 +81,12 @@ impl Default for LaunchFlags {
             utf8_mode: None,
             safe_path: false,
             optimize: 0,
+            bytes_warning: 0,
             dont_write_bytecode: false,
+            unbuffered: false,
+            warnoptions: Vec::new(),
+            stdio_encoding: None,
+            xoptions: Vec::new(),
         }
     }
 }
@@ -226,6 +240,33 @@ fn finalize_flags(mut flags: LaunchFlags) -> LaunchFlags {
     flags.optimize = resolve_optimize(&flags);
     flags.dont_write_bytecode = resolve_dont_write_bytecode(&flags);
     flags.safe_path = resolve_safe_path(&flags);
+    flags.stdio_encoding = if flags.ignore_environment {
+        None
+    } else {
+        std::env::var("PYTHONIOENCODING").ok()
+    };
+    // pypy/interpreter/app_main.py:892-906 — lowest-precedence entries first;
+    // the warnings module installs later entries ahead of earlier ones.
+    let mut warnoptions = Vec::new();
+    if flags.dev_mode {
+        warnoptions.push("default".to_string());
+    }
+    if !flags.ignore_environment {
+        if let Ok(value) = std::env::var("PYTHONWARNINGS") {
+            if !value.is_empty() {
+                warnoptions.extend(value.split(',').map(str::to_string));
+            }
+        }
+    }
+    warnoptions.append(&mut flags.warnoptions);
+    if flags.bytes_warning > 0 {
+        warnoptions.push(if flags.bytes_warning > 1 {
+            "error::BytesWarning".to_string()
+        } else {
+            "default::BytesWarning".to_string()
+        });
+    }
+    flags.warnoptions = warnoptions;
     flags
 }
 
@@ -270,24 +311,26 @@ fn parse_args(binary_name: &str) -> Result<(RunMode, LaunchFlags, Vec<String>), 
                     }
                     _ => {}
                 }
+                flags.xoptions.push(option);
             }
             // Accepted for CPython/PyPy command-line compatibility.  Warning
             // filter installation is handled by the warnings module; keeping
             // the option/value in launcher parsing lets stdlib subprocesses
             // reach their command or module.
             Short('W') => {
-                let _filter = parser.value()?.string()?;
+                flags.warnoptions.push(parser.value()?.string()?);
             }
             // `-O` / `-OO` raise the optimization level; each occurrence counts
             // (app_main.py `optimize`). PYTHONOPTIMIZE folds in during finalize.
             Short('O') => flags.optimize = flags.optimize.saturating_add(1),
+            // PyPy app_main.py `simple_option`: repeated `-b` increments the
+            // bytes-warning level (`-bb` therefore records 2).
+            Short('b') => flags.bytes_warning = flags.bytes_warning.saturating_add(1),
             // `-B` disables writing bytecode caches (PYTHONDONTWRITEBYTECODE).
             Short('B') => flags.dont_write_bytecode = true,
-            // Unbuffered stdio: pyre's stdout/stderr wrappers already write
-            // through to the fd on every call, so the flag has nothing left
-            // to disable; accepting it keeps `script_helper`-style spawns
-            // (`sys.executable -E -u script`) working.
-            Short('u') => {}
+            // PyPy app_main.py `unbuffered`: writing streams use raw FileIO
+            // underneath TextIOWrapper and set write_through.
+            Short('u') => flags.unbuffered = true,
             Short('q') => flags.quiet = true,
             Short('s') => flags.no_user_site = true,
             Short('S') => flags.no_site = true,
@@ -556,6 +599,10 @@ fn real_main(binary_name: &str) {
             default_hook(info);
         }
     }));
+    // pypy/interpreter/app_main.py `entry_point`: preserve the executable and
+    // every original launcher argument before command-line parsing rewrites
+    // them into the run mode and `sys.argv`.
+    importing::set_sys_orig_argv(std::env::args().collect());
     let (mode, flags, args) = match parse_args(binary_name) {
         Ok(v) => v,
         Err(e) => {
@@ -574,7 +621,12 @@ fn real_main(binary_name: &str) {
         utf8_mode,
         safe_path,
         optimize,
+        bytes_warning,
         dont_write_bytecode,
+        unbuffered,
+        xoptions,
+        warnoptions,
+        stdio_encoding,
     } = flags;
 
     // The `interact` controller does not run the embedded interpreter; it only
@@ -614,7 +666,12 @@ fn real_main(binary_name: &str) {
         utf8_mode.unwrap_or(0),
         safe_path,
         optimize,
+        bytes_warning,
         dont_write_bytecode,
+        unbuffered,
+        xoptions,
+        warnoptions,
+        stdio_encoding,
     );
 
     // OS-level hardening (default-on in any Linux `sandbox` build): lock the


### PR DESCRIPTION
Seven commits on top of `main`, each a separate parity fix.

| commit | area |
| --- | --- |
| `_socket: encode an IDNA hostname through the codec, not an encode attribute` | `_socket` |
| `executioncontext: drop the space-null guard from the trace hooks` | tracing |
| `faulthandler: coerce all_threads and chain as integers` | `faulthandler` |
| `mapdict: release the code-owned cache lock before touching an instance` | attribute caching |
| `posix: give the result structseqs their dotted names and named-only extras` | `posix` |
| `_warnings: take warn's source positionally` | `_warnings`, `pyre-macros` |
| `sys, _io, builtins: carry the launcher's option state into sys and the std streams` | launcher, `sys`, `_io`, `builtins` |

## Authorship

Only the `_socket` commit was written and verified here. The other six are the
output of a `codex` session running in the same worktree; they were left
uncommitted and are split into themed commits and given commit messages citing
the upstream lines they follow, but their code has not been reviewed
line-by-line here.

## `_socket` — what the change rests on

`socket_idna_converter` looked up `encode` on the host object and called it.
`interp_socket.py:108-129 idna_converter` reaches the codec through
`space.encode_unicode_object`, which is `objspace.py:786` ->
`unicodeobject.py:1683 encode_object`; `type_methods::encode_object` is the
counterpart already shared by `str.encode`, `bytes(str, ...)` and
`bytearray(str, ...)`.

A review suggestion motivating this said the codec route avoids invoking a
`str` subclass's `encode` override. Both oracles refute that: `encodings/idna.py`
`Codec.encode` itself calls `input.encode('ascii')`, so the override runs either
way.

```
CPython 3.14 : RuntimeError : subclass encode was called
PyPy         : RuntimeError : encoding with 'idna' codec failed (RuntimeError: subclass encode was called)
pyre (after) : RuntimeError : subclass encode was called
```

The change is made on the structural ground above, not that one. Observable
behaviour on the normal paths:

```
                CPython 3.14                     pyre
nonascii        gaierror                         gaierror (xn--4ca.example.invalid)
surrogate       UnicodeEncodeError 'idna' ...    UnicodeEncodeError 'idna' ...
nullbyte        TypeError                        TypeError
int             TypeError                        TypeError
```

## Verification

`ba42511c81`, HEAD pinned across every stage:

| stage | result |
| --- | --- |
| LLBC extraction | ok |
| dynasm release build | ok |
| cranelift release build | ok |
| `cargo test --all --no-default-features --features dynasm` | ok — 100 `test result: ok`, 0 failed |
| `pyre/check.py` | dynasm 331/332, cranelift 331/332, wasm 328/329 |
| `cargo test -p pyre-sandbox --test e2e_interact -- --ignored` | ok — 2 passed, 0 failed |

The one `check.py` failure is `synth/ast_compile_roundtrip` on all three
backends, reported as `BASEFAIL` / `cpython/pypy output mismatch`. The two
oracles disagree with each other, so no baseline is established:

```
CPython 3.14 : hand reject named-target-not-name TypeError
PyPy         : hand reject named-target-not-name ValueError
```

That benchmark arrived with `a510d58a73` (#856) and is untouched by this
branch, so the failure is not attributable to it.

The first `cargo test --all` run aborted in
`pyre-object functional::range_obj_tests::iter_routes_increment_overflow_to_longrange`
(`handle_alloc_error` -> SIGABRT). No commit here touches `pyre-object`; the
test passes alone, the crate's 279 tests pass together, and the same command at
the same commit passes on re-run, with sibling worktrees running concurrent
builds during the failing run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Follow-up in this branch

The first push failed `sandbox build + e2e (ubuntu-24.04)`: both e2e tests died
in the guest with

```
panicked at pyre/pyre-interpreter/src/module/sys/vm.rs:2029:6:
standard file descriptor must produce a binary buffer: PyError { kind: OSError, ... }
```

`make_std_stream` opened the binary layer for fd 0/1/2 and called `.expect` on
the result, so a descriptor the sandbox controller does not expose aborted
interpreter startup. `app_main.py:465-470 create_stdio` takes that failure as
`except OSError` rather than aborting. Its `return None` is not the right
mapping here — these streams keep instance-override methods that reach the
descriptor without the buffer, and the e2e guests assert on `print` output — so
the open failure now leaves the buffer absent and the stream in place.

Reproduced locally (2 failed), fixed, re-run green (2 passed), and squashed
into the `sys, _io, builtins` commit.
