### PR TITLE
mapdict off-GC side-table values, per-guard aarch64 reach check, paused-call floor on the third recipe path, and a per-return getenv

### DIFF
--- a/majit/majit-backend-dynasm/src/aarch64/assembler.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/assembler.rs
@@ -322,9 +322,16 @@ pub struct AssemblerARM64<'a> {
     /// inversion and `b`.  Decided once per trace in `_assemble`.
     long_guard_branch: bool,
 
-    /// Offset of the current trace's first emitted byte, for the
-    /// `long_guard_branch` range check.
-    trace_start_offset: usize,
+    /// Buffer offset of the first single-instruction `b.cond` emitted to each
+    /// label, so `write_pending_failure_recoveries` can measure the real
+    /// displacement to the recovery stub it binds that label to.  The earliest
+    /// branch is the one that has to reach furthest, and a label with no entry
+    /// was never branched to in the short form.
+    short_guard_branch_offsets: IndexMap<DynamicLabel, usize>,
+    /// `(branch offset, stub offset)` for every short guard branch whose stub
+    /// landed outside `b.cond`'s forward reach.  Read by `check_guard_reach`.
+    guard_reach_violations: Vec<(usize, usize)>,
+
     /// x86/assembler.py:93 target_tokens_currently_compiling parity.
     /// Keyed by descriptor pointer identity (PyPy uses Python `is`).
     target_tokens_currently_compiling: IndexMap<usize, DynamicLabel>,
