### PR TITLE
jit: restore four dropped codewriter statements from jtransform/assembler

### DIFF
--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -3390,6 +3390,9 @@ mod tests {
             let mut builder = BlackholeInterpBuilder::new();
             let mut entries: indexmap::IndexMap<String, u8> = indexmap::IndexMap::new();
             entries.insert("int_copy/i>i".to_string(), insns::BC_MOVE_I);
+            // `load_const_i_value` picks the `USE_C_FORM` short encoding for
+            // byte-sized constants, so both `int_copy` variants must be wired.
+            entries.insert("int_copy/c>i".to_string(), insns::BC_MOVE_I_C);
             entries.insert("ref_copy/r>r".to_string(), insns::BC_MOVE_R);
             entries.insert("int_add/ii>i".to_string(), insns::BC_INT_ADD);
             entries.insert("int_mul/ii>i".to_string(), insns::BC_INT_MUL);

--- a/majit/majit-metainterp/src/jitcode/assembler.rs
+++ b/majit/majit-metainterp/src/jitcode/assembler.rs
@@ -368,7 +368,24 @@ impl JitCodeBuilder {
         self.constants_f.len() as u16
     }
 
+    /// Materialise an integer constant into `dst`.
+    ///
+    /// `assembler.py:163` sets `allow_short = (insn[0] in USE_C_FORM)` and
+    /// `int_copy` is in `USE_C_FORM` (`assembler.py:312`), so a value that
+    /// fits a signed byte is written inline as `int_copy/c>i`
+    /// (`assembler.py:99-107`) and costs no `constants_i` slot.  Registers
+    /// and constants of one kind share a single 256-wide index space, so
+    /// pooling every small constant instead pushes `try_finish` over the
+    /// `total_i > 256` ceiling and declines JitCodes the build-time
+    /// assembler — which does emit the short form — would have accepted.
     pub fn load_const_i_value(&mut self, dst: u16, value: i64) {
+        if let Ok(short) = i8::try_from(value) {
+            self.touch_reg(dst);
+            self.write_insn("int_copy/c>i");
+            self.push_u8(short as u8);
+            self.push_reg_u8(dst, "int_copy/c>i dst");
+            return;
+        }
         let const_idx = self.add_const_i(value);
         self.load_const_i(dst, const_idx);
     }
@@ -5795,6 +5812,9 @@ mod tests {
         let mut entries: indexmap::IndexMap<String, u8> = indexmap::IndexMap::new();
         entries.insert("switch/id".to_string(), jitcode::insns::BC_SWITCH);
         entries.insert("int_copy/i>i".to_string(), jitcode::insns::BC_MOVE_I);
+        // `load_const_i_value` emits the `USE_C_FORM` short encoding for
+        // byte-sized constants, so wire both `int_copy` variants.
+        entries.insert("int_copy/c>i".to_string(), jitcode::insns::BC_MOVE_I_C);
         entries.insert("int_return/i".to_string(), jitcode::insns::BC_INT_RETURN);
         let mut builder = BlackholeInterpBuilder::new();
         builder.setup_insns(&entries);
@@ -6436,6 +6456,52 @@ mod tests {
             builder.add_const_i(value);
         }
         assert!(builder.try_finish().is_none());
+    }
+
+    /// `int_copy` is in `USE_C_FORM` (`assembler.py:312`), so a byte-sized
+    /// constant is written inline rather than into `constants_i`.
+    #[test]
+    fn load_const_i_value_uses_the_short_form_for_byte_sized_values() {
+        let mut builder = JitCodeBuilder::new();
+        builder.ensure_i_regs(1);
+        builder.load_const_i_value(0, -5);
+        let jitcode = builder.try_finish().expect("short form must assemble");
+        assert_eq!(
+            jitcode.code,
+            vec![
+                majit_translate::codewriter::insns::insn_byte("int_copy/c>i"),
+                (-5i8) as u8,
+                0
+            ]
+        );
+    }
+
+    /// A value that does not fit a signed byte still goes through the pool
+    /// as `int_copy/i>i`.
+    #[test]
+    fn load_const_i_value_pools_values_wider_than_a_byte() {
+        let mut builder = JitCodeBuilder::new();
+        builder.ensure_i_regs(1);
+        builder.load_const_i_value(0, 1000);
+        let jitcode = builder.try_finish().expect("pooled form must assemble");
+        assert_eq!(
+            jitcode.code[0],
+            majit_translate::codewriter::insns::insn_byte("int_copy/i>i")
+        );
+    }
+
+    /// Registers and constants of one kind share a single 256-wide index
+    /// space.  Pooling every small constant pushes `total_i` past it and
+    /// declines the JitCode; the short form keeps them out of the pool
+    /// entirely, so a full byte range of distinct constants still assembles.
+    #[test]
+    fn a_full_byte_range_of_small_constants_still_assembles() {
+        let mut builder = JitCodeBuilder::new();
+        builder.ensure_i_regs(1);
+        for value in -128..=127i64 {
+            builder.load_const_i_value(0, value);
+        }
+        assert!(builder.try_finish().is_some());
     }
 
     fn fill_descr_pool(entries: usize) -> JitCodeBuilder {

--- a/majit/majit-metainterp/src/jitcode/assembler.rs
+++ b/majit/majit-metainterp/src/jitcode/assembler.rs
@@ -4554,13 +4554,30 @@ impl JitCodeBuilder {
         self.add_sub_jitcode_arc(std::sync::Arc::new(jitcode))
     }
 
+    /// Append a descr-pool entry and return the two-byte operand index that
+    /// refers to it.
+    ///
+    /// `assembler.py:204 assert 0 <= num <= 0xFFFF, "too many AbstractDescrs!"`
+    /// bounds the same index; upstream aborts translation, and the
+    /// build-time builder does too.  This builder runs at runtime and cannot
+    /// panic, so an index past the operand width latches the overflow flag
+    /// and `try_finish` declines the JitCode, the same way `push_reg_u8`
+    /// handles a register index that outgrows its byte.
+    fn push_descr_entry(&mut self, entry: RuntimeBhDescr) -> u16 {
+        let idx = self.descrs.len();
+        self.descrs.push(entry);
+        if idx > u16::MAX as usize {
+            self.encoding_overflow = true;
+            return 0;
+        }
+        idx as u16
+    }
+
     /// Variant accepting an already-shared `Arc<JitCode>` for callers
     /// that already hold a shared handle (e.g. a re-export from
     /// `MetaInterpStaticData::indirectcalltargets`).
     pub fn add_sub_jitcode_arc(&mut self, jitcode: std::sync::Arc<JitCode>) -> u16 {
-        let idx = self.descrs.len() as u16;
-        self.descrs.push(RuntimeBhDescr::JitCode(jitcode));
-        idx
+        self.push_descr_entry(RuntimeBhDescr::JitCode(jitcode))
     }
 
     pub fn add_fn_ptr(&mut self, ptr: *const ()) -> u16 {
@@ -4639,9 +4656,7 @@ impl JitCodeBuilder {
                 }
             }
         }
-        let idx = self.descrs.len() as u16;
-        self.descrs.push(RuntimeBhDescr::Call(target));
-        idx
+        self.push_descr_entry(RuntimeBhDescr::Call(target))
     }
 
     pub fn add_call_assembler_target_number(
@@ -4657,9 +4672,7 @@ impl JitCodeBuilder {
                 }
             }
         }
