### PR TITLE
gc: drive majors from the old-gen allocator, and root the min/max live values

### DIFF
--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -9,7 +9,7 @@
 use indexmap::{IndexMap, IndexSet};
 use majit_ir::GcRef;
 use std::collections::VecDeque;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
 use crate::address_dict::AddressMap;
 use crate::flags;
@@ -18,6 +18,32 @@ use crate::nursery::{DEFAULT_NURSERY_SIZE, Nursery};
 use crate::oldgen::OldGen;
 use crate::trace::{ClassTypeLayout, TypeEntry, TypeInfo, TypeInfoLayout, TypeRegistry};
 use crate::{FinalizerTriggerFn, GcAllocator};
+
+/// Whether a born-old allocation that crosses the next-major threshold may
+/// request a collection through the eval-breaker word.
+///
+/// The request is only useful where something consumes it: the interpreter
+/// dispatch-loop safepoint. Left off, the threshold is answered the way it
+/// always was — by the major progress every minor collection drives. Armed
+/// with no consumer, the request would re-fail every compiled back-edge poll
+/// until a major completed, since `threshold_reached` stays true across the
+/// whole span. The host turns it on when it installs that safepoint.
+static DEFERRED_MAJOR_REQUEST: AtomicBool = AtomicBool::new(false);
+
+/// Let born-old allocations request a major collection at the next
+/// root-complete point. See [`DEFERRED_MAJOR_REQUEST`].
+pub fn set_deferred_major_request_enabled(on: bool) {
+    DEFERRED_MAJOR_REQUEST.store(on, Ordering::Relaxed);
+}
+
+/// Consume a pending request, reporting whether one was armed.
+///
+/// Clear it whether or not the caller goes on to collect: a request left armed
+/// fails every compiled back-edge poll until it is taken, so the loop would
+/// deopt once per iteration rather than once per request.
+pub fn take_deferred_major_request() -> bool {
+    majit_ir::eval_breaker_word::take_gc()
+}
 
 /// Configuration for the MiniMarkGC.
 pub struct GcConfig {
@@ -1171,6 +1197,17 @@ impl MiniMarkGC {
             if info.is_weakref {
                 self.old_objects_with_weakrefs.push(obj_addr);
             }
+        }
+        // external_malloc (incminimark.py:987-994) tests the same threshold
+        // here and drives `minor_collection_with_major_progress` before
+        // handing the block back. Collecting at this point is what pyre cannot
+        // do: the caller is holding the raw pointer on the Rust stack, which
+        // is not a root, and so is whatever else it had live. Ask the question
+        // where upstream asks it and defer only the answer — the request rides
+        // the eval-breaker word to the interpreter dispatch loop, where the
+        // frame walker sees the whole root set.
+        if DEFERRED_MAJOR_REQUEST.load(Ordering::Relaxed) && self.threshold_reached(total_size) {
+            majit_ir::eval_breaker_word::set_gc();
         }
         GcRef(obj_addr)
     }
@@ -4428,6 +4465,34 @@ mod tests {
             large_object_threshold: nursery_size / 2,
             ..GcConfig::default()
         })
+    }
+
+    /// A born-old allocation that crosses the next-major threshold asks for a
+    /// collection the way `external_malloc` (incminimark.py:987-994) does — and
+    /// only where a safepoint is there to answer, since a request no one takes
+    /// re-fails every compiled back-edge poll.
+    #[test]
+    fn born_old_allocation_past_the_threshold_requests_a_major() {
+        let mut gc = test_gc(4096);
+        let tid = gc.register_type(TypeInfo::object(64));
+        // Put the threshold within reach of any single allocation.
+        gc.next_major_collection_threshold = gc.get_total_memory_used() as f64;
+        let size = GcHeader::SIZE + 64;
+        majit_ir::eval_breaker_word::take_gc();
+
+        set_deferred_major_request_enabled(false);
+        gc.alloc_in_oldgen(tid, size);
+        assert!(
+            !majit_ir::eval_breaker_word::take_gc(),
+            "no consumer installed, so no request should be armed"
+        );
+
+        set_deferred_major_request_enabled(true);
+        gc.alloc_in_oldgen(tid, size);
+        assert!(majit_ir::eval_breaker_word::take_gc());
+
+        set_deferred_major_request_enabled(false);
+        majit_ir::eval_breaker_word::take_gc();
     }
 
     #[test]

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -9,7 +9,7 @@
 use indexmap::{IndexMap, IndexSet};
 use majit_ir::GcRef;
 use std::collections::VecDeque;
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use crate::address_dict::AddressMap;
 use crate::flags;
@@ -19,28 +19,49 @@ use crate::oldgen::OldGen;
 use crate::trace::{ClassTypeLayout, TypeEntry, TypeInfo, TypeInfoLayout, TypeRegistry};
 use crate::{FinalizerTriggerFn, GcAllocator};
 
-/// Whether a born-old allocation that crosses the next-major threshold may
-/// request a collection through the eval-breaker word.
+/// Host predicate answering whether the consumer of a deferred major request
+/// would act on one right now. Unset = never arm.
 ///
