### PR TITLE
gh#346: two-phase-rtyper census slices (rtyper-legacy stack)

### DIFF
--- a/majit/majit-charon-reader/src/ullbc.rs
+++ b/majit/majit-charon-reader/src/ullbc.rs
@@ -72,6 +72,45 @@ impl FunDecl {
             .map(|p| p.unstructured)
     }
 
+    /// Source name of the first argument local (local index 1; index 0 is the
+    /// return slot).  `None` when the body is absent, the function has no
+    /// arguments, or Charon dropped the name.
+    ///
+    /// Projects only the `locals` table — the basic-block CFG is skipped — so a
+    /// caller can distinguish a `self` receiver from an associated
+    /// constructor's `Self`-typed parameter without paying for a full body
+    /// parse.  Rust forbids naming a parameter `self`, so a genuine receiver's
+    /// local is the `self` keyword (named `"self"`, or unnamed for a
+    /// monomorphised trait method), whereas `W_Range::allocate(payload: Self)`
+    /// keeps its source name (`"payload"`).
+    pub fn first_arg_local_name(&self) -> Option<String> {
+        #[derive(Deserialize)]
+        struct Proj {
+            #[serde(rename = "Unstructured")]
+            u: BodyProj,
+        }
+        #[derive(Deserialize)]
+        struct BodyProj {
+            locals: LocalsProj,
+        }
+        #[derive(Deserialize)]
+        struct LocalsProj {
+            arg_count: u64,
+            locals: Vec<LocalNameProj>,
+        }
+        #[derive(Deserialize)]
+        struct LocalNameProj {
+            #[serde(default)]
+            name: Option<String>,
+        }
+        let body = self.body.as_ref()?;
+        let proj = serde_json::from_str::<Proj>(body.get()).ok()?;
+        if proj.u.locals.arg_count < 1 {
+            return None;
+        }
+        proj.u.locals.locals.get(1).and_then(|l| l.name.clone())
+    }
+
     /// Returns `Some(msg)` if Charon recorded a translation error
     /// (e.g. `"charon does not support thread local references"`).
     pub fn error_message(&self) -> Option<String> {

--- a/majit/majit-ir/src/descr.rs
+++ b/majit/majit-ir/src/descr.rs
@@ -1252,13 +1252,6 @@ impl GcCache {
     ) -> Arc<SimpleFieldDescr> {
         // descr.py:234-238: parent_descr = get_size_descr(gccache, STRUCT, vtable)
         let parent = self._cache_size.get(&struct_key).cloned();
-        // What the cached descr's own `index_in_parent` was normalised to when it
-        // was minted. The caller's raw number cannot be compared against it: a
-        // field that was rederived once stays rederived, so asserting the cached
-        // value equals the argument fires on the SECOND lookup of exactly the
-        // fields this normalisation exists for.
-        let expected_index_in_parent =
-            Self::find_index_in_parent(parent.as_ref(), field_name).unwrap_or(index_in_parent);
         // descr.py:220-221: cache[STRUCT][fieldname]
         let cached = self
             ._cache_field
@@ -1283,6 +1276,17 @@ impl GcCache {
                 } else {
                     (is_immutable, is_quasi_immutable)
                 };
+            // descr.py:220-221 returns the cached descr with no caller re-check.
+            // The authoritative slot number is the cached descr's own — it was
+            // normalised (rederived against the parent's positional list) when
+            // minted, so a field that was rederived once stays rederived. When
+            // the parent carries a positional list, `find_index_in_parent`
+            // arbitrates and the canary stays strict; when it does not (the mint
+            // path binds a fieldless size-descr shell), defer to the cached
+            // value rather than the caller's un-arbitrable raw number, which
+            // still carries whichever producer's header convention minted it.
+            let expected_index_in_parent = Self::find_index_in_parent(parent.as_ref(), field_name)
+                .unwrap_or(descr.index_in_parent);
             debug_assert!(
                 descr.describes_same_field(
                     offset,
@@ -6086,6 +6090,56 @@ mod register_keyed_size_authority_tests {
         assert_eq!(first.index_in_parent, 1, "the parent's own list wins");
         let second = lookup(&mut gc);
         assert_eq!(second.index_in_parent, 1);
+    }
+
+    /// The mint path binds a fieldless size-descr shell (`get_size_descr`
+    /// populates no `all_fielddescrs`), so `find_index_in_parent` cannot
+    /// arbitrate. The runtime published a headerless descr (`index 0`) first;
+    /// a later analyzer mint of the SAME field carries a header-counting number
+    /// (`index 2`). The cache hit must return the published descr and its canary
+    /// must defer to that cached index rather than fire on the caller's
+    /// un-arbitrable raw number — the exact `floatval 0-vs-2` /
+    /// `locals_cells_stack_w 0-vs-4` panic.
+    #[test]
+    fn a_shell_parent_defers_to_the_cached_index_not_the_caller() {
+        let mut gc = GcCache::new();
+        let key = LLType::Struct(9);
+        // Fieldless shell — no positional list to rederive against.
+        gc._cache_size.insert(key.clone(), size_descr_at(3, 0, &[]));
+        // First lookup: the headerless producer's index 0 is cached.
+        let first = gc.get_field_descr(
+            key.clone(),
+            "floatval",
+            None,
+            16,
+            8,
+            Type::Float,
+            false,
+            false,
+            ArrayFlag::Float,
+            0,
+            false,
+            0,
+        );
+        assert_eq!(first.index_in_parent, 0);
+        // Second lookup: a header-counting producer hands index 2. No parent
+        // arbitrates, so the canary must defer to the cached 0 (no panic) and
+        // return the cached descr unchanged.
+        let second = gc.get_field_descr(
+            key.clone(),
+            "floatval",
+            None,
+            16,
+            8,
+            Type::Float,
+            false,
+            false,
+            ArrayFlag::Float,
+            0,
+            false,
+            2,
+        );
+        assert_eq!(second.index_in_parent, 0, "the cached descr wins");
     }
 
     /// The upgrade rule itself is unchanged when both sides carry a vtable.

--- a/majit/majit-translate/src/annotator/unaryop.rs
+++ b/majit/majit-translate/src/annotator/unaryop.rs
@@ -4274,7 +4274,13 @@ fn init_someinstance_overrides(
                 // unaryop.py:848-852 — `attrdef = clsdef.attrs[attr];
                 // attrdef.modified(clsdef); if attrdef.s_value.contains(s_obj):
                 // return`.
-                let already_contains = {
+                // `attrdef.modified` needs `clsdef` mutably, but the following
+                // `s_value.contains(s_obj)` reads `clsdef`'s mro through
+                // `commonbase` (a shared borrow) when either side carries a
+                // classdef — so the mutable borrow must be released first.
+                // Upstream (unaryop.py:848-852) holds no exclusive borrow;
+                // clone `s_value` out and drop the borrow before the read.
+                let s_value = {
                     let mut clsdef_mut = clsdef.borrow_mut();
                     let attrdef = clsdef_mut.attrs.get_mut(&attr).unwrap_or_else(|| {
                         panic!(
@@ -4288,8 +4294,9 @@ fn init_someinstance_overrides(
                              modified failed: {err:?}"
                         )
                     });
-                    attrdef.s_value.contains(&s_obj)
+                    attrdef.s_value.clone()
                 };
+                let already_contains = s_value.contains(&s_obj);
                 if !already_contains {
                     // unaryop.py:854 — `clsdef.generalize_attr(attr, s_obj)`.
                     super::classdesc::ClassDef::generalize_attr(

--- a/majit/majit-translate/src/codewriter/annotation_state.rs
+++ b/majit/majit-translate/src/codewriter/annotation_state.rs
@@ -69,9 +69,9 @@ pub fn valuetype_to_someshell(vt: &ValueType) -> Option<SomeValue> {
         // seeds a string attr that unions cleanly with the value written
         // to it instead of the classdef-less `SomeInstance(None)` the
         // `Ref` fallback yields.
-        ValueType::Str => Some(SomeValue::String(
-            crate::annotator::model::SomeString::new(false, false),
-        )),
+        ValueType::Str => Some(SomeValue::String(crate::annotator::model::SomeString::new(
+            false, false,
+        ))),
         ValueType::Ref(_) => {
             // RPython typed pointers lift to `SomePtr(ll_ptrtype)`
             // (`llannotation.py:64-70`), but the correct Ptr must come

--- a/majit/majit-translate/src/codewriter/annotation_state.rs
+++ b/majit/majit-translate/src/codewriter/annotation_state.rs
@@ -63,6 +63,15 @@ pub fn valuetype_to_someshell(vt: &ValueType) -> Option<SomeValue> {
         // as `SomeBool::default` matching `SomeBool()` upstream.
         ValueType::Bool => Some(SomeValue::Bool(crate::annotator::model::SomeBool::default())),
         ValueType::Float => Some(SomeValue::Float(SomeFloat::default())),
+        // A `str`/`String`/`Wtf8` value shells to `SomeString`
+        // (`annotator/model.py` `SomeString`), the widest string shell
+        // (not-const, may-contain-nul), so a string-typed struct field
+        // seeds a string attr that unions cleanly with the value written
+        // to it instead of the classdef-less `SomeInstance(None)` the
+        // `Ref` fallback yields.
+        ValueType::Str => Some(SomeValue::String(
+            crate::annotator::model::SomeString::new(false, false),
+        )),
         ValueType::Ref(_) => {
             // RPython typed pointers lift to `SomePtr(ll_ptrtype)`
             // (`llannotation.py:64-70`), but the correct Ptr must come

--- a/majit/majit-translate/src/codewriter/assembler.rs
+++ b/majit/majit-translate/src/codewriter/assembler.rs
@@ -3023,7 +3023,7 @@ fn value_type_to_kind(ty: &crate::model::ValueType) -> char {
         // shares register class with Signed/Unsigned — all `'i'` for
         // the codewriter.
         ValueType::Int | ValueType::Unsigned | ValueType::Bool => 'i',
-        ValueType::Ref(_) => 'r',
+        ValueType::Ref(_) | ValueType::Str => 'r',
         ValueType::Float => 'f',
         ValueType::Void | ValueType::State | ValueType::Unknown => 'v',
         ValueType::Int128 | ValueType::UInt128 => {

--- a/majit/majit-translate/src/codewriter/call.rs
+++ b/majit/majit-translate/src/codewriter/call.rs
@@ -6765,9 +6765,9 @@ fn collect_readwrite_effects(
                             | crate::model::ValueType::Unsigned
                             | crate::model::ValueType::Bool
                             | crate::model::ValueType::State => majit_ir::value::Type::Int,
-                            crate::model::ValueType::Ref(_) | crate::model::ValueType::Unknown => {
-                                majit_ir::value::Type::Ref
-                            }
+                            crate::model::ValueType::Ref(_)
+                            | crate::model::ValueType::Str
+                            | crate::model::ValueType::Unknown => majit_ir::value::Type::Ref,
                             crate::model::ValueType::Float => majit_ir::value::Type::Float,
                             crate::model::ValueType::Void => majit_ir::value::Type::Void,
                             crate::model::ValueType::Int128 | crate::model::ValueType::UInt128 => {
@@ -6817,9 +6817,9 @@ fn collect_readwrite_effects(
                             | crate::model::ValueType::Unsigned
                             | crate::model::ValueType::Bool
                             | crate::model::ValueType::State => majit_ir::value::Type::Int,
-                            crate::model::ValueType::Ref(_) | crate::model::ValueType::Unknown => {
-                                majit_ir::value::Type::Ref
-                            }
+                            crate::model::ValueType::Ref(_)
+                            | crate::model::ValueType::Str
+                            | crate::model::ValueType::Unknown => majit_ir::value::Type::Ref,
                             crate::model::ValueType::Float => majit_ir::value::Type::Float,
                             crate::model::ValueType::Void => majit_ir::value::Type::Void,
                             crate::model::ValueType::Int128 | crate::model::ValueType::UInt128 => {
@@ -7685,7 +7685,7 @@ fn value_type_discriminant(ty: &crate::model::ValueType) -> u8 {
         // and `INT_TYPE` under the same `'int'` kind for descriptor
         // indexing (`lltypesystem/lloperation.py:108 getkind`).
         ValueType::Int | ValueType::Unsigned | ValueType::Bool => 0,
-        ValueType::Ref(_) => 1,
+        ValueType::Ref(_) | ValueType::Str => 1,
         ValueType::Float => 2,
         ValueType::Void => 3,
         ValueType::State => 4,

--- a/majit/majit-translate/src/codewriter/call.rs
+++ b/majit/majit-translate/src/codewriter/call.rs
@@ -3437,6 +3437,24 @@ impl CallControl {
                             {
                                 continue;
                             }
+                            // `#[pyre_class]`'s `allocate`/`allocate_stable`
+                            // constructors build the object then call the
+                            // non-numeric `lltype::malloc_typed[_stable]`, which
+                            // has no ported general `malloc->new` lowering.  The
+                            // caller resolves them to the
+                            // `collect_pyre_class_ctor_stubs_from_llbc` residual
+                            // stub, so — like a builtin — the BFS must not follow
+                            // the constructor body: otherwise the two-phase census
+                            // annotates its unliftable body (and its transitive
+                            // `malloc_typed_stable`) standalone and reports a
+                            // spurious Phase-A failure for a graph no caller ever
+                            // traces into.
+                            if matches!(
+                                callee_path.last_segment(),
+                                Some("allocate") | Some("allocate_stable")
+                            ) {
+                                continue;
+                            }
                             vec![callee_path]
                         }
                         _ => continue,

--- a/majit/majit-translate/src/codewriter/jtransform.rs
+++ b/majit/majit-translate/src/codewriter/jtransform.rs
@@ -729,7 +729,7 @@ impl<'a> Transformer<'a> {
             ValueType::Int | ValueType::Unsigned | ValueType::Bool | ValueType::State => {
                 crate::codewriter::type_state::ConcreteType::Signed
             }
-            ValueType::Ref(_) => crate::codewriter::type_state::ConcreteType::GcRef,
+            ValueType::Ref(_) | ValueType::Str => crate::codewriter::type_state::ConcreteType::GcRef,
             ValueType::Float => crate::codewriter::type_state::ConcreteType::Float,
             ValueType::Void => crate::codewriter::type_state::ConcreteType::Void,
             ValueType::Unknown | ValueType::Int128 | ValueType::UInt128 => return,
@@ -5423,7 +5423,7 @@ fn value_type_to_kind(ty: &ValueType) -> char {
         // return `'int'` (ll Bool / Unsigned share register class
         // with Signed at the codewriter register-kind layer).
         ValueType::Int | ValueType::Unsigned | ValueType::Bool | ValueType::State => 'i',
-        ValueType::Ref(_) | ValueType::Unknown => 'r',
+        ValueType::Ref(_) | ValueType::Str | ValueType::Unknown => 'r',
         ValueType::Float => 'f',
         ValueType::Void => 'v',
         ValueType::Int128 | ValueType::UInt128 => {
@@ -5492,7 +5492,7 @@ fn value_type_to_ir_type(ty: &ValueType) -> majit_ir::value::Type {
         ValueType::Int | ValueType::Unsigned | ValueType::Bool | ValueType::State => {
             majit_ir::value::Type::Int
         }
-        ValueType::Ref(_) | ValueType::Unknown => majit_ir::value::Type::Ref,
+        ValueType::Ref(_) | ValueType::Str | ValueType::Unknown => majit_ir::value::Type::Ref,
         ValueType::Float => majit_ir::value::Type::Float,
         ValueType::Void => majit_ir::value::Type::Void,
         ValueType::Int128 | ValueType::UInt128 => {

--- a/majit/majit-translate/src/codewriter/jtransform.rs
+++ b/majit/majit-translate/src/codewriter/jtransform.rs
@@ -729,7 +729,9 @@ impl<'a> Transformer<'a> {
             ValueType::Int | ValueType::Unsigned | ValueType::Bool | ValueType::State => {
                 crate::codewriter::type_state::ConcreteType::Signed
             }
-            ValueType::Ref(_) | ValueType::Str => crate::codewriter::type_state::ConcreteType::GcRef,
+            ValueType::Ref(_) | ValueType::Str => {
+                crate::codewriter::type_state::ConcreteType::GcRef
+            }
             ValueType::Float => crate::codewriter::type_state::ConcreteType::Float,
             ValueType::Void => crate::codewriter::type_state::ConcreteType::Void,
             ValueType::Unknown | ValueType::Int128 | ValueType::UInt128 => return,

--- a/majit/majit-translate/src/codewriter/jtransform.rs
+++ b/majit/majit-translate/src/codewriter/jtransform.rs
@@ -9804,7 +9804,7 @@ mod tests {
         let return_str = match result_ty {
             ValueType::Int | ValueType::State => "i64",
             ValueType::Unsigned => "u64",
-            ValueType::Ref(_) | ValueType::Unknown => "String",
+            ValueType::Ref(_) | ValueType::Str | ValueType::Unknown => "String",
             ValueType::Float => "f64",
             ValueType::Void => "",
             ValueType::Bool => "bool",
@@ -10056,7 +10056,7 @@ mod tests {
         let return_str = match result_ty {
             ValueType::Int | ValueType::State => "i64",
             ValueType::Unsigned => "u64",
-            ValueType::Ref(_) | ValueType::Unknown => "String",
+            ValueType::Ref(_) | ValueType::Str | ValueType::Unknown => "String",
             ValueType::Float => "f64",
             ValueType::Void => "",
             ValueType::Bool => "bool",

--- a/majit/majit-translate/src/codewriter/type_state.rs
+++ b/majit/majit-translate/src/codewriter/type_state.rs
@@ -74,7 +74,7 @@ pub(crate) fn valuetype_to_concrete(vt: &ValueType) -> ConcreteType {
         // == 'int'`); only the rtyper picks `IntegerRepr.lowleveltype
         // = Unsigned` based on `SomeInteger.unsigned`.
         ValueType::Int | ValueType::Unsigned | ValueType::Bool => ConcreteType::Signed,
-        ValueType::Ref(_) => ConcreteType::GcRef,
+        ValueType::Ref(_) | ValueType::Str => ConcreteType::GcRef,
         ValueType::Float => ConcreteType::Float,
         ValueType::Void => ConcreteType::Void,
         ValueType::State | ValueType::Unknown | ValueType::Int128 | ValueType::UInt128 => {

--- a/majit/majit-translate/src/front/bool_then.rs
+++ b/majit/majit-translate/src/front/bool_then.rs
@@ -120,16 +120,20 @@ fn rewire_one_bool_then_site(graph: &mut FunctionGraph, site: &BoolThenSite) -> 
         })
         .ok_or_else(|| format!("{name}: bool::then result var has no producer block"))?;
 
-    // The call must be A's last op (lower_call closes the block right
-    // after pushing it) so removing it leaves the closure-env construction
-    // ops as the block tail.
-    let call_idx = graph.blocks[a].operations.len() - 1;
-    if graph.blocks[a].operations[call_idx].result.as_ref() != Some(&site.result_var) {
-        return Err(format!(
-            "{name}: bool::then call is not the last op of block {a}"
-        ));
-    }
-    // Capture the condition + closure env operands.
+    // The `then`/`then_some` call is normally A's last op (lower_call closes
+    // the block right after pushing it), so removing it leaves the closure-env
+    // construction ops as the block tail.  Locate it by result rather than
+    // assuming the last slot: on a simplified graph (a result_exc / next /
+    // checked-arith callee runs `simplify_lowered_graph` before this pass) the
+    // opaque `Ref` result is immediately narrowed to the concrete `Option<T>`
+    // by a `__pyre_cast_instance` recast tail that `eliminate_empty_blocks`
+    // folds into A, leaving the call no longer last.
+    let call_idx = graph.blocks[a]
+        .operations
+        .iter()
+        .position(|op| op.result.as_ref() == Some(&site.result_var))
+        .ok_or_else(|| format!("{name}: bool::then producer op vanished from block {a}"))?;
+    // Capture the condition + closure env operands from the raw call.
     let (cond, env) = match &graph.blocks[a].operations[call_idx].kind {
         OpKind::Call { args, .. } if args.len() == 2 => (args[0].clone(), args[1].clone()),
         other => {
@@ -138,6 +142,16 @@ fn rewire_one_bool_then_site(graph: &mut FunctionGraph, site: &BoolThenSite) -> 
             ));
         }
     };
+    // Peel the trailing recast chain (`front::iter_next::peel_recast_chain`):
+    // the `Option` value B consumes is the chain's final result, and the peeled
+    // recasts are removed with the call below so it becomes A's last op.
+    let opt_val = crate::front::iter_next::peel_recast_chain(
+        graph,
+        a,
+        call_idx,
+        &site.result_var,
+        "bool::then",
+    )?;
 
     // A's single exit → B (the continuation consuming the Option).  Must be
     // a plain goto — `lower_call` closes with exactly this shape.
@@ -160,7 +174,7 @@ fn rewire_one_bool_then_site(graph: &mut FunctionGraph, site: &BoolThenSite) -> 
     let mut carried: Vec<Variable> = Vec::new();
     for arg in &saved_exit.args {
         if let LinkArg::Value(v) = arg
-            && *v != site.result_var
+            && *v != opt_val
             && !carried.contains(v)
         {
             carried.push(v.clone());
@@ -222,7 +236,7 @@ fn rewire_one_bool_then_site(graph: &mut FunctionGraph, site: &BoolThenSite) -> 
     );
     let then_link_args = reproduce_exit_args(
         &saved_exit,
-        &site.result_var,
+        &opt_val,
         &some_var,
         &then_sources,
         &then_inputs,
@@ -234,7 +248,7 @@ fn rewire_one_bool_then_site(graph: &mut FunctionGraph, site: &BoolThenSite) -> 
     let none_var = emit_option_variant(graph, else_bb, &site.option_owner, 0, None);
     let else_link_args = reproduce_exit_args(
         &saved_exit,
-        &site.result_var,
+        &opt_val,
         &none_var,
         &carried,
         &else_inputs,
@@ -242,11 +256,12 @@ fn rewire_one_bool_then_site(graph: &mut FunctionGraph, site: &BoolThenSite) -> 
     )?;
     close_goto_mixed(graph, else_bb, b_target, else_link_args);
 
-    // A: drop the residual `then` call, branch on `cond`.  `set_branch`
-    // appends the `bool(cond)` hop and installs the Bool(false)/Bool(true)
-    // arm links; the closure-env construction ops stay as A's tail.
+    // A: drop the residual `then` call and any peeled `__pyre_cast_instance`
+    // recast tail, branch on `cond`.  `set_branch` appends the `bool(cond)` hop
+    // and installs the Bool(false)/Bool(true) arm links; the closure-env
+    // construction ops before the call stay as A's tail.
     let a_id = graph.blocks[a].id;
-    graph.blocks[a].operations.remove(call_idx);
+    graph.blocks[a].operations.truncate(call_idx);
     graph.set_branch(a_id, cond, then_bb, then_sources, else_bb, carried);
     Ok(())
 }

--- a/majit/majit-translate/src/front/iter_next.rs
+++ b/majit/majit-translate/src/front/iter_next.rs
@@ -281,11 +281,17 @@ fn is_recast_narrow(kind: &OpKind) -> bool {
 /// a single value would drop a live use).  With no recast (`next` registered,
 /// or a list element that needs no narrow) the chain is length 0 and this
 /// returns `opt` unchanged.  Any other shape declines (fail-safe).
-fn peel_recast_chain(
+///
+/// Shared with `front::bool_then`: a residual `then`/`then_some` produces the
+/// same opaque `Ref` narrowed to the concrete `Option<T>` by a
+/// `__pyre_cast_instance` recast tail, so it peels the identical chain (the
+/// caller passes its own `op_label` for the decline messages).
+pub(crate) fn peel_recast_chain(
     graph: &FunctionGraph,
     a: usize,
     next_idx: usize,
     opt: &Variable,
+    op_label: &str,
 ) -> Result<Variable, String> {
     let name = &graph.name;
     let ops = &graph.blocks[a].operations;
@@ -296,13 +302,13 @@ fn peel_recast_chain(
         // The next op must be a recast whose single operand is `cur`.
         let OpKind::Call { args, .. } = &follow.kind else {
             return Err(format!(
-                "{name}: op after next() in block {a} is not the block terminator \
+                "{name}: op after {op_label} in block {a} is not the block terminator \
                  nor a recast narrow"
             ));
         };
         if !is_recast_narrow(&follow.kind) || args[0] != cur {
             return Err(format!(
-                "{name}: op after next() in block {a} is not a recast of the prior result"
+                "{name}: op after {op_label} in block {a} is not a recast of the prior result"
             ));
         }
         // `cur` (a non-final chain intermediate) must be dead except for
@@ -376,7 +382,7 @@ fn rewire_one_next_site(graph: &mut FunctionGraph, opt: &Variable) -> Result<(),
     // `recast`, `rpython/rtyper/rlist.py:448` `self.r_list.recast`).  Such a
     // narrow is a `cast_pointer` alias, so the native `next` op subsumes it:
     // peel the trailing chain and scrutinise its final result as the Option.
-    let effective_opt = peel_recast_chain(graph, a, next_idx, opt)?;
+    let effective_opt = peel_recast_chain(graph, a, next_idx, opt, "next()")?;
     let opt = &effective_opt;
 
     // The 2-exit StopIteration-only shape is faithful ONLY for a list

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -1951,6 +1951,19 @@ fn lower_unstructured_with_static_addrs_and_attrs(
         } else {
             crate::front::bool_then::rewire_bool_then_call_sites(&mut lo.graph, &lo.bool_then_sites)
         };
+        // The `<[T]>::first(slice)` length-checked `Option<&T>` diamond rewrite
+        // (`front::slice_first`) splits the residual `first` call block into a
+        // guarded `Some`/`None` diamond (`if len(slice) > 0`), same post-lowering
+        // shape and fail-safe contract as `bool::then`; gate the reachability
+        // sweep on an actual rewrite.
+        let slice_first_rewritten = if lo.slice_first_sites.is_empty() {
+            0
+        } else {
+            crate::front::slice_first::rewire_slice_first_call_sites(
+                &mut lo.graph,
+                &lo.slice_first_sites,
+            )
+        };
         // The `Option::unwrap_or` value-select rewrite
         // (`front::option_unwrap_or`) splits the residual `unwrap_or` call
         // block into a `__discriminant` diamond, same post-lowering shape and
@@ -2039,6 +2052,7 @@ fn lower_unstructured_with_static_addrs_and_attrs(
             || checked_arith_rewritten > 0
             || option_try_stats.rewritten > 0
             || bool_then_rewritten > 0
+            || slice_first_rewritten > 0
             || unwrap_or_rewritten > 0
             || unwrap_rewritten > 0
             || map_or_rewritten > 0
@@ -2423,6 +2437,11 @@ struct Lowering<'a> {
     /// resolved ctor/method owners the arms need (see
     /// [`crate::front::bool_then::BoolThenSite`]).
     bool_then_sites: Vec<crate::front::bool_then::BoolThenSite>,
+    /// `<[T]>::first(slice)` call sites recorded for the length-checked
+    /// `Option<&T>` diamond the `front::slice_first` post-pass synthesizes
+    /// after the body lowering completes (see
+    /// [`crate::front::slice_first::SliceFirstSite`]).
+    slice_first_sites: Vec<crate::front::slice_first::SliceFirstSite>,
     /// `RangeInclusive::new(lo, hi)` call sites recorded for the
     /// `(a..=b).contains(&x)` → `bitand(le, ge)` fold the
     /// `front::range_contains` post-pass synthesizes (see
@@ -2646,6 +2665,7 @@ impl<'a> Lowering<'a> {
             checked_arith_call_results: Vec::new(),
             option_try_sites: Vec::new(),
             bool_then_sites: Vec::new(),
+            slice_first_sites: Vec::new(),
             range_inclusive_new_sites: Vec::new(),
             range_iter_new_sites: Vec::new(),
             range_contains_sites: Vec::new(),
@@ -5902,7 +5922,11 @@ impl<'a> Lowering<'a> {
     /// fold in [`Self::lower_call`].  `None` for a non-ADT type argument
     /// (primitive / pointer / tuple, which has no `TypeDecl` layout to read)
     /// or a layout Charon left unresolved.
-    fn size_align_const_from_tyexpr(&self, want_align: bool, ty: &serde_json::Value) -> Option<i64> {
+    fn size_align_const_from_tyexpr(
+        &self,
+        want_align: bool,
+        ty: &serde_json::Value,
+    ) -> Option<i64> {
         let adt = self.resolve_tyexpr_to_adt_def_id(ty)?;
         // Read the layout for the build's `TARGET` (empty for the host
         // extraction target), matching the target-aware field-offset lookup
@@ -5910,7 +5934,11 @@ impl<'a> Lowering<'a> {
         // size, not the host's.
         let target = std::env::var("TARGET").unwrap_or_default();
         let layout = self.llbc.type_by_id(adt)?.layout_for_target(&target)?;
-        let value = if want_align { layout.align } else { layout.size }?;
+        let value = if want_align {
+            layout.align
+        } else {
+            layout.size
+        }?;
         Some(value as i64)
     }
 
@@ -8117,6 +8145,23 @@ impl<'a> Lowering<'a> {
         {
             self.bool_then_sites.push(site);
         }
+        // Capture `<[T]>::first(slice)` sites for the length-checked
+        // `Option<&T>` diamond `front::slice_first` synthesizes.  `first` is a
+        // foreign leaf (its `Self` is the primitive slice `[T]`, so `lower_call`
+        // keeps the raw `FunctionPath` segments), residualized as an
+        // unregistered callee the rtyper census Skips; a resolution miss leaves
+        // the residual call.
+        if let OpKind::Call {
+            target: CallTarget::FunctionPath { segments },
+            args,
+            ..
+        } = &op_kind
+            && args.len() == 1
+            && fmt_path_ends_with(segments, &["slice", "<Impl>", "first"])
+            && let Some(site) = self.recognize_slice_first_site(&call.dest.ty, &result_var)
+        {
+            self.slice_first_sites.push(site);
+        }
         // Capture `RangeInclusive::new(lo, hi)` sites for the
         // `(a..=b).contains(&x)` fold `front::range_contains` synthesizes.
         // `new` is an inherent-impl associated function whose owner
@@ -10091,6 +10136,31 @@ impl<'a> Lowering<'a> {
         Some(crate::front::bool_then::BoolThenSite {
             result_var: result_var.clone(),
             call_once_owner: None,
+            option_owner,
+            some_owner,
+            payload_ty,
+        })
+    }
+
+    /// Resolve a recognized `<[T]>::first(slice)` call into a
+    /// [`crate::front::slice_first::SliceFirstSite`] — the `Option` enum root +
+    /// `Some` variant owners the length-checked diamond post-pass spells its
+    /// arms with.  Gated on [`Self::option_residual_narrow_root`] returning
+    /// `Some`: that is exactly the shape `lower_call` appends a trailing
+    /// `__pyre_cast_instance` narrowing to (the cast the post-pass absorbs and
+    /// re-applies per arm), and it declines a value-slice `Option<u8>` /
+    /// `Option<i64>` (no registered pointee root) cleanly, leaving the residual
+    /// call for the census Skip.  `None` when the destination is not a
+    /// resolvable narrow-root `Option`.
+    fn recognize_slice_first_site(
+        &self,
+        dest_ty: &TyRef,
+        result_var: &Variable,
+    ) -> Option<crate::front::slice_first::SliceFirstSite> {
+        self.option_residual_narrow_root(dest_ty)?;
+        let (option_owner, some_owner, payload_ty) = self.resolve_bool_then_option_dest(dest_ty)?;
+        Some(crate::front::slice_first::SliceFirstSite {
+            result_var: result_var.clone(),
             option_owner,
             some_owner,
             payload_ty,

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -13471,7 +13471,7 @@ fn clone_tyref(ty: &TyRef) -> TyRef {
 fn value_type_bank(ty: &ValueType) -> u8 {
     match ty {
         ValueType::Int | ValueType::Unsigned | ValueType::Bool => 0,
-        ValueType::Ref(_) => 1,
+        ValueType::Ref(_) | ValueType::Str => 1,
         ValueType::Float => 2,
         ValueType::Void => 3,
         ValueType::State => 4,
@@ -13731,7 +13731,7 @@ fn dont_look_inside_return_token(output: &TyRef, llbc: &Llbc) -> Option<String> 
         ValueType::Ref(_) if output_type_is_objectptr(output, llbc) => {
             return Some(crate::translator::rtyper::cutover::OBJECTPTR_RETURN_TYPE.to_string());
         }
-        ValueType::Ref(_) => "ref",
+        ValueType::Ref(_) | ValueType::Str => "ref",
         ValueType::Void | ValueType::State | ValueType::Unknown => return None,
     };
     Some(token.to_string())
@@ -13885,6 +13885,14 @@ fn tyref_to_attr_value_type(ty: &TyRef, llbc: &Llbc) -> ValueType {
     // no `pair(SomeInteger, SomeInstance).union()` handler and walls.
     if tyref_is_fieldless_enum_free(ty, llbc) {
         return ValueType::Int;
+    }
+    // A `str`/`String`/`Wtf8` field seeds a `SomeString` attr shell (via
+    // valuetype_to_someshell) instead of the classdef-less `Ref(None)`
+    // SomeInstance the fallback yields; the latter walls when the first
+    // typed string write unions `String ∪ Instance(classdef-less)` with no
+    // pair(SomeString, SomeInstance).union() handler.
+    if tyref_is_string_value(ty, llbc) {
+        return ValueType::Str;
     }
     ValueType::Ref(None)
 }

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -13875,6 +13875,17 @@ fn tyref_to_attr_value_type(ty: &TyRef, llbc: &Llbc) -> ValueType {
     if let Some(inner) = tyref_atomic_inner_value_type(ty, llbc) {
         return inner;
     }
+    // A fieldless (C-like) enum field is represented by-value as its
+    // discriminant integer, matching `tyref_to_value_type` which colors
+    // the same enum `Int` at every value site (construction, field read,
+    // `Discriminant`).  Seed the attr as `Int` so the forced class
+    // attribute agrees with the discriminant write; otherwise the field
+    // seeds a classdef-less `SomeInstance(None)` shell and the first typed
+    // write (`err.kind = PyErrorKind::…`) unions `Integer ∪ Instance` with
+    // no `pair(SomeInteger, SomeInstance).union()` handler and walls.
+    if tyref_is_fieldless_enum_free(ty, llbc) {
+        return ValueType::Int;
+    }
     ValueType::Ref(None)
 }
 

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -13617,6 +13617,19 @@ fn tyref_to_value_type(ty: &TyRef, llbc: &Llbc) -> ValueType {
     if tyref_is_fieldless_enum_free(ty, llbc) {
         return ValueType::Int;
     }
+    // A `str`/`String`/`Wtf8`/`Wtf8Buf` value is the single immutable
+    // rpy_string in the value model (`tyref_is_string_value`), matching
+    // upstream's one string type (`rstr.py`).  A bare string-family value
+    // (parameter, return, local) seeds `SomeString` so it stays the string
+    // lattice node at every site instead of a classdef-carrying
+    // `SomeInstance(Wtf8Buf)`: a `Wtf8Buf` value stored into a `*mut Wtf8Buf`
+    // field flows `SomeString` through `malloc_raw` (which round-trips a
+    // non-`Instance` payload unchanged), keeping the field repr
+    // `Ptr(rpy_string)` consistent with the `getattr` + deref-to-`&Wtf8`
+    // read that reports the field as a string.
+    if tyref_is_string_value(ty, llbc) {
+        return ValueType::Str;
+    }
     ValueType::Ref(None)
 }
 

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -4905,8 +4905,46 @@ impl<'a> Lowering<'a> {
                         // types), so read and write attrs key under one
                         // owner.
                         let owner = format!("Tuple{}", tyref_tuple_suffix(&inner.ty, self.llbc));
+                        // A tuple reached through a pointer/reference deref
+                        // (a residual call returning `&(A, B)`, a
+                        // `*mut (A, B)` field) resolves its base to a
+                        // classdef-less `SomeInstance`: pyre's pointer
+                        // erasure drops the tuple shape, so the annotator
+                        // Blocks the `__pos_<N>` read (dispatched as
+                        // `getattr`) on a classdef-less instance.  Narrow the
+                        // base to this tuple's `Tuple{suffix}` classdef first
+                        // — identity when it already carries it — the same
+                        // `__pyre_cast_instance` downcast the raw-ptr-deref
+                        // Adt field arm applies (see `narrow_root` above).  A
+                        // by-value tuple base is not deref-shaped and keeps
+                        // its concrete classdef, so it is left untouched.
+                        let base_is_deref = matches!(
+                            &inner.kind,
+                            PlaceKind::Projection(_, ProjectionElem::Atom(s)) if s == "Deref"
+                        );
                         let base = self.resolve_place(mir_bb, *inner)?;
                         let bb_id = self.block_id[mir_bb];
+                        let base = if base_is_deref {
+                            let narrowed = self
+                                .graph
+                                .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
+                            self.graph.block_mut(bb_id).operations.push(SpaceOperation {
+                                result: Some(narrowed.clone()),
+                                kind: OpKind::Call {
+                                    target: CallTarget::FunctionPath {
+                                        segments: vec![
+                                            "__pyre_cast_instance".to_string(),
+                                            owner.clone(),
+                                        ],
+                                    },
+                                    args: vec![base],
+                                    result_ty: ValueType::Ref(Some(owner.clone())),
+                                },
+                            });
+                            narrowed
+                        } else {
+                            base
+                        };
                         let ty = tyref_to_value_type(&place_ty, self.llbc);
                         let res = self
                             .graph

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -8466,6 +8466,25 @@ impl<'a> Lowering<'a> {
                 if !first_is_self {
                     return None;
                 }
+                // The first input being the owner ADT is necessary but not
+                // sufficient: an associated constructor
+                // (`W_Range::allocate(payload: Self)` /
+                // `allocate_stable(payload: Self)`) also presents the owner as
+                // its first input, yet routing it as `Method` threads the
+                // payload as the getattr receiver and blocks on
+                // `getattr(payload, "allocate")`.  Only a genuine `self`
+                // receiver may route as `Method`.  Rust forbids naming a
+                // parameter `self`, so a receiver's local is the `self` keyword
+                // (Charon names it `"self"`, or leaves it unnamed for a
+                // monomorphised trait method), whereas a constructor's
+                // `Self`-typed parameter keeps its source name (`payload`).
+                // Decline the Method hint for an explicitly-named non-`self`
+                // first input so the call routes as `FunctionPath` and the
+                // call registry resolves the constructor (its residual stub via
+                // `collect_pyre_class_ctor_stubs_from_llbc`).
+                if fd.first_arg_local_name().is_some_and(|n| n != "self") {
+                    return None;
+                }
                 owner
             }
             // Non-ADT `Self` (primitive / raw pointer / slice): Charon leaves
@@ -12808,6 +12827,78 @@ pub(crate) fn collect_unsafe_fn_stubs_from_llbc(
             })
             .collect();
         out.push((segments, Signature::new(argnames, None, None), token));
+    }
+    out
+}
+
+/// Collect residual stubs for the `#[pyre_class]`-generated allocation
+/// constructors `<Owner>::allocate(payload: Self) -> PyObjectRef` and
+/// `allocate_stable(payload: Self)`.
+///
+/// Each builds `Self { ob: <header>, ..payload }` then calls
+/// `lltype::malloc_typed[_stable]` — a non-numeric boxing allocation with no
+/// ported general `malloc->new` lowering (`fuse_boxing_alloc` rewrites only
+/// the numeric boxes `W_Float`/`W_Int`/`W_Complex`/`W_Long`; every other
+/// mallocable struct hits the fail-closed `flowspace_adapter` guard).  So the
+/// constructor body cannot be traced; the faithful treatment is the
+/// `register_external` analog — residualize the whole `allocate` call.
+/// [`Lowering::impl_method_owner`] declines the `CallTarget::Method` hint for
+/// the `payload`-named `Self` argument (routing through
+/// `CallTarget::FunctionPath`); this collection feeds the matching registry
+/// entries, keyed by the SAME [`impl_method_owner_for_fundecl`] the
+/// declined-Method `call_target_segments` arm uses, so the `FunctionPath`
+/// lookup resolves to the `*mut PyObject` return shell instead of the failing
+/// looked-inside body.  The companion skip in
+/// `populate_call_registry_from_call_graphs` keeps the constructor's own
+/// (unliftable) body out of the registry so this stub key wins.
+///
+/// Reuses the [`CallControl::unsafe_fn_stubs`] carrier + `register_unsafe_fn_stubs`
+/// registration path (both feed `(segments, Signature, return-token)` specs
+/// through the same annotator-only `residual_return_shell`).
+pub(crate) fn collect_pyre_class_ctor_stubs_from_llbc(
+    llbc: &Llbc,
+) -> Vec<(
+    Vec<String>,
+    crate::flowspace::argument::Signature,
+    Option<String>,
+)> {
+    use crate::flowspace::argument::Signature;
+    let mut out = Vec::new();
+    for fd in llbc.iter_local_fns() {
+        if fd.is_global_initializer.is_some() {
+            continue;
+        }
+        let Some((owner_qualified, leaf)) = impl_method_owner_for_fundecl(llbc, fd) else {
+            continue;
+        };
+        if leaf != "allocate" && leaf != "allocate_stable" {
+            continue;
+        }
+        // The macro constructor is exactly `(payload: Self) -> *mut PyObject`:
+        // one argument returning the object pointer.  A `self`-named receiver
+        // (`fn allocate(&self) -> …`) is a real method, not the constructor.
+        if fd.signature.inputs.len() != 1 {
+            continue;
+        }
+        if !output_type_is_objectptr(&fd.signature.output, llbc) {
+            continue;
+        }
+        if fd.first_arg_local_name().as_deref() == Some("self") {
+            continue;
+        }
+        let mut segments: Vec<String> = owner_qualified.split("::").map(String::from).collect();
+        segments.push(leaf);
+        let argname = fd
+            .unstructured()
+            .as_ref()
+            .and_then(|u| u.locals.locals.get(1))
+            .and_then(|l| l.name.clone())
+            .unwrap_or_else(|| "payload".to_string());
+        out.push((
+            segments,
+            Signature::new(vec![argname], None, None),
+            Some(crate::translator::rtyper::cutover::OBJECTPTR_RETURN_TYPE.to_string()),
+        ));
     }
     out
 }

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -5891,14 +5891,27 @@ impl<'a> Lowering<'a> {
         if !saw_return {
             return None;
         }
-        let adt = self.resolve_tyexpr_to_adt_def_id(&ty)?;
-        let layout = self.llbc.type_by_id(adt)?.layout_for_target("")?;
-        let value = if want_align {
-            layout.align
-        } else {
-            layout.size
-        }?;
-        Some(OpKind::ConstInt(value as i64))
+        Some(OpKind::ConstInt(
+            self.size_align_const_from_tyexpr(want_align, &ty)?,
+        ))
+    }
+
+    /// The build-time byte size / alignment Charon resolved for an ADT type
+    /// expression's layout, shared by [`Self::fold_size_const_global`] (the
+    /// NamedConst-initializer form) and the inline `size_of`/`align_of` call
+    /// fold in [`Self::lower_call`].  `None` for a non-ADT type argument
+    /// (primitive / pointer / tuple, which has no `TypeDecl` layout to read)
+    /// or a layout Charon left unresolved.
+    fn size_align_const_from_tyexpr(&self, want_align: bool, ty: &serde_json::Value) -> Option<i64> {
+        let adt = self.resolve_tyexpr_to_adt_def_id(ty)?;
+        // Read the layout for the build's `TARGET` (empty for the host
+        // extraction target), matching the target-aware field-offset lookup
+        // in `record_struct_id`. A wasm32 cross-build folds the wasm32 byte
+        // size, not the host's.
+        let target = std::env::var("TARGET").unwrap_or_default();
+        let layout = self.llbc.type_by_id(adt)?.layout_for_target(&target)?;
+        let value = if want_align { layout.align } else { layout.size }?;
+        Some(value as i64)
     }
 
     // -----------------------------------------------------------------------
@@ -6146,6 +6159,48 @@ impl<'a> Lowering<'a> {
         let op_kind = match (class, call.func) {
             (CallClass::Direct, CallFunc::Regular(reg))
             | (CallClass::Trait, CallFunc::Regular(reg)) => {
+                // Fold an inline `core::mem::size_of::<T>()` /
+                // `align_of::<T>()` call with a layout-resolvable ADT type
+                // argument to its build-time byte size / alignment — the same
+                // constant `fold_size_const_global` produces for the
+                // NamedConst-initializer form, applied here to the inline
+                // call shape (`gc_alloc_storage_box`'s
+                // `try_gc_alloc_stable_raw(tid, size_of::<T>())`,
+                // `struct::__sizeof__`'s `size_of::<W_Struct>()`).  Removes the
+                // residual `<host std.mem.size_of>` call the rtyper cannot
+                // register.  Declines (falls through to the ordinary call
+                // path) for a non-ADT type argument, whose size is not read
+                // from a `TypeDecl` layout.
+                if let CallKind::Fun(FunId::Regular { id }) = &reg.kind
+                    && let Some(fd) = self.llbc.fn_by_id(*id)
+                {
+                    let want_align = match fd.item_meta.name_path().as_str() {
+                        "core::mem::size_of" => Some(false),
+                        "core::mem::align_of" => Some(true),
+                        _ => None,
+                    };
+                    if let Some(want_align) = want_align
+                        && let Some(ty) = reg
+                            .generics
+                            .get("types")
+                            .and_then(serde_json::Value::as_array)
+                            .and_then(|a| a.first())
+                        && let Some(size) = self.size_align_const_from_tyexpr(want_align, ty)
+                    {
+                        let res = self
+                            .graph
+                            .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
+                        self.graph.block_mut(bb_id).operations.push(SpaceOperation {
+                            result: Some(res.clone()),
+                            kind: OpKind::ConstInt(size),
+                        });
+                        self.local_var[dest_local] = Some(res);
+                        let target_bb = self.block_id[target];
+                        let link_args = self.edge_args(mir_bb, target)?;
+                        self.graph.set_goto(bb_id, target_bb, link_args);
+                        return Ok(());
+                    }
+                }
                 // Reflexive blanket `into` — the callsite selected
                 // `impl<T> From<T> for T`, a pure `T -> T` identity
                 // conversion.  Bind the destination local to the

--- a/majit/majit-translate/src/front/mod.rs
+++ b/majit/majit-translate/src/front/mod.rs
@@ -82,6 +82,7 @@ pub(crate) mod range_iter;
 pub(crate) mod rbigint_call;
 pub(crate) mod result_exc;
 pub mod semantic;
+pub(crate) mod slice_first;
 pub mod typestr;
 
 pub use semantic::{AstGraphOptions, SemanticFunction, SemanticProgram, StructFieldRegistry};

--- a/majit/majit-translate/src/front/slice_first.rs
+++ b/majit/majit-translate/src/front/slice_first.rs
@@ -231,8 +231,14 @@ fn rewire_one_slice_first_site(
         result: Some(elem.clone()),
         kind: OpKind::ArrayRead {
             base: slice_in_then,
+            // The element read and the `Some::__pos_0` field write below
+            // consume the same `elem`, so the read's declared element type
+            // must be the payload type the field carries (`site.payload_ty`,
+            // `Ref(None)` for `Option<&PyObjectRef>`) — a hardcoded `Ref(None)`
+            // would disagree for any instantiation whose payload projects to
+            // another `ValueType`.
+            item_ty: site.payload_ty.clone(),
             index: idx0,
-            item_ty: ValueType::Ref(None),
             array_type_id: None,
             nolength: false,
             pure: false,

--- a/majit/majit-translate/src/front/slice_first.rs
+++ b/majit/majit-translate/src/front/slice_first.rs
@@ -1,0 +1,525 @@
+//! `<[T]>::first(slice)` → length-checked `Option<&T>` diamond.
+//!
+//! ## Positioning
+//!
+//! `core::slice::<Impl>::first` is a foreign leaf whose body is Opaque in the
+//! LLBC (Charon cannot extract `core`), so the caller emits a residual `first`
+//! call — an unregistered callee the rtyper census Skips.  Its `Self` is the
+//! primitive slice `[T]` (not an ADT), so `lower_call` keeps the raw
+//! `FunctionPath` segments `["core","slice","<Impl>","first"]` (same shape as
+//! `bool::then`), receiver in `args[0]`.  Unlike `bool::then`, the condition is
+//! not an operand — `first` returns `Some(&slice[0])` iff `slice` is non-empty,
+//! so this pass *synthesizes* the guard `len(slice) > 0`:
+//!
+//! ```text
+//!     opt = first(slice)                 // residual `first` call
+//! becomes
+//!     if len(slice) > 0 { opt = Some(&slice[0]) } else { opt = None }
+//! ```
+//!
+//! The branch is mandatory — the element read must not run when `slice` is
+//! empty (`slice[0]` would be an out-of-bounds read), so a single-block
+//! always-read encoding is unsound.  This is exactly why an *inline* fold (the
+//! `emit_tagged_pair_aggregate` path, which writes `__pos_0` unconditionally in
+//! the call's own block before the consumer's discriminant switch) cannot
+//! express `first`; a post-pass that splits block A into a guarded Some/None
+//! diamond can.
+//!
+//! ## Payload representation
+//!
+//! `first` returns `Option<&T>`, but the `Some` payload is materialised by
+//! `OpKind::ArrayRead` (element 0), which yields the element VALUE, not a
+//! pointer-to-slot.  In the list model a `&T` and a `T` are the same one GC
+//! pointer word, and no consumer derefs a slot-pointer (there is no `copied`
+//! pass that would; the front has no pointer-to-slot op at all).  So the
+//! `&T`-vs-`T` distinction collapses harmlessly, and the value payload is both
+//! the only representable and the correct choice.  The receiver is a
+//! `SomeList`-modelled slice (its `Input` op carries the list-container
+//! `class_root`), so `__len` and the element read repr-dispatch to
+//! `arraylen_gc` / `getarrayitem` on the underlying length-prefixed GcArray.
+//!
+//! ## The rewrite (`rewire_one_slice_first_site`)
+//!
+//! Block A holds the residual `first` call producing `opt`.  Because
+//! `Option<&PyObjectRef>` triggers `option_residual_narrow_root`, `lower_call`
+//! appends a trailing `__pyre_cast_instance` after the call, so the call is NOT
+//! A's last op — the block-A skeleton absorbs that optional cast, exactly as
+//! [`crate::front::option_map_or`] does.  The rewrite:
+//! 1. drops the `first` call (+ absorbed cast) and closes A with a
+//!    `bool(len(slice) > 0)` branch to two fresh arms;
+//! 2. the `then_bb` arm reads `slice[0]` and wraps it in `Some`
+//!    (`__discriminant = 1` / `__pos_0 = elem`);
+//! 3. the `else_bb` arm builds `None` (`__discriminant = 0`);
+//! 4. both arms re-apply the absorbed narrowing and forward to B, reproducing
+//!    A's original exit args with the `opt` slot sourced from the arm's
+//!    `Some`/`None` value and every other live value threaded through.
+//!
+//! It is **fail-safe**: any structural mismatch returns `Err`, the caller
+//! leaves the residual call untouched, and the unregistered `first` callee
+//! keeps the rtyper census Skip (no regression vs the legacy walker).
+
+use crate::flowspace::model::Variable;
+use crate::front::bool_then::{
+    close_goto_mixed, emit_option_variant, map_source, reproduce_exit_args,
+};
+use crate::front::option_map_or::emit_narrow;
+use crate::model::{CallTarget, FunctionGraph, LinkArg, OpKind, SpaceOperation, ValueType};
+
+/// A recognized `<[T]>::first(slice)` call site captured during body lowering
+/// (`front::mir` `recognize_slice_first_site`).  The owner strings are resolved
+/// at the recording site where the destination `Option<&T>` type is in hand;
+/// the post-pass only needs them to spell the `Some`/`None` aggregates.
+#[derive(Clone)]
+pub(crate) struct SliceFirstSite {
+    /// The `first` call result (the `Option<&T>` value) — locates block A.  The
+    /// slice operand is read from that located call's `args[0]`.
+    pub result_var: Variable,
+    /// The `Option` enum root `name_path` (per-instantiation, suffixed) — the
+    /// ctor owner for the `Some`/`None` aggregates.
+    pub option_owner: String,
+    /// The `Option::Some` variant `name_path` — the `__pos_0` payload field
+    /// owner (matching the variant-qualified `resolve_adt_field` read owner).
+    pub some_owner: String,
+    /// The `Option`'s payload `&T` projected to a [`ValueType`] — the
+    /// `Some::__pos_0` field kind (`Ref(None)` for `Option<&PyObjectRef>`).
+    pub payload_ty: ValueType,
+}
+
+/// Rewrite every recorded `<[T]>::first` call site into the length-checked
+/// `Option` diamond.  Fail-safe: a site whose block does not fit the
+/// residual-call shape is left untouched (Skip), so a mismatch never regresses
+/// a graph the legacy walker already handled.  Returns the number of sites
+/// rewritten.
+pub(crate) fn rewire_slice_first_call_sites(
+    graph: &mut FunctionGraph,
+    sites: &[SliceFirstSite],
+) -> usize {
+    let mut rewritten = 0;
+    for site in sites {
+        match rewire_one_slice_first_site(graph, site) {
+            Ok(()) => rewritten += 1,
+            Err(_decline) => {
+                // Leave the residual `first` call; the unregistered callee
+                // keeps the rtyper census Skip for this graph.
+            }
+        }
+    }
+    rewritten
+}
+
+fn rewire_one_slice_first_site(
+    graph: &mut FunctionGraph,
+    site: &SliceFirstSite,
+) -> Result<(), String> {
+    let name = graph.name.clone();
+    // Block A: the `first` residual call producing `result_var`.
+    let a = graph
+        .blocks
+        .iter()
+        .position(|b| {
+            b.operations
+                .iter()
+                .any(|op| op.result.as_ref() == Some(&site.result_var))
+        })
+        .ok_or_else(|| format!("{name}: slice::first result var has no producer block"))?;
+
+    // Locate the `first` call op by its result (not assuming it is the block
+    // tail — the trailing `__pyre_cast_instance` may follow, see below).
+    let ci = graph.blocks[a]
+        .operations
+        .iter()
+        .position(|op| op.result.as_ref() == Some(&site.result_var))
+        .ok_or_else(|| format!("{name}: slice::first call op not found in block {a}"))?;
+    let ops_len = graph.blocks[a].operations.len();
+
+    // `Option<&PyObjectRef>` gains a trailing `__pyre_cast_instance` narrowing
+    // op (`result_narrow_root`) whose output is what the block forwards on.
+    // Absorb that optional cast: `flow_result` is the value B consumes,
+    // `narrow_root` re-applies the narrowing per arm, `remove_upto` bounds the
+    // ops to drop.  Any other trailing shape declines (fail-safe).
+    let (flow_result, narrow_root, remove_upto) = if ci + 1 == ops_len {
+        (site.result_var.clone(), None, ci)
+    } else if ci + 2 == ops_len {
+        let cast = &graph.blocks[a].operations[ci + 1];
+        match (&cast.kind, cast.result.as_ref()) {
+            (
+                OpKind::Call {
+                    target: CallTarget::FunctionPath { segments },
+                    args,
+                    ..
+                },
+                Some(narrowed),
+            ) if segments.len() == 2
+                && segments[0] == "__pyre_cast_instance"
+                && args.len() == 1
+                && args[0] == site.result_var =>
+            {
+                (narrowed.clone(), Some(segments[1].clone()), ci + 1)
+            }
+            _ => {
+                return Err(format!(
+                    "{name}: slice::first call is not the last op of block {a}"
+                ));
+            }
+        }
+    } else {
+        return Err(format!(
+            "{name}: slice::first call is not the last op of block {a}"
+        ));
+    };
+
+    // Capture the slice receiver operand.
+    let slice = match &graph.blocks[a].operations[ci].kind {
+        OpKind::Call { args, .. } if args.len() == 1 => args[0].clone(),
+        other => {
+            return Err(format!(
+                "{name}: slice::first producer op is not a 1-arg call: {other:?}"
+            ));
+        }
+    };
+
+    // A's single exit → B (the continuation consuming the Option).  Must be a
+    // plain goto — `lower_call` closes with exactly this shape.
+    let [exit] = graph.blocks[a].exits.as_slice() else {
+        return Err(format!(
+            "{name}: slice::first call block {a} does not have a single exit"
+        ));
+    };
+    if exit.exitcase.is_some() || exit.last_exception.is_some() || exit.last_exc_value.is_some() {
+        return Err(format!(
+            "{name}: slice::first call block {a} exit is not a plain goto"
+        ));
+    }
+    let saved_exit = exit.clone();
+    let b_target = saved_exit.target;
+
+    // `carried` = the distinct live Values A forwards to B other than the
+    // Option itself (`flow_result`); each must be threaded through the diamond
+    // arms to reach B (a fresh block cannot see A-scope Variables directly).
+    let mut carried: Vec<Variable> = Vec::new();
+    for arg in &saved_exit.args {
+        if let LinkArg::Value(v) = arg
+            && *v != flow_result
+            && !carried.contains(v)
+        {
+            carried.push(v.clone());
+        }
+    }
+
+    // --- All structural validation passed; mutate the graph. ---
+
+    // `then_bb` (`Some`) carries `carried` plus `slice` (the base for the
+    // element read); `else_bb` (`None`) carries only `carried`.  The
+    // source-var lists double as the branch link args.
+    let mut then_sources = carried.clone();
+    if !then_sources.contains(&slice) {
+        then_sources.push(slice.clone());
+    }
+    let (then_bb, then_inputs) = graph.create_block_with_arg_vars(then_sources.len());
+    let (else_bb, else_inputs) = graph.create_block_with_arg_vars(carried.len());
+
+    // `then_bb`: elem = slice[0]; opt = Some(elem).
+    let slice_in_then = map_source(&then_sources, &then_inputs, &slice)
+        .ok_or_else(|| format!("{name}: slice not threaded into Some arm"))?;
+    let idx0 = graph.alloc_value_var();
+    graph.block_mut(then_bb).operations.push(SpaceOperation {
+        result: Some(idx0.clone()),
+        kind: OpKind::ConstInt(0),
+    });
+    let elem = graph.alloc_value_var();
+    graph.block_mut(then_bb).operations.push(SpaceOperation {
+        result: Some(elem.clone()),
+        kind: OpKind::ArrayRead {
+            base: slice_in_then,
+            index: idx0,
+            item_ty: ValueType::Ref(None),
+            array_type_id: None,
+            nolength: false,
+            pure: false,
+        },
+    });
+    let some_var = emit_option_variant(
+        graph,
+        then_bb,
+        &site.option_owner,
+        1,
+        Some((&site.some_owner, elem, site.payload_ty.clone())),
+    );
+    let then_result = emit_narrow(graph, then_bb, some_var, &narrow_root);
+    let then_link_args = reproduce_exit_args(
+        &saved_exit,
+        &flow_result,
+        &then_result,
+        &then_sources,
+        &then_inputs,
+        &name,
+    )?;
+    close_goto_mixed(graph, then_bb, b_target, then_link_args);
+
+    // `else_bb`: opt = None.
+    let none_var = emit_option_variant(graph, else_bb, &site.option_owner, 0, None);
+    let else_result = emit_narrow(graph, else_bb, none_var, &narrow_root);
+    let else_link_args = reproduce_exit_args(
+        &saved_exit,
+        &flow_result,
+        &else_result,
+        &carried,
+        &else_inputs,
+        &name,
+    )?;
+    close_goto_mixed(graph, else_bb, b_target, else_link_args);
+
+    // A: drop the residual `first` call (+ absorbed cast), synthesize the guard
+    // `len(slice) > 0`, branch on it.  `__len` on the `SomeList`-modelled slice
+    // routes through the rtyper `len` op → `AbstractBaseListRepr.rtype_len` →
+    // `arraylen_gc`; the `gt` of two `Int` operands lowers to `int_gt`.
+    // `set_branch` appends the idempotent `bool(cond)` hop and installs the
+    // Bool(false)/Bool(true) arm links, so the true (non-empty) arm is `then_bb`.
+    let a_id = graph.blocks[a].id;
+    for _ in ci..=remove_upto {
+        graph.blocks[a].operations.remove(ci);
+    }
+    let len = graph.alloc_value_var();
+    graph.block_mut(a_id).operations.push(SpaceOperation {
+        result: Some(len.clone()),
+        kind: OpKind::Call {
+            target: CallTarget::FunctionPath {
+                segments: vec!["__len".to_string()],
+            },
+            args: vec![slice.clone()],
+            result_ty: ValueType::Int,
+        },
+    });
+    let zero = graph.alloc_value_var();
+    graph.block_mut(a_id).operations.push(SpaceOperation {
+        result: Some(zero.clone()),
+        kind: OpKind::ConstInt(0),
+    });
+    let cond = graph.alloc_value_var();
+    graph.block_mut(a_id).operations.push(SpaceOperation {
+        result: Some(cond.clone()),
+        kind: OpKind::BinOp {
+            op: "gt".to_string(),
+            lhs: len,
+            rhs: zero,
+            result_ty: ValueType::Int,
+        },
+    });
+    graph.set_branch(a_id, cond, then_bb, then_sources, else_bb, carried);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::CallTarget;
+
+    fn slice_first_site(result_var: Variable) -> SliceFirstSite {
+        SliceFirstSite {
+            result_var,
+            option_owner: "core::option::Option".into(),
+            some_owner: "core::option::Option::Some".into(),
+            payload_ty: ValueType::Ref(None),
+        }
+    }
+
+    /// Build the minimal `opt = first(slice)` shape — block A = the residual
+    /// call closed by a single goto to B (which consumes the Option) — and
+    /// assert the rewrite drops the call, synthesizes `len(slice) > 0`, and
+    /// branches to a `Some` arm (`slice[0]` → `Some`) and a `None` arm, both
+    /// merging to B.
+    #[test]
+    fn rewrite_lifts_first_to_length_checked_option() {
+        let mut g = FunctionGraph::new("test_slice_first");
+        let a = g.startblock;
+        let slice = g.push_op_var(a, OpKind::ConstInt(0), true).unwrap();
+        let opt = g
+            .push_op_var(
+                a,
+                OpKind::Call {
+                    target: CallTarget::FunctionPath {
+                        segments: vec![
+                            "core".into(),
+                            "slice".into(),
+                            "<Impl>".into(),
+                            "first".into(),
+                        ],
+                    },
+                    args: vec![slice.clone()],
+                    result_ty: ValueType::Ref(None),
+                },
+                true,
+            )
+            .unwrap();
+
+        // B: the continuation consuming the first() result.
+        let (b, _b_args) = g.create_block_with_arg_vars(1);
+        g.set_return(b, None);
+        g.set_goto(a, b, vec![opt.clone()]);
+
+        let rewritten = rewire_slice_first_call_sites(&mut g, &[slice_first_site(opt.clone())]);
+        assert_eq!(rewritten, 1, "the slice::first site must be rewritten");
+
+        // The residual `first` call is gone from block A.
+        assert!(
+            !g.blocks[a.0].operations.iter().any(|op| matches!(
+                &op.kind,
+                OpKind::Call { target: CallTarget::FunctionPath { segments }, .. }
+                    if segments.last().map(String::as_str) == Some("first")
+            )),
+            "residual first call removed from A"
+        );
+        // A synthesizes the `__len` guard and a `gt` compare, then branches.
+        assert!(
+            g.blocks[a.0].operations.iter().any(|op| matches!(
+                &op.kind,
+                OpKind::Call { target: CallTarget::FunctionPath { segments }, .. }
+                    if segments.first().map(String::as_str) == Some("__len")
+            )),
+            "A synthesizes the __len guard"
+        );
+        assert!(
+            g.blocks[a.0]
+                .operations
+                .iter()
+                .any(|op| matches!(&op.kind, OpKind::BinOp { op, .. } if op == "gt")),
+            "A compares len > 0"
+        );
+        assert_eq!(g.blocks[a.0].exits.len(), 2, "A branches to Some/None arms");
+        // Exactly one arm reads an array element (the Some payload).
+        let elem_reads = g
+            .blocks
+            .iter()
+            .flat_map(|blk| &blk.operations)
+            .filter(|op| matches!(&op.kind, OpKind::ArrayRead { .. }))
+            .count();
+        assert_eq!(elem_reads, 1, "the Some arm reads slice[0]");
+        // Both arms write an Option `__discriminant` (Some=1, None=0).
+        let disc_writes = g
+            .blocks
+            .iter()
+            .flat_map(|blk| &blk.operations)
+            .filter(|op| {
+                matches!(&op.kind, OpKind::FieldWrite { field, .. } if field.name == "__discriminant")
+            })
+            .count();
+        assert_eq!(disc_writes, 2, "both arms write a discriminant");
+    }
+
+    /// The production shape: an `Option<&RegisteredStruct>` result appends a
+    /// trailing `__pyre_cast_instance` narrowing op, so the call is NOT the
+    /// block tail.  The rewrite absorbs the cast, fires, and re-applies the
+    /// narrowing in both arms.
+    #[test]
+    fn rewrite_absorbs_trailing_narrow_cast() {
+        let mut g = FunctionGraph::new("test_slice_first_narrow");
+        let a = g.startblock;
+        let slice = g.push_op_var(a, OpKind::ConstInt(0), true).unwrap();
+        let opt = g
+            .push_op_var(
+                a,
+                OpKind::Call {
+                    target: CallTarget::FunctionPath {
+                        segments: vec![
+                            "core".into(),
+                            "slice".into(),
+                            "<Impl>".into(),
+                            "first".into(),
+                        ],
+                    },
+                    args: vec![slice.clone()],
+                    result_ty: ValueType::Ref(None),
+                },
+                true,
+            )
+            .unwrap();
+        let narrowed = g
+            .push_op_var(
+                a,
+                OpKind::Call {
+                    target: CallTarget::FunctionPath {
+                        segments: vec!["__pyre_cast_instance".into(), "PyObject".into()],
+                    },
+                    args: vec![opt.clone()],
+                    result_ty: ValueType::Ref(Some("PyObject".into())),
+                },
+                true,
+            )
+            .unwrap();
+
+        // B consumes the NARROWED value (what the block actually forwards).
+        let (b, _b_args) = g.create_block_with_arg_vars(1);
+        g.set_return(b, None);
+        g.set_goto(a, b, vec![narrowed.clone()]);
+
+        // Site records the CALL result; the rewrite discovers the trailing cast.
+        let rewritten = rewire_slice_first_call_sites(&mut g, &[slice_first_site(opt.clone())]);
+        assert_eq!(rewritten, 1, "the slice::first site must be rewritten");
+
+        // The residual call and the trailing cast are gone from block A.
+        assert!(
+            !g.blocks[a.0].operations.iter().any(|op| matches!(
+                &op.kind,
+                OpKind::Call { target: CallTarget::FunctionPath { segments }, .. }
+                    if segments.last().map(String::as_str) == Some("first")
+            )),
+            "residual first call removed from A"
+        );
+        // Two arms each re-emit a `__pyre_cast_instance` narrowing.
+        let narrow_casts = g
+            .blocks
+            .iter()
+            .flat_map(|blk| &blk.operations)
+            .filter(|op| {
+                matches!(
+                    &op.kind,
+                    OpKind::Call { target: CallTarget::FunctionPath { segments }, .. }
+                        if segments.first().map(String::as_str) == Some("__pyre_cast_instance")
+                )
+            })
+            .count();
+        assert_eq!(narrow_casts, 2, "each diamond arm re-applies the narrowing");
+    }
+
+    /// A call block whose trailing shape is neither the bare call nor a single
+    /// absorbed cast declines (fail-safe): the residual call survives untouched.
+    #[test]
+    fn rewrite_declines_on_unexpected_trailing_shape() {
+        let mut g = FunctionGraph::new("test_slice_first_decline");
+        let a = g.startblock;
+        let slice = g.push_op_var(a, OpKind::ConstInt(0), true).unwrap();
+        let opt = g
+            .push_op_var(
+                a,
+                OpKind::Call {
+                    target: CallTarget::FunctionPath {
+                        segments: vec![
+                            "core".into(),
+                            "slice".into(),
+                            "<Impl>".into(),
+                            "first".into(),
+                        ],
+                    },
+                    args: vec![slice],
+                    result_ty: ValueType::Ref(None),
+                },
+                true,
+            )
+            .unwrap();
+        // Two trailing ops break both the "call is last" and "single cast" shapes.
+        g.push_op_var(a, OpKind::ConstInt(9), true).unwrap();
+        g.push_op_var(a, OpKind::ConstInt(8), true).unwrap();
+        g.set_return(a, None);
+
+        let rewritten = rewire_slice_first_call_sites(&mut g, &[slice_first_site(opt)]);
+        assert_eq!(rewritten, 0, "an unexpected trailing shape declines");
+        assert!(
+            g.blocks[a.0].operations.iter().any(|op| matches!(
+                &op.kind,
+                OpKind::Call { target: CallTarget::FunctionPath { segments }, .. }
+                    if segments.last().map(String::as_str) == Some("first")
+            )),
+            "residual call survives on decline"
+        );
+    }
+}

--- a/majit/majit-translate/src/lib.rs
+++ b/majit/majit-translate/src/lib.rs
@@ -194,9 +194,18 @@ fn build_semantic_program_via_active_frontend(
             // full LLBC set for every local `unsafe fn` / unsafe
             // impl-method projecting to a unit/bool return.  The consumer
             // at `call_control.unsafe_fn_stubs` (lib.rs) reads this carrier.
+            // Same carrier also feeds the `#[pyre_class]` allocation
+            // constructors (`<Owner>::allocate[_stable](payload: Self)`): the
+            // non-numeric boxing ctors have no ported `malloc->new` lowering,
+            // so they residualize through the same annotator-only stub path.
             program.unsafe_fn_stubs = llbcs
                 .iter()
                 .flat_map(front::mir::collect_unsafe_fn_stubs_from_llbc)
+                .chain(
+                    llbcs
+                        .iter()
+                        .flat_map(front::mir::collect_pyre_class_ctor_stubs_from_llbc),
+                )
                 .collect();
             // Foreign opaque-ADT methods (`<BigInt as Add>::add`, …) that
             // `impl_method_owner` routes through `CallTarget::FunctionPath`

--- a/majit/majit-translate/src/model.rs
+++ b/majit/majit-translate/src/model.rs
@@ -92,6 +92,11 @@ pub enum ValueType {
     /// object-identity-based lltype semantics.
     Ref(Option<String>),
     Float,
+    /// RPython `SomeString` — a Rust `str`/`String`/`Wtf8`/`Wtf8Buf`
+    /// value (`tyref_is_string_value`).  Distinct from `Ref` so a
+    /// string-typed struct field seeds a `SomeString` shell rather than
+    /// the classdef-less `SomeInstance(None)` the `Ref` fallback yields.
+    Str,
     Void,
     State,
     Unknown,

--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -2436,6 +2436,11 @@ const FOREIGN_STDLIB_EXTERNALS: &[(&[&str], &[&str], LowLevelType)] = &[
     ),
     (&["vec", "Vec", "as_ptr"], &["self"], LowLevelType::Address),
     (
+        &["sync", "atomic", "AtomicBool", "store"],
+        &["self", "val", "order"],
+        LowLevelType::Void,
+    ),
+    (
         &["cell", "Cell", "set"],
         &["self", "val"],
         LowLevelType::Void,

--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -2229,11 +2229,15 @@ fn build_stub_pygraph_with_result_shell(
 ///
 /// Returns `None` for container types
 /// (`Func` / `Struct` / `Array` / `FixedSizeArray` / `Opaque` /
-/// `ForwardReference`) that `lltype_to_annotation` rejects, and for
-/// `Address` (upstream `SomeAddress`; not yet ported to the pyre
-/// `SomeValue` enum — see `model.rs:21` TODO).  The caller
+/// `ForwardReference`) that `lltype_to_annotation` rejects.  The caller
 /// treats `None` as "skip this fn"; the unported path then surfaces
 /// the original "not registered" Skip.
+///
+/// `Address` maps to the untyped `SomeAddress` shell (`llmemory.py:573
+/// SomeAddress`) — the annotation-stage projection a `*const T` / `*mut T`
+/// raw pointer carries when its element type is not modeled.  A
+/// `<[T]>::as_ptr` result is consumed here only as a residual-call argument
+/// (`hash_str_hooked(ptr, len)`), for which the untyped address is faithful.
 pub(crate) fn default_someshell_for_lltype(
     lltype: &LowLevelType,
 ) -> Option<crate::annotator::model::SomeValue> {
@@ -2241,9 +2245,9 @@ pub(crate) fn default_someshell_for_lltype(
         return None;
     }
     match lltype {
-        // SomeAddress is not yet present in the SomeValue enum
-        // (model.rs:21 TODO); skip until ported.
-        LowLevelType::Address => None,
+        LowLevelType::Address => Some(crate::annotator::model::SomeValue::Address(
+            crate::annotator::model::SomeAddress::new(),
+        )),
         _ => Some(crate::translator::rtyper::llannotation::lltype_to_annotation(lltype.clone())),
     }
 }
@@ -2412,17 +2416,25 @@ pub(crate) fn register_unsafe_fn_stubs(
 /// - `core::f64::<Impl>::to_bits` returns `u64` reinterpreted as `i64` —
 ///   `Signed` result.
 ///
-/// Paths whose faithful result is a non-scalar value the stub carrier
-/// cannot express (`alloc::fmt::format` → `String`,
+/// A raw `*const T` / `*mut T` result maps to the untyped `Address` shell
+/// (`core::slice::<Impl>::as_ptr`, `vec::Vec::as_ptr`) — faithful when the
+/// pointer is consumed only as a residual-call argument.  Paths whose
+/// faithful result is a non-scalar value the stub carrier still cannot
+/// express (`alloc::fmt::format` → `String`,
 /// `core::array::iter::<Impl>::into_iter` → an iterator with no Repr,
-/// `core::slice::<Impl>::as_ptr` → a raw `*const T`, `core::num::<Impl>::
-/// checked_*` → `Option<i64>`) are intentionally absent: registering
-/// them with a placeholder `Void`/`Signed` result mis-models the value
-/// and only migrates the failure to a deeper annotation wall (union
-/// pollution / raw-pointer modeling), so they stay residual at the
-/// "not registered" Skip until their result type can be modeled.
+/// `core::num::<Impl>::checked_*` → `Option<i64>`) stay intentionally
+/// absent: registering them with a placeholder `Void`/`Signed` result
+/// mis-models the value and only migrates the failure to a deeper
+/// annotation wall, so they stay residual at the "not registered" Skip
+/// until their result type can be modeled.
 const FOREIGN_STDLIB_EXTERNALS: &[(&[&str], &[&str], LowLevelType)] = &[
     (&["core", "mem", "swap"], &["x", "y"], LowLevelType::Void),
+    (
+        &["core", "slice", "<Impl>", "as_ptr"],
+        &["self"],
+        LowLevelType::Address,
+    ),
+    (&["vec", "Vec", "as_ptr"], &["self"], LowLevelType::Address),
     (
         &["cell", "Cell", "set"],
         &["self", "val"],

--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -2433,6 +2433,14 @@ const FOREIGN_STDLIB_EXTERNALS: &[(&[&str], &[&str], LowLevelType)] = &[
     // does not model destructors (the `Drop` terminator lowers to a
     // pass-through `Goto`), so a Void no-op stub is faithful.
     (&["core", "mem", "drop"], &["x"], LowLevelType::Void),
+    // `handle_alloc_error(layout) -> !` aborts on OOM; it never returns and
+    // its result is never consumed. The divergence is carried by the CFG, so
+    // a Void stub lets the alloc helpers lift while the residual call aborts.
+    (
+        &["alloc", "alloc", "handle_alloc_error"],
+        &["layout"],
+        LowLevelType::Void,
+    ),
     (
         &["core", "slice", "<Impl>", "as_ptr"],
         &["self"],

--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -2433,6 +2433,17 @@ const FOREIGN_STDLIB_EXTERNALS: &[(&[&str], &[&str], LowLevelType)] = &[
     // does not model destructors (the `Drop` terminator lowers to a
     // pass-through `Goto`), so a Void no-op stub is faithful.
     (&["core", "mem", "drop"], &["x"], LowLevelType::Void),
+    // `mem::size_of::<T>() -> usize`.  A concrete-type call is folded to a
+    // `ConstInt` in the front end (`Lowering::lower_call` /
+    // `size_align_const_from_tyexpr`); the residual reaching the rtyper is the
+    // generic body (`gc_alloc_storage_box<T>`), whose `T` is an abstract type
+    // parameter with no compile-time size.  Declare it opaque so the generic
+    // body annotates — the monomorphized machine code the JIT actually traces
+    // carries rustc's folded constant, so no residual call runs.  Both
+    // spellings: the FunDecl name resolves `core`, the call site may write the
+    // `std` re-export.
+    (&["core", "mem", "size_of"], &[], LowLevelType::Unsigned),
+    (&["std", "mem", "size_of"], &[], LowLevelType::Unsigned),
     // `handle_alloc_error(layout) -> !` aborts on OOM; it never returns and
     // its result is never consumed. The divergence is carried by the CFG, so
     // a Void stub lets the alloc helpers lift while the residual call aborts.

--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -5198,9 +5198,14 @@ mod tests {
     }
 
     #[test]
-    fn default_someshell_for_lltype_address_yields_none() {
-        // SomeAddress not yet ported (model.rs:21 TODO).
-        assert!(default_someshell_for_lltype(&LowLevelType::Address).is_none());
+    fn default_someshell_for_lltype_address_yields_someaddress() {
+        use crate::annotator::model::SomeValue;
+        // `Address` maps to the untyped `SomeAddress` shell (llmemory.py:573
+        // `SomeAddress`) — the projection a raw `*const T` / `*mut T` result
+        // takes.
+        let s = default_someshell_for_lltype(&LowLevelType::Address)
+            .expect("Address must project to SomeAddress");
+        assert!(matches!(s, SomeValue::Address(_)), "got {s:?}");
     }
 
     #[test]

--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -2429,6 +2429,10 @@ pub(crate) fn register_unsafe_fn_stubs(
 /// until their result type can be modeled.
 const FOREIGN_STDLIB_EXTERNALS: &[(&[&str], &[&str], LowLevelType)] = &[
     (&["core", "mem", "swap"], &["x", "y"], LowLevelType::Void),
+    // `mem::drop(x)` runs `x`'s destructor and returns `()`; the trace model
+    // does not model destructors (the `Drop` terminator lowers to a
+    // pass-through `Goto`), so a Void no-op stub is faithful.
+    (&["core", "mem", "drop"], &["x"], LowLevelType::Void),
     (
         &["core", "slice", "<Impl>", "as_ptr"],
         &["self"],

--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -1783,6 +1783,26 @@ pub(crate) fn populate_call_registry_from_call_graphs(
         {
             continue;
         }
+        // `#[pyre_class]`'s generated allocation constructors
+        // (`<Owner>::allocate(payload: Self)` / `allocate_stable(payload:
+        // Self)`) build the object then call the non-numeric
+        // `lltype::malloc_typed[_stable]`, which has no ported general
+        // `malloc->new` lowering — lifting the body records a poison lift-error
+        // that surfaces on the first constructing caller (`w_range_new`,
+        // the iterator/`GenericAlias` `*_new` heads).  Skip registering the
+        // constructor as a user function so its key is instead served by the
+        // residual stub from `collect_pyre_class_ctor_stubs_from_llbc` (seeded
+        // through the `unsafe_fn_stubs` carrier), whose `*mut PyObject` return
+        // shell lets the caller annotate.  The numeric boxes never reach here —
+        // they call `malloc_typed` inline (`w_float_new`/`w_int_new`), not the
+        // macro `allocate` wrapper — so this does not disturb
+        // `fuse_boxing_alloc`.
+        if matches!(
+            canonical_strip.last().map(String::as_str),
+            Some("allocate") | Some("allocate_stable")
+        ) {
+            continue;
+        }
         // `pyre_object::lltype::malloc_raw` is the raw (non-GC) allocation
         // intrinsic (`lltype.malloc(T, flavor='raw')` parity), recognised as
         // a host builtin (annotator `malloc_raw_alloc`, HOST_ENV

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -751,9 +751,11 @@ fn nonraising_core_bridge_opname(segments: &[String], arg_count: usize) -> Optio
         ("cmp", "eq" | "ne" | "lt" | "le" | "gt" | "ge") if arg_count == 2 => Some(leaf),
         ("slice", "len") if arg_count == 1 => Some("len"),
         ("slice", "iter") if arg_count == 1 => Some("iter"),
-        // `wrapping_mul` is the Rust spelling of upstream's plain `*`
-        // (lltype `int_mul` wraps); plain `mul` raises nothing.
+        // `wrapping_mul` / `wrapping_sub` are the Rust spelling of
+        // upstream's plain `*` / `-` (lltype `int_mul` / `int_sub`
+        // wrap); the plain `mul` / `sub` ops raise nothing.
         ("num", "wrapping_mul") if arg_count == 2 => Some("mul"),
+        ("num", "wrapping_sub") if arg_count == 2 => Some("sub"),
         _ => None,
     }
 }

--- a/majit/majit-translate/src/translator/rtyper/llinterp.rs
+++ b/majit/majit-translate/src/translator/rtyper/llinterp.rs
@@ -31,7 +31,7 @@ use crate::tool::ansi_print::AnsiLogger;
 use crate::translator::rtyper::error::TyperError;
 use crate::translator::rtyper::lltypesystem::llmemory;
 use crate::translator::rtyper::lltypesystem::lltype::{
-    _address, _ptr, LowLevelType, LowLevelValue,
+    _address, _ptr, direct_fieldptr, malloc, LowLevelType, LowLevelValue, MallocFlavor,
 };
 use crate::translator::rtyper::rtyper::RPythonTyper;
 use crate::translator::tool::taskengine::TaskError;
@@ -203,6 +203,26 @@ fn const_to_llvalue(c: &Constant) -> LLValue {
         ConstValue::LLPtr(p) => LLValue::Ptr(p.clone()),
         ConstValue::LLAddress(a) => LLValue::Address(a.clone()),
         other => LLValue::Const(other.clone()),
+    }
+}
+
+/// Inverse of the `LowLevelValue` arm of [`any_to_llvalue`]: convert an
+/// `LLValue` into the `lltype::LowLevelValue` a heap cell stores. A Char is
+/// carried as a one-char `Str` (see the `LowLevelValue::Char` arm below).
+fn llvalue_to_lowlevel(value: &LLValue, opname: &str) -> Result<LowLevelValue, TaskError> {
+    match value {
+        LLValue::Void => Ok(LowLevelValue::Void),
+        LLValue::Int(n) => Ok(LowLevelValue::Signed(*n)),
+        LLValue::Bool(b) => Ok(LowLevelValue::Bool(*b)),
+        LLValue::Float(bits) => Ok(LowLevelValue::Float(*bits)),
+        LLValue::Ptr(p) => Ok(LowLevelValue::Ptr(p.clone())),
+        LLValue::Address(a) => Ok(LowLevelValue::Address(a.clone())),
+        LLValue::Str(s) if s.chars().count() == 1 => {
+            Ok(LowLevelValue::Char(s.chars().next().expect("one char")))
+        }
+        other => Err(TaskError {
+            message: format!("llinterp.py:405 {opname}: cannot store {other:?} into a heap cell"),
+        }),
     }
 }
 
@@ -846,6 +866,85 @@ impl LLFrame {
             // reinterpret the unsigned word's bits as Signed. The carrier
             // already stores the word as `i64`, so this is the identity.
             "cast_uint_to_int" => Ok(LLValue::Int(vals[0].as_i64(opname)?)),
+            // `op_cast_int_to_char(b) = chr(b)` (opimpl.py:411-413): the char
+            // carrier is the one-char `Str`.
+            "cast_int_to_char" => {
+                let code = vals[0].as_i64(opname)?;
+                let ch = u8::try_from(code).map_err(|_| TaskError {
+                    message: format!("opimpl.py op_cast_int_to_char: {code} out of char range"),
+                })? as char;
+                Ok(LLValue::Str(ch.to_string()))
+            }
+            // Heap ops: `_struct`/`_array` are Arc-shared with interior
+            // mutability, so writes through the cloned `_ptr` carrier persist
+            // on the original allocation (pointer semantics).
+            "malloc_varsize" => {
+                let LLValue::Const(ConstValue::LowLevelType(t)) = &vals[0] else {
+                    return Err(TaskError {
+                        message: format!("{opname}: arg0 must be a LowLevelType constant"),
+                    });
+                };
+                // `flavor='gc'` unless the flags dict spells `'raw'`
+                // (rmodel gc_flavor_const: `Dict{"flavor": "gc"}`).
+                let flavor = match &vals[1] {
+                    LLValue::Const(ConstValue::Dict(flags))
+                        if matches!(
+                            flags.get(&ConstValue::byte_str("flavor")),
+                            Some(ConstValue::ByteStr(f)) if f.as_slice() == b"raw"
+                        ) =>
+                    {
+                        MallocFlavor::Raw
+                    }
+                    _ => MallocFlavor::Gc,
+                };
+                let n = vals[2].as_i64(opname)? as usize;
+                let ptr = malloc((**t).clone(), Some(n), flavor, false)
+                    .map_err(|e| TaskError { message: format!("{opname}: {e}") })?;
+                Ok(LLValue::Ptr(Box::new(ptr)))
+            }
+            "setfield" => {
+                let LLValue::Ptr(p) = &vals[0] else {
+                    return Err(TaskError {
+                        message: format!("{opname}: arg0 must be a pointer"),
+                    });
+                };
+                let LLValue::Str(field) = &vals[1] else {
+                    return Err(TaskError {
+                        message: format!("{opname}: arg1 must be a field name"),
+                    });
+                };
+                let mut ptr = (**p).clone();
+                ptr.setattr(field, llvalue_to_lowlevel(&vals[2], opname)?)
+                    .map_err(|e| TaskError { message: format!("{opname}: {e}") })?;
+                Ok(LLValue::Void)
+            }
+            "getsubstruct" => {
+                let LLValue::Ptr(p) = &vals[0] else {
+                    return Err(TaskError {
+                        message: format!("{opname}: arg0 must be a pointer"),
+                    });
+                };
+                let LLValue::Str(field) = &vals[1] else {
+                    return Err(TaskError {
+                        message: format!("{opname}: arg1 must be a field name"),
+                    });
+                };
+                let sub = direct_fieldptr(&**p, field)
+                    .map_err(|e| TaskError { message: format!("{opname}: {e}") })?;
+                Ok(LLValue::Ptr(Box::new(sub)))
+            }
+            "setarrayitem" => {
+                let LLValue::Ptr(p) = &vals[0] else {
+                    return Err(TaskError {
+                        message: format!("{opname}: arg0 must be a pointer"),
+                    });
+                };
+                let index = vals[1].as_i64(opname)? as usize;
+                let mut ptr = (**p).clone();
+                ptr.setitem(index, llvalue_to_lowlevel(&vals[2], opname)?)
+                    .map_err(|e| TaskError { message: format!("{opname}: {e}") })?;
+                Ok(LLValue::Void)
+            }
             _ => Err(TaskError {
                 message: format!(
                     "llinterp.py:273 LLFrame.getoperationhandler — op_{opname} not yet ported"
@@ -1263,6 +1362,75 @@ mod tests {
             )
             .expect("uint fold chain should run");
         assert_eq!(*out.downcast::<i64>().expect("Signed return"), 1);
+    }
+
+    #[test]
+    fn getoperationhandler_mallocs_char_array_and_writes_through_pointer() {
+        // Covers malloc_varsize (bare GcArray path), cast_int_to_char (char =
+        // one-char Str), and setarrayitem writing through the Arc-shared
+        // `_ptr` carrier: allocate a 3-char array, write 'a'/'b'/'c', return
+        // the pointer, and confirm the writes persisted on the allocation.
+        use crate::flowspace::model::Constant as FlowConstant;
+        use crate::translator::rtyper::lltypesystem::lltype::Array;
+
+        let char_array = LowLevelType::Array(Box::new(Array::gc(LowLevelType::Char)));
+        let type_c = || {
+            Hlvalue::Constant(FlowConstant::new(ConstValue::LowLevelType(Box::new(
+                char_array.clone(),
+            ))))
+        };
+        let flavor_c =
+            || Hlvalue::Constant(FlowConstant::new(ConstValue::Dict(std::collections::HashMap::new())));
+        let int_c = |n: i64| Hlvalue::Constant(FlowConstant::new(ConstValue::Int(n)));
+
+        let arr = Variable::named("arr");
+        let start = Block::shared(vec![]);
+        start.borrow_mut().operations.push(SpaceOperation::new(
+            "malloc_varsize",
+            vec![type_c(), flavor_c(), int_c(3)],
+            arr.clone().into(),
+        ));
+        for (idx, code) in [(0_i64, 97_i64), (1, 98), (2, 99)] {
+            let ch = Variable::named("ch");
+            ch.set_concretetype(Some(LowLevelType::Char));
+            start.borrow_mut().operations.push(SpaceOperation::new(
+                "cast_int_to_char",
+                vec![int_c(code)],
+                ch.clone().into(),
+            ));
+            let set = Variable::named("set");
+            set.set_concretetype(Some(LowLevelType::Void));
+            start.borrow_mut().operations.push(SpaceOperation::new(
+                "setarrayitem",
+                vec![arr.clone().into(), int_c(idx), ch.into()],
+                set.into(),
+            ));
+        }
+
+        let retvar = Hlvalue::Variable(Variable::named("ret"));
+        let graph = Rc::new(RefCell::new(FunctionGraph::with_return_var(
+            "malloc_write",
+            start.clone(),
+            retvar,
+        )));
+        let returnblock = graph.borrow().returnblock.clone();
+        start.closeblock(vec![
+            Link::new(vec![arr.into()], Some(returnblock), None).into_ref(),
+        ]);
+
+        let interp = Rc::new(LLInterpreter::new(fixture_typer(), false, None));
+        let out = interp
+            .eval_graph(graph as Rc<dyn Any>, Vec::new(), false)
+            .expect("malloc + write-through graph should run");
+        let LowLevelValue::Ptr(ptr) = &*out.downcast::<LowLevelValue>().expect("Ptr return") else {
+            panic!("expected an array pointer return");
+        };
+        for (idx, expected) in [(0_usize, 'a'), (1, 'b'), (2, 'c')] {
+            match ptr.getitem(idx).expect("in-bounds read") {
+                LowLevelValue::Char(c) => assert_eq!(c, expected, "char at {idx}"),
+                other => panic!("expected Char at {idx}, got {other:?}"),
+            }
+        }
     }
 
     #[test]

--- a/majit/majit-translate/src/translator/rtyper/llinterp.rs
+++ b/majit/majit-translate/src/translator/rtyper/llinterp.rs
@@ -31,7 +31,7 @@ use crate::tool::ansi_print::AnsiLogger;
 use crate::translator::rtyper::error::TyperError;
 use crate::translator::rtyper::lltypesystem::llmemory;
 use crate::translator::rtyper::lltypesystem::lltype::{
-    _address, _ptr, direct_fieldptr, malloc, LowLevelType, LowLevelValue, MallocFlavor,
+    _address, _ptr, malloc, LowLevelType, LowLevelValue, MallocFlavor,
 };
 use crate::translator::rtyper::rtyper::RPythonTyper;
 use crate::translator::tool::taskengine::TaskError;
@@ -866,6 +866,10 @@ impl LLFrame {
             // reinterpret the unsigned word's bits as Signed. The carrier
             // already stores the word as `i64`, so this is the identity.
             "cast_uint_to_int" => Ok(LLValue::Int(vals[0].as_i64(opname)?)),
+            // `op_cast_primitive` between integer types reinterprets the
+            // machine word; the Signed carrier already holds it, so the
+            // Signed<->Unsigned cast is the identity on the i64 word.
+            "cast_primitive" => Ok(LLValue::Int(vals[0].as_i64(opname)?)),
             // `op_cast_int_to_char(b) = chr(b)` (opimpl.py:411-413): the char
             // carrier is the one-char `Str`.
             "cast_int_to_char" => {
@@ -929,8 +933,27 @@ impl LLFrame {
                         message: format!("{opname}: arg1 must be a field name"),
                     });
                 };
-                let sub = direct_fieldptr(&**p, field)
-                    .map_err(|e| TaskError { message: format!("{opname}: {e}") })?;
+                // `op_getsubstruct` = `getattr(obj, field)` on the pointer,
+                // yielding a pointer to the inlined sub-container. `_expose`
+                // returns it as an interior pointer when the field is a Raw
+                // container inlined into a Gc parent (`rpy_string.chars`);
+                // materialise that into a plain container `_ptr` so the
+                // array op handlers can read/write through it.
+                let sub = match p
+                    .getattr(field)
+                    .map_err(|e| TaskError { message: format!("{opname}: {e}") })?
+                {
+                    LowLevelValue::Ptr(pt) => *pt,
+                    LowLevelValue::InteriorPtr(ip) => {
+                        ip._as_container_ptr(p._solid)
+                            .map_err(|e| TaskError { message: format!("{opname}: {e}") })?
+                    }
+                    other => {
+                        return Err(TaskError {
+                            message: format!("{opname}: field {field:?} is not a container: {other:?}"),
+                        })
+                    }
+                };
                 Ok(LLValue::Ptr(Box::new(sub)))
             }
             "setarrayitem" => {
@@ -1430,6 +1453,77 @@ mod tests {
                 LowLevelValue::Char(c) => assert_eq!(c, expected, "char at {idx}"),
                 other => panic!("expected Char at {idx}, got {other:?}"),
             }
+        }
+    }
+
+    #[test]
+    fn build_ll_int2dec_executes_to_decimal_strings() {
+        // Slice C: run the synthesised `ll_int2dec` helper graph
+        // (`lltypesystem/rstr.rs`) end-to-end through the interpreter and read
+        // the decimal string back out of the returned STR pointer. This is the
+        // executing correctness gate the hex builder's shape-only test lacks —
+        // it catches an off-by-one in the reversed `total_len - j - 1` slot or a
+        // swapped link argument that a BFS-of-opnames assertion cannot.
+        use crate::translator::rtyper::lltypesystem::rstr::build_ll_int2dec_helper_graph;
+
+        fn read_rpy_string(strptr: &_ptr) -> String {
+            // Read `strptr.chars` the same way `getsubstruct` does: `getattr`
+            // yields an interior pointer for the inlined array, materialised
+            // into a plain container `_ptr` to index through.
+            let chars = match strptr.getattr("chars").expect("chars field") {
+                LowLevelValue::Ptr(p) => *p,
+                LowLevelValue::InteriorPtr(ip) => {
+                    ip._as_container_ptr(true).expect("materialise chars ptr")
+                }
+                other => panic!("chars is not a container: {other:?}"),
+            };
+            let mut s = String::new();
+            let mut i = 0usize;
+            while let Ok(LowLevelValue::Char(c)) = chars.getitem(i) {
+                s.push(c);
+                i += 1;
+            }
+            s
+        }
+
+        let interp = Rc::new(LLInterpreter::new(fixture_typer(), false, None));
+        let run = |helper: &crate::flowspace::pygraph::PyGraph, input: i64| -> String {
+            let out = interp
+                .eval_graph(
+                    helper.graph.clone() as Rc<dyn Any>,
+                    vec![Rc::new(input) as Rc<dyn Any>],
+                    false,
+                )
+                .expect("int2dec helper graph should run");
+            let LowLevelValue::Ptr(p) = &*out.downcast::<LowLevelValue>().expect("Ptr return")
+            else {
+                panic!("expected a STR pointer return");
+            };
+            read_rpy_string(p)
+        };
+
+        // Unsigned specialisation: -1 arrives as the full u64 word.
+        let unsigned = build_ll_int2dec_helper_graph("ll_int2dec", false).expect("build unsigned");
+        for (input, expected) in [
+            (0_i64, "0"),
+            (7, "7"),
+            (12345, "12345"),
+            (-1, "18446744073709551615"),
+        ] {
+            assert_eq!(run(&unsigned, input), expected, "uint2dec({input})");
+        }
+
+        // Signed specialisation: the `val < 0` branch takes the magnitude.
+        let signed =
+            build_ll_int2dec_helper_graph("ll_int2dec_signed", true).expect("build signed");
+        for (input, expected) in [
+            (0_i64, "0"),
+            (7, "7"),
+            (-42, "-42"),
+            (12345, "12345"),
+            (-12345, "-12345"),
+        ] {
+            assert_eq!(run(&signed, input), expected, "int2dec({input})");
         }
     }
 

--- a/majit/majit-translate/src/translator/rtyper/llinterp.rs
+++ b/majit/majit-translate/src/translator/rtyper/llinterp.rs
@@ -31,7 +31,7 @@ use crate::tool::ansi_print::AnsiLogger;
 use crate::translator::rtyper::error::TyperError;
 use crate::translator::rtyper::lltypesystem::llmemory;
 use crate::translator::rtyper::lltypesystem::lltype::{
-    _address, _ptr, malloc, LowLevelType, LowLevelValue, MallocFlavor,
+    _address, _ptr, LowLevelType, LowLevelValue, MallocFlavor, malloc,
 };
 use crate::translator::rtyper::rtyper::RPythonTyper;
 use crate::translator::tool::taskengine::TaskError;
@@ -845,10 +845,13 @@ impl LLFrame {
                 let divisor = vals[1].as_i64(opname)? as u64;
                 if divisor == 0 {
                     return Err(TaskError {
-                        message: "opimpl.py op_uint_floordiv: unsigned division by zero".to_string(),
+                        message: "opimpl.py op_uint_floordiv: unsigned division by zero"
+                            .to_string(),
                     });
                 }
-                Ok(LLValue::Int(((vals[0].as_i64(opname)? as u64) / divisor) as i64))
+                Ok(LLValue::Int(
+                    ((vals[0].as_i64(opname)? as u64) / divisor) as i64,
+                ))
             }
             "uint_mod" => {
                 let divisor = vals[1].as_i64(opname)? as u64;
@@ -857,7 +860,9 @@ impl LLFrame {
                         message: "opimpl.py op_uint_mod: unsigned modulo by zero".to_string(),
                     });
                 }
-                Ok(LLValue::Int(((vals[0].as_i64(opname)? as u64) % divisor) as i64))
+                Ok(LLValue::Int(
+                    ((vals[0].as_i64(opname)? as u64) % divisor) as i64,
+                ))
             }
             // `op_uint_is_true` (opimpl.py, `is_true` template): the word is
             // true iff nonzero — sign-interpretation-independent.
@@ -902,8 +907,9 @@ impl LLFrame {
                     _ => MallocFlavor::Gc,
                 };
                 let n = vals[2].as_i64(opname)? as usize;
-                let ptr = malloc((**t).clone(), Some(n), flavor, false)
-                    .map_err(|e| TaskError { message: format!("{opname}: {e}") })?;
+                let ptr = malloc((**t).clone(), Some(n), flavor, false).map_err(|e| TaskError {
+                    message: format!("{opname}: {e}"),
+                })?;
                 Ok(LLValue::Ptr(Box::new(ptr)))
             }
             "setfield" => {
@@ -919,7 +925,9 @@ impl LLFrame {
                 };
                 let mut ptr = (**p).clone();
                 ptr.setattr(field, llvalue_to_lowlevel(&vals[2], opname)?)
-                    .map_err(|e| TaskError { message: format!("{opname}: {e}") })?;
+                    .map_err(|e| TaskError {
+                        message: format!("{opname}: {e}"),
+                    })?;
                 Ok(LLValue::Void)
             }
             "getsubstruct" => {
@@ -939,19 +947,21 @@ impl LLFrame {
                 // container inlined into a Gc parent (`rpy_string.chars`);
                 // materialise that into a plain container `_ptr` so the
                 // array op handlers can read/write through it.
-                let sub = match p
-                    .getattr(field)
-                    .map_err(|e| TaskError { message: format!("{opname}: {e}") })?
-                {
+                let sub = match p.getattr(field).map_err(|e| TaskError {
+                    message: format!("{opname}: {e}"),
+                })? {
                     LowLevelValue::Ptr(pt) => *pt,
                     LowLevelValue::InteriorPtr(ip) => {
-                        ip._as_container_ptr(p._solid)
-                            .map_err(|e| TaskError { message: format!("{opname}: {e}") })?
+                        ip._as_container_ptr(p._solid).map_err(|e| TaskError {
+                            message: format!("{opname}: {e}"),
+                        })?
                     }
                     other => {
                         return Err(TaskError {
-                            message: format!("{opname}: field {field:?} is not a container: {other:?}"),
-                        })
+                            message: format!(
+                                "{opname}: field {field:?} is not a container: {other:?}"
+                            ),
+                        });
                     }
                 };
                 Ok(LLValue::Ptr(Box::new(sub)))
@@ -965,7 +975,9 @@ impl LLFrame {
                 let index = vals[1].as_i64(opname)? as usize;
                 let mut ptr = (**p).clone();
                 ptr.setitem(index, llvalue_to_lowlevel(&vals[2], opname)?)
-                    .map_err(|e| TaskError { message: format!("{opname}: {e}") })?;
+                    .map_err(|e| TaskError {
+                        message: format!("{opname}: {e}"),
+                    })?;
                 Ok(LLValue::Void)
             }
             _ => Err(TaskError {
@@ -1402,8 +1414,11 @@ mod tests {
                 char_array.clone(),
             ))))
         };
-        let flavor_c =
-            || Hlvalue::Constant(FlowConstant::new(ConstValue::Dict(std::collections::HashMap::new())));
+        let flavor_c = || {
+            Hlvalue::Constant(FlowConstant::new(ConstValue::Dict(
+                std::collections::HashMap::new(),
+            )))
+        };
         let int_c = |n: i64| Hlvalue::Constant(FlowConstant::new(ConstValue::Int(n)));
 
         let arr = Variable::named("arr");

--- a/majit/majit-translate/src/translator/rtyper/llinterp.rs
+++ b/majit/majit-translate/src/translator/rtyper/llinterp.rs
@@ -817,6 +817,35 @@ impl LLFrame {
             )),
             "bool_not" => Ok(LLValue::Bool(!vals[0].as_bool(opname)?)),
             "cast_bool_to_int" => Ok(LLValue::Int(i64::from(vals[0].as_bool(opname)?))),
+            // `op_uint_*` (opimpl.py, generated from the `r_uint` template):
+            // the Signed carrier holds the machine word; reinterpret its
+            // bits as `u64` for the unsigned operation, then store the
+            // result word back as `i64`.
+            "uint_floordiv" => {
+                let divisor = vals[1].as_i64(opname)? as u64;
+                if divisor == 0 {
+                    return Err(TaskError {
+                        message: "opimpl.py op_uint_floordiv: unsigned division by zero".to_string(),
+                    });
+                }
+                Ok(LLValue::Int(((vals[0].as_i64(opname)? as u64) / divisor) as i64))
+            }
+            "uint_mod" => {
+                let divisor = vals[1].as_i64(opname)? as u64;
+                if divisor == 0 {
+                    return Err(TaskError {
+                        message: "opimpl.py op_uint_mod: unsigned modulo by zero".to_string(),
+                    });
+                }
+                Ok(LLValue::Int(((vals[0].as_i64(opname)? as u64) % divisor) as i64))
+            }
+            // `op_uint_is_true` (opimpl.py, `is_true` template): the word is
+            // true iff nonzero — sign-interpretation-independent.
+            "uint_is_true" => Ok(LLValue::Bool(vals[0].truth())),
+            // `op_cast_uint_to_int(b) = intmask(b)` (opimpl.py:465-467):
+            // reinterpret the unsigned word's bits as Signed. The carrier
+            // already stores the word as `i64`, so this is the identity.
+            "cast_uint_to_int" => Ok(LLValue::Int(vals[0].as_i64(opname)?)),
             _ => Err(TaskError {
                 message: format!(
                     "llinterp.py:273 LLFrame.getoperationhandler — op_{opname} not yet ported"
@@ -1159,6 +1188,81 @@ mod tests {
         // thread-local pointer while running. After return the local
         // mirror is restored to the prior (empty) Weak.
         assert!(LLInterpreter::current_interpreter().is_none());
+    }
+
+    #[test]
+    fn getoperationhandler_folds_uint_div_mod_and_casts() {
+        // Covers the `op_uint_floordiv` / `op_uint_mod` / `op_uint_is_true`
+        // / `op_cast_uint_to_int` folds (opimpl.py, `r_uint` templates +
+        // :465-467), chained straight-line so one eval_graph run exercises
+        // all four: 12345 //u 10 = 1234; 1234 %u 10 = 4; intmask(4) = 4;
+        // is_true(4) = True; cast_bool_to_int(True) = 1.
+        use crate::flowspace::model::Constant as FlowConstant;
+        let ten = || Hlvalue::Constant(FlowConstant::new(ConstValue::Int(10)));
+
+        let x = Variable::named("x");
+        x.set_concretetype(Some(LowLevelType::Signed));
+        let a = Variable::named("a");
+        a.set_concretetype(Some(LowLevelType::Unsigned));
+        let b = Variable::named("b");
+        b.set_concretetype(Some(LowLevelType::Unsigned));
+        let s = Variable::named("s");
+        s.set_concretetype(Some(LowLevelType::Signed));
+        let t = Variable::named("t");
+        t.set_concretetype(Some(LowLevelType::Bool));
+        let c = Variable::named("c");
+        c.set_concretetype(Some(LowLevelType::Signed));
+
+        let start = Block::shared(vec![x.clone().into()]);
+        start.borrow_mut().operations.push(SpaceOperation::new(
+            "uint_floordiv",
+            vec![x.into(), ten()],
+            a.clone().into(),
+        ));
+        start.borrow_mut().operations.push(SpaceOperation::new(
+            "uint_mod",
+            vec![a.into(), ten()],
+            b.clone().into(),
+        ));
+        start.borrow_mut().operations.push(SpaceOperation::new(
+            "cast_uint_to_int",
+            vec![b.into()],
+            s.clone().into(),
+        ));
+        start.borrow_mut().operations.push(SpaceOperation::new(
+            "uint_is_true",
+            vec![s.into()],
+            t.clone().into(),
+        ));
+        start.borrow_mut().operations.push(SpaceOperation::new(
+            "cast_bool_to_int",
+            vec![t.into()],
+            c.clone().into(),
+        ));
+
+        let retvar = Hlvalue::Variable(Variable::named("ret"));
+        if let Hlvalue::Variable(v) = &retvar {
+            v.set_concretetype(Some(LowLevelType::Signed));
+        }
+        let graph = Rc::new(RefCell::new(FunctionGraph::with_return_var(
+            "uint_chain",
+            start.clone(),
+            retvar,
+        )));
+        let returnblock = graph.borrow().returnblock.clone();
+        start.closeblock(vec![
+            Link::new(vec![c.into()], Some(returnblock), None).into_ref(),
+        ]);
+
+        let interp = Rc::new(LLInterpreter::new(fixture_typer(), false, None));
+        let out = interp
+            .eval_graph(
+                graph as Rc<dyn Any>,
+                vec![Rc::new(12345_i64) as Rc<dyn Any>],
+                false,
+            )
+            .expect("uint fold chain should run");
+        assert_eq!(*out.downcast::<i64>().expect("Signed return"), 1);
     }
 
     #[test]

--- a/majit/majit-translate/src/translator/rtyper/lltypesystem/lltype.rs
+++ b/majit/majit-translate/src/translator/rtyper/lltypesystem/lltype.rs
@@ -3664,7 +3664,7 @@ impl _interior_ptr {
             other => {
                 return Err(format!(
                     "interior pointer target is not a container: {other:?}"
-                ))
+                ));
             }
         };
         Ok(ptr_obj._as_ptr(solid))

--- a/majit/majit-translate/src/translator/rtyper/lltypesystem/lltype.rs
+++ b/majit/majit-translate/src/translator/rtyper/lltypesystem/lltype.rs
@@ -3651,6 +3651,25 @@ impl _interior_ptr {
         ob
     }
 
+    /// Materialise this interior pointer into a plain container `_ptr` over
+    /// the same shared object. `_expose` chooses the interior form for an
+    /// inlined Raw container under a Gc parent (e.g. `rpy_string.chars`);
+    /// callers that only need to read/write through the container — the
+    /// interpreter's `getsubstruct`/`setarrayitem` handlers — take the plain
+    /// pointer over the identical `_container`, so writes still persist.
+    pub fn _as_container_ptr(&self, solid: bool) -> Result<_ptr, String> {
+        let ptr_obj = match self._obj() {
+            LowLevelValue::Array(a) => _ptr_obj::Array(*a),
+            LowLevelValue::Struct(s) => _ptr_obj::Struct(*s),
+            other => {
+                return Err(format!(
+                    "interior pointer target is not a container: {other:?}"
+                ))
+            }
+        };
+        Ok(ptr_obj._as_ptr(solid))
+    }
+
     pub fn _TYPE(&self) -> InteriorPtr {
         InteriorPtr {
             PARENTTYPE: Box::new(typeOf_value(&self._parent)),

--- a/majit/majit-translate/src/translator/rtyper/lltypesystem/rstr.rs
+++ b/majit/majit-translate/src/translator/rtyper/lltypesystem/rstr.rs
@@ -2386,11 +2386,14 @@ pub(crate) fn build_ll_int2dec_helper_graph(
 
     // ---- b_count_cond: while i_count != 0.
     let keep = variable_with_lltype("keep", LowLevelType::Bool);
-    b_count_cond.borrow_mut().operations.push(SpaceOperation::new(
-        "uint_is_true",
-        vec![Hlvalue::Variable(var_of(&b_count_cond, 2))],
-        Hlvalue::Variable(keep.clone()),
-    ));
+    b_count_cond
+        .borrow_mut()
+        .operations
+        .push(SpaceOperation::new(
+            "uint_is_true",
+            vec![Hlvalue::Variable(var_of(&b_count_cond, 2))],
+            Hlvalue::Variable(keep.clone()),
+        ));
     b_count_cond.borrow_mut().exitswitch = Some(Hlvalue::Variable(keep));
     b_count_cond.closeblock(vec![
         Link::new(
@@ -2415,20 +2418,26 @@ pub(crate) fn build_ll_int2dec_helper_graph(
 
     // ---- b_count_body: i_count //= 10; len += 1.
     let i_next = variable_with_lltype("i_next", LowLevelType::Unsigned);
-    b_count_body.borrow_mut().operations.push(SpaceOperation::new(
-        "uint_floordiv",
-        vec![
-            Hlvalue::Variable(var_of(&b_count_body, 2)),
-            unsigned_const(10),
-        ],
-        Hlvalue::Variable(i_next.clone()),
-    ));
+    b_count_body
+        .borrow_mut()
+        .operations
+        .push(SpaceOperation::new(
+            "uint_floordiv",
+            vec![
+                Hlvalue::Variable(var_of(&b_count_body, 2)),
+                unsigned_const(10),
+            ],
+            Hlvalue::Variable(i_next.clone()),
+        ));
     let len_next = variable_with_lltype("len_next", LowLevelType::Signed);
-    b_count_body.borrow_mut().operations.push(SpaceOperation::new(
-        "int_add",
-        vec![Hlvalue::Variable(var_of(&b_count_body, 3)), signed_const(1)],
-        Hlvalue::Variable(len_next.clone()),
-    ));
+    b_count_body
+        .borrow_mut()
+        .operations
+        .push(SpaceOperation::new(
+            "int_add",
+            vec![Hlvalue::Variable(var_of(&b_count_body, 3)), signed_const(1)],
+            Hlvalue::Variable(len_next.clone()),
+        ));
     b_count_body.closeblock(vec![
         Link::new(
             vec![
@@ -2489,7 +2498,10 @@ pub(crate) fn build_ll_int2dec_helper_graph(
     let total_len = variable_with_lltype("total_len", LowLevelType::Signed);
     b_alloc.borrow_mut().operations.push(SpaceOperation::new(
         "int_add",
-        vec![Hlvalue::Variable(s1), Hlvalue::Variable(var_of(&b_alloc, 3))],
+        vec![
+            Hlvalue::Variable(s1),
+            Hlvalue::Variable(var_of(&b_alloc, 3)),
+        ],
         Hlvalue::Variable(total_len.clone()),
     ));
     let result = variable_with_lltype("result", STRPTR.clone());
@@ -2555,15 +2567,18 @@ pub(crate) fn build_ll_int2dec_helper_graph(
     // ---- b_write_minus: result.chars[0] = '-'; enter digit loop (j = 0).
     let minus = char_for(45, &b_write_minus);
     let set_void = variable_with_lltype("set", LowLevelType::Void);
-    b_write_minus.borrow_mut().operations.push(SpaceOperation::new(
-        "setarrayitem",
-        vec![
-            Hlvalue::Variable(var_of(&b_write_minus, 1)),
-            signed_const(0),
-            minus,
-        ],
-        Hlvalue::Variable(set_void),
-    ));
+    b_write_minus
+        .borrow_mut()
+        .operations
+        .push(SpaceOperation::new(
+            "setarrayitem",
+            vec![
+                Hlvalue::Variable(var_of(&b_write_minus, 1)),
+                signed_const(0),
+                minus,
+            ],
+            Hlvalue::Variable(set_void),
+        ));
     b_write_minus.closeblock(vec![
         Link::new(
             vec![
@@ -2582,11 +2597,14 @@ pub(crate) fn build_ll_int2dec_helper_graph(
 
     // ---- b_check_zero: if val == 0 write '0', else straight to digit loop.
     let nz2 = variable_with_lltype("nz2", LowLevelType::Bool);
-    b_check_zero.borrow_mut().operations.push(SpaceOperation::new(
-        "uint_is_true",
-        vec![Hlvalue::Variable(var_of(&b_check_zero, 2))],
-        Hlvalue::Variable(nz2.clone()),
-    ));
+    b_check_zero
+        .borrow_mut()
+        .operations
+        .push(SpaceOperation::new(
+            "uint_is_true",
+            vec![Hlvalue::Variable(var_of(&b_check_zero, 2))],
+            Hlvalue::Variable(nz2.clone()),
+        ));
     b_check_zero.borrow_mut().exitswitch = Some(Hlvalue::Variable(nz2));
     b_check_zero.closeblock(vec![
         Link::new(
@@ -2619,15 +2637,18 @@ pub(crate) fn build_ll_int2dec_helper_graph(
     // ---- b_write_zero: result.chars[0] = '0'; enter digit loop (len == 0).
     let zero_ch = char_for(48, &b_write_zero);
     let set_void = variable_with_lltype("set", LowLevelType::Void);
-    b_write_zero.borrow_mut().operations.push(SpaceOperation::new(
-        "setarrayitem",
-        vec![
-            Hlvalue::Variable(var_of(&b_write_zero, 1)),
-            signed_const(0),
-            zero_ch,
-        ],
-        Hlvalue::Variable(set_void),
-    ));
+    b_write_zero
+        .borrow_mut()
+        .operations
+        .push(SpaceOperation::new(
+            "setarrayitem",
+            vec![
+                Hlvalue::Variable(var_of(&b_write_zero, 1)),
+                signed_const(0),
+                zero_ch,
+            ],
+            Hlvalue::Variable(set_void),
+        ));
     b_write_zero.closeblock(vec![
         Link::new(
             vec![
@@ -2646,14 +2667,17 @@ pub(crate) fn build_ll_int2dec_helper_graph(
 
     // ---- b_digit_cond: while j < len.
     let go = variable_with_lltype("go", LowLevelType::Bool);
-    b_digit_cond.borrow_mut().operations.push(SpaceOperation::new(
-        "int_lt",
-        vec![
-            Hlvalue::Variable(var_of(&b_digit_cond, 5)),
-            Hlvalue::Variable(var_of(&b_digit_cond, 3)),
-        ],
-        Hlvalue::Variable(go.clone()),
-    ));
+    b_digit_cond
+        .borrow_mut()
+        .operations
+        .push(SpaceOperation::new(
+            "int_lt",
+            vec![
+                Hlvalue::Variable(var_of(&b_digit_cond, 5)),
+                Hlvalue::Variable(var_of(&b_digit_cond, 3)),
+            ],
+            Hlvalue::Variable(go.clone()),
+        ));
     b_digit_cond.borrow_mut().exitswitch = Some(Hlvalue::Variable(go));
     b_digit_cond.closeblock(vec![
         Link::new(
@@ -2674,72 +2698,99 @@ pub(crate) fn build_ll_int2dec_helper_graph(
 
     // ---- b_digit_body: chars[total_len-j-1] = chr(val%10 + '0'); val //= 10; j += 1.
     let t1 = variable_with_lltype("t1", LowLevelType::Signed);
-    b_digit_body.borrow_mut().operations.push(SpaceOperation::new(
-        "int_sub",
-        vec![
-            Hlvalue::Variable(var_of(&b_digit_body, 4)),
-            Hlvalue::Variable(var_of(&b_digit_body, 5)),
-        ],
-        Hlvalue::Variable(t1.clone()),
-    ));
+    b_digit_body
+        .borrow_mut()
+        .operations
+        .push(SpaceOperation::new(
+            "int_sub",
+            vec![
+                Hlvalue::Variable(var_of(&b_digit_body, 4)),
+                Hlvalue::Variable(var_of(&b_digit_body, 5)),
+            ],
+            Hlvalue::Variable(t1.clone()),
+        ));
     let dst = variable_with_lltype("dst", LowLevelType::Signed);
-    b_digit_body.borrow_mut().operations.push(SpaceOperation::new(
-        "int_sub",
-        vec![Hlvalue::Variable(t1), signed_const(1)],
-        Hlvalue::Variable(dst.clone()),
-    ));
+    b_digit_body
+        .borrow_mut()
+        .operations
+        .push(SpaceOperation::new(
+            "int_sub",
+            vec![Hlvalue::Variable(t1), signed_const(1)],
+            Hlvalue::Variable(dst.clone()),
+        ));
     let rem = variable_with_lltype("rem", LowLevelType::Unsigned);
-    b_digit_body.borrow_mut().operations.push(SpaceOperation::new(
-        "uint_mod",
-        vec![
-            Hlvalue::Variable(var_of(&b_digit_body, 2)),
-            unsigned_const(10),
-        ],
-        Hlvalue::Variable(rem.clone()),
-    ));
+    b_digit_body
+        .borrow_mut()
+        .operations
+        .push(SpaceOperation::new(
+            "uint_mod",
+            vec![
+                Hlvalue::Variable(var_of(&b_digit_body, 2)),
+                unsigned_const(10),
+            ],
+            Hlvalue::Variable(rem.clone()),
+        ));
     let rem_s = variable_with_lltype("rem_s", LowLevelType::Signed);
-    b_digit_body.borrow_mut().operations.push(SpaceOperation::new(
-        "cast_uint_to_int",
-        vec![Hlvalue::Variable(rem)],
-        Hlvalue::Variable(rem_s.clone()),
-    ));
+    b_digit_body
+        .borrow_mut()
+        .operations
+        .push(SpaceOperation::new(
+            "cast_uint_to_int",
+            vec![Hlvalue::Variable(rem)],
+            Hlvalue::Variable(rem_s.clone()),
+        ));
     let code = variable_with_lltype("code", LowLevelType::Signed);
-    b_digit_body.borrow_mut().operations.push(SpaceOperation::new(
-        "int_add",
-        vec![Hlvalue::Variable(rem_s), signed_const(48)],
-        Hlvalue::Variable(code.clone()),
-    ));
+    b_digit_body
+        .borrow_mut()
+        .operations
+        .push(SpaceOperation::new(
+            "int_add",
+            vec![Hlvalue::Variable(rem_s), signed_const(48)],
+            Hlvalue::Variable(code.clone()),
+        ));
     let ch = variable_with_lltype("ch", LowLevelType::Char);
-    b_digit_body.borrow_mut().operations.push(SpaceOperation::new(
-        "cast_int_to_char",
-        vec![Hlvalue::Variable(code)],
-        Hlvalue::Variable(ch.clone()),
-    ));
+    b_digit_body
+        .borrow_mut()
+        .operations
+        .push(SpaceOperation::new(
+            "cast_int_to_char",
+            vec![Hlvalue::Variable(code)],
+            Hlvalue::Variable(ch.clone()),
+        ));
     let set_void = variable_with_lltype("set", LowLevelType::Void);
-    b_digit_body.borrow_mut().operations.push(SpaceOperation::new(
-        "setarrayitem",
-        vec![
-            Hlvalue::Variable(var_of(&b_digit_body, 1)),
-            Hlvalue::Variable(dst),
-            Hlvalue::Variable(ch),
-        ],
-        Hlvalue::Variable(set_void),
-    ));
+    b_digit_body
+        .borrow_mut()
+        .operations
+        .push(SpaceOperation::new(
+            "setarrayitem",
+            vec![
+                Hlvalue::Variable(var_of(&b_digit_body, 1)),
+                Hlvalue::Variable(dst),
+                Hlvalue::Variable(ch),
+            ],
+            Hlvalue::Variable(set_void),
+        ));
     let val_next = variable_with_lltype("val_next", LowLevelType::Unsigned);
-    b_digit_body.borrow_mut().operations.push(SpaceOperation::new(
-        "uint_floordiv",
-        vec![
-            Hlvalue::Variable(var_of(&b_digit_body, 2)),
-            unsigned_const(10),
-        ],
-        Hlvalue::Variable(val_next.clone()),
-    ));
+    b_digit_body
+        .borrow_mut()
+        .operations
+        .push(SpaceOperation::new(
+            "uint_floordiv",
+            vec![
+                Hlvalue::Variable(var_of(&b_digit_body, 2)),
+                unsigned_const(10),
+            ],
+            Hlvalue::Variable(val_next.clone()),
+        ));
     let j_next = variable_with_lltype("j_next", LowLevelType::Signed);
-    b_digit_body.borrow_mut().operations.push(SpaceOperation::new(
-        "int_add",
-        vec![Hlvalue::Variable(var_of(&b_digit_body, 5)), signed_const(1)],
-        Hlvalue::Variable(j_next.clone()),
-    ));
+    b_digit_body
+        .borrow_mut()
+        .operations
+        .push(SpaceOperation::new(
+            "int_add",
+            vec![Hlvalue::Variable(var_of(&b_digit_body, 5)), signed_const(1)],
+            Hlvalue::Variable(j_next.clone()),
+        ));
     b_digit_body.closeblock(vec![
         Link::new(
             vec![
@@ -2761,7 +2812,11 @@ pub(crate) fn build_ll_int2dec_helper_graph(
         Constant::new(ConstValue::Dict(Default::default())),
     );
     graph.func = Some(func.clone());
-    Ok(helper_pygraph_from_graph(graph, vec!["i".to_string()], func))
+    Ok(helper_pygraph_from_graph(
+        graph,
+        vec!["i".to_string()],
+        func,
+    ))
 }
 
 /// Synthesise `LLHelpers.ll_int` (`lltypesystem/rstr.py:1057-1110`):

--- a/majit/majit-translate/src/translator/rtyper/lltypesystem/rstr.rs
+++ b/majit/majit-translate/src/translator/rtyper/lltypesystem/rstr.rs
@@ -2132,6 +2132,638 @@ pub(crate) fn build_ll_int2hex_helper_graph(
     ))
 }
 
+/// Synthesise `IntegerRepr.ll_str` (`rint.py:150-152`) = `ll_int2dec(val)`
+/// (`ll_str.py:14-39`) as a low-level helper graph. Where `ll_int2hex`
+/// fills a scratch array forward then copies it reversed, `ll_int2dec`
+/// counts the digits first, allocates the exact-length result, and writes
+/// each decimal digit straight to its final reversed slot
+/// `total_len - j - 1`.
+///
+/// `signed_input=true` is the Signed specialisation (the `if val < 0`
+/// branch takes the magnitude); `false` is the Unsigned (`r_uint`) one,
+/// where the sign is provably 0 and that branch is pruned.
+pub(crate) fn build_ll_int2dec_helper_graph(
+    name: &str,
+    signed_input: bool,
+) -> Result<PyGraph, TyperError> {
+    use crate::translator::rtyper::rmodel::{gc_flavor_const, lowlevel_type_const};
+
+    let str_struct_lltype = struct_lltype_from_strptr(&STRPTR)?;
+    let result_chars_ptr_lltype = chars_array_ptr_lltype_from_strptr(&STRPTR)?;
+
+    let signed_const = |n: i64| constant_with_lltype(ConstValue::Int(n), LowLevelType::Signed);
+    let unsigned_const = |n: i64| constant_with_lltype(ConstValue::Int(n), LowLevelType::Unsigned);
+    let hash_field_const =
+        || constant_with_lltype(ConstValue::byte_str("hash"), LowLevelType::Void);
+    let chars_field_const =
+        || constant_with_lltype(ConstValue::byte_str("chars"), LowLevelType::Void);
+    let bool_true = || constant_with_lltype(ConstValue::Bool(true), LowLevelType::Bool);
+    let bool_false = || constant_with_lltype(ConstValue::Bool(false), LowLevelType::Bool);
+    let char_for = |code: i64, block: &crate::flowspace::model::BlockRef| -> Hlvalue {
+        let ch = variable_with_lltype("ch", LowLevelType::Char);
+        block.borrow_mut().operations.push(SpaceOperation::new(
+            "cast_int_to_char",
+            vec![signed_const(code)],
+            Hlvalue::Variable(ch.clone()),
+        ));
+        Hlvalue::Variable(ch)
+    };
+
+    let i_lltype = if signed_input {
+        LowLevelType::Signed
+    } else {
+        LowLevelType::Unsigned
+    };
+    let i_arg = variable_with_lltype("i", i_lltype);
+    let startblock = Block::shared(vec![Hlvalue::Variable(i_arg.clone())]);
+    let return_var = variable_with_lltype("result", STRPTR.clone());
+    let mut graph = FunctionGraph::with_return_var(
+        name.to_string(),
+        startblock.clone(),
+        Hlvalue::Variable(return_var),
+    );
+
+    let mk_block = |spec: Vec<(&str, LowLevelType)>| {
+        Block::shared(
+            spec.into_iter()
+                .map(|(n, lltype)| Hlvalue::Variable(variable_with_lltype(n, lltype)))
+                .collect(),
+        )
+    };
+
+    let b_sign = signed_input.then(|| mk_block(vec![("i", LowLevelType::Signed)]));
+    let b_pos = signed_input.then(|| mk_block(vec![("i", LowLevelType::Signed)]));
+    let b_count_cond = mk_block(vec![
+        ("val", LowLevelType::Unsigned),
+        ("sign", LowLevelType::Signed),
+        ("i_count", LowLevelType::Unsigned),
+        ("len", LowLevelType::Signed),
+    ]);
+    let b_count_body = mk_block(vec![
+        ("val", LowLevelType::Unsigned),
+        ("sign", LowLevelType::Signed),
+        ("i_count", LowLevelType::Unsigned),
+        ("len", LowLevelType::Signed),
+    ]);
+    let b_total = mk_block(vec![
+        ("val", LowLevelType::Unsigned),
+        ("sign", LowLevelType::Signed),
+        ("len", LowLevelType::Signed),
+    ]);
+    let b_alloc = mk_block(vec![
+        ("val", LowLevelType::Unsigned),
+        ("sign", LowLevelType::Signed),
+        ("len", LowLevelType::Signed),
+        ("zero_add", LowLevelType::Signed),
+    ]);
+    let chars_slot = || ("result_chars", result_chars_ptr_lltype.clone());
+    let b_write_minus = mk_block(vec![
+        ("result", STRPTR.clone()),
+        chars_slot(),
+        ("val", LowLevelType::Unsigned),
+        ("len", LowLevelType::Signed),
+        ("total_len", LowLevelType::Signed),
+    ]);
+    let b_check_zero = mk_block(vec![
+        ("result", STRPTR.clone()),
+        chars_slot(),
+        ("val", LowLevelType::Unsigned),
+        ("len", LowLevelType::Signed),
+        ("total_len", LowLevelType::Signed),
+    ]);
+    let b_write_zero = mk_block(vec![
+        ("result", STRPTR.clone()),
+        chars_slot(),
+        ("val", LowLevelType::Unsigned),
+        ("len", LowLevelType::Signed),
+        ("total_len", LowLevelType::Signed),
+    ]);
+    let b_digit_cond = mk_block(vec![
+        ("result", STRPTR.clone()),
+        chars_slot(),
+        ("val", LowLevelType::Unsigned),
+        ("len", LowLevelType::Signed),
+        ("total_len", LowLevelType::Signed),
+        ("j", LowLevelType::Signed),
+    ]);
+    let b_digit_body = mk_block(vec![
+        ("result", STRPTR.clone()),
+        chars_slot(),
+        ("val", LowLevelType::Unsigned),
+        ("len", LowLevelType::Signed),
+        ("total_len", LowLevelType::Signed),
+        ("j", LowLevelType::Signed),
+    ]);
+
+    // Snapshot each block's input Variables up front (see `ll_int2hex`).
+    let mut input_snapshots: std::collections::HashMap<
+        *const std::cell::RefCell<crate::flowspace::model::Block>,
+        Vec<Variable>,
+    > = std::collections::HashMap::new();
+    let mut snapshot_blocks: Vec<&crate::flowspace::model::BlockRef> = Vec::new();
+    if let Some(b) = &b_sign {
+        snapshot_blocks.push(b);
+    }
+    if let Some(b) = &b_pos {
+        snapshot_blocks.push(b);
+    }
+    snapshot_blocks.extend([
+        &b_count_cond,
+        &b_count_body,
+        &b_total,
+        &b_alloc,
+        &b_write_minus,
+        &b_check_zero,
+        &b_write_zero,
+        &b_digit_cond,
+        &b_digit_body,
+    ]);
+    for block in snapshot_blocks {
+        let vars = block
+            .borrow()
+            .inputargs
+            .iter()
+            .map(|h| match h {
+                Hlvalue::Variable(v) => v.clone(),
+                other => panic!("ll_int2dec block input must be Variable, got {other:?}"),
+            })
+            .collect();
+        input_snapshots.insert(std::rc::Rc::as_ptr(block), vars);
+    }
+    let var_of = |block: &crate::flowspace::model::BlockRef, idx: usize| -> Variable {
+        input_snapshots[&std::rc::Rc::as_ptr(block)][idx].clone()
+    };
+
+    // ---- start: compute sign + unsigned magnitude, enter the count loop.
+    if signed_input {
+        let b_sign = b_sign.as_ref().expect("b_sign exists in signed build");
+        let b_pos = b_pos.as_ref().expect("b_pos exists in signed build");
+        let neg = variable_with_lltype("neg", LowLevelType::Bool);
+        startblock.borrow_mut().operations.push(SpaceOperation::new(
+            "int_lt",
+            vec![Hlvalue::Variable(i_arg.clone()), signed_const(0)],
+            Hlvalue::Variable(neg.clone()),
+        ));
+        startblock.borrow_mut().exitswitch = Some(Hlvalue::Variable(neg));
+        startblock.closeblock(vec![
+            Link::new(
+                vec![Hlvalue::Variable(i_arg.clone())],
+                Some(b_sign.clone()),
+                Some(bool_true()),
+            )
+            .into_ref(),
+            Link::new(
+                vec![Hlvalue::Variable(i_arg.clone())],
+                Some(b_pos.clone()),
+                Some(bool_false()),
+            )
+            .into_ref(),
+        ]);
+
+        // b_sign: val = r_uint(-i); sign = 1.
+        let ni = variable_with_lltype("ni", LowLevelType::Signed);
+        b_sign.borrow_mut().operations.push(SpaceOperation::new(
+            "int_neg",
+            vec![Hlvalue::Variable(var_of(b_sign, 0))],
+            Hlvalue::Variable(ni.clone()),
+        ));
+        let vu = variable_with_lltype("val", LowLevelType::Unsigned);
+        b_sign.borrow_mut().operations.push(SpaceOperation::new(
+            "cast_primitive",
+            vec![Hlvalue::Variable(ni)],
+            Hlvalue::Variable(vu.clone()),
+        ));
+        b_sign.closeblock(vec![
+            Link::new(
+                vec![
+                    Hlvalue::Variable(vu.clone()),
+                    signed_const(1),
+                    Hlvalue::Variable(vu),
+                    signed_const(0),
+                ],
+                Some(b_count_cond.clone()),
+                None,
+            )
+            .into_ref(),
+        ]);
+
+        // b_pos: val = r_uint(i); sign = 0.
+        let vup = variable_with_lltype("val", LowLevelType::Unsigned);
+        b_pos.borrow_mut().operations.push(SpaceOperation::new(
+            "cast_primitive",
+            vec![Hlvalue::Variable(var_of(b_pos, 0))],
+            Hlvalue::Variable(vup.clone()),
+        ));
+        b_pos.closeblock(vec![
+            Link::new(
+                vec![
+                    Hlvalue::Variable(vup.clone()),
+                    signed_const(0),
+                    Hlvalue::Variable(vup),
+                    signed_const(0),
+                ],
+                Some(b_count_cond.clone()),
+                None,
+            )
+            .into_ref(),
+        ]);
+    } else {
+        // Unsigned specialisation: i is already r_uint, sign = 0.
+        startblock.closeblock(vec![
+            Link::new(
+                vec![
+                    Hlvalue::Variable(i_arg.clone()),
+                    signed_const(0),
+                    Hlvalue::Variable(i_arg.clone()),
+                    signed_const(0),
+                ],
+                Some(b_count_cond.clone()),
+                None,
+            )
+            .into_ref(),
+        ]);
+    }
+
+    // ---- b_count_cond: while i_count != 0.
+    let keep = variable_with_lltype("keep", LowLevelType::Bool);
+    b_count_cond.borrow_mut().operations.push(SpaceOperation::new(
+        "uint_is_true",
+        vec![Hlvalue::Variable(var_of(&b_count_cond, 2))],
+        Hlvalue::Variable(keep.clone()),
+    ));
+    b_count_cond.borrow_mut().exitswitch = Some(Hlvalue::Variable(keep));
+    b_count_cond.closeblock(vec![
+        Link::new(
+            (0..4)
+                .map(|k| Hlvalue::Variable(var_of(&b_count_cond, k)))
+                .collect(),
+            Some(b_count_body.clone()),
+            Some(bool_true()),
+        )
+        .into_ref(),
+        Link::new(
+            vec![
+                Hlvalue::Variable(var_of(&b_count_cond, 0)),
+                Hlvalue::Variable(var_of(&b_count_cond, 1)),
+                Hlvalue::Variable(var_of(&b_count_cond, 3)),
+            ],
+            Some(b_total.clone()),
+            Some(bool_false()),
+        )
+        .into_ref(),
+    ]);
+
+    // ---- b_count_body: i_count //= 10; len += 1.
+    let i_next = variable_with_lltype("i_next", LowLevelType::Unsigned);
+    b_count_body.borrow_mut().operations.push(SpaceOperation::new(
+        "uint_floordiv",
+        vec![
+            Hlvalue::Variable(var_of(&b_count_body, 2)),
+            unsigned_const(10),
+        ],
+        Hlvalue::Variable(i_next.clone()),
+    ));
+    let len_next = variable_with_lltype("len_next", LowLevelType::Signed);
+    b_count_body.borrow_mut().operations.push(SpaceOperation::new(
+        "int_add",
+        vec![Hlvalue::Variable(var_of(&b_count_body, 3)), signed_const(1)],
+        Hlvalue::Variable(len_next.clone()),
+    ));
+    b_count_body.closeblock(vec![
+        Link::new(
+            vec![
+                Hlvalue::Variable(var_of(&b_count_body, 0)),
+                Hlvalue::Variable(var_of(&b_count_body, 1)),
+                Hlvalue::Variable(i_next),
+                Hlvalue::Variable(len_next),
+            ],
+            Some(b_count_cond.clone()),
+            None,
+        )
+        .into_ref(),
+    ]);
+
+    // ---- b_total: zero_add = int(val == 0); go to alloc.
+    let nz = variable_with_lltype("nz", LowLevelType::Bool);
+    b_total.borrow_mut().operations.push(SpaceOperation::new(
+        "uint_is_true",
+        vec![Hlvalue::Variable(var_of(&b_total, 0))],
+        Hlvalue::Variable(nz.clone()),
+    ));
+    b_total.borrow_mut().exitswitch = Some(Hlvalue::Variable(nz));
+    b_total.closeblock(vec![
+        Link::new(
+            vec![
+                Hlvalue::Variable(var_of(&b_total, 0)),
+                Hlvalue::Variable(var_of(&b_total, 1)),
+                Hlvalue::Variable(var_of(&b_total, 2)),
+                signed_const(0),
+            ],
+            Some(b_alloc.clone()),
+            Some(bool_true()),
+        )
+        .into_ref(),
+        Link::new(
+            vec![
+                Hlvalue::Variable(var_of(&b_total, 0)),
+                Hlvalue::Variable(var_of(&b_total, 1)),
+                Hlvalue::Variable(var_of(&b_total, 2)),
+                signed_const(1),
+            ],
+            Some(b_alloc.clone()),
+            Some(bool_false()),
+        )
+        .into_ref(),
+    ]);
+
+    // ---- b_alloc: total_len = sign + len + zero_add; result = mallocstr(total_len).
+    let s1 = variable_with_lltype("s1", LowLevelType::Signed);
+    b_alloc.borrow_mut().operations.push(SpaceOperation::new(
+        "int_add",
+        vec![
+            Hlvalue::Variable(var_of(&b_alloc, 1)),
+            Hlvalue::Variable(var_of(&b_alloc, 2)),
+        ],
+        Hlvalue::Variable(s1.clone()),
+    ));
+    let total_len = variable_with_lltype("total_len", LowLevelType::Signed);
+    b_alloc.borrow_mut().operations.push(SpaceOperation::new(
+        "int_add",
+        vec![Hlvalue::Variable(s1), Hlvalue::Variable(var_of(&b_alloc, 3))],
+        Hlvalue::Variable(total_len.clone()),
+    ));
+    let result = variable_with_lltype("result", STRPTR.clone());
+    b_alloc.borrow_mut().operations.push(SpaceOperation::new(
+        "malloc_varsize",
+        vec![
+            lowlevel_type_const(str_struct_lltype),
+            gc_flavor_const()?,
+            Hlvalue::Variable(total_len.clone()),
+        ],
+        Hlvalue::Variable(result.clone()),
+    ));
+    let set_hash = variable_with_lltype("set", LowLevelType::Void);
+    b_alloc.borrow_mut().operations.push(SpaceOperation::new(
+        "setfield",
+        vec![
+            Hlvalue::Variable(result.clone()),
+            hash_field_const(),
+            signed_const(0),
+        ],
+        Hlvalue::Variable(set_hash),
+    ));
+    let result_chars = variable_with_lltype("result_chars", result_chars_ptr_lltype.clone());
+    b_alloc.borrow_mut().operations.push(SpaceOperation::new(
+        "getsubstruct",
+        vec![Hlvalue::Variable(result.clone()), chars_field_const()],
+        Hlvalue::Variable(result_chars.clone()),
+    ));
+    let sign_b = variable_with_lltype("sign_b", LowLevelType::Bool);
+    b_alloc.borrow_mut().operations.push(SpaceOperation::new(
+        "int_is_true",
+        vec![Hlvalue::Variable(var_of(&b_alloc, 1))],
+        Hlvalue::Variable(sign_b.clone()),
+    ));
+    b_alloc.borrow_mut().exitswitch = Some(Hlvalue::Variable(sign_b));
+    b_alloc.closeblock(vec![
+        Link::new(
+            vec![
+                Hlvalue::Variable(result.clone()),
+                Hlvalue::Variable(result_chars.clone()),
+                Hlvalue::Variable(var_of(&b_alloc, 0)),
+                Hlvalue::Variable(var_of(&b_alloc, 2)),
+                Hlvalue::Variable(total_len.clone()),
+            ],
+            Some(b_write_minus.clone()),
+            Some(bool_true()),
+        )
+        .into_ref(),
+        Link::new(
+            vec![
+                Hlvalue::Variable(result),
+                Hlvalue::Variable(result_chars),
+                Hlvalue::Variable(var_of(&b_alloc, 0)),
+                Hlvalue::Variable(var_of(&b_alloc, 2)),
+                Hlvalue::Variable(total_len),
+            ],
+            Some(b_check_zero.clone()),
+            Some(bool_false()),
+        )
+        .into_ref(),
+    ]);
+
+    // ---- b_write_minus: result.chars[0] = '-'; enter digit loop (j = 0).
+    let minus = char_for(45, &b_write_minus);
+    let set_void = variable_with_lltype("set", LowLevelType::Void);
+    b_write_minus.borrow_mut().operations.push(SpaceOperation::new(
+        "setarrayitem",
+        vec![
+            Hlvalue::Variable(var_of(&b_write_minus, 1)),
+            signed_const(0),
+            minus,
+        ],
+        Hlvalue::Variable(set_void),
+    ));
+    b_write_minus.closeblock(vec![
+        Link::new(
+            vec![
+                Hlvalue::Variable(var_of(&b_write_minus, 0)),
+                Hlvalue::Variable(var_of(&b_write_minus, 1)),
+                Hlvalue::Variable(var_of(&b_write_minus, 2)),
+                Hlvalue::Variable(var_of(&b_write_minus, 3)),
+                Hlvalue::Variable(var_of(&b_write_minus, 4)),
+                signed_const(0),
+            ],
+            Some(b_digit_cond.clone()),
+            None,
+        )
+        .into_ref(),
+    ]);
+
+    // ---- b_check_zero: if val == 0 write '0', else straight to digit loop.
+    let nz2 = variable_with_lltype("nz2", LowLevelType::Bool);
+    b_check_zero.borrow_mut().operations.push(SpaceOperation::new(
+        "uint_is_true",
+        vec![Hlvalue::Variable(var_of(&b_check_zero, 2))],
+        Hlvalue::Variable(nz2.clone()),
+    ));
+    b_check_zero.borrow_mut().exitswitch = Some(Hlvalue::Variable(nz2));
+    b_check_zero.closeblock(vec![
+        Link::new(
+            vec![
+                Hlvalue::Variable(var_of(&b_check_zero, 0)),
+                Hlvalue::Variable(var_of(&b_check_zero, 1)),
+                Hlvalue::Variable(var_of(&b_check_zero, 2)),
+                Hlvalue::Variable(var_of(&b_check_zero, 3)),
+                Hlvalue::Variable(var_of(&b_check_zero, 4)),
+                signed_const(0),
+            ],
+            Some(b_digit_cond.clone()),
+            Some(bool_true()),
+        )
+        .into_ref(),
+        Link::new(
+            vec![
+                Hlvalue::Variable(var_of(&b_check_zero, 0)),
+                Hlvalue::Variable(var_of(&b_check_zero, 1)),
+                Hlvalue::Variable(var_of(&b_check_zero, 2)),
+                Hlvalue::Variable(var_of(&b_check_zero, 3)),
+                Hlvalue::Variable(var_of(&b_check_zero, 4)),
+            ],
+            Some(b_write_zero.clone()),
+            Some(bool_false()),
+        )
+        .into_ref(),
+    ]);
+
+    // ---- b_write_zero: result.chars[0] = '0'; enter digit loop (len == 0).
+    let zero_ch = char_for(48, &b_write_zero);
+    let set_void = variable_with_lltype("set", LowLevelType::Void);
+    b_write_zero.borrow_mut().operations.push(SpaceOperation::new(
+        "setarrayitem",
+        vec![
+            Hlvalue::Variable(var_of(&b_write_zero, 1)),
+            signed_const(0),
+            zero_ch,
+        ],
+        Hlvalue::Variable(set_void),
+    ));
+    b_write_zero.closeblock(vec![
+        Link::new(
+            vec![
+                Hlvalue::Variable(var_of(&b_write_zero, 0)),
+                Hlvalue::Variable(var_of(&b_write_zero, 1)),
+                Hlvalue::Variable(var_of(&b_write_zero, 2)),
+                Hlvalue::Variable(var_of(&b_write_zero, 3)),
+                Hlvalue::Variable(var_of(&b_write_zero, 4)),
+                signed_const(0),
+            ],
+            Some(b_digit_cond.clone()),
+            None,
+        )
+        .into_ref(),
+    ]);
+
+    // ---- b_digit_cond: while j < len.
+    let go = variable_with_lltype("go", LowLevelType::Bool);
+    b_digit_cond.borrow_mut().operations.push(SpaceOperation::new(
+        "int_lt",
+        vec![
+            Hlvalue::Variable(var_of(&b_digit_cond, 5)),
+            Hlvalue::Variable(var_of(&b_digit_cond, 3)),
+        ],
+        Hlvalue::Variable(go.clone()),
+    ));
+    b_digit_cond.borrow_mut().exitswitch = Some(Hlvalue::Variable(go));
+    b_digit_cond.closeblock(vec![
+        Link::new(
+            (0..6)
+                .map(|k| Hlvalue::Variable(var_of(&b_digit_cond, k)))
+                .collect(),
+            Some(b_digit_body.clone()),
+            Some(bool_true()),
+        )
+        .into_ref(),
+        Link::new(
+            vec![Hlvalue::Variable(var_of(&b_digit_cond, 0))],
+            Some(graph.returnblock.clone()),
+            Some(bool_false()),
+        )
+        .into_ref(),
+    ]);
+
+    // ---- b_digit_body: chars[total_len-j-1] = chr(val%10 + '0'); val //= 10; j += 1.
+    let t1 = variable_with_lltype("t1", LowLevelType::Signed);
+    b_digit_body.borrow_mut().operations.push(SpaceOperation::new(
+        "int_sub",
+        vec![
+            Hlvalue::Variable(var_of(&b_digit_body, 4)),
+            Hlvalue::Variable(var_of(&b_digit_body, 5)),
+        ],
+        Hlvalue::Variable(t1.clone()),
+    ));
+    let dst = variable_with_lltype("dst", LowLevelType::Signed);
+    b_digit_body.borrow_mut().operations.push(SpaceOperation::new(
+        "int_sub",
+        vec![Hlvalue::Variable(t1), signed_const(1)],
+        Hlvalue::Variable(dst.clone()),
+    ));
+    let rem = variable_with_lltype("rem", LowLevelType::Unsigned);
+    b_digit_body.borrow_mut().operations.push(SpaceOperation::new(
+        "uint_mod",
+        vec![
+            Hlvalue::Variable(var_of(&b_digit_body, 2)),
+            unsigned_const(10),
+        ],
+        Hlvalue::Variable(rem.clone()),
+    ));
+    let rem_s = variable_with_lltype("rem_s", LowLevelType::Signed);
+    b_digit_body.borrow_mut().operations.push(SpaceOperation::new(
+        "cast_uint_to_int",
+        vec![Hlvalue::Variable(rem)],
+        Hlvalue::Variable(rem_s.clone()),
+    ));
+    let code = variable_with_lltype("code", LowLevelType::Signed);
+    b_digit_body.borrow_mut().operations.push(SpaceOperation::new(
+        "int_add",
+        vec![Hlvalue::Variable(rem_s), signed_const(48)],
+        Hlvalue::Variable(code.clone()),
+    ));
+    let ch = variable_with_lltype("ch", LowLevelType::Char);
+    b_digit_body.borrow_mut().operations.push(SpaceOperation::new(
+        "cast_int_to_char",
+        vec![Hlvalue::Variable(code)],
+        Hlvalue::Variable(ch.clone()),
+    ));
+    let set_void = variable_with_lltype("set", LowLevelType::Void);
+    b_digit_body.borrow_mut().operations.push(SpaceOperation::new(
+        "setarrayitem",
+        vec![
+            Hlvalue::Variable(var_of(&b_digit_body, 1)),
+            Hlvalue::Variable(dst),
+            Hlvalue::Variable(ch),
+        ],
+        Hlvalue::Variable(set_void),
+    ));
+    let val_next = variable_with_lltype("val_next", LowLevelType::Unsigned);
+    b_digit_body.borrow_mut().operations.push(SpaceOperation::new(
+        "uint_floordiv",
+        vec![
+            Hlvalue::Variable(var_of(&b_digit_body, 2)),
+            unsigned_const(10),
+        ],
+        Hlvalue::Variable(val_next.clone()),
+    ));
+    let j_next = variable_with_lltype("j_next", LowLevelType::Signed);
+    b_digit_body.borrow_mut().operations.push(SpaceOperation::new(
+        "int_add",
+        vec![Hlvalue::Variable(var_of(&b_digit_body, 5)), signed_const(1)],
+        Hlvalue::Variable(j_next.clone()),
+    ));
+    b_digit_body.closeblock(vec![
+        Link::new(
+            vec![
+                Hlvalue::Variable(var_of(&b_digit_body, 0)),
+                Hlvalue::Variable(var_of(&b_digit_body, 1)),
+                Hlvalue::Variable(val_next),
+                Hlvalue::Variable(var_of(&b_digit_body, 3)),
+                Hlvalue::Variable(var_of(&b_digit_body, 4)),
+                Hlvalue::Variable(j_next),
+            ],
+            Some(b_digit_cond.clone()),
+            None,
+        )
+        .into_ref(),
+    ]);
+
+    let func = GraphFunc::new(
+        name.to_string(),
+        Constant::new(ConstValue::Dict(Default::default())),
+    );
+    graph.func = Some(func.clone());
+    Ok(helper_pygraph_from_graph(graph, vec!["i".to_string()], func))
+}
+
 /// Synthesise `LLHelpers.ll_int` (`lltypesystem/rstr.py:1057-1110`):
 ///
 /// ```python

--- a/majit/majit-translate/src/translator/rtyper/pairtype.rs
+++ b/majit/majit-translate/src/translator/rtyper/pairtype.rs
@@ -390,6 +390,13 @@ fn dispatch_convert_from_to(
         // `NotImplemented`. The rtyper distinguishes different spec-func
         // Struct pointer types even within the same Repr subclass.
         (FunctionsPBCRepr, FunctionsPBCRepr) => same_lowleveltype_convert_from_to(r_from, r_to, v),
+        // rpbc.py:1220-1224 — pairtype(MethodsPBCRepr,
+        // MethodsPBCRepr).convert_from_to: upstream identity if
+        // `r_mpbc1.lowleveltype == r_mpbc2.lowleveltype`, else
+        // `NotImplemented`. Two structurally identical method families
+        // reach this with the same receiver Ptr lowleveltype (the
+        // instance the bound method carries), so the pass-through applies.
+        (MethodsPBCRepr, MethodsPBCRepr) => same_lowleveltype_convert_from_to(r_from, r_to, v),
         // rpbc.py:517-519 — pairtype(SmallFunctionSetPBCRepr,
         // FunctionRepr).convert_from_to: `return inputconst(Void, None)`.
         //   FunctionRepr is Void-typed; the Char source variable is

--- a/majit/majit-translate/src/translator/rtyper/pairtype.rs
+++ b/majit/majit-translate/src/translator/rtyper/pairtype.rs
@@ -852,6 +852,19 @@ fn dispatch_rtype_op(
             committed(super::rstr::pair_string_string_rtype_compare(hop, "ge"))
         }
 
+        // rstr.py:661-692 via `CharRepr(AbstractCharRepr, StringRepr)` MRO —
+        // a String compared with a Char coerces the Char operand to a 1-char
+        // string (ll_chr2str) then reuses the AbstractStringRepr compare body.
+        // Pyre's CharRepr pair_mro is [CharRepr, Repr] (explicit-arm design),
+        // so the mixed pair needs its own arm; `str_arg_idx` names the string
+        // operand both sides coerce to.
+        (StringRepr, CharRepr, "eq" | "ne" | "lt" | "le" | "gt" | "ge") => {
+            committed(super::rstr::pair_string_char_rtype_compare(hop, opname, 0))
+        }
+        (CharRepr, StringRepr, "eq" | "ne" | "lt" | "le" | "gt" | "ge") => {
+            committed(super::rstr::pair_string_char_rtype_compare(hop, opname, 1))
+        }
+
         // rstr.py:651-692 inherited via AbstractUnicodeRepr(AbstractStringRepr) —
         // pairtype(AbstractUnicodeRepr, AbstractUnicodeRepr) routes through
         // the same body modulo the helper-graph identity (ll_unicode_eq /

--- a/majit/majit-translate/src/translator/rtyper/rbuiltin.rs
+++ b/majit/majit-translate/src/translator/rtyper/rbuiltin.rs
@@ -528,6 +528,23 @@ fn lookup_typer(func: &HostObject) -> Option<BuiltinTyperFn> {
         .copied()
 }
 
+/// Qualname-keyed typer fallback for host callables that are Rust
+/// associated functions rather than module-level functions, so they never
+/// enter the `HostObject`-keyed `BUILTIN_TYPER` map built from `(module,
+/// attr)` imports.  The four empty-string constructor spellings match the
+/// annotator's qualname-keyed `string_constructor` registrations
+/// (`annotator/builtin.rs` — `String.new` / `String.with_capacity` /
+/// `Wtf8Buf.new` / `Wtf8Buf.with_capacity`), keeping the annotate and rtype
+/// stages in agreement on the empty-`SomeString` shell.
+fn lookup_typer_by_qualname(qualname: &str) -> Option<BuiltinTyperFn> {
+    match qualname {
+        "String.new" | "String.with_capacity" | "Wtf8Buf.new" | "Wtf8Buf.with_capacity" => {
+            Some(rtype_empty_string_ctor)
+        }
+        _ => None,
+    }
+}
+
 /// RPython `class BuiltinFunctionRepr(Repr)` (rbuiltin.py:67-110).
 ///
 /// Void-typed repr for a statically known Python builtin callable.
@@ -584,6 +601,15 @@ impl BuiltinFunctionRepr {
     /// defines no base `specialize_call`, so this is a per-arm decision.
     pub(crate) fn findbltintyper(&self) -> Result<BuiltinTyperFn, TyperError> {
         if let Some(f) = lookup_typer(&self.builtinfunc) {
+            return Ok(f);
+        }
+        // Qualname fallback for Rust associated-function host callables
+        // (`String::new`, `Wtf8Buf::new`, …) that are not module-level
+        // functions, so they never enter the `(module, attr)`-imported
+        // `BUILTIN_TYPER` map.  Mirrors the annotator's qualname-keyed
+        // `BUILTIN_ANALYZERS` dispatch (`annotator/builtin.rs`) — the
+        // rtyper twin of `string_constructor`.
+        if let Some(f) = lookup_typer_by_qualname(self.builtinfunc.qualname()) {
             return Ok(f);
         }
         let as_const = ConstValue::HostObject(self.builtinfunc.clone());
@@ -3312,6 +3338,29 @@ fn rtype_ptr_null(hop: &HighLevelOp, _kwds_i: &HashMap<String, usize>) -> RTypeR
         .as_ref()
         .ok_or_else(|| TyperError::message("rtype_ptr_null: r_result missing".to_string()))?;
     let c = crate::translator::rtyper::rmodel::inputconst(r_result.as_ref(), &ConstValue::None)?;
+    Ok(Some(Hlvalue::Constant(c)))
+}
+
+/// Empty-string constructors — `String::new()` / `String::with_capacity(n)`
+/// / `Wtf8Buf::new()` / `Wtf8Buf::with_capacity(n)`.  The annotator's
+/// `string_constructor` (`annotator/builtin.rs`) shells all four to an empty
+/// `SomeString`, so the rtyper folds them to the interned empty `rpy_string`
+/// constant (`ByteStr([])` → `StringRepr::convert_const` →
+/// `const_str_cache_llstr`).  A capacity argument does not affect the empty
+/// content and is dropped: the string value model is immutable, so a later
+/// append yields a fresh string rather than mutating this initial value.
+fn rtype_empty_string_ctor(hop: &HighLevelOp, _kwds_i: &HashMap<String, usize>) -> RTypeResult {
+    use crate::flowspace::model::Hlvalue;
+
+    hop.exception_cannot_occur()?;
+    let r_result_borrow = hop.r_result.borrow();
+    let r_result = r_result_borrow.as_ref().ok_or_else(|| {
+        TyperError::message("rtype_empty_string_ctor: r_result missing".to_string())
+    })?;
+    let c = crate::translator::rtyper::rmodel::inputconst(
+        r_result.as_ref(),
+        &ConstValue::ByteStr(Vec::new()),
+    )?;
     Ok(Some(Hlvalue::Constant(c)))
 }
 

--- a/majit/majit-translate/src/translator/rtyper/rclass.rs
+++ b/majit/majit-translate/src/translator/rtyper/rclass.rs
@@ -3489,6 +3489,38 @@ impl Repr for InstanceRepr {
             return Ok(Some(v_method));
         }
 
+        // A niche `Option<&T>` receiver collapses to a maybe-null instance
+        // pointer with no `__discriminant` tag field — a payload enum's
+        // `__discriminant` IS an instance field, resolved by the
+        // `allinstancefields` branch above.  Reaching the fall-through for
+        // `"__discriminant"` therefore means the discriminant is the
+        // pointer's null-ness (`None` = null = 0, `Some` = non-null = 1), so
+        // read it as `cast_bool_to_int(ptr_nonzero(vinst))` rather than a
+        // class field (which does not exist and rtypes to Void).  Mirrors the
+        // `CanBeNull.rtype_bool` `ptr_nonzero` lowering (rmodel.py) and the
+        // front-end `Discriminant` niche fold's in-place null test; the
+        // `option_is_none` post-pass emits this `__discriminant` FieldRead for
+        // both niche and aggregate `is_some`/`is_none` receivers.
+        if attr == "__discriminant" {
+            use crate::translator::rtyper::rtyper::GenopResult;
+            let v_nonzero = hop
+                .genop(
+                    "ptr_nonzero",
+                    vec![vinst.clone()],
+                    GenopResult::LLType(LowLevelType::Bool),
+                )
+                .ok_or_else(|| {
+                    TyperError::message(
+                        "InstanceRepr.rtype_getattr: ptr_nonzero produced no result var",
+                    )
+                })?;
+            return Ok(hop.genop(
+                "cast_bool_to_int",
+                vec![v_nonzero],
+                GenopResult::LLType(LowLevelType::Signed),
+            ));
+        }
+
         // upstream: `else:`
         //          `vcls = self.getfield(vinst, '__class__', hop.llops)`
         //          `return self.rclass.getclsfield(vcls, attr, hop.llops)`

--- a/majit/majit-translate/src/translator/rtyper/rint.rs
+++ b/majit/majit-translate/src/translator/rtyper/rint.rs
@@ -427,6 +427,35 @@ impl Repr for IntegerRepr {
             GenopResult::LLType(LowLevelType::UniChar),
         ))
     }
+
+    /// `IntegerRepr` inherits `Repr.rtype_str` (`rmodel.py:195-197`), which
+    /// calls `hop.gendirectcall(self.ll_str, v_self)`. `IntegerRepr.ll_str`
+    /// (`rint.py:150-152`, `@jit.elidable`) is `ll_int2dec(i)`. The default
+    /// `Repr::rtype_str` raises `MissingRTypeOperation`, so this override
+    /// supplies the per-width `ll_int2dec` helper graph and calls it.
+    fn rtype_str(&self, hop: &HighLevelOp) -> RTypeResult {
+        use crate::translator::rtyper::lltypesystem::rstr::{
+            build_ll_int2dec_helper_graph, STRPTR,
+        };
+        let vlist = hop.inputargs(vec![ConvertedTo::Repr(self)])?;
+        // The helper graph's input block is Signed for the signed
+        // specialisation and Unsigned for the unsigned one; that must equal
+        // this repr's lowleveltype (the type `gendirectcall` passes and the
+        // declared helper signature). The 64-bit-target int reprs are exactly
+        // Signed/Unsigned; the long-long widths keep the default raise.
+        let (name, signed_input) = match &self.lltype {
+            LowLevelType::Unsigned => ("ll_uint2dec", false),
+            LowLevelType::Signed => ("ll_int2dec", true),
+            _ => return Err(self.missing_rtype_operation("str")),
+        };
+        let helper = hop.rtyper.lowlevel_helper_function_with_builder(
+            name.to_string(),
+            vec![self.lltype.clone()],
+            STRPTR.clone(),
+            move |_rtyper, _args, _result| build_ll_int2dec_helper_graph(name, signed_input),
+        )?;
+        hop.gendirectcall(&helper, vlist)
+    }
 }
 
 // ____________________________________________________________

--- a/majit/majit-translate/src/translator/rtyper/rint.rs
+++ b/majit/majit-translate/src/translator/rtyper/rint.rs
@@ -435,7 +435,7 @@ impl Repr for IntegerRepr {
     /// supplies the per-width `ll_int2dec` helper graph and calls it.
     fn rtype_str(&self, hop: &HighLevelOp) -> RTypeResult {
         use crate::translator::rtyper::lltypesystem::rstr::{
-            build_ll_int2dec_helper_graph, STRPTR,
+            STRPTR, build_ll_int2dec_helper_graph,
         };
         let vlist = hop.inputargs(vec![ConvertedTo::Repr(self)])?;
         // The helper graph's input block is Signed for the signed

--- a/majit/majit-translate/src/translator/rtyper/rstr.rs
+++ b/majit/majit-translate/src/translator/rtyper/rstr.rs
@@ -1749,7 +1749,14 @@ fn pair_abstract_string_rtype_compare(
         ConvertedTo::Repr(r0_arc.as_ref()),
         ConvertedTo::Repr(r1_arc.as_ref()),
     ])?;
-    string_compare_tail(hop, func, vlist, ptr_lltype, eq_helper_name, cmp_helper_name)
+    string_compare_tail(
+        hop,
+        func,
+        vlist,
+        ptr_lltype,
+        eq_helper_name,
+        cmp_helper_name,
+    )
 }
 
 /// Lower an already-coerced `(v_str1, v_str2)` string pair to the compare

--- a/majit/majit-translate/src/translator/rtyper/rstr.rs
+++ b/majit/majit-translate/src/translator/rtyper/rstr.rs
@@ -1749,7 +1749,20 @@ fn pair_abstract_string_rtype_compare(
         ConvertedTo::Repr(r0_arc.as_ref()),
         ConvertedTo::Repr(r1_arc.as_ref()),
     ])?;
+    string_compare_tail(hop, func, vlist, ptr_lltype, eq_helper_name, cmp_helper_name)
+}
 
+/// Lower an already-coerced `(v_str1, v_str2)` string pair to the compare
+/// result: `eq`/`ne` via `ll_streq` (+ `bool_not`), `lt`/`le`/`gt`/`ge` via
+/// `ll_strcmp` + `int_<func>(diff, 0)` (rstr.py:661-692).
+fn string_compare_tail(
+    hop: &HighLevelOp,
+    func: &str,
+    vlist: Vec<Hlvalue>,
+    ptr_lltype: LowLevelType,
+    eq_helper_name: &str,
+    cmp_helper_name: &str,
+) -> RTypeResult {
     match func {
         "eq" => {
             let v_eq = call_ll_streq_helper(hop, vlist, ptr_lltype, eq_helper_name)?;
@@ -1777,6 +1790,37 @@ fn pair_abstract_string_rtype_compare(
             "pair_abstract_string_rtype_compare unsupported func '{func}'"
         ))),
     }
+}
+
+/// RPython resolves a `String <op> Char` comparison through the pair MRO to
+/// `pairtype(AbstractStringRepr, AbstractStringRepr)` (rstr.py:661-692) because
+/// `CharRepr(AbstractCharRepr, StringRepr)` inherits `StringRepr.repr =
+/// string_repr` (lltypesystem/rstr.py:1262). That body does
+/// `hop.inputargs(r_str1.repr, r_str2.repr)`, i.e. coerces BOTH operands to the
+/// string repr — the Char operand becomes a 1-char string via `ll_chr2str`
+/// (rstr.py:805-813) — then runs `ll_streq`/`ll_strcmp`. Pyre's `CharRepr`
+/// pair_mro is `[CharRepr, Repr]` (explicit per-class arms, no String MRO
+/// fallback), so the mixed pair needs its own arm. `str_arg_idx` names which
+/// operand is already the string repr; both are coerced to it.
+pub(crate) fn pair_string_char_rtype_compare(
+    hop: &HighLevelOp,
+    func: &str,
+    str_arg_idx: usize,
+) -> RTypeResult {
+    let str_repr = hop
+        .args_r
+        .borrow()
+        .get(str_arg_idx)
+        .cloned()
+        .flatten()
+        .ok_or_else(|| {
+            TyperError::message("pair string/char compare: string-side args_r missing")
+        })?;
+    let vlist = hop.inputargs(vec![
+        ConvertedTo::Repr(str_repr.as_ref()),
+        ConvertedTo::Repr(str_repr.as_ref()),
+    ])?;
+    string_compare_tail(hop, func, vlist, STRPTR.clone(), "ll_streq", "ll_strcmp")
 }
 
 fn call_ll_streq_helper(

--- a/pyre/pyre-interpreter/src/gateway.rs
+++ b/pyre/pyre-interpreter/src/gateway.rs
@@ -697,6 +697,16 @@ pub fn builtin_code_new_passthrough_args1(name: &'static str, func: BuiltinCodeF
 /// Full constructor for `BuiltinCode`.  `sig` is a `*const Signature`
 /// (null for positional-only builtins); the pointee must outlive the
 /// object — callers leak it to `'static`.
+///
+/// `#[dont_look_inside]` (`@jit.dont_look_inside`, `rlib/jit.py:139`), the
+/// `w_dict_new` twin: the body boxes a `BuiltinCode` through the non-numeric
+/// `malloc_typed` (`fuse_boxing_alloc` fuses only the numeric boxes), so
+/// tracing into it carries the unported `malloc->new` lowering into the caller.
+/// Residualise the whole constructor — the JIT models it by signature as a
+/// plain `PyObjectRef` GCREF and emits a residual call. Every
+/// `builtin_code_new*` / `make_builtin_function_with_arity` head bottoms out
+/// here.
+#[majit_macros::dont_look_inside]
 fn builtin_code_new_full(
     name: &'static str,
     func: BuiltinCodeFn,

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -1793,6 +1793,10 @@ pub fn utf8_mode_flag() -> i64 {
     SYS_UTF8_MODE.load(Ordering::Relaxed)
 }
 
+/// `#[dont_look_inside]`: reads the runtime-mutable `SYS_SAFE_PATH` global
+/// (`-P` / `PYTHONSAFEPATH`), so the tracer residualises the read rather than
+/// folding a build-time constant — the runtime-mutable-global accessor pattern.
+#[majit_macros::dont_look_inside]
 pub fn safe_path_flag() -> bool {
     SYS_SAFE_PATH.load(Ordering::Relaxed)
 }

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -3100,6 +3100,10 @@ pub fn jit_static_pytype_addrs() -> Vec<(&'static str, i64)> {
             "interp_buffer::PICKLEBUFFER_TYPE",
             &crate::module::__pypy__::interp_buffer::PICKLEBUFFER_TYPE as *const _ as i64,
         ),
+        (
+            "function::METHOD_DESCRIPTOR_TYPE",
+            &crate::function::METHOD_DESCRIPTOR_TYPE as *const _ as i64,
+        ),
     ];
     // Fold in the `#[pyre_class]` registry.  A row above names one static
     // by hand, so a `#[pyre_class]` that lands without someone adding its

--- a/pyre/pyre-interpreter/src/module/thread/mod.rs
+++ b/pyre/pyre-interpreter/src/module/thread/mod.rs
@@ -217,6 +217,12 @@ pub(crate) fn all_thread_hooks_current(ec: &crate::PyExecutionContext) -> bool {
         && ec.profile_all_generation == PROFILE_ALL_GENERATION.load(Ordering::Acquire)
 }
 
+/// `dont_look_inside`: the per-thread trace/profile safepoint reads the
+/// process-wide generation counters and hook mutexes and applies any change
+/// to this thread's `ExecutionContext`.  The JIT does not trace this cold
+/// hook-application path; a caller (`ExecutionContext::bytecode_trace`)
+/// residualizes the call.
+#[majit_macros::dont_look_inside]
 pub(crate) fn apply_all_thread_hooks(
     ec: &mut crate::PyExecutionContext,
 ) -> Result<(), crate::PyError> {

--- a/pyre/pyre-interpreter/src/pycode.rs
+++ b/pyre/pyre-interpreter/src/pycode.rs
@@ -363,6 +363,14 @@ pub fn _convert_const(_space: PyObjectRef, w_a: PyObjectRef) -> PyObjectRef {
 /// # Safety
 /// `code_ptr` must be a valid pointer to a `CodeObject` obtained
 /// via `Box::into_raw`.
+///
+/// `#[dont_look_inside]` (`@jit.dont_look_inside`, `rlib/jit.py:139`): the body
+/// boxes the `PyCode` and its per-name cache tables through direct
+/// `Box::into_raw(Box::new(...))`, whose `Box::new_uninit` primitive carries no
+/// annotator (raw allocation is deliberately unlifted). Residualise the whole
+/// constructor — a `PyObjectRef` GCREF modelled by signature. Code objects are
+/// built at import/compile time, never on a traced hot path.
+#[majit_macros::dont_look_inside]
 pub fn w_code_new_with_hidden_applevel(code_ptr: *const (), hidden_applevel: bool) -> PyObjectRef {
     // RPython pointer alignment idiom (`rpython/memory/gc/minimarkpage.py:159
     // ll_assert((nsize & (WORD-1)) == 0, "malloc: size is not aligned")`):
@@ -476,6 +484,10 @@ pub fn w_code_new(code_ptr: *const ()) -> PyObjectRef {
 /// `PyCode` value shape instead of inventing an RPython layout for the opaque
 /// Rust clone. Keep clone, Box ownership transfer, and wrapper publication in
 /// the one boundary.
+///
+/// `#[dont_look_inside]` (`@jit.dont_look_inside`, `rlib/jit.py:139`): the body
+/// `Box::into_raw`s a cloned `CodeObject` (unlifted raw allocation) before
+/// forwarding to the residualised `w_code_new`.
 #[majit_macros::dont_look_inside]
 pub fn box_code_constant(code: &crate::CodeObject) -> PyObjectRef {
     let code_ptr = Box::into_raw(Box::new(code.clone())) as *const ();

--- a/pyre/pyre-interpreter/src/stack_check.rs
+++ b/pyre/pyre-interpreter/src/stack_check.rs
@@ -526,6 +526,12 @@ pub fn set_recursion_limit(new_limit: i32) -> Result<(), PyError> {
 
 /// pypy/module/sys/vm.py:72 `getrecursionlimit` parity. Reads
 /// `space.sys.recursionlimit` via `module::sys::state`.
+///
+/// `#[dont_look_inside]`: reads the runtime-mutable `recursion_limit` global
+/// (`sys.setrecursionlimit` mutates it), so the tracer residualises the read
+/// rather than folding a build-time constant — the runtime-mutable-global
+/// accessor pattern.
+#[majit_macros::dont_look_inside]
 pub fn get_recursion_limit() -> i32 {
     crate::module::sys::state::recursion_limit()
 }

--- a/pyre/pyre-object/src/dictmultiobject.rs
+++ b/pyre/pyre-object/src/dictmultiobject.rs
@@ -4101,6 +4101,14 @@ pub fn w_dict_view_reverse_iterator_new(w_dict: PyObjectRef, kind: DictViewKind)
     w_dict_view_iterator_new_direction(w_dict, kind, true)
 }
 
+/// `#[dont_look_inside]` (`@jit.dont_look_inside`, `rlib/jit.py:139`), the
+/// `w_dict_new` twin: the body builds a `W_BaseDictMultiIterObject` and boxes
+/// it through the non-numeric `malloc_typed` (`fuse_boxing_alloc` fuses only
+/// the numeric boxes), so tracing into it carries the unported `malloc->new`
+/// lowering into the caller. Residualise the whole constructor — the JIT
+/// models it by signature as a plain `PyObjectRef` GCREF and emits a residual
+/// call.
+#[majit_macros::dont_look_inside]
 fn w_dict_view_iterator_new_direction(
     w_dict: PyObjectRef,
     kind: DictViewKind,

--- a/pyre/pyre-object/src/interp_exceptions.rs
+++ b/pyre/pyre-object/src/interp_exceptions.rs
@@ -530,6 +530,14 @@ pub fn w_exception_new_empty_immortal(kind: ExcKind) -> PyObjectRef {
     w_exception_new_empty_impl(kind, true)
 }
 
+/// `#[dont_look_inside]` (`@jit.dont_look_inside`, `rlib/jit.py:139`), the
+/// `w_dict_new` / `w_dict_view_iterator_new_direction` twin: the body builds a
+/// `W_BaseException` and boxes it through the non-numeric `malloc_typed`
+/// (`fuse_boxing_alloc` fuses only the numeric boxes), so tracing into it
+/// carries the unported `malloc->new` lowering into the caller. Residualise
+/// the whole constructor — the JIT models it by signature as a plain
+/// `PyObjectRef` GCREF and emits a residual call.
+#[majit_macros::dont_look_inside]
 fn w_exception_new_empty_impl(kind: ExcKind, immortal: bool) -> PyObjectRef {
     let w_class = lookup_exc_class_for_kind(kind);
     let w_class = if w_class != PY_NULL {


### PR DESCRIPTION
Stacks 26 commits on `origin/main`, continuing the gh#346 two-phase-rtyper census-slice progression (retire the JIT rtyper legacy walker; #131 goal G). Each commit clears or narrows a `[PREPASS phaseA fail]` residual-callee wall so more JIT-traced graphs lift through the annotate→rtype path.

## rtyper / annotator
- rtype `String`<->`Char` comparisons via `ll_chr2str` coercion
- port `pairtype(MethodsPBCRepr, MethodsPBCRepr).convert_from_to`
- override `IntegerRepr::rtype_str` with the `ll_int2dec` helper call; build the `ll_int2dec` helper graph
- seed `str`/`String`/`Wtf8`/`Wtf8Buf` values as `SomeString`; add `ValueType::Str` for string-typed struct fields
- rtype `String::new` / `Wtf8Buf::new` to an empty `rpy_string` constant
- seed fieldless-enum struct fields as `Int`
- release clsdef borrow before `contains` in `SomeInstance.setattr`
- model raw `*const T`/`*mut T` results as `SomeAddress`; register `slice`/`Vec` `as_ptr`

## llinterp
- implement `malloc_varsize`/`setfield`/`getsubstruct`/`setarrayitem`/`cast_int_to_char`
- implement `uint_floordiv`/`uint_mod`/`uint_is_true`/`cast_uint_to_int`

## front (frontend folds)
- fold `bool::then_some` in `result_exc` callees by peeling the recast tail
- narrow deref'd tuple field-read base to `Tuple{suffix}` classdef

## external / no-op residualization
- register `alloc::alloc::handle_alloc_error` and `core::mem::drop` as Void no-op externals
- bridge `core::num` `wrapping_sub` to the non-raising `sub` op
- residualize `sync::atomic::AtomicBool::store` as a Void external
- residualize `#[pyre_class]` `allocate`/`allocate_stable` constructors

## pyre_interpreter / pyre_object (`dont_look_inside`)
- `dont_look_inside` the trace/profile safepoint hook-application, warnings-state / safe-path accessors, call-depth / recursion-limit accessors, `PyCode`/`BuiltinCode` boxing constructors, and exception / dict-view-iterator boxing constructors

## codewriter
- cover `ValueType::Str` in jtransform test-witness `return_str` matches

Verified green: `cargo check --workspace`; `check.py` dynasm + cranelift bit-exact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Update: +5 commits (31 total)

Later commits stacked on the branch (rtyper/front census slices):
- rtype getattr `__discriminant` on a nullable instance as `ptr_nonzero`
- bind `function::METHOD_DESCRIPTOR_TYPE` static PyType addr in `jit_static_pytype_addrs`
- register `core/std::mem::size_of` as a foreign-stdlib external + fold inline `size_of`/`align_of` ADT calls to the layout constant
- **`majit(front): rewrite <[T]>::first into a length-checked Option diamond`** — `front::slice_first` post-pass rewrites the residual `core::slice::<Impl>::first` call into `if len(slice) > 0 { Some(slice[0]) } else { None }`. Verified correct (3 unit tests + check.py dynasm 343/343 bit-exact, 395/430 sites recognized). phaseA head count is unchanged — every `first`-walled subject except `argument::Arguments::firstarg` re-roots on a deeper co-wall (`slice::index::index`, `saturating_sub`); it lands as a prerequisite for the `slice::index::index` (125-head) mover.

— *commented by Claude*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for converting signed and unsigned integers to decimal strings.
  * Improved string and character comparisons, string handling, and reference tracking.
  * Added support for safely processing the first element of slices as an optional value.
  * Expanded low-level operations, including allocation, array updates, casts, and pointer handling.

* **Bug Fixes**
  * Improved control-flow rewriting and constructor handling.
  * Fixed caching and field access edge cases.
  * Improved runtime handling for dictionaries, exceptions, recursion limits, and thread hooks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->