### PR TITLE
majit: carry _immutable_fields_ through ullbc and fold w_class past forcing (append loop 45 → 31 ops)

### DIFF
--- a/majit/majit-macros/src/lib.rs
+++ b/majit/majit-macros/src/lib.rs
@@ -1523,21 +1523,75 @@ fn parse_release_gil_save_err(attr: proc_macro2::TokenStream) -> syn::Result<i32
 ///
 /// Usage:
 /// ```ignore
-/// #[majit_macros::jit_immutable_fields(pools)]
+/// #[majit_macros::jit_immutable_fields("pools", "size?", "digits[*]")]
 /// pub struct Storage {
 ///     pub pools: [*mut Stack; STORAGE_COUNT],
 ///     ...
 /// }
 /// ```
 ///
-/// The proc-macro is a pass-through: it leaves the struct definition
-/// untouched and exists solely so `rustc` accepts the attribute. The
-/// codewriter front-end reads the struct's field list from the lowered
-/// MIR type metadata (`majit-translate::front::mir` `struct_field_attrs`)
-/// and feeds it into the struct layout / descr pipeline.
+/// Entries carry the `rclass.py:644-678 _parse_field_list` suffixes
+/// (`?` quasi-immutable, `[*]` immutable array); a bare identifier is
+/// accepted as shorthand for a plain immutable field.
+///
+/// The struct definition itself is left untouched.  Like the other
+/// `majit_macros` attributes, the attribute is consumed at expansion
+/// time and does not survive in Charon's `attr_info`, so the macro
+/// leaves a `#[doc(hidden)]` marker const
+/// `_immutable_fields_<Struct>: &str` next to the struct holding the
+/// comma-joined entry list.  Charon extracts it into `global_decls`,
+/// and `majit-translate::front::llbc_hints::
+/// harvest_immutable_fields_from_llbcs` reads it back into
+/// `SemanticProgram.immutable_fields` — the analog of RPython's
+/// translator reading `cls._immutable_fields_` off the class object.
 #[proc_macro_attribute]
-pub fn jit_immutable_fields(_attr: TokenStream, item: TokenStream) -> TokenStream {
-    item
+pub fn jit_immutable_fields(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let entries = parse_macro_input!(attr as ImmutableFieldList);
+    let item_struct = parse_macro_input!(item as syn::ItemStruct);
+    let vis = &item_struct.vis;
+    let const_name = format_ident!("_immutable_fields_{}", item_struct.ident);
+    // `rclass.py:644-678 _parse_field_list` splits the declared list into
+    // (name, rank) pairs; the marker carries the list verbatim and the
+    // harvester does the splitting, so the suffix grammar stays in one
+    // place (`majit_translate::model::ImmutableRank::parse`).
+    let joined = entries.0.join(",");
+    quote! {
+        #item_struct
+
+        #[doc(hidden)]
+        #[allow(non_upper_case_globals, dead_code)]
+        #vis const #const_name: &'static str = #joined;
+    }
+    .into()
+}
+
+/// `_immutable_fields_` entry list as written in the attribute —
+/// either string literals (`"size?"`, `"digits[*]"`) or bare
+/// identifiers for plain immutable fields.
+struct ImmutableFieldList(Vec<String>);
+
+impl Parse for ImmutableFieldList {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let mut entries = Vec::new();
+        while !input.is_empty() {
+            if input.peek(syn::LitStr) {
+                entries.push(input.parse::<syn::LitStr>()?.value());
+            } else {
+                entries.push(input.parse::<Ident>()?.to_string());
+            }
+            if input.is_empty() {
+                break;
+            }
+            input.parse::<Token![,]>()?;
+        }
+        if entries.is_empty() {
+            return Err(syn::Error::new(
+                proc_macro2::Span::call_site(),
+                "#[jit_immutable_fields] needs at least one field entry",
+            ));
+        }
+        Ok(Self(entries))
+    }
 }
 
 /// Mark a method (or free function) as elidable / pure.

