### PR TITLE
pytraceback: correct the frame-slot documentation and drop the unused offsets constant

### DIFF
--- a/pyre/gate-triage.md
+++ b/pyre/gate-triage.md
@@ -495,6 +495,42 @@ pre-move address into `PyTraceback.frame`.  The port therefore needs the
 root-and-reload shape on the recorder first, which also covers the same
 pre-existing exposure on its `w_next` argument.
 
+**That contract is a pyre deviation, and it is not the traceback's.**  Upstream
+attaches no allocation rule to a traceback's frame at all: `pytraceback.py:29`
+stores an ordinary traced field of an ordinary movable `pyframe.py:52 class
+PyFrame(W_Root)`, nothing under `pypy/interpreter/` calls `rgc.pin` (whose own
+doc, `rpython/rlib/rgc.py:88-97`, rules out the lifetime use), and a minor
+collection relocates the frame and rewrites every referring slot
+(`rpython/memory/gc/incminimark.py:2237` / `:2252`) because roots arrive as slot
+addresses (`rpython/memory/gctransform/shadowstack.py:43-46`) and compiled code
+re-reads the frame after each collecting call
+(`rpython/jit/backend/x86/assembler.py:1369-1377`).  The one obligation upstream
+does attach is a JIT one — force the vref, `error.py:370
+tb.frame.mark_as_escaped()` — which pyre already has.
+
+The traceback edge itself is likewise already upstream-shaped:
+`pytraceback_object_custom_trace` forwards `frame` as a *mutable* slot, so a
+relocation would be written back today.  What forbids a movable frame is
+elsewhere — raw `*mut PyFrame` duplicates no root walker reaches.  `FrameBox`
+holds a forwarding-capable `owner_root` and never reads it back, so every
+`Deref` goes through the stale raw field; `eval_loop` runs behind a
+`&mut PyFrame` across a safepoint (the exact class RPython's translated
+shadowstack enumerates for free); the blackhole keeps the virtualizable as a
+bare integer, as does `INLINE_CONCRETE_FRAME`.  Converging means, in order:
+teach `FrameBox::deref` to read its own root and root the inline concrete frame
+the same way; then give compiled code a virtualizable reload after collecting
+calls — pyre has only the JITFRAME half (`reload_frame_if_necessary` in the
+dynasm aarch64 assembler, cited against `assembler.py:1369-1377`).  Only after
+both does dropping the non-moving frame allocation become safe, and with it the
+`PyTraceback.w_code` snapshot, which exists solely because the frame edge is
+conditional.
+
+Two hand-placed props currently hold the invariant up rather than the allocator:
+the dynasm runner routes a resume-materialized virtual `PyFrame` to oldgen on
+purpose, and the JIT's traceback recorder builds a fresh oldgen frame instead of
+handing `record_application_traceback` a materialized virtual.  Both are
+comment-enforced.
+
 One thing the ON path already fixes: with a side-effecting inlined callee under
 a `while` loop that returns from inside the loop, the OFF path runs the callee's
 side effect ~5.2k extra times (the recorded trace-abort double-run class) while

--- a/pyre/pyre-interpreter/src/pytraceback.rs
+++ b/pyre/pyre-interpreter/src/pytraceback.rs
@@ -10,13 +10,30 @@
 //!         self.lineno = lineno
 //! ```
 //!
