### PR TITLE
importing: demote module-dict functions to non-binding BuiltinFunction

### DIFF
--- a/pyre/bench/synth/module_function_not_descriptor.py
+++ b/pyre/bench/synth/module_function_not_descriptor.py
@@ -1,0 +1,69 @@
+# A function directly in a builtin module is a non-descriptor
+# `builtin_function_or_method` (no `__get__`), so storing it on a user class
+# and reading it through an instance does not synthesize a bound method and
+# does not inject `self`.  Mirrors mixedmodule.py:_load_lazily; guards the
+# demote_module_function_to_builtin pass at both call sites:
+#   - builtins.rs new_builtin_module_dict   (the `builtins` module: len)
+#   - importing.rs load_builtin_module      (every other builtin module:
+#       sys.exc_info from a non-macro register_module; math.sqrt; time.sleep)
+# A plain user `def` on a class is the control: it MUST still bind.
+#
+# A function that carries an instance attribute (populated `w_func_dict`) must
+# NOT be demoted: `builtin_function_or_method` has no instance `__dict__`, so
+# the retag would hide the attribute.  `itertools.chain` is a function-shaped
+# constructor whose `from_iterable` alternate constructor is attached as such
+# an attribute; demoting it dropped `chain.from_iterable`, which broke
+# `import unittest.mock` -> asyncio -> dataclasses.  It stays binding here.
+# Output verified against CPython 3.14.
+import sys
+import math
+import time
+import itertools
+
+
+def check_non_binding(f, expected_name):
+    assert type(f).__name__ == "builtin_function_or_method", type(f).__name__
+    assert not hasattr(type(f), "__get__"), expected_name
+    assert f.__name__ == expected_name, f.__name__
+
+    class C:
+        m = f
+
+    inst = C()
+    assert C.m is f
+    assert inst.m is f
+    assert type(inst.m).__name__ == "builtin_function_or_method"
+    assert getattr(inst.m, "__self__", None) is not inst
+
+
+def main():
+    check_non_binding(len, "len")                # builtins module dict path
+    check_non_binding(sys.exc_info, "exc_info")  # non-macro register_module path
+    check_non_binding(math.sqrt, "sqrt")         # macro-module inline function
+    check_non_binding(time.sleep, "sleep")       # non-macro register_module path
+
+    class C:
+        info = sys.exc_info
+
+    assert C().info() == (None, None, None)      # no implicit self injected
+
+    # A function carrying an attribute is left binding so the attribute
+    # survives — `itertools.chain.from_iterable` must remain reachable.
+    assert list(itertools.chain.from_iterable([[1, 2], [3], []])) == [1, 2, 3]
+    assert list(itertools.chain.from_iterable(["ab", "c"])) == ["a", "b", "c"]
+
+    class D:
+        def g(self):
+            return type(self).__name__
+
+    d = D()
+    assert type(D.g).__name__ == "function"
+    assert hasattr(type(D.g), "__get__")
+    assert type(d.g).__name__ == "method"
+    assert d.g.__self__ is d
+    assert d.g() == "D"
+
+    print("OK")
+
+
+main()

--- a/pyre/bench/synth/module_function_not_descriptor.py
+++ b/pyre/bench/synth/module_function_not_descriptor.py
@@ -1,65 +1,67 @@
-# A function directly in a builtin module is a non-descriptor
-# `builtin_function_or_method` (no `__get__`), so storing it on a user class
-# and reading it through an instance does not synthesize a bound method and
-# does not inject `self`.  Mirrors mixedmodule.py:_load_lazily; guards the
-# demote_module_function_to_builtin pass at both call sites:
+# A function directly in a builtin module is a non-descriptor builtin function
+# (no `__get__`), so storing it on a user class and reading it through an
+# instance returns the SAME function object — it does not synthesize a bound
+# method or inject `self`.  Mirrors mixedmodule.py:_load_lazily; guards
+# demote_module_function_to_builtin at both call sites:
 #   - builtins.rs new_builtin_module_dict   (the `builtins` module: len)
 #   - importing.rs load_builtin_module      (every other builtin module:
 #       sys.exc_info from a non-macro register_module; math.sqrt; time.sleep)
-# A plain user `def` on a class is the control: it MUST still bind.
-#
 # A function that carries an instance attribute (populated `w_func_dict`) must