--- a/majit/majit-metainterp/src/box_trace.rs
+++ b/majit/majit-metainterp/src/box_trace.rs
@@ -130,7 +130,7 @@ pub fn trace_box_int(
     size_descr: majit_ir::DescrRef,
     _ob_type_descr: majit_ir::DescrRef,
     intval_descr: majit_ir::DescrRef,
-    _int_type_addr: i64,
+    int_type_addr: i64,
 ) -> majit_ir::OpRef {
     use majit_ir::OpCode;
 
@@ -140,7 +140,13 @@ pub fn trace_box_int(
     // jtransform.py:908-911 parity: typeptr setfield filtered in trace.
     // rewrite.py:479-484 GC rewriter emits vtable via fielddescr_vtable.
     let obj = ctx.record_op_with_descr(OpCode::NewWithVtable, &[], size_descr);
+    // pyjitpl.py:2714-2718 `execute_new_with_vtable` stamps BOTH halves —
+    // `heapcache.new(resbox)` AND `heapcache.class_now_known(resbox)`; only
+    // plain `execute_new` (:2720-2723) stops at `new`. The vtable the GC
+    // rewriter writes from `size_descr` IS the class, so it is known by
+    // construction and upstream records it unconditionally.
     ctx.heap_cache_mut().new_object(obj);
+    ctx.heap_cache_mut().class_now_known(obj, int_type_addr);
     let intval_idx = intval_descr.index();
     ctx.record_op_with_descr(OpCode::SetfieldGc, &[obj, value], intval_descr);
     // `upd.setfield(valuebox)` parity — the cache stores the Box
@@ -390,13 +396,16 @@ pub fn trace_box_float(
     size_descr: majit_ir::DescrRef,
     _ob_type_descr: majit_ir::DescrRef,
     floatval_descr: majit_ir::DescrRef,
-    _float_type_addr: i64,
+    float_type_addr: i64,
 ) -> majit_ir::OpRef {
     use majit_ir::OpCode;
     // RPython parity: NEW_WITH_VTABLE + jtransform.py typeptr filter +
     // rewrite.py GC rewriter fielddescr_vtable emission.
     let obj = ctx.record_op_with_descr(OpCode::NewWithVtable, &[], size_descr);
+    // pyjitpl.py:2714-2718: `execute_new_with_vtable` records the class too.
+    // Same reasoning as `trace_box_int`.
     ctx.heap_cache_mut().new_object(obj);
+    ctx.heap_cache_mut().class_now_known(obj, float_type_addr);
     let floatval_idx = floatval_descr.index();
     ctx.record_op_with_descr(OpCode::SetfieldGc, &[obj, value], floatval_descr);
     // `upd.setfield(valuebox)` parity — the cache stores the Box

--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -2091,6 +2091,20 @@ impl OptHeap {
         // canonical OpRef.
         let obj = ctx.get_replacement_opref(raw_obj);
         let _ = ctx.ensure_ptr_info_arg0(op);
+        // heap.py:649 `cf = self.field_cache(descr)` — get-or-CREATE
+        // (heap.py:392-397), so the aliasing check and the cache consult below
+        // run even for a descr this pass has not touched yet.
+        //
+        // That matters at the head of the peeled loop, where every
+        // `cached_fields` entry starts empty while the imported short box's
+        // `PreambleOp` already sits on the STRUCT's ptr_info (`_getfield` reads
+        // `info.getfield(field_idx)`). Looking the cache up read-only skipped
+        // the `FieldEntry::Preamble` arm for every first-touch field, so
+        // `force_op_from_preamble_op` — and with it `use_box`, which appends the
+        // re-executed op to the short preamble — never ran: `used_boxes` and
+        // the short jump args stayed empty and the peeled LABEL never grew the
+        // hoisted field slots.
+        self.field_cache(&descr);
         let mut force_lazy = false;
         if let Some(cf) = self.get_cached_field(&descr) {
             if let Some(lazy_op) = &cf.lazy_set {
@@ -3926,6 +3940,16 @@ mod tests {
         fn get_parent_descr(&self) -> Option<DescrRef> {
             Some(test_parent_descr())
         }
+        // The declared `offset()` already places this descr at slot `index` of
+        // `test_parent_descr()`; `index_in_parent` must agree, because
+        // `info.py:212-214 _fields[fielddescr.get_index()]` indexes the
+        // struct's PtrInfo by it. Leaving the trait default (0) made every
+        // fixture descr claim slot 0 of the SAME parent, so two distinct
+        // descrs aliased one PtrInfo field slot — a layout no real struct can
+        // have.
+        fn index_in_parent(&self) -> usize {
+            self.index as usize
+        }
         fn offset(&self) -> usize {
             self.index as usize * 8
         }
@@ -4003,6 +4027,10 @@ mod tests {
     impl FieldDescr for ImmutableDescr {
         fn get_parent_descr(&self) -> Option<DescrRef> {
             Some(test_parent_descr())
+        }
+        // See TestDescr::index_in_parent.
+        fn index_in_parent(&self) -> usize {
+            self.index as usize
         }
         fn offset(&self) -> usize {
             self.index as usize * 8

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -4070,14 +4070,40 @@ impl OptUnroll {
             }
         }
 
-        // RPython: get_box_replacement follows forwarding after mapping
-        current_short_jump_args(short_preamble, ctx)
-            .iter()
-            .map(|&jump_arg| {
-                let mapped = mapping.get(&jump_arg).copied().unwrap_or(jump_arg);
-                ctx.get_replacement_opref(mapped)
-            })
-            .collect()
+        // unroll.py:438-439 `return [get_box_replacement(box) for box in
+        // self._map_args(mapping, short_jump_args)]`.
+        //
+        // `_map_args` (unroll.py:364-370) is STRICT for non-Const boxes:
+        // `box = mapping[box]` raises KeyError when the short op that produces
+        // this jump arg was never replayed into the peeled body. Substituting
+        // the unmapped arg instead hands the JUMP the PREAMBLE's box — the
+        // loop-entry value — so the back edge re-supplies the entry value every
+        // iteration and a field the body mutates reads as loop-invariant. Treat
+        // it as the InvalidLoop that KeyError amounts to and fall back to
+        // jump_to_preamble; the loop still compiles, it just declines to inline
+        // this short preamble.
+        let final_jump_args = current_short_jump_args(short_preamble, ctx);
+        let mut mapped_args = Vec::with_capacity(final_jump_args.len());
+        for jump_arg in final_jump_args {
+            if jump_arg.is_constant() {
+                mapped_args.push(ctx.get_replacement_opref(jump_arg));
+                continue;
+            }
+            let Some(&mapped) = mapping.get(&jump_arg) else {
+                if crate::optimizeopt::majit_log_enabled() {
+                    eprintln!(
+                        "[jit] inline_short_preamble: unmapped short jump arg {jump_arg:?} \
+                         (short op never replayed into the peeled body) — InvalidLoop"
+                    );
+                }
+                ctx.signal_invalid_loop(
+                    "inline_short_preamble: unmapped short jump arg at end of inlining",
+                );
+                return Vec::new();
+            };
+            mapped_args.push(ctx.get_replacement_opref(mapped));
+        }
+        mapped_args
     }
 
     /// unroll.py:479-504 import_state — line-by-line port.

--- a/majit/majit-metainterp/src/optimizeopt/virtualize.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualize.rs
@@ -893,6 +893,67 @@ impl OptVirtualize {
                     // rather than mis-indexing a value field.
                     return OptimizationResult::PassOn;
                 }
+                // Same resolution once the allocation has been forced.
+                // `info.py:152 force_box` keeps the SAME info object and only
+                // clears `_is_virtual`, so `info.py:324 get_known_class` still
+                // answers afterwards; pyre reproduces that by installing
+                // `PtrInfo::Instance` carrying the virtual's `descr` and
+                // `known_class` (info.rs:1113-1118). Without this arm the class
+                // is known but unusable the moment the allocation escapes, and
+                // every later header read re-emits with its guard.
+                //
+                // The slot is looked up the same way as the virtual arm above —
+                // through the layout's own `w_class` field descr, never through
+                // the read descr's index, which for a parent-bearing spelling is
+                // `index_in_parent == 0` and would alias the first value field.
+                if let PtrInfo::Instance(ref iinfo) = info {
+                    let stored = iinfo
+                        .descr
+                        .as_ref()
+                        .and_then(|d| d.as_size_descr())
+                        .and_then(|sd| {
+                            sd.all_fielddescrs()
+                                .iter()
+                                .find(|fd| fd.is_w_class())
+                                .map(|fd| fd.index_in_parent() as u32)
+                        })
+                        .and_then(|widx| {
+                            iinfo
+                                .fields
+                                .iter()
+                                .find(|(idx, _)| *idx == widx)
+                                .map(|(_, e)| e)
+                        });
+                    match stored {
+                        // A recorded write wins over the descr's canonical
+                        // class, exactly as the virtual arm prefers `stored`.
+                        Some(crate::optimizeopt::info::FieldEntry::Value(b_val)) => {
+                            let b_old = Operand::from_bound_op(op_rc);
+                            let b_val = ctx.get_box_replacement_operand(b_val.to_opref());
+                            ctx.make_equal_to(&b_old, &b_val);
+                            return OptimizationResult::Remove;
+                        }
+                        // Not a value yet — leave the read alone rather than
+                        // folding past the pending preamble op.
+                        Some(crate::optimizeopt::info::FieldEntry::Preamble(_)) => {}
+                        None => {
+                            if let Some(w_class) = iinfo
+                                .descr
+                                .as_ref()
+                                .and_then(|d| d.as_size_descr())
+                                .and_then(|sd| sd.w_class_obj())
+                                .filter(|&w| w != 0)
+                            {
+                                let b = ctx.materialize_operand_at(op.pos.get());
+                                ctx.make_constant_box(
+                                    &b,
+                                    majit_ir::Value::Ref(majit_ir::GcRef(w_class as usize)),
+                                );
+                                return OptimizationResult::Remove;
+                            }
+                        }
+                    }
+                }
             }
             let field_val = match &info {
                 PtrInfo::Virtual(vinfo) => get_field(&vinfo.fields, field_idx),

--- a/majit/majit-translate/src/front/llbc_hints.rs
+++ b/majit/majit-translate/src/front/llbc_hints.rs
@@ -142,6 +142,79 @@ pub fn harvest_hints_from_llbcs(llbcs: &[Llbc]) -> HashMap<String, Vec<String>> 
     out
 }
 
+/// Marker-const prefix `#[jit_immutable_fields]` leaves next to the
+/// annotated struct.  The const leaf with the prefix stripped is the
+/// struct name; the value is the comma-joined entry list.
+const IMMUTABLE_FIELDS_PREFIX: &str = "_immutable_fields_";
+
+/// Build a `{struct_name → [(field_name, rank)]}` map from the
+/// `_immutable_fields_<Struct>` marker consts present in `llbcs`.
+///
+/// RPython reads `cls._immutable_fields_` off the class object
+/// (`rclass.py:644-678 _parse_field_list`); the marker const is the
+/// ullbc-visible carrier for the same declaration, since the
+/// proc-macro attribute is consumed at expansion time and never
+/// reaches Charon's `attr_info`.
+///
+/// Both the bare struct name and the crate-stripped qualified path are
+/// inserted, mirroring `SemanticProgram.struct_fields`: the codewriter
+/// looks the declaration up by the analyzer's `owner_root`, which is
+/// the bare use-site identifier today and the qualified path once the
+/// use-import resolver lands.
+pub fn harvest_immutable_fields_from_llbcs(
+    llbcs: &[Llbc],
+) -> HashMap<String, Vec<(String, crate::model::ImmutableRank)>> {
+    let mut out: HashMap<String, Vec<(String, crate::model::ImmutableRank)>> = HashMap::new();
+    for llbc in llbcs {
+        for gd in llbc.iter_global_decls() {
+            let path = gd.item_meta.name_path();
+            let leaf = path.rsplit("::").next().unwrap_or(path.as_str());
+            let Some(struct_name) = leaf.strip_prefix(IMMUTABLE_FIELDS_PREFIX) else {
+                continue;
+            };
+            // Fail fast like the `oopspec_` arm: the macro emits a literal
+            // string, so an undecodable initializer is a marker
+            // encoding/decoder drift, not an absent declaration.  Silently
+            // dropping it would quietly demote every listed field back to
+            // mutable.
+            let joined = global_marker_str(llbc, gd).unwrap_or_else(|| {
+                panic!(
+                    "_immutable_fields_ marker `{path}` has an undecodable string \
+                     initializer; this signals a marker encoding/decoder drift"
+                )
+            });
+            let fields = parse_immutable_entry_list(&joined);
+            if fields.is_empty() {
+                continue;
+            }
+            let qualified = {
+                let stripped = strip_crate_prefix(&path);
+                match stripped.rsplit_once("::") {
+                    Some((module, _)) => format!("{module}::{struct_name}"),
+                    None => struct_name.to_string(),
+                }
+            };
+            for key in [struct_name.to_string(), qualified] {
+                out.entry(key).or_insert_with(|| fields.clone());
+            }
+        }
+    }
+    out
+}
+
+/// Split the marker's comma-joined payload into `(field_name, rank)`
+/// pairs — `rclass.py:644-678 _parse_field_list` over the declared
+/// `_immutable_fields_` list.  The suffix grammar lives entirely in
+/// [`crate::model::ImmutableRank::parse`].
+fn parse_immutable_entry_list(joined: &str) -> Vec<(String, crate::model::ImmutableRank)> {
+    joined
+        .split(',')
+        .map(str::trim)
+        .filter(|entry| !entry.is_empty())
+        .map(crate::model::ImmutableRank::parse)
+        .collect()
+}
+
 fn should_skip_generated_elidable_helper(fn_name: &str) -> bool {
     fn_name.starts_with("_orig_") && fn_name.ends_with("_unlikely_name")
 }
@@ -310,7 +383,8 @@ fn decode_bool_const(value: &serde_json::Value) -> Option<bool> {
 
 #[cfg(test)]
 mod tests {
-    use super::{decode_str_const, marker_path_to_fn_path};
+    use super::{decode_str_const, marker_path_to_fn_path, parse_immutable_entry_list};
+    use crate::model::ImmutableRank;
     use std::collections::HashSet;
 
     #[test]
@@ -337,6 +411,34 @@ mod tests {
             ),
             "rbigint::RBigInt::mul"
         );
+    }
+
+    #[test]
+    fn immutable_entry_list_parses_every_rank_suffix() {
+        // The payload shape `#[jit_immutable_fields]` writes into
+        // `_immutable_fields_<Struct>`: the declared entries joined by
+        // commas, each still carrying its `rclass.py:649-661` suffix.
+        assert_eq!(
+            parse_immutable_entry_list("_digits[*],_size,version?,defs_w?[*]"),
+            vec![
+                ("_digits".to_string(), ImmutableRank::ImmutableArray),
+                ("_size".to_string(), ImmutableRank::Immutable),
+                ("version".to_string(), ImmutableRank::QuasiImmutable),
+                ("defs_w".to_string(), ImmutableRank::QuasiImmutableArray),
+            ]
+        );
+    }
+
+    #[test]
+    fn immutable_entry_list_drops_blanks() {
+        assert_eq!(
+            parse_immutable_entry_list(" name , , instantiate "),
+            vec![
+                ("name".to_string(), ImmutableRank::Immutable),
+                ("instantiate".to_string(), ImmutableRank::Immutable),
+            ]
+        );
+        assert!(parse_immutable_entry_list("").is_empty());
     }
 
     #[test]

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -298,8 +298,12 @@ fn normalize_module_filter(module_paths: &[&str]) -> Option<std::collections::Ha
 /// `known_trait_names`, `struct_fields`) is populated from
 /// `type_decls` / `trait_decls`; struct field-type strings are resolved
 /// by [`tyref_to_ast_string`] from Charon's type IR.  `immutable_fields`
-/// stays empty until the `#[majit_macros::immutable]` attribute is
-/// surfaced by Charon.
+/// is left empty here and filled by
+/// [`crate::front::llbc_hints::harvest_immutable_fields_from_llbcs`],
+/// which reads the `_immutable_fields_<Struct>` marker consts
+/// `#[majit_macros::jit_immutable_fields]` leaves in `global_decls` —
+/// the attribute itself is consumed at expansion time and never
+/// reaches Charon's `attr_info`.
 ///
 /// Functions Charon could not extract (opaque body / `null` entry) or
 /// global-initializer bodies are skipped silently — they are not JIT

--- a/majit/majit-translate/src/lib.rs
+++ b/majit/majit-translate/src/lib.rs
@@ -724,6 +724,51 @@ fn live_rss_bytes() -> u64 {
     0
 }
 
+/// Give every `struct_fields` spelling of a declared struct the same
+/// `_immutable_fields_` entry list.
+///
+/// `rclass.py:644-678 _parse_field_list` reads the declaration off the class
+/// object, which has one identity. Pyre's registry keys layouts by name and
+/// carries several names for one struct — the bare leaf (`PyType`) and the
+/// crate-qualified path (`pyre_object::pyobject::PyType`) — while the harvester
+/// registers only the leaf and the crate-stripped path. Since layouts are
+/// stored per [`majit_ir::descr::StructId`], an undeclared spelling could
+/// overwrite the declared one's layout and silently drop `is_immutable`, and
+/// which spelling won depended on `HashMap` iteration order, so the
+/// declaration took effect on some builds and not others.
+///
+/// Declared keys are visited in sorted order so that a struct reachable under
+/// several declared spellings resolves to the same entry list on every run.
+fn expand_immutable_fields_to_all_spellings(
+    declared: &std::collections::HashMap<String, Vec<(String, model::ImmutableRank)>>,
+    struct_fields: &front::StructFieldRegistry,
+) -> std::collections::HashMap<String, Vec<(String, model::ImmutableRank)>> {
+    let mut by_struct_id: std::collections::HashMap<
+        majit_ir::descr::StructId,
+        &Vec<(String, model::ImmutableRank)>,
+    > = std::collections::HashMap::new();
+    let mut declared_names: Vec<&String> = declared.keys().collect();
+    declared_names.sort();
+    for name in declared_names {
+        if let Some(sid) = majit_ir::descr::struct_id_for_name(name) {
+            by_struct_id.entry(sid).or_insert(&declared[name]);
+        }
+    }
+    let mut out = declared.clone();
+    for name in struct_fields.fields.keys() {
+        if out.contains_key(name) {
+            continue;
+        }
+        let Some(entries) =
+            majit_ir::descr::struct_id_for_name(name).and_then(|sid| by_struct_id.get(&sid))
+        else {
+            continue;
+        };
+        out.insert(name.clone(), (*entries).clone());
+    }
+    out
+}
+
 fn analyze_pipeline_from_module_paths(
     module_paths: &[&str],
     explicit_llbc_paths: Option<&[&str]>,
@@ -1026,6 +1071,16 @@ fn analyze_pipeline_from_module_paths(
     // RPython: symbolic.get_field_token / get_size — resolve struct layouts
     // through the LayoutProvider. If no provider is given, use the heuristic
     // (type-string-based approximation of #[repr(C)] layout).
+    // `_immutable_fields_` is declared on the class (`rclass.py:644-678`
+    // reads it off the class object, which has exactly one identity), but
+    // `struct_fields` carries several spellings of the same struct —
+    // `PyType` and `pyre_object::pyobject::PyType` both resolve to one
+    // `StructId`. The layout loop below stores a single layout per
+    // `StructId`, so the spelling `HashMap` iteration happens to reach last
+    // decides whether that layout carries `is_immutable`. Give every
+    // spelling of a declared struct the declaration first.
+    let immutable_fields =
+        expand_immutable_fields_to_all_spellings(&program.immutable_fields, &program.struct_fields);
     let heuristic;
     let provider: &dyn layout::LayoutProvider = match layout_provider {
         Some(p) => p,
@@ -1033,7 +1088,7 @@ fn analyze_pipeline_from_module_paths(
             heuristic = layout::HeuristicLayoutProvider::from_struct_fields(
                 &program.struct_fields.fields,
                 &program.known_struct_names,
-                &program.immutable_fields,
+                &immutable_fields,
             );
             &heuristic
         }
@@ -1042,7 +1097,7 @@ fn analyze_pipeline_from_module_paths(
     // `FieldDescr.is_pure` for the heuristic-fallback path inside
     // `all_interiorfielddescrs` (the layout-provider path already carries
     // `is_immutable` on `StructFieldLayout`).
-    call_control.immutable_fields_by_struct = program.immutable_fields.clone();
+    call_control.immutable_fields_by_struct = immutable_fields;
     // `descr.py:364 ARRAY_INSIDE._immutable_field(None)` parity.
     // Summarise `field[*]` annotations into the array-type-keyed set so
     // `arraydescrof_concrete` can fold field-level immutability into the

--- a/majit/majit-translate/src/lib.rs
+++ b/majit/majit-translate/src/lib.rs
@@ -190,6 +190,15 @@ fn build_semantic_program_via_active_frontend(
             // RPython's translator reading `func._elidable_function_` off
             // the function object.
             merge_hints_from_llbcs(&mut program, &llbcs);
+            // Same carrier for the struct-level declaration:
+            // `#[jit_immutable_fields(...)]` leaves
+            // `_immutable_fields_<Struct>` next to the struct, which is
+            // read back here into the field the layout provider and
+            // `CallControl::field_immutability` consume — the analog of
+            // RPython reading `cls._immutable_fields_` off the class
+            // (`rclass.py:644-678 _parse_field_list`).
+            program.immutable_fields =
+                front::llbc_hints::harvest_immutable_fields_from_llbcs(&llbcs);
             // Re-source the unsafe-fn stub carrier from Charon: walk the
             // full LLBC set for every local `unsafe fn` / unsafe
             // impl-method projecting to a unit/bool return.  The consumer

--- a/pyre/pyre-object/src/pyobject.rs
+++ b/pyre/pyre-object/src/pyobject.rs
@@ -24,7 +24,21 @@ use std::sync::atomic::{AtomicI64, AtomicPtr, AtomicU64, Ordering};
 /// mirroring `assign_inheritance_ids` (normalizecalls.py:373-389).
 /// The JIT backend reads them at raw offsets — atomics are layout-
 /// compatible with their inner types (same size and alignment).
+/// `rclass.py:173-174` gives OBJECT_VTABLE `hints={'immutable': True,
+/// 'static_immutable': True}`, and `lltype.py:372-374 _immutable_field`
+/// answers `True` for *every* field of a struct carrying that hint, so
+/// each vtable slot reaches `descr.py:231 is_pure = STRUCT.
+/// _immutable_field(fieldname) != False` as a pure field.  Pyre's
+/// per-field spelling of the same declaration: all four slots are
+/// written once during startup (`assign_subclass_range` /
+/// `set_instantiate`, both before any bytecode runs) and never again.
 #[repr(C)]
+#[majit_macros::jit_immutable_fields(
+    "subclassrange_min",
+    "subclassrange_max",
+    "name",
+    "instantiate"
+)]
 pub struct PyType {
     pub subclassrange_min: AtomicI64,
     pub subclassrange_max: AtomicI64,


### PR DESCRIPTION
Six commits on the append-loop class-identity cluster (`for i in range(n): r.append(i)`), ending with a build-reproducibility fix without which the last two are a coin flip.

Steady loop body over the series: **45 → 43 → 37 → 31 ops**.

## What lands

**`majit: record class_now_known alongside new_object in trace_box_int/float`**
`execute_new_with_vtable` (`pyjitpl.py:2714-2718`) records both `heapcache.new(resbox)` and `heapcache.class_now_known(resbox)`; only plain `execute_new` (`:2720-2723`) stops at `new`. `trace_box_int` / `trace_box_float` emit `NewWithVtable` but recorded only `new_object` and took the type address as an ignored parameter. Measured perf-neutral — the optimized-trace op sequence is byte-identical.

**`majit: make inline_short_preamble's final _map_args strict on unmapped args`**
`unroll.py:364-370 _map_args` is strict for non-Const boxes; the closing `_map_args` at `unroll.py:438-439` used `mapping.get(..).unwrap_or(jump_arg)`, handing the JUMP the preamble's own box — the loop-entry value, re-supplied on every back edge. Treat the miss as the `InvalidLoop` the KeyError amounts to. Measured inert: fires 0 times across the corpus on both backends.

**`majit: make optimize_getfield's field cache lookup get-or-create`**
`heap.py:648 cf = self.field_cache(descr)` is get-or-create (`heap.py:392-397`), so `getfield_from_cache` — and its `PreambleOp` arm — runs for the first touch of a descr too. `optimize_getfield` looked the cache up read-only and skipped the whole consult when absent, which is every field at the head of the peeled loop. Also fixes the `TestDescr` / `ImmutableDescr` fixtures, which left `index_in_parent` at 0 so every fixture descr mapped to ptr_info slot 0 of the same parent — a state `info.py:212-214` cannot represent.

**`majit: fold the w_class header read from a forced allocation's kept class`** (43 → 37)
`info.py:152 force_box` keeps the SAME info object and only clears `_is_virtual`, so `info.py:324 get_known_class` still answers after the allocation escapes. pyre installs `PtrInfo::Instance { descr, known_class }` on force but the consumer arm was missing, so the class became unusable the moment the allocation escaped. The stored-write probe goes through the layout's own `w_class` field descr, never the read descr's index — a parent-bearing `w_class` spelling has `index_in_parent == 0` and would alias the first value field.

**`majit: carry #[jit_immutable_fields] through ullbc and declare PyType's slots`** (37 → 31)
The attribute was a pure pass-through. Like every other `majit_macros` attribute it is consumed at expansion time and does not survive in Charon's `attr_info`, so `SemanticProgram.immutable_fields` stayed empty for every build and **no struct's declaration ever reached** `CallControl::field_immutability`, `StructFieldLayout::is_immutable`, or `BhDescr::Field::is_immutable` — `pyre-object`'s one existing declaration (`RBigInt`, matching `rbigint.py:157`) was inert.

Routed through the carrier the other attributes already use: the macro leaves `#[doc(hidden)] const _immutable_fields_<Struct>: &str` next to the struct, Charon extracts it into `global_decls`, and `harvest_immutable_fields_from_llbcs` reads it back — the analog of the translator reading `cls._immutable_fields_` off the class object.

`PyType`'s four slots are then declared immutable: `rclass.py:173-174` gives OBJECT_VTABLE `hints={'immutable': True, 'static_immutable': True}` and `lltype.py:372-374 _immutable_field` answers True for every field of a struct carrying that hint, so each vtable slot reaches `descr.py:231`. The walker's ConstPtr fast path (`pyjitpl.py:876-880`) then folds the read during the walk instead of recording it.

**`majit: give every struct-name spelling the struct's _immutable_fields_ entries`**
`struct_fields` carries more than one name per struct — the bare leaf (`PyType`) and the crate-qualified path (`pyre_object::pyobject::PyType`) — while the harvester registers only the leaf and the crate-stripped path. The layout loop iterates a `HashMap` and stores one layout per `StructId`, so the undeclared spelling could overwrite the declared spelling's layout and drop `is_immutable` from it, and which one won depended on iteration order.

`PyType.*` and `RBigInt.*` therefore reached `bh_all_field_specs_for_struct_into` as mutable on some builds and immutable on others, while the standalone field descrs for the same fields always carried the flag. **Three forced codegen runs at one unchanged source state produced 37 / 31 / 31 ops.** After the fix, six runs all produce 31.

## Verification

- `check.py --backend dynasm,cranelift`: **dynasm 348/348, cranelift 348/348**
- `cargo test --release`: majit-metainterp `--features dynasm` 1425, pyre-jit-trace `--features dynasm` 313, pyre-object 3048, majit-macros 34, majit-translate 105+ — 0 failed except the pre-existing red below
- Steady loop body re-measured on this base: **31 ops**, and `all_descrs=4038` agrees across the two independently-run codegen pipelines (dynasm and cranelift have different `codegen_cache_key`s, so this is two full runs converging, not one cached result)
- Class-identity regression (run out of band, since a wrongly skipped class check is a silent miscompile): a hot append loop interleaving plain ints with a `MyInt(int)` subclass reads the same sum and preserves `type(x) is MyInt` under JIT and `PYRE_NO_JIT` on both backends; `synth/callee_store_global_read_after_call` stays at 240008 on both backends and under `PYRE_NO_JIT`.

### Pre-existing red, not from this branch

`majit-translate`'s `slow_generated_jitcodes_preserve_complete_dispatcher_graph` fails at
`test_make_jitcodes_produces_graph_keyed_output.rs:255` with `left: 115, right: 111`. That operand
is produced by `syn`-parsing `pyre/pyre-interpreter/src/pyopcode.rs` and comparing against a
hardcoded arm count. Both that file and the test are byte-identical to `origin/main` in this branch
(`git diff origin/main --name-only` lists neither), so it fails the same way on the base. The
constants were last updated 2026-07-16 (#573) while `pyopcode.rs` kept gaining dispatcher arms
through 2026-07-29 (#654, #814) — belongs to whoever added them.

## Not the destination

Upstream never traces a typeptr read at all: `jtransform.py:833-834 rewrite_op_getfield` routes it to `handle_getfield_typeptr` (`:1004-1009`), which yields a codewriter-time `Constant(cls)` for a constant receiver and `guard_class` otherwise, and `rewrite_op_setfield` (`:909-911`) deletes typeptr stores outright. This series is convergence toward that codewriter shape.

The remaining `GetfieldGcR(list, w_class)` + `GuardValue` / `GetfieldGcI(type, _version_tag)` + `GuardValue` pair in the 31-op body is blocked on two separate things: `ensure_ptr_info_arg0` builds a parent-less `PtrInfo::instance(None, None)` for `is_w_class()` and never calls `init_fields`, so `produce_short_preamble_ops` (`info.py:255-271`) has no `_fields` to export; and the version-tag read sits on a `ConstPtr`, whose `ConstPtrInfo` upstream exports nothing to the short preamble either — the orthodox route there is `_version_tag?` quasi-immutable (`typeobject.py:177`), not hoisting.

— *authored by Claude*
