### PR TITLE
majit: native checked-arith / layout / Option front passes, uint_mul_high rtyper, static-global residualization

### DIFF
--- a/majit/majit-translate/src/annotator/annrpython.rs
+++ b/majit/majit-translate/src/annotator/annrpython.rs
@@ -2479,6 +2479,47 @@ impl RPythonAnnotator {
                 }
             }
 
+            // `uint_mul_high` / `uint_lt` — low-level unsigned ops the
+            // front-end (`front::checked_arith_uint`) emits directly for the
+            // native unsigned-overflow tests (`checked_mul`/`checked_add`
+            // lowering).  RPython's flowspace registers neither (they are
+            // rtyper-level ops, not `add_operator` operators), so
+            // `OpKind::from_opname` declines them and the canonical dispatch
+            // below would skip them, leaving the result Variable unbound — the
+            // next reader (`eq(result, 0)`) then raises an unbound-argument
+            // `AnnotatorError`.  Bind the result at the annotation level:
+            // `uint_mul_high` yields an unsigned integer (the widening
+            // product's high word), `uint_lt` a bool (the carry / order
+            // predicate).  The lltype retype is applied later at rtype.
+            {
+                let uint_result = {
+                    let blk = block.borrow();
+                    let sp = &blk.operations[i];
+                    match sp.opname.as_str() {
+                        "uint_mul_high" if sp.args.len() == 2 => {
+                            // `SomeInteger { unsigned: true }`, matching how
+                            // `ValueType::Unsigned` shells elsewhere
+                            // (`codewriter::annotation_state`).
+                            Some(SomeValue::Integer(super::model::SomeInteger::new(
+                                false, true,
+                            )))
+                        }
+                        "uint_lt" if sp.args.len() == 2 => {
+                            Some(SomeValue::Bool(super::model::SomeBool::new()))
+                        }
+                        _ => None,
+                    }
+                };
+                if let Some(s_result) = uint_result {
+                    let mut blk = block.borrow_mut();
+                    if let Hlvalue::Variable(v) = &mut blk.operations[i].result {
+                        self.setbinding(v, s_result);
+                    }
+                    i += 1;
+                    continue;
+                }
+            }
+
             // Reify `SpaceOperation` (Block storage) into an
             // `HLOperation` the dispatcher can consume. Upstream
             // `Block.operations` carries HLOperations directly; the