-# NOT be demoted: `builtin_function_or_method` has no instance `__dict__`, so
-# the retag would hide the attribute.  `itertools.chain` is a function-shaped
-# constructor whose `from_iterable` alternate constructor is attached as such
-# an attribute; demoting it dropped `chain.from_iterable`, which broke
-# `import unittest.mock` -> asyncio -> dataclasses.  It stays binding here.
-# Output verified against CPython 3.14.
+# NOT be demoted (`builtin_function_or_method` has no instance `__dict__`, so
+# the retag would hide the attribute): `itertools.chain` keeps its
+# `from_iterable` alternate constructor, whose loss broke `import unittest.mock`
+# -> asyncio -> dataclasses.  A plain user `def` is the binding control.
+#
+# The exact builtin type name differs across interpreters (CPython/pyre 3.14
+# `builtin_function_or_method` vs PyPy `builtin_function`), so this asserts the
+# non-binding BEHAVIOUR, which is invariant.  Output verified on CPython 3.14,
+# PyPy, and pyre.
 import sys
 import math
 import time
 import itertools
 
+BUILTIN_FN_NAMES = ("builtin_function_or_method", "builtin_function")
 
-def check_non_binding(f, expected_name):
-    assert type(f).__name__ == "builtin_function_or_method", type(f).__name__
-    assert not hasattr(type(f), "__get__"), expected_name
-    assert f.__name__ == expected_name, f.__name__
+
+def check_non_binding(f):
+    tname = type(f).__name__
+    assert tname in BUILTIN_FN_NAMES, tname
+    assert not hasattr(type(f), "__get__"), tname
 
     class C:
         m = f
 
     inst = C()
-    assert C.m is f
-    assert inst.m is f
-    assert type(inst.m).__name__ == "builtin_function_or_method"
+    assert C.m is f            # class access does not transform a non-descriptor
+    assert inst.m is f         # instance access does NOT bind (the key property)
     assert getattr(inst.m, "__self__", None) is not inst
 
 
 def main():
-    check_non_binding(len, "len")                # builtins module dict path
-    check_non_binding(sys.exc_info, "exc_info")  # non-macro register_module path
-    check_non_binding(math.sqrt, "sqrt")         # macro-module inline function
-    check_non_binding(time.sleep, "sleep")       # non-macro register_module path
+    check_non_binding(len)           # builtins module dict path
+    check_non_binding(sys.exc_info)  # non-macro register_module path
+    check_non_binding(math.sqrt)     # macro-module inline function
+    check_non_binding(time.sleep)    # non-macro register_module path
 
     class C:
         info = sys.exc_info
 
     assert C().info() == (None, None, None)      # no implicit self injected
 
-    # A function carrying an attribute is left binding so the attribute
-    # survives — `itertools.chain.from_iterable` must remain reachable.
+    # `itertools.chain` carries `from_iterable` as an attribute, so it is left
+    # binding rather than demoted — the attribute must stay reachable.
     assert list(itertools.chain.from_iterable([[1, 2], [3], []])) == [1, 2, 3]
     assert list(itertools.chain.from_iterable(["ab", "c"])) == ["a", "b", "c"]
 
+    # a plain user `def` IS a descriptor and still binds through an instance
     class D:
         def g(self):
             return type(self).__name__
 
     d = D()
-    assert type(D.g).__name__ == "function"
     assert hasattr(type(D.g), "__get__")
-    assert type(d.g).__name__ == "method"
+    assert d.g is not D.g            # instance access binds -> a distinct object
     assert d.g.__self__ is d
     assert d.g() == "D"
 

--- a/pyre/bench/synth/module_function_not_descriptor.py
+++ b/pyre/bench/synth/module_function_not_descriptor.py
@@ -5,7 +5,7 @@
 # demote_module_function_to_builtin at both call sites:
 #   - builtins.rs new_builtin_module_dict   (the `builtins` module: len)
 #   - importing.rs load_builtin_module      (every other builtin module:
-#       sys.exc_info from a non-macro register_module; math.sqrt; time.sleep)
+#       sys.exc_info from a non-macro register_module; math.sqrt inline)
 # A function that carries an instance attribute (populated `w_func_dict`) must
 # NOT be demoted (`builtin_function_or_method` has no instance `__dict__`, so
 # the retag would hide the attribute): `itertools.chain` keeps its
