### PR TITLE
majit: reserve the header word in front of off-GC jitframes

### DIFF
--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -3779,10 +3779,11 @@ pub unsafe extern "C" fn cranelift_realloc_frame(old_jf: *mut i64, new_depth: us
             gcref.0 as *mut i64
         }
         None => {
-            let layout = std::alloc::Layout::from_size_align(new_bytes, 8)
-                .expect("cranelift_realloc_frame: invalid layout");
-            let p = unsafe { std::alloc::alloc_zeroed(layout) as *mut i64 };
-            assert!(!p.is_null(), "cranelift_realloc_frame: alloc_zeroed failed");
+            // Reserves the header word the emitted write-barrier fast path
+            // reads at a negative offset, so this frame answers that read the
+            // way the nursery-allocated one above does.
+            let p = majit_backend::jitframe::alloc_off_gc_jitframe(new_bytes) as *mut i64;
+            assert!(!p.is_null(), "cranelift_realloc_frame: alloc failed");
             // Host-test fallback only — register with the libc-jitframe
             // tracer so any interior Ref scan still works.
             majit_gc::shadow_stack::register_libc_jitframe(p as usize);
@@ -7260,8 +7261,14 @@ fn run_compiled_code_inner(
         }
         (gcref, None)
     } else {
-        let mut buf = vec![0i64; jf_total];
-        let gcref = GcRef(buf.as_mut_ptr() as usize);
+        // One leading word stands in for the GcHeader the nursery branch
+        // above puts in front of the frame: the emitted write-barrier fast
+        // path loads the flag byte at a negative offset from the frame
+        // pointer, so without it that load reads outside the buffer.
+        const HEADER_WORDS: usize = majit_gc::header::GcHeader::SIZE / 8;
+        const _: () = assert!(HEADER_WORDS * 8 == majit_gc::header::GcHeader::SIZE);
+        let mut buf = vec![0i64; HEADER_WORDS + jf_total];
+        let gcref = GcRef(unsafe { buf.as_mut_ptr().add(HEADER_WORDS) } as usize);
         // jitframe.py:84 parity — `jf_frame.length` is the count of `Signed`
         // payload slots after the length word.  The GC-alloc branch above
         // already does this at line 6282; mirror it here so frame-size

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -862,7 +862,7 @@ pub extern "C" fn dynasm_nursery_slowpath_jitframe(frame_size: u64) -> u64 {
             gc.alloc_nursery(frame_size as usize).0 as u64
         }
     })
-    .unwrap_or_else(|| unsafe { libc::calloc(1, frame_size as usize) as u64 })
+    .unwrap_or_else(|| majit_backend::jitframe::alloc_off_gc_jitframe(frame_size as usize) as u64)
 }
 
 /// `_build_malloc_slowpath(kind='var')` parity: varsize nursery