-//! Pyre stores `frame` as a raw `*mut PyFrame` opaque pointer.  PyPy's
-//! `frame` is a `PyFrame` W_Root; pyre's `PyFrame` lacks the
-//! `PyObject` header (`pyframe.py:39` `#[repr(C)]` without `ob_header`
-//! — frames are heap-allocated outside the nursery and walked by a
-//! custom GC walker).  Until `PyFrame` grows a W_Root header (which is
-//! itself a multi-file change), the descriptor `tb_frame` cannot
-//! return a Python-visible object directly.
+//! Upstream `frame` is an ordinary traced field of an ordinary movable
+//! instance: `pytraceback.py:29 self.frame = frame` on a
+//! `baseobjspace.W_Root`, pointing at `pyframe.py:52 class
+//! PyFrame(W_Root)`, which declares no `_alloc_flavor_` and is never
+//! pinned — `rpython/rlib/rgc.py:88-97` documents `pin` as a
+//! short-lived-buffer facility that does not extend lifetime, and
+//! nothing under `pypy/interpreter/` calls it.  A minor collection
+//! copies the frame (`rpython/memory/gc/incminimark.py:2237`) and
+//! rewrites every referring slot in place (`:2252`), because roots
+//! reach the collector as slot addresses
+//! (`rpython/memory/gctransform/shadowstack.py:43-46`) and compiled
+//! code re-reads the frame after each collecting call
+//! (`rpython/jit/backend/x86/assembler.py:1369-1377`).
+//!
+//! Pyre's `PyFrame` does carry the `PyObject` prefix (its `ob_header`
+//! field), so `tb_frame` returns a Python-visible object.  What
+//! diverges is the slot type: this struct holds a raw `*mut PyFrame`
+//! rather than a `PyObjectRef`, and the edge reaches the collector
+//! only through the hand-written `pytraceback_object_custom_trace`
+//! hook, which forwards it as a mutable slot but skips a frame the GC
+//! does not own (a `FrameBox::new_boxed` tracer snapshot).  The
+//! pointee must additionally never move, which is not an upstream
+//! requirement and is not caused by anything in this file — see
+//! `w_pytraceback_new`.
 
 use pyre_object::pyobject::*;
 
@@ -29,21 +46,24 @@ pub const LINENO_NOT_COMPUTED: i64 = i64::MIN;
 pub static PYTRACEBACK_TYPE: PyType = new_pytype("traceback");
 
 /// Layout: `[ob_header | frame: *mut PyFrame | lasti: i64 | w_next:
-/// PyObjectRef | lineno: i64]`.
+/// PyObjectRef | lineno: i64 | w_code: PyObjectRef]`.
 ///
