### PR TITLE
interp: remove duplicate interp_return_log_enabled definition

### DIFF
--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -610,15 +610,6 @@ fn gc_prebuilt_remember_enabled() -> bool {
     })
 }
 
-/// Whether the per-return diagnostic dump is enabled
-/// (`PYRE_INTERP_RETURN_LOG`). The probe sits on the RETURN_VALUE path, so an
-/// uncached read would pay a `getenv` on every Python return.
-#[cfg(not(feature = "sandbox"))]
-fn interp_return_log_enabled() -> bool {
-    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *ENABLED.get_or_init(|| std::env::var_os("PYRE_INTERP_RETURN_LOG").is_some())
-}
-
 pub fn capture_pyframe_root_area() -> *const () {
     PYFRAME_ROOT_AREA.with(|area| area as *const _ as *const ())
 }


### PR DESCRIPTION
## Problem

`main`'s `pyre CI` fails at **prepare Charon/LLBC on all three OS** (run [30564467242](https://github.com/youknowone/pyre/actions/runs/30564467242) on `25b2442c4e`); every downstream JIT job is skipped because LLBC extraction is a prerequisite. The Charon `cargo --ullbc` compile of `pyre-interpreter` exits 101 with:

```
error[E0428]: the name `interp_return_log_enabled` is defined multiple times
```

Two identical `#[cfg(not(feature = "sandbox"))]` definitions of `interp_return_log_enabled` landed in `pyre/pyre-interpreter/src/eval.rs` (a merge artifact — the cached-`getenv` helper was added on two lines). Under any non-sandbox build both are active, so the crate does not compile and LLBC extraction dies.

## Fix

Drop the second copy. The kept definition is byte-identical, so behavior is unchanged; this only removes the duplicate name.

```
1 file changed, 9 deletions(-)
```

— *created by Claude*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified internal interpreter instrumentation without changing public APIs or application behavior.
  - Existing return logging functionality remains available through its supported implementation path.
  - No user-facing features, workflows, or configuration options were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->