@@ -523,7 +530,8 @@ impl<'a> AssemblerARM64<'a> {
             guard_success_cc: None,
             pending_cmp_cc: None,
             long_guard_branch: false,
-            trace_start_offset: 0,
+            short_guard_branch_offsets: IndexMap::new(),
+            guard_reach_violations: Vec::new(),
             target_tokens_currently_compiling: IndexMap::new(),
             compiled_target_tokens: Vec::new(),
             vtable_offset,
@@ -2060,7 +2068,8 @@ impl<'a> AssemblerARM64<'a> {
     fn _assemble(&mut self, emit_prologue: bool) -> Result<(), BackendError> {
         let inputargs: &'a [InputArg] = self.inputargs;
         let ops: &'a [Op] = self.operations;
-        self.trace_start_offset = self.mc.offset().0;
+        self.short_guard_branch_offsets.clear();
+        self.guard_reach_violations.clear();
         // A guard's `b.cond` has to reach a stub that is written after the
         // whole body, so the budget is the body plus every stub — not the body
         // alone.  `const_stores` makes a stub grow independently of the
@@ -4216,25 +4225,28 @@ impl<'a> AssemblerARM64<'a> {
     /// fixed jitframe prefix before publishing jf_descr and returning.
     /// Every guard that took the single-instruction form has to reach its
     /// failure-recovery stub with a `b.cond`, whose signed 19-bit word
-    /// displacement spans [`BCOND_FORWARD_RANGE`].  The stubs are written after
-    /// the body, so the span is only exact once
-    /// [`Self::write_pending_failure_recoveries`] has run — and by then the
-    /// branches are already emitted, so an overflow can no longer be answered
-    /// by re-emitting them in the two-instruction form.  Refuse the trace
-    /// instead: the up-front `MAX_BYTES_PER_OP` / `MAX_BYTES_PER_GUARD_STUB`
-    /// estimate is a heuristic, and letting a relocation that cannot be encoded
-    /// reach the assembler is not an acceptable way to find that out.
+    /// displacement spans [`BCOND_FORWARD_RANGE`].  A stub is bound in
+    /// [`Self::write_pending_failure_recoveries`], which measures each such
+    /// branch against the stub it actually has to reach — by then the branches
+    /// are emitted, so an overflow can no longer be answered by re-emitting
+    /// them in the two-instruction form.  Refuse the trace instead: the
+    /// up-front `MAX_BYTES_PER_OP` / `MAX_BYTES_PER_GUARD_STUB` estimate is a
+    /// heuristic, and letting a relocation that cannot be encoded reach the
+    /// assembler is not an acceptable way to find that out.  A trace that took
+    /// the two-instruction form everywhere records no branches and so always
+    /// passes.
     fn check_guard_reach(&self) -> Result<(), BackendError> {
-        let span = self.mc.offset().0 - self.trace_start_offset;
-        if self.long_guard_branch || span < BCOND_FORWARD_RANGE {
+        let Some(&(branch, stub)) = self.guard_reach_violations.first() else {
             return Ok(());
-        }
+        };
         Err(BackendError::CompilationFailed(format!(
-            "trace emitted {} bytes of body and guard stubs with {} guards, past \
-             b.cond's {BCOND_FORWARD_RANGE}-byte forward reach, but the up-front \
-             estimate chose single-instruction guard branches",
-            span,
-            self.pending_guard_tokens.len(),
+            "{} of {} single-instruction guard branches cannot reach their \
+             recovery stub; the first branches at offset {branch} to a stub at \
+             {stub}, {} bytes past b.cond's {BCOND_FORWARD_RANGE}-byte forward \
+             reach, but the up-front estimate chose that form",
+            self.guard_reach_violations.len(),
+            self.short_guard_branch_offsets.len(),
+            stub - branch - BCOND_FORWARD_RANGE,
         )))
     }
 
@@ -4325,7 +4337,16 @@ impl<'a> AssemblerARM64<'a> {
         }
         let mut stub_offsets = Vec::new();
         for guard_token in std::mem::take(&mut self.pending_guard_tokens) {
-            stub_offsets.push(self.generate_quick_failure(guard_token, save_regs_label));
+            let fail_label = guard_token.fail_label;
+            let entry = self.generate_quick_failure(guard_token, save_regs_label);
+            // The stub is bound here, so this is the first point at which the
+            // displacement each `b.cond` to that label has to encode is known.
+            if let Some(&branch) = self.short_guard_branch_offsets.get(&fail_label)
+                && entry.1 >= branch + BCOND_FORWARD_RANGE
+            {
+                self.guard_reach_violations.push((branch, entry.1));
+            }
+            stub_offsets.push(entry);
         }
         if majit_ir::debug::have_debug_prints() {
             majit_ir::debug::log_one(
@@ -4701,6 +4722,12 @@ impl<'a> AssemblerARM64<'a> {
     /// guard.  logo's 70000-op trace needs it.
     fn emit_bcond_to_label(&mut self, cc: u8, label: DynamicLabel) {
         if !self.long_guard_branch {
+            // Keep the earliest branch to this label: it is the one furthest
+            // from the recovery stub the label is later bound to.
+            let offset = self.mc.offset().0;
+            self.short_guard_branch_offsets
+                .entry(label)
+                .or_insert(offset);
             match cc {
                 CC_L => dynasm!(self.mc ; .arch aarch64 ; b.lt =>label),
                 CC_LE => dynasm!(self.mc ; .arch aarch64 ; b.le =>label),

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -579,6 +579,18 @@ unsafe fn walk_builtin_type_dicts_gc(forward: &mut dyn FnMut(&mut PyObjectRef)) 
     }
 }
 
+/// Whether `PYRE_INTERP_RETURN_LOG` asks the RETURN_VALUE handler to trace
+/// every returning frame.
+///
+/// Read once: `finish_value` runs on every interpreted return, and `getenv`
+/// takes a lock and scans the environment array, so an uncached read puts that
+/// scan on the return path of every Python-level call.
+#[cfg(not(feature = "sandbox"))]
+fn interp_return_log_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| std::env::var_os("PYRE_INTERP_RETURN_LOG").is_some())
+}
+
 /// Whether the incminimark-parity minor-collection skip of clean prebuilt
 /// structures is enabled (`PYRE_GC_PREBUILT_REMEMBER=0` opts out, restoring
 /// the rescan-everything-every-minor behavior).
@@ -2688,7 +2700,7 @@ impl ControlFlowOpcodeHandler for PyFrame {
     /// when the returning path exits the frame (matched by StepResult::Return).
     fn finish_value(&mut self, value: Self::Value) -> Result<StepResult<Self::Value>, PyError> {
         #[cfg(not(feature = "sandbox"))]
-        if std::env::var_os("PYRE_INTERP_RETURN_LOG").is_some() {
+        if interp_return_log_enabled() {
             unsafe {
                 let code_ptr = crate::pyframe::pyframe_get_pycode(self);
                 let name = if !code_ptr.is_null() {

--- a/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
+++ b/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
@@ -3668,7 +3668,9 @@ pub fn capture_mapdict_root_area() -> *const () {
 /// own contents are reached through its write barrier and custom trace
 /// (`dict_write_barrier` / `dict_object_custom_trace`), never from here.  A
 /// non-moving major (`do_collect_oldgen`) leaves the nursery intact, so only
-/// the minor walk may drain the pending set.
+/// the minor walk may drain the pending set.  A value the GC does not own has
+/// neither of those two paths, so [`walk_mapdict_roots_area`] puts its key
+/// straight back.
 ///
 /// Without this split each collection cloned and walked the whole table, whose
 /// entries are roots and therefore outlive their owners: the per-collection
@@ -3767,12 +3769,23 @@ pub unsafe fn walk_mapdict_roots_area(_data: *const (), mut visitor: impl FnMut(
     // and w_dict_walk_entries_mut may re-enter mapdict/dict APIs; every write
     // back into the table is deferred to `apply_root_rekeys`.
     let mut dict_rekeys = Vec::new();
+    let mut dict_offgc = Vec::new();
     for (key, mut dict) in dict_values {
         let old_dict = dict;
         visitor(&mut dict);
         let new_key = current_owner_key(key);
         if new_key != key || dict != old_dict {
             dict_rekeys.push((key, new_key, dict as usize));
+        }
+        // A value the GC does not own — `alloc_dict_object` falls back to
+        // `malloc_typed` when no allocation hook is installed — carries no
+        // header, so `do_write_barrier` drops it (it admits only a nursery or
+        // old-generation address) and no custom trace ever reaches its entries.
+        // The entry walk below is the only thing that traces them, so such a
+        // key stays pending: a minor has to revisit it after every store into
+        // the dict, not once when the table entry was first created.
+        if !pyre_object::gc_hook::try_gc_owns_object(dict as *mut u8) {
+            dict_offgc.push(new_key);
         }
         // Trace the dict's own r_dict entries. INSTANCE_DICT now holds only
         // non-instance hasdict wrappers (property/member) — never a
@@ -3804,7 +3817,13 @@ pub unsafe fn walk_mapdict_roots_area(_data: *const (), mut visitor: impl FnMut(
         // So no instance is walked here.
     }
     apply_root_rekeys(&INSTANCE_DICT, dict_rekeys);
+    if !dict_offgc.is_empty() {
+        INSTANCE_DICT_PENDING.lock().unwrap().extend(dict_offgc);
+    }
 
+    // The weakref walk visits the lifeline pointer and stops there, so it needs
+    // no such re-arming: an off-GC lifeline never moves, and its own fields are
+    // outside what this walk ever traced.
     let weakref_values = snapshot_root_entries(&WEAKREF_TABLE, &WEAKREF_TABLE_PENDING, minor);
     let mut weakref_rekeys = Vec::new();
     for (key, mut value) in weakref_values {
@@ -4965,5 +4984,71 @@ mod tests {
                 10
             );
         }
+    }
+
+    // The side-table root bookkeeping below takes its table and pending set as
+    // arguments, so these exercise the real functions on local tables — the
+    // process-global `INSTANCE_DICT` / `WEAKREF_TABLE` are shared with every
+    // other test running concurrently and must not be touched here.
+    fn table(entries: &[(usize, usize)]) -> Mutex<HashMap<usize, usize>> {
+        Mutex::new(entries.iter().copied().collect())
+    }
+    fn pending(keys: &[usize]) -> Mutex<HashSet<usize>> {
+        Mutex::new(keys.iter().copied().collect())
+    }
+    fn keys_of(snapshot: &[(usize, PyObjectRef)]) -> Vec<usize> {
+        let mut keys: Vec<usize> = snapshot.iter().map(|&(key, _)| key).collect();
+        keys.sort_unstable();
+        keys
+    }
+
+    #[test]
+    fn major_snapshot_takes_the_whole_table_and_keeps_the_pending_set() {
+        let table = table(&[(0x10, 0xA0), (0x20, 0xB0), (0x30, 0xC0)]);
+        let pending = pending(&[0x20]);
+        let snapshot = snapshot_root_entries(&table, &pending, false);
+        assert_eq!(keys_of(&snapshot), [0x10, 0x20, 0x30]);
+        // A major moves nothing, so it must not retire the keys a later minor
+        // still owes a visit to.
+        assert_eq!(pending.lock().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn minor_snapshot_drains_the_pending_set() {
+        let table = table(&[(0x10, 0xA0), (0x20, 0xB0), (0x30, 0xC0)]);
+        let pending = pending(&[0x20, 0x30]);
+        let snapshot = snapshot_root_entries(&table, &pending, true);
+        assert_eq!(keys_of(&snapshot), [0x20, 0x30]);
+        assert!(pending.lock().unwrap().is_empty());
+        // Drained: the entries are old by now and reached through their own
+        // write barrier, so the next minor visits nothing.
+        assert!(snapshot_root_entries(&table, &pending, true).is_empty());
+    }
+
+    #[test]
+    fn minor_snapshot_drops_a_pending_key_whose_entry_is_gone() {
+        let table = table(&[(0x10, 0xA0)]);
+        let pending = pending(&[0x10, 0x99]);
+        let snapshot = snapshot_root_entries(&table, &pending, true);
+        assert_eq!(keys_of(&snapshot), [0x10]);
+    }
+
+    #[test]
+    fn rekey_moves_a_promoted_owner_and_repoints_a_moved_value() {
+        let table = table(&[(0x10, 0xA0), (0x20, 0xB0)]);
+        // 0x10's owner moved to 0x11 and its value to 0xA1; 0x20 stayed put but
+        // its value moved.
+        apply_root_rekeys(&table, vec![(0x10, 0x11, 0xA1), (0x20, 0x20, 0xB1)]);
+        let table = table.lock().unwrap();
+        assert_eq!(table.get(&0x10), None);
+        assert_eq!(table.get(&0x11), Some(&0xA1));
+        assert_eq!(table.get(&0x20), Some(&0xB1));
+    }
+
+    #[test]
+    fn rekey_of_an_entry_deleted_during_the_walk_reinserts_nothing() {
+        let table = table(&[]);
+        apply_root_rekeys(&table, vec![(0x10, 0x11, 0xA1), (0x20, 0x20, 0xB1)]);
+        assert!(table.lock().unwrap().is_empty());
     }
 }

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -7256,8 +7256,14 @@ fn reconstruct_inline_recipe(
     // the slot holds a value neither path can reconstruct (an int/float operand
     // constant, or an unsupported shape) — decline to the single-frame bridge
     // rather than seed a NULL operand the re-executed bridge would deref.
+    // This path rebuilds from resumedata colors exactly as the virtual-array
+    // one above does, so it owes the operands a paused call consumed the same
+    // exemption: no callee ever flushed them and the resume collapses them to
+    // the result `make_result_of_lastop` delivers.
     for s in nlocals..valuestackdepth {
-        if Some(s) == pending_result_abs_slot {
+        if Some(s) == pending_result_abs_slot
+            || unreconstructable_operand_floor.is_some_and(|floor| s >= floor)
+        {
             continue;
         }
         if registers_r[s] == OpRef::NONE {


### PR DESCRIPTION
Follow-ups to the review comments on #885, plus one profiling find.

## 1. mapdict: a side-table value the GC does not own (Codex P1 on #885)

`alloc_dict_object` falls back to `malloc_typed` when no allocation hook is
installed. Such a dict carries no header, so `do_write_barrier` drops it (it
admits only a nursery or old-generation address) and no custom trace reaches
its entries — `walk_mapdict_roots_area` is the only thing that traces them.
Since #885 a minor walk visits an INSTANCE_DICT entry only while its key is
pending, so a store into an off-GC dict after that first visit went unseen.

The walk now puts the key back when the value is not GC-owned. The weakref
walk stops at the lifeline pointer and is left alone.

Adds unit tests for `snapshot_root_entries` and `apply_root_rekeys` over local
tables (the process-global tables are shared with concurrently running tests).

## 2. dynasm/aarch64: measure each guard branch against its own stub (CodeRabbit)

`check_guard_reach` compared the whole trace span — body plus every recovery
stub — against `BCOND_FORWARD_RANGE`, which is no particular branch's
displacement, and reported `pending_guard_tokens.len()`, drained to zero by
`write_pending_failure_recoveries` before the check ran.

It now records the offset of the first single-instruction `b.cond` emitted to
each label and compares it to the stub that label is bound to, so the
diagnostic names the branches that actually overflow. A trace that took the
two-instruction form everywhere records nothing and passes.
`trace_start_offset` had no remaining reader and is removed.

## 3. jit(fbw): the paused-call operand floor on the third recipe path (CodeRabbit)

`reconstruct_inline_recipe` has three exits. #885 exempted the operand region a
paused call consumes on the virtual-array path; the color-inversion fallthrough
rebuilds from the same resumedata colors but demanded the whole region, so an
`in_a_call` frame reaching it declined once the call took an argument.

The materialized-frame exit is deliberately unchanged: it reads those operands
out of the frame's own `locals_cells_stack_w`, where they are present.

## 4. interp: `PYRE_INTERP_RETURN_LOG` read once instead of per return

Found while profiling `synth/arith_int_bool`. `finish_value` runs on every
interpreted RETURN_VALUE and probed the variable with `std::env::var_os`, which
takes a lock and scans the environment array.

Interleaved median-of-5, dynasm, arm64:

| fixture | before | after | |
|---|---|---|---|
| `calls_closures` | 0.470s | 0.400s | +14.9% |
| `closure_per_call` | 0.540s | 0.470s | +13.0% |
| `class_attrs_methods` | 0.820s | 0.730s | +11.0% |
| `exception_reraise_tb_depth_jitstress` | 0.690s | 0.630s | +8.7% |

## Verification

- `pyre/check.py --backend dynasm,cranelift`: 342 passed on both backends. The
  one failure is `synth/ast_compile_roundtrip`, a local cpython/pypy output
  mismatch (BASEFAIL) unrelated to these changes; it passes in CI.
- `cargo test` over majit-gc, majit-metainterp, majit-backend-dynasm and
  pyre-interpreter: 2218 passed, 0 failed.
- GC discriminators — a recycled address must not inherit a dead owner's
  `__dict__`, an indirectly reached owner must not lose it, weakref lifelines
  survive with their owner and clear when it dies — all match pypy3 exactly.
  mapdict scaling stays linear (N x4 -> x2.9).

The local gate ran before the branch was rebased onto 0135f56 (#901); CI on
this PR is the check against the current base.

## Not addressed

The Codex parity note that a value whose owner dies survives one extra major
collection is accurate and left as is: the walk marks table values as roots
before `finish_incremental_marking` prunes dead owners, so pruning is one cycle
behind. A true ephemeron relationship would need a marking fixpoint.

— *commented by Claude*
