### PR TITLE
jit: enforce the recursion-unroll bound once; frame and tuple owner roots

### DIFF
--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -1298,7 +1298,7 @@ impl MiniMarkGC {
                 // RPython parity: old-gen jitframes need their interior
                 // nursery refs traced directly. The custom_trace hook
                 // walks gcmap bits to find Ref slots.
-                self.trace_and_update_object(gcref.0);
+                self.trace_and_update_object(gcref.0, "minor_jitframe_root");
             } else if !gcref.is_null() && crate::shadow_stack::is_libc_jitframe(gcref.0) {
                 // pyre dynasm extension: jitframes allocated via
                 // `libc::calloc` in execute_token are neither in the
@@ -1429,7 +1429,7 @@ impl MiniMarkGC {
 
                 // Trace this old-gen object's fields and copy any nursery
                 // objects they reference.
-                self.trace_and_update_object(obj_addr);
+                self.trace_and_update_object(obj_addr, "minor_remembered_set");
             }
             self.remembered_set.clear();
 
@@ -1907,6 +1907,12 @@ impl MiniMarkGC {
                 (*(new_header_ptr as *mut GcHeader)).clear_flag(flags::TRACK_YOUNG_PTRS);
             }
             self.remembered_set.push(new_obj_addr);
+            if std::env::var_os("MAJIT_GC_LIFETIME_LOG").is_some() {
+                eprintln!(
+                    "[gc][remember] addr={:#x} type_id={} source=promotion state={:?}",
+                    new_obj_addr, type_id, self.gc_state
+                );
+            }
         }
 
         GcRef(new_obj_addr)