-/// The request is only useful where something consumes it: the interpreter
-/// dispatch-loop safepoint. Left off, the threshold is answered the way it
-/// always was — by the major progress every minor collection drives. Armed
-/// with no consumer, the request would re-fail every compiled back-edge poll
-/// until a major completed, since `threshold_reached` stays true across the
-/// whole span. The host turns it on when it installs that safepoint.
-static DEFERRED_MAJOR_REQUEST: AtomicBool = AtomicBool::new(false);
+/// A standing switch is not enough, because the consumer — the interpreter
+/// dispatch-loop safepoint — refuses in two different ways. It refuses for the
+/// whole process when the interpreter GC is off, and it refuses per-thread,
+/// moment to moment, whenever the eval loop is nested too deep for the frame
+/// walker to see the full root set. Arming through the second kind of refusal
+/// is not merely wasted: `threshold_reached` stays true until a major
+/// completes, so every subsequent born-old allocation re-arms, the compiled
+/// back-edge poll fails continuously, and the guard accumulates bridges. Once
+/// a bridge is attached at each level the chain closes on itself and compiled
+/// code stops returning to the dispatch loop at all — which starves the rest of
+/// the word, `EB_ASYNC` included, so a signal goes undelivered for as long as
+/// the loop runs. Measured on a depth-3 loop: SIGINT delivery went from 0.11 s
+/// to over 30 s.
+///
+/// So ask the consumer. The probe is called only after `threshold_reached`, and
+/// only on the born-old path, so it costs nothing on the ordinary nursery
+/// allocation. Left unset the threshold is answered the way it always was — by
+/// the major progress every minor collection drives.
+pub type DeferredMajorRequestProbeFn = fn() -> bool;
 
