### PR TITLE
jit(bridge): read the traced frame's vable pointer when patching a retraced loop

### DIFF
--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -5229,15 +5229,17 @@ impl<M: Clone> MetaInterp<M> {
         if let Some(ptr) = from_consts {
             return ptr;
         }
-        // Bridge traces start from rebuilt resume state, not a fresh portal
-        // entry, so `initial_inputarg_consts` is not seeded with the
-        // virtualizable inputarg's ConstPtr. The live virtualizable pointer
-        // cached by `set_vable_ptr` during JitState setup is the same heap
-        // object (`orig_inpargs[idx].getref_base()`), so fall back to it.
-        if !self.vable_ptr.is_null() {
-            return self.vable_ptr;
+        // Bridge traces have no ConstPtr seeded in `initial_inputarg_consts`.
+        // Prefer the trace-local pointer (RPython's `orig_inpargs` is the
+        // trace's own history): `TraceCtx::virtualizable_heap_ptr` is restored
+        // by the residual-call epilogue after a re-entrant callee deopts,
+        // while `MetaInterp::vable_ptr` may still point at a nested frame
+        // whose shorter `locals_cells_stack_w` would break the virtualizable
+        // field-load preamble's inputargs accounting.
+        if let Some(ptr) = ctx.virtualizable_heap_ptr().filter(|p| !p.is_null()) {
+            return ptr;
         }
-        ctx.virtualizable_heap_ptr().unwrap_or(std::ptr::null())
+        self.vable_ptr
     }
 
     /// compile.py:168 / pyjitpl.py:3605 parity: every real loop token must


### PR DESCRIPTION
## Summary

`python3 pyre/check.py --backend dynasm` failed on `synth/str_search_index_bounds` with:

```
rust panic: compile.py:458 assert i == len(inputargs) failed (16 != 26)
```

A loop compiled from a bridge (`trace_and_compile_from_bridge`) reads the virtualizable's array lengths through `orig_vable_ptr_from_trace_ctx`, which preferred the MetaInterp's cached `vable_ptr`. That cache is clobbered when a residual call re-enters compiled code and deopts nested frames, and the residual-call epilogue only restores `TraceCtx::virtualizable_heap_ptr` — so the compile-time length read hit a nested callee frame whose `locals_cells_stack_w` (8 slots) is shorter than the traced frame's (18 slots), tripping the field-load preamble's inputargs accounting (16 = 2 reds + 6 statics + 8 vs the trace's 26 expanded inputargs).

## Fix

Prefer the trace-local `TraceCtx::virtualizable_heap_ptr` in the bridge fallback — RPython's `orig_inpargs` is the trace's own history, so the trace-local pointer is the parity-correct source — and keep the MetaInterp cache only as a last resort.

## Testing

- `synth/str_search_index_bounds` completes and its output matches CPython exactly
- `cargo test -p majit-metainterp --release`: 1510 passed
- `python3 pyre/check.py --backend dynasm`: 342/342 ALL PASSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bridge-trace handling during re-entrant deoptimization.
  * Corrected virtualizable state selection to use the most accurate available runtime pointer, improving stability in affected execution paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->