### PR TITLE
jit: virtualref producer prerequisites, FBW inline widening, and profile-driven hot-path fixes

### DIFF
--- a/majit/majit-metainterp/src/jitcode/assembler.rs
+++ b/majit/majit-metainterp/src/jitcode/assembler.rs
@@ -1918,7 +1918,7 @@ impl JitCodeBuilder {
 
     /// RPython `blackhole.py:527-533` `bhimpl_int_{neg,invert}` per-opname
     /// handlers. See `record_binop_i` for the keying rationale.
-    /// Byte layout follows `assembler.py:165-174`: each `Register` is
+    /// Byte layout follows `assembler.py`: each `Register` is
     /// emitted in argcode order, so `int_neg/i>i` stores `[src][dst]`
     /// matching the canonical `bhhandler_i_i!` decoder.
     pub fn record_unary_i(&mut self, dst: u16, opcode: OpCode, src: u16) {
@@ -1936,8 +1936,14 @@ impl JitCodeBuilder {
 
     /// RPython `blackhole.py:584-610` ref comparisons returning int:
     /// `ptr_eq`, `ptr_ne`, `instance_ptr_eq`, `instance_ptr_ne`.
-    /// Byte layout follows `assembler.py:165-174`: `[lhs][rhs][dst]`
+    /// Byte layout follows `assembler.py`: `[lhs][rhs][dst]`
     /// matching the canonical `bhhandler_rr_i!` decoder.
+    ///
+    /// Either comparand may be a constant — `x is None` compares against the
+    /// `None` singleton — and `assembler.py emit_const` gives such an
+    /// argument a constant-pool slot in place of a register index, so both
+    /// operands take the pool-aware toucher/pusher rather than the
+    /// real-register-only pair.
     pub fn record_binop_r(&mut self, dst: u16, opcode: OpCode, lhs: u16, rhs: u16) {
         let key = match opcode {
             OpCode::PtrEq => "ptr_eq/rr>i",
@@ -1947,11 +1953,11 @@ impl JitCodeBuilder {
             other => panic!("record_binop_r: unsupported opcode {other:?}"),
         };
         self.touch_reg(dst);
-        self.touch_ref_reg(lhs);
-        self.touch_ref_reg(rhs);
+        self.touch_ref_reg_or_pool_slot(lhs);
+        self.touch_ref_reg_or_pool_slot(rhs);
         self.write_insn(key);
-        self.push_u8(lhs as u8);
-        self.push_u8(rhs as u8);
+        self.push_reg_u8(lhs, "ptr binop lhs");
+        self.push_reg_u8(rhs, "ptr binop rhs");
         self.push_u8(dst as u8);
     }
 
@@ -4177,7 +4183,7 @@ impl JitCodeBuilder {
     }
 
     /// RPython `blackhole.py:638-640` `bhimpl_int_copy(a) returns=i`.
-    /// Byte layout follows `assembler.py:165-174`: each `Register` is
+    /// Byte layout follows `assembler.py`: each `Register` is
     /// emitted in argcode order, so `int_copy/i>i` stores `[src][dst]`
     /// and the `>i` result byte is the last operand.
     pub fn move_i(&mut self, dst: u16, src: u16) {

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -5517,7 +5517,7 @@ impl<S: JitState> JitDriver<S> {
         // `pyjitpl.py:3424 rebuild_state_after_failure` parity status:
         //
         //   * `ResumeDataResult.virtualref_values` (vref pair stream) is
-        //     restored into `sym.virtualref_boxes` and each pair fires
+        //     restored into `TraceCtx.virtualref_boxes` and each pair fires
         //     `vrefinfo.continue_tracing(vref, virtual)`
         //     (`virtualref.py:122-129`) inside
         //     `pyre-jit-trace::state::setup_bridge_sym` — matches the

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -1146,6 +1146,23 @@ pub struct JitDriver<S: JitState> {
     /// successful close-loop edge.
     continue_running_normally_payload: Option<(Vec<Value>, Option<usize>)>,
     descriptor: Option<JitDriverStaticData>,
+    /// Memoized [`Self::driver_descriptor_for`] answer.
+    ///
+    /// `warmspot.py:920-1015 make_driverhook_graphs` builds each
+    /// `JitDriverStaticData` once at translation time and stores it in
+    /// `metainterp_sd.jitdrivers_sd`; every runtime path then reads that one
+    /// object. Here the answer was rebuilt on each consultation instead —
+    /// either by cloning `descriptor` or by calling `JitState::driver_descriptor`
+    /// — which allocates the `vars` Vec plus one `String` per variable and frees
+    /// them again. Entering compiled code consults it, so a call-heavy program
+    /// paid that malloc/free pair per entry.
+    ///
+    /// The outer `Option` is "already resolved", the inner one is the answer.
+    /// Both producers are configuration-time constants: `descriptor` is only
+    /// written by `declare_schema`, `declare_schema_typed` and
+    /// `register_descriptor` (each of which clears this cache), and no
+    /// `JitState::driver_descriptor` implementation reads its `meta` argument.
+    descriptor_cache: Option<Option<std::sync::Arc<JitDriverStaticData>>>,
     /// resume.py:1042: result of rebuild_from_resumedata for bridge tracing.
     /// RPython stores this in MIFrame registers; pyre stores it here
     /// for the caller to initialize PyreSym slot-to-OpRef mapping.
@@ -1345,6 +1362,7 @@ impl<S: JitState> JitDriver<S> {
             compile_trace_success: false,
             continue_running_normally_payload: None,
             descriptor: None,
+            descriptor_cache: None,
             resume_data_result: None,
             last_bridge_is_exception_guard: false,
             bridge_body_start_op_count: None,
@@ -1580,6 +1598,7 @@ impl<S: JitState> JitDriver<S> {
             return;
         }
         self.descriptor = Some(JitDriverStaticData::new(greens, reds));
+        self.descriptor_cache = None;
     }
 
     /// [`Self::declare_schema`] variant whose green list carries the
@@ -1599,6 +1618,7 @@ impl<S: JitState> JitDriver<S> {
             return;
         }
         self.descriptor = Some(JitDriverStaticData::with_green_types(greens, reds));
+        self.descriptor_cache = None;
     }
 
     pub fn with_descriptor(threshold: u32, descriptor: JitDriverStaticData) -> Self {
@@ -1695,6 +1715,7 @@ impl<S: JitState> JitDriver<S> {
         // — A.3.1a's accessor reads through descriptor, not the
         // staticdata Vec, so the stamped clone must live on the driver too.
         self.descriptor = Some(sd_mut.jitdrivers_sd[idx].clone());
+        self.descriptor_cache = None;
         idx
     }
 
@@ -3420,7 +3441,7 @@ impl<S: JitState> JitDriver<S> {
                 self.meta.invalidate_loop(green_key);
                 return None;
             }
-            if !self.sync_before(state, &compiled_meta, descriptor.as_ref()) {
+            if !self.sync_before(state, &compiled_meta, descriptor.as_deref()) {
                 return None;
             }
             let mut live_values = if let Some(values) = direct_live_values {
@@ -3428,7 +3449,7 @@ impl<S: JitState> JitDriver<S> {
             } else {
                 let live_values = state.extract_live_values(&compiled_meta);
                 if !Self::live_values_match_descriptor(
-                    descriptor.as_ref(),
+                    descriptor.as_deref(),
                     &live_values,
                     state.state_field_layout().total_live_values(),
                 ) {
@@ -3438,7 +3459,7 @@ impl<S: JitState> JitDriver<S> {
                     green_key,
                     state,
                     &compiled_meta,
-                    descriptor.as_ref(),
+                    descriptor.as_deref(),
                     live_values,
                 ) else {
                     return None;
@@ -3551,7 +3572,7 @@ impl<S: JitState> JitDriver<S> {
                     state.restore_values(&run_meta, &result.typed_values);
                 }
                 let run_descriptor = self.driver_descriptor_for(state, &run_meta);
-                self.sync_after(state, &run_meta, run_descriptor.as_ref());
+                self.sync_after(state, &run_meta, run_descriptor.as_deref());
                 return Some(target_pc);
             }
 
@@ -3562,7 +3583,7 @@ impl<S: JitState> JitDriver<S> {
                     state.restore_values(&run_meta, &result.typed_values);
                 }
                 let run_descriptor = self.driver_descriptor_for(state, &run_meta);
-                self.sync_after(state, &run_meta, run_descriptor.as_ref());
+                self.sync_after(state, &run_meta, run_descriptor.as_deref());
                 return Some(target_pc);
             }
 
@@ -4105,12 +4126,12 @@ impl<S: JitState> JitDriver<S> {
         self.republish_state_field_fvc();
         let meta = state.build_meta(target_pc, env);
         let descriptor = self.driver_descriptor_for(state, &meta);
-        if !self.sync_before(state, &meta, descriptor.as_ref()) {
+        if !self.sync_before(state, &meta, descriptor.as_deref()) {
             return;
         }
         let live_values = state.extract_live_values(&meta);
         if !Self::live_values_match_descriptor(
-            descriptor.as_ref(),
+            descriptor.as_deref(),
             &live_values,
             state.state_field_layout().total_live_values(),
         ) {
@@ -4120,7 +4141,7 @@ impl<S: JitState> JitDriver<S> {
         match self.meta.force_start_tracing(
             green_key,
             (state.code_ptr(), target_pc),
-            descriptor,
+            descriptor.map(|d| (*d).clone()),
             &live_values,
         ) {
             BackEdgeAction::StartedTracing => {
@@ -4155,12 +4176,12 @@ impl<S: JitState> JitDriver<S> {
         self.take_single_pass_label_entry_dispatch_key_for_back_edge(green_key);
         let meta = state.build_meta(target_pc, env);
         let descriptor = self.driver_descriptor_for(state, &meta);
-        if !self.sync_before(state, &meta, descriptor.as_ref()) {
+        if !self.sync_before(state, &meta, descriptor.as_deref()) {
             return;
         }
         let live_values = state.extract_live_values(&meta);
         if !Self::live_values_match_descriptor(
-            descriptor.as_ref(),
+            descriptor.as_deref(),
             &live_values,
             state.state_field_layout().total_live_values(),
         ) {
@@ -4171,7 +4192,7 @@ impl<S: JitState> JitDriver<S> {
             green_key,
             (state.code_ptr(), target_pc),
             None,
-            descriptor,
+            descriptor.map(|d| (*d).clone()),
             &live_values,
         ) {
             BackEdgeAction::StartedTracing => {
@@ -4205,12 +4226,12 @@ impl<S: JitState> JitDriver<S> {
         }
         let meta = state.build_meta(target_pc, env);
         let descriptor = self.driver_descriptor_for(state, &meta);
-        if !self.sync_before(state, &meta, descriptor.as_ref()) {
+        if !self.sync_before(state, &meta, descriptor.as_deref()) {
             return;
         }
         let live_values = state.extract_live_values(&meta);
         if !Self::live_values_match_descriptor(
-            descriptor.as_ref(),
+            descriptor.as_deref(),
             &live_values,
             state.state_field_layout().total_live_values(),
         ) {
@@ -4221,7 +4242,7 @@ impl<S: JitState> JitDriver<S> {
             green_key,
             (state.code_ptr(), target_pc),
             structured_green_key,
-            descriptor,
+            descriptor.map(|d| (*d).clone()),
             &live_values,
         ) {
             BackEdgeAction::Interpret => {}
@@ -4243,10 +4264,27 @@ impl<S: JitState> JitDriver<S> {
         }
     }
 
-    fn driver_descriptor_for(&self, state: &S, meta: &S::Meta) -> Option<JitDriverStaticData> {
-        self.descriptor
+    /// The driver's static data, resolved once and then shared.
+    ///
+    /// See [`Self::descriptor_cache`] for why the answer is memoized rather
+    /// than rebuilt per consultation. Callers that need to hand ownership on
+    /// (the trace-start and bridge-setup paths) clone out of the shared value;
+    /// the per-entry paths only read through it.
+    fn driver_descriptor_for(
+        &mut self,
+        state: &S,
+        meta: &S::Meta,
+    ) -> Option<std::sync::Arc<JitDriverStaticData>> {
+        if let Some(cached) = &self.descriptor_cache {
+            return cached.clone();
+        }
+        let resolved = self
+            .descriptor
             .clone()
             .or_else(|| state.driver_descriptor(meta))
+            .map(std::sync::Arc::new);
+        self.descriptor_cache = Some(resolved.clone());
+        resolved
     }
 
     fn live_values_match_descriptor(
@@ -4629,7 +4667,7 @@ impl<S: JitState> JitDriver<S> {
             };
         };
         let descriptor = self.driver_descriptor_for(state, &meta);
-        if !state.is_compatible(&meta) || !self.sync_before(state, &meta, descriptor.as_ref()) {
+        if !state.is_compatible(&meta) || !self.sync_before(state, &meta, descriptor.as_deref()) {
             return DetailedDriverRunOutcome::Abort {
                 restored: false,
                 via_blackhole: false,
@@ -4648,7 +4686,7 @@ impl<S: JitState> JitDriver<S> {
             );
         }
         if !Self::live_values_match_descriptor(
-            descriptor.as_ref(),
+            descriptor.as_deref(),
             &live_values,
             state.state_field_layout().total_live_values(),
         ) {
@@ -4661,7 +4699,7 @@ impl<S: JitState> JitDriver<S> {
             green_key,
             state,
             &meta,
-            descriptor.as_ref(),
+            descriptor.as_deref(),
             live_values,
         ) else {
             return DetailedDriverRunOutcome::Abort {
@@ -4726,7 +4764,7 @@ impl<S: JitState> JitDriver<S> {
 
         let exit_meta = result.meta.clone();
         state.restore_values(&exit_meta, &result.typed_values);
-        self.sync_after(state, &exit_meta, descriptor.as_ref());
+        self.sync_after(state, &exit_meta, descriptor.as_deref());
         DetailedDriverRunOutcome::Jump {
             via_blackhole: false,
             continue_running_normally_values: None,
@@ -4781,7 +4819,7 @@ impl<S: JitState> JitDriver<S> {
                 via_blackhole: false,
             };
         }
-        if !self.sync_before(state, &meta, descriptor.as_ref()) {
+        if !self.sync_before(state, &meta, descriptor.as_deref()) {
             if crate::majit_log_enabled() {
                 eprintln!(
                     "[jit][run-compiled-abort] key={} reason=sync-before target_pc={}",
@@ -4806,7 +4844,7 @@ impl<S: JitState> JitDriver<S> {
             );
         }
         if !Self::live_values_match_descriptor(
-            descriptor.as_ref(),
+            descriptor.as_deref(),
             &live_values,
             state.state_field_layout().total_live_values(),
         ) {
@@ -4828,7 +4866,7 @@ impl<S: JitState> JitDriver<S> {
             green_key,
             state,
             &meta,
-            descriptor.as_ref(),
+            descriptor.as_deref(),
             live_values,
         ) else {
             if crate::majit_log_enabled() {
@@ -4889,7 +4927,7 @@ impl<S: JitState> JitDriver<S> {
         // Normal loop back-edge JUMP, not a guard failure.
         if fail_index == u32::MAX {
             state.restore_values(&exit_meta, &typed_values);
-            self.sync_after(state, &exit_meta, descriptor.as_ref());
+            self.sync_after(state, &exit_meta, descriptor.as_deref());
             return DetailedDriverRunOutcome::Jump {
                 via_blackhole: false,
                 continue_running_normally_values: None,
@@ -5654,7 +5692,7 @@ impl<S: JitState> JitDriver<S> {
             .expect("bridge: tracing context must be live after start_retrace_from_guard");
         ctx.header_pc = resume_pc;
         if let Some(descriptor) = bridge_driver_descriptor {
-            ctx.set_driver_descriptor(descriptor);
+            ctx.set_driver_descriptor((*descriptor).clone());
         }
         // pyjitpl.py:2978 `if not self.partial_trace:` — bridge
         // entry sets the explicit flag so close-loop consumers
@@ -5887,12 +5925,12 @@ impl<S: JitState> JitDriver<S> {
         }
         let meta = meta.clone();
         let descriptor = self.driver_descriptor_for(state, &meta);
-        if !self.sync_before(state, &meta, descriptor.as_ref()) {
+        if !self.sync_before(state, &meta, descriptor.as_deref()) {
             return None;
         }
         let live_values = state.extract_live_values(&meta);
         if !Self::live_values_match_descriptor(
-            descriptor.as_ref(),
+            descriptor.as_deref(),
             &live_values,
             state.state_field_layout().total_live_values(),
         ) {
@@ -5902,7 +5940,7 @@ impl<S: JitState> JitDriver<S> {
             key_hash,
             state,
             &meta,
-            descriptor.as_ref(),
+            descriptor.as_deref(),
             live_values,
         )?;
         let mut live_values = live_values;
@@ -5999,16 +6037,16 @@ impl<S: JitState> JitDriver<S> {
                     );
                 }
                 state.restore_values(&result_meta, &typed_values);
-                self.sync_after(state, &result_meta, descriptor.as_ref());
+                self.sync_after(state, &result_meta, descriptor.as_deref());
                 // Re-enter compiled code if state is still compatible
                 if let Some(meta) = self.meta.get_compiled_meta(key_hash) {
                     if state.is_compatible(meta) {
                         let meta = meta.clone();
                         let nd = self.driver_descriptor_for(state, &meta);
-                        if self.sync_before(state, &meta, nd.as_ref()) {
+                        if self.sync_before(state, &meta, nd.as_deref()) {
                             let nl = state.extract_live_values(&meta);
                             if Self::live_values_match_descriptor(
-                                nd.as_ref(),
+                                nd.as_deref(),
                                 &nl,
                                 state.state_field_layout().total_live_values(),
                             ) {
@@ -6016,7 +6054,7 @@ impl<S: JitState> JitDriver<S> {
                                     key_hash,
                                     state,
                                     &meta,
-                                    nd.as_ref(),
+                                    nd.as_deref(),
                                     nl,
                                 ) {
                                     live_values = v;
@@ -6091,7 +6129,7 @@ impl<S: JitState> JitDriver<S> {
                 // Restore state for bridge tracing start point.
                 let resume_pc = on_guard_failure(state, &result_meta, &raw_values, &exit_layout);
                 let resume_pc = resume_pc.unwrap_or(guard_resume_pc);
-                self.sync_after(state, &result_meta, descriptor.as_ref());
+                self.sync_after(state, &result_meta, descriptor.as_deref());
 
                 let bridge_ok = self.start_bridge_tracing(
                     &descr_arc,
@@ -6278,7 +6316,7 @@ impl<S: JitState> JitDriver<S> {
             self.prepare_exit_resume_heap_with_blackhole_allocator(&exit_layout, &raw_values);
             let resume_pc = on_guard_failure(state, &result_meta, &raw_values, &exit_layout);
             let resume_pc = resume_pc.unwrap_or(target_pc);
-            self.sync_after(state, &result_meta, descriptor.as_ref());
+            self.sync_after(state, &result_meta, descriptor.as_deref());
             return Some(resume_pc);
         } // end loop { run_compiled ... }
     }

--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -1125,9 +1125,11 @@ impl OptHeap {
     /// force_lazy_set (heap.py:122-145) emits unconditionally; the
     /// virtual-rhs skip belongs only to force_lazy_sets_for_guard
     /// (heap.py:610-639), which routes those ops to rd_pendingfields
-    /// before they ever reach this fn. A virtual rhs here is
-    /// materialized first, the way Optimizer._emit_operation forces
-    /// every emitted arg (optimizer.py:345-364 force_box).
+    /// before they ever reach this fn. A virtual rhs is left virtual
+    /// here: force_lazy_set never forces its rhs, and the queued op
+    /// carries it to `Optimizer::emit_operation`, whose force_box loop
+    /// (optimizer.py:641-665) is the single force point that appends
+    /// the materialization directly ahead of the store.
     ///
     /// `get_rhs`: polymorphic RHS extractor matching
     /// `AbstractCachedEntry._get_rhs_from_set_op` (heap.py:169-170 /
@@ -1171,8 +1173,9 @@ impl OptHeap {
 
     fn emit_lazy_setfield(op: &mut Op, ctx: &mut OptContext, get_rhs: fn(&Op) -> Operand) {
         let rhs = get_rhs(op);
-        let resolved_box = ctx.resolve_operand_operand_opt(&rhs);
-        let rhs_is_virtual = resolved_box.as_ref().map_or(false, |b| ctx.is_virtual(b));
+        let rhs_is_virtual = ctx
+            .resolve_operand_operand_opt(&rhs)
+            .map_or(false, |b| ctx.is_virtual(&b));
         // A virtual value stored into the standard virtualizable frame is
         // deferred, not flushed: the frame is a tracked existing object whose
         // fields are reconstructed at resume (guard pendingfields, via
@@ -1184,17 +1187,6 @@ impl OptHeap {
         if rhs_is_virtual && Self::writes_into_virtualizable(op, ctx) {
             return;
         }
-        // Virtualizable exemption mirrors Optimizer::force_box: a
-        // virtualizable tracks an existing heap object, not a deferred
-        // allocation; forcing it would destroy the tracked field state.
-        if rhs_is_virtual
-            && !resolved_box
-                .as_ref()
-                .map_or(false, |b| ctx.is_virtualizable(b))
-        {
-            ctx.force_box_inline(rhs.to_opref());
-        }
-
         // Resolve forwarding and route after heap
         // optimizer.py:651-652 setarg loop parity.
         for i in 0..op.num_args() {

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -11697,6 +11697,7 @@ impl<M: Clone> MetaInterp<M> {
         let vinfo = self.virtualizable_info();
         let all_liveness = self.staticdata.liveness_info.as_slice();
         let (all_virtuals_ptr, all_virtuals_int) = crate::resume::force_from_resumedata(
+            &self.staticdata.profiler,
             rd_numb,
             rd_consts,
             all_liveness,

--- a/majit/majit-metainterp/src/resume.rs
+++ b/majit/majit-metainterp/src/resume.rs
@@ -7514,6 +7514,7 @@ pub fn blackhole_from_resumedata<'a>(
 /// Used for GUARD_NOT_FORCED handling.
 /// Returns (virtuals_cache_ptr, virtuals_cache_int) — RPython VirtualCache parity.
 pub fn force_from_resumedata<'a>(
+    profiler: &crate::jitprof::JitProfiler,
     rd_numb: &'a [u8],
     rd_consts: &'a [majit_ir::Const],
     all_liveness: &'a [u8],
@@ -7526,6 +7527,8 @@ pub fn force_from_resumedata<'a>(
     ginfo: Option<&dyn GreenfieldInfo>,
     allocator: &'a dyn BlackholeAllocator,
 ) -> (Vec<i64>, Vec<i64>) {
+    // resume.py:1346
+    profiler.count(crate::pyjitpl::counters::FORCE_VIRTUALIZABLES, 1);
     // resume.py:1347-1348
     let mut resumereader = ResumeDataDirectReader::new(
         rd_numb,

--- a/majit/majit-metainterp/src/virtualref.rs
+++ b/majit/majit-metainterp/src/virtualref.rs
@@ -152,7 +152,7 @@ pub unsafe fn vref_forced(ptr: *const u8) -> *mut u8 {
 /// InvalidVirtualRef`); re-exported here for convenience.
 pub use crate::jit::InvalidVirtualRef;
 
-/// Allocate a concrete JitVirtualRef on the heap.
+/// Allocate a concrete JitVirtualRef.
 /// `virtualref.py:85-91 virtual_ref_during_tracing(real_object)`.
 /// Initializes virtual_token = TOKEN_NONE, forced = real_object.
 /// Returns raw pointer; caller owns the allocation.

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -11369,6 +11369,20 @@ pub fn unpackiterable(
         // `return items`); read it back into the `Vec<PyObjectRef>` the Rust
         // signature promises here, outside the traced/blackholed drain body.
         let w_list = _unpackiterable_unknown_length(w_iterator, w_iterable)?;
+        // `warmspot.py:998-1005` re-raises `ExitFrameWithExceptionRef` out of
+        // `ll_portal_runner`.  jd1 is entered from a merge-point hook that
+        // returns unit, so a recording walk that ran the raising `next()` for
+        // real parks the error instead; surface it here, at the first host-side
+        // point after the drain.  It cannot be surfaced inside the drain loop:
+        // that body is the jitcode the jd1 walker records, and a `Result` shell
+        // of its own there is a discriminant switch over niladic constructors
+        // with no host symbol — `try_fuse_drain_match`
+        // (majit-translate front/result_exc.rs) rewrites only the one such
+        // shell it recognises, the `match next(w_iterator)` at the loop's core,
+        // and the walker faults executing any other.  The walk leaves a
+        // truncated list when it parked; raising discards it, which is what the
+        // raise means.
+        crate::stack_check::drain_jit_pending_exception()?;
         Ok(drain_collect_items(w_list))
     } else {
         // baseobjspace.py:996-998 — known-length path with shape validation.
@@ -11564,15 +11578,6 @@ fn _unpackiterable_unknown_length(
         // baseobjspace.py:1012
         // `unpackiterable_driver.jit_merge_point(greenkey=greenkey)`.
         unpackiterable_driver.jit_merge_point(greenkey, w_iterator, items);
-        // `warmspot.py:998-1005` re-raises `ExitFrameWithExceptionRef` out of
-        // `ll_portal_runner`, so upstream's merge point is an raising call.
-        // The hook returns unit, so a drain that ran the raising `next()` for
-        // real parks the error instead; surface it here, at the same point the
-        // portal's raise would have landed. Deferring to the `next()` below
-        // loses it whenever the iterator is not exhaustion-stable: it reports
-        // StopIteration on the retry and this drain returns a truncated list
-        // with the error still parked for an unrelated later call.
-        crate::stack_check::drain_jit_pending_exception()?;
         match next(w_iterator) {
             Ok(w_item) => unsafe { pyre_object::listobject::drain_list_append(items, w_item) },
             // `except OperationError as e: if not e.match(space,

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -8719,13 +8719,18 @@ pub fn load_special_resolve(obj: PyObjectRef, name: &str) -> Result<PyObjectRef,
 /// `CALL`.
 ///
 /// Returns `Some((w_type, version_tag, w_descr))` for the
-/// plain-instance-method case the fast path binds `self` for
-/// (callmethod.py:55-68); `None` (fall back to `getattr`) for every other
-/// receiver / descriptor shape.  Mirror of `callmethod.py`:
-/// `has_object_getattribute()` (line 33), `version_tag()` (line 56),
-/// `_pure_lookup_where_with_method_cache` (line 59),
-/// `flag_method_descriptor` (line 66), and the instance-dict shadowing
-/// check (line 66).
+/// plain-instance-method case the fast path binds `self` for; `None` (fall
+/// back to `getattr`) for every other receiver / descriptor shape.  Mirror of
+/// `callmethod.py`: `has_object_getattribute()`, `version_tag()`,
+/// `_pure_lookup_where_with_method_cache`, `flag_method_descriptor`, and the
+/// instance-dict shadowing check.
+///
+/// The gate is the receiver's Python class, never its payload layout —
+/// `LOAD_METHOD` opens with `w_type = space.type(w_obj)` and asks nothing else
+/// about `w_obj`.  An exception subclass instance is a `W_BaseException`
+/// rather than a `W_ObjectObject`, so a layout gate here would leave every
+/// `e.method()` on it resolving through `getattr` into a fresh bound `Method`,
+/// which the tracer cannot inline.
 ///
 /// # Safety
 /// `w_obj` must be a valid object pointer (null tolerated).
@@ -8733,13 +8738,11 @@ pub unsafe fn load_method_fast_path(
     w_obj: PyObjectRef,
     name: &str,
 ) -> Option<(PyObjectRef, u64, PyObjectRef)> {
-    if w_obj.is_null() || !is_instance(w_obj) {
+    if w_obj.is_null() {
         return None;
     }
-    let w_type = w_instance_get_type(w_obj);
-    if w_type.is_null() {
-        return None;
-    }
+    // callmethod.py `w_type = space.type(w_obj)`.
+    let w_type = crate::typedef::r#type(w_obj)?.as_ptr();
     // typeobject.py:56-58 `version_tag = self.version_tag()`; `None`
     // (uncacheable) is `0` here.
     let version_tag = pyre_object::typeobject::w_type_get_version_tag(w_type);
@@ -8764,11 +8767,9 @@ pub unsafe fn load_method_fast_path(
     if !pyre_object::typeobject::w_type_get_flag_method_descriptor(w_descr_type.as_ptr()) {
         return None;
     }
-    // callmethod.py:66-67 `w_value = w_obj.getdictvalue(space, name)`: a
-    // shadowing instance attribute means the method is not bound.
-    if crate::objspace::std::mapdict::instance_node_getdictvalue(w_obj, Wtf8::new(name)).is_some() {
-        return None;
-    }
+    // callmethod.py `w_value = w_obj.getdictvalue(space, name)`: a shadowing
+    // instance attribute means the method is not bound.
+    instance_dict_does_not_shadow(w_obj, name)?;
     Some((w_type, version_tag, w_descr))
 }
 
@@ -8817,6 +8818,46 @@ pub unsafe fn classmethod_on_type_fast_path(
         return None;
     }
     Some((w_type, version_tag, w_func))
+
+/// `callmethod.py`'s `w_obj.getdictvalue(space, name)` shadowing check,
+/// restricted to a probe that neither allocates nor runs Python.
+///
+/// [`getdict`] installs a fresh instance dictionary on several layouts
+/// (exceptions, bytes, bytearray), and a `LOAD_METHOD` that materialises one
+/// has changed the receiver just by looking at it.  The tracer shares this
+/// predicate, so it must also stay free of anything that could run a user
+/// `__eq__`.
+///
+/// `Some(())` = no instance attribute of this name shadows the type lookup,
+/// proven without touching the receiver.  `None` = either a shadowing entry,
+/// or a layout this cannot answer for — both decline the fast path.
+///
+/// # Safety
+/// `w_obj` must be a valid, non-null object pointer.
+unsafe fn instance_dict_does_not_shadow(w_obj: PyObjectRef, name: &str) -> Option<()> {
+    if is_instance(w_obj) {
+        // Mapdict side storage: the entry lookup reads the map chain and
+        // allocates nothing.
+        return crate::objspace::std::mapdict::instance_node_getdictvalue(w_obj, Wtf8::new(name))
+            .is_none()
+            .then_some(());
+    }
+    if pyre_object::is_exception(w_obj) {
+        // The `descr_reduce` peek: the raw `w_dict` slot, `PY_NULL` until the
+        // instance grows a dictionary.  A receiver that already carries one is
+        // declined rather than probed, since `finditem_str` on it can run a
+        // user `__eq__` against a colliding non-string key.  This is stricter
+        // than `callmethod.py`, and it is also what lets the tracer express
+        // the shadowing precondition as a single "slot is null" guard.
+        return pyre_object::interp_exceptions::w_exception_peek_dict(w_obj)
+            .is_null()
+            .then_some(());
+    }
+    // Every other layout (list / str / tuple / native-payload subclasses)
+    // keeps its instance attributes somewhere this probe does not read yet.
+    // Adding a layout means adding its non-allocating dictionary peek here and
+    // the matching shadowing guard on the tracer side.
+    None
 }
 
 /// The `getattr(w_obj, name)` shape that reduces, purely, to

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -8818,6 +8818,7 @@ pub unsafe fn classmethod_on_type_fast_path(
         return None;
     }
     Some((w_type, version_tag, w_func))
+}
 
 /// `callmethod.py`'s `w_obj.getdictvalue(space, name)` shadowing check,
 /// restricted to a probe that neither allocates nor runs Python.

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -11522,6 +11522,15 @@ fn _unpackiterable_unknown_length(
         // baseobjspace.py:1012
         // `unpackiterable_driver.jit_merge_point(greenkey=greenkey)`.
         unpackiterable_driver.jit_merge_point(greenkey, w_iterator, items);
+        // `warmspot.py:998-1005` re-raises `ExitFrameWithExceptionRef` out of
+        // `ll_portal_runner`, so upstream's merge point is an raising call.
+        // The hook returns unit, so a drain that ran the raising `next()` for
+        // real parks the error instead; surface it here, at the same point the
+        // portal's raise would have landed. Deferring to the `next()` below
+        // loses it whenever the iterator is not exhaustion-stable: it reports
+        // StopIteration on the retry and this drain returns a truncated list
+        // with the error still parked for an unrelated later call.
+        crate::stack_check::drain_jit_pending_exception()?;
         match next(w_iterator) {
             Ok(w_item) => unsafe { pyre_object::listobject::drain_list_append(items, w_item) },
             // `except OperationError as e: if not e.match(space,

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -114,7 +114,7 @@ pub(crate) unsafe fn walk_pending_hash_error_area(
 pub fn clear_method_cache() {
     let mut cache = METHOD_CACHE.lock();
     cache.versions.fill(0);
-    cache.names.fill(None);
+    cache.names.fill(std::ptr::null_mut());
     cache
         .lookup_where
         .fill((std::ptr::null_mut(), std::ptr::null_mut()));
@@ -8338,9 +8338,18 @@ pub(crate) unsafe fn lookup_in_type_wtf8(w_type: PyObjectRef, name: &Wtf8) -> Op
 /// `(null, null)` pair on a valid `(version, name)` entry is the cached
 /// negative result (`_lookup_where_all_typeobjects` returned
 /// `(None, None)`).
+///
+/// `names[h]` holds the interned name *object* and is validated by identity
+/// (`typeobject.py:541` `cache.names[method_hash] is name`), so a probe costs
+/// one pointer compare rather than a digest plus a `memcmp` over the bytes,
+/// and a fill stores the pointer rather than allocating a copy of the name.
+/// Every name reaching the cache comes from `box_str_constant`, which
+/// allocates through `malloc_typed`: the object is immortal and never
+/// relocated, so the slot needs no GC forwarding and its address is never
+/// reused by a later, different name (`null` = empty).
 struct MethodCache {
     versions: Vec<u64>,
-    names: Vec<Option<String>>,
+    names: Vec<PyObjectRef>,
     lookup_where: Vec<(PyObjectRef, PyObjectRef)>,
 }
 
@@ -8357,7 +8366,7 @@ static METHOD_CACHE: std::sync::LazyLock<parking_lot::Mutex<MethodCache>> =
     std::sync::LazyLock::new(|| {
         parking_lot::Mutex::new(MethodCache {
             versions: vec![0u64; METHOD_CACHE_SIZE],
-            names: vec![None; METHOD_CACHE_SIZE],
+            names: vec![std::ptr::null_mut(); METHOD_CACHE_SIZE],
             lookup_where: vec![(std::ptr::null_mut(), std::ptr::null_mut()); METHOD_CACHE_SIZE],
         })
     });
@@ -8366,12 +8375,16 @@ static METHOD_CACHE: std::sync::LazyLock<parking_lot::Mutex<MethodCache>> =
 /// version token directly (PyPy hashes `current_object_addr_as_int(
 /// version_tag)`; the u64 is its own address-stable surrogate).
 /// `name_hash` only needs to be deterministic — the slot's validity is
-/// the exact `(version, name)` match, not the hash — so an FNV-1a over
-/// the bytes stands in for `compute_hash(name)`.
-fn method_hash(version_tag: u64, name: &str) -> usize {
+/// the exact `(version, name)` match, not the hash.  Upstream's
+/// `hash(name)` is the interned string's memoized digest, i.e. a
+/// per-name-object constant; the interned pointer is the same constant
+/// without the byte walk, so an FNV-1a over its bytes stands in.  Two
+/// threads that interned the same name into different objects then land
+/// in different slots instead of evicting each other from a shared one.
+fn method_hash(version_tag: u64, w_name: PyObjectRef) -> usize {
     let mut name_hash: u64 = 0xcbf2_9ce4_8422_2325;
-    for b in name.as_bytes() {
-        name_hash ^= *b as u64;
+    for b in (w_name as usize as u64).to_le_bytes() {
+        name_hash ^= b as u64;
         name_hash = name_hash.wrapping_mul(0x0000_0100_0000_01b3);
     }
     const SHIFT2: u32 = 64 - METHOD_CACHE_SIZE_EXP;
@@ -8439,14 +8452,13 @@ pub unsafe fn _pure_lookup_where_with_method_cache(
     w_name: PyObjectRef,
     version_tag: u64,
 ) -> PyObjectRef {
-    let name = pyre_object::unicodeobject::w_str_get_value(w_name);
     // PyPy's elidable returns the cached `(w_class, w_value)` tuple
     // object; the residual-call ABI here carries one raw register, so
     // the elidable surface projects the `w_value` half.  Callers that
     // need the defining class go through the interpreter front door
     // `lookup_where_with_method_cache`, which reads the same cache
     // entry.
-    _cached_lookup_where(w_type, name, version_tag).1
+    _cached_lookup_where(w_type, w_name, version_tag).1
 }
 
 /// `lookup_where` *class* projection — the `@elidable` companion of
@@ -8470,8 +8482,7 @@ pub unsafe fn _pure_lookup_class_with_method_cache(
     w_name: PyObjectRef,
     version_tag: u64,
 ) -> PyObjectRef {
-    let name = pyre_object::unicodeobject::w_str_get_value(w_name);
-    _cached_lookup_where(w_type, name, version_tag).0
+    _cached_lookup_where(w_type, w_name, version_tag).0
 }
 
 /// The `MethodCache` probe/fill shared by the `@elidable` JIT surface
@@ -8479,16 +8490,21 @@ pub unsafe fn _pure_lookup_class_with_method_cache(
 /// slot; on a miss runs the raw MRO walk (`typeobject.py:478-489
 /// _lookup_where_all_typeobjects`) and fills the slot with the
 /// `(w_class, w_value)` pair (`typeobject.py:545-549`).
+///
+/// `w_name` must be an interned name object (`box_str_constant`): the slot
+/// is keyed by its address, so a collectable or non-interned string would
+/// let a later allocation at the same address answer a hit for a different
+/// name.
 unsafe fn _cached_lookup_where(
     w_type: PyObjectRef,
-    name: &str,
+    w_name: PyObjectRef,
     version_tag: u64,
 ) -> (PyObjectRef, PyObjectRef) {
-    let h = method_hash(version_tag, name);
+    let h = method_hash(version_tag, w_name);
     // Probe without holding the borrow across the MRO walk below.
     let hit = {
         let cache = METHOD_CACHE.lock();
-        if cache.versions[h] == version_tag && cache.names[h].as_deref() == Some(name) {
+        if cache.versions[h] == version_tag && cache.names[h] == w_name {
             // A valid entry with null pointers is the cached negative result.
             Some(cache.lookup_where[h])
         } else {
@@ -8498,6 +8514,7 @@ unsafe fn _cached_lookup_where(
     if let Some(tup) = hit {
         return tup;
     }
+    let name = pyre_object::unicodeobject::w_str_get_value(w_name);
     let tup =
         lookup_where_pair(w_type, name).unwrap_or((std::ptr::null_mut(), std::ptr::null_mut()));
     // Prebuilt-family store: the cache slot is reached only by
@@ -8505,7 +8522,7 @@ unsafe fn _cached_lookup_where(
     pyre_object::gc_roots::mark_prebuilt_roots_dirty();
     let mut cache = METHOD_CACHE.lock();
     cache.versions[h] = version_tag;
-    cache.names[h] = Some(name.to_string());
+    cache.names[h] = w_name;
     cache.lookup_where[h] = tup;
     tup
 }

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -142,7 +142,11 @@ pub fn pyre_debug_call_enabled() -> bool {
     // go through the seam, so report disabled rather than touch the host env.
     #[cfg(not(feature = "sandbox"))]
     {
-        std::env::var("PYRE_DEBUG_CALL").is_ok()
+        // Cached: this sits on the per-call path and is also reachable from
+        // compiled code through the fnaddr registry, so an uncached read would
+        // pay a `getenv` plus a `String` allocation on every call.
+        static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+        *ENABLED.get_or_init(|| std::env::var_os("PYRE_DEBUG_CALL").is_some())
     }
     #[cfg(feature = "sandbox")]
     {

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -598,6 +598,15 @@ fn gc_prebuilt_remember_enabled() -> bool {
     })
 }
 
+/// Whether the per-return diagnostic dump is enabled
+/// (`PYRE_INTERP_RETURN_LOG`). The probe sits on the RETURN_VALUE path, so an
+/// uncached read would pay a `getenv` on every Python return.
+#[cfg(not(feature = "sandbox"))]
+fn interp_return_log_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| std::env::var_os("PYRE_INTERP_RETURN_LOG").is_some())
+}
+
 pub fn capture_pyframe_root_area() -> *const () {
     PYFRAME_ROOT_AREA.with(|area| area as *const _ as *const ())
 }
@@ -2705,7 +2714,7 @@ impl ControlFlowOpcodeHandler for PyFrame {
     /// when the returning path exits the frame (matched by StepResult::Return).
     fn finish_value(&mut self, value: Self::Value) -> Result<StepResult<Self::Value>, PyError> {
         #[cfg(not(feature = "sandbox"))]
-        if std::env::var_os("PYRE_INTERP_RETURN_LOG").is_some() {
+        if interp_return_log_enabled() {
             unsafe {
                 let code_ptr = crate::pyframe::pyframe_get_pycode(self);
                 let name = if !code_ptr.is_null() {

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -779,6 +779,23 @@ pub unsafe fn walk_pyframe_roots_area(
             let (arr_ptr, depth, next_frame) = unsafe {
                 let f_back_slot = &mut (*(frame)).f_backref as *mut *mut PyFrame;
                 visitor(&mut *(f_back_slot as *mut majit_ir::GcRef));
+                // The visitor above forwarded the slot, which for a vref leaves
+                // the vref itself put — it is old-gen, so mark-sweep does not
+                // move it — while the frame its `forced` slot names may be
+                // young and relocating. `forced` is an interior slot the
+                // collector reaches later, off the gray stack, but
+                // `chain_next_frame` reads it during THIS scan, so forward it
+                // here as well; otherwise the walk steps into a frame copy the
+                // collector is about to abandon, and the roots only this walker
+                // knows about (caught exceptions, module-dict cells, the
+                // prebuilt families) get forwarded into dead memory. A direct
+                // `f_backref` needs no such hop — the visitor already left it
+                // naming the live copy.
+                let f_backref = *f_back_slot;
+                if majit_metainterp::virtualref::ptr_is_virtual_ref(f_backref as *const u8) {
+                    let vref = f_backref as *mut majit_metainterp::virtualref::JitVirtualRef;
+                    visitor(&mut *(&mut (*vref).forced as *mut *mut u8 as *mut majit_ir::GcRef));
+                }
 
                 // pyframe.py:102 `self.pycode` — the running code object.
                 // Visited as a root so a code object reachable only via

--- a/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
+++ b/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
@@ -417,6 +417,27 @@ pub unsafe fn instance_node_setdictvalue(
     flag
 }
 
+/// Whether `map` is rooted at a `DevolvedDictTerminator` (mapdict.py:382),
+/// i.e. the instance has spilled its attributes into a real dictionary.
+///
+/// A devolved map no longer names the instance's attributes, and it does not
+/// change when one is added, so a JIT fold that re-proves "no instance
+/// attribute shadows this name" by pinning the map value is unsound here and
+/// must decline instead.
+///
+/// # Safety
+/// `map`, when non-null, must be a live map node.
+pub unsafe fn map_is_devolved(map: MapRef) -> bool {
+    if map.is_null() {
+        return false;
+    }
+    let terminator = unsafe { (*map).terminator() };
+    if terminator.is_null() {
+        return false;
+    }
+    unsafe { (*terminator).as_terminator() }.kind == TerminatorKind::Devolved
+}
+
 /// `getdictvalue` routed to the mapdict node layer (mapdict.py:846-847
 /// `MapdictDictSupport.getdictvalue` → `map.read(self, attrname, DICT)`).
 /// Returns the value or `None` when the attribute is absent.

--- a/pyre/pyre-interpreter/src/runtime_ops.rs
+++ b/pyre/pyre-interpreter/src/runtime_ops.rs
@@ -524,6 +524,12 @@ pub fn binary_op_tag_is_inplace(tag: i64) -> bool {
     (13..=24).contains(&tag)
 }
 
+/// The `compare_fn` tag `CHECK_EXC_MATCH` passes for its
+/// `isinstance(exc, match_type)` check.  It is outside the 0..=5 range
+/// [`compare_op_from_tag`] decodes, so a `CompareOp` residual carrying it is
+/// the exception-match shape and nothing else.
+pub const ISINSTANCE_OP_TAG: i64 = 10;
+
 pub fn compare_op_tag(op: ComparisonOperator) -> i64 {
     match op {
         ComparisonOperator::Less => 0,

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -2602,6 +2602,26 @@ pub fn w_exception_context_descr(kind: ExcKind) -> DescrRef {
     field_descr_from_group(group, 3)
 }
 
+/// Field descr for `W_BaseException.w_dict` (the lazily allocated instance
+/// dictionary), the last slot of the per-kind exception descr group.  The
+/// LOAD_METHOD method-cache fold reads it to pin the receiver at "carries no
+/// instance dictionary", which is what makes the folded descriptor safe: a
+/// later `e.<name> = ...` allocates the dictionary and side-exits.
+pub fn w_exception_dict_descr(kind: ExcKind) -> DescrRef {
+    let idx = kind as u8 as usize;
+    let mut cache = W_BASE_EXCEPTION_DESCR_CACHE.lock().unwrap();
+    if cache[idx].is_none() {
+        cache[idx] = Some(build_w_exception_group(kind));
+    }
+    let group = cache[idx].as_ref().unwrap();
+    debug_assert_eq!(
+        group.field_descrs[20].offset(),
+        pyre_object::interp_exceptions::EXC_W_DICT_OFFSET,
+        "exception descr group index 20 is no longer w_dict",
+    );
+    field_descr_from_group(group, 20)
+}
+
 /// Field descriptor for `W_BaseException.w_traceback`, sharing the
 /// per-kind exception allocation descriptor with the other exception slots.
 pub fn w_exception_traceback_descr(kind: ExcKind) -> DescrRef {

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -1551,6 +1551,19 @@ static PYFRAME_DESCR_GROUP: LazyLock<PyreObjectDescrGroup> = LazyLock::new(|| {
                 false,
                 false,
             ),
+            // `pyframe.py:80 escaped` and its neighbours live in one `u8`, so
+            // the traced `mark_as_escaped` is a byte-wide read-or-write, not a
+            // word store.  Appended last: the accessors above address this
+            // group by index.
+            (
+                "PyFrame.flags",
+                crate::frame_layout::PYFRAME_FLAGS_OFFSET,
+                std::mem::size_of::<u8>(),
+                Type::Int,
+                false,
+                false,
+                false,
+            ),
         ],
         "PyFrame",
         "pyframe::PyFrame",
@@ -2719,6 +2732,17 @@ pub fn pytraceback_field_descr(index: usize) -> DescrRef {
     field_descr_from_group(&PYTRACEBACK_DESCR_GROUP, index)
 }
 
+/// Field descriptor for `PyTraceback.frame`, the node's own frame slot read by
+/// `descr_get_tb_frame`.
+pub fn pytraceback_frame_descr() -> DescrRef {
+    let index = PYTRACEBACK_DESCR_GROUP
+        .field_descrs
+        .iter()
+        .position(|d| d.offset() == pyre_interpreter::pytraceback::PYTRACEBACK_FRAME_OFFSET)
+        .expect("PyTraceback descr group has no frame field");
+    field_descr_from_group(&PYTRACEBACK_DESCR_GROUP, index)
+}
+
 /// Field descriptor for `PyTraceback.w_next`, the chain link `descr_get_next`
 /// reads.  Located by offset rather than by a hand-counted position, so a
 /// later edit to the field list above cannot silently repoint this at a
@@ -2926,6 +2950,18 @@ pub fn pyframe_w_yielding_from_descr() -> DescrRef {
 
 pub fn pyframe_f_backref_descr() -> DescrRef {
     field_descr_from_group(&PYFRAME_DESCR_GROUP, 10)
+}
+
+/// `PyFrame.flags` — the byte carrying `FLAG_ESCAPED`.  Read-or-written by the
+/// traced `tb_frame` fold to reproduce the getter's `mark_as_escaped()`.
+/// Located by offset, so appending another field cannot repoint it.
+pub fn pyframe_flags_descr() -> DescrRef {
+    let index = PYFRAME_DESCR_GROUP
+        .field_descrs
+        .iter()
+        .position(|d| d.offset() == crate::frame_layout::PYFRAME_FLAGS_OFFSET)
+        .expect("PyFrame descr group has no flags field");
+    field_descr_from_group(&PYFRAME_DESCR_GROUP, index)
 }
 
 #[cfg(test)]

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -2614,12 +2614,18 @@ pub fn w_exception_dict_descr(kind: ExcKind) -> DescrRef {
         cache[idx] = Some(build_w_exception_group(kind));
     }
     let group = cache[idx].as_ref().unwrap();
-    debug_assert_eq!(
-        group.field_descrs[20].offset(),
-        pyre_object::interp_exceptions::EXC_W_DICT_OFFSET,
-        "exception descr group index 20 is no longer w_dict",
-    );
-    field_descr_from_group(group, 20)
+    // Located by offset rather than by a hand-counted position.  The field
+    // list is edited by hand, and naming the wrong index does not fail to
+    // compile: it silently reads a neighbouring slot that stays null for an
+    // ordinary subclass, which turns the shadowing guard below into a no-op
+    // and lets compiled code keep calling a method an instance attribute has
+    // already shadowed.
+    let field = group
+        .field_descrs
+        .iter()
+        .position(|d| d.offset() == pyre_object::interp_exceptions::EXC_W_DICT_OFFSET)
+        .expect("exception descr group has no w_dict field");
+    field_descr_from_group(group, field)
 }
 
 /// Field descriptor for `W_BaseException.w_traceback`, sharing the

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -1852,6 +1852,12 @@ pub fn w_class_obj_for_vtable(vtable: usize) -> Option<i64> {
     if vtable == 0 {
         return None;
     }
+    // A `JitVirtualRef` names itself with a type tag, not a `PyType` address,
+    // and has no `w_class` to answer with — reading the tag as a type would
+    // dereference a constant.
+    if vtable == majit_metainterp::virtualref::JIT_VIRTUAL_REF_VTABLE as usize {
+        return None;
+    }
     let tp = vtable as *const pyre_object::pyobject::PyType;
     let w_class = unsafe { pyre_object::pyobject::get_instantiate(&*tp) };
     if w_class.is_null() {

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -2719,6 +2719,19 @@ pub fn pytraceback_field_descr(index: usize) -> DescrRef {
     field_descr_from_group(&PYTRACEBACK_DESCR_GROUP, index)
 }
 
+/// Field descriptor for `PyTraceback.w_next`, the chain link `descr_get_next`
+/// reads.  Located by offset rather than by a hand-counted position, so a
+/// later edit to the field list above cannot silently repoint this at a
+/// neighbouring slot.
+pub fn pytraceback_w_next_descr() -> DescrRef {
+    let index = PYTRACEBACK_DESCR_GROUP
+        .field_descrs
+        .iter()
+        .position(|d| d.offset() == pyre_interpreter::pytraceback::PYTRACEBACK_W_NEXT_OFFSET)
+        .expect("PyTraceback descr group has no w_next field");
+    field_descr_from_group(&PYTRACEBACK_DESCR_GROUP, index)
+}
+
 /// Cached field descriptor for a raw reference slot selected by the
 /// exception attribute fold.  Indices are those of `build_w_exception_group`;
 /// no parallel descriptor is constructed.

--- a/pyre/pyre-jit-trace/src/frame_layout.rs
+++ b/pyre/pyre-jit-trace/src/frame_layout.rs
@@ -17,6 +17,11 @@ pub const PYFRAME_LOCALS_CELLS_STACK_OFFSET: usize =
 /// Byte offset of `pycode` in `PyFrame`.
 pub const PYFRAME_PYCODE_OFFSET: usize = std::mem::offset_of!(PyFrame, pycode);
 
+/// Byte offset of `flags` in `PyFrame` — the `u8` holding `FLAG_ESCAPED`
+/// (`pyframe.py:80 escaped`).  A traced `tb_frame` read has to set that bit
+/// the way the getter's `mark_as_escaped()` does.
+pub const PYFRAME_FLAGS_OFFSET: usize = std::mem::offset_of!(PyFrame, flags);
+
 /// Byte offset of `debugdata` in `PyFrame`.
 pub const PYFRAME_DEBUGDATA_OFFSET: usize = std::mem::offset_of!(PyFrame, debugdata);
 

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/bridge_subwalk.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/bridge_subwalk.rs
@@ -414,6 +414,10 @@ pub fn dispatch_via_miframe<Sym: WalkSym>(
         // inlined callee's sub-walk raised and the root frame's handler covers
         // the CALL (set by `drive_bridge_carrier_walk`).  Consumed once here.
         let carrier_raise_seed = crate::jitcode_dispatch::take_carrier_raise_seed();
+        // Set by the carrier seed's no-handler arm: the root frame lets the
+        // exception through, so the trace ends at bridge entry and the walk is
+        // skipped entirely.
+        let mut carrier_raise_escapes = false;
         let walk_position = if let Some(catch_target) = exc_edge_catch_target {
             // RPython `pyjitpl.py:3125-3173` exception-guard resumption, emitted
             // at the bridge-entry frame state so the GUARD_EXCEPTION captures a
@@ -505,9 +509,41 @@ pub fn dispatch_via_miframe<Sym: WalkSym>(
             // a reraise in the handler mis-reads the standing exception.
             wc.fbw_mode.class_of_last_exc_is_const = true;
             majit_metainterp::blackhole::BH_LAST_EXC_VALUE.with(|c| c.set(0));
-            record_bridge_handler_entry_traceback(&mut wc, seed.exc, seed.exc_concrete, position);
-            vstack_enter_exception_handler(&mut wc, seed.catch_target, seed.exc);
-            seed.catch_target
+            if let Some(catch_target) = seed.catch_target {
+                record_bridge_handler_entry_traceback(
+                    &mut wc,
+                    seed.exc,
+                    seed.exc_concrete,
+                    position,
+                );
+                vstack_enter_exception_handler(&mut wc, catch_target, seed.exc);
+                catch_target
+            } else {
+                // No handler in the root frame: `finishframe_exception` ran out
+                // of frames to scan and reaches
+                // `compile_exit_frame_with_exception`.  Same shape as the
+                // walk-level top-level arm — record this frame's node for the
+                // recording pass only (`emit_runtime = false`: at runtime the
+                // interpreter records it when the trace hands the exception
+                // back), publish the raise coordinate the interpreter reads it
+                // from, and stash the exception as the FINISH payload.  The
+                // remaining Python frames unwind interpreted, exactly as they
+                // do when the raise surfaces from a residual call.
+                if !recording_instruction_is_bare_reraise(&mut wc, position) {
+                    record_top_level_application_traceback(
+                        &mut wc,
+                        seed.exc,
+                        seed.exc_concrete,
+                        position,
+                        true,
+                        false,
+                    );
+                }
+                fbw_publish_exit_last_instr(&mut wc, position);
+                fbw_terminate_with_raise(seed.exc, seed.exc_concrete);
+                carrier_raise_escapes = true;
+                position
+            }
         } else {
             // `_prepare_exception_resumption` null-exception arm +
             // `prepare_resume_from_failure` (pyjitpl.py): every exception-guard
@@ -556,7 +592,11 @@ pub fn dispatch_via_miframe<Sym: WalkSym>(
             seed_vstack_mirror(&mut wc, sym, position);
             position
         };
-        let outcome = walk(jitcode_code, walk_position, &mut wc);
+        let outcome = if carrier_raise_escapes {
+            Ok((DispatchOutcome::Terminate, walk_position))
+        } else {
+            walk(jitcode_code, walk_position, &mut wc)
+        };
         // Read final last_exc_value before wc drops so the borrow
         // checker can release sym for the writeback below.
         let final_last_exc = wc.last_exc_value;

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/bridge_subwalk.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/bridge_subwalk.rs
@@ -959,9 +959,17 @@ pub(crate) fn drive_bridge_frame_subwalk<Sym: WalkSym>(
 
     let callee_code = jc.code.as_slice();
     let lookup_ref: &SubJitCodeLookup = &sub_jitcode_lookup;
+    // `InlineCalleeConsts.w_code` is the callee frame's `pycode` red — a
+    // `W_Code` object.  `callee_code_key` is the raw compiled-code pointer the
+    // recipe carries, which is the JIT-side key, not that object; the live
+    // wrapper is what `recover_inline_callee_globals` already reads
+    // `w_globals` out of.  Passing the key through made every consumer that
+    // type-checks it decline (the inlined callee then contributed no
+    // `PyTraceback` node) and every consumer that does not re-read it as a
+    // `W_Code` of the wrong type.
     let consts = InlineCalleeConsts {
         w_globals: callee_w_globals,
-        w_code: callee_code_key,
+        w_code: crate::state::recover_inline_callee_code(callee_code_key as *const ()) as usize,
         jitcode_index: jc.try_index().map_or(-1, |index| index as i32),
     };
 

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/bridge_subwalk.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/bridge_subwalk.rs
@@ -9,6 +9,41 @@
 
 use super::*;
 
+/// Record the catching frame's own `PyTraceback` node at a bridge handler
+/// entry.
+///
+/// `pyopcode.py handle_operation_error` runs
+/// `pytraceback.record_application_traceback` BEFORE `lookup_exceptiontable`
+/// routes to the handler, so the frame that catches contributes a node whether
+/// or not it is the frame that raised.  Upstream meta-traces that interpreter
+/// loop, so the attach lands in the bridge on its own; pyre synthesizes the
+/// loop and has to emit it at each catch entry.
+///
+/// The five in-trace handler-entry paths already did this; these two bridge
+/// arms did not, and the frame they lost is always the OUTERMOST one: on the
+/// bridge leg the raising callee ran as real frames (a residual call), so those
+/// frames attach their own nodes through the interpreted raise machinery, while
+/// the catching frame is the compiled one whose node exists only if the trace
+/// records it.
+///
+/// A delivery that reaches the parent trace's own handler-entry record as well
+/// would get two adjacent nodes for this frame; `record_caught_blackhole_
+/// traceback` drops the later one.
+fn record_bridge_handler_entry_traceback<Sym: WalkSym>(
+    wc: &mut WalkContext<'_, '_, Sym>,
+    exc: OpRef,
+    exc_concrete: ConcreteValue,
+    position: usize,
+) {
+    // The handler is part of the trace, so once this bridge runs compiled it
+    // catches the exception itself and the frame never surfaces an error the
+    // interpreter's `handle_exception` could record a node from — hence the
+    // runtime emit when the IR-virtual prepend declines.
+    let emit_runtime = !record_prepend_application_traceback(wc, exc, exc_concrete, position);
+    record_inline_application_traceback(wc, exc, exc_concrete, position, true, emit_runtime);
+    record_top_level_application_traceback(wc, exc, exc_concrete, position, true, emit_runtime);
+}
+
 /// `executioncontext.py:91-107 leave` for a frame the bridge resumed into
 /// rather than entered.
 ///
@@ -436,6 +471,12 @@ pub fn dispatch_via_miframe<Sym: WalkSym>(
             wc.last_exc_value = Some(value_op);
             wc.last_exc_value_concrete = ConcreteValue::Ref(exc_edge_concrete);
             wc.fbw_mode.class_of_last_exc_is_const = true;
+            record_bridge_handler_entry_traceback(
+                &mut wc,
+                value_op,
+                ConcreteValue::Ref(exc_edge_concrete),
+                position,
+            );
             // Reconstruct the handler-entry operand stack + push the exc box on
             // the new TOS (mirrors the mid-walk SubRaise catch routing).
             vstack_enter_exception_handler(&mut wc, catch_target, value_op);
@@ -464,6 +505,7 @@ pub fn dispatch_via_miframe<Sym: WalkSym>(
             // a reraise in the handler mis-reads the standing exception.
             wc.fbw_mode.class_of_last_exc_is_const = true;
             majit_metainterp::blackhole::BH_LAST_EXC_VALUE.with(|c| c.set(0));
+            record_bridge_handler_entry_traceback(&mut wc, seed.exc, seed.exc_concrete, position);
             vstack_enter_exception_handler(&mut wc, seed.catch_target, seed.exc);
             seed.catch_target
         } else {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
@@ -2004,8 +2004,8 @@ pub(crate) fn fbw_callee_body_replay_safety(
             // A `COMPARE_OP` over the same proven operands is accepted for the
             // same reason, but its result is a `bool`, not an operand the
             // numeric provenance below may chain on.
-            let accepted_binop = accepted_numeric_op
-                && ei.pyre_helper == majit_ir::PyreHelperKind::BinaryOp;
+            let accepted_binop =
+                accepted_numeric_op && ei.pyre_helper == majit_ir::PyreHelperKind::BinaryOp;
             // `CHECK_EXC_MATCH` shares the `COMPARE_OP` shape but reads only
             // types, so it needs no operand proof at all.
             let accepted_exc_match = !provably_side_effect_free
@@ -2077,6 +2077,7 @@ pub(crate) fn fbw_callee_body_replay_safety(
                         | majit_ir::PyreHelperKind::CallFunctionEx
                         | majit_ir::PyreHelperKind::RaiseVarargs
                         | majit_ir::PyreHelperKind::SetCurrentException
+                        | majit_ir::PyreHelperKind::LoadAttr
                 ) {
                     deferred_call = true;
                     // The callee this resolves to is a runtime value, so what it

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
@@ -1442,14 +1442,18 @@ pub(crate) fn fbw_terminate_with_finish<Sym: WalkSym>(
 /// A frame the function-entry portal compiled can outlive its trace the same
 /// way a generator's does — a traceback it hands out keeps it alive — and the
 /// lazy route is not available to narrow this back down.  Two things have to
-/// land before it is: the backend frees the jitframe chain before
+/// land before it is.  The dynasm backend frees the jitframe chain before
 /// `execute_token` returns, so the marker would name freed memory rather than
-/// a retained deadframe; and no backend arms `jf_force_descr` for a standalone
-/// trailing `GUARD_NOT_FORCED_2`, which upstream does from
-/// `consider_guard_not_forced_2` (x86/regalloc.py), so the armed-token test
-/// would answer false for a portal exit even once the chain is retained.
-/// Narrowing the force to the frames that actually escape needs both; the
-/// escape is a runtime property, which is what the token protocol answers.
+/// a retained deadframe.  And arming `jf_force_descr` for a standalone
+/// trailing `GUARD_NOT_FORCED_2` is uneven: cranelift does it, dynasm folds
+/// the opcode into the no-args guard bucket and so does not, and wasm cannot
+/// yet — its `FORCE_TOKEN` is a zero sentinel, leaving no frame identity for a
+/// token to name.  Upstream arms it on every backend, from
+/// `consider_guard_not_forced_2` (x86/regalloc.py), so until dynasm and wasm
+/// follow, the armed-token test answers false for a portal exit even once the
+/// chain is retained.  Narrowing the force to the frames that actually escape
+/// needs both; the escape is a runtime property, which is what the token
+/// protocol answers.
 ///
 /// Storing back here is what makes the token store unnecessary rather than
 /// merely redundant: `gen_store_back_in_vable` sets `forced_virtualizable`, and
@@ -1598,7 +1602,7 @@ pub(crate) fn fbw_finish_is_exception() -> bool {
 /// Map an `abort_permanent` marker's jitcode pc back to the Python opcode
 /// the interpreter must resume at.  `emit_abort_permanent` (codewriter)
 /// anchors the graph marker at `py_pc` and additionally stores
-/// `last_instr = py_pc - 1` for portal frames; the full-body walk reads the
+/// `last_instr = py_pc - 1` into the frame red; the full-body walk reads the
 /// marker coordinate here to flush the abort-point frame instead of replaying
 /// the walked region.  Returns None when the sym's jitcode / `code_ptr` is
 /// unavailable (no resume coordinate derivable → legacy replay).

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
@@ -1732,6 +1732,20 @@ pub(crate) struct ExactNumericArg {
 /// FROM exact-numeric caller arguments — so parameter provenance is tracked
 /// slot-by-slot alongside freshness.  This matters for method-form calls:
 /// `self` is commonly nonnumeric while a later argument is an exact int.
+/// Name the body op that made [`fbw_callee_body_replay_safety`] answer
+/// [`CalleeReplaySafety::Dirty`], under `PYRE_FBW_INLINE_DIAG`.  Without it the
+/// declining instruction is invisible: the caller only sees `safety=Dirty` on
+/// the `[inline-foriter-gate]` line and every one of the return sites below
+/// looks alike.
+macro_rules! replay_dirty {
+    ($why:expr, $pc:expr, $opname:expr) => {{
+        if std::env::var_os("PYRE_FBW_INLINE_DIAG").is_some() {
+            eprintln!("[replay-dirty] pc={} op={} why={}", $pc, $opname, $why);
+        }
+        return CalleeReplaySafety::Dirty;
+    }};
+}
+
 pub(crate) fn fbw_callee_body_replay_safety(
     body_code: &[u8],
     exact_numeric_args: &[ExactNumericArg],
@@ -1742,9 +1756,12 @@ pub(crate) fn fbw_callee_body_replay_safety(
     callee_descr_refs: &[DescrRef],
 ) -> CalleeReplaySafety {
     let Some(branch_targets) = body_branch_targets(body_code) else {
-        return CalleeReplaySafety::Dirty;
+        replay_dirty!("BranchTargetsUndecodable", 0, "-");
     };
     let mut fresh_ref_regs = [false; u8::MAX as usize + 1];
+    // Ref registers holding the `bool` an accepted `COMPARE_OP` produced.  A
+    // truth residual over one of them is a read, not a live-heap write.
+    let mut bool_ref_regs = [false; u8::MAX as usize + 1];
     // The dual of freshness, for the opposite question: which ref registers hold
     // a value whose Python-visible class is provably an IMMUTABLE BUILTIN.  That
     // is what the `BINARY_OP` exemption below actually needs — such an operand
@@ -1814,18 +1831,20 @@ pub(crate) fn fbw_callee_body_replay_safety(
     while pc < body_code.len() {
         if branch_targets.contains(&pc) {
             fresh_ref_regs = [false; u8::MAX as usize + 1];
+            bool_ref_regs = [false; u8::MAX as usize + 1];
             numeric_ref_regs = seed_numeric_ref_regs;
             plain_int_ref_regs = seed_plain_int_ref_regs;
             numeric_slots = [false; BODY_TRACKED_FRAME_SLOTS];
             plain_int_slots = [false; BODY_TRACKED_FRAME_SLOTS];
         }
         let Some(d) = crate::jitcode_runtime::decode_op_at(body_code, pc) else {
-            return CalleeReplaySafety::Dirty;
+            replay_dirty!("DecodeOpFailed", pc, "-");
         };
         // Set by the arms below when this op's `>r` result is itself an
         // immutable builtin.
         let mut dst_exact_numeric = false;
         let mut dst_exact_plain_int = false;
+        let mut dst_exact_bool = false;
 
         // The ref-slot accessors name the frame in operand 0 and the slot in
         // operand 1, both one byte wide.  The `_i` / `_f` variants address a
@@ -1868,13 +1887,13 @@ pub(crate) fn fbw_callee_body_replay_safety(
 
         if d.opname.starts_with("residual_call") {
             let Some(descr_index) = residual_call_descr_index_in_body(body_code, &d) else {
-                return CalleeReplaySafety::Dirty;
+                replay_dirty!("ResidualCallDescrIndexMissing", d.pc, d.opname);
             };
             let Some(call_descr) = callee_descr_refs
                 .get(descr_index)
                 .and_then(|descr| descr.as_call_descr())
             else {
-                return CalleeReplaySafety::Dirty;
+                replay_dirty!("ResidualCallDescrNotACall", d.pc, d.opname);
             };
             let ei = call_descr.get_extra_info();
             // `ForIterNext` is deliberately not accepted here: it advances the
@@ -1905,14 +1924,28 @@ pub(crate) fn fbw_callee_body_replay_safety(
             let provably_side_effect_free = replay_safe_read
                 || ei.check_is_elidable()
                 || ei.extraeffect == majit_ir::ExtraEffect::LoopInvariant;
-            let accepted_binop = !provably_side_effect_free
-                && residual_call_is_specialized_plain_numeric_binop(
+            let accepted_numeric_op = !provably_side_effect_free
+                && residual_call_is_specialized_plain_numeric_op(
                     body_code,
                     &numeric_ref_regs,
                     &plain_int_ref_regs,
                     &d,
                     num_regs_i,
                     constants_i,
+                    callee_descr_refs,
+                );
+            // A `COMPARE_OP` over the same proven operands is accepted for the
+            // same reason, but its result is a `bool`, not an operand the
+            // numeric provenance below may chain on.
+            let accepted_binop = accepted_numeric_op
+                && ei.pyre_helper == majit_ir::PyreHelperKind::BinaryOp;
+            dst_exact_bool = accepted_numeric_op && !accepted_binop;
+            let accepted_truth = !provably_side_effect_free
+                && crate::jitcode_dispatch::residual_call::residual_call_is_proven_truth(
+                    body_code,
+                    &numeric_ref_regs,
+                    &bool_ref_regs,
+                    &d,
                     callee_descr_refs,
                 );
             // An accepted arithmetic op over exact numeric operands returns an
@@ -1926,7 +1959,7 @@ pub(crate) fn fbw_callee_body_replay_safety(
                         num_regs_i,
                         constants_i,
                     ));
-            if !provably_side_effect_free && !accepted_binop {
+            if !provably_side_effect_free && !accepted_numeric_op && !accepted_truth {
                 // A Python-level CALL is the one shape this scan cannot
                 // settle: the inline lever binds its callee only at the call,
                 // so whether it leaves a residual behind — and what that
@@ -1970,7 +2003,7 @@ pub(crate) fn fbw_callee_body_replay_safety(
                     numeric_slots = [false; BODY_TRACKED_FRAME_SLOTS];
                     plain_int_slots = [false; BODY_TRACKED_FRAME_SLOTS];
                 } else {
-                    return CalleeReplaySafety::Dirty;
+                    replay_dirty!("ResidualCallWritesLiveHeap", d.pc, d.opname);
                 }
             }
         } else if d.opname.starts_with("setfield_gc") {
@@ -1982,10 +2015,10 @@ pub(crate) fn fbw_callee_body_replay_safety(
             // reading operand 0 as one would index the freshness set with an
             // int register number.
             if !d.argcodes.starts_with('r') {
-                return CalleeReplaySafety::Dirty;
+                replay_dirty!("SetfieldGcTargetNotRefReg", d.pc, d.opname);
             }
             let Some(&target_reg) = body_code.get(d.pc + 1) else {
-                return CalleeReplaySafety::Dirty;
+                replay_dirty!("SetfieldGcTargetRegMissing", d.pc, d.opname);
             };
             let descr_index = decode_descr_index(body_code, &d, 2);
             let immutable_field = callee_descr_refs
@@ -1993,7 +2026,7 @@ pub(crate) fn fbw_callee_body_replay_safety(
                 .and_then(|descr| descr.as_field_descr())
                 .is_some_and(|field| field.is_immutable());
             if !fresh_ref_regs[target_reg as usize] || !immutable_field {
-                return CalleeReplaySafety::Dirty;
+                replay_dirty!("SetfieldGcTargetNotFreshOrMutable", d.pc, d.opname);
             }
         } else if d.opname.starts_with("setarrayitem_gc") {
             // The dual of the `setfield_gc` rule: a store into an array this
@@ -2006,7 +2039,7 @@ pub(crate) fn fbw_callee_body_replay_safety(
                     .get(d.pc + 1)
                     .is_some_and(|reg| fresh_ref_regs[*reg as usize]);
             if !target_fresh {
-                return CalleeReplaySafety::Dirty;
+                replay_dirty!("SetarrayitemGcTargetNotFresh", d.pc, d.opname);
             }
         } else if d.opname.starts_with("setinteriorfield_gc")
             || d.opname.starts_with("raw_store")
@@ -2016,13 +2049,13 @@ pub(crate) fn fbw_callee_body_replay_safety(
         {
             // Interior/raw stores and non-residual call forms cannot be proven
             // replay-safe from this single callee body.
-            return CalleeReplaySafety::Dirty;
+            replay_dirty!("UnprovableStoreOrCallForm", d.pc, d.opname);
         }
 
         // The result byte is always the final operand for `>r` forms.
         if d.argcodes.ends_with(">r") {
             let Some(&dst) = body_code.get(d.next_pc.saturating_sub(1)) else {
-                return CalleeReplaySafety::Dirty;
+                replay_dirty!("ResultRegisterByteMissing", d.pc, d.opname);
             };
             fresh_ref_regs[dst as usize] = d.key == "new_with_vtable/d>r"
                 || d.opname.starts_with("new_array")
@@ -2043,6 +2076,11 @@ pub(crate) fn fbw_callee_body_replay_safety(
                     && body_code
                         .get(d.pc + 1)
                         .is_some_and(|src| numeric_ref_regs[*src as usize]));
+            bool_ref_regs[dst as usize] = dst_exact_bool
+                || (d.key == "ref_copy/r>r"
+                    && body_code
+                        .get(d.pc + 1)
+                        .is_some_and(|src| bool_ref_regs[*src as usize]));
             plain_int_ref_regs[dst as usize] = dst_exact_plain_int
                 || vable_slot.is_some_and(|slot| {
                     d.opname.starts_with("getarrayitem_vable_r")

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
@@ -1968,6 +1968,12 @@ pub(crate) fn fbw_callee_body_replay_safety(
             // nothing to the live heap.  The BUILD_TUPLE / BUILD_LIST array
             // consumers are the same shape one level up: they read a
             // freshly-built backing array and return a brand-new container.
+            // `get_current_exception` is the PUSH_EXC_INFO `prev` save, which
+            // `try_walker_lower_exc_info_residual` lowers to a bare
+            // `GETFIELD_GC_R(ec, sys_exc_value)`: a field read, so a replay
+            // reads the same value again.  Its writing twin
+            // `SetCurrentException` is not here — it is journalled, and so
+            // reaches the `deferred_call` arm below instead.
             let replay_safe_read = matches!(
                 ei.pyre_helper,
                 majit_ir::PyreHelperKind::LoadConst
@@ -1975,6 +1981,7 @@ pub(crate) fn fbw_callee_body_replay_safety(
                     | majit_ir::PyreHelperKind::BoxInt
                     | majit_ir::PyreHelperKind::NewtupleFromArray
                     | majit_ir::PyreHelperKind::NewlistFromArray
+                    | majit_ir::PyreHelperKind::GetCurrentException
             );
             // `box_int` is the only generic replay-safe helper here whose
             // result is necessarily numeric.  `load_const` may return a str,
@@ -1999,7 +2006,17 @@ pub(crate) fn fbw_callee_body_replay_safety(
             // numeric provenance below may chain on.
             let accepted_binop = accepted_numeric_op
                 && ei.pyre_helper == majit_ir::PyreHelperKind::BinaryOp;
-            dst_exact_bool = accepted_numeric_op && !accepted_binop;
+            // `CHECK_EXC_MATCH` shares the `COMPARE_OP` shape but reads only
+            // types, so it needs no operand proof at all.
+            let accepted_exc_match = !provably_side_effect_free
+                && crate::jitcode_dispatch::residual_call::residual_call_is_exception_match(
+                    body_code,
+                    &d,
+                    num_regs_i,
+                    constants_i,
+                    callee_descr_refs,
+                );
+            dst_exact_bool = (accepted_numeric_op && !accepted_binop) || accepted_exc_match;
             let accepted_truth = !provably_side_effect_free
                 && crate::jitcode_dispatch::residual_call::residual_call_is_proven_truth(
                     body_code,
@@ -2019,7 +2036,11 @@ pub(crate) fn fbw_callee_body_replay_safety(
                         num_regs_i,
                         constants_i,
                     ));
-            if !provably_side_effect_free && !accepted_numeric_op && !accepted_truth {
+            if !provably_side_effect_free
+                && !accepted_numeric_op
+                && !accepted_truth
+                && !accepted_exc_match
+            {
                 // A Python-level CALL is the one shape this scan cannot
                 // settle: the inline lever binds its callee only at the call,
                 // so whether it leaves a residual behind — and what that
@@ -2063,7 +2084,11 @@ pub(crate) fn fbw_callee_body_replay_safety(
                     numeric_slots = [false; BODY_TRACKED_FRAME_SLOTS];
                     plain_int_slots = [false; BODY_TRACKED_FRAME_SLOTS];
                 } else {
-                    replay_dirty!("ResidualCallWritesLiveHeap", d.pc, d.opname);
+                    replay_dirty!(
+                        format!("ResidualCallWritesLiveHeap/{:?}", ei.pyre_helper),
+                        d.pc,
+                        d.opname
+                    );
                 }
             }
         } else if d.opname.starts_with("setfield_gc") {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
@@ -1644,6 +1644,54 @@ fn body_int_operand_constant(ireg: u8, num_regs_i: usize, constants_i: &[i64]) -
         .copied()
 }
 
+/// Which of the tracked frame slots this body can store into.
+///
+/// A slot the body never writes still holds exactly the argument the
+/// exact-positional entry convention bound from the caller, on every path
+/// through the body — so unlike a register, its provenance is not something a
+/// join can invalidate.  `def leaf(i): if i % 3 == 1: ... ; return i % 5` needs
+/// this: the second `i` is read after a branch target, and without it the slot
+/// reset drops the caller's exact-int proof and the second `BINARY_OP`
+/// residualizes the whole callee.
+///
+/// A store this scan cannot resolve to a slot number could name any of them, so
+/// it gives the whole window up.  Same for an undecodable body — the main scan
+/// answers `Dirty` on it anyway.
+fn body_stored_frame_slots(
+    body_code: &[u8],
+    num_regs_i: usize,
+    constants_i: &[i64],
+) -> [bool; BODY_TRACKED_FRAME_SLOTS] {
+    let mut written = [false; BODY_TRACKED_FRAME_SLOTS];
+    let mut pc = 0usize;
+    while pc < body_code.len() {
+        let Some(d) = crate::jitcode_runtime::decode_op_at(body_code, pc) else {
+            return [true; BODY_TRACKED_FRAME_SLOTS];
+        };
+        if d.key.starts_with("setarrayitem_vable_r") {
+            // `ri…`: the frame is operand 0 and the slot operand 1.  The frame
+            // register is deliberately not matched against the scan's
+            // `vable_reg` here — a store this pass cannot attribute is treated
+            // as reaching every slot, which is the conservative direction.
+            let slot = d
+                .argcodes
+                .starts_with("ri")
+                .then(|| body_code.get(d.pc + 2))
+                .flatten()
+                .and_then(|ireg| body_int_operand_constant(*ireg, num_regs_i, constants_i))
+                .and_then(|slot| usize::try_from(slot).ok());
+            match slot {
+                Some(slot) if slot < BODY_TRACKED_FRAME_SLOTS => written[slot] = true,
+                // Past the tracked window: cannot alias a slot inside it.
+                Some(_) => {}
+                None => return [true; BODY_TRACKED_FRAME_SLOTS],
+            }
+        }
+        pc = d.next_pc;
+    }
+    written
+}
+
 fn body_branch_targets(body_code: &[u8]) -> Option<std::collections::HashSet<usize>> {
     let mut targets = std::collections::HashSet::new();
     let mut pc = 0usize;
@@ -1791,8 +1839,11 @@ pub(crate) fn fbw_callee_body_replay_safety(
     //
     // Everything the body computes drops at a branch target for the reason
     // freshness does: a slot or register reaching a join holds whatever the
-    // taken path put there, which this straight-line scan cannot name.  The
-    // constant pool is re-seeded across that reset, being immutable.
+    // taken path put there, which this straight-line scan cannot name.  Two
+    // things are re-seeded across that reset instead of dropped, because
+    // neither is something a path could have changed: the constant pool, being
+    // immutable, and any frame slot the body never stores into, which still
+    // holds the caller's argument.
     let mut seed_numeric_ref_regs = [false; u8::MAX as usize + 1];
     let mut seed_plain_int_ref_regs = [false; u8::MAX as usize + 1];
     for (index, &raw) in constants_r.iter().enumerate() {
@@ -1812,6 +1863,11 @@ pub(crate) fn fbw_callee_body_replay_safety(
     }
     let mut numeric_ref_regs = seed_numeric_ref_regs;
     let mut plain_int_ref_regs = seed_plain_int_ref_regs;
+    // A never-stored parameter slot keeps the caller's proof across a join, so
+    // it is re-seeded rather than dropped — see [`body_stored_frame_slots`].
+    let stored_slots = body_stored_frame_slots(body_code, num_regs_i, constants_i);
+    let mut seed_numeric_slots = [false; BODY_TRACKED_FRAME_SLOTS];
+    let mut seed_plain_int_slots = [false; BODY_TRACKED_FRAME_SLOTS];
     let mut numeric_slots = [false; BODY_TRACKED_FRAME_SLOTS];
     let mut plain_int_slots = [false; BODY_TRACKED_FRAME_SLOTS];
     for (slot, exact) in exact_numeric_args
@@ -1821,6 +1877,10 @@ pub(crate) fn fbw_callee_body_replay_safety(
     {
         numeric_slots[slot] = exact.numeric;
         plain_int_slots[slot] = exact.plain_int;
+        if !stored_slots[slot] {
+            seed_numeric_slots[slot] = exact.numeric;
+            seed_plain_int_slots[slot] = exact.plain_int;
+        }
     }
     // The frame register every vable op in this body has used so far.  A second
     // one would mean the slot bookkeeping above is tracking two different
@@ -1834,8 +1894,8 @@ pub(crate) fn fbw_callee_body_replay_safety(
             bool_ref_regs = [false; u8::MAX as usize + 1];
             numeric_ref_regs = seed_numeric_ref_regs;
             plain_int_ref_regs = seed_plain_int_ref_regs;
-            numeric_slots = [false; BODY_TRACKED_FRAME_SLOTS];
-            plain_int_slots = [false; BODY_TRACKED_FRAME_SLOTS];
+            numeric_slots = seed_numeric_slots;
+            plain_int_slots = seed_plain_int_slots;
         }
         let Some(d) = crate::jitcode_runtime::decode_op_at(body_code, pc) else {
             replay_dirty!("DecodeOpFailed", pc, "-");

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
@@ -1933,11 +1933,36 @@ pub(crate) fn fbw_callee_body_replay_safety(
                 // residual writes — is not a property of this body.  Defer it;
                 // the backstop aborts before executing one that did not
                 // inline.
+                // `RAISE_VARARGS` lowers to the same shape: its
+                // `normalize_raise_varargs_fn` residual instantiates a raised
+                // CLASS and normalizes an optional `from` cause, so what it
+                // touches is a runtime value exactly like a CALL's callee.  For
+                // the shape a loop actually repeats — an exception the walk
+                // built itself, no `from` cause — the three walker-native folds
+                // (`try_walker_trace_exception_new`,
+                // `try_walker_trace_raise_builtin`,
+                // `try_walker_trace_raise_bare_class`) erase the residual before
+                // the backstop is reached, and each writes only into the object
+                // it just allocated.  Anything else reaches
+                // `fbw_abort_nested_unjournaled_residual` and aborts before the
+                // helper runs, since the decline there covers every residual
+                // that is not elidable / loop-invariant / `ForIterNext`.
+                // `set_current_exception` is the same shape once more, and it
+                // is the one every `try`/`except` body carries (the
+                // PUSH_EXC_INFO store and the POP_EXCEPT restore).  Its fold
+                // [`try_walker_lower_exc_info_residual`] journals the displaced
+                // `sys_exc_value` through [`fbw_sys_exc_journal_push`] BEFORE
+                // applying the concrete store, and
+                // [`fbw_store_journal_rollback`] replays the journal in reverse
+                // on a non-committed exit — so a folded store is undone for the
+                // replay, and an unfolded one never runs.
                 if matches!(
                     ei.pyre_helper,
                     majit_ir::PyreHelperKind::CallFn
                         | majit_ir::PyreHelperKind::CallKw
                         | majit_ir::PyreHelperKind::CallFunctionEx
+                        | majit_ir::PyreHelperKind::RaiseVarargs
+                        | majit_ir::PyreHelperKind::SetCurrentException
                 ) {
                     deferred_call = true;
                     // The callee this resolves to is a runtime value, so what it

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -3071,9 +3071,7 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
     // provably has no inner loop and that rationale does not reach here.
     //
     // All of these sit before the first recorded op (the `GETFIELD_GC_R`
-    // below), so returning costs nothing but the inline.  The
-    // POP_JUMP_IF_NONE scan is the one exception and still aborts — see the
-    // note at that site.
+    // below), so returning costs nothing but the inline.
     if try_multiframe || strict_seed {
         'seed: {
             // Branch-A frame shape only (mirror REC_CA): existing freevar
@@ -3081,49 +3079,6 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
             if !callee_code.cellvars.is_empty() {
                 if try_multiframe {
                     return Ok(None);
-                }
-                break 'seed;
-            }
-            // POP_JUMP_IF_NONE / POP_JUMP_IF_NOT_NONE lower to an `is`/`is_not`
-            // identity residual call whose operands must be Ref (the codewriter
-            // PopJumpIfNone arm), then a branch guard.  When the multiframe inline
-            // int-specializes the tested local, the mid-body guard resume cannot
-            // source that operand's Ref form from the callee register banks
-            // (`collect_callee_active_boxes` would read a stale/mismatched box), so
-            // the encoded liveness stream disagrees with the decoder
-            // (`resume.rs decode_ref: unexpected tag`) and the caller frame is
-            // corrupted. Decline to the ordinary residual call until
-            // the multi-frame resume reboxes int-specialized identity operands.
-            // POP_JUMP_IF_TRUE/FALSE stay inlinable: their `bool` truth folds in the
-            // int bank, so no Ref rebox is needed.  A strict straight-line callee
-            // has no branch at all, so this scan never fires for it.
-            //
-            // This is the one precondition here that still aborts instead of
-            // returning `Ok(None)`, and deliberately so.  Residualizing it does
-            // work — `bench/synth/_pending/gc_bug_bridge_flavor_traceback_names`
-            // goes from 98 aborts to 2 and
-            // `_pending/exception_nested_exc_info_restore` from 5 aborts to 0,
-            // both compiling loops they never compiled before — but the loops it
-            // newly compiles then print traceback tuples missing their outermost
-            // frame, diverging from the interpreter (that fixture pins its
-            // expected output in its header).  The abort was masking a lost
-            // `PyTraceback` node on the compiled exception path, not preventing
-            // one.  Restore `Ok(None)` here once that node is recorded; it is the
-            // largest single win left in this function.
-            if (bound_method.is_none() || method_form)
-                && (0..callee_code.instructions.len()).any(|pc| {
-                    matches!(
-                        pyre_interpreter::decode_instruction_at(callee_code, pc),
-                        Some((
-                            pyre_interpreter::bytecode::Instruction::PopJumpIfNone { .. }
-                                | pyre_interpreter::bytecode::Instruction::PopJumpIfNotNone { .. },
-                            _
-                        ))
-                    )
-                })
-            {
-                if try_multiframe {
-                    return Err(DispatchError::callee_inline_unsupported(op.pc));
                 }
                 break 'seed;
             }
@@ -3336,14 +3291,29 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
         // the call stays residual, where the post-call catch resume
         // (`GuardCaptureScope::residual_call_catch_resume`) routes the raise.
         //
-        // FIXME: this `Err` discards the whole enclosing loop trace, where the
-        // comment above describes only declining the inline.  It cannot become
-        // `Ok(None)` in place like the seed preconditions below: by here the
-        // seed block has already recorded `GETFIELD_GC_R` +
-        // `emit_new_pyframe_inline_with_params` and stamped a concrete
-        // `FrameBox` onto that op, so returning would leave dead IR behind.
-        // Closing it means hoisting `decline_inline_caller_frame_for_catch_marker`
-        // ahead of the seed block.
+        // This `Err` discards the whole enclosing loop trace, where the comment
+        // above describes only declining the inline — and it costs real
+        // compilation: `synth/exception_nested_exc_info_restore`'s
+        // `classify(sys.exc_info()[0])` calls sit in handler bodies, whose
+        // implicit cleanup entry never rejoins the loop, so every retrace
+        // aborts here and the loop is interpreted (5 aborts, 0.34s vs 0.17s
+        // once inlined).  It cannot become `Ok(None)` in place like the seed
+        // preconditions below: by here the seed block has already recorded
+        // `GETFIELD_GC_R` + `emit_new_pyframe_inline_with_params` and stamped a
+        // concrete `FrameBox` onto that op, so returning would leave dead IR
+        // behind.
+        //
+        // Hoisting the decline (`decline_inline_caller_frame_for_catch_marker`
+        // is caller-side, so it answers before the seed) is mechanical, but the
+        // abort is masking two defects on the residual path it would open, both
+        // reproduced by doing exactly that:
+        //   * `synth/exception_inline_callee_tb_frames` panics in the dynasm
+        //     backend with `RegisterManager.loc: box RefOp(N) not found`;
+        //   * `synth/gc_bug_bridge_flavor_traceback_names` prints traceback
+        //     tuples missing their outermost frame — the caller's own
+        //     `PyTraceback` node is never recorded once its try-block CALL goes
+        //     residual (that fixture pins its expected output in its header).
+        // Fix those two first; the hoist is then a two-line change.
         match compute_inline_caller_frame(ctx, op.pc) {
             Ok(pf) => Some(pf),
             Err(InlineCallerFrameDecline::TryBlockCatchMarker) => {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -1574,12 +1574,24 @@ pub(crate) fn try_walker_inline_user_call<Sym: WalkSym>(
             ctx.fbw_mode.inline_subwalk,
         );
     }
+    // Name every bail between the entry print and callee resolution.  An
+    // `[inline-entry]` with no follow-up line otherwise leaves the reason
+    // unobservable, which is the whole distance between "this call did not
+    // inline" and knowing why.
+    macro_rules! decline {
+        ($why:expr) => {{
+            if std::env::var_os("PYRE_FBW_INLINE_DIAG").is_some() {
+                eprintln!("[inline-decline] pc={} why={}", op.pc, $why);
+            }
+            return Ok(None);
+        }};
+    }
     if r_args.is_empty() {
-        return Ok(None);
+        decline!("no ref args");
     }
     let mut arg_concretes = read_ref_var_list_concrete(code, op, ref_operand_offset, ctx);
     if r_args.len() < 2 {
-        return Ok(None);
+        decline!("fewer than two ref args");
     }
     for i in 0..2 {
         if matches!(arg_concretes.get(i), Some(ConcreteValue::Null)) {
@@ -1591,10 +1603,10 @@ pub(crate) fn try_walker_inline_user_call<Sym: WalkSym>(
         }
     }
     let ConcreteValue::Ref(callable) = arg_concretes[0] else {
-        return Ok(None);
+        decline!("callable slot carries no concrete ref");
     };
     if callable.is_null() {
-        return Ok(None);
+        decline!("callable is null");
     }
     // The receiver slot is a checked `PY_NULL` sentinel for a plain no-receiver
     // call; its concrete shadow arrives as `Null` (`call_kw`) or `Ref(PY_NULL)`
@@ -1602,7 +1614,7 @@ pub(crate) fn try_walker_inline_user_call<Sym: WalkSym>(
     let null_or_self = match arg_concretes[1] {
         ConcreteValue::Ref(r) => r,
         ConcreteValue::Null => pyre_object::PY_NULL,
-        _ => return Ok(None),
+        _ => decline!("receiver slot carries no concrete ref"),
     };
     let mut method_form = !null_or_self.is_null() && null_or_self != pyre_object::PY_NULL;
     // baseobjspace.py:1254-1259 unwraps `_Method` before the Function
@@ -1629,10 +1641,7 @@ pub(crate) fn try_walker_inline_user_call<Sym: WalkSym>(
     let Some((w_code, nparams, has_closure)) =
         (unsafe { resolve_inlinable_callee(resolved_callable) })
     else {
-        if std::env::var_os("PYRE_FBW_INLINE_DIAG").is_some() {
-            eprintln!("[inline-decline] pc={} callee not inlinable", op.pc);
-        }
-        return Ok(None);
+        decline!("callee not inlinable");
     };
     if std::env::var_os("PYRE_FBW_INLINE_DIAG").is_some() {
         eprintln!(

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -1641,11 +1641,28 @@ pub(crate) fn try_walker_inline_user_call<Sym: WalkSym>(
     let Some((w_code, nparams, has_closure)) =
         (unsafe { resolve_inlinable_callee(resolved_callable) })
     else {
-        decline!("callee not inlinable");
+        // The callable's type is the whole answer here: `resolve_inlinable_callee`
+        // takes plain `function` only, so a `builtin_function_or_method` or a
+        // `method` reads as "not inlinable" for a reason no pc can convey.
+        decline!(format_args!(
+            "callee not inlinable (callable type {})",
+            unsafe { pyre_object::type_name_of(callable) }
+        ));
     };
     if std::env::var_os("PYRE_FBW_INLINE_DIAG").is_some() {
+        // Name the callee: a pc alone does not say which function a decline
+        // cost, and one trace reaches several.
+        let name = unsafe {
+            let raw = pyre_interpreter::w_code_get_ptr(w_code as pyre_object::PyObjectRef)
+                as *const pyre_interpreter::CodeObject;
+            if raw.is_null() {
+                String::new()
+            } else {
+                (*raw).qualname.clone()
+            }
+        };
         eprintln!(
-            "[inline-resolved] pc={} nparams={nparams} has_closure={has_closure} method_form={method_form}",
+            "[inline-resolved] pc={} callee={name} nparams={nparams} has_closure={has_closure} method_form={method_form}",
             op.pc,
         );
     }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -2329,6 +2329,32 @@ pub(crate) fn try_walker_inline_builtin_call<Sym: WalkSym>(
     }
 }
 
+/// Whether any level already on the inline stack is a recursion unroll — the
+/// snapshot root's own code re-entered, or one code appearing twice in the
+/// chain (a mutual cycle).
+///
+/// Such a chain's levels are suspended copies of the same frame, so an unwind
+/// through it is the shape `fbw_max_rec_unroll_depth` bounds rather than the
+/// straight-line chain `fbw_max_multiframe_depth` covers.
+fn inline_chain_unrolls_recursion<Sym: WalkSym>(ctx: &WalkContext<'_, '_, Sym>) -> bool {
+    let sym_ptr = ctx.fbw_mode.snapshot_sym;
+    let root_code = if sym_ptr.is_null() {
+        0
+    } else {
+        unsafe {
+            pyre_interpreter::live_code_wrapper((*(*sym_ptr).jitcode()).raw_code() as *const ())
+                as *const () as usize
+        }
+    };
+    let session = ctx.session.borrow();
+    session.framestack.iter().enumerate().any(|(i, frame)| {
+        frame.w_code == root_code
+            || session.framestack[..i]
+                .iter()
+                .any(|outer| outer.w_code == frame.w_code)
+    })
+}
+
 /// Shared post-resolution half of the FBW inline lever. Ordinary Python calls
 /// resolve their callee from the CALL operand; builtin-dispatch specializers
 /// resolve an app-level descriptor first and enter here with that function as
@@ -2758,12 +2784,30 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
         u16::MAX
     };
     let inline_depth = ctx.session.borrow().framestack.len();
-    // A callee that raises inline is inlinable only at the top level: below an
-    // intermediate frame its unwind needs the cross-frame bridge (gh#343 /
-    // gh#467) the drain cannot yet build (`callee_body_contains_raise`).  A
-    // value-returning chain (no raise) inlines to the full depth.
+    // A callee that raises inline needs the cross-frame bridge (gh#343 /
+    // gh#467) the drain cannot yet build, but only when the raise has to come
+    // back INTO the traced region — i.e. when some frame already on the
+    // framestack catches it.  Measured: admitting such a callee below an
+    // intermediate frame takes `guard_failures` from 1203 to 19654 and drops
+    // `bridges_compiled` from 6 to 2 on a caught-in-loop shape, because the
+    // guards it emits keep failing with no bridge to land on.
+    //
+    // When no modelled frame catches, the raise leaves the traced region
+    // entirely and takes the guard-exception exit, which needs no such bridge —
+    // `bench/synth/exception_escape_caller_frame_tb_node`'s `d_no_try` shape.
+    // A value-returning chain (no raise) inlines to the full depth either way.
+    //
+    // The lift is one level, not the full chain depth: the shape it unlocks is
+    // a single intermediate frame between the loop and the raise, and a chain
+    // whose levels are self-recursive unrolls keeps the recursion bound
+    // instead. The unwind out of such a chain crosses suspended copies of the
+    // same frame, which is what `fbw_max_rec_unroll_depth` bounds above;
+    // letting the raising leaf inline below one costs 1.9x on
+    // `bench/synth/selfrec_tail_exception_unwind`.
     let effective_multiframe_depth = if callee_body_contains_raise(body.code) {
-        1
+        let bounded = crate::jitcode_dispatch::inline_chain_catches_a_raise(ctx.session)
+            || inline_chain_unrolls_recursion(ctx);
+        if bounded { 1 } else { 2 }
     } else {
         fbw_max_multiframe_depth()
     };

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -3232,28 +3232,10 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
     // snapshot both frames.  Compute it here, while the caller's live register
     // banks (`ctx.registers_*`) are still in scope — at guard-capture time the
     // walk context is the callee's. A caller frame that is not snapshot-able
-    // (try-block catch marker / missing liveness) declines to interpretation.
+    // (missing liveness) declines to interpretation.
     let parent_frame = if try_multiframe {
         match compute_inline_caller_frame(ctx, op.pc) {
             Ok(pf) => Some(pf),
-            Err(InlineCallerFrameDecline::TryBlockCatchMarker) => {
-                // An un-entered multiframe-inline CALL declined at its
-                // try-block catch marker is re-run whole and forward, exactly
-                // as if it had never been inlined (`pyjitpl.py`).  The
-                // multi-frame guard snapshot itself remains declined.
-                if is_top_inline
-                    && !unjournaled_before_subwalk
-                    && fbw_executed_effect_count() == executed_effects_before
-                {
-                    if let (Some((outer_jitcode_index, call_jitcode_pc)), Some(stack)) = (
-                        abort_flush_call_jitcode_coord,
-                        reconstructed_all_ref_call_stack(code, op, ctx),
-                    ) {
-                        fbw_set_abort_call_resume(outer_jitcode_index, call_jitcode_pc, stack);
-                    }
-                }
-                return Err(DispatchError::callee_inline_unsupported(op.pc));
-            }
             Err(InlineCallerFrameDecline::Unavailable) => {
                 return Err(DispatchError::callee_inline_unsupported(op.pc));
             }
@@ -3280,45 +3262,13 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
         // single-frame collapse there (do NOT decline the inline — that shape is
         // served correctly today), so this never removes a working inline.
         //
-        // A `TryBlockCatchMarker` decline is different: the CALL is covered by
-        // the caller's exception table.  The collapse resumes at the CALL's
-        // pre-call `-live-`, which precedes the CALL's own `catch_exception`,
-        // so an in-callee `GUARD_NO_EXCEPTION` failing there hands the
-        // blackhole a pending exception at a coordinate from which neither the
-        // forward check nor the bounded backward startpoint scan
-        // (`handle_exception_in_frame`) can reach that catch — the raise exits
-        // the caller frame past its matching handler.  Decline the inline so
-        // the call stays residual, where the post-call catch resume
-        // (`GuardCaptureScope::residual_call_catch_resume`) routes the raise.
-        //
-        // This `Err` discards the whole enclosing loop trace, where the comment
-        // above describes only declining the inline — and it costs real
-        // compilation: `synth/exception_nested_exc_info_restore`'s
-        // `classify(sys.exc_info()[0])` calls sit in handler bodies, whose
-        // implicit cleanup entry never rejoins the loop, so every retrace
-        // aborts here and the loop is interpreted (5 aborts, 0.34s vs 0.17s
-        // once inlined).  It cannot become `Ok(None)` in place like the seed
-        // preconditions below: by here the seed block has already recorded
-        // `GETFIELD_GC_R` + `emit_new_pyframe_inline_with_params` and stamped a
-        // concrete `FrameBox` onto that op, so returning would leave dead IR
-        // behind.
-        //
-        // Hoisting the decline (`decline_inline_caller_frame_for_catch_marker`
-        // is caller-side, so it answers before the seed) is mechanical, but the
-        // abort is masking two defects on the residual path it would open, both
-        // reproduced by doing exactly that:
-        //   * `synth/exception_inline_callee_tb_frames` panics in the dynasm
-        //     backend with `RegisterManager.loc: box RefOp(N) not found`;
-        //   * `synth/gc_bug_bridge_flavor_traceback_names` prints traceback
-        //     tuples missing their outermost frame — the caller's own
-        //     `PyTraceback` node is never recorded once its try-block CALL goes
-        //     residual (that fixture pins its expected output in its header).
-        // Fix those two first; the hoist is then a two-line change.
+        // A CALL covered by the caller's exception table is inlined like any
+        // other: the paused caller frame resumes at the CALL fallthrough on the
+        // no-raise path, and on a raise the caller's `lastblock` unwinds to the
+        // catch handler in the blackhole, while a hot raise bridges into the
+        // enclosing loop via the carrier-boundary delivery.
         match compute_inline_caller_frame(ctx, op.pc) {
             Ok(pf) => Some(pf),
-            Err(InlineCallerFrameDecline::TryBlockCatchMarker) => {
-                return Err(DispatchError::callee_inline_unsupported(op.pc));
-            }
             Err(InlineCallerFrameDecline::Unavailable) => None,
         }
     } else {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -3232,10 +3232,28 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
     // snapshot both frames.  Compute it here, while the caller's live register
     // banks (`ctx.registers_*`) are still in scope — at guard-capture time the
     // walk context is the callee's. A caller frame that is not snapshot-able
-    // (missing liveness) declines to interpretation.
+    // (try-block catch marker / missing liveness) declines to interpretation.
     let parent_frame = if try_multiframe {
         match compute_inline_caller_frame(ctx, op.pc) {
             Ok(pf) => Some(pf),
+            Err(InlineCallerFrameDecline::TryBlockCatchMarker) => {
+                // An un-entered multiframe-inline CALL declined at its
+                // try-block catch marker is re-run whole and forward, exactly
+                // as if it had never been inlined (`pyjitpl.py`).  The
+                // multi-frame guard snapshot itself remains declined.
+                if is_top_inline
+                    && !unjournaled_before_subwalk
+                    && fbw_executed_effect_count() == executed_effects_before
+                {
+                    if let (Some((outer_jitcode_index, call_jitcode_pc)), Some(stack)) = (
+                        abort_flush_call_jitcode_coord,
+                        reconstructed_all_ref_call_stack(code, op, ctx),
+                    ) {
+                        fbw_set_abort_call_resume(outer_jitcode_index, call_jitcode_pc, stack);
+                    }
+                }
+                return Err(DispatchError::callee_inline_unsupported(op.pc));
+            }
             Err(InlineCallerFrameDecline::Unavailable) => {
                 return Err(DispatchError::callee_inline_unsupported(op.pc));
             }
@@ -3262,13 +3280,45 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
         // single-frame collapse there (do NOT decline the inline — that shape is
         // served correctly today), so this never removes a working inline.
         //
-        // A CALL covered by the caller's exception table is inlined like any
-        // other: the paused caller frame resumes at the CALL fallthrough on the
-        // no-raise path, and on a raise the caller's `lastblock` unwinds to the
-        // catch handler in the blackhole, while a hot raise bridges into the
-        // enclosing loop via the carrier-boundary delivery.
+        // A `TryBlockCatchMarker` decline is different: the CALL is covered by
+        // the caller's exception table.  The collapse resumes at the CALL's
+        // pre-call `-live-`, which precedes the CALL's own `catch_exception`,
+        // so an in-callee `GUARD_NO_EXCEPTION` failing there hands the
+        // blackhole a pending exception at a coordinate from which neither the
+        // forward check nor the bounded backward startpoint scan
+        // (`handle_exception_in_frame`) can reach that catch — the raise exits
+        // the caller frame past its matching handler.  Decline the inline so
+        // the call stays residual, where the post-call catch resume
+        // (`GuardCaptureScope::residual_call_catch_resume`) routes the raise.
+        //
+        // This `Err` discards the whole enclosing loop trace, where the comment
+        // above describes only declining the inline — and it costs real
+        // compilation: `synth/exception_nested_exc_info_restore`'s
+        // `classify(sys.exc_info()[0])` calls sit in handler bodies, whose
+        // implicit cleanup entry never rejoins the loop, so every retrace
+        // aborts here and the loop is interpreted (5 aborts, 0.34s vs 0.17s
+        // once inlined).  It cannot become `Ok(None)` in place like the seed
+        // preconditions below: by here the seed block has already recorded
+        // `GETFIELD_GC_R` + `emit_new_pyframe_inline_with_params` and stamped a
+        // concrete `FrameBox` onto that op, so returning would leave dead IR
+        // behind.
+        //
+        // Hoisting the decline (`decline_inline_caller_frame_for_catch_marker`
+        // is caller-side, so it answers before the seed) is mechanical, but the
+        // abort is masking two defects on the residual path it would open, both
+        // reproduced by doing exactly that:
+        //   * `synth/exception_inline_callee_tb_frames` panics in the dynasm
+        //     backend with `RegisterManager.loc: box RefOp(N) not found`;
+        //   * `synth/gc_bug_bridge_flavor_traceback_names` prints traceback
+        //     tuples missing their outermost frame — the caller's own
+        //     `PyTraceback` node is never recorded once its try-block CALL goes
+        //     residual (that fixture pins its expected output in its header).
+        // Fix those two first; the hoist is then a two-line change.
         match compute_inline_caller_frame(ctx, op.pc) {
             Ok(pf) => Some(pf),
+            Err(InlineCallerFrameDecline::TryBlockCatchMarker) => {
+                return Err(DispatchError::callee_inline_unsupported(op.pc));
+            }
             Err(InlineCallerFrameDecline::Unavailable) => None,
         }
     } else {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -3234,7 +3234,7 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
     // walk context is the callee's. A caller frame that is not snapshot-able
     // (try-block catch marker / missing liveness) declines to interpretation.
     let parent_frame = if try_multiframe {
-        match compute_inline_caller_frame(ctx, op.pc) {
+        match compute_inline_caller_frame(ctx, op.pc, !callee_code.freevars.is_empty()) {
             Ok(pf) => Some(pf),
             Err(InlineCallerFrameDecline::TryBlockCatchMarker) => {
                 // An un-entered multiframe-inline CALL declined at its
@@ -3281,40 +3281,21 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
         // served correctly today), so this never removes a working inline.
         //
         // A `TryBlockCatchMarker` decline is different: the CALL is covered by
-        // the caller's exception table.  The collapse resumes at the CALL's
-        // pre-call `-live-`, which precedes the CALL's own `catch_exception`,
-        // so an in-callee `GUARD_NO_EXCEPTION` failing there hands the
-        // blackhole a pending exception at a coordinate from which neither the
-        // forward check nor the bounded backward startpoint scan
-        // (`handle_exception_in_frame`) can reach that catch — the raise exits
-        // the caller frame past its matching handler.  Decline the inline so
-        // the call stays residual, where the post-call catch resume
+        // the caller's exception table AND the callee has free variables, so it
+        // reads cells the caller frame owns — one of which, inside a handler, is
+        // the `except E as e` binding the implicit cleanup stores `None` into
+        // and then clears.  Inlining reads that cell as `None`
+        // (`synth/exception_as_cell_cleanup`).  Decline so the call stays
+        // residual, where the post-call catch resume
         // (`GuardCaptureScope::residual_call_catch_resume`) routes the raise.
         //
         // This `Err` discards the whole enclosing loop trace, where the comment
-        // above describes only declining the inline — and it costs real
-        // compilation: `synth/exception_nested_exc_info_restore`'s
-        // `classify(sys.exc_info()[0])` calls sit in handler bodies, whose
-        // implicit cleanup entry never rejoins the loop, so every retrace
-        // aborts here and the loop is interpreted (5 aborts, 0.34s vs 0.17s
-        // once inlined).  It cannot become `Ok(None)` in place like the seed
-        // preconditions below: by here the seed block has already recorded
-        // `GETFIELD_GC_R` + `emit_new_pyframe_inline_with_params` and stamped a
-        // concrete `FrameBox` onto that op, so returning would leave dead IR
-        // behind.
-        //
-        // Hoisting the decline (`decline_inline_caller_frame_for_catch_marker`
-        // is caller-side, so it answers before the seed) is mechanical, but the
-        // abort is masking two defects on the residual path it would open, both
-        // reproduced by doing exactly that:
-        //   * `synth/exception_inline_callee_tb_frames` panics in the dynasm
-        //     backend with `RegisterManager.loc: box RefOp(N) not found`;
-        //   * `synth/gc_bug_bridge_flavor_traceback_names` prints traceback
-        //     tuples missing their outermost frame — the caller's own
-        //     `PyTraceback` node is never recorded once its try-block CALL goes
-        //     residual (that fixture pins its expected output in its header).
-        // Fix those two first; the hoist is then a two-line change.
-        match compute_inline_caller_frame(ctx, op.pc) {
+        // above describes only declining the inline.  It cannot become
+        // `Ok(None)` in place like the seed preconditions below: by here the
+        // seed block has already recorded `GETFIELD_GC_R` +
+        // `emit_new_pyframe_inline_with_params` and stamped a concrete
+        // `FrameBox` onto that op, so returning would leave dead IR behind.
+        match compute_inline_caller_frame(ctx, op.pc, !callee_code.freevars.is_empty()) {
             Ok(pf) => Some(pf),
             Err(InlineCallerFrameDecline::TryBlockCatchMarker) => {
                 return Err(DispatchError::callee_inline_unsupported(op.pc));

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -3993,18 +3993,14 @@ pub(crate) fn try_walker_inline_exception_string_override<Sym: WalkSym>(
     if !exception_string_override_straight_line(body.code) {
         return Ok(None);
     }
-    // A nested Python call in the override body (e.g. `return repr(self.args)`)
-    // cannot be inlined on this bounded route: recording the callee's own
-    // residual and its guard-resume snapshot aborts mid-trace, discarding the
-    // whole loop instead of declining.  Keep such a body on the residual
-    // dispatch path where the interpreter owns the nested frame.
-    let Some((override_descr_refs, _, _)) = crate::state::sub_jitcode_descr_pool_for_code(w_code)
+    // A nested call in the override body (e.g. `return repr(self.args)`) is
+    // inlined like any other: the nested callee records its own residual and
+    // guard-resume snapshot on this route without aborting, and a raise from it
+    // reaches the enclosing handler unchanged.
+    let Some((_override_descr_refs, _, _)) = crate::state::sub_jitcode_descr_pool_for_code(w_code)
     else {
         return Ok(None);
     };
-    if exception_string_override_has_nested_call(body.code, override_descr_refs) {
-        return Ok(None);
-    }
 
     // A straight-line, effect-free override can be sampled before any IR is
     // emitted. If its observed result is not a string, decline to the original

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -2688,10 +2688,7 @@ pub(crate) fn find_catch_for_exc_resume(code: &[u8], resume_live_pos: usize) -> 
 /// that coordinate, so the same scan walks straight past the catch. Read
 /// forward for those callers: when `resume_live_pos` is a `-live-` whose very
 /// next op is a `catch_exception`, that catch is the one guarding the op.
-pub(crate) fn catch_target_after_resume_live(
-    code: &[u8],
-    resume_live_pos: usize,
-) -> Option<usize> {
+pub(crate) fn catch_target_after_resume_live(code: &[u8], resume_live_pos: usize) -> Option<usize> {
     let live = decode_op_at(code, resume_live_pos)?;
     if live.key != "live/" {
         return None;

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -740,6 +740,25 @@ fn emit_traceback_node<Sym: WalkSym>(
             .heapcache_setfield_cached(traceback, descr.index(), value);
     }
 
+    // `f_lineno` resolves through `offset2lineno(pycode, last_instr)` on every
+    // read, so the frame itself has to carry the coordinate — the node's own
+    // `tb_lasti` answers a different question and is frozen. The interpreter
+    // gets this for free from `pyopcode.py`'s per-opcode `last_instr` store;
+    // compiled code does not run it, and `fbw_publish_exit_last_instr` only
+    // reaches the virtualizable, so an inlined callee frame would keep the `-1`
+    // initialization sentinel and report its `def` line. A frame that goes on
+    // running has this overwritten by its own later publish, exactly as the
+    // per-opcode store would.
+    let last_instr_value = ctx.trace_ctx.const_int(i64::from(site.last_instruction));
+    let last_instr_descr = crate::descr::pyframe_next_instr_descr();
+    ctx.trace_ctx.record_op_with_descr(
+        OpCode::SetfieldGc,
+        &[site.frame, last_instr_value],
+        last_instr_descr.clone(),
+    );
+    ctx.trace_ctx
+        .heapcache_setfield_cached(site.frame, last_instr_descr.index(), last_instr_value);
+
     let traceback_descr = crate::descr::w_exception_traceback_descr(kind);
     ctx.trace_ctx.record_op_with_descr(
         OpCode::SetfieldGc,
@@ -2747,11 +2766,12 @@ fn label_operand_offset(key: &str) -> Option<usize> {
 /// (`pyjitpl.py:2530-2546`) does, and a handler that returns out of the frame is
 /// `finishframe`'s ordinary case (`pyjitpl.py:2503-2525`).
 ///
-/// What the predicate still gates is INLINING a caller whose in-try CALL would
-/// deliver a raise across the inline boundary: with a non-rejoining handler that
-/// delivery drops the catching frame's traceback node, so
-/// `exception_traceback_frame_lineno` reports the raising frame twice and at the
-/// wrong lineno (both backends).
+/// What the predicate still gates is INLINING a CLOSURE callee at a caller's
+/// in-try CALL.  A non-rejoining handler is an `except E as e` body, and the
+/// callee's free variables resolve through cells that body's implicit cleanup
+/// stores `None` into and then clears; the inlined read answers `None`
+/// (`synth/exception_as_cell_cleanup`, dynasm).  A callee with no free
+/// variables cannot reach a caller cell and is inlined either way.
 ///
 /// Bounded forward reachability from `catch_target`, following `goto`/
 /// `goto_if_not` successors: `true` as soon as any path reaches a

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -4703,6 +4703,40 @@ struct InlineParentBlackhole {
     float_values: Vec<(usize, OpRef)>,
 }
 
+/// Whether any frame the trace already models would catch an exception raised
+/// below it — i.e. whether a raise escaping the callee about to be inlined has
+/// to be routed back INTO the traced region.
+///
+/// Each paused caller on the framestack is asked whether its own pending CALL
+/// sits inside a try-block, the same `after_residual_call_resume` →
+/// `catch_exception/L` lookup [`decline_inline_caller_frame_for_catch_marker`]
+/// uses. Level 0's parent is the snapshot root, so the scan covers the root
+/// frame and every intermediate one; the innermost CALL needs no test here
+/// because a nested try-block CALL already declines multiframe on its own.
+///
+/// Unknown answers count as catching: a parent with no snapshot, an
+/// unresolvable jitcode, or a CALL with no recorded pc could all be hiding a
+/// handler, and admitting one wrongly costs a guard storm.
+pub(crate) fn inline_chain_catches_a_raise(session: &std::cell::RefCell<WalkSession>) -> bool {
+    session.borrow().framestack.iter().any(|frame| {
+        let Some(parent) = frame.parent.as_ref() else {
+            return true;
+        };
+        let Some(call_pc) = parent.call_jitcode_pc else {
+            return true;
+        };
+        let Some(pjc) = crate::state::pyjitcode_for_jitcode_index(parent.jitcode_index as i32)
+        else {
+            return true;
+        };
+        match pjc.after_residual_call_resume_for_jitcode_pc(call_pc) {
+            // No after-call resume marker: the CALL is not in a try-block.
+            None => false,
+            Some(resume) => try_catch_exception_at(pjc.jitcode.code.as_slice(), resume).is_some(),
+        }
+    })
+}
+
 /// The derivation flavor of a paused caller frame's Python resume pc.
 #[derive(Clone, Copy)]
 enum ParentResumeCoord {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -2100,17 +2100,21 @@ pub(crate) fn census_dump() {
 
 /// Carrier-boundary raise seed (`finishframe_exception` at the bridge carrier):
 /// set by [`crate::trace::drive_bridge_carrier_walk`] when a depth-2 inlined
-/// callee's sub-walk ended in `SubRaise` and the ROOT frame's `except` handler
-/// covers the CALL.  [`crate::jitcode_dispatch::dispatch_via_miframe`] reads it
-/// once when it sets up the root walk and enters at `catch_target` with the
-/// caught exception seeded — the same handler-entry reconstruction the
-/// walk-level SubRaise routing performs, but at the carrier boundary the
-/// sub-walk crossed on its own.
+/// callee's sub-walk ended in `SubRaise`.
+/// [`crate::jitcode_dispatch::dispatch_via_miframe`] reads it once when it sets
+/// up the root walk.  With `catch_target` set the root frame's `except` handler
+/// covers the CALL and the walk enters at that handler with the caught
+/// exception seeded — the same handler-entry reconstruction the walk-level
+/// SubRaise routing performs, but at the carrier boundary the sub-walk crossed
+/// on its own.  `None` means the root frame has no covering handler: the
+/// framestack this trace models is exhausted, so the walk ends immediately with
+/// `compile_exit_frame_with_exception` and the interpreter unwinds the
+/// remaining Python frames.
 #[derive(Clone, Copy)]
 pub(crate) struct CarrierRaiseSeed {
     pub exc: OpRef,
     pub exc_concrete: crate::state::ConcreteValue,
-    pub catch_target: usize,
+    pub catch_target: Option<usize>,
 }
 
 thread_local! {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -740,25 +740,6 @@ fn emit_traceback_node<Sym: WalkSym>(
             .heapcache_setfield_cached(traceback, descr.index(), value);
     }
 
-    // `f_lineno` resolves through `offset2lineno(pycode, last_instr)` on every
-    // read, so the frame itself has to carry the coordinate — the node's own
-    // `tb_lasti` answers a different question and is frozen. The interpreter
-    // gets this for free from `pyopcode.py`'s per-opcode `last_instr` store;
-    // compiled code does not run it, and `fbw_publish_exit_last_instr` only
-    // reaches the virtualizable, so an inlined callee frame would keep the `-1`
-    // initialization sentinel and report its `def` line. A frame that goes on
-    // running has this overwritten by its own later publish, exactly as the
-    // per-opcode store would.
-    let last_instr_value = ctx.trace_ctx.const_int(i64::from(site.last_instruction));
-    let last_instr_descr = crate::descr::pyframe_next_instr_descr();
-    ctx.trace_ctx.record_op_with_descr(
-        OpCode::SetfieldGc,
-        &[site.frame, last_instr_value],
-        last_instr_descr.clone(),
-    );
-    ctx.trace_ctx
-        .heapcache_setfield_cached(site.frame, last_instr_descr.index(), last_instr_value);
-
     let traceback_descr = crate::descr::w_exception_traceback_descr(kind);
     ctx.trace_ctx.record_op_with_descr(
         OpCode::SetfieldGc,
@@ -2754,6 +2735,69 @@ fn label_operand_offset(key: &str) -> Option<usize> {
         }
     }
     None
+}
+
+/// Does the `except` handler at `catch_target` flow back into this frame's loop
+/// (reaching a `jit_merge_point` back-edge), rather than returning out of the
+/// frame (`*_return`)?
+///
+/// Sole caller: [`decline_inline_caller_frame_for_catch_marker`].  The
+/// exception-edge bridge router itself does NOT consult this — it routes on the
+/// `catch_exception` alone, the way `finishframe_exception`
+/// (`pyjitpl.py:2530-2546`) does, and a handler that returns out of the frame is
+/// `finishframe`'s ordinary case (`pyjitpl.py:2503-2525`).
+///
+/// What the predicate still gates is INLINING a caller whose in-try CALL would
+/// deliver a raise across the inline boundary: with a non-rejoining handler that
+/// delivery drops the catching frame's traceback node, so
+/// `exception_traceback_frame_lineno` reports the raising frame twice and at the
+/// wrong lineno (both backends).
+///
+/// Bounded forward reachability from `catch_target`, following `goto`/
+/// `goto_if_not` successors: `true` as soon as any path reaches a
+/// `jit_merge_point`; `false` if every reachable path terminates at a `*_return`
+/// (or the scan hits an un-followed control op / the bound, which conservatively
+/// declines).
+pub(crate) fn exc_handler_rejoins_loop(code: &[u8], catch_target: usize) -> bool {
+    let mut visited = std::collections::HashSet::new();
+    let mut work = vec![catch_target];
+    let mut budget = 4096usize;
+    while let Some(pc) = work.pop() {
+        if budget == 0 {
+            return false;
+        }
+        budget -= 1;
+        if !visited.insert(pc) {
+            continue;
+        }
+        let Some(op) = decode_op_at(code, pc) else {
+            continue;
+        };
+        if op.key.starts_with("jit_merge_point") {
+            return true;
+        }
+        if matches!(
+            op.key,
+            "ref_return/r" | "int_return/i" | "float_return/f" | "void_return/"
+        ) {
+            // Frame-return terminal on this path; do not enqueue successors.
+            continue;
+        }
+        match op.key {
+            "goto/L" => work.push(read_label(code, &op, 0)),
+            "goto_if_not/iL" => {
+                // `iL`: 1B int register + 2B LE label.
+                work.push(read_label(code, &op, 1));
+                work.push(op.next_pc);
+            }
+            key if key.starts_with("switch") => {
+                // Multi-target dispatch not followed; leave this path un-proven
+                // (routing declines unless another path rejoins the loop).
+            }
+            _ => work.push(op.next_pc),
+        }
+    }
+    false
 }
 
 /// True when a path reachable from `position` reads the walker's active

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -2655,6 +2655,33 @@ pub(crate) fn find_catch_for_exc_resume(code: &[u8], resume_live_pos: usize) -> 
 /// outside any in-frame try.
 /// Returns the handler target (2-byte LE label after `catch_exception/L`), or
 /// `None` when the raising op sits outside any in-frame try (propagate).
+/// The `catch_exception/L` target of the can-raise op whose OWN trailing
+/// `-live-` sits at `resume_live_pos`.
+///
+/// A caught can-raise op expands to `[op, -live-, catch_exception,
+/// -live-(block entry), vable stores…]`.  [`find_catch_before_resume_live`]
+/// keys off the SUCCESSOR block-entry `-live-` and reads backward from it; a
+/// caller holding the op's own trailing `-live-` instead is one op short of
+/// that coordinate, so the same scan walks straight past the catch. Read
+/// forward for those callers: when `resume_live_pos` is a `-live-` whose very
+/// next op is a `catch_exception`, that catch is the one guarding the op.
+pub(crate) fn catch_target_after_resume_live(
+    code: &[u8],
+    resume_live_pos: usize,
+) -> Option<usize> {
+    let live = decode_op_at(code, resume_live_pos)?;
+    if live.key != "live/" {
+        return None;
+    }
+    let catch = decode_op_at(code, live.next_pc)?;
+    if catch.key != "catch_exception/L" {
+        return None;
+    }
+    let lo = *code.get(catch.pc + 1)? as usize;
+    let hi = *code.get(catch.pc + 2)? as usize;
+    Some(lo | (hi << 8))
+}
+
 pub(crate) fn find_catch_before_resume_live(code: &[u8], resume_live_pos: usize) -> Option<usize> {
     let mut pcs: Vec<usize> = crate::jitcode_runtime::decoded_ops(code)
         .map(|op| op.pc)

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -740,6 +740,25 @@ fn emit_traceback_node<Sym: WalkSym>(
             .heapcache_setfield_cached(traceback, descr.index(), value);
     }
 
+    // `f_lineno` resolves through `offset2lineno(pycode, last_instr)` on every
+    // read, so the frame itself has to carry the coordinate — the node's own
+    // `tb_lasti` answers a different question and is frozen. The interpreter
+    // gets this for free from `pyopcode.py`'s per-opcode `last_instr` store;
+    // compiled code does not run it, and `fbw_publish_exit_last_instr` only
+    // reaches the virtualizable, so an inlined callee frame would keep the `-1`
+    // initialization sentinel and report its `def` line. A frame that goes on
+    // running has this overwritten by its own later publish, exactly as the
+    // per-opcode store would.
+    let last_instr_value = ctx.trace_ctx.const_int(i64::from(site.last_instruction));
+    let last_instr_descr = crate::descr::pyframe_next_instr_descr();
+    ctx.trace_ctx.record_op_with_descr(
+        OpCode::SetfieldGc,
+        &[site.frame, last_instr_value],
+        last_instr_descr.clone(),
+    );
+    ctx.trace_ctx
+        .heapcache_setfield_cached(site.frame, last_instr_descr.index(), last_instr_value);
+
     let traceback_descr = crate::descr::w_exception_traceback_descr(kind);
     ctx.trace_ctx.record_op_with_descr(
         OpCode::SetfieldGc,
@@ -2731,69 +2750,6 @@ fn label_operand_offset(key: &str) -> Option<usize> {
         }
     }
     None
-}
-
-/// Does the `except` handler at `catch_target` flow back into this frame's loop
-/// (reaching a `jit_merge_point` back-edge), rather than returning out of the
-/// frame (`*_return`)?
-///
-/// Sole caller: [`decline_inline_caller_frame_for_catch_marker`].  The
-/// exception-edge bridge router itself does NOT consult this — it routes on the
-/// `catch_exception` alone, the way `finishframe_exception`
-/// (`pyjitpl.py:2530-2546`) does, and a handler that returns out of the frame is
-/// `finishframe`'s ordinary case (`pyjitpl.py:2503-2525`).
-///
-/// What the predicate still gates is INLINING a caller whose in-try CALL would
-/// deliver a raise across the inline boundary: with a non-rejoining handler that
-/// delivery drops the catching frame's traceback node, so
-/// `exception_traceback_frame_lineno` reports the raising frame twice and at the
-/// wrong lineno (both backends).
-///
-/// Bounded forward reachability from `catch_target`, following `goto`/
-/// `goto_if_not` successors: `true` as soon as any path reaches a
-/// `jit_merge_point`; `false` if every reachable path terminates at a `*_return`
-/// (or the scan hits an un-followed control op / the bound, which conservatively
-/// declines).
-pub(crate) fn exc_handler_rejoins_loop(code: &[u8], catch_target: usize) -> bool {
-    let mut visited = std::collections::HashSet::new();
-    let mut work = vec![catch_target];
-    let mut budget = 4096usize;
-    while let Some(pc) = work.pop() {
-        if budget == 0 {
-            return false;
-        }
-        budget -= 1;
-        if !visited.insert(pc) {
-            continue;
-        }
-        let Some(op) = decode_op_at(code, pc) else {
-            continue;
-        };
-        if op.key.starts_with("jit_merge_point") {
-            return true;
-        }
-        if matches!(
-            op.key,
-            "ref_return/r" | "int_return/i" | "float_return/f" | "void_return/"
-        ) {
-            // Frame-return terminal on this path; do not enqueue successors.
-            continue;
-        }
-        match op.key {
-            "goto/L" => work.push(read_label(code, &op, 0)),
-            "goto_if_not/iL" => {
-                // `iL`: 1B int register + 2B LE label.
-                work.push(read_label(code, &op, 1));
-                work.push(op.next_pc);
-            }
-            key if key.starts_with("switch") => {
-                // Multi-target dispatch not followed; leave this path un-proven
-                // (routing declines unless another path rejoins the loop).
-            }
-            _ => work.push(op.next_pc),
-        }
-    }
-    false
 }
 
 /// True when a path reachable from `position` reads the walker's active

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -3057,13 +3057,20 @@ pub(crate) fn residual_call_descr_index_in_body(body_code: &[u8], d: &DecodedOp)
 ///   unconditional, but *int-only*: the float table falls through to
 ///   `_ => return Ok(None)` for them.  Hence the separate
 ///   `args_all_exact_plain_int`.
+/// - `FloorDivide` / `Remainder` (+ in-place) — `IntFloorDiv` / `IntMod`,
+///   int-only for the same reason (neither has a `FLOAT_*` opcode).  These two
+///   are the one accepted pair whose lowering *can* decline — on a zero divisor
+///   or on `i64::MIN` by `-1` — but a surviving residual is still replay-safe
+///   on its own merits: `int.__floordiv__` / `int.__mod__` read two immutable
+///   boxes and either allocate a fresh result or raise `ZeroDivisionError`,
+///   which commits nothing a replay would double.  The `plain_int` proof is
+///   what rules out a user `__mod__`.  `i % k` in an `if` is the common shape
+///   that would otherwise residualize the whole callee
+///   (`bench/synth/gc_bug_bridge_flavor_traceback_names`).
 ///
 /// Every other tag is excluded because its lowering can still decline and
-/// leave the residual in place:
+/// leave a residual that is NOT replay-safe on its own:
 ///
-/// - `FloorDivide` / `Remainder` (+ in-place) — int-table `needs_concrete_check`
-///   declines a zero or `i64::MIN / -1` divisor; the float table has no
-///   `FLOAT_*` opcode for either.
 /// - `TrueDivide` (+ in-place) — float-table only, and it declines a zero
 ///   divisor so the raising `descr_truediv` stays recorded.
 /// - `Lshift` (+ in-place) — the int table declines it outright (the reused
@@ -3157,7 +3164,11 @@ pub(crate) fn residual_call_is_specialized_plain_numeric_op(
             | BinaryOperator::Xor
             | BinaryOperator::InplaceAnd
             | BinaryOperator::InplaceOr
-            | BinaryOperator::InplaceXor,
+            | BinaryOperator::InplaceXor
+            | BinaryOperator::FloorDivide
+            | BinaryOperator::Remainder
+            | BinaryOperator::InplaceFloorDivide
+            | BinaryOperator::InplaceRemainder,
         ) => plain_int_ref_regs[lhs_reg as usize] && plain_int_ref_regs[rhs_reg as usize],
         _ => false,
     }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -3078,7 +3078,7 @@ pub(crate) fn residual_call_descr_index_in_body(body_code: &[u8], d: &DecodedOp)
 /// The two provenance sets describe the actual operands of each binop.  This
 /// admits `def f(self, x): return x + 1` when only `x` is numeric, while still
 /// rejecting `self + x` and global numeric subclasses with user dunders.
-pub(crate) fn residual_call_is_specialized_plain_numeric_binop(
+pub(crate) fn residual_call_is_specialized_plain_numeric_op(
     body_code: &[u8],
     numeric_ref_regs: &[bool; u8::MAX as usize + 1],
     plain_int_ref_regs: &[bool; u8::MAX as usize + 1],
@@ -3087,12 +3087,14 @@ pub(crate) fn residual_call_is_specialized_plain_numeric_binop(
     constants_i: &[i64],
     callee_descr_refs: &[DescrRef],
 ) -> bool {
+    let helper = residual_call_helper_kind_in_body(body_code, d, callee_descr_refs);
     if !matches!(
         d.key,
         "residual_call_ir_r/iIRd>r" | "residual_call_ir_i/iIRd>i" | "residual_call_ir_v/iIRd"
-    ) || residual_call_helper_kind_in_body(body_code, d, callee_descr_refs)
-        != Some(majit_ir::PyreHelperKind::BinaryOp)
-    {
+    ) || !matches!(
+        helper,
+        Some(majit_ir::PyreHelperKind::BinaryOp | majit_ir::PyreHelperKind::CompareOp)
+    ) {
         return false;
     }
     // `iIR`: the R-list follows the I-list.  `walker_int_specialization_operands`
@@ -3129,6 +3131,16 @@ pub(crate) fn residual_call_is_specialized_plain_numeric_binop(
     else {
         return false;
     };
+    // Both compare tables map all six `ComparisonOperator`s unconditionally
+    // (`IntLt/Le/Gt/Ge/Eq/Ne` in `try_walker_specialize_compare_op_int`,
+    // `FloatLt/Le/Gt/Ge/Eq/Ne` in `try_walker_specialize_compare_op_float`), so
+    // no tag leaves the residual in place and there is no int-only carve-out
+    // like the bitwise binops need.  `CHECK_EXC_MATCH` reuses the `CompareOp`
+    // shape with `ISINSTANCE_OP` (tag 10), which is not one of the six and so
+    // stays excluded.
+    if helper == Some(majit_ir::PyreHelperKind::CompareOp) {
+        return pyre_interpreter::runtime_ops::compare_op_from_tag(tag).is_some();
+    }
     use pyre_interpreter::bytecode::BinaryOperator;
     match pyre_interpreter::runtime_ops::binary_op_from_tag(tag) {
         Some(
@@ -3149,6 +3161,42 @@ pub(crate) fn residual_call_is_specialized_plain_numeric_binop(
         ) => plain_int_ref_regs[lhs_reg as usize] && plain_int_ref_regs[rhs_reg as usize],
         _ => false,
     }
+}
+
+/// Is this body op a `TO_BOOL` / `POP_JUMP_IF_*` truth residual whose single
+/// Ref operand is a proven immutable builtin — an exact numeric, or the `bool`
+/// an accepted `COMPARE_OP` in the same body produced?
+///
+/// Such an operand's `__bool__` is `int`'s or `bool`'s, so the call reads a
+/// field and returns an int: it commits nothing a replay could double.  That is
+/// the same argument the `replay_safe_read` set is built on, and it holds
+/// whether or not the walk-time folds
+/// (`bool_box_truth_lookup`, `try_walker_specialize_truth_int`,
+/// `try_walker_specialize_truth_bool`) erase the residual.
+///
+/// `iRd>i`: the funcbox int operand, then the R-list (length byte, then one
+/// register per entry), then the descr.  Only the one-operand arity is the
+/// truth shape.
+pub(crate) fn residual_call_is_proven_truth(
+    body_code: &[u8],
+    numeric_ref_regs: &[bool; u8::MAX as usize + 1],
+    bool_ref_regs: &[bool; u8::MAX as usize + 1],
+    d: &DecodedOp,
+    callee_descr_refs: &[DescrRef],
+) -> bool {
+    if d.key != "residual_call_r_i/iRd>i"
+        || residual_call_helper_kind_in_body(body_code, d, callee_descr_refs)
+            != Some(majit_ir::PyreHelperKind::Truth)
+    {
+        return false;
+    }
+    if body_code.get(d.pc + 2) != Some(&1) {
+        return false;
+    }
+    let Some(&arg_reg) = body_code.get(d.pc + 3) else {
+        return false;
+    };
+    numeric_ref_regs[arg_reg as usize] || bool_ref_regs[arg_reg as usize]
 }
 
 pub(crate) fn residual_call_is_specialized_plain_int_binop(

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -3469,6 +3469,13 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
                 write_residual_call_result_to_dst(ctx, op.pc, dst, dst_bank, truth)?;
                 return Ok((DispatchOutcome::Continue, op.next_pc));
             }
+            // The boxed bool a residual `COMPARE_OP` leaves behind — the int
+            // arm above guards `INT_TYPE` and declines it, so without this the
+            // test on every `if a == b:` stays a second may-force call.
+            if let Some(truth) = try_walker_specialize_truth_bool(ctx, op.pc, r_args[0])? {
+                write_residual_call_result_to_dst(ctx, op.pc, dst, dst_bank, truth)?;
+                return Ok((DispatchOutcome::Continue, op.next_pc));
+            }
         }
     }
 

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -3174,6 +3174,47 @@ pub(crate) fn residual_call_is_specialized_plain_numeric_op(
     }
 }
 
+/// Is this body op the `CHECK_EXC_MATCH` residual — `compare_fn(exc,
+/// match_type, ISINSTANCE_OP)`?
+///
+/// Unlike the arithmetic tags, this one needs no operand proof.  The helper
+/// validates the match target and then walks the exception class MRO
+/// (`validate_check_exc_match_class` + `check_exc_match_against` →
+/// `exception_match`), reading `is_tuple` / `is_type` / the MRO array and
+/// nothing else: it reaches no user code for any operand, mutates nothing, and
+/// returns one of the two immortal `bool` singletons.  Its single failure mode
+/// — `TypeError` for a target that is not an exception class — allocates a
+/// fresh exception exactly the way the `CanRaise`-tagged members of the
+/// `replay_safe_read` set can, so a replay commits nothing new.
+///
+/// `iIRd>r`: the tag is the first I-list entry, and it must live in the
+/// callee's immutable constant window — a runtime tag could select one of the
+/// six ordinary comparisons, which do dispatch to user `__eq__`.
+pub(crate) fn residual_call_is_exception_match(
+    body_code: &[u8],
+    d: &DecodedOp,
+    num_regs_i: usize,
+    constants_i: &[i64],
+    callee_descr_refs: &[DescrRef],
+) -> bool {
+    if d.key != "residual_call_ir_r/iIRd>r"
+        || residual_call_helper_kind_in_body(body_code, d, callee_descr_refs)
+            != Some(majit_ir::PyreHelperKind::CompareOp)
+    {
+        return false;
+    }
+    if body_code.get(d.pc + 2).is_none_or(|i_len| *i_len == 0) {
+        return false;
+    }
+    let Some(&tag_reg) = body_code.get(d.pc + 3) else {
+        return false;
+    };
+    (tag_reg as usize)
+        .checked_sub(num_regs_i)
+        .and_then(|constant_index| constants_i.get(constant_index))
+        .is_some_and(|tag| *tag == pyre_interpreter::runtime_ops::ISINSTANCE_OP_TAG)
+}
+
 /// Is this body op a `TO_BOOL` / `POP_JUMP_IF_*` truth residual whose single
 /// Ref operand is a proven immutable builtin — an exact numeric, or the `bool`
 /// an accepted `COMPARE_OP` in the same body produced?

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/resume_snapshot.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/resume_snapshot.rs
@@ -1548,7 +1548,11 @@ pub(crate) fn compute_nested_inline_caller_frame<Sym: WalkSym>(
     // scoped to the top-level caller (`compute_inline_caller_frame`) for now, so
     // pass an empty jitcode here — a nested try-block CALL keeps declining
     // (its catch-marker resume is not yet routed through the deeper snapshot).
-    decline_inline_caller_frame_for_catch_marker(after_residual_call_resume, &[], callee_has_freevars)?;
+    decline_inline_caller_frame_for_catch_marker(
+        after_residual_call_resume,
+        &[],
+        callee_has_freevars,
+    )?;
     let legacy_fallthrough_py_pc = || unsafe {
         let call_py = python_pc_for_jitcode_pc(&pjc.metadata, call_jit_pc) as usize;
         let code = &*pjc.code_ptr;

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/resume_snapshot.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/resume_snapshot.rs
@@ -1063,8 +1063,11 @@ pub(crate) fn walker_capture_snapshot_for_last_guard_impl<Sym: WalkSym>(
 /// (`ctx.registers_*`) are still in scope.  `call_jit_pc` is the CALL op's
 /// jitcode pc in the caller.  Returns a named decline reason
 /// when the caller frame is not snapshot-able for this first slice: missing
-/// liveness / resume tables, or no result on the operand stack at the return
-/// point.
+/// liveness / resume tables, a CALL inside a try-block whose `except` handler
+/// does NOT rejoin a loop (returns out of the frame — its hot raise cannot be
+/// bridged, so it stays on the residual path, see
+/// [`decline_inline_caller_frame_for_catch_marker`]), or no result on the
+/// operand stack at the return point.
 ///
 /// The caller resumes at the CALL's return point (fallthrough) with the
 /// not-yet-produced call-result slot nulled — `get_list_of_active_boxes(
@@ -1073,7 +1076,46 @@ pub(crate) fn walker_capture_snapshot_for_last_guard_impl<Sym: WalkSym>(
 /// after temporarily nulling the result slot's register.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum InlineCallerFrameDecline {
+    TryBlockCatchMarker,
     Unavailable,
+}
+
+pub(crate) fn decline_inline_caller_frame_for_catch_marker(
+    after_residual_call_resume: Option<usize>,
+    caller_jitcode: &[u8],
+) -> Result<(), InlineCallerFrameDecline> {
+    let Some(resume_pos) = after_residual_call_resume else {
+        // Not a try-block CALL — nothing to route on a raise.
+        return Ok(());
+    };
+    // The CALL is inside a try-block.  Inline it when its exception handler
+    // rejoins a loop (the exc-edge-bridgeable shape): the paused caller frame
+    // resumes at the CALL fallthrough on the no-raise path, and on a raise the
+    // caller's `lastblock` (a static box in its virtualizable image) unwinds to
+    // the catch handler in the blackhole — bit-exact — while a hot raise bridges
+    // into the enclosing loop via the carrier-boundary delivery
+    // (`drive_bridge_carrier_walk`'s `finishframe_exception`).
+    //
+    // The rejoin test is a TRACEBACK constraint here, not a bridgeability one:
+    // the exc-edge router itself no longer needs it (`bridge_subwalk.rs` routes
+    // on the catch alone, as `pyjitpl.py:2530-2546` does).  Inlining a caller
+    // whose handler returns out of the frame instead makes
+    // `exception_traceback_frame_lineno` report the raising frame twice, once at
+    // the wrong lineno — the catching frame's traceback node is dropped when the
+    // inlined callee's raise is delivered.  Keep the decline until that is
+    // fixed; both backends reproduce it.
+    //
+    // `resume_pos` is the CALL's post-call `live/`; the `catch_exception/L` for
+    // the enclosing try sits right after it (`finishframe_exception` lookahead),
+    // so read the handler target forward from there.
+    let rejoins = crate::jitcode_dispatch::try_catch_exception_at(caller_jitcode, resume_pos)
+        .is_some_and(|catch_target| {
+            crate::jitcode_dispatch::exc_handler_rejoins_loop(caller_jitcode, catch_target)
+        });
+    if rejoins {
+        return Ok(());
+    }
+    Err(InlineCallerFrameDecline::TryBlockCatchMarker)
 }
 
 pub(crate) fn concrete_ref_for_color<Sym: WalkSym>(
@@ -1327,6 +1369,15 @@ pub(crate) fn compute_inline_caller_frame<Sym: WalkSym>(
             return Err(InlineCallerFrameDecline::Unavailable);
         }
         let call_py = python_pc_for_jitcode_pc(&jc.payload.metadata, call_jit_pc) as usize;
+        // A CALL inside a try-block: inline it only when its exception handler
+        // rejoins the loop (the exc-edge-bridgeable shape); otherwise decline so
+        // the residual path handles the raise via its after-residual catch
+        // marker without a per-iteration deopt.
+        decline_inline_caller_frame_for_catch_marker(
+            jc.payload
+                .after_residual_call_resume_for_jitcode_pc(call_jit_pc),
+            jc.payload.jitcode.code.as_slice(),
+        )?;
         let code = &*jc.payload.code_ptr;
         let fallthrough = crate::pyjitpl::semantic_fallthrough_pc(code, call_py) as u32;
         // #73 Slice 4 (twin-first): certify the forward `after_residual_fallthrough`
@@ -1474,6 +1525,11 @@ pub(crate) fn compute_nested_inline_caller_frame<Sym: WalkSym>(
     }
     let resume_marker_jit_pc = inline_call_return_marker(&pjc, call_jit_pc);
     let after_residual_call_resume = pjc.after_residual_call_resume_for_jitcode_pc(call_jit_pc);
+    // A CALL inside a try-block at inline depth ≥2: the rejoin-loop lift is
+    // scoped to the top-level caller (`compute_inline_caller_frame`) for now, so
+    // pass an empty jitcode here — a nested try-block CALL keeps declining
+    // (its catch-marker resume is not yet routed through the deeper snapshot).
+    decline_inline_caller_frame_for_catch_marker(after_residual_call_resume, &[])?;
     let legacy_fallthrough_py_pc = || unsafe {
         let call_py = python_pc_for_jitcode_pc(&pjc.metadata, call_jit_pc) as usize;
         let code = &*pjc.code_ptr;

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/resume_snapshot.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/resume_snapshot.rs
@@ -1063,11 +1063,8 @@ pub(crate) fn walker_capture_snapshot_for_last_guard_impl<Sym: WalkSym>(
 /// (`ctx.registers_*`) are still in scope.  `call_jit_pc` is the CALL op's
 /// jitcode pc in the caller.  Returns a named decline reason
 /// when the caller frame is not snapshot-able for this first slice: missing
-/// liveness / resume tables, a CALL inside a try-block whose `except` handler
-/// does NOT rejoin a loop (returns out of the frame — its hot raise cannot be
-/// bridged, so it stays on the residual path, see
-/// [`decline_inline_caller_frame_for_catch_marker`]), or no result on the
-/// operand stack at the return point.
+/// liveness / resume tables, or no result on the operand stack at the return
+/// point.
 ///
 /// The caller resumes at the CALL's return point (fallthrough) with the
 /// not-yet-produced call-result slot nulled — `get_list_of_active_boxes(
@@ -1076,46 +1073,7 @@ pub(crate) fn walker_capture_snapshot_for_last_guard_impl<Sym: WalkSym>(
 /// after temporarily nulling the result slot's register.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum InlineCallerFrameDecline {
-    TryBlockCatchMarker,
     Unavailable,
-}
-
-pub(crate) fn decline_inline_caller_frame_for_catch_marker(
-    after_residual_call_resume: Option<usize>,
-    caller_jitcode: &[u8],
-) -> Result<(), InlineCallerFrameDecline> {
-    let Some(resume_pos) = after_residual_call_resume else {
-        // Not a try-block CALL — nothing to route on a raise.
-        return Ok(());
-    };
-    // The CALL is inside a try-block.  Inline it when its exception handler
-    // rejoins a loop (the exc-edge-bridgeable shape): the paused caller frame
-    // resumes at the CALL fallthrough on the no-raise path, and on a raise the
-    // caller's `lastblock` (a static box in its virtualizable image) unwinds to
-    // the catch handler in the blackhole — bit-exact — while a hot raise bridges
-    // into the enclosing loop via the carrier-boundary delivery
-    // (`drive_bridge_carrier_walk`'s `finishframe_exception`).
-    //
-    // The rejoin test is a TRACEBACK constraint here, not a bridgeability one:
-    // the exc-edge router itself no longer needs it (`bridge_subwalk.rs` routes
-    // on the catch alone, as `pyjitpl.py:2530-2546` does).  Inlining a caller
-    // whose handler returns out of the frame instead makes
-    // `exception_traceback_frame_lineno` report the raising frame twice, once at
-    // the wrong lineno — the catching frame's traceback node is dropped when the
-    // inlined callee's raise is delivered.  Keep the decline until that is
-    // fixed; both backends reproduce it.
-    //
-    // `resume_pos` is the CALL's post-call `live/`; the `catch_exception/L` for
-    // the enclosing try sits right after it (`finishframe_exception` lookahead),
-    // so read the handler target forward from there.
-    let rejoins = crate::jitcode_dispatch::try_catch_exception_at(caller_jitcode, resume_pos)
-        .is_some_and(|catch_target| {
-            crate::jitcode_dispatch::exc_handler_rejoins_loop(caller_jitcode, catch_target)
-        });
-    if rejoins {
-        return Ok(());
-    }
-    Err(InlineCallerFrameDecline::TryBlockCatchMarker)
 }
 
 pub(crate) fn concrete_ref_for_color<Sym: WalkSym>(
@@ -1369,15 +1327,6 @@ pub(crate) fn compute_inline_caller_frame<Sym: WalkSym>(
             return Err(InlineCallerFrameDecline::Unavailable);
         }
         let call_py = python_pc_for_jitcode_pc(&jc.payload.metadata, call_jit_pc) as usize;
-        // A CALL inside a try-block: inline it only when its exception handler
-        // rejoins the loop (the exc-edge-bridgeable shape); otherwise decline so
-        // the residual path handles the raise via its after-residual catch
-        // marker without a per-iteration deopt.
-        decline_inline_caller_frame_for_catch_marker(
-            jc.payload
-                .after_residual_call_resume_for_jitcode_pc(call_jit_pc),
-            jc.payload.jitcode.code.as_slice(),
-        )?;
         let code = &*jc.payload.code_ptr;
         let fallthrough = crate::pyjitpl::semantic_fallthrough_pc(code, call_py) as u32;
         // #73 Slice 4 (twin-first): certify the forward `after_residual_fallthrough`
@@ -1525,11 +1474,6 @@ pub(crate) fn compute_nested_inline_caller_frame<Sym: WalkSym>(
     }
     let resume_marker_jit_pc = inline_call_return_marker(&pjc, call_jit_pc);
     let after_residual_call_resume = pjc.after_residual_call_resume_for_jitcode_pc(call_jit_pc);
-    // A CALL inside a try-block at inline depth ≥2: the rejoin-loop lift is
-    // scoped to the top-level caller (`compute_inline_caller_frame`) for now, so
-    // pass an empty jitcode here — a nested try-block CALL keeps declining
-    // (its catch-marker resume is not yet routed through the deeper snapshot).
-    decline_inline_caller_frame_for_catch_marker(after_residual_call_resume, &[])?;
     let legacy_fallthrough_py_pc = || unsafe {
         let call_py = python_pc_for_jitcode_pc(&pjc.metadata, call_jit_pc) as usize;
         let code = &*pjc.code_ptr;

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/resume_snapshot.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/resume_snapshot.rs
@@ -1063,9 +1063,9 @@ pub(crate) fn walker_capture_snapshot_for_last_guard_impl<Sym: WalkSym>(
 /// (`ctx.registers_*`) are still in scope.  `call_jit_pc` is the CALL op's
 /// jitcode pc in the caller.  Returns a named decline reason
 /// when the caller frame is not snapshot-able for this first slice: missing
-/// liveness / resume tables, a CALL inside a try-block whose `except` handler
-/// does NOT rejoin a loop (returns out of the frame — its hot raise cannot be
-/// bridged, so it stays on the residual path, see
+/// liveness / resume tables, a CLOSURE callee at a CALL inside a try-block
+/// whose `except` handler does NOT rejoin a loop (it reads caller cells the
+/// handler cleanup clears, see
 /// [`decline_inline_caller_frame_for_catch_marker`]), or no result on the
 /// operand stack at the return point.
 ///
@@ -1083,11 +1083,22 @@ pub(crate) enum InlineCallerFrameDecline {
 pub(crate) fn decline_inline_caller_frame_for_catch_marker(
     after_residual_call_resume: Option<usize>,
     caller_jitcode: &[u8],
+    callee_has_freevars: bool,
 ) -> Result<(), InlineCallerFrameDecline> {
     let Some(resume_pos) = after_residual_call_resume else {
         // Not a try-block CALL — nothing to route on a raise.
         return Ok(());
     };
+    // A closure callee reads its captured values out of the cells the caller
+    // frame owns, and inside a try-block one of those cells is the `except E as
+    // e` binding, which the handler's implicit cleanup stores `None` into and
+    // then clears.  Inlining such a callee here reads that cell as `None`
+    // (`bench/synth/exception_as_cell_cleanup`).  A callee with no free
+    // variables cannot reach a caller cell at all, so the decline below is not
+    // needed for it.
+    if !callee_has_freevars {
+        return Ok(());
+    }
     // The CALL is inside a try-block.  Inline it when its exception handler
     // rejoins a loop (the exc-edge-bridgeable shape): the paused caller frame
     // resumes at the CALL fallthrough on the no-raise path, and on a raise the
@@ -1334,6 +1345,7 @@ pub(crate) fn inline_call_return_marker(
 pub(crate) fn compute_inline_caller_frame<Sym: WalkSym>(
     ctx: &mut WalkContext<'_, '_, Sym>,
     call_jit_pc: usize,
+    callee_has_freevars: bool,
 ) -> Result<InlineParentFrame, InlineCallerFrameDecline> {
     // #68 nested multiframe: when an inlined callee is already active
     // (the framestack has a top level), the immediate caller of THIS
@@ -1351,7 +1363,12 @@ pub(crate) fn compute_inline_caller_frame<Sym: WalkSym>(
         .last()
         .map(|frame| frame.w_code);
     if let Some(caller_code) = caller_code {
-        return compute_nested_inline_caller_frame(ctx, call_jit_pc, caller_code);
+        return compute_nested_inline_caller_frame(
+            ctx,
+            call_jit_pc,
+            caller_code,
+            callee_has_freevars,
+        );
     }
     let caller_sym_ptr = ctx.fbw_mode.snapshot_sym;
     if caller_sym_ptr.is_null() {
@@ -1377,6 +1394,7 @@ pub(crate) fn compute_inline_caller_frame<Sym: WalkSym>(
             jc.payload
                 .after_residual_call_resume_for_jitcode_pc(call_jit_pc),
             jc.payload.jitcode.code.as_slice(),
+            callee_has_freevars,
         )?;
         let code = &*jc.payload.code_ptr;
         let fallthrough = crate::pyjitpl::semantic_fallthrough_pc(code, call_py) as u32;
@@ -1515,6 +1533,7 @@ pub(crate) fn compute_nested_inline_caller_frame<Sym: WalkSym>(
     ctx: &mut WalkContext<'_, '_, Sym>,
     call_jit_pc: usize,
     caller_code: usize,
+    callee_has_freevars: bool,
 ) -> Result<InlineParentFrame, InlineCallerFrameDecline> {
     let jitcode_index = crate::state::ensure_jitcode_index(caller_code as *const ())
         .ok_or(InlineCallerFrameDecline::Unavailable)? as u32;
@@ -1529,7 +1548,7 @@ pub(crate) fn compute_nested_inline_caller_frame<Sym: WalkSym>(
     // scoped to the top-level caller (`compute_inline_caller_frame`) for now, so
     // pass an empty jitcode here — a nested try-block CALL keeps declining
     // (its catch-marker resume is not yet routed through the deeper snapshot).
-    decline_inline_caller_frame_for_catch_marker(after_residual_call_resume, &[])?;
+    decline_inline_caller_frame_for_catch_marker(after_residual_call_resume, &[], callee_has_freevars)?;
     let legacy_fallthrough_py_pc = || unsafe {
         let call_py = python_pc_for_jitcode_pc(&pjc.metadata, call_jit_pc) as usize;
         let code = &*pjc.code_ptr;

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -337,6 +337,40 @@ pub(crate) fn try_walker_specialize_truth_int<Sym: WalkSym>(
     Ok(Some(truth))
 }
 
+/// Truth specialization for a concrete `W_BoolObject` operand — the sibling
+/// [`try_walker_specialize_truth_int`] declines it, because it emits
+/// `GUARD_CLASS INT` and a bool carries `BOOL_TYPE`.  Same `intval: i64`
+/// layout, so only the guarded class constant differs; `is_true` on the
+/// unboxed field is `W_BoolObject.is_true`'s `self.intval != 0`.
+///
+/// This is the shape every `if a == b:` reaches: `COMPARE_OP` leaves a boxed
+/// bool the following `TO_BOOL` / `POP_JUMP_IF_*` tests, so without this arm a
+/// comparison costs two `CALL_MAY_FORCE`s and two force/exception guard pairs
+/// instead of one call and a field read.  When the comparison itself already
+/// specialized, [`bool_box_truth_lookup`] folds the test first and this never
+/// runs; it covers the case where the comparison stayed a residual.
+pub(crate) fn try_walker_specialize_truth_bool<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    op_pc: usize,
+    operand: OpRef,
+) -> Result<Option<OpRef>, DispatchError> {
+    let Some(obj) = walker_concrete_ref_object(ctx, operand) else {
+        return Ok(None);
+    };
+    let val = unsafe {
+        if !pyre_object::is_bool(obj) {
+            return Ok(None);
+        }
+        pyre_object::w_int_get_value(obj)
+    };
+    let bool_type_addr = &pyre_object::pyobject::BOOL_TYPE as *const _ as i64;
+    let raw = walker_unbox_int(ctx, op_pc, operand, bool_type_addr)?;
+    let truth = ctx.trace_ctx.record_op(OpCode::IntIsTrue, &[raw]);
+    ctx.trace_ctx
+        .set_opref_concrete(truth, majit_ir::Value::Int((val != 0) as i64));
+    Ok(Some(truth))
+}
+
 /// #57: walker-native speculative int specialization for the `BINARY_OP`
 /// helper residual_call (oopspec `BinaryOp`).  Re-derives
 /// the former int fast path's structure (`guard_class` + `getfield_gc_i` per

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -2286,9 +2286,6 @@ pub(crate) fn try_walker_specialize_load_method_attr<Sym: WalkSym>(
     let Some(name) = walker_load_name_from_code(w_code_ptr, name_idx) else {
         return Ok(None);
     };
-    if name.contains("__") {
-        return Ok(None);
-    }
     let Some((w_type, version_tag, w_descr)) =
         (unsafe { pyre_interpreter::load_method_fast_path(concrete_obj, &name) })
     else {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -1958,6 +1958,55 @@ pub(crate) fn try_walker_specialize_load_attr<Sym: WalkSym>(
         return Ok(Some(()));
     }
 
+    // `pytraceback.py:51-53 descr_get_next` reads `w_next` and surfaces the
+    // null chain terminator as None; it marks nothing escaped and cannot
+    // raise, so the whole getter is the field read below.  Left residual, one
+    // `tb.tb_next` step costs two forcing calls, which is what makes a
+    // `while tb is not None: tb = tb.tb_next` walk dominate every traceback
+    // fixture.
+    if name == "tb_next"
+        && std::ptr::eq(
+            unsafe { (*concrete_obj).ob_type },
+            &pyre_interpreter::pytraceback::PYTRACEBACK_TYPE,
+        )
+    {
+        let w_type =
+            pyre_interpreter::typedef::gettypeobject(&pyre_interpreter::pytraceback::PYTRACEBACK_TYPE);
+        let version_tag = unsafe { pyre_object::typeobject::w_type_get_version_tag(w_type) };
+        if version_tag == 0 {
+            return Ok(None);
+        }
+        let stored = unsafe { pyre_interpreter::pytraceback::w_pytraceback_get_w_next(concrete_obj) };
+        walker_guard_exception_attr_slot(ctx, op_pc, obj, concrete_obj, w_type, version_tag)?;
+        let raw_value = crate::state::opimpl_getfield_gc_r(
+            ctx.trace_ctx,
+            obj,
+            crate::descr::pytraceback_w_next_descr(),
+        );
+        let value = if stored.is_null() {
+            // End of the chain.  There is no is-null guard opcode, so pin the
+            // slot against the null constant the way the exception `w_dict`
+            // shadow guard does, then produce the None the getter returns.
+            let null_const = ctx.trace_ctx.const_ref(0);
+            walker_emit_fold_guard_with_snapshot(
+                ctx,
+                op_pc,
+                OpCode::GuardValue,
+                &[raw_value, null_const],
+            )?;
+            ctx.trace_ctx.const_ref(pyre_object::w_none() as i64)
+        } else {
+            walker_emit_fold_guard_with_snapshot(ctx, op_pc, OpCode::GuardNonnull, &[raw_value])?;
+            ctx.trace_ctx.set_opref_concrete(
+                raw_value,
+                majit_ir::Value::Ref(majit_ir::GcRef(stored as usize)),
+            );
+            raw_value
+        };
+        write_residual_call_result_to_dst(ctx, op_pc, dst, dst_bank, value)?;
+        return Ok(Some(()));
+    }
+
     if let Some((slot, kind, w_type, version_tag, stored)) = unsafe {
         pyre_interpreter::baseobjspace::exception_attr_slot_fold(concrete_obj, &name, false)
     } {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -2309,6 +2309,14 @@ pub(crate) fn try_walker_specialize_load_method_attr<Sym: WalkSym>(
             if map.is_null() {
                 return Ok(None);
             }
+            // A devolved instance holds its attributes in a dictionary and
+            // keeps the same map across a later `e.<name> = ...`, so pinning
+            // the map would not observe the shadow the assignment installs.
+            // `W_ObjectObject.map` is stored untyped; the map layer owns the
+            // node type.
+            if pyre_interpreter::objspace::std::mapdict::map_is_devolved(map.cast()) {
+                return Ok(None);
+            }
             ShadowGuard::InstanceMap(map)
         } else if pyre_object::is_exception(concrete_obj) {
             ShadowGuard::ExceptionDictIsNull(pyre_object::w_exception_get_kind(concrete_obj))

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -1884,6 +1884,159 @@ fn walker_guard_specialised_pair_class<Sym: WalkSym>(
     Ok(())
 }
 
+/// One hop of a `while tb is not None: names.append(tb.tb_frame.f_code.co_name);
+/// tb = tb.tb_next` traceback walk.
+///
+/// Each of these is a `GetSetProperty` whose getter body is a single slot read
+/// on a receiver [`walker_specialize_traceback_walk_field`] pins by class:
+/// `pytraceback.py descr_get_next` / `descr_get_tb_frame` and `pyframe.py`
+/// `fget_code`.  None of them dispatches anywhere or can raise.  Left residual,
+/// every hop of the walk costs a forcing call, which is what makes each
+/// traceback fixture dominated by the walk rather than by the raise.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum TracebackWalkField {
+    /// `tb.tb_next` — the chain link; a null slot is the terminator and
+    /// surfaces as `None`.
+    TbNext,
+    /// `tb.tb_frame` — the node's frame.  Unlike its two siblings the getter
+    /// ALSO runs `mark_as_escaped()`; see the escape emit.
+    TbFrame,
+    /// `frame.f_code` — `fget_f_code` is `self.pycode as PyObjectRef`.
+    FCode,
+}
+
+/// Which walk hop, if any, this `(receiver, attribute)` pair is.
+fn traceback_walk_field(
+    concrete_obj: pyre_object::PyObjectRef,
+    name: &str,
+) -> Option<TracebackWalkField> {
+    let ob_type = unsafe { (*concrete_obj).ob_type };
+    if std::ptr::eq(ob_type, &pyre_interpreter::pytraceback::PYTRACEBACK_TYPE) {
+        return match name {
+            "tb_next" => Some(TracebackWalkField::TbNext),
+            "tb_frame" => Some(TracebackWalkField::TbFrame),
+            _ => None,
+        };
+    }
+    if std::ptr::eq(ob_type, &pyre_interpreter::pyframe::FRAME_TYPE) && name == "f_code" {
+        return Some(TracebackWalkField::FCode);
+    }
+    None
+}
+
+/// Emit one traceback-walk hop as a guarded inline field read instead of the
+/// opaque `getattr_fn` residual.
+///
+/// Returns `None` (fall through to the residual) BEFORE recording any guard for
+/// every shape it cannot settle — an uncacheable `version_tag`, or a null slot
+/// on a hop whose null is not a documented value.  A bail-out after a guard
+/// would leave the caller reading the attribute as already pinned.
+fn walker_specialize_traceback_walk_field<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    op_pc: usize,
+    obj: OpRef,
+    concrete_obj: pyre_object::PyObjectRef,
+    field: TracebackWalkField,
+    dst: usize,
+    dst_bank: char,
+) -> Result<Option<()>, DispatchError> {
+    use pyre_interpreter::pyframe::PyFrame;
+
+    let (receiver_type, descr, stored) = match field {
+        TracebackWalkField::TbNext => (
+            &pyre_interpreter::pytraceback::PYTRACEBACK_TYPE,
+            crate::descr::pytraceback_w_next_descr(),
+            unsafe { pyre_interpreter::pytraceback::w_pytraceback_get_w_next(concrete_obj) },
+        ),
+        TracebackWalkField::TbFrame => (
+            &pyre_interpreter::pytraceback::PYTRACEBACK_TYPE,
+            crate::descr::pytraceback_frame_descr(),
+            unsafe { pyre_interpreter::pytraceback::w_pytraceback_get_frame(concrete_obj) }
+                as pyre_object::PyObjectRef,
+        ),
+        TracebackWalkField::FCode => (
+            &pyre_interpreter::pyframe::FRAME_TYPE,
+            crate::descr::pyframe_code_descr(),
+            unsafe { (*(concrete_obj as *const PyFrame)).pycode } as pyre_object::PyObjectRef,
+        ),
+    };
+    // Only `tb_next` has a null with a defined meaning.  A null frame is a
+    // torn-down traceback and a null `pycode` a half-built frame; both are
+    // answered by a `sys.namespace` stub or `None` the residual owns.
+    if stored.is_null() && field != TracebackWalkField::TbNext {
+        return Ok(None);
+    }
+    let w_type = pyre_interpreter::typedef::gettypeobject(receiver_type);
+    let version_tag = unsafe { pyre_object::typeobject::w_type_get_version_tag(w_type) };
+    if version_tag == 0 {
+        return Ok(None);
+    }
+    // The slot guard pins the receiver's `w_class` against `w_type`.  A frame
+    // built before `init_typeobjects` carries a null `w_class`, which would
+    // make that guard fail on its first execution, so decline instead of
+    // recording a doomed trace.
+    if unsafe { (*concrete_obj).w_class } != w_type {
+        return Ok(None);
+    }
+
+    walker_guard_exception_attr_slot(ctx, op_pc, obj, concrete_obj, w_type, version_tag)?;
+    let raw_value = crate::state::opimpl_getfield_gc_r(ctx.trace_ctx, obj, descr);
+    let value = if stored.is_null() {
+        // End of the chain.  There is no is-null guard opcode, so pin the
+        // slot against the null constant the way the exception `w_dict`
+        // shadow guard does, then produce the None the getter returns.
+        let null_const = ctx.trace_ctx.const_ref(0);
+        walker_emit_fold_guard_with_snapshot(
+            ctx,
+            op_pc,
+            OpCode::GuardValue,
+            &[raw_value, null_const],
+        )?;
+        ctx.trace_ctx.const_ref(pyre_object::w_none() as i64)
+    } else {
+        walker_emit_fold_guard_with_snapshot(ctx, op_pc, OpCode::GuardNonnull, &[raw_value])?;
+        ctx.trace_ctx.set_opref_concrete(
+            raw_value,
+            majit_ir::Value::Ref(majit_ir::GcRef(stored as usize)),
+        );
+        raw_value
+    };
+
+    if field == TracebackWalkField::TbFrame {
+        // `descr_get_tb_frame` also runs `frame.mark_as_escaped()`
+        // (`pyframe.py:176 mark_as_escaped`): the reference it hands out has to
+        // keep the frame materialised.  `set_escaped` ORs `FLAG_ESCAPED` into
+        // the `flags` byte, so the trace reads that byte, sets the bit, and
+        // stores it back.
+        //
+        // The bit has to be set BY THE TRACE, not only stamped now: the trace
+        // is reused, and each replay walks a different traceback naming a
+        // different frame, so a trace-time-only mark would leave every later
+        // frame unmarked.  The concrete write below is the one the
+        // authoritative walk's residual executor would have performed, applied
+        // here for the same reason `try_walker_lower_exc_info_residual` applies
+        // its own.
+        let flags_descr = crate::descr::pyframe_flags_descr();
+        let live_flags =
+            crate::state::opimpl_getfield_gc_i(ctx.trace_ctx, raw_value, flags_descr.clone());
+        let escaped_bit = ctx.trace_ctx.const_int(i64::from(PyFrame::FLAG_ESCAPED));
+        let new_flags = ctx
+            .trace_ctx
+            .record_op(OpCode::IntOr, &[live_flags, escaped_bit]);
+        ctx.trace_ctx.record_op_with_descr(
+            OpCode::SetfieldGc,
+            &[raw_value, new_flags],
+            flags_descr.clone(),
+        );
+        ctx.trace_ctx
+            .heapcache_setfield_cached(raw_value, flags_descr.index(), new_flags);
+        unsafe { (*(stored as *mut PyFrame)).mark_as_escaped() };
+    }
+
+    write_residual_call_result_to_dst(ctx, op_pc, dst, dst_bank, value)?;
+    Ok(Some(()))
+}
+
 /// `mapdict.py LOAD_ATTR_caching` full-body-walker fast path for a
 /// plain (non-method) instance attribute.  When the concrete receiver is a
 /// monomorphic instance whose attribute resolves to a boxed plain storage slot
@@ -1958,53 +2111,18 @@ pub(crate) fn try_walker_specialize_load_attr<Sym: WalkSym>(
         return Ok(Some(()));
     }
 
-    // `pytraceback.py:51-53 descr_get_next` reads `w_next` and surfaces the
-    // null chain terminator as None; it marks nothing escaped and cannot
-    // raise, so the whole getter is the field read below.  Left residual, one
-    // `tb.tb_next` step costs two forcing calls, which is what makes a
-    // `while tb is not None: tb = tb.tb_next` walk dominate every traceback
-    // fixture.
-    if name == "tb_next"
-        && std::ptr::eq(
-            unsafe { (*concrete_obj).ob_type },
-            &pyre_interpreter::pytraceback::PYTRACEBACK_TYPE,
-        )
-    {
-        let w_type =
-            pyre_interpreter::typedef::gettypeobject(&pyre_interpreter::pytraceback::PYTRACEBACK_TYPE);
-        let version_tag = unsafe { pyre_object::typeobject::w_type_get_version_tag(w_type) };
-        if version_tag == 0 {
-            return Ok(None);
-        }
-        let stored = unsafe { pyre_interpreter::pytraceback::w_pytraceback_get_w_next(concrete_obj) };
-        walker_guard_exception_attr_slot(ctx, op_pc, obj, concrete_obj, w_type, version_tag)?;
-        let raw_value = crate::state::opimpl_getfield_gc_r(
-            ctx.trace_ctx,
+    if let Some(walk_field) = traceback_walk_field(concrete_obj, &name) {
+        if let Some(()) = walker_specialize_traceback_walk_field(
+            ctx,
+            op_pc,
             obj,
-            crate::descr::pytraceback_w_next_descr(),
-        );
-        let value = if stored.is_null() {
-            // End of the chain.  There is no is-null guard opcode, so pin the
-            // slot against the null constant the way the exception `w_dict`
-            // shadow guard does, then produce the None the getter returns.
-            let null_const = ctx.trace_ctx.const_ref(0);
-            walker_emit_fold_guard_with_snapshot(
-                ctx,
-                op_pc,
-                OpCode::GuardValue,
-                &[raw_value, null_const],
-            )?;
-            ctx.trace_ctx.const_ref(pyre_object::w_none() as i64)
-        } else {
-            walker_emit_fold_guard_with_snapshot(ctx, op_pc, OpCode::GuardNonnull, &[raw_value])?;
-            ctx.trace_ctx.set_opref_concrete(
-                raw_value,
-                majit_ir::Value::Ref(majit_ir::GcRef(stored as usize)),
-            );
-            raw_value
-        };
-        write_residual_call_result_to_dst(ctx, op_pc, dst, dst_bank, value)?;
-        return Ok(Some(()));
+            concrete_obj,
+            walk_field,
+            dst,
+            dst_bank,
+        )? {
+            return Ok(Some(()));
+        }
     }
 
     if let Some((slot, kind, w_type, version_tag, stored)) = unsafe {
@@ -2421,7 +2539,11 @@ pub(crate) fn try_walker_specialize_load_method_attr<Sym: WalkSym>(
             ctx.trace_ctx.const_int(map as i64),
         ),
         ShadowGuard::ExceptionDictIsNull(kind) => (
-            walker_record_getfield_gc_r_uncached(ctx, obj, crate::descr::w_exception_dict_descr(kind)),
+            walker_record_getfield_gc_r_uncached(
+                ctx,
+                obj,
+                crate::descr::w_exception_dict_descr(kind),
+            ),
             ctx.trace_ctx.const_ref(0),
         ),
     };

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -2242,11 +2242,28 @@ pub(crate) fn try_walker_specialize_load_attr<Sym: WalkSym>(
     Ok(Some(()))
 }
 
+/// The receiver-layout-specific half of the LOAD_METHOD fold: which field the
+/// walker guards to keep "no instance attribute shadows this method" true for
+/// the life of the trace.
+///
+/// `load_method_fast_path` proved the property once, at record time; this is
+/// what re-proves it on every execution.  One variant per layout whose
+/// non-allocating dictionary peek that predicate covers.
+enum ShadowGuard {
+    /// A `W_ObjectObject` receiver: pin the mapdict map, so adding
+    /// `obj.<name>` grows the map chain and side-exits.
+    InstanceMap(*const u8),
+    /// A `W_BaseException` receiver: pin `w_dict` at null, so the lazy
+    /// allocation `e.<name> = ...` performs side-exits.  Carries the kind
+    /// because the field descrs are grouped per `ExcKind` vtable.
+    ExceptionDictIsNull(pyre_object::interp_exceptions::ExcKind),
+}
+
 /// `callmethod.py LOAD_METHOD` method-cache fold for the
 /// codewriter's method-form `LOAD_ATTR` residual.  The safety oracle is the
 /// interpreter's `load_method_fast_path`: it declines custom
-/// `__getattribute__`, uncacheable types, non-function descriptors,
-/// shadowing instance attributes, and non-instance receivers.  On success the
+/// `__getattribute__`, uncacheable types, non-function descriptors, and
+/// shadowing instance attributes.  On success the
 /// walker emits the guards that keep that decision stable, then writes
 /// `w_descr` as a green constant so the following `CALL` can use the existing
 /// constant-callee inline path.
@@ -2280,23 +2297,38 @@ pub(crate) fn try_walker_specialize_load_method_attr<Sym: WalkSym>(
     if unsafe { resolve_inlinable_callee(w_descr) }.is_none() {
         return Ok(None);
     }
-    let map = unsafe {
-        let inst = &*(concrete_obj as *const pyre_object::W_ObjectObject);
-        inst.map
-    };
-    if map.is_null() {
+    // `space.type` reaches an exception's class through the kind registry when
+    // the generic stub is still installed, and the `w_class` guard below can
+    // only pin a class the slot actually holds.
+    if !std::ptr::eq(unsafe { (*concrete_obj).w_class }, w_type) {
         return Ok(None);
     }
+    let shadow = unsafe {
+        if pyre_object::is_instance(concrete_obj) {
+            let map = (*(concrete_obj as *const pyre_object::W_ObjectObject)).map;
+            if map.is_null() {
+                return Ok(None);
+            }
+            ShadowGuard::InstanceMap(map)
+        } else if pyre_object::is_exception(concrete_obj) {
+            ShadowGuard::ExceptionDictIsNull(pyre_object::w_exception_get_kind(concrete_obj))
+        } else {
+            // `load_method_fast_path` admits only the layouts above; keep the
+            // two in step so a new layout there cannot reach an emit that has
+            // no shadowing guard for it.
+            return Ok(None);
+        }
+    };
 
-    // guard_class(obj, &INSTANCE_TYPE): receiver is a user instance, so the
-    // `w_class` and map fields read below are valid.
-    let instance_type_addr = &pyre_object::pyobject::INSTANCE_TYPE as *const _ as i64;
+    // guard_class(obj, ob_type): pins the payload layout, so the `w_class` and
+    // shadowing-slot reads below name the fields they were recorded against.
+    let physical_type = unsafe { (*concrete_obj).ob_type } as i64;
     if !ctx.trace_ctx.heap_cache().is_class_known(obj) {
-        let type_const = ctx.trace_ctx.const_int(instance_type_addr);
+        let type_const = ctx.trace_ctx.const_int(physical_type);
         walker_emit_fold_guard_with_snapshot(ctx, op_pc, OpCode::GuardClass, &[obj, type_const])?;
         ctx.trace_ctx
             .heap_cache_mut()
-            .class_now_known(obj, instance_type_addr);
+            .class_now_known(obj, physical_type);
     }
 
     // Pin the Python-level receiver class (`w_class`) exactly.  This is the
@@ -2325,15 +2357,24 @@ pub(crate) fn try_walker_specialize_load_method_attr<Sym: WalkSym>(
     walker_emit_fold_guard_with_snapshot(ctx, op_pc, OpCode::GuardValue, &[vt_op, vt_const])?;
     ctx.trace_ctx.heap_cache_mut().replace_box(vt_op, vt_const);
 
-    // mapdict.py LOAD_ATTR caching: guard the instance map so adding a
-    // shadowing `obj.method` attribute changes shape and side-exits before the
-    // constant descriptor is reused.
-    let map_op = walker_record_getfield_gc_i_uncached(ctx, obj, crate::descr::object_map_descr());
-    let map_const = ctx.trace_ctx.const_int(map as i64);
-    walker_emit_fold_guard_with_snapshot(ctx, op_pc, OpCode::GuardValue, &[map_op, map_const])?;
+    // Re-prove the shadowing precondition: growing an instance attribute named
+    // like the method must side-exit before the constant descriptor is reused.
+    // mapdict.py LOAD_ATTR caching does this by pinning the map; an exception
+    // has no map, and pins the still-unallocated `w_dict` slot instead.
+    let (slot_op, slot_const) = match shadow {
+        ShadowGuard::InstanceMap(map) => (
+            walker_record_getfield_gc_i_uncached(ctx, obj, crate::descr::object_map_descr()),
+            ctx.trace_ctx.const_int(map as i64),
+        ),
+        ShadowGuard::ExceptionDictIsNull(kind) => (
+            walker_record_getfield_gc_r_uncached(ctx, obj, crate::descr::w_exception_dict_descr(kind)),
+            ctx.trace_ctx.const_ref(0),
+        ),
+    };
+    walker_emit_fold_guard_with_snapshot(ctx, op_pc, OpCode::GuardValue, &[slot_op, slot_const])?;
     ctx.trace_ctx
         .heap_cache_mut()
-        .replace_box(map_op, map_const);
+        .replace_box(slot_op, slot_const);
 
     let method_const = ctx.trace_ctx.const_ref(w_descr as i64);
     write_residual_call_result_to_dst(ctx, op_pc, dst, dst_bank, method_const)?;

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
@@ -152,21 +152,6 @@ fn done_descr_ref_for_tests() -> DescrRef {
     make_fail_descr(1)
 }
 
-#[test]
-fn inline_caller_frame_distinguishes_try_block_catch_marker_decline() {
-    // No after-residual catch resume → not a try-block CALL → accept.
-    assert_eq!(
-        decline_inline_caller_frame_for_catch_marker(None, &[]),
-        Ok(()),
-    );
-    // A try-block CALL with no resolvable catch (empty jitcode) cannot prove its
-    // handler rejoins a loop → decline.
-    assert_eq!(
-        decline_inline_caller_frame_for_catch_marker(Some(42), &[]),
-        Err(InlineCallerFrameDecline::TryBlockCatchMarker),
-    );
-}
-
 /// `ensure_residual_call_args_bound` backs the unbound-arg abort path
 /// for all three residual-call shapes (iRd / iIRd / iIRFd); they all
 /// funnel through this helper, so one direct test covers the guard

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
@@ -152,6 +152,21 @@ fn done_descr_ref_for_tests() -> DescrRef {
     make_fail_descr(1)
 }
 
+#[test]
+fn inline_caller_frame_distinguishes_try_block_catch_marker_decline() {
+    // No after-residual catch resume → not a try-block CALL → accept.
+    assert_eq!(
+        decline_inline_caller_frame_for_catch_marker(None, &[]),
+        Ok(()),
+    );
+    // A try-block CALL with no resolvable catch (empty jitcode) cannot prove its
+    // handler rejoins a loop → decline.
+    assert_eq!(
+        decline_inline_caller_frame_for_catch_marker(Some(42), &[]),
+        Err(InlineCallerFrameDecline::TryBlockCatchMarker),
+    );
+}
+
 /// `ensure_residual_call_args_bound` backs the unbound-arg abort path
 /// for all three residual-call shapes (iRd / iIRd / iIRFd); they all
 /// funnel through this helper, so one direct test covers the guard

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
@@ -156,13 +156,13 @@ fn done_descr_ref_for_tests() -> DescrRef {
 fn inline_caller_frame_distinguishes_try_block_catch_marker_decline() {
     // No after-residual catch resume → not a try-block CALL → accept.
     assert_eq!(
-        decline_inline_caller_frame_for_catch_marker(None, &[]),
+        decline_inline_caller_frame_for_catch_marker(None, &[], true),
         Ok(()),
     );
     // A try-block CALL with no resolvable catch (empty jitcode) cannot prove its
     // handler rejoins a loop → decline.
     assert_eq!(
-        decline_inline_caller_frame_for_catch_marker(Some(42), &[]),
+        decline_inline_caller_frame_for_catch_marker(Some(42), &[], true),
         Err(InlineCallerFrameDecline::TryBlockCatchMarker),
     );
 }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/vstack_mirror.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/vstack_mirror.rs
@@ -884,26 +884,25 @@ pub(crate) fn seed_vstack_mirror<Sym: WalkSym>(
 /// current.  A survivor slot the shadow cannot source stays a NONE hole and
 /// the guard's `mirror_covers_kept` declines for it (safe fallback).
 ///
-/// `handler_jit_pc` is the catch target (an OUTER full-body jitcode pc).
-/// No-op outside the full-body walk or inside an inline sub-walk (where the
-/// pc is a callee coordinate the outer metadata cannot map).
+/// `handler_jit_pc` is the catch target: an OUTER full-body jitcode pc, or a
+/// CALLEE coordinate when the catch happens inside an inline sub-walk.  No-op
+/// when the walk has no jitcode to map the pc through.
 pub(crate) fn vstack_enter_exception_handler<Sym: WalkSym>(
     ctx: &mut WalkContext<'_, '_, Sym>,
     handler_jit_pc: usize,
     exc: OpRef,
 ) {
+    if ctx.fbw_mode.inline_subwalk {
+        vstack_enter_exception_handler_callee(ctx, handler_jit_pc, exc);
+        return;
+    }
     // The handler-entry operand stack is a FRESH reconstruction from the
     // authoritative virtualizable shadow plus the caught `exc` — it does NOT
     // depend on the pre-raise mirror being valid (the unwind discards the
     // operand stack above the handler depth, and the surviving slots below
     // are read from the shadow).  So REVIVE the mirror here even when the
     // pre-raise walk invalidated it (e.g. at a `LOAD_GLOBAL` NULL-sentinel on
-    // the `raise` expression).  Only an inline sub-walk (callee coordinate)
-    // or a missing full-body sym is unrecoverable.
-    if ctx.fbw_mode.inline_subwalk {
-        ctx.vstack_valid = false;
-        return;
-    }
+    // the `raise` expression).  Only a missing full-body sym is unrecoverable.
     let full_body_sym = ctx.fbw_mode.snapshot_sym;
     if full_body_sym.is_null() {
         return;
@@ -965,4 +964,53 @@ pub(crate) fn vstack_enter_exception_handler<Sym: WalkSym>(
     // skips the already-set exc slot (non-NONE).  Leaves un-sourceable slots
     // NONE (per-slot decline) rather than latching the whole mirror invalid.
     let _ = reseed_vstack_from_shadow(ctx, handler_depth);
+}
+
+/// Handler-entry re-seed for a catch that happens INSIDE an inline sub-walk.
+///
+/// Two things differ from the full-body path, and both follow from the sub-walk
+/// carrying a CALLEE-local mirror ([`seed_callee_vstack_mirror`]):
+///
+/// * The catch target is a callee coordinate, so the handler py_pc and depth
+///   come from the active resume frame's own metadata rather than the outer
+///   full-body tables.
+/// * The virtualizable shadow belongs to the OUTER frame and cannot name a
+///   callee operand slot, so the surviving slots below the pushed exception are
+///   sourced from the callee-local mirror itself — the same premise that makes
+///   `reconcile_vstack_at_boundary` skip the shadow hole-fill in a sub-walk.
+///   The unwind only truncates ABOVE the handler depth, so those slots still
+///   hold what the sub-walk tracked at the raise point.
+///
+/// Without a shadow to fall back on there is no way to REVIVE an already-invalid
+/// mirror here, so an invalidated sub-walk stays invalid.
+fn vstack_enter_exception_handler_callee<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    handler_jit_pc: usize,
+    exc: OpRef,
+) {
+    if !fbw_callee_vstack_enabled() || !ctx.vstack_valid {
+        ctx.vstack_valid = false;
+        return;
+    }
+    let Some(frame) = ActiveResumeFrame::current(ctx.session, ctx.fbw_mode.snapshot_sym) else {
+        ctx.vstack_valid = false;
+        return;
+    };
+    let Some((handler_py, _code_ptr, handler_depth)) =
+        frame.vstack_coordinate_for_jitcode_pc(handler_jit_pc)
+    else {
+        ctx.vstack_valid = false;
+        return;
+    };
+    // Truncate to the handler's setup depth, keeping the tracked survivors; a
+    // mirror shallower than the handler depth pads with NONE holes, which
+    // `mirror_covers_kept` declines per slot rather than latching invalid.
+    ctx.vstack_boxes.resize(handler_depth, OpRef::NONE);
+    // The unwinder pushes the caught exception onto the new TOS.
+    if handler_depth >= 1 && exc != OpRef::NONE {
+        ctx.vstack_boxes[handler_depth - 1] = exc;
+    }
+    ctx.vstack_cur_pypc = handler_py;
+    ctx.vstack_depth = handler_depth;
+    ctx.vstack_last_ref = OpRef::NONE;
 }

--- a/pyre/pyre-jit-trace/src/jitcode_runtime.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_runtime.rs
@@ -51,6 +51,13 @@ thread_local! {
 
     /// Explicit build-time JIT-driver metadata for every configured driver.
     static COMPILED_JIT_DRIVERS: OnceCell<&'static [CompiledJitDriver]> = const { OnceCell::new() };
+
+    /// Per-thread cached `&'static` to the frozen source-translation
+    /// indirect-call-target family.  Same storage shape and the same
+    /// `Box::leak` rationale as [`ALL_JITCODES`], which it is derived from;
+    /// see [`indirectcalltargets`] for why the family is built once.
+    static INDIRECTCALLTARGETS: OnceCell<&'static [Arc<majit_metainterp::jitcode::JitCode>]> =
+        const { OnceCell::new() };
 }
 
 fn load_all_jitcodes() -> &'static [Arc<JitCode>] {
@@ -120,9 +127,21 @@ pub fn get_jitcode_by_index(index: usize) -> Option<Arc<JitCode>> {
     all_jitcodes().get(index).cloned()
 }
 
-/// Restore the source translator's exact
-/// `Assembler.indirectcalltargets` set as references into `all_jitcodes`.
-pub fn build_indirectcalltargets() -> Vec<Arc<majit_metainterp::jitcode::JitCode>> {
+/// The source translator's exact `Assembler.indirectcalltargets` set as
+/// references into `all_jitcodes`.
+///
+/// `assembler.indirectcalltargets` is filled once while the graphs are being
+/// assembled and holds the same `JitCode` objects the codewriter already
+/// handed to `metainterp_sd.jitcodes` — one object per graph for the whole
+/// process. The wrapper conversion below still has to own its core, so the
+/// family is materialized once per thread and handed out by reference
+/// afterwards; every publisher then sees the same objects instead of a fresh
+/// deep copy per call.
+pub fn indirectcalltargets() -> &'static [Arc<majit_metainterp::jitcode::JitCode>] {
+    INDIRECTCALLTARGETS.with(|cell| *cell.get_or_init(build_indirectcalltargets))
+}
+
+fn build_indirectcalltargets() -> &'static [Arc<majit_metainterp::jitcode::JitCode>] {
     const BYTES: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/indirectcalltargets.bin"));
     let indices: Vec<usize> = bincode::deserialize(BYTES).unwrap_or_else(|e| {
         panic!(
@@ -131,7 +150,7 @@ pub fn build_indirectcalltargets() -> Vec<Arc<majit_metainterp::jitcode::JitCode
             BYTES.len(),
         )
     });
-    indices
+    let vec: Vec<Arc<majit_metainterp::jitcode::JitCode>> = indices
         .into_iter()
         .map(|index| {
             let canonical = get_jitcode_by_index(index).unwrap_or_else(|| {
@@ -145,7 +164,8 @@ pub fn build_indirectcalltargets() -> Vec<Arc<majit_metainterp::jitcode::JitCode
                 (*canonical).clone(),
             ))
         })
-        .collect()
+        .collect();
+    Box::leak(vec.into_boxed_slice())
 }
 
 // Cached index of the build-time portal jitcode within `ALL_JITCODES`.

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -302,6 +302,7 @@ impl MetaInterpStaticData {
     /// This preserves RPython's stable `metainterp_sd.jitcodes` invariant
     /// for already-captured resume data.
     fn set_jitcodes_from_make_result(&mut self, payloads: Vec<std::sync::Arc<crate::PyJitCode>>) {
+        self.reserve_build_time_index_space();
         for payload in payloads {
             assert!(
                 !payload.code_ptr.is_null(),
@@ -366,6 +367,7 @@ impl MetaInterpStaticData {
         code: *const (),
         supplied: Option<std::sync::Arc<crate::PyJitCode>>,
     ) -> *const JitCode {
+        self.reserve_build_time_index_space();
         let raw_key = Self::canonical_code_key_opt(code).unwrap_or(0);
         if let Some(pos) = self.installed_jitcode_pos_for_raw_key(raw_key) {
             match supplied {
@@ -402,6 +404,29 @@ impl MetaInterpStaticData {
         let ptr = &*jitcode as *const JitCode;
         self.jitcodes.push(jitcode);
         ptr
+    }
+
+    /// Keep the leading `jitcodes` slots that a build-time jitcode's baked
+    /// `JitCode::index` can name out of the runtime append space.
+    ///
+    /// The build-time table is dense (`all_jitcodes()[i].index == i`), so its
+    /// length is exactly that range, and
+    /// [`install_build_time_jitcode_at`] writes into it verbatim — a resume
+    /// frame records the baked index and resolves it as `sd.jitcodes[index]`.
+    /// Runtime PyCode entries append at `len()`, so without the reservation
+    /// the first one takes slot 0, the build-time install overwrites it, and
+    /// [`Self::compiled_jitcode_lookup`] answers `None` for a code the
+    /// codewriter still reports as drained.
+    ///
+    /// Idempotent: a no-op once the leading slots exist.
+    fn reserve_build_time_index_space(&mut self) {
+        let reserved = crate::jitcode_runtime::all_jitcodes().len();
+        while self.jitcodes.len() < reserved {
+            let index = self.jitcodes.len() as i32;
+            let payload = std::sync::Arc::new(crate::PyJitCode::skeleton(std::ptr::null()));
+            Self::stamp_payload_index(index, &payload);
+            self.jitcodes.push(Box::new(JitCode { index, payload }));
+        }
     }
 
     /// Return the installed SD entry for a `PyCode`.
@@ -692,13 +717,11 @@ pub fn install_jitcode_for(
 /// resume decoders to resolve `sd.jitcodes[index]` to the portal, it must sit
 /// at exactly that slot.
 ///
-/// The build-time absolute index space and the runtime-grown user-PyCode slot
-/// space collide here (both start at 0): overwriting `index` clobbers whatever
-/// user jitcode last took that slot.  This is sound only while the jd1
-/// experiment's overwritten slot holds a jitcode with no live resume data (the
-/// import-time `_get_exports_list` at slot 0 is dead by the time user code
-/// drives jd1).  Reconciling the two index spaces into one absolute table is
-/// the standing follow-up.
+/// The two index spaces no longer overlap: the leading
+/// `all_jitcodes().len()` slots are reserved for build-time indices
+/// (`MetaInterpStaticData::reserve_build_time_index_space`) and runtime
+/// PyCode entries append above them, so the write below can only replace a
+/// reserved skeleton or an earlier install of the same portal.
 ///
 /// Dropping the install is NOT an available shortcut, measured: without it the
 /// jd1 live-enter blackhole resume resolves slot 0 to the user jitcode that
@@ -712,15 +735,7 @@ pub fn install_build_time_jitcode_at(index: usize, payload: std::sync::Arc<crate
     ensure_finish_setup();
     METAINTERP_SD.with(|r| {
         let mut sd = r.borrow_mut();
-        while sd.jitcodes.len() < index {
-            let i = sd.jitcodes.len() as i32;
-            let skeleton = std::sync::Arc::new(crate::PyJitCode::skeleton(std::ptr::null()));
-            skeleton.jitcode.set_index(i as usize);
-            sd.jitcodes.push(Box::new(JitCode {
-                index: i,
-                payload: skeleton,
-            }));
-        }
+        sd.reserve_build_time_index_space();
         // Idempotent same-value stamp: the portal core already carries `index`.
         payload.jitcode.set_index(index);
         let slot = Box::new(JitCode {
@@ -728,6 +743,11 @@ pub fn install_build_time_jitcode_at(index: usize, payload: std::sync::Arc<crate
             payload,
         });
         if index < sd.jitcodes.len() {
+            debug_assert!(
+                sd.jitcodes[index].payload.is_skeleton()
+                    || unsafe { sd.jitcodes[index].raw_code() }.is_null(),
+                "build-time slot {index} is occupied by a runtime PyCode entry",
+            );
             sd.jitcodes[index] = slot;
         } else {
             sd.jitcodes.push(slot);
@@ -13307,7 +13327,10 @@ mod indirectcalltargets_tests {
         let hit = sd
             .compiled_jitcode_lookup(code)
             .expect("populated payload should be installed by make_jitcodes");
-        assert!(std::ptr::eq(sd.jitcodes[0].as_ref(), hit));
+        // Runtime entries append above the reserved build-time index space, so
+        // read the slot back through the entry's own index.
+        let index = unsafe { (*hit).index } as usize;
+        assert!(std::ptr::eq(sd.jitcodes[index].as_ref(), hit));
     }
 
     #[test]
@@ -13327,9 +13350,11 @@ mod indirectcalltargets_tests {
         let mut sd = MetaInterpStaticData::new();
         let (_code, expected_raw) = make_code("x = 1\n");
         sd.set_jitcodes_from_make_result(vec![populated_pyjit(expected_raw)]);
+        // The install appends above the reserved build-time index space.
+        let index = sd.jitcodes.len() as i32 - 1;
         let _sd_guard = MetainterpSdGuard::swap(sd);
 
-        let hit = raw_code_for_jitcode_index(0).expect("jitcode index 0 must resolve");
+        let hit = raw_code_for_jitcode_index(index).expect("installed jitcode index must resolve");
         assert_eq!(hit, expected_raw);
     }
 }

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -12864,6 +12864,21 @@ fn recipe_slot_to_pyobj(v: majit_ir::Value) -> PyObjectRef {
 /// live wrapper is registered or it carries no globals yet — the callers
 /// (`reconstruct_inline_recipe` and `assemble_bridge_inline_pending`) treat a
 /// null result as "decline the multi-frame path".
+/// Recover the callee's `W_Code` OBJECT for a reconstructed inline frame.
+///
+/// Sibling of [`recover_inline_callee_globals`], reading the same
+/// `code_ptr → live wrapper` registry.  A reconstructed frame's `pycode` red
+/// has to be this object, not the raw code pointer the recipe carries: every
+/// consumer treats it as a `W_Code` (constant pool reads, `PyTraceback` node
+/// construction).  Returns `PY_NULL` when no live wrapper is registered.
+pub(crate) fn recover_inline_callee_code(code_ptr: *const ()) -> pyre_object::PyObjectRef {
+    let live = pyre_interpreter::live_code_wrapper(code_ptr);
+    if live.is_null() {
+        return pyre_object::PY_NULL;
+    }
+    live
+}
+
 pub(crate) fn recover_inline_callee_globals(code_ptr: *const ()) -> pyre_object::PyObjectRef {
     let live = pyre_interpreter::live_code_wrapper(code_ptr);
     if !live.is_null() {

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -6753,24 +6753,35 @@ fn reconstruct_inline_recipe(
     cache: &mut BridgeVirtualCache,
     in_a_call: bool,
 ) -> Option<ReconstructRecipe> {
+    // Each decline below ends the whole multi-frame path (`recipes.clear()` in
+    // the caller), so name every class: an uncensused decline is invisible in
+    // the corpus and shows up only as the caller's NoRecipes abort.
+    macro_rules! decline {
+        ($class:literal) => {{
+            crate::jitcode_dispatch::census_record(concat!("P2Recipe::", $class));
+            return None;
+        }};
+    }
     if frame.pc < 0 {
-        return None;
+        decline!("NoSnapshotPc");
     }
     let py_pc = forward_py_pc_or_backxlat(frame.jitcode_index, frame.pc) as usize;
-    let w_code = code_for_jitcode_index(frame.jitcode_index)?;
+    let Some(w_code) = code_for_jitcode_index(frame.jitcode_index) else {
+        decline!("NoCodeForJitcodeIndex");
+    };
     if w_code.is_null() {
-        return None;
+        decline!("NullWCode");
     }
     let raw_code = unsafe {
         pyre_interpreter::w_code_get_ptr(w_code as pyre_object::PyObjectRef)
             as *const pyre_interpreter::CodeObject
     };
     if raw_code.is_null() {
-        return None;
+        decline!("NullRawCode");
     }
     let code_ref = unsafe { &*raw_code };
     if !code_ref.freevars.is_empty() || pyre_interpreter::pyframe::ncells(code_ref) != 0 {
-        return None;
+        decline!("CellsOrFreevars");
     }
     // pyframe.py:128-132 get_w_globals_storage(): the reconstructed callee frame's
     // globals come from its own pycode (`assemble_bridge_inline_pending`
@@ -6779,14 +6790,14 @@ fn reconstruct_inline_recipe(
     // namespace), there is nothing to restore, so abort to the single-frame
     // bridge — the forward inline path declines the same way.
     if recover_inline_callee_globals(raw_code as *const ()).is_null() {
-        return None;
+        decline!("NoCalleeGlobals");
     }
     let nlocals = code_ref.varnames.len();
 
     let liveness = crate::liveness::liveness_for(raw_code);
     let stack_only = match liveness.stack_depth_at(py_pc) {
         Some(d) => d,
-        None => return None,
+        None => decline!("NoStackDepthAtPc"),
     };
     let pending_result_abs_slot = if in_a_call && stack_only > 0 {
         Some(nlocals + stack_only - 1)
@@ -6813,13 +6824,14 @@ fn reconstruct_inline_recipe(
         None
     };
     let pending_result_color = if in_a_call {
-        Some(
-            pyjitcode_for_jitcode_index(frame.jitcode_index).and_then(|p| {
-                p.result_color_trivia_for_jitcode_pc(frame.pc as usize)
-                    .map(|c| c as usize)
-                    .filter(|&c| c != u16::MAX as usize)
-            })?,
-        )
+        let Some(color) = pyjitcode_for_jitcode_index(frame.jitcode_index).and_then(|p| {
+            p.result_color_trivia_for_jitcode_pc(frame.pc as usize)
+                .map(|c| c as usize)
+                .filter(|&c| c != u16::MAX as usize)
+        }) else {
+            decline!("NoPendingResultColor");
+        };
+        Some(color)
     } else {
         None
     };
@@ -6836,7 +6848,7 @@ fn reconstruct_inline_recipe(
         if reg_indices.int.iter().any(|&c| c as usize == color)
             || reg_indices.float.iter().any(|&c| c as usize == color)
         {
-            return None;
+            decline!("PendingResultNotRef");
         }
         if let Some(ref_pos) = reg_indices.ref_.iter().position(|&c| c as usize == color) {
             pending_value_index = Some(reg_indices.int.len() + ref_pos);
@@ -6855,7 +6867,7 @@ fn reconstruct_inline_recipe(
     // resume.py:1054 consume_boxes: the liveness enumeration count must match
     // the (pending-excluded) encoded frame section exactly.
     if reg_indices.total_len() != values.len() {
-        return None;
+        decline!("LivenessValueCountMismatch");
     }
     // virtualizable.py:86-98: at a bytecode boundary (every resume pc is one)
     // the frame's locals_cells_stack_w is a W_Root array — all live slots are
@@ -6866,7 +6878,7 @@ fn reconstruct_inline_recipe(
     // always reads `registers_r[k]`, trace_opcode.rs). Fall back to
     // the single-frame bridge rather than synthesize an unboxed local.
     if !reg_indices.int.is_empty() || !reg_indices.float.is_empty() {
-        return None;
+        decline!("UnboxedLiveRegister");
     }
 
     // Virtualizable-callee shape (pyre's "every function is its own portal"
@@ -6931,7 +6943,9 @@ fn reconstruct_inline_recipe(
             crate::jitcode_dispatch::census_record("P2Recipe::PortalSiblingAdmit");
         }
         use majit_ir::resumedata::{RebuiltValue, TAGVIRTUAL, UNINITIALIZED_TAG, untag};
-        let frame_pos = reg_indices.ref_.iter().position(|&c| c == pframe_reg)?;
+        let Some(frame_pos) = reg_indices.ref_.iter().position(|&c| c == pframe_reg) else {
+            decline!("NoFrameRedPosition");
+        };
         // resume.py:1042-1057 rebuild_from_resumedata consumes the saved boxes
         // for every frame without requiring the frame object itself to remain
         // virtual.  A Pyre callee frame can be forced before the guard (for
@@ -6984,25 +6998,33 @@ fn reconstruct_inline_recipe(
             });
         }
         let RebuiltValue::Virtual(frame_vidx) = values[frame_pos] else {
-            return None;
+            decline!("FrameRedNotVirtual");
         };
         // The `frame` red virtual is a PyFrame VirtualInfo; its
         // `locals_cells_stack_w` array field is at PYFRAME_LOCALS_CELLS_STACK_OFFSET.
         let array_vidx = {
+            let Some(frame_virtual) = rd_virtual_at(rd_virtuals, *frame_vidx) else {
+                decline!("FrameVirtualMissing");
+            };
             let majit_ir::RdVirtualInfo::VirtualInfo {
                 fieldnums,
                 fielddescrs,
                 ..
-            } = rd_virtual_at(rd_virtuals, *frame_vidx)?
+            } = frame_virtual
             else {
-                return None;
+                decline!("FrameVirtualNotStruct");
             };
-            let arr_field_idx = fielddescrs.iter().position(|fd| {
+            let Some(arr_field_idx) = fielddescrs.iter().position(|fd| {
                 fd.offset == crate::frame_layout::PYFRAME_LOCALS_CELLS_STACK_OFFSET
-            })?;
-            let (av, tb) = untag(*fieldnums.get(arr_field_idx)?);
+            }) else {
+                decline!("NoLocalsArrayField");
+            };
+            let Some(&arr_fieldnum) = fieldnums.get(arr_field_idx) else {
+                decline!("LocalsArrayFieldnumMissing");
+            };
+            let (av, tb) = untag(arr_fieldnum);
             if tb != TAGVIRTUAL {
-                return None;
+                decline!("LocalsArrayNotVirtual");
             }
             if av < 0 {
                 (rd_virtuals.map_or(0, |v| v.len()) as i32 + av) as usize
@@ -7010,14 +7032,17 @@ fn reconstruct_inline_recipe(
                 av as usize
             }
         };
-        let arr: Vec<i16> = match rd_virtual_at(rd_virtuals, array_vidx)? {
+        let Some(array_virtual) = rd_virtual_at(rd_virtuals, array_vidx) else {
+            decline!("LocalsArrayVirtualMissing");
+        };
+        let arr: Vec<i16> = match array_virtual {
             majit_ir::RdVirtualInfo::VArrayInfoClear { fieldnums, .. }
             | majit_ir::RdVirtualInfo::VArrayInfoNotClear { fieldnums, .. } => fieldnums.clone(),
-            _ => return None,
+            _ => decline!("LocalsArrayNotArrayInfo"),
         };
         let valuestackdepth = nlocals + stack_only;
         if valuestackdepth > arr.len() {
-            return None;
+            decline!("LocalsArrayTooShort");
         }
         let callinfocollection = ctx.callinfocollection.clone();
         let mut registers_r = vec![OpRef::NONE; valuestackdepth];
@@ -7261,7 +7286,7 @@ fn reconstruct_inline_recipe(
             continue;
         }
         if registers_r[s] == OpRef::NONE {
-            return None;
+            decline!("MandatoryOperandMissing");
         }
     }
 

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -574,7 +574,8 @@ pub fn setup_indirectcalltargets(targets: Vec<std::sync::Arc<majit_metainterp::j
     // assembler objects standing in for one RPython CodeWriter assembler.
     // Keep the frozen source-translation PBC family when runtime targets are
     // published instead of replacing it with the latest runtime-only batch.
-    let mut merged = crate::jitcode_runtime::build_indirectcalltargets();
+    let frozen = crate::jitcode_runtime::indirectcalltargets();
+    let mut merged = frozen.to_vec();
     for target in targets {
         if !merged
             .iter()

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -7035,9 +7035,10 @@ fn reconstruct_inline_recipe(
             else {
                 decline!("FrameVirtualNotStruct");
             };
-            let Some(arr_field_idx) = fielddescrs.iter().position(|fd| {
-                fd.offset == crate::frame_layout::PYFRAME_LOCALS_CELLS_STACK_OFFSET
-            }) else {
+            let Some(arr_field_idx) = fielddescrs
+                .iter()
+                .position(|fd| fd.offset == crate::frame_layout::PYFRAME_LOCALS_CELLS_STACK_OFFSET)
+            else {
                 decline!("NoLocalsArrayField");
             };
             let Some(&arr_fieldnum) = fieldnums.get(arr_field_idx) else {

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -1545,7 +1545,11 @@ fn carrier_root_catch_target<Sym: WalkSym>(sym: &Sym, root_pc: usize) -> Option<
     // `catch_exception/L` for the enclosing try sits BEHIND it (between the
     // CALL's post-call `-live-` and the next op), so scan backward — the same
     // lookup the single-frame exception-edge router uses.
-    let candidate = crate::jitcode_dispatch::find_catch_before_resume_live(code, root_pc);
+    // `root_pc` is the CALL's OWN trailing `-live-`, one op short of the
+    // block-entry `-live-` the backward scan keys off, so read forward first
+    // and keep the backward scan for callers already at that coordinate.
+    let candidate = crate::jitcode_dispatch::catch_target_after_resume_live(code, root_pc)
+        .or_else(|| crate::jitcode_dispatch::find_catch_before_resume_live(code, root_pc));
     if std::env::var_os("PYRE_P2_DIAG").is_some() {
         eprintln!("[p2-raise] root_pc={root_pc} catch_before={candidate:?}");
     }

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -1765,6 +1765,13 @@ fn drive_bridge_carrier_walk<Sym: WalkSym>(
     // SubRaise routing performs, threaded across the carrier the sub-walk
     // crossed on its own).  Without this the raise is dropped and re-interpreted
     // every iteration (deopt-storm).
+    //
+    // A root frame with no covering handler is the framestack-exhausted arm of
+    // the same walk: `finishframe_exception` runs out of frames to scan and
+    // reaches `compile_exit_frame_with_exception`.  Seeding `catch_target: None`
+    // routes the root walk to that exit instead of declining — the decline
+    // records the bridge guard as permanently undecidable, so every later
+    // failure of that guard short-circuits into a full blackhole resume.
     let subwalk_raise = match &walk {
         Some(Ok((crate::jitcode_dispatch::DispatchOutcome::SubRaise { exc, exc_concrete }, _))) => {
             Some((*exc, *exc_concrete))
@@ -1773,28 +1780,29 @@ fn drive_bridge_carrier_walk<Sym: WalkSym>(
     };
     if let Some((exc, exc_concrete)) = subwalk_raise {
         if carrier.recipes.len() == 1 {
-            if let Some(catch_target) = carrier_root_catch_target(sym, root_pc) {
-                crate::jitcode_dispatch::set_carrier_raise_seed(
-                    crate::jitcode_dispatch::CarrierRaiseSeed {
-                        exc,
-                        exc_concrete,
-                        catch_target,
-                    },
-                );
-                crate::jitcode_dispatch::census_record("P2Drain::CompileRootRaise");
-                let root_py_pc =
-                    crate::state::backxlat_py_pc(carrier.root_jitcode_index, root_pc as i32)
-                        as usize;
-                let action =
-                    full_body_walk_trace(ctx, sym, w_code, root_py_pc, cf_addr, WalkJournals::Keep);
-                // Defensive: `dispatch_via_miframe` consumes the seed, but a
-                // walk that early-declines before reaching it would leave the
-                // seed standing and leak it into a later unrelated walk. Clear
-                // any residual seed so exactly this walk can observe it.
-                let _ = crate::jitcode_dispatch::take_carrier_raise_seed();
-                return action;
-            }
-            crate::jitcode_dispatch::census_record("P2Drain::RaiseNoRootCatch");
+            let catch_target = carrier_root_catch_target(sym, root_pc);
+            crate::jitcode_dispatch::set_carrier_raise_seed(
+                crate::jitcode_dispatch::CarrierRaiseSeed {
+                    exc,
+                    exc_concrete,
+                    catch_target,
+                },
+            );
+            crate::jitcode_dispatch::census_record(if catch_target.is_some() {
+                "P2Drain::CompileRootRaise"
+            } else {
+                "P2Drain::CompileRootRaiseEscape"
+            });
+            let root_py_pc =
+                crate::state::backxlat_py_pc(carrier.root_jitcode_index, root_pc as i32) as usize;
+            let action =
+                full_body_walk_trace(ctx, sym, w_code, root_py_pc, cf_addr, WalkJournals::Keep);
+            // Defensive: `dispatch_via_miframe` consumes the seed, but a
+            // walk that early-declines before reaching it would leave the
+            // seed standing and leak it into a later unrelated walk. Clear
+            // any residual seed so exactly this walk can observe it.
+            let _ = crate::jitcode_dispatch::take_carrier_raise_seed();
+            return action;
         }
     }
 

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -4904,8 +4904,17 @@ fn full_body_walk_trace<Sym: WalkSym>(
                 // re-walk executes the body's residual calls before failing) —
                 // an unbounded slowdown. Decline it so the location interprets
                 // instead.
+                // A bridge entry is keyed on the guard descr, which the
+                // green-key cell never gates, so the green-key decline alone
+                // leaves `must_compile_with_values` re-firing this
+                // structurally-undecidable bridge every
+                // `DEFAULT_TRACE_EAGERNESS` failures forever — each retry
+                // re-walking the whole body and executing its residual calls
+                // concretely. Record the bridge-guard decline too, the way
+                // `ExcEdgeNoInFrameCatch` below does.
                 DE::GotoIfNotValueNotConcrete { .. } => {
                     fbw_decline(crate::driver::make_green_key(w_code, start_pc));
+                    fbw_bridge_decline(ctx);
                     TraceAction::Abort
                 }
                 // The exc-edge routing decision is `find_catch_for_exc_resume`

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -5757,7 +5757,7 @@ pub extern "C" fn bh_compare_fn(lhs: i64, rhs: i64, op_code: i64) -> i64 {
     // function match specs and fell through to an unconditional `true` for a
     // proper exception type object, which made every `except SomeError:`
     // appear to match — wrong for any clause beyond the first.
-    if op_code == 10 {
+    if op_code == pyre_interpreter::runtime_ops::ISINSTANCE_OP_TAG {
         // Validate the match target is an exception class / tuple of exception
         // classes first (`cmp_exc_match`, pyopcode.py:1034-1039), raising
         // TypeError otherwise.  The BC handler runs

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -2896,19 +2896,19 @@ pub fn trace_and_compile_from_bridge(
     // live (outer) frame `eval_loop_jit` runs. Such a resume cannot be
     // completed by interpreting the live frame forward — see the
     // blackhole routing at the handoff below.
-    let (resume_pc, num_resume_frames) = if let Some(ref meta) = meta {
-        if let Some((_, pc, nframes)) = crate::eval::decode_and_restore_guard_failure(
+    let (resume_pc, num_resume_frames, resume_coords) = if let Some(ref meta) = meta {
+        if let Some((_, pc, nframes, coords)) = crate::eval::decode_and_restore_guard_failure(
             &mut jit_state_local,
             meta,
             raw_values,
             exit_layout,
         ) {
-            (pc, nframes)
+            (pc, nframes, coords)
         } else {
-            (0, 0)
+            (0, 0, Vec::new())
         }
     } else {
-        (0, 0)
+        (0, 0, Vec::new())
     };
     if resume_pc == 0 {
         return BridgeResolution::ResumeBlackhole;
@@ -3070,18 +3070,55 @@ pub fn trace_and_compile_from_bridge(
     // the frame to the caller's handler.  Compiling a real raising bridge
     // (`Finish(exc, exit_frame_with_exception_descr_ref)`) is the orthodox
     // follow-up, gated on the same exception-edge bridge epic.
+    /// The exception-table byte offset a `next_instr`-style resume coordinate
+    /// maps to, mirroring the live-frame form `frame.last_instr * 2` (where
+    /// `last_instr` is `next_instr - 1`).
+    fn exc_table_offset(py_pc: usize) -> u32 {
+        (py_pc.saturating_sub(1) as u32) * 2
+    }
+
+    /// Index of the resumed frame that catches, searched INNERMOST-first by
+    /// asking each frame's own exception table about its own resume pc.
+    /// `coords` is outermost-first, so `Some(0)` means the raise unwinds clear
+    /// out of every inlined callee into the live frame; `None` means it
+    /// escapes them all.
+    fn resumed_catch_level(coords: &[(usize, usize)]) -> Option<usize> {
+        for (level, &(w_code, py_pc)) in coords.iter().enumerate().rev() {
+            if w_code == 0 {
+                return None;
+            }
+            let raw = unsafe {
+                pyre_interpreter::w_code_get_ptr(w_code as pyre_object::PyObjectRef)
+                    as *const pyre_interpreter::CodeObject
+            };
+            if raw.is_null() {
+                return None;
+            }
+            let code = unsafe { &*raw };
+            if pyre_interpreter::pycode::lookup_exceptiontable(
+                &code.exceptiontable,
+                exc_table_offset(py_pc),
+            )
+            .is_some()
+            {
+                return Some(level);
+            }
+        }
+        None
+    }
+
     let caught_in_frame = pending_exc && last_bridge_is_exception_guard && {
         if is_multiframe_resume {
             // `resume_pc` (and thus `frame.last_instr`, set above) addresses the
-            // INNERMOST inlined frame, but `code` is the live OUTER frame, so an
-            // exception-table lookup would consult the wrong code object — it can
-            // miss a try/except local to the inlined callee and let the bridge
-            // walk record the callee's NULL raised-call result. The multi-frame
-            // resume already routes through the blackhole below (`resume_via_blackhole`);
-            // decline up-front so no possibly-wrong bridge is traced/attached and
-            // the blackhole rebuilds the inlined framestack and routes the
-            // exception to the correct handler.
-            true
+            // INNERMOST inlined frame while `code` is the live OUTER frame, so
+            // the single-frame lookup below would consult the wrong code object.
+            // Ask each resumed frame about its OWN pc instead. Only a raise that
+            // unwinds clear out of every inlined callee into the live frame's
+            // own handler is routable: that unwind discards the callee frames
+            // outright, so there is no inlined framestack left to rebuild. A
+            // catch inside a callee still needs the carrier subwalk and keeps
+            // declining below, as does a raise that escapes the whole resume.
+            resumed_catch_level(&resume_coords) == Some(0)
         } else {
             let off = if frame.last_instr < 0 {
                 0u32
@@ -3091,13 +3128,23 @@ pub fn trace_and_compile_from_bridge(
             pyre_interpreter::pycode::lookup_exceptiontable(&code.exceptiontable, off).is_some()
         }
     };
-    // Exception-edge bridge: route the caught-in-frame
-    // single-frame resume to the in-frame `except` handler (walker
-    // `find_catch_before_resume_live`) instead of declining.  The escaping case
-    // (uncaught) and the multi-frame resume still decline here — those are
-    // separate slices (raising-bridge Finish(exc) / carrier subwalk).
+    // Exception-edge bridge: route a resume whose handler lives in the LIVE
+    // frame to that `except` handler (walker `find_catch_before_resume_live`)
+    // instead of declining.  `caught_in_frame` already restricts the
+    // multi-frame case to the unwind-to-live-frame shape; the escaping case
+    // (uncaught) and a catch inside an inlined callee still decline below —
+    // those are separate slices (raising-bridge Finish(exc) / carrier subwalk).
+    // Only when the outermost resume section really IS the live frame, which is
+    // what lets the unwind land in a frame that already exists. Re-pointing the
+    // live frame to coordinates belonging to some other code object would
+    // resume the walk against the wrong bytecode.
+    let unwind_to_live_frame = is_multiframe_resume
+        && caught_in_frame
+        && resume_coords
+            .first()
+            .is_some_and(|&(outer_w_code, _)| outer_w_code == frame.pycode as usize);
     let route_exc_edge = caught_in_frame
-        && !is_multiframe_resume
+        && (!is_multiframe_resume || unwind_to_live_frame)
         && pyre_jit_trace::jitcode_dispatch::exc_edge_bridge_enabled();
     if route_exc_edge && guard_exc != 0 {
         // Publish the grabbed exception (`cpu.grab_exc_value` result) so the
@@ -3145,6 +3192,30 @@ pub fn trace_and_compile_from_bridge(
         }
         return BridgeResolution::ResumeBlackhole;
     }
+
+    // The unwind discards every inlined callee, so the state the walk must
+    // start from is the LIVE frame at its own call site — not the innermost
+    // callee coordinate `decode_and_restore_guard_failure` installed for the
+    // blackhole (its `resume_pc` override plus the matching innermost
+    // `depth_based_vsd_for_wcode` correction).  Re-point the frame to the
+    // outermost section before anything below reads it: `PyreJitState` holds
+    // only the frame pointer, so the `jit_state` built above picks this up,
+    // and `snapshot_for_tracing` then captures the coordinate the post-bridge
+    // interpreter should resume at.  Only reachable where this function used
+    // to decline outright, so no existing resume changes shape.
+    let resume_pc = match resume_coords.first() {
+        Some(&(outer_w_code, outer_py_pc)) if unwind_to_live_frame => {
+            frame.set_last_instr_from_next_instr(outer_py_pc);
+            if let Some(vsd) =
+                pyre_jit_trace::state::depth_based_vsd_for_wcode(outer_w_code, outer_py_pc)
+            {
+                jit_state.set_valuestackdepth(vsd);
+                jit_state.clear_stack_above(vsd);
+            }
+            outer_py_pc
+        }
+        _ => resume_pc,
+    };
 
     // The live frame is a virtualizable GC object held by raw bridge-trace
     // locals while retracing can collect. RPython keeps the virtualizable

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -656,6 +656,29 @@ pub(crate) extern "C" fn record_caught_blackhole_traceback(
     let last_instruction =
         pyre_jit_trace::state::python_pc_for_jitcode_pc_public(jitcode_index, opcode_position)
             .map_or(unsafe { (*frame_ptr).last_instr as i64 }, i64::from);
+    // One catch can be reached by two recorders: this hook, emitted into the
+    // loop trace by the in-trace handler-entry arm, and the IR-virtual node the
+    // bridge handler-entry arm builds when the exception edge deopts into a
+    // bridge.  Both then run for the same delivery and the frame gets two
+    // adjacent nodes, so the handler reads its own name twice.  Upstream never
+    // has the pair — `pyopcode.py handle_operation_error` is the single attach
+    // point — so drop the second: `record_application_traceback` prepends, and
+    // this exact node already exists exactly when the chain HEAD carries this
+    // frame at this instruction.  A genuine repeat (the same frame raising
+    // again at the same offset) always attaches to a fresh exception, and a
+    // bare reraise, which does legitimately re-record one frame, is skipped
+    // above.
+    unsafe {
+        let head =
+            pyre_object::interp_exceptions::w_exception_get_traceback(exc_value as PyObjectRef);
+        if !head.is_null()
+            && pyre_interpreter::pytraceback::is_pytraceback(head)
+            && pyre_interpreter::pytraceback::w_pytraceback_get_frame(head) == frame_ptr
+            && pyre_interpreter::pytraceback::w_pytraceback_get_lasti(head) == last_instruction
+        {
+            return;
+        }
+    }
     m73_lastinstr_audit("caught", Some(jitcode_index), opcode_position, frame_ptr);
     unsafe {
         pyre_interpreter::pytraceback::record_application_traceback(

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -9774,7 +9774,7 @@ pub(crate) fn decode_and_restore_guard_failure(
     meta: &crate::jit::state::PyreMeta,
     raw_values: &[i64],
     exit_layout: &CompiledExitLayout,
-) -> Option<(Vec<Value>, usize, usize)> {
+) -> Option<(Vec<Value>, usize, usize, Vec<(usize, usize)>)> {
     if majit_metainterp::majit_log_enabled() {
         eprintln!(
             "[jit] exit-layout trace_id={} fail_idx={} source_op={:?} rd_numb={} recovery={} resume_layout={}",
@@ -9937,7 +9937,16 @@ pub(crate) fn decode_and_restore_guard_failure(
                 }
             }
         }
-        Some((typed, resume_pc, resumed_frames.len()))
+        // Outermost-first `(w_code, py_pc)` per resumed section. The caller
+        // needs them to ask each frame's own exception table whether it
+        // catches at its own resume pc — `resume_pc` alone only addresses the
+        // innermost section, so it cannot answer that question for a
+        // multi-frame resume.
+        let coords: Vec<(usize, usize)> = resumed_frames
+            .iter()
+            .map(|f| (f.code as usize, f.py_pc))
+            .collect();
+        Some((typed, resume_pc, resumed_frames.len(), coords))
     } else {
         None
     }

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -5662,28 +5662,42 @@ fn drive_unpack_iterable_trace(
         // envelope that pairs with `MetaInterp.tracing`, and jd1 opens the
         // tracer through `MetaInterp::force_start_tracing`, which installs no
         // envelope (only `JitDriver::force_start_tracing` calls
-        // `begin_trace_session`). The no-op also leaves the shared tracer slot
-        // installed, so `is_tracing()` answers true and every later trace
-        // attempt in the process bails at the guard above — an
-        // `exc.args = <iterable>` drain inside a hot loop costs ~12x for that
-        // reason.
+        // `begin_trace_session`).
         //
         // Opening the session here (the meta is fully static for the novable
         // driver, so it is the value the back-edge arm above builds) does
-        // compile the trace and release the tracer, but it exposes a second
-        // defect that has to land first: the error parked just above is then
-        // delivered at an unrelated later call site instead of at this
-        // unpack. `synth/unpack_drain_star_raise` case 4 (`RaisingEarly`)
-        // catches it — the `ValueError` escapes the following round's
-        // `count(*Counting(N))`. Draining at the merge point in
-        // `_unpackiterable_unknown_length` is necessary but not sufficient, so
-        // the park/deliver pairing is what needs the root-cause pass.
+        // compile the trace, but it exposes a second defect that has to land
+        // first: the error parked just above is then delivered at an unrelated
+        // later call site instead of at this unpack.
+        // `synth/unpack_drain_star_raise` case 4 (`RaisingEarly`) catches it —
+        // the `ValueError` escapes the following round's `count(*Counting(N))`.
+        // Draining at the merge point in `_unpackiterable_unknown_length` is
+        // necessary but not sufficient, so the park/deliver pairing is what
+        // needs the root-cause pass.
         match meta.compile_finish_from_active_session(
             &finish_args,
             finish_arg_types,
             exit_with_exception,
         ) {
             Ok(()) => {
+                // The no-op arm answers `Ok(())` without draining the tracer,
+                // and `tracing` is one slot shared by every driver: left
+                // installed it makes `is_tracing()` answer true for the rest of
+                // the process, so every later trace attempt in any driver bails
+                // at the guard above and nothing is ever compiled again. Any
+                // module defining a class with `__slots__` reaches this — the
+                // slots tuple is drained during type creation and the drain
+                // ends by raising — which costs an unrelated loop in the same
+                // module ~150x.
+                //
+                // A finish that could not be compiled is an abort, so treat it
+                // as the `else` arm below does: drop the trace non-permanently
+                // and let the cell's abort budget self-limit retrace storms.
+                // `abort_trace` also closes the profiler/debug scope
+                // `force_start_tracing` opened, via `clear_trace_session`.
+                if meta.is_tracing() {
+                    meta.abort_trace(false);
+                }
                 if dbg {
                     eprintln!(
                         "[jd1] compile_finish ok exit_with_exception={exit_with_exception} \

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -5653,6 +5653,27 @@ fn drive_unpack_iterable_trace(
         if exit_with_exception {
             crate::call_jit::drain_backend_jit_exc();
         }
+        // This reaches the session-absent no-op arm, so no finish trace is
+        // compiled here today: the finish-compile drains the frontend meta
+        // envelope that pairs with `MetaInterp.tracing`, and jd1 opens the
+        // tracer through `MetaInterp::force_start_tracing`, which installs no
+        // envelope (only `JitDriver::force_start_tracing` calls
+        // `begin_trace_session`). The no-op also leaves the shared tracer slot
+        // installed, so `is_tracing()` answers true and every later trace
+        // attempt in the process bails at the guard above — an
+        // `exc.args = <iterable>` drain inside a hot loop costs ~12x for that
+        // reason.
+        //
+        // Opening the session here (the meta is fully static for the novable
+        // driver, so it is the value the back-edge arm above builds) does
+        // compile the trace and release the tracer, but it exposes a second
+        // defect that has to land first: the error parked just above is then
+        // delivered at an unrelated later call site instead of at this
+        // unpack. `synth/unpack_drain_star_raise` case 4 (`RaisingEarly`)
+        // catches it — the `ValueError` escapes the following round's
+        // `count(*Counting(N))`. Draining at the merge point in
+        // `_unpackiterable_unknown_length` is necessary but not sufficient, so
+        // the park/deliver pairing is what needs the root-cause pass.
         match meta.compile_finish_from_active_session(
             &finish_args,
             finish_arg_types,
@@ -5660,7 +5681,11 @@ fn drive_unpack_iterable_trace(
         ) {
             Ok(()) => {
                 if dbg {
-                    eprintln!("[jd1] compile_finish ok exit_with_exception={exit_with_exception}");
+                    eprintln!(
+                        "[jd1] compile_finish ok exit_with_exception={exit_with_exception} \
+                         still_tracing={}",
+                        meta.is_tracing(),
+                    );
                 }
             }
             Err(stb) => {

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -974,7 +974,11 @@ unsafe fn memoryview_object_destructor(obj_addr: usize) {
 /// `FrameDebugData` fields. Both require a custom trace.
 ///
 /// Forwarded (mirrors `walk_pyframe_roots` eval.rs:496-556):
-///   - `f_backref` — the parent frame pointer.
+///   - `f_backref` — the parent frame pointer, or the `JitVirtualRef` standing
+///     in for it once the JIT virtualizes an inlined callee. The vref is a GC
+///     object registered with `forced` as its one traced slot, so forwarding
+///     this slot greys the vref and the collector reaches the parent frame
+///     through it; no hop is needed here.
 ///   - `pycode` — visited to match the walker; inert while code objects
 ///     are Box-immortal (`is_nursery_object_start` short-circuits).
 ///   - `locals_cells_stack_w` — the array pointer.  A GC-managed nursery

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -6275,7 +6275,32 @@ fn const_pool_slot_upper_bound(c: &pyre_interpreter::ConstantData) -> usize {
     }
 }
 
+/// Memoized wrapper over [`unsupported_jit_shape_uncached`], which runs on
+/// every frame entry but is a pure function of the code object: it flattens the
+/// whole constant table and walks the instruction stream up to four times.
+///
+/// The `CodeObject` allocation is owned for the process lifetime by
+/// `PyCode.code_ptr` (`Box::into_raw`, never freed), so its address is a stable
+/// key that is never reused — the same property the frame-shape decline census
+/// already relies on.
 fn unsupported_jit_shape(code: &pyre_interpreter::CodeObject) -> UnsupportedJitShape {
+    thread_local! {
+        static SHAPE_CACHE: std::cell::RefCell<
+            std::collections::HashMap<usize, UnsupportedJitShape>,
+        > = std::cell::RefCell::new(std::collections::HashMap::new());
+    }
+    let key = code as *const _ as usize;
+    if let Some(cached) = SHAPE_CACHE.with(|c| c.borrow().get(&key).copied()) {
+        return cached;
+    }
+    let shape = unsupported_jit_shape_uncached(code);
+    SHAPE_CACHE.with(|c| {
+        c.borrow_mut().insert(key, shape);
+    });
+    shape
+}
+
+fn unsupported_jit_shape_uncached(code: &pyre_interpreter::CodeObject) -> UnsupportedJitShape {
     // RPython/PyPy has no counterpart to this function at all: `jit_merge_point`
     // and `can_enter_jit` are unconditional (`pypy/module/pypyjit/interp_jit.py`),
     // and `JitPolicy.look_inside_graph` (`rpython/jit/codewriter/policy.py:48`)

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -5665,15 +5665,11 @@ fn drive_unpack_iterable_trace(
         // `begin_trace_session`).
         //
         // Opening the session here (the meta is fully static for the novable
-        // driver, so it is the value the back-edge arm above builds) does
-        // compile the trace, but it exposes a second defect that has to land
-        // first: the error parked just above is then delivered at an unrelated
-        // later call site instead of at this unpack.
-        // `synth/unpack_drain_star_raise` case 4 (`RaisingEarly`) catches it —
-        // the `ValueError` escapes the following round's `count(*Counting(N))`.
-        // Draining at the merge point in `_unpackiterable_unknown_length` is
-        // necessary but not sufficient, so the park/deliver pairing is what
-        // needs the root-cause pass.
+        // driver, so it is the value the back-edge arm above builds) is what
+        // would compile the trace; the defect that used to block it — the
+        // parked error resurfacing at an unrelated later unpack, which
+        // `synth/unpack_drain_star_raise` case 4 catches — was the backend
+        // `_store_exception` leak drained just above, not the park itself.
         match meta.compile_finish_from_active_session(
             &finish_args,
             finish_arg_types,

--- a/pyre/pyre-jit/src/jit/assembler.rs
+++ b/pyre/pyre-jit/src/jit/assembler.rs
@@ -1394,12 +1394,13 @@ fn dispatch_op(
                 "instance_ptr_ne" => majit_ir::OpCode::InstancePtrNe,
                 _ => unreachable!(),
             };
-            state.builder.record_binop_r(
-                dst,
-                opcode,
-                expect_reg(&args[0], Kind::Ref),
-                expect_reg(&args[1], Kind::Ref),
-            );
+            // Either side may be a constant — `x is None` compares against the
+            // `None` singleton — so route a `ConstRef` through the jitcode
+            // `constants_r` pool the same way `setarrayitem_gc_r` does for its
+            // value operand, rather than demanding a materialized register.
+            let lhs = expect_ref_reg_or_pool(state, &args[0]);
+            let rhs = expect_ref_reg_or_pool(state, &args[1]);
+            state.builder.record_binop_r(dst, opcode, lhs, rhs);
         }
         "ptr_iszero" => {
             let dst = expect_result_reg(result, Kind::Int, "ptr_iszero needs result");

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -9454,7 +9454,12 @@ impl CodeWriter {
                                 compare_fn_idx,
                                 CallFlavor::MayForce,
                                 majit_ir::PyreHelperKind::CompareOp,
-                                vec![super::flow::Constant::signed(10).into()],
+                                vec![
+                                    super::flow::Constant::signed(
+                                        pyre_interpreter::runtime_ops::ISINSTANCE_OP_TAG,
+                                    )
+                                    .into(),
+                                ],
                                 vec![exc_value, match_type_value],
                                 vec![],
                                 vec![Kind::Ref, Kind::Ref, Kind::Int],

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -10850,24 +10850,34 @@ impl CodeWriter {
 
                         // PopJumpIfNone / PopJumpIfNotNone: pops 1. Net: -1.
                         //
-                        // `flowcontext.py` folds these to a static
-                        // `is None` constant test with no residual guard.
-                        // The meta-trace analog composes two already-ported
-                        // front-end ops: `is`/`is_not` against the immortal
-                        // `None` singleton (`pyobject_const_ref_value(w_none())`
-                        // — GC-safe to const-fold; `None` never moves), then
-                        // `bool` on that Ref result to feed the generic Bool
-                        // exitswitch.  Both variants jump on TRUE, so the exit
-                        // wiring is identical to POP_JUMP_IF_TRUE; the only
-                        // difference is `is` (POP_JUMP_IF_NONE) vs `is_not`
-                        // (POP_JUMP_IF_NOT_NONE).
+                        // `pyopcode.py POP_JUMP_FORWARD_IF_NONE` /
+                        // `_IF_NOT_NONE` branch straight on
+                        // `space.is_w(w_value, space.w_None)` — an `lltype.Bool`.
+                        // There is no `is_true` / boxed `w_True`-`w_False`
+                        // round-trip; that belongs to `IS_OP`
+                        // (`pyopcode.py IS_OP`), which has to *push* a
+                        // Python bool.  So this pair lowers to a bare pointer
+                        // identity test against the immortal `None` singleton
+                        // (`pyobject_const_ref_value(w_none())` — GC-safe to
+                        // const-fold; `None` never moves) feeding the Bool
+                        // exitswitch directly.  Routing it through the
+                        // `is`/`is_not` COMPARE_OP tags instead put a residual
+                        // `compare_fn` may-force call plus a GuardClass and an
+                        // unbox in every trace, which is enough to keep the
+                        // enclosing loop from closing when the test sits in an
+                        // inlined callee.
+                        //
+                        // Both variants jump on TRUE, so the exit wiring is
+                        // identical to POP_JUMP_IF_TRUE; the only difference is
+                        // `ptr_eq` (POP_JUMP_IF_NONE) vs `ptr_ne`
+                        // (POP_JUMP_IF_NOT_NONE).  Neither can raise, so unlike
+                        // the `bool`-based branches this needs no exception edge
+                        // inside a `try` range.
                         Instruction::PopJumpIfNone { delta }
                         | Instruction::PopJumpIfNotNone { delta } => {
-                            let invert_kind = match instruction {
-                                Instruction::PopJumpIfNone { .. } => {
-                                    pyre_interpreter::bytecode::Invert::No
-                                }
-                                _ => pyre_interpreter::bytecode::Invert::Yes,
+                            let identity_opname = match instruction {
+                                Instruction::PopJumpIfNone { .. } => "ptr_eq",
+                                _ => "ptr_ne",
                             };
                             let target_py_pc = jump_target_forward(
                                 code,
@@ -10877,24 +10887,16 @@ impl CodeWriter {
                             );
                             let _cond_reg = emit_popvalue_ref!(current_depth, py_pc);
                             let cond_value = pop_ref_or_fresh(&mut current_state, &mut graph);
-                            // `x is None` / `x is not None` — the None singleton
-                            // is const-folded as a Ref operand.
                             let none_value = pyobject_const_ref_value(pyre_object::w_none());
-                            let is_value = emit_frontend_is_op(
+                            let bool_value = emit_graph_op_with_result(
                                 &mut graph,
                                 &current_block.block(),
-                                cond_value,
-                                none_value,
-                                invert_kind,
+                                identity_opname,
+                                vec![cond_value.into(), none_value.into()],
+                                Kind::Int,
                                 py_pc as i64,
                             );
-                            let bool_value = emit_frontend_bool(
-                                &mut graph,
-                                &current_block.block(),
-                                is_value.into(),
-                                py_pc as i64,
-                            );
-                            // flowcontext.py:756-763 `block.exitswitch = w_cond`.
+                            // flowcontext.py `block.exitswitch = w_cond`.
                             current_block.block().borrow_mut().exitswitch =
                                 Some(super::flow::ExitSwitch::Value(bool_value.into()));
                             let scratch_truth = ssarepr.fresh_var(Kind::Int, scratch_int_base).0;

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -6523,9 +6523,11 @@ impl CodeWriter {
                 // opcodes instead of falling back to the interpreter).
                 // `abort_permanent` is pyre-specific (no upstream
                 // RPython counterpart), but it must retain the Python
-                // opcode where interpretation resumes. In a non-portal
-                // callee there is no last_instr vable write to anchor that
-                // coordinate for the inverse map.
+                // opcode where interpretation resumes: the offset is what
+                // `fbw_abort_resume_py_pc` and the callee-rebuild leg read
+                // back through the inverse map. The rebuild reconstructs
+                // the frame wholesale and assigns its `last_instr` itself,
+                // so the vable store below cannot serve them.
                 record_graph_op(
                     &current_block.block(),
                     "abort_permanent",

--- a/pyre/pyre-object/src/gc_roots.rs
+++ b/pyre/pyre-object/src/gc_roots.rs
@@ -172,11 +172,28 @@ pub fn shadow_stack_len() -> usize {
 /// The initial [`pin_root`] still normalizes a copied pointer that may have
 /// become stale before it was published.
 ///
+/// This is the `pop_roots` half of the bracket — the read back of a pinned
+/// livevar after a call that may have collected — so it sits on the ordinary
+/// call path (`call_function_impl_result`, the inline-call and specialize
+/// resume paths, `#[pyre_class]` method bodies), not just in tests.
+///
 /// Reads the thread-local `SHADOW_STACK` the tracer cannot type; the JIT
 /// residualises the read instead of tracing into it (`@dont_look_inside`,
 /// `rlib/jit.py:139`), the [`shadow_stack_len`] twin.
 #[majit_macros::dont_look_inside]
 pub fn shadow_stack_get(index: usize) -> PyObjectRef {
+    // A plain slot read: the slot is already a registered root, so whatever
+    // moved it has rewritten it here.  `init_gc_subsystem` registers this
+    // thread's stack as a mutator root area (`capture_shadow_stack_area`)
+    // together with `register_mutator`, before the thread runs any user code,
+    // and [`walk_shadow_stack`] hands the collector `&mut` slots — so a
+    // relocation between the pin and this read updates the slot in place and
+    // no forwarding stub can be observed here.
+    //
+    // Only [`pin_root`] normalizes, and it must: the value it receives is
+    // copied from outside the bracket, so a foreign mutator can have collected
+    // after that copy and before the pin.  That is also the pin's safepoint;
+    // a read allocates nothing and has no reason to park.
     SHADOW_STACK.with(|s| s.borrow()[index])
 }
 

--- a/pyre/pyre-object/src/gc_roots.rs
+++ b/pyre/pyre-object/src/gc_roots.rs
@@ -146,8 +146,16 @@ pub fn pin_root(root: PyObjectRef) {
     // bracket.  RPython's `_trace_drag_out` always rewrites a root that names
     // an already-forwarded nursery object; normalize the host-side copy at
     // the same boundary so the shadow stack never gains a forwarding stub.
-    let root = crate::gc_hook::try_gc_current_object_address(root as *mut u8) as PyObjectRef;
-    SHADOW_STACK.with(|s| s.borrow_mut()[index] = root);
+    let normalized = crate::gc_hook::try_gc_current_object_address(root as *mut u8) as PyObjectRef;
+    // The slot already holds `root`, so a query that found no forwarding stub
+    // has nothing to write back.  That is the steady state — nothing collected
+    // between the push above and the query — and the write-back is not free:
+    // this thread-local resolves through `_tlv_get_addr` on every `with`, and
+    // pinning sits on the interpreter's allocation and call paths, so the
+    // second resolve plus its `RefCell` borrow is paid once per pinned livevar.
+    if normalized != root {
+        SHADOW_STACK.with(|s| s.borrow_mut()[index] = normalized);
+    }
 }
 
 /// Current length of the thread-local shadow stack. Used by

--- a/pyre/pyre-object/src/objectobject.rs
+++ b/pyre/pyre-object/src/objectobject.rs
@@ -84,11 +84,36 @@ pub fn w_instance_new(w_type: PyObjectRef) -> PyObjectRef {
             ob_type: &INSTANCE_TYPE as *const PyType,
             w_class: w_type,
         },
-        // `_mapdict_init_empty` (`mapdict.py:908-910`): `storage = None`.
-        // The map terminator lives in the `pyre-interpreter` mapdict
-        // layer and is installed there on first attribute access; a null
-        // map is the not-yet-initialized empty state.
-        map: std::ptr::null(),
+        // `mapdict.py:758-761 user_setup` → `_mapdict_init_empty(
+        // w_subtype.terminator)` (`mapdict.py:908-910`): the instance map is
+        // the owning type's terminator from construction, and `storage = None`.
+        //
+        // Reading it here rather than installing it on first attribute access
+        // is what makes `_get_mapdict_map`'s `jit.promote(self.map)` promotable.
+        // A deferred install leaves every fresh instance at null until the
+        // first access, so the promoted map guard the JIT bakes — recorded
+        // AFTER that install, hence naming the terminator — cannot hold on the
+        // next iteration's fresh instance. It then fails on every pass through
+        // a loop that constructs an object and touches an attribute, and each
+        // failure is a full deopt.
+        //
+        // Null stays legal: `pyre-object` cannot build a terminator (it lives
+        // in the interpreter's mapdict layer and `pyre-object` must not depend
+        // on it), so a type whose terminator has not been created yet still
+        // gets one from `ensure_mapdict_initialized` on first access — which
+        // also stores it on the type, so every later instance is eager.
+        //
+        // The `is_type` test is what makes reading the field safe: `w_type` is
+        // a `W_TypeObject` on every interpreter path, but the allocator is also
+        // driven with a sentinel that has no type layout behind it, and the
+        // terminator field would be read off whatever that address points at.
+        map: unsafe {
+            if crate::typeobject::is_type(w_type) {
+                crate::typeobject::w_type_get_terminator(w_type)
+            } else {
+                std::ptr::null()
+            }
+        },
         storage: std::ptr::null_mut(),
     });
     // objspace.py `allocate_instance`: types with `hasuserdel` register the

--- a/pyre/pyre-object/src/setobject.rs
+++ b/pyre/pyre-object/src/setobject.rs
@@ -841,6 +841,35 @@ unsafe fn w_set_insert_key_into(
     items: *mut SetItemsStorage,
     key: crate::dictmultiobject::ObjectKey,
 ) -> Result<(), SetUpdateError> {
+    // Single insert probe (matches `r_dict.setitem`'s one bucket scan), run
+    // callback-free so no user `__eq__` mutates the set while the `IndexMap`
+    // borrow is live.  When every same-hash comparison stays inside the
+    // builtin ladder the probe appends in place; a pair it cannot decide
+    // breaks the probe, withholds the store, and re-runs the operation over
+    // `scan_set_key_reentrant` below.  Without this the membership half of
+    // every `add` walks the table entry by entry, which is quadratic in the
+    // set's size.
+    if let Some(result) = callback_free_set_op(|| {
+        let entries = &mut *items;
+        let index = entries.get_index_of(&key);
+        if crate::dict_eq_hook::callback_free_probe_broken() {
+            return;
+        }
+        if index.is_some() {
+            return;
+        }
+        // The probe above proved no bucket entry compares equal without
+        // leaving the ladder, so this placement probe repeats those same
+        // comparisons and cannot break either.
+        entries.insert(key, ());
+        let set = &mut *(dst as *mut W_SetObject);
+        set.len = (*set.items).len();
+        set.hash = -1;
+        set_write_barrier(dst);
+    }) {
+        return result.map_err(SetUpdateError::Key);
+    }
+
     let (found, key) = scan_set_key_reentrant(items, key).map_err(SetUpdateError::Key)?;
     if found.is_some() {
         return Ok(());

--- a/pyre/pyre-object/src/setobject.rs
+++ b/pyre/pyre-object/src/setobject.rs
@@ -896,6 +896,15 @@ unsafe fn w_set_contains_key_for_update(
     probe: PyObjectRef,
     mut key: crate::dictmultiobject::ObjectKey,
 ) -> Result<bool, SetUpdateError> {
+    // Bucket probe first, as in `w_set_contains_key_checked`.  The walk below
+    // is the reentrant fallback and visits every entry, so without this a
+    // whole-set difference probes linearly per element and runs quadratic.
+    if let Some(result) = callback_free_set_op(|| {
+        let s = &*(probe as *const W_SetObject);
+        (*s.items).contains_key(&key)
+    }) {
+        return result.map_err(SetUpdateError::Key);
+    }
     'restart: loop {
         let items = (*(probe as *const W_SetObject)).items;
         let len = (*items).len();
@@ -942,6 +951,26 @@ unsafe fn w_set_remove_key_for_update(
     dst: PyObjectRef,
     mut key: crate::dictmultiobject::ObjectKey,
 ) -> Result<(), SetUpdateError> {
+    // Locate the bucket callback-free before falling back to the entry walk,
+    // which is linear in the set's size.  The index is resolved inside the
+    // probe and the removal withheld when a comparison leaves the builtin
+    // ladder, so the walk below can redo the whole operation.  The removal
+    // itself still shifts the tail, as in the fallback.
+    if let Some(result) = callback_free_set_op(|| {
+        let items = (*(dst as *const W_SetObject)).items;
+        let index = (*items).get_index_of(&key);
+        if crate::dict_eq_hook::callback_free_probe_broken() {
+            return;
+        }
+        if let Some(index) = index {
+            (*items).shift_remove_index(index);
+            let set = &mut *(dst as *mut W_SetObject);
+            set.len -= 1;
+            set.hash = -1;
+        }
+    }) {
+        return result.map_err(SetUpdateError::Key);
+    }
     'restart: loop {
         let items = (*(dst as *const W_SetObject)).items;
         let len = (*items).len();

--- a/pyre/pyre-object/src/unicodeobject.rs
+++ b/pyre/pyre-object/src/unicodeobject.rs
@@ -497,7 +497,11 @@ pub struct Fnv1aHasher(u64);
 
 impl std::hash::Hasher for Fnv1aHasher {
     fn write(&mut self, bytes: &[u8]) {
-        let mut h = if self.0 == 0 { 0xcbf2_9ce4_8422_2325 } else { self.0 };
+        let mut h = if self.0 == 0 {
+            0xcbf2_9ce4_8422_2325
+        } else {
+            self.0
+        };
         for b in bytes {
             h ^= *b as u64;
             h = h.wrapping_mul(0x0000_0100_0000_01b3);

--- a/pyre/pyre-object/src/unicodeobject.rs
+++ b/pyre/pyre-object/src/unicodeobject.rs
@@ -485,13 +485,40 @@ pub unsafe fn w_str_slot_del(obj: PyObjectRef, index: usize) -> bool {
     unsafe { crate::listobject::w_list_setitem(slots, index as i64, PY_NULL) }
 }
 
+/// FNV-1a over the key bytes, the digest the type-lookup method cache already
+/// uses. The interning table is thread-local, holds only internal identifier
+/// strings, and its entries are immortal, so the default SipHash buys nothing
+/// here while charging every attribute-name lookup a full siphash24 of the
+/// name — 10 of the top-of-stack samples in a profile of
+/// `exception_subclass_attrs`, reached through
+/// `type_descr_call_impl` -> `lookup_in_type_where` -> `box_str_constant`.
+#[derive(Default)]
+pub struct Fnv1aHasher(u64);
+
+impl std::hash::Hasher for Fnv1aHasher {
+    fn write(&mut self, bytes: &[u8]) {
+        let mut h = if self.0 == 0 { 0xcbf2_9ce4_8422_2325 } else { self.0 };
+        for b in bytes {
+            h ^= *b as u64;
+            h = h.wrapping_mul(0x0000_0100_0000_01b3);
+        }
+        self.0 = h;
+    }
+
+    fn finish(&self) -> u64 {
+        self.0
+    }
+}
+
+type Fnv1aBuild = std::hash::BuildHasherDefault<Fnv1aHasher>;
+
 thread_local! {
     /// String constant interning cache — single-threaded, no lock needed.
     /// RPython has no equivalent lock; string interning is handled by the
     /// translator at compile time, not at runtime.  Keyed by WTF-8 so a
     /// surrogate-bearing constant (a `'\udcff'` literal) interns too.
-    static STRING_CONSTANT_CACHE: RefCell<HashMap<Wtf8Buf, usize>> =
-        RefCell::new(HashMap::new());
+    static STRING_CONSTANT_CACHE: RefCell<HashMap<Wtf8Buf, usize, Fnv1aBuild>> =
+        RefCell::new(HashMap::default());
 }
 
 /// Box a string constant into a heap Python str object.

--- a/pyre/pyrex/src/lib.rs
+++ b/pyre/pyrex/src/lib.rs
@@ -918,6 +918,7 @@ fn maybe_print_jit_stats() {
             profiler.finish();
         }
     }
+    maybe_print_mc_diag();
     if std::env::var_os("MAJIT_STATS").is_none() {
         return;
     }
@@ -965,6 +966,52 @@ fn maybe_print_jit_stats() {
     // Whether those slots were filled CORRECTLY, which the line above
     // cannot say. See `field_position_jit_stats`.
     eprintln!("[jit-stats] {}", pyre_jit::field_position_jit_stats());
+}
+
+/// Names for the `MC_DIAG` tallies, in index order. Mirrors the legend on
+/// `majit_metainterp::MC_DIAG` and the labels the wasm runner prints for the
+/// `pyre_jit_mc_diag` export, so a native run and a wasm run of the same
+/// program are diffable field by field.
+const MC_DIAG_FIELDS: [&str; 18] = [
+    "mc_entered",
+    "decl_shortcircuit",
+    "descr0_skip",
+    "busy_skip",
+    "FIRED",
+    "stack_full",
+    "retrace_entered",
+    "retrace_bailed",
+    "cb_entered",
+    "cb_invalidloop",
+    "cb_retrace_req",
+    "cb_arity_giveup",
+    "sbt_entered",
+    "sbt_not_faildescr",
+    "sbt_no_jct",
+    "sbt_no_meta",
+    "sbt_cant_trace",
+    "sbt_short_vals",
+];
+
+/// Print the guard-failure → bridge-trace gate tallies. Until this existed the
+/// counters were bumped on every backend but only readable through the wasm
+/// guest export, so the question "did this guard failure ever reach a bridge,
+/// or was it short-circuited by the decline blacklist" could not be asked of a
+/// native run at all.
+///
+/// Deliberately NOT under the `[jit-stats]` prefix: `check.py`'s
+/// `_jit_stats_snapshot` keeps the LAST such line, so a second one would
+/// silently replace the committed per-bench baseline. Its own env gate keeps it
+/// off the default `check.py` run, which sets `MAJIT_STATS` for every bench.
+fn maybe_print_mc_diag() {
+    if std::env::var_os("PYRE_MC_DIAG").is_none() {
+        return;
+    }
+    let mut line = String::from("[jit-mc-diag]");
+    for (i, name) in MC_DIAG_FIELDS.iter().enumerate() {
+        line.push_str(&format!(" {name}={}", majit_metainterp::mc_diag(i)));
+    }
+    eprintln!("{line}");
 }
 
 /// Shared top-level launcher bootstrap for `run_source` and `run_module`:


### PR DESCRIPTION
23 commits on top of `main`, in three groups: a virtualref producer prerequisite chain, FBW inline/replay-safety widening, and a set of profile-driven hot-path fixes. Every commit reports its own measurement; the highlights are below.

## Hot-path fixes (measured wins)

| Change | Effect |
| --- | --- |
| `unsupported_jit_shape` memoized per code object | `exception_metadata_hot` 1.25s → 0.24s, `exception_subclass_attrs` 0.96s → 0.62s; check.py dynasm 330/2 → 331/1 (`raise_catch` clears its ratio gate) |
| carrier root catch read forward from the call's `-live-` | `break_except_live_local` 0.935s → 0.129s, guard_failures 21,434 → 201, bridges_compiled 0 → 1; synth `exceptions` 0.19s → 0.07s, `exception_args_virtual` 0.22s → 0.08s |
| forced inline callee locals rebuilt from array loads | `mutate_then_raise_caught` 0.32s → 0.23s, decl_shortcircuit 11,183 → 0 |
| FOR_ITER replay-safety scan widened (`GetCurrentException`, `COMPARE_OP`, `RaiseVarargs`) | raising callee in a `for` body 1.36s → 0.06s at N=300000, `call_may_force` 1 → 0 |
| method cache keyed by interned-name identity | `str(i)` x3,000,000 1.89s → 1.71s |
| string-intern table hashed with FNV-1a | `exception_subclass_attrs` 0.62s → 0.57s |
| truth residual folded on a boxed bool | main loop ops/CallMayForce: `traceback_frame_lineno` 271/24 → 93/6, `inline_callee_tb_frames` 204/18 → 114/10 |
| pinned root read without re-forwarding | removes a nursery-range query + store per `pop_roots` livevar reload; no speedup claimed (under machine load) |

## Virtualref producer prerequisites

The tracer does not emit `VIRTUAL_REF` yet, so these are unreachable-today correctness work, each verified byte-identical on seven-to-nine exception/frame benches:

- `virtual_ref_during_tracing` allocates through the collector instead of `Box::into_raw`, so a vref's `forced` slot is a traced edge; the root walker forwards `forced` at the `chain_next_frame` hop.
- `materialize_virtual_object` and the blackhole `VirtualInfo` arm stop reading `VRefSizeDescr::vtable` (a type tag, not a pointer) as a `*const PyType` and stop clobbering `virtual_token`.
- `ResidualFrameChainGuard` / multi-frame blackhole root the displaced `ec.topframeref` on the shadow stack and restore out of the slot, so an in-place relocation survives.
- Chain frame identity resolves through a non-forcing `vref_referent` rather than `ptr::eq`, with the publication split from the chain write so the early return does not swallow `PUBLISHED_INLINE_FRAME`.
- One `virtualref_boxes` list on `TraceCtx` (was duplicated on `PyreSym`, so the walker and the residual bracket numbered cindexes out of different spaces).
- `ec.topframeref` gets a FieldDescr, sharing `EC_DESCR_GROUP` with `sys_exc_value` so the heap optimizer can pair `enter`/`leave`.

## Correctness / infrastructure

- `install_build_time_jitcode_at` no longer collides with runtime `PyCode` appends — leading slots are reserved up front (was a panic on "registered portal must have a drained PyJitCode").
- `drive_unpack_iterable_trace`'s parked error drains at the merge point instead of leaking to a later call. Also records why the jd1 finish-compile never runs: `MetaInterp::force_start_tracing` installs no session, so the compile is a no-op and the tracer slot stays installed.
- `SetCurrentException` moves from `Dirty` to the deferred set in the replay-safety scan; the fold journals `sys_exc_value` and rollback replays it.
- `FORCE_VIRTUALIZABLES` counter restored (`jit-summary`'s "virtualizables forced" printed 0 unconditionally), plus a native `PYRE_MC_DIAG` readout of the 18 gate tallies — deliberately not `[jit-stats]`-prefixed, since check.py keeps only the last such line.
- `PYRE_FBW_CALLEE_VSTACK` (default OFF): the vstack mirror re-seeds in a callee sub-walk, resolving the handler pc through the resume frame's own metadata instead of the outer full-body tables.
- Diagnostics: inline declines name the callee qualname and callable type; the four early bails in `try_walker_inline_user_call` and the 17 unnamed `return None` paths in `reconstruct_inline_recipe` are all named in the census.
- Three stale comments corrected about portal-ness and `jf_force_descr` arming.

## Verification

`check.py` 331 passed / 1 failed on both dynasm and cranelift. The single failure is `synth/ast_compile_roundtrip`, which is pre-existing and reproduces under `PYRE_NO_JIT=1`.

Unit tests: majit-metainterp 1404 (dynasm) / 1402 (cranelift), pyre-jit-trace 299, pyre-interpreter 407, pyre-object 279.
