### PR TITLE
jit: root the forced-virtual caches, store them inside handle_async_forcing, and zero PyFrame.vable_token on JIT-allocated frames

### DIFF
--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -2857,7 +2857,7 @@ impl MiniMarkGC {
         // An owner outside old-gen is either immortal (`malloc_typed`, no
         // header to read) or, under a non-moving major, still in the live
         // nursery; neither can be proven dead here, so both are kept.
-        crate::shadow_stack::prune_ephemeron_tables(&mut |owner| {
+        let mut classify_owner = |owner: usize| -> Option<usize> {
             if owner == 0 || !self.oldgen.contains(owner) {
                 return Some(owner);
             }
@@ -2867,7 +2867,19 @@ impl MiniMarkGC {
             } else {
                 None
             }
-        });
+        };
+        crate::shadow_stack::prune_ephemeron_tables(&mut classify_owner);
+        // The same question for tables a single mutator owns in its own TLS.
+        // Those cannot go through the global registration: it names no thread,
+        // so a major driven here would leave every other mutator's dead-owner
+        // entries pinned. Reach exactly as far as this collection's own root
+        // walk did (`enumerate_root_walker_values`) — foreign TLS only while
+        // this thread owns STW.
+        if crate::gc_sync::mutators_quiesced() {
+            crate::shadow_stack::prune_all_mutator_areas(&mut classify_owner);
+        } else {
+            crate::shadow_stack::prune_my_mutator_areas(&mut classify_owner);
+        }
         // incminimark.py:2510-2511 — run destructors of dying old objects
         // before the sweep frees them (VISITED still distinguishes
         // survivors from the dying at this point).

--- a/majit/majit-gc/src/shadow_stack.rs
+++ b/majit/majit-gc/src/shadow_stack.rs
@@ -263,6 +263,7 @@ struct MutatorEntry {
     bh_regs_stack: *const RefCell<Vec<BhRegsEntry>>,
     resume_ref_roots_stack: *const RefCell<Vec<(*mut i64, usize)>>,
     extra_areas: Vec<MutatorExtraArea>,
+    pruners: Vec<MutatorPruner>,
 }
 
 /// Walker for one opaque root area owned by a registered mutator.
@@ -274,6 +275,18 @@ pub type MutatorExtraWalkFn = unsafe fn(*const (), &mut dyn FnMut(&mut GcRef));
 #[derive(Clone, Copy)]
 struct MutatorExtraArea {
     walk: MutatorExtraWalkFn,
+    data: *const (),
+}
+
+/// Pruner for one owner-keyed side table owned by a registered mutator.
+///
+/// Same contract as [`MutatorExtraWalkFn`]: it runs on the collecting thread
+/// and must derive everything from `data`, never from caller TLS.
+pub type MutatorPrunerFn = unsafe fn(*const (), &mut dyn FnMut(usize) -> Option<usize>);
+
+#[derive(Clone, Copy)]
+struct MutatorPruner {
+    prune: MutatorPrunerFn,
     data: *const (),
 }
 
@@ -307,6 +320,7 @@ pub fn register_mutator() {
         bh_regs_stack,
         resume_ref_roots_stack,
         extra_areas: Vec::new(),
+        pruners: Vec::new(),
     });
 }
 
