### PR TITLE
jit(fbw): inline property/classmethod descriptors; always barrier the Object in-place append

### DIFF
--- a/pyre/bench/synth/classmethod_type_dispatch_hot.py
+++ b/pyre/bench/synth/classmethod_type_dispatch_hot.py
@@ -1,0 +1,30 @@
+"""Hot classmethod dispatch through a type receiver: `Type.cmethod(i)`.
+
+Both `Derived.scaled` (inherited) and `Base.scaled` resolve to a classmethod
+whose `cls` binds to the accessed class; the walker inlines the underlying
+`__func__(cls, value)` in place of the descriptor-build + call residual pair.
+Reading `cls.__name__` inside the body keeps a LOAD_ATTR in the inlined callee,
+and the two distinct receiver classes exercise per-site type/version guards.
+"""
+
+
+class Base:
+    @classmethod
+    def scaled(cls, value):
+        return value * 2 + len(cls.__name__)
+
+
+class Derived(Base):
+    pass
+
+
+def main():
+    total = 0
+    i = 0
+    while i < 50000:
+        total += Derived.scaled(i) + Base.scaled(i)
+        i += 1
+    print(total)
+
+
+main()

--- a/pyre/bench/synth/property_custom_hook_decline.py
+++ b/pyre/bench/synth/property_custom_hook_decline.py
@@ -1,0 +1,50 @@
+"""A property whose owner overrides __setattr__/__getattribute__.
+
+The property getter/setter folds must decline when a custom read/write hook
+owns the access: `obj.value = i` dispatches through `__setattr__` (raw store,
+no `* 100`, and a write counter), and `obj.value` through `__getattribute__`
+(raw read, no `+ 1`, and a read counter), never the property `fset`/`fget`.
+Inlining the property body would drop the hooks and diverge silently.
+"""
+
+
+class Hooked:
+    def __init__(self):
+        object.__setattr__(self, "_value", 0)
+        object.__setattr__(self, "writes", 0)
+        object.__setattr__(self, "reads", 0)
+
+    @property
+    def value(self):
+        return self._value + 1
+
+    @value.setter
+    def value(self, value):
+        object.__setattr__(self, "_value", value * 100)
+
+    def __setattr__(self, name, value):
+        if name == "value":
+            object.__setattr__(self, "_value", value)
+            object.__setattr__(self, "writes", object.__getattribute__(self, "writes") + 1)
+        else:
+            object.__setattr__(self, name, value)
+
+    def __getattribute__(self, name):
+        if name == "value":
+            object.__setattr__(self, "reads", object.__getattribute__(self, "reads") + 1)
+            return object.__getattribute__(self, "_value")
+        return object.__getattribute__(self, name)
+
+
+def main():
+    obj = Hooked()
+    total = 0
+    i = 0
+    while i < 50000:
+        obj.value = i
+        total += obj.value
+        i += 1
+    print(total, obj._value, obj.writes, obj.reads)
+
+
+main()

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -8565,6 +8565,53 @@ pub unsafe fn load_method_fast_path(
     Some((w_type, version_tag, w_descr))
 }
 
+/// `Type.name(...)` classmethod method-load fast path: when `w_obj` is a class
+/// whose metaclass is exactly `type` and `name` resolves to a `classmethod` in
+/// the class's own MRO, return the class, its cacheable version tag, and the
+/// classmethod's underlying `__func__`.  The full-body walker writes `__func__`
+/// as the method-load result so `compute_load_method_bound` (eval.rs) binds the
+/// class as `cls` and the following `CALL` inlines `__func__(cls, ...)` — the
+/// same shape a plain instance method takes, with the class in the receiver
+/// slot instead of an instance.
+///
+/// `is_type` is exact-metatype, so a custom metaclass declines (its
+/// `__getattribute__` may not follow `type.__getattribute__`).  A name the
+/// metatype itself defines is declined too: a metatype attribute would shadow
+/// the class attribute (data descriptor) or be returned in its place.  An
+/// uncacheable type and any non-`classmethod` descriptor also decline.
+///
+/// # Safety
+/// `w_obj` must be a valid object pointer (null tolerated).
+pub unsafe fn classmethod_on_type_fast_path(
+    w_obj: PyObjectRef,
+    name: &str,
+) -> Option<(PyObjectRef, u64, PyObjectRef)> {
+    if w_obj.is_null() || !pyre_object::typeobject::is_type(w_obj) {
+        return None;
+    }
+    let w_type = w_obj;
+    // `is_type` pins the metaclass to exactly `type`, so `type.__getattribute__`
+    // is the resolution path.  A metatype attribute of the same name would win
+    // over the class attribute, so decline any name the metatype defines.
+    let metatype = &pyre_object::pyobject::TYPE_TYPE as *const _ as PyObjectRef;
+    if lookup_in_type(metatype, name).is_some() {
+        return None;
+    }
+    let version_tag = pyre_object::typeobject::w_type_get_version_tag(w_type);
+    if version_tag == 0 {
+        return None;
+    }
+    let w_descr = lookup_in_type(w_type, name)?;
+    if !pyre_object::is_classmethod(w_descr) {
+        return None;
+    }
+    let w_func = pyre_object::function::w_classmethod_get_func(w_descr);
+    if w_func.is_null() {
+        return None;
+    }
+    Some((w_type, version_tag, w_func))
+}
+
 /// The `getattr(w_obj, name)` shape that reduces, purely, to
 /// `w_method_new(w_descr, w_obj, w_type)` — the bound method
 /// `object.__getattribute__` builds when the name resolves to a plain

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -1479,12 +1479,10 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
     // store leaves to native ops, leaving `list_write_barrier(l)` as a
     // residual call. Register it so the codewriter resolves the residual to a
     // runtime-patchable address instead of a `symbolic_fnaddr_for_path` hash
