### PR TITLE
jit: emit class instantiation and the mapdict attribute-add transition in-trace

### DIFF
--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -3930,6 +3930,60 @@ extern "C" fn gc_malloc_array_nonstandard_helper(
     ))
 }
 
+/// Old-generation twin of [`gc_malloc_array_helper`], selected by
+/// `gen_malloc_array` for a `non_moving` array descr.  Same signature.
+extern "C" fn gc_malloc_array_oldgen_helper(item_size: u64, type_id: u64, num_elem: u64) -> u64 {
+    oom_signal_if_zero(active_runtime_alloc_oldgen_varsize_typed_and_set_len(
+        type_id as u32,
+        std::mem::size_of::<usize>(),
+        item_size as usize,
+        0,
+        num_elem as usize,
+    ))
+}
+
+/// Old-generation twin of [`gc_malloc_array_nonstandard_helper`].
+extern "C" fn gc_malloc_array_nonstandard_oldgen_helper(
+    base_size: u64,
+    item_size: u64,
+    length_ofs: u64,
+    type_id: u64,
+    num_elem: u64,
+) -> u64 {
+    oom_signal_if_zero(active_runtime_alloc_oldgen_varsize_typed_and_set_len(
+        type_id as u32,
+        base_size as usize,
+        item_size as usize,
+        length_ofs as usize,
+        num_elem as usize,
+    ))
+}
+
+/// Variable-size old-generation allocation, stamping the GcArray length
+/// header the way [`active_runtime_alloc_varsize_typed_and_set_len`] does
+/// for the nursery.
+fn active_runtime_alloc_oldgen_varsize_typed_and_set_len(
+    type_id: u32,
+    base_size: usize,
+    item_size: usize,
+    length_ofs: usize,
+    length: usize,
+) -> u64 {
+    let Some(var_bytes) = item_size.checked_mul(length) else {
+        return 0;
+    };
+    let Some(payload_size) = base_size.checked_add(var_bytes) else {
+        return 0;
+    };
+    let obj = active_runtime_alloc_oldgen_typed(type_id, payload_size);
+    if obj != 0 {
+        unsafe {
+            *((obj as *mut u8).add(length_ofs) as *mut usize) = length;
+        }
+    }
+    obj
+}
+
 fn raw_fixedsize_alloc_typed(type_id: u32, size: usize) -> u64 {
     let Some(total_size) = GcHeader::SIZE.checked_add(size) else {
         return 0;
@@ -8193,6 +8247,9 @@ impl CraneliftBackend {
             fielddescr_tid: Some(majit_ir::make_tid_field_descr()),
             malloc_array_fn: gc_malloc_array_helper as *const () as i64,
             malloc_array_nonstandard_fn: gc_malloc_array_nonstandard_helper as *const () as i64,
+            malloc_array_oldgen_fn: gc_malloc_array_oldgen_helper as *const () as i64,
+            malloc_array_nonstandard_oldgen_fn: gc_malloc_array_nonstandard_oldgen_helper
+                as *const () as i64,
             malloc_str_fn: gc_malloc_str_helper as *const () as i64,
             malloc_unicode_fn: gc_malloc_unicode_helper as *const () as i64,
             malloc_big_fixedsize_fn: gc_malloc_big_fixedsize_helper as *const () as i64,

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -1068,6 +1068,35 @@ pub extern "C" fn dynasm_malloc_array_nonstandard(
     ))
 }
 
+/// Old-generation twin of [`dynasm_malloc_array`], selected by
+/// `gen_malloc_array` for a `non_moving` array descr.  Same signature.
+pub extern "C" fn dynasm_malloc_array_oldgen(item_size: u64, type_id: u64, num_elem: u64) -> u64 {
+    oom_signal_if_zero(dynasm_alloc_oldgen_varsize_typed_and_set_len(
+        type_id as u32,
+        std::mem::size_of::<usize>(),
+        item_size as usize,
+        0,
+        num_elem as usize,
+    ))
+}
+
+/// Old-generation twin of [`dynasm_malloc_array_nonstandard`].
+pub extern "C" fn dynasm_malloc_array_nonstandard_oldgen(
+    base_size: u64,
+    item_size: u64,
+    length_ofs: u64,
+    type_id: u64,
+    num_elem: u64,
+) -> u64 {
+    oom_signal_if_zero(dynasm_alloc_oldgen_varsize_typed_and_set_len(
+        type_id as u32,
+        base_size as usize,
+        item_size as usize,
+        length_ofs as usize,
+        num_elem as usize,
+    ))
+}
+
 fn dynasm_raw_fixedsize_alloc_typed(type_id: u32, size: usize) -> u64 {
     let Some(total_size) = majit_gc::header::GcHeader::SIZE.checked_add(size) else {
         return 0;
@@ -1608,6 +1637,9 @@ impl DynasmBackend {
                 fielddescr_tid: Some(majit_ir::make_tid_field_descr()),
                 malloc_array_fn: dynasm_malloc_array as *const () as i64,
                 malloc_array_nonstandard_fn: dynasm_malloc_array_nonstandard as *const () as i64,
+                malloc_array_oldgen_fn: dynasm_malloc_array_oldgen as *const () as i64,
+                malloc_array_nonstandard_oldgen_fn: dynasm_malloc_array_nonstandard_oldgen
+                    as *const () as i64,
                 malloc_str_fn: dynasm_malloc_str as *const () as i64,
                 malloc_unicode_fn: dynasm_malloc_unicode as *const () as i64,
                 malloc_big_fixedsize_fn: dynasm_malloc_big_fixedsize as *const () as i64,

--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -1257,6 +1257,22 @@ pub struct NurseryAllocParams {
     pub plain_tids: std::collections::HashSet<u32>,
 }
 
+/// `__indirect_function_table` indices of the allocation helpers a compiled
+/// trace calls for `New*` / `NewArray*`.
+///
+/// Two generations, picked per operation from the descr's `non_moving` flag:
+/// the nursery pair is the default, the old-gen pair is for a descr whose
+/// object must not move (see `majit_backend_wasm::wasm_jit_alloc_oldgen`).
+/// The native backends make the same choice inside the GC rewrite pass, which
+/// the wasm backend bypasses in favour of this lowering.
+#[derive(Clone, Copy, Default)]
+pub struct AllocHelpers {
+    pub new_fn_ptr: i64,
+    pub new_array_fn_ptr: i64,
+    pub new_oldgen_fn_ptr: i64,
+    pub new_array_oldgen_fn_ptr: i64,
+}
+
 /// Build a wasm module from majit IR.
 pub fn build_wasm_module(
     inputargs: &[InputArg],
@@ -1265,8 +1281,7 @@ pub fn build_wasm_module(
     vtable_offset: Option<usize>,
     classptr_to_typeid: &HashMap<i64, u32>,
     guard_gc_type_info: &GuardGcTypeInfo,
-    alloc_fn_ptr: i64,
-    alloc_array_fn_ptr: i64,
+    alloc: AllocHelpers,
     wb_fn_ptr: i64,
     // Inline nursery-bump fast path for eligible `New`/`NewWithVtable`
     // (see `NurseryAllocParams`); `None` keeps allocations on the helper.
@@ -1558,8 +1573,7 @@ pub fn build_wasm_module(
         vtable_offset,
         classptr_to_typeid,
         guard_gc_type_info,
-        alloc_fn_ptr,
-        alloc_array_fn_ptr,
+        alloc,
         wb_fn_ptr,
         nursery,
         &ref_values,
@@ -1600,8 +1614,7 @@ fn build_function(
     vtable_offset: Option<usize>,
     classptr_to_typeid: &HashMap<i64, u32>,
     guard_gc_type_info: &GuardGcTypeInfo,
-    alloc_fn_ptr: i64,
-    alloc_array_fn_ptr: i64,
+    alloc: AllocHelpers,
     wb_fn_ptr: i64,
     nursery: Option<&NurseryAllocParams>,
     ref_values: &RefValues,
@@ -3674,6 +3687,16 @@ fn build_function(
                     })
                 });
 
+                // `rewrite.rs handle_new`: a `non_moving` descr declines the
+                // nursery outright — both the inline bump and the collecting
+                // helper — and allocates through the old-generation twin, whose
+                // address is the only thing that differs from the nursery call.
+                let non_moving = sd.is_some_and(|sd| sd.non_moving());
+                let alloc_fn_ptr = if non_moving {
+                    alloc.new_oldgen_fn_ptr
+                } else {
+                    alloc.new_fn_ptr
+                };
                 // Inline nursery bump (rewrite.py malloc fast path, x86
                 // `malloc_cond`): total = align8(max(header+size, MIN)); if
                 // `free + total` fits below `nursery_top`, commit the bump and
@@ -3686,7 +3709,7 @@ fn build_function(
                     use majit_gc::header::GcHeader;
                     ((GcHeader::SIZE + size as usize).max(GcHeader::MIN_NURSERY_OBJ_SIZE) + 7) & !7
                 };
-                let inline_nursery = nursery.filter(|na| {
+                let inline_nursery = nursery.filter(|_| !non_moving).filter(|na| {
                     total_size <= na.large_threshold
                         && u32::try_from(type_id).is_ok_and(|t| na.plain_tids.contains(&t))
                 });
@@ -3878,6 +3901,17 @@ fn build_function(
                 let (base_size, item_size) = (ad.base_size() as i64, ad.item_size() as i64);
                 let len_offset = ad.len_descr().map_or(0i64, |ld| ld.offset() as i64);
                 let type_id = ad.type_id() as i64;
+
+                // `rewrite.rs handle_new_array`: a `non_moving` descr declines
+                // both nursery routes and allocates through the old-generation
+                // twin. See the `New` arm.
+                let non_moving = ad.non_moving();
+                let alloc_array_fn_ptr = if non_moving {
+                    alloc.new_array_oldgen_fn_ptr
+                } else {
+                    alloc.new_array_fn_ptr
+                };
+                let nursery = nursery.filter(|_| !non_moving);
 
                 // Inline nursery bump for arrays of a plain type under the
                 // large-object threshold (same fast path as the `New` arm).

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -657,6 +657,63 @@ pub extern "C" fn wasm_jit_alloc_array(
     .unwrap_or(0)
 }
 
+/// Old-generation twin of [`wasm_jit_alloc`], selected by the `New` /
+/// `NewWithVtable` codegen for a `non_moving` size descr. Same signature, so it
+/// shares the call shape; only the generation differs.
+///
+/// A descr marked `non_moving` is one whose object is reached through a raw
+/// pointer nothing forwards — the interpreter holds it across an allocation, or
+/// another object's field stores it outside the collector's view. Placing such
+/// an object in the movable nursery leaves those pointers aimed at the pre-move
+/// copy. The native backends honour the flag in the GC rewrite pass
+/// (`rewrite.rs` `handle_new`); wasm lowers `New` itself, so it must apply the
+/// same policy here.
+pub extern "C" fn wasm_jit_alloc_oldgen(type_id: i64, size: i64) -> i64 {
+    with_wasm_active_gc_mut(|gc| gc.alloc_oldgen_typed(type_id as u32, size as usize).0 as i64)
+        .unwrap_or(0)
+}
+
+/// Old-generation twin of [`wasm_jit_alloc_array`], selected by the `NewArray` /
+/// `NewArrayClear` codegen for a `non_moving` array descr. Same signature and
+/// the same length stamp; see [`wasm_jit_alloc_oldgen`] for why the generation
+/// is part of the descr's contract.
+pub extern "C" fn wasm_jit_alloc_array_oldgen(
+    type_id: i64,
+    base_size: i64,
+    item_size: i64,
+    length: i64,
+    len_offset: i64,
+) -> i64 {
+    let Ok(length) = usize::try_from(length) else {
+        return 0;
+    };
+    let payload_size = base_size as usize + item_size as usize * length;
+    with_wasm_active_gc_mut(|gc| {
+        let obj = gc.alloc_oldgen_typed(type_id as u32, payload_size);
+        if obj.is_null() {
+            0
+        } else {
+            unsafe {
+                *((obj.0 as *mut u8).add(len_offset as usize) as *mut usize) = length;
+            }
+            obj.0 as i64
+        }
+    })
+    .unwrap_or(0)
+}
+
+/// Table indices of the four allocation trampolines, for the `New*` /
+/// `NewArray*` codegen. Taking each address here is what keeps the function in
+/// the module's `__indirect_function_table`, so a trace can `call_indirect` it.
+fn alloc_helpers() -> codegen::AllocHelpers {
+    codegen::AllocHelpers {
+        new_fn_ptr: wasm_jit_alloc as *const () as usize as i64,
+        new_array_fn_ptr: wasm_jit_alloc_array as *const () as usize as i64,
+        new_oldgen_fn_ptr: wasm_jit_alloc_oldgen as *const () as usize as i64,
+        new_array_oldgen_fn_ptr: wasm_jit_alloc_array_oldgen as *const () as usize as i64,
+    }
+}
+
 /// JIT-trace write-barrier trampoline target for ref-storing `SetfieldGc` /
 /// `SetarrayitemGc` / `SetinteriorfieldGc`. Routes through the host `jit_call`
 /// trampoline; invokes the active GC's `write_barrier`, which adds an old
@@ -1705,8 +1762,7 @@ impl majit_backend::Backend for WasmBackend {
         // Allocation helpers reached from a compiled trace through the host
         // `jit_call` trampoline. `fn as usize` is the `__indirect_function_table`
         // index on wasm32; taking it here keeps the function in the table.
-        let alloc_fn_ptr = wasm_jit_alloc as *const () as usize as i64;
-        let alloc_array_fn_ptr = wasm_jit_alloc_array as *const () as usize as i64;
+        let alloc = alloc_helpers();
         let wb_fn_ptr = wasm_jit_write_barrier as *const () as usize as i64;
         // Exit indices come from the global fail-index space so a cross-trace
         // chain's `frame[0]` resolves regardless of which module wrote it
@@ -1720,8 +1776,7 @@ impl majit_backend::Backend for WasmBackend {
                 self.vtable_offset,
                 &typeid_table,
                 &guard_gc_type_info,
-                alloc_fn_ptr,
-                alloc_array_fn_ptr,
+                alloc,
                 wb_fn_ptr,
                 nursery_alloc_params(ops).as_ref(),
                 Arc::as_ptr(&token.invalidated) as usize as u32,
@@ -2385,8 +2440,7 @@ impl majit_backend::Backend for WasmBackend {
 
         let typeid_table = self.collect_classptr_typeid_table(ops);
         let guard_gc_type_info = self.collect_guard_gc_type_info(ops);
-        let alloc_fn_ptr = wasm_jit_alloc as *const () as usize as i64;
-        let alloc_array_fn_ptr = wasm_jit_alloc_array as *const () as usize as i64;
+        let alloc = alloc_helpers();
         let wb_fn_ptr = wasm_jit_write_barrier as *const () as usize as i64;
 
         // CALL_ASSEMBLER: the CA arm allocates a fresh callee using the target
@@ -2433,8 +2487,7 @@ impl majit_backend::Backend for WasmBackend {
                 self.vtable_offset,
                 &typeid_table,
                 &guard_gc_type_info,
-                alloc_fn_ptr,
-                alloc_array_fn_ptr,
+                alloc,
                 wb_fn_ptr,
                 nursery_alloc_params(ops).as_ref(),
                 Arc::as_ptr(&bridge_flag) as usize as u32,

--- a/majit/majit-backend-wasm/tests/codegen_test.rs
+++ b/majit/majit-backend-wasm/tests/codegen_test.rs
@@ -207,8 +207,7 @@ fn build_module(
         vtable_offset,
         &HashMap::new(),
         gc_info,
-        0,
-        0,
+        codegen::AllocHelpers::default(),
         0,
         None, // nursery
         0,    // invalidated_flag_addr
@@ -581,8 +580,7 @@ fn test_guard_not_invalidated_loads_runtime_flag() {
         None,
         &HashMap::new(),
         &codegen::GuardGcTypeInfo::default(),
-        0,
-        0,
+        codegen::AllocHelpers::default(),
         0,
         None,
         0x1000,
@@ -1048,4 +1046,105 @@ fn test_registration_loop_stamps_label_block_id() {
         .getdescr()
         .and_then(|d| d.as_loop_target_descr().map(|t| t.label_block_id()));
     assert_eq!(recovered, Some(1));
+}
+
+/// Collect every `i32.const` / `i64.const` immediate in the emitted body, so a
+/// test can assert which helper address the allocation arms baked in.
+fn const_immediates(bytes: &[u8]) -> Vec<i64> {
+    let mut out = Vec::new();
+    for payload in wasmparser::Parser::new(0).parse_all(bytes) {
+        if let wasmparser::Payload::CodeSectionEntry(body) = payload.unwrap() {
+            let mut operators = body.get_operators_reader().unwrap();
+            while !operators.eof() {
+                match operators.read().unwrap() {
+                    wasmparser::Operator::I32Const { value } => out.push(value as i64),
+                    wasmparser::Operator::I64Const { value } => out.push(value),
+                    _ => {}
+                }
+            }
+        }
+    }
+    out
+}
+
+/// A `non_moving` descr must allocate through the old-generation helper, never
+/// the nursery one. The native backends make that choice in the GC rewrite pass
+/// (`handle_new` / `handle_new_array`); the wasm backend lowers `New*` itself,
+/// so the flag has to be honoured here or it is silently dropped.
+///
+/// Dropping it is not a slowdown, it is a use-after-move: a `non_moving` descr
+/// marks an object reached through a raw pointer nothing forwards, so a movable
+/// copy leaves those pointers on the pre-move address.
+#[test]
+fn test_non_moving_descr_allocates_through_the_oldgen_helper() {
+    use majit_ir::descr::{SimpleArrayDescr, SimpleSizeDescr};
+    use std::sync::Arc;
+
+    const NEW_FN: i64 = 0x11;
+    const NEW_ARRAY_FN: i64 = 0x22;
+    const NEW_OLDGEN_FN: i64 = 0x33;
+    const NEW_ARRAY_OLDGEN_FN: i64 = 0x44;
+
+    // One `New` and one `NewArrayClear`, both marked non-moving.
+    let build = |non_moving: bool| {
+        let size_descr = SimpleSizeDescr::new(0, 32, 53);
+        size_descr.set_non_moving(non_moving);
+        let array_descr = SimpleArrayDescr::new(1, 8, 8, 55, Type::Ref);
+        array_descr.set_non_moving(non_moving);
+
+        let new_op = make_op(OpCode::New, &[], OpRef::ref_op(1));
+        new_op.setdescr(Arc::new(size_descr));
+        let new_array_op = make_op(
+            OpCode::NewArrayClear,
+            &[OpRef::input_arg_int(0)],
+            OpRef::ref_op(2),
+        );
+        new_array_op.setdescr(Arc::new(array_descr));
+        let finish = Op::new(OpCode::Finish, &[rb(OpRef::input_arg_int(0))]);
+        finish.setfailargs(smallvec![rb(OpRef::input_arg_int(0))]);
+
+        let (bytes, _, _, _, _) = codegen::build_wasm_module(
+            &[InputArg::from_type(Type::Int, 0)],
+            &[new_op, new_array_op, finish],
+            &indexmap::IndexMap::new(),
+            Some(0),
+            &HashMap::new(),
+            &codegen::GuardGcTypeInfo::default(),
+            codegen::AllocHelpers {
+                new_fn_ptr: NEW_FN,
+                new_array_fn_ptr: NEW_ARRAY_FN,
+                new_oldgen_fn_ptr: NEW_OLDGEN_FN,
+                new_array_oldgen_fn_ptr: NEW_ARRAY_OLDGEN_FN,
+            },
+            0,
+            None, // nursery: the inline bump is off, so only the helper choice shows
+            0,
+            0,
+            0,
+            0,
+            codegen::FrameGeometry::fixed(),
+            codegen::CaParams::default(),
+        )
+        .expect("wasm codegen should succeed");
+        validate_wasm(&bytes);
+        const_immediates(&bytes)
+    };
+
+    let moving = build(false);
+    assert!(moving.contains(&NEW_FN) && moving.contains(&NEW_ARRAY_FN));
+    assert!(!moving.contains(&NEW_OLDGEN_FN) && !moving.contains(&NEW_ARRAY_OLDGEN_FN));
+
+    let non_moving = build(true);
+    assert!(
+        non_moving.contains(&NEW_OLDGEN_FN),
+        "non_moving New must call the old-gen helper"
+    );
+    assert!(
+        non_moving.contains(&NEW_ARRAY_OLDGEN_FN),
+        "non_moving NewArrayClear must call the old-gen helper"
+    );
+    assert!(
+        !non_moving.contains(&NEW_FN) && !non_moving.contains(&NEW_ARRAY_FN),
+        "non_moving descrs must not reach the nursery helpers"
+    );
 }

--- a/majit/majit-gc/src/rewrite.rs
+++ b/majit/majit-gc/src/rewrite.rs
@@ -210,6 +210,14 @@ pub struct GcRewriterImpl {
     /// gc.py:433-444 `generate_function('malloc_array_nonstandard', ...)`
     /// function addr.
     pub malloc_array_nonstandard_fn: i64,
+    /// Old-generation twin of [`Self::malloc_array_fn`], selected by
+    /// `gen_malloc_array` when the array descr is
+    /// [`majit_ir::descr::ArrayDescr::non_moving`].  Same call signature,
+    /// so it shares `malloc_array_descr`; only the allocator differs.
+    pub malloc_array_oldgen_fn: i64,
+    /// Old-generation twin of [`Self::malloc_array_nonstandard_fn`], and
+    /// shares `malloc_array_nonstandard_descr` for the same reason.
+    pub malloc_array_nonstandard_oldgen_fn: i64,
     /// gc.py:453-458 `generate_function('malloc_str', ...)` function addr.
     pub malloc_str_fn: i64,
     /// gc.py:460-465 `generate_function('malloc_unicode', ...)` function addr.
@@ -1199,6 +1207,11 @@ impl GcRewriterImpl {
             .expect("handle_new_array descr must be ArrayDescr");
 
         let item_size = descr.item_size();
+        // A `non_moving` descr declines both nursery routes and lands on the
+        // typed malloc helpers, whose old-generation twin never moves the
+        // block.  Same opt-in as `SizeDescr::non_moving` on the fixed-size
+        // path.
+        let non_moving = descr.non_moving();
         let v_length = st.resolve(op.arg(0)); // the length operand
         let length_const = st.resolve_constant(&v_length);
 
@@ -1219,7 +1232,7 @@ impl GcRewriterImpl {
             // rewrite.py:557-558 — non-const length but zero itemsize
             // means no variable payload; fold to fixed-size basesize.
             total_size = descr.base_size() as i64;
-        } else if self.can_use_nursery(1) {
+        } else if !non_moving && self.can_use_nursery(1) {
             // rewrite.py:559-568 path #1 — varsize nursery fast path.
             // Returns None when the descr is non-standard FLAG_ARRAY,
             // in which case we fall through to path #4
@@ -1255,7 +1268,12 @@ impl GcRewriterImpl {
             // already includes the header offset.  Add HDR_SIZE here so
             // the bump-pointer alloc covers the same span.
             let s = crate::header::GcHeader::SIZE + total_size as usize;
-            if let Some(r) = self.gen_malloc_nursery(s, op.pos.get(), st) {
+            let nursery_ref = if non_moving {
+                None
+            } else {
+                self.gen_malloc_nursery(s, op.pos.get(), st)
+            };
+            if let Some(r) = nursery_ref {
                 // rewrite.py:569-572 path #2 — constant-size nursery.
                 st.record_result_mapping(op.pos.get(), r.clone());
                 self.gen_initialize_tid(r.clone(), descr.type_id(), st);
@@ -1515,8 +1533,15 @@ impl GcRewriterImpl {
         let length_ofs = len_descr.map_or(self.standard_array_length_ofs, |fd| fd.offset());
         let is_standard = ad.base_size() == self.standard_array_basesize
             && len_descr.is_some_and(|fd| fd.offset() == self.standard_array_length_ofs);
+        // The old-generation twins take the same arguments as the nursery
+        // helpers, so only the callee address changes.
+        let non_moving = ad.non_moving();
         if is_standard {
-            let fn_ref = st.const_int(self.malloc_array_fn);
+            let fn_ref = st.const_int(if non_moving {
+                self.malloc_array_oldgen_fn
+            } else {
+                self.malloc_array_fn
+            });
             let itemsize_ref = st.const_int(ad.item_size() as i64);
             let typeid_ref = st.const_int(ad.type_id() as i64);
             self.gen_call_malloc_gc(
@@ -1526,7 +1551,11 @@ impl GcRewriterImpl {
                 st,
             )
         } else {
-            let fn_ref = st.const_int(self.malloc_array_nonstandard_fn);
+            let fn_ref = st.const_int(if non_moving {
+                self.malloc_array_nonstandard_oldgen_fn
+            } else {
+                self.malloc_array_nonstandard_fn
+            });
             let basesize_ref = st.const_int(ad.base_size() as i64);
             let itemsize_ref = st.const_int(ad.item_size() as i64);
             let lengthofs_ref = st.const_int(length_ofs as i64);
@@ -1550,11 +1579,17 @@ impl GcRewriterImpl {
     /// rewrite.py:778-796 `gen_malloc_fixedsize` (framework GC arm).
     ///
     /// Emits `CALL_R(malloc_big_fixedsize_fn, size, typeid)` followed
-    /// by `CHECK_MEMORY_ERROR` (via `gen_call_malloc_gc`) and stamps
-    /// `remember_wb` on the result so the freshly-malloc'd object
-    /// skips the write barrier (rewrite.py:794-796 — fixed-size
-    /// objects are zero-initialized by `clear_gc_fields`, so any
-    /// store into a gc field needs no WB).
+    /// by `CHECK_MEMORY_ERROR` (via `gen_call_malloc_gc`).
+    ///
+    /// rewrite.py:794-796 stamps `remember_write_barrier` on the result
+    /// there, sound because upstream's `malloc_big_fixedsize` hands back a
+    /// *young* raw-malloced object: a young object needs no barrier for a
+    /// young pointer stored into it.  pyre's helper allocates in the old
+    /// generation on both backends (`dynasm_malloc_big_fixedsize` /
+    /// `gc_malloc_big_fixedsize_helper` → `alloc_oldgen_typed`), so the
+    /// same stamp would silently drop the barrier on the first `SETFIELD_GC`
+    /// of a young value into an old object and leave that value unforwarded
+    /// after the next minor collection.  The stamp is therefore not applied.
     ///
     /// pyre is framework-GC only; the Boehm `else` arm
     /// (`malloc_fixedsize_fn`) is intentionally not ported.  The
@@ -1577,14 +1612,12 @@ impl GcRewriterImpl {
         let fn_ref = st.const_int(self.malloc_big_fixedsize_fn);
         let size_ref = st.const_int(size as i64);
         let typeid_ref = st.const_int(type_id as i64);
-        let result = self.gen_call_malloc_gc(
+        self.gen_call_malloc_gc(
             &[fn_ref, size_ref, typeid_ref],
             result_pos,
             self.malloc_big_fixedsize_descr.clone(),
             st,
-        );
-        st.remember_wb(&result);
-        result
+        )
     }
 
     /// rewrite.py:836-840 `gen_malloc_str`.
@@ -3292,6 +3325,8 @@ mod tests {
     const TEST_STANDARD_ARRAY_LENGTH_OFS: usize = 0;
     const TEST_MALLOC_ARRAY_FN: i64 = 0x1111;
     const TEST_MALLOC_ARRAY_NONSTANDARD_FN: i64 = 0x2222;
+    const TEST_MALLOC_ARRAY_OLDGEN_FN: i64 = 0x1113;
+    const TEST_MALLOC_ARRAY_NONSTANDARD_OLDGEN_FN: i64 = 0x2223;
     const TEST_MALLOC_STR_FN: i64 = 0x3333;
     const TEST_MALLOC_UNICODE_FN: i64 = 0x4444;
     const TEST_MALLOC_BIG_FIXEDSIZE_FN: i64 = 0x5555;
@@ -3403,6 +3438,7 @@ mod tests {
         type_id: u32,
         item_type: Type,
         len_descr: Option<Arc<TestFieldDescr>>,
+        non_moving: bool,
     }
 
     impl Descr for TestArrayDescr {
@@ -3428,6 +3464,9 @@ mod tests {
             self.len_descr
                 .as_ref()
                 .map(|fd| fd.as_ref() as &dyn FieldDescr)
+        }
+        fn non_moving(&self) -> bool {
+            self.non_moving
         }
     }
 
@@ -3476,6 +3515,8 @@ mod tests {
             fielddescr_tid: Some(majit_ir::make_tid_field_descr()),
             malloc_array_fn: TEST_MALLOC_ARRAY_FN,
             malloc_array_nonstandard_fn: TEST_MALLOC_ARRAY_NONSTANDARD_FN,
+            malloc_array_oldgen_fn: TEST_MALLOC_ARRAY_OLDGEN_FN,
+            malloc_array_nonstandard_oldgen_fn: TEST_MALLOC_ARRAY_NONSTANDARD_OLDGEN_FN,
             malloc_str_fn: TEST_MALLOC_STR_FN,
             malloc_unicode_fn: TEST_MALLOC_UNICODE_FN,
             malloc_big_fixedsize_fn: TEST_MALLOC_BIG_FIXEDSIZE_FN,
@@ -3618,6 +3659,18 @@ mod tests {
             type_id: 5,
             item_type: Type::Ref,
             len_descr: Some(array_len_field_descr()),
+            non_moving: false,
+        })
+    }
+
+    fn non_moving_array_descr() -> DescrRef {
+        Arc::new(TestArrayDescr {
+            base_size: TEST_STANDARD_ARRAY_BASESIZE,
+            item_size: 8,
+            type_id: 55,
+            item_type: Type::Ref,
+            len_descr: Some(array_len_field_descr()),
+            non_moving: true,
         })
     }
 
@@ -3628,6 +3681,7 @@ mod tests {
             type_id: 6,
             item_type: Type::Int,
             len_descr: Some(array_len_field_descr()),
+            non_moving: false,
         })
     }
 
@@ -3703,7 +3757,9 @@ mod tests {
             rw.rewrite_for_gc_with_constants(&ops, &ConstMap::new());
 
         assert!(
-            result.iter().all(|op| op.opcode != OpCode::CallMallocNursery),
+            result
+                .iter()
+                .all(|op| op.opcode != OpCode::CallMallocNursery),
             "a non_moving descr must never reach the nursery bump path"
         );
         assert_eq!(result.len(), 2);
@@ -3724,6 +3780,53 @@ mod tests {
                 .inline_const_bits()
                 .expect("headered total size const"),
             round_up(payload_size + crate::header::GcHeader::SIZE) as i64
+        );
+    }
+
+    /// The varsize twin: a `non_moving` array descr declines the nursery at a
+    /// constant length the nursery would accept, and lands on the old-generation
+    /// `malloc_array` helper rather than the nursery one.  The length still
+    /// reaches the helper as its last argument, so the block's GcArray length
+    /// header is stamped by the helper itself.
+    #[test]
+    fn test_non_moving_new_array_declines_nursery_at_small_length() {
+        let rw = make_rewriter();
+        let num_elem = 3;
+        let len_ref = OpRef::int_op(10_000);
+        let mut constants: ConstMap<Const> = ConstMap::new();
+        constants.insert(10_000, Const::Int(num_elem));
+        let new_array = Op::with_descr(
+            OpCode::NewArrayClear,
+            &[ro(len_ref)],
+            non_moving_array_descr(),
+        );
+        new_array.pos.set(OpRef::ref_op(0));
+        let ops = vec![new_array, Op::new(OpCode::Finish, &[])];
+
+        let (result, _constants, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &constants);
+
+        assert!(
+            result
+                .iter()
+                .all(|op| op.opcode != OpCode::CallMallocNursery
+                    && op.opcode != OpCode::CallMallocNurseryVarsize),
+            "a non_moving array descr must never reach either nursery path"
+        );
+        let call = result
+            .iter()
+            .find(|op| op.opcode == OpCode::CallR)
+            .expect("non_moving NEW_ARRAY must emit the typed malloc CALL_R");
+        assert_eq!(
+            call.arg(0)
+                .to_opref()
+                .inline_const_bits()
+                .expect("malloc_array fn const"),
+            TEST_MALLOC_ARRAY_OLDGEN_FN
+        );
+        assert_eq!(
+            call.arg(3).to_opref(),
+            len_ref,
+            "the length operand is threaded through as the helper's num_elem"
         );
     }
 
@@ -5087,6 +5190,8 @@ mod tests {
             fielddescr_tid: Some(majit_ir::make_tid_field_descr()),
             malloc_array_fn: TEST_MALLOC_ARRAY_FN,
             malloc_array_nonstandard_fn: TEST_MALLOC_ARRAY_NONSTANDARD_FN,
+            malloc_array_oldgen_fn: TEST_MALLOC_ARRAY_OLDGEN_FN,
+            malloc_array_nonstandard_oldgen_fn: TEST_MALLOC_ARRAY_NONSTANDARD_OLDGEN_FN,
             malloc_str_fn: TEST_MALLOC_STR_FN,
             malloc_unicode_fn: TEST_MALLOC_UNICODE_FN,
             malloc_big_fixedsize_fn: TEST_MALLOC_BIG_FIXEDSIZE_FN,
@@ -5217,6 +5322,7 @@ mod tests {
                 field_size: std::mem::size_of::<usize>(),
                 field_type: Type::Int,
             })),
+            non_moving: false,
         })
     }
 
@@ -5232,6 +5338,7 @@ mod tests {
                 field_size: std::mem::size_of::<usize>(),
                 field_type: Type::Int,
             })),
+            non_moving: false,
         })
     }
 

--- a/majit/majit-gc/src/rewrite.rs
+++ b/majit/majit-gc/src/rewrite.rs
@@ -1077,7 +1077,15 @@ impl GcRewriterImpl {
         // CALL_R helper (`malloc_big_fixedsize`) does it inside the
         // helper so `gen_malloc_fixedsize` does NOT call
         // `gen_initialize_tid` after the fact.
-        let obj_ref = match self.gen_malloc_nursery(size, op.pos.get(), st) {
+        // A descr marked `non_moving` declines the nursery the same way an
+        // oversized one does, and lands on the same helper: `gen_malloc_fixedsize`
+        // allocates in the old generation, which never moves an object.
+        let nursery_ref = if descr.non_moving() {
+            None
+        } else {
+            self.gen_malloc_nursery(size, op.pos.get(), st)
+        };
+        let obj_ref = match nursery_ref {
             Some(r) => {
                 self.gen_initialize_tid(r.clone(), type_id, st);
                 r
@@ -3297,6 +3305,7 @@ mod tests {
         vtable: usize,
         w_class: Option<i64>,
         headerless: bool,
+        non_moving: bool,
         gc_fields: Vec<Arc<dyn FieldDescr>>,
     }
 
@@ -3327,6 +3336,9 @@ mod tests {
         }
         fn headerless(&self) -> bool {
             self.headerless
+        }
+        fn non_moving(&self) -> bool {
+            self.non_moving
         }
         fn gc_fielddescrs(&self) -> &[Arc<dyn FieldDescr>] {
             &self.gc_fields
@@ -3500,6 +3512,7 @@ mod tests {
             vtable: 0,
             w_class: None,
             headerless: false,
+            non_moving: false,
             gc_fields: Vec::new(),
         })
     }
@@ -3511,6 +3524,19 @@ mod tests {
             vtable: 0,
             w_class: None,
             headerless: true,
+            non_moving: false,
+            gc_fields: Vec::new(),
+        })
+    }
+
+    fn non_moving_size_descr(size: usize, type_id: u32) -> DescrRef {
+        Arc::new(TestSizeDescr {
+            size,
+            type_id,
+            vtable: 0,
+            w_class: None,
+            headerless: false,
+            non_moving: true,
             gc_fields: Vec::new(),
         })
     }
@@ -3526,6 +3552,7 @@ mod tests {
             vtable: 0,
             w_class: None,
             headerless: false,
+            non_moving: false,
             gc_fields,
         })
     }
@@ -3543,6 +3570,7 @@ mod tests {
             vtable,
             w_class,
             headerless: false,
+            non_moving: false,
             gc_fields,
         })
     }
@@ -3554,6 +3582,7 @@ mod tests {
             vtable,
             w_class: None,
             headerless: false,
+            non_moving: false,
             gc_fields: Vec::new(),
         })
     }
@@ -3652,6 +3681,50 @@ mod tests {
                  for each constant it mints"
             );
         }
+    }
+
+    /// A `non_moving` descr takes the `malloc_big_fixedsize` helper even at a
+    /// size the nursery would happily accept, so the object is born in the
+    /// non-moving old generation. The size the helper is handed is still the
+    /// headered total, and no separate `gen_initialize_tid` follows — the
+    /// helper stamps the tid itself.
+    #[test]
+    fn test_non_moving_new_declines_nursery_at_small_size() {
+        let rw = make_rewriter();
+        let payload_size = 32;
+        let type_id = 53;
+        let ops = vec![Op::with_descr(
+            OpCode::New,
+            &[],
+            non_moving_size_descr(payload_size, type_id),
+        )];
+
+        let (result, _constants, _gcrefs) =
+            rw.rewrite_for_gc_with_constants(&ops, &ConstMap::new());
+
+        assert!(
+            result.iter().all(|op| op.opcode != OpCode::CallMallocNursery),
+            "a non_moving descr must never reach the nursery bump path"
+        );
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].opcode, OpCode::CallR);
+        assert_eq!(result[1].opcode, OpCode::CheckMemoryError);
+        assert_eq!(
+            result[0]
+                .arg(0)
+                .to_opref()
+                .inline_const_bits()
+                .expect("malloc_big_fixedsize fn const"),
+            TEST_MALLOC_BIG_FIXEDSIZE_FN
+        );
+        assert_eq!(
+            result[0]
+                .arg(1)
+                .to_opref()
+                .inline_const_bits()
+                .expect("headered total size const"),
+            round_up(payload_size + crate::header::GcHeader::SIZE) as i64
+        );
     }
 
     #[test]

--- a/majit/majit-ir/src/descr.rs
+++ b/majit/majit-ir/src/descr.rs
@@ -3707,6 +3707,13 @@ pub trait ArrayDescr: Descr {
         false
     }
 
+    /// Whether `NEW_ARRAY` for this descr must allocate in the non-moving
+    /// old generation instead of the movable nursery.  Same contract as
+    /// [`SizeDescr::non_moving`], for the varsize path.
+    fn non_moving(&self) -> bool {
+        false
+    }
+
     /// Whether the array is a real GC-managed array (has a GC header so
     /// `GUARD_GC_TYPE` may read a type-id at `ptr - GcHeader::SIZE`).
     /// Default `true` so existing array descrs keep their guard; only a
@@ -5028,6 +5035,10 @@ pub struct SimpleArrayDescr {
     /// `ArrayDescr::is_gc_managed`).  `false` only for a header-less raw
     /// native pointer-array minted by `add_ptr_array_descr`.
     is_gc_managed: bool,
+    /// Allocation-generation bit for `NEW_ARRAY` rewriting; see
+    /// [`ArrayDescr::non_moving`].  Atomic so a frontend can stamp it onto
+    /// an already-shared descr, the way `type_id` is stamped.
+    non_moving: AtomicBool,
 }
 
 impl Clone for SimpleArrayDescr {
@@ -5051,6 +5062,7 @@ impl Clone for SimpleArrayDescr {
             concrete_type: self.concrete_type,
             all_interiorfielddescrs: interior,
             is_gc_managed: self.is_gc_managed,
+            non_moving: AtomicBool::new(self.non_moving.load(Ordering::Relaxed)),
         }
     }
 }
@@ -5079,6 +5091,7 @@ impl SimpleArrayDescr {
             concrete_type: '\x00',
             all_interiorfielddescrs: std::sync::OnceLock::new(),
             is_gc_managed: true,
+            non_moving: AtomicBool::new(false),
         }
     }
 
@@ -5106,7 +5119,15 @@ impl SimpleArrayDescr {
             concrete_type: '\x00',
             all_interiorfielddescrs: std::sync::OnceLock::new(),
             is_gc_managed: true,
+            non_moving: AtomicBool::new(false),
         }
+    }
+
+    /// Override the allocation-generation flag (default `false`); see
+    /// [`ArrayDescr::non_moving`].  Takes `&self` so a frontend can stamp
+    /// it after the descr is already behind an `Arc` and registered.
+    pub fn set_non_moving(&self, non_moving: bool) {
+        self.non_moving.store(non_moving, Ordering::Relaxed);
     }
 
     /// Set the GC-managed flag (`false` for a header-less raw native
@@ -5175,6 +5196,9 @@ impl Descr for SimpleArrayDescr {
 impl ArrayDescr for SimpleArrayDescr {
     fn is_gc_managed(&self) -> bool {
         self.is_gc_managed
+    }
+    fn non_moving(&self) -> bool {
+        self.non_moving.load(Ordering::Relaxed)
     }
     fn base_size(&self) -> usize {
         self.base_size

--- a/majit/majit-ir/src/descr.rs
+++ b/majit/majit-ir/src/descr.rs
@@ -100,7 +100,7 @@ use std::sync::Mutex;
 use std::sync::OnceLock;
 use std::sync::RwLock;
 use std::sync::Weak;
-use std::sync::atomic::{AtomicI32, AtomicU32, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicI32, AtomicU32, AtomicU64, Ordering};
 
 use crate::OpRef;
 use crate::effectinfo::{DescrMintEntry, DescrMintSpec, DescrSetMember};
@@ -3346,6 +3346,21 @@ pub trait SizeDescr: Descr {
         false
     }
 
+    /// Whether `NEW` for this descr must allocate in the non-moving old
+    /// generation instead of the movable nursery.
+    ///
+    /// Set it for a type whose objects the host reaches through raw
+    /// pointers it does not register as GC roots: a minor collection
+    /// inside any residual call would move such an object out from under
+    /// those pointers, and the caller would then read and write the dead
+    /// pre-move copy.  The flag exists so a JIT-emitted allocation can
+    /// match the allocator the host itself uses for that type; a type
+    /// whose host allocator is the ordinary nursery one must leave it
+    /// `false`, since the old generation is never collected as cheaply.
+    fn non_moving(&self) -> bool {
+        false
+    }
+
     /// Vtable address, if is_object().
     fn vtable(&self) -> usize {
         0
@@ -4540,6 +4555,10 @@ pub struct SimpleSizeDescr {
     /// Explicit allocation-shape bit for `NEW` rewriting.  Defaults false:
     /// normal JIT-GC structs are headered unless an emitter opts in.
     headerless: bool,
+    /// Allocation-generation bit for `NEW` rewriting; see
+    /// [`SizeDescr::non_moving`].  Atomic so a frontend can stamp it onto
+    /// an already-shared descr, the way `descr_index` is stamped.
+    non_moving: AtomicBool,
     /// descr.py:72 `self.all_fielddescrs = all_fielddescrs`.
     all_fielddescrs: Vec<Arc<dyn FieldDescr>>,
     /// descr.py:71 `self.gc_fielddescrs = gc_fielddescrs`.
@@ -4561,6 +4580,7 @@ impl Clone for SimpleSizeDescr {
             vtable: self.vtable,
             is_gc_managed: self.is_gc_managed,
             headerless: self.headerless,
+            non_moving: AtomicBool::new(self.non_moving.load(Ordering::Relaxed)),
             all_fielddescrs: self.all_fielddescrs.clone(),
             gc_fielddescrs: self.gc_fielddescrs.clone(),
         }
@@ -4579,6 +4599,7 @@ impl SimpleSizeDescr {
             vtable: 0,
             is_gc_managed: true,
             headerless: false,
+            non_moving: AtomicBool::new(false),
             all_fielddescrs: Vec::new(),
             gc_fielddescrs: Vec::new(),
         }
@@ -4595,6 +4616,7 @@ impl SimpleSizeDescr {
             vtable,
             is_gc_managed: true,
             headerless: false,
+            non_moving: AtomicBool::new(false),
             all_fielddescrs: Vec::new(),
             gc_fielddescrs: Vec::new(),
         }
@@ -4618,6 +4640,13 @@ impl SimpleSizeDescr {
     /// Override the allocation-shape flag (default `false`).
     pub fn set_headerless(&mut self, headerless: bool) {
         self.headerless = headerless;
+    }
+
+    /// Override the allocation-generation flag (default `false`); see
+    /// [`SizeDescr::non_moving`].  Takes `&self` so a frontend can stamp
+    /// it after the descr is already behind an `Arc` and registered.
+    pub fn set_non_moving(&self, non_moving: bool) {
+        self.non_moving.store(non_moving, Ordering::Relaxed);
     }
 
     /// descr.py:123-126 — `get_size_descr` calls
@@ -4706,6 +4735,9 @@ impl SizeDescr for SimpleSizeDescr {
     }
     fn headerless(&self) -> bool {
         self.headerless
+    }
+    fn non_moving(&self) -> bool {
+        self.non_moving.load(Ordering::Relaxed)
     }
     fn vtable(&self) -> usize {
         self.vtable

--- a/pyre/bench/synth/attr_store_add_transition.py
+++ b/pyre/bench/synth/attr_store_add_transition.py
@@ -1,0 +1,75 @@
+# pyre-check: max-pypy-ratio=12
+# STORE_ATTR that ADDS an attribute not yet in the instance's map: the
+# `map -> PlainAttribute` transition plus the grow-by-one storage rewrite
+# (mapdict.py:942-959 `_set_mapdict_increase_storage1`).  The values are
+# strings so every slot stays boxed, which is the shape the JIT emits inline;
+# an unboxed slot keeps the general residual.
+#
+# The hot loop holds the two folded shapes — the first attribute of a fresh
+# instance (empty storage block) and a second attribute (the live slot is
+# copied into the wider block) — so the ratio measures the fold itself.  The
+# shapes the fold declines or that force materialization are exercised once
+# each in `edges()`, for agreement with the interpreter rather than for speed.
+N = 200000
+
+
+class Fresh:
+    pass
+
+
+class Pair:
+    def __init__(self, a, b):
+        self.a = a
+        self.b = b
+
+
+class Either:
+    pass
+
+
+def edges():
+    out = []
+    # `_reorder_and_add` (mapdict.py:204-258): both orders off one class, so
+    # the second instance finds the attribute above its own map.
+    for first in (0, 1):
+        obj = Either()
+        if first:
+            obj.p = "p"
+            obj.q = "qq"
+        else:
+            obj.q = "qq"
+            obj.p = "p"
+        out.append(sorted(vars(obj).items()))
+    # An instance the loop keeps has to materialize instead of staying virtual.
+    kept = []
+    for i in range(4):
+        obj = Pair("a" * i, "b")
+        kept.append(obj)
+    out.append([(o.a, o.b) for o in kept])
+    # Add, delete, re-add: the second add starts from the popped-back map.
+    obj = Fresh()
+    obj.x = "1"
+    del obj.x
+    obj.x = "2"
+    out.append((obj.x, sorted(vars(obj).items())))
+    return out
+
+
+def main():
+    total = 0
+    i = 0
+    while i < N:
+        # first attribute: storage grows 0 -> 1
+        one = Fresh()
+        one.x = "x"
+        total = total + len(one.x)
+
+        # second attribute: the existing slot is copied into the wider block
+        two = Pair("ab", "cde")
+        total = total + len(two.a) + len(two.b)
+
+        i = i + 1
+    print(total, edges())
+
+
+main()

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -579,18 +579,6 @@ unsafe fn walk_builtin_type_dicts_gc(forward: &mut dyn FnMut(&mut PyObjectRef)) 
     }
 }
 
-/// Whether `PYRE_INTERP_RETURN_LOG` asks the RETURN_VALUE handler to trace
-/// every returning frame.
-///
-/// Read once: `finish_value` runs on every interpreted return, and `getenv`
-/// takes a lock and scans the environment array, so an uncached read puts that
-/// scan on the return path of every Python-level call.
-#[cfg(not(feature = "sandbox"))]
-fn interp_return_log_enabled() -> bool {
-    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *ENABLED.get_or_init(|| std::env::var_os("PYRE_INTERP_RETURN_LOG").is_some())
-}
-
 /// Whether the incminimark-parity minor-collection skip of clean prebuilt
 /// structures is enabled (`PYRE_GC_PREBUILT_REMEMBER=0` opts out, restoring
 /// the rescan-everything-every-minor behavior).

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -579,6 +579,18 @@ unsafe fn walk_builtin_type_dicts_gc(forward: &mut dyn FnMut(&mut PyObjectRef)) 
     }
 }
 
+/// Whether `PYRE_INTERP_RETURN_LOG` asks the RETURN_VALUE handler to trace
+/// every returning frame.
+///
+/// Read once: `finish_value` runs on every interpreted return, and `getenv`
+/// takes a lock and scans the environment array, so an uncached read puts that
+/// scan on the return path of every Python-level call.
+#[cfg(not(feature = "sandbox"))]
+fn interp_return_log_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| std::env::var_os("PYRE_INTERP_RETURN_LOG").is_some())
+}
+
 /// Whether the incminimark-parity minor-collection skip of clean prebuilt
 /// structures is enabled (`PYRE_GC_PREBUILT_REMEMBER=0` opts out, restoring
 /// the rescan-everything-every-minor behavior).

--- a/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
+++ b/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
@@ -341,6 +341,17 @@ pub unsafe fn ensure_mapdict_initialized(obj: PyObjectRef) {
     inst._set_mapdict_map(term);
 }
 
+/// [`type_terminator_or_create`] for callers outside the mapdict layer — the
+/// JIT's instantiation emit bakes the terminator into the trace as the fresh
+/// instance's `map`, so it needs the same one the interpreter would install
+/// rather than the null a not-yet-touched type still carries.
+///
+/// # Safety
+/// `w_type` must be a live `W_TypeObject`.
+pub unsafe fn ensure_type_terminator(w_type: PyObjectRef) -> *const u8 {
+    unsafe { type_terminator_or_create(w_type) as *const u8 }
+}
+
 /// Fetch `w_type`'s instance terminator, lazily creating and storing it on the
 /// type if absent (covering types built before the eager install site).
 ///

--- a/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
+++ b/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
@@ -1676,6 +1676,180 @@ pub unsafe fn store_attr_boxed_fast_path(
     Some((w_type, version_tag, map, p.storageindex))
 }
 
+/// The map transition an attribute-adding STORE_ATTR takes, resolved without
+/// performing it.  See [`store_attr_add_fast_path`].
+pub struct StoreAttrAdd {
+    /// The receiver's type, whose `version_tag` the caller guards.
+    pub w_type: PyObjectRef,
+    /// That type's live version tag.
+    pub version_tag: u64,
+    /// The instance's current map, which the caller guards.
+    pub map: MapRef,
+    /// The `PlainAttribute` the instance's map becomes — a direct child of
+    /// `map`, so the transition is `map -> new_map` with no reordering.
+    pub new_map: MapRef,
+    /// `new_map.storageindex`, which is also `map.storage_needed()`: the
+    /// transition appends exactly one slot, and the value lands in it.
+    pub storageindex: usize,
+}
+
+/// Resolve the `map -> PlainAttribute` transition that a STORE_ATTR adding a
+/// not-yet-present boxed attribute would take, *without* performing it, so the
+/// JIT can emit `_set_mapdict_increase_storage1` (mapdict.py:942-959) as trace
+/// operations instead of an opaque residual call.  Every value the caller needs
+/// is a trace-time constant once the receiver's map and its type's version tag
+/// are guarded.
+///
+/// Declines anything the plain grow-by-one shape does not cover, so the caller
+/// can fall back to the general residual: an attribute already in the map (the
+/// [`store_attr_boxed_fast_path`] / [`store_attr_unboxed_fast_path`] cases), a
+/// value that would take an unboxed slot, a terminator that routes the write
+/// elsewhere, the `_reorder_and_add` case (mapdict.py:204-258), the
+/// `LIMIT_MAP_ATTRIBUTES` devolve, and a storage block the collector does not
+/// own (whose replacement the interpreter would have to free).
+///
+/// Resolving interns the transition through `_find_branch_to_move_into`, which
+/// `add_attr` would do anyway on this very store; it is idempotent and the
+/// resulting node is immortal.
+///
+/// # Safety
+/// `w_obj` must be a live object and `w_value` a live value.
+pub unsafe fn store_attr_add_fast_path(
+    w_obj: PyObjectRef,
+    name: &str,
+    w_value: PyObjectRef,
+) -> Option<StoreAttrAdd> {
+    if name == "__class__" {
+        return None;
+    }
+    // mapdict.py:1591 `if map is not None:` — also filters non-instances.
+    let map = unsafe { mapdict_map_or_null(w_obj) };
+    if map.is_null() {
+        return None;
+    }
+    let terminator = unsafe { (*map).terminator() };
+    let term = unsafe { (*terminator).as_terminator() };
+    let w_type = term.w_cls;
+    if w_type.is_null() {
+        return None;
+    }
+    // mapdict.py:1612-1614 / 1630-1631 — a custom `__setattr__` owns the
+    // write, and STORE caching also requires the standard `__getattribute__`.
+    if unsafe { crate::baseobjspace::setattr_if_not_from_object(w_type) }.is_some() {
+        return None;
+    }
+    if unsafe { crate::baseobjspace::getattribute_if_not_from_object(w_type) }.is_some() {
+        return None;
+    }
+    // mapdict.py:1616 `if version_tag is not None:`.
+    let version_tag = unsafe { crate::baseobjspace::w_type_version_tag(w_type) };
+    if version_tag == 0 {
+        return None;
+    }
+    // mapdict.py:1618-1627 `_pure_lookup_where_with_method_cache` + classify.
+    let w_descr = unsafe { crate::baseobjspace::lookup_in_type_where(w_type, name) };
+    let (attrkind, is_slot) = unsafe { classify_attr(w_type, w_descr, true) };
+    if attrkind == INVALID {
+        return None;
+    }
+    let attrname = Wtf8::new(if is_slot { "slot" } else { name });
+    // This arm is the ADD; an attribute already in the map belongs to the
+    // in-place write paths (mapdict.py:1628 `map.find_map_attr`).
+    if unsafe { find_map_attr(map, attrname, attrkind) }.is_some() {
+        return None;
+    }
+    // mapdict.py:312-321 `_write_terminator` — a `NoDictTerminator` rejects a
+    // DICT write and a `DevolvedDictTerminator` sends it to the materialised
+    // instance dict; neither reaches `add_attr`.
+    if attrkind == DICT && term.kind != TerminatorKind::Dict {
+        return None;
+    }
+    // Only the boxed shape is emittable: an unboxed slot holds an erased
+    // longlong list the trace has no way to build (mapdict.py:629-646).
+    if unsafe { pick_unbox_type(map, w_value) }.is_some() {
+        return None;
+    }
+    // The emitted transition copies the live slots into the wider block with
+    // reference loads, so every existing slot must hold a reference.  An
+    // unboxed attribute anywhere in the chain puts an erased `Vec<i64>` raw
+    // pointer in its slot (mapdict.py:600-601 `_prim_direct_read`), which
+    // `instance_walk_boxed_storage` skips precisely because it is not one.
+    let mut node = map;
+    while unsafe { (*node).is_plain() } {
+        let n = unsafe { (*node).as_plain() };
+        if n.unboxed.is_some() {
+            return None;
+        }
+        node = n.back;
+    }
+    // mapdict.py:170-193 — `number_to_readd != 0` is `_reorder_and_add`, which
+    // pops and re-adds intermediate attributes.
+    let (number_to_readd, holder) =
+        unsafe { find_branch_to_move_into(map, attrname, attrkind, None) };
+    if number_to_readd != 0 {
+        return None;
+    }
+    let new_map = unsafe { holder_pick_attr(holder, None) };
+    if !unsafe { (*new_map).is_plain() } {
+        return None;
+    }
+    let p = unsafe { (*new_map).as_plain() };
+    if p.unboxed.is_some() || !std::ptr::eq(p.back, map) {
+        return None;
+    }
+    // mapdict.py:317-323 — a DICT add that reaches the attribute limit devolves
+    // the instance's `__dict__` into a text-strategy dict.
+    if attrkind == DICT && unsafe { (*new_map).num_attributes() } >= LIMIT_MAP_ATTRIBUTES {
+        return None;
+    }
+    // The grow-by-one shape `_set_mapdict_increase_storage1` implements: the
+    // new slot is appended at the current length.
+    let storage_needed = unsafe { (*map).storage_needed() };
+    if p.storageindex != storage_needed
+        || unsafe { (*new_map).storage_needed() } != storage_needed + 1
+    {
+        return None;
+    }
+    // `grow_instance_items_block` frees the block it replaces, which is a no-op
+    // only for a collector-owned block.  A `std::alloc` fallback block (no GC
+    // hook) would leak once the emitted allocation replaces it without a free.
+    let inst = unsafe { &*(w_obj as *const pyre_object::W_ObjectObject) };
+    if !inst.storage.is_null() && !pyre_object::gc_hook::try_gc_owns_object(inst.storage as *mut u8)
+    {
+        return None;
+    }
+    if unsafe { pyre_object::object_array::items_block_capacity(inst.storage) } != storage_needed {
+        return None;
+    }
+    Some(StoreAttrAdd {
+        w_type,
+        version_tag,
+        map,
+        new_map,
+        storageindex: p.storageindex,
+    })
+}
+
+/// Perform the transition [`store_attr_add_fast_path`] resolved.  The JIT's
+/// walk is the authoritative execution path, so it applies the store itself
+/// after emitting the equivalent trace operations.
+///
+/// # Safety
+/// `w_obj` must be the live instance the resolution came from, still on
+/// `resolved.map`, and `w_value` a live value.
+pub unsafe fn store_attr_add_commit(
+    w_obj: PyObjectRef,
+    resolved: &StoreAttrAdd,
+    w_value: PyObjectRef,
+) {
+    let _instance_guard = instance_lock(w_obj);
+    let inst = unsafe { &mut *(w_obj as *mut pyre_object::W_ObjectObject) };
+    debug_assert!(std::ptr::eq(inst._get_mapdict_map(), resolved.map));
+    // mapdict.py:449-459 with `storage_needed() > _mapdict_storage_length()`,
+    // which `store_attr_add_fast_path` proved by construction.
+    inst._set_mapdict_increase_storage1(resolved.new_map, w_value);
+}
+
 /// mapdict.py:914-916 `_mapdict_read_storage(storageindex)` for a
 /// `W_ObjectObject` — the boxed-slot read the JIT LOAD_ATTR fast path folds
 /// to. `load_attr_fast_path` already established that the resolved attribute

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -2174,13 +2174,22 @@ pub fn type_version_tag_descr() -> DescrRef {
 /// `ensure_ptr_info_arg0` (`optimizer.py:478`); the LOAD_ATTR fold reads these
 /// fields inline, so they must carry the owning struct's SizeDescr.
 ///
-/// Only `map` and `storage` are enumerated (the header `ob_type`/`w_class` are
-/// read through their own `ob_type_descr` / `w_class_descr`).  `map` is an
-/// opaque `Int` word (interned immortal map nodes — not a GC ref, stays off
-/// `gc_fielddescrs`); `storage` is a `Ref` block pointer (enters
+/// `map` is an opaque `Int` word (interned immortal map nodes — not a GC ref,
+/// stays off `gc_fielddescrs`); `storage` is a `Ref` block pointer (enters
 /// `gc_fielddescrs` so a `setfield_gc` emits the write barrier).
+///
+/// The inherited header `w_class` is a member of the group — not just the
+/// standalone `w_class_descr` — because the instantiation emit
+/// (`try_walker_inline_type_call`) builds instances with `NewWithVtable`, and
+/// the class a `getfield_gc(w_class)` off such a virtual must answer with is
+/// the *stored* one.  Every instance shares `INSTANCE_TYPE` as its vtable
+/// while its Python class varies per instance, so the vtable-derived fallback
+/// (`w_class_obj`, which resolves `INSTANCE_TYPE`'s `get_instantiate` to
+/// `object`) is wrong here; only a field the virtual actually tracks gives
+/// `OptVirtualize` the right answer, and materialization then reproduces the
+/// header.
 static W_OBJECT_OBJECT_DESCR_GROUP: LazyLock<PyreObjectDescrGroup> = LazyLock::new(|| {
-    build_object_descr_group_with_def_path(
+    let group = build_object_descr_group_with_def_path(
         pyre_object::W_OBJECT_OBJECT_SIZE,
         pyre_object::objectobject::W_OBJECT_OBJECT_GC_TYPE_ID,
         &pyre_object::pyobject::INSTANCE_TYPE as *const _ as usize,
@@ -2209,10 +2218,29 @@ static W_OBJECT_OBJECT_DESCR_GROUP: LazyLock<PyreObjectDescrGroup> = LazyLock::n
                 false,
                 false,
             ),
+            (
+                "PyObject.w_class",
+                pyre_object::pyobject::W_CLASS_OFFSET,
+                8,
+                Type::Ref,
+                false,
+                false,
+                false,
+            ),
         ],
         "W_ObjectObject",
         "objectobject::W_ObjectObject",
-    )
+    );
+    // `alloc_instance_object` (`objectobject.rs`) allocates every interpreter
+    // instance through the stable, non-moving old-gen allocator, because the
+    // instance layer reaches an instance through raw pointers it does not root
+    // — `store_attr_caching` holds one across the allocation of the storage
+    // block it is about to install.  A JIT-emitted instance has to agree: put
+    // it in the nursery and the first minor collection inside such a residual
+    // moves it, after which the caller finishes writing `map` / `storage` into
+    // the dead pre-move copy and the attribute is lost.
+    group.size_descr.set_non_moving(true);
+    group
 });
 
 /// `W_ObjectObject.map` (`objectobject.rs:38`) — the erased `*const MapNode`
@@ -2235,6 +2263,22 @@ pub fn object_map_descr() -> DescrRef {
 /// replaces the block.
 pub fn object_storage_descr() -> DescrRef {
     field_descr_from_group(&W_OBJECT_OBJECT_DESCR_GROUP, 1)
+}
+
+/// The instance's own `PyObject.w_class` — the Python class `w_instance_new`
+/// stamps into the header. Kept in the instance group (not the standalone
+/// `w_class_descr`) so the instantiation emit's store is a virtual field of
+/// the same size descr; see [`W_OBJECT_OBJECT_DESCR_GROUP`].
+pub fn object_header_w_class_descr() -> DescrRef {
+    field_descr_from_group(&W_OBJECT_OBJECT_DESCR_GROUP, 2)
+}
+
+/// Size descriptor for a `W_ObjectObject` allocation via `NewWithVtable`
+/// (vtable = `&INSTANCE_TYPE`); the header `w_class` and `map` are
+/// `SetfieldGc`'d after, and `storage` stays at the allocator's zero (the
+/// `_mapdict_init_empty` `storage = None` state).
+pub fn w_object_object_size_descr() -> DescrRef {
+    W_OBJECT_OBJECT_DESCR_GROUP.size_descr.clone()
 }
 
 /// rlist.py:116 `l.length` — live length of a list under the Object

--- a/pyre/pyre-jit-trace/src/helpers.rs
+++ b/pyre/pyre-jit-trace/src/helpers.rs
@@ -648,16 +648,15 @@ pub fn emit_instance_inline(ctx: &mut TraceCtx, header_w_class: OpRef, map: OpRe
 /// `CondCallGcWb(obj)` for it, and it is emitted after the item stores, so a
 /// young value already in the block is remembered with the instance.
 ///
-/// The two instance field stores are ordered `storage` before `map`, and that
-/// order is load-bearing under free threading.  These are raw stores, so a
-/// concurrent reader of the same instance can observe the pair half-written;
-/// with this order the only visible intermediate is the longer block under the
-/// shorter map, which over-allocates by one slot.  The reverse order would
-/// publish a map claiming an index the installed block does not have.  Nothing
-/// here serializes against another thread mutating the same instance — the
-/// pre-existing in-trace mapdict fast paths (`jit_mapdict_read`,
-/// `jit_mapdict_boxed_write`) reach `storage` without the striped
-/// `instance_lock` in the same way.
+/// Free threading: these are raw stores, so unlike the interpreter's transition
+/// they do not hold the striped `instance_lock`, and unlike the single-slot
+/// in-place write they publish two fields.  The caller is what makes that
+/// sound — it folds only an `is_unescaped` receiver, one this trace allocated
+/// and no other thread can name yet.  The two stores are still ordered
+/// `storage` before `map`, so the only intermediate a later reader can observe
+/// is the longer block under the shorter map, which over-allocates by one slot;
+/// the reverse order would publish a map claiming an index the installed block
+/// does not have.
 pub fn emit_mapdict_add_attr_inline(
     ctx: &mut TraceCtx,
     obj: OpRef,

--- a/pyre/pyre-jit-trace/src/helpers.rs
+++ b/pyre/pyre-jit-trace/src/helpers.rs
@@ -622,6 +622,69 @@ pub fn emit_instance_inline(ctx: &mut TraceCtx, header_w_class: OpRef, map: OpRe
     new_op
 }
 
+/// Emit `_set_mapdict_increase_storage1` (`mapdict.py:942-959`) as trace
+/// operations: allocate the one-slot-longer storage block, copy the
+/// `old_len` live slots over, append the new value, then install the block
+/// and the transition map on the instance.
+///
+/// `old_len` and `new_map` are trace-time constants, established by the map
+/// guard `store_attr_add_fast_path`'s caller emits; a fresh instance has
+/// `old_len == 0`, so the loop body disappears and only the allocation and
+/// the two field stores remain.
+///
+/// The point of emitting this rather than calling a residual is virtualization:
+/// with the store folded, an instance built and thrown away inside one loop
+/// iteration escapes nowhere and the optimizer removes it, its storage block,
+/// and the value box along with it.
+///
+/// The old block is left to the collector.  `grow_instance_items_block` frees
+/// the block it replaces, but that free is a no-op for a GC-owned block, which
+/// `store_attr_add_fast_path` requires.
+///
+/// GC: the block is a leaf, so the barrier that matters is the one on the
+/// *instance* — the collector reaches the block's slots only through
+/// `object_object_custom_trace`.  Storing `new_block` into the instance's
+/// `storage` field is a reference store, so the GC rewriter emits
+/// `CondCallGcWb(obj)` for it, and it is emitted after the item stores, so a
+/// young value already in the block is remembered with the instance.
+pub fn emit_mapdict_add_attr_inline(
+    ctx: &mut TraceCtx,
+    obj: OpRef,
+    old_len: usize,
+    new_map: OpRef,
+    value: OpRef,
+) {
+    let new_len = ctx.const_int(old_len as i64 + 1);
+    let new_block = ctx.record_op_with_descr(
+        OpCode::NewArrayClear,
+        &[new_len],
+        crate::state::mapdict_storage_gcarray_descr(),
+    );
+    ctx.heap_cache_mut().new_object(new_block);
+
+    if old_len > 0 {
+        let old_block =
+            crate::state::opimpl_getfield_gc_r(ctx, obj, crate::descr::object_storage_descr());
+        for index in 0..old_len {
+            let index_op = ctx.const_int(index as i64);
+            let item = crate::state::trace_mapdict_storage_getitem(ctx, old_block, index_op);
+            crate::state::trace_mapdict_storage_setitem(ctx, new_block, index_op, item);
+        }
+    }
+
+    let value_index = ctx.const_int(old_len as i64);
+    crate::state::trace_mapdict_storage_setitem(ctx, new_block, value_index, value);
+
+    for (field_descr, stored) in [
+        (crate::descr::object_storage_descr(), new_block),
+        (crate::descr::object_map_descr(), new_map),
+    ] {
+        let index = field_descr.index();
+        ctx.record_op_with_descr(OpCode::SetfieldGc, &[obj, stored], field_descr);
+        ctx.heapcache_setfield_cached(obj, index, stored);
+    }
+}
+
 /// Emit inline Object-strategy `W_ListObject` creation as traced
 /// `NewArrayClear` + `SetarrayitemGc` + `NewWithVtable` + `SetfieldGc`
 /// ops the optimizer can virtualize when the list never escapes — instead

--- a/pyre/pyre-jit-trace/src/helpers.rs
+++ b/pyre/pyre-jit-trace/src/helpers.rs
@@ -589,6 +589,39 @@ pub fn emit_bound_method_inline(
     new_op
 }
 
+/// Emit inline `W_ObjectObject` creation (`NewWithVtable` + `SetfieldGc` for
+/// the inherited header `PyObject.w_class` and `map`), mirroring
+/// `objectobject.rs w_instance_new`.
+///
+/// `storage` keeps the allocation's zero — `w_instance_new` stores a null
+/// there as well (`mapdict.py:908-910 _mapdict_init_empty`, `storage = None`).
+/// `map` is the owning type's terminator, read eagerly for the same reason
+/// `w_instance_new` reads it: a deferred install leaves the promoted map guard
+/// on the next iteration's fresh instance naming a map the instance does not
+/// have yet.
+///
+/// Emitting the instantiation as New+SetField instead of the opaque
+/// `bh_call_fn` residual lets the optimizer virtualize the instance away when
+/// it never escapes the loop — the shape PyPy gets by tracing through
+/// `typeobject.py descr_call` → `space.allocate_instance`.
+pub fn emit_instance_inline(ctx: &mut TraceCtx, header_w_class: OpRef, map: OpRef) -> OpRef {
+    let new_op = ctx.record_op_with_descr(
+        OpCode::NewWithVtable,
+        &[],
+        crate::descr::w_object_object_size_descr(),
+    );
+    ctx.heap_cache_mut().new_object(new_op);
+    for (descr, value) in [
+        (crate::descr::object_header_w_class_descr(), header_w_class),
+        (crate::descr::object_map_descr(), map),
+    ] {
+        let index = descr.index();
+        ctx.record_op_with_descr(OpCode::SetfieldGc, &[new_op, value], descr);
+        ctx.heapcache_setfield_cached(new_op, index, value);
+    }
+    new_op
+}
+
 /// Emit inline Object-strategy `W_ListObject` creation as traced
 /// `NewArrayClear` + `SetarrayitemGc` + `NewWithVtable` + `SetfieldGc`
 /// ops the optimizer can virtualize when the list never escapes — instead

--- a/pyre/pyre-jit-trace/src/helpers.rs
+++ b/pyre/pyre-jit-trace/src/helpers.rs
@@ -647,6 +647,17 @@ pub fn emit_instance_inline(ctx: &mut TraceCtx, header_w_class: OpRef, map: OpRe
 /// `storage` field is a reference store, so the GC rewriter emits
 /// `CondCallGcWb(obj)` for it, and it is emitted after the item stores, so a
 /// young value already in the block is remembered with the instance.
+///
+/// The two instance field stores are ordered `storage` before `map`, and that
+/// order is load-bearing under free threading.  These are raw stores, so a
+/// concurrent reader of the same instance can observe the pair half-written;
+/// with this order the only visible intermediate is the longer block under the
+/// shorter map, which over-allocates by one slot.  The reverse order would
+/// publish a map claiming an index the installed block does not have.  Nothing
+/// here serializes against another thread mutating the same instance — the
+/// pre-existing in-trace mapdict fast paths (`jit_mapdict_read`,
+/// `jit_mapdict_boxed_write`) reach `storage` without the striped
+/// `instance_lock` in the same way.
 pub fn emit_mapdict_add_attr_inline(
     ctx: &mut TraceCtx,
     obj: OpRef,

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -1744,6 +1744,7 @@ pub(crate) fn try_walker_inline_user_call<Sym: WalkSym>(
         None,
         false,
         false,
+        None,
     )
 }
 
@@ -2410,6 +2411,7 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
     arg_class_guard: Option<ArgClassGuard>,
     allow_method_load_attr: bool,
     require_str_result: bool,
+    constructor_result: Option<(OpRef, ConcreteValue)>,
 ) -> Result<Option<(DispatchOutcome, usize)>, DispatchError> {
     // `_compute_flatcall` (`pycode.py:256-268`) leaves `fast_natural_arity`
     // HOPELESS for a `*args` / `**kwargs` / keyword-only callee, so
@@ -3990,6 +3992,22 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
                 }
                 return Err(DispatchError::callee_inline_unsupported(op.pc));
             }
+            // `descr_call` discards `__init__`'s result after checking it is
+            // None and returns the instance instead (`check_init_returned_none`).
+            // A non-None result is a TypeError the inlined body cannot raise, so
+            // give the callee back to the interpreter, which re-runs the call and
+            // raises the faithful message.
+            let (value, concrete_for_shadow) = match constructor_result {
+                Some(instance) => {
+                    if !matches!(concrete_for_shadow,
+                        ConcreteValue::Ref(obj) if unsafe { pyre_object::is_none(obj) })
+                    {
+                        return Err(DispatchError::callee_inline_unsupported(op.pc));
+                    }
+                    instance
+                }
+                None => (value, concrete_for_shadow),
+            };
             match dst_bank {
                 'r' => write_ref_reg(ctx, op.pc, dst, value, concrete_for_shadow)?,
                 'i' => write_int_reg(ctx, op.pc, dst, value, concrete_for_shadow)?,
@@ -4072,6 +4090,238 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
 }
 
 /// Route `str(exc)` / `repr(exc)` through an app-level exception override.
+/// Instantiate a user-defined class inside the trace instead of leaving `P()`
+/// an opaque `bh_call_fn` residual that re-enters `type_descr_call_impl`,
+/// `object.__new__` and an interpreted `__init__` frame every iteration.
+///
+/// This is the walker counterpart of `typeobject.py descr_call`: promote the
+/// class, run `__new__`, then `__init__` with the fresh instance as `self`.
+/// Only the shape where `__new__` is `object`'s is emitted — that is exactly
+/// the case whose allocation `object_descr_new` performs unconditionally
+/// (`w_instance_new`), so the emitted `NewWithVtable` + header/`map` stores
+/// reproduce it field for field.  A class that overrides `__new__`, is
+/// abstract, refuses instantiation, or carries `__del__` (whose instances
+/// `w_instance_new` registers on the finalizer queue) declines to the residual.
+///
+/// The payoff is not the removed dispatch alone: an instance built by
+/// `new_with_vtable` is a virtual, so a constructor whose result never escapes
+/// the loop optimizes away entirely, as it does upstream.
+#[allow(clippy::too_many_arguments)]
+/// Report why the instantiation emit declined, under `PYRE_FBW_INLINE_DIAG`.
+fn type_call_decline(reason: &str) -> Result<Option<(DispatchOutcome, usize)>, DispatchError> {
+    if std::env::var("PYRE_FBW_INLINE_DIAG").is_ok() {
+        eprintln!("[type-call-decline] {reason}");
+    }
+    Ok(None)
+}
+
+pub(crate) fn try_walker_inline_type_call<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    op: &DecodedOp,
+    code: &[u8],
+    funcptr: OpRef,
+    r_args: &[OpRef],
+    call_descr: &dyn majit_ir::descr::CallDescr,
+    dst_bank: char,
+    dst: usize,
+) -> Result<Option<(DispatchOutcome, usize)>, DispatchError> {
+    if !ctx.is_authoritative_executor || ctx.fbw_mode.inline_subwalk || dst_bank != 'r' {
+        return Ok(None);
+    }
+    // `[callable, null_or_self, args...]`.  A method-form call (`null_or_self`
+    // populated) never names a class as its callable.
+    if r_args.len() < 2 || walker_concrete_ref_object(ctx, r_args[1]).is_some() {
+        return Ok(None);
+    }
+    let Some(w_type) = walker_concrete_ref_object(ctx, r_args[0]) else {
+        return Ok(None);
+    };
+    if !unsafe { pyre_object::is_type(w_type) } {
+        return Ok(None);
+    }
+    // `type(x)` is the one-argument class introspection shortcut, not an
+    // instantiation (`type_call_type_x_shortcut`).
+    let w_metatype = pyre_interpreter::typedef::w_type();
+    if std::ptr::eq(w_type, w_metatype) {
+        return type_call_decline("type(x) shortcut");
+    }
+    // What follows is `type.__call__`.  A metaclass that overrides `__call__`
+    // runs instead of it and may return anything at all, so it stays residual.
+    if !std::ptr::eq(unsafe { (*w_type).w_class }, w_metatype) {
+        return type_call_decline("metaclass overrides __call__");
+    }
+    // A version tag of 0 is a type whose dict changes are not tracked, so the
+    // `__new__` / `__init__` / `__del__` lookups below cannot be pinned.
+    let version_tag = unsafe { pyre_object::typeobject::w_type_get_version_tag(w_type) };
+    if version_tag == 0 {
+        return type_call_decline("no version tag");
+    }
+    if unsafe {
+        pyre_object::w_type_disallows_instantiation(w_type)
+            || pyre_object::w_type_is_abstract(w_type)
+            || pyre_object::typeobject::w_type_get_hasuserdel(w_type)
+    } {
+        return type_call_decline("not instantiable, abstract, or has __del__");
+    }
+    // `map` is baked as a constant, so install the terminator now if the type
+    // has not been asked for one yet — a class nobody has read an attribute off
+    // still carries null, and baking that would hand every traced instance a
+    // map the interpreter's own instances do not have.  The terminator is
+    // created once and never replaced, so the constant stays valid.
+    let terminator =
+        unsafe { pyre_interpreter::objspace::std::mapdict::ensure_type_terminator(w_type) };
+    if terminator.is_null() {
+        return type_call_decline("no terminator");
+    }
+    let w_object = pyre_interpreter::typedef::w_object();
+    if w_object.is_null() {
+        return Ok(None);
+    }
+    // Only `object.__new__` allocates the plain `[ob_type | w_class | map |
+    // storage]` instance this emit builds; any other `__new__` picks its own
+    // layout (a builtin subclass) or runs arbitrary code.
+    let tp_new = unsafe { pyre_interpreter::baseobjspace::lookup_in_type(w_type, "__new__") };
+    let obj_new = unsafe { pyre_interpreter::baseobjspace::lookup_in_type(w_object, "__new__") };
+    if tp_new != obj_new {
+        return type_call_decline("__new__ overridden");
+    }
+    let tp_init = unsafe { pyre_interpreter::baseobjspace::lookup_in_type(w_type, "__init__") };
+    let obj_init = unsafe { pyre_interpreter::baseobjspace::lookup_in_type(w_object, "__init__") };
+    let init_override = (tp_init != obj_init).then_some(tp_init).flatten();
+    // `object.__new__`/`object.__init__` both reject surplus arguments when
+    // neither is overridden; leave that TypeError to the interpreter.
+    if init_override.is_none() && r_args.len() != 2 {
+        return type_call_decline("surplus args without __init__");
+    }
+    let inlinable_init = match init_override {
+        Some(init) => match unsafe { resolve_inlinable_callee(init) } {
+            Some(resolved) => Some((init, resolved)),
+            // An overridden `__init__` that is not a plain Python function
+            // (a builtin, or a callable object) has no body to walk.
+            None => return type_call_decline("__init__ not inlinable"),
+        },
+        None => None,
+    };
+
+    let mut arg_concretes = vec![ConcreteValue::Ref(w_type), ConcreteValue::Null];
+    let mut callee_arg_concretes = Vec::with_capacity(r_args.len() - 1);
+    for &arg in &r_args[2..] {
+        let Some(concrete) = walker_concrete_ref_object(ctx, arg) else {
+            return Ok(None);
+        };
+        arg_concretes.push(ConcreteValue::Ref(concrete));
+        callee_arg_concretes.push(ConcreteValue::Ref(concrete));
+    }
+
+    // Everything below emits.  `try_walker_inline_resolved_user_call` has
+    // decline paths of its own past this point, so keep a rewind point and cut
+    // back to it — the orphaned instance is unreachable and `__init__` has not
+    // run, so the residual re-does the whole instantiation from scratch.
+    let pre_fold_pos = ctx.trace_ctx.get_trace_position();
+
+    // Pin the class and the type-dict version the two lookups above resolved
+    // against, so redefining `__new__` / `__init__` / `__del__` deopts.
+    let type_const = ctx.trace_ctx.const_ref(w_type as i64);
+    walker_emit_fold_guard_with_snapshot(ctx, op.pc, OpCode::GuardValue, &[r_args[0], type_const])?;
+    ctx.trace_ctx
+        .heap_cache_mut()
+        .replace_box(r_args[0], type_const);
+    let live_version = crate::state::opimpl_getfield_gc_i(
+        ctx.trace_ctx,
+        type_const,
+        crate::descr::type_version_tag_descr(),
+    );
+    let version_const = ctx.trace_ctx.const_int(version_tag as i64);
+    walker_emit_fold_guard_with_snapshot(
+        ctx,
+        op.pc,
+        OpCode::GuardValue,
+        &[live_version, version_const],
+    )?;
+    ctx.trace_ctx
+        .heap_cache_mut()
+        .replace_box(live_version, version_const);
+
+    // The walker is the executor here, so the instance the rest of this walk
+    // reads has to be a real one — the same split `trace_box_int` makes between
+    // the recorded allocation and the concrete object it hands back.
+    let concrete_instance = pyre_object::w_instance_new(w_type);
+    let terminator_const = ctx.trace_ctx.const_int(terminator as i64);
+    let instance =
+        crate::helpers::emit_instance_inline(ctx.trace_ctx, type_const, terminator_const);
+    // Bind the emitted allocation to the object the walker actually made, and
+    // record the layout its `NewWithVtable` stamps.  Without the concrete
+    // binding the instance reaches a residual as a box with no value and the
+    // residual declines (`[fbw-resid-decline] box_value=None`), which costs the
+    // recording iteration; without the class the receiver re-guards its own
+    // freshly emitted layout.
+    ctx.trace_ctx.set_opref_concrete(
+        instance,
+        majit_ir::Value::Ref(majit_ir::GcRef(concrete_instance as usize)),
+    );
+    ctx.trace_ctx.heap_cache_mut().class_now_known(
+        instance,
+        &pyre_object::pyobject::INSTANCE_TYPE as *const _ as i64,
+    );
+    if std::env::var("PYRE_FBW_INLINE_DIAG").is_ok() {
+        eprintln!(
+            "[type-call-inline] pc={} class={} init={}",
+            op.pc,
+            unsafe { pyre_object::w_type_get_name(w_type) },
+            inlinable_init.is_some(),
+        );
+    }
+
+    let Some((init, (w_code, nparams, has_closure))) = inlinable_init else {
+        write_ref_reg(
+            ctx,
+            op.pc,
+            dst,
+            instance,
+            ConcreteValue::Ref(concrete_instance),
+        )?;
+        return Ok(Some((DispatchOutcome::Continue, op.next_pc)));
+    };
+
+    let mut callee_args = vec![instance];
+    callee_args.extend_from_slice(&r_args[2..]);
+    callee_arg_concretes.insert(0, ConcreteValue::Ref(concrete_instance));
+    let inlined = try_walker_inline_resolved_user_call(
+        ctx,
+        op,
+        code,
+        funcptr,
+        r_args,
+        call_descr,
+        dst_bank,
+        dst,
+        init,
+        r_args[0],
+        w_type,
+        arg_concretes,
+        callee_args,
+        callee_arg_concretes,
+        true,
+        None,
+        w_code,
+        nparams,
+        has_closure,
+        None,
+        None,
+        // `__init__` bodies are `self.x = ...` stores; the sub-walk folds them
+        // to slot writes on the fresh instance exactly as the property-setter
+        // route folds its own.
+        true,
+        false,
+        Some((instance, ConcreteValue::Ref(concrete_instance))),
+    )?;
+    if inlined.is_none() {
+        ctx.trace_ctx.cut_trace(pre_fold_pos);
+        ctx.trace_ctx.heap_cache_mut().reset();
+    }
+    Ok(inlined)
+}
+
 /// Pyre's exact `str` type call follows `str_descr_new` → `builtin_str` →
 /// `exc_user_dunder_obj`; the builtin `repr` follows `builtin_repr` →
 /// `py_repr_obj`. Both paths look up the receiver dunder before builtin
@@ -4210,6 +4460,7 @@ pub(crate) fn try_walker_inline_exception_string_override<Sym: WalkSym>(
         None,
         true,
         true,
+        None,
     )?
     else {
         return Ok(None);
@@ -4332,6 +4583,7 @@ pub(crate) fn try_walker_inline_property_get<Sym: WalkSym>(
         // read (same allowance the exception `__str__`/`__repr__` override uses).
         true,
         false,
+        None,
     )
 }
 
@@ -4430,6 +4682,7 @@ pub(crate) fn try_walker_inline_property_set<Sym: WalkSym>(
         None,
         true,
         false,
+        None,
     )
 }
 
@@ -4585,6 +4838,7 @@ pub(crate) fn try_walker_inline_user_binop<Sym: WalkSym>(
         Some((rhs, concrete_rhs, w_typ_r.as_ptr())),
         false,
         false,
+        None,
     )?
     else {
         return Ok(None);
@@ -4730,6 +4984,7 @@ pub(crate) fn try_walker_inline_user_compareop<Sym: WalkSym>(
         Some((rhs, concrete_rhs, w_typ_r.as_ptr())),
         false,
         false,
+        None,
     )?
     else {
         return Ok(None);

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -2387,6 +2387,39 @@ fn inline_chain_unrolls_recursion<Sym: WalkSym>(ctx: &WalkContext<'_, '_, Sym>) 
 /// resolve an app-level descriptor first and enter here with that function as
 /// the callee while independently pinning the original builtin callable.
 #[allow(clippy::too_many_arguments)]
+/// Latch the outer CALL boundary as the forward-resume point for a discarded
+/// inline sub-walk, so the walk driver re-executes the whole call in the
+/// interpreter instead of rolling back and replaying the loop from entry.
+///
+/// Sound only when the attempt committed nothing observable: it must be the
+/// top-level inline, no unjournaled effect may predate it, and the callee must
+/// have executed no concrete effect.  Otherwise the re-execution would apply
+/// twice what the sub-walk already ran.  Every caller that discards a sub-walk
+/// result must go through this — returning the error without latching leaves
+/// the driver replaying the loop, which repeats the callee's effects.
+fn latch_abort_call_resume<Sym: WalkSym>(
+    code: &[u8],
+    op: &DecodedOp,
+    ctx: &WalkContext<'_, '_, Sym>,
+    is_top_inline: bool,
+    unjournaled_before_subwalk: bool,
+    executed_effects_before: usize,
+    abort_flush_call_jitcode_coord: Option<(u32, usize)>,
+) {
+    if !is_top_inline
+        || unjournaled_before_subwalk
+        || fbw_executed_effect_count() != executed_effects_before
+    {
+        return;
+    }
+    let Some((outer_jitcode_index, call_jitcode_pc)) = abort_flush_call_jitcode_coord else {
+        return;
+    };
+    if let Some(stack) = reconstructed_all_ref_call_stack(code, op, ctx) {
+        fbw_set_abort_call_resume(outer_jitcode_index, call_jitcode_pc, stack);
+    }
+}
+
 pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
     ctx: &mut WalkContext<'_, '_, Sym>,
     op: &DecodedOp,
@@ -3947,16 +3980,16 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
                 e,
                 DispatchError::AbortPermanentMarkerReached { .. }
                     | DispatchError::LoopBearingCalleeInlineUnsupported { .. }
-            ) && is_top_inline
-                && !unjournaled_before_subwalk
-                && fbw_executed_effect_count() == executed_effects_before
-            {
-                if let Some((outer_jitcode_index, call_jitcode_pc)) = abort_flush_call_jitcode_coord
-                {
-                    if let Some(stack) = reconstructed_all_ref_call_stack(code, op, ctx) {
-                        fbw_set_abort_call_resume(outer_jitcode_index, call_jitcode_pc, stack);
-                    }
-                }
+            ) {
+                latch_abort_call_resume(
+                    code,
+                    op,
+                    ctx,
+                    is_top_inline,
+                    unjournaled_before_subwalk,
+                    executed_effects_before,
+                    abort_flush_call_jitcode_coord,
+                );
             }
             return Err(e);
         }
@@ -3978,30 +4011,39 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
                 // original builtin call at the caller boundary so the
                 // interpreter raises its faithful TypeError; the inlined
                 // body has no committed concrete effect at this point.
-                if is_top_inline
-                    && !unjournaled_before_subwalk
-                    && fbw_executed_effect_count() == executed_effects_before
-                {
-                    if let Some((outer_jitcode_index, call_jitcode_pc)) =
-                        abort_flush_call_jitcode_coord
-                    {
-                        if let Some(stack) = reconstructed_all_ref_call_stack(code, op, ctx) {
-                            fbw_set_abort_call_resume(outer_jitcode_index, call_jitcode_pc, stack);
-                        }
-                    }
-                }
+                latch_abort_call_resume(
+                    code,
+                    op,
+                    ctx,
+                    is_top_inline,
+                    unjournaled_before_subwalk,
+                    executed_effects_before,
+                    abort_flush_call_jitcode_coord,
+                );
                 return Err(DispatchError::callee_inline_unsupported(op.pc));
             }
             // `descr_call` discards `__init__`'s result after checking it is
             // None and returns the instance instead (`check_init_returned_none`).
             // A non-None result is a TypeError the inlined body cannot raise, so
             // give the callee back to the interpreter, which re-runs the call and