-        let idx = self.descrs.len() as u16;
-        self.descrs.push(RuntimeBhDescr::AssemblerToken(target));
-        idx
+        self.push_descr_entry(RuntimeBhDescr::AssemblerToken(target))
     }
 
     pub fn add_call_assembler_target(
@@ -4759,22 +4772,17 @@ impl JitCodeBuilder {
                 }
             }
         }
-        let idx = self.descrs.len() as u16;
-        self.descrs.push(RuntimeBhDescr::Descr(descr));
-        idx
+        self.push_descr_entry(RuntimeBhDescr::Descr(descr))
     }
 
     fn add_switch_descr(&mut self, mut const_keys_in_order: Vec<i64>) -> u16 {
         const_keys_in_order.sort();
-        let idx = self.descrs.len() as u16;
         // RPython creates one SwitchDictDescr object per switch site
         // (`flatten.py:282-285`), so do not deduplicate.
-        self.descrs
-            .push(RuntimeBhDescr::Descr(CanonicalBhDescr::Switch {
-                dict: std::collections::HashMap::new(),
-                const_keys_in_order,
-            }));
-        idx
+        self.push_descr_entry(RuntimeBhDescr::Descr(CanonicalBhDescr::Switch {
+            dict: std::collections::HashMap::new(),
+            const_keys_in_order,
+        }))
     }
 
     pub fn try_finish(mut self) -> Option<JitCode> {
@@ -6427,6 +6435,35 @@ mod tests {
         for value in 0..256 {
             builder.add_const_i(value);
         }
+        assert!(builder.try_finish().is_none());
+    }
+
+    fn fill_descr_pool(entries: usize) -> JitCodeBuilder {
+        let mut builder = JitCodeBuilder::new();
+        for _ in 0..entries {
+            builder.push_descr_entry(RuntimeBhDescr::Call(JitCallTarget::new(
+                std::ptr::null(),
+                std::ptr::null(),
+            )));
+        }
+        builder
+    }
+
+    /// A descr operand is two bytes wide, so `0xFFFF` is the last index a
+    /// bytecode can name (`assembler.py:204`).
+    #[test]
+    fn try_finish_accepts_last_two_byte_descr_slot() {
+        let builder = fill_descr_pool(u16::MAX as usize + 1);
+        assert!(builder.try_finish().is_some());
+    }
+
+    /// One entry past the operand width. Upstream aborts translation with
+    /// `assert 0 <= num <= 0xFFFF, "too many AbstractDescrs!"`; this builder
+    /// runs at runtime, so it latches the overflow flag and declines the
+    /// JitCode instead of wrapping the index with `as u16`.
+    #[test]
+    fn try_finish_declines_descr_pool_overflow() {
+        let builder = fill_descr_pool(u16::MAX as usize + 2);
         assert!(builder.try_finish().is_none());
     }
 }

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -11229,7 +11229,10 @@ mod tests {
     fn build_state_field_snapshot_reads_constants_from_liveness() {
         let mut asm = majit_translate::codewriter::assembler::Assembler::new();
         let mut builder = JitCodeBuilder::new();
-        builder.load_const_i_value(0, 0);
+        // Wider than a signed byte so it takes a `constants_i` slot rather
+        // than `int_copy`'s inline `USE_C_FORM` encoding — the pool read is
+        // what this test covers.
+        builder.load_const_i_value(0, 1000);
         let const_slot = 1u8;
         builder.live(&mut asm, &[const_slot], &[], &[]);
         let pc = builder.current_pos();
@@ -11253,7 +11256,7 @@ mod tests {
         assert_eq!(
             f.boxes,
             vec![crate::recorder::SnapshotTagged::Const(
-                0,
+                1000,
                 majit_ir::Type::Int
             )]
         );

--- a/majit/majit-translate/src/codewriter/jtransform.rs
+++ b/majit/majit-translate/src/codewriter/jtransform.rs
@@ -4436,6 +4436,25 @@ impl<'a> Transformer<'a> {
         }
         match key {
             JitMarkerKey::LoopHeader | JitMarkerKey::CanEnterJit => {
+                // `support.py:77-80` runs its `assert methname ==
+                // 'jit_merge_point'` over every marker of a reds='auto'
+                // driver, so a `can_enter_jit` on such a driver is a hard
+                // error: the auto-detected red set is computed from the
+                // jit_merge_point's own block and is not valid for a
+                // marker sitting in another block.
+                if let Some(cc) = self.callcontrol.as_deref()
+                    && let Some(jd) = cc.jitdriver_sd_from_jitdriver(jitdriver_index)
+                {
+                    assert!(
+                        !jd.autoreds,
+                        "reds='auto' is supported only for jit drivers which \
+                         calls only jit_merge_point. Found a call to {}",
+                        match key {
+                            JitMarkerKey::CanEnterJit => "can_enter_jit",
+                            _ => "loop_header",
+                        },
+                    );
+                }
                 // jtransform.py:1723 `handle_jit_marker__can_enter_jit =
                 // handle_jit_marker__loop_header`.
                 Some(self.handle_jit_marker__loop_header(jitdriver_index))
@@ -8382,6 +8401,32 @@ mod tests {
             OpKind::LoopHeader { jitdriver_index } => assert_eq!(*jitdriver_index, 2),
             other => panic!("expected LoopHeader, got {other:?}"),
         }
+    }
+
+    #[test]
+    #[should_panic(expected = "reds='auto' is supported only for jit drivers")]
+    fn try_handle_jit_marker_rejects_can_enter_jit_on_an_autoreds_driver() {
+        // `support.py:77-80` — the auto-detected red set comes from the
+        // jit_merge_point's own block, so a second marker kind on the same
+        // driver has no consistent red set and upstream refuses to translate.
+        let config = GraphTransformConfig::default();
+        let mut cc = crate::call::CallControl::new();
+        cc.setup_jitdriver(
+            crate::parse::CallPath::from_segments(["autoreds_portal"]),
+            vec!["greenkey".to_string()],
+            Vec::new(),
+            true,
+            Vec::new(),
+            Vec::new(),
+        );
+        let mut transformer = Transformer::new(&config)
+            .with_callcontrol(&mut cc)
+            .with_portal_jd(Some(0));
+        let _ = transformer.try_handle_jit_marker(
+            JitMarkerKey::CanEnterJit,
+            &[],
+            &crate::model::FunctionGraph::new("fixture"),
+        );
     }
 
     #[test]

--- a/majit/majit-translate/src/codewriter/jtransform.rs
+++ b/majit/majit-translate/src/codewriter/jtransform.rs
@@ -981,6 +981,25 @@ impl<'a> Transformer<'a> {
                 });
                 RewriteResult::Keep
             }
+            // `jtransform.py:384-392` `rewrite_op_int_add_ovf` (aliased to
+            // `rewrite_op_int_mul_ovf`) and `rewrite_op_int_sub_ovf` both
+            // return `[SpaceOperation('-live-', [], None), op]`.  `flatten`
+            // pops the overflow-checked op back off the emitted line and
+            // re-spells it as `int_*_jump_if_ovf`, a guard that resumes at
+            // this point — the `-live-` in front is what makes that a valid
+            // resume point rather than one that merely happens to inherit a
+            // marker from the preceding operation.
+            OpKind::BinOp { op: binop_name, .. }
+                if matches!(binop_name.as_str(), "add_ovf" | "sub_ovf" | "mul_ovf") =>
+            {
+                RewriteResult::Replace(vec![
+                    SpaceOperation {
+                        result: None,
+                        kind: OpKind::Live,
+                    },
+                    op.clone(),
+                ])
+            }
             OpKind::BinOp {
                 op: binop_name,
                 lhs,
@@ -2443,14 +2462,23 @@ impl<'a> Transformer<'a> {
                 OpKind::FieldRead { base, .. } => base.clone(),
                 _ => unreachable!("rewrite_op_getfield called on non-FieldRead op"),
             };
-            return RewriteResult::Replace(vec![SpaceOperation {
-                result: op.result.clone(),
-                kind: OpKind::VableFieldRead {
-                    base: base_var,
-                    field_index: vable_field.index,
-                    ty: typed_ty.clone(),
+            // `jtransform.py:845-847` returns a two-element list led by
+            // `-live-`: a virtualizable access is a valid resume point, so
+            // the liveness marker belongs in front of it.
+            return RewriteResult::Replace(vec![
+                SpaceOperation {
+                    result: None,
+                    kind: OpKind::Live,
                 },
-            }]);
+                SpaceOperation {
+                    result: op.result.clone(),
+                    kind: OpKind::VableFieldRead {
+                        base: base_var,
+                        field_index: vable_field.index,
+                        ty: typed_ty.clone(),
+                    },
+                },
+            ]);
         }
         // `jtransform.py:867-903` — immutable and quasi-immutable
         // field reads both become `getfield_*_pure`; the quasi variant
@@ -2581,20 +2609,28 @@ impl<'a> Transformer<'a> {
                 OpKind::FieldWrite { base, .. } => base.clone(),
                 _ => unreachable!("rewrite_op_setfield called on non-FieldWrite op"),
             };
-            return RewriteResult::Replace(vec![SpaceOperation {
-                result: op.result.clone(),
-                kind: OpKind::VableFieldWrite {
-                    base: base_var,
-                    field_index: vable_field.index,
-                    // `rewrite_op_setfield` forwards `v_value` unchanged to
-                    // `setfield_vable_%s` (`jtransform.py:921-927`); a
-                    // constant operand stays inline.  `setfield_vable_i`
-                    // is not in USE_C_FORM, so the assembler encodes it as
-                    // a pool `i` slot rather than the short `c` byte.
-                    value: value.clone(),
-                    ty: typed_ty,
+            // `jtransform.py:926-928` — `-live-` leads the virtualizable
+            // write for the same reason as the read.
+            return RewriteResult::Replace(vec![
+                SpaceOperation {
+                    result: None,
+                    kind: OpKind::Live,
                 },
-            }]);
+                SpaceOperation {
+                    result: op.result.clone(),
+                    kind: OpKind::VableFieldWrite {
+                        base: base_var,
+                        field_index: vable_field.index,
+                        // `rewrite_op_setfield` forwards `v_value` unchanged to
+                        // `setfield_vable_%s` (`jtransform.py:921-927`); a
+                        // constant operand stays inline.  `setfield_vable_i`
+                        // is not in USE_C_FORM, so the assembler encodes it as
+                        // a pool `i` slot rather than the short `c` byte.
+                        value: value.clone(),
+                        ty: typed_ty,
+                    },
+                },
+            ]);
         }
         if &typed_ty != ty {
             let base_var = match &op.kind {
@@ -2636,17 +2672,25 @@ impl<'a> Transformer<'a> {
                 detail: format!("rewrite: array[idx] → VableArrayRead[{arr_idx}]"),
             });
             self.vable_rewrites += 1;
-            return RewriteResult::Replace(vec![SpaceOperation {
-                result: op.result.clone(),
-                kind: OpKind::VableArrayRead {
-                    base: vable_base,
-                    array_index: arr_idx,
-                    elem_index: index.clone(),
-                    item_ty: typed_item_ty,
-                    array_itemsize: itemsize,
-                    array_is_signed: is_signed,
+            // `jtransform.py:764-767` — `-live-` leads the virtualizable
+            // array read.
+            return RewriteResult::Replace(vec![
+                SpaceOperation {
+                    result: None,
+                    kind: OpKind::Live,
                 },
-            }]);
+                SpaceOperation {
+                    result: op.result.clone(),
+                    kind: OpKind::VableArrayRead {
+                        base: vable_base,
+                        array_index: arr_idx,
+                        elem_index: index.clone(),
+                        item_ty: typed_item_ty,
+                        array_itemsize: itemsize,
+                        array_is_signed: is_signed,
+                    },
+                },
+            ]);
         }
         if &typed_item_ty != item_ty {
             return RewriteResult::Replace(vec![SpaceOperation {
@@ -2698,24 +2742,32 @@ impl<'a> Transformer<'a> {
                 detail: format!("rewrite: array[idx] = v → VableArrayWrite[{arr_idx}]"),
             });
             self.vable_rewrites += 1;
-            return RewriteResult::Replace(vec![SpaceOperation {
-                result: op.result.clone(),
-                kind: OpKind::VableArrayWrite {
-                    base: vable_base,
-                    array_index: arr_idx,
-                    elem_index: index.clone(),
-                    // The vable rewrite only fires for virtualizable
-                    // arrays, which never carry an inline-const store; a
-                    // VableArrayWrite value is always a register.
-                    value: value
-                        .as_variable()
-                        .expect("vable array writes carry a Variable value")
-                        .clone(),
-                    item_ty: typed_item_ty,
-                    array_itemsize: itemsize,
-                    array_is_signed: is_signed,
+            // `jtransform.py:798-801` — `-live-` leads the virtualizable
+            // array write.
+            return RewriteResult::Replace(vec![
+                SpaceOperation {
+                    result: None,
+                    kind: OpKind::Live,
                 },
-            }]);
+                SpaceOperation {
+                    result: op.result.clone(),
+                    kind: OpKind::VableArrayWrite {
+                        base: vable_base,
+                        array_index: arr_idx,
+                        elem_index: index.clone(),
+                        // The vable rewrite only fires for virtualizable
+                        // arrays, which never carry an inline-const store; a
+                        // VableArrayWrite value is always a register.
+                        value: value
+                            .as_variable()
+                            .expect("vable array writes carry a Variable value")
+                            .clone(),
+                        item_ty: typed_item_ty,
+                        array_itemsize: itemsize,
+                        array_is_signed: is_signed,
+                    },
+                },
+            ]);
         }
         if &typed_item_ty != item_ty {
             return RewriteResult::Replace(vec![SpaceOperation {
@@ -3087,6 +3139,12 @@ impl<'a> Transformer<'a> {
         if let Some(base) = user_oopspec.as_deref() {
             // jtransform.py:497 — jit.* oopspecs → __handle_jit_call
             if base.starts_with("jit.") {
+                // `jit.not_in_trace` discards the decoded args (see
+                // `_handle_jit_call`), so the ops materialising their
+                // constants have no consumer left.
+                if base == "jit.not_in_trace" {
+                    const_prefix_ops.clear();
+                }
                 let result =
                     self._handle_jit_call(base, op, target, args, result_ty, graph_name, graph);
                 return prepend_const_prefix(&mut const_prefix_ops, result);
@@ -4115,11 +4173,18 @@ impl<'a> Transformer<'a> {
                     *result_ty == ValueType::Void,
                     "jit.not_in_trace() function must return None"
                 );
+                // jtransform.py:1749 "ignore 'args' and use the original
+                // 'op.args'": the residual call carries the arguments the
+                // call site actually passes, not the oopspec-decoded list.
+                let original_args = match &op.kind {
+                    OpKind::Call { args, .. } => args.clone(),
+                    _ => unreachable!("_handle_jit_call reached on non-Call op"),
+                };
                 self._handle_oopspec_call(
                     graph,
                     op,
                     target,
-                    args,
+                    &original_args,
                     result_ty,
                     graph_name,
                     OopSpecIndex::NotInTrace,
@@ -6827,8 +6892,15 @@ mod tests {
         };
         let result = transform_graph(&graph, &config);
         assert_eq!(result.vable_rewrites, 1);
-        // Should be rewritten to VableFieldRead
-        let rewritten_op = &result.graph.block(graph.startblock).operations[0];
+        // Should be rewritten to `-live-` + VableFieldRead
+        // (`jtransform.py:845-847`).
+        let ops = &result.graph.block(graph.startblock).operations;
+        assert!(
+            matches!(ops[0].kind, OpKind::Live),
+            "virtualizable read must be led by -live-, got {:?}",
+            ops[0].kind
+        );
+        let rewritten_op = &ops[1];
         let OpKind::VableFieldRead {
             base: rewritten_base,
             field_index,
@@ -6888,7 +6960,14 @@ mod tests {
         };
         let result = transform_graph(&graph, &config);
         assert_eq!(result.vable_rewrites, 1);
-        let rewritten_op = &result.graph.block(graph.startblock).operations[1];
+        // `jtransform.py:764-767` — `-live-` leads the vable array read.
+        let ops = &result.graph.block(graph.startblock).operations;
+        assert!(
+            matches!(ops[1].kind, OpKind::Live),
+            "virtualizable array read must be led by -live-, got {:?}",
+            ops[1].kind
+        );
+        let rewritten_op = &ops[2];
         let OpKind::VableArrayRead {
             base: rewritten_base,
             array_index,
@@ -7604,8 +7683,14 @@ mod tests {
             },
         );
 
-        assert_eq!(result.graph.block(graph.startblock).operations.len(), 1);
-        match &result.graph.block(graph.startblock).operations[0].kind {
+        let ops = &result.graph.block(graph.startblock).operations;
+        assert_eq!(ops.len(), 2);
+        assert!(
+            matches!(ops[0].kind, OpKind::Live),
+            "virtualizable read must be led by -live-, got {:?}",
+            ops[0].kind
+        );
+        match &ops[1].kind {
             OpKind::VableFieldRead { field_index, .. } => assert_eq!(*field_index, 0),
             other => panic!("expected VableFieldRead after hint suppression, got {other:?}"),
         }
@@ -7661,10 +7746,104 @@ mod tests {
             panic!("expected ops[0] to be VableForce, got {:?}", ops[0].kind);
         };
         assert_eq!(base, &frame_var);
+        assert!(
+            matches!(ops[1].kind, OpKind::Live),
+            "virtualizable read must be led by -live-, got {:?}",
+            ops[1].kind
+        );
         assert!(matches!(
-            ops[1].kind,
+            ops[2].kind,
             OpKind::VableFieldRead { field_index: 0, .. }
         ));
+    }
+
+    /// `jtransform.py:384-392` — `rewrite_op_int_add_ovf` (aliased to
+    /// `rewrite_op_int_mul_ovf`) and `rewrite_op_int_sub_ovf` both return
+    /// `[SpaceOperation('-live-', [], None), op]`.  `flatten` pops the
+    /// overflow-checked op back off the emitted line and re-spells it as
+    /// `int_*_jump_if_ovf`, a guard that resumes at this point, so the
+    /// marker must be established here rather than inherited from whatever
+    /// operation happens to precede it.
+    #[test]
+    fn transform_graph_leads_overflow_checked_binops_with_live() {
+        for opname in ["add_ovf", "sub_ovf", "mul_ovf"] {
+            let mut graph = FunctionGraph::new("ovf");
+            let entry = graph.startblock;
+            let lhs = graph.push_op_var(entry, OpKind::ConstInt(1), true).unwrap();
+            let rhs = graph.push_op_var(entry, OpKind::ConstInt(2), true).unwrap();
+            graph.push_op_var(
+                entry,
+                OpKind::BinOp {
+                    op: opname.into(),
+                    lhs,
+                    rhs,
+                    result_ty: crate::model::ValueType::Int,
+                },
+                true,
+            );
+
+            let result = transform_graph(&graph, &GraphTransformConfig::default());
+            let ops = &result.graph.block(entry).operations;
+            let ovf_idx = ops
+                .iter()
+                .position(|o| matches!(&o.kind, OpKind::BinOp { op, .. } if op == opname))
+                .unwrap_or_else(|| panic!("{opname} did not survive the rewrite: {ops:?}"));
+            assert!(
+                ovf_idx > 0 && matches!(ops[ovf_idx - 1].kind, OpKind::Live),
+                "{opname} must be led by -live-, got {ops:?}"
+            );
+        }
+    }
+
+    /// `jtransform.py:1748-1755` — `jit.not_in_trace`'s registered spec is
+    /// `"jit.not_in_trace()"` (`rlib/jit.py:260`), an empty argtuple, so the
+    /// decoded arg list comes back empty.  Upstream ignores it ("use the
+    /// original 'op.args'") and the residual call keeps the arguments the
+    /// call site passes.
+    #[test]
+    fn not_in_trace_residual_call_keeps_the_original_arguments() {
+        let path = crate::parse::CallPath::from_segments(["helper", "trace_hook"]);
+        let target = CallTarget::function_path(["helper", "trace_hook"]);
+
+        let mut cc = crate::call::CallControl::new();
+        cc.mark_oopspec(path.clone(), "jit.not_in_trace()".to_string());
+        // A non-empty argname list is what routes the decode through
+        // `parse_oopspec` + `normalize_opargs` rather than the positional
+        // pass-through fallback.
+        cc.mark_oopspec_argnames(path, vec!["x".into(), "y".into()]);
+
+        let mut graph = FunctionGraph::new("caller");
+        let x = graph.alloc_value_var();
+        let y = graph.alloc_value_var();
+        FunctionGraph::set_concretetype_of_inline(&x, ConcreteType::Signed);
+        FunctionGraph::set_concretetype_of_inline(&y, ConcreteType::Signed);
+        let startblock = graph.startblock;
+        graph.push_op_var(
+            startblock,
+            OpKind::Call {
+                target,
+                args: vec![x.clone(), y.clone()],
+                result_ty: ValueType::Void,
+            },
+            false,
+        );
+
+        let config = GraphTransformConfig::default();
+        let transformed = Transformer::new(&config)
+            .with_callcontrol(&mut cc)
+            .transform(&graph);
+
+        let args_i = transformed
+            .graph
+            .block(startblock)
+            .operations
+            .iter()
+            .find_map(|op| match &op.kind {
+                OpKind::CallResidual { args_i, .. } => Some(args_i.clone()),
+                _ => None,
+            })
+            .expect("not_in_trace must lower to a residual call");
+        assert_eq!(args_i, vec![x, y]);
     }
 
     /// `rpython/jit/codewriter/jtransform.py:608-614 rewrite_op_hint`

--- a/majit/majit-translate/src/codewriter/support.rs
+++ b/majit/majit-translate/src/codewriter/support.rs
@@ -702,8 +702,13 @@ pub fn builtin_func_for_spec(
     extra: Option<&[String]>,
     extrakey: Option<&str>,
 ) -> BuiltinFuncSpec {
-    // `support.py:769`: assert (extra is None) == (extrakey is None)
-    debug_assert_eq!(
+    // `support.py:769`: assert (extra is None) == (extrakey is None).
+    // The workspace defines no `[profile.release]`, so `debug_assertions`
+    // is off in the profile that actually runs the codewriter (the
+    // `pyre-jit-trace` build script) — a `debug_assert_eq!` here would be
+    // compiled out of every shipping build, unlike the sibling
+    // `support.py:708` port below, which panics unconditionally.
+    assert_eq!(
         extra.is_none(),
         extrakey.is_none(),
         "support.py:769 — extra and extrakey must be supplied together",
@@ -1069,7 +1074,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(debug_assertions)]
     #[should_panic(expected = "extra and extrakey must be supplied together")]
     fn builtin_func_for_spec_rejects_mismatched_extra_extrakey() {
         // `support.py:769 assert (extra is None) == (extrakey is None)`

--- a/pyre/pyre-jit/src/jit/assembler.rs
+++ b/pyre/pyre-jit/src/jit/assembler.rs
@@ -2476,9 +2476,11 @@ mod tests {
     #[test]
     fn assemble_int_copy_from_constant_uses_copy_opcode_and_constant_pool() {
         let mut ssarepr = SSARepr::new("const_copy");
+        // Outside the signed-byte range `assembler.py:101` accepts, so the
+        // value takes a `constants_i` slot and the `i` argcode.
         ssarepr.insns.push(Insn::op_with_result(
             "int_copy",
-            vec![Operand::ConstInt(42)],
+            vec![Operand::ConstInt(4242)],
             Register::new(Kind::Int, 0),
         ));
 
@@ -2494,9 +2496,39 @@ mod tests {
         let copy_opcode = *majit_metainterp::jitcode::wellknown_bh_insns()
             .get("int_copy/i>i")
             .expect("int_copy must be registered in wellknown insns");
-        assert_eq!(jitcode.constants_i, vec![42]);
+        assert_eq!(jitcode.constants_i, vec![4242]);
         assert_eq!(jitcode.code[0], copy_opcode);
         assert_eq!(jitcode.code[1], 1);
+        assert_eq!(jitcode.code[2], 0);
+    }
+
+    #[test]
+    fn assemble_int_copy_from_small_constant_uses_the_short_form() {
+        let mut ssarepr = SSARepr::new("small_const_copy");
+        ssarepr.insns.push(Insn::op_with_result(
+            "int_copy",
+            vec![Operand::ConstInt(42)],
+            Register::new(Kind::Int, 0),
+        ));
+
+        let jitcode = assemble(
+            &mut ssarepr,
+            JitCodeBuilder::default(),
+            Some(NumRegs {
+                int: 1,
+                ..NumRegs::default()
+            }),
+        );
+
+        // `int_copy` is in `USE_C_FORM` (`assembler.py:312`), so
+        // `assembler.py:99-107` writes a byte-sized value inline and
+        // `assembler.py:172` spells the argcode `c` instead of `i`.
+        let copy_opcode = *majit_metainterp::jitcode::wellknown_bh_insns()
+            .get("int_copy/c>i")
+            .expect("int_copy/c>i must be registered in wellknown insns");
+        assert!(jitcode.constants_i.is_empty());
+        assert_eq!(jitcode.code[0], copy_opcode);
+        assert_eq!(jitcode.code[1], 42);
         assert_eq!(jitcode.code[2], 0);
     }
 


### PR DESCRIPTION
Four places where pyre's codewriter port dropped a statement upstream emits. Each landed with a test proven to FAIL without the change.

## 1. `-live-` before the four virtualizable rewrites

`jtransform.py:764-767` / `:798-801` / `:845-847` / `:926-928` each return a **two**-element list led by `SpaceOperation('-live-', [], None)`. pyre's `VableArrayRead` / `VableArrayWrite` / `VableFieldRead` / `VableFieldWrite` arms returned the op alone. The idiom to copy was already in the same function — the quasi-immutable arm two blocks below.

**This one was live, not latent.** Decoding the shipped jitcode corpus at its serialised `startpoints`:

| | before | after |
|---|---|---|
| vable ops emitted | 10 | 10 |
| preceded by `live/` | **3** | **10** |
| not preceded | **7** | **0** |

Corpus-wide the only opcode-count delta is `live/` 9331 → 9338 (exactly +7). Four jitcodes grew, +21 bytes total: `pop_value` +3, `peek_at` +3, `swap_values` +6, `eval_loop_jit` +9.

## 2. `rewrite_op_int_{add,sub,mul}_ovf` not ported

`jtransform.py:384-392`. `add_ovf` / `sub_ovf` / `mul_ovf` `BinOp`s fell through to the catch-all `RewriteResult::Keep`. `flatten` pops the overflow-checked op back off the emitted line and re-spells it as `int_*_jump_if_ovf`, a guard that resumes at that point, so the marker has to be established there rather than inherited from whatever happens to precede it.

**Emitted bytecode is unchanged** at both extant sites: `remove_repeated_live` collapses the new marker into the trailing `-live-` that the preceding `inline_call_r_i` already emits. Verified — the corpus opcode histogram shows no delta beyond the seven vable markers above.

## 3. `jit.not_in_trace` forwarded the oopspec-decoded args

`jtransform.py:1749` — *"ignore 'args' and use the original 'op.args'"* — because the registered spec is `jit.not_in_trace()` (`rlib/jit.py:260`), an **empty** argtuple. Without the fix the added test emits a residual call with zero arguments (`left: []`). The const-materialisation prefix built for the discarded args is dropped along with them.

Masked today only because `get_oopspec_argnames` filters an empty list to `None`, taking the positional pass-through branch.

## 4. `too many AbstractDescrs!` bound missing from the runtime assembler

`assembler.py:204`'s `assert 0 <= num <= 0xFFFF`. `majit-metainterp`'s `JitCodeBuilder` is a transitional duplicate of the build-time assembler and had narrowed five `descrs.len()` values with a silent `as u16`. The five sites now share one `push_descr_entry`.

The runtime copy **latches `encoding_overflow` so `try_finish` declines** rather than panicking like the build-time copy — mirroring `push_reg_u8`. Same duplicated-encoder drift class as the const-pool bound in #866; not reachable today (needs >65535 descrs in one JitCode).

## Gates

- `majit-translate` 3037 passed, `majit-metainterp` green
- **dynasm 331 passed, cranelift 331 passed**

Two pre-existing failures were discriminated against a pristine tree and are unrelated:

- `test_rbigint_mir` (2 tests) fails identically on pristine `HEAD` — this worktree's LLBC predates #814.
- `synth/ast_compile_roundtrip` is `BASEFAIL` on **both** backends: cpython and pypy disagree with each other and pyre is never run.

## Noted, not fixed

- `arraylen_vable` (`jtransform.py:811-818`) has no build-time producer at all. The runtime/walker side implements it; the codewriter never emits it. Needs a new `OpKind` + flatten + assembler.
- `_rewrite_symmetric` (`jtransform.py:369-378`) is unported for all ~15 of its users, so porting it only inside the ovf arm would be inconsistent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of large runtime metadata tables, preventing invalid references when capacity limits are exceeded.
  * Corrected execution resume points for overflow-checked arithmetic and virtualizable field or array operations.
  * Preserved all arguments when processing calls that execute outside the optimized trace.

* **Reliability**
  * Added boundary coverage to ensure valid maximum-capacity cases continue to work while overflow cases fail safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->