-/// Let born-old allocations request a major collection at the next
-/// root-complete point. See [`DEFERRED_MAJOR_REQUEST`].
-pub fn set_deferred_major_request_enabled(on: bool) {
-    DEFERRED_MAJOR_REQUEST.store(on, Ordering::Relaxed);
+crate::global_hook!(static DEFERRED_MAJOR_REQUEST_PROBE: DeferredMajorRequestProbeFn);
+
+/// Install the predicate gating born-old major requests, or `None` to stop
+/// arming them. See [`DEFERRED_MAJOR_REQUEST_PROBE`].
+pub fn set_deferred_major_request_probe(probe: Option<DeferredMajorRequestProbeFn>) {
+    DEFERRED_MAJOR_REQUEST_PROBE.set(probe);
+}
+
+/// Whether a request armed now would be acted on. False with no probe installed.
+fn deferred_major_request_wanted() -> bool {
+    DEFERRED_MAJOR_REQUEST_PROBE
+        .get()
+        .is_some_and(|probe| probe())
 }
 
 /// Consume a pending request, reporting whether one was armed.
 ///
-/// Clear it whether or not the caller goes on to collect: a request left armed
-/// fails every compiled back-edge poll until it is taken, so the loop would
-/// deopt once per iteration rather than once per request.
+/// Clear it whether or not the caller goes on to collect: the bit is the
+/// compiled back edge's deopt trigger, so one the caller keeps fires again on
+/// the next back edge, and the next.
 pub fn take_deferred_major_request() -> bool {
     majit_ir::eval_breaker_word::take_gc()
 }
@@ -1206,7 +1227,12 @@ impl MiniMarkGC {
         // where upstream asks it and defer only the answer — the request rides
         // the eval-breaker word to the interpreter dispatch loop, where the
         // frame walker sees the whole root set.
-        if DEFERRED_MAJOR_REQUEST.load(Ordering::Relaxed) && self.threshold_reached(total_size) {
+        //
+        // Only where that walk will actually happen: the threshold stays
+        // reached until a major completes, so arming past a consumer that
+        // refuses re-arms on every following allocation.
+        // See [`DEFERRED_MAJOR_REQUEST_PROBE`].
+        if self.threshold_reached(total_size) && deferred_major_request_wanted() {
             majit_ir::eval_breaker_word::set_gc();
         }
         GcRef(obj_addr)
@@ -4469,10 +4495,23 @@ mod tests {
 
     /// A born-old allocation that crosses the next-major threshold asks for a
     /// collection the way `external_malloc` (incminimark.py:987-994) does — and
-    /// only where a safepoint is there to answer, since a request no one takes
-    /// re-fails every compiled back-edge poll.
+    /// asks the consumer first, every time.
+    ///
+    /// The refusing arm is the load-bearing one. The threshold stays reached
+    /// until a major completes, so arming past a consumer that will not answer
+    /// re-arms on every following allocation; the compiled back-edge poll then
+    /// fails continuously and the guard grows a bridge chain that stops
+    /// returning to the dispatch loop, starving the rest of the eval-breaker
+    /// word — signals included.
     #[test]
-    fn born_old_allocation_past_the_threshold_requests_a_major() {
+    fn born_old_allocation_past_the_threshold_asks_the_consumer_every_time() {
+        fn refuse() -> bool {
+            false
+        }
+        fn accept() -> bool {
+            true
+        }
+
         let mut gc = test_gc(4096);
         let tid = gc.register_type(TypeInfo::object(64));
         // Put the threshold within reach of any single allocation.
@@ -4480,18 +4519,27 @@ mod tests {
         let size = GcHeader::SIZE + 64;
         majit_ir::eval_breaker_word::take_gc();
 
-        set_deferred_major_request_enabled(false);
+        set_deferred_major_request_probe(None);
         gc.alloc_in_oldgen(tid, size);
         assert!(
             !majit_ir::eval_breaker_word::take_gc(),
             "no consumer installed, so no request should be armed"
         );
 
-        set_deferred_major_request_enabled(true);
+        set_deferred_major_request_probe(Some(refuse));
+        for _ in 0..4 {
+            gc.alloc_in_oldgen(tid, size);
+        }
+        assert!(
+            !majit_ir::eval_breaker_word::take_gc(),
+            "the consumer refused, so none of the four allocations may arm"
+        );
+
+        set_deferred_major_request_probe(Some(accept));
         gc.alloc_in_oldgen(tid, size);
         assert!(majit_ir::eval_breaker_word::take_gc());
 
-        set_deferred_major_request_enabled(false);
+        set_deferred_major_request_probe(None);
         majit_ir::eval_breaker_word::take_gc();
     }
 

--- a/majit/majit-ir/src/eval_breaker_word.rs
+++ b/majit/majit-ir/src/eval_breaker_word.rs
@@ -11,6 +11,9 @@
 //!                       is masked out of compiled back-edge polls: it avoids
 //!                       a second per-opcode atomic load in the interpreter,
 //!                       but is not itself a reason to leave machine code.
+//!   bit4 EB_GC    — the old-gen allocator reached the next-major threshold;
+//!                   OR'd in by the collector, consumed by the interpreter
+//!                   dispatch-loop GC safepoint.
 //! A compiled loop loads the whole word at the back-edge and deopts to the
 //! interpreter when it is non-zero. The interpreter/warm-up loop and the STW
 //! park gate remain authoritative; this word is only the JIT's deopt trigger.
@@ -34,8 +37,15 @@ pub const EB_STW: usize = 2;
 pub const EB_FINALIZING: usize = 4;
 /// bit3 — interpreter-path allocation/collection integration is enabled.
 pub const EB_GC_INTERP: usize = 8;
+/// bit4 — the old-gen allocator crossed the next-major threshold and a
+/// collection is owed at the next root-complete point.
+pub const EB_GC: usize = 16;
 /// Bits that require a compiled loop to deopt to the interpreter.
-pub const JIT_BREAKER_MASK: usize = EB_ASYNC | EB_STW | EB_FINALIZING;
+///
+/// `EB_GC` belongs here: the allocator only arms the request, and the
+/// collection itself runs at the dispatch-loop safepoint, so a compiled loop
+/// has to leave machine code for the request to be serviced at all.
+pub const JIT_BREAKER_MASK: usize = EB_ASYNC | EB_STW | EB_FINALIZING | EB_GC;
 
 /// The shared eval-breaker word (see module docs).
 static EVAL_BREAKER_WORD: AtomicUsize = AtomicUsize::new(0);
@@ -95,9 +105,69 @@ pub fn set_gc_interp() {
     EVAL_BREAKER_WORD.fetch_or(EB_GC_INTERP, Ordering::Release);
 }
 
+// --- gc (bit4): armed by the old-gen allocator, consumed by the safepoint ---
+
+/// Request a major collection at the next root-complete point.
+///
+/// `external_malloc` (incminimark.py:987-994) tests `threshold_reached` in the
+/// allocator and drives `minor_collection_with_major_progress` there. pyre
+/// cannot collect at an arbitrary allocation site — a Rust caller's locals are
+/// not roots — so the check stays in the allocator and only the action is
+/// deferred: this bit fails the next back-edge poll, and the interpreter
+/// dispatch loop, where the frame walker sees the whole root set, performs the
+/// collection.
+pub fn set_gc() {
+    EVAL_BREAKER_WORD.fetch_or(EB_GC, Ordering::Relaxed);
+}
+
+/// Consume the pending-collection request, reporting whether one was armed.
+///
+/// The caller must clear unconditionally — before any decision about whether it
+/// can service the request. A bit left armed by a safepoint that declined to
+/// collect fails every subsequent back edge, so a compiled loop would deopt on
+/// each iteration instead of once.
+pub fn take_gc() -> bool {
+    // The taker runs on every eligible bytecode dispatch, the armer only when
+    // the threshold is crossed; read before the read-modify-write so the
+    // common case is a plain load.
+    if EVAL_BREAKER_WORD.load(Ordering::Relaxed) & EB_GC == 0 {
+        return false;
+    }
+    EVAL_BREAKER_WORD.fetch_and(!EB_GC, Ordering::Relaxed) & EB_GC != 0
+}
+
 /// Every flag must fit in the word the poll actually loads. Checked per target,
 /// so a flag too wide for a 32-bit `usize` fails the wasm32 build rather than
 /// silently reading as unarmed there.
 const _: () = assert!(
-    (EB_ASYNC | EB_STW | EB_FINALIZING | EB_GC_INTERP) < (1 << (EVAL_BREAKER_WORD_SIZE * 8 - 1))
+    (EB_ASYNC | EB_STW | EB_FINALIZING | EB_GC_INTERP | EB_GC)
+        < (1 << (EVAL_BREAKER_WORD_SIZE * 8 - 1))
 );
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// One request arms the poll once: the taker reports it, clears it, and the
+    /// next taker sees nothing. A taker that failed to clear would keep failing
+    /// the back-edge guard and deopt the loop on every iteration. Taking it
+    /// must also leave the other two bits alone — they address disjoint parts
+    /// of the same word.
+    ///
+    /// The word is a process-global, so this is deliberately the only test in
+    /// the crate that touches it.
+    #[test]
+    fn gc_request_is_taken_exactly_once_and_leaves_the_other_bits() {
+        assert!(!take_gc(), "no request armed at the start of the test");
+        set_async();
+        set_stw();
+        set_gc();
+        assert_ne!(load() & EB_GC, 0);
+        assert!(take_gc());
+        assert_eq!(load() & EB_GC, 0);
+        assert!(!take_gc());
+        assert_eq!(load() & (EB_ASYNC | EB_STW), EB_ASYNC | EB_STW);
+        clear_async();
+        clear_stw();
+    }
+}

--- a/pyre/bench/synth/minmax_key_rooting.py
+++ b/pyre/bench/synth/minmax_key_rooting.py
@@ -1,0 +1,90 @@
+# `min()`/`max()` with `key=`: the callback re-enters the interpreter, so the
+# running best item and best key must survive a collection that happens inside
+# it. Both live in shadow-stack slots and are re-read from those slots at every
+# use, which is only correct if the surrounding bookkeeping still observes the
+# order `min_max` specifies -- one key computed and compared at a time, strict
+# comparison so equal keys keep the first-seen extremum. These cases pin that
+# observable behaviour: the tie rule for both directions, the exact call order
+# and count of the callback, a key= that allocates every iteration, error
+# propagation out of the compare and out of the callback itself, and the
+# `default=` path that returns before any of the rooting starts. Output
+# verified against CPython/PyPy.
+N = 20000
+
+
+def tie_keeps_first(n):
+    # A later equal key must never displace the incumbent, in either direction.
+    pairs = [(i, i & 3) for i in range(n)]
+    lo = min(pairs, key=lambda p: p[1])
+    hi = max(pairs, key=lambda p: p[1])
+    return lo, hi
+
+
+def call_order(n):
+    # Exactly one call per item, in iteration order: the key of an item is
+    # computed and compared immediately rather than all keys up front.
+    seen = []
+
+    def spy(i):
+        seen.append(i)
+        return i & 7
+
+    lo = min(range(n), key=spy)
+    return lo, len(seen), seen[0], seen[-1]
+
+
+def allocating_key(n):
+    # Each callback allocates a fresh string, so the best key is a young object
+    # that must stay reachable across the following callbacks.
+    items = ("abcdefgh" + str(i) for i in range(n))
+    shortest = min(items, key=lambda s: len(s))
+    items = ("abcdefgh" + str(i) for i in range(n))
+    longest = max(items, key=lambda s: len(s))
+    return shortest, longest
+
+
+def nested_key(n):
+    # The callback itself calls min(), so a second rooting bracket is open
+    # while the outer one is live.
+    rows = [[(i + j) & 15 for j in range(4)] for i in range(n)]
+    return min(rows, key=lambda r: min(r)), max(rows, key=lambda r: min(r))
+
+
+def errors(n):
+    out = []
+    try:
+        min([1, "a"])
+    except TypeError:
+        out.append("compare TypeError")
+    try:
+        min([])
+    except ValueError:
+        out.append("empty ValueError")
+
+    def boom(x):
+        if x == n - 1:
+            raise KeyError(x)
+        return x
+
+    try:
+        min(range(n), key=boom)
+    except KeyError as e:
+        out.append("key KeyError %d" % e.args[0])
+    return out
+
+
+def defaults():
+    return min([], default="d"), max([], default="d"), min([5], default="d")
+
+
+def no_key(n):
+    return min(range(n)), max(range(n)), min(3, 1, 2), max(3, 1, 2), min([7])
+
+
+print(tie_keeps_first(N))
+print(call_order(N))
+print(allocating_key(N))
+print(nested_key(N // 8))
+print(errors(N))
+print(defaults())
+print(no_key(N))

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -9463,19 +9463,16 @@ fn builtin_chr(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let val = val
         .to_u32()
         .expect("chr range check guarantees a value fitting u32");
-    match char::from_u32(val) {
-        Some(c) => Ok(w_str_new(&c.to_string())),
+    let cp = match char::from_u32(val) {
+        Some(c) => CodePoint::from(c),
         // Surrogate code points (0xD800-0xDFFF) are valid chr() arguments and
         // produce a lone-surrogate string; char::from_u32 rejects them, so
         // build the string through a WTF-8 code point instead.
-        None => {
-            let cp = CodePoint::from_u32(val as u32)
-                .expect("val is in 0..=0x10ffff per the range check above");
-            let mut one = Wtf8Buf::new();
-            one.push(cp);
-            Ok(w_str_from_wtf8(one))
-        }
-    }
+        None => CodePoint::from_u32(val).expect("val is in 0..=0x10ffff per the range check above"),
+    };
+    let mut one = Wtf8Buf::new();
+    one.push(cp);
+    Ok(pyre_object::w_str_from_wtf8_managed(one))
 }
 
 /// `filter(function or None, iterable)` — `functional.py:980-995

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -3728,63 +3728,207 @@ fn min_max_dispatch(
             "Cannot specify a default for {fn_name}() with multiple positional arguments"
         )));
     }
-    let items: Vec<PyObjectRef> = if positional.len() == 1 {
-        collect_iterable(positional[0])?
+    if positional.len() == 1 {
+        min_max_sequence(positional[0], key_fn, default, want_max, fn_name)
     } else {
-        positional.to_vec()
-    };
-    if items.is_empty() {
-        if let Some(d) = default {
-            return Ok(d);
-        }
-        return Err(crate::PyError::new(
-            crate::PyErrorKind::ValueError,
-            format!("{fn_name}() iterable argument is empty"),
-        ));
+        min_max_multiple_args(positional, key_fn, want_max)
     }
-    select_extremum(&items, key_fn, want_max)
 }
 
-/// Shared min/max body — `pypy/module/__builtin__/functional.py:115-148
-/// min_max`.  Builds (key, item) pairs (identity when no `key=`),
-/// keeps a running best by comparing keys via `space.gt`/`space.lt`
-/// (the PyPy compare paths invoke `__gt__` / `__lt__` and propagate
-/// errors), returns the corresponding item.  PyPy's stable-tie rule:
-/// keep the first-seen extremum (`<` for min, `>` for max), matching
-/// CPython 3.x semantics.
-fn select_extremum(
-    items: &[PyObjectRef],
+/// `pypy/module/__builtin__/functional.py:125-158 min_max_sequence`.
+fn min_max_sequence(
+    sequence: PyObjectRef,
     key_fn: Option<PyObjectRef>,
+    default: Option<PyObjectRef>,
     want_max: bool,
+    fn_name: &str,
 ) -> Result<PyObjectRef, crate::PyError> {
-    let key_of = |item: PyObjectRef| -> PyObjectRef {
-        match key_fn {
-            Some(kf) => crate::call_function(kf, &[item]),
-            None => item,
-        }
+    let _roots = pyre_object::gc_roots::push_roots();
+    let sequence_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(sequence);
+    let it = crate::baseobjspace::iter(pyre_object::gc_roots::shadow_stack_get(sequence_slot))?;
+    let iterator_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(it);
+    // Dict-view iterators are off-GC carriers, so retain their source dict
+    // explicitly while the iterator is rooted by this native loop.
+    if unsafe {
+        pyre_object::dictmultiobject::is_dict_view_iterator(
+            pyre_object::gc_roots::shadow_stack_get(iterator_slot),
+        )
+    } {
+        let w_dict = unsafe {
+            pyre_object::dictmultiobject::w_dict_view_iterator_get_dict(
+                pyre_object::gc_roots::shadow_stack_get(iterator_slot),
+            )
+        };
+        pyre_object::gc_roots::pin_root(w_dict);
+    }
+    let key_fn_slot = key_fn.map(|key| {
+        let slot = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(key);
+        slot
+    });
+    let has_default = default.is_some();
+    let best_item_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(default.unwrap_or_else(pyre_object::w_none));
+    let best_key_slot = if key_fn_slot.is_some() {
+        let slot = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(pyre_object::w_none());
+        slot
+    } else {
+        best_item_slot
+    };
+    let candidate_item_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(pyre_object::w_none());
+    let candidate_key_slot = if key_fn_slot.is_some() {
+        let slot = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(pyre_object::w_none());
+        slot
+    } else {
+        candidate_item_slot
     };
     let cmp_op = if want_max {
         crate::baseobjspace::CompareOp::Gt
     } else {
         crate::baseobjspace::CompareOp::Lt
     };
-    let mut best_item = items[0];
-    let mut best_key = key_of(best_item);
-    for &item in &items[1..] {
-        let key = key_of(item);
+    let mut has_item = false;
+    loop {
+        let it_now = pyre_object::gc_roots::shadow_stack_get(iterator_slot);
+        let item = match crate::baseobjspace::next(it_now) {
+            Ok(item) => item,
+            Err(e) if e.kind == crate::PyErrorKind::StopIteration => break,
+            Err(e) => return Err(e),
+        };
+        pyre_object::gc_roots::shadow_stack_set(candidate_item_slot, item);
+        if let Some(key_fn_slot) = key_fn_slot {
+            let candidate_key = crate::call::call_function_impl_result(
+                pyre_object::gc_roots::shadow_stack_get(key_fn_slot),
+                &[pyre_object::gc_roots::shadow_stack_get(candidate_item_slot)],
+            )?;
+            pyre_object::gc_roots::shadow_stack_set(candidate_key_slot, candidate_key);
+        }
+        if !has_item {
+            pyre_object::gc_roots::shadow_stack_set(
+                best_item_slot,
+                pyre_object::gc_roots::shadow_stack_get(candidate_item_slot),
+            );
+            if key_fn_slot.is_some() {
+                pyre_object::gc_roots::shadow_stack_set(
+                    best_key_slot,
+                    pyre_object::gc_roots::shadow_stack_get(candidate_key_slot),
+                );
+            }
+            has_item = true;
+            continue;
+        }
+        if crate::baseobjspace::is_true(crate::baseobjspace::compare(
+            pyre_object::gc_roots::shadow_stack_get(candidate_key_slot),
+            pyre_object::gc_roots::shadow_stack_get(best_key_slot),
+            cmp_op,
+        )?)? {
+            pyre_object::gc_roots::shadow_stack_set(
+                best_item_slot,
+                pyre_object::gc_roots::shadow_stack_get(candidate_item_slot),
+            );
+            if key_fn_slot.is_some() {
+                pyre_object::gc_roots::shadow_stack_set(
+                    best_key_slot,
+                    pyre_object::gc_roots::shadow_stack_get(candidate_key_slot),
+                );
+            }
+        }
+    }
+    if !has_item && !has_default {
+        return Err(crate::PyError::new(
+            crate::PyErrorKind::ValueError,
+            format!("{fn_name}() iterable argument is empty"),
+        ));
+    }
+    Ok(pyre_object::gc_roots::shadow_stack_get(best_item_slot))
+}
+
+/// `pypy/module/__builtin__/functional.py:163-184 min_max_multiple_args`.
+fn min_max_multiple_args(
+    positional: &[PyObjectRef],
+    key_fn: Option<PyObjectRef>,
+    want_max: bool,
+) -> Result<PyObjectRef, crate::PyError> {
+    let _roots = pyre_object::gc_roots::push_roots();
+    let item_base = pyre_object::gc_roots::shadow_stack_len();
+    for &item in positional {
+        pyre_object::gc_roots::pin_root(item);
+    }
+    let key_fn_slot = key_fn.map(|key| {
+        let slot = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(key);
+        slot
+    });
+    let cmp_op = if want_max {
+        crate::baseobjspace::CompareOp::Gt
+    } else {
+        crate::baseobjspace::CompareOp::Lt
+    };
+    let best_item_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(pyre_object::gc_roots::shadow_stack_get(item_base));
+    let best_key_slot = if let Some(key_fn_slot) = key_fn_slot {
+        let slot = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(pyre_object::w_none());
+        let first_key = crate::call::call_function_impl_result(
+            pyre_object::gc_roots::shadow_stack_get(key_fn_slot),
+            &[pyre_object::gc_roots::shadow_stack_get(best_item_slot)],
+        )?;
+        pyre_object::gc_roots::shadow_stack_set(slot, first_key);
+        slot
+    } else {
+        best_item_slot
+    };
+    let candidate_item_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(pyre_object::gc_roots::shadow_stack_get(best_item_slot));
+    let candidate_key_slot = if key_fn_slot.is_some() {
+        let slot = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(pyre_object::gc_roots::shadow_stack_get(best_key_slot));
+        slot
+    } else {
+        candidate_item_slot
+    };
+    for i in 1..positional.len() {
+        pyre_object::gc_roots::shadow_stack_set(
+            candidate_item_slot,
+            pyre_object::gc_roots::shadow_stack_get(item_base + i),
+        );
+        if let Some(key_fn_slot) = key_fn_slot {
+            let candidate_key = crate::call::call_function_impl_result(
+                pyre_object::gc_roots::shadow_stack_get(key_fn_slot),
+                &[pyre_object::gc_roots::shadow_stack_get(candidate_item_slot)],
+            )?;
+            pyre_object::gc_roots::shadow_stack_set(candidate_key_slot, candidate_key);
+        }
         // `functional.py:139 if space.is_true(space.gt(key, best_key))`
         // — route through the generic comparison dispatch which
         // handles int/long/str/float/tuple natively and falls
         // through to user-defined `__gt__`/`__lt__` for other
-        // types.  Errors (TypeError from incomparable types) are
-        // propagated to the caller as PyPy does.
-        let result = crate::baseobjspace::compare(key, best_key, cmp_op)?;
-        if crate::baseobjspace::is_true(result)? {
-            best_item = item;
-            best_key = key;
+        // types.  Errors (TypeError from incomparable types or an
+        // exception from the key call, as in functional.py min_max)
+        // are propagated to the caller.
+        if crate::baseobjspace::is_true(crate::baseobjspace::compare(
+            pyre_object::gc_roots::shadow_stack_get(candidate_key_slot),
+            pyre_object::gc_roots::shadow_stack_get(best_key_slot),
+            cmp_op,
+        )?)? {
+            pyre_object::gc_roots::shadow_stack_set(
+                best_item_slot,
+                pyre_object::gc_roots::shadow_stack_get(candidate_item_slot),
+            );
+            if key_fn_slot.is_some() {
+                pyre_object::gc_roots::shadow_stack_set(
+                    best_key_slot,
+                    pyre_object::gc_roots::shadow_stack_get(candidate_key_slot),
+                );
+            }
         }
     }
-    Ok(best_item)
+    Ok(pyre_object::gc_roots::shadow_stack_get(best_item_slot))
 }
 
 /// `type(obj)` — return the type name as a string (simplified).

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -2527,7 +2527,7 @@ impl IterOpcodeHandler for PyFrame {
                     .map(|c| {
                         let mut one = rustpython_wtf8::Wtf8Buf::new();
                         one.push(c);
-                        pyre_object::w_str_from_wtf8(one)
+                        pyre_object::w_str_from_wtf8_managed(one)
                     })
                     .collect();
                 let len = chars.len();

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -598,6 +598,12 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
     );
     push_alias_pair(
         &mut entries,
+        "pyre_object::gc_roots::shadow_stack_set",
+        "pyre_object::shadow_stack_set",
+        pyre_object::gc_roots::shadow_stack_set as *const (),
+    );
+    push_alias_pair(
+        &mut entries,
         "pyre_object::typeobject::w_type_set_uses_object_setattr",
         "pyre_object::w_type_set_uses_object_setattr",
         crate::opcode_ops::bh_w_type_set_uses_object_setattr as *const (),

--- a/pyre/pyre-interpreter/src/runtime_ops.rs
+++ b/pyre/pyre-interpreter/src/runtime_ops.rs
@@ -1192,7 +1192,7 @@ pub fn sequence_getitem(seq: PyObjectRef, index: usize) -> Result<PyObjectRef, P
                 .map(|c| {
                     let mut one = Wtf8Buf::new();
                     one.push(c);
-                    w_str_from_wtf8(one)
+                    pyre_object::w_str_from_wtf8_managed(one)
                 })
                 .ok_or_else(|| PyError::type_error("string index out of range"));
         }
@@ -1464,7 +1464,7 @@ pub fn range_iter_next_or_null(iter: PyObjectRef) -> Result<PyObjectRef, PyError
                 pyre_object::w_str_codepoint_at(si.seq, idx as usize).map(|cp| {
                     let mut one = Wtf8Buf::new();
                     one.push(cp);
-                    w_str_from_wtf8(one)
+                    pyre_object::w_str_from_wtf8_managed(one)
                 })
             } else if pyre_object::bytesobject::is_bytes_like(si.seq) {
                 // Each item is the byte's ordinal, read from the live buffer so

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -3614,6 +3614,14 @@ fn install_pyre_object_hooks() {
     );
     pyre_object::register_gc_write_barrier_hook(pyre_object_gc_write_barrier_trampoline);
     pyre_object::gc_hook::register_gc_identity_hash_hook(pyre_object_gc_identity_hash_trampoline);
+    // Let a born-old allocation that crosses the next-major threshold request
+    // a collection, the check `external_malloc` (incminimark.py:987-994) makes
+    // in the allocator. `gc_interp::safepoint` — installed just above, through
+    // the collect-oldgen hook — is what consumes the request, so arm it only
+    // where that safepoint will act on one.
+    majit_gc::collector::set_deferred_major_request_enabled(
+        pyre_object::gc_interp::enabled() && pyre_object::gc_interp::collect_enabled(),
+    );
 }
 
 /// Build the GC once and store it in `gc_sync::GC_STORE`.

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -3617,11 +3617,12 @@ fn install_pyre_object_hooks() {
     // Let a born-old allocation that crosses the next-major threshold request
     // a collection, the check `external_malloc` (incminimark.py:987-994) makes
     // in the allocator. `gc_interp::safepoint` — installed just above, through
-    // the collect-oldgen hook — is what consumes the request, so arm it only
-    // where that safepoint will act on one.
-    majit_gc::collector::set_deferred_major_request_enabled(
-        pyre_object::gc_interp::enabled() && pyre_object::gc_interp::collect_enabled(),
-    );
+    // the collect-oldgen hook — is what consumes the request, so hand the
+    // allocator that safepoint's own precondition rather than a standing flag:
+    // it refuses per-thread by eval depth as well as process-wide.
+    majit_gc::collector::set_deferred_major_request_probe(Some(
+        pyre_object::gc_interp::would_collect,
+    ));
 }
 
 /// Build the GC once and store it in `gc_sync::GC_STORE`.

--- a/pyre/pyre-object/src/gc_interp.rs
+++ b/pyre/pyre-object/src/gc_interp.rs
@@ -212,6 +212,16 @@ pub fn enabled() -> bool {
 /// that remembered to report, and would answer for a heap that is not the one
 /// being collected.
 ///
+/// Born-old allocations ask it in the allocator too, as `external_malloc`
+/// (incminimark.py:987-994) does, and hand the answer here through the
+/// eval-breaker word (`majit_gc::collector::take_deferred_major_request`).
+/// That path is what reaches compiled code: a trace runs its loop without
+/// returning to this dispatch loop, so a poll placed here alone is never
+/// executed while one is hot, and old-gen allocations made from inside it
+/// would go unanswered until the loop exited. The armed bit fails the trace's
+/// back-edge poll instead, which deopts to this loop and lands on the taker
+/// above.
+///
 /// The collection is `try_gc_collect_oldgen` — it seeds roots, marks, and
 /// sweeps ONLY the old generation, never touching the nursery (not moved, not
 /// freed). So unlike `do_collect_full` (whose leading moving minor would
@@ -241,11 +251,19 @@ pub fn safepoint() {
     if !enabled() {
         return;
     }
-    if collect_enabled()
-        && at_outermost_activation()
-        && poll_due()
-        && crate::gc_hook::try_gc_major_threshold_reached()
-    {
+    // Take any request the old-gen allocator armed, and take it before the
+    // decisions below: a request left armed fails every compiled back-edge
+    // poll, so a safepoint that declined to collect but kept the bit would
+    // deopt the loop once per iteration.
+    let requested = majit_gc::collector::take_deferred_major_request();
+    if !collect_enabled() || !at_outermost_activation() {
+        return;
+    }
+    // The request already carries the collector's answer — it was armed by
+    // `threshold_reached` in the allocator — so it does not wait for the poll
+    // interval. The poll remains for the allocations that reach the collector
+    // without passing the born-old path.
+    if requested || (poll_due() && crate::gc_hook::try_gc_major_threshold_reached()) {
         crate::gc_hook::try_gc_collect_oldgen();
     }
 }

--- a/pyre/pyre-object/src/gc_interp.rs
+++ b/pyre/pyre-object/src/gc_interp.rs
@@ -192,6 +192,22 @@ pub fn enabled() -> bool {
     }
 }
 
+/// Whether a collection reaching this safepoint right now would be performed.
+///
+/// The allocator asks it too, before arming a deferred major request, so the
+/// two cannot drift: a request armed past a safepoint that will refuse is
+/// re-armed by every following born-old allocation, because the threshold
+/// stays reached until a major completes
+/// (`majit_gc::collector::set_deferred_major_request_probe`).
+///
+/// Plain rather than `@dont_look_inside`: both callers are already outside
+/// traced code — [`safepoint`] is itself a residual, and the allocator reaches
+/// this through an installed `fn` pointer — and each of the three questions it
+/// asks carries the attribute in its own right.
+pub fn would_collect() -> bool {
+    enabled() && collect_enabled() && at_outermost_activation()
+}
+
 /// Dispatch-loop safepoint: when the collector says it has reached the
 /// threshold it set for its next major, run a non-moving old-gen-only major.
 /// A no-op when the flag is off or no collection hook is installed.
@@ -220,7 +236,8 @@ pub fn enabled() -> bool {
 /// executed while one is hot, and old-gen allocations made from inside it
 /// would go unanswered until the loop exited. The armed bit fails the trace's
 /// back-edge poll instead, which deopts to this loop and lands on the taker
-/// above.
+/// above. The allocator arms it only when [`would_collect`] holds, so the
+/// request cannot outlive the conditions that let this safepoint answer it.
 ///
 /// The collection is `try_gc_collect_oldgen` — it seeds roots, marks, and
 /// sweeps ONLY the old generation, never touching the nursery (not moved, not
@@ -252,11 +269,11 @@ pub fn safepoint() {
         return;
     }
     // Take any request the old-gen allocator armed, and take it before the
-    // decisions below: a request left armed fails every compiled back-edge
-    // poll, so a safepoint that declined to collect but kept the bit would
-    // deopt the loop once per iteration.
+    // decision below: the bit is a compiled loop's deopt trigger, so one left
+    // armed by a safepoint that declined to collect fires again on the next
+    // back edge, and the next.
     let requested = majit_gc::collector::take_deferred_major_request();
-    if !collect_enabled() || !at_outermost_activation() {
+    if !would_collect() {
         return;
     }
     // The request already carries the collector's answer — it was armed by

--- a/pyre/pyre-object/src/gc_roots.rs
+++ b/pyre/pyre-object/src/gc_roots.rs
@@ -197,6 +197,27 @@ pub fn shadow_stack_copy_range(base: usize, dst: &mut [PyObjectRef]) {
     });
 }
 
+/// Overwrite a single shadow-stack slot by index, panicking if the index
+/// is out of bounds. A slot whose contents change over a bracket's lifetime
+/// is written here rather than re-pinned, mirroring `gc_save_root`'s
+/// overwrite of an already allocated slot (`shadowcolor.py:126-129`).
+///
+/// Writes the thread-local `SHADOW_STACK` the tracer cannot type; the JIT
+/// residualises the write instead of tracing into it (`@dont_look_inside`,
+/// `rlib/jit.py:139`), the [`shadow_stack_get`] twin.
+#[majit_macros::dont_look_inside]
+pub fn shadow_stack_set(index: usize, root: PyObjectRef) {
+    // Publish the raw value first, for the reason [`pin_root`] gives: the
+    // `try_gc_current_object_address` query is itself a GC operation and may
+    // wait behind another thread's collection, so the value must already be
+    // visible to that collector before we enter the query safepoint.
+    SHADOW_STACK.with(|s| s.borrow_mut()[index] = root);
+    // Then normalize a GCREF the caller may have copied before a foreign
+    // mutator's nursery collection, so the slot never keeps a forwarding stub.
+    let root = crate::gc_hook::try_gc_current_object_address(root as *mut u8) as PyObjectRef;
+    SHADOW_STACK.with(|s| s.borrow_mut()[index] = root);
+}
+
 /// Visit every pinned root in the shadow stack with mutable access.
 /// `pyre-jit/src/eval.rs` registers a thin adapter through
 /// `majit_gc::shadow_stack::register_extra_root_walker` that forwards

--- a/pyre/pyre-object/src/unicodeobject.rs
+++ b/pyre/pyre-object/src/unicodeobject.rs
@@ -219,7 +219,7 @@ pub fn w_str_from_wtf8(value: Wtf8Buf) -> PyObjectRef {
 pub fn w_str_from_codepoint(code_point: u32) -> PyObjectRef {
     let mut one = Wtf8Buf::new();
     one.push(CodePoint::from_u32(code_point).unwrap_or(CodePoint::from_char('\u{fffd}')));
-    w_str_from_wtf8(one)
+    w_str_from_wtf8_managed(one)
 }
 
 /// The code points at `start, start + step, …` boxed as a fresh `str` —
@@ -253,7 +253,7 @@ pub unsafe fn w_str_slice_codepoints(
             i += step;
         }
     }
-    w_str_from_wtf8(result)
+    w_str_from_wtf8_managed(result)
 }
 
 /// `ll_strconcat` (`rstr.py:425-428`) — the two operands' WTF-8 buffers


### PR DESCRIPTION
Four commits. The first three wire the interpreter GC safepoint to the old-gen
allocator; the fourth fixes a use-after-free that wiring made reachable.

## `634449462c` request a major from the old-gen allocator

`external_malloc` (`incminimark.py:993-995`) checks `threshold_reached` and drives
major progress *in the allocator*. pyre cannot collect there — a Rust caller's
locals are not roots — so the check goes where upstream puts it and only the
action is deferred: arm `EB_GC` in the eval-breaker word, which compiled back
edges already poll and which deopts into the dispatch loop.

On a probe that allocates ~20M born-old objects with the JIT hot, majors went
12 → 74 and RSS 2359 MB climbing → 147 MB plateau.

## `9c684b08d9` route the remaining str-boxing sites through the managed allocator

Seven sites bypassed `_managed`, so their objects carried no GC header.

## `db1f0550f1` ask the safepoint before arming

`at_outermost_activation()` makes the safepoint refuse at eval depth ≥ 3, but
`threshold_reached` stays true until a major completes, so every following
born-old allocation re-armed `EB_GC`. The poll failed continuously, the guard
grew a bridge chain, and compiled code stopped returning to the dispatch loop —
starving the whole eval-breaker word, `EB_ASYNC` included.

SIGINT delivery latency, quiet box:

| probe | before this series | after `634449462c` | after `db1f0550f1` |
|---|---|---|---|
| depth 2, no alloc | 0.11s | 0.11s | 0.11s |
| depth 3, no alloc | 0.11s | **17.17s** | **0.10s** |
| depth 2, alloc | 0.23s | 0.11s | 0.11s |
| depth 3, alloc | 0.22s | **21.96s** | 3.01s |

The non-allocating depth-3 arm is the discriminator — it isolates poll starvation
from GC work. The fix asks the consumer rather than caching a switch: `majit-gc`
stores a host `fn() -> bool` in the existing `FnPtrCell`, and pyre-jit installs
`gc_interp::would_collect`. Guard churn after: 1 bridge / 201 guard failures, flat.

## `c8c34a7c6b` split min/max, root their live values

Two defects in `select_extremum`, both pre-existing; the first became far easier
to hit once the safepoint started completing majors.

**Use-after-free.** It held the item array, the running best item and the running
best key across the `key=` callback with no GC root. The array came from
`collect_iterable`, whose `RootScope` had already dropped.

    PYRE_GC_INTERP=1 pyre -c 'print(min(("abcdefgh"+str(i) for i in range(400000)), key=lambda s: len(s)))'

printed `TypeError: object of type 'frame' has no len()` or died with SIGSEGV —
6/6 runs failed. With `PYRE_GC_INTERP_COLLECT=0` it was clean, and `sorted(key=)`
was always clean because it already routes through the converted
`sort_rooted_items`. 6/6 clean after.

**An exception from `key=` did not propagate.** `key_of` called
`baseobjspace::call_function`, which stashes the error in `PENDING_CALL_ERROR`
and returns `PY_NULL`; nothing consulted the stash, so the exception escaped the
caller's `try`/`except` and terminated the program. Not JIT-specific — it
reproduces under `PYRE_NO_JIT=1`.

The fix restores the upstream structure rather than bolting roots onto the
existing shape. `functional.py:125-158 min_max_sequence` streams
`space.next(w_iter)` holding two live values; `functional.py:163-184
min_max_multiple_args` walks the argument array. pyre had collapsed both onto one
materialized `Vec`, and that materialization is what forced pinning every element.
The sequence form no longer builds the array at all, so `min(generator)` also stops
holding the whole iterable in memory.

Also adds `shadow_stack_set`, the write half of the shadow stack
(`shadowcolor.py:126-129 _gc_save_root`), for a slot whose contents change over a
bracket's lifetime.

`pyre/bench/synth/minmax_key_rooting.py` is the regression test: tie rule in both
directions, `key=` call order and count, an allocating `key=`, a nested `min()`
inside `key=`, error propagation, and `default=`. Note that it gates the
observable behaviour on every check.py run but **not** the GC sweep path itself —
`PYRE_GC_INTERP` is not in check.py's matrix.

## Verification

`cargo test` green. check.py **335 passed / 1 failed** on both dynasm and cranelift,
run serially; the failure is the pre-existing `synth/ast_compile_roundtrip`
cpython/pypy oracle mismatch (local skew, CPython 3.14.2 vs pypy3 3.11.13 — pyre is
never run for it).

Perf, interleaved min-of-5 × 7 rounds against a same-base control:

| case | ratio |
|---|---|
| `min(list)` / `max(list)`, no `key=` | 1.07x / 1.10x |
| `min` / `max` with `key=` | 1.04x / 1.05x |
| `sorted(key=)` control | 0.99x |

The residual on the no-key path is per-iteration shadow-stack slot traffic.
Upstream's `shadowcolor` pass eliminates redundant save/restores by register-
allocating the shadow stack; pyre has no counterpart to it yet.