-            // raises the faithful message.
+            // raises the faithful message.  Latch the CALL boundary first, like
+            // the invalid-`str`/`repr`-result path above: the sub-walk already
+            // executed the constructor body, so a plain abort would have the
+            // interpreter replay it and repeat any effect it performed.
             let (value, concrete_for_shadow) = match constructor_result {
                 Some(instance) => {
                     if !matches!(concrete_for_shadow,
                         ConcreteValue::Ref(obj) if unsafe { pyre_object::is_none(obj) })
                     {
+                        latch_abort_call_resume(
+                            code,
+                            op,
+                            ctx,
+                            is_top_inline,
+                            unjournaled_before_subwalk,
+                            executed_effects_before,
+                            abort_flush_call_jitcode_coord,
+                        );
                         return Err(DispatchError::callee_inline_unsupported(op.pc));
                     }
                     instance

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -3457,6 +3457,12 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
         )? {
             return Ok(inlined);
         }
+        // A class is not a `Function`, so the user-call route above declined it.
+        if let Some(inlined) =
+            try_walker_inline_type_call(ctx, op, code, funcptr, &r_args, call_descr, dst_bank, dst)?
+        {
+            return Ok(inlined);
+        }
     }
 
     // #62: a self-recursive call the inline path declined (e.g. the