@@ -15,10 +15,14 @@
 # The exact builtin type name differs across interpreters (CPython/pyre 3.14
 # `builtin_function_or_method` vs PyPy `builtin_function`), so this asserts the
 # non-binding BEHAVIOUR, which is invariant.  Output verified on CPython 3.14,
-# PyPy, and pyre.
+# PyPy, and pyre (dynasm/cranelift/wasm).
+#
+# Only modules present on every pyre backend are imported: the synth suite also
+# runs the wasm build, which does not register `time` (no libc `clock_gettime`),
+# so `time.sleep` is left out — `sys.exc_info` already covers the same non-macro
+# register_module path.
 import sys
 import math
-import time
 import itertools
 
 BUILTIN_FN_NAMES = ("builtin_function_or_method", "builtin_function")
@@ -42,7 +46,6 @@ def main():
     check_non_binding(len)           # builtins module dict path
     check_non_binding(sys.exc_info)  # non-macro register_module path
     check_non_binding(math.sqrt)     # macro-module inline function
-    check_non_binding(time.sleep)    # non-macro register_module path
 
     class C:
         info = sys.exc_info

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -2767,6 +2767,9 @@ pub fn new_builtin_module_dict() -> pyre_object::PyObjectRef {
     for key in &keys {
         if let Some(value) = unsafe { pyre_object::w_dict_getitem_str(w_dict, key) } {
             unsafe {
+                // MixedModule._load_lazily: a function directly in the builtins
+                // module is a non-descriptor `BuiltinFunction` (no `__get__`).
+                crate::function::demote_module_function_to_builtin(value);
                 crate::function::builtin_function_set_module(
                     value,
                     pyre_object::gc_roots::shadow_stack_get(save_point + 1),

--- a/pyre/pyre-interpreter/src/function.rs
+++ b/pyre/pyre-interpreter/src/function.rs
@@ -656,6 +656,36 @@ pub unsafe fn builtin_function_set_module_attr(obj: PyObjectRef, value: PyObject
     }
 }
 
+/// mixedmodule.py:_load_lazily — "all functions that are directly in a
+/// mixed-module are 'builtin', e.g. they get a special type without a
+/// `__get__`".  A module dict entry that is a globals-less
+/// `FunctionWithFixedCode` is retagged in place to `BuiltinFunction`
+/// (`BUILTIN_FUNCTION_TYPE`, whose typedef omits `__get__`) so storing it on a
+/// user class and reading it through an instance does not synthesize a bound
+/// method (`typedef.py:918 del BuiltinFunction.typedef.rawdict['__get__']`).
+///
+/// Both PyTypes share the `Function` layout and GC type id
+/// (`eval.rs` maps both to `function_tid`), so only `ob_type` (the binding
+/// dispatch tag read by `getdescriptor`) and `w_class` (the Python-visible
+/// `type()`) are retagged — code, name, and every other field are preserved
+/// and object identity is kept, so two dict keys aliasing one function stay
+/// identical.  Callers pass module dict values only; builtin-type methods live
+/// in type dicts, never reach this, and keep `Function.__get__` to bind as
+/// methods.  App-level functions carry globals and are left alone.
+///
+/// # Safety
+/// `obj` must be a valid, non-null pointer to a `PyObject`.
+pub unsafe fn demote_module_function_to_builtin(obj: PyObjectRef) {
+    unsafe {
+        if py_type_check(obj, &FUNCTION_TYPE)
+            && (*(obj as *const Function)).w_func_globals_obj.is_null()
+        {
+            (*obj).ob_type = &BUILTIN_FUNCTION_TYPE as *const PyType;
+            (*obj).w_class = pyre_object::pyobject::get_instantiate(&BUILTIN_FUNCTION_TYPE);
+        }
+    }
+}
+
 /// Stamp the `__self__` of a builtin `__new__` carrier — the defining
 /// type whose `tp_new` it wraps (`typeobject.c add_tp_new_wrapper`).
 /// Only touches functions whose `w_new_self` is still unset, so an

--- a/pyre/pyre-interpreter/src/function.rs
+++ b/pyre/pyre-interpreter/src/function.rs
@@ -673,12 +673,20 @@ pub unsafe fn builtin_function_set_module_attr(obj: PyObjectRef, value: PyObject
 /// in type dicts, never reach this, and keep `Function.__get__` to bind as
 /// methods.  App-level functions carry globals and are left alone.
 ///
+/// A function carrying instance attributes (`w_func_dict` populated) is also
+/// left alone: `BUILTIN_FUNCTION_TYPE` has no instance `__dict__` surface, so
+/// retagging would hide those attributes.  `itertools.chain` is a function-
+/// shaped constructor whose `from_iterable` alternate constructor is attached
+/// as an attribute (`itertools::register_module`), so demoting it would drop
+/// `chain.from_iterable` — kept binding here rather than lose the attribute.
+///
 /// # Safety
 /// `obj` must be a valid, non-null pointer to a `PyObject`.
 pub unsafe fn demote_module_function_to_builtin(obj: PyObjectRef) {
     unsafe {
         if py_type_check(obj, &FUNCTION_TYPE)
             && (*(obj as *const Function)).w_func_globals_obj.is_null()
+            && (*(obj as *const Function)).w_func_dict.is_null()
         {
             (*obj).ob_type = &BUILTIN_FUNCTION_TYPE as *const PyType;
             (*obj).w_class = pyre_object::pyobject::get_instantiate(&BUILTIN_FUNCTION_TYPE);

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -927,6 +927,10 @@ pub(crate) fn load_builtin_module(name: &str) -> Option<PyObjectRef> {
             unsafe { pyre_object::dictmultiobject::w_dict_getitem_str(w_dict, key) }
         {
             unsafe {
+                // MixedModule._load_lazily: every function directly in a
+                // mixed-module is a non-descriptor `BuiltinFunction` (no
+                // `__get__`), so storing it on a user class does not bind `self`.
+                crate::function::demote_module_function_to_builtin(value);
                 crate::function::builtin_function_set_module(
                     value,
                     pyre_object::gc_roots::shadow_stack_get(save_point + 1),


### PR DESCRIPTION
## Summary

Ports PyPy's `MixedModule._load_lazily` demotion (`pypy/interpreter/mixedmodule.py:112-139`)
to pyre: a function directly in a mixed-module is a non-descriptor
`BuiltinFunction` (no `__get__`), so storing it on a user class and reading it
through an instance does not synthesize a bound method.

New `demote_module_function_to_builtin` retags a globals-less `FUNCTION_TYPE`
object in place to `BUILTIN_FUNCTION_TYPE` — only `ob_type` (the binding
dispatch tag) and `w_class` (the Python-visible `type()`) change; code, name,
and every other field are preserved and object identity is kept. Both PyTypes
share the `Function` layout and GC type id, so the retag is sound and
allocation-free (`get_instantiate` is a cached atomic load).

Called at the two mixed-module namespace-load sites:
- `new_builtin_module_dict` (the `builtins` module)
- `load_builtin_module` (every other builtin module)

In `load_builtin_module` the demoted functions now also receive
`builtin_function_set_module_obj` in the second key loop (they are
`BUILTIN_FUNCTION_TYPE` after demotion), matching PyPy's
`bltin.w_moduleobj = self`.

## Parity notes (deliberate structural adaptations)

- **In-place retag vs. distinct wrapper**: PyPy creates a separate
  `BuiltinFunction(func)` cached as `func._builtinversion_`; pyre retags the
  single object to preserve identity/GC-tid. Callers pass module dict values
  only, so no external reference to a pre-demotion function exists.
- **globals-null guard**: pyre walks the whole completed module dict, so it
  excludes app-level functions (which carry globals) from demotion; PyPy's
  loader population is interp-level (globals-less) only, so behavior matches on
  the real population.
- `name`/`qualname` are preserved from the source function rather than set to
  the dict key, which diverges from PyPy only for aliased exports.

## Verification

- `cargo check -p pyre-interpreter` — clean
- `pyre/check.py --backend dynasm` — ALL PASSED: dynasm 343/343
- Codex parity review (scoped to this change): section 1 = none; section 2
  findings are all deliberate, already-documented structural adaptations.

— *commented by Claude*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of built-in functions retrieved from built-in modules so they remain non-descriptors when attached to user-defined classes (preventing unexpected instance binding).
  * Preserved standard binding behavior for user-defined methods.
  * Ensured consistent behavior for common built-ins like `len`, `math.sqrt`, and `sys.exc_info` across class and instance attribute access.

* **Tests**
  * Added a benchmark/test script that validates non-binding behavior for multiple built-in entry points and confirms related stdlib behaviors remain intact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->