### PR TITLE
descr: fix the #892 review findings, then measure which descr-universe hypotheses survive

### DIFF
--- a/majit/majit-ir/src/descr.rs
+++ b/majit/majit-ir/src/descr.rs
@@ -1056,10 +1056,27 @@ impl GcCache {
     /// that means two producers disagree about which fields the struct has, and
     /// inventing a position would be worse than leaving the caller's, since the
     /// existing `debug_assert!` canaries are what should catch it.
+    /// The lookup itself, with no census side effect.
+    ///
+    /// Separate from [`derive_index_in_parent`] because the cache-hit path has to
+    /// ask the same question and must not be counted: the census measures what
+    /// producers hand in, and a cached field is one producer's answer read back,
+    /// not a second producer disagreeing.
+    ///
+    /// Name only. An offset fallback looks tempting but is unsound while one
+    /// struct is reachable under several identity keys: the parent found may
+    /// belong to a different struct, and a same-offset field of another type
+    /// then reads as this one.
+    ///
+    /// [`derive_index_in_parent`]: Self::derive_index_in_parent
+    fn find_index_in_parent(parent: Option<&DescrRef>, field_name: &str) -> Option<usize> {
+        let fields = parent.and_then(|p| p.as_size_descr())?.all_fielddescrs();
+        fields.iter().position(|f| f.field_key() == field_name)
+    }
+
     fn derive_index_in_parent(
         parent: Option<&DescrRef>,
         field_name: &str,
-        offset: usize,
         caller_index: usize,
     ) -> Option<usize> {
         use std::sync::atomic::Ordering::Relaxed;
@@ -1067,18 +1084,11 @@ impl GcCache {
             FIELD_PARENT_ABSENT.fetch_add(1, Relaxed);
             return None;
         };
-        let fields = size_descr.all_fielddescrs();
-        if fields.is_empty() {
+        if size_descr.all_fielddescrs().is_empty() {
             FIELD_PARENT_EMPTY.fetch_add(1, Relaxed);
             return None;
         }
-        // Name only. An offset fallback looks tempting but is unsound while one
-        // struct is reachable under several identity keys: the parent found may
-        // belong to a different struct, and a same-offset field of another type
-        // then reads as this one.
-        let _ = offset;
-        let found = fields.iter().position(|f| f.field_key() == field_name);
-        match found {
+        match Self::find_index_in_parent(parent, field_name) {
             Some(i) => {
                 if i != caller_index {
                     FIELD_INDEX_REDERIVED.fetch_add(1, Relaxed);
@@ -1123,6 +1133,15 @@ impl GcCache {
         virtualizable: bool,
         index_in_parent: usize,
     ) -> Arc<SimpleFieldDescr> {
+        // descr.py:234-238: parent_descr = get_size_descr(gccache, STRUCT, vtable)
+        let parent = self._cache_size.get(&struct_key).cloned();
+        // What the cached descr's own `index_in_parent` was normalised to when it
+        // was minted. The caller's raw number cannot be compared against it: a
+        // field that was rederived once stays rederived, so asserting the cached
+        // value equals the argument fires on the SECOND lookup of exactly the
+        // fields this normalisation exists for.
+        let expected_index_in_parent =
+            Self::find_index_in_parent(parent.as_ref(), field_name).unwrap_or(index_in_parent);
         // descr.py:220-221: cache[STRUCT][fieldname]
         if let Some(inner) = self._cache_field.get(&struct_key) {
             if let Some(descr) = inner.get(field_name) {
@@ -1134,13 +1153,14 @@ impl GcCache {
                         is_immutable,
                         is_quasi_immutable,
                         virtualizable,
-                        index_in_parent,
+                        expected_index_in_parent,
                     ),
                     "get_field_descr cache hit for {field_name} disagrees with the caller: \
                      cached (offset {}, size {}, type {:?}, immutable {}, quasi {}, vable {}, \
                      index_in_parent {}) vs requested (offset {offset}, size {field_size}, \
                      type {field_type:?}, immutable {is_immutable}, quasi {is_quasi_immutable}, \
-                     vable {virtualizable}, index_in_parent {index_in_parent})",
+                     vable {virtualizable}, index_in_parent {expected_index_in_parent} \
+                     [caller said {index_in_parent}])",
                     descr.offset,
                     descr.field_size,
                     descr.field_type,
@@ -1163,8 +1183,6 @@ impl GcCache {
                 format!("T{type_id}.{field_name}")
             }
         };
-        // descr.py:234-238: parent_descr = get_size_descr(gccache, STRUCT, vtable)
-        let parent = self._cache_size.get(&struct_key).cloned();
         // descr.py:230-231: FieldDescr(name, offset, size, flag, index_in_parent, is_pure)
         let mut fd = SimpleFieldDescr::new_with_name(
             index,
@@ -1196,7 +1214,7 @@ impl GcCache {
         // So take the index from the parent that will actually be indexed,
         // rather than from whoever happened to call.
         fd.index_in_parent =
-            Self::derive_index_in_parent(parent.as_ref(), field_name, offset, index_in_parent)
+            Self::derive_index_in_parent(parent.as_ref(), field_name, index_in_parent)
                 .unwrap_or(index_in_parent);
         // descr.py:229 `is_quasi_immutable = '%s?' in STRUCT._hints.get(
         // '_immutable_fields_', ())` parity.  The analyzer side reads
@@ -5891,6 +5909,44 @@ mod register_keyed_size_authority_tests {
         gc._cache_size.insert(LLType::Struct(2), shell_descr(32));
 
         assert_eq!(gc.size_shell_census(), [1, 1, 0, 0, 0]);
+    }
+
+    /// A rederived field must survive being looked up twice.
+    ///
+    /// `get_field_descr` normalises `index_in_parent` against the parent, so the
+    /// cached descr holds the derived number while the caller keeps handing in
+    /// its own. Validating the cache hit against the raw argument therefore
+    /// fires on the SECOND lookup of exactly the fields the normalisation exists
+    /// for — and only in debug builds, where `debug_assert!` is live, so the
+    /// release gate cannot see it.
+    #[test]
+    fn a_rederived_field_survives_a_second_lookup() {
+        let mut gc = GcCache::new();
+        let key = LLType::Struct(5);
+        // Parent lists f16, f24, f32 — so `f24` is at index 1.
+        gc._cache_size
+            .insert(key.clone(), size_descr_at(7, 0, &[16, 24, 32]));
+        let mut lookup = |gc: &mut GcCache| {
+            gc.get_field_descr(
+                key.clone(),
+                "f24",
+                None,
+                24,
+                8,
+                Type::Int,
+                false,
+                false,
+                ArrayFlag::Signed,
+                0,
+                false,
+                // A header-counting producer's number, two slots high.
+                3,
+            )
+        };
+        let first = lookup(&mut gc);
+        assert_eq!(first.index_in_parent, 1, "the parent's own list wins");
+        let second = lookup(&mut gc);
+        assert_eq!(second.index_in_parent, 1);
     }
 
     /// The upgrade rule itself is unchanged when both sides carry a vtable.

--- a/majit/majit-ir/src/descr.rs
+++ b/majit/majit-ir/src/descr.rs
@@ -659,15 +659,6 @@ pub fn next_call_descr_heapcache_index() -> u32 {
     NEXT_CALL_DESCR_HEAPCACHE_INDEX.fetch_add(1, Ordering::Relaxed)
 }
 
-/// descr.py:14-23 GcCache.
-///
-/// Per-type descriptor caches keyed by LLType (structural equality).
-/// Factory functions (get_size_descr, get_field_descr, etc.) check
-/// the cache first and return the existing object on hit.
-///
-/// setup_descrs() iterates caches in RPython's fixed order:
-///   _cache_size, _cache_field, _cache_array, _cache_arraylen,
-///   _cache_call, _cache_interiorfield
 /// Counters behind [`GcCache::field_position_census`]. Process-global like the
 /// gccache itself; only ever incremented under its lock.
 static FIELD_PARENT_ABSENT: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
@@ -677,6 +668,15 @@ static FIELD_INDEX_REDERIVED: std::sync::atomic::AtomicUsize =
 static FIELD_INDEX_UNRESOLVED: std::sync::atomic::AtomicUsize =
     std::sync::atomic::AtomicUsize::new(0);
 
+/// descr.py:14-23 GcCache.
+///
+/// Per-type descriptor caches keyed by LLType (structural equality).
+/// Factory functions (get_size_descr, get_field_descr, etc.) check
+/// the cache first and return the existing object on hit.
+///
+/// setup_descrs() iterates caches in RPython's fixed order:
+///   _cache_size, _cache_field, _cache_array, _cache_arraylen,
+///   _cache_call, _cache_interiorfield
 pub struct GcCache {
     /// descr.py:18: _cache_size[STRUCT]
     pub _cache_size: HashMap<LLType, DescrRef>,
@@ -889,22 +889,6 @@ impl GcCache {
         descr
     }
 
-    /// descr.py:218-239 get_field_descr(gccache, STRUCT, fieldname).
-    ///
-    /// `struct_key`: LLType::Struct — the owning type identity.
-    /// `index_in_parent`: descr.py:228 heaptracker.get_fielddescr_index_in(STRUCT, fieldname).
-    ///   The structural slot number within the parent struct's field list.
-    ///   Caller must provide this — Rust has no heaptracker auto-discovery.
-    /// `flag`: descr.py:226 get_type_flag(FIELDTYPE).
-    ///
-    /// descr.py:234-238: parent_descr = get_size_descr(gccache, STRUCT, vtable).
-    /// Looked up from _cache_size[STRUCT]. Caller must ensure get_size_descr
-    /// was called first (matches RPython's call at descr.py:238).
-    ///
-    /// `display_name`: descr.py:227 `'%s.%s' % (STRUCT._name, fieldname)`.
-    /// Callers that know the owning struct's source name pass the full
-    /// `Owner.field` spelling; `None` falls back to the `T<type_id>.` stand-in
-    /// for the mint sites that only carry the numeric struct identity.
     /// Census of what `get_field_descr` found when it bound a field to a parent.
     ///
     /// `descr_set_absent` / `descr_set_ambiguous` cannot see any of this: they
@@ -923,6 +907,144 @@ impl GcCache {
             FIELD_PARENT_EMPTY.load(Relaxed),
             FIELD_INDEX_REDERIVED.load(Relaxed),
             FIELD_INDEX_UNRESOLVED.load(Relaxed),
+        ]
+    }
+
+    /// How many published parents still list no fields, and how many of those
+    /// are shadowing a layout this same cache already knows.
+    ///
+    /// `get_size_descr` returns on cache hit (`descr.py:108-109`), so whoever
+    /// publishes a key FIRST decides what every later consumer sees. Upstream
+    /// that is harmless because `descr.py:111-127` is the only producer and it
+    /// always builds the full `SizeDescr` before inserting. A pyre mint that
+    /// publishes a caller-sized, vtable-less shell — a shape `descr.py:111-116`
+    /// cannot produce — therefore silently outranks the real layout a later
+    /// producer would have installed.
+    ///
+    /// Returns `[published, fieldless, shadowing, aliased]`:
+    /// - `published` — `_cache_size` entries, the denominator.
+    /// - `fieldless` — entries whose `all_fielddescrs()` is empty. Benign on its
+    ///   own: a struct may legitimately have nothing the JIT indexes.
+    /// - `shadowing` — fieldless entries for which `_cache_field` holds fields
+    ///   under the SAME key. Not benign: the cache simultaneously knows the
+    ///   struct has fields and answers "it has none" to
+    ///   `all_fielddescrs_from_descr`, which is what `force_box` indexes.
+    /// - `aliased` — shadowing entries whose struct ALSO reaches this cache under
+    ///   some other key that did get a populated list. These are the ones the
+    ///   layout exists for; they are shells only because one struct is reachable
+    ///   under several identity keys. The rest are structs no producer ever
+    ///   published a layout for at all.
+    ///
+    /// The `shadowing` / `aliased` split is what decides where the fix belongs:
+    /// canonicalizing the identity keys fixes the first group and cannot fix the
+    /// second. `field_position_census`'s `parent_empty` cannot answer this — it
+    /// counts mint attempts, so one shell hit by many fields reads as many.
+    ///
+    /// `aliased` matches on SHAPE, not on name. The mint sites that publish
+    /// shells carry only the numeric struct identity, so their fields get
+    /// `get_field_descr`'s `T<type_id>.` stand-in display name; comparing those
+    /// against real `Owner.field` spellings can only ever report zero, which
+    /// would read as "no aliasing" when it means "nothing was compared". Same
+    /// declared size, and every cached field landing on a matching
+    /// `(offset, field_size)` slot, is a statement about the struct itself.
+    /// `aliased_multi` is the same match restricted to shells carrying at least
+    /// two cached fields. A one-field shell matches any populated struct of the
+    /// same size that happens to own that one slot, so `aliased` alone overstates
+    /// its case; the gap between the two is how much of the finding rests on
+    /// single-slot evidence.
+    pub fn size_shell_census(&self) -> [usize; 5] {
+        let mut populated: Vec<(usize, std::collections::HashSet<(usize, usize)>)> = Vec::new();
+        for descr in self._cache_size.values() {
+            let Some(sd) = descr.as_size_descr() else {
+                continue;
+            };
+            let slots = sd.all_fielddescrs();
+            if slots.is_empty() {
+                continue;
+            }
+            populated.push((
+                sd.size(),
+                slots.iter().map(|f| (f.offset(), f.field_size())).collect(),
+            ));
+        }
+
+        let mut fieldless = 0;
+        let mut shadowing = 0;
+        let mut aliased = 0;
+        let mut aliased_multi = 0;
+        for (key, descr) in &self._cache_size {
+            let Some(sd) = descr.as_size_descr() else {
+                continue;
+            };
+            if !sd.all_fielddescrs().is_empty() {
+                continue;
+            }
+            fieldless += 1;
+            let Some(cached) = self._cache_field.get(key).filter(|m| !m.is_empty()) else {
+                continue;
+            };
+            shadowing += 1;
+            let want: Vec<(usize, usize)> =
+                cached.values().map(|f| (f.offset, f.field_size)).collect();
+            if populated
+                .iter()
+                .any(|(size, slots)| *size == sd.size() && want.iter().all(|w| slots.contains(w)))
+            {
+                aliased += 1;
+                if want.len() > 1 {
+                    aliased_multi += 1;
+                }
+            }
+        }
+        [
+            self._cache_size.len(),
+            fieldless,
+            shadowing,
+            aliased,
+            aliased_multi,
+        ]
+    }
+
+    /// The owner names behind [`size_shell_census`]'s `shadowing` and
+    /// `populated` groups, so `aliased=0` can be read as a finding rather than
+    /// taken on faith.
+    ///
+    /// `get_field_descr` falls back to a `T<type_id>.` stand-in when a mint site
+    /// carries only the numeric struct identity, and a stand-in can never match a
+    /// real struct name. Without seeing the strings, an `aliased` of zero is
+    /// indistinguishable from an owner comparison that had nothing to compare.
+    ///
+    /// [`size_shell_census`]: Self::size_shell_census
+    pub fn size_shell_owner_sample(&self, limit: usize) -> Vec<String> {
+        fn owner_of(display_name: &str) -> &str {
+            display_name
+                .rsplit_once('.')
+                .map_or(display_name, |(o, _)| o)
+        }
+        let mut shell: std::collections::BTreeSet<&str> = std::collections::BTreeSet::new();
+        let mut populated: std::collections::BTreeSet<&str> = std::collections::BTreeSet::new();
+        for (key, descr) in &self._cache_size {
+            match descr.as_size_descr() {
+                Some(sd) if !sd.all_fielddescrs().is_empty() => {
+                    populated.extend(
+                        sd.all_fielddescrs()
+                            .iter()
+                            .map(|f| owner_of(f.field_name())),
+                    );
+                }
+                _ => {
+                    if let Some(m) = self._cache_field.get(key) {
+                        shell.extend(m.values().map(|f| owner_of(f.field_name())));
+                    }
+                }
+            }
+        }
+        let take = |s: &std::collections::BTreeSet<&str>| {
+            s.iter().take(limit).copied().collect::<Vec<_>>().join(",")
+        };
+        vec![
+            format!("shell_owners({}) {}", shell.len(), take(&shell)),
+            format!("populated_owners({}) {}", populated.len(), take(&populated)),
         ]
     }
 
@@ -970,6 +1092,22 @@ impl GcCache {
         }
     }
 
+    /// descr.py:218-239 get_field_descr(gccache, STRUCT, fieldname).
+    ///
+    /// `struct_key`: LLType::Struct — the owning type identity.
+    /// `index_in_parent`: descr.py:228 heaptracker.get_fielddescr_index_in(STRUCT, fieldname).
+    ///   The structural slot number within the parent struct's field list.
+    ///   Caller must provide this — Rust has no heaptracker auto-discovery.
+    /// `flag`: descr.py:226 get_type_flag(FIELDTYPE).
+    ///
+    /// descr.py:234-238: parent_descr = get_size_descr(gccache, STRUCT, vtable).
+    /// Looked up from _cache_size[STRUCT]. Caller must ensure get_size_descr
+    /// was called first (matches RPython's call at descr.py:238).
+    ///
+    /// `display_name`: descr.py:227 `'%s.%s' % (STRUCT._name, fieldname)`.
+    /// Callers that know the owning struct's source name pass the full
+    /// `Owner.field` spelling; `None` falls back to the `T<type_id>.` stand-in
+    /// for the mint sites that only carry the numeric struct identity.
     pub fn get_field_descr(
         &mut self,
         struct_key: LLType,
@@ -1056,9 +1194,7 @@ impl GcCache {
         // store against it.
         //
         // So take the index from the parent that will actually be indexed,
-        // rather than from whoever happened to call. Match on the cache key
-        // first and fall back to the offset, which identifies a field even when
-        // two producers spell its name differently.
+        // rather than from whoever happened to call.
         fd.index_in_parent =
             Self::derive_index_in_parent(parent.as_ref(), field_name, offset, index_in_parent)
                 .unwrap_or(index_in_parent);
@@ -5657,6 +5793,104 @@ mod register_keyed_size_authority_tests {
             survivor(runtime(), analyzer()),
             survivor(analyzer(), runtime())
         );
+    }
+
+    /// A published parent that lists nothing — what a mint installs when it
+    /// calls `get_size_descr(key, size, 0, false)`.
+    fn shell_descr(size: usize) -> DescrRef {
+        Arc::new(SimpleSizeDescr::new(u32::MAX, size, 0)) as DescrRef
+    }
+
+    /// `_cache_field[key]`, spelled the way a mint site spells it: the
+    /// `T<type_id>.` stand-in `get_field_descr` falls back to when the caller
+    /// carries only the numeric struct identity.
+    fn shell_fields(slots: &[(&str, usize)]) -> HashMap<String, Arc<SimpleFieldDescr>> {
+        slots
+            .iter()
+            .enumerate()
+            .map(|(i, (name, offset))| {
+                let fd = SimpleFieldDescr::new_with_name(
+                    i as u32,
+                    *offset,
+                    8,
+                    Type::Int,
+                    false,
+                    ArrayFlag::Signed,
+                    format!("T99.{name}"),
+                    (*name).to_string(),
+                );
+                ((*name).to_string(), Arc::new(fd))
+            })
+            .collect()
+    }
+
+    /// `size_shell_census` must match an aliased twin by SHAPE, never by name.
+    ///
+    /// The shells come from mint sites that carry only the numeric struct
+    /// identity, so their fields get the `T<type_id>.` stand-in spelling. An
+    /// owner-name comparison against the real `Owner.field` spellings can only
+    /// ever report zero, and a vacuous zero reads exactly like "no aliasing" —
+    /// which is how the first version of this census got the answer backwards.
+    #[test]
+    fn size_shell_census_matches_an_aliased_twin_by_shape_not_by_name() {
+        let mut gc = GcCache::new();
+        // One key that did get a layout, under real `Owner.field` names.
+        gc._cache_size
+            .insert(LLType::Struct(1), size_descr_at(7, 0, &[16, 24, 32]));
+        // A second key for the same struct: fields known, never listed.
+        let shell = LLType::Struct(2);
+        gc._cache_size.insert(shell.clone(), shell_descr(32));
+        gc._cache_field
+            .insert(shell, shell_fields(&[("a", 16), ("b", 24)]));
+
+        assert_eq!(
+            gc.size_shell_census(),
+            [2, 1, 1, 1, 1],
+            "the twin owns both cached slots at the same size, and two slots \
+             is more than single-slot evidence",
+        );
+    }
+
+    /// A shell whose slots no populated list owns is a producer gap, not an
+    /// aliasing artifact — the layout was never published anywhere. Conflating
+    /// the two would point the fix at the wrong task.
+    #[test]
+    fn size_shell_census_claims_no_twin_for_a_layout_nobody_published() {
+        let mut gc = GcCache::new();
+        gc._cache_size
+            .insert(LLType::Struct(1), size_descr_at(7, 0, &[16, 24, 32]));
+        let shell = LLType::Struct(2);
+        gc._cache_size.insert(shell.clone(), shell_descr(32));
+        gc._cache_field
+            .insert(shell, shell_fields(&[("a", 40), ("b", 48)]));
+
+        assert_eq!(gc.size_shell_census(), [2, 1, 1, 0, 0]);
+    }
+
+    /// One cached field matches any same-size struct that happens to own that
+    /// slot, so `aliased` alone overstates its case. `aliased_multi` is the
+    /// share that does not rest on single-slot evidence.
+    #[test]
+    fn size_shell_census_separates_single_slot_evidence() {
+        let mut gc = GcCache::new();
+        gc._cache_size
+            .insert(LLType::Struct(1), size_descr_at(7, 0, &[16, 24, 32]));
+        let shell = LLType::Struct(2);
+        gc._cache_size.insert(shell.clone(), shell_descr(32));
+        gc._cache_field.insert(shell, shell_fields(&[("a", 16)]));
+
+        assert_eq!(gc.size_shell_census(), [2, 1, 1, 1, 0]);
+    }
+
+    /// A fieldless parent with nothing cached under its key is just a struct
+    /// the JIT never indexed. It is `fieldless` but not `shadowing`, because
+    /// nothing is being contradicted.
+    #[test]
+    fn size_shell_census_does_not_call_an_unused_struct_a_shell() {
+        let mut gc = GcCache::new();
+        gc._cache_size.insert(LLType::Struct(2), shell_descr(32));
+
+        assert_eq!(gc.size_shell_census(), [1, 1, 0, 0, 0]);
     }
 
     /// The upgrade rule itself is unchanged when both sides carry a vtable.

--- a/majit/majit-ir/src/descr.rs
+++ b/majit/majit-ir/src/descr.rs
@@ -1005,6 +1005,79 @@ impl GcCache {
         ]
     }
 
+    /// The upstream invariant, counted: `all_fielddescrs(S)[i].get_index() == i`.
+    ///
+    /// `heaptracker.py:60-72 get_fielddescr_index_in` and `:96-112
+    /// all_fielddescrs` are one walker sharing one skip set, so upstream this
+    /// holds by construction and there is nothing to check. pyre builds the
+    /// positional list from cache-or-mint results
+    /// (`make_simple_descr_group_keyed_with_headerless`), so a descr minted
+    /// EARLIER by a header-counting producer keeps its own number while this
+    /// producer places it at its own position — and the two need not agree.
+    ///
+    /// Returns `[checked, disagreeing]` over every populated `_cache_size` entry.
+    /// `disagreeing` is the count of slots where the descr sitting at position
+    /// `i` reports some other `index_in_parent`, which is precisely the state
+    /// `optimizeopt/info.rs force_box` cannot survive: it indexes the list by the
+    /// descr's own number.
+    pub fn positional_invariant_census(&self) -> [usize; 2] {
+        let mut checked = 0;
+        let mut disagreeing = 0;
+        for descr in self._cache_size.values() {
+            let Some(sd) = descr.as_size_descr() else {
+                continue;
+            };
+            for (i, fd) in sd.all_fielddescrs().iter().enumerate() {
+                checked += 1;
+                if fd.index_in_parent() != i {
+                    disagreeing += 1;
+                }
+            }
+        }
+        [checked, disagreeing]
+    }
+
+    /// Whether one identity key is carrying more than one struct.
+    ///
+    /// `descr.py` keys `_cache_size` / `_cache_field` on the lltype STRUCT
+    /// object, so a key means exactly one struct and `id(STRUCT)` never aliases.
+    /// pyre keys on `path_hash(<some spelling>)`, and the spellings are minted by
+    /// several producers, so two different structs can land on one key while one
+    /// struct lands on several.
+    ///
+    /// Returns `[compared, conflicting]` over fields that are cached under a key
+    /// whose parent also lists them: `conflicting` is the count naming the same
+    /// field at a DIFFERENT offset. A field cannot be at two offsets in one
+    /// struct, so every one of those is two structs sharing a key — the failure
+    /// `last_instr` was caught in (offset 48 from one producer, 32 from another).
+    ///
+    /// This is the question `positional_invariant_census` cannot ask: that one
+    /// checks a list against itself and passes as long as each producer is
+    /// internally consistent, which two colliding structs both are.
+    pub fn identity_collision_census(&self) -> [usize; 2] {
+        let mut compared = 0;
+        let mut conflicting = 0;
+        for (key, cached) in &self._cache_field {
+            let Some(sd) = self._cache_size.get(key).and_then(|d| d.as_size_descr()) else {
+                continue;
+            };
+            for fd in cached.values() {
+                let Some(listed) = sd
+                    .all_fielddescrs()
+                    .iter()
+                    .find(|f| f.field_key() == fd.field_key)
+                else {
+                    continue;
+                };
+                compared += 1;
+                if listed.offset() != fd.offset {
+                    conflicting += 1;
+                }
+            }
+        }
+        [compared, conflicting]
+    }
+
     /// The owner names behind [`size_shell_census`]'s `shadowing` and
     /// `populated` groups, so `aliased=0` can be read as a finding rather than
     /// taken on faith.
@@ -1042,9 +1115,48 @@ impl GcCache {
         let take = |s: &std::collections::BTreeSet<&str>| {
             s.iter().take(limit).copied().collect::<Vec<_>>().join(",")
         };
+        // The `unresolved` population, named. A field cached under a key whose
+        // parent lists OTHER fields but not this one means the two sides
+        // disagree about what the struct contains — either the field belongs to
+        // a different struct that shares the key, or the parent's list is short.
+        // The counter alone cannot tell those apart; the names can.
+        let mut orphans: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+        for (key, cached) in &self._cache_field {
+            let Some(sd) = self._cache_size.get(key).and_then(|d| d.as_size_descr()) else {
+                continue;
+            };
+            let listed = sd.all_fielddescrs();
+            if listed.is_empty() {
+                continue;
+            }
+            for fd in cached.values() {
+                if !listed.iter().any(|f| f.field_key() == fd.field_key) {
+                    orphans.insert(format!(
+                        "{}@{}~[{}]",
+                        fd.field_key,
+                        fd.offset,
+                        listed
+                            .iter()
+                            .map(|f| f.field_key())
+                            .collect::<Vec<_>>()
+                            .join("|")
+                    ));
+                }
+            }
+        }
         vec![
             format!("shell_owners({}) {}", shell.len(), take(&shell)),
             format!("populated_owners({}) {}", populated.len(), take(&populated)),
+            format!(
+                "orphan_fields({}) {}",
+                orphans.len(),
+                orphans
+                    .iter()
+                    .take(limit)
+                    .cloned()
+                    .collect::<Vec<_>>()
+                    .join("  ")
+            ),
         ]
     }
 

--- a/pyre/pyre-jit-trace/src/jitcode_runtime.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_runtime.rs
@@ -623,13 +623,6 @@ pub fn descr_set_jit_stats() -> String {
     )
 }
 
-/// The same four numbers [`descr_set_jit_stats`] formats, as numbers.
-///
-/// Backends that cannot print a line reach the counters through here rather than
-/// re-deriving them, so the gated values cannot drift from the printed ones. The
-/// wasm guest has no stderr and exports these individually
-/// (`pyre_jit_descr_set_*` in `pyre-wasm`), which the runner prints on its
-/// behalf.
 /// The field-position census, as `[jit-stats]` key/value tokens.
 ///
 /// This sits next to `descr_set_*` because it answers the question those
@@ -647,15 +640,43 @@ pub fn descr_set_jit_stats() -> String {
 /// `optimizeopt/info.rs force_box`. Every one of those was, before this was
 /// derived rather than transported, either an out-of-range panic or a store
 /// emitted against a DIFFERENT field.
+///
+/// `size_shell_*` is the producer-side companion. `parent_empty` counts mint
+/// attempts that found a fieldless parent, so one shell hit by many fields reads
+/// as many; `size_shell_shadowing` counts the shells themselves, and only those
+/// for which this same cache already holds fields under the key. That is the
+/// state `descr.py` cannot reach: `get_size_descr` returns on cache hit, so a
+/// shell published first outranks the real layout for the rest of the run.
 pub fn field_position_jit_stats() -> String {
     let [parent_absent, parent_empty, rederived, unresolved] =
         majit_ir::descr::GcCache::field_position_census();
+    let ([published, fieldless, shadowing, aliased, aliased_multi], sample) = {
+        let gc = majit_ir::descr::gc_cache();
+        let guard = gc.lock().unwrap_or_else(|e| e.into_inner());
+        let sample = if std::env::var_os("PYRE_SIZE_SHELL_OWNERS").is_some() {
+            let lines = guard.size_shell_owner_sample(24);
+            format!("\n[jit-stats] {}", lines.join("\n[jit-stats] "))
+        } else {
+            String::new()
+        };
+        (guard.size_shell_census(), sample)
+    };
     format!(
         "field_pos_parent_absent={parent_absent} field_pos_parent_empty={parent_empty} \
-         field_pos_rederived={rederived} field_pos_unresolved={unresolved}"
+         field_pos_rederived={rederived} field_pos_unresolved={unresolved} \
+         size_shell_published={published} size_shell_fieldless={fieldless} \
+         size_shell_shadowing={shadowing} size_shell_aliased={aliased} \
+         size_shell_aliased_multi={aliased_multi}{sample}"
     )
 }
 
+/// The same four numbers [`descr_set_jit_stats`] formats, as numbers.
+///
+/// Backends that cannot print a line reach the counters through here rather than
+/// re-deriving them, so the gated values cannot drift from the printed ones. The
+/// wasm guest has no stderr and exports these individually
+/// (`pyre_jit_descr_set_*` in `pyre-wasm`), which the runner prints on its
+/// behalf.
 pub fn descr_set_counts() -> DescrSetCounts {
     let ledger = crate::descr::set_member_ledger();
     DescrSetCounts {

--- a/pyre/pyre-jit-trace/src/jitcode_runtime.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_runtime.rs
@@ -650,7 +650,12 @@ pub fn descr_set_jit_stats() -> String {
 pub fn field_position_jit_stats() -> String {
     let [parent_absent, parent_empty, rederived, unresolved] =
         majit_ir::descr::GcCache::field_position_census();
-    let ([published, fieldless, shadowing, aliased, aliased_multi], sample) = {
+    let (
+        [published, fieldless, shadowing, aliased, aliased_multi],
+        [slots, misplaced],
+        [key_compared, key_conflicting],
+        sample,
+    ) = {
         let gc = majit_ir::descr::gc_cache();
         let guard = gc.lock().unwrap_or_else(|e| e.into_inner());
         let sample = if std::env::var_os("PYRE_SIZE_SHELL_OWNERS").is_some() {
@@ -659,14 +664,21 @@ pub fn field_position_jit_stats() -> String {
         } else {
             String::new()
         };
-        (guard.size_shell_census(), sample)
+        (
+            guard.size_shell_census(),
+            guard.positional_invariant_census(),
+            guard.identity_collision_census(),
+            sample,
+        )
     };
     format!(
         "field_pos_parent_absent={parent_absent} field_pos_parent_empty={parent_empty} \
          field_pos_rederived={rederived} field_pos_unresolved={unresolved} \
          size_shell_published={published} size_shell_fieldless={fieldless} \
          size_shell_shadowing={shadowing} size_shell_aliased={aliased} \
-         size_shell_aliased_multi={aliased_multi}{sample}"
+         size_shell_aliased_multi={aliased_multi} \
+         positional_slots={slots} positional_misplaced={misplaced} \
+         key_compared={key_compared} key_conflicting={key_conflicting}{sample}"
     )
 }
 

--- a/pyre/pyre-wasm-runner/src/main.rs
+++ b/pyre/pyre-wasm-runner/src/main.rs
@@ -608,30 +608,38 @@ fn run(module_path: &PathBuf, source: &str) -> Result<i32> {
     // the same fields as the native backends. Kept separate from the verbose
     // PYRE_WASM_JIT_STATS block above; which line they land on no longer
     // matters, since check.py merges every [jit-stats] line into one snapshot.
-    // The exports read 0 on an old module that predates them, which is the
-    // healthy value, so a stale runner degrades safely rather than reporting a
-    // false regression — but that also means this line is the ONLY thing
-    // standing between a wasm-only descr-universe regression and a green gate,
-    // because a field absent from the current run is read as zero.
+    // This line is the ONLY thing standing between a wasm-only descr-universe
+    // regression and a green gate, because `_jit_stats_regression_floor` reads a
+    // field absent from the current run as zero — the healthy value. So a
+    // counter that cannot be read must not resolve to zero: a module that
+    // predates these exports would then look perfectly healthy while gating on
+    // nothing at all, which is the exact hole this block exists to close.
     if std::env::var_os("MAJIT_STATS").is_some() {
-        let loops_aborted = instance
-            .get_typed_func::<(), u64>(&mut store, "pyre_jit_loops_aborted")
+        let mut missing: Vec<&str> = Vec::new();
+        let mut counter = |name: &'static str, missing: &mut Vec<&'static str>| match instance
+            .get_typed_func::<(), u64>(&mut store, name)
             .and_then(|f| f.call(&mut store, ()))
-            .unwrap_or(0);
-        let internal_compile_panics = instance
-            .get_typed_func::<(), u64>(&mut store, "pyre_jit_internal_compile_panics")
-            .and_then(|f| f.call(&mut store, ()))
-            .unwrap_or(0);
-        let mut counter = |name| {
-            instance
-                .get_typed_func::<(), u64>(&mut store, name)
-                .and_then(|f| f.call(&mut store, ()))
-                .unwrap_or(0)
+        {
+            Ok(v) => v,
+            Err(_) => {
+                missing.push(name);
+                0
+            }
         };
-        let descr_set_resolved = counter("pyre_jit_descr_set_resolved");
-        let descr_set_absent = counter("pyre_jit_descr_set_absent");
-        let descr_set_ambiguous = counter("pyre_jit_descr_set_ambiguous");
-        let descr_set_stale_absent = counter("pyre_jit_descr_set_stale_absent");
+        let loops_aborted = counter("pyre_jit_loops_aborted", &mut missing);
+        let internal_compile_panics = counter("pyre_jit_internal_compile_panics", &mut missing);
+        let descr_set_resolved = counter("pyre_jit_descr_set_resolved", &mut missing);
+        let descr_set_absent = counter("pyre_jit_descr_set_absent", &mut missing);
+        let descr_set_ambiguous = counter("pyre_jit_descr_set_ambiguous", &mut missing);
+        let descr_set_stale_absent = counter("pyre_jit_descr_set_stale_absent", &mut missing);
+        if !missing.is_empty() {
+            eprintln!(
+                "pyre-wasm-runner: MAJIT_STATS is set but the module exports no {} — \
+                 refusing to report a gated counter as 0, which reads as healthy",
+                missing.join(", "),
+            );
+            std::process::exit(1);
+        }
         eprintln!(
             "[jit-stats] loops_aborted={loops_aborted} \
              internal_compile_panics={internal_compile_panics} \


### PR DESCRIPTION
Follow-up to #892. Closes the two review findings that PR collected after it was
approved, then measures the descr universe until the standing hypotheses about it
either survive or die. Three of them died.

## 1. Two review findings from #892

**The cache-hit check compared against an un-normalised index.**
`get_field_descr` derives `index_in_parent` from the parent that will actually be
indexed, so the cached descr holds the derived number while callers keep handing
in their own. The cache-hit `debug_assert!` compared the cached value against the
raw argument, so the **second** lookup of any rederived field asserted that (say)
cached 0 equals requested 2 — firing on exactly the fields the normalisation
exists for. Only debug builds carry `debug_assert!`, so the release gate could
not see it; `field_pos_rederived=21` on int_loop is how many fields were
eligible.

The check now runs the caller's index through the same parent lookup first.
`find_index_in_parent` is that lookup with no census side effect, because the
census measures what producers hand in and a cache hit is one producer's answer
read back, not a second producer disagreeing.
`a_rederived_field_survives_a_second_lookup` covers it; it panics without the
change.

**The wasm runner read a missing export as healthy.** Every `MAJIT_STATS`
counter resolved with `unwrap_or(0)`, and zero is the healthy value for all six.
`_jit_stats_regression_floor` also reads a field missing from a run as zero, so a
module built before these exports existed would have gated on nothing while
looking perfectly green — the same vacuous-gate hole #892 set out to close,
reintroduced one level down. Missing or wrongly typed exports are now named and
the run exits non-zero.

## 2. Then: is any of this actually broken right now?

`descr_set_absent` / `descr_set_ambiguous` cannot say. They ask whether a member
resolved to *some* descr, not whether it resolved *correctly*, and they read 0
throughout. So this adds the counters that can. All are diagnostic — `check.py`
narrows snapshots to `JITSTATS_SNAPSHOT_FIELDS`, so no baseline records them.

On int_loop (dynasm; byte-identical on fannkuch and nbody, because the ONCE
resolves the whole serialized universe at startup regardless of the program):

    field_pos_parent_absent=1739 field_pos_parent_empty=1749
    field_pos_rederived=21       field_pos_unresolved=229
    size_shell_published=1106    size_shell_fieldless=693  size_shell_shadowing=693
    size_shell_aliased=572       size_shell_aliased_multi=190
    positional_slots=1794        positional_misplaced=0
    key_compared=1766            key_conflicting=0

**`fieldless == shadowing`, exactly.** 693 of 1106 published parents list no
fields, and every one has fields cached under its own key. `get_size_descr`
returns on cache hit (`descr.py:108-109`), so a mint publishing
`get_size_descr(key, size, 0, false)` — vtable-less and caller-sized, a shape
`descr.py:111-116` cannot produce — outranks the real layout a later producer
would install.

**`positional_misplaced=0` over 1794 slots.** `all_fielddescrs(S)[i].get_index()
== i` — the lookup `optimizeopt/info.rs force_box` `.expect`s in release — holds
everywhere. Upstream gets this from `heaptracker.py:60-72` and `:96-112` being
one walker with one skip set; pyre builds the list from cache-or-mint results and
gets it anyway.

**`key_conflicting=0` over 1766 comparisons.** A field cannot sit at two offsets
in one struct, so a conflict would be two structs sharing an identity key. None
among fields both sides name.

## 3. What those numbers killed

- **"`mint_field` should decline rather than publish a fieldless parent"** (the
  `heap.py:827-836` posture, assumed while reachability was unmeasured). 572 of
  the 693 shells have a shape-matching *populated* twin under another key, 190
  matching on two or more slots. The layout is not missing, it is filed
  elsewhere; declining abandons it and merely relabels `parent_empty` as
  `parent_absent`.
- **"cache-hit descrs carry a header-counting number into another producer's
  positional list."** `positional_misplaced=0`.
- **"one identity key is carrying two structs."** `key_conflicting=0`.

`aliased` matches on **shape** — equal `size()`, every cached
`(offset, field_size)` present in the candidate. An earlier name-based version
reported 0, which was vacuous: `get_field_descr` falls back to a `T<type_id>.`
stand-in for mint sites carrying only the numeric struct identity, so all 693
shell owners are `T<id>` strings that cannot match a real `Owner.field` spelling.
`size_shell_owner_sample` (`PYRE_SIZE_SHELL_OWNERS=1`) prints both sets so that
zero cannot be read as a finding again. `aliased_multi` is the share not resting
on single-slot evidence.

## 4. What is actually left

`field_pos_unresolved=229` — fields cached under a key whose parent lists other
fields but not them. Named, they are one shape, 178 distinct:

    __pos_0@0 ~ [__pos_0.flags|__pos_0.input]
    __pos_0@0 ~ [__pos_0.ob.ob_type|__pos_0.ob.w_class|__pos_0.deque|...]

The cached key is a bare `__pos_0`; the parent lists dotted `__pos_0.<field>`.
That is the key **spelling** split, not struct identity.

Closing it is deliberately not attempted here. `descr.py:218-233` keys on the
bare `fieldname` and uses the qualified spelling only for the display `name` at
:227, but `assembler.rs bh_field_name` qualifies a name only when it does not
already contain a `.`, so the prefixed runtime keys and the serialized spec keys
agree *through* that heuristic. Stripping one side alone reds the gate (measured
on #892: 22/4/17 synth failures with `Const::getint on non-Int variant: Ref(..)`
and SIGSEGV). Both sides plus a serialization-cache regeneration have to move in
one commit.

## Verification

    ALL PASSED: dynasm    345/345
    ALL PASSED: cranelift 345/345
    ALL PASSED: wasm      341/341

`cargo test -p majit-ir -p majit-metainterp`, release and debug: 0 failed,
including five new census tests and the debug-build regression test that the
first finding above would otherwise trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
