### PR TITLE
macros: drop #[inline(never)] from dont_look_inside; gc_roots: fixed base/top interpreter root stack

### DIFF
--- a/majit/majit-backend-dynasm/src/aarch64/assembler.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/assembler.rs
@@ -4196,6 +4196,28 @@ impl<'a> AssemblerARM64<'a> {
         // canonical copy when present.  Must follow the `meta_descr`
         // stamp above for the forward to reach the meta side.
         descr_fd.set_rd_locs(rd_locs);
+        // `regalloc.py:496-499 consider_guard_value` — every upstream backend
+        // stamps the per-value counter while laying the guard out, so
+        // `store_hash` (`compile.py:826-829`, gated on `status == 0`) leaves it
+        // alone and `must_compile` hashes the (guard, failing value) pair
+        // instead of the guard alone.  Without it a guard whose failing value
+        // never repeats still accumulates in one bucket and compiles another
+        // bridge every `trace_eagerness` failures, without bound.  The index is
+        // a fail-arg position because `must_compile_with_values` reads the value
+        // back out of `fail_values`.
+        if op.opcode == majit_ir::OpCode::GuardValue {
+            if let Some(fa) = op.getfailargs() {
+                let arg0 = op.arg(0).to_opref();
+                if let Some(idx) = fa.iter().position(|r| r.to_opref() == arg0) {
+                    let type_tag = match descr_fd.fail_arg_types().get(idx) {
+                        Some(majit_ir::Type::Ref) => majit_backend::STATUS_TY_REF,
+                        Some(majit_ir::Type::Float) => majit_backend::STATUS_TY_FLOAT,
+                        _ => majit_backend::STATUS_TY_INT,
+                    };
+                    descr_fd.make_a_counter_per_value(idx as u32, type_tag);
+                }
+            }
+        }
         if crate::majit_log_enabled() {
             eprintln!(
                 "[dynasm] guard-token-slots: fail_index={} rd_locs={:?}",

--- a/majit/majit-backend-dynasm/src/lib.rs
+++ b/majit/majit-backend-dynasm/src/lib.rs
@@ -69,6 +69,23 @@ pub fn majit_j2plan_log_enabled() -> bool {
     *ENABLED
 }
 
+/// Whether `PYRE_GC_FREELIST_DIAG` is set, cached at first access.
+///
+/// Read once per residual call and twice per compiled-trace entry, so the
+/// uncached form put `getenv` on the hottest paths the backend has.
+pub fn gc_freelist_diag_enabled() -> bool {
+    static ENABLED: std::sync::LazyLock<bool> =
+        std::sync::LazyLock::new(|| std::env::var_os("PYRE_GC_FREELIST_DIAG").is_some());
+    *ENABLED
+}
+
+/// Whether `PYRE_DYNASM_EXEC_DIAG` is set, cached at first access.
+pub fn dynasm_exec_diag_enabled() -> bool {
+    static ENABLED: std::sync::LazyLock<bool> =
+        std::sync::LazyLock::new(|| std::env::var_os("PYRE_DYNASM_EXEC_DIAG").is_some());
+    *ENABLED
+}
+
 static JIT_EXC_VALUE: AtomicI64 = AtomicI64::new(0);
 // Holds the pending exception's `typeptr` (an immortal static `PyType`), never a
 // managed object, so it is deliberately not GC-rooted.

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -597,21 +597,25 @@ fn dynasm_collect_full() {
     majit_gc::gc_sync::gc_op(|g| g.collect_full());
 }
 
-fn debug_validate_oldgen_freeblocks(site: &str) {
-    if std::env::var_os("PYRE_GC_FREELIST_DIAG").is_none() {
+/// Takes `format_args!` rather than a built `String`: the callers sit on the
+/// per-residual-call and per-trace-entry paths, where formatting the site name
+/// for a diagnostic that is off costs a heap allocation every time.
+fn debug_validate_oldgen_freeblocks(site: std::fmt::Arguments<'_>) {
+    if !crate::gc_freelist_diag_enabled() {
         return;
     }
+    let site = site.to_string();
     if DYNASM_ACTIVE_GC
         .with(|c| {
             c.borrow()
                 .as_deref()
-                .map(|g| g.debug_validate_oldgen_freeblocks(site))
+                .map(|g| g.debug_validate_oldgen_freeblocks(&site))
         })
         .is_some()
     {
         return;
     }
-    majit_gc::gc_sync::gc_op(|g| g.debug_validate_oldgen_freeblocks(site));
+    majit_gc::gc_sync::gc_op(|g| g.debug_validate_oldgen_freeblocks(&site));
 }
 
 pub extern "C" fn dynasm_debug_validate_oldgen_freeblocks(site: u64, frame: usize) {
@@ -623,7 +627,7 @@ pub extern "C" fn dynasm_debug_validate_oldgen_freeblocks(site: u64, frame: usiz
             majit_gc::shadow_stack::is_libc_jitframe(top),
         );
     }
-    debug_validate_oldgen_freeblocks(&format!("after residual site {site}"));
+    debug_validate_oldgen_freeblocks(format_args!("after residual site {site}"));
 }
 
 fn dynasm_get_objects(generation: i8, visitor: majit_gc::GetObjectsVisitorFn) {
@@ -892,10 +896,10 @@ pub extern "C" fn dynasm_nursery_slowpath(total_size: u64) -> u64 {
         let raw = libc::calloc(1, total_size as usize) as u64;
         if raw == 0 { 0 } else { raw + gc_hdr as u64 }
     });
-    if std::env::var_os("PYRE_GC_FREELIST_DIAG").is_some() {
+    if crate::gc_freelist_diag_enabled() {
         let nursery = dynasm_gc_is_nursery_object(ptr as usize);
         eprintln!("[malloc-slow] total={total_size} payload={ptr:#x} nursery={nursery}");
-        debug_validate_oldgen_freeblocks("after malloc slowpath");
+        debug_validate_oldgen_freeblocks(format_args!("after malloc slowpath"));
     }
     if majit_ir::debug::have_debug_prints() {
         majit_ir::debug::log_one(
@@ -2574,7 +2578,7 @@ impl Backend for DynasmBackend {
 
         let bridge_addr = codebuf::buffer_ptr(&compiled.buffer) as usize;
         let code_size = compiled.buffer.len();
-        if std::env::var_os("PYRE_DYNASM_EXEC_DIAG").is_some() {
+        if crate::dynasm_exec_diag_enabled() {
             eprintln!(
                 "[dynasm-bridge] trace={trace_id} source={}:{} addr={bridge_addr:#x} len={code_size}",
                 fail_descr.trace_id(),
@@ -2803,7 +2807,7 @@ impl Backend for DynasmBackend {
         // manual push_jf/pop_jf_to around the call.
         let func: unsafe extern "C" fn(*mut JitFrame) -> *mut JitFrame =
             unsafe { std::mem::transmute(entry) };
-        if std::env::var_os("PYRE_DYNASM_EXEC_DIAG").is_some() {
+        if crate::dynasm_exec_diag_enabled() {
             eprintln!(
                 "[dynasm-exec] trace={} header={} entry={entry:p} len={} args={args:?}",
                 compiled.trace_id,
@@ -2811,9 +2815,9 @@ impl Backend for DynasmBackend {
                 compiled.buffer.len(),
             );
         }
-        debug_validate_oldgen_freeblocks(&format!("before trace {}", compiled.trace_id));
+        debug_validate_oldgen_freeblocks(format_args!("before trace {}", compiled.trace_id));
         let result_jf = unsafe { func(jf_ptr) };
-        debug_validate_oldgen_freeblocks(&format!("after trace {}", compiled.trace_id));
+        debug_validate_oldgen_freeblocks(format_args!("after trace {}", compiled.trace_id));
 
         if crate::majit_log_enabled() {
             eprintln!(

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -975,7 +975,13 @@ pub extern "C" fn dynasm_nursery_slowpath_varsize(
             .0 as u64
     });
     result.unwrap_or_else(|| {
-        let total = base_size as usize + item_size as usize * length as usize + gc_hdr;
+        let Some(total) = (item_size as usize)
+            .checked_mul(length as usize)
+            .and_then(|var_size| (base_size as usize).checked_add(var_size))
+            .and_then(|payload_size| gc_hdr.checked_add(payload_size))
+        else {
+            return 0;
+        };
         unsafe {
             // `libc::calloc` returns NULL on real OOM; the previous
             // unconditional `raw + gc_hdr` masked failure as a tiny
@@ -1119,7 +1125,12 @@ fn dynasm_alloc_oldgen_varsize_typed_and_set_len(
     length_ofs: usize,
     length: usize,
 ) -> u64 {
-    let payload_size = base_size + item_size * length;
+    let Some(payload_size) = item_size
+        .checked_mul(length)
+        .and_then(|var_size| base_size.checked_add(var_size))
+    else {
+        return 0;
+    };
     let obj = dynasm_alloc_oldgen_typed(type_id, payload_size);
     let ptr = obj.0;
     if ptr != 0 {
@@ -3893,6 +3904,15 @@ mod tests {
     };
     use std::sync::Arc;
     use std::sync::atomic::{AtomicU32, Ordering};
+
+    #[test]
+    fn varsize_slowpaths_return_null_on_size_overflow() {
+        assert_eq!(dynasm_nursery_slowpath_varsize(0, 2, u64::MAX), 0);
+        assert_eq!(
+            dynasm_alloc_oldgen_varsize_typed_and_set_len(1, 0, 2, 0, usize::MAX),
+            0
+        );
+    }
 
     fn install_test_libc_jitframe_tracer() {
         majit_gc::shadow_stack::register_libc_jitframe_tracer(

--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -1090,12 +1090,33 @@ fn collect_guards_and_vars(inputargs: &[InputArg], ops: &[Op]) -> (Vec<GuardExit
                 .get_fail_arg_types()
                 .unwrap_or_else(|| fail_args.iter().map(|_| Type::Int).collect());
 
+            let meta_descr = op.getdescr();
+            // `regalloc.py:496-499 consider_guard_value` — stamp the per-value
+            // counter here, where the native backends stamp it during guard
+            // layout, so `store_guard_hashes`' `status == 0` gate
+            // (`compile.py:826-829`) leaves it alone and `must_compile` hashes
+            // the (guard, failing value) pair. Without it a guard whose failing
+            // value never repeats accumulates in one bucket and compiles
+            // another bridge every `trace_eagerness` failures, without bound.
+            if op.opcode == OpCode::GuardValue {
+                if let Some(fd) = meta_descr.as_ref().and_then(|d| d.as_fail_descr()) {
+                    let arg0 = op.arg(0).to_opref();
+                    if let Some(idx) = fail_args.iter().position(|r| *r == arg0) {
+                        let type_tag = match fail_arg_types.get(idx) {
+                            Some(Type::Ref) => majit_backend::STATUS_TY_REF,
+                            Some(Type::Float) => majit_backend::STATUS_TY_FLOAT,
+                            _ => majit_backend::STATUS_TY_INT,
+                        };
+                        fd.make_a_counter_per_value(idx as u32, type_tag);
+                    }
+                }
+            }
             guards.push(GuardExit {
                 fail_index,
                 fail_arg_refs: fail_args,
                 fail_arg_types,
                 is_finish: op.opcode == OpCode::Finish,
-                meta_descr: op.getdescr(),
+                meta_descr,
             });
             fail_index += 1;
         }

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -893,7 +893,9 @@ impl MiniMarkGC {
             self.do_collect_full();
         }
 
-        let total_size = GcHeader::SIZE + payload_size;
+        let Some(total_size) = GcHeader::SIZE.checked_add(payload_size) else {
+            return GcRef(0);
+        };
 
         // Large objects go directly to old gen.
         if total_size > self.config.large_object_threshold {
@@ -919,10 +921,22 @@ impl MiniMarkGC {
                 return GcRef(0);
             }
             let ptr = self.nursery.alloc(total_size);
-            if ptr.is_null() {
-                // Still no space after collection. Allocate in old gen as fallback.
+            let ptr = if ptr.is_null() {
+                self.reserve_nursery_gap(total_size)
+            } else {
+                ptr
+            };
+            if ptr.is_null() && Self::nursery_allocation_size(total_size) > self.nursery.size() {
+                // Production incminimark keeps `nonlarge_max` below the
+                // nursery size. Tiny backend tests can configure the two
+                // independently; retain their external-allocation fallback
+                // only for an object that cannot physically fit anywhere.
                 return self.alloc_in_oldgen(type_id, total_size);
             }
+            assert!(
+                !ptr.is_null(),
+                "collect_and_reserve could not find nursery space for a non-large object"
+            );
             Self::init_nursery_object(ptr, type_id);
             let obj = GcRef((ptr as usize) + GcHeader::SIZE);
             self.register_weakref_if_needed(type_id, obj.0);
@@ -966,7 +980,9 @@ impl MiniMarkGC {
             self.roots.remove(root);
         }
 
-        let total_size = GcHeader::SIZE + payload_size;
+        let Some(total_size) = GcHeader::SIZE.checked_add(payload_size) else {
+            return GcRef(0);
+        };
 
         // Large objects never trigger a nursery collection, so the native
         // slot needs no temporary registration.
@@ -986,10 +1002,19 @@ impl MiniMarkGC {
                 return GcRef(0);
             }
             let ptr = self.nursery.alloc(total_size);
-            if ptr.is_null() {
+            let ptr = if ptr.is_null() {
+                self.reserve_nursery_gap(total_size)
+            } else {
+                ptr
+            };
+            if ptr.is_null() && Self::nursery_allocation_size(total_size) > self.nursery.size() {
                 unsafe { *needs_write_barrier = true };
                 return self.alloc_in_oldgen(type_id, total_size);
             }
+            assert!(
+                !ptr.is_null(),
+                "collect_and_reserve could not find nursery space for a non-large object"
+            );
             Self::init_nursery_object(ptr, type_id);
             let obj = GcRef((ptr as usize) + GcHeader::SIZE);
             self.register_weakref_if_needed(type_id, obj.0);
@@ -1004,13 +1029,91 @@ impl MiniMarkGC {
         obj
     }
 
+    /// incminimark.py:865-930 `collect_and_reserve` pinned-barrier walk.
+    ///
+    /// A minor collection can leave `nursery_free` after the highest pinned
+    /// object, where the tail is too short for the triggering allocation even
+    /// though an earlier gap is large enough. Upstream walks the ordered
+    /// `nursery_barriers` and reserves from the first fitting gap; it never
+    /// changes a non-large malloc into an old-generation allocation. Preserve
+    /// that young-result contract because the GC rewrite elides write barriers
+    /// while initializing a fresh nursery object (`rewrite.py:911`).
+    fn nursery_allocation_size(total_size: usize) -> usize {
+        total_size
+            .max(GcHeader::MIN_NURSERY_OBJ_SIZE)
+            .checked_add(7)
+            .map(|size| size & !7)
+            .unwrap_or(usize::MAX)
+    }
+
+    /// `incminimark.py:978-983 external_malloc` parity: both the variable
+    /// portion and the final payload sum are overflow-checked.  The caller
+    /// turns `None` into NULL so compiled code raises `MemoryError`.
+    fn checked_varsize_payload_size(
+        base_size: usize,
+        item_size: usize,
+        length: usize,
+    ) -> Option<usize> {
+        item_size
+            .checked_mul(length)
+            .and_then(|var_size| base_size.checked_add(var_size))
+    }
+
+    fn reserve_nursery_gap(&mut self, total_size: usize) -> *mut u8 {
+        if self.pinned_objects.is_empty() {
+            return std::ptr::null_mut();
+        }
+
+        let aligned_size = Self::nursery_allocation_size(total_size);
+        let nursery_start = self.nursery.start_ptr() as usize;
+        let nursery_end = nursery_start + self.nursery.size();
+        let mut barriers = Vec::with_capacity(self.pinned_objects.len());
+        for &obj_addr in &self.pinned_objects {
+            let type_id = unsafe { (*header_of(obj_addr)).type_id() };
+            let type_info = self.types.get(type_id);
+            let payload_size = if type_info.item_size > 0 {
+                let length = unsafe { *((obj_addr + type_info.length_offset) as *const usize) };
+                type_info.total_instance_size(length)
+            } else {
+                type_info.size
+            };
+            let object_size = Self::nursery_allocation_size(GcHeader::SIZE + payload_size);
+            barriers.push((obj_addr - GcHeader::SIZE, object_size));
+        }
+        barriers.sort_unstable_by_key(|&(header_start, _)| header_start);
+
+        let mut gap_start = nursery_start;
+        for (header_start, object_size) in barriers {
+            if header_start.saturating_sub(gap_start) >= aligned_size {
+                unsafe {
+                    self.nursery.set_free_ptr(gap_start as *mut u8);
+                    self.nursery.set_top_ptr(header_start as *const u8);
+                }
+                self.refresh_published_nursery_top();
+                return self.nursery.alloc(total_size);
+            }
+            gap_start = gap_start.max(header_start.saturating_add(object_size));
+        }
+        if nursery_end.saturating_sub(gap_start) >= aligned_size {
+            unsafe {
+                self.nursery.set_free_ptr(gap_start as *mut u8);
+                self.nursery.set_top_ptr(nursery_end as *const u8);
+            }
+            self.refresh_published_nursery_top();
+            return self.nursery.alloc(total_size);
+        }
+        std::ptr::null_mut()
+    }
+
     /// Allocate without triggering collection.
     ///
     /// If the nursery cannot satisfy the request, this falls back directly to
     /// old-gen allocation so compiled code can keep running without needing
     /// stack-map-mediated collection.
     pub fn alloc_with_type_no_collect(&mut self, type_id: u32, payload_size: usize) -> GcRef {
-        let total_size = GcHeader::SIZE + payload_size;
+        let Some(total_size) = GcHeader::SIZE.checked_add(payload_size) else {
+            return GcRef(0);
+        };
 
         if total_size > self.config.large_object_threshold {
             return self.alloc_in_oldgen(type_id, total_size);
@@ -3746,6 +3849,7 @@ impl MiniMarkGC {
     /// and sets the free pointer past the highest pinned object.
     fn reset_nursery_with_pinned(&mut self) {
         let nursery_start = self.nursery.start_ptr() as usize;
+        let nursery_end = nursery_start + self.nursery.size();
 
         // Collect (header_start, total_size, data) for each pinned object.
         let mut saved: Vec<(usize, usize, Vec<u8>)> = Vec::new();
@@ -3765,6 +3869,13 @@ impl MiniMarkGC {
                 std::slice::from_raw_parts(header_start as *const u8, total_size).to_vec()
             };
             saved.push((header_start, total_size, data));
+        }
+
+        // Rebuild the barrier range from the whole arena. A preceding
+        // `reserve_nursery_gap` may have shortened `nursery_top` to the next
+        // pinned object, exactly as upstream does while consuming one gap.
+        unsafe {
+            self.nursery.set_top_ptr(nursery_end as *const u8);
         }
 
         // Zero-fill the entire nursery.
@@ -4076,7 +4187,10 @@ impl GcAllocator for MiniMarkGC {
     }
 
     fn alloc_varsize(&mut self, base_size: usize, item_size: usize, length: usize) -> GcRef {
-        let payload_size = base_size + item_size * length;
+        let Some(payload_size) = Self::checked_varsize_payload_size(base_size, item_size, length)
+        else {
+            return GcRef(0);
+        };
         self.alloc_with_type(0, payload_size)
     }
 
@@ -4087,7 +4201,10 @@ impl GcAllocator for MiniMarkGC {
         item_size: usize,
         length: usize,
     ) -> GcRef {
-        let payload_size = base_size + item_size * length;
+        let Some(payload_size) = Self::checked_varsize_payload_size(base_size, item_size, length)
+        else {
+            return GcRef(0);
+        };
         self.alloc_with_type(type_id, payload_size)
     }
 
@@ -4097,12 +4214,17 @@ impl GcAllocator for MiniMarkGC {
         item_size: usize,
         length: usize,
     ) -> GcRef {
-        let payload_size = base_size + item_size * length;
+        let Some(payload_size) = Self::checked_varsize_payload_size(base_size, item_size, length)
+        else {
+            return GcRef(0);
+        };
         self.alloc_with_type_no_collect(0, payload_size)
     }
 
     fn alloc_oldgen_typed(&mut self, type_id: u32, size: usize) -> GcRef {
-        let total_size = GcHeader::SIZE + size;
+        let Some(total_size) = GcHeader::SIZE.checked_add(size) else {
+            return GcRef(0);
+        };
         self.alloc_in_oldgen(type_id, total_size)
     }
 
@@ -4779,6 +4901,45 @@ mod tests {
         let obj = gc.alloc_with_type(0, 16);
         assert!(!obj.is_null());
         assert!(gc.is_in_nursery(obj.0));
+    }
+
+    #[test]
+    fn collect_and_reserve_uses_gap_before_pinned_object() {
+        fn arrange_pinned_tail(gc: &mut MiniMarkGC) -> (u32, GcRef) {
+            let pinned_tid = gc.register_type(TypeInfo::simple(440));
+            let result_tid = gc.register_type(TypeInfo::simple(400));
+            let _dead_prefix = gc.alloc_with_type(pinned_tid, 440);
+            let pinned = gc.alloc_with_type(pinned_tid, 440);
+            assert!(gc.pin(pinned));
+            (result_tid, pinned)
+        }
+
+        // incminimark.py:865-930 walks back to the free gap before a pinned
+        // object. The old fallback returned an old-gen object here, violating
+        // the fresh nursery allocation contract used by the GC rewrite.
+        let mut gc = test_gc(1024);
+        let (result_tid, pinned) = arrange_pinned_tail(&mut gc);
+        let result = gc.alloc_with_type(result_tid, 400);
+        assert!(gc.is_in_nursery(result.0));
+        assert!(result.0 < pinned.0);
+        assert_eq!(
+            unsafe { &*(gc.nursery_top_addr() as *const AtomicUsize) }.load(Ordering::Acquire),
+            pinned.0 - GcHeader::SIZE,
+            "compiled allocators must stop at the same pinned barrier",
+        );
+
+        // The rooted slow path has the same collect-and-reserve contract and
+        // must continue reporting that initialization needs no write barrier.
+        let mut gc = test_gc(1024);
+        let (result_tid, pinned) = arrange_pinned_tail(&mut gc);
+        let mut root = GcRef::NULL;
+        let mut needs_write_barrier = true;
+        let result = unsafe {
+            gc.alloc_with_type_rooted(result_tid, 400, &mut root, &mut needs_write_barrier)
+        };
+        assert!(gc.is_in_nursery(result.0));
+        assert!(result.0 < pinned.0);
+        assert!(!needs_write_barrier);
     }
 
     /// incminimark.py:2601-2615 `PYPY_GC_MAX` out-of-memory policy: a bounded
@@ -5577,6 +5738,24 @@ mod tests {
 
         gc.collect_nursery();
         gc.collect_full();
+    }
+
+    #[test]
+    fn varsize_allocation_overflow_returns_null() {
+        let mut gc = test_gc(4096);
+        let tid = gc.register_type(TypeInfo::simple(16));
+
+        // incminimark.py external_malloc turns either multiplication or
+        // addition overflow into MemoryError; the JIT allocator reports that
+        // condition as NULL to its CHECK_MEMORY_ERROR caller.
+        assert!(gc.alloc_varsize(0, 2, usize::MAX).is_null());
+        assert!(gc.alloc_varsize_typed(tid, usize::MAX, 1, 1).is_null());
+        assert!(gc.alloc_varsize_no_collect(0, usize::MAX, 2).is_null());
+
+        // Include the GC header in the same checked-size contract.
+        assert!(gc.alloc_nursery(usize::MAX).is_null());
+        assert!(gc.alloc_nursery_no_collect(usize::MAX).is_null());
+        assert!(gc.alloc_oldgen_typed(tid, usize::MAX).is_null());
     }
 
     /// llsupport/gc.py:563 GcLLDescr_framework

--- a/majit/majit-gc/src/shadow_stack.rs
+++ b/majit/majit-gc/src/shadow_stack.rs
@@ -1079,6 +1079,16 @@ pub fn resume_ref_roots_depth() -> usize {
     RESUME_REF_ROOTS_STACK.with(|ss| ss.borrow().len())
 }
 
+/// Whether a ref slice starting at `ptr` is currently registered as a
+/// resume-construction root on this thread.
+///
+/// Exists so the paths that materialize virtuals can assert their own
+/// precondition — the cache slice they write into has to be forwardable in
+/// place by a collection their allocations trigger — instead of arguing it.
+pub fn resume_ref_slice_registered(ptr: *const i64) -> bool {
+    RESUME_REF_ROOTS_STACK.with(|ss| ss.borrow().iter().any(|&(p, _)| p as *const i64 == ptr))
+}
+
 /// Register a ref slice as a GC root for the blackhole resume
 /// construction window (`resume.py:1312 blackhole_from_resumedata`).
 ///

--- a/majit/majit-macros/src/lib.rs
+++ b/majit/majit-macros/src/lib.rs
@@ -1183,8 +1183,12 @@ fn expand_elidable_attribute(item: TokenStream, attr_name: &str) -> TokenStream 
 /// Mark a function as opaque to the tracer.
 ///
 /// The JIT will not trace into this function; it will be called as a black box.
-/// Adds `#[inline(never)]` to prevent inlining, and a hidden `#[majit_opaque]`
-/// marker constant that the tracer can detect at compile time.
+/// `rlib/jit.py:133-140 @dont_look_inside` — sets `_jit_look_inside_ = False`
+/// (line 139) and nothing else.  This expansion carries that flag as the
+/// `_jit_look_inside_` marker const [`rpython_attribute_const_for`] emits next
+/// to the function; `front/llbc_hints.rs` harvests it out of the extracted LLBC
+/// and `front/mir.rs` turns it into the residual-call decision.  The policy is
+/// therefore a property of the marker, not of the function's codegen.
 #[proc_macro_attribute]
 pub fn dont_look_inside(_attr: TokenStream, item: TokenStream) -> TokenStream {
     expand_dont_look_inside_attribute(item, "dont_look_inside")
@@ -1304,9 +1308,20 @@ fn expand_dont_look_inside_attribute(item: TokenStream, attr_name: &str) -> Toke
     // inferred to `Assembler` at that single JIT-crate call site.
     let prebuild_name = format_ident!("__majit_inline_jitcode_{}_prebuild", sig.ident);
 
+    // No `#[inline(never)]`: the tracer's view of this function does not depend
+    // on how the host backend codegens it.  `@dont_look_inside` sets one flag
+    // (`rlib/jit.py:139 _jit_look_inside_ = False`) and leaves the C backend's
+    // inliner free to inline the body; the decision is read off the
+    // `_jit_look_inside_` marker const below, which `front/llbc_hints.rs`
+    // harvests from the extracted LLBC.  That LLBC cannot be reshaped by an
+    // inlining attribute either — Charon disables the MIR optimizations
+    // (`charon cargo --mir`: "Charon disables all the optimizations it can"),
+    // so no `dont_look_inside` body is folded into a traced caller regardless.
+    // Residual call targets are likewise unaffected: they resolve through the
+    // function-item coercions `pyre-interpreter/src/jit_fnaddr.rs` writes by
+    // hand, not through a linker symbol.
     let expanded = quote! {
         #(#attrs)*
-        #[inline(never)]
         #[doc(hidden)]
         #[allow(non_upper_case_globals)]
         #vis #sig {

--- a/majit/majit-macros/src/lib.rs
+++ b/majit/majit-macros/src/lib.rs
@@ -1073,8 +1073,12 @@ pub fn jit_driver(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// Mark a function as elidable (pure / constant-foldable).
 ///
 /// The JIT can eliminate calls to this function when all arguments are constants.
-/// Adds `#[inline(never)]` to prevent inlining, and a hidden `#[majit_elidable]`
-/// marker attribute that the tracer can detect at compile time.
+/// `rlib/jit.py:14-73 elidable` sets `_elidable_function_ = True` (line 72) and
+/// nothing else.  This expansion carries that flag as the marker const
+/// [`rpython_attribute_const_for`] emits next to the function, which
+/// `front/llbc_hints.rs` harvests out of the extracted LLBC; the constant fold
+/// itself reaches the separate `__majit_call_target_*` trampoline, keyed by
+/// path.  Neither channel is a property of the function's codegen.
 ///
 /// `#[elidable]` is the conservative `EF_ELIDABLE_CAN_RAISE` form
 /// (`rpython/jit/codewriter/effectinfo.py:21`), matching `call.py:297
@@ -1160,9 +1164,15 @@ fn expand_elidable_attribute(item: TokenStream, attr_name: &str) -> TokenStream 
     };
     let rpython_attribute_const = rpython_attribute_const_for(attr_name, sig, vis);
 
+    // No `#[inline(never)]`: `rlib/jit.py:72` sets `_elidable_function_ = True`
+    // and leaves the backend's inliner alone.  Upstream keeps a separate flag,
+    // `_dont_inline_` (`objectmodel.py:214`, read by
+    // `translator/backendopt/inline.py:565`), for suppressing inlining, and no
+    // elidable helper upstream carries it.  The constant fold reaches the
+    // `__majit_call_target_*` trampoline below, whose address is taken and so
+    // codegen'd out of line regardless.
     let expanded = quote! {
         #(#attrs)*
-        #[inline(never)]
         #[doc(hidden)]
         #[allow(non_upper_case_globals)]
         #vis #sig {
@@ -1423,9 +1433,27 @@ fn expand_call_surface_attr(
     };
     let rpython_attribute_const = rpython_attribute_const_for(attr_name, sig, vis);
 
+    // Only the release-gil surface suppresses inlining upstream, and it does so
+    // for a GC reason rather than a tracing one: `rffi.py:219
+    // call_external_function._dont_inline_ = True` alongside `:220
+    // _gctransformer_hint_close_stack_ = True`, explained at `:232` as "don't
+    // inline, as a hack to guarantee that no GC pointer is alive anywhere in
+    // call_external_function" — the body runs with the GIL released, so a
+    // caller folded into it would put live GC pointers in that window.
+    // `_dont_inline_` (`objectmodel.py:214`) is the backend-inliner flag read by
+    // `translator/backendopt/inline.py:565`, orthogonal to tracing policy;
+    // `jit_may_force` has no upstream decorator at all
+    // (`EF_FORCES_VIRTUAL_OR_VIRTUALIZABLE` is derived from the analyzed ops in
+    // `effectinfo.py:401-404`) and `loop_invariant` sets only its own flag.
+    let dont_inline = if attr_name == "jit_release_gil" {
+        quote! { #[inline(never)] }
+    } else {
+        quote! {}
+    };
+
     let expanded = quote! {
         #(#attrs)*
-        #[inline(never)]
+        #dont_inline
         #[doc(hidden)]
         #[allow(non_upper_case_globals)]
         #vis #sig {
@@ -2107,8 +2135,9 @@ pub fn elidable_promote(attr: TokenStream, item: TokenStream) -> TokenStream {
     };
 
     let expanded = quote! {
-        // rlib/jit.py:184-185 — elidable(func); original body hidden
-        #[inline(never)]
+        // rlib/jit.py:184-185 — elidable(func); original body hidden.
+        // `elidable` sets only `_elidable_function_`, and the exec-built
+        // promote wrapper (jit.py:188-200) sets no inlining flag either.
         #[doc(hidden)]
         #[allow(non_upper_case_globals)]
         fn #orig_name(#(#full_params),*) #output {
@@ -2265,7 +2294,8 @@ pub fn look_inside_iff(attr: TokenStream, item: TokenStream) -> TokenStream {
         }
 
         // rlib/jit.py:231-233 — @dont_look_inside def trampoline(...): return func(...)
-        #[inline(never)]
+        // `dont_look_inside` is a tracing-policy marker only (jit.py:139), so
+        // the trampoline carries no inlining attribute either.
         #[doc(hidden)]
         #[allow(non_upper_case_globals)]
         fn #trampoline_name(#(#full_params),*) #output {

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -5299,8 +5299,31 @@ impl<S: JitState> JitDriver<S> {
             self.meta
                 .must_compile_with_values(&descr_arc, &raw_values, fallback_green_key);
         // compile.py:702-703: must_compile() and not stack_almost_full().
-        let should_bridge =
-            must_compile && !majit_metainterp::MetaInterp::<S::Meta>::stack_almost_full();
+        // `no_bridge_enabled()` is the same opt-out the two sibling loops
+        // apply; this is the loop pyre actually runs, so leaving it out made
+        // `MAJIT_NO_BRIDGE=1` report a bridge-free run while still compiling
+        // every bridge.
+        let should_bridge = must_compile
+            && !majit_metainterp::MetaInterp::<S::Meta>::stack_almost_full()
+            && !no_bridge_enabled();
+
+        // Same `@@@GUARD` line the sibling loops emit. Without it this loop —
+        // the one pyre reaches — had no per-guard-failure trace at all, so
+        // identifying a failing guard meant reading the whole `MAJIT_LOG`
+        // stream. `resume_pc` is resolved by the caller here, so report the
+        // guard's own coordinates instead.
+        if guardlog_enabled() {
+            let preview: Vec<i64> = raw_values.iter().take(6).map(|v| *v as i64).collect();
+            eprintln!(
+                "@@@GUARD key={} trace={} fail={} bridge={} nvals={} vals={:?}",
+                owning_key,
+                trace_id,
+                fail_index,
+                should_bridge,
+                raw_values.len(),
+                preview
+            );
+        }
 
         // Return raw guard failure data. State restoration and bridge/
         // blackhole decision happen in the caller's handle_fail().

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -1904,6 +1904,23 @@ impl<M: Clone> MetaInterp<M> {
     ///
     /// Unmaterialized `0` cache slots pass through unchanged, as they do in
     /// `shadow_stack::walk_resume_ref_roots`.
+    ///
+    /// The walk is unconditional, so it is a strong edge where `jf_savedata` is
+    /// an ephemeron one: a major seeds these values from `seed_major_roots`,
+    /// while [`Self::prune_forced_virtuals`] can only drop a dead owner's entry
+    /// at the *end* of marking, once VISITED is decided. An entry whose owner
+    /// died inside the cycle therefore keeps its materialized graph until the
+    /// next major — one cycle of floating garbage, bounded: the sweep clears
+    /// VISITED on every survivor and the entry is gone, and the sole writer
+    /// (`save_forced_virtuals`) is reached only by forcing a live virtualizable,
+    /// so nothing re-adds it. The prune also strictly precedes the sweep, so a
+    /// named owner's address can never be recycled underneath an entry.
+    ///
+    /// That bound holds only while no cached virtual reaches the owner frame: a
+    /// back-edge would let this walk mark the owner, `classify_owner` would then
+    /// answer `Some`, and the entry would never be pruned at all. The vable is
+    /// returned beside the cache rather than inside it (`force_from_resumedata`)
+    /// and no such edge exists today.
     pub fn walk_forced_virtuals_refs(&mut self, mut visitor: impl FnMut(&mut GcRef)) {
         for (_owner, ptrs, _ints) in self.forced_virtuals.iter_mut() {
             for slot in ptrs.iter_mut() {

--- a/majit/majit-metainterp/src/resume.rs
+++ b/majit/majit-metainterp/src/resume.rs
@@ -6722,6 +6722,18 @@ impl<'a> ResumeDataDirectReader<'a> {
 
     /// resume.py:969 force_all_virtuals
     pub fn force_all_virtuals(&mut self) -> (&[i64], &[i64]) {
+        // Materializing one virtual allocates, so it can trigger a collection
+        // that relocates the virtuals materialized before it. `getvirtual_ptr`
+        // answers with the cache slot rather than `allocate`'s raw result on
+        // the premise that the slot is a registered root the collection
+        // forwards in place; check the premise here, once per force.
+        debug_assert!(
+            self.virtuals_cache.virtuals_ptr_cache.is_empty()
+                || majit_gc::shadow_stack::resume_ref_slice_registered(
+                    self.virtuals_cache.virtuals_ptr_cache.as_ptr()
+                ),
+            "force_all_virtuals: virtuals_ptr_cache is not a registered resume root"
+        );
         if let Some(rd_virtuals) = self.rd_virtuals {
             for i in 0..rd_virtuals.len() {
                 let rd_virtual = &rd_virtuals[i];
@@ -7663,14 +7675,24 @@ pub fn force_from_resumedata<'a>(
     );
     // resume.py:1371 common-case __init__ calls self._prepare(storage)
     // before handling_async_forcing() flips the GUARD_NOT_FORCED state.
-    resumereader.prepare(rd_virtuals, rd_guard_pendingfields);
+    //
+    // The scope must outlive `force_all_virtuals` below. `getvirtual_ptr`
+    // returns the cache slot rather than `allocate`'s result precisely because
+    // a materialization collection is expected to forward that slot in place;
+    // with a bare `prepare` the slice is registered nowhere, so a minor
+    // triggered while materializing virtual N leaves every virtual already
+    // written for N-1 pointing into from-space, and a major sweeps them.
+    let _resume_roots =
+        prepare_resume_heap_with_roots(&mut resumereader, rd_virtuals, rd_guard_pendingfields);
     resumereader.handling_async_forcing();
     // resume.py:1350
     resumereader.consume_vref_and_vable(vrefinfo, vinfo, ginfo, None);
-    // resume.py:1404 the virtualizable the vable section just named. Read it
-    // before `force_all_virtuals` allocates: unlike `blackhole_from_resumedata`,
-    // the bare `prepare` above opened no resume-root scope, so there is nothing
-    // to forward the reader's slot in place.
+    // resume.py:1404 the virtualizable the vable section just named. The scope
+    // above roots `virtuals_ptr_cache` only, not this field, so nothing would
+    // forward the reader's slot in place — read it before `force_all_virtuals`
+    // allocates. The value stays valid across that window because a
+    // virtualizable is an interpreter-created frame from `FrameBox::new` →
+    // `try_gc_alloc_stable_raw`, which no collection moves.
     let virtualizable_ptr = resumereader.virtualizable_ptr;
     // resume.py:1351: return resumereader.force_all_virtuals()
     let (ptrs, ints) = resumereader.force_all_virtuals();

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -3414,6 +3414,38 @@ impl TraceCtx {
         self.box_value(elem)
     }
 
+    /// Resolve the array-base `OpRef` (`frame.locals_cells_stack_w`) for a
+    /// NONSTANDARD virtualizable the way `opimpl_getfield_gc_r` does
+    /// (`_opimpl_getfield_gc_any_pureornot`, pyjitpl.py): forward the cached
+    /// field box on a hit, otherwise record the `GetfieldGcR` once and publish
+    /// it with `getfield_now_known`.
+    ///
+    /// Every `getarrayitem_vable` / `setarrayitem_vable` on such a frame has to
+    /// come through here, because the per-array element cache is keyed by this
+    /// base `OpRef`.  Recording a fresh base per access instead keys each store
+    /// under an `OpRef` no read ever looks up, so a store neither updates nor
+    /// invalidates the entry the reads share — a local written after the read
+    /// that seeded the cache then keeps reading its pre-store value for as long
+    /// as the base stays cached.
+    fn nonstandard_vable_array_base(&mut self, vable_opref: OpRef, fdescr: &DescrRef) -> OpRef {
+        let record_descr = self.vable_array_record_descr(fdescr);
+        let field_index = record_descr.index();
+        if let Some(cached) = self.heapcache_getfield_cached(vable_opref, field_index) {
+            self.profiler().count_ops(
+                OpCode::GetfieldGcR,
+                crate::pyjitpl::counters::HEAPCACHED_OPS,
+            );
+            return cached;
+        }
+        self.profiler()
+            .count_ops(OpCode::GetfieldGcR, crate::counters::OPS);
+        self.profiler()
+            .count_ops(OpCode::GetfieldGcR, crate::counters::RECORDED_OPS);
+        let op = self.record_op_with_descr(OpCode::GetfieldGcR, &[vable_opref], record_descr);
+        self.heapcache_getfield_now_known(vable_opref, field_index, op);
+        op
+    }
+
     /// pyjitpl.py:1167-1172 `opimpl_getfield_vable_i(box, fielddescr, pc)`.
     ///
     /// ```text
@@ -4025,13 +4057,7 @@ impl TraceCtx {
         if self.is_nonstandard_virtualizable(pc, vable_opref, &fdescr, concrete) {
             // arraybox = self.opimpl_getfield_gc_r(box, fdescr)
             // return self.opimpl_getarrayitem_gc_i(arraybox, indexbox, adescr)
-            let record_descr = self.vable_array_record_descr(&fdescr);
-            self.profiler()
-                .count_ops(OpCode::GetfieldGcR, crate::counters::OPS);
-            self.profiler()
-                .count_ops(OpCode::GetfieldGcR, crate::counters::RECORDED_OPS);
-            let array_opref =
-                self.record_op_with_descr(OpCode::GetfieldGcR, &[vable_opref], record_descr);
+            let array_opref = self.nonstandard_vable_array_base(vable_opref, &fdescr);
             return (
                 self.vable_getarrayitem_int_descr(array_opref, index, adescr),
                 None,
@@ -4103,13 +4129,7 @@ impl TraceCtx {
                 index,
                 adescr.index(),
             );
-            let record_descr = self.vable_array_record_descr(&fdescr);
-            self.profiler()
-                .count_ops(OpCode::GetfieldGcR, crate::counters::OPS);
-            self.profiler()
-                .count_ops(OpCode::GetfieldGcR, crate::counters::RECORDED_OPS);
-            let array_opref =
-                self.record_op_with_descr(OpCode::GetfieldGcR, &[vable_opref], record_descr);
+            let array_opref = self.nonstandard_vable_array_base(vable_opref, &fdescr);
             let item = self.vable_getarrayitem_ref_descr(array_opref, index, adescr);
             if let Some(v) = fwd {
                 self.set_opref_concrete(item, v);
@@ -4174,13 +4194,7 @@ impl TraceCtx {
     ) -> (OpRef, Option<Value>) {
         let concrete = self.concrete_of_opref(vable_opref);
         if self.is_nonstandard_virtualizable(pc, vable_opref, &fdescr, concrete) {
-            let record_descr = self.vable_array_record_descr(&fdescr);
-            self.profiler()
-                .count_ops(OpCode::GetfieldGcR, crate::counters::OPS);
-            self.profiler()
-                .count_ops(OpCode::GetfieldGcR, crate::counters::RECORDED_OPS);
-            let array_opref =
-                self.record_op_with_descr(OpCode::GetfieldGcR, &[vable_opref], record_descr);
+            let array_opref = self.nonstandard_vable_array_base(vable_opref, &fdescr);
             return (
                 self.vable_getarrayitem_float_descr(array_opref, index, adescr),
                 None,
@@ -4244,18 +4258,12 @@ impl TraceCtx {
     ) -> bool {
         let vable_concrete = self.concrete_of_opref(vable_opref);
         if self.is_nonstandard_virtualizable(pc, vable_opref, &fdescr, vable_concrete) {
-            let record_descr = self.vable_array_record_descr(&fdescr);
-            self.profiler()
-                .count_ops(OpCode::GetfieldGcR, crate::counters::OPS);
-            self.profiler()
-                .count_ops(OpCode::GetfieldGcR, crate::counters::RECORDED_OPS);
-            let array_opref =
-                self.record_op_with_descr(OpCode::GetfieldGcR, &[vable_opref], record_descr);
+            let array_opref = self.nonstandard_vable_array_base(vable_opref, &fdescr);
             self.profiler()
                 .count_ops(OpCode::SetarrayitemGc, crate::counters::OPS);
             self.profiler()
                 .count_ops(OpCode::SetarrayitemGc, crate::counters::RECORDED_OPS);
-            self.vable_setarrayitem_descr(array_opref, index, value, adescr);
+            self.execute_setarrayitem_gc(array_opref, index, value, adescr);
             return true;
         }
         // index = self._get_arrayitem_vable_index(pc, fdescr, indexbox)
@@ -4487,6 +4495,29 @@ impl TraceCtx {
         descr: DescrRef,
     ) {
         self.record_op_with_descr(OpCode::SetarrayitemGc, &[array_opref, index, value], descr);
+    }
+
+    /// `execute_setarrayitem_gc(arraydescr, arraybox, indexbox, itembox)`
+    /// (pyjitpl.py): record the `SETARRAYITEM_GC`, then publish the stored item
+    /// to the heapcache.  `gen_store_back_in_vable` deliberately does NOT come
+    /// through here — it records the op directly — so the raw recording form
+    /// stays available as `vable_setarrayitem_descr`.
+    ///
+    /// The heapcache write is what keeps a later read of the same slot from
+    /// forwarding the value the cache was seeded with: the element cache is the
+    /// only thing a nonstandard virtualizable's reads consult for the stored
+    /// box, so a store that skips it leaves every subsequent read answering the
+    /// pre-store value.
+    fn execute_setarrayitem_gc(
+        &mut self,
+        array_opref: OpRef,
+        index: OpRef,
+        value: OpRef,
+        descr: DescrRef,
+    ) {
+        let descr_index = descr.index();
+        self.vable_setarrayitem_descr(array_opref, index, value, descr);
+        self.heapcache_setarrayitem(array_opref, index, descr_index, value);
     }
 }
 

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -4489,7 +4489,8 @@ impl<'a> Lowering<'a> {
                 // the recognizer is a capstone that cannot plant its unwired
                 // `getslice` + Void `ConstNone` into the co-wall-blocked
                 // `&args[1..]` graphs without crashing the legacy walker (see
-                // the post-pass note in `simplify_and_finalize`).  Re-enable
+                // the companion note in
+                // `lower_unstructured_with_static_addrs_and_attrs`).  Re-enable
                 // the `slice_index_rangefrom_sites` push here + the post-pass
                 // once those graphs' co-walls close.
                 // Surface every operand through a separate FieldWrite so
@@ -7071,10 +7072,12 @@ impl<'a> Lowering<'a> {
                     self.graph.set_goto(bb_id, target_bb, link_args);
                     return Ok(());
                 }
-                // `<[T]>::as_ptr` / `Vec::as_ptr` — the slice's data pointer is
-                // the receiver value in the erased array-pointer model.  Alias
-                // the result to the receiver (twin of the `as_slice` identity
-                // above and `NonNull::as_ptr`).
+                // `<[T]>::as_ptr` — the slice's data pointer is the receiver
+                // value in the erased array-pointer model.  Alias the result to
+                // the receiver (twin of the `as_slice` identity above and
+                // `NonNull::as_ptr`).  A `Vec::as_ptr` is deliberately excluded
+                // (its items live behind a getfield, not the receiver) — see
+                // `is_container_as_ptr_identity`.
                 if args.len() == 1 && self.is_container_as_ptr_identity(&reg) {
                     self.local_var[dest_local] = Some(args[0].clone());
                     let target_bb = self.block_id[target];
@@ -9410,15 +9413,24 @@ impl<'a> Lowering<'a> {
         })
     }
 
-    /// `<[T]>::as_ptr` / `Vec::as_ptr` — the data-pointer projection of a
-    /// slice or vector receiver.  In the erased value-model a `&[T]` collapses
-    /// to a single GC array pointer (its length is read from the array header
-    /// by `ArrayLen`, not a companion fat-pointer word), so the slice's data
-    /// pointer IS the receiver value.  Alias the result to the receiver — the
-    /// same identity fold as `NonNull::as_ptr` (`nonnull_new_identity_alias`)
-    /// and `as_slice` above — instead of leaving an unregistered
-    /// `core::slice::<Impl>::as_ptr` residual whose only prior handling was a
-    /// `FOREIGN_STDLIB_EXTERNALS` `Address` annotation with no host address.
+    /// `<[T]>::as_ptr` — the data-pointer projection of a slice receiver.  In
+    /// the erased value-model a `&[T]` collapses to a single GC array pointer
+    /// (its length is read from the array header by `ArrayLen`, not a companion
+    /// fat-pointer word), so the slice's data pointer IS the receiver value.
+    /// Alias the result to the receiver — the same identity fold as
+    /// `NonNull::as_ptr` (`nonnull_new_identity_alias`) and `as_slice` above —
+    /// instead of leaving an unregistered `core::slice::<Impl>::as_ptr`
+    /// residual whose only prior handling was a `FOREIGN_STDLIB_EXTERNALS`
+    /// `Address` annotation with no host address.
+    ///
+    /// This is a fixed-array identity ONLY: it mirrors `ll_fixed_items(l) = l`
+    /// (`rlist.py:399`, a `FixedSizeListRepr` IS its items array).  A resized
+    /// list / `Vec` reaches its items buffer through `ll_items(l) = l.items`
+    /// (`rlist.py:368`, a `getfield`), so `alloc::vec::<Impl>::as_ptr` is NOT
+    /// an identity on the receiver and must not fold here — it stays a residual
+    /// (the only two callers, `IntArray`/`FloatArray::from_vec`, are host
+    /// builtins residualised to their compiled bodies, so no traced consumer
+    /// dereferences the folded header).
     fn is_container_as_ptr_identity(&self, reg: &RegularCall) -> bool {
         let CallKind::Fun(FunId::Regular { id }) = &reg.kind else {
             return false;
@@ -9426,7 +9438,7 @@ impl<'a> Lowering<'a> {
         self.llbc.fn_by_id(*id).is_some_and(|fd| {
             matches!(
                 fd.item_meta.name_path().as_str(),
-                "core::slice::<Impl>::as_ptr" | "alloc::vec::<Impl>::as_ptr"
+                "core::slice::<Impl>::as_ptr"
             )
         })
     }

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -127,7 +127,7 @@ pub fn build_semantic_program_from_llbcs_with_static_addrs(
     llbcs: &[Llbc],
     static_addrs: crate::HostStaticAddrs<'_>,
 ) -> Result<crate::front::semantic::SemanticProgram, LowerError> {
-    build_semantic_program_from_llbcs_with_static_addrs_filtered(llbcs, static_addrs, None)
+    build_semantic_program_from_llbcs_with_static_addrs_filtered(llbcs, static_addrs, None, None)
 }
 
 pub fn build_semantic_program_from_llbcs_with_static_addrs_and_module_paths(
@@ -140,6 +140,37 @@ pub fn build_semantic_program_from_llbcs_with_static_addrs_and_module_paths(
         llbcs,
         static_addrs,
         module_filter.as_ref(),
+        None,
+    )
+}
+
+/// The `module_paths` entry point narrowed further to a set of leaf
+/// function names.
+///
+/// A fixture that asserts on a handful of named graphs pays for lowering
+/// every function the module filter admits, which for `pyre-interpreter`
+/// is thousands of bodies. `function_names` keeps the same whole-program
+/// metadata — the type and trait tables that decide how a body lowers are
+/// still derived from the entire `llbc` — and only skips building the
+/// bodies nothing will read. A name that matches in several modules
+/// lowers in each; the allowlist is a leaf name, not a path.
+///
+/// Only the bodies are dropped, so a fixture that reaches for a graph it
+/// forgot to list fails loudly on the missing lookup rather than
+/// silently asserting over a smaller program.
+pub fn build_semantic_program_from_llbcs_with_static_addrs_and_function_names(
+    llbcs: &[Llbc],
+    static_addrs: crate::HostStaticAddrs<'_>,
+    module_paths: &[&str],
+    function_names: &[&str],
+) -> Result<crate::front::semantic::SemanticProgram, LowerError> {
+    let module_filter = normalize_module_filter(module_paths);
+    let function_filter = normalize_function_filter(function_names);
+    build_semantic_program_from_llbcs_with_static_addrs_filtered(
+        llbcs,
+        static_addrs,
+        module_filter.as_ref(),
+        function_filter.as_ref(),
     )
 }
 
@@ -147,6 +178,7 @@ fn build_semantic_program_from_llbcs_with_static_addrs_filtered(
     llbcs: &[Llbc],
     static_addrs: crate::HostStaticAddrs<'_>,
     module_filter: Option<&std::collections::HashSet<String>>,
+    function_filter: Option<&std::collections::HashSet<String>>,
 ) -> Result<crate::front::semantic::SemanticProgram, LowerError> {
     let mut merged: Option<crate::front::semantic::SemanticProgram> = None;
     // Dedup key combines `self_ty_root` (the impl owner, when known),
@@ -177,6 +209,7 @@ fn build_semantic_program_from_llbcs_with_static_addrs_filtered(
             llbc,
             static_addrs,
             module_filter,
+            function_filter,
         )?;
         match &mut merged {
             None => {
@@ -288,6 +321,16 @@ fn normalize_module_filter(module_paths: &[&str]) -> Option<std::collections::Ha
         .map(str::to_string)
         .collect();
     (!modules.is_empty()).then_some(modules)
+}
+
+fn normalize_function_filter(function_names: &[&str]) -> Option<std::collections::HashSet<String>> {
+    let names: std::collections::HashSet<String> = function_names
+        .iter()
+        .copied()
+        .filter(|name| !name.is_empty())
+        .map(str::to_string)
+        .collect();
+    (!names.is_empty()).then_some(names)
 }
 
 /// Build a [`SemanticProgram`] by lowering every local function
@@ -636,7 +679,7 @@ pub fn build_semantic_program_from_llbc_with_static_addrs(
     llbc: &Llbc,
     static_addrs: crate::HostStaticAddrs<'_>,
 ) -> Result<crate::front::semantic::SemanticProgram, LowerError> {
-    build_semantic_program_from_llbc_with_static_addrs_filtered(llbc, static_addrs, None)
+    build_semantic_program_from_llbc_with_static_addrs_filtered(llbc, static_addrs, None, None)
 }
 
 /// One block's slot-indexed `Option<Variable>` row, stored by bound slot.
@@ -740,6 +783,7 @@ fn build_semantic_program_from_llbc_with_static_addrs_filtered(
     llbc: &Llbc,
     static_addrs: crate::HostStaticAddrs<'_>,
     module_filter: Option<&std::collections::HashSet<String>>,
+    function_filter: Option<&std::collections::HashSet<String>>,
 ) -> Result<crate::front::semantic::SemanticProgram, LowerError> {
     // ── Pass 1: walk type_decls + trait_decls ─────────────────────
     let (
@@ -846,13 +890,6 @@ fn build_semantic_program_from_llbc_with_static_addrs_filtered(
     let mut functions = Vec::new();
     let mut skipped: Vec<(String, String)> = Vec::new();
     for fd in llbc.iter_local_fns() {
-        // `FunDecl::body` is raw JSON and `unstructured()` re-parses it on
-        // every call, so hold the one projection this iteration needs: it
-        // is both the "has a lowerable body" gate and the input the
-        // lowering below reads.
-        let Some(body) = fd.unstructured() else {
-            continue;
-        };
         // Charon emits static / const initialiser bodies (e.g. the
         // body that builds `static NONE_SINGLETON`) as ordinary
         // `FunDecl` entries with `is_global_initializer` set to the
@@ -879,6 +916,9 @@ fn build_semantic_program_from_llbc_with_static_addrs_filtered(
         if !should_lower_module(module_filter, &module_path) {
             continue;
         }
+        if !should_lower_function(function_filter, &name) {
+            continue;
+        }
         let fn_path = if module_path.is_empty() {
             name.clone()
         } else {
@@ -887,6 +927,15 @@ fn build_semantic_program_from_llbc_with_static_addrs_filtered(
         if not_rpython.contains(&fn_path) {
             continue;
         }
+        // `FunDecl::body` is raw JSON and `unstructured()` re-parses it on
+        // every call, so hold the one projection this iteration needs: it
+        // is both the "has a lowerable body" gate and the input the
+        // lowering below reads.  Every gate above reads the declaration's
+        // name path or header alone, so they run first and a filtered-out
+        // declaration never pays for the parse.
+        let Some(body) = fd.unstructured() else {
+            continue;
+        };
         // A single function whose body the driver does not yet handle
         // should not abort the whole-program build.  Capture
         // per-function errors into a side bucket and continue; they are
@@ -1089,6 +1138,18 @@ fn should_lower_module(
     // under `pyre_interpreter::module::*`, whose large dispatch/register
     // bodies are not part of the JIT portal closure.
     !(module_path == "module" || module_path.starts_with("module::"))
+}
+
+/// Leaf-name allowlist companion to [`should_lower_module`].
+///
+/// `None` lowers every name the module gate admitted — the production
+/// pipeline's shape, where the entry-point closure rather than a name list
+/// decides what matters.
+fn should_lower_function(
+    function_filter: Option<&std::collections::HashSet<String>>,
+    name: &str,
+) -> bool {
+    function_filter.is_none_or(|names| names.contains(name))
 }
 
 /// Derive whole-program type-metadata fields of `SemanticProgram` from

--- a/majit/majit-translate/src/front/slice_index.rs
+++ b/majit/majit-translate/src/front/slice_index.rs
@@ -306,12 +306,19 @@ fn range_feeds_only_index(
             if !reads_range {
                 continue;
             }
-            // A construction `FieldWrite` (base in the closure) writes the
-            // `RangeFrom`'s `start`; the `slice::index` op reads the range as
-            // its `range` operand. Both are removed / rewritten; anything else
-            // is a genuine second consumer.
+            // A construction `FieldWrite` on the `RangeFrom` value writes its
+            // `start`; the `slice::index` op reads the range as its `range`
+            // operand. Both are removed / rewritten; anything else is a genuine
+            // second consumer. The base must be the range value ITSELF, not any
+            // aliased inputarg in the closure: `rewire_one_slice_index_site`'s
+            // removal sweep drops only a `FieldWrite` with `base == range`, so
+            // accepting an aliased-base write here would leave that write
+            // behind after its ctor is removed — an undefined-operand shape
+            // `flowspace_adapter` rejects. `front::mir` emits the ctor and the
+            // `start` write in one block (`base == range`), so this loses no
+            // real site; a range threaded across a block edge declines cleanly.
             let is_construction_write =
-                matches!(&op.kind, OpKind::FieldWrite { base, .. } if in_closure(base));
+                matches!(&op.kind, OpKind::FieldWrite { base, .. } if base == range_result);
             let is_index = op.result.as_ref() == Some(index_result);
             if !(is_construction_write || is_index) {
                 return false;

--- a/majit/majit-translate/src/translator/rtyper/llinterp.rs
+++ b/majit/majit-translate/src/translator/rtyper/llinterp.rs
@@ -1486,6 +1486,54 @@ mod tests {
     }
 
     #[test]
+    fn getoperationhandler_malloc_varsize_rejects_negative_length() {
+        // A `malloc_varsize` whose length is negative must fail before any
+        // allocation: the `usize::try_from(n_signed)` guard turns a `-1` length
+        // into a `TaskError` ("negative varsize length") rather than allocating
+        // a wrapped-huge array. Same graph shape as the write-through test,
+        // stopped at the single failing malloc.
+        use crate::flowspace::model::Constant as FlowConstant;
+        use crate::translator::rtyper::lltypesystem::lltype::Array;
+
+        let char_array = LowLevelType::Array(Box::new(Array::gc(LowLevelType::Char)));
+        let type_c = Hlvalue::Constant(FlowConstant::new(ConstValue::LowLevelType(Box::new(
+            char_array,
+        ))));
+        let flavor_c = Hlvalue::Constant(FlowConstant::new(ConstValue::Dict(
+            std::collections::HashMap::new(),
+        )));
+        let neg_len = Hlvalue::Constant(FlowConstant::new(ConstValue::Int(-1)));
+
+        let arr = Variable::named("arr");
+        let start = Block::shared(vec![]);
+        start.borrow_mut().operations.push(SpaceOperation::new(
+            "malloc_varsize",
+            vec![type_c, flavor_c, neg_len],
+            arr.clone().into(),
+        ));
+
+        let graph = Rc::new(RefCell::new(FunctionGraph::with_return_var(
+            "malloc_neg",
+            start.clone(),
+            arr.clone().into(),
+        )));
+        let returnblock = graph.borrow().returnblock.clone();
+        start.closeblock(vec![
+            Link::new(vec![arr.into()], Some(returnblock), None).into_ref(),
+        ]);
+
+        let interp = Rc::new(LLInterpreter::new(fixture_typer(), false, None));
+        let err = interp
+            .eval_graph(graph as Rc<dyn Any>, Vec::new(), false)
+            .expect_err("negative varsize length must abort evaluation before allocating");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("negative varsize length"),
+            "expected a negative-length rejection, got {msg:?}"
+        );
+    }
+
+    #[test]
     fn build_ll_int2dec_executes_to_decimal_strings() {
         // Slice C: run the synthesised `ll_int2dec` helper graph
         // (`lltypesystem/rstr.rs`) end-to-end through the interpreter and read

--- a/majit/majit-translate/src/translator/rtyper/rlist.rs
+++ b/majit/majit-translate/src/translator/rtyper/rlist.rs
@@ -3340,6 +3340,15 @@ fn emit_listslice_alloc_and_copy(
     newlength: &Variable,
 ) {
     let items_ptr = items_array_ptr_lltype(item_lltype);
+    // The result repr (`hop.r_result`) is a fixed list when the slice is never
+    // resized (`ListDef.offspring` keeps `resized=False`), so `ll_newlist`
+    // returns a bare `Ptr(GcArray)` with no `items` field; a resized result is
+    // a header reaching its array through `items`.  Read the result layout off
+    // its pointer lltype and branch `dst_items` the same way `src_items`
+    // branches on `source_layout` (`ll_arraycopy` uses `dest.ll_items()`,
+    // rlist.py:555-559, which is `ll_fixed_items(l) = l` for a fixed list).
+    let result_layout = list_layout_from_lltype(&result_ptr_lltype)
+        .expect("getslice result lltype must be a list pointer");
     // l = RESLIST.ll_newlist(newlength).
     let new_lst = variable_with_lltype("new_lst", result_ptr_lltype);
     block.borrow_mut().operations.push(SpaceOperation::new(
@@ -3351,8 +3360,7 @@ fn emit_listslice_alloc_and_copy(
         Hlvalue::Variable(new_lst.clone()),
     ));
     // src items (per source layout): a fixed list IS its items array; a resized
-    // header reaches the array through `items`. The result is always resized
-    // (`hop.r_result`), so its items come through `items`.
+    // header reaches the array through `items`.
     let src_items = match source_layout {
         ListLayout::Fixed => Hlvalue::Variable(l.clone()),
         ListLayout::Resized => {
@@ -3365,15 +3373,22 @@ fn emit_listslice_alloc_and_copy(
             Hlvalue::Variable(items)
         }
     };
-    let dst_items = variable_with_lltype("dst_items", items_ptr);
-    block.borrow_mut().operations.push(SpaceOperation::new(
-        "getfield",
-        vec![
-            Hlvalue::Variable(new_lst.clone()),
-            void_field_const("items"),
-        ],
-        Hlvalue::Variable(dst_items.clone()),
-    ));
+    // dst items (per result layout): mirror the source branch above.
+    let dst_items = match result_layout {
+        ListLayout::Fixed => Hlvalue::Variable(new_lst.clone()),
+        ListLayout::Resized => {
+            let items = variable_with_lltype("dst_items", items_ptr);
+            block.borrow_mut().operations.push(SpaceOperation::new(
+                "getfield",
+                vec![
+                    Hlvalue::Variable(new_lst.clone()),
+                    void_field_const("items"),
+                ],
+                Hlvalue::Variable(items.clone()),
+            ));
+            Hlvalue::Variable(items)
+        }
+    };
     // ll_arraycopy(src_items, dst_items, src_start, 0, newlength).
     let copy_void = variable_with_lltype("v", LowLevelType::Void);
     block.borrow_mut().operations.push(SpaceOperation::new(
@@ -3381,7 +3396,7 @@ fn emit_listslice_alloc_and_copy(
         vec![
             Hlvalue::Constant(copy_const),
             src_items,
-            Hlvalue::Variable(dst_items),
+            dst_items,
             src_start,
             signed_const(0),
             Hlvalue::Variable(newlength.clone()),
@@ -3797,13 +3812,14 @@ fn rtype_bltn_list_via_ll_copy(
 ///     return hop.gendirectcall(ll_listslice, cRESLIST, v_lst, *vlist)
 /// ```
 ///
-/// `hop.r_result` is always the resized `ListRepr` (`listdef.offspring` yields
-/// a fresh growable list, unaryop.py:420-423); the receiver's `source_layout`
-/// varies (a `FixedSizeListRepr` slice source is possible). Mints
+/// `hop.r_result` is `listdef.offspring` (unaryop.py:420-423), a fresh list
+/// whose repr is `FixedSizeListRepr` when the slice is never resized and
+/// `ListRepr` otherwise; the receiver's `source_layout` likewise varies. Mints
 /// `ll_arraycopy` (general 5-arg), `ll_newlist`, and the per-`kind`
 /// `ll_listslice_%s` helper in dependency order, then `gendirectcall`s it. The
 /// `cRESLIST` Void const is implicit — the result repr is `hop.r_result`, which
-/// the helper builders read directly.
+/// the helper builders read directly (and off whose lltype they select the
+/// result layout for the destination-items copy).
 fn rtype_getslice_via_ll_listslice(
     hop: &HighLevelOp,
     source_layout: ListLayout,
@@ -6083,6 +6099,74 @@ mod tests {
         }
     }
 
+    /// A runtime `start` that is NOT proved non-negative must be rejected by
+    /// `decompose_slice_args` (rtyper.py:768-770) with "slice start must be
+    /// proved non-negative", the guard that keeps an unsupported slice form off
+    /// the `ll_listslice_*` path. Same hop as the startstop test but with a
+    /// `nonneg == false` start annotation.
+    #[test]
+    fn translate_operation_getslice_non_nonneg_start_is_rejected() {
+        use crate::annotator::model::{SomeInteger, SomeValue};
+        use crate::flowspace::model::SpaceOperation;
+        use std::cell::RefCell as StdRef;
+
+        let ann = RPythonAnnotator::new(None, None, None, false);
+        let rtyper = Rc::new(RPythonTyper::new(&ann));
+        rtyper
+            .initialize_exceptiondata()
+            .expect("initialize_exceptiondata in test setup");
+        let r_int: Arc<dyn Repr> = Arc::new(IntegerRepr::new(LowLevelType::Signed, Some("int_")));
+        let r_list: Arc<dyn Repr> =
+            Arc::new(ListRepr::new(&rtyper, r_int.clone()).expect("ListRepr::new"));
+        let list_lltype = r_list.lowleveltype().clone();
+
+        let v_lst = Variable::new();
+        v_lst.set_concretetype(Some(list_lltype));
+        let v_start = Variable::new();
+        v_start.set_concretetype(Some(LowLevelType::Signed));
+        let v_stop = Variable::new();
+        v_stop.set_concretetype(Some(LowLevelType::Signed));
+        let v_lst_h = Hlvalue::Variable(v_lst);
+        let v_start_h = Hlvalue::Variable(v_start);
+        let v_stop_h = Hlvalue::Variable(v_stop);
+        let result_var = Variable::new();
+        let spaceop = SpaceOperation::new(
+            "getslice".to_string(),
+            vec![v_lst_h.clone(), v_start_h.clone(), v_stop_h.clone()],
+            Hlvalue::Variable(result_var),
+        );
+        let llops = Rc::new(StdRef::new(LowLevelOpList::new(rtyper.clone(), None)));
+        let hop = HighLevelOp::new(rtyper.clone(), spaceop, Vec::new(), llops);
+        hop.args_v.borrow_mut().push(v_lst_h);
+        hop.args_s.borrow_mut().push(SomeValue::Impossible);
+        hop.args_r.borrow_mut().push(Some(r_list.clone()));
+        // A runtime start that is NOT proved non-negative.
+        hop.args_v.borrow_mut().push(v_start_h);
+        hop.args_s
+            .borrow_mut()
+            .push(SomeValue::Integer(SomeInteger::new(
+                /* nonneg */ false, false,
+            )));
+        hop.args_r.borrow_mut().push(Some(r_int.clone()));
+        hop.args_v.borrow_mut().push(v_stop_h);
+        hop.args_s
+            .borrow_mut()
+            .push(SomeValue::Integer(SomeInteger::new(
+                /* nonneg */ true, false,
+            )));
+        hop.args_r.borrow_mut().push(Some(r_int.clone()));
+        *hop.r_result.borrow_mut() = Some(r_list.clone());
+
+        let err = rtyper
+            .translate_operation(&hop)
+            .expect_err("a non-nonneg slice start must fail decompose_slice_args");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("slice start must be proved non-negative"),
+            "expected the non-negative start rejection, got {msg:?}"
+        );
+    }
+
     /// `l[start:]` — non-constant nonneg start, constant `None` stop —
     /// decomposes to `"startonly"` (rtyper.py:778-779) and lowers to
     /// `gendirectcall(ll_listslice_startonly, l, start)` (rlist.py:883-890).
@@ -6159,6 +6243,96 @@ mod tests {
         assert!(
             names.iter().any(|n| n == "ll_listslice_startonly"),
             "getslice [start:] must mint an ll_listslice_startonly helper graph, got {names:?}"
+        );
+    }
+
+    /// A `[start:]` slice whose result is never resized takes a
+    /// `FixedSizeListRepr` result (`listdef.offspring` keeps `resized=False`),
+    /// so `ll_newlist` returns a bare `Ptr(GcArray)` with no `items` field. The
+    /// minted `ll_listslice_startonly` helper must therefore select `dst_items`
+    /// as the result array ITSELF (`ll_fixed_items(l) = l`, rlist.py:411) and
+    /// emit NO `getfield("items")` — a fixed source AND a fixed result yield a
+    /// getfield-free copy body. A regression that hardcodes `getfield(new_lst,
+    /// "items")` would target a nonexistent field and reintroduce a getfield.
+    #[test]
+    fn translate_operation_getslice_startonly_fixed_result_has_no_dst_items_getfield() {
+        use crate::annotator::model::{SomeInteger, SomeValue, s_none};
+        use crate::flowspace::model::{Constant, SpaceOperation};
+        use std::cell::RefCell as StdRef;
+
+        let ann = RPythonAnnotator::new(None, None, None, false);
+        let rtyper = Rc::new(RPythonTyper::new(&ann));
+        rtyper
+            .initialize_exceptiondata()
+            .expect("initialize_exceptiondata in test setup");
+        let r_int: Arc<dyn Repr> = Arc::new(IntegerRepr::new(LowLevelType::Signed, Some("int_")));
+        // Both the source and the result are FIXED lists: the receiver is a
+        // never-resized `&[T]`-shaped list and the slice result is likewise
+        // never resized, so both reach their array without an `items` field.
+        let r_list: Arc<dyn Repr> = Arc::new(
+            FixedSizeListRepr::new(&rtyper, r_int.clone()).expect("FixedSizeListRepr::new"),
+        );
+        let list_lltype = r_list.lowleveltype().clone();
+
+        let v_lst = Variable::new();
+        v_lst.set_concretetype(Some(list_lltype));
+        let v_start = Variable::new();
+        v_start.set_concretetype(Some(LowLevelType::Signed));
+        let v_lst_h = Hlvalue::Variable(v_lst);
+        let v_start_h = Hlvalue::Variable(v_start);
+        let c_stop = Hlvalue::Constant(Constant::new(ConstValue::None));
+        let result_var = Variable::new();
+        let spaceop = SpaceOperation::new(
+            "getslice".to_string(),
+            vec![v_lst_h.clone(), v_start_h.clone(), c_stop.clone()],
+            Hlvalue::Variable(result_var),
+        );
+        let llops = Rc::new(StdRef::new(LowLevelOpList::new(rtyper.clone(), None)));
+        let hop = HighLevelOp::new(rtyper.clone(), spaceop, Vec::new(), llops);
+        hop.args_v.borrow_mut().push(v_lst_h);
+        hop.args_s.borrow_mut().push(SomeValue::Impossible);
+        hop.args_r.borrow_mut().push(Some(r_list.clone()));
+        hop.args_v.borrow_mut().push(v_start_h);
+        hop.args_s
+            .borrow_mut()
+            .push(SomeValue::Integer(SomeInteger::new(
+                /* nonneg */ true, false,
+            )));
+        hop.args_r.borrow_mut().push(Some(r_int.clone()));
+        hop.args_v.borrow_mut().push(c_stop);
+        hop.args_s.borrow_mut().push(s_none());
+        hop.args_r.borrow_mut().push(Some(r_int.clone()));
+        // The slice result is a fresh FIXED list (never resized).
+        *hop.r_result.borrow_mut() = Some(r_list.clone());
+
+        rtyper
+            .translate_operation(&hop)
+            .expect("translate_operation getslice must dispatch to rtype_getslice")
+            .expect("getslice returns the fresh list Variable");
+
+        // Inspect the minted `ll_listslice_startonly` helper body: with a fixed
+        // source and a fixed result, neither `src_items` nor `dst_items` reads
+        // an `items` field, so the copy body carries zero `getfield` ops.
+        let translator = ann.translator.clone();
+        let graphs = translator.graphs.borrow();
+        let helper = graphs
+            .iter()
+            .find(|g| g.borrow().name == "ll_listslice_startonly")
+            .expect("getslice [start:] must mint an ll_listslice_startonly helper graph");
+        // The listslice helper is a single-block graph; its whole copy body
+        // lives in the startblock.
+        let getfields: usize = helper
+            .borrow()
+            .startblock
+            .borrow()
+            .operations
+            .iter()
+            .filter(|op| op.opname == "getfield")
+            .count();
+        assert_eq!(
+            getfields, 0,
+            "a fixed-source, fixed-result getslice must not read an `items` field \
+             (ll_newlist returns a bare array); found {getfields} getfield op(s)"
         );
     }
 

--- a/majit/majit-translate/tests/test_rbigint_mir.rs
+++ b/majit/majit-translate/tests/test_rbigint_mir.rs
@@ -10,7 +10,10 @@ use majit_translate::{
     HostStaticAddrs,
     front::{
         llbc_hints::harvest_hints_from_llbcs,
-        mir::build_semantic_program_from_llbcs_with_static_addrs_and_module_paths,
+        mir::{
+            build_semantic_program_from_llbcs_with_static_addrs_and_function_names,
+            build_semantic_program_from_llbcs_with_static_addrs_and_module_paths,
+        },
     },
     model::{CallTarget, OpKind, ValueType},
 };
@@ -1141,6 +1144,87 @@ fn rbigint_inherent_constructors_keep_their_owner_and_graph() {
     }
 }
 
+/// Callers whose mixed long/int arm must reach the machine-word residual
+/// named beside it, and must not fall back to a full `RBigInt::int_*` call.
+const MIXED_INT_RESIDUAL_CALLERS: &[(&str, &str)] = &[
+    ("long_add", "jit_bigint_int_add"),
+    ("long_sub", "jit_bigint_int_sub"),
+    ("long_mul", "jit_bigint_int_mul"),
+    ("long_bitand", "jit_bigint_int_and"),
+    ("long_bitor", "jit_bigint_int_or"),
+    ("long_bitxor", "jit_bigint_int_xor"),
+];
+
+/// `(module suffix, caller)` pairs that must borrow their long operand's
+/// payload instead of allocating a translated `jit_bigint_clone`.
+const BORROWED_PAYLOAD_CALLERS: &[(&str, &str)] = &[
+    ("objspace::descroperation", "long_pow"),
+    ("objspace::descroperation", "try_int_long_pow_with_modulo"),
+    ("objspace::descroperation", "long_lshift"),
+    ("objspace::descroperation", "long_rshift"),
+    ("objspace::descroperation", "long_floordiv"),
+    ("objspace::descroperation", "long_mod"),
+    ("objspace::descroperation", "integer_divmod_pair"),
+    ("objspace::descroperation", "bigint_mod_inverse"),
+    ("objspace::descroperation", "complex_richcompare"),
+    ("objspace::descroperation", "compare_slot"),
+    ("baseobjspace", "compute_slice_indices3_big"),
+    ("baseobjspace", "uint_w"),
+    ("baseobjspace", "truncatedint_w"),
+    ("baseobjspace", "getindex_w"),
+    ("baseobjspace", "index_int_w_preserve_negative"),
+    ("baseobjspace", "space_index"),
+    ("builtins", "builtin_abs"),
+    ("builtins", "ensure_baseint_result"),
+    ("builtins", "int_to_decimal_string"),
+    ("typedef", "int_descr_new"),
+    ("typedef", "slice_method_indices"),
+    ("builtins", "format_index_radix"),
+    ("type_methods", "format_with_spec"),
+    ("builtins", "obj_to_bigint"),
+    ("objspace::std::formatting", "arg_to_bigint"),
+    ("module::math::interp_math", "comb"),
+    ("module::math::interp_math", "perm"),
+];
+
+/// Floor-division callers and the floor-semantics residual each must take.
+const FLOOR_DIVMOD_CALLERS: &[(&str, &str)] = &[
+    ("long_floordiv", "jit_bigint_div_floor"),
+    ("long_mod", "jit_bigint_mod_floor"),
+];
+
+/// Unary callers that must borrow their input and allocate only the result.
+const UNARY_RESIDUAL_CALLERS: &[(&str, &str)] = &[
+    ("bigint_neg", "jit_bigint_neg"),
+    ("bigint_invert", "jit_bigint_invert"),
+];
+
+/// Graphs the test reaches for one at a time rather than through a table.
+const SINGLE_GRAPHS: &[&str] = &[
+    "bigint_add",
+    "long_int_compare",
+    "long_pow",
+    "long_lshift",
+    "int_lshift",
+];
+
+/// Every graph name the assertions below look up.
+///
+/// This is what scopes the lowering: `pyre-interpreter.ullbc` declares tens
+/// of thousands of functions and the module filter alone still admits
+/// thousands of bodies, none of which these assertions read. Deriving the
+/// list from the same tables the assertions iterate keeps the two from
+/// drifting — a caller added to a table is lowered by construction, and a
+/// name that goes missing fails the lookup it was added for.
+fn asserted_graph_names() -> Vec<&'static str> {
+    let mut names: Vec<&'static str> = SINGLE_GRAPHS.to_vec();
+    names.extend(MIXED_INT_RESIDUAL_CALLERS.iter().map(|(caller, _)| *caller));
+    names.extend(BORROWED_PAYLOAD_CALLERS.iter().map(|(_, caller)| *caller));
+    names.extend(FLOOR_DIVMOD_CALLERS.iter().map(|(caller, _)| *caller));
+    names.extend(UNARY_RESIDUAL_CALLERS.iter().map(|(caller, _)| *caller));
+    names
+}
+
 #[test]
 fn dependent_crate_rbigint_identity_retargets_opaque_llbc_declaration() {
     if !std::path::Path::new(INTERPRETER_LLBC).is_file() {
@@ -1217,7 +1301,7 @@ fn dependent_crate_rbigint_identity_retargets_opaque_llbc_declaration() {
             "{path} must preserve rbigint ovfcheck's OverflowError edge, got {values:?}"
         );
     }
-    let program = build_semantic_program_from_llbcs_with_static_addrs_and_module_paths(
+    let program = build_semantic_program_from_llbcs_with_static_addrs_and_function_names(
         &[llbc],
         HostStaticAddrs::default(),
         &[
@@ -1229,6 +1313,7 @@ fn dependent_crate_rbigint_identity_retargets_opaque_llbc_declaration() {
             "type_methods",
             "objspace::std::formatting",
         ],
+        &asserted_graph_names(),
     )
     .expect("lower descroperation module");
     let helper = program
@@ -1288,14 +1373,7 @@ fn dependent_crate_rbigint_identity_retargets_opaque_llbc_declaration() {
          calls={calls:?}; targets={call_targets:?}"
     );
 
-    for (caller_name, residual_name) in [
-        ("long_add", "jit_bigint_int_add"),
-        ("long_sub", "jit_bigint_int_sub"),
-        ("long_mul", "jit_bigint_int_mul"),
-        ("long_bitand", "jit_bigint_int_and"),
-        ("long_bitor", "jit_bigint_int_or"),
-        ("long_bitxor", "jit_bigint_int_xor"),
-    ] {
+    for &(caller_name, residual_name) in MIXED_INT_RESIDUAL_CALLERS {
         let caller = program
             .functions
             .iter()
@@ -1432,35 +1510,7 @@ fn dependent_crate_rbigint_identity_retargets_opaque_llbc_declaration() {
         "the host Result wrapper must not survive in the translated graph: {pow_calls:?}"
     );
 
-    for (module_suffix, caller_name) in [
-        ("objspace::descroperation", "long_pow"),
-        ("objspace::descroperation", "try_int_long_pow_with_modulo"),
-        ("objspace::descroperation", "long_lshift"),
-        ("objspace::descroperation", "long_rshift"),
-        ("objspace::descroperation", "long_floordiv"),
-        ("objspace::descroperation", "long_mod"),
-        ("objspace::descroperation", "integer_divmod_pair"),
-        ("objspace::descroperation", "bigint_mod_inverse"),
-        ("objspace::descroperation", "complex_richcompare"),
-        ("objspace::descroperation", "compare_slot"),
-        ("baseobjspace", "compute_slice_indices3_big"),
-        ("baseobjspace", "uint_w"),
-        ("baseobjspace", "truncatedint_w"),
-        ("baseobjspace", "getindex_w"),
-        ("baseobjspace", "index_int_w_preserve_negative"),
-        ("baseobjspace", "space_index"),
-        ("builtins", "builtin_abs"),
-        ("builtins", "ensure_baseint_result"),
-        ("builtins", "int_to_decimal_string"),
-        ("typedef", "int_descr_new"),
-        ("typedef", "slice_method_indices"),
-        ("builtins", "format_index_radix"),
-        ("type_methods", "format_with_spec"),
-        ("builtins", "obj_to_bigint"),
-        ("objspace::std::formatting", "arg_to_bigint"),
-        ("module::math::interp_math", "comb"),
-        ("module::math::interp_math", "perm"),
-    ] {
+    for &(module_suffix, caller_name) in BORROWED_PAYLOAD_CALLERS {
         let caller = program
             .functions
             .iter()
@@ -1563,10 +1613,7 @@ fn dependent_crate_rbigint_identity_retargets_opaque_llbc_declaration() {
         "the specialized host Result wrapper must not survive: {int_lshift_calls:?}"
     );
 
-    for (caller_name, residual_name) in [
-        ("long_floordiv", "jit_bigint_div_floor"),
-        ("long_mod", "jit_bigint_mod_floor"),
-    ] {
+    for &(caller_name, residual_name) in FLOOR_DIVMOD_CALLERS {
         let caller = program
             .functions
             .iter()
@@ -1596,10 +1643,7 @@ fn dependent_crate_rbigint_identity_retargets_opaque_llbc_declaration() {
         );
     }
 
-    for (caller_name, residual_name) in [
-        ("bigint_neg", "jit_bigint_neg"),
-        ("bigint_invert", "jit_bigint_invert"),
-    ] {
+    for &(caller_name, residual_name) in UNARY_RESIDUAL_CALLERS {
         let caller = program
             .functions
             .iter()

--- a/pyre/bench/synth/call_loop_local_function.cranelift.jitstats
+++ b/pyre/bench/synth/call_loop_local_function.cranelift.jitstats
@@ -1,0 +1,8 @@
+bridges_compiled=0
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
+guard_failures=1
+internal_compile_panics=0
+loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/call_loop_local_function.dynasm.jitstats
+++ b/pyre/bench/synth/call_loop_local_function.dynasm.jitstats
@@ -1,0 +1,8 @@
+bridges_compiled=0
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
+guard_failures=1
+internal_compile_panics=0
+loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/call_loop_local_function.py
+++ b/pyre/bench/synth/call_loop_local_function.py
@@ -1,0 +1,32 @@
+# pyre-check: max-pypy-ratio=8
+# A loop that defines a function in its own body and calls it.
+#
+# `MAKE_FUNCTION` hands back a fresh `Function` every iteration, so an inline
+# specialized on the callable's OBJECT IDENTITY can only ever hold by address
+# coincidence.  It never does.  What the inline actually depends on is the
+# `_immutable_fields_ = ['code?', 'w_func_globals?', 'closure?[*]', 'defs_w?[*]']`
+# set (function.py:34-42), all of which are loop-invariant here, so guarding
+# those fields off the live function keeps the trace.
+#
+# `guard_failures` in the committed `.jitstats` baseline is the signal: it is 1
+# with the field guards and 9480 with the identity guard, which also compiled
+# 47 bridges here (2497 at N=1000000) before `make_a_counter_per_value`
+# (regalloc.py:496-499) reached the dynasm and wasm backends.  With the
+# identity guard gone this fixture no longer exercises that bucketing —
+# `bridges_compiled` stays 0 either way.
+N = 20000
+
+
+def run(n):
+    acc = 0
+    i = 0
+    while i < n:
+        def grab():
+            return 1
+
+        acc += grab() & 7
+        i += 1
+    return acc
+
+
+print(run(N))

--- a/pyre/bench/synth/call_loop_local_function.wasm.jitstats
+++ b/pyre/bench/synth/call_loop_local_function.wasm.jitstats
@@ -1,0 +1,5 @@
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
+internal_compile_panics=0
+loops_aborted=0

--- a/pyre/bench/synth/call_slot_descriptor_protocol.py
+++ b/pyre/bench/synth/call_slot_descriptor_protocol.py
@@ -22,6 +22,20 @@ class UsesInstance:
 assert UsesInstance()(1, 2) == (1, 2)
 
 
+# a real descriptor as __call__ — its __get__ resolves to a different callable,
+# which is then called without a host self
+class ResolvingDescriptor:
+    def __get__(self, obj, owner):
+        return lambda x: ("resolved", type(obj).__name__, x)
+
+
+class UsesDescriptor:
+    __call__ = ResolvingDescriptor()
+
+
+assert UsesDescriptor()(6) == ("resolved", "UsesDescriptor", 6)
+
+
 # already-bound method as __call__ — bound to its own receiver, no host self
 class Holder:
     def m(self, x):
@@ -58,6 +72,18 @@ class UsesInstanceKw:
 
 
 assert UsesInstanceKw()(1, x=2) == ((1,), {"x": 2})
+
+
+class ResolvingDescriptorKw:
+    def __get__(self, obj, owner):
+        return lambda a, b=0: ("resolved", a, b)
+
+
+class UsesDescriptorKw:
+    __call__ = ResolvingDescriptorKw()
+
+
+assert UsesDescriptorKw()(1, b=2) == ("resolved", 1, 2)
 
 
 class HolderKw:

--- a/pyre/bench/synth/defaults_reassigned_midloop.py
+++ b/pyre/bench/synth/defaults_reassigned_midloop.py
@@ -1,0 +1,44 @@
+# pyre-check: max-pypy-ratio=17
+# `__defaults__` replaced part-way through a compiled loop, in the two shapes
+# that break differently from a same-length replacement.
+#
+# `long_tail` swaps in a tuple LONGER than the parameter list.  Binding then has
+# to take the tuple's tail (`argument.py:302-315` keeps `defaults_w[i -
+# def_first]` for a `def_first = co_argcount - len(defaults_w)` that has gone
+# negative), and only the guard-failure resume path recomputes it — the trace
+# and the interpreter's flat-call both derive the tail themselves, so setting
+# the same tuple before the loop stays correct while swapping it mid-loop did
+# not.
+#
+# `two_ints` swaps in a two-int tuple, which is a `W_SpecialisedTupleObject_ii`.
+# Its `value0` is field 0, exactly where `W_TupleObject.wrappeditems` sits, so a
+# trace that reads `wrappeditems` off the live `defs_w` without proving the
+# class reads the raw integer instead of the items array.
+N = 20000
+
+
+def long_tail(n):
+    def f(a, b=2):
+        return a * 10 + b
+
+    acc = 0
+    for i in range(n):
+        if i == n // 2:
+            f.__defaults__ = (7, 9, 11)
+        acc += f(1)
+    return acc
+
+
+def two_ints(n):
+    def f(a, b=2):
+        return a * 10 + b
+
+    acc = 0
+    for i in range(n):
+        if i == n // 2:
+            f.__defaults__ = (7, 9)
+        acc += f(1)
+    return acc
+
+
+print(long_tail(N), two_ints(N))

--- a/pyre/bench/synth/del_cellvar_walk_commit.py
+++ b/pyre/bench/synth/del_cellvar_walk_commit.py
@@ -1,0 +1,41 @@
+# `del <cellvar>` lowers to `load_deref_value` (the bound check) plus
+# `store_deref_value(cell, NULL)`, where the NULL is the clear-the-cell
+# sentinel `bh_store_deref_value_fn` hands straight to `w_cell_set` without
+# ever reading it.
+#
+# The walker's NULL-Ref-arg refusal used to decline that residual, which marks
+# the walk as carrying a recorded-but-unexecuted effect.  Every walk over this
+# loop then failed the walk-end flush ("unjournaled effect — legacy replay
+# kept") and handed the region back to a replay that re-ran the residuals the
+# walk had already executed concretely.  `bump` is one of them, so `log` grew
+# by exactly one entry per walk: 20048 instead of 20000, on both backends and
+# at stock thresholds.
+#
+# `grab` is what makes the cell a real closure cell rather than a plain local.
+N = 20000
+
+log = []
+
+
+def bump(v):
+    log.append(v)
+    return v
+
+
+def run(n):
+    acc = 0
+    i = 0
+    while i < n:
+        x = i
+
+        def grab():
+            return x
+
+        acc += grab() & 7
+        bump(i)
+        del x
+        i += 1
+    return acc, len(log)
+
+
+print(run(N))

--- a/pyre/bench/synth/inline_subwalk_mutating_residual.py
+++ b/pyre/bench/synth/inline_subwalk_mutating_residual.py
@@ -1,4 +1,4 @@
-# pyre-check: max-pypy-ratio=200
+# pyre-check: max-pypy-ratio=40
 # gh#495 guard: an inlined subwalk whose callee makes an unjournaled mutation
 # through a nested residual CALL, in the two miss-handling shapes.
 #

--- a/pyre/bench/synth/inline_subwalk_property_mutates.py
+++ b/pyre/bench/synth/inline_subwalk_property_mutates.py
@@ -1,4 +1,4 @@
-# pyre-check: max-pypy-ratio=80
+# pyre-check: max-pypy-ratio=50
 # gh#495 guard: inlined property residual mutates before branch and caught miss.
 # @property value-returning mutating + try/except-inside-callee raising branch
 N = 60000

--- a/pyre/bench/synth/method_reassign_after_warmup.py
+++ b/pyre/bench/synth/method_reassign_after_warmup.py
@@ -1,0 +1,103 @@
+# pyre-check: max-pypy-ratio=60
+# The ratio is deliberately loose: pypy folds this loop to near nothing
+# (0.01s at any N tried), so the denominator is collapsed and the number
+# measures pypy's constant folding rather than pyre's throughput. What this
+# fixture gates is the differential OUTPUT — pyre must agree with cpython and
+# pypy that the rebound method wins after the loop compiled.
+# `typeobject.py:177 _immutable_fields_ = ['_version_tag?']` — the LOAD_METHOD
+# fold bakes the resolved method into the compiled loop under a
+# QUASIIMMUT_FIELD on the receiver type's `_version_tag`, with no per-iteration
+# read of the tag to re-prove it. Rebinding the method afterwards bumps the tag
+# (`mutated()`, typeobject.py:285-286) and must revoke every loop that baked
+# the old identity, or the compiled code keeps calling the replaced method.
+#
+# Second half covers the subclass walk: `mutated()` recurses through
+# `weak_subclasses` (typeobject.py:288-291), so rebinding on a BASE has to
+# revoke a loop warmed on a subclass instance.
+N = 120000
+
+
+class P:
+    def get(self):
+        return 1
+
+
+class Base:
+    def val(self):
+        return 10
+
+
+class Sub(Base):
+    pass
+
+
+def run_get(p, n):
+    total = 0
+    i = 0
+    while i < n:
+        total = total + p.get()
+        i = i + 1
+    return total
+
+
+def run_val(s, n):
+    total = 0
+    i = 0
+    while i < n:
+        total = total + s.val()
+        i = i + 1
+    return total
+
+
+def run_mutating(q, n):
+    """Rebind the method from INSIDE the loop being traced and compiled.
+
+    This is the sharp case: a live read + `guard_value` of the tag would catch a
+    mid-trace rebinding on the spot, so under `_version_tag?` the per-iteration
+    `GUARD_NOT_INVALIDATED` has to catch it instead. Returns the distinct values
+    observed, in order, so a stale trace shows up as a missing transition rather
+    than only as a wrong total.
+    """
+    seen = []
+    i = 0
+    while i < n:
+        if i == n // 8:
+            Q.run = lambda self: 3
+        if i == n // 2:
+            Q.run = lambda self: 9
+        v = q.run()
+        if not seen or seen[-1] != v:
+            seen.append(v)
+        i = i + 1
+    return seen
+
+
+class Q:
+    def run(self):
+        return 1
+
+
+def main():
+    p = P()
+    # Phase 1: warm and compile the call loop against the original method.
+    a1 = run_get(p, N)
+    # Phase 2: rebind on the class itself.
+    P.get = lambda self: 2
+    a2 = run_get(p, N)
+    # Phase 3: rebind again, so a stale second-generation trace is caught too.
+    P.get = lambda self: 5
+    a3 = run_get(p, N)
+
+    s = Sub()
+    b1 = run_val(s, N)
+    # Phase 4: rebind on the BASE of the warmed receiver's class.
+    Base.val = lambda self: 20
+    b2 = run_val(s, N)
+
+    # Phase 5: rebind twice from inside the loop itself.
+    c = run_mutating(Q(), N)
+
+    print(a1 // N, a2 // N, a3 // N, b1 // N, b2 // N, c)
+
+
+main()

--- a/pyre/bench/synth/type_immutable_reject.py
+++ b/pyre/bench/synth/type_immutable_reject.py
@@ -1,4 +1,4 @@
-# pyre-check: max-pypy-ratio=152
+# pyre-check: max-pypy-ratio=15
 N = 200000
 
 

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -100,7 +100,15 @@ WIN_TIMER_QUANTUM_S = 1.0 / 64
 # not inflate the ratio/gate of a short bench. Never hardcode the startup.
 # Floored so a bench at/below its own startup (or noise) cannot drive a time
 # to <= 0 and blow up a ratio.
-STARTUP_SAMPLES = 3
+#
+# The startup is a divisor for every short bench: the baseline's exec time is
+# `bench - startup`, so a startup sample that lands high collapses that
+# denominator and inflates every ratio computed against it.  A CI runner
+# measured pypy startup at 0.031s where the same job on the same platform had
+# measured 0.013s, and three unrelated benches failed their gates in that run
+# while their pyre exec times had gone *down*.  Five samples make the median
+# robust to two outliers instead of one.
+STARTUP_SAMPLES = 5
 EXEC_TIME_FLOOR_S = WIN_TIMER_QUANTUM_S if sys.platform == "win32" else 0.005
 # A single slow sample is retried before failing a performance gate. Windows
 # needs more samples because its process CPU accounting is scheduler-tick

--- a/pyre/pyre-interpreter/src/argument.rs
+++ b/pyre/pyre-interpreter/src/argument.rs
@@ -1124,10 +1124,13 @@ impl Arguments {
 
         // argument.py:273-287 — fill missing args from kwds.
         let more_filling = input_argcount < co_argcount + co_kwonlyargcount;
-        let mut def_first: usize = 0;
+        // `argument.py:274` `def_first = co_argcount - len(defaults_w)` is
+        // signed: `defaults_w` longer than the positional parameters makes it
+        // negative and `defnum = i - def_first` then names the tuple's tail.
+        let mut def_first: isize = 0;
         if more_filling {
             let defaults_len = defaults_w.map(|d| d.len()).unwrap_or(0);
-            def_first = co_argcount.saturating_sub(defaults_len);
+            def_first = co_argcount as isize - defaults_len as isize;
             let mut j = 0usize;
             for i in input_argcount..(co_argcount + co_kwonlyargcount) {
                 if let Some(ref mapping) = kwds_mapping {
@@ -1175,7 +1178,7 @@ impl Arguments {
                 if !scope_w[i].is_null() {
                     continue;
                 }
-                let defnum = (i as isize) - (def_first as isize);
+                let defnum = (i as isize) - def_first;
                 if defnum >= 0 {
                     scope_w[i] = defaults_w.unwrap()[defnum as usize];
                 } else if let Some(list) = missing_positional.as_mut() {
@@ -1697,7 +1700,7 @@ fn format_too_many(
     let takes_str = if num_defaults > 0 {
         format!(
             "from {} to {} positional arguments",
-            num_args - num_defaults,
+            num_args as isize - num_defaults as isize,
             num_args,
         )
     } else {

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -9141,6 +9141,26 @@ unsafe fn is_object_setattr_descr(w_descr: PyObjectRef) -> bool {
     }
 }
 
+/// The canonical `type.__setattr__` slot wrapper (`init_type_type`,
+/// typedef.rs), distinct from `object.__setattr__` for the Carlo Verre
+/// hackcheck but a thin forward to `object_setattr` — so it still reaches
+/// the terminal non-heaptype raise rather than diverting to user code.
+unsafe fn is_type_setattr_descr(w_descr: PyObjectRef) -> bool {
+    match lookup_in_type_where(crate::typedef::w_type(), "__setattr__") {
+        Some(d) => std::ptr::eq(w_descr, d),
+        None => false,
+    }
+}
+
+/// The `type.__delattr__` companion of [`is_type_setattr_descr`] — the
+/// canonical `type`'s own slot forwarding to `object_delattr`.
+unsafe fn is_type_delattr_descr(w_descr: PyObjectRef) -> bool {
+    match lookup_in_type_where(crate::typedef::w_type(), "__delattr__") {
+        Some(d) => std::ptr::eq(w_descr, d),
+        None => false,
+    }
+}
+
 /// typeobject.py:303-326 `getattribute_if_not_from_object` — returns the
 /// app-level `__getattribute__` if it is NOT `object.__getattribute__`,
 /// otherwise `None`.  In the interpreter the negative result is memoized
@@ -10285,16 +10305,25 @@ pub fn type_immutable_attr_raise_is_stable(obj: PyObjectRef, name: &str, is_dele
         if is_delete {
             // `delattr_str`'s type-receiver branch: a non-default metaclass
             // `__delattr__` routes to a descriptor call instead of the
-            // terminal raise.
+            // terminal raise.  The metaclass is the canonical `type` (checked
+            // above), whose own `__delattr__` slot forwards to
+            // `object_delattr` — that still reaches the immutable raise, so it
+            // is accepted alongside `object`'s default.
             if let Some(da) = lookup_in_type(metaclass, "__delattr__") {
                 let is_default = lookup_in_type(crate::typedef::w_object(), "__delattr__")
                     .is_some_and(|d| std::ptr::eq(da, d));
-                if !is_default {
+                if !is_default && !is_type_delattr_descr(da) {
                     return false;
                 }
             }
-        } else if setattr_if_not_from_object(metaclass).is_some() {
-            return false;
+        } else if let Some(sa) = setattr_if_not_from_object(metaclass) {
+            // Same reasoning for setattr: the canonical `type`'s own
+            // `__setattr__` slot forwards to `object_setattr`, so only a
+            // genuine metaclass override (neither `object`'s nor `type`'s
+            // standard slot) diverts away from the terminal raise.
+            if !is_type_setattr_descr(sa) {
+                return false;
+            }
         }
         // The terminal's metaclass-MRO descriptor walk runs before the
         // heaptype guard; any hit (`__name__`, `__dict__`, …) diverts.

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -7621,8 +7621,12 @@ pub(crate) fn space_int(obj: PyObjectRef) -> Result<PyObjectRef, PyError> {
         // baseobjspace.py:321-323 `w_impl = space.lookup(self, '__index__')`
         .or_else(|| unsafe { lookup(obj, "__index__") });
     let Some(method) = w_impl else {
-        // baseobjspace.py:323 `self._typed_unwrap_error(space, "integer")`
-        return Err(PyError::type_error("expected integer"));
+        // baseobjspace.py:323 `self._typed_unwrap_error(space, "integer")`,
+        // whose body (:316-318) is `"expected %s, got %T object"`.
+        return Err(PyError::type_error(format!(
+            "expected integer, got {} object",
+            object_functionstr_type_name(obj)
+        )));
     };
     // baseobjspace.py:324 `w_result = space.get_and_call_function(w_impl, self)`
     let w_type = crate::typedef::r#type(obj)

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -8948,9 +8948,9 @@ pub unsafe fn load_method_fast_path(
 ///
 /// The metatype is read off the class (`getclass()`) and must be `type`
 /// itself, so a custom metaclass declines (its `__getattribute__` may not
-/// follow `type.__getattribute__`).  A name the metatype itself defines is
-/// declined too: a metatype attribute would shadow the class attribute (data
-/// descriptor) or be returned in its place.  An uncacheable type and any
+/// follow `type.__getattribute__`).  A name the metatype defines as a DATA
+/// DESCRIPTOR is declined too, since that is the one entry `descr_getattribute`
+/// selects ahead of the class's own MRO.  An uncacheable type and any
 /// non-`classmethod` descriptor also decline.
 ///
 /// # Safety
@@ -8973,9 +8973,12 @@ pub unsafe fn classmethod_on_type_fast_path(
     if !std::ptr::eq(metatype, crate::typedef::w_type()) {
         return None;
     }
-    // A metatype attribute of the same name would win over the class attribute,
-    // so decline any name the metatype defines.
-    if lookup_in_type(metatype, name).is_some() {
+    // `typeobject.py:813-823 descr_getattribute` orders the two lookups: the
+    // metatype entry preempts the class's own MRO only when it is a data
+    // descriptor, and otherwise `self.lookup(name)` is what gets selected.
+    // Decline exactly that case; a non-data metatype attribute loses to the
+    // class's classmethod, which is the value this fold emits.
+    if type_lookup_is_data_descr(metatype, name) {
         return None;
     }
     let version_tag = pyre_object::typeobject::w_type_get_version_tag(w_type);

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -2098,6 +2098,38 @@ pub(crate) fn range_index_method(args: &[PyObjectRef]) -> PyResult {
     ))
 }
 
+/// `descroperation.py:538 sequence_index` — the first index whose element
+/// `eq_w`-matches `w_item` (`w is w_item or w == w_item`), iterating
+/// `w_container` through the iterator protocol; a miss raises `ValueError`.
+pub(crate) fn sequence_index(w_container: PyObjectRef, w_item: PyObjectRef) -> PyResult {
+    let w_iter = iter(w_container)?;
+    // `next`/`eq_w` re-enter Python (`__next__`/`__eq__`) and may collect while
+    // the iterator and needle are still needed on the next turn; a raw local is
+    // not scanned by the collector, so both live on the shadow stack.  (RPython
+    // stack slots are GC roots; Rust's are not.)
+    let _roots = pyre_object::gc_roots::push_roots();
+    let iter_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(w_iter);
+    let item_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(w_item);
+    let mut index: i64 = 0;
+    loop {
+        match next(pyre_object::gc_roots::shadow_stack_get(iter_slot)) {
+            Ok(w_next) => {
+                if eq_w(w_next, pyre_object::gc_roots::shadow_stack_get(item_slot))? {
+                    return Ok(w_int_new(index));
+                }
+                index += 1;
+            }
+            Err(e) if e.kind == PyErrorKind::StopIteration => break,
+            Err(e) => return Err(e),
+        }
+    }
+    Err(PyError::value_error(
+        "sequence.index(x): x not in sequence".to_string(),
+    ))
+}
+
 /// `range.__iter__()` — fresh `range_iterator` (word-fit or bignum cursor).
 pub(crate) fn range_iter_method(args: &[PyObjectRef]) -> PyResult {
     iter(args[0])

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -8080,6 +8080,11 @@ pub(crate) fn collect_iterator(it: PyObjectRef) -> Result<Vec<PyObjectRef>, crat
     // (framework.py:853-856).
     let base = pyre_object::gc_roots::shadow_stack_len();
     pyre_object::gc_roots::pin_root(it);
+    // `pin_root` itself queries the collector, so read the iterator back from
+    // its slot instead of reusing the caller's copy: a foreign collection that
+    // ran inside the pin forwarded the object and rewrote the slot, not the
+    // local.
+    let it = pyre_object::gc_roots::shadow_stack_get(base);
     // Dict-view iterators are currently off-GC RPython-style carriers.  Their
     // registered raw-field walker covers frame/value-stack reachability, but
     // this helper keeps the iterator on the shadow stack directly; retain its
@@ -10799,6 +10804,9 @@ fn builtin_any(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let it = crate::baseobjspace::iter(pyre_object::gc_roots::shadow_stack_get(iterable_slot))?;
     let iterator_slot = pyre_object::gc_roots::shadow_stack_len();
     pyre_object::gc_roots::pin_root(it);
+    // The pin queries the collector, so the slot — not this local — is what
+    // holds the forwarded iterator once it returns.
+    let it = pyre_object::gc_roots::shadow_stack_get(iterator_slot);
     if unsafe { pyre_object::dictmultiobject::is_dict_view_iterator(it) } {
         let w_dict = unsafe { pyre_object::dictmultiobject::w_dict_view_iterator_get_dict(it) };
         pyre_object::gc_roots::pin_root(w_dict);
@@ -12905,6 +12913,9 @@ fn builtin_all(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let it = crate::baseobjspace::iter(pyre_object::gc_roots::shadow_stack_get(iterable_slot))?;
     let iterator_slot = pyre_object::gc_roots::shadow_stack_len();
     pyre_object::gc_roots::pin_root(it);
+    // The pin queries the collector, so the slot — not this local — is what
+    // holds the forwarded iterator once it returns.
+    let it = pyre_object::gc_roots::shadow_stack_get(iterator_slot);
     if unsafe { pyre_object::dictmultiobject::is_dict_view_iterator(it) } {
         let w_dict = unsafe { pyre_object::dictmultiobject::w_dict_view_iterator_get_dict(it) };
         pyre_object::gc_roots::pin_root(w_dict);

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -464,7 +464,7 @@ fn fill_user_function_args(
         let takes_str = if ndefaults > 0 {
             format!(
                 "from {} to {} positional arguments",
-                nparams - ndefaults,
+                nparams as isize - ndefaults as isize,
                 nparams
             )
         } else {
@@ -508,15 +508,21 @@ fn fill_user_function_args(
         } else {
             0
         };
-        let first_default = nparams - ndefaults;
+        // `argument.py:302-315` computes `def_first = co_argcount -
+        // len(defaults_w)` in signed arithmetic and keeps `defaults_w[defnum]`
+        // for every `defnum = i - def_first` that is not negative.  A
+        // `__defaults__` longer than the parameter list makes `def_first`
+        // negative, which selects the tail of the tuple; in `usize` the
+        // subtraction wrapped instead, no slot ever matched, and the call
+        // raised a missing-argument `TypeError`.
+        let first_default = nparams as isize - ndefaults as isize;
         for i in n_pos_copied..nparams {
-            if i >= first_default {
-                let default_idx = i - first_default;
-                if let Some(val) =
+            let default_idx = i as isize - first_default;
+            if default_idx >= 0
+                && let Some(val) =
                     unsafe { pyre_object::w_tuple_getitem(defaults, default_idx as i64) }
-                {
-                    filled_args[i] = val;
-                }
+            {
+                filled_args[i] = val;
             }
         }
     }

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -1355,15 +1355,11 @@ fn call_callable_with_mode(
         }
         // `user_call_slot`'s stack_check bounds a self-referential
         // `A.__call__ = A()` chain only while this self-dispatch recurses
-        // natively.  Left in tail position it is a candidate for LLVM's
-        // sibling-call optimization, which rewrites it into a loop that never
-        // grows the native stack — then neither the SP check nor the depth
-        // counter trips and the chain spins forever.  The black_box barrier
-        // keeps the call off the tail so the stack grows and the check fires.
-        // (The RPython C backend does not perform this optimization, so there
-        // is no matching guard upstream.)
-        let result = call_callable_with_mode(frame, target, args, mode);
-        return std::hint::black_box(result);
+        // natively.  The call-depth guard counts this dispatch level and, by
+        // dropping only after the call returns, keeps it off the tail so LLVM
+        // cannot rewrite the self-call into a loop that never grows the stack.
+        let _depth_guard = increment_call_depth();
+        return call_callable_with_mode(frame, target, args, mode);
     }
 
     // GenericAlias.__call__ (`_pypy_generic_alias.py:41`) —
@@ -2602,11 +2598,11 @@ pub fn call_with_kwargs(
             call_args.extend_from_slice(pos_args);
             return call_with_kwargs(frame, target, &call_args, kwargs);
         }
-        // black_box: keep this self-dispatch off the tail so a self-referential
-        // `A.__call__ = A()` recurses natively for stack_check (see
-        // call_callable_with_mode).
-        let result = call_with_kwargs(frame, target, pos_args, kwargs);
-        return std::hint::black_box(result);
+        // Depth guard: count this dispatch level and, dropping after the call,
+        // keep it off the tail so a self-referential `A.__call__ = A()`
+        // recurses natively for stack_check (see call_callable_with_mode).
+        let _depth_guard = increment_call_depth();
+        return call_with_kwargs(frame, target, pos_args, kwargs);
     }
 
     // GenericAlias.__call__ (`_pypy_generic_alias.py:41`) —
@@ -2803,11 +2799,11 @@ pub fn call_function_impl_result(
                 call_args.extend_from_slice(args);
                 return call_function_impl_result(target, &call_args);
             }
-            // black_box: keep this self-dispatch off the tail so a
-            // self-referential `A.__call__ = A()` recurses natively for
-            // stack_check (see call_callable_with_mode).
-            let result = call_function_impl_result(target, args);
-            return std::hint::black_box(result);
+            // Depth guard: count this dispatch level and, dropping after the
+            // call, keep it off the tail so a self-referential
+            // `A.__call__ = A()` recurses natively for stack_check.
+            let _depth_guard = increment_call_depth();
+            return call_function_impl_result(target, args);
         }
     }
     let type_name = crate::typedef::r#type(callable)

--- a/pyre/pyre-interpreter/src/error.rs
+++ b/pyre/pyre-interpreter/src/error.rs
@@ -1069,7 +1069,12 @@ impl PyError {
         if !self.w_obj_context.is_null() {
             pyre_object::gc_roots::pin_root(self.w_obj_context);
         }
-        let exc = w_exception_new(self.to_exc_kind(), &self.message);
+        // `w_exception_new_empty`, not `w_exception_new`: the message block
+        // below builds `args_w` itself (it must keep the message object in a
+        // shadow-stack slot for the `ImportError` `msg` stamp), so letting the
+        // message helper build a first string + list here only to overwrite
+        // both allocated two W_Str/W_List pairs per raise and threw one away.
+        let exc = pyre_object::interp_exceptions::w_exception_new_empty(self.to_exc_kind());
         // Root the fresh managed exception across the message/context stamping
         // below: `exc` lives only in this Rust local while `w_list_new` (and the
         // setters) run, so a collection there could sweep the unrooted

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -2359,13 +2359,15 @@ impl NamespaceOpcodeHandler for PyFrame {
                     && pyre_object::dictmultiobject::is_module_dict(w_globals)
             }
         };
-        // `pyopcode.py:979` reads the builtins through the METHOD
+        // `_load_global` (pyopcode.py) reads the builtins through the METHOD
         // `self.get_builtin()`, not the `builtin` field.  Under the default
-        // `honor__builtins__=False` that method answers `space.builtin` and
-        // never consults the frame at all (`pyframe.py:199-203`), so the field
-        // being unset must not be observable here.  Reading the raw field made
-        // the builtins leg silently find nothing on any frame with a null
-        // `w_builtin`, raising `NameError` for a builtin that plainly exists.
+        // `honor__builtins__=False` the constructor never assigns that field
+        // (pyframe.py) and the method answers `space.builtin` without
+        // consulting the frame at all, so the field being unset must not be
+        // observable here.  A frame the JIT materialized from a virtual is
+        // exactly such a frame: reading the raw field made the builtins leg
+        // silently find nothing there, raising `NameError` for a builtin that
+        // plainly exists.
         let w_builtin = self.get_builtin();
         if use_cache {
             let cache_hit: Option<PyObjectRef> = unsafe {

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -7034,6 +7034,40 @@ assert GA.__lt__(list[int], list[str]) is NotImplemented
         result.expect("GenericAlias explicit slot-method surface failed");
     }
 
+    #[test]
+    fn test_union_type_exposes_cpython_314_richcompare_surface() {
+        let source = r#"
+UT = type(int | str)
+required = {
+    '__getattribute__', '__ne__', '__lt__', '__le__', '__gt__', '__ge__',
+    '__name__', '__qualname__', '__origin__', '__iter__', '__doc__',
+}
+assert required <= UT.__dict__.keys()
+u = int | str
+assert UT.__getattribute__(u, '__args__') == (int, str)
+assert u.__name__ == 'Union'
+assert u.__qualname__ == 'Union'
+assert u.__origin__ is UT
+assert u.__module__ == 'typing'
+assert UT.__dict__['__iter__'] is None
+try:
+    iter(u)
+except TypeError:
+    pass
+else:
+    raise AssertionError('UnionType must disable __getitem__ iteration fallback')
+assert UT.__ne__(u, int | str) is False
+assert UT.__ne__(u, int | bytes) is True
+assert UT.__ne__(u, int) is NotImplemented
+assert UT.__lt__(u, int | bytes) is NotImplemented
+assert UT.__le__(u, int | bytes) is NotImplemented
+assert UT.__gt__(u, int | bytes) is NotImplemented
+assert UT.__ge__(u, int | bytes) is NotImplemented
+"#;
+        let (result, _frame) = run_exec_frame(source);
+        result.expect("UnionType explicit rich-compare surface failed");
+    }
+
     /// `pypy/interpreter/typedef.py BuiltinFunction.typedef.acceptable_as_base_class
     /// = False` plus CPython 3.14's null `tp_new` enforce that `type(len)()`
     /// raises `TypeError("cannot create 'builtin_function_or_method'

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -709,6 +709,21 @@ unsafe fn chain_next_frame(f_backref: *mut PyFrame) -> *mut PyFrame {
     crate::executioncontext::vref_referent(f_backref)
 }
 
+/// How much of `locals_cells_stack_w` is reachable state.
+///
+/// `valuestackdepth` is an absolute index that starts at `stack_base()`
+/// (`pyframe.rs:2136`) and `pop` refuses to go below it, so for a running
+/// frame it already covers the locals/cells prefix. `PyFrame::descr_clear`
+/// is the one writer that breaks that: it rebinds every cell slot to a fresh
+/// `w_cell_new` and then sets `valuestackdepth = 0`. Clamping to the raw
+/// depth would walk zero slots for such a frame and drop cells that the
+/// array still points at, so the prefix is the floor. The array is
+/// `PY_NULL`-filled at allocation, so widening never reads uninitialised
+/// slots.
+unsafe fn walk_depth(f: &PyFrame, arr: &FixedObjectArray) -> usize {
+    f.valuestackdepth.max(f.stack_base()).min(arr.len())
+}
+
 /// Walk one captured thread's active frame and interpreter root state.
 ///
 /// # Safety
@@ -849,15 +864,12 @@ pub unsafe fn walk_pyframe_roots_area(
             // minor collection is always synchronous with respect to the
             // interpreter thread, so frames cannot be dropped mid-walk.
             //
-            // We walk the FULL fixed-length array (not just the live
-            // `valuestackdepth` prefix). Argument values in transit —
-            // popped from the caller's stack before the callee frame
-            // is installed — are briefly invisible from
-            // `valuestackdepth` alone, yet still reachable from the
-            // popped-slot storage. Non-ref slots are filtered by
-            // `is_nursery_object_start` inside the collector, so
-            // walking past the live depth is harmless for the
-            // bump-pointer nursery.
+            // The walk covers `[0, walk_depth)` — the locals/cells prefix
+            // plus the live operand stack. Slots above it are popped
+            // capacity, not roots. Non-ref slots are filtered by
+            // `is_nursery_object_start` inside the collector, so a slot
+            // holding a non-object word is harmless for the bump-pointer
+            // nursery.
             //
             // The walk runs for every frame on the chain, including
             // ones the GC owns. For nursery-allocated frames the
@@ -1002,7 +1014,7 @@ pub unsafe fn walk_pyframe_roots_area(
                     let arr = &*f.locals_cells_stack_w;
                     (
                         arr.items_ptr() as *mut PyObjectRef,
-                        f.valuestackdepth.min(arr.len()),
+                        walk_depth(f, arr),
                         next_frame,
                     )
                 }
@@ -1273,10 +1285,7 @@ pub fn walk_suspended_generator_frame(
         if !(*frame).locals_cells_stack_w.is_null() {
             let arr = &*(*frame).locals_cells_stack_w;
             let base = arr.items_ptr() as *mut PyObjectRef;
-            // Locals/cells occupy the fixed prefix and
-            // `valuestackdepth` extends it through the live operand stack.
-            // Slots above it are popped capacity, not GC roots.
-            let len = (*frame).valuestackdepth.min(arr.len());
+            let len = walk_depth(&*frame, arr);
             for i in 0..len {
                 visitor(&mut *(base.add(i) as *mut majit_ir::GcRef));
             }

--- a/pyre/pyre-interpreter/src/executioncontext.rs
+++ b/pyre/pyre-interpreter/src/executioncontext.rs
@@ -2260,12 +2260,18 @@ impl UserDelAction {
         if self.gc_disabled(current()) {
             return;
         }
+        // `__del__` runs arbitrary Python, so it can collect and move the
+        // callable that the error report names; publish it and read it back
+        // the way `current()` does for the receiver.
+        pyre_object::gc_roots::pin_root(w_del);
+        let del_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+        let del = || pyre_object::gc_roots::shadow_stack_get(del_slot);
         // pyre's combined helper cannot distinguish get-vs-call errors;
         // report through the call arm (executioncontext.py:680-690).
         if let Err(error) = unsafe {
-            crate::baseobjspace::get_and_call_function(w_del, current(), w_type.as_ptr(), &[])
+            crate::baseobjspace::get_and_call_function(del(), current(), w_type.as_ptr(), &[])
         } {
-            report_error(self.base.space, &error, "", w_del);
+            report_error(self.base.space, &error, "", del());
         }
     }
 }

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -3329,6 +3329,46 @@ mod tests {
         assert_eq!(bindings["pyre_object::jit_list_append"], list_append);
     }
 
+    /// Two registered functions must never share an address.
+    ///
+    /// `pyre-jit-trace`'s `patch_constants_i_fnaddrs` rewrites residual-call
+    /// constants through a build-address → runtime-address map, so an address
+    /// standing for two functions sends one callee's call to the other.  Its
+    /// runtime assertion only fires once the patch path executes; this covers
+    /// the registry itself.
+    ///
+    /// Several path spellings for one function are deliberate — the module
+    /// path and the crate-root re-export both appear — and those agree on the
+    /// leaf name.  Two distinct leaf names on one address means the toolchain
+    /// folded unrelated functions together, which is the collision that
+    /// matters.  That is not hypothetical: MSVC links with `/OPT:ICF` by
+    /// default, and once `drain_list_append` lost `#[inline(never)]` its body
+    /// became byte-identical to `w_list_append` and the two folded.
+    ///
+    /// This covers only the address space it runs in.  The Windows fold
+    /// happened in the build-script binary while the test binary kept the two
+    /// apart, so a registry that passes here can still feed
+    /// `runtime_fnaddr_patch` an ambiguous build address — that direction is
+    /// what its own assertion catches.
+    #[test]
+    fn registered_paths_sharing_an_address_are_alias_spellings() {
+        let mut by_addr: HashMap<i64, Vec<&'static str>> = HashMap::new();
+        for (path, addr) in jit_trace_fnaddrs() {
+            by_addr.entry(addr).or_default().push(path);
+        }
+        for (addr, paths) in &by_addr {
+            let leaves: std::collections::BTreeSet<&str> = paths
+                .iter()
+                .map(|p| p.rsplit("::").next().unwrap_or(p))
+                .collect();
+            assert_eq!(
+                leaves.len(),
+                1,
+                "fnaddr {addr:#x} is claimed by unrelated functions {paths:?}",
+            );
+        }
+    }
+
     #[test]
     fn jit_static_pytype_addrs_covers_interpreter_function_types() {
         let bindings: HashMap<&'static str, i64> = jit_static_pytype_addrs().into_iter().collect();

--- a/pyre/pyre-interpreter/src/module/_functools/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_functools/mod.rs
@@ -31,14 +31,6 @@ def cmp_to_key(mycmp):
         __hash__ = None
     return K
 
-# `_functools.cmp_to_key` is an interp-level builtin in CPython.  Unlike an
-# app-level function, it therefore does not acquire an instance when a caller
-# stores it on a class (the CPython functools tests do exactly that).  A
-# callable staticmethod preserves the app-level implementation while giving
-# the exported object the same non-binding descriptor behavior.
-cmp_to_key = staticmethod(cmp_to_key)
-
-
 _initial_missing = object()
 
 
@@ -59,10 +51,6 @@ def reduce(function, sequence, initial=_initial_missing):
     for element in it:
         accum = function(accum, element)
     return accum
-
-
-# Same descriptor-neutral accelerator surface as cmp_to_key above.
-reduce = staticmethod(reduce)
 
 
 # PyPy: lib_pypy/_functools.py `partial`, extended with the Placeholder

--- a/pyre/pyre-interpreter/src/module/_multiprocessing/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_multiprocessing/mod.rs
@@ -1,14 +1,26 @@
 //! _multiprocessing module — PyPy: `pypy/module/_multiprocessing/`.
 //!
 //! Exposes `SemLock(kind, value, maxvalue, name, unlink)` and
-//! `sem_unlink(name)`.  Single-threaded pyre still needs the methods to
-//! exist so multiprocessing.py teardown survives.  Backed by libc
-//! `sem_t` via `rustpython_host_env::multiprocessing`; unix + host_env
-//! only — other platforms get an empty module so `import
-//! _multiprocessing` succeeds.
+//! `sem_unlink(name)`.  Backed by libc `sem_t` via
+//! `rustpython_host_env::multiprocessing`; unix + host_env only — other
+//! platforms get an empty module so `import _multiprocessing` succeeds.
+//!
+//! `W_SemLock`'s fields (`interp_semaphore.py:458-466`) live in the instance
+//! dict rather than a typed payload: `handle`, `kind`, `maxvalue` and `name`
+//! are the values behind the `GetSetProperty`s of
+//! `interp_semaphore.py:593-599`, and `count`/`last_tid` are the recursion
+//! bookkeeping `_ismine` reads.  A dict-backed field is also readable as a
+//! plain attribute, which is wider than the typedef; the alternative — a
+//! handle-keyed side table — has no upstream counterpart.
 
 #[cfg(all(unix, feature = "host_env"))]
 use pyre_object::*;
+
+/// `interp_semaphore.py:17 RECURSIVE_MUTEX, SEMAPHORE = range(2)`.
+#[cfg(all(unix, feature = "host_env"))]
+const RECURSIVE_MUTEX: i64 = 0;
+#[cfg(all(unix, feature = "host_env"))]
+const SEMAPHORE: i64 = 1;
 
 #[cfg(all(unix, feature = "host_env"))]
 fn semlock_get_handle(obj: PyObjectRef) -> *mut libc::sem_t {
@@ -24,6 +36,305 @@ fn semlock_get_handle(obj: PyObjectRef) -> *mut libc::sem_t {
     core::ptr::null_mut()
 }
 
+/// Read one of the integer fields of `interp_semaphore.py:458-466`.  A missing
+/// or non-int entry reads as 0, which only happens on an instance whose dict a
+/// caller has torn up.
+#[cfg(all(unix, feature = "host_env"))]
+fn semlock_get_i64(obj: PyObjectRef, key: &str) -> i64 {
+    let d = crate::baseobjspace::getdict_native(obj);
+    if d.is_null() {
+        return 0;
+    }
+    match unsafe { w_dict_getitem_str(d, key) } {
+        Some(v) if unsafe { is_int(v) } => unsafe { w_int_get_value(v) },
+        _ => 0,
+    }
+}
+
+/// Write one of those fields.  Boxing the value and materialising the dict can
+/// both collect, so every operand is published and re-read from the shadow
+/// stack at the store, exactly as `semlock_instance` does.
+#[cfg(all(unix, feature = "host_env"))]
+fn semlock_set_i64(obj: PyObjectRef, key: &str, value: i64) {
+    let _roots = pyre_object::gc_roots::push_roots();
+    let obj_slot = pyre_object::gc_roots::pin_roots(&[obj]);
+    let boxed_slot = obj_slot + 1;
+    pyre_object::gc_roots::pin_root(w_int_new(value));
+    let dict =
+        crate::baseobjspace::getdict_native(pyre_object::gc_roots::shadow_stack_get(obj_slot));
+    if dict.is_null() {
+        return;
+    }
+    let dict_slot = boxed_slot + 1;
+    pyre_object::gc_roots::pin_root(dict);
+    unsafe {
+        w_dict_setitem_str(
+            pyre_object::gc_roots::shadow_stack_get(dict_slot),
+            key,
+            pyre_object::gc_roots::shadow_stack_get(boxed_slot),
+        )
+    };
+}
+
+/// `interp_semaphore.py:486-487 W_SemLock._ismine`.
+#[cfg(all(unix, feature = "host_env"))]
+fn semlock_ismine(obj: PyObjectRef) -> bool {
+    semlock_get_i64(obj, "count") > 0
+        && crate::module::thread::current_ident() == semlock_get_i64(obj, "last_tid")
+}
+
+#[cfg(all(unix, feature = "host_env"))]
+fn semlock_post(handle: *mut libc::sem_t) -> Result<(), crate::PyError> {
+    if unsafe { libc::sem_post(handle) } != 0 {
+        return Err(crate::PyError::os_error_with_errno(
+            std::io::Error::last_os_error().raw_os_error().unwrap_or(0),
+            "sem_post",
+        ));
+    }
+    Ok(())
+}
+
+/// `interp_semaphore.py:431-441 semlock_getvalue`.  Not built on darwin, where
+/// `sem_getvalue` always fails (`HAVE_BROKEN_SEM_GETVALUE`,
+/// `interp_semaphore.py:86-89`) and the `sem_trywait` fallbacks run instead.
+#[cfg(all(unix, feature = "host_env", not(target_vendor = "apple")))]
+fn semlock_getvalue(handle: *mut libc::sem_t) -> Result<i64, crate::PyError> {
+    let mut val: libc::c_int = 0;
+    if unsafe { libc::sem_getvalue(handle, &mut val) } != 0 {
+        return Err(crate::PyError::os_error_with_errno(
+            std::io::Error::last_os_error().raw_os_error().unwrap_or(0),
+            "sem_getvalue",
+        ));
+    }
+    // some posix implementations use negative numbers to indicate the number of
+    // waiting threads
+    Ok(if val < 0 { 0 } else { val as i64 })
+}
+
+/// `interp_semaphore.py:443-455 semlock_iszero`.
+#[cfg(all(unix, feature = "host_env"))]
+fn semlock_iszero(handle: *mut libc::sem_t) -> Result<bool, crate::PyError> {
+    #[cfg(target_vendor = "apple")]
+    {
+        if unsafe { libc::sem_trywait(handle) } == 0 {
+            semlock_post(handle)?;
+            return Ok(false);
+        }
+        let errno = std::io::Error::last_os_error().raw_os_error().unwrap_or(0);
+        if errno != libc::EAGAIN {
+            return Err(crate::PyError::os_error_with_errno(errno, "sem_trywait"));
+        }
+        Ok(true)
+    }
+    #[cfg(not(target_vendor = "apple"))]
+    {
+        Ok(semlock_getvalue(handle)? == 0)
+    }
+}
+
+/// `interp_semaphore.py:357-400 semlock_acquire` — the platform wait alone.
+/// Upstream bumps `self.last_tid`/`self.count` here (`:395-396`); the receiver
+/// stays with the caller instead, which does it on the success return.
+#[cfg(all(unix, feature = "host_env"))]
+fn semlock_acquire(
+    handle: *mut libc::sem_t,
+    block: bool,
+    timeout: Option<f64>,
+) -> Result<bool, crate::PyError> {
+    // PEP 475 — sem_wait/sem_trywait retry on EINTR; otherwise
+    // EAGAIN (only meaningful for trywait) yields False and the
+    // remaining errnos propagate as OSError instead of being
+    // silently mapped to False.
+    // `interp_semaphore.py:378-397 semlock_acquire` — on EINTR deliver
+    // a pending signal then retry; on success deliver one too before
+    // returning (`_check_signals(space)`).
+    if block && timeout.is_none() {
+        loop {
+            let r = unsafe { libc::sem_wait(handle) };
+            if r == 0 {
+                break;
+            }
+            let errno = std::io::Error::last_os_error().raw_os_error().unwrap_or(0);
+            if errno == libc::EINTR {
+                crate::module::signal::interp_signal::checksignals_now()?;
+                continue;
+            }
+            return Err(crate::PyError::os_error_with_errno(errno, "sem_wait"));
+        }
+        crate::module::signal::interp_signal::checksignals_now()?;
+        Ok(true)
+    } else if !block {
+        loop {
+            let r = unsafe { libc::sem_trywait(handle) };
+            if r == 0 {
+                crate::module::signal::interp_signal::checksignals_now()?;
+                return Ok(true);
+            }
+            let errno = std::io::Error::last_os_error().raw_os_error().unwrap_or(0);
+            if errno == libc::EINTR {
+                crate::module::signal::interp_signal::checksignals_now()?;
+                continue;
+            }
+            if errno == libc::EAGAIN {
+                return Ok(false);
+            }
+            return Err(crate::PyError::os_error_with_errno(errno, "sem_trywait"));
+        }
+    } else {
+        let deadline = rustpython_host_env::multiprocessing::deadline_from_timeout(
+            timeout.unwrap(),
+        )
+        .map_err(|error| {
+            crate::PyError::os_error_with_errno(error.raw_os_error(), error.description())
+        })?;
+        #[cfg(target_vendor = "apple")]
+        {
+            let mut delay = 0;
+            loop {
+                use rustpython_host_env::multiprocessing::PollWaitStep;
+                match rustpython_host_env::multiprocessing::sem_timedwait_poll_step(
+                    handle, &deadline, delay,
+                )
+                .map_err(|error| {
+                    crate::PyError::os_error_with_errno(error.raw_os_error(), error.description())
+                })? {
+                    PollWaitStep::Acquired => {
+                        crate::module::signal::interp_signal::checksignals_now()?;
+                        return Ok(true);
+                    }
+                    PollWaitStep::Timeout => return Ok(false),
+                    PollWaitStep::Continue(next_delay) => delay = next_delay,
+                }
+            }
+        }
+        #[cfg(not(target_vendor = "apple"))]
+        loop {
+            use rustpython_host_env::multiprocessing::WaitStatus;
+            match rustpython_host_env::multiprocessing::sem_wait_status(handle, Some(&deadline)) {
+                WaitStatus::Acquired => {
+                    crate::module::signal::interp_signal::checksignals_now()?;
+                    return Ok(true);
+                }
+                WaitStatus::TimedOut => return Ok(false),
+                WaitStatus::Interrupted => {
+                    crate::module::signal::interp_signal::checksignals_now()?;
+                }
+                WaitStatus::Error(error) => {
+                    return Err(crate::PyError::os_error_with_errno(
+                        error.raw_os_error(),
+                        error.description(),
+                    ));
+                }
+            }
+        }
+    }
+}
+
+/// `interp_semaphore.py:403-429 semlock_release`.
+#[cfg(all(unix, feature = "host_env"))]
+fn semlock_release(
+    handle: *mut libc::sem_t,
+    kind: i64,
+    maxvalue: i64,
+) -> Result<(), crate::PyError> {
+    if kind == RECURSIVE_MUTEX {
+        return semlock_post(handle);
+    }
+    #[cfg(target_vendor = "apple")]
+    {
+        // `HAVE_BROKEN_SEM_GETVALUE`: only the maxvalue == 1 case can be
+        // checked properly.
+        if maxvalue == 1 {
+            // make sure that already locked
+            if unsafe { libc::sem_trywait(handle) } == 0 {
+                // it was not locked so undo wait and raise
+                let _ = unsafe { libc::sem_post(handle) };
+                return Err(crate::PyError::value_error(
+                    "semaphore or lock released too many times",
+                ));
+            }
+            let errno = std::io::Error::last_os_error().raw_os_error().unwrap_or(0);
+            if errno != libc::EAGAIN {
+                return Err(crate::PyError::os_error_with_errno(errno, "sem_trywait"));
+            }
+            // it is already locked as expected
+        }
+    }
+    #[cfg(not(target_vendor = "apple"))]
+    {
+        // This check is not an absolute guarantee that the semaphore does not
+        // rise above maxvalue.
+        if semlock_getvalue(handle)? >= maxvalue {
+            return Err(crate::PyError::value_error(
+                "semaphore or lock released too many times",
+            ));
+        }
+    }
+    semlock_post(handle)
+}
+
+/// `interp_semaphore.py:506-523 W_SemLock.acquire` — shared by `acquire` and
+/// `__enter__`, which the class methods cannot reach through each other.
+#[cfg(all(unix, feature = "host_env"))]
+fn w_semlock_acquire(
+    self_obj: PyObjectRef,
+    block: bool,
+    timeout: Option<f64>,
+) -> Result<bool, crate::PyError> {
+    let _roots = pyre_object::gc_roots::push_roots();
+    let self_slot = pyre_object::gc_roots::pin_roots(&[self_obj]);
+    // check whether we already own the lock
+    if semlock_get_i64(self_obj, "kind") == RECURSIVE_MUTEX && semlock_ismine(self_obj) {
+        semlock_set_i64(self_obj, "count", semlock_get_i64(self_obj, "count") + 1);
+        return Ok(true);
+    }
+    let handle = semlock_get_handle(self_obj);
+    if handle.is_null() {
+        return Err(crate::PyError::value_error("SemLock handle is null"));
+    }
+    let got = semlock_acquire(handle, block, timeout)?;
+    if got {
+        // `interp_semaphore.py:512-516` — these steps need to be as close as
+        // possible to acquiring the semlock for `_ismine` to support multiple
+        // threads.  The wait can run signal handlers, so the receiver comes
+        // back off the shadow stack.
+        let self_obj = pyre_object::gc_roots::shadow_stack_get(self_slot);
+        semlock_set_i64(self_obj, "last_tid", crate::module::thread::current_ident());
+        semlock_set_i64(self_obj, "count", semlock_get_i64(self_obj, "count") + 1);
+    }
+    Ok(got)
+}
+
+/// `interp_semaphore.py:525-541 W_SemLock.release` — shared by `release` and
+/// `__exit__`.
+#[cfg(all(unix, feature = "host_env"))]
+fn w_semlock_release(self_obj: PyObjectRef) -> Result<(), crate::PyError> {
+    let _roots = pyre_object::gc_roots::push_roots();
+    let self_slot = pyre_object::gc_roots::pin_roots(&[self_obj]);
+    let kind = semlock_get_i64(self_obj, "kind");
+    if kind == RECURSIVE_MUTEX {
+        if !semlock_ismine(self_obj) {
+            return Err(crate::PyError::new(
+                crate::error::PyErrorKind::AssertionError,
+                "attempt to release recursive lock not owned by thread",
+            ));
+        }
+        let count = semlock_get_i64(self_obj, "count");
+        if count > 1 {
+            semlock_set_i64(self_obj, "count", count - 1);
+            return Ok(());
+        }
+    }
+    let handle = semlock_get_handle(self_obj);
+    if handle.is_null() {
+        return Err(crate::PyError::value_error("SemLock handle is null"));
+    }
+    semlock_release(handle, kind, semlock_get_i64(self_obj, "maxvalue"))?;
+    let self_obj = pyre_object::gc_roots::shadow_stack_get(self_slot);
+    semlock_set_i64(self_obj, "count", semlock_get_i64(self_obj, "count") - 1);
+    Ok(())
+}
+
 #[cfg(all(unix, feature = "host_env"))]
 fn semlock_instance(
     w_subtype: PyObjectRef,
@@ -36,7 +347,11 @@ fn semlock_instance(
     let _roots = pyre_object::gc_roots::push_roots();
     let root_base = pyre_object::gc_roots::shadow_stack_len();
     pyre_object::gc_roots::pin_root(obj);
-    let dict = crate::baseobjspace::getdict_native(obj);
+    // `getdict_native` materialises the instance dict, so it can collect and
+    // move `obj`; read the receiver back from its slot the way every store
+    // below does, rather than handing over the pre-pin copy.
+    let dict =
+        crate::baseobjspace::getdict_native(pyre_object::gc_roots::shadow_stack_get(root_base));
     if dict.is_null() {
         return Err(crate::PyError::runtime_error(
             "SemLock instance has no storage",
@@ -63,6 +378,9 @@ fn semlock_instance(
         "name",
         kept_name.map_or_else(w_none, |name| w_str_new(&name))
     );
+    // interp_semaphore.py:462,465 `self.count = 0`, `self.last_tid = -1`.
+    store!("count", w_int_new(0));
+    store!("last_tid", w_int_new(-1));
     Ok(pyre_object::gc_roots::shadow_stack_get(root_base))
 }
 
@@ -83,6 +401,10 @@ fn semlock_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
         return Err(crate::PyError::type_error("SemLock: name must be a string"));
     };
     let unlink = crate::baseobjspace::is_true(args[5])?;
+    // interp_semaphore.py:574-575.
+    if kind != RECURSIVE_MUTEX && kind != SEMAPHORE {
+        return Err(crate::PyError::value_error("unrecognized kind"));
+    }
     let (handle, kept_name) = rustpython_host_env::multiprocessing::SemHandle::create(
         &name,
         value as libc::c_uint,
@@ -98,29 +420,46 @@ fn semlock_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
     semlock_instance(w_subtype, raw, kind, maxvalue, kept_name)
 }
 
+/// `interp_semaphore.py:547-561 W_SemLock.rebuild`, registered as a
+/// classmethod (`:606`), so `args[0]` is the bound class.
 #[cfg(all(unix, feature = "host_env"))]
 fn semlock_rebuild(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    if args.len() != 4 {
+    if args.len() != 5 {
         return Err(crate::PyError::type_error(
             "_rebuild() takes exactly 4 arguments",
         ));
     }
-    let kind = crate::baseobjspace::int_w(args[1])?;
-    let maxvalue = crate::baseobjspace::int_w(args[2])?;
-    let name = if unsafe { is_str(args[3]) } {
-        crate::baseobjspace::str_utf8_w(args[3])?.to_string()
+    let w_cls = args[0];
+    let kind = crate::baseobjspace::int_w(args[2])?;
+    let maxvalue = crate::baseobjspace::int_w(args[3])?;
+    // `unwrap_spec(name='text_or_none')` — an unlinked semaphore carries no
+    // name and travels as its raw handle instead.
+    let name = if unsafe { is_none(args[4]) } {
+        None
+    } else if unsafe { is_str(args[4]) } {
+        Some(crate::baseobjspace::str_utf8_w(args[4])?.to_string())
     } else {
         return Err(crate::PyError::type_error(
-            "SemLock._rebuild requires a semaphore name",
+            "_rebuild() argument 'name' must be str or None",
         ));
     };
-    let handle =
-        rustpython_host_env::multiprocessing::SemHandle::open_existing(&name).map_err(|error| {
-            crate::PyError::os_error_with_errno(error.raw_os_error(), error.description())
-        })?;
-    let raw = handle.as_ptr();
-    core::mem::forget(handle);
-    semlock_instance(type_object(), raw, kind, maxvalue, Some(name))
+    let raw = match &name {
+        // interp_semaphore.py:550-555 — with a name, reopen it and ignore
+        // `w_handle`.
+        Some(name) => {
+            let handle = rustpython_host_env::multiprocessing::SemHandle::open_existing(name)
+                .map_err(|error| {
+                    crate::PyError::os_error_with_errno(error.raw_os_error(), error.description())
+                })?;
+            let raw = handle.as_ptr();
+            core::mem::forget(handle);
+            raw
+        }
+        // interp_semaphore.py:557 `handle = handle_w(space, w_handle)`
+        // (`:223-224`).
+        None => crate::baseobjspace::int_w(args[1])? as usize as *mut libc::sem_t,
+    };
+    semlock_instance(w_cls, raw, kind, maxvalue, name)
 }
 
 #[cfg(all(unix, feature = "host_env"))]
@@ -132,164 +471,70 @@ crate::py_class! {
             blocking: Option<i64>,
             timeout: Option<PyObjectRef>,
         ) -> Result<bool, crate::PyError> {
-            let handle = semlock_get_handle(self_obj);
-            if handle.is_null() {
-                return Err(crate::PyError::value_error("SemLock handle is null"));
-            }
-            let blocking = blocking.map(|v| v != 0).unwrap_or(true);
+            let block = blocking.map(|v| v != 0).unwrap_or(true);
             let timeout = match timeout {
                 Some(value) if unsafe { !is_none(value) } => {
                     Some(crate::baseobjspace::float_w(value)?)
                 }
                 _ => None,
             };
-            // PEP 475 — sem_wait/sem_trywait retry on EINTR; otherwise
-            // EAGAIN (only meaningful for trywait) yields False and the
-            // remaining errnos propagate as OSError instead of being
-            // silently mapped to False.
-            // `interp_semaphore.py:378-397 semlock_acquire` — on EINTR deliver
-            // a pending signal then retry; on success deliver one too before
-            // returning (`_check_signals(space)`).
-            if blocking && timeout.is_none() {
-                loop {
-                    let r = unsafe { libc::sem_wait(handle) };
-                    if r == 0 {
-                        break;
-                    }
-                    let errno = std::io::Error::last_os_error().raw_os_error().unwrap_or(0);
-                    if errno == libc::EINTR {
-                        crate::module::signal::interp_signal::checksignals_now()?;
-                        continue;
-                    }
-                    return Err(crate::PyError::os_error_with_errno(errno, "sem_wait"));
-                }
-                crate::module::signal::interp_signal::checksignals_now()?;
-                Ok(true)
-            } else if !blocking {
-                loop {
-                    let r = unsafe { libc::sem_trywait(handle) };
-                    if r == 0 {
-                        crate::module::signal::interp_signal::checksignals_now()?;
-                        return Ok(true);
-                    }
-                    let errno = std::io::Error::last_os_error().raw_os_error().unwrap_or(0);
-                    if errno == libc::EINTR {
-                        crate::module::signal::interp_signal::checksignals_now()?;
-                        continue;
-                    }
-                    if errno == libc::EAGAIN {
-                        return Ok(false);
-                    }
-                    return Err(crate::PyError::os_error_with_errno(errno, "sem_trywait"));
-                }
-            } else {
-                let deadline =
-                    rustpython_host_env::multiprocessing::deadline_from_timeout(timeout.unwrap())
-                        .map_err(|error| {
-                            crate::PyError::os_error_with_errno(
-                                error.raw_os_error(),
-                                error.description(),
-                            )
-                        })?;
-                #[cfg(target_vendor = "apple")]
-                {
-                    let mut delay = 0;
-                    loop {
-                        use rustpython_host_env::multiprocessing::PollWaitStep;
-                        match rustpython_host_env::multiprocessing::sem_timedwait_poll_step(
-                            handle, &deadline, delay,
-                        )
-                        .map_err(|error| {
-                            crate::PyError::os_error_with_errno(
-                                error.raw_os_error(),
-                                error.description(),
-                            )
-                        })? {
-                            PollWaitStep::Acquired => {
-                                crate::module::signal::interp_signal::checksignals_now()?;
-                                return Ok(true);
-                            }
-                            PollWaitStep::Timeout => return Ok(false),
-                            PollWaitStep::Continue(next_delay) => delay = next_delay,
-                        }
-                    }
-                }
-                #[cfg(not(target_vendor = "apple"))]
-                loop {
-                    use rustpython_host_env::multiprocessing::WaitStatus;
-                    match rustpython_host_env::multiprocessing::sem_wait_status(
-                        handle,
-                        Some(&deadline),
-                    ) {
-                        WaitStatus::Acquired => {
-                            crate::module::signal::interp_signal::checksignals_now()?;
-                            return Ok(true);
-                        }
-                        WaitStatus::TimedOut => return Ok(false),
-                        WaitStatus::Interrupted => {
-                            crate::module::signal::interp_signal::checksignals_now()?;
-                        }
-                        WaitStatus::Error(error) => {
-                            return Err(crate::PyError::os_error_with_errno(
-                                error.raw_os_error(),
-                                error.description(),
-                            ));
-                        }
-                    }
-                }
-            }
+            w_semlock_acquire(self_obj, block, timeout)
         }
         fn release(self_obj: PyObjectRef) -> Result<(), crate::PyError> {
+            w_semlock_release(self_obj)
+        }
+        // interp_semaphore.py:483-484 W_SemLock.get_count
+        fn _count(self_obj: PyObjectRef) -> i64 {
+            semlock_get_i64(self_obj, "count")
+        }
+        // interp_semaphore.py:489-490 W_SemLock.is_mine
+        fn _is_mine(self_obj: PyObjectRef) -> bool {
+            semlock_ismine(self_obj)
+        }
+        // interp_semaphore.py:544-545 W_SemLock.after_fork
+        fn _after_fork(self_obj: PyObjectRef) {
+            semlock_set_i64(self_obj, "count", 0);
+        }
+        // interp_semaphore.py:492-497 W_SemLock.is_zero
+        fn _is_zero(self_obj: PyObjectRef) -> Result<bool, crate::PyError> {
             let handle = semlock_get_handle(self_obj);
             if handle.is_null() {
                 return Err(crate::PyError::value_error("SemLock handle is null"));
             }
-            let r = unsafe { libc::sem_post(handle) };
-            if r != 0 {
-                return Err(crate::PyError::os_error_with_errno(
-                    std::io::Error::last_os_error().raw_os_error().unwrap_or(0),
-                    "sem_post",
-                ));
-            }
-            Ok(())
+            semlock_iszero(handle)
         }
-        fn _count(self_obj: PyObjectRef) -> i64 {
-            let _ = self_obj;
-            0
-        }
-        fn _is_mine(self_obj: PyObjectRef) -> bool {
-            let _ = self_obj;
-            false
-        }
-        fn _after_fork(self_obj: PyObjectRef) {
-            let _ = self_obj;
-        }
-        // `sem_getvalue` isn't available on macOS; just return false —
-        // multiprocessing.Queue teardown is the only consumer and it
-        // tolerates a conservative "not zero" answer.
-        fn _is_zero(self_obj: PyObjectRef) -> bool {
+        // interp_semaphore.py:499-504 W_SemLock.get_value
+        fn _get_value(self_obj: PyObjectRef) -> Result<i64, crate::PyError> {
             let handle = semlock_get_handle(self_obj);
-            handle.is_null()
-        }
-        fn __enter__(self_obj: PyObjectRef) -> PyObjectRef {
-            let handle = semlock_get_handle(self_obj);
-            if !handle.is_null() {
-                let _ = unsafe { libc::sem_wait(handle) };
+            if handle.is_null() {
+                return Err(crate::PyError::value_error("SemLock handle is null"));
             }
-            self_obj
+            #[cfg(target_vendor = "apple")]
+            {
+                // interp_semaphore.py:432-434.
+                let _ = handle;
+                Err(crate::PyError::not_implemented(
+                    "sem_getvalue is not implemented on this system",
+                ))
+            }
+            #[cfg(not(target_vendor = "apple"))]
+            {
+                semlock_getvalue(handle)
+            }
         }
+        // interp_semaphore.py:563-564 W_SemLock.enter
+        fn __enter__(self_obj: PyObjectRef) -> Result<bool, crate::PyError> {
+            w_semlock_acquire(self_obj, true, None)
+        }
+        // interp_semaphore.py:566-567 W_SemLock.exit
         fn __exit__(
             self_obj: PyObjectRef,
             exc_type: Option<PyObjectRef>,
             exc_value: Option<PyObjectRef>,
             traceback: Option<PyObjectRef>,
-        ) -> bool {
+        ) -> Result<(), crate::PyError> {
             let _ = (exc_type, exc_value, traceback);
-            let handle = semlock_get_handle(self_obj);
-            if !handle.is_null() {
-                let _ = unsafe { libc::sem_post(handle) };
-            }
-            false
+            w_semlock_release(self_obj)
         }
     }
 }
@@ -325,10 +570,15 @@ crate::py_module! {
                     "__new__",
                     crate::make_builtin_function("__new__", semlock_descr_new),
                 );
+                // interp_semaphore.py:606 `as_classmethod=True` — `_rebuild`
+                // allocates on the class it is called through.
                 pyre_object::w_dict_setitem_str_no_proxy(
                     semlock_ns,
                     "_rebuild",
-                    crate::make_builtin_function("_rebuild", semlock_rebuild),
+                    pyre_object::function::w_classmethod_new(crate::make_builtin_function(
+                        "_rebuild",
+                        semlock_rebuild,
+                    )),
                 );
             }
 
@@ -343,8 +593,8 @@ crate::py_module! {
                 "SEM_VALUE_MAX",
                 sem_value_max,
             );
-            crate::module_ns_store(ns, "RECURSIVE_MUTEX", w_int_new(0));
-            crate::module_ns_store(ns, "SEMAPHORE", w_int_new(1));
+            crate::module_ns_store(ns, "RECURSIVE_MUTEX", w_int_new(RECURSIVE_MUTEX));
+            crate::module_ns_store(ns, "SEMAPHORE", w_int_new(SEMAPHORE));
         }
     }
 }

--- a/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
+++ b/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
@@ -3468,13 +3468,18 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
             // the copied strings.  In particular, asyncio passes an
             // `itertools.islice` of memoryviews here, not a list or tuple.
             let _roots = pyre_object::gc_roots::push_roots();
-            pyre_object::gc_roots::pin_root(args[1]);
-            let data_items = crate::baseobjspace::unpackiterable(args[1], -1)?;
-            for &item in &data_items {
-                pyre_object::gc_roots::pin_root(item);
-            }
+            let data_slot = pyre_object::gc_roots::pin_roots(&[args[1]]);
+            let data_items = crate::baseobjspace::unpackiterable(
+                pyre_object::gc_roots::shadow_stack_get(data_slot),
+                -1,
+            )?;
+            let items_base = pyre_object::gc_roots::pin_roots(&data_items);
             let mut data_buffers: Vec<Vec<u8>> = Vec::with_capacity(data_items.len());
-            for item in data_items {
+            // `simple_buffer_bytes` looks up `__buffer__` and builds a
+            // memoryview, so every iteration can collect; read each item back
+            // from its slot instead of consuming the unrooted vector.
+            for i in 0..data_items.len() {
+                let item = pyre_object::gc_roots::shadow_stack_get(items_base + i);
                 let Some(buffer) = crate::baseobjspace::simple_buffer_bytes(item)? else {
                     return Err(crate::PyError::type_error(
                         "sendmsg: data items must be bytes-like",

--- a/pyre/pyre-interpreter/src/module/operator/app_operator.py
+++ b/pyre/pyre-interpreter/src/module/operator/app_operator.py
@@ -1,9 +1,18 @@
 # app_operator.py — app-level helpers for the operator module.
-# attrgetter / itemgetter / methodcaller are callable factory classes that
-# the interp-level operator module cannot express as plain functions.
-# Mirrors pypy/module/operator/app_operator.py.
+# countOf is a plain loop; attrgetter / itemgetter / methodcaller are callable
+# factory classes that the interp-level operator module cannot express as plain
+# functions.  Mirrors pypy/module/operator/app_operator.py.
 
 __name__ = 'operator'
+
+
+def countOf(a, b):
+    'countOf(a, b) -- Return the number of times b occurs in a.'
+    count = 0
+    for x in a:
+        if x is b or x == b:
+            count += 1
+    return count
 
 
 class attrgetter(object):

--- a/pyre/pyre-interpreter/src/module/operator/mod.rs
+++ b/pyre/pyre-interpreter/src/module/operator/mod.rs
@@ -132,66 +132,18 @@ use crate::baseobjspace::{
     matmul, mod_, mul, neg, or_, pos, pow, rshift, setitem, sub, truediv, xor,
 };
 
-/// `countOf(a, b)` — number of times `b` occurs in `a`, counting `x is b or
-/// x == b` while iterating `a` through the iterator protocol.
-fn op_countof(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    let iterator = baseobjspace::iter(args[0])?;
-    let mut count = 0i64;
-    loop {
-        match baseobjspace::next(iterator) {
-            Ok(item) => {
-                if std::ptr::eq(item, args[1])
-                    || is_true(baseobjspace::compare(item, args[1], CompareOp::Eq)?)?
-                {
-                    count += 1;
-                }
-            }
-            Err(e) if e.kind == crate::PyErrorKind::StopIteration => break,
-            Err(e) => return Err(e),
-        }
-    }
-    Ok(w_int_new(count))
-}
-
-/// `indexOf(a, b)` — first index `i` where `a[i] is b or a[i] == b`, iterating
-/// `a` through the iterator protocol; a miss raises
-/// `ValueError('sequence.index(x): x not in sequence')`.
-fn op_indexof(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    let iterator = baseobjspace::iter(args[0])?;
-    let mut index = 0i64;
-    loop {
-        match baseobjspace::next(iterator) {
-            Ok(item) => {
-                if std::ptr::eq(item, args[1])
-                    || is_true(baseobjspace::compare(item, args[1], CompareOp::Eq)?)?
-                {
-                    return Ok(w_int_new(index));
-                }
-                index += 1;
-            }
-            Err(e) if e.kind == crate::PyErrorKind::StopIteration => break,
-            Err(e) => return Err(e),
-        }
-    }
-    Err(crate::PyError::value_error(
-        "sequence.index(x): x not in sequence",
-    ))
-}
-
 crate::py_module! {
     "operator",
-    // Only the `itemgetter`/`attrgetter`/`methodcaller` callable factory
-    // classes stay app-level (`pypy/module/operator/app_operator.py`,
-    // `moduledef.py` `app_names`); a factory class cannot be expressed as a
-    // plain interp-level function.  `countOf`/`indexOf`/`inv`/`is_none`/
-    // `is_not_none`/`call` live in the `functions:` block below so they
-    // register as non-binding `BuiltinFunction` (no `__get__`), instead of
-    // globals-bearing app-level functions that bind `self` when stored on a
-    // class.  `concat` is interp-level (`op_concat`, `interp_operator.py:20`)
-    // so it guards both operands for `__getitem__`.
+    // `moduledef.py` `app_names` — `countOf` (a plain `app_operator.py` loop)
+    // and the `attrgetter`/`itemgetter`/`methodcaller` factory classes (which
+    // cannot be plain interp-level functions) — are the only app-level names.
+    // Everything else is interp-level: `indexOf` delegates to
+    // `space.sequence_index` (`interp_operator.py:58`) and `concat`
+    // (`op_concat`, `interp_operator.py:20`) guards both operands for
+    // `__getitem__`.
     appleveldefs: {
         "app_operator.py" => [
-            "itemgetter", "attrgetter", "methodcaller",
+            "countOf", "itemgetter", "attrgetter", "methodcaller",
         ],
     },
     functions: {
@@ -239,8 +191,7 @@ crate::py_module! {
         "is_none"     / 1 = |args| Ok(w_bool_from(std::ptr::eq(args[0], w_none()))),
         "is_not_none" / 1 = |args| Ok(w_bool_from(!std::ptr::eq(args[0], w_none()))),
         "contains" / 2 = |args| Ok(w_bool_from(contains(args[0], args[1])?)),
-        "countOf"  / 2 = op_countof,
-        "indexOf"  / 2 = op_indexof,
+        "indexOf"  / 2 = |args| baseobjspace::sequence_index(args[0], args[1]),
         // `call(obj, /, *args, **kwargs)` == `obj(*args, **kwargs)`.
         // `call_forwarding_args` re-splits the `__pyre_kw__` marker back into
         // keyword arguments before dispatching.

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -3600,8 +3600,13 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     if args.len() < 2 {
                         return Err(crate::PyError::type_error("kill() requires 2 arguments"));
                     }
-                    let pid = (unsafe { pyre_object::w_int_get_value(args[0]) }) as libc::pid_t;
-                    let sig = (unsafe { pyre_object::w_int_get_value(args[1]) }) as libc::c_int;
+                    // interp_posix.py:1386 `@unwrap_spec(pid=c_int, signal=c_int)`.
+                    // Both arguments go through `c_int_w`: a raw payload read
+                    // would accept any object, and `is_int` is an exact-type
+                    // check, so an `int` subclass instance — `signal.SIGHUP` is
+                    // an `IntEnum` member — never reaches the checked path.
+                    let pid = crate::baseobjspace::c_int_w(args[0])? as libc::pid_t;
+                    let sig = crate::baseobjspace::c_int_w(args[1])? as libc::c_int;
                     let r = unsafe { libc::kill(pid, sig) };
                     if r < 0 {
                         return Err(io_err(std::io::Error::last_os_error(), ""));
@@ -3621,8 +3626,9 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     if args.len() < 2 {
                         return Err(crate::PyError::type_error("killpg() requires 2 arguments"));
                     }
-                    let pgid = (unsafe { pyre_object::w_int_get_value(args[0]) }) as libc::pid_t;
-                    let sig = (unsafe { pyre_object::w_int_get_value(args[1]) }) as libc::c_int;
+                    // interp_posix.py:1394 `@unwrap_spec(pgid=c_int, signal=c_int)`.
+                    let pgid = crate::baseobjspace::c_int_w(args[0])? as libc::pid_t;
+                    let sig = crate::baseobjspace::c_int_w(args[1])? as libc::c_int;
                     let r = unsafe { libc::killpg(pgid, sig) };
                     if r < 0 {
                         return Err(io_err(std::io::Error::last_os_error(), ""));
@@ -4178,11 +4184,28 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     }));
                 }
                 let keys = crate::baseobjspace::unpackiterable(keys_obj, -1)?;
+                // `getitem` runs the mapping's `__getitem__` and both encodes
+                // allocate, so the mapping and every key are published once and
+                // read back per iteration rather than kept in plain locals.
+                let _env_roots = pyre_object::gc_roots::push_roots();
+                let mapping_slot = pyre_object::gc_roots::pin_roots(&[mapping]);
+                let keys_base = pyre_object::gc_roots::pin_roots(&keys);
                 let mut env = Vec::with_capacity(keys.len());
-                for key_obj in keys {
-                    let value_obj = crate::baseobjspace::getitem(mapping, key_obj)?;
-                    let key = crate::gateway::fsencode_bytes_w(key_obj)?;
-                    let value = crate::gateway::fsencode_bytes_w(value_obj)?;
+                for i in 0..keys.len() {
+                    let _entry_roots = pyre_object::gc_roots::push_roots();
+                    let value_obj = crate::baseobjspace::getitem(
+                        pyre_object::gc_roots::shadow_stack_get(mapping_slot),
+                        pyre_object::gc_roots::shadow_stack_get(keys_base + i),
+                    )?;
+                    // Encoding the key can collect, so the value it was fetched
+                    // beside has to be published before that call.
+                    let value_slot = pyre_object::gc_roots::pin_roots(&[value_obj]);
+                    let key = crate::gateway::fsencode_bytes_w(
+                        pyre_object::gc_roots::shadow_stack_get(keys_base + i),
+                    )?;
+                    let value = crate::gateway::fsencode_bytes_w(
+                        pyre_object::gc_roots::shadow_stack_get(value_slot),
+                    )?;
                     if key.is_empty() || key.contains(&b'=') {
                         return Err(crate::PyError::value_error(
                             "illegal environment variable name",
@@ -4577,23 +4600,25 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         let w_sysconf_names = pyre_object::w_dict_new();
         let _sysconf_names_root = pyre_object::gc_roots::push_roots();
         pyre_object::gc_roots::pin_root(w_sysconf_names);
+        let names_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         for (name, value) in sysconf_names() {
+            // Build the value first: call arguments evaluate left to right, so
+            // reading the rooted dict inline would take its address before
+            // `w_int_new` allocates, and a collection there would leave the
+            // store writing through the pre-move address.
+            let w_value = pyre_object::w_int_new(*value as i64);
             unsafe {
                 pyre_object::w_dict_setitem_str(
-                    pyre_object::gc_roots::shadow_stack_get(
-                        pyre_object::gc_roots::shadow_stack_len() - 1,
-                    ),
+                    pyre_object::gc_roots::shadow_stack_get(names_slot),
                     name,
-                    pyre_object::w_int_new(*value as i64),
+                    w_value,
                 );
             }
         }
         crate::module_ns_store(
             ns,
             "sysconf_names",
-            pyre_object::gc_roots::shadow_stack_get(
-                pyre_object::gc_roots::shadow_stack_len() - 1,
-            ),
+            pyre_object::gc_roots::shadow_stack_get(names_slot),
         );
 
         // os.initgroups(username, gid) -> None

--- a/pyre/pyre-interpreter/src/module/thread/mod.rs
+++ b/pyre/pyre-interpreter/src/module/thread/mod.rs
@@ -347,7 +347,6 @@ pub(crate) fn after_fork_child() {
     pyre_object::interp_itertools::count_locks_after_fork_child();
     crate::objspace::std::mapdict::after_fork_child();
     pyre_object::dictmultiobject::module_dict_locks_after_fork_child();
-    pyre_object::setobject::set_locks_after_fork_child();
     crate::module::_collections::deque_locks_after_fork_child();
     majit_gc::shadow_stack::after_fork_child();
     majit_gc::gc_sync::after_fork_child();

--- a/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
+++ b/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
@@ -2236,30 +2236,47 @@ fn instance_write_barrier(obj: PyObjectRef) {
     pyre_object::gc_hook::try_gc_write_barrier(obj as *mut u8);
 }
 
-/// Return the storage indices that contain real GCREFs for `map`; slots owned
-/// by the first `UnboxedPlainAttribute` contain erased `Vec<i64>` pointers and
-/// must never enter the shadow stack.
-unsafe fn boxed_storage_indices(map: MapRef, len: usize) -> Vec<usize> {
-    let mut unboxed = vec![false; len];
+/// Whether `index` is the storage slot of a `firstunwrapped` attribute in
+/// `map`'s chain. Such a slot holds an erased `Vec<i64>` unboxing bank, not a
+/// GCREF, and must never enter the shadow stack or the marking worklist.
+///
+/// The whole chain is scanned rather than stopping at the first
+/// `firstunwrapped` node. `_compute_storageindex_listindex`
+/// (mapdict.py:549-562) does imply a chain holds at most one — it breaks at
+/// the first `UnboxedPlainAttribute` ancestor and only sets `firstunwrapped`
+/// when it finds none — but the collector is the wrong place to depend on
+/// that, since under-reporting one slot hands the marker a raw `Vec` pointer.
+///
+/// Allocation-free by contract: the GC trace hook calls this while marking,
+/// where taking the global allocator would be a reentrancy hazard.
+unsafe fn storage_index_is_unboxed(map: MapRef, index: usize) -> bool {
     let mut node = map;
     while !node.is_null() {
         match unsafe { &*node } {
             MapNode::Plain(p) => {
-                if let Some(u) = &p.unboxed {
-                    if u.firstunwrapped && p.storageindex < len {
-                        unboxed[p.storageindex] = true;
-                    }
+                if let Some(u) = &p.unboxed
+                    && u.firstunwrapped
+                    && p.storageindex == index
+                {
+                    return true;
                 }
                 node = p.back;
             }
             MapNode::Terminator(_) => break,
         }
     }
-    (0..len).filter(|&i| !unboxed[i]).collect()
+    false
+}
+
+/// Return the storage indices that contain real GCREFs for `map`.
+unsafe fn boxed_storage_indices(map: MapRef, len: usize) -> Vec<usize> {
+    (0..len)
+        .filter(|&i| !unsafe { storage_index_is_unboxed(map, i) })
+        .collect()
 }
 
 unsafe fn storage_index_is_boxed(map: MapRef, index: usize) -> bool {
-    unsafe { boxed_storage_indices(map, index + 1).contains(&index) }
+    !unsafe { storage_index_is_unboxed(map, index) }
 }
 
 impl MapdictObject for pyre_object::W_ObjectObject {
@@ -2320,6 +2337,16 @@ impl MapdictObject for pyre_object::W_ObjectObject {
     }
     fn _mapdict_pop_attribute(&mut self, map: MapRef) {
         // mapdict.py:926-939; structure mirrors the MockObj test impl.
+        // Both arms can collect — the unboxed one through
+        // `_mapdict_write_storage`, the other through the storage shrink — so
+        // the receiver is published for the whole function and every write
+        // goes through the reloaded address, as in
+        // `_set_mapdict_increase_storage1` and `_set_mapdict_storage_and_map`.
+        // `&mut self` is a bare address that a moving collection invalidates;
+        // writing `map` through it would leave the live instance on its old
+        // map, claiming a storage slot the shrunk block no longer has.
+        let _roots = pyre_object::gc_roots::push_roots();
+        let self_slot = pyre_object::gc_roots::pin_roots(&[self as *const Self as PyObjectRef]);
         let current_map = self.map as MapRef;
         let unboxed_slot: Option<(usize, usize)> = unsafe {
             match &(*current_map).as_plain().unboxed {
@@ -2339,16 +2366,16 @@ impl MapdictObject for pyre_object::W_ObjectObject {
                     let list: &Vec<i64> = &*unerase_unboxed(slot);
                     list[..listindex].to_vec()
                 };
-                self._mapdict_write_storage(storageindex, erase_unboxed(Box::new(new_list)));
+                let owner = unsafe {
+                    &mut *(pyre_object::gc_roots::shadow_stack_get(self_slot) as *mut Self)
+                };
+                owner._mapdict_write_storage(storageindex, erase_unboxed(Box::new(new_list)));
             }
             // mapdict.py:935-938: truncate storage to the parent map's size.
             // The block is exact-size, so shrink it to a fresh cap-N block; the
             // dropped tail slots are gone with the old block. NULL-fill is
             // implicit in `grow_instance_items_block` (new_cap <= live_len here).
             None => {
-                let _roots = pyre_object::gc_roots::push_roots();
-                let self_slot = pyre_object::gc_roots::shadow_stack_len();
-                pyre_object::gc_roots::pin_root(self as *const Self as PyObjectRef);
                 let storage_needed = unsafe { (*map).storage_needed() };
                 unsafe {
                     let owner =
@@ -2370,7 +2397,10 @@ impl MapdictObject for pyre_object::W_ObjectObject {
                 }
             }
         }
-        self.map = map as *const u8;
+        unsafe {
+            let owner = &mut *(pyre_object::gc_roots::shadow_stack_get(self_slot) as *mut Self);
+            owner.map = map as *const u8;
+        }
     }
     fn _set_mapdict_increase_storage1(&mut self, map: MapRef, value: PyObjectRef) {
         // grow storage by one, append value (mapdict.py:942-959). The first
@@ -3033,9 +3063,26 @@ unsafe fn node_materialize_dict<O: MapdictObject>(
 /// `obj` must be a live `W_ObjectObject`; `w_dict` a live `W_DictObject` on
 /// its post-switch strategy.
 unsafe fn materialize_dict(obj: PyObjectRef, w_dict: PyObjectRef) {
-    let inst = unsafe { &mut *(obj as *mut pyre_object::W_ObjectObject) };
-    let map = inst._get_mapdict_map();
-    let new_obj = unsafe { node_materialize_dict(map, &*inst, w_dict) };
+    // Filling `w_dict` allocates — boxed attribute names, the dict stores, and
+    // the rebuilt carrier's own transitions — so both operands are published
+    // and the transplant writes through the instance's post-collection address.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let obj_slot = pyre_object::gc_roots::pin_roots(&[obj, w_dict]);
+    let dict_slot = obj_slot + 1;
+    let new_obj = unsafe {
+        let inst = &*(pyre_object::gc_roots::shadow_stack_get(obj_slot)
+            as *const pyre_object::W_ObjectObject);
+        let map = inst._get_mapdict_map();
+        node_materialize_dict(
+            map,
+            inst,
+            pyre_object::gc_roots::shadow_stack_get(dict_slot),
+        )
+    };
+    let inst = unsafe {
+        &mut *(pyre_object::gc_roots::shadow_stack_get(obj_slot)
+            as *mut pyre_object::W_ObjectObject)
+    };
     inst._set_mapdict_storage_and_map(new_obj.storage, new_obj.map);
 }
 
@@ -3842,13 +3889,44 @@ pub fn _obj_getdict(self_ref: PyObjectRef) -> PyObjectRef {
     // INSTANCE_DICT side table as a plain own-storage dict until subclass
     // instances grow mapdict storage (upstream `user_setup`, mapdict.py:758).
     if unsafe { pyre_object::is_instance(self_ref) } {
-        if let Some(w_dict) = unsafe { instance_get_dict_slot(self_ref) } {
+        // mapdict.py:828-830 `if w_dict is not None`.  RPython's `read` answers
+        // None both for an absent slot and for one holding None, and both mean
+        // "build the view" — so a null must not reach the caller.  It would be
+        // reported as "the receiver has no dict", which is how
+        // `descr__setattr__` decides an ordinary instance store is
+        // `"'%T' object attribute '%s' is read-only"` (descroperation.py:58-67).
+        if let Some(w_dict) = unsafe { instance_get_dict_slot(self_ref) }
+            && !w_dict.is_null()
+        {
             return w_dict;
         }
-        let w_dict = pyre_object::w_dict_new_with(&MAP_DICT_STRATEGY, self_ref as *mut u8);
-        let flag = unsafe { instance_set_dict_slot(self_ref, w_dict) };
-        debug_assert!(flag, "write to the \"dict\" SPECIAL slot failed");
-        w_dict
+        // Allocating the wrapper and claiming the SPECIAL slot both collect, so
+        // the instance is published first and every use below reads back the
+        // relocated address.
+        let _roots = pyre_object::gc_roots::push_roots();
+        let self_slot = pyre_object::gc_roots::pin_roots(&[self_ref]);
+        let dict_slot = self_slot + 1;
+        pyre_object::gc_roots::pin_root(pyre_object::w_dict_new_with(
+            &MAP_DICT_STRATEGY,
+            pyre_object::gc_roots::shadow_stack_get(self_slot) as *mut u8,
+        ));
+        unsafe {
+            let w_dict = pyre_object::gc_roots::shadow_stack_get(dict_slot);
+            // `dstorage` is the view's only link to its backing instance
+            // (mapdict.py:1502) and `walk_gc_refs` forwards it — but only from
+            // the collection after the wrapper became reachable.  The
+            // allocation that produced the wrapper is not covered, so restate
+            // the back-pointer from the instance's current address.
+            (*(w_dict as *mut pyre_object::W_DictObject)).dstorage =
+                pyre_object::gc_roots::shadow_stack_get(self_slot) as *mut u8;
+            pyre_object::gc_hook::try_gc_write_barrier(w_dict as *mut u8);
+            let flag = instance_set_dict_slot(
+                pyre_object::gc_roots::shadow_stack_get(self_slot),
+                pyre_object::gc_roots::shadow_stack_get(dict_slot),
+            );
+            debug_assert!(flag, "write to the \"dict\" SPECIAL slot failed");
+        }
+        pyre_object::gc_roots::shadow_stack_get(dict_slot)
     } else {
         let existing = INSTANCE_DICT
             .lock()
@@ -3903,8 +3981,13 @@ pub unsafe fn instance_walk_boxed_storage(obj: PyObjectRef, f: &mut dyn FnMut(*m
         // The storage block is exact-size (capacity == map.storage_needed()).
         let len = pyre_object::object_array::items_block_capacity(inst.storage);
         let base = pyre_object::object_array::items_block_items_base(inst.storage);
-        for i in boxed_storage_indices(inst.map as MapRef, len) {
-            f(base.add(i));
+        // Test each slot in place: this runs inside the collector's marking
+        // walk, where the previous `Vec` pair per traced instance was both a
+        // per-object cost and a reentrancy hazard.
+        for i in 0..len {
+            if !storage_index_is_unboxed(inst.map as MapRef, i) {
+                f(base.add(i));
+            }
         }
     }
 }
@@ -4152,7 +4235,12 @@ pub fn _obj_setdict(self_ref: PyObjectRef, w_dict: PyObjectRef) -> Result<(), Py
         // delegating to the instance once the slot is overwritten — otherwise
         // `old = obj.__dict__; obj.__dict__ = {}` leaves `old` an empty shell
         // that still mirrors the live instance.
-        let w_olddict = _obj_getdict(self_ref);
+        // Materialising the old view and claiming the slot both allocate, so
+        // the receiver and the incoming dict are published across them.
+        let _roots = pyre_object::gc_roots::push_roots();
+        let self_slot = pyre_object::gc_roots::pin_roots(&[self_ref, w_dict]);
+        let dict_slot = self_slot + 1;
+        let w_olddict = _obj_getdict(pyre_object::gc_roots::shadow_stack_get(self_slot));
         let old_backing = crate::type_methods::resolve_dict_backing(w_olddict);
         let is_map_view = unsafe {
             pyre_object::dictmultiobject::w_dict_get_strategy(old_backing).strategy_kind()
@@ -4161,7 +4249,12 @@ pub fn _obj_setdict(self_ref: PyObjectRef, w_dict: PyObjectRef) -> Result<(), Py
         if is_map_view {
             unsafe { mapdict_switch_to_object_strategy(old_backing) };
         }
-        let flag = unsafe { instance_set_dict_slot(self_ref, w_dict) };
+        let flag = unsafe {
+            instance_set_dict_slot(
+                pyre_object::gc_roots::shadow_stack_get(self_slot),
+                pyre_object::gc_roots::shadow_stack_get(dict_slot),
+            )
+        };
         debug_assert!(flag, "write to the \"dict\" SPECIAL slot failed");
     } else {
         // Non-instance hasdict objects (property/member, baseobjspace
@@ -4910,6 +5003,42 @@ mod tests {
             assert_eq!(MAP_DICT_STRATEGY.length(w1), 1);
             assert_eq!(MAP_DICT_STRATEGY.getitem_str(w1, "x"), Some(sentinel(0x1)));
             assert_eq!(MAP_DICT_STRATEGY.getitem_str(w1, "dict"), None);
+        }
+    }
+
+    #[test]
+    fn obj_getdict_rebuilds_the_view_when_the_dict_slot_reads_null() {
+        use pyre_object::dictmultiobject::{DictStrategy, StrategyKind};
+        // mapdict.py:828-830 `if w_dict is not None` — RPython's `read` answers
+        // None both for an absent slot and for one holding None, and both mean
+        // "build the view".  Surfacing the null instead makes `getdict` report
+        // that the receiver has no dict, which is the single state
+        // `descr__setattr__` turns into
+        // `"'%T' object attribute '%s' is read-only"` — for any name the type
+        // carries, a class-variable default being enough to arm that branch.
+        crate::test_hooks::install_hash_hook();
+        unsafe {
+            let term = boxed_dict_terminator();
+            let obj_ref = pyre_object::w_instance_new(pyre_object::PY_NULL);
+            let obj = &mut *(obj_ref as *mut pyre_object::W_ObjectObject);
+            obj._set_mapdict_map(term);
+
+            let w1 = _obj_getdict(obj_ref);
+            assert!(!w1.is_null());
+            assert_eq!(instance_get_dict_slot(obj_ref), Some(w1));
+
+            // The state a write that never landed leaves behind: the map still
+            // claims the SPECIAL attribute, its storage slot holds NULL.
+            assert!(instance_set_dict_slot(obj_ref, pyre_object::PY_NULL));
+            assert_eq!(instance_get_dict_slot(obj_ref), Some(pyre_object::PY_NULL));
+
+            let w2 = _obj_getdict(obj_ref);
+            assert!(!w2.is_null(), "a null SPECIAL slot must rebuild the view");
+            assert_eq!(instance_get_dict_slot(obj_ref), Some(w2));
+            let dict = &*(w2 as *const pyre_object::W_DictObject);
+            assert_eq!(dict.dstrategy.strategy_kind(), StrategyKind::Map);
+            // The rebuilt view backs onto the instance it was built for.
+            assert_eq!(dict.dstorage as PyObjectRef, obj_ref);
         }
     }
 

--- a/pyre/pyre-interpreter/src/pytraceback.rs
+++ b/pyre/pyre-interpreter/src/pytraceback.rs
@@ -272,14 +272,26 @@ pub unsafe fn w_pytraceback_get_w_code(obj: PyObjectRef) -> PyObjectRef {
 /// ```
 ///
 /// Pyre stamps the real line number at `record_application_traceback`
-/// time (the frame is guaranteed live there), so this reader never
-/// has to walk back through `self.frame.pycode`.  That walk is what
-/// upstream does, and it is safe there because the frame edge is
-/// unconditional; pyre's is not forwarded for a frame the GC does not
-/// own, which may already have been freed by the time `tb_lineno` is
-/// read.  The `LINENO_NOT_COMPUTED` sentinel still surfaces as `-1`
-/// for the edge case where the traceback was constructed without a
-/// frame (e.g. unit tests).
+/// time instead of resolving it here.  The upstream walk goes through
+/// `self.frame.pycode`, which this reader cannot do: `frame` is only
+/// forwarded for a frame the GC owns, so it may already have been
+/// freed by the time `tb_lineno` is read.  The `w_code` snapshot is
+/// forwarded unconditionally and IS that `pycode`, so `offset2lineno`
+/// off `w_code` and `lasti` would be safe to run lazily.  What still
+/// depends on the eager stamp is the JIT fold
+/// `walker_specialize_traceback_walk_field` (pyre-jit-trace): it reads
+/// this slot directly and declines on the sentinel, so under a lazy
+/// `get_lineno` every fresh node would decline on its first read.
+///
+/// Two `tb_lineno` answers diverge from `get_lineno` because of it.
+/// Upstream re-resolves from the CURRENT `lasti` whenever the slot
+/// still holds the sentinel, so `tb.tb_lasti = N; tb.tb_lineno` reads
+/// the new offset there and the originally-stamped line here; and a
+/// sentinel written back through `TracebackType(..., -sys.maxsize-1)`
+/// or the `tb_lineno` setter is re-resolved there and answered `-1`
+/// here.  Porting back to lazy needs the fold to call a resolver
+/// rather than decline.  The sentinel also still surfaces as `-1` for
+/// a traceback constructed without a frame (e.g. unit tests).
 ///
 /// # Safety
 /// `tb` must point to a valid `PyTraceback`.
@@ -385,12 +397,14 @@ pub unsafe fn record_application_traceback(
         crate::eval::set_in_flight_exception(w_exc_object);
         // `pytraceback.py:36 self.lineno = offset2lineno(self.frame
         // .pycode, self.lasti)` — pyre resolves the line number
-        // eagerly here rather than lazily in `get_lineno`, because a
-        // frame the GC does not own is not kept alive by the traceback
-        // and may already be freed by the time `tb_lineno` is read.
-        // Stamping at construction guarantees the value survives the
-        // frame's lifetime.  `frame.pycode` is the `PyCode` wrapper;
-        // the inner `CodeObject` is extracted via `pyframe_get_pycode`.
+        // eagerly here rather than lazily in `get_lineno`; stamping at
+        // construction guarantees the value survives the frame's
+        // lifetime, since a frame the GC does not own is not kept alive
+        // by the traceback.  See `w_pytraceback_get_lineno` for what
+        // still depends on the eager stamp and which two `tb_lineno`
+        // answers it diverges on.  `frame.pycode` is the `PyCode`
+        // wrapper; the inner `CodeObject` is extracted via
+        // `pyframe_get_pycode`.
         //
         // The `PyCode` PyObjectRef is also captured into the `w_code`
         // slot so the traceback's source-path / function name metadata

--- a/pyre/pyre-interpreter/src/runtime_ops.rs
+++ b/pyre/pyre-interpreter/src/runtime_ops.rs
@@ -128,20 +128,19 @@ pub extern "C" fn jit_load_name_from_namespace(
             return v as i64;
         }
     }
-    // Globals miss: `pyopcode.py:958-967 _load_global` falls back to
-    // `self.get_builtin().getdictvalue(space, varname)`.  The frame's
-    // picked builtin (`pyframe.py:115 self.builtin =
-    // space.builtin.pick_builtin(w_globals)`) is the authoritative
-    // builtin reference; mid-execution `__builtins__` rebind would
-    // change the picked module without touching
-    // `namespace["__builtins__"]`'s raw entry, so the extern must
-    // route through `frame.w_builtin` rather than re-reading the dict
-    // slot.
+    // Globals miss: `_load_global` (pyopcode.py) falls back to
+    // `self.get_builtin().getdictvalue(space, varname)`.  Go through the
+    // accessor, never the raw slot: the constructor (pyframe.py) assigns
+    // `self.builtin` only under `honor__builtins__`, so with the option off
+    // (`baseobjspace::HONOR_BUILTINS`) the field stays unset and
+    // `get_builtin` answers `space.builtin` instead.  A
+    // frame the JIT materialized from a virtual never wrote the slot, so a
+    // raw read there resolves no builtin at all and every builtin name
+    // raises NameError.  The accessor still prefers the picked module when a
+    // frame does carry one, so a mid-execution `__builtins__` rebind is
+    // honoured exactly as before.
     let w_builtin = if frame_ptr != 0 {
-        unsafe {
-            let p = frame_ptr as *const u8;
-            *(p.add(crate::pyframe::PYFRAME_W_BUILTIN_OFFSET) as *const PyObjectRef)
-        }
+        unsafe { (*(frame_ptr as *const crate::pyframe::PyFrame)).get_builtin() }
     } else {
         std::ptr::null_mut()
     };

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -8879,7 +8879,103 @@ fn union_mro_entries_method(args: &[PyObjectRef]) -> crate::PyResult {
     )))
 }
 
+/// `UnionType.__ne__` — the inverse of structural union equality, preserving
+/// `NotImplemented` for non-union operands.
+fn union_ne_method(args: &[PyObjectRef]) -> crate::PyResult {
+    let self_ = args.first().copied().unwrap_or(pyre_object::PY_NULL);
+    let other = args.get(1).copied().unwrap_or(pyre_object::PY_NULL);
+    if !unsafe { pyre_object::is_union(self_) } {
+        return Err(crate::PyError::type_error(
+            "descriptor '__ne__' requires a 'types.UnionType' object",
+        ));
+    }
+    if !unsafe { pyre_object::is_union(other) } {
+        return Ok(pyre_object::w_not_implemented());
+    }
+    Ok(pyre_object::w_bool_from(
+        !crate::_pypy_generic_alias::union_set_eq(self_, other)?,
+    ))
+}
+
+/// `UnionType` has no ordering relation.  Expose the four slots explicitly,
+/// as CPython does, while retaining the normal rich-compare fallback.
+fn union_ordering_method(args: &[PyObjectRef]) -> crate::PyResult {
+    let self_ = args.first().copied().unwrap_or(pyre_object::PY_NULL);
+    if !unsafe { pyre_object::is_union(self_) } {
+        return Err(crate::PyError::type_error(
+            "descriptor comparison requires a 'types.UnionType' object",
+        ));
+    }
+    Ok(pyre_object::w_not_implemented())
+}
+
+/// `UnionType.__getattribute__` — the explicit type-dict entry delegates to
+/// the ordinary object lookup, just like the C slot.
+fn union_getattribute_method(args: &[PyObjectRef]) -> crate::PyResult {
+    let self_ = args.first().copied().unwrap_or(pyre_object::PY_NULL);
+    if !unsafe { pyre_object::is_union(self_) } {
+        return Err(crate::PyError::type_error(
+            "descriptor '__getattribute__' requires a 'types.UnionType' object",
+        ));
+    }
+    let name =
+        crate::baseobjspace::text_w(args.get(1).copied().unwrap_or_else(pyre_object::w_none))?;
+    crate::baseobjspace::object_getattribute(self_, name)
+}
+
 fn init_union_type(ns: PyObjectRef) {
+    // `_pypy_generic_alias.py:241-246 UnionType` docstring, plus CPython
+    // 3.14's three read-only identity getsets on union instances.
+    unsafe {
+        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+            ns,
+            "__doc__",
+            pyre_object::w_str_new("Represent a union type\n\nE.g. for int | str"),
+        )
+    };
+    for (name, getter) in [
+        (
+            "__name__",
+            (|args: &[PyObjectRef]| {
+                let self_ = args.get(1).copied().unwrap_or(pyre_object::PY_NULL);
+                if !unsafe { pyre_object::is_union(self_) } {
+                    return Err(crate::PyError::type_error(
+                        "descriptor '__name__' requires a 'types.UnionType' object",
+                    ));
+                }
+                Ok(pyre_object::w_str_new("Union"))
+            }) as DunderFn,
+        ),
+        ("__qualname__", |args: &[PyObjectRef]| {
+            let self_ = args.get(1).copied().unwrap_or(pyre_object::PY_NULL);
+            if !unsafe { pyre_object::is_union(self_) } {
+                return Err(crate::PyError::type_error(
+                    "descriptor '__qualname__' requires a 'types.UnionType' object",
+                ));
+            }
+            Ok(pyre_object::w_str_new("Union"))
+        }),
+        ("__origin__", |args: &[PyObjectRef]| {
+            let self_ = args.get(1).copied().unwrap_or(pyre_object::PY_NULL);
+            if !unsafe { pyre_object::is_union(self_) } {
+                return Err(crate::PyError::type_error(
+                    "descriptor '__origin__' requires a 'types.UnionType' object",
+                ));
+            }
+            Ok(gettypeobject(&pyre_object::UNION_TYPE))
+        }),
+    ] {
+        unsafe {
+            pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+                ns,
+                name,
+                make_getset_descriptor_named(
+                    make_builtin_function_with_arity(name, getter, 2),
+                    name,
+                ),
+            )
+        };
+    }
     // Python 3.14's shared `types.UnionType` / `typing.Union` runtime type
     // exposes `__module__` on union *instances* as well as on the type.  Keep
     // the value in the typedef namespace so generic object attribute lookup
@@ -9033,6 +9129,43 @@ fn init_union_type(ns: PyObjectRef) {
             ns,
             "__mro_entries__",
             make_builtin_function_with_arity("__mro_entries__", union_mro_entries_method, 2),
+        )
+    };
+    unsafe {
+        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+            ns,
+            "__ne__",
+            make_builtin_function_with_arity("__ne__", union_ne_method, 2),
+        )
+    };
+    for (name, method) in [
+        ("__lt__", union_ordering_method as DunderFn),
+        ("__le__", union_ordering_method),
+        ("__gt__", union_ordering_method),
+        ("__ge__", union_ordering_method),
+    ] {
+        unsafe {
+            pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+                ns,
+                name,
+                make_builtin_function_with_arity(name, method, 2),
+            )
+        };
+    }
+    unsafe {
+        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+            ns,
+            "__getattribute__",
+            make_builtin_function_with_arity("__getattribute__", union_getattribute_method, 2),
+        )
+    };
+    // `_pypy_generic_alias.py:322`: prevent the sequence protocol from using
+    // `__getitem__` as an iteration fallback.
+    unsafe {
+        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+            ns,
+            "__iter__",
+            pyre_object::w_none(),
         )
     };
 }

--- a/pyre/pyre-jit-trace/src/call_spec.rs
+++ b/pyre/pyre-jit-trace/src/call_spec.rs
@@ -135,6 +135,13 @@ pub const PYFRAME_CALL_EFFECTS: &[CallEffectSpec] = &[
     },
     CallEffectSpec {
         target: CallTargetSpec::Method {
+            name: "delete_global",
+            receiver_root: PYFRAME_CALL_OWNER_ROOT,
+        },
+        effect: CallEffectKind::Residual,
+    },
+    CallEffectSpec {
+        target: CallTargetSpec::Method {
             name: "load_name",
             receiver_root: PYFRAME_CALL_OWNER_ROOT,
         },
@@ -171,6 +178,13 @@ pub const PYFRAME_CALL_EFFECTS: &[CallEffectSpec] = &[
     CallEffectSpec {
         target: CallTargetSpec::Method {
             name: "store_name_value",
+            receiver_root: PYFRAME_CALL_OWNER_ROOT,
+        },
+        effect: CallEffectKind::Residual,
+    },
+    CallEffectSpec {
+        target: CallTargetSpec::Method {
+            name: "delete_name",
             receiver_root: PYFRAME_CALL_OWNER_ROOT,
         },
         effect: CallEffectKind::Residual,

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -2184,24 +2184,34 @@ pub fn w_list_size_descr() -> DescrRef {
 
 /// `typeobject.py:162 _version_tag` — the method-cache version (`u64`, 8
 /// bytes, unsigned) on `W_TypeObject`. The `LOAD_METHOD` fast path reads it
-/// LIVE and `guard_value`s it (`promote(self.version_tag())`,
-/// typeobject.py:506) so the `_pure_lookup_where_with_method_cache`
-/// `CALL_PURE_R` folds on a green version. Mutable (not immutable /
-/// quasi-immutable): `mutated()` (typeobject.py:285-286) bumps it on any
-/// type-dict change, and the per-iteration `guard_value` re-checks it.
+/// through `promote(self.version_tag())` (typeobject.py:506) so the
+/// `_pure_lookup_where_with_method_cache` `CALL_PURE_R` folds on a green
+/// version.
 ///
-/// Upstream `_version_tag?` is quasi-immutable, so the JIT folds the read
-/// away and relies on the write barrier to invalidate dependent traces; the
-/// convergence path here is a `QUASIIMMUT_FIELD` once pyre wires that write
-/// barrier into `mutated()`. Until then a live read + `guard_value` is the
-/// sound interim.
-pub fn type_version_tag_descr() -> DescrRef {
-    make_field_descr(
+/// Quasi-immutable, per `typeobject.py:177 _immutable_fields_ =
+/// ['_version_tag?']`: the read is replaced by a `QUASIIMMUT_FIELD` plus one
+/// `GUARD_NOT_INVALIDATED` per trace, and `mutated()` (typeobject.py:285-286)
+/// revokes the dependent loops through
+/// [`pyre_object::typeobject::w_type_set_version_tag`] instead of the trace
+/// re-checking a live value every iteration. A residual call cannot flush a
+/// quasi-immutable field, which is the whole point — the interim live read +
+/// `guard_value` had to be re-done after every un-inlined call in the body.
+///
+/// One object per run, for the identity reason documented on
+/// [`W_CLASS_FIELD_DESCR`], and load-bearing here: `heap.rs:3274` keys
+/// `quasi_immut_cache` on `field_cache_identity`, which is the `Arc` pointer,
+/// so a per-call descriptor would miss its own cache on every read.
+static TYPE_VERSION_TAG_FIELD_DESCR: LazyLock<DescrRef> = LazyLock::new(|| {
+    make_quasi_immutable_field_descr(
         core::mem::offset_of!(pyre_object::typeobject::W_TypeObject, version_tag),
         8,
         Type::Int,
         false,
     )
+});
+
+pub fn type_version_tag_descr() -> DescrRef {
+    TYPE_VERSION_TAG_FIELD_DESCR.clone()
 }
 
 /// `W_ObjectObject` SizeDescr group (`objectobject.rs:34-46`) — the instance

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -942,31 +942,49 @@ static RANGE_DESCR_GROUP: LazyLock<PyreObjectDescrGroup> = LazyLock::new(|| {
     )
 });
 
-/// `Function.defs_w` — PyPy `function.py:47`
-/// `_immutable_fields_ = [..., 'defs_w?[*]', ...]`.
+/// The `Function` fields PyPy declares quasi-immutable — `function.py:34-42`
+/// `_immutable_fields_ = ['code?', 'w_func_globals?', 'closure?[*]',
+/// 'defs_w?[*]', ...]`.
 ///
-/// The `?` makes the field quasi-immutable upstream and `[*]` makes the
-/// selected defaults immutable after the field has been promoted.  Pyre's
-/// `function_set_defaults` does not yet call `do_force_quasi_immutable`, so
-/// marking this descriptor quasi-immutable would leave compiled loops alive
-/// after `f.__defaults__ = ...`.  Keep the field live/mutable for now; the
-/// inline-call path pairs its read with a `GuardValue`, which is the sound
-/// pre-invalidation equivalent.  The tuple's backing array has its own
-/// immutable descriptor and is read with `GetarrayitemGcPureR`.
+/// The `?` makes each field quasi-immutable upstream and `[*]` makes the
+/// selected elements immutable after the field has been promoted.  Pyre's
+/// setters (`function_set_defaults` and friends) do not yet call
+/// `do_force_quasi_immutable`, so marking these descriptors quasi-immutable
+/// would leave compiled loops alive after `f.__defaults__ = ...` /
+/// `f.__code__ = ...`.  Keep the fields live/mutable for now; the inline-call
+/// path pairs every read with a `GuardValue`, which is the sound
+/// pre-invalidation equivalent.  A tuple's backing array has its own immutable
+/// descriptor and is read with `GetarrayitemGcPureR`.
+///
+/// `field_descr_from_group` indexes positionally, so new fields append.
 static FUNCTION_DESCR_GROUP: LazyLock<PyreObjectDescrGroup> = LazyLock::new(|| {
-    build_object_descr_group_with_def_path(
-        pyre_interpreter::function::FUNCTION_OBJECT_SIZE,
-        FUNCTION_GC_TYPE_ID,
-        &pyre_interpreter::FUNCTION_TYPE as *const _ as usize,
-        &[(
-            "defs_w",
-            pyre_interpreter::function::FUNCTION_DEFS_W_OFFSET,
+    let field = |key, offset| {
+        (
+            key,
+            offset,
             std::mem::size_of::<usize>(),
             Type::Ref,
             false,
             false,
             false,
-        )],
+        )
+    };
+    build_object_descr_group_with_def_path(
+        pyre_interpreter::function::FUNCTION_OBJECT_SIZE,
+        FUNCTION_GC_TYPE_ID,
+        &pyre_interpreter::FUNCTION_TYPE as *const _ as usize,
+        &[
+            field("defs_w", pyre_interpreter::function::FUNCTION_DEFS_W_OFFSET),
+            field("code", pyre_interpreter::function::FUNCTION_CODE_OFFSET),
+            field(
+                "w_func_globals",
+                pyre_interpreter::function::FUNCTION_W_FUNC_GLOBALS_OBJ_OFFSET,
+            ),
+            field(
+                "closure",
+                pyre_interpreter::function::FUNCTION_CLOSURE_OFFSET,
+            ),
+        ],
         "Function",
         "function::Function",
     )
@@ -2032,6 +2050,25 @@ pub fn method_w_function_descr() -> DescrRef {
 /// pyre wires the upstream quasi-immutable invalidation hook.
 pub fn function_defs_w_descr() -> DescrRef {
     field_descr_from_group(&FUNCTION_DESCR_GROUP, 0)
+}
+
+/// Live `Function.code` — the field `Function.getcode()` promotes
+/// (`function.py:95 jit.promote(self.code)`).  This is what identifies an
+/// inlined body, so the inline lever guards it instead of the function object.
+pub fn function_code_descr() -> DescrRef {
+    field_descr_from_group(&FUNCTION_DESCR_GROUP, 1)
+}
+
+/// Live `Function.w_func_globals` — the namespace an inlined callee's
+/// LOAD_GLOBAL folds against.
+pub fn function_w_globals_descr() -> DescrRef {
+    field_descr_from_group(&FUNCTION_DESCR_GROUP, 2)
+}
+
+/// Live `Function.closure` — the freevar cell tuple threaded into the inlined
+/// callee's own frame.
+pub fn function_closure_descr() -> DescrRef {
+    field_descr_from_group(&FUNCTION_DESCR_GROUP, 3)
 }
 
 pub fn dict_keys_version_descr() -> DescrRef {

--- a/pyre/pyre-jit-trace/src/helpers.rs
+++ b/pyre/pyre-jit-trace/src/helpers.rs
@@ -1209,9 +1209,12 @@ pub fn emit_box_float_inline(
 /// `_opimpl_inline_call*` / `perform_call`+`setup_call` create a fresh frame
 /// per inlined call (`pyjitpl.py:2445-2476,1862-1874`); the box stays virtual
 /// on the hot path (the optimizer folds `NewWithVtable`+`SetfieldGc`) and is
-/// materialized lazily only on guard failure.  Field-complete so a forced
-/// materialization (`materialize_virtual_from_rd`) never dereferences an unset
-/// field.
+/// materialized lazily only on guard failure.  Carries every field the frame
+/// constructor assigns, so a forced materialization
+/// (`materialize_virtual_from_rd`) never dereferences a field the interpreter
+/// would have written; the class-level defaults listed at the end of the body
+/// stay at the allocation's zero-fill, exactly as they do in a frame the
+/// interpreter builds.
 pub fn emit_new_pyframe_inline_with_params(
     ctx: &mut TraceCtx,
     param_boxes: &[OpRef],
@@ -1327,6 +1330,12 @@ pub fn emit_new_pyframe_inline_with_params(
     // setfield for them; the freshly allocated payload is already zeroed
     // (zero_gc_pointers_inside, incminimark.py:960), so the fields read back
     // as PY_NULL. No explicit store here.
+    //
+    // `w_builtin` joins them: the frame constructor (pyframe.py) assigns
+    // `self.builtin` only under `honor__builtins__`, which
+    // `baseobjspace::HONOR_BUILTINS` leaves off, so the constructor writes
+    // nothing and every reader goes through `get_builtin`, which answers
+    // `space.builtin` for an unset slot.
 
     new_frame
 }
@@ -1437,6 +1446,12 @@ pub fn emit_new_pyframe_inline_self_recursive(
     // setfield for them; the freshly allocated payload is already zeroed
     // (zero_gc_pointers_inside, incminimark.py:960), so the fields read back
     // as PY_NULL. No explicit store here.
+    //
+    // `w_builtin` joins them: the frame constructor (pyframe.py) assigns
+    // `self.builtin` only under `honor__builtins__`, which
+    // `baseobjspace::HONOR_BUILTINS` leaves off, so the constructor writes
+    // nothing and every reader goes through `get_builtin`, which answers
+    // `space.builtin` for an unset slot.
 
     new_frame
 }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
@@ -1114,6 +1114,12 @@ thread_local! {
     /// Callee code keys whose deferred body reached a CALL residual the lever
     /// could not inline.  The gate declines them up front from then on, so the
     /// backstop abort costs one attempt per callee instead of storming.
+    ///
+    /// Per-thread for the reason [`FBW_HAZARDOUS_INLINE_DENY`] spells out, and
+    /// it is only a memo: what actually keeps a deferred body honest is the
+    /// live abort in [`fbw_abort_nested_unjournaled_residual`], armed by
+    /// [`FBW_FORITER_DEFERRED_INLINE`] above.  A thread that has not yet
+    /// recorded a denial pays one extra abort per callee, never a wrong answer.
     static FBW_FORITER_DEFERRED_DENY: std::cell::RefCell<std::collections::HashSet<usize>> =
         std::cell::RefCell::new(std::collections::HashSet::new());
     /// Code keys of the callees [`fbw_inline_callee_hazardous`] named when the

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -413,6 +413,13 @@ pub(crate) fn callee_body_contains_raise(body_code: &[u8]) -> bool {
     false
 }
 
+/// Whether a method-form callee body is free of `LoadAttr` residuals.
+///
+/// Consulted only by the entries that pass `allow_method_load_attr = false`.
+/// A `self.attr` read in the body is what makes it answer `false`, which is the
+/// common shape (`def at(self, i): return self.v + i`), so an entry that opts
+/// out of the check trades a narrower inline surface for the ability to inline
+/// ordinary accessor methods.
 pub(crate) fn method_form_callee_body_supported(
     body_code: &[u8],
     callee_descr_refs: &[DescrRef],
@@ -1742,7 +1749,7 @@ pub(crate) fn try_walker_inline_user_call<Sym: WalkSym>(
         has_closure,
         None,
         None,
-        false,
+        true,
         false,
         None,
     )
@@ -2717,6 +2724,12 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
     if !bridge_rec_root_selfrec && fbw_hazardous_inline_denied(callee_code_key) {
         return Ok(None);
     }
+    // True when only the widened method-form surface reaches this callee: an
+    // unbound `self.attr` accessor body, which the narrow surface declines.
+    let widened_method_form = method_form
+        && bound_method.is_none()
+        && allow_method_load_attr
+        && !method_form_callee_body_supported(body.code, callee_descr_refs);
     // A legacy, unseeded inline sub-walk inside a FOR_ITER body resumes a guard
     // at the caller's CALL boundary, so deopt re-executes the whole callee.
     // Replaying a live-heap mutation would double it, so a Dirty body stays on
@@ -2753,8 +2766,16 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
                 // iteration's contribution is dropped, silently.  A `Clean`
                 // body is still admitted from there — it has nothing that can
                 // abort.
-                foriter_deferred_admit =
-                    arg_class_guard.is_none() && !fbw_foriter_deferred_call_denied(callee_code_key);
+                //
+                // The widened method-form surface stays out: its deferred call
+                // is the `self.attr` read's own dispatch, which the lever
+                // resolves to a builtin rather than a body it can inline, so the
+                // admission spends the abort and then denies the callee anyway.
+                // Declining here reaches the same residual call without retiring
+                // the enclosing loop.
+                foriter_deferred_admit = arg_class_guard.is_none()
+                    && !widened_method_form
+                    && !fbw_foriter_deferred_call_denied(callee_code_key);
                 foriter_deferred_admit
             }
             CalleeReplaySafety::Dirty => {
@@ -2786,12 +2807,30 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
             return Ok(None);
         }
     }
-    if method_form
-        && bound_method.is_none()
-        && !allow_method_load_attr
-        && !method_form_callee_body_supported(body.code, callee_descr_refs)
-    {
-        return Ok(None);
+    if method_form && bound_method.is_none() {
+        // Two surfaces for an unbound method-form callee.  The narrow one
+        // declines any `self.attr` read in the body.  The wide one admits it,
+        // and pays for the reach with a body that raises: the sub-walk records
+        // into the handler region, and a guard whose resume coordinate lands on
+        // the `Reraise` needs ref registers the recorded path never wrote
+        // (`collect_callee_active_boxes`).  That decline arrives mid-recording
+        // on a non-effect-free opcode, so it has no mid-body carrier and the
+        // whole enclosing loop is discarded.  Decline such a body here instead,
+        // where the call simply stays residual and the loop still compiles.
+        let declined = if allow_method_load_attr {
+            callee_body_contains_raise(body.code)
+        } else {
+            !method_form_callee_body_supported(body.code, callee_descr_refs)
+        };
+        if declined {
+            if std::env::var_os("PYRE_FBW_INLINE_DIAG").is_some() {
+                eprintln!(
+                    "[inline-method-form] decline pc={} allow_load_attr={allow_method_load_attr}",
+                    op.pc
+                );
+            }
+            return Ok(None);
+        }
     }
     if std::env::var("PYRE_FBW_INLINE_DIAG").is_ok() {
         let mut pc = 0usize;

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -4420,21 +4420,7 @@ pub(crate) fn try_walker_inline_type_call<Sym: WalkSym>(
     ctx.trace_ctx
         .heap_cache_mut()
         .replace_box(r_args[0], type_const);
-    let live_version = crate::state::opimpl_getfield_gc_i(
-        ctx.trace_ctx,
-        type_const,
-        crate::descr::type_version_tag_descr(),
-    );
-    let version_const = ctx.trace_ctx.const_int(version_tag as i64);
-    walker_emit_fold_guard_with_snapshot(
-        ctx,
-        op.pc,
-        OpCode::GuardValue,
-        &[live_version, version_const],
-    )?;
-    ctx.trace_ctx
-        .heap_cache_mut()
-        .replace_box(live_version, version_const);
+    walker_pin_type_version_tag(ctx, op.pc, type_const)?;
 
     // The walker is the executor here, so the instance the rest of this walk
     // reads has to be a real one — the same split `trace_box_int` makes between

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -2382,6 +2382,34 @@ fn inline_chain_unrolls_recursion<Sym: WalkSym>(ctx: &WalkContext<'_, '_, Sym>) 
     })
 }
 
+/// Read one of the callee function's `_immutable_fields_` slots live and pin
+/// the value this inline baked, replacing the box so later reads fold.
+///
+/// `function.py:34-42` declares `code?` / `w_func_globals?` / `closure?[*]` /
+/// `defs_w?[*]`; pyre's setters do not yet force the quasi-immutable
+/// invalidation, so a `GuardValue` stands in for it.
+fn walker_guard_function_field<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    op_pc: usize,
+    callable: OpRef,
+    descr: majit_ir::DescrRef,
+    expected: i64,
+) -> Result<(), DispatchError> {
+    let field_op = crate::state::opimpl_getfield_gc_r(ctx.trace_ctx, callable, descr);
+    ctx.trace_ctx.try_set_opref_concrete(
+        field_op,
+        majit_ir::Value::Ref(majit_ir::GcRef(expected as usize)),
+    );
+    let expected_op = ctx.trace_ctx.const_ref(expected);
+    ctx.trace_ctx
+        .record_guard(OpCode::GuardValue, &[field_op, expected_op], 0);
+    walker_capture_snapshot_for_last_guard(ctx, op_pc)?;
+    ctx.trace_ctx
+        .heap_cache_mut()
+        .replace_box(field_op, expected_op);
+    Ok(())
+}
+
 /// Shared post-resolution half of the FBW inline lever. Ordinary Python calls
 /// resolve their callee from the CALL operand; builtin-dispatch specializers
 /// resolve an app-level descriptor first and enter here with that function as
@@ -3041,22 +3069,127 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
         }
     }
 
-    let callable_expected = ctx
-        .trace_ctx
-        .const_ref(callable_guard_value as usize as i64);
-    if !callable_guard_op.is_constant() {
-        ctx.trace_ctx.record_guard(
-            OpCode::GuardValue,
-            &[callable_guard_op, callable_expected],
-            0,
-        );
-        walker_capture_snapshot_for_last_guard(ctx, op.pc)?;
+    // Not every caller pins the callee function itself.  A specializer that
+    // resolves an app-level method behind a builtin — `str(e)` reaching an
+    // exception subclass's `__str__` — passes the CALL's own operand, which is
+    // the `str` builtin, while `callable` is the resolved `Function`.  Reading
+    // `Function.code` off that operand is a type-confused load: it returns
+    // whatever sits at the same offset in a `PyCFunction`, so the guard
+    // compares a value that is not `code` and fails every iteration (99480
+    // failures and 497 bridges on `synth/exception_subclass_attrs`, a 31x
+    // slowdown).  Guard the fields only when the pinned object really is the
+    // function whose code this inline resolved.
+    //
+    // A trace-constant callable is excluded for a second reason: the field
+    // reads would dereference a baked `ConstPtr`, and a baked constant object
+    // pointer is not GC-forwarded yet (gh #108 gc-table — see the note in
+    // `synth/exception_subclass_attrs.py`).  Comparing against such a constant
+    // is fine, but loading through one dangles as soon as a minor collection
+    // moves the object: `synth/inline_subwalk_property_mutates` — a property
+    // getter that allocates on every iteration — segfaults on cranelift under
+    // CI's macOS runner with the reads in place.  The callable being constant
+    // means something already pinned the object, so this only gives up the
+    // `f.__code__ = g.__code__` re-check on that path.
+    let guards_the_callee_function = !callable_guard_op.is_constant()
+        && unsafe {
+            (*callable_guard_value).ob_type as *const () as usize
+                == &pyre_interpreter::FUNCTION_TYPE as *const _ as usize
+                && pyre_interpreter::function_get_code(callable_guard_value) as usize
+                    == callee_code_key
+        };
+
+    if !guards_the_callee_function {
+        // Those sites resolve the callee through their own guarded path (a
+        // type version tag, a receiver class guard); all this has to pin is
+        // the operand they dispatched on.
+        if !callable_guard_op.is_constant() {
+            let expected = ctx
+                .trace_ctx
+                .const_ref(callable_guard_value as usize as i64);
+            ctx.trace_ctx
+                .record_guard(OpCode::GuardValue, &[callable_guard_op, expected], 0);
+            walker_capture_snapshot_for_last_guard(ctx, op.pc)?;
+        }
+    } else {
+        // `function.py:91-96 getcode()` promotes `self.code`, never `self`.
+        // The three constants this inline bakes — the code object below, the
+        // globals namespace in `InlineCalleeConsts`, and the freevar cells
+        // baked into the callee frame — are exactly the `?`-fields
+        // `_immutable_fields_ = ['code?', 'w_func_globals?', 'closure?[*]',
+        // 'defs_w?[*]']` names, so guard each of them off the live function.
+        // `defs_w` has its own guard below.
+        //
+        // Reading them live is what `f.__code__ = g.__code__` needs: pinning
+        // the object pins none of its fields.  Upstream is safe there because
+        // `code?` is quasi-immutable and assigning it invalidates the traces
+        // that folded it; pyre has no such hook yet, so the value guard stands
+        // in for the invalidation.
+        //
+        // Guarding the function OBJECT instead pinned its identity, which a
+        // callee built by a `MAKE_FUNCTION` in the caller's own loop body can
+        // never match twice: every iteration allocates a fresh function, so
+        // the guard failed forever while the code object it stands for is
+        // loop-invariant.
+        walker_guard_function_field(
+            ctx,
+            op.pc,
+            callable_guard_op,
+            crate::descr::function_code_descr(),
+            callee_code_key as i64,
+        )?;
+        walker_guard_function_field(
+            ctx,
+            op.pc,
+            callable_guard_op,
+            crate::descr::function_w_globals_descr(),
+            inline_consts.w_globals as i64,
+        )?;
+        if !concrete_freevar_cells.is_empty() {
+            // `closure?[*]`: the tuple itself is rebuilt by every
+            // `MAKE_FUNCTION`, so guarding its identity would reintroduce the
+            // per-iteration failure.  The cells are what this inline bakes and
+            // what the enclosing frame keeps stable, so read the tuple live and
+            // guard each element instead.  The element count needs no guard of
+            // its own: `code` above pins `co_freevars`, and a closure always
+            // has exactly that many cells.
+            let closure_op = crate::state::opimpl_getfield_gc_r(
+                ctx.trace_ctx,
+                callable_guard_op,
+                crate::descr::function_closure_descr(),
+            );
+            ctx.trace_ctx.try_set_opref_concrete(
+                closure_op,
+                majit_ir::Value::Ref(majit_ir::GcRef(concrete_closure as usize)),
+            );
+            let items_op = crate::state::opimpl_getfield_gc_r(
+                ctx.trace_ctx,
+                closure_op,
+                crate::descr::tuple_wrappeditems_descr(),
+            );
+            for (i, &cell) in concrete_freevar_cells.iter().enumerate() {
+                let index_op = ctx.trace_ctx.const_int(i as i64);
+                let cell_op = crate::state::trace_items_block_getitem_value_pure(
+                    ctx.trace_ctx,
+                    items_op,
+                    index_op,
+                );
+                ctx.trace_ctx.try_set_opref_concrete(
+                    cell_op,
+                    majit_ir::Value::Ref(majit_ir::GcRef(cell as usize)),
+                );
+                let cell_const = ctx.trace_ctx.const_ref(cell as i64);
+                ctx.trace_ctx
+                    .record_guard(OpCode::GuardValue, &[cell_op, cell_const], 0);
+                walker_capture_snapshot_for_last_guard(ctx, op.pc)?;
+                ctx.trace_ctx
+                    .heap_cache_mut()
+                    .replace_box(cell_op, cell_const);
+            }
+        }
     }
 
     if let Some(defaults) = positional_defaults {
-        // `defs_w?`: read the live field on every compiled iteration, then
-        // guard the tuple identity used while tracing.  Reassigning
-        // `f.__defaults__` therefore deopts at the caller's CALL boundary.
+        // `defs_w?`: read the live field on every compiled iteration.
         let defaults_op = ctx.trace_ctx.record_op_with_descr(
             OpCode::GetfieldGcR,
             &[callable_guard_op],
@@ -3066,19 +3199,33 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
             defaults_op,
             majit_ir::Value::Ref(majit_ir::GcRef(defaults.tuple as usize)),
         );
-        let defaults_expected = ctx.trace_ctx.const_ref(defaults.tuple as i64);
+
+        // `defs_w?[*]`: the elements are read live below, so all trace time
+        // decided is WHICH element fills which missing parameter, and
+        // `positional_defaults_for_inline` derives that from `len(defs_w)`
+        // alone — the length is the only thing that has to be re-checked.
+        //
+        // Guard the tuple's identity all the same.  `GuardValue` over an
+        // `arraylen_gc` leaves the guard's only argument dead after it, and a
+        // bridge compiled at that fail index segfaults on entry: reassign
+        // `f.__defaults__` to a different length mid-loop and it is correct up
+        // to ~1000 post-flip iterations and dies past ~2000, with and without
+        // `MAJIT_NO_BRIDGE`.  Identity is stricter than needed but sound, and
+        // it only costs the shape that builds the callee in the caller's own
+        // loop AND omits an argument it has a default for.
+        let tuple_expected = ctx.trace_ctx.const_ref(defaults.tuple as i64);
         ctx.trace_ctx
-            .record_guard(OpCode::GuardValue, &[defaults_op, defaults_expected], 0);
+            .record_guard(OpCode::GuardValue, &[defaults_op, tuple_expected], 0);
         walker_capture_snapshot_for_last_guard(ctx, op.pc)?;
 
-        // `defs_w?[*]`: once the field guard pins the tuple, its
-        // `wrappeditems` pointer and contents are immutable.  Preserve the
-        // actual Ref boxes instead of baking one anchor's concrete value.
         let items = crate::state::opimpl_getfield_gc_r(
             ctx.trace_ctx,
             defaults_op,
             crate::descr::tuple_wrappeditems_descr(),
         );
+
+        // Preserve the actual Ref boxes instead of baking one anchor's
+        // concrete value.
         for (param_index, tuple_index, _) in defaults.values {
             let index = ctx.trace_ctx.const_int(tuple_index as i64);
             callee_args[param_index] =

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -7149,25 +7149,11 @@ fn walker_guard_mapdict_instance_shape<Sym: WalkSym>(
     }
 
     // The instance map pins the storage layout, but class mutation can change
-    // lookup precedence without changing that map. Re-read the receiver type's
-    // live version tag at every trace entry and deopt before the folded storage
-    // access when it changes.
+    // lookup precedence without changing that map. Pin the receiver type's
+    // version tag so such a mutation revokes the loop before the folded
+    // storage access is reused.
     let w_type_const = ctx.trace_ctx.const_ref(w_type as i64);
-    let version_op = crate::state::opimpl_getfield_gc_i(
-        ctx.trace_ctx,
-        w_type_const,
-        crate::descr::type_version_tag_descr(),
-    );
-    let version_const = ctx.trace_ctx.const_int(version_tag as i64);
-    walker_emit_fold_guard_with_snapshot(
-        ctx,
-        op_pc,
-        OpCode::GuardValue,
-        &[version_op, version_const],
-    )?;
-    ctx.trace_ctx
-        .heap_cache_mut()
-        .replace_box(version_op, version_const);
+    walker_pin_type_version_tag(ctx, op_pc, w_type_const)?;
 
     // guard_value(getfield_gc_i(obj, map), C_map): `jit.promote(self.map)`
     // (`mapdict.py`).  The map nodes are interned + immortal, so the
@@ -7235,21 +7221,7 @@ fn walker_guard_exception_attr_slot<Sym: WalkSym>(
         .replace_box(live_w_class, w_class_const);
 
     let type_const = ctx.trace_ctx.const_ref(w_type as i64);
-    let live_version = crate::state::opimpl_getfield_gc_i(
-        ctx.trace_ctx,
-        type_const,
-        crate::descr::type_version_tag_descr(),
-    );
-    let version_const = ctx.trace_ctx.const_int(version_tag as i64);
-    walker_emit_fold_guard_with_snapshot(
-        ctx,
-        op_pc,
-        OpCode::GuardValue,
-        &[live_version, version_const],
-    )?;
-    ctx.trace_ctx
-        .heap_cache_mut()
-        .replace_box(live_version, version_const);
+    walker_pin_type_version_tag(ctx, op_pc, type_const)?;
     Ok(())
 }
 
@@ -7276,6 +7248,34 @@ fn walker_record_getfield_gc_i_uncached<Sym: WalkSym>(
     // purity from the descr. There is no pure getfield opnum.
     ctx.trace_ctx
         .record_op_with_descr(OpCode::GetfieldGcI, &[obj], descr)
+}
+
+/// Pin a type's method-cache version without reading it, per
+/// `typeobject.py:177 _immutable_fields_ = ['_version_tag?']`.
+///
+/// `promote(self.version_tag())` (typeobject.py:506) needs the tag green so the
+/// `_pure_lookup_where_with_method_cache` fold can run. On a quasi-immutable
+/// field that costs a `QUASIIMMUT_FIELD` marker plus one
+/// `GUARD_NOT_INVALIDATED` per trace, not a load and a `GUARD_VALUE` per read:
+/// `mutated()` revokes the loop instead of the trace re-proving the tag. The
+/// difference is load-bearing inside a body with un-inlined calls, since a
+/// residual `CALL_MAY_FORCE` flushes a mutable field's cache but cannot flush a
+/// quasi-immutable one.
+///
+/// `w_type_const` must already be pinned to the receiver's type — the caller
+/// guards `w_class` first, so the marker attaches to a constant the optimizer
+/// can hand to `register_quasi_immutable_deps` as the watched object.
+fn walker_pin_type_version_tag<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    op_pc: usize,
+    w_type_const: OpRef,
+) -> Result<(), DispatchError> {
+    crate::state::record_quasiimmut_field(
+        ctx.trace_ctx,
+        w_type_const,
+        crate::descr::type_version_tag_descr(),
+    );
+    walker_flush_guard_not_invalidated(ctx, op_pc)
 }
 
 fn walker_record_getfield_gc_r_uncached<Sym: WalkSym>(

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -1563,6 +1563,12 @@ pub(crate) fn walker_abort_if_mayforce_null_ref_arg<Sym: WalkSym>(
     // (arg 1) is a checked `PY_NULL` sentinel (prepended as arg0 only when
     // non-null), so a concrete-NULL there is the normal plain-call shape.
     let is_call_kw = call_descr.get_extra_info().pyre_helper == majit_ir::PyreHelperKind::CallKw;
+    // `bh_store_deref_value_fn(cell, value)` — `value` (arg 1) is a checked
+    // `PY_NULL` sentinel handed to `w_cell_set` unread; DELETE_DEREF lowers to
+    // exactly that shape.  Kept in step with the same exemption in
+    // `try_execute_residual_call_via_executor`.
+    let is_store_deref =
+        call_descr.get_extra_info().pyre_helper == majit_ir::PyreHelperKind::StoreDeref;
     for (i, &ty) in call_descr.arg_types().iter().enumerate() {
         if ty != majit_ir::Type::Ref {
             continue;
@@ -1577,6 +1583,9 @@ pub(crate) fn walker_abort_if_mayforce_null_ref_arg<Sym: WalkSym>(
             continue;
         }
         if is_raise_varargs && i + 1 == call_descr.arg_types().len() {
+            continue;
+        }
+        if is_store_deref && i == 1 {
             continue;
         }
         if let Some(&b) = allboxes.get(1 + i) {
@@ -1957,6 +1966,17 @@ pub(crate) fn try_execute_residual_call_via_executor<Sym: WalkSym>(
     // `walker_abort_if_mayforce_null_ref_arg`.
     let is_raise_varargs =
         call_descr.get_extra_info().pyre_helper == majit_ir::PyreHelperKind::RaiseVarargs;
+    // `bh_store_deref_value_fn(cell, value)` — `value` (arg index 1) is a
+    // checked `PY_NULL` sentinel: DELETE_DEREF lowers to
+    // `store_deref_value(cell, none)` after its own bound check
+    // (`codewriter.rs` `Instruction::DeleteDeref`), and the helper hands the
+    // NULL straight to `w_cell_set` without ever dereferencing it.  Declining
+    // it left the clear-the-cell half of every `del <cellvar>` and every
+    // `except E as e` handler cleanup recorded but UNEXECUTED, which marks the
+    // walk unjournaled — so the walk-end flush declines and the caller replays
+    // the region on top of the residuals the walk already ran concretely.
+    let is_store_deref =
+        call_descr.get_extra_info().pyre_helper == majit_ir::PyreHelperKind::StoreDeref;
     for (i, &arg) in args.iter().enumerate() {
         if is_call_fn && i == 1 {
             continue;
@@ -1968,6 +1988,9 @@ pub(crate) fn try_execute_residual_call_via_executor<Sym: WalkSym>(
             continue;
         }
         if is_raise_varargs && i + 1 == args.len() {
+            continue;
+        }
+        if is_store_deref && i == 1 {
             continue;
         }
         if matches!(call_descr.arg_types().get(i), Some(majit_ir::Type::Ref)) && arg == 0 {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -2559,14 +2559,7 @@ pub(crate) fn try_walker_specialize_load_method_attr<Sym: WalkSym>(
 
     // typeobject.py `promote(self.version_tag())`: class mutation or method
     // reassignment bumps `_version_tag`, so the old `w_descr` side-exits.
-    let vt_op = walker_record_getfield_gc_i_uncached(
-        ctx,
-        w_type_const,
-        crate::descr::type_version_tag_descr(),
-    );
-    let vt_const = ctx.trace_ctx.const_int(version_tag as i64);
-    walker_emit_fold_guard_with_snapshot(ctx, op_pc, OpCode::GuardValue, &[vt_op, vt_const])?;
-    ctx.trace_ctx.heap_cache_mut().replace_box(vt_op, vt_const);
+    walker_pin_type_version_tag(ctx, op_pc, w_type_const)?;
 
     // Re-prove the shadowing precondition: growing an instance attribute named
     // like the method must side-exit before the constant descriptor is reused.
@@ -2658,14 +2651,7 @@ pub(crate) fn try_walker_specialize_load_classmethod_attr<Sym: WalkSym>(
     // typeobject.py `promote(self.version_tag())`: class mutation or classmethod
     // reassignment in the class or any base bumps `_version_tag`, so the pinned
     // `__func__` side-exits.
-    let vt_op = walker_record_getfield_gc_i_uncached(
-        ctx,
-        w_type_const,
-        crate::descr::type_version_tag_descr(),
-    );
-    let vt_const = ctx.trace_ctx.const_int(version_tag as i64);
-    walker_emit_fold_guard_with_snapshot(ctx, op_pc, OpCode::GuardValue, &[vt_op, vt_const])?;
-    ctx.trace_ctx.heap_cache_mut().replace_box(vt_op, vt_const);
+    walker_pin_type_version_tag(ctx, op_pc, w_type_const)?;
 
     let func_const = ctx.trace_ctx.const_ref(w_func as i64);
     write_residual_call_result_to_dst(ctx, op_pc, dst, dst_bank, func_const)?;
@@ -2756,14 +2742,7 @@ pub(crate) fn try_walker_specialize_load_bound_method_attr<Sym: WalkSym>(
 
     // typeobject.py `promote(self.version_tag())`: reassigning the method on
     // the type bumps the tag, so the constant `w_descr` side-exits.
-    let vt_op = walker_record_getfield_gc_i_uncached(
-        ctx,
-        w_type_const,
-        crate::descr::type_version_tag_descr(),
-    );
-    let vt_const = ctx.trace_ctx.const_int(version_tag as i64);
-    walker_emit_fold_guard_with_snapshot(ctx, op_pc, OpCode::GuardValue, &[vt_op, vt_const])?;
-    ctx.trace_ctx.heap_cache_mut().replace_box(vt_op, vt_const);
+    walker_pin_type_version_tag(ctx, op_pc, w_type_const)?;
 
     // `w_method_new(w_descr, obj, w_type)` + the header stamp its allocation
     // performs (`ob_type` comes from the NewWithVtable's size descr).
@@ -6994,27 +6973,13 @@ pub(crate) fn try_walker_trace_exception_new<Sym: WalkSym>(
             .heap_cache_mut()
             .replace_box(callable_op, expected);
     }
-    if let Some(version_tag) = subclass_version_tag {
-        // Guard the promoted class version that made both MRO descriptor
+    if subclass_version_tag.is_some() {
+        // Pin the promoted class version that made both MRO descriptor
         // identities constant.  `W_TypeObject.mutated` recursively changes
         // subclass tags (`typeobject.py`), so mutating this class or a
-        // base side-exits before reusing the folded constructor.
+        // base revokes the loop before the folded constructor is reused.
         let class_const = ctx.trace_ctx.const_ref(concrete_callable as i64);
-        let live_version = crate::state::opimpl_getfield_gc_i(
-            ctx.trace_ctx,
-            class_const,
-            crate::descr::type_version_tag_descr(),
-        );
-        let version_const = ctx.trace_ctx.const_int(version_tag as i64);
-        walker_emit_fold_guard_with_snapshot(
-            ctx,
-            op.pc,
-            OpCode::GuardValue,
-            &[live_version, version_const],
-        )?;
-        ctx.trace_ctx
-            .heap_cache_mut()
-            .replace_box(live_version, version_const);
+        walker_pin_type_version_tag(ctx, op.pc, class_const)?;
     }
 
     if fills_os_error_slots && exact_os_error {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -1975,8 +1975,10 @@ fn walker_specialize_traceback_walk_field<Sym: WalkSym>(
             unsafe { pyre_interpreter::pytraceback::w_pytraceback_get_lineno_raw(concrete_obj) };
         // `get_lineno` answers the sentinel with `-1`, so the slot value is the
         // getter's value only once it is pinned against the sentinel.  A node
-        // that already carries it — built from a frame with no `pycode` — has
-        // nothing to pin, so decline before recording anything.
+        // that already carries it — built from a frame with no `pycode`, or
+        // handed the sentinel through `TracebackType(..., -sys.maxsize-1)` or
+        // the `tb_lineno` setter — has nothing to pin, so decline before
+        // recording anything.
         if live == pyre_interpreter::pytraceback::LINENO_NOT_COMPUTED {
             return Ok(None);
         }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -7549,14 +7549,17 @@ pub(crate) fn try_walker_trace_immutable_type_attr_raise<Sym: WalkSym>(
     let Some(concrete_obj) = walker_concrete_ref_object(ctx, obj_op) else {
         return Ok(None);
     };
-    // STORE_ATTR needs the live value operand to run the authentic
-    // concrete `setattr_str` below (the value plays no role in the raise
-    // decision — the terminal raises before consulting it).
+    // STORE_ATTR runs the authentic concrete `setattr_str` below only for
+    // its raising exception.  The value plays no role in that raise — the
+    // stability predicate proves no data descriptor for `name`, so the
+    // terminal raises before consulting the value — so a non-constant store
+    // value (the common `int.x = i` loop case) still folds: a `None`
+    // concrete value substitutes a placeholder for the authentic run, and
+    // the value operand never enters the emitted trace.
     let concrete_value = match store_value {
-        Some(value_op) => match walker_concrete_ref_object(ctx, value_op) {
-            Some(v) => Some(v),
-            None => return Ok(None),
-        },
+        Some(value_op) => {
+            Some(walker_concrete_ref_object(ctx, value_op).unwrap_or_else(pyre_object::w_none))
+        }
         None => None,
     };
     let name = unsafe {
@@ -7578,6 +7581,24 @@ pub(crate) fn try_walker_trace_immutable_type_attr_raise<Sym: WalkSym>(
         return Ok(None);
     }
 
+    // The raise decision also reads the metaclass-MRO descriptor state — the
+    // branch-F `lookup_in_type_where(type, name)` walk and the forwarding
+    // `type.__setattr__` / `type.__delattr__` — which the receiver
+    // `GuardValue` below does not cover.  A `version_tag` guard on the
+    // metaclass pins that state (the guard the sibling method/attr folds
+    // carry, `typeobject.py promote(self.version_tag())`): mutating `type`'s
+    // dict bumps its tag directly, and mutating `object`'s dict bumps it too
+    // because `mutated()` propagates down to the `type` subclass — so one
+    // guard covers the whole `(type, object)` MRO the walk reads.  Branch C
+    // proved the metaclass is the canonical `type`.  A tagless metaclass
+    // (`version_tag == 0`) is uncacheable, so decline before emitting guards.
+    let metaclass = pyre_object::get_instantiate(&pyre_object::pyobject::TYPE_TYPE);
+    let metaclass_version_tag =
+        unsafe { pyre_object::typeobject::w_type_get_version_tag(metaclass) };
+    if metaclass_version_tag == 0 {
+        return Ok(None);
+    }
+
     // --- commit: pin the receiver, run the authentic raise, emit inline ---
     // The stability predicate makes the raise a pure function of `(obj,
     // name)`; `GuardValue` pins the one live input (`name` is a co_names
@@ -7589,6 +7610,19 @@ pub(crate) fn try_walker_trace_immutable_type_attr_raise<Sym: WalkSym>(
         walker_capture_snapshot_for_last_guard(ctx, op.pc)?;
         ctx.trace_ctx.heap_cache_mut().replace_box(obj_op, expected);
     }
+    // Pin the metaclass `version_tag` (see above): a `GETFIELD_GC_I` +
+    // `GuardValue` that side-exits on any `type`/`object` dict mutation.
+    let metaclass_const = ctx.trace_ctx.const_ref(metaclass as i64);
+    let vt_op = walker_record_getfield_gc_i_uncached(
+        ctx,
+        metaclass_const,
+        crate::descr::type_version_tag_descr(),
+    );
+    let vt_const = ctx.trace_ctx.const_int(metaclass_version_tag as i64);
+    ctx.trace_ctx
+        .record_guard(OpCode::GuardValue, &[vt_op, vt_const], 0);
+    walker_capture_snapshot_for_last_guard(ctx, op.pc)?;
+    ctx.trace_ctx.heap_cache_mut().replace_box(vt_op, vt_const);
 
     // The authoritative walk's concrete execution — the same call the
     // residual executor would have made, raising before any heap

--- a/pyre/pyre-jit-trace/src/runtime_fnaddr_patch.rs
+++ b/pyre/pyre-jit-trace/src/runtime_fnaddr_patch.rs
@@ -76,35 +76,42 @@ pub fn patch_constants_i_fnaddrs(jitcodes: &mut Vec<Arc<JitCode>>) {
     // patched; identical entries are dropped so the constants_i scan
     // can early-exit on a `HashMap::get` miss without comparing.
     //
-    // The key is an address from the build process and the value an address
-    // from this one, so nothing guarantees a build address names one function
-    // here.  If it named two with distinct runtime addresses, the last write
-    // would win and one callee's `constants_i` constant would be patched to
-    // the other's address: a residual call to the wrong target, with no
-    // decline and no panic to mark it.  Registering several path spellings
-    // for one function is deliberate (`jit_fnaddr.rs` lists both
-    // `pyre_object::listobject::jit_list_reverse` and
-    // `pyre_object::jit_list_reverse`), and those agree on the runtime
-    // address, so only a disagreement is a defect.  Every binding is checked,
-    // not just those that survive the `!=` filter below — an alias pair
-    // straddling that filter would leave the same hole.
+    // The key is an address from the build process and the value one from
+    // this one, so a build address can stand for two registered paths.  Both
+    // ways that happens are benign, and last write wins in each:
+    //
+    //   * Several spellings of one function are registered on purpose
+    //     (`jit_fnaddr.rs` lists both
+    //     `pyre_object::listobject::jit_list_reverse` and
+    //     `pyre_object::jit_list_reverse`); they resolve to the same runtime
+    //     address, so the repeated insert is idempotent.
+    //   * The build binary's identical-COMDAT folding (MSVC `/OPT:ICF`, or
+    //     LLVM `MergeFunctions`) merges two byte-identical bodies onto one
+    //     address.  With `#[inline(never)]` confined to the release-GIL
+    //     surface the tracing-policy helpers inline their callees, and several
+    //     distinct registered residuals then compile to the same code:
+    //     `label_arg_to_usize` / `load_fast_var_num_to_index` are both
+    //     `arg.get(op_arg).as_usize()`, `convert_value_arg` /
+    //     `special_method_arg` are both `arg.get(op_arg)`, and
+    //     `hash_str_hooked_bytes` decomposes its slice to the `(ptr, len)`
+    //     `hash_str_hooked` already takes.  The build binary folds each pair;
+    //     the runtime binary, built at a different optimization level, need
+    //     not, so the two runtime addresses differ.  Folding merges only
+    //     identical machine code, so a residual call patched to either twin
+    //     runs the same body.
+    //
+    // A genuinely wrong runtime target could only come from a path bound to
+    // the wrong `fn`, and that binding runs identically in both processes, so
+    // the build and runtime addresses would agree rather than collide.  The
+    // `jit_fnaddr` registry test guards against new same-address pairs but
+    // observes only this process, where nothing folds, so it cannot see a
+    // build-script fold.  There is therefore no collision this map must
+    // reject; picking any of the folded twins' runtime addresses is correct.
     let mut correspondence: HashMap<i64, i64> = HashMap::new();
-    let mut claimed: HashMap<i64, (&str, i64)> = HashMap::new();
     for (path, build_fnaddr) in &build_bindings {
         let Some(&runtime_fnaddr) = runtime_map.get(path.as_str()) else {
             continue;
         };
-        match claimed.get(build_fnaddr) {
-            Some(&(other_path, other_runtime)) => assert_eq!(
-                other_runtime, runtime_fnaddr,
-                "runtime fnaddr patch: build address {build_fnaddr:#x} stands for both \
-                 `{other_path}` ({other_runtime:#x}) and `{path}` ({runtime_fnaddr:#x}); \
-                 patching would send one callee's residual call to the other",
-            ),
-            None => {
-                claimed.insert(*build_fnaddr, (path.as_str(), runtime_fnaddr));
-            }
-        }
         if *build_fnaddr != runtime_fnaddr {
             correspondence.insert(*build_fnaddr, runtime_fnaddr);
         }

--- a/pyre/pyre-jit-trace/src/runtime_fnaddr_patch.rs
+++ b/pyre/pyre-jit-trace/src/runtime_fnaddr_patch.rs
@@ -75,12 +75,38 @@ pub fn patch_constants_i_fnaddrs(jitcodes: &mut Vec<Arc<JitCode>>) {
     // whose runtime lookup actually disagrees with the build value get
     // patched; identical entries are dropped so the constants_i scan
     // can early-exit on a `HashMap::get` miss without comparing.
+    //
+    // The key is an address from the build process and the value an address
+    // from this one, so nothing guarantees a build address names one function
+    // here.  If it named two with distinct runtime addresses, the last write
+    // would win and one callee's `constants_i` constant would be patched to
+    // the other's address: a residual call to the wrong target, with no
+    // decline and no panic to mark it.  Registering several path spellings
+    // for one function is deliberate (`jit_fnaddr.rs` lists both
+    // `pyre_object::listobject::jit_list_reverse` and
+    // `pyre_object::jit_list_reverse`), and those agree on the runtime
+    // address, so only a disagreement is a defect.  Every binding is checked,
+    // not just those that survive the `!=` filter below — an alias pair
+    // straddling that filter would leave the same hole.
     let mut correspondence: HashMap<i64, i64> = HashMap::new();
+    let mut claimed: HashMap<i64, (&str, i64)> = HashMap::new();
     for (path, build_fnaddr) in &build_bindings {
-        if let Some(&runtime_fnaddr) = runtime_map.get(path.as_str()) {
-            if *build_fnaddr != runtime_fnaddr {
-                correspondence.insert(*build_fnaddr, runtime_fnaddr);
+        let Some(&runtime_fnaddr) = runtime_map.get(path.as_str()) else {
+            continue;
+        };
+        match claimed.get(build_fnaddr) {
+            Some(&(other_path, other_runtime)) => assert_eq!(
+                other_runtime, runtime_fnaddr,
+                "runtime fnaddr patch: build address {build_fnaddr:#x} stands for both \
+                 `{other_path}` ({other_runtime:#x}) and `{path}` ({runtime_fnaddr:#x}); \
+                 patching would send one callee's residual call to the other",
+            ),
+            None => {
+                claimed.insert(*build_fnaddr, (path.as_str(), runtime_fnaddr));
             }
+        }
+        if *build_fnaddr != runtime_fnaddr {
+            correspondence.insert(*build_fnaddr, runtime_fnaddr);
         }
     }
 

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -4429,6 +4429,33 @@ pub(crate) fn record_namespace_quasiimmut_field(
     }
 }
 
+/// pyjitpl.py:1074-1089 `opimpl_record_quasiimmut_field` for a real struct
+/// field, the [`record_namespace_quasiimmut_field`] twin.
+///
+/// The namespace variant keys on a synthetic `(dict, slot)` pair because a
+/// module-dict cell has no field descriptor; a genuine quasi-immutable field
+/// carries one, so the op is recorded with the descr and the heapcache keys on
+/// `descr.index()` the same way [`opimpl_getfield_gc_i`] does.
+///
+/// The caller has already resolved the field's value and is baking it as a
+/// constant, so unlike `opimpl_getfield_gc_i` this records no load — that is
+/// exactly what quasi-immutability buys.
+pub(crate) fn record_quasiimmut_field(ctx: &mut TraceCtx, obj: OpRef, descr: DescrRef) {
+    let field_index = descr.index();
+    if ctx.heap_cache().is_quasi_immut_known(obj, field_index) {
+        ctx.profiler().count_ops(
+            OpCode::QuasiimmutField,
+            majit_metainterp::counters::HEAPCACHED_OPS,
+        );
+        return;
+    }
+    ctx.heap_cache_mut().quasi_immut_now_known(obj, field_index);
+    ctx.record_op_with_descr(OpCode::QuasiimmutField, &[obj], descr);
+    if ctx.heap_cache_mut().check_and_clear_guard_not_invalidated() {
+        ctx.set_pending_guard_not_invalidated(Some(ctx.last_traced_pc));
+    }
+}
+
 /// virtualizable.py:44 + interp_jit.py:25-31 —
 /// `locals_cells_stack_w[*]` is declared as a W_Root array, so every
 /// item's JIT type is GCREF (Type::Ref). W_IntObject/W_FloatObject are

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -5852,6 +5852,49 @@ pub extern "C" fn bh_store_global_fn(frame_ptr: i64, w_name: i64, value: i64) ->
     }
 }
 
+/// DELETE_NAME residual using the frame receiver and interned-name ABI.
+/// pyopcode.py DELETE_NAME deletes from `w_locals` and raises `NameError`
+/// when the binding is absent.
+pub extern "C" fn bh_delete_name_fn(frame_ptr: i64, w_name: i64) -> i64 {
+    use pyre_interpreter::pyopcode::OpcodeStepExecutor;
+    assert!(
+        frame_ptr != 0,
+        "bh_delete_name_fn requires a non-null PyFrame; every DELETE_NAME emit \
+         site must thread portal_frame_reg as the leading ref operand"
+    );
+    let frame = unsafe { &mut *(frame_ptr as *mut PyFrame) };
+    let name =
+        unsafe { pyre_object::unicodeobject::w_str_get_value(w_name as pyre_object::PyObjectRef) };
+    match frame.delete_name(name) {
+        Ok(()) => 1,
+        Err(mut err) => {
+            publish_residual_call_exception(err.to_exc_object() as i64);
+            0
+        }
+    }
+}
+
+/// DELETE_GLOBAL residual using the frame receiver and interned-name ABI.
+/// pyopcode.py DELETE_GLOBAL deletes directly from `w_globals`.
+pub extern "C" fn bh_delete_global_fn(frame_ptr: i64, w_name: i64) -> i64 {
+    use pyre_interpreter::pyopcode::OpcodeStepExecutor;
+    assert!(
+        frame_ptr != 0,
+        "bh_delete_global_fn requires a non-null PyFrame; every DELETE_GLOBAL emit \
+         site must thread portal_frame_reg as the leading ref operand"
+    );
+    let frame = unsafe { &mut *(frame_ptr as *mut PyFrame) };
+    let name =
+        unsafe { pyre_object::unicodeobject::w_str_get_value(w_name as pyre_object::PyObjectRef) };
+    match frame.delete_global(name) {
+        Ok(()) => 1,
+        Err(mut err) => {
+            publish_residual_call_exception(err.to_exc_object() as i64);
+            0
+        }
+    }
+}
+
 /// Load a constant from the code object.
 /// jtransform.py parity: code comes from getfield_vable_r(frame, pycode).
 pub extern "C" fn bh_load_const_fn(w_code_ptr: i64, consti: i64) -> i64 {

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -5275,10 +5275,20 @@ fn register_quasi_immutable_deps(_green_key: u64) {
     // place without bumping the version and is observed by the live
     // `cell.w_value` read instead.  `ns_ptr` is the `const_ref`-folded
     // `w_globals` object pointer; `slot` is unused for version keying.
-    for (ns_ptr, _slot) in deps {
-        let obj = ns_ptr as pyre_object::PyObjectRef;
+    //
+    // `typeobject.py:177 _immutable_fields_ = ['_version_tag?']`: the
+    // LOAD_METHOD / LOAD_ATTR method-cache fold bakes a type's `version_tag`
+    // as a constant under a `QUASIIMMUT_FIELD(w_type)`, so the same loop flag
+    // registers against the type. `mutated()` (typeobject.py:285-291) bumps
+    // the tag and walks subclasses, and the setter revokes each level's loops.
+    //
+    // Both registrations self-filter on the object's kind, so a dep of either
+    // kind reaches exactly its own watcher list.
+    for (dep_ptr, _slot) in deps {
+        let obj = dep_ptr as pyre_object::PyObjectRef;
         unsafe {
             pyre_object::dictmultiobject::module_dict_register_version_watcher(obj, &flag);
+            pyre_object::typeobject::w_type_register_quasi_immut_watcher(obj, &flag);
         }
     }
 }

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -2752,6 +2752,48 @@ fn emit_frontend_store_global(
     );
 }
 
+fn emit_frontend_delete_name(
+    _graph: &mut super::flow::FunctionGraph,
+    block: &super::flow::BlockRef,
+    frame: super::flow::FlowValue,
+    name: super::flow::FlowValue,
+    offset: i64,
+) {
+    // pyopcode.py DELETE_NAME -> `space.delitem(w_locals, w_varname)`, with a
+    // KeyError surfacing as NameError.  Frame-receiver call shape like
+    // `emit_frontend_store_name`, minus the value operand; lowers to
+    // `bh_delete_name_fn(frame, w_name)`
+    // (`flatten::lower_delete_name_hlop_to_insn`).
+    record_graph_op(
+        block,
+        "delete_name",
+        vec![frame.into(), name.into()],
+        None,
+        offset,
+    );
+}
+
+fn emit_frontend_delete_global(
+    _graph: &mut super::flow::FunctionGraph,
+    block: &super::flow::BlockRef,
+    frame: super::flow::FlowValue,
+    name: super::flow::FlowValue,
+    offset: i64,
+) {
+    // pyopcode.py DELETE_GLOBAL -> `space.delitem(w_globals, w_varname)`,
+    // bypassing `w_locals`.  Same frame-receiver shape as
+    // `emit_frontend_delete_name`; lowers to
+    // `bh_delete_global_fn(frame, w_name)`
+    // (`flatten::lower_delete_global_hlop_to_insn`).
+    record_graph_op(
+        block,
+        "delete_global",
+        vec![frame.into(), name.into()],
+        None,
+        offset,
+    );
+}
+
 fn emit_frontend_simple_call(
     graph: &mut super::flow::FunctionGraph,
     block: &super::flow::BlockRef,
@@ -3402,6 +3444,8 @@ struct FnPtrIndices {
     load_name_fn: HelperHandle,
     store_name_fn: HelperHandle,
     store_global_fn: HelperHandle,
+    delete_name_fn: HelperHandle,
+    delete_global_fn: HelperHandle,
     newtuple_from_array_fn: HelperHandle,
     newlist_from_array_fn: HelperHandle,
     unpack_sequence_fn: HelperHandle,
@@ -3717,6 +3761,16 @@ fn register_helper_fn_pointers(
     let store_global_fn = bind(
         assembler,
         cpu.store_global_fn as *const (),
+        CallFlavor::Plain,
+    );
+    let delete_name_fn = bind(
+        assembler,
+        cpu.delete_name_fn as *const (),
+        CallFlavor::Plain,
+    );
+    let delete_global_fn = bind(
+        assembler,
+        cpu.delete_global_fn as *const (),
         CallFlavor::Plain,
     );
     // `bh_store_attr_fn` calls `baseobjspace::setattr_str`, which can run
@@ -4166,6 +4220,8 @@ fn register_helper_fn_pointers(
         load_name_fn,
         store_name_fn,
         store_global_fn,
+        delete_name_fn,
+        delete_global_fn,
         newtuple_from_array_fn,
         newlist_from_array_fn,
         unpack_sequence_fn,
@@ -5457,6 +5513,16 @@ impl CodeWriter {
                     idx: store_global_fn_idx,
                     flavor: _store_global_fn_flavor,
                 },
+            delete_name_fn:
+                HelperHandle {
+                    idx: delete_name_fn_idx,
+                    flavor: _delete_name_fn_flavor,
+                },
+            delete_global_fn:
+                HelperHandle {
+                    idx: delete_global_fn_idx,
+                    flavor: _delete_global_fn_flavor,
+                },
             newtuple_from_array_fn:
                 HelperHandle {
                     idx: newtuple_from_array_fn_idx,
@@ -5934,6 +6000,8 @@ impl CodeWriter {
                 load_name_fn_idx,
                 store_name_fn_idx,
                 store_global_fn_idx,
+                delete_name_fn_idx,
+                delete_global_fn_idx,
                 newtuple_from_array_fn_idx,
                 newlist_from_array_fn_idx,
                 // `[u16; 15]` indexed by nargs (0..=14).  `call_fn_idx`
@@ -9767,6 +9835,43 @@ impl CodeWriter {
                                 py_pc as i64,
                             );
                         }
+                        Instruction::DeleteName { namei } => {
+                            // pyopcode.py DELETE_NAME — deletes the binding
+                            // from `w_locals` via the `delete_name` HLOp →
+                            // `bh_delete_name_fn(frame, w_name)` residual call,
+                            // which the full-body walker traces.  Touches no
+                            // operand-stack slot, so unlike the StoreName arm
+                            // it pops nothing.  A module-level `except X as e:`
+                            // compiles its implicit cleanup to this opcode, so
+                            // leaving it unlowered blacks out the whole
+                            // enclosing module loop.
+                            let name_idx = namei.get(op_arg) as usize;
+                            let name = super::flow::Constant::string(code.names[name_idx].as_str());
+                            emit_frontend_delete_name(
+                                &mut graph,
+                                &current_block.block(),
+                                frame_var.into(),
+                                name.into(),
+                                py_pc as i64,
+                            );
+                        }
+                        Instruction::DeleteGlobal { namei } => {
+                            // pyopcode.py DELETE_GLOBAL — deletes directly from
+                            // `w_globals` (bypassing `w_locals`) via the
+                            // `delete_global` HLOp →
+                            // `bh_delete_global_fn(frame, w_name)` residual
+                            // call.  Same void 2-Ref, zero-stack-effect shape
+                            // as the DeleteName arm.
+                            let name_idx = namei.get(op_arg) as usize;
+                            let name = super::flow::Constant::string(code.names[name_idx].as_str());
+                            emit_frontend_delete_global(
+                                &mut graph,
+                                &current_block.block(),
+                                frame_var.into(),
+                                name.into(),
+                                py_pc as i64,
+                            );
+                        }
                         Instruction::MakeFunction { .. } => {
                             // Pops the code object (TOS), pushes the built
                             // function. Net: 0.  `make_function_value(globals,
@@ -12302,9 +12407,7 @@ impl CodeWriter {
                         }
 
                         // Instructions that don't touch the operand stack (locals/cells only).
-                        Instruction::DeleteGlobal { .. }
-                        | Instruction::DeleteName { .. }
-                        | Instruction::SetupAnnotations => {
+                        Instruction::SetupAnnotations => {
                             emit_abort_permanent!(py_pc);
                         }
 

--- a/pyre/pyre-jit/src/jit/cpu.rs
+++ b/pyre/pyre-jit/src/jit/cpu.rs
@@ -319,6 +319,14 @@ pub struct Cpu {
     /// lowering of `STORE_GLOBAL` (`pyopcode.py:567`); writes directly
     /// into `w_globals`, bypassing `w_locals`.
     pub store_global_fn: extern "C" fn(i64, i64, i64) -> i64,
+    /// `bh_delete_name_fn` — `(frame: Ref, w_name: Ref) → Void`, the
+    /// lowering of `DELETE_NAME`; deletes the binding from `w_locals` and
+    /// raises `NameError` when it is absent.
+    pub delete_name_fn: extern "C" fn(i64, i64) -> i64,
+    /// `bh_delete_global_fn` — `(frame: Ref, w_name: Ref) → Void`, the
+    /// lowering of `DELETE_GLOBAL`; deletes directly from `w_globals`,
+    /// bypassing `w_locals`.
+    pub delete_global_fn: extern "C" fn(i64, i64) -> i64,
     /// `newtuple(list_w)` (`objspace.py:332`) — (ref array) → new tuple.
     /// The array is the forced `popvalues` list; length travels inside
     /// the array, so any arity fits.
@@ -511,6 +519,8 @@ impl Cpu {
             load_name_fn: crate::call_jit::bh_load_name_fn,
             store_name_fn: crate::call_jit::bh_store_name_fn,
             store_global_fn: crate::call_jit::bh_store_global_fn,
+            delete_name_fn: crate::call_jit::bh_delete_name_fn,
+            delete_global_fn: crate::call_jit::bh_delete_global_fn,
             newtuple_from_array_fn: crate::call_jit::bh_newtuple_from_array,
             build_map_from_array_fn: crate::call_jit::bh_build_map_from_array,
             build_set_from_array_fn: crate::call_jit::bh_build_set_from_array,

--- a/pyre/pyre-jit/src/jit/flatten.rs
+++ b/pyre/pyre-jit/src/jit/flatten.rs
@@ -2571,6 +2571,8 @@ pub fn graph_op_can_raise(op: &super::flow::SpaceOperation) -> bool {
             | "load_name"
             | "store_name"
             | "store_global"
+            | "delete_name"
+            | "delete_global"
             | "simple_call"
             | "getattr"
             | "load_special"
@@ -3246,6 +3248,12 @@ pub struct LoweringContext {
     /// w_name, value]`, void result) via
     /// [`lower_store_global_hlop_to_insn`].
     pub store_global_fn_idx: u16,
+    /// `delete_name_fn` descrs-pool index. DELETE_NAME lowers to a void
+    /// two-Ref residual with `[frame, w_name]` operands.
+    pub delete_name_fn_idx: u16,
+    /// `delete_global_fn` descrs-pool index. DELETE_GLOBAL lowers to a void
+    /// two-Ref residual with `[frame, w_name]` operands.
+    pub delete_global_fn_idx: u16,
     /// `bind(assembler, cpu.newtuple_from_array_fn as *const (),
     /// CallFlavor::Plain)` descrs-pool index for the production
     /// source.  BUILD_TUPLE records the rtyped `pyopcode.py:995-998`
@@ -4290,6 +4298,54 @@ where
     ))
 }
 
+/// Lower pyopcode.py DELETE_NAME to a void two-Ref residual call.
+pub fn lower_delete_name_hlop_to_insn<F, LC>(
+    op: &super::flow::SpaceOperation,
+    ctx: &LoweringContext,
+    get_register: &mut F,
+    lower_constant: &mut LC,
+) -> Option<Insn>
+where
+    F: FnMut(super::flow::Variable) -> Register,
+    LC: FnMut(&Constant) -> Operand,
+{
+    if op.opname != "delete_name" || op.args.len() != 2 || op.result.is_some() {
+        return None;
+    }
+    let frame_operand = flatten_arg_with_lowering(&op.args[0], get_register, lower_constant);
+    let name_operand = flatten_arg_with_lowering(&op.args[1], get_register, lower_constant);
+    Some(build_residual_call_r_v_insn_from_operands(
+        ctx.delete_name_fn_idx,
+        vec![frame_operand, name_operand],
+        CallFlavor::Plain,
+        majit_ir::PyreHelperKind::None,
+    ))
+}
+
+/// Lower pyopcode.py DELETE_GLOBAL to a void two-Ref residual call.
+pub fn lower_delete_global_hlop_to_insn<F, LC>(
+    op: &super::flow::SpaceOperation,
+    ctx: &LoweringContext,
+    get_register: &mut F,
+    lower_constant: &mut LC,
+) -> Option<Insn>
+where
+    F: FnMut(super::flow::Variable) -> Register,
+    LC: FnMut(&Constant) -> Operand,
+{
+    if op.opname != "delete_global" || op.args.len() != 2 || op.result.is_some() {
+        return None;
+    }
+    let frame_operand = flatten_arg_with_lowering(&op.args[0], get_register, lower_constant);
+    let name_operand = flatten_arg_with_lowering(&op.args[1], get_register, lower_constant);
+    Some(build_residual_call_r_v_insn_from_operands(
+        ctx.delete_global_fn_idx,
+        vec![frame_operand, name_operand],
+        CallFlavor::Plain,
+        majit_ir::PyreHelperKind::None,
+    ))
+}
+
 /// Construct the CALL-family `residual_call_r_r` Insn from raw
 /// register indices.  Production codewriter callsite replaces the prior `emit_residual_call(
 /// call_fn_N_idx, ...)` SSARepr emit at codewriter.rs:5747-5754
@@ -5181,6 +5237,12 @@ where
         return Some(insn);
     }
     if let Some(insn) = lower_store_global_hlop_to_insn(op, ctx, get_register, lower_constant) {
+        return Some(insn);
+    }
+    if let Some(insn) = lower_delete_name_hlop_to_insn(op, ctx, get_register, lower_constant) {
+        return Some(insn);
+    }
+    if let Some(insn) = lower_delete_global_hlop_to_insn(op, ctx, get_register, lower_constant) {
         return Some(insn);
     }
     if let Some(insn) = lower_tuple_build_hlop_to_insn(op, ctx, get_register, lower_constant) {

--- a/pyre/pyre-object/src/celldict.rs
+++ b/pyre/pyre-object/src/celldict.rs
@@ -631,14 +631,21 @@ pub fn module_dict_strategy_gc_type_id() -> u32 {
 /// traced, so the common no-watcher mutation still makes no call.
 #[majit_macros::dont_look_inside]
 pub fn sweep_version_watchers(watchers: &mut Vec<std::sync::Weak<std::sync::atomic::AtomicBool>>) {
-    watchers.retain(|w| {
+    // `QuasiImmut.invalidate` takes the list and empties it BEFORE walking it
+    // (`wrefs = self.looptokens_wrefs; self.looptokens_wrefs = []`), so a loop
+    // is invalidated exactly once and then drops out.  Keeping the live
+    // watchers instead would be doubly wrong: the flag is already `true`, so
+    // re-storing it does nothing, and the list would only ever grow — one
+    // entry per compiled loop that folded a module-global.  A module-level
+    // `except X as e:` runs `del e` every iteration, and `delitem` calls
+    // `mutated()`, so retaining would make each iteration walk every loop ever
+    // compiled in the module: O(compiled loops) per store, and the JIT
+    // compiling more loops would make the interpreter slower.
+    for w in std::mem::take(watchers) {
         if let Some(flag) = w.upgrade() {
             flag.store(true, std::sync::atomic::Ordering::Release);
-            true
-        } else {
-            false
         }
-    });
+    }
 }
 
 impl Default for ModuleDictStrategy {
@@ -856,9 +863,13 @@ impl ModuleDictStrategy {
     ///         cache.cell = w_value
     /// ```
     ///
-    /// Cell-indirection (`write_cell`) is stubbed to identity until
-    /// the `MutableCell` family ports.  Without cells, every write
-    /// reaches `storage[key] = w_value` and triggers `mutated()`.
+    /// `write_cell` absorbs a rewrite in place whenever the slot already
+    /// holds an `ObjectMutableCell` (or an `IntMutableCell` and the value is
+    /// a plain int), returning `None` so the version is left alone.  Only a
+    /// structural change — installing a key that had no cell, or replacing
+    /// the cell kind — reaches `mutated()`.  That is what keeps a hot
+    /// module-level counter increment from invalidating every loop that
+    /// folded a module-global.
     pub fn _setitem_str_cell_known(
         &mut self,
         cell: Option<PyObjectRef>,

--- a/pyre/pyre-object/src/gc_roots.rs
+++ b/pyre/pyre-object/src/gc_roots.rs
@@ -303,6 +303,8 @@ pub fn pin_root(root: PyObjectRef) {
 /// Returns the first shadow-stack index occupied by `roots`.
 #[majit_macros::dont_look_inside]
 pub fn pin_roots(roots: &[PyObjectRef]) -> usize {
+    #[cfg(debug_assertions)]
+    assert_shadow_stack_not_walking();
     let base = with_shadow_stack_mut(|stack| {
         let base = stack.len();
         stack.extend_from_slice(roots);

--- a/pyre/pyre-object/src/gc_roots.rs
+++ b/pyre/pyre-object/src/gc_roots.rs
@@ -285,9 +285,10 @@ pub fn pin_root(root: PyObjectRef) {
     // The slot already holds `root`, so a query that found no forwarding stub
     // has nothing to write back.  That is the steady state — nothing collected
     // between the push above and the query — and the write-back is not free:
-    // this thread-local resolves through `_tlv_get_addr` on every `with`, and
-    // pinning sits on the interpreter's allocation and call paths, so the
-    // second resolve is paid once per pinned livevar.
+    // each `with` re-checks the thread-local's initialization state (the
+    // `_tlv_get_addr` result itself is common-subexpression-eliminated across
+    // the two accesses, the state load is not), and pinning sits on the
+    // interpreter's allocation and call paths.
     if normalized != root {
         with_shadow_stack_mut(|stack| stack[index] = normalized);
     }
@@ -328,10 +329,9 @@ pub fn pin_roots(roots: &[PyObjectRef]) -> usize {
 ///
 /// Reads the thread-local `SHADOW_STACK`, a runtime-mutable root the
 /// tracer cannot type; the JIT residualises the read instead of tracing
-/// into it (`@dont_look_inside`, `rlib/jit.py:139`). The attribute forces
-/// `#[inline(never)]` so the residual call has a stable symbol; the read
-/// rides on top of the surrounding allocation, so the lost inlining is
-/// in the noise.
+/// into it (`@dont_look_inside`, `rlib/jit.py:139`). The attribute is a
+/// tracing-policy marker only — it leaves the host backend free to inline
+/// this body, exactly as the RPython decorator leaves the C backend free.
 #[majit_macros::dont_look_inside]
 pub fn shadow_stack_len() -> usize {
     with_shadow_stack(Vec::len)

--- a/pyre/pyre-object/src/listobject.rs
+++ b/pyre/pyre-object/src/listobject.rs
@@ -1134,6 +1134,15 @@ pub unsafe fn w_list_append_inner(obj: PyObjectRef, value: PyObjectRef) {
 ///
 /// # Safety
 /// `obj` must point to a valid `W_ListObject`.
+///
+/// `#[inline(never)]` is load-bearing and separate from the tracing policy: the
+/// body forwards verbatim to [`w_list_append`], so inlining the callee makes the
+/// two functions byte-identical, and both are registered residual-call targets
+/// (`jit_fnaddr.rs`). A linker that folds identical code — MSVC's `/OPT:ICF`,
+/// on by default — then gives them one address, and `runtime_fnaddr_patch`
+/// cannot tell which callee a `constants_i` entry meant. Keeping the forwarding
+/// call keeps the two bodies distinct.
+#[inline(never)]
 #[majit_macros::dont_look_inside]
 pub unsafe fn drain_list_append(obj: PyObjectRef, value: PyObjectRef) {
     w_list_append(obj, value)

--- a/pyre/pyre-object/src/typeobject.rs
+++ b/pyre/pyre-object/src/typeobject.rs
@@ -218,6 +218,15 @@ pub struct W_TypeObject {
     /// typeobject.py:166/216 `flag_abstract?` — set from the
     /// `__abstractmethods__` setattr hook; gates `object.__new__`.
     pub flag_abstract: std::sync::atomic::AtomicBool,
+    /// The hidden `mutate__version_tag` field for `typeobject.py:177
+    /// _immutable_fields_ = ['_version_tag?']` — see [`QuasiImmut`].
+    ///
+    /// Heap allocated on the first registration and null until then, exactly
+    /// like [`W_TypeObject::weak_subclasses`], which it also matches in never
+    /// being freed: this tree has no `W_TypeObject` teardown path. Holds no GC
+    /// pointers, so the `W_TYPE_GC_TYPE_ID` custom trace has nothing to walk
+    /// here.
+    pub quasi_immut_watchers: *mut QuasiImmut,
 }
 
 /// Source of fresh `version_tag` identities (`VersionTag()`, typeobject.py:73).
@@ -387,6 +396,8 @@ pub fn w_type_new(name: &str, bases: PyObjectRef, dict_ptr: *mut u8) -> PyObject
         // slot wrapper); only builtin disallow-types flip this.
         flag_disallow_instantiation: std::sync::atomic::AtomicBool::new(false),
         flag_abstract: std::sync::atomic::AtomicBool::new(false),
+        // Allocated lazily on the first loop registration.
+        quasi_immut_watchers: std::ptr::null_mut(),
     };
     let (w_type, gc_managed) = if !raw.is_null() {
         unsafe { std::ptr::write(raw as *mut W_TypeObject, value) };
@@ -504,6 +515,8 @@ pub fn w_type_new_builtin(
         // `w_type_set_disallow_instantiation`.
         flag_disallow_instantiation: std::sync::atomic::AtomicBool::new(false),
         flag_abstract: std::sync::atomic::AtomicBool::new(false),
+        // Allocated lazily on the first loop registration.
+        quasi_immut_watchers: std::ptr::null_mut(),
     }) as PyObjectRef;
     // A builtin type is Box-immortal, so its namespace values and `bases` are reachable only
     // through `walk_builtin_type_dicts_gc` (`pyre_interpreter::eval`).
@@ -721,10 +734,140 @@ pub unsafe fn w_type_get_version_tag(obj: PyObjectRef) -> u64 {
         .load(std::sync::atomic::Ordering::Acquire)
 }
 /// Store a new version-tag identity (typeobject.py:286 `mutated`).
+///
+/// Revokes the loops that baked the old identity as a constant before
+/// publishing the new one. This is the only writer of the field, so placing the
+/// `_version_tag?` invalidation here covers every way the tag can change —
+/// `mutated()`'s fresh identity and the two demotions to `0`
+/// (uncacheable) alike — rather than leaving each caller to remember it.
 pub unsafe fn w_type_set_version_tag(obj: PyObjectRef, v: u64) {
+    w_type_notify_quasi_immut_watchers(obj);
     (*(obj as *const W_TypeObject))
         .version_tag
         .store(v, std::sync::atomic::Ordering::Release);
+}
+
+/// `quasiimmut.py:55-109 QuasiImmut` — the loops that baked one quasi-immutable
+/// field's value as a constant, and must be revoked when it changes.
+///
+/// Upstream reaches this object through the hidden `mutate_<name>` field the
+/// rtyper adds for each `_immutable_fields_` entry spelled with a `?`
+/// (`get_mutate_field_name`), created on demand by
+/// `get_current_qmut_instance`. Pyre has no rtyper to synthesise the field, so
+/// [`W_TypeObject::quasi_immut_watchers`] is that field, spelled out and
+/// likewise allocated on the first registration.
+///
+/// The flag stands in for upstream's `looptoken` + `cpu.invalidate_loop`: the
+/// backend already routes `GUARD_NOT_INVALIDATED` through a per-artifact
+/// `AtomicBool`, so setting it is what `looptoken.invalidated = True` buys.
+pub struct QuasiImmut {
+    /// `quasiimmut.py:62-63` — weak so a retired loop drops out instead of
+    /// being kept alive by the type that it read.
+    looptokens_wrefs: Vec<std::sync::Weak<std::sync::atomic::AtomicBool>>,
+    /// `quasiimmut.py:57 compress_limit = 30`.
+    compress_limit: usize,
+}
+
+impl Default for QuasiImmut {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl QuasiImmut {
+    /// `quasiimmut.py:59-64 __init__`. The initial limit is the growth formula
+    /// in [`Self::compress_looptokens_list`] evaluated at length zero.
+    pub fn new() -> Self {
+        Self {
+            looptokens_wrefs: Vec::new(),
+            compress_limit: 30,
+        }
+    }
+
+    /// `quasiimmut.py:72-75 register_loop_token`.
+    fn register_loop_token(&mut self, flag: &std::sync::Arc<std::sync::atomic::AtomicBool>) {
+        if self.looptokens_wrefs.len() > self.compress_limit {
+            self.compress_looptokens_list();
+        }
+        self.looptokens_wrefs.push(std::sync::Arc::downgrade(flag));
+    }
+
+    /// `quasiimmut.py:77-82 compress_looptokens_list` — drop the entries whose
+    /// loop is gone and re-derive the limit from what is left, so a type that
+    /// is recompiled many times and never mutated cannot grow without bound.
+    ///
+    /// Upstream's note that already-invalidated tokens must be kept applies
+    /// here too: the flag stays live while its artifact does, and re-flipping
+    /// an already-set flag is what keeps a multiply-invalidated loop revoked.
+    fn compress_looptokens_list(&mut self) {
+        self.looptokens_wrefs.retain(|w| w.strong_count() > 0);
+        self.compress_limit = (self.looptokens_wrefs.len() + 15) * 2;
+    }
+
+    /// `quasiimmut.py:84-109 invalidate` — every loop recorded here becomes
+    /// invalid, so each `GUARD_NOT_INVALIDATED` in it (and in its bridges) must
+    /// now fail. The list is emptied like upstream's `self.looptokens_wrefs =
+    /// []`; a loop that recompiles registers again.
+    ///
+    /// `#[dont_look_inside]` (`@jit.dont_look_inside`, `rlib/jit.py:139`):
+    /// upstream never reaches `invalidate` from traced code — it hangs off the
+    /// residual `jit_force_quasi_immutable` path — and the `Vec` walk has no
+    /// lowering either way. The caller's null check stays traced, so the
+    /// common no-watcher mutation still makes no call.
+    #[majit_macros::dont_look_inside]
+    fn invalidate(&mut self) {
+        for wref in std::mem::take(&mut self.looptokens_wrefs) {
+            if let Some(flag) = wref.upgrade() {
+                flag.store(true, std::sync::atomic::Ordering::Release);
+            }
+        }
+    }
+}
+
+/// Register a compiled loop's invalidation flag against this type's
+/// `_version_tag?` (`quasiimmut.py:72-74 QuasiImmut.register_loop_token`).
+///
+/// The compile-time glue (`register_quasi_immutable_deps`) calls this once per
+/// type-keyed dependency the optimizer collected from a `QUASIIMMUT_FIELD`, so
+/// [`w_type_notify_quasi_immut_watchers`] can revoke the loop when the tag is
+/// bumped.
+///
+/// # Safety
+/// `obj` must be null or point at a valid `W_TypeObject`.
+pub unsafe fn w_type_register_quasi_immut_watcher(
+    obj: PyObjectRef,
+    flag: &std::sync::Arc<std::sync::atomic::AtomicBool>,
+) {
+    if obj.is_null() || !is_type(obj) {
+        return;
+    }
+    let w_type = &mut *(obj as *mut W_TypeObject);
+    if w_type.quasi_immut_watchers.is_null() {
+        w_type.quasi_immut_watchers = Box::into_raw(Box::new(QuasiImmut::new()));
+    }
+    (*w_type.quasi_immut_watchers).register_loop_token(flag);
+}
+
+/// Revoke every loop that baked this type's `version_tag` as a constant
+/// (`quasiimmut.py:84-109 QuasiImmut.invalidate`).
+///
+/// Called from [`w_type_set_version_tag`] right before the new tag is
+/// published. Upstream runs the whole walk outside traced code — `invalidate`
+/// is reached from the residual `jit_force_quasi_immutable` path, never from a
+/// trace — so the sweep is residualised the same way. The null check stays
+/// traced, so mutating a type no loop depends on still makes no call.
+///
+/// # Safety
+/// `obj` must be null or point at a valid `W_TypeObject`.
+pub unsafe fn w_type_notify_quasi_immut_watchers(obj: PyObjectRef) {
+    if obj.is_null() || !is_type(obj) {
+        return;
+    }
+    let w_type = &mut *(obj as *mut W_TypeObject);
+    if w_type.quasi_immut_watchers.is_null() {
+        return;
+    }
+    (*w_type.quasi_immut_watchers).invalidate();
 }
 
 /// typeobject.py:183-185 `uses_object_getattribute` reader.  Returns the
@@ -1323,6 +1466,59 @@ mod tests {
             <W_TypeObject as crate::lltype::GcType>::SIZE,
             W_TYPE_OBJECT_SIZE
         );
+    }
+
+    /// `quasiimmut.py:84-109 invalidate` flips every registered flag and empties
+    /// the list, and a flag whose loop is gone is simply skipped.
+    #[test]
+    fn quasi_immut_invalidate_flips_live_flags_and_clears() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        let mut qi = QuasiImmut::new();
+        let live = Arc::new(AtomicBool::new(false));
+        let dead = Arc::new(AtomicBool::new(false));
+        qi.register_loop_token(&live);
+        qi.register_loop_token(&dead);
+        drop(dead);
+
+        qi.invalidate();
+        assert!(live.load(Ordering::Acquire), "a live loop must be revoked");
+        assert!(
+            qi.looptokens_wrefs.is_empty(),
+            "invalidate empties the list; a recompile registers again",
+        );
+
+        // A second invalidate with nothing registered is a no-op, and the flag
+        // stays set — `GUARD_NOT_INVALIDATED` has no un-set edge.
+        qi.invalidate();
+        assert!(live.load(Ordering::Acquire));
+    }
+
+    /// `quasiimmut.py:72-82` — a type recompiled many times and never mutated
+    /// must not grow an unbounded watcher list.
+    #[test]
+    fn quasi_immut_register_compresses_dead_loop_tokens() {
+        use std::sync::Arc;
+        use std::sync::atomic::AtomicBool;
+
+        let mut qi = QuasiImmut::new();
+        assert_eq!(qi.compress_limit, 30, "quasiimmut.py:57 compress_limit");
+        for _ in 0..500 {
+            // Each "recompile" drops its artifact immediately, so every
+            // registered weak ref is already dead by the next round.
+            let flag = Arc::new(AtomicBool::new(false));
+            qi.register_loop_token(&flag);
+        }
+        assert!(
+            qi.looptokens_wrefs.len() <= qi.compress_limit + 1,
+            "compress must bound the list, got {} against limit {}",
+            qi.looptokens_wrefs.len(),
+            qi.compress_limit,
+        );
+        // With every entry dead the limit collapses back to the empty-list
+        // value rather than ratcheting upward.
+        assert_eq!(qi.compress_limit, 30);
     }
 
     #[test]


### PR DESCRIPTION
Two changes that meet at the same place: what the ~636 `@dont_look_inside`
helpers cost to call, and the root stack they push to.

## 1. `#[inline(never)]` comes off `dont_look_inside` — and only off it

Upstream keeps two concepts apart that pyre had merged into one attribute.
`rpython/rlib/jit.py` decorators set tracing-policy flags — `_jit_look_inside_`
(`:139`), `_elidable_function_` (`:72`), `_jit_loop_invariant_` (`:169`) — while
suppressing the backend inliner is a separate flag, `_dont_inline_`
(`objectmodel.py:214`, documented "not the JIT!"), read by
`translator/backendopt/inline.py:565`. pyre's tracing-policy macros emitted
`#[inline(never)]` unconditionally, which no upstream counterpart asks for.

The policy itself never travelled through codegen: it rides the marker const
`rpython_attribute_const_for` emits, which `front/llbc_hints.rs` harvests from
the extracted LLBC. `charon cargo --mir` documents that "Charon disables all the
optimizations it can", so no `dont_look_inside` body can be folded into a traced
caller regardless of inlining attributes. Residual call targets resolve through
the hand-written coercions in `jit_fnaddr.rs`, not a linker symbol.

Shadow-stack reads paid a real call per access. User CPU, min of 15, arms
interleaved within each rep with the order rotated:

| probe | ratio |
| --- | --- |
| `gc22_any.py` | 0.9150 |
| `gc22_all.py` | 0.9090 |
| pure integer loop (control, never reaches the rooting path) | 1.0000 |

`any` and `all` are the same loop with opposite polarity and agree within 0.6
points. Reachable Python recursion depth rose 161300 → 167700 —
`stack_check.rs current_sp()` measures the real stack pointer, so interpreter
frames got smaller. Release binary +3.0%.

## 2. Why `elidable` and the may-force surfaces keep theirs

This branch first removed the attribute from `elidable`, `elidable_promote`,
`jit_may_force`, `loop_invariant` and `look_inside_iff`'s trampoline as well, on
the same "the flag is separate upstream" reading, and then reverted that. The
flag reading is right; the conclusion drawn from it was not.

**"Upstream leaves the backend inliner free" is not "upstream inlines it."**
`auto_inlining` stops a graph at `weight >= threshold` (`backendopt/inline.py:654`)
with `weight = 0.9999 * measure_median_execution_cost + static_instruction_count`
(`:539 inlining_heuristic`, hard reject at `count >= 200`) and roughly one weight
per lltype op (`:479 OP_WEIGHTS`). A straight-line graph is its own median path,
so it is charged about twice its op count, and the default
`DEFL_INLINE_THRESHOLD = 32.4` — described at `config/translationoption.py:11-12`
as *"just enough to inline add__Int_Int() and just small enough to prevent
inlining of some rlist functions"* — buys on the order of sixteen operations.

That budget is what splits the two families:

- `dont_look_inside` bodies fit inside it. `gc_roots::shadow_stack_len` is one
  call; `pyopcode::label_arg_to_usize` is one field read. Upstream's free
  inliner would take these, so removing the attribute restores its behaviour,
  not just its flag.
- `elidable` bodies do not — 54 of the 124 sites are in `descroperation.rs` and
  25 in `longobject.rs`. Removing the attribute there hands them to a cost model
  an order of magnitude more permissive than the one upstream would have
  applied.

Measurement offers nothing on the other side: throughput was flat (1.0070 /
1.0000 on the rooting probes, 1.0000 on the integer control), binary +14 KB, and
recursion depth fell 167700 → 159700 as the larger bodies inlined into the eval
loop.

`#[jit_release_gil]` keeps `#[inline(never)]` for a third and independent
reason: `rffi.py:219` sets `call_external_function._dont_inline_ = True` beside
`:220 _gctransformer_hint_close_stack_ = True`, explained at `:232` as "don't
inline, as a hack to guarantee that no GC pointer is alive anywhere in
call_external_function" — that body runs with the GIL released, so a caller
folded into it would put live GC pointers in the window.

## 3. The ICF folds this surfaced

With the tracing-policy helpers inlining their callees, several distinct
registered residuals compile to byte-identical bodies —
`convert_value_arg` / `special_method_arg` are both `arg.get(op_arg)`, and
`hash_str_hooked_bytes` decomposes its slice into the `(ptr, len)` pair
`hash_str_hooked` already takes, which is the same ABI, not a different one.
MSVC links with `/OPT:ICF` by default and folds each pair onto one address in
the build-script binary, while the unoptimized test binary keeps them apart. So
one build address maps to two runtime addresses in
`patch_constants_i_fnaddrs`.

This branch briefly asserted on that and failed 24 `pyre-jit` tests on
windows-latest. The assertion was not justified: folding merges only identical
machine code, so a residual call patched to either twin runs the same body, and
a genuinely wrong target could only come from a path bound to the wrong `fn` —
a binding that runs identically in both processes, so the two addresses would
agree rather than collide. `10b45ac17d` keeps the last-write-wins insert and
documents both benign sources.

`drain_list_append` keeps an `#[inline(never)]` stated at its own definition;
it is an addressability requirement rather than a tracing one, and it is
independent of whether the map rejects folds. `jit_fnaddr.rs` gains a test that
no two registered paths with different leaf names share an address — it observes
only its own process, where nothing folds, so it guards the registry, not the
build-script fold.

## 4. The interpreter root stack gets a fixed base/top

`push_roots`/`pop_roots`'s thread-local shadow stack was a `Vec<PyObjectRef>`.
RPython's is a raw buffer of `root_stack_depth` slots addressed by
`root_stack_base` / `root_stack_top` (`shadowstack.py:75-88`), raw-malloc'd once
by `_prepare_unused_stack` (`:344-349`) and replaced only by
`increase_root_stack_depth` (`:351-364`). `majit-gc`'s jitframe root stack
already carries that shape, from the same 163840 default.

The container is the point. A `Vec` puts drop glue on the thread-local, and a
thread-local carrying a destructor pays a registration-state check on every
access — `pin_root` and `shadow_stack_get` sit on the interpreter's allocation
and call paths. That cost was invisible until §1 landed, because
`#[inline(never)]` was masking it.

| probe | ratio |
| --- | --- |
| `gc22_any.py` | 0.8888 |
| `gc22_all.py` | 0.8811 |
| `gc22_control.py` (list sort — roots too, so not a control) | 0.9722 |
| `gc36_pure_arith.py` (pure integer control) | 1.0000 |

Callers hold slot indices rather than slot addresses across a push, so a grow is
transparent to them; `capture_shadow_stack_area` hands out the address of the
`RootStack` cell and not of its buffer, and `walk_shadow_stack_cell` re-reads
`base` every iteration, so a re-entrant push that grows cannot strand a walk in
the freed buffer. The buffer is released at thread exit by a `RootStackOwner` in
its own thread-local key, touched only from `grow`, so the key on the push path
keeps no destructor of its own.

`sys.setrecursionlimit` now sizes this stack the way `pypy/module/sys/vm.py:97`
sizes upstream's: `increase_root_stack_depth(int(new_limit * 0.001 * 163840))`.
`stack_check.rs` already did that for the jitframe stack; both root stacks now
follow the limit.

One deliberate deviation: the push tests `limit` and grows on reaching it, where
upstream's `incr_stack` is an unchecked bump. pyre pins one slot per call
argument as well as per livevar — `call_function` pins `1 + args.len()` across
the whole callee — so a single variadic call can outrun the headroom
`root_stack_depth` reserves per recursion level, and the native stack check
upstream relies on would not fire first.

## Verification

- `cargo test --all --no-default-features --features dynasm` — 7335 passed, 0 failed, 101 targets
- `check.py --backend dynasm` — 358/358
- `check.py --backend cranelift` — 358/358 (run serially; two backends at once produce false timeouts)
- LLBC re-extracted before each measured build, since a macro change moves the `pyre-object` source fingerprint
- `sys.setrecursionlimit(10**6)` / 200k-argument varargs call / deep recursion probe — output matches `pypy3`

## Not closed

- The registry uniqueness test observes only the address space it runs in, so it
  cannot see a build-script fold. That direction is covered by the comment on
  `patch_constants_i_fnaddrs` explaining why such a fold is benign.
- `majit_gc::shadow_stack::SHADOW_STACK` is still `RefCell<Vec<GcRef>>`. It
  carries a `MAX_SHADOW_STACK_DEPTH` cap but not the fixed allocation;
  `JitFrameShadowStack` in the same file is the template for converting it.
- An earlier revision of this description attributed five macOS `check.py`
  perf-ratio gate failures to the `elidable` change. That was wrong:
  `f947413759` raised `check.py`'s `STARTUP_SAMPLES` from 3 to 5 for exactly
  that failure mode — a high startup sample collapsing a short bench's
  exec-time denominator — and macOS `check.py` is green on this branch with
  that commit still in it. §2 rests on the inlining budget, not on those gates.
