### PR TITLE
_operator: register inv/is_none/is_not_none/countOf/indexOf/call interp-level

### DIFF
--- a/pyre/pyre-interpreter/src/module/operator/app_operator.py
+++ b/pyre/pyre-interpreter/src/module/operator/app_operator.py
@@ -6,44 +6,6 @@
 __name__ = 'operator'
 
 
-def countOf(a, b):
-    'countOf(a, b) -- Return the number of times b occurs in a.'
-    count = 0
-    for x in a:
-        if x is b or x == b:
-            count += 1
-    return count
-
-
-def indexOf(a, b):
-    "Return the first index of b in a."
-    for i, j in enumerate(a):
-        if j is b or j == b:
-            return i
-    else:
-        raise ValueError('sequence.index(x): x not in sequence')
-
-
-def inv(a):
-    "Same as ~a."
-    return ~a
-
-
-def is_none(a):
-    "Same as a is None."
-    return a is None
-
-
-def is_not_none(a):
-    "Same as a is not None."
-    return a is not None
-
-
-def call(obj, /, *args, **kwargs):
-    "Same as obj(*args, **kwargs)."
-    return obj(*args, **kwargs)
-
-
 class attrgetter(object):
     """
     Return a callable object that fetches the given attribute(s) from its operand.

--- a/pyre/pyre-interpreter/src/module/operator/mod.rs
+++ b/pyre/pyre-interpreter/src/module/operator/mod.rs
@@ -132,19 +132,66 @@ use crate::baseobjspace::{
     matmul, mod_, mul, neg, or_, pos, pow, rshift, setitem, sub, truediv, xor,
 };
 
+/// `countOf(a, b)` — number of times `b` occurs in `a`, counting `x is b or
+/// x == b` while iterating `a` through the iterator protocol.
+fn op_countof(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let iterator = baseobjspace::iter(args[0])?;
+    let mut count = 0i64;
+    loop {
+        match baseobjspace::next(iterator) {
+            Ok(item) => {
+                if std::ptr::eq(item, args[1])
+                    || is_true(baseobjspace::compare(item, args[1], CompareOp::Eq)?)?
+                {
+                    count += 1;
+                }
+            }
+            Err(e) if e.kind == crate::PyErrorKind::StopIteration => break,
+            Err(e) => return Err(e),
+        }
+    }
+    Ok(w_int_new(count))
+}
+
+/// `indexOf(a, b)` — first index `i` where `a[i] is b or a[i] == b`, iterating
+/// `a` through the iterator protocol; a miss raises
+/// `ValueError('sequence.index(x): x not in sequence')`.
+fn op_indexof(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let iterator = baseobjspace::iter(args[0])?;
+    let mut index = 0i64;
+    loop {
+        match baseobjspace::next(iterator) {
+            Ok(item) => {
+                if std::ptr::eq(item, args[1])
+                    || is_true(baseobjspace::compare(item, args[1], CompareOp::Eq)?)?
+                {
+                    return Ok(w_int_new(index));
+                }
+                index += 1;
+            }
+            Err(e) if e.kind == crate::PyErrorKind::StopIteration => break,
+            Err(e) => return Err(e),
+        }
+    }
+    Err(crate::PyError::value_error(
+        "sequence.index(x): x not in sequence",
+    ))
+}
+
 crate::py_module! {
     "operator",
-    // `countOf` + the `itemgetter`/`attrgetter`/`methodcaller` callable
-    // classes are app-level (`pypy/module/operator/app_operator.py`,
-    // `moduledef.py` `app_names`), not interp-level.  `indexOf`/`inv`/
-    // `is_none`/`is_not_none`/`call` follow the `operator.py` pure-Python
-    // definitions verbatim (`call`'s `**kwargs` forwarding is awkward to
-    // express interp-level).  `concat` is interp-level (`op_concat`,
-    // `interp_operator.py:20`) so it guards both operands for `__getitem__`.
+    // Only the `itemgetter`/`attrgetter`/`methodcaller` callable factory
+    // classes stay app-level (`pypy/module/operator/app_operator.py`,
+    // `moduledef.py` `app_names`); a factory class cannot be expressed as a
+    // plain interp-level function.  `countOf`/`indexOf`/`inv`/`is_none`/
+    // `is_not_none`/`call` live in the `functions:` block below so they
+    // register as non-binding `BuiltinFunction` (no `__get__`), instead of
+    // globals-bearing app-level functions that bind `self` when stored on a
+    // class.  `concat` is interp-level (`op_concat`, `interp_operator.py:20`)
+    // so it guards both operands for `__getitem__`.
     appleveldefs: {
         "app_operator.py" => [
-            "countOf", "itemgetter", "attrgetter", "methodcaller",
-            "indexOf", "inv", "is_none", "is_not_none", "call",
+            "itemgetter", "attrgetter", "methodcaller",
         ],
     },
     functions: {
@@ -161,6 +208,8 @@ crate::py_module! {
         "pos"      / 1 = |args| pos(args[0]),
         "abs"      / 1 = |args| crate::builtins::builtin_abs(args),
         "invert"   / 1 = |args| invert(args[0]),
+        // `inv` is the historical spelling of `invert` — same as `~a`.
+        "inv"      / 1 = |args| invert(args[0]),
         "lshift"   / 2 = |args| lshift(args[0], args[1]),
         "rshift"   / 2 = |args| rshift(args[0], args[1]),
         "and_"     / 2 = |args| and_(args[0], args[1]),
@@ -187,7 +236,22 @@ crate::py_module! {
         "truth"    / 1 = |args| Ok(w_bool_from(is_true(args[0])?)),
         "is_"      / 2 = |args| Ok(w_bool_from(std::ptr::eq(args[0], args[1]))),
         "is_not"   / 2 = |args| Ok(w_bool_from(!std::ptr::eq(args[0], args[1]))),
+        "is_none"     / 1 = |args| Ok(w_bool_from(std::ptr::eq(args[0], w_none()))),
+        "is_not_none" / 1 = |args| Ok(w_bool_from(!std::ptr::eq(args[0], w_none()))),
         "contains" / 2 = |args| Ok(w_bool_from(contains(args[0], args[1])?)),
+        "countOf"  / 2 = op_countof,
+        "indexOf"  / 2 = op_indexof,
+        // `call(obj, /, *args, **kwargs)` == `obj(*args, **kwargs)`.
+        // `call_forwarding_args` re-splits the `__pyre_kw__` marker back into
+        // keyword arguments before dispatching.
+        "call"     / * = |args: &[PyObjectRef]| {
+            if args.is_empty() {
+                return Err(crate::PyError::type_error(
+                    "call expected at least 1 argument, got 0",
+                ));
+            }
+            crate::builtins::call_forwarding_args(args[0], &args[1..])
+        },
         "getitem"  / 2 = |args| getitem(args[0], args[1]),
         "setitem"  / 3 = |args| { setitem(args[0], args[1], args[2])?; Ok(w_none()) },
         "delitem"  / 2 = |args| { delitem(args[0], args[1])?; Ok(w_none()) },


### PR DESCRIPTION
## What

Moves six `_operator` callables — `inv`, `is_none`, `is_not_none`, `countOf`, `indexOf`, `call` — from `app_operator.py` (app-level) to the interp-level `functions:` block in `operator/mod.rs`.

## Why

As app-level Python functions they were `type == 'function'` with `__get__`, so storing one on a class bound `self` when read through an instance. CPython 3.14 exposes them as non-binding `builtin_function_or_method`, and PyPy places `inv`/`indexOf` in `interp_operator.py` (non-binding `builtin_function`). Registered interp-level they become non-binding `BuiltinFunction` (no `__get__`), matching both references.

First module slice of task #40 (make C-module callables non-binding, `builtin_function_or_method`). The `demote_module_function_to_builtin` machinery and its globals-null guard are unchanged — the guard must stay (it correctly preserves legitimately-binding assigned functions such as `sys.__interactivehook__`); the fix is purely per-module interp-level registration.

## Details

- `inv` reuses the existing `invert` helper (`~a`).
- `is_none` / `is_not_none` compare identity against the `None` singleton.
- `countOf` / `indexOf` iterate via the iterator protocol on `x is b or x == b`; `indexOf` raises `ValueError('sequence.index(x): x not in sequence')` on a miss.
- `call` forwards `obj(*args, **kwargs)` through `call_forwarding_args` (the same `__pyre_kw__`-marker resplit used by `breakpoint`/`sys.breakpointhook`).
- `attrgetter` / `itemgetter` / `methodcaller` stay app-level (callable factory classes; already non-binding).

## Verification

Side-by-side probe on `python3.14` and a pure-interpreter pyre build produced byte-identical output: each function is `builtin_function_or_method` with no `__get__`; `class C: f = _operator.countOf; C().f is _operator.countOf` is True (non-binding); `countOf`/`indexOf` (list + str, identity-or-equality path), `indexOf` miss message, `inv`, `is_none`/`is_not_none`, and `call` (positional / keyword / mixed / empty-arg `TypeError`) all match. `pyre/bench/synth/module_function_not_descriptor.py` prints `OK`; `import operator` re-export path works. `test.test_operator` is a `CRASH` baseline (not a PASS gate), so no cpython-suite regression is possible.

Note: the local `pyre-dynasm` build is blocked by stale Charon/LLBC artefacts (386 commits behind `origin/main`, charon not installed on this machine) — a pre-existing environment issue unrelated to this diff. The change is purely interpreter-level (module-function registration + operator semantics are JIT-independent), so it was verified on a pure-interpreter build; CI performs the full dynasm/cranelift/wasm/cpython-suite verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)