### PR TITLE
descr gate: state the invariants as jit-stats badness counters, and repair the floor that was silently disarmed

### DIFF
--- a/majit/majit-ir/src/descr.rs
+++ b/majit/majit-ir/src/descr.rs
@@ -103,6 +103,7 @@ use std::sync::Weak;
 use std::sync::atomic::{AtomicI32, AtomicU32, AtomicU64, Ordering};
 
 use crate::OpRef;
+use crate::effectinfo::{DescrMintEntry, DescrMintSpec, DescrSetMember};
 use crate::resoperation::{GuardPendingFieldEntry, RdVirtualInfo};
 use crate::value::{Const, Type};
 use serde::{Deserialize, Serialize};
@@ -1563,6 +1564,51 @@ static GC_CACHE: OnceLock<Mutex<GcCache>> = OnceLock::new();
 pub fn gc_cache() -> &'static Mutex<GcCache> {
     GC_CACHE.get_or_init(|| Mutex::new(GcCache::new()))
 }
+
+/// The mint arguments behind every `GcCache` slot an `EffectInfo` raw set
+/// names — the projection of this cache that has to survive the
+/// analyzer→runtime process split.
+///
+/// Upstream needs no such table: `setup_descrs` (`descr.py:25-47`) snapshots
+/// the one gccache the raw-set descrs were minted into, so
+/// `compute_bitstrings` (`effectinfo.py:465-499`) unions descrs that are
+/// already present. Pyre carries only the assembler's opcode table across
+/// (`pyjitpl.py:2261 setup_descrs(asm.descrs)`), so a descr minted *solely* for
+/// a raw set — referenced by no opcode — would otherwise have no slot to
+/// resolve against on the far side.
+///
+/// Insertion-ordered and keyed by the member, so a repeated mint of the same
+/// `(STRUCT, fieldname)` records once, exactly as the cache itself dedups.
+static EI_DESCR_MINTS: OnceLock<Mutex<indexmap::IndexMap<DescrSetMember, DescrMintSpec>>> =
+    OnceLock::new();
+
+fn ei_descr_mints() -> &'static Mutex<indexmap::IndexMap<DescrSetMember, DescrMintSpec>> {
+    EI_DESCR_MINTS.get_or_init(|| Mutex::new(indexmap::IndexMap::new()))
+}
+
+/// Record how a raw-set member's slot was filled, at the mint site where the
+/// layout is in scope. First writer wins, matching the cache-or-mint order in
+/// `descr.py:220-233`.
+pub fn record_ei_descr_mint(member: DescrSetMember, spec: DescrMintSpec) {
+    ei_descr_mints()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .entry(member)
+        .or_insert(spec);
+}
+
+/// Every recorded `(member, mint spec)` pair, in mint order.
+pub fn ei_descr_mints_snapshot() -> Vec<DescrMintEntry> {
+    ei_descr_mints()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .iter()
+        .map(|(member, spec)| DescrMintEntry {
+            member: member.clone(),
+            spec: spec.clone(),
+        })
+        .collect()
+}
 /// history.py: TargetToken / JitCellToken identity. PyPy keys
 /// `target_tokens_currently_compiling` and `consider_jump`'s
 /// `jump_target_descr` by descriptor object identity (Python's default
@@ -3001,6 +3047,23 @@ pub trait FieldDescr: Descr {
         true
     }
 
+    /// `descr.py:151 FieldDescr.flag` — `get_type_flag(FIELDTYPE)`
+    /// (`descr.py:240-252`).
+    ///
+    /// The default reconstructs the classification from the IR type the way
+    /// `get_type_flag` does, which is exact for the pointer / float / integer
+    /// cases; implementations that store the flag verbatim override it and so
+    /// also keep `FLAG_STRUCT` and `FLAG_VOID`.
+    fn field_flag(&self) -> ArrayFlag {
+        match self.field_type() {
+            Type::Ref => ArrayFlag::Pointer,
+            Type::Float => ArrayFlag::Float,
+            Type::Void => ArrayFlag::Void,
+            Type::Int if self.is_field_signed() => ArrayFlag::Signed,
+            Type::Int => ArrayFlag::Unsigned,
+        }
+    }
+
     /// Whether this field is immutable (never written after object creation).
     ///
     /// Immutable field reads from a constant object can be folded to constants,
@@ -4020,6 +4083,11 @@ impl FieldDescr for SimpleFieldDescr {
     /// descr.py:179: is_field_signed() → self.flag == FLAG_SIGNED
     fn is_field_signed(&self) -> bool {
         self.flag == ArrayFlag::Signed
+    }
+    /// descr.py:151: the stored `FieldDescr.flag`, so `FLAG_STRUCT` /
+    /// `FLAG_VOID` survive instead of being re-derived from the IR type.
+    fn field_flag(&self) -> ArrayFlag {
+        self.flag
     }
     fn is_immutable(&self) -> bool {
         self.is_immutable

--- a/majit/majit-ir/src/effectinfo.rs
+++ b/majit/majit-ir/src/effectinfo.rs
@@ -32,9 +32,9 @@ impl std::error::Error for UnsupportedFieldExc {}
 /// key can — both halves of the split agree on it by construction, since
 /// `cpu.fielddescrof(STRUCT, fieldname)` / `cpu.arraydescrof(ARRAY)` /
 /// `cpu.interiorfielddescrof(ARRAY, fieldname)` are cache lookups on exactly
-/// these tuples.  The key alone is enough because the member is resolved by
-/// lookup only, never by minting (see `descr_from_set_member` in
-/// `pyre-jit-trace`).
+/// these tuples.  The key alone identifies the slot; what it does *not* carry
+/// is the layout needed to create the descr when the slot is empty, which is
+/// what [`DescrMintSpec`] adds.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum DescrSetMember {
     /// `descr.py:218-239 get_field_descr(gccache, STRUCT, fieldname)` —
@@ -46,6 +46,86 @@ pub enum DescrSetMember {
     /// `descr.py:404-437 get_interiorfield_descr(gccache, ARRAY, fieldname)` —
     /// `_cache_interiorfield[(Array(array_id), name, "")]`.
     InteriorField { array_id: u64, name: String },
+}
+
+/// The layout arguments `descr.py`'s three getters pass to the descr
+/// constructor on a cache miss.
+///
+/// `get_field_descr` (`descr.py:218-239`), `get_array_descr`
+/// (`descr.py:348-378`) and `get_interiorfield_descr` (`descr.py:404-437`) are
+/// all `try: return cache[key] / except KeyError: <construct>; cache[key] = d`
+/// — they **mint** when the slot is empty.  Upstream never has to serialize
+/// those arguments because there is one gccache in one process: the raw sets
+/// hold the descr objects themselves, and `setup_descrs` (`descr.py:25-47`)
+/// snapshots the same cache they were minted into, so
+/// `compute_bitstrings` (`effectinfo.py:465-499`) only ever unions descrs that
+/// are already present.
+///
+/// Pyre mints in the analyzer process and resolves in the runtime one, and only
+/// the assembler's opcode table (`pyjitpl.py:2261 setup_descrs(asm.descrs)`)
+/// crosses between them.  A descr the analyzer minted *solely* to fill a raw
+/// set is referenced by no opcode, so it does not cross, and the runtime lookup
+/// finds an empty slot.  Pairing each member with the arguments its cache miss
+/// would need restores upstream's mint-or-hit at the far end.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum DescrMintSpec {
+    /// `descr.py:224-231` — the `FieldDescr(name, offset, size, flag,
+    /// index_in_parent, is_pure)` arguments, plus `descr.py:234-238
+    /// parent_descr = get_size_descr(gccache, STRUCT, vtable)`'s `STRUCT` size.
+    ///
+    /// No vtable: the analyzer has no vtable surface, and a runtime publish
+    /// under the same key carries the real one — the authority rule in
+    /// `descr::GcCache::register_keyed_size` keeps that one whichever side
+    /// registers first.
+    Field {
+        struct_size: usize,
+        offset: usize,
+        field_size: usize,
+        field_type: crate::value::Type,
+        flag: crate::descr::ArrayFlag,
+        is_immutable: bool,
+        is_quasi_immutable: bool,
+        index_in_parent: usize,
+    },
+    /// `descr.py:353-370` — the `ArrayDescr(basesize, itemsize, lendescr, flag,
+    /// is_pure, concrete_type)` arguments. `length_offset` is what
+    /// `get_field_arraylen_descr` (`descr.py:256-267`) needs, and is read only
+    /// when `!nolength`, matching `descr.py:359-362`.
+    Array {
+        base_size: usize,
+        item_size: usize,
+        flag: crate::descr::ArrayFlag,
+        item_type: crate::value::Type,
+        nolength: bool,
+        length_offset: usize,
+        is_pure: bool,
+        concrete_type: char,
+    },
+    /// `descr.py:429-436` — an interior field is minted out of the array descr
+    /// and the element-struct field descr, so it carries both halves rather
+    /// than a flat layout.
+    ///
+    /// `field_struct_id` is the `REALARRAY.OF` cache key
+    /// (`descr.py:435 get_field_descr(gc_ll_descr, REALARRAY.OF, name)`).
+    /// Upstream recovers it from the ARRAY lltype; the serialized member names
+    /// only the array, so the element struct's key travels explicitly.
+    InteriorField {
+        array: Box<DescrMintSpec>,
+        field_struct_id: u64,
+        field_name: String,
+        field: Box<DescrMintSpec>,
+    },
+}
+
+/// One `(slot key, how to fill it)` pair, as serialized alongside the jitcodes.
+///
+/// The union over every `EffectInfo`'s six raw sets — the same union
+/// `compute_bitstrings` builds in `descrs = {'fields': set(), ...}`
+/// (`effectinfo.py:478-495`).
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct DescrMintEntry {
+    pub member: DescrSetMember,
+    pub spec: DescrMintSpec,
 }
 
 /// `effectinfo.py:128-145 frozenset_or_none`: serializable projection of

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -5284,13 +5284,21 @@ impl<M: Clone> MetaInterp<M> {
         }
         // Bridge traces start from rebuilt resume state, not a fresh portal
         // entry, so `initial_inputarg_consts` is not seeded with the
-        // virtualizable inputarg's ConstPtr. The live virtualizable pointer
-        // cached by `set_vable_ptr` during JitState setup is the same heap
-        // object (`orig_inpargs[idx].getref_base()`), so fall back to it.
+        // virtualizable inputarg's ConstPtr.  The TraceCtx pointer is the
+        // trace-bound equivalent of `orig_inpargs[idx].getref_base()`.
+        //
+        // Prefer it over MetaInterp's ambient pointer: an inlined residual
+        // callee can temporarily update `self.vable_ptr`, while the residual
+        // boundary restores the caller's pointer on this TraceCtx. Reading the
+        // ambient slot here would combine the caller loop's expanded inputargs
+        // with the callee frame's array length, collapsing frame identity.
+        if let Some(ptr) = ctx.virtualizable_heap_ptr() {
+            return ptr;
+        }
         if !self.vable_ptr.is_null() {
             return self.vable_ptr;
         }
-        ctx.virtualizable_heap_ptr().unwrap_or(std::ptr::null())
+        std::ptr::null()
     }
 
     /// compile.py:168 / pyjitpl.py:3605 parity: every real loop token must