@@ -1977,9 +1983,9 @@ impl MiniMarkGC {
 
     /// Trace an object's GC pointer fields and update any that point
     /// into the nursery by copying the target.
-    fn trace_and_update_object(&mut self, obj_addr: usize) {
+    fn trace_and_update_object(&mut self, obj_addr: usize, site: &str) {
         let type_id = unsafe { (*header_of(obj_addr)).type_id() };
-        self.validate_type_id(type_id, obj_addr, "trace_and_update_object");
+        self.validate_type_id(type_id, obj_addr, site);
         let custom_trace = self.types.get(type_id).custom_trace;
 
         // custom_trace_hook parity: use custom trace function if registered.
@@ -2155,6 +2161,14 @@ impl MiniMarkGC {
             if !self.is_in_nursery(gcref.0) && unsafe { (*hdr).has_flag(flags::TRACK_YOUNG_PTRS) } {
                 unsafe { (*hdr).clear_flag(flags::TRACK_YOUNG_PTRS) };
                 self.remembered_set.push(gcref.0);
+                if std::env::var_os("MAJIT_GC_LIFETIME_LOG").is_some() {
+                    eprintln!(
+                        "[gc][remember] addr={:#x} type_id={} source=major_seed state={:?}",
+                        gcref.0,
+                        unsafe { (*hdr).type_id() },
+                        self.gc_state
+                    );
+                }
             }
         }
     }
@@ -3381,6 +3395,17 @@ impl MiniMarkGC {
         // mutated and therefore cannot be re-added between sweep steps.
         self.remembered_set.push(obj.0);
         let hdr = unsafe { header_of(obj.0) };
+        if std::env::var_os("MAJIT_GC_LIFETIME_LOG").is_some() {
+            eprintln!(
+                "[gc][remember] addr={:#x} type_id={} source=write_barrier state={:?}",
+                obj.0,
+                unsafe { (*hdr).type_id() },
+                self.gc_state
+            );
+            if unsafe { (*hdr).type_id() } == 9 {
+                eprintln!("{}", std::backtrace::Backtrace::force_capture());
+            }
+        }
         unsafe { (*hdr).clear_flag(flags::TRACK_YOUNG_PTRS) };
     }
 

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -1907,7 +1907,7 @@ impl MiniMarkGC {
                 (*(new_header_ptr as *mut GcHeader)).clear_flag(flags::TRACK_YOUNG_PTRS);
             }
             self.remembered_set.push(new_obj_addr);
-            if std::env::var_os("MAJIT_GC_LIFETIME_LOG").is_some() {
+            if crate::gc_lifetime_log_enabled() {
                 eprintln!(
                     "[gc][remember] addr={:#x} type_id={} source=promotion state={:?}",
                     new_obj_addr, type_id, self.gc_state
@@ -2161,7 +2161,7 @@ impl MiniMarkGC {
             if !self.is_in_nursery(gcref.0) && unsafe { (*hdr).has_flag(flags::TRACK_YOUNG_PTRS) } {
                 unsafe { (*hdr).clear_flag(flags::TRACK_YOUNG_PTRS) };
                 self.remembered_set.push(gcref.0);
-                if std::env::var_os("MAJIT_GC_LIFETIME_LOG").is_some() {
+                if crate::gc_lifetime_log_enabled() {
                     eprintln!(
                         "[gc][remember] addr={:#x} type_id={} source=major_seed state={:?}",
                         gcref.0,
@@ -3395,7 +3395,7 @@ impl MiniMarkGC {
         // mutated and therefore cannot be re-added between sweep steps.
         self.remembered_set.push(obj.0);
         let hdr = unsafe { header_of(obj.0) };
-        if std::env::var_os("MAJIT_GC_LIFETIME_LOG").is_some() {
+        if crate::gc_lifetime_log_enabled() {
             eprintln!(
                 "[gc][remember] addr={:#x} type_id={} source=write_barrier state={:?}",
                 obj.0,

--- a/majit/majit-gc/src/lib.rs
+++ b/majit/majit-gc/src/lib.rs
@@ -87,6 +87,18 @@ pub fn gc_stress_enabled() -> bool {
     cfg!(feature = "gc_stress")
 }
 
+/// `MAJIT_GC_LIFETIME_LOG` — trace remembered-set adds and old-gen frees.
+///
+/// Read once.  The gate sits in the write barrier and the old-gen sweep, and
+/// `std::env::var_os` takes the environment lock and scans it linearly on every
+/// call, so asking per event costs whether or not the variable is set.  Same
+/// shape as `majit_metainterp::majit_log_enabled`.
+pub fn gc_lifetime_log_enabled() -> bool {
+    static ENABLED: std::sync::LazyLock<bool> =
+        std::sync::LazyLock::new(|| std::env::var_os("MAJIT_GC_LIFETIME_LOG").is_some());
+    *ENABLED
+}
+
 /// Write barrier descriptor — information the JIT needs to emit write barrier checks.
 ///
 /// From rpython/jit/backend/llsupport/gc.py WriteBarrierDescr.

--- a/majit/majit-gc/src/oldgen.rs
+++ b/majit/majit-gc/src/oldgen.rs
@@ -186,7 +186,7 @@ impl OldGen {
                 hdr.clear_flag(flags::VISITED);
                 self.old_rawmalloced_objects.push(object);
             } else {
-                if std::env::var_os("MAJIT_GC_LIFETIME_LOG").is_some() {
+                if crate::gc_lifetime_log_enabled() {
                     eprintln!(
                         "[gc][free] addr={:#x} type_id={} kind=raw",
                         object.header_addr + GcHeader::SIZE,
@@ -219,7 +219,7 @@ impl OldGen {
                     hdr.clear_flag(flags::VISITED);
                     false
                 } else {
-                    if std::env::var_os("MAJIT_GC_LIFETIME_LOG").is_some() {
+                    if crate::gc_lifetime_log_enabled() {
                         eprintln!(
                             "[gc][free] addr={:#x} type_id={} kind=arena",
                             header_ptr as usize + GcHeader::SIZE,

--- a/majit/majit-gc/src/oldgen.rs
+++ b/majit/majit-gc/src/oldgen.rs
@@ -186,6 +186,13 @@ impl OldGen {
                 hdr.clear_flag(flags::VISITED);
                 self.old_rawmalloced_objects.push(object);
             } else {
+                if std::env::var_os("MAJIT_GC_LIFETIME_LOG").is_some() {
+                    eprintln!(
+                        "[gc][free] addr={:#x} type_id={} kind=raw",
+                        object.header_addr + GcHeader::SIZE,
+                        hdr.type_id()
+                    );
+                }
                 self.rawmalloced_total_size -= object.layout.size();
                 let removed = self
                     .rawmalloced_payloads
@@ -212,6 +219,13 @@ impl OldGen {
                     hdr.clear_flag(flags::VISITED);
                     false
                 } else {
+                    if std::env::var_os("MAJIT_GC_LIFETIME_LOG").is_some() {
+                        eprintln!(
+                            "[gc][free] addr={:#x} type_id={} kind=arena",
+                            header_ptr as usize + GcHeader::SIZE,
+                            hdr.type_id()
+                        );
+                    }
                     true
                 }
             },

--- a/majit/majit-gc/src/shadow_stack.rs
+++ b/majit/majit-gc/src/shadow_stack.rs
@@ -214,6 +214,12 @@ thread_local! {
     /// Thread-local shadow stack for individual GcRef roots.
     static SHADOW_STACK: RefCell<ShadowStack> = const { RefCell::new(ShadowStack::new()) };
 
+    /// Long-lived translated livevar slots whose owners are not lexical
+    /// `push`/`pop_to` scopes.  RPython assigns these values fixed shadow-stack
+    /// frame slots; keeping a separate slot vector preserves that ownership
+    /// when Rust RAII scopes nest across a `FrameBox`.
+    static OWNER_ROOTS: RefCell<Vec<Option<GcRef>>> = const { RefCell::new(Vec::new()) };
+
     /// Thread-local flat jitframe root stack. Rust tests run multiple
     /// JIT/GC tests in parallel, so using one process-global root stack lets
     /// one GC walk another test's jitframe. RPython's root stack is per
@@ -252,6 +258,7 @@ thread_local! {
 struct MutatorEntry {
     thread_id: std::thread::ThreadId,
     shadow_stack: *const RefCell<ShadowStack>,
+    owner_roots: *const RefCell<Vec<Option<GcRef>>>,
     jf_root_stack: *const RefCell<JitFrameShadowStack>,
     bh_regs_stack: *const RefCell<Vec<BhRegsEntry>>,
     resume_ref_roots_stack: *const RefCell<Vec<(*mut i64, usize)>>,
@@ -277,11 +284,12 @@ unsafe impl Send for MutatorEntry {}
 
 static MUTATOR_REGISTRY: Mutex<Vec<MutatorEntry>> = Mutex::new(Vec::new());
 
-/// Register the current thread's four TLS root structures for STW root walks.
+/// Register the current thread's TLS root structures for STW root walks.
 /// Unregistration is supplied by the caller's RAII destructor (pyre-jit's `GcMutatorRegistration` thread-local, armed in `init_gc_subsystem`, whose `Drop` calls [`unregister_mutator`]); callers must arm that pairing, while an API-level return guard is a tracked follow-up.
 pub fn register_mutator() {
     let thread_id = std::thread::current().id();
     let shadow_stack = SHADOW_STACK.with(|stack| stack as *const _);
+    let owner_roots = OWNER_ROOTS.with(|roots| roots as *const _);
     let jf_root_stack = JF_ROOT_STACK.with(|stack| stack as *const _);
     let bh_regs_stack = BH_REGS_STACK.with(|stack| stack as *const _);
     let resume_ref_roots_stack = RESUME_REF_ROOTS_STACK.with(|stack| stack as *const _);
@@ -294,6 +302,7 @@ pub fn register_mutator() {
     registry.push(MutatorEntry {
         thread_id,
         shadow_stack,
+        owner_roots,
         jf_root_stack,
         bh_regs_stack,
         resume_ref_roots_stack,
@@ -441,6 +450,59 @@ pub fn get(index: usize) -> GcRef {
     })
 }
 
+/// Acquire a fixed translated-livevar root slot.
+pub fn acquire_owner_root(root: GcRef) -> usize {
+    OWNER_ROOTS.with(|roots| {
+        let mut roots = roots.borrow_mut();
+        if let Some(index) = roots.iter().position(Option::is_none) {
+            roots[index] = Some(root);
+            index
+        } else {
+            let index = roots.len();
+            roots.push(Some(root));
+            index
+        }
+    })
+}
+
+/// Release a fixed translated-livevar root slot.
+pub fn release_owner_root(index: usize) {
+    let _ = OWNER_ROOTS.try_with(|roots| {
+        let mut roots = roots.borrow_mut();
+        assert!(
+            index < roots.len() && roots[index].is_some(),
+            "releasing an inactive owner-root slot"
+        );
+        roots[index] = None;
+        while roots.last().is_some_and(Option::is_none) {
+            roots.pop();
+        }
+    });
+}
+
+/// RAII owner for one fixed translated-livevar root slot.
+pub struct OwnerRootGuard {
+    index: usize,
+}
+
+impl OwnerRootGuard {
+    pub fn new(root: GcRef) -> Self {
+        Self {
+            index: acquire_owner_root(root),
+        }
+    }
+
+    pub fn get(&self) -> GcRef {
+        OWNER_ROOTS.with(|roots| roots.borrow()[self.index].expect("inactive owner-root guard"))
+    }
+}
+
+impl Drop for OwnerRootGuard {
+    fn drop(&mut self) {
+        release_owner_root(self.index);
+    }
+}
+
 /// An opaque handle to this thread's `SHADOW_STACK` cell.
 ///
 /// The pointer is stable for the life of the owning thread (the same
@@ -482,6 +544,13 @@ pub fn walk_roots(mut visitor: impl FnMut(&mut GcRef)) {
             }
         }
     });
+    OWNER_ROOTS.with(|roots| {
+        for root in roots.borrow_mut().iter_mut().flatten() {
+            if !root.is_null() {
+                visitor(root);
+            }
+        }
+    });
 }
 
 /// Walk every registered mutator's GcRef shadow stack during STW.
@@ -503,6 +572,12 @@ pub fn walk_all_roots(mut visitor: impl FnMut(&mut GcRef)) {
         for entry in ss.entries.iter_mut() {
             if !entry.is_null() {
                 visitor(entry);
+            }
+        }
+        let owner_roots = unsafe { &mut *(*mutator.owner_roots).as_ptr() };
+        for root in owner_roots.iter_mut().flatten() {
+            if !root.is_null() {
+                visitor(root);
             }
         }
     }
@@ -546,6 +621,7 @@ pub fn increase_root_stack_depth(new_depth: usize) {
 /// Clear both shadow stacks.
 pub fn clear() {
     SHADOW_STACK.with(|ss| ss.borrow_mut().entries.clear());
+    OWNER_ROOTS.with(|roots| roots.borrow_mut().clear());
     JF_ROOT_STACK.with(|stack| {
         let mut stack = stack.borrow_mut();
         stack.ensure_init();
@@ -1246,6 +1322,27 @@ mod tests {
         assert_eq!(get(0), GcRef(0x1100));
         assert_eq!(get(1), GcRef(0x2100));
         clear();
+    }
+
+    #[test]
+    fn test_owner_roots_have_independent_fixed_slots() {
+        let _lock = TEST_MUTEX.lock().unwrap_or_else(|p| p.into_inner());
+        clear();
+        let lexical = push(GcRef(0x1000));
+        let first = acquire_owner_root(GcRef(0x2000));
+        let second = acquire_owner_root(GcRef(0x3000));
+
+        pop_to(lexical);
+        assert_eq!(super::depth(), 0);
+        let mut walked = Vec::new();
+        walk_roots(|root| walked.push(*root));
+        assert_eq!(walked, vec![GcRef(0x2000), GcRef(0x3000)]);
+
+        release_owner_root(first);
+        release_owner_root(second);
+        walked.clear();
+        walk_roots(|root| walked.push(*root));
+        assert!(walked.is_empty());
     }
 
     #[test]

--- a/majit/majit-translate/src/codewriter/call.rs
+++ b/majit/majit-translate/src/codewriter/call.rs
@@ -3361,11 +3361,24 @@ impl CallControl {
                         // `IndirectCall`.  That lowering runs inside
                         // `transform_graph_to_jitcode`, i.e. strictly
                         // after `find_all_graphs`, so this is the shape
-                        // the BFS actually sees.  The family is the same
-                        // one the lowering stamps into `graphs`
-                        // (`rpbc.py:216 c_graphs = row_of_graphs.values()`),
-                        // so resolving it here keeps the walk equivalent
-                        // to walking the lowered op.
+                        // the BFS actually sees.
+                        //
+                        // This is not a second family resolver: the arm
+                        // below and `lower_indirect_calls` both call
+                        // `all_impls_for_indirect`, and the lowering only
+                        // folds an empty answer into `graphs = None`,
+                        // which the arm above skips exactly as an empty
+                        // `callees` does here.  The two arms therefore
+                        // enumerate the same callees
+                        // (`rpbc.py:216 c_graphs = row_of_graphs.values()`).
+                        //
+                        // Running the lowering before graph discovery so
+                        // only the post-rtyper shape reaches the BFS would
+                        // match RPython's phase order, but it forces every
+                        // registered graph to be lowered up front, which is
+                        // the eager pass on-demand body lowering replaced
+                        // when the prepass peak RSS came down from 7.71 GB
+                        // to 4.25 GB.
                         OpKind::Call {
                             target:
                                 CallTarget::Indirect {

--- a/pypy/objspace/std/test/apptest_unicode.py
+++ b/pypy/objspace/std/test/apptest_unicode.py
@@ -827,6 +827,21 @@ def test_count_unicode():
     assert u'aaa'.count(u'a', 0, -10) == 0
     assert u'ababa'.count(u'aba') == 1
 
+    # Non-ASCII receivers.  The empty string matches between code points, so
+    # the answer is a code point count; it must not follow the width of the
+    # encoded form.
+    assert u'\xe9\xe8\xe9\xe8\xe9'.count(u'') == 6
+    assert u'\u4e00\u4e8c'.count(u'') == 3
+    assert u'\U0001f600'.count(u'') == 2
+    assert u'a\xe9\u4e00\U0001f600'.count(u'') == 5
+    assert u'\xe9\xe8\xe9\xe8\xe9'.count(u'', 1, 3) == 3
+    for s in [u'aaa', u'\xe9\xe8\xe9', u'\u4e00\u4e8c', u'\U0001f600',
+              u'a\xe9\u4e00\U0001f600']:
+        assert s.count(u'') == len(s) + 1
+        # find/rfind already report the first and last empty match as code
+        # point indices, so the count between them has to agree.
+        assert s.count(u'') == s.rfind(u'') - s.find(u'') + 1
+
 def test_swapcase():
     assert '\xe4\xc4\xdf'.swapcase() == '\xc4\xe4SS'
     # sigma-little becomes sigma-little-final

--- a/pypy/objspace/std/unicodeobject.py
+++ b/pypy/objspace/std/unicodeobject.py
@@ -1118,6 +1118,21 @@ class W_UnicodeObject(W_Root):
         start_index, end_index = self._unwrap_and_compute_idx_params(
             space, w_start, w_end)
         sub = self.convert_arg_to_w_unicode(space, w_sub)._utf8
+        if len(sub) == 0:
+            # The empty string matches between code points, so the result is a
+            # number of code points.  start_index and end_index are byte
+            # offsets, and counting the matches in that domain would answer the
+            # width of the encoded form instead.  end_index can be one past
+            # the end, which is how an out of range start is signalled; clip it
+            # the way the search below would.
+            if end_index > len(value):
+                end_index = len(value)
+            if start_index > end_index:
+                return space.newint(0)
+            if start_index == 0 and end_index == len(value):
+                return space.newint(self._len() + 1)
+            return space.newint(
+                self._codepoints_in_utf8(start_index, end_index) + 1)
         return space.newint(value.count(sub, start_index, end_index))
 
     def descr_contains(self, space, w_sub):

--- a/pyre/pyre-interpreter/src/module/_io/textio.rs
+++ b/pyre/pyre-interpreter/src/module/_io/textio.rs
@@ -821,7 +821,16 @@ impl W_TextIOWrapper {
             w_buffer: buffer,
             w_encoding: w_str_new(encoding),
             w_errors: w_str_new(errors),
-            w_newline: w_none(),
+            // `app_main.py create_stdio:494`
+            // `newline = None if sys.platform == 'win32' else '\n'`.  Universal
+            // newline mode must never be on for POSIX stdio — '\r\n' in stdin
+            // does not mean '\n' there, unlike a file explicitly opened in text
+            // mode — while Windows wants the translation in both directions.
+            w_newline: if cfg!(windows) {
+                w_none()
+            } else {
+                w_str_new("\n")
+            },
             w_stdio_name: w_str_new(name),
             w_encoder: PY_NULL,
             w_decoder: PY_NULL,
@@ -834,8 +843,9 @@ impl W_TextIOWrapper {
             chunk_size: 8192,
             b2cratio: 0.0,
             has_read1: false,
-            readuniversal: true,
-            readtranslate: true,
+            // What `set_newline` derives from the `w_newline` above.
+            readuniversal: cfg!(windows),
+            readtranslate: cfg!(windows),
             seekable_flag: false,
             telling: false,
             encoding_start_of_stream: false,

--- a/pyre/pyre-interpreter/src/module/_io/textio.rs
+++ b/pyre/pyre-interpreter/src/module/_io/textio.rs
@@ -802,6 +802,46 @@ impl W_TextIOWrapper {
         crate::module::_codecs::lookup_text_codec("open", encoding)
     }
 
+    /// Install the buffer and everything derived from it.  The interpreter
+    /// built standard streams run this too, so they reach the same state a
+    /// constructed wrapper does instead of only the fields a struct literal
+    /// can spell.
+    #[allow(clippy::too_many_arguments)]
+    fn attach_buffer(
+        &mut self,
+        buffer: PyObjectRef,
+        encoding: &str,
+        errors: &str,
+        newline: PyObjectRef,
+        newline_value: Option<&str>,
+        codec: PyObjectRef,
+        line_buffering: bool,
+        write_through: bool,
+    ) -> Result<(), crate::PyError> {
+        self.w_buffer = buffer;
+        self.w_encoding = w_str_new(encoding);
+        self.w_errors = w_str_new(errors);
+        self.w_newline = newline;
+        self.line_buffering = line_buffering;
+        self.write_through = write_through;
+        self.decoded.reset();
+        self.snapshot = None;
+        self.pending_bytes = None;
+        self.pending_bytes_count = 0;
+        self.chunk_size = 8192;
+        self.b2cratio = 0.0;
+        self.set_newline(newline_value);
+        self.has_read1 = crate::baseobjspace::getattr_str(buffer, "read1").is_ok();
+        self.set_encoder_decoder(codec)?;
+        self.seekable_flag =
+            crate::baseobjspace::is_true(super::call_method_result(buffer, "seekable", &[])?)?;
+        self.telling = self.seekable_flag;
+        self.state = STATE_OK;
+        self.reset_encoder_state();
+        pyre_object::gc_hook::try_gc_write_barrier(self as *mut Self as *mut u8);
+        Ok(())
+    }
+
     /// Allocate the typed payload used by the interpreter-created standard
     /// streams.  Their methods and metadata remain instance overrides until
     /// sys stream construction is ported to a real FileIO-backed pipeline.
@@ -817,42 +857,72 @@ impl W_TextIOWrapper {
         // a payload whose stdio methods are installed in the instance dict.
         let _ = type_object();
         let obj = Self::allocate_stable(Self {
-            state: STATE_OK,
-            w_buffer: buffer,
-            w_encoding: w_str_new(encoding),
-            w_errors: w_str_new(errors),
-            // `app_main.py create_stdio:494`
-            // `newline = None if sys.platform == 'win32' else '\n'`.  Universal
-            // newline mode must never be on for POSIX stdio — '\r\n' in stdin
-            // does not mean '\n' there, unlike a file explicitly opened in text
-            // mode — while Windows wants the translation in both directions.
-            w_newline: if cfg!(windows) {
-                w_none()
-            } else {
-                w_str_new("\n")
-            },
             w_stdio_name: w_str_new(name),
-            w_encoder: PY_NULL,
-            w_decoder: PY_NULL,
-            line_buffering,
-            write_through,
-            decoded: DecodeBuffer::default(),
-            snapshot: None,
-            pending_bytes: None,
-            pending_bytes_count: 0,
-            chunk_size: 8192,
-            b2cratio: 0.0,
-            has_read1: false,
-            // What `set_newline` derives from the `w_newline` above.
-            readuniversal: cfg!(windows),
-            readtranslate: cfg!(windows),
-            seekable_flag: false,
-            telling: false,
-            encoding_start_of_stream: false,
             ..Self::default()
         });
+        let _roots = pyre_object::gc_roots::push_roots();
+        pyre_object::gc_roots::pin_root(obj);
+        pyre_object::gc_roots::pin_root(buffer);
+        // `app_main.py create_stdio:494`
+        // `newline = None if sys.platform == 'win32' else '\n'`.  Universal
+        // newline mode must never be on for POSIX stdio — '\r\n' in stdin does
+        // not mean '\n' there, unlike a file explicitly opened in text mode —
+        // while Windows wants the translation in both directions.
+        let newline_value = if cfg!(windows) { None } else { Some("\n") };
+        let newline = newline_value.map_or_else(w_none, w_str_new);
+        // No codec here: looking one up imports `encodings`, whose own
+        // `import sys` would re-enter the `sys` creation this runs inside and
+        // hand the import system a second, half built module.
+        // [`attach_stdio_codec`] supplies it once the import system is up.
+        let payload = unsafe { &mut *(obj as *mut Self) };
+        let _ = payload.attach_buffer(
+            buffer,
+            encoding,
+            errors,
+            newline,
+            newline_value,
+            PY_NULL,
+            line_buffering,
+            write_through,
+        );
+        // `attach_buffer` reaches its fallible calls only once the buffer and
+        // the newline mode are stored, so a stream whose buffer answers no
+        // `seekable` — a descriptor the host refused to open arrives as none at
+        // all — is still the stream this used to build unconditionally.
+        payload.state = STATE_OK;
+        pyre_object::gc_hook::try_gc_write_barrier(payload as *mut Self as *mut u8);
         crate::baseobjspace::setdictvalue_native(obj, "name", w_str_new(name));
         obj
+    }
+
+    /// Give a stream [`allocate_stdio`] built the encoder and decoder it had to
+    /// go without.  Every read path needs the decoder: without it the stream
+    /// reports itself unreadable however readable its buffer is, and only the
+    /// methods `make_std_stream` installs as instance overrides work.
+    ///
+    /// Ignores anything else — a replaced `sys.stdout`, a stream that already
+    /// has a codec, one whose encoding is unknown to the codec registry.
+    pub fn attach_stdio_codec(stream: PyObjectRef) {
+        if stream.is_null()
+            || !std::ptr::eq(
+                unsafe { pyre_object::ll_type(stream) },
+                <Self as pyre_object::lltype::PyreClassPyTypeOf>::PYTYPE,
+            )
+        {
+            return;
+        }
+        let payload = unsafe { &mut *(stream as *mut Self) };
+        if !payload.w_encoder.is_null() || !payload.w_decoder.is_null() {
+            return;
+        }
+        let Some(encoding) =
+            unsafe { pyre_object::w_str_get_value_opt(payload.w_encoding) }.map(str::to_owned)
+        else {
+            return;
+        };
+        if let Ok(codec) = Self::lookup_text_codec(&encoding) {
+            let _ = payload.set_encoder_decoder(codec);
+        }
     }
 }
 
@@ -891,32 +961,24 @@ impl W_TextIOWrapper {
         Self::io_check_errors(&errors)?;
         let newline_value = Self::unwrap_newline(newline)?;
         let codec = Self::lookup_text_codec(&encoding)?;
-
-        self.w_buffer = buffer;
-        self.w_encoding = w_str_new(&encoding);
-        self.w_errors = w_str_new(&errors);
-        self.w_newline = newline;
         // 3.14's constructor uses the `bool` Argument Clinic converter (truth
         // testing), unlike `reconfigure`'s `int` converter — an object with
-        // `__bool__` but no `__index__` is accepted here.
-        self.line_buffering = crate::baseobjspace::is_true(line_buffering)?;
-        self.write_through = crate::baseobjspace::is_true(write_through)?;
-        self.decoded.reset();
-        self.snapshot = None;
-        self.pending_bytes = None;
-        self.pending_bytes_count = 0;
-        self.chunk_size = 8192;
-        self.b2cratio = 0.0;
-        self.set_newline(newline_value.as_deref());
-        self.has_read1 = crate::baseobjspace::getattr_str(buffer, "read1").is_ok();
-        self.set_encoder_decoder(codec)?;
-        self.seekable_flag =
-            crate::baseobjspace::is_true(super::call_method_result(buffer, "seekable", &[])?)?;
-        self.telling = self.seekable_flag;
-        self.state = STATE_OK;
-        self.reset_encoder_state();
-        pyre_object::gc_hook::try_gc_write_barrier(self as *mut Self as *mut u8);
-        Ok(())
+        // `__bool__` but no `__index__` is accepted here.  Argument parsing
+        // runs before the body, so an object whose `__bool__` raises leaves
+        // the stream unattached rather than half filled in.
+        let line_buffering = crate::baseobjspace::is_true(line_buffering)?;
+        let write_through = crate::baseobjspace::is_true(write_through)?;
+
+        self.attach_buffer(
+            buffer,
+            &encoding,
+            &errors,
+            newline,
+            newline_value.as_deref(),
+            codec,
+            line_buffering,
+            write_through,
+        )
     }
 
     fn read(

--- a/pyre/pyre-interpreter/src/module/faulthandler/handler.rs
+++ b/pyre/pyre-interpreter/src/module/faulthandler/handler.rs
@@ -8,23 +8,31 @@
 //
 // CPython's faulthandler dumps the Python traceback on fatal signals.
 // Pyre has no Python-level traceback machinery yet, so our handler
-// writes a short "Fatal Python error: <name>" line to fd 2 and then
-// restores the default disposition + reraises the signal so the
-// process dies the normal way.
+// writes a short "Fatal Python error: <name>" line to the descriptor
+// `enable` was given and then restores the default disposition +
+// reraises the signal so the process dies the normal way.
 // ──────────────────────────────────────────────────────────────────────
 
 #[cfg(all(unix, feature = "host_env"))]
 static FAULTHANDLER_ENABLED: std::sync::atomic::AtomicBool =
     std::sync::atomic::AtomicBool::new(false);
 
+/// The descriptor `enable` resolved from its `file` argument.  `handler.py`
+/// keeps it on the Handler instance, but the signal handler below is a bare
+/// `extern "C" fn` and cannot capture, so it is handed over through a static.
+/// Defaults to 2, which is what `get_fileno_and_file` answers for None.
+#[cfg(all(unix, feature = "host_env"))]
+static FAULTHANDLER_FD: std::sync::atomic::AtomicI32 = std::sync::atomic::AtomicI32::new(2);
+
 #[cfg(all(unix, feature = "host_env"))]
 extern "C" fn faulthandler_signal_handler(signum: libc::c_int) {
-    // Stay async-signal-safe: write to fd 2 with raw libc::write and
-    // restore the default disposition before reraising.
+    // Stay async-signal-safe: write with raw libc::write and restore the
+    // default disposition before reraising.
     let name =
         rustpython_host_env::faulthandler::fatal_signal_name(signum).unwrap_or("unknown signal");
     let msg = format!("Fatal Python error: {name}\n");
-    rustpython_host_env::faulthandler::write_fd(2, msg.as_bytes());
+    let fd = FAULTHANDLER_FD.load(std::sync::atomic::Ordering::Relaxed);
+    rustpython_host_env::faulthandler::write_fd(fd, msg.as_bytes());
     rustpython_host_env::faulthandler::signal_default_and_raise(signum);
 }
 
@@ -60,10 +68,11 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             "enable",
             |args| {
                 // `handler.py:141-145 enable` — file=None, all_threads=True.
-                let _fd =
+                let fd =
                     faulthandler_extract_fd(args.first().copied().unwrap_or(pyre_object::PY_NULL))?;
                 #[cfg(all(unix, feature = "host_env"))]
                 {
+                    FAULTHANDLER_FD.store(fd, std::sync::atomic::Ordering::Relaxed);
                     let ok = rustpython_host_env::faulthandler::enable_fatal_handlers(
                         faulthandler_signal_handler,
                         libc::SA_NODEFER | libc::SA_ONSTACK,
@@ -77,9 +86,12 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     ));
                 }
                 #[cfg(not(all(unix, feature = "host_env")))]
-                Err(crate::PyError::not_implemented(
-                    "faulthandler.enable requires host_env feature",
-                ))
+                {
+                    let _ = fd;
+                    Err(crate::PyError::not_implemented(
+                        "faulthandler.enable requires host_env feature",
+                    ))
+                }
             },
             // `enable(file=sys.stderr, all_threads=True, c_stack=True)` —
             // `c_stack` (3.14) selects C-stack dumping; accept and ignore it.

--- a/pyre/pyre-interpreter/src/module/sys/vm.rs
+++ b/pyre/pyre-interpreter/src/module/sys/vm.rs
@@ -2046,6 +2046,26 @@ fn stdio_stdin_readline(args: &[PyObjectRef]) -> crate::PyResult {
     ])
 }
 
+/// `pylifecycle.c init_sys_streams` builds the standard streams after the
+/// import system, so a text codec is reachable by the time they need one.
+/// Pyre builds them from `sys` module creation instead, where the codec lookup
+/// would import `encodings` and re-enter that creation through its own
+/// `import sys`.  They start without an encoder and decoder and pick them up
+/// here, once the import system is up.
+///
+/// The `__std*__` aliases name the streams this built even after user code
+/// rebinds `sys.stdout`; a rebound one is not this function's to reconfigure.
+pub fn init_stream_codecs() {
+    let Some(sys) = crate::importing::get_sys_module("sys") else {
+        return;
+    };
+    for name in ["__stdout__", "__stderr__", "__stdin__"] {
+        if let Ok(stream) = crate::baseobjspace::getattr_str(sys, name) {
+            crate::module::_io::W_TextIOWrapper::attach_stdio_codec(stream);
+        }
+    }
+}
+
 fn make_std_stream(name: &'static str, fd: i32) -> PyObjectRef {
     let writable = fd != 0;
     let to_stderr = fd == 2;

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -556,6 +556,11 @@ const _: () = assert!(std::mem::offset_of!(GcFramePrefix, frame) == GC_HEADER_SI
 /// valid header at `frame - GC_HEADER_SIZE`.
 pub struct FrameBox {
     ptr: *mut PyFrame,
+    /// RPython's translated Rust local is a shadow-stack livevar for the
+    /// complete lifetime of the owning handle.  In particular it remains a
+    /// root after `FrameBox::new` returns and before `execute_frame` installs
+    /// the frame on the ExecutionContext chain.
+    owner_root: Option<majit_gc::shadow_stack::OwnerRootGuard>,
 }
 
 impl FrameBox {
@@ -578,7 +583,31 @@ impl FrameBox {
     /// every reader (`frame - GC_HEADER_SIZE` write-barrier header,
     /// `pyframe_object_custom_trace`) is regime-independent; `Drop`
     /// distinguishes them with `try_gc_owns_object`.
-    pub fn new(frame: PyFrame) -> Self {
+    pub fn new(mut frame: PyFrame) -> Self {
+        // `frame` is an RPython aggregate local whose GCREF fields are all
+        // translated livevars across the frame allocation. Publish every field
+        // before the first GC operation; a contended stable allocation parks
+        // this mutator and lets another collector run.
+        let input_roots = [
+            majit_gc::shadow_stack::OwnerRootGuard::new(majit_ir::GcRef(
+                frame.ob_header.w_class as usize,
+            )),
+            majit_gc::shadow_stack::OwnerRootGuard::new(majit_ir::GcRef(frame.pycode as usize)),
+            majit_gc::shadow_stack::OwnerRootGuard::new(majit_ir::GcRef(
+                frame.locals_cells_stack_w as usize,
+            )),
+            majit_gc::shadow_stack::OwnerRootGuard::new(majit_ir::GcRef(frame.debugdata as usize)),
+            majit_gc::shadow_stack::OwnerRootGuard::new(majit_ir::GcRef(frame.lastblock as usize)),
+            majit_gc::shadow_stack::OwnerRootGuard::new(majit_ir::GcRef(
+                frame.f_generator_nowref as usize,
+            )),
+            majit_gc::shadow_stack::OwnerRootGuard::new(majit_ir::GcRef(
+                frame.w_yielding_from as usize,
+            )),
+            majit_gc::shadow_stack::OwnerRootGuard::new(majit_ir::GcRef(frame.f_backref as usize)),
+            majit_gc::shadow_stack::OwnerRootGuard::new(majit_ir::GcRef(frame.w_builtin as usize)),
+            majit_gc::shadow_stack::OwnerRootGuard::new(majit_ir::GcRef(frame.w_globals as usize)),
+        ];
         let raw = pyre_object::gc_hook::try_gc_alloc_stable_raw(
             PYFRAME_GC_TYPE_ID,
             std::mem::size_of::<PyFrame>(),
@@ -592,6 +621,17 @@ impl FrameBox {
             // collector between this allocation and the barrier below.
             let frame_root = pyre_object::gc_roots::push_roots();
             pyre_object::gc_roots::pin_root(raw as pyre_object::PyObjectRef);
+            frame.ob_header.w_class = input_roots[0].get().0 as pyre_object::PyObjectRef;
+            frame.pycode = input_roots[1].get().0 as *const ();
+            frame.locals_cells_stack_w =
+                input_roots[2].get().0 as *mut pyre_object::FixedObjectArray;
+            frame.debugdata = input_roots[3].get().0 as *mut FrameDebugData;
+            frame.lastblock = input_roots[4].get().0 as *mut FrameBlock;
+            frame.f_generator_nowref = input_roots[5].get().0 as pyre_object::PyObjectRef;
+            frame.w_yielding_from = input_roots[6].get().0 as pyre_object::PyObjectRef;
+            frame.f_backref = input_roots[7].get().0 as *mut PyFrame;
+            frame.w_builtin = input_roots[8].get().0 as pyre_object::PyObjectRef;
+            frame.w_globals = input_roots[9].get().0 as pyre_object::PyObjectRef;
             debug_assert!(pyre_object::gc_hook::try_gc_owns_object(
                 frame.locals_cells_stack_w as *mut u8
             ));
@@ -604,8 +644,13 @@ impl FrameBox {
             // tracer, exactly as `generator.rs:72` does for a stable
             // generator wrapping young frame contents.
             pyre_object::gc_hook::try_gc_write_barrier(raw);
+            let owner_root =
+                majit_gc::shadow_stack::OwnerRootGuard::new(majit_ir::GcRef(ptr as usize));
             drop(frame_root);
-            return FrameBox { ptr };
+            return FrameBox {
+                ptr,
+                owner_root: Some(owner_root),
+            };
         }
         debug_assert!(!pyre_object::gc_hook::try_gc_owns_object(
             frame.locals_cells_stack_w as *mut u8
@@ -627,13 +672,17 @@ impl FrameBox {
             frame,
         }));
         let ptr = unsafe { std::ptr::addr_of_mut!((*raw).frame) };
-        FrameBox { ptr }
+        FrameBox {
+            ptr,
+            owner_root: None,
+        }
     }
 
     /// Relinquish ownership, returning the inner-frame pointer. The header
     /// remains at `ptr - GC_HEADER_SIZE`; reclaim via [`FrameBox::from_raw`].
-    pub fn into_raw(self) -> *mut PyFrame {
+    pub fn into_raw(mut self) -> *mut PyFrame {
         let ptr = self.ptr;
+        drop(self.owner_root.take());
         std::mem::forget(self);
         ptr
     }
@@ -645,7 +694,22 @@ impl FrameBox {
     /// `ptr` must originate from [`FrameBox::into_raw`] / [`FrameBox::new`]
     /// and must not have been freed.
     pub unsafe fn from_raw(ptr: *mut PyFrame) -> Self {
-        FrameBox { ptr }
+        // Publish before asking the collector whether the address is managed:
+        // the ownership query is a GC operation and may park behind another
+        // thread's collection.
+        let owner_root = majit_gc::shadow_stack::OwnerRootGuard::new(majit_ir::GcRef(ptr as usize));
+        if pyre_object::gc_hook::try_gc_owns_object(ptr as *mut u8) {
+            FrameBox {
+                ptr,
+                owner_root: Some(owner_root),
+            }
+        } else {
+            drop(owner_root);
+            FrameBox {
+                ptr,
+                owner_root: None,
+            }
+        }
     }
 
     /// Raw pointer to the inner frame (header at `ptr - GC_HEADER_SIZE`).
@@ -828,7 +892,7 @@ impl Drop for FrameBox {
         // and block chain with the frame, so no manual cleanup runs here.
         // Only a `std::alloc` snapshot / bootstrap fallback box is freed
         // manually — reconstruct and drop it, which runs `PyFrame::drop`.
-        if pyre_object::gc_hook::try_gc_owns_object(self.ptr as *mut u8) {
+        if self.owner_root.take().is_some() {
             return;
         }
         unsafe {
@@ -3731,6 +3795,12 @@ impl PyFrame {
         let locals_cells_stack_w = unsafe {
             alloc_frame_locals_array(num_locals + num_cells + max_stack, PY_NULL, allocation)
         };
+        // The allocation result is a translated livevar before it is stored in
+        // the eventual PyFrame. Publish it before `w_cell_new`, the barrier,
+        // or any other GC operation can park this free-threaded mutator.
+        let _locals_owner_root = majit_gc::shadow_stack::OwnerRootGuard::new(majit_ir::GcRef(
+            locals_cells_stack_w as usize,
+        ));
 
         {
             // Populate the freshly-allocated array via its mutable slice.

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
@@ -24,19 +24,15 @@ use super::*;
 /// and each extra inlined level removes a residual call — measured ~2.0–2.3×
 /// on the `depthN_inline_chain` fixtures with no regression elsewhere.
 ///
-/// Deep unrolling is a loss for exactly two callee shapes, each capped
-/// separately so the chain depth can rise freely:
-///   - a self-recursive callee (tree recursion `fib`, whose `n < 2` base-case
-///     guard fails per call) — its unrolled copy guard-fails and deopts to the
-///     blackhole on essentially every recursive call (two orders of magnitude
-///     more blackhole resumes, ~20–30× slower).  Bounded by the distinct
-///     `max_unroll_recursion` limit (`fbw_max_rec_unroll_depth`, kept at 1).
-///   - a callee that raises inline below an intermediate frame — its unwind
-///     needs the cross-frame bridge (gh#343 / gh#467) the drain cannot yet
-///     build.  Capped to the top inline level by `callee_body_contains_raise`.
-/// This mirrors `max_unroll_recursion` folding a recursive call straight to
-/// `CALL_ASSEMBLER` (`_opimpl_recursive_call` → `do_recursive_call`,
-/// `pyjitpl.py`) past the bound rather than continuing to unroll the call tree.
+/// A callee that raises inline below an intermediate frame is capped separately,
+/// to the top inline level by `callee_body_contains_raise`: its unwind needs the
+/// cross-frame bridge (gh#343 / gh#467) the drain cannot yet build.
+///
+/// A self-recursive callee is bounded instead by
+/// [`fbw_inline_recursion_count`] against `max_unroll_recursion`, mirroring
+/// `opimpl_recursive_call` (`pyjitpl.py:1390-1416`) folding the recursive call
+/// straight to `CALL_ASSEMBLER` past the bound rather than continuing to unroll
+/// the call tree.
 /// (The depth-≥2 blackhole-resume crash that previously blocked this path was a
 /// GC-rooting gap in the nested `run()` chain, fixed by rooting the whole
 /// pending `nextblackholeinterp` chain across `run()`; the bound is now a
@@ -52,29 +48,10 @@ pub(crate) fn fbw_max_multiframe_depth() -> usize {
     })
 }
 
-/// `max_unroll_recursion`: how many levels a self-recursive callee unrolls
-/// before folding the deepest self-call to `CALL_ASSEMBLER`
-/// (`_opimpl_recursive_call` → `do_recursive_call`, `pyjitpl.py`).  This is a
-/// bound distinct from the straight-line inline depth
-/// (`fbw_max_multiframe_depth`): a value-returning callee CHAIN inlines deeply
-/// with a clean win, but unrolling a self-recursive callee past one level is a
-/// loss — the extra copy guard-fails / cannot materialize a residual self-call
-/// argument on the exception-unwind path and deopts (measured: a depth-2 unroll
-/// of `recur(depth-1, acc+check(...))` drops a bridge and runs ~13% slower).
-/// Kept at 1 so that raising the chain-inline depth never deepens recursion
-/// unrolling.  `PYRE_FBW_REC_UNROLL_DEPTH` overrides for A/B.
-pub(crate) fn fbw_max_rec_unroll_depth() -> usize {
-    static DEPTH: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
-    *DEPTH.get_or_init(|| {
-        std::env::var("PYRE_FBW_REC_UNROLL_DEPTH")
-            .ok()
-            .and_then(|v| v.parse::<usize>().ok())
-            .unwrap_or(1)
-            .clamp(1, 7)
-    })
-}
-
-/// Recursion depth of `w_code` on the walk's framestack.
+/// Recursion depth of `w_code` on the walk's framestack —
+/// `opimpl_recursive_call` (`pyjitpl.py:1390-1402`) counting the portal frames
+/// already on `MetaInterp.framestack` before comparing against
+/// `max_unroll_recursion`.
 pub(crate) fn fbw_inline_recursion_count<Sym: WalkSym>(
     ctx: &WalkContext<'_, '_, Sym>,
     w_code: usize,

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -2517,10 +2517,12 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
         // admit it too so a rare guard-bridge continuation inlines its nested
         // int-arith calls instead of residualizing them (the gh#343 branchy-callee
         // cost).
-        let root_bridge = !ctx.fbw_mode.carrier_resume
-            && !ctx.fbw_mode.inline_subwalk
-            && !ctx.fbw_mode.snapshot_sym.is_null()
-            && ctx.session.borrow().framestack.is_empty();
+        // The nested levels are admitted on the same terms.
+        // `opimpl_recursive_call` (`pyjitpl.py:1390-1416`) makes the inline
+        // decision from the portal-frame count alone — already applied above via
+        // `fbw_inline_recursion_count` — and asks nothing about how deep the
+        // framestack is or whether a bridge or a primary trace is walking.
+        let root_bridge = !ctx.fbw_mode.carrier_resume && !ctx.fbw_mode.snapshot_sym.is_null();
         // A carrier-resume sub-walk (`drive_bridge_frame_subwalk`) drives its
         // reconstructed frame(s) forward through the same metainterp the initial
         // trace uses, so its inline of a nested int-arith call is the SAME as a
@@ -2675,17 +2677,17 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
         return Ok(None);
     }
 
-    // A self-recursive callee routes to the direct `CALL_ASSEMBLER` arm
+    // A self-recursive callee unrolls until its own frame count reaches
+    // `max_unroll_recursion`, then routes to the direct `CALL_ASSEMBLER` arm
     // (`try_walker_call_assembler_self_recursive`, reached when this inline
-    // attempt returns `Ok(None)`) rather than the multiframe inline path.
-    // Multi-parameter all-int calls fold there; other self-recursive shapes
-    // decline from the fold to the plain residual call instead of aborting.
-    // Detected before the multiframe gate: a forward-branch self-recursive
-    // callee is `try_multiframe`-eligible, but unbounded self-recursion bottoms
-    // out the multiframe inline at the depth cap.  A strict-inlinable callee is
-    // a straight-line leaf (no self-recursion), so this never preempts the
-    // strict path.
-    if !strict_inlinable && nparams >= 1 {
+    // attempt returns `Ok(None)`).  That bound is the one
+    // `fbw_inline_recursion_count` already applied above, matching
+    // `opimpl_recursive_call` (`pyjitpl.py:1390-1416`), which counts the portal
+    // frames already on the framestack and inlines while the count is below
+    // `max_unroll_recursion`.  A carrier-resume sub-walk is the exception: it
+    // reconstructs its frames rather than entering them, so the count is not
+    // the walk's own recursion depth.
+    if !strict_inlinable && nparams >= 1 && ctx.fbw_mode.carrier_resume {
         let sym_ptr = ctx.fbw_mode.snapshot_sym;
         let self_recursive = !sym_ptr.is_null()
             && unsafe {
@@ -2694,20 +2696,7 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
             } as usize
                 == w_code as usize;
         if self_recursive {
-            // RPython `opimpl_recursive_call` / `do_recursive_call`
-            // (`pyjitpl.py`) unroll within `max_unroll_recursion`,
-            // then fall back to the assembler-call path. A primary trace spends the
-            // recursion-unroll budget unrolling below `max_unroll_recursion`
-            // (`fbw_max_rec_unroll_depth`, a bound distinct from the
-            // straight-line chain-inline depth `fbw_max_multiframe_depth`)
-            // before folding the deepest call to the recursive portal
-            // `CALL_ASSEMBLER`.
-            let unroll = !ctx.fbw_mode.carrier_resume
-                && ctx.session.borrow().framestack.len() < fbw_max_rec_unroll_depth();
-            if !unroll {
-                return Ok(None);
-            }
-            // fall through to the multiframe gate (unroll one level)
+            return Ok(None);
         }
     }
     // #68: a forward-branch-bearing callee is inlinable with a multi-frame

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -2522,7 +2522,19 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
         // decision from the portal-frame count alone — already applied above via
         // `fbw_inline_recursion_count` — and asks nothing about how deep the
         // framestack is or whether a bridge or a primary trace is walking.
-        let root_bridge = !ctx.fbw_mode.carrier_resume && !ctx.fbw_mode.snapshot_sym.is_null();
+        //
+        // An inline sub-walk is the exception, and it is one with no upstream
+        // counterpart: `perform_call` pushes onto `MetaInterp.framestack` and
+        // returns to the single `interpret()` loop, so upstream is never inside
+        // one walk while starting another and can never seed a multiframe
+        // snapshot from a sub-walk. Seeding one here makes the wasm bridge
+        // replay re-execute the sub-walk's body — wrong output from
+        // `synth/ca_bridge_multiframe_resume_double_call` and
+        // `synth/recursion_memo_branch`, and a `fib_recursive` timeout, all
+        // while dynasm and cranelift stay green.
+        let root_bridge = !ctx.fbw_mode.carrier_resume
+            && !ctx.fbw_mode.inline_subwalk
+            && !ctx.fbw_mode.snapshot_sym.is_null();
         // A carrier-resume sub-walk (`drive_bridge_frame_subwalk`) drives its
         // reconstructed frame(s) forward through the same metainterp the initial
         // trace uses, so its inline of a nested int-arith call is the SAME as a

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -10143,7 +10143,17 @@ fn handle<Sym: WalkSym>(
                     // the same case for the same reason. Only a cross-loop cut
                     // is declined: a trace that started at these greens still
                     // closes on its own back-edge below.
-                    if key != ctx.trace_ctx.root_green_key() {
+                    // One decline is not a plain "keep tracing": compile.py:1079
+                    // `metainterp.retrace_needed` leaves `partial_trace` and
+                    // `retracing_from` pointing at this header's position. The
+                    // return below skips the merge-point registration further
+                    // down, so the later close at the root header would compare
+                    // the root merge point against a `retracing_from` no merge
+                    // point was ever recorded for, and abort instead of
+                    // retracing. `has_partial` was false above, so a partial
+                    // trace here is the one this attempt just requested.
+                    let retrace_requested = driver.meta_interp().partial_trace().is_some();
+                    if !retrace_requested && key != ctx.trace_ctx.root_green_key() {
                         if majit_metainterp::majit_log_enabled() {
                             eprintln!(
                                 "[jit][walker-reached-loop-header] merge point pc={} already \

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -8575,6 +8575,17 @@ pub fn try_function_entry_jit(frame: &mut PyFrame) -> Option<PyResult> {
     if stack_almost_full() {
         return None;
     }
+    // `compile_and_run_once` traces, runs the backend compiler, and then enters
+    // the code it just produced, all in native frames no `stack_check()` ever
+    // saw.  Upstream's backend is a few RPython frames and stays well inside the
+    // budget, so it marks only the sub-regions where an interruption would leave
+    // dangling state (`compile.py:976`, `pyjitpl.py:3305`, `resume.py:1318`);
+    // Cranelift's is an optimizing compiler measuring ~1.2 MB against a 768 KB
+    // budget, so the prologue probe of the code being entered reports an
+    // overflow at a Python call depth of 2.  `report_error = 0` for the region
+    // is what `stack.h:42-43` is for — a real overflow still surfaces from the
+    // interpreter once the region exits.
+    let _cc_guard = majit_metainterp::CriticalCodeGuard::enter();
     let env = PyreEnv;
     if majit_metainterp::majit_log_enabled() {
         eprintln!(

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -5501,6 +5501,11 @@ fn drive_unpack_iterable_trace(
         {
             pending_err.get_or_insert(err);
         }
+        // The backend `_store_exception` cells are a compiled-side slot too:
+        // a guard exit that carried the drain's exception leaves them set even
+        // after the two clears above. See the walk's finish arm for what a
+        // survivor does to the next compiled trace.
+        crate::call_jit::drain_backend_jit_exc();
         // Parked last, so the clears above cannot swallow it.
         if let Some(err) = pending_err {
             pyre_interpreter::stack_check::park_jit_pending_error(err);
@@ -5632,6 +5637,21 @@ fn drive_unpack_iterable_trace(
         // (`walk_jit_pending_exception`).
         if exit_with_exception && let Some(err) = drain_error_from_exc_ref(exc_value) {
             pyre_interpreter::stack_check::park_jit_pending_error(err);
+        }
+        // The `next()` that ended the drain raised for real, and the shared
+        // `bh_*` residual helper published its exception into the backend
+        // `_store_exception` cells as well as `BH_LAST_EXC_VALUE`
+        // (`publish_residual_call_exception`). The trace exit consumed it just
+        // above — the loop-exit `StopIteration` is dropped so `ln` re-derives
+        // its own, anything else is parked — but the cells still hold it, and
+        // tracing must leave them pristine (`drain_backend_jit_exc`). A
+        // survivor is read by the next compiled trace's `must_save_exception`
+        // guard, whose recovery stub stages it into `jf_guard_exc`: the
+        // blackhole then unwinds an exception no one raised and the call
+        // returns NULL, surfacing much later as a `StopIteration` out of an
+        // unrelated operator.
+        if exit_with_exception {
+            crate::call_jit::drain_backend_jit_exc();
         }
         match meta.compile_finish_from_active_session(
             &finish_args,

--- a/pyre/pyre-object/src/tupleobject.rs
+++ b/pyre/pyre-object/src/tupleobject.rs
@@ -187,6 +187,16 @@ pub fn w_tuple_new_array_backed(items: Vec<PyObjectRef>) -> PyObjectRef {
         w_class: get_instantiate(&TUPLE_TYPE),
     };
     let raw = crate::gc_hook::try_gc_alloc_stable_raw(W_TUPLE_GC_TYPE_ID, W_TUPLE_OBJECT_SIZE);
+    // The freshly allocated tuple header is itself a translated livevar across
+    // the items-block allocation and the write barrier below. Publish it
+    // immediately; in a free-threaded run either operation may park behind a
+    // foreign collector even though the address is old-gen and non-moving.
+    let raw_slot = if raw.is_null() {
+        None
+    } else {
+        crate::gc_roots::pin_root(raw as PyObjectRef);
+        Some(crate::gc_roots::shadow_stack_len() - 1)
+    };
 
     // pop_roots: read the relocated item pointers back out of the shadow
     // stack, then build the items block. On the Phase L2 nursery path
@@ -198,6 +208,9 @@ pub fn w_tuple_new_array_backed(items: Vec<PyObjectRef>) -> PyObjectRef {
         .map(|i| crate::gc_roots::shadow_stack_get(save_point + i))
         .collect();
     let items_block = unsafe { alloc_tuple_items_block_gc(&relocated) };
+    let raw = raw_slot
+        .map(crate::gc_roots::shadow_stack_get)
+        .unwrap_or(std::ptr::null_mut()) as *mut u8;
 
     if !raw.is_null() {
         unsafe {

--- a/pyre/pyrex/src/lib.rs
+++ b/pyre/pyrex/src/lib.rs
@@ -1059,6 +1059,19 @@ pub(crate) fn init_importlib_bootstrap(
     canonical: pyre_object::PyObjectRef,
     ec_ptr: *const pyre_interpreter::PyExecutionContext,
 ) -> Result<(), pyre_interpreter::PyError> {
+    let bootstrapped = bootstrap_importlib_modules(canonical, ec_ptr);
+    // pylifecycle.c init_sys_streams, which follows init_importlib: the
+    // standard streams can reach a text codec from here on.  A failed
+    // bootstrap leaves the native importer serving imports, so the codec is
+    // still reachable and the streams still want it.
+    pyre_interpreter::module::sys::vm::init_stream_codecs();
+    bootstrapped
+}
+
+fn bootstrap_importlib_modules(
+    canonical: pyre_object::PyObjectRef,
+    ec_ptr: *const pyre_interpreter::PyExecutionContext,
+) -> Result<(), pyre_interpreter::PyError> {
     let import =
         |name: &str| importing::importhook(name, canonical, pyre_object::PY_NULL, 0, ec_ptr);
 


### PR DESCRIPTION
Four commits on top of `main`.

## `jit: enforce the recursion-unroll bound once, and mark loop compilation stack-critical`

`opimpl_recursive_call` (`pyjitpl.py:1390-1416`) bounds recursive inlining with a single check: count the portal frames already on the framestack, and inline while that count is below `max_unroll_recursion` (default 7). pyre applied that check via `fbw_inline_recursion_count` / `FBW_MAX_INLINE_RECURSION` and then added two conditions upstream does not have:

- a `framestack.len()` bound against a separate `fbw_max_rec_unroll_depth` knob (default 1), and
- a `framestack.is_empty()` requirement on bridge admission.

Together they made `max_unroll_recursion` unreachable for a bridge-served recursion, so the knob was inert at every value. Both are dropped, along with `fbw_max_rec_unroll_depth` and `PYRE_FBW_REC_UNROLL_DEPTH`.

Removing them exposed a second, independent defect. `compile_and_run_once` (the `warmstate.py:425-444` `bound_reached` analogue) traces, runs the backend compiler, and enters the code it just produced on one native stack. Upstream's backend is a few RPython frames and stays well inside the budget; Cranelift's is an optimizing compiler, measured at ~1.2 MB against the 768 KB `MAX_STACK_SIZE`, so the entered code's prologue probe reported an overflow at a Python call depth of 2 — a spurious `RecursionError` in `synth/wasm_ca_trampoline_decline`. The region is now marked with `CriticalCodeGuard`, the `report_error = 0` window of `stack.h:42-43` that `compile.py:976`, `pyjitpl.py:3305` and `resume.py:1318` already use; a real overflow still surfaces once the region exits.

Diagnosis notes: the failure is not a leak (capacity is flat at 441 before and after 190 hot-loop iterations, both backends) and not a bad probe (Cranelift's `stack_addr` proxy differs from a real `current_sp()` read by 80 bytes). Guards placed on the walker's inline-push site, on the CA-bridge compile, and around all of `handle_fail` changed nothing, which is what narrowed it to the primary-loop compile path.

## `frame and tuple owner roots, POSIX stdio newline, faulthandler fd, GC lifetime logging`

Working-tree changes that were in flight, collected into one commit at the author's request:

- `pyframe`: `FrameBox` holds an `OwnerRootGuard` so the frame stays a shadow-stack root between `FrameBox::new` and `execute_frame` installing it on the ExecutionContext chain.
- `shadow_stack`: `OWNER_ROOTS`, a fixed-slot root vector with acquire/release and an RAII `OwnerRootGuard`, registered per mutator for the STW root walk.
- `tupleobject`: pin the freshly allocated tuple header across the items-block allocation and the write barrier.
- `_io/textio`: POSIX stdio takes `newline='\n'` (`app_main.py create_stdio:494`), so `readuniversal` / `readtranslate` are Windows-only.
- `faulthandler`: write the fatal-error line to the descriptor `enable` was given.
- `jitcode_dispatch`: a non-root header that requested a retrace no longer returns before merge-point registration (`compile.py:1079 retrace_needed`).
- `majit-gc`: `MAJIT_GC_LIFETIME_LOG`-gated logging of remembered-set adds and old-gen frees.

**This commit carries debug scaffolding** — the `MAJIT_GC_LIFETIME_LOG` logging includes a hard-coded `type_id == 9` backtrace print. Worth stripping before merge.

## Verification

- `cargo fmt --all -- --check` clean.
- `cargo test -p pyre-jit-trace -p pyre-jit --features dynasm` — 650 passed, 0 failed.
- `check.py`: dynasm 340/342, cranelift 340/342.
  - `synth/wasm_ca_trampoline_decline` passes on both (it is the fixture the second half of the first commit fixes).
  - `synth/str_search_index_bounds` panics (`compile.py:458 assert i == len(inputargs)`, 16 != 26) — **pre-existing on `main`**: verified by building `main`'s tree unmodified and reproducing it there. Also reproduced with this branch's JIT commit reverted and with the whole WIP commit reverted.
  - `synth/const_arg_call_resume` trips the 30x perf gate at ~40x against a 0.01s pypy denominator, on a machine that was concurrently building.

Perf numbers for `fib_recursive` are **not** being claimed here: the earlier 2.20x → 1.98x-vs-pypy reading was taken on a previous base, and a re-measure on this base landed at 2.26x with pypy and CPython both 13-15% slower in the same run, i.e. under load. It needs a quiet machine before it means anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Unicode `count('')` to count code points (including astral characters) and handle ranged slices properly.
  * Fixed platform-specific text I/O newline defaults and ensured std stream codec setup during import bootstrap.
  * Faulthandler fatal-error output now respects the `enable(file=...)` target.
  * Strengthened GC root/lifetime handling to improve safety for long-lived objects and allocation/initialization paths.
  * Improved JIT tracing, recursive-call handling, and partial retrace behavior.

* **Documentation**
  * Clarified indirect-call BFS behavior and inlining/recursion limits.

* **Tests**
  * Added Unicode assertions and coverage for persistent owner-root behavior across scope popping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->