@@ -4466,6 +4472,15 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
         dst,
     )? {
         return Ok(inlined);
+    }
+
+    // A class is not a `Function`, so the user-call route above declined it.
+    if ei.pyre_helper == majit_ir::PyreHelperKind::CallFn {
+        if let Some(inlined) =
+            try_walker_inline_type_call(ctx, op, code, funcptr, &r_args, call_descr, dst_bank, dst)?
+        {
+            return Ok(inlined);
+        }
     }
 
     // LoadConst fold: the LOAD_CONST helper (oopspec `LoadConst`, set

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -2137,7 +2137,7 @@ pub(crate) fn try_walker_specialize_load_attr<Sym: WalkSym>(
 
         // getfield_gc_r(obj, storage) + getarrayitem_gc_r(block, C_storageindex):
         // the inline value read (`mapdict.py`).  `storageindex` is a green
-        // constant (the map guard pinned it); `trace_items_block_getitem_value`
+        // constant (the map guard pinned it); `trace_mapdict_storage_getitem`
         // stamps the dst's concrete shadow from the live block slot.
         let block = crate::state::opimpl_getfield_gc_r(
             ctx.trace_ctx,
@@ -2145,7 +2145,7 @@ pub(crate) fn try_walker_specialize_load_attr<Sym: WalkSym>(
             crate::descr::object_storage_descr(),
         );
         let idx_const = ctx.trace_ctx.const_int(storageindex as i64);
-        let value = crate::state::trace_items_block_getitem_value(ctx.trace_ctx, block, idx_const);
+        let value = crate::state::trace_mapdict_storage_getitem(ctx.trace_ctx, block, idx_const);
         write_residual_call_result_to_dst(ctx, op_pc, dst, dst_bank, value)?;
         return Ok(Some(()));
     }
@@ -3126,6 +3126,37 @@ pub(crate) fn try_walker_specialize_store_attr<Sym: WalkSym>(
                 }
             }
         }
