### PR TITLE
jit(blackhole): root the caught exception across the handler handoff

### DIFF
--- a/majit/majit-gc/src/shadow_stack.rs
+++ b/majit/majit-gc/src/shadow_stack.rs
@@ -773,12 +773,15 @@ pub fn jf_under_top_ptr() -> GcRef {
 /// is the number of slots (working registers AND constants — constants
 /// are pre-existing old-gen pointers and pass through `copy_nursery_object`
 /// untouched). `tmpreg_ptr` points at the temporary ref register that
-/// holds in-flight call return values.
+/// holds in-flight call return values.  `exc_ptr` points at the caught
+/// exception slot, which holds a reference for as long as the frame's
+/// handler runs.
 #[derive(Clone, Copy)]
 struct BhRegsEntry {
     regs_ptr: *mut i64,
     regs_len: usize,
     tmpreg_ptr: *mut i64,
+    exc_ptr: *mut i64,
 }
 
 // `*mut i64` is not `Send` by default. The thread-local storage means we
@@ -795,7 +798,7 @@ unsafe impl Send for BhRegsEntry {}
 ///
 /// # Safety
 /// `regs` must remain alive and pinned until pop.
-pub unsafe fn push_bh_regs(regs: &mut [i64], tmpreg: &mut i64) -> usize {
+pub unsafe fn push_bh_regs(regs: &mut [i64], tmpreg: &mut i64, exc: &mut i64) -> usize {
     BH_REGS_STACK.with(|ss| {
         let mut ss = ss.borrow_mut();
         let depth = ss.len();
@@ -805,6 +808,7 @@ pub unsafe fn push_bh_regs(regs: &mut [i64], tmpreg: &mut i64) -> usize {
             regs_ptr: regs.as_mut_ptr(),
             regs_len: regs.len(),
             tmpreg_ptr: tmpreg as *mut i64,
+            exc_ptr: exc as *mut i64,
         });
         depth
     })
@@ -842,6 +846,16 @@ pub fn walk_bh_regs(mut visitor: impl FnMut(&mut GcRef)) {
             // automatically a root.
             let tmp = unsafe { &mut *(entry.tmpreg_ptr as *mut GcRef) };
             visitor(tmp);
+            // `exception_last_value` is the same kind of slot: `route_to_catch`
+            // stores the caught exception there and jumps to the handler
+            // (`blackhole.py:396-411`), and the handler recovers it much later
+            // through `last_exc_value` / `last_exception` — which dereferences
+            // it via `bh_classof`. Everything the handler runs in between can
+            // allocate, so the reference has to survive a minor collection.
+            // Upstream needs no root here for the same reason it needs none for
+            // tmpreg: the field lives on a GC-managed interpreter object.
+            let exc = unsafe { &mut *(entry.exc_ptr as *mut GcRef) };
+            visitor(exc);
         }
     });
 }
@@ -865,6 +879,8 @@ pub fn walk_all_bh_regs(mut visitor: impl FnMut(&mut GcRef)) {
             }
             let tmp = unsafe { &mut *(entry.tmpreg_ptr as *mut GcRef) };
             visitor(tmp);
+            let exc = unsafe { &mut *(entry.exc_ptr as *mut GcRef) };
+            visitor(exc);
         }
     }
 }