-/// Only `w_next` is GC-traced.  `frame` is a raw pointer to a
-/// custom-walked `PyFrame` allocation; the frame walker scans the
-/// traceback chain separately once wired up.
+/// Every reference slot is traced, but by the hand-written
+/// `pytraceback_object_custom_trace` rather than by an offsets table:
+/// `TypeInfo::object_subclass_with_custom_trace` leaves
+/// `gc_ptr_offsets` empty for every type that supplies a hook.
 #[repr(C)]
 pub struct PyTraceback {
     pub ob_header: PyObject,
-    /// `pytraceback.py:29 self.frame = frame` — opaque `*mut PyFrame`.
-    /// Not a `PyObjectRef` because `PyFrame` has no `PyObject` header.
-    /// Frames are GC-owned non-moving blocks and
-    /// `pytraceback_object_custom_trace` forwards this edge, so the
-    /// pointer stays live for the traceback's whole lifetime and
-    /// `tb_frame` is safe to dereference.  The `w_code` snapshot below
-    /// still exists for readers that run without the GC hook wired.
+    /// `pytraceback.py:29 self.frame = frame` — a raw `*mut PyFrame`
+    /// rather than a `PyObjectRef`, so it takes part in collection
+    /// only through `pytraceback_object_custom_trace`.  That hook
+    /// forwards the slot when the GC owns the frame, which keeps it
+    /// live and would rewrite it if the frame ever moved; it skips a
+    /// frame the GC does not own — a `FrameBox::new_boxed` tracer
+    /// snapshot, freed at the end of its walk — and such a pointer is
+    /// left dangling and must not be dereferenced.  The `w_code`
+    /// snapshot below is what readers use in that case.
     pub frame: *mut crate::pyframe::PyFrame,
     /// `pytraceback.py:30 self.lasti = lasti` — bytecode index at
     /// which the exception was raised (in instruction units).
@@ -57,14 +77,15 @@ pub struct PyTraceback {
     /// `get_lineno` calls `offset2lineno` to resolve it lazily
     /// (`pytraceback.py:34-37`).
     pub lineno: i64,
-    /// Snapshot of the raising frame's `pycode` — kept alive via GC
-    /// tracing so `tb_frame`-less traceback consumers (e.g.
-    /// `write_traceback_chain`) can still read `source_path` /
-    /// `obj_name` / `qualname` after the underlying `PyFrame` has
-    /// been freed.  PyPy doesn't need this because its `PyFrame` is
-    /// itself a W_Root; pyre's frame isn't, so the PyCode is
-    /// the smallest GC-rooted handle that preserves the parity-
-    /// visible metadata.
+    /// Snapshot of the raising frame's `pycode`, with no upstream
+    /// counterpart — `pytraceback.py` reads `self.frame.pycode`
+    /// directly (`:36`), because upstream's frame edge is unconditional
+    /// and the frame therefore outlives the traceback.  Pyre's does not
+    /// hold for a frame the GC does not own, so consumers that must
+    /// keep working then (`write_traceback_chain`) read `source_path` /
+    /// `obj_name` / `qualname` through this handle instead.  Retiring
+    /// the field is blocked on making every frame that can reach a
+    /// traceback GC-owned.
     pub w_code: PyObjectRef,
 }
 
@@ -81,14 +102,6 @@ pub const PYTRACEBACK_W_CODE_OFFSET: usize = std::mem::offset_of!(PyTraceback, w
 pub const PYTRACEBACK_GC_TYPE_ID: u32 = 44;
 
 pub const PYTRACEBACK_OBJECT_SIZE: usize = std::mem::size_of::<PyTraceback>();
-
-/// Two `PyObjectRef`-shaped slots are GC-traced — the chained
-/// `w_next` traceback link and the `w_code` snapshot kept alive so
-/// `source_path` / `obj_name` survive after the raising frame is
-/// freed.  `frame` is a raw `*mut PyFrame` to a custom-walked
-/// structure and `lasti`/`lineno` are scalar tags.
-pub const PYTRACEBACK_GC_PTR_OFFSETS: [usize; 2] =
-    [PYTRACEBACK_W_NEXT_OFFSET, PYTRACEBACK_W_CODE_OFFSET];
 
 impl pyre_object::lltype::GcType for PyTraceback {
     fn type_id() -> u32 {
@@ -122,15 +135,26 @@ pub fn w_pytraceback_new(
         w_code,
     };
 
-    // Executing frames are GC-managed non-moving oldgen blocks
-    // (`PYFRAME_GC_TYPE_ID`); to keep `tb_frame` alive across the
-    // traceback's lifetime the traceback itself must be a GC object
-    // whose `pytraceback_object_custom_trace` forwards the `frame`
-    // edge.  Allocate into oldgen (non-moving — raw `*mut PyTraceback`
-    // readers and the exception `w_traceback` chain hold bare
-    // pointers), mirroring `FrameBox::new` (`pyframe.rs:307`).  Before
-    // the GC hook is wired (bootstrap, tests) `try_gc_alloc_stable`
-    // returns `None`; fall back to the leaked `malloc_typed` block.
+    // `frame` was copied into `value` above and is not among the roots
+    // pinned here, so the allocation below — which can safepoint — must
+    // not be able to move it.  Upstream has no such rule: a minor
+    // collection would relocate the frame and rewrite the slot
+    // (`incminimark.py:2237` / `:2252`).  Pyre cannot, because raw
+    // `*mut PyFrame` copies exist that no root walker reaches —
+    // `FrameBox::deref` reads its raw field while holding a
+    // forwarding-capable `owner_root` it never reads back, `eval_loop`
+    // runs behind a `&mut PyFrame` across a safepoint, and the
+    // blackhole keeps the virtualizable as a bare integer.  Frames are
+    // therefore allocated non-moving (`FrameBox::new`), and callers of
+    // `record_application_traceback` owe this function a frame that
+    // stays reachable across the allocation: on the `CURRENT_FRAME` /
+    // `f_backref` chain, or pinned by hand.
+    //
+    // Allocate the traceback itself into oldgen for the same reason —
+    // raw `*mut PyTraceback` readers and the exception `w_traceback`
+    // chain hold bare pointers.  Before the GC hook is wired
+    // (bootstrap, tests) `try_gc_alloc_stable` returns `None`; fall
+    // back to the leaked `malloc_typed` block.
     let raw = pyre_object::gc_hook::try_gc_alloc_stable_raw(
         PYTRACEBACK_GC_TYPE_ID,
         PYTRACEBACK_OBJECT_SIZE,
@@ -245,11 +269,12 @@ pub unsafe fn w_pytraceback_get_w_code(obj: PyObjectRef) -> PyObjectRef {
 ///
 /// Pyre stamps the real line number at `record_application_traceback`
 /// time (the frame is guaranteed live there), so this reader never
-/// has to walk back through `self.frame.pycode` — which would be
-/// unsafe in pyre because `PyFrame` is not a GC-traced W_Root and
-/// the frame may have been freed by the time `tb_lineno` is read.
-/// The `LINENO_NOT_COMPUTED` sentinel still surfaces as `-1` for
-/// the edge case where the traceback was constructed without a
+/// has to walk back through `self.frame.pycode`.  That walk is what
+/// upstream does, and it is safe there because the frame edge is
+/// unconditional; pyre's is not forwarded for a frame the GC does not
+/// own, which may already have been freed by the time `tb_lineno` is
+/// read.  The `LINENO_NOT_COMPUTED` sentinel still surfaces as `-1`
+/// for the edge case where the traceback was constructed without a
 /// frame (e.g. unit tests).
 ///
 /// # Safety
@@ -356,20 +381,18 @@ pub unsafe fn record_application_traceback(
         crate::eval::set_in_flight_exception(w_exc_object);
         // `pytraceback.py:36 self.lineno = offset2lineno(self.frame
         // .pycode, self.lasti)` — pyre resolves the line number
-        // eagerly here (rather than lazily in `get_lineno`) because
-        // pyframe.rs's `PyFrame` is not a GC-traced W_Root, so by
-        // the time `tb_lineno` is read the frame may already be
-        // freed.  Stamping at construction guarantees the value
-        // survives the frame's lifetime.  `frame.pycode` is the
-        // `PyCode` wrapper; the inner `CodeObject` is
-        // extracted via `pyframe_get_pycode`.
+        // eagerly here rather than lazily in `get_lineno`, because a
+        // frame the GC does not own is not kept alive by the traceback
+        // and may already be freed by the time `tb_lineno` is read.
+        // Stamping at construction guarantees the value survives the
+        // frame's lifetime.  `frame.pycode` is the `PyCode` wrapper;
+        // the inner `CodeObject` is extracted via `pyframe_get_pycode`.
         //
-        // The `PyCode` PyObjectRef is also captured into the
-        // `w_code` slot so the traceback's source-path / function
-        // name metadata stays GC-rooted after the raising frame's
-        // freed — readers (e.g. `write_traceback_chain` in
-        // `error.rs`) MUST go through `w_code` rather than
-        // dereferencing the dangling `frame` pointer.
+        // The `PyCode` PyObjectRef is also captured into the `w_code`
+        // slot so the traceback's source-path / function name metadata
+        // stays GC-rooted in that same case — readers (e.g.
+        // `write_traceback_chain` in `error.rs`) MUST go through
+        // `w_code` rather than dereferencing the `frame` pointer.
         let w_code = (*frame).pycode as PyObjectRef;
         let lineno = {
             let code_obj = crate::pyframe::pyframe_get_pycode(&*frame);

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -396,8 +396,11 @@ pub unsafe fn walk_jit_callee_frame_roots_area(
     let live_frames = unsafe { &mut *(*area.live_frames).get() };
     for slot in live_frames.iter_mut() {
         // Mark the frame object itself — this list is its only root
-        // until the call returns. The frame is a non-moving stable
-        // allocation, so the visitor never rewrites the slot.
+        // until the call returns. The slot is handed over as a mutable
+        // `GcRef` so a relocation would be written back, as upstream's
+        // slot-address roots are (`shadowstack.py:43-46`); it stays
+        // unwritten only because `FrameBox::new` allocates frames
+        // non-moving.
         visitor(unsafe { &mut *(slot as *mut *mut PyFrame as *mut GcRef) });
         unsafe { visit_callee_frame_roots(*slot, visitor) };
     }

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -521,9 +521,11 @@ unsafe fn generator_object_custom_trace(obj_addr: usize, f: &mut dyn FnMut(*mut 
 /// chain) through the ordinary reference.  Pyre stores `frame` as a
 /// raw `*mut PyFrame` and the two `PyObjectRef` slots (`w_next`,
 /// `w_code`) inline; none are reachable through `gc_ptr_offsets`
-/// (the type was registered with empty offsets), so forward all three
-/// here:
+/// (the type was registered with empty offsets), so forward all of
+/// them here:
 ///
+///   * `ob_header.w_class` — the type object every `PyObject`-layout
+///     struct carries.
 ///   * `w_next` — the chained caller-side traceback link.
 ///   * `w_code` — the raising frame's PyCode snapshot (kept alive so
 ///     source-path / function-name metadata survives).


### PR DESCRIPTION
Comment and dead-constant changes only; no behavior change.

An audit of the "traceback frames are non-moving oldgen blocks" contract against
the vendored tree found that the contract is a pyre deviation with no upstream
counterpart, and that three of the comments justifying it state the opposite of
what the code does.

## Upstream has no such contract

`pytraceback.py:29 self.frame = frame` is an ordinary traced field of an
ordinary movable `pyframe.py:52 class PyFrame(W_Root)`, which declares no
`_alloc_flavor_`. Nothing under `pypy/interpreter/` calls `rgc.pin`, and
`rpython/rlib/rgc.py:88-97` documents `pin` as a short-lived-buffer facility
that does not extend lifetime. A minor collection copies the frame
(`rpython/memory/gc/incminimark.py:2237`) and rewrites every referring slot
(`:2252`), because roots reach the collector as slot addresses
(`rpython/memory/gctransform/shadowstack.py:43-46`) and compiled code re-reads
the frame after each collecting call
(`rpython/jit/backend/x86/assembler.py:1369-1377`). The one obligation upstream
does attach to a traceback's frame is a JIT one — force the vref,
`error.py:370 tb.frame.mark_as_escaped()` — which pyre already has.

## What changed

- `PYTRACEBACK_GC_PTR_OFFSETS` deleted. It had no consumer: a type registered
  through `TypeInfo::object_subclass_with_custom_trace` gets an empty
  `gc_ptr_offsets` and reaches the collector only through its hook.
- The module doc and the `frame` field doc claimed pyre's `PyFrame` has no
  `PyObject` header. It has one (`PyFrame::ob_header`), so `tb_frame` does
  return a Python-visible object; the divergence left is the slot *type*. The
  citation `pyframe.py:39` pointed at `FrameDebugData.f_lineno` rather than
  `class PyFrame` (`pyframe.py:52`).
- The `frame` field doc said the pointer stays live for the traceback's whole
  lifetime, while the `get_lineno` and `record_application_traceback` comments
  said the frame may already be freed. Both hold, for different frames:
  `pytraceback_object_custom_trace` forwards the slot only when the GC owns the
  frame, and skips a `FrameBox::new_boxed` tracer snapshot. Restated that way,
  which is also the real reason the non-upstream `w_code` field exists.
- The struct doc said only `w_next` is traced; the hook forwards
  `ob_header.w_class`, `w_next`, `w_code`, and the owned `frame`.
- The oldgen-allocation comment in `w_pytraceback_new` attributed the
  non-moving frame requirement to this file. Re-attributed: `frame` is copied
  into the struct before the safepointing allocation and is not among the
  pinned roots, and the raw `*mut PyFrame` copies no root walker reaches live
  in `FrameBox::deref`, `eval_loop`'s `&mut PyFrame`, and the blackhole's
  bare-integer virtualizable. The caller obligation the code relies on is now
  stated.
- `walk_jit_callee_frame_roots_area`'s "the visitor never rewrites the slot" now
  cites why (`FrameBox::new` allocates non-moving) rather than asserting it, and
  the custom trace's doc gained its missing `ob_header.w_class` bullet.
- `gate-triage.md` records the convergence order: teach `FrameBox::deref` to
  read its own root and root the inline concrete frame likewise; then give
  compiled code a virtualizable reload after collecting calls (pyre has only the
  JITFRAME half). Only after both can the non-moving frame allocation go, and
  with it `PyTraceback.w_code`.

## Verification

`cargo fmt --check` clean; `python3 pyre/check.py --backend dynasm` ALL PASSED
351/351.

— *written by Claude*