-    // the inline sub-walk must decline. The address is also what the walker
-    // matches on to drop the residual entirely when the backend GC rewrite
-    // already covers the store (`FbwWalkMode::append_inplace_wb_covered`);
-    // with an off-GC ItemsBlock the residual stays, because there the
-    // collector reaches the block's slots only through the remembered
-    // `W_ListObject`.
+    // the inline sub-walk must decline. The residual barrier remembers the
+    // enclosing `W_ListObject`, whose trace reaches every item slot, and is
+    // the only thing keeping an appended `old -> young` element reachable
+    // across a minor collection.
     push_alias_pair(
         &mut entries,
         "pyre_object::listobject::list_write_barrier",

--- a/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
+++ b/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
@@ -1358,6 +1358,89 @@ pub unsafe fn load_attr_fast_path(
     Some((w_type, version_tag, map, p.storageindex))
 }
 
+/// Shared resolution for [`property_get_fast_path`] / [`property_set_fast_path`]:
+/// when `name` on `w_obj`'s type resolves to a `property` data descriptor,
+/// return the type, its cacheable version tag, and the property object.  Applies
+/// the shape gates common to both directions — a mapdict instance and a non-zero
+/// `version_tag`.  The read/write hook gate differs (`__getattribute__` for the
+/// getter, `__setattr__` for the setter), so each caller applies its own.  A
+/// property is a data descriptor, so it takes precedence over the instance dict
+/// and the version-pinned type lookup is authoritative; the instance map is not
+/// read.
+///
+/// # Safety
+/// `w_obj` must be a live object.
+unsafe fn property_descr_fast_path(
+    w_obj: PyObjectRef,
+    name: &str,
+) -> Option<(PyObjectRef, u64, PyObjectRef)> {
+    let map = unsafe { mapdict_map_or_null(w_obj) };
+    if map.is_null() {
+        return None;
+    }
+    let w_type = unsafe { (*(*map).terminator()).as_terminator() }.w_cls;
+    if w_type.is_null() {
+        return None;
+    }
+    let version_tag = unsafe { crate::baseobjspace::w_type_version_tag(w_type) };
+    if version_tag == 0 {
+        return None;
+    }
+    let w_descr = unsafe { crate::baseobjspace::lookup_in_type(w_type, name) }?;
+    if !unsafe { pyre_object::descriptor::is_property(w_descr) } {
+        return None;
+    }
+    Some((w_type, version_tag, w_descr))
+}
+
+/// LOAD_ATTR `property` fast path: return the type, version tag, and Python
+/// `fget` when `obj.name` reads a property getter, so the full-body walker can
+/// inline `fget(obj)` in place of the opaque `getattr` residual.  Returns `None`
+/// (leave the residual) for a write-only property or any shape
+/// [`property_descr_fast_path`] declines.  A custom `__getattribute__` owns the
+/// read (mapdict.py:1497-1499), so it declines to the residual.
+///
+/// # Safety
+/// `w_obj` must be a live object.
+pub unsafe fn property_get_fast_path(
+    w_obj: PyObjectRef,
+    name: &str,
+) -> Option<(PyObjectRef, u64, PyObjectRef)> {
+    let (w_type, version_tag, w_descr) = unsafe { property_descr_fast_path(w_obj, name) }?;
+    if unsafe { crate::baseobjspace::getattribute_if_not_from_object(w_type) }.is_some() {
+        return None;
+    }
+    let fget = unsafe { pyre_object::descriptor::w_property_get_fget(w_descr) };
+    if fget.is_null() || unsafe { pyre_object::pyobject::is_none(fget) } {
+        return None;
+    }
+    Some((w_type, version_tag, fget))
+}
+
+/// STORE_ATTR `property` fast path: the setter twin of
+/// [`property_get_fast_path`], returning the type, version tag, and Python
+/// `fset` when `obj.name = value` writes a property setter.  Returns `None`
+/// (leave the residual) for a read-only property or any shape
+/// [`property_descr_fast_path`] declines.  A custom `__setattr__` owns the write
+/// (mapdict.py:1612-1614), so it declines to the residual.
+///
+/// # Safety
+/// `w_obj` must be a live object.
+pub unsafe fn property_set_fast_path(
+    w_obj: PyObjectRef,
+    name: &str,
+) -> Option<(PyObjectRef, u64, PyObjectRef)> {
+    let (w_type, version_tag, w_descr) = unsafe { property_descr_fast_path(w_obj, name) }?;
+    if unsafe { crate::baseobjspace::setattr_if_not_from_object(w_type) }.is_some() {
+        return None;
+    }
+    let fset = unsafe { pyre_object::descriptor::w_property_get_fset(w_descr) };
+    if fset.is_null() || unsafe { pyre_object::pyobject::is_none(fset) } {
+        return None;
+    }
+    Some((w_type, version_tag, fset))
+}
+
 /// The unboxed counterpart of [`load_attr_fast_path`].  It applies the same
 /// LOAD_ATTR resolution gates, but accepts only an `UnboxedPlainAttribute`
 /// and returns the shared longlong-list coordinates and type needed to perform

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -3129,6 +3129,208 @@ pub(crate) fn try_walker_inline_exception_string_override<Sym: WalkSym>(
     Ok(Some(inlined))
 }
 
+/// Inline a `property` getter read (`obj.value`) after the plain-attribute
+/// mapdict fold declines because the attribute is a data descriptor.  PyPy
+/// traces *through* `space.getattr` → `property.__get__` →
+/// `space.call_function(fget, obj)`, inlining the pure-Python getter body; pyre
+/// leaves LOAD_ATTR an opaque `getattr` `CALL_MAY_FORCE` residual whose fget
+/// runs as a fresh interpreter frame every iteration.  This fold reproduces
+/// PyPy's shape: pin the receiver class + version tag (so the property lookup
+/// const-folds), then enter the resolved-callee inline plumbing with the
+/// receiver as `self` so the getter body (commonly `return self._value`) folds
+/// to a guarded slot read inside the trace.
+///
+/// Restricted to a straight-line, nested-call-free getter: the inline then
+/// stays on the leaf sub-walk path and never reaches the loop/`CALL_ASSEMBLER`
+/// route (the only consumer of this LOAD_ATTR residual's non-call `r_args`).
+/// Top full-body frame only, for the resume-doubling reason
+/// [`try_walker_specialize_load_bound_method_attr`] documents.  Every other
+/// shape declines to the residual (SAFE — no acceleration, unchanged
+/// semantics).
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn try_walker_inline_property_get<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    op: &DecodedOp,
+    code: &[u8],
+    r_args: &[OpRef],
+    call_descr: &dyn majit_ir::descr::CallDescr,
+    obj: OpRef,
+    w_code_ptr: usize,
+    name_idx: usize,
+    dst: usize,
+    dst_bank: char,
+) -> Result<Option<(DispatchOutcome, usize)>, DispatchError> {
+    if !ctx.is_authoritative_executor || dst_bank != 'r' || ctx.fbw_mode.inline_subwalk {
+        return Ok(None);
+    }
+    let Some(concrete_obj) = walker_concrete_ref_object(ctx, obj) else {
+        return Ok(None);
+    };
+    let Some(name) = walker_load_name_from_code(w_code_ptr, name_idx) else {
+        return Ok(None);
+    };
+    let Some((w_type, version_tag, fget)) = (unsafe {
+        pyre_interpreter::objspace::std::mapdict::property_get_fast_path(concrete_obj, &name)
+    }) else {
+        return Ok(None);
+    };
+    let Some((w_code, nparams, has_closure)) = (unsafe { resolve_inlinable_callee(fget) }) else {
+        return Ok(None);
+    };
+    if nparams != 1 {
+        return Ok(None);
+    }
+    // Leaf-only getter body: a branch or a nested Python call would drive the
+    // sub-walk into plumbing that consumes the non-call `r_args`; decline those
+    // to the residual instead.
+    let Some(body) = crate::state::sub_jitcode_body_for_code(w_code) else {
+        return Ok(None);
+    };
+    if !exception_string_override_straight_line(body.code) {
+        return Ok(None);
+    }
+    let Some((getter_descr_refs, _, _)) = crate::state::sub_jitcode_descr_pool_for_code(w_code)
+    else {
+        return Ok(None);
+    };
+    if exception_string_override_has_nested_call(body.code, getter_descr_refs) {
+        return Ok(None);
+    }
+
+    // `[fget, <self-placeholder>, obj]`: the method-form call header the inline
+    // plumbing expects (`callable`, unused self slot, then the receiver).
+    let arg_concretes = vec![
+        ConcreteValue::Ref(fget),
+        ConcreteValue::Null,
+        ConcreteValue::Ref(concrete_obj),
+    ];
+    let fget_const = ctx.trace_ctx.const_ref(fget as i64);
+    try_walker_inline_resolved_user_call(
+        ctx,
+        op,
+        code,
+        fget_const,
+        r_args,
+        call_descr,
+        'r',
+        dst,
+        fget,
+        fget_const,
+        fget,
+        arg_concretes,
+        vec![obj],
+        vec![ConcreteValue::Ref(concrete_obj)],
+        true,
+        w_code,
+        nparams,
+        has_closure,
+        Some((obj, concrete_obj, w_type, version_tag)),
+        None,
+        // Getter bodies commonly read `self._slot` — a LOAD_ATTR the method-form
+        // support gate would otherwise reject; the sub-walk folds it to a slot
+        // read (same allowance the exception `__str__`/`__repr__` override uses).
+        true,
+        false,
+    )
+}
+
+/// Inline a `property` setter store (`obj.value = x`) after the plain-attribute
+/// mapdict store fold declines because the attribute is a data descriptor — the
+/// setter twin of [`try_walker_inline_property_get`].  Pin the receiver class +
+/// version tag (so the property lookup const-folds), then inline `fset(obj, x)`
+/// with the receiver as `self`; the setter body (commonly `self._value =
+/// value`) folds to a guarded slot store instead of the opaque `setattr`
+/// residual.  Same leaf-only / top-frame restrictions and residual fall-through
+/// as the getter fold.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn try_walker_inline_property_set<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    op: &DecodedOp,
+    code: &[u8],
+    r_args: &[OpRef],
+    call_descr: &dyn majit_ir::descr::CallDescr,
+    obj: OpRef,
+    value: OpRef,
+    w_code_ptr: usize,
+    name_idx: usize,
+    dst: usize,
+    dst_bank: char,
+) -> Result<Option<(DispatchOutcome, usize)>, DispatchError> {
+    if !ctx.is_authoritative_executor || ctx.fbw_mode.inline_subwalk {
+        return Ok(None);
+    }
+    let Some(concrete_obj) = walker_concrete_ref_object(ctx, obj) else {
+        return Ok(None);
+    };
+    let Some(concrete_value) = walker_concrete_ref_object(ctx, value) else {
+        return Ok(None);
+    };
+    let Some(name) = walker_load_name_from_code(w_code_ptr, name_idx) else {
+        return Ok(None);
+    };
+    let Some((w_type, version_tag, fset)) = (unsafe {
+        pyre_interpreter::objspace::std::mapdict::property_set_fast_path(concrete_obj, &name)
+    }) else {
+        return Ok(None);
+    };
+    let Some((w_code, nparams, has_closure)) = (unsafe { resolve_inlinable_callee(fset) }) else {
+        return Ok(None);
+    };
+    if nparams != 2 {
+        return Ok(None);
+    }
+    let Some(body) = crate::state::sub_jitcode_body_for_code(w_code) else {
+        return Ok(None);
+    };
+    if !exception_string_override_straight_line(body.code) {
+        return Ok(None);
+    }
+    let Some((setter_descr_refs, _, _)) = crate::state::sub_jitcode_descr_pool_for_code(w_code)
+    else {
+        return Ok(None);
+    };
+    if exception_string_override_has_nested_call(body.code, setter_descr_refs) {
+        return Ok(None);
+    }
+
+    // `[fset, <self-placeholder>, obj, value]`: the method-form call header the
+    // inline plumbing expects, then the two positional args (`self`, `value`).
+    let arg_concretes = vec![
+        ConcreteValue::Ref(fset),
+        ConcreteValue::Null,
+        ConcreteValue::Ref(concrete_obj),
+        ConcreteValue::Ref(concrete_value),
+    ];
+    let fset_const = ctx.trace_ctx.const_ref(fset as i64);
+    try_walker_inline_resolved_user_call(
+        ctx,
+        op,
+        code,
+        fset_const,
+        r_args,
+        call_descr,
+        dst_bank,
+        dst,
+        fset,
+        fset_const,
+        fset,
+        arg_concretes,
+        vec![obj, value],
+        vec![
+            ConcreteValue::Ref(concrete_obj),
+            ConcreteValue::Ref(concrete_value),
+        ],
+        true,
+        w_code,
+        nparams,
+        has_closure,
+        Some((obj, concrete_obj, w_type, version_tag)),
+        None,
+        true,
+        false,
+    )
+}
+
 /// Inline a plain Python `__add__` after the numeric BINARY_OP
 /// specializations decline. The receiver class and its version tag pin the
 /// descriptor lookup, matching `try_dispatch_binary_special`'s forward arm.

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -889,34 +889,6 @@ pub struct FbwWalkMode<Sym: WalkSym> {
     /// boundary rather than mapping the callee `op_pc` through the outer
     /// jitcode in `walker_capture_snapshot_for_last_guard`.
     pub inline_subwalk: bool,
-    /// The enclosing `w_list_append` fold took the Object strategy's in-place
-    /// arm on a block that existed before this append, so the appended ref
-    /// lands in a `SetarrayitemGc` the backend GC rewrite already covers with
-    /// `COND_CALL_GC_WB_ARRAY`
-    /// (`rewrite.py:936-944` `handle_write_barrier_setarrayitem`). The list's
-    /// own `items` pointer is unchanged on that arm, so remembering the
-    /// `W_ListObject` adds nothing the array barrier does not already do.
-    ///
-    /// `list_write_barrier` still RUNS concretely during the walk — the walk
-    /// mutates the live heap — but recording it would leave a barrier call in
-    /// the compiled trace, and upstream emits none: pyjitpl never executes a
-    /// write barrier (`executor.py:446`), `COND_CALL_GC_WB` is neither
-    /// can-raise nor a call (`resoperation.py:1124-1125`), and the only
-    /// barrier in a compiled loop is the one the backend rewrite inserts.
-    ///
-    /// Carries the receiver address rather than a flag so only that list's
-    /// barrier is dropped — a barrier reached for any other list inside the
-    /// sub-walk is recorded normally.
-    ///
-    /// Never set for Empty->Object promotion: that transition also installs
-    /// the new block in `W_ListObject.items`, so the owner barrier is
-    /// load-bearing even though the subsequent element store is in-place.
-    ///
-    /// Only set while the items block is GC-managed. With
-    /// `PYRE_GC_ITEMSBLOCK=0` the block is `std::alloc` memory with no GC
-    /// header, the collector reaches its slots only through the remembered
-    /// `W_ListObject`, and the hand barrier is load-bearing.
-    pub append_inplace_wb_covered_receiver: Option<usize>,
     /// A bridge-carrier resume folds nested self-recursive calls directly to
     /// `CALL_ASSEMBLER` (`opimpl_recursive_call_assembler`) rather than
     /// re-unrolling the call tree to the multi-frame depth cap.
@@ -982,7 +954,6 @@ impl<Sym: WalkSym> Default for FbwWalkMode<Sym> {
         Self {
             snapshot_sym: std::ptr::null(),
             inline_subwalk: false,
-            append_inplace_wb_covered_receiver: None,
             carrier_resume: false,
             current_exception_seed: None,
             current_exception_seed_concrete: pyre_object::PY_NULL,

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -3977,6 +3977,54 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
                 {
                     return Ok((DispatchOutcome::Continue, op.next_pc));
                 }
+                // The plain-slot fold declines a `property` (data descriptor);
+                // inline its Python getter instead of the opaque residual.
+                if let Some(inlined) = try_walker_inline_property_get(
+                    ctx,
+                    op,
+                    code,
+                    &r_args,
+                    call_descr,
+                    obj_opref,
+                    w_code_ptr,
+                    namei as usize,
+                    dst,
+                    dst_bank,
+                )? {
+                    return Ok(inlined);
+                }
+            }
+        }
+    }
+    // STORE_ATTR property setter: the plain-slot store fold above declines a
+    // `property` data descriptor; inline its Python setter instead of the
+    // opaque `setattr` residual.  `store_attr_fn` r_args = [obj, value, code].
+    if ctx.is_authoritative_executor && ei.pyre_helper == majit_ir::PyreHelperKind::StoreAttr {
+        if let (Some(&obj_opref), Some(&value_opref), Some(&code_opref), Some(&namei_opref)) =
+            (r_args.first(), r_args.get(1), r_args.get(2), i_args.first())
+        {
+            if let (
+                Some(majit_ir::Value::Ref(majit_ir::GcRef(w_code_ptr))),
+                Some(majit_ir::Value::Int(namei)),
+            ) = (
+                ctx.trace_ctx.box_value(code_opref),
+                ctx.trace_ctx.box_value(namei_opref),
+            ) {
+                if let Some(inlined) = try_walker_inline_property_set(
+                    ctx,
+                    op,
+                    code,
+                    &r_args,
+                    call_descr,
+                    obj_opref,
+                    value_opref,
+                    w_code_ptr,
+                    namei as usize,
+                    dst,
+                    dst_bank,
+                )? {
+                    return Ok(inlined);
+                }
             }
         }
     }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -4055,6 +4055,24 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
                 {
                     return Ok((DispatchOutcome::Continue, op.next_pc));
                 }
