### PR TITLE
jit, gc, mapdict: inline-recipe rebuild past a paused call; mapdict side tables off the minor path and given ephemeron semantics; aarch64 guard reach

### DIFF
--- a/majit/majit-backend-dynasm/src/aarch64/assembler.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/assembler.rs
@@ -195,6 +195,17 @@ const BCOND_FORWARD_RANGE: usize = 1 << 20;
 /// full argument list; 1KB leaves roughly an 8x margin.
 const MAX_BYTES_PER_OP: usize = 1024;
 
+/// Ceiling assumed for one guard's failure-recovery stub, which
+/// [`AssemblerARM64::write_pending_failure_recoveries`] emits after the body a
+/// guard's `b.cond` has to reach across.  The fixed part is a `bl`, the
+/// optional exception block, the descriptor `mov`+`str`, the gcmap push and
+/// the call footer — under 128 bytes; the rest is `const_stores`, which costs
+/// a `mov` plus a `str` per entry and is not bounded by the operation count.
+/// The exact span is still checked in [`AssemblerARM64::check_guard_reach`]
+/// once every stub is written, so this only has to be right often enough to
+/// keep large traces off the two-instruction form.
+const MAX_BYTES_PER_GUARD_STUB: usize = 512;
+
 fn invert_cc(cc: u8) -> u8 {
     match cc {
         CC_O => CC_NO,
@@ -1821,6 +1832,7 @@ impl<'a> AssemblerARM64<'a> {
 
         // assembler.py:553 write_pending_failure_recoveries
         let stub_offsets = self.write_pending_failure_recoveries();
+        self.check_guard_reach()?;
 
         // assembler.py:556 materialize_loop — finalize to executable memory
         let buffer = self
@@ -1980,6 +1992,7 @@ impl<'a> AssemblerARM64<'a> {
         let entry = self.mc.offset();
         self._assemble(false)?;
         let stub_offsets = self.write_pending_failure_recoveries();
+        self.check_guard_reach()?;
 
         let buffer = self
             .mc
@@ -2048,7 +2061,17 @@ impl<'a> AssemblerARM64<'a> {
         let inputargs: &'a [InputArg] = self.inputargs;
         let ops: &'a [Op] = self.operations;
         self.trace_start_offset = self.mc.offset().0;
-        self.long_guard_branch = ops.len().saturating_mul(MAX_BYTES_PER_OP) >= BCOND_FORWARD_RANGE;
+        // A guard's `b.cond` has to reach a stub that is written after the
+        // whole body, so the budget is the body plus every stub — not the body
+        // alone.  `const_stores` makes a stub grow independently of the
+        // operation count, so charge it separately instead of leaving it to
+        // `MAX_BYTES_PER_OP`.
+        let guard_count = ops.iter().filter(|op| op.opcode.is_guard()).count();
+        self.long_guard_branch = ops
+            .len()
+            .saturating_mul(MAX_BYTES_PER_OP)
+            .saturating_add(guard_count.saturating_mul(MAX_BYTES_PER_GUARD_STUB))
+            >= BCOND_FORWARD_RANGE;
         if emit_prologue {
             self._call_header(inputargs);
         } else {
@@ -2233,22 +2256,6 @@ impl<'a> AssemblerARM64<'a> {
                 fail_index
             );
         }
-
-        // The `MAX_BYTES_PER_OP` estimate that let this trace use
-        // single-instruction guard branches has to have held: every guard's
-        // stub is written after this point, so the body plus the stubs must
-        // stay inside `b.cond`'s forward reach.  One stub is a handful of
-        // instructions per guard, so charge 64 bytes each.
-        debug_assert!(
-            self.long_guard_branch
-                || (self.mc.offset().0 - self.trace_start_offset)
-                    + self.pending_guard_tokens.len() * 64
-                    < BCOND_FORWARD_RANGE,
-            "trace emitted {} bytes with {} guards but used single-instruction \
-             guard branches; MAX_BYTES_PER_OP is too small",
-            self.mc.offset().0 - self.trace_start_offset,
-            self.pending_guard_tokens.len(),
-        );
 
         // assembler.py:1167-1171 `_assemble`: grow the frame to fit a
         // cross-loop JUMP target.  The closing `br` jumps into the target
@@ -4207,6 +4214,30 @@ impl<'a> AssemblerARM64<'a> {
     ///
     /// RPython parity: the quick-failure stub saves managed registers into the
     /// fixed jitframe prefix before publishing jf_descr and returning.
+    /// Every guard that took the single-instruction form has to reach its
+    /// failure-recovery stub with a `b.cond`, whose signed 19-bit word
+    /// displacement spans [`BCOND_FORWARD_RANGE`].  The stubs are written after
+    /// the body, so the span is only exact once
+    /// [`Self::write_pending_failure_recoveries`] has run — and by then the
+    /// branches are already emitted, so an overflow can no longer be answered
+    /// by re-emitting them in the two-instruction form.  Refuse the trace
+    /// instead: the up-front `MAX_BYTES_PER_OP` / `MAX_BYTES_PER_GUARD_STUB`
+    /// estimate is a heuristic, and letting a relocation that cannot be encoded
+    /// reach the assembler is not an acceptable way to find that out.
+    fn check_guard_reach(&self) -> Result<(), BackendError> {
+        let span = self.mc.offset().0 - self.trace_start_offset;
+        if self.long_guard_branch || span < BCOND_FORWARD_RANGE {
+            return Ok(());
+        }
+        Err(BackendError::CompilationFailed(format!(
+            "trace emitted {} bytes of body and guard stubs with {} guards, past \
+             b.cond's {BCOND_FORWARD_RANGE}-byte forward reach, but the up-front \
+             estimate chose single-instruction guard branches",
+            span,
+            self.pending_guard_tokens.len(),
+        )))
+    }
+
     fn generate_quick_failure(
         &mut self,
         guard_token: GuardToken,

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -2773,6 +2773,24 @@ impl MiniMarkGC {
             .retain(|&addr| unsafe { (*header_of(addr)).has_flag(flags::VISITED) });
         self.old_objects_with_cards_set
             .retain(|&addr| unsafe { (*header_of(addr)).has_flag(flags::VISITED) });
+        // Embedder side tables keyed by owner address hold their value as a
+        // root, so an entry outlives its owner unless it is dropped here —
+        // the same "the target died" question `invalidate_old_weakrefs` just
+        // answered, asked on behalf of a table the collector cannot see.
+        // An owner outside old-gen is either immortal (`malloc_typed`, no
+        // header to read) or, under a non-moving major, still in the live
+        // nursery; neither can be proven dead here, so both are kept.
+        crate::shadow_stack::prune_ephemeron_tables(&mut |owner| {
+            if owner == 0 || !self.oldgen.contains(owner) {
+                return Some(owner);
+            }
+            let hdr = unsafe { header_of(owner) };
+            if unsafe { (*hdr).has_flag(flags::VISITED) } {
+                Some(owner)
+            } else {
+                None
+            }
+        });
         // incminimark.py:2510-2511 — run destructors of dying old objects
         // before the sweep frees them (VISITED still distinguishes
         // survivors from the dying at this point).

--- a/majit/majit-gc/src/shadow_stack.rs
+++ b/majit/majit-gc/src/shadow_stack.rs
@@ -1064,6 +1064,67 @@ pub fn walk_extra_roots(mut visitor: impl FnMut(&mut GcRef)) {
     }
 }
 
+// ── Ephemeron side tables ───────────────────────────────────────
+//
+// An embedder side table keyed by owner address holds its value as a root, so
+// the value outlives the owner and the table only grows.  Upstream has no such
+// table — `typedef.py`'s generated subclass carries the field on the object,
+// which dies with it — so the entries need the ephemeron semantics that
+// layout gives for free: the value is kept only while the key is alive.
+
+/// Signature expected by [`register_ephemeron_pruner`].
+///
+/// The registered function walks its own table and asks the supplied
+/// classifier about each owner address: `Some(addr)` means the owner survived
+/// and now lives at `addr`, `None` means it died and the entry must be
+/// dropped.
+pub type EphemeronPrunerFn = fn(&mut dyn FnMut(usize) -> Option<usize>);
+
+const MAX_EPHEMERON_PRUNERS: usize = 4;
+
+static EPHEMERON_PRUNERS: std::sync::RwLock<[Option<EphemeronPrunerFn>; MAX_EPHEMERON_PRUNERS]> =
+    std::sync::RwLock::new([None; MAX_EPHEMERON_PRUNERS]);
+
+/// Register a side table whose entries must be dropped when their owner dies.
+///
+/// Duplicate registrations are tolerated — the pruner is only appended if not
+/// already present.
+pub fn register_ephemeron_pruner(pruner: EphemeronPrunerFn) {
+    let mut guard = EPHEMERON_PRUNERS.write().unwrap();
+    for slot in guard.iter_mut() {
+        match slot {
+            Some(existing) if std::ptr::fn_addr_eq(*existing, pruner) => return,
+            None => {
+                *slot = Some(pruner);
+                return;
+            }
+            _ => {}
+        }
+    }
+    panic!(
+        "register_ephemeron_pruner: capacity exceeded ({MAX_EPHEMERON_PRUNERS} pruners already \
+         registered)"
+    );
+}
+
+/// Invoke every registered pruner with a classifier that answers whether an
+/// owner survived this collection.
+///
+/// Called by `MiniMarkGC::finish_incremental_marking` once marking has settled
+/// and before the sweep, where VISITED still tells a survivor from a dying
+/// object.  Only a major collection prunes: it already costs O(live heap), so
+/// an O(table) pass adds no asymptotic term, whereas doing it per minor would
+/// put the whole table back on the minor path.
+pub fn prune_ephemeron_tables(classify: &mut dyn FnMut(usize) -> Option<usize>) {
+    let pruners = {
+        let guard = EPHEMERON_PRUNERS.read().unwrap();
+        *guard
+    };
+    for slot in pruners.iter().flatten() {
+        slot(classify);
+    }
+}
+
 // ── Extern "C" interface for compiled code ──────────────────────
 
 /// Push a GC reference from compiled code.

--- a/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
+++ b/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
@@ -3694,6 +3694,42 @@ fn snapshot_root_entries(
         .collect()
 }
 
+/// Drop every entry whose owner did not survive the collection.
+///
+/// These tables are keyed by owner address and hold their value as a root, so
+/// without this an owner's `__dict__` / `__weakref__` outlives it: the tables
+/// only grow, and every major collection marks the whole accumulation.
+/// Upstream has no equivalent table — `typedef.py`'s generated subclass carries
+/// `w_dict` as a field of the object, which dies with it — so the entries have
+/// to be given the same ephemeron semantics explicitly.
+///
+/// Registered with `majit_gc::shadow_stack::register_ephemeron_pruner`, which
+/// runs it from a major collection only.  `classify` returns the owner's
+/// current address, or `None` if it died; a major is mark-and-sweep and moves
+/// nothing, so a surviving owner always answers with the key it was asked
+/// about and the surviving entries keep their keys.
+pub fn prune_dead_owner_entries(classify: &mut dyn FnMut(usize) -> Option<usize>) {
+    for (table, pending) in [
+        (&INSTANCE_DICT, &INSTANCE_DICT_PENDING),
+        (&WEAKREF_TABLE, &WEAKREF_TABLE_PENDING),
+    ] {
+        let mut table = table.lock().unwrap();
+        let dead: Vec<usize> = table
+            .keys()
+            .copied()
+            .filter(|&key| classify(key) != Some(key))
+            .collect();
+        if dead.is_empty() {
+            continue;
+        }
+        let mut pending = pending.lock().unwrap();
+        for key in dead {
+            table.remove(&key);
+            pending.remove(&key);
+        }
+    }
+}
+
 /// Re-key and re-point the entries a root walk moved, as `(old, new, value)`.
 ///
 /// Collected during the walk and applied in one pass because the walk must not

--- a/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
+++ b/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
@@ -14,7 +14,7 @@ use pyre_object::PyObjectRef;
 
 use rustpython_wtf8::{Wtf8, Wtf8Buf};
 use std::cell::{Cell, RefCell, UnsafeCell};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::{LazyLock, Mutex};
 
 // PyPy serializes mapdict map/storage transitions with the GIL.  Pyre is
@@ -3121,6 +3121,29 @@ pub static INSTANCE_DICT: LazyLock<Mutex<HashMap<usize, usize>>> =
 pub static WEAKREF_TABLE: LazyLock<Mutex<HashMap<usize, usize>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
 
+/// Keys whose table value has been stored since the last minor root walk, and
+/// so may still be a nursery object.  See [`snapshot_root_entries`].
+static INSTANCE_DICT_PENDING: LazyLock<Mutex<HashSet<usize>>> =
+    LazyLock::new(|| Mutex::new(HashSet::new()));
+static WEAKREF_TABLE_PENDING: LazyLock<Mutex<HashSet<usize>>> =
+    LazyLock::new(|| Mutex::new(HashSet::new()));
+
+fn instance_dict_insert(key: PyObjectRef, w_dict: PyObjectRef) {
+    INSTANCE_DICT
+        .lock()
+        .unwrap()
+        .insert(key as usize, w_dict as usize);
+    INSTANCE_DICT_PENDING.lock().unwrap().insert(key as usize);
+}
+
+fn weakref_table_insert(key: PyObjectRef, value: PyObjectRef) {
+    WEAKREF_TABLE
+        .lock()
+        .unwrap()
+        .insert(key as usize, value as usize);
+    WEAKREF_TABLE_PENDING.lock().unwrap().insert(key as usize);
+}
+
 struct MapdictRootArea;
 static MAPDICT_ROOT_AREA: MapdictRootArea = MapdictRootArea;
 
@@ -3540,10 +3563,7 @@ pub fn _obj_getdict(self_ref: PyObjectRef) -> PyObjectRef {
             return w_dict;
         }
         let w_dict = pyre_object::w_dict_new();
-        INSTANCE_DICT
-            .lock()
-            .unwrap()
-            .insert(self_ref as usize, w_dict as usize);
+        instance_dict_insert(self_ref, w_dict);
         w_dict
     }
 }
@@ -3639,32 +3659,84 @@ pub fn capture_mapdict_root_area() -> *const () {
     &MAPDICT_ROOT_AREA as *const _ as *const ()
 }
 
+/// The `(owner, value)` pairs a root walk of `table` has to visit.
+///
+/// A major walk visits the whole table.  A minor one visits only the keys
+/// stored since the previous minor walk, and retires them: an entry an earlier
+/// minor walk already visited had its value dragged out to the old generation
+/// and its key rewritten to the owner's post-move address, and an old value's
+/// own contents are reached through its write barrier and custom trace
+/// (`dict_write_barrier` / `dict_object_custom_trace`), never from here.  A
+/// non-moving major (`do_collect_oldgen`) leaves the nursery intact, so only
+/// the minor walk may drain the pending set.
+///
+/// Without this split each collection cloned and walked the whole table, whose
+/// entries are roots and therefore outlive their owners: the per-collection
+/// cost grew with the number of hasdict builtin-layout objects the program had
+/// ever created.
+fn snapshot_root_entries(
+    table: &Mutex<HashMap<usize, usize>>,
+    pending: &Mutex<HashSet<usize>>,
+    minor: bool,
+) -> Vec<(usize, PyObjectRef)> {
+    if !minor {
+        return table
+            .lock()
+            .unwrap()
+            .iter()
+            .map(|(&key, &value)| (key, value as PyObjectRef))
+            .collect();
+    }
+    let keys = std::mem::take(&mut *pending.lock().unwrap());
+    let table = table.lock().unwrap();
+    keys.into_iter()
+        .filter_map(|key| table.get(&key).map(|&value| (key, value as PyObjectRef)))
+        .collect()
+}
+
+/// Re-key and re-point the entries a root walk moved, as `(old, new, value)`.
+///
+/// Collected during the walk and applied in one pass because the walk must not
+/// hold the table lock across a visitor callback, and a major walk that
+/// re-locked per entry paid a lock and a hash lookup for every entry the
+/// program had ever created — almost none of which move, since only a nursery
+/// object has an address to rewrite.
+fn apply_root_rekeys(table: &Mutex<HashMap<usize, usize>>, rekeys: Vec<(usize, usize, usize)>) {
+    if rekeys.is_empty() {
+        return;
+    }
+    let mut table = table.lock().unwrap();
+    for (key, new_key, value) in rekeys {
+        if new_key == key {
+            if let Some(slot) = table.get_mut(&key) {
+                *slot = value;
+            }
+        } else if table.remove(&key).is_some() {
+            table.insert(new_key, value);
+        }
+    }
+}
+
 /// # Safety
 /// `data` must come from [`capture_mapdict_root_area`], and the owning thread
 /// must be quiesced.
 pub unsafe fn walk_mapdict_roots_area(_data: *const (), mut visitor: impl FnMut(&mut PyObjectRef)) {
-    let dict_values = {
-        INSTANCE_DICT
-            .lock()
-            .unwrap()
-            .iter()
-            .map(|(&key, &dict)| (key, dict as PyObjectRef))
-            .collect::<Vec<_>>()
-    };
-    // SAFETY: do not hold the RefCell borrow while invoking callbacks. The
-    // visitor and w_dict_walk_entries_mut may re-enter mapdict/dict APIs.
+    // incminimark.py:339-355 prebuilt-object scanning parity: a minor
+    // collection reaches an old structure only through the write barrier, so
+    // only the entries stored since the previous minor walk are visited here.
+    let minor = majit_gc::shadow_stack::extra_root_walk_kind()
+        == majit_gc::shadow_stack::ExtraRootWalkKind::Minor;
+    let dict_values = snapshot_root_entries(&INSTANCE_DICT, &INSTANCE_DICT_PENDING, minor);
+    // SAFETY: do not hold the table lock while invoking callbacks. The visitor
+    // and w_dict_walk_entries_mut may re-enter mapdict/dict APIs; every write
+    // back into the table is deferred to `apply_root_rekeys`.
+    let mut dict_rekeys = Vec::new();
     for (key, mut dict) in dict_values {
+        let old_dict = dict;
         visitor(&mut dict);
         let new_key = current_owner_key(key);
-        {
-            let mut table = INSTANCE_DICT.lock().unwrap();
-            if new_key == key {
-                if let Some(slot) = table.get_mut(&key) {
-                    *slot = dict as usize;
-                }
-            } else if table.remove(&key).is_some() {
-                table.insert(new_key, dict as usize);
-            }
+        if new_key != key || dict != old_dict {
+            dict_rekeys.push((key, new_key, dict as usize));
         }
         // Trace the dict's own r_dict entries. INSTANCE_DICT now holds only
         // non-instance hasdict wrappers (property/member) — never a
@@ -3695,28 +3767,19 @@ pub unsafe fn walk_mapdict_roots_area(_data: *const (), mut visitor: impl FnMut(
         // via the instance/wrapper write barriers that enter the remembered set.
         // So no instance is walked here.
     }
-    let weakref_values = {
-        WEAKREF_TABLE
-            .lock()
-            .unwrap()
-            .iter()
-            .map(|(&key, &value)| (key, value as PyObjectRef))
-            .collect::<Vec<_>>()
-    };
+    apply_root_rekeys(&INSTANCE_DICT, dict_rekeys);
+
+    let weakref_values = snapshot_root_entries(&WEAKREF_TABLE, &WEAKREF_TABLE_PENDING, minor);
+    let mut weakref_rekeys = Vec::new();
     for (key, mut value) in weakref_values {
+        let old_value = value;
         visitor(&mut value);
         let new_key = current_owner_key(key);
-        {
-            let mut table = WEAKREF_TABLE.lock().unwrap();
-            if new_key == key {
-                if let Some(slot) = table.get_mut(&key) {
-                    *slot = value as usize;
-                }
-            } else if table.remove(&key).is_some() {
-                table.insert(new_key, value as usize);
-            }
+        if new_key != key || value != old_value {
+            weakref_rekeys.push((key, new_key, value as usize));
         }
     }
+    apply_root_rekeys(&WEAKREF_TABLE, weakref_rekeys);
 }
 
 /// objspace/std/mapdict.py:842-860 _obj_setdict.
@@ -3773,10 +3836,7 @@ pub fn _obj_setdict(self_ref: PyObjectRef, w_dict: PyObjectRef) -> Result<(), Py
         // Non-instance hasdict objects (property/member, baseobjspace
         // 1850/3786) keep a plain own-storage dict in the address-keyed side
         // table; it never delegates to a backing object, so no force step.
-        INSTANCE_DICT
-            .lock()
-            .unwrap()
-            .insert(self_ref as usize, w_dict as usize);
+        instance_dict_insert(self_ref, w_dict);
     }
     Ok(())
 }
@@ -3820,10 +3880,7 @@ pub fn setweakref(self_ref: PyObjectRef, weakreflifeline: PyObjectRef) {
         let flag = unsafe { instance_set_weakref_slot(self_ref, weakreflifeline) };
         debug_assert!(flag, "write to the weakref SPECIAL slot failed");
     } else {
-        WEAKREF_TABLE
-            .lock()
-            .unwrap()
-            .insert(self_ref as usize, weakreflifeline as usize);
+        weakref_table_insert(self_ref, weakreflifeline);
     }
 }
 

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -6783,12 +6783,32 @@ fn reconstruct_inline_recipe(
     }
     let nlocals = code_ref.varnames.len();
 
-    let stack_only = match crate::liveness::liveness_for(raw_code).stack_depth_at(py_pc) {
+    let liveness = crate::liveness::liveness_for(raw_code);
+    let stack_only = match liveness.stack_depth_at(py_pc) {
         Some(d) => d,
         None => return None,
     };
     let pending_result_abs_slot = if in_a_call && stack_only > 0 {
         Some(nlocals + stack_only - 1)
+    } else {
+        None
+    };
+    // `stack_depth_at(pc)` is the depth BEFORE executing `pc` (`[0]` is the
+    // entry depth and `[pc + 1]` is `pc`'s fallthrough depth), so at the call
+    // site an `in_a_call` frame is paused on, it still counts the whole operand
+    // region the call consumes — the callable and every argument.  Resuming
+    // once the callee returns collapses that region to one result, which the
+    // framestack walk delivers through `make_result_of_lastop` rather than from
+    // resumedata, so no callee ever flushed those operands to
+    // `locals_cells_stack_w` and none of them is reconstructable.  Exempt the
+    // whole region from the mandatory-operand demand below, not just its
+    // topmost slot: with one argument or more the top slot alone left the
+    // callable and the arguments demanded, so every argument-taking inlined
+    // call declined and its guard was blacklisted.
+    let unreconstructable_operand_floor = if in_a_call {
+        liveness
+            .stack_depth_at(py_pc + 1)
+            .map(|post| nlocals + post.saturating_sub(1))
     } else {
         None
     };
@@ -7029,10 +7049,35 @@ fn reconstruct_inline_recipe(
             concrete_r[k] = value_for_slot(Type::Ref, bits);
         }
         for s in nlocals..valuestackdepth {
-            if Some(s) == pending_result_abs_slot {
+            if Some(s) == pending_result_abs_slot
+                || unreconstructable_operand_floor.is_some_and(|floor| s >= floor)
+            {
                 continue;
             }
             if registers_r[s] == OpRef::NONE {
+                if std::env::var_os("PYRE_P2_DIAG").is_some() {
+                    let sem: Vec<(u32, Option<usize>)> = reg_indices
+                        .ref_
+                        .iter()
+                        .map(|&c| {
+                            (
+                                c,
+                                semantic_ref_slot_for_reg_color(
+                                    nlocals,
+                                    stack_only,
+                                    &maps.pcdep_entries,
+                                    c as usize,
+                                ),
+                            )
+                        })
+                        .collect();
+                    eprintln!(
+                        "[p2-recipe] jitcode_index={} pc={} py_pc={py_pc} in_a_call={in_a_call} \
+                         nlocals={nlocals} stack_only={stack_only} vsd={valuestackdepth} \
+                         missing={s} arr={arr:?} pframe={pframe_reg} pec={pec_reg} live_ref={sem:?}",
+                        frame.jitcode_index, frame.pc
+                    );
+                }
                 crate::jitcode_dispatch::census_record("P2Recipe::MandatoryOperandMissing");
                 return None;
             }

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -3512,6 +3512,12 @@ fn install_gc_root_walkers() {
     majit_gc::shadow_stack::register_extra_root_walker(
         pyre_jit_trace::trace::walk_active_sym_exc_roots,
     );
+    // The mapdict side tables are keyed by owner address and root their
+    // values, so a major collection has to drop the entries whose owner it is
+    // about to sweep.
+    majit_gc::shadow_stack::register_ephemeron_pruner(
+        pyre_interpreter::objspace::std::mapdict::prune_dead_owner_entries,
+    );
 }
 
 fn register_thread_root_areas() {


### PR DESCRIPTION
Four fixes found by ranking `check.py` fixtures against pypy3.

## 1. `reconstruct_inline_recipe` demanded a paused call's already-consumed operands

`liveness.stack_depth_at(pc)` is pre-state — `[0]` is the entry depth and
`[pc + 1]` is `pc`'s fallthrough — so for a frame paused at its own CALL it
still counts the callable and every argument the CALL consumes. Only the top
slot was exempted as the pending result, so with one argument or more the
callable and the remaining arguments stayed **mandatory operands**, which no
callee ever flushes to `locals_cells_stack_w`.

The chain was `P2Recipe::MandatoryOperandMissing` → recipe `None` →
`recipes.clear()` → `P2Drain::NoRecipes` → a **permanent** entry in
`declined_bridge_guards`, after which every later guard failure resumed
through the blackhole. It only ever worked for a zero-argument call.

`stack_only` is left alone — it also gates stack-slot liveness in
`semantic_ref_slot_for_reg_color`, and shrinking it to the post-call depth
regressed `nested_callee_chain_mutation_abort` by 2.04x (2 bridges → 0, 402 →
7788 guard failures). The fix only widens the exemption in the
mandatory-operand loop to the whole consumed region, a strict relaxation of the
previous acceptance set.

arm64, interleaved median of 5, startup subtracted:

| fixture | before | after |
|---|---|---|
| `synth/inline_chain_depth_typeflip` | 4.365s | 0.193s (22.6x) |
| `synth/p2_local_result_bridge` | 1.253s | 0.016s (76.4x) |

`inline_chain_depth_typeflip` goes from 0 bridges / 180444 guard failures
(177641 short-circuited) to 14 bridges / 5787.

Neither fixture carries a `# pyre-check: max-pypy-ratio=` header or a committed
`.jitstats` baseline, so nothing gates this win today. `loops_aborted`
(10 → 2) is the direction-stable counter that would catch a revert.

## 2. Every collection walked the whole mapdict side tables

`INSTANCE_DICT` and `WEAKREF_TABLE` carry `__dict__` / `__weakref__` for
builtin-layout subclass instances (`class T(tuple)`), keyed by owner address,
and `walk_mapdict_roots_area` cloned and walked all of both on *every*
collection.

A minor walk now visits only the keys stored since the previous minor walk. An
entry an earlier minor walk visited had its value dragged out to the old
generation and its key rewritten to the owner's post-move address, and an old
value's contents are reached through `dict_write_barrier` /
`dict_object_custom_trace`. A major walk still visits the whole table, and only
the minor walk drains the pending set, since `do_collect_oldgen` leaves the
nursery intact. Rekeys are batched into one pass instead of re-locking the
table per entry.

## 3. The side-table entries were roots, so they outlived their owners

That is why the tables grew without bound: an entry was never dropped when its
owner died, so the `__dict__` of every such instance ever materialised stayed
reachable and every major collection marked the whole accumulation. Upstream
has no equivalent table — `typedef.py`'s generated subclass carries `w_dict` as
a field of the object, which dies with it.

`majit_gc::shadow_stack::register_ephemeron_pruner` registers a table whose
entries must be dropped when their owner dies, and `finish_incremental_marking`
runs the pruners after marking has settled and before the sweep, where VISITED
still tells a survivor from a dying object — the same point and the same
predicate `invalidate_old_weakrefs` uses. Only a major prunes: it already costs
O(live heap), while doing this per minor would put the whole table back on the
minor path. An owner outside old-gen is either immortal or, under a non-moving
major, in the still-live nursery; neither can be proven dead there, so both are
kept.

`synth/attr_instance_shadows_class`, dynasm, arm64, interleaved median of 5,
both fixes against the branch point:

| N | before | after | |
|---|---|---|---|
| 16000 | 1.423s | 0.190s | 7.47x |
| 30000 | 3.012s | 0.389s | 7.75x |
| 60000 | 7.602s | 0.728s | 10.44x |
| 120000 | 24.408s | 1.396s | 17.48x |

The speedup grows with N because a complexity term is gone, not a constant.
Peak RSS at N=120000: 387 MB → 294 MB. `check.py` 4.38s → 0.45s (dynasm),
4.45s → 0.52s (cranelift).

Three GC-staleness discriminators cover the side-table changes, all matching
pypy3 exactly: a recycled nursery address must not inherit a dead owner's
`__dict__`; an owner reached only indirectly must not lose its `__dict__`; and
weakref lifelines must survive with their owners and clear when they die.

## 4. aarch64 guard branches were sized without their recovery stubs

A guard's `b.cond` has to reach a stub that `write_pending_failure_recoveries`
emits after the whole body, so the span it must cover is the body plus every
stub. `_assemble` decided the branch form from `ops.len() * MAX_BYTES_PER_OP`
alone, and the `debug_assert` backing that decision charged 64 bytes per stub —
less than a stub's fixed part, before `const_stores`, which costs a `mov` plus
a `str` per entry and does not scale with the operation count. `debug_assert`
is also compiled out of release, so nothing checked the estimate in a shipped
build.

The up-front decision now charges `MAX_BYTES_PER_GUARD_STUB` per guard
operation, and `check_guard_reach` measures the real span once every stub is
written. The branches are already emitted by then, so an overflow cannot be
answered by re-emitting them in the two-instruction form; it returns
`BackendError::CompilationFailed` rather than handing the assembler a
relocation that cannot be encoded.

## Verification

`python3 pyre/check.py --backend dynasm,cranelift` on the rebased branch:
**341 passed on both backends**. The single failure is
`synth/ast_compile_roundtrip`, a pre-existing BASEFAIL.

`cargo test -p majit-gc -p majit-metainterp -p pyre-interpreter --features dynasm`:
2162 passed, 0 failed.

## Dropped during the rebase

This branch also carried a fix for
`compile.py:458 assert i == len(inputargs) failed (16 != 26)`, which
`synth/str_search_index_bounds` hit 8/8 on both backends:
`orig_vable_ptr_from_trace_ctx` preferred `MetaInterp::vable_ptr` over
`TraceCtx::virtualizable_heap_ptr`, and since `sync_before` refreshes
`vable_ptr` on every trace entry, a retrace read `locals_cells_stack_w` off an
unrelated frame. #876 landed the identical reordering on `main` first, so the
commit was dropped as redundant; `synth/str_search_index_bounds` now passes 8/8
with output identical to pypy3.

— *commented by Claude*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved garbage collection cleanup for weak references, ephemeron data, and object side tables, reducing stale references and unnecessary retention.
  * Improved JIT handling of call-related stack state and diagnostic reporting, helping avoid incorrect trace reconstruction.
  * Strengthened AArch64 guard-branch reach checks to prevent invalid generated code.

* **Performance**
  * Reduced repeated liveness analysis during JIT trace reconstruction.
  * Optimized minor garbage-collection scans by tracking newly added side-table entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->