--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -1118,6 +1118,20 @@ impl BlackholeInterpreter {
     pub(crate) fn bhimpl_abort_permanent(&mut self) -> Result<(), DispatchError> {
         let exc = BH_LAST_EXC_VALUE.with(|c| c.get());
         if exc != 0 {
+            // Hand the exception to the other walked root before dropping this
+            // one.  A residual-call raise is reachable *only* through this cell
+            // (`walk_bh_last_exc_value`) until something stores it, and the
+            // `RaiseException` arm below routes it into
+            // `handle_exception_in_frame` → `route_to_catch`, which records a
+            // traceback node — an allocation — before it performs that store.
+            // Exception objects are non-moving (`w_exception_new_empty` uses
+            // the stable old gen), but old gen is mark-sweep, so an unrooted
+            // one in that window is collectable.  `route_to_catch` clears the
+            // cell only *after* the record for the same reason
+            // (blackhole.py:407 parity); `exception_last_value` is a
+            // `walk_bh_regs` root, so writing it first keeps the value covered
+            // across the handoff.
+            self.exception_last_value = exc;
             BH_LAST_EXC_VALUE.with(|c| c.set(0));
             return Err(DispatchError::RaiseException(exc));
         }
@@ -4181,6 +4195,43 @@ mod tests {
                 !bh.got_exception,
                 "abort_permanent without pending TLS exception must not set got_exception"
             );
+        }
+
+        /// `bhimpl_abort_permanent` must re-home the exception into a walked
+        /// root before it clears `BH_LAST_EXC_VALUE`.
+        ///
+        /// The cell is the only root over a residual-call raise
+        /// (`walk_bh_last_exc_value`), and the `RaiseException` handoff runs
+        /// `handle_exception_in_frame` → `route_to_catch`, which records a
+        /// traceback node — an allocation — before it stores the value itself.
+        /// Exceptions are non-moving but old gen is mark-sweep, so clearing the
+        /// cell first leaves the exception collectable across that allocation.
+        /// `exception_last_value` is a `walk_bh_regs` root, so it must already
+        /// carry the exception at the moment the cell goes to zero.
+        #[test]
+        fn test_bh_abort_permanent_rehomes_exception_into_walked_root() {
+            const EXC: i64 = 0x5eed_0001;
+            let mut builder = super::build_inline_call_only_bh_builder();
+            let mut bh = builder.acquire_interp();
+            super::BH_LAST_EXC_VALUE.with(|c| c.set(EXC));
+
+            let outcome = bh.bhimpl_abort_permanent();
+
+            assert!(
+                matches!(outcome, Err(super::DispatchError::RaiseException(e)) if e == EXC),
+                "a pending TLS exception must route through RaiseException"
+            );
+            assert_eq!(
+                bh.exception_last_value, EXC,
+                "the cell is cleared here, so the walked `exception_last_value` \
+                 slot must already carry the exception"
+            );
+            assert_eq!(
+                super::BH_LAST_EXC_VALUE.with(|c| c.get()),
+                0,
+                "the cell is drained once the value has another root"
+            );
+            super::BH_LAST_EXC_VALUE.with(|c| c.set(0));
         }
 
         /// Tier 2.3: callee `abort/` propagates aborted=true.

--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -1313,11 +1313,18 @@ impl BlackholeInterpreter {
         // slot NULL) and a vable opcode dereferences it.  Rooting the full
         // pending chain here mirrors the RPython invariant.
         let bh_depth = unsafe {
-            let depth =
-                majit_gc::shadow_stack::push_bh_regs(&mut self.registers_r, &mut self.tmpreg_r);
+            let depth = majit_gc::shadow_stack::push_bh_regs(
+                &mut self.registers_r,
+                &mut self.tmpreg_r,
+                &mut self.exception_last_value,
+            );
             let mut caller = self.nextblackholeinterp.as_deref_mut();
             while let Some(frame) = caller {
-                majit_gc::shadow_stack::push_bh_regs(&mut frame.registers_r, &mut frame.tmpreg_r);
+                majit_gc::shadow_stack::push_bh_regs(
+                    &mut frame.registers_r,
+                    &mut frame.tmpreg_r,
+                    &mut frame.exception_last_value,
+                );
                 caller = frame.nextblackholeinterp.as_deref_mut();
             }
             depth
@@ -3651,7 +3658,11 @@ mod tests {
             assert_eq!(reused.tmpreg_r, 0);
 
             let depth = unsafe {
-                majit_gc::shadow_stack::push_bh_regs(&mut reused.registers_r, &mut reused.tmpreg_r)
+                majit_gc::shadow_stack::push_bh_regs(
+                    &mut reused.registers_r,
+                    &mut reused.tmpreg_r,
+                    &mut reused.exception_last_value,
+                )
             };
             let mut roots: Vec<usize> = Vec::new();
             majit_gc::shadow_stack::walk_bh_regs(|slot| roots.push(slot.0));
@@ -3659,6 +3670,43 @@ mod tests {
             assert!(
                 roots.iter().all(|&word| word == 0),
                 "pooled interp handed the root walker stale references: {roots:x?}",
+            );
+        }
+
+        /// The caught exception is reachable from the root walker while the
+        /// frame's handler runs.
+        ///
+        /// `route_to_catch` stores it in `exception_last_value` and jumps to
+        /// the handler (`blackhole.py:396-411`); the handler recovers it much
+        /// later through `last_exc_value` / `last_exception`, and the latter
+        /// dereferences it via `bh_classof`.  Every allocation the handler
+        /// performs in between can trigger a minor collection, so the slot has
+        /// to be a root — a moved object would leave the read on a from-space
+        /// address, and an otherwise-unreferenced one would simply be
+        /// reclaimed.  Upstream gets this for free: the field lives on a
+        /// GC-managed interpreter object, exactly like `tmpreg_r`.
+        #[test]
+        fn the_caught_exception_slot_is_a_gc_root_for_the_handler_window() {
+            let mut builder = BlackholeInterpBuilder::new();
+            let mut bh = builder.acquire_interp();
+            const EXC: i64 = 0x7f00_0000_abc0;
+            bh.exception_last_value = EXC;
+            bh.tmpreg_r = 0;
+
+            let depth = unsafe {
+                majit_gc::shadow_stack::push_bh_regs(
+                    &mut bh.registers_r,
+                    &mut bh.tmpreg_r,
+                    &mut bh.exception_last_value,
+                )
+            };
+            let mut roots: Vec<usize> = Vec::new();
+            majit_gc::shadow_stack::walk_bh_regs(|slot| roots.push(slot.0));
+            majit_gc::shadow_stack::pop_bh_regs_to(depth);
+            assert!(
+                roots.contains(&(EXC as usize)),
+                "the caught exception is invisible to the collector while the \
+                 handler runs; roots were {roots:x?}",
             );
         }
 

--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -1204,6 +1204,16 @@ impl BlackholeInterpreter {
             return false;
         }
         let target = (code[catch_pos + 1] as usize) | ((code[catch_pos + 2] as usize) << 8);
+        // Take the exception into this frame's walked slot before anything
+        // below can allocate.  `record` builds a traceback node, and on the
+        // inline-callee path this slot is the exception's ONLY root at that
+        // moment: `handler_inline_call_pyre_nested` reads
+        // `callee.exception_last_value` after `callee.run()` returned, which
+        // popped the callee's `push_bh_regs` entry, and a callee-local `raise`
+        // never went through `BH_LAST_EXC_VALUE`.  Exception objects do not
+        // move (`w_exception_new_empty` allocates in the stable old gen), but
+        // old gen is mark-sweep, so an unrooted one is collectable.
+        self.exception_last_value = exc_value;
         // pyopcode.py raise_varargs records the raising instruction before
         // handler lookup; RaiseWithExplicitTraceback skips it for bare
         // reraise.
@@ -1217,7 +1227,6 @@ impl BlackholeInterpreter {
                 self.last_opcode_position as i64,
             );
         }
-        self.exception_last_value = exc_value;
         self.position = target;
         BH_LAST_EXC_VALUE.with(|c| c.set(0));
         // A residual `bh_call` that raised published the exception into BOTH
@@ -4118,6 +4127,78 @@ mod tests {
                 "caught path must run; fallthrough sentinel is {FALLTHROUGH_SENTINEL}"
             );
             assert_eq!(bh.return_type, BhReturnType::Int);
+        }
+
+        thread_local! {
+            /// Address of the interpreter's `exception_last_value` slot, read
+            /// back by [`probe_exception_slot_at_record_time`].
+            static PROBE_SLOT: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+            /// What that slot held when the recorder ran.
+            static PROBE_SEEN: std::cell::Cell<i64> = const { std::cell::Cell::new(-1) };
+        }
+
+        /// Stand-in for pyre's `record_caught_blackhole_traceback`.  The real
+        /// one allocates a `PyTraceback`, i.e. it is a GC safepoint; this one
+        /// just samples the slot that has to be covering the exception by then.
+        extern "C" fn probe_exception_slot_at_record_time(
+            _exc: i64,
+            _frame: i64,
+            _jitcode_index: i64,
+            _opcode_position: i64,
+        ) {
+            let slot = PROBE_SLOT.with(|c| c.get()) as *const i64;
+            let seen = if slot.is_null() { -1 } else { unsafe { *slot } };
+            PROBE_SEEN.with(|c| c.set(seen));
+        }
+
+        /// `route_to_catch` must publish the exception into the walked
+        /// `exception_last_value` slot BEFORE it invokes the traceback
+        /// recorder.
+        ///
+        /// The recorder allocates, and on this path — a `raise` inside an
+        /// inlined callee, caught by the caller — that slot is the exception's
+        /// only root: `handler_inline_call_pyre_nested` reads
+        /// `callee.exception_last_value` after `callee.run()` popped the
+        /// callee's `push_bh_regs` entry, and a callee-local raise never went
+        /// through `BH_LAST_EXC_VALUE`.  Exceptions do not move but old gen is
+        /// mark-sweep, so an unrooted one there is collectable.
+        #[test]
+        fn test_bh_route_to_catch_roots_the_exception_before_recording() {
+            const EXC_VAL: i64 = 0xCAFE_F00D;
+
+            let mut sub = JitCodeBuilder::default();
+            sub.load_const_r_value(0, EXC_VAL);
+            sub.emit_raise(0);
+            let sub_jitcode = sub.finish();
+
+            let mut b = JitCodeBuilder::default();
+            let sub_idx = b.add_sub_jitcode(sub_jitcode);
+            b.inline_call_ir_v(sub_idx, &[], &[], None);
+            let handler_lbl = b.new_label();
+            b.catch_exception(handler_lbl);
+            b.load_const_i_value(2, 999);
+            b.int_return(2);
+            b.mark_label(handler_lbl);
+            b.load_const_i_value(2, 42);
+            b.int_return(2);
+            let jitcode = b.finish();
+
+            let mut builder = super::build_inline_call_only_bh_builder();
+            let mut bh = builder.acquire_interp();
+            bh.setposition(std::sync::Arc::new(jitcode), 0);
+            bh.record_caught_exception = Some(probe_exception_slot_at_record_time);
+
+            PROBE_SEEN.with(|c| c.set(-1));
+            PROBE_SLOT.with(|c| c.set(std::ptr::addr_of!(bh.exception_last_value) as usize));
+            let _ = bh.run();
+            PROBE_SLOT.with(|c| c.set(0));
+
+            assert_eq!(
+                PROBE_SEEN.with(|c| c.get()),
+                EXC_VAL,
+                "the recorder is a GC safepoint, so `exception_last_value` must \
+                 already carry the exception when it runs"
+            );
         }
 
         /// Tier 2.2: exception raised inside the callee

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -5950,6 +5950,16 @@ impl<S: JitState> JitDriver<S> {
             // blackhole.py:1794 `_prepare_resume_from_failure(deadframe)`:
             // seed the blackhole resume with the exception grabbed at guard
             // failure so an exception guard unwinds into its handler.
+            //
+            // `cpu.grab_exc_value` (llmodel.py:240) reads `jf_guard_exc` and
+            // drops the deadframe, which was the collector's only handle on the
+            // exception, and everything between here and the two consumers
+            // allocates: `prepare_exit_resume_heap_with_blackhole_allocator`
+            // before `start_bridge_tracing`, and `blackhole_from_resumedata`
+            // before `prepare_resume_from_failure`.  Park it where the
+            // frontend's root walker can reach it for the rest of the function,
+            // exactly as `back_edge_internal` does around its own handoff.
+            let _guard_exc_root = crate::blackhole::GuardExcRoot::park(result_exc);
 
             if is_finish || fail_index == u32::MAX {
                 if guardlog_enabled() {


### PR DESCRIPTION
<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary

Three defects in the blackhole interpreter that leave a caught Python exception
unreachable by any GC root while something allocates, plus one invariant
alignment. Exception objects are allocated non-moving (`w_exception_new_empty`
-> `try_gc_alloc_stable_raw`), but old gen is mark-sweep, so an unrooted one in
these windows is collectable.

Follow-up to #864, which fixed five defects of the neighbouring "frame-scoped
state not managed at pool/chain boundaries" class in the same subsystem. None of
these overlap with it: `push_bh_regs` was still 2-arg on this base, and #864's
`cleanup_registers` / `release_interp` additions are release-time clears rather
than run-time stores.

### `081adc65` — `exception_last_value` was outside the root set

`push_bh_regs` rooted `registers_r` and `tmpreg_r` but not
`exception_last_value`, even though `route_to_catch` stores the caught exception
there and the handler reads it back much later through `last_exc_value` /
`last_exception`, which dereferences it via `bh_classof`. Everything the handler
runs in between can allocate.

`BhRegsEntry` gains an `exc_ptr`; `walk_bh_regs` / `walk_all_bh_regs` visit it.
Upstream needs no root here for the same reason it needs none for `tmpreg`: the
field lives on a GC-managed interpreter object.

### `b08e7ca5` — `bhimpl_abort_permanent` dropped the only root before the handoff

It read `BH_LAST_EXC_VALUE`, cleared it, then returned the exception as a bare
`i64` through `DispatchError::RaiseException`. `walk_bh_last_exc_value` is the
only root over a residual-call raise, and the `run_inner` arm routes that value
into `handle_exception_in_frame` -> `route_to_catch`, which records a traceback
node — an allocation — before it stores the value.

Now writes the walked `exception_last_value` slot before clearing the cell.

### `6177cc49` — `route_to_catch` recorded before rooting

The same ordering defect one level down: the `record_caught_exception` callback
builds a `PyTraceback`, so it is a GC safepoint, and the store came after it.

The exposed path is `handler_inline_call_pyre_nested`, which reads
`callee.exception_last_value` after `callee.run()` popped the callee's
`push_bh_regs` entry; a callee-local `raise` never went through
`BH_LAST_EXC_VALUE`, so nothing rooted it.

Hoisting the store above the recorder covers every entry into
`handle_exception_in_frame` — residual call, `raise`, `reraise`,
`abort_permanent`, inline callee — at one point rather than per arm.

### `74bcdd27` — `run_back_edge_generic` guard-exception park

`back_edge_internal` brackets its guard-exception handoff with
`GuardExcRoot::park`, because `cpu.grab_exc_value` (llmodel.py:240) reads
`jf_guard_exc` and drops the deadframe that was the collector's only handle on
the value. `run_back_edge_generic` carries the same grabbed value as a bare
`i64` across `prepare_exit_resume_heap_with_blackhole_allocator` and
`blackhole_from_resumedata` without that bracket. This adds it.

> **This commit is inert and can be dropped.** `run_back_edge_generic` has no
> caller anywhere in the tree — `git grep back_edge_generic` returns only the
> definition (`jitdriver.rs:5816`) and one log string, and the macro-generated
> back edge emits `back_edge_structured` instead. So it aligns the invariant
> with its live sibling but cannot fix a reachable failure, and the commit
> message's "zero probe hits across 335 check.py cases" does not discriminate
> between "guards carried no exception" and "the function never ran". Say the
> word and I will drop it.

## Testing

These defects produce no Python-visible wrong answer on their own — they are
GC-timing dependent, so behavioural tests do not catch them. Both new unit tests
assert the coverage/ordering invariant directly, and each was verified to **fail
when its fix line is reverted**:

- `test_bh_abort_permanent_rehomes_exception_into_walked_root` — asserts the
  walked slot already carries the exception at the moment the TLS cell is
  cleared.
- `test_bh_route_to_catch_roots_the_exception_before_recording` — installs a
  recorder stub that samples `exception_last_value` at record time, on the
  existing inline-call raise/catch fixture.

Verified on this branch after rebasing onto `main` and re-extracting the LLBC
corpus (`pyre-object` / `pyre-interpreter` / `pyre-jit` fingerprints all match):

- `cargo fmt --all --check` — clean
- `cargo test --all --no-fail-fast` — exit 0, no failures
- `pyre/check.py --backend dynasm` — 335/335

## Origin

These were found by auditing the blackhole seam after #864's CI crash
(`GC BUG: invalid type_id ... site=copy_nursery_object` in
`synth/exception_traceback_frame_lineno`). That crash is fixed by #864 itself;
this PR is the continuation of the same audit, covering the "GcRef-bearing slot
outside the root set" axis rather than the pool/chain axis.

<sub>Summary drafted by Claude; the code changes carry `Assisted-by: Claude` trailers.</sub>

## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 will be run automatically when this is ready for review.
The prompt is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
-->

- [ ] I fully resolved all reasonable code review comments from Codex and CodeRabbit.
  - [ ] Auto-review section 1 is clear. This check is mandatory.
  - [ ] Auto-review section 2 is clear. If this is not checked, please add a comment explaining why.
- [ ] I did not use AI to write the code of this patch.
  - If this is not checked, commits must include `Assisted-by`

