### PR TITLE
majit, pyre: twenty census slices — residual boundaries, unsigned-bank folds, dyn-indirect on by default

### DIFF
--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -7520,6 +7520,20 @@ pub fn build_inline_call_only_bh_builder() -> BlackholeInterpBuilder {
         "abort_permanent/".to_string(),
         majit_translate::insns::BC_ABORT_PERMANENT,
     );
+    // `vtable_method_ptr/rd>i` — the dyn-trait method-pointer reification.
+    // Routing `dyn Trait` calls through `CallTarget::Indirect` is the
+    // default, so the codewriter now emits this byte into real jitcodes and
+    // this builder's dispatch table has to span it: `setup_insns(asm.insns)`
+    // (`blackhole.py:58-59`) resolves every opname the assembler emitted, and
+    // a byte outside the curated set reaches the unwired-opcode placeholder
+    // instead of the handler.  The handler it binds is deliberately
+    // `handler_vtable_method_ptr_unimplemented` — no layer executes this op
+    // yet, so the point of the entry is that a resume landing here says which
+    // op is missing rather than reporting an unwired byte.
+    insns.insert(
+        "vtable_method_ptr/rd>i".to_string(),
+        majit_translate::insns::BC_VTABLE_METHOD_PTR,
+    );
     // blackhole.py:954-960 bhimpl_switch. `handler_switch` is wired in
     // `wire_bhimpl_handlers` but the byte was absent from this builder's
     // insns map, so a deopt through a `switch/id` op landed on the
@@ -8628,12 +8642,19 @@ fn handler_guard_class(
     Ok(p + 2)
 }
 /// `vtable_method_ptr` reaches the blackhole only when a `dyn Trait`
-/// indirect call survives unfrozen into a metainterp resume.  pyre's hot
-/// path does not currently emit this pattern; intentionally panic so any
-/// future regression is loud rather than silent.  The codewriter still
-/// emits the op + descriptor (TODO of
-/// `rpython/rtyper/rclass.py:371-377 getclsfield()`) so the IR survives
-/// serialization for the next integration step.
+/// indirect call survives unfrozen into a metainterp resume.
+///
+/// The codewriter does emit the op + descriptor (TODO of
+/// `rpython/rtyper/rclass.py:371-377 getclsfield()`) now that indirect
+/// routing is the default, but no layer consumes it: there is no backend
+/// lowering (`codewriter/assembler.rs`, "backend lowering of the actual
+/// vtable slot read is not yet implemented"), the walker answers
+/// `DispatchError::UnsupportedOpname`, and `PyreVtableMethodDescr` carries
+/// the `(trait_root, method_name)` pair as strings with nothing that
+/// resolves them to an address.  The walker's abort is what keeps this
+/// unreachable in practice — a trace meeting the op never compiles, so no
+/// resume can land past it.  Panic intentionally so that if one ever does,
+/// it is loud rather than a silent miscompile.
 fn handler_vtable_method_ptr_unimplemented(
     _bh: &mut BlackholeInterpreter,
     _code: &[u8],

--- a/majit/majit-translate/docs/design-346-dstrategy-trait-object-field.md
+++ b/majit/majit-translate/docs/design-346-dstrategy-trait-object-field.md
@@ -48,10 +48,11 @@ Registration is driven two ways:
 - **config** `PipelineConfig.register_trait_families: Vec<String>` (pipeline.rs:58) — a list of
   trait qualified paths; harvested into `TraitFamilyRegistration` at lib.rs:1225, applied at
   codewriter.rs:158. **Empty in production** (test_support.rs:51). NOT gated.
-- **auto** every `>=2`-impl trait, gated behind `PYRE_DYN_INDIRECT` (lib.rs:1264). The gate
-  comment (lib.rs:1257) warns: minting base/impl subclass classdefs perturbs
-  `pyre_struct_root_names` → `ensure_session` inheritance-id numbering even off-path, so the
-  gate keeps prod byte-identical.
+- **auto** every `>=2`-impl trait, behind `dyn_indirect_enabled()` — **on by default** since
+  the `__dyn_call` flip; `PYRE_DYN_INDIRECT=0` is the kill switch. The gate comment warns:
+  minting base/impl subclass classdefs perturbs `pyre_struct_root_names` → `ensure_session`
+  inheritance-id numbering even off-path, which is why the kill switch has to restore this
+  registration and the `__dyn_call` emit together.
 
 The machinery is wired only to the **parameter-seeding** path (`derive_subject_inputcells`
 trait-family arm, flowspace_adapter.rs:2823) — a `&dyn Trait` function argument. It is NOT
@@ -70,8 +71,8 @@ register_trait_families: vec!["pyre_object::dictmultiobject::DictStrategy".to_st
 
 `trait_impl_owners` (lib.rs:1158, harvested from `concrete_trait_methods`) already maps this
 qualified path to its 6 impl owners, so `make_registration` (lib.rs:1200) builds the family
-with no further work. This runs through the NON-gated config path, so `PYRE_DYN_INDIRECT` is
-untouched.
+with no further work. This runs through the NON-gated config path, so `dyn_indirect_enabled()`
+is untouched.
 
 **RISK (measure first, in isolation):** the gate comment says config registration also mints
 classdefs that shift `ensure_session` inheritance-id numbering. Whether one family shifts prod

--- a/majit/majit-translate/src/annotator/annrpython.rs
+++ b/majit/majit-translate/src/annotator/annrpython.rs
@@ -2227,7 +2227,7 @@ impl RPythonAnnotator {
         // reaching here means a call-site interface (recursivecall /
         // addpendinggraph) leaked an unannotated arg through —
         // fail-loud matches the upstream AttributeError.
-        let unions: Result<Vec<SomeValue>, UnionError> = oldcells
+        let unions: Result<Vec<SomeValue>, (usize, UnionError)> = oldcells
             .iter()
             .zip(inputcells.iter())
             .enumerate()
@@ -2239,23 +2239,41 @@ impl RPythonAnnotator {
                          raised AttributeError)"
                     )
                 });
-                unionof([c1, s2])
+                unionof([c1, s2]).map_err(|e| (i, e))
             })
             .collect();
 
         let unions = match unions {
             Ok(u) => u,
-            Err(e) => {
+            Err((slot, e)) => {
+                // `annrpython.py:437-438` attaches the offending source to the
+                // UnionError before it is recorded or re-raised. `UnionError`
+                // renders only the two annotations, which on its own does not
+                // say which merge produced them — and the merging block is
+                // routinely an inlined callee, so the graph the caller was
+                // annotating is not the graph that failed. Carry the same
+                // `source_lines` context here, plus the input slot the two
+                // annotations belong to.
+                let source = crate::tool::error::source_lines(
+                    graph,
+                    Some(block),
+                    None,
+                    None,
+                    true,
+                    crate::tool::error::SHOW_DEFAULT_LINES_OF_CODE,
+                )
+                .join("\n");
+                let e = format!("{e}\n\n[mergeinputargs slot={slot}]\n{source}");
                 // Upstream keeps going when `self.keepgoing` is set;
                 // otherwise re-raises.
                 if self.keepgoing {
-                    self.errors.borrow_mut().push(format!("{e}"));
+                    self.errors.borrow_mut().push(e);
                     self.failed_blocks
                         .borrow_mut()
                         .insert(BlockKey::of(block), Rc::clone(block));
                     return;
                 }
-                panic!("UnionError in mergeinputargs: {}", e);
+                panic!("UnionError in mergeinputargs: {e}");
             }
         };
 

--- a/majit/majit-translate/src/annotator/annrpython.rs
+++ b/majit/majit-translate/src/annotator/annrpython.rs
@@ -2263,7 +2263,25 @@ impl RPythonAnnotator {
                     crate::tool::error::SHOW_DEFAULT_LINES_OF_CODE,
                 )
                 .join("\n");
-                let e = format!("{e}\n\n[mergeinputargs slot={slot}]\n{source}");
+                // `source_lines1` answers `no source!` for every graph lowered
+                // from LLBC rather than from Python (`graph.source` is absent),
+                // which is all of them here. Quote the block's operations
+                // instead — the same "show the offending block" role upstream's
+                // source-line range plays, rendered the way `gather_error`
+                // already renders an operation (`tool/error.rs:498`).
+                let ops = {
+                    let b = block.borrow();
+                    if b.operations.is_empty() {
+                        "    <no operations>".to_string()
+                    } else {
+                        b.operations
+                            .iter()
+                            .map(|op| format!("    {op}"))
+                            .collect::<Vec<_>>()
+                            .join("\n")
+                    }
+                };
+                let e = format!("{e}\n\n[mergeinputargs slot={slot}]\n{source}\n{ops}");
                 // Upstream keeps going when `self.keepgoing` is set;
                 // otherwise re-raises.
                 if self.keepgoing {

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -11597,10 +11597,11 @@ fn constants_call_leaf(reg: &RegularCall, llbc: &Llbc) -> Option<&'static str> {
 /// so the index type must be an integer.  Charon runs `monomorphize:false`,
 /// so the signature keeps the generic index param `I` (a `TypeVar` typing
 /// as `Ref`); the concrete index type is the callsite substitution
-/// `types[1]` of the impl generics `[T, I, A]`.  `Index<usize>` types as
-/// `Unsigned` and signed integer indices as `Int`; both occupy RPython's
-/// integer register bank. `Index<Range<…>>` resolves to a `Range*` Adt
-/// (`Ref`) and returns `None`. Owner/leaf are derived the same way
+/// `types[1]` of the impl generics `[T, I, A]`, which
+/// [`vec_index_type_is_scalar`] classifies: `Index<usize>` types as
+/// `Unsigned` and signed integer indices as `Int`, and both occupy RPython's
+/// integer register bank, while `Index<Range<…>>` resolves to a `Range*` Adt
+/// (`Ref`) and returns `None`.  Owner/leaf are derived the same way
 /// [`call_target_segments`]
 /// derives the call key (`impl_method_owner_for_fundecl`).  Free so the
 /// same gate is shared by the call-lowering intercept and the deferred-write
@@ -11627,13 +11628,25 @@ fn vec_index_regular_leaf(reg: &RegularCall, llbc: &Llbc) -> Option<&'static str
         .and_then(serde_json::Value::as_array)
         .and_then(|tys| tys.get(1))
         .and_then(|t| serde_json::from_value::<TyRef>(t.clone()).ok())
-        .is_some_and(|t| {
-            matches!(
-                tyref_to_value_type(&t, llbc),
-                ValueType::Int | ValueType::Unsigned
-            )
-        });
+        .is_some_and(|t| vec_index_type_is_scalar(&t, llbc));
     int_indexed.then_some(leaf)
+}
+
+/// Whether `ty` is an index type [`vec_index_regular_leaf`] may lower to a
+/// scalar `ArrayRead` / `ArrayWrite`.
+///
+/// Both integer banks count. `usize` — what essentially every real callsite
+/// indexes with — serializes as `{"UInt": "Usize"}` and types as
+/// [`ValueType::Unsigned`], so an `Int`-only test silently rejects it and
+/// leaves the whole fold dead: the `#[ignore]`d real-LLBC anchor
+/// `vec_index_mut_fill_user_function_args_real` failed with two residual
+/// `index_mut` calls.  A `Range` index types as `Ref` and is still rejected,
+/// which is what the gate exists for.
+fn vec_index_type_is_scalar(ty: &TyRef, llbc: &Llbc) -> bool {
+    matches!(
+        tyref_to_value_type(ty, llbc),
+        ValueType::Int | ValueType::Unsigned
+    )
 }
 
 /// Whether a [`RegularCall`] is a `Vec<T>` `index` **or** `index_mut` on an
@@ -20351,6 +20364,48 @@ mod tests {
             }
         });
         Llbc::from_slice(file.to_string().as_bytes()).expect("fixture Llbc parses")
