### PR TITLE
jit: record the catching frame's traceback node at bridge handler entries, and widen bridge ref-root/merge-point handling

### DIFF
--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -4992,64 +4992,34 @@ fn build_ref_root_slots(
     let mut seen = IndexSet::new();
     let mut slots = Vec::new();
 
-    // RPython parity: when jump_to_preamble is used without
-    // force_box_for_end_of_preamble, the body JUMP may pass Float/Int
-    // values at Ref-typed inputarg positions. Build a set of inputarg
-    // OpRef raw values that receive non-Ref values from the backedge JUMP.
-    // These positions must NOT be treated as GC ref roots, because
-    // (1) the GC would try to trace Float/Int bits as pointers, and
-    // (2) the preamble guard check would dereference non-pointer values.
+    // `regalloc.py:786` `v.type == REF`: a frame slot is a GC root because of
+    // the type of the value that lives in it, never because of what some JUMP
+    // passes. A JUMP writes into the *target label's* arg locations
+    // (`x86/regalloc.py:1303-1326 consider_jump` moves each arg into
+    // `descr._x86_arglocs[i]`), so the closing JUMP says nothing about this
+    // trace's own inputarg slots: in a bridge the target is a different
+    // trace's label, and in an unrolled loop it is the LABEL in the middle of
+    // this trace — in neither case the entry `inputargs` this list is built
+    // from. Positional comparison against `inputargs` therefore lines up two
+    // unrelated lists and drops live Ref roots.
     //
     // Phase E.2b: bridge `InputArg.index` is shifted into the disjoint
     // `[bridge_inputarg_base..)` range, so `arg.0` and `inputargs[i].index`
     // are not interchangeable. RPython relies on Box identity here
     // (regalloc.py treats `box is inputarg` as the test); pyre's
-    // line-by-line analog is `arg.0 == inputargs[i].index`. Key both
-    // `non_ref_at_backedge` and `used_inputargs` by the InputArg's raw
-    // OpRef value so the downstream loop's `contains(&input.index)` checks
-    // line up with the keys we inserted.
+    // line-by-line analog is `arg.0 == inputargs[i].index`. Key
+    // `used_inputargs` by the InputArg's raw OpRef value so the downstream
+    // loop's `contains(&input.index)` checks line up with the keys inserted.
     let inputarg_oprefs: IndexSet<u32> = inputargs.iter().map(|ia| ia.index).collect();
-    let mut non_ref_at_backedge: IndexSet<u32> = IndexSet::new();
-    // Find the closing JUMP and check arg types against inputarg types
-    if let Some((jump_idx, jump)) = ops
-        .iter()
-        .enumerate()
-        .rfind(|(_, op)| op.opcode == OpCode::Jump && op.num_args() == inputargs.len())
-    {
-        let num_inputs = inputargs.len();
-        for (i, arg) in jump.getarglist().iter().enumerate() {
-            if i >= num_inputs {
-                break;
-            }
-            if inputargs[i].tp != Type::Ref {
-                continue;
-            }
-            // RPython regalloc.py: backedge JUMP arg `is` an inputarg Box →
-            // GC roots already cover it. Pyre analog: arg.raw() matches some
-            // InputArg.index whose .tp is Ref. Phase E.2b shifted bridge
-            // inputargs into `[bridge_inputarg_base..)`, so a dense lookup
-            // by position no longer maps to the right InputArg.
-            // Const operands (history.py:189-220) are never InputArgs.
-            if !arg.is_constant()
-                && inputargs
-                    .iter()
-                    .any(|ia| ia.index == arg.to_opref().raw() && ia.tp == Type::Ref)
-            {
-                continue; // inputarg reference — always safe
-            }
-            if let Some(actual_tp) = lookup_type_at(type_index, overrides, arg.to_opref(), jump_idx)
-            {
-                if actual_tp != Type::Ref {
-                    non_ref_at_backedge.insert(inputargs[i].index);
-                    if std::env::var_os("MAJIT_LOG").is_some() {
-                        eprintln!(
-                            "[ref-root] SKIP inputarg idx={}: backedge passes {:?} (arg={:?})",
-                            inputargs[i].index, actual_tp, arg
-                        );
-                    }
-                }
-            }
-        }
+
+    // The one JUMP whose target *is* part of this trace does have to line up
+    // type-for-type with the LABEL it writes into. RPython cannot express a
+    // violation — a Box carries its type through every forwarding step — while
+    // majit's flat, typeless OpRef can (SameAsF/SameAsI replacing a Ref).
+    // Report it rather than compensating for it: a trace that reaches the
+    // backend ill-typed is a defect upstream of codegen.
+    if std::env::var_os("MAJIT_LOG").is_some() {
+        log_internal_jump_type_mismatches(ops, type_index, overrides);
     }
 
     // RPython regalloc parity: only track ref roots that are actually
@@ -5076,7 +5046,6 @@ fn build_ref_root_slots(
     for input in inputargs {
         if input.tp == Type::Ref
             && !force_tokens.contains(&input.index)
-            && !non_ref_at_backedge.contains(&input.index)
             && used_inputargs.contains(&input.index)
             && seen.insert(input.index)
         {
@@ -5113,22 +5082,76 @@ fn build_ref_root_slots(
         }
     }
 
-    // RPython parity note: this situation (non-Ref at Ref inputarg position)
-    // does not arise in RPython because Box identity preserves types through
-    // optimization. In RPython, force_box_for_end_of_preamble materializes
-    // virtuals; the type of the Box never changes. majit's flat OpRef model
-    // allows type substitution (SameAsF/SameAsI replacing Ref) which RPython
-    // cannot express.
-    //
-    // Both crossings are handled the same way, by `non_ref_at_backedge` above:
-    // the slot is left out of the root list, so the GC never reads the
-    // non-pointer bits sitting there. Float needs no separate treatment — an
-    // IEEE754 payload is never a pointer, which makes dropping the slot exactly
-    // right, where Int is the crossing that can still be carrying a live GC
-    // pointer forwarded through SameAsI. The dynasm backend has no analogous
-    // check because regalloc.rs builds its gcmap from the runtime live type
-    // rather than the declared inputarg type, so the crossing never reaches it.
     Ok(slots)
+}
+
+/// Report JUMPs whose args do not line up type-for-type with the LABEL they
+/// write into, for the LABELs that live inside this same trace.
+///
+/// `x86/regalloc.py:1303-1326 consider_jump` moves arg `i` straight into the
+/// target's `_x86_arglocs[i]` and classifies it by the *arg's* own type, which
+/// is sound only because RPython cannot build a JUMP that disagrees with its
+/// LABEL — a Box carries its type through every forwarding step. majit's flat
+/// OpRef is typeless, so the disagreement is expressible; when it happens the
+/// trace is ill-typed before codegen ever sees it.
+///
+/// Debug-only: this reports, it does not compensate.
+fn log_internal_jump_type_mismatches(
+    ops: &[Op],
+    type_index: &OpTypeIndex<'_>,
+    overrides: &IndexMap<u32, Type>,
+) {
+    // Key by `descr_identity` (Arc allocation address) per `history.py:477`
+    // TargetToken object identity: `d.index()` is not unique across distinct
+    // TargetTokens in the same trace.
+    let labels: Vec<(usize, usize)> = ops
+        .iter()
+        .enumerate()
+        .filter(|(_, op)| op.opcode == OpCode::Label)
+        .filter_map(|(idx, op)| {
+            op.getdescr()
+                .as_ref()
+                .map(|d| (majit_ir::descr_identity(d), idx))
+        })
+        .collect();
+    if labels.is_empty() {
+        return;
+    }
+    for (jump_idx, jump) in ops.iter().enumerate() {
+        if jump.opcode != OpCode::Jump {
+            continue;
+        }
+        let Some(jump_id) = jump.getdescr().as_ref().map(majit_ir::descr_identity) else {
+            continue;
+        };
+        // A JUMP whose descr matches no LABEL here targets another trace; its
+        // types are that trace's contract, not ours.
+        let Some(&(_, label_idx)) = labels.iter().find(|(id, _)| *id == jump_id) else {
+            continue;
+        };
+        let label = &ops[label_idx];
+        if label.num_args() != jump.num_args() {
+            continue;
+        }
+        for (i, (arg, want_arg)) in jump
+            .getarglist()
+            .iter()
+            .zip(label.getarglist().iter())
+            .enumerate()
+        {
+            let got = lookup_type_at(type_index, overrides, arg.to_opref(), jump_idx);
+            let want = lookup_type_at(type_index, overrides, want_arg.to_opref(), label_idx);
+            if let (Some(got), Some(want)) = (got, want) {
+                if got != want {
+                    eprintln!(
+                        "[ref-root] JUMP/LABEL type mismatch at arg {i}: \
+                         label wants {want:?}, jump passes {got:?} \
+                         (jump_idx={jump_idx} label_idx={label_idx})"
+                    );
+                }
+            }
+        }
+    }
 }
 
 /// Simple normalization: assign sequential pos to ops without pos.
@@ -18494,11 +18517,10 @@ mod tests {
     fn test_compiled_terminal_exit_layouts_include_backend_jump_recovery_layout() {
         let mut backend = CraneliftBackend::new();
 
-        // Int (not Float) at slot 0 so the JUMP backedge passes Int into a
-        // Ref-typed inputarg position. build_ref_root_slots permits Int-at-Ref
-        // (SameAsI may forward GC pointers without changing runtime value);
-        // Float-at-Ref is rejected because IEEE754 bits are never valid
-        // pointers.
+        // The JUMP passes its two args in the opposite order to the LABEL, so
+        // the recovery layout under test is built from a Ref and an Int that
+        // sit at swapped positions rather than from a straight-through
+        // backedge.
         let inputargs = vec![InputArg::new_int(0), InputArg::new_ref(1)];
         let ops = vec![
             mk_op(

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -5010,7 +5010,6 @@ fn build_ref_root_slots(
     // line up with the keys we inserted.
     let inputarg_oprefs: IndexSet<u32> = inputargs.iter().map(|ia| ia.index).collect();
     let mut non_ref_at_backedge: IndexSet<u32> = IndexSet::new();
-    let mut has_float_at_ref_position = false;
     // Find the closing JUMP and check arg types against inputarg types
     if let Some((jump_idx, jump)) = ops
         .iter()
@@ -5042,9 +5041,6 @@ fn build_ref_root_slots(
             {
                 if actual_tp != Type::Ref {
                     non_ref_at_backedge.insert(inputargs[i].index);
-                    if actual_tp == Type::Float {
-                        has_float_at_ref_position = true;
-                    }
                     if std::env::var_os("MAJIT_LOG").is_some() {
                         eprintln!(
                             "[ref-root] SKIP inputarg idx={}: backedge passes {:?} (arg={:?})",
@@ -5124,15 +5120,14 @@ fn build_ref_root_slots(
     // allows type substitution (SameAsF/SameAsI replacing Ref) which RPython
     // cannot express.
     //
-    // Float at Ref is unsafe: IEEE754 bits are never valid pointers. Int at Ref
-    // can be safe when the optimizer forwards a GC pointer through SameAsI
-    // without changing the actual runtime value.
-    if has_float_at_ref_position {
-        return Err(BackendError::Unsupported(
-            "jump_to_preamble: backedge passes Float at Ref-typed inputarg position".to_string(),
-        ));
-    }
-
+    // Both crossings are handled the same way, by `non_ref_at_backedge` above:
+    // the slot is left out of the root list, so the GC never reads the
+    // non-pointer bits sitting there. Float needs no separate treatment — an
+    // IEEE754 payload is never a pointer, which makes dropping the slot exactly
+    // right, where Int is the crossing that can still be carrying a live GC
+    // pointer forwarded through SameAsI. The dynasm backend has no analogous
+    // check because regalloc.rs builds its gcmap from the runtime live type
+    // rather than the declared inputarg type, so the crossing never reaches it.
     Ok(slots)
 }
 

--- a/majit/majit-backend-wasm/src/failguard.rs
+++ b/majit/majit-backend-wasm/src/failguard.rs
@@ -518,6 +518,8 @@ impl Drop for CompiledWasmLoop {
                     if let Some(t) = map.get(&id) {
                         if t.func_handle == self.func_handle {
                             map.remove(&id);
+                            crate::BRIDGE_DIAG[22]
+                                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                         }
                     }
                 }

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -33,10 +33,19 @@ use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
 /// (guard side-trace that would livelock the chained loop), 14 = accepted
 /// CALL_ASSEMBLER trace, 15 = declined CA because a trace would use the host
 /// call trampoline on a movable CA frame.  Index 16 records the dormant
-/// forced-terminal-decline runtime regression hook.
-pub static BRIDGE_DIAG: [AtomicU64; 17] = {
+/// forced-terminal-decline runtime regression hook. Sub-breakdown of the
+/// index-8 unresolved-target decline: 17 = the terminal JUMP carries no descr
+/// at all, 18 = the descr is present but `LABEL_TARGETS` holds no entry for it.
+/// Publish-side counterpart, so an unresolved lookup can be told from a label
+/// that was never offered: 19 = labels published off a peeled loop, 20 =
+/// published off a non-peeled loop, 21 = a non-peeled loop's first label left
+/// unpublished (no descr, or its arity is not the inputarg count), 22 = a
+/// dropped loop retracted a published entry.
+pub static BRIDGE_DIAG: [AtomicU64; 23] = {
     const Z: AtomicU64 = AtomicU64::new(0);
-    [Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z]
+    [
+        Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z,
+    ]
 };
 
 /// Read a `BRIDGE_DIAG` tally (saturating index). Surfaced to the host through
@@ -1862,6 +1871,7 @@ impl majit_backend::Backend for WasmBackend {
                 if id == 0 {
                     continue;
                 }
+                diag_bump(19);
                 publish_label_target(
                     id,
                     LabelTarget {
@@ -1874,8 +1884,15 @@ impl majit_backend::Backend for WasmBackend {
                     },
                 );
             }
-        } else if let Some(&id) = label_descrs.first() {
-            if id != 0 && label_num_args.first() == Some(&inputargs.len()) {
+        } else {
+            let publishable = label_descrs.first().is_some_and(|&id| id != 0)
+                && label_num_args.first() == Some(&inputargs.len());
+            if !publishable {
+                diag_bump(21);
+            }
+            if publishable {
+                let id = label_descrs[0];
+                diag_bump(20);
                 publish_label_target(
                     id,
                     LabelTarget {
@@ -2238,16 +2255,17 @@ impl majit_backend::Backend for WasmBackend {
                 .iter()
                 .rev()
                 .find(|op| op.opcode == majit_ir::OpCode::Jump);
-            let target = closing_jump
+            let target_descr_id = closing_jump
                 .and_then(|j| j.getdescr())
                 .map(|d| std::sync::Arc::as_ptr(&d) as *const () as usize)
-                .filter(|id| *id != 0)
-                .and_then(label_target);
+                .filter(|id| *id != 0);
+            let target = target_descr_id.and_then(label_target);
             let arity = closing_jump.map_or(0, |j| j.getarglist().len());
             let accepted_target = match target {
                 // Descr stripped, or the target label was never published.
                 None => {
                     diag_bump(8);
+                    diag_bump(if target_descr_id.is_none() { 17 } else { 18 });
                     false
                 }
                 Some(t) if arity != t.num_args => {

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -2666,6 +2666,15 @@ impl<S: JitState> JitDriver<S> {
                                     self.meta.take_bridge_info();
                                     // Fall through — do NOT return.
                                 }
+                                // pyjitpl.py:3220 raise_if_successful() does not
+                                // raise on a None target token, so the trace is
+                                // not given up: fall through to compile_loop the
+                                // way reached_loop_header falls into its
+                                // merge-point scan.
+                                crate::pyjitpl::BridgeCompileResult::Declined => {
+                                    self.meta.take_bridge_info();
+                                    // Fall through — do NOT return.
+                                }
                                 crate::pyjitpl::BridgeCompileResult::Failed => {
                                     self.meta.abort_trace(false);
                                     self.sym = None;
@@ -2830,6 +2839,15 @@ impl<S: JitState> JitDriver<S> {
                             // partial_trace is set on MetaInterp. Fall through
                             // to compile_loop → compile_retrace in same call.
                             crate::pyjitpl::BridgeCompileResult::RetraceNeeded => {
+                                self.meta.take_bridge_info();
+                                // Fall through — do NOT return.
+                            }
+                            // pyjitpl.py:3220 raise_if_successful() does not
+                            // raise on a None target token, so the trace is not
+                            // given up: fall through to compile_loop the way
+                            // reached_loop_header falls into its merge-point
+                            // scan.
+                            crate::pyjitpl::BridgeCompileResult::Declined => {
                                 self.meta.take_bridge_info();
                                 // Fall through — do NOT return.
                             }

--- a/majit/majit-metainterp/src/lib.rs
+++ b/majit/majit-metainterp/src/lib.rs
@@ -599,17 +599,26 @@ pub fn register_stack_almost_full_hook(f: fn() -> bool) {
 /// should_trace_function_entry declined (dead procedure token cleanup), 25 =
 /// should_trace_function_entry answered from the counter tick, 26 = walk steps
 /// recorded past `trace_limit` whose abort was suppressed because the walk had
-/// already executed an unrollbackable effect.
-pub static MC_DIAG: [std::sync::atomic::AtomicU64; 27] = {
+/// already executed an unrollbackable effect, 27 = the walker's in-trace
+/// `compile_trace` attempt did not take and fell through to the merge-point
+/// scan, 28 = `compile_loop` gave the trace up at its own
+/// `has_compiled_targets`, 29 = `compile_trace` cancelled with no
+/// front target token to jump at, 30 = `compile_trace` cancelled because the
+/// origin guard's loop is no longer compiled, 31 = the interp-origin entry
+/// bridge did not compile, 32 = `compile_trace` had neither a guard origin nor
+/// entry-bridge data to close against, 33 = `compile_trace` was called with no
+/// tracing session.
+pub static MC_DIAG: [std::sync::atomic::AtomicU64; 34] = {
     const Z: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
     [
-        Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z,
+        Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z,
+        Z, Z, Z, Z,
     ]
 };
 
 /// Short label per [`MC_DIAG`] slot, in index order, so a tally cannot be added
 /// without naming it. Readers join these with the counter values.
-pub const MC_DIAG_LABELS: [&str; 27] = [
+pub const MC_DIAG_LABELS: [&str; 34] = [
     "mc_entered",
     "decl_shortcircuit",
     "descr0_skip",
@@ -637,6 +646,13 @@ pub const MC_DIAG_LABELS: [&str; 27] = [
     "stfe_dead_token",
     "stfe_tick",
     "toolong_suppressed",
+    "wct_declined",
+    "cl_hct_giveup",
+    "ct_no_front_token",
+    "ct_origin_loop_gone",
+    "ct_entry_bridge_failed",
+    "ct_no_entry_data",
+    "ct_not_tracing",
 ];
 
 /// Render every [`MC_DIAG`] tally as space-separated `label=count` pairs.

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -2848,11 +2848,24 @@ impl Optimizer {
             let mut force_needed: Vec<usize> = Vec::new();
             // optimizer.py:651-652 force_box loop parity:
             //   for i in range(op.numargs()): op.setarg(i, force_box(...))
+            //
+            // `trace_inputargs` names the positions this JUMP writes into only
+            // on the unroll paths, where unroll.py:454 builds `end_args` from
+            // `original_label_args`: the preamble closes back to the loop start,
+            // and the peeled body closes back to the LABEL made from those same
+            // args. A bridge's JUMP targets a different trace's label while
+            // `trace_inputargs` holds the guard's failargs — two unrelated
+            // lists, so a positional Ref check reads arbitrary positions. There
+            // the type contract belongs to virtual-state matching
+            // (virtualstate.py:646-653 `generate_guards`), and what applies here
+            // is the plain force_box loop.
+            let inputargs_are_the_jump_target = !self.building_bridge;
             for i in 0..terminal_op.num_args() {
                 let arg = terminal_op.arg(i);
                 let resolved = ctx.resolve_operand_operand(&arg).to_opref();
-                let expected_ref =
-                    i < inputargs.len() && inputargs[i].ty() == Some(majit_ir::Type::Ref);
+                let expected_ref = inputargs_are_the_jump_target
+                    && i < inputargs.len()
+                    && inputargs[i].ty() == Some(majit_ir::Type::Ref);
                 // setup_optimizations seeds `trace_inputargs` into
                 // ctx.inputargs (optimizer.py:34), and `opref_type`
                 // consults it via the inputarg-slot fallback after the
@@ -2888,6 +2901,12 @@ impl Optimizer {
                         // the non-ref replacement. This matches the upstream
                         // force_box_for_end_of_preamble contract more closely than
                         // allowing Ref -> Float/Int type substitution at the JUMP.
+                        if crate::majit_log_enabled() {
+                            eprintln!(
+                                "[jump-type] arg {i}: label position is Ref, replacement is not; \
+                                 keeping the original arg"
+                            );
+                        }
                     }
                 } else {
                     let arg = ctx.materialize_operand_at(resolved);

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -1855,15 +1855,10 @@ impl UnrollOptimizer {
         if !jump_to_self {
             // unroll.py:170-171: jump_to_preamble — body JUMP → preamble Label
             //
-            // RPython parity: force_box_for_end_of_preamble (unroll.py:126-127)
-            // re-boxes unboxed values before the JUMP so types match the
-            // preamble inputargs. Without force_box, the body JUMP may pass
-            // Float/Int values at Ref-typed positions, causing the preamble's
-            // guard checks to dereference non-pointer values → segfault.
-            //
-            // Until force_box_for_end_of_preamble is implemented, reject
-            // traces where the body JUMP types don't match preamble inputarg
-            // types. The metainterp falls back to interpretation.
+            // force_box_for_end_of_preamble (unroll.py:126-127) has already run
+            // over the body JUMP's args above, so they carry the types the
+            // preamble's Label declares and the retarget below is a plain
+            // send_extra_operation.
             let preamble_target = self
                 .target_tokens
                 .first()

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -5501,22 +5501,6 @@ impl<M: Clone> MetaInterp<M> {
         if self.retrace_after_bridge {
             self.retrace_after_bridge = false;
         }
-        // pyjitpl.py:3162: has_compiled_targets(ptoken) →
-        // raise SwitchToBlackhole(ABORT_BAD_LOOP).
-        if let Some(ctx) = self.tracing.as_ref() {
-            let gk = ctx.green_key;
-            if self.has_compiled_targets(gk) {
-                if crate::majit_log_enabled() {
-                    eprintln!(
-                        "[jit] compile_loop → SwitchToBlackhole: has_compiled_targets key={}",
-                        gk
-                    );
-                }
-                self.abort_trace(false);
-                return CompileOutcome::Aborted;
-            }
-        }
-
         let vable_config = self.current_virtualizable_optimizer_config();
         // pyjitpl.py:3015-3032 parity: compile_loop uses `self.history`
         // without consuming it, so cancel paths can fall through to
@@ -5535,6 +5519,25 @@ impl<M: Clone> MetaInterp<M> {
             // jitcell_token. RPython: jitcell_token = cross_loop.jitcell_token.
             (cut_inner.unwrap_or(outer), cut_inner)
         };
+
+        // pyjitpl.py:3185-3189: has_compiled_targets(ptoken) →
+        // raise SwitchToBlackhole(ABORT_BAD_LOOP).  The key is the one the
+        // loop would be stored under — `original_boxes[:num_green_args]`,
+        // the greens of the merge point that was closed at, which for a
+        // cross-loop cut is the inner loop's key, not the trace's own.
+        if self.has_compiled_targets(green_key) {
+            if crate::majit_log_enabled() {
+                eprintln!(
+                    "[jit] compile_loop → SwitchToBlackhole: has_compiled_targets key={}",
+                    green_key
+                );
+            }
+            // Reason-keyed, so the profiler tallies this under `bad loop`
+            // and not the `Generic` catch-all, which is ABORT_BRIDGE.
+            self.abort_trace_live(false);
+            self.aborted_tracing(counters::ABORT_BAD_LOOP);
+            return CompileOutcome::Aborted;
+        }
 
         // pyjitpl.py:3015-3032 parity: pyre caches the retrace limit per
         // green_key so guard-heavy recompilations do not loop forever.

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -5554,6 +5554,7 @@ impl<M: Clone> MetaInterp<M> {
             // the single `aborted_tracing` to the `abort_trace` that follows
             // this `Aborted`. Tallying here as well would count one aborted
             // trace twice, and under the `Generic` catch-all besides.
+            crate::mc_diag_bump(28); // compile_loop: has_compiled_targets giveup
             self.pending_abort_reason = Some(counters::ABORT_BAD_LOOP);
             return CompileOutcome::Aborted;
         }
@@ -6779,7 +6780,10 @@ impl<M: Clone> MetaInterp<M> {
         let ends_with_jump = finish_descr.is_none();
         let ctx = match self.tracing.as_mut() {
             Some(ctx) => ctx,
-            None => return CompileOutcome::Cancelled,
+            None => {
+                crate::mc_diag_bump(33); // compile_trace: no tracing session
+                return CompileOutcome::Cancelled;
+            }
         };
 
         // pyjitpl.py:3187: save position before recording JUMP/FINISH
@@ -6805,6 +6809,7 @@ impl<M: Clone> MetaInterp<M> {
                 if crate::closedbg_enabled() {
                     eprintln!("@@@CANCEL-SITE line={}", line!());
                 }
+                crate::mc_diag_bump(29); // compile_trace: no front target token
                 return CompileOutcome::Cancelled;
             };
             ctx.recorder
@@ -6915,6 +6920,7 @@ impl<M: Clone> MetaInterp<M> {
                     if crate::closedbg_enabled() {
                         eprintln!("@@@CANCEL-SITE line={}", line!());
                     }
+                    crate::mc_diag_bump(30); // compile_trace: origin loop gone
                     return CompileOutcome::Cancelled;
                 }
                 let descr_arc = match self.bridge_info() {
@@ -6956,6 +6962,7 @@ impl<M: Clone> MetaInterp<M> {
                     if crate::closedbg_enabled() {
                         eprintln!("@@@CANCEL-SITE line={}", line!());
                     }
+                    crate::mc_diag_bump(32); // compile_trace: no entry-bridge data
                     return CompileOutcome::Cancelled;
                 };
                 let success = self.compile_entry_bridge(
@@ -6977,6 +6984,7 @@ impl<M: Clone> MetaInterp<M> {
                         from_retry: false,
                     }
                 } else {
+                    crate::mc_diag_bump(31); // compile_trace: entry bridge failed
                     CompileOutcome::Cancelled
                 }
             }

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -955,8 +955,14 @@ fn compute_next_global_opref<T: AsRef<majit_ir::Op>>(inputargs: &[InputArg], ops
 pub enum BridgeCompileResult {
     /// Bridge was compiled and attached to the guard.
     Compiled,
-    /// Bridge compilation failed.
+    /// Bridge compilation gave the whole trace up.
     Failed,
+    /// `compile.compile_trace` returned None: compile.py:227 cuts the
+    /// tentative jump and returns, and `raise_if_successful`
+    /// (pyjitpl.py:3119) does not raise on None, so the trace is not given
+    /// up. The tracing context is intact and the caller falls through to
+    /// the merge-point scan, as `reached_loop_header` does.
+    Declined,
     /// Optimizer requested retrace (no matching target token).
     /// The tracing context is intact — caller should continue tracing.
     /// pyjitpl.py:3196: compile_trace returns None → MetaInterp continues.
@@ -1403,6 +1409,14 @@ pub struct MetaInterp<M: Clone> {
     /// payload the old monolithic `abort_trace` produced.
     pub(crate) pending_abort_green_key: Option<u64>,
     pub(crate) pending_abort_permanent: bool,
+
+    /// The `Counters.ABORT_*` reason a `CompileOutcome::Aborted` carries to
+    /// the caller that performs the accounting. `raise SwitchToBlackhole(reason)`
+    /// names the reason at the raise site and the single catch calls
+    /// `aborted_tracing(stb.reason)` (pyjitpl.py:2910/2930), so a compile step
+    /// that gives the trace up records its reason here rather than tallying
+    /// itself — tallying at both ends counts one aborted trace twice.
+    pub(crate) pending_abort_reason: Option<i32>,
 
     /// pyjitpl.py:2381 `MetaInterp.last_exc_box = None` (class
     /// attribute).  Set by `handle_possible_exception` to the boxed
@@ -2579,6 +2593,7 @@ impl<M: Clone> MetaInterp<M> {
             active_jitdriver_sd: None,
             aborted_tracing_greenkey: None,
             pending_abort_green_key: None,
+            pending_abort_reason: None,
             pending_abort_permanent: false,
             last_exc_box: None,
             class_of_last_exc_is_const: false,
@@ -5415,6 +5430,8 @@ impl<M: Clone> MetaInterp<M> {
 
     fn compile_loop_body(&mut self, jump_args: &[OpRef], meta: M) -> CompileOutcome {
         let _snapshot_guard = CompileSnapshotRootsGuard::new(&mut self.compile_snapshot_refs);
+        // Only this call's own give-up decides the reason the caller accounts.
+        self.pending_abort_reason = None;
         self.single_pass_compact_label_values = None;
         let single_pass_full_live_values = self.single_pass_full_live_values.take();
         // pyjitpl.py:2995 `assert len(self.virtualref_boxes) == 0,
@@ -5532,10 +5549,12 @@ impl<M: Clone> MetaInterp<M> {
                     green_key
                 );
             }
-            // Reason-keyed, so the profiler tallies this under `bad loop`
-            // and not the `Generic` catch-all, which is ABORT_BRIDGE.
-            self.abort_trace_live(false);
-            self.aborted_tracing(counters::ABORT_BAD_LOOP);
+            // The raise names the reason and the caller's catch does the
+            // accounting, so stage ABORT_BAD_LOOP and leave the teardown and
+            // the single `aborted_tracing` to the `abort_trace` that follows
+            // this `Aborted`. Tallying here as well would count one aborted
+            // trace twice, and under the `Generic` catch-all besides.
+            self.pending_abort_reason = Some(counters::ABORT_BAD_LOOP);
             return CompileOutcome::Aborted;
         }
 
@@ -7524,7 +7543,15 @@ impl<M: Clone> MetaInterp<M> {
     /// is fully ported).
     pub fn abort_trace(&mut self, permanent: bool) {
         self.abort_trace_live(permanent);
-        self.aborted_tracing(AbortReason::Generic.as_int());
+        // A compile step that already decided to give the trace up staged its
+        // `Counters.ABORT_*` reason; this is the catch that turns it into the
+        // one accounting event, as `aborted_tracing(stb.reason)` does for the
+        // reason the `SwitchToBlackhole` raise carried.
+        let reason = self
+            .pending_abort_reason
+            .take()
+            .unwrap_or(AbortReason::Generic.as_int());
+        self.aborted_tracing(reason);
     }
 
     /// Live-cleanup half of `abort_trace` — no stats, no hooks.
@@ -7599,6 +7626,7 @@ impl<M: Clone> MetaInterp<M> {
     pub fn clear_pending_abort(&mut self) {
         self.pending_abort_green_key = None;
         self.pending_abort_permanent = false;
+        self.pending_abort_reason = None;
     }
 
     /// Finish the current trace with a terminal `FINISH`, then optimize and compile it.
@@ -10175,7 +10203,11 @@ impl<M: Clone> MetaInterp<M> {
                 // is before 3162 has_compiled_targets.
                 BridgeCompileResult::RetraceNeeded
             }
-            _ => BridgeCompileResult::Failed,
+            // `compile_trace_inner` also answers `Cancelled` when there is no
+            // trace at all — a state upstream cannot be in, and one the
+            // fall-through cannot serve because `compile_loop` needs the ctx.
+            CompileOutcome::Cancelled if self.tracing.is_some() => BridgeCompileResult::Declined,
+            CompileOutcome::Cancelled | CompileOutcome::Aborted => BridgeCompileResult::Failed,
         }
     }
 

--- a/pyre/bench/fannkuch.cranelift.jitstats
+++ b/pyre/bench/fannkuch.cranelift.jitstats
@@ -1,5 +1,8 @@
 bridges_compiled=23
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
 guard_failures=5394
 internal_compile_panics=0
-loops_aborted=4
+loops_aborted=2
 loops_compiled=5

--- a/pyre/bench/fannkuch.cranelift.jitstats
+++ b/pyre/bench/fannkuch.cranelift.jitstats
@@ -1,5 +1,5 @@
-bridges_compiled=26
-guard_failures=5628
+bridges_compiled=23
+guard_failures=5394
 internal_compile_panics=0
-loops_aborted=0
+loops_aborted=4
 loops_compiled=5

--- a/pyre/bench/fannkuch.dynasm.jitstats
+++ b/pyre/bench/fannkuch.dynasm.jitstats
@@ -1,5 +1,8 @@
 bridges_compiled=23
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
 guard_failures=5394
 internal_compile_panics=0
-loops_aborted=4
+loops_aborted=2
 loops_compiled=5

--- a/pyre/bench/fannkuch.dynasm.jitstats
+++ b/pyre/bench/fannkuch.dynasm.jitstats
@@ -1,5 +1,5 @@
-bridges_compiled=26
-guard_failures=5628
+bridges_compiled=23
+guard_failures=5394
 internal_compile_panics=0
-loops_aborted=0
+loops_aborted=4
 loops_compiled=5

--- a/pyre/bench/fannkuch.wasm.jitstats
+++ b/pyre/bench/fannkuch.wasm.jitstats
@@ -1,2 +1,2 @@
 internal_compile_panics=0
-loops_aborted=0
+loops_aborted=4

--- a/pyre/bench/fannkuch.wasm.jitstats
+++ b/pyre/bench/fannkuch.wasm.jitstats
@@ -1,2 +1,5 @@
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
 internal_compile_panics=0
-loops_aborted=4
+loops_aborted=2

--- a/pyre/bench/fib_loop.cranelift.jitstats
+++ b/pyre/bench/fib_loop.cranelift.jitstats
@@ -1,5 +1,5 @@
 bridges_compiled=0
-guard_failures=190
+guard_failures=191
 internal_compile_panics=0
 loops_aborted=0
 loops_compiled=1

--- a/pyre/bench/fib_loop.cranelift.jitstats
+++ b/pyre/bench/fib_loop.cranelift.jitstats
@@ -1,4 +1,7 @@
 bridges_compiled=0
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
 guard_failures=191
 internal_compile_panics=0
 loops_aborted=0

--- a/pyre/bench/fib_loop.dynasm.jitstats
+++ b/pyre/bench/fib_loop.dynasm.jitstats
@@ -1,5 +1,5 @@
 bridges_compiled=0
-guard_failures=190
+guard_failures=191
 internal_compile_panics=0
 loops_aborted=0
 loops_compiled=1

--- a/pyre/bench/fib_loop.dynasm.jitstats
+++ b/pyre/bench/fib_loop.dynasm.jitstats
@@ -1,4 +1,7 @@
 bridges_compiled=0
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
 guard_failures=191
 internal_compile_panics=0
 loops_aborted=0

--- a/pyre/bench/fib_loop.wasm.jitstats
+++ b/pyre/bench/fib_loop.wasm.jitstats
@@ -1,2 +1,5 @@
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
 internal_compile_panics=0
 loops_aborted=0

--- a/pyre/bench/fib_recursive.cranelift.jitstats
+++ b/pyre/bench/fib_recursive.cranelift.jitstats
@@ -1,4 +1,7 @@
 bridges_compiled=3
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
 guard_failures=406
 internal_compile_panics=0
 loops_aborted=0

--- a/pyre/bench/fib_recursive.dynasm.jitstats
+++ b/pyre/bench/fib_recursive.dynasm.jitstats
@@ -1,4 +1,7 @@
 bridges_compiled=3
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
 guard_failures=406
 internal_compile_panics=0
 loops_aborted=0

--- a/pyre/bench/fib_recursive.wasm.jitstats
+++ b/pyre/bench/fib_recursive.wasm.jitstats
@@ -1,2 +1,5 @@
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
 internal_compile_panics=0
 loops_aborted=0

--- a/pyre/bench/float_loop.cranelift.jitstats
+++ b/pyre/bench/float_loop.cranelift.jitstats
@@ -1,4 +1,7 @@
 bridges_compiled=0
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
 guard_failures=1
 internal_compile_panics=0
 loops_aborted=0

--- a/pyre/bench/float_loop.dynasm.jitstats
+++ b/pyre/bench/float_loop.dynasm.jitstats
@@ -1,4 +1,7 @@
 bridges_compiled=0
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
 guard_failures=1
 internal_compile_panics=0
 loops_aborted=0

--- a/pyre/bench/float_loop.wasm.jitstats
+++ b/pyre/bench/float_loop.wasm.jitstats
@@ -1,2 +1,5 @@
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
 internal_compile_panics=0
 loops_aborted=0

--- a/pyre/bench/inline_helper.cranelift.jitstats
+++ b/pyre/bench/inline_helper.cranelift.jitstats
@@ -1,4 +1,7 @@
 bridges_compiled=0
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
 guard_failures=1
 internal_compile_panics=0
 loops_aborted=0

--- a/pyre/bench/inline_helper.dynasm.jitstats
+++ b/pyre/bench/inline_helper.dynasm.jitstats
@@ -1,4 +1,7 @@
 bridges_compiled=0
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
 guard_failures=1
 internal_compile_panics=0
 loops_aborted=0

--- a/pyre/bench/inline_helper.wasm.jitstats
+++ b/pyre/bench/inline_helper.wasm.jitstats
@@ -1,2 +1,5 @@
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
 internal_compile_panics=0
 loops_aborted=0

--- a/pyre/bench/int_loop.cranelift.jitstats
+++ b/pyre/bench/int_loop.cranelift.jitstats
@@ -1,4 +1,7 @@
 bridges_compiled=0
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
 guard_failures=1
 internal_compile_panics=0
 loops_aborted=0

--- a/pyre/bench/int_loop.dynasm.jitstats
+++ b/pyre/bench/int_loop.dynasm.jitstats
@@ -1,4 +1,7 @@
 bridges_compiled=0
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
 guard_failures=1
 internal_compile_panics=0
 loops_aborted=0

--- a/pyre/bench/int_loop.wasm.jitstats
+++ b/pyre/bench/int_loop.wasm.jitstats
@@ -1,2 +1,5 @@
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
 internal_compile_panics=0
 loops_aborted=0

--- a/pyre/bench/nbody.cranelift.jitstats
+++ b/pyre/bench/nbody.cranelift.jitstats
@@ -1,5 +1,5 @@
-bridges_compiled=7
-guard_failures=1949
+bridges_compiled=6
+guard_failures=1580
 internal_compile_panics=0
 loops_aborted=0
 loops_compiled=5

--- a/pyre/bench/nbody.cranelift.jitstats
+++ b/pyre/bench/nbody.cranelift.jitstats
@@ -1,5 +1,8 @@
-bridges_compiled=6
-guard_failures=1580
+bridges_compiled=5
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
+guard_failures=1547
 internal_compile_panics=0
 loops_aborted=0
 loops_compiled=5

--- a/pyre/bench/nbody.dynasm.jitstats
+++ b/pyre/bench/nbody.dynasm.jitstats
@@ -1,5 +1,8 @@
-bridges_compiled=6
-guard_failures=1580
+bridges_compiled=5
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
+guard_failures=1547
 internal_compile_panics=0
 loops_aborted=0
 loops_compiled=5

--- a/pyre/bench/nbody.wasm.jitstats
+++ b/pyre/bench/nbody.wasm.jitstats
@@ -1,2 +1,5 @@
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
 internal_compile_panics=0
 loops_aborted=0

--- a/pyre/bench/nested_loop.cranelift.jitstats
+++ b/pyre/bench/nested_loop.cranelift.jitstats
@@ -1,4 +1,7 @@
 bridges_compiled=1
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
 guard_failures=201
 internal_compile_panics=0
 loops_aborted=0

--- a/pyre/bench/nested_loop.dynasm.jitstats
+++ b/pyre/bench/nested_loop.dynasm.jitstats
@@ -1,4 +1,7 @@
 bridges_compiled=1
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
 guard_failures=201
 internal_compile_panics=0
 loops_aborted=0

--- a/pyre/bench/nested_loop.wasm.jitstats
+++ b/pyre/bench/nested_loop.wasm.jitstats
@@ -1,2 +1,5 @@
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
 internal_compile_panics=0
 loops_aborted=0

--- a/pyre/bench/raise_catch_loop.cranelift.jitstats
+++ b/pyre/bench/raise_catch_loop.cranelift.jitstats
@@ -1,4 +1,7 @@
 bridges_compiled=1
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
 guard_failures=201
 internal_compile_panics=0
 loops_aborted=0

--- a/pyre/bench/raise_catch_loop.dynasm.jitstats
+++ b/pyre/bench/raise_catch_loop.dynasm.jitstats
@@ -1,4 +1,7 @@
 bridges_compiled=1
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
 guard_failures=201
 internal_compile_panics=0
 loops_aborted=0

--- a/pyre/bench/raise_catch_loop.wasm.jitstats
+++ b/pyre/bench/raise_catch_loop.wasm.jitstats
@@ -1,2 +1,5 @@
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
 internal_compile_panics=0
 loops_aborted=0

--- a/pyre/bench/spectral_norm.cranelift.jitstats
+++ b/pyre/bench/spectral_norm.cranelift.jitstats
@@ -1,4 +1,7 @@
 bridges_compiled=2
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
 guard_failures=520
 internal_compile_panics=0
 loops_aborted=0

--- a/pyre/bench/spectral_norm.dynasm.jitstats
+++ b/pyre/bench/spectral_norm.dynasm.jitstats
@@ -1,4 +1,7 @@
 bridges_compiled=2
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
 guard_failures=520
 internal_compile_panics=0
 loops_aborted=0

--- a/pyre/bench/spectral_norm.wasm.jitstats
+++ b/pyre/bench/spectral_norm.wasm.jitstats
@@ -1,2 +1,5 @@
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
 internal_compile_panics=0
 loops_aborted=0

--- a/pyre/bench/synth/comprehension_object_append_hot.cranelift.jitstats
+++ b/pyre/bench/synth/comprehension_object_append_hot.cranelift.jitstats
@@ -1,5 +1,5 @@
 bridges_compiled=18
-guard_failures=3611
+guard_failures=3612
 internal_compile_panics=0
 loops_aborted=0
 loops_compiled=6

--- a/pyre/bench/synth/comprehension_object_append_hot.cranelift.jitstats
+++ b/pyre/bench/synth/comprehension_object_append_hot.cranelift.jitstats
@@ -1,4 +1,7 @@
 bridges_compiled=18
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
 guard_failures=3612
 internal_compile_panics=0
 loops_aborted=0

--- a/pyre/bench/synth/comprehension_object_append_hot.dynasm.jitstats
+++ b/pyre/bench/synth/comprehension_object_append_hot.dynasm.jitstats
@@ -1,5 +1,8 @@
 bridges_compiled=18
-guard_failures=3612
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
+guard_failures=3611
 internal_compile_panics=0
 loops_aborted=0
 loops_compiled=6

--- a/pyre/bench/synth/comprehension_object_append_hot.dynasm.jitstats
+++ b/pyre/bench/synth/comprehension_object_append_hot.dynasm.jitstats
@@ -1,5 +1,5 @@
 bridges_compiled=18
-guard_failures=3611
+guard_failures=3612
 internal_compile_panics=0
 loops_aborted=0
 loops_compiled=6

--- a/pyre/bench/synth/comprehension_object_append_hot.wasm.jitstats
+++ b/pyre/bench/synth/comprehension_object_append_hot.wasm.jitstats
@@ -1,2 +1,5 @@
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
 internal_compile_panics=0
-loops_aborted=2
+loops_aborted=0

--- a/pyre/bench/synth/const_arg_call_resume.cranelift.jitstats
+++ b/pyre/bench/synth/const_arg_call_resume.cranelift.jitstats
@@ -1,4 +1,7 @@
 bridges_compiled=9
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
 guard_failures=1804
 internal_compile_panics=0
 loops_aborted=0

--- a/pyre/bench/synth/const_arg_call_resume.dynasm.jitstats
+++ b/pyre/bench/synth/const_arg_call_resume.dynasm.jitstats
@@ -1,4 +1,7 @@
 bridges_compiled=9
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
 guard_failures=1804
 internal_compile_panics=0
 loops_aborted=0

--- a/pyre/bench/synth/const_arg_call_resume.wasm.jitstats
+++ b/pyre/bench/synth/const_arg_call_resume.wasm.jitstats
@@ -1,2 +1,5 @@
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
 internal_compile_panics=0
-loops_aborted=1
+loops_aborted=0

--- a/pyre/bench/synth/exception_bridge_traceback_head.py
+++ b/pyre/bench/synth/exception_bridge_traceback_head.py
@@ -1,0 +1,34 @@
+# Two exception classes in one hot try force an exception-edge bridge for the
+# non-recorded class. Reading the traceback head in each handler pins that the
+# compiled catching frame contributes its node before handler entry.
+#
+# Expected output: [('T', 'outer'), ('V', 'outer')]
+N = 60000
+
+
+def leaf(i):
+    if i % 3 == 1:
+        raise ValueError(i)
+    if i % 3 == 2:
+        raise TypeError(i)
+    return i
+
+
+def mid(i):
+    return leaf(i)
+
+
+def outer():
+    shapes = set()
+    acc = 0
+    for i in range(N):
+        try:
+            acc += mid(i)
+        except ValueError as e:
+            shapes.add(("V", e.__traceback__.tb_frame.f_code.co_name))
+        except TypeError as e:
+            shapes.add(("T", e.__traceback__.tb_frame.f_code.co_name))
+    return sorted(shapes)
+
+
+print(outer())

--- a/pyre/bench/synth/nested_list_comprehension_hot.cranelift.jitstats
+++ b/pyre/bench/synth/nested_list_comprehension_hot.cranelift.jitstats
@@ -1,4 +1,7 @@
 bridges_compiled=6
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
 guard_failures=1204
 internal_compile_panics=0
 loops_aborted=0

--- a/pyre/bench/synth/nested_list_comprehension_hot.cranelift.jitstats
+++ b/pyre/bench/synth/nested_list_comprehension_hot.cranelift.jitstats
@@ -1,5 +1,5 @@
 bridges_compiled=6
-guard_failures=1203
+guard_failures=1204
 internal_compile_panics=0
 loops_aborted=0
 loops_compiled=2

--- a/pyre/bench/synth/nested_list_comprehension_hot.dynasm.jitstats
+++ b/pyre/bench/synth/nested_list_comprehension_hot.dynasm.jitstats
@@ -1,4 +1,7 @@
 bridges_compiled=6
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
 guard_failures=1204
 internal_compile_panics=0
 loops_aborted=0

--- a/pyre/bench/synth/nested_list_comprehension_hot.dynasm.jitstats
+++ b/pyre/bench/synth/nested_list_comprehension_hot.dynasm.jitstats
@@ -1,5 +1,5 @@
 bridges_compiled=6
-guard_failures=1203
+guard_failures=1204
 internal_compile_panics=0
 loops_aborted=0
 loops_compiled=2

--- a/pyre/bench/synth/nested_list_comprehension_hot.wasm.jitstats
+++ b/pyre/bench/synth/nested_list_comprehension_hot.wasm.jitstats
@@ -1,2 +1,5 @@
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
 internal_compile_panics=0
-loops_aborted=2
+loops_aborted=0

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/bridge_subwalk.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/bridge_subwalk.rs
@@ -54,7 +54,10 @@ fn record_bridge_handler_entry_traceback<Sym: WalkSym>(
     record_inline_application_traceback(wc, exc, exc_concrete, position, true, emit_runtime);
     record_top_level_application_traceback(wc, exc, exc_concrete, position, true, emit_runtime);
     if let Some(exception) = traceback_exception {
-        crate::jitcode_dispatch::fbw_traceback_journal_push_if_attached(exception, traceback_before);
+        crate::jitcode_dispatch::fbw_traceback_journal_push_if_attached(
+            exception,
+            traceback_before,
+        );
     }
 }
 

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/bridge_subwalk.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/bridge_subwalk.rs
@@ -39,9 +39,23 @@ fn record_bridge_handler_entry_traceback<Sym: WalkSym>(
     // catches the exception itself and the frame never surfaces an error the
     // interpreter's `handle_exception` could record a node from — hence the
     // runtime emit when the IR-virtual prepend declines.
+    //
+    // The concrete leg of the record mutates the live exception, and a walk
+    // that is later discarded would leave that mutation behind while the
+    // metainterp's own delivery attaches the node again. Journal the attach so
+    // a rollback restores `exception.w_traceback` to the head recorded here.
+    let traceback_exception = match exc_concrete {
+        ConcreteValue::Ref(exception) => Some(exception),
+        _ => None,
+    };
+    let traceback_before =
+        traceback_exception.and_then(crate::jitcode_dispatch::fbw_traceback_journal_head);
     let emit_runtime = !record_prepend_application_traceback(wc, exc, exc_concrete, position);
     record_inline_application_traceback(wc, exc, exc_concrete, position, true, emit_runtime);
     record_top_level_application_traceback(wc, exc, exc_concrete, position, true, emit_runtime);
+    if let Some(exception) = traceback_exception {
+        crate::jitcode_dispatch::fbw_traceback_journal_push_if_attached(exception, traceback_before);
+    }
 }
 
 /// `executioncontext.py:91-107 leave` for a frame the bridge resumed into

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
@@ -346,6 +346,7 @@ pub(crate) fn fbw_store_journal_reset() {
     FBW_APPEND_PROMOTE_JOURNAL.with(|j| j.borrow_mut().clear());
     FBW_CELL_STORE_JOURNAL.with(|j| j.borrow_mut().clear());
     FBW_SYS_EXC_JOURNAL.with(|j| j.borrow_mut().clear());
+    FBW_TRACEBACK_STORE_JOURNAL.with(|j| *j.borrow_mut() = None);
     FBW_UNJOURNALED_VALUE_UNAVAILABLE.with(|c| c.set(false));
     FBW_UNJOURNALED_SYMBOLIC.with(|c| c.set(false));
     FBW_EXECUTED_RESIDUAL_VOID.with(|c| c.set(0));
@@ -464,6 +465,47 @@ pub(crate) fn fbw_sys_exc_journal_push(displaced: pyre_object::PyObjectRef) {
     FBW_SYS_EXC_JOURNAL.with(|j| j.borrow_mut().push(displaced));
 }
 
+/// Read an exception's concrete traceback head before a bridge-entry recording
+/// helper runs.  `None` means the concrete is not an exception and therefore
+/// cannot receive a host-side attach.
+pub(crate) fn fbw_traceback_journal_head(
+    exception: pyre_object::PyObjectRef,
+) -> Option<pyre_object::PyObjectRef> {
+    if exception.is_null() || unsafe { !pyre_object::is_exception(exception) } {
+        return None;
+    }
+    Some(unsafe { pyre_object::interp_exceptions::w_exception_get_traceback(exception) })
+}
+
+/// Journal the node a bridge-entry recording helper concretely prepended.
+/// An unchanged head means the helper declined the host attach.
+pub(crate) fn fbw_traceback_journal_push_if_attached(
+    exception: pyre_object::PyObjectRef,
+    previous_head: Option<pyre_object::PyObjectRef>,
+) {
+    let Some(previous_head) = previous_head else {
+        return;
+    };
+    let node = unsafe { pyre_object::interp_exceptions::w_exception_get_traceback(exception) };
+    if node == previous_head {
+        return;
+    }
+    debug_assert!(!node.is_null());
+    debug_assert!(unsafe { pyre_interpreter::pytraceback::is_pytraceback(node) });
+    debug_assert_eq!(
+        unsafe { pyre_interpreter::pytraceback::w_pytraceback_get_w_next(node) },
+        previous_head
+    );
+    FBW_TRACEBACK_STORE_JOURNAL.with(|j| {
+        let mut entry = j.borrow_mut();
+        assert!(
+            entry.is_none(),
+            "bridge-entry traceback attach ran more than once in one walk session"
+        );
+        *entry = Some((exception, node));
+    });
+}
+
 /// Commit-path epilogue: the walk's eager stores and appends stand; drop
 /// the undo logs.
 pub(crate) fn fbw_store_journal_commit() {
@@ -475,6 +517,9 @@ pub(crate) fn fbw_store_journal_commit() {
     // trace or the adopted end state carries the same exception state), so
     // drop the undo log without re-applying it.
     FBW_SYS_EXC_JOURNAL.with(|j| j.borrow_mut().clear());
+    // The compiled trace owns the recorded attach and the authoritative walk
+    // already applied this iteration's concrete node, so keep it in place.
+    FBW_TRACEBACK_STORE_JOURNAL.with(|j| *j.borrow_mut() = None);
     // #57 Option C: a committed walk's end-flush adopts the advanced
     // iterator + the body that consumed it (counted once), so the in-flight
     // items must NOT also be delivered — drop the stash (and with it the
@@ -904,6 +949,22 @@ pub(crate) fn fbw_store_journal_rollback() {
         let mut entries = j.borrow_mut();
         while let Some(displaced) = entries.pop() {
             pyre_interpreter::eval::set_current_exception(displaced);
+        }
+    });
+    // Remove the bridge-entry node only while it remains the exact head the
+    // recording helper installed.  If later concrete execution replaced the
+    // head, discarding this walk must not overwrite that newer state.
+    FBW_TRACEBACK_STORE_JOURNAL.with(|j| {
+        let Some((exception, node)) = j.borrow_mut().take() else {
+            return;
+        };
+        let current =
+            unsafe { pyre_object::interp_exceptions::w_exception_get_traceback(exception) };
+        if current == node {
+            let previous = unsafe { pyre_interpreter::pytraceback::w_pytraceback_get_w_next(node) };
+            unsafe {
+                pyre_object::interp_exceptions::w_exception_set_traceback(exception, previous);
+            }
         }
     });
 }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -10243,37 +10243,16 @@ fn handle<Sym: WalkSym>(
                             op.next_pc,
                         ));
                     }
-                    // The jump did not take. Closing here anyway lands on
-                    // `compile_loop`'s own `has_compiled_targets` check
-                    // (pyjitpl.py:3185-3189), which gives the whole trace up
-                    // with SwitchToBlackhole; and the cut would store the loop
-                    // under `cut_inner_green_key`, replacing reachable code
-                    // with code stored where nothing enters. Keep tracing
-                    // instead, so the trace closes at its own header with this
-                    // loop's body inlined — the interpreter front end declines
-                    // the same case for the same reason. Only a cross-loop cut
-                    // is declined: a trace that started at these greens still
-                    // closes on its own back-edge below.
-                    // One decline is not a plain "keep tracing": compile.py:1079
-                    // `metainterp.retrace_needed` leaves `partial_trace` and
-                    // `retracing_from` pointing at this header's position. The
-                    // return below skips the merge-point registration further
-                    // down, so the later close at the root header would compare
-                    // the root merge point against a `retracing_from` no merge
-                    // point was ever recorded for, and abort instead of
-                    // retracing. `has_partial` was false above, so a partial
-                    // trace here is the one this attempt just requested.
-                    let retrace_requested = driver.meta_interp().partial_trace().is_some();
-                    if !retrace_requested && key != ctx.trace_ctx.root_green_key() {
-                        if majit_metainterp::majit_log_enabled() {
-                            eprintln!(
-                                "[jit][walker-reached-loop-header] merge point pc={} already \
-                                 has a compiled loop key={} — declining the cross-loop cut",
-                                next_instr, key
-                            );
-                        }
-                        return Ok((DispatchOutcome::Continue, op.next_pc));
-                    }
+                    // The jump did not take (`compile.compile_trace` returns
+                    // None when none of the existing loop tokens match). Fall
+                    // through to the merge-point scan below, exactly as
+                    // `reached_loop_header` does after its own
+                    // `self.compile_trace(...)` call returns (pyjitpl.py:3003-3018):
+                    // the scan closes at the first same-greenkey merge point, and
+                    // `compile_loop` gives that trace up at its own
+                    // `has_compiled_targets` (pyjitpl.py:3185-3189); a first visit
+                    // registers a merge point (pyjitpl.py:3057-3059) and keeps
+                    // tracing.
                 }
             }
 

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -4968,6 +4968,18 @@ thread_local! {
     static FBW_SYS_EXC_JOURNAL: std::cell::RefCell<Vec<pyre_object::PyObjectRef>> =
         const { std::cell::RefCell::new(Vec::new()) };
 
+    /// Undo entry for the concrete traceback-head store performed while a
+    /// bridge-entry exception arm is recorded: `(exception, attached_node)`.
+    /// The two arms are mutually exclusive and each is entered at most once
+    /// per walk session, so one slot covers the concrete attach.  It shares
+    /// the store journal's lifecycle: a committing walk keeps the node and
+    /// clears the entry, while a discarded walk removes the node only when it
+    /// is still the exception's current traceback head.  Both refs are GC
+    /// roots via [`fbw_store_journal_root_walker`].
+    static FBW_TRACEBACK_STORE_JOURNAL:
+        std::cell::RefCell<Option<(pyre_object::PyObjectRef, pyre_object::PyObjectRef)>> =
+        const { std::cell::RefCell::new(None) };
+
     /// In-flight FOR_ITER continuation (#57 Option C): `(consumed_item,
     /// body coordinate)` stashed when the FOR_ITER `for_iter_next` residual
     /// ([`PyreHelperKind::ForIterNext`]) runs concretely on the
@@ -5156,6 +5168,8 @@ struct FbwStoreJournalRootArea {
     abort_overrides: *const std::cell::RefCell<Vec<(usize, pyre_object::PyObjectRef)>>,
     cell_stores: *const std::cell::RefCell<Vec<(pyre_object::PyObjectRef, i64)>>,
     sys_exc: *const std::cell::RefCell<Vec<pyre_object::PyObjectRef>>,
+    traceback_store:
+        *const std::cell::RefCell<Option<(pyre_object::PyObjectRef, pyre_object::PyObjectRef)>>,
     foriter: *const std::cell::RefCell<Vec<InflightForiter>>,
     bridge_iter: *const std::cell::RefCell<Vec<(pyre_object::PyObjectRef, i64, i64)>>,
     abort_resume: *const std::cell::RefCell<Option<InlineAbortCarrier>>,
@@ -5173,6 +5187,7 @@ thread_local! {
         abort_overrides: FBW_ABORT_OUTER_STACK_OVERRIDES.with(|value| value as *const _),
         cell_stores: FBW_CELL_STORE_JOURNAL.with(|value| value as *const _),
         sys_exc: FBW_SYS_EXC_JOURNAL.with(|value| value as *const _),
+        traceback_store: FBW_TRACEBACK_STORE_JOURNAL.with(|value| value as *const _),
         foriter: FBW_FORITER_INFLIGHT.with(|value| value as *const _),
         bridge_iter: FBW_BRIDGE_ITER_JOURNAL.with(|value| value as *const _),
         abort_resume: FBW_ABORT_CALL_RESUME.with(|value| value as *const _),
@@ -5476,6 +5491,14 @@ pub unsafe fn fbw_store_journal_root_walker_area(
         // SAFETY: `PyObjectRef` and `GcRef` share the usize repr; the
         // borrowed area keeps the Vec storage alive for the visit.
         visitor(unsafe { &mut *(displaced as *mut pyre_object::PyObjectRef).cast() });
+    }
+    // The exception and freshly attached traceback node remain live until the
+    // walk commits or rolls back.  The entry may be their only scanned owner
+    // after later concrete execution changes the exception's head.
+    let traceback_store = unsafe { &mut *(*area.traceback_store).as_ptr() };
+    if let Some((exception, node)) = traceback_store.as_mut() {
+        visitor(unsafe { &mut *(exception as *mut pyre_object::PyObjectRef).cast() });
+        visitor(unsafe { &mut *(node as *mut pyre_object::PyObjectRef).cast() });
     }
     // #57 Option C: each captured in-flight FOR_ITER item is nursery-resident
     // across the rest of the walk (subsequent residual calls allocate and a

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -10253,6 +10253,7 @@ fn handle<Sym: WalkSym>(
                     // `has_compiled_targets` (pyjitpl.py:3185-3189); a first visit
                     // registers a merge point (pyjitpl.py:3057-3059) and keeps
                     // tracing.
+                    majit_metainterp::mc_diag_bump(27);
                 }
             }
 

--- a/pyre/pyre-wasm-runner/src/main.rs
+++ b/pyre/pyre-wasm-runner/src/main.rs
@@ -476,6 +476,12 @@ fn run(module_path: &PathBuf, source: &str) -> Result<i32> {
                 "accepted_ca",
                 "decl_ca_trampoline",
                 "forced_ca_terminal_decline",
+                "ml_no_descr",
+                "ml_unpublished",
+                "pub_peeled",
+                "pub_flat",
+                "pub_flat_skipped",
+                "label_retracted",
             ];
             let mut parts = Vec::new();
             for (i, lbl) in labels.iter().enumerate() {
@@ -563,6 +569,13 @@ fn run(module_path: &PathBuf, source: &str) -> Result<i32> {
                 "stfe_dead_token",
                 "stfe_tick",
                 "toolong_suppressed",
+                "wct_declined",
+                "cl_hct_giveup",
+                "ct_no_front_token",
+                "ct_origin_loop_gone",
+                "ct_entry_bridge_failed",
+                "ct_no_entry_data",
+                "ct_not_tracing",
             ];
             let mut parts = Vec::new();
             for (i, lbl) in labels.iter().enumerate() {

--- a/pyre/pyrex/src/lib.rs
+++ b/pyre/pyrex/src/lib.rs
@@ -976,30 +976,12 @@ fn maybe_print_jit_stats() {
     eprintln!("[jit-stats] {}", pyre_jit::field_position_jit_stats());
 }
 
-/// Names for the `MC_DIAG` tallies, in index order. Mirrors the legend on
-/// `majit_metainterp::MC_DIAG` and the labels the wasm runner prints for the
-/// `pyre_jit_mc_diag` export, so a native run and a wasm run of the same
-/// program are diffable field by field.
-const MC_DIAG_FIELDS: [&str; 18] = [
-    "mc_entered",
-    "decl_shortcircuit",
-    "descr0_skip",
-    "busy_skip",
-    "FIRED",
-    "stack_full",
-    "retrace_entered",
-    "retrace_bailed",
-    "cb_entered",
-    "cb_invalidloop",
-    "cb_retrace_req",
-    "cb_arity_giveup",
-    "sbt_entered",
-    "sbt_not_faildescr",
-    "sbt_no_jct",
-    "sbt_no_meta",
-    "sbt_cant_trace",
-    "sbt_short_vals",
-];
+/// Names for the `MC_DIAG` tallies, in index order — the array
+/// `majit_metainterp` declares beside the counters themselves, so a slot cannot
+/// be added there and go unnamed here. The wasm runner prints the same names for
+/// the `pyre_jit_mc_diag` export, making a native run and a wasm run of the same
+/// program diffable field by field.
+use majit_metainterp::MC_DIAG_LABELS as MC_DIAG_FIELDS;
 
 /// Print the guard-failure → bridge-trace gate tallies. Until this existed the
 /// counters were bumped on every backend but only readable through the wasm


### PR DESCRIPTION
Eight commits on top of `main`, all in the bridge-compilation path. The last two
are the substantive ones; the first six were landed earlier on this branch and
are carried across the rebase.

## `jit(fbw)`: the catching frame's traceback node at a bridge handler entry

Wrong output in shipped binaries on both backends, not just a missed
optimization.

Seven walker paths enter an `except` handler. The five in-trace ones record a
traceback node for the catching frame; the two in `dispatch_via_miframe` — the
exception-edge arm and the carrier-raise-seed arm — called
`vstack_enter_exception_handler` with no record at all. On the bridge leg the
raising callee runs as real frames, so its nodes are attached by the interpreted
raise machinery, but the catching frame is the compiled one and its node exists
only if the trace records it. A handler reading `__traceback__` saw a chain
whose head was the callee frame. `pyopcode.py` runs
`record_application_traceback` before `lookup_exceptiontable` routes to the
handler.

Both arms now record the same triple. The concrete leg of that record mutates
the live exception, and a walk that is later discarded would leave the mutation
behind while the metainterp's own delivery attaches the node again — the
doubled head observed on `gc_bug_bridge_flavor_traceback_names`. So the attach
is journalled: the arm records `(exception, node)` in a slot sharing the store
journal's lifecycle, the rollback epilogues restore
`exception.w_traceback = node.tb_next` while that node is still the head, and
the commit path clears the slot without applying it. Both refs are GC roots
through the existing store-journal root walker.

`synth/exception_bridge_traceback_head.py` pins the head frame name for two
exception classes raised into one hot try. It reads the traceback inline, so it
does not depend on the callee-inline gates.

## `jit(fbw)`: hoist the inline caller-frame catch-marker decline

The decline was decided after the callee frame had been seeded and IR recorded.
Deciding it from the same caller payload before the `'seed` block removes the
half-built state; the post-seed arm is now `unreachable!`.
`exception_traceback_frame_lineno`: `loops_aborted 7 -> 2`, `loops_compiled
12 -> 13`.

## Carried commits

* `jit(cranelift)`: drop the Float-at-Ref-inputarg bail from the bridge ref-root
  scan, and build the ref-root list from the declared inputarg types alone.
* `jit(metainterp)`: key `compile_loop`'s `has_compiled_targets` check to the
  closed merge point; scope the end-of-`JUMP` Ref check to the traces whose
  inputargs the `JUMP` writes into.
* `jit`: let the walker fall through to the merge-point scan when
  `compile_trace` declines.
* `bench`: re-record the `.jitstats` baselines on both backends.

## Verification

Rebased onto `main` after #886 and #876 landed, LLBC re-extracted, both backends
rebuilt.

* 17 traceback/exception fixtures x 2 backends x 3 runs, diffed against
  `PYRE_JIT=off`: 0 diverged, no crashes. Includes
  `exception_traceback_frame_lineno` (the indicator #886 names) and
  `exc_caught_in_callee_return_loop` (a shape #886 newly routes through the
  exception-edge arm), plus `str_search_index_bounds`.
* `cargo test` on `pyre-jit-trace`, `pyre-jit`, `majit-metainterp`: 0 failed.
* `check.py --snapshot-diff`: 73 failed / 270 passed on both backends, the same
  count `main` produces on this host. The local `bench/synth/*.jitstats` are
  untracked scratch from a pre-rebase run, so those diffs are not attributable
  on their own. Measured directly instead, by reverting this branch's `.rs`
  files to `main` and rebuilding: of the 11 benches reporting a `loops_aborted`
  regression, 10 read identically on `main`, and
  `exception_try_call_inlined_callee_raise` goes 4 -> 1 on this branch. No
  `loops_aborted` regression originates here.
* Of the 9 tracked baselines, 8 match exactly; `const_arg_call_resume` reads
  `guard_failures` 1805 against a recorded 1804, the build-sensitive +/-1 noted
  in the re-record commit. It is not a badness field and does not gate a plain
  run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved JIT loop and bridge handling, reducing incorrect type mismatches and allowing declined optimizations to continue through normal compilation.
  - Improved exception traceback restoration when speculative execution is rolled back.
  - Added clearer handling for cancelled or unsuccessful compilation attempts.

- **New Features**
  - Added a benchmark covering nested exception handling and traceback reporting.

- **Diagnostics**
  - Expanded runtime and benchmark statistics to report descriptor resolution, bridge compilation, guard failures, and aborted loops more consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->