### PR TITLE
jit: resume overlong traces from post-step frames

### DIFF
--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -145,7 +145,7 @@ pub fn drive_single_frame_blackhole(
     virtualizable_ptr: i64,
     virtualizable_stack_base: usize,
     metainterp_sd: &crate::pyjitpl::MetaInterpStaticData,
-    last_exc_value: i64,
+    mut last_exc_value: i64,
     raising_exception: bool,
 ) -> SingleFrameBlackholeResult {
     // The MIFrame is handed here from a force-time TLS latch.  Publish its Ref
@@ -161,6 +161,15 @@ pub fn drive_single_frame_blackhole(
         .collect();
     let root_depth = majit_gc::shadow_stack::resume_ref_roots_depth();
     let mut packed_ref_roots: Vec<i64> = ref_roots.iter().map(|(_, value)| *value).collect();
+    // `MetaInterp.last_exc_value` is not necessarily present in an MIFrame
+    // Ref register (e.g. between `last_exception` and `last_exc_value/>r`).
+    // Root it beside the bank for the full drive, matching the multi-frame
+    // driver's explicit exception root.
+    let exception_root = (last_exc_value != 0).then(|| {
+        let index = packed_ref_roots.len();
+        packed_ref_roots.push(last_exc_value);
+        index
+    });
     unsafe {
         majit_gc::shadow_stack::push_resume_ref_roots(packed_ref_roots.as_mut_slice());
     }
@@ -174,6 +183,9 @@ pub fn drive_single_frame_blackhole(
     for ((index, value), forwarded) in ref_roots.iter_mut().zip(&packed_ref_roots) {
         *value = *forwarded;
         miframe.ref_values[*index] = Some(*forwarded);
+    }
+    if let Some(index) = exception_root {
+        last_exc_value = packed_ref_roots[index];
     }
 
     builder.setup_jitdrivers_sd(bh_jitdrivers_sd(metainterp_sd));

--- a/pyre/bench/synth/trace_too_long_effect_replay.py
+++ b/pyre/bench/synth/trace_too_long_effect_replay.py
@@ -64,3 +64,25 @@ while i < N:
     i = i + 1
 
 print(free_total, total, box[0], d["k"], len(obj), sum(obj) % 1000003)
+
+
+# Phase C — the same exactly-once contract for a function-entry trace. Its
+# trace root is pc 0 rather than the loop header below, so the root key is
+# never revisited and only ABORT_TOO_LONG's forward blackhole handoff bounds
+# the recording. Returning the three independently observable mutation
+# classes also checks that the handoff does not replay from function entry.
+def function_entry_effects(n):
+    box = [0]
+    d = {"k": 0}
+    obj = []
+    total = 0
+    for i in range(n):
+        box[0] += 1
+        d["k"] = d["k"] + 1
+        obj.append(i)
+        total += i
+    return total, box[0], d["k"], len(obj)
+
+
+set_trace_limit(100)
+print(function_entry_effects(N))

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -5406,8 +5406,8 @@ pub unsafe fn fbw_store_journal_root_walker_area(
     // The vable-force and trace-too-long MIFrame images survive the dispatch
     // unwind in TLS. Their Option<i64> Ref banks are not otherwise visible to
     // the collector, so forward every populated color until the walk-end
-    // handler takes the latch. The blackhole drivers install their own packed
-    // roots after the image leaves TLS.
+    // handler takes the latch. The adopters bridge the pre-drive publication
+    // window and the blackhole drivers then install their own packed roots.
     let single_frame_blackhole = unsafe { &mut *(*area.single_frame_blackhole).as_ptr() };
     if let Some(latched) = single_frame_blackhole.as_mut() {
         for value in latched.miframe.ref_values.iter_mut().flatten() {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -2195,24 +2195,22 @@ pub fn walk<Sym: WalkSym>(
         // `disable_noninlinable_function` half (pyjitpl.py:2817) still only
         // runs on the per-opcode path.
         //
-        // DEVIATION from `SwitchToBlackhole(ABORT_TOO_LONG)`, which resumes in
-        // the blackhole from the traced state: a `DispatchError` resumes by
-        // re-interpreting the iteration from the trace entry, so an effect the
-        // walk already executed and cannot roll back would be applied twice.
-        // Every other walker abort upholds that invariant by declining BEFORE
-        // it executes such an effect (see `InplaceContainerMutationUnsupported`
-        // and the `FBW_STRUCTURAL_ABORT_OPCODE_EFFECTS` effect-free check); a
-        // length check fires at an arbitrary opcode instead, so it must consult
-        // the odometer itself. `fbw_executed_effect_count` is reset per walk, so
-        // zero means nothing the replay would redo has run yet. A walk that is
-        // already past that point keeps recording — the pre-existing unbounded
-        // behaviour — rather than corrupt the heap. That overshoot is otherwise
-        // silent, so it is tallied: it is what turns a walk which never reaches
-        // a close into unbounded recording.
+        // `blackhole_if_trace_too_long` raises AFTER `run_one_step`, so the
+        // forward image must carry `pc`, the already-advanced `next_pc`, rather
+        // than `opcode_position`.  `latch_trace_too_long_blackhole` copies the
+        // live MIFrame registers while this WalkContext still owns them; the
+        // run-per-fn epilogue drives that image forward exactly like RPython's
+        // `run_blackhole_interp_to_cancel_tracing`.
+        //
+        // A complete image makes the abort safe regardless of effects.  If the
+        // image cannot be built, a zero-effect walk may still take the legacy
+        // replay; an effectful walk must retain the former keep-recording
+        // fallback because replay would apply an irreversible effect twice.
+        // The remaining overshoot is tallied so an unsupported multi-frame
+        // shape cannot silently become unbounded.
         if ctx.trace_ctx.is_too_long() {
-            if fbw_executed_effect_count() != 0 {
-                majit_metainterp::mc_diag_bump(26);
-            } else {
+            let blackhole_latched = latch_trace_too_long_blackhole(ctx, pc);
+            if blackhole_latched || fbw_executed_effect_count() == 0 {
                 let ops = ctx.trace_ctx.num_recorded_ops();
                 crate::state::note_root_trace_too_long(
                     ctx.trace_ctx.current_merge_points_first_greenkey(),
@@ -2222,6 +2220,8 @@ pub fn walk<Sym: WalkSym>(
                     pc: opcode_position,
                     ops,
                 });
+            } else {
+                majit_metainterp::mc_diag_bump(26);
             }
         }
         match outcome {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -1470,6 +1470,14 @@ fn trace_too_long_blackhole_snapshot_safe(outcome: &DispatchOutcome) -> bool {
     matches!(outcome, DispatchOutcome::Continue)
 }
 
+fn trace_too_long_abort_safe(
+    outcome: &DispatchOutcome,
+    blackhole_latched: bool,
+    executed_effects: usize,
+) -> bool {
+    trace_too_long_blackhole_snapshot_safe(outcome) && (blackhole_latched || executed_effects == 0)
+}
+
 /// Errors surfaced by the trace-side walker.
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum DispatchError {
@@ -2218,11 +2226,13 @@ pub fn walk<Sym: WalkSym>(
             // frame transition: in particular, `SubRaise` may enter this
             // frame's handler and `SubReturn` is delivered to its caller by
             // the inline-call boundary. RPython checks the length only after
-            // those transitions have happened, so never publish the
-            // pre-transition callee image here.
-            let blackhole_latched = trace_too_long_blackhole_snapshot_safe(&outcome)
-                && latch_trace_too_long_blackhole(ctx, pc);
-            if blackhole_latched || fbw_executed_effect_count() == 0 {
+            // those transitions have happened, so never abort from the
+            // pre-transition callee image here — even a zero-effect entry
+            // replay would resume the caller without delivering the return or
+            // raise that this step produced.
+            let snapshot_safe = trace_too_long_blackhole_snapshot_safe(&outcome);
+            let blackhole_latched = snapshot_safe && latch_trace_too_long_blackhole(ctx, pc);
+            if trace_too_long_abort_safe(&outcome, blackhole_latched, fbw_executed_effect_count()) {
                 let ops = ctx.trace_ctx.num_recorded_ops();
                 crate::state::note_root_trace_too_long(
                     ctx.trace_ctx.current_merge_points_first_greenkey(),

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -1466,6 +1466,10 @@ impl PartialEq for DispatchOutcome {
     }
 }
 
+fn trace_too_long_blackhole_snapshot_safe(outcome: &DispatchOutcome) -> bool {
+    matches!(outcome, DispatchOutcome::Continue)
+}
+
 /// Errors surfaced by the trace-side walker.
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum DispatchError {
@@ -2209,7 +2213,15 @@ pub fn walk<Sym: WalkSym>(
         // The remaining overshoot is tallied so an unsupported multi-frame
         // shape cannot silently become unbounded.
         if ctx.trace_ctx.is_too_long() {
-            let blackhole_latched = latch_trace_too_long_blackhole(ctx, pc);
+            // `step` has advanced the register banks for `Continue`. The
+            // other outcomes still need the match below to perform their
+            // frame transition: in particular, `SubRaise` may enter this
+            // frame's handler and `SubReturn` is delivered to its caller by
+            // the inline-call boundary. RPython checks the length only after
+            // those transitions have happened, so never publish the
+            // pre-transition callee image here.
+            let blackhole_latched = trace_too_long_blackhole_snapshot_safe(&outcome)
+                && latch_trace_too_long_blackhole(ctx, pc);
             if blackhole_latched || fbw_executed_effect_count() == 0 {
                 let ops = ctx.trace_ctx.num_recorded_ops();
                 crate::state::note_root_trace_too_long(

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -5403,9 +5403,11 @@ pub unsafe fn fbw_store_journal_root_walker_area(
             visitor(unsafe { &mut *(slot as *mut pyre_object::PyObjectRef).cast() });
         }
     }
-    // C3 S1: the force-time MIFrame survives the dispatch unwind in TLS.
-    // Its Option<i64> Ref bank is not visible to the collector, so forward
-    // every populated color until the walk-end handler takes the latch.
+    // The vable-force and trace-too-long MIFrame images survive the dispatch
+    // unwind in TLS. Their Option<i64> Ref banks are not otherwise visible to
+    // the collector, so forward every populated color until the walk-end
+    // handler takes the latch. The blackhole drivers install their own packed
+    // roots after the image leaves TLS.
     let single_frame_blackhole = unsafe { &mut *(*area.single_frame_blackhole).as_ptr() };
     if let Some(latched) = single_frame_blackhole.as_mut() {
         for value in latched.miframe.ref_values.iter_mut().flatten() {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -165,10 +165,10 @@ pub(crate) fn latch_trace_too_long_blackhole<Sym: WalkSym>(
         let Some(jitcode) = jitcode else {
             return false;
         };
-        let Some(mut miframe) = build_single_frame_miframe(ctx, jitcode, resume_pc, None) else {
+        let Some(miframe) = build_trace_too_long_single_frame_miframe(ctx, jitcode, resume_pc)
+        else {
             return false;
         };
-        fill_trace_too_long_register_banks(ctx, &mut miframe);
         // Keep the per-frame red identity seeded by `frame_box`.  The
         // authoritative walk executed against `snapshot_for_tracing`, but the
         // adopter validates this identity and publishes that snapshot's locals
@@ -184,12 +184,11 @@ pub(crate) fn latch_trace_too_long_blackhole<Sym: WalkSym>(
         });
         true
     } else if ctx.fbw_mode.inline_subwalk && multi_frame_blackhole_resume_enabled() {
-        let Some(mut framestack) = build_multi_frame_miframe(ctx, resume_pc, None) else {
+        let Some(framestack) =
+            build_multi_frame_miframe(ctx, resume_pc, InnermostMiframeBuild::TraceTooLong)
+        else {
             return false;
         };
-        if let Some(innermost) = framestack.frames.last_mut() {
-            fill_trace_too_long_register_banks(ctx, innermost);
-        }
         FBW_MULTI_FRAME_BLACKHOLE.with(|slot| {
             *slot.borrow_mut() = Some(LatchedMultiFrameBlackhole {
                 framestack,
@@ -359,6 +358,22 @@ fn build_single_frame_miframe<Sym: WalkSym>(
     Some(miframe)
 }
 
+/// Build the `ABORT_TOO_LONG` image at an arbitrary post-step JitCode pc.
+///
+/// Unlike the residual-call handoff above, this coordinate need not be a
+/// `-live-` marker: RPython copies the complete MIFrame banks after every
+/// `run_one_step`. Requiring marker liveness here would make an effectful
+/// straight-line tail unbounded again whenever the limit lands between
+/// markers.
+pub(super) fn build_trace_too_long_single_frame_miframe<Sym: WalkSym>(
+    ctx: &WalkContext<'_, '_, Sym>,
+    jitcode: std::sync::Arc<majit_metainterp::jitcode::JitCode>,
+    resume_pc: usize,
+) -> Option<majit_metainterp::MIFrame> {
+    let mut miframe = majit_metainterp::MIFrame::new(jitcode, resume_pc);
+    fill_trace_too_long_register_banks(ctx, &mut miframe).then_some(miframe)
+}
+
 /// Fill every currently-known register color, matching
 /// `blackhole.py:_copy_data_from_miframe`.
 ///
@@ -372,7 +387,7 @@ fn build_single_frame_miframe<Sym: WalkSym>(
 fn fill_trace_too_long_register_banks<Sym: WalkSym>(
     ctx: &WalkContext<'_, '_, Sym>,
     miframe: &mut majit_metainterp::MIFrame,
-) {
+) -> bool {
     for color in 0..miframe.int_values.len() {
         if let Some(value) = ctx
             .concrete_registers_i
@@ -388,15 +403,16 @@ fn fill_trace_too_long_register_banks<Sym: WalkSym>(
             continue;
         }
         if miframe.int_values[color].is_none() {
-            miframe.int_values[color] = ctx
-                .registers_i
-                .get(color)
-                .copied()
-                .and_then(|opref| ctx.trace_ctx.concrete_of_opref(opref))
-                .and_then(|value| match value {
-                    majit_ir::Value::Int(value) => Some(value),
-                    _ => None,
-                });
+            let Some(opref) = ctx.registers_i.get(color).copied() else {
+                continue;
+            };
+            if opref == OpRef::NONE {
+                continue;
+            }
+            let Some(majit_ir::Value::Int(value)) = ctx.trace_ctx.concrete_of_opref(opref) else {
+                return false;
+            };
+            miframe.int_values[color] = Some(value);
         }
     }
 
@@ -414,15 +430,17 @@ fn fill_trace_too_long_register_banks<Sym: WalkSym>(
             continue;
         }
         if miframe.ref_values[color].is_none() {
-            miframe.ref_values[color] = ctx
-                .registers_r
-                .get(color)
-                .copied()
-                .and_then(|opref| ctx.trace_ctx.recover_ref_value(opref, 8))
-                .and_then(|value| match value {
-                    majit_ir::Value::Ref(value) => Some(value.0 as i64),
-                    _ => None,
-                });
+            let Some(opref) = ctx.registers_r.get(color).copied() else {
+                continue;
+            };
+            if opref == OpRef::NONE {
+                continue;
+            }
+            let Some(majit_ir::Value::Ref(value)) = ctx.trace_ctx.recover_ref_value(opref, 8)
+            else {
+                return false;
+            };
+            miframe.ref_values[color] = Some(value.0 as i64);
         }
     }
 
@@ -430,22 +448,30 @@ fn fill_trace_too_long_register_banks<Sym: WalkSym>(
         if miframe.float_values[color].is_some() {
             continue;
         }
-        miframe.float_values[color] = ctx
-            .registers_f
-            .get(color)
-            .copied()
-            .and_then(|opref| ctx.trace_ctx.concrete_of_opref(opref))
-            .and_then(|value| match value {
-                majit_ir::Value::Float(value) => Some(value.to_bits() as i64),
-                _ => None,
-            });
+        let Some(opref) = ctx.registers_f.get(color).copied() else {
+            continue;
+        };
+        if opref == OpRef::NONE {
+            continue;
+        }
+        let Some(majit_ir::Value::Float(value)) = ctx.trace_ctx.concrete_of_opref(opref) else {
+            return false;
+        };
+        miframe.float_values[color] = Some(value.to_bits() as i64);
     }
+    true
+}
+
+#[derive(Clone, Copy)]
+enum InnermostMiframeBuild {
+    LiveMarker(Option<(char, usize, i64)>),
+    TraceTooLong,
 }
 
 fn build_multi_frame_miframe<Sym: WalkSym>(
     ctx: &WalkContext<'_, '_, Sym>,
     resume_pc: usize,
-    lastop_result: Option<(char, usize, i64)>,
+    innermost_build: InnermostMiframeBuild,
 ) -> Option<majit_metainterp::MIFrameStack> {
     let session = ctx.session.borrow();
     if session.framestack.is_empty() {
@@ -506,9 +532,15 @@ fn build_multi_frame_miframe<Sym: WalkSym>(
             (&(*sym.jitcode()).payload).jitcode.clone()
         }
     };
-    let Some(innermost) =
-        build_single_frame_miframe(ctx, innermost_jitcode, resume_pc, lastop_result)
-    else {
+    let innermost = match innermost_build {
+        InnermostMiframeBuild::LiveMarker(lastop_result) => {
+            build_single_frame_miframe(ctx, innermost_jitcode, resume_pc, lastop_result)
+        }
+        InnermostMiframeBuild::TraceTooLong => {
+            build_trace_too_long_single_frame_miframe(ctx, innermost_jitcode, resume_pc)
+        }
+    };
+    let Some(innermost) = innermost else {
         s2dbg!("innermost build_single_frame_miframe declined");
         return None;
     };
@@ -2412,8 +2444,11 @@ pub(crate) fn try_execute_residual_call_via_executor<Sym: WalkSym>(
                     }
                 } else if ctx.fbw_mode.inline_subwalk
                     && multi_frame_blackhole_resume_enabled()
-                    && let Some(framestack) =
-                        build_multi_frame_miframe(ctx, resume_pc, lastop_result)
+                    && let Some(framestack) = build_multi_frame_miframe(
+                        ctx,
+                        resume_pc,
+                        InnermostMiframeBuild::LiveMarker(lastop_result),
+                    )
                 {
                     FBW_MULTI_FRAME_BLACKHOLE.with(|slot| {
                         *slot.borrow_mut() = Some(LatchedMultiFrameBlackhole {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -154,21 +154,59 @@ pub(crate) fn latch_trace_too_long_blackhole<Sym: WalkSym>(
     };
 
     if ctx.session.borrow().framestack.is_empty() && !ctx.fbw_mode.inline_subwalk {
-        let jitcode = unsafe {
+        let Some((jitcode, cf_addr, live_root_addr)) = (unsafe {
             if ctx.fbw_mode.snapshot_sym.is_null() {
                 None
             } else {
-                let jitcode = (&*ctx.fbw_mode.snapshot_sym).jitcode();
-                (!jitcode.is_null()).then(|| (&(*jitcode).payload).jitcode.clone())
+                let sym = &*ctx.fbw_mode.snapshot_sym;
+                let jitcode = sym.jitcode();
+                (!jitcode.is_null()).then(|| {
+                    (
+                        (&(*jitcode).payload).jitcode.clone(),
+                        sym.tracing_vable_frame_addr(),
+                        sym.live_vable_frame_addr(),
+                    )
+                })
             }
-        };
-        let Some(jitcode) = jitcode else {
+        }) else {
             return false;
         };
         let Some(miframe) = build_trace_too_long_single_frame_miframe(ctx, jitcode, resume_pc)
         else {
             return false;
         };
+        // `walk()` has already executed this step, so returning TraceTooLong
+        // is safe only when every pre-drive adopter gate is known to pass.
+        // RPython's `run_blackhole_interp_to_cancel_tracing()` cannot return
+        // to entry replay. Keep the same boundary: incomplete images merely
+        // keep recording until a later step supplies a complete handoff.
+        let Some(jitcode_index) = i32::try_from(miframe.jitcode.index()).ok() else {
+            return false;
+        };
+        if ctx.trace_ctx.virtualizable_info().is_none()
+            || crate::state::concrete_nlocals(cf_addr).is_none()
+        {
+            return false;
+        }
+        let root_addr = if live_root_addr != 0 {
+            live_root_addr
+        } else {
+            cf_addr
+        };
+        let (frame_reg, _) = crate::state::portal_red_regs_at(jitcode_index);
+        let vable_frame = miframe
+            .ref_values
+            .get(frame_reg as usize)
+            .copied()
+            .flatten()
+            .unwrap_or(0) as usize;
+        if vable_frame == 0
+            || vable_frame != root_addr
+            || crate::state::capture_frame_locals(vable_frame).is_none()
+            || !crate::state::can_write_back_outer_locals(ctx.trace_ctx, vable_frame)
+        {
+            return false;
+        }
         // Keep the per-frame red identity seeded by `frame_box`.  The
         // authoritative walk executed against `snapshot_for_tracing`, but the
         // adopter validates this identity and publishes that snapshot's locals
@@ -183,21 +221,11 @@ pub(crate) fn latch_trace_too_long_blackhole<Sym: WalkSym>(
             });
         });
         true
-    } else if ctx.fbw_mode.inline_subwalk && multi_frame_blackhole_resume_enabled() {
-        let Some(framestack) =
-            build_multi_frame_miframe(ctx, resume_pc, InnermostMiframeBuild::TraceTooLong)
-        else {
-            return false;
-        };
-        FBW_MULTI_FRAME_BLACKHOLE.with(|slot| {
-            *slot.borrow_mut() = Some(LatchedMultiFrameBlackhole {
-                framestack,
-                last_exc_value,
-                raising_exception: false,
-            });
-        });
-        true
     } else {
+        // An inlined trace needs one independently materialized locals image
+        // per MIFrame. The opt-in multi-frame vable-force experiment still
+        // lacks that shape, so it cannot serve ABORT_TOO_LONG: this abort has
+        // already executed effects and has no safe entry-replay fallback.
         false
     }
 }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -148,6 +148,9 @@ pub(crate) fn latch_trace_too_long_blackhole<Sym: WalkSym>(
     ctx: &WalkContext<'_, '_, Sym>,
     resume_pc: usize,
 ) -> bool {
+    if !ctx.is_authoritative_executor {
+        return false;
+    }
     let last_exc_value = match ctx.last_exc_value_concrete {
         ConcreteValue::Ref(value) => value as i64,
         _ => 0,

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -129,6 +129,80 @@ pub(crate) fn reset_single_frame_blackhole() {
     });
 }
 
+/// Snapshot the live meta-interpreter framestack for
+/// `SwitchToBlackhole(ABORT_TOO_LONG)`.
+///
+/// RPython calls `blackhole_if_trace_too_long()` immediately after
+/// `MIFrame.run_one_step()` and `convert_and_run_from_pyjitpl` copies every
+/// live MIFrame at its already-advanced `pc` (`pyjitpl.py:2863-2866`,
+/// `blackhole.py:1799-1821`).  The full-body walker has the same state here:
+/// `resume_pc` is `walk()`'s post-step `next_pc`, and the current
+/// [`WalkContext`] plus [`WalkSession::framestack`] own the concrete banks for
+/// the live frame and all paused callers.
+///
+/// Return `false` without publishing a partial image when any live value is
+/// unresolved.  A zero-effect walk may then use the legacy entry replay;
+/// an effectful walk must keep recording until a complete image can be built,
+/// because replaying it would apply the effect twice.
+pub(crate) fn latch_trace_too_long_blackhole<Sym: WalkSym>(
+    ctx: &WalkContext<'_, '_, Sym>,
+    resume_pc: usize,
+) -> bool {
+    let last_exc_value = match ctx.last_exc_value_concrete {
+        ConcreteValue::Ref(value) => value as i64,
+        _ => 0,
+    };
+
+    if ctx.session.borrow().framestack.is_empty() && !ctx.fbw_mode.inline_subwalk {
+        let jitcode = unsafe {
+            if ctx.fbw_mode.snapshot_sym.is_null() {
+                None
+            } else {
+                let jitcode = (&*ctx.fbw_mode.snapshot_sym).jitcode();
+                (!jitcode.is_null()).then(|| (&(*jitcode).payload).jitcode.clone())
+            }
+        };
+        let Some(jitcode) = jitcode else {
+            return false;
+        };
+        let Some(mut miframe) = build_single_frame_miframe(ctx, jitcode, resume_pc, None) else {
+            return false;
+        };
+        fill_trace_too_long_register_banks(ctx, &mut miframe);
+        // Keep the per-frame red identity seeded by `frame_box`.  The
+        // authoritative walk executed against `snapshot_for_tracing`, but the
+        // adopter validates this identity and publishes that snapshot's locals
+        // to the matching live frame before driving the blackhole. Replacing
+        // the register with the snapshot address would collapse those two
+        // identities and fail the live-root check.
+        FBW_SINGLE_FRAME_BLACKHOLE.with(|slot| {
+            *slot.borrow_mut() = Some(LatchedSingleFrameBlackhole {
+                miframe,
+                last_exc_value,
+                raising_exception: false,
+            });
+        });
+        true
+    } else if ctx.fbw_mode.inline_subwalk && multi_frame_blackhole_resume_enabled() {
+        let Some(mut framestack) = build_multi_frame_miframe(ctx, resume_pc, None) else {
+            return false;
+        };
+        if let Some(innermost) = framestack.frames.last_mut() {
+            fill_trace_too_long_register_banks(ctx, innermost);
+        }
+        FBW_MULTI_FRAME_BLACKHOLE.with(|slot| {
+            *slot.borrow_mut() = Some(LatchedMultiFrameBlackhole {
+                framestack,
+                last_exc_value,
+                raising_exception: false,
+            });
+        });
+        true
+    } else {
+        false
+    }
+}
+
 /// `PYRE_FBW_BLACKHOLE_RESUME` (default ON) — a top-level one-frame walk whose
 /// residual forced the vable and writes live heap resumes PAST the escaping
 /// opcode through the blackhole instead of falling back to escape/replay.  Both
@@ -283,6 +357,89 @@ fn build_single_frame_miframe<Sym: WalkSym>(
     }
 
     Some(miframe)
+}
+
+/// Fill every currently-known register color, matching
+/// `blackhole.py:_copy_data_from_miframe`.
+///
+/// The vable-escape latch above only needs the resume marker's live set: it
+/// resumes immediately after one forcing residual whose result is supplied
+/// separately. `ABORT_TOO_LONG` is different — the blackhole can follow
+/// arbitrary control flow from a post-step pc before reaching a terminal, so
+/// colors outside that marker-local live set may be read later. RPython copies
+/// all three complete MIFrame banks; do the same for this abort instead of
+/// relying on the narrower resume-liveness cache.
+fn fill_trace_too_long_register_banks<Sym: WalkSym>(
+    ctx: &WalkContext<'_, '_, Sym>,
+    miframe: &mut majit_metainterp::MIFrame,
+) {
+    for color in 0..miframe.int_values.len() {
+        if let Some(value) = ctx
+            .concrete_registers_i
+            .get(color)
+            .copied()
+            .and_then(|value| match value {
+                ConcreteValue::Int(value) => Some(value),
+                ConcreteValue::Bool(value) => Some(i64::from(value)),
+                _ => None,
+            })
+        {
+            miframe.int_values[color] = Some(value);
+            continue;
+        }
+        if miframe.int_values[color].is_none() {
+            miframe.int_values[color] = ctx
+                .registers_i
+                .get(color)
+                .copied()
+                .and_then(|opref| ctx.trace_ctx.concrete_of_opref(opref))
+                .and_then(|value| match value {
+                    majit_ir::Value::Int(value) => Some(value),
+                    _ => None,
+                });
+        }
+    }
+
+    for color in 0..miframe.ref_values.len() {
+        if let Some(value) = ctx
+            .concrete_registers_r
+            .get(color)
+            .copied()
+            .and_then(|value| match value {
+                ConcreteValue::Ref(value) => Some(value as i64),
+                _ => None,
+            })
+        {
+            miframe.ref_values[color] = Some(value);
+            continue;
+        }
+        if miframe.ref_values[color].is_none() {
+            miframe.ref_values[color] = ctx
+                .registers_r
+                .get(color)
+                .copied()
+                .and_then(|opref| ctx.trace_ctx.recover_ref_value(opref, 8))
+                .and_then(|value| match value {
+                    majit_ir::Value::Ref(value) => Some(value.0 as i64),
+                    _ => None,
+                });
+        }
+    }
+
+    for color in 0..miframe.float_values.len() {
+        if miframe.float_values[color].is_some() {
+            continue;
+        }
+        miframe.float_values[color] = ctx
+            .registers_f
+            .get(color)
+            .copied()
+            .and_then(|opref| ctx.trace_ctx.concrete_of_opref(opref))
+            .and_then(|value| match value {
+                majit_ir::Value::Float(value) => Some(value.to_bits() as i64),
+                _ => None,
+            });
+    }
 }
 
 fn build_multi_frame_miframe<Sym: WalkSym>(

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -163,11 +163,15 @@ pub(crate) fn latch_trace_too_long_blackhole<Sym: WalkSym>(
             } else {
                 let sym = &*ctx.fbw_mode.snapshot_sym;
                 let jitcode = sym.jitcode();
+                let forwarded_live_root = match ctx.trace_ctx.lookup_opref_concrete(sym.frame()) {
+                    Some(majit_ir::Value::Ref(value)) if value.0 != 0 => value.0,
+                    _ => sym.live_vable_frame_addr(),
+                };
                 (!jitcode.is_null()).then(|| {
                     (
                         (&(*jitcode).payload).jitcode.clone(),
                         sym.tracing_vable_frame_addr(),
-                        sym.live_vable_frame_addr(),
+                        forwarded_live_root,
                     )
                 })
             }
@@ -207,6 +211,7 @@ pub(crate) fn latch_trace_too_long_blackhole<Sym: WalkSym>(
             || vable_frame != root_addr
             || crate::state::capture_frame_locals(vable_frame).is_none()
             || !crate::state::can_write_back_outer_locals(ctx.trace_ctx, vable_frame)
+            || !crate::state::can_publish_frame_stack(cf_addr, vable_frame)
         {
             return false;
         }
@@ -448,30 +453,31 @@ fn fill_trace_too_long_register_banks<Sym: WalkSym>(
     }
 
     for color in 0..miframe.ref_values.len() {
-        if let Some(value) = ctx
-            .concrete_registers_r
-            .get(color)
-            .copied()
-            .and_then(|value| match value {
-                ConcreteValue::Ref(value) => Some(value as i64),
-                _ => None,
-            })
-        {
+        let opref = ctx.registers_r.get(color).copied();
+        let forwarded = opref
+            .filter(|&value| value != OpRef::NONE)
+            .and_then(|value| {
+                match ctx
+                    .trace_ctx
+                    .lookup_opref_concrete(value)
+                    .or_else(|| ctx.trace_ctx.recover_ref_value(value, 8))
+                {
+                    Some(majit_ir::Value::Ref(value)) => Some(value.0 as i64),
+                    _ => None,
+                }
+            });
+        let from_shadow =
+            ctx.concrete_registers_r
+                .get(color)
+                .copied()
+                .and_then(|value| match value {
+                    ConcreteValue::Ref(value) => Some(value as i64),
+                    _ => None,
+                });
+        if let Some(value) = forwarded.or(from_shadow) {
             miframe.ref_values[color] = Some(value);
-            continue;
-        }
-        if miframe.ref_values[color].is_none() {
-            let Some(opref) = ctx.registers_r.get(color).copied() else {
-                continue;
-            };
-            if opref == OpRef::NONE {
-                continue;
-            }
-            let Some(majit_ir::Value::Ref(value)) = ctx.trace_ctx.recover_ref_value(opref, 8)
-            else {
-                return false;
-            };
-            miframe.ref_values[color] = Some(value.0 as i64);
+        } else if opref.is_some_and(|value| value != OpRef::NONE) {
+            return false;
         }
     }
 

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
@@ -160,7 +160,10 @@ fn read_ref_reg_concrete_returns_slot_matching_symbolic_read() {
     let exc_obj_ptr: pyre_object::PyObjectRef = 0xDEAD_BEEFusize as _;
     let descr_pool: Vec<DescrRef> = Vec::new();
     let mut tc = fresh_trace_ctx();
-    let oprefs = distinct_const_refs(&mut tc, 3);
+    let mut oprefs = distinct_const_refs(&mut tc, 3);
+    // A non-constant input box has no intrinsic `TraceCtx` concrete payload;
+    // only the parallel MIFrame-style register shadow knows its value.
+    oprefs[1] = OpRef::input_arg_ref(17);
     let mut regs_r = oprefs.clone();
     let mut concrete = vec![
         ConcreteValue::Null,
@@ -227,6 +230,20 @@ fn read_ref_reg_concrete_returns_slot_matching_symbolic_read() {
             reg_idx,
         );
     }
+    let code = [0u8, 1u8];
+    let op = DecodedOp {
+        key: "fixture/r",
+        opname: "fixture",
+        argcodes: "r",
+        pc: 0,
+        next_pc: 2,
+    };
+    assert_eq!(wc.trace_ctx.concrete_of_opref(wc.registers_r[1]), None);
+    assert_eq!(
+        super::vable_ops::vable_value_concrete(&code, &op, 0, &wc, 'r', wc.registers_r[1]),
+        Some(Value::Ref(majit_ir::GcRef(exc_obj_ptr as usize))),
+        "vable writes must preserve the concrete half of a non-constant register Box",
+    );
 }
 
 /// `getfield_vable_*` must abort to `VableBoxNotSeeded` when the

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
@@ -151,17 +151,33 @@ fn switch_descr_pool(entries: &[(i64, usize)]) -> Vec<DescrRef> {
 
 #[test]
 fn trace_too_long_snapshot_waits_for_frame_transition_outcomes() {
-    assert!(trace_too_long_blackhole_snapshot_safe(
-        &DispatchOutcome::Continue
+    assert!(trace_too_long_abort_safe(
+        &DispatchOutcome::Continue,
+        false,
+        0,
     ));
-    assert!(!trace_too_long_blackhole_snapshot_safe(
-        &DispatchOutcome::SubReturn { result: None }
+    assert!(!trace_too_long_abort_safe(
+        &DispatchOutcome::SubReturn { result: None },
+        false,
+        0,
     ));
-    assert!(!trace_too_long_blackhole_snapshot_safe(
+    assert!(!trace_too_long_abort_safe(
         &DispatchOutcome::SubRaise {
             exc: OpRef::input_arg_ref(0),
             exc_concrete: ConcreteValue::Ref(0xCAFEusize as _),
-        }
+        },
+        false,
+        0,
+    ));
+    assert!(!trace_too_long_abort_safe(
+        &DispatchOutcome::Continue,
+        false,
+        1,
+    ));
+    assert!(trace_too_long_abort_safe(
+        &DispatchOutcome::Continue,
+        true,
+        1,
     ));
 }
 
@@ -175,16 +191,22 @@ fn trace_too_long_snapshot_waits_for_frame_transition_outcomes() {
 fn read_ref_reg_concrete_returns_slot_matching_symbolic_read() {
     let exc_obj_ptr: pyre_object::PyObjectRef = 0xDEAD_BEEFusize as _;
     let descr_pool: Vec<DescrRef> = Vec::new();
-    let mut tc = fresh_trace_ctx();
+    let mut tc = TraceCtx::for_test_types(&[Type::Ref, Type::Ref, Type::Ref]);
     let mut oprefs = distinct_const_refs(&mut tc, 3);
     // A non-constant input box has no intrinsic `TraceCtx` concrete payload;
     // only the parallel MIFrame-style register shadow knows its value.
-    oprefs[1] = OpRef::input_arg_ref(17);
+    oprefs[1] = OpRef::input_arg_ref(1);
+    // Model a collection that forwarded the recorder Box while the raw
+    // concrete-register shadow retained its old address.
+    oprefs[2] = OpRef::input_arg_ref(2);
+    let forwarded_obj_ptr = 0xF0A0_0000usize;
+    let stale_obj_ptr = 0xDEAD_0000usize;
+    tc.set_opref_concrete(oprefs[2], Value::Ref(majit_ir::GcRef(forwarded_obj_ptr)));
     let mut regs_r = oprefs.clone();
     let mut concrete = vec![
         ConcreteValue::Null,
         ConcreteValue::Ref(exc_obj_ptr),
-        ConcreteValue::Int(42),
+        ConcreteValue::Ref(stale_obj_ptr as pyre_object::PyObjectRef),
     ];
     // Snapshot expected values before `&mut concrete` enters wc —
     // the assertion below cannot read `concrete[reg_idx]` while wc
@@ -273,6 +295,19 @@ fn read_ref_reg_concrete_returns_slot_matching_symbolic_read() {
         Some(Value::Ref(majit_ir::GcRef(0xC0DE_0000))),
         "a TOS override must resolve its own box instead of the stale encoded register shadow",
     );
+    let forwarded_code = [0u8, 2u8];
+    assert_eq!(
+        super::vable_ops::vable_value_concrete(
+            &forwarded_code,
+            &op,
+            0,
+            &wc,
+            'r',
+            wc.registers_r[2],
+        ),
+        Some(Value::Ref(majit_ir::GcRef(forwarded_obj_ptr))),
+        "a forwarded recorder Box must win over the stale raw Ref shadow",
+    );
 
     let runtime_jc = majit_metainterp::jitcode::JitCode::new("trace_too_long_arbitrary_pc");
     runtime_jc.set_body(majit_translate::jitcode::JitCodeBody {
@@ -292,6 +327,11 @@ fn read_ref_reg_concrete_returns_slot_matching_symbolic_read() {
         miframe.ref_values[1],
         Some(exc_obj_ptr as i64),
         "the complete-bank image must retain non-constant register concrete values",
+    );
+    assert_eq!(
+        miframe.ref_values[2],
+        Some(forwarded_obj_ptr as i64),
+        "the complete-bank image must prefer the GC-forwarded Box payload",
     );
 }
 

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
@@ -260,6 +260,19 @@ fn read_ref_reg_concrete_returns_slot_matching_symbolic_read() {
         Some(Value::Ref(majit_ir::GcRef(exc_obj_ptr as usize))),
         "vable writes must preserve the concrete half of a non-constant register Box",
     );
+    assert_eq!(
+        super::vable_ops::vable_effective_value_concrete(
+            &code,
+            &op,
+            0,
+            &wc,
+            'r',
+            wc.registers_r[1],
+            wc.registers_r[0],
+        ),
+        Some(Value::Ref(majit_ir::GcRef(0xC0DE_0000))),
+        "a TOS override must resolve its own box instead of the stale encoded register shadow",
+    );
 
     let runtime_jc = majit_metainterp::jitcode::JitCode::new("trace_too_long_arbitrary_pc");
     runtime_jc.set_body(majit_translate::jitcode::JitCodeBody {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
@@ -149,6 +149,22 @@ fn switch_descr_pool(entries: &[(i64, usize)]) -> Vec<DescrRef> {
     vec![std::sync::Arc::new(crate::descr::PyreSwitchDescr::new(dict)) as DescrRef]
 }
 
+#[test]
+fn trace_too_long_snapshot_waits_for_frame_transition_outcomes() {
+    assert!(trace_too_long_blackhole_snapshot_safe(
+        &DispatchOutcome::Continue
+    ));
+    assert!(!trace_too_long_blackhole_snapshot_safe(
+        &DispatchOutcome::SubReturn { result: None }
+    ));
+    assert!(!trace_too_long_blackhole_snapshot_safe(
+        &DispatchOutcome::SubRaise {
+            exc: OpRef::input_arg_ref(0),
+            exc_concrete: ConcreteValue::Ref(0xCAFEusize as _),
+        }
+    ));
+}
+
 /// Concrete-shadow round-trip: a `WalkContext` built with
 /// `concrete_registers_r` exposes each slot's `ConcreteValue` via
 /// `read_ref_reg_concrete` indexed by the same byte the symbolic
@@ -243,6 +259,26 @@ fn read_ref_reg_concrete_returns_slot_matching_symbolic_read() {
         super::vable_ops::vable_value_concrete(&code, &op, 0, &wc, 'r', wc.registers_r[1]),
         Some(Value::Ref(majit_ir::GcRef(exc_obj_ptr as usize))),
         "vable writes must preserve the concrete half of a non-constant register Box",
+    );
+
+    let runtime_jc = majit_metainterp::jitcode::JitCode::new("trace_too_long_arbitrary_pc");
+    runtime_jc.set_body(majit_translate::jitcode::JitCodeBody {
+        code: vec![0, 0],
+        c_num_regs_r: 3,
+        startpoints: Some([0_usize].into_iter().collect()),
+        ..Default::default()
+    });
+    let miframe = super::residual_call::build_trace_too_long_single_frame_miframe(
+        &wc,
+        std::sync::Arc::new(runtime_jc),
+        1,
+    )
+    .expect("an arbitrary post-step pc must not require a -live- marker");
+    assert_eq!(miframe.pc, 1);
+    assert_eq!(
+        miframe.ref_values[1],
+        Some(exc_obj_ptr as i64),
+        "the complete-bank image must retain non-constant register concrete values",
     );
 }
 

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/vable_ops.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/vable_ops.rs
@@ -10,6 +10,38 @@
 
 use super::*;
 
+/// Resolve the concrete half of a JitCode register operand.
+///
+/// RPython's MIFrame banks hold Box objects, so assigning a valuebox to
+/// `virtualizable_boxes` preserves its concrete value. Pyre splits that Box
+/// between an OpRef bank and a parallel concrete bank. Prefer the latter:
+/// residual results do not necessarily have an intrinsic value attached to
+/// their OpRef, but they do have the concrete value produced by the
+/// authoritative walker.
+pub(super) fn vable_value_concrete<Sym: WalkSym>(
+    code: &[u8],
+    op: &DecodedOp,
+    operand_offset: usize,
+    ctx: &WalkContext<'_, '_, Sym>,
+    bank: char,
+    value: OpRef,
+) -> Option<Value> {
+    let concrete = match bank {
+        'i' => read_int_reg_concrete(code, op, operand_offset, ctx),
+        'r' => read_ref_reg_concrete(code, op, operand_offset, ctx),
+        'f' => read_float_reg_concrete(code, op, operand_offset, ctx),
+        _ => unreachable!("value bank must be 'i', 'r' or 'f'"),
+    };
+    let from_register = match (bank, concrete) {
+        ('i', ConcreteValue::Int(value)) => Some(Value::Int(value)),
+        ('i', ConcreteValue::Bool(value)) => Some(Value::Int(i64::from(value))),
+        ('r', ConcreteValue::Ref(value)) => Some(Value::Ref(majit_ir::GcRef(value as usize))),
+        ('f', ConcreteValue::Float(value)) => Some(Value::Float(value)),
+        _ => None,
+    };
+    from_register.or_else(|| ctx.trace_ctx.concrete_of_opref(value))
+}
+
 /// `getfield_vable_<i|r|f>/rd>X` handler. Operand layout `rd>X`:
 /// 1B r-reg(vable_box) + 2B descr(field) + 1B X-dst.
 ///
@@ -170,8 +202,8 @@ pub(crate) fn getfield_vable_via_metainterp<Sym: WalkSym>(
 /// (`majit-metainterp/src/trace_ctx.rs`) which implements the
 /// full `_nonstandard_virtualizable` -> SETFIELD_GC fallback +
 /// `virtualizable_boxes[index] = valuebox` write + `synchronize_virtualizable`
-/// mirror.  The concrete `Value` is reconstructed via
-/// `TraceCtx::concrete_of_opref` (matching the
+/// mirror.  The concrete `Value` is read from the same register's parallel
+/// concrete bank (matching the
 /// `pyjitpl/dispatch.rs` shape `let (value, concrete) =
 /// self.read_<bank>_reg(src); ctx.vable_setfield(...)`).
 ///
@@ -205,7 +237,7 @@ pub(crate) fn setfield_vable_via_metainterp<Sym: WalkSym>(
         _ => unreachable!("value_bank must be 'i', 'r' or 'f'"),
     };
     let descr = read_descr(code, op, 2, ctx)?;
-    let concrete = ctx.trace_ctx.concrete_of_opref(value);
+    let concrete = vable_value_concrete(code, op, 1, ctx, value_bank, value);
     // R7 parity: pyjitpl.py `_opimpl_setfield_vable(box,
     // valuebox, fielddescr, pc)` threads orgpc through
     // `_nonstandard_virtualizable(pc, ...)`; walker has `op.pc` for the
@@ -512,9 +544,7 @@ pub(crate) fn setarrayitem_vable_via_metainterp<Sym: WalkSym>(
                 'f' => read_float_reg(code, op, 2, ctx)?,
                 _ => unreachable!("value_bank must be 'i', 'r' or 'f'"),
             };
-            let concrete = ctx
-                .trace_ctx
-                .concrete_of_opref(value)
+            let concrete = vable_value_concrete(code, op, 2, ctx, value_bank, value)
                 .unwrap_or(majit_ir::Value::Void);
             if let Some(shadow) = ctx.callee_shadow.as_mut() {
                 shadow.set_opref(slot, value);
@@ -573,10 +603,7 @@ pub(crate) fn setarrayitem_vable_via_metainterp<Sym: WalkSym>(
         }
     }
     let (fdescr, adescr) = vable_array_descrs_from_jitcode(code, op, 3, 5, ctx)?;
-    let concrete = ctx
-        .trace_ctx
-        .concrete_of_opref(value)
-        .unwrap_or(Value::Void);
+    let concrete = vable_value_concrete(code, op, 2, ctx, value_bank, value).unwrap_or(Value::Void);
     let guards_before = ctx.trace_ctx.num_guards();
     ctx.trace_ctx.vable_setarrayitem_indexed(
         op.pc,

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/vable_ops.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/vable_ops.rs
@@ -42,6 +42,29 @@ pub(super) fn vable_value_concrete<Sym: WalkSym>(
     from_register.or_else(|| ctx.trace_ctx.concrete_of_opref(value))
 }
 
+/// Resolve the concrete value after an operand-stack recovery may have
+/// replaced the bytecode register's box.
+///
+/// The register shadow is authoritative only while `effective_value` is the
+/// box encoded by the instruction. Once TOS recovery substitutes another box,
+/// re-reading that original color can return a stale concrete value from a
+/// prior loop iteration.
+pub(super) fn vable_effective_value_concrete<Sym: WalkSym>(
+    code: &[u8],
+    op: &DecodedOp,
+    operand_offset: usize,
+    ctx: &WalkContext<'_, '_, Sym>,
+    bank: char,
+    encoded_value: OpRef,
+    effective_value: OpRef,
+) -> Option<Value> {
+    if effective_value == encoded_value {
+        vable_value_concrete(code, op, operand_offset, ctx, bank, effective_value)
+    } else {
+        ctx.trace_ctx.concrete_of_opref(effective_value)
+    }
+}
+
 /// `getfield_vable_<i|r|f>/rd>X` handler. Operand layout `rd>X`:
 /// 1B r-reg(vable_box) + 2B descr(field) + 1B X-dst.
 ///
@@ -569,12 +592,13 @@ pub(crate) fn setarrayitem_vable_via_metainterp<Sym: WalkSym>(
             });
         }
     };
-    let mut value = match value_bank {
+    let encoded_value = match value_bank {
         'i' => read_int_reg(code, op, 2, ctx)?,
         'r' => read_ref_reg(code, op, 2, ctx)?,
         'f' => read_float_reg(code, op, 2, ctx)?,
         _ => unreachable!("value_bank must be 'i', 'r' or 'f'"),
     };
+    let mut value = encoded_value;
     // A STORE_FAST (`index < nlocals`) pops the operand-stack TOS and writes
     // it into a local slot.  When the popped value lives in an operand-stack
     // temp that spans a nested loop, the loop-header merge-point seeds no
@@ -603,7 +627,9 @@ pub(crate) fn setarrayitem_vable_via_metainterp<Sym: WalkSym>(
         }
     }
     let (fdescr, adescr) = vable_array_descrs_from_jitcode(code, op, 3, 5, ctx)?;
-    let concrete = vable_value_concrete(code, op, 2, ctx, value_bank, value).unwrap_or(Value::Void);
+    let concrete =
+        vable_effective_value_concrete(code, op, 2, ctx, value_bank, encoded_value, value)
+            .unwrap_or(Value::Void);
     let guards_before = ctx.trace_ctx.num_guards();
     ctx.trace_ctx.vable_setarrayitem_indexed(
         op.pc,

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/vable_ops.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/vable_ops.rs
@@ -14,10 +14,12 @@ use super::*;
 ///
 /// RPython's MIFrame banks hold Box objects, so assigning a valuebox to
 /// `virtualizable_boxes` preserves its concrete value. Pyre splits that Box
-/// between an OpRef bank and a parallel concrete bank. Prefer the latter:
-/// residual results do not necessarily have an intrinsic value attached to
-/// their OpRef, but they do have the concrete value produced by the
-/// authoritative walker.
+/// between an OpRef bank and a parallel concrete bank. Ref values prefer the
+/// recorder Box payload because the active-trace root walker forwards it in
+/// place across a collection; the raw concrete shadow is not a GC root and can
+/// retain the pre-forwarding address. Residual results do not necessarily have
+/// such a payload, so they fall back to the authoritative walker's shadow.
+/// Int/Float values are not GC addresses and keep the shadow-first order.
 pub(super) fn vable_value_concrete<Sym: WalkSym>(
     code: &[u8],
     op: &DecodedOp,
@@ -39,7 +41,14 @@ pub(super) fn vable_value_concrete<Sym: WalkSym>(
         ('f', ConcreteValue::Float(value)) => Some(Value::Float(value)),
         _ => None,
     };
-    from_register.or_else(|| ctx.trace_ctx.concrete_of_opref(value))
+    if bank == 'r' {
+        ctx.trace_ctx
+            .lookup_opref_concrete(value)
+            .or_else(|| ctx.trace_ctx.recover_ref_value(value, 8))
+            .or(from_register)
+    } else {
+        from_register.or_else(|| ctx.trace_ctx.concrete_of_opref(value))
+    }
 }
 
 /// Resolve the concrete value after an operand-stack recovery may have

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -2502,6 +2502,8 @@ pub trait WalkSym {
     fn valuestackdepth(&self) -> usize;
     fn jitcode(&self) -> *const JitCode;
     fn concrete_execution_context(&self) -> *const pyre_interpreter::PyExecutionContext;
+    /// Interpreter-frame snapshot the authoritative walker steps concretely.
+    fn tracing_vable_frame_addr(&self) -> usize;
     fn live_vable_frame_addr(&self) -> usize;
     fn set_live_vable_frame_addr(&mut self, value: usize);
     fn bridge_walk_entry_pc(&self) -> Option<usize>;
@@ -2610,6 +2612,11 @@ impl WalkSym for PyreSym {
     #[inline]
     fn concrete_execution_context(&self) -> *const pyre_interpreter::PyExecutionContext {
         self.concrete_execution_context
+    }
+
+    #[inline]
+    fn tracing_vable_frame_addr(&self) -> usize {
+        self.concrete_vable_ptr as usize
     }
 
     #[inline]
@@ -4904,15 +4911,18 @@ pub(crate) fn restore_frame_scalars(frame: usize, saved: FrameScalars) {
 /// Materialize the outer frame's locals from the virtualizable shadow.
 /// Callers must run their complete preflight before executing a rebuilt
 /// callee; after that point a failure would make replay unsafe.
-pub(crate) fn write_back_outer_locals(ctx: &TraceCtx, frame: usize) -> bool {
+fn outer_locals_publish_target(
+    ctx: &TraceCtx,
+    frame: usize,
+) -> Option<(usize, *mut pyre_object::FixedObjectArray, usize)> {
     if frame == 0 {
-        return false;
+        return None;
     }
     let Some(nlocals) = concrete_nlocals(frame) else {
-        return false;
+        return None;
     };
     let Some(info) = ctx.virtualizable_info() else {
-        return false;
+        return None;
     };
     let frame_ptr = frame as *mut u8;
     let arr_ptr = unsafe {
@@ -4920,7 +4930,7 @@ pub(crate) fn write_back_outer_locals(ctx: &TraceCtx, frame: usize) -> bool {
             as *const *mut pyre_object::FixedObjectArray)
     };
     if arr_ptr.is_null() || unsafe { &*arr_ptr }.as_slice().len() < nlocals {
-        return false;
+        return None;
     }
     let base = info.num_static_extra_boxes;
     // Every slot has to resolve before the first store, the way the merge-point
@@ -4928,15 +4938,31 @@ pub(crate) fn write_back_outer_locals(ctx: &TraceCtx, frame: usize) -> bool {
     // the frame carrying a mix of walk-current and pre-walk locals, which is
     // neither of the two states a caller can recover from.
     if (0..nlocals).any(|abs| ctx.virtualizable_entry_at(base + abs).is_none()) {
-        return false;
+        return None;
     }
+    Some((nlocals, arr_ptr, base))
+}
+
+/// Read-only half of [`write_back_outer_locals`].
+///
+/// `ABORT_TOO_LONG` has already executed the current opcode when it decides to
+/// stop tracing. It uses this census before publishing a blackhole image so a
+/// later adoption cannot decline into trace-entry replay after those effects.
+pub(crate) fn can_write_back_outer_locals(ctx: &TraceCtx, frame: usize) -> bool {
+    outer_locals_publish_target(ctx, frame).is_some()
+}
+
+pub(crate) fn write_back_outer_locals(ctx: &TraceCtx, frame: usize) -> bool {
+    let Some((nlocals, arr_ptr, base)) = outer_locals_publish_target(ctx, frame) else {
+        return false;
+    };
     // Boxing an Int/Float slot allocates; the detached frame array is
     // forwarded only while it is in the remembered set, and each minor
     // consumes that entry, so re-arm the barrier after every store.
     for abs in 0..nlocals {
-        let Some((_opref, value)) = ctx.virtualizable_entry_at(base + abs) else {
-            return false;
-        };
+        let (_opref, value) = ctx
+            .virtualizable_entry_at(base + abs)
+            .expect("outer-locals target was completely preflighted");
         let boxed = boxed_slot_value_for_type(Type::Ref, &value);
         unsafe {
             (*arr_ptr).as_mut_slice()[abs] = boxed;

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -4871,6 +4871,129 @@ pub(crate) fn restore_frame_locals(frame: usize, saved: &[i64]) {
     frame_array_write_barrier(frame as *mut u8, arr_ptr);
 }
 
+/// The active operand-stack half of a tracer snapshot that must be published
+/// to its live virtualizable before an overlong trace is continued in the
+/// blackhole.
+///
+/// RPython has no separate copy step here: `convert_and_run_from_pyjitpl`
+/// copies the already-advanced MIFrame, whose red virtualizable is the one
+/// frame object carrying that call's locals and stack.  Pyre concretely steps
+/// a detached `snapshot_for_tracing`, so the corresponding state has to cross
+/// back to that same live frame explicitly.  The raw Ref words are exposed as
+/// a mutable slice because publishing locals can allocate; callers root the
+/// slice so nursery forwarding is reflected before the stack is stored.
+pub(crate) struct CapturedFrameStack {
+    stack_base: usize,
+    scalars: FrameScalars,
+    roots: Vec<i64>,
+}
+
+impl CapturedFrameStack {
+    pub(crate) fn roots_mut(&mut self) -> &mut [i64] {
+        self.roots.as_mut_slice()
+    }
+}
+
+fn frame_stack_transfer_shape(
+    snapshot: usize,
+    live_frame: usize,
+) -> Option<(
+    usize,
+    usize,
+    *const pyre_object::FixedObjectArray,
+    *mut pyre_object::FixedObjectArray,
+)> {
+    if snapshot == 0 || live_frame == 0 {
+        return None;
+    }
+    let snapshot_base = concrete_nlocals(snapshot)?;
+    let live_base = concrete_nlocals(live_frame)?;
+    if snapshot_base != live_base {
+        return None;
+    }
+    let snapshot_depth = concrete_stack_depth(snapshot)?;
+    if snapshot_depth < snapshot_base {
+        return None;
+    }
+    let snapshot_arr = unsafe {
+        *((snapshot as *const u8).add(PYFRAME_LOCALS_CELLS_STACK_OFFSET)
+            as *const *const pyre_object::FixedObjectArray)
+    };
+    let live_arr = unsafe {
+        *((live_frame as *const u8).add(PYFRAME_LOCALS_CELLS_STACK_OFFSET)
+            as *const *mut pyre_object::FixedObjectArray)
+    };
+    if snapshot_arr.is_null()
+        || live_arr.is_null()
+        || unsafe { &*snapshot_arr }.as_slice().len() < snapshot_depth
+        || unsafe { &*live_arr }.as_slice().len() < snapshot_depth
+    {
+        return None;
+    }
+    Some((snapshot_base, snapshot_depth, snapshot_arr, live_arr))
+}
+
+/// Allocation-free preflight for [`capture_frame_stack_for_publish`].
+pub(crate) fn can_publish_frame_stack(snapshot: usize, live_frame: usize) -> bool {
+    frame_stack_transfer_shape(snapshot, live_frame).is_some()
+}
+
+/// Copy the tracer snapshot's active operand stack into a rootable carrier.
+/// The destination is checked at capture time and checked again at commit, so
+/// no partial stack is ever published if frame identity or layout changes.
+pub(crate) fn capture_frame_stack_for_publish(
+    snapshot: usize,
+    live_frame: usize,
+) -> Option<CapturedFrameStack> {
+    let (stack_base, stack_depth, snapshot_arr, _) =
+        frame_stack_transfer_shape(snapshot, live_frame)?;
+    let slots = unsafe { &*snapshot_arr }.as_slice();
+    Some(CapturedFrameStack {
+        stack_base,
+        scalars: capture_frame_scalars(snapshot)?,
+        roots: slots[stack_base..stack_depth]
+            .iter()
+            .map(|&value| value as i64)
+            .collect(),
+    })
+}
+
+/// Commit a captured post-step operand stack and its Python-frame coordinate
+/// to the live red frame.  This performs no allocation: once the caller has
+/// published locals and reached this point, the blackhole handoff is
+/// irrevocable.
+pub(crate) fn publish_captured_frame_stack(
+    live_frame: usize,
+    captured: &CapturedFrameStack,
+) -> bool {
+    let Some(live_base) = concrete_nlocals(live_frame) else {
+        return false;
+    };
+    if live_base != captured.stack_base
+        || captured.scalars.valuestackdepth != live_base + captured.roots.len()
+    {
+        return false;
+    }
+    let live_arr = unsafe {
+        *((live_frame as *const u8).add(PYFRAME_LOCALS_CELLS_STACK_OFFSET)
+            as *const *mut pyre_object::FixedObjectArray)
+    };
+    if live_arr.is_null()
+        || unsafe { &*live_arr }.as_slice().len() < captured.scalars.valuestackdepth
+    {
+        return false;
+    }
+    unsafe {
+        let slots = (*live_arr).as_mut_slice();
+        for (offset, &value) in captured.roots.iter().enumerate() {
+            slots[live_base + offset] = value as usize as PyObjectRef;
+        }
+    }
+    restore_frame_scalars(live_frame, captured.scalars);
+    frame_array_write_barrier(live_frame as *mut u8, live_arr);
+    true
+}
+
 /// The scalar half of the frame image [`capture_frame_locals`] covers.
 #[derive(Clone, Copy)]
 pub(crate) struct FrameScalars {

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -2094,6 +2094,11 @@ fn try_adopt_single_frame_blackhole(
         .iter()
         .map(|&index| latched.miframe.ref_values[index].expect("location came from Some"))
         .collect();
+    let image_exception_root = (latched.last_exc_value != 0).then(|| {
+        let index = image_ref_roots.len();
+        image_ref_roots.push(latched.last_exc_value);
+        index
+    });
     let root_depth = majit_gc::shadow_stack::resume_ref_roots_depth();
     unsafe {
         majit_gc::shadow_stack::push_resume_ref_roots(image_ref_roots.as_mut_slice());
@@ -2113,6 +2118,9 @@ fn try_adopt_single_frame_blackhole(
     }
     for (&index, &forwarded) in image_ref_locations.iter().zip(&image_ref_roots) {
         latched.miframe.ref_values[index] = Some(forwarded);
+    }
+    if let Some(index) = image_exception_root {
+        latched.last_exc_value = image_ref_roots[index];
     }
     let committed_root_addr = latched
         .miframe

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -2151,15 +2151,26 @@ fn try_adopt_single_frame_blackhole(
         latched.last_exc_value,
         latched.raising_exception,
     );
+    // The blackhole roots and forwards its Ref bank in place. A collection
+    // during the drive can therefore move the live frame away from the
+    // pre-drive `committed_root_addr`; recover the authoritative post-drive
+    // identity from the same per-frame red register before dereferencing it.
+    let forwarded_root_addr = terminal
+        .registers_r
+        .get(frame_reg as usize)
+        .copied()
+        .filter(|&addr| addr != 0)
+        .expect("post-blackhole frame register lost the live frame identity")
+        as usize;
     // Vable opcodes address the frame carried in the MIFrame's red register,
     // i.e. the live frame whose locals were published above. Fold every
     // blackhole write back into the tracing snapshot before the portal
     // epilogue propagates that snapshot. This matters for terminal exceptions:
     // their traceback keeps `tb_frame.f_locals` observable after the walk.
-    if committed_root_addr != cf_addr {
+    if forwarded_root_addr != cf_addr {
         unsafe {
             (*(cf_addr as *mut pyre_interpreter::PyFrame)).restore_resume_state_from(
-                &*(committed_root_addr as *const pyre_interpreter::PyFrame),
+                &*(forwarded_root_addr as *const pyre_interpreter::PyFrame),
             );
         }
     }

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -2057,18 +2057,23 @@ fn try_adopt_single_frame_blackhole(
     // QUIETER, not smaller — before it the accumulator was visibly wrong too.
     // So the decline had to go, not be gated around.
     //
-    // The escape flush that ran ahead of the forcing residual is
-    // all-or-nothing, and its decline is what this latch is gated on
-    // (`committed_frame_escape_pc().is_none()`).  What it declines on is the
-    // operand-stack half — the shadow's stack region reads NULL away from a
-    // merge point — and the drive reconstructs that half itself, through the
-    // vable stores its own execution makes.
-    // The LOCALS half is not optional: every LOAD_FAST lowers to
+    // The escape flush that ran ahead of the forcing residual is all-or-
+    // nothing, and its decline is what the vable-escape latch is gated on
+    // (`committed_frame_escape_pc().is_none()`).  The LOCALS half is not
+    // optional: every LOAD_FAST lowers to
     // `getarrayitem_vable_r` on the frame the latched image's register names,
     // so without it the drive reads whatever that frame held before the walk
     // began, and a local the walk assigned comes back null.  Publish that half
     // here, and withdraw it if it cannot complete — the withdrawal is honest
     // only because nothing has run at that point.
+    //
+    // Trace-too-long is also post-step: its MIFrame `resume_pc` and concrete
+    // banks already describe the next jitcode instruction.  The detached
+    // `snapshot_for_tracing` therefore owns the matching active operand stack
+    // and Python-frame coordinate.  RPython's MIFrame and red frame are one
+    // coherent per-call state at this boundary; publish the snapshot stack to
+    // the same live red frame before driving instead of leaving only
+    // `valuestackdepth` to advance over null slots.
     //
     // Which frame gets it is an identity question, and the walked frame has two
     // representations: `cf_addr` is the `snapshot_for_tracing` copy the walk
@@ -2106,10 +2111,25 @@ fn try_adopt_single_frame_blackhole(
         );
         return false;
     };
+    let mut captured_stack = if commit_leg == WalkEndCommitLeg::TraceTooLong {
+        match crate::state::capture_frame_stack_for_publish(cf_addr, vable_frame) {
+            Some(stack) => Some(stack),
+            None => {
+                assert!(
+                    !trace_too_long,
+                    "preflighted trace-too-long operand stack became uncapturable"
+                );
+                return false;
+            }
+        }
+    } else {
+        None
+    };
     // `take_single_frame_blackhole` removed the image from the TLS root
     // walker. `write_back_outer_locals` may box Int/Float locals and collect
-    // before the blackhole driver installs its own packed roots, so bridge
-    // that interval explicitly and copy forwarding updates into the MIFrame.
+    // before the blackhole driver installs its own packed roots. Bridge that
+    // interval explicitly, including the detached snapshot's active operand
+    // stack, and copy forwarding updates into the MIFrame.
     let image_ref_locations: Vec<usize> = latched
         .miframe
         .ref_values
@@ -2130,6 +2150,9 @@ fn try_adopt_single_frame_blackhole(
     unsafe {
         majit_gc::shadow_stack::push_resume_ref_roots(image_ref_roots.as_mut_slice());
         majit_gc::shadow_stack::push_resume_ref_roots(locals_undo.as_mut_slice());
+        if let Some(stack) = captured_stack.as_mut() {
+            majit_gc::shadow_stack::push_resume_ref_roots(stack.roots_mut());
+        }
     }
     if !crate::state::write_back_outer_locals(ctx, vable_frame) {
         crate::state::restore_frame_locals(vable_frame, &locals_undo);
@@ -2157,13 +2180,25 @@ fn try_adopt_single_frame_blackhole(
         .flatten()
         .expect("preflighted frame register disappeared after forwarding")
         as usize;
-    // The locals publish is the last recoverable adoption gate. Its undo image
-    // only needs rooting through that gate; after this point the blackhole may
-    // execute irreversible effects and the handoff must commit or fail loudly,
-    // never return to trace-entry replay.
+    if let Some(stack) = captured_stack.as_ref() {
+        if !crate::state::publish_captured_frame_stack(committed_root_addr, stack) {
+            crate::state::restore_frame_locals(committed_root_addr, &locals_undo);
+            majit_gc::shadow_stack::pop_resume_ref_roots_to(root_depth);
+            assert!(
+                !trace_too_long,
+                "preflighted trace-too-long operand-stack publication declined"
+            );
+            return false;
+        }
+    }
+    // Locals plus the no-allocation stack publication are the last recoverable
+    // adoption gates. Their undo image only needs rooting through this point;
+    // after it the blackhole may execute irreversible effects and the handoff
+    // must commit or fail loudly, never return to trace-entry replay.
     majit_gc::shadow_stack::pop_resume_ref_roots_to(root_depth);
     drop(locals_undo);
     drop(image_ref_roots);
+    drop(captured_stack);
     let terminal = majit_metainterp::drive_single_frame_blackhole(
         &mut latched.miframe,
         majit_metainterp::blackhole::StateFieldLayout::default(),
@@ -2236,7 +2271,7 @@ fn try_adopt_single_frame_blackhole(
                  replay is forbidden after blackhole effects",
             );
             let resume_py_pc = resume_py_pc as usize;
-            adopt_blackhole_crn(cf_addr, vable_frame, resume_py_pc);
+            adopt_blackhole_crn(cf_addr, forwarded_root_addr, resume_py_pc);
             sfdbg!("adopted with green resume_py_pc={resume_py_pc}");
             WALK_END_RESTART_PC.with(|slot| slot.set(Some(resume_py_pc)));
         }

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -2141,7 +2141,11 @@ fn try_adopt_single_frame_blackhole(
         &mut latched.miframe,
         majit_metainterp::blackhole::StateFieldLayout::default(),
         virtualizable_info,
-        cf_addr as i64,
+        // RPython threads the current MIFrame's own red virtualizable through
+        // blackhole execution. Keep the explicit driver field aligned with
+        // the same live frame carried in the MIFrame register; the tracing
+        // snapshot is only the epilogue's committed copy.
+        committed_root_addr as i64,
         stack_base,
         ctx.metainterp_sd().as_ref(),
         latched.last_exc_value,

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -1967,21 +1967,44 @@ fn try_adopt_single_frame_blackhole(
             }
         };
     }
+    // A zero-effect overlong walk deliberately permits entry replay even when
+    // no blackhole image was representable. Only an effectful TraceTooLong
+    // carries the irrevocable, fully preflighted adoption contract.
+    let trace_too_long = commit_leg == WalkEndCommitLeg::TraceTooLong
+        && crate::jitcode_dispatch::fbw_executed_effect_count() != 0;
     let Some(mut latched) = crate::jitcode_dispatch::take_single_frame_blackhole() else {
+        assert!(
+            !trace_too_long,
+            "preflighted trace-too-long blackhole image disappeared before adoption"
+        );
         return false;
     };
     let jitcode_index = match i32::try_from(latched.miframe.jitcode.index()) {
         Ok(index) => index,
-        Err(_) => return false,
+        Err(_) => {
+            assert!(
+                !trace_too_long,
+                "preflighted trace-too-long jitcode index no longer fits i32"
+            );
+            return false;
+        }
     };
     let virtualizable_info = ctx
         .virtualizable_info()
         .map(std::sync::Arc::as_ptr)
         .unwrap_or(std::ptr::null());
     if virtualizable_info.is_null() {
+        assert!(
+            !trace_too_long,
+            "preflighted trace-too-long virtualizable info disappeared"
+        );
         return false;
     }
     let Some(stack_base) = crate::state::concrete_nlocals(cf_addr) else {
+        assert!(
+            !trace_too_long,
+            "preflighted trace-too-long frame lost its concrete locals base"
+        );
         return false;
     };
     // Two gates used to sit here, and both were scaffolding around a decline
@@ -2043,29 +2066,69 @@ fn try_adopt_single_frame_blackhole(
         .flatten()
         .unwrap_or(0) as usize;
     if vable_frame == 0 || vable_frame != root_addr {
+        assert!(
+            !trace_too_long,
+            "preflighted trace-too-long frame identity changed before adoption"
+        );
         return false;
     }
     let Some(mut locals_undo) = crate::state::capture_frame_locals(vable_frame) else {
+        assert!(
+            !trace_too_long,
+            "preflighted trace-too-long frame locals became uncapturable"
+        );
         return false;
     };
+    // `take_single_frame_blackhole` removed the image from the TLS root
+    // walker. `write_back_outer_locals` may box Int/Float locals and collect
+    // before the blackhole driver installs its own packed roots, so bridge
+    // that interval explicitly and copy forwarding updates into the MIFrame.
+    let image_ref_locations: Vec<usize> = latched
+        .miframe
+        .ref_values
+        .iter()
+        .enumerate()
+        .filter_map(|(index, value)| value.map(|_| index))
+        .collect();
+    let mut image_ref_roots: Vec<i64> = image_ref_locations
+        .iter()
+        .map(|&index| latched.miframe.ref_values[index].expect("location came from Some"))
+        .collect();
     let root_depth = majit_gc::shadow_stack::resume_ref_roots_depth();
     unsafe {
+        majit_gc::shadow_stack::push_resume_ref_roots(image_ref_roots.as_mut_slice());
         majit_gc::shadow_stack::push_resume_ref_roots(locals_undo.as_mut_slice());
     }
     if !crate::state::write_back_outer_locals(ctx, vable_frame) {
         crate::state::restore_frame_locals(vable_frame, &locals_undo);
         majit_gc::shadow_stack::pop_resume_ref_roots_to(root_depth);
+        assert!(
+            !trace_too_long,
+            "preflighted trace-too-long locals publication declined"
+        );
         if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
             eprintln!("[fbw-blackhole] single-frame locals publish declined — legacy replay kept");
         }
         return false;
     }
+    for (&index, &forwarded) in image_ref_locations.iter().zip(&image_ref_roots) {
+        latched.miframe.ref_values[index] = Some(forwarded);
+    }
+    let committed_root_addr = latched
+        .miframe
+        .ref_values
+        .get(frame_reg as usize)
+        .copied()
+        .flatten()
+        .expect("preflighted frame register disappeared after forwarding")
+        as usize;
     // The locals publish is the last recoverable adoption gate. Its undo image
     // only needs rooting through that gate; after this point the blackhole may
     // execute irreversible effects and the handoff must commit or fail loudly,
     // never return to trace-entry replay.
     majit_gc::shadow_stack::pop_resume_ref_roots_to(root_depth);
     drop(locals_undo);
+    drop(image_ref_roots);
     let terminal = majit_metainterp::drive_single_frame_blackhole(
         &mut latched.miframe,
         majit_metainterp::blackhole::StateFieldLayout::default(),
@@ -2076,6 +2139,18 @@ fn try_adopt_single_frame_blackhole(
         latched.last_exc_value,
         latched.raising_exception,
     );
+    // Vable opcodes address the frame carried in the MIFrame's red register,
+    // i.e. the live frame whose locals were published above. Fold every
+    // blackhole write back into the tracing snapshot before the portal
+    // epilogue propagates that snapshot. This matters for terminal exceptions:
+    // their traceback keeps `tb_frame.f_locals` observable after the walk.
+    if committed_root_addr != cf_addr {
+        unsafe {
+            (*(cf_addr as *mut pyre_interpreter::PyFrame)).restore_resume_state_from(
+                &*(committed_root_addr as *const pyre_interpreter::PyFrame),
+            );
+        }
+    }
 
     // Its own prefix: this is not a decline, and reading it as one is exactly
     // the confusion that made the CRN arm look unreachable.

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -128,6 +128,10 @@ pub(crate) enum WalkEndCommitLeg {
     /// otherwise reports these walks as `committed=true leg=0`, which reads as
     /// "no leg" when it means "a commit path outside the leg contract".
     TerminateNoReplay = 8,
+    /// `SwitchToBlackhole(ABORT_TOO_LONG)`: the post-step MIFrame image was
+    /// converted to blackhole frames and run forward, never replayed from the
+    /// trace entry.
+    TraceTooLong = 9,
 }
 
 /// Where a committing leg puts the interpreter, relative to the effects the
@@ -1953,6 +1957,7 @@ fn try_adopt_single_frame_blackhole(
     ctx: &mut TraceCtx,
     cf_addr: usize,
     live_root_addr: usize,
+    commit_leg: WalkEndCommitLeg,
 ) -> bool {
     macro_rules! sfdbg {
         ($($a:tt)*) => {
@@ -2149,7 +2154,7 @@ fn try_adopt_single_frame_blackhole(
         crate::jitcode_dispatch::fbw_foriter_inflight_clear();
         // The blackhole ran the region to a frame terminal, so the resume is
         // the frame's RESULT, not a pc that re-runs anything.
-        let _ = commit_walk_end(WalkEndCommitLeg::VableEscape, WalkEndResume::Terminal);
+        let _ = commit_walk_end(commit_leg, WalkEndResume::Terminal);
         if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
             eprintln!(
                 "[fbw-blackhole] adopted single-frame terminal at jitcode_index={} \
@@ -2186,6 +2191,7 @@ fn try_adopt_multi_frame_blackhole(
     ctx: &mut TraceCtx,
     cf_addr: usize,
     live_root_addr: usize,
+    commit_leg: WalkEndCommitLeg,
 ) -> bool {
     // Every arm below returns to the legacy escape/replay path.  Name each one
     // under `PYRE_FBW_DEBUG_ABORT`, the way `build_multi_frame_miframe`'s
@@ -2581,7 +2587,7 @@ fn try_adopt_multi_frame_blackhole(
         crate::jitcode_dispatch::discard_escape_flush_undo();
         crate::jitcode_dispatch::fbw_foriter_inflight_clear();
         // Same as the single-frame adoption: a frame terminal, not a resume pc.
-        let _ = commit_walk_end(WalkEndCommitLeg::VableEscape, WalkEndResume::Terminal);
+        let _ = commit_walk_end(commit_leg, WalkEndResume::Terminal);
         if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
             eprintln!("[fbw-blackhole] adopted multi-frame terminal depth={depth}");
         }
@@ -2600,9 +2606,14 @@ fn try_adopt_multi_frame_blackhole(
     adopted
 }
 
-fn try_adopt_force_blackhole(ctx: &mut TraceCtx, cf_addr: usize, live_root_addr: usize) -> bool {
-    try_adopt_multi_frame_blackhole(ctx, cf_addr, live_root_addr)
-        || try_adopt_single_frame_blackhole(ctx, cf_addr, live_root_addr)
+fn try_adopt_blackhole(
+    ctx: &mut TraceCtx,
+    cf_addr: usize,
+    live_root_addr: usize,
+    commit_leg: WalkEndCommitLeg,
+) -> bool {
+    try_adopt_multi_frame_blackhole(ctx, cf_addr, live_root_addr, commit_leg)
+        || try_adopt_single_frame_blackhole(ctx, cf_addr, live_root_addr, commit_leg)
 }
 
 fn run_perfn_walk<Sym: WalkSym>(
@@ -3319,10 +3330,19 @@ fn run_perfn_walk<Sym: WalkSym>(
         // forward abort has already distinguished an outside mark from a mark
         // inside its discarded attempt.
         let live_root_addr = sym.live_vable_frame_addr();
-        let force_blackhole_adopted = matches!(
-            &walk_result,
-            Err(crate::jitcode_dispatch::DispatchError::VableEscapedDuringResidualCall { .. })
-        ) && try_adopt_force_blackhole(ctx, cf_addr, live_root_addr);
+        let trace_too_long_adopted =
+            matches!(
+                &walk_result,
+                Err(crate::jitcode_dispatch::DispatchError::TraceTooLong { .. })
+            ) && try_adopt_blackhole(ctx, cf_addr, live_root_addr, WalkEndCommitLeg::TraceTooLong);
+        let force_blackhole_adopted =
+            matches!(
+                &walk_result,
+                Err(crate::jitcode_dispatch::DispatchError::VableEscapedDuringResidualCall { .. })
+            ) && try_adopt_blackhole(ctx, cf_addr, live_root_addr, WalkEndCommitLeg::VableEscape);
+        if trace_too_long_adopted && crate::jitcode_dispatch::fbw_debug_abort_enabled() {
+            eprintln!("[fbw-blackhole] adopted ABORT_TOO_LONG forward resume");
+        }
         if !force_blackhole_adopted
             && matches!(
                 &walk_result,
@@ -3821,6 +3841,7 @@ fn run_perfn_walk<Sym: WalkSym>(
     let blackhole_terminal_no_replay = matches!(
         &walk_result,
         Err(crate::jitcode_dispatch::DispatchError::VableEscapedDuringResidualCall { .. })
+            | Err(crate::jitcode_dispatch::DispatchError::TraceTooLong { .. })
     ) && WALK_END_FLUSH_COMMITTED.with(|slot| slot.get())
         && crate::jitcode_dispatch::fbw_finish_concrete_peek().is_some();
     if !terminate_no_replay && !blackhole_terminal_no_replay {

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -80,6 +80,16 @@ thread_local! {
     /// from `ContinueRunningNormally` mirrors `_exit_frame_with_exception`.
     static WALK_END_PROPAGATED_EXCEPTION: std::cell::RefCell<Option<pyre_interpreter::PyError>> =
         const { std::cell::RefCell::new(None) };
+    /// Stable address for the in-flight walk-end exception carrier above.
+    ///
+    /// RPython keeps this value in the translated MIFrame / exception object
+    /// graph, which its root walker visits for every mutator. Pyre's
+    /// trace→portal seam is genuinely per-thread, but its raw TLS is outside
+    /// that graph, so the owning mutator publishes its address to the
+    /// collector's STW root-area registry.
+    static WALK_END_ROOT_AREA: WalkEndRootArea = WalkEndRootArea {
+        propagated_exception: WALK_END_PROPAGATED_EXCEPTION.with(|value| value as *const _),
+    };
     /// True at portal trace sites that can consume
     /// `WALK_END_PROPAGATED_EXCEPTION`. Bridge tracing leaves this false and
     /// conservatively retains its legacy preflight.
@@ -89,6 +99,10 @@ thread_local! {
     /// merge point's green pc, but the interpreter fallback must resume at
     /// the opcode whose entry stack matches the restored live boxes.
     static WALK_END_RESTART_PC: std::cell::Cell<Option<usize>> = const { std::cell::Cell::new(None) };
+}
+
+struct WalkEndRootArea {
+    propagated_exception: *const std::cell::RefCell<Option<pyre_interpreter::PyError>>,
 }
 
 /// Take-and-reset the walk-end flush flag for the trace that just
@@ -263,21 +277,34 @@ pub fn take_walk_end_propagated_exception() -> Option<pyre_interpreter::PyError>
     WALK_END_PROPAGATED_EXCEPTION.with(|c| c.borrow_mut().take())
 }
 
-/// Root the no-handler exception parked in `WALK_END_PROPAGATED_EXCEPTION`
-/// across the trace→portal boundary until `take_walk_end_propagated_exception`
-/// consumes it. The parked `PyError`'s GC refs are unreachable through the raw
-/// `RefCell`; forward them in place via `PyError::walk_gc_refs`. Never
-/// materialises the lazy-null `exc_object`.
+/// Capture this mutator's raw walk-end carrier address for STW root walking.
+pub fn capture_walk_end_root_area() -> *const () {
+    WALK_END_ROOT_AREA.with(|area| area as *const _ as *const ())
+}
+
+/// Root the no-handler exception parked across the trace→portal boundary until
+/// `take_walk_end_propagated_exception` consumes it. Forward its GC refs in
+/// place without materialising the lazy-null `exc_object`.
 pub fn walk_walk_end_propagated_exception(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
-    WALK_END_PROPAGATED_EXCEPTION.with(|c| {
-        // SAFETY: `as_ptr` yields the `Option<PyError>` interior; this closure
-        // holds the only reference for its duration and does not re-borrow the
-        // cell, so no borrow-flag conflict with a walker-triggered path.
-        let opt = unsafe { &mut *c.as_ptr() };
-        if let Some(err) = opt.as_mut() {
-            err.walk_gc_refs(visitor);
-        }
-    });
+    let data = capture_walk_end_root_area();
+    unsafe { walk_walk_end_roots_area(data, visitor) };
+}
+
+/// # Safety
+/// `data` must come from [`capture_walk_end_root_area`], and the owning
+/// mutator must be quiesced when a foreign collector thread calls this.
+pub unsafe fn walk_walk_end_roots_area(
+    data: *const (),
+    visitor: &mut dyn FnMut(&mut majit_ir::GcRef),
+) {
+    let area = unsafe { &*(data as *const WalkEndRootArea) };
+    let exception_cell = unsafe { &*area.propagated_exception };
+    // SAFETY: the owner is either synchronously collecting or STW-quiesced;
+    // no Rust borrow is live while the collector forwards these raw slots.
+    let opt = unsafe { &mut *exception_cell.as_ptr() };
+    if let Some(err) = opt.as_mut() {
+        err.walk_gc_refs(visitor);
+    }
 }
 
 thread_local! {
@@ -4921,6 +4948,46 @@ mod tests {
     use pyre_interpreter::bytecode::Instruction;
     use pyre_interpreter::compile_exec;
     use pyre_interpreter::decode_instruction_at;
+
+    #[test]
+    fn walk_end_root_area_forwards_a_quiesced_foreign_mutator() {
+        let (area_tx, area_rx) = std::sync::mpsc::channel();
+        let (resume_tx, resume_rx) = std::sync::mpsc::channel();
+        let (roots_tx, roots_rx) = std::sync::mpsc::channel();
+        let owner = std::thread::spawn(move || {
+            let mut err = pyre_interpreter::PyError::new(
+                pyre_interpreter::PyErrorKind::RuntimeError,
+                "foreign mutator root",
+            );
+            err.w_name_context = 0x3000 as pyre_object::PyObjectRef;
+            err.w_obj_context = 0x4000 as pyre_object::PyObjectRef;
+            super::WALK_END_PROPAGATED_EXCEPTION.with(|slot| {
+                *slot.borrow_mut() = Some(err);
+            });
+            area_tx
+                .send(super::capture_walk_end_root_area() as usize)
+                .unwrap();
+            resume_rx.recv().unwrap();
+            super::WALK_END_PROPAGATED_EXCEPTION.with(|slot| {
+                let err = slot.borrow_mut().take().unwrap();
+                roots_tx
+                    .send((err.w_name_context as usize, err.w_obj_context as usize))
+                    .unwrap();
+            });
+        });
+
+        let area = area_rx.recv().unwrap() as *const ();
+        // The owner is blocked after publishing its stable TLS addresses,
+        // matching the mutator quiescence required by the STW registry.
+        unsafe {
+            super::walk_walk_end_roots_area(area, &mut |root| {
+                *root = majit_ir::GcRef(root.as_usize() + 0x20);
+            });
+        }
+        resume_tx.send(()).unwrap();
+        assert_eq!(roots_rx.recv().unwrap(), (0x3020, 0x4020));
+        owner.join().unwrap();
+    }
 
     /// The walk-end commit contract: only a resume pc that does not precede
     /// something the walk already applied may keep the store journal.

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -1946,8 +1946,9 @@ fn adopt_blackhole_crn(snapshot: usize, live_root: usize, resume_py_pc: usize) {
 /// and `ExitFrameWithExceptionRef` record a concrete frame result, and
 /// `ContinueRunningNormally` hands the frame over through
 /// [`adopt_blackhole_crn`], which validates nothing because it rebuilds
-/// nothing.  The one `false` left in the match is an empty green list, a
-/// codewriter contract violation with no upstream counterpart.
+/// nothing. An empty green list is a codewriter contract violation with no
+/// upstream counterpart, so it fails loudly instead of returning to replay
+/// after the drive has executed.
 ///
 /// Over `pyre/bench/synth` that is 50 frame-terminal adoptions plus 15 CRN
 /// adoptions (five each from the three `getframe_root_loop_force_*` fixtures),
@@ -2047,7 +2048,6 @@ fn try_adopt_single_frame_blackhole(
     let Some(mut locals_undo) = crate::state::capture_frame_locals(vable_frame) else {
         return false;
     };
-    let scalars_undo = crate::state::capture_frame_scalars(vable_frame);
     let root_depth = majit_gc::shadow_stack::resume_ref_roots_depth();
     unsafe {
         majit_gc::shadow_stack::push_resume_ref_roots(locals_undo.as_mut_slice());
@@ -2060,10 +2060,12 @@ fn try_adopt_single_frame_blackhole(
         }
         return false;
     }
-    // The undo image stays rooted across the drive.  The publish overwrote the
-    // slots it was taken from, so these words are the only remaining reference
-    // to the pre-walk locals, and a collection inside the drive would both free
-    // them and leave the withdrawal below writing back pre-move addresses.
+    // The locals publish is the last recoverable adoption gate. Its undo image
+    // only needs rooting through that gate; after this point the blackhole may
+    // execute irreversible effects and the handoff must commit or fail loudly,
+    // never return to trace-entry replay.
+    majit_gc::shadow_stack::pop_resume_ref_roots_to(root_depth);
+    drop(locals_undo);
     let terminal = majit_metainterp::drive_single_frame_blackhole(
         &mut latched.miframe,
         majit_metainterp::blackhole::StateFieldLayout::default(),
@@ -2096,95 +2098,61 @@ fn try_adopt_single_frame_blackhole(
             }
         );
     }
-    let adopted = match terminal.outcome {
+    match terminal.outcome {
         majit_metainterp::jitexc::JitException::ContinueRunningNormally {
             ref green_int, ..
-        } => match green_int.first() {
-            Some(&resume_py_pc) => {
-                let resume_py_pc = resume_py_pc as usize;
-                adopt_blackhole_crn(cf_addr, vable_frame, resume_py_pc);
-                sfdbg!("adopted with green resume_py_pc={resume_py_pc}");
-                WALK_END_RESTART_PC.with(|slot| slot.set(Some(resume_py_pc)));
-                true
-            }
-            None => {
-                // The last post-drive decline in this arm, and a codewriter
-                // contract violation rather than a runtime condition: the
-                // portal's `jit_merge_point` carries `py_pc` as its first int
-                // green, so an empty list means the op was emitted without its
-                // greens.  Upstream indexes the greens unconditionally
-                // (`warmspot.py:973-976` `getattr(e, attrname)[count]`), so it
-                // has no decline for this to correspond to.
-                sfdbg!("ContinueRunningNormally with no green int");
-                false
-            }
-        },
+        } => {
+            // The portal's `jit_merge_point` carries `py_pc` as its first int
+            // green. Upstream indexes that green unconditionally
+            // (`warmspot.py:973-976`); a missing one is a codewriter invariant
+            // failure, never a licence to replay an already-driven region.
+            let &resume_py_pc = green_int.first().expect(
+                "post-blackhole ContinueRunningNormally has no resume pc; \
+                 replay is forbidden after blackhole effects",
+            );
+            let resume_py_pc = resume_py_pc as usize;
+            adopt_blackhole_crn(cf_addr, vable_frame, resume_py_pc);
+            sfdbg!("adopted with green resume_py_pc={resume_py_pc}");
+            WALK_END_RESTART_PC.with(|slot| slot.set(Some(resume_py_pc)));
+        }
         majit_metainterp::jitexc::JitException::DoneWithThisFrameVoid => {
             crate::jitcode_dispatch::fbw_finish_concrete_set(crate::state::ConcreteValue::Null);
-            true
         }
         majit_metainterp::jitexc::JitException::DoneWithThisFrameInt(value) => {
             crate::jitcode_dispatch::fbw_finish_concrete_set(crate::state::ConcreteValue::Int(
                 value,
             ));
-            true
         }
         majit_metainterp::jitexc::JitException::DoneWithThisFrameRef(value) => {
             crate::jitcode_dispatch::fbw_finish_concrete_set(crate::state::ConcreteValue::Ref(
                 value.as_usize() as pyre_object::PyObjectRef,
             ));
-            true
         }
         majit_metainterp::jitexc::JitException::DoneWithThisFrameFloat(value) => {
             crate::jitcode_dispatch::fbw_finish_concrete_set(crate::state::ConcreteValue::Float(
                 value,
             ));
-            true
         }
         majit_metainterp::jitexc::JitException::ExitFrameWithExceptionRef(value) => {
             crate::jitcode_dispatch::fbw_finish_raise_set(crate::state::ConcreteValue::Ref(
                 value.as_usize() as pyre_object::PyObjectRef,
             ));
-            true
-        }
-    };
-    if adopted {
-        let _ = crate::jitcode_dispatch::take_committed_frame_escape_pc();
-        crate::jitcode_dispatch::discard_escape_flush_undo();
-        crate::jitcode_dispatch::fbw_foriter_inflight_clear();
-        // The blackhole ran the region to a frame terminal, so the resume is
-        // the frame's RESULT, not a pc that re-runs anything.
-        let _ = commit_walk_end(commit_leg, WalkEndResume::Terminal);
-        if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
-            eprintln!(
-                "[fbw-blackhole] adopted single-frame terminal at jitcode_index={} \
-                 position={} last_opcode_position={}",
-                jitcode_index, terminal.position, terminal.last_opcode_position,
-            );
-        }
-    } else {
-        // Only the empty-green-list arm gets here, and that is a codewriter
-        // contract violation rather than a runtime outcome.  This returns to the
-        // legacy escape/replay path, which resumes the frame from its pre-walk
-        // state — the state `restore_escape_flush_undo` puts back for the flush
-        // half.  The publish above and the drive's own vable stores both landed
-        // on this frame, so both have to come off.  The drive reached the
-        // frame's scalars through `setfield_vable_i`, for which no undo image
-        // exists anywhere else: the store journal covers heap effects and
-        // `fbw_exit_last_instr_rollback` only arms on a return or void-return
-        // exit, which an unadoptable terminal is not.
-        //
-        // ⚠️Putting the FRAME back is all this can do.  The drive already ran,
-        // so any heap effect in the region it executed stays, and the replay
-        // performs it a second time.  That is why no new post-drive decline may
-        // be added here: the withdrawal looks total and is not.
-        crate::state::restore_frame_locals(vable_frame, &locals_undo);
-        if let Some(scalars) = scalars_undo {
-            crate::state::restore_frame_scalars(vable_frame, scalars);
         }
     }
-    majit_gc::shadow_stack::pop_resume_ref_roots_to(root_depth);
-    adopted
+    let _ = crate::jitcode_dispatch::take_committed_frame_escape_pc();
+    crate::jitcode_dispatch::discard_escape_flush_undo();
+    crate::jitcode_dispatch::fbw_foriter_inflight_clear();
+    // The blackhole ran the region to a frame terminal, so the resume is
+    // the frame's RESULT, not a pc that re-runs anything.
+    let _ = commit_walk_end(commit_leg, WalkEndResume::Terminal);
+    if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
+        eprintln!(
+            "[fbw-blackhole] adopted single-frame terminal at jitcode_index={} \
+             position={} last_opcode_position={}",
+            jitcode_index, terminal.position, terminal.last_opcode_position,
+        );
+    }
+    true
 }
 
 fn try_adopt_multi_frame_blackhole(
@@ -2204,12 +2172,10 @@ fn try_adopt_multi_frame_blackhole(
     // that already ran and hand back to a caller that replays it, and no undo
     // reaches the heap effects that chain committed.
     //
-    // Exactly one post-drive decline survives here, the empty `green_int`, and
-    // it is a codewriter contract violation rather than a runtime outcome.  The
-    // three that used to sit beside it — no terminal image, terminal jitcode
-    // index out of i32 range, and the register-image rebuild's own rejection —
-    // all existed only to serve that rebuild, and went with it when the CRN
-    // handoff became [`adopt_blackhole_crn`].
+    // No post-drive decline survives here. An empty `green_int` is a codewriter
+    // invariant failure rather than a runtime outcome; the three checks that
+    // used to sit beside it existed only for the retired register-image
+    // rebuild.
     //
     // Note that they could not have been hoisted instead.  The rebuild's index
     // here is `terminal.jitcode_index` = `bh.jitcode.index()` of whichever
@@ -2422,7 +2388,6 @@ fn try_adopt_multi_frame_blackhole(
         restore_links(&saved_links);
         return false;
     };
-    let scalars_undo = crate::state::capture_frame_scalars(root_addr);
     let undo_depth = majit_gc::shadow_stack::resume_ref_roots_depth();
     unsafe {
         majit_gc::shadow_stack::push_resume_ref_roots(locals_undo.as_mut_slice());
@@ -2434,8 +2399,11 @@ fn try_adopt_multi_frame_blackhole(
         mfdbg!("frame 0: {root_addr:#x} locals publish declined");
         return false;
     }
-    // Rooted across the drive for the same reason as the single-frame arm: the
-    // publish overwrote the slots these words came from.
+    // As in the single-frame path, locals publication is the final recoverable
+    // gate. Once the roots are released and the chain starts running, adoption
+    // is irrevocable.
+    majit_gc::shadow_stack::pop_resume_ref_roots_to(undo_depth);
+    drop(locals_undo);
     let ec = unsafe {
         (*(cf_addr as *mut pyre_interpreter::PyFrame)).execution_context
             as *mut pyre_interpreter::PyExecutionContext
@@ -2505,15 +2473,14 @@ fn try_adopt_multi_frame_blackhole(
                 .restore_resume_state_from(&*(root_addr as *const pyre_interpreter::PyFrame));
         }
     }
-    let adopted = match outcome {
+    match outcome {
         majit_metainterp::jitexc::JitException::ContinueRunningNormally {
-            ref green_int,
-            ..
-        } => 'crn: {
-            let Some(&resume_py_pc) = green_int.first() else {
-                mfdbg!("ContinueRunningNormally with no green int");
-                break 'crn false;
-            };
+            ref green_int, ..
+        } => {
+            let &resume_py_pc = green_int.first().expect(
+                "post-blackhole ContinueRunningNormally has no resume pc; \
+                 replay is forbidden after blackhole effects",
+            );
             let resume_py_pc = resume_py_pc as usize;
             // `resume_py_pc` is deliberately NOT checked.  It is a
             // `depth_at_py_pc` index written through to
@@ -2551,59 +2518,40 @@ fn try_adopt_multi_frame_blackhole(
             // chain that had already run back to a replay.
             adopt_blackhole_crn(cf_addr, root_addr, resume_py_pc);
             WALK_END_RESTART_PC.with(|slot| slot.set(Some(resume_py_pc)));
-            true
         }
         majit_metainterp::jitexc::JitException::DoneWithThisFrameVoid => {
             crate::jitcode_dispatch::fbw_finish_concrete_set(crate::state::ConcreteValue::Null);
-            true
         }
         majit_metainterp::jitexc::JitException::DoneWithThisFrameInt(value) => {
             crate::jitcode_dispatch::fbw_finish_concrete_set(crate::state::ConcreteValue::Int(
                 value,
             ));
-            true
         }
         majit_metainterp::jitexc::JitException::DoneWithThisFrameRef(value) => {
             crate::jitcode_dispatch::fbw_finish_concrete_set(crate::state::ConcreteValue::Ref(
                 value.as_usize() as pyre_object::PyObjectRef,
             ));
-            true
         }
         majit_metainterp::jitexc::JitException::DoneWithThisFrameFloat(value) => {
             crate::jitcode_dispatch::fbw_finish_concrete_set(crate::state::ConcreteValue::Float(
                 value,
             ));
-            true
         }
         majit_metainterp::jitexc::JitException::ExitFrameWithExceptionRef(value) => {
             crate::jitcode_dispatch::fbw_finish_raise_set(crate::state::ConcreteValue::Ref(
                 value.as_usize() as pyre_object::PyObjectRef,
             ));
-            true
         }
-    };
-    if adopted {
-        let _ = crate::jitcode_dispatch::take_committed_frame_escape_pc();
-        crate::jitcode_dispatch::discard_escape_flush_undo();
-        crate::jitcode_dispatch::fbw_foriter_inflight_clear();
-        // Same as the single-frame adoption: a frame terminal, not a resume pc.
-        let _ = commit_walk_end(commit_leg, WalkEndResume::Terminal);
-        if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
-            eprintln!("[fbw-blackhole] adopted multi-frame terminal depth={depth}");
-        }
-    } else {
-        // Same withdrawal as the single-frame arm: an unadoptable terminal
-        // returns to legacy escape/replay, which resumes the walked frame from
-        // its pre-walk state.  The chain the drive was given comes down with it,
-        // and so do the frame scalars the drive moved.
-        crate::state::restore_frame_locals(root_addr, &locals_undo);
-        if let Some(scalars) = scalars_undo {
-            crate::state::restore_frame_scalars(root_addr, scalars);
-        }
-        restore_links(&saved_links);
     }
-    majit_gc::shadow_stack::pop_resume_ref_roots_to(undo_depth);
-    adopted
+    let _ = crate::jitcode_dispatch::take_committed_frame_escape_pc();
+    crate::jitcode_dispatch::discard_escape_flush_undo();
+    crate::jitcode_dispatch::fbw_foriter_inflight_clear();
+    // Same as the single-frame adoption: a frame terminal, not a resume pc.
+    let _ = commit_walk_end(commit_leg, WalkEndResume::Terminal);
+    if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
+        eprintln!("[fbw-blackhole] adopted multi-frame terminal depth={depth}");
+    }
+    true
 }
 
 fn try_adopt_blackhole(

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -3437,18 +3437,14 @@ fn install_gc_root_walkers() {
     // Children of the off-GC exception singletons, which no carrier and no
     // collection phase reaches on its own.
     majit_gc::shadow_stack::register_extra_root_walker(walk_immortal_exception_singleton_roots);
-    // Stored `PyError` carriers whose GC refs the precise collector cannot
-    // reach through their raw TLS cells: the call-assembler FFI stash and the
-    // no-handler trace→portal stash. Mirrors `walk_pending_call_error`.
+    // Stored `PyError` carrier whose GC refs the precise collector cannot
+    // reach through its raw TLS cell. Mirrors `walk_pending_call_error`.
     majit_gc::shadow_stack::register_extra_root_walker(crate::call_jit::walk_last_ca_exception);
     // Exception parked for the next interpreter call boundary (JIT prologue
     // overflow, or a jd1 drain error handed back to the caller loop): live in
     // a raw TLS cell across the collecting code that runs before the drain.
     majit_gc::shadow_stack::register_extra_root_walker(
         pyre_interpreter::stack_check::walk_jit_pending_exception,
-    );
-    majit_gc::shadow_stack::register_extra_root_walker(
-        pyre_jit_trace::trace::walk_walk_end_propagated_exception,
     );
     // Trace-time exception carriers held only in the active `PyreSym`
     // (`trace_built_exc` / `last_exc_value` / `current_exc_value`): a
@@ -3485,6 +3481,10 @@ fn register_thread_root_areas() {
         register(
             fbw_finish_concrete_root_walker_area,
             pyre_jit_trace::jitcode_dispatch::capture_fbw_finish_concrete_root_area(),
+        );
+        register(
+            walk_end_root_walker_area,
+            pyre_jit_trace::trace::capture_walk_end_root_area(),
         );
         register(
             mapdict_root_walker_area,
@@ -4070,6 +4070,13 @@ unsafe fn fbw_finish_concrete_root_walker_area(
     unsafe {
         pyre_jit_trace::jitcode_dispatch::fbw_finish_concrete_root_walker_area(data, visitor)
     };
+}
+
+unsafe fn walk_end_root_walker_area(
+    data: *const (),
+    visitor: &mut dyn FnMut(&mut majit_ir::GcRef),
+) {
+    unsafe { pyre_jit_trace::trace::walk_walk_end_roots_area(data, visitor) };
 }
 
 unsafe fn mapdict_root_walker_area(data: *const (), visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {

--- a/pyre/pyre-object/src/gc_hook.rs
+++ b/pyre/pyre-object/src/gc_hook.rs
@@ -608,34 +608,92 @@ pub extern "C" fn try_gc_write_barrier(obj: *mut u8) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::atomic::{AtomicUsize, Ordering};
 
-    // The hook cells are process-global. These tests are the only hook
-    // *installers* in this binary, so they take this lock first to serialize
-    // against each other — that keeps every "unregistered/cleared -> None/false"
-    // assertion sound (no other test installs a hook concurrently).
+    // The hook cells are process-global, and every allocator in this crate
+    // reads them with no gate — `malloc_typed_managed`, `alloc_dict_object`,
+    // `w_weakref_new`, `alloc_items_block_gc`,
+    // `try_alloc_typed_items_block_nursery`, `alloc_rbigint_nursery_impl`, …
+    // So from `register_*` until the matching `clear_*` an installed mock
+    // answers *every* thread in this binary, and libtest runs the other tests
+    // on their own threads concurrently. That shapes the mocks twice over:
     //
-    // Assertions on a mock's *invocation* are a separate concern: the alloc and
-    // root hooks are read only behind `gc_interp::enabled()` / a registered
-    // backend type id, both off by default in this binary, so no concurrent
-    // production path invokes those mocks — their arg-recording statics are safe
-    // under `cargo test`. (They are NOT safe under `PYRE_GC_INTERP=1`, which is
-    // never set for a pyre-object test run.) The write-barrier hook has ungated
-    // production callers, so its test asserts on the `try_*` return value rather
-    // than a shared counter.
+    //   * a mock must return memory the caller can build its object in.
+    //     A synthetic pointer value took the process down:
+    //     `try_alloc_typed_items_block_nursery` writes the capacity header
+    //     through whatever the hook returns, so a concurrent
+    //     `try_gc_alloc(tid, 24)` stored to address 0x18.
+    //   * a mock must record its arguments per thread. A concurrent allocation
+    //     calls the same mock with its own type id and size, and a shared cell
+    //     would carry that call's values into the installing test's assertions.
+    //
+    // The lock below only serializes the installers against each other; that is
+    // what keeps the "unregistered/cleared -> None/false" assertions sound.
     static HOOK_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
     fn hook_test_guard() -> std::sync::MutexGuard<'static, ()> {
         HOOK_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner())
     }
 
-    static LAST_TYPE_ID: AtomicUsize = AtomicUsize::new(0);
-    static LAST_SIZE: AtomicUsize = AtomicUsize::new(0);
+    /// What the mock allocator was last asked for on this thread, and what it
+    /// handed back.
+    #[derive(Clone, Copy)]
+    struct MockCall {
+        type_id: u32,
+        payload_size: usize,
+        ptr: *mut u8,
+    }
+
+    thread_local! {
+        static LAST_MOCK_CALL: std::cell::Cell<Option<MockCall>> =
+            const { std::cell::Cell::new(None) };
+    }
+
+    fn last_mock_call() -> MockCall {
+        LAST_MOCK_CALL
+            .with(|cell| cell.get())
+            .expect("the mock allocator was not invoked on this thread")
+    }
+
+    /// Alignment of the mock's blocks.
+    ///
+    /// `ItemsBlock` / `TypedItemsBlock` are the only payloads this crate hands
+    /// back to `std::alloc::dealloc` (`dealloc_items_block` /
+    /// `dealloc_typed_items_block`, reached here because no owns-object hook is
+    /// installed), and both lead with a `usize` capacity header — so matching
+    /// that alignment makes those frees exact instead of layout-mismatched.
+    /// Every other payload routed through these hooks is a `repr(C)` struct of
+    /// pointer / `usize` / `u64` / `f64` fields, which this covers too.
+    const MOCK_ALIGN: usize = std::mem::align_of::<usize>();
+
+    const _: () = assert!(MOCK_ALIGN == std::mem::align_of::<crate::object_array::ItemsBlock>());
+    const _: () =
+        assert!(MOCK_ALIGN == std::mem::align_of::<crate::object_array::TypedItemsBlock>());
+
+    /// Real, zeroed memory of exactly `payload_size` bytes — what a GC
+    /// allocator returns — or null when the request cannot be served, which is
+    /// the failure [`GcAllocHookFn`] specifies. Reporting that faithfully is
+    /// load-bearing: `RBigInt::lshift(i64::MAX)` asks for a block no allocator
+    /// can hand out and expects `RBigIntError::Memory` back.
+    ///
+    /// A block whose caller does not free it stays leaked for the rest of the
+    /// run, which is what the collector this stands in for would do with it.
+    fn mock_alloc(payload_size: usize) -> *mut u8 {
+        let Ok(layout) = std::alloc::Layout::from_size_align(payload_size.max(1), MOCK_ALIGN)
+        else {
+            return std::ptr::null_mut();
+        };
+        unsafe { std::alloc::alloc_zeroed(layout) }
+    }
 
     fn mock_hook(type_id: u32, payload_size: usize) -> *mut u8 {
-        LAST_TYPE_ID.store(type_id as usize, Ordering::Relaxed);
-        LAST_SIZE.store(payload_size, Ordering::Relaxed);
-        // Return a non-null dummy pointer. Tests don't dereference it.
-        payload_size as *mut u8
+        let ptr = mock_alloc(payload_size);
+        LAST_MOCK_CALL.with(|cell| {
+            cell.set(Some(MockCall {
+                type_id,
+                payload_size,
+                ptr,
+            }))
+        });
+        ptr
     }
 
     fn null_hook(_type_id: u32, _payload_size: usize) -> *mut u8 {
@@ -673,10 +731,10 @@ mod tests {
         let _hook_lock = hook_test_guard();
         register_gc_alloc_hook(mock_hook);
         let ptr = try_gc_alloc(7, 24);
-        assert!(ptr.is_some());
-        assert_eq!(ptr.unwrap() as usize, 24);
-        assert_eq!(LAST_TYPE_ID.load(Ordering::Relaxed), 7);
-        assert_eq!(LAST_SIZE.load(Ordering::Relaxed), 24);
+        let call = last_mock_call();
+        assert_eq!(ptr, Some(call.ptr));
+        assert_eq!(call.type_id, 7);
+        assert_eq!(call.payload_size, 24);
         clear_gc_alloc_hook();
     }
 
@@ -713,15 +771,20 @@ mod tests {
         clear_gc_alloc_hook();
     }
 
-    static LAST_ROOT_PTR: AtomicUsize = AtomicUsize::new(0);
-    static REMOVE_CALLS: AtomicUsize = AtomicUsize::new(0);
+    // Per-thread for the same reason the allocation record is: while these
+    // hooks are installed, `try_gc_alloc_collecting_rooted`'s fallback pins and
+    // unpins the caller's slot, and that runs on whichever thread allocates.
+    thread_local! {
+        static LAST_ROOT_PTR: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+        static REMOVE_CALLS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+    }
 
     unsafe fn mock_add_root(slot: *mut *mut u8) {
-        LAST_ROOT_PTR.store(slot as usize, Ordering::Relaxed);
+        LAST_ROOT_PTR.with(|cell| cell.set(slot as usize));
     }
     fn mock_remove_root(slot: *mut *mut u8) {
         let _ = slot;
-        REMOVE_CALLS.fetch_add(1, Ordering::Relaxed);
+        REMOVE_CALLS.with(|cell| cell.set(cell.get() + 1));
     }
 
     fn mock_write_barrier(_obj: *mut u8) {}
@@ -734,15 +797,15 @@ mod tests {
         assert!(!unsafe { try_gc_add_root(&mut slot as *mut *mut u8) });
         assert!(!try_gc_remove_root(&mut slot as *mut *mut u8));
 
-        LAST_ROOT_PTR.store(0, Ordering::Relaxed);
-        REMOVE_CALLS.store(0, Ordering::Relaxed);
+        LAST_ROOT_PTR.with(|cell| cell.set(0));
+        REMOVE_CALLS.with(|cell| cell.set(0));
         register_gc_root_hooks(mock_add_root, mock_remove_root);
 
         let slot_ptr = &mut slot as *mut *mut u8;
         assert!(unsafe { try_gc_add_root(slot_ptr) });
-        assert_eq!(LAST_ROOT_PTR.load(Ordering::Relaxed), slot_ptr as usize);
+        assert_eq!(LAST_ROOT_PTR.with(|cell| cell.get()), slot_ptr as usize);
         assert!(try_gc_remove_root(slot_ptr));
-        assert_eq!(REMOVE_CALLS.load(Ordering::Relaxed), 1);
+        assert_eq!(REMOVE_CALLS.with(|cell| cell.get()), 1);
 
         clear_gc_root_hooks();
         assert!(!unsafe { try_gc_add_root(slot_ptr) });
@@ -764,10 +827,10 @@ mod tests {
 
         register_gc_alloc_stable_hook(mock_hook);
         let ptr = try_gc_alloc_stable(3, 32);
-        assert!(ptr.is_some());
-        assert_eq!(ptr.unwrap() as usize, 32);
-        assert_eq!(LAST_TYPE_ID.load(Ordering::Relaxed), 3);
-        assert_eq!(LAST_SIZE.load(Ordering::Relaxed), 32);
+        let call = last_mock_call();
+        assert_eq!(ptr, Some(call.ptr));
+        assert_eq!(call.type_id, 3);
+        assert_eq!(call.payload_size, 32);
 
         clear_gc_alloc_hook();
         clear_gc_alloc_stable_hook();
@@ -782,12 +845,12 @@ mod tests {
 
         register_gc_alloc_hook(mock_hook);
         let result = try_gc_alloc_with_placement(7, 24, &mut needs_write_barrier);
-        assert_eq!(result, Some(24usize as *mut u8));
+        assert_eq!(result, Some(last_mock_call().ptr));
         assert!(needs_write_barrier);
 
         register_gc_alloc_with_placement_hook(nursery_placement_hook);
         let result = try_gc_alloc_with_placement(7, 24, &mut needs_write_barrier);
-        assert_eq!(result, Some(24usize as *mut u8));
+        assert_eq!(result, Some(last_mock_call().ptr));
         assert!(!needs_write_barrier);
 
         clear_gc_alloc_hook();
@@ -806,14 +869,14 @@ mod tests {
         register_gc_alloc_collecting_hook(mock_hook);
         let result =
             unsafe { try_gc_alloc_collecting_rooted(7, 24, &mut root, &mut needs_write_barrier) };
-        assert_eq!(result, Some(24usize as *mut u8));
+        assert_eq!(result, Some(last_mock_call().ptr));
         assert!(needs_write_barrier);
 
         register_gc_alloc_collecting_rooted_hook(nursery_rooted_hook);
         needs_write_barrier = true;
         let result =
             unsafe { try_gc_alloc_collecting_rooted(7, 24, &mut root, &mut needs_write_barrier) };
-        assert_eq!(result, Some(24usize as *mut u8));
+        assert_eq!(result, Some(last_mock_call().ptr));
         assert!(!needs_write_barrier);
 
         clear_gc_alloc_collecting_hook();


### PR DESCRIPTION
## Summary

The full-body walker carried a documented deviation from
`SwitchToBlackhole(ABORT_TOO_LONG)`, and the cost of that deviation was that the
trace-length check could not fire on the walks that need it most.

RPython calls `blackhole_if_trace_too_long()` immediately after
`MIFrame.run_one_step()`, and `convert_and_run_from_pyjitpl` copies every live
MIFrame at its already-advanced `pc` (`pyjitpl.py:2863-2866`,
`blackhole.py:1799-1821`) so the interpreter continues **forward** from the
traced state. pyre instead raised a `DispatchError`, which resumes by
re-interpreting the iteration from the trace entry. Any irreversible effect the
walk had already executed would then be applied twice.

The previous guard avoided that corruption by declining to abort at all:

```rust
if ctx.trace_ctx.is_too_long() {
    if fbw_executed_effect_count() != 0 {
        majit_metainterp::mc_diag_bump(26);   // keep recording, unbounded
    } else {
        /* ... abort ... */
    }
}
```

So the length bound only held for a walk that had executed no effect yet. An
effectful walk kept recording — the unbounded behaviour that counter was there
to make visible rather than to fix.

### The forward handoff

`latch_trace_too_long_blackhole` snapshots the live meta-interpreter framestack
while the `WalkContext` still owns it, at `walk()`'s post-step `next_pc` — not
`opcode_position`. `blackhole_if_trace_too_long` raises *after* the step, so the
image has to carry the advanced pc. The run-per-fn epilogue then adopts that
image and drives it forward, the way `run_blackhole_interp_to_cancel_tracing`
does.

Both shapes are covered: a single live frame goes through
`build_single_frame_miframe`, and an inline subwalk with paused callers goes
through `build_multi_frame_miframe` when multi-frame blackhole resume is enabled.

`try_adopt_force_blackhole` becomes `try_adopt_blackhole` and takes the commit
leg as a parameter, so the vable-escape path and the new length path share the
adoption machinery without reporting the same leg.

### Distinguishing the commit

`WalkEndCommitLeg::TraceTooLong = 9` is new. Both adoption sites previously
hardcoded `VableEscape`, so without it these commits would be indistinguishable
in the walk-end tallies from "a virtualizable escaped during a residual call".

### Concrete values for the image

`vable_value_concrete` resolves a register operand's concrete half from the
parallel concrete bank first, falling back to the OpRef's intrinsic value.
RPython's MIFrame banks hold Box objects, so assigning a valuebox to
`virtualizable_boxes` carries its concrete value along; pyre splits that Box
between an OpRef bank and a concrete bank, and a residual result does not
necessarily have a value attached to its OpRef — only the authoritative walker's
concrete bank knows it. Reading the OpRef alone would publish a hole into the
forward image.

### Fallbacks that stay

A complete image makes the abort safe regardless of effects. When one cannot be
built, the old behaviour is kept exactly:

- a zero-effect walk still takes the legacy entry replay;
- an effectful walk still keeps recording, because replaying it would apply an
  irreversible effect twice.

The remaining overshoot is still tallied (`mc_diag_bump(26)`), so an unsupported
frame shape cannot silently become unbounded recording again.

### Coverage

`pyre/bench/synth/trace_too_long_effect_replay.py` gains Phase C: a
function-entry trace, whose root is pc 0 rather than a loop header. The root key
is therefore never revisited, so `ABORT_TOO_LONG`'s forward handoff is the only
thing bounding the recording. It returns three independently observable mutation
classes (list element, dict value, list length) alongside the sum, so a handoff
that replayed from function entry would show up as a doubled count rather than
as a timing difference.

## Self-review

This patch is AI-assisted.

This description was written by reading the diff, in a different session from
the one that wrote the code, and it has not been through a separate review pass.
Two things a reviewer should not take on trust from it:

- **The multi-frame path is the new risk.** Single-frame adoption already had a
  caller in the vable-escape path; driving an inline-subwalk framestack forward
  from a length abort is the new shape, and it is gated on
  `multi_frame_blackhole_resume_enabled()`. Whether every paused caller's banks
  are complete at that point is the claim worth checking against
  `build_multi_frame_miframe`'s own preconditions.
- **`pyre/check.py` was not run against this branch by the session that opened
  the PR.** CI on this head is the first end-to-end signal.

`latch_trace_too_long_blackhole` documents the invariant it depends on — return
`false` without publishing a partial image when any live value is unresolved —
so the reviewable question is whether every early return in the builders it
calls actually upholds that. A partially filled image would still be adopted and
run forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability when JIT traces exceed their configured length by making abort/replay decisions more precise and preventing unintended side-effect replays.
  * Preserved correct concrete values for virtualized operands and mutable data during trace recovery.
  * Strengthened exception and garbage-collection root forwarding across trace transitions, reducing stale references and data loss.

* **Tests**
  * Added/extended unit coverage for trace-too-long snapshot behavior, frame-transition handling, and single-frame recovery.
  * Improved GC-hook test infrastructure for reliable multithreaded test execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->