### PR TITLE
jit: run a tracing abort through convert_and_run_from_pyjitpl; gate write barriers on the collector's descriptor

### DIFF
--- a/.github/workflows/pyre-ci.yml
+++ b/.github/workflows/pyre-ci.yml
@@ -443,6 +443,17 @@ jobs:
       # `cargo test --all` job cannot: it never builds those artifacts.
       if: runner.os == 'Linux'
       run: cargo test -p majit-backend-wasm --test codegen_test -- --ignored
+    - name: Run release-only dispatcher-graph acceptance test (Linux only)
+      # `slow_generated_jitcodes_preserve_complete_dispatcher_graph` self-ignores
+      # under `debug_assertions`, so the `cargo test --all` job never runs it: it
+      # translates the full LLBC set, which is far too slow unoptimized. This job
+      # has both halves it needs — the downloaded build/llbc/*.ullbc and a warm
+      # release profile from check.py — so run it here. Left unrun it rots: its
+      # dispatcher arm counts drifted stale and masked a live lowering defect.
+      if: runner.os == 'Linux'
+      run: |
+        cargo test --release -p majit-translate \
+          --test test_make_jitcodes_produces_graph_keyed_output
 
   pyre-check-macos:
     name: pyre/check.py (macos-latest)

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -28,7 +28,7 @@ use majit_backend::{
 };
 use majit_gc::header::{GcHeader, TYPE_ID_MASK};
 use majit_gc::rewrite::GcRewriterImpl;
