### PR TITLE
jit-trace: bridge the codewriter's PyObject.w_class read to the walker descr (append loop 40 → 33 ops)

### DIFF
--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -3628,33 +3628,66 @@ mod tests {
         }
     }
 
-    /// The shared `PyObject` header's `w_class` bridges to the same descr the
-    /// walker pins a value's class through, so a codewriter-lowered subclass
-    /// test (`is_plain_int1`) reads the header the walker already guarded
-    /// instead of emitting a second, uncacheable read of offset 8.
-    #[test]
-    fn make_descr_from_bh_bridges_pyobject_w_class_to_the_walker_descr() {
+    /// A `PyObject.w_class` `BhDescr` describing the same access as the
+    /// canonical header descr, for both owner spellings the codewriter emits.
+    fn w_class_bh(owner: &str, field_size: usize) -> majit_translate::jitcode::BhDescr {
         use majit_ir::descr::ArrayFlag;
         use majit_translate::jitcode::BhDescr;
 
+        BhDescr::Field {
+            offset: pyre_object::pyobject::W_CLASS_OFFSET,
+            field_size,
+            field_type: Type::Ref,
+            field_flag: ArrayFlag::Signed,
+            is_field_signed: false,
+            is_immutable: false,
+            is_quasi_immutable: false,
+            // slot 0 is `ob_type`; `w_class` is slot 1 of the header.
+            index_in_parent: 1,
+            parent: None,
+            name: "w_class".into(),
+            owner: owner.into(),
+        }
+    }
+
+    /// The shared `PyObject` header's `w_class` bridges to the same descr the
+    /// walker pins a value's class through, so a codewriter-lowered subclass
+    /// test (`is_plain_int1`) reads the header the walker already guarded
+    /// instead of emitting a second, uncacheable read of the same offset.
+    #[test]
+    fn make_descr_from_bh_bridges_pyobject_w_class_to_the_walker_descr() {
+        let canonical = w_class_descr();
+        let width = W_CLASS_FIELD_DESCR.field_size();
+
         for owner in ["PyObject", "pyre_object::pyobject::PyObject"] {
-            let descr = make_descr_from_bh(&BhDescr::Field {
-                offset: 8,
-                field_size: 8,
-                field_type: Type::Ref,
-                field_flag: ArrayFlag::Signed,
-                is_field_signed: false,
-                is_immutable: false,
-                is_quasi_immutable: false,
-                // slot 0 is `ob_type`; `w_class` is slot 1 of the header.
-                index_in_parent: 1,
-                parent: None,
-                name: "w_class".into(),
-                owner: owner.into(),
-            });
+            let descr = make_descr_from_bh(&w_class_bh(owner, width));
             assert!(
-                std::sync::Arc::ptr_eq(&descr, &w_class_descr()),
+                std::sync::Arc::ptr_eq(&descr, &canonical),
                 "{owner}.w_class must bridge to the walker's w_class descr Arc",
+            );
+        }
+    }
+
+    /// …but only when the two spellings describe the same access. The canonical
+    /// descr hardcodes an 8-byte width while the codewriter sizes a pointer by
+    /// `target_word_size()`, so on a 32-bit target the incoming descr is a
+    /// narrower load at the same offset. Bridging there would widen the read
+    /// over the adjacent payload, so the mismatch declines instead.
+    #[test]
+    fn make_descr_from_bh_declines_w_class_bridge_on_a_width_mismatch() {
+        let canonical = w_class_descr();
+        let narrower = W_CLASS_FIELD_DESCR.field_size() / 2;
+
+        for owner in ["PyObject", "pyre_object::pyobject::PyObject"] {
+            let descr = make_descr_from_bh(&w_class_bh(owner, narrower));
+            assert!(
+                !std::sync::Arc::ptr_eq(&descr, &canonical),
+                "{owner}.w_class must not bridge to a descr of a different width",
+            );
+            assert_eq!(
+                descr.as_field_descr().map(|f| f.field_size()),
+                Some(narrower),
+                "the declined descr must keep the width the codewriter asked for",
             );
         }
     }
@@ -4351,13 +4384,30 @@ pub fn make_descr_from_bh(bh: &majit_translate::jitcode::BhDescr) -> DescrRef {
             //
             // Like the leaves below this runs BEFORE the parent-group lookup,
             // which would otherwise answer with the parent's own entry.
+            //
+            // Only when the two spellings describe the same memory access.
+            // `new_w_class_field_descr` hardcodes `field_size: 8` while the
+            // codewriter sizes a pointer field by `layout::target_word_size()`
+            // (`call.rs get_type_flag`), so on wasm32 the incoming descr is a
+            // 4-byte load and the canonical one an 8-byte load at the same
+            // offset. Merging them there would widen the read over four bytes
+            // of the adjacent payload. That size split is deliberate and
+            // documented at `new_w_class_field_descr`; until it is resolved the
+            // bridge declines rather than papering over it, leaving those
+            // targets exactly as they were before the bridge existed.
             if name.as_str() == "w_class"
                 && matches!(
                     owner.as_str(),
                     "PyObject" | "pyre_object::pyobject::PyObject"
                 )
             {
-                return w_class_descr();
+                let canonical = &*W_CLASS_FIELD_DESCR;
+                if canonical.offset() == *offset
+                    && canonical.field_size() == *field_size
+                    && canonical.field_type() == *field_type
+                {
+                    return w_class_descr();
+                }
             }
             if owner.as_str() == "W_ListObject" {
                 match name.as_str() {

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -3628,6 +3628,37 @@ mod tests {
         }
     }
 
+    /// The shared `PyObject` header's `w_class` bridges to the same descr the
+    /// walker pins a value's class through, so a codewriter-lowered subclass
+    /// test (`is_plain_int1`) reads the header the walker already guarded
+    /// instead of emitting a second, uncacheable read of offset 8.
+    #[test]
+    fn make_descr_from_bh_bridges_pyobject_w_class_to_the_walker_descr() {
+        use majit_ir::descr::ArrayFlag;
+        use majit_translate::jitcode::BhDescr;
+
+        for owner in ["PyObject", "pyre_object::pyobject::PyObject"] {
+            let descr = make_descr_from_bh(&BhDescr::Field {
+                offset: 8,
+                field_size: 8,
+                field_type: Type::Ref,
+                field_flag: ArrayFlag::Signed,
+                is_field_signed: false,
+                is_immutable: false,
+                is_quasi_immutable: false,
+                // slot 0 is `ob_type`; `w_class` is slot 1 of the header.
+                index_in_parent: 1,
+                parent: None,
+                name: "w_class".into(),
+                owner: owner.into(),
+            });
+            assert!(
+                std::sync::Arc::ptr_eq(&descr, &w_class_descr()),
+                "{owner}.w_class must bridge to the walker's w_class descr Arc",
+            );
+        }
+    }
+
     #[test]
     fn make_descr_from_bh_struct_array_preserves_type_and_interior_fields() {
         use majit_ir::descr::ArrayFlag;
@@ -4308,6 +4339,26 @@ pub fn make_descr_from_bh(bh: &majit_translate::jitcode::BhDescr) -> DescrRef {
             // (one skipped `list.pop(0)` per compiled loop entry). One field is
             // one descr — `metainterp_sd.all_descrs` has no second entry for a
             // field just because a different interpreter reached it.
+            // Same split, one struct up: the shared `PyObject` header's
+            // `w_class`. The walker pins a value's Python-level class by
+            // reading offset 8 through `w_class_descr()`; a codewriter-lowered
+            // body testing the same header — `is_plain_int1` reading
+            // `value.w_class` (listobject.rs) — reaches it through the modelled
+            // `PyObject` parent, whose group entry is a different identity for
+            // the same field. The pinned constant then never reached the
+            // second read, so the strict subclass test stayed symbolic and
+            // re-emitted the load plus its null and equality tests.
+            //
+            // Like the leaves below this runs BEFORE the parent-group lookup,
+            // which would otherwise answer with the parent's own entry.
+            if name.as_str() == "w_class"
+                && matches!(
+                    owner.as_str(),
+                    "PyObject" | "pyre_object::pyobject::PyObject"
+                )
+            {
+                return w_class_descr();
+            }
             if owner.as_str() == "W_ListObject" {
                 match name.as_str() {
                     "int_items.len" => return list_int_items_len_descr(),


### PR DESCRIPTION
Recovers most of what #922 gave up, and this time by deleting a duplicate read rather than folding past a pending write.

## The duplicate

`make_descr_from_bh` already redirects a codewriter-lowered body's field descr to the walker's canonical one — for `W_ListObject.int_items.*`, `ItemsBlock.capacity` and the box payloads. The reason is stated in that function: the heapcache and the optimizer's heap pass both key on descr identity, so a field carrying two descrs silently breaks aliasing between them. *"One field is one descr."*

The shared `PyObject` header's `w_class` had no such arm, and it is read from both sides in the same loop:

- `orthodox_list_append_commit` (`specialize.rs:6446`) pins the appended value's class — reads offset 8 through `w_class_descr()`, guards it to a constant, `replace_box`.
- the sub-walk then evaluates `is_plain_int1(value)` (`pyre-object/src/listobject.rs`), whose `value.w_class` read comes through the modelled `PyObject` parent — **a different identity for the same field**.

So the pinned constant never reached the second read. In the steady body that showed up as the load appearing twice, the second followed by its own null test and equality test:

```
v233 = GetfieldGcR(v231) descr=<PyreFieldDescr { offset: 8 …     ← walker
GuardValue(v233, ptr(0x102954938))
v235 = GetfieldGcR(v231) descr=<SimpleFieldDescr { index: 1 …    ← layout entry
v236 = PtrEq(v235, ptr(0x0));        v237 = IntIsTrue; GuardFalse(v237)
v238 = PtrEq(v235, ptr(0x102954938)); v239 = IntIsTrue; GuardTrue(v239)
```

## The fix

Bridge `("PyObject" | "pyre_object::pyobject::PyObject", "w_class")` to `w_class_descr()`.

Placed **ahead of** the parent-group lookup, for the reason the neighbouring `int_items.*` arm documents: when the codewriter does model the parent, that lookup answers with the parent's own entry for the same offset and re-creates the split. Putting the arm in the later `(owner, name)` match — where the box-payload bridges live — measured no change at all, because the parented path returns first.

## Result

Append loop steady body **40 → 33 ops**, so 7 of the 9 #922 gave up.

The remaining pair is the single genuine read and its guard. `guard_class` cannot replace it: a builtin subclass instance shares the payload `ob_type` and passes `guard_class`, retagging only `w_class` (`walker_frame_ops.rs:196-200`). Removing it needs the object-model split behind `builtin subclass shares the base layout`, not another descr change.

## Verification

- `check.py --backend dynasm,cranelift`: **dynasm 352/352, cranelift 352/352**
- `cargo test --release -p pyre-jit-trace --features dynasm`: 314 passed, 0 failed, including a new test asserting both owner spellings bridge to the same `Arc`
- `retag_force.py` matches the `PYRE_NO_JIT` oracle on both backends (`25000 50000 1249975000 tuple MyTuple`); `w_subclass2.py` and `synth/callee_store_global_read_after_call` unchanged
- Re-measured on the current base after the branch was rebased mid-work, not on the tree the first measurement used

— *authored by Claude*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of object class descriptors for supported object layouts.
  * Ensured compatible descriptors are reused correctly while preserving distinct descriptors when their sizes differ.

* **Tests**
  * Added coverage for descriptor reuse and size-mismatch behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->