+                // `Type.cmethod(...)`: the receiver is a class and the name
+                // resolves to a `classmethod`, which `load_method_fast_path`
+                // declines (non-instance receiver, non-method descriptor).
+                // Write the classmethod's `__func__` so the paired
+                // `load_method_self` binds the class and the CALL inlines it.
+                if try_walker_specialize_load_classmethod_attr(
+                    ctx,
+                    op.pc,
+                    obj_opref,
+                    w_code_ptr,
+                    namei as usize,
+                    dst,
+                    dst_bank,
+                )?
+                .is_some()
+                {
+                    return Ok((DispatchOutcome::Continue, op.next_pc));
+                }
                 // The `[w_descr, w_obj]` push above is restricted to
                 // `flag_method_descriptor` types, so a builtin method on a
                 // builtin receiver (`lst.append`) leaves `getattr` to build a

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -1480,9 +1480,7 @@ pub(crate) fn try_execute_residual_call_via_executor<Sym: WalkSym>(
     // (`rpython/jit/metainterp/executor.py:446`), is neither can-raise nor a
     // call (`resoperation.py:1124-1125`), and is inserted only by the backend
     // GC rewrite pass after optimization (`backend/llsupport/rewrite.py:948`),
-    // so it never participates in the metainterp's side-effect analysis.  On
-    // the in-place Object-append arm it is not recorded at all, for the same
-    // reason — see `FbwWalkMode::append_inplace_wb_covered`.
+    // so it never participates in the metainterp's side-effect analysis.
     let is_idempotent_gc_barrier = pyre_interpreter::is_list_write_barrier(func_ptr as usize);
     if allboxes.len() - 1 > majit_translate::codewriter::insns::MAX_HOST_CALL_ARITY {
         return Ok(ResidualExecOutcome::Declined(ResidualDecline::Symbolic));
@@ -3398,31 +3396,18 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
                 .profiler()
                 .count_ops(call_opcode, majit_metainterp::counters::RECORDED_OPS);
         }
-        // `list_write_barrier` on the Object strategy's in-place append arm:
-        // the backend GC rewrite already marks the same store's items block
-        // with `COND_CALL_GC_WB_ARRAY`, and the list's `items` pointer did not
-        // change, so a recorded barrier call is a second barrier upstream never
-        // emits. Skip the record; the executor below still runs it concretely,
-        // because the walk itself mutates the live heap. `OpRef::NONE` is safe
-        // as the result slot: the barrier is void, so the only consumer
-        // (`set_opref_concrete` on the executed result) is the `Type::Void`
-        // no-op arm.
-        let wb_covered = ctx
-            .fbw_mode
-            .append_inplace_wb_covered_receiver
-            .is_some_and(|receiver| {
-                allboxes.len() == 2
-                    && matches!(ctx.trace_ctx.box_value(allboxes[0]), Some(majit_ir::Value::Int(addr))
-                        if pyre_interpreter::is_list_write_barrier(addr as usize))
-                    && matches!(ctx.trace_ctx.box_value(allboxes[1]), Some(majit_ir::Value::Ref(r))
-                        if r.as_usize() == receiver)
-            });
-        let recorded = if wb_covered {
-            OpRef::NONE
-        } else {
-            ctx.trace_ctx
-                .record_op_with_descr(call_opcode, &allboxes, descr.clone())
-        };
+        // Always record `list_write_barrier` on the Object strategy's in-place
+        // append arm.  Dropping it in favour of the backend's
+        // `COND_CALL_GC_WB_ARRAY` on the block's `setarrayitem` is unsound: a
+        // guard-failure bridge that re-materializes the items block appends into
+        // it without that array barrier ever firing, so an `old -> young` slot
+        // store leaves the block off the remembered set.  A later minor frees
+        // the still-referenced young element and the collector then reads a
+        // freed (poison) header.  The list barrier remembers the enclosing
+        // `W_ListObject`, whose trace reaches every slot, and keeps them alive.
+        let recorded = ctx
+            .trace_ctx
+            .record_op_with_descr(call_opcode, &allboxes, descr.clone());
 
         // pyjitpl.py `_record_helper_pure` parity: for
         // `CallPure*` whose every argbox carries a known `box_value`,

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -2360,7 +2360,9 @@ pub(crate) fn try_walker_specialize_load_classmethod_attr<Sym: WalkSym>(
     // classmethod lookup walks; the version tag below covers method reassignment.
     let w_type_const = ctx.trace_ctx.const_ref(w_type as i64);
     walker_emit_fold_guard_with_snapshot(ctx, op_pc, OpCode::GuardValue, &[obj, w_type_const])?;
-    ctx.trace_ctx.heap_cache_mut().replace_box(obj, w_type_const);
+    ctx.trace_ctx
+        .heap_cache_mut()
+        .replace_box(obj, w_type_const);
 
     // typeobject.py `promote(self.version_tag())`: class mutation or classmethod
     // reassignment in the class or any base bumps `_version_tag`, so the pinned
@@ -5495,16 +5497,6 @@ pub(crate) fn orthodox_list_append_commit<Sym: WalkSym>(
     let value_concrete = ConcreteValue::Ref(value);
     let saved_fbw_mode = ctx.fbw_mode;
     ctx.fbw_mode.inline_subwalk = true;
-    // Read the arm AFTER any empty-strategy promotion above, so the predicate
-    // sees the storage the sub-walk will actually append into.  An
-    // Empty->Object promotion is not the pre-existing-block in-place case:
-    // it has just installed a young `items` block into the (possibly old)
-    // list wrapper.  Keep the body's `list_write_barrier` for that transition;
-    // only an append whose Object block predated this append is covered solely
-    // by the SetarrayitemGc array barrier.
-    ctx.fbw_mode.append_inplace_wb_covered_receiver = (!promote_empty
-        && unsafe { pyre_object::w_list_append_stores_into_gc_block_in_place(inner_self) })
-    .then_some(inner_self as usize);
     let walk_result = run_sub_jitcode_walk(
         ctx,
         op.pc,

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -2305,6 +2305,80 @@ pub(crate) fn try_walker_specialize_load_method_attr<Sym: WalkSym>(
     Ok(Some(()))
 }
 
+/// `LOAD_METHOD` classmethod fold for a type receiver (`Type.cmethod(...)`).
+/// The safety oracle is [`pyre_interpreter::classmethod_on_type_fast_path`]: it
+/// declines a custom metaclass, a metatype-defined name, an uncacheable type,
+/// and any non-`classmethod` descriptor.  On success the walker pins the exact
+/// type and its version tag, then writes the classmethod's `__func__` as a
+/// green constant.  Because the method-load result is the plain `__func__` (not
+/// a bound `Method`), the paired [`try_walker_fold_load_method_self`] runs
+/// `compute_load_method_bound`, whose `is_type` + `is_classmethod` arm binds the
+/// type as `cls`, and the following `CALL` inlines `__func__(cls, ...)` — the
+/// instance-method shape with the class in the receiver slot.
+///
+/// Restricted to the top full-body frame for the reason
+/// [`try_walker_specialize_load_bound_method_attr`] carries: a fold guard
+/// inside an inlined callee sub-walk resumes at the caller's CALL, re-running
+/// side effects.  The `getattr` residual resumes past the call, so declining
+/// there re-runs nothing.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn try_walker_specialize_load_classmethod_attr<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    op_pc: usize,
+    obj: OpRef,
+    w_code_ptr: usize,
+    name_idx: usize,
+    dst: usize,
+    dst_bank: char,
+) -> Result<Option<()>, DispatchError> {
+    if !ctx.is_authoritative_executor || dst_bank != 'r' {
+        return Ok(None);
+    }
+    if ctx.fbw_mode.inline_subwalk {
+        return Ok(None);
+    }
+    let Some(concrete_obj) = walker_concrete_ref_object(ctx, obj) else {
+        return Ok(None);
+    };
+    let Some(name) = walker_load_name_from_code(w_code_ptr, name_idx) else {
+        return Ok(None);
+    };
+    if name.contains("__") {
+        return Ok(None);
+    }
+    let Some((w_type, version_tag, w_func)) =
+        (unsafe { pyre_interpreter::classmethod_on_type_fast_path(concrete_obj, &name) })
+    else {
+        return Ok(None);
+    };
+    if unsafe { resolve_inlinable_callee(w_func) }.is_none() {
+        return Ok(None);
+    }
+
+    // Pin the exact class.  The receiver IS the type, so a single GuardValue
+    // anchors both the metaclass (exact `type`, via `is_type`) and the MRO the
+    // classmethod lookup walks; the version tag below covers method reassignment.
+    let w_type_const = ctx.trace_ctx.const_ref(w_type as i64);
+    walker_emit_fold_guard_with_snapshot(ctx, op_pc, OpCode::GuardValue, &[obj, w_type_const])?;
+    ctx.trace_ctx.heap_cache_mut().replace_box(obj, w_type_const);
+
+    // typeobject.py `promote(self.version_tag())`: class mutation or classmethod
+    // reassignment in the class or any base bumps `_version_tag`, so the pinned
+    // `__func__` side-exits.
+    let vt_op = walker_record_getfield_gc_i_uncached(
+        ctx,
+        w_type_const,
+        crate::descr::type_version_tag_descr(),
+    );
+    let vt_const = ctx.trace_ctx.const_int(version_tag as i64);
+    walker_emit_fold_guard_with_snapshot(ctx, op_pc, OpCode::GuardValue, &[vt_op, vt_const])?;
+    ctx.trace_ctx.heap_cache_mut().replace_box(vt_op, vt_const);
+
+    let func_const = ctx.trace_ctx.const_ref(w_func as i64);
+    write_residual_call_result_to_dst(ctx, op_pc, dst, dst_bank, func_const)?;
+    Ok(Some(()))
+}
+
 /// Fold the `LOAD_ATTR`-method `getattr` residual for a receiver whose name
 /// resolves to a plain builtin-code function on its type — the `lst.append`
 /// shape [`try_walker_specialize_load_method_attr`] declines because upstream

--- a/pyre/pyre-object/src/listobject.rs
+++ b/pyre/pyre-object/src/listobject.rs
@@ -1161,27 +1161,6 @@ pub unsafe fn w_list_uses_empty_storage(obj: PyObjectRef) -> bool {
     list.strategy == ListStrategy::Empty
 }
 
-/// True when the next `w_list_append` on `obj` takes the Object strategy's
-/// in-place arm (`rlist.py:285` resize-ge fast case) into a GC-managed items
-/// block: spare capacity, so the store is an item-slot write and the list's
-/// `items` pointer does not change.
-///
-/// The tracer uses this to decide whether the recorded trace needs
-/// `list_write_barrier` at all — see `FbwWalkMode::append_inplace_wb_covered`.
-/// A `std::alloc` block (`PYRE_GC_ITEMSBLOCK=0`) answers false: it has no GC
-/// header for an array barrier to mark, so the barrier on the enclosing
-/// `W_ListObject` is the only thing keeping the block's slots reachable.
-///
-/// # Safety
-/// `obj` must point to a valid `W_ListObject`.
-pub unsafe fn w_list_append_stores_into_gc_block_in_place(obj: PyObjectRef) -> bool {
-    let list = &*(obj as *const W_ListObject);
-    list.strategy == ListStrategy::Object
-        && ll_list_obj_length(list) < ll_list_obj_capacity(list)
-        && !list.items.is_null()
-        && crate::gc_hook::try_gc_owns_object(list.items as *mut u8)
-}
-
 /// Rebuild the list's object storage from a Vec.
 unsafe fn rebuild_object_items(list: &mut W_ListObject, items: Vec<PyObjectRef>) {
     list.set_object_items_from_vec(items);


### PR DESCRIPTION
Three FBW-tracer changes: two descriptor folds (property, classmethod) and a GC write-barrier correctness fix.

## `jit(fbw): inline property fget/fset` (c86b43c11e)

A hot `obj.attr` / `obj.attr = v` against a `property` descriptor previously stayed an opaque `LOAD_ATTR`/`STORE_ATTR` residual. The fold now inlines the pure-Python `fget`/`fset` bodies. The getter gates on `__getattribute__` not being overridden from `object`; the **setter gates independently on `__setattr__`** (they are separate hooks — a class overriding only one must not decline the other). `allow_method_load_attr=true` so a method-valued `fget` still folds. Fixture: `property_custom_hook_decline.py`.

## `jit(fbw): inline a type-receiver classmethod call` (358a3076fd)

`Type.cmethod(x)` compiles to a `LOAD_ATTR`(method-flag) + `CALL` residual pair. The getattr fold now writes the classmethod's `__func__` as a green const; the existing `compute_load_method_bound` / `load_method_self` path binds `cls=type`, and the existing CALL inliner inlines `__func__(cls, x)`. `is_type` is exact-metatype, so a custom metaclass declines for free; `version_tag` catches base-class reassignment (mutation recurses `weak_subclasses`). Fixture: `classmethod_type_dispatch_hot.py`.

## `jit(fbw): always record list_write_barrier on the Object in-place append arm` (0465251afc)

Fixes a dynasm-only GC abort (`validate_type_id` / `object_total_size` panic in `copy_nursery_object`) when `nested_list_comprehension_hot` is sized up (`k>=3500`).

The `append_inplace_wb_covered` optimization dropped the recorded `list_write_barrier(W_ListObject)` on `w_list_append`'s Object-strategy in-place arm, betting the backend's `COND_CALL_GC_WB_ARRAY` on the block's `setarrayitem` covered it. A **guard-failure bridge** re-materializes the items block and appends into it without that array barrier firing, so an `old -> young` element store never enters the remembered set; a later minor collection frees the still-referenced young element and the collector reads a freed (poison) header.

Fix: delete the optimization and always record the barrier. Removes `FbwWalkMode::append_inplace_wb_covered_receiver` (field + setter) and the `w_list_append_stores_into_gc_block_in_place` predicate.

Validated with `MAJIT_GC_NURSERY_POISON=1` at k=6000: rc=127 (poison panic) → rc=0, output `23994000`; cranelift identical.

## Verification

`check.py`: dynasm **333/333**, cranelift **333/333**, both ALL PASSED.