+        return Ok(Some(WalkerStoreAttrSpecialization::Direct));
+    }
+
+    // The attribute is not in the map yet: fold the `map -> PlainAttribute`
+    // transition and the grow-by-one storage rewrite into trace ops instead of
+    // leaving the generic `setattr` residual, which would force the receiver.
+    if let Some(add) = unsafe {
+        pyre_interpreter::objspace::std::mapdict::store_attr_add_fast_path(
+            concrete_obj,
+            &name,
+            concrete_value,
+        )
+    } {
+        walker_guard_mapdict_instance_shape(ctx, op_pc, obj, add.w_type, add.version_tag, add.map)?;
+        let new_map_const = ctx.trace_ctx.const_int(add.new_map as i64);
+        crate::helpers::emit_mapdict_add_attr_inline(
+            ctx.trace_ctx,
+            obj,
+            add.storageindex,
+            new_map_const,
+            value,
+        );
+        // The walk is the authoritative execution path, so apply the resolved
+        // transition now; the emitted operations reproduce it in compiled code.
+        unsafe {
+            pyre_interpreter::objspace::std::mapdict::store_attr_add_commit(
+                concrete_obj,
+                &add,
+                concrete_value,
+            )
+        };
         return Ok(Some(WalkerStoreAttrSpecialization::Direct));
     }
 

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -3132,13 +3132,25 @@ pub(crate) fn try_walker_specialize_store_attr<Sym: WalkSym>(
     // The attribute is not in the map yet: fold the `map -> PlainAttribute`
     // transition and the grow-by-one storage rewrite into trace ops instead of
     // leaving the generic `setattr` residual, which would force the receiver.
-    if let Some(add) = unsafe {
-        pyre_interpreter::objspace::std::mapdict::store_attr_add_fast_path(
-            concrete_obj,
-            &name,
-            concrete_value,
-        )
-    } {
+    //
+    // Only for a receiver this trace allocated and has not let escape.  The
+    // emitted transition is a pair of raw field stores, so unlike the
+    // interpreter's it does not hold the striped `instance_lock`, and unlike
+    // the single-slot in-place write it publishes two fields: a concurrent
+    // mutator of the same instance could pair one thread's `map` with
+    // another's `storage`.  `is_unescaped` is what rules that out — no other
+    // thread has a reference yet.  It costs almost nothing, because the fold's
+    // payoff is exactly the unescaped case: an escaped receiver is one the
+    // optimizer cannot remove anyway.
+    if ctx.trace_ctx.heap_cache().is_unescaped(obj)
+        && let Some(add) = unsafe {
+            pyre_interpreter::objspace::std::mapdict::store_attr_add_fast_path(
+                concrete_obj,
+                &name,
+                concrete_value,
+            )
+        }
+    {
         walker_guard_mapdict_instance_shape(ctx, op_pc, obj, add.w_type, add.version_tag, add.map)?;
         let new_map_const = ctx.trace_ctx.const_int(add.new_map as i64);
         crate::helpers::emit_mapdict_add_attr_inline(

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -3064,6 +3064,42 @@ pub(crate) fn int_gcarray_descr() -> DescrRef {
     )
 }
 
+/// `Ptr(GcArray(OBJECTPTR))` — `W_ObjectObject.storage`, the mapdict
+/// attribute-value block (`mapdict.py:910` `self.storage`).
+///
+/// Structurally the same `ItemsBlock` as [`pyobject_gcarray_descr`] and
+/// differing only in the two properties the allocation shape turns on:
+///
+/// * `W_MAPDICT_STORAGE_GC_TYPE_ID` is a GC **leaf** — the block is a mixed
+///   boxed/unboxed array, so the collector must never walk its interior; the
+///   owning instance's `object_object_custom_trace` walks the boxed slots
+///   itself, masked by the map. Reusing the object-array tid would have the
+///   tracer read an unboxed slot as a reference.
+/// * `non_moving`, because the instance's `storage` field is a raw pointer the
+///   custom trace marks but never rewrites, so a moved block would leave the
+///   instance pointing at the pre-move copy.
+///
+/// Both match `alloc_mapdict_storage_block` (`object_array.rs`), the allocator
+/// the interpreter itself uses for this block.
+pub(crate) fn mapdict_storage_gcarray_descr() -> DescrRef {
+    let token = &pyre_object::ITEMS_BLOCK_TOKEN;
+    let descr = crate::descr::make_array_descr_with_type(
+        token.base_size,
+        token.item_size,
+        pyre_object::object_array::W_MAPDICT_STORAGE_GC_TYPE_ID,
+        Some(token.len_offset),
+        Type::Ref,
+        false,
+    );
+    if let Some(simple) = descr
+        .as_any()
+        .and_then(|any| any.downcast_ref::<majit_ir::descr::SimpleArrayDescr>())
+    {
+        simple.set_non_moving(true);
+    }
+    descr
+}
+
 /// `Ptr(GcArray(Float))` — the `FloatListStrategy` backing block
 /// (`erase([float])`). See [`int_gcarray_descr`].
 pub(crate) fn float_gcarray_descr() -> DescrRef {
@@ -3977,6 +4013,54 @@ pub(crate) fn trace_items_block_setitem_value(
     // pyjitpl.py:980 `upd.setarrayitem(valuebox)` — cache stores the
     // Box identity (`value` OpRef); cache-hit readers resolve the
     // intrinsic value via `box_value(cached)` at hit time.
+    ctx.heapcache_setarrayitem(block, index, descr_idx, value);
+}
+
+/// `mapdict.py:914-916 _mapdict_read_storage` — the mapdict-storage twin of
+/// [`trace_items_block_getitem_value`], against
+/// [`mapdict_storage_gcarray_descr`].  Only ever issued for a slot the guarded
+/// map proves is boxed.
+pub(crate) fn trace_mapdict_storage_getitem(
+    ctx: &mut TraceCtx,
+    block: OpRef,
+    index: OpRef,
+) -> OpRef {
+    let descr = mapdict_storage_gcarray_descr();
+    let descr_idx = descr.index();
+    if let Some(cached) = ctx.heapcache_getarrayitem(block, index, descr_idx) {
+        return cached;
+    }
+    ctx.profiler()
+        .count_ops(OpCode::GetarrayitemGcR, majit_metainterp::counters::OPS);
+    ctx.profiler().count_ops(
+        OpCode::GetarrayitemGcR,
+        majit_metainterp::counters::RECORDED_OPS,
+    );
+    let result = ctx.record_op_with_descr(OpCode::GetarrayitemGcR, &[block, index], descr.clone());
+    if let Some(live_value) = array_load_for_cache(ctx, block, index, &descr, majit_ir::Type::Ref) {
+        ctx.set_opref_concrete(result, live_value);
+    }
+    ctx.heapcache_getarrayitem_now_known(block, index, descr_idx, result);
+    result
+}
+
+/// `mapdict.py:918-919 _mapdict_write_storage` — companion of
+/// [`trace_mapdict_storage_getitem`].
+pub(crate) fn trace_mapdict_storage_setitem(
+    ctx: &mut TraceCtx,
+    block: OpRef,
+    index: OpRef,
+    value: OpRef,
+) {
+    let descr = mapdict_storage_gcarray_descr();
+    let descr_idx = descr.index();
+    ctx.profiler()
+        .count_ops(OpCode::SetarrayitemGc, majit_metainterp::counters::OPS);
+    ctx.profiler().count_ops(
+        OpCode::SetarrayitemGc,
+        majit_metainterp::counters::RECORDED_OPS,
+    );
+    ctx.record_op_with_descr(OpCode::SetarrayitemGc, &[block, index, value], descr);
     ctx.heapcache_setarrayitem(block, index, descr_idx, value);
 }
 

--- a/pyre/pyre-object/src/objectobject.rs
+++ b/pyre/pyre-object/src/objectobject.rs
@@ -129,17 +129,30 @@ pub fn w_instance_new(w_type: PyObjectRef) -> PyObjectRef {
 /// installed (single-crate tests / pre-init snapshot tools).
 ///
 /// PRE-EXISTING-ADAPTATION: PyPy instances live in the movable nursery
-/// (`rclass`/`gctypelayout` standard `GcStruct`). Pyre uses the stable
-/// (non-moving) old-gen allocator instead of `try_gc_alloc`, because the
-/// JIT trace GC-safepoint gcmap does not yet forward a transient
-/// instance ref held across an in-trace minor collection — a movable
-/// instance read from e.g. `objs[i % 3]` and carried into a method-call
-/// guard reads a stale (relocated) pointer out of the deadframe and
-/// SIGSEGVs (`synth/inheritance_dispatch`; the interpreter path is fine,
-/// `PYRE_NO_JIT=1` and stable allocation both pass). Convergence path:
-/// extend the trace GC-safepoint liveness/gcmap (the `op_live`
-/// subsystem) to cover transient Ref slots, then switch this call back
-/// to `try_gc_alloc` for the movable nursery.
+/// (`rclass`/`gctypelayout` standard `GcStruct`). Pyre allocates them
+/// through the stable (non-moving) old-gen allocator instead.
+///
+/// This note used to record a SIGSEGV as the reason — a movable instance
+/// read from `objs[i % 3]` and carried into a method-call guard reading a
+/// stale pointer out of the deadframe, reproduced by
+/// `synth/inheritance_dispatch` — and named "extend the trace GC-safepoint
+/// gcmap to cover transient Ref slots" as the convergence path. That crash
+/// no longer reproduces: with this call switched to `try_gc_alloc`,
+/// `inheritance_dispatch` passes at the default, 256 KB and 128 KB nursery
+/// sizes, the whole `check.py` corpus passes on both backends, and seven
+/// GC-sensitive fixtures produce byte-identical output under a 128 KB
+/// nursery.
+///
+/// The switch is not made because it measures nothing. Allocation is about
+/// a twentieth of what instantiating an object costs — the rest is call
+/// dispatch — and the host-side "nursery" allocator is non-collecting and
+/// falls back to old-gen once the nursery is full
+/// (`majit-backend-dynasm/src/runner.rs` `dynasm_alloc_nursery_typed`), so
+/// the flip only reorders "try nursery, else old-gen" against "always
+/// old-gen": minor and major collection counts and peak RSS come out
+/// unchanged, and every non-microbenchmark fixture moves within noise.
+/// Real convergence needs host-side allocation that may collect, which in
+/// turn needs every allocation site to root the raw pointers it holds.
 fn alloc_instance_object(value: W_ObjectObject) -> PyObjectRef {
     let raw =
         crate::gc_hook::try_gc_alloc_stable_raw(W_OBJECT_OBJECT_GC_TYPE_ID, W_OBJECT_OBJECT_SIZE);


### PR DESCRIPTION
Two allocation shapes the JIT could not emit, and the class-instantiation /
attribute-store path that needed both.

## `NewWithVtable` put JIT-built instances in the movable nursery

`try_walker_inline_type_call` emits `C()` as `NewWithVtable` + `SetfieldGc`
instead of the opaque `bh_call_fn` residual, so the optimizer can virtualize an
instance that never escapes. That first landed with a `GC BUG: invalid
type_id=4294967254 ... site=minor_remembered_set` and a silent
`AttributeError: 'C' object has no attribute 'y'` on
`pyre/bench/synth/attr_store_cache.py`.

Both are one cause. `NewWithVtable` lowers to `CallMallocNursery`, while every
interpreter instance comes from `alloc_instance_object` →
`try_gc_alloc_stable_raw`, the non-moving old gen. That is load-bearing:
`store_attr_caching` is `#[dont_look_inside]` and holds an unrooted raw pointer
to the instance across the allocation of the storage block it installs. In the
nursery, that allocation's minor collection moves the instance and the helper
writes `map` / `storage` into the dead pre-move copy. `4294967254` is
`0xFFFFFFD6`, the low half of `FORWARDED_MARKER` — the object was forwarded,
not corrupt, and a forwarded header carries every flag including
`TRACK_YOUNG_PTRS`, so the stale write also passed `do_write_barrier` and
pushed a nursery address into the remembered set.

`SizeDescr::non_moving()` (default false, shaped like the existing
`headerless()`) makes `handle_new` decline the nursery and take
`gen_malloc_fixedsize`. The routing lives in the shared GC rewriter, so both
backends inherit it. `ArrayDescr::non_moving()` is the varsize twin, added for
the storage block below, and lands on old-generation twins of the typed
`malloc_array` helpers.

While adding it: `gen_malloc_fixedsize` no longer stamps `remember_wb` on its
result. rewrite.py:794-796 stamps it because upstream's `malloc_big_fixedsize`
returns a *young* raw-malloced object; pyre's helper allocates in the old
generation on both backends, so the stamp would drop the barrier on the first
`SETFIELD_GC` of a young value into it — which is exactly what the attribute
store below emits.

## STORE_ATTR that adds a new attribute was an opaque residual

With the instantiation folded, the first `self.a = ...` was still the generic
`setattr` residual, which forces the receiver and so undoes the virtual. A
profile of `PA(1)` showed no single hot spot — write barriers, the map attr
cache hash lookup, the stripe locks, `box_str_constant` on the attribute name,
and two allocations, all per iteration.

`store_attr_add_fast_path` resolves the `map -> PlainAttribute` transition
without performing it, and the walker emits
`_set_mapdict_increase_storage1` (mapdict.py:942-959) as `NEW_ARRAY_CLEAR` +
`SETARRAYITEM_GC` + the `storage` and `map` field stores. The storage block
gets its own array descr carrying its leaf GC type id
(`W_MAPDICT_STORAGE_GC_TYPE_ID`) and `non_moving`, matching
`alloc_mapdict_storage_block`.

The LOAD_ATTR fold read that block through `pyobject_gcarray_descr`. Unifying
both on the mapdict descr is what makes the fold pay: with two descrs for one
block, a read after the emitted write missed the heap cache and the loop
aborted with `InvalidLoop: protect_speculative_field` — 0 traces compiled,
0.60s for 200k iterations. On one descr it is 0.06s.

Declined, leaving the general residual: an attribute already in the map, a
value that takes an unboxed slot, an unboxed slot anywhere in the map chain, a
`NoDict` / `Devolved` terminator, `_reorder_and_add`, the
`LIMIT_MAP_ATTRIBUTES` devolve, and a storage block the collector does not own.

## Measured

2M-iteration loops, user time. The empty loop is 0.06s; pypy3 runs all of them
in 0.01s.

| loop body | before | after |
| --- | --- | --- |
| `x = P()`, `class P: pass` | 0.62s | 0.06s |
| `x = PA("s")`, `__init__` storing a str | 1.45s | 0.05s |
| `x = PA(1)`, `__init__` storing an int | 1.39s | 0.91s |

The instance, its storage block and the value box are all removed when nothing
escapes; the str case is indistinguishable from the empty loop.

## Known gap

An int attribute takes an unboxed slot, whose value is an erased
`Box<Vec<i64>>` on the Rust heap — off-GC, and never freed (2M instances leak
~100 MB). The trace has no way to build it, so `PA(1)` keeps the residual. The
fix is the representation: a GC block the way upstream uses
`Ptr(GcArray(Signed))`. That also has to root the block from the instance's
custom trace and from the transient `Object` carrier, so it is a separate
change.

## Verification

- `check.py --backend dynasm` 349/349, `--backend cranelift` 349/349
- `cargo test -p majit-gc` 218/0, `-p majit-ir` 301/0
- 17-shape attribute oracle vs CPython: match, and unchanged at
  `PYPY_GC_NURSERY` 131072 / 262144 / 1048576 / 8388608
- new fixture `pyre/bench/synth/attr_store_add_transition.py` covers the two
  folded shapes in the hot loop and the declined / materializing shapes once
  each; 4.0x pypy on dynasm, 4.3x on cranelift against its 12x gate

The branch also carries `eval: drop the duplicate interp_return_log_enabled
definition` and its revert: a mid-session rebase moved the base to one where
only a single definition existed, so the replayed deletion removed the
survivor. Left as a revert rather than a history rewrite.

— *authored by Claude*
