### PR TITLE
jit: route the exception-edge bridge on the catch alone

### DIFF
--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/bridge_subwalk.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/bridge_subwalk.rs
@@ -208,22 +208,24 @@ pub fn dispatch_via_miframe<Sym: WalkSym>(
         && trace_ctx.bridge_source_is_exception_guard()
         && !sym.last_exc_box().is_none()
         && !sym.last_exc_value().is_null();
+    // `finishframe_exception` (`pyjitpl.py:2530-2546`) reads the frame's
+    // `catch_exception` and jumps to the handler with no further condition on
+    // where the handler leads.  A handler that RETURNS out of the frame instead
+    // of rejoining a loop is the ordinary `finishframe` case
+    // (`pyjitpl.py:2503-2525`): the frame is popped and the result either lands
+    // in the caller's last op or, with the framestack empty, becomes
+    // `DoneWithThisFrame`.  Route on the catch alone.
     let exc_edge_catch_target = if exc_edge_precondition {
         find_catch_for_exc_resume(jitcode_code, position)
-            // Only route when the handler rejoins this frame's loop; a handler
-            // that returns out of the frame (called function's `try/except:
-            // return`, compiled as its own function trace) needs cross-frame
-            // resume pyre does not yet reconstruct — decline it to the blackhole.
-            .filter(|&catch_target| exc_handler_rejoins_loop(jitcode_code, catch_target))
     } else {
         None
     };
     if exc_edge_precondition && exc_edge_catch_target.is_none() {
-        // Routed by `call_jit` but the handler is unroutable here (returns out of
-        // the frame).  Abort BEFORE any recording so the guard failure resumes
-        // via the blackhole (correct caught-exception + callee-return handling),
+        // Routed by `call_jit` with no `catch_exception` in this frame at all,
+        // which the routing precondition above is supposed to exclude.  Abort
+        // BEFORE any recording so the guard failure resumes via the blackhole,
         // exactly as when the flag is off.
-        return Err(DispatchError::ExcEdgeCrossFrameReturnUnsupported { pc: position });
+        return Err(DispatchError::ExcEdgeNoInFrameCatch { pc: position });
     }
     let exc_edge_concrete = sym.last_exc_value();
     // typeptr at offset 0 (`_store_exception` invariant): the expected class the

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -1896,17 +1896,17 @@ pub enum DispatchError {
     /// rewind it and a deliver re-run would double it, so the walk declines BEFORE
     /// the commit and the location interprets permanently (`AbortPermanent`).
     InplaceContainerMutationUnsupported { pc: usize },
-    /// Exception-edge bridge: the failing exception
-    /// guard is caught in-frame, but the `except` handler RETURNS out of the
-    /// frame (a called function's `try/except: return`, compiled as its own
-    /// function trace) rather than rejoining this frame's loop.  Routing the
-    /// walk to such a handler records a `Finish`/`DoneWithThisFrame` whose
-    /// cross-frame return pyre cannot yet reconstruct (the caller frame is not
-    /// rebuilt at the bridge → NULL-frame deref on return).  Abort so the guard
-    /// failure resumes via the blackhole, which handles the caught exception and
-    /// the callee return correctly.  The loop-rejoin case (same-frame handler)
-    /// still routes.
-    ExcEdgeCrossFrameReturnUnsupported { pc: usize },
+    /// Exception-edge bridge: `call_jit` routed the exc edge (published the
+    /// standing exception and declined to hand the guard to the blackhole), but
+    /// this frame carries no `catch_exception` covering the raise — a state the
+    /// routing precondition is supposed to exclude, since a routed walk must
+    /// resume at a handler rather than fall through to the NULL raised-call
+    /// result.  Abort so the guard failure resumes via the blackhole instead.
+    /// Where the handler LEADS does not reach this error: a handler that returns
+    /// out of the frame routes like any other (`pyjitpl.py:2530-2546`
+    /// `finishframe_exception` jumps to the catch unconditionally, and the
+    /// return is `finishframe`'s ordinary case, `pyjitpl.py:2503-2525`).
+    ExcEdgeNoInFrameCatch { pc: usize },
     /// The recorded trace passed `warmstate.trace_limit` (`rlib/jit.py:592`
     /// default 6000). RPython checks this after every traced step —
     /// `pyjitpl.py:2865 _interpret` calls `blackhole_if_trace_too_long()` right
@@ -1980,7 +1980,7 @@ impl DispatchError {
             Self::InplaceContainerMutationUnsupported { .. } => {
                 "InplaceContainerMutationUnsupported"
             }
-            Self::ExcEdgeCrossFrameReturnUnsupported { .. } => "ExcEdgeCrossFrameReturnUnsupported",
+            Self::ExcEdgeNoInFrameCatch { .. } => "ExcEdgeNoInFrameCatch",
             Self::TraceTooLong { .. } => "TraceTooLong",
         }
     }
@@ -2692,16 +2692,17 @@ fn label_operand_offset(key: &str) -> Option<usize> {
 /// (reaching a `jit_merge_point` back-edge), rather than returning out of the
 /// frame (`*_return`)?
 ///
-/// The exception-edge bridge is only sound when the handler REJOINS the loop in
-/// the SAME frame: the bridge records the handler body and closes with a `Jump`
-/// to the loop header, exactly like the no-exception path.  When the handler
-/// instead RETURNS out of the frame (a called function's `try/except: return`,
-/// compiled as its own function trace, not inlined into the caller's loop), the
-/// walk records a `Finish`/`DoneWithThisFrame` and the bridge must hand the
-/// return value back across the frame boundary to the caller — a cross-frame
-/// exception resume pyre does not yet reconstruct (the caller frame is not
-/// rebuilt at the bridge, so the return path derefs a NULL frame).  Route only
-/// the loop-rejoin case; the caller-return case declines to the blackhole.
+/// Sole caller: [`decline_inline_caller_frame_for_catch_marker`].  The
+/// exception-edge bridge router itself does NOT consult this — it routes on the
+/// `catch_exception` alone, the way `finishframe_exception`
+/// (`pyjitpl.py:2530-2546`) does, and a handler that returns out of the frame is
+/// `finishframe`'s ordinary case (`pyjitpl.py:2503-2525`).
+///
+/// What the predicate still gates is INLINING a caller whose in-try CALL would
+/// deliver a raise across the inline boundary: with a non-rejoining handler that
+/// delivery drops the catching frame's traceback node, so
+/// `exception_traceback_frame_lineno` reports the raising frame twice and at the
+/// wrong lineno (both backends).
 ///
 /// Bounded forward reachability from `catch_target`, following `goto`/
 /// `goto_if_not` successors: `true` as soon as any path reaches a

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/resume_snapshot.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/resume_snapshot.rs
@@ -1094,9 +1094,16 @@ pub(crate) fn decline_inline_caller_frame_for_catch_marker(
     // caller's `lastblock` (a static box in its virtualizable image) unwinds to
     // the catch handler in the blackhole — bit-exact — while a hot raise bridges
     // into the enclosing loop via the carrier-boundary delivery
-    // (`drive_bridge_carrier_walk`'s `finishframe_exception`).  A handler that
-    // does not rejoin any loop (returns out of the frame) stays declined, since
-    // its raise cannot be bridged.
+    // (`drive_bridge_carrier_walk`'s `finishframe_exception`).
+    //
+    // The rejoin test is a TRACEBACK constraint here, not a bridgeability one:
+    // the exc-edge router itself no longer needs it (`bridge_subwalk.rs` routes
+    // on the catch alone, as `pyjitpl.py:2530-2546` does).  Inlining a caller
+    // whose handler returns out of the frame instead makes
+    // `exception_traceback_frame_lineno` report the raising frame twice, once at
+    // the wrong lineno — the catching frame's traceback node is dropped when the
+    // inlined callee's raise is delivered.  Keep the decline until that is
+    // fixed; both backends reproduce it.
     //
     // `resume_pos` is the CALL's post-call `live/`; the `catch_exception/L` for
     // the enclosing try sits right after it (`finishframe_exception` lookahead),

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -1501,9 +1501,9 @@ fn inject_root_call_result<Sym: WalkSym>(
 /// inlined callee raised).  `root_pc` is the CALL's post-call resume `-live-`,
 /// with the enclosing try's `catch_exception/L` sitting BEHIND it (the same
 /// shape the single-frame exception-edge router scans), so read backward.
-/// Accept the handler only when it rejoins a loop (`exc_handler_rejoins_loop`)
-/// so the bridge closes with a `Jump` into the enclosing loop instead of a
-/// cross-frame return the carrier cannot reconstruct.
+/// The handler is accepted on the catch alone, as `finishframe_exception`
+/// (`pyjitpl.py:2530-2546`) does; where the handler leads is `finishframe`'s
+/// business (`pyjitpl.py:2503-2525`).
 fn carrier_root_catch_target<Sym: WalkSym>(sym: &Sym, root_pc: usize) -> Option<usize> {
     if sym.jitcode().is_null() {
         return None;
@@ -1516,12 +1516,9 @@ fn carrier_root_catch_target<Sym: WalkSym>(sym: &Sym, root_pc: usize) -> Option<
     // lookup the single-frame exception-edge router uses.
     let candidate = crate::jitcode_dispatch::find_catch_before_resume_live(code, root_pc);
     if std::env::var_os("PYRE_P2_DIAG").is_some() {
-        eprintln!(
-            "[p2-raise] root_pc={root_pc} catch_before={candidate:?} rejoins={:?}",
-            candidate.map(|t| crate::jitcode_dispatch::exc_handler_rejoins_loop(code, t)),
-        );
+        eprintln!("[p2-raise] root_pc={root_pc} catch_before={candidate:?}");
     }
-    candidate.filter(|&t| crate::jitcode_dispatch::exc_handler_rejoins_loop(code, t))
+    candidate
 }
 
 fn drive_bridge_carrier_walk<Sym: WalkSym>(
@@ -4737,16 +4734,16 @@ fn full_body_walk_trace<Sym: WalkSym>(
                     TraceAction::Abort
                 }
                 // The exc-edge routing decision is `find_catch_for_exc_resume`
-                // + `exc_handler_rejoins_loop` over `(jitcode_code, position)`
-                // alone, so the same guard reaches it on every retrace — the
-                // premise the `AbortPermanent` decline below is written for.
-                // It cannot take that mapping: the abort is raised before any
-                // recording precisely so the guard resumes via the blackhole,
-                // which is the correct handling, not a location to retire.
-                // Record only the bridge-guard decline, so the guard stops
-                // re-walking the whole body (executing its residual calls
-                // concretely) to re-derive a static answer.
-                DE::ExcEdgeCrossFrameReturnUnsupported { .. } => {
+                // over `(jitcode_code, position)` alone, so the same guard
+                // reaches it on every retrace — the premise the `AbortPermanent`
+                // decline below is written for.  It cannot take that mapping:
+                // the abort is raised before any recording precisely so the
+                // guard resumes via the blackhole, which is the correct
+                // handling, not a location to retire.  Record only the
+                // bridge-guard decline, so the guard stops re-walking the whole
+                // body (executing its residual calls concretely) to re-derive a
+                // static answer.
+                DE::ExcEdgeNoInFrameCatch { .. } => {
                     fbw_bridge_decline(ctx);
                     TraceAction::Abort
                 }


### PR DESCRIPTION
## Summary

`exc_handler_rejoins_loop` — a bounded forward scan from a catch target that
returns `true` only when the handler reaches a `jit_merge_point`, and `false`
when every path out of it hits a `*_return` — gated the exception-edge bridge at
three sites. It has no upstream counterpart, and the premise it was written on
is no longer true.

`finishframe_exception` (`pyjitpl.py:2530-2546`) reads the frame's
`catch_exception` and jumps there with no further condition on where that
handler leads. A handler that returns out of the frame is the ordinary
`finishframe` case (`pyjitpl.py:2503-2525`): the frame is popped and the result
either lands in the caller's `make_result_of_lastop` + `ChangeFrame` or, with
the framestack empty, becomes `DoneWithThisFrame`. There is no exc-shape
filter anywhere in the upstream bridge path.

The predicate was added as a correctness band-aid for a SIGSEGV whose stated
cause was "the caller frame is not rebuilt at the bridge, so the return path
derefs a NULL frame". The multi-frame carrier walk and
`rebuild_state_after_failure` (`pyjitpl.py:3424`) parity have since made that
unreachable.

### The two router sites are dropped

`bridge_subwalk.rs` now routes on `find_catch_for_exc_resume` alone, and
`trace.rs carrier_root_catch_target` returns its candidate unfiltered.
`DispatchError::ExcEdgeCrossFrameReturnUnsupported` is renamed
`ExcEdgeNoInFrameCatch`: it now fires only for the genuine invariant break —
`call_jit` routed an exc-edge into a frame with no `catch_exception` at all,
which the routing precondition is supposed to exclude. `ExcEdge*` aborts are 0
across the synth corpus after the change.

`MAJIT_STATS=1`, `loops/bridges/aborted/guard_failures`:

| fixture | before | after |
| --- | --- | --- |
| `exc_caught_in_callee_return_loop` | 2/2/1/23746 | 2/3/0/611 |
| `type_name_surrogate_reject` | 1/0/2/9462 | 1/1/1/200 |
| `list_length_hint_validate` | 2/1/16/13364 | 2/4/14/828 |
| `inline_subwalk_property_mutates` | -/0/117/35066 | -/1/116/23784 |
| `inline_subwalk_mutating_residual` | -/2/117/35442 | -/3/116/24185 |

### The third site stays, for a traceback reason

`resume_snapshot.rs decline_inline_caller_frame_for_catch_marker` keeps the
predicate and is now its only caller. Removing it there — and only there —
diverges `synth/exception_traceback_frame_lineno` on both backends: inlining a
caller whose handler returns out of the frame makes the raising frame appear
twice in the traceback, once at the wrong lineno, because the catching frame's
traceback node is dropped when the inlined callee's raise is delivered. The
comment at that site now records that this is a traceback constraint rather
than a bridgeability one, so the decline is a band-aid for a separate defect.

### Verification

- All 325 synth fixtures byte-identical in stdout, stderr and exit code against
  `PYRE_NO_JIT=1`, on dynasm and cranelift.
- `cargo test -p pyre-jit-trace`, `-p majit-metainterp`.
- `check.py --backend dynasm,cranelift`: 341 passed, 1 failed on both.
  The failure is `synth/str_search_index_bounds`
  (`compile.py:458 assert i == len(inputargs) failed (16 != 26)`), a pre-existing
  main red — it reproduces 101/101 with this diff removed, on all three backends.

## Self-review

No Codex review has been run on this diff yet — the automatic one on this PR is
the first. The change is a deletion of a pyre-only predicate with no upstream
counterpart, so it moves toward `pyjitpl.py` rather than away from it; the one
remaining use is retained deliberately and documented in place as a band-aid.

- [ ] I fully resolved all reasonable code review comments from Codex and CodeRabbit.
  - [ ] Auto-review section 1 is clear. This check is mandatory.
  - [ ] Auto-review section 2 is clear. If this is not checked, please add a comment explaining why.
- [ ] I did not use AI to write the code of this patch.
  - If this is not checked, commits must include `Assisted-by`

<sub>PR description written by Claude.</sub>