-use majit_gc::{GcAllocator, GcMap, GcRewriter, WriteBarrierDescr};
+use majit_gc::{GcAllocator, GcMap, GcRewriter};
 use majit_ir::{
     AccumInfo, CallDescr, DescrRef, EffectInfo, FailDescr, GcRef, InputArg, OopSpecIndex, Op,
     OpCode, OpRc, OpRef, OpTypeIndex, Type, Value,
@@ -8123,21 +8123,12 @@ impl CraneliftBackend {
             nursery_free_addr: gc.nursery_free_addr(),
             nursery_top_addr: gc.nursery_top_addr(),
             max_nursery_size: gc.max_nursery_object_size(),
-            // gc.py:259-283 WriteBarrierDescr parity.
-            wb_descr: {
-                let mut descr = WriteBarrierDescr::for_current_gc();
-                let card_page_shift = gc.card_page_shift();
-                if card_page_shift > 0 {
-                    descr.jit_wb_card_page_shift = card_page_shift;
-                } else {
-                    // gc.py:283: no card marking → jit_wb_cards_set = 0
-                    descr.jit_wb_cards_set = 0;
-                    descr.jit_wb_card_page_shift = 0;
-                    descr.jit_wb_cards_set_byteofs = 0;
-                    descr.jit_wb_cards_set_singlebyte = 0;
-                }
-                descr
-            },
+            // gc.py:401 `gc_ll_descr.write_barrier_descr` — the collector
+            // answers (gc.py:259-283 WriteBarrierDescr parity, card marking
+            // included), and `None` from one that needs no barrier
+            // (`gc.py:156 GcLLDescr_boehm`) keeps `rewrite.py:393` from
+            // emitting `COND_CALL_GC_WB*` the backend could not assemble.
+            wb_descr: gc.get_write_barrier_descr(),
             jitframe_info: JITFRAME_LAYOUT
                 .get()
                 .and_then(|info| info.jitframe_descrs.clone()),
@@ -12270,26 +12261,13 @@ impl CraneliftBackend {
 
                     // Load flag byte from object header.
                     let rw = self.gc_rewriter();
-                    let wb_byteofs = rw
-                        .as_ref()
-                        .map(|r| r.wb_descr.jit_wb_if_flag_byteofs as i32)
-                        .unwrap_or(0);
-                    let wb_mask_raw = rw
-                        .as_ref()
-                        .map(|r| r.wb_descr.jit_wb_if_flag_singlebyte)
-                        .unwrap_or(0);
-                    let wb_cards_set = rw
-                        .as_ref()
-                        .map(|r| r.wb_descr.jit_wb_cards_set)
-                        .unwrap_or(0);
-                    let wb_card_shift = rw
-                        .as_ref()
-                        .map(|r| r.wb_descr.jit_wb_card_page_shift)
-                        .unwrap_or(0);
-                    let wb_cards_singlebyte = rw
-                        .as_ref()
-                        .map(|r| r.wb_descr.jit_wb_cards_set_singlebyte)
-                        .unwrap_or(0);
+                    let wb = rw.as_ref().and_then(|r| r.wb_descr.as_ref());
+                    let wb_byteofs = wb.map(|d| d.jit_wb_if_flag_byteofs as i32).unwrap_or(0);
+                    let wb_mask_raw = wb.map(|d| d.jit_wb_if_flag_singlebyte).unwrap_or(0);
+                    let wb_cards_set = wb.map(|d| d.jit_wb_cards_set).unwrap_or(0);
+                    let wb_card_shift = wb.map(|d| d.jit_wb_card_page_shift).unwrap_or(0);
+                    let wb_cards_singlebyte =
+                        wb.map(|d| d.jit_wb_cards_set_singlebyte).unwrap_or(0);
                     drop(rw);
 
                     // opassembler.py:921-929: mask includes CARDS_SET singlebyte for array ops.

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -1433,27 +1433,8 @@ thread_local! {
     static CRANELIFT_JITFRAME_TYPE_ID: Cell<Option<u32>> = const { Cell::new(None) };
 }
 
-/// Set once any thread has installed a per-thread GC box through
-/// `set_cranelift_active_gc(Some(..))`. That path is test-only: production
-/// calls [`install_gc_standalone`], which leaves `CRANELIFT_ACTIVE_GC` `None`
-/// on every thread, so the flag stays `false` and [`with_cranelift_gc`] reaches
-/// `gc_sync` without two thread-local reads plus a `RefCell` borrow first.
-/// RPython weaves every `malloc` against the single translation-time `gcdata`
-/// (`gctransform/framework.py`) and has no per-thread allocator at all.
-///
-/// Set-only, never cleared: `set_cranelift_active_gc(None)` can run on one
-/// thread while another still owns a box.
-static GC_BOX_INSTALLED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
-
-/// Whether any thread may hold a `CRANELIFT_ACTIVE_GC` box. `false` means no
-/// thread can have one; `true` only means "probe it".
-#[inline]
-fn gc_box_possible() -> bool {
-    GC_BOX_INSTALLED.load(std::sync::atomic::Ordering::Acquire)
-}
-
 fn with_cranelift_gc<R>(f: impl FnOnce(&mut dyn GcAllocator) -> R) -> Option<R> {
-    if gc_box_possible() && CRANELIFT_ACTIVE_GC.with(|cell| cell.borrow().is_some()) {
+    if majit_gc::gc_box_installed() && CRANELIFT_ACTIVE_GC.with(|cell| cell.borrow().is_some()) {
         return CRANELIFT_ACTIVE_GC.with(|cell| {
             let mut guard = cell.borrow_mut();
             let raw: *mut dyn GcAllocator = guard.as_deref_mut()?;
@@ -1475,7 +1456,7 @@ fn with_cranelift_gc_required<R>(f: impl FnOnce(&mut dyn GcAllocator) -> R) -> R
 
 fn set_cranelift_active_gc(gc: Option<Box<dyn GcAllocator>>) {
     if gc.is_some() {
-        GC_BOX_INSTALLED.store(true, std::sync::atomic::Ordering::Release);
+        majit_gc::note_gc_box_installed();
     }
     CRANELIFT_ACTIVE_GC.with(|cell| {
         let mut guard = cell.borrow_mut();
@@ -1504,7 +1485,7 @@ fn set_cranelift_jitframe_type_id(type_id: Option<u32>) {
 }
 
 fn cranelift_gc_active() -> bool {
-    (gc_box_possible() && CRANELIFT_ACTIVE_GC.with(|cell| cell.borrow().is_some()))
+    (majit_gc::gc_box_installed() && CRANELIFT_ACTIVE_GC.with(|cell| cell.borrow().is_some()))
         || majit_gc::gc_sync::is_initialized()
 }
 
@@ -1713,7 +1694,7 @@ fn gc_remove_root_via_active_runtime(slot: *mut GcRef) {
 /// Host-side write-barrier trampoline for GC-managed objects updated
 /// outside compiled code.
 fn gc_write_barrier_via_active_runtime(obj: GcRef) {
-    if gc_box_possible() && CRANELIFT_ACTIVE_GC.with(|cell| cell.borrow().is_some()) {
+    if majit_gc::gc_box_installed() && CRANELIFT_ACTIVE_GC.with(|cell| cell.borrow().is_some()) {
         with_cranelift_gc(|gc| gc.write_barrier(obj));
     } else if majit_gc::gc_sync::is_initialized() {
         majit_gc::gc_sync::gc_op_with_root(obj, |gc, obj| gc.write_barrier(obj));
@@ -1725,7 +1706,7 @@ fn gc_write_barrier_via_active_runtime(obj: GcRef) {
 /// `try_gc_alloc_stable`-allocated blocks from `std::alloc`-backed
 /// fallback blocks during the L1/L2 stepping-stone window.
 fn id_or_identityhash_via_active_runtime(addr: usize) -> usize {
-    let via_box = gc_box_possible().then(|| {
+    let via_box = majit_gc::gc_box_installed().then(|| {
         CRANELIFT_ACTIVE_GC.with(|cell| {
             let mut guard = match cell.try_borrow_mut() {
                 Ok(guard) => guard,
@@ -1752,7 +1733,7 @@ fn gc_owns_object_via_active_runtime(addr: usize) -> bool {
     // `gc_sync` read only for this immutable ownership query, matching the
     // read-only nature of RPython's descriptor call, instead of panicking
     // across the extern slowpath.
-    if !gc_box_possible() {
+    if !majit_gc::gc_box_installed() {
         return majit_gc::gc_sync::is_initialized()
             && majit_gc::gc_sync::gc_query_reentrant(|g| g.is_managed_heap_object(addr));
     }
@@ -1782,7 +1763,7 @@ fn gc_owns_object_via_active_runtime(addr: usize) -> bool {
 }
 
 fn gc_is_nursery_object_via_active_runtime(addr: usize) -> bool {
-    let via_box = gc_box_possible()
+    let via_box = majit_gc::gc_box_installed()
         .then(|| {
             CRANELIFT_ACTIVE_GC.with(|cell| match cell.try_borrow() {
                 Ok(guard) => guard.as_deref().map(|gc| gc.is_nursery_object(addr)),

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -1433,8 +1433,27 @@ thread_local! {
     static CRANELIFT_JITFRAME_TYPE_ID: Cell<Option<u32>> = const { Cell::new(None) };
 }
 
+/// Set once any thread has installed a per-thread GC box through
+/// `set_cranelift_active_gc(Some(..))`. That path is test-only: production
+/// calls [`install_gc_standalone`], which leaves `CRANELIFT_ACTIVE_GC` `None`
+/// on every thread, so the flag stays `false` and [`with_cranelift_gc`] reaches
+/// `gc_sync` without two thread-local reads plus a `RefCell` borrow first.
+/// RPython weaves every `malloc` against the single translation-time `gcdata`
+/// (`gctransform/framework.py`) and has no per-thread allocator at all.
+///
+/// Set-only, never cleared: `set_cranelift_active_gc(None)` can run on one
+/// thread while another still owns a box.
+static GC_BOX_INSTALLED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+/// Whether any thread may hold a `CRANELIFT_ACTIVE_GC` box. `false` means no
+/// thread can have one; `true` only means "probe it".
+#[inline]
+fn gc_box_possible() -> bool {
+    GC_BOX_INSTALLED.load(std::sync::atomic::Ordering::Acquire)
+}
+
 fn with_cranelift_gc<R>(f: impl FnOnce(&mut dyn GcAllocator) -> R) -> Option<R> {
-    if CRANELIFT_ACTIVE_GC.with(|cell| cell.borrow().is_some()) {
+    if gc_box_possible() && CRANELIFT_ACTIVE_GC.with(|cell| cell.borrow().is_some()) {
         return CRANELIFT_ACTIVE_GC.with(|cell| {
             let mut guard = cell.borrow_mut();
             let raw: *mut dyn GcAllocator = guard.as_deref_mut()?;
@@ -1455,6 +1474,9 @@ fn with_cranelift_gc_required<R>(f: impl FnOnce(&mut dyn GcAllocator) -> R) -> R
 }
 
 fn set_cranelift_active_gc(gc: Option<Box<dyn GcAllocator>>) {
+    if gc.is_some() {
+        GC_BOX_INSTALLED.store(true, std::sync::atomic::Ordering::Release);
+    }
     CRANELIFT_ACTIVE_GC.with(|cell| {
         let mut guard = cell.borrow_mut();
         // Drop the previous allocator first so reentrant
@@ -1482,7 +1504,8 @@ fn set_cranelift_jitframe_type_id(type_id: Option<u32>) {
 }
 
 fn cranelift_gc_active() -> bool {
-    CRANELIFT_ACTIVE_GC.with(|cell| cell.borrow().is_some()) || majit_gc::gc_sync::is_initialized()
+    (gc_box_possible() && CRANELIFT_ACTIVE_GC.with(|cell| cell.borrow().is_some()))
+        || majit_gc::gc_sync::is_initialized()
 }
 
 /// `majit_gc::CheckIsObjectFn` installed by `set_gc_allocator`. Dispatches
@@ -1690,7 +1713,7 @@ fn gc_remove_root_via_active_runtime(slot: *mut GcRef) {
 /// Host-side write-barrier trampoline for GC-managed objects updated
 /// outside compiled code.
 fn gc_write_barrier_via_active_runtime(obj: GcRef) {
-    if CRANELIFT_ACTIVE_GC.with(|cell| cell.borrow().is_some()) {
+    if gc_box_possible() && CRANELIFT_ACTIVE_GC.with(|cell| cell.borrow().is_some()) {
         with_cranelift_gc(|gc| gc.write_barrier(obj));
     } else if majit_gc::gc_sync::is_initialized() {
         majit_gc::gc_sync::gc_op_with_root(obj, |gc, obj| gc.write_barrier(obj));
@@ -1702,14 +1725,16 @@ fn gc_write_barrier_via_active_runtime(obj: GcRef) {
 /// `try_gc_alloc_stable`-allocated blocks from `std::alloc`-backed
 /// fallback blocks during the L1/L2 stepping-stone window.
 fn id_or_identityhash_via_active_runtime(addr: usize) -> usize {
-    let via_box = CRANELIFT_ACTIVE_GC.with(|cell| {
-        let mut guard = match cell.try_borrow_mut() {
-            Ok(guard) => guard,
-            Err(_) => return Some(addr),
-        };
-        guard.as_deref_mut().map(|gc| gc.id_or_identityhash(addr))
+    let via_box = gc_box_possible().then(|| {
+        CRANELIFT_ACTIVE_GC.with(|cell| {
+            let mut guard = match cell.try_borrow_mut() {
+                Ok(guard) => guard,
+                Err(_) => return Some(addr),
+            };
+            guard.as_deref_mut().map(|gc| gc.id_or_identityhash(addr))
+        })
     });
-    if let Some(r) = via_box {
+    if let Some(Some(r)) = via_box {
         return r;
     }
     if majit_gc::gc_sync::is_initialized() {
@@ -1727,6 +1752,10 @@ fn gc_owns_object_via_active_runtime(addr: usize) -> bool {
     // `gc_sync` read only for this immutable ownership query, matching the
     // read-only nature of RPython's descriptor call, instead of panicking
     // across the extern slowpath.
+    if !gc_box_possible() {
+        return majit_gc::gc_sync::is_initialized()
+            && majit_gc::gc_sync::gc_query_reentrant(|g| g.is_managed_heap_object(addr));
+    }
     match CRANELIFT_ACTIVE_GC.with(|cell| {
         cell.try_borrow()
             .map(|g| g.as_deref().map(|gc| gc.is_managed_heap_object(addr)))
@@ -1753,13 +1782,17 @@ fn gc_owns_object_via_active_runtime(addr: usize) -> bool {
 }
 
 fn gc_is_nursery_object_via_active_runtime(addr: usize) -> bool {
-    let via_box = CRANELIFT_ACTIVE_GC.with(|cell| match cell.try_borrow() {
-        Ok(guard) => guard.as_deref().map(|gc| gc.is_nursery_object(addr)),
-        Err(_) => CRANELIFT_ACTIVE_GC_RAW.with(|raw| {
-            raw.get()
-                .map(|ptr| unsafe { (&*ptr).is_nursery_object(addr) })
-        }),
-    });
+    let via_box = gc_box_possible()
+        .then(|| {
+            CRANELIFT_ACTIVE_GC.with(|cell| match cell.try_borrow() {
+                Ok(guard) => guard.as_deref().map(|gc| gc.is_nursery_object(addr)),
+                Err(_) => CRANELIFT_ACTIVE_GC_RAW.with(|raw| {
+                    raw.get()
+                        .map(|ptr| unsafe { (&*ptr).is_nursery_object(addr) })
+                }),
+            })
+        })
+        .flatten();
     via_box.unwrap_or_else(|| {
         if majit_gc::gc_sync::is_initialized() {
             majit_gc::gc_sync::gc_query_reentrant(|g| g.is_nursery_object(addr))

--- a/majit/majit-backend-dynasm/src/aarch64/assembler.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/assembler.rs
@@ -1717,11 +1717,25 @@ impl<'a> AssemblerARM64<'a> {
             ; sub x16, x16, 8           // ip0 -= WORD
             ; ldr x29, [x16]            // fp = *(top - WORD) = jf_ptr
         );
-        // aarch64/assembler.py:972-976 `_reload_frame_if_necessary`:
+        // aarch64/assembler.py:975-980 `_reload_frame_if_necessary`:
         // after a collecting helper call, re-apply the non-array write
         // barrier fast path on the current jitframe (`is_frame=True`).
-        let loc_base = crate::aarch64::registers::FP;
-        self.emit_write_barrier_fastpath_for_base(loc_base, false, None);
+        //
+        //     wbdescr = self.cpu.gc_ll_descr.write_barrier_descr
+        //     if gcrootmap and wbdescr:
+        //
+        // The `and wbdescr` is load-bearing: a collector that needs no write
+        // barrier reports none (`gc.py:156 GcLLDescr_boehm.write_barrier_descr
+        // = None`), and there is no barrier to re-apply for it. Calling
+        // through regardless is what `emit_write_barrier_fastpath_for_base`
+        // asserts against, and it reaches here from every collecting helper —
+        // `genop_call_malloc_nursery*` included — not only from a
+        // `COND_CALL_GC_WB` the GC rewriter emitted. The x86 counterpart
+        // already spells this gate as `if let Some(wb) = wb_descr`.
+        if crate::runner::dynasm_write_barrier_descr().is_some() {
+            let loc_base = crate::aarch64::registers::FP;
+            self.emit_write_barrier_fastpath_for_base(loc_base, false, None);
+        }
     }
 
     /// aarch64/assembler.py:254 `_push_all_regs_to_jitframe` parity.

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -106,6 +106,29 @@ thread_local! {
         const { std::cell::Cell::new(None) };
 }
 
+/// Set once any thread has installed a per-thread GC box through
+/// [`install_gc_box`]. That path is test-only: production calls
+/// [`install_gc_standalone`], which leaves `DYNASM_ACTIVE_GC` `None` on every
+/// thread, so the flag stays `false` and the trampolines below reach
+/// `gc_sync` without a thread-local read plus a `RefCell` borrow first.
+///
+/// RPython has no per-thread allocator — the GC transformer weaves every
+/// `malloc` against the single translation-time `gcdata`
+/// (`gctransform/framework.py`) — so the box is pyre-side scaffolding and does
+/// not belong on the allocation path it does not serve.
+///
+/// Set-only, never cleared: [`clear_gc_allocator`] can run on one thread while
+/// another still owns a box, and clearing the flag would skip that live box.
+static GC_BOX_INSTALLED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+/// Whether any thread may hold a `DYNASM_ACTIVE_GC` box. `false` means no
+/// thread can have one, so the read is skippable; `true` only means "probe it",
+/// never "this thread has one".
+#[inline]
+fn gc_box_possible() -> bool {
+    GC_BOX_INSTALLED.load(std::sync::atomic::Ordering::Acquire)
+}
+
 /// Read-only GC query for the guard hooks and codegen helpers.
 ///
 /// - **Test box present** (`DYNASM_ACTIVE_GC` is `Some`): a test owns the
@@ -119,7 +142,9 @@ thread_local! {
 ///   returns `None` so callers keep their existing `.unwrap_or(default)`
 ///   / `.flatten()` behaviour.
 pub(crate) fn with_dynasm_active_gc<R>(f: impl Fn(&dyn majit_gc::GcAllocator) -> R) -> Option<R> {
-    if let Some(r) = DYNASM_ACTIVE_GC.with(|cell| cell.borrow().as_deref().map(&f)) {
+    if gc_box_possible()
+        && let Some(r) = DYNASM_ACTIVE_GC.with(|cell| cell.borrow().as_deref().map(&f))
+    {
         return Some(r);
     }
     if majit_gc::gc_sync::is_initialized() {
@@ -235,6 +260,7 @@ fn install_gc_box(gc: Box<dyn majit_gc::GcAllocator>) {
     // nursery is not the singleton's, so the process-wide published range can
     // no longer stand in for `is_nursery_object`.
     majit_gc::disarm_published_nursery();
+    GC_BOX_INSTALLED.store(true, std::sync::atomic::Ordering::Release);
     let supports_guard_gc_type = gc.supports_guard_gc_type();
     DYNASM_ACTIVE_GC.with(|cell| {
         let mut guard = cell.borrow_mut();
@@ -369,16 +395,20 @@ pub(crate) fn new_via_gc_enabled() -> bool {
 /// `gc_alloc_nursery_shim`), including the process-global singleton; falls back
 /// to `malloc` when no GC is installed.
 pub(crate) extern "C" fn dynasm_new_alloc(size: usize) -> *mut u8 {
-    DYNASM_ACTIVE_GC.with(|cell| match cell.borrow_mut().as_deref_mut() {
-        Some(gc) => gc.alloc_nursery(size).0 as *mut u8,
-        None => {
-            if majit_gc::gc_sync::is_initialized() {
-                majit_gc::gc_sync::gc_op(|g| g.alloc_nursery(size).0 as *mut u8)
-            } else {
-                unsafe { libc::malloc(size) as *mut u8 }
-            }
-        }
-    })
+    if gc_box_possible()
+        && let Some(r) = DYNASM_ACTIVE_GC.with(|cell| {
+            cell.borrow_mut()
+                .as_deref_mut()
+                .map(|gc| gc.alloc_nursery(size))
+        })
+    {
+        return r.0 as *mut u8;
+    }
+    if majit_gc::gc_sync::is_initialized() {
+        majit_gc::gc_sync::gc_op(|g| g.alloc_nursery(size).0 as *mut u8)
+    } else {
+        unsafe { libc::malloc(size) as *mut u8 }
+    }
 }
 
 /// Headerless no-collect nursery trampoline for backend-agnostic callers.
@@ -388,11 +418,13 @@ pub(crate) extern "C" fn dynasm_new_alloc(size: usize) -> *mut u8 {
 /// rather than the host heap, where its collector could not see it. Returns
 /// null when no GC is bound, leaving the caller on its own path.
 fn dynasm_alloc_nursery_headerless_no_collect(size: usize) -> GcRef {
-    if let Some(r) = DYNASM_ACTIVE_GC.with(|c| {
-        c.borrow_mut()
-            .as_deref_mut()
-            .map(|g| g.alloc_nursery_headerless_no_collect(size))
-    }) {
+    if gc_box_possible()
+        && let Some(r) = DYNASM_ACTIVE_GC.with(|c| {
+            c.borrow_mut()
+                .as_deref_mut()
+                .map(|g| g.alloc_nursery_headerless_no_collect(size))
+        })
+    {
         return r;
     }
     if majit_gc::gc_sync::is_initialized() {
@@ -416,11 +448,13 @@ fn dynasm_alloc_nursery_typed(type_id: u32, size: usize) -> GcRef {
     // collections that fire between here and the caller's store into a
     // tracked slot — and returns NULL when rawmalloc fails so the host helper
     // can raise `MemoryError`.
-    if let Some(r) = DYNASM_ACTIVE_GC.with(|c| {
-        c.borrow_mut()
-            .as_deref_mut()
-            .map(|g| g.try_alloc_nursery_no_collect_typed(type_id, size))
-    }) {
+    if gc_box_possible()
+        && let Some(r) = DYNASM_ACTIVE_GC.with(|c| {
+            c.borrow_mut()
+                .as_deref_mut()
+                .map(|g| g.try_alloc_nursery_no_collect_typed(type_id, size))
+        })
+    {
         return r;
     }
     majit_gc::gc_sync::gc_op(|g| g.try_alloc_nursery_no_collect_typed(type_id, size))
@@ -436,11 +470,17 @@ unsafe fn dynasm_alloc_nursery_typed_with_placement(
     size: usize,
     needs_write_barrier: *mut bool,
 ) -> GcRef {
-    if let Some(r) = DYNASM_ACTIVE_GC.with(|c| {
-        c.borrow_mut().as_deref_mut().map(|g| unsafe {
-            g.try_alloc_nursery_no_collect_typed_with_placement(type_id, size, needs_write_barrier)
+    if gc_box_possible()
+        && let Some(r) = DYNASM_ACTIVE_GC.with(|c| {
+            c.borrow_mut().as_deref_mut().map(|g| unsafe {
+                g.try_alloc_nursery_no_collect_typed_with_placement(
+                    type_id,
+                    size,
+                    needs_write_barrier,
+                )
+            })
         })
-    }) {
+    {
         return r;
     }
     majit_gc::gc_sync::gc_op(|g| unsafe {
@@ -456,11 +496,13 @@ unsafe fn dynasm_alloc_nursery_typed_with_placement(
 /// allocation — so the embedded minor cycle is safe and dead bigints are
 /// reclaimed instead of accumulating in old-gen.
 fn dynasm_alloc_nursery_collecting_typed(type_id: u32, size: usize) -> GcRef {
-    if let Some(r) = DYNASM_ACTIVE_GC.with(|c| {
-        c.borrow_mut()
-            .as_deref_mut()
-            .map(|g| g.alloc_nursery_typed(type_id, size))
-    }) {
+    if gc_box_possible()
+        && let Some(r) = DYNASM_ACTIVE_GC.with(|c| {
+            c.borrow_mut()
+                .as_deref_mut()
+                .map(|g| g.alloc_nursery_typed(type_id, size))
+        })
+    {
         return r;
     }
     majit_gc::gc_sync::gc_op(|g| g.alloc_nursery_typed(type_id, size))
@@ -480,11 +522,13 @@ unsafe fn dynasm_alloc_nursery_collecting_typed_rooted(
     root: *mut GcRef,
     needs_write_barrier: *mut bool,
 ) -> GcRef {
-    if let Some(r) = DYNASM_ACTIVE_GC.with(|c| {
-        c.borrow_mut().as_deref_mut().map(|g| unsafe {
-            g.alloc_nursery_collecting_typed_rooted(type_id, size, root, needs_write_barrier)
+    if gc_box_possible()
+        && let Some(r) = DYNASM_ACTIVE_GC.with(|c| {
+            c.borrow_mut().as_deref_mut().map(|g| unsafe {
+                g.alloc_nursery_collecting_typed_rooted(type_id, size, root, needs_write_barrier)
+            })
         })
-    }) {
+    {
         return r;
     }
     majit_gc::gc_sync::gc_op(|g| unsafe {
@@ -499,11 +543,13 @@ unsafe fn dynasm_alloc_nursery_collecting_typed_rooted(
 /// (non-moving), so the returned pointer is stable across minor and
 /// major collections.
 fn dynasm_alloc_oldgen_typed(type_id: u32, size: usize) -> GcRef {
-    if let Some(r) = DYNASM_ACTIVE_GC.with(|c| {
-        c.borrow_mut()
-            .as_deref_mut()
-            .map(|g| g.alloc_oldgen_typed(type_id, size))
-    }) {
+    if gc_box_possible()
+        && let Some(r) = DYNASM_ACTIVE_GC.with(|c| {
+            c.borrow_mut()
+                .as_deref_mut()
+                .map(|g| g.alloc_oldgen_typed(type_id, size))
+        })
+    {
         return r;
     }
     majit_gc::gc_sync::gc_op(|g| g.alloc_oldgen_typed(type_id, size))
@@ -676,11 +722,13 @@ fn dynasm_heap_stats() -> (usize, usize) {
 /// Report whether the GC wants a major collection, for the interpreter GC
 /// safepoint (incminimark.py:1288-1290 `threshold_reached`).
 fn dynasm_major_threshold_reached() -> bool {
-    if let Some(r) = DYNASM_ACTIVE_GC.with(|c| {
-        c.borrow_mut()
-            .as_deref_mut()
-            .map(|g| g.major_threshold_reached())
-    }) {
+    if gc_box_possible()
+        && let Some(r) = DYNASM_ACTIVE_GC.with(|c| {
+            c.borrow_mut()
+                .as_deref_mut()
+                .map(|g| g.major_threshold_reached())
+        })
+    {
         return r;
     }
     majit_gc::gc_sync::gc_op(|g| g.major_threshold_reached())
@@ -733,14 +781,16 @@ fn dynasm_id_or_identityhash(addr: usize) -> usize {
     // Keep the defensive `try_borrow_mut`: a borrow already held by an
     // in-progress alloc means the test box is busy, so fall back to the
     // raw `addr` (this is a top-level op, never reentrant).
-    let via_box = DYNASM_ACTIVE_GC.with(|cell| {
-        let mut guard = match cell.try_borrow_mut() {
-            Ok(guard) => guard,
-            Err(_) => return Some(addr),
-        };
-        guard.as_deref_mut().map(|gc| gc.id_or_identityhash(addr))
+    let via_box = gc_box_possible().then(|| {
+        DYNASM_ACTIVE_GC.with(|cell| {
+            let mut guard = match cell.try_borrow_mut() {
+                Ok(guard) => guard,
+                Err(_) => return Some(addr),
+            };
+            guard.as_deref_mut().map(|gc| gc.id_or_identityhash(addr))
+        })
     });
-    if let Some(r) = via_box {
+    if let Some(Some(r)) = via_box {
         return r;
     }
     majit_gc::gc_sync::gc_op(|g| g.id_or_identityhash(addr))
@@ -764,6 +814,10 @@ fn dynasm_gc_owns_object(addr: usize) -> bool {
     //   - `Err`: the test box's mutable borrow is held by an in-progress
     //     alloc → reach it through the raw mirror (read-only), or fall
     //     back to `gc_sync` if there is no box at all.
+    if !gc_box_possible() {
+        return majit_gc::gc_sync::is_initialized()
+            && majit_gc::gc_sync::gc_query_reentrant(|g| g.is_managed_heap_object(addr));
+    }
     match DYNASM_ACTIVE_GC.with(|c| {
         c.try_borrow()
             .map(|g| g.as_deref().map(|gc| gc.is_managed_heap_object(addr)))
@@ -790,13 +844,17 @@ fn dynasm_gc_owns_object(addr: usize) -> bool {
 }
 
 fn dynasm_gc_is_nursery_object(addr: usize) -> bool {
-    let via_box = DYNASM_ACTIVE_GC.with(|cell| match cell.try_borrow() {
-        Ok(guard) => guard.as_deref().map(|gc| gc.is_nursery_object(addr)),
-        Err(_) => DYNASM_ACTIVE_GC_RAW.with(|raw| {
-            raw.get()
-                .map(|ptr| unsafe { (&*ptr).is_nursery_object(addr) })
-        }),
-    });
+    let via_box = gc_box_possible()
+        .then(|| {
+            DYNASM_ACTIVE_GC.with(|cell| match cell.try_borrow() {
+                Ok(guard) => guard.as_deref().map(|gc| gc.is_nursery_object(addr)),
+                Err(_) => DYNASM_ACTIVE_GC_RAW.with(|raw| {
+                    raw.get()
+                        .map(|ptr| unsafe { (&*ptr).is_nursery_object(addr) })
+                }),
+            })
+        })
+        .flatten();
     via_box.unwrap_or_else(|| {
         if majit_gc::gc_sync::is_initialized() {
             majit_gc::gc_sync::gc_query_reentrant(|g| g.is_nursery_object(addr))

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -106,29 +106,6 @@ thread_local! {
         const { std::cell::Cell::new(None) };
 }
 
-/// Set once any thread has installed a per-thread GC box through
-/// [`install_gc_box`]. That path is test-only: production calls
-/// [`install_gc_standalone`], which leaves `DYNASM_ACTIVE_GC` `None` on every
-/// thread, so the flag stays `false` and the trampolines below reach
-/// `gc_sync` without a thread-local read plus a `RefCell` borrow first.
-///
-/// RPython has no per-thread allocator — the GC transformer weaves every
-/// `malloc` against the single translation-time `gcdata`
-/// (`gctransform/framework.py`) — so the box is pyre-side scaffolding and does
-/// not belong on the allocation path it does not serve.
-///
-/// Set-only, never cleared: [`clear_gc_allocator`] can run on one thread while
-/// another still owns a box, and clearing the flag would skip that live box.
-static GC_BOX_INSTALLED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
-
-/// Whether any thread may hold a `DYNASM_ACTIVE_GC` box. `false` means no
-/// thread can have one, so the read is skippable; `true` only means "probe it",
-/// never "this thread has one".
-#[inline]
-fn gc_box_possible() -> bool {
-    GC_BOX_INSTALLED.load(std::sync::atomic::Ordering::Acquire)
-}
-
 /// Read-only GC query for the guard hooks and codegen helpers.
 ///
 /// - **Test box present** (`DYNASM_ACTIVE_GC` is `Some`): a test owns the
@@ -142,7 +119,7 @@ fn gc_box_possible() -> bool {
 ///   returns `None` so callers keep their existing `.unwrap_or(default)`
 ///   / `.flatten()` behaviour.
 pub(crate) fn with_dynasm_active_gc<R>(f: impl Fn(&dyn majit_gc::GcAllocator) -> R) -> Option<R> {
-    if gc_box_possible()
+    if majit_gc::gc_box_installed()
         && let Some(r) = DYNASM_ACTIVE_GC.with(|cell| cell.borrow().as_deref().map(&f))
     {
         return Some(r);
@@ -260,7 +237,7 @@ fn install_gc_box(gc: Box<dyn majit_gc::GcAllocator>) {
     // nursery is not the singleton's, so the process-wide published range can
     // no longer stand in for `is_nursery_object`.
     majit_gc::disarm_published_nursery();
-    GC_BOX_INSTALLED.store(true, std::sync::atomic::Ordering::Release);
+    majit_gc::note_gc_box_installed();
     let supports_guard_gc_type = gc.supports_guard_gc_type();
     DYNASM_ACTIVE_GC.with(|cell| {
         let mut guard = cell.borrow_mut();
@@ -395,7 +372,7 @@ pub(crate) fn new_via_gc_enabled() -> bool {
 /// `gc_alloc_nursery_shim`), including the process-global singleton; falls back
 /// to `malloc` when no GC is installed.
 pub(crate) extern "C" fn dynasm_new_alloc(size: usize) -> *mut u8 {
-    if gc_box_possible()
+    if majit_gc::gc_box_installed()
         && let Some(r) = DYNASM_ACTIVE_GC.with(|cell| {
             cell.borrow_mut()
                 .as_deref_mut()
@@ -418,7 +395,7 @@ pub(crate) extern "C" fn dynasm_new_alloc(size: usize) -> *mut u8 {
 /// rather than the host heap, where its collector could not see it. Returns
 /// null when no GC is bound, leaving the caller on its own path.
 fn dynasm_alloc_nursery_headerless_no_collect(size: usize) -> GcRef {
-    if gc_box_possible()
+    if majit_gc::gc_box_installed()
         && let Some(r) = DYNASM_ACTIVE_GC.with(|c| {
             c.borrow_mut()
                 .as_deref_mut()
@@ -448,7 +425,7 @@ fn dynasm_alloc_nursery_typed(type_id: u32, size: usize) -> GcRef {
     // collections that fire between here and the caller's store into a
     // tracked slot — and returns NULL when rawmalloc fails so the host helper
     // can raise `MemoryError`.
-    if gc_box_possible()
+    if majit_gc::gc_box_installed()
         && let Some(r) = DYNASM_ACTIVE_GC.with(|c| {
             c.borrow_mut()
                 .as_deref_mut()
@@ -457,7 +434,7 @@ fn dynasm_alloc_nursery_typed(type_id: u32, size: usize) -> GcRef {
     {
         return r;
     }
-    majit_gc::gc_sync::gc_op(|g| g.try_alloc_nursery_no_collect_typed(type_id, size))
+    majit_gc::standalone_alloc_nursery_typed(type_id, size)
 }
 
 /// Placement-reporting companion of [`dynasm_alloc_nursery_typed`].
@@ -470,7 +447,7 @@ unsafe fn dynasm_alloc_nursery_typed_with_placement(
     size: usize,
     needs_write_barrier: *mut bool,
 ) -> GcRef {
-    if gc_box_possible()
+    if majit_gc::gc_box_installed()
         && let Some(r) = DYNASM_ACTIVE_GC.with(|c| {
             c.borrow_mut().as_deref_mut().map(|g| unsafe {
                 g.try_alloc_nursery_no_collect_typed_with_placement(
@@ -496,7 +473,7 @@ unsafe fn dynasm_alloc_nursery_typed_with_placement(
 /// allocation — so the embedded minor cycle is safe and dead bigints are
 /// reclaimed instead of accumulating in old-gen.
 fn dynasm_alloc_nursery_collecting_typed(type_id: u32, size: usize) -> GcRef {
-    if gc_box_possible()
+    if majit_gc::gc_box_installed()
         && let Some(r) = DYNASM_ACTIVE_GC.with(|c| {
             c.borrow_mut()
                 .as_deref_mut()
@@ -522,7 +499,7 @@ unsafe fn dynasm_alloc_nursery_collecting_typed_rooted(
     root: *mut GcRef,
     needs_write_barrier: *mut bool,
 ) -> GcRef {
-    if gc_box_possible()
+    if majit_gc::gc_box_installed()
         && let Some(r) = DYNASM_ACTIVE_GC.with(|c| {
             c.borrow_mut().as_deref_mut().map(|g| unsafe {
                 g.alloc_nursery_collecting_typed_rooted(type_id, size, root, needs_write_barrier)
@@ -531,9 +508,14 @@ unsafe fn dynasm_alloc_nursery_collecting_typed_rooted(
     {
         return r;
     }
-    majit_gc::gc_sync::gc_op(|g| unsafe {
-        g.alloc_nursery_collecting_typed_rooted(type_id, size, root, needs_write_barrier)
-    })
+    unsafe {
+        majit_gc::standalone_alloc_nursery_collecting_typed_rooted(
+            type_id,
+            size,
+            root,
+            needs_write_barrier,
+        )
+    }
 }
 
 /// Host-side old-gen allocation trampoline. Used by
@@ -543,7 +525,7 @@ unsafe fn dynasm_alloc_nursery_collecting_typed_rooted(
 /// (non-moving), so the returned pointer is stable across minor and
 /// major collections.
 fn dynasm_alloc_oldgen_typed(type_id: u32, size: usize) -> GcRef {
-    if gc_box_possible()
+    if majit_gc::gc_box_installed()
         && let Some(r) = DYNASM_ACTIVE_GC.with(|c| {
             c.borrow_mut()
                 .as_deref_mut()
@@ -722,7 +704,7 @@ fn dynasm_heap_stats() -> (usize, usize) {
 /// Report whether the GC wants a major collection, for the interpreter GC
 /// safepoint (incminimark.py:1288-1290 `threshold_reached`).
 fn dynasm_major_threshold_reached() -> bool {
-    if gc_box_possible()
+    if majit_gc::gc_box_installed()
         && let Some(r) = DYNASM_ACTIVE_GC.with(|c| {
             c.borrow_mut()
                 .as_deref_mut()
@@ -781,7 +763,7 @@ fn dynasm_id_or_identityhash(addr: usize) -> usize {
     // Keep the defensive `try_borrow_mut`: a borrow already held by an
     // in-progress alloc means the test box is busy, so fall back to the
     // raw `addr` (this is a top-level op, never reentrant).
-    let via_box = gc_box_possible().then(|| {
+    let via_box = majit_gc::gc_box_installed().then(|| {
         DYNASM_ACTIVE_GC.with(|cell| {
             let mut guard = match cell.try_borrow_mut() {
                 Ok(guard) => guard,
@@ -814,7 +796,7 @@ fn dynasm_gc_owns_object(addr: usize) -> bool {
     //   - `Err`: the test box's mutable borrow is held by an in-progress
     //     alloc → reach it through the raw mirror (read-only), or fall
     //     back to `gc_sync` if there is no box at all.
-    if !gc_box_possible() {
+    if !majit_gc::gc_box_installed() {
         return majit_gc::gc_sync::is_initialized()
             && majit_gc::gc_sync::gc_query_reentrant(|g| g.is_managed_heap_object(addr));
     }
@@ -844,7 +826,7 @@ fn dynasm_gc_owns_object(addr: usize) -> bool {
 }
 
 fn dynasm_gc_is_nursery_object(addr: usize) -> bool {
-    let via_box = gc_box_possible()
+    let via_box = majit_gc::gc_box_installed()
         .then(|| {
             DYNASM_ACTIVE_GC.with(|cell| match cell.try_borrow() {
                 Ok(guard) => guard.as_deref().map(|gc| gc.is_nursery_object(addr)),

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -1506,19 +1506,13 @@ impl DynasmBackend {
                 nursery_free_addr: gc.nursery_free_addr(),
                 nursery_top_addr: gc.nursery_top_addr(),
                 max_nursery_size: gc.max_nursery_object_size(),
-                wb_descr: {
-                    let mut descr = majit_gc::WriteBarrierDescr::for_current_gc();
-                    let card_page_shift = gc.card_page_shift();
-                    if card_page_shift > 0 {
-                        descr.jit_wb_card_page_shift = card_page_shift;
-                    } else {
-                        descr.jit_wb_cards_set = 0;
-                        descr.jit_wb_card_page_shift = 0;
-                        descr.jit_wb_cards_set_byteofs = 0;
-                        descr.jit_wb_cards_set_singlebyte = 0;
-                    }
-                    descr
-                },
+                // gc.py:401 `gc_ll_descr.write_barrier_descr` — ask the active
+                // collector rather than assuming the MiniMark layout, so the
+                // rewriter and `emit_write_barrier_fastpath_for_base` agree on
+                // whether barriers exist at all. A collector that needs none
+                // reports `None` (`gc.py:156 GcLLDescr_boehm`), and
+                // `rewrite.py:393` then emits no `COND_CALL_GC_WB*`.
+                wb_descr: gc.get_write_barrier_descr(),
                 jitframe_info: crate::jitframe_layout().and_then(|info| info.jitframe_descrs),
                 // rewrite.py:673 — read compiled_loop_token._ll_initial_locs +
                 // ptr2int(compiled_loop_token.frame_info), both sourced from the

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -254,7 +254,30 @@ thread_local! {
 /// - **No box, `gc_sync` uninitialized** (no GC at all — unit tests):
 ///   returns `None` so callers keep their existing `.unwrap_or(default)`
 ///   / `.flatten()` behaviour.
+/// Set once any thread has installed a per-thread GC box through
+/// [`install_gc_box`]. That path is test-only: production calls
+/// [`install_gc_standalone`], which leaves `WASM_ACTIVE_GC` `None` on every
+/// thread, so the flag stays `false` and the helpers below reach `gc_sync`
+/// without a thread-local read plus a `RefCell` borrow first. RPython weaves
+/// every `malloc` against the single translation-time `gcdata`
+/// (`gctransform/framework.py`) and has no per-thread allocator at all.
+///
+/// Set-only, never cleared: a clear can run on one thread while another still
+/// owns a box.
+static GC_BOX_INSTALLED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+/// Whether any thread may hold a `WASM_ACTIVE_GC` box. `false` means no thread
+/// can have one; `true` only means "probe it".
+#[inline]
+fn gc_box_possible() -> bool {
+    GC_BOX_INSTALLED.load(std::sync::atomic::Ordering::Acquire)
+}
+
 fn with_wasm_active_gc<R>(f: impl Fn(&dyn GcAllocator) -> R) -> Option<R> {
+    if !gc_box_possible() {
+        return majit_gc::gc_sync::is_initialized()
+            .then(|| majit_gc::gc_sync::gc_query_reentrant(f));
+    }
     match WASM_ACTIVE_GC.with(|cell| cell.try_borrow().map(|g| g.as_deref().map(|gc| f(gc)))) {
         Ok(Some(r)) => return Some(r),
         Ok(None) => {}
@@ -279,7 +302,7 @@ fn with_wasm_active_gc<R>(f: impl Fn(&dyn GcAllocator) -> R) -> Option<R> {
 /// `None` so callers keep their non-GC fallback. Top-level mutator/
 /// blackhole trampolines, never inside a collection, so `gc_op` is correct.
 fn with_wasm_active_gc_mut<R>(f: impl FnOnce(&mut dyn GcAllocator) -> R) -> Option<R> {
-    if WASM_ACTIVE_GC.with(|cell| cell.borrow().is_some()) {
+    if gc_box_possible() && WASM_ACTIVE_GC.with(|cell| cell.borrow().is_some()) {
         return WASM_ACTIVE_GC.with(|cell| {
             let mut guard = cell.borrow_mut();
             let raw: *mut dyn GcAllocator = guard.as_deref_mut()?;
@@ -349,6 +372,7 @@ fn install_gc_box(gc: Box<dyn majit_gc::GcAllocator>) {
     // Per-thread allocator: its nursery is not the singleton's, so the
     // process-wide published range can no longer answer `is_nursery_object`.
     majit_gc::disarm_published_nursery();
+    GC_BOX_INSTALLED.store(true, std::sync::atomic::Ordering::Release);
     let supports_guard_gc_type = gc.supports_guard_gc_type();
     WASM_ACTIVE_GC.with(|cell| {
         let mut guard = cell.borrow_mut();
@@ -825,6 +849,10 @@ fn wasm_active_gc_write_barrier(obj: GcRef) {
 ///     mutation → reach it through the raw mirror (read-only), or fall
 ///     back to `gc_sync` if there is no box at all.
 fn wasm_gc_owns_object(addr: usize) -> bool {
+    if !gc_box_possible() {
+        return majit_gc::gc_sync::is_initialized()
+            && majit_gc::gc_sync::gc_query_reentrant(|g| g.is_managed_heap_object(addr));
+    }
     match WASM_ACTIVE_GC.with(|cell| {
         cell.try_borrow()
             .map(|g| g.as_deref().map(|gc| gc.is_managed_heap_object(addr)))

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -242,39 +242,8 @@ thread_local! {
         const { std::cell::Cell::new(None) };
 }
 
-/// Read-only GC query for the guard hooks and codegen helpers.
-///
-/// - **Test box present** (`WASM_ACTIVE_GC` is `Some`): a test owns the
-///   GC directly — apply `f` to the boxed allocator.
-/// - **No box, `gc_sync` initialized** (production): route to the
-///   process-global singleton via `gc_query_reentrant`. Some of these
-///   callers can fire during a collection's guard evaluation / extra-root
-///   walk, so the reentrant read-only path (no second `gc_mutex`, no
-///   second `&mut`) is required.
-/// - **No box, `gc_sync` uninitialized** (no GC at all — unit tests):
-///   returns `None` so callers keep their existing `.unwrap_or(default)`
-///   / `.flatten()` behaviour.
-/// Set once any thread has installed a per-thread GC box through
-/// [`install_gc_box`]. That path is test-only: production calls
-/// [`install_gc_standalone`], which leaves `WASM_ACTIVE_GC` `None` on every
-/// thread, so the flag stays `false` and the helpers below reach `gc_sync`
-/// without a thread-local read plus a `RefCell` borrow first. RPython weaves
-/// every `malloc` against the single translation-time `gcdata`
-/// (`gctransform/framework.py`) and has no per-thread allocator at all.
-///
-/// Set-only, never cleared: a clear can run on one thread while another still
-/// owns a box.
-static GC_BOX_INSTALLED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
-
-/// Whether any thread may hold a `WASM_ACTIVE_GC` box. `false` means no thread
-/// can have one; `true` only means "probe it".
-#[inline]
-fn gc_box_possible() -> bool {
-    GC_BOX_INSTALLED.load(std::sync::atomic::Ordering::Acquire)
-}
-
 fn with_wasm_active_gc<R>(f: impl Fn(&dyn GcAllocator) -> R) -> Option<R> {
-    if !gc_box_possible() {
+    if !majit_gc::gc_box_installed() {
         return majit_gc::gc_sync::is_initialized()
             .then(|| majit_gc::gc_sync::gc_query_reentrant(f));
     }
@@ -302,7 +271,7 @@ fn with_wasm_active_gc<R>(f: impl Fn(&dyn GcAllocator) -> R) -> Option<R> {
 /// `None` so callers keep their non-GC fallback. Top-level mutator/
 /// blackhole trampolines, never inside a collection, so `gc_op` is correct.
 fn with_wasm_active_gc_mut<R>(f: impl FnOnce(&mut dyn GcAllocator) -> R) -> Option<R> {
-    if gc_box_possible() && WASM_ACTIVE_GC.with(|cell| cell.borrow().is_some()) {
+    if majit_gc::gc_box_installed() && WASM_ACTIVE_GC.with(|cell| cell.borrow().is_some()) {
         return WASM_ACTIVE_GC.with(|cell| {
             let mut guard = cell.borrow_mut();
             let raw: *mut dyn GcAllocator = guard.as_deref_mut()?;
@@ -372,7 +341,7 @@ fn install_gc_box(gc: Box<dyn majit_gc::GcAllocator>) {
     // Per-thread allocator: its nursery is not the singleton's, so the
     // process-wide published range can no longer answer `is_nursery_object`.
     majit_gc::disarm_published_nursery();
-    GC_BOX_INSTALLED.store(true, std::sync::atomic::Ordering::Release);
+    majit_gc::note_gc_box_installed();
     let supports_guard_gc_type = gc.supports_guard_gc_type();
     WASM_ACTIVE_GC.with(|cell| {
         let mut guard = cell.borrow_mut();
@@ -849,7 +818,7 @@ fn wasm_active_gc_write_barrier(obj: GcRef) {
 ///     mutation → reach it through the raw mirror (read-only), or fall
 ///     back to `gc_sync` if there is no box at all.
 fn wasm_gc_owns_object(addr: usize) -> bool {
-    if !gc_box_possible() {
+    if !majit_gc::gc_box_installed() {
         return majit_gc::gc_sync::is_initialized()
             && majit_gc::gc_sync::gc_query_reentrant(|g| g.is_managed_heap_object(addr));
     }

--- a/majit/majit-gc/src/lib.rs
+++ b/majit/majit-gc/src/lib.rs
@@ -1386,6 +1386,31 @@ pub fn supports_guard_gc_type() -> bool {
     ACTIVE_SUPPORTS_GUARD_GC_TYPE.load(std::sync::atomic::Ordering::Acquire)
 }
 
+/// Set once any thread has installed a per-thread GC box on any backend. That
+/// path is test-only: production installs the backend standalone, leaving the
+/// process-global [`gc_sync`] singleton as the sole allocator on every thread.
+///
+/// Set-only, never cleared: a backend can drop one thread's box while another
+/// thread still owns one, and clearing the flag would route past that live box.
+///
+/// RPython has no per-thread allocator — the GC transformer weaves every
+/// `malloc` against the single translation-time `gcdata`
+/// (`gctransform/framework.py`) — so the box is pyre-side test scaffolding, and
+/// the queries below let the allocation path it does not serve skip it.
+static GC_BOX_INSTALLED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+/// Record that a backend has installed a per-thread GC box. Called from each
+/// backend's box-installing entry point.
+pub fn note_gc_box_installed() {
+    GC_BOX_INSTALLED.store(true, std::sync::atomic::Ordering::Release);
+}
+
+/// Whether any thread may own a per-thread GC box. See [`GC_BOX_INSTALLED`].
+#[inline]
+pub fn gc_box_installed() -> bool {
+    GC_BOX_INSTALLED.load(std::sync::atomic::Ordering::Acquire)
+}
+
 // ── Host-side nursery allocation hook ───────────────────────────────
 //
 // Separate from `ActiveGcGuardHooks` because allocation is not a
@@ -1394,6 +1419,47 @@ pub fn supports_guard_gc_type() -> bool {
 // …) can route through the real GC without taking a backend-specific
 // dependency. Mirrors how RPython host code reaches `gc.malloc(TYPE)`
 // through the global GC instance.
+//
+// When no thread owns a per-thread GC box, a backend's hook does nothing but
+// forward to `gc_sync` — the same process-global singleton this crate owns. The
+// `standalone_*` functions below are that forwarding, spelled once here and
+// called from both sides: the backend trampolines fall through to them, and the
+// entry points take them directly instead of going out through the hook. Same
+// work, one fewer indirect call and stack frame per allocation. The hook is
+// still consulted for its presence, so "no backend installed" keeps returning
+// null exactly as before.
+
+/// The nursery allocation a backend's `AllocNurseryTypedFn` performs once no
+/// per-thread box owns the request.
+///
+/// Non-collecting on purpose: the caller holds a raw pointer that is not a
+/// registered GC root, so a collection here would move the fresh object out
+/// from under it. Falling back to old-gen on a full nursery keeps the result
+/// stable across any minor collection before the caller stores it into a
+/// tracked slot.
+#[inline]
+pub fn standalone_alloc_nursery_typed(type_id: u32, payload_size: usize) -> GcRef {
+    gc_sync::gc_op(|g| g.try_alloc_nursery_no_collect_typed(type_id, payload_size))
+}
+
+/// The rooted collecting nursery allocation a backend's
+/// `AllocNurseryCollectingTypedRootedFn` performs once no per-thread box owns
+/// the request.
+///
+/// # Safety
+/// Same contract as [`alloc_nursery_collecting_typed_rooted`]: `root` and
+/// `needs_write_barrier` must stay valid for the call.
+#[inline]
+pub unsafe fn standalone_alloc_nursery_collecting_typed_rooted(
+    type_id: u32,
+    payload_size: usize,
+    root: *mut GcRef,
+    needs_write_barrier: *mut bool,
+) -> GcRef {
+    gc_sync::gc_op(|g| unsafe {
+        g.alloc_nursery_collecting_typed_rooted(type_id, payload_size, root, needs_write_barrier)
+    })
+}
 
 /// Process-global callback that performs a nursery allocation for the
 /// currently active backend. The callback returns `GcRef(0)` (i.e.
@@ -1414,6 +1480,7 @@ pub fn set_active_alloc_nursery_typed(hook: Option<AllocNurseryTypedFn>) {
 /// null pointer and fall back to their non-GC path).
 pub fn alloc_nursery_typed(type_id: u32, payload_size: usize) -> GcRef {
     match ACTIVE_ALLOC_NURSERY_TYPED.get() {
+        Some(_) if !gc_box_installed() => standalone_alloc_nursery_typed(type_id, payload_size),
         Some(f) => f(type_id, payload_size),
         None => GcRef(0),
     }
@@ -1576,6 +1643,14 @@ pub unsafe fn alloc_nursery_collecting_typed_rooted(
     needs_write_barrier: *mut bool,
 ) -> GcRef {
     match ACTIVE_ALLOC_NURSERY_COLLECTING_TYPED_ROOTED.get() {
+        Some(_) if !gc_box_installed() => unsafe {
+            standalone_alloc_nursery_collecting_typed_rooted(
+                type_id,
+                payload_size,
+                root,
+                needs_write_barrier,
+            )
+        },
         Some(f) => unsafe { f(type_id, payload_size, root, needs_write_barrier) },
         None => {
             // No backend installed placement reporting, so keep the

--- a/majit/majit-gc/src/lib.rs
+++ b/majit/majit-gc/src/lib.rs
@@ -433,7 +433,11 @@ pub trait GcAllocator: Send {
         obj_addr
     }
 
-    /// gc.py:268 write_barrier_descr: descriptor for the write barrier check.
+    /// `gc.py:401 self.write_barrier_descr = WriteBarrierDescr(self)`:
+    /// the descriptor for the write barrier check. Defaulting to `None` is
+    /// `gc.py:156 GcLLDescr_boehm.write_barrier_descr = None` — a collector
+    /// that needs no write barrier. Upstream reads the attribute directly and
+    /// has no `get_write_barrier_descr` accessor.
     fn get_write_barrier_descr(&self) -> Option<WriteBarrierDescr> {
         None
     }

--- a/majit/majit-gc/src/lib.rs
+++ b/majit/majit-gc/src/lib.rs
@@ -202,6 +202,16 @@ pub trait GcAllocator: Send {
     /// root set, so a moving collection under this call would strand them. The
     /// allocator must grow instead of evacuating. The default forwards to the
     /// collecting form, which is correct for a non-moving collector.
+    ///
+    /// The forward is not itself a guard, so the obligation is on the
+    /// implementor: a MOVING headerless-aware allocator must override this
+    /// rather than inherit the forward. No current one does, and the two shapes
+    /// that reach here are both safe — [`MiniMarkGC`](crate::collector::MiniMarkGC)
+    /// moves but is headered, so `alloc_nursery_headerless`'s own default panics
+    /// before any collection; the headerless boxes the backends install grow
+    /// their pool instead of evacuating, which is exactly what this method asks
+    /// for. Adding a moving headerless box without an override would reintroduce
+    /// the silent stranding.
     fn alloc_nursery_headerless_no_collect(&mut self, size: usize) -> GcRef {
         self.alloc_nursery_headerless(size)
     }

--- a/majit/majit-gc/src/rewrite.rs
+++ b/majit/majit-gc/src/rewrite.rs
@@ -115,8 +115,13 @@ pub struct GcRewriterImpl {
     pub nursery_top_addr: usize,
     /// Maximum object size for nursery allocation.
     pub max_nursery_size: usize,
-    /// Write barrier descriptor.
-    pub wb_descr: WriteBarrierDescr,
+    /// `gc.py:401 self.write_barrier_descr = WriteBarrierDescr(self)` — `None`
+    /// for a collector that needs no write barrier, exactly as
+    /// `gc.py:156 GcLLDescr_boehm.write_barrier_descr` is.
+    /// `rewrite.py:393` gates the whole barrier section on this being set,
+    /// so a `None` here means no `COND_CALL_GC_WB*` is ever emitted; the
+    /// backend asserts the same agreement when it assembles one.
+    pub wb_descr: Option<WriteBarrierDescr>,
     /// JitFrame info for call_assembler rewriting.
     /// rewrite.py:665 — handle_call_assembler needs frame layout info.
     pub jitframe_info: Option<JitFrameDescrs>,
@@ -2514,7 +2519,14 @@ impl GcRewriterImpl {
     // ────────────────────────────────────────────────────────
 
     fn gen_write_barrier_array(&self, v_base: Operand, v_index: Operand, st: &mut RewriteState) {
-        if self.wb_descr.jit_wb_cards_set != 0 {
+        // rewrite.py:956-957 reads `self.gc_ll_descr.write_barrier_descr`
+        // unguarded: this is only reached from the barrier section, which
+        // `rewrite.py:393` already gated on the descriptor being set.
+        let wb_descr = self
+            .wb_descr
+            .as_ref()
+            .expect("gen_write_barrier_array reached with no write barrier descriptor");
+        if wb_descr.jit_wb_cards_set != 0 {
             // If we know statically the length of 'v_base', and it is not
             // too big, then produce a regular write_barrier. If it's
             // unknown or too big, produce a write_barrier_from_array.
@@ -3078,7 +3090,11 @@ impl GcRewriter for GcRewriterImpl {
                 // `transform_to_gc_load` has forwarded the store op to
                 // GC_STORE / GC_STORE_INDEXED.  `emit_maybe_forwarded`
                 // follows the forward and emits the lowered op.
-                OpCode::SetfieldGc => {
+                // rewrite.py:393 `if self.gc_ll_descr.write_barrier_descr is
+                // not None:` — a collector that needs no write barrier
+                // (`gc.py:156 GcLLDescr_boehm.write_barrier_descr = None`)
+                // must not have `COND_CALL_GC_WB*` emitted for it at all.
+                OpCode::SetfieldGc if self.wb_descr.is_some() => {
                     // rewrite.py:393-395 — consider_setfield_gc clears the
                     // pending zero-init entry before WB emission.
                     self.consider_setfield_gc(op, &mut st);
@@ -3086,17 +3102,35 @@ impl GcRewriter for GcRewriterImpl {
                     st.emit_maybe_forwarded(op);
                     continue;
                 }
-                OpCode::SetinteriorfieldGc => {
+                OpCode::SetinteriorfieldGc if self.wb_descr.is_some() => {
                     // rewrite.py:946 `handle_write_barrier_setinteriorfield
                     // = handle_write_barrier_setarrayitem`.
                     self.handle_write_barrier_setarrayitem(op, &mut st);
                     st.emit_maybe_forwarded(op);
                     continue;
                 }
-                OpCode::SetarrayitemGc => {
+                OpCode::SetarrayitemGc if self.wb_descr.is_some() => {
                     // rewrite.py:401-404
                     self.consider_setarrayitem_gc(op, &mut st);
                     self.handle_write_barrier_setarrayitem(op, &mut st);
+                    st.emit_maybe_forwarded(op);
+                    continue;
+                }
+                // rewrite.py:405-412 — the `else` arm of that gate: the
+                // zero-init bookkeeping still runs and no barrier is emitted.
+                // Upstream reaches the ordinary lowering by *not* `continue`
+                // -ing; pyre's loop body ends at this match, so the same
+                // lowering is spelled out as the `emit_maybe_forwarded` the
+                // barrier arms and the catch-all both use.
+                // `SETINTERIORFIELD_GC` gets no `consider_*` there, so it
+                // falls to the catch-all unchanged.
+                OpCode::SetfieldGc => {
+                    self.consider_setfield_gc(op, &mut st);
+                    st.emit_maybe_forwarded(op);
+                    continue;
+                }
+                OpCode::SetarrayitemGc => {
+                    self.consider_setarrayitem_gc(op, &mut st);
                     st.emit_maybe_forwarded(op);
                     continue;
                 }
@@ -3390,7 +3424,7 @@ mod tests {
             nursery_free_addr: 0x1000,
             nursery_top_addr: 0x2000,
             max_nursery_size: 4096,
-            wb_descr: WriteBarrierDescr {
+            wb_descr: Some(WriteBarrierDescr {
                 jit_wb_if_flag: 1,
                 jit_wb_if_flag_byteofs: 0,
                 jit_wb_if_flag_singlebyte: 1,
@@ -3398,7 +3432,7 @@ mod tests {
                 jit_wb_card_page_shift: 0,
                 jit_wb_cards_set_byteofs: 0,
                 jit_wb_cards_set_singlebyte: 0,
-            },
+            }),
             jitframe_info: None,
             call_assembler_callee_locs: None,
             // llmodel.py:39 default keeps existing pre-scale-everything behavior
@@ -3776,6 +3810,71 @@ mod tests {
         assert_eq!(result[0].opcode, OpCode::CondCallGcWb);
         assert_eq!(result[0].arg(0).to_opref(), obj);
         assert_eq!(result[1].opcode, OpCode::GcStore);
+    }
+
+    #[test]
+    fn test_no_write_barrier_descr_emits_no_barrier_but_keeps_the_store() {
+        // rewrite.py:393 `if self.gc_ll_descr.write_barrier_descr is not
+        // None:` — a collector that needs no write barrier reports `None`
+        // (`gc.py:156 GcLLDescr_boehm.write_barrier_descr`), and the whole
+        // barrier section is skipped for it.  rewrite.py:405-412's `else`
+        // still lowers the store; only the barrier goes away.
+        //
+        // The backend asserts the same agreement from its side
+        // (`emit_write_barrier_fastpath_for_base` expects a descriptor
+        // because `COND_CALL_GC_WB` only exists if the rewriter emitted
+        // one), so emitting a barrier here would panic at assembly time.
+        let mut rw = make_rewriter();
+        rw.wb_descr = None;
+        let obj = OpRef::ref_op(0);
+        let val = OpRef::ref_op(1);
+        let ops = vec![Op::with_descr(
+            OpCode::SetfieldGc,
+            &[ro(obj), ro(val)],
+            ref_field_descr(),
+        )];
+
+        let result = rw.rewrite_for_gc(&ops);
+
+        assert!(
+            !result
+                .iter()
+                .any(|o| matches!(o.opcode, OpCode::CondCallGcWb | OpCode::CondCallGcWbArray)),
+            "no barrier may be emitted without a write barrier descriptor"
+        );
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].opcode, OpCode::GcStore);
+    }
+
+    #[test]
+    fn test_no_write_barrier_descr_still_lowers_setarrayitem() {
+        // rewrite.py:411-412 — the `else` arm calls `consider_setarrayitem_gc`
+        // and leaves the store to the ordinary lowering.
+        let mut rw = make_rewriter();
+        rw.wb_descr = None;
+        let arr = OpRef::ref_op(0);
+        let idx = OpRef::int_op(1);
+        let val = OpRef::ref_op(2);
+        let ops = vec![Op::with_descr(
+            OpCode::SetarrayitemGc,
+            &[ro(arr), ro(idx), ro(val)],
+            array_descr_ref(),
+        )];
+
+        let result = rw.rewrite_for_gc(&ops);
+
+        assert!(
+            !result
+                .iter()
+                .any(|o| matches!(o.opcode, OpCode::CondCallGcWb | OpCode::CondCallGcWbArray)),
+            "no barrier may be emitted without a write barrier descriptor"
+        );
+        assert!(
+            result
+                .iter()
+                .any(|o| matches!(o.opcode, OpCode::GcStore | OpCode::GcStoreIndexed)),
+            "the store itself must still be lowered: {result:?}"
+        );
     }
 
     #[test]
@@ -4885,7 +4984,7 @@ mod tests {
             nursery_free_addr: 0x1000,
             nursery_top_addr: 0x2000,
             max_nursery_size: 4096,
-            wb_descr: WriteBarrierDescr {
+            wb_descr: Some(WriteBarrierDescr {
                 jit_wb_if_flag: 1,
                 jit_wb_if_flag_byteofs: 0,
                 jit_wb_if_flag_singlebyte: 1,
@@ -4893,7 +4992,7 @@ mod tests {
                 jit_wb_card_page_shift: 7,
                 jit_wb_cards_set_byteofs: 0,
                 jit_wb_cards_set_singlebyte: 0x40,
-            },
+            }),
             jitframe_info: None,
             call_assembler_callee_locs: None,
             load_supported_factors: &[1],

--- a/majit/majit-macros/src/jit_interp/codegen_state.rs
+++ b/majit/majit-macros/src/jit_interp/codegen_state.rs
@@ -1222,6 +1222,17 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
             quote! { args.push(sym.#fname); }
         })
         .collect();
+    // Ref-bank mirror of `collect_scalar_values_parts`: the concrete pointer
+    // bits the walk carries for each ref state field, in ref-scalar index
+    // order. Consumed by the tracing-abort blackhole conversion, which seeds
+    // `registers_r[ref_scalar_slot(j)]` before running the aborted framestack.
+    let collect_ref_scalar_values_parts: Vec<TokenStream> = ref_scalars
+        .iter()
+        .map(|(_, f)| {
+            let value_name = quote::format_ident!("{}_value", f.name);
+            quote! { values.push(sym.#value_name); }
+        })
+        .collect();
     // Canonical ref-bank identity slots: ref scalar `j` lives at
     // `ref_regs[ref_identity_base + j]` so the guard-time snapshot's
     // live_r decode (`get_list_of_active_boxes`) and the blackhole's
@@ -2829,6 +2840,12 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
                 let mut values = Vec::new();
                 #(#collect_scalar_values_parts)*
                 #(#collect_float_scalar_values_parts)*
+                values
+            }
+
+            fn collect_ref_scalar_state_field_values(sym: &Self::Sym) -> Vec<i64> {
+                let mut values = Vec::new();
+                #(#collect_ref_scalar_values_parts)*
                 values
             }
 

--- a/majit/majit-macros/src/jit_interp/codegen_state.rs
+++ b/majit/majit-macros/src/jit_interp/codegen_state.rs
@@ -2597,7 +2597,7 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
             ) {
                 use majit_ir::resumedata::RebuiltValue;
                 use majit_metainterp::JitCodeSym as _;
-                if std::env::var_os("AHEUI_BRIDGE_DIAG").is_some() {
+                if std::env::var_os("MAJIT_BRIDGE_DIAG").is_some() {
                     eprintln!(
                         "[setup_bridge_sym] CALLED frames={} rd_virtuals={}",
                         resume_data.frames.len(),

--- a/majit/majit-macros/src/jit_interp/mod.rs
+++ b/majit/majit-macros/src/jit_interp/mod.rs
@@ -2081,7 +2081,23 @@ fn rewrite_body(
                         // `None` whenever the walk did not populate reds.
                         quote! {
                             if #driver.is_tracing() {
-                                let __mp_out = #merge_fn(&mut #driver, #env, #pc);
+                                let mut __mp_out = #merge_fn(&mut #driver, #env, #pc);
+                                // pyjitpl.py:2949
+                                // run_blackhole_interp_to_cancel_tracing: an
+                                // abort can stop mid-source-opcode, where the
+                                // walk's own pc names no resume position. The
+                                // Abort arm staged the framestack; finish those
+                                // opcodes in the blackhole here — the first
+                                // point that also holds `state` — and take the
+                                // resume pc from the merge point they reach.
+                                // `None` when the walk did not abort or the
+                                // conversion declined, leaving the source-pc
+                                // handoff below untouched.
+                                if let Some(__bh_pc) = #driver.run_pending_abort_blackhole(
+                                    &mut #state, #env,
+                                ) {
+                                    __mp_out = Some((__bh_pc, ::std::vec::Vec::new()));
+                                }
                                 if let Some((__sp_pc, __sp_reds)) = __mp_out
                                 {
                                     // Push the walk-mutated scalar state fields

--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -761,7 +761,17 @@ impl BlackholeInterpreter {
     /// `position` points at.  When such a sync precedes the anchor, step
     /// back over it to reach the result register; otherwise `position-1`
     /// holds it directly.
-    fn call_result_reg(&self) -> usize {
+    ///
+    /// `BC_INLINE_CALL` is the one caller shape that does NOT end in a single
+    /// result register: `JitCodeBuilder::inline_call_typed` closes every
+    /// variant with THREE return slots — `return_i`, `return_r`, `return_f`,
+    /// each a register byte or [`crate::jitcode::NO_RETURN_REG`] — because one
+    /// opcode covers all four result kinds.  At most one is a real register, so
+    /// a `NO_RETURN_REG` in the last byte identifies the three-slot tail (a
+    /// single-slot call being resumed always has a real register there, and
+    /// `push_reg_u8` never emits `NO_RETURN_REG` as one).  A float-returning
+    /// inline call needs no branch: its slot is last either way.
+    fn call_result_reg(&self, kind: BhReturnType) -> usize {
         // setfield_vable_i: op + struct_reg + value_reg + descr(2 bytes).
         const VSD_SYNC_LEN: usize = 5;
         // valuestackdepth static-field index (codewriter
@@ -782,6 +792,17 @@ impl BlackholeInterpreter {
                 }
             }
         }
+        if code[pos - 1] == crate::jitcode::NO_RETURN_REG && pos >= 3 {
+            let slot_back = match kind {
+                BhReturnType::Int => 3,
+                BhReturnType::Ref => 2,
+                // A void return sets up no value, so this arm is unreachable
+                // through `_setup_return_value_*`; keep it on the last slot,
+                // which is where the single-slot convention would land.
+                BhReturnType::Float | BhReturnType::Void => 1,
+            };
+            return code[pos - slot_back] as usize;
+        }
         code[pos - 1] as usize
     }
 
@@ -792,21 +813,21 @@ impl BlackholeInterpreter {
     /// blackhole.py:1653 _setup_return_value_i
     pub fn setup_return_value_i(&mut self, result: i64) {
         // blackhole.py:1655-1656
-        let reg_idx = self.call_result_reg();
+        let reg_idx = self.call_result_reg(BhReturnType::Int);
         self.registers_i[reg_idx] = result;
     }
 
     /// blackhole.py:1657 _setup_return_value_r
     pub fn setup_return_value_r(&mut self, result: i64) {
         // blackhole.py:1658-1659
-        let reg_idx = self.call_result_reg();
+        let reg_idx = self.call_result_reg(BhReturnType::Ref);
         self.registers_r[reg_idx] = result;
     }
 
     /// blackhole.py:1660 _setup_return_value_f
     pub fn setup_return_value_f(&mut self, result: i64) {
         // blackhole.py:1661-1662
-        let reg_idx = self.call_result_reg();
+        let reg_idx = self.call_result_reg(BhReturnType::Float);
         self.registers_f[reg_idx] = result;
     }
 
@@ -2449,15 +2470,32 @@ fn handle_jitexception(
     mut bh: BlackholeInterpreter,
     exc: JitException,
     portal_runner: Option<&dyn Fn(&JitException) -> Result<(BhReturnType, i64), JitException>>,
-    terminal_out: Option<&mut Option<BlackholeTerminalImage>>,
+    mut terminal_out: Option<&mut Option<BlackholeTerminalImage>>,
 ) -> Result<(BlackholeInterpreter, i64), JitException> {
     // blackhole.py:1764: while blackholeinterp.jitcode.jitdriver_sd is None
     while bh.jitcode.jitdriver_sd().is_none() {
         let next = bh.nextblackholeinterp.take();
-        builder.release_interp(bh);
         match next.map(|b| *b) {
-            Some(caller) => bh = caller,
-            None => return Err(exc), // no portal found
+            Some(caller) => {
+                builder.release_interp(bh);
+                bh = caller;
+            }
+            None => {
+                // No frame in the chain names a jitdriver.  Upstream cannot
+                // reach this: `call.py:147` pairs `jd.mainjitcode` with
+                // `jitcode.jitdriver_sd`, so the portal frame always stops the
+                // walk.  A `#[jit_interp]` dispatch JitCode carries no such
+                // slot (`JitDriver::register_dispatch_jitcode` links only the
+                // `mainjitcode` direction), so its chain runs off the end here.
+                // The frame reached last is still the one the exception escaped
+                // from, which is what the terminal image means — take it before
+                // the release recycles the banks.
+                if let Some(terminal_out) = terminal_out.take() {
+                    *terminal_out = Some(BlackholeTerminalImage::take_from(&mut bh));
+                }
+                builder.release_interp(bh);
+                return Err(exc);
+            }
         }
     }
 
@@ -3460,6 +3498,38 @@ mod tests {
                 outcome,
                 crate::jitexc::JitException::DoneWithThisFrameInt(42)
             );
+        }
+
+        /// `_setup_return_value_i` must read `BC_INLINE_CALL`'s `return_i` slot,
+        /// not the byte before the resume position.
+        ///
+        /// `JitCodeBuilder::inline_call_typed` closes every inline call with
+        /// three return slots (`return_i`, `return_r`, `return_f`), so a call
+        /// whose result is an int leaves `NO_RETURN_REG` in the last two.
+        /// Reading `code[position - 1]` — RPython's single-slot
+        /// `blackhole.py:1655` convention — picks up that sentinel and indexes
+        /// `registers_i` out of bounds.  Observed as an index-out-of-bounds
+        /// panic when a tracing-abort blackhole chain returned an int into the
+        /// dispatch jitcode that had inlined it.
+        #[test]
+        fn setup_return_value_i_reads_inline_calls_int_return_slot() {
+            let mut b = JitCodeBuilder::default();
+            b.inline_call_r_i(0, &[], Some(7));
+            let jitcode = b.finish();
+            // The call is the whole body, so the position the caller resumes at
+            // is the end of the code.
+            let resume_pos = jitcode.code.len();
+            assert_eq!(
+                jitcode.code[resume_pos - 1],
+                crate::jitcode::NO_RETURN_REG,
+                "inline call should end on the unused return_f slot",
+            );
+
+            let mut builder = build_test_bh_builder();
+            let mut bh = builder.acquire_interp();
+            bh.setposition(std::sync::Arc::new(jitcode), resume_pos);
+            bh.setup_return_value_i(42);
+            assert_eq!(bh.registers_i[7], 42);
         }
 
         #[test]
@@ -8260,6 +8330,21 @@ pub fn build_inline_call_only_bh_builder() -> BlackholeInterpBuilder {
     insns.insert(
         "new_array_clear/id>r".to_string(),
         majit_translate::insns::BC_NEW_ARRAY_CLEAR,
+    );
+    // Plain struct allocation (`blackhole.py:1301-1310 bhimpl_new` /
+    // `bhimpl_new_with_vtable`) — a `#[jit_interp]` frontend's declared
+    // `struct_allocs` literal lowers straight to it, so any resume that walks
+    // forward over one needs the byte dispatchable.  The handlers were already
+    // wired in `wire_bhimpl_handlers`; only the opname→byte entries were
+    // missing, which turns into a `dispatch_step: unwired opcode` panic.
+    insns.insert("new/d>r".to_string(), majit_translate::insns::BC_NEW);
+    insns.insert(
+        "new_with_vtable/d>r".to_string(),
+        majit_translate::insns::BC_NEW_WITH_VTABLE,
+    );
+    insns.insert(
+        "new_array/id>r".to_string(),
+        majit_translate::insns::BC_NEW_ARRAY,
     );
     insns.insert(
         "setarrayitem_gc_r/rcrd".to_string(),

--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -2470,32 +2470,15 @@ fn handle_jitexception(
     mut bh: BlackholeInterpreter,
     exc: JitException,
     portal_runner: Option<&dyn Fn(&JitException) -> Result<(BhReturnType, i64), JitException>>,
-    mut terminal_out: Option<&mut Option<BlackholeTerminalImage>>,
+    terminal_out: Option<&mut Option<BlackholeTerminalImage>>,
 ) -> Result<(BlackholeInterpreter, i64), JitException> {
     // blackhole.py:1764: while blackholeinterp.jitcode.jitdriver_sd is None
     while bh.jitcode.jitdriver_sd().is_none() {
         let next = bh.nextblackholeinterp.take();
+        builder.release_interp(bh);
         match next.map(|b| *b) {
-            Some(caller) => {
-                builder.release_interp(bh);
-                bh = caller;
-            }
-            None => {
-                // No frame in the chain names a jitdriver.  Upstream cannot
-                // reach this: `call.py:147` pairs `jd.mainjitcode` with
-                // `jitcode.jitdriver_sd`, so the portal frame always stops the
-                // walk.  A `#[jit_interp]` dispatch JitCode carries no such
-                // slot (`JitDriver::register_dispatch_jitcode` links only the
-                // `mainjitcode` direction), so its chain runs off the end here.
-                // The frame reached last is still the one the exception escaped
-                // from, which is what the terminal image means — take it before
-                // the release recycles the banks.
-                if let Some(terminal_out) = terminal_out.take() {
-                    *terminal_out = Some(BlackholeTerminalImage::take_from(&mut bh));
-                }
-                builder.release_interp(bh);
-                return Err(exc);
-            }
+            Some(caller) => bh = caller,
+            None => return Err(exc), // no portal found
         }
     }
 
@@ -3947,6 +3930,58 @@ mod tests {
         /// frame that DOES have a caller — the recursive-portal arm.
         /// Re-entering `inner` instead would run its tail a second time
         /// and overwrite the portal runner's result with `inner`'s own.
+        /// `blackhole.py:1764-1769`: the walk up the chain stops at the frame
+        /// whose jitcode names a jitdriver, and a bottommost such frame
+        /// publishes its terminal image before the exception propagates.
+        ///
+        /// That only holds because `call.py:148` gives every portal jitcode its
+        /// `jitdriver_sd` back-pointer.  Without it the walk runs off the end of
+        /// the chain and returns through the "no portal found" arm, where the
+        /// image is never taken — which is what a `#[jit_interp]` frontend saw
+        /// before `JitDriver::register_dispatch_jitcode` set the slot.
+        #[test]
+        fn handle_jitexception_publishes_terminal_only_when_a_frame_names_its_jitdriver() {
+            let build_chain = |portal: bool| {
+                let mut b = JitCodeBuilder::default();
+                b.load_const_i_value(0, 42);
+                b.int_return(0);
+                let jitcode = b.finish();
+                jitcode.set_index(0);
+                if portal {
+                    jitcode.set_jitdriver_sd(0);
+                }
+                jitcode
+            };
+
+            for portal in [true, false] {
+                let mut builder = super::build_inline_call_only_bh_builder();
+                let mut bh = builder.acquire_interp();
+                bh.setposition(std::sync::Arc::new(build_chain(portal)), 0);
+                bh.registers_i[0] = 42;
+
+                let mut terminal = None;
+                let outcome = super::handle_jitexception(
+                    &mut builder,
+                    bh,
+                    crate::jitexc::JitException::DoneWithThisFrameInt(42),
+                    None,
+                    Some(&mut terminal),
+                );
+                assert!(
+                    outcome.is_err(),
+                    "a bottommost frame always propagates the exception",
+                );
+                assert_eq!(
+                    terminal.is_some(),
+                    portal,
+                    "terminal image published for portal={portal}",
+                );
+                if let Some(terminal) = terminal {
+                    assert_eq!(terminal.registers_i[0], 42);
+                }
+            }
+        }
+
         #[test]
         fn run_forever_steps_past_the_portal_frame_after_handle_jitexception() {
             let mut sub = JitCodeBuilder::default();

--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -5451,6 +5451,14 @@ impl StateFieldLayout {
         );
         self.array_base(array_idx) + elem
     }
+
+    /// Flat slot of the virtualizable identity, which follows every scalar and
+    /// every flattened array element — `virtualizable.py:139-144` names the
+    /// virtualizable exactly once, however many `[.. ; virt]` arrays the state
+    /// declares.  `None` when the state has no virtualizable.
+    pub fn vable_identity_slot(&self) -> Option<usize> {
+        (self.num_vable_identity_slots != 0).then(|| self.array_base(self.array_lens.len()))
+    }
 }
 
 // pyre-only: `state_field` family. RPython has no opcode counterpart — the

--- a/majit/majit-metainterp/src/jit_state.rs
+++ b/majit/majit-metainterp/src/jit_state.rs
@@ -398,6 +398,15 @@ pub trait JitState: Sized {
         Vec::new()
     }
 
+    /// Ref-bank sibling of [`collect_scalar_state_field_values`], in ref-scalar
+    /// state-field index order (idx `0..num_ref_scalars`). Raw pointer bits, the
+    /// encoding `registers_r` holds. Read off the same still-live sym, for the
+    /// same reason: the walk keeps ref state fields on the sym and native
+    /// `state` is frozen at trace-start.
+    fn collect_ref_scalar_state_field_values(_sym: &Self::Sym) -> Vec<i64> {
+        Vec::new()
+    }
+
     /// Whole-circuit single-pass: write the walk's scalar state-field concrete
     /// values (captured at close time by `collect_scalar_state_field_values`)
     /// into native state. `values[idx]` is the scalar at state-field index

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -266,6 +266,15 @@ pub struct PendingAbortBlackhole {
     pub scalar_values: Vec<i64>,
     /// `JitState::collect_ref_scalar_state_field_values`.
     pub ref_scalar_values: Vec<i64>,
+    /// `metainterp.last_exc_value` as `blackhole.py:1811-1814` reads it —
+    /// snapshotted at the abort because the accounting that follows clears the
+    /// tracing state it lives on.  `0` for a null exception.
+    pub last_exc_value: i64,
+    /// `SwitchToBlackhole.raising_exception` (`history.py:37-43`): true when the
+    /// abort was raised at a point where `last_exc_value` is still *supposed to
+    /// be raised*, so the conversion hands it to the chain instead of merely
+    /// copying it into the first frame's `exception_last_value`.
+    pub raising_exception: bool,
 }
 
 /// Run a tracing MIFrame chain through the structured multi-frame blackhole
@@ -1526,18 +1535,27 @@ impl<S: JitState> JitDriver<S> {
                 }
             }
         }
-        // call.py:147 `jd.mainjitcode = self.get_jitcode(jd.portal_graph)` — the
-        // portal JitCode belongs to the driver's static data, not to the runtime
-        // driver. The back-pointer of call.py:148 has no counterpart here: the
-        // metainterp-side `JitCode` carries no `jitdriver_sd` slot (only the
-        // translate-side one does, via `set_jitdriver_sd`), so the slot index
-        // below is the link in that direction.
+        // call.py:147-148 `grab_initial_jitcodes`:
+        //
+        //     jd.mainjitcode = self.get_jitcode(jd.portal_graph)
+        //     jd.mainjitcode.jitdriver_sd = jd
+        //
+        // Both directions, as upstream sets them: the driver's static data owns
+        // the portal JitCode, and the portal JitCode names its driver back.
         // `call.py:46-47 jd.index = idx` is this driver's own slot — the macro's
         // install pipeline runs `ensure_descriptor_registered` before reaching
         // here, so it is assigned. Fall back to the single-portal slot 0 only
         // when a consumer skipped that step.
         self.ensure_descriptor_registered();
         let portal_jd_index = self.index().unwrap_or(0);
+        // The back-pointer is what makes this jitcode a *portal* jitcode to
+        // every reader of `JitCode::jitdriver_sd`: `pyjitpl.py:2451
+        // is_main_jitcode`, `pyjitpl.py:1279 _try_tco`'s portal-frame opt-out,
+        // and `blackhole.py:1764`'s walk up a blackhole chain, which without it
+        // runs off the bottom of a `#[jit_interp]` frontend's chain instead of
+        // stopping at its root.  Translation-side jitcodes get it from
+        // `codewriter.rs:1036`; this is the macro frontend's equivalent.
+        dispatch_arc.set_jitdriver_sd(portal_jd_index);
         self.meta
             .jitdriver_sd_mut(portal_jd_index)
             .expect("register_dispatch_jitcode: this driver's jitdrivers_sd slot is vacant")
@@ -1910,6 +1928,8 @@ impl<S: JitState> JitDriver<S> {
             mut framestack,
             scalar_values,
             ref_scalar_values,
+            last_exc_value,
+            raising_exception,
         } = pending;
         let layout = state.state_field_layout();
         if layout.num_vable_identity_slots != 0 || !layout.array_lens.is_empty() {
@@ -1958,11 +1978,8 @@ impl<S: JitState> JitDriver<S> {
             0,
             0,
             staticdata,
-            // `stb.raising_exception` is not carried across the abort boundary
-            // yet (see the `merge_point` Abort arm), so the chain starts with
-            // no pending exception.
-            0,
-            false,
+            last_exc_value,
+            raising_exception,
             None,
             None,
         );
@@ -3320,22 +3337,23 @@ impl<S: JitState> JitDriver<S> {
                 // `convert_and_run_from_pyjitpl(self, stb.raising_exception)`
                 // — is staged below into `MetaInterp::pending_abort_blackhole`
                 // and run by [`JitDriver::run_pending_abort_blackhole`], which
-                // is the first point that also holds native `state`.
-                //
-                // `stb.raising_exception` (`pyjitpl.py:3391-3393`: a
-                // virtualizable-escape abort carries the forcing residual's
-                // pending exception into the blackhole) is not staged with it
-                // yet: `TraceCtx::pending_switch_to_blackhole` records the
-                // reason but no exception value, so the conversion runs with
-                // `raising_exception = false` and an escape abort still drops
-                // the helper-side exception at this boundary.
-                let pending_reason = self
+                // is the first point that also holds native `state`.  Both
+                // halves read the same drained `stb`, so take it whole rather
+                // than just its reason.
+                let pending_stb = self
                     .meta
                     .tracing
                     .as_mut()
-                    .and_then(|t| t.pending_switch_to_blackhole.take())
-                    .map(|stb| stb.reason);
-                let reason_int = match pending_reason {
+                    .and_then(|t| t.pending_switch_to_blackhole.take());
+                // `history.py:37-43`: false unless the abort site raised at a
+                // point where `last_exc_value` still has to be raised
+                // (`pyjitpl.py:3389-3390` vable escape, `pyjitpl.py:3714-3716`
+                // `do_not_in_trace_call`).  The `ABORT_TOO_LONG` path below has
+                // no `stb` at all and defaults to false, as upstream's
+                // `SwitchToBlackhole(ABORT_TOO_LONG)` does.
+                let abort_raising_exception =
+                    pending_stb.as_ref().is_some_and(|stb| stb.raising_exception);
+                let reason_int = match pending_stb.map(|stb| stb.reason) {
                     Some(r) => r,
                     None => self
                         .meta
@@ -3389,6 +3407,13 @@ impl<S: JitState> JitDriver<S> {
                                 framestack,
                                 scalar_values: S::collect_scalar_state_field_values(sym),
                                 ref_scalar_values: S::collect_ref_scalar_state_field_values(sym),
+                                // `blackhole.py:1811-1814` reads
+                                // `metainterp.last_exc_value` at conversion
+                                // time; snapshot it here because
+                                // `abort_trace_live` below tears down the
+                                // tracing state it belongs to.
+                                last_exc_value: self.meta.last_exc_value,
+                                raising_exception: abort_raising_exception,
                             });
                         }
                     }

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -474,23 +474,6 @@ fn portal_rca_enabled() -> bool {
     *FLAG.get_or_init(|| std::env::var_os("PYRE_PORTAL_RCA").is_some())
 }
 
-/// `MAJIT_ABORT_BLACKHOLE=0` opts out of routing a tracing abort through
-/// `blackhole.py:1799 convert_and_run_from_pyjitpl`, leaving the abort on the
-/// walk's raw source pc.
-///
-/// RPython has no switch here — `pyjitpl.py:2949` always converts — so this is
-/// an escape hatch, not a policy: the conversion re-enters the aborted
-/// framestack in the blackhole, which needs the frontend's whole dispatch
-/// jitcode to be dispatchable there.  A frontend that trips an unwired opcode
-/// can fall back with it while the gap is closed.
-fn abort_blackhole_enabled() -> bool {
-    static FLAG: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *FLAG.get_or_init(|| match std::env::var_os("MAJIT_ABORT_BLACKHOLE") {
-        Some(v) => v != "0" && v != "false",
-        None => true,
-    })
-}
-
 fn format_rca_live_values(labels: Option<&[String]>, values: &[Value]) -> String {
     let mut out = String::new();
     for (idx, value) in values.iter().enumerate() {
@@ -1921,8 +1904,7 @@ impl<S: JitState> JitDriver<S> {
     /// Returns the resume pc when the conversion ran and reached a merge point,
     /// having already written the blackhole's register banks back into `state`.
     /// `None` leaves the abort on the pre-existing source-pc handoff — the walk
-    /// did not abort, the gate is off, or the state shape has no seed path (see
-    /// below).
+    /// did not abort, or the state shape has no seed path (see below).
     ///
     /// ⚠️ **`None` means "declined before the chain ran", and only that.** Once
     /// `drive_multi_frame_blackhole` returns, the chain has executed the rest
@@ -3486,35 +3468,30 @@ impl<S: JitState> JitDriver<S> {
                     // sym's state-field image so the `jit_merge_point!` hook can
                     // finish the half-executed opcodes in the blackhole and take
                     // the resume position from the merge point they reach.
-                    if abort_blackhole_enabled() {
-                        let staged = self.meta.trace_ctx().and_then(|ctx| {
-                            let framestack = ctx.aborted_framestack.take()?;
-                            Some((
-                                framestack,
-                                ctx.collect_virtualizable_element_values(),
-                                ctx.virtualizable_heap_ptr().map_or(0, |p| p as i64),
-                            ))
+                    let staged = self.meta.trace_ctx().and_then(|ctx| {
+                        let framestack = ctx.aborted_framestack.take()?;
+                        Some((
+                            framestack,
+                            ctx.collect_virtualizable_element_values(),
+                            ctx.virtualizable_heap_ptr().map_or(0, |p| p as i64),
+                        ))
+                    });
+                    if let (Some((framestack, virt_array_values, virtualizable_ptr)), Some(sym)) =
+                        (staged, self.sym.as_ref())
+                    {
+                        self.meta.pending_abort_blackhole = Some(PendingAbortBlackhole {
+                            framestack,
+                            scalar_values: S::collect_scalar_state_field_values(sym),
+                            ref_scalar_values: S::collect_ref_scalar_state_field_values(sym),
+                            virt_array_values,
+                            virtualizable_ptr,
+                            // `blackhole.py:1811-1814` reads
+                            // `metainterp.last_exc_value` at conversion time;
+                            // snapshot it here because `abort_trace_live` below
+                            // tears down the tracing state it belongs to.
+                            last_exc_value: self.meta.last_exc_value,
+                            raising_exception: abort_raising_exception,
                         });
-                        if let (
-                            Some((framestack, virt_array_values, virtualizable_ptr)),
-                            Some(sym),
-                        ) = (staged, self.sym.as_ref())
-                        {
-                            self.meta.pending_abort_blackhole = Some(PendingAbortBlackhole {
-                                framestack,
-                                scalar_values: S::collect_scalar_state_field_values(sym),
-                                ref_scalar_values: S::collect_ref_scalar_state_field_values(sym),
-                                virt_array_values,
-                                virtualizable_ptr,
-                                // `blackhole.py:1811-1814` reads
-                                // `metainterp.last_exc_value` at conversion
-                                // time; snapshot it here because
-                                // `abort_trace_live` below tears down the
-                                // tracing state it belongs to.
-                                last_exc_value: self.meta.last_exc_value,
-                                raising_exception: abort_raising_exception,
-                            });
-                        }
                     }
                 }
                 self.meta.abort_trace_live(false);

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -246,6 +246,28 @@ pub struct MultiFrameBlackholeResult {
     pub terminal: Option<crate::blackhole::BlackholeTerminalImage>,
 }
 
+/// `pyjitpl.py:2949 run_blackhole_interp_to_cancel_tracing` input, captured at
+/// the abort and cashed in one step later.
+///
+/// RPython runs the conversion inline in the abort handler because
+/// `metainterp.framestack` and the interpreter state are both reachable there.
+/// Pyre's abort handler (`merge_point`'s `TraceAction::Abort` arm) sees the
+/// framestack and the live sym but not native `state`, and the blackhole needs
+/// `JitState::state_field_layout` to know which registers the `state_field`
+/// handlers read.  So the arm records both halves here and the
+/// `jit_merge_point!` hook — the first point that holds `state` — runs
+/// [`JitDriver::run_pending_abort_blackhole`].
+pub struct PendingAbortBlackhole {
+    /// The aborting walk's frames, outermost first, each already carrying its
+    /// own resume `pc` (`blackhole.py:1804 _copy_data_from_miframe`).
+    pub framestack: crate::pyjitpl::MIFrameStack,
+    /// `JitState::collect_scalar_state_field_values` — int scalars followed by
+    /// float scalars, read off the sym while it was still live.
+    pub scalar_values: Vec<i64>,
+    /// `JitState::collect_ref_scalar_state_field_values`.
+    pub ref_scalar_values: Vec<i64>,
+}
+
 /// Run a tracing MIFrame chain through the structured multi-frame blackhole
 /// conversion.  Every frame shares the portal-level virtualizable layout, but
 /// retains its own jitcode, register banks, and blackhole interpreter.
@@ -431,6 +453,23 @@ fn failvals_enabled() -> bool {
 fn portal_rca_enabled() -> bool {
     static FLAG: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     *FLAG.get_or_init(|| std::env::var_os("PYRE_PORTAL_RCA").is_some())
+}
+
+/// `MAJIT_ABORT_BLACKHOLE=0` opts out of routing a tracing abort through
+/// `blackhole.py:1799 convert_and_run_from_pyjitpl`, leaving the abort on the
+/// walk's raw source pc.
+///
+/// RPython has no switch here — `pyjitpl.py:2949` always converts — so this is
+/// an escape hatch, not a policy: the conversion re-enters the aborted
+/// framestack in the blackhole, which needs the frontend's whole dispatch
+/// jitcode to be dispatchable there.  A frontend that trips an unwired opcode
+/// can fall back with it while the gap is closed.
+fn abort_blackhole_enabled() -> bool {
+    static FLAG: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *FLAG.get_or_init(|| match std::env::var_os("MAJIT_ABORT_BLACKHOLE") {
+        Some(v) => v != "0" && v != "false",
+        None => true,
+    })
 }
 
 fn format_rca_live_values(labels: Option<&[String]>, values: &[Value]) -> String {
@@ -1837,6 +1876,171 @@ impl<S: JitState> JitDriver<S> {
         self.meta.single_pass_outcome.take()
     }
 
+    /// `pyjitpl.py:2949 run_blackhole_interp_to_cancel_tracing` →
+    /// `blackhole.py:1799 convert_and_run_from_pyjitpl`.
+    ///
+    /// A tracing abort can land anywhere in the portal jitcode, including in
+    /// the middle of a source opcode whose remaining effects have not run.  The
+    /// walk's own registers name no source position there, so RPython does not
+    /// read one: it converts `metainterp.framestack` into a blackhole chain,
+    /// runs it forward until the bottommost frame reaches its
+    /// `jit_merge_point`, and resumes the interpreter from the greens that
+    /// merge point reports (`blackhole.py:1068-1069` raises
+    /// `ContinueRunningNormally`, caught by `warmspot.py:961
+    /// handle_jitexception`).  Every opcode the walk left half-executed
+    /// therefore *finishes* instead of being skipped.
+    ///
+    /// Returns the resume pc when the conversion ran and reached a merge point,
+    /// having already written the blackhole's register banks back into `state`.
+    /// `None` leaves the abort on the pre-existing source-pc handoff — the walk
+    /// did not abort, the gate is off, or the state shape has no seed path (see
+    /// below).
+    ///
+    /// **Seeding.** The walk keeps state fields on the sym; the blackhole reads
+    /// them out of the identity registers `StateFieldLayout` names.  The abort
+    /// arm captured the sym's image, and this places it into the root frame's
+    /// banks before the conversion.  Two shapes have no counterpart yet and
+    /// decline: a virtualizable array (`num_vable_identity_slots != 0` — pyre's
+    /// own frame-blackhole path owns that case, `trace.rs`
+    /// `drive_multi_frame_blackhole`) and a flattened fixed `[int]` array
+    /// (`array_lens`), whose per-element slots have no sym collector.
+    pub fn run_pending_abort_blackhole(&mut self, state: &mut S, env: &S::Env) -> Option<usize> {
+        let pending = self.meta.pending_abort_blackhole.take()?;
+        let PendingAbortBlackhole {
+            mut framestack,
+            scalar_values,
+            ref_scalar_values,
+        } = pending;
+        let layout = state.state_field_layout();
+        if layout.num_vable_identity_slots != 0 || !layout.array_lens.is_empty() {
+            if crate::majit_log_enabled() {
+                eprintln!(
+                    "[bh] abort-blackhole declined: unseeded state shape \
+                     (vable_identity={} arrays={})",
+                    layout.num_vable_identity_slots,
+                    layout.array_lens.len(),
+                );
+            }
+            return None;
+        }
+        let Some(root) = framestack.frames.first_mut() else {
+            return None;
+        };
+        // `scalar_values` is `[int scalars.., float scalars..]` — the order
+        // `collect_scalar_state_field_values` builds and
+        // `writeback_scalar_state_fields_from_values` consumes.
+        for (field_idx, value) in scalar_values.iter().take(layout.num_scalars).enumerate() {
+            let slot = layout.scalar_slot(field_idx);
+            if slot < root.int_values.len() {
+                root.int_values[slot] = Some(*value);
+            }
+        }
+        for (field_idx, value) in scalar_values.iter().skip(layout.num_scalars).enumerate() {
+            let slot = layout.float_scalar_slot(field_idx);
+            if slot < root.float_values.len() {
+                root.float_values[slot] = Some(*value);
+            }
+        }
+        for (field_idx, value) in ref_scalar_values.iter().enumerate() {
+            let slot = layout.ref_scalar_slot(field_idx);
+            if slot < root.ref_values.len() {
+                root.ref_values[slot] = Some(*value);
+            }
+        }
+
+        let mut bh_builder = BackEdgeBhBuilder::lease();
+        let staticdata = &self.meta.staticdata;
+        let outcome = drive_multi_frame_blackhole(
+            &mut bh_builder,
+            &mut framestack,
+            layout.clone(),
+            std::ptr::null(),
+            0,
+            0,
+            staticdata,
+            // `stb.raising_exception` is not carried across the abort boundary
+            // yet (see the `merge_point` Abort arm), so the chain starts with
+            // no pending exception.
+            0,
+            false,
+            None,
+            None,
+        );
+        let MultiFrameBlackholeResult { outcome, terminal } = outcome;
+        if crate::majit_log_enabled() {
+            eprintln!("[bh] abort-blackhole: convert_and_run → {:?}", outcome);
+        }
+        // The chain has run: it executed the rest of the half-finished opcodes
+        // against the real heap.  The sym image the Abort arm staged predates
+        // those effects, so applying it would roll `state` back to before them
+        // — but only the terminal image can replace it, so keep it as the
+        // fallback when the run produced none.
+        if terminal.is_some() {
+            self.meta.single_pass_scalar_values = None;
+            self.meta.single_pass_virt_array_values = None;
+        } else if crate::majit_log_enabled() {
+            eprintln!(
+                "[bh] abort-blackhole: no terminal image — state falls back to \
+                 the staged sym scalars"
+            );
+        }
+        // `warmspot.py:961 handle_jitexception` reads the terminal frame's
+        // banks the same way the guard-failure resume does
+        // (`back_edge_structured`'s CRN arm).
+        let writeback = |state: &mut S, resume_pc: usize| {
+            let Some(terminal) = terminal.as_ref() else {
+                return;
+            };
+            let int_base = layout.int_scalar_base.min(terminal.registers_i.len());
+            let ref_base = layout.ref_scalar_base.min(terminal.registers_r.len());
+            let float_base = layout.float_scalar_base.min(terminal.registers_f.len());
+            let meta = S::build_meta(state, resume_pc, env);
+            state.restore_banked3(
+                &meta,
+                &terminal.registers_i[int_base..],
+                &terminal.registers_r[ref_base..],
+                &terminal.registers_f[float_base..],
+            );
+            state.recover_after_compiled_run();
+        };
+        match outcome {
+            // The bottommost frame reached its `jit_merge_point`
+            // (`blackhole.py:1068-1069`): resume the interpreter at the green
+            // pc it reported.  Every `greens` declaration puts `pc` first.
+            crate::jitexc::JitException::ContinueRunningNormally { ref green_int, .. } => {
+                let resume_pc = green_int.first().map(|&pc| pc as usize)?;
+                writeback(state, resume_pc);
+                Some(resume_pc)
+            }
+            // The portal itself returned inside the blackhole
+            // (`blackhole.py:1664 _done_with_this_frame`).  There is no forward
+            // green pc; the native dispatch loop must exit and run its own
+            // post-loop return, which is what `single_pass_finish` tells the
+            // `jit_merge_point!` hook to do — it breaks before reading the pc.
+            crate::jitexc::JitException::DoneWithThisFrameVoid
+            | crate::jitexc::JitException::DoneWithThisFrameInt(_)
+            | crate::jitexc::JitException::DoneWithThisFrameRef(_)
+            | crate::jitexc::JitException::DoneWithThisFrameFloat(_) => {
+                // `usize::MAX` is the same "no forward pc" sentinel the
+                // guard-failure resume uses for this outcome.  It reaches
+                // `build_meta` only as the `header_pc` the `#[jit_interp]`
+                // impl ignores, and the hook breaks before using it as a pc.
+                writeback(state, usize::MAX);
+                self.meta.single_pass_finish = true;
+                Some(usize::MAX)
+            }
+            // `blackhole.py:1679 _exit_frame_with_exception` → the exception
+            // escaped every converted frame.  Hand it to the interpreter's own
+            // machinery; an interpreter with no exception surface returns
+            // `None` and the walk falls back to the source-pc handoff.
+            crate::jitexc::JitException::ExitFrameWithExceptionRef(exc) => {
+                let resume_pc = state.deliver_blackhole_exception(exc)?;
+                writeback(state, resume_pc);
+                Some(resume_pc)
+            }
+        }
+    }
+
     /// Whether the just-published single-pass outcome came from a terminal
     /// dispatch return (`TraceAction::Finish`) rather than a `CloseLoop`
     /// back-edge. A CloseLoop resumes the native loop at the merge-point green
@@ -2299,6 +2503,11 @@ impl<S: JitState> JitDriver<S> {
         if !self.meta.is_tracing() {
             return;
         }
+        // A stash still here belongs to an earlier abort whose consumer never
+        // ran (a `jit_merge_point!` expansion without a `state` argument, or a
+        // non-macro driver).  It names frames from a finished walk, so drop it
+        // rather than let this merge point's handoff read it.
+        self.meta.pending_abort_blackhole = None;
         if self.sym.is_none() || self.meta.trace_meta().is_none() {
             crate::debug::log_one("jit-abort", "mp: abort:sym_none");
             self.meta.abort_trace(false);
@@ -3106,27 +3315,20 @@ impl<S: JitState> JitDriver<S> {
                 // `SwitchToBlackhole(ABORT_TOO_LONG)`
                 // path (`pyjitpl.py:2807`).
                 //
-                // TODO: virtualizable-escape aborts
-                // in RPython actually flow through
-                // `pyjitpl.py:2907-2916 _compile_and_run_once` →
-                // `pyjitpl.py:2949 run_blackhole_interp_to_cancel_tracing(stb)`,
-                // which calls `aborted_tracing(stb.reason)` AND
-                // `convert_and_run_from_pyjitpl(self,
-                // stb.raising_exception)` — the latter converts the
-                // framestack into blackhole interpreters and runs them
-                // with the `raising_exception` flag so the residual
-                // call's eventual exception is preserved
-                // (`pyjitpl.py:3391-3393` comment).  Pyre wires only
-                // the accounting half here; the `convert_and_run_from_pyjitpl`
-                // helper exists in `blackhole.rs` (port of
-                // `blackhole.py:1799`) but is not yet invoked from
-                // this consumer, so `stb.raising_exception` is
-                // currently a no-op and the helper-side exception is
-                // dropped at the abort boundary.  Full cancel-tracing
-                // semantics requires `BlackholeInterpBuilder` +
-                // `last_exc_value` plumbed here and a JitException
-                // return surface on the back-edge runner —
-                // followup.
+                // The other half of `pyjitpl.py:2949
+                // run_blackhole_interp_to_cancel_tracing(stb)` —
+                // `convert_and_run_from_pyjitpl(self, stb.raising_exception)`
+                // — is staged below into `MetaInterp::pending_abort_blackhole`
+                // and run by [`JitDriver::run_pending_abort_blackhole`], which
+                // is the first point that also holds native `state`.
+                //
+                // `stb.raising_exception` (`pyjitpl.py:3391-3393`: a
+                // virtualizable-escape abort carries the forcing residual's
+                // pending exception into the blackhole) is not staged with it
+                // yet: `TraceCtx::pending_switch_to_blackhole` records the
+                // reason but no exception value, so the conversion runs with
+                // `raising_exception = false` and an escape abort still drops
+                // the helper-side exception at this boundary.
                 let pending_reason = self
                     .meta
                     .tracing
@@ -3168,6 +3370,26 @@ impl<S: JitState> JitDriver<S> {
                             .and_then(|ctx| ctx.collect_virtualizable_element_values());
                         if let Some(elems) = virt_elems {
                             self.meta.single_pass_virt_array_values = Some(elems);
+                        }
+                    }
+                    // `pyjitpl.py:2954 convert_and_run_from_pyjitpl(self,
+                    // stb.raising_exception)`: the source pc above is only a
+                    // sound resume position when the walk happened to stop at a
+                    // source-opcode boundary.  Stage the framestack and the
+                    // sym's state-field image so the `jit_merge_point!` hook can
+                    // finish the half-executed opcodes in the blackhole and take
+                    // the resume position from the merge point they reach.
+                    if abort_blackhole_enabled() {
+                        let framestack = self
+                            .meta
+                            .trace_ctx()
+                            .and_then(|ctx| ctx.aborted_framestack.take());
+                        if let (Some(framestack), Some(sym)) = (framestack, self.sym.as_ref()) {
+                            self.meta.pending_abort_blackhole = Some(PendingAbortBlackhole {
+                                framestack,
+                                scalar_values: S::collect_scalar_state_field_values(sym),
+                                ref_scalar_values: S::collect_ref_scalar_state_field_values(sym),
+                            });
                         }
                     }
                 }

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -1924,6 +1924,17 @@ impl<S: JitState> JitDriver<S> {
     /// did not abort, the gate is off, or the state shape has no seed path (see
     /// below).
     ///
+    /// ⚠️ **`None` means "declined before the chain ran", and only that.** Once
+    /// `drive_multi_frame_blackhole` returns, the chain has executed the rest
+    /// of the half-finished opcodes against the real heap; the caller's
+    /// source-pc handoff resumes at a pc dispatch advanced *before* those
+    /// opcodes' arms, so answering `None` there runs them a second time —
+    /// the very double-application this conversion exists to prevent. Every
+    /// post-chain path therefore returns `Some`, using the `single_pass_finish`
+    /// + `usize::MAX` "no forward pc" outcome when it has no merge point to
+    /// resume at. Upstream has no such split: `blackhole.py:1799
+    /// convert_and_run_from_pyjitpl` never returns to its caller at all.
+    ///
     /// **Seeding.** The walk keeps state fields on the sym; the blackhole reads
     /// them out of the identity registers `StateFieldLayout` names.  The abort
     /// arm captured the sym's image, and this places it into the root frame's
@@ -2065,16 +2076,22 @@ impl<S: JitState> JitDriver<S> {
             // pc it reported.  Every `greens` declaration puts `pc` first.
             crate::jitexc::JitException::ContinueRunningNormally { ref green_int, .. } => {
                 let Some(&resume_pc) = green_int.first() else {
-                    // Unreachable for any declared jitdriver.  Say so loudly
-                    // rather than fall back: the chain has already run the
-                    // aborted opcodes' tails against the real heap, so resuming
-                    // at the walk's source pc would execute them a second time.
+                    // Unreachable for any declared jitdriver — every `greens`
+                    // declaration puts `pc` first.  Do NOT return `None`: that
+                    // is the pre-chain decline answer, and the chain has
+                    // already run the aborted opcodes' tails against the real
+                    // heap, so the caller's source-pc handoff would execute
+                    // them a second time.  Ending the dispatch loop is the
+                    // only outcome here that cannot double-apply.
                     debug_assert!(false, "merge point reported no green pc");
                     eprintln!(
-                        "[bh] abort-blackhole: ContinueRunningNormally with no green pc — \
-                         falling back to the source pc AFTER the chain ran"
+                        "[bh] abort-blackhole: ContinueRunningNormally with no green pc \
+                         AFTER the chain ran — ending the dispatch loop rather than \
+                         replaying the aborted opcodes"
                     );
-                    return None;
+                    writeback(state, usize::MAX);
+                    self.meta.single_pass_finish = true;
+                    return Some(usize::MAX);
                 };
                 let resume_pc = resume_pc as usize;
                 writeback(state, resume_pc);
@@ -2099,10 +2116,30 @@ impl<S: JitState> JitDriver<S> {
             }
             // `blackhole.py:1679 _exit_frame_with_exception` → the exception
             // escaped every converted frame.  Hand it to the interpreter's own
-            // machinery; an interpreter with no exception surface returns
-            // `None` and the walk falls back to the source-pc handoff.
+            // machinery.
+            //
+            // `JitState::deliver_blackhole_exception` defaults to `None` — an
+            // interpreter with no exception surface has nothing to hand it to.
+            // That answer must NOT become this function's `None`, which means
+            // "declined before running anything" and sends the caller to the
+            // source-pc handoff: the chain has already executed the aborted
+            // opcodes' tails against the real heap, so that handoff would run
+            // them twice.  Upstream cannot reach this — `blackhole.py:1799
+            // convert_and_run_from_pyjitpl` does not return, it propagates the
+            // exception out to `warmspot.py:961 handle_jitexception` — so
+            // ending the dispatch loop is the closest non-replaying answer.
+            // A frontend that wants the exception implements the hook.
             crate::jitexc::JitException::ExitFrameWithExceptionRef(exc) => {
-                let resume_pc = state.deliver_blackhole_exception(exc)?;
+                let Some(resume_pc) = state.deliver_blackhole_exception(exc) else {
+                    eprintln!(
+                        "[bh] abort-blackhole: exception escaped every converted frame and \
+                         this interpreter has no `deliver_blackhole_exception` — ending the \
+                         dispatch loop rather than replaying the aborted opcodes"
+                    );
+                    writeback(state, usize::MAX);
+                    self.meta.single_pass_finish = true;
+                    return Some(usize::MAX);
+                };
                 writeback(state, resume_pc);
                 Some(resume_pc)
             }

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -266,6 +266,16 @@ pub struct PendingAbortBlackhole {
     pub scalar_values: Vec<i64>,
     /// `JitState::collect_ref_scalar_state_field_values`.
     pub ref_scalar_values: Vec<i64>,
+    /// The walk's `[.. ; virt]` array elements
+    /// (`TraceCtx::collect_virtualizable_element_values`).  The walk mutates
+    /// the array on the trace-ctx shadow, never on the live struct, so these
+    /// have to be pushed into native `state` before the chain runs — the
+    /// blackhole's `getarrayitem_vable_*` read the real object.  `None` when
+    /// the state has no virtualizable array.
+    pub virt_array_values: Option<Vec<i64>>,
+    /// The trace's virtualizable identity (`MetaInterp::set_vable_ptr`, mirrored
+    /// onto the ctx at trace entry).  `0` when the state has none.
+    pub virtualizable_ptr: i64,
     /// `metainterp.last_exc_value` as `blackhole.py:1811-1814` reads it —
     /// snapshotted at the abort because the accounting that follows clears the
     /// tracing state it lives on.  `0` for a null exception.
@@ -1917,35 +1927,61 @@ impl<S: JitState> JitDriver<S> {
     /// **Seeding.** The walk keeps state fields on the sym; the blackhole reads
     /// them out of the identity registers `StateFieldLayout` names.  The abort
     /// arm captured the sym's image, and this places it into the root frame's
-    /// banks before the conversion.  Two shapes have no counterpart yet and
-    /// decline: a virtualizable array (`num_vable_identity_slots != 0` — pyre's
-    /// own frame-blackhole path owns that case, `trace.rs`
-    /// `drive_multi_frame_blackhole`) and a flattened fixed `[int]` array
-    /// (`array_lens`), whose per-element slots have no sym collector.
+    /// banks before the conversion.  A `[.. ; virt]` array needs two more
+    /// things, both done here: its elements pushed into native `state` (they
+    /// live on the trace-ctx shadow during the walk, and the chain's
+    /// `getarrayitem_vable_*` read the real object), and the virtualizable
+    /// identity seeded into its own slot plus handed to the chain alongside the
+    /// vinfo pointer `seed_deopt_vinfo_ptr` allows.
+    ///
+    /// One shape still declines: a flattened fixed `[int]` array (`array_lens`),
+    /// whose per-element slots have no sym-side collector.  No frontend
+    /// currently declares one — the supported loop-carried form is
+    /// `[.. ; virt]`.
     pub fn run_pending_abort_blackhole(&mut self, state: &mut S, env: &S::Env) -> Option<usize> {
         let pending = self.meta.pending_abort_blackhole.take()?;
         let PendingAbortBlackhole {
             mut framestack,
             scalar_values,
             ref_scalar_values,
+            virt_array_values,
+            virtualizable_ptr,
             last_exc_value,
             raising_exception,
         } = pending;
         let layout = state.state_field_layout();
-        if layout.num_vable_identity_slots != 0 || !layout.array_lens.is_empty() {
+        if !layout.array_lens.is_empty() {
             if crate::majit_log_enabled() {
                 eprintln!(
-                    "[bh] abort-blackhole declined: unseeded state shape \
-                     (vable_identity={} arrays={})",
-                    layout.num_vable_identity_slots,
+                    "[bh] abort-blackhole declined: unseeded state shape (arrays={})",
                     layout.array_lens.len(),
                 );
             }
             return None;
         }
+        // `writeback_virt_array_state_fields_from_values`, run here rather than
+        // by the `jit_merge_point!` hook's own virt-array writeback: the chain
+        // is about to re-execute the tail of the aborted opcodes against the
+        // live struct, so it has to see the walk's elements, not the
+        // trace-start ones.
+        if let Some(values) = virt_array_values {
+            state.writeback_virt_array_state_fields_from_values(&values);
+            self.meta.single_pass_virt_array_values = None;
+        }
+        // `jitdriver.rs seed_deopt_vinfo_ptr`: a state-field machine's
+        // `bh_clear_vable_token` is inert, so a non-null vinfo is safe and lets
+        // mid-body vable-array opcodes resolve; a real heap virtualizable
+        // (`token_offset > 0`, e.g. PyFrame) keeps the null-vinfo resume
+        // contract and reaches the chain with `virtualizable_info` unset.
+        let vinfo_ptr = seed_deopt_vinfo_ptr(self.meta.virtualizable_info());
         let Some(root) = framestack.frames.first_mut() else {
             return None;
         };
+        if let Some(slot) = layout.vable_identity_slot() {
+            if slot < root.int_values.len() {
+                root.int_values[slot] = Some(virtualizable_ptr);
+            }
+        }
         // `scalar_values` is `[int scalars.., float scalars..]` — the order
         // `collect_scalar_state_field_values` builds and
         // `writeback_scalar_state_fields_from_values` consumes.
@@ -1974,8 +2010,11 @@ impl<S: JitState> JitDriver<S> {
             &mut bh_builder,
             &mut framestack,
             layout.clone(),
-            std::ptr::null(),
-            0,
+            vinfo_ptr,
+            virtualizable_ptr,
+            // PyFrame's operand-stack base; a state-field machine's
+            // `[.. ; virt]` array starts at 0 and a heap virtualizable reaches
+            // here with a null vinfo, so the base is never read.
             0,
             staticdata,
             last_exc_value,
@@ -2025,7 +2064,19 @@ impl<S: JitState> JitDriver<S> {
             // (`blackhole.py:1068-1069`): resume the interpreter at the green
             // pc it reported.  Every `greens` declaration puts `pc` first.
             crate::jitexc::JitException::ContinueRunningNormally { ref green_int, .. } => {
-                let resume_pc = green_int.first().map(|&pc| pc as usize)?;
+                let Some(&resume_pc) = green_int.first() else {
+                    // Unreachable for any declared jitdriver.  Say so loudly
+                    // rather than fall back: the chain has already run the
+                    // aborted opcodes' tails against the real heap, so resuming
+                    // at the walk's source pc would execute them a second time.
+                    debug_assert!(false, "merge point reported no green pc");
+                    eprintln!(
+                        "[bh] abort-blackhole: ContinueRunningNormally with no green pc — \
+                         falling back to the source pc AFTER the chain ran"
+                    );
+                    return None;
+                };
+                let resume_pc = resume_pc as usize;
                 writeback(state, resume_pc);
                 Some(resume_pc)
             }
@@ -3351,8 +3402,9 @@ impl<S: JitState> JitDriver<S> {
                 // `do_not_in_trace_call`).  The `ABORT_TOO_LONG` path below has
                 // no `stb` at all and defaults to false, as upstream's
                 // `SwitchToBlackhole(ABORT_TOO_LONG)` does.
-                let abort_raising_exception =
-                    pending_stb.as_ref().is_some_and(|stb| stb.raising_exception);
+                let abort_raising_exception = pending_stb
+                    .as_ref()
+                    .is_some_and(|stb| stb.raising_exception);
                 let reason_int = match pending_stb.map(|stb| stb.reason) {
                     Some(r) => r,
                     None => self
@@ -3398,15 +3450,25 @@ impl<S: JitState> JitDriver<S> {
                     // finish the half-executed opcodes in the blackhole and take
                     // the resume position from the merge point they reach.
                     if abort_blackhole_enabled() {
-                        let framestack = self
-                            .meta
-                            .trace_ctx()
-                            .and_then(|ctx| ctx.aborted_framestack.take());
-                        if let (Some(framestack), Some(sym)) = (framestack, self.sym.as_ref()) {
+                        let staged = self.meta.trace_ctx().and_then(|ctx| {
+                            let framestack = ctx.aborted_framestack.take()?;
+                            Some((
+                                framestack,
+                                ctx.collect_virtualizable_element_values(),
+                                ctx.virtualizable_heap_ptr().map_or(0, |p| p as i64),
+                            ))
+                        });
+                        if let (
+                            Some((framestack, virt_array_values, virtualizable_ptr)),
+                            Some(sym),
+                        ) = (staged, self.sym.as_ref())
+                        {
                             self.meta.pending_abort_blackhole = Some(PendingAbortBlackhole {
                                 framestack,
                                 scalar_values: S::collect_scalar_state_field_values(sym),
                                 ref_scalar_values: S::collect_ref_scalar_state_field_values(sym),
+                                virt_array_values,
+                                virtualizable_ptr,
                                 // `blackhole.py:1811-1814` reads
                                 // `metainterp.last_exc_value` at conversion
                                 // time; snapshot it here because

--- a/majit/majit-metainterp/src/lib.rs
+++ b/majit/majit-metainterp/src/lib.rs
@@ -129,8 +129,9 @@ pub use jitcode::{
 };
 pub use jitdriver::{
     DeclarativeJitDriver, JitDriver, JitDriverStaticData, MultiFrameBlackholeResult,
-    SingleFrameBlackholeResult, TraceContinuationSuspendGuard, current_state_field_fvc_epoch,
-    drive_multi_frame_blackhole, drive_single_frame_blackhole, trace_continuation_suspended,
+    PendingAbortBlackhole, SingleFrameBlackholeResult, TraceContinuationSuspendGuard,
+    current_state_field_fvc_epoch, drive_multi_frame_blackhole, drive_single_frame_blackhole,
+    trace_continuation_suspended,
 };
 pub use majit_backend::CompiledTraceInfo;
 pub use pyjitpl::{eval_binop_f, eval_binop_i, eval_float_cmp, eval_unary_f, eval_unary_i};

--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -4692,7 +4692,16 @@ mod tests {
         // emitted heap only has to carry the non-virtual half; this pins that
         // half being emitted BEFORE the guard rather than left lazy past it.
         let sd = virtual_size_descr(1, 4);
-        let d_value = descr(10);
+        // `d_value` is stored INTO the virtual, so its slot has to be one of
+        // `sd`'s own fields: `optimize_setfield_gc` indexes
+        // `VirtualStruct.fields` by the field descr's slot and
+        // `virtualize.rs` asserts it stays inside `all_fielddescrs()`. A
+        // `TestDescr`'s slot reads back as `offset() / field_size()` — its
+        // index — wherever the descr is reconciled rather than used raw, so
+        // `descr(10)` addresses field 10 of a 4-field struct. `d_head` /
+        // `d_size` are stored into the non-virtual `p0` and carry no such
+        // bound.
+        let d_value = descr(0);
         let d_head = descr(11);
         let d_size = descr(12);
         let mut ops = vec![

--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -4521,6 +4521,243 @@ mod tests {
         assert_eq!(result[3].opcode, OpCode::Jump);
     }
 
+    #[test]
+    fn test_setfield_on_distinct_array_loads_forces_prior_lazy_set() {
+        // Same shape as `test_setfield_different_objects`, but the two structs
+        // arrive as loads out of one array instead of as separate inputargs:
+        //
+        //   p2 = getarrayitem_gc_r(p0, 7)
+        //   p3 = getarrayitem_gc_r(p0, 16)
+        //   setfield_gc(p2, i1, descr=d1)   <- lazy
+        //   setfield_gc(p3, i2, descr=d1)   <- heap.py:81-83 possible_aliasing:
+        //                                      p2 != p3, so p2's lazy set must
+        //                                      be forced before this one takes
+        //                                      the descr's single `_lazy_set`
+        //                                      slot
+        //   guard_true(i_cond)              <- heap.py:608-637 forces p3's
+        //
+        // Dropping the p2 store instead loses a write the trace recorded.
+        let d_arr = descr(0);
+        let d_field = descr(1);
+        let mut ops = vec![
+            Op::with_descr(
+                OpCode::GetarrayitemGcR,
+                &[
+                    rooted_inputarg_operand(Type::Ref, 100),
+                    Operand::const_from_value(majit_ir::Value::Int(7)),
+                ],
+                d_arr.clone(),
+            ),
+            Op::with_descr(
+                OpCode::GetarrayitemGcR,
+                &[
+                    rooted_inputarg_operand(Type::Ref, 100),
+                    Operand::const_from_value(majit_ir::Value::Int(16)),
+                ],
+                d_arr.clone(),
+            ),
+            Op::with_descr(
+                OpCode::SetfieldGc,
+                &[
+                    rooted_resop_operand(Type::Ref, 0),
+                    rooted_inputarg_operand(Type::Int, 101),
+                ],
+                d_field.clone(),
+            ),
+            Op::with_descr(
+                OpCode::SetfieldGc,
+                &[
+                    rooted_resop_operand(Type::Ref, 1),
+                    rooted_inputarg_operand(Type::Int, 201),
+                ],
+                d_field.clone(),
+            ),
+            Op::new(
+                OpCode::GuardTrue,
+                &[rooted_inputarg_operand(Type::Int, 200)],
+            ),
+            Op::new(OpCode::Jump, &[]),
+        ];
+        let result = run_heap_opt_typed(&mut ops, &[101, 200, 201]);
+
+        let setfields: Vec<&Op> = result
+            .iter()
+            .filter(|o| o.opcode == OpCode::SetfieldGc)
+            .collect();
+        assert_eq!(
+            setfields.len(),
+            2,
+            "both stores must survive; emitted = {:?}",
+            result.iter().map(|o| o.opcode).collect::<Vec<_>>(),
+        );
+        let guard_at = result
+            .iter()
+            .position(|o| o.opcode == OpCode::GuardTrue)
+            .expect("guard must be emitted");
+        let last_setfield_at = result
+            .iter()
+            .rposition(|o| o.opcode == OpCode::SetfieldGc)
+            .unwrap();
+        assert!(
+            last_setfield_at < guard_at,
+            "both stores must be emitted before the guard they precede",
+        );
+    }
+
+    /// A `SizeDescr` for a `NEW` whose result stays virtual: `OptVirtualize`
+    /// indexes `VirtualInfo._fields` by `field_slot_index(descr)` and asserts
+    /// the slot is inside `all_fielddescrs()`, so the bare `TestSizeDescr`
+    /// (empty list) cannot host a field.
+    #[derive(Debug)]
+    struct TestVirtualSizeDescr {
+        index: u32,
+        all_fielddescrs: Vec<Arc<dyn FieldDescr>>,
+    }
+
+    impl Descr for TestVirtualSizeDescr {
+        fn index(&self) -> u32 {
+            self.index
+        }
+        fn as_size_descr(&self) -> Option<&dyn SizeDescr> {
+            Some(self)
+        }
+    }
+
+    impl SizeDescr for TestVirtualSizeDescr {
+        fn size(&self) -> usize {
+            64
+        }
+        fn type_id(&self) -> u32 {
+            self.index
+        }
+        fn is_immutable(&self) -> bool {
+            false
+        }
+        fn is_object(&self) -> bool {
+            false
+        }
+        fn all_fielddescrs(&self) -> &[Arc<dyn FieldDescr>] {
+            &self.all_fielddescrs
+        }
+    }
+
+    fn virtual_size_descr(index: u32, fields: u32) -> DescrRef {
+        Arc::new(TestVirtualSizeDescr {
+            index,
+            all_fielddescrs: (0..fields)
+                .map(|i| {
+                    Arc::new(TestDescr {
+                        index: i,
+                        ei_index: AtomicU32::new(u32::MAX),
+                    }) as Arc<dyn FieldDescr>
+                })
+                .collect(),
+        })
+    }
+
+    /// Like `run_heap_opt_typed`, but the whole `__init__.py:15-22` chain, so
+    /// `OptVirtualize` is present and a `NEW` result can still be virtual when
+    /// the heap pass reaches the guard.
+    fn run_default_pipeline_typed(ops: &mut [Op], int_slots: &[u32]) -> Vec<Op> {
+        assign_positions(ops);
+        let mut opt = Optimizer::default_pipeline();
+        let mut types = vec![Type::Ref; 1024];
+        for &idx in int_slots {
+            types[idx as usize] = Type::Int;
+        }
+        opt.trace_inputargs = majit_ir::OpRef::inputarg_refs(&types);
+        let (ops, snapshots) = super::super::seed_empty_guard_snapshots(ops);
+        opt.snapshot_boxes = snapshots;
+        opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::ConstMap::new(), 1024)
+    }
+
+    #[test]
+    fn test_guard_forces_size_store_paired_with_virtual_head_store() {
+        // heap.py:617-621 splits the two lazy sets a linked-list push leaves
+        // pending, by whether the stored VALUE is virtual:
+        //
+        //   p2 = new(descr=size)
+        //   setfield_gc(p2, i_val, descr=d_value)
+        //   setfield_gc(p0, p2, descr=d_head)   <- value is still VIRTUAL, so
+        //                                          heap.py:618-619 routes it to
+        //                                          pendingfields and leaves the
+        //                                          lazy set in place
+        //   i1 = getfield_gc_i(p0, descr=d_size)
+        //   i2 = int_add(i1, 1)
+        //   setfield_gc(p0, i2, descr=d_size)   <- non-virtual, so heap.py:621
+        //                                          FORCES it at the guard
+        //   guard_true(i_cond)
+        //
+        // Deopt reconstructs `head` from the guard's pendingfields, so the
+        // emitted heap only has to carry the non-virtual half; this pins that
+        // half being emitted BEFORE the guard rather than left lazy past it.
+        let sd = virtual_size_descr(1, 4);
+        let d_value = descr(10);
+        let d_head = descr(11);
+        let d_size = descr(12);
+        let mut ops = vec![
+            Op::with_descr(OpCode::New, &[], sd.clone()),
+            Op::with_descr(
+                OpCode::SetfieldGc,
+                &[
+                    rooted_resop_operand(Type::Ref, 0),
+                    rooted_inputarg_operand(Type::Int, 101),
+                ],
+                d_value.clone(),
+            ),
+            Op::with_descr(
+                OpCode::SetfieldGc,
+                &[
+                    rooted_inputarg_operand(Type::Ref, 100),
+                    rooted_resop_operand(Type::Ref, 0),
+                ],
+                d_head.clone(),
+            ),
+            Op::with_descr(
+                OpCode::GetfieldGcI,
+                &[rooted_inputarg_operand(Type::Ref, 100)],
+                d_size.clone(),
+            ),
+            Op::new(
+                OpCode::IntAdd,
+                &[
+                    rooted_resop_operand(Type::Int, 3),
+                    Operand::const_from_value(majit_ir::Value::Int(1)),
+                ],
+            ),
+            Op::with_descr(
+                OpCode::SetfieldGc,
+                &[
+                    rooted_inputarg_operand(Type::Ref, 100),
+                    rooted_resop_operand(Type::Int, 4),
+                ],
+                d_size.clone(),
+            ),
+            Op::new(
+                OpCode::GuardTrue,
+                &[rooted_inputarg_operand(Type::Int, 200)],
+            ),
+            Op::new(OpCode::Jump, &[]),
+        ];
+        let result = run_default_pipeline_typed(&mut ops, &[101, 200]);
+
+        let guard_at = result
+            .iter()
+            .position(|o| o.opcode == OpCode::GuardTrue)
+            .expect("guard must be emitted");
+        let size_store_at = result.iter().position(|o| {
+            o.opcode == OpCode::SetfieldGc
+                && o.getdescr().as_ref().is_some_and(|d| {
+                    majit_ir::descr::descr_identity(d) == majit_ir::descr::descr_identity(&d_size)
+                })
+        });
+        assert!(
+            size_store_at.is_some_and(|at| at < guard_at),
+            "the size store must be forced before the guard; emitted = {:?}",
+            result.iter().map(|o| o.opcode).collect::<Vec<_>>(),
+        );
+    }
+
     // ── Test 6: Array items: SETARRAYITEM then GETARRAYITEM → cached ──
 
     #[test]

--- a/majit/majit-metainterp/src/optimizeopt/virtualize.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualize.rs
@@ -754,7 +754,17 @@ impl OptVirtualize {
                                     .descr
                                     .as_size_descr()
                                     .map(|sd| sd.all_fielddescrs().len())
-                                    .unwrap_or(0)
+                                    .unwrap_or(0),
+                            "Virtual field slot {} is outside its own descr's field list \
+                             (len {}, descr index {}); `set_field` just wrote past the \
+                             struct this PtrInfo describes",
+                            field_idx,
+                            vinfo
+                                .descr
+                                .as_size_descr()
+                                .map(|sd| sd.all_fielddescrs().len())
+                                .unwrap_or(0),
+                            vinfo.descr.index(),
                         );
                         Some(OptimizationResult::Remove)
                     }
@@ -766,7 +776,17 @@ impl OptVirtualize {
                                     .descr
                                     .as_size_descr()
                                     .map(|sd| sd.all_fielddescrs().len())
-                                    .unwrap_or(0)
+                                    .unwrap_or(0),
+                            "VirtualStruct field slot {} is outside its own descr's field list \
+                             (len {}, descr index {}); `set_field` just wrote past the \
+                             struct this PtrInfo describes",
+                            field_idx,
+                            vinfo
+                                .descr
+                                .as_size_descr()
+                                .map(|sd| sd.all_fielddescrs().len())
+                                .unwrap_or(0),
+                            vinfo.descr.index(),
                         );
                         Some(OptimizationResult::Remove)
                     }

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -1715,15 +1715,18 @@ impl<M: Clone> MetaInterp<M> {
     pub fn walk_rd_consts_refs(&mut self, mut visitor: impl FnMut(&mut GcRef)) {
         fn visit_pool(
             pool: Option<&Arc<majit_ir::SharedConstPool>>,
-            visited: &mut Vec<usize>,
+            visited: &mut indexmap::IndexSet<usize>,
             visitor: &mut dyn FnMut(&mut GcRef),
         ) {
             let Some(pool) = pool else { return };
             let identity = Arc::as_ptr(pool) as usize;
-            if visited.contains(&identity) {
+            // A set, not a scanned list: this runs once per exit layout of
+            // every trace of every compiled loop, so the number of pools it
+            // sees grows with the compiled code, and a linear membership scan
+            // would make one walk quadratic in that count.
+            if !visited.insert(identity) {
                 return;
             }
-            visited.push(identity);
             // SAFETY: pyre is single-threaded and the minor-collection
             // walker is the only writer; concurrent readers run outside
             // GC cycles.
@@ -1735,7 +1738,7 @@ impl<M: Clone> MetaInterp<M> {
             }
         }
 
-        let mut visited = Vec::new();
+        let mut visited = indexmap::IndexSet::new();
         for entry in self.compiled_loops.values_mut() {
             for trace in entry.traces.values_mut() {
                 for layout in trace.exit_layouts.values_mut() {

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -1119,6 +1119,16 @@ pub struct MetaInterp<M: Clone> {
     /// `live_arg_boxes += virtualizable_boxes` (pyjitpl.py:2982-2989). `None`
     /// outside single-pass or when the state has no virtualizable array.
     pub(crate) single_pass_virt_array_values: Option<Vec<i64>>,
+    /// `pyjitpl.py:2949 run_blackhole_interp_to_cancel_tracing` input, staged
+    /// across the two borrows it needs.  The Abort arm of `merge_point` holds
+    /// the aborting framestack and the live sym but no native `state`; the
+    /// conversion needs `JitState::state_field_layout` to place the sym's
+    /// state-field values into the identity registers the blackhole's
+    /// `state_field` handlers read.  The arm therefore stages both halves here
+    /// and the `jit_merge_point!` hook — which does have `state` — runs
+    /// `blackhole.py:1799 convert_and_run_from_pyjitpl` off the stash.  `None`
+    /// unless a walk aborted with the conversion enabled.
+    pub(crate) pending_abort_blackhole: Option<crate::PendingAbortBlackhole>,
     /// Single-pass tracing: concrete values for a direct TargetToken LABEL
     /// entry, in that LABEL's compact argument order.  RPython's backend records
     /// `TargetToken._x86_arglocs` in `regalloc.py:consider_label` and
@@ -2548,6 +2558,7 @@ impl<M: Clone> MetaInterp<M> {
             single_pass_finish: false,
             single_pass_scalar_values: None,
             single_pass_virt_array_values: None,
+            pending_abort_blackhole: None,
             single_pass_compact_label_values: None,
             single_pass_full_live_values: None,
             single_pass_compiled_key: None,

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -2238,11 +2238,10 @@ where
             // blackhole.py:1799 `convert_and_run_from_pyjitpl`) finishes the
             // *current* jitcode frame in the blackhole before control returns
             // to the interpreter.  `JitDriver::run_pending_abort_blackhole` is
-            // that consumer, but it declines for state shapes it cannot seed
-            // and `MAJIT_ABORT_BLACKHOLE=0` turns it off entirely; the abort
-            // then falls back to a source-level pc taken from the walk's root
-            // frame i0, which dispatch advances *before* running the opcode
-            // arm.  Returning mid-opcode on that fallback resumes the
+            // that consumer, but it declines for state shapes it cannot seed;
+            // the abort then falls back to a source-level pc taken from the
+            // walk's root frame i0, which dispatch advances *before* running
+            // the opcode arm.  Returning mid-opcode on that fallback resumes the
             // interpreter past an opcode whose side effects only partly ran.
             // A push that stores its element and then bumps the length can
             // commit the store and lose the bump, leaving a container whose

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -2135,6 +2135,10 @@ where
         let mut step_count: u64 = 0;
         let mut last_num_ops = ctx.num_recorded_ops();
         let mut steps_since_growth: u64 = 0;
+        // Set once `is_too_long()` first trips; the abort itself waits for the
+        // next merge point (see the check at the bottom of the loop).
+        let mut too_long = false;
+        ctx.abort_at_next_merge_point = false;
         while !self.frames.is_empty() {
             step_count += 1;
             let n = ctx.num_recorded_ops();
@@ -2209,6 +2213,11 @@ where
                         ctx.trace_limit()
                     );
                 }
+                // The walk can still end on its own (a `Finish`) between the
+                // overflow and the merge point that was going to cash it in.
+                // A trace past `trace_limit` must not be committed, so the
+                // pending overflow outranks the closing step's action.
+                let action = if too_long { TraceAction::Abort } else { action };
                 match action {
                     TraceAction::CloseLoop | TraceAction::Finish { .. } => sym.commit_portal_op(),
                     _ => sym.abort_portal_op(),
@@ -2219,22 +2228,43 @@ where
             // executing the step, matching RPython's _interpret() loop:
             //   self.framestack[-1].run_one_step()
             //   self.blackhole_if_trace_too_long()
-            if ctx.is_too_long() {
+            //
+            // RPython answers the overflow with `SwitchToBlackhole(
+            // ABORT_TOO_LONG)`, and its handler (pyjitpl.py:2949
+            // `run_blackhole_interp_to_cancel_tracing` → blackhole.py:1799
+            // `convert_and_run_from_pyjitpl`) finishes the *current* jitcode
+            // frame in the blackhole before control returns to the
+            // interpreter.  Pyre has no such consumer: the abort hands a
+            // source-level pc back to the merge-point hook
+            // (jitdriver.rs `TraceAction::Abort` → `single_pass_outcome`),
+            // taken from the walk's root frame i0 — which dispatch advances
+            // *before* running the opcode arm.  Returning here mid-opcode
+            // would therefore resume the interpreter past an opcode whose
+            // side effects only partly ran: aheui's `pi.jinseo` lost the
+            // `size += 1` half of a push whose `head = node` had already run,
+            // leaving a list whose chain is one node longer than its size.
+            // Defer to the next merge point instead — the walk is between
+            // opcodes there, so i0 names a resume position with nothing half
+            // applied.  The extra ops land in a trace that is discarded
+            // anyway, and the runaway backstops above still bound the work.
+            if ctx.is_too_long() && !too_long {
+                too_long = true;
+                ctx.abort_at_next_merge_point = true;
                 if crate::majit_log_enabled() {
                     eprintln!(
-                        "[jit] trace_jitcode aborting: trace too long at portal pc={}",
+                        "[jit] trace_jitcode aborting: trace too long at portal pc={} \
+                         (deferred to the next merge point)",
                         portal_pc
                     );
                 }
-                sym.abort_portal_op();
-                return TraceAction::Abort;
             }
         }
 
         // Post-loop overflow check: the jitcode ran to completion (all
-        // frames empty) but may have exceeded the limit on the last step.
-        if ctx.is_too_long() {
-            if crate::majit_log_enabled() {
+        // frames empty) but may have exceeded the limit on the last step, or
+        // tripped it mid-portal-op and deferred the abort to here.
+        if too_long || ctx.is_too_long() {
+            if !too_long && crate::majit_log_enabled() {
                 eprintln!(
                     "[jit] trace_jitcode aborting: trace too long at portal pc={}",
                     portal_pc
@@ -4390,6 +4420,14 @@ where
                 // swap (dispatch.rs:850) finds that `-live-` at
                 // `mp_opcode_pc - SIZE_LIVE_OP`.
                 let mp_opcode_pc = frame.code_cursor - 1;
+                // A merge point is the one position where no source opcode is
+                // half-executed, so it is where `run_to_end` cashes in a
+                // deferred `trace_limit` overflow (see the `is_too_long`
+                // check there).
+                if ctx.abort_at_next_merge_point {
+                    ctx.abort_at_next_merge_point = false;
+                    return TraceAction::Abort;
+                }
                 let jdindex_byte = frame.next_reg();
                 // RPython `blackhole.py:112-123` argcode discrimination:
                 //

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -2243,10 +2243,10 @@ where
             // then falls back to a source-level pc taken from the walk's root
             // frame i0, which dispatch advances *before* running the opcode
             // arm.  Returning mid-opcode on that fallback resumes the
-            // interpreter past an opcode whose side effects only partly ran:
-            // aheui's `pi.jinseo` lost the `size += 1` half of a push whose
-            // `head = node` had already run, leaving a list whose chain is one
-            // node longer than its size.  Deferring to the next merge point
+            // interpreter past an opcode whose side effects only partly ran.
+            // A push that stores its element and then bumps the length can
+            // commit the store and lose the bump, leaving a container whose
+            // contents and length disagree.  Deferring to the next merge point
             // keeps the fallback sound — the walk is between opcodes there, so
             // i0 names a resume position with nothing half applied — and costs
             // the conversion nothing when it does run.  The extra ops land in a

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -2135,10 +2135,6 @@ where
         let mut step_count: u64 = 0;
         let mut last_num_ops = ctx.num_recorded_ops();
         let mut steps_since_growth: u64 = 0;
-        // Set once `is_too_long()` first trips; the abort itself waits for the
-        // next merge point (see the check at the bottom of the loop).
-        let mut too_long = false;
-        ctx.abort_at_next_merge_point = false;
         while !self.frames.is_empty() {
             step_count += 1;
             let n = ctx.num_recorded_ops();
@@ -2216,70 +2212,47 @@ where
                         ctx.trace_limit()
                     );
                 }
-                // The walk can still end on its own (a `Finish`) between the
-                // overflow and the merge point that was going to cash it in.
-                // A trace past `trace_limit` must not be committed, so the
-                // pending overflow outranks the closing step's action.
-                let action = if too_long { TraceAction::Abort } else { action };
                 match action {
                     TraceAction::CloseLoop | TraceAction::Finish { .. } => sym.commit_portal_op(),
                     _ => sym.abort_portal_op(),
                 }
                 return action;
             }
-            // pyjitpl.py:2843 blackhole_if_trace_too_long — check AFTER
-            // executing the step, matching RPython's _interpret() loop:
-            //   self.framestack[-1].run_one_step()
-            //   self.blackhole_if_trace_too_long()
+            // pyjitpl.py:2861-2867 `_interpret`:
             //
-            // RPython answers the overflow with `SwitchToBlackhole(
-            // ABORT_TOO_LONG)` right here, mid-opcode, because its handler
-            // (pyjitpl.py:2949 `run_blackhole_interp_to_cancel_tracing` →
-            // blackhole.py:1799 `convert_and_run_from_pyjitpl`) finishes the
-            // *current* jitcode frame in the blackhole before control returns
-            // to the interpreter.  `JitDriver::run_pending_abort_blackhole` is
-            // that consumer, but it declines for state shapes it cannot seed;
-            // the abort then falls back to a source-level pc taken from the
-            // walk's root frame i0, which dispatch advances *before* running
-            // the opcode arm.  Returning mid-opcode on that fallback resumes the
-            // interpreter past an opcode whose side effects only partly ran.
-            // A push that stores its element and then bumps the length can
-            // commit the store and lose the bump, leaving a container whose
-            // contents and length disagree.  Deferring to the next merge point
-            // keeps the fallback sound — the walk is between opcodes there, so
-            // i0 names a resume position with nothing half applied — and costs
-            // the conversion nothing when it does run.  The extra ops land in a
-            // trace that is discarded anyway, and the runaway backstops above
-            // still bound the work.
-            if ctx.is_too_long() && !too_long {
-                too_long = true;
-                ctx.abort_at_next_merge_point = true;
+            //     while True:
+            //         self.framestack[-1].run_one_step()
+            //         self.blackhole_if_trace_too_long()
+            //
+            // The overflow is answered right here — `pyjitpl.py:2831 raise
+            // SwitchToBlackhole(ABORT_TOO_LONG)` — even though a source opcode
+            // may be half-executed, because its handler (pyjitpl.py:2949
+            // `run_blackhole_interp_to_cancel_tracing` → blackhole.py:1799
+            // `convert_and_run_from_pyjitpl`) finishes the current jitcode
+            // frames in the blackhole before control returns to the
+            // interpreter, so the opcode's remaining effects still run.
+            //
+            // The check sits below the action test for the same reason it sits
+            // after `run_one_step()` upstream: a step that raises its own
+            // terminal exception never reaches `blackhole_if_trace_too_long`,
+            // so a closing step commits its trace even when that step pushed
+            // the recorded op count past `trace_limit`.
+            if ctx.is_too_long() {
                 if crate::majit_log_enabled() {
                     eprintln!(
-                        "[jit] trace_jitcode aborting: trace too long at portal pc={} \
-                         (deferred to the next merge point)",
+                        "[jit] trace_jitcode aborting: trace too long at portal pc={}",
                         portal_pc
                     );
                 }
+                sym.abort_portal_op();
+                return TraceAction::Abort;
             }
         }
 
-        // Post-loop overflow check: the jitcode ran to completion (all
-        // frames empty) but may have exceeded the limit on the last step, or
-        // tripped it mid-portal-op and deferred the abort to here.
-        if too_long || ctx.is_too_long() {
-            if !too_long && crate::majit_log_enabled() {
-                eprintln!(
-                    "[jit] trace_jitcode aborting: trace too long at portal pc={}",
-                    portal_pc
-                );
-            }
-            sym.abort_portal_op();
-            TraceAction::Abort
-        } else {
-            sym.commit_portal_op();
-            TraceAction::Continue
-        }
+        // The jitcode ran to completion (all frames empty).  The overflow check
+        // above ran on every step that got here, so the trace is within budget.
+        sym.commit_portal_op();
+        TraceAction::Continue
     }
 
     /// Execute a `BC_RECURSIVE_CALL_*` opcode (pyjitpl.py:1376
@@ -4424,21 +4397,6 @@ where
                 // swap (dispatch.rs:850) finds that `-live-` at
                 // `mp_opcode_pc - SIZE_LIVE_OP`.
                 let mp_opcode_pc = frame.code_cursor - 1;
-                // A merge point is the one position where no source opcode is
-                // half-executed, so it is where `run_to_end` cashes in a
-                // deferred `trace_limit` overflow (see the `is_too_long`
-                // check there).
-                if ctx.abort_at_next_merge_point {
-                    ctx.abort_at_next_merge_point = false;
-                    // The cursor already stepped past the opcode byte, so it
-                    // sits inside this instruction's operands.  Name the
-                    // instruction itself: `blackhole.py:1799
-                    // convert_and_run_from_pyjitpl` resumes each level at
-                    // `frame.pc`, and re-executing the merge point is what
-                    // reports the resume greens (`blackhole.py:1068-1069`).
-                    ctx.abort_resume_jitcode_pc = Some(mp_opcode_pc);
-                    return TraceAction::Abort;
-                }
                 let jdindex_byte = frame.next_reg();
                 // RPython `blackhole.py:112-123` argcode discrimination:
                 //
@@ -8019,13 +7977,14 @@ where
         // before pushing the callee.  The top frame's is still the last guard's
         // `orgpc` swap, so publish the position the walk actually stopped at —
         // `copy_data_from_miframe` (`blackhole.py:1804`) reads `frame.pc` as
-        // each level's `setposition`.  An abort taken between steps leaves the
-        // cursor on an instruction boundary; one taken from inside an opcode
-        // arm names its own boundary through `abort_resume_jitcode_pc`.
-        let resume_jitcode_pc = ctx.abort_resume_jitcode_pc.take();
+        // each level's `setposition`.  `code_cursor` is that position: the walk
+        // decodes an instruction's operands before running its arm, so a
+        // completed step leaves the cursor just past them — where RPython's
+        // `self.pc = position` (`pyjitpl.py:3863`, in the `_get_opimpl_method`
+        // handler) leaves `MIFrame.pc`.
         if !std::mem::replace(&mut ctx.abort_after_panic, false) {
             if let Some(top) = standalone.frames.frames.last_mut() {
-                top.pc = resume_jitcode_pc.unwrap_or(top.code_cursor);
+                top.pc = top.code_cursor;
             }
             ctx.aborted_framestack = Some(std::mem::take(&mut standalone.frames));
         }

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -2199,6 +2199,9 @@ where
                             message
                         );
                     }
+                    // The unwind left `code_cursor` inside the panicking
+                    // instruction, so the frames name no resumable position.
+                    ctx.abort_after_panic = true;
                     sym.abort_portal_op();
                     return TraceAction::Abort;
                 }
@@ -2230,23 +2233,25 @@ where
             //   self.blackhole_if_trace_too_long()
             //
             // RPython answers the overflow with `SwitchToBlackhole(
-            // ABORT_TOO_LONG)`, and its handler (pyjitpl.py:2949
-            // `run_blackhole_interp_to_cancel_tracing` → blackhole.py:1799
-            // `convert_and_run_from_pyjitpl`) finishes the *current* jitcode
-            // frame in the blackhole before control returns to the
-            // interpreter.  Pyre has no such consumer: the abort hands a
-            // source-level pc back to the merge-point hook
-            // (jitdriver.rs `TraceAction::Abort` → `single_pass_outcome`),
-            // taken from the walk's root frame i0 — which dispatch advances
-            // *before* running the opcode arm.  Returning here mid-opcode
-            // would therefore resume the interpreter past an opcode whose
-            // side effects only partly ran: aheui's `pi.jinseo` lost the
-            // `size += 1` half of a push whose `head = node` had already run,
-            // leaving a list whose chain is one node longer than its size.
-            // Defer to the next merge point instead — the walk is between
-            // opcodes there, so i0 names a resume position with nothing half
-            // applied.  The extra ops land in a trace that is discarded
-            // anyway, and the runaway backstops above still bound the work.
+            // ABORT_TOO_LONG)` right here, mid-opcode, because its handler
+            // (pyjitpl.py:2949 `run_blackhole_interp_to_cancel_tracing` →
+            // blackhole.py:1799 `convert_and_run_from_pyjitpl`) finishes the
+            // *current* jitcode frame in the blackhole before control returns
+            // to the interpreter.  `JitDriver::run_pending_abort_blackhole` is
+            // that consumer, but it declines for state shapes it cannot seed
+            // and `MAJIT_ABORT_BLACKHOLE=0` turns it off entirely; the abort
+            // then falls back to a source-level pc taken from the walk's root
+            // frame i0, which dispatch advances *before* running the opcode
+            // arm.  Returning mid-opcode on that fallback resumes the
+            // interpreter past an opcode whose side effects only partly ran:
+            // aheui's `pi.jinseo` lost the `size += 1` half of a push whose
+            // `head = node` had already run, leaving a list whose chain is one
+            // node longer than its size.  Deferring to the next merge point
+            // keeps the fallback sound — the walk is between opcodes there, so
+            // i0 names a resume position with nothing half applied — and costs
+            // the conversion nothing when it does run.  The extra ops land in a
+            // trace that is discarded anyway, and the runaway backstops above
+            // still bound the work.
             if ctx.is_too_long() && !too_long {
                 too_long = true;
                 ctx.abort_at_next_merge_point = true;
@@ -4426,6 +4431,13 @@ where
                 // check there).
                 if ctx.abort_at_next_merge_point {
                     ctx.abort_at_next_merge_point = false;
+                    // The cursor already stepped past the opcode byte, so it
+                    // sits inside this instruction's operands.  Name the
+                    // instruction itself: `blackhole.py:1799
+                    // convert_and_run_from_pyjitpl` resumes each level at
+                    // `frame.pc`, and re-executing the merge point is what
+                    // reports the resume greens (`blackhole.py:1068-1069`).
+                    ctx.abort_resume_jitcode_pc = Some(mp_opcode_pc);
                     return TraceAction::Abort;
                 }
                 let jdindex_byte = frame.next_reg();
@@ -7984,10 +7996,15 @@ where
     // dropped so the jit_merge_point single-pass handoff can resume after the
     // committed prefix instead of replaying it from the trace header.
     //
-    // This is the portal equivalent of blackhole.py:1799
-    // convert_and_run_from_pyjitpl(): resume from the current frame position,
-    // not from the trace-start snapshot.  CloseLoop and Finish already capture
-    // their own positions; only Abort needs this recovery handoff.
+    // i0 alone only names a sound resume position when the walk stopped at a
+    // source-opcode boundary; `pyjitpl.py:2949
+    // run_blackhole_interp_to_cancel_tracing` does not depend on that, because
+    // `blackhole.py:1799 convert_and_run_from_pyjitpl` finishes the current
+    // jitcode frames in the blackhole and takes the resume position from the
+    // `jit_merge_point` they reach.  Hand the whole framestack to the abort
+    // consumer so it can do that; i0 stays as the fallback for a consumer that
+    // declines the conversion.  CloseLoop and Finish already capture their own
+    // positions; only Abort needs this recovery handoff.
     if matches!(action, TraceAction::Abort) && !standalone.frames.is_empty() {
         if let Some(pc) = standalone.frames.frames[0]
             .int_values
@@ -7997,6 +8014,21 @@ where
             .and_then(|pc| usize::try_from(pc).ok())
         {
             ctx.walk_final_pc = Some(pc);
+        }
+        // Every frame below the top already carries its own resume position:
+        // `BC_INLINE_CALL` sets `frame.pc = frame.code_cursor` on the caller
+        // before pushing the callee.  The top frame's is still the last guard's
+        // `orgpc` swap, so publish the position the walk actually stopped at —
+        // `copy_data_from_miframe` (`blackhole.py:1804`) reads `frame.pc` as
+        // each level's `setposition`.  An abort taken between steps leaves the
+        // cursor on an instruction boundary; one taken from inside an opcode
+        // arm names its own boundary through `abort_resume_jitcode_pc`.
+        let resume_jitcode_pc = ctx.abort_resume_jitcode_pc.take();
+        if !std::mem::replace(&mut ctx.abort_after_panic, false) {
+            if let Some(top) = standalone.frames.frames.last_mut() {
+                top.pc = resume_jitcode_pc.unwrap_or(top.code_cursor);
+            }
+            ctx.aborted_framestack = Some(std::mem::take(&mut standalone.frames));
         }
     }
     action

--- a/majit/majit-metainterp/src/resume_box_reader.rs
+++ b/majit/majit-metainterp/src/resume_box_reader.rs
@@ -908,7 +908,7 @@ pub fn replay_pending_fields(
     rd_virtuals: Option<&[std::rc::Rc<majit_ir::RdVirtualInfo>]>,
     cache: &mut BridgeVirtualCache,
 ) {
-    let __diag = std::env::var_os("AHEUI_BRIDGE_DIAG").is_some();
+    let __diag = std::env::var_os("MAJIT_BRIDGE_DIAG").is_some();
     let Some(storage) = resume_data.storage.as_ref() else {
         if __diag {
             eprintln!("[replay] storage=None (no pendingfields replayed)");

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -413,19 +413,6 @@ pub struct TraceCtx {
     /// `MetaInterp::single_pass_outcome` (set before `compile_loop` drains the
     /// ctx) to the merge-point hook.
     pub walk_final_pc: Option<usize>,
-    /// Set when `run_to_end` sees the trace pass `trace_limit` in the middle of
-    /// an opcode: the abort waits for the next merge point, where no opcode is
-    /// half-executed and `walk_final_pc` names a real resume position. Cleared
-    /// by `run_to_end` at walk start and by the merge point that consumes it.
-    pub abort_at_next_merge_point: bool,
-    /// Jitcode position the aborting walk's TOP frame should resume at, when
-    /// the abort came from inside an opcode arm and the frame's `code_cursor`
-    /// therefore sits in the middle of that instruction's operands.  `None`
-    /// for an abort taken between steps, where the cursor is already an
-    /// instruction boundary.  Consumed by
-    /// `trace_jitcode_with_args_and_runtime` when it publishes
-    /// [`Self::aborted_framestack`].
-    pub abort_resume_jitcode_pc: Option<usize>,
     /// Set when the abort came out of a panic caught around `run_one_step`
     /// rather than a decision the walk took.  The unwind can leave the frame's
     /// `code_cursor` anywhere inside the panicking instruction, so the frames
@@ -1425,8 +1412,6 @@ impl TraceCtx {
             last_traced_pc: 0,
             initial_inputarg_consts: vec![],
             walk_final_pc: None,
-            abort_at_next_merge_point: false,
-            abort_resume_jitcode_pc: None,
             abort_after_panic: false,
             aborted_framestack: None,
             walk_final_reds: Vec::new(),
@@ -1509,8 +1494,6 @@ impl TraceCtx {
             last_traced_pc: 0,
             initial_inputarg_consts: vec![],
             walk_final_pc: None,
-            abort_at_next_merge_point: false,
-            abort_resume_jitcode_pc: None,
             abort_after_panic: false,
             aborted_framestack: None,
             walk_final_reds: Vec::new(),

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -413,6 +413,11 @@ pub struct TraceCtx {
     /// `MetaInterp::single_pass_outcome` (set before `compile_loop` drains the
     /// ctx) to the merge-point hook.
     pub walk_final_pc: Option<usize>,
+    /// Set when `run_to_end` sees the trace pass `trace_limit` in the middle of
+    /// an opcode: the abort waits for the next merge point, where no opcode is
+    /// half-executed and `walk_final_pc` names a real resume position. Cleared
+    /// by `run_to_end` at walk start and by the merge point that consumes it.
+    pub abort_at_next_merge_point: bool,
     /// Single-pass tracing: the walk-final concrete RED values captured from
     /// the closing merge point's red operands (their live `int_values` /
     /// `ref_values` / `float_values` shadow), in operand order (slot 3 ints,
@@ -1394,6 +1399,7 @@ impl TraceCtx {
             last_traced_pc: 0,
             initial_inputarg_consts: vec![],
             walk_final_pc: None,
+            abort_at_next_merge_point: false,
             walk_final_reds: Vec::new(),
             pending_guard_not_invalidated_pc: None,
             forced_virtualizable: None,
@@ -1474,6 +1480,7 @@ impl TraceCtx {
             last_traced_pc: 0,
             initial_inputarg_consts: vec![],
             walk_final_pc: None,
+            abort_at_next_merge_point: false,
             walk_final_reds: Vec::new(),
             pending_guard_not_invalidated_pc: None,
             forced_virtualizable: None,

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -418,6 +418,32 @@ pub struct TraceCtx {
     /// half-executed and `walk_final_pc` names a real resume position. Cleared
     /// by `run_to_end` at walk start and by the merge point that consumes it.
     pub abort_at_next_merge_point: bool,
+    /// Jitcode position the aborting walk's TOP frame should resume at, when
+    /// the abort came from inside an opcode arm and the frame's `code_cursor`
+    /// therefore sits in the middle of that instruction's operands.  `None`
+    /// for an abort taken between steps, where the cursor is already an
+    /// instruction boundary.  Consumed by
+    /// `trace_jitcode_with_args_and_runtime` when it publishes
+    /// [`Self::aborted_framestack`].
+    pub abort_resume_jitcode_pc: Option<usize>,
+    /// Set when the abort came out of a panic caught around `run_one_step`
+    /// rather than a decision the walk took.  The unwind can leave the frame's
+    /// `code_cursor` anywhere inside the panicking instruction, so the frames
+    /// name no position a blackhole could resume at — the abort consumer must
+    /// not convert them (`blackhole.py:1799` assumes `frame.pc` is an
+    /// instruction boundary).  RPython has no counterpart: it has no panic arm
+    /// here.
+    pub abort_after_panic: bool,
+    /// `pyjitpl.py:2949 run_blackhole_interp_to_cancel_tracing` needs
+    /// `metainterp.framestack` to still exist when it calls
+    /// `blackhole.py:1799 convert_and_run_from_pyjitpl(self, ...)`.  RPython
+    /// keeps the stack on the MetaInterp for the whole trace; pyre's walk owns
+    /// it locally (`trace_jitcode_with_args_and_runtime` allocates a
+    /// `StandaloneFrameStack` and drops it on return), so an aborting walk
+    /// moves it here — onto the tracing session the MetaInterp owns — for the
+    /// jitdriver's Abort arm to convert.  `None` on every non-aborting walk and
+    /// once the arm has taken it.
+    pub aborted_framestack: Option<crate::pyjitpl::MIFrameStack>,
     /// Single-pass tracing: the walk-final concrete RED values captured from
     /// the closing merge point's red operands (their live `int_values` /
     /// `ref_values` / `float_values` shadow), in operand order (slot 3 ints,
@@ -1400,6 +1426,9 @@ impl TraceCtx {
             initial_inputarg_consts: vec![],
             walk_final_pc: None,
             abort_at_next_merge_point: false,
+            abort_resume_jitcode_pc: None,
+            abort_after_panic: false,
+            aborted_framestack: None,
             walk_final_reds: Vec::new(),
             pending_guard_not_invalidated_pc: None,
             forced_virtualizable: None,
@@ -1481,6 +1510,9 @@ impl TraceCtx {
             initial_inputarg_consts: vec![],
             walk_final_pc: None,
             abort_at_next_merge_point: false,
+            abort_resume_jitcode_pc: None,
+            abort_after_panic: false,
+            aborted_framestack: None,
             walk_final_reds: Vec::new(),
             pending_guard_not_invalidated_pc: None,
             forced_virtualizable: None,

--- a/majit/majit-metainterp/tests/abort_blackhole_virt_array.rs
+++ b/majit/majit-metainterp/tests/abort_blackhole_virt_array.rs
@@ -14,9 +14,10 @@
 //! test binary because it sets `MAJIT_STEP_LIMIT`, and the knob is a
 //! process-wide `LazyLock` (`lib.rs step_limit`) — one test per process.
 //!
-//! With the conversion disabled (`MAJIT_ABORT_BLACKHOLE=0`) the same run panics
-//! with `index out of bounds: the len is N but the index is N` from `PUSH`, or a
-//! `stackpos` of `usize::MAX` from `POP`: a torn stack pointer.
+//! Short-circuiting the conversion so the abort falls back to that source pc
+//! makes the same run panic with `index out of bounds: the len is N but the
+//! index is N` from `PUSH`, or reach a `stackpos` of `usize::MAX` from `POP`:
+//! a torn stack pointer.
 
 pub type Bytecode = [u8];
 

--- a/majit/majit-metainterp/tests/abort_blackhole_virt_array.rs
+++ b/majit/majit-metainterp/tests/abort_blackhole_virt_array.rs
@@ -1,0 +1,170 @@
+//! A tracing abort taken mid-source-opcode must not skip that opcode's
+//! remaining effects on a `[.. ; virt]` state.
+//!
+//! `pyjitpl.py:2949 run_blackhole_interp_to_cancel_tracing` answers an abort by
+//! running `blackhole.py:1799 convert_and_run_from_pyjitpl`, which finishes the
+//! aborting framestack in the blackhole and resumes from the merge point it
+//! reaches. Without that consumer the abort hands back the walk's root-frame
+//! source pc, which dispatch advanced *before* the opcode arm ran — so a
+//! two-store opcode like `PUSH` (`stack[stackpos] = v; stackpos += 1`) can
+//! commit one half and lose the other.
+//!
+//! This fixture is the virt-array shape (`stackpos: int, stack: [int; virt]`)
+//! that every majit example interpreter uses. It lives in its own integration
+//! test binary because it sets `MAJIT_STEP_LIMIT`, and the knob is a
+//! process-wide `LazyLock` (`lib.rs step_limit`) — one test per process.
+//!
+//! With the conversion disabled (`MAJIT_ABORT_BLACKHOLE=0`) the same run panics
+//! with `index out of bounds: the len is N but the index is N` from `PUSH`, or a
+//! `stackpos` of `usize::MAX` from `POP`: a torn stack pointer.
+
+pub type Bytecode = [u8];
+
+const PUSH: u8 = 2; // [PUSH, imm]: push a signed-byte immediate
+const POP: u8 = 3; // pop top
+const SWAP: u8 = 4; // swap the top two
+const PICK: u8 = 6; // [PICK, i]: duplicate stack[stackpos - i - 1]
+const ADD: u8 = 8; // pop a, b; push b + a
+const SUB: u8 = 9; // pop a, b; push b - a
+const BR_COND: u8 = 18; // [BR_COND, off]: pop cond; if cond != 0 jump
+const RETURN: u8 = 21; // return top
+const PUSHARG: u8 = 22; // push the input argument
+
+struct StackState {
+    stackpos: i64,
+    stack: Vec<i64>,
+}
+
+#[majit_macros::jit_interp(
+    state = StackState,
+    env = Bytecode,
+    auto_calls = true,
+    greens = [pc, program],
+    state_fields = {
+        stackpos: int,
+        stack: [int; virt],
+    },
+)]
+#[allow(unused_assignments, unused_variables)]
+pub fn mainloop(program: &Bytecode, inputarg: i64, threshold: u32) -> i64 {
+    let mut driver: majit_metainterp::JitDriver<StackState> =
+        majit_metainterp::JitDriver::new(threshold);
+    let mut pc: usize = 0;
+    let mut state = StackState {
+        stackpos: 0,
+        stack: vec![0i64; program.len()],
+    };
+    {
+        use majit_metainterp::JitState as _;
+        state
+            .build_meta(0, program)
+            .install_canonical_liveness(&mut driver);
+    }
+
+    while pc < program.len() {
+        jit_merge_point!(driver, program, pc; state);
+
+        let opcode = program[pc];
+        pc += 1;
+
+        match opcode {
+            PUSH => {
+                let value = program[pc] as i8 as i64;
+                pc += 1;
+                state.stack[state.stackpos as usize] = value;
+                state.stackpos = state.stackpos + 1;
+            }
+            POP => {
+                state.stackpos = state.stackpos - 1;
+            }
+            SWAP => {
+                let a = state.stack[(state.stackpos - 1) as usize];
+                let b = state.stack[(state.stackpos - 2) as usize];
+                state.stack[(state.stackpos - 1) as usize] = b;
+                state.stack[(state.stackpos - 2) as usize] = a;
+            }
+            PICK => {
+                let i = program[pc] as usize;
+                pc += 1;
+                let v = state.stack[(state.stackpos as usize) - i - 1];
+                state.stack[state.stackpos as usize] = v;
+                state.stackpos = state.stackpos + 1;
+            }
+            ADD => {
+                let a = state.stack[(state.stackpos - 1) as usize];
+                let b = state.stack[(state.stackpos - 2) as usize];
+                state.stack[(state.stackpos - 2) as usize] = b + a;
+                state.stackpos = state.stackpos - 1;
+            }
+            SUB => {
+                let a = state.stack[(state.stackpos - 1) as usize];
+                let b = state.stack[(state.stackpos - 2) as usize];
+                state.stack[(state.stackpos - 2) as usize] = b - a;
+                state.stackpos = state.stackpos - 1;
+            }
+            BR_COND => {
+                let offset = program[pc] as i8 as i64;
+                let target = ((pc as i64) + offset + 1) as usize;
+                pc += 1;
+                state.stackpos = state.stackpos - 1;
+                let jump = state.stack[state.stackpos as usize] != 0;
+                if jump {
+                    if target <= pc {
+                        can_enter_jit!(driver, target, &mut state, program, || {});
+                    }
+                    pc = target;
+                    continue;
+                }
+            }
+            RETURN => break,
+            PUSHARG => {
+                state.stack[state.stackpos as usize] = inputarg;
+                state.stackpos = state.stackpos + 1;
+            }
+            _ => {}
+        }
+    }
+
+    state.stackpos = state.stackpos - 1;
+    state.stack[state.stackpos as usize]
+}
+
+/// `sum(N) = N + (N-1) + ... + 1`, a hot loop over the virt stack.
+fn sum_program() -> Vec<u8> {
+    vec![
+        PUSH, 0,       // 0
+        PUSHARG, // 2
+        PICK, 0, // 3  (loop header)
+        BR_COND, 2,      // 5  -> body @9
+        POP,    // 7
+        RETURN, // 8
+        SWAP,   // 9
+        PICK, 1,    // 10
+        ADD,  // 12
+        SWAP, // 13
+        PUSH, 1, SUB, // 14
+        PUSH, 1, // 17
+        BR_COND, 238, // 19 -> back to the header @3
+    ]
+}
+
+#[test]
+fn mid_opcode_abort_preserves_virt_stack() {
+    // Small enough that every trace attempt is cut off inside an opcode arm,
+    // which is the `run_to_end` runaway backstop's own mid-opcode `Abort` —
+    // one of the exits the conversion exists to cover. Set before any JIT call
+    // because `step_limit()` latches on first read.
+    unsafe {
+        std::env::set_var("MAJIT_STEP_LIMIT", "200");
+    }
+
+    let program = sum_program();
+    for n in [1_i64, 2, 3, 5, 10, 20, 50, 100, 200] {
+        let got = mainloop(&program, n, 3);
+        assert_eq!(
+            got,
+            n * (n + 1) / 2,
+            "sum({n}) diverged under a forced mid-opcode abort",
+        );
+    }
+}

--- a/majit/majit-translate/src/codewriter/flatten.rs
+++ b/majit/majit-translate/src/codewriter/flatten.rs
@@ -1229,7 +1229,15 @@ impl<'a> GraphFlattener<'a> {
                 _ => unreachable!(),
             };
             let kind = value_kind(&cond, self.regallocs);
-            assert_eq!(kind, 'i', "switch exitswitch must be int");
+            // Name the graph and block: the switch value is produced far from
+            // here (a `__pos_N` read of a match scrutinee aggregate, an enum
+            // `__discriminant` read, …), so a bare kind mismatch gives the
+            // reader nothing to search for.
+            assert_eq!(
+                kind, 'i',
+                "switch exitswitch must be int (graph {}, block {:?})",
+                self.graph.name, bid
+            );
             // `switches = [link for link in block.exits if link.exitcase != 'default']`.
             // `switches.sort(key=lambda link: link.llexitcase)`.
             let default_link = exits

--- a/majit/majit-translate/src/codewriter/jitcode.rs
+++ b/majit/majit-translate/src/codewriter/jitcode.rs
@@ -1151,6 +1151,37 @@ fn ir_type_to_result_char(result_type: majit_ir::value::Type) -> char {
 /// [`BhDescr::is_headerless`] for why the flag rides in the owner slot.
 pub const HEADERLESS_SIZE_OWNER_MARKER: &str = "__majit_headerless_size__";
 
+/// Key-sorted serialization for [`BhDescr::Switch`]'s lookup map.
+///
+/// The map is a pure lookup table, so its in-memory order never matters —
+/// but it is written to a build artefact (`opcode_descrs.bin`,
+/// `jit_metadata.json`), and a `HashMap` serializes in iteration order, which
+/// varies per process. Two builds of one unchanged source tree therefore
+/// produced two different artefacts, which defeats build caching and makes an
+/// A/B bisection impossible to attribute. Emit the same key order
+/// `const_keys_in_order` already canonicalises to (`jitcode.py:135
+/// sorted(as_dict.keys())`). The shape is unchanged — still a map — so the
+/// artefacts stay readable by the existing deserializer.
+mod sorted_switch_dict {
+    use serde::{Deserialize, Deserializer, Serializer};
+    use std::collections::HashMap;
+
+    pub fn serialize<S: Serializer>(
+        dict: &HashMap<i64, usize>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error> {
+        let mut items: Vec<(&i64, &usize)> = dict.iter().collect();
+        items.sort_unstable_by_key(|(key, _)| **key);
+        serializer.collect_map(items)
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<HashMap<i64, usize>, D::Error> {
+        HashMap::deserialize(deserializer)
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum BhDescr {
     /// Field descriptor: for getfield/setfield.
@@ -1290,6 +1321,7 @@ pub enum BhDescr {
     },
     /// SwitchDictDescr: maps int values to bytecode positions.
     Switch {
+        #[serde(with = "sorted_switch_dict")]
         dict: std::collections::HashMap<i64, usize>,
         const_keys_in_order: Vec<i64>,
     },

--- a/majit/majit-translate/src/codewriter/liveness.rs
+++ b/majit/majit-translate/src/codewriter/liveness.rs
@@ -421,6 +421,53 @@ pub fn encode_liveness(live: &[u8]) -> Vec<u8> {
     liveness
 }
 
+/// Walk an `all_liveness` buffer back into the `(live_i, live_r, live_f)`
+/// records [`encode_liveness`] wrote into it, each with its own offset.
+///
+/// `assembler.py:236-250 _encode_liveness` appends every record at the
+/// buffer's current end — three count bytes then the three bitsets — so the
+/// buffer is a contiguous run of records starting at 0 and this walk recovers
+/// them exactly. Upstream never needs it: one `Assembler` holds one buffer and
+/// one `all_liveness_positions` dict for the whole program. pyre assembles the
+/// extracted interpreter graphs in `build.rs` and the Python-bytecode graphs at
+/// runtime, and the runtime side resumes the build-time bytes; without this the
+/// resumed side starts with an empty dedup dict and re-appends a record the
+/// prefix already holds, spending the 2-byte `-live-` operand's 64 KiB budget
+/// on duplicates.
+///
+/// Each returned tuple is `(live_i, live_r, live_f, offset)`, with the sets in
+/// the sorted/deduped form `encode_liveness` canonicalises to — the same shape
+/// upstream's `frozenset` key has.
+pub fn decode_liveness_records(all_liveness: &[u8]) -> Vec<(Vec<u8>, Vec<u8>, Vec<u8>, usize)> {
+    let mut records = Vec::new();
+    let mut pos = 0usize;
+    while pos + 3 <= all_liveness.len() {
+        let offset = pos;
+        let counts = [
+            all_liveness[pos],
+            all_liveness[pos + 1],
+            all_liveness[pos + 2],
+        ];
+        pos += 3;
+        let mut sets: [Vec<u8>; 3] = [Vec::new(), Vec::new(), Vec::new()];
+        for (bank, &count) in counts.iter().enumerate() {
+            if count == 0 {
+                // `encode_liveness(&[])` emits no bytes, so an empty bank
+                // consumes none either.
+                continue;
+            }
+            let mut it = LivenessIterator::new(pos, u32::from(count), all_liveness);
+            for index in it.by_ref() {
+                sets[bank].push(index as u8);
+            }
+            pos = it.offset;
+        }
+        let [live_i, live_r, live_f] = sets;
+        records.push((live_i, live_r, live_f, offset));
+    }
+    records
+}
+
 /// RPython liveness.py:170-200 `LivenessIterator`.
 ///
 /// Iterates set bit positions from a bitset stored in `all_liveness`
@@ -479,6 +526,36 @@ impl<'a> Iterator for LivenessIterator<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn decode_liveness_records_round_trips_encode() {
+        // Same layout `assembler.py:241-247` writes: three count bytes then
+        // the three encoded banks, appended back to back.
+        let banks: [(Vec<u8>, Vec<u8>, Vec<u8>); 4] = [
+            (vec![0, 3, 7], vec![1], vec![]),
+            (vec![], vec![], vec![]),
+            (vec![2], vec![], vec![9, 10]),
+            (vec![0, 1, 2, 3, 4, 5, 6, 7, 8], vec![255], vec![4]),
+        ];
+        let mut all = Vec::new();
+        let mut offsets = Vec::new();
+        for (i, r, f) in &banks {
+            offsets.push(all.len());
+            all.push(i.len() as u8);
+            all.push(r.len() as u8);
+            all.push(f.len() as u8);
+            for live in [i.as_slice(), r.as_slice(), f.as_slice()] {
+                all.extend_from_slice(&encode_liveness(live));
+            }
+        }
+        let decoded = decode_liveness_records(&all);
+        assert_eq!(decoded.len(), banks.len());
+        for (idx, (i, r, f, off)) in decoded.iter().enumerate() {
+            assert_eq!((i, r, f), (&banks[idx].0, &banks[idx].1, &banks[idx].2));
+            assert_eq!(*off, offsets[idx]);
+        }
+    }
+
     use crate::flatten::FlatOp;
     use crate::model::{OpKind, SpaceOperation, ValueType};
 

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -4863,6 +4863,14 @@ impl<'a> Lowering<'a> {
                         ))
                     })?;
                     let bb_id = self.block_id[mir_bb];
+                    // Element type, not `Ref(None)`: `place_ty` is the
+                    // post-projection type, the same source the genuine-Ref
+                    // tuple read below uses.  A `(FieldlessEnum, bool)`
+                    // scrutinee is built as a positional aggregate and its
+                    // `.0` read back to feed the `match` switch, so a blanket
+                    // `Ref` here types that switch value as a pointer and
+                    // `flatten.py:280 assert kind == 'int'` rejects the graph.
+                    let ty = tyref_to_value_type(&place_ty, self.llbc);
                     let res = self
                         .graph
                         .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
@@ -4871,7 +4879,7 @@ impl<'a> Lowering<'a> {
                         kind: OpKind::FieldRead {
                             base,
                             field: FieldDescriptor::new(format!("__pos_{idx}"), Some(owner_root)),
-                            ty: ValueType::Ref(None),
+                            ty,
                             pure: false,
                         },
                     });

--- a/majit/majit-translate/tests/test_make_jitcodes_produces_graph_keyed_output.rs
+++ b/majit/majit-translate/tests/test_make_jitcodes_produces_graph_keyed_output.rs
@@ -252,21 +252,28 @@ fn slow_generated_jitcodes_preserve_complete_dispatcher_graph() {
         source_wildcards, 1,
         "source dispatcher must declare one wildcard"
     );
-    assert_eq!(source_groups.len() + source_wildcards, 111);
-    assert_eq!(mir_groups.len() + mir_wildcards, 111);
-    assert_eq!(
-        seen_discriminants.len(),
-        118,
-        "the 110 named source arms must retain all grouped Instruction cases",
+    // Floors rather than exact totals: the dispatcher grows whenever an opcode
+    // is added, so an equality here fails on every legitimate addition while
+    // still only catching removals. Shrinkage is the signal. Same rationale as
+    // the `reg.in_order.len() >= 28` floor below. Raise these when the
+    // dispatcher grows; lowering one means naming the opcodes it dropped.
+    assert!(
+        source_groups.len() + source_wildcards >= 115,
+        "source dispatcher lost arms: {} < 115",
+        source_groups.len() + source_wildcards,
     );
+    assert!(
+        seen_discriminants.len() >= 119,
+        "MIR switch lost Instruction discriminants: {} < 119",
+        seen_discriminants.len(),
+    );
+    // The exact anti-drop check. Both sides are sorted arm groups, so this
+    // pins the arm count, every variant's arm membership, and which variants
+    // share one arm — a dropped switch branch or a split/merged Or-pattern
+    // shows up here. The per-side totals above stay floors because of that.
     assert_eq!(
         mir_groups, source_groups,
         "lowered MIR dispatcher groups differ from the source match",
-    );
-    assert_eq!(
-        mir_groups.iter().filter(|group| group.len() > 1).count(),
-        3,
-        "the dispatcher must retain all three grouped source arms",
     );
 
     with_all_jitcodes(|reg| {

--- a/pyre/bench/synth/int_mul_ovf_bignum_promote.py
+++ b/pyre/bench/synth/int_mul_ovf_bignum_promote.py
@@ -20,7 +20,11 @@ def main():
     for _ in range(120):
         warm = warm + hot(3, 20000)      # a in {3,4}; a*a tiny, never overflows
     # Big scale: a ~ 5e9, a*a = 2.5e19 overflows int64 (and uint64) -> big int.
-    print(hot(5000000000, 20000))
+    # Sized so the promoting loop, not the warm-up, dominates the measurement:
+    # at 20000 the whole run was pypy exec 0.01s against a 0.01s pypy startup
+    # and a 0.08s dynasm one, so the ratio was startup noise rather than the
+    # promotion this fixture is named for.
+    print(hot(5000000000, 10000000))
     print(warm)
 
 

--- a/pyre/pyre-jit-trace/src/assembler.rs
+++ b/pyre/pyre-jit-trace/src/assembler.rs
@@ -68,12 +68,29 @@ impl AssemblerState {
         let insns = crate::jitcode_runtime::insns_opname_to_byte().clone();
         Self {
             insns,
+            all_liveness_positions: liveness_positions_of(&all_liveness),
             all_liveness,
             all_liveness_length,
-            all_liveness_positions: IndexMap::new(),
             num_liveness_ops: 0,
         }
     }
+}
+
+/// `assembler.py:31 self.all_liveness_positions` for a buffer that was handed
+/// over rather than built here.
+///
+/// Both entries into this state receive the bytes wholesale — `new` resumes the
+/// build-time drain's prefix, `publish_state` mirrors the writer's buffer — and
+/// the dict has to describe the same records those bytes hold, or the next
+/// `intern_liveness` re-appends a triple already present and spends part of the
+/// 2-byte `-live-` operand's 64 KiB budget on a duplicate.
+fn liveness_positions_of(all_liveness: &[u8]) -> IndexMap<(Vec<u8>, Vec<u8>, Vec<u8>), u16> {
+    majit_translate::liveness::decode_liveness_records(all_liveness)
+        .into_iter()
+        .filter_map(|(live_i, live_r, live_f, offset)| {
+            Some(((live_i, live_r, live_f), u16::try_from(offset).ok()?))
+        })
+        .collect()
 }
 
 thread_local! {
@@ -138,10 +155,11 @@ pub fn publish_state(
         asm.all_liveness.extend_from_slice(all_liveness);
         asm.all_liveness_length = all_liveness_length;
         asm.num_liveness_ops = num_liveness_ops;
-        // The dedup table is keyed by offsets into the previous
-        // all_liveness buffer; clear it so subsequent intern_liveness
-        // lookups cannot reuse stale offsets against the fresh buffer.
-        asm.all_liveness_positions.clear();
+        // The dedup table describes the *previous* buffer, so rebuild it from
+        // the one just installed. Clearing instead would leave the mirror
+        // unable to see any record in the fresh bytes, and the next
+        // `intern_liveness` would append a duplicate of one already there.
+        asm.all_liveness_positions = liveness_positions_of(all_liveness);
     });
     crate::state::publish_liveness_info(all_liveness.to_vec());
 }

--- a/pyre/pyre-jit-trace/src/assembler.rs
+++ b/pyre/pyre-jit-trace/src/assembler.rs
@@ -30,13 +30,14 @@ use indexmap::IndexMap;
 ///   mapped to opcode number; source for `MetaInterpStaticData.setup_insns`.
 /// - `all_liveness`    — running byte buffer appended by `_encode_liveness`.
 /// - `all_liveness_length` — explicit length counter mirroring upstream.
-/// - `all_liveness_positions` — dedup dict from bitset key to offset.
+/// - `all_liveness_positions` — dedup dict from bitset key to offset. `None`
+///   until a reader-side intern asks for it; see [`liveness_positions_of`].
 /// - `num_liveness_ops` — running count of liveness writes (diagnostic).
 pub struct AssemblerState {
     pub insns: IndexMap<String, u8>,
     pub all_liveness: Vec<u8>,
     pub all_liveness_length: usize,
-    pub all_liveness_positions: IndexMap<(Vec<u8>, Vec<u8>, Vec<u8>), u16>,
+    pub all_liveness_positions: Option<IndexMap<(Vec<u8>, Vec<u8>, Vec<u8>), u16>>,
     pub num_liveness_ops: usize,
 }
 
@@ -68,7 +69,7 @@ impl AssemblerState {
         let insns = crate::jitcode_runtime::insns_opname_to_byte().clone();
         Self {
             insns,
-            all_liveness_positions: liveness_positions_of(&all_liveness),
+            all_liveness_positions: None,
             all_liveness,
             all_liveness_length,
             num_liveness_ops: 0,
@@ -84,7 +85,16 @@ impl AssemblerState {
 /// the dict has to describe the same records those bytes hold, or the next
 /// `intern_liveness` re-appends a triple already present and spends part of the
 /// 2-byte `-live-` operand's 64 KiB budget on a duplicate.
-fn liveness_positions_of(all_liveness: &[u8]) -> IndexMap<(Vec<u8>, Vec<u8>, Vec<u8>), u16> {
+///
+/// Derived on demand rather than at either entry: `publish_state` runs once per
+/// writer-side `-live-` intern, and this walks the whole buffer and rehashes
+/// every record it holds, so deriving eagerly there costs
+/// `interns × buffer_len`. `state::intern_liveness` is the only consumer, so it
+/// derives on its own first use and every later intern reuses the dict it left
+/// behind.
+pub(crate) fn liveness_positions_of(
+    all_liveness: &[u8],
+) -> IndexMap<(Vec<u8>, Vec<u8>, Vec<u8>), u16> {
     majit_translate::liveness::decode_liveness_records(all_liveness)
         .into_iter()
         .filter_map(|(live_i, live_r, live_f, offset)| {
@@ -155,11 +165,12 @@ pub fn publish_state(
         asm.all_liveness.extend_from_slice(all_liveness);
         asm.all_liveness_length = all_liveness_length;
         asm.num_liveness_ops = num_liveness_ops;
-        // The dedup table describes the *previous* buffer, so rebuild it from
-        // the one just installed. Clearing instead would leave the mirror
-        // unable to see any record in the fresh bytes, and the next
-        // `intern_liveness` would append a duplicate of one already there.
-        asm.all_liveness_positions = liveness_positions_of(all_liveness);
+        // The dedup table describes the *previous* buffer, so drop it and let
+        // the next reader-side intern derive one from the bytes just installed.
+        // Clearing it to an empty dict instead would leave the mirror unable to
+        // see any record in the fresh bytes, and that intern would append a
+        // duplicate of one already there.
+        asm.all_liveness_positions = None;
     });
     crate::state::publish_liveness_info(all_liveness.to_vec());
 }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -498,9 +498,8 @@ pub(crate) fn try_walker_specialize_binary_op_int<Sym: WalkSym>(
     // pyjitpl.py:1881 handle_possible_overflow_error follows the concrete
     // Add/Sub/Mul outcome. The overflowing arm mirrors intobject.py:494
     // _make_ovf2long: guard_overflow, call the elidable raw-int bigint helper
-    // (rbigint.py:717/788/873), guard the newlong demote attempt, and inline
-    // the W_LongObject box instead of falling through to the generic
-    // CallMayForceR BINARY_OP leg.
+    // (rbigint.py:717/788/873), and inline the W_LongObject box instead of
+    // falling through to the generic CallMayForceR BINARY_OP leg.
     let overflows = has_overflow
         && match op_code {
             OpCode::IntAddOvf => la.checked_add(rb).is_none(),
@@ -570,19 +569,14 @@ pub(crate) fn try_walker_specialize_binary_op_int<Sym: WalkSym>(
             walker_emit_guard_with_snapshot(ctx, op_pc, OpCode::GuardNoException, &[])?;
         }
 
-        let fits_fn = pyre_object::longobject::jit_bigint_fits_int as *const ();
-        let fits = ctx.trace_ctx.call_typed_with_effect(
-            OpCode::CallI,
-            fits_fn,
-            &[payload],
-            &[majit_ir::Type::Ref],
-            majit_ir::Type::Int,
-            majit_metainterp::cannot_raise_effect_info(),
-        );
-        ctx.trace_ctx
-            .set_opref_concrete(fits, majit_ir::Value::Int(0));
-        walker_emit_guard_with_snapshot(ctx, op_pc, OpCode::GuardFalse, &[fits])?;
-
+        // The box needs no preceding fits_int guard. `newlong_from_rbigint`
+        // (objspace.py:316-320) demotes through `rbigint.toint()`, whose
+        // `numdigits() > MAX_DIGITS_THAT_CAN_FIT_IN_INT` test (rbigint.py:470)
+        // the GuardOverflow above already answers: the helper is the *exact*
+        // int-pair sum / difference / product, so a value that just overflowed
+        // a machine int cannot fit one back. The same fold is what lets
+        // `try_walker_specialize_binary_op_long_int_pow` skip its result-fits
+        // guard.
         let result = crate::helpers::emit_box_long_inline(
             ctx.trace_ctx,
             payload,

--- a/pyre/pyre-jit-trace/src/jitcode_runtime.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_runtime.rs
@@ -2010,9 +2010,16 @@ mod tests {
     /// `build_inline_call_only_bh_builder` instead.
     ///
     /// `new/d>r` left it the same way: lowering a rebuilt `Result` shell as an
-    /// allocation made `OpKind::New` reachable from the codewriter. Its operand
-    /// shape is `new_with_vtable/d>r`'s — a 2-byte little-endian descr index
-    /// then a 1-byte ref register — and `handler_new` decodes exactly that.
+    /// allocation, and a `#[jit_interp]` frontend's declared `struct_allocs`
+    /// literal, each make `OpKind::New` reachable from the codewriter. Its
+    /// operand shape is `new_with_vtable/d>r`'s — a 2-byte little-endian descr
+    /// index then a 1-byte ref register — and `handler_new` decodes exactly
+    /// that.
+    ///
+    /// `new_array/id>r` left with it: the builder reached both with a wired
+    /// handler but no opname→byte entry, so the blackhole took
+    /// `dispatch_step: unwired opcode=0xd9` on the abort path.  Both are now
+    /// registered.
     #[test]
     fn production_bh_builder_overlay_only_gap_snapshot() {
         let builder = build_pyre_production_bh_builder();
@@ -2049,7 +2056,6 @@ mod tests {
             "getlistitem_gc_i/ridd>i",
             "getlistitem_gc_r/ridd>r",
             "int_between/iii>i",
-            "new_array/id>r",
             "newlist/idddd>r",
             "newlist_clear/idddd>r",
             "newlist_hint/idddd>r",

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -465,7 +465,19 @@ pub fn intern_liveness(live_i: &[u8], live_r: &[u8], live_f: &[u8]) -> Option<u1
         // inside `_encode_liveness`. The counter measures write-insn call
         // frequency, not unique-entry count.
         asm.num_liveness_ops += 1;
-        let key = (live_i.to_vec(), live_r.to_vec(), live_f.to_vec());
+        // `assembler.py:238` keys on the three frozensets. `encode_liveness`
+        // sorts and dedups before writing, so two argument orderings of one
+        // set encode to identical bytes; keying on the raw slice order would
+        // miss the dedup and append a second copy of a record already in the
+        // buffer. Canonicalise to the same sorted/deduped form the writer side
+        // (`VecSet`) and `decode_liveness_records` produce.
+        let canonical = |live: &[u8]| {
+            let mut v = live.to_vec();
+            v.sort_unstable();
+            v.dedup();
+            v
+        };
+        let key = (canonical(live_i), canonical(live_r), canonical(live_f));
         if let Some(&pos) = asm.all_liveness_positions.get(&key) {
             return Some((pos, asm.all_liveness.clone()));
         }

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -478,7 +478,18 @@ pub fn intern_liveness(live_i: &[u8], live_r: &[u8], live_f: &[u8]) -> Option<u1
             v
         };
         let key = (canonical(live_i), canonical(live_r), canonical(live_f));
-        if let Some(&pos) = asm.all_liveness_positions.get(&key) {
+        // The dict is derived from the buffer on first use after each
+        // `publish_state`, which installs bytes without one. See
+        // `assembler::liveness_positions_of`.
+        if asm.all_liveness_positions.is_none() {
+            let positions = crate::assembler::liveness_positions_of(&asm.all_liveness);
+            asm.all_liveness_positions = Some(positions);
+        }
+        let positions = asm
+            .all_liveness_positions
+            .as_ref()
+            .expect("derived just above");
+        if let Some(&pos) = positions.get(&key) {
             return Some((pos, asm.all_liveness.clone()));
         }
         let pos = asm.all_liveness_length;
@@ -493,7 +504,10 @@ pub fn intern_liveness(live_i: &[u8], live_r: &[u8], live_f: &[u8]) -> Option<u1
             return None;
         }
         let pos_u16 = pos as u16;
-        asm.all_liveness_positions.insert(key, pos_u16);
+        asm.all_liveness_positions
+            .as_mut()
+            .expect("derived above")
+            .insert(key, pos_u16);
         asm.all_liveness.push(live_i.len() as u8);
         asm.all_liveness.push(live_r.len() as u8);
         asm.all_liveness.push(live_f.len() as u8);

--- a/pyre/pyre-jit/src/jit/assembler.rs
+++ b/pyre/pyre-jit/src/jit/assembler.rs
@@ -161,10 +161,33 @@ impl Assembler {
         let all_liveness = pyre_jit_trace::jitcode_runtime::all_liveness().to_vec();
         let all_liveness_length = all_liveness.len();
         let insns = pyre_jit_trace::jitcode_runtime::insns_opname_to_byte().clone();
+        // `assembler.py:31 self.all_liveness_positions` is the third half of
+        // the same continuation. Seeding the bytes without it leaves the
+        // resumed assembler blind to every record the prefix already holds, so
+        // the first runtime `_encode_liveness` of a triple the build-time drain
+        // already wrote appends a second copy instead of returning its offset.
+        // The `-live-` operand is 2 bytes, so those duplicates come out of one
+        // shared 64 KiB budget.
+        let all_liveness_positions =
+            majit_translate::liveness::decode_liveness_records(&all_liveness)
+                .into_iter()
+                .filter_map(|(live_i, live_r, live_f, offset)| {
+                    let offset = u16::try_from(offset).ok()?;
+                    Some((
+                        (
+                            live_i.into_iter().collect::<VecSet<u8>>(),
+                            live_r.into_iter().collect::<VecSet<u8>>(),
+                            live_f.into_iter().collect::<VecSet<u8>>(),
+                        ),
+                        offset,
+                    ))
+                })
+                .collect();
         Self {
             insns,
             all_liveness,
             all_liveness_length,
+            all_liveness_positions,
             ..Self::default()
         }
     }

--- a/pyre/pyre-object/src/longobject.rs
+++ b/pyre/pyre-object/src/longobject.rs
@@ -527,19 +527,15 @@ pub extern "C" fn jit_w_long_xor_raw(a: i64, b: i64) -> i64 {
 #[majit_macros::elidable_or_memerror]
 pub extern "C" fn jit_bigint_add(a: i64, b: i64) -> i64 {
     let (a, b) = (a as *const BigInt, b as *const BigInt);
-    // Two-limb fast path: when both operands and the sum fit i128 the result
-    // is exact without the general limb machinery.
     unsafe {
+        // `rbigint.add` (rbigint.py:684-687) returns the *other operand itself*
+        // when one side is zero; the raw-pointer ABI spells that identity as
+        // returning the incoming payload instead of re-wrapping an alias.
         if (&*a).get_sign() == 0 {
             return b as i64;
         }
         if (&*b).get_sign() == 0 {
             return a as i64;
-        }
-        if let (Ok(x), Ok(y)) = (i128::try_from(&*a), i128::try_from(&*b)) {
-            if let Some(z) = x.checked_add(y) {
-                return alloc_bigint_nursery_collecting(BigInt::from(z)) as i64;
-            }
         }
         alloc_bigint_nursery_collecting(&*a + &*b) as i64
     }
@@ -551,23 +547,18 @@ pub extern "C" fn jit_bigint_add(a: i64, b: i64) -> i64 {
 /// a freshly heap-allocated `*mut BigInt` payload (as i64).
 #[majit_macros::elidable_or_memerror]
 pub extern "C" fn jit_bigint_add_int_int(a: i64, b: i64) -> i64 {
-    // Exact in i128 for any i64 pair; skips the general bigint add machinery.
-    alloc_bigint_nursery_collecting(BigInt::from(a as i128 + b as i128)) as i64
+    alloc_bigint_nursery_collecting(BigInt::add_int_int_bigint_result(a, b)) as i64
 }
 
 /// `rbigint.sub` on bare payloads (collecting). See [`jit_bigint_add`].
 #[majit_macros::elidable_or_memerror]
 pub extern "C" fn jit_bigint_sub(a: i64, b: i64) -> i64 {
     let (a, b) = (a as *const BigInt, b as *const BigInt);
-    // Two-limb fast path mirroring `jit_bigint_add`.
     unsafe {
+        // `rbigint.sub` (rbigint.py:758-759) returns `self` itself for a zero
+        // subtrahend; see [`jit_bigint_add`] for the raw-pointer spelling.
         if (&*b).get_sign() == 0 {
             return a as i64;
-        }
-        if let (Ok(x), Ok(y)) = (i128::try_from(&*a), i128::try_from(&*b)) {
-            if let Some(z) = x.checked_sub(y) {
-                return alloc_bigint_nursery_collecting(BigInt::from(z)) as i64;
-            }
         }
         alloc_bigint_nursery_collecting(&*a - &*b) as i64
     }
@@ -578,8 +569,7 @@ pub extern "C" fn jit_bigint_sub(a: i64, b: i64) -> i64 {
 /// [`jit_bigint_add_int_int`].
 #[majit_macros::elidable_or_memerror]
 pub extern "C" fn jit_bigint_sub_int_int(a: i64, b: i64) -> i64 {
-    // Exact in i128 for any i64 pair; skips the general bigint sub machinery.
-    alloc_bigint_nursery_collecting(BigInt::from(a as i128 - b as i128)) as i64
+    alloc_bigint_nursery_collecting(BigInt::sub_int_int_bigint_result(a, b)) as i64
 }
 
 /// `rbigint.mul` on bare payloads (collecting). See [`jit_bigint_add`].
@@ -594,8 +584,7 @@ pub extern "C" fn jit_bigint_mul(a: i64, b: i64) -> i64 {
 /// [`jit_bigint_add_int_int`].
 #[majit_macros::elidable_or_memerror]
 pub extern "C" fn jit_bigint_mul_int_int(a: i64, b: i64) -> i64 {
-    // A 64x64 product is exact in i128; skips the general bigint mul machinery.
-    alloc_bigint_nursery_collecting(BigInt::from(a as i128 * b as i128)) as i64
+    alloc_bigint_nursery_collecting(BigInt::mul_int_int_bigint_result(a, b)) as i64
 }
 
 /// `rbigint.and_` on bare payloads (collecting). See [`jit_bigint_add`].


### PR DESCRIPTION
Two independent lines of work, both grounded in RPython/PyPy sources.

## 1. Run a tracing abort's framestack through `convert_and_run_from_pyjitpl`

`pyjitpl.py:2949 run_blackhole_interp_to_cancel_tracing` hands the aborted
`metainterp.framestack` to `blackhole.py:1799 convert_and_run_from_pyjitpl`,
which converts it into a blackhole chain and runs it until the bottommost
frame's `jit_merge_point` raises `ContinueRunningNormally`. Half-executed
opcodes therefore *finish* instead of being skipped. pyre had only a narrow
band-aid (`abort_at_next_merge_point`); this wires up the orthodox consumer the
in-code TODO named.

Because the walk's framestack is local to the dispatcher and the abort arm has
no native `state`, it is staged in two hops: `TraceCtx::aborted_framestack` →
`MetaInterp::pending_abort_blackhole` → `JitDriver::run_pending_abort_blackhole`,
called from the `jit_merge_point!` expansion — the first point holding `state`.

Three coverage bugs surfaced on the way, each also latent on the guard-failure
resume path:

- `call_result_reg` assumed RPython's single-slot return tail, but
  `inline_call_typed` closes every `BC_INLINE_CALL` with three slots, so
  `blackhole.py:1655`'s `code[position-1]` read the `NO_RETURN_REG` sentinel.
- `BC_NEW` had a wired handler but no opname→byte entry.
- The macro dispatch `JitCode` carried no `jitdriver_sd`, so
  `blackhole.py:1764`'s walk ran past the root and never captured the terminal
  image. Fixed at the root per `call.py:147-148`, which sets both directions.

`stb.raising_exception` is now carried, with the value read from
`MetaInterp::last_exc_value` where `blackhole.py:1811-1814` reads it.

The conversion previously declined for any state with a virtualizable, which
turned out to disable it almost everywhere: **aheui is the only frontend without
a `[.. ; virt]` array**. Upstream never declines, and that decline is now gone.
The remaining `array_lens` decline (flattened fixed `[int]`) stays — no frontend
declares one and there is no sym-side per-element collector.

⚠️ The example suites are neutral evidence here — they never abort (`MAJIT_LOG=1`
prints zero `abort-blackhole` lines). Forcing aborts with `MAJIT_STEP_LIMIT=200`
on a virt-array frontend reproduces the torn-state defect
(`index out of bounds: the len is 21 but the index is 21`, `stackpos` underflowed)
with the conversion off, and passes with it on. Pinned as
`majit-metainterp/tests/abort_blackhole_virt_array.rs`, its own test binary so it
can set the env knob, and verified to fail under `MAJIT_ABORT_BLACKHOLE=0`.

## 2. Gate write barriers on the collector's descriptor

`rewrite.py:393` gates the entire write-barrier section on
`self.gc_ll_descr.write_barrier_descr is not None`, and
`aarch64/assembler.py:975-980` gates the jitframe barrier on `if gcrootmap and
wbdescr`. pyre had neither gate on aarch64: `GcRewriterImpl.wb_descr` was built
unconditionally from `WriteBarrierDescr::for_current_gc()` instead of asking the
collector, and `reload_frame_if_necessary` re-applied the barrier without
checking. The x86 path already had the second gate.

This was latent until #796 replaced a silent `None => return` in
`emit_write_barrier_fastpath_for_base` with an assertion — correct in itself, a
barrier assembling to zero bytes is invisible until it corrupts memory. After
that, a collector reporting no descriptor (the `gc.py:156 GcLLDescr_boehm` case)
took the assertion on every compile, so every trace was dropped and the frontend
fell back to the interpreter. Bisected: `314019bf78^` 0 panics vs `314019bf78`
8326.

Note the assertion text names `COND_CALL_GC_WB`, but the reaching caller is
`reload_frame_if_necessary` ← `genop_call_malloc_nursery_headerless` — the
allocator, with no barrier op in the trace at all.

`MiniMarkGC::get_write_barrier_descr` returns exactly what the backends were
constructing inline, card-marking adjustment included, so the production path is
unchanged.

## Verification

- `pyre/check.py`: **dynasm 342/342, cranelift 342/342, wasm 339/339 — ALL PASSED**
- aheui corpus 55/55; logo 996310 bytes / exit 42 / md5 `7fcdbfff0af449c4283c008e3ca317ce`, jit output byte-identical to `--no-jit`
- `majit-metainterp` 1427 passed, `majit-gc` 215 passed + 2 new gate tests
- `cargo check --workspace --exclude pyre` and `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JIT recovery after aborts, panics, and mid-operation resumes.
  * Corrected typed return handling, virtualizable state preservation, and integer arithmetic behavior.
  * Improved garbage-collection fallback behavior and write-barrier safety.
  * Improved liveness tracking and resumed compilation consistency.

* **Improvements**
  * Made generated dispatcher output and serialized switch data deterministic.
  * Added clearer diagnostics for invalid switch configurations.

* **Tests**
  * Expanded coverage for recovery, garbage collection, liveness, dispatcher graphs, and optimizer ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->