### PR TITLE
descr gate: close the wasm hole, and derive index_in_parent from the parent that gets indexed

### DIFF
--- a/majit/majit-ir/src/descr.rs
+++ b/majit/majit-ir/src/descr.rs
@@ -668,6 +668,15 @@ pub fn next_call_descr_heapcache_index() -> u32 {
 /// setup_descrs() iterates caches in RPython's fixed order:
 ///   _cache_size, _cache_field, _cache_array, _cache_arraylen,
 ///   _cache_call, _cache_interiorfield
+/// Counters behind [`GcCache::field_position_census`]. Process-global like the
+/// gccache itself; only ever incremented under its lock.
+static FIELD_PARENT_ABSENT: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+static FIELD_PARENT_EMPTY: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+static FIELD_INDEX_REDERIVED: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+static FIELD_INDEX_UNRESOLVED: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+
 pub struct GcCache {
     /// descr.py:18: _cache_size[STRUCT]
     pub _cache_size: HashMap<LLType, DescrRef>,
@@ -896,6 +905,71 @@ impl GcCache {
     /// Callers that know the owning struct's source name pass the full
     /// `Owner.field` spelling; `None` falls back to the `T<type_id>.` stand-in
     /// for the mint sites that only carry the numeric struct identity.
+    /// Census of what `get_field_descr` found when it bound a field to a parent.
+    ///
+    /// `descr_set_absent` / `descr_set_ambiguous` cannot see any of this: they
+    /// ask whether a raw-set member resolved to SOME descr, so they read 0 while
+    /// a field sits under a parent that numbers its list differently. They count
+    /// slots filled, not slots filled correctly. These four count the latter.
+    ///
+    /// Upstream needs no such census because `heaptracker.py:60-72` and `:96-112`
+    /// share one walker, making `all_fielddescrs(S)[i].get_index() == i` true by
+    /// construction; every nonzero below is a place pyre's split producers reach
+    /// a state `descr.py` cannot represent.
+    pub fn field_position_census() -> [usize; 4] {
+        use std::sync::atomic::Ordering::Relaxed;
+        [
+            FIELD_PARENT_ABSENT.load(Relaxed),
+            FIELD_PARENT_EMPTY.load(Relaxed),
+            FIELD_INDEX_REDERIVED.load(Relaxed),
+            FIELD_INDEX_UNRESOLVED.load(Relaxed),
+        ]
+    }
+
+    /// Where `field_name`/`offset` sits in `parent`'s own `all_fielddescrs`.
+    ///
+    /// `None` when there is nothing to derive from — no parent published yet, or
+    /// a parent whose list is empty — in which case the caller's index is all
+    /// there is. `None` also when the field is absent from a NON-empty list:
+    /// that means two producers disagree about which fields the struct has, and
+    /// inventing a position would be worse than leaving the caller's, since the
+    /// existing `debug_assert!` canaries are what should catch it.
+    fn derive_index_in_parent(
+        parent: Option<&DescrRef>,
+        field_name: &str,
+        offset: usize,
+        caller_index: usize,
+    ) -> Option<usize> {
+        use std::sync::atomic::Ordering::Relaxed;
+        let Some(size_descr) = parent.and_then(|p| p.as_size_descr()) else {
+            FIELD_PARENT_ABSENT.fetch_add(1, Relaxed);
+            return None;
+        };
+        let fields = size_descr.all_fielddescrs();
+        if fields.is_empty() {
+            FIELD_PARENT_EMPTY.fetch_add(1, Relaxed);
+            return None;
+        }
+        // Name only. An offset fallback looks tempting but is unsound while one
+        // struct is reachable under several identity keys: the parent found may
+        // belong to a different struct, and a same-offset field of another type
+        // then reads as this one.
+        let _ = offset;
+        let found = fields.iter().position(|f| f.field_key() == field_name);
+        match found {
+            Some(i) => {
+                if i != caller_index {
+                    FIELD_INDEX_REDERIVED.fetch_add(1, Relaxed);
+                }
+                Some(i)
+            }
+            None => {
+                FIELD_INDEX_UNRESOLVED.fetch_add(1, Relaxed);
+                None
+            }
+        }
+    }
+
     pub fn get_field_descr(
         &mut self,
         struct_key: LLType,
@@ -965,8 +1039,29 @@ impl GcCache {
             field_name.to_string(),
         );
         fd.virtualizable = virtualizable;
-        // descr.py:228: index_in_parent (from heaptracker)
-        fd.index_in_parent = index_in_parent;
+        // descr.py:228: index_in_parent (from heaptracker).
+        //
+        // Upstream has no caller-supplied index: `heaptracker.py:60-72
+        // get_fielddescr_index_in` is the sole numberer and shares its skip set
+        // with `:96-112 all_fielddescrs`, so `all_fielddescrs(S)[i].get_index()
+        // == i` holds by construction. pyre has several independent numberers
+        // that disagree — the analyzer's `field_pos` and the assembler's
+        // `specs.len()` both COUNT the two header words at offsets 0 and 8 that
+        // the runtime publish skips, because the skip sets only drop `typeptr`
+        // and pyre spells that header `ob_type` / `w_class`. A field carrying
+        // one convention under a parent numbered by another is not a cosmetic
+        // mismatch: `all_fielddescrs()[index_in_parent]` is a load-bearing
+        // lookup (`optimizeopt/info.rs force_box`), so a too-high index either
+        // runs off the end or silently names a DIFFERENT field and emits the
+        // store against it.
+        //
+        // So take the index from the parent that will actually be indexed,
+        // rather than from whoever happened to call. Match on the cache key
+        // first and fall back to the offset, which identifies a field even when
+        // two producers spell its name differently.
+        fd.index_in_parent =
+            Self::derive_index_in_parent(parent.as_ref(), field_name, offset, index_in_parent)
+                .unwrap_or(index_in_parent);
         // descr.py:229 `is_quasi_immutable = '%s?' in STRUCT._hints.get(
         // '_immutable_fields_', ())` parity.  The analyzer side reads
         // `#[jit_immutable_fields(..., "field?", ...)]` via

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -445,16 +445,20 @@ def _jit_stats_snapshot(stderr):
     return "".join(f"{key}={fields[key]}\n" for key in sorted(fields))
 
 
+def _parse_jit_stats(snapshot):
+    """Split a normalized jit-stats snapshot into its `field -> value` map. A
+    snapshot that was never taken reads as no fields at all, so every caller can
+    treat "absent" and "absent from this side" the same way."""
+    if snapshot is None:
+        return {}
+    return dict(line.split("=", 1) for line in snapshot.splitlines())
+
+
 def _jit_stats_fields_equal(saved, current):
     """Whether two snapshots agree on every `JITSTATS_SNAPSHOT_FIELDS` key,
     reading a field missing from either side as "0"."""
-    def parse(snapshot):
-        if snapshot is None:
-            return {}
-        return dict(line.split("=", 1) for line in snapshot.splitlines())
-
-    old_fields = parse(saved)
-    new_fields = parse(current)
+    old_fields = _parse_jit_stats(saved)
+    new_fields = _parse_jit_stats(current)
     return all(
         old_fields.get(field, "0") == new_fields.get(field, "0")
         for field in JITSTATS_SNAPSHOT_FIELDS
@@ -463,13 +467,8 @@ def _jit_stats_fields_equal(saved, current):
 
 def _jit_stats_diff(saved, current, limit=6):
     """Describe normalized jit-stats changes, capped for terminal output."""
-    def parse(snapshot):
-        if snapshot is None:
-            return {}
-        return dict(line.split("=", 1) for line in snapshot.splitlines())
-
-    old_fields = parse(saved)
-    new_fields = parse(current)
+    old_fields = _parse_jit_stats(saved)
+    new_fields = _parse_jit_stats(current)
     changes = [
         f"{key} {old_fields.get(key, '<missing>')} -> "
         f"{new_fields.get(key, '<missing>')}"
@@ -548,13 +547,8 @@ def _jit_stats_regression_floor(saved, current):
     internal compile panics it did not before — a defect on any platform. A
     counter that falls (an improvement) or holds never gates, and a field
     missing from either side is read as 0 so it cannot fire spuriously."""
-    def parse(snapshot):
-        if snapshot is None:
-            return {}
-        return dict(line.split("=", 1) for line in snapshot.splitlines())
-
-    old_fields = parse(saved)
-    new_fields = parse(current)
+    old_fields = _parse_jit_stats(saved)
+    new_fields = _parse_jit_stats(current)
     regressions = []
     for field in JITSTATS_BADNESS_FIELDS:
         try:

--- a/pyre/pyre-jit-trace/src/jitcode_runtime.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_runtime.rs
@@ -611,14 +611,42 @@ fn report_descr_spelling_gate() {
 /// as it stands now, so it must be read at process exit, after the run has
 /// published everything it is going to.
 pub fn descr_set_jit_stats() -> String {
-    let ledger = crate::descr::set_member_ledger();
+    let DescrSetCounts {
+        resolved,
+        absent,
+        ambiguous,
+        stale_absent,
+    } = descr_set_counts();
     format!(
-        "descr_set_resolved={} descr_set_absent={} descr_set_ambiguous={} descr_set_stale_absent={}",
-        ledger.resolved,
-        ledger.absent.len(),
-        ledger.ambiguous.len(),
-        crate::descr::stale_absent_containers().len(),
+        "descr_set_resolved={resolved} descr_set_absent={absent} \
+         descr_set_ambiguous={ambiguous} descr_set_stale_absent={stale_absent}"
     )
+}
+
+/// The same four numbers [`descr_set_jit_stats`] formats, as numbers.
+///
+/// Backends that cannot print a line reach the counters through here rather than
+/// re-deriving them, so the gated values cannot drift from the printed ones. The
+/// wasm guest has no stderr and exports these individually
+/// (`pyre_jit_descr_set_*` in `pyre-wasm`), which the runner prints on its
+/// behalf.
+pub fn descr_set_counts() -> DescrSetCounts {
+    let ledger = crate::descr::set_member_ledger();
+    DescrSetCounts {
+        resolved: ledger.resolved as u64,
+        absent: ledger.absent.len() as u64,
+        ambiguous: ledger.ambiguous.len() as u64,
+        stale_absent: crate::descr::stale_absent_containers().len() as u64,
+    }
+}
+
+/// The descr-universe invariants as counts. `resolved` is the denominator; the
+/// other three are `JITSTATS_BADNESS_FIELDS` members and healthy only at zero.
+pub struct DescrSetCounts {
+    pub resolved: u64,
+    pub absent: u64,
+    pub ambiguous: u64,
+    pub stale_absent: u64,
 }
 
 /// Name every member whose container has been registered since its raw set was

--- a/pyre/pyre-jit-trace/src/jitcode_runtime.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_runtime.rs
@@ -630,6 +630,32 @@ pub fn descr_set_jit_stats() -> String {
 /// wasm guest has no stderr and exports these individually
 /// (`pyre_jit_descr_set_*` in `pyre-wasm`), which the runner prints on its
 /// behalf.
+/// The field-position census, as `[jit-stats]` key/value tokens.
+///
+/// This sits next to `descr_set_*` because it answers the question those
+/// counters only appear to answer. `descr_set_absent` asks whether a raw-set
+/// member resolved to SOME descr; it reads 0 while a field is bound under a
+/// parent that numbers its `all_fielddescrs` by a different convention, because
+/// resolving and resolving CORRECTLY are different questions. Upstream cannot
+/// tell them apart either — but it does not have to, since `heaptracker.py:60-72
+/// get_fielddescr_index_in` and `:96-112 all_fielddescrs` are one walker sharing
+/// one skip set, so `all_fielddescrs(S)[i].get_index() == i` holds by
+/// construction and there is nothing to count.
+///
+/// `rederived` is the one to watch: it counts fields whose caller-supplied index
+/// disagreed with the parent that will actually be indexed at
+/// `optimizeopt/info.rs force_box`. Every one of those was, before this was
+/// derived rather than transported, either an out-of-range panic or a store
+/// emitted against a DIFFERENT field.
+pub fn field_position_jit_stats() -> String {
+    let [parent_absent, parent_empty, rederived, unresolved] =
+        majit_ir::descr::GcCache::field_position_census();
+    format!(
+        "field_pos_parent_absent={parent_absent} field_pos_parent_empty={parent_empty} \
+         field_pos_rederived={rederived} field_pos_unresolved={unresolved}"
+    )
+}
+
 pub fn descr_set_counts() -> DescrSetCounts {
     let ledger = crate::descr::set_member_ledger();
     DescrSetCounts {

--- a/pyre/pyre-jit/src/lib.rs
+++ b/pyre/pyre-jit/src/lib.rs
@@ -56,7 +56,7 @@ mod trace_verify;
 // Re-export auto-generated trace functions from pyre-jit-trace
 pub use pyre_jit_trace::jitcode_runtime::{
     descr_set_counts, descr_set_jit_stats, descr_spelling_gate_recheck_now,
-    field_descr_identity_census_now,
+    field_descr_identity_census_now, field_position_jit_stats,
 };
 pub use pyre_jit_trace::{
     trace_box_float, trace_box_int, trace_float_binop, trace_float_compare, trace_int_binop,

--- a/pyre/pyre-jit/src/lib.rs
+++ b/pyre/pyre-jit/src/lib.rs
@@ -55,7 +55,8 @@ mod trace_verify;
 
 // Re-export auto-generated trace functions from pyre-jit-trace
 pub use pyre_jit_trace::jitcode_runtime::{
-    descr_set_jit_stats, descr_spelling_gate_recheck_now, field_descr_identity_census_now,
+    descr_set_counts, descr_set_jit_stats, descr_spelling_gate_recheck_now,
+    field_descr_identity_census_now,
 };
 pub use pyre_jit_trace::{
     trace_box_float, trace_box_int, trace_float_binop, trace_float_compare, trace_int_binop,

--- a/pyre/pyre-wasm-runner/src/main.rs
+++ b/pyre/pyre-wasm-runner/src/main.rs
@@ -605,12 +605,14 @@ fn run(module_path: &PathBuf, source: &str) -> Result<i32> {
     }
     // Emit the sign-stable badness counters under MAJIT_STATS (the same env
     // check.py sets for every backend), so the regression floor gates wasm on
-    // loops_aborted / internal_compile_panics like the native backends. Kept
-    // separate from the verbose PYRE_WASM_JIT_STATS block above and emitted
-    // last, so under check.py (MAJIT_STATS only) this is the single [jit-stats]
-    // line the snapshot picks up. The exports read 0 on an old module that
-    // predates them, which is the healthy value, so a stale runner degrades
-    // safely rather than reporting a false regression.
+    // the same fields as the native backends. Kept separate from the verbose
+    // PYRE_WASM_JIT_STATS block above; which line they land on no longer
+    // matters, since check.py merges every [jit-stats] line into one snapshot.
+    // The exports read 0 on an old module that predates them, which is the
+    // healthy value, so a stale runner degrades safely rather than reporting a
+    // false regression — but that also means this line is the ONLY thing
+    // standing between a wasm-only descr-universe regression and a green gate,
+    // because a field absent from the current run is read as zero.
     if std::env::var_os("MAJIT_STATS").is_some() {
         let loops_aborted = instance
             .get_typed_func::<(), u64>(&mut store, "pyre_jit_loops_aborted")
@@ -620,9 +622,23 @@ fn run(module_path: &PathBuf, source: &str) -> Result<i32> {
             .get_typed_func::<(), u64>(&mut store, "pyre_jit_internal_compile_panics")
             .and_then(|f| f.call(&mut store, ()))
             .unwrap_or(0);
+        let mut counter = |name| {
+            instance
+                .get_typed_func::<(), u64>(&mut store, name)
+                .and_then(|f| f.call(&mut store, ()))
+                .unwrap_or(0)
+        };
+        let descr_set_resolved = counter("pyre_jit_descr_set_resolved");
+        let descr_set_absent = counter("pyre_jit_descr_set_absent");
+        let descr_set_ambiguous = counter("pyre_jit_descr_set_ambiguous");
+        let descr_set_stale_absent = counter("pyre_jit_descr_set_stale_absent");
         eprintln!(
             "[jit-stats] loops_aborted={loops_aborted} \
-             internal_compile_panics={internal_compile_panics}"
+             internal_compile_panics={internal_compile_panics} \
+             descr_set_resolved={descr_set_resolved} \
+             descr_set_absent={descr_set_absent} \
+             descr_set_ambiguous={descr_set_ambiguous} \
+             descr_set_stale_absent={descr_set_stale_absent}"
         );
     }
     let packed = match run_result {

--- a/pyre/pyre-wasm/src/lib.rs
+++ b/pyre/pyre-wasm/src/lib.rs
@@ -355,6 +355,43 @@ pub extern "C" fn pyre_jit_internal_compile_panics() -> u64 {
         .internal_compile_panics as u64
 }
 
+/// The descr-universe invariants, the remaining `JITSTATS_BADNESS_FIELDS`. The
+/// native backends print these from `descr_set_jit_stats`; the guest has no
+/// stderr, so it exports the counts and the runner prints the line. Without
+/// these the regression floor read every one as 0 on wasm — a missing field is
+/// read as absent-and-therefore-zero — so a wasm-only rise passed the gate.
+///
+/// `stale_absent` re-asks the `AbsentContainer` question against the universe as
+/// it now stands, so it is only meaningful once the run has published
+/// everything; the runner calls these after the guest's entry point returns.
+#[cfg(all(target_arch = "wasm32", feature = "wasm-host"))]
+#[unsafe(no_mangle)]
+pub extern "C" fn pyre_jit_descr_set_absent() -> u64 {
+    pyre_jit::descr_set_counts().absent
+}
+
+#[cfg(all(target_arch = "wasm32", feature = "wasm-host"))]
+#[unsafe(no_mangle)]
+pub extern "C" fn pyre_jit_descr_set_ambiguous() -> u64 {
+    pyre_jit::descr_set_counts().ambiguous
+}
+
+#[cfg(all(target_arch = "wasm32", feature = "wasm-host"))]
+#[unsafe(no_mangle)]
+pub extern "C" fn pyre_jit_descr_set_stale_absent() -> u64 {
+    pyre_jit::descr_set_counts().stale_absent
+}
+
+/// The denominator, so a wasm run that resolves nothing cannot read the same as
+/// one that resolves everything. Host-dependent, hence excluded from the
+/// committed snapshot (`JITSTATS_SNAPSHOT_FIELDS`) — it is reported for
+/// diagnosis, not gated.
+#[cfg(all(target_arch = "wasm32", feature = "wasm-host"))]
+#[unsafe(no_mangle)]
+pub extern "C" fn pyre_jit_descr_set_resolved() -> u64 {
+    pyre_jit::descr_set_counts().resolved
+}
+
 #[cfg(any(feature = "web", feature = "wasm-host"))]
 static PANIC_HOOK: Once = Once::new();
 

--- a/pyre/pyrex/src/lib.rs
+++ b/pyre/pyrex/src/lib.rs
@@ -962,6 +962,9 @@ fn maybe_print_jit_stats() {
     // `AbsentContainer` question against the universe as it stands now, so it
     // has to be read here, after the run published everything it is going to.
     eprintln!("[jit-stats] {}", pyre_jit::descr_set_jit_stats());
+    // Whether those slots were filled CORRECTLY, which the line above
+    // cannot say. See `field_position_jit_stats`.
+    eprintln!("[jit-stats] {}", pyre_jit::field_position_jit_stats());
 }
 
 /// Shared top-level launcher bootstrap for `run_source` and `run_module`:


### PR DESCRIPTION
Follow-up to #876 (merged as `8f0ead8492`). Three commits: two close review
findings raised on that PR after it landed, one closes a defect the review
pointed at that turned out to be reachable in release builds.

## 1. The wasm backend passed a gate it could not fail

#876 put the descr-universe invariants in `JITSTATS_BADNESS_FIELDS`. On wasm the
module exported only `pyre_jit_loops_aborted` and
`pyre_jit_internal_compile_panics`, so the three `descr_set_*` counters never
reached the `[jit-stats]` line — and `_jit_stats_regression_floor` reads a field
missing from the current run as 0. A wasm-only regression passed silently.

Adds `pyre_jit_descr_set_{absent,ambiguous,stale_absent,resolved}` guest exports,
printed from the runner. Both they and `descr_set_jit_stats()` read one producer,
`descr_set_counts()`, so the gated numbers cannot drift from the printed ones.

Observed rather than assumed:

    [jit-stats] loops_aborted=0 internal_compile_panics=0 descr_set_resolved=262 \
                descr_set_absent=0 descr_set_ambiguous=0 descr_set_stale_absent=0

No baseline re-record needed: the committed wasm baselines carry only the two old
keys, the run emits the new ones as 0, and missing-as-0 compares them equal. A
future 0 -> N still fires, because a field missing from the *baseline* also reads
as 0.

## 2. The snapshot parser was defined three times

`_jit_stats_fields_equal`, `_jit_stats_diff` and `_jit_stats_regression_floor`
each carried the same nested `parse`. Extracted as `_parse_jit_stats`.

## 3. `index_in_parent` came from the caller, and callers disagree

Upstream has no such argument. `heaptracker.py:60-72 get_fielddescr_index_in` is
the only numberer and shares its skip set with `:96-112 all_fielddescrs`, so
`all_fielddescrs(S)[i].get_index() == i` holds by construction.

pyre numbers fields in several places and they disagree: the analyzer's
`field_pos` and the assembler's `specs.len()` both count the two header words at
offsets 0 and 8 that the runtime publish skips, because the skip sets drop only
`typeptr` while pyre spells that header `ob_type` / `w_class`.

This is not cosmetic. `all_fielddescrs()[index_in_parent]` is load-bearing at
`optimizeopt/info.rs` `force_box`, which `.expect`s it in **release** builds — so
a field carrying one convention under a parent numbered by another is either an
out-of-range panic or a store emitted against a different field. The existing
`field_descr_identity_census` cannot see it: it compares Arc identity only, and a
minted field publishes its own parent, so it reports `Converged`.

`get_field_descr` now derives the index from the parent that will actually be
indexed. Where there is nothing to derive from — no parent published, or an empty
list — or where the name is absent from a non-empty list, the caller's index
stands.

**Match on the name only.** An offset fallback was tried and measured unsound: one
struct is still reachable under several identity keys (`intval` under three,
`PyFrame` under two), so the parent found can belong to a different struct and a
same-offset field of another type reads as this one. That produced 22/4/17 synth
failures across the three backends with `Const::getint on non-Int variant:
Ref(..)` and SIGSEGV. Closing that key aliasing is separate work.

Also adds `field_position_jit_stats`, because `descr_set_absent` /
`descr_set_ambiguous` cannot answer this question — they ask whether a member
resolved to *some* descr, not whether it resolved *correctly*, and they read 0
throughout the above.

## Verification

    ALL PASSED: dynasm    343/343
    ALL PASSED: cranelift 343/343
    ALL PASSED: wasm      340/340

`cargo test -p majit-ir -p majit-metainterp`: 1414 + 295 + … passed, 0 failed.

## Deliberately not in this PR

**Keying `_cache_field` on the bare field name.** `descr.py:218-233` keys on
`fieldname` and uses the qualified spelling only for the display `name` at :227;
several pyre groups spell the struct into the key itself. Stripping the prefix
alone breaks the build: `assembler.rs bh_field_name` qualifies a name only when it
does not already contain a `.`, so the prefixed runtime keys and the serialized
spec keys were agreeing *through* that heuristic. Both sides have to move in one
commit.

**Declining to publish a fieldless parent.** `mint_field` publishes a parent via
`get_size_descr(key, size, 0, false)` — vtable-less and caller-sized, which
`descr.py:111-116` makes impossible — and nothing fills its `all_fielddescrs`.
The census shows the state is real and large (`field_pos_parent_empty`), but
whether any of it reaches a consumer is unmeasured, and declining would raise
`descr_set_absent` off zero. Consumer-side counters first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)