### PR TITLE
majit: resolve a forced instance's w_class in optimize_getfield, not virtualize (#915 P1)

### DIFF
--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -861,6 +861,26 @@ impl OptHeap {
         }
     }
 
+    /// Is a `w_class` store still pending under ANY descr spelling?
+    ///
+    /// The field caches are keyed by `Arc::as_ptr` identity
+    /// (`cached_field_pos_for_descr`), and pyre mints more than one descr for
+    /// the `w_class` header (a walker singleton with no parent, and the size
+    /// descr's own `all_fielddescrs` entry). A miss on the descr being read
+    /// therefore does not prove the field is untouched — the store may sit in
+    /// the other spelling's `lazy_set`. Asking across every spelling costs a
+    /// fold, never correctness.
+    ///
+    /// Only `lazy_set` is consulted: a store that has already been flushed
+    /// (`force_lazy_set` → `put_field_back_to_info`) is readable from the
+    /// instance's own field slot, and `cached_structs` also fills up from plain
+    /// reads, which say nothing about the field having been written.
+    fn w_class_set_pending(&self) -> bool {
+        self.cached_fields.iter().any(|(_, descr, cf)| {
+            descr.as_field_descr().is_some_and(|fd| fd.is_w_class()) && cf.lazy_set.is_some()
+        })
+    }
+
     fn cached_field_pos_for_descr(&self, descr: &DescrRef) -> Option<usize> {
         let identity = descr_identity(descr);
         self.cached_fields
@@ -2205,6 +2225,75 @@ impl OptHeap {
                 ctx.structinfo_setfield(&lazy_op, lazy_field_idx, final_value.to_opref());
             }
             // Cache miss — fall through to emit the getfield
+        }
+
+        // Pyre object-model: `w_class` (PyObject header) carries Python-level
+        // class identity. `virtualize.rs` resolves it from a virtual's own
+        // class; once the allocation is forced the read arrives here instead.
+        // `info.py:152 force_box` keeps the class (`info.py:324
+        // get_known_class` still answers), so a forced instance still names its
+        // layout and the header value is that layout's canonical class.
+        //
+        // A store that reached the instance's own slot wins over the layout's
+        // canonical class; only when the header was never written does the
+        // layout answer, and then only if no store is still pending. A retag to
+        // a user subclass writes this header, and folding past that write would
+        // answer with the base class and silently defeat a class check. Reads
+        // of an object whose layout is unknown (`descr: None`, what
+        // `ensure_ptr_info_arg0` builds for a plain heap object) resolve to
+        // nothing and stay in the trace.
+        //
+        // The slot is looked up through the LAYOUT's own `w_class` fielddescr,
+        // never the read descr's index: a parent-bearing `w_class` spelling has
+        // `index_in_parent == 0`, which is the first VALUE field, and folding
+        // through it forwards `Ref <- Int` (`virtualize.rs:850-856`).
+        if descr.as_field_descr().is_some_and(|fd| fd.is_w_class()) {
+            let obj_box = ctx.get_box_replacement_operand(obj);
+            if let Some(crate::optimizeopt::info::PtrInfo::Instance(iinfo)) =
+                ctx.peek_ptr_info(&obj_box)
+            {
+                let size_descr = iinfo.descr.as_ref().and_then(|d| d.as_size_descr());
+                let stored = size_descr
+                    .and_then(|sd| {
+                        sd.all_fielddescrs()
+                            .iter()
+                            .find(|fd| fd.is_w_class())
+                            .map(|fd| fd.index_in_parent() as u32)
+                    })
+                    .and_then(|widx| {
+                        iinfo
+                            .fields
+                            .iter()
+                            .find(|(idx, _)| *idx == widx)
+                            .map(|(_, e)| e.clone())
+                    });
+                match stored {
+                    Some(crate::optimizeopt::info::FieldEntry::Value(b_val)) => {
+                        let b_old = Operand::from_bound_op(op_rc);
+                        let b_val = ctx.get_box_replacement_operand(b_val.to_opref());
+                        ctx.make_equal_to(&b_old, &b_val);
+                        return OptimizationResult::Remove;
+                    }
+                    // Not a value yet — leave the read rather than folding past
+                    // the pending preamble op.
+                    Some(crate::optimizeopt::info::FieldEntry::Preamble(_)) => {}
+                    None => {
+                        if !self.w_class_set_pending() {
+                            if let Some(w_class) = size_descr
+                                .and_then(|sd| sd.w_class_obj())
+                                .filter(|&w| w != 0)
+                            {
+                                let b = ctx.materialize_operand_at(op.pos.get());
+                                ctx.make_constant_box(
+                                    &b,
+                                    majit_ir::Value::Ref(majit_ir::GcRef(w_class as usize)),
+                                );
+                                return OptimizationResult::Remove;
+                            }
+                        }
+                    }
+                }
+            }
         }
 
         // Virtualizable fields are loop-variant; skip caching/import.

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -4040,7 +4040,10 @@ impl OptUnroll {
                 // producer first, since the top-of-loop _map_args above would
                 // otherwise read an unmapped arg.
                 let grown = current_short_jump_args(short_preamble, ctx);
-                if grown.len() == num_short_jump_args {
+                // `<=`, not `==`: the list only grows here, but the slice below
+                // indexes from `num_short_jump_args`, so a shrink would panic
+                // rather than fall into the "did not grow" exit.
+                if grown.len() <= num_short_jump_args {
                     break;
                 }
                 let all_new_mapped = grown[num_short_jump_args..]

--- a/majit/majit-metainterp/src/optimizeopt/virtualize.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualize.rs
@@ -893,67 +893,18 @@ impl OptVirtualize {
                     // rather than mis-indexing a value field.
                     return OptimizationResult::PassOn;
                 }
-                // Same resolution once the allocation has been forced.
-                // `info.py:152 force_box` keeps the SAME info object and only
-                // clears `_is_virtual`, so `info.py:324 get_known_class` still
-                // answers afterwards; pyre reproduces that by installing
-                // `PtrInfo::Instance` carrying the virtual's `descr` and
-                // `known_class` (info.rs:1113-1118). Without this arm the class
-                // is known but unusable the moment the allocation escapes, and
-                // every later header read re-emits with its guard.
-                //
-                // The slot is looked up the same way as the virtual arm above —
-                // through the layout's own `w_class` field descr, never through
-                // the read descr's index, which for a parent-bearing spelling is
-                // `index_in_parent == 0` and would alias the first value field.
-                if let PtrInfo::Instance(ref iinfo) = info {
-                    let stored = iinfo
-                        .descr
-                        .as_ref()
-                        .and_then(|d| d.as_size_descr())
-                        .and_then(|sd| {
-                            sd.all_fielddescrs()
-                                .iter()
-                                .find(|fd| fd.is_w_class())
-                                .map(|fd| fd.index_in_parent() as u32)
-                        })
-                        .and_then(|widx| {
-                            iinfo
-                                .fields
-                                .iter()
-                                .find(|(idx, _)| *idx == widx)
-                                .map(|(_, e)| e)
-                        });
-                    match stored {
-                        // A recorded write wins over the descr's canonical
-                        // class, exactly as the virtual arm prefers `stored`.
-                        Some(crate::optimizeopt::info::FieldEntry::Value(b_val)) => {
-                            let b_old = Operand::from_bound_op(op_rc);
-                            let b_val = ctx.get_box_replacement_operand(b_val.to_opref());
-                            ctx.make_equal_to(&b_old, &b_val);
-                            return OptimizationResult::Remove;
-                        }
-                        // Not a value yet — leave the read alone rather than
-                        // folding past the pending preamble op.
-                        Some(crate::optimizeopt::info::FieldEntry::Preamble(_)) => {}
-                        None => {
-                            if let Some(w_class) = iinfo
-                                .descr
-                                .as_ref()
-                                .and_then(|d| d.as_size_descr())
-                                .and_then(|sd| sd.w_class_obj())
-                                .filter(|&w| w != 0)
-                            {
-                                let b = ctx.materialize_operand_at(op.pos.get());
-                                ctx.make_constant_box(
-                                    &b,
-                                    majit_ir::Value::Ref(majit_ir::GcRef(w_class as usize)),
-                                );
-                                return OptimizationResult::Remove;
-                            }
-                        }
-                    }
-                }
+                // Once the allocation is forced the read is NOT resolved here.
+                // `virtualize.py:184-195 optimize_GETFIELD_GC_*` folds only
+                // under `opinfo.is_virtual()` and otherwise emits, leaving a
+                // non-virtual's field read to `heap.py`. That layering is
+                // load-bearing for this field: `force_box` empties the forced
+                // instance's field list (info.rs:1113-1118, so heap's
+                // `do_setfield` cannot MUST_ALIAS-elide the materializing
+                // SETFIELD_GC) and routes the write into `OptHeap`, where it
+                // sits in `CachedField::lazy_set`. Folding here would run
+                // BEFORE that pass and answer from the layout's canonical
+                // class, discarding a pending retag to a user subclass.
+                // The canonical-class fallback lives in `optimize_getfield`.
             }
             let field_val = match &info {
                 PtrInfo::Virtual(vinfo) => get_field(&vinfo.fields, field_idx),


### PR DESCRIPTION
Follow-up to #915, which merged before its Codex review could be acted on. The P1 raised there is **real**, and worse than the report described — the fold it names is live on main right now.

## The defect

#915's `f20f9925c0` extended the `w_class` header fold from `PtrInfo::Virtual` to `PtrInfo::Instance`, so the class stayed usable after an allocation escaped. But `virtualize.py:184-195 optimize_GETFIELD_GC_*` folds only under `opinfo.is_virtual()` and otherwise emits, leaving a non-virtual's read to `heap.py`. That layering is load-bearing for this field:

- `force_box` installs the forced instance with an **empty** field list (`info.rs:1113-1118` — deliberately, so heap's `do_setfield` cannot MUST_ALIAS-elide the materializing SETFIELD_GC),
- and emits the header write as an ordinary `SetfieldGc`, which lands in `CachedField::lazy_set`,
- while OptVirtualize runs a pass **earlier** than OptHeap.

So the `Instance` arm saw an empty slot on *every* forced instance and answered from the size descr's canonical class. Two consequences: the recorded-value branch was effectively dead code, and **the entire 43 → 37 op win came from the unsound fallback**. An instance retagged to a user subclass and then forced would read back as the base class — a silent miscompile of a class check, not a crash.

## The fix

Both resolutions move into `optimize_getfield`, after the cache consult: a value already in the instance's own slot wins, and only when the header was never written does the layout's canonical class answer — gated on no `w_class` store still being pending.

The pending check scans **every** `is_w_class()` descr rather than the one being read. The caches are keyed by `Arc::as_ptr` (`heap.rs cached_field_pos_for_descr`) and pyre mints more than one descr for this header (a walker singleton with no parent, and the size descr's own `all_fielddescrs` entry), so a miss on the read descr does not prove the field is untouched — the store may sit in the other spelling's `lazy_set`.

The slot is still looked up through the layout's own `w_class` fielddescr, never the read descr's index: a parent-bearing spelling has `index_in_parent == 0`, which is the first *value* field, and folding through it forwards `Ref <- Int`.

### One wrong turn worth recording

The first gate also refused on `!cached_structs.is_empty()` and dropped the loop to **40 ops**. Plain *reads* fill `cached_structs` via `register_info`, so the first `w_class` read blocked every later fold. Only `lazy_set` distinguishes a pending write; a store that has already been flushed is readable from the instance slot instead. Gating on `lazy_set` alone restores 31 ops.

## Regression coverage

`w_subclass2.py` does **not** cover this shape — it passed throughout the unsound window. Added `retag_force.py`: `MyTuple`/`MyInt` interleaved with their base types, class read both **before and after** the forcing store.

```
NO_JIT (oracle) : 25000 50000 1249975000 tuple MyTuple
dynasm JIT      : 25000 50000 1249975000 tuple MyTuple
cranelift JIT   : 25000 50000 1249975000 tuple MyTuple
```

## Also here

`majit: exit the short-preamble force loop on a non-growing arg list` — the loop reads `grown[num_short_jump_args..]` immediately after testing `grown.len() == num_short_jump_args`, so a list that ever came back shorter would slice out of bounds instead of taking the "did not grow" exit. Raised on #556, which added the surrounding guard.

## Verification

- `check.py --backend dynasm,cranelift`: **dynasm 349/349, cranelift 349/349**
- `cargo test --release -p majit-metainterp --features dynasm`: 1425 passed, 0 failed
- Append loop steady body stays at **31 ops**; `w_subclass2.py` and `synth/callee_store_global_read_after_call` (240008) unchanged on both backends and under `PYRE_NO_JIT`

## Not addressed

The parity review's §2 on `unroll.rs` (`signal_invalid_loop` where upstream's `mapping[box]` raises `KeyError`) is left as-is. #556 already ported upstream's own answer for an unmapped jump arg in this function — `unroll.py:425-434`, which **defers to the outer replay loop** rather than raising — and the same carrier is used 25 lines earlier for `optimizer.flush()`. That reads as a documented structural adaptation (§4), not a new divergence.

— *authored by Claude*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved optimization of class-field reads by reusing known stored values when safe.
  - Preserved unresolved or pending class-field reads for correct later processing.
  - Fixed short-preamble handling when jump arguments shrink, preventing invalid processing.
  - Corrected forced object reads so they are handled safely during subsequent heap processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->