### PR TITLE
Review fixes for #878, plus continued walker/translator work

### DIFF
--- a/majit/majit-ir/src/descr.rs
+++ b/majit/majit-ir/src/descr.rs
@@ -1260,34 +1260,56 @@ impl GcCache {
         let expected_index_in_parent =
             Self::find_index_in_parent(parent.as_ref(), field_name).unwrap_or(index_in_parent);
         // descr.py:220-221: cache[STRUCT][fieldname]
-        if let Some(inner) = self._cache_field.get(&struct_key) {
-            if let Some(descr) = inner.get(field_name) {
-                debug_assert!(
-                    descr.describes_same_field(
-                        offset,
-                        field_size,
-                        field_type,
-                        is_immutable,
-                        is_quasi_immutable,
-                        virtualizable,
-                        expected_index_in_parent,
-                    ),
-                    "get_field_descr cache hit for {field_name} disagrees with the caller: \
-                     cached (offset {}, size {}, type {:?}, immutable {}, quasi {}, vable {}, \
-                     index_in_parent {}) vs requested (offset {offset}, size {field_size}, \
-                     type {field_type:?}, immutable {is_immutable}, quasi {is_quasi_immutable}, \
-                     vable {virtualizable}, index_in_parent {expected_index_in_parent} \
-                     [caller said {index_in_parent}])",
-                    descr.offset,
-                    descr.field_size,
-                    descr.field_type,
-                    descr.is_immutable,
-                    descr.is_quasi_immutable(),
-                    descr.virtualizable,
-                    descr.index_in_parent,
-                );
-                return descr.clone();
-            }
+        let cached = self
+            ._cache_field
+            .get(&struct_key)
+            .and_then(|inner| inner.get(field_name))
+            .cloned();
+        if let Some(descr) = cached {
+            // `front/mir.rs` leaves `SemanticProgram::immutable_fields`
+            // empty for the whole LLBC pipeline — Charon serializes doc
+            // comments but not the `#[jit_immutable_fields]` hint — so
+            // every spec built from that side reports the pair
+            // `(false, false)` for a field no matter what
+            // `_immutable_fields_` says about it. That pair is the absence
+            // of the declaration channel, not a claim the field is mutable,
+            // and the hit path resolves it by keeping the cached descr's
+            // flags. Compare what is kept. The opposite direction — a
+            // caller claiming purity a cached descr denies — is a real
+            // disagreement and still trips.
+            let (expected_immutable, expected_quasi_immutable) =
+                if !is_immutable && !is_quasi_immutable {
+                    (descr.is_immutable, descr.is_quasi_immutable())
+                } else {
+                    (is_immutable, is_quasi_immutable)
+                };
+            debug_assert!(
+                descr.describes_same_field(
+                    offset,
+                    field_size,
+                    field_type,
+                    expected_immutable,
+                    expected_quasi_immutable,
+                    virtualizable,
+                    expected_index_in_parent,
+                ),
+                "get_field_descr cache hit for {field_name} disagrees with the caller: \
+                     cached {:?} (offset {}, size {}, type {:?}, immutable {}, quasi {}, vable {}, \
+                     index_in_parent {}) vs requested {display_name:?} (offset {offset}, \
+                     size {field_size}, type {field_type:?}, immutable \
+                     {expected_immutable}, quasi {expected_quasi_immutable}, \
+                     vable {virtualizable}, index_in_parent \
+                     {expected_index_in_parent} [caller said {index_in_parent}])",
+                descr.name,
+                descr.offset,
+                descr.field_size,
+                descr.field_type,
+                descr.is_immutable,
+                descr.is_quasi_immutable(),
+                descr.virtualizable,
+                descr.index_in_parent,
+            );
+            return descr;
         }
         // descr.py:227: name = '%s.%s' % (STRUCT._name, fieldname)
         let name = match display_name {

--- a/majit/majit-ir/src/descr.rs
+++ b/majit/majit-ir/src/descr.rs
@@ -408,8 +408,13 @@ pub fn struct_id_for_name(raw: &str) -> Option<StructId> {
         .trim_start_matches("&mut ")
         .trim_start_matches('&')
         .trim();
+    // Generic instantiations share the defining ADT's one physical Rust
+    // layout.  The annotator keeps `Result<T>::Ok` spellings distinct for
+    // ClassDef payload precision, but the descriptor layer must resolve all
+    // of them to the template variant identity registered from the TypeDecl.
+    let s = strip_generic_args(s);
     let guard = STRUCT_ID_BY_NAME.lock().unwrap();
-    guard.get(s).copied().flatten()
+    guard.get(s.as_ref()).copied().flatten()
 }
 
 /// Use-import resolver / module-aware canonicalisation table.

--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -8391,7 +8391,7 @@ pub fn build_inline_call_only_bh_builder() -> BlackholeInterpBuilder {
         "int_mul_jump_if_ovf/Lii>i".to_string(),
         majit_translate::insns::BC_INT_MUL_JUMP_IF_OVF,
     );
-    // The three remaining opnames the build-time `pipeline.insns` records as
+    // The remaining opnames the build-time `pipeline.insns` records as
     // actually emitted (`build_emitted_insns()`) that this curated set did not
     // cover.  Upstream never has this gap: `setup_insns(asm.insns)`
     // (`blackhole.py:58-59`) registers exactly what the assembler emitted, so
@@ -8399,18 +8399,19 @@ pub fn build_inline_call_only_bh_builder() -> BlackholeInterpBuilder {
     // missing entry is a live `dispatch_step` unwired-opcode panic that fires
     // only once a forward resume happens to land on the byte.
     //
-    // All three emit canonical operands matching their wired decoders — a
+    // All of them emit canonical operands matching their wired decoders — a
     // 1-byte register per `r`/`i`, a 2-byte little-endian descr index per `d`
-    // (`assembler.rs` `OpKind::{ArrayLen, NewWithVtable}` and the generic
-    // `UnaryOp` path vs `handler_arraylen_gc`, `handler_new_with_vtable`,
-    // `bhhandler_r_i!`) — and `arraylen_gc` / `new_with_vtable` read
-    // `bh.cpu`, which this builder sets above.
+    // (`assembler.rs` `OpKind::{ArrayLen, New, NewWithVtable}` and the generic
+    // `UnaryOp` path vs `handler_arraylen_gc`, `handler_new`,
+    // `handler_new_with_vtable`, `bhhandler_r_i!`) — and `arraylen_gc` / `new`
+    // / `new_with_vtable` read `bh.cpu`, which this builder sets above.
     for (key, byte) in [
         ("arraylen_gc/rd>i", majit_translate::insns::BC_ARRAYLEN_GC),
         (
             "cast_ptr_to_int/r>i",
             majit_translate::insns::BC_CAST_PTR_TO_INT,
         ),
+        ("new/d>r", majit_translate::insns::BC_NEW),
         (
             "new_with_vtable/d>r",
             majit_translate::insns::BC_NEW_WITH_VTABLE,

--- a/majit/majit-metainterp/src/optimizeopt/virtualize.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualize.rs
@@ -6212,4 +6212,92 @@ mod tests {
             "rd_virtuals should encode the virtual array"
         );
     }
+
+    #[test]
+    fn test_guard_fail_args_virtual_array_with_nested_virtual_item() {
+        // RPython resume.py:_number_virtuals recursively numbers a virtual
+        // stored in a virtual array item.  The array and the item remain
+        // TAGVIRTUAL; only the item's scalar payload is a TAGBOX live value.
+        let array_sd = array_descr(40);
+        let item_sd = size_descr(41);
+        let item_value_fd = field_descr(42);
+        let mut guard = Op::new(
+            OpCode::GuardTrue,
+            &[crate::history::test_support::rooted_inputarg_operand(
+                Type::Int,
+                30,
+            )],
+        );
+        guard.setfailargs(
+            vec![crate::history::test_support::rooted_resop_operand(
+                Type::Ref,
+                0,
+            )]
+            .into(),
+        );
+        let mut ops = vec![
+            Op::with_descr(
+                OpCode::NewArray,
+                &[crate::history::test_support::rooted_resop_operand(
+                    Type::Int,
+                    10,
+                )],
+                array_sd.clone(),
+            ),
+            Op::with_descr(OpCode::NewWithVtable, &[], item_sd),
+            Op::with_descr(
+                OpCode::SetfieldGc,
+                &[
+                    crate::history::test_support::rooted_resop_operand(Type::Ref, 1),
+                    crate::history::test_support::rooted_inputarg_operand(Type::Int, 40),
+                ],
+                item_value_fd,
+            ),
+            Op::with_descr(
+                OpCode::SetarrayitemGc,
+                &[
+                    crate::history::test_support::rooted_resop_operand(Type::Ref, 0),
+                    crate::history::test_support::rooted_resop_operand(Type::Int, 11),
+                    crate::history::test_support::rooted_resop_operand(Type::Ref, 1),
+                ],
+                array_sd,
+            ),
+            guard,
+        ];
+        assign_positions(&mut ops);
+
+        let result = run_pass_with_constants(
+            &ops,
+            &[
+                (OpRef::int_op(10), Value::Int(1)),
+                (OpRef::int_op(11), Value::Int(0)),
+            ],
+        );
+        let guard_op = result
+            .iter()
+            .find(|o| o.opcode == OpCode::GuardTrue)
+            .expect("guard should be emitted");
+        assert_eq!(
+            result
+                .iter()
+                .filter(|op| matches!(op.opcode, OpCode::NewArray | OpCode::NewWithVtable))
+                .count(),
+            0,
+            "nested virtual array item should remain virtual; got {result:?}"
+        );
+        let failargs = guard_op.getfailargs().unwrap();
+        assert!(
+            failargs
+                .iter()
+                .any(|arg| arg.to_opref() == OpRef::input_arg_int(40)),
+            "nested item payload should be a live TAGBOX; got {failargs:?}"
+        );
+        let virtuals = guard_op
+            .resolved_rd_virtuals()
+            .expect("rd_virtuals should encode the array and nested item");
+        assert!(
+            virtuals.len() >= 2,
+            "rd_virtuals should recursively number both virtuals; got {virtuals:?}"
+        );
+    }
 }

--- a/majit/majit-translate/src/annotator/builtin.rs
+++ b/majit/majit-translate/src/annotator/builtin.rs
@@ -373,6 +373,11 @@ fn register_builtins() -> HashMap<String, BuiltinAnalyzer> {
         "longlong2float.float2longlong",
         float2longlong_analyzer,
     );
+    analyzer_for(
+        &mut reg,
+        "longlong2float.longlong2float",
+        longlong2float_analyzer,
+    );
     // Foreign Rust container constructors — `Vec::new` /
     // `Vec::with_capacity` / `indexmap::IndexMap::new` / `Box::new`.
     // Each returns the classdef-less opaque `SomeInstance` shell (twin
@@ -1276,6 +1281,16 @@ pub fn float2longlong_analyzer(
         false,
         crate::annotator::model::KnownType::LongLong,
     )))
+}
+
+/// `longlong2float.longlong2float(llval)` — upstream
+/// `LongLong2FloatEntry.compute_result_annotation` returns `SomeFloat`.
+pub fn longlong2float_analyzer(
+    _bk: &Rc<Bookkeeper>,
+    _args_s: &[Option<SomeValue>],
+    _kwds: &HashMap<String, Option<SomeValue>>,
+) -> Result<SomeValue, AnnotatorError> {
+    Ok(SomeValue::Float(Default::default()))
 }
 
 /// Analyzer for `std::ptr::eq(p1, p2) -> bool` — Rust pointer identity

--- a/majit/majit-translate/src/codewriter/assembler.rs
+++ b/majit/majit-translate/src/codewriter/assembler.rs
@@ -1585,6 +1585,34 @@ impl Assembler {
                 let opnum = self.get_opnum(&key);
                 state.code[startposition] = opnum;
             }
+            // RPython `jtransform.py:1040-1045 rewrite_op_malloc`: a fixed-size
+            // GC struct without a vtable lowers to `new(descr)`.
+            OpKind::New { owner } => {
+                let spec = bh_size_spec_from_callcontrol(
+                    callcontrol.expect("new assembly requires a CallControl"),
+                    owner,
+                )
+                .unwrap_or_else(|| panic!("new: no struct layout registered for owner {owner:?}"));
+                let descr_idx = self.emit_ready_descr(crate::jitcode::BhDescr::Size {
+                    size: spec.size,
+                    type_id: spec.type_id,
+                    vtable: 0,
+                    owner: String::new(),
+                    all_fielddescrs: spec.all_fielddescrs,
+                    is_gc_managed: spec.is_gc_managed,
+                });
+                state.code.push((descr_idx & 0xFF) as u8);
+                state.code.push((descr_idx >> 8) as u8);
+                argcodes.push('d');
+                let result = op.result.as_ref().expect("new must produce a result");
+                let (reg, kind) = self.lookup_reg_with_kind_var(result, regallocs);
+                assert_eq!(kind, 'r', "new result must use the ref register bank");
+                state.code.push(reg);
+                argcodes.push('>');
+                argcodes.push('r');
+                let key = format!("new/{argcodes}");
+                state.code[startposition] = self.get_opnum(&key);
+            }
             // Boxing GC allocation (`fuse_boxing_alloc`).  Mirrors the runtime
             // tracer oracle (`box_trace.rs trace_box_float`): a `new_with_vtable`
             // carrying ONLY a size descriptor and a fresh ref-kind result, no
@@ -2608,6 +2636,7 @@ impl Assembler {
                 OpKind::Abort { .. } => "Abort",
                 OpKind::NewTuple { .. } => "NewTuple",
                 OpKind::NewList { .. } => "NewList",
+                OpKind::New { .. } => "New",
                 OpKind::NewWithVtable { .. } => "NewWithVtable",
                 OpKind::LoweredBlackholeOp { .. } => "LoweredBlackholeOp",
                 OpKind::LoadStatic { .. } => "LoadStatic",
@@ -3214,10 +3243,17 @@ fn bh_size_spec_from_callcontrol(
     if owner.is_empty() {
         return None;
     }
+    // RPython keys SizeDescrs on the low-level STRUCT object, not on an
+    // annotation-side generic instantiation.  Charon registers one physical
+    // layout for the generic TypeDecl, so `Result<T>::Ok` and
+    // `Result<U>::Ok` must converge on the template variant here while their
+    // ClassDefs remain distinct in the annotator.
+    let layout_owner = majit_ir::descr::strip_generic_args(owner);
+    let layout_owner = layout_owner.as_ref();
     let size = cc
-        .struct_layout_for(owner)
+        .struct_layout_for(layout_owner)
         .map(|layout| layout.size)
-        .or_else(|| heuristic_struct_size_for_bh(cc, owner))?;
+        .or_else(|| heuristic_struct_size_for_bh(cc, layout_owner))?;
     Some(crate::jitcode::BhSizeSpec {
         size,
         // Analyzer-side structs keep the guard (unchanged); the raw
@@ -3239,9 +3275,9 @@ fn bh_size_spec_from_callcontrol(
         // structs (birthday paradox), whereas PyPy's `id(STRUCT)` never
         // aliases.  The rare hash-to-zero case (1 in 2^64) is handled
         // by `simple_descr_group_from_bh_size`'s no-identity branch.
-        type_id: majit_ir::descr::path_hash(owner),
+        type_id: majit_ir::descr::path_hash(layout_owner),
         vtable: 0,
-        all_fielddescrs: bh_all_field_specs_for_struct(cc, owner),
+        all_fielddescrs: bh_all_field_specs_for_struct(cc, layout_owner),
     })
 }
 
@@ -3956,6 +3992,7 @@ fn op_kind_to_opname(kind: &crate::model::OpKind) -> String {
             opname
         }
         OpKind::FieldWrite { ty, .. } => format!("setfield_gc_{}", value_type_to_kind(ty)),
+        OpKind::New { .. } => "new".into(),
         OpKind::NewWithVtable { .. } => "new_with_vtable".into(),
         // RPython: getarrayitem_gc_i etc.
         OpKind::ArrayRead { item_ty, .. } => {

--- a/majit/majit-translate/src/codewriter/assembler.rs
+++ b/majit/majit-translate/src/codewriter/assembler.rs
@@ -3481,6 +3481,22 @@ fn fielddescrof(
 
     if let (Some(cc), Some(owner)) = (callcontrol, field.owner_root.as_deref()) {
         parent = bh_size_spec_from_callcontrol(cc, owner);
+        // RPython `descr.py:108-118,218-239` keys both the SizeDescr and
+        // FieldDescr caches on the low-level STRUCT object, never on the
+        // spelling used to reach that object.  The Rust front end can carry
+        // the same external type as `core::result::Result<T, E>` at a
+        // synthetic constructor and `result::Result<T, E>` at a MIR
+        // discriminant read (the crate prefix is stripped from the latter).
+        // Preserve the source-attached StructId across that spelling split so
+        // both operations resolve through one parent SizeDescr and therefore
+        // one `__discriminant` FieldDescr.
+        if let Some(parent_spec) = parent.as_mut()
+            && let Some(owner_id) = field
+                .owner_id
+                .or_else(|| majit_ir::descr::struct_id_for_name(owner))
+        {
+            parent_spec.type_id = owner_id.as_u64();
+        }
         if let Some(parent_spec) = parent.as_ref() {
             let full_name = bh_field_name(owner, &field.name);
             if let Some(spec) = parent_spec
@@ -4588,6 +4604,44 @@ mod tests {
         // base; the mint must fail the build rather than pick a base.
         let word = crate::layout::target_word_size();
         let _ = vable_arraydescrof(&crate::model::ValueType::Int, word * 2, true);
+    }
+
+    #[test]
+    fn fielddescrof_uses_struct_id_across_owner_spellings() {
+        use crate::call::CallControl;
+        use crate::model::FieldDescriptor;
+
+        let mut cc = CallControl::new();
+        let mut struct_fields = crate::front::StructFieldRegistry::default();
+        for owner in ["core::result::Result", "result::Result"] {
+            struct_fields.fields.insert(
+                owner.to_string(),
+                vec![("__discriminant".to_string(), "i64".to_string())],
+            );
+        }
+        cc.set_struct_fields(struct_fields);
+        let owner_id = majit_ir::descr::StructId::from_canonical("result::Result");
+        let parent_type_id = |owner: &str| {
+            let field = FieldDescriptor::new("__discriminant", Some(owner.to_string()))
+                .with_owner_id(Some(owner_id));
+            let crate::jitcode::BhDescr::Field {
+                parent: Some(parent),
+                ..
+            } = fielddescrof(&field, &crate::model::ValueType::Int, Some(&cc))
+            else {
+                panic!("Result discriminant must carry a parent descriptor");
+            };
+            parent.type_id
+        };
+
+        assert_eq!(
+            parent_type_id("core::result::Result<i64,PyError>"),
+            parent_type_id("result::Result<i64,PyError>"),
+        );
+        assert_eq!(
+            parent_type_id("core::result::Result<i64,PyError>"),
+            owner_id.as_u64(),
+        );
     }
 
     #[test]

--- a/majit/majit-translate/src/codewriter/call.rs
+++ b/majit/majit-translate/src/codewriter/call.rs
@@ -760,6 +760,18 @@ pub struct CallControl {
     /// the stable symbolic address shim.
     function_fnaddrs: HashMap<CallPath, i64>,
 
+    /// Memoised [`Self::builtin_wrapper_indirect_graphs`] family.
+    ///
+    /// Derived from `function_fnaddrs` + `function_graphs`, both of which
+    /// are written only in the setup phase that precedes `make_jitcodes`
+    /// (`register_function_fnaddr` is the single `function_fnaddrs` insert
+    /// site).  The readers — the `find_all_graphs` BFS seed,
+    /// `grab_initial_jitcodes` and `lower_indirect_calls`, the last of
+    /// which runs once per drained graph — all see those frozen inputs, so
+    /// the family is computed once.  `OnceCell` for the same shared-`&self`
+    /// reason as `builtin_func_for_spec_cache`.
+    builtin_wrapper_family: std::cell::OnceCell<Vec<CallPath>>,
+
     /// RPython `rtyper._builtin_func_for_spec_cache` (`support.py:805-807`).
     ///
     /// Memoises the `(c_func, LIST_OR_DICT)` pair upstream computes
@@ -1342,6 +1354,7 @@ impl CallControl {
             jitdrivers_sd: Vec::new(),
             jitcodes: indexmap::IndexMap::new(),
             function_fnaddrs: HashMap::new(),
+            builtin_wrapper_family: std::cell::OnceCell::new(),
             builtin_func_for_spec_cache: std::cell::RefCell::new(HashMap::new()),
             need_result_type_registry: std::cell::RefCell::new(HashMap::new()),
             builtin_factory_registry: std::cell::RefCell::new(HashMap::new()),
@@ -3203,9 +3216,10 @@ impl CallControl {
         // `bh_call_fn`, bypassing that source-level dispatch graph, so seed the
         // same generated-wrapper PBC family explicitly.  This is the builtin
         // gateway analogue of call.py:59-64's oopspec helper seeds below.
-        for path in self.builtin_wrapper_indirect_graphs() {
+        let builtin_wrappers = self.builtin_wrapper_indirect_graphs().to_vec();
+        for path in &builtin_wrappers {
             if self.candidate_graphs.insert(path.clone()) {
-                todo.push(path);
+                todo.push(path.clone());
             }
         }
         // call.py:59-64 — seed the BFS with builtin oopspec helpers so
@@ -3349,9 +3363,7 @@ impl CallControl {
                         // `c_graphs` family, `None` meaning "unknown
                         // family" and classifying the site as residual.
                         OpKind::IndirectCall { graphs, .. } => match graphs {
-                            Some(graphs) if graphs.is_empty() => {
-                                self.builtin_wrapper_indirect_graphs()
-                            }
+                            Some(graphs) if graphs.is_empty() => builtin_wrappers.clone(),
                             Some(graphs) => graphs.clone(),
                             None => continue,
                         },
@@ -3794,7 +3806,8 @@ impl CallControl {
         // indirect op to perform the allocation.  Materialise the same PBC
         // family here so runtime fnaddr dispatch can resolve each generated
         // gateway body to its JitCode.
-        for wrapper in self.builtin_wrapper_indirect_graphs() {
+        let wrappers = self.builtin_wrapper_indirect_graphs().to_vec();
+        for wrapper in wrappers {
             self.get_jitcode(&wrapper);
         }
     }
@@ -4636,8 +4649,16 @@ impl CallControl {
     /// `jit_trace_fnaddrs`; pair those addresses with their registered source
     /// graphs here. Aliases sharing an address name the same wrapper; select
     /// the most-qualified source identity for the one graph object entered
-    /// into the PBC family.
-    pub fn builtin_wrapper_indirect_graphs(&self) -> Vec<CallPath> {
+    /// into the PBC family.  The family is memoised in
+    /// `builtin_wrapper_family`; its inputs are frozen before the first
+    /// reader runs.  Members are ordered by wrapper address (the
+    /// `by_address` key), i.e. by the link-time layout of the host binary.
+    pub fn builtin_wrapper_indirect_graphs(&self) -> &[CallPath] {
+        self.builtin_wrapper_family
+            .get_or_init(|| self.compute_builtin_wrapper_indirect_graphs())
+    }
+
+    fn compute_builtin_wrapper_indirect_graphs(&self) -> Vec<CallPath> {
         let mut by_address: std::collections::BTreeMap<i64, Vec<CallPath>> =
             std::collections::BTreeMap::new();
         for (path, &fnaddr) in &self.function_fnaddrs {
@@ -4649,10 +4670,28 @@ impl CallControl {
             }
             by_address.entry(fnaddr).or_default().push(path.clone());
         }
+        // Most-qualified spelling wins.  `register_macro_helper_trace_fnaddr`
+        // binds one address under both a `crate`-prefixed alias and the
+        // crate-root-qualified spelling, which tie at maximal length, so the
+        // pick resolves on a total order rather than on `function_fnaddrs`
+        // iteration order: demote the `crate` placeholder, leaving the
+        // spelling `target_to_path` returns for a direct call to the wrapper,
+        // then compare the segment sequences.
+        let crate_placeholder =
+            |path: &CallPath| path.segments.first().is_some_and(|seg| seg == "crate");
         let mut result = Vec::new();
-        for mut aliases in by_address.into_values() {
-            aliases.sort_by_key(|path| std::cmp::Reverse(path.segments.len()));
-            result.push(aliases.remove(0));
+        for aliases in by_address.into_values() {
+            let pick = aliases
+                .into_iter()
+                .min_by(|a, b| {
+                    b.segments
+                        .len()
+                        .cmp(&a.segments.len())
+                        .then_with(|| crate_placeholder(a).cmp(&crate_placeholder(b)))
+                        .then_with(|| a.segments.cmp(&b.segments))
+                })
+                .expect("address bucket holds at least one alias");
+            result.push(pick);
         }
         result
     }

--- a/majit/majit-translate/src/codewriter/call.rs
+++ b/majit/majit-translate/src/codewriter/call.rs
@@ -7459,7 +7459,7 @@ fn op_can_raise(op: &OpKind) -> RaiseClass {
         OpKind::FieldRead { .. } | OpKind::FieldWrite { .. } => RaiseClass::No,
         // `malloc` can only raise MemoryError; with `ignore_memoryerror`
         // it is treated as non-raising (canraise = (MemoryError,)).
-        OpKind::NewWithVtable { .. } => RaiseClass::MemoryErrorOnly,
+        OpKind::New { .. } | OpKind::NewWithVtable { .. } => RaiseClass::MemoryErrorOnly,
         // RPython LL: getarrayitem_gc, setarrayitem_gc, arraylen_gc → cannot raise
         OpKind::ArrayRead { .. } | OpKind::ArrayWrite { .. } | OpKind::ArrayLen { .. } => {
             RaiseClass::No

--- a/majit/majit-translate/src/codewriter/jtransform.rs
+++ b/majit/majit-translate/src/codewriter/jtransform.rs
@@ -2878,6 +2878,56 @@ impl<'a> Transformer<'a> {
                 kind: OpKind::ConstRefNull,
             }]);
         }
+        // RPython `rtyper` lowers a heap-carried `Result` variant to
+        // `malloc(GcStruct)` plus its discriminant/payload `setfield`s before
+        // `jtransform`; `rewrite_op_malloc` then emits `new(descr)`.
+        // Charon exposes the pre-rtyper shape instead: a niladic synthetic
+        // ctor followed by a payload `FieldWrite`, and it does not spell the
+        // enum tag as a separate MIR operand. Restore the exact low-level
+        // shape here. The existing payload write follows this replacement in
+        // program order; the tag write is emitted beside the allocation.
+        if let CallTarget::SyntheticTransparentCtor { name, owner_path } = target
+            && args.is_empty()
+            && matches!(name.as_str(), "Ok" | "Err")
+            && owner_path
+                .last()
+                .is_some_and(|owner| owner.starts_with("Result"))
+            && let ValueType::Ref(Some(owner)) = result_ty
+        {
+            let tag = i64::from(name == "Err");
+            let result_base = owner
+                .strip_suffix(format!("::{name}").as_str())
+                .unwrap_or(owner)
+                .to_string();
+            let result = op
+                .result
+                .clone()
+                .expect("SyntheticTransparentCtor must produce a value");
+            return RewriteResult::Replace(vec![
+                SpaceOperation {
+                    result: Some(result.clone()),
+                    kind: OpKind::New {
+                        owner: owner.clone(),
+                    },
+                },
+                SpaceOperation {
+                    result: None,
+                    kind: OpKind::FieldWrite {
+                        base: result,
+                        field: crate::model::FieldDescriptor::new(
+                            "__discriminant",
+                            Some(result_base),
+                        ),
+                        value: crate::model::LinkArg::Const(
+                            crate::flowspace::model::Constant::new(
+                                crate::flowspace::model::ConstValue::Int(tag),
+                            ),
+                        ),
+                        ty: ValueType::Int,
+                    },
+                },
+            ]);
+        }
         // `rbuiltin.py:412-418 rtype_const_result` /
         // `translator/rtyper/rbuiltin.rs::rtype_ptr_null`: by the time
         // jtransform runs, `ptr::null[_mut]()` is a typed null pointer
@@ -5644,6 +5694,7 @@ fn remap_op(
         | OpKind::LoopHeader { .. }
         | OpKind::Abort { .. }
         | OpKind::LoadStatic { .. }
+        | OpKind::New { .. }
         | OpKind::NewWithVtable { .. } => op.kind.clone(),
         OpKind::NewTuple { args } => OpKind::NewTuple {
             args: args.iter().map(|a| remap_value(a, aliases)).collect(),
@@ -8832,6 +8883,64 @@ mod tests {
             RewriteResult::Identity(alias) => assert_eq!(alias, arg),
             _ => panic!("expected Identity alias to the operand"),
         }
+    }
+
+    #[test]
+    fn niladic_result_variant_lowers_to_new_and_tag_store() {
+        let config = GraphTransformConfig::default();
+        let mut transformer = Transformer::new(&config);
+        let mut graph = FunctionGraph::new("result_variant_malloc");
+        let result_var = graph.alloc_value_var_with_type(ConcreteType::GcRef);
+        let owner = "core::result::Result<i64,PyError>::Err".to_string();
+        let target = CallTarget::synthetic_transparent_ctor_with_owner(
+            vec![
+                "core".to_string(),
+                "result".to_string(),
+                "Result<i64,PyError>".to_string(),
+            ],
+            "Err",
+        );
+        let result_ty = ValueType::Ref(Some(owner.clone()));
+        let op = SpaceOperation {
+            result: Some(result_var.clone()),
+            kind: OpKind::Call {
+                target: target.clone(),
+                args: vec![],
+                result_ty: result_ty.clone(),
+            },
+        };
+
+        let RewriteResult::Replace(ops) = transformer.rewrite_op_direct_call(
+            &op,
+            &target,
+            &[],
+            &result_ty,
+            "result_variant_malloc",
+            &mut graph,
+        ) else {
+            panic!("niladic Result variant must lower to malloc + tag store");
+        };
+        assert_eq!(ops.len(), 2);
+        assert!(matches!(
+            &ops[0],
+            SpaceOperation {
+                result: Some(result),
+                kind: OpKind::New { owner: allocated },
+            } if result == &result_var && allocated == &owner
+        ));
+        assert!(matches!(
+            &ops[1].kind,
+            OpKind::FieldWrite {
+                base,
+                field,
+                value: crate::model::LinkArg::Const(value),
+                ty: ValueType::Int,
+            } if base == &result_var
+                && field.name == "__discriminant"
+                && field.owner_root.as_deref()
+                    == Some("core::result::Result<i64,PyError>")
+                && value.value == crate::flowspace::model::ConstValue::Int(1)
+        ));
     }
 
     /// `fold_we_are_jitted_calls` rewrites the `we_are_jitted()`

--- a/majit/majit-translate/src/flowspace/model.rs
+++ b/majit/majit-translate/src/flowspace/model.rs
@@ -1969,16 +1969,18 @@ impl HostEnv {
         let bigint = HostObject::new_module("BigInt");
         bigint.module_set("from", HostObject::new_builtin_callable("BigInt.from"));
 
-        // `longlong2float.float2longlong(x)` reinterprets an f64 bit pattern as
-        // i64 (`convert_float_bytes_to_longlong` llop).  The front-end mints this
-        // callsite in the `f64::is_sign_negative` lowering; surface a module-shaped
-        // stub so Branch 3b in `flowspace_adapter::translate_op` resolves the
-        // 2-segment path, the annotator types it `SomeInteger(r_longlong)`, and the
-        // rtyper's `Float2LongLong` extregistry entry emits the genop.
+        // RPython `rlib.longlong2float` bitcast pair.  The front-end mints
+        // these callsites for Rust's `f64::{to_bits,from_bits}` surface;
+        // expose both ExtRegistryEntry-backed functions so annotation and
+        // rtyping emit the matching convert_* llops.
         let longlong2float = HostObject::new_module("longlong2float");
         longlong2float.module_set(
             "float2longlong",
             HostObject::new_builtin_callable("longlong2float.float2longlong"),
+        );
+        longlong2float.module_set(
+            "longlong2float",
+            HostObject::new_builtin_callable("longlong2float.longlong2float"),
         );
 
         // Rust primitive type conversion impls (`u32::from`,

--- a/majit/majit-translate/src/front/llbc_hints.rs
+++ b/majit/majit-translate/src/front/llbc_hints.rs
@@ -18,7 +18,7 @@ use majit_charon_reader::{
     Llbc,
     ullbc::{GlobalDecl, Operand, PlaceKind, Rvalue, StmtKind},
 };
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 /// Marker-const name prefix → the JIT hint strings it implies.  The
 /// user function's leaf name is the const leaf with the prefix stripped.
@@ -47,6 +47,10 @@ const CONST_PREFIX_HINTS: &[(&str, &[&str])] = &[
 pub fn harvest_hints_from_llbcs(llbcs: &[Llbc]) -> HashMap<String, Vec<String>> {
     let mut out: HashMap<String, Vec<String>> = HashMap::new();
     for llbc in llbcs {
+        let function_paths: HashSet<String> = llbc
+            .iter_local_fns()
+            .map(|fd| strip_crate_prefix(&fd.item_meta.name_path()))
+            .collect();
         for gd in llbc.iter_global_decls() {
             let path = gd.item_meta.name_path();
             let leaf = path.rsplit("::").next().unwrap_or(path.as_str());
@@ -75,7 +79,7 @@ pub fn harvest_hints_from_llbcs(llbcs: &[Llbc]) -> HashMap<String, Vec<String>> 
                 };
                 push_hint(
                     &mut out,
-                    marker_path_to_fn_path(&path, "_jit_look_inside_"),
+                    marker_path_to_fn_path(&path, "_jit_look_inside_", &function_paths),
                     hint,
                 );
                 continue;
@@ -108,7 +112,7 @@ pub fn harvest_hints_from_llbcs(llbcs: &[Llbc]) -> HashMap<String, Vec<String>> 
                 // resolve names→positions; emit it here when such a spec lands.
                 push_hint(
                     &mut out,
-                    marker_path_to_fn_path(&path, "oopspec_"),
+                    marker_path_to_fn_path(&path, "oopspec_", &function_paths),
                     &format!("oopspec:{spec}"),
                 );
                 continue;
@@ -122,7 +126,7 @@ pub fn harvest_hints_from_llbcs(llbcs: &[Llbc]) -> HashMap<String, Vec<String>> 
                     if should_skip_generated_elidable_helper(fn_name) {
                         continue;
                     }
-                    let key = marker_path_to_fn_path(&path, prefix);
+                    let key = marker_path_to_fn_path(&path, prefix, &function_paths);
                     for hint in *hints {
                         push_hint(&mut out, key.clone(), hint);
                     }
@@ -146,7 +150,11 @@ fn push_hint(out: &mut HashMap<String, Vec<String>>, key: String, hint: &str) {
     out.entry(key).or_default().push(hint.to_string());
 }
 
-fn marker_path_to_fn_path(marker_path: &str, prefix: &str) -> String {
+fn marker_path_to_fn_path(
+    marker_path: &str,
+    prefix: &str,
+    function_paths: &HashSet<String>,
+) -> String {
     let stripped = strip_crate_prefix(marker_path);
     match stripped.rsplit_once("::") {
         Some((module, leaf)) => {
@@ -157,10 +165,20 @@ fn marker_path_to_fn_path(marker_path: &str, prefix: &str) -> String {
             // promotes under `<method>::_elidable_function_<method>`.
             // In that spelling the parent already is the function path; do
             // not append the leaf a second time.
-            if module.rsplit("::").next() == Some(fn_leaf) {
+            // A module and its free function may legitimately have the same
+            // leaf (`stack_check::stack_check`).  The old leaf-equality
+            // heuristic collapsed that path to `stack_check`, silently
+            // dropping its `dont_look_inside` hint.  Resolve against Charon's
+            // actual function declarations: a sibling marker names
+            // `module::fn_leaf`, while an impl/body-local marker names its
+            // already-complete parent function path.
+            let sibling_path = format!("{module}::{fn_leaf}");
+            if function_paths.contains(&sibling_path) {
+                sibling_path
+            } else if function_paths.contains(module) {
                 module.to_string()
             } else {
-                format!("{module}::{fn_leaf}")
+                sibling_path
             }
         }
         None => stripped
@@ -292,7 +310,34 @@ fn decode_bool_const(value: &serde_json::Value) -> Option<bool> {
 
 #[cfg(test)]
 mod tests {
-    use super::decode_str_const;
+    use super::{decode_str_const, marker_path_to_fn_path};
+    use std::collections::HashSet;
+
+    #[test]
+    fn marker_path_keeps_same_named_module_function() {
+        let functions = HashSet::from(["stack_check::stack_check".to_string()]);
+        assert_eq!(
+            marker_path_to_fn_path(
+                "pyre_interpreter::stack_check::_jit_look_inside_stack_check",
+                "_jit_look_inside_",
+                &functions,
+            ),
+            "stack_check::stack_check"
+        );
+    }
+
+    #[test]
+    fn marker_path_keeps_impl_body_local_parent() {
+        let functions = HashSet::from(["rbigint::RBigInt::mul".to_string()]);
+        assert_eq!(
+            marker_path_to_fn_path(
+                "pyre_object::rbigint::RBigInt::mul::_elidable_function_mul",
+                "_elidable_function_",
+                &functions,
+            ),
+            "rbigint::RBigInt::mul"
+        );
+    }
 
     #[test]
     fn decode_str_const_reads_constant_expr_literal() {

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -6643,6 +6643,32 @@ impl<'a> Lowering<'a> {
                     self.graph.set_goto(bb_id, target_bb, link_args);
                     return Ok(());
                 }
+                // `f64::from_bits(bits)` is RPython's
+                // `longlong2float.longlong2float(bits)`: reinterpret the integer
+                // bit pattern as an f64 instead of following the opaque core body.
+                if args.len() == 1 && self.is_f64_from_bits(&reg) {
+                    let res = self
+                        .graph
+                        .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
+                    self.graph.block_mut(bb_id).operations.push(SpaceOperation {
+                        result: Some(res.clone()),
+                        kind: OpKind::Call {
+                            target: CallTarget::FunctionPath {
+                                segments: vec![
+                                    "longlong2float".to_string(),
+                                    "longlong2float".to_string(),
+                                ],
+                            },
+                            args: vec![args[0].clone()],
+                            result_ty: ValueType::Float,
+                        },
+                    });
+                    self.local_var[dest_local] = Some(res);
+                    let target_bb = self.block_id[target];
+                    let link_args = self.edge_args(mir_bb, target)?;
+                    self.graph.set_goto(bb_id, target_bb, link_args);
+                    return Ok(());
+                }
                 // `f64::is_sign_negative(x)` is `float2longlong(x) < 0` — reinterpret
                 // the f64 bits as i64 (sign bit = MSB) instead of an unresolved call.
                 if args.len() == 1 && self.is_f64_is_sign_negative(&reg) {
@@ -9226,6 +9252,19 @@ impl<'a> Lowering<'a> {
         self.llbc
             .fn_by_id(*id)
             .is_some_and(|fd| fd.item_meta.name_path() == "core::f64::<Impl>::is_finite")
+    }
+
+    /// `f64::from_bits(bits)` — `core` has no graph body (Opaque), so map the
+    /// callsite to RPython's `longlong2float.longlong2float` external operation.
+    /// Its rtyper specialization emits `convert_longlong_bytes_to_float`, the
+    /// exact inverse of `float2longlong`.
+    fn is_f64_from_bits(&self, reg: &RegularCall) -> bool {
+        let CallKind::Fun(FunId::Regular { id }) = &reg.kind else {
+            return false;
+        };
+        self.llbc
+            .fn_by_id(*id)
+            .is_some_and(|fd| fd.item_meta.name_path() == "core::f64::<Impl>::from_bits")
     }
 
     /// `f64::is_sign_negative(self)` — `core` has no graph body (Opaque), so the

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -2403,7 +2403,7 @@ struct Lowering<'a> {
     /// lowering completes.  The paired `Option<String>` is the callee's
     /// per-instantiation `<…>` suffix (Ref-shaped payloads only) keying
     /// the rebuilt `Ok`/`Err` shells' ClassDef per instantiation.
-    result_exc_call_results: Vec<(Variable, Option<String>)>,
+    result_exc_call_results: Vec<(Variable, Option<String>, ValueType)>,
     /// `Iterator::next()` call results (`Option<T>`-typed) recorded for
     /// the `next`-diamond rewiring pass (`front::iter_next`) that runs
     /// after the body lowering completes.
@@ -7941,8 +7941,11 @@ impl<'a> Lowering<'a> {
                 &call.dest.ty,
                 self.llbc,
             );
+            let payload_ty = crate::front::result_exc::tyref_result_ok(&call.dest.ty, self.llbc)
+                .map(|ty| tyref_to_value_type(&ty, self.llbc))
+                .unwrap_or(ValueType::Ref(None));
             self.result_exc_call_results
-                .push((result_var.clone(), suffix));
+                .push((result_var.clone(), suffix, payload_ty));
         }
         // Capture `Iterator::next()` results (`Option<T>`-typed) for the
         // `next`-diamond rewiring pass (`front::iter_next`).  Recognition

--- a/majit/majit-translate/src/front/result_exc.rs
+++ b/majit/majit-translate/src/front/result_exc.rs
@@ -667,6 +667,7 @@ pub(crate) fn op_operand_vars(kind: &OpKind) -> Vec<Variable> {
         | OpKind::LoopHeader { .. }
         | OpKind::Abort { .. }
         | OpKind::LoadStatic { .. }
+        | OpKind::New { .. }
         | OpKind::NewWithVtable { .. } => Vec::new(),
 
         OpKind::FieldRead { base, .. }
@@ -1013,7 +1014,7 @@ enum SiteOutcome {
 /// custom `match` consumer that gets the catch-and-rewrap treatment.
 pub(crate) fn rewire_result_exc_call_sites(
     graph: &mut FunctionGraph,
-    results: &[(Variable, Option<String>)],
+    results: &[(Variable, Option<String>, ValueType)],
     enclosing_scoped: bool,
 ) -> Result<RewireOutcome, String> {
     let mut outcome = RewireOutcome {
@@ -1022,8 +1023,14 @@ pub(crate) fn rewire_result_exc_call_sites(
         rewrapped: 0,
         fused: 0,
     };
-    for (r, suffix) in results {
-        match rewire_one_call_site(graph, r, suffix.as_deref().unwrap_or(""), enclosing_scoped)? {
+    for (r, suffix, payload_ty) in results {
+        match rewire_one_call_site(
+            graph,
+            r,
+            suffix.as_deref().unwrap_or(""),
+            payload_ty,
+            enclosing_scoped,
+        )? {
             SiteOutcome::Diamond => outcome.diamonds += 1,
             SiteOutcome::TailForward => outcome.tail_forwards += 1,
             SiteOutcome::Rewrapped => outcome.rewrapped += 1,
@@ -1037,6 +1044,7 @@ fn rewire_one_call_site(
     graph: &mut FunctionGraph,
     r: &Variable,
     suffix: &str,
+    payload_ty: &ValueType,
     enclosing_scoped: bool,
 ) -> Result<SiteOutcome, String> {
     let name = graph.name.clone();
@@ -1083,7 +1091,7 @@ fn rewire_one_call_site(
         if try_fuse_drain_match(graph, a, r).is_ok() {
             return Ok(SiteOutcome::Fused);
         }
-        catch_and_rewrap(graph, a, r, suffix)?;
+        catch_and_rewrap(graph, a, r, suffix, payload_ty)?;
         return Ok(SiteOutcome::Rewrapped);
     };
     assert_single_pred(graph, b, &name)?;
@@ -1246,6 +1254,7 @@ fn catch_and_rewrap(
     a: usize,
     r: &Variable,
     suffix: &str,
+    payload_ty: &ValueType,
 ) -> Result<(), String> {
     use crate::model::BlockId;
     let name = graph.name.clone();
@@ -1283,7 +1292,14 @@ fn catch_and_rewrap(
             .position(|a| is_r(a))
             .expect("has_r implies a Value position");
         let payload = n_inputs[r_value_idx].clone();
-        Some(build_shell(graph, n_id, "Ok", payload, suffix))
+        Some(build_shell(
+            graph,
+            n_id,
+            "Ok",
+            payload,
+            payload_ty.clone(),
+            suffix,
+        ))
     } else {
         None
     };
@@ -1352,7 +1368,14 @@ fn catch_and_rewrap(
                 true,
             )
             .expect("from_exc_object must produce a value");
-        Some(build_shell(graph, e_id, "Err", v_err, suffix))
+        Some(build_shell(
+            graph,
+            e_id,
+            "Err",
+            v_err,
+            ValueType::Ref(None),
+            suffix,
+        ))
     } else {
         None
     };
@@ -2198,6 +2221,7 @@ fn build_shell(
     block: crate::model::BlockId,
     variant: &str,
     payload: Variable,
+    payload_ty: ValueType,
     suffix: &str,
 ) -> Variable {
     use crate::model::FieldDescriptor;
@@ -2235,7 +2259,7 @@ fn build_shell(
                     owner_id: None,
                 },
                 value: crate::model::LinkArg::Value(payload),
-                ty: ValueType::Ref(None),
+                ty: payload_ty,
             },
         });
     shell

--- a/majit/majit-translate/src/inline.rs
+++ b/majit/majit-translate/src/inline.rs
@@ -430,6 +430,9 @@ pub(crate) fn remap_op_kind(
         OpKind::ConstRef(obj) => OpKind::ConstRef(obj.clone()),
         OpKind::ConstRefNull => OpKind::ConstRefNull,
         OpKind::ConstRefAddr(addr) => OpKind::ConstRefAddr(*addr),
+        OpKind::New { owner } => OpKind::New {
+            owner: owner.clone(),
+        },
         OpKind::NewWithVtable { owner, vtable } => OpKind::NewWithVtable {
             owner: owner.clone(),
             vtable: *vtable,
@@ -876,6 +879,7 @@ pub fn op_variable_refs(kind: &OpKind) -> Vec<crate::flowspace::model::Variable>
         | OpKind::LoopHeader { .. }
         | OpKind::Abort { .. }
         | OpKind::LoadStatic { .. }
+        | OpKind::New { .. }
         | OpKind::NewWithVtable { .. } => {
             vec![]
         }
@@ -1109,10 +1113,10 @@ pub fn op_variable_refs(kind: &OpKind) -> Vec<crate::flowspace::model::Variable>
 /// pure op's args even though both should die together.
 pub fn is_pure_op(kind: &OpKind) -> bool {
     match kind {
-        // `new_with_vtable` heap-allocates a fresh boxed object: NOT pure.
+        // `new` / `new_with_vtable` heap-allocate fresh objects: NOT pure.
         // CSE must never coalesce two allocations, or Python `is` object
         // identity would break.
-        OpKind::NewWithVtable { .. } => false,
+        OpKind::New { .. } | OpKind::NewWithVtable { .. } => false,
         // `OpKind::ConstInt` / `OpKind::ConstFloat` materialize a
         // `Variable` for a literal in pyre's IR.  There
         // is NO upstream `int_constant` op — RPython's `Constant` is

--- a/majit/majit-translate/src/lib.rs
+++ b/majit/majit-translate/src/lib.rs
@@ -1921,8 +1921,8 @@ fn make_jitcodes(
     // `grab_initial_jitcodes`, preserving RPython object identity.
     let builtin_wrapper_targets: Vec<jitcode::JitCodeHandle> = call_control
         .builtin_wrapper_indirect_graphs()
-        .into_iter()
-        .filter_map(|path| call_control.jitcodes().get(&path).cloned())
+        .iter()
+        .filter_map(|path| call_control.jitcodes().get(path).cloned())
         .map(jitcode::JitCodeHandle::from)
         .collect();
     codewriter

--- a/majit/majit-translate/src/model.rs
+++ b/majit/majit-translate/src/model.rs
@@ -620,6 +620,14 @@ pub enum OpKind {
         value: LinkArg,
         ty: ValueType,
     },
+    /// RPython `malloc(GcStruct, flavor='gc')` lowered by
+    /// `jtransform.py:1012-1045 rewrite_op_malloc` to `new(descr)`.
+    /// Synthetic Rust aggregate constructors reach pyre before the missing
+    /// rtyper malloc lowering, so jtransform restores that exact operation
+    /// using the aggregate owner to resolve its size descriptor.
+    New {
+        owner: String,
+    },
     /// RPython `malloc(STRUCT, flavor='gc')` for a fixed-size GcStruct: the
     /// heap allocation of a boxed object (`pyre_object::lltype::malloc_typed`).
     /// Lowered to the `new_with_vtable` jitcode op (executor

--- a/majit/majit-translate/src/translator/rtyper/extregistry.rs
+++ b/majit/majit-translate/src/translator/rtyper/extregistry.rs
@@ -193,6 +193,9 @@ pub enum ExtRegistryEntry {
     /// (`float2longlong_analyzer` → `SomeInteger(r_longlong)`); this entry fires on
     /// the rtyper's `findbltintyper` → `specialize_call` path.
     Float2LongLong,
+    /// `longlong2float.longlong2float(i64) -> f64` — RPython
+    /// `LongLong2FloatEntry`, the inverse bit reinterpretation.
+    LongLong2Float,
 }
 
 /// Small Send-able annotation payload for static HostObject type
@@ -303,6 +306,7 @@ pub enum ExtRegistryEntryKey {
     /// `self.__class__` and there is no `self.instance`.
     BigIntFrom,
     Float2LongLong,
+    LongLong2Float,
 }
 
 impl ExtRegistryEntry {
@@ -340,6 +344,7 @@ impl ExtRegistryEntry {
             ExtRegistryEntry::WeAreJitted => ExtRegistryEntryKey::WeAreJitted,
             ExtRegistryEntry::BigIntFrom => ExtRegistryEntryKey::BigIntFrom,
             ExtRegistryEntry::Float2LongLong => ExtRegistryEntryKey::Float2LongLong,
+            ExtRegistryEntry::LongLong2Float => ExtRegistryEntryKey::LongLong2Float,
         }
     }
 
@@ -484,6 +489,9 @@ impl ExtRegistryEntry {
                     crate::annotator::model::KnownType::LongLong,
                 ),
             )),
+            ExtRegistryEntry::LongLong2Float => Ok(SomeValue::Float(
+                crate::annotator::model::SomeFloat::default(),
+            )),
         }
     }
 
@@ -626,6 +634,10 @@ impl ExtRegistryEntry {
             // emits `genop('convert_float_bytes_to_longlong', [v_float], SignedLongLong)`.
             ExtRegistryEntry::Float2LongLong => {
                 Ok(super::rbuiltin::rtype_float2longlong as BuiltinTyperFn)
+            }
+            // `rlib/longlong2float.py:95-98` — inverse bitcast.
+            ExtRegistryEntry::LongLong2Float => {
+                Ok(super::rbuiltin::rtype_longlong2float as BuiltinTyperFn)
             }
         }
     }
@@ -874,6 +886,9 @@ fn lookup_host_object(host: &HostObject) -> Option<ExtRegistryEntry> {
     }
     if host.qualname() == "longlong2float.float2longlong" {
         return Some(ExtRegistryEntry::Float2LongLong);
+    }
+    if host.qualname() == "longlong2float.longlong2float" {
+        return Some(ExtRegistryEntry::LongLong2Float);
     }
     if let Some(entry) = host_value_registry().lock().unwrap().get(host).cloned() {
         return Some(entry);

--- a/majit/majit-translate/src/translator/rtyper/legacy_annotator.rs
+++ b/majit/majit-translate/src/translator/rtyper/legacy_annotator.rs
@@ -280,6 +280,7 @@ fn infer_op_type(kind: &OpKind) -> ValueType {
         }
         OpKind::FieldRead { ty, .. } => ty.clone(),
         OpKind::FieldWrite { .. } => ValueType::Void,
+        OpKind::New { owner } => ValueType::Ref(Some(owner.clone())),
         OpKind::NewWithVtable { owner, .. } => ValueType::Ref(Some(owner.clone())),
         OpKind::ArrayRead { item_ty, .. } => item_ty.clone(),
         OpKind::ArrayLen { .. } => ValueType::Int,

--- a/majit/majit-translate/src/translator/rtyper/rbuiltin.rs
+++ b/majit/majit-translate/src/translator/rtyper/rbuiltin.rs
@@ -1548,6 +1548,22 @@ pub fn rtype_float2longlong(hop: &HighLevelOp, _kwds_i: &HashMap<String, usize>)
     ))
 }
 
+/// `rlib/longlong2float.py:95-98` —
+/// `LongLong2FloatEntry.specialize_call`.
+pub fn rtype_longlong2float(hop: &HighLevelOp, _kwds_i: &HashMap<String, usize>) -> RTypeResult {
+    use crate::translator::rtyper::rtyper::GenopResult;
+
+    let vlist = hop.inputargs(vec![ConvertedTo::LowLevelType(
+        &LowLevelType::SignedLongLong,
+    )])?;
+    hop.exception_cannot_occur()?;
+    Ok(hop.genop(
+        "convert_longlong_bytes_to_float",
+        vlist,
+        GenopResult::LLType(LowLevelType::Float),
+    ))
+}
+
 /// `@typer_for(pyre_object.lltype.malloc_raw)` — residual external
 /// lowering of the raw (non-GC) typed allocation intrinsic
 /// `malloc_raw::<T>(value: T) -> *mut T` (`malloc_raw_alloc` annotator

--- a/majit/majit-translate/src/translator/rtyper/rpbc.rs
+++ b/majit/majit-translate/src/translator/rtyper/rpbc.rs
@@ -338,7 +338,7 @@ pub fn lower_indirect_calls(graph: &mut JitFunctionGraph, call_control: &CallCon
             } = &mut op.kind
                 && graphs.is_empty()
             {
-                *graphs = builtin_wrappers.clone();
+                *graphs = builtin_wrappers.to_vec();
             }
         }
     }

--- a/pyre/bench/synth/list_append_virtual_payload.py
+++ b/pyre/bench/synth/list_append_virtual_payload.py
@@ -1,0 +1,16 @@
+# A list strategy consumes the payload of a freshly boxed comprehension value.
+# Keep both integer and float payloads live across hot range iterations: an
+# append specialization must not retain a trace-entry value or lose a payload
+# when the comprehension crosses from tracing into compiled execution.
+
+expected = list(range(100))
+checksum = 0
+for outer in range(1000):
+    ints = [item for item in range(100)]
+    assert ints == expected
+    floats = [float(item) - 0.5 for item in range(100)]
+    assert floats[0] == -0.5
+    assert floats[-1] == 98.5
+    checksum += ints[-1] + int(floats[-1])
+
+print(checksum)

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -2204,7 +2204,7 @@ pub fn install_default_builtins(ns: PyObjectRef) {
     });
     crate::module_ns_get_or_insert_with(ns, "type", || crate::typedef::w_type());
     crate::module_ns_get_or_insert_with(ns, "isinstance", || {
-        make_module_builtin_function_with_arity("isinstance", builtin_isinstance, 2)
+        make_module_builtin_function_with_arity("isinstance", __pyre_wrap_builtin_isinstance, 2)
     });
     crate::module_ns_get_or_insert_with(ns, "str", || crate::typedef::gettypeobject(&STR_TYPE));
     crate::module_ns_get_or_insert_with(ns, "repr", || {
@@ -4484,6 +4484,24 @@ fn builtin_isinstance(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErro
         args[0], args[1],
     )?))
 }
+
+/// Manual interp2app gateway for `isinstance`.
+///
+/// `#[pyre_methods]` emits this same wrapper/descriptor pair automatically.
+/// Builtins installed by hand must publish the equivalent `BuiltinCode.func`
+/// PBC member so source translation can discover and codewrite its graph.
+pub fn __pyre_wrap_builtin_isinstance(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    builtin_isinstance(args)
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[linkme::distributed_slice(crate::gateway::BUILTIN_WRAPPER_DESCRIPTORS)]
+#[allow(non_upper_case_globals)]
+static __pyre_wrap_builtin_isinstance_target: crate::gateway::BuiltinWrapperDescriptor =
+    crate::gateway::BuiltinWrapperDescriptor {
+        path: concat!(module_path!(), "::", "__pyre_wrap_builtin_isinstance"),
+        func: __pyre_wrap_builtin_isinstance,
+    };
 
 /// isinstance(obj, cls) for JIT fast path.
 ///

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -190,7 +190,12 @@ thread_local! {
 }
 
 /// Get current call depth. Used by pyre-jit for JIT_CALL_DEPTH parity.
-#[inline(always)]
+///
+/// The counter is runtime-mutable execution-context state.  Like
+/// [`frame_entry_count`], its TLS read has no source-translatable graph and
+/// must remain a residual read rather than exposing `LocalKey::with` to the
+/// annotator.
+#[majit_macros::dont_look_inside]
 pub fn call_depth() -> u32 {
     CALL_DEPTH.with(|d| d.get())
 }

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -610,15 +610,6 @@ fn gc_prebuilt_remember_enabled() -> bool {
     })
 }
 
-/// Whether the per-return diagnostic dump is enabled
-/// (`PYRE_INTERP_RETURN_LOG`). The probe sits on the RETURN_VALUE path, so an
-/// uncached read would pay a `getenv` on every Python return.
-#[cfg(not(feature = "sandbox"))]
-fn interp_return_log_enabled() -> bool {
-    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *ENABLED.get_or_init(|| std::env::var_os("PYRE_INTERP_RETURN_LOG").is_some())
-}
-
 pub fn capture_pyframe_root_area() -> *const () {
     PYFRAME_ROOT_AREA.with(|area| area as *const _ as *const ())
 }

--- a/pyre/pyre-interpreter/src/gateway.rs
+++ b/pyre/pyre-interpreter/src/gateway.rs
@@ -539,6 +539,23 @@ pub fn method_noarg_failure(
     }
 }
 
+/// Cold gateway failure for a missing required argument.
+///
+/// A wrapper whose optional trailing parameters turn the accepted count into a
+/// range reports the PyArg_UnpackTuple `expected at least N arguments, got M`
+/// form.  The wrapper keeps the count guard; the message is built only here.
+#[majit_macros::dont_look_inside]
+pub fn method_min_arity_failure(
+    name: &str,
+    min: usize,
+    given: usize,
+) -> Result<PyObjectRef, crate::PyError> {
+    Err(crate::PyError::type_error(format!(
+        "{name} expected at least {min} argument{}, got {given}",
+        if min == 1 { "" } else { "s" },
+    )))
+}
+
 /// Translation-visible registry of generated interp2app gateway bodies.
 ///
 /// RPython's `BuiltinCode.func` is a PBC whose possible function values are

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -347,6 +347,12 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
     );
     push_alias_pair(
         &mut entries,
+        "pyre_interpreter::gateway::method_min_arity_failure",
+        "gateway::method_min_arity_failure",
+        crate::gateway::method_min_arity_failure as *const (),
+    );
+    push_alias_pair(
+        &mut entries,
         "pyre_interpreter::builtins::builtin_kwargs_marker_dict",
         "builtins::builtin_kwargs_marker_dict",
         crate::builtins::builtin_kwargs_marker_dict as *const (),

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -1223,6 +1223,16 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         "pyre_interpreter::call::bump_frame_entry_count",
         crate::call::bump_frame_entry_count as *const (),
     );
+    push_fnaddr(
+        &mut entries,
+        "pyre_interpreter::call::call_depth",
+        crate::call::call_depth as *const (),
+    );
+    push_fnaddr(
+        &mut entries,
+        "pyre_interpreter::module::sys::state::recursion_limit",
+        crate::module::sys::state::recursion_limit as *const (),
+    );
     // The dispatch-loop safepoint entry itself paces the poll inline and
     // dispatches to the threshold and collection hooks.
     push_alias_pair(
@@ -3061,6 +3071,10 @@ pub fn jit_static_pytype_addrs() -> Vec<(&'static str, i64)> {
             &crate::function::BUILTIN_FUNCTION_TYPE as *const _ as i64,
         ),
         (
+            "function::METHOD_DESCRIPTOR_TYPE",
+            &crate::function::METHOD_DESCRIPTOR_TYPE as *const _ as i64,
+        ),
+        (
             "function::SLOT_WRAPPER_TYPE",
             &crate::function::SLOT_WRAPPER_TYPE as *const _ as i64,
         ),
@@ -3272,7 +3286,10 @@ pub fn jit_static_int_values() -> Vec<(&'static str, i64)> {
 
 #[cfg(test)]
 mod tests {
-    use super::{is_list_write_barrier, is_pyframe_operand_stack_accessor, jit_trace_fnaddrs};
+    use super::{
+        is_list_write_barrier, is_pyframe_operand_stack_accessor, jit_static_pytype_addrs,
+        jit_trace_fnaddrs,
+    };
     use std::collections::HashMap;
 
     #[test]
@@ -3296,6 +3313,16 @@ mod tests {
             list_append
         );
         assert_eq!(bindings["pyre_object::jit_list_append"], list_append);
+    }
+
+    #[test]
+    fn jit_static_pytype_addrs_covers_interpreter_function_types() {
+        let bindings: HashMap<&'static str, i64> = jit_static_pytype_addrs().into_iter().collect();
+
+        assert_eq!(
+            bindings["function::METHOD_DESCRIPTOR_TYPE"],
+            &crate::function::METHOD_DESCRIPTOR_TYPE as *const _ as i64
+        );
     }
 
     #[test]
@@ -3492,6 +3519,16 @@ mod tests {
         assert_eq!(
             bindings["pyre_interpreter::call::bump_frame_entry_count"],
             bump
+        );
+
+        let call_depth = crate::call::call_depth as *const () as usize as i64;
+        assert_eq!(bindings["pyre_interpreter::call::call_depth"], call_depth);
+
+        let recursion_limit =
+            crate::module::sys::state::recursion_limit as *const () as usize as i64;
+        assert_eq!(
+            bindings["pyre_interpreter::module::sys::state::recursion_limit"],
+            recursion_limit
         );
 
         let safepoint = pyre_object::gc_interp::safepoint as *const () as usize as i64;

--- a/pyre/pyre-interpreter/src/module/sys/state.rs
+++ b/pyre/pyre-interpreter/src/module/sys/state.rs
@@ -37,7 +37,10 @@ static INT_MAX_STR_DIGITS: AtomicI32 = AtomicI32::new(DEFAULT_MAX_STR_DIGITS);
 
 /// `space.sys.recursionlimit` getter. Matches
 /// `pypy/module/sys/vm.py:102 return space.newint(space.sys.recursionlimit)`.
-#[inline]
+///
+/// The value is mutable sys-module state, so tracing must read it at runtime
+/// rather than bake the build process's atomic value into a JitCode.
+#[majit_macros::dont_look_inside]
 pub fn recursion_limit() -> i32 {
     RECURSION_LIMIT.load(Ordering::Relaxed)
 }

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -15358,17 +15358,8 @@ fn float_descr_as_integer_ratio(args: &[PyObjectRef]) -> Result<PyObjectRef, cra
         ));
     }
     let v = unsafe { pyre_object::w_float_get_value(args[0]) };
-    // Exact numerator/denominator via the shared rational decomposition
-    // (full exponent range, reduced to lowest terms).
-    let (numer, denom) = rustpython_common::int::float_to_ratio(v).ok_or_else(|| {
-        if v.is_infinite() {
-            crate::PyError::overflow_error("cannot convert Infinity to integer ratio")
-        } else {
-            crate::PyError::value_error("cannot convert NaN to integer ratio")
-        }
-    })?;
-    let to_pyint = |b| {
-        let b = crate::compiler_bigint_to_rbigint(&b);
+    let (numer, denom) = float_as_rbigint_ratio(v)?;
+    let to_pyint = |b: BigInt| {
         if pyre_object::jit_bigint_to_i64_fits(&b) != 0 {
             pyre_object::w_int_new(pyre_object::jit_bigint_to_i64_value(&b))
         } else {
@@ -15379,6 +15370,48 @@ fn float_descr_as_integer_ratio(args: &[PyObjectRef]) -> Result<PyObjectRef, cra
         to_pyint(numer),
         to_pyint(denom),
     ]))
+}
+
+/// RPython `rpython/rlib/rfloat.py:292 float_as_rbigint_ratio`.
+///
+/// Keeping the decomposition on pyre's translated `RBigInt` surface matches
+/// PyPy's `W_FloatObject.descr_as_integer_ratio` and avoids crossing into
+/// RustPython's opaque malachite `Rational` implementation.
+fn float_as_rbigint_ratio(value: f64) -> Result<(BigInt, BigInt), crate::PyError> {
+    if value.is_infinite() {
+        return Err(crate::PyError::overflow_error(
+            "cannot convert Infinity to integer ratio",
+        ));
+    }
+    if value.is_nan() {
+        return Err(crate::PyError::value_error(
+            "cannot convert NaN to integer ratio",
+        ));
+    }
+    let (mut float_part, mut exp_int) = float_frexp(value);
+    for _ in 0..300 {
+        if float_part == float_part.floor() {
+            break;
+        }
+        float_part *= 2.0;
+        exp_int -= 1;
+    }
+    let mut num = match BigInt::fromfloat(float_part) {
+        Ok(num) => num,
+        Err(_) => return Err(crate::PyError::memory_error("")),
+    };
+    let mut den = BigInt::fromint(1);
+    let shift = if exp_int < 0 { -exp_int } else { exp_int };
+    let exp = match den.lshift(shift as i64) {
+        Ok(exp) => exp,
+        Err(_) => return Err(crate::PyError::memory_error("")),
+    };
+    if exp_int > 0 {
+        num = num.mul(&exp);
+    } else {
+        den = exp;
+    }
+    Ok((num, den))
 }
 
 /// Manual interp2app gateway for `float.as_integer_ratio`.

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -15092,38 +15092,7 @@ fn init_float_type(ns: PyObjectRef) {
             "as_integer_ratio",
             make_builtin_function_with_arity(
                 "as_integer_ratio",
-                |args| {
-                    if args.is_empty() {
-                        return Err(crate::PyError::type_error(
-                            "as_integer_ratio() requires self",
-                        ));
-                    }
-                    let v = unsafe { pyre_object::w_float_get_value(args[0]) };
-                    // Exact numerator/denominator via the shared rational
-                    // decomposition (full exponent range, reduced to lowest terms).
-                    let (numer, denom) =
-                        rustpython_common::int::float_to_ratio(v).ok_or_else(|| {
-                            if v.is_infinite() {
-                                crate::PyError::overflow_error(
-                                    "cannot convert Infinity to integer ratio",
-                                )
-                            } else {
-                                crate::PyError::value_error("cannot convert NaN to integer ratio")
-                            }
-                        })?;
-                    let to_pyint = |b| {
-                        let b = crate::compiler_bigint_to_rbigint(&b);
-                        if pyre_object::jit_bigint_to_i64_fits(&b) != 0 {
-                            pyre_object::w_int_new(pyre_object::jit_bigint_to_i64_value(&b))
-                        } else {
-                            pyre_object::w_long_new(b)
-                        }
-                    };
-                    Ok(pyre_object::w_tuple_new(vec![
-                        to_pyint(numer),
-                        to_pyint(denom),
-                    ]))
-                },
+                __pyre_wrap_float_descr_as_integer_ratio,
                 1,
             ),
         )
@@ -15375,6 +15344,62 @@ fn init_float_type(ns: PyObjectRef) {
         )
     };
 }
+
+/// `float.as_integer_ratio()` — PyPy
+/// `W_FloatObject.descr_as_integer_ratio`.
+///
+/// Kept as a named function, matching the upstream interp2app target shape,
+/// so source translation can include it in the finite `BuiltinCode.func`
+/// target family.
+fn float_descr_as_integer_ratio(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    if args.is_empty() {
+        return Err(crate::PyError::type_error(
+            "as_integer_ratio() requires self",
+        ));
+    }
+    let v = unsafe { pyre_object::w_float_get_value(args[0]) };
+    // Exact numerator/denominator via the shared rational decomposition
+    // (full exponent range, reduced to lowest terms).
+    let (numer, denom) = rustpython_common::int::float_to_ratio(v).ok_or_else(|| {
+        if v.is_infinite() {
+            crate::PyError::overflow_error("cannot convert Infinity to integer ratio")
+        } else {
+            crate::PyError::value_error("cannot convert NaN to integer ratio")
+        }
+    })?;
+    let to_pyint = |b| {
+        let b = crate::compiler_bigint_to_rbigint(&b);
+        if pyre_object::jit_bigint_to_i64_fits(&b) != 0 {
+            pyre_object::w_int_new(pyre_object::jit_bigint_to_i64_value(&b))
+        } else {
+            pyre_object::w_long_new(b)
+        }
+    };
+    Ok(pyre_object::w_tuple_new(vec![
+        to_pyint(numer),
+        to_pyint(denom),
+    ]))
+}
+
+/// Manual interp2app gateway for `float.as_integer_ratio`.
+pub fn __pyre_wrap_float_descr_as_integer_ratio(
+    args: &[PyObjectRef],
+) -> Result<PyObjectRef, crate::PyError> {
+    float_descr_as_integer_ratio(args)
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[linkme::distributed_slice(crate::gateway::BUILTIN_WRAPPER_DESCRIPTORS)]
+#[allow(non_upper_case_globals)]
+static __pyre_wrap_float_descr_as_integer_ratio_target: crate::gateway::BuiltinWrapperDescriptor =
+    crate::gateway::BuiltinWrapperDescriptor {
+        path: concat!(
+            module_path!(),
+            "::",
+            "__pyre_wrap_float_descr_as_integer_ratio"
+        ),
+        func: __pyre_wrap_float_descr_as_integer_ratio,
+    };
 
 #[derive(Copy, Clone)]
 pub(crate) enum FloatToIntMode {
@@ -15777,6 +15802,20 @@ pub(crate) fn object_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crat
     Ok(w_instance_new(cls))
 }
 
+/// Manual interp2app gateway for `object.__new__`.
+pub fn __pyre_wrap_object_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    object_descr_new(args)
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[linkme::distributed_slice(crate::gateway::BUILTIN_WRAPPER_DESCRIPTORS)]
+#[allow(non_upper_case_globals)]
+static __pyre_wrap_object_descr_new_target: crate::gateway::BuiltinWrapperDescriptor =
+    crate::gateway::BuiltinWrapperDescriptor {
+        path: concat!(module_path!(), "::", "__pyre_wrap_object_descr_new"),
+        func: __pyre_wrap_object_descr_new,
+    };
+
 /// `object.__init__(self)` — no-op base __init__.  Surplus arguments are
 /// accepted only when __init__ or __new__ is overridden (objectobject.py
 /// descr__init__); otherwise the bare object initializer takes none.
@@ -15847,7 +15886,7 @@ fn init_object_type(ns: PyObjectRef) {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
             ns,
             "__new__",
-            make_new_descr(object_descr_new),
+            make_new_descr(__pyre_wrap_object_descr_new),
         )
     };
     unsafe {

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -2805,7 +2805,7 @@ pub fn w_exception_slot_descr(
 /// dead-store-eliminates a balanced save/restore (and the stored
 /// exception, if it never otherwise escapes, stays virtual and DCEs).
 pub fn ec_sys_exc_value_descr() -> DescrRef {
-    EC_DESCR_GROUP.field_descrs[0].clone() as DescrRef
+    ec_field_descr(pyre_interpreter::EC_SYS_EXC_VALUE_OFFSET)
 }
 
 /// Field descr for `ExecutionContext::topframeref`, used by the JIT lowering
@@ -2817,7 +2817,16 @@ pub fn ec_sys_exc_value_descr() -> DescrRef {
 /// heap optimizer can forward an `enter` store to the matching `leave` read
 /// and dead-store-eliminate a balanced pair whose frame never escaped.
 pub fn ec_topframeref_descr() -> DescrRef {
-    EC_DESCR_GROUP.field_descrs[1].clone() as DescrRef
+    ec_field_descr(pyre_interpreter::EC_TOPFRAMEREF_OFFSET)
+}
+
+/// Resolve one `EC_DESCR_GROUP` field by byte offset.  The group stamps
+/// `index_in_parent` as the field's rank by offset, so the positional order of
+/// `field_descrs` follows the offsets rather than the declaration order; look
+/// the field up by offset so the two accessors above cannot swap.
+fn ec_field_descr(offset: usize) -> DescrRef {
+    let parent = EC_DESCR_GROUP.size_descr.clone() as DescrRef;
+    majit_ir::descr::field_descr_from_parent_by_offset(&parent, offset)
 }
 
 /// The `ExecutionContext` field group.  `type_id 0 + vtable 0` →
@@ -2842,22 +2851,32 @@ static EC_DESCR_GROUP: LazyLock<majit_ir::descr::SimpleDescrGroup> = LazyLock::n
         is_quasi_immutable: false,
         flag: ArrayFlag::Unsigned,
         virtualizable: false,
+        // Stamped below, once the specs are in offset order.
         index_in_parent: 0,
     };
-    majit_ir::descr::make_simple_descr_group(
-        u32::MAX,
-        pyre_interpreter::EC_SIZE,
-        0,
-        0,
-        &[
-            field(
-                0,
-                "sys_exc_value",
-                pyre_interpreter::EC_SYS_EXC_VALUE_OFFSET,
-            ),
-            field(1, "topframeref", pyre_interpreter::EC_TOPFRAMEREF_OFFSET),
-        ],
-    )
+    let mut specs = vec![
+        field(
+            0,
+            "sys_exc_value",
+            pyre_interpreter::EC_SYS_EXC_VALUE_OFFSET,
+        ),
+        field(1, "topframeref", pyre_interpreter::EC_TOPFRAMEREF_OFFSET),
+    ];
+    // `index_in_parent` is the field's rank by byte offset
+    // (`jitcode/assembler.rs:625`), and once a parent SizeDescr is bound it is
+    // also the `PtrInfo._fields` slot key the heap optimizer reads
+    // (`optimizeopt/heap.rs` `field_slot_index`), so the two fields must not
+    // share a rank — a shared rank makes a read of one field resolve to the
+    // cached value of the other.  `ExecutionContext` is `repr(Rust)`, so rank by
+    // the actual offsets instead of the declaration order; sorting the specs
+    // first keeps the rank, the spec order and the `all_fielddescrs` positional
+    // order one numbering, as `.enumerate()` gives
+    // `build_object_descr_group_with_def_path`.
+    specs.sort_by_key(|spec| spec.offset);
+    for (index_in_parent, spec) in specs.iter_mut().enumerate() {
+        spec.index_in_parent = index_in_parent;
+    }
+    majit_ir::descr::make_simple_descr_group(u32::MAX, pyre_interpreter::EC_SIZE, 0, 0, &specs)
 });
 
 /// Size descriptor for W_SliceObject allocation via NewWithVtable.

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -3198,6 +3198,54 @@ mod tests {
     }
 
     #[test]
+    fn make_descr_from_bh_items_block_capacity_with_parent_is_canonical() {
+        use majit_ir::descr::ArrayFlag;
+        use majit_translate::jitcode::{BhDescr, BhFieldSpec, BhSizeSpec};
+
+        let capacity = BhFieldSpec {
+            index: 0,
+            field_key: "capacity".into(),
+            name: "ItemsBlock.capacity".into(),
+            offset: 0,
+            field_size: std::mem::size_of::<usize>(),
+            field_type: Type::Int,
+            field_flag: ArrayFlag::Unsigned,
+            is_field_signed: false,
+            is_immutable: false,
+            is_quasi_immutable: false,
+            index_in_parent: 0,
+        };
+        let parent = BhSizeSpec {
+            size: std::mem::size_of::<usize>(),
+            type_id: 3938139489201595032,
+            vtable: 0,
+            is_gc_managed: true,
+            headerless: false,
+            all_fielddescrs: vec![capacity.clone()],
+        };
+        let descr = make_descr_from_bh(&BhDescr::Field {
+            offset: capacity.offset,
+            field_size: capacity.field_size,
+            field_type: capacity.field_type,
+            field_flag: capacity.field_flag,
+            is_field_signed: capacity.is_field_signed,
+            is_immutable: capacity.is_immutable,
+            is_quasi_immutable: capacity.is_quasi_immutable,
+            index_in_parent: capacity.index_in_parent,
+            parent: Some(parent),
+            name: "capacity".into(),
+            owner: "ItemsBlock".into(),
+        });
+        let canonical = items_block_capacity_descr();
+
+        assert!(
+            std::sync::Arc::ptr_eq(&descr, &canonical),
+            "the build-time parent must not mint a second capacity FieldDescr",
+        );
+        assert_eq!(descr.index(), canonical.index());
+    }
+
+    #[test]
     fn make_descr_from_bh_bridges_codewriter_int_items_leaves_to_group() {
         use majit_ir::descr::ArrayFlag;
         use majit_translate::jitcode::BhDescr;
@@ -4070,6 +4118,20 @@ pub fn make_descr_from_bh(bh: &majit_translate::jitcode::BhDescr) -> DescrRef {
                     _ => {}
                 }
             }
+            // #171 object-strategy capacity read: `list.obj_capacity` lowers
+            // to getfield_gc_r(items) + getfield_gc_i(block.capacity). The
+            // block's offset-0 GcArray length header IS the allocated
+            // capacity (immutable for the block's lifetime).
+            //
+            // This must precede the generic parent-group lookup. Charon gives
+            // `ItemsBlock.capacity` a real parent, whose local field index is
+            // zero; rebuilding that group would therefore return a distinct
+            // index-0 descriptor. Walker-native list promotion seeds the
+            // capacity under the canonical descriptor's stable index, and
+            // RPython has only one FieldDescr identity for this field.
+            if owner.as_str() == "ItemsBlock" && name.as_str() == "capacity" {
+                return items_block_capacity_descr();
+            }
             if let Some(parent) = parent {
                 if parent.type_id != 0 {
                     let key = majit_ir::descr::LLType::Struct(parent.type_id);
@@ -4093,13 +4155,6 @@ pub fn make_descr_from_bh(bh: &majit_translate::jitcode::BhDescr) -> DescrRef {
                         }
                     }
                 }
-            }
-            // #171 object-strategy capacity read: `list.obj_capacity` lowers
-            // to getfield_gc_r(items) + getfield_gc_i(block.capacity). The
-            // block's offset-0 GcArray length header IS the allocated
-            // capacity (immutable for the block's lifetime).
-            if owner.as_str() == "ItemsBlock" && name.as_str() == "capacity" {
-                return items_block_capacity_descr();
             }
             // #171 codewriter descr-bridge: a codewriter-lowered body reads a
             // box payload (`W_IntObject.intval` / `W_BoolObject.intval` /

--- a/pyre/pyre-jit-trace/src/helpers.rs
+++ b/pyre/pyre-jit-trace/src/helpers.rs
@@ -106,18 +106,34 @@ pub fn emit_trace_call_ref_typed(
     ctx.call_ref_typed_with_effect(helper, args, arg_types, default_effect_info())
 }
 
-/// Read the value at a promoted exact-dict entry index.  The caller guards
-/// `W_DictObject.keys_version`, the explicit pyre representation of PyPy's
-/// live strategy-iterator state, so the index remains attached to the same
-/// identity key.  Value overwrites do not bump that version and are observed
-/// by this live read, matching the r_dict entry-value load.
-pub extern "C" fn jit_dict_nth_value(dict: i64, index: i64) -> i64 {
+/// Read the value at a promoted exact-dict entry index, re-checking
+/// `W_DictObject.keys_version` — the explicit pyre representation of PyPy's
+/// live strategy-iterator state — under the dict's own lock.
+///
+/// The trace's `keys_version` guard is an unlocked field read, so another
+/// thread can mutate the key set between that guard and this call.
+/// `IndexMap::shift_remove_index` compacts, so a stale index names a
+/// different key or none at all; one `w_dict_lock` held across the version
+/// re-check and the indexed read keeps `index` attached to the guarded
+/// identity key.  A mismatch or an out-of-range index returns `PY_NULL` for
+/// the caller's `guard_nonnull` to side-exit on.  Value overwrites do not bump
+/// the version and are observed by this live read, matching the r_dict
+/// entry-value load.
+pub extern "C" fn jit_dict_nth_value_versioned(
+    dict: i64,
+    index: i64,
+    expected_version: i64,
+) -> i64 {
+    let dict = dict as PyObjectRef;
     unsafe {
-        pyre_object::dictmultiobject::w_dict_nth_item(
-            dict as pyre_object::PyObjectRef,
-            index as usize,
-        )
-        .map_or(0, |(_, value)| value as i64)
+        // `w_dict_lock` is reentrant, so the nested acquire inside
+        // `w_dict_nth_item` neither blocks nor releases this guard.
+        let _dict_guard = pyre_object::dictmultiobject::w_dict_lock(dict);
+        if pyre_object::dictmultiobject::w_dict_keys_version(dict) != expected_version as usize {
+            return PY_NULL as i64;
+        }
+        pyre_object::dictmultiobject::w_dict_nth_item(dict, index as usize)
+            .map_or(PY_NULL as i64, |(_, value)| value as i64)
     }
 }
 

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
@@ -1991,8 +1991,10 @@ pub(crate) fn fbw_callee_body_replay_safety(
             let provably_side_effect_free = replay_safe_read
                 || ei.check_is_elidable()
                 || ei.extraeffect == majit_ir::ExtraEffect::LoopInvariant;
-            let accepted_numeric_op = !provably_side_effect_free
-                && residual_call_is_specialized_plain_numeric_op(
+            let accepted_numeric_op = if provably_side_effect_free {
+                None
+            } else {
+                residual_call_specialized_plain_numeric_binop(
                     body_code,
                     &numeric_ref_regs,
                     &plain_int_ref_regs,
@@ -2000,12 +2002,15 @@ pub(crate) fn fbw_callee_body_replay_safety(
                     num_regs_i,
                     constants_i,
                     callee_descr_refs,
-                );
+                )
+            };
             // A `COMPARE_OP` over the same proven operands is accepted for the
             // same reason, but its result is a `bool`, not an operand the
             // numeric provenance below may chain on.
-            let accepted_binop =
-                accepted_numeric_op && ei.pyre_helper == majit_ir::PyreHelperKind::BinaryOp;
+            let accepted_binop = matches!(
+                accepted_numeric_op,
+                Some(SpecializedBinop::Numeric | SpecializedBinop::PlainInt)
+            );
             // `CHECK_EXC_MATCH` shares the `COMPARE_OP` shape but reads only
             // types, so it needs no operand proof at all.
             let accepted_exc_match = !provably_side_effect_free
@@ -2016,7 +2021,8 @@ pub(crate) fn fbw_callee_body_replay_safety(
                     constants_i,
                     callee_descr_refs,
                 );
-            dst_exact_bool = (accepted_numeric_op && !accepted_binop) || accepted_exc_match;
+            dst_exact_bool =
+                accepted_numeric_op == Some(SpecializedBinop::Compare) || accepted_exc_match;
             let accepted_truth = !provably_side_effect_free
                 && crate::jitcode_dispatch::residual_call::residual_call_is_proven_truth(
                     body_code,
@@ -2028,16 +2034,10 @@ pub(crate) fn fbw_callee_body_replay_safety(
             // An accepted arithmetic op over exact numeric operands returns an
             // exact numeric.  Bitwise ops require and return exact ints.
             dst_exact_numeric = dst_boxed_int || accepted_binop;
-            dst_exact_plain_int = dst_boxed_int
-                || (accepted_binop
-                    && residual_call_is_specialized_plain_int_binop(
-                        body_code,
-                        &d,
-                        num_regs_i,
-                        constants_i,
-                    ));
+            dst_exact_plain_int =
+                dst_boxed_int || accepted_numeric_op == Some(SpecializedBinop::PlainInt);
             if !provably_side_effect_free
-                && !accepted_numeric_op
+                && accepted_numeric_op.is_none()
                 && !accepted_truth
                 && !accepted_exc_match
             {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -1692,12 +1692,11 @@ pub(crate) fn try_walker_inline_user_call<Sym: WalkSym>(
         // built: its element boxes are still in the heap cache, so the callee
         // seeds from them and the tuple keeps no consumer.
         //
-        // The seeding fills `registers_r[0..nparams]` and nothing else, so a
-        // callee owning a local the arity check cannot see must stay residual:
-        // `co_argcount` counts neither `*args` nor `**kwargs` nor keyword-only
-        // params, so `def f(a, *, b=5)` accepts a 1-tuple here while `b` is
-        // never bound.  Same decline the keyword fold applies.
-        if method_form || !fbw_callee_scope_is_positional_only(w_code) {
+        // The unpacked arguments come from the star tuple alone, so a
+        // method-form call — whose receiver is an implicit leading argument the
+        // unpack never sees — stays residual.  The callee-scope decline this
+        // seeding also needs is applied once in the resolved half.
+        if method_form {
             return Ok(None);
         }
         let Some(unpacked) = fbw_unpack_call_function_ex_args(ctx, r_args, &arg_concretes, nparams)
@@ -2412,6 +2411,15 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
     allow_method_load_attr: bool,
     require_str_result: bool,
 ) -> Result<Option<(DispatchOutcome, usize)>, DispatchError> {
+    // `_compute_flatcall` (`pycode.py:256-268`) leaves `fast_natural_arity`
+    // HOPELESS for a `*args` / `**kwargs` / keyword-only callee, so
+    // `funccall_valuestack` is never entered for one.  Same boundary here: the
+    // seeding fills `locals[0..nparams]` and `co_argcount` counts none of the
+    // three, so a callee owning a local the arity check cannot see must stay
+    // residual.
+    if !fbw_callee_scope_is_positional_only(w_code) {
+        return Ok(None);
+    }
     // `Function.funccall_valuestack` fills a missing positional tail from
     // `defs_w` before entering the frame (`function.py:188-193,217-231`).
     // Mirror that frame shape here.  Placeholder boxes are replaced by live

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -1939,17 +1939,18 @@ pub(crate) fn walker_ec_leave(
 /// descriptor. The first instruction's arraylen descriptor is deliberately
 /// not interchangeable with the later getarrayitem descriptor.
 pub(super) fn wrapper_args_item_descr_index(code: &[u8]) -> Option<u32> {
-    let mut wrapper_ops = crate::jitcode_runtime::decoded_ops(code);
-    let wrapper_abi_matches = wrapper_ops.next().is_some_and(|first| {
-        first.key == "arraylen_gc/rd>i" && code.get(first.pc + 1).copied() == Some(0)
-    });
-    if !wrapper_abi_matches {
-        return None;
-    }
+    // Keyword-capable generated wrappers first call
+    // `split_builtin_kwargs(args)` before their arity/unwrap code.  Its
+    // positional-slice result can therefore occupy a register other than the
+    // wrapper input r0, and register colouring can move it again between the
+    // arity check and unwrap.  Generated gateways perform their argument
+    // extraction before entering the typed body, so the first Ref item read
+    // after the first slice-length read is the wrapper-argument descriptor.
+    let arraylen_pc = crate::jitcode_runtime::decoded_ops(code)
+        .find(|decoded| decoded.key == "arraylen_gc/rd>i")
+        .map(|decoded| decoded.pc)?;
     crate::jitcode_runtime::decoded_ops(code)
-        .find(|decoded| {
-            decoded.key == "getarrayitem_gc_r/rid>r" && code.get(decoded.pc + 1).copied() == Some(0)
-        })
+        .find(|decoded| decoded.pc > arraylen_pc && decoded.key == "getarrayitem_gc_r/rid>r")
         .and_then(|decoded| {
             let lo = *code.get(decoded.pc + 3)? as usize;
             let hi = *code.get(decoded.pc + 4)? as usize;
@@ -1984,7 +1985,6 @@ pub(crate) fn try_walker_inline_builtin_call<Sym: WalkSym>(
     dst: usize,
 ) -> Result<Option<(DispatchOutcome, usize)>, DispatchError> {
     if !ctx.is_authoritative_executor
-        || ctx.fbw_mode.inline_subwalk
         || !matches!(
             pyre_helper,
             majit_ir::PyreHelperKind::CallFn | majit_ir::PyreHelperKind::CallKw
@@ -2046,6 +2046,14 @@ pub(crate) fn try_walker_inline_builtin_call<Sym: WalkSym>(
     if body.num_regs_r < 1 {
         return Ok(None);
     }
+    let nested_helper_entry = if ctx.fbw_mode.inline_subwalk {
+        match compute_inline_helper_call_entry_frame(ctx, op.pc) {
+            Ok(frame) => Some(frame),
+            Err(_) => return Ok(None),
+        }
+    } else {
+        None
+    };
     // Guards inside the generated wrapper must resume at the outer Python
     // CALL, because helper JitCodes have no blackhole entry point of their
     // own.  The full-body symbol is the authority for that caller frame's
@@ -2062,30 +2070,40 @@ pub(crate) fn try_walker_inline_builtin_call<Sym: WalkSym>(
     if sym.jitcode().is_null() {
         return Ok(None);
     }
-    let (call_site_py_pc, vsd_value, outer_jitcode_index, call_site_marker) = unsafe {
-        let jc = &*sym.jitcode();
-        let jc_index = jc.index as u32;
-        let marker = jc.payload.resume_marker_for_jitcode_pc(op.pc);
-        let mut py = python_pc_for_jitcode_pc(&jc.payload.metadata, op.pc);
-        if jc.payload.code_ptr.is_null() {
-            (py, sym.valuestackdepth() as i64, jc_index, marker)
+    let (call_site_py_pc, vsd_value, outer_jitcode_index, call_site_marker) =
+        if nested_helper_entry.is_some() {
+            (
+                ctx.entry_py_pc(),
+                0,
+                ctx.outer_jitcode_index,
+                ctx.outer_resume_marker_jit_pc,
+            )
         } else {
-            let codeobj = &*jc.payload.code_ptr;
-            py = skip_python_trivia_forward(codeobj, py as usize) as u32;
-            let depth = if jc.payload.depth_trivia_populated() {
-                jc.payload.depth_trivia_for_jitcode_pc(op.pc)
-            } else {
-                crate::liveness::liveness_for(jc.payload.code_ptr)
-                    .depth_at_py_pc()
-                    .get(py as usize)
-                    .copied()
-            };
-            let vsd = depth
-                .map(|d| (sym.nlocals() + d as usize) as i64)
-                .unwrap_or(sym.valuestackdepth() as i64);
-            (py, vsd, jc_index, marker)
-        }
-    };
+            unsafe {
+                let jc = &*sym.jitcode();
+                let jc_index = jc.index as u32;
+                let marker = jc.payload.resume_marker_for_jitcode_pc(op.pc);
+                let mut py = python_pc_for_jitcode_pc(&jc.payload.metadata, op.pc);
+                if jc.payload.code_ptr.is_null() {
+                    (py, sym.valuestackdepth() as i64, jc_index, marker)
+                } else {
+                    let codeobj = &*jc.payload.code_ptr;
+                    py = skip_python_trivia_forward(codeobj, py as usize) as u32;
+                    let depth = if jc.payload.depth_trivia_populated() {
+                        jc.payload.depth_trivia_for_jitcode_pc(op.pc)
+                    } else {
+                        crate::liveness::liveness_for(jc.payload.code_ptr)
+                            .depth_at_py_pc()
+                            .get(py as usize)
+                            .copied()
+                    };
+                    let vsd = depth
+                        .map(|d| (sym.nlocals() + d as usize) as i64)
+                        .unwrap_or(sym.valuestackdepth() as i64);
+                    (py, vsd, jc_index, marker)
+                }
+            }
+        };
     let call_site_word = call_site_marker
         .map(|marker| marker as i32)
         .unwrap_or(majit_ir::resumedata::NO_JITCODE_PC);
@@ -2093,21 +2111,25 @@ pub(crate) fn try_walker_inline_builtin_call<Sym: WalkSym>(
     // this line records IR or touches the heap cache, so cutting back to it
     // leaves the caller's trace exactly as the ordinary residual call found it.
     let pre_fold_pos = ctx.trace_ctx.get_trace_position();
-    let call_site_active = collect_outer_active_boxes(
-        sym,
-        ctx.trace_ctx,
-        ctx.registers_i,
-        ctx.registers_r,
-        ctx.registers_f,
-        outer_jitcode_index,
-        false,
-        call_site_word,
-        op.pc as i32,
-        OuterActiveBoxesEntryTwin::Plain,
-        "builtin_wrapper_call_site",
-        None,
-        &[],
-    );
+    let call_site_active = if nested_helper_entry.is_some() {
+        ctx.outer_active_boxes.clone()
+    } else {
+        collect_outer_active_boxes(
+            sym,
+            ctx.trace_ctx,
+            ctx.registers_i,
+            ctx.registers_r,
+            ctx.registers_f,
+            outer_jitcode_index,
+            false,
+            call_site_word,
+            op.pc as i32,
+            OuterActiveBoxesEntryTwin::Plain,
+            "builtin_wrapper_call_site",
+            None,
+            &[],
+        )
+    };
 
     // The generated builtin-wrapper ABI takes its `&[PyObjectRef]` argument
     // in r0 and begins by checking its length.  Resolve that instruction's
@@ -2199,7 +2221,7 @@ pub(crate) fn try_walker_inline_builtin_call<Sym: WalkSym>(
             .heapcache_setarrayitem(args_array, index, wrapper_args_descr_index, item);
     }
 
-    if sym.owns_virtualizable_shadow() {
+    if nested_helper_entry.is_none() && sym.owns_virtualizable_shadow() {
         let last_instr = call_site_py_pc as i64 - 1;
         let last_instr_op = ctx.trace_ctx.const_int(last_instr);
         crate::trace_opcode::mirror_vable_static_to_boxes(
@@ -2239,6 +2261,9 @@ pub(crate) fn try_walker_inline_builtin_call<Sym: WalkSym>(
     ctx.raw_descrs = RawDescrPool::Global;
     ctx.sub_jitcode_lookup = &GLOBAL_SUB_JITCODE_LOOKUP_FN;
     ctx.fbw_mode.inline_subwalk = true;
+    ctx.fbw_mode.transparent_helper_subwalk = nested_helper_entry.is_some();
+    let _helper_frame =
+        nested_helper_entry.map(|frame| InlineFrameGuard::enter(ctx.session, 0, Some(frame)));
     let walk_result = run_sub_jitcode_walk(
         ctx,
         op.pc,

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -1985,10 +1985,12 @@ pub(crate) fn try_walker_inline_builtin_call<Sym: WalkSym>(
     dst: usize,
 ) -> Result<Option<(DispatchOutcome, usize)>, DispatchError> {
     if !ctx.is_authoritative_executor
-        || !matches!(
-            pyre_helper,
-            majit_ir::PyreHelperKind::CallFn | majit_ir::PyreHelperKind::CallKw
-        )
+        // A `call_kw` residual carries its kwnames tuple in arg index 2, and
+        // keywords reach a builtin as the trailing `__pyre_kw__` marker dict
+        // that `split_builtin_kwargs` strips — a shape the flat
+        // `&[PyObjectRef]` array built below does not construct, so leave those
+        // calls to `bh_call_kw_<n>`.
+        || pyre_helper != majit_ir::PyreHelperKind::CallFn
         || r_args.len() < 2
         || dst_bank != 'r'
     {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -2655,7 +2655,6 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
                 // recursive callees residual: either requires another loop
                 // header rather than one bounded callee walk.
                 foriter_dirty_bound = bound_method.is_some()
-                    && !method_form
                     && !pyre_interpreter::code_has_for_iter(callee_code)
                     && !pyre_interpreter::code_is_self_recursive(callee_code);
                 foriter_dirty_bound
@@ -2669,16 +2668,18 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
                 exact_numeric_args.iter().filter(|arg| arg.numeric).count(),
             );
         }
-        // A `Dirty` body is not admitted by seeding its frame.  Its residual
-        // can raise, and the local `except` that catches it is a callee-owned
-        // catch edge the inline path does not compile, so the exception
-        // escapes the caller instead of being handled where the source
-        // handles it.  Keep the ordinary residual call until that edge exists.
+        // An unbound `Dirty` body is not admitted by seeding its frame.  Its
+        // residual can raise, and the local `except` that catches it is a
+        // callee-owned catch edge the inline path does not compile, so the
+        // exception escapes the caller instead of being handled where the
+        // source handles it.  Stored bound methods instead take the explicit
+        // multi-frame red-frame path above.
         if !legacy_admit {
             return Ok(None);
         }
     }
     if method_form
+        && bound_method.is_none()
         && !allow_method_load_attr
         && !method_form_callee_body_supported(body.code, callee_descr_refs)
     {
@@ -3123,6 +3124,51 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
             if !callee_code.cellvars.is_empty() {
                 if try_multiframe {
                     return Ok(None);
+                }
+                break 'seed;
+            }
+            // POP_JUMP_IF_NONE / POP_JUMP_IF_NOT_NONE lower to an `is`/`is_not`
+            // identity residual call whose operands must be Ref (the codewriter
+            // PopJumpIfNone arm), then a branch guard.  When the multiframe inline
+            // int-specializes the tested local, the mid-body guard resume cannot
+            // source that operand's Ref form from the callee register banks
+            // (`collect_callee_active_boxes` would read a stale/mismatched box), so
+            // the encoded liveness stream disagrees with the decoder
+            // (`resume.rs decode_ref: unexpected tag`) and the caller frame is
+            // corrupted. Decline to the ordinary residual call until
+            // the multi-frame resume reboxes int-specialized identity operands.
+            // POP_JUMP_IF_TRUE/FALSE stay inlinable: their `bool` truth folds in the
+            // int bank, so no Ref rebox is needed.  A strict straight-line callee
+            // has no branch at all, so this scan never fires for it.
+            // Stored bound methods carry their explicit receiver and callee frame,
+            // so their Ref operands remain available to the resume path.
+            //
+            // This is the one precondition here that still aborts instead of
+            // returning `Ok(None)`, and deliberately so.  Residualizing it does
+            // work — `bench/synth/_pending/gc_bug_bridge_flavor_traceback_names`
+            // goes from 98 aborts to 2 and
+            // `_pending/exception_nested_exc_info_restore` from 5 aborts to 0,
+            // both compiling loops they never compiled before — but the loops it
+            // newly compiles then print traceback tuples missing their outermost
+            // frame, diverging from the interpreter (that fixture pins its
+            // expected output in its header).  The abort was masking a lost
+            // `PyTraceback` node on the compiled exception path, not preventing
+            // one.  Restore `Ok(None)` here once that node is recorded; it is the
+            // largest single win left in this function.
+            if bound_method.is_none()
+                && (0..callee_code.instructions.len()).any(|pc| {
+                    matches!(
+                        pyre_interpreter::decode_instruction_at(callee_code, pc),
+                        Some((
+                            pyre_interpreter::bytecode::Instruction::PopJumpIfNone { .. }
+                                | pyre_interpreter::bytecode::Instruction::PopJumpIfNotNone { .. },
+                            _
+                        ))
+                    )
+                })
+            {
+                if try_multiframe {
+                    return Err(DispatchError::callee_inline_unsupported(op.pc));
                 }
                 break 'seed;
             }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -906,6 +906,11 @@ pub struct FbwWalkMode<Sym: WalkSym> {
     /// boundary rather than mapping the callee `op_pc` through the outer
     /// jitcode in `walker_capture_snapshot_for_last_guard`.
     pub inline_subwalk: bool,
+    /// The current sub-walk is a translated builtin gateway helper, which has
+    /// no Python blackhole frame of its own. Guard snapshots therefore encode
+    /// only the precomputed Python caller chain on `framestack`, omitting the
+    /// helper JitCode itself.
+    pub transparent_helper_subwalk: bool,
     /// A bridge-carrier resume folds nested self-recursive calls directly to
     /// `CALL_ASSEMBLER` (`opimpl_recursive_call_assembler`) rather than
     /// re-unrolling the call tree to the multi-frame depth cap.
@@ -971,6 +976,7 @@ impl<Sym: WalkSym> Default for FbwWalkMode<Sym> {
         Self {
             snapshot_sym: std::ptr::null(),
             inline_subwalk: false,
+            transparent_helper_subwalk: false,
             carrier_resume: false,
             current_exception_seed: None,
             current_exception_seed_concrete: pyre_object::PY_NULL,

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -3036,6 +3036,21 @@ pub(crate) fn residual_call_descr_index_in_body(body_code: &[u8], d: &DecodedOp)
     Some(decode_descr_index(body_code, d, descr_offset))
 }
 
+/// Which specialization table arm a body `BINARY_OP` residual was admitted
+/// under, hence what its result is proven to be.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum SpecializedBinop {
+    /// `Add` / `Subtract` / `Multiply` (+ in-place): exact-numeric operands,
+    /// exact-numeric result.
+    Numeric,
+    /// `And` / `Or` / `Xor` (+ in-place): exact-plain-int operands,
+    /// exact-plain-int result.
+    PlainInt,
+    /// One of the six ordinary comparisons over exact numeric operands:
+    /// exact-bool result.
+    Compare,
+}
+
 /// A `BINARY_OP` has the generic residual shape in a per-function jitcode, but
 /// the walker replaces a statically tagged plain arithmetic op with a native
 /// one before the generic residual executor (and its nested-residual decline)
@@ -3056,7 +3071,8 @@ pub(crate) fn residual_call_descr_index_in_body(body_code: &[u8], d: &DecodedOp)
 /// - `And` / `Or` / `Xor` (+ in-place) — `IntAnd` / `IntOr` / `IntXor`, also
 ///   unconditional, but *int-only*: the float table falls through to
 ///   `_ => return Ok(None)` for them.  Hence the separate
-///   `args_all_exact_plain_int`.
+///   [`SpecializedBinop::PlainInt`] arm, which additionally demands both
+///   operands be proven plain ints.
 /// - `FloorDivide` / `Remainder` (+ in-place) — `IntFloorDiv` / `IntMod`,
 ///   int-only for the same reason (neither has a `FLOAT_*` opcode).  These two
 ///   are the one accepted pair whose lowering *can* decline — on a zero divisor
@@ -3085,7 +3101,8 @@ pub(crate) fn residual_call_descr_index_in_body(body_code: &[u8], d: &DecodedOp)
 /// The two provenance sets describe the actual operands of each binop.  This
 /// admits `def f(self, x): return x + 1` when only `x` is numeric, while still
 /// rejecting `self + x` and global numeric subclasses with user dunders.
-pub(crate) fn residual_call_is_specialized_plain_numeric_op(
+/// `None` for every op outside the accepted set.
+pub(crate) fn residual_call_specialized_plain_numeric_binop(
     body_code: &[u8],
     numeric_ref_regs: &[bool; u8::MAX as usize + 1],
     plain_int_ref_regs: &[bool; u8::MAX as usize + 1],
@@ -3093,7 +3110,7 @@ pub(crate) fn residual_call_is_specialized_plain_numeric_op(
     num_regs_i: usize,
     constants_i: &[i64],
     callee_descr_refs: &[DescrRef],
-) -> bool {
+) -> Option<SpecializedBinop> {
     let helper = residual_call_helper_kind_in_body(body_code, d, callee_descr_refs);
     if !matches!(
         d.key,
@@ -3102,41 +3119,41 @@ pub(crate) fn residual_call_is_specialized_plain_numeric_op(
         helper,
         Some(majit_ir::PyreHelperKind::BinaryOp | majit_ir::PyreHelperKind::CompareOp)
     ) {
-        return false;
+        return None;
     }
     // `iIR`: the R-list follows the I-list.  `walker_int_specialization_operands`
     // / `walker_float_specialization_operands` read exactly `r_args[0]` (lhs)
     // and `r_args[1]` (rhs) and decline any other arity, so demand the same
     // shape here and require both operands to be proven.
     let Some(&i_len) = body_code.get(d.pc + 2) else {
-        return false;
+        return None;
     };
     let r_len_pc = d.pc + 1 + 1 + 1 + i_len as usize;
     if body_code.get(r_len_pc) != Some(&2) {
-        return false;
+        return None;
     }
     let (Some(&lhs_reg), Some(&rhs_reg)) =
         (body_code.get(r_len_pc + 1), body_code.get(r_len_pc + 2))
     else {
-        return false;
+        return None;
     };
     if !numeric_ref_regs[lhs_reg as usize] || !numeric_ref_regs[rhs_reg as usize] {
-        return false;
+        return None;
     }
     // The first I-list item is the BINARY_OP tag.  It must be in the callee's
     // immutable constants window; a runtime tag could select an operation
     // outside the accepted set.
     if i_len == 0 {
-        return false;
+        return None;
     }
     let Some(&tag_reg) = body_code.get(d.pc + 3) else {
-        return false;
+        return None;
     };
     let Some(&tag) = (tag_reg as usize)
         .checked_sub(num_regs_i)
         .and_then(|constant_index| constants_i.get(constant_index))
     else {
-        return false;
+        return None;
     };
     // Both compare tables map all six `ComparisonOperator`s unconditionally
     // (`IntLt/Le/Gt/Ge/Eq/Ne` in `try_walker_specialize_compare_op_int`,
@@ -3146,7 +3163,9 @@ pub(crate) fn residual_call_is_specialized_plain_numeric_op(
     // shape with `ISINSTANCE_OP` (tag 10), which is not one of the six and so
     // stays excluded.
     if helper == Some(majit_ir::PyreHelperKind::CompareOp) {
-        return pyre_interpreter::runtime_ops::compare_op_from_tag(tag).is_some();
+        return pyre_interpreter::runtime_ops::compare_op_from_tag(tag)
+            .is_some()
+            .then_some(SpecializedBinop::Compare);
     }
     use pyre_interpreter::bytecode::BinaryOperator;
     match pyre_interpreter::runtime_ops::binary_op_from_tag(tag) {
@@ -3157,7 +3176,7 @@ pub(crate) fn residual_call_is_specialized_plain_numeric_op(
             | BinaryOperator::InplaceAdd
             | BinaryOperator::InplaceSubtract
             | BinaryOperator::InplaceMultiply,
-        ) => true,
+        ) => Some(SpecializedBinop::Numeric),
         Some(
             BinaryOperator::And
             | BinaryOperator::Or
@@ -3169,8 +3188,9 @@ pub(crate) fn residual_call_is_specialized_plain_numeric_op(
             | BinaryOperator::Remainder
             | BinaryOperator::InplaceFloorDivide
             | BinaryOperator::InplaceRemainder,
-        ) => plain_int_ref_regs[lhs_reg as usize] && plain_int_ref_regs[rhs_reg as usize],
-        _ => false,
+        ) => (plain_int_ref_regs[lhs_reg as usize] && plain_int_ref_regs[rhs_reg as usize])
+            .then_some(SpecializedBinop::PlainInt),
+        _ => None,
     }
 }
 
@@ -3250,42 +3270,6 @@ pub(crate) fn residual_call_is_proven_truth(
     };
     numeric_ref_regs[arg_reg as usize] || bool_ref_regs[arg_reg as usize]
 }
-
-pub(crate) fn residual_call_is_specialized_plain_int_binop(
-    body_code: &[u8],
-    d: &DecodedOp,
-    num_regs_i: usize,
-    constants_i: &[i64],
-) -> bool {
-    let Some(&i_len) = body_code.get(d.pc + 2) else {
-        return false;
-    };
-    if i_len == 0 {
-        return false;
-    }
-    let Some(&tag_reg) = body_code.get(d.pc + 3) else {
-        return false;
-    };
-    let Some(&tag) = (tag_reg as usize)
-        .checked_sub(num_regs_i)
-        .and_then(|constant_index| constants_i.get(constant_index))
-    else {
-        return false;
-    };
-    use pyre_interpreter::bytecode::BinaryOperator;
-    matches!(
-        pyre_interpreter::runtime_ops::binary_op_from_tag(tag),
-        Some(
-            BinaryOperator::And
-                | BinaryOperator::Or
-                | BinaryOperator::Xor
-                | BinaryOperator::InplaceAnd
-                | BinaryOperator::InplaceOr
-                | BinaryOperator::InplaceXor
-        )
-    )
-}
-
 pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     code: &[u8],
     op: &DecodedOp,

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/resume_snapshot.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/resume_snapshot.rs
@@ -1748,6 +1748,176 @@ pub(crate) fn compute_nested_inline_caller_frame<Sym: WalkSym>(
     })
 }
 
+/// Capture the current inlined Python frame at a translated helper call's
+/// entry boundary. The helper has no blackhole frame, so a guard inside it
+/// must rebuild this frame at the CALL and re-execute the helper, while the
+/// already-paused outer frames remain below it.
+pub(crate) fn compute_inline_helper_call_entry_frame<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    call_jit_pc: usize,
+) -> Result<InlineParentFrame, InlineCallerFrameDecline> {
+    let caller_code = ctx
+        .session
+        .borrow()
+        .framestack
+        .last()
+        .map(|frame| frame.w_code)
+        .ok_or(InlineCallerFrameDecline::Unavailable)?;
+    let jitcode_index = crate::state::ensure_jitcode_index(caller_code as *const ())
+        .ok_or(InlineCallerFrameDecline::Unavailable)? as u32;
+    let pjc = crate::state::pyjitcode_for_jitcode_index(jitcode_index as i32)
+        .ok_or(InlineCallerFrameDecline::Unavailable)?;
+    if !pjc.is_populated() || pjc.code_ptr.is_null() {
+        return Err(InlineCallerFrameDecline::Unavailable);
+    }
+    let resume_marker_jit_pc = pjc
+        .resume_marker_for_jitcode_pc(call_jit_pc)
+        .ok_or(InlineCallerFrameDecline::Unavailable)?;
+    let boxes = collect_callee_active_boxes(
+        ctx.registers_i,
+        ctx.registers_r,
+        ctx.registers_f,
+        jitcode_index,
+        call_jit_pc,
+        resume_marker_jit_pc as i32,
+    )
+    .map_err(|_| InlineCallerFrameDecline::Unavailable)?;
+    Ok(InlineParentFrame {
+        jitcode_index,
+        call_jitcode_pc: None,
+        call_stack_overrides: Vec::new(),
+        blackhole: None,
+        resume_coord: ParentResumeCoord::Backxlat(resume_marker_jit_pc),
+        resume_marker_jit_pc: Some(resume_marker_jit_pc),
+        boxes,
+    })
+}
+
+fn publish_outermost_parent_vable_scalars<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    parent_frames: &[InlineParentFrame],
+    op_pc: usize,
+) -> Result<(), DispatchError> {
+    let Some(outer) = parent_frames.first() else {
+        return Err(DispatchError::callee_inline_unsupported(op_pc));
+    };
+    let caller_sym_ptr = ctx.fbw_mode.snapshot_sym;
+    if caller_sym_ptr.is_null() {
+        return Ok(());
+    }
+    let caller_sym = unsafe { &*caller_sym_ptr };
+    if !caller_sym.owns_virtualizable_shadow() || caller_sym.jitcode().is_null() {
+        return Ok(());
+    }
+
+    let resume_py_pc = resolve_parent_resume_py_pc(outer)
+        .ok_or(DispatchError::GuardResumeCoordinateUnavailable { pc: op_pc })?;
+    let last_instr_value = resume_py_pc as i64 - 1;
+    let last_instr_op = ctx.trace_ctx.const_int(last_instr_value);
+    crate::trace_opcode::mirror_vable_static_to_boxes(
+        ctx.trace_ctx,
+        "last_instr",
+        last_instr_op,
+        Value::Int(last_instr_value),
+    );
+    let vsd_value = unsafe {
+        let jc = &*caller_sym.jitcode();
+        if jc.payload.code_ptr.is_null() {
+            caller_sym.valuestackdepth() as i64
+        } else {
+            let raw = || {
+                crate::liveness::liveness_for(jc.payload.code_ptr)
+                    .depth_at_py_pc()
+                    .get(resume_py_pc as usize)
+                    .copied()
+            };
+            let twin: Option<Option<u16>> = if outer.jitcode_index != jc.index as u32 {
+                None
+            } else {
+                match outer.resume_coord {
+                    ParentResumeCoord::Backxlat(jitcode_pc) => jc
+                        .payload
+                        .depth_trivia_populated()
+                        .then(|| jc.payload.depth_trivia_for_jitcode_pc(jitcode_pc)),
+                    ParentResumeCoord::CallFallthrough(call_jit_pc) => jc
+                        .payload
+                        .depth_after_residual_populated()
+                        .then(|| jc.payload.depth_after_residual_for_jitcode_pc(call_jit_pc)),
+                }
+            };
+            let depth = match twin {
+                Some(d) => {
+                    if pcmap_afterresidual_audit_enabled() {
+                        assert_eq!(
+                            d,
+                            raw(),
+                            "PYRE_PCMAP_AFTERRESIDUAL_AUDIT: multiframe vsd depth twin diverged (py {resume_py_pc})"
+                        );
+                    }
+                    d
+                }
+                None => raw(),
+            };
+            match depth {
+                Some(d) => (caller_sym.nlocals() + d as usize) as i64,
+                None => caller_sym.valuestackdepth() as i64,
+            }
+        }
+    };
+    let vsd_op = ctx.trace_ctx.const_int(vsd_value);
+    crate::trace_opcode::mirror_vable_static_to_boxes(
+        ctx.trace_ctx,
+        "valuestackdepth",
+        vsd_op,
+        Value::Int(vsd_value),
+    );
+    Ok(())
+}
+
+fn walker_capture_transparent_helper_snapshot<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    op_pc: usize,
+    parent_frames: Vec<InlineParentFrame>,
+    stamp_last_guard_op: bool,
+) -> Result<(), DispatchError> {
+    if parent_frames.is_empty() || !ctx.trace_ctx.vable_snapshot_buildable() {
+        return Err(DispatchError::callee_inline_unsupported(op_pc));
+    }
+    publish_outermost_parent_vable_scalars(ctx, &parent_frames, op_pc)?;
+    let (vable_boxes, vref_boxes) = ctx.trace_ctx.build_snapshot_vable_vref_boxes();
+    let mut frames: Vec<(u32, u32, u32, &[OpRef])> = Vec::with_capacity(parent_frames.len());
+    for frame in &parent_frames {
+        let word = frame
+            .resume_marker_jit_pc
+            .map(|marker| marker as i32)
+            .unwrap_or(majit_ir::resumedata::NO_JITCODE_PC);
+        let pc_word = crate::state::pyjitcode_for_jitcode_index(frame.jitcode_index as i32)
+            .and_then(|payload| {
+                payload.resolve_resume_pc_with_jitcode_pc(word, crate::state::op_live())
+            })
+            .map(|offset| offset as u32)
+            .ok_or(DispatchError::GuardResumeCoordinateUnavailable { pc: op_pc })?;
+        let py_pc = forward_snapshot_py_pc(frame.jitcode_index, pc_word)?;
+        frames.push((frame.jitcode_index, pc_word, py_pc, frame.boxes.as_slice()));
+    }
+    if stamp_last_guard_op {
+        ctx.trace_ctx
+            .capture_snapshot_for_last_guard_op_multi_frame_with_vable_vref(
+                &frames,
+                &vable_boxes,
+                &vref_boxes,
+            );
+    } else {
+        ctx.trace_ctx
+            .capture_snapshot_for_last_guard_multi_frame_with_vable_vref(
+                &frames,
+                &vable_boxes,
+                &vref_boxes,
+            );
+    }
+    Ok(())
+}
+
 /// Emit a multi-frame inline guard snapshot (#68): the inlined callee's OWN
 /// (top/innermost) frame built from the live sub-walk register banks, plus the
 /// pre-computed paused caller frame(s) on the walk framestack. Frame
@@ -1767,6 +1937,14 @@ pub(crate) fn walker_capture_multi_frame_inline_snapshot<Sym: WalkSym>(
     // Straight-line / branch inline guards ARE the last op and pass `false`.
     stamp_last_guard_op: bool,
 ) -> Result<(), DispatchError> {
+    if ctx.fbw_mode.transparent_helper_subwalk {
+        return walker_capture_transparent_helper_snapshot(
+            ctx,
+            callee_op_pc,
+            parent_frames,
+            stamp_last_guard_op,
+        );
+    }
     if !ctx.trace_ctx.vable_snapshot_buildable() {
         return Err(DispatchError::GuardSnapshotVableUntyped { pc: callee_op_pc });
     }
@@ -1916,85 +2094,7 @@ pub(crate) fn walker_capture_multi_frame_inline_snapshot<Sym: WalkSym>(
     // the resume reader restores the caller's `PyFrame` at the CALL return
     // point rather than the stale loop-header seed the walker never crosses
     // `set_orgpc` to update (mirror of the single-frame path above, 6366-6426).
-    let outer = &parent_frames[0];
-    let caller_sym_ptr = ctx.fbw_mode.snapshot_sym;
-    if !caller_sym_ptr.is_null() {
-        let caller_sym = unsafe { &*caller_sym_ptr };
-        if caller_sym.owns_virtualizable_shadow() && !caller_sym.jitcode().is_null() {
-            let resume_py_pc = resolve_parent_resume_py_pc(outer)
-                .ok_or(DispatchError::GuardResumeCoordinateUnavailable { pc: callee_op_pc })?;
-            let last_instr_value = resume_py_pc as i64 - 1;
-            let last_instr_op = ctx.trace_ctx.const_int(last_instr_value);
-            crate::trace_opcode::mirror_vable_static_to_boxes(
-                ctx.trace_ctx,
-                "last_instr",
-                last_instr_op,
-                Value::Int(last_instr_value),
-            );
-            let resume_py_pc = resolve_parent_resume_py_pc(outer)
-                .ok_or(DispatchError::GuardResumeCoordinateUnavailable { pc: callee_op_pc })?;
-            let vsd_value = unsafe {
-                let jc = &*caller_sym.jitcode();
-                if jc.payload.code_ptr.is_null() {
-                    caller_sym.valuestackdepth() as i64
-                } else {
-                    // Raw py_pc-keyed static-liveness read: the fallback where the
-                    // twin does not apply (cross-jitcode parent, or empty twin),
-                    // and the audit oracle.
-                    let raw = || {
-                        crate::liveness::liveness_for(jc.payload.code_ptr)
-                            .depth_at_py_pc()
-                            .get(resume_py_pc as usize)
-                            .copied()
-                    };
-                    // The raw read resolves `resume_py_pc` against
-                    // `outer.jitcode_index`'s tables but indexes THIS jitcode's
-                    // liveness; the twins key one jitcode, so cut only when both
-                    // are the same jitcode. `Some(inner)` = twin applies (inner is
-                    // its Option<u16> depth); `None` = not applicable -> raw.
-                    let twin: Option<Option<u16>> = if outer.jitcode_index != jc.index as u32 {
-                        None
-                    } else {
-                        match outer.resume_coord {
-                            ParentResumeCoord::Backxlat(jitcode_pc) => jc
-                                .payload
-                                .depth_trivia_populated()
-                                .then(|| jc.payload.depth_trivia_for_jitcode_pc(jitcode_pc)),
-                            ParentResumeCoord::CallFallthrough(call_jit_pc) => {
-                                jc.payload.depth_after_residual_populated().then(|| {
-                                    jc.payload.depth_after_residual_for_jitcode_pc(call_jit_pc)
-                                })
-                            }
-                        }
-                    };
-                    let depth = match twin {
-                        Some(d) => {
-                            if pcmap_afterresidual_audit_enabled() {
-                                assert_eq!(
-                                    d,
-                                    raw(),
-                                    "PYRE_PCMAP_AFTERRESIDUAL_AUDIT: multiframe vsd depth twin diverged (py {resume_py_pc})"
-                                );
-                            }
-                            d
-                        }
-                        None => raw(),
-                    };
-                    match depth {
-                        Some(d) => (caller_sym.nlocals() + d as usize) as i64,
-                        None => caller_sym.valuestackdepth() as i64,
-                    }
-                }
-            };
-            let vsd_op = ctx.trace_ctx.const_int(vsd_value);
-            crate::trace_opcode::mirror_vable_static_to_boxes(
-                ctx.trace_ctx,
-                "valuestackdepth",
-                vsd_op,
-                Value::Int(vsd_value),
-            );
-        }
-    }
+    publish_outermost_parent_vable_scalars(ctx, &parent_frames, callee_op_pc)?;
 
     let (vable_boxes, vref_boxes) = ctx.trace_ctx.build_snapshot_vable_vref_boxes();
 

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -4800,6 +4800,11 @@ fn is_builtin_dict_get_function(callable: pyre_object::PyObjectRef) -> bool {
 /// as `W_DictObject.keys_version`, so guard it and issue a live nth-value read.
 /// Value-only replacement is intentionally visible without invalidation.
 ///
+/// The emitted `keys_version` guard is an unlocked field read, which is a
+/// pre-filter only — `jit_dict_nth_value_versioned` re-checks the version
+/// under the dict's own lock, and a `guard_nonnull` on its result side-exits
+/// when a concurrent key-set mutation detached the index from the key.
+///
 /// Equal-but-nonidentical keys and misses remain residual because reproducing
 /// their hash/equality effects requires the complete r_dict probe.
 pub(crate) fn try_walker_specialize_builtin_dict_get<Sym: WalkSym>(
@@ -4945,14 +4950,22 @@ pub(crate) fn try_walker_specialize_builtin_dict_get<Sym: WalkSym>(
 
     let index_op = ctx.trace_ctx.const_int(index as i64);
     let value = ctx.trace_ctx.call_ref_typed_with_effect(
-        crate::helpers::jit_dict_nth_value as *const (),
-        &[dict_op, index_op],
-        &[majit_ir::Type::Ref, majit_ir::Type::Int],
+        crate::helpers::jit_dict_nth_value_versioned as *const (),
+        &[dict_op, index_op, expected_version],
+        &[
+            majit_ir::Type::Ref,
+            majit_ir::Type::Int,
+            majit_ir::Type::Int,
+        ],
         majit_ir::EffectInfo::new(
             majit_ir::ExtraEffect::CannotRaise,
             majit_ir::OopSpecIndex::None,
         ),
     );
+    // A key set that moved after the unlocked version guard, or an index the
+    // compacted table no longer holds, comes back as `PY_NULL`: side-exit to
+    // the generic `dict.get` residual instead of writing it to a Ref register.
+    walker_emit_fold_guard_with_snapshot(ctx, op.pc, OpCode::GuardNonnull, &[value])?;
     ctx.trace_ctx.set_opref_concrete(
         value,
         majit_ir::Value::Ref(majit_ir::GcRef(concrete_value as usize)),

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -5509,8 +5509,8 @@ pub(crate) fn try_walker_specialize_math_ldexp<Sym: WalkSym>(
 /// result.  Pyre's native module wrapper otherwise materializes an `RBigInt`
 /// before the walker can see that arm.  Recreate the translated shape as an
 /// exact-class guard, unbox, pure non-raising integer call, and `wrapint`.
-/// Longs, subclasses, negative values, rebound callables, and `__index__`
-/// objects retain the generic residual path.
+/// Longs, bools, subclasses, negative values, rebound callables, and
+/// `__index__` objects retain the generic residual path.
 pub(crate) fn try_walker_specialize_math_isqrt<Sym: WalkSym>(
     ctx: &mut WalkContext<'_, '_, Sym>,
     code: &[u8],
@@ -5538,7 +5538,15 @@ pub(crate) fn try_walker_specialize_math_isqrt<Sym: WalkSym>(
         return Ok(None);
     }
     let value = unsafe {
-        if !pyre_object::is_exact_builtin_instance(arg_obj) || !pyre_object::is_int(arg_obj) {
+        // `is_int` also accepts a `bool`, whose singletons carry a `&BOOL_TYPE`
+        // vtable and a NULL `w_class`.  The unbox and the exact-class guard
+        // below both pin the canonical `int` class, so neither can hold for one;
+        // decline it here as the int/long binop specializations do instead of
+        // emitting a guard that fails on the operand it was recorded from.
+        if !pyre_object::is_exact_builtin_instance(arg_obj)
+            || !pyre_object::is_int(arg_obj)
+            || pyre_object::is_bool(arg_obj)
+        {
             return Ok(None);
         }
         pyre_object::w_int_get_value(arg_obj)

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
@@ -94,6 +94,42 @@ fn builtin_wrapper_heapcache_uses_item_not_length_descr() {
 }
 
 #[test]
+fn keyword_builtin_wrapper_finds_colored_argument_slice_item_descr() {
+    let wrapper =
+        named_jitcode("__pyre_wrap_getrandbits").expect("getrandbits builtin wrapper jitcode");
+    let mut ops = crate::jitcode_runtime::decoded_ops(&wrapper.code);
+    let first = ops.next().expect("wrapper first op");
+    assert_eq!(
+        first.key, "inline_call_r_r/dR>r",
+        "keyword wrapper starts by splitting positional and keyword arguments"
+    );
+
+    let arraylen = crate::jitcode_runtime::decoded_ops(&wrapper.code)
+        .find(|op| op.key == "arraylen_gc/rd>i")
+        .expect("keyword wrapper argument-slice length");
+    assert_ne!(
+        wrapper.code[arraylen.pc + 1],
+        0,
+        "register coloring moves the positional slice away from wrapper r0"
+    );
+    let getitem = crate::jitcode_runtime::decoded_ops(&wrapper.code)
+        .find(|op| op.pc > arraylen.pc && op.key == "getarrayitem_gc_r/rid>r")
+        .expect("keyword wrapper argument-slice item read");
+    assert_ne!(
+        wrapper.code[getitem.pc + 1],
+        0,
+        "register coloring keeps the argument slice off r0 at extraction"
+    );
+
+    let item_pool_index =
+        wrapper.code[getitem.pc + 3] as usize | ((wrapper.code[getitem.pc + 4] as usize) << 8);
+    assert_eq!(
+        wrapper_args_item_descr_index(&wrapper.code),
+        Some(crate::jitcode_runtime::all_descr_refs()[item_pool_index].index())
+    );
+}
+
+#[test]
 fn random_core_residuals_use_registered_genrand32_address() {
     let expected = pyre_interpreter::jit_trace_fnaddrs()
         .into_iter()

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
@@ -99,34 +99,47 @@ fn keyword_builtin_wrapper_finds_colored_argument_slice_item_descr() {
         named_jitcode("__pyre_wrap_getrandbits").expect("getrandbits builtin wrapper jitcode");
     let mut ops = crate::jitcode_runtime::decoded_ops(&wrapper.code);
     let first = ops.next().expect("wrapper first op");
-    assert_eq!(
-        first.key, "inline_call_r_r/dR>r",
-        "keyword wrapper starts by splitting positional and keyword arguments"
+    // The result colour is not pinned. `split_builtin_kwargs` returns the
+    // aggregate `(&[PyObjectRef], Option<PyObjectRef>)`; when the codewriter
+    // materializes that pair the entry call yields it by reference
+    // (`inline_call_r_r`), and when it inlines the body far enough to leave
+    // only the leading `args.is_empty()` test at the entry the same call
+    // yields that by value (`inline_call_r_i`). Both start the wrapper by
+    // splitting positional from keyword arguments, which is what this asserts.
+    assert!(
+        first.opname.starts_with("inline_call_"),
+        "keyword wrapper starts by splitting positional and keyword arguments, got {}",
+        first.key
     );
 
-    let arraylen = crate::jitcode_runtime::decoded_ops(&wrapper.code)
-        .find(|op| op.key == "arraylen_gc/rd>i")
-        .expect("keyword wrapper argument-slice length");
-    assert_ne!(
-        wrapper.code[arraylen.pc + 1],
-        0,
-        "register coloring moves the positional slice away from wrapper r0"
-    );
+    let item_descr_index =
+        wrapper_args_item_descr_index(&wrapper.code).expect("wrapper item descriptor");
+    // Select by descr identity rather than by position. The inlined splitter
+    // reads `args.len()` off the wrapper's own `r0` before the split, so "the
+    // first `arraylen_gc`" names that read and not the positional slice's once
+    // the body inlines; the item descr names the slice under every inline
+    // depth.
     let getitem = crate::jitcode_runtime::decoded_ops(&wrapper.code)
-        .find(|op| op.pc > arraylen.pc && op.key == "getarrayitem_gc_r/rid>r")
+        .find(|op| {
+            op.key == "getarrayitem_gc_r/rid>r"
+                && item_pool_descr_index(&wrapper.code, op.pc + 3) == item_descr_index
+        })
         .expect("keyword wrapper argument-slice item read");
+    let slice_reg = wrapper.code[getitem.pc + 1];
     assert_ne!(
-        wrapper.code[getitem.pc + 1],
-        0,
+        slice_reg, 0,
         "register coloring keeps the argument slice off r0 at extraction"
     );
+    crate::jitcode_runtime::decoded_ops(&wrapper.code)
+        .find(|op| op.key == "arraylen_gc/rd>i" && wrapper.code[op.pc + 1] == slice_reg)
+        .expect("keyword wrapper reads the argument-slice length off the colored slice");
+}
 
-    let item_pool_index =
-        wrapper.code[getitem.pc + 3] as usize | ((wrapper.code[getitem.pc + 4] as usize) << 8);
-    assert_eq!(
-        wrapper_args_item_descr_index(&wrapper.code),
-        Some(crate::jitcode_runtime::all_descr_refs()[item_pool_index].index())
-    );
+/// Descr-pool index encoded little-endian at `at`, resolved to its
+/// `all_descrs` index.
+fn item_pool_descr_index(code: &[u8], at: usize) -> u32 {
+    let pool_index = code[at] as usize | ((code[at + 1] as usize) << 8);
+    crate::jitcode_runtime::all_descr_refs()[pool_index].index()
 }
 
 #[test]

--- a/pyre/pyre-jit-trace/src/jitcode_runtime.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_runtime.rs
@@ -2008,6 +2008,11 @@ mod tests {
     /// `dyn Trait` calls through `CallTarget::Indirect` became the default, so
     /// the codewriter emits it and it is now registered in
     /// `build_inline_call_only_bh_builder` instead.
+    ///
+    /// `new/d>r` left it the same way: lowering a rebuilt `Result` shell as an
+    /// allocation made `OpKind::New` reachable from the codewriter. Its operand
+    /// shape is `new_with_vtable/d>r`'s — a 2-byte little-endian descr index
+    /// then a 1-byte ref register — and `handler_new` decodes exactly that.
     #[test]
     fn production_bh_builder_overlay_only_gap_snapshot() {
         let builder = build_pyre_production_bh_builder();
@@ -2044,7 +2049,6 @@ mod tests {
             "getlistitem_gc_i/ridd>i",
             "getlistitem_gc_r/ridd>r",
             "int_between/iii>i",
-            "new/d>r",
             "new_array/id>r",
             "newlist/idddd>r",
             "newlist_clear/idddd>r",

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -5973,7 +5973,20 @@ fn for_iter_bodies_all_jit_safe(code: &pyre_interpreter::CodeObject) -> bool {
                 let mut scan_pc = pc + 1;
                 let mut has_call = false;
                 while scan_pc < exit && scan_pc < instructions.len() {
-                    let (scan_instr, _) = scan_state.get(instructions[scan_pc]);
+                    let (scan_instr, scan_arg) = scan_state.get(instructions[scan_pc]);
+                    if let I::ForIter { delta } = scan_instr {
+                        // A nested loop owns its body.  It is validated when
+                        // the outer instruction walk reaches that FOR_ITER;
+                        // calls inside it must not taint a LIST_APPEND owned by
+                        // this lexical loop (and vice versa).
+                        scan_pc = pyre_interpreter::jump_target_forward(
+                            instructions,
+                            scan_pc + 1,
+                            delta.get(scan_arg).as_usize(),
+                        );
+                        scan_state = pyre_interpreter::OpArgState::default();
+                        continue;
+                    }
                     if matches!(
                         scan_instr,
                         I::Call { .. }
@@ -5991,7 +6004,20 @@ fn for_iter_bodies_all_jit_safe(code: &pyre_interpreter::CodeObject) -> bool {
             let mut body_state = pyre_interpreter::OpArgState::default();
             let mut body_pc = pc + 1;
             while body_pc < exit && body_pc < instructions.len() {
-                let (body_instr, _) = body_state.get(instructions[body_pc]);
+                let (body_instr, body_arg) = body_state.get(instructions[body_pc]);
+                if let I::ForIter { delta } = body_instr {
+                    // Validate the nested body exactly once, under its own
+                    // lexical FOR_ITER.  Scanning it again as part of the
+                    // outer body conflates unrelated calls with its
+                    // LIST_APPEND and declines safe PEP 709 comprehensions.
+                    body_pc = pyre_interpreter::jump_target_forward(
+                        instructions,
+                        body_pc + 1,
+                        delta.get(body_arg).as_usize(),
+                    );
+                    body_state = pyre_interpreter::OpArgState::default();
+                    continue;
+                }
                 let permitted = for_iter_body_op_is_jit_safe(body_instr)
                     || matches!(
                         body_instr,
@@ -11480,6 +11506,23 @@ mod tests {
         let code = function_code_from_module(&module, "f");
 
         assert!(!nested_break_bridge_resume_hazard(&code));
+    }
+
+    #[test]
+    fn nested_comprehension_calls_after_it_stays_jit_safe() {
+        // The inner comprehension owns its call-free LIST_APPEND. Calls after
+        // that loop belong to the outer body and must not retroactively turn
+        // the inner append into a call-bearing comprehension. This is the
+        // nested-loop shape used by test_math.testDist.
+        use pyre_interpreter::compile_exec;
+        let module = compile_exec(
+            "def f(rows, pred, sink):\n    for p in rows:\n        for q in rows:\n            diffs = [x for x in q]\n            if pred(diffs):\n                sink(diffs)\n            elif pred(q):\n                sink(q)\n",
+        )
+        .expect("test code should compile");
+        let code = function_code_from_module(&module, "f");
+
+        assert!(for_iter_bodies_all_jit_safe(&code));
+        assert_eq!(unsupported_jit_shape(&code), UnsupportedJitShape::None);
     }
 
     #[test]

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -7253,13 +7253,19 @@ fn maybe_compile_and_run(
     if *NO_JIT.get_or_init(|| std::env::var_os("PYRE_NO_JIT").is_some()) {
         return None;
     }
-    // `eval_with_jit_inner` classifies the frame once, before entering
-    // `eval_loop_jit`.  Consequently every back-edge reaching this helper is
-    // already known traceable.  Do not repeat `unsupported_jit_shape` here:
-    // that pyre-only safety gate walks the constant tree and the complete
-    // bytecode, while RPython's `can_enter_jit` is unconditional.  Re-running
-    // it at every back-edge made the classification scan itself one of
-    // test_math's hottest native functions.
+    // Not every back-edge reaching this helper passed `eval_with_jit_inner`'s
+    // classification: `portal_runner_dispatch` enters `eval_loop_jit` for a
+    // frame forced through the portal, and that route exists precisely for a
+    // callee with no compiled loop (`compile_tmp_callback` bakes
+    // `portal_runner_adr` as the callee body, and the `!is_resolved`
+    // CALL_ASSEMBLER force leg calls the same shim).  The classification is
+    // cached per code object in `CallControl.graph_jit_shapes`, so consulting
+    // it here is a pointer-keyed lookup rather than the constant-tree plus
+    // whole-bytecode walk that used to run on every back-edge.
+    let code = unsafe { &*pyre_interpreter::pyframe_get_pycode(frame) };
+    if cached_unsupported_jit_shape(code) != UnsupportedJitShape::None {
+        return None;
+    }
     if let Some(expected_vsd) =
         pyre_jit_trace::state::depth_based_vsd_for_wcode(frame.pycode as usize, loop_header_pc)
     {
@@ -8417,13 +8423,18 @@ pub fn try_function_entry_jit(frame: &mut PyFrame) -> Option<PyResult> {
         return None;
     }
     let code = unsafe { &*pyre_interpreter::pyframe_get_pycode(frame_root.frame()) };
-    // The ordinary caller is `eval_with_jit_inner`, immediately after its
-    // one authoritative `unsupported_jit_shape` check.  The other caller,
-    // `portal_runner_dispatch`, is recursive re-entry for a portal that could
-    // only have obtained compiled code after passing that same check.  Keep
-    // this warmstate entry shaped like RPython's unconditional
-    // `maybe_compile_and_run`; repeating the whole-frame scan here charged
-    // every Python call even before a warm counter could take the fast path.
+    // The other caller, `portal_runner_dispatch`, does not imply a frame that
+    // already passed `eval_with_jit_inner`'s classification: the portal entry
+    // points are reached when the callee has *no* compiled loop —
+    // `compile_tmp_callback` bakes `portal_runner_adr` as the whole callee body
+    // and the `!is_resolved` CALL_ASSEMBLER force leg calls the same shim — and
+    // the counter tick below starts a trace for such a frame.  Consult the
+    // frame-shape gate here as well.  The classification is cached per code
+    // object in `CallControl.graph_jit_shapes`, so this is a pointer-keyed
+    // lookup, not the whole-frame scan that charged every Python call.
+    if cached_unsupported_jit_shape(code) != UnsupportedJitShape::None {
+        return None;
+    }
     if dump_bytecode_enabled() {
         if code.obj_name.as_str() == "fannkuch" && frame_root.frame().next_instr() == 0 {
             use std::sync::OnceLock;

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -14179,6 +14179,12 @@ impl CodeWriter {
             // matches RPython's "same JitCode object is filled later"
             // identity flow even after other stores cloned the Arc.
             let Some(pyjitcode) = self.transform_graph_to_jitcode(unsafe { &*code_ptr }) else {
+                // Cache the authoritative assembler result for shapes that
+                // reach this exact check. The graph is immutable, so a later
+                // drain cannot make this encoding failure disappear.
+                self.callcontrol()
+                    .graph_jit_shapes
+                    .insert(code_ptr as usize, 3);
                 continue;
             };
             let key = code_ptr as usize;

--- a/pyre/pyre-macros/src/lib.rs
+++ b/pyre/pyre-macros/src/lib.rs
@@ -125,13 +125,17 @@ fn expand_pyre_function(func: ItemFn) -> syn::Result<proc_macro2::TokenStream> {
         let req_lits = param_required.iter().map(|b| quote! { #b });
         let fn_name_str = user_name.to_string();
         quote! {
-            let __pyre_positional_count =
-                crate::builtins::split_builtin_kwargs(args).0.len();
+            let __pyre_has_kwargs = crate::builtins::has_builtin_kwargs(args);
+            let __pyre_positional_count = if __pyre_has_kwargs {
+                args.len() - 1
+            } else {
+                args.len()
+            };
             const __PYRE_PARAM_NAMES: &[&str] = &[ #(#name_lits),* ];
             const __PYRE_PARAM_REQUIRED: &[bool] = &[ #(#req_lits),* ];
             let __pyre_bound_args;
             let args: &[::pyre_object::PyObjectRef] =
-                if crate::builtins::has_builtin_kwargs(args) {
+                if __pyre_has_kwargs {
                     __pyre_bound_args = crate::builtins::bind_builtin_kwargs(
                         args,
                         __PYRE_PARAM_NAMES,
@@ -1892,13 +1896,17 @@ fn expand_pyre_methods(
                 let req_lits = all_required.iter().map(|b| quote! { #b });
                 let fn_name_str = mname.to_string();
                 quote! {
-                    let __pyre_positional_count =
-                        crate::builtins::split_builtin_kwargs(args).0.len();
+                    let __pyre_has_kwargs = crate::builtins::has_builtin_kwargs(args);
+                    let __pyre_positional_count = if __pyre_has_kwargs {
+                        args.len() - 1
+                    } else {
+                        args.len()
+                    };
                     const __PYRE_PARAM_NAMES: &[&str] = &[ #(#name_lits),* ];
                     const __PYRE_PARAM_REQUIRED: &[bool] = &[ #(#req_lits),* ];
                     let __pyre_bound_args;
                     let args: &[::pyre_object::PyObjectRef] =
-                        if crate::builtins::has_builtin_kwargs(args) {
+                        if __pyre_has_kwargs {
                             __pyre_bound_args = crate::builtins::bind_builtin_kwargs(
                                 args,
                                 __PYRE_PARAM_NAMES,

--- a/pyre/pyre-macros/src/lib.rs
+++ b/pyre/pyre-macros/src/lib.rs
@@ -1981,16 +1981,12 @@ fn expand_pyre_methods(
                         )
                     }
                 } else {
-                    let text = format!(
-                        "{} expected at least {visible_required} argument{}, got {{}}",
-                        fn_name,
-                        if visible_required == 1 { "" } else { "s" },
-                    );
                     quote! {
-                        ::std::result::Result::Err(crate::PyError::type_error(format!(
-                            #text,
+                        crate::gateway::method_min_arity_failure(
+                            #fn_name,
+                            #visible_required,
                             args.len().saturating_sub(#receiver_slots),
-                        )))
+                        )
                     }
                 };
                 quote! {


### PR DESCRIPTION
Follow-up work on `gc-decouple` after #878 merged. Two independent strands sit on
this branch:

- **Review fixes for #878** (9 commits, `Assisted-by: Claude`) — every finding the
  Codex and CodeRabbit reviews raised on #878, verified against the code before
  being fixed.
- **Continued walker/translator work** (8 commits) — the peer session's ongoing
  jitcode-dispatch and frontend changes.

## Review fixes

Thirteen review findings were checked against the branch tip. **Nine were
confirmed and fixed**, one was already being addressed on the branch, and three
were refuted with the code that refutes them.

| Fix | Finding | What was wrong |
|---|---|---|
| `jit: restrict the builtin-wrapper fold to positional calls` | Codex P1 + CodeRabbit Critical | `try_walker_inline_builtin_call` admitted `CallKw` and built the wrapper's positional array from `r_args[2..]`, where index 2 is the **kwnames tuple** |
| `jit: require a positional-only callee scope for the walker inline lever` | Codex P1 | Admission tested `callee_args.len() == nparams` only, and `co_argcount` excludes `*args` / `**kwargs` / keyword-only slots |
| `jit: consult the cached frame-shape classification on the portal entry paths` | Codex P1 | The classification-caching commit removed the two `unsupported_jit_shape` consults; `portal_runner_dispatch` reaches both without one |
| `jit: re-check the dict keys_version under the dict lock` | Codex P1 | `keys_version` was guarded by an unlocked read, then `jit_dict_nth_value` locked only for the indexed read |
| `jit: decline bool operands in the math.isqrt specialization` | Codex P2 | `is_int` accepts a bool, but the emitted code unboxes through `INT_TYPE` and guards the canonical `int` `w_class` |
| `jit(descr): rank ExecutionContext field descrs by byte offset` | CodeRabbit Major | Both EC fields carried `index_in_parent: 0`, and `OptHeap::field_slot_index` prefers it over `descr.index()` when a parent is bound |
| `jit: return the accepted binop class from one decode` | CodeRabbit Major | Two predicates each decoded the `BINARY_OP` tag and each carried the bitwise operator set, needing lockstep maintenance |
| `majit: order the builtin-wrapper alias pick totally and memoise the family` | CodeRabbit Minor + Trivial | The alias tie-break resolved on `HashMap` iteration order; the family was rebuilt per op and per graph |
| `interp: route the variable-arity argument-count error through a gateway helper` | CodeRabbit Major | The "expected at least N arguments" branch built its message with `format!` inline in the traced body |

### Worth calling out

**`CallKw`** was the most consequential. The residual layout was established from
four independent sites — `Instruction::CallKw` (producer), the `call_kw` flatten
tag, `bh_call_kw_arity` (consumer) and the `EffectInfo` doc, which states
outright that arg index 2 is the kwnames tuple. Because a generated wrapper
expects keywords as the **trailing** `__pyre_kw__` marker dict that
`split_builtin_kwargs` strips, a kwnames tuple in slot 0 is consumed as a
positional value. Three reachable outcomes:

- `dq.index(7, start=1)` binds `x = ('start',)` and raises `ValueError`
- `dq.rotate(n=1)` trips the arity guard and raises `TypeError`
- `lock.acquire(blocking=0)` passes the arity guard, then
  `unsafe { w_int_get_value(args[1]) }` reads the **tuple** at `W_IntObject`
  layout — an unchecked deref yielding a garbage `i64`

The fix declines rather than implements: binding keywords inside the wrapper fold
would need either the marker dict materialized in trace IR or the wrapper's
`__PYRE_PARAM_NAMES` table at trace time, both new machinery.
`CallFunctionEx` was already declined, which is the precedent.

**`portal_runner_dispatch`** is the second. The caching commit's justification was
that `eval_with_jit_inner` classifies every frame first, but the portal entry
points exist precisely for a callee with *no* compiled loop —
`compile_tmp_callback` bakes `portal_runner_adr` as the whole callee body, and
the `!is_resolved` CALL_ASSEMBLER force leg calls the same shim. The consults are
restored through the cache, so the commit's performance win is kept.

### Refuted, with reasons

- **`mir.rs` impl-method owner path** — `impl_method_owner_for_fundecl` returns
  `strip_crate_prefix(name_path())`, already module-qualified, so the `GraphKey`
  partition is unchanged. No duplication occurs.
- **`lib.rs` silent discard** — the `filter_map` is infallible:
  `grab_initial_jitcodes` already ran `get_jitcode` over the identical path list
  and `jitcodes` is insert-only. A diagnostic there would be dead code, so the
  invariant is enforced by indexing instead.
- **`tests.rs` selector split** — `name == "random"` matches two distinct
  jitcodes (`W_Random::random` and `Random::random`), so dropping the
  disambiguator as suggested would break the test. Only the `expect` wording was
  wrong.

## Verification

`cargo check` passes for every touched crate. LLBC was re-extracted for
`pyre-interpreter` and `pyre-jit`, the two crates whose sources changed.

Full gate, all three backends: **dynasm 343 / cranelift 343 / wasm 340 pass,
one failure.** `synth/str_search_index_bounds`, red on `main` for some time, now
passes.

### Open: `synth/sre_pattern_methods` is red

`280000` expected, `279999` actual, identically on all three backends. The
fixture runs `N = 2500` iterations each contributing exactly 112, so this is
**one unit lost in a single iteration** — a miscompile, not a systematic
mis-count.

Attribution was measured, not guessed:

| Tree state | Result |
|---|---|
| branch tip (17 commits over `main`) | `279999` |
| the 7 review fixes needing no LLBC re-extract reverted | `279999` |
| **all 9 review fixes reverted**, LLBC re-extracted | `279999` |
| **merge-base `83c356da3e0`** (neither strand), LLBC re-extracted | **PASS** |

So the regression comes from the walker/translator commits on this branch, not
from the review fixes: reverting all nine leaves the failure bit-identical,
while the merge-base is green. It has not yet been bisected to a single commit
among those eight.

— *authored by Claude*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for `longlong2float.longlong2float` and 64-bit integer bit-pattern to float conversions.
  * Expanded built-in wrapper/type descriptor coverage (including improved `isinstance` and `object.__new__` gateway wiring).

* **Bug Fixes**
  * Improved `Result` variant lowering to restore correct allocation and discriminator writes.
  * Enhanced generic instantiation resolution for struct/field descriptors and discriminant consistency.
  * Strengthened dictionary specialization and made JIT handling more reliable for nested loops and unsupported shapes.

* **Performance**
  * Reduced repeated call-graph and wrapper discovery work via caching.
  * Added version-aware dict value lookup to avoid unsafe specialization paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->