+    }
+
+    /// The `Vec` index fold must accept a `usize` index.
+    ///
+    /// `usize` types as `Unsigned`, not `Int`, so gating on `Int` alone left
+    /// both the read and write lifts dead for every real callsite — caught
+    /// only by the `#[ignore]`d real-LLBC anchor
+    /// (`vec_index_mut_fill_user_function_args_real`), which does not run in
+    /// CI.  This pins the acceptance set without the 440MB corpus.
+    #[test]
+    fn vec_index_gate_accepts_both_integer_banks_and_rejects_range() {
+        let llbc = llbc_with_trait_impls(serde_json::json!([]));
+        let ty = |v: serde_json::Value| {
+            serde_json::from_value::<super::TyRef>(serde_json::json!({
+                "HashConsedValue": [0, v]
+            }))
+            .expect("fixture TyRef parses")
+        };
+        let usize_ty = ty(serde_json::json!({ "Literal": { "UInt": "Usize" } }));
+        assert_eq!(
+            super::tyref_to_value_type(&usize_ty, &llbc),
+            crate::model::ValueType::Unsigned,
+            "usize must type as Unsigned — the trap this gate fell into"
+        );
+        assert!(
+            super::vec_index_type_is_scalar(&usize_ty, &llbc),
+            "Vec index fold must accept a usize index"
+        );
+        assert!(
+            super::vec_index_type_is_scalar(
+                &ty(serde_json::json!({ "Literal": { "Int": "I64" } })),
+                &llbc
+            ),
+            "Vec index fold must accept a signed index"
+        );
+        assert!(
+            !super::vec_index_type_is_scalar(
+                &ty(serde_json::json!({ "Adt": { "id": { "Adt": 7 } } })),
+                &llbc
+            ),
+            "a Range index types as Ref and must stay rejected"
+        );
     }
 
     #[test]

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -8694,10 +8694,15 @@ impl<'a> Lowering<'a> {
 
     /// `<String as AsRef<str>>::as_ref(&self) -> &str`,
     /// `String::as_str(&self) -> &str`, `Wtf8::as_str(&self) -> &str`, and
-    /// `<String as Borrow<str>>::borrow(&self) -> &str` — every one
+    /// `<String as Borrow<str>>::borrow(&self) -> &str`, and pyre's
+    /// `as_str_unchecked(&Wtf8) -> &str` — every one
     /// returns a `&str` view of the same string, an identity in the
     /// lifted value model (Rust `String`/`&str`/`str`/`Wtf8`/`Wtf8Buf`
-    /// all lower to the immutable rpy_string).  Without the intercept the
+    /// all lower to the immutable rpy_string).  `as_str_unchecked` names
+    /// the view `Wtf8::as_str` gives once its validity arm has been taken
+    /// separately: `as_str` itself returns `Result<&str, Utf8Error>`,
+    /// whose destination does not strip to `str`, so it fails the gate
+    /// below and stays a wall.  Without the intercept the
     /// call keeps a `CallTarget::Method` `as_ref` getattr the rtyper
     /// cannot route on the classdef-less string receiver (the `Cannot
     /// find attribute "as_ref" on UnicodeString` wall).  Bind the
@@ -8724,7 +8729,7 @@ impl<'a> Lowering<'a> {
         let Some(leaf) = np.rsplit("::").next() else {
             return false;
         };
-        if !matches!(leaf, "as_ref" | "as_str" | "borrow") {
+        if !matches!(leaf, "as_ref" | "as_str" | "as_str_unchecked" | "borrow") {
             return false;
         }
         if !first_arg_ty.is_some_and(|ty| tyref_is_string_value(ty, self.llbc)) {

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -10144,14 +10144,31 @@ impl<'a> Lowering<'a> {
     /// and keeps the generic `Call` form (none arise today; the live
     /// callers are `neg`'s `int_value` and `functional`'s `step`,
     /// both `i64`).
-    /// Lower `i64::wrapping_{add,sub,mul}` (`core::num::<Impl>::wrapping_*`,
-    /// Opaque in the LLBC like every core fn) to the native
-    /// `BinOp("add"/"sub"/"mul")`.  `Signed` arithmetic is modular
-    /// machine arithmetic — `rint.py rtype_add` emits `int_add` with no
-    /// overflow check, and `int_add` wraps (`rarithmetic.py intmask`
-    /// semantics) — so the wrapping method IS the plain llop.  Restricted
-    /// to word-sized signed receivers; a narrower `wrapping_add` (which
-    /// wraps at its own width) keeps the `Call` form.
+    /// Lower `{i64,u64}::wrapping_{add,sub,mul}`
+    /// (`core::num::<Impl>::wrapping_*`, Opaque in the LLBC like every
+    /// core fn) to the native `BinOp("add"/"sub"/"mul")`.  `Signed`
+    /// arithmetic is modular machine arithmetic — `rint.py:217
+    /// rtype_add` emits `int_add` with no overflow check, and `int_add`
+    /// wraps (`rarithmetic.py intmask` semantics) — so the wrapping
+    /// method IS the plain llop.  Restricted to word-sized receivers; a
+    /// narrower `wrapping_add` (which wraps at its own width) keeps the
+    /// `Call` form.
+    ///
+    /// Both integer banks count, the lesson [`vec_index_type_is_scalar`]
+    /// already carries: `usize` serializes as `{"UInt": "Usize"}`, which
+    /// `tyref_literal_int_atom` does not see at all, so an `Int`-only
+    /// test silently declined every unsigned counter (`keys_version`,
+    /// `clear_gen`) and left the enclosing graph blocked on the call.
+    /// Unsigned is the same machine op under a different rtyper
+    /// dispatch: `rint.py`'s `opprefix` makes it `uint_add`, and
+    /// `jtransform.py:1608-1610` renames `uint_{add,sub,mul}` straight
+    /// back to `int_{add,sub,mul}` for the JIT.
+    ///
+    /// The result carries the receiver's signedness rather than a flat
+    /// `Int`.  `union_type` widens `Int ∪ Unsigned` to `Unknown`
+    /// (`binaryop.py:191` UnionError), so annotating a `usize` sum as
+    /// `Int` would poison the merge where it meets the unsigned field
+    /// read it came from.
     fn try_lower_wrapping_binop(
         &mut self,
         mir_bb: usize,
@@ -10187,7 +10204,9 @@ impl<'a> Lowering<'a> {
         let Some(src) = fd.signature.inputs.first() else {
             return Ok(false);
         };
-        if !matches!(self.tyref_literal_int_atom(src), Some("I64" | "Isize")) {
+        let signed_word = matches!(self.tyref_literal_int_atom(src), Some("I64" | "Isize"));
+        let unsigned_word = matches!(self.tyref_literal_uint_atom(src), Some("U64" | "Usize"));
+        if !signed_word && !unsigned_word {
             return Ok(false);
         }
         let bb_id = self.block_id[mir_bb];
@@ -10200,7 +10219,11 @@ impl<'a> Lowering<'a> {
                 op: op.to_string(),
                 lhs: lhs.clone(),
                 rhs: rhs.clone(),
-                result_ty: ValueType::Int,
+                result_ty: if unsigned_word {
+                    ValueType::Unsigned
+                } else {
+                    ValueType::Int
+                },
             },
         });
         self.local_var[dest_local] = Some(res);

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -14624,12 +14624,25 @@ fn tuple_per_shape_enabled() -> bool {
 /// Route inline-Field `dyn Trait` virtual calls through the faithful
 /// `CallTarget::Indirect` vtable pipeline instead of the synthetic
 /// `__dyn_call` residual (see the `(CallClass::Dynamic, ..)` arm).
-/// Default-OFF — `PYRE_DYN_INDIRECT=1` opts in; every other value (unset
-/// included) keeps the inert `__dyn_call` emit.
+///
+/// `__dyn_call` is not a lowering, it is a placeholder: an unregistered
+/// synthetic path that stops whatever graph reaches it.  Routing through
+/// `Indirect` is what `jtransform.py`'s `indirect_call` does, so this is the
+/// faithful side.  It was gated while the widening it forces — the annotator
+/// now annotates every family member's body — outweighed what it bought;
+/// census at the flip point, both states, same corpus:
+///
+/// | gate | records | biggest wall |
+/// |---|---:|---|
+/// | off | 243 | `__dyn_call` 48 |
+/// | on  | **224** | `Wtf8::as_str` 37 |
+///
+/// On by default; `PYRE_DYN_INDIRECT=0` is the kill switch that restores the
+/// inert `__dyn_call` emit.
 pub(crate) fn dyn_indirect_enabled() -> bool {
-    matches!(
+    !matches!(
         std::env::var("PYRE_DYN_INDIRECT").as_deref(),
-        Ok("1") | Ok("true")
+        Ok("0") | Ok("false")
     )
 }
 

--- a/majit/majit-translate/src/lib.rs
+++ b/majit/majit-translate/src/lib.rs
@@ -1450,18 +1450,20 @@ fn analyze_pipeline_from_module_paths(
             },
         )
         .collect();
-    // Gated auto-population (issue #346): with `PYRE_DYN_INDIRECT`
-    // on, register EVERY `>=2`-impl trait so its inline `dyn Trait`
-    // receiver (lowered to `CallTarget::Indirect`) narrows to the family
-    // base ClassDef.  Union with the config list (dedup by base_root),
-    // never replacing it, to stay forward-safe with the aheui census.
-    // MUST stay behind the gate: minting base/impl subclass classdefs
-    // perturbs `pyre_struct_root_names` → `ensure_session` inheritance-id
-    // numbering even off-path, so gate-OFF keeps the config-only (empty in
-    // prod) set byte-identical.  Applies the same within-family `dup_leaf`
-    // guard as the config path plus the cross-registry `struct_leaf_counts`
-    // bail: an impl leaf that also names a DIFFERENT registered struct
-    // would mis-seed the family, so skip it (fail-safe classdef-less).
+    // Auto-population (issue #346): register EVERY `>=2`-impl trait so its
+    // inline `dyn Trait` receiver (lowered to `CallTarget::Indirect`) narrows
+    // to the family base ClassDef.  Union with the config list (dedup by
+    // base_root), never replacing it, to stay forward-safe with the aheui
+    // census.  Shares [`dyn_indirect_enabled`] with the lowering arm because
+    // the two are one decision: minting base/impl subclass classdefs perturbs
+    // `pyre_struct_root_names` → `ensure_session` inheritance-id numbering
+    // even off-path, so `PYRE_DYN_INDIRECT=0` must restore BOTH the
+    // `__dyn_call` emit and the config-only (empty in prod) set together for
+    // the kill switch to be byte-identical.  Applies the same within-family
+    // `dup_leaf` guard as the config path plus the cross-registry
+    // `struct_leaf_counts` bail: an impl leaf that also names a DIFFERENT
+    // registered struct would mis-seed the family, so skip it (fail-safe
+    // classdef-less).
     if front::mir::dyn_indirect_enabled() {
         let already: std::collections::HashSet<&str> = trait_family_registrations
             .iter()

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -3503,7 +3503,13 @@ unsafe fn setitem_list_slice(obj: PyObjectRef, index: PyObjectRef, value: PyObje
             ),
         ));
     }
-    for (k, &idx) in indices.iter().enumerate() {
+    // Walked by index rather than `.iter().enumerate()`: `Enumerate::next` is
+    // an unregistered foreign leaf that stops this graph, and the position is
+    // already needed as `k`.  `listobject.py setitem__List_ANY_ANY`'s extended
+    // arm spells the same walk as a plain `range` loop.
+    let mut k = 0usize;
+    while k < indices.len() {
+        let idx = indices[k];
         let item =
             pyre_object::w_list_getitem(w_other, k as i64).expect("k < other_len by construction");
         if !pyre_object::w_list_setitem(obj, idx, item) {
@@ -3512,6 +3518,7 @@ unsafe fn setitem_list_slice(obj: PyObjectRef, index: PyObjectRef, value: PyObje
                 "list assignment index out of range",
             ));
         }
+        k += 1;
     }
     Ok(w_none())
 }
@@ -3775,10 +3782,17 @@ unsafe fn setitem_bytearray_slice(
             ),
         ));
     }
-    for (k, &idx) in indices.iter().enumerate() {
-        if let Some(slot) = vec.get_mut(idx) {
-            *slot = sequence2[k];
+    // Index walk rather than `.iter().enumerate()` / `slice::get_mut`, both of
+    // which are unregistered foreign leaves that stop this graph;
+    // `bytearrayobject.py setitem__Bytearray_ANY_ANY`'s extended arm is the
+    // same plain `range` loop.
+    let mut k = 0usize;
+    while k < indices.len() {
+        let idx = indices[k];
+        if idx < vec.len() {
+            vec[idx] = sequence2[k];
         }
+        k += 1;
     }
     Ok(w_none())
 }

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -1662,19 +1662,12 @@ unsafe fn getitem_str(obj: PyObjectRef, index: PyObjectRef) -> PyResult {
         {
             return Ok(obj);
         }
-        let mut result = Wtf8Buf::new();
-        let mut i = start;
-        for n in 0..slicelength {
-            if i >= 0 {
-                if let Some(cp) = at(i as usize) {
-                    result.push(cp);
-                }
-            }
-            if n + 1 < slicelength {
-                i += step;
-            }
-        }
-        return Ok(w_str_from_wtf8(result));
+        return Ok(pyre_object::unicodeobject::w_str_slice_codepoints(
+            obj,
+            start,
+            step,
+            slicelength,
+        ));
     }
     // `descr_getitem`: getindex_w(index, IndexError, "string") — coercion
     // inlined for the same rtyper reason as `getitem_list`.
@@ -1707,9 +1700,9 @@ unsafe fn getitem_str(obj: PyObjectRef, index: PyObjectRef) -> PyResult {
     let actual_idx = if idx < 0 { len as i64 + idx } else { idx };
     if actual_idx >= 0 {
         if let Some(cp) = at(actual_idx as usize) {
-            let mut one = Wtf8Buf::new();
-            one.push(cp);
-            return Ok(w_str_from_wtf8(one));
+            return Ok(pyre_object::unicodeobject::w_str_from_codepoint(
+                cp.to_u32(),
+            ));
         }
     }
     Err(PyError::new(
@@ -7642,15 +7635,14 @@ pub fn str_utf8_w(obj: PyObjectRef) -> Result<&'static str, PyError> {
             crate::type_methods::arg_type_name(obj)
         )));
     }
-    // The raw buffer read below is only valid for a `str`.
-    let wtf8 = unsafe { pyre_object::w_str_get_wtf8(obj) };
-    match wtf8.as_str() {
-        Ok(s) => Ok(s),
-        Err(_) => {
-            let pos = wtf8
-                .code_points()
-                .position(|cp| cp.to_char().is_none())
-                .unwrap_or(0);
+    // The buffer read below is only valid for a `str`.
+    match unsafe { pyre_object::w_str_get_value_opt(obj) } {
+        Some(s) => Ok(s),
+        None => {
+            // `w_str_first_surrogate` already located the offending code
+            // point while deciding there was no `&str` view; re-reading it
+            // costs a second scan only on the raising path.
+            let pos = unsafe { pyre_object::w_str_first_surrogate(obj) }.max(0) as usize;
             Err(crate::typedef::unicode_encode_error(
                 "utf-8",
                 obj,
@@ -12731,11 +12723,8 @@ pub fn next(obj: PyObjectRef) -> PyResult {
                 // Box the idx-th code point as a one-character str,
                 // reading the WTF-8 view so a lone surrogate is yielded
                 // instead of panicking.
-                pyre_object::w_str_codepoint_at(seq, idx as usize).map(|cp| {
-                    let mut one = Wtf8Buf::new();
-                    one.push(cp);
-                    w_str_from_wtf8(one)
-                })
+                pyre_object::w_str_codepoint_at(seq, idx as usize)
+                    .map(|cp| pyre_object::unicodeobject::w_str_from_codepoint(cp.to_u32()))
             } else if pyre_object::bytesobject::is_bytes_like(seq) {
                 // Each item is the byte's ordinal, read from the live buffer.
                 if (idx as usize) < pyre_object::bytesobject::bytes_like_len(seq) {
@@ -13010,9 +12999,12 @@ pub fn next(obj: PyObjectRef) -> PyResult {
             for &arg in &call_args {
                 pyre_object::gc_roots::pin_root(arg);
             }
-            let rooted_args: Vec<_> = (0..call_args.len())
-                .map(|index| pyre_object::gc_roots::shadow_stack_get(first_arg_slot + index))
-                .collect();
+            let mut rooted_args = Vec::with_capacity(call_args.len());
+            for index in 0..call_args.len() {
+                rooted_args.push(pyre_object::gc_roots::shadow_stack_get(
+                    first_arg_slot + index,
+                ));
+            }
             let w_fun = (*(pyre_object::gc_roots::shadow_stack_get(obj_slot)
                 as *const pyre_object::interp_itertools::W_StarMap))
                 .w_fun;
@@ -13130,9 +13122,12 @@ pub fn next(obj: PyObjectRef) -> PyResult {
             // Rebuild from roots because any preceding `next` may have moved
             // the yielded objects after their raw addresses entered `objects`.
             let objects_base = pyre_object::gc_roots::shadow_stack_len() - objects.len();
-            let rooted_objects = (0..objects.len())
-                .map(|index| pyre_object::gc_roots::shadow_stack_get(objects_base + index))
-                .collect();
+            let mut rooted_objects = Vec::with_capacity(objects.len());
+            for index in 0..objects.len() {
+                rooted_objects.push(pyre_object::gc_roots::shadow_stack_get(
+                    objects_base + index,
+                ));
+            }
             return Ok(pyre_object::w_tuple_new(rooted_objects));
         }
         // `pypy/module/__builtin__/functional.py:930-942 W_Filter.next_w`
@@ -13217,9 +13212,11 @@ pub fn next(obj: PyObjectRef) -> PyResult {
                         mo::w_map_get_fun(pyre_object::gc_roots::shadow_stack_get(obj_slot));
                     pyre_object::gc_roots::pin_root(w_fun);
                     let fun_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-                    let rooted_items: Vec<_> = (0..items.len())
-                        .map(|index| pyre_object::gc_roots::shadow_stack_get(items_base + index))
-                        .collect();
+                    let mut rooted_items = Vec::with_capacity(items.len());
+                    for index in 0..items.len() {
+                        rooted_items
+                            .push(pyre_object::gc_roots::shadow_stack_get(items_base + index));
+                    }
                     crate::call::call_function_impl_result(
                         pyre_object::gc_roots::shadow_stack_get(fun_slot),
                         &rooted_items,

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -14508,8 +14508,8 @@ fn generator_throw_impl(args: &[PyObjectRef], warn_legacy_signature: bool) -> Py
     }
     let gen_obj = args[0];
     let w_type = args[1];
-    let w_val = args.get(2).copied().unwrap_or_else(w_none);
-    let w_tb = args.get(3).copied().unwrap_or_else(w_none);
+    let w_val = crate::type_methods::arg_or_none(args, 2);
+    let w_tb = crate::type_methods::arg_or_none(args, 3);
     let argc = given;
 
     // Python 3.14 deprecates only the legacy three-argument spelling; the
@@ -14632,7 +14632,7 @@ pub(crate) fn coroutine_wrapper_next_method(args: &[PyObjectRef]) -> PyResult {
 pub(crate) fn coroutine_wrapper_send_method(args: &[PyObjectRef]) -> PyResult {
     let wrapper = args.first().copied().unwrap_or(PY_NULL);
     let coroutine = unsafe { pyre_object::generator::w_coroutine_wrapper_get_coroutine(wrapper) };
-    let value = args.get(1).copied().unwrap_or_else(w_none);
+    let value = crate::type_methods::arg_or_none(args, 1);
     generator_send_ex(coroutine, value, None, None)
 }
 
@@ -14687,7 +14687,7 @@ pub(crate) fn async_generator_anext_method(args: &[PyObjectRef]) -> PyResult {
 
 pub(crate) fn async_generator_asend_method(args: &[PyObjectRef]) -> PyResult {
     let async_gen = args.first().copied().unwrap_or(PY_NULL);
-    let value = args.get(1).copied().unwrap_or_else(w_none);
+    let value = crate::type_methods::arg_or_none(args, 1);
     async_generator_init_hooks(async_gen)?;
     Ok(pyre_object::generator::w_async_gen_asend_new(
         async_gen, value,
@@ -14720,8 +14720,8 @@ pub(crate) fn async_generator_athrow_method(args: &[PyObjectRef]) -> PyResult {
     Ok(pyre_object::generator::w_async_gen_athrow_new(
         async_gen,
         args[1],
-        args.get(2).copied().unwrap_or_else(w_none),
-        args.get(3).copied().unwrap_or_else(w_none),
+        crate::type_methods::arg_or_none(args, 2),
+        crate::type_methods::arg_or_none(args, 3),
     ))
 }
 
@@ -14795,7 +14795,7 @@ pub(crate) fn async_gen_asend_next_method(args: &[PyObjectRef]) -> PyResult {
 pub(crate) fn async_gen_asend_send_method(args: &[PyObjectRef]) -> PyResult {
     async_gen_asend_do_send(
         args.first().copied().unwrap_or(PY_NULL),
-        args.get(1).copied().unwrap_or_else(w_none),
+        crate::type_methods::arg_or_none(args, 1),
     )
 }
 
@@ -14974,7 +14974,7 @@ pub(crate) fn async_gen_athrow_next_method(args: &[PyObjectRef]) -> PyResult {
 pub(crate) fn async_gen_athrow_send_method(args: &[PyObjectRef]) -> PyResult {
     async_gen_athrow_do_send(
         args.first().copied().unwrap_or(PY_NULL),
-        args.get(1).copied().unwrap_or_else(w_none),
+        crate::type_methods::arg_or_none(args, 1),
     )
 }
 

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -2018,7 +2018,7 @@ pub(crate) fn range_count_method(args: &[PyObjectRef]) -> PyResult {
     if args.len() != 2 {
         return Err(PyError::type_error(format!(
             "range.count() takes exactly one argument ({} given)",
-            args.len().saturating_sub(1)
+            crate::type_methods::args_given(args)
         )));
     }
     let obj = args[0];
@@ -2057,7 +2057,7 @@ pub(crate) fn range_index_method(args: &[PyObjectRef]) -> PyResult {
     if args.len() != 2 {
         return Err(PyError::type_error(format!(
             "range.index() takes exactly one argument ({} given)",
-            args.len().saturating_sub(1)
+            crate::type_methods::args_given(args)
         )));
     }
     let obj = args[0];
@@ -13874,7 +13874,7 @@ pub(crate) fn property_set_name_impl(args: &[PyObjectRef]) -> PyResult {
     if positional.len() != 3 {
         return Err(crate::PyError::type_error(format!(
             "__set_name__() takes 2 positional arguments but {} were given",
-            positional.len().saturating_sub(1),
+            crate::type_methods::args_given(positional),
         )));
     }
     let prop = property_require_obj(
@@ -14495,7 +14495,7 @@ pub(crate) fn generator_throw_method(args: &[PyObjectRef]) -> PyResult {
 }
 
 fn generator_throw_impl(args: &[PyObjectRef], warn_legacy_signature: bool) -> PyResult {
-    let given = args.len().saturating_sub(1);
+    let given = crate::type_methods::args_given(args);
     if given == 0 {
         return Err(PyError::type_error(
             "throw expected at least 1 argument, got 0",
@@ -14695,7 +14695,7 @@ pub(crate) fn async_generator_asend_method(args: &[PyObjectRef]) -> PyResult {
 }
 
 pub(crate) fn async_generator_athrow_method(args: &[PyObjectRef]) -> PyResult {
-    let given = args.len().saturating_sub(1);
+    let given = crate::type_methods::args_given(args);
     if given == 0 {
         return Err(PyError::type_error(
             "athrow expected at least 1 argument, got 0",

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -8,9 +8,10 @@ use std::sync::OnceLock;
 
 use rustpython_wtf8::Wtf8Buf;
 
+use crate::runtime_ops::{CallableKind, classify_callable};
 use crate::{
-    PyError, PyResult, builtin_code_get, dispatch_callable, function_get_closure,
-    function_get_globals_obj, function_get_name, function_get_qualname,
+    PyError, PyResult, builtin_code_get, function_get_closure, function_get_globals_obj,
+    function_get_name, function_get_qualname,
 };
 
 /// `function.py:131/214/231 new_frame.run(self.name, self.qualname)`.
@@ -1288,19 +1289,17 @@ fn call_callable_with_mode(
     }
 
     let frame_ptr = frame as *mut PyFrame;
-    dispatch_callable(
-        callable,
-        |callable| {
+    match classify_callable(callable)? {
+        CallableKind::Builtin => {
             // baseobjspace.py:1243 — `if frame.get_is_being_profiled() and
             // is_builtin_code(w_func): ... return self.call_args_and_c_profile(...)`
             // The `is_builtin_code(w_func)` check is structurally implicit
-            // here: dispatch_callable already routed via the builtin arm
-            // (runtime_ops.rs:275 `if is_builtin_code(code) { on_builtin }`),
-            // so reaching this closure means the callable is a builtin.
-            // The remaining condition is the per-frame profile flag, set
-            // by `ec.call_trace` (executioncontext.py:150) on frame entry
-            // and cleared by `_c_call_return_trace` when profilefunc was
-            // turned off (executioncontext.py:122-123).
+            // here: `classify_callable` already answered `Builtin`, so
+            // reaching this arm means the callable is one.  The remaining
+            // condition is the per-frame profile flag, set by `ec.call_trace`
+            // (executioncontext.py:150) on frame entry and cleared by
+            // `_c_call_return_trace` when profilefunc was turned off
+            // (executioncontext.py:122-123).
             let profile_active = unsafe { (*frame_ptr).get_is_being_profiled() };
             if profile_active {
                 let w_res = crate::baseobjspace::call_args_and_c_profile(
@@ -1316,12 +1315,12 @@ fn call_callable_with_mode(
             }
             let code = unsafe { crate::getcode(callable) };
             call_builtin_code_positional(code as pyre_object::PyObjectRef, args)
-        },
-        |callable| match mode {
+        }
+        CallableKind::User => match mode {
             CallMode::Jit => call_user_function(frame, callable, args),
             CallMode::Plain => call_user_function_plain(frame, callable, args),
         },
-    )
+    }
 }
 
 pub fn call_user_function(

--- a/pyre/pyre-interpreter/src/executioncontext.rs
+++ b/pyre/pyre-interpreter/src/executioncontext.rs
@@ -1311,6 +1311,24 @@ impl ExecutionContext {
 
 /// Residual entry point for the bytecode-trace slow path: run pending
 /// async actions (signal delivery, finalizers).  Marked
+/// Arm the eval breaker's async bit (`interp_signal.py:34-36`
+/// `SignalActionFlag.reset_ticker` publishing a negative ticker).
+///
+/// `#[dont_look_inside]` (`@jit.dont_look_inside`, `rlib/jit.py:139`): the
+/// bit lives in a process-global word an OS signal handler also writes, so
+/// the tracer cannot model the read-modify-write and residualises it, the
+/// [`disarm_async_eval_breaker`] twin.
+#[majit_macros::dont_look_inside]
+pub fn arm_async_eval_breaker() {
+    majit_ir::eval_breaker_word::set_async();
+}
+
+/// Clear the eval breaker's async bit — see [`arm_async_eval_breaker`].
+#[majit_macros::dont_look_inside]
+pub fn disarm_async_eval_breaker() {
+    majit_ir::eval_breaker_word::clear_async();
+}
+
 /// `dont_look_inside` so the tracer treats it as an opaque call and never
 /// follows the action machinery's trait-object virtual dispatch +
 /// `Result<(), PyError>` propagation (which the JIT codewriter cannot
@@ -1695,10 +1713,10 @@ impl ActionFlagOps for ActionFlag {
         self._ticker = value;
         if self.is_registered_ticker() {
             if value < 0 {
-                majit_ir::eval_breaker_word::set_async();
+                arm_async_eval_breaker();
             } else {
                 if !crate::module::thread::has_pending_async_exception() {
-                    majit_ir::eval_breaker_word::clear_async();
+                    disarm_async_eval_breaker();
                 }
                 // A signal delivered between the ticker store and this clear
                 // rearms the ticker to -1 and re-sets the async bit; the clear
@@ -1708,7 +1726,7 @@ impl ActionFlagOps for ActionFlag {
                 // registered pointer, so force a fresh load — and restore the
                 // bit if it was rearmed.
                 if unsafe { std::ptr::read_volatile(&self._ticker) } < 0 {
-                    majit_ir::eval_breaker_word::set_async();
+                    arm_async_eval_breaker();
                 }
             }
         }
@@ -1739,7 +1757,7 @@ impl ActionFlagOps for ActionFlag {
             // This path bypasses reset_ticker, so mirror a future periodic
             // decrement that crosses negative.
             if self.is_registered_ticker() && self._ticker < 0 {
-                majit_ir::eval_breaker_word::set_async();
+                arm_async_eval_breaker();
             }
         }
         self._ticker

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -1416,9 +1416,26 @@ pub(crate) fn check_sys_modules(name: &str) -> Option<PyObjectRef> {
             }
         }
     }
+    sys_modules_registry_get(name)
+}
+
+/// Look `name` up in `SYS_MODULES`, the process-owned name→module registry.
+///
+/// The single read seam every traced reader of `SYS_MODULES` goes through.
+/// Entries are stamped at runtime by `set_sys_module` / `remove_sys_module`,
+/// so the map is not a build-time constant and the JIT residualizes the read
+/// instead of tracing into it (`@dont_look_inside`, the `sys_modules_dict`
+/// shape).  The mutating and GC-walking users keep the raw static.
+///
+/// The read is poison-tolerant, following the `get_interpreter_sys_module`
+/// spelling this replaces: a poisoned mutex means another thread panicked
+/// while holding it, and a `HashMap<String, usize>` has no invariant a panic
+/// mid-`insert`/`remove` could leave broken.
+#[majit_macros::dont_look_inside]
+pub(crate) fn sys_modules_registry_get(name: &str) -> Option<PyObjectRef> {
     SYS_MODULES
         .lock()
-        .unwrap()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
         .get(name)
         .copied()
         .map(|module| module as PyObjectRef)
@@ -1462,12 +1479,7 @@ pub fn get_sys_module(name: &str) -> Option<PyObjectRef> {
 /// module registry and is independently walked as a GC root, so its original
 /// `sys` entry is the corresponding owner.
 pub fn get_interpreter_sys_module() -> Option<PyObjectRef> {
-    SYS_MODULES
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner())
-        .get("sys")
-        .copied()
-        .map(|module| module as PyObjectRef)
+    sys_modules_registry_get("sys")
 }
 
 /// The Python-visible `sys.modules` dict, or `PY_NULL` before it is

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -558,6 +558,12 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         "pyre_object::w_type_set_uses_object_setattr",
         crate::opcode_ops::bh_w_type_set_uses_object_setattr as *const (),
     );
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::typeobject::w_type_set_uses_object_getattribute",
+        "pyre_object::w_type_set_uses_object_getattribute",
+        crate::opcode_ops::bh_w_type_set_uses_object_getattribute as *const (),
+    );
     // `w_type_issubtype` is the MRO membership scan (`_issubtype`,
     // typeobject.py:1640), run under the JIT inside `_pure_issubtype`
     // (`@elidable_promote`, typeobject.py:1657).  Its `#[dont_look_inside]`
@@ -628,6 +634,42 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         "pyre_object::unicodeobject::w_str_new",
         "pyre_object::w_str_new",
         pyre_object::unicodeobject::w_str_new as *const (),
+    );
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::unicodeobject::w_str_from_codepoint",
+        "pyre_object::w_str_from_codepoint",
+        pyre_object::unicodeobject::w_str_from_codepoint as *const (),
+    );
+    let w_str_slice_codepoints: unsafe fn(
+        pyre_object::PyObjectRef,
+        i64,
+        i64,
+        i64,
+    ) -> pyre_object::PyObjectRef = pyre_object::unicodeobject::w_str_slice_codepoints;
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::unicodeobject::w_str_slice_codepoints",
+        "pyre_object::w_str_slice_codepoints",
+        w_str_slice_codepoints as *const (),
+    );
+    let w_str_concat: unsafe fn(
+        pyre_object::PyObjectRef,
+        pyre_object::PyObjectRef,
+    ) -> pyre_object::PyObjectRef = pyre_object::unicodeobject::w_str_concat;
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::unicodeobject::w_str_concat",
+        "pyre_object::w_str_concat",
+        w_str_concat as *const (),
+    );
+    let w_str_first_surrogate: unsafe fn(pyre_object::PyObjectRef) -> i64 =
+        pyre_object::unicodeobject::w_str_first_surrogate;
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::unicodeobject::w_str_first_surrogate",
+        "pyre_object::w_str_first_surrogate",
+        w_str_first_surrogate as *const (),
     );
     push_alias_pair(
         &mut entries,
@@ -1055,6 +1097,20 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
             "pyre_interpreter::module::mmap::interp_mmap::mmap_type",
             "pyre_interpreter::mmap_type",
             mmap_type as *const (),
+        );
+    }
+    // `cdata_bytes_object` carries the `_ctypes` module's own gate
+    // (`module/mod.rs`), so the row repeats it rather than resolving a path
+    // configured out of the build.
+    #[cfg(all(unix, feature = "host_env", not(feature = "sandbox")))]
+    {
+        let cdata_bytes_object: fn(pyre_object::PyObjectRef) -> Option<pyre_object::PyObjectRef> =
+            crate::module::_ctypes::cdata::cdata_bytes_object;
+        push_alias_pair(
+            &mut entries,
+            "pyre_interpreter::module::_ctypes::cdata::cdata_bytes_object",
+            "pyre_interpreter::cdata_bytes_object",
+            cdata_bytes_object as *const (),
         );
     }
     push_alias_pair(
@@ -1824,6 +1880,33 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
     );
     push_alias_pair(
         &mut entries,
+        "pyre_interpreter::executioncontext::arm_async_eval_breaker",
+        "pyre_interpreter::arm_async_eval_breaker",
+        crate::executioncontext::arm_async_eval_breaker as *const (),
+    );
+    let show_warning: fn(
+        pyre_object::PyObjectRef,
+        pyre_object::PyObjectRef,
+        pyre_object::PyObjectRef,
+        pyre_object::PyObjectRef,
+        i64,
+        pyre_object::PyObjectRef,
+        pyre_object::PyObjectRef,
+    ) -> Result<(), crate::PyError> = crate::module::_warnings::show_warning;
+    push_alias_pair(
+        &mut entries,
+        "pyre_interpreter::module::_warnings::show_warning",
+        "pyre_interpreter::show_warning",
+        show_warning as *const (),
+    );
+    push_alias_pair(
+        &mut entries,
+        "pyre_interpreter::executioncontext::disarm_async_eval_breaker",
+        "pyre_interpreter::disarm_async_eval_breaker",
+        crate::executioncontext::disarm_async_eval_breaker as *const (),
+    );
+    push_alias_pair(
+        &mut entries,
         "pyre_interpreter::executioncontext::execution_context_builtin_cache_get",
         "pyre_interpreter::execution_context_builtin_cache_get",
         crate::executioncontext::execution_context_builtin_cache_get as *const (),
@@ -2146,6 +2229,15 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         "pyre_interpreter::pyframe::pyframe_get_pycode",
         "pyre_interpreter::pyframe_get_pycode",
         pyframe_get_pycode_fn as *const (),
+    );
+
+    let report_stack_underflow: fn(&crate::pyframe::PyFrame) =
+        crate::pyframe::report_stack_underflow;
+    push_alias_pair(
+        &mut entries,
+        "pyre_interpreter::pyframe::report_stack_underflow",
+        "pyre_interpreter::report_stack_underflow",
+        report_stack_underflow as *const (),
     );
 
     let pyframe_ncells_free: fn(&crate::CodeObject) -> usize = crate::pyframe::ncells;

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -1765,6 +1765,12 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
     );
     push_alias_pair(
         &mut entries,
+        "pyre_object::identitydict::w_dict_delete_identity_strategy",
+        "pyre_object::w_dict_delete_identity_strategy",
+        pyre_object::identitydict::w_dict_delete_identity_strategy as *const (),
+    );
+    push_alias_pair(
+        &mut entries,
         "pyre_interpreter::objspace::descroperation::jit_float_abs",
         "pyre_interpreter::jit_float_abs",
         crate::objspace::descroperation::jit_float_abs as *const (),

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -976,6 +976,29 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         "pyre_interpreter::sys_modules_registry_get",
         sys_modules_registry_get as *const (),
     );
+    // The host-boundary seams beside them: the two fd writers every
+    // diagnostic path funnels through, and the thread-identity read.
+    let emit_stdout: fn(&[u8]) = crate::host_seam::emit_stdout;
+    push_alias_pair(
+        &mut entries,
+        "pyre_interpreter::host_seam::emit_stdout",
+        "pyre_interpreter::emit_stdout",
+        emit_stdout as *const (),
+    );
+    let emit_stderr: fn(&[u8]) = crate::host_seam::emit_stderr;
+    push_alias_pair(
+        &mut entries,
+        "pyre_interpreter::host_seam::emit_stderr",
+        "pyre_interpreter::emit_stderr",
+        emit_stderr as *const (),
+    );
+    let current_ident: fn() -> i64 = crate::module::thread::current_ident;
+    push_alias_pair(
+        &mut entries,
+        "pyre_interpreter::module::thread::current_ident",
+        "pyre_interpreter::current_ident",
+        current_ident as *const (),
+    );
     let set_in_flight_exception: fn(pyre_object::PyObjectRef) =
         crate::eval::set_in_flight_exception;
     push_alias_pair(

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -807,6 +807,18 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
     );
     push_alias_pair(
         &mut entries,
+        "pyre_object::identitydict::w_dict_lookup_identity_strategy",
+        "pyre_object::w_dict_lookup_identity_strategy",
+        pyre_object::identitydict::w_dict_lookup_identity_strategy as *const (),
+    );
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::dictmultiobject::w_module_dict_lookup_object_entries",
+        "pyre_object::w_module_dict_lookup_object_entries",
+        pyre_object::dictmultiobject::w_module_dict_lookup_object_entries as *const (),
+    );
+    push_alias_pair(
+        &mut entries,
         "pyre_object::dictmultiobject::w_dict_store_bytes_strategy",
         "pyre_object::w_dict_store_bytes_strategy",
         pyre_object::dictmultiobject::w_dict_store_bytes_strategy as *const (),

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -988,6 +988,13 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         "pyre_interpreter::sys_modules_registry_get",
         sys_modules_registry_get as *const (),
     );
+    let warnings_state_ns: fn() -> pyre_object::PyObjectRef = crate::module::_warnings::state_ns;
+    push_alias_pair(
+        &mut entries,
+        "pyre_interpreter::module::_warnings::state_ns",
+        "pyre_interpreter::state_ns",
+        warnings_state_ns as *const (),
+    );
     // The host-boundary seams beside them: the two fd writers every
     // diagnostic path funnels through, and the thread-identity read.
     let emit_stdout: fn(&[u8]) = crate::host_seam::emit_stdout;
@@ -1711,6 +1718,18 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         "pyre_object::dict_eq_hook::hash_str_hooked_bytes",
         "pyre_object::hash_str_hooked_bytes",
         pyre_object::dict_eq_hook::hash_str_hooked_bytes as *const (),
+    );
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::dictmultiobject::dict_entries_probe_str",
+        "pyre_object::dict_entries_probe_str",
+        pyre_object::dictmultiobject::dict_entries_probe_str as *const (),
+    );
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::dictmultiobject::dict_entries_probe_object",
+        "pyre_object::dict_entries_probe_object",
+        pyre_object::dictmultiobject::dict_entries_probe_object as *const (),
     );
     push_alias_pair(
         &mut entries,

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -1731,6 +1731,38 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         "pyre_object::dict_entries_probe_object",
         pyre_object::dictmultiobject::dict_entries_probe_object as *const (),
     );
+    // The three typed-storage promotions: `IndexMap` construction and refill
+    // end to end, so the residual boundary is the whole migration.
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::dictmultiobject::w_dict_switch_int_to_object_strategy",
+        "pyre_object::w_dict_switch_int_to_object_strategy",
+        pyre_object::dictmultiobject::w_dict_switch_int_to_object_strategy as *const (),
+    );
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::dictmultiobject::w_dict_switch_bytes_to_object_strategy",
+        "pyre_object::w_dict_switch_bytes_to_object_strategy",
+        pyre_object::dictmultiobject::w_dict_switch_bytes_to_object_strategy as *const (),
+    );
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::dictmultiobject::w_module_dict_switch_to_object_strategy",
+        "pyre_object::w_module_dict_switch_to_object_strategy",
+        pyre_object::dictmultiobject::w_module_dict_switch_to_object_strategy as *const (),
+    );
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::kwargsdict::w_dict_switch_kwargs_to_object_strategy",
+        "pyre_object::w_dict_switch_kwargs_to_object_strategy",
+        pyre_object::kwargsdict::w_dict_switch_kwargs_to_object_strategy as *const (),
+    );
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::identitydict::w_dict_switch_identity_to_object_strategy",
+        "pyre_object::w_dict_switch_identity_to_object_strategy",
+        pyre_object::identitydict::w_dict_switch_identity_to_object_strategy as *const (),
+    );
     push_alias_pair(
         &mut entries,
         "pyre_interpreter::objspace::descroperation::jit_float_abs",

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -1672,6 +1672,18 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
     );
     push_alias_pair(
         &mut entries,
+        "pyre_object::dict_eq_hook::has_eq_w_hook",
+        "pyre_object::has_eq_w_hook",
+        pyre_object::dict_eq_hook::has_eq_w_hook as *const (),
+    );
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::dict_eq_hook::eq_w_hooked",
+        "pyre_object::eq_w_hooked",
+        pyre_object::dict_eq_hook::eq_w_hooked as *const (),
+    );
+    push_alias_pair(
+        &mut entries,
         "pyre_object::dict_eq_hook::has_hash_str_hook",
         "pyre_object::has_hash_str_hook",
         pyre_object::dict_eq_hook::has_hash_str_hook as *const (),

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -1708,6 +1708,12 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
     );
     push_alias_pair(
         &mut entries,
+        "pyre_object::dict_eq_hook::hash_str_hooked_bytes",
+        "pyre_object::hash_str_hooked_bytes",
+        pyre_object::dict_eq_hook::hash_str_hooked_bytes as *const (),
+    );
+    push_alias_pair(
+        &mut entries,
         "pyre_interpreter::objspace::descroperation::jit_float_abs",
         "pyre_interpreter::jit_float_abs",
         crate::objspace::descroperation::jit_float_abs as *const (),

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -1731,6 +1731,28 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         "pyre_object::dict_entries_probe_object",
         pyre_object::dictmultiobject::dict_entries_probe_object as *const (),
     );
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::dictmultiobject::dict_entries_remove_object",
+        "pyre_object::dict_entries_remove_object",
+        pyre_object::dictmultiobject::dict_entries_remove_object as *const (),
+    );
+    // A runtime-mutable global counter, not a build-time constant: bind the
+    // read seam by address so the JIT calls it instead of folding whatever
+    // serial the build process saw.
+    let next_version_tag_serial: fn() -> u64 = pyre_object::celldict::next_version_tag_serial;
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::celldict::next_version_tag_serial",
+        "pyre_object::next_version_tag_serial",
+        next_version_tag_serial as *const (),
+    );
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::celldict::sweep_version_watchers",
+        "pyre_object::sweep_version_watchers",
+        pyre_object::celldict::sweep_version_watchers as *const (),
+    );
     // The three typed-storage promotions: `IndexMap` construction and refill
     // end to end, so the residual boundary is the whole migration.
     push_alias_pair(

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -950,7 +950,9 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
     );
     // The same shape over the object space's remaining runtime-mutable
     // globals: `sys_modules_dict` reads the `SYS_MODULES_DICT` pointer
-    // `set_sys_modules_dict` stamps, `set_in_flight_exception` writes the
+    // `set_sys_modules_dict` stamps, `sys_modules_registry_get` the
+    // `SYS_MODULES` name→module registry those stamps mirror,
+    // `set_in_flight_exception` writes the
     // `IN_FLIGHT_EXCEPTION` thread-local, `lookup_exc_class` reads the
     // `EXC_CLASS_REGISTRY` `OnceLock`, `check_sys_modules` the process-owned
     // `SYS_MODULES` registry, `mmap_type` the lazily-installed
@@ -965,6 +967,14 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         "pyre_interpreter::importing::sys_modules_dict",
         "pyre_interpreter::sys_modules_dict",
         sys_modules_dict as *const (),
+    );
+    let sys_modules_registry_get: fn(&str) -> Option<pyre_object::PyObjectRef> =
+        crate::importing::sys_modules_registry_get;
+    push_alias_pair(
+        &mut entries,
+        "pyre_interpreter::importing::sys_modules_registry_get",
+        "pyre_interpreter::sys_modules_registry_get",
+        sys_modules_registry_get as *const (),
     );
     let set_in_flight_exception: fn(pyre_object::PyObjectRef) =
         crate::eval::set_in_flight_exception;

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -1737,6 +1737,25 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         "pyre_object::dict_entries_remove_object",
         pyre_object::dictmultiobject::dict_entries_remove_object as *const (),
     );
+    // The checked probe / store pair, keyed on an already-hashed key.
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::dictmultiobject::dict_entries_probe_hashed",
+        "pyre_object::dict_entries_probe_hashed",
+        pyre_object::dictmultiobject::dict_entries_probe_hashed as *const (),
+    );
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::dictmultiobject::dict_entries_insert_hashed",
+        "pyre_object::dict_entries_insert_hashed",
+        pyre_object::dictmultiobject::dict_entries_insert_hashed as *const (),
+    );
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::dictmultiobject::dict_entries_pop_last",
+        "pyre_object::dict_entries_pop_last",
+        pyre_object::dictmultiobject::dict_entries_pop_last as *const (),
+    );
     // A runtime-mutable global counter, not a build-time constant: bind the
     // read seam by address so the JIT calls it instead of folding whatever
     // serial the build process saw.

--- a/pyre/pyre-interpreter/src/lib.rs
+++ b/pyre/pyre-interpreter/src/lib.rs
@@ -50,12 +50,19 @@ pub mod host_seam;
 #[cfg(not(unix))]
 pub mod host_seam {
     /// Emit bytes to the interpreter's stdout (fd 1).
+    ///
+    /// Carries `dont_look_inside` for the same reason as the unix body: the
+    /// write is the host boundary, so the front end residualizes the call.
+    /// Both spellings need it — a corpus extracted on a non-unix host sees
+    /// only this one.
+    #[majit_macros::dont_look_inside]
     pub fn emit_stdout(bytes: &[u8]) {
         use std::io::Write;
         let _ = std::io::stdout().write_all(bytes);
     }
 
     /// Emit bytes to the interpreter's stderr (fd 2).
+    #[majit_macros::dont_look_inside]
     pub fn emit_stderr(bytes: &[u8]) {
         use std::io::Write;
         let _ = std::io::stderr().write_all(bytes);

--- a/pyre/pyre-interpreter/src/module/_ctypes/cdata.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/cdata.rs
@@ -544,6 +544,20 @@ pub(crate) fn cdata_bytes(obj: PyObjectRef) -> Option<&'static [u8]> {
     }
 }
 
+/// `b_ptr[..b_size]` boxed as a `bytes`, or `None` for an instance with no
+/// view.
+///
+/// `#[dont_look_inside]` (`@jit.dont_look_inside`, `rlib/jit.py:139`): the
+/// address arm borrows foreign memory through `host_ctypes::borrow_memory`,
+/// which has no lifted model, and the `&[u8]` [`cdata_bytes`] hands back is
+/// two words where a residual result is one.  Every caller boxes the slice
+/// immediately, so the box happens inside the boundary and a single
+/// null-niche `Option<PyObjectRef>` crosses it.
+#[majit_macros::dont_look_inside]
+pub(crate) fn cdata_bytes_object(obj: PyObjectRef) -> Option<PyObjectRef> {
+    cdata_bytes(obj).map(pyre_object::bytesobject::w_bytes_from_bytes)
+}
+
 /// `b_size` — the view length.
 pub(super) fn cdata_len(obj: PyObjectRef) -> Option<usize> {
     if let Some(ba) = cdata_buffer(obj) {

--- a/pyre/pyre-interpreter/src/module/_warnings/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_warnings/mod.rs
@@ -49,7 +49,16 @@ fn import_module(name: &str) -> Result<PyObjectRef, PyError> {
 /// valid and unmoved.
 static STATE_NS: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
 
-fn state_ns() -> PyObjectRef {
+/// The captured `State` namespace, or `PY_NULL` before the module is built —
+/// the single read seam every traced reader of `STATE_NS` goes through.
+///
+/// `setup_after_space_initialization` stamps the pointer at runtime, so it is
+/// not a build-time constant and the JIT residualizes the read rather than
+/// folding whatever the build process happened to see
+/// (`@dont_look_inside`, the `importing::sys_modules_dict` shape).  The
+/// `-> PyObjectRef` return fits a single word and it cannot raise.
+#[majit_macros::dont_look_inside]
+pub(crate) fn state_ns() -> PyObjectRef {
     STATE_NS.load(std::sync::atomic::Ordering::Acquire) as PyObjectRef
 }
 

--- a/pyre/pyre-interpreter/src/module/_warnings/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_warnings/mod.rs
@@ -408,7 +408,12 @@ fn update_registry(
     )
 }
 
-fn show_warning(
+/// `#[dont_look_inside]` (`@jit.dont_look_inside`, `rlib/jit.py:139`): the
+/// line is assembled in a `Wtf8Buf`, which has no counterpart in the
+/// immutable lifted string model, and the whole body is a write to
+/// `sys.stderr` — an opaque host action with nothing for a trace to reuse.
+#[majit_macros::dont_look_inside]
+pub(crate) fn show_warning(
     message: PyObjectRef,
     text: PyObjectRef,
     category: PyObjectRef,

--- a/pyre/pyre-interpreter/src/module/thread/mod.rs
+++ b/pyre/pyre-interpreter/src/module/thread/mod.rs
@@ -1280,6 +1280,13 @@ fn thread_is_stopping(ec: &mut crate::PyExecutionContext) {
     }
 }
 
+/// The calling thread's identity.
+///
+/// The host thread id is read fresh on every call and is never a build-time
+/// constant, so the front end residualizes the read instead of tracing into
+/// `rustpython_host_env::thread::current_thread_id`.  This is the single
+/// in-tree seam every traced caller reaches it through.
+#[majit_macros::dont_look_inside]
 pub(crate) fn current_ident() -> i64 {
     #[cfg(all(
         feature = "host_env",

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -1909,17 +1909,10 @@ unsafe fn long_bitxor(a: PyObjectRef, b: PyObjectRef) -> PyResult {
 /// Concatenate two str objects.
 
 pub(crate) unsafe fn str_concat(a: PyObjectRef, b: PyObjectRef) -> PyResult {
-    // Read the surrogate-aware WTF-8 view so concatenating a
+    // `w_str_concat` joins the surrogate-aware WTF-8 views, so concatenating a
     // surrogateescape/surrogatepass-decoded string does not go through
     // `w_str_get_value` (which rejects lone surrogates).
-    let sa = w_str_get_wtf8(a);
-    let sb = w_str_get_wtf8(b);
-    let mut result = Wtf8Buf::with_capacity(sa.len() + sb.len());
-    result.push_wtf8(sa);
-    result.push_wtf8(sb);
-    // Concatenation is a dominant dynamic-churn producer; its result lives in
-    // GC-traced slots (locals, list/dict/set members), so make it collectable.
-    Ok(w_str_from_wtf8_managed(result))
+    Ok(pyre_object::unicodeobject::w_str_concat(a, b))
 }
 
 /// Extract a non-negative repeat count from an int or long.

--- a/pyre/pyre-interpreter/src/opcode_ops.rs
+++ b/pyre/pyre-interpreter/src/opcode_ops.rs
@@ -973,6 +973,16 @@ pub extern "C" fn bh_w_type_set_uses_object_setattr(obj: i64, v: i64) {
 }
 
 /// C-ABI residual bridge for the `dont_look_inside`
+/// [`pyre_object::typeobject::w_type_set_uses_object_getattribute`], the
+/// [`bh_w_type_set_uses_object_setattr`] twin.
+#[allow(improper_ctypes_definitions)]
+pub extern "C" fn bh_w_type_set_uses_object_getattribute(obj: i64, v: i64) {
+    unsafe {
+        pyre_object::typeobject::w_type_set_uses_object_getattribute(obj as PyObjectRef, v != 0);
+    }
+}
+
+/// C-ABI residual bridge for the `dont_look_inside`
 /// [`pyre_object::interp_exceptions::lookup_exc_class_for_kind`]: its `ExcKind`
 /// parameter does not match the integer arg slot a residual call
 /// supplies, so reconstruct it from `i64` here before forwarding. The

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -1109,6 +1109,53 @@ pub unsafe fn pyframe_get_pycode(frame: &PyFrame) -> *const CodeObject {
     unsafe { crate::w_code_get_ptr(frame.pycode as pyre_object::PyObjectRef) as *const CodeObject }
 }
 
+/// Name the frame a stack underflow was detected on. A bare depth
+/// assertion says an opcode popped from an empty stack but not which
+/// opcode of which code object, which is the whole question when the
+/// underflow means the frame — or the code behind it — is no longer the
+/// one the loop started with.
+///
+/// `#[dont_look_inside]` (`@jit.dont_look_inside`, `rlib/jit.py:139`):
+/// [`PyFrame::pop`] reaches this on the branch it never takes, so the
+/// instruction-window formatting below — a `Vec<String>` built through
+/// `enumerate`/`skip`/`take`/`map` over the `CodeUnits` deref — would
+/// otherwise be lowered into every graph that pops a value.  The report
+/// diverges by panicking; the `()` result is what crosses the residual
+/// boundary.
+#[majit_macros::dont_look_inside]
+#[cold]
+#[inline(never)]
+pub fn report_stack_underflow(frame: &PyFrame) {
+    let code = unsafe { &*pyframe_get_pycode(frame) };
+    let window: Vec<String> = code
+        .instructions
+        .iter()
+        .copied()
+        .enumerate()
+        .skip(frame.next_instr().saturating_sub(4))
+        .take(8)
+        .map(|(pc, unit)| format!("{pc}:{unit:?}"))
+        .collect();
+    panic!(
+        "value-stack underflow: depth={} base={} (nlocals={} ncells={}) \
+         pc={} last_instr={} ninstrs={} code={:?} file={:?} frame={:p} \
+         pycode={:p} back={:p} window=[{}]",
+        frame.valuestackdepth,
+        frame.stack_base(),
+        frame.nlocals(),
+        frame.ncells(),
+        frame.next_instr(),
+        frame.last_instr,
+        code.instructions.len(),
+        code.obj_name,
+        code.source_path,
+        frame,
+        frame.pycode,
+        frame.f_backref,
+        window.join(" "),
+    );
+}
+
 /// True when a `sys.settrace` / `sys.setprofile` hook is installed on the
 /// execution context this frame runs under.
 ///
@@ -2381,44 +2428,6 @@ impl PyFrame {
         self.nlocals() + self.ncells()
     }
 
-    /// Name the frame a stack underflow was detected on. A bare depth
-    /// assertion says an opcode popped from an empty stack but not which
-    /// opcode of which code object, which is the whole question when the
-    /// underflow means the frame — or the code behind it — is no longer the
-    /// one the loop started with.
-    #[cold]
-    #[inline(never)]
-    fn report_stack_underflow(&self) -> ! {
-        let code = unsafe { &*pyframe_get_pycode(self) };
-        let window: Vec<String> = code
-            .instructions
-            .iter()
-            .copied()
-            .enumerate()
-            .skip(self.next_instr().saturating_sub(4))
-            .take(8)
-            .map(|(pc, unit)| format!("{pc}:{unit:?}"))
-            .collect();
-        panic!(
-            "value-stack underflow: depth={} base={} (nlocals={} ncells={}) \
-             pc={} last_instr={} ninstrs={} code={:?} file={:?} frame={:p} \
-             pycode={:p} back={:p} window=[{}]",
-            self.valuestackdepth,
-            self.stack_base(),
-            self.nlocals(),
-            self.ncells(),
-            self.next_instr(),
-            self.last_instr,
-            code.instructions.len(),
-            code.obj_name,
-            code.source_path,
-            self,
-            self.pycode,
-            self.f_backref,
-            window.join(" "),
-        );
-    }
-
     // ── Stack operations ──────────────────────────────────────────────
 
     #[inline]
@@ -2432,7 +2441,7 @@ impl PyFrame {
     #[inline]
     pub fn pop(&mut self) -> PyObjectRef {
         if self.valuestackdepth <= self.stack_base() {
-            self.report_stack_underflow();
+            report_stack_underflow(self);
         }
         let depth = self.valuestackdepth - 1;
         let value = self.locals_w()[depth];
@@ -2857,7 +2866,7 @@ impl PyFrame {
     /// user-visible callbacks never see the gateway machinery.
     ///
     /// Pyre does not allocate a `PyFrame` for builtin calls — the
-    /// `dispatch_callable` builtin closure (`runtime_ops.rs:275`)
+    /// `CallableKind::Builtin` arm (`classify_callable`, `runtime_ops.rs`)
     /// invokes the BuiltinCode function pointer directly, with no
     /// frame attached, so the trace path never observes builtin
     /// frames.  Hidden-applevel user frames (the `app_main.py`
@@ -3621,9 +3630,10 @@ impl PyFrame {
             pyre_object::gc_roots::shadow_stack_get(root_base + 1),
             execution_context,
         )?;
-        let current_args: Vec<PyObjectRef> = (0..args.len())
-            .map(|i| pyre_object::gc_roots::shadow_stack_get(root_base + 3 + i))
-            .collect();
+        let mut current_args: Vec<PyObjectRef> = Vec::with_capacity(args.len());
+        for i in 0..args.len() {
+            current_args.push(pyre_object::gc_roots::shadow_stack_get(root_base + 3 + i));
+        }
         Ok(Self::finish_for_call_with_globals_obj(
             pyre_object::gc_roots::shadow_stack_get(root_base) as *const (),
             &current_args,
@@ -3663,9 +3673,10 @@ impl PyFrame {
             pyre_object::gc_roots::shadow_stack_get(root_base + 1),
             execution_context,
         );
-        let current_args: Vec<PyObjectRef> = (0..args.len())
-            .map(|i| pyre_object::gc_roots::shadow_stack_get(root_base + 3 + i))
-            .collect();
+        let mut current_args: Vec<PyObjectRef> = Vec::with_capacity(args.len());
+        for i in 0..args.len() {
+            current_args.push(pyre_object::gc_roots::shadow_stack_get(root_base + 3 + i));
+        }
         Self::finish_for_call_with_globals_obj(
             pyre_object::gc_roots::shadow_stack_get(root_base) as *const (),
             &current_args,

--- a/pyre/pyre-interpreter/src/runtime_ops.rs
+++ b/pyre/pyre-interpreter/src/runtime_ops.rs
@@ -401,15 +401,23 @@ define_known_function_call_helper!(
     arg7
 );
 
-pub fn dispatch_callable<R, FBuiltin, FUser>(
-    callable: PyObjectRef,
-    on_builtin: FBuiltin,
-    on_user: FUser,
-) -> Result<R, PyError>
-where
-    FBuiltin: FnOnce(PyObjectRef) -> Result<R, PyError>,
-    FUser: FnOnce(PyObjectRef) -> Result<R, PyError>,
-{
+/// Which arm a callable dispatches through (`baseobjspace.py:1243`).
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum CallableKind {
+    /// A `BuiltinCode` carrier — `call_args_and_c_profile` / native code.
+    Builtin,
+    /// A `PyCode` carrier — an interpreted user function.
+    User,
+}
+
+/// Name the arm `callable` dispatches through, or report it as not
+/// callable.
+///
+/// The caller branches on the answer with the two arms written out
+/// (`baseobjspace.py:1243`); handing them in as closures instead puts an
+/// `FnOnce::call_once` in front of every dispatch, and a closure has no
+/// lifted counterpart — RPython spells this as a plain conditional.
+pub fn classify_callable(callable: PyObjectRef) -> Result<CallableKind, PyError> {
     // Drain any pending JIT-prologue overflow first so a backend probe that
     // already detected an overflow surfaces here as the user-visible
     // RecursionError.  A fresh check is performed only when a Python frame is
@@ -422,9 +430,9 @@ where
             // builtins (BuiltinCode) from user functions (PyCode).
             let code = crate::getcode(callable);
             if is_builtin_code(code as PyObjectRef) {
-                on_builtin(callable)
+                Ok(CallableKind::Builtin)
             } else {
-                on_user(callable)
+                Ok(CallableKind::User)
             }
         } else {
             let type_name = crate::typedef::r#type(callable)
@@ -1664,20 +1672,18 @@ mod tests {
     use pyre_object::{w_int_get_value, w_int_new};
 
     #[test]
-    fn test_dispatch_callable_runs_builtin_branch() {
+    fn test_classify_callable_names_the_builtin_arm() {
         let ctx = PyExecutionContext::default();
         let abs = ctx.lookup_builtin("abs").expect("abs builtin must exist");
-        let result = dispatch_callable(
-            abs,
-            |callable| {
-                // Builtins are now Function objects; extract code then func pointer.
-                let code = unsafe { crate::getcode(callable) };
-                let func = unsafe { crate::builtin_code_get(code as PyObjectRef) };
-                func(&[w_int_new(-9)])
-            },
-            |_callable| panic!("builtin callable should not take user branch"),
-        )
-        .expect("builtin dispatch should succeed");
+        assert_eq!(
+            classify_callable(abs).expect("builtin dispatch should succeed"),
+            CallableKind::Builtin
+        );
+
+        // Builtins are now Function objects; extract code then func pointer.
+        let code = unsafe { crate::getcode(abs) };
+        let func = unsafe { crate::builtin_code_get(code as PyObjectRef) };
+        let result = func(&[w_int_new(-9)]).expect("abs(-9) should succeed");
 
         unsafe {
             assert_eq!(w_int_get_value(result), 9);
@@ -1685,9 +1691,8 @@ mod tests {
     }
 
     #[test]
-    fn test_dispatch_callable_rejects_non_callable() {
-        let err = dispatch_callable(w_int_new(3), |_callable| Ok(()), |_callable| Ok(()))
-            .expect_err("non-callable dispatch should fail");
+    fn test_classify_callable_rejects_non_callable() {
+        let err = classify_callable(w_int_new(3)).expect_err("non-callable dispatch should fail");
 
         assert!(matches!(err.kind, PyErrorKind::TypeError));
         assert!(err.message.contains("not callable"));

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -41,6 +41,21 @@ pub(crate) fn args_given(args: &[PyObjectRef]) -> usize {
     if args.is_empty() { 0 } else { args.len() - 1 }
 }
 
+/// The `i`th entry of a gateway argument slice, or `None` when the caller did
+/// not pass it — the optional-positional-argument default.
+///
+/// Spelled as an explicit bounds test rather than `args.get(i)`: `slice::get`
+/// yields an `Option<&T>` whose payload is valid on only one arm, and the front
+/// end has no lowering that can build one.  Its single `Option`-synthesizing
+/// path, `emit_tagged_pair_aggregate`, writes the payload unconditionally
+/// before the consumer's discriminant switch runs (`front/mir.rs:9936`), so an
+/// out-of-bounds read would execute on the absent arm.  A plain index lowers to
+/// a native read plus an overflow `Assert` the front end strips.
+#[inline]
+pub(crate) fn arg_or_none(args: &[PyObjectRef], i: usize) -> PyObjectRef {
+    if i < args.len() { args[i] } else { w_none() }
+}
+
 /// TypeError for a method requiring exactly `n` positional arguments after
 /// the receiver, called with a different count.
 pub(crate) fn arity_exact(

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -29,6 +29,18 @@ use rustpython_wtf8::{CodePoint, Wtf8, Wtf8Buf};
 // argument count and raise instead of asserting. `args[0]` is the bound
 // receiver, so the counts in these messages exclude it.
 
+/// The argument count `args` carries once its receiver slot is discounted —
+/// `len() - 1`, floored at zero for the malformed empty slice.
+///
+/// Spelled as an explicit branch rather than `saturating_sub`: the front end
+/// lowers a plain subtraction (`Sub` plus an overflow `Assert` it strips), but
+/// `core::num::<Impl>::saturating_sub` is an unregistered foreign leaf that
+/// stops the enclosing graph before it can be lifted.
+#[inline]
+pub(crate) fn args_given(args: &[PyObjectRef]) -> usize {
+    if args.is_empty() { 0 } else { args.len() - 1 }
+}
+
 /// TypeError for a method requiring exactly `n` positional arguments after
 /// the receiver, called with a different count.
 pub(crate) fn arity_exact(
@@ -44,7 +56,7 @@ pub(crate) fn arity_exact(
         };
         return Err(crate::PyError::type_error(format!(
             "{name}() takes {expected} ({} given)",
-            args.len().saturating_sub(1),
+            args_given(args),
         )));
     }
     Ok(())
@@ -62,7 +74,7 @@ pub(crate) fn arity_at_least(
         return Err(crate::PyError::type_error(format!(
             "{name} expected at least {min} argument{}, got {}",
             if min == 1 { "" } else { "s" },
-            args.len().saturating_sub(1),
+            args_given(args),
         )));
     }
     Ok(())
@@ -81,7 +93,7 @@ pub(crate) fn arity_at_least_positional(
         return Err(crate::PyError::type_error(format!(
             "{name}() takes at least {min} positional argument{} ({} given)",
             if min == 1 { "" } else { "s" },
-            args.len().saturating_sub(1),
+            args_given(args),
         )));
     }
     Ok(())
@@ -114,7 +126,7 @@ pub(crate) fn arity_at_most(
         return Err(crate::PyError::type_error(format!(
             "{name} expected at most {max} argument{}, got {}",
             if max == 1 { "" } else { "s" },
-            args.len().saturating_sub(1),
+            args_given(args),
         )));
     }
     Ok(())
@@ -135,7 +147,7 @@ pub(crate) fn arity_exact_unpack(
         return Err(crate::PyError::type_error(format!(
             "{name} expected {n} argument{}, got {}",
             if n == 1 { "" } else { "s" },
-            args.len().saturating_sub(1),
+            args_given(args),
         )));
     }
     Ok(())
@@ -150,7 +162,7 @@ pub(crate) fn arity_slot(args: &[PyObjectRef], n: usize) -> Result<(), crate::Py
         return Err(crate::PyError::type_error(format!(
             "expected {n} argument{}, got {}",
             if n == 1 { "" } else { "s" },
-            args.len().saturating_sub(1),
+            args_given(args),
         )));
     }
     Ok(())
@@ -162,7 +174,7 @@ pub(crate) fn arity_no_args(args: &[PyObjectRef], name: &str) -> Result<(), crat
     if args.len() != 1 {
         return Err(crate::PyError::type_error(format!(
             "{name}() takes no arguments ({} given)",
-            args.len().saturating_sub(1),
+            args_given(args),
         )));
     }
     Ok(())
@@ -172,7 +184,7 @@ pub(crate) fn arity_no_args(args: &[PyObjectRef], name: &str) -> Result<(), crat
 /// accepts one or two positional arguments after the receiver — the
 /// "expected 1 or 2 arguments, got M" form with no method name.
 pub(crate) fn arity_pow(args: &[PyObjectRef]) -> Result<(), crate::PyError> {
-    let extra = args.len().saturating_sub(1);
+    let extra = args_given(args);
     if !(1..=2).contains(&extra) {
         return Err(crate::PyError::type_error(format!(
             "expected 1 or 2 arguments, got {extra}"
@@ -1238,7 +1250,7 @@ pub fn str_method_replace(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
     if pos.len() < 3 {
         return Err(crate::PyError::type_error(format!(
             "replace() takes at least 2 positional arguments ({} given)",
-            pos.len().saturating_sub(1)
+            args_given(pos)
         )));
     }
     crate::builtins::kwarg_reject_unknown(kwargs, &["count"], "replace")?;
@@ -5230,7 +5242,7 @@ pub fn str_method_splitlines(args: &[PyObjectRef]) -> Result<PyObjectRef, crate:
     if pos.len() > 2 {
         return Err(crate::PyError::type_error(format!(
             "splitlines() takes at most 1 argument ({} given)",
-            pos.len().saturating_sub(1)
+            args_given(pos)
         )));
     }
     crate::builtins::kwarg_reject_unknown(kwargs, &["keepends"], "splitlines")?;
@@ -5279,7 +5291,7 @@ pub fn str_method_removeprefix(args: &[PyObjectRef]) -> Result<PyObjectRef, crat
     if pos.len() != 2 {
         return Err(crate::PyError::type_error(format!(
             "str.removeprefix() takes exactly one argument ({} given)",
-            pos.len().saturating_sub(1)
+            args_given(pos)
         )));
     }
     if !unsafe { pyre_object::is_str(pos[1]) } {
@@ -5302,7 +5314,7 @@ pub fn str_method_removesuffix(args: &[PyObjectRef]) -> Result<PyObjectRef, crat
     if pos.len() != 2 {
         return Err(crate::PyError::type_error(format!(
             "str.removesuffix() takes exactly one argument ({} given)",
-            pos.len().saturating_sub(1)
+            args_given(pos)
         )));
     }
     if !unsafe { pyre_object::is_str(pos[1]) } {
@@ -5334,7 +5346,7 @@ pub fn str_method_expandtabs(args: &[PyObjectRef]) -> Result<PyObjectRef, crate:
     if pos.len() > 2 {
         return Err(crate::PyError::type_error(format!(
             "expandtabs() takes at most 1 argument ({} given)",
-            pos.len().saturating_sub(1)
+            args_given(pos)
         )));
     }
     crate::builtins::kwarg_reject_unknown(kwargs, &["tabsize"], "expandtabs")?;
@@ -5493,9 +5505,12 @@ pub fn resolve_dict_backing(obj: PyObjectRef) -> PyObjectRef {
                 let mut layout = pyre_object::w_type_get_layout_ptr(w_type);
                 while !layout.is_null() {
                     let current = &*layout;
-                    let first_slot = current
-                        .nslots
-                        .saturating_sub(current.newslotnames.len() as u32);
+                    let newslots = current.newslotnames.len() as u32;
+                    let first_slot = if current.nslots > newslots {
+                        current.nslots - newslots
+                    } else {
+                        0
+                    };
                     if let Some(offset) = current
                         .newslotnames
                         .iter()
@@ -6197,7 +6212,7 @@ pub fn tuple_method_index(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
     if args.len() < 2 {
         return Err(crate::PyError::type_error(format!(
             "index expected at least 1 argument, got {}",
-            args.len().saturating_sub(1)
+            args_given(args)
         )));
     }
     if args.len() > 4 {
@@ -6255,7 +6270,7 @@ pub fn tuple_method_count(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
     if args.len() != 2 {
         return Err(crate::PyError::type_error(format!(
             "tuple.count() takes exactly one argument ({} given)",
-            args.len().saturating_sub(1)
+            args_given(args)
         )));
     }
     let tup = args[0];

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -17083,8 +17083,8 @@ pub(crate) fn buffer_as_bytes_like(
         })));
     }
     #[cfg(all(unix, feature = "host_env", not(feature = "sandbox")))]
-    if let Some(data) = crate::module::_ctypes::cdata::cdata_bytes(obj) {
-        return Ok(Some(pyre_object::bytesobject::w_bytes_from_bytes(data)));
+    if let Some(data) = crate::module::_ctypes::cdata::cdata_bytes_object(obj) {
+        return Ok(Some(data));
     }
     // `W_MMap.readbuf_w` — the mapping is a bytes-like source in its own
     // right, so `bytes(m)` / `bytearray(m)` copy it here instead of falling

--- a/pyre/pyre-jit-trace/src/jitcode_runtime.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_runtime.rs
@@ -1807,6 +1807,11 @@ mod tests {
     /// pinned so that an opname MOVING out of this list (because the codewriter
     /// started emitting it) shows up as a test failure to be classified,
     /// instead of silently becoming a live `dispatch_step` panic.
+    ///
+    /// `vtable_method_ptr/rd>i` left the list exactly that way: routing
+    /// `dyn Trait` calls through `CallTarget::Indirect` became the default, so
+    /// the codewriter emits it and it is now registered in
+    /// `build_inline_call_only_bh_builder` instead.
     #[test]
     fn production_bh_builder_overlay_only_gap_snapshot() {
         let builder = build_pyre_production_bh_builder();
@@ -1853,7 +1858,6 @@ mod tests {
             "record_known_result_r_ir_v/riIRd",
             "record_quasiimmut_field/rdd",
             "rvmprof_code/ii",
-            "vtable_method_ptr/rd>i",
         ];
         assert_eq!(
             gap, expected,

--- a/pyre/pyre-object/src/celldict.rs
+++ b/pyre/pyre-object/src/celldict.rs
@@ -332,12 +332,28 @@ pub unsafe fn write_cell(w_cell: Option<PyObjectRef>, w_value: PyObjectRef) -> O
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct VersionTag(pub u64);
 
+/// The serial [`VersionTag::fresh`] hands out — a process-global counter
+/// bumped once per tag.
+///
+/// The counter is a runtime-mutable global, so the read seam is residual
+/// (`@dont_look_inside`, `rlib/jit.py:139`, the `importing::sys_modules_dict`
+/// shape): whatever value the build process happens to observe is not a
+/// constant, and folding it would hand every dict the same tag.  Upstream
+/// allocates a fresh `VersionTag()` object here instead, which rtypes to a
+/// `malloc` the JIT models; a `static AtomicU64` has no llop counterpart, so
+/// the call itself is the last modellable point.  The `u64` serial is a single
+/// word and the newtype wrap stays traced.
+#[majit_macros::dont_look_inside]
+pub fn next_version_tag_serial() -> u64 {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static NEXT: AtomicU64 = AtomicU64::new(1);
+    NEXT.fetch_add(1, Ordering::Relaxed)
+}
+
 impl VersionTag {
     /// Allocate a fresh, never-before-seen version tag.
     pub fn fresh() -> Self {
-        use std::sync::atomic::{AtomicU64, Ordering};
-        static NEXT: AtomicU64 = AtomicU64::new(1);
-        VersionTag(NEXT.fetch_add(1, Ordering::Relaxed))
+        VersionTag(next_version_tag_serial())
     }
 }
 
@@ -602,6 +618,29 @@ pub fn module_dict_strategy_gc_type_id() -> u32 {
     MODULE_DICT_STRATEGY_GC_TYPE_ID.load(std::sync::atomic::Ordering::Relaxed)
 }
 
+/// Flip every live watcher flag and drop the dead weak refs — the non-empty
+/// half of [`ModuleDictStrategy::notify_version_watchers`].
+///
+/// This is the `version?` quasi-immutable invalidation walk, and upstream runs
+/// the whole of it outside traced code: `QuasiImmut.invalidate`
+/// (`metainterp/quasiimmut.py`) iterates `looptokens_wrefs` and calls
+/// `invalidate_loop` from the residual `jit_force_quasi_immutable` path, never
+/// from a trace.  Residualise it here for the same reason
+/// (`@dont_look_inside`, `rlib/jit.py:139`); the `Vec::retain` closure over
+/// `Weak::upgrade` has no lowering either way.  The `is_empty` early-out stays
+/// traced, so the common no-watcher mutation still makes no call.
+#[majit_macros::dont_look_inside]
+pub fn sweep_version_watchers(watchers: &mut Vec<std::sync::Weak<std::sync::atomic::AtomicBool>>) {
+    watchers.retain(|w| {
+        if let Some(flag) = w.upgrade() {
+            flag.store(true, std::sync::atomic::Ordering::Release);
+            true
+        } else {
+            false
+        }
+    });
+}
+
 impl Default for ModuleDictStrategy {
     fn default() -> Self {
         Self::new()
@@ -639,14 +678,7 @@ impl ModuleDictStrategy {
         if self.version_watchers.is_empty() {
             return;
         }
-        self.version_watchers.retain(|w| {
-            if let Some(flag) = w.upgrade() {
-                flag.store(true, std::sync::atomic::Ordering::Release);
-                true
-            } else {
-                false
-            }
-        });
+        sweep_version_watchers(&mut self.version_watchers);
     }
 
     /// `celldict.py:214-240 get_global_cache`:

--- a/pyre/pyre-object/src/dict_eq_hook.rs
+++ b/pyre/pyre-object/src/dict_eq_hook.rs
@@ -322,6 +322,19 @@ pub extern "C" fn hash_str_hooked(ptr: *const u8, len: usize) -> i64 {
     HASH_STR_HOOK.with(|cell| cell.get().map(|f| unsafe { f(ptr, len) }).unwrap_or(0))
 }
 
+/// [`hash_str_hooked`] over a byte slice.
+///
+/// Marked so the `as_ptr` decomposition runs *inside* the boundary that is
+/// already opaque (`rlib/jit.py:139`): `core::slice::<Impl>::as_ptr` is an
+/// unregistered foreign leaf, and spelling it in [`try_hash_str`]'s traced body
+/// stopped that graph and every caller above it.  A `&[u8]` argument crosses a
+/// residual call unchanged — the same shape `host_seam::emit_stdout` uses — and
+/// the `i64` result is a single word, so nothing here widens the residual ABI.
+#[majit_macros::dont_look_inside]
+pub fn hash_str_hooked_bytes(bytes: &[u8]) -> i64 {
+    hash_str_hooked(bytes.as_ptr(), bytes.len())
+}
+
 /// Invoke the installed `hash_str` hook over `bytes`.  Returns `None` when no
 /// hook is installed (pyre-object lib tests without the str hook, pre-init
 /// snapshot tools); the str-keyed GET helpers then fall back to the
@@ -329,7 +342,7 @@ pub extern "C" fn hash_str_hooked(ptr: *const u8, len: usize) -> i64 {
 #[inline]
 pub fn try_hash_str(bytes: &[u8]) -> Option<i64> {
     if has_hash_str_hook() {
-        Some(hash_str_hooked(bytes.as_ptr(), bytes.len()))
+        Some(hash_str_hooked_bytes(bytes))
     } else {
         None
     }

--- a/pyre/pyre-object/src/dict_eq_hook.rs
+++ b/pyre/pyre-object/src/dict_eq_hook.rs
@@ -216,6 +216,24 @@ pub fn clear_hash_w_hook() {
     HASH_W_HOOK.with(|cell| cell.set(None));
 }
 
+/// True when an `eq_w` hook is installed on this thread.
+/// `dont_look_inside`: thread-local read, residualizes via the registered
+/// fnaddr (same pattern as [`has_hash_w_hook`]).
+#[majit_macros::dont_look_inside]
+pub extern "C" fn has_eq_w_hook() -> bool {
+    EQ_W_HOOK.with(|cell| cell.get().is_some())
+}
+
+/// Invoke the installed `eq_w` hook; returns `false` when no hook is
+/// installed — gate with [`has_eq_w_hook`] (the [`try_eq_w`] wrapper does).
+/// Not `unsafe` for ABI-surface reasons (residual calls dispatch through a
+/// plain fnaddr); `a` / `b` must nonetheless be valid PyObjectRefs (null
+/// tolerated as per PyPy's `is_w` shortcut at `baseobjspace.py:818-822`).
+#[majit_macros::dont_look_inside]
+pub extern "C" fn eq_w_hooked(a: PyObjectRef, b: PyObjectRef) -> bool {
+    EQ_W_HOOK.with(|cell| cell.get().map(|f| unsafe { f(a, b) }).unwrap_or(false))
+}
+
 /// Invoke the installed `eq_w` hook.  Returns `None` when no hook is
 /// installed (pyre-object lib tests, pre-init snapshot tools); the
 /// caller falls back to the limited-type builtin equality so existing
@@ -226,7 +244,11 @@ pub fn clear_hash_w_hook() {
 /// PyPy's `is_w` shortcut at `baseobjspace.py:818-822`).
 #[inline]
 pub unsafe fn try_eq_w(a: PyObjectRef, b: PyObjectRef) -> Option<bool> {
-    EQ_W_HOOK.with(|cell| cell.get().map(|f| unsafe { f(a, b) }))
+    if has_eq_w_hook() {
+        Some(eq_w_hooked(a, b))
+    } else {
+        None
+    }
 }
 
 /// Invoke the installed `hash_w` hook.  Returns `None` when no hook

--- a/pyre/pyre-object/src/dictmultiobject.rs
+++ b/pyre/pyre-object/src/dictmultiobject.rs
@@ -184,6 +184,49 @@ impl indexmap::Equivalent<ObjectKey> for StrLookupKey<'_> {
     }
 }
 
+/// The borrow-key probe [`dict_entries_get_str`] runs once the str hash hook
+/// has produced `hash` — `celldict.py:143-145 getitem_str`'s single
+/// `self.unerase(w_dict.dstorage).get(key)`.
+///
+/// Residualise the probe alone (`@dont_look_inside`, `rlib/jit.py:139`), the
+/// twin of [`w_dict_lookup_int_strategy`] and
+/// [`w_module_dict_lookup_object_entries`]: the `IndexMap::get` it wraps is an
+/// external-crate heap lookup the tracer cannot model — the oopspec'd residual
+/// arm of `rordereddict.ll_dict_getitem` (traced only for a virtual dict).  The
+/// user `__eq__` a str-subclass key can run sits inside the same probe upstream
+/// (`rdict.py:576 ll_dict_lookup` carries `@jit.oopspec('dict.lookup')` over
+/// the whole `keyeq` loop), so it does not argue for a narrower boundary.  The
+/// enclosing [`dict_entries_get_str`] keeps its hook gate and its allocating
+/// fallback visible.
+///
+/// # Safety
+/// `entries` must be a live entry table whose keys are valid `ObjectKey`s.
+#[majit_macros::dont_look_inside]
+pub unsafe fn dict_entries_probe_str(
+    entries: &indexmap::IndexMap<ObjectKey, PyObjectRef>,
+    hash: i64,
+    key: &str,
+) -> Option<PyObjectRef> {
+    entries.get(&StrLookupKey { hash, key }).copied()
+}
+
+/// The owned-key probe [`dict_entries_get_str`]'s no-hook arm runs — the same
+/// `IndexMap::get` behind an [`object_key_for`] key instead of a borrowed one.
+///
+/// Residualised for the reason [`dict_entries_probe_str`] is: a body that
+/// reaches either `get` stops there, so leaving one arm traced keeps the
+/// enclosing graph blocked no matter what the other arm does.
+///
+/// # Safety
+/// Same as [`dict_entries_probe_str`]; `key` must be a valid PyObjectRef.
+#[majit_macros::dont_look_inside]
+pub unsafe fn dict_entries_probe_object(
+    entries: &indexmap::IndexMap<ObjectKey, PyObjectRef>,
+    key: PyObjectRef,
+) -> Option<PyObjectRef> {
+    entries.get(&object_key_for(key)).copied()
+}
+
 /// Borrow-key str dict GET: hash `key`'s WTF-8 bytes via the str hook and
 /// probe `entries` without building a `W_UnicodeObject`.  Falls back to the
 /// allocating `object_key_for(w_str_new(key))` path when no str hash hook is
@@ -199,9 +242,9 @@ unsafe fn dict_entries_get_str(
             // Clear any stale eq flag so a str-subclass comparison in the probe
             // starts clean, matching `object_key_for`'s pre-probe reset (:125).
             crate::dict_eq_hook::take_eq_error();
-            entries.get(&StrLookupKey { hash, key }).copied()
+            dict_entries_probe_str(entries, hash, key)
         }
-        None => entries.get(&object_key_for(crate::w_str_new(key))).copied(),
+        None => dict_entries_probe_object(entries, crate::w_str_new(key)),
     }
 }
 

--- a/pyre/pyre-object/src/dictmultiobject.rs
+++ b/pyre/pyre-object/src/dictmultiobject.rs
@@ -1443,8 +1443,13 @@ pub unsafe fn w_module_dict_object_storage_mut_opt<'a>(
 ///
 /// No-op when already in object-strategy mode.
 ///
+/// Residualised for the reason [`w_dict_switch_int_to_object_strategy`] is —
+/// the promotion is `IndexMap` construction and refill end to end, so there is
+/// no modellable point inside it to put the boundary at.
+///
 /// # Safety
 /// `obj` must point to a valid `W_ModuleDictObject`.
+#[majit_macros::dont_look_inside]
 pub unsafe fn w_module_dict_switch_to_object_strategy(obj: PyObjectRef) {
     let _module_guard = w_dict_lock(obj);
     let raw = &mut *(obj as *mut W_ModuleDictObject);
@@ -3568,6 +3573,38 @@ pub unsafe fn w_dict_clear_int_strategy(obj: PyObjectRef) {
     entries.clear();
 }
 
+/// `dictmultiobject.py:1223-1230 AbstractTypedStrategy.switch_to_object_strategy`
+/// for `IntDictStrategy` — rebuild the erased `{}` on the object shape, refill
+/// it with `newint(key)` keys, then relabel the dict.
+///
+/// Residualised (`@dont_look_inside`, `rlib/jit.py:139`) even though upstream
+/// carries no marker here: upstream can trace the body because every step is an
+/// RPython dict primitive the JIT models (`ll_newdict`,
+/// `ll_dict_setitem`'s `look_inside_iff(isvirtual)`), whereas the whole body is
+/// `IndexMap` — an external crate with no lowering at all — so the last
+/// modellable point is the call itself.  The `()` return crosses the residual
+/// boundary the way `setobject::w_set_copy_storage_from` does.
+///
+/// # Safety
+/// `w_dict` must be a valid `W_DictObject` on `INT_DICT_STRATEGY`.
+#[majit_macros::dont_look_inside]
+pub unsafe fn w_dict_switch_int_to_object_strategy(w_dict: PyObjectRef) {
+    let dict = &mut *(w_dict as *mut W_DictObject);
+    // Borrow the old typed box (its field stays live, so it is traced
+    // while the migration allocates keys); after the store the box is
+    // unreachable and the sweep reclaims it.
+    let old = &*(dict.dstorage as *const IntDictStorage);
+    let mut new_map = ObjectDictStorage::with_capacity(old.len());
+    for (&k, &v) in old.iter() {
+        let w_key = crate::w_int_new(k);
+        new_map.insert(object_key_for(w_key), v);
+    }
+    dict.dstorage =
+        crate::gc_storage::gc_alloc_storage_box(new_map, object_dict_storage_gc_type_id())
+            as *mut u8;
+    dict.dstrategy = &OBJECT_DICT_STRATEGY;
+}
+
 /// Internal helper: `BytesDictStrategy::setitem` body —
 /// `dictmultiobject.py:1061-1064` direct typed-storage write.  Caller
 /// must have already verified `is_correct_type(w_key)`.
@@ -3684,6 +3721,26 @@ pub unsafe fn w_dict_clear_bytes_strategy(obj: PyObjectRef) {
         dict.keys_version = dict.keys_version.wrapping_add(1);
     }
     entries.clear();
+}
+
+/// [`w_dict_switch_int_to_object_strategy`] for `BytesDictStrategy`, refilling
+/// with `newbytes(key)` keys.  Residualised for the same reason.
+///
+/// # Safety
+/// `w_dict` must be a valid `W_DictObject` on `BYTES_DICT_STRATEGY`.
+#[majit_macros::dont_look_inside]
+pub unsafe fn w_dict_switch_bytes_to_object_strategy(w_dict: PyObjectRef) {
+    let dict = &mut *(w_dict as *mut W_DictObject);
+    let old = &*(dict.dstorage as *const BytesDictStorage);
+    let mut new_map = ObjectDictStorage::with_capacity(old.len());
+    for (k, v) in old.iter() {
+        let w_key = crate::w_bytes_from_bytes(k.as_slice());
+        new_map.insert(object_key_for(w_key), *v);
+    }
+    dict.dstorage =
+        crate::gc_storage::gc_alloc_storage_box(new_map, object_dict_storage_gc_type_id())
+            as *mut u8;
+    dict.dstrategy = &OBJECT_DICT_STRATEGY;
 }
 
 /// Internal helper: `ObjectDictStrategy::items` body for pyre's
@@ -5229,21 +5286,7 @@ impl DictStrategy for BytesDictStrategy {
     /// `IndexMap<ObjectKey, _>` with each `Vec<u8>` wrapped via
     /// `w_bytes_from_bytes`, drops the typed box.
     unsafe fn switch_to_object_strategy(&self, w_dict: PyObjectRef) {
-        let dict = &mut *(w_dict as *mut crate::dictmultiobject::W_DictObject);
-        // Borrow the old typed box (its field stays live, so it is traced
-        // while the migration allocates keys); after the store the box is
-        // unreachable and the sweep reclaims it.
-        let old = &*(dict.dstorage as *const crate::dictmultiobject::BytesDictStorage);
-        let mut new_map = crate::dictmultiobject::ObjectDictStorage::with_capacity(old.len());
-        for (k, v) in old.iter() {
-            let w_key = crate::w_bytes_from_bytes(k.as_slice());
-            new_map.insert(crate::dictmultiobject::object_key_for(w_key), *v);
-        }
-        dict.dstorage = crate::gc_storage::gc_alloc_storage_box(
-            new_map,
-            crate::dictmultiobject::object_dict_storage_gc_type_id(),
-        ) as *mut u8;
-        dict.dstrategy = &OBJECT_DICT_STRATEGY;
+        crate::dictmultiobject::w_dict_switch_bytes_to_object_strategy(w_dict);
     }
 
     /// `dictmultiobject.py:1244-1247 get_empty_storage` — erased `{}`
@@ -5624,21 +5667,7 @@ impl DictStrategy for IntDictStrategy {
     /// fresh `IndexMap<ObjectKey, PyObjectRef>` and drops the old typed
     /// `IndexMap<i64, PyObjectRef>` box.
     unsafe fn switch_to_object_strategy(&self, w_dict: PyObjectRef) {
-        let dict = &mut *(w_dict as *mut crate::dictmultiobject::W_DictObject);
-        // Borrow the old typed box (its field stays live, so it is traced
-        // while the migration allocates keys); after the store the box is
-        // unreachable and the sweep reclaims it.
-        let old = &*(dict.dstorage as *const crate::dictmultiobject::IntDictStorage);
-        let mut new_map = crate::dictmultiobject::ObjectDictStorage::with_capacity(old.len());
-        for (&k, &v) in old.iter() {
-            let w_key = crate::w_int_new(k);
-            new_map.insert(crate::dictmultiobject::object_key_for(w_key), v);
-        }
-        dict.dstorage = crate::gc_storage::gc_alloc_storage_box(
-            new_map,
-            crate::dictmultiobject::object_dict_storage_gc_type_id(),
-        ) as *mut u8;
-        dict.dstrategy = &OBJECT_DICT_STRATEGY;
+        crate::dictmultiobject::w_dict_switch_int_to_object_strategy(w_dict);
     }
 
     /// `dictmultiobject.py:1339-1352 IntDictStrategy.get_empty_storage`

--- a/pyre/pyre-object/src/dictmultiobject.rs
+++ b/pyre/pyre-object/src/dictmultiobject.rs
@@ -2123,21 +2123,29 @@ pub unsafe fn w_dict_lookup_checked(
 /// `dict_keys_equal` answers from its builtin type ladder and no user
 /// `__eq__` observes or mutates the dict mid-probe.
 ///
-/// Returns `None` when a comparison escaped the ladder: `op` withholds its
+/// Yields `None` when a comparison escaped the ladder: the body withholds its
 /// mutation in that case, so the dict is untouched and the caller re-runs the
 /// operation by scanning entries without holding a table borrow across a
 /// callback.
-#[inline]
-unsafe fn callback_free_dict_op<T>(op: impl FnOnce() -> T) -> Option<Result<T, DictKeyError>> {
-    crate::dict_eq_hook::begin_callback_free_probe();
-    let result = op();
-    if crate::dict_eq_hook::end_callback_free_probe() {
-        return None;
-    }
-    if take_dict_key_error() {
-        return Some(Err(DictKeyError));
-    }
-    Some(Ok(result))
+///
+/// A macro rather than a function taking `impl FnOnce`: a closure parameter
+/// puts an `FnOnce::call_once` in front of every probe and closures have no
+/// lifted counterpart, so each dict graph that probes stops there.  Upstream
+/// writes the attempt out at the call site (`ll_dict_lookup`'s fast pass
+/// before the paranoia restart, `rordereddict.py:1057`) rather than passing
+/// it as a callable.
+macro_rules! callback_free_dict_op {
+    ($body:block) => {{
+        crate::dict_eq_hook::begin_callback_free_probe();
+        let result = $body;
+        if crate::dict_eq_hook::end_callback_free_probe() {
+            None
+        } else if take_dict_key_error() {
+            Some(Err(DictKeyError))
+        } else {
+            Some(Ok(result))
+        }
+    }};
 }
 
 /// Find `key` in the object storage by scanning same-hash entries one at a
@@ -2246,7 +2254,7 @@ pub unsafe fn w_dict_lookup_object_strategy_checked(
 ) -> Result<Option<PyObjectRef>, DictKeyError> {
     let _dict_guard = w_dict_lock(obj);
     let object_key = object_key_for_checked(key)?;
-    if let Some(result) = callback_free_dict_op(|| {
+    if let Some(result) = callback_free_dict_op!({
         let dict = &*(obj as *const W_DictObject);
         let entries = &*(dict.dstorage as *const indexmap::IndexMap<ObjectKey, PyObjectRef>);
         entries.get(&object_key).copied()
@@ -2543,20 +2551,21 @@ pub unsafe fn w_dict_setdefault_checked(
         // comparison the builtin ladder cannot settle withholds the insert and
         // re-runs the probe over `scan_dict_key_reentrant`.
         let object_key = object_key_for_checked(key)?;
-        if let Some(result) = callback_free_dict_op(|| -> Option<PyObjectRef> {
+        if let Some(result) = callback_free_dict_op!({
             let dict = &mut *(obj as *mut W_DictObject);
             let entries = &mut *(dict.dstorage as *mut indexmap::IndexMap<ObjectKey, PyObjectRef>);
             let index = entries.get_index_of(&object_key);
             if crate::dict_eq_hook::callback_free_probe_broken() {
-                return None;
-            }
-            match index {
-                Some(i) => Some(*entries.get_index(i).unwrap().1),
-                None => {
-                    entries.insert(object_key, value);
-                    w_dict_bump_keys_version(obj);
-                    dict_write_barrier(obj);
-                    Some(value)
+                None
+            } else {
+                match index {
+                    Some(i) => Some(*entries.get_index(i).unwrap().1),
+                    None => {
+                        entries.insert(object_key, value);
+                        w_dict_bump_keys_version(obj);
+                        dict_write_barrier(obj);
+                        Some(value)
+                    }
                 }
             }
         }) {
@@ -2632,19 +2641,23 @@ pub unsafe fn w_dict_pop_checked(
             // withholds the removal and re-runs it over
             // `scan_dict_key_reentrant`.
             let object_key = object_key_for_checked(key)?;
-            if let Some(result) = callback_free_dict_op(|| -> Option<PyObjectRef> {
+            if let Some(result) = callback_free_dict_op!({
                 let dict = &mut *(obj as *mut W_DictObject);
                 let entries =
                     &mut *(dict.dstorage as *mut indexmap::IndexMap<ObjectKey, PyObjectRef>);
                 let index = entries.get_index_of(&object_key);
                 if crate::dict_eq_hook::callback_free_probe_broken() {
-                    return None;
+                    None
+                } else {
+                    match index {
+                        Some(i) => {
+                            let removed = entries.shift_remove_index(i).unwrap().1;
+                            w_dict_bump_keys_version(obj);
+                            Some(removed)
+                        }
+                        None => None,
+                    }
                 }
-                index.map(|i| {
-                    let removed = entries.shift_remove_index(i).unwrap().1;
-                    w_dict_bump_keys_version(obj);
-                    removed
-                })
             }) {
                 return result;
             }
@@ -2715,23 +2728,22 @@ unsafe fn w_dict_store_object_strategy_checked_inner(
     // builtin ladder the probe updates or appends in place; a pair it cannot
     // decide breaks the probe, withholds the store, and re-runs it over
     // `scan_dict_key_reentrant`.
-    if let Some(result) = callback_free_dict_op(|| {
+    if let Some(result) = callback_free_dict_op!({
         let dict = &mut *(obj as *mut W_DictObject);
         let entries = &mut *(dict.dstorage as *mut indexmap::IndexMap<ObjectKey, PyObjectRef>);
         let index = entries.get_index_of(&object_key);
-        if crate::dict_eq_hook::callback_free_probe_broken() {
-            return;
-        }
-        match index {
-            Some(i) => {
-                *entries.get_index_mut(i).unwrap().1 = value;
+        if !crate::dict_eq_hook::callback_free_probe_broken() {
+            match index {
+                Some(i) => {
+                    *entries.get_index_mut(i).unwrap().1 = value;
+                }
+                None => {
+                    entries.insert(object_key, value);
+                    dict.keys_version = dict.keys_version.wrapping_add(1);
+                }
             }
-            None => {
-                entries.insert(object_key, value);
-                dict.keys_version = dict.keys_version.wrapping_add(1);
-            }
+            dict_write_barrier(obj);
         }
-        dict_write_barrier(obj);
     }) {
         return result;
     }
@@ -3178,22 +3190,25 @@ pub unsafe fn w_dict_delitem_if_value_is_checked(
             w_module_dict_switch_to_object_strategy(obj);
         }
         let object_key = object_key_for_checked(key)?;
-        if let Some(result) = callback_free_dict_op(|| {
+        if let Some(result) = callback_free_dict_op!({
             let entries = w_module_dict_object_storage_mut(obj);
-            let Some(index) = entries.get_index_of(&object_key) else {
-                return false;
-            };
-            if entries
-                .get_index(index)
-                .is_none_or(|(_, stored)| *stored != value)
-            {
-                return false;
+            match entries.get_index_of(&object_key) {
+                Some(index)
+                    if entries
+                        .get_index(index)
+                        .is_none_or(|(_, stored)| *stored != value) =>
+                {
+                    false
+                }
+                Some(index) => {
+                    entries.shift_remove_index(index);
+                    let strategy = &mut *(*(obj as *mut W_ModuleDictObject)).mstrategy;
+                    strategy.mutated();
+                    w_dict_bump_keys_version(obj);
+                    true
+                }
+                None => false,
             }
-            entries.shift_remove_index(index);
-            let strategy = &mut *(*(obj as *mut W_ModuleDictObject)).mstrategy;
-            strategy.mutated();
-            w_dict_bump_keys_version(obj);
-            true
         }) {
             return result;
         }
@@ -3205,21 +3220,24 @@ pub unsafe fn w_dict_delitem_if_value_is_checked(
         strategy.switch_to_object_strategy(obj);
     }
     let object_key = object_key_for_checked(key)?;
-    if let Some(result) = callback_free_dict_op(|| {
+    if let Some(result) = callback_free_dict_op!({
         let dict = &mut *(obj as *mut W_DictObject);
         let entries = &mut *(dict.dstorage as *mut indexmap::IndexMap<ObjectKey, PyObjectRef>);
-        let Some(index) = entries.get_index_of(&object_key) else {
-            return false;
-        };
-        if entries
-            .get_index(index)
-            .is_none_or(|(_, stored)| *stored != value)
-        {
-            return false;
+        match entries.get_index_of(&object_key) {
+            Some(index)
+                if entries
+                    .get_index(index)
+                    .is_none_or(|(_, stored)| *stored != value) =>
+            {
+                false
+            }
+            Some(index) => {
+                entries.shift_remove_index(index);
+                dict.keys_version = dict.keys_version.wrapping_add(1);
+                true
+            }
+            None => false,
         }
-        entries.shift_remove_index(index);
-        dict.keys_version = dict.keys_version.wrapping_add(1);
-        true
     }) {
         return result;
     }
@@ -3268,20 +3286,21 @@ pub unsafe fn w_dict_delitem_object_strategy_checked(
     // dict while the `IndexMap` borrow is live.  A comparison the builtin
     // ladder cannot settle withholds the removal and re-runs the probe over
     // `scan_dict_key_reentrant`.
-    if let Some(result) = callback_free_dict_op(|| {
+    if let Some(result) = callback_free_dict_op!({
         let dict = &mut *(obj as *mut W_DictObject);
         let entries = &mut *(dict.dstorage as *mut indexmap::IndexMap<ObjectKey, PyObjectRef>);
         let index = entries.get_index_of(&object_key);
         if crate::dict_eq_hook::callback_free_probe_broken() {
-            return false;
-        }
-        match index {
-            Some(i) => {
-                entries.shift_remove_index(i);
-                dict.keys_version = dict.keys_version.wrapping_add(1);
-                true
+            false
+        } else {
+            match index {
+                Some(i) => {
+                    entries.shift_remove_index(i);
+                    dict.keys_version = dict.keys_version.wrapping_add(1);
+                    true
+                }
+                None => false,
             }
-            None => false,
         }
     }) {
         return result;

--- a/pyre/pyre-object/src/dictmultiobject.rs
+++ b/pyre/pyre-object/src/dictmultiobject.rs
@@ -2151,8 +2151,8 @@ pub unsafe fn w_module_dict_lookup_inner(
     key: PyObjectRef,
 ) -> Option<PyObjectRef> {
     let _module_guard = w_dict_lock(obj);
-    if let Some(entries) = w_module_dict_object_storage(obj) {
-        return entries.get(&object_key_for(key)).copied();
+    if w_module_dict_object_storage(obj).is_some() {
+        return w_module_dict_lookup_object_entries(obj, key);
     }
     if let Some(ks) = key_as_utf8(key) {
         return w_module_dict_getitem_str(obj, ks);
@@ -2161,6 +2161,31 @@ pub unsafe fn w_module_dict_lookup_inner(
         return None;
     }
     w_module_dict_switch_to_object_strategy(obj);
+    w_module_dict_lookup_object_entries(obj, key)
+}
+
+/// The unified-entries probe both arms of [`w_module_dict_lookup_inner`]
+/// perform — `celldict.py:139 self.unerase(w_dict.dstorage).get(w_key)` once
+/// the module dict has been promoted to object storage.
+///
+/// Residualise the probe alone (`@dont_look_inside`, `rlib/jit.py:139`), the
+/// twin of [`w_dict_lookup_int_strategy`]: the `IndexMap::get` it wraps is an
+/// external-crate heap-lookup the tracer cannot model — the oopspec'd residual
+/// arm of `rordereddict.ll_dict_getitem` (traced only for a virtual dict).
+/// The enclosing router keeps its str fast path, its never-equal shortcut and
+/// its strategy promotion visible, because `celldict.py:131-141` carries no
+/// residual marker of its own.
+///
+/// Returns `None` when the dict is not on object storage, matching the `?` the
+/// second call site used to spell.
+///
+/// # Safety
+/// `obj` must point to a valid `W_ModuleDictObject`.
+#[majit_macros::dont_look_inside]
+pub unsafe fn w_module_dict_lookup_object_entries(
+    obj: PyObjectRef,
+    key: PyObjectRef,
+) -> Option<PyObjectRef> {
     let entries = w_module_dict_object_storage(obj)?;
     entries.get(&object_key_for(key)).copied()
 }

--- a/pyre/pyre-object/src/dictmultiobject.rs
+++ b/pyre/pyre-object/src/dictmultiobject.rs
@@ -227,6 +227,29 @@ pub unsafe fn dict_entries_probe_object(
     entries.get(&object_key_for(key)).copied()
 }
 
+/// The object-keyed remove side of the same table — `dictmultiobject.py:1081
+/// delitem`'s `del self.unerase(w_dict.dstorage)[self.unwrap(w_key)]`.
+///
+/// Residualised (`@dont_look_inside`, `rlib/jit.py:139`) because upstream's
+/// `_ll_dict_del` (`rordereddict.py:884`) carries
+/// `@jit.look_inside_iff(jit.isvirtual(d) and jit.isconstant(i))`, and an
+/// `IndexMap` can never be virtual to this front end, so the predicate is
+/// permanently false and the residual arm is the only reachable one.  Every
+/// arm that reaches the remove must go through here: leaving one traced keeps
+/// the enclosing graph blocked no matter what the others do
+/// ([`dict_entries_probe_object`]'s lesson).  The `bool` result is a single
+/// word, and the strategy / keys-version bumps stay traced.
+///
+/// # Safety
+/// Same as [`dict_entries_probe_object`].
+#[majit_macros::dont_look_inside]
+pub unsafe fn dict_entries_remove_object(
+    entries: &mut indexmap::IndexMap<ObjectKey, PyObjectRef>,
+    key: PyObjectRef,
+) -> bool {
+    entries.shift_remove(&object_key_for(key)).is_some()
+}
+
 /// Borrow-key str dict GET: hash `key`'s WTF-8 bytes via the str hook and
 /// probe `entries` without building a `W_UnicodeObject`.  Falls back to the
 /// allocating `object_key_for(w_str_new(key))` path when no str hash hook is
@@ -3233,7 +3256,7 @@ pub unsafe fn w_module_dict_delitem_inner(obj: PyObjectRef, key: PyObjectRef) ->
     let _module_guard = w_dict_lock(obj);
     if w_module_dict_is_object_strategy(obj) {
         let entries = w_module_dict_object_storage_mut(obj);
-        if entries.shift_remove(&object_key_for(key)).is_some() {
+        if dict_entries_remove_object(entries, key) {
             let strategy = &mut *(*(obj as *mut W_ModuleDictObject)).mstrategy;
             strategy.mutated();
             w_dict_bump_keys_version(obj);
@@ -3249,7 +3272,7 @@ pub unsafe fn w_module_dict_delitem_inner(obj: PyObjectRef, key: PyObjectRef) ->
     }
     w_module_dict_switch_to_object_strategy(obj);
     let entries = w_module_dict_object_storage_mut(obj);
-    if entries.shift_remove(&object_key_for(key)).is_some() {
+    if dict_entries_remove_object(entries, key) {
         let strategy = &mut *(*(obj as *mut W_ModuleDictObject)).mstrategy;
         strategy.mutated();
         w_dict_bump_keys_version(obj);

--- a/pyre/pyre-object/src/dictmultiobject.rs
+++ b/pyre/pyre-object/src/dictmultiobject.rs
@@ -250,6 +250,63 @@ pub unsafe fn dict_entries_remove_object(
     entries.shift_remove(&object_key_for(key)).is_some()
 }
 
+/// [`dict_entries_probe_object`] for a caller that already ran
+/// [`object_key_for_checked`] — the checked paths, which must hash before the
+/// probe so a raising `__hash__` is reported without touching the table.
+///
+/// The key arrives DECOMPOSED into its two words rather than as an
+/// [`ObjectKey`]: a struct by value is not a residual-ABI argument shape, and
+/// `hash` + `obj` are exactly what the caller holds anyway (the same split
+/// [`dict_entries_probe_str`] takes).
+///
+/// # Safety
+/// Same as [`dict_entries_probe_object`]; `hash` must be the digest
+/// [`object_key_for_checked`] produced for `obj`.
+#[majit_macros::dont_look_inside]
+pub unsafe fn dict_entries_probe_hashed(
+    entries: &indexmap::IndexMap<ObjectKey, PyObjectRef>,
+    hash: i64,
+    obj: PyObjectRef,
+) -> Option<PyObjectRef> {
+    entries.get(&ObjectKey { hash, obj }).copied()
+}
+
+/// The store side of [`dict_entries_probe_hashed`] —
+/// `dictmultiobject.py:1067 setitem`'s
+/// `self.unerase(w_dict.dstorage)[self.unwrap(w_key)] = w_value`, returning
+/// the displaced value so the caller can tell an overwrite from an insert.
+///
+/// Residualised for [`dict_entries_probe_object`]'s reason: `IndexMap` has no
+/// lowering, so the call is the last modellable point.  Upstream's
+/// `_ll_dict_setitem_lookup_done` (`rordereddict.py:674`) is likewise
+/// `@jit.look_inside_iff(jit.isvirtual(d) and jit.isconstant(key))`, and
+/// neither conjunct can hold for an `IndexMap` here.
+///
+/// # Safety
+/// Same as [`dict_entries_probe_hashed`].
+#[majit_macros::dont_look_inside]
+pub unsafe fn dict_entries_insert_hashed(
+    entries: &mut indexmap::IndexMap<ObjectKey, PyObjectRef>,
+    hash: i64,
+    obj: PyObjectRef,
+    value: PyObjectRef,
+) -> Option<PyObjectRef> {
+    entries.insert(ObjectKey { hash, obj }, value)
+}
+
+/// Drop the last entry — the undo the checked store runs when a user `__eq__`
+/// raised mid-probe and `insert` therefore appended a spurious entry.
+///
+/// Residual for the same reason its `insert` twin is; separating it keeps the
+/// error test itself traced.
+///
+/// # Safety
+/// Same as [`dict_entries_probe_hashed`].
+#[majit_macros::dont_look_inside]
+pub unsafe fn dict_entries_pop_last(entries: &mut indexmap::IndexMap<ObjectKey, PyObjectRef>) {
+    entries.pop();
+}
+
 /// Borrow-key str dict GET: hash `key`'s WTF-8 bytes via the str hook and
 /// probe `entries` without building a `W_UnicodeObject`.  Falls back to the
 /// allocating `object_key_for(w_str_new(key))` path when no str hash hook is
@@ -2268,7 +2325,7 @@ pub unsafe fn w_module_dict_lookup_inner_checked(
     let _module_guard = w_dict_lock(obj);
     if let Some(entries) = w_module_dict_object_storage(obj) {
         let object_key = object_key_for_checked(key)?;
-        let hit = entries.get(&object_key).copied();
+        let hit = dict_entries_probe_hashed(entries, object_key.hash, object_key.obj);
         if take_dict_key_error() {
             return Err(DictKeyError);
         }
@@ -2283,7 +2340,7 @@ pub unsafe fn w_module_dict_lookup_inner_checked(
     w_module_dict_switch_to_object_strategy(obj);
     let entries = w_module_dict_object_storage(obj).ok_or(DictKeyError)?;
     let object_key = object_key_for_checked(key)?;
-    let hit = entries.get(&object_key).copied();
+    let hit = dict_entries_probe_hashed(entries, object_key.hash, object_key.obj);
     if take_dict_key_error() {
         return Err(DictKeyError);
     }
@@ -2761,9 +2818,9 @@ pub unsafe fn w_module_dict_store_inner_checked(
     // Single setitem probe; on an `__eq__` raise mid-probe `insert` appends
     // a spurious entry, so drop it with `pop` and leave the dict unchanged
     // (see `w_dict_store_object_strategy_checked`).
-    let previous = entries.insert(object_key, value);
+    let previous = dict_entries_insert_hashed(entries, object_key.hash, object_key.obj, value);
     if take_dict_key_error() {
-        entries.pop();
+        dict_entries_pop_last(entries);
         return Err(DictKeyError);
     }
     let strategy = &mut *(*(obj as *mut W_ModuleDictObject)).mstrategy;

--- a/pyre/pyre-object/src/identitydict.rs
+++ b/pyre/pyre-object/src/identitydict.rs
@@ -96,6 +96,37 @@ pub unsafe fn w_dict_lookup_identity_strategy(
     identity_storage(obj).get(&IdentityKey(key)).copied()
 }
 
+/// `dictmultiobject.py:1143-1150 AbstractTypedStrategy.switch_to_object_strategy`
+/// instantiation for IdentityDictStrategy — `wrap` is identity (`:26-27`), so
+/// the migration ports each `IdentityKey(obj)` into
+/// `ObjectKey { hash: hash_w(obj), obj }` without rewrapping keys.
+///
+/// Residualised (`@dont_look_inside`, `rlib/jit.py:139`) for the reason
+/// `dictmultiobject::w_dict_switch_int_to_object_strategy` is: the body is
+/// `IndexMap` construction and refill end to end, and the front end has no
+/// lowering for it, so there is no modellable point inside to put the boundary
+/// at.
+///
+/// # Safety
+/// `w_dict` must be a valid `W_DictObject` on [`IDENTITY_DICT_STRATEGY`].
+#[majit_macros::dont_look_inside]
+pub unsafe fn w_dict_switch_identity_to_object_strategy(w_dict: PyObjectRef) {
+    let dict = &mut *(w_dict as *mut crate::dictmultiobject::W_DictObject);
+    // Borrow the old typed box (its field stays live, so it is traced
+    // while the migration builds the object map); after the store the
+    // box is unreachable and the sweep reclaims it.
+    let old = &*(dict.dstorage as *const IdentityDictStorage);
+    let mut new_map = crate::dictmultiobject::ObjectDictStorage::with_capacity(old.len());
+    for (k, &v) in old.iter() {
+        new_map.insert(crate::dictmultiobject::object_key_for(k.0), v);
+    }
+    dict.dstorage = crate::gc_storage::gc_alloc_storage_box(
+        new_map,
+        crate::dictmultiobject::object_dict_storage_gc_type_id(),
+    ) as *mut u8;
+    dict.dstrategy = &OBJECT_DICT_STRATEGY;
+}
+
 #[inline]
 unsafe fn identity_storage_mut<'a>(
     obj: PyObjectRef,
@@ -170,20 +201,7 @@ impl DictStrategy for IdentityDictStrategy {
     /// (`:26-27`), so the migration ports each `IdentityKey(obj)` into
     /// `ObjectKey { hash: hash_w(obj), obj }` without rewrapping keys.
     unsafe fn switch_to_object_strategy(&self, w_dict: PyObjectRef) {
-        let dict = &mut *(w_dict as *mut crate::dictmultiobject::W_DictObject);
-        // Borrow the old typed box (its field stays live, so it is traced
-        // while the migration builds the object map); after the store the
-        // box is unreachable and the sweep reclaims it.
-        let old = &*(dict.dstorage as *const IdentityDictStorage);
-        let mut new_map = crate::dictmultiobject::ObjectDictStorage::with_capacity(old.len());
-        for (k, &v) in old.iter() {
-            new_map.insert(crate::dictmultiobject::object_key_for(k.0), v);
-        }
-        dict.dstorage = crate::gc_storage::gc_alloc_storage_box(
-            new_map,
-            crate::dictmultiobject::object_dict_storage_gc_type_id(),
-        ) as *mut u8;
-        dict.dstrategy = &OBJECT_DICT_STRATEGY;
+        w_dict_switch_identity_to_object_strategy(w_dict);
     }
 
     /// `identitydict.py:67-70 get_empty_storage` — erased `{}` with

--- a/pyre/pyre-object/src/identitydict.rs
+++ b/pyre/pyre-object/src/identitydict.rs
@@ -96,6 +96,26 @@ pub unsafe fn w_dict_lookup_identity_strategy(
     identity_storage(obj).get(&IdentityKey(key)).copied()
 }
 
+/// `dictmultiobject.py:1081-1087 delitem`'s identity-keyed remove — drop the
+/// entry for `key` and report whether one was there.
+///
+/// Residualise the storage remove alone (`@dont_look_inside`,
+/// `rlib/jit.py:139`), the delete twin of [`w_dict_lookup_identity_strategy`]:
+/// upstream's `_ll_dict_del` (`rordereddict.py:884`) carries
+/// `@jit.look_inside_iff(jit.isvirtual(d) and jit.isconstant(i))`, and an
+/// `IndexMap` can never be virtual to this front end, so the predicate is
+/// permanently false and the residual arm is the only one reachable.  The
+/// keys-version bump stays traced.
+///
+/// # Safety
+/// `obj` must point to a valid `W_DictObject` on [`IDENTITY_DICT_STRATEGY`].
+#[majit_macros::dont_look_inside]
+pub unsafe fn w_dict_delete_identity_strategy(obj: PyObjectRef, key: PyObjectRef) -> bool {
+    identity_storage_mut(obj)
+        .shift_remove(&IdentityKey(key))
+        .is_some()
+}
+
 /// `dictmultiobject.py:1143-1150 AbstractTypedStrategy.switch_to_object_strategy`
 /// instantiation for IdentityDictStrategy — `wrap` is identity (`:26-27`), so
 /// the migration ports each `IdentityKey(obj)` into
@@ -255,8 +275,7 @@ impl DictStrategy for IdentityDictStrategy {
     /// on mismatch, promote to Object.
     unsafe fn delitem(&self, w_dict: PyObjectRef, w_key: PyObjectRef) -> bool {
         if Self::is_correct_type(w_key) {
-            let entries = identity_storage_mut(w_dict);
-            let removed = entries.shift_remove(&IdentityKey(w_key)).is_some();
+            let removed = w_dict_delete_identity_strategy(w_dict, w_key);
             if removed {
                 crate::dictmultiobject::w_dict_bump_keys_version(w_dict);
             }

--- a/pyre/pyre-object/src/identitydict.rs
+++ b/pyre/pyre-object/src/identitydict.rs
@@ -74,6 +74,28 @@ unsafe fn identity_storage<'a>(
     &*(dict.dstorage as *const indexmap::IndexMap<IdentityKey, PyObjectRef>)
 }
 
+/// Internal helper: `IdentityDictStrategy::getitem` body.  Caller must have
+/// already verified `is_correct_type(w_key)`.
+///
+/// Residualise the identity-storage getitem leaf (`@dont_look_inside`,
+/// `rlib/jit.py:139`), the twin of `dictmultiobject::w_dict_lookup_int_strategy`:
+/// the `IndexMap::get` it wraps is an external-crate heap-lookup the tracer
+/// cannot model — the oopspec'd residual arm of
+/// `rordereddict.ll_dict_getitem` (traced only for a virtual dict).
+/// [`IdentityKey`] hashes and compares by address, so the probe runs no user
+/// Python code at all.
+///
+/// # Safety
+/// `obj` must point to a valid `W_DictObject` on
+/// [`IDENTITY_DICT_STRATEGY`].
+#[majit_macros::dont_look_inside]
+pub unsafe fn w_dict_lookup_identity_strategy(
+    obj: PyObjectRef,
+    key: PyObjectRef,
+) -> Option<PyObjectRef> {
+    identity_storage(obj).get(&IdentityKey(key)).copied()
+}
+
 #[inline]
 unsafe fn identity_storage_mut<'a>(
     obj: PyObjectRef,
@@ -180,7 +202,7 @@ impl DictStrategy for IdentityDictStrategy {
     /// O(1) identity-keyed lookup.
     unsafe fn getitem(&self, w_dict: PyObjectRef, w_key: PyObjectRef) -> Option<PyObjectRef> {
         if Self::is_correct_type(w_key) {
-            return identity_storage(w_dict).get(&IdentityKey(w_key)).copied();
+            return w_dict_lookup_identity_strategy(w_dict, w_key);
         }
         // `identitydict.py:40-41 _never_equal_to` → always False, so
         // mismatched keys always promote and retry.

--- a/pyre/pyre-object/src/interp_exceptions.rs
+++ b/pyre/pyre-object/src/interp_exceptions.rs
@@ -694,21 +694,26 @@ pub unsafe fn w_exception_get_args(obj: PyObjectRef) -> PyObjectRef {
         // a freshly-allocated tuple.
         let items: Vec<PyObjectRef> = if crate::pyobject::is_list(stored) {
             let len = crate::listobject::w_list_len(stored) as i64;
-            (0..len)
-                .map(|i| {
-                    crate::listobject::w_list_getitem(stored, i).unwrap_or(crate::pyobject::PY_NULL)
-                })
-                .collect()
+            let mut items = Vec::with_capacity(len as usize);
+            for i in 0..len {
+                items.push(
+                    crate::listobject::w_list_getitem(stored, i)
+                        .unwrap_or(crate::pyobject::PY_NULL),
+                );
+            }
+            items
         } else if crate::pyobject::is_tuple(stored) {
             // Legacy compat — pre-list storage path; treat as already
             // a sequence and rebuild the tuple identically.
             let len = crate::tupleobject::w_tuple_len(stored) as i64;
-            (0..len)
-                .map(|i| {
+            let mut items = Vec::with_capacity(len as usize);
+            for i in 0..len {
+                items.push(
                     crate::tupleobject::w_tuple_getitem(stored, i)
-                        .unwrap_or(crate::pyobject::PY_NULL)
-                })
-                .collect()
+                        .unwrap_or(crate::pyobject::PY_NULL),
+                );
+            }
+            items
         } else {
             Vec::new()
         };

--- a/pyre/pyre-object/src/kwargsdict.rs
+++ b/pyre/pyre-object/src/kwargsdict.rs
@@ -73,6 +73,37 @@ pub fn kwargs_dict_storage_gc_type_id() -> u32 {
     KWARGS_DICT_STORAGE_GC_TYPE_ID.load(std::sync::atomic::Ordering::Relaxed)
 }
 
+/// `kwargsdict.py:134-141 switch_to_object_strategy` — walk the parallel
+/// arrays, rebuild `IndexMap<ObjectKey, PyObjectRef>`, retire the typed
+/// parallel-array box.
+///
+/// Residualised (`@dont_look_inside`, `rlib/jit.py:139`) for the reason
+/// `dictmultiobject::w_dict_switch_int_to_object_strategy` is: upstream traces
+/// the same loop because every step is an RPython dict primitive the JIT
+/// models, whereas this body is `IndexMap` end to end and the front end has no
+/// lowering for it, so the last modellable point is the call itself.
+///
+/// # Safety
+/// `w_dict` must be a valid `W_DictObject` on [`KWARGS_DICT_STRATEGY`].
+#[majit_macros::dont_look_inside]
+pub unsafe fn w_dict_switch_kwargs_to_object_strategy(w_dict: PyObjectRef) {
+    let dict = &mut *(w_dict as *mut crate::dictmultiobject::W_DictObject);
+    // Borrow the old typed box (its field stays live, so it is traced
+    // while the migration builds the object map); after the store the
+    // box is unreachable and the sweep reclaims it. `PyObjectRef` is a
+    // raw pointer (Copy), so iterate by reference and copy each slot.
+    let old = &*(dict.dstorage as *const KwargsDictStorage);
+    let mut new_map = crate::dictmultiobject::ObjectDictStorage::with_capacity(old.0.len());
+    for (k, v) in old.0.iter().zip(old.1.iter()) {
+        new_map.insert(crate::dictmultiobject::object_key_for(*k), *v);
+    }
+    dict.dstorage = crate::gc_storage::gc_alloc_storage_box(
+        new_map,
+        crate::dictmultiobject::object_dict_storage_gc_type_id(),
+    ) as *mut u8;
+    dict.dstrategy = &OBJECT_DICT_STRATEGY;
+}
+
 /// `kwargsdict.py:62` size threshold past which the strategy
 /// promotes itself to UnicodeDictStrategy to avoid O(n) lookup
 /// degeneracy on too-large kwarg dicts.
@@ -144,21 +175,7 @@ impl DictStrategy for KwargsDictStrategy {
     /// parallel arrays, rebuild `IndexMap<ObjectKey, PyObjectRef>`,
     /// retire the typed parallel-array box.
     unsafe fn switch_to_object_strategy(&self, w_dict: PyObjectRef) {
-        let dict = &mut *(w_dict as *mut crate::dictmultiobject::W_DictObject);
-        // Borrow the old typed box (its field stays live, so it is traced
-        // while the migration builds the object map); after the store the
-        // box is unreachable and the sweep reclaims it. `PyObjectRef` is a
-        // raw pointer (Copy), so iterate by reference and copy each slot.
-        let old = &*(dict.dstorage as *const KwargsDictStorage);
-        let mut new_map = crate::dictmultiobject::ObjectDictStorage::with_capacity(old.0.len());
-        for (k, v) in old.0.iter().zip(old.1.iter()) {
-            new_map.insert(crate::dictmultiobject::object_key_for(*k), *v);
-        }
-        dict.dstorage = crate::gc_storage::gc_alloc_storage_box(
-            new_map,
-            crate::dictmultiobject::object_dict_storage_gc_type_id(),
-        ) as *mut u8;
-        dict.dstrategy = &OBJECT_DICT_STRATEGY;
+        w_dict_switch_kwargs_to_object_strategy(w_dict);
     }
 
     /// `kwargsdict.py:100-108 getitem` — `is_correct_type` →

--- a/pyre/pyre-object/src/listobject.rs
+++ b/pyre/pyre-object/src/listobject.rs
@@ -1231,18 +1231,22 @@ unsafe fn temporarily_as_objects(list: &W_ListObject) -> Vec<PyObjectRef> {
         // listobject.py:1142 EmptyListStrategy.getitems returns [].
         ListStrategy::Empty => Vec::new(),
         ListStrategy::Object => list.object_to_vec(),
-        ListStrategy::Integer => list
-            .int_items
-            .as_slice()
-            .iter()
-            .map(|&v| w_int_new(v))
-            .collect(),
-        ListStrategy::Float => list
-            .float_items
-            .as_slice()
-            .iter()
-            .map(|&v| w_float_new(v))
-            .collect(),
+        ListStrategy::Integer => {
+            let items = list.int_items.as_slice();
+            let mut boxed = Vec::with_capacity(items.len());
+            for &v in items {
+                boxed.push(w_int_new(v));
+            }
+            boxed
+        }
+        ListStrategy::Float => {
+            let items = list.float_items.as_slice();
+            let mut boxed = Vec::with_capacity(items.len());
+            for &v in items {
+                boxed.push(w_float_new(v));
+            }
+            boxed
+        }
     }
 }
 

--- a/pyre/pyre-object/src/typeobject.rs
+++ b/pyre/pyre-object/src/typeobject.rs
@@ -740,6 +740,12 @@ pub unsafe fn w_type_get_uses_object_getattribute(obj: PyObjectRef) -> bool {
 }
 /// Write-side companion to [`w_type_get_uses_object_getattribute`]
 /// (typeobject.py:275, 315).
+///
+/// Mutates the per-type `uses_object_getattribute` atomic — a side effect on
+/// runtime type state the tracer cannot model, so the JIT residualises
+/// the call rather than tracing into it (`@dont_look_inside`,
+/// `rlib/jit.py:139`), the [`w_type_set_uses_object_setattr`] twin.
+#[majit_macros::dont_look_inside]
 pub unsafe fn w_type_set_uses_object_getattribute(obj: PyObjectRef, v: bool) {
     if obj.is_null() || !is_type(obj) {
         return;

--- a/pyre/pyre-object/src/unicodeobject.rs
+++ b/pyre/pyre-object/src/unicodeobject.rs
@@ -202,6 +202,84 @@ pub fn w_str_from_wtf8(value: Wtf8Buf) -> PyObjectRef {
     }) as PyObjectRef
 }
 
+/// Box one code point as a one-character `str`, `rutf8.unichr_as_utf8`
+/// (`rutf8.py:40`) under `_getitem_result` (`unicodeobject.py:1205`).
+///
+/// `#[dont_look_inside]` (`@jit.dont_look_inside`, `rlib/jit.py:139`), the
+/// [`w_str_new`] twin: the body encodes into a fresh `Wtf8Buf` and runs the
+/// unfused `malloc_typed` NewWithVtable behind it.  The code point crosses
+/// as its scalar value because a `CodePoint` is a struct, which the residual
+/// argument slots do not carry.
+///
+/// The value is `w_str_from_wtf8`'s, so a code point outside the Unicode
+/// range cannot reach here; an out-of-range word yields `U+FFFD` rather than
+/// constructing an invalid string.
+#[majit_macros::dont_look_inside]
+pub fn w_str_from_codepoint(code_point: u32) -> PyObjectRef {
+    let mut one = Wtf8Buf::new();
+    one.push(CodePoint::from_u32(code_point).unwrap_or(CodePoint::from_char('\u{fffd}')));
+    w_str_from_wtf8(one)
+}
+
+/// The code points at `start, start + step, …` boxed as a fresh `str` —
+/// `_unicode_sliced` / `descr_getslice` (`unicodeobject.py:1373-1379`).
+///
+/// `#[dont_look_inside]` (`@jit.dont_look_inside`, `rlib/jit.py:139`), the
+/// [`w_str_from_codepoint`] twin: the cut is assembled by pushing code
+/// points into a `Wtf8Buf`, and a mutable string builder has no counterpart
+/// in the immutable lifted string model.  The caller keeps the
+/// whole-string identity shortcut traced ahead of this call, so only a real
+/// cut reaches here.
+///
+/// # Safety
+/// `obj` must point to a valid `W_UnicodeObject`.
+#[majit_macros::dont_look_inside]
+pub unsafe fn w_str_slice_codepoints(
+    obj: PyObjectRef,
+    start: i64,
+    step: i64,
+    slicelength: i64,
+) -> PyObjectRef {
+    let mut result = Wtf8Buf::new();
+    let mut i = start;
+    for n in 0..slicelength {
+        if i >= 0
+            && let Some(cp) = unsafe { w_str_codepoint_at(obj, i as usize) }
+        {
+            result.push(cp);
+        }
+        if n + 1 < slicelength {
+            i += step;
+        }
+    }
+    w_str_from_wtf8(result)
+}
+
+/// `ll_strconcat` (`rstr.py:425-428`) — the two operands' WTF-8 buffers
+/// joined into a fresh collectable `str`.
+///
+/// `#[dont_look_inside]` (`@jit.dont_look_inside`, `rlib/jit.py:139`):
+/// upstream reaches concatenation through `@jit.oopspec('stroruni.concat')`
+/// rather than tracing the buffer build, and pyre's build — `Wtf8Buf`
+/// reserve plus two `push_wtf8` — has no lowering in the immutable lifted
+/// string model.
+///
+/// Concatenation is a dominant dynamic-churn producer and its result lives
+/// in GC-traced slots (locals, list/dict/set members), so the result is
+/// collectable.
+///
+/// # Safety
+/// `a` and `b` must point to valid `W_UnicodeObject`s.
+#[majit_macros::dont_look_inside]
+pub unsafe fn w_str_concat(a: PyObjectRef, b: PyObjectRef) -> PyObjectRef {
+    let sa = unsafe { w_str_get_wtf8(a) };
+    let sb = unsafe { w_str_get_wtf8(b) };
+    let mut result = Wtf8Buf::with_capacity(sa.len() + sb.len());
+    result.push_wtf8(sa);
+    result.push_wtf8(sb);
+    w_str_from_wtf8_managed(result)
+}
+
 /// Collectable `w_str_from_wtf8` for dynamic strings — see [`w_str_new_managed`].
 ///
 /// Builds config (b): a GC value box (greyed by the header `value` edge, tid 34
@@ -445,12 +523,63 @@ pub fn box_str_constant(value: &Wtf8) -> PyObjectRef {
 /// surrogate rather than silently corrupting.
 #[inline]
 pub unsafe fn w_str_get_value(obj: PyObjectRef) -> &'static str {
-    unsafe {
-        let str_obj = obj as *const W_UnicodeObject;
-        (*(*str_obj).value)
-            .as_str()
-            .expect("w_str_get_value: backing Wtf8Buf is not valid UTF-8 (lone surrogate)")
+    match unsafe { w_str_get_value_opt(obj) } {
+        Some(value) => value,
+        None => panic!("w_str_get_value: backing Wtf8Buf is not valid UTF-8 (lone surrogate)"),
     }
+}
+
+/// The `&str` view of a WTF-8 buffer already known to hold no lone
+/// surrogate.
+///
+/// `str`, `String`, `Wtf8` and `Wtf8Buf` all project to the single immutable
+/// lifted string value, so this is the identity `Wtf8::as_str` is minus the
+/// validity arm the caller has already taken — `as_str` itself hands back a
+/// `Result<&str, Utf8Error>` whose two-word `Ok` payload crosses no residual
+/// boundary, which is why the check and the view are split here.
+///
+/// # Safety
+/// `value` must be valid UTF-8; [`w_str_is_utf8`] is what decides that.
+#[inline]
+pub unsafe fn as_str_unchecked(value: &Wtf8) -> &str {
+    unsafe { std::str::from_utf8_unchecked(value.as_bytes()) }
+}
+
+/// Scan the buffer for the code point index of its first lone surrogate, or
+/// `-1` when every code point encodes as UTF-8.
+///
+/// `#[dont_look_inside]` (`@jit.dont_look_inside`, `rlib/jit.py:139`): the
+/// scan walks the whole buffer, and both answers it carries — the validity
+/// bit [`w_str_is_utf8`] tests and the error offset `str_utf8_w` reports —
+/// ride back in the one machine word.
+///
+/// # Safety
+/// `obj` must point to a valid `W_UnicodeObject`.
+#[majit_macros::dont_look_inside]
+pub unsafe fn w_str_first_surrogate(obj: PyObjectRef) -> i64 {
+    let value = unsafe { &*(*(obj as *const W_UnicodeObject)).value };
+    if value.as_str().is_ok() {
+        return -1;
+    }
+    value
+        .code_points()
+        .position(|cp| cp.to_char().is_none())
+        .map_or(0, |pos| pos as i64)
+}
+
+/// Whether the backing buffer has a `&str` view — false exactly when it
+/// carries a lone surrogate.
+///
+/// An ascii payload is one byte per code point (`unicodeobject.py:1245`
+/// `_length == len(_utf8)`) and so is valid UTF-8 by construction; the
+/// cached counts answer for it without touching the bytes, and anything
+/// else scans behind [`w_str_first_surrogate`].
+///
+/// # Safety
+/// `obj` must point to a valid `W_UnicodeObject`.
+#[inline]
+pub unsafe fn w_str_is_utf8(obj: PyObjectRef) -> bool {
+    unsafe { w_str_is_ascii(obj) || w_str_first_surrogate(obj) < 0 }
 }
 
 /// Borrow the WTF-8 view of a known W_UnicodeObject, surrogate-aware.
@@ -504,8 +633,10 @@ pub unsafe fn w_str_set_hash(obj: PyObjectRef, hash: i64) {
 #[inline]
 pub unsafe fn w_str_get_value_opt(obj: PyObjectRef) -> Option<&'static str> {
     unsafe {
-        let str_obj = obj as *const W_UnicodeObject;
-        (*(*str_obj).value).as_str().ok()
+        if !w_str_is_utf8(obj) {
+            return None;
+        }
+        Some(as_str_unchecked(w_str_get_wtf8(obj)))
     }
 }
 


### PR DESCRIPTION
Twenty slices against the rtyper census, plus the two front-end changes they
depended on. Each slice moves a call the rtyper has no lowering for behind a
named boundary, so the graph that reached it keeps going.

A twenty-first commit follows from the dyn-indirect default below: the
codewriter now emits `vtable_method_ptr/rd>i` into real jitcodes, so the
production blackhole's hand-curated insns map has to span that byte. Its
handler stays `unimplemented!()` — no layer consumes the op (no backend
lowering, the walker answers `UnsupportedOpname`, and `PyreVtableMethodDescr`
holds `(trait_root, method_name)` as strings with nothing resolving them to an
address). The walker's abort is what keeps it unreachable; the registration
only means a resume landing there names the missing op instead of reporting an
unwired byte.

## What is in here

**Residual-boundary slices (pyre)** — most of the branch. The recurring shapes:

- **Named leaves for probes that were routers.** `try_eq_w` splits into
  `has_eq_w_hook` + `eq_w_hooked`; `IdentityDictStrategy::getitem` gets its own
  lookup leaf; the module-dict entries probe residualizes instead of its router;
  the checked module-dict probe/store and the three leaves on the delete path
  follow.
- **Host seams.** fd-write, thread identity, the `SYS_MODULES` registry read,
  both entry-table probes, the `_warnings` state namespace, and the five
  typed-storage promotions.
- **Shapes the residual ABI could not carry.** `hash_str`'s pointer/length moves
  *inside* the boundary; the optional generator-throw arguments are indexed
  rather than `slice::get`'d; the receiver-discounted argument count is spelled
  without `saturating_sub`; the extended-slice walks are indexed.

**Front-end (majit).**

- `wrapping_{add,sub,mul}` folds on the unsigned word bank too. `usize`
  serializes as `{"UInt": "Usize"}`, which `tyref_literal_int_atom` does not see
  at all, so an `Int`-only test silently declined every unsigned counter. It is
  the same machine op under a different rtyper dispatch — `rint.py`'s `opprefix`
  makes it `uint_add`, and `jtransform.py:1608-1610` renames
  `uint_{add,sub,mul}` straight back to `int_{add,sub,mul}` for the JIT.
- **`dyn-indirect` routing is now the default.** `__dyn_call` is not a lowering,
  it is a placeholder: an unregistered synthetic path that stops whatever graph
  reaches it. Routing through `CallTarget::Indirect` is what `jtransform.py`'s
  `indirect_call` does. `PYRE_DYN_INDIRECT=0` is the kill switch.
- Two diagnostics: a `mergeinputargs` `UnionError` now carries `source_lines`
  context and quotes the block's operations.

**The last commit** clears eight walls at once. The largest is
`report_stack_underflow` — a cold panic reporter reached from a branch
`PyFrame::pop` never takes, whose instruction-window formatting was therefore
lowered into every graph that pops a value. `Wtf8::as_str` closes by
decomposition rather than by the cached-flag epic it looked like it needed:
`w_str_is_ascii` (`len == byte_len`) already implies valid UTF-8, so a one-word
`w_str_first_surrogate` scan plus an `as_str_unchecked` view that folds to its
receiver is enough. That commit message carries the per-wall table.

## Measurement

> [!WARNING]
> These figures were taken **before** this branch was rebased onto `#814`. The
> absolute count moves with the traced-source tree, so they are reported against
> their exact base rather than restated against the new one. The post-rebase
> tree has not been re-censused.

- base `66dada91c8` → phaseA **288**
- tip (pre-rebase `2e27e62601`) → phaseA **196**

Nine walls went to zero in the final commit alone: `CodeUnits::deref` 88,
`Wtf8::as_str` 33, `Map::collect` 8, `FnOnce::call_once` 7, `AtomicBool::store`
6, `Wtf8Buf::push` 4, `ctypes::borrow_memory` 4, `push_wtf8` 3, `set_async` 2.

That is −92, not the −148 those walls held. A graph that no longer stops at a
cleared wall does not become clean — it walks on to the next wall down its own
chain, so part of the count **relocates** rather than disappears
(`core::mem::drop` 2→14, `from_raw_parts` 2→9, `saturating_sub` 0→6). Budget a
wall slice at roughly 60% of the records it holds.

## Rebase note

`#814` independently widened the same `Vec` index gate this branch widened
(`ValueType::Int` → `Int | Unsigned` in `mir.rs`) — the one conflict. It
resolved to the helper form so the predicate is not spelled twice, and that
commit is reworded to state what it now does: extract `vec_index_type_is_scalar`
and pin both banks with a unit test that actually runs. The original trap was
caught only by the `#[ignore]`d real-LLBC anchor
`vec_index_mut_fill_user_function_args_real`, which needs the 440MB corpus and
does not run in CI.

The branch was then replayed again onto `78ebd2d842` (#865), picking up #869,
#838 and #871 as well. That is the base these numbers and checks describe.

## Verification

On `78ebd2d842`, after a full LLBC re-extract (the newer base touches 17
traced-crate files, so the corpus had to be rebuilt for the census-facing
tests to mean anything):

- `check.py` — dynasm 332/332, cranelift 332/332, wasm 329/329.
- `cargo test -p pyre-jit-trace -p majit-metainterp -p majit-translate
  --features dynasm` — 4952 passed, 0 failed.

Two macOS-only failures seen on an earlier push (`synth/sre_pattern_methods`
and `test.test_strtod`, both a silent `exit -10` under dynasm) were confirmed
**flaky**: re-running those jobs on the identical commit, with no code change,
passed both. They do not reproduce locally (18 runs) and `main` does not show
them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
