### PR TITLE
jit: force the caller's frame on its own vable_token, through the real allocator, and reuse what the force materialized

### DIFF
--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -2699,6 +2699,7 @@ pub fn resume_in_blackhole(
         None, // vinfo
         None, // ginfo
         None, // virtualizable_identity_override
+        None, // all_virtuals
         &null_alloc,
     );
 

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -3763,6 +3763,7 @@ impl<S: JitState> JitDriver<S> {
                         .map(|a| a.as_ref() as &dyn crate::resume::VirtualizableInfo),
                     None, // ginfo
                     vable_identity_override,
+                    None, // all_virtuals
                     allocator,
                 );
                 if let Some((mut bh, vable_ptr)) = bh {
@@ -4551,14 +4552,14 @@ impl<S: JitState> JitDriver<S> {
     /// virtuals through the same resume allocator used by ordinary guard
     /// failure.  In particular, a `jit.virtual_ref` frame must not be decoded
     /// through `NullAllocator`, or its `forced` writeback remains null.
-    pub fn force_virtualizable_token(&mut self, token: u64) {
+    pub fn force_virtualizable_token(&mut self, token: u64) -> Option<(Vec<i64>, Vec<i64>)> {
         let fallback_alloc = crate::resume::NullAllocator;
         let allocator: &dyn crate::resume::BlackholeAllocator = self
             .blackhole_allocator
             .as_deref()
             .unwrap_or(&fallback_alloc);
         self.meta
-            .force_virtualizable_token_with_allocator(token, allocator);
+            .force_virtualizable_token_with_allocator(token, allocator)
     }
 
     fn prepare_exit_resume_heap_with_blackhole_allocator(
@@ -6205,6 +6206,7 @@ impl<S: JitState> JitDriver<S> {
                         .map(|a| a.as_ref() as &dyn crate::resume::VirtualizableInfo),
                     None, // ginfo
                     vable_identity_override,
+                    None, // all_virtuals
                     allocator,
                 );
                 if let Some((mut bh, vable_ptr)) = bh {

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -1157,6 +1157,17 @@ pub struct MetaInterp<M: Clone> {
     /// Used to derive lengths from the actual object when the interpreter
     /// does not provide them explicitly.
     pub(crate) vable_ptr: *const u8,
+    /// `compile.py:999-1000` — the virtual cache `handle_async_forcing`
+    /// produced, kept for the `GUARD_NOT_FORCED` failure that must follow.
+    ///
+    /// Upstream hides an `AllVirtuals` instance in the deadframe's
+    /// `jf_savedata` GCREF slot and `ResumeGuardForcedDescr.handle_fail`
+    /// fishes it back out. pyre cannot put a Rust value there — the GC
+    /// traces `jf_savedata` as a real object reference
+    /// (`jitframe.rs:278`) — so the cache is held here, keyed by the
+    /// virtualizable that was forced. One entry per frame, overwritten on
+    /// re-force, exactly like the single `jf_savedata` word.
+    pub(crate) forced_virtuals: Vec<(u64, Vec<i64>, Vec<i64>)>,
     /// Virtualizable array lengths for trace-entry box layout.
     pub(crate) vable_array_lengths: Vec<usize>,
     /// warmspot.py:449 jd.result_type — per-driver static result type.
@@ -2479,6 +2490,7 @@ impl<M: Clone> MetaInterp<M> {
             pending_token: None,
             stats: JitStatsCounters::default(),
             vable_ptr: std::ptr::null(),
+            forced_virtuals: Vec::new(),
             vable_array_lengths: Vec::new(),
             result_type: Type::Ref,
             max_unroll_recursion: 7, // RPython default from rlib/jit.py
@@ -11721,7 +11733,7 @@ impl<M: Clone> MetaInterp<M> {
         &mut self,
         token: u64,
         allocator: &dyn crate::resume::BlackholeAllocator,
-    ) {
+    ) -> Option<(Vec<i64>, Vec<i64>)> {
         let deadframe = self
             .backend
             .force(GcRef(token as usize))
@@ -11746,13 +11758,43 @@ impl<M: Clone> MetaInterp<M> {
                 Type::Void => 0,
             })
             .collect::<Vec<_>>();
-        let _ = self.handle_async_forcing_with_allocator(
+        // compile.py:995-1000: the forced cache is returned so the caller can
+        // attach it to the frame this force belongs to.
+        self.handle_async_forcing_with_allocator(
             green_key,
             trace_id,
             fail_index,
             &fail_values,
             allocator,
-        );
+        )
+    }
+
+    /// `compile.py:1000 cpu.set_savedata_ref(deadframe, obj.hide())`.
+    ///
+    /// `owner` is the forced virtualizable. Upstream can key on the deadframe
+    /// because `handle_fail` receives it; pyre's guard-failure path surfaces
+    /// the frame rather than the jitframe, and the two ends agree on the
+    /// frame: the force runs against a named virtualizable and the
+    /// GUARD_NOT_FORCED that follows deopts that same frame's loop.
+    pub fn save_forced_virtuals(&mut self, owner: u64, ptrs: Vec<i64>, ints: Vec<i64>) {
+        match self.forced_virtuals.iter_mut().find(|e| e.0 == owner) {
+            // A second force of the same frame overwrites, the way a second
+            // `set_savedata_ref` overwrites the one `jf_savedata` word.
+            Some(entry) => *entry = (owner, ptrs, ints),
+            None => self.forced_virtuals.push((owner, ptrs, ints)),
+        }
+    }
+
+    /// `compile.py:706-709` — `handle_fail` of a `GUARD_NOT_FORCED` fishes
+    /// the cache `handle_async_forcing` left on the deadframe and hands it
+    /// to `resume_in_blackhole`, which is what makes the blackhole reuse
+    /// the objects the force already materialized instead of building a
+    /// second set (`resume.py:1373-1374`, and the `vable_size` skip in
+    /// `consume_vref_and_vable`).
+    pub fn take_forced_virtuals(&mut self, owner: u64) -> Option<(Vec<i64>, Vec<i64>)> {
+        let index = self.forced_virtuals.iter().position(|e| e.0 == owner)?;
+        let (_, ptrs, ints) = self.forced_virtuals.swap_remove(index);
+        Some((ptrs, ints))
     }
 
     pub fn is_force_token_armed(&self, token: u64) -> bool {

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -11710,10 +11710,13 @@ impl<M: Clone> MetaInterp<M> {
     }
 
     /// Force a running virtualizable identified by its backend force token.
-    pub fn force_virtualizable_token(&mut self, token: u64) {
-        self.force_virtualizable_token_with_allocator(token, &crate::resume::NullAllocator);
-    }
-
+    ///
+    /// `compile.py:966-1000 ResumeGuardForcedDescr.force_now` has no
+    /// allocator-free form: the resume decode it drives materializes every
+    /// virtual a vable slot names.  So there is deliberately no
+    /// `NullAllocator` convenience wrapper here — callers go through
+    /// `JitDriver::force_virtualizable_token`, which supplies the registered
+    /// blackhole allocator.
     pub fn force_virtualizable_token_with_allocator(
         &mut self,
         token: u64,

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -11785,7 +11785,7 @@ impl<M: Clone> MetaInterp<M> {
         }
     }
 
-    /// `compile.py:706-709` — `handle_fail` of a `GUARD_NOT_FORCED` fishes
+    /// `compile.py:956-958` — `handle_fail` of a `GUARD_NOT_FORCED` fishes
     /// the cache `handle_async_forcing` left on the deadframe and hands it
     /// to `resume_in_blackhole`, which is what makes the blackhole reuse
     /// the objects the force already materialized instead of building a

--- a/majit/majit-metainterp/src/resume.rs
+++ b/majit/majit-metainterp/src/resume.rs
@@ -7399,7 +7399,7 @@ pub fn blackhole_from_resumedata<'a>(
     // resume.py:1312 `blackhole_from_resumedata(..., all_virtuals=None)`.
     // `Some` only when resuming from a GUARD_NOT_FORCED whose
     // `handle_async_forcing` already materialized the virtuals
-    // (compile.py:706-709): the reader then runs with
+    // (compile.py:956-958): the reader then runs with
     // `resume_after_guard_not_forced == 2`, reuses this cache and leaves
     // the already-forced virtualizable alone.
     all_virtuals: Option<(Vec<i64>, Vec<i64>)>,

--- a/majit/majit-metainterp/src/resume.rs
+++ b/majit/majit-metainterp/src/resume.rs
@@ -5189,6 +5189,7 @@ mod tests {
             None,
             None,
             None,
+            None, // all_virtuals
             &NullAllocator,
         )
         .expect("runtime-only jitcode should still resume");
@@ -7395,6 +7396,13 @@ pub fn blackhole_from_resumedata<'a>(
     vinfo: Option<&dyn VirtualizableInfo>,
     ginfo: Option<&dyn GreenfieldInfo>,
     virtualizable_identity_override: Option<i64>,
+    // resume.py:1312 `blackhole_from_resumedata(..., all_virtuals=None)`.
+    // `Some` only when resuming from a GUARD_NOT_FORCED whose
+    // `handle_async_forcing` already materialized the virtuals
+    // (compile.py:706-709): the reader then runs with
+    // `resume_after_guard_not_forced == 2`, reuses this cache and leaves
+    // the already-forced virtualizable alone.
+    all_virtuals: Option<(Vec<i64>, Vec<i64>)>,
     allocator: &'a dyn BlackholeAllocator,
 ) -> Option<(BlackholeInterpreter, i64)> {
     // resume.py:1315-1327 The initialization is stack-critical code: it
@@ -7407,18 +7415,28 @@ pub fn blackhole_from_resumedata<'a>(
     // all re-enable the report_error flag.
     let _cc_guard = crate::CriticalCodeGuard::enter();
     // resume.py:1317-1321
+    let resuming_after_guard_not_forced = all_virtuals.is_some();
     let mut resumereader = ResumeDataDirectReader::new(
         rd_numb,
         rd_consts,
         all_liveness,
         deadframe,
         deadframe_types,
-        None,
+        all_virtuals,
         allocator,
     );
 
-    let _resume_roots =
-        prepare_resume_heap_with_roots(&mut resumereader, rd_virtuals, rd_guard_pendingfields);
+    // resume.py:1368-1375: `_prepare` — and so both `_prepare_virtuals` and
+    // `_prepare_pendingfields` — runs only in the `all_virtuals is None`
+    // case. Resuming after a GUARD_NOT_FORCED, the force's own reader
+    // already built the virtuals and applied the pending fields; redoing
+    // either would rebuild the objects it handed to the interpreter and
+    // replay its heap writes.
+    let _resume_roots = if resuming_after_guard_not_forced {
+        prepare_resume_heap_with_roots(&mut resumereader, None, None)
+    } else {
+        prepare_resume_heap_with_roots(&mut resumereader, rd_virtuals, rd_guard_pendingfields)
+    };
 
     // resume.py:1325
     resumereader.consume_vref_and_vable(vrefinfo, vinfo, ginfo, virtualizable_identity_override);

--- a/pyre/bench/synth/getframe_caller_locals_nested_compiled_callee.py
+++ b/pyre/bench/synth/getframe_caller_locals_nested_compiled_callee.py
@@ -12,6 +12,16 @@
 #      went through an allocator that could not materialize the virtual the
 #      slot named -- and a null slot reads back as an ABSENT name, so
 #      `f_locals['acc']` raised KeyError instead of returning a value.
+#
+# pyre-check: skip-backends=wasm
+# The wasm backend cannot force a running frame at all, so it reaches neither
+# defect: `OpCode::ForceToken` lowers to a literal `0` sentinel
+# (`majit-backend-wasm/src/codegen.rs:4225`), so the compiled loop stores 0 into
+# `vable_token` and `force_virtualizable_if_necessary` never forces; and the
+# backend does not override `force()` (`majit-backend/src/lib.rs:2170` returns
+# None), so it has no deadframe to decode if it did. wasm keeps loop state in
+# wasm locals rather than a heap jitframe, so a mid-execution force is a wasm
+# backend epic of its own, not a variant of the two defects above.
 import sys
 
 

--- a/pyre/bench/synth/getframe_caller_locals_nested_compiled_callee.py
+++ b/pyre/bench/synth/getframe_caller_locals_nested_compiled_callee.py
@@ -1,0 +1,35 @@
+# Regression guard: a callee that reads its CALLER's frame via sys._getframe(1)
+# must see the caller's live locals, even though the callee has a hot loop of its
+# own and so takes its own compiled-loop entry from inside the caller's running
+# compiled loop.
+#
+# Two defects met here and produced a JIT-only wrong answer (acc frozen at the
+# value it held when the caller's loop was compiled):
+#   1. the force was skipped, because it required the frame to equal
+#      `MetaInterp::vable_ptr` and the callee's compiled entry had re-pointed
+#      that cell at the callee frame with no restore;
+#   2. once the force ran it wrote a null over `acc`, because the resume decode
+#      went through an allocator that could not materialize the virtual the
+#      slot named -- and a null slot reads back as an ABSENT name, so
+#      `f_locals['acc']` raised KeyError instead of returning a value.
+import sys
+
+
+def inner(k):
+    s = 0
+    for j in range(3):        # callee's own hot loop -> its own compiled entry
+        s += j * k
+    if k > 29990:
+        g = sys._getframe(1)  # the CALLER's frame, mid-activation
+        return s + g.f_locals['acc']
+    return s
+
+
+def outer(n):
+    acc = 0                   # loop-carried, virtual inside the compiled loop
+    for i in range(n):
+        acc += inner(i) & 7
+    return acc
+
+
+print(outer(30000))

--- a/pyre/bench/synth/getframe_caller_locals_nested_compiled_callee.py
+++ b/pyre/bench/synth/getframe_caller_locals_nested_compiled_callee.py
@@ -1,3 +1,11 @@
+# pyre-check: skip-backends=wasm
+# wasm still gets this WRONG, for a cause neither fix below can reach. It is
+# exempted so the guard stays meaningful on the backends it guards -- not because
+# wasm is right here. Measured: wasm reads 3691 on all nine `f_locals['acc']`
+# reads while the truth walks 104967 -> 105000, printing 104995; dynasm,
+# cranelift, PYRE_NO_JIT=1 and CPython all print 105005 -- stale in exactly the
+# way defect 1 was. See the wasm note at the bottom of this header.
+#
 # Regression guard: a callee that reads its CALLER's frame via sys._getframe(1)
 # must see the caller's live locals, even though the callee has a hot loop of its
 # own and so takes its own compiled-loop entry from inside the caller's running
@@ -13,15 +21,19 @@
 #      slot named -- and a null slot reads back as an ABSENT name, so
 #      `f_locals['acc']` raised KeyError instead of returning a value.
 #
-# pyre-check: skip-backends=wasm
-# The wasm backend cannot force a running frame at all, so it reaches neither
-# defect: `OpCode::ForceToken` lowers to a literal `0` sentinel
-# (`majit-backend-wasm/src/codegen.rs:4225`), so the compiled loop stores 0 into
-# `vable_token` and `force_virtualizable_if_necessary` never forces; and the
-# backend does not override `force()` (`majit-backend/src/lib.rs:2170` returns
-# None), so it has no deadframe to decode if it did. wasm keeps loop state in
-# wasm locals rather than a heap jitframe, so a mid-execution force is a wasm
-# backend epic of its own, not a variant of the two defects above.
+# wasm note. It is not a blanket wasm `f_locals` failure: a caller local read
+# through sys._getframe(1) is correct on wasm when the callee does not take a
+# compiled entry of its own from inside the caller's running loop. That shape is
+# what breaks it, and it breaks the invariant the wasm backend states three times
+# to justify lowering `GuardNotForced` to a no-op and calling may-force residuals
+# directly -- "the wasm virtualizable is always materialized"
+# (`majit-backend-wasm/src/codegen.rs:859`, `:908`, `:950`; the no-op guard at
+# `:2175`). Neither fix above can repair it: `OpCode::ForceToken` lowers to a
+# literal `0` sentinel (`codegen.rs:4225`), so the compiled loop stores 0 into
+# `vable_token` and `force_virtualizable_if_necessary` never forces; and wasm does
+# not override `force()` (`majit-backend/src/lib.rs:2170` returns None), so there
+# is no deadframe to decode even if it did. wasm holds loop state in wasm locals
+# rather than a heap jitframe, so forcing mid-execution is a wasm backend epic.
 import sys
 
 

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -611,6 +611,42 @@ def synth_perf_gate(path):
     return None
 
 
+def synth_skip_backends(path):
+    """Read an optional per-fixture backend exemption from its header:
+        # pyre-check: skip-backends=wasm
+
+    For a fixture that guards a mechanism a backend does not implement at
+    all, so the fixture can only ever restate that known gap. The named
+    backends print `skip` instead of running, the way
+    `run_bench(skip_backends=...)` already does.
+
+    This is not a way to park a failure: the header line must be followed by
+    a comment saying which mechanism is missing, so the exemption is
+    reviewable next to the workload. Unknown backend names are an error, not
+    a silent no-op — a typo would otherwise read as "exempted".
+    """
+    prefix = "# pyre-check: skip-backends="
+    with open(path, encoding="utf-8") as source:
+        for _ in range(20):
+            line = source.readline()
+            if not line:
+                break
+            if not line.startswith(prefix):
+                continue
+            names = [n.strip() for n in line[len(prefix):].split(",")]
+            names = [n for n in names if n]
+            if not names:
+                raise ValueError(f"empty synthetic backend exemption in {path}: {line.strip()}")
+            unknown = [n for n in names if n not in ALL_BACKENDS]
+            if unknown:
+                raise ValueError(
+                    f"unknown backend(s) {unknown} in synthetic backend exemption in {path}: "
+                    f"{line.strip()}"
+                )
+            return tuple(names)
+    return ()
+
+
 def default_binary(backend):
     name = CARGO_CONFIG[backend]["bin"]
     return f"./target/release/{name}{EXE}"
@@ -1509,6 +1545,7 @@ class Check:
         effective_timeout = scaled_timeout(timeout, self.args.timeout_scale)
         try:
             max_pypy_ratio = synth_perf_gate(path)
+            skip_backends = synth_skip_backends(path)
         except ValueError as e:
             print(f"{red('ERROR')}: {e}")
             sys.exit(1)
@@ -1560,6 +1597,14 @@ class Check:
 
         for backend in ALL_BACKENDS:
             if not self.enabled(backend):
+                continue
+            # `# pyre-check: skip-backends=` — the fixture guards a mechanism
+            # this backend does not implement, so running it here would only
+            # restate that gap.
+            if backend in skip_backends:
+                sys.stdout.write(f"    {backend:<10s}")
+                print(dim("skip"))
+                self._append_comparison(backend, name, t_cpython, t_pypy, "skip")
                 continue
             # wasm carries no perf-ratio gate, matching `run_bench` (which has no
             # `wasm_vs_*` parameter at all): it legitimately runs a few× slower

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -623,7 +623,15 @@ def synth_skip_backends(path):
     This is not a way to park a failure: the header line must be followed by
     a comment saying which mechanism is missing, so the exemption is
     reviewable next to the workload. Unknown backend names are an error, not
-    a silent no-op — a typo would otherwise read as "exempted".
+    a silent no-op — a typo would otherwise read as "exempted". A directive
+    below the 20-line window is likewise not silently honored: the fixture
+    simply runs everywhere and goes red, which is the safe direction.
+
+    The exemption covers a backend's *execution* only. It deliberately does
+    NOT cover the three baseline-failure paths below (cpython crash, pypy
+    crash, cpython/pypy output mismatch): those mean the fixture itself is
+    broken, and that must stay loud on every backend rather than be hidden
+    behind an exemption written for a different reason.
     """
     prefix = "# pyre-check: skip-backends="
     with open(path, encoding="utf-8") as source:

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -2000,7 +2000,7 @@ pub fn blackhole_resume_via_rd_numb(
     // consume a phantom vable and dereference garbage; a novable resume passes
     // `None` for both the vinfo and the per-frame virtualizable handle.
     novable: bool,
-    // compile.py:706-709 — the cache `handle_async_forcing` already
+    // compile.py:956-958 — the cache `handle_async_forcing` already
     // materialized, when this resume is the GUARD_NOT_FORCED that follows a
     // force. `None` for every other guard.
     all_virtuals: Option<(Vec<i64>, Vec<i64>)>,

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -1794,6 +1794,21 @@ fn jit_blackhole_resume_from_guard(
         // callee delivers its pending exception to the blackhole resume
         // instead of resuming the no-exception continuation with a NULL
         // result.
+        // compile.py:950-958 `ResumeGuardForcedDescr.handle_fail` fishes the
+        // cache `handle_async_forcing` saved; no other `handle_fail` does.
+        // `fail_values[0]` IS the callee's `PyFrame*` for the Python portal
+        // (the entry-green-key recovery above relies on the same contract), so
+        // it names the frame a force would have attached its cache to.
+        let all_virtuals = if descr_arc.is_guard_forced() {
+            crate::eval::take_forced_virtuals_for_frame(
+                fail_values
+                    .first()
+                    .map(|v| *v as *const pyre_interpreter::pyframe::PyFrame)
+                    .unwrap_or(std::ptr::null()),
+            )
+        } else {
+            None
+        };
         let result = blackhole_resume_via_rd_numb(
             &storage.rd_numb,
             storage.rd_consts(),
@@ -1803,6 +1818,7 @@ fn jit_blackhole_resume_from_guard(
             deadframe_types.as_deref(),
             guard_exc,
             false, // CALL_ASSEMBLER portal is jd0 (virtualizable)
+            all_virtuals,
         );
         return handle_blackhole_result(result, actual_green_key);
     }
@@ -1984,6 +2000,10 @@ pub fn blackhole_resume_via_rd_numb(
     // consume a phantom vable and dereference garbage; a novable resume passes
     // `None` for both the vinfo and the per-frame virtualizable handle.
     novable: bool,
+    // compile.py:706-709 — the cache `handle_async_forcing` already
+    // materialized, when this resume is the GUARD_NOT_FORCED that follows a
+    // force. `None` for every other guard.
+    all_virtuals: Option<(Vec<i64>, Vec<i64>)>,
 ) -> BlackholeResult {
     // Same window as `handle_fail`, for every blackhole resume including the
     // CALL_ASSEMBLER caller: the decode below rebuilds virtuals through the
@@ -2126,6 +2146,7 @@ pub fn blackhole_resume_via_rd_numb(
             vinfo_arg,              // resume.py:1312 self.jitdriver_sd.virtualizable_info
             None,                   // resume.py:1316 greenfield_info unused in pyre
             None,                   // heap PyFrame identity remains the live TAGBOX
+            all_virtuals,           // resume.py:1373-1374 GUARD_NOT_FORCED cache
             &allocator,
         )
     });
@@ -3795,10 +3816,19 @@ pub extern "C" fn wasm_ca_resume_deopt(frame_ptr: i64, compiled_ptr: i64) -> i64
             {
                 return result;
             }
+            // compile.py:950-958 `ResumeGuardForcedDescr.handle_fail`: only a
+            // GUARD_NOT_FORCED failure fishes the cache the force saved, keyed
+            // by the callee frame `raw_values[0]` names.
+            let forced_cache_owner = if descr_arc.is_guard_forced() {
+                callee_frame as *const pyre_interpreter::pyframe::PyFrame
+            } else {
+                std::ptr::null()
+            };
             let bh = crate::eval::resume_in_blackhole_from_exit_layout(
                 &raw_values,
                 &exit_layout,
                 guard_exc,
+                forced_cache_owner,
                 false,
             );
             handle_blackhole_result(bh, green_key).unwrap_or(0)

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -3933,7 +3933,7 @@ unsafe extern "C" fn force_pyframe(frame: *mut pyre_interpreter::PyFrame) {
                 majit_metainterp::virtualizable::VableToken::TracingRescall
             )
         });
-        // `virtualizable.py:214-217 force_virtualizable_if_necessary` decides
+        // `virtualizable.py:282-284 force_virtualizable_if_necessary` decides
         // this from the frame's OWN `vable_token` and nothing else.  An inlined
         // callee materialized through a virtual reference is an ordinary frame,
         // not the standard virtualizable, and its token slot is not part of its

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -3962,7 +3962,15 @@ unsafe extern "C" fn force_pyframe(frame: *mut pyre_interpreter::PyFrame) {
                 // Decoding it through `NullAllocator` instead wrote a null over
                 // that slot, and `fast2locals` renders a null slot as an absent
                 // name — a live local vanished from `f_locals`.
-                driver.force_virtualizable_token(token);
+                let all_virtuals = driver.force_virtualizable_token(token);
+                // compile.py:999-1000 set_savedata_ref: hold what was
+                // materialized for the GUARD_NOT_FORCED that follows, keyed by
+                // the frame this force ran against.
+                if let Some((ptrs, ints)) = all_virtuals {
+                    driver
+                        .meta_interp_mut()
+                        .save_forced_virtuals(ptr as u64, ptrs, ints);
+                }
             });
         };
         // Force the traced frame only when the frame handed to Python belongs
@@ -5433,7 +5441,14 @@ fn drive_unpack_iterable_trace(
             }
             // compile.py:710-716 resume_in_blackhole: complete the in-flight
             // `next()`/`append` and run forward to the next merge point.
-            let bh = resume_in_blackhole_from_exit_layout(&values, &exit_layout, guard_exc, true);
+            let bh = resume_in_blackhole_from_exit_layout(
+                &values,
+                &exit_layout,
+                guard_exc,
+                // jd1 is novable: it has no virtualizable to force.
+                std::ptr::null(),
+                true,
+            );
             match bh {
                 // Merge point reached: re-enter the compiled drain.
                 crate::call_jit::BlackholeResult::ContinueRunningNormally { .. } => continue,
@@ -7493,6 +7508,57 @@ fn blackhole_result_tag(r: &crate::call_jit::BlackholeResult) -> &'static str {
     }
 }
 
+/// `compile.py:950-958 ResumeGuardForcedDescr.handle_fail` — the frame whose
+/// forced-virtual cache this guard failure may fish, or null.
+///
+/// Only the `GUARD_NOT_FORCED` / `GUARD_NOT_FORCED_2` failure reads the cache
+/// `handle_async_forcing` saved; every other `handle_fail` resumes with
+/// `all_virtuals = None`. `invent_fail_descr_for_op` marks exactly those two
+/// guards (`optimizeopt/mod.rs:6524`), so `is_guard_forced()` is the same
+/// discriminator upstream gets from the descr subtype.
+fn forced_guard_cache_owner(
+    descr_arc: &std::sync::Arc<dyn majit_ir::Descr>,
+    frame: *const pyre_interpreter::PyFrame,
+) -> *const pyre_interpreter::PyFrame {
+    if descr_arc.is_guard_forced() {
+        frame
+    } else {
+        std::ptr::null()
+    }
+}
+
+/// `compile.py:956-957` — `hidden_all_virtuals =
+/// metainterp_sd.cpu.get_savedata_ref(deadframe)`.
+///
+/// Upstream reads the cache straight out of the deadframe it is resuming,
+/// because `handle_fail` receives that deadframe. pyre's guard-failure path
+/// surfaces the running frame instead, so the cache is keyed by the frame the
+/// force ran against (`force_pyframe`) and taken back here by the same frame.
+///
+/// The jitframe address is not usable as the key: only cranelift populates
+/// `FailDescr::force_token_slots`, so on dynasm the failing exit does not name
+/// its own force token at all.
+///
+/// A miss returns `None`, which resumes the ordinary way. Upstream instead
+/// substitutes an empty `VirtualCache` (`compile.py:959-960`) and still runs
+/// the reader with `resume_after_guard_not_forced == 2` — it can, because a
+/// deadframe-local savedata slot cannot miss. A frame-keyed reconstruction
+/// can, and skipping the vable section with an empty virtuals cache would
+/// leave the resumed frame's virtuals unbound; falling back to a full decode
+/// is the same work pyre did before the cache existed.
+///
+// dont_look_inside: post-trace blackhole resume machinery.
+#[majit_macros::dont_look_inside]
+pub(crate) fn take_forced_virtuals_for_frame(
+    frame: *const pyre_interpreter::PyFrame,
+) -> Option<(Vec<i64>, Vec<i64>)> {
+    if frame.is_null() {
+        return None;
+    }
+    let (driver, _) = driver_pair();
+    driver.meta_interp_mut().take_forced_virtuals(frame as u64)
+}
+
 /// compile.py:710-716 resume_in_blackhole parity.
 ///
 /// RPython: resume_in_blackhole → blackhole_from_resumedata →
@@ -7504,6 +7570,10 @@ pub(crate) fn resume_in_blackhole_from_exit_layout(
     raw_values: &[i64],
     exit_layout: &CompiledExitLayout,
     guard_exc: i64,
+    // `forced_guard_cache_owner` of the failing guard: the frame whose
+    // forced-virtual cache this resume may fish, null for any guard that is
+    // not a GUARD_NOT_FORCED.
+    forced_cache_owner: *const pyre_interpreter::PyFrame,
     // True when the failing guard belongs to a novable jitdriver (jd1
     // `unpackiterable_driver`): its resume data has no vable section, so the
     // decode must not consume one. jd0 guards pass `false`.
@@ -7536,6 +7606,7 @@ pub(crate) fn resume_in_blackhole_from_exit_layout(
                 exit_layout.fail_index,
             )
         };
+        let all_virtuals = take_forced_virtuals_for_frame(forced_cache_owner);
         let result = crate::call_jit::blackhole_resume_via_rd_numb(
             &storage.rd_numb,
             storage.rd_consts(),
@@ -7545,6 +7616,7 @@ pub(crate) fn resume_in_blackhole_from_exit_layout(
             deadframe_types.as_deref(),
             guard_exc,
             novable,
+            all_virtuals,
         );
         if majit_metainterp::majit_log_enabled() {
             eprintln!(
@@ -7835,6 +7907,7 @@ fn execute_assembler(
                         raw_values,
                         exit_layout,
                         guard_exc,
+                        forced_guard_cache_owner(descr_arc, frame_root.frame()),
                         false,
                     );
                     match &bh_result {
@@ -8173,6 +8246,7 @@ fn bound_reached(
                         raw_values,
                         exit_layout,
                         guard_exc,
+                        forced_guard_cache_owner(descr_arc, frame_root.frame()),
                         false,
                     );
                     match &bh_result {
@@ -8385,6 +8459,7 @@ pub fn try_function_entry_jit(frame: &mut PyFrame) -> Option<PyResult> {
                         raw_values,
                         exit_layout,
                         guard_exc,
+                        forced_guard_cache_owner(descr_arc, frame_root.frame()),
                         false,
                     );
                     match &bh_result {

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -3933,25 +3933,36 @@ unsafe extern "C" fn force_pyframe(frame: *mut pyre_interpreter::PyFrame) {
                 majit_metainterp::virtualizable::VableToken::TracingRescall
             )
         });
-        // `pyjitpl.py:3326-3334` reads the token only from
-        // `virtualizable_boxes[-1]`.  An inlined callee materialized through
-        // a virtual reference is an ordinary frame, not that one standard
-        // virtualizable, and its token slot is not part of its resume image.
-        let standard_frame = driver
-            .meta_interp()
-            .standard_virtualizable_heap_ptr()
-            .cast_mut()
-            .cast::<pyre_interpreter::PyFrame>();
-        let live_frame_armed = std::ptr::eq(frame, standard_frame)
-            && match info.read_token(frame.cast()) {
-                majit_metainterp::virtualizable::VableToken::Active(token) => {
-                    driver.meta_interp_mut().is_force_token_armed(token)
-                }
-                _ => false,
-            };
+        // `virtualizable.py:214-217 force_virtualizable_if_necessary` decides
+        // this from the frame's OWN `vable_token` and nothing else.  An inlined
+        // callee materialized through a virtual reference is an ordinary frame,
+        // not the standard virtualizable, and its token slot is not part of its
+        // resume image: `PyFrame` is built with `vable_token: 0` and the
+        // materialization never writes the slot, so the token read already
+        // excludes it.
+        //
+        // Comparing against `MetaInterp::vable_ptr` as well named the WRONG
+        // frame.  That cell is rewritten by every `sync_before`, including the
+        // entry a callee's own compiled loop takes from inside the caller's
+        // running loop, and nothing restores it when the callee returns — so
+        // the caller stopped matching for the rest of its own activation, and a
+        // callee reading the caller's frame through `sys._getframe(1)` saw
+        // fields the caller's compiled loop was still holding in registers.
+        let live_frame_armed = match info.read_token(frame.cast()) {
+            majit_metainterp::virtualizable::VableToken::Active(token) => {
+                driver.meta_interp_mut().is_force_token_armed(token)
+            }
+            _ => false,
+        };
         let mut force = |ptr: *mut u8| {
             info.force_virtualizable_if_necessary(ptr, |token| {
-                driver.meta_interp_mut().force_virtualizable_token(token);
+                // `compile.py:966-1000 ResumeGuardForcedDescr.force_now` decodes
+                // the resume data with the same allocator ordinary guard failure
+                // uses, so a vable slot whose value is a virtual is materialized.
+                // Decoding it through `NullAllocator` instead wrote a null over
+                // that slot, and `fast2locals` renders a null slot as an absent
+                // name — a live local vanished from `f_locals`.
+                driver.force_virtualizable_token(token);
             });
         };
         // Force the traced frame only when the frame handed to Python belongs


### PR DESCRIPTION
Three stacked defects in one code path — a callee reading its **caller's** frame
through `sys._getframe(1)` saw the caller's locals frozen at the value they held
when the caller's loop was compiled. Silent wrong answer on both native backends,
no crash, no abort.

Regression fixture: `bench/synth/getframe_caller_locals_nested_compiled_callee.py`
— `104995` before, `105005` after, matching `PYRE_NO_JIT=1` and CPython.

## L1 — the force was skipped (`force_pyframe`)

`sys._getframe(depth)` does force the frame it hands out, so `force_pyframe` was
reached with the caller frame. It then additionally required
`ptr::eq(frame, MetaInterp::vable_ptr)`. That cell is written only by
`sync_before`, and the callee's *own* compiled-loop entry runs `sync_before` from
inside the caller's still-running loop, re-pointing it at the callee frame. Nothing
restores it — `sync_before` (8 sites) and `sync_after` (7 sites) are not paired
1:1 — so the caller stopped matching for the rest of its activation.

Fixed by testing the frame's own `vable_token`, which is what
`virtualizable.py:282-284 force_virtualizable_if_necessary` does. Safe because
`PyFrame` is built with `vable_token: 0` (`pyframe.rs:3790`, `:4096`) and
materialization never writes the slot.

## L2 — the force then wrote NULL over a live local

With L1 fixed the fixture raised `KeyError: 'acc'`. The force went through
`MetaInterp::force_virtualizable_token`, hardcoded to `NullAllocator`, whose
`BlackholeAllocator` default method bodies return `0`. A vable slot whose resume
value is a *virtual* therefore materialized as `0`, and `fast2locals` renders a
null slot as an **absent name**.

Fixed by routing through `JitDriver::force_virtualizable_token`, which supplies
the registered blackhole allocator, and deleting the `NullAllocator` wrapper so
the footgun cannot be re-picked. `compile.py:966-1000 force_now` has no
allocator-free form.

An earlier hypothesis — that the resume image did not cover every vable array
slot — was **refuted**: `consume_vable_info` asserts
`get_total_size(virtualizable) == vable_size - 1`, so a short vector would panic
rather than silently null.

## L3 — the async-forcing virtual cache was discarded

`force_virtualizable_token_with_allocator` dropped what
`handle_async_forcing_with_allocator` returned, so the `GUARD_NOT_FORCED` failure
that follows a force decoded the resume data **again** through a fresh
`ResumeDataDirectReader`.

Measured by probing `write_from_resume_data_partial` with
`reader.resume_after_guard_not_forced` (`ragnf`):

| | forced frame |
|---|---|
| before | 5× `ragnf=1` (the forces) **+ 5× `ragnf=0`** (the re-decode); the second pass installed a *different* pointer for a slot the first had materialized (`item[1] 0x…9140 → 0x…91c0`) |
| after | 5× `ragnf=1`, **0× `ragnf=0`**; each force consumed exactly once, nothing left pending |

`ResumeDataDirectReader::new` already implemented the `all_virtuals is Some` →
`(2, from_caches(..))` branch (`resume.rs:6134`) — it had simply never been
passed a `Some`. Only the producer, the store and the consumer were missing.
With `ragnf == 2`, `consume_vref_and_vable` jumps the vable section and the vref
pairs, and `_prepare` is skipped entirely, so neither `_prepare_virtuals` nor
`_prepare_pendingfields` runs (`resume.py:1368-1375`).

Two upstream mechanisms are unavailable here, each forcing a documented choice:

- **`jf_savedata` cannot hold the cache.** The GC traces it as a real object
  reference (`majit-backend/src/jitframe.rs:120` is a `usize`, `:278`
  `trace_callback(&mut (*obj_addr).jf_savedata)`), so a leaked Rust value there
  would be walked as a heap object. The cache lives on
  `MetaInterp::forced_virtuals` instead, one entry per frame, overwritten on
  re-force exactly like the single `jf_savedata` word.
- **`FailDescr::force_token_slots` cannot key it.** Only cranelift calls
  `set_force_token_slots`; dynasm leaves it empty. Keying on the jitframe address
  silently never hit on dynasm — that version was built and measured, and the
  `ragnf=0` re-write was still there. The working key is the identity both ends
  share: the forced `PyFrame`.

The consume side is gated on `Descr::is_guard_forced()`, the flag
`invent_fail_descr_for_op` sets for `GUARD_NOT_FORCED` / `GUARD_NOT_FORCED_2`, so
no other guard reads the cache — `compile.py:950-963` is the only `handle_fail`
that calls `get_savedata_ref`. A key **miss** falls back to a full decode rather
than `compile.py:959-960`'s empty `VirtualCache`, because a deadframe-local slot
cannot miss and a frame-keyed lookup can; an empty cache plus a skipped vable
section would leave the resumed virtuals unbound.

Five call sites need the new parameter, and a native `cargo check` sees only four
— the fifth is the **wasm** CALL_ASSEMBLER deopt path (`call_jit.rs:3819`).
`check.py` caught it.

## check.py: `# pyre-check: skip-backends=`

`run_bench` and `run_selfcheck` already took `skip_backends`; the synthetic suite
discovers fixtures by glob and had no equivalent. `synth_skip_backends` reads the
directive from the first 20 lines the way `synth_perf_gate` reads
`max-pypy-ratio=`. An unrecognized backend name raises rather than exempting
nothing, and a directive below the window makes the fixture run everywhere and go
red rather than being honored silently. The exemption deliberately does **not**
cover the three baseline-failure paths (cpython crash, pypy crash, cpython/pypy
mismatch) — a broken fixture must stay loud on every backend.

## Known wasm defect this exempts (not fixed here)

wasm still gets the fixture wrong, and the exemption is there so the guard stays
meaningful on the backends it guards — not because wasm is right.

Measured: wasm reads `3691` on all nine `f_locals['acc']` reads while the value
walks 104967 → 105000, printing `104995`; dynasm, cranelift, `PYRE_NO_JIT=1` and
CPython print `105005`. It is **not** a blanket wasm `f_locals` failure — the same
read is correct on wasm when the callee does not take a compiled entry of its own
from inside the caller's running loop. That shape breaks the invariant the wasm
backend states three times to justify lowering `GuardNotForced` to a no-op:
*"the wasm virtualizable is always materialized"*
(`majit-backend-wasm/src/codegen.rs:859`, `:908`, `:950`; the no-op guard at
`:2175`).

Neither fix above can reach it: `OpCode::ForceToken` lowers to a literal `0`
sentinel (`codegen.rs:4225`), so the compiled loop stores 0 into `vable_token` and
`force_virtualizable_if_necessary` never forces; and wasm does not override
`force()` (`majit-backend/src/lib.rs:2170` returns `None`), so there would be no
deadframe to decode. wasm holds loop state in wasm locals rather than a heap
jitframe, so forcing mid-execution is a wasm backend epic of its own.

## Also corrected

Four upstream citations that were wrong. `compile.py:706-709` was cited three
times for the `GUARD_NOT_FORCED` savedata fetch; those lines are the
`must_compile` branch of the *base* `ResumeGuardDescr.handle_fail`, and because
`ResumeGuardForcedDescr` overrides `handle_fail`, a forced guard never reaches
line 706 at all — the fetch is `compile.py:956-958`. `virtualizable.py:214-217`
was cited for `force_virtualizable_if_necessary`; those lines are
`cast_gcref_to_vtype` and the function is at `:282-284`.

## Not addressed

- `force_pyframe_vref` discards the cache `force_virtualizable_token` now returns,
  keeping the double-decode on the vref path. Its forced-frame identity is murkier
  than the direct `force_pyframe` case.
- The wasm force gap above.

An earlier note claiming pyre lacked upstream's *"failures of a GUARD_NOT_FORCED
are never compiled, but always just blackholed"* rule was **wrong**: pyre
implements it as descr dispatch, not an opcode check —
`call_jit.rs:2861 if descr_arc.is_guard_forced() { return BridgeResolution::ResumeBlackhole; }`.

## Verification

On base `d873f1396e` (#742):

- `check.py` — dynasm **344/344**, cranelift **344/344**, wasm **340/340**
- `bench/synth` JIT vs `PYRE_NO_JIT=1` differential — **329/329 identical** on
  both native backends
- `cargo test --release -p majit-metainterp --features dynasm --lib` — **1416
  passed**, 0 failed
- fixture prints `105005` on dynasm, cranelift, `PYRE_NO_JIT=1` and CPython

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of forced virtualizable state during JIT guard failures and deoptimization.
  * Prevented duplicate materialization and replay of virtual values when resuming execution.
  * Improved visibility of caller locals in nested compiled-loop scenarios.

* **Testing**
  * Added a synthetic benchmark covering nested compiled calls and frame-local access.
  * Added support for skipping explicitly unsupported backends in synthetic benchmarks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->