@@ -1152,8 +1152,8 @@ pub unsafe extern "C" fn dynasm_realloc_frame(
             old_jf,
             expected_depth,
             base_ofs,
-            // `alloc`: libc::calloc to match the runner-allocated frame.
-            |size_bytes| libc::calloc(1, size_bytes as usize) as *mut JitFrame,
+            // `alloc`: off-GC, header-reserving, to match the runner-allocated frame.
+            |size_bytes| majit_backend::jitframe::alloc_off_gc_jitframe(size_bytes as usize),
             // `write_barrier`: register the new frame with the shadow
             // stack tracer.  The old frame stays registered for the
             // duration of the running call; `jf_forward` is followed
@@ -1773,7 +1773,8 @@ impl DynasmBackend {
         while !cur.is_null() {
             let next = unsafe { (*cur).jf_forward };
             majit_gc::shadow_stack::unregister_libc_jitframe(cur as usize);
-            unsafe { libc::free(cur as *mut std::ffi::c_void) };
+            // Frees the block base, which sits one header word behind `cur`.
+            unsafe { majit_backend::jitframe::free_off_gc_jitframe(cur) };
             cur = next;
         }
     }
@@ -2587,8 +2588,9 @@ impl Backend for DynasmBackend {
             Self::input_slot(args.len()),
             args.len()
         );
-        let jf_ptr = unsafe { libc::calloc(1, JitFrame::alloc_size(num_slots)) as *mut JitFrame };
-        assert!(!jf_ptr.is_null(), "execute_token: calloc failed");
+        let jf_ptr =
+            majit_backend::jitframe::alloc_off_gc_jitframe(JitFrame::alloc_size(num_slots));
+        assert!(!jf_ptr.is_null(), "execute_token: frame allocation failed");
         unsafe { JitFrame::init(jf_ptr, fi_ptr, num_slots) };
         // Register this libc-allocated jitframe with the GC so its
         // interior Ref slots (pinned by gcmap bits) remain visible to
@@ -2770,8 +2772,12 @@ impl Backend for DynasmBackend {
             Self::input_slot(args.len()),
             args.len()
         );
-        let jf_ptr = unsafe { libc::calloc(1, JitFrame::alloc_size(num_slots)) as *mut JitFrame };
-        assert!(!jf_ptr.is_null(), "execute_token_ints_raw: calloc failed");
+        let jf_ptr =
+            majit_backend::jitframe::alloc_off_gc_jitframe(JitFrame::alloc_size(num_slots));
+        assert!(
+            !jf_ptr.is_null(),
+            "execute_token_ints_raw: frame allocation failed"
+        );
         unsafe { JitFrame::init(jf_ptr, fi_ptr, num_slots) };
         // Same registration as `execute_token` above: the libc-allocated
         // jitframe must be visible to the minor-collection walker so its

--- a/majit/majit-backend/src/jitframe.rs
+++ b/majit/majit-backend/src/jitframe.rs
@@ -181,6 +181,82 @@ pub const UNSIGN_SIZE: usize = std::mem::size_of::<usize>();
 // jitframe.py:138
 pub type JitFramePtr = *mut JitFrame;
 
+/// An off-GC jitframe's block starts with the total size, so the frame
+/// pointer alone is enough to free it, and then the header word the JIT's
+/// negative reads land in. See [`alloc_off_gc_jitframe`].
+///
+/// ```text
+///   base            base+8            base+16 == the frame pointer
+///   [ total size ]  [ header word ]   [ JitFrame … ]
+/// ```
+const OFF_GC_SIZE_SLOT: usize = majit_gc::header::GcHeader::SIZE;
+const OFF_GC_HEADER: usize = majit_gc::header::GcHeader::SIZE;
+const OFF_GC_PREFIX: usize = OFF_GC_SIZE_SLOT + OFF_GC_HEADER;
+const _: () = assert!(OFF_GC_SIZE_SLOT >= std::mem::size_of::<u64>());
+
+fn off_gc_layout(total: usize) -> Option<std::alloc::Layout> {
+    std::alloc::Layout::from_size_align(total, majit_gc::header::GcHeader::SIZE).ok()
+}
+
+/// Allocate a JITFRAME outside the GC, with the header word in front of it.
+///
+/// `jitframe.py:48` allocates every frame through the GC, so upstream's
+/// compiled code always holds a frame that has a header behind it. Pyre also
+/// builds frames off the GC — the runner's entry frame, the realloc slowpath,
+/// and the JITFRAME nursery slowpath's fallback, the class
+/// `shadow_stack::register_libc_jitframe` tracks — and compiled code cannot
+/// tell the two apart. `_reload_frame_if_necessary`
+/// (`aarch64/assembler.py:967-980`) re-applies the non-array write-barrier
+/// fast path to the current frame after every collecting call, and that fast
+/// path loads the flag byte at `jit_wb_if_flag_byteofs`, which is *negative*
+/// (`gc.py:285-293` measures it from the object pointer, and the flags sit in
+/// the header at `obj-4`).
+///
+/// Handing out a bare allocation base therefore puts that load outside the
+/// block: usually it reads unrelated bytes and, when they happen to carry
+/// TRACK_YOUNG_PTRS, enters the barrier helper for nothing; when the block
+/// lands at the start of a mapped region it faults outright. Reserving the
+/// header word makes the read in-bounds, and the zeroed flags give it the
+/// same answer a freshly nursery-allocated frame gives — no barrier.
+///
+/// Returns null when the allocation fails.
+pub fn alloc_off_gc_jitframe(size_bytes: usize) -> *mut JitFrame {
+    let Some(total) = OFF_GC_PREFIX.checked_add(size_bytes) else {
+        return std::ptr::null_mut();
+    };
+    let Some(layout) = off_gc_layout(total) else {
+        return std::ptr::null_mut();
+    };
+    let base = unsafe { std::alloc::alloc_zeroed(layout) };
+    if base.is_null() {
+        return std::ptr::null_mut();
+    }
+    unsafe {
+        *(base as *mut u64) = total as u64;
+        base.add(OFF_GC_PREFIX) as *mut JitFrame
+    }
+}
+
+/// Release a frame from [`alloc_off_gc_jitframe`].
+///
+/// The frame pointer is not the block base — the size slot and the header word
+/// precede it — so this must be used instead of freeing the frame pointer.
+///
+/// # Safety
+/// `frame` must have come from [`alloc_off_gc_jitframe`] and must no longer be
+/// reachable from compiled code or the shadow stack.
+pub unsafe fn free_off_gc_jitframe(frame: *mut JitFrame) {
+    if frame.is_null() {
+        return;
+    }
+    unsafe {
+        let base = (frame as *mut u8).sub(OFF_GC_PREFIX);
+        let total = *(base as *const u64) as usize;
+        let layout = off_gc_layout(total).expect("off-GC jitframe size slot was corrupted");
+        std::alloc::dealloc(base, layout);
+    }
+}
+
 // ── JitFrame methods ────────────────────────────────────────────────
 
 impl JitFrame {
@@ -443,5 +519,39 @@ where
         write_barrier(new_jf);
 
         new_jf
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The emitted write-barrier fast path loads one byte at
+    /// `jit_wb_if_flag_byteofs` from the frame pointer, and that offset is
+    /// negative. An off-GC frame must answer that load the way a nursery
+    /// frame does — in-bounds, and with the flag clear so the barrier helper
+    /// is not entered — which is the whole reason `alloc_off_gc_jitframe`
+    /// reserves a header word instead of handing out the block base.
+    #[test]
+    fn off_gc_jitframe_reserves_the_negative_flag_byte() {
+        let descr = majit_gc::WriteBarrierDescr::for_current_gc();
+        assert!(
+            descr.jit_wb_if_flag_byteofs < 0,
+            "the flag byte is expected behind the object pointer"
+        );
+        assert!(
+            (-descr.jit_wb_if_flag_byteofs) as usize <= majit_gc::header::GcHeader::SIZE,
+            "the reserved header word must cover the flag byte offset"
+        );
+
+        let frame = alloc_off_gc_jitframe(JitFrame::alloc_size(8));
+        assert!(!frame.is_null());
+        let flag = unsafe { *(frame as *const u8).offset(descr.jit_wb_if_flag_byteofs as isize) };
+        assert_eq!(
+            flag & descr.jit_wb_if_flag_singlebyte,
+            0,
+            "a fresh off-GC frame must not look like it tracks young pointers"
+        );
+        unsafe { free_off_gc_jitframe(frame) };
     }
 }

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -3256,18 +3256,18 @@ impl MiniMarkGC {
     /// non-array COND_CALL_GC_WB helper calls. `_reload_frame_if_necessary`
     /// (aarch64/assembler.py:967-980) re-applies the non-array barrier fast
     /// path to the *current jitframe* after every collecting helper call.
-    /// Most jitframes are nursery-allocated and carry a GcHeader, but not
-    /// all: the JITFRAME slow path falls back to `libc::calloc` when no
-    /// allocator is active, and CALL_ASSEMBLER builds some callee frames the
-    /// same way — the class `shadow_stack::register_libc_jitframe` exists to
-    /// track. Those have no GcHeader, so the inline flag test reads
-    /// `jit_wb_if_flag_byteofs` (negative, where a header would be) out of
-    /// bytes whose contents are unspecified. When they happen to carry
-    /// TRACK_YOUNG_PTRS' bit the helper is entered in earnest, and only
-    /// `is_managed_heap_object` keeps the unmanaged block out of
-    /// `remembered_set`, where the next minor would decode a type id from it.
-    /// `write_barrier_ignores_unmanaged_jitframe_with_flag_byte_set` pins
-    /// that case.
+    /// Not every jitframe is nursery-allocated: the runner's entry frame, the
+    /// realloc slowpath, and the JITFRAME nursery slowpath's fallback build
+    /// frames off the GC — the class `shadow_stack::register_libc_jitframe`
+    /// exists to track. Those go through `jitframe::alloc_libc_jitframe`,
+    /// which reserves a zeroed header word so the inline test's read at
+    /// `jit_wb_if_flag_byteofs` (negative, where a header would be) stays
+    /// inside the allocation and finds the flag clear. Reaching this helper
+    /// with such a frame therefore takes a set flag bit the allocator did not
+    /// write; `is_managed_heap_object` is what still keeps the unmanaged block
+    /// out of `remembered_set`, where the next minor would decode a type id
+    /// from it. `write_barrier_ignores_unmanaged_jitframe_with_flag_byte_set`
+    /// pins that case.
     pub fn do_write_barrier(&mut self, obj: GcRef) {
         // incminimark's write_barrier receives a typed, non-null struct pointer.
         // pyre's GcRef is nullable (GcRef::NULL is the sentinel) and reaches the
@@ -5150,21 +5150,20 @@ mod tests {
         // plain COND_CALL_GC_WB on the frame reaches the generic barrier at
         // runtime.
         //
-        // A jitframe that came from the `libc::calloc` fallback rather than
-        // the nursery has no GcHeader, so the byte the inline test reads
-        // (`jit_wb_if_flag_byteofs`, negative — where a header would be) is
-        // not a header and its contents are unspecified. Whether it carries
-        // TRACK_YOUNG_PTRS' bit is a property of the host allocator and the
-        // heap's history, so the bit is set by hand here rather than waited
-        // for. Without the `is_managed_heap_object` guard in
-        // `do_write_barrier`, that block would enter `remembered_set` and the
-        // next minor would decode a type id from those bytes.
+        // A jitframe allocated off the GC is not in any managed generation,
+        // so the word in front of it is not a header this collector owns.
+        // `jitframe::alloc_libc_jitframe` keeps that word reserved and zeroed,
+        // which is what stops the inline test from entering the helper at all;
+        // this test covers the residue — the helper being entered anyway, with
+        // the flag bit set, for a block the GC does not manage. Without the
+        // `is_managed_heap_object` guard in `do_write_barrier`, that block
+        // would enter `remembered_set` and the next minor would decode a type
+        // id from those bytes.
         let mut gc = test_gc(1024);
 
-        // Same shape the JITFRAME slow path calloc's: the fixed `JitFrame`
-        // words plus the trailing slot array, zero-filled. One extra leading
-        // word keeps the negative flag-byte read inside this allocation,
-        // standing in for whatever precedes a real malloc'd frame.
+        // Same shape the off-GC jitframe allocator produces: one reserved
+        // leading word, then the fixed `JitFrame` words plus the trailing slot
+        // array, zero-filled.
         let slots = 32usize;
         let frame_size = std::mem::size_of::<usize>() * (7 + 1 + slots);
         let layout =

--- a/pyre/cpython_tests/run.py
+++ b/pyre/cpython_tests/run.py
@@ -52,6 +52,7 @@ import argparse
 import concurrent.futures
 import json
 import os
+import signal
 import subprocess
 import sys
 import tempfile
@@ -129,6 +130,29 @@ def jit_panic_reason(stderr: str) -> str | None:
     return None
 
 
+def last_stderr_line(err: str) -> str:
+    """The last non-empty stderr line — the only evidence a dying run leaves."""
+    for line in reversed(err.splitlines()):
+        if line.strip():
+            return line.strip()
+    return ""
+
+
+def death_signal(rc: int) -> str:
+    """`SIGBUS` for a run killed by a signal, else a bare return code.
+
+    POSIX `subprocess` reports a signal death as a negative return code; a
+    shell-mediated one arrives as 128+n. Naming the signal is what separates
+    "the interpreter faulted" from "the interpreter aborted an assertion",
+    and those two want completely different investigations.
+    """
+    num = -rc if rc < 0 else rc - 128
+    try:
+        return signal.Signals(num).name
+    except ValueError:
+        return f"rc={rc}"
+
+
 def classify(rc: int, out: str, err: str) -> tuple[str, str]:
     """Map a finished run to (status, detail).
 
@@ -142,14 +166,15 @@ def classify(rc: int, out: str, err: str) -> tuple[str, str]:
     if panic:
         return "CRASH", panic
     if rc < 0 or rc > 128:
-        return "CRASH", f"signal/abort rc={rc}"
+        # Keep the stderr tail. A signal death is precisely the case where no
+        # test framework got to report anything, so the last line the
+        # interpreter wrote is all the evidence there is — and dropping it
+        # left CI runs that could only be re-run, never diagnosed.
+        detail = f"signal/abort {death_signal(rc)} rc={rc} {last_stderr_line(err)}"
+        return "CRASH", detail.strip()[:200]
     if rc == 0:
         return "PASS", ""
-    last = ""
-    for line in reversed(err.splitlines()):
-        if line.strip():
-            last = line.strip()
-            break
+    last = last_stderr_line(err)
     ran = "Ran " in out or "Ran " in err or "FAILED (" in out or "FAILED (" in err
     # A module that bails with unittest.SkipTest before any test runs is
     # opting out (a missing optional C extension or wrong platform) — CPython


### PR DESCRIPTION
## What

The emitted `COND_CALL_GC_WB` fast path loads the flag byte at `jit_wb_if_flag_byteofs`. `WriteBarrierDescr::extract_flag_byte` measures that offset **from the object pointer**, so it is negative — the flags are the high half of `tid_and_flags`, at `obj-4`.

Frames built outside the GC were handed to compiled code as bare allocation bases, which puts that load in front of the allocation. Usually it reads unrelated bytes and enters the barrier helper for nothing whenever they happen to carry `TRACK_YOUNG_PTRS`; when the block lands at the start of a mapped region, the load faults.

`majit_backend::jitframe::alloc_libc_jitframe` now allocates `GcHeader::SIZE + size` and returns the payload with the header word zeroed — the same thing a nursery-allocated frame presents to that load — and `free_libc_jitframe` releases the matching base.

## Call sites

Six, not the nine `libc::calloc` sites in `runner.rs`. `dynasm_nursery_slowpath`, `..._varsize`, `dynasm_raw_varsize_alloc_typed_and_set_len` and `dynasm_raw_fixedsize_alloc_typed` already allocate `+ GcHeader::SIZE` and return `raw + gc_hdr`; `..._headerless` is headerless by contract. The ones handing out a *jitframe* were the gap:

| site | note |
| --- | --- |
| `DynasmBackend::execute_token` | **production** — every JIT entry frame |
| `DynasmBackend::execute_token_ints_raw` | **production** |
| `dynasm_realloc_frame` | frame-realloc slowpath |
| `dynasm_nursery_slowpath_jitframe` fallback | no-GC path |
| `cranelift_realloc_frame` fallback | host-test path |
| cranelift `run_compiled_code_inner` `vec![0i64; …]` | host-test path |

`free_jitframe_chain` moves to the paired free: the frame pointer is no longer the block base.

Alignment is unaffected — `collector.rs` rounds allocations to 8 (`(total_size + 7) & !7`), so a GC frame's payload is 8-aligned too; `base + 8` matches it rather than degrading it.

## Verification

- 800-seed 8-way `test_strtod` load sweep: **0 hits**. Prior baseline on the same script was ~3 hits per 400 seeds (all `rc=138`, SIGBUS), so `P(0 hits | unfixed) ≈ e⁻⁶`.
- Three macOS `.ips` crash reports for those hits agreed exactly: `fault == fp - 4`, `fp` at the start of a `MALLOC_SMALL` region, `sp` in an unrelated range (not a stack overflow), `pc` outside every `usedImage` (JIT-generated code), `KERN_PROTECTION_FAILURE`.
- `majit-backend` 15, `majit-gc` 213, `majit-backend-dynasm` 59 tests green.
- New regression test `jitframe::tests::libc_jitframe_reserves_the_negative_flag_byte` pins that the flag byte is in-bounds and clear.

The hazard was already half-documented at `collector.rs:3254-3270`, and `write_barrier_ignores_unmanaged_jitframe_with_flag_byte_set` covered the case where the out-of-bounds read *succeeds* and returns garbage. Nothing covered it faulting; that test even reserved a leading word by hand, which production did not. Both comments are updated to match.

## Second commit

`cpython_tests/run.py` `classify()` discarded stderr entirely for `rc < 0 or rc > 128`, so a signal death recorded no evidence at all while the FAIL path kept the last non-empty line. It now shares that line and decodes the signal: `signal/abort SIGBUS rc=-10 <last stderr line>`.

Seeding was deliberately not added: this failure is load-driven (a failing seed replayed alone always passes), and every way to seed a script-mode child perturbs what the suite sees — `sitecustomize` needs the temp cwd on `PYTHONPATH` (`test_site`, `test_cmd_line`), and a driver wrapper changes `__main__` identity, which is exactly why `DOTTED_IDENTITY_MODULES` exists. `--mode regrtest` is the non-perturbing route if seeds are ever wanted.

— *authored by Claude*