### PR TITLE
jit: read the loop's virtualizable out of the merge point it is cut from

### DIFF
--- a/majit/majit-metainterp/src/compile.rs
+++ b/majit/majit-metainterp/src/compile.rs
@@ -5230,11 +5230,18 @@ impl TraceCtx {
         // would report `snapshot_data_len: 0`, causing `cut_trace` to
         // truncate valid snapshots when this merge point is restored).
         let position = self.get_trace_position();
+        // `green_boxes` describes the virtualizable that is live right now, so
+        // pair the snapshot with its address: `compile.py:510` reads the frame
+        // out of the same list it hands to the backend as `loop.inputargs`, and
+        // the trace-level pointer has moved on by the time a cut selects this
+        // entry.
+        let vable_ptr = self.standard_virtualizable_ptr().unwrap_or(0);
         self.current_merge_points.push(MergePoint {
             green_key: key,
             position,
             green_boxes,
             header_pc,
+            vable_ptr,
         });
     }
 

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -5212,6 +5212,30 @@ impl<M: Clone> MetaInterp<M> {
         // unconditional `send_loop_to_backend` wiring (compile.py:504-511).
     }
 
+    /// compile.py:510 `vable = orig_inpargs[index_of_virtualizable].getref_base()`
+    /// for a loop that may be re-labelled from a merge point the walk reached
+    /// later (the cross-loop cut, compile.py:269).
+    ///
+    /// `orig_inpargs` is the very list `compile.py:264 part.inputargs =
+    /// inputargs[:]` builds the loop from, so the frame has to come from
+    /// whichever snapshot supplies those inputargs. Under a cut that is the
+    /// merge point, whose header can belong to a different frame than the one
+    /// the trace started in — resolving from the trace instead names a frame
+    /// whose `locals_cells_stack_w` is a different length, and the field-load
+    /// preamble then expands to an arity the inputargs never had
+    /// (compile.py:458).
+    fn orig_vable_ptr_for_cut(
+        &self,
+        cut: Option<&crate::trace_ctx::MergePoint>,
+        ctx: &TraceCtx,
+        driver_descriptor: Option<&crate::jitdriver::JitDriverStaticData>,
+    ) -> *const u8 {
+        match cut.filter(|mp| mp.vable_ptr != 0) {
+            Some(mp) => mp.vable_ptr as *const u8,
+            None => self.orig_vable_ptr_from_trace_ctx(ctx, driver_descriptor),
+        }
+    }
+
     fn orig_vable_ptr_from_trace_ctx(
         &self,
         ctx: &TraceCtx,
@@ -5483,13 +5507,6 @@ impl<M: Clone> MetaInterp<M> {
         // Cache driver descriptor before ctx is partially consumed below;
         // mirrors the FINISH-path capture pattern (see `finish_and_compile`).
         let driver_descriptor = ctx.driver_descriptor().cloned();
-        // compile.py:510 `vable = orig_inpargs[index_of_virtualizable].getref_base()`.
-        // Resolve while `ctx` is still whole (before `ctx.constants` is moved
-        // out below) so `patch_new_loop_to_load_virtualizable_fields` can
-        // read the heap object via `vinfo.get_array_length(vable, i)`
-        // (compile.py:443).
-        let orig_vable_ptr_loop =
-            self.orig_vable_ptr_from_trace_ctx(&ctx, driver_descriptor.as_ref());
         // pyjitpl.py:3018-3030: compile_loop(original_boxes, live_arg_boxes,
         // start) always compiles from the merge point registered by the
         // first header visit — `start` and `original_boxes` come from
@@ -5501,15 +5518,21 @@ impl<M: Clone> MetaInterp<M> {
         // prefix from the guard to the header must be cut off — otherwise
         // the root entry contract pairs the guard's fail-arg inputargs
         // with the merge point's full-shape JUMP and aborts on arity.
-        let cross_loop_cut = ctx
+        let cut_merge_point = ctx
             .get_merge_point_at(green_key, ctx.header_pc)
-            .filter(|mp| mp.position._pos > 0)
-            .map(|mp| {
-                (
-                    mp.green_boxes.clone(),
-                    crate::history::TreeLoopCutPosition::new(mp.position._pos),
-                )
-            });
+            .filter(|mp| mp.position._pos > 0);
+        // Resolve while `ctx` is still whole (before `ctx.constants` is moved
+        // out below) so `patch_new_loop_to_load_virtualizable_fields` can
+        // read the heap object via `vinfo.get_array_length(vable, i)`
+        // (compile.py:443).
+        let orig_vable_ptr_loop =
+            self.orig_vable_ptr_for_cut(cut_merge_point, &ctx, driver_descriptor.as_ref());
+        let cross_loop_cut = cut_merge_point.map(|mp| {
+            (
+                mp.green_boxes.clone(),
+                crate::history::TreeLoopCutPosition::new(mp.position._pos),
+            )
+        });
 
         // compile.py:221: call_pure_results = metainterp.call_pure_results
         let call_pure_results = ctx.take_call_pure_results();
@@ -6963,18 +6986,18 @@ impl<M: Clone> MetaInterp<M> {
             let green_key = ctx.green_key;
             let header_pc = ctx.header_pc;
             let driver_descriptor = ctx.driver_descriptor().cloned();
-            let retrace_cut = retracing_from.and_then(|retrace_pos| {
+            let retrace_merge_point = retracing_from.and_then(|retrace_pos| {
                 ctx.get_merge_point_at(green_key, header_pc)
                     .filter(|mp| mp.position == retrace_pos && mp.position._pos > 0)
-                    .map(|mp| {
-                        (
-                            mp.green_boxes.clone(),
-                            crate::history::TreeLoopCutPosition::new(mp.position._pos),
-                        )
-                    })
+            });
+            let retrace_cut = retrace_merge_point.map(|mp| {
+                (
+                    mp.green_boxes.clone(),
+                    crate::history::TreeLoopCutPosition::new(mp.position._pos),
+                )
             });
             let orig_vable_ptr_retrace =
-                self.orig_vable_ptr_from_trace_ctx(&ctx, driver_descriptor.as_ref());
+                self.orig_vable_ptr_for_cut(retrace_merge_point, &ctx, driver_descriptor.as_ref());
             // The recorder carries Const values inline on the OpRef variants
             // (history.py:227/268/314), so there is no legacy TraceCtx
             // ConstantPool to snapshot — this typed-constant map starts fresh.

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -175,6 +175,19 @@ pub struct MergePoint {
     /// Bytecode PC of this loop header. Used by cut_trace_from to update
     /// meta when the trace closes at a different loop.
     pub header_pc: usize,
+    /// The virtualizable `green_boxes` was snapshotted against, as a raw
+    /// address (0 when none was live at registration).
+    ///
+    /// RPython's `original_boxes` are Boxes that carry their concrete value
+    /// inline, so `compile.py:510
+    /// orig_inpargs[index_of_virtualizable].getref_base()` reads the frame
+    /// belonging to the very list that becomes `loop.inputargs`. A
+    /// [`GreenBox`] is symbolic, so the address is paired with the snapshot
+    /// here to keep that read exact — the trace-level
+    /// `virtualizable_heap_ptr` tracks the walk and names a different frame
+    /// once the trace is cut to a header the walk reached later
+    /// (compile.py:269).
+    pub vable_ptr: usize,
 }
 
 /// Tracing context: wraps the recorder Trace with a convenience API.
@@ -1372,6 +1385,7 @@ impl TraceCtx {
                     .map(|(&opref, &ty)| GreenBox::new(opref, ty))
                     .collect(),
                 header_pc: 0,
+                vable_ptr: 0,
             }],
             header_greens: None,
             close_greens: None,
@@ -1451,6 +1465,7 @@ impl TraceCtx {
                     .map(|(&opref, &ty)| GreenBox::new(opref, ty))
                     .collect(),
                 header_pc: 0,
+                vable_ptr: 0,
             }],
             header_greens: None,
             close_greens: None,
@@ -2485,6 +2500,22 @@ impl TraceCtx {
         self.virtualizable_boxes
             .as_ref()
             .and_then(|boxes| boxes.last().copied())
+    }
+
+    /// `vinfo.unwrap_virtualizable_box(virtualizable_boxes[-1])` — the concrete
+    /// object the identity box carries, as a raw address.
+    ///
+    /// This is the frame the shadow was expanded against, which is not the
+    /// same as [`Self::virtualizable_heap_ptr`]: that one is the
+    /// synchronization target, and a root portal seed deliberately points it
+    /// at the `snapshot_for_tracing` copy while baking the identity against
+    /// the live frame the compiled loop runs on.  Readers that need "which
+    /// object do these boxes describe" — `compile.py:510` — want the identity.
+    pub fn standard_virtualizable_ptr(&self) -> Option<usize> {
+        match self.virtualizable_values.as_ref()?.last()? {
+            Value::Ref(gcref) if gcref.as_usize() != 0 => Some(gcref.as_usize()),
+            _ => None,
+        }
     }
 
     /// Length of the symbolic virtualizable shadow, or `None` when no
@@ -4985,6 +5016,56 @@ mod tests {
         let ops = take_all_ops(ctx);
         assert_eq!(ops.len(), 1);
         assert_eq!(ops[0].opcode, OpCode::SetfieldGc);
+    }
+
+    /// `add_merge_point` must stamp the header snapshot with the virtualizable
+    /// IDENTITY, not the synchronization target.
+    ///
+    /// A root portal seed points `virtualizable_heap_ptr` at the
+    /// `snapshot_for_tracing` copy while baking the identity against the live
+    /// frame, so the two name different objects. `compile.py:510` wants the one the
+    /// boxes describe; taking the sync target instead hands
+    /// `patch_new_loop_to_load_virtualizable_fields` a frame whose array field
+    /// is unrelated to the snapshot, and its `assert i == len(inputargs)`
+    /// (compile.py:458) fires on the arity that comes back.
+    #[test]
+    fn merge_point_records_the_vable_identity_not_the_sync_target() {
+        const LIVE_FRAME: usize = 0x5000;
+        const SNAPSHOT_COPY: usize = 0x9000;
+
+        let info = make_test_vable_info();
+        let mut recorder = Trace::new();
+        let vable = recorder.record_input_arg(Type::Ref);
+        let box0 = recorder.record_input_arg(Type::Int);
+        let mut ctx = TraceCtx::new(
+            recorder,
+            0,
+            std::sync::Arc::new(crate::MetaInterpStaticData::new()),
+        );
+        ctx.set_virtualizable_heap_ptr(SNAPSHOT_COPY as *const u8);
+
+        // Before the seed there is no snapshot to describe, so a header
+        // registered here records nothing and the compile step keeps its
+        // trace-start resolution.
+        ctx.add_merge_point(1, vec![GreenBox::new(box0, Type::Int)], 7);
+        assert_eq!(ctx.current_merge_points.last().unwrap().vable_ptr, 0);
+
+        ctx.init_virtualizable_boxes(
+            &info,
+            vable,
+            Value::Ref(majit_ir::GcRef(LIVE_FRAME)),
+            &[box0],
+            &[ph(Type::Int)],
+            &[],
+        );
+        ctx.add_merge_point(2, vec![GreenBox::new(box0, Type::Int)], 9);
+
+        assert_eq!(ctx.standard_virtualizable_ptr(), Some(LIVE_FRAME));
+        assert_eq!(
+            ctx.current_merge_points.last().unwrap().vable_ptr,
+            LIVE_FRAME,
+            "merge point took the sync target instead of the identity",
+        );
     }
 
     #[test]


### PR DESCRIPTION
> **Framing corrected after measurement.** This PR was opened as the fix for a
> red `check.py` on main. It is not needed for that any more: the same defect was
> closed on main independently by `8f0ead8492` (#876), which carries a one-line
> reorder of the same fallback chain. Measured on that base, `check.py --backend
> dynasm,cranelift` is **342/342 ×2 with and without this commit**. What remains
> is a parity fix for a *different, currently unexercised* shape — see
> [Why keep it](#why-keep-it).

`compile.py:510` takes the frame from `orig_inpargs`:

```python
vable = orig_inpargs[jitdriver_sd.index_of_virtualizable].getref_base()
patch_new_loop_to_load_virtualizable_fields(loop, jitdriver_sd, vable)
```

`orig_inpargs` is the same list `compile.py:264 part.inputargs = inputargs[:]`
builds the loop from — `original_boxes[num_green_args:]` of the merge point
`pyjitpl.py:3039 compile_loop` selected. Frame and inputargs therefore always
describe each other, which is what makes `compile.py:443
vinfo.get_array_length(vable, arrayindex)` add up to `compile.py:458 assert i ==
len(inputargs)`.

Pyre resolves it from the **trace** instead, as an ordered chain
(`pyjitpl.rs:5239 orig_vable_ptr_from_trace_ctx`):

1. `initial_inputarg_consts[virtualizable_arg_index]` — seeded at a root portal entry only
2. `ctx.virtualizable_heap_ptr()`
3. `self.vable_ptr` (the MetaInterp-ambient pointer)

All three track the *trace*, so they coincide with `orig_inpargs` only while the
loop is labelled from its own head. A **cross-loop cut** (`compile.py:269`
`cut_trace_from_with_consts`) re-labels the loop from a header the walk reached
later, and that header can belong to a different frame:

| | `locals_cells_stack_w` | 2 red + 6 static + array |
|---|---|---|
| cut merge point (26 boxes → the inputargs) | 18 | **26** |
| vable resolved from the trace | 8 | **16** |

The field-load preamble then expands to an arity the inputargs never had. On
`synth/str_search_index_bounds` that surfaced as an internal compile panic on all
three backends (interpreter output was correct throughout — `PYRE_NO_JIT=1` was
byte-identical, only the compile of one loop died):

```
compile.rs | compile.py:458 assert i == len(inputargs) failed (16 != 26)
   patch_new_loop_to_load_virtualizable_fields
 ← compile_loop_body ← compile_loop ← compile_and_record_loop
 ← jit_merge_point_keyed ← trace_and_compile_from_bridge ← handle_fail
```

## What this changes

`MergePoint` carries the virtualizable its `green_boxes` were snapshotted
against, and `compile_loop_body` / `compile_retrace` take it whenever a cut
supplies the inputargs. RPython gets this for free — its `original_boxes` are
Boxes with the concrete value inline — while pyre's `GreenBox` is symbolic, so
the address is paired with the snapshot.

The recorded pointer is the **identity** (`virtualizable_boxes[-1]`, exposed as
`TraceCtx::standard_virtualizable_ptr`), *not* `virtualizable_heap_ptr`. Those
are two different objects by design: a root portal seed points the heap pointer
at the `snapshot_for_tracing` copy — it is the synchronization *target* — while
baking the identity against the live frame the compiled loop runs on. The
snapshot copy's `locals_cells_stack_w` reads null, so recording the sync target
instead fixes `str_search_index_bounds` and turns the same assert on six others
(`nbody`, `global_quasiimmut_invalidation`, `nested_break_not_hot`,
`nested_for_outer_local_postread`, `recursive_call_frame_relocation`,
`polymorphic_binary_receiver`). `merge_point_records_the_vable_identity_not_the_sync_target`
pins that distinction and fails if the recording is switched back.

## Why keep it

The panic on main is closed by `8f0ead8492`, which reorders step (2) above step
(3). That is sufficient because the failing compile is a **bridge** trace, so (1)
is unseeded and the fallback is reached at all; and it is safe because the six
root-portal benches never reach the fallback, so the reorder is inert for them.

This commit covers what that reorder structurally cannot: a **root portal with a
cross-loop cut**. There, step (1) wins and returns the trace-*start* frame, while
`compile.py:510` wants the frame belonging to the cut header's `orig_inpargs` —
so this reads the merge point's identity ahead of the chain. No bench in the
corpus produces that shape today, which is exactly why both measurements below
are green; the change is a parity fix, not a repair of an observable failure.

It also removes the source of the latent hazard in the current fallback: step (2)
is the sync target, whose array length is 0 at a root portal seed. That is masked
today only by (1) always winning first.

## Verification

Base `6efa1e2bb5`, all three LLBC crates re-extracted for it.

| | dynasm | cranelift |
|---|---|---|
| A = this branch | 342/342 | 342/342 |
| B = `origin/main` alone (revert this commit's 3 files) | 342/342 | 342/342 |

B's control was validated: the revert showed `3 files changed, 23 insertions(+),
134 deletions(-)` and `git diff origin/main --stat -- majit/majit-metainterp/src/`
was empty afterwards.

Also measured at the earlier base `18e8847e9d` (#881, before `8f0ead8492`
landed), where the defect was live: dynasm 341/342 → **342/342**, cranelift
341/342 → **342/342**, wasm 338/339 → **339/339**, and reverting only this
commit's three files reproduced `(16 != 26)`.

- `cargo test -p majit-metainterp` 1511 passed, 0 failed.
- `cargo test -p pyre-interpreter --features dynasm` 430, `-p pyre-object` 282, 0 failed.
- `pyre/extra_tests/parity_tests/run.py` — no pyre-side failures.
- JIT vs `PYRE_NO_JIT=1` output on the bench: identical.

## Provenance

Not from #840, which only added the bench that reaches the shape. Bisect evidence
from two independent worktrees and a before/after CI pair on #875 had fenced it to
`de46bc2f4d..a0aa600bb6`; the defect itself is older and was exposed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
