### PR TITLE
review: act on the Codex and CodeRabbit findings on #887

### DIFF
--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -3402,9 +3402,6 @@ impl MiniMarkGC {
                 unsafe { (*hdr).type_id() },
                 self.gc_state
             );
-            if unsafe { (*hdr).type_id() } == 9 {
-                eprintln!("{}", std::backtrace::Backtrace::force_capture());
-            }
         }
         unsafe { (*hdr).clear_flag(flags::TRACK_YOUNG_PTRS) };
     }

--- a/majit/majit-gc/src/shadow_stack.rs
+++ b/majit/majit-gc/src/shadow_stack.rs
@@ -483,12 +483,19 @@ pub fn release_owner_root(index: usize) {
 /// RAII owner for one fixed translated-livevar root slot.
 pub struct OwnerRootGuard {
     index: usize,
+    /// `index` names a slot in the ACQUIRING thread's `OWNER_ROOTS`, so the
+    /// guard must not outlive that thread's stack frame.  Bare `usize` would
+    /// make it auto-`Send`, and dropping it elsewhere would release a foreign
+    /// thread's slot (or trip the inactive-slot assert).  The raw-pointer
+    /// marker pins it to one thread at compile time.
+    _not_send: std::marker::PhantomData<*mut ()>,
 }
 
 impl OwnerRootGuard {
     pub fn new(root: GcRef) -> Self {
         Self {
             index: acquire_owner_root(root),
+            _not_send: std::marker::PhantomData,
         }
     }
 

--- a/majit/majit-gc/src/shadow_stack.rs
+++ b/majit/majit-gc/src/shadow_stack.rs
@@ -220,6 +220,14 @@ thread_local! {
     /// when Rust RAII scopes nest across a `FrameBox`.
     static OWNER_ROOTS: RefCell<Vec<Option<GcRef>>> = const { RefCell::new(Vec::new()) };
 
+    /// Interior `OWNER_ROOTS` slots that have been released but still sit
+    /// below the live tail.  Popping one is what keeps `acquire_owner_root`
+    /// O(1): searching for the first `None` instead is a linear scan, and a
+    /// recursion `depth` frames deep pays O(depth²) just to root its frames.
+    /// Trailing slots never land here — `release_owner_root` shrinks those
+    /// away so an unwound recursion leaves no walked tail behind.
+    static OWNER_ROOTS_FREE: RefCell<Vec<usize>> = const { RefCell::new(Vec::new()) };
+
     /// Thread-local flat jitframe root stack. Rust tests run multiple
     /// JIT/GC tests in parallel, so using one process-global root stack lets
     /// one GC walk another test's jitframe. RPython's root stack is per
@@ -454,7 +462,9 @@ pub fn get(index: usize) -> GcRef {
 pub fn acquire_owner_root(root: GcRef) -> usize {
     OWNER_ROOTS.with(|roots| {
         let mut roots = roots.borrow_mut();
-        if let Some(index) = roots.iter().position(Option::is_none) {
+        let reused = OWNER_ROOTS_FREE.with(|free| free.borrow_mut().pop());
+        if let Some(index) = reused {
+            debug_assert!(roots[index].is_none(), "reusing a live owner-root slot");
             roots[index] = Some(root);
             index
         } else {
@@ -474,9 +484,20 @@ pub fn release_owner_root(index: usize) {
             "releasing an inactive owner-root slot"
         );
         roots[index] = None;
+        if index + 1 < roots.len() {
+            // An interior hole: hand it to the next acquire.
+            let _ = OWNER_ROOTS_FREE.try_with(|free| free.borrow_mut().push(index));
+            return;
+        }
+        // The tail — the ordinary case, since these guards nest with the Rust
+        // scopes that own them.  Shrink rather than queueing, so the walked
+        // range tracks the live depth, and drop the queued indices the shrink
+        // just took out of range.
         while roots.last().is_some_and(Option::is_none) {
             roots.pop();
         }
+        let live = roots.len();
+        let _ = OWNER_ROOTS_FREE.try_with(|free| free.borrow_mut().retain(|&i| i < live));
     });
 }
 

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -610,15 +610,6 @@ fn gc_prebuilt_remember_enabled() -> bool {
     })
 }
 
-/// Whether the per-return diagnostic dump is enabled
-/// (`PYRE_INTERP_RETURN_LOG`). The probe sits on the RETURN_VALUE path, so an
-/// uncached read would pay a `getenv` on every Python return.
-#[cfg(not(feature = "sandbox"))]
-fn interp_return_log_enabled() -> bool {
-    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *ENABLED.get_or_init(|| std::env::var_os("PYRE_INTERP_RETURN_LOG").is_some())
-}
-
 pub fn capture_pyframe_root_area() -> *const () {
     PYFRAME_ROOT_AREA.with(|area| area as *const _ as *const ())
 }
@@ -1006,7 +997,7 @@ pub fn register_pyframe_root_walker() {
     majit_gc::shadow_stack::register_extra_root_walker(crate::module::thread::walk_thread_roots);
     #[cfg(all(not(target_arch = "wasm32"), not(feature = "sandbox")))]
     majit_gc::shadow_stack::register_extra_root_walker(
-        crate::module::faulthandler::handler::walk_fatal_error_file,
+        crate::module::faulthandler::handler::walk_faulthandler_roots,
     );
 }
 

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -1004,6 +1004,10 @@ pub unsafe fn walk_pyframe_roots_area(
 pub fn register_pyframe_root_walker() {
     majit_gc::shadow_stack::register_extra_root_walker(walk_global_prebuilt_roots);
     majit_gc::shadow_stack::register_extra_root_walker(crate::module::thread::walk_thread_roots);
+    #[cfg(all(not(target_arch = "wasm32"), not(feature = "sandbox")))]
+    majit_gc::shadow_stack::register_extra_root_walker(
+        crate::module::faulthandler::handler::walk_fatal_error_file,
+    );
 }
 
 thread_local! {

--- a/pyre/pyre-interpreter/src/module/_io/textio.rs
+++ b/pyre/pyre-interpreter/src/module/_io/textio.rs
@@ -496,6 +496,17 @@ impl W_TextIOWrapper {
         }
     }
 
+    /// Record `self` in the remembered set (incminimark.py:1495
+    /// `write_barrier_from_array`).  An already-old wrapper is NOT scanned by a
+    /// minor collection unless the barrier ran since the previous one, so a
+    /// reference field storing a fresh (nursery) object has to be published
+    /// before the next operation that can collect — not once at the end of a
+    /// sequence that allocates and calls back into Python between the stores.
+    #[inline]
+    fn publish_refs(&mut self) {
+        pyre_object::gc_hook::try_gc_write_barrier(self as *mut Self as *mut u8);
+    }
+
     /// PyPy `W_TextIOWrapper._set_encoder_decoder`.
     fn set_encoder_decoder(&mut self, codec: PyObjectRef) -> Result<(), crate::PyError> {
         self.w_encoder = PY_NULL;
@@ -521,14 +532,16 @@ impl W_TextIOWrapper {
                 )?;
             }
             self.w_decoder = decoder;
+            // `writable` below runs arbitrary Python and can collect.
+            self.publish_refs();
         }
 
         if crate::baseobjspace::is_true(super::call_method_result(self.w_buffer, "writable", &[])?)?
         {
             self.w_encoder =
                 super::call_method_result(codec, "incrementalencoder", &[self.w_errors])?;
+            self.publish_refs();
         }
-        pyre_object::gc_hook::try_gc_write_barrier(self as *mut Self as *mut u8);
         Ok(())
     }
 
@@ -818,10 +831,19 @@ impl W_TextIOWrapper {
         line_buffering: bool,
         write_through: bool,
     ) -> Result<(), crate::PyError> {
+        // Every `w_str_new` here allocates and `set_newline` /
+        // `getattr_str` / `set_encoder_decoder` below run Python, so a
+        // collection can land between any two of these stores.  Publish after
+        // each reference store instead of once at the end, or a store made
+        // before a collection is one the collection never traced.
         self.w_buffer = buffer;
+        self.publish_refs();
         self.w_encoding = w_str_new(encoding);
+        self.publish_refs();
         self.w_errors = w_str_new(errors);
+        self.publish_refs();
         self.w_newline = newline;
+        self.publish_refs();
         self.line_buffering = line_buffering;
         self.write_through = write_through;
         self.decoded.reset();
@@ -838,7 +860,7 @@ impl W_TextIOWrapper {
         self.telling = self.seekable_flag;
         self.state = STATE_OK;
         self.reset_encoder_state();
-        pyre_object::gc_hook::try_gc_write_barrier(self as *mut Self as *mut u8);
+        self.publish_refs();
         Ok(())
     }
 
@@ -875,22 +897,34 @@ impl W_TextIOWrapper {
         // hand the import system a second, half built module.
         // [`attach_stdio_codec`] supplies it once the import system is up.
         let payload = unsafe { &mut *(obj as *mut Self) };
-        let _ = payload.attach_buffer(
-            buffer,
-            encoding,
-            errors,
-            newline,
-            newline_value,
-            PY_NULL,
-            line_buffering,
-            write_through,
-        );
-        // `attach_buffer` reaches its fallible calls only once the buffer and
-        // the newline mode are stored, so a stream whose buffer answers no
-        // `seekable` — a descriptor the host refused to open arrives as none at
-        // all — is still the stream this used to build unconditionally.
+        if payload
+            .attach_buffer(
+                buffer,
+                encoding,
+                errors,
+                newline,
+                newline_value,
+                PY_NULL,
+                line_buffering,
+                write_through,
+            )
+            .is_err()
+        {
+            // With a null codec the only fallible step `attach_buffer` reaches
+            // is `buffer.seekable()`, and a descriptor the host refused to open
+            // arrives as no buffer at all.  `create_stdio`
+            // (`app_main.py:495-497`) propagates such a failure, but this runs
+            // inside `sys` module creation — there is no interpreter to raise
+            // into yet, and the streams have to exist for one to start.  Finish
+            // the two fields the early return skipped rather than leaving them
+            // at their `Default`, so the stream below is initialized whichever
+            // path built it.
+            payload.seekable_flag = false;
+            payload.telling = false;
+            payload.reset_encoder_state();
+        }
         payload.state = STATE_OK;
-        pyre_object::gc_hook::try_gc_write_barrier(payload as *mut Self as *mut u8);
+        payload.publish_refs();
         crate::baseobjspace::setdictvalue_native(obj, "name", w_str_new(name));
         obj
     }
@@ -900,29 +934,33 @@ impl W_TextIOWrapper {
     /// reports itself unreadable however readable its buffer is, and only the
     /// methods `make_std_stream` installs as instance overrides work.
     ///
-    /// Ignores anything else — a replaced `sys.stdout`, a stream that already
-    /// has a codec, one whose encoding is unknown to the codec registry.
-    pub fn attach_stdio_codec(stream: PyObjectRef) {
+    /// Skips a stream this did not build — a replaced `sys.stdout`, one that
+    /// already has a codec, one carrying no encoding string.  A codec the
+    /// registry refuses, or an incremental encoder/decoder that will not
+    /// construct, is NOT skipped: `create_stdio` (`app_main.py:495-497`) builds
+    /// the wrapper with its codec in one step and propagates both, and a stream
+    /// left silently without one reports itself unreadable however readable its
+    /// buffer is.
+    pub fn attach_stdio_codec(stream: PyObjectRef) -> Result<(), crate::PyError> {
         if stream.is_null()
             || !std::ptr::eq(
                 unsafe { pyre_object::ll_type(stream) },
                 <Self as pyre_object::lltype::PyreClassPyTypeOf>::PYTYPE,
             )
         {
-            return;
+            return Ok(());
         }
         let payload = unsafe { &mut *(stream as *mut Self) };
         if !payload.w_encoder.is_null() || !payload.w_decoder.is_null() {
-            return;
+            return Ok(());
         }
         let Some(encoding) =
             unsafe { pyre_object::w_str_get_value_opt(payload.w_encoding) }.map(str::to_owned)
         else {
-            return;
+            return Ok(());
         };
-        if let Ok(codec) = Self::lookup_text_codec(&encoding) {
-            let _ = payload.set_encoder_decoder(codec);
-        }
+        let codec = Self::lookup_text_codec(&encoding)?;
+        payload.set_encoder_decoder(codec)
     }
 }
 

--- a/pyre/pyre-interpreter/src/module/faulthandler/handler.rs
+++ b/pyre/pyre-interpreter/src/module/faulthandler/handler.rs
@@ -24,6 +24,45 @@ static FAULTHANDLER_ENABLED: std::sync::atomic::AtomicBool =
 #[cfg(all(unix, feature = "host_env"))]
 static FAULTHANDLER_FD: std::sync::atomic::AtomicI32 = std::sync::atomic::AtomicI32::new(2);
 
+/// `handler.py:145` `self.fatal_error_w_file = w_file` / `handler.py:150`
+/// `self.fatal_error_w_file = None`: the descriptor the handler writes to
+/// belongs to this object, so it has to outlive the installed handlers rather
+/// than be collected and have its finalizer close the fd under them.  pyre has
+/// no Handler instance and the signal callback is a bare `extern "C" fn` that
+/// cannot capture one, so the owner is a process-global slot, walked as a GC
+/// root by [`walk_fatal_error_file`].
+#[cfg(all(unix, feature = "host_env"))]
+static FAULTHANDLER_FILE: std::sync::atomic::AtomicPtr<pyre_object::PyObject> =
+    std::sync::atomic::AtomicPtr::new(std::ptr::null_mut());
+
+/// Take ownership of the object owning the fatal-error descriptor; a null
+/// drops it (`enable` with a plain fd, and `disable`).
+#[cfg(all(unix, feature = "host_env"))]
+fn set_fatal_error_file(w_file: pyre_object::PyObjectRef) {
+    FAULTHANDLER_FILE.store(w_file, std::sync::atomic::Ordering::Relaxed);
+}
+
+/// Root walker for [`FAULTHANDLER_FILE`], registered alongside the other
+/// process-global interpreter roots.  Forwards the slot in place so a moving
+/// collection relocates the held file rather than leaving a stale address the
+/// next `enable` would compare against.
+#[cfg(all(unix, feature = "host_env"))]
+pub fn walk_fatal_error_file(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
+    let mut slot: pyre_object::PyObjectRef =
+        FAULTHANDLER_FILE.load(std::sync::atomic::Ordering::Relaxed);
+    if slot.is_null() {
+        return;
+    }
+    visitor(unsafe {
+        &mut *(&mut slot as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef)
+    });
+    FAULTHANDLER_FILE.store(slot, std::sync::atomic::Ordering::Relaxed);
+}
+
+/// No fatal-signal handlers to own a file for off the host_env unix path.
+#[cfg(not(all(unix, feature = "host_env")))]
+pub fn walk_fatal_error_file(_visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {}
+
 #[cfg(all(unix, feature = "host_env"))]
 extern "C" fn faulthandler_signal_handler(signum: libc::c_int) {
     // Stay async-signal-safe: write with raw libc::write and restore the
@@ -36,28 +75,54 @@ extern "C" fn faulthandler_signal_handler(signum: libc::c_int) {
     rustpython_host_env::faulthandler::signal_default_and_raise(signum);
 }
 
-/// `handler.py:35-49 Handler.get_fileno_and_file` — extract a fileno
-/// from a python file-or-fd-or-None argument.  None → fd 2 (stderr);
-/// int → used directly; any other object → call `.fileno()`.
-fn faulthandler_extract_fd(w_file: pyre_object::PyObjectRef) -> Result<i32, crate::PyError> {
-    if w_file.is_null() || unsafe { pyre_object::is_none(w_file) } {
-        return Ok(2);
-    }
-    if unsafe { pyre_object::is_int(w_file) } {
+/// `handler.py:35-49 Handler.get_fileno_and_file` — resolve a
+/// file-or-fd-or-None argument to `(fileno, file)`.  None resolves the CURRENT
+/// `sys.stderr` rather than a hard-coded fd 2, so a redirected stderr is
+/// honoured; an int is used directly and names no file; anything else is asked
+/// for its `fileno()` and then flushed, with an ordinary flush error ignored.
+///
+/// The returned file is the object the descriptor belongs to, and the caller
+/// parks it for as long as the handlers are installed — a null means there is
+/// nothing to own.
+fn faulthandler_get_fileno_and_file(
+    w_file: pyre_object::PyObjectRef,
+) -> Result<(i32, pyre_object::PyObjectRef), crate::PyError> {
+    let _roots = pyre_object::gc_roots::push_roots();
+    let resolved = if w_file.is_null() || unsafe { pyre_object::is_none(w_file) } {
+        let sys = crate::importing::get_sys_module("sys")
+            .ok_or_else(|| crate::PyError::runtime_error("sys.stderr is None"))?;
+        let w_stderr = crate::baseobjspace::getattr_str(sys, "stderr")?;
+        if w_stderr.is_null() || unsafe { pyre_object::is_none(w_stderr) } {
+            return Err(crate::PyError::runtime_error("sys.stderr is None"));
+        }
+        w_stderr
+    } else if unsafe { pyre_object::is_int(w_file) } {
         let fd = unsafe { pyre_object::w_int_get_value(w_file) } as i32;
         if fd < 0 {
             return Err(crate::PyError::value_error(
                 "file is not a valid file descriptor",
             ));
         }
-        return Ok(fd);
-    }
-    let method = crate::baseobjspace::getattr_str(w_file, "fileno")?;
-    let res = crate::call_function(method, &[]);
-    if res.is_null() || !unsafe { pyre_object::is_int(res) } {
+        return Ok((fd, pyre_object::PY_NULL));
+    } else {
+        w_file
+    };
+    // `fileno` and `flush` both run Python; keep the file addressable across
+    // them so the caller receives the relocated pointer, not a stale one.
+    pyre_object::gc_roots::pin_root(resolved);
+    let file_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+    let method = crate::baseobjspace::getattr_str(resolved, "fileno")?;
+    let res = crate::call::call_function_impl_result(method, &[])?;
+    if !unsafe { pyre_object::is_int(res) } {
         return Err(crate::PyError::type_error("fileno() returned non-integer"));
     }
-    Ok(unsafe { pyre_object::w_int_get_value(res) } as i32)
+    let fd = unsafe { pyre_object::w_int_get_value(res) } as i32;
+    // `handler.py:44-48` `try: file.flush() except OperationError: pass`.
+    let resolved = pyre_object::gc_roots::shadow_stack_get(file_slot);
+    if let Ok(flush) = crate::baseobjspace::getattr_str(resolved, "flush") {
+        let _ = crate::call::call_function_impl_result(flush, &[]);
+    }
+    Ok((fd, pyre_object::gc_roots::shadow_stack_get(file_slot)))
 }
 
 pub fn register_module(ns: pyre_object::PyObjectRef) {
@@ -68,10 +133,18 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             "enable",
             |args| {
                 // `handler.py:141-145 enable` — file=None, all_threads=True.
-                let fd =
-                    faulthandler_extract_fd(args.first().copied().unwrap_or(pyre_object::PY_NULL))?;
+                let (fd, w_file) = faulthandler_get_fileno_and_file(
+                    args.first().copied().unwrap_or(pyre_object::PY_NULL),
+                )?;
                 #[cfg(all(unix, feature = "host_env"))]
                 {
+                    // `set_fatal_error_file` allocates its key, so the file has
+                    // to stay addressable from here to the store below.
+                    let _roots = pyre_object::gc_roots::push_roots();
+                    let file_slot = (!w_file.is_null()).then(|| {
+                        pyre_object::gc_roots::pin_root(w_file);
+                        pyre_object::gc_roots::shadow_stack_len() - 1
+                    });
                     // `pypy_faulthandler_enable(fileno, all_threads)` takes the
                     // descriptor as an argument, so the handler never observes
                     // a descriptor the install did not commit to. Split across
@@ -88,6 +161,11 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     );
                     if ok {
                         FAULTHANDLER_ENABLED.store(true, std::sync::atomic::Ordering::Relaxed);
+                        // `handler.py:145` `self.fatal_error_w_file = w_file`.
+                        set_fatal_error_file(file_slot.map_or(
+                            pyre_object::PY_NULL,
+                            pyre_object::gc_roots::shadow_stack_get,
+                        ));
                         return Ok(pyre_object::w_none());
                     }
                     FAULTHANDLER_FD.store(previous_fd, std::sync::atomic::Ordering::Relaxed);
@@ -97,7 +175,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 }
                 #[cfg(not(all(unix, feature = "host_env")))]
                 {
-                    let _ = fd;
+                    let _ = (fd, w_file);
                     Err(crate::PyError::not_implemented(
                         "faulthandler.enable requires host_env feature",
                     ))
@@ -118,6 +196,8 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 {
                     rustpython_host_env::faulthandler::disable_fatal_handlers();
                     FAULTHANDLER_ENABLED.store(false, std::sync::atomic::Ordering::Relaxed);
+                    // `handler.py:150` `self.fatal_error_w_file = None`.
+                    set_fatal_error_file(pyre_object::PY_NULL);
                 }
                 Ok(pyre_object::w_none())
             },
@@ -189,8 +269,9 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     return Err(crate::PyError::type_error("register() missing signal"));
                 }
                 let signum = (unsafe { pyre_object::w_int_get_value(w_signum) }) as libc::c_int;
-                let fd =
-                    faulthandler_extract_fd(args.get(1).copied().unwrap_or(pyre_object::PY_NULL))?;
+                let (fd, _w_file) = faulthandler_get_fileno_and_file(
+                    args.get(1).copied().unwrap_or(pyre_object::PY_NULL),
+                )?;
                 // handler.py:174 `@unwrap_spec(all_threads=int, chain=int)`
                 // with defaults `all_threads=1, chain=0`: the arguments are
                 // coerced as integers (`gateway_int_w`, raising on a non-int),

--- a/pyre/pyre-interpreter/src/module/faulthandler/handler.rs
+++ b/pyre/pyre-interpreter/src/module/faulthandler/handler.rs
@@ -72,7 +72,16 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     faulthandler_extract_fd(args.first().copied().unwrap_or(pyre_object::PY_NULL))?;
                 #[cfg(all(unix, feature = "host_env"))]
                 {
-                    FAULTHANDLER_FD.store(fd, std::sync::atomic::Ordering::Relaxed);
+                    // `pypy_faulthandler_enable(fileno, all_threads)` takes the
+                    // descriptor as an argument, so the handler never observes
+                    // a descriptor the install did not commit to. Split across
+                    // two statements here, the new fd has to be visible before
+                    // the handlers go in — a fatal signal in between would
+                    // otherwise dump to the old one — and has to be rolled back
+                    // when the install fails, or a failed re-enable would
+                    // redirect the handlers already installed.
+                    let previous_fd =
+                        FAULTHANDLER_FD.swap(fd, std::sync::atomic::Ordering::Relaxed);
                     let ok = rustpython_host_env::faulthandler::enable_fatal_handlers(
                         faulthandler_signal_handler,
                         libc::SA_NODEFER | libc::SA_ONSTACK,
@@ -81,6 +90,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                         FAULTHANDLER_ENABLED.store(true, std::sync::atomic::Ordering::Relaxed);
                         return Ok(pyre_object::w_none());
                     }
+                    FAULTHANDLER_FD.store(previous_fd, std::sync::atomic::Ordering::Relaxed);
                     return Err(crate::PyError::runtime_error(
                         "faulthandler.enable: sigaction failed",
                     ));

--- a/pyre/pyre-interpreter/src/module/faulthandler/handler.rs
+++ b/pyre/pyre-interpreter/src/module/faulthandler/handler.rs
@@ -42,26 +42,62 @@ fn set_fatal_error_file(w_file: pyre_object::PyObjectRef) {
     FAULTHANDLER_FILE.store(w_file, std::sync::atomic::Ordering::Relaxed);
 }
 
-/// Root walker for [`FAULTHANDLER_FILE`], registered alongside the other
-/// process-global interpreter roots.  Forwards the slot in place so a moving
-/// collection relocates the held file rather than leaving a stale address the
-/// next `enable` would compare against.
+/// `handler.py:22` `self.user_w_files = None` / `:125`
+/// `self.user_w_files[signum] = w_file` / `:132`
+/// `self.user_w_files.pop(signum, None)`: `register` owns the file per signal
+/// for the same reason `enable` owns one, and `unregister` releases it.
+/// Addresses rather than `PyObjectRef` so the table is `Sync`; the walker below
+/// forwards them.  Process-global, matching one `Handler` per space, and tiny —
+/// one entry per registered signal.
 #[cfg(all(unix, feature = "host_env"))]
-pub fn walk_fatal_error_file(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
-    let mut slot: pyre_object::PyObjectRef =
-        FAULTHANDLER_FILE.load(std::sync::atomic::Ordering::Relaxed);
-    if slot.is_null() {
-        return;
+static FAULTHANDLER_USER_FILES: parking_lot::Mutex<Vec<(libc::c_int, usize)>> =
+    parking_lot::const_mutex(Vec::new());
+
+/// `handler.py:123-125` — take ownership of a registered signal's file; a null
+/// (a plain fd, which `get_fileno_and_file` answers `None` for) drops any
+/// previous owner for that signal.
+#[cfg(all(unix, feature = "host_env"))]
+fn set_user_signal_file(signum: libc::c_int, w_file: pyre_object::PyObjectRef) {
+    let mut files = FAULTHANDLER_USER_FILES.lock();
+    files.retain(|&(s, _)| s != signum);
+    if !w_file.is_null() {
+        files.push((signum, w_file as usize));
     }
-    visitor(unsafe {
-        &mut *(&mut slot as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef)
-    });
-    FAULTHANDLER_FILE.store(slot, std::sync::atomic::Ordering::Relaxed);
+}
+
+/// `handler.py:131-132` `self.user_w_files.pop(signum, None)`.
+#[cfg(all(unix, feature = "host_env"))]
+fn clear_user_signal_file(signum: libc::c_int) {
+    FAULTHANDLER_USER_FILES.lock().retain(|&(s, _)| s != signum);
+}
+
+/// Root walker for the two file-owner tables, registered alongside the other
+/// process-global interpreter roots.  Forwards each slot in place so a moving
+/// collection relocates the held file rather than leaving a stale address the
+/// installed handler would keep writing through.
+#[cfg(all(unix, feature = "host_env"))]
+pub fn walk_faulthandler_roots(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
+    let mut forward = |addr: usize| -> usize {
+        let mut slot: pyre_object::PyObjectRef = addr as pyre_object::PyObjectRef;
+        // SAFETY: `PyObjectRef` and `GcRef` are layout-compatible.
+        visitor(unsafe { &mut *(&mut slot as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef) });
+        slot as usize
+    };
+    let fatal = FAULTHANDLER_FILE.load(std::sync::atomic::Ordering::Relaxed);
+    if !fatal.is_null() {
+        FAULTHANDLER_FILE.store(
+            forward(fatal as usize) as pyre_object::PyObjectRef,
+            std::sync::atomic::Ordering::Relaxed,
+        );
+    }
+    for entry in FAULTHANDLER_USER_FILES.lock().iter_mut() {
+        entry.1 = forward(entry.1);
+    }
 }
 
 /// No fatal-signal handlers to own a file for off the host_env unix path.
 #[cfg(not(all(unix, feature = "host_env")))]
-pub fn walk_fatal_error_file(_visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {}
+pub fn walk_faulthandler_roots(_visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {}
 
 #[cfg(all(unix, feature = "host_env"))]
 extern "C" fn faulthandler_signal_handler(signum: libc::c_int) {
@@ -117,11 +153,31 @@ fn faulthandler_get_fileno_and_file(
         return Err(crate::PyError::type_error("fileno() returned non-integer"));
     }
     let fd = unsafe { pyre_object::w_int_get_value(res) } as i32;
-    // `handler.py:44-48` `try: file.flush() except OperationError: pass`.
-    let resolved = pyre_object::gc_roots::shadow_stack_get(file_slot);
-    if let Ok(flush) = crate::baseobjspace::getattr_str(resolved, "flush") {
-        let _ = crate::call::call_function_impl_result(flush, &[]);
+    if fd < 0 {
+        // `handler.py:42` hands the value straight to
+        // `pypy_faulthandler_enable`, and PyPy accepts a negative descriptor
+        // (measured: `enable()` succeeds); 3.14 rejects it, with a message
+        // naming `fileno()` to distinguish it from the direct-int arm above.
+        return Err(crate::PyError::runtime_error(
+            "file.fileno() is not a valid file descriptor",
+        ));
     }
+    // `handler.py:44-48`:
+    //
+    //     try:
+    //         space.call_method(w_file, 'flush')
+    //     except OperationError as e:
+    //         if e.async(space):
+    //             raise
+    //         pass   # ignore flush() error
+    //
+    // 3.14 clears the flush error unconditionally instead, so a `SystemExit`
+    // raised out of `flush` does NOT abort `enable` there (measured on 3.14.5
+    // and on PyPy: they disagree, and 3.14 is the behaviour target).  Ignore
+    // every flush failure, including an asynchronous one.
+    let resolved = pyre_object::gc_roots::shadow_stack_get(file_slot);
+    let _ = crate::baseobjspace::getattr_str(resolved, "flush")
+        .and_then(|flush| crate::call::call_function_impl_result(flush, &[]));
     Ok((fd, pyre_object::gc_roots::shadow_stack_get(file_slot)))
 }
 
@@ -133,11 +189,15 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             "enable",
             |args| {
                 // `handler.py:141-145 enable` — file=None, all_threads=True.
-                let (fd, w_file) = faulthandler_get_fileno_and_file(
-                    args.first().copied().unwrap_or(pyre_object::PY_NULL),
-                )?;
+                // Resolving the argument runs a user `fileno()` and `flush()`;
+                // keep those side effects behind the support gate, so a build
+                // that can only answer NotImplementedError does not run them
+                // first.
                 #[cfg(all(unix, feature = "host_env"))]
                 {
+                    let (fd, w_file) = faulthandler_get_fileno_and_file(
+                        args.first().copied().unwrap_or(pyre_object::PY_NULL),
+                    )?;
                     // `set_fatal_error_file` allocates its key, so the file has
                     // to stay addressable from here to the store below.
                     let _roots = pyre_object::gc_roots::push_roots();
@@ -175,7 +235,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 }
                 #[cfg(not(all(unix, feature = "host_env")))]
                 {
-                    let _ = (fd, w_file);
+                    let _ = args;
                     Err(crate::PyError::not_implemented(
                         "faulthandler.enable requires host_env feature",
                     ))
@@ -269,9 +329,6 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     return Err(crate::PyError::type_error("register() missing signal"));
                 }
                 let signum = (unsafe { pyre_object::w_int_get_value(w_signum) }) as libc::c_int;
-                let (fd, _w_file) = faulthandler_get_fileno_and_file(
-                    args.get(1).copied().unwrap_or(pyre_object::PY_NULL),
-                )?;
                 // handler.py:174 `@unwrap_spec(all_threads=int, chain=int)`
                 // with defaults `all_threads=1, chain=0`: the arguments are
                 // coerced as integers (`gateway_int_w`, raising on a non-int),
@@ -296,6 +353,22 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     != 0;
                 #[cfg(all(unix, feature = "host_env"))]
                 {
+                    // Resolving the file runs a user `fileno()` and `flush()`.
+                    // `register(signum, file, all_threads, chain)` parses and
+                    // coerces the two integer arguments before touching the
+                    // file, and a build that can only answer NotImplementedError
+                    // must not run those side effects at all — so this sits
+                    // after the coercions above and inside the support gate.
+                    let (fd, w_file) = faulthandler_get_fileno_and_file(
+                        args.get(1).copied().unwrap_or(pyre_object::PY_NULL),
+                    )?;
+                    // `set_user_signal_file` allocates, so keep the file
+                    // addressable from here to the store below.
+                    let _roots = pyre_object::gc_roots::push_roots();
+                    let file_slot = (!w_file.is_null()).then(|| {
+                        pyre_object::gc_roots::pin_root(w_file);
+                        pyre_object::gc_roots::shadow_stack_len() - 1
+                    });
                     rustpython_host_env::faulthandler::register_user_signal(
                         signum,
                         fd,
@@ -309,11 +382,20 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                             format!("register: {e}"),
                         )
                     })?;
+                    // `handler.py:123-125` `self.user_w_files[signum] = w_file`,
+                    // after `check_err` — a register that failed owns nothing.
+                    set_user_signal_file(
+                        signum,
+                        file_slot.map_or(
+                            pyre_object::PY_NULL,
+                            pyre_object::gc_roots::shadow_stack_get,
+                        ),
+                    );
                     return Ok(pyre_object::w_none());
                 }
                 #[cfg(not(all(unix, feature = "host_env")))]
                 {
-                    let _ = (fd, all_threads, chain);
+                    let _ = (signum, all_threads, chain);
                     Err(crate::PyError::not_implemented(
                         "faulthandler.register requires host_env feature",
                     ))
@@ -340,9 +422,12 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                         return Err(crate::PyError::type_error("unregister() missing signal"));
                     }
                     let signum = (unsafe { pyre_object::w_int_get_value(args[0]) }) as libc::c_int;
-                    return Ok(pyre_object::w_bool_from(
-                        rustpython_host_env::faulthandler::unregister_user_signal(signum),
-                    ));
+                    let changed =
+                        rustpython_host_env::faulthandler::unregister_user_signal(signum);
+                    // `handler.py:131-132` `self.user_w_files.pop(signum, None)`,
+                    // run whether or not the signal was registered.
+                    clear_user_signal_file(signum);
+                    return Ok(pyre_object::w_bool_from(changed));
                 }
                 #[cfg(not(all(unix, feature = "host_env")))]
                 {

--- a/pyre/pyre-interpreter/src/module/sys/vm.rs
+++ b/pyre/pyre-interpreter/src/module/sys/vm.rs
@@ -2055,15 +2055,16 @@ fn stdio_stdin_readline(args: &[PyObjectRef]) -> crate::PyResult {
 ///
 /// The `__std*__` aliases name the streams this built even after user code
 /// rebinds `sys.stdout`; a rebound one is not this function's to reconfigure.
-pub fn init_stream_codecs() {
+pub fn init_stream_codecs() -> Result<(), crate::PyError> {
     let Some(sys) = crate::importing::get_sys_module("sys") else {
-        return;
+        return Ok(());
     };
     for name in ["__stdout__", "__stderr__", "__stdin__"] {
         if let Ok(stream) = crate::baseobjspace::getattr_str(sys, name) {
-            crate::module::_io::W_TextIOWrapper::attach_stdio_codec(stream);
+            crate::module::_io::W_TextIOWrapper::attach_stdio_codec(stream)?;
         }
     }
+    Ok(())
 }
 
 fn make_std_stream(name: &'static str, fd: i32) -> PyObjectRef {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
@@ -52,6 +52,23 @@ pub(crate) fn fbw_max_multiframe_depth() -> usize {
 /// `opimpl_recursive_call` (`pyjitpl.py:1390-1402`) counting the portal frames
 /// already on `MetaInterp.framestack` before comparing against
 /// `max_unroll_recursion`.
+///
+/// Upstream compares the whole greenkey element-wise (`pyjitpl.py:1396-1401`
+/// `gk[i].same_constant(greenboxes[i])`) over `(next_instr, is_being_profiled,
+/// bytecode)` (`interp_jit.py:34`); matching `w_code` alone is that comparison,
+/// because every entry this scan can see carries `next_instr == 0`:
+///
+/// * `MIFrame.setup` (`pyjitpl.py:74-80`) assigns `greenkey` once and never
+///   updates it, so a frame's greenkey stays its ENTRY greens however far its
+///   pc has since advanced;
+/// * every [`InlineFrame`] is pushed by `InlineFrameGuard::enter` at a callee
+///   entry, and the bridge-reconstructed frames stamp the same `(w_code, 0)`
+///   identity (`state.rs` `reconstruct_inline_recipe`).
+///
+/// The root frame is deliberately absent from this framestack, which is also
+/// what upstream's greenkey compare achieves: the root's greenkey holds the
+/// merge-point pc, so it fails `same_constant` against a call's `next_instr ==
+/// 0` greens and is not counted either.
 pub(crate) fn fbw_inline_recursion_count<Sym: WalkSym>(
     ctx: &WalkContext<'_, '_, Sym>,
     w_code: usize,

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -8659,17 +8659,6 @@ pub fn try_function_entry_jit(frame: &mut PyFrame) -> Option<PyResult> {
     if stack_almost_full() {
         return None;
     }
-    // `compile_and_run_once` traces, runs the backend compiler, and then enters
-    // the code it just produced, all in native frames no `stack_check()` ever
-    // saw.  Upstream's backend is a few RPython frames and stays well inside the
-    // budget, so it marks only the sub-regions where an interruption would leave
-    // dangling state (`compile.py:976`, `pyjitpl.py:3305`, `resume.py:1318`);
-    // Cranelift's is an optimizing compiler measuring ~1.2 MB against a 768 KB
-    // budget, so the prologue probe of the code being entered reports an
-    // overflow at a Python call depth of 2.  `report_error = 0` for the region
-    // is what `stack.h:42-43` is for — a real overflow still surfaces from the
-    // interpreter once the region exits.
-    let _cc_guard = majit_metainterp::CriticalCodeGuard::enter();
     let env = PyreEnv;
     if majit_metainterp::majit_log_enabled() {
         eprintln!(

--- a/pyre/pyre-object/src/tupleobject.rs
+++ b/pyre/pyre-object/src/tupleobject.rs
@@ -191,9 +191,27 @@ pub fn w_tuple_new_array_backed(items: Vec<PyObjectRef>) -> PyObjectRef {
     // the items-block allocation and the write barrier below. Publish it
     // immediately; in a free-threaded run either operation may park behind a
     // foreign collector even though the address is old-gen and non-moving.
+    //
+    // The allocator hands back UNINITIALIZED payload, and once the root is
+    // published `tuple_object_custom_trace` may read `ob_header.w_class` and
+    // `wrappeditems` off it at any parking point.  Write both slots first, with
+    // a null items block — the state the trace hook already returns early on —
+    // and install the real block below.
     let raw_slot = if raw.is_null() {
         None
     } else {
+        unsafe {
+            std::ptr::write(
+                raw as *mut W_TupleObject,
+                W_TupleObject {
+                    ob_header: PyObject {
+                        ob_type: header.ob_type,
+                        w_class: header.w_class,
+                    },
+                    wrappeditems: std::ptr::null_mut(),
+                },
+            );
+        }
         crate::gc_roots::pin_root(raw as PyObjectRef);
         Some(crate::gc_roots::shadow_stack_len() - 1)
     };
@@ -213,14 +231,10 @@ pub fn w_tuple_new_array_backed(items: Vec<PyObjectRef>) -> PyObjectRef {
         .unwrap_or(std::ptr::null_mut()) as *mut u8;
 
     if !raw.is_null() {
+        // The header went in before the root was published; only the items
+        // block is still outstanding.
         unsafe {
-            std::ptr::write(
-                raw as *mut W_TupleObject,
-                W_TupleObject {
-                    ob_header: header,
-                    wrappeditems: items_block,
-                },
-            );
+            (*(raw as *mut W_TupleObject)).wrappeditems = items_block;
         }
         // The tuple lives in old-gen (`try_gc_alloc_stable`); its items
         // may still be in the nursery. The element pointers are stored in

--- a/pyre/pyrex/src/lib.rs
+++ b/pyre/pyrex/src/lib.rs
@@ -1114,8 +1114,11 @@ pub(crate) fn init_importlib_bootstrap(
     // standard streams can reach a text codec from here on.  A failed
     // bootstrap leaves the native importer serving imports, so the codec is
     // still reachable and the streams still want it.
-    pyre_interpreter::module::sys::vm::init_stream_codecs();
-    bootstrapped
+    let stream_codecs = pyre_interpreter::module::sys::vm::init_stream_codecs();
+    // A bootstrap failure is the more fundamental of the two, so it wins;
+    // otherwise a codec the streams could not build is reported rather than
+    // leaving a stream that reports itself unreadable.
+    bootstrapped.and(stream_codecs)
 }
 
 fn bootstrap_importlib_modules(


### PR DESCRIPTION
Follow-up to #887, acting on the automated review findings that landed on it after the merge.

## Removed

- **`CriticalCodeGuard` in the `bound_reached` compile path** (`pyre-jit/src/eval.rs`). It spanned the whole trace-compile-and-dispatch region, so `report_error = 0` covered the walk's residual calls into user code — `stack.c:111` returns that flag in place of the overflow verdict, turning a `RecursionError` into an unreported native overflow. Upstream marks only regions that run no user code (`compile.py:976`, `pyjitpl.py:3305`, `resume.py:1318`). Measured on the fixture it was added for, `synth/wasm_ca_trampoline_decline`: with the guard suppressed the overflow no longer occurs at all, so the region is inert.
- **The `type_id == 9` backtrace capture** in `remember_young_pointer`.

## GC correctness

- **`w_tuple_new_array_backed` published an uninitialized tuple.** `try_gc_alloc_stable_raw` returns uninitialized payload and `tuple_object_custom_trace` reads `ob_header.w_class` and `wrappeditems`, so a collection between `pin_root` and the items-block allocation read garbage. The header now goes in first with a null items block — the state the trace hook returns early on — and the block is stored after.
- **`W_TextIOWrapper` published its reference fields with one barrier at the end of `attach_buffer`**, but every `w_str_new` in between allocates and `set_newline` / `getattr_str` / `set_encoder_decoder` run Python. Barrier after each reference store instead.
- **`OwnerRootGuard` was auto-`Send`.** Its `index` names a slot in the acquiring thread's `OWNER_ROOTS`; a `PhantomData<*mut ()>` pins it to that thread at compile time.

## Error handling

- **`attach_stdio_codec` dropped both the codec lookup and the encoder/decoder construction errors**, leaving a stream that reports itself unreadable however readable its buffer is. `init_stream_codecs` and `init_importlib_bootstrap` now propagate; a bootstrap failure still wins as the more fundamental one.
- **`allocate_stdio`** still cannot propagate — it runs inside `sys` module creation — but no longer discards the result blind: it finishes the two fields the early return skipped instead of forcing `STATE_OK` over a half-applied init.
- **`faulthandler.enable` restores `FAULTHANDLER_FD`** when `enable_fatal_handlers` fails; a failed re-enable was redirecting the handlers already installed.

## faulthandler file ownership

`enable` resolved `file=None` to a hard-coded fd 2 and dropped the file object. `get_fileno_and_file` (`handler.py:35-49`) resolves the *current* `sys.stderr`, asks it for `fileno()`, and flushes it ignoring an ordinary flush error; `enable` then parks it as `fatal_error_w_file` (`:145`) and `disable` clears it (`:150`), because the descriptor the installed handler writes to belongs to that object. pyre has no Handler instance, so the owner is a process-global slot walked as a GC root alongside the other interpreter globals — not a module attribute, which would show up in `dir(faulthandler)` where upstream has none.

## Performance

`acquire_owner_root` scanned `OWNER_ROOTS` from 0 for a free slot, so rooting the frames of a recursion `depth` deep cost O(depth²). Released interior slots now go on a free stack; a released tail still shrinks the walked range.

## Documentation

Recorded why `fbw_inline_recursion_count` matching `w_code` alone *is* the element-wise greenkey compare of `pyjitpl.py:1396-1401`: `MIFrame.setup` (`pyjitpl.py:74-80`) assigns `greenkey` once, so a frame's greenkey stays its entry greens, and every `InlineFrame` is pushed at a callee entry with the `(w_code, 0)` identity `reconstruct_inline_recipe` also stamps. Codex had flagged this as a mismatch; it is not one.

## Verification

```
ALL PASSED: dynasm 345/345
ALL PASSED: wasm   341/341
FAILED:     cranelift 1 failed, 344 passed
```

`cargo test`: pyre-interpreter 432 passed, majit-gc 215 passed.

The one cranelift failure, `synth/mutate_then_raise_caught`, panics in `collector.rs` (`minor_custom_trace_target`, invalid type_id). It reproduces 3/3 on a rebuild of `main` with none of these changes applied, and passes on the Linux CI runner — it is a pre-existing macOS-only failure, not introduced here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved garbage collection reliability when managing interpreter and stream references.
  - Fixed faulthandler file ownership and signal-handler behavior, including safer file descriptor validation.
  - Improved tuple initialization safety during garbage collection.
  - Prevented stream codec setup errors from being silently ignored.

- **Reliability**
  - Interpreter startup now reports failures when standard stream codecs cannot be initialized.
  - Improved reuse and cleanup of internal root slots for more consistent runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->