--- a/majit/majit-translate/src/codegen.rs
+++ b/majit/majit-translate/src/codegen.rs
@@ -174,6 +174,7 @@ mod tests {
             jitcodes_by_path: indexmap::IndexMap::new(),
             insns: indexmap::IndexMap::new(),
             descrs: Vec::new(),
+            ei_descr_mints: Vec::new(),
             all_liveness: Vec::new(),
             total_blocks: 0,
             total_ops: 0,

--- a/majit/majit-translate/src/codewriter/call.rs
+++ b/majit/majit-translate/src/codewriter/call.rs
@@ -1782,6 +1782,22 @@ impl CallControl {
                 let key = majit_ir::effectinfo::DescrSetMember::Array {
                     array_id: path_hash_u64,
                 };
+                // The same arguments the `get_array_descr` call above passed,
+                // so a runtime cache that has never seen this ARRAY can take
+                // `descr.py:353-370`'s miss branch rather than find nothing.
+                majit_ir::descr::record_ei_descr_mint(
+                    key.clone(),
+                    majit_ir::effectinfo::DescrMintSpec::Array {
+                        base_size,
+                        item_size,
+                        flag,
+                        item_type: ir_type,
+                        nolength,
+                        length_offset,
+                        is_pure,
+                        concrete_type,
+                    },
+                );
                 (ad_arc, Some(key))
             }
             None => {
@@ -2111,6 +2127,24 @@ impl CallControl {
                         let stored = fd.field_name();
                         if stored == field_name || stored.ends_with(&needle) {
                             fd.set_index(idx);
+                            // This slot is filled in *this* process; the
+                            // runtime's own cache is a different one, so the
+                            // layout still has to travel. Read it back off the
+                            // descr rather than off the locals below, which
+                            // describe the mint that did not happen.
+                            majit_ir::descr::record_ei_descr_mint(
+                                member.clone(),
+                                majit_ir::effectinfo::DescrMintSpec::Field {
+                                    struct_size,
+                                    offset: fd.offset(),
+                                    field_size: fd.field_size(),
+                                    field_type: fd.field_type(),
+                                    flag: fd.field_flag(),
+                                    is_immutable: fd.is_immutable(),
+                                    is_quasi_immutable: fd.is_quasi_immutable(),
+                                    index_in_parent: fd.index_in_parent(),
+                                },
+                            );
                             return Some((fd.clone() as majit_ir::descr::DescrRef, member));
                         }
                     }
@@ -2146,6 +2180,22 @@ impl CallControl {
                     field_pos,
                 );
                 descr.set_index(idx);
+                // Same arguments this `get_field_descr` miss just used, kept so
+                // the runtime's own cache can take the same miss branch
+                // (`descr.py:224-238`) instead of finding an empty slot.
+                majit_ir::descr::record_ei_descr_mint(
+                    member.clone(),
+                    majit_ir::effectinfo::DescrMintSpec::Field {
+                        struct_size,
+                        offset: field_offset,
+                        field_size,
+                        field_type: ir_type,
+                        flag,
+                        is_immutable,
+                        is_quasi_immutable,
+                        index_in_parent: field_pos,
+                    },
+                );
                 return Some((descr as majit_ir::descr::DescrRef, member));
             }
             offset = offset.saturating_add(field_size);
@@ -2325,6 +2375,36 @@ impl CallControl {
                 let array_descr: std::sync::Arc<dyn majit_ir::descr::ArrayDescr> =
                     majit_ir::descr::descr_arc_as_array_descr(cached)
                         .expect("gc_cache._cache_array slot held a non-ArrayDescr Arc");
+                // `descr.py:429-436` builds an interior field out of the array
+                // descr and the element-struct field descr, so both halves
+                // travel — the runtime miss branch has to rebuild the same two.
+                majit_ir::descr::record_ei_descr_mint(
+                    member.clone(),
+                    majit_ir::effectinfo::DescrMintSpec::InteriorField {
+                        array: Box::new(majit_ir::effectinfo::DescrMintSpec::Array {
+                            base_size,
+                            item_size,
+                            flag: ArrayFlag::Struct,
+                            item_type: majit_ir::value::Type::Ref,
+                            nolength: false,
+                            length_offset: 0,
+                            is_pure: false,
+                            concrete_type: '\x00',
+                        }),
+                        field_struct_id: majit_ir::descr::path_hash(&elem_canonical),
+                        field_name: field_name.to_string(),
+                        field: Box::new(majit_ir::effectinfo::DescrMintSpec::Field {
+                            struct_size,
+                            offset: field_descr.offset(),
+                            field_size: field_descr.field_size(),
+                            field_type: field_descr.field_type(),
+                            flag: field_descr.field_flag(),
+                            is_immutable: field_descr.is_immutable(),
+                            is_quasi_immutable: field_descr.is_quasi_immutable(),
+                            index_in_parent: field_descr.index_in_parent(),
+                        }),
+                    },
+                );
                 let descr = majit_ir::descr::gc_cache()
                     .lock()
                     .unwrap()

--- a/majit/majit-translate/src/lib.rs
+++ b/majit/majit-translate/src/lib.rs
@@ -1752,6 +1752,7 @@ fn analyze_pipeline_from_module_paths(
         insns: indexmap::IndexMap::new(),
         descrs: Vec::new(),
         all_liveness: Vec::new(),
+        ei_descr_mints: Vec::new(),
         total_blocks: 0,
         total_ops: 0,
         total_vable_rewrites: 0,
@@ -1786,6 +1787,11 @@ fn analyze_pipeline_from_module_paths(
     // "".join(asm.all_liveness)`) so the runtime can resolve the `BC_LIVE`
     // offsets baked into `JitCode.code`.
     pipeline.all_liveness = all_liveness;
+    // Taken after `make_jitcodes`, when every `EffectInfo` has been built and
+    // so every raw-set member has passed through its `get_*_descr` mint site.
+    // The equivalent of what `descr.py:25-47 setup_descrs` would have picked up
+    // for free had the analyzer and the runtime shared one gccache.
+    pipeline.ei_descr_mints = majit_ir::descr::ei_descr_mints_snapshot();
 
     pipeline
 }

--- a/majit/majit-translate/src/pipeline.rs
+++ b/majit/majit-translate/src/pipeline.rs
@@ -158,6 +158,18 @@ pub struct ProgramPipelineResult {
     /// self.liveness_info = "".join(asm.all_liveness)`.
     #[serde(default)]
     pub all_liveness: Vec<u8>,
+    /// The `(gccache slot key, mint arguments)` pairs behind every descr an
+    /// `EffectInfo` raw set names — see `majit_ir::descr::ei_descr_mints_snapshot`.
+    ///
+    /// `descrs` above is upstream's `opcode_descrs` (`pyjitpl.py:2261
+    /// setup_descrs(asm.descrs)`), not its `all_descrs` (`pyjitpl.py:2289
+    /// self.cpu.setup_descrs()`, the full gccache walk at `descr.py:25-47`).
+    /// A descr the analyzer minted only to fill a raw set is named by no
+    /// opcode, so it is absent from `descrs` and would have no slot to resolve
+    /// against once the process boundary is crossed. Upstream never needs this
+    /// because there is one gccache in one process.
+    #[serde(default)]
+    pub ei_descr_mints: Vec<majit_ir::effectinfo::DescrMintEntry>,
     pub total_blocks: usize,
     pub total_ops: usize,
     pub total_vable_rewrites: usize,
@@ -200,6 +212,7 @@ mod tests {
             insns: indexmap::IndexMap::new(),
             descrs: Vec::new(),
             all_liveness: Vec::new(),
+            ei_descr_mints: Vec::new(),
             total_blocks: 1,
             total_ops: 1,
             total_vable_rewrites: 0,

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -397,30 +397,35 @@ def _jit_panic_reason(stderr):
 # ── Helpers ──────────────────────────────────────────────────────────
 
 def _jit_stats_snapshot(stderr):
-    """Return the last structural jit-stats line as normalized key/value text.
+    """Return every jit-stats line merged into normalized key/value text.
 
-    The diagnostic lines (mc_diag, heap_buckets, bridge_diag, fbw_diag,
-    exec_hist) share the `[jit-stats]` prefix but name themselves in a bare
-    first token; only the structural summary starts straight into key=value.
-    Reading one of those instead leaves loops_aborted and
-    internal_compile_panics missing, which the regression floor below reads as
-    0 — the gate would then never fire again, silently."""
-    stats_line = None
+    The interpreter emits more than one `[jit-stats]` line — the counters, the
+    mc_diag tallies, the descr-set universe. Keeping only the last one dropped
+    `loops_aborted` and `internal_compile_panics` from the snapshot, which
+    silently disarmed `_jit_stats_regression_floor`: it read both counters as
+    absent on the current side, so `cur > base` could never hold no matter how
+    far they rose. Later lines still win on a repeated key.
+
+    Merging is what keeps that true as lines are added. Selecting one line
+    instead — the last whose first token is not a bare diagnostic name like
+    `mc_diag` / `heap_buckets` / `bridge_diag` / `fbw_diag` / `exec_hist` —
+    re-disarms the floor the moment a second key=value line joins the first,
+    because the newcomer displaces the counters. The bare-name lines need no
+    special case here: their name token carries no `=` and is skipped with
+    every other non-assignment token.
+    """
+    fields = {}
+    seen = False
     for line in stderr.splitlines():
         if not line.startswith("[jit-stats]"):
             continue
-        head = line[len("[jit-stats]") :].split()
-        if head and "=" not in head[0]:
-            continue
-        stats_line = line
-    if stats_line is None:
+        seen = True
+        for token in line[len("[jit-stats]") :].split():
+            if "=" in token:
+                key, value = token.split("=", 1)
+                fields[key] = value
+    if not seen:
         return None
-
-    fields = {}
-    for token in stats_line[len("[jit-stats]") :].split():
-        if "=" in token:
-            key, value = token.split("=", 1)
-            fields[key] = value
     # This watches what the JIT compiles, never how well. A regression that
     # changes no structure (for example, an extra spill) is invisible here.
     return "".join(f"{key}={fields[key]}\n" for key in sorted(fields))

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -421,6 +421,11 @@ def _jit_stats_snapshot(stderr):
     because the newcomer displaces the counters. The bare-name lines need no
     special case here: their name token carries no `=` and is skipped with
     every other non-assignment token.
+
+    The merged set is then narrowed to `JITSTATS_SNAPSHOT_FIELDS`, because what
+    a run may read and what a committed baseline may contain are two different
+    questions: merging arms the floor, the filter keeps the recorded surface
+    host-stable.
     """
     fields = {}
     seen = False
@@ -434,9 +439,26 @@ def _jit_stats_snapshot(stderr):
                 fields[key] = value
     if not seen:
         return None
+    fields = {k: v for k, v in fields.items() if k in JITSTATS_SNAPSHOT_FIELDS}
     # This watches what the JIT compiles, never how well. A regression that
     # changes no structure (for example, an extra spill) is invisible here.
     return "".join(f"{key}={fields[key]}\n" for key in sorted(fields))
+
+
+def _jit_stats_fields_equal(saved, current):
+    """Whether two snapshots agree on every `JITSTATS_SNAPSHOT_FIELDS` key,
+    reading a field missing from either side as "0"."""
+    def parse(snapshot):
+        if snapshot is None:
+            return {}
+        return dict(line.split("=", 1) for line in snapshot.splitlines())
+
+    old_fields = parse(saved)
+    new_fields = parse(current)
+    return all(
+        old_fields.get(field, "0") == new_fields.get(field, "0")
+        for field in JITSTATS_SNAPSHOT_FIELDS
+    )
 
 
 def _jit_stats_diff(saved, current, limit=6):
@@ -492,6 +514,31 @@ JITSTATS_BADNESS_FIELDS = (
     "descr_set_absent",
     "descr_set_ambiguous",
     "descr_set_stale_absent",
+)
+
+# What a committed `.jitstats` baseline is allowed to contain. `_jit_stats_snapshot`
+# merges every `[jit-stats]` line so the floor above cannot be disarmed by
+# reshuffling them, but the merged set also carries keys that are not comparable
+# against a file checked into the repo:
+#
+# * `all_descrs` and `descr_set_resolved` are HOST-DEPENDENT — the Charon/LLBC
+#   extraction runs per host, so the same commit reads `all_descrs` 1168 on
+#   macOS, 1396 on ubuntu and 1365 on windows. Committing either makes every
+#   host but one disagree.
+# * the `mc_diag` tallies include contention counters (`busy_skip`,
+#   `stfe_cell_busy`, `stfe_tick`) that move with machine load.
+# * `PYRE_WASM_JIT_STATS=1` adds wall-clock (`compile_ms`) and repeated
+#   `exec_hist` lines whose keys collide across lines; check.py never sets it,
+#   but a developer who has it exported would otherwise poison a `--snapshot`
+#   re-record.
+#
+# The badness fields are all zero in a healthy run and the three structural
+# counts are host-stable, so this surface needs no re-record when a new
+# diagnostic line is added.
+JITSTATS_SNAPSHOT_FIELDS = JITSTATS_BADNESS_FIELDS + (
+    "loops_compiled",
+    "bridges_compiled",
+    "guard_failures",
 )
 
 
@@ -872,7 +919,12 @@ class Check:
                 self.jitstats_missing.append(f"{backend}/{name}")
             else:
                 saved_jitstats = jitstats_path.read_text(encoding="utf-8")
-                if jitstats != saved_jitstats:
+                # Compare key-wise with a missing field read as "0", the same
+                # semantics `_jit_stats_regression_floor` documents. A baseline
+                # recorded before a counter existed is then still equal to a
+                # run that reports it as 0, so adding an invariant counter
+                # costs no re-record — only a real change diffs.
+                if not _jit_stats_fields_equal(saved_jitstats, jitstats):
                     self.jitstats_diffs.append(f"{backend}/{name}")
                     delta = _jit_stats_diff(saved_jitstats, jitstats)
                     return "fail", f"jit-stats diff: {delta}"

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -466,7 +466,23 @@ def _jit_stats_diff(saved, current, limit=6):
 # (guard_failures, loops_compiled, bridges_compiled) are deliberately excluded:
 # they move in both directions under ordinary tuning and their absolute value is
 # not yet confirmed stable across runners, so they stay informational.
-JITSTATS_BADNESS_FIELDS = ("loops_aborted", "internal_compile_panics")
+#
+# `descr_set_ambiguous` and `descr_set_stale_absent` are the descr-universe
+# invariants. Upstream cannot reach either state — `effectinfo.py:492-494`
+# builds its sets out of the descr objects `cpu.*descrof` just created in the
+# same process — so upstream expresses this class of condition with a plain
+# `assert` (`descr.py:47`, `effectinfo.py:486,525`). Pyre resolves the sets
+# across a build-time/runtime split where both are reachable in principle and
+# the runtime answer is a sound degradation rather than a crash, so the
+# assertion is expressed as a counter that must not rise off zero. A field
+# absent from a baseline reads as 0, so these gate from the first run without
+# re-recording anything.
+JITSTATS_BADNESS_FIELDS = (
+    "loops_aborted",
+    "internal_compile_panics",
+    "descr_set_ambiguous",
+    "descr_set_stale_absent",
+)
 
 
 def _jit_stats_regression_floor(saved, current):

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -467,19 +467,21 @@ def _jit_stats_diff(saved, current, limit=6):
 # they move in both directions under ordinary tuning and their absolute value is
 # not yet confirmed stable across runners, so they stay informational.
 #
-# `descr_set_ambiguous` and `descr_set_stale_absent` are the descr-universe
-# invariants. Upstream cannot reach either state — `effectinfo.py:492-494`
-# builds its sets out of the descr objects `cpu.*descrof` just created in the
-# same process — so upstream expresses this class of condition with a plain
-# `assert` (`descr.py:47`, `effectinfo.py:486,525`). Pyre resolves the sets
-# across a build-time/runtime split where both are reachable in principle and
-# the runtime answer is a sound degradation rather than a crash, so the
-# assertion is expressed as a counter that must not rise off zero. A field
-# absent from a baseline reads as 0, so these gate from the first run without
-# re-recording anything.
+# `descr_set_absent`, `descr_set_ambiguous` and `descr_set_stale_absent` are the
+# descr-universe invariants. Upstream cannot reach any of the three —
+# `effectinfo.py:492-494` builds its sets out of the descr objects `cpu.*descrof`
+# just created in the same process, so no member of a raw set can fail to
+# resolve — and it expresses this class of condition with a plain `assert`
+# (`descr.py:47`, `effectinfo.py:486,525`). Pyre resolves the sets across a
+# build-time/runtime split where all three are reachable in principle and the
+# runtime answer is a sound degradation rather than a crash, so the assertion is
+# expressed as a counter that must not rise off zero. A field absent from a
+# baseline reads as 0, so these gate from the first run without re-recording
+# anything.
 JITSTATS_BADNESS_FIELDS = (
     "loops_aborted",
     "internal_compile_panics",
+    "descr_set_absent",
     "descr_set_ambiguous",
     "descr_set_stale_absent",
 )

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -289,10 +289,18 @@ def pyre_env():
     falling back to the interpreter, so a JIT bug surfaces as a crash here
     rather than as correct-but-uncompiled output. MAJIT_STATS=1 prints the
     `[jit-stats]` line that `_jit_panic_reason` inspects.
+
+    PYRE_DESCR_SPELLING_GATE=1 makes the descr-universe counters in that line
+    name their members. The counters are gated at zero
+    (JITSTATS_BADNESS_FIELDS), and a bare `descr_set_ambiguous 0 -> 1` says
+    nothing about which container disagreed — on a platform the developer
+    cannot reproduce, the name is the whole diagnosis. Naming costs one stderr
+    line per member and only ever prints when a member fails to resolve.
     """
     env = dict(os.environ)
     env["MAJIT_STRICT"] = "1"
     env["MAJIT_STATS"] = "1"
+    env["PYRE_DESCR_SPELLING_GATE"] = "1"
     # Pin the vendored, `_sre.MAGIC`-matched stdlib so pyre never picks up a
     # version-mismatched host `python3` off the PATH. An explicit PYRE_STDLIB
     # in the environment wins.

--- a/pyre/pyre-jit-trace/Cargo.toml
+++ b/pyre/pyre-jit-trace/Cargo.toml
@@ -40,6 +40,7 @@ majit-backend-dynasm = { workspace = true, optional = true }
 majit-backend-wasm = { path = "../../majit/majit-backend-wasm", version = "0.0.2", default-features = false }
 
 [build-dependencies]
+majit-ir = { workspace = true }
 majit-translate = { workspace = true }
 mimalloc = { version = "0.1" }
 pyre-interpreter = { workspace = true, features = ["dynasm"] }

--- a/pyre/pyre-jit-trace/build.rs
+++ b/pyre/pyre-jit-trace/build.rs
@@ -24,6 +24,7 @@ const CODEGEN_OUTPUTS: &[&str] = &[
     "jit_drivers.bin",
     "insns.bin",
     "descrs.bin",
+    "ei_descr_mints.bin",
     "liveness.bin",
     "fnaddr_bindings.bin",
     "static_pytype_bindings.bin",
@@ -100,6 +101,11 @@ fn emit_llbc_extraction_placeholders() {
     std::fs::write(
         format!("{out_dir}/descrs.bin"),
         bincode::serialize(&Vec::<majit_translate::jitcode::BhDescr>::new()).unwrap(),
+    )
+    .unwrap();
+    std::fs::write(
+        format!("{out_dir}/ei_descr_mints.bin"),
+        bincode::serialize(&Vec::<majit_ir::effectinfo::DescrMintEntry>::new()).unwrap(),
     )
     .unwrap();
     std::fs::write(
@@ -545,6 +551,18 @@ fn real_main() {
     // by `acquire_interp`).
     let descrs_bin = bincode::serialize(&pipeline.descrs).unwrap();
     std::fs::write(format!("{out_dir}/descrs.bin"), &descrs_bin).unwrap();
+
+    // The table above is RPython's `opcode_descrs` (`pyjitpl.py:2261
+    // setup_descrs(asm.descrs)`), not its `all_descrs` (`pyjitpl.py:2289
+    // self.cpu.setup_descrs()` = the full gccache walk at `descr.py:25-47`).
+    // Upstream never has to distinguish them here because one gccache serves
+    // one process, so `compute_bitstrings` unions descrs that are already
+    // present. Pyre mints in this process and resolves in another, so the
+    // raw-set members no opcode names would have no slot on the far side;
+    // persist their mint arguments and let the runtime cache take the same
+    // `descr.py:224-238` miss branch this one did.
+    let ei_descr_mints_bin = bincode::serialize(&pipeline.ei_descr_mints).unwrap();
+    std::fs::write(format!("{out_dir}/ei_descr_mints.bin"), &ei_descr_mints_bin).unwrap();
 
     // RPython `pyjitpl.py:2264 self.liveness_info = "".join(asm.all_liveness)`.
     // Persist the build-time assembler's shared `all_liveness` byte stream so a

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -4710,3 +4710,69 @@ pub fn make_interior_field_descr(
     majit_ir::descr_registry::register_interior_field(interior.clone());
     interior
 }
+
+#[cfg(test)]
+mod set_member_lookup_tests {
+    use super::*;
+    use majit_ir::effectinfo::DescrSetMember;
+
+    /// Distinguishing the two non-resolving outcomes is the whole gate:
+    /// `AbsentContainer` is the projection onto a universe that never named the
+    /// container, `Ambiguous` is the container being named under a different
+    /// key. Only the second is a defect, and it is the one `check.py` gates at
+    /// zero.
+    ///
+    /// Both assertions turn on one key each, so they hold whatever else the
+    /// process-global gccache already carries.
+    #[test]
+    fn an_unnamed_container_is_absent_and_a_named_one_missing_the_field_is_ambiguous() {
+        let published = 0x7e57_0000_0000_0001u64;
+        let never_named = 0x7e57_0000_0000_0002u64;
+
+        majit_ir::descr::gc_cache()
+            .lock()
+            .unwrap()
+            .register_keyed_size(
+                majit_ir::descr::LLType::Struct(published),
+                Arc::new(majit_ir::descr::SimpleSizeDescr::with_vtable(
+                    u32::MAX,
+                    32,
+                    0,
+                    0,
+                )) as DescrRef,
+            );
+
+        let member = |struct_id| DescrSetMember::Field {
+            struct_id,
+            field_name: "no_such_field".to_string(),
+        };
+        assert!(matches!(
+            descr_from_set_member(&member(never_named)),
+            SetMemberLookup::AbsentContainer
+        ));
+        assert!(matches!(
+            descr_from_set_member(&member(published)),
+            SetMemberLookup::Ambiguous
+        ));
+    }
+
+    /// The label is what `PYRE_DESCR_SPELLING_GATE` prints, and it has to name
+    /// the container in the same hex form `descrs.bin` keys on so an entry can
+    /// be grepped straight back to a producer.
+    #[test]
+    fn labels_carry_the_container_key_and_member_name() {
+        assert_eq!(
+            set_member_label(&DescrSetMember::Field {
+                struct_id: 0xa3af111df5325ac5,
+                field_name: "items".to_string(),
+            }),
+            "Struct(0xa3af111df5325ac5).items"
+        );
+        assert_eq!(
+            set_member_label(&DescrSetMember::Array {
+                array_id: 0x0000000000000010
+            }),
+            "Array(0x0000000000000010)"
+        );
+    }
+}

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -4705,6 +4705,17 @@ pub fn rehydrate_effect_info(ei: &mut majit_ir::EffectInfo) {
         ei.extraeffect = majit_ir::ExtraEffect::RandomEffects;
         // effectinfo.py:364-365 — the wildcard forces can_collect.
         ei.can_collect = true;
+        // `call.py:284-286` states it outright: "random_effects implies
+        // can_invalidate".  `effectinfo.py:271-273 MOST_GENERAL` is built with
+        // `can_invalidate=True`, and so is pyre's own
+        // `EffectInfo::MOST_GENERAL`.  Without this a degraded EI is a shape
+        // upstream cannot construct — random effects with
+        // `check_can_invalidate()` still false — and `check_can_invalidate`
+        // is read on a path `has_random_effects()` does not cover
+        // (`heap.py:457-459`; `_seen_guard_not_invalidated` is otherwise only
+        // reset in `__init__`, `heap.py:341`), so a quasi-immutable guard
+        // would survive a call the wildcard says invalidates everything.
+        ei.can_invalidate = true;
         ei._readonly_descrs_fields = None;
         ei._write_descrs_fields = None;
         ei._readonly_descrs_arrays = None;
@@ -4734,6 +4745,14 @@ pub fn rehydrate_effect_info(ei: &mut majit_ir::EffectInfo) {
     };
     let resolve = |members: &[majit_ir::effectinfo::DescrSetMember]| {
         let mut out = Vec::with_capacity(members.len());
+        // Walk the WHOLE set even once it is known to be incomplete: the
+        // ledger behind `record_set_member_lookup` is what
+        // `descr_set_absent` / `descr_set_ambiguous` report, and those are
+        // gated in `check.py`.  Returning at the first non-answer would stop
+        // counting the rest of the set, so the gate's own numbers would shrink
+        // with the defect they exist to measure — by an order-dependent
+        // amount, which is worse than useless.
+        let mut complete = true;
         for m in members {
             let looked_up = descr_from_set_member(m);
             record_set_member_lookup(m, &looked_up);
@@ -4758,10 +4777,10 @@ pub fn rehydrate_effect_info(ei: &mut majit_ir::EffectInfo) {
                 // lives on.  Closing the serialized universe (the
                 // build-time `DescrMintSpec` channel) is what makes this
                 // arm unreachable rather than merely rare.
-                SetMemberLookup::AbsentContainer | SetMemberLookup::Ambiguous => return None,
+                SetMemberLookup::AbsentContainer | SetMemberLookup::Ambiguous => complete = false,
             }
         }
-        Some(majit_ir::effectinfo::canonicalize_descr_set(out))
+        complete.then(|| majit_ir::effectinfo::canonicalize_descr_set(out))
     };
     let resolved = (
         resolve(&keys.readonly_fields),

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -4395,10 +4395,22 @@ pub(crate) fn publish_runtime_descr_groups() {
 /// so re-deriving would land on a different slot than the one the member
 /// names.
 ///
-/// Ordering is the same as for the runtime groups above — after them, before
-/// the `make_descr_from_bh` loop — and for the same reason: these specs carry
-/// no vtable, and `register_keyed_size`'s authority rule keeps whichever
-/// registration does.
+/// Runs **last**, after both the runtime groups and the `make_descr_from_bh`
+/// loop (`jitcode_runtime.rs rehydrate_build_descr_raw_sets`), and writes only
+/// into slots those left empty.  Going first would pre-fill a slot the loop
+/// then asks for, with the analyzer's `index_in_parent` numbering rather than
+/// the established producer's — the two disagree on any `#[pyre_class]`
+/// struct, by the two injected header words.  Publishing the leftovers keeps
+/// the established answers untouched.
+///
+/// The slots left empty are the ones no opcode names, which is why
+/// `descrs.bin` — RPython's `opcode_descrs`, not its `all_descrs` — does not
+/// carry them.  Upstream has that population too: `effectinfo.py:300-322`
+/// builds every raw set through `cpu.fielddescrof` / `arraydescrof` /
+/// `interiorfielddescrof`, a cache-or-mint into the gccache that runs whether
+/// or not any operation names the field, and `descr.py:25-47 setup_descrs`
+/// then snapshots that gccache into `all_descrs`.  So a raw-set-only descr
+/// referenced by no trace op is normal, not a sign of a mis-keyed publish.
 pub(crate) fn publish_effect_info_descr_mints(entries: &[majit_ir::effectinfo::DescrMintEntry]) {
     use majit_ir::descr::LLType;
     use majit_ir::effectinfo::{DescrMintSpec, DescrSetMember};

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -4266,39 +4266,33 @@ enum SetMemberLookup {
     /// The gccache holds the slot the analyzer minted through.
     Resolved(majit_ir::DescrRef),
     /// The *container* (`STRUCT` / `ARRAY`) is absent from this process's
-    /// descr universe entirely, so no operation recorded here can carry a
-    /// descr for it and the member cannot participate in any
-    /// `check_*_descr_*` answer.  Dropping it is the faithful projection of
-    /// the analyzer's frozenset onto the runtime universe — the analyzer
-    /// walks the whole translated program, the runtime only registers what
-    /// it actually traces.  Upstream has no counterpart because
-    /// `cpu.*descrof` and `compute_bitstrings` share one process.
+    /// descr universe entirely, so the member is dropped from the raw set.
     ///
-    /// KNOWN GAP: "absent" is evaluated once, when the `BhCallDescr` is
-    /// materialised (`jitcode_runtime.rs rehydrated_call_descr_ref`), but the
-    /// runtime universe keeps growing after that.  A container registered
-    /// later — under the same `path_hash` key — leaves this EI permanently
-    /// claiming "not written" for a field the callee does write, so the
-    /// heapcache would not invalidate a read across the call.
+    /// **Upstream cannot reach this.** `cpu.*descrof` and `compute_bitstrings`
+    /// share one gccache in one process, so `setup_descrs` (`descr.py:25-47`)
+    /// snapshots the very cache the raw-set descrs were minted into and
+    /// `effectinfo.py:465-499` only ever unions descrs that are already there.
+    /// A member that fails to resolve is therefore not a legitimate projection
+    /// but a divergence, and its count is a badness counter held at zero
+    /// (`descr_set_absent` on the `[jit-stats]` line) — pyre's form of the bare
+    /// `assert`s upstream states this class of condition with.
     ///
-    /// `publish_runtime_descr_groups` closes the gap for the module-scope
-    /// groups by forcing all of them before the first lookup;
-    /// `W_IntObject.intval` was landing here until it did.  What is still
-    /// published on demand, and so can still fall into this arm: the
-    /// per-exception-class groups behind `W_BASE_EXCEPTION_DESCR_CACHE`, and
-    /// the `ARRAY_DESCR_REGISTRY` entries minted per element layout.
+    /// Two publishes are what hold it at zero, both inside the `Once` in
+    /// `jitcode_runtime::rehydrate_build_descr_raw_sets` and both ahead of the
+    /// first lookup: `publish_runtime_descr_groups` for the module-scope
+    /// groups (`W_IntObject.intval` was landing here until it did), and
+    /// `publish_effect_info_descr_mints` for the slots no opcode names, which
+    /// `descrs.bin` — upstream's `opcode_descrs`, not its `all_descrs` — does
+    /// not carry.
     ///
-    /// The conservative repair (treat this like [`Self::Ambiguous`] and
-    /// degrade the EI to `EF_RANDOM_EFFECTS`) is not taken here: a probe over
-    /// `bench/synth/comprehension_object_append_hot` counts 211 drops across
-    /// ~40 distinct containers (`W_TupleObject.wrappeditems`,
-    /// `PyFrame.w_globals`, `intval`, rbigint `_digits`/`_size`, …), so it
-    /// would turn most residual calls into whole-heap barriers.  The
-    /// convergence path is to stop freezing the sets at materialisation and
-    /// re-resolve from the retained `ei.descr_set_keys` as the universe grows
-    /// (i.e. inside `compute_bitstrings`, which already re-runs); that is
-    /// blocked on the descr-universe work and on `compute_bitstrings`' own
-    /// per-`jitcode_for` cost.
+    /// The arm stays because the answer is still reachable in principle, and a
+    /// dropped member is a real hazard when it is: "absent" is evaluated once,
+    /// when the `BhCallDescr` is materialised
+    /// (`jitcode_runtime.rs rehydrated_call_descr_ref`), so a container
+    /// registered afterwards would leave that EI permanently claiming "not
+    /// written" for a field the callee does write, and the heapcache would not
+    /// invalidate a read across the call. [`stale_absent_containers`] re-asks
+    /// the question at exit and gates that residue at zero too.
     AbsentContainer,
     /// The container IS published but not under this member's key.  A real
     /// runtime descr for the field may exist under a different spelling, so
@@ -4325,15 +4319,14 @@ enum SetMemberLookup {
 /// process's descr universe, just not under the key the analyzer minted
 /// through.
 ///
-/// `Ambiguous` is the two-spellings defect by construction, and it is the only
-/// one of the three outcomes that is never a legitimate projection:
-/// `Resolved` joined, `AbsentContainer` means the runtime never named the
-/// container at all (the analyzer walks the whole translated program, the
-/// runtime only registers what it actually traces), but `Ambiguous` means both
-/// sides named the same container and disagreed on how to spell it.  Its
-/// consumer degrades the whole `EffectInfo` to `EF_RANDOM_EFFECTS`, so every
-/// entry below is a residual call that stopped invalidating precisely and
-/// became a whole-heap barrier.
+/// `Ambiguous` is the two-spellings defect by construction: both sides named
+/// the same container and disagreed on how to spell it.  Its consumer degrades
+/// the whole `EffectInfo` to `EF_RANDOM_EFFECTS`, so every entry below is a
+/// residual call that stopped invalidating precisely and became a whole-heap
+/// barrier.  `AbsentContainer` is the other non-answer and is equally a
+/// divergence rather than a projection — see [`SetMemberLookup`] — but it is
+/// the *missing table* defect, not the *two spellings* one, so the two are
+/// counted apart.
 ///
 /// This is the gate for struct-identity work; a converged-field-descr count is
 /// not.  A field-descr census only counts the descrs a particular run happens
@@ -4383,11 +4376,181 @@ pub(crate) fn publish_runtime_descr_groups() {
     ];
 }
 
+/// Fill the gccache slots that only an `EffectInfo` raw set names, from the
+/// mint arguments the analyzer recorded at its own `get_*_descr` call.
+///
+/// This is the far half of `descr.py`'s mint-or-hit: `get_field_descr`
+/// (`:218-239`), `get_array_descr` (`:348-378`) and `get_interiorfield_descr`
+/// (`:404-437`) all *construct* on a cache miss, and upstream reaches every one
+/// of these slots because `compute_bitstrings` (`effectinfo.py:465-499`) unions
+/// descr objects out of the same gccache `setup_descrs` (`descr.py:25-47`) then
+/// snapshots.  Pyre carries only the assembler's opcode table across the
+/// build/runtime split (`pyjitpl.py:2261 setup_descrs(asm.descrs)`), so a descr
+/// minted purely to fill a raw set — named by no opcode — arrives with nothing
+/// to resolve against.
+///
+/// Each entry is published under **the member's own key**, never a key
+/// re-derived from a struct name: the analyzer prefers a source-attached
+/// identity token over `path_hash(canonical_struct_name(..))` when it has one,
+/// so re-deriving would land on a different slot than the one the member
+/// names.
+///
+/// Ordering is the same as for the runtime groups above — after them, before
+/// the `make_descr_from_bh` loop — and for the same reason: these specs carry
+/// no vtable, and `register_keyed_size`'s authority rule keeps whichever
+/// registration does.
+pub(crate) fn publish_effect_info_descr_mints(entries: &[majit_ir::effectinfo::DescrMintEntry]) {
+    use majit_ir::descr::LLType;
+    use majit_ir::effectinfo::{DescrMintSpec, DescrSetMember};
+
+    for entry in entries {
+        match (&entry.member, &entry.spec) {
+            (
+                DescrSetMember::Field {
+                    struct_id,
+                    field_name,
+                },
+                spec,
+            ) => {
+                mint_field(LLType::Struct(*struct_id), field_name, spec);
+            }
+            (DescrSetMember::Array { array_id }, spec) => {
+                mint_array(LLType::Array(*array_id), spec);
+            }
+            (
+                DescrSetMember::InteriorField { array_id, name },
+                DescrMintSpec::InteriorField {
+                    array,
+                    field_struct_id,
+                    field_name,
+                    field,
+                },
+            ) => {
+                let array_key = LLType::Array(*array_id);
+                let Some(array_descr) = mint_array(array_key.clone(), array)
+                    .and_then(majit_ir::descr::descr_arc_as_array_descr)
+                else {
+                    continue;
+                };
+                // `descr.py:435 fielddescr = get_field_descr(gc_ll_descr,
+                // REALARRAY.OF, name)` — the element struct's own slot, then
+                // `:436 InteriorFieldDescr(arraydescr, fielddescr)`.
+                let Some(field_descr) =
+                    mint_field(LLType::Struct(*field_struct_id), field_name, field)
+                else {
+                    continue;
+                };
+                let _ = majit_ir::descr::gc_cache()
+                    .lock()
+                    .unwrap()
+                    .get_interiorfield_descr(
+                        array_key,
+                        name.clone(),
+                        String::new(),
+                        array_descr,
+                        field_descr,
+                    );
+            }
+            // A member paired with a spec of another shape cannot describe its
+            // own slot; leaving it unpublished keeps it counted as absent
+            // rather than filling the slot with the wrong layout.
+            _ => {}
+        }
+    }
+}
+
+/// `descr.py:234-238` — bind the parent size descr, then mint the field.
+fn mint_field(
+    struct_key: majit_ir::descr::LLType,
+    field_name: &str,
+    spec: &majit_ir::effectinfo::DescrMintSpec,
+) -> Option<std::sync::Arc<dyn majit_ir::descr::FieldDescr>> {
+    let majit_ir::effectinfo::DescrMintSpec::Field {
+        struct_size,
+        offset,
+        field_size,
+        field_type,
+        flag,
+        is_immutable,
+        is_quasi_immutable,
+        index_in_parent,
+    } = spec
+    else {
+        return None;
+    };
+    let mut gc = majit_ir::descr::gc_cache().lock().unwrap();
+    // Only an empty slot is this function's business: an unresolvable member is
+    // by definition one nothing has filled, and a filled slot already belongs
+    // to whoever published it. `get_field_descr` would return that owner's
+    // descr anyway (`descr.py:220-221`), so taking the hit through it changes
+    // nothing except to offer a second opinion on the layout — and the two
+    // producers do not agree on one field of it. `index_in_parent` here is the
+    // analyzer's `field_pos`, which counts the header words at offsets 0 and 8
+    // that `heaptracker.py:60-71 all_fielddescrs` skips, so it reads two higher
+    // than the runtime publish's for the same field.
+    if let Some(existing) = gc
+        ._cache_field
+        .get(&struct_key)
+        .and_then(|inner| inner.get(field_name))
+    {
+        return Some(existing.clone() as std::sync::Arc<dyn majit_ir::descr::FieldDescr>);
+    }
+    // `descr.py:238 fielddescr.parent_descr = get_size_descr(gccache, STRUCT,
+    // vtable)`; the analyzer has no vtable surface, so 0 — a runtime publish
+    // that carries one wins the slot either way.
+    let _parent = gc.get_size_descr(struct_key.clone(), *struct_size, 0, false);
+    Some(gc.get_field_descr(
+        struct_key,
+        field_name,
+        None,
+        *offset,
+        *field_size,
+        *field_type,
+        *is_immutable,
+        *is_quasi_immutable,
+        *flag,
+        u32::MAX,
+        false,
+        *index_in_parent,
+    ))
+}
+
+/// `descr.py:353-370` — mint the array descr, including its lendescr.
+fn mint_array(
+    array_key: majit_ir::descr::LLType,
+    spec: &majit_ir::effectinfo::DescrMintSpec,
+) -> Option<majit_ir::DescrRef> {
+    let majit_ir::effectinfo::DescrMintSpec::Array {
+        base_size,
+        item_size,
+        flag,
+        item_type,
+        nolength,
+        length_offset,
+        is_pure,
+        concrete_type,
+    } = spec
+    else {
+        return None;
+    };
+    Some(majit_ir::descr::gc_cache().lock().unwrap().get_array_descr(
+        array_key,
+        *base_size,
+        *item_size,
+        *flag,
+        *item_type,
+        *nolength,
+        *length_offset,
+        *is_pure,
+        *concrete_type,
+    ))
+}
+
 /// `ambiguous` empty alone is not enough to call the gate green: a member
-/// whose container is not registered *yet* answers `AbsentContainer`, which
-/// looks identical to the legitimate projection.  So the ledger carries all
-/// three outcomes — a run where `absent` dwarfs `resolved` has an empty
-/// `ambiguous` set vacuously, because nothing was ever joined.
+/// whose container is not registered answers `AbsentContainer` instead, so a
+/// run where `absent` dwarfs `resolved` has an empty `ambiguous` set
+/// vacuously, because nothing was ever joined.  The ledger carries all three
+/// outcomes so the denominator is visible next to the two failures.
 #[derive(Default)]
 pub struct SetMemberLedger {
     pub resolved: usize,
@@ -4774,5 +4937,52 @@ mod set_member_lookup_tests {
             }),
             "Array(0x0000000000000010)"
         );
+    }
+
+    /// The point of carrying the mint arguments across the build/runtime split:
+    /// a container this process would never otherwise name resolves anyway,
+    /// because the publish takes the same `descr.py:224-238` miss branch the
+    /// analyzer took. Without it the member reads `AbsentContainer` — which is
+    /// the pre-state this asserts first, on the same key.
+    #[test]
+    fn publishing_the_recorded_mint_turns_an_absent_member_into_a_resolved_one() {
+        use majit_ir::effectinfo::{DescrMintEntry, DescrMintSpec};
+
+        let struct_id = 0x7e57_0000_0000_0003u64;
+        let member = DescrSetMember::Field {
+            struct_id,
+            field_name: "carried".to_string(),
+        };
+        assert!(
+            matches!(
+                descr_from_set_member(&member),
+                SetMemberLookup::AbsentContainer
+            ),
+            "nothing has named this container yet"
+        );
+
+        publish_effect_info_descr_mints(&[DescrMintEntry {
+            member: member.clone(),
+            spec: DescrMintSpec::Field {
+                struct_size: 24,
+                offset: 16,
+                field_size: 8,
+                field_type: majit_ir::value::Type::Int,
+                flag: majit_ir::descr::ArrayFlag::Signed,
+                is_immutable: false,
+                is_quasi_immutable: false,
+                index_in_parent: 1,
+            },
+        }]);
+
+        let SetMemberLookup::Resolved(descr) = descr_from_set_member(&member) else {
+            panic!("the published slot must resolve");
+        };
+        let field = descr
+            .as_field_descr()
+            .expect("a Field member resolves to a FieldDescr");
+        assert_eq!(field.offset(), 16);
+        assert_eq!(field.field_size(), 8);
+        assert_eq!(field.index_in_parent(), 1);
     }
 }

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -4739,8 +4739,26 @@ pub fn rehydrate_effect_info(ei: &mut majit_ir::EffectInfo) {
             record_set_member_lookup(m, &looked_up);
             match looked_up {
                 SetMemberLookup::Resolved(d) => out.push(d),
-                SetMemberLookup::AbsentContainer => {}
-                SetMemberLookup::Ambiguous => return None,
+                // `effectinfo.py:479-494 compute_bitstrings` unions EVERY
+                // member of every raw set; a member there is a live descr
+                // object, so upstream has no third answer.  Both of pyre's
+                // non-answers therefore mean the same thing — this set
+                // cannot be completed — and the only sound reply is the
+                // `EF_RANDOM_EFFECTS` wildcard.  Keeping a *concrete* set
+                // with the member omitted is what breaks the contract
+                // `optimizeopt/heap.rs force_from_effectinfo` relies on:
+                // out-of-range `bitcheck` returns false (`bitstring.py:16-20`
+                // parity), so the omission reads as "the callee does not
+                // write this field" and the optimizer keeps a stale heap
+                // cache entry across a call that does write it.
+                //
+                // Absence is not even stable — the descr universe keeps
+                // growing after the raw sets freeze, so a container absent
+                // at rehydrate time can arrive later while the omission
+                // lives on.  Closing the serialized universe (the
+                // build-time `DescrMintSpec` channel) is what makes this
+                // arm unreachable rather than merely rare.
+                SetMemberLookup::AbsentContainer | SetMemberLookup::Ambiguous => return None,
             }
         }
         Some(majit_ir::effectinfo::canonicalize_descr_set(out))

--- a/pyre/pyre-jit-trace/src/jitcode_runtime.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_runtime.rs
@@ -401,10 +401,34 @@ static ALL_DESCRS: LazyLock<Vec<BhDescr>> = LazyLock::new(|| {
     })
 });
 
-/// RPython: `metainterp_sd.all_descrs` — full shared descr pool.
+/// RPython: `metainterp_sd.opcode_descrs` (`pyjitpl.py:2245-2246`) — the
+/// bytecode constant pool, not `metainterp_sd.all_descrs`.
+///
+/// `all_descrs` upstream is `cpu.setup_descrs()` (`pyjitpl.py:2289`), the full
+/// gccache walk of `descr.py:25-47`; pyre's counterpart of *that* is
+/// `MetaInterpStaticData::finish_setup_descrs`, which enumerates the live
+/// `descr_registry`. The gap between the two tables is what
+/// [`ALL_EI_DESCR_MINTS`] carries.
 pub fn all_descrs() -> &'static [BhDescr] {
     &ALL_DESCRS
 }
+
+/// Deserialized `pipeline.ei_descr_mints` — the gccache slots that only an
+/// `EffectInfo` raw set names, paired with the arguments their mint took.
+///
+/// See `descr::publish_effect_info_descr_mints` for why the opcode table alone
+/// leaves these slots empty on this side of the build/runtime split.
+static ALL_EI_DESCR_MINTS: LazyLock<Vec<majit_ir::effectinfo::DescrMintEntry>> =
+    LazyLock::new(|| {
+        const BYTES: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/ei_descr_mints.bin"));
+        bincode::deserialize(BYTES).unwrap_or_else(|e| {
+            panic!(
+                "pyre-jit-trace: failed to deserialize ei_descr_mints.bin \
+                 ({} bytes): {e}",
+                BYTES.len(),
+            )
+        })
+    });
 
 /// Deserialized `pipeline.all_liveness` — RPython `Assembler.all_liveness`
 /// (assembler.py), the target of `pyjitpl.py:2264 self.liveness_info =
@@ -492,6 +516,18 @@ pub fn rehydrate_build_descr_raw_sets() {
                 crate::descr::make_descr_from_bh(bh);
             }
         }
+        // Last, and only into what is still empty: the slots no opcode names,
+        // which `descrs.bin` — RPython's `opcode_descrs`, not its `all_descrs`
+        // — therefore does not carry.  Without them a raw-set member whose
+        // container appears in no bytecode reads as `AbsentContainer` even
+        // though the analyzer minted it.
+        //
+        // After the loop above rather than before it, because both are
+        // build-time producers that disagree on `index_in_parent` for a shared
+        // field, and going first would mean pre-filling a slot the loop then
+        // asks for with its own numbering.  Publishing what the established
+        // producers left over keeps their answers untouched.
+        crate::descr::publish_effect_info_descr_mints(&ALL_EI_DESCR_MINTS);
         let mut refs = vec![None; all.len()];
         for (i, bh) in all.iter().enumerate() {
             let calldescr = match bh {
@@ -531,13 +567,17 @@ fn report_descr_spelling_gate() {
 
 /// The descr-universe invariants, as `[jit-stats]` key/value tokens.
 ///
-/// `ambiguous` and `stale_absent` are the two upstream cannot reach, so
-/// `check.py` lists them in `JITSTATS_BADNESS_FIELDS` and fails the run if
-/// either rises off zero. `absent` is the divergence itself rather than a
-/// benign projection — `effectinfo.py:492-494` builds its sets out of descr
-/// objects `cpu.*descrof` just minted, so upstream has no member that fails to
-/// resolve — and it is carried as a ratchet: the committed baseline pins what
-/// this `descrs.bin` still drops, and it may fall but never rise.
+/// All three of `absent`, `ambiguous` and `stale_absent` are answers upstream
+/// cannot reach — `effectinfo.py:492-494` builds its sets out of descr objects
+/// `cpu.*descrof` just minted, so no member of a raw set can fail to resolve —
+/// so `check.py` lists them in `JITSTATS_BADNESS_FIELDS` and fails the run if
+/// any rises off zero. That is pyre's form of the bare `assert` upstream states
+/// this class of condition with (`descr.py:47`, `effectinfo.py:486`, `:525`),
+/// which the build-time/runtime split makes reachable and therefore
+/// unassertable.
+///
+/// `resolved` is the denominator, and rides along so a run that resolves
+/// nothing cannot look identical to one that resolves everything.
 ///
 /// `stale_absent` re-asks the `AbsentContainer` question against the universe
 /// as it stands now, so it must be read at process exit, after the run has

--- a/pyre/pyre-jit-trace/src/jitcode_runtime.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_runtime.rs
@@ -505,24 +505,22 @@ pub fn rehydrate_build_descr_raw_sets() {
     });
 }
 
-/// Print the [`crate::descr::set_member_ledger`] under
+/// Name every member the ledger could not join, under
 /// `PYRE_DESCR_SPELLING_GATE=1`.
+///
+/// The counts themselves ride the `[jit-stats]` line
+/// ([`descr_set_jit_stats`]), which is what gates in CI. This is the detail
+/// behind them — the counterpart of `effectinfo.py:474-499`, where
+/// `compute_bitstrings` logs its per-key descr tallies through
+/// `policy.log` while expressing the impossible cases as bare `assert`s.
 ///
 /// The whole serialized raw-set universe is resolved inside the `Once` above
 /// and nowhere else, so this runs exactly once with the ledger complete.
-/// Green is `ambiguous=0` **with** a `resolved` count that shows the join
-/// actually happened; `ambiguous=0, resolved=0` is vacuous.
 fn report_descr_spelling_gate() {
     if std::env::var_os("PYRE_DESCR_SPELLING_GATE").is_none() {
         return;
     }
     let ledger = crate::descr::set_member_ledger();
-    eprintln!(
-        "[descr-spelling-gate] resolved={} absent={} ambiguous={}",
-        ledger.resolved,
-        ledger.absent.len(),
-        ledger.ambiguous.len()
-    );
     for label in &ledger.ambiguous {
         eprintln!("[descr-spelling-gate] ambiguous {label}");
     }
@@ -531,19 +529,42 @@ fn report_descr_spelling_gate() {
     }
 }
 
-/// Re-ask the `AbsentContainer` question once the run is over, and report
-/// every member whose container has since been registered.
+/// The descr-universe invariants, as `[jit-stats]` key/value tokens.
 ///
-/// Called from the same post-`real_main` hook as
-/// [`field_descr_identity_census_now`], so it sees the fully grown universe
-/// rather than the one the `Once` above resolved against. Each entry is a live
-/// instance of the gap documented on `SetMemberLookup::AbsentContainer`: an
-/// `EffectInfo` frozen while its container was unregistered still claims the
-/// callee does not touch it.
+/// `ambiguous` and `stale_absent` are the two upstream cannot reach, so
+/// `check.py` lists them in `JITSTATS_BADNESS_FIELDS` and fails the run if
+/// either rises off zero. `absent` is the divergence itself rather than a
+/// benign projection — `effectinfo.py:492-494` builds its sets out of descr
+/// objects `cpu.*descrof` just minted, so upstream has no member that fails to
+/// resolve — and it is carried as a ratchet: the committed baseline pins what
+/// this `descrs.bin` still drops, and it may fall but never rise.
+///
+/// `stale_absent` re-asks the `AbsentContainer` question against the universe
+/// as it stands now, so it must be read at process exit, after the run has
+/// published everything it is going to.
+pub fn descr_set_jit_stats() -> String {
+    let ledger = crate::descr::set_member_ledger();
+    format!(
+        "descr_set_resolved={} descr_set_absent={} descr_set_ambiguous={} descr_set_stale_absent={}",
+        ledger.resolved,
+        ledger.absent.len(),
+        ledger.ambiguous.len(),
+        crate::descr::stale_absent_containers().len(),
+    )
+}
+
+/// Name every member whose container has been registered since its raw set was
+/// frozen, under `PYRE_DESCR_SPELLING_GATE=1`.
+///
+/// Each one is a live instance of the gap documented on
+/// `SetMemberLookup::AbsentContainer`: an `EffectInfo` frozen while its
+/// container was unregistered still claims the callee does not touch it. The
+/// count is gated through [`descr_set_jit_stats`]; this is the detail.
 pub fn descr_spelling_gate_recheck_now() {
-    let stale = crate::descr::stale_absent_containers();
-    eprintln!("[descr-spelling-gate] stale_absent={}", stale.len());
-    for label in &stale {
+    if std::env::var_os("PYRE_DESCR_SPELLING_GATE").is_none() {
+        return;
+    }
+    for label in &crate::descr::stale_absent_containers() {
         eprintln!("[descr-spelling-gate] stale_absent {label}");
     }
 }

--- a/pyre/pyre-jit/src/lib.rs
+++ b/pyre/pyre-jit/src/lib.rs
@@ -55,7 +55,7 @@ mod trace_verify;
 
 // Re-export auto-generated trace functions from pyre-jit-trace
 pub use pyre_jit_trace::jitcode_runtime::{
-    descr_spelling_gate_recheck_now, field_descr_identity_census_now,
+    descr_set_jit_stats, descr_spelling_gate_recheck_now, field_descr_identity_census_now,
 };
 pub use pyre_jit_trace::{
     trace_box_float, trace_box_int, trace_float_binop, trace_float_compare, trace_int_binop,

--- a/pyre/pyrex/src/lib.rs
+++ b/pyre/pyrex/src/lib.rs
@@ -545,7 +545,10 @@ pub fn main_entry(binary_name: &'static str) {
     // stack. A child that raises the limit far past that, or shrinks the stack
     // via ulimit, gets a SIGSEGV reaped by the trusted controller, not an escape.
     #[cfg(feature = "sandbox")]
-    real_main(binary_name);
+    {
+        real_main(binary_name);
+        post_run_diagnostics();
+    }
 
     // Block async signals on this (the process's original) thread so the
     // kernel delivers process-directed signals to the interpreter thread
@@ -559,17 +562,27 @@ pub fn main_entry(binary_name: &'static str) {
             .stack_size(256 * 1024 * 1024)
             .spawn(|| {
                 real_main(binary_name);
-                if std::env::var_os("PYRE_FIELD_IDENTITY_CENSUS").is_some() {
-                    pyre_jit::field_descr_identity_census_now();
-                }
-                if std::env::var_os("PYRE_DESCR_SPELLING_GATE").is_some() {
-                    pyre_jit::descr_spelling_gate_recheck_now();
-                }
+                post_run_diagnostics();
             })
             .expect("spawn main thread")
             .join()
             .unwrap();
     }
+}
+
+/// Diagnostics that have to read the descr universe *after* it has finished
+/// growing, so they run once `real_main` returns rather than inside it. Each is
+/// gated on its own environment variable internally.
+///
+/// The counts these name are already on the `[jit-stats]` line, which
+/// `maybe_print_jit_stats` emits from `real_main`'s exit paths and so survives
+/// a `process::exit` this hook does not reach. These print *which* members,
+/// never whether the gate holds.
+fn post_run_diagnostics() {
+    if std::env::var_os("PYRE_FIELD_IDENTITY_CENSUS").is_some() {
+        pyre_jit::field_descr_identity_census_now();
+    }
+    pyre_jit::descr_spelling_gate_recheck_now();
 }
 
 fn real_main(binary_name: &str) {
@@ -916,10 +929,12 @@ fn maybe_print_jit_stats() {
     // per trace while `descr.py:47` asserts it stays under 2**15 — upstream
     // fills it once at translation time, so only pyre can run into that bound.
     //
-    // Printed BEFORE the structural summary: `check.py` `_jit_stats_snapshot`
-    // keeps the LAST `[jit-stats]` line, so the structural counters have to be
-    // last or the baseline compare reads these tallies instead and the
-    // loops_aborted / internal_compile_panics floor silently stops firing.
+    // Printed BEFORE the structural summary, which is where it used to have to
+    // be: `check.py` `_jit_stats_snapshot` once kept only the LAST
+    // `[jit-stats]` line, so a diag line emitted after the counters displaced
+    // them and the loops_aborted / internal_compile_panics floor silently
+    // stopped firing. That snapshot now merges every line, so the order is no
+    // longer load-bearing — but the reading stays grouped diag-then-summary.
     // The wasm runner orders its diag lines the same way.
     let all_descrs_len = pyre_jit::eval::driver_pair()
         .0
@@ -943,6 +958,10 @@ fn maybe_print_jit_stats() {
         stats.guard_failures,
         stats.internal_compile_panics,
     );
+    // The descr-universe invariants. `descr_set_stale_absent` re-asks the
+    // `AbsentContainer` question against the universe as it stands now, so it
+    // has to be read here, after the run published everything it is going to.
+    eprintln!("[jit-stats] {}", pyre_jit::descr_set_jit_stats());
 }
 
 /// Shared top-level launcher bootstrap for `run_source` and `run_module`:


### PR DESCRIPTION
Follow-up to #865, which landed the descr-universe ledger. Reviewing it against
upstream showed it was an instrument, not a gate — and that the channel a gate
would have to ride on was itself broken.

## The jit-stats badness floor was inert

`_jit_stats_snapshot` kept only the **last** `[jit-stats]` line. The interpreter
emits two — the counters, then the mc_diag tallies — so the snapshot carried the
mc_diag fields and neither `loops_aborted` nor `internal_compile_panics`.
`_jit_stats_regression_floor` reads both through `.get(field, 0)`, so on the
current side they were always 0 and `cur > base` could never hold.

Measured against the committed `bench/int_loop.dynasm.jitstats`:

| synthetic run | floor verdict, before | after |
|---|---|---|
| `loops_aborted=7` | `''` | `jit-stats regression: loops_aborted 0 -> 7` |
| `internal_compile_panics=3` | `''` | `jit-stats regression: internal_compile_panics 0 -> 3` |

This is the only jit-stats check that runs on **every** invocation rather than
under `--snapshot-diff`, so nothing was gating it. Merging the lines leaves the
committed baselines valid — the floor compares per field and reads a missing one
as 0 — so no re-record is needed. `check.py` stays at 6 failed / 326 passed per
backend, which also says nothing had drifted while the floor was blind.

## What upstream says about the gate

`compute_bitstrings` (`effectinfo.py:474-499`) **does** log its per-key descr
tallies through `policy.log`, so counting at this point has a counterpart. What
it has no category for is a member that fails to resolve: `effectinfo.py:492-494`
builds the sets out of the descr objects `cpu.*descrof` just minted in the same
process. Upstream states that class of condition as a bare `assert`
(`descr.py:47`, `effectinfo.py:486,525`).

Two consequences:

1. **`absent` is not a benign projection.** It is the divergence itself, and its
   count is the number to drive down. This removes the half of the green
   condition I had been computing by hand in #865 — intersecting `absent` keys
   against `path_hash` of every spelling of every published group. No spelling
   table is needed; `absent` *is* the answer.
2. **The failure conditions want an assert, and pyre's form of one is a badness
   counter.** Pyre cannot hard-assert — the build-time/runtime split makes both
   states reachable in principle, and the runtime answer is a sound degradation
   to `EF_RANDOM_EFFECTS` rather than a crash — so the assertion becomes a
   counter that must not rise off zero.

## What that makes the gate

```
[jit-stats] descr_set_resolved=88 descr_set_absent=58 descr_set_ambiguous=0 descr_set_stale_absent=0
```

`JITSTATS_BADNESS_FIELDS` now carries `descr_set_ambiguous` and
`descr_set_stale_absent`. A field missing from a baseline reads as 0, so both
gate from the first run with **no baseline re-record**. `descr_set_absent` stays
informational — 58 today — pinned by the committed baselines as a ratchet that
may fall but not rise.

Verified each field fires:

```
clean run             -> ''
ambiguous rose        -> 'jit-stats regression: descr_set_ambiguous 0 -> 1'
stale_absent rose     -> 'jit-stats regression: descr_set_stale_absent 0 -> 2'
```

`PYRE_DESCR_SPELLING_GATE` keeps only what the counts cannot say — *which*
members — mirroring upstream's split between the `log` detail and the assert.

## Coverage gaps closed

`post_run_diagnostics` replaces the two inline env checks at the one call site
that had them and now runs on the sandbox path too. The counts no longer depend
on that hook at all: `maybe_print_jit_stats` emits them from `real_main`'s exit
paths, which a `process::exit` reaches and the post-run hook does not — that was
why 7 of 337 scripts printed nothing in the #865 sweep.

## Verification

- `check.py --backend dynasm,cranelift`: 6 failed / 326 passed per backend, the
  same 6 names as baseline (`jd1 drain body must contain a jit_merge_point` ×5 +
  `getframe_force_cancel_journal`), all pre-existing.
- `cargo test -p pyre-jit-trace ... set_member_lookup`: 2 passed — the
  `AbsentContainer` / `Ambiguous` split, and the label format.
- Floor behaviour measured per field, table above.

Note: `pyre/check.py (ubuntu-24.04)` is expected to fail on the inherited
`synth/exception_traceback_frame_lineno` GC crash that is red on `main` — see
the bisect in #865.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved reliability when rebuilding runtime type and field descriptors from cached compilation data.
  - Added support for preserving descriptor metadata across analysis, code generation, and runtime loading.
  - Enhanced handling and reporting of descriptor-resolution states, including missing and ambiguous entries.
  - Added descriptor consistency metrics to JIT statistics.

- **Diagnostics**
  - Post-run diagnostics now run consistently in sandboxed and non-sandboxed execution.
  - Expanded JIT regression checks with descriptor-related counters and normalized comparisons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->