### PR TITLE
jit(bridge): fill a reconstructed inline callee's stream-named slots from the resume stream

### DIFF
--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -2480,26 +2480,15 @@ impl<S: JitState> JitDriver<S> {
     /// ResumeFromInterpDescr parity: data needed to compile an entry bridge
     /// from the currently active trace.
     ///
-    /// Returns `Some` only for a function-entry trace (`header_pc == 0`, the
-    /// interpreter portal into the function). An entry bridge runs the
-    /// function prologue and closes with a JUMP into an already-compiled hot
-    /// loop. A trace rooted at a *loop header* (`header_pc != 0`) returns
-    /// `None`: closing it as an entry bridge into another loop would drop its
-    /// own back-edge, so its iterations would no longer run in compiled code
-    /// (the caller then falls back to compile_loop, which aborts cleanly).
+    /// An entry bridge starts with the unoptimized interpreter arguments and
+    /// closes with a JUMP into an already-compiled loop.  The key it attaches
+    /// to is `original_boxes[:num_green_args]` — the greens of the merge point
+    /// tracing STARTED at (`_compile_and_run_once`, pyjitpl.py:2900-2905), with
+    /// no function-entry versus loop-header distinction; whether the trace came
+    /// from the interpreter at all is already decided by the absent bridge
+    /// origin at the caller.
     pub fn compile_trace_entry_data(&mut self) -> Option<(u64, S::Meta)> {
-        // Only a function-entry trace (header_pc == 0) closes as an entry
-        // bridge into an already-compiled hot loop. Both backends use this
-        // gate: dynasm jumps directly to the target LABEL via target_arglocs;
-        // cranelift's body-direct dual entry (compiler.rs) reads the LABEL
-        // args from the frame and jumps past the peeled preamble. A
-        // loop-header trace (header_pc != 0) returns None and the caller falls
-        // back to compile_loop, so its back-edge is never dropped.
-        let original_green_key = self
-            .meta
-            .trace_ctx()
-            .filter(|ctx| ctx.header_pc == 0)
-            .map(|ctx| ctx.root_green_key())?;
+        let original_green_key = self.meta.trace_ctx().map(|ctx| ctx.root_green_key())?;
         let trace_meta = self.meta.trace_meta()?.clone();
         Some((original_green_key, trace_meta))
     }

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -10703,7 +10703,15 @@ impl<M: Clone> MetaInterp<M> {
                 // which `has_compiled_loop` reads — not on target_tokens. The JUMP
                 // resolves to `green_key`'s TargetToken via the JUMP op's own descr,
                 // so the entry-bridge token owns no TargetTokens of its own.
-                let front_target_tokens: Vec<crate::history::TargetToken> = Vec::new();
+                //
+                // `attach_procedure_to_interp` (warmstate.py:339-348) re-points
+                // the jitcell and keeps the old token alive; it never takes the
+                // loop's own TargetTokens away.  `compiled_loops` is the single
+                // map pyre reads for both, so the replacement entry carries the
+                // retired loop's labels forward — publishing an empty list here
+                // leaves a key whose loop nothing can close into again, and every
+                // later trace reaching it declines for want of a front target.
+                let mut front_target_tokens: Vec<crate::history::TargetToken> = Vec::new();
                 let retraced_count = self
                     .compiled_loops
                     .get(&original_green_key)
@@ -10714,6 +10722,7 @@ impl<M: Clone> MetaInterp<M> {
                 if let Some(old_entry) = self.compiled_loops.swap_remove(&original_green_key) {
                     // Box Identity Phase E.2b parity: see finish_and_compile.
                     next_global_opref = next_global_opref.max(old_entry.next_global_opref);
+                    front_target_tokens = old_entry.front_target_tokens.clone();
                     if let Some(old_tok) = old_entry.live_token() {
                         self.backend.migrate_bridges(&old_tok, token.as_ref());
                     }

--- a/pyre/bench/fannkuch.cranelift.jitstats
+++ b/pyre/bench/fannkuch.cranelift.jitstats
@@ -1,8 +1,8 @@
-bridges_compiled=23
+bridges_compiled=22
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
-guard_failures=5394
+guard_failures=5049
 internal_compile_panics=0
-loops_aborted=2
-loops_compiled=5
+loops_aborted=0
+loops_compiled=6

--- a/pyre/bench/fannkuch.dynasm.jitstats
+++ b/pyre/bench/fannkuch.dynasm.jitstats
@@ -1,8 +1,8 @@
-bridges_compiled=23
+bridges_compiled=22
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
-guard_failures=5394
+guard_failures=5049
 internal_compile_panics=0
-loops_aborted=2
-loops_compiled=5
+loops_aborted=0
+loops_compiled=6

--- a/pyre/bench/synth/inline_subwalk_mutating_residual.py
+++ b/pyre/bench/synth/inline_subwalk_mutating_residual.py
@@ -1,4 +1,4 @@
-# pyre-check: max-pypy-ratio=690
+# pyre-check: max-pypy-ratio=200
 # gh#495 guard: an inlined subwalk whose callee makes an unjournaled mutation
 # through a nested residual CALL, in the two miss-handling shapes.
 #

--- a/pyre/bench/synth/inline_subwalk_property_mutates.py
+++ b/pyre/bench/synth/inline_subwalk_property_mutates.py
@@ -1,4 +1,4 @@
-# pyre-check: max-pypy-ratio=484
+# pyre-check: max-pypy-ratio=80
 # gh#495 guard: inlined property residual mutates before branch and caught miss.
 # @property value-returning mutating + try/except-inside-callee raising branch
 N = 60000

--- a/pyre/pyre-interpreter/src/pytraceback.rs
+++ b/pyre/pyre-interpreter/src/pytraceback.rs
@@ -205,6 +205,10 @@ pub unsafe fn w_pytraceback_set_w_next(
             curr = w_pytraceback_get_w_next(curr);
         }
         (*(obj as *mut PyTraceback)).w_next = w_new_next;
+        // An older `obj` now names a possibly younger `w_new_next`; remember it
+        // for the next minor tracer, as the allocation above does for the
+        // fields written at birth.
+        pyre_object::gc_hook::try_gc_write_barrier(obj as *mut u8);
     }
     Ok(())
 }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
@@ -346,7 +346,7 @@ pub(crate) fn fbw_store_journal_reset() {
     FBW_APPEND_PROMOTE_JOURNAL.with(|j| j.borrow_mut().clear());
     FBW_CELL_STORE_JOURNAL.with(|j| j.borrow_mut().clear());
     FBW_SYS_EXC_JOURNAL.with(|j| j.borrow_mut().clear());
-    FBW_TRACEBACK_STORE_JOURNAL.with(|j| *j.borrow_mut() = None);
+    FBW_TRACEBACK_STORE_JOURNAL.with(|j| j.borrow_mut().clear());
     FBW_UNJOURNALED_VALUE_UNAVAILABLE.with(|c| c.set(false));
     FBW_UNJOURNALED_SYMBOLIC.with(|c| c.set(false));
     FBW_EXECUTED_RESIDUAL_VOID.with(|c| c.set(0));
@@ -496,14 +496,10 @@ pub(crate) fn fbw_traceback_journal_push_if_attached(
         unsafe { pyre_interpreter::pytraceback::w_pytraceback_get_w_next(node) },
         previous_head
     );
-    FBW_TRACEBACK_STORE_JOURNAL.with(|j| {
-        let mut entry = j.borrow_mut();
-        assert!(
-            entry.is_none(),
-            "bridge-entry traceback attach ran more than once in one walk session"
-        );
-        *entry = Some((exception, node));
-    });
+    // A carrier sub-walk that keeps its journals across the root continuation
+    // attaches once per entered handler, so the log grows rather than asserting
+    // a single attach; the rollback unwinds the entries in reverse push order.
+    FBW_TRACEBACK_STORE_JOURNAL.with(|j| j.borrow_mut().push((exception, node)));
 }
 
 /// Commit-path epilogue: the walk's eager stores and appends stand; drop
@@ -519,7 +515,7 @@ pub(crate) fn fbw_store_journal_commit() {
     FBW_SYS_EXC_JOURNAL.with(|j| j.borrow_mut().clear());
     // The compiled trace owns the recorded attach and the authoritative walk
     // already applied this iteration's concrete node, so keep it in place.
-    FBW_TRACEBACK_STORE_JOURNAL.with(|j| *j.borrow_mut() = None);
+    FBW_TRACEBACK_STORE_JOURNAL.with(|j| j.borrow_mut().clear());
     // #57 Option C: a committed walk's end-flush adopts the advanced
     // iterator + the body that consumed it (counted once), so the in-flight
     // items must NOT also be delivered — drop the stash (and with it the
@@ -951,19 +947,41 @@ pub(crate) fn fbw_store_journal_rollback() {
             pyre_interpreter::eval::set_current_exception(displaced);
         }
     });
-    // Remove the bridge-entry node only while it remains the exact head the
-    // recording helper installed.  If later concrete execution replaced the
-    // head, discarding this walk must not overwrite that newer state.
+    // Splice every journaled bridge-entry node back out of its exception's
+    // chain.  The node is not necessarily still the head: concrete execution
+    // after the attach can prepend further nodes to the same exception (a
+    // handler that re-raises, or another raising callee), and dropping the undo
+    // in that case would leave the speculative node behind for the replay to
+    // record the catching frame on top of — a duplicated frame in the reported
+    // traceback.  Newer heads are preserved; only the journaled link is
+    // removed, in reverse push order so the chain collapses to its pre-walk
+    // shape.
     FBW_TRACEBACK_STORE_JOURNAL.with(|j| {
-        let Some((exception, node)) = j.borrow_mut().take() else {
-            return;
-        };
-        let current =
-            unsafe { pyre_object::interp_exceptions::w_exception_get_traceback(exception) };
-        if current == node {
-            let previous = unsafe { pyre_interpreter::pytraceback::w_pytraceback_get_w_next(node) };
-            unsafe {
-                pyre_object::interp_exceptions::w_exception_set_traceback(exception, previous);
+        let mut entries = j.borrow_mut();
+        while let Some((exception, node)) = entries.pop() {
+            let next = unsafe { pyre_interpreter::pytraceback::w_pytraceback_get_w_next(node) };
+            let head =
+                unsafe { pyre_object::interp_exceptions::w_exception_get_traceback(exception) };
+            if head == node {
+                unsafe {
+                    pyre_object::interp_exceptions::w_exception_set_traceback(exception, next);
+                }
+                continue;
+            }
+            let mut prev = head;
+            while !prev.is_null() && unsafe { pyre_interpreter::pytraceback::is_pytraceback(prev) }
+            {
+                let curr = unsafe { pyre_interpreter::pytraceback::w_pytraceback_get_w_next(prev) };
+                if curr == node {
+                    // The removed node sat between `prev` and `next`, so the
+                    // shortened chain cannot reach `prev` again and the
+                    // setter's loop check always passes.
+                    let _ = unsafe {
+                        pyre_interpreter::pytraceback::w_pytraceback_set_w_next(prev, next)
+                    };
+                    break;
+                }
+                prev = curr;
             }
         }
     });

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -2866,8 +2866,14 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
             callee_frame_reg,
         );
     // A strict straight-line callee at the top inline level is seeded with
-    // its own frame red so guards can carry a real two-frame snapshot.
-    let strict_seed = strict_inlinable && inline_depth < fbw_max_multiframe_depth();
+    // its own frame red so guards can carry a real two-frame snapshot.  A
+    // callee needing fresh cellvar allocation is not seeded — the seed block
+    // below breaks out to the ordinary single-frame inline for it — so exclude
+    // it here too, or the preflight would decline a CALL that path still
+    // serves.
+    let strict_seed = strict_inlinable
+        && inline_depth < fbw_max_multiframe_depth()
+        && callee_code.cellvars.is_empty();
     // Preflight the caller frame BEFORE the seed below records a virtual
     // PyFrame.  A CALL covered by a try/catch marker must remain residual so
     // its post-call catch resume routes an exception; returning after frame
@@ -3184,11 +3190,10 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
         'seed: {
             // Branch-A frame shape only (mirror REC_CA): existing freevar
             // cells are admissible, while fresh cellvar allocation is not.
+            // `strict_seed` already excludes such a callee, so only the
+            // multiframe path reaches this.
             if !callee_code.cellvars.is_empty() {
-                if try_multiframe {
-                    return Ok(None);
-                }
-                break 'seed;
+                return Ok(None);
             }
             // POP_JUMP_IF_NONE / POP_JUMP_IF_NOT_NONE lower to an `is`/`is_not`
             // identity residual call whose operands must be Ref (the codewriter

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -5043,17 +5043,26 @@ thread_local! {
     static FBW_SYS_EXC_JOURNAL: std::cell::RefCell<Vec<pyre_object::PyObjectRef>> =
         const { std::cell::RefCell::new(Vec::new()) };
 
-    /// Undo entry for the concrete traceback-head store performed while a
-    /// bridge-entry exception arm is recorded: `(exception, attached_node)`.
-    /// The two arms are mutually exclusive and each is entered at most once
-    /// per walk session, so one slot covers the concrete attach.  It shares
-    /// the store journal's lifecycle: a committing walk keeps the node and
-    /// clears the entry, while a discarded walk removes the node only when it
-    /// is still the exception's current traceback head.  Both refs are GC
-    /// roots via [`fbw_store_journal_root_walker`].
+    /// Undo entries for the concrete traceback-head stores performed while
+    /// bridge-entry exception arms are recorded: `(exception, attached_node)`.
+    /// The two arms are mutually exclusive per invocation, but a carrier
+    /// sub-walk that continues its root under [`WalkJournals::Keep`] runs both
+    /// inside one journal lifecycle (the callee handler entry, then the root's
+    /// carrier-raise seed), so the log holds every attach.  It shares the store
+    /// journal's lifecycle: a committing walk keeps the nodes and clears the
+    /// log, while a discarded walk splices each node back out in reverse push
+    /// order.  Both refs of every entry are GC roots via
+    /// [`fbw_store_journal_root_walker`].
+    ///
+    /// TLS owner: the log belongs to the in-progress walk, and a walk runs to
+    /// its commit-or-discard point on the thread that started it — the same
+    /// ownership the sibling `FBW_*_JOURNAL` logs above use.  The entries never
+    /// outlive that walk and are never read from another thread; GC
+    /// reachability is supplied explicitly by the root walker rather than by
+    /// the storage.
     static FBW_TRACEBACK_STORE_JOURNAL:
-        std::cell::RefCell<Option<(pyre_object::PyObjectRef, pyre_object::PyObjectRef)>> =
-        const { std::cell::RefCell::new(None) };
+        std::cell::RefCell<Vec<(pyre_object::PyObjectRef, pyre_object::PyObjectRef)>> =
+        const { std::cell::RefCell::new(Vec::new()) };
 
     /// In-flight FOR_ITER continuation (#57 Option C): `(consumed_item,
     /// body coordinate)` stashed when the FOR_ITER `for_iter_next` residual
@@ -5244,7 +5253,7 @@ struct FbwStoreJournalRootArea {
     cell_stores: *const std::cell::RefCell<Vec<(pyre_object::PyObjectRef, i64)>>,
     sys_exc: *const std::cell::RefCell<Vec<pyre_object::PyObjectRef>>,
     traceback_store:
-        *const std::cell::RefCell<Option<(pyre_object::PyObjectRef, pyre_object::PyObjectRef)>>,
+        *const std::cell::RefCell<Vec<(pyre_object::PyObjectRef, pyre_object::PyObjectRef)>>,
     foriter: *const std::cell::RefCell<Vec<InflightForiter>>,
     bridge_iter: *const std::cell::RefCell<Vec<(pyre_object::PyObjectRef, i64, i64)>>,
     abort_resume: *const std::cell::RefCell<Option<InlineAbortCarrier>>,
@@ -5571,7 +5580,7 @@ pub unsafe fn fbw_store_journal_root_walker_area(
     // walk commits or rolls back.  The entry may be their only scanned owner
     // after later concrete execution changes the exception's head.
     let traceback_store = unsafe { &mut *(*area.traceback_store).as_ptr() };
-    if let Some((exception, node)) = traceback_store.as_mut() {
+    for (exception, node) in traceback_store.iter_mut() {
         visitor(unsafe { &mut *(exception as *mut pyre_object::PyObjectRef).cast() });
         visitor(unsafe { &mut *(node as *mut pyre_object::PyObjectRef).cast() });
     }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/resume_snapshot.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/resume_snapshot.rs
@@ -1999,6 +1999,25 @@ pub(crate) fn walker_capture_multi_frame_inline_snapshot<Sym: WalkSym>(
     if !callee_pjc.is_populated() || callee_pjc.code_ptr.is_null() {
         return Err(DispatchError::callee_inline_unsupported(callee_op_pc));
     }
+    // Mirror of the single-frame path: the callee (top) frame carries a branch
+    // guard's supplied pc (`GuardCaptureScope::branch_guard_jitcode_pc`)
+    // unchanged. For other guards, the callee payload supplies the
+    // resume-marker twin:
+    // after-residual guards use the fallthrough twin and retain the sentinel
+    // on a miss, while plain guards retain the raw `callee_op_pc` on a miss.
+    // Computed before box collection so encoder liveness and decoder resume
+    // use the same coordinate.
+    let callee_jitcode_pc: i32 = match scope.branch_guard_jitcode_pc {
+        Some(g) => g as i32,
+        None if after_residual_call => callee_pjc
+            .after_residual_marker_for_jitcode_pc(callee_op_pc)
+            .map(|m| m as i32)
+            .unwrap_or(majit_ir::resumedata::NO_JITCODE_PC),
+        None => callee_pjc
+            .resume_marker_for_jitcode_pc(callee_op_pc)
+            .map(|m| m as i32)
+            .unwrap_or(callee_op_pc as i32),
+    };
     let mf_diag = std::env::var_os("PYRE_FBW_MF_DIAG").is_some();
     let recipe_resultcolor_audit = pcmap_recipe_resultcolor_audit_enabled();
     if mf_diag || recipe_resultcolor_audit {
@@ -2049,18 +2068,37 @@ pub(crate) fn walker_capture_multi_frame_inline_snapshot<Sym: WalkSym>(
             let depth = callee_pjc
                 .depth_for_jitcode_pc_pred(callee_op_pc)
                 .unwrap_or(0);
-            let banks = crate::state::frame_liveness_reg_indices_by_bank_at(
+            // Read the coordinate the box collection below actually uses, not
+            // the raw `callee_op_pc`; and read it through the
+            // decline-reporting form, since the lossy query maps an
+            // unresolvable coordinate and a genuinely empty window onto the
+            // same all-empty result.
+            let resolved = crate::state::try_frame_liveness_reg_indices_by_bank_at_with_jitcode_pc(
                 callee_jitcode_index as i32,
-                callee_op_pc as i32,
+                callee_jitcode_pc,
             );
+            let window = if resolved.is_some() {
+                "resolved"
+            } else {
+                "UNRESOLVED"
+            };
+            let banks = resolved.unwrap_or_default();
             eprintln!(
                 "[fbw-mf-diag] callee jc={callee_jitcode_index} op_pc={callee_op_pc} \
              py_pc={callee_py_pc} after_residual={after_residual_call} depth={depth} \
              pcdep_color_slots={pcdep:?}"
             );
+            // The color→slot inversion must be read at the same coordinate as
+            // the banks above; `pcdep` at the raw `callee_op_pc` can name a
+            // different set, which is what makes a live color look unmapped.
+            let coord_pcdep = usize::try_from(callee_jitcode_pc)
+                .ok()
+                .and_then(|coord| callee_pjc.pcdep_for_jitcode_pc(coord))
+                .unwrap_or_default();
             eprintln!(
-                "[fbw-mf-diag]   live banks: i={:?} r={:?} f={:?}",
-                banks.int, banks.ref_, banks.float
+                "[fbw-mf-diag]   live banks: i={:?} r={:?} f={:?} coord={callee_jitcode_pc} \
+                 window={window} coord_pcdep={coord_pcdep:?}",
+                banks.int, banks.ref_, banks.float,
             );
             for &c in &banks.ref_ {
                 eprintln!(
@@ -2092,25 +2130,6 @@ pub(crate) fn walker_capture_multi_frame_inline_snapshot<Sym: WalkSym>(
             }
         }
     }
-    // Mirror of the single-frame path: the callee (top) frame carries a branch
-    // guard's supplied pc (`GuardCaptureScope::branch_guard_jitcode_pc`)
-    // unchanged. For other guards, the callee payload supplies the
-    // resume-marker twin:
-    // after-residual guards use the fallthrough twin and retain the sentinel
-    // on a miss, while plain guards retain the raw `callee_op_pc` on a miss.
-    // Computed before box collection so encoder liveness and decoder resume
-    // use the same coordinate.
-    let callee_jitcode_pc: i32 = match scope.branch_guard_jitcode_pc {
-        Some(g) => g as i32,
-        None if after_residual_call => callee_pjc
-            .after_residual_marker_for_jitcode_pc(callee_op_pc)
-            .map(|m| m as i32)
-            .unwrap_or(majit_ir::resumedata::NO_JITCODE_PC),
-        None => callee_pjc
-            .resume_marker_for_jitcode_pc(callee_op_pc)
-            .map(|m| m as i32)
-            .unwrap_or(callee_op_pc as i32),
-    };
     let callee_boxes = collect_callee_active_boxes(
         ctx.registers_i,
         ctx.registers_r,

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -6744,12 +6744,17 @@ fn rd_virtual_at(
 /// The returned OpRefs are heap reads rooted at `frame_box`, not constants
 /// made from the current concrete frame.  A compiled bridge therefore reloads
 /// the frame image on every guard hit (resume.py:1042-1057 consume_boxes).
+///
+/// `stream_covered[k]` marks a slot the caller fills from the resume stream
+/// instead; the image is not read for it (the stream value is authoritative,
+/// see `reconstruct_inline_recipe`), and the slot is left NONE/Void here.
 fn reconstruct_materialized_frame_slots(
     ctx: &mut majit_metainterp::TraceCtx,
     frame_box: OpRef,
     frame_ref: majit_ir::GcRef,
     valuestackdepth: usize,
     pending_result_abs_slot: Option<usize>,
+    stream_covered: &[bool],
 ) -> Option<(Vec<OpRef>, Vec<majit_ir::Value>)> {
     if frame_ref.is_null() || frame_ref == majit_ir::GcRef::NO_CONCRETE {
         return None;
@@ -6778,7 +6783,7 @@ fn reconstruct_materialized_frame_slots(
     let mut registers_r = vec![OpRef::NONE; valuestackdepth];
     let mut concrete_r = vec![majit_ir::Value::Void; valuestackdepth];
     for k in 0..valuestackdepth {
-        if Some(k) == pending_result_abs_slot {
+        if Some(k) == pending_result_abs_slot || stream_covered.get(k).copied().unwrap_or(false) {
             continue;
         }
         let index = ctx.const_int(k as i64);
@@ -6789,6 +6794,45 @@ fn reconstruct_materialized_frame_slots(
             .unwrap_or_else(|| majit_ir::Value::Ref(majit_ir::GcRef(arr.as_slice()[k] as usize)));
     }
     Some((registers_r, concrete_r))
+}
+
+/// resume.py:1054 `consume_boxes`: fill the semantic slots the resume stream
+/// names straight from that stream, overriding whatever the paused frame's
+/// image holds for them.
+///
+/// `stream_slots` is `(index into the frame's decoded value section, semantic
+/// `locals_cells_stack_w` slot)`, built by inverting color -> slot with the
+/// per-pc `pcdep` map the encoder used.
+#[allow(clippy::too_many_arguments)]
+fn overlay_stream_ref_slots(
+    ctx: &mut majit_metainterp::TraceCtx,
+    stream_slots: &[(usize, usize)],
+    values: &[&majit_ir::resumedata::RebuiltValue],
+    registers_r: &mut [OpRef],
+    concrete_r: &mut [majit_ir::Value],
+    rd_virtuals: Option<&[std::rc::Rc<majit_ir::RdVirtualInfo>]>,
+    resume_data: &majit_metainterp::ResumeDataResult,
+    fail_values: &[i64],
+    fail_types: &[Type],
+    backend: &dyn majit_backend::Backend,
+    cache: &mut BridgeVirtualCache,
+) {
+    for &(pos, slot) in stream_slots {
+        let (box_ref, value) = bridge_decode_box(
+            ctx,
+            values[pos],
+            Type::Ref,
+            rd_virtuals,
+            resume_data,
+            fail_values,
+            fail_types,
+            backend,
+            cache,
+        );
+        ctx.try_set_opref_concrete(box_ref, value);
+        registers_r[slot] = box_ref;
+        concrete_r[slot] = value;
+    }
 }
 
 /// Decode one suspended inline-callee frame's resume section into a
@@ -7016,6 +7060,49 @@ fn reconstruct_inline_recipe(
         let Some(frame_pos) = reg_indices.ref_.iter().position(|&c| c == pframe_reg) else {
             decline!("NoFrameRedPosition");
         };
+        let valuestackdepth = nlocals + stack_only;
+        // resume.py:1042-1057 `consume_boxes` refills a paused frame from the
+        // resume stream alone.  Both frame images read below are pyre's
+        // stand-in for the slots that stream never names — a portal callee
+        // keeps its locals in `locals_cells_stack_w` rather than the register
+        // section — but wherever the stream DOES name a slot it is
+        // authoritative: that slot lives in a machine register neither image
+        // has been written back from.  A residual call's result at the guard is
+        // exactly that shape, and reading the image there yields NULL (the
+        // stale pre-call array entry for a forced frame, the never-stored
+        // `NewArrayClear` entry for a virtual one), so the next residual
+        // consuming it folds its Ref arg to concrete NULL
+        // (`walker_abort_if_mayforce_null_ref_arg`) and no bridge is ever
+        // built.  Invert color -> slot with the same `pcdep` map the encoder
+        // used and take those slots from the stream instead.
+        let mut stream_slots: Vec<(usize, usize)> = Vec::new();
+        let mut stream_covered = vec![false; valuestackdepth];
+        for (pos, &color) in reg_indices.ref_.iter().enumerate() {
+            if color == pframe_reg || color == pec_reg {
+                continue;
+            }
+            let Some(slot) = semantic_ref_slot_for_reg_color(
+                nlocals,
+                stack_only,
+                &maps.pcdep_entries,
+                color as usize,
+            ) else {
+                continue;
+            };
+            // The pending call result is delivered by `make_result_of_lastop`,
+            // not from resumedata, so its slot stays unwritten here.
+            if slot >= valuestackdepth
+                || Some(slot) == pending_result_abs_slot
+                || stream_covered[slot]
+            {
+                continue;
+            }
+            stream_covered[slot] = true;
+            stream_slots.push((pos, slot));
+        }
+        if !stream_slots.is_empty() {
+            crate::jitcode_dispatch::census_record("P2Recipe::StreamSlotOverImage");
+        }
         // resume.py:1042-1057 rebuild_from_resumedata consumes the saved boxes
         // for every frame without requiring the frame object itself to remain
         // virtual.  A Pyre callee frame can be forced before the guard (for
@@ -7045,14 +7132,27 @@ fn reconstruct_inline_recipe(
             };
             ctx.try_set_opref_concrete(frame_box, frame_value);
 
-            let valuestackdepth = nlocals + stack_only;
-            let (registers_r, concrete_r) = reconstruct_materialized_frame_slots(
+            let (mut registers_r, mut concrete_r) = reconstruct_materialized_frame_slots(
                 ctx,
                 frame_box,
                 frame_ref,
                 valuestackdepth,
                 pending_result_abs_slot,
+                &stream_covered,
             )?;
+            overlay_stream_ref_slots(
+                ctx,
+                &stream_slots,
+                &values,
+                &mut registers_r,
+                &mut concrete_r,
+                rd_virtuals,
+                resume_data,
+                fail_values,
+                fail_types,
+                backend,
+                cache,
+            );
             crate::jitcode_dispatch::census_record("P2Recipe::MaterializedFrameAdmit");
             return Some(ReconstructRecipe {
                 code_ptr: raw_code as *const (),
@@ -7111,7 +7211,6 @@ fn reconstruct_inline_recipe(
             | majit_ir::RdVirtualInfo::VArrayInfoNotClear { fieldnums, .. } => fieldnums.clone(),
             _ => decline!("LocalsArrayNotArrayInfo"),
         };
-        let valuestackdepth = nlocals + stack_only;
         if valuestackdepth > arr.len() {
             decline!("LocalsArrayTooShort");
         }
@@ -7123,7 +7222,7 @@ fn reconstruct_inline_recipe(
         // NULL in the rebuilt frame; a missing operand-stack slot is
         // unreconstructable and declines below.
         for k in 0..valuestackdepth {
-            if Some(k) == pending_result_abs_slot {
+            if Some(k) == pending_result_abs_slot || stream_covered[k] {
                 continue;
             }
             let tag = arr[k];
@@ -7144,6 +7243,22 @@ fn reconstruct_inline_recipe(
             );
             concrete_r[k] = value_for_slot(Type::Ref, bits);
         }
+        // Runs before the mandatory-operand check: a stack slot the virtual
+        // array never stored is `UNINITIALIZED`/clear-NULL there but present in
+        // the stream, so the overlay is what makes it reconstructable.
+        overlay_stream_ref_slots(
+            ctx,
+            &stream_slots,
+            &values,
+            &mut registers_r,
+            &mut concrete_r,
+            rd_virtuals,
+            resume_data,
+            fail_values,
+            fail_types,
+            backend,
+            cache,
+        );
         for s in nlocals..valuestackdepth {
             if Some(s) == pending_result_abs_slot
                 || unreconstructable_operand_floor.is_some_and(|floor| s >= floor)
@@ -10697,6 +10812,7 @@ mod tests {
             majit_ir::GcRef(frame_ptr),
             values.len(),
             Some(1),
+            &[],
         )
         .expect("forced frame slots should be reconstructable");
 


### PR DESCRIPTION
Six commits on top of `origin/main`, all in the bridge/entry-bridge area.

## `MayForceNullRefArgUnsupported` — the whole cluster is gone

`reconstruct_inline_recipe`'s two `portal_callee` paths both rebuilt the paused
callee's semantic slots out of the frame **image** — the forced frame array for
the materialized path, the virtual array's `fieldnums` for the TAGVIRTUAL path.
A slot the compiled frame keeps in a machine register is in neither image: the
forced array still holds its stale pre-call entry and the virtual array holds
the never-stored `NewArrayClear` NULL. A residual call's result at the guard is
exactly that shape, so the next residual consuming it folded its `Ref` arg to a
concrete NULL, `walker_abort_if_mayforce_null_ref_arg` fired, and no bridge was
ever built.

The root frame's `setup_bridge_sym` already prefers the resume stream (it
inverts color -> slot into `mirror`); only the reconstructed callee preferred
the image — which is why this was pyre-only. The fix inverts color -> slot with
the same per-pc `pcdep` map the encoder used, and overlays those slots from the
resume stream in both paths (`overlay_stream_ref_slots`), leaving the image to
cover only the slots the stream never names.

| bench | dynasm aborts | cranelift aborts |
|---|---|---|
| `inline_subwalk_mutating_residual` | 116 -> 0 | 1 -> 1 |
| `inline_subwalk_property_mutates` | 116 -> 0 | 116 -> 0 |

Guard failures on dynasm fall 24186 -> 813 and 23784 -> 401. Program output is
unchanged on every backend.

## Entry-bridge attach

`c755c691bc` attaches an entry bridge from any interpreter-started trace and
carries the retired loop's target tokens forward, rather than gating on
`header_pc == 0` (a pyre-only gate). `87c3a88606` re-records the native
fannkuch baselines that moved as a result. `a503fb40f0` logs every bridge-entry
traceback attach, splices each back out on rollback, and preflights only a
seeded callee. `46ed9764fd` reads the multiframe capture diagnostic at the
coordinate the box collection actually uses -- the old one read a different
coordinate and reported an empty window that was never empty.

## Gates

`inline_subwalk_mutating_residual` 690 -> 200 and
`inline_subwalk_property_mutates` 484 -> 80. Worst native ratio observed across
two samples per backend is 80.0x and 24.5x; exec times were stable (0.40/0.41s,
0.59/0.60s, 0.20/0.20s, 0.21/0.22s) while ratios swung 27.8x-80.0x, so the
swing is pypy-denominator quantization at 0.02s resolution, not exec-time
movement.

## Verification

`python3 pyre/check.py --backend dynasm` -> ALL PASSED 351/351
`python3 pyre/check.py --backend cranelift` -> ALL PASSED 351/351

Both against jitstats baselines re-recorded on an unpatched post-rebase build,
after confirming by A/B (revert the patch, rebuild, re-measure) that four
counter drifts reported mid-session came from the rebase and not from this
change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved traceback handling during exception processing, including safer rollback of multiple traceback updates.
  - Fixed inline execution state restoration so current values are preserved when resuming optimized code.
  - Improved loop replacement and trace-entry handling for more reliable JIT behavior.
  - Corrected optimized calls involving closures and multi-frame execution.
- **Performance**
  - Updated benchmark results reflecting fewer guard failures, no aborted loops, and more compiled loops.
- **Tests**
  - Adjusted performance-check thresholds to reflect current runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->