### PR TITLE
pyre: let a raised dict probe fail to match by identity too

### DIFF
--- a/pyre/extra_tests/parity_tests/module_dict_invariants.py
+++ b/pyre/extra_tests/parity_tests/module_dict_invariants.py
@@ -61,4 +61,57 @@ del g["_bbb"]
 del g["_ccc"]
 
 
+# (6) A store that raises mid-probe leaves the module dict untouched.
+#
+# `ll_dict_lookup` propagates at the first raising comparison
+# (`rordereddict.py:1055`), so nothing later in the bucket is found and the
+# store never lands.  Reproduce the shape that stresses it: one key whose
+# `__eq__` raises and, in the SAME bucket, the incoming key's own object —
+# so the raise is seen before the entry that would otherwise match.
+_armed = False
+
+
+class _Raiser:
+    def __hash__(self):
+        return 7
+
+    def __eq__(self, other):
+        if _armed:
+            raise ValueError("boom")
+        return self is other
+
+
+class _Quiet:
+    def __hash__(self):
+        return 7
+
+    def __eq__(self, other):
+        return self is other
+
+
+def _store_must_not_mutate_on_raise():
+    global _armed
+    quiet = _Quiet()
+    g[_Raiser()] = "raiser"
+    g[quiet] = "quiet-old"
+    before = list(g.items())
+    _armed = True
+    try:
+        g[quiet] = "quiet-new"
+    except ValueError:
+        pass
+    else:
+        assert False, "raising __eq__ must propagate out of the store"
+    finally:
+        _armed = False
+    live = {id(k) for k, _ in g.items()}
+    dropped = [k for k, _ in before if id(k) not in live]
+    assert not dropped, f"store dropped unrelated keys: {dropped!r}"
+    assert len(g) == len(before), f"len {len(before)} -> {len(g)}"
+    assert g[quiet] == "quiet-old", f"value applied despite raise: {g[quiet]!r}"
+
+
+_store_must_not_mutate_on_raise()
+
+
 print("OK")

--- a/pyre/pyre-object/src/dictmultiobject.rs
+++ b/pyre/pyre-object/src/dictmultiobject.rs
@@ -1920,20 +1920,29 @@ unsafe fn key_equality_is_builtin(key: PyObjectRef) -> bool {
 /// to the limited-type builtin equality below — sufficient for the
 /// hashable-builtin smoke tests but not for arbitrary user types.
 pub(crate) unsafe fn dict_keys_equal(a: PyObjectRef, b: PyObjectRef) -> bool {
+    // Once `space.eq_w` has raised earlier in this probe, nothing may match —
+    // not by user comparison and not by identity.  The Rust `Eq` callback
+    // cannot abort the `IndexMap` scan, so answering `false` for the rest of it
+    // is how a raised probe is made to look like the `r_dict(space.eq_w,
+    // space.hash_w)` lookup it stands for: `ll_dict_lookup` propagates at the
+    // first comparison, so no later key — however it would have compared — can
+    // still be found.  The flag is cleared per op in
+    // `object_key_for(_checked)`, so this only fires after a raise within the
+    // current probe.
+    //
+    // This has to sit above the identity shortcut, not below it.  A bucket can
+    // hold both a key whose `__eq__` raises and the incoming key's own object;
+    // if the raising one is probed first and identity still answered `true`
+    // afterwards, `insert` would REPLACE rather than append, and the checked
+    // store's `dict_entries_pop_last` undo would then drop an unrelated last
+    // entry while leaving the replaced value overwritten.
+    if crate::dict_eq_hook::eq_error_pending() {
+        return false;
+    }
     if std::ptr::eq(a, b) {
         return true;
     }
     if a.is_null() || b.is_null() {
-        return false;
-    }
-    // Once `space.eq_w` has raised earlier in this probe, skip every
-    // remaining user comparison.  The Rust `Eq` callback cannot abort the
-    // `IndexMap` scan, but suppressing further `__eq__` calls means no extra
-    // comparison runs and the first exception is the one that propagates —
-    // matching `r_dict(space.eq_w, space.hash_w)` raising at the first
-    // comparison.  The flag is cleared per op in `object_key_for(_checked)`,
-    // so this only fires after a raise within the current probe.
-    if crate::dict_eq_hook::eq_error_pending() {
         return false;
     }
     if crate::dict_eq_hook::callback_free_probe_active() {


### PR DESCRIPTION
A failing dict store could delete an unrelated entry from a module dict, and
apply the store it had just reported as failed.

## What was wrong

`dict_keys_equal` answered `std::ptr::eq` before it consulted
`eq_error_pending()`:

```rust
if std::ptr::eq(a, b) { return true; }     // identity shortcut
if a.is_null() || b.is_null() { return false; }
if crate::dict_eq_hook::eq_error_pending() { return false; }   // ← too late
```

The pending-error test is how pyre stands in for RPython aborting the lookup:
`ll_dict_lookup` propagates at the first raising comparison
(`rordereddict.py:1055`), so nothing later in the bucket can be found. The Rust
`Eq` callback cannot abort an `IndexMap` scan, so it answers `false` for the
rest of it instead — but the identity shortcut sat above that test and kept
answering `true`.

That is reachable. A bucket can hold both a key whose `__eq__` raises and the
incoming key's own object. Probed in that order the raise poisons the probe,
the identity hit still reports a match, and `IndexMap::insert` therefore
**replaces** instead of appending. `w_module_dict_store_inner_checked`'s undo is
`dict_entries_pop_last`, which assumes the failed probe appended — so it drops
the dict's unrelated last entry, and leaves the replaced value overwritten.

Measured against CPython 3.14, storing under such a key in a module dict:

| | CPython | pyre (before) |
|---|---|---|
| value under the key | `'quiet-old'` — store must not land | **`'quiet-new'`** |
| keys lost | none | **`['run']`** — a module-level function, gone from `globals()` |
| net entries | 0 | **−1** |

## The fix

Move the pending-error test above the identity shortcut. A poisoned probe then
matches nothing, `insert` appends, and the existing `pop_last` undo is correct
again — no signature or ABI changes.

## Verification

`module_dict_invariants.py` gains the case. It fails on both backends before
this change and passes on CPython, dynasm and cranelift after.

- `pyre/extra_tests/parity_tests/run.py` — no pyre-side failures.
- `cargo test -p pyre-object` 284, `-p pyre-interpreter --features dynasm` 430,
  0 failed.
- `check.py` — 339/340 on each of dynasm, cranelift and wasm.

> [!NOTE]
> That one `check.py` failure is `synth/str_search_index_bounds`, a JIT-PANIC
> (`compile.rs`, `assert i == len(inputargs) failed (16 != 26)`) identical on
> all three backends. It is **pre-existing on this base**, not from this change:
> reverting the two-line reorder and rebuilding reproduces the same panic. It
> arrived with #860 and is unrelated to dict key comparison.

## Provenance

Reported by the Codex parity review on #873 as a pre-existing mismatch. Its
stated mechanism — a later *user* comparison returning true — is not the live
one; `eq_error_pending()` already blocks that path. The identity shortcut
sitting above the guard is what was left, and it reproduces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed dictionary updates when key comparisons raise an exception during hash-collision handling.
  * Prevented partially applied mutations, including dropped entries, incorrect lengths, or unintended value changes.
  * Improved consistency of dictionary behavior in these error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->