### PR TITLE
review: act on the #904 findings, and scope the descr type_id split out

### DIFF
--- a/majit/majit-ir/src/descr.rs
+++ b/majit/majit-ir/src/descr.rs
@@ -1285,8 +1285,19 @@ impl GcCache {
             // path binds a fieldless size-descr shell), defer to the cached
             // value rather than the caller's un-arbitrable raw number, which
             // still carries whichever producer's header convention minted it.
-            let expected_index_in_parent = Self::find_index_in_parent(parent.as_ref(), field_name)
-                .unwrap_or(descr.index_in_parent);
+            // The arbitration walks the parent's whole positional list, and the
+            // canary below is its only reader — `debug_assert!` keeps the code
+            // but guards it on the same `cfg!(debug_assertions)`, so a release
+            // build would scan and discard. Repeat lookups are the common case
+            // (`make_simple_descr_group_keyed_with_headerless` calls this once
+            // per field spec under the `gc_cache` lock), so spell the gate out
+            // and let the release build keep the cached number.
+            let expected_index_in_parent = if cfg!(debug_assertions) {
+                Self::find_index_in_parent(parent.as_ref(), field_name)
+                    .unwrap_or(descr.index_in_parent)
+            } else {
+                descr.index_in_parent
+            };
             debug_assert!(
                 descr.describes_same_field(
                     offset,

--- a/majit/majit-metainterp/src/optimizeopt/virtualize.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualize.rs
@@ -6307,9 +6307,138 @@ mod tests {
         let virtuals = guard_op
             .resolved_rd_virtuals()
             .expect("rd_virtuals should encode the array and nested item");
+        // A count alone also passes when the two are numbered as UNRELATED
+        // virtuals. What the bridge decoder follows is the link: it reads the
+        // array's item slot, resolves its TAGVIRTUAL number back into
+        // `rd_virtuals`, and materializes the entry it lands on. Assert that
+        // path, locating each end by what it is rather than by slot order.
+        use majit_ir::resumedata::{TAGBOX, TAGVIRTUAL, UNINITIALIZED_TAG, untag};
+
+        let array_idx = {
+            let found = virtuals
+                .iter()
+                .enumerate()
+                .filter(|(_, v)| {
+                    matches!(
+                        v.as_ref(),
+                        majit_ir::RdVirtualInfo::VArrayInfoClear { .. }
+                            | majit_ir::RdVirtualInfo::VArrayInfoNotClear { .. }
+                    )
+                })
+                .map(|(i, _)| i)
+                .collect::<Vec<_>>();
+            assert_eq!(
+                found.len(),
+                1,
+                "exactly one VArrayInfo entry expected; got {virtuals:?}"
+            );
+            found[0]
+        };
+        let (array_arraydescr, array_items) = match virtuals[array_idx].as_ref() {
+            majit_ir::RdVirtualInfo::VArrayInfoClear {
+                arraydescr,
+                fieldnums,
+                ..
+            }
+            | majit_ir::RdVirtualInfo::VArrayInfoNotClear {
+                arraydescr,
+                fieldnums,
+                ..
+            } => (arraydescr.clone(), fieldnums.clone()),
+            _ => unreachable!("filtered by the matches! above"),
+        };
+        // The materializer dereferences the arraydescr unconditionally.
         assert!(
-            virtuals.len() >= 2,
-            "rd_virtuals should recursively number both virtuals; got {virtuals:?}"
+            array_arraydescr.is_some(),
+            "VArrayInfo must carry its live arraydescr"
+        );
+        assert_eq!(
+            array_items.len(),
+            1,
+            "NEW_ARRAY(len=1) leaves exactly one item slot; got {array_items:?}"
+        );
+        let (item_num, item_tagbits) = untag(array_items[0]);
+        assert_eq!(
+            item_tagbits,
+            TAGVIRTUAL,
+            "array item 0 must stay TAGVIRTUAL rather than force-boxing to a \
+             failarg; got {:?}",
+            untag(array_items[0])
+        );
+        // resume.py:278-284 assign_number_to_virtual numbers nested virtuals
+        // negatively and resume.py:945-954 getvirtual_ptr resolves them by
+        // Python negative indexing.
+        let item_idx = if item_num < 0 {
+            (virtuals.len() as i32 + item_num) as usize
+        } else {
+            item_num as usize
+        };
+        assert_ne!(
+            item_idx, array_idx,
+            "the item's TAGVIRTUAL must name a slot other than the array's"
+        );
+        let majit_ir::RdVirtualInfo::VirtualInfo {
+            descr: item_descr,
+            fielddescrs: item_fielddescrs,
+            fieldnums: item_fieldnums,
+            ..
+        } = virtuals[item_idx].as_ref()
+        else {
+            panic!(
+                "the array item's TAGVIRTUAL must resolve to the nested \
+                 NEW_WITH_VTABLE VirtualInfo; got {:?}",
+                virtuals[item_idx]
+            )
+        };
+        // A `None` size descr silently drops the whole nested materialization.
+        assert!(
+            item_descr.is_some(),
+            "nested VirtualInfo must carry its live SizeDescr"
+        );
+        assert_eq!(
+            item_fielddescrs.len(),
+            item_fieldnums.len(),
+            "fielddescrs and fieldnums must stay 1:1"
+        );
+        // resume.py:597-603 setfields skips UNINITIALIZED, so the item's only
+        // live slot is the one the SETFIELD_GC wrote.
+        let live = item_fieldnums
+            .iter()
+            .copied()
+            .enumerate()
+            .filter(|&(_, n)| n != UNINITIALIZED_TAG)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            live.len(),
+            1,
+            "nested item has exactly one live field slot; got {live:?}"
+        );
+        let (live_slot, live_tag) = live[0];
+        assert_eq!(
+            item_fielddescrs[live_slot].index, 42,
+            "the live slot must be the field_descr(42) the SETFIELD_GC named; \
+             got {:?}",
+            item_fielddescrs[live_slot]
+        );
+        let (leaf_num, leaf_tagbits) = untag(live_tag);
+        assert_eq!(
+            leaf_tagbits,
+            TAGBOX,
+            "the nested item's leaf must be a TAGBOX failarg; got {:?}",
+            untag(live_tag)
+        );
+        // resume.py:1259-1261 decode_box indexes liveboxes with the same
+        // negative-index rule.
+        let leaf_slot = if leaf_num < 0 {
+            leaf_num + failargs.len() as i32
+        } else {
+            leaf_num
+        } as usize;
+        assert_eq!(
+            failargs[leaf_slot].to_opref(),
+            OpRef::input_arg_int(40),
+            "the leaf TAGBOX must resolve to the SETFIELD_GC value i40; \
+             got {failargs:?}"
         );
     }
 }

--- a/majit/majit-translate/src/codewriter/jtransform.rs
+++ b/majit/majit-translate/src/codewriter/jtransform.rs
@@ -2888,15 +2888,18 @@ impl<'a> Transformer<'a> {
         // enum tag as a separate MIR operand. Restore the exact low-level
         // shape here. The existing payload write follows this replacement in
         // program order; the tag write is emitted beside the allocation.
-        if let CallTarget::SyntheticTransparentCtor { name, owner_path } = target
-            && args.is_empty()
-            && matches!(name.as_str(), "Ok" | "Err")
-            && owner_path
-                .last()
-                .is_some_and(|owner| owner.starts_with("Result"))
+        // Recognize the ctor through the front-side rule rather than a second
+        // spelling test: it anchors the owner path head at `core::result` and
+        // compares the instantiation-stripped leaf for equality, where a
+        // `starts_with("Result")` leaf test also accepts an unrelated enum whose
+        // name merely begins with it and carries `Ok`/`Err` variants. Both gates
+        // decide the same question, so they must not be able to drift.
+        if args.is_empty()
+            && let Some(is_err) = crate::front::result_exc::result_ctor_kind(target)
             && let ValueType::Ref(Some(owner)) = result_ty
         {
-            let tag = i64::from(name == "Err");
+            let name = if is_err { "Err" } else { "Ok" };
+            let tag = i64::from(is_err);
             let result_base = owner
                 .strip_suffix(format!("::{name}").as_str())
                 .unwrap_or(owner)

--- a/majit/majit-translate/src/front/result_exc.rs
+++ b/majit/majit-translate/src/front/result_exc.rs
@@ -302,7 +302,7 @@ pub(crate) fn widen_unit_return_to_void(graph: &mut FunctionGraph) {
 /// (`Result<Tuple,PyError>`) minted by the generic-ADT projection; strip
 /// it before the bare-path compare so suffixed and bare Result ctors are
 /// recognised alike.
-fn result_ctor_kind(target: &CallTarget) -> Option<bool> {
+pub(crate) fn result_ctor_kind(target: &CallTarget) -> Option<bool> {
     let CallTarget::SyntheticTransparentCtor { name, owner_path } = target else {
         return None;
     };

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -5971,6 +5971,15 @@ enum UnsupportedJitShape {
     ConstEncodingOverflow,
 }
 
+// The codewriter records `ConstEncodingOverflow` for a graph whose jitcode
+// fails to assemble, but `crate::jit` must not name this private type, so it
+// writes `call::JIT_SHAPE_CONST_ENCODING_OVERFLOW` instead. Pin the two
+// together here — this is the only module that sees both.
+const _: () = assert!(
+    crate::jit::call::JIT_SHAPE_CONST_ENCODING_OVERFLOW
+        == UnsupportedJitShape::ConstEncodingOverflow as u8
+);
+
 /// Return the immutable frame-shape classification for an immortal user-code
 /// graph.  RPython decides the analogous graph facts once while populating
 /// `CallControl.jitcodes`; pyre's temporary runtime gate must have the same
@@ -5979,11 +5988,18 @@ fn cached_unsupported_jit_shape(code: &pyre_interpreter::CodeObject) -> Unsuppor
     let key = code as *const _ as usize;
     let callcontrol = crate::jit::codewriter::CodeWriter::instance().callcontrol();
     if let Some(&raw) = callcontrol.graph_jit_shapes.get(&key) {
+        // Match on the discriminants themselves so the decode is the inverse of
+        // the `shape as u8` encode below by construction, rather than by a
+        // hand-kept numbering the compiler never checks.
+        const NONE: u8 = UnsupportedJitShape::None as u8;
+        const CURRENT_FRAME_ONLY: u8 = UnsupportedJitShape::CurrentFrameOnly as u8;
+        const NESTED_BREAK_BRIDGE_RESUME: u8 = UnsupportedJitShape::NestedBreakBridgeResume as u8;
+        const CONST_ENCODING_OVERFLOW: u8 = UnsupportedJitShape::ConstEncodingOverflow as u8;
         return match raw {
-            0 => UnsupportedJitShape::None,
-            1 => UnsupportedJitShape::CurrentFrameOnly,
-            2 => UnsupportedJitShape::NestedBreakBridgeResume,
-            3 => UnsupportedJitShape::ConstEncodingOverflow,
+            NONE => UnsupportedJitShape::None,
+            CURRENT_FRAME_ONLY => UnsupportedJitShape::CurrentFrameOnly,
+            NESTED_BREAK_BRIDGE_RESUME => UnsupportedJitShape::NestedBreakBridgeResume,
+            CONST_ENCODING_OVERFLOW => UnsupportedJitShape::ConstEncodingOverflow,
             _ => unreachable!("invalid cached UnsupportedJitShape discriminant"),
         };
     }

--- a/pyre/pyre-jit/src/jit/call.rs
+++ b/pyre/pyre-jit/src/jit/call.rs
@@ -224,6 +224,17 @@ pub struct CallControl {
     pub graph_jit_shapes: HashMap<usize, u8>,
 }
 
+/// The [`CallControl::graph_jit_shapes`] value recorded for a graph whose
+/// jitcode fails to assemble.
+///
+/// The map's values are `eval::UnsupportedJitShape` discriminants, and the
+/// codewriter must not name that private portal-evaluator type, so the one
+/// discriminant it has to write lives beside the map it writes into. `eval.rs`
+/// pins this to the enum with a `const _: () = assert!(..)`, so renumbering or
+/// removing the variant is a build error rather than a silently misclassified
+/// frame shape.
+pub(crate) const JIT_SHAPE_CONST_ENCODING_OVERFLOW: u8 = 3;
+
 impl CallControl {
     /// RPython: `CallControl.__init__(cpu=None, jitdrivers_sd=[])`
     /// (call.py:25-47).

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -14182,9 +14182,10 @@ impl CodeWriter {
                 // Cache the authoritative assembler result for shapes that
                 // reach this exact check. The graph is immutable, so a later
                 // drain cannot make this encoding failure disappear.
-                self.callcontrol()
-                    .graph_jit_shapes
-                    .insert(code_ptr as usize, 3);
+                self.callcontrol().graph_jit_shapes.insert(
+                    code_ptr as usize,
+                    super::call::JIT_SHAPE_CONST_ENCODING_OVERFLOW,
+                );
                 continue;
             };
             let key = code_ptr as usize;


### PR DESCRIPTION
Acts on the code review left on #904, after verifying each finding against post-merge `main` rather than against the PR diff.

Twelve findings were filed (1 by Codex, 11 by CodeRabbit). Five did not survive verification, two are style suggestions whose advice does not apply, one is epic-sized and is deliberately left alone. The four here are the ones worth landing.

## What lands

**`get_field_descr` cache hit: gate the index arbitration on `debug_assertions`.**
The hit path derived `expected_index_in_parent` by walking the parent SizeDescr's whole `all_fielddescrs()` list and comparing field keys. Its only reader is the `debug_assert!` directly below it, which `cfg!(debug_assertions)` compiles away — so release builds performed the walk and discarded the result. `make_simple_descr_group_keyed_with_headerless` calls `get_field_descr` once per field spec while holding the `gc_cache` lock, and every field after the first publication is a cache hit, so this is not off the hot path.

**Recognize the `Result` ctor through the front-side rule.**
`jtransform`'s malloc + `__discriminant` lowering gated on `owner_path.last().starts_with("Result")`. That also accepts an enum whose leaf merely begins with the literal — `ResultCode`, say — which, with `Ok`/`Err` variants, would be rerouted through the `Result`-specific lowering. No name in the current LLBC corpus does that. `front::result_exc::result_ctor_kind` already decides the same question precisely: it anchors the owner path head at `core::result` and compares the instantiation-stripped leaf for equality. Reuses it, so the two gates cannot drift.

**Name the `graph_jit_shapes` discriminant.**
`drain_unfinished_graphs` recorded `ConstEncodingOverflow` as the bare literal `3`; `cached_unsupported_jit_shape` decoded it with a hand-written match over `0..=3`. Both numberings tracked `UnsupportedJitShape`'s implicit discriminants by hand, in two files, with nothing linking them — renumbering or removing a variant misclassifies every cached frame shape with no build error and no test signal. Adds `call::JIT_SHAPE_CONST_ENCODING_OVERFLOW` beside the map, pins it to the enum in `eval.rs` with `const _: () = assert!(..)`, and names the decode arms after the discriminants themselves. Written value and decode unchanged.

**Assert the nested virtual's link, not the `rd_virtuals` count.**
`test_guard_fail_args_virtual_array_with_nested_virtual_item` ended at `virtuals.len() >= 2`, which also holds when the array and the item are numbered as two *unrelated* virtuals. What the bridge decoder follows is the link: it reads the array's item slot, resolves that TAGVIRTUAL number back into `rd_virtuals` under the negative-index rule, and materializes the entry it lands on. The test now asserts that path — locating the array by its `VArrayInfo*` variant rather than by slot order, requiring the resolved slot to be a different one holding the nested `VirtualInfo`, and requiring its one live field slot to be `field_descr(42)` carrying a TAGBOX that resolves to the `SETFIELD_GC` value `i40`. Both descr references must be live, since a `None` on either silently drops the materialization. Passes on the current encoding unchanged.

## Deliberately not fixed

CodeRabbit filed the `fielddescrof` test gap as a trivial coverage nit. Verifying it surfaced something larger: **the SizeDescr `type_id` is minted two ways.**

```
bh_size_spec_from_callcontrol : path_hash(strip_generic_args(owner))   <- the call-site spelling
fielddescrof                  : struct_id_for_name(owner).as_u64()     =  path_hash(strip_crate_prefix(path))
```

`OpKind::New` / `OpKind::NewWithVtable` ship the first verbatim. The tell is inside that function: it fetches the layout through `cc.struct_layout_for`, which *is* `struct_id_for_name(name)? -> struct_layouts[sid]`, and then stamps a different identity onto that layout. `"W_FloatObject"` alone splits into `path_hash("W_FloatObject")` versus `path_hash("floatobject::W_FloatObject")`. A `NewWithVtable` and the payload `setfield_gc` emitted one instruction later on the same object therefore mint two disjoint `Arc<SimpleFieldDescr>` sets for the same offsets — and `OptHeap` keys `cached_fields` on Arc identity, so the store does not invalidate the load's cache slot.

Converging the keys is not inert, which is why it is not in this PR: it moves every `New` spec onto the same `_cache_size` key the runtime group already occupies, activating `register_keyed_size` arbitration where it is dormant today. That tiebreak is *vtable wins, else more fields wins*, and the analyzer's list is longer by exactly the GC-header words — so a `NewWithVtable` spec would win and replace the orthodox headerless runtime group. This belongs with the header-convention unification, as its own change with a full gate.

## Findings that did not survive

Codex's P1 asked to keep the nested-gateway `inline_subwalk` path disabled, on the evidence that `synth/sre_pattern_methods` printed `279999` instead of `280000`. That benchmark now passes — but it passes because the branch was rebased onto a `main` carrying #874/#905/#906/#907, not because the blamed commits were reverted, so "fixed" and "masked" had to be separated. The path is unreachable: `compute_inline_caller_frame` has exactly two callers, both under `try_walker_inline_user_call`, which declines unless `pyre_helper` is `CallFn`/`CallKw`/`CallFunctionEx`; `PyreHelperKind::CallFn` is assigned only in `pyre-jit/src/jit/flatten.rs`, while `majit-translate/src/codewriter/call.rs` — which builds the gateway body's residuals — writes `PyreHelperKind::None` at all three of its construction sites.

One residue is worth recording: what makes that safe today is an unrelated helper-kind filter, not a check at the resolution site. The sibling guard-capture path in `resume_snapshot.rs` gates the same hazard explicitly (`if !inline_subwalk && !full_body_sym.is_null()`), and `compute_inline_caller_frame` maps the same kind of `op_pc` without it; upstream traps the class outright at `pyjitpl.py:199`.

Four more were misreads: `Descr::index()` and `FieldDescr::index_in_parent()` are different axes, not a mismatched identity; the `_helper_frame` guard does outlive the `fbw_mode` restore but no call in that tail reads `framestack.last()`; `float.as_integer_ratio(1)` already raises `TypeError` because `builtin_code_call` rejects any positional count differing from the recorded arity, in both directions; and no ruff configuration covers `pyre/bench/synth`, so B007 never runs there.

## Verification

`cargo test --all --no-default-features --features dynasm` — exit 0, 100 test binaries, no failures.
`python3 pyre/check.py --backend dynasm` — 349/349.
Both against a freshly extracted LLBC whose `pyre-object` / `pyre-interpreter` / `pyre-jit` fingerprints match the working tree, run at base `59d87af4d9`. The base has since moved by one commit (#920, `optimizeopt/virtualize.rs`); `cargo test -p majit-metainterp --lib` was re-run on the current base — 1434 passed.

— *authored by Claude*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected handling of `Result` variants so unrelated enum types are no longer misidentified as `Ok` or `Err`.
  - Improved JIT shape decoding consistency for constant-encoding overflow cases.
  - Preserved reliable field descriptor lookup behavior in release builds.

- **Tests**
  - Expanded validation of nested virtual arrays and their encoded fields.
  - Added checks to keep JIT shape status values synchronized across components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->