### PR TITLE
majit: stop resolving a forced instance's w_class header in the optimizer (#920 review)

### DIFF
--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -861,26 +861,6 @@ impl OptHeap {
         }
     }
 
-    /// Is a `w_class` store still pending under ANY descr spelling?
-    ///
-    /// The field caches are keyed by `Arc::as_ptr` identity
-    /// (`cached_field_pos_for_descr`), and pyre mints more than one descr for
-    /// the `w_class` header (a walker singleton with no parent, and the size
-    /// descr's own `all_fielddescrs` entry). A miss on the descr being read
-    /// therefore does not prove the field is untouched — the store may sit in
-    /// the other spelling's `lazy_set`. Asking across every spelling costs a
-    /// fold, never correctness.
-    ///
-    /// Only `lazy_set` is consulted: a store that has already been flushed
-    /// (`force_lazy_set` → `put_field_back_to_info`) is readable from the
-    /// instance's own field slot, and `cached_structs` also fills up from plain
-    /// reads, which say nothing about the field having been written.
-    fn w_class_set_pending(&self) -> bool {
-        self.cached_fields.iter().any(|(_, descr, cf)| {
-            descr.as_field_descr().is_some_and(|fd| fd.is_w_class()) && cf.lazy_set.is_some()
-        })
-    }
-
     fn cached_field_pos_for_descr(&self, descr: &DescrRef) -> Option<usize> {
         let identity = descr_identity(descr);
         self.cached_fields
@@ -2225,75 +2205,6 @@ impl OptHeap {
                 ctx.structinfo_setfield(&lazy_op, lazy_field_idx, final_value.to_opref());
             }
             // Cache miss — fall through to emit the getfield
-        }
-
-        // Pyre object-model: `w_class` (PyObject header) carries Python-level
-        // class identity. `virtualize.rs` resolves it from a virtual's own
-        // class; once the allocation is forced the read arrives here instead.
-        // `info.py:152 force_box` keeps the class (`info.py:324
-        // get_known_class` still answers), so a forced instance still names its
-        // layout and the header value is that layout's canonical class.
-        //
-        // A store that reached the instance's own slot wins over the layout's
-        // canonical class; only when the header was never written does the
-        // layout answer, and then only if no store is still pending. A retag to
-        // a user subclass writes this header, and folding past that write would
-        // answer with the base class and silently defeat a class check. Reads
-        // of an object whose layout is unknown (`descr: None`, what
-        // `ensure_ptr_info_arg0` builds for a plain heap object) resolve to
-        // nothing and stay in the trace.
-        //
-        // The slot is looked up through the LAYOUT's own `w_class` fielddescr,
-        // never the read descr's index: a parent-bearing `w_class` spelling has
-        // `index_in_parent == 0`, which is the first VALUE field, and folding
-        // through it forwards `Ref <- Int` (`virtualize.rs:850-856`).
-        if descr.as_field_descr().is_some_and(|fd| fd.is_w_class()) {
-            let obj_box = ctx.get_box_replacement_operand(obj);
-            if let Some(crate::optimizeopt::info::PtrInfo::Instance(iinfo)) =
-                ctx.peek_ptr_info(&obj_box)
-            {
-                let size_descr = iinfo.descr.as_ref().and_then(|d| d.as_size_descr());
-                let stored = size_descr
-                    .and_then(|sd| {
-                        sd.all_fielddescrs()
-                            .iter()
-                            .find(|fd| fd.is_w_class())
-                            .map(|fd| fd.index_in_parent() as u32)
-                    })
-                    .and_then(|widx| {
-                        iinfo
-                            .fields
-                            .iter()
-                            .find(|(idx, _)| *idx == widx)
-                            .map(|(_, e)| e.clone())
-                    });
-                match stored {
-                    Some(crate::optimizeopt::info::FieldEntry::Value(b_val)) => {
-                        let b_old = Operand::from_bound_op(op_rc);
-                        let b_val = ctx.get_box_replacement_operand(b_val.to_opref());
-                        ctx.make_equal_to(&b_old, &b_val);
-                        return OptimizationResult::Remove;
-                    }
-                    // Not a value yet — leave the read rather than folding past
-                    // the pending preamble op.
-                    Some(crate::optimizeopt::info::FieldEntry::Preamble(_)) => {}
-                    None => {
-                        if !self.w_class_set_pending() {
-                            if let Some(w_class) = size_descr
-                                .and_then(|sd| sd.w_class_obj())
-                                .filter(|&w| w != 0)
-                            {
-                                let b = ctx.materialize_operand_at(op.pos.get());
-                                ctx.make_constant_box(
-                                    &b,
-                                    majit_ir::Value::Ref(majit_ir::GcRef(w_class as usize)),
-                                );
-                                return OptimizationResult::Remove;
-                            }
-                        }
-                    }
-                }
-            }
         }
 
         // Virtualizable fields are loop-variant; skip caching/import.

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -4040,10 +4040,7 @@ impl OptUnroll {
                 // producer first, since the top-of-loop _map_args above would
                 // otherwise read an unmapped arg.
                 let grown = current_short_jump_args(short_preamble, ctx);
-                // `<=`, not `==`: the list only grows here, but the slice below
-                // indexes from `num_short_jump_args`, so a shrink would panic
-                // rather than fall into the "did not grow" exit.
-                if grown.len() <= num_short_jump_args {
+                if grown.len() == num_short_jump_args {
                     break;
                 }
                 let all_new_mapped = grown[num_short_jump_args..]

--- a/majit/majit-metainterp/src/optimizeopt/virtualize.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualize.rs
@@ -893,18 +893,27 @@ impl OptVirtualize {
                     // rather than mis-indexing a value field.
                     return OptimizationResult::PassOn;
                 }
-                // Once the allocation is forced the read is NOT resolved here.
-                // `virtualize.py:184-195 optimize_GETFIELD_GC_*` folds only
-                // under `opinfo.is_virtual()` and otherwise emits, leaving a
-                // non-virtual's field read to `heap.py`. That layering is
-                // load-bearing for this field: `force_box` empties the forced
-                // instance's field list (info.rs:1113-1118, so heap's
-                // `do_setfield` cannot MUST_ALIAS-elide the materializing
-                // SETFIELD_GC) and routes the write into `OptHeap`, where it
-                // sits in `CachedField::lazy_set`. Folding here would run
-                // BEFORE that pass and answer from the layout's canonical
-                // class, discarding a pending retag to a user subclass.
-                // The canonical-class fallback lives in `optimize_getfield`.
+                // Once the allocation is forced the read is NOT resolved — not
+                // here and not in `optimize_getfield`. `virtualize.py:184-195
+                // optimize_GETFIELD_GC_*` folds only under
+                // `opinfo.is_virtual()` and otherwise emits; upstream has no
+                // counterpart to resolve afterwards because
+                // `jtransform.py:1004-1009 handle_getfield_typeptr` deletes the
+                // read at codewriter time, so no typeptr getfield ever reaches
+                // the optimizer.
+                //
+                // Answering from the layout's canonical class here is unsound:
+                // `force_box` empties the forced instance's field list
+                // (info.rs:1113-1118, so heap's `do_setfield` cannot
+                // MUST_ALIAS-elide the materializing SETFIELD_GC) and routes
+                // the header write into `OptHeap`, where it sits in
+                // `CachedField::lazy_set`. A retag to a user subclass would be
+                // discarded and the base class answered instead. Resolving it
+                // in `OptHeap` does not close the hole either: reads and writes
+                // of this header carry different descr spellings, and the
+                // caches are keyed by `Arc::as_ptr` while `structinfo_setfield`
+                // slots by `field_slot_index`, so the two do not meet. Removing
+                // that split is the prerequisite for folding this read at all.
             }
             let field_val = match &info {
                 PtrInfo::Virtual(vinfo) => get_field(&vinfo.fields, field_idx),


### PR DESCRIPTION
Acts on the two P1s and the CodeRabbit finding on #920, which merged before they could be addressed.

All three land on the same conclusion: **the `w_class` fold cannot be made sound while reads and writes of that header carry different descr spellings.** Removing it is the fix; re-earning the ops needs the split closed first.

## Why the heap-side version was still wrong

#920 moved the resolution into `optimize_getfield`, after the cache consult, gated on no store being pending. Two paths still answer with the layout's canonical class while a retag to a user subclass is outstanding:

- **A store IS pending under the other spelling.** Suppressing the fold only declines the *constant*. Execution falls through and emits the `GETFIELD_GC` while the materializing `SETFIELD_GC` is still sitting unflushed in `CachedField::lazy_set`, so at runtime the load reads the pre-retag word and the store lands after it. Upstream's `UNKNOWN_ALIAS` path calls `force_lazy_set` before returning a miss precisely to prevent this; the cross-spelling case never reaches that call.
- **A store has already been flushed.** `put_field_back_to_info` slots it by `field_slot_index(write_descr)`, which for the parentless walker spelling is `Descr::index()` — not the `index_in_parent()` the lookup reads. The value is invisible to the read, and `lazy_set` is empty by then, so the gate passes and the canonical class wins anyway.

## Why not patch it again

Upstream has no counterpart to repair. `jtransform.py:1004-1009 handle_getfield_typeptr` deletes this read at codewriter time — no typeptr getfield reaches the optimizer at all — and `descr.py:236-238` cannot mint the parentless FieldDescr the walker uses here. Every optimizer-side repair so far has been a special case stacked on a split that upstream does not have, and each one has needed another. AGENTS.md's parity rule points the other way.

## Cost

Append loop steady body **31 → 40 ops**. That is 9, not the 6 the original 43 → 37 measurement implied — the fold was also carrying part of the `_immutable_fields_` win. Correctness first; the ops come back when the read and the write name the same descr.

## Also reverted

`majit: exit the short-preamble force loop on a non-growing arg list` (`==` → `<=`). `unroll.py:425` uses equality and the list can only grow at that point, so it covered an unreachable shrink at the cost of a divergence in a line-by-line port — #556 left it literal for that reason. Reverted.

## Verification

- `check.py --backend dynasm,cranelift`: **dynasm 349/349, cranelift 349/349**
- `retag_force.py` (class read before AND after the forcing store) matches the `PYRE_NO_JIT` oracle on both backends: `25000 50000 1249975000 tuple MyTuple`
- `w_subclass2.py` unchanged: `799600000 50000 MyInt int`

## Follow-up

The blocker named here is the same one blocking the `LOAD_ATTR` method-cache pair: the walker mints ad-hoc field descrs with no parent, so its reads share neither the OptHeap cache key nor the `PtrInfo` slot with the layout's own fielddescrs, and `AbstractStructPtrInfo.produce_short_preamble_ops` (`info.py:255-271`) has no `_fields` to export. Unifying the walker's field-descr minting with the layout's is the prerequisite for both.

— *authored by Claude*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved optimization stability by ensuring processing completes only after all jump arguments are fully accounted for.
  * Updated field access handling to follow the standard loading path, improving consistency and reducing the risk of incorrect value substitutions.

* **Documentation**
  * Clarified optimization behavior and limitations for specialized object field reads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->