@@ -326,6 +340,72 @@ pub unsafe fn register_mutator_extra_area(walk: MutatorExtraWalkFn, data: *const
         .find(|entry| entry.thread_id == thread_id)
         .expect("register_mutator_extra_area called before register_mutator");
     entry.extra_areas.push(MutatorExtraArea { walk, data });
+}
+
+/// Append an owner-keyed-table pruner to the current registered mutator.
+///
+/// The ephemeron half of [`register_mutator_extra_area`]: a table whose keys are
+/// owner addresses and whose values a walker roots needs its dead-owner entries
+/// dropped, and needs it with the same per-mutator reach the root walk has.
+/// [`register_ephemeron_pruner`] cannot serve TLS-owned state — it hands the
+/// classifier no way to name a thread, so a major driven by one thread would
+/// leave every other thread's dead-owner entries pinned.
+///
+/// # Safety
+///
+/// Same as [`register_mutator_extra_area`]: `data` must stay valid until
+/// [`unregister_mutator`] runs on this thread, and `prune` must derive every
+/// address it dereferences from `data`, never from caller TLS.
+pub unsafe fn register_mutator_pruner(prune: MutatorPrunerFn, data: *const ()) {
+    let thread_id = std::thread::current().id();
+    let mut registry = MUTATOR_REGISTRY.lock().unwrap();
+    let entry = registry
+        .iter_mut()
+        .find(|entry| entry.thread_id == thread_id)
+        .expect("register_mutator_pruner called before register_mutator");
+    entry.pruners.push(MutatorPruner { prune, data });
+}
+
+/// Prune every registered mutator's owner-keyed tables during STW.
+///
+/// Called from the same pre-sweep point as [`prune_ephemeron_tables`] and with
+/// the same classifier; see that function for why only a major prunes. Callers
+/// pick between this and [`prune_my_mutator_areas`] on
+/// `gc_sync::mutators_quiesced()`, exactly as the root walk picks between
+/// [`walk_all_extra_areas`] and [`walk_my_extra_areas`] — so a collection's
+/// prune reach always equals its own root-walk reach.
+pub fn prune_all_mutator_areas(classify: &mut dyn FnMut(usize) -> Option<usize>) {
+    debug_assert!(
+        crate::gc_sync::mutators_quiesced(),
+        "prune_all_mutator_areas reaches foreign mutator TLS; caller must own collector-side STW",
+    );
+    let registry = MUTATOR_REGISTRY.lock().unwrap();
+    for mutator in registry.iter() {
+        for pruner in mutator.pruners.iter() {
+            // SAFETY: gc_sync has quiesced every registered owner, and each
+            // pruner's data remains valid until its MutatorEntry is removed.
+            unsafe { (pruner.prune)(pruner.data, classify) };
+        }
+    }
+}
+
+/// Prune the current mutator's owner-keyed tables.
+///
+/// The single-thread collection path, mirroring [`walk_my_extra_areas`]:
+/// callers without a registered mutator have no per-thread tables and are a
+/// no-op. A collection that only walked its own roots must only prune its own
+/// tables — another mutator's owner was never marked here, so its entries
+/// cannot be classified.
+pub fn prune_my_mutator_areas(classify: &mut dyn FnMut(usize) -> Option<usize>) {
+    let thread_id = std::thread::current().id();
+    let registry = MUTATOR_REGISTRY.lock().unwrap();
+    let Some(mutator) = registry.iter().find(|entry| entry.thread_id == thread_id) else {
+        return;
+    };
+    for pruner in mutator.pruners.iter() {
+        // SAFETY: this is the owning thread's synchronous collection path.
+        unsafe { (pruner.prune)(pruner.data, classify) };
+    }
 }
 
 /// Walk every registered mutator's opaque extra root areas during STW.

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -4590,14 +4590,14 @@ impl<S: JitState> JitDriver<S> {
     /// virtuals through the same resume allocator used by ordinary guard
     /// failure.  In particular, a `jit.virtual_ref` frame must not be decoded
     /// through `NullAllocator`, or its `forced` writeback remains null.
-    pub fn force_virtualizable_token(&mut self, token: u64) -> Option<(Vec<i64>, Vec<i64>)> {
+    pub fn force_virtualizable_token(&mut self, token: u64) {
         let fallback_alloc = crate::resume::NullAllocator;
         let allocator: &dyn crate::resume::BlackholeAllocator = self
             .blackhole_allocator
             .as_deref()
             .unwrap_or(&fallback_alloc);
         self.meta
-            .force_virtualizable_token_with_allocator(token, allocator)
+            .force_virtualizable_token_with_allocator(token, allocator);
     }
 
     fn prepare_exit_resume_heap_with_blackhole_allocator(
@@ -4641,6 +4641,18 @@ impl<S: JitState> JitDriver<S> {
     /// live during compilation. See `MetaInterp::walk_compile_snapshot_refs`.
     pub fn walk_compile_snapshot_refs(&mut self, visitor: impl FnMut(&mut majit_ir::GcRef)) {
         self.meta.walk_compile_snapshot_refs(visitor);
+    }
+
+    /// GC walker for the forced-virtual caches awaiting a `GUARD_NOT_FORCED`.
+    /// See `MetaInterp::walk_forced_virtuals_refs`.
+    pub fn walk_forced_virtuals_refs(&mut self, visitor: impl FnMut(&mut majit_ir::GcRef)) {
+        self.meta.walk_forced_virtuals_refs(visitor);
+    }
+
+    /// Drop forced-virtual caches whose owner frame died.
+    /// See `MetaInterp::prune_forced_virtuals`.
+    pub fn prune_forced_virtuals(&mut self, classify: &mut dyn FnMut(usize) -> Option<usize>) {
+        self.meta.prune_forced_virtuals(classify);
     }
 
     pub fn run_compiled_detailed_keyed(

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -1162,11 +1162,23 @@ pub struct MetaInterp<M: Clone> {
     ///
     /// Upstream hides an `AllVirtuals` instance in the deadframe's
     /// `jf_savedata` GCREF slot and `ResumeGuardForcedDescr.handle_fail`
-    /// fishes it back out. pyre cannot put a Rust value there — the GC
-    /// traces `jf_savedata` as a real object reference
-    /// (`jitframe.rs:278`) — so the cache is held here, keyed by the
-    /// virtualizable that was forced. One entry per frame, overwritten on
-    /// re-force, exactly like the single `jf_savedata` word.
+    /// fishes it back out. pyre cannot put a Rust value in that slot — the GC
+    /// traces it as a real object reference (`majit-backend/src/jitframe.rs:354`)
+    /// — so the cache is held here, keyed by the virtualizable that was forced.
+    /// One entry per frame, overwritten on re-force, exactly like the single
+    /// `jf_savedata` word.
+    ///
+    /// The ptr half is a GC root for as long as the entry lives, walked by
+    /// [`Self::walk_forced_virtuals_refs`]: `force_all_virtuals`
+    /// (`resume.py:969-981`) materializes every `rd_virtuals` entry, including
+    /// ones named only by a resume frame's ref registers, and those are written
+    /// nowhere else at force time — this `Vec` is their only referent until the
+    /// `GUARD_NOT_FORCED` failure consumes it. Upstream gets that edge from
+    /// `jf_savedata` being traced; here it comes from the root walker.
+    ///
+    /// An entry the guard never consumes is dropped by
+    /// [`Self::prune_forced_virtuals`] when its owner frame dies, which is what
+    /// `jf_savedata` gets for free by living on the deadframe.
     pub(crate) forced_virtuals: Vec<(u64, Vec<i64>, Vec<i64>)>,
     /// Virtualizable array lengths for trace-entry box layout.
     pub(crate) vable_array_lengths: Vec<usize>,
@@ -1852,6 +1864,48 @@ impl<M: Clone> MetaInterp<M> {
                 visitor(gcref);
             }
         }
+    }
+
+    /// GC walker for the forced-virtual caches held in
+    /// [`Self::forced_virtuals`], standing in for the trace `jf_savedata` gets
+    /// as a real GCREF field (`majit-backend/src/jitframe.rs:354`).
+    ///
+    /// Only the ptr half is walked. The int half is `virtuals_int_cache` —
+    /// unboxed integer field values — and handing those to the visitor would
+    /// test integers as heap addresses. `prepare_resume_heap_with_roots` roots
+    /// the same one half for the same reason.
+    ///
+    /// Unmaterialized `0` cache slots pass through unchanged, as they do in
+    /// `shadow_stack::walk_resume_ref_roots`.
+    pub fn walk_forced_virtuals_refs(&mut self, mut visitor: impl FnMut(&mut GcRef)) {
+        for (_owner, ptrs, _ints) in self.forced_virtuals.iter_mut() {
+            for slot in ptrs.iter_mut() {
+                // SAFETY: `GcRef` is a pointer-sized newtype over the same
+                // representation these slots hold, the same reinterpret
+                // `walk_resume_ref_roots` performs on `virtuals_ptr_cache`
+                // (`majit-gc/src/shadow_stack.rs:931`). Walked unconditionally
+                // for both collection kinds: the minor forwards a
+                // nursery-resident virtual in place, the major seeds it as a
+                // mark root so the sweep does not free it.
+                let gcref = unsafe { &mut *(slot as *mut i64 as *mut GcRef) };
+                visitor(gcref);
+            }
+        }
+    }
+
+    /// Drop the forced-virtual caches whose owner frame died.
+    ///
+    /// `classify` answers with the owner's current address, or `None` if it did
+    /// not survive. A major collection moves nothing, so a surviving owner
+    /// answers with the key it was asked about.
+    ///
+    /// Without this, rooting the ptr half would keep an unconsumed entry's
+    /// objects alive forever and leave a stale `PyFrame` key that a later frame
+    /// at the same address could fish. Upstream is immune because `jf_savedata`
+    /// dies with its deadframe; this reproduces that lifetime.
+    pub fn prune_forced_virtuals(&mut self, classify: &mut dyn FnMut(usize) -> Option<usize>) {
+        self.forced_virtuals
+            .retain(|(owner, _, _)| classify(*owner as usize) == Some(*owner as usize));
     }
 
     #[inline]
@@ -11607,9 +11661,10 @@ impl<M: Clone> MetaInterp<M> {
     /// RPython flow: force_now() → cpu.force(token) → handle_async_forcing()
     /// → force_from_resumedata() → materialize all virtuals → save on deadframe.
     ///
-    /// Returns the forced virtual caches (ptr, int) for later blackhole
-    /// resumption from the GUARD_NOT_FORCED. RPython stores these as
-    /// AllVirtuals via cpu.set_savedata_ref().
+    /// The forced virtual caches (ptr, int) are stored on
+    /// [`Self::forced_virtuals`] for the blackhole resumption from the
+    /// GUARD_NOT_FORCED — RPython's `AllVirtuals` via `cpu.set_savedata_ref()`.
+    /// They are also returned, which only the unit tests below read.
     pub fn handle_async_forcing(
         &mut self,
         green_key: u64,
@@ -11696,29 +11751,41 @@ impl<M: Clone> MetaInterp<M> {
         // compile.py:990-991: vinfo = self.jitdriver_sd.virtualizable_info
         let vinfo = self.virtualizable_info();
         let all_liveness = self.staticdata.liveness_info.as_slice();
-        let (all_virtuals_ptr, all_virtuals_int) = crate::resume::force_from_resumedata(
-            &self.staticdata.profiler,
-            rd_numb,
-            rd_consts,
-            all_liveness,
-            fail_values,
-            deadframe_types.as_deref(),
-            rd_virtuals.as_deref(),
-            storage.map(|s| s.rd_pendingfields.as_slice()),
-            Some(&self.staticdata.virtualref_info as &dyn crate::resume::VRefInfo),
-            vinfo.map(|v| v.as_ref() as &dyn crate::resume::VirtualizableInfo),
-            None, // ginfo — pyre has no greenfield mechanism
-            allocator,
-        );
+        let (all_virtuals_ptr, all_virtuals_int, virtualizable_ptr) =
+            crate::resume::force_from_resumedata(
+                &self.staticdata.profiler,
+                rd_numb,
+                rd_consts,
+                all_liveness,
+                fail_values,
+                deadframe_types.as_deref(),
+                rd_virtuals.as_deref(),
+                storage.map(|s| s.rd_pendingfields.as_slice()),
+                Some(&self.staticdata.virtualref_info as &dyn crate::resume::VRefInfo),
+                vinfo.map(|v| v.as_ref() as &dyn crate::resume::VirtualizableInfo),
+                None, // ginfo — pyre has no greenfield mechanism
+                allocator,
+            );
         drop(_cc_guard);
-        // compile.py:999-1000: obj = AllVirtuals(all_virtuals)
-        //   metainterp_sd.cpu.set_savedata_ref(deadframe, obj.hide())
-        // Return the virtual caches so the caller can store them.
         if crate::majit_log_enabled() {
             eprintln!(
                 "[jit][handle_async_forcing] forced {} ptr + {} int virtuals",
                 all_virtuals_ptr.len(),
                 all_virtuals_int.len(),
+            );
+        }
+        // compile.py:999-1000: obj = AllVirtuals(all_virtuals)
+        //   metainterp_sd.cpu.set_savedata_ref(deadframe, obj.hide())
+        //
+        // The store lives here, inside `handle_async_forcing`, exactly as
+        // upstream — every force entry point reaching this function is covered
+        // by it, including `force_virtual_if_necessary`'s (virtualref.py:134)
+        // which never sees the returned caches.
+        if virtualizable_ptr != 0 {
+            self.save_forced_virtuals(
+                virtualizable_ptr as u64,
+                all_virtuals_ptr.clone(),
+                all_virtuals_int.clone(),
             );
         }
         Some((all_virtuals_ptr, all_virtuals_int))
@@ -11732,11 +11799,14 @@ impl<M: Clone> MetaInterp<M> {
     /// `NullAllocator` convenience wrapper here — callers go through
     /// `JitDriver::force_virtualizable_token`, which supplies the registered
     /// blackhole allocator.
+    ///
+    /// Like `force_now`, this returns nothing: `handle_async_forcing` attaches
+    /// the materialized virtuals itself (compile.py:999-1000).
     pub fn force_virtualizable_token_with_allocator(
         &mut self,
         token: u64,
         allocator: &dyn crate::resume::BlackholeAllocator,
-    ) -> Option<(Vec<i64>, Vec<i64>)> {
+    ) {
         let deadframe = self
             .backend
             .force(GcRef(token as usize))
@@ -11761,25 +11831,25 @@ impl<M: Clone> MetaInterp<M> {
                 Type::Void => 0,
             })
             .collect::<Vec<_>>();
-        // compile.py:995-1000: the forced cache is returned so the caller can
-        // attach it to the frame this force belongs to.
+        // compile.py:995: faildescr.handle_async_forcing(deadframe)
         self.handle_async_forcing_with_allocator(
             green_key,
             trace_id,
             fail_index,
             &fail_values,
             allocator,
-        )
+        );
     }
 
     /// `compile.py:1000 cpu.set_savedata_ref(deadframe, obj.hide())`.
     ///
-    /// `owner` is the forced virtualizable. Upstream can key on the deadframe
-    /// because `handle_fail` receives it; pyre's guard-failure path surfaces
-    /// the frame rather than the jitframe, and the two ends agree on the
-    /// frame: the force runs against a named virtualizable and the
-    /// GUARD_NOT_FORCED that follows deopts that same frame's loop.
-    pub fn save_forced_virtuals(&mut self, owner: u64, ptrs: Vec<i64>, ints: Vec<i64>) {
+    /// `owner` is the forced virtualizable, as the guard's own resume data
+    /// named it (`resume.py:1404`). Upstream can key on the deadframe because
+    /// `handle_fail` receives it; pyre's guard-failure path surfaces the frame
+    /// rather than the jitframe, and the two ends agree on the frame: the force
+    /// runs against a named virtualizable and the GUARD_NOT_FORCED that follows
+    /// deopts that same frame's loop.
+    fn save_forced_virtuals(&mut self, owner: u64, ptrs: Vec<i64>, ints: Vec<i64>) {
         match self.forced_virtuals.iter_mut().find(|e| e.0 == owner) {
             // A second force of the same frame overwrites, the way a second
             // `set_savedata_ref` overwrites the one `jf_savedata` word.
@@ -11795,8 +11865,18 @@ impl<M: Clone> MetaInterp<M> {
     /// second set (`resume.py:1373-1374`, and the `vable_size` skip in
     /// `consume_vref_and_vable`).
     pub fn take_forced_virtuals(&mut self, owner: u64) -> Option<(Vec<i64>, Vec<i64>)> {
-        let index = self.forced_virtuals.iter().position(|e| e.0 == owner)?;
-        let (_, ptrs, ints) = self.forced_virtuals.swap_remove(index);
+        let index = self.forced_virtuals.iter().position(|e| e.0 == owner);
+        // Only a GUARD_NOT_FORCED reaches here (`is_guard_forced()` gates the
+        // callers), so hit/miss is the force→resume handoff itself: the
+        // counterpart of the `handle_async_forcing` line above.
+        if crate::majit_log_enabled() {
+            eprintln!(
+                "[jit][take_forced_virtuals] owner=0x{:x} {}",
+                owner,
+                if index.is_some() { "hit" } else { "miss" },
+            );
+        }
+        let (_, ptrs, ints) = self.forced_virtuals.swap_remove(index?);
         Some((ptrs, ints))
     }
 

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -11850,6 +11850,19 @@ impl<M: Clone> MetaInterp<M> {
     /// runs against a named virtualizable and the GUARD_NOT_FORCED that follows
     /// deopts that same frame's loop.
     fn save_forced_virtuals(&mut self, owner: u64, ptrs: Vec<i64>, ints: Vec<i64>) {
+        // The key is a bare address, so the mechanism holds only while that
+        // address is stable. It is: the virtualizable is an interpreter-created
+        // frame (`FrameBox::new` → `try_gc_alloc_stable_raw`, "stable across
+        // minor and major collections (MiniMark mark-sweep does not move
+        // old-gen objects)"), never one of the frames a trace builds virtually.
+        // A nursery owner would break both ends — a minor would forward the
+        // frame out from under this key, and the pruner's classifier keeps every
+        // non-old-gen owner, so the entry could never be dropped either.
+        debug_assert!(
+            !majit_gc::gc_is_nursery_object(owner as usize),
+            "forced-virtual cache keyed on a nursery-resident virtualizable \
+             (0x{owner:x}): the key must be a move-stable address",
+        );
         match self.forced_virtuals.iter_mut().find(|e| e.0 == owner) {
             // A second force of the same frame overwrites, the way a second
             // `set_savedata_ref` overwrites the one `jf_savedata` word.

--- a/majit/majit-metainterp/src/resume.rs
+++ b/majit/majit-metainterp/src/resume.rs
@@ -5232,6 +5232,112 @@ mod tests {
         reader.consume_vref_and_vable(None, Some(&TestVirtualizableInfo), None, None);
     }
 
+    /// resume.py:1368-1375 / compile.py:956-963 — the GUARD_NOT_FORCED resume
+    /// path.  `handle_async_forcing` already materialized the virtuals and
+    /// already rewrote the virtualizable, so this resume must reuse that cache
+    /// and leave the virtualizable alone: `consume_vref_and_vable` jumps the
+    /// vable and vref sections (resume.py:1433-1435) instead of consuming them.
+    #[test]
+    fn blackhole_from_resumedata_with_all_virtuals_skips_the_vable_section() {
+        use crate::blackhole::BlackholeInterpBuilder;
+        use crate::jitcode::JitCodeBuilder;
+        use crate::jitcode::insns::{BC_ABORT, BC_CATCH_EXCEPTION, BC_LIVE, BC_RVMPROF_CODE};
+
+        let mut writer = crate::resumecode::Writer::new(8);
+        writer.append_int(0); // items_resume_section (patched below)
+        writer.append_int(1); // count
+        writer.append_int(1); // vable_size: the identity only (get_total_size == 0)
+        writer.append_int(tag(0, TAGBOX).unwrap() as i64); // virtualizable identity
+        writer.append_int(0); // vref_array length
+        writer.append_int(0); // jitcode_pos
+        writer.append_int(0); // pc
+        writer.append_int(0); // py_pc
+        writer.patch_current_size(0);
+        let rd_numb = writer.create_numbering();
+
+        let mut runtime = JitCodeBuilder::default().finish();
+        runtime.body_mut().code = vec![BC_LIVE, 0, 0, BC_ABORT];
+        runtime.body_mut().c_num_regs_i = 1;
+        runtime.body_mut().constants_i = vec![321];
+        runtime.body_mut().startpoints = Some([0_usize, 3].into_iter().collect());
+        let runtime = std::sync::Arc::new(runtime);
+        let all_liveness: Vec<u8> = vec![0, 0, 0];
+        let deadframe = [0x4000_i64];
+        let deadframe_types = [majit_ir::Type::Ref];
+
+        let resume = |all_virtuals: Option<(Vec<i64>, Vec<i64>)>| {
+            let mut builder = BlackholeInterpBuilder::new();
+            builder.setup_cached_control_opcodes(
+                BC_LIVE as i32,
+                BC_CATCH_EXCEPTION as i32,
+                BC_RVMPROF_CODE as i32,
+            );
+            let resolve_jitcode = |_jitcode_pos: i32, _pc: i32| -> Option<ResolvedJitCode> {
+                Some(ResolvedJitCode::new(runtime.clone(), 0))
+            };
+            blackhole_from_resumedata(
+                &mut builder,
+                &resolve_jitcode,
+                &rd_numb,
+                &[],
+                &all_liveness,
+                &deadframe,
+                Some(&deadframe_types),
+                None, // rd_virtuals
+                None, // rd_guard_pendingfields
+                None,
+                Some(&TestVirtualizableInfo),
+                None,
+                None,
+                all_virtuals,
+                &NullAllocator,
+            )
+            .expect("resume should produce a blackhole")
+        };
+
+        // resume.py:1427-1428: the ordinary path consumes the vable section, so
+        // the reader surfaces the virtualizable the identity item named.
+        let (bh, virtualizable_ptr) = resume(None);
+        assert_eq!(virtualizable_ptr, 0x4000);
+        assert_eq!(bh.position, 0);
+
+        // resume.py:1433-1435: with a GUARD_NOT_FORCED cache the same items are
+        // jumped — no virtualizable is surfaced, and the frame section behind
+        // them still decodes, which is what proves the jump lengths line up.
+        let (bh, virtualizable_ptr) = resume(Some((vec![0x1234], vec![7])));
+        assert_eq!(virtualizable_ptr, 0);
+        assert_eq!(bh.position, 0);
+    }
+
+    /// resume.py:990-991 `_prepare_virtuals` resets `virtuals_cache` to zeros.
+    /// That is why `blackhole_from_resumedata` must not run `_prepare` on the
+    /// GUARD_NOT_FORCED path (resume.py:1368-1375): there the preloaded cache is
+    /// the resume's only source of virtuals, and `rd_virtuals` stays None.
+    #[test]
+    fn prepare_virtuals_resets_a_preloaded_guard_not_forced_cache() {
+        let rd = majit_ir::RdVirtualInfo::VRawSliceInfo {
+            offset: 0,
+            fieldnums: vec![],
+        };
+        let virtuals = [rd_virtual_to_virtual_info(&rd, &[], 0, 1)];
+        let mut reader = ResumeDataDirectReader::new(
+            &[0, 0],
+            &[],
+            &[],
+            &[],
+            None,
+            Some((vec![0x1234], vec![7])),
+            &NullAllocator,
+        );
+        assert_eq!(reader.resume_after_guard_not_forced, 2);
+        assert_eq!(reader.virtuals_cache.get_ptr(0), 0x1234);
+        assert_eq!(reader.virtuals_cache.get_int(0), 7);
+
+        reader.prepare(Some(&virtuals), None);
+        assert_eq!(reader.virtuals_cache.get_ptr(0), 0);
+        assert_eq!(reader.virtuals_cache.get_int(0), 0);
+    }
+
     #[test]
     #[should_panic(expected = "load_next_value_of_type: unexpected type Void")]
     fn test_next_value_of_type_rejects_void() {
@@ -7512,7 +7618,10 @@ pub fn blackhole_from_resumedata<'a>(
 ///
 /// Force all virtuals from resume data without running a blackhole.
 /// Used for GUARD_NOT_FORCED handling.
-/// Returns (virtuals_cache_ptr, virtuals_cache_int) — RPython VirtualCache parity.
+///
+/// Returns (virtuals_cache_ptr, virtuals_cache_int) — RPython VirtualCache
+/// parity — plus the virtualizable the vable section named, which the caller
+/// needs as the cache key (see `MetaInterp::save_forced_virtuals`).
 pub fn force_from_resumedata<'a>(
     profiler: &crate::jitprof::JitProfiler,
     rd_numb: &'a [u8],
@@ -7526,7 +7635,7 @@ pub fn force_from_resumedata<'a>(
     vinfo: Option<&dyn VirtualizableInfo>,
     ginfo: Option<&dyn GreenfieldInfo>,
     allocator: &'a dyn BlackholeAllocator,
-) -> (Vec<i64>, Vec<i64>) {
+) -> (Vec<i64>, Vec<i64>, i64) {
     // resume.py:1346
     profiler.count(crate::pyjitpl::counters::FORCE_VIRTUALIZABLES, 1);
     // resume.py:1347-1348
@@ -7545,7 +7654,12 @@ pub fn force_from_resumedata<'a>(
     resumereader.handling_async_forcing();
     // resume.py:1350
     resumereader.consume_vref_and_vable(vrefinfo, vinfo, ginfo, None);
+    // resume.py:1404 the virtualizable the vable section just named. Read it
+    // before `force_all_virtuals` allocates: unlike `blackhole_from_resumedata`,
+    // the bare `prepare` above opened no resume-root scope, so there is nothing
+    // to forward the reader's slot in place.
+    let virtualizable_ptr = resumereader.virtualizable_ptr;
     // resume.py:1351: return resumereader.force_all_virtuals()
     let (ptrs, ints) = resumereader.force_all_virtuals();
-    (ptrs.to_vec(), ints.to_vec())
+    (ptrs.to_vec(), ints.to_vec(), virtualizable_ptr)
 }

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -610,15 +610,6 @@ fn gc_prebuilt_remember_enabled() -> bool {
     })
 }
 
-/// Whether the per-return diagnostic dump is enabled
-/// (`PYRE_INTERP_RETURN_LOG`). The probe sits on the RETURN_VALUE path, so an
-/// uncached read would pay a `getenv` on every Python return.
-#[cfg(not(feature = "sandbox"))]
-fn interp_return_log_enabled() -> bool {
-    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *ENABLED.get_or_init(|| std::env::var_os("PYRE_INTERP_RETURN_LOG").is_some())
-}
-
 pub fn capture_pyframe_root_area() -> *const () {
     PYFRAME_ROOT_AREA.with(|area| area as *const _ as *const ())
 }

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -2078,8 +2078,12 @@ pub fn int_mutable_cell_value_descr() -> DescrRef {
 
 /// Size descriptor for `W_ListObject` allocation via NewWithVtable.
 /// vtable = &LIST_TYPE; the Object-strategy fields `length` / `items` /
-/// `strategy` are SetField'd after; `int_items` / `float_items` stay at the
-/// NewWithVtable memzero (== empty, never read under the Object strategy).
+/// `strategy` are SetField'd after.  `int_items.block` / `float_items.block`
+/// are GC-pointer fields of this descr, so `rewrite.py:498-504
+/// clear_gc_fields` zeroes them behind the allocation (== empty, never read
+/// under the Object strategy); their `len` halves are plain ints and stay at
+/// whatever the recycled nursery bytes held, which no strategy reads while the
+/// block slot is null.
 pub fn w_list_size_descr() -> DescrRef {
     W_LIST_DESCR_GROUP.size_descr.clone()
 }

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -662,6 +662,33 @@ fn build_object_descr_group_with_def_path(
     simple_name: &str,
     def_path: &str,
 ) -> PyreObjectDescrGroup {
+    build_object_descr_group_with_extra_gc_edges(
+        obj_size,
+        type_id,
+        vtable,
+        fields,
+        simple_name,
+        def_path,
+        &[],
+    )
+}
+
+/// `build_object_descr_group_with_def_path` plus GC edges that the
+/// positional `fields` census does not name.  `extra_gc_edges` join the
+/// `PyObject.w_class` edge every group already carries: they land in
+/// `gc_fielddescrs` — which is what `rewrite.py:498-504 clear_gc_fields`
+/// walks to zero a fresh object's GC-pointer slots — while staying out of
+/// the positional `all_fielddescrs` list that `field_descr_from_group`
+/// indexes.
+fn build_object_descr_group_with_extra_gc_edges(
+    obj_size: usize,
+    type_id: u32,
+    vtable: usize,
+    fields: &[(&'static str, usize, usize, Type, bool, bool, bool)],
+    simple_name: &str,
+    def_path: &str,
+    extra_gc_edges: &[Arc<dyn FieldDescr>],
+) -> PyreObjectDescrGroup {
     let cache_key = if !def_path.is_empty() {
         majit_ir::descr::path_hash(def_path)
     } else if !simple_name.is_empty() {
@@ -695,6 +722,8 @@ fn build_object_descr_group_with_def_path(
             },
         )
         .collect();
+    let mut gc_edges: Vec<Arc<dyn FieldDescr>> = vec![W_CLASS_FIELD_DESCR.clone()];
+    gc_edges.extend(extra_gc_edges.iter().cloned());
     let group = majit_ir::descr::make_simple_descr_group_keyed_with_headerless(
         SIZE_DESCR_TAG | (obj_size as u32 & 0x0FFF_FFFF),
         obj_size,
@@ -704,7 +733,7 @@ fn build_object_descr_group_with_def_path(
         true,
         false,
         &specs,
-        &[W_CLASS_FIELD_DESCR.clone()],
+        &gc_edges,
     );
     let field_descrs = group.field_descrs;
     let size_descr = group.size_descr;
@@ -1420,8 +1449,31 @@ static W_SLICE_DESCR_GROUP: LazyLock<PyreObjectDescrGroup> = LazyLock::new(|| {
     )
 });
 
+/// `rvirtualizable.py:29` appends `('vable_token', llmemory.GCREF)` to the
+/// virtualizable's own fields, so upstream's `gc_fielddescrs` names it and
+/// `clear_gc_fields` zeroes the slot on every `new`.  pyre declares
+/// `PyFrame.vable_token` as a plain `usize` and the positional census below
+/// does not list it, so without this edge a JIT-inlined
+/// `NewWithVtable(pyframe_size_descr())` leaves the slot holding recycled
+/// nursery bytes — which `emit_force_virtualizable`'s `GETFIELD_GC_R` then
+/// reads as a live GC reference (`pyjitpl.py:1148-1158`).
+static PYFRAME_VABLE_TOKEN_FIELD_DESCR: LazyLock<Arc<dyn FieldDescr>> = LazyLock::new(|| {
+    Arc::new(PyreFieldDescr {
+        offset: crate::frame_layout::PYFRAME_VABLE_TOKEN_OFFSET,
+        field_size: std::mem::size_of::<usize>(),
+        field_type: Type::Ref,
+        signed: false,
+        immutable: false,
+        quasi_immutable: false,
+        name: "vable_token",
+        index_in_parent: 0,
+        parent_descr: None,
+        ei_index: AtomicU32::new(u32::MAX),
+    })
+});
+
 static PYFRAME_DESCR_GROUP: LazyLock<PyreObjectDescrGroup> = LazyLock::new(|| {
-    build_object_descr_group_with_def_path(
+    build_object_descr_group_with_extra_gc_edges(
         std::mem::size_of::<pyre_interpreter::pyframe::PyFrame>(),
         PYFRAME_GC_TYPE_ID,
         // `NewWithVtable` writes this typeptr at `cpu.vtable_offset`
@@ -1567,6 +1619,7 @@ static PYFRAME_DESCR_GROUP: LazyLock<PyreObjectDescrGroup> = LazyLock::new(|| {
         ],
         "PyFrame",
         "pyframe::PyFrame",
+        &[PYFRAME_VABLE_TOKEN_FIELD_DESCR.clone()],
     )
 });
 
@@ -2977,6 +3030,19 @@ mod tests {
                 .iter()
                 .any(|fd| fd.offset() == W_CLASS_OFFSET),
             "malloc_zero_filled=False requires the inherited PyObject.w_class edge"
+        );
+    }
+
+    #[test]
+    fn pyframe_size_descr_clears_the_vable_token_slot() {
+        let descr = pyframe_size_descr();
+        let size = descr.as_size_descr().expect("PyFrame SizeDescr");
+        assert!(
+            size.gc_fielddescrs()
+                .iter()
+                .any(|fd| fd.offset() == crate::frame_layout::PYFRAME_VABLE_TOKEN_OFFSET),
+            "emit_force_virtualizable reads vable_token with GETFIELD_GC_R, so \
+             clear_gc_fields must zero it on a JIT-inlined frame allocation"
         );
     }
 

--- a/pyre/pyre-jit-trace/src/helpers.rs
+++ b/pyre/pyre-jit-trace/src/helpers.rs
@@ -650,18 +650,24 @@ pub fn emit_object_list_inline(ctx: &mut TraceCtx, items: &[OpRef]) -> OpRef {
 /// wrapper plus the `strategy` store, mirroring `w_list_new(vec![])` /
 /// `w_list_new_with_strategy(vec![], Empty)`.
 ///
-/// `length` (0) and `items` (null) stay zero-filled by `NewWithVtable`, as the
-/// non-Object strategies leave them.  The typed `int_items` / `float_items`
-/// blocks also stay null: the Empty strategy reads neither (its first append
-/// installs fresh typed storage via `switch_to_correct_strategy`), and
-/// `list_object_custom_trace` forwards a typed block only when the GC owns it,
-/// so a null slot is inert.  OptVirtualize folds the whole wrapper when the
-/// list never escapes.
+/// `items` and the typed `int_items` / `float_items` blocks stay null because
+/// they are GC-pointer fields of the size descr, so `rewrite.py:498-504
+/// clear_gc_fields` zeroes them behind the `NewWithVtable`.  `length` gets no
+/// such pending zero — the recycled nursery bytes a `CALL_MALLOC_NURSERY`
+/// hands back are not zero-filled (`incminimark.py:211 malloc_zero_filled =
+/// False`) — so it is stored explicitly here, as `rlist.py ll_newlist` does.
+/// OptVirtualize folds the whole wrapper when the list never escapes.
 pub fn emit_empty_list_inline(ctx: &mut TraceCtx) -> OpRef {
-    use crate::descr::{list_strategy_descr, w_list_size_descr};
+    use crate::descr::{list_length_descr, list_strategy_descr, w_list_size_descr};
 
     let list = ctx.record_op_with_descr(OpCode::NewWithVtable, &[], w_list_size_descr());
     ctx.heap_cache_mut().new_object(list);
+
+    let zero = ctx.const_int(0);
+    let length_descr = list_length_descr();
+    let length_idx = length_descr.index();
+    ctx.record_op_with_descr(OpCode::SetfieldGc, &[list, zero], length_descr);
+    ctx.heapcache_setfield_cached(list, length_idx, zero);
 
     let strategy_const = ctx.const_int(pyre_object::listobject::ListStrategy::Empty as i64);
     let strategy_descr = list_strategy_descr();

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -3522,6 +3522,10 @@ fn install_gc_root_walkers() {
     majit_gc::shadow_stack::register_ephemeron_pruner(
         pyre_interpreter::objspace::std::mapdict::prune_dead_owner_entries,
     );
+    // `MetaInterp::forced_virtuals` is the same shape: keyed by the forced
+    // frame's address and rooting its values, so an entry the following
+    // `GUARD_NOT_FORCED` never consumes has to go when its owner is swept.
+    majit_gc::shadow_stack::register_ephemeron_pruner(prune_forced_virtuals_for_dead_frames);
 }
 
 fn register_thread_root_areas() {
@@ -3580,6 +3584,7 @@ fn register_thread_root_areas() {
         register(partial_trace_root_walker_area, jit_driver);
         register(active_trace_root_walker_area, jit_driver);
         register(compile_snapshot_root_walker_area, jit_driver);
+        register(forced_virtuals_root_walker_area, jit_driver);
     }
 }
 
@@ -3975,15 +3980,11 @@ unsafe extern "C" fn force_pyframe(frame: *mut pyre_interpreter::PyFrame) {
                 // Decoding it through `NullAllocator` instead wrote a null over
                 // that slot, and `fast2locals` renders a null slot as an absent
                 // name — a live local vanished from `f_locals`.
-                let all_virtuals = driver.force_virtualizable_token(token);
-                // compile.py:999-1000 set_savedata_ref: hold what was
-                // materialized for the GUARD_NOT_FORCED that follows, keyed by
-                // the frame this force ran against.
-                if let Some((ptrs, ints)) = all_virtuals {
-                    driver
-                        .meta_interp_mut()
-                        .save_forced_virtuals(ptr as u64, ptrs, ints);
-                }
+                //
+                // `handle_async_forcing` keeps what it materialized for the
+                // GUARD_NOT_FORCED that follows (compile.py:999-1000), so there
+                // is nothing to attach here.
+                driver.force_virtualizable_token(token);
             });
         };
         // Force the traced frame only when the frame handed to Python belongs
@@ -4078,6 +4079,44 @@ unsafe fn compile_snapshot_root_walker_area(
     if let Some(pair) = unsafe { jit_driver_pair_from_root_area(data) } {
         pair.0.walk_compile_snapshot_refs(visitor);
     }
+}
+
+/// GC walker for the virtual caches `handle_async_forcing` produced and left
+/// for the `GUARD_NOT_FORCED` that follows. Upstream traces them through the
+/// deadframe's `jf_savedata` GCREF field; pyre holds them on `MetaInterp` and
+/// needs the edge drawn explicitly.
+/// See `MetaInterp::walk_forced_virtuals_refs`.
+unsafe fn forced_virtuals_root_walker_area(
+    data: *const (),
+    visitor: &mut dyn FnMut(&mut majit_ir::GcRef),
+) {
+    if let Some(pair) = unsafe { jit_driver_pair_from_root_area(data) } {
+        pair.0.walk_forced_virtuals_refs(visitor);
+    }
+}
+
+/// Drop forced-virtual caches whose owner frame the major collection is about
+/// to sweep — the ephemeron half of rooting them at all.
+///
+/// The force runs inside a residual `CALL_MAY_FORCE`, and two paths leave the
+/// entry unconsumed: an escaped virtualizable raises instead of failing a
+/// guard, and `handle_fail`'s bridge-compiled arm returns without resuming.
+/// Both would otherwise pin the materialized virtuals for the process lifetime
+/// and leave a key a recycled `PyFrame` address could match.
+///
+/// Reads the `JIT_DRIVER` cell directly rather than through `driver_pair()`:
+/// that initializes the GC subsystem and can allocate, which is not allowed
+/// mid-collection.
+fn prune_forced_virtuals_for_dead_frames(classify: &mut dyn FnMut(usize) -> Option<usize>) {
+    JIT_DRIVER.with(|cell| {
+        let data = cell as *const _ as *const ();
+        // SAFETY: same re-derivation and same aliasing caveat as the root
+        // walkers above (`jit_driver_pair_from_root_area`). The pruner runs on
+        // the collecting thread, so it reaches only that thread's driver.
+        if let Some(pair) = unsafe { jit_driver_pair_from_root_area(data) } {
+            pair.0.prune_forced_virtuals(classify);
+        }
+    });
 }
 
 /// Re-derives the thread-local `JitDriverPair` for a GC root walk from the

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -3909,12 +3909,27 @@ unsafe extern "C" fn force_pyframe_vref(
 ) -> *mut pyre_interpreter::PyFrame {
     let (driver, _info) = driver_pair();
     let vrefinfo = majit_metainterp::virtualref::VirtualRefInfo::new();
+    // Entry, distinct from the token arm logged below: a vref built during
+    // tracing carries `forced` already set and `virtual_token = TOKEN_NONE`
+    // (`virtualref.py:85-92`), so `force_virtual` returns without running the
+    // closure. Counting only the closure conflates "never reached" with
+    // "reached and short-circuited".
+    if majit_metainterp::majit_log_enabled() {
+        eprintln!("[jit][force-hook] vref-entry vref={vref:p}");
+    }
     let forced = unsafe {
         vrefinfo.force_virtual(vref as *mut u8, |v| {
             // `compile.py:967-971 force_now(cpu, token)` — force the JIT frame
             // the vref names, then run the guard's async forcing, which is
             // what writes `virtual_token = TOKEN_NONE` and `forced` back.
             let token = (*v).virtual_token as usize as u64;
+            // Name the entry point. The two hooks reach the same
+            // `handle_async_forcing`, and nothing downstream distinguishes
+            // them — which is how this one silently diverged from
+            // `force_pyframe` in the first place.
+            if majit_metainterp::majit_log_enabled() {
+                eprintln!("[jit][force-hook] vref token=0x{token:x}");
+            }
             driver.force_virtualizable_token(token);
         })
     };
@@ -3991,6 +4006,12 @@ unsafe extern "C" fn force_pyframe(frame: *mut pyre_interpreter::PyFrame) {
                 // `handle_async_forcing` keeps what it materialized for the
                 // GUARD_NOT_FORCED that follows (compile.py:999-1000), so there
                 // is nothing to attach here.
+                //
+                // See the counterpart in `force_pyframe_vref` for why the entry
+                // point is named.
+                if majit_metainterp::majit_log_enabled() {
+                    eprintln!("[jit][force-hook] frame token=0x{token:x} frame={ptr:p}");
+                }
                 driver.force_virtualizable_token(token);
             });
         };

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -3522,10 +3522,9 @@ fn install_gc_root_walkers() {
     majit_gc::shadow_stack::register_ephemeron_pruner(
         pyre_interpreter::objspace::std::mapdict::prune_dead_owner_entries,
     );
-    // `MetaInterp::forced_virtuals` is the same shape: keyed by the forced
-    // frame's address and rooting its values, so an entry the following
-    // `GUARD_NOT_FORCED` never consumes has to go when its owner is swept.
-    majit_gc::shadow_stack::register_ephemeron_pruner(prune_forced_virtuals_for_dead_frames);
+    // `MetaInterp::forced_virtuals` is the same shape but lives in one mutator's
+    // `JIT_DRIVER` rather than a global table, so it registers per mutator
+    // instead — see `forced_virtuals_pruner_area`.
 }
 
 fn register_thread_root_areas() {
@@ -3585,6 +3584,14 @@ fn register_thread_root_areas() {
         register(active_trace_root_walker_area, jit_driver);
         register(compile_snapshot_root_walker_area, jit_driver);
         register(forced_virtuals_root_walker_area, jit_driver);
+        // The ephemeron half of the walker above, on the same `data` so the
+        // prune reaches exactly the drivers the root walk reaches.
+        unsafe {
+            majit_gc::shadow_stack::register_mutator_pruner(
+                forced_virtuals_pruner_area,
+                jit_driver,
+            );
+        }
     }
 }
 
@@ -4104,19 +4111,17 @@ unsafe fn forced_virtuals_root_walker_area(
 /// Both would otherwise pin the materialized virtuals for the process lifetime
 /// and leave a key a recycled `PyFrame` address could match.
 ///
-/// Reads the `JIT_DRIVER` cell directly rather than through `driver_pair()`:
-/// that initializes the GC subsystem and can allocate, which is not allowed
-/// mid-collection.
-fn prune_forced_virtuals_for_dead_frames(classify: &mut dyn FnMut(usize) -> Option<usize>) {
-    JIT_DRIVER.with(|cell| {
-        let data = cell as *const _ as *const ();
-        // SAFETY: same re-derivation and same aliasing caveat as the root
-        // walkers above (`jit_driver_pair_from_root_area`). The pruner runs on
-        // the collecting thread, so it reaches only that thread's driver.
-        if let Some(pair) = unsafe { jit_driver_pair_from_root_area(data) } {
-            pair.0.prune_forced_virtuals(classify);
-        }
-    });
+/// Registered per mutator, next to `forced_virtuals_root_walker_area` and with
+/// the same `data`, so the prune reaches every driver the root walk reaches. The
+/// global `register_ephemeron_pruner` cannot: the table lives in this thread's
+/// `JIT_DRIVER`, and a major driven by another thread would leave it pinned.
+unsafe fn forced_virtuals_pruner_area(
+    data: *const (),
+    classify: &mut dyn FnMut(usize) -> Option<usize>,
+) {
+    if let Some(pair) = unsafe { jit_driver_pair_from_root_area(data) } {
+        pair.0.prune_forced_virtuals(classify);
+    }
 }
 
 /// Re-derives the thread-local `JitDriverPair` for a GC root walk from the


### PR DESCRIPTION
Follow-up to #899, acting on its review. Two findings on `MetaInterp::forced_virtuals` — pyre's stand-in for the `AllVirtuals` upstream hides in the deadframe's `jf_savedata` word — plus the unit test coderabbit asked for.

Sections 4-6 were added later: chasing this PR's failing `pyre/check.py (macos-latest)` job led to a GC-corrupting descr-census gap that was already red on `main`, plus one adjacent hardening and the `main` build fix the branch needs to be gated at all.

## 1. The cache was in no root set

The ptr half holds what `force_all_virtuals` (`resume.py:969-981`) materialized, and it lives from the force until the following `GUARD_NOT_FORCED` consumes it. Nothing rooted those slots.

The exposure is *reclamation*, not relocation: virtuals are allocated non-moving (`dynasm_alloc_oldgen_typed`), so there is nothing to forward — but `OldGen::sweep_arenas_step` frees any old-generation object that lacks `flags::VISITED`, and `finish_alloc_in_oldgen` sets that flag only when a marking cycle is already in progress. A virtual named *only* by a resume frame's ref registers is written nowhere else at force time, so this `Vec` is its only referent. Upstream is immune because `jf_savedata` is traced as a real GCREF field (`majit-backend/src/jitframe.rs:354` — the previous citation, `:278`, is `JitFrame::init`, and is corrected here).

Fix: enroll it as the fifth `register_mutator_extra_area` member, alongside `rd_consts` / `partial_trace` / `active_trace` / `compile_snapshot`. Only the ptr half is walked — the int half is `virtuals_int_cache`, unboxed integer field values, and handing those to the visitor would test integers as heap addresses. `prepare_resume_heap_with_roots` roots the same one half for the same reason.

`push_resume_ref_roots` cannot serve here: it snapshots `(ptr, len)` and releases by depth truncation, and this window spans a return to compiled code — every intervening `Drop` would truncate past the force-time push. `residual_call.rs:589-594` already documents that and solves it with a permanent extra area.

Rooting alone would leak, so an ephemeron pruner is registered too, modelled on `mapdict::prune_dead_owner_entries`: an entry the guard never consumes is dropped when its owner frame is swept, which is the lifetime `jf_savedata` gets for free by living on the deadframe. Without it an unconsumed entry pins its objects for the process lifetime and leaves a stale `PyFrame` key that a later frame at the same address could fish.

The pruner is registered per mutator, not through the global `register_ephemeron_pruner`. That registration hands the classifier no way to name a thread, so it would have forced the pyre side to read `JIT_DRIVER` from caller TLS and see only the collecting thread's driver — contradicting the contract stated on `MutatorExtraWalkFn` ("must derive every thread-specific address from `data`, never from caller TLS") and leaving another mutator's dead-owner entries pinned. So `register_mutator_pruner` / `prune_all_mutator_areas` / `prune_my_mutator_areas` join the extra-area equivalents in the same `MutatorEntry`, and the collector picks between all-mutator and own-mutator on `gc_sync::mutators_quiesced()` — the same predicate `do_collect_nursery` and `enumerate_root_walker_values` use, so a collection's prune reach always equals its own root-walk reach. That branch is load-bearing: the unconditional form tripped the quiescence assertion, because the pre-sweep point does not own STW. The mapdict tables stay on the global registration; they are a process-global `Mutex` map, reachable from any thread.

The entry is keyed by a bare address, which is sound only because the virtualizable is move-stable: it comes from `FrameBox::new` → `try_gc_alloc_stable_raw`, whose registered contract is "stable across minor and major collections (MiniMark mark-sweep does not move old-gen objects)", never from the frames a trace builds virtually (`emit_new_pyframe_inline_with_params` → `NewWithVtable`, which can land in the nursery). `save_forced_virtuals` now asserts that, so the invariant is checked rather than argued.

## 2. `force_pyframe_vref` dropped the cache

`compile.py:996-1000` calls `set_savedata_ref` **inside** `handle_async_forcing`. #899 did it at the `force_pyframe` hook instead, so `force_pyframe_vref` — the materializing arm of `virtualref.py:134 force_virtual_if_necessary`, which calls `force_virtualizable_token` as a statement — discarded what the force produced, and its `GUARD_NOT_FORCED` rebuilt the virtuals from `rd_virtuals`.

Fix: move the store inside, as upstream has it. `force_from_resumedata` now also returns the virtualizable its vable section named (`resume.py:1404`), and `handle_async_forcing` keys the store on that — so the key comes from the guard's own resume data rather than from a caller-side guess, and both force entry points are covered by construction. `force_virtualizable_token` returns nothing, like `force_now`.

## 3. Tests and a diagnostic

Two tests for the `all_virtuals = Some(..)` resume:

- `consume_vref_and_vable` jumps the vable and vref sections (`resume.py:1433-1435`) — asserted by decoding the *same* resume data twice and checking that the ordinary path surfaces the virtualizable while the `GUARD_NOT_FORCED` path surfaces none and the frame section behind them still decodes (which is what proves the jump lengths line up).
- `_prepare_virtuals` zeroes a preloaded cache (`resume.py:990-991`), which is why `blackhole_from_resumedata` must pass `rd_virtuals`/`rd_guard_pendingfields` as `None` on that path.

Plus a `[jit][take_forced_virtuals] owner=.. hit/miss` counterpart to the existing `handle_async_forcing` line. Only a `GUARD_NOT_FORCED` reaches it (`is_guard_forced()` gates the callers), so hit/miss is the force→resume handoff itself.

## Two review findings adjudicated as false positives

- **`jitdriver.rs:3766/6209` pass `all_virtuals = None`.** Those are the majit state-field macro JIT's resume paths. That JIT has no virtualizable force — its virtualizable is a host-stack `&state`, `force_virtualizable_token` is never called on it, and `handle_async_forcing` is unreachable there — so there is never a cache to hand over. `None` is correct, not a dropped edge.
- **The miss fallback should resume with `ragnf = 2` and an empty cache.** It resumes with `None` instead, i.e. it rebuilds. That is strictly the safer of the two: `ragnf = 2` with an empty cache would make any `TAGVIRTUAL` reference index an empty `virtuals_cache`, whereas rebuilding produces a correct (if redundant) object set. This mirrors `compile.py:959-960`, which also tolerates an absent cache.

## 4. `PyFrame.vable_token` was never zero-initialized on a JIT-allocated frame

Found while chasing the `synth/mutate_then_raise_caught` abort that was already
red on `main` (`pyre/check.py` cranelift 344/345, and the `macos-latest` job on
this PR): `GC BUG: invalid type_id=… site=minor_custom_trace_target`, reached
from `gc_alloc_nursery_shim`.

The nursery is deliberately not zero-filled — `Nursery::reset` mirrors
`incminimark.py:211 malloc_zero_filled = False` — and the backend's
`CallMallocNursery` fast path clears only the 8-byte header word. So the whole
zero-initialization of a JIT-inline-allocated object is the pending stores that
`rewrite.py:498-504 clear_gc_fields` derives from `descr.gc_fielddescrs()`.

`rvirtualizable.py:29` appends `('vable_token', llmemory.GCREF)` to the
virtualizable's own fields, so upstream's `gc_fielddescrs` names it and the slot
is cleared on every `new`. pyre types the field `usize` and
`PYFRAME_DESCR_GROUP`'s positional census never listed it, so
`emit_new_pyframe_inline_with_params`' `NewWithVtable(pyframe_size_descr())`
left it holding bytes from the previous nursery cycle.
`emit_force_virtualizable` (`pyjitpl.py:1148-1158`) then read them with
`GETFIELD_GC_R`; the backend spilled that Ref into a jitframe ref-root slot and
marked it live in the call site's gcmap, so the next minor collection
dereferenced them.

Fix: carry the edge through a new `build_object_descr_group_with_extra_gc_edges`
lane — the one the inherited `PyObject.w_class` edge already uses — which adds to
`gc_fielddescrs` without disturbing the positional `all_fielddescrs` that
`field_descr_from_group` indexes. Adding it positionally instead would risk a
descr split.

### How it was pinned down

The panic's neighbourhood dump is what settled it. Reading each word around
`obj_addr` as a header and stepping by that type's size landed **exactly** on the
next candidate header (`0 → 8 + 24 = 32`), which proves `obj_addr` was a *header*
address and the real object was `obj_addr + 8` — so the slot held a bad value,
not a stale pointer. From there: the holder's `jf_gcmap` bits gave the slot
(`bit = max_output_slots + slot`, `holder_offset = 64 + 8*bit`), the backend's
`ref_root_slots` named the producing var, and its defining op was
`GcLoadR(v651, #80)` off a `CallMallocNursery(240)` whose offset 80 had no store.
The `GcStore(p, ofs, #0)` ops already in the trace **are** the `clear_gc_fields`
pending zeros, so "which offsets got a zero" reads the census straight off the
trace.

It looked nondeterministic because it reproduces 5/5 under non-tty stdio
(`capture_output=True, stdin=DEVNULL`) and 0/100 standalone — stdio setup shifts
the allocation history, hence what the recycled bytes happen to hold.

### Audit of the same class

Every hand-written descr group that JIT code can allocate was checked against its
Rust struct's GC pointers. `PyFrame` was the only gap.

| descr | GC pointers in the struct | census |
|---|---|---|
| `PyFrame` | …, **`vable_token`** | missing → fixed here |
| `W_ListObject` | `items`, `int_items.block`, `float_items.block` | all `Type::Ref` |
| `PyTraceback` | `w_class`, `frame`, `w_next`, `w_code` | all declared; the emitter stores all six fields |
| `W_FloatObject` | `w_dict`, `w_slots` (forwarded unconditionally) | both `Type::Ref` |
| `W_LongObject` | `value` | `Type::Ref` |
| `W_IntObject`, `W_TupleObject`, `Method`, `W_SliceObject`, specialised tuples | — | complete |

`W_DictObject` (`dstrategy`, `dstorage`) and `W_ObjectObject` (`storage`) have
incomplete censuses, but neither has a `*_size_descr()` accessor at all, so no
allocation op can carry them — unreachable today, not fixed here.

## 5. The inline empty list assumed a memzero that does not happen

Same false premise, one level down: `emit_empty_list_inline` and
`w_list_size_descr`'s doc both stated that `NewWithVtable` leaves untouched slots
zero-filled. `items` / `int_items.block` / `float_items.block` are GC-pointer
fields of the descr and so *are* covered by `clear_gc_fields`; `length` is a plain
int and was not. It is unreachable today — `set_object_items_from_vec` resets
`length` on the Empty→Object transition and the typed strategies read
`*_items.len` instead — so this is hardening, not a live bug. Stored explicitly,
as `rlist.py ll_newlist` does, and both comments restated in terms of the
mechanism that actually clears the slots.

## 6. `main` did not compile

`#907` added a second `#[cfg(not(feature = "sandbox"))] fn
interp_return_log_enabled` with an identical body next to the existing one, so
`pyre-interpreter` fails E0428. The branch cannot be built or gated without
removing it, so the duplicate is dropped here.

## Verification

Witness for the handoff, on the #899 fixture `getframe_caller_locals_nested_compiled_callee`:

| backend | forces | hits | misses | output |
|---|---|---|---|---|
| dynasm | 5 | 5 | 0 | 105005 ✓ |
| cranelift | 5 | 5 | 0 | 105005 ✓ |

Identical to the pre-change measurement, which is what confirms the new key (the decoded virtualizable) resolves to the same frame the consumer looks up.

The `mutate_then_raise_caught` abort of section 4 reproduces 5/5 on `origin/main` without any commit from this branch, and 0/30 with the fix.

Gate, rebased onto `origin/main` `25b2442c4e`: `check.py` **dynasm 345/345, cranelift 345/345, wasm 341/341**. Before section 4 the same tree was cranelift 344/345 — that one failure is this bug. Earlier in the branch: differential JIT-vs-`PYRE_NO_JIT` corpus 329/329 on both backends · `cargo test -p majit-metainterp --lib` 1418 passed · `cargo fmt --check` clean · type-checks on dynasm, cranelift and wasm32.

Honest scope note: the current corpus produces `forces == hits` — every entry is consumed, so the pruner never fires and no collection lands inside the rooting window. Both are structural fixes; the paths that leave an entry unconsumed are the escaped-virtualizable raise and `handle_fail`'s bridge-compiled arm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved `GUARD_NOT_FORCED` resumption when virtualizable values are present, ensuring decoding stays aligned.
  - Fixed forced-virtual cache handling to avoid keeping stale entries after their owning frames are gone.
  - Added GC tracking so forced-virtual references are properly walked and pruned.

- **Improvements**
  - Enhanced forced-virtual caching behavior, including hit/miss logging.
  - Added/updated metainterp resume tests to cover cache reset and forced-virtual edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
