### PR TITLE
_ast: move the NamedExpr target check out of the roundtrip fixture

### DIFF
--- a/pyre/bench/synth/ast_compile_roundtrip.py
+++ b/pyre/bench/synth/ast_compile_roundtrip.py
@@ -172,7 +172,6 @@ def handbuilt():
         ("boolop-one-value", ast.BoolOp(op=ast.And(), values=[ast.Constant(1)])),
         ("boolop-no-values", ast.BoolOp(op=ast.And(), values=[])),
         ("comprehension-no-generators", ast.ListComp(elt=ast.Constant(1), generators=[])),
-        ("named-target-not-name", ast.NamedExpr(target=ast.Constant(1), value=ast.Constant(1))),
         ("name-is-a-constant", ast.Name("None", L)),
         ("store-in-load-position", ast.Name("x", S)),
         ("empty-body-functiondef", ast.Module(body=[ast.FunctionDef(

--- a/pyre/pyre-interpreter/src/astcompiler/validate.rs
+++ b/pyre/pyre-interpreter/src/astcompiler/validate.rs
@@ -999,4 +999,31 @@ mod tests {
             "identifier field can't represent 'None' constant"
         );
     }
+
+    #[test]
+    fn named_expr_target_must_be_a_name() {
+        let named = |target| {
+            vec![ast::Stmt::Expr(ast::StmtExpr {
+                node_index: Default::default(),
+                range: Default::default(),
+                value: Box::new(ast::Expr::Named(ast::ExprNamed {
+                    node_index: Default::default(),
+                    range: Default::default(),
+                    target: Box::new(target),
+                    value: Box::new(constant(1)),
+                })),
+            })]
+        };
+
+        // The class is the whole case: a runtime without this check reaches
+        // the code generator and reports the target as an unassignable
+        // expression, a ValueError.
+        let error = validate(named(constant(1))).unwrap_err();
+        assert_eq!(error.kind, crate::error::PyErrorKind::TypeError);
+        assert_eq!(error.message, "NamedExpr target must be a Name");
+
+        // Only the shape is checked here; the context the target carries is
+        // not, so a `Store` name passes the walk.
+        assert!(validate(named(name("x", ast::ExprContext::Store))).is_ok());
+    }
 }


### PR DESCRIPTION
`check.py --backend dynasm` reported `synth/ast_compile_roundtrip` as a
cpython/pypy output mismatch, so the bench had no baseline to compare a
backend against.

The two oracles disagreed on exactly one line:

```
hand reject named-target-not-name
  cpython 3.14.2  -> TypeError  "NamedExpr target must be a Name"
  pypy3   7.3.20  -> ValueError "expression which can't be assigned to in Store context"
```

This is oracle version skew, not a divergence. `validate.py:585` carries
`visit_NamedExpr` raising `ValidationTypeError("NamedExpr target must be a
Name")`; pypy3 7.3.20 predates it, so the target reaches the code generator
and is reported as an unassignable expression instead. Both `astcompiler/
validate.rs` and 3.14 raise the TypeError, and the bench's output under
pyre is byte-identical to 3.14's.

The fixture holds only trees the two oracles agree on, because every
backend's output there is compared byte for byte against PyPy's. The case
is dropped from it and the class it turns on is covered in `validate`'s own
tests, which is where the fixture's own comment already directs such cases.

Verified: cpython, pypy3 and pyre-dynasm now produce byte-identical output
for the bench; `check.py --backend dynasm` is 343/343 (a full run on the
pre-rebase base, re-running on this one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)