### PR TITLE
interp: admit method_descriptor in the LOAD_ATTR-method fold precondition

### DIFF
--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -8866,14 +8866,21 @@ pub unsafe fn bound_method_attr_fast_path(
         return None;
     }
     let w_descr = lookup_in_type(w_type, name)?;
-    // `get()` binds exactly this shape: a `function` whose code is builtin
-    // (a `BuiltinFunction` returns itself unbound; every other descriptor
-    // kind takes a different arm).  A function is never a data descriptor,
-    // so the data-descriptor arm above it cannot fire either.
+    // The exact shape `get()` binds through `w_method_new`: a `function` OR a
+    // `method_descriptor` whose code is builtin.  Both take the SAME arm there
+    // (the `FUNCTION_TYPE || METHOD_DESCRIPTOR_TYPE` test above `w_method_new`),
+    // so admitting only one of them declines a receiver the fold reproduces
+    // exactly — `list.append` and every other `TypeDef` method are
+    // `method_descriptor`.  `BuiltinFunction` is excluded because `get()`
+    // returns it unbound, i.e. no `Method` to emit.  Neither kind is a data
+    // descriptor, so the data-descriptor arm above cannot fire either.
     if !crate::is_function(w_descr) {
         return None;
     }
-    if !std::ptr::eq((*w_descr).ob_type, &crate::FUNCTION_TYPE as *const _) {
+    let descr_ob_type = (*w_descr).ob_type;
+    if !std::ptr::eq(descr_ob_type, &crate::FUNCTION_TYPE as *const _)
+        && !std::ptr::eq(descr_ob_type, &crate::METHOD_DESCRIPTOR_TYPE as *const _)
+    {
         return None;
     }
     if !crate::is_builtin_code(crate::function_get_code(w_descr) as PyObjectRef) {
@@ -15428,6 +15435,53 @@ mod tests {
         let cls = crate::typedef::make_builtin_type("TestUserClass", |_| {});
         unsafe { pyre_object::w_type_set_hasdict(cls, true) };
         w_instance_new(cls)
+    }
+
+    /// `bound_method_attr_fast_path` must admit every descriptor kind the
+    /// `get()` it reproduces binds through `w_method_new` — otherwise the
+    /// `LOAD_ATTR`-method fold declines and the walker emits an opaque
+    /// may-force `getattr` residual per iteration instead.
+    ///
+    /// `TypeDef` methods are retagged `method_descriptor`
+    /// (`function_retag_method_descriptor`), not `function`, so a predicate
+    /// testing `FUNCTION_TYPE` alone silently declines `lst.append` and every
+    /// sibling. Both types take the SAME arm in `get()`.
+    #[test]
+    fn bound_method_fast_path_admits_the_same_kinds_get_binds() {
+        crate::typedef::init_typeobjects();
+        crate::test_hooks::install_hash_hook();
+        let w_list = pyre_object::listobject::w_list_new(vec![]);
+        let w_type = crate::typedef::r#type(w_list)
+            .expect("list has a type")
+            .as_ptr();
+
+        let w_descr = unsafe { lookup_in_type(w_type, "append") }.expect("list.append exists");
+        assert!(
+            std::ptr::eq(
+                unsafe { (*w_descr).ob_type },
+                &crate::METHOD_DESCRIPTOR_TYPE as *const _,
+            ),
+            "premise: a TypeDef method is a method_descriptor, not a function",
+        );
+
+        // `get()` is the behaviour the fold reproduces: it binds this descriptor
+        // into a Method carrying (w_function = descr, w_self = the receiver).
+        let bound = unsafe { get(w_descr, w_list, w_type) }
+            .expect("get() must not raise")
+            .expect("get() binds a method_descriptor");
+        assert!(unsafe { pyre_object::function::is_method(bound) });
+        assert!(std::ptr::eq(
+            unsafe { pyre_object::function::w_method_get_func(bound) },
+            w_descr,
+        ));
+
+        // So the predicate must admit it, naming the very same descriptor.
+        let (fp_type, fp_version_tag, fp_descr) =
+            unsafe { bound_method_attr_fast_path(w_list, "append") }
+                .expect("the fold precondition must admit what get() binds");
+        assert!(std::ptr::eq(fp_type, w_type));
+        assert!(std::ptr::eq(fp_descr, w_descr));
+        assert_ne!(fp_version_tag, 0);
     }
 
     /// typeobject.py:293-301 — under the interpreter (`we_are_jitted()`


### PR DESCRIPTION
`bound_method_attr_fast_path` — the precondition for
`try_walker_specialize_load_bound_method_attr` — gated on:

```rust
if !std::ptr::eq((*w_descr).ob_type, &crate::FUNCTION_TYPE as *const _) { return None; }
```

The `get()` it reproduces (`baseobjspace.rs:9516-9527`) takes the **same arm** for
`FUNCTION_TYPE` and `METHOD_DESCRIPTOR_TYPE` — both with builtin code bind through
`w_method_new` — and `is_function()` already covers both. So the predicate was
narrower than the behaviour it mirrors.

Every `TypeDef` method is retagged `method_descriptor`
(`function_retag_method_descriptor`, `function.rs:541`), so the gate declined
`lst.append`, `d.get`, `s.add`, `str.find`, `lst.pop` — every builtin method, i.e.
exactly the shape the fold was written for and names in its own doc. The walker
fell through to the `bh_load_attr_fn` residual on every iteration:

```
ForceToken; SetfieldGc ×2; CallMayForceR; GuardNotForced; GuardNoException;
GuardClass; GetfieldGcR Method.w_function; GuardValue; GetfieldGcR Method.w_self
```

`CALL_MAY_FORCE` forces the virtualizable frame through `GUARD_NOT_FORCED` every
iteration, and the `Method` the fold would have virtualized away is allocated for
real.

`BUILTIN_FUNCTION_TYPE` stays excluded: `get()` returns it unbound, so there is no
`Method` to emit.

## Why the PyPy reading misleads here

`type(list.append)` is `method_descriptor` in pyre and **`function`** in PyPy — so
reading upstream for the shape suggests the `FUNCTION_TYPE` gate is right. Pyre's
spelling is the correct one for the 3.14 target and PyPy's `function` is the
PyPy-ism, so the fix is to widen the predicate, not to retype `list.append`.

## How it was localized

`MAJIT_STATS` for the append loop and the same loop written as a comprehension were
**byte-identical** — `loops_compiled=3 bridges_compiled=3 loops_aborted=3
guard_failures=11742` for both — while exec time differed 8x. That rules out trace
count, aborts and bridge churn in one step. The optimized-trace diff was the 9 ops
above. The residual was identified by matching `CallMayForceR(addr, v9,
ptr(const), 1)` with `arg_types: [Ref, Ref, Int] -> Ref` against
`bh_load_attr_fn(obj, w_code_ptr, name_idx)` (`call_jit.rs:4871`): v9 = the
loop-invariant list, const = the code object, 1 = the `co_names` index of
`"append"`.

## Measurement

A/B at base `8c878513ef` with the LLBC corpus re-extracted for it — user+sys CPU
execution time (check.py's own metric), min of 3, dynasm vs pypy:

| | A (base) | B (this commit) |
|---|---|---|
| `r = []; for i in range(1000): r.append(i)` | 1.6863s **56.1x** | 0.2428s **7.8x** |
| `synth/const_arg_call_resume` (k=12800) | 2.4903s **34.0x** | 1.1180s **16.0x** |
| `CallMayForceR` in the optimized loop | 49 | **0** |

6.9x on the target form, 2.2x on the bench. The `Method` allocation is gone from
the trace as well — the optimizer virtualizes it once the fold emits it as
New+SetField instead of a residual result.

Attribution note: #878 ("inline bound methods and defaults") landed on main while
this was in progress. It is complementary, not overlapping — its
`try_walker_inline_builtin_call` (`inline_call.rs:1994`) unwraps a `Method`
callable into (function, receiver) and inlines the **CALL** half, and it consumes
the virtual `Method` this fold emits. Measured on its own it moves the append loop
63.9x → 56.1x and leaves the residual intact; the **LOAD_ATTR** half is this
commit's.

## Verification

At base `8c878513ef`, corpus freshly extracted, both backends rebuilt:

- `pyre/check.py --backend dynasm,cranelift` — **342/342 and 342/342**, exit 0.
- `cargo test -p pyre-interpreter --features dynasm` — 432 passed, 0 failed.
- `cargo test -p pyre-object` — 282 passed, 0 failed.
- A mixed `list.append` / `dict.get` / `set.add` / `str.find` / `list.pop` load:
  JIT output identical to `PYRE_NO_JIT=1`, pypy and cpython.
- `const_arg_call_resume.dynasm.jitstats` is unchanged against the committed
  baseline (`loops_compiled=3 bridges_compiled=9 loops_aborted=0
  guard_failures=1804`) — the win is per-iteration cost, not fewer guard failures,
  so no baseline re-record.
- In the gate the bench moved 22.8x/25.2x → **12.6x/14.0x** against its 30x limit.

The branch has since been replayed onto `fdca72a7fe`, which adds only #891 (already
verified green with and without on the previous base); the numbers above are from
`8c878513ef`.

## Side effect on the perf gate

`synth/const_arg_call_resume`'s `max-pypy-ratio=30` was calibrated against a
collapsed denominator: at the committed `k=400` pypy's execution time is 0.0061s,
barely above `EXEC_TIME_FLOOR_S = 0.005`, and the ratio converged **upward** to
36x/41x as the workload grew — which is why CI reported 41.2x/45.7x while local runs
passed at 22.8x. With this commit k=12800 reads 16.0x, so sizing that bench to an
honest denominator no longer needs the gate moved.

## Remaining levers in the same loop (not in this commit)

- The fold's own `w_class` and `version_tag` GuardValues are re-emitted every
  iteration although the receiver is loop-invariant — not hoisted to the preamble
  the way upstream's `@elidable_promote` version_tag read is.
- `NewWithVtable W_IntObject` + `SetfieldGc intval` followed immediately by
  `GetfieldGcI W_IntObject.intval` — box then unbox, the allocation surviving even
  though the box is dead after the int-strategy store. All three bench forms pay
  it (7.8x / 15.2x / 20.4x).
- Three `PtrEq`/`IntIsTrue`/`Guard` chains plus `GetfieldGcR PyType.instantiate` —
  per-iteration strategy/type dispatch after the strategy is already guarded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed descriptor binding for built-in type methods accessed through `get()`.
  - Improved compatibility between `get()` and fast-path method binding, ensuring methods such as `list.append` bind correctly.
- **Tests**
  - Added regression coverage for built-in method descriptors and their version tagging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->