### PR TITLE
gc: root the working values in any/all and set.union/update, and make shadow-stack reads cheap

### DIFF
--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -10173,9 +10173,23 @@ fn builtin_any(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
             positional.len()
         )));
     }
-    let it = crate::baseobjspace::iter(positional[0])?;
+    // `iter` and every `next` run arbitrary Python. Pin the iterable, the
+    // iterator, and a dict view's backing dict for the whole walk, and reload
+    // the iterator from its slot before each call: a moving minor collection
+    // relocates it behind a plain Rust local. The shape `collect_iterator` uses.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let iterable_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(positional[0]);
+    let it = crate::baseobjspace::iter(pyre_object::gc_roots::shadow_stack_get(iterable_slot))?;
+    let iterator_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(it);
+    if unsafe { pyre_object::dictmultiobject::is_dict_view_iterator(it) } {
+        let w_dict = unsafe { pyre_object::dictmultiobject::w_dict_view_iterator_get_dict(it) };
+        pyre_object::gc_roots::pin_root(w_dict);
+    }
     loop {
-        match crate::baseobjspace::next(it) {
+        let it_now = pyre_object::gc_roots::shadow_stack_get(iterator_slot);
+        match crate::baseobjspace::next(it_now) {
             Ok(item) if crate::baseobjspace::is_true(item)? => return Ok(w_bool_from(true)),
             Ok(_) => {}
             Err(e) if e.kind == crate::PyErrorKind::StopIteration => return Ok(w_bool_from(false)),
@@ -12267,9 +12281,21 @@ fn builtin_all(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
             positional.len()
         )));
     }