--- a/majit/majit-translate/src/annotator/builtin.rs
+++ b/majit/majit-translate/src/annotator/builtin.rs
@@ -341,6 +341,11 @@ fn register_builtins() -> HashMap<String, BuiltinAnalyzer> {
     // Keyed by the qualname `flowspace/model.rs`'s HOST_ENV bootstrap
     // assigns (which also keys the `BUILTIN_TYPER` entry on the same Arc).
     analyzer_for(&mut reg, "__pyre_cast_instance", pyre_cast_instance);
+    // `__pyre_cast_address` — the erasing twin.  `p as *mut u8` lowers to
+    // a simple_call against this stub so the pointee class is dropped
+    // instead of riding along on a value whose declared type is a bare
+    // byte pointer.
+    analyzer_for(&mut reg, "__pyre_cast_address", pyre_cast_address);
     // Rust `String::new()` / `String::with_capacity(n)` construct an empty
     // owned UTF-8 buffer; both annotate as a mutable `SomeString` so the
     // `String.new` / `String.with_capacity` HOST_ENV stubs do not reach the
@@ -1365,6 +1370,50 @@ fn std_mem_align_of(
     kwds: &HashMap<String, Option<SomeValue>>,
 ) -> Result<SomeValue, AnnotatorError> {
     std_mem_size_of(bk, args_s, kwds)
+}
+
+/// Analyzer for `__pyre_cast_address` — the front-end pointer-type
+/// erasure (`p as *mut u8`).  Upstream a heterogeneous heap block that
+/// reaches a GC ownership predicate or a write barrier travels as
+/// `llmemory.Address` (`llmemory.cast_ptr_to_adr`), never as
+/// `Ptr(instance)`: the hook discriminates blocks by address range, so
+/// the pointee type is not merely unused, it must not exist.  Aliasing
+/// the cast instead leaves `SomeInstance(PyFrame)` on the argument, and
+/// the hook's slot 0 then unions `PyFrame ∪ ItemsBlock` and blocks with
+/// "cannot unify instances with no common base class".
+///
+/// The erased result is the classdef-less pointer shell — the annotation
+/// a pointee-less raw pointer already carries here — rather than
+/// `SomeAddress`.  That keeps one annotation across both kinds of caller:
+/// the ones that erase a typed pointer, and the ones that pass an
+/// untyped `*mut u8` field straight through.  `SomeInstance` union takes
+/// the classdef-less side as the result (model.rs:3260), so every such
+/// slot merges cleanly.  `args[0]` is the pointer operand.
+///
+/// The operand's own annotation is not constrained: `cast_ptr_to_adr`
+/// takes any `Ptr`, and the operand here is whatever the pointee ADT
+/// annotated to — an instance, but also a `SomeList` for a `Vec` whose
+/// address is erased.  Only the nullability carries over, since an
+/// erasure of a nullable pointer is itself nullable.  (Its narrowing
+/// twin does reject a non-pointer operand: a downcast to a named root
+/// off a non-pointer is a producer bug, whereas dropping type
+/// information off one never is.)
+fn pyre_cast_address(
+    _bk: &Rc<Bookkeeper>,
+    args_s: &[Option<SomeValue>],
+    kwds: &HashMap<String, Option<SomeValue>>,
+) -> Result<SomeValue, AnnotatorError> {
+    if !kwds.is_empty() || args_s.len() != 1 {
+        return Err(AnnotatorError::new(
+            "__pyre_cast_address expects exactly one positional pointer argument",
+        ));
+    }
+    let can_be_none = arg_at(args_s, 0, "__pyre_cast_address").can_be_none();
+    Ok(SomeValue::Instance(super::model::SomeInstance::new(
+        None,
+        can_be_none,
+        std::collections::BTreeMap::new(),
+    )))
 }
 
 /// Analyzer for `__pyre_cast_instance` — the front-end pointer-downcast

--- a/majit/majit-translate/src/annotator/unaryop.rs
+++ b/majit/majit-translate/src/annotator/unaryop.rs
@@ -4080,15 +4080,30 @@ fn init_someinstance_overrides(
                 // types the boxed `W_BaseException` result while the codewriter
                 // keeps the real fnaddr conversion.
                 if attr == "to_exc_object" {
-                    let is_pyerror = inst
-                        .classdef
-                        .as_ref()
-                        .is_some_and(|cd| cd.borrow().name.rsplit('.').next() == Some("PyError"));
+                    // Fires for a `classdef=Some(PyError)` receiver and for a
+                    // classdef-less one.  `to_exc_object` is the sole method of
+                    // that name (error.rs `PyError::to_exc_object`); it is only
+                    // lowered from `.to_exc_object()` callsites rustc typechecks
+                    // against a `PyError` receiver and from the result_exc
+                    // `?`-lowering (`Method{receiver_root: "PyError"}`,
+                    // result_exc.rs), so a classdef-less receiver here is a
+                    // pointer-erased `PyError` call-result — `OpKind::Call`
+                    // stamps a struct return `Ref(None)` with no `class_root`,
+                    // unlike the seeded `Input` arm, so a call-returned `PyError`
+                    // lifts `SomeInstance(classdef=None)`.  Same rustc-typecheck
+                    // reasoning as the `is_null` ptr-method arm above.  The
+                    // builtin result (`PyObjectRef`) and the codewriter residual
+                    // (`for_impl_method("PyError", "to_exc_object")`) are both
+                    // fixed, reading nothing off the receiver's classdef.
+                    let receiver_is_pyerror = match inst.classdef.as_ref() {
+                        Some(cd) => cd.borrow().name.rsplit('.').next() == Some("PyError"),
+                        None => true,
+                    };
                     let class_defines_attr = inst.classdef.as_ref().is_some_and(|cd| {
                         let classdesc = cd.borrow().classdesc.clone();
                         super::classdesc::ClassDesc::lookup(&classdesc, "to_exc_object").is_some()
                     });
-                    if is_pyerror && !class_defines_attr {
+                    if receiver_is_pyerror && !class_defines_attr {
                         return SomeValue::BuiltinMethod(SomeBuiltinMethod::new(
                             "pyerror_method_to_exc_object",
                             s_self.clone(),

--- a/majit/majit-translate/src/codewriter/assembler.rs
+++ b/majit/majit-translate/src/codewriter/assembler.rs
@@ -4072,6 +4072,11 @@ fn op_kind_to_opname(kind: &crate::model::OpKind) -> String {
             // jtransform-rewritten float operands carry the full RPython
             // opname (`float_add` / `float_lt` / etc.) — preserve as-is.
             s if s.starts_with("float_") => op.clone(),
+            // Already-canonical unsigned low-level ops the front-end emits
+            // directly (`uint_mul_high` / `uint_lt` from
+            // `front::checked_arith_uint`); pass through so the `int_` prefix
+            // does not double up (`int_uint_lt` has no `insns` entry).
+            s if s.starts_with("uint_") => op.clone(),
             _ => format!("int_{op}"),
         },
         // RPython `blackhole.py:488-498`: bitwise NOT on i64 is `int_invert`.

--- a/majit/majit-translate/src/codewriter/jtransform.rs
+++ b/majit/majit-translate/src/codewriter/jtransform.rs
@@ -2976,9 +2976,14 @@ impl<'a> Transformer<'a> {
         // the charon front-end skips the rtyper, so fold the marker to the
         // operand alias here too.  The JIT does not distinguish a downcast
         // pointer from its source, so this emits no jitcode op.
+        // `__pyre_cast_address` — the erasing twin (`p as *mut u8`), which
+        // carries no root and so is single-segment.  It reinterprets the
+        // same pointer too, and the JIT distinguishes a pointer no more
+        // from its erasure than from its downcast, so it folds the same
+        // way: the operand alias, no jitcode op.
         if let CallTarget::FunctionPath { segments } = target
-            && segments.len() == 2
-            && segments[0] == "__pyre_cast_instance"
+            && ((segments.len() == 2 && segments[0] == "__pyre_cast_instance")
+                || (segments.len() == 1 && segments[0] == "__pyre_cast_address"))
             && args.len() == 1
         {
             return RewriteResult::Identity(args[0].clone());

--- a/majit/majit-translate/src/flowspace/model.rs
+++ b/majit/majit-translate/src/flowspace/model.rs
@@ -1642,6 +1642,19 @@ impl HostEnv {
             "__pyre_cast_instance",
             HostObject::new_builtin_callable("__pyre_cast_instance"),
         );
+        // Pyre-internal front-end pointer-type ERASURE, the twin of the
+        // narrow above: the frontend lowers `obj as *mut u8` to a
+        // `simple_call` against this stub so the result drops the pointee
+        // class and annotates as the classdef-less pointer shell.  This is
+        // the `llmemory.cast_ptr_to_adr` role — a heterogeneous heap block
+        // reaching a GC hook travels as an opaque address, never as
+        // `Ptr(instance)` — spelled in the annotation the port already uses
+        // for a pointee-less raw pointer.  Same three-way binding as the
+        // narrow (analyzer keys the qualname, typer keys this Arc).
+        self.insert_builtin(
+            "__pyre_cast_address",
+            HostObject::new_builtin_callable("__pyre_cast_address"),
+        );
     }
 
     fn bootstrap_std_modules(&mut self) {

--- a/majit/majit-translate/src/front/bool_then.rs
+++ b/majit/majit-translate/src/front/bool_then.rs
@@ -320,22 +320,8 @@ pub(crate) fn emit_option_variant(
     disc: i64,
     payload: Option<(&str, Variable, ValueType)>,
 ) -> Variable {
-    let mut owner_path: Vec<String> = option_owner.split("::").map(str::to_string).collect();
-    let ctor_name = owner_path.pop().unwrap_or_default();
-    let ctor_target = if owner_path.is_empty() {
-        CallTarget::synthetic_transparent_ctor(ctor_name)
-    } else {
-        CallTarget::synthetic_transparent_ctor_with_owner(owner_path, ctor_name)
-    };
     let res = graph.alloc_value_var();
-    graph.block_mut(block).operations.push(SpaceOperation {
-        result: Some(res.clone()),
-        kind: OpKind::Call {
-            target: ctor_target,
-            args: Vec::new(),
-            result_ty: ValueType::Ref(Some(option_owner.to_string())),
-        },
-    });
+    push_option_ctor(graph, block, res.clone(), option_owner);
     // `__discriminant` keys the enum root (tag offset 0 of every variant);
     // materialize the tag as a `ConstInt` value, matching the aggregate
     // path's `FieldWrite { value: Value(..) }` shape.
@@ -344,10 +330,68 @@ pub(crate) fn emit_option_variant(
         result: Some(disc_var.clone()),
         kind: OpKind::ConstInt(disc),
     });
+    write_option_fields(graph, block, &res, option_owner, disc_var, payload);
+    res
+}
+
+/// Build an `Option` variant aggregate in `block`, reusing `result` as the
+/// ctor result and a **dynamic** discriminant `Variable` (rather than a
+/// compile-time tag) — the shape a residual whose Some/None outcome is only
+/// known at runtime folds to (`front::checked_arith_uint`).  `disc` must be a
+/// `0`/`1` integer value (`None` = 0, `Some` = 1).  Same transparent-ctor +
+/// `FieldWrite` chain as [`emit_option_variant`], only the discriminant is a
+/// live value instead of a materialized `ConstInt`.
+pub(crate) fn emit_option_variant_dynamic(
+    graph: &mut FunctionGraph,
+    block: BlockId,
+    result: Variable,
+    option_owner: &str,
+    disc: Variable,
+    payload: Option<(&str, Variable, ValueType)>,
+) {
+    push_option_ctor(graph, block, result.clone(), option_owner);
+    write_option_fields(graph, block, &result, option_owner, disc, payload);
+}
+
+/// Push the enum-root transparent ctor for `option_owner`, binding it to
+/// `result`.
+fn push_option_ctor(
+    graph: &mut FunctionGraph,
+    block: BlockId,
+    result: Variable,
+    option_owner: &str,
+) {
+    let mut owner_path: Vec<String> = option_owner.split("::").map(str::to_string).collect();
+    let ctor_name = owner_path.pop().unwrap_or_default();
+    let ctor_target = if owner_path.is_empty() {
+        CallTarget::synthetic_transparent_ctor(ctor_name)
+    } else {
+        CallTarget::synthetic_transparent_ctor_with_owner(owner_path, ctor_name)
+    };
+    graph.block_mut(block).operations.push(SpaceOperation {
+        result: Some(result),
+        kind: OpKind::Call {
+            target: ctor_target,
+            args: Vec::new(),
+            result_ty: ValueType::Ref(Some(option_owner.to_string())),
+        },
+    });
+}
+
+/// Write the `__discriminant` tag (offset 0 of every variant) and, for a
+/// `Some`, the `__pos_0` payload keyed to the `Some` variant owner.
+fn write_option_fields(
+    graph: &mut FunctionGraph,
+    block: BlockId,
+    result: &Variable,
+    option_owner: &str,
+    disc_var: Variable,
+    payload: Option<(&str, Variable, ValueType)>,
+) {
     graph.block_mut(block).operations.push(SpaceOperation {
         result: None,
         kind: OpKind::FieldWrite {
-            base: res.clone(),
+            base: result.clone(),
             field: FieldDescriptor {
                 name: "__discriminant".to_string(),
                 owner_root: Some(option_owner.to_string()),
@@ -363,7 +407,7 @@ pub(crate) fn emit_option_variant(
         graph.block_mut(block).operations.push(SpaceOperation {
             result: None,
             kind: OpKind::FieldWrite {
-                base: res.clone(),
+                base: result.clone(),
                 field: FieldDescriptor {
                     name: "__pos_0".to_string(),
                     owner_root: Some(some_owner.to_string()),
@@ -374,7 +418,6 @@ pub(crate) fn emit_option_variant(
             },
         });
     }
-    res
 }
 
 /// Close `block` with a single plain-goto exit carrying mixed

--- a/majit/majit-translate/src/front/checked_arith_uint.rs
+++ b/majit/majit-translate/src/front/checked_arith_uint.rs
@@ -1,0 +1,413 @@
+//! `usize::checked_{add,mul}()` → native unsigned-overflow ops + a
+//! virtualized `Option`.
+//!
+//! ## Positioning
+//!
+//! `core::num::<Impl>::checked_add` / `checked_mul` on **unsigned** operands
+//! are Opaque core bodies (Charon cannot extract `core`), so the caller
+//! carries a residual `checked_*` call the rtyper census cannot type.
+//! [`crate::front::checked_arith`] lowers the **signed** match-shape into a
+//! `*_ovf` op + `OverflowError` edge, but that path is wrong for unsigned
+//! arithmetic: RPython has no unsigned overflow op (`r_uint` wraps), so a
+//! signed `mul_ovf` would diverge for operands in `(i64::MAX, usize::MAX]`.
+//!
+//! The unsigned overflow tests have native, wrapping-safe forms:
+//!   - `checked_mul(x, y)` overflows iff the high word of the widening
+//!     product is non-zero: `uint_mul_high(x, y) != 0`.
+//!   - `checked_add(x, y)` overflows iff the sum wrapped below an addend
+//!     (carry): `uint_lt(x + y, x)`.
+//!
+//! ## The rewrite (`rewire_one_checked_arith_uint_site`)
+//!
+//! Block A's last op is the residual `opt = checked_*(x, y)` call.  The
+//! rewrite drops that call and, **in place**, emits the native sequence plus a
+//! virtualized `Option` reusing `opt` as the ctor result:
+//!   - `checked_mul`: `lo = mul(x, y)`, `hi = uint_mul_high(x, y)`,
+//!     `disc = eq(hi, 0)`, value = `lo`.
+//!   - `checked_add`: `sum = add(x, y)`, `ovf = uint_lt(sum, x)`,
+//!     `disc = eq(ovf, 0)`, value = `sum`.
+//!   - `opt = Some/None` aggregate with `__discriminant = disc` (dynamic,
+//!     `1` = `Some` when no overflow, `0` = `None` on overflow) and
+//!     `__pos_0 = value`.
+//!
+//! Unlike [`crate::front::checked_arith`] / [`crate::front::option_try`] this
+//! is **order-independent**: it produces a valid virtualized `Option` value
+//! that the downstream `?` / match / let-else consumes unchanged — no diamond
+//! matching, no exit rewiring.
+//!
+//! It is **fail-safe**: any structural mismatch returns `Err`, the caller
+//! leaves the residual call untouched, and the census Skip / legacy-walker
+//! fallback is unchanged.  Gating (an unsigned `checked_{add,mul}` producer
+//! still present as its `Call`) is applied both at the recording site (only
+//! unsigned operands are recorded) and here (the producer must still be the
+//! `Call`, so a site [`crate::front::checked_arith`] already rewrote is
+//! skipped).
+
+use crate::flowspace::model::Variable;
+use crate::front::bool_then::emit_option_variant_dynamic;
+use crate::model::{CallTarget, FunctionGraph, OpKind, SpaceOperation, ValueType};
+
+/// A recorded unsigned `checked_{add,mul}` call whose result is an
+/// `Option<T>`, captured during body lowering with the `Option`/`Some` owners
+/// and payload type resolved from the destination type.
+#[derive(Clone)]
+pub(crate) struct CheckedArithUintSite {
+    /// The `checked_*` call result (the `Option<T>` value) — locates block A
+    /// and is reused as the virtualized `Option` ctor result.
+    pub opt: Variable,
+    /// The `Option` enum root `name_path` — the `__discriminant` field owner
+    /// and the ctor owner.
+    pub option_owner: String,
+    /// The `Option::Some` variant `name_path` — the `__pos_0` payload owner.
+    pub some_owner: String,
+    /// The `Option` payload `T` — the `Some::__pos_0` field kind.
+    pub payload_ty: ValueType,
+}
+
+/// Rewrite every recorded unsigned `checked_{add,mul}` site into the native
+/// overflow-test + virtualized `Option` shape.  Returns the number of sites
+/// rewritten; declined sites keep their residual call (census Skip).
+pub(crate) fn rewire_checked_arith_uint_sites(
+    graph: &mut FunctionGraph,
+    sites: &[CheckedArithUintSite],
+) -> usize {
+    let mut rewritten = 0;
+    for site in sites {
+        match rewire_one_checked_arith_uint_site(graph, site) {
+            Ok(()) => rewritten += 1,
+            Err(_decline) => {
+                if std::env::var_os("PYRE_MIR_FRONTEND_DEBUG").is_some() {
+                    eprintln!(
+                        "[checked_arith_uint] {} decline at {:?}: {_decline}",
+                        graph.name, site.opt
+                    );
+                }
+                // Leave the residual `checked_*` call; the unregistered callee
+                // makes the rtyper census Skip this graph (no regression).
+            }
+        }
+    }
+    rewritten
+}
+
+/// The unsigned `checked_*` operators this pass lowers.  `checked_sub` is
+/// intentionally absent: unsigned subtraction underflow is a `uint_lt(x, y)`
+/// guard, but no census site spells it in the `?`-shape, so it stays a
+/// residual.
+#[derive(Clone, Copy)]
+enum UintArith {
+    Add,
+    Mul,
+}
+
+impl UintArith {
+    fn from_leaf(leaf: &str) -> Option<Self> {
+        match leaf {
+            "checked_add" => Some(UintArith::Add),
+            "checked_mul" => Some(UintArith::Mul),
+            _ => None,
+        }
+    }
+}
+
+fn rewire_one_checked_arith_uint_site(
+    graph: &mut FunctionGraph,
+    site: &CheckedArithUintSite,
+) -> Result<(), String> {
+    let name = graph.name.clone();
+    let opt = &site.opt;
+
+    // Block A: the `checked_*()` residual call producing `opt`, closed by
+    // `lower_call` with a single forwarding exit.
+    let a = graph
+        .blocks
+        .iter()
+        .position(|b| {
+            b.operations
+                .iter()
+                .any(|op| op.result.as_ref() == Some(opt))
+        })
+        .ok_or_else(|| format!("{name}: checked_* result var has no producer block"))?;
+
+    // The call must still be A's last op (a `[..]::checked_add/checked_mul`
+    // 2-arg FunctionPath call); a site `checked_arith`'s first pass already
+    // rewrote is now a `*_ovf` BinOp producer — skip it.  The overflow op is
+    // resolved here (before any mutation) so an unsupported leaf declines
+    // without touching the graph.
+    let call_idx = graph.blocks[a].operations.len() - 1;
+    let (lhs, rhs, arith) = match &graph.blocks[a].operations[call_idx] {
+        SpaceOperation {
+            result: Some(r),
+            kind:
+                OpKind::Call {
+                    target: target @ CallTarget::FunctionPath { segments },
+                    args,
+                    ..
+                },
+        } if r == opt
+            && args.len() == 2
+            && crate::front::checked_arith::is_checked_arith_target(target) =>
+        {
+            let leaf = segments.last().map(String::as_str).unwrap_or_default();
+            let arith = UintArith::from_leaf(leaf).ok_or_else(|| {
+                format!("{name}: unsigned checked lowering does not handle {leaf}")
+            })?;
+            (args[0].clone(), args[1].clone(), arith)
+        }
+        _ => {
+            return Err(format!(
+                "{name}: block {a} last op is not the 2-arg checked_* call producing {opt:?}"
+            ));
+        }
+    };
+
+    // --- All structural validation passed; mutate the graph. ---
+
+    let a_id = graph.blocks[a].id;
+    // Drop the residual call (A's last op) so `opt` is produced solely by the
+    // virtualized ctor appended below, then re-emit the native sequence in
+    // place of the removed call.
+    graph.blocks[a].operations.truncate(call_idx);
+
+    // The two operators differ only in the payload value and the overflow
+    // test; build the `Option` once from the resulting `(value, disc)`.
+    let (value, disc) = match arith {
+        UintArith::Mul => {
+            let lo = push_binop(
+                graph,
+                a_id,
+                "mul",
+                lhs.clone(),
+                rhs.clone(),
+                ValueType::Unsigned,
+            );
+            let hi = push_binop(graph, a_id, "uint_mul_high", lhs, rhs, ValueType::Unsigned);
+            let disc = push_no_overflow_disc(graph, a_id, hi);
+            (lo, disc)
+        }
+        UintArith::Add => {
+            let sum = push_binop(
+                graph,
+                a_id,
+                "add",
+                lhs.clone(),
+                rhs.clone(),
+                ValueType::Unsigned,
+            );
+            // Unsigned carry: the wrapped sum is strictly below an addend.
+            let ovf = push_binop(graph, a_id, "uint_lt", sum.clone(), lhs, ValueType::Int);
+            let disc = push_no_overflow_disc(graph, a_id, ovf);
+            (sum, disc)
+        }
+    };
+
+    emit_option_variant_dynamic(
+        graph,
+        a_id,
+        opt.clone(),
+        &site.option_owner,
+        disc,
+        Some((&site.some_owner, value, site.payload_ty.clone())),
+    );
+    Ok(())
+}
+
+/// `disc = eq(test, 0)` — the `Option` tag: `1` (`Some`) when the overflow
+/// `test` is `0` (no overflow), `0` (`None`) when it is non-zero.
+fn push_no_overflow_disc(
+    graph: &mut FunctionGraph,
+    block: crate::model::BlockId,
+    test: Variable,
+) -> Variable {
+    let zero = push_const_int(graph, block, 0);
+    push_binop(graph, block, "eq", test, zero, ValueType::Int)
+}
+
+pub(crate) fn push_binop(
+    graph: &mut FunctionGraph,
+    block: crate::model::BlockId,
+    op: &str,
+    lhs: Variable,
+    rhs: Variable,
+    result_ty: ValueType,
+) -> Variable {
+    let res = graph.alloc_value_var();
+    graph.block_mut(block).operations.push(SpaceOperation {
+        result: Some(res.clone()),
+        kind: OpKind::BinOp {
+            op: op.to_string(),
+            lhs,
+            rhs,
+            result_ty,
+        },
+    });
+    res
+}
+
+pub(crate) fn push_const_int(
+    graph: &mut FunctionGraph,
+    block: crate::model::BlockId,
+    value: i64,
+) -> Variable {
+    let res = graph.alloc_value_var();
+    graph.block_mut(block).operations.push(SpaceOperation {
+        result: Some(res.clone()),
+        kind: OpKind::ConstInt(value),
+    });
+    res
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::CallTarget;
+
+    fn checked_target(leaf: &str) -> CallTarget {
+        CallTarget::FunctionPath {
+            segments: ["core", "num", "<Impl>", leaf]
+                .iter()
+                .map(|s| s.to_string())
+                .collect(),
+        }
+    }
+
+    fn site_for(opt: &Variable) -> CheckedArithUintSite {
+        CheckedArithUintSite {
+            opt: opt.clone(),
+            option_owner: "core::option::Option".to_string(),
+            some_owner: "core::option::Option::Some".to_string(),
+            payload_ty: ValueType::Unsigned,
+        }
+    }
+
+    /// The op names / owners the virtualized `Option` tail carries, in order.
+    fn tail_binops(graph: &FunctionGraph, a: usize) -> Vec<String> {
+        graph.blocks[a]
+            .operations
+            .iter()
+            .filter_map(|op| match &op.kind {
+                OpKind::BinOp { op: name, .. } => Some(name.clone()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    fn build_checked_site(leaf: &str) -> (FunctionGraph, Variable, usize) {
+        let mut g = FunctionGraph::new("test_checked_uint");
+        let a = g.startblock;
+        let x = g.push_op_var(a, OpKind::ConstInt(3), true).unwrap();
+        let y = g.push_op_var(a, OpKind::ConstInt(8), true).unwrap();
+        // Block A's last op = the residual unsigned `checked_*(x, y)`.
+        let opt = g
+            .push_op_var(
+                a,
+                OpKind::Call {
+                    target: checked_target(leaf),
+                    args: vec![x, y],
+                    result_ty: ValueType::Ref(Some("core::option::Option".into())),
+                },
+                true,
+            )
+            .unwrap();
+        // A continuation consuming `opt` (single forwarding goto exit).
+        let (cont, _) = g.create_block_with_arg_vars(1);
+        g.set_return(cont, None);
+        g.set_goto(a, cont, vec![opt.clone()]);
+        (g, opt, a.0)
+    }
+
+    #[test]
+    fn checked_mul_lowers_to_uint_mul_high_and_virtualized_option() {
+        let (mut g, opt, a) = build_checked_site("checked_mul");
+        let rewritten = rewire_checked_arith_uint_sites(&mut g, &[site_for(&opt)]);
+        assert_eq!(rewritten, 1, "the unsigned checked_mul site must rewrite");
+
+        // No residual `checked_*` call survives in block A.
+        assert!(
+            !g.blocks[a].operations.iter().any(|op| matches!(
+                &op.kind,
+                OpKind::Call {
+                    target: CallTarget::FunctionPath { .. },
+                    ..
+                }
+            )),
+            "the residual checked_mul call must be gone"
+        );
+        // Overflow tests: `mul` (low word) + `uint_mul_high` (high word) + `eq`.
+        assert_eq!(tail_binops(&g, a), vec!["mul", "uint_mul_high", "eq"]);
+
+        // `opt` is now produced by the transparent Option ctor.
+        let ctor = g.blocks[a]
+            .operations
+            .iter()
+            .find(|op| op.result.as_ref() == Some(&opt))
+            .expect("opt must be produced");
+        assert!(
+            matches!(
+                &ctor.kind,
+                OpKind::Call {
+                    target: CallTarget::SyntheticTransparentCtor { .. },
+                    ..
+                }
+            ),
+            "opt must be the synthetic transparent Option ctor result"
+        );
+        // The aggregate writes the dynamic `__discriminant` and the `__pos_0`
+        // payload keyed to the Some owner.
+        let disc_write = g.blocks[a].operations.iter().any(|op| {
+            matches!(&op.kind, OpKind::FieldWrite { base, field, .. }
+                if *base == opt && field.name == "__discriminant")
+        });
+        let pos0_write = g.blocks[a].operations.iter().any(|op| {
+            matches!(&op.kind, OpKind::FieldWrite { base, field, .. }
+                if *base == opt && field.name == "__pos_0"
+                    && field.owner_root.as_deref() == Some("core::option::Option::Some"))
+        });
+        assert!(disc_write, "the __discriminant tag write must be present");
+        assert!(pos0_write, "the __pos_0 payload write must be present");
+    }
+
+    #[test]
+    fn checked_add_lowers_to_uint_lt_carry_test() {
+        let (mut g, opt, a) = build_checked_site("checked_add");
+        let rewritten = rewire_checked_arith_uint_sites(&mut g, &[site_for(&opt)]);
+        assert_eq!(rewritten, 1, "the unsigned checked_add site must rewrite");
+        // Carry test: `add` (wrapping sum) + `uint_lt(sum, x)` + `eq`.
+        assert_eq!(tail_binops(&g, a), vec!["add", "uint_lt", "eq"]);
+    }
+
+    #[test]
+    fn declines_when_producer_is_no_longer_the_checked_call() {
+        // A site `checked_arith` already rewrote (producer is now a `mul_ovf`
+        // BinOp, not the `Call`) must be left untouched.
+        let mut g = FunctionGraph::new("test_already_rewritten");
+        let a = g.startblock;
+        let x = g.push_op_var(a, OpKind::ConstInt(3), true).unwrap();
+        let y = g.push_op_var(a, OpKind::ConstInt(8), true).unwrap();
+        let opt = g
+            .push_op_var(
+                a,
+                OpKind::BinOp {
+                    op: "mul_ovf".to_string(),
+                    lhs: x,
+                    rhs: y,
+                    result_ty: ValueType::Int,
+                },
+                true,
+            )
+            .unwrap();
+        let (cont, _) = g.create_block_with_arg_vars(1);
+        g.set_return(cont, None);
+        g.set_goto(a, cont, vec![opt.clone()]);
+
+        let rewritten = rewire_checked_arith_uint_sites(&mut g, &[site_for(&opt)]);
+        assert_eq!(rewritten, 0, "a non-Call producer must decline");
+        assert!(
+            g.blocks[a.0].operations.iter().any(|op| matches!(
+                &op.kind,
+                OpKind::BinOp { op, .. } if op == "mul_ovf"
+            )),
+            "the mul_ovf producer must survive untouched"
+        );
+    }
+}

--- a/majit/majit-translate/src/front/from_size_align.rs
+++ b/majit/majit-translate/src/front/from_size_align.rs
@@ -1,0 +1,913 @@
+//! `Layout::from_size_align(size, const_align).ok()` → a native power-of-two
+//! bound check + a virtualized `Option<Layout>` (nested transparent ctors), and
+//! the sibling `Layout::from_size_align(size, const_align).expect(msg)` → the
+//! same bound check + a by-value virtualized `Layout` (no `Option` wrapper),
+//! branching to an implicit raise on the overflowed (`Err`) case
+//! ([`rewire_from_size_align_expect_sites`]).
+//!
+//! ## Positioning
+//!
+//! `core::alloc::layout::Layout::from_size_align` and `core::result::Result::ok`
+//! are Opaque core bodies (Charon cannot extract `core`), so the caller carries
+//! two residual calls the rtyper census cannot type:
+//!   - `res = from_size_align(size, align)` → `Result<Layout, LayoutError>`,
+//!   - `opt = res.ok()` → `Option<Layout>`.
+//! Both cross a value the census cannot model as a residual return (`Layout` is
+//! a 2-word `{size, align}` aggregate; `Result`/`Option` of it likewise), so
+//! the pair is the standing wall in `object_array::try_typed_items_block_layout`
+//! once `checked_mul`/`checked_add` are natively lowered
+//! ([`crate::front::checked_arith_uint`]).
+//!
+//! `from_size_align(size, align)` returns `Ok(Layout { size, align })` iff
+//! `align.is_power_of_two()` and `size <= isize::MAX - (align - 1)`.  An earlier
+//! commit folds `align_of::<T>()` to a compile-time `ConstInt` power of two, so
+//! `align.is_power_of_two()` is statically true and the bound `isize::MAX -
+//! (align - 1)` is a constant.  The residual pair therefore has a native form:
+//!   - `too_big = uint_lt(bound, size)` — `size > bound`, the overflowed case;
+//!   - the `Option` tag is `Some` (`1`) iff `too_big` is `0` (fits), else `None`.
+//!
+//! ## The rewrite (`rewire_one_from_size_align_site`)
+//!
+//! The `.ok()` residual (block Q) produces the `Option<Layout>`; its single arg
+//! is the `from_size_align` residual result (block P).  The rewrite drops both
+//! residuals and, **in place** in block P, emits the native sequence plus a
+//! virtualized nested aggregate reusing the `from_size_align` result var as the
+//! `Option` ctor result:
+//!   - `bound = ConstInt(isize::MAX - (align - 1))`, `too_big = uint_lt(bound,
+//!     size)`, `disc = eq(too_big, 0)`;
+//!   - `layout = <transparent Layout ctor>{ __pos_0 = size, __pos_1 = align }`;
+//!   - `opt = <transparent Option ctor>{ __discriminant = disc, __pos_0(Some) =
+//!     layout }`.
+//! Block Q's `ok` call is deleted and its result aliased to the block-P
+//! `Option` value threaded across the P→Q edge — no diamond, no exit rewiring.
+//!
+//! Like [`crate::front::checked_arith_uint`] it is **order-independent** and
+//! **fail-safe**: any structural mismatch returns `Err`, the caller leaves both
+//! residual calls untouched, and the unregistered callees keep the rtyper
+//! census Skip (no regression).
+
+use crate::flowspace::model::Variable;
+use crate::front::bool_then::emit_option_variant_dynamic;
+use crate::front::checked_arith_uint::{push_binop, push_const_int};
+use crate::model::{
+    BlockId, CallTarget, FieldDescriptor, FunctionGraph, LinkArg, OpKind, SpaceOperation, ValueType,
+};
+
+/// A recorded `Layout::from_size_align(..).ok()` call whose result is an
+/// `Option<Layout>`, captured during body lowering with the `Option`/`Some`
+/// owners, the `Layout` payload owner, and the payload type resolved from the
+/// `.ok()` destination type.
+#[derive(Clone)]
+pub(crate) struct FromSizeAlignSite {
+    /// The `.ok()` call result (the `Option<Layout>` value) — locates block Q.
+    pub ok_result: Variable,
+    /// The `Option` enum root `name_path` — the `__discriminant` field owner
+    /// and the ctor owner.
+    pub option_owner: String,
+    /// The `Option::Some` variant `name_path` — the `__pos_0` payload owner.
+    pub some_owner: String,
+    /// The `Option` payload `Layout` projected to a [`ValueType`] — the
+    /// `Some::__pos_0` field kind (a `Ref` to the `Layout` aggregate).
+    pub payload_ty: ValueType,
+    /// The `Layout` ADT `name_path` — the nested transparent-ctor owner and its
+    /// `__pos_0`/`__pos_1` field owner.
+    pub layout_owner: String,
+}
+
+/// A recorded `Layout::from_size_align(..).expect(msg)` call whose result is a
+/// by-value `Layout` (the `Result::Ok` payload), captured during body lowering.
+/// The `.expect()` receiver is a `Result<Layout, LayoutError>`, so — unlike the
+/// `.ok()` shape — there is no `Option` wrapper: the rewrite virtualizes the
+/// `Layout` directly and raises on the overflowed (`Err`) case.
+#[derive(Clone)]
+pub(crate) struct FromSizeAlignExpectSite {
+    /// The `.expect()` call result (the by-value `Layout`) — locates block Q.
+    pub result_var: Variable,
+    /// The `Layout` ADT `name_path` — the transparent-ctor owner and its
+    /// `__pos_0`/`__pos_1` field owner.
+    pub layout_owner: String,
+}
+
+/// Rewrite every recorded `from_size_align(..).ok()` site into the native
+/// bound-check + virtualized `Option<Layout>` shape.  Returns the number of
+/// sites rewritten; declined sites keep their residual calls (census Skip).
+pub(crate) fn rewire_from_size_align_sites(
+    graph: &mut FunctionGraph,
+    sites: &[FromSizeAlignSite],
+) -> usize {
+    let mut rewritten = 0;
+    for site in sites {
+        match rewire_one_from_size_align_site(graph, site) {
+            Ok(()) => rewritten += 1,
+            Err(_decline) => {
+                if std::env::var_os("PYRE_MIR_FRONTEND_DEBUG").is_some() {
+                    eprintln!(
+                        "[from_size_align] {} decline at {:?}: {_decline}",
+                        graph.name, site.ok_result
+                    );
+                }
+                // Leave both residual calls; the unregistered callees make the
+                // rtyper census Skip this graph (no regression).
+            }
+        }
+    }
+    rewritten
+}
+
+/// `true` iff `segments` names `Layout::from_size_align` (the last two path
+/// components), whatever the crate/module prefix Charon emits
+/// (`alloc::layout::Layout` here).
+fn is_layout_from_size_align(segments: &[String]) -> bool {
+    matches!(segments.last().map(String::as_str), Some("from_size_align"))
+        && matches!(
+            segments
+                .get(segments.len().wrapping_sub(2))
+                .map(String::as_str),
+            Some("Layout")
+        )
+}
+
+fn rewire_one_from_size_align_site(
+    graph: &mut FunctionGraph,
+    site: &FromSizeAlignSite,
+) -> Result<(), String> {
+    let name = graph.name.clone();
+    let ok = &site.ok_result;
+
+    // Block Q: the `.ok()` residual call producing `ok`, closed by `lower_call`
+    // with a single forwarding exit.  The call must still be Q's last op — a
+    // `Result::ok` Method call with a single arg (the `from_size_align` result).
+    let q = graph
+        .blocks
+        .iter()
+        .position(|b| b.operations.iter().any(|op| op.result.as_ref() == Some(ok)))
+        .ok_or_else(|| format!("{name}: .ok() result var has no producer block"))?;
+    let ok_idx = graph.blocks[q].operations.len() - 1;
+    let fsa_res = match &graph.blocks[q].operations[ok_idx] {
+        SpaceOperation {
+            result: Some(r),
+            kind:
+                OpKind::Call {
+                    target:
+                        CallTarget::Method {
+                            name: method,
+                            receiver_root,
+                            ..
+                        },
+                    args,
+                    ..
+                },
+        } if r == ok
+            && method == "ok"
+            && receiver_root.as_deref() == Some("Result")
+            && args.len() == 1 =>
+        {
+            args[0].clone()
+        }
+        _ => {
+            return Err(format!(
+                "{name}: block {q} last op is not the Result::ok call producing {ok:?}"
+            ));
+        }
+    };
+
+    // Block P: the `from_size_align` residual producing `fsa_res` as its last
+    // op — a 2-arg `[..]::Layout::from_size_align` FunctionPath call.
+    let p = graph
+        .blocks
+        .iter()
+        .position(|b| {
+            b.operations
+                .iter()
+                .any(|op| op.result.as_ref() == Some(&fsa_res))
+        })
+        .ok_or_else(|| format!("{name}: from_size_align result var has no producer block"))?;
+    let fsa_idx = graph.blocks[p].operations.len() - 1;
+    let (size, align_arg) = match &graph.blocks[p].operations[fsa_idx] {
+        SpaceOperation {
+            result: Some(r),
+            kind:
+                OpKind::Call {
+                    target: CallTarget::FunctionPath { segments },
+                    args,
+                    ..
+                },
+        } if r == &fsa_res && is_layout_from_size_align(segments) && args.len() == 2 => {
+            (args[0].clone(), args[1].clone())
+        }
+        _ => {
+            return Err(format!(
+                "{name}: block {p} last op is not the 2-arg Layout::from_size_align call"
+            ));
+        }
+    };
+
+    // The folded `align_of::<T>()` constant — the `from_size_align` align arg
+    // must be a `ConstInt` power of two (else the pow2 branch is not statically
+    // true and the bound is not a constant).  Resolved from its unique producer
+    // op anywhere in the graph before any mutation.
+    let align = graph
+        .blocks
+        .iter()
+        .flat_map(|b| &b.operations)
+        .find_map(|op| match &op.kind {
+            OpKind::ConstInt(n) if op.result.as_ref() == Some(&align_arg) => Some(*n),
+            _ => None,
+        })
+        .ok_or_else(|| format!("{name}: from_size_align align arg is not a folded ConstInt"))?;
+    if align <= 0 || !(align as u64).is_power_of_two() {
+        return Err(format!(
+            "{name}: from_size_align align {align} is not a power of two"
+        ));
+    }
+    // `Ok` iff `size <= isize::MAX - (align - 1)`.  `isize::MAX == i64::MAX`.
+    let bound = i64::MAX - (align - 1);
+
+    // --- All structural validation passed; mutate the graph. ---
+
+    let p_id = graph.blocks[p].id;
+    // Drop the residual `from_size_align` call (P's last op) so `fsa_res` is
+    // produced solely by the virtualized `Option` ctor appended below.
+    graph.blocks[p].operations.truncate(fsa_idx);
+
+    // Native bound check: `too_big = uint_lt(bound, size)` (size > bound → the
+    // overflowed case), `disc = eq(too_big, 0)` (Some when it fits, else None).
+    let bound_var = push_const_int(graph, p_id, bound);
+    let too_big = push_binop(
+        graph,
+        p_id,
+        "uint_lt",
+        bound_var,
+        size.clone(),
+        ValueType::Int,
+    );
+    let zero = push_const_int(graph, p_id, 0);
+    let disc = push_binop(graph, p_id, "eq", too_big, zero, ValueType::Int);
+
+    // Nested `Layout { size, align }` transparent-ctor aggregate; its
+    // `Ref` is the `Some` payload.
+    let layout = graph.alloc_value_var();
+    build_layout_aggregate(
+        graph,
+        p_id,
+        &site.layout_owner,
+        layout.clone(),
+        size,
+        align_arg,
+    );
+
+    // Reuse `fsa_res` as the virtualized `Option` ctor result.
+    emit_option_variant_dynamic(
+        graph,
+        p_id,
+        fsa_res.clone(),
+        &site.option_owner,
+        disc,
+        Some((&site.some_owner, layout, site.payload_ty.clone())),
+    );
+
+    // Block Q: drop the `.ok()` call and alias its result to the block-P
+    // `Option` threaded across the P→Q edge (`fsa_res` is a Q inputarg).
+    graph.blocks[q].operations.truncate(ok_idx);
+    for exit in &mut graph.blocks[q].exits {
+        for arg in &mut exit.args {
+            if let LinkArg::Value(v) = arg
+                && v == ok
+            {
+                *v = fsa_res.clone();
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Rewrite every recorded `from_size_align(..).expect(msg)` site into the
+/// native bound-check + a by-value virtualized `Layout`, raising on overflow.
+/// Returns the number of sites rewritten; declined sites keep their residual
+/// calls (census Skip).
+pub(crate) fn rewire_from_size_align_expect_sites(
+    graph: &mut FunctionGraph,
+    sites: &[FromSizeAlignExpectSite],
+) -> usize {
+    let mut rewritten = 0;
+    for site in sites {
+        match rewire_one_from_size_align_expect_site(graph, site) {
+            Ok(()) => rewritten += 1,
+            Err(_decline) => {
+                if std::env::var_os("PYRE_MIR_FRONTEND_DEBUG").is_some() {
+                    eprintln!(
+                        "[from_size_align expect] {} decline at {:?}: {_decline}",
+                        graph.name, site.result_var
+                    );
+                }
+                // Leave both residual calls; the unregistered callees make the
+                // rtyper census Skip this graph (no regression).
+            }
+        }
+    }
+    rewritten
+}
+
+fn rewire_one_from_size_align_expect_site(
+    graph: &mut FunctionGraph,
+    site: &FromSizeAlignExpectSite,
+) -> Result<(), String> {
+    let name = graph.name.clone();
+    let result = &site.result_var;
+
+    // Block Q: the `.expect()` residual call producing `result`, closed by
+    // `lower_call` with a single forwarding exit.  The call must still be Q's
+    // last op — a `Result::expect` Method call with two args (the
+    // `from_size_align` result and the panic message).
+    let q = graph
+        .blocks
+        .iter()
+        .position(|b| {
+            b.operations
+                .iter()
+                .any(|op| op.result.as_ref() == Some(result))
+        })
+        .ok_or_else(|| format!("{name}: .expect() result var has no producer block"))?;
+    let expect_idx = graph.blocks[q].operations.len() - 1;
+    let fsa_res = match &graph.blocks[q].operations[expect_idx].kind {
+        OpKind::Call {
+            target:
+                CallTarget::Method {
+                    name: method,
+                    receiver_root,
+                    ..
+                },
+            args,
+            ..
+        } if graph.blocks[q].operations[expect_idx].result.as_ref() == Some(result)
+            && method == "expect"
+            && receiver_root.as_deref() == Some("Result")
+            && args.len() == 2 =>
+        {
+            args[0].clone()
+        }
+        _ => {
+            return Err(format!(
+                "{name}: block {q} last op is not the Result::expect call producing {result:?}"
+            ));
+        }
+    };
+
+    // Block P: the `from_size_align` residual producing `fsa_res` as its last op
+    // — a 2-arg `[..]::Layout::from_size_align` FunctionPath call.
+    let p = graph
+        .blocks
+        .iter()
+        .position(|b| {
+            b.operations
+                .iter()
+                .any(|op| op.result.as_ref() == Some(&fsa_res))
+        })
+        .ok_or_else(|| format!("{name}: from_size_align result var has no producer block"))?;
+    let fsa_idx = graph.blocks[p].operations.len() - 1;
+    let (size, align_arg) = match &graph.blocks[p].operations[fsa_idx] {
+        SpaceOperation {
+            result: Some(r),
+            kind:
+                OpKind::Call {
+                    target: CallTarget::FunctionPath { segments },
+                    args,
+                    ..
+                },
+        } if r == &fsa_res && is_layout_from_size_align(segments) && args.len() == 2 => {
+            (args[0].clone(), args[1].clone())
+        }
+        _ => {
+            return Err(format!(
+                "{name}: block {p} last op is not the 2-arg Layout::from_size_align call"
+            ));
+        }
+    };
+
+    // The folded `align_of::<T>()` constant — the align arg must be a `ConstInt`
+    // power of two (else the pow2 branch is not statically true and the bound is
+    // not a constant).  Resolved before any mutation.
+    let align = graph
+        .blocks
+        .iter()
+        .flat_map(|b| &b.operations)
+        .find_map(|op| match &op.kind {
+            OpKind::ConstInt(n) if op.result.as_ref() == Some(&align_arg) => Some(*n),
+            _ => None,
+        })
+        .ok_or_else(|| format!("{name}: from_size_align align arg is not a folded ConstInt"))?;
+    if align <= 0 || !(align as u64).is_power_of_two() {
+        return Err(format!(
+            "{name}: from_size_align align {align} is not a power of two"
+        ));
+    }
+    // `Ok` iff `size <= isize::MAX - (align - 1)`.  `isize::MAX == i64::MAX`.
+    let bound = i64::MAX - (align - 1);
+
+    // Block P must forward `fsa_res` to Q via a single plain goto — the shape
+    // the branch replaces (the `Ok` arm re-forwards P's original link args).
+    let q_id = graph.blocks[q].id;
+    let p_goto_args: Vec<Variable> = {
+        let [exit] = graph.blocks[p].exits.as_slice() else {
+            return Err(format!(
+                "{name}: from_size_align block {p} is not single-exit"
+            ));
+        };
+        if exit.exitcase.is_some() || exit.target != q_id {
+            return Err(format!(
+                "{name}: from_size_align block {p} exit is not a plain goto to the expect block"
+            ));
+        }
+        exit.args
+            .iter()
+            .map(|a| match a {
+                LinkArg::Value(v) => Ok(v.clone()),
+                _ => Err(format!(
+                    "{name}: from_size_align P->Q link carries a non-Value arg"
+                )),
+            })
+            .collect::<Result<Vec<_>, _>>()?
+    };
+    if !p_goto_args.contains(&fsa_res) {
+        return Err(format!(
+            "{name}: fsa_res is not forwarded across the P->Q edge"
+        ));
+    }
+
+    // --- All structural validation passed; mutate the graph. ---
+
+    let p_id = graph.blocks[p].id;
+    // Drop the residual `from_size_align` call (P's last op).
+    graph.blocks[p].operations.truncate(fsa_idx);
+
+    // Native bound check: `too_big = uint_lt(bound, size)` (size > bound → the
+    // overflowed case), `disc = eq(too_big, 0)` (Ok when it fits, else Err).
+    let bound_var = push_const_int(graph, p_id, bound);
+    let too_big = push_binop(
+        graph,
+        p_id,
+        "uint_lt",
+        bound_var,
+        size.clone(),
+        ValueType::Int,
+    );
+    let zero = push_const_int(graph, p_id, 0);
+    let disc = push_binop(graph, p_id, "eq", too_big, zero, ValueType::Int);
+
+    // The by-value `Layout { size, align }` reuses `fsa_res` — the value P
+    // already forwards to Q — so the `Ok` arm needs no fresh threading.
+    build_layout_aggregate(
+        graph,
+        p_id,
+        &site.layout_owner,
+        fsa_res.clone(),
+        size,
+        align_arg,
+    );
+
+    // `Err` arm (overflow): raise the implicit `AssertionError` — `expect`
+    // panics on `Err`, the never-`Err` contract making this the "shouldn't
+    // occur" shape `remove_assertion_errors` prunes.
+    let (else_bb, _else_inputs) = graph.create_block_with_arg_vars(0);
+    graph.set_raise_implicit(
+        else_bb,
+        "Layout::from_size_align().expect() on overflowing size",
+    );
+
+    // P branches on `disc`: fits (`1`) → Q with P's original link args (the
+    // reused `fsa_res` now carrying the virtualized `Layout`); overflow (`0`) →
+    // the raise arm.
+    graph.set_branch(p_id, disc, q_id, p_goto_args, else_bb, Vec::new());
+
+    // Block Q: drop the `.expect()` call and alias its result to the block-P
+    // `Layout` threaded across the P→Q edge (`fsa_res` is a Q inputarg).
+    graph.blocks[q].operations.truncate(expect_idx);
+    for exit in &mut graph.blocks[q].exits {
+        for arg in &mut exit.args {
+            if let LinkArg::Value(v) = arg
+                && v == result
+            {
+                *v = fsa_res.clone();
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Build a `Layout { __pos_0 = size, __pos_1 = align }` transparent-ctor
+/// aggregate in `block`, writing it into `result`.  Both fields are `Unsigned`
+/// (`usize`); the aggregate is virtualized (the ctor + `FieldWrite` chain folds
+/// to SSA), so nothing materializes a real `Layout`.  `result` is a fresh var
+/// for the `.ok()` `Some` payload, or the reused `from_size_align` result var
+/// for the by-value `.expect()` shape.
+fn build_layout_aggregate(
+    graph: &mut FunctionGraph,
+    block: BlockId,
+    layout_owner: &str,
+    result: Variable,
+    size: Variable,
+    align: Variable,
+) {
+    let mut owner_path: Vec<String> = layout_owner.split("::").map(str::to_string).collect();
+    let ctor_name = owner_path.pop().unwrap_or_default();
+    let ctor_target = if owner_path.is_empty() {
+        CallTarget::synthetic_transparent_ctor(ctor_name)
+    } else {
+        CallTarget::synthetic_transparent_ctor_with_owner(owner_path, ctor_name)
+    };
+    graph.block_mut(block).operations.push(SpaceOperation {
+        result: Some(result.clone()),
+        kind: OpKind::Call {
+            target: ctor_target,
+            args: Vec::new(),
+            result_ty: ValueType::Ref(Some(layout_owner.to_string())),
+        },
+    });
+    for (name, value) in [("__pos_0", size), ("__pos_1", align)] {
+        graph.block_mut(block).operations.push(SpaceOperation {
+            result: None,
+            kind: OpKind::FieldWrite {
+                base: result.clone(),
+                field: FieldDescriptor {
+                    name: name.to_string(),
+                    owner_root: Some(layout_owner.to_string()),
+                    owner_id: None,
+                },
+                value: LinkArg::Value(value),
+                ty: ValueType::Unsigned,
+            },
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::CallTarget;
+
+    fn fsa_target() -> CallTarget {
+        CallTarget::FunctionPath {
+            segments: ["alloc", "layout", "Layout", "from_size_align"]
+                .iter()
+                .map(|s| s.to_string())
+                .collect(),
+        }
+    }
+
+    fn ok_target() -> CallTarget {
+        CallTarget::Method {
+            name: "ok".to_string(),
+            receiver_root: Some("Result".to_string()),
+            resolved_path: None,
+        }
+    }
+
+    fn site_for(ok_result: &Variable) -> FromSizeAlignSite {
+        FromSizeAlignSite {
+            ok_result: ok_result.clone(),
+            option_owner: "core::option::Option".to_string(),
+            some_owner: "core::option::Option::Some".to_string(),
+            payload_ty: ValueType::Ref(Some("core::alloc::layout::Layout".to_string())),
+            layout_owner: "core::alloc::layout::Layout".to_string(),
+        }
+    }
+
+    /// Build P (from_size_align) → Q (.ok()) → returnblock with `align` folded
+    /// to a `ConstInt` in P.  Returns the graph and the `.ok()` result var.
+    fn build_site() -> (FunctionGraph, Variable) {
+        let mut g = FunctionGraph::new("test_from_size_align");
+        let p = g.startblock;
+        let size = g.push_op_var(p, OpKind::ConstInt(64), true).unwrap();
+        let align = g.push_op_var(p, OpKind::ConstInt(8), true).unwrap();
+        let fsa = g
+            .push_op_var(
+                p,
+                OpKind::Call {
+                    target: fsa_target(),
+                    args: vec![size, align],
+                    result_ty: ValueType::Ref(None),
+                },
+                true,
+            )
+            .unwrap();
+        // Block Q consumes `fsa` via `.ok()`.  The single-predecessor
+        // framestate threading reuses the same `Variable` identity across the
+        // P→Q edge, so `.ok()`'s arg is `fsa` itself (its producer op lives in
+        // P) — the shape the rewrite walks back through.
+        let (q, _q_args) = g.create_block_with_arg_vars(1);
+        let ok = g
+            .push_op_var(
+                q,
+                OpKind::Call {
+                    target: ok_target(),
+                    args: vec![fsa.clone()],
+                    result_ty: ValueType::Ref(None),
+                },
+                true,
+            )
+            .unwrap();
+        let (cont, _) = g.create_block_with_arg_vars(1);
+        g.set_return(cont, None);
+        g.set_goto(q, cont, vec![ok.clone()]);
+        g.set_goto(p, q, vec![fsa]);
+        (g, ok)
+    }
+
+    #[test]
+    fn from_size_align_ok_lowers_to_bound_check_and_nested_option() {
+        let (mut g, ok) = build_site();
+        let rewritten = rewire_from_size_align_sites(&mut g, &[site_for(&ok)]);
+        assert_eq!(rewritten, 1, "the from_size_align().ok() site must rewrite");
+
+        // No residual FunctionPath / Method call survives.
+        let has_residual = g.blocks.iter().flat_map(|b| &b.operations).any(|op| {
+            matches!(
+                &op.kind,
+                OpKind::Call {
+                    target: CallTarget::FunctionPath { .. } | CallTarget::Method { .. },
+                    ..
+                }
+            )
+        });
+        assert!(
+            !has_residual,
+            "both from_size_align and ok residuals must be gone"
+        );
+
+        // The bound-check binops (`uint_lt` + `eq`) landed.
+        let binops: Vec<String> = g
+            .blocks
+            .iter()
+            .flat_map(|b| &b.operations)
+            .filter_map(|op| match &op.kind {
+                OpKind::BinOp { op, .. } => Some(op.clone()),
+                _ => None,
+            })
+            .collect();
+        assert!(binops.contains(&"uint_lt".to_string()));
+        assert!(binops.contains(&"eq".to_string()));
+
+        // A nested `Layout` transparent ctor and an `Option` transparent ctor
+        // both exist.
+        let ctor_owners: Vec<String> = g
+            .blocks
+            .iter()
+            .flat_map(|b| &b.operations)
+            .filter_map(|op| match &op.kind {
+                OpKind::Call {
+                    target: CallTarget::SyntheticTransparentCtor { name, .. },
+                    ..
+                } => Some(name.clone()),
+                _ => None,
+            })
+            .collect();
+        assert!(
+            ctor_owners.contains(&"Layout".to_string()),
+            "Layout ctor present"
+        );
+        assert!(
+            ctor_owners.contains(&"Option".to_string()),
+            "Option ctor present"
+        );
+
+        // The Layout aggregate writes `__pos_0` and `__pos_1`.
+        let layout_fields: Vec<String> = g
+            .blocks
+            .iter()
+            .flat_map(|b| &b.operations)
+            .filter_map(|op| match &op.kind {
+                OpKind::FieldWrite { field, .. }
+                    if field.owner_root.as_deref() == Some("core::alloc::layout::Layout") =>
+                {
+                    Some(field.name.clone())
+                }
+                _ => None,
+            })
+            .collect();
+        assert_eq!(layout_fields, vec!["__pos_0", "__pos_1"]);
+    }
+
+    #[test]
+    fn declines_when_align_is_not_a_folded_const() {
+        let mut g = FunctionGraph::new("test_dynamic_align");
+        let p = g.startblock;
+        let size = g.push_op_var(p, OpKind::ConstInt(64), true).unwrap();
+        // A non-const align (a plain input-threaded value) has no ConstInt
+        // producer, so the bound cannot be materialized — decline.
+        let align = g
+            .push_op_var(
+                p,
+                OpKind::Input {
+                    name: "a".to_string(),
+                    ty: ValueType::Unsigned,
+                    class_root: None,
+                },
+                true,
+            )
+            .unwrap();
+        let fsa = g
+            .push_op_var(
+                p,
+                OpKind::Call {
+                    target: fsa_target(),
+                    args: vec![size, align],
+                    result_ty: ValueType::Ref(None),
+                },
+                true,
+            )
+            .unwrap();
+        let (q, _q_args) = g.create_block_with_arg_vars(1);
+        let ok = g
+            .push_op_var(
+                q,
+                OpKind::Call {
+                    target: ok_target(),
+                    args: vec![fsa.clone()],
+                    result_ty: ValueType::Ref(None),
+                },
+                true,
+            )
+            .unwrap();
+        let (cont, _) = g.create_block_with_arg_vars(1);
+        g.set_return(cont, None);
+        g.set_goto(q, cont, vec![ok.clone()]);
+        g.set_goto(p, q, vec![fsa]);
+
+        let rewritten = rewire_from_size_align_sites(&mut g, &[site_for(&ok)]);
+        assert_eq!(rewritten, 0, "a non-const align must decline");
+    }
+
+    fn expect_target() -> CallTarget {
+        CallTarget::Method {
+            name: "expect".to_string(),
+            receiver_root: Some("Result".to_string()),
+            resolved_path: None,
+        }
+    }
+
+    /// Build P (from_size_align) → Q (.expect(msg)) → returnblock with `align`
+    /// folded to a `ConstInt` in P.  Returns the graph and the `.expect()`
+    /// result var (the by-value `Layout`).
+    fn build_expect_site() -> (FunctionGraph, Variable) {
+        let mut g = FunctionGraph::new("test_from_size_align_expect");
+        let p = g.startblock;
+        let size = g.push_op_var(p, OpKind::ConstInt(64), true).unwrap();
+        let align = g.push_op_var(p, OpKind::ConstInt(8), true).unwrap();
+        let fsa = g
+            .push_op_var(
+                p,
+                OpKind::Call {
+                    target: fsa_target(),
+                    args: vec![size, align],
+                    result_ty: ValueType::Ref(None),
+                },
+                true,
+            )
+            .unwrap();
+        let (q, _q_args) = g.create_block_with_arg_vars(1);
+        let msg = g.push_op_var(q, OpKind::ConstInt(1), true).unwrap();
+        let layout = g
+            .push_op_var(
+                q,
+                OpKind::Call {
+                    target: expect_target(),
+                    args: vec![fsa.clone(), msg],
+                    result_ty: ValueType::Ref(None),
+                },
+                true,
+            )
+            .unwrap();
+        let (cont, _) = g.create_block_with_arg_vars(1);
+        g.set_return(cont, None);
+        g.set_goto(q, cont, vec![layout.clone()]);
+        g.set_goto(p, q, vec![fsa]);
+        (g, layout)
+    }
+
+    fn expect_site_for(result_var: &Variable) -> FromSizeAlignExpectSite {
+        FromSizeAlignExpectSite {
+            result_var: result_var.clone(),
+            layout_owner: "core::alloc::layout::Layout".to_string(),
+        }
+    }
+
+    #[test]
+    fn from_size_align_expect_lowers_to_bound_check_and_by_value_layout() {
+        let (mut g, layout) = build_expect_site();
+        let rewritten = rewire_from_size_align_expect_sites(&mut g, &[expect_site_for(&layout)]);
+        assert_eq!(
+            rewritten, 1,
+            "the from_size_align().expect() site must rewrite"
+        );
+
+        // No residual FunctionPath / Method call survives.
+        let has_residual = g.blocks.iter().flat_map(|b| &b.operations).any(|op| {
+            matches!(
+                &op.kind,
+                OpKind::Call {
+                    target: CallTarget::FunctionPath { .. } | CallTarget::Method { .. },
+                    ..
+                }
+            )
+        });
+        assert!(
+            !has_residual,
+            "both from_size_align and expect residuals must be gone"
+        );
+
+        // The bound-check binops (`uint_lt` + `eq`) landed.
+        let binops: Vec<String> = g
+            .blocks
+            .iter()
+            .flat_map(|b| &b.operations)
+            .filter_map(|op| match &op.kind {
+                OpKind::BinOp { op, .. } => Some(op.clone()),
+                _ => None,
+            })
+            .collect();
+        assert!(binops.contains(&"uint_lt".to_string()));
+        assert!(binops.contains(&"eq".to_string()));
+
+        // A by-value `Layout` transparent ctor exists — and NO `Option` ctor
+        // (unlike the `.ok()` shape).
+        let ctor_owners: Vec<String> = g
+            .blocks
+            .iter()
+            .flat_map(|b| &b.operations)
+            .filter_map(|op| match &op.kind {
+                OpKind::Call {
+                    target: CallTarget::SyntheticTransparentCtor { name, .. },
+                    ..
+                } => Some(name.clone()),
+                _ => None,
+            })
+            .collect();
+        assert!(
+            ctor_owners.contains(&"Layout".to_string()),
+            "Layout ctor present"
+        );
+        assert!(
+            !ctor_owners.contains(&"Option".to_string()),
+            "no Option wrapper"
+        );
+
+        // Exactly one arm raises to the exceptblock (the overflow `Err` arm).
+        let raises = g
+            .blocks
+            .iter()
+            .filter(|blk| blk.exits.iter().any(|link| link.target == g.exceptblock))
+            .count();
+        assert_eq!(raises, 1, "the overflow arm raises to exceptblock");
+    }
+
+    #[test]
+    fn expect_declines_when_align_is_not_a_folded_const() {
+        let mut g = FunctionGraph::new("test_expect_dynamic_align");
+        let p = g.startblock;
+        let size = g.push_op_var(p, OpKind::ConstInt(64), true).unwrap();
+        let align = g
+            .push_op_var(
+                p,
+                OpKind::Input {
+                    name: "a".to_string(),
+                    ty: ValueType::Unsigned,
+                    class_root: None,
+                },
+                true,
+            )
+            .unwrap();
+        let fsa = g
+            .push_op_var(
+                p,
+                OpKind::Call {
+                    target: fsa_target(),
+                    args: vec![size, align],
+                    result_ty: ValueType::Ref(None),
+                },
+                true,
+            )
+            .unwrap();
+        let (q, _q_args) = g.create_block_with_arg_vars(1);
+        let msg = g.push_op_var(q, OpKind::ConstInt(1), true).unwrap();
+        let layout = g
+            .push_op_var(
+                q,
+                OpKind::Call {
+                    target: expect_target(),
+                    args: vec![fsa.clone(), msg],
+                    result_ty: ValueType::Ref(None),
+                },
+                true,
+            )
+            .unwrap();
+        let (cont, _) = g.create_block_with_arg_vars(1);
+        g.set_return(cont, None);
+        g.set_goto(q, cont, vec![layout.clone()]);
+        g.set_goto(p, q, vec![fsa]);
+
+        let rewritten = rewire_from_size_align_expect_sites(&mut g, &[expect_site_for(&layout)]);
+        assert_eq!(rewritten, 0, "a non-const align must decline");
+    }
+}

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -1827,8 +1827,6 @@ fn lower_unstructured_with_static_addrs_and_attrs(
     // descriptor's `FUNC.RESULT` is `v`, not the `Ref`-typed unit shell.
     let result_exc_ok_is_unit = result_exc_callee
         && crate::front::result_exc::tyref_result_ok_is_unit(&fd.signature.output, llbc);
-    let option_try_return_owner =
-        crate::front::option_try::tyref_option_owner(&fd.signature.output, llbc);
     let finish = |lo: &mut Lowering<'_>| -> Result<(), LowerError> {
         if !lo.result_exc_call_results.is_empty()
             || result_exc_callee
@@ -1928,6 +1926,51 @@ fn lower_unstructured_with_static_addrs_and_attrs(
                 &lo.checked_arith_call_results,
             )
         };
+        // The unsigned checked-arith rewrite (`front::checked_arith_uint`) runs
+        // AFTER `checked_arith`: a signed match-shape site the first pass
+        // already rewrote is now a `*_ovf` BinOp producer (skipped by the "the
+        // producer must still be the `Call`" gate), so the two passes never
+        // fight over a site.  It replaces each residual in place with native
+        // `uint_mul_high` / `uint_lt` overflow tests + a virtualized `Option`;
+        // the block-local rewrite detaches no edges, but reuses the same
+        // reachability-sweep gate for safety.
+        let checked_arith_uint_rewritten = if lo.checked_arith_uint_sites.is_empty() {
+            0
+        } else {
+            crate::front::checked_arith_uint::rewire_checked_arith_uint_sites(
+                &mut lo.graph,
+                &lo.checked_arith_uint_sites,
+            )
+        };
+        // The `Layout::from_size_align(..).ok()` rewrite
+        // (`front::from_size_align`) collapses the `from_size_align` + `ok`
+        // residual pair into a native `uint_lt` bound test + a virtualized
+        // nested `Option<Layout>` aggregate.  Independent of the checked-arith
+        // passes (it consumes their `Option<usize>` result as its `size` arg
+        // only after they have already produced it); the block-local rewrite
+        // detaches no edges but reuses the same reachability-sweep gate.
+        let from_size_align_rewritten = if lo.from_size_align_sites.is_empty() {
+            0
+        } else {
+            crate::front::from_size_align::rewire_from_size_align_sites(
+                &mut lo.graph,
+                &lo.from_size_align_sites,
+            )
+        };
+        // The by-value `Layout::from_size_align(..).expect(..)` sibling
+        // (`front::from_size_align`) collapses the `from_size_align` + `expect`
+        // residual pair into the same native `uint_lt` bound test + a by-value
+        // virtualized `Layout`, branching to an implicit raise on overflow.  It
+        // splits the `from_size_align` block into a fits/overflow diamond, so it
+        // needs the reachability sweep gate below.
+        let from_size_align_expect_rewritten = if lo.from_size_align_expect_sites.is_empty() {
+            0
+        } else {
+            crate::front::from_size_align::rewire_from_size_align_expect_sites(
+                &mut lo.graph,
+                &lo.from_size_align_expect_sites,
+            )
+        };
         // The `Option` `?` rewrite (`front::option_try`) consumes the same
         // `Try::branch` / `ControlFlow` diamond as `result_exc`, but its break
         // arm returns a freshly-built `None` to this graph's returnblock.  It
@@ -1936,10 +1979,14 @@ fn lower_unstructured_with_static_addrs_and_attrs(
         let option_try_stats = if lo.option_try_sites.is_empty() {
             crate::front::option_try::OptionTryStats::default()
         } else {
+            // The `?`-None return owner is spelled per-instantiation to match
+            // the suffixed producers reaching the returnblock (ref/str/float
+            // payloads); the `Int`/`Unsigned`/niche carve-out stays bare.
+            let return_owner = lo.resolve_option_return_owner(&fd.signature.output);
             crate::front::option_try::rewire_option_try_call_sites(
                 &mut lo.graph,
                 &lo.option_try_sites,
-                option_try_return_owner.as_deref(),
+                return_owner.as_deref(),
             )
         };
         // The `bool::then` short-circuit rewrite (`front::bool_then`) splits
@@ -1990,6 +2037,16 @@ fn lower_unstructured_with_static_addrs_and_attrs(
             0
         } else {
             crate::front::option_unwrap::rewire_unwrap_call_sites(&mut lo.graph, &lo.unwrap_sites)
+        };
+        // The `Option::expect` guard rewrite (`front::option_expect`) splits the
+        // residual `expect` call block into a `__discriminant` guard the same
+        // way `unwrap` does — its `Some` arm extracts `__pos_0`, its `None` arm
+        // raises the implicit `AssertionError` and drops the panic message; same
+        // fail-safe contract, gate the reachability sweep on an actual rewrite.
+        let expect_rewritten = if lo.expect_sites.is_empty() {
+            0
+        } else {
+            crate::front::option_expect::rewire_expect_call_sites(&mut lo.graph, &lo.expect_sites)
         };
         // The `Option::map_or` closure-select rewrite (`front::option_map_or`)
         // splits the residual `map_or` call block into a `__discriminant`
@@ -2054,11 +2111,15 @@ fn lower_unstructured_with_static_addrs_and_attrs(
             || result_exc_callee
             || next_rewritten > 0
             || checked_arith_rewritten > 0
+            || checked_arith_uint_rewritten > 0
+            || from_size_align_rewritten > 0
+            || from_size_align_expect_rewritten > 0
             || option_try_stats.rewritten > 0
             || bool_then_rewritten > 0
             || slice_first_rewritten > 0
             || unwrap_or_rewritten > 0
             || unwrap_rewritten > 0
+            || expect_rewritten > 0
             || map_or_rewritten > 0
             || closure_select_rewritten > 0
         {
@@ -2431,6 +2492,22 @@ struct Lowering<'a> {
     /// (`front::checked_arith`) that runs after the body lowering
     /// completes, rewriting each into an `*_ovf` op + OverflowError edge.
     checked_arith_call_results: Vec<Variable>,
+    /// Unsigned `usize::checked_{add,mul}()` call sites (`Option<usize>`-
+    /// typed) recorded for the native-overflow rewiring pass
+    /// (`front::checked_arith_uint`) that runs after `front::checked_arith`,
+    /// replacing each residual with `uint_mul_high`/`uint_lt`-based overflow
+    /// tests + a virtualized `Option`.  Kept separate from
+    /// `checked_arith_call_results` because it needs the `Option`/`Some`
+    /// owners + payload type resolved at the recording site.
+    checked_arith_uint_sites: Vec<crate::front::checked_arith_uint::CheckedArithUintSite>,
+    /// `Layout::from_size_align(size, const_align).ok()` call sites
+    /// (`Option<Layout>`-typed) recorded for the native bound-check rewiring
+    /// pass (`front::from_size_align`), which replaces the `from_size_align` +
+    /// `ok` residual pair with a `uint_lt` bound test + a virtualized nested
+    /// `Option<Layout>` aggregate.  The `Option`/`Some`/`Layout` owners and the
+    /// payload type are resolved here from the `.ok()` destination type.
+    from_size_align_sites: Vec<crate::front::from_size_align::FromSizeAlignSite>,
+    from_size_align_expect_sites: Vec<crate::front::from_size_align::FromSizeAlignExpectSite>,
     /// `Try::branch(opt)` call sites where `opt: Option<T>`, recorded for
     /// the `Option` `?` rewiring pass (`front::option_try`) that runs after
     /// body lowering completes.
@@ -2470,6 +2547,11 @@ struct Lowering<'a> {
     /// `front::option_unwrap` post-pass synthesizes (see
     /// [`crate::front::option_unwrap::UnwrapSite`]).
     unwrap_sites: Vec<crate::front::option_unwrap::UnwrapSite>,
+    /// `Option::expect(opt, msg)` call sites recorded for the discriminant
+    /// guard the `front::option_expect` post-pass synthesizes — the two-arg
+    /// sibling of `unwrap` (the panic message is dropped; see
+    /// [`crate::front::option_expect::ExpectSite`]).
+    expect_sites: Vec<crate::front::option_expect::ExpectSite>,
     /// `Option::map_or(opt, default, closure)` call sites recorded for the
     /// discriminant closure-select the `front::option_map_or` post-pass
     /// synthesizes (see [`crate::front::option_map_or::MapOrSite`]).
@@ -2667,6 +2749,9 @@ impl<'a> Lowering<'a> {
             result_exc_call_results: Vec::new(),
             next_call_results: Vec::new(),
             checked_arith_call_results: Vec::new(),
+            checked_arith_uint_sites: Vec::new(),
+            from_size_align_sites: Vec::new(),
+            from_size_align_expect_sites: Vec::new(),
             option_try_sites: Vec::new(),
             bool_then_sites: Vec::new(),
             slice_first_sites: Vec::new(),
@@ -2675,6 +2760,7 @@ impl<'a> Lowering<'a> {
             range_contains_sites: Vec::new(),
             unwrap_or_sites: Vec::new(),
             unwrap_sites: Vec::new(),
+            expect_sites: Vec::new(),
             map_or_sites: Vec::new(),
             is_none_sites: Vec::new(),
             closure_select_sites: Vec::new(),
@@ -3920,6 +4006,7 @@ impl<'a> Lowering<'a> {
                         Operand::Const(_) => None,
                     };
                     let src_kind = self.operand_value_kind(&operand);
+                    let src_root = self.operand_class_root(&operand);
                     let arg = self.resolve_operand(mir_bb, operand)?;
                     let dst_kind = tyref_to_value_type(dest_ty, self.llbc);
                     // Signedness-flipping int cast (`w_tuple_len(obj) as i64`)
@@ -3999,38 +4086,19 @@ impl<'a> Lowering<'a> {
                             }
                             // Same bank (or a bank pair with no host cast
                             // callable): alias the operand — except a
-                            // ptr→ptr cast to a registered struct root,
-                            // which narrows to `SomeInstance(root)` so a
-                            // field read on the pointee resolves (#298;
-                            // see the `Rvalue::Cast` arm for the full
-                            // rationale).  The SOURCE must already be a Ref
-                            // for this to be a genuine `cast_pointer`
-                            // (ptr→ptr); an int→ptr or unknown-source cast
-                            // is `cast_int_to_ptr` territory and aliases
-                            // instead of narrowing to an instance.
+                            // ptr→ptr cast whose destination pointee type
+                            // the annotator must honour, which travels as a
+                            // marker call ([`Lowering::ptr_cast_marker`],
+                            // shared with the `Rvalue::Cast` arm).
                             None => {
-                                if matches!(src_kind, Some(ValueType::Ref(_)))
-                                    && let ValueType::Ref(_) = dst_kind
-                                    && let Some(root) = tyref_class_root(dest_ty, self.llbc)
-                                {
-                                    let res = self.graph.alloc_value_var_with_type(
-                                        crate::model::ConcreteType::Unknown,
-                                    );
-                                    (
-                                        Some(OpKind::Call {
-                                            target: CallTarget::FunctionPath {
-                                                segments: vec![
-                                                    "__pyre_cast_instance".to_string(),
-                                                    root.clone(),
-                                                ],
-                                            },
-                                            args: vec![arg],
-                                            result_ty: ValueType::Ref(Some(root)),
-                                        }),
-                                        res,
-                                    )
-                                } else {
-                                    (None, arg)
+                                match self.ptr_cast_marker(
+                                    src_kind.as_ref(),
+                                    src_root.as_deref(),
+                                    dest_ty,
+                                    &arg,
+                                ) {
+                                    Some((op, res)) => (Some(op), res),
+                                    None => (None, arg),
                                 }
                             }
                         },
@@ -4168,45 +4236,23 @@ impl<'a> Lowering<'a> {
             Rvalue::Cast(kind, operand, ty) => {
                 // Classify the source BEFORE `resolve_operand` consumes
                 // `operand` (mirrors the `UnaryOp::Cast` twin above): only a
-                // Ref source may narrow to an instance downcast below.
+                // Ref source may narrow or erase below.
                 let src_kind = self.operand_value_kind(&operand);
+                let src_root = self.operand_class_root(&operand);
                 let v = self.resolve_operand(mir_bb, operand)?;
-                // #298: a same-bank ptr→ptr cast to a registered struct
-                // root (`obj as *const PyCode`) keeps the i64
-                // pointer carrier in place, so it would alias like above
-                // — but the result is then read like an instance of that
-                // struct (`(*p).code_ptr`), and aliasing leaves the
-                // pointer classdef-less so the field read blocks at the
-                // annotator getattr arm.  `tyref_class_root` returns
-                // `Some` only for a named-ADT pointee (None for
-                // primitives / builtin containers / generics / multi-impl
-                // type-vars), so emit a `__pyre_cast_instance` narrow
-                // whose annotator types the result `SomeInstance(root)`
-                // and whose typer folds to a `cast_pointer`.  Gate on the
+                // A same-bank ptr→ptr cast keeps the i64 pointer carrier in
+                // place, so it would alias — but the pointee type it
+                // reinterprets to is load-bearing for the annotator, in both
+                // directions ([`Lowering::ptr_cast_marker`]).  Gate on the
                 // raw-pointer cast kind: `lltype.cast_pointer`
                 // (`lltype.py:964-975`) is pointer-to-pointer only, and
                 // int-to-pointer is the separate `cast_int_to_ptr`
-                // analyzer, so an `addr_usize as *const Struct` reinterpret
-                // must NOT be narrowed to an instance downcast — the
-                // `src_kind` Ref guard enforces exactly that.
+                // analyzer.
                 if cast_kind_is_raw_ptr(&kind)
-                    && matches!(src_kind, Some(ValueType::Ref(_)))
-                    && let ValueType::Ref(_) = tyref_to_value_type(&ty, self.llbc)
-                    && let Some(root) = tyref_class_root(&ty, self.llbc)
+                    && let Some((op, res)) =
+                        self.ptr_cast_marker(src_kind.as_ref(), src_root.as_deref(), &ty, &v)
                 {
-                    let res = self
-                        .graph
-                        .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
-                    return Ok((
-                        Some(OpKind::Call {
-                            target: CallTarget::FunctionPath {
-                                segments: vec!["__pyre_cast_instance".to_string(), root.clone()],
-                            },
-                            args: vec![v],
-                            result_ty: ValueType::Ref(Some(root)),
-                        }),
-                        res,
-                    ));
+                    return Ok((Some(op), res));
                 }
                 Ok((None, v))
             }
@@ -4616,6 +4662,81 @@ impl<'a> Lowering<'a> {
             }
             Operand::Const(_) => None,
         }
+    }
+
+    /// The monomorphic-ADT class root of a `Copy` / `Move` operand's
+    /// place type, or `None` for a `Const` operand / a pointee-less
+    /// pointer.  Read by [`Self::ptr_cast_marker`] to tell a genuine
+    /// type erasure (`*mut PyFrame` → `*mut u8`) apart from a cast whose
+    /// source already carries no pointee class.
+    fn operand_class_root(&self, op: &Operand) -> Option<String> {
+        match op {
+            Operand::Copy(place) | Operand::Move(place) => tyref_class_root(&place.ty, self.llbc),
+            Operand::Const(_) => None,
+        }
+    }
+
+    /// The marker call a same-bank pointer-to-pointer reinterpret lowers
+    /// to, or `None` when the cast simply aliases its operand.
+    ///
+    /// Two shapes share this decision, so both `Cast` lowering arms route
+    /// through here:
+    ///
+    /// * **erase** — `p as *mut u8` drops the pointee class.  Aliasing
+    ///   would keep `SomeInstance(PyFrame)` on a value whose declared type
+    ///   is a bare byte pointer, so a callee taking `*mut u8` from
+    ///   heterogeneous heap blocks (`gc_hook::try_gc_owns_object`,
+    ///   `try_gc_write_barrier`) unions `PyFrame ∪ ItemsBlock` at its slot
+    ///   0 and blocks with "cannot unify instances with no common base
+    ///   class".  `llmemory.cast_ptr_to_adr` is the upstream erasure: a
+    ///   GC ownership / write-barrier hook operates on a type-erased
+    ///   `Address`, never on `Ptr(instance)`.  `__pyre_cast_address` is
+    ///   that erasure — its annotator drops the classdef, which is the
+    ///   annotation a pointee-less raw pointer already carries here, so
+    ///   the erased callers and the callers that pass an untyped `*mut u8`
+    ///   straight through agree on one annotation.
+    /// * **narrow** — `obj as *const RegisteredStruct` (#298); see
+    ///   `__pyre_cast_instance` below.
+    ///
+    /// Both are pointer-to-pointer only: a `Ref` source is required, since
+    /// an `addr_usize as *const Struct` reinterpret is `cast_int_to_ptr`
+    /// territory and must alias instead.
+    fn ptr_cast_marker(
+        &mut self,
+        src_kind: Option<&ValueType>,
+        src_root: Option<&str>,
+        dest_ty: &TyRef,
+        arg: &Variable,
+    ) -> Option<(OpKind, Variable)> {
+        if !matches!(src_kind, Some(ValueType::Ref(_)))
+            || !matches!(tyref_to_value_type(dest_ty, self.llbc), ValueType::Ref(_))
+        {
+            return None;
+        }
+        let (segments, result_ty) =
+            if src_root.is_some() && tyref_is_raw_byte_ptr(dest_ty, self.llbc) {
+                (
+                    vec!["__pyre_cast_address".to_string()],
+                    ValueType::Ref(None),
+                )
+            } else {
+                let root = tyref_class_root(dest_ty, self.llbc)?;
+                (
+                    vec!["__pyre_cast_instance".to_string(), root.clone()],
+                    ValueType::Ref(Some(root)),
+                )
+            };
+        let res = self
+            .graph
+            .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
+        Some((
+            OpKind::Call {
+                target: CallTarget::FunctionPath { segments },
+                args: vec![arg.clone()],
+                result_ty,
+            },
+            res,
+        ))
     }
 
     /// Decode a Charon `Operand::Const` value and emit the matching
@@ -7656,6 +7777,35 @@ impl<'a> Lowering<'a> {
             op_kind
         };
 
+        // A derived `PartialEq` comparison between two FIELDLESS enums is an
+        // integer comparison of their discriminants.  The enum is modelled
+        // by-value as that discriminant (`tyref_to_value_type` colors it
+        // `Int`), so the derived `eq` arrives as a `CallTarget::Method` whose
+        // receiver already sits in the int bank — and `SomeInteger` has no
+        // `eq` attribute, so leaving the call residual blocks the annotator
+        // with `Cannot find attribute "eq" on Integer`.  Emit the `BinOp`
+        // instead: RPython spells a C-like enum's dispatch as an `int_eq`
+        // chain against named int constants (`pypy/interpreter/pyopcode.py`
+        // `dispatch_bytecode`, folded by `merge_if_blocks`), never as a
+        // method on the tag.  Twin of the `<str as PartialEq>::eq` fold.
+        let op_kind = if let OpKind::Call { target, args, .. } = &op_kind
+            && args.len() == 2
+            && let CallTarget::Method { name, .. } = target
+            && let Some(binop) = fieldless_enum_cmp_binop(name)
+            && [first_arg_ty.as_ref(), second_arg_ty.as_ref()]
+                .iter()
+                .all(|t| t.is_some_and(|t| self.tyref_is_borrowed_fieldless_enum(t)))
+        {
+            OpKind::BinOp {
+                op: binop.to_string(),
+                lhs: args[0].clone(),
+                rhs: args[1].clone(),
+                result_ty: ValueType::Int,
+            }
+        } else {
+            op_kind
+        };
+
         // Mixed W_LongObject/W_IntObject comparisons use rbigint.int_* in
         // both operand orders (the int-left descriptor reverses the relation).
         // The receiver remains one RBigInt GCREF, the other operand is exactly
@@ -8105,6 +8255,85 @@ impl<'a> Lowering<'a> {
         {
             self.checked_arith_call_results.push(result_var.clone());
         }
+        // Capture UNSIGNED `usize::checked_{add,mul}()` results
+        // (`Option<usize>`) for the native-overflow rewiring pass
+        // (`front::checked_arith_uint`).  Signed arithmetic stays on
+        // `front::checked_arith` (→ `*_ovf` + OverflowError); unsigned has no
+        // signed-overflow op, so it lowers to `uint_mul_high` / `uint_lt`
+        // overflow tests + a virtualized `Option`.  The operand-signedness
+        // gate lives here because the operand types are only in hand at the
+        // call site; `checked_sub` is excluded (no `?`-shape census site).
+        if let OpKind::Call { target, .. } = &op_kind
+            && let CallTarget::FunctionPath { segments } = target
+            && matches!(
+                segments.last().map(String::as_str),
+                Some("checked_add" | "checked_mul")
+            )
+            && crate::front::checked_arith::is_checked_arith_target(target)
+            && crate::front::result_exc::tyref_is_option(&call.dest.ty, self.llbc)
+            && first_arg_ty
+                .as_ref()
+                .is_some_and(|t| tyref_to_value_type(t, self.llbc) == ValueType::Unsigned)
+            && second_arg_ty
+                .as_ref()
+                .is_some_and(|t| tyref_to_value_type(t, self.llbc) == ValueType::Unsigned)
+            && let Some(site) = self.recognize_checked_arith_uint_site(&call.dest.ty, &result_var)
+        {
+            self.checked_arith_uint_sites.push(site);
+        }
+        // Capture `Result::ok()` results whose payload is `Layout`
+        // (`Option<Layout>`) for the `from_size_align` bound-check rewiring pass
+        // (`front::from_size_align`).  The `.ok()` is the second residual of
+        // `Layout::from_size_align(size, align).ok()`; the destination
+        // `Option<Layout>` type resolves the `Option`/`Some`/`Layout` owners
+        // here, and the post-pass validates the preceding `from_size_align`
+        // residual + folded-const align before mutating.  A miss leaves both
+        // residual calls for the existing Skip fallback.
+        if let OpKind::Call {
+            target:
+                CallTarget::Method {
+                    name,
+                    receiver_root,
+                    ..
+                },
+            args,
+            ..
+        } = &op_kind
+            && name == "ok"
+            && receiver_root.as_deref() == Some("Result")
+            && args.len() == 1
+            && crate::front::result_exc::tyref_is_option(&call.dest.ty, self.llbc)
+            && let Some(site) = self.recognize_from_size_align_ok_site(&call.dest.ty, &result_var)
+        {
+            self.from_size_align_sites.push(site);
+        }
+        // Capture `Result::expect(res, msg)` results whose payload is `Layout`
+        // (the by-value `Layout`) for the `from_size_align` bound-check rewiring
+        // pass (`front::from_size_align`).  The `.expect()` is the second
+        // residual of `Layout::from_size_align(size, align).expect(msg)`; unlike
+        // `.ok()`, the destination is `Layout` (not `Option<Layout>`), so the
+        // receiver is `Result` (not `Option`) — distinguishing it from
+        // `Option::expect`.  The post-pass validates the preceding
+        // `from_size_align` residual before mutating; a miss leaves both
+        // residual calls for the existing Skip fallback.
+        if let OpKind::Call {
+            target:
+                CallTarget::Method {
+                    name,
+                    receiver_root,
+                    ..
+                },
+            args,
+            ..
+        } = &op_kind
+            && name == "expect"
+            && receiver_root.as_deref() == Some("Result")
+            && args.len() == 2
+            && let Some(site) =
+                self.recognize_from_size_align_expect_site(&call.dest.ty, &result_var)
+        {
+            self.from_size_align_expect_sites.push(site);
+        }
         // Capture `Try::branch(opt)` sites where the receiver is an
         // `Option<T>`, the compiler-generated core call behind `opt?`.  The
         // rewrite validates the surrounding `ControlFlow` diamond and the
@@ -8272,6 +8501,24 @@ impl<'a> Lowering<'a> {
             && let Some(site) = self.recognize_unwrap_site(first_arg_ty.as_ref(), &result_var)
         {
             self.unwrap_sites.push(site);
+        }
+        // Capture `Option::expect(opt, msg)` sites for the discriminant guard
+        // `front::option_expect` synthesizes — the two-arg sibling of `unwrap`.
+        // Its body is Opaque (foreign `core`) and its receiver is the `Option`
+        // ADT, so `first_is_self` routes it to a `CallTarget::Method` (receiver
+        // `args[0]`, panic message `args[1]`).  `recognize_expect_site` confirms
+        // the receiver is an `Option` (not `Result`).  A resolution miss leaves
+        // the residual call — an unregistered callee the rtyper census Skips.
+        if let OpKind::Call {
+            target: CallTarget::Method { name, .. },
+            args,
+            ..
+        } = &op_kind
+            && args.len() == 2
+            && name == "expect"
+            && let Some(site) = self.recognize_expect_site(first_arg_ty.as_ref(), &result_var)
+        {
+            self.expect_sites.push(site);
         }
         // Capture `Option::map_or(opt, default, closure)` sites for the
         // discriminant closure-select `front::option_map_or` synthesizes.
@@ -9938,6 +10185,45 @@ impl<'a> Lowering<'a> {
         }
     }
 
+    /// Peel `Ref` / `RawPtr` wrappers (through dedup / hash-cons
+    /// indirections) to the pointee as an owned [`TyRef`] — the by-value shape
+    /// the `Option` owner resolvers expect.  Returns `ty` itself (cloned) when
+    /// it is not a reference.  Used to feed an `&Option<..>` receiver (e.g.
+    /// `is_none`/`is_some`, which take `&self`) into
+    /// [`Self::resolve_option_consumer_owners`], whose payload / suffix reads
+    /// need the un-wrapped `Option<..>`.  Same wrapper set as
+    /// [`Self::tyref_ref_adt_def_id`], which resolves to a `def_id` instead.
+    fn tyref_peel_ref_to_pointee(&self, ty: &TyRef) -> Option<TyRef> {
+        let mut v: &serde_json::Value = match ty {
+            TyRef::Inline { value: (_, v) } | TyRef::Other(v) => v,
+            TyRef::Dedup { id } => self.llbc.dedup_body(*id)?,
+        };
+        loop {
+            let obj = v.as_object()?;
+            if let Some(id) = obj.get("Deduplicated").and_then(serde_json::Value::as_u64) {
+                v = self.llbc.dedup_body(id)?;
+                continue;
+            }
+            if let Some(arr) = obj
+                .get("HashConsedValue")
+                .and_then(serde_json::Value::as_array)
+                && arr.len() == 2
+            {
+                v = &arr[1];
+                continue;
+            }
+            if let Some(arr) = obj.get("Ref").and_then(serde_json::Value::as_array) {
+                v = arr.get(1)?;
+                continue;
+            }
+            if let Some(arr) = obj.get("RawPtr").and_then(serde_json::Value::as_array) {
+                v = arr.first()?;
+                continue;
+            }
+            return serde_json::from_value(v.clone()).ok();
+        }
+    }
+
     /// The `Option`'s payload type `T` (its first `generics.types` entry)
     /// projected to a [`ValueType`] — the `call_once` result kind and the
     /// `Some::__pos_0` field kind the `bool::then` diamond writes.  `None`
@@ -10106,6 +10392,60 @@ impl<'a> Lowering<'a> {
         Some((option_owner, some_owner, payload_ty))
     }
 
+    /// Resolve the `(option_owner, some_owner, payload_ty)` an `Option`
+    /// *consumer* pass (`option_try` `?`, `expect`) must spell so its
+    /// `__discriminant` / `__pos_0` reads key the SAME classdef the value's
+    /// *producer* wrote.
+    ///
+    /// Agreement is by construction: the suffixed producers (`bool::then` /
+    /// `then_some`, `map_or`, `slice_first`, `from_size_align`) mint a
+    /// per-instantiation `Option<X>` root through
+    /// [`Self::resolve_bool_then_option_dest`], so the consumer reuses that
+    /// exact derivation — a `Str`/`Float`/`Ref`/nested-enum payload keys the
+    /// suffixed root identically on both sides.  The one deviation is
+    /// [`crate::front::checked_arith_uint`], which mints a BARE `Option` root
+    /// for its `Int`/`Unsigned` payload; an integer-payload `Option` therefore
+    /// stays bare here to match it.  A niche `Option<NonNull>` has no aggregate
+    /// `__discriminant` / `__pos_0` (the arms use a pointer null-test and an
+    /// identity payload), so its owners are never read — keep them bare, which
+    /// also mirrors [`Self::resolve_bool_then_option_dest`]'s own aggregate
+    /// applicability.
+    fn resolve_option_consumer_owners(
+        &self,
+        recv_ty: &TyRef,
+    ) -> Option<(String, String, ValueType)> {
+        let payload_ty = self.tyref_option_payload_value_type(recv_ty)?;
+        if matches!(payload_ty, ValueType::Int | ValueType::Unsigned)
+            || self.tyref_is_niche_option_ptr(recv_ty)
+        {
+            let def_id = self.tyref_adt_def_id(recv_ty)?;
+            let td = self.llbc.type_by_id(def_id)?;
+            let option_owner = td.item_meta.name_path();
+            let some_owner = Self::tagged_pair_payload_owner(td, &option_owner, 1)?;
+            return Some((option_owner, some_owner, payload_ty));
+        }
+        self.resolve_bool_then_option_dest(recv_ty)
+    }
+
+    /// Resolve the enclosing function's return `Option` owner for the
+    /// `?`-None construction ([`crate::front::option_try`]).  It must MATCH the
+    /// spelling of the suffixed producers whose `Some` values reach the same
+    /// returnblock — otherwise a suffixed `Some` and a bare `None` union to the
+    /// bare template, payload-erasing the return.  Reuses
+    /// [`Self::resolve_option_consumer_owners`], so a ref/str/float-payload
+    /// return is instantiation-suffixed and the `Int`/`Unsigned` /
+    /// niche-pointer carve-out stays bare (matching
+    /// [`crate::front::checked_arith_uint`]).  `None` when the output is not a
+    /// resolvable `Option` — the `?` rewrite then declines all sites.
+    fn resolve_option_return_owner(&self, output_ty: &TyRef) -> Option<String> {
+        if !crate::front::result_exc::tyref_is_option(output_ty, self.llbc) {
+            return None;
+        }
+        let (option_owner, _some_owner, _payload_ty) =
+            self.resolve_option_consumer_owners(output_ty)?;
+        Some(option_owner)
+    }
+
     /// Resolve a recognized `bool::then(cond, closure_env)` call into a
     /// [`crate::front::bool_then::BoolThenSite`] — the owners and payload
     /// type the short-circuit diamond post-pass needs.  `None` (leaving the
@@ -10201,24 +10541,34 @@ impl<'a> Lowering<'a> {
         // left residual (Skip) rather than risk a value-select on an
         // exception-form value.  Only `Option` and plain-error `Result` (e.g.
         // `io::Result`) select here.
-        let (payload_disc, payload_on_disc_true) =
-            if crate::front::result_exc::tyref_is_option(recv_ty, self.llbc) {
-                (1, true)
-            } else if crate::front::result_exc::tyref_is_result(recv_ty, self.llbc)
-                && !crate::front::result_exc::tyref_is_result_of_pyerror(recv_ty, self.llbc)
-            {
-                (0, false)
-            } else {
-                return None;
-            };
-        let def_id = self.tyref_adt_def_id(recv_ty)?;
-        let td = self.llbc.type_by_id(def_id)?;
-        let enum_owner = td.item_meta.name_path();
-        let payload_owner = Self::tagged_pair_payload_owner(td, &enum_owner, payload_disc)?;
+        let is_option = crate::front::result_exc::tyref_is_option(recv_ty, self.llbc);
+        let (payload_disc, payload_on_disc_true) = if is_option {
+            (1, true)
+        } else if crate::front::result_exc::tyref_is_result(recv_ty, self.llbc)
+            && !crate::front::result_exc::tyref_is_result_of_pyerror(recv_ty, self.llbc)
+        {
+            (0, false)
+        } else {
+            return None;
+        };
         // The payload `T` is the first type arg for both `Option<T>` and
         // `Result<T, E>`.
         let payload_ty = self.tyref_option_payload_value_type(recv_ty)?;
         let niche = self.tyref_is_niche_option_ptr(recv_ty);
+        // An `Option` payload read keys the per-instantiation classdef its
+        // producer wrote (bare for the `Int`/`Unsigned`/niche carve-out); a
+        // plain-error `Result` has no suffixed producers here, so its `Ok`/`Err`
+        // owners stay bare.
+        let (enum_owner, payload_owner) = if is_option {
+            let (option_owner, some_owner, _) = self.resolve_option_consumer_owners(recv_ty)?;
+            (option_owner, some_owner)
+        } else {
+            let def_id = self.tyref_adt_def_id(recv_ty)?;
+            let td = self.llbc.type_by_id(def_id)?;
+            let enum_owner = td.item_meta.name_path();
+            let payload_owner = Self::tagged_pair_payload_owner(td, &enum_owner, payload_disc)?;
+            (enum_owner, payload_owner)
+        };
         Some(crate::front::option_unwrap_or::UnwrapOrSite {
             result_var: result_var.clone(),
             enum_owner,
@@ -10247,9 +10597,13 @@ impl<'a> Lowering<'a> {
         if !crate::front::result_exc::tyref_is_option_ref(recv_ty, self.llbc) {
             return None;
         }
-        let def_id = self.tyref_ref_adt_def_id(recv_ty)?;
-        let td = self.llbc.type_by_id(def_id)?;
-        let option_owner = td.item_meta.name_path();
+        // Resolve the enum root the same way a value consumer does, off the
+        // peeled `Option<..>`, so the `__discriminant` read keys the classdef
+        // the producer wrote — per-instantiation for a ref/str/float payload,
+        // bare for the `Int`/`Unsigned`/niche carve-out.
+        let pointee = self.tyref_peel_ref_to_pointee(recv_ty)?;
+        let (option_owner, _some_owner, _payload_ty) =
+            self.resolve_option_consumer_owners(&pointee)?;
         Some(crate::front::option_is_none::IsNoneSite {
             result_var: result_var.clone(),
             option_owner,
@@ -10273,13 +10627,40 @@ impl<'a> Lowering<'a> {
         if !crate::front::result_exc::tyref_is_option(recv_ty, self.llbc) {
             return None;
         }
-        let def_id = self.tyref_adt_def_id(recv_ty)?;
-        let td = self.llbc.type_by_id(def_id)?;
-        let option_owner = td.item_meta.name_path();
-        let some_owner = Self::tagged_pair_payload_owner(td, &option_owner, 1)?;
-        let payload_ty = self.tyref_option_payload_value_type(recv_ty)?;
+        let (option_owner, some_owner, payload_ty) =
+            self.resolve_option_consumer_owners(recv_ty)?;
         let niche = self.tyref_is_niche_option_ptr(recv_ty);
         Some(crate::front::option_unwrap::UnwrapSite {
+            result_var: result_var.clone(),
+            option_owner,
+            some_owner,
+            payload_ty,
+            niche,
+        })
+    }
+
+    /// Resolve a recognized `Option::expect(opt, msg)` call into an
+    /// [`crate::front::option_expect::ExpectSite`] — the two-arg sibling of
+    /// [`Self::recognize_unwrap_site`].  Guards on `Option` (not `Result`:
+    /// `Result::expect` shares the name but its `Ok`/`Err` tags do not match
+    /// `Some`=1/`None`=0).  The owners route through
+    /// [`Self::resolve_option_consumer_owners`] so the synthesized
+    /// `__discriminant` / `__pos_0` reads key the same classdef the value's
+    /// producer wrote.  `None` (leaving the residual call) when the receiver is
+    /// not a resolvable `Option`.
+    fn recognize_expect_site(
+        &self,
+        recv_ty: Option<&TyRef>,
+        result_var: &Variable,
+    ) -> Option<crate::front::option_expect::ExpectSite> {
+        let recv_ty = recv_ty?;
+        if !crate::front::result_exc::tyref_is_option(recv_ty, self.llbc) {
+            return None;
+        }
+        let (option_owner, some_owner, payload_ty) =
+            self.resolve_option_consumer_owners(recv_ty)?;
+        let niche = self.tyref_is_niche_option_ptr(recv_ty);
+        Some(crate::front::option_expect::ExpectSite {
             result_var: result_var.clone(),
             option_owner,
             some_owner,
@@ -10291,6 +10672,98 @@ impl<'a> Lowering<'a> {
     /// Resolve a recognized `Try::branch(opt)` call where `opt: Option<T>`
     /// into an [`crate::front::option_try::OptionTrySite`].  `None` leaves the
     /// residual call untouched when the receiver is not a resolvable `Option`.
+    /// Resolve an unsigned `usize::checked_{add,mul}` call whose result is an
+    /// `Option<usize>` into a
+    /// [`crate::front::checked_arith_uint::CheckedArithUintSite`] — the
+    /// `Option` enum root + `Some` variant owners and the payload type, keyed
+    /// off the destination `Option<usize>` type.  Mirrors
+    /// [`Self::recognize_option_try_site`]'s owner derivation so the
+    /// virtualized `Option` this pass builds shares field descrs with the
+    /// downstream `?` reads (`front::option_try`).
+    fn recognize_checked_arith_uint_site(
+        &self,
+        dest_ty: &TyRef,
+        result_var: &Variable,
+    ) -> Option<crate::front::checked_arith_uint::CheckedArithUintSite> {
+        if !crate::front::result_exc::tyref_is_option(dest_ty, self.llbc) {
+            return None;
+        }
+        let def_id = self.tyref_adt_def_id(dest_ty)?;
+        let td = self.llbc.type_by_id(def_id)?;
+        let option_owner = td.item_meta.name_path();
+        let some_owner = Self::tagged_pair_payload_owner(td, &option_owner, 1)?;
+        let payload_ty = self.tyref_option_payload_value_type(dest_ty)?;
+        Some(crate::front::checked_arith_uint::CheckedArithUintSite {
+            opt: result_var.clone(),
+            option_owner,
+            some_owner,
+            payload_ty,
+        })
+    }
+
+    /// Resolve a `Result::ok()` call whose result is an `Option<Layout>` into a
+    /// [`crate::front::from_size_align::FromSizeAlignSite`] — the `Option` enum
+    /// root + `Some` variant owners, the payload `ValueType`, and the nested
+    /// `Layout` ADT owner, keyed off the `.ok()` destination `Option<Layout>`
+    /// type.  Gated on the payload being `core::alloc::layout::Layout` so only
+    /// the `from_size_align(..).ok()` shape is recorded; the post-pass validates
+    /// the preceding `from_size_align` residual.  The `Option` root is
+    /// **instantiation-suffixed** (`resolve_bool_then_option_dest`, matching
+    /// `bool::then`): the enclosing `try_typed_items_block_layout` also builds
+    /// `checked_{mul,add}` `Option<usize>` values, and a bare `Option` root
+    /// would share one `core.option.Option::Some::__pos_0` field with them,
+    /// unioning `Integer` with `Instance(Layout)` (annotator UnionError).  The
+    /// suffix gives `Option<Layout>` its own ClassDef and `__pos_0` field.
+    fn recognize_from_size_align_ok_site(
+        &self,
+        dest_ty: &TyRef,
+        result_var: &Variable,
+    ) -> Option<crate::front::from_size_align::FromSizeAlignSite> {
+        if !crate::front::result_exc::tyref_is_option(dest_ty, self.llbc) {
+            return None;
+        }
+        let (option_owner, some_owner, payload_ty) = self.resolve_bool_then_option_dest(dest_ty)?;
+        // The `Some` payload must be the opaque `core::alloc::layout::Layout`
+        // ADT — this gates recording to the `from_size_align(..).ok()` shape.
+        let payload_ty_ref = self.tyref_adt_type_arg(dest_ty, 0)?;
+        let layout_def_id = self.tyref_adt_def_id(&payload_ty_ref)?;
+        let layout_owner = self.llbc.type_by_id(layout_def_id)?.item_meta.name_path();
+        if layout_owner != "core::alloc::layout::Layout" {
+            return None;
+        }
+        Some(crate::front::from_size_align::FromSizeAlignSite {
+            ok_result: result_var.clone(),
+            option_owner,
+            some_owner,
+            payload_ty,
+            layout_owner,
+        })
+    }
+
+    /// Resolve a `Result::expect(res, msg)` call whose result is a by-value
+    /// `Layout` into a
+    /// [`crate::front::from_size_align::FromSizeAlignExpectSite`] — the
+    /// by-value sibling of [`Self::recognize_from_size_align_ok_site`].  Gated
+    /// on the destination being `core::alloc::layout::Layout` so only the
+    /// `from_size_align(..).expect(..)` shape is recorded; the post-pass
+    /// validates the preceding `from_size_align` residual + folded-const align
+    /// before mutating.  `None` (leaving the residual call) otherwise.
+    fn recognize_from_size_align_expect_site(
+        &self,
+        dest_ty: &TyRef,
+        result_var: &Variable,
+    ) -> Option<crate::front::from_size_align::FromSizeAlignExpectSite> {
+        let layout_def_id = self.tyref_adt_def_id(dest_ty)?;
+        let layout_owner = self.llbc.type_by_id(layout_def_id)?.item_meta.name_path();
+        if layout_owner != "core::alloc::layout::Layout" {
+            return None;
+        }
+        Some(crate::front::from_size_align::FromSizeAlignExpectSite {
+            result_var: result_var.clone(),
+            layout_owner,
+        })
+    }
+
     fn recognize_option_try_site(
         &self,
         recv_ty: Option<&TyRef>,
@@ -10300,11 +10773,15 @@ impl<'a> Lowering<'a> {
         if !crate::front::result_exc::tyref_is_option(recv_ty, self.llbc) {
             return None;
         }
-        let def_id = self.tyref_adt_def_id(recv_ty)?;
-        let td = self.llbc.type_by_id(def_id)?;
-        let option_owner = td.item_meta.name_path();
-        let some_owner = Self::tagged_pair_payload_owner(td, &option_owner, 1)?;
-        let payload_ty = self.tyref_option_payload_value_type(recv_ty)?;
+        // The branched `__discriminant` / `__pos_0` reads key the SAME classdef
+        // the branched Option's producer wrote — per-instantiation for a
+        // ref/str/float payload, bare for the `Int`/`Unsigned` carve-out.  A
+        // cross-payload `?` (branch `Option<usize>`, return `Option<Layout>`)
+        // is fine: the branched owners here are independent of the enclosing
+        // function's return owner (`front::option_try` reads the Some arm from
+        // these owners and builds the None arm from the return owner).
+        let (option_owner, some_owner, payload_ty) =
+            self.resolve_option_consumer_owners(recv_ty)?;
         let niche = self.tyref_is_niche_option_ptr(recv_ty);
         Some(crate::front::option_try::OptionTrySite {
             branch_result_var: result_var.clone(),
@@ -10444,18 +10921,20 @@ impl<'a> Lowering<'a> {
     /// and keep the `__discriminant` field read against their aggregate
     /// `Ref` base.
     fn tyref_is_fieldless_enum(&self, ty: &TyRef) -> bool {
-        let Some(def_id) = self.tyref_adt_def_id(ty) else {
-            return false;
-        };
-        let Some(td) = self.llbc.type_by_id(def_id) else {
-            return false;
-        };
-        match &td.kind {
-            TypeDeclKind::Enum(variants) => {
-                !variants.is_empty() && variants.iter().all(|v| v.fields.is_empty())
-            }
-            _ => false,
-        }
+        self.tyref_adt_def_id(ty)
+            .and_then(|def_id| self.llbc.type_by_id(def_id))
+            .is_some_and(type_decl_is_fieldless_enum)
+    }
+
+    /// [`Self::tyref_is_fieldless_enum`] through a `&` borrow — the shape a
+    /// derived trait method sees, since `PartialEq::eq(&self, &other)` types
+    /// both operands as references.  A fieldless enum is modelled by-value as
+    /// its discriminant integer, and `Rvalue::Ref` is the identity on it, so
+    /// the borrow carries no representation of its own.
+    fn tyref_is_borrowed_fieldless_enum(&self, ty: &TyRef) -> bool {
+        self.tyref_ref_adt_def_id(ty)
+            .and_then(|def_id| self.llbc.type_by_id(def_id))
+            .is_some_and(type_decl_is_fieldless_enum)
     }
 
     /// `true` when `ty` is a niche-optimised `Option<NonNull<T>>` or
@@ -11411,7 +11890,7 @@ impl<'a> Lowering<'a> {
         Some(td.item_meta.name_path())
     }
 
-    /// The struct-root `name_path()` of `ty` when it resolves to a
+    /// The struct-root canonical name of `ty` when it resolves to a
     /// zero-field unit struct — the shape of the prebuilt dict-strategy
     /// singletons (`EmptyDictStrategy`, `ObjectDictStrategy`, …).  The
     /// `PlaceKind::Global` reader narrows a `refs`-bucket static of such a
@@ -11419,12 +11898,25 @@ impl<'a> Lowering<'a> {
     /// `SomeInstance`.  Returns `None` for a field-bearing struct (the
     /// object singletons `W_NoneObject` / `W_BoolObject` / … in the same
     /// bucket keep their raw-pointer lowering) or any non-struct shape.
+    ///
+    /// The name is crate-stripped ([`strip_crate_prefix`]) so it matches
+    /// the canonical `module::Leaf` spelling every other classdef path keys
+    /// on (`STRUCT_ORIGIN_REGISTRY` / `canonical_struct_name`, the struct
+    /// field registry, and the `register_trait_family` impl subclasses).
+    /// The raw `name_path()` carries the crate segment (`pyre_object::…`),
+    /// which `canonical_struct_name` passes through verbatim, minting a
+    /// SEPARATE `ClassDef` from the trait-family subclass — so the singleton
+    /// instance would have no `basedef` and two sibling strategy singletons
+    /// (`EmptyDictStrategy` / `EmptyKwargsDictStrategy`) `commonbase` to
+    /// nothing at a `mergeinputargs` join (`UnionError: no common base`).
     fn refs_static_zerofield_struct_root(&self, ty: &TyRef) -> Option<String> {
         let v = self.tyref_adt_body(ty)?;
         let def_id = inline_adt_def_id(v)?;
         let td = self.llbc.type_by_id(def_id)?;
         match &td.kind {
-            TypeDeclKind::Struct(fields) if fields.is_empty() => Some(td.item_meta.name_path()),
+            TypeDeclKind::Struct(fields) if fields.is_empty() => {
+                Some(strip_crate_prefix(&td.item_meta.name_path()))
+            }
             _ => None,
         }
     }
@@ -13838,14 +14330,33 @@ fn tyref_fieldless_enum_def<'l>(ty: &TyRef, llbc: &'l Llbc) -> Option<&'l TypeDe
         TyRef::Inline { value: (_, v) } | TyRef::Other(v) => inline_adt_def_id(v),
         TyRef::Dedup { id } => llbc.dedup_to_adt_def_id(*id),
     }?;
-    let td = llbc.type_by_id(def_id)?;
-    match &td.kind {
-        TypeDeclKind::Enum(variants)
-            if !variants.is_empty() && variants.iter().all(|v| v.fields.is_empty()) =>
-        {
-            Some(td)
-        }
+    llbc.type_by_id(def_id)
+        .filter(|td| type_decl_is_fieldless_enum(td))
+}
+
+/// The integer-comparison `BinOp` opname a derived `PartialEq` method on
+/// a fieldless enum folds to, or `None` for any other method leaf.  Only
+/// the two equality halves the `#[derive(PartialEq)]` expansion provides
+/// are recognized; ordering (`PartialOrd`) is a separate derive that no
+/// fieldless enum in the corpus compares by.
+fn fieldless_enum_cmp_binop(method: &str) -> Option<&'static str> {
+    match method {
+        "eq" => Some("eq"),
+        "ne" => Some("ne"),
         _ => None,
+    }
+}
+
+/// Whether a `TypeDecl` is a fieldless (C-like) enum: at least one
+/// variant, every variant carrying zero payload fields.  Such an enum is
+/// modelled by-value as its discriminant integer, so it has no
+/// `SomeInstance` at all.
+fn type_decl_is_fieldless_enum(td: &TypeDecl) -> bool {
+    match &td.kind {
+        TypeDeclKind::Enum(variants) => {
+            !variants.is_empty() && variants.iter().all(|v| v.fields.is_empty())
+        }
+        _ => false,
     }
 }
 
@@ -14371,6 +14882,39 @@ fn adt_node_class_root(node: &serde_json::Value, llbc: &Llbc) -> Option<String> 
 fn raw_ptr_pointee_class_root(node: &serde_json::Value, llbc: &Llbc) -> Option<String> {
     let raw = node.as_object()?.get("RawPtr")?.as_array()?;
     adt_node_class_root(strip_ty_wrappers(raw.first()?, llbc)?, llbc)
+}
+
+/// Whether `ty` is a raw pointer onto a byte-sized integer literal —
+/// `*mut u8` / `*const u8` / the `i8` spellings.  This is the
+/// type-erased "opaque memory address" pointer: `llmemory.Address`
+/// upstream, the parameter type every heterogeneous-heap-block hook in
+/// `pyre_object::gc_hook` declares.  A pointee-typed raw pointer
+/// (`*mut PyFrame`, `*mut *mut PyObject`) and a wider primitive array
+/// head (`*mut i64`) are all excluded — only the byte pointee carries
+/// the "no pointee type at all" contract.
+fn tyref_is_raw_byte_ptr(ty: &TyRef, llbc: &Llbc) -> bool {
+    let Some(pointee) = tyref_node(ty, llbc)
+        .and_then(|n| strip_ty_wrappers(n, llbc))
+        .and_then(|n| n.as_object()?.get("RawPtr")?.as_array()?.first())
+        .and_then(|n| strip_ty_wrappers(n, llbc))
+    else {
+        return false;
+    };
+    let Some(lit) = pointee.as_object().and_then(|o| o.get("Literal")) else {
+        return false;
+    };
+    // The literal-type schema splits `{"UInt": "U8"}` / `{"Int": "I8"}`
+    // across the two integer keys, plus the older `{"Integer": …}`
+    // spelling some .ullbc artefacts still carry.
+    let Some(lit_obj) = lit.as_object() else {
+        return false;
+    };
+    ["UInt", "Int", "Integer"].into_iter().any(|key| {
+        matches!(
+            lit_obj.get(key).and_then(serde_json::Value::as_str),
+            Some("U8" | "I8")
+        )
+    })
 }
 
 /// Whether `ty` is a `*mut PyObjectRef` / `*const PyObjectRef`
@@ -18700,9 +19244,9 @@ mod tests {
     use super::harden_duplicate_leaf_metadata;
     use super::{
         DecodedConst, cast_kind_is_raw_ptr, cast_pointer_marker_op, charon_const_generic_to_string,
-        charon_type_value_to_ast_string, decode_literal,
+        charon_type_value_to_ast_string, decode_literal, tyref_is_raw_byte_ptr,
     };
-    use majit_charon_reader::Llbc;
+    use majit_charon_reader::{Llbc, ullbc::TyRef};
 
     #[test]
     fn decode_scalar_i128_and_u128_preserves_full_width() {
@@ -21282,6 +21826,40 @@ mod tests {
         assert!(!cast_kind_is_raw_ptr(&serde_json::json!({"Scalar": []})));
     }
 
+    /// Only a byte pointee spells the type-erased address; a pointee-typed
+    /// raw pointer and a wider primitive array head must stay narrows /
+    /// aliases, since erasing those would drop a pointee class the
+    /// annotator still needs.
+    #[test]
+    fn raw_byte_ptr_recognizes_only_the_byte_pointee() {
+        let llbc = llbc_with_trait_impls(serde_json::json!([]));
+        let ptr_to = |pointee: serde_json::Value| {
+            TyRef::Other(serde_json::json!({ "RawPtr": [pointee, "Mut"] }))
+        };
+        for pointee in ["U8", "I8"] {
+            assert!(
+                tyref_is_raw_byte_ptr(
+                    &ptr_to(serde_json::json!({"Literal": {"UInt": pointee}})),
+                    &llbc
+                ),
+                "*mut {pointee} is the erased address pointer"
+            );
+        }
+        assert!(!tyref_is_raw_byte_ptr(
+            &ptr_to(serde_json::json!({"Literal": {"Int": "I64"}})),
+            &llbc
+        ));
+        assert!(!tyref_is_raw_byte_ptr(
+            &ptr_to(serde_json::json!({"Adt": {"id": {"Builtin": "Str"}}})),
+            &llbc
+        ));
+        // A bare `u8` (no pointer around it) is not an address either.
+        assert!(!tyref_is_raw_byte_ptr(
+            &TyRef::Other(serde_json::json!({"Literal": {"UInt": "U8"}})),
+            &llbc
+        ));
+    }
+
     fn rows(spec: &[(&str, &str)]) -> Vec<(String, String)> {
         spec.iter()
             .map(|(n, t)| (n.to_string(), t.to_string()))
@@ -22009,6 +22587,44 @@ mod tests {
         assert!(
             checked >= 1,
             "object_functionstr_type_name: expected a niche `ne` null-test switch block"
+        );
+    }
+
+    /// Anchor the fieldless-enum `PartialEq` fold to the real lowered IR of
+    /// `strategy_is` — `current.strategy_kind() == expected.strategy_kind()`
+    /// over the fieldless `StrategyKind`.  Both operands come back in the int
+    /// bank, so the derived `eq` must fold to `BinOp("eq")`; leaving it a
+    /// `Method` call blocks the annotator with `Cannot find attribute "eq" on
+    /// Integer`.  Ignored by default (loads the real LLBC).
+    #[test]
+    #[ignore]
+    fn fieldless_enum_eq_fold_real_strategy_is() {
+        use crate::model::{CallTarget, OpKind};
+
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../build/llbc/pyre-object.ullbc"
+        );
+        let llbc = Llbc::load(path).expect("load real LLBC");
+        let graph = super::lower_function(&llbc, "pyre_object::dictmultiobject::strategy_is")
+            .expect("lower strategy_is");
+        let ops = || graph.blocks.iter().flat_map(|b| b.operations.iter());
+        assert_eq!(
+            ops()
+                .filter(|op| matches!(
+                    &op.kind,
+                    OpKind::Call { target: CallTarget::Method { name, .. }, .. } if name == "eq"
+                ))
+                .count(),
+            0,
+            "no residual `eq` Method call survives the fold"
+        );
+        assert_eq!(
+            ops()
+                .filter(|op| matches!(&op.kind, OpKind::BinOp { op, .. } if op == "eq"))
+                .count(),
+            1,
+            "the discriminant comparison lowers to one int `BinOp(eq)`"
         );
     }
 }

--- a/majit/majit-translate/src/front/mod.rs
+++ b/majit/majit-translate/src/front/mod.rs
@@ -67,11 +67,14 @@
 pub(crate) mod bigint_binop;
 pub(crate) mod bool_then;
 pub(crate) mod checked_arith;
+pub(crate) mod checked_arith_uint;
+pub(crate) mod from_size_align;
 pub(crate) mod graph_body;
 pub(crate) mod iter_next;
 pub mod llbc_hints;
 pub mod mir;
 pub(crate) mod option_closure_select;
+pub(crate) mod option_expect;
 pub(crate) mod option_is_none;
 pub(crate) mod option_map_or;
 pub(crate) mod option_try;

--- a/majit/majit-translate/src/front/option_expect.rs
+++ b/majit/majit-translate/src/front/option_expect.rs
@@ -1,0 +1,355 @@
+//! `Option::expect(opt, msg)` → discriminant guard + payload extraction.
+//!
+//! ## Positioning
+//!
+//! `core::option::<Impl>::expect` is a foreign combinator whose body is Opaque
+//! in the LLBC (Charon cannot extract `core`), so the caller emits a residual
+//! `expect` call — an unregistered callee the rtyper census Skips.  Like
+//! [`crate::front::option_unwrap`] the combinator's match lives inside the
+//! opaque body: at the call site there is only `result = expect(opt, msg)`
+//! flowing on.  This pass creates the guard the combinator's semantics imply:
+//!
+//! ```text
+//!     result = opt.expect(msg)            // residual `expect` call
+//! becomes
+//!     if opt.__discriminant == 1 { result = opt.__pos_0 } else { <panic> }
+//! ```
+//!
+//! It is the two-argument sibling of `Option::unwrap`: `expect` panics on `None`
+//! with the caller-supplied `&str` message.  The message argument is dropped —
+//! the `None` arm is not a value path but an implicit-`AssertionError` raise
+//! ([`FunctionGraph::set_raise_implicit`]), the "shouldn't occur at run-time"
+//! shape [`crate::model::remove_assertion_errors`] prunes, matching `expect`'s
+//! never-`None` contract.  The runtime message never reaches the raise, so its
+//! producing op is left dead for the reachability sweep.  The `Some` arm reads
+//! `opt.__pos_0` exactly as `unwrap`'s does.  `Option`'s tags are `None = 0` /
+//! `Some = 1`, so branching on `bool(disc)` selects the `Some` arm.
+//!
+//! ## The rewrite (`rewire_one_expect_site`)
+//!
+//! Block A holds the residual `expect` call producing `result` as its last op,
+//! closed by `lower_call` with a single forwarding exit to block B (the
+//! continuation consuming `result`).  The rewrite:
+//! 1. drops the `expect` call, reads `disc = opt.__discriminant`, and closes A
+//!    with a `bool(disc)` branch to two fresh arms;
+//! 2. the `then_bb` (`Some`) arm reads `opt.__pos_0` and forwards it to B as
+//!    the `result` slot, threading every other live value through;
+//! 3. the `else_bb` (`None`) arm raises the implicit `AssertionError` (no edge
+//!    to B — the `None` path never produces a `result`).
+//!
+//! It is **fail-safe**: any structural mismatch returns `Err`, the caller
+//! leaves the residual call untouched, and the unregistered `expect` callee
+//! keeps the rtyper census Skip (no regression vs the legacy walker).
+
+use crate::flowspace::model::Variable;
+use crate::front::bool_then::{close_goto_mixed, map_source, reproduce_exit_args};
+use crate::model::{FieldDescriptor, FunctionGraph, LinkArg, OpKind, SpaceOperation, ValueType};
+
+/// A recognized `Option::expect(opt, msg)` call site captured during body
+/// lowering (`front::mir` `recognize_expect_site`).  The owner strings are
+/// resolved at the recording site where the receiver `Option` type is in hand;
+/// the post-pass only needs them to spell the `__discriminant` / `__pos_0`
+/// field reads in the synthesized `Some` arm.
+#[derive(Clone)]
+pub(crate) struct ExpectSite {
+    /// The `expect` call result (the payload `T` value) — locates block A.
+    pub result_var: Variable,
+    /// The `Option` enum root `name_path` — the `__discriminant` field owner.
+    pub option_owner: String,
+    /// The `Option::Some` variant `name_path` — the `__pos_0` payload field
+    /// owner (matching the variant-qualified `resolve_adt_field` read owner).
+    pub some_owner: String,
+    /// The `Option`'s payload `T` projected to a [`ValueType`] — the
+    /// `Some::__pos_0` field kind and the extracted result kind.
+    pub payload_ty: ValueType,
+    /// True when the receiver is a niche `Option<NonNull<_>>` — a one-word
+    /// pointer with no aggregate `__discriminant` / `__pos_0`.  The `Some`-arm
+    /// discriminant is then `opt != null` and the payload is the base pointer
+    /// itself (identity), not a `__pos_0` field read.
+    pub niche: bool,
+}
+
+/// Rewrite every recorded `Option::expect` call site into the discriminant
+/// guard.  Fail-safe: a site whose block does not fit the residual-call shape
+/// is left untouched (Skip), so a mismatch never regresses a graph the legacy
+/// walker already handled.  Returns the number of sites rewritten.
+pub(crate) fn rewire_expect_call_sites(graph: &mut FunctionGraph, sites: &[ExpectSite]) -> usize {
+    let mut rewritten = 0;
+    for site in sites {
+        match rewire_one_expect_site(graph, site) {
+            Ok(()) => rewritten += 1,
+            Err(_decline) => {
+                // Leave the residual `expect` call; the unregistered callee
+                // keeps the rtyper census Skip for this graph.
+            }
+        }
+    }
+    rewritten
+}
+
+fn rewire_one_expect_site(graph: &mut FunctionGraph, site: &ExpectSite) -> Result<(), String> {
+    let name = graph.name.clone();
+    // Block A: the `expect` residual call producing `result_var`.
+    let a = graph
+        .blocks
+        .iter()
+        .position(|b| {
+            b.operations
+                .iter()
+                .any(|op| op.result.as_ref() == Some(&site.result_var))
+        })
+        .ok_or_else(|| format!("{name}: expect result var has no producer block"))?;
+
+    // The call must be A's last op (lower_call closes the block right after
+    // pushing it) so removing it leaves the receiver construction as the tail.
+    let call_idx = graph.blocks[a].operations.len() - 1;
+    if graph.blocks[a].operations[call_idx].result.as_ref() != Some(&site.result_var) {
+        return Err(format!(
+            "{name}: expect call is not the last op of block {a}"
+        ));
+    }
+    // Capture the receiver `Option` operand (`args[0]`); `args[1]` is the
+    // panic-message `&str`, dropped — the `None` arm raises without it.
+    let opt = match &graph.blocks[a].operations[call_idx].kind {
+        OpKind::Call { args, .. } if args.len() == 2 => args[0].clone(),
+        other => {
+            return Err(format!(
+                "{name}: expect producer op is not a 2-arg call: {other:?}"
+            ));
+        }
+    };
+
+    // A's single exit → B (the continuation consuming the payload).  Must be a
+    // plain goto — `lower_call` closes with exactly this shape.
+    let [exit] = graph.blocks[a].exits.as_slice() else {
+        return Err(format!(
+            "{name}: expect call block {a} does not have a single exit"
+        ));
+    };
+    if exit.exitcase.is_some() || exit.last_exception.is_some() || exit.last_exc_value.is_some() {
+        return Err(format!(
+            "{name}: expect call block {a} exit is not a plain goto"
+        ));
+    }
+    let saved_exit = exit.clone();
+    let b_target = saved_exit.target;
+
+    // `carried` = the distinct live Values A forwards to B other than the
+    // payload itself; each must be threaded through the `Some` arm to reach B.
+    // The `None` arm raises and never reaches B, so it carries nothing.
+    let mut carried: Vec<Variable> = Vec::new();
+    for arg in &saved_exit.args {
+        if let LinkArg::Value(v) = arg
+            && *v != site.result_var
+            && !carried.contains(v)
+        {
+            carried.push(v.clone());
+        }
+    }
+
+    // --- All structural validation passed; mutate the graph. ---
+
+    // `then_bb` (`Some`) carries `carried` plus `opt` (the base for the
+    // `__pos_0` read); `else_bb` (`None`) has no inputs — it raises.  The
+    // source-var lists double as the branch link args.
+    let mut then_sources = carried.clone();
+    if !then_sources.contains(&opt) {
+        then_sources.push(opt.clone());
+    }
+    let (then_bb, then_inputs) = graph.create_block_with_arg_vars(then_sources.len());
+    let (else_bb, _else_inputs) = graph.create_block_with_arg_vars(0);
+
+    // `then_bb`: payload = opt.__pos_0.  A niche `Option<NonNull>` has no
+    // aggregate `__pos_0`; the payload IS the base pointer (identity).
+    let opt_in_then = map_source(&then_sources, &then_inputs, &opt)
+        .ok_or_else(|| format!("{name}: Option value not threaded into Some arm"))?;
+    let payload = if site.niche {
+        opt_in_then
+    } else {
+        let payload = graph.alloc_value_var();
+        graph.block_mut(then_bb).operations.push(SpaceOperation {
+            result: Some(payload.clone()),
+            kind: OpKind::FieldRead {
+                base: opt_in_then,
+                field: FieldDescriptor {
+                    name: "__pos_0".to_string(),
+                    owner_root: Some(site.some_owner.clone()),
+                    owner_id: None,
+                },
+                ty: site.payload_ty.clone(),
+                pure: true,
+            },
+        });
+        payload
+    };
+    let then_link_args = reproduce_exit_args(
+        &saved_exit,
+        &site.result_var,
+        &payload,
+        &then_sources,
+        &then_inputs,
+        &name,
+    )?;
+    close_goto_mixed(graph, then_bb, b_target, then_link_args);
+
+    // `else_bb` (`None`): raise the implicit `AssertionError` — `expect` panics
+    // on `None`, and the never-`None` contract makes this the "shouldn't occur"
+    // shape `remove_assertion_errors` prunes.
+    graph.set_raise_implicit(else_bb, "Option::expect on None value");
+
+    // A: drop the residual `expect` call, read the discriminant, branch on it.
+    // `Option` tags None=0 / Some=1, so `bool(disc)` selects the `Some` (then)
+    // arm.  The receiver construction ops stay as A's tail.
+    let a_id = graph.blocks[a].id;
+    graph.blocks[a].operations.remove(call_idx);
+    let disc = graph.alloc_value_var();
+    if site.niche {
+        // Niche `Option<NonNull>`: discriminant = `opt != null` (`None` = null
+        // = 0, `Some` = non-null = 1) — a `ne` on two `Ref` operands lowers to
+        // `ptr_ne` with an `Int` result matching the aggregate read.  The null
+        // is a repr-adaptive `null_mut()` call, not a fixed-GCREF
+        // `ConstRefNull`, so `ptr_ne` sees the receiver's `InstanceRepr`.
+        let nullc = graph.push_null_mut_ptr(a_id);
+        graph.block_mut(a_id).operations.push(SpaceOperation {
+            result: Some(disc.clone()),
+            kind: OpKind::BinOp {
+                op: "ne".to_string(),
+                lhs: opt.clone(),
+                rhs: nullc,
+                result_ty: ValueType::Int,
+            },
+        });
+    } else {
+        graph.block_mut(a_id).operations.push(SpaceOperation {
+            result: Some(disc.clone()),
+            kind: OpKind::FieldRead {
+                base: opt.clone(),
+                field: FieldDescriptor {
+                    name: "__discriminant".to_string(),
+                    owner_root: Some(site.option_owner.clone()),
+                    owner_id: None,
+                },
+                ty: ValueType::Int,
+                pure: true,
+            },
+        });
+    }
+    graph.set_branch(a_id, disc, then_bb, then_sources, else_bb, Vec::new());
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::CallTarget;
+
+    fn expect_target() -> CallTarget {
+        CallTarget::method("expect", None)
+    }
+
+    /// Build `result = opt.expect(msg)` closed by a goto to a continuation
+    /// block consuming `result`, and assert the rewrite drops the `expect`
+    /// call, reads `opt.__discriminant`, branches, extracts `opt.__pos_0` in
+    /// the `Some` arm, and raises in the `None` arm.
+    #[test]
+    fn rewrite_lifts_expect_to_discriminant_guard() {
+        let mut g = FunctionGraph::new("test_option_expect");
+        let a = g.startblock;
+        let opt = g.push_op_var(a, OpKind::ConstInt(0), true).unwrap();
+        let msg = g.push_op_var(a, OpKind::ConstInt(1), true).unwrap();
+        let result = g
+            .push_op_var(
+                a,
+                OpKind::Call {
+                    target: expect_target(),
+                    args: vec![opt.clone(), msg],
+                    result_ty: ValueType::Int,
+                },
+                true,
+            )
+            .unwrap();
+        let (b, _b_args) = g.create_block_with_arg_vars(1);
+        g.set_return(b, None);
+        g.set_goto(a, b, vec![result.clone()]);
+
+        let rewritten = rewire_expect_call_sites(
+            &mut g,
+            &[ExpectSite {
+                result_var: result.clone(),
+                option_owner: "core::option::Option".to_string(),
+                some_owner: "core::option::Option::Some".to_string(),
+                payload_ty: ValueType::Int,
+                niche: false,
+            }],
+        );
+        assert_eq!(rewritten, 1, "the expect site must be rewritten");
+
+        // The residual `expect` call is gone.
+        let has_expect_call = g.blocks.iter().flat_map(|blk| &blk.operations).any(|op| {
+            matches!(
+                &op.kind,
+                OpKind::Call { target: CallTarget::Method { name, .. }, .. } if name == "expect"
+            )
+        });
+        assert!(!has_expect_call, "residual expect call removed");
+
+        // A `__discriminant` read and a `__pos_0` read exist.
+        let field_reads: Vec<String> = g
+            .blocks
+            .iter()
+            .flat_map(|blk| &blk.operations)
+            .filter_map(|op| match &op.kind {
+                OpKind::FieldRead { field, .. } => Some(field.name.clone()),
+                _ => None,
+            })
+            .collect();
+        assert!(
+            field_reads.iter().any(|n| n == "__discriminant"),
+            "discriminant read emitted"
+        );
+        assert!(
+            field_reads.iter().any(|n| n == "__pos_0"),
+            "Some-arm payload read emitted"
+        );
+
+        // Exactly one arm raises to the exceptblock (the `None` arm).
+        let raises = g
+            .blocks
+            .iter()
+            .filter(|blk| blk.exits.iter().any(|link| link.target == g.exceptblock))
+            .count();
+        assert_eq!(raises, 1, "the None arm raises to exceptblock");
+    }
+
+    /// A producer op that is not a 2-arg call declines (fail-safe).
+    #[test]
+    fn rewrite_declines_when_producer_not_binary_call() {
+        let mut g = FunctionGraph::new("test_option_expect_decline");
+        let a = g.startblock;
+        let opt = g.push_op_var(a, OpKind::ConstInt(0), true).unwrap();
+        let result = g
+            .push_op_var(
+                a,
+                OpKind::Call {
+                    target: expect_target(),
+                    args: vec![opt],
+                    result_ty: ValueType::Int,
+                },
+                true,
+            )
+            .unwrap();
+        g.set_return(a, None);
+
+        let rewritten = rewire_expect_call_sites(
+            &mut g,
+            &[ExpectSite {
+                result_var: result,
+                option_owner: "core::option::Option".to_string(),
+                some_owner: "core::option::Option::Some".to_string(),
+                payload_ty: ValueType::Int,
+                niche: false,
+            }],
+        );
+        assert_eq!(rewritten, 0, "a non-binary producer declines");
+    }
+}

--- a/majit/majit-translate/src/front/option_try.rs
+++ b/majit/majit-translate/src/front/option_try.rs
@@ -32,9 +32,6 @@
 //! leaves the residual `branch` call untouched, and the graph keeps its
 //! existing rtyper Skip / legacy-walker fallback.
 
-use majit_charon_reader::Llbc;
-use majit_charon_reader::ullbc::TyRef;
-
 use crate::flowspace::model::{ConstValue, Constant, Variable};
 use crate::front::bool_then::{emit_option_variant, map_source};
 use crate::front::result_exc::{
@@ -74,19 +71,6 @@ pub(crate) struct OptionTryStats {
     pub declined: usize,
 }
 
-/// The `Option` enum root name for `ty`, or `None` when `ty` is not
-/// `core::option::Option<...>`.
-pub(crate) fn tyref_option_owner(ty: &TyRef, llbc: &Llbc) -> Option<String> {
-    let body = match ty {
-        TyRef::Inline { value: (_, v) } => v,
-        TyRef::Other(v) => v,
-        TyRef::Dedup { id } => llbc.dedup_body(*id)?,
-    };
-    let id = body.get("Adt")?.get("id")?.get("Adt")?.as_u64()?;
-    let owner = llbc.type_by_id(id)?.item_meta.name_path();
-    (owner == "core::option::Option").then_some(owner)
-}
-
 /// Rewrite every recorded `Option` `Try::branch` site.  `return_option_owner`
 /// is the enclosing function's declared `Option<U>` root; `None` means the
 /// function is not Option-returning, so all sites decline.
@@ -122,12 +106,13 @@ fn rewire_one_option_try_site(
     let Some(return_option_owner) = return_option_owner else {
         return Err(format!("{name}: enclosing function does not return Option"));
     };
-    if return_option_owner != site.option_owner {
-        return Err(format!(
-            "{name}: branched Option owner {} differs from return owner {}",
-            site.option_owner, return_option_owner
-        ));
-    }
+    // The branched Option owner (`site.option_owner`, the payload read at the
+    // `?`) and the enclosing function's return Option owner may differ under
+    // per-instantiation classdef spelling — a cross-payload `?` branches one
+    // Option<A> and returns Option<B>.  The Some arm reads `__pos_0`/
+    // `__discriminant` from the branched owners; the None arm constructs from
+    // `return_option_owner`.  The arms are independent, so no equality is
+    // required here.
     if graph.blocks[graph.returnblock.0].inputargs.len() != 1 {
         return Err(format!(
             "{name}: Option-returning function returnblock is not unary"

--- a/majit/majit-translate/src/front/result_exc.rs
+++ b/majit/majit-translate/src/front/result_exc.rs
@@ -1736,6 +1736,19 @@ fn try_fuse_drain_match(graph: &mut FunctionGraph, a: usize, r: &Variable) -> Re
             {
                 op.result.clone().map(|m| (i, m))
             }
+            // The derived `PyErrorKind::eq` between two fieldless enums lowers
+            // to a discriminant `BinOp { op: "eq" }` (both operands sit in the
+            // int bank), the twin of the `sc` ConstInt form handled above. Pin
+            // the operands to exactly `{kind_var, sc}` in either order — as
+            // strict as the `Method` `args.contains` pair — so a comparison
+            // against any other kind can never fuse into a StopIteration test.
+            OpKind::BinOp { op: binop, lhs, rhs, .. }
+                if binop == "eq"
+                    && ((*lhs == kind_var && *rhs == sc)
+                        || (*lhs == sc && *rhs == kind_var)) =>
+            {
+                op.result.clone().map(|m| (i, m))
+            }
             _ => None,
         })
         .ok_or_else(|| format!("{name}: drain fuse: Err arm lacks the PyErrorKind::eq call"))?;

--- a/majit/majit-translate/src/front/result_exc.rs
+++ b/majit/majit-translate/src/front/result_exc.rs
@@ -1742,10 +1742,13 @@ fn try_fuse_drain_match(graph: &mut FunctionGraph, a: usize, r: &Variable) -> Re
             // the operands to exactly `{kind_var, sc}` in either order — as
             // strict as the `Method` `args.contains` pair — so a comparison
             // against any other kind can never fuse into a StopIteration test.
-            OpKind::BinOp { op: binop, lhs, rhs, .. }
-                if binop == "eq"
-                    && ((*lhs == kind_var && *rhs == sc)
-                        || (*lhs == sc && *rhs == kind_var)) =>
+            OpKind::BinOp {
+                op: binop,
+                lhs,
+                rhs,
+                ..
+            } if binop == "eq"
+                && ((*lhs == kind_var && *rhs == sc) || (*lhs == sc && *rhs == kind_var)) =>
             {
                 op.result.clone().map(|m| (i, m))
             }

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -1613,6 +1613,35 @@ pub fn translate_op(
                         ))));
                         return Ok(vec![FlowspaceOp::new("simple_call", call_args, result)]);
                     }
+                    // `__pyre_cast_address` — the erasing twin of the narrow
+                    // above (`front::mir` emits it for `p as *mut u8`).  It
+                    // carries no root, so the reconstruction is the plain
+                    // `simple_call(callable, operand)`; resolving through the
+                    // HOST_ENV singleton keeps the Arc identity that keys its
+                    // `BUILTIN_TYPER` entry, which a single-segment path
+                    // consulting the `PyreCallRegistry` first would lose.
+                    if segments.len() == 1 && segments[0] == "__pyre_cast_address" {
+                        if arg_hls.len() != 1 {
+                            return Err(TyperError::message(format!(
+                                "__pyre_cast_address requires exactly one operand, got {}",
+                                arg_hls.len()
+                            )));
+                        }
+                        let callable_host = HOST_ENV
+                            .lookup_builtin("__pyre_cast_address")
+                            .ok_or_else(|| {
+                                TyperError::message(
+                                    "__pyre_cast_address missing from HOST_ENV bootstrap"
+                                        .to_string(),
+                                )
+                            })?;
+                        let mut call_args = Vec::with_capacity(arg_hls.len() + 1);
+                        call_args.push(Hlvalue::Constant(Constant::new(ConstValue::HostObject(
+                            callable_host,
+                        ))));
+                        call_args.extend(arg_hls);
+                        return Ok(vec![FlowspaceOp::new("simple_call", call_args, result)]);
+                    }
                     // `front::range_iter`'s synthesized `range(start, stop)`
                     // (the exclusive int-`Range` for-loop divert).  It carries
                     // the reserved `__pyre_range` spelling rather than a bare

--- a/majit/majit-translate/src/translator/rtyper/lltypesystem/lloperation.rs
+++ b/majit/majit-translate/src/translator/rtyper/lltypesystem/lloperation.rs
@@ -324,6 +324,11 @@ pub fn ll_operations() -> &'static HashMap<&'static str, LLOp> {
         );
         insert_llop(
             &mut ops,
+            "uint_mul_high",
+            LLOp::new(true, true, &[], false, false, false, false),
+        );
+        insert_llop(
+            &mut ops,
             "uint_floordiv",
             LLOp::new(true, true, &[], false, false, false, false),
         );

--- a/majit/majit-translate/src/translator/rtyper/lltypesystem/opimpl.rs
+++ b/majit/majit-translate/src/translator/rtyper/lltypesystem/opimpl.rs
@@ -602,6 +602,14 @@ pub fn op_uint_mul(args: &[ConstValue]) -> Option<ConstValue> {
     Some(ConstValue::Int(a.wrapping_mul(b) as i64))
 }
 
+/// High 64 bits of the unsigned 64x64 -> 128 product — the overflow high
+/// word `checked_mul` tests. Matches the backend `OpCode::UintMulHigh`
+/// (`umulhi`) and `bhimpl_uint_mul_high`.
+pub fn op_uint_mul_high(args: &[ConstValue]) -> Option<ConstValue> {
+    let (a, b) = uint_pair(args)?;
+    Some(ConstValue::Int((((a as u128) * (b as u128)) >> 64) as i64))
+}
+
 pub fn op_uint_floordiv(args: &[ConstValue]) -> Option<ConstValue> {
     let (a, b) = uint_pair(args)?;
     if b == 0 {
@@ -1596,6 +1604,7 @@ pub fn get_op_impl(opname: &str) -> Option<FoldFn> {
         m.insert("uint_add", op_uint_add);
         m.insert("uint_sub", op_uint_sub);
         m.insert("uint_mul", op_uint_mul);
+        m.insert("uint_mul_high", op_uint_mul_high);
         m.insert("uint_floordiv", op_uint_floordiv);
         m.insert("uint_mod", op_uint_mod);
         m.insert("uint_lshift", op_uint_lshift);

--- a/majit/majit-translate/src/translator/rtyper/rbuiltin.rs
+++ b/majit/majit-translate/src/translator/rtyper/rbuiltin.rs
@@ -234,6 +234,12 @@ fn install_default_typers(map: &mut HashMap<HostObject, BuiltinTyperFn>) {
         // adapter resolves the call's callable to), lowers to a
         // `cast_pointer` into the narrowed `InstanceRepr`.
         ("__pyre_cast_instance", rtype_pyre_cast_instance),
+        // The erasing twin (`p as *mut u8`).  Its annotator dropped the
+        // pointee class, so `hop.r_result` is the classdef-less
+        // `InstanceRepr` and the same `cast_pointer` body applies — this
+        // time as the upcast direction of `pairtype(InstanceRepr,
+        // InstanceRepr).convert_from_to`.
+        ("__pyre_cast_address", rtype_pyre_cast_instance),
     ];
     for (name, typer) in entries {
         if let Some(host) = HOST_ENV.lookup_builtin(name) {
@@ -3588,16 +3594,20 @@ pub fn rtype_cast_int_to_ptr(hop: &HighLevelOp, _kwds_i: &HashMap<String, usize>
     Ok(hop.genop("cast_int_to_ptr", vlist, GenopResult::LLType(result_lltype)))
 }
 
-/// `__pyre_cast_instance` typer — front-end pointer-downcast narrow
-/// (#298).  The annotator typed the result as `SomeInstance(root)`, so
-/// `hop.r_result` is the target `InstanceRepr`; lower the call to a
-/// `cast_pointer` of the pointer operand to that lowleveltype.  This
-/// mirrors `pairtype(InstanceRepr, InstanceRepr).convert_from_to`
-/// (rclass.py:1035) — the same `genop('cast_pointer', [v],
-/// resulttype=r_ins2.lowleveltype)` it emits for the `r_ins1.classdef is
-/// None` (classdef-less → concrete) arm.  `args[0]` is the pointer
-/// operand; `args[1]` is the constant root name (read by the annotator,
-/// unused here — it carries no runtime value).
+/// Typer for both front-end pointer-cast markers — the
+/// `__pyre_cast_instance` downcast narrow (#298) and the
+/// `__pyre_cast_address` erasure.  Either way the annotator has already
+/// decided the result's `InstanceRepr` (the target root, or the
+/// classdef-less shell), so `hop.r_result` names the destination and the
+/// call lowers to a `cast_pointer` of the pointer operand to that
+/// lowleveltype.  This mirrors `pairtype(InstanceRepr,
+/// InstanceRepr).convert_from_to` (rclass.py:1035) — the same
+/// `genop('cast_pointer', [v], resulttype=r_ins2.lowleveltype)` it emits
+/// for the `r_ins1.classdef is None` (classdef-less → concrete) arm, run
+/// in one direction by the narrow and the other by the erasure.
+/// `args[0]` is the pointer operand; the narrow's `args[1]` is the
+/// constant root name (read by the annotator, unused here — it carries
+/// no runtime value).
 pub fn rtype_pyre_cast_instance(
     hop: &HighLevelOp,
     _kwds_i: &HashMap<String, usize>,

--- a/majit/majit-translate/src/translator/rtyper/rtyper.rs
+++ b/majit/majit-translate/src/translator/rtyper/rtyper.rs
@@ -2197,6 +2197,17 @@ impl RPythonTyper {
             }
             "cmp" => self.translate_pair_operation(hop, super::pairtype::pair_rtype_cmp),
             "coerce" => self.translate_pair_operation(hop, super::pairtype::pair_rtype_coerce),
+            // `front::checked_arith_uint` emits these unsigned overflow-test
+            // ops with the low-level opname already fixed (not the generic
+            // `mul`/`lt` the pairtype dispatch lowers by repr): the widening
+            // multiply's high word (`checked_mul`) and the wrapped-sum carry
+            // compare (`checked_add`).  Both operands are Unsigned, so the
+            // integer templates rebuild the identical `uint_` opname and emit
+            // it once — `uint_mul_high` (Unsigned result) through
+            // `rtype_template`, `uint_lt` (Bool result) through
+            // `rtype_compare_template`, exactly as `mul` / `lt` route.
+            "uint_mul_high" => super::rint::rtype_template(hop, "mul_high"),
+            "uint_lt" => super::rint::rtype_compare_template(hop, "lt"),
             // rtyper.py:547-549 — `translate_op_newtuple` calls the
             // free function `rtuple.rtype_newtuple(hop)` which routes
             // to `TupleRepr._rtype_newtuple`. No per-Repr dispatch.

--- a/pyre/pyre-interpreter/src/display.rs
+++ b/pyre/pyre-interpreter/src/display.rs
@@ -162,34 +162,51 @@ thread_local! {
         const { std::cell::RefCell::new(Vec::new()) };
 }
 
+/// Record `obj` as mid-repr on this thread, or report `false` when it already
+/// is (`Py_ReprEnter`).  Writes the runtime-mutable `REPR_ACTIVE` thread-local,
+/// not a build-time constant, so the JIT residualises the call instead of
+/// tracing into it (`@dont_look_inside`, the `eval::set_in_flight_exception`
+/// shape), the [`repr_leave`] twin.
+#[majit_macros::dont_look_inside]
+pub(crate) fn repr_enter(obj: PyObjectRef) -> bool {
+    let key = obj as usize;
+    REPR_ACTIVE.with(|active| {
+        let mut active = active.borrow_mut();
+        if active.contains(&key) {
+            false
+        } else {
+            active.push(key);
+            true
+        }
+    })
+}
+
+/// Drop `obj` from the mid-repr set (`Py_ReprLeave`) — see [`repr_enter`].
+#[majit_macros::dont_look_inside]
+pub(crate) fn repr_leave(obj: PyObjectRef) {
+    let key = obj as usize;
+    REPR_ACTIVE.with(|active| {
+        let mut active = active.borrow_mut();
+        if let Some(pos) = active.iter().rposition(|&k| k == key) {
+            active.remove(pos);
+        }
+    });
+}
+
 /// RAII cycle guard.  `enter` returns `None` when `obj` is already being
 /// repr'd on this thread — the caller emits the `...` placeholder — and
 /// otherwise records `obj`, removing it again when the guard drops.
-pub(crate) struct ReprGuard(usize);
+pub(crate) struct ReprGuard(PyObjectRef);
 
 impl ReprGuard {
     pub(crate) fn enter(obj: PyObjectRef) -> Option<ReprGuard> {
-        let key = obj as usize;
-        REPR_ACTIVE.with(|active| {
-            let mut active = active.borrow_mut();
-            if active.contains(&key) {
-                None
-            } else {
-                active.push(key);
-                Some(ReprGuard(key))
-            }
-        })
+        repr_enter(obj).then_some(ReprGuard(obj))
     }
 }
 
 impl Drop for ReprGuard {
     fn drop(&mut self) {
-        REPR_ACTIVE.with(|active| {
-            let mut active = active.borrow_mut();
-            if let Some(pos) = active.iter().rposition(|&k| k == self.0) {
-                active.remove(pos);
-            }
-        });
+        repr_leave(self.0);
     }
 }
 

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -127,6 +127,18 @@ fn push_current_frame_previous_root(
     }
 }
 
+/// Flat TLS read of the per-thread `CURRENT_FRAME` slot — the frame a builtin
+/// was called from, since a builtin call creates no Python frame of its own.
+/// Null when no frame is installed.
+///
+/// The slot is runtime-mutable, not a build-time constant, so the JIT
+/// residualises the read instead of tracing into it (`@dont_look_inside`, the
+/// [`get_current_exception`] shape).
+#[majit_macros::dont_look_inside]
+pub fn current_frame() -> *mut PyFrame {
+    CURRENT_FRAME.with(|current| current.get())
+}
+
 pub fn install_current_frame(frame: &mut PyFrame) -> CurrentFrameGuard {
     let previous = CURRENT_FRAME.with(|current| {
         let previous = current.get();

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -2064,19 +2064,24 @@ impl SharedOpcodeHandler for PyFrame {
     }
 
     fn load_special_attr(&mut self, obj: Self::Value, name: &str) -> Result<Self::Value, PyError> {
-        let w_type = crate::typedef::r#type(obj).ok_or_else(|| {
-            PyError::type_error(format!(
-                "'{}' object does not support the context manager protocol",
-                crate::baseobjspace::object_functionstr_type_name(obj)
-            ))
-        })?;
-        let descr = unsafe { crate::baseobjspace::lookup_in_type(w_type.as_ptr(), name) }
-            .ok_or_else(|| {
-                PyError::type_error(format!(
+        let w_type = match crate::typedef::r#type(obj) {
+            Some(t) => t,
+            None => {
+                return Err(PyError::type_error(format!(
                     "'{}' object does not support the context manager protocol",
                     crate::baseobjspace::object_functionstr_type_name(obj)
-                ))
-            })?;
+                )));
+            }
+        };
+        let descr = match unsafe { crate::baseobjspace::lookup_in_type(w_type.as_ptr(), name) } {
+            Some(d) => d,
+            None => {
+                return Err(PyError::type_error(format!(
+                    "'{}' object does not support the context manager protocol",
+                    crate::baseobjspace::object_functionstr_type_name(obj)
+                )));
+            }
+        };
         Ok(unsafe { crate::baseobjspace::get(descr, obj, w_type.as_ptr()) }?.unwrap_or(descr))
     }
 

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -1086,6 +1086,51 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         "pyre_interpreter::sys_modules_registry_get",
         sys_modules_registry_get as *const (),
     );
+    // The same shape over four more runtime-mutable cells:
+    // `_io::unsupported_operation_type` reads the `UNSUPPORTED_OPERATION_TYPE`
+    // `OnceLock` the `_io` module init stamps with its module-local
+    // `UnsupportedOperation` class, `eval::current_frame` the `CURRENT_FRAME`
+    // thread-local `install_current_frame` moves, the two `display::repr_*`
+    // twins the `REPR_ACTIVE` mid-repr set (the
+    // `note_eval_activation_{enter,exit}` twin shape), and `autoflusher_add`
+    // the `AUTOFLUSHER` thread-local handle table.
+    let unsupported_operation_type: fn() -> pyre_object::PyObjectRef =
+        crate::module::_io::unsupported_operation_type;
+    push_alias_pair(
+        &mut entries,
+        "pyre_interpreter::module::_io::unsupported_operation_type",
+        "pyre_interpreter::unsupported_operation_type",
+        unsupported_operation_type as *const (),
+    );
+    let current_frame: fn() -> *mut crate::pyframe::PyFrame = crate::eval::current_frame;
+    push_alias_pair(
+        &mut entries,
+        "pyre_interpreter::eval::current_frame",
+        "pyre_interpreter::current_frame",
+        current_frame as *const (),
+    );
+    let repr_enter: fn(pyre_object::PyObjectRef) -> bool = crate::display::repr_enter;
+    push_alias_pair(
+        &mut entries,
+        "pyre_interpreter::display::repr_enter",
+        "pyre_interpreter::repr_enter",
+        repr_enter as *const (),
+    );
+    let repr_leave: fn(pyre_object::PyObjectRef) = crate::display::repr_leave;
+    push_alias_pair(
+        &mut entries,
+        "pyre_interpreter::display::repr_leave",
+        "pyre_interpreter::repr_leave",
+        repr_leave as *const (),
+    );
+    let autoflusher_add: fn(pyre_object::PyObjectRef) -> pyre_object::PyObjectRef =
+        crate::module::_io::autoflusher_add;
+    push_alias_pair(
+        &mut entries,
+        "pyre_interpreter::module::_io::autoflusher_add",
+        "pyre_interpreter::autoflusher_add",
+        autoflusher_add as *const (),
+    );
     let warnings_state_ns: fn() -> pyre_object::PyObjectRef = crate::module::_warnings::state_ns;
     push_alias_pair(
         &mut entries,

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -1921,6 +1921,78 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         "pyre_object::dict_entries_pop_last",
         pyre_object::dictmultiobject::dict_entries_pop_last as *const (),
     );
+    // The positional slot reads the post-scan lookup arms and the reentrant
+    // key scan perform: an index the caller already settled on, so no
+    // comparison runs behind these boundaries.
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::dictmultiobject::dict_entries_value_at",
+        "pyre_object::dict_entries_value_at",
+        pyre_object::dictmultiobject::dict_entries_value_at as *const (),
+    );
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::dictmultiobject::dict_entries_key_obj_at",
+        "pyre_object::dict_entries_key_obj_at",
+        pyre_object::dictmultiobject::dict_entries_key_obj_at as *const (),
+    );
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::dictmultiobject::dict_entries_key_hash_at",
+        "pyre_object::dict_entries_key_hash_at",
+        pyre_object::dictmultiobject::dict_entries_key_hash_at as *const (),
+    );
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::dictmultiobject::dict_entries_key_is_at",
+        "pyre_object::dict_entries_key_is_at",
+        pyre_object::dictmultiobject::dict_entries_key_is_at as *const (),
+    );
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::dictmultiobject::dict_entries_capacity",
+        "pyre_object::dict_entries_capacity",
+        pyre_object::dictmultiobject::dict_entries_capacity as *const (),
+    );
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::dictmultiobject::dict_entries_value_set_at",
+        "pyre_object::dict_entries_value_set_at",
+        pyre_object::dictmultiobject::dict_entries_value_set_at as *const (),
+    );
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::dictmultiobject::dict_entries_insert_object",
+        "pyre_object::dict_entries_insert_object",
+        pyre_object::dictmultiobject::dict_entries_insert_object as *const (),
+    );
+    // The index-returning twins of the `dict_entries_probe_*` pair, for
+    // `setitem_str`'s borrow-key membership test.
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::dictmultiobject::dict_entries_index_of_str_hashed",
+        "pyre_object::dict_entries_index_of_str_hashed",
+        pyre_object::dictmultiobject::dict_entries_index_of_str_hashed as *const (),
+    );
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::dictmultiobject::dict_entries_index_of_object",
+        "pyre_object::dict_entries_index_of_object",
+        pyre_object::dictmultiobject::dict_entries_index_of_object as *const (),
+    );
+    // The module-dict storage's own `String`-keyed probe / store pair.
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::celldict::module_dict_entries_get",
+        "pyre_object::module_dict_entries_get",
+        pyre_object::celldict::module_dict_entries_get as *const (),
+    );
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::celldict::module_dict_entries_insert",
+        "pyre_object::module_dict_entries_insert",
+        pyre_object::celldict::module_dict_entries_insert as *const (),
+    );
     // A runtime-mutable global counter, not a build-time constant: bind the
     // read seam by address so the JIT calls it instead of folding whatever
     // serial the build process saw.
@@ -1974,6 +2046,12 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         "pyre_object::identitydict::w_dict_delete_identity_strategy",
         "pyre_object::w_dict_delete_identity_strategy",
         pyre_object::identitydict::w_dict_delete_identity_strategy as *const (),
+    );
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::identitydict::w_dict_store_identity_strategy",
+        "pyre_object::w_dict_store_identity_strategy",
+        pyre_object::identitydict::w_dict_store_identity_strategy as *const (),
     );
     push_alias_pair(
         &mut entries,

--- a/pyre/pyre-interpreter/src/module/__pypy__/interp_buffer.rs
+++ b/pyre/pyre-interpreter/src/module/__pypy__/interp_buffer.rs
@@ -305,7 +305,7 @@ pub(crate) fn is_contiguous(obj: PyObjectRef) -> Result<bool, PyError> {
 
 /// The `memoryview` builtin type via the live execution context.
 fn memoryview_type() -> Option<PyObjectRef> {
-    let frame = crate::eval::CURRENT_FRAME.with(|f| f.get());
+    let frame = crate::eval::current_frame();
     if frame.is_null() {
         return None;
     }

--- a/pyre/pyre-interpreter/src/module/_io/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_io/mod.rs
@@ -64,17 +64,29 @@ fn iobase_set_internal_closed(obj: PyObjectRef, closed: bool) -> Result<(), crat
     }
 }
 
+/// Reads the `io.UnsupportedOperation` type installed into
+/// `UNSUPPORTED_OPERATION_TYPE` at module init; null before then.  The value is
+/// not a build-time constant, so the JIT residualises the read instead of
+/// tracing into it (`@dont_look_inside`).
+#[majit_macros::dont_look_inside]
+pub(crate) fn unsupported_operation_type() -> PyObjectRef {
+    UNSUPPORTED_OPERATION_TYPE
+        .get()
+        .map_or(std::ptr::null_mut(), |&addr| addr as PyObjectRef)
+}
+
 /// `interp_iobase.py:unsupported` — construct the module-local
 /// `UnsupportedOperation`, preserving its OSError + ValueError MRO.
 pub(crate) fn unsupported(message: &str) -> crate::PyError {
-    let Some(&type_addr) = UNSUPPORTED_OPERATION_TYPE.get() else {
+    let w_type = unsupported_operation_type();
+    if w_type.is_null() {
         return crate::PyError::value_error(message);
-    };
+    }
     let _roots = pyre_object::gc_roots::push_roots();
     let sp = pyre_object::gc_roots::shadow_stack_len();
     pyre_object::gc_roots::pin_root(w_str_new(message));
     match crate::call::call_function_impl_result(
-        type_addr as PyObjectRef,
+        w_type,
         &[pyre_object::gc_roots::shadow_stack_get(sp)],
     ) {
         Ok(exc) => unsafe { crate::PyError::from_exc_object(exc) },
@@ -278,7 +290,13 @@ thread_local! {
 /// opt out.
 ///
 /// Returns `w_iobase`, which the rweakref allocation may have relocated.
-fn autoflusher_add(w_iobase: PyObjectRef) -> PyObjectRef {
+///
+/// Reads and rewrites the runtime-mutable `AUTOFLUSHER` thread-local handle
+/// table, not a build-time constant, so the JIT residualises the call instead
+/// of tracing into it (`@dont_look_inside`, the `importing::sys_modules_dict`
+/// shape).
+#[majit_macros::dont_look_inside]
+pub(crate) fn autoflusher_add(w_iobase: PyObjectRef) -> PyObjectRef {
     if w_iobase.is_null() {
         return w_iobase;
     }

--- a/pyre/pyre-interpreter/src/module/_pickle/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_pickle/mod.rs
@@ -201,7 +201,7 @@ pub(crate) fn import_module(name: &str) -> Result<PyObjectRef, PyError> {
 /// The live execution context reached via the current frame, or `None`
 /// when no frame is on the stack.
 fn current_ec() -> Option<*const crate::PyExecutionContext> {
-    let frame = crate::eval::CURRENT_FRAME.with(|f| f.get());
+    let frame = crate::eval::current_frame();
     if frame.is_null() {
         return None;
     }

--- a/pyre/pyre-interpreter/src/module/mmap/interp_mmap.rs
+++ b/pyre/pyre-interpreter/src/module/mmap/interp_mmap.rs
@@ -143,7 +143,10 @@ fn mmap_ptr(obj: pyre_object::PyObjectRef) -> Result<(*mut u8, usize), crate::Py
 /// True when `obj` is an `mmap` instance.
 #[cfg(unix)]
 pub(crate) fn is_mmap(obj: pyre_object::PyObjectRef) -> bool {
-    crate::typedef::r#type(obj).is_some_and(|tp| std::ptr::eq(tp.as_ptr(), mmap_type()))
+    match crate::typedef::r#type(obj) {
+        Some(tp) => std::ptr::eq(tp.as_ptr(), mmap_type()),
+        None => false,
+    }
 }
 
 /// `_exports` — how many buffers are currently exported from the mapping.

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -147,11 +147,11 @@ pub mod frame_locals_proxy {
         }
 
         fn __reversed__(&self) -> Result<PyObjectRef, crate::PyError> {
-            let mut keys: Vec<_> =
-                unsafe { pyre_object::dictmultiobject::w_dict_items(self.mapping()?) }
-                    .into_iter()
-                    .map(|(key, _)| key)
-                    .collect();
+            let items = unsafe { pyre_object::dictmultiobject::w_dict_items(self.mapping()?) };
+            let mut keys: Vec<PyObjectRef> = Vec::with_capacity(items.len());
+            for (key, _) in items {
+                keys.push(key);
+            }
             keys.reverse();
             Ok(pyre_object::w_list_new(keys))
         }
@@ -161,29 +161,30 @@ pub mod frame_locals_proxy {
         }
 
         fn keys(&self) -> Result<PyObjectRef, crate::PyError> {
-            let keys = unsafe { pyre_object::dictmultiobject::w_dict_items(self.mapping()?) }
-                .into_iter()
-                .map(|(key, _)| key)
-                .collect();
+            let items = unsafe { pyre_object::dictmultiobject::w_dict_items(self.mapping()?) };
+            let mut keys: Vec<PyObjectRef> = Vec::with_capacity(items.len());
+            for (key, _) in items {
+                keys.push(key);
+            }
             Ok(pyre_object::w_list_new(keys))
         }
 
         fn values(&self) -> Result<PyObjectRef, crate::PyError> {
-            let values = unsafe { pyre_object::dictmultiobject::w_dict_items(self.mapping()?) }
-                .into_iter()
-                .map(|(_, value)| value)
-                .collect();
+            let items = unsafe { pyre_object::dictmultiobject::w_dict_items(self.mapping()?) };
+            let mut values: Vec<PyObjectRef> = Vec::with_capacity(items.len());
+            for (_, value) in items {
+                values.push(value);
+            }
             Ok(pyre_object::w_list_new(values))
         }
 
         fn items(&self) -> Result<PyObjectRef, crate::PyError> {
             let items = unsafe { pyre_object::dictmultiobject::w_dict_items(self.mapping()?) };
-            Ok(pyre_object::w_list_new(
-                items
-                    .into_iter()
-                    .map(|(key, value)| pyre_object::w_tuple_new(vec![key, value]))
-                    .collect(),
-            ))
+            let mut out: Vec<PyObjectRef> = Vec::with_capacity(items.len());
+            for (key, value) in items {
+                out.push(pyre_object::w_tuple_new(vec![key, value]));
+            }
+            Ok(pyre_object::w_list_new(out))
         }
 
         fn copy(&self) -> Result<PyObjectRef, crate::PyError> {

--- a/pyre/pyre-object/src/bufferview.rs
+++ b/pyre/pyre-object/src/bufferview.rs
@@ -63,13 +63,14 @@ fn copy_rec(
 unsafe fn read_dims(t: PyObjectRef) -> Vec<i64> {
     unsafe {
         let n = crate::tupleobject::w_tuple_len(t);
-        (0..n)
-            .map(|i| {
-                crate::tupleobject::w_tuple_getitem(t, i as i64)
-                    .map(|w| crate::intobject::w_int_get_value(w))
-                    .unwrap_or(0)
-            })
-            .collect()
+        let mut dims: Vec<i64> = Vec::with_capacity(n as usize);
+        for i in 0..n {
+            let d = crate::tupleobject::w_tuple_getitem(t, i as i64)
+                .map(|w| crate::intobject::w_int_get_value(w))
+                .unwrap_or(0);
+            dims.push(d);
+        }
+        dims
     }
 }
 

--- a/pyre/pyre-object/src/celldict.rs
+++ b/pyre/pyre-object/src/celldict.rs
@@ -408,6 +408,44 @@ pub fn module_dict_storage_gc_type_id() -> u32 {
     MODULE_DICT_STORAGE_GC_TYPE_ID.load(std::sync::atomic::Ordering::Relaxed)
 }
 
+/// The single `IndexMap` probe [`ModuleDictStorage::get`] runs —
+/// `celldict.py:143-145 getitem_str`'s
+/// `self.unerase(w_dict.dstorage).get(key)`.
+///
+/// Residualise the probe alone (`@dont_look_inside`, `rlib/jit.py:139`), the
+/// twin of `dictmultiobject::dict_entries_probe_str`: the `IndexMap::get` it
+/// wraps is an external-crate heap lookup the tracer cannot model — the
+/// oopspec'd residual arm of `rordereddict.ll_dict_getitem` (traced only for a
+/// virtual dict).  The keys are owned `String`s, so no user `__eq__` or
+/// `__hash__` can run inside the boundary at all.
+#[majit_macros::dont_look_inside]
+pub fn module_dict_entries_get(
+    entries: &indexmap::IndexMap<String, PyObjectRef>,
+    key: &str,
+) -> Option<PyObjectRef> {
+    entries.get(key).copied()
+}
+
+/// The store side of [`module_dict_entries_get`] — `celldict.py:47`'s
+/// `self.unerase(w_dict.dstorage)[key] = w_value`, returning the displaced
+/// value so the caller can tell an overwrite from an insert.
+///
+/// `IndexMap::insert` preserves the existing slot's position on overwrite,
+/// matching Python `{}`'s assignment semantics (rewriting an existing key does
+/// not move it to the end).  Residualised for [`module_dict_entries_get`]'s
+/// reason; upstream's `_ll_dict_setitem_lookup_done` (`rordereddict.py:674`)
+/// is likewise `@jit.look_inside_iff(jit.isvirtual(d) and jit.isconstant(key))`
+/// and neither conjunct can hold for an `IndexMap` here.  The borrowed name is
+/// copied to the owned `String` the entry table stores inside the boundary.
+#[majit_macros::dont_look_inside]
+pub fn module_dict_entries_insert(
+    entries: &mut indexmap::IndexMap<String, PyObjectRef>,
+    key: &str,
+    w_value: PyObjectRef,
+) -> Option<PyObjectRef> {
+    entries.insert(key.to_string(), w_value)
+}
+
 impl ModuleDictStorage {
     pub fn new() -> Self {
         Self {
@@ -427,7 +465,7 @@ impl ModuleDictStorage {
     /// `dict.__getitem__(key)` returning the raw stored value (or
     /// cell — eventually).  None when absent.
     pub fn get(&self, key: &str) -> Option<PyObjectRef> {
-        self.entries.get(key).copied()
+        module_dict_entries_get(&self.entries, key)
     }
 
     /// `dict[key] = w_value` — insertion-ordered.  Returns the
@@ -436,10 +474,7 @@ impl ModuleDictStorage {
         // Prebuilt-family store (see `write_cell`): the module-dict storage
         // is Box-immortal, so the write-tracking bit is its write barrier.
         crate::gc_roots::mark_prebuilt_roots_dirty();
-        // `IndexMap::insert` preserves the existing slot's position
-        // on overwrite, matching Python `{}`'s assignment semantics
-        // (rewriting an existing key does not move it to the end).
-        self.entries.insert(key.to_string(), w_value)
+        module_dict_entries_insert(&mut self.entries, key, w_value)
     }
 
     /// `del dict[key]` — returns the removed value or None.

--- a/pyre/pyre-object/src/dictmultiobject.rs
+++ b/pyre/pyre-object/src/dictmultiobject.rs
@@ -294,6 +294,132 @@ pub unsafe fn dict_entries_insert_hashed(
     entries.insert(ObjectKey { hash, obj }, value)
 }
 
+/// Read the value stored at an entry index the caller already settled on —
+/// `rordereddict.py:709 ll_dict_getitem`'s `d.entries[i].value` after
+/// `ll_dict_lookup` returned the slot.
+///
+/// Residualised for [`dict_entries_probe_hashed`]'s reason: `IndexMap` has no
+/// lowering, so `get_index` is the last modellable point.  No comparison runs
+/// here — the index is already known, so this is a pure slot read and the
+/// residual boundary swallows no user code at all.
+///
+/// # Safety
+/// Same as [`dict_entries_probe_hashed`]; `index` must be a live entry index.
+#[majit_macros::dont_look_inside]
+pub unsafe fn dict_entries_value_at(
+    entries: &indexmap::IndexMap<ObjectKey, PyObjectRef>,
+    index: usize,
+) -> PyObjectRef {
+    *entries.get_index(index).unwrap().1
+}
+
+/// Overwrite the value at an entry index the caller already settled on —
+/// `dictmultiobject.py:1220-1221 setitem_str`'s in-place update, which reuses
+/// the stored key rather than re-inserting.
+///
+/// Residualised for [`dict_entries_value_at`]'s reason, and the store twin of
+/// it: the index is already known, so the boundary swallows a slot write and
+/// no comparison.
+///
+/// # Safety
+/// Same as [`dict_entries_value_at`].
+#[majit_macros::dont_look_inside]
+pub unsafe fn dict_entries_value_set_at(
+    entries: &mut indexmap::IndexMap<ObjectKey, PyObjectRef>,
+    index: usize,
+    value: PyObjectRef,
+) {
+    *entries.get_index_mut(index).unwrap().1 = value;
+}
+
+/// The owned-key store — [`dict_entries_probe_object`]'s twin, hashing `key`
+/// through [`object_key_for`] the way `dict_entries_remove_object` does.
+///
+/// Residualised for [`dict_entries_insert_hashed`]'s reason: `IndexMap` has no
+/// lowering, and upstream's `_ll_dict_setitem_lookup_done`
+/// (`rordereddict.py:674`) is `@jit.look_inside_iff(jit.isvirtual(d) and
+/// jit.isconstant(key))`, neither conjunct of which can hold here.
+///
+/// # Safety
+/// Same as [`dict_entries_probe_object`].
+#[majit_macros::dont_look_inside]
+pub unsafe fn dict_entries_insert_object(
+    entries: &mut indexmap::IndexMap<ObjectKey, PyObjectRef>,
+    key: PyObjectRef,
+    value: PyObjectRef,
+) {
+    entries.insert(object_key_for(key), value);
+}
+
+/// The stored key's object word at an entry index, `None` once the walk has
+/// passed the last entry — `rordereddict.py:1051-1052 ll_dict_lookup`'s
+/// `entries[i].key` plus the bound that ends its scan.
+///
+/// Residualised for [`dict_entries_value_at`]'s reason: a positional slot read
+/// runs no comparison, so the boundary swallows no user code.  It is the read
+/// [`scan_dict_key_reentrant`] performs per step; the scan's `keyeq` loop and
+/// its paranoia restart stay traced around it, which is what
+/// `ll_dict_lookup`'s own `@jit.look_inside_iff(jit.isvirtual(d))` keeps
+/// visible for a dict the tracer can see.
+///
+/// # Safety
+/// Same as [`dict_entries_value_at`].
+#[majit_macros::dont_look_inside]
+pub unsafe fn dict_entries_key_obj_at(
+    entries: &indexmap::IndexMap<ObjectKey, PyObjectRef>,
+    index: usize,
+) -> Option<PyObjectRef> {
+    entries.get_index(index).map(|(stored, _)| stored.obj)
+}
+
+/// The stored key's cached digest at an entry index — `rordereddict.py:1053
+/// entries.hash(i)`, the hash compared before `keyeq` is allowed to run.
+///
+/// Split from [`dict_entries_key_obj_at`] rather than returned beside it: an
+/// `ObjectKey` by value is not a residual-ABI argument shape, and the caller
+/// reads both words at the same index with no callback in between.
+///
+/// # Safety
+/// Same as [`dict_entries_value_at`].
+#[majit_macros::dont_look_inside]
+pub unsafe fn dict_entries_key_hash_at(
+    entries: &indexmap::IndexMap<ObjectKey, PyObjectRef>,
+    index: usize,
+) -> i64 {
+    entries.get_index(index).unwrap().0.hash
+}
+
+/// `entries.valid(index) && entries[index].key == checkingkey` — the second
+/// half of `ll_dict_lookup`'s paranoia condition (`rordereddict.py:1058`),
+/// answered against the two key words the caller sampled before the
+/// comparison it is validating.
+///
+/// # Safety
+/// Same as [`dict_entries_value_at`].
+#[majit_macros::dont_look_inside]
+pub unsafe fn dict_entries_key_is_at(
+    entries: &indexmap::IndexMap<ObjectKey, PyObjectRef>,
+    index: usize,
+    hash: i64,
+    obj: PyObjectRef,
+) -> bool {
+    entries
+        .get_index(index)
+        .is_some_and(|(stored, _)| stored.hash == hash && stored.obj == obj)
+}
+
+/// The table's allocation identity, as `ll_dict_lookup`'s paranoia restart
+/// reads it (`rordereddict.py:1058 entries != d.entries`): a grow reallocates
+/// every entry, so a capacity change is the observable that a stale index can
+/// no longer be trusted.
+///
+/// # Safety
+/// Same as [`dict_entries_value_at`].
+#[majit_macros::dont_look_inside]
+pub unsafe fn dict_entries_capacity(entries: &indexmap::IndexMap<ObjectKey, PyObjectRef>) -> usize {
+    entries.capacity()
+}
+
 /// Drop the last entry — the undo the checked store runs when a user `__eq__`
 /// raised mid-probe and `insert` therefore appended a spurious entry.
 ///
@@ -343,10 +469,49 @@ unsafe fn dict_entries_index_of_str(
     match crate::dict_eq_hook::try_hash_str(key.as_bytes()) {
         Some(hash) => {
             crate::dict_eq_hook::take_eq_error();
-            entries.get_index_of(&StrLookupKey { hash, key })
+            dict_entries_index_of_str_hashed(entries, hash, key)
         }
-        None => entries.get_index_of(&object_key_for(crate::w_str_new(key))),
+        None => dict_entries_index_of_object(entries, crate::w_str_new(key)),
     }
+}
+
+/// The borrow-key membership probe [`dict_entries_index_of_str`] runs once the
+/// str hash hook has produced `hash` — [`dict_entries_probe_str`]'s twin,
+/// returning the entry index instead of the value.
+///
+/// Residualised for [`dict_entries_probe_str`]'s reason: the
+/// `IndexMap::get_index_of` it wraps is the same external-crate heap lookup,
+/// and the user `__eq__` a str-subclass key can run sits inside the probe
+/// upstream too (`rdict.py:576 ll_dict_lookup` carries
+/// `@jit.oopspec('dict.lookup')` over the whole `keyeq` loop).  The enclosing
+/// router keeps its hook gate and its allocating fallback visible.
+///
+/// # Safety
+/// Same as [`dict_entries_probe_str`].
+#[majit_macros::dont_look_inside]
+pub unsafe fn dict_entries_index_of_str_hashed(
+    entries: &indexmap::IndexMap<ObjectKey, PyObjectRef>,
+    hash: i64,
+    key: &str,
+) -> Option<usize> {
+    entries.get_index_of(&StrLookupKey { hash, key })
+}
+
+/// The owned-key membership probe [`dict_entries_index_of_str`]'s no-hook arm
+/// runs — [`dict_entries_probe_object`]'s twin.
+///
+/// Residualised for [`dict_entries_probe_object`]'s reason: a body that
+/// reaches either `get_index_of` stops there, so leaving one arm traced keeps
+/// the enclosing graph blocked no matter what the other arm does.
+///
+/// # Safety
+/// Same as [`dict_entries_probe_object`].
+#[majit_macros::dont_look_inside]
+pub unsafe fn dict_entries_index_of_object(
+    entries: &indexmap::IndexMap<ObjectKey, PyObjectRef>,
+    key: PyObjectRef,
+) -> Option<usize> {
+    entries.get_index_of(&object_key_for(key))
 }
 
 /// Build the persistent exact-str key for a new `setitem_str` entry.
@@ -1721,11 +1886,11 @@ unsafe fn w_module_dict_setitem_str_internal(obj: PyObjectRef, key: &str, w_valu
         let entries = w_module_dict_object_storage_mut(obj);
         match dict_entries_index_of_str(entries, key) {
             Some(idx) => {
-                *entries.get_index_mut(idx).unwrap().1 = w_value;
+                dict_entries_value_set_at(entries, idx, w_value);
             }
             None => {
                 let w_key = crate::w_str_new(key);
-                entries.insert(object_key_for(w_key), w_value);
+                dict_entries_insert_object(entries, w_key, w_value);
                 w_dict_bump_keys_version(obj);
             }
         };
@@ -2180,22 +2345,23 @@ unsafe fn scan_dict_key_reentrant(
         let (table_capacity, clear_generation) = {
             let dict = &*(obj as *const W_DictObject);
             (
-                (*(dict.dstorage as *const indexmap::IndexMap<ObjectKey, PyObjectRef>)).capacity(),
+                dict_entries_capacity(
+                    &*(dict.dstorage as *const indexmap::IndexMap<ObjectKey, PyObjectRef>),
+                ),
                 dict.clear_gen,
             )
         };
         let mut i = 0;
         loop {
             obj = crate::gc_roots::shadow_stack_get(obj_slot);
-            let Some((stored_hash, stored_obj)) = ({
+            let (stored_hash, stored_obj) = {
                 let dict = &*(obj as *const W_DictObject);
                 let entries =
                     &*(dict.dstorage as *const indexmap::IndexMap<ObjectKey, PyObjectRef>);
-                entries
-                    .get_index(i)
-                    .map(|(stored, _)| (stored.hash, stored.obj))
-            }) else {
-                return Ok((None, key, obj));
+                let Some(stored_obj) = dict_entries_key_obj_at(entries, i) else {
+                    return Ok((None, key, obj));
+                };
+                (dict_entries_key_hash_at(entries, i), stored_obj)
             };
 
             if stored_hash == key.hash {
@@ -2224,12 +2390,10 @@ unsafe fn scan_dict_key_reentrant(
                     // `entries != d.entries`: a realloc grew the table, or a
                     // `clear` reset it in place (`clear_gen`) — either
                     // reallocates `d.entries` in `ll_dict_lookup`'s eyes.
-                    entries.capacity() != table_capacity
+                    dict_entries_capacity(entries) != table_capacity
                         || dict.clear_gen != clear_generation
                         // `entries.valid(index) && entries[index].key == checkingkey`.
-                        || !entries.get_index(i).is_some_and(|(stored, _)| {
-                            stored.hash == stored_hash && stored.obj == stored_obj
-                        })
+                        || !dict_entries_key_is_at(entries, i, stored_hash, stored_obj)
                 };
                 if disturbed {
                     continue 'restart;
@@ -2266,7 +2430,7 @@ pub unsafe fn w_dict_lookup_object_strategy_checked(
     if let Some(result) = callback_free_dict_op!({
         let dict = &*(obj as *const W_DictObject);
         let entries = &*(dict.dstorage as *const indexmap::IndexMap<ObjectKey, PyObjectRef>);
-        entries.get(&object_key).copied()
+        dict_entries_probe_hashed(entries, object_key.hash, object_key.obj)
     }) {
         return result;
     }
@@ -2274,7 +2438,7 @@ pub unsafe fn w_dict_lookup_object_strategy_checked(
     Ok(found.map(|i| {
         let dict = &*(obj as *const W_DictObject);
         let entries = &*(dict.dstorage as *const indexmap::IndexMap<ObjectKey, PyObjectRef>);
-        *entries.get_index(i).unwrap().1
+        dict_entries_value_at(entries, i)
     }))
 }
 
@@ -2570,7 +2734,7 @@ pub unsafe fn w_dict_setdefault_checked(
                 match index {
                     Some(i) => Some(*entries.get_index(i).unwrap().1),
                     None => {
-                        entries.insert(object_key, value);
+                        dict_entries_insert_hashed(entries, object_key.hash, object_key.obj, value);
                         w_dict_bump_keys_version(obj);
                         dict_write_barrier(obj);
                         Some(value)
@@ -2603,7 +2767,7 @@ pub unsafe fn w_dict_setdefault_checked(
         crate::dict_eq_hook::begin_callback_free_probe();
         let dict = &mut *(obj as *mut W_DictObject);
         let entries = &mut *(dict.dstorage as *mut indexmap::IndexMap<ObjectKey, PyObjectRef>);
-        entries.insert(object_key, value);
+        dict_entries_insert_hashed(entries, object_key.hash, object_key.obj, value);
         let _ = crate::dict_eq_hook::end_callback_free_probe();
         w_dict_bump_keys_version(obj);
         dict_write_barrier(obj);
@@ -2747,7 +2911,7 @@ unsafe fn w_dict_store_object_strategy_checked_inner(
                     *entries.get_index_mut(i).unwrap().1 = value;
                 }
                 None => {
-                    entries.insert(object_key, value);
+                    dict_entries_insert_hashed(entries, object_key.hash, object_key.obj, value);
                     dict.keys_version = dict.keys_version.wrapping_add(1);
                 }
             }
@@ -2778,7 +2942,7 @@ unsafe fn w_dict_store_object_strategy_checked_inner(
             crate::dict_eq_hook::begin_callback_free_probe();
             let dict = &mut *(obj as *mut W_DictObject);
             let entries = &mut *(dict.dstorage as *mut indexmap::IndexMap<ObjectKey, PyObjectRef>);
-            entries.insert(object_key, value);
+            dict_entries_insert_hashed(entries, object_key.hash, object_key.obj, value);
             let _ = crate::dict_eq_hook::end_callback_free_probe();
             dict.keys_version = dict.keys_version.wrapping_add(1);
         }
@@ -2810,7 +2974,9 @@ pub unsafe fn w_module_dict_store_inner(obj: PyObjectRef, key: PyObjectRef, valu
         w_module_dict_switch_to_object_strategy(obj);
     }
     let entries = w_module_dict_object_storage_mut(obj);
-    let inserted = entries.insert(object_key_for(key), value).is_none();
+    let object_key = object_key_for(key);
+    let inserted =
+        dict_entries_insert_hashed(entries, object_key.hash, object_key.obj, value).is_none();
     let strategy = &mut *(*(obj as *mut W_ModuleDictObject)).mstrategy;
     strategy.mutated();
     if inserted {
@@ -5608,7 +5774,7 @@ impl DictStrategy for UnicodeDictStrategy {
             }
             None => {
                 let stored_key = object_key_for_new_str(key);
-                entries.insert(stored_key, w_value);
+                dict_entries_insert_hashed(entries, stored_key.hash, stored_key.obj, w_value);
                 dict.keys_version = dict.keys_version.wrapping_add(1);
             }
         };

--- a/pyre/pyre-object/src/identitydict.rs
+++ b/pyre/pyre-object/src/identitydict.rs
@@ -116,6 +116,32 @@ pub unsafe fn w_dict_delete_identity_strategy(obj: PyObjectRef, key: PyObjectRef
         .is_some()
 }
 
+/// `dictmultiobject.py:1061-1067 setitem`'s identity-keyed store — insert
+/// `value` under the address-identity of `key`, reporting whether the slot was
+/// newly filled so the caller bumps the keys-version only on a real insert.
+///
+/// Residualise the storage insert alone (`@dont_look_inside`,
+/// `rlib/jit.py:139`), the store twin of [`w_dict_lookup_identity_strategy`]:
+/// upstream's `_ll_dict_setitem_lookup_done` (`rordereddict.py:674`) is
+/// `@jit.look_inside_iff(jit.isvirtual(d) and jit.isconstant(key))`, and an
+/// `IndexMap` can never be virtual to this front end, so neither conjunct can
+/// hold and the residual arm is the only one reachable.  [`IdentityKey`]
+/// hashes and compares by address, so the store runs no user Python code at
+/// all; the keys-version bump and the GC write barrier stay traced.
+///
+/// # Safety
+/// `obj` must point to a valid `W_DictObject` on [`IDENTITY_DICT_STRATEGY`].
+#[majit_macros::dont_look_inside]
+pub unsafe fn w_dict_store_identity_strategy(
+    obj: PyObjectRef,
+    key: PyObjectRef,
+    value: PyObjectRef,
+) -> bool {
+    identity_storage_mut(obj)
+        .insert(IdentityKey(key), value)
+        .is_none()
+}
+
 /// `dictmultiobject.py:1143-1150 AbstractTypedStrategy.switch_to_object_strategy`
 /// instantiation for IdentityDictStrategy — `wrap` is identity (`:26-27`), so
 /// the migration ports each `IdentityKey(obj)` into
@@ -252,8 +278,7 @@ impl DictStrategy for IdentityDictStrategy {
     /// on mismatch, promote to Object.
     unsafe fn setitem(&self, w_dict: PyObjectRef, w_key: PyObjectRef, w_value: PyObjectRef) {
         if Self::is_correct_type(w_key) {
-            let entries = identity_storage_mut(w_dict);
-            if entries.insert(IdentityKey(w_key), w_value).is_none() {
+            if w_dict_store_identity_strategy(w_dict, w_key, w_value) {
                 crate::dictmultiobject::w_dict_bump_keys_version(w_dict);
             }
             crate::gc_hook::try_gc_write_barrier(w_dict as *mut u8);


### PR DESCRIPTION
Squashed net delta of the long-running `aggregate-return-abi` work that was not already present on `main`, rebuilt as one clean commit on top of current `main`. Most of the original epic had already landed via separate PRs; this is the remaining 23-file delta.

## Contents
- **front passes**: native `checked_{mul,add}`; `Layout::from_size_align(..).ok()/.expect()`; `Option::expect` and `Option::try`; per-instantiation ref-payload `Option` return-shell with consumer canonicalization
- **rtyper**: `uint_mul_high` / `uint_lt` annotator bindings and LL lowering
- **front/mir**: crate-strip the zero-field-unit-struct singleton reader root (resolves DictStrategy `commonbase` unions)
- **static globals**: residualize runtime-mutable global accessors (`display`, `eval`, `_io` statics) via `dont_look_inside` + `push_alias_pair`

## Verification
- `check.py --backend dynasm,cranelift`: **ALL PASSED — dynasm 351/351, cranelift 351/351**
- descr universe stable across two independent codegen builds (`all_descrs=4438`), ruling out first-build-after-extract truncation
- delta compiles cleanly against current `main`; 3-way squash-merge auto-merged 47/48 files (the one conflict was `call_depth`'s `dont_look_inside` conversion, landed identically on both sides)

Assisted-by: Claude

— *opened by Claude*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for unsigned high-word multiplication and comparisons.
  * Improved handling of pointer/address casts and erased pointer values.
  * Added optimized handling for checked unsigned arithmetic, layout creation, and `Option` operations.

* **Bug Fixes**
  * Fixed previously unrecognized operations that could leave values unavailable during translation.
  * Improved fieldless enum comparisons and `Option` branching across varied return types.
  * Strengthened recursion detection and active-frame handling for JIT execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->