-    let it = crate::baseobjspace::iter(positional[0])?;
+    // Rooted exactly as `builtin_any`: `iter` and every `next` run arbitrary
+    // Python, so the iterator is reloaded from its slot before each call.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let iterable_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(positional[0]);
+    let it = crate::baseobjspace::iter(pyre_object::gc_roots::shadow_stack_get(iterable_slot))?;
+    let iterator_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(it);
+    if unsafe { pyre_object::dictmultiobject::is_dict_view_iterator(it) } {
+        let w_dict = unsafe { pyre_object::dictmultiobject::w_dict_view_iterator_get_dict(it) };
+        pyre_object::gc_roots::pin_root(w_dict);
+    }
     loop {
-        match crate::baseobjspace::next(it) {
+        let it_now = pyre_object::gc_roots::shadow_stack_get(iterator_slot);
+        match crate::baseobjspace::next(it_now) {
             Ok(item) if !crate::baseobjspace::is_true(item)? => return Ok(w_bool_from(false)),
             Ok(_) => {}
             Err(e) if e.kind == crate::PyErrorKind::StopIteration => return Ok(w_bool_from(true)),

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -21189,16 +21189,40 @@ pub(crate) fn set_method_union(
         return Ok(pyre_object::w_set_new());
     }
     let result = set_copy_real(args[0]);
+    // `collect_iterable` runs a user `__iter__`/`__next__` and
+    // `builtin_set_add_items` a user `__hash__`/`__eq__`, so the set being
+    // built stays live across every operand — with two non-set operands it
+    // crosses two full drains. `set_init_from_iterable_impl` pins for the same
+    // reason: the set body is non-moving old-gen storage, but it still has to
+    // be marked live instead of swept while Rust holds the only reference.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let result_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(result);
     for other in &args[1..] {
-        if unsafe { pyre_object::is_set_or_frozenset(*other) } {
-            unsafe { pyre_object::w_set_update_from_set(result, *other) }
-                .map_err(crate::baseobjspace::map_set_update_error)?;
+        let _operand_root = pyre_object::gc_roots::push_roots();
+        let operand_slot = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(*other);
+        if unsafe {
+            pyre_object::is_set_or_frozenset(pyre_object::gc_roots::shadow_stack_get(operand_slot))
+        } {
+            unsafe {
+                pyre_object::w_set_update_from_set(
+                    pyre_object::gc_roots::shadow_stack_get(result_slot),
+                    pyre_object::gc_roots::shadow_stack_get(operand_slot),
+                )
+            }
+            .map_err(crate::baseobjspace::map_set_update_error)?;
         } else {
-            let other_items = crate::builtins::collect_iterable(*other)?;
-            crate::builtins::builtin_set_add_items(result, &other_items)?;
+            let other_items = crate::builtins::collect_iterable(
+                pyre_object::gc_roots::shadow_stack_get(operand_slot),
+            )?;
+            crate::builtins::builtin_set_add_items(
+                pyre_object::gc_roots::shadow_stack_get(result_slot),
+                &other_items,
+            )?;
         }
     }
-    Ok(result)
+    Ok(pyre_object::gc_roots::shadow_stack_get(result_slot))
 }
 
 /// A clone of the set, keeping the digest each element was stored under.
@@ -21601,16 +21625,36 @@ fn set_method_update(
     if args.is_empty() {
         return Ok(pyre_object::w_none());
     }
+    // Rooted as `set_method_union`, except that the operands merge into
+    // `args[0]` itself: a raw Rust slice the collector cannot see either.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let set_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(args[0]);
     // `setobject.py _descr_update` — a set operand's storage merges in
     // as it stands; only another iterable is walked and hashed element by
     // element.
     for other in &args[1..] {
-        if unsafe { pyre_object::is_set_or_frozenset(*other) } {
-            unsafe { pyre_object::w_set_update_from_set(args[0], *other) }
-                .map_err(crate::baseobjspace::map_set_update_error)?;
+        let _operand_root = pyre_object::gc_roots::push_roots();
+        let operand_slot = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(*other);
+        if unsafe {
+            pyre_object::is_set_or_frozenset(pyre_object::gc_roots::shadow_stack_get(operand_slot))
+        } {
+            unsafe {
+                pyre_object::w_set_update_from_set(
+                    pyre_object::gc_roots::shadow_stack_get(set_slot),
+                    pyre_object::gc_roots::shadow_stack_get(operand_slot),
+                )
+            }
+            .map_err(crate::baseobjspace::map_set_update_error)?;
         } else {
-            let other_items = crate::builtins::collect_iterable(*other)?;
-            crate::builtins::builtin_set_add_items(args[0], &other_items)?;
+            let other_items = crate::builtins::collect_iterable(
+                pyre_object::gc_roots::shadow_stack_get(operand_slot),
+            )?;
+            crate::builtins::builtin_set_add_items(
+                pyre_object::gc_roots::shadow_stack_get(set_slot),
+                &other_items,
+            )?;
         }
     }
     Ok(pyre_object::w_none())

--- a/pyre/pyre-jit/tests/gc_stress.rs
+++ b/pyre/pyre-jit/tests/gc_stress.rs
@@ -987,6 +987,257 @@ while i < 40:
     );
 }
 
+/// `min_max_sequence` keeps the current best item and key in shadow-stack
+/// slots while the `key=` function runs Python and calls `gc.collect()`.
+#[test]
+fn min_max_key_values_survive_python_callbacks() {
+    run_on_worker(
+        r#"
+import gc
+
+class K:
+    def __init__(self, v):
+        self.v = v
+
+def keyf(o):
+    gc.collect()
+    return o.v
+
+i = 0
+while i < 40:
+    lo = min([K(5), K(3), K(9), K(1), K(7)], key=keyf)
+    assert lo.v == 1, lo.v
+    hi = max([K(5), K(3), K(9), K(1), K(7)], key=keyf)
+    assert hi.v == 9, hi.v
+    i += 1
+"#,
+        "<min_max_key_gc_rooting>",
+        "min/max key callback-root checks",
+        "min/max key callback GC rooting program failed",
+    );
+}
+
+/// `sort_rooted_items` keeps every item and computed key in shadow-stack
+/// slots while the `key=` function runs Python and calls `gc.collect()`.
+#[test]
+fn sorted_key_values_survive_python_callbacks() {
+    run_on_worker(
+        r#"
+import gc
+
+class K:
+    def __init__(self, v):
+        self.v = v
+
+def keyf(o):
+    gc.collect()
+    return o.v
+
+i = 0
+while i < 40:
+    ordered = sorted([K(5), K(3), K(9), K(1), K(7)], key=keyf)
+    values = (ordered[0].v, ordered[1].v, ordered[2].v, ordered[3].v, ordered[4].v)
+    assert values == (1, 3, 5, 7, 9), values
+    i += 1
+"#,
+        "<sorted_key_gc_rooting>",
+        "sorted key callback-root checks",
+        "sorted key callback GC rooting program failed",
+    );
+}
+
+/// The reflected binary-operator helper holds both operands and the reflected
+/// implementation in Rust locals while `L.__add__` / `L.__sub__` run Python
+/// and collect before `R.__radd__` / `R.__rsub__` use those values.
+#[test]
+fn reflected_binary_operands_survive_python_callbacks() {
+    run_on_worker(
+        r#"
+import gc
+
+class L:
+    def __init__(self, v):
+        self.v = v
+    def __add__(self, other):
+        gc.collect()
+        return NotImplemented
+    def __sub__(self, other):
+        gc.collect()
+        return NotImplemented
+
+class R:
+    def __init__(self, v):
+        self.v = v
+    def __radd__(self, other):
+        gc.collect()
+        return (other.v, self.v)
+    def __rsub__(self, other):
+        gc.collect()
+        return (other.v, self.v)
+
+i = 0
+while i < 60:
+    assert L(i) + R(i + 1) == (i, i + 1)
+    assert L(i) - R(i + 1) == (i, i + 1)
+    i += 1
+"#,
+        "<reflected_binary_gc_rooting>",
+        "reflected binary operand callback-root checks",
+        "reflected binary operand callback GC rooting program failed",
+    );
+}
+
+/// The comparison helper holds its two-entry `(ov, recv, other)` order array
+/// in Rust locals while the first `P.__eq__` runs Python and collects before
+/// the second `Q.__eq__` reads both captured operands.
+#[test]
+fn comparison_order_operands_survive_python_callbacks() {
+    run_on_worker(
+        r#"
+import gc
+
+class P:
+    def __init__(self, v):
+        self.v = v
+    def __eq__(self, other):
+        gc.collect()
+        return NotImplemented
+
+class Q:
+    def __init__(self, v):
+        self.v = v
+    def __eq__(self, other):
+        gc.collect()
+        return (self.v, other.v)
+
+i = 0
+while i < 60:
+    assert (P(i) == Q(i + 1)) == (i + 1, i)
+    i += 1
+"#,
+        "<comparison_order_gc_rooting>",
+        "comparison order callback-root checks",
+        "comparison order callback GC rooting program failed",
+    );
+}
+
+/// `_regular_sum` holds its accumulator and the remaining collected elements
+/// in Rust locals while `Addend.__add__` runs Python and collects.
+/// `collect_iterable` / `collect_iterator` root elements only while building
+/// the Vec; their `RootScope` is dropped before `sum` consumes that Vec.
+#[test]
+fn sum_accumulator_and_items_survive_python_callbacks() {
+    run_on_worker(
+        r#"
+import gc
+
+class Addend:
+    def __init__(self, v):
+        self.v = v
+    def __add__(self, other):
+        gc.collect()
+        return Addend(self.v + other.v)
+
+i = 0
+while i < 60:
+    total = sum(
+        [Addend(1), Addend(2), Addend(3), Addend(4),
+         Addend(5), Addend(6), Addend(7), Addend(8)],
+        Addend(0),
+    )
+    assert total.v == 36, total.v
+    i += 1
+"#,
+        "<sum_gc_rooting>",
+        "sum accumulator and item callback-root checks",
+        "sum callback GC rooting program failed",
+    );
+}
+
+/// `any` / `all` hold their iterator in a Rust local while `RootingIter.__next__`
+/// and `CollectingBool.__bool__` run Python and collect. `collect_iterator`
+/// states the required opposite rule: reload the iterator from its
+/// post-relocation shadow-stack slot before every `next` call.
+#[test]
+fn any_all_iterators_survive_python_callbacks() {
+    run_on_worker(
+        r#"
+import gc
+
+class CollectingBool:
+    def __init__(self, value):
+        self.value = value
+    def __bool__(self):
+        gc.collect()
+        return self.value
+
+class RootingIter:
+    def __init__(self, count, true_count):
+        self.i = 0
+        self.count = count
+        self.true_count = true_count
+    def __iter__(self):
+        return self
+    def __next__(self):
+        gc.collect()
+        if self.i >= self.count:
+            raise StopIteration
+        value = self.i < self.true_count
+        self.i += 1
+        return CollectingBool(value)
+
+i = 0
+while i < 60:
+    assert any(RootingIter(8, 0)) is False
+    assert all(RootingIter(8, 3)) is False
+    i += 1
+"#,
+        "<any_all_gc_rooting>",
+        "any/all iterator callback-root checks",
+        "any/all callback GC rooting program failed",
+    );
+}
+
+/// `set_method_union` / `set_method_update` hold their result and each
+/// collected item Vec in Rust locals while `RootingIter.__next__` runs Python
+/// and collects. Unlike these methods, sibling `set_init_from_iterable_impl`
+/// pins its working values for exactly this reason.
+#[test]
+fn set_union_update_values_survive_python_callbacks() {
+    run_on_worker(
+        r#"
+import gc
+
+class RootingIter:
+    def __init__(self, start, stop):
+        self.current = start
+        self.stop = stop
+    def __iter__(self):
+        return self
+    def __next__(self):
+        gc.collect()
+        if self.current >= self.stop:
+            raise StopIteration
+        value = self.current
+        self.current += 1
+        return value
+
+i = 0
+while i < 60:
+    united = {0}.union(RootingIter(1, 5), RootingIter(5, 9))
+    assert united == {0, 1, 2, 3, 4, 5, 6, 7, 8}, united
+
+    updated = {0}
+    updated.update(RootingIter(1, 5), RootingIter(5, 9))
+    assert updated == {0, 1, 2, 3, 4, 5, 6, 7, 8}, updated
+    i += 1
+"#,
+        "<set_union_update_gc_rooting>",
+        "set union/update callback-root checks",
+        "set union/update callback GC rooting program failed",
+    );
+}
+
 /// `PyCode.co_consts_w` owns the one wrapped object for each constant index
 /// (`pycode.py:126`, `pyopcode.py:498-499`). A large integer constant is a
 /// managed `W_LongObject`; the Box-immortal PyCode therefore has to expose the

--- a/pyre/pyre-object/src/gc_roots.rs
+++ b/pyre/pyre-object/src/gc_roots.rs
@@ -48,7 +48,9 @@
 //!   pointers are now observable to the active `MiniMarkGC`
 //!   instance and survive across collections.
 
-use std::cell::RefCell;
+#[cfg(debug_assertions)]
+use std::cell::Cell;
+use std::cell::UnsafeCell;
 
 use crate::pyobject::PyObjectRef;
 
@@ -58,11 +60,96 @@ thread_local! {
     /// each [`RootScope`]'s lifetime; the matching [`Drop`] truncates
     /// back to the saved length.
     ///
-    /// `RefCell` (rather than `Cell` of a raw pointer) is deliberate:
-    /// every public entry point goes through `borrow` / `borrow_mut`
-    /// so re-entrant access from within a [`Drop`] would surface as a
-    /// `BorrowMutError` rather than silently corrupting the stack.
-    static SHADOW_STACK: RefCell<Vec<PyObjectRef>> = const { RefCell::new(Vec::new()) };
+    /// Access is raw, matching RPython's base/top shadow-stack shape.
+    /// Debug builds retain the old re-entrancy safety net through
+    /// `SHADOW_STACK_ACCESS_DEPTH`; release builds pay no borrow-check cost.
+    static SHADOW_STACK: UnsafeCell<Vec<PyObjectRef>> =
+        const { UnsafeCell::new(Vec::new()) };
+
+    /// Signed debug borrow depth for [`SHADOW_STACK`]: non-negative values
+    /// count shared accesses, while `-1` marks an exclusive access.
+    #[cfg(debug_assertions)]
+    static SHADOW_STACK_ACCESS_DEPTH: Cell<i32> = const { Cell::new(0) };
+}
+
+#[cfg(debug_assertions)]
+struct ShadowStackAccess<'a> {
+    depth: &'a Cell<i32>,
+    previous: i32,
+}
+
+#[cfg(debug_assertions)]
+impl<'a> ShadowStackAccess<'a> {
+    #[inline(always)]
+    fn shared(depth: &'a Cell<i32>) -> Self {
+        let previous = depth.get();
+        debug_assert!(
+            previous >= 0,
+            "shared shadow-stack access re-entered an exclusive access"
+        );
+        depth.set(previous + 1);
+        Self { depth, previous }
+    }
+
+    #[inline(always)]
+    fn exclusive(depth: &'a Cell<i32>) -> Self {
+        let previous = depth.get();
+        debug_assert_eq!(previous, 0, "exclusive shadow-stack access was re-entered");
+        depth.set(-1);
+        Self { depth, previous }
+    }
+}
+
+#[cfg(debug_assertions)]
+impl Drop for ShadowStackAccess<'_> {
+    #[inline(always)]
+    fn drop(&mut self) {
+        self.depth.set(self.previous);
+    }
+}
+
+#[inline(always)]
+fn with_shadow_stack<R>(f: impl FnOnce(&Vec<PyObjectRef>) -> R) -> R {
+    SHADOW_STACK.with(|cell| {
+        #[cfg(debug_assertions)]
+        {
+            SHADOW_STACK_ACCESS_DEPTH.with(|depth| {
+                let _access = ShadowStackAccess::shared(depth);
+                // SAFETY: the debug-only access guard rejects overlap with an
+                // exclusive access. In release this is the raw, thread-local
+                // root-stack access shape used upstream.
+                f(unsafe { &*cell.get() })
+            })
+        }
+        #[cfg(not(debug_assertions))]
+        {
+            // SAFETY: the stack is thread-local, and callers must not
+            // re-enter an access that holds an exclusive reference.
+            f(unsafe { &*cell.get() })
+        }
+    })
+}
+
+#[inline(always)]
+fn with_shadow_stack_mut<R>(f: impl FnOnce(&mut Vec<PyObjectRef>) -> R) -> R {
+    SHADOW_STACK.with(|cell| {
+        #[cfg(debug_assertions)]
+        {
+            SHADOW_STACK_ACCESS_DEPTH.with(|depth| {
+                let _access = ShadowStackAccess::exclusive(depth);
+                // SAFETY: the debug-only access guard rejects every
+                // overlapping access. Release preserves the same
+                // non-re-entrancy invariant without runtime bookkeeping.
+                f(unsafe { &mut *cell.get() })
+            })
+        }
+        #[cfg(not(debug_assertions))]
+        {
+            // SAFETY: the stack is thread-local, and callers must not
+            // overlap this exclusive access with another stack access.
+            f(unsafe { &mut *cell.get() })
+        }
+    })
 }
 
 /// RAII guard returned by [`push_roots`].
@@ -98,8 +185,7 @@ impl Drop for RootScope {
     /// bracketed `livevars` slots.
     #[inline]
     fn drop(&mut self) {
-        SHADOW_STACK.with(|s| {
-            let mut stack = s.borrow_mut();
+        with_shadow_stack_mut(|stack| {
             // `truncate` is a no-op if `save_point >= len()`, which is
             // the steady-state case for an empty bracket.
             stack.truncate(self.save_point);
@@ -135,8 +221,7 @@ pub fn pin_root(root: PyObjectRef) {
     // enter the query safepoint.  RPython's push_roots writes the livevar to
     // the shadow stack before calling the allocation/GC slow path for the
     // same reason.
-    let index = SHADOW_STACK.with(|s| {
-        let mut stack = s.borrow_mut();
+    let index = with_shadow_stack_mut(|stack| {
         let index = stack.len();
         stack.push(root);
         index
@@ -152,9 +237,9 @@ pub fn pin_root(root: PyObjectRef) {
     // between the push above and the query — and the write-back is not free:
     // this thread-local resolves through `_tlv_get_addr` on every `with`, and
     // pinning sits on the interpreter's allocation and call paths, so the
-    // second resolve plus its `RefCell` borrow is paid once per pinned livevar.
+    // second resolve is paid once per pinned livevar.
     if normalized != root {
-        SHADOW_STACK.with(|s| s.borrow_mut()[index] = normalized);
+        with_shadow_stack_mut(|stack| stack[index] = normalized);
     }
 }
 
@@ -170,7 +255,7 @@ pub fn pin_root(root: PyObjectRef) {
 /// in the noise.
 #[majit_macros::dont_look_inside]
 pub fn shadow_stack_len() -> usize {
-    SHADOW_STACK.with(|s| s.borrow().len())
+    with_shadow_stack(Vec::len)
 }
 
 /// Read a single shadow-stack slot by index, panicking if the index
@@ -202,7 +287,7 @@ pub fn shadow_stack_get(index: usize) -> PyObjectRef {
     // copied from outside the bracket, so a foreign mutator can have collected
     // after that copy and before the pin.  That is also the pin's safepoint;
     // a read allocates nothing and has no reason to park.
-    SHADOW_STACK.with(|s| s.borrow()[index])
+    with_shadow_stack(|stack| stack[index])
 }
 
 /// Copy a contiguous range of rooted values out of the shadow stack.
@@ -216,8 +301,7 @@ pub fn shadow_stack_get(index: usize) -> PyObjectRef {
 /// like indexing the corresponding slots individually.
 #[majit_macros::dont_look_inside]
 pub fn shadow_stack_copy_range(base: usize, dst: &mut [PyObjectRef]) {
-    SHADOW_STACK.with(|s| {
-        let stack = s.borrow();
+    with_shadow_stack(|stack| {
         dst.copy_from_slice(&stack[base..base + dst.len()]);
     });
 }
@@ -236,11 +320,11 @@ pub fn shadow_stack_set(index: usize, root: PyObjectRef) {
     // `try_gc_current_object_address` query is itself a GC operation and may
     // wait behind another thread's collection, so the value must already be
     // visible to that collector before we enter the query safepoint.
-    SHADOW_STACK.with(|s| s.borrow_mut()[index] = root);
+    with_shadow_stack_mut(|stack| stack[index] = root);
     // Then normalize a GCREF the caller may have copied before a foreign
     // mutator's nursery collection, so the slot never keeps a forwarding stub.
     let root = crate::gc_hook::try_gc_current_object_address(root as *mut u8) as PyObjectRef;
-    SHADOW_STACK.with(|s| s.borrow_mut()[index] = root);
+    with_shadow_stack_mut(|stack| stack[index] = root);
 }
 
 /// Visit every pinned root in the shadow stack with mutable access.
@@ -252,14 +336,13 @@ pub fn shadow_stack_set(index: usize, root: PyObjectRef) {
 /// *mut PyObject` is also pointer-sized.
 ///
 /// The visitor receives mutable references so a moving collector can
-/// rewrite slot contents post-relocation. Re-entrant access from
-/// within the visitor would surface as a `BorrowMutError` — the
-/// `RefCell` is the safety net that catches an accidentally
-/// allocating walker.
+/// rewrite slot contents post-relocation. In debug builds the signed
+/// `SHADOW_STACK_ACCESS_DEPTH` guard catches re-entrant access from an
+/// accidentally allocating walker; release builds match upstream's raw
+/// root-stack access without that safety net.
 #[inline]
 pub fn walk_shadow_stack(mut visitor: impl FnMut(&mut PyObjectRef)) {
-    SHADOW_STACK.with(|s| {
-        let mut stack = s.borrow_mut();
+    with_shadow_stack_mut(|stack| {
         for slot in stack.iter_mut() {
             visitor(slot);
         }
@@ -277,7 +360,7 @@ pub fn capture_shadow_stack_area() -> *const () {
 /// `data` must come from [`capture_shadow_stack_area`], and the owning thread
 /// must be quiesced for the duration of the walk.
 pub unsafe fn walk_shadow_stack_area(data: *const (), mut visitor: impl FnMut(&mut PyObjectRef)) {
-    let stack = unsafe { &mut *(*(data as *const RefCell<Vec<PyObjectRef>>)).as_ptr() };
+    let stack = unsafe { &mut *(*(data as *const UnsafeCell<Vec<PyObjectRef>>)).get() };
     for slot in stack.iter_mut() {
         visitor(slot);
     }


### PR DESCRIPTION
Three commits: a rooting regression harness, the two fixes it demonstrates, and the shadow-stack read cost that rooting a streaming loop exposes.

## What was wrong

A `PyObjectRef` in a plain Rust local is not a root — the collector walks Python frames, not the Rust stack. Two helpers held working values across calls that run arbitrary Python:

- **`any` / `all`** bound the iterator in a Rust local and called `next()` and `is_true()` — a user `__next__` and `__bool__` — without pinning it and without reloading it between calls. `collect_iterator`, in the same file, states the opposite rule above its own loop and follows it.
- **`set.union` / `set.update`** held the set being built across every operand's drain. `collect_iterable` runs a user `__iter__`/`__next__` and `builtin_set_add_items` a user `__hash__`/`__eq__`, so with two or more non-set operands the set crosses two full drains. The sibling `set_init_from_iterable_impl` already pins for exactly this reason.

## How they were demonstrated first

The first commit adds the tests and lands them **red**, so the defects are reproducible from history rather than asserted. At that commit:

```
any_all_iterators_survive_python_callbacks
  GC BUG: invalid major child type_id=... site=major_varsize_item
set_union_update_values_survive_python_callbacks
  Went past end of probe sequence
```

The reported `type_id` differs between runs.

Two of the seven programs are **baselines** over helpers that already root correctly — `min`/`max` and `sorted` with a collecting `key=`. Both pass, which is what makes the other results attributable to the helper under test rather than to the harness. Operands are passed as temporaries, never bound to a Python local, so the frame cannot keep them reachable incidentally.

Three programs — reflected binop, comparison order, and `sum` — **pass**. Their operands stay reachable in these shapes, so those helpers are untested, not shown sound. They are deliberately left unfixed: there is no discriminator for them yet.

`builtin_set_add_items_impl` is unchanged. It already pins the set and every slice element and reloads them after each hash.

## The third commit

Rooting a streaming loop costs one `shadow_stack_get` per element, which was `SHADOW_STACK.with(|s| s.borrow()[index])` — a TLS access, a `RefCell` borrow flag with its guard drop, and a bounds check. Measured on a 300k-element `any`/`all` walk (user CPU, min of 15, machine quiet): control 2.75s → 3.02s, **9.8%**, with `any` and `all` agreeing to three decimals (1.0981 / 1.0978) and an untouched `sorted` control at 0.9944.

`ShadowStackPool` (`shadowstack.py:277-281`) is a fixed-capacity raw array addressed through `root_stack_base`/`root_stack_top` with raw address arithmetic (`:81-88`) and `ll_assert` (`:319`) as its check — so the `RefCell` was the deviation. Access now goes through an `UnsafeCell`, and the re-entrancy net moves to a signed depth counter under `cfg(debug_assertions)`, where `cargo test` runs. Bounds checks stay; `pin_root`'s publish-then-normalize ordering is untouched.

`walk_shadow_stack_area` names the cell type in a raw cast and moves in lockstep — the two walkers over this storage are independent, and leaving that one behind would still compile while walking a quiesced thread's roots through the wrong layout.

## Verification

| | status |
|---|---|
| `gc_stress` | 21 passed / 2 failed at commit 1 → **23 passed / 0 failed** at commit 2, held at commit 3 |
| `cargo test -p pyre-object` | 282 passed |
| `check.py` both backends | 344 passed, 1 failed — the pre-existing `synth/ast_compile_roundtrip` cpython/pypy oracle mismatch |

**Pending, and I will post them as a comment:** `check.py` has been run through commit 2 but not yet over commit 3, and the A/B has not been re-run to show how much of the 9.8% the third commit recovers. Both need a quiet machine; load has been sitting above 100. The accessor change stands on the orthodoxy argument regardless of the recovery figure, but the figure is owed.

— *commented by Claude*