### PR TITLE
gh#346: getslice copy infra + llinterp ops + slice/Vec as_ptr fold (rtyper-legacy stack)

### DIFF
--- a/majit/majit-translate/src/codewriter/assembler.rs
+++ b/majit/majit-translate/src/codewriter/assembler.rs
@@ -2593,6 +2593,7 @@ impl Assembler {
                 OpKind::ConstFloat(_) => "ConstFloat",
                 OpKind::ConstRef(_) => "ConstRef",
                 OpKind::ConstRefNull => "ConstRefNull",
+                OpKind::ConstNone => "ConstNone",
                 OpKind::ConstRefAddr(_) => "ConstRefAddr",
                 OpKind::FieldRead { .. } => "FieldRead",
                 OpKind::FieldWrite { .. } => "FieldWrite",
@@ -3999,6 +4000,16 @@ fn op_kind_to_opname(kind: &crate::model::OpKind) -> String {
         // `emit_const_r`, then a `ref_copy/r>r` op moves it into the
         // SSA destination register.
         OpKind::ConstRef(_) | OpKind::ConstRefNull | OpKind::ConstRefAddr(_) => "ref_copy".into(),
+        // `ConstNone` (Void `None`) is const-inlined by
+        // `legacy_const_define_hlvalue`, and `decompose_slice_args` DROPS
+        // the getslice `stop` operand for a `[start:]` slice
+        // (rtyper.rs:2841) — so it never reaches the assembler in a lifted
+        // graph.  It only appears here if a graph that planted it dropped
+        // to the legacy walker (the gate failed); the distinctive
+        // handler-less `const_none` opname trips
+        // `default_bh_builder_unwired_set_matches_task_85_snapshot` loudly
+        // rather than mis-materialising a Void into a register.
+        OpKind::ConstNone => "const_none".into(),
         // RPython: getfield_gc_i, getfield_gc_r, getfield_gc_f and `_pure`
         // variants from jtransform.py rewrite_op_getfield().
         OpKind::FieldRead { ty, pure, .. } => {

--- a/majit/majit-translate/src/codewriter/assembler.rs
+++ b/majit/majit-translate/src/codewriter/assembler.rs
@@ -2636,6 +2636,7 @@ impl Assembler {
                 OpKind::Abort { .. } => "Abort",
                 OpKind::NewTuple { .. } => "NewTuple",
                 OpKind::NewList { .. } => "NewList",
+                OpKind::GetSlice { .. } => "GetSlice",
                 OpKind::New { .. } => "New",
                 OpKind::NewWithVtable { .. } => "NewWithVtable",
                 OpKind::LoweredBlackholeOp { .. } => "LoweredBlackholeOp",
@@ -4159,6 +4160,12 @@ fn op_kind_to_opname(kind: &crate::model::OpKind) -> String {
         OpKind::Abort { .. } => "abort".into(),
         OpKind::NewTuple { .. } => "newtuple".into(),
         OpKind::NewList { .. } => "newlist".into(),
+        // `getslice` never reaches the assembler in a lifted graph — the
+        // rtyper's `rtype_getslice` replaces it with a `direct_call` to the
+        // `ll_listslice_*` helper, and the gated front recognizer keeps it
+        // out of graphs that drop to the legacy walker.  The opname exists
+        // only for exhaustiveness / diagnostics.
+        OpKind::GetSlice { .. } => "getslice".into(),
         // The opname-dispatch spine lowers the rtyper helper graphs to
         // register-shaped blackhole insns, carrying the resolved opname
         // (`strlen`/`strgetitem`/`strsetitem`/`newstr`/…) verbatim.  The

--- a/majit/majit-translate/src/codewriter/call.rs
+++ b/majit/majit-translate/src/codewriter/call.rs
@@ -7620,6 +7620,11 @@ fn op_can_raise(op: &OpKind) -> RaiseClass {
         // RPython `newlist` is a `PureOperation`; pure list construction
         // cannot raise.
         OpKind::NewList { .. } => RaiseClass::No,
+        // RPython `getslice` is a `PureOperation` (`operation.py:461`);
+        // its high-level canraise is False (the MemoryError of the
+        // `ll_listslice_*` malloc is carried by the lowered `direct_call`
+        // after rtyping).
+        OpKind::GetSlice { .. } => RaiseClass::No,
         // `LoweredBlackholeOp` carries register-shaped blackhole insns
         // lowered from the rtyper helper graphs.  String allocation
         // (`newstr`/`newunicode`) has `canraise = (MemoryError,)`; the

--- a/majit/majit-translate/src/codewriter/call.rs
+++ b/majit/majit-translate/src/codewriter/call.rs
@@ -7545,6 +7545,7 @@ fn op_can_raise(op: &OpKind) -> RaiseClass {
         | OpKind::ConstFloat(_)
         | OpKind::ConstRef(_)
         | OpKind::ConstRefNull
+        | OpKind::ConstNone
         | OpKind::ConstRefAddr(_) => RaiseClass::No,
         // JIT-specific ops that cannot raise
         OpKind::GuardTrue { .. }

--- a/majit/majit-translate/src/codewriter/jtransform.rs
+++ b/majit/majit-translate/src/codewriter/jtransform.rs
@@ -410,6 +410,7 @@ fn is_source_constant_variable(
                 | OpKind::ConstFloat(_)
                 | OpKind::ConstRef(_)
                 | OpKind::ConstRefNull
+                | OpKind::ConstNone
                 | OpKind::ConstRefAddr(_) => true,
                 OpKind::Call { target, .. } => match target {
                     CallTarget::FunctionPath { segments } => {
@@ -5693,6 +5694,7 @@ fn remap_op(
         | OpKind::ConstFloat(_)
         | OpKind::ConstRef(_)
         | OpKind::ConstRefNull
+        | OpKind::ConstNone
         | OpKind::ConstRefAddr(_)
         | OpKind::CurrentTraceLength
         | OpKind::Live

--- a/majit/majit-translate/src/codewriter/jtransform.rs
+++ b/majit/majit-translate/src/codewriter/jtransform.rs
@@ -5707,6 +5707,9 @@ fn remap_op(
         OpKind::NewList { args } => OpKind::NewList {
             args: args.iter().map(|a| remap_value(a, aliases)).collect(),
         },
+        OpKind::GetSlice { args } => OpKind::GetSlice {
+            args: args.iter().map(|a| remap_value(a, aliases)).collect(),
+        },
         OpKind::LoweredBlackholeOp { opname, args } => OpKind::LoweredBlackholeOp {
             opname: opname.clone(),
             args: args.iter().map(|a| remap_value(a, aliases)).collect(),

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -1907,6 +1907,21 @@ fn lower_unstructured_with_static_addrs_and_attrs(
                 &lo.next_call_results,
             );
         }
+        // NOTE: the `&s[k..]` (`RangeFrom` sub-slice) → orthodox `getslice`
+        // copy recognizer (`front::slice_index`) is DORMANT — it is not wired
+        // into the pipeline here.  Empirically (census build 8c68710) it is a
+        // CAPSTONE, not a standalone slice: `getslice` + its Void `ConstNone`
+        // stop are UNWIRED at the legacy walker (unlike `slice_first`'s
+        // legacy-safe `ArrayRead`/`ConstInt`/discriminant ops), so planting
+        // them into a graph that still drops to legacy — which every real
+        // `&args[1..]` interpreter method does, blocked by a co-wall such as
+        // the scalar `args[1..][0]` slice index or a `compute_at_fixpoint`
+        // failure — crashes regalloc on the Void `ConstNone`
+        // (`assembler.rs:2529 lookup_coloring`) or breaks the unwired-opname
+        // snapshot on the bare `getslice`.  The recognizer, `ConstNone`, and
+        // the `getslice` rtyper lowering stay built + tested so the capstone
+        // can activate once these graphs' co-walls close (mirrors the dormant
+        // vec!/`NewList` recognizer, `design-346-foreign-lib-cluster-epic.md`).
         let next_rewritten = if lo.next_call_results.is_empty() {
             0
         } else {
@@ -4408,6 +4423,14 @@ impl<'a> Lowering<'a> {
                             end: arg_vars[1].clone(),
                         });
                 }
+                // NOTE: `RangeFrom { start }` aggregate (`&s[k..]`) capture for
+                // `front::slice_index`'s orthodox `getslice` copy is DORMANT —
+                // the recognizer is a capstone that cannot plant its unwired
+                // `getslice` + Void `ConstNone` into the co-wall-blocked
+                // `&args[1..]` graphs without crashing the legacy walker (see
+                // the post-pass note in `simplify_and_finalize`).  Re-enable
+                // the `slice_index_rangefrom_sites` push here + the post-pass
+                // once those graphs' co-walls close.
                 // Surface every operand through a separate FieldWrite so
                 // the field-to-value binding survives into the
                 // codewriter / annotator.  Field names default to
@@ -18608,6 +18631,7 @@ fn panic_block_is_pure_message(block: &crate::model::Block) -> bool {
             | OpKind::ConstFloat(_)
             | OpKind::ConstRef(_)
             | OpKind::ConstRefNull
+            | OpKind::ConstNone
             | OpKind::ConstRefAddr(_)
             | OpKind::ConstSymbolic { .. }
             | OpKind::FieldRead { .. }

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -6987,6 +6987,17 @@ impl<'a> Lowering<'a> {
                     self.graph.set_goto(bb_id, target_bb, link_args);
                     return Ok(());
                 }
+                // `<[T]>::as_ptr` / `Vec::as_ptr` — the slice's data pointer is
+                // the receiver value in the erased array-pointer model.  Alias
+                // the result to the receiver (twin of the `as_slice` identity
+                // above and `NonNull::as_ptr`).
+                if args.len() == 1 && self.is_container_as_ptr_identity(&reg) {
+                    self.local_var[dest_local] = Some(args[0].clone());
+                    let target_bb = self.block_id[target];
+                    let link_args = self.edge_args(mir_bb, target)?;
+                    self.graph.set_goto(bb_id, target_bb, link_args);
+                    return Ok(());
+                }
                 // `alloc::fmt::format` of a no-placeholder constant
                 // message — `format!("literal")`, whose `format_args!`
                 // lowered to `Arguments::from_str` (aliased to its
@@ -9311,6 +9322,27 @@ impl<'a> Lowering<'a> {
                     | "pyre_object::int_array::<Impl>::as_mut_slice"
                     | "pyre_object::float_array::<Impl>::as_slice"
                     | "pyre_object::float_array::<Impl>::as_mut_slice"
+            )
+        })
+    }
+
+    /// `<[T]>::as_ptr` / `Vec::as_ptr` — the data-pointer projection of a
+    /// slice or vector receiver.  In the erased value-model a `&[T]` collapses
+    /// to a single GC array pointer (its length is read from the array header
+    /// by `ArrayLen`, not a companion fat-pointer word), so the slice's data
+    /// pointer IS the receiver value.  Alias the result to the receiver — the
+    /// same identity fold as `NonNull::as_ptr` (`nonnull_new_identity_alias`)
+    /// and `as_slice` above — instead of leaving an unregistered
+    /// `core::slice::<Impl>::as_ptr` residual whose only prior handling was a
+    /// `FOREIGN_STDLIB_EXTERNALS` `Address` annotation with no host address.
+    fn is_container_as_ptr_identity(&self, reg: &RegularCall) -> bool {
+        let CallKind::Fun(FunId::Regular { id }) = &reg.kind else {
+            return false;
+        };
+        self.llbc.fn_by_id(*id).is_some_and(|fd| {
+            matches!(
+                fd.item_meta.name_path().as_str(),
+                "core::slice::<Impl>::as_ptr" | "alloc::vec::<Impl>::as_ptr"
             )
         })
     }

--- a/majit/majit-translate/src/front/mod.rs
+++ b/majit/majit-translate/src/front/mod.rs
@@ -83,6 +83,7 @@ pub(crate) mod rbigint_call;
 pub(crate) mod result_exc;
 pub mod semantic;
 pub(crate) mod slice_first;
+pub(crate) mod slice_index;
 pub mod typestr;
 
 pub use semantic::{AstGraphOptions, SemanticFunction, SemanticProgram, StructFieldRegistry};

--- a/majit/majit-translate/src/front/result_exc.rs
+++ b/majit/majit-translate/src/front/result_exc.rs
@@ -661,6 +661,7 @@ pub(crate) fn op_operand_vars(kind: &OpKind) -> Vec<Variable> {
         | OpKind::ConstFloat(_)
         | OpKind::ConstRef(_)
         | OpKind::ConstRefNull
+        | OpKind::ConstNone
         | OpKind::ConstRefAddr(_)
         | OpKind::CurrentTraceLength
         | OpKind::Live

--- a/majit/majit-translate/src/front/result_exc.rs
+++ b/majit/majit-translate/src/front/result_exc.rs
@@ -723,6 +723,7 @@ pub(crate) fn op_operand_vars(kind: &OpKind) -> Vec<Variable> {
         | OpKind::JitDebug { args }
         | OpKind::NewTuple { args }
         | OpKind::NewList { args }
+        | OpKind::GetSlice { args }
         | OpKind::LoweredBlackholeOp { args, .. } => args.clone(),
         OpKind::GuardTrue { cond } | OpKind::GuardFalse { cond } => vec![cond.clone()],
         OpKind::GuardValue { value, .. }

--- a/majit/majit-translate/src/front/slice_index.rs
+++ b/majit/majit-translate/src/front/slice_index.rs
@@ -1,0 +1,646 @@
+//! `&s[k..]` (a `RangeFrom` sub-slice index) → orthodox `getslice` copy.
+//!
+//! ## Status: DORMANT capstone (built + tested, not yet wired)
+//!
+//! This recognizer is a CAPSTONE, not a standalone census slice. `getslice`
+//! and its Void `ConstNone` stop operand are UNWIRED at the legacy walker
+//! (unlike `slice_first`'s legacy-safe `ArrayRead`/`ConstInt`/discriminant
+//! ops). Every real `&args[1..]` interpreter method still drops to the legacy
+//! walker — blocked by a co-wall such as the scalar `args[1..][0]` slice index
+//! or a `compute_at_fixpoint` failure — so planting these ops crashes regalloc
+//! on the Void `ConstNone` (`assembler.rs:2529 lookup_coloring`) or breaks the
+//! unwired-opname snapshot on the bare `getslice`. The recognizer therefore
+//! stays built + unit-tested but is NOT invoked from `front::mir`; activate it
+//! (the capture site + post-pass call, both marked with re-enable notes) once
+//! these graphs' co-walls close. Mirrors the dormant vec!/`NewList` capstone
+//! (`design-346-foreign-lib-cluster-epic.md`).
+#![allow(dead_code)]
+//!
+//! ## Positioning
+//!
+//! `&s[k..]` on a `&[T]` slice desugars to
+//! `<[T] as Index<RangeFrom<usize>>>::index(s, RangeFrom { start: k })`.
+//! `lower_call` keeps `core::slice::index::<Impl>::index` as an unregistered
+//! residual (the gh#346 census wall), and the `RangeFrom { start }` operand is
+//! built by `front::mir`'s `Rvalue::Aggregate` arm as a
+//! `SyntheticTransparentCtor("RangeFrom")` + `FieldWrite("start")` chain —
+//! i.e. `SomeInstance(classdef='core.ops.range.RangeFrom')`, the same shape
+//! `front::range_iter` sees for a `Range { start, end }` for-loop.
+//!
+//! RPython models `l[start:]` as a **copy**: the annotator's `getslice`
+//! handler (`unaryop.py:420-423`) returns a fresh `listdef.offspring`, and the
+//! rtyper lowers it through `AbstractBaseListRepr.rtype_getslice`
+//! (`rlist.py:409-414`) to a `gendirectcall` of `ll_listslice_startonly`.
+//! There is no borrowed-view concept upstream. This pass reroutes the residual
+//! `slice::index` onto that orthodox path:
+//!
+//! ```text
+//!     r = RangeFrom { start = k }        // ctor + FieldWrite(start)
+//!     v = slice::index(s, r)             // residual index call
+//! becomes
+//!     v = getslice(s, k, None)           // StartOnly: stop is a const None
+//! ```
+//!
+//! The `getslice` operand contract (`decompose_slice_args`,
+//! `rtyper.rs:2787-2846`) selects `SliceKind::StartOnly` when args[2] (`stop`)
+//! annotates as a constant `None`; `k` (a proven-nonneg / const start) becomes
+//! args[1]. The stop operand is a fresh [`OpKind::ConstNone`] — the annotator
+//! constant `None` (`Void` `concretetype`), which folds to `SomeValue::None_`
+//! so the `stop_is_none` branch fires and the `len-k` copy runs at runtime.
+//!
+//! ## Consumer gate + fail-safe (the UNWIRED hazard)
+//!
+//! `getslice` is UNWIRED at the assembler — a bare `getslice` opname has no
+//! blackhole handler. In a graph that fully rtypes, `rtype_getslice` replaces
+//! the op with a `direct_call` before assembly, so no bare primitive survives.
+//! But a graph that plants `getslice` and then DROPS to the legacy walker
+//! (blocked by a co-wall the recognizer does not touch) would carry the raw op
+//! to the assembler default arm and break
+//! `default_bh_builder_unwired_set_matches_task_85_snapshot` — the same hazard
+//! the vec!/`NewList` recognizer has (`design-346-foreign-lib-cluster-epic.md`).
+//! Unlike `slice_first`, whose planted ops (`ArrayRead`/`ConstInt`/`Some`/
+//! `None`) are all wired, this pass is only safe once the rewritten graph
+//! rtypes. The rewrite is therefore fail-safe by construction: a range whose
+//! value feeds anything other than exactly its own construction
+//! (`FieldWrite`) and this one `slice::index` call is left as the residual
+//! ADT ctor + call chain (census Skip), so a decline never regresses a graph
+//! the legacy walker already handled, and the snapshot test is the empirical
+//! gate that no dropped graph carries a bare `getslice`.
+
+use crate::flowspace::model::Variable;
+use crate::model::{CallTarget, FunctionGraph, LinkArg, OpKind, SpaceOperation};
+
+/// A recognized `RangeFrom { start }` aggregate feeding a residual
+/// `core::slice::index::<Impl>::index(slice, range)` call, captured during
+/// body lowering (`front::mir`'s `Rvalue::Aggregate` arm). Carries the ctor
+/// result (the `RangeFrom` value the index call consumes as its `range`
+/// operand) and the `start` bound threaded into the `getslice` op.
+#[derive(Clone)]
+pub(crate) struct SliceIndexRangeFromSite {
+    /// The `SyntheticTransparentCtor` result (the `RangeFrom` value) — locates
+    /// the ctor op and the consuming `slice::index` call's `range` operand.
+    pub range_result: Variable,
+    /// The `start` bound `k` — the `getslice` `start` argument (args[1]).
+    pub start: Variable,
+}
+
+/// Rewrite every captured `RangeFrom` aggregate that feeds exactly one
+/// residual `slice::index` call into an orthodox `getslice(slice, start,
+/// None)` op. Fail-safe: a site that does not match the expected single-
+/// consumer shape is left as the ordinary ctor + FieldWrite + residual call
+/// chain (census Skip). Returns the number of sites rewritten.
+pub(crate) fn rewire_slice_index_rangefrom_sites(
+    graph: &mut FunctionGraph,
+    sites: &[SliceIndexRangeFromSite],
+) -> usize {
+    let mut rewritten = 0;
+    for site in sites {
+        match rewire_one_slice_index_site(graph, site) {
+            Ok(()) => rewritten += 1,
+            Err(_decline) => {
+                // Leave the ctor + FieldWrite + residual `slice::index` call;
+                // the unregistered callee keeps the rtyper census Skip for
+                // this graph.
+            }
+        }
+    }
+    rewritten
+}
+
+fn rewire_one_slice_index_site(
+    graph: &mut FunctionGraph,
+    site: &SliceIndexRangeFromSite,
+) -> Result<(), String> {
+    let name = graph.name.clone();
+    let range = site.range_result.clone();
+
+    // 1. Locate the residual `slice::index` call consuming the `RangeFrom`
+    //    value as its `range` operand (args[1]). Capture its `slice` operand
+    //    (args[0]) and result; the position is re-found after the sweeps
+    //    below, since removing the ctor / FieldWrite shifts op indices.
+    let (slice, index_result) = graph
+        .blocks
+        .iter()
+        .find_map(|b| {
+            b.operations.iter().find_map(|op| {
+                if !is_slice_range_index_call(&op.kind) {
+                    return None;
+                }
+                let OpKind::Call { args, .. } = &op.kind else {
+                    return None;
+                };
+                if args.len() != 2 || args[1] != range {
+                    return None;
+                }
+                let result = op.result.as_ref()?;
+                Some((args[0].clone(), result.clone()))
+            })
+        })
+        .ok_or_else(|| format!("{name}: no slice::index call consumes the RangeFrom value"))?;
+
+    // 2. Consumer gate: the `RangeFrom` value must feed EXACTLY its own
+    //    construction (`FieldWrite`) and this one index call. A range read by
+    //    a `.start` field read, a second index, or a stored range keeps the
+    //    ordinary ADT ctor path — rewriting it would break that consumer.
+    if !range_feeds_only_index(graph, &range, &index_result) {
+        return Err(format!(
+            "{name}: RangeFrom value has a non-index consumer — declining"
+        ));
+    }
+
+    // 3. The `start` bound must be defined so the `getslice` op is well-formed.
+    if !graph_defines(graph, &site.start) {
+        return Err(format!(
+            "{name}: RangeFrom start is not defined in the graph"
+        ));
+    }
+
+    // 3a. The `start` must be a NON-NEGATIVE CONSTANT. `decompose_slice_args`
+    //     (rtyper.rs:2809-2816) raises "slice start must be proved
+    //     non-negative" for a `nonneg==false` runtime `SomeInteger` start, and
+    //     a `usize` literal decodes to a bare `OpKind::ConstInt(k)` with no
+    //     `Unsigned`/nonneg annotation (only its value is ≥ 0). A runtime
+    //     start could annotate `nonneg==false`, making the getslice fail to
+    //     rtype → the graph drops to legacy carrying a bare unwired `getslice`
+    //     → the unwired-opname snapshot breaks. Restricting to a const k ≥ 0
+    //     (the `&s[1..]` / `&s[k..]` literal shape, which
+    //     `immutablevalue(ConstInt(k))` annotates `nonneg = k>=0`) keeps every
+    //     rewritten graph lift-able; a computed start declines cleanly
+    //     (residual, census Skip).
+    if !start_is_const_nonneg(graph, &site.start) {
+        return Err(format!(
+            "{name}: RangeFrom start is not a non-negative constant — declining"
+        ));
+    }
+
+    // --- All structural validation passed; mutate the graph. ---
+
+    // 4. Remove every `start` `FieldWrite` on the `RangeFrom` value and the
+    //    `SyntheticTransparentCtor` producing it. After the rewrite `range` is
+    //    dead (the gate proved the index call is its only non-construction
+    //    consumer), so a surviving `setattr("start")` or ctor would wall on a
+    //    value nothing reads.
+    for b in &mut graph.blocks {
+        b.operations.retain(|op| {
+            let is_field_write =
+                matches!(&op.kind, OpKind::FieldWrite { base, .. } if base == &range);
+            let is_ctor = op.result.as_ref() == Some(&range)
+                && matches!(
+                    &op.kind,
+                    OpKind::Call {
+                        target: CallTarget::SyntheticTransparentCtor { .. },
+                        ..
+                    }
+                );
+            !(is_field_write || is_ctor)
+        });
+    }
+
+    // 5. Replace the residual `slice::index` call (re-located by result
+    //    identity — the sweeps above shifted op indices) with
+    //    `getslice(slice, start, None)`. The `None` stop is a fresh
+    //    `ConstNone` op inserted immediately before the getslice so its result
+    //    Variable is defined in the same block.
+    let (rb, ri) = graph
+        .blocks
+        .iter()
+        .enumerate()
+        .find_map(|(bi, b)| {
+            b.operations
+                .iter()
+                .position(|op| {
+                    op.result.as_ref() == Some(&index_result) && is_slice_range_index_call(&op.kind)
+                })
+                .map(|oi| (bi, oi))
+        })
+        .ok_or_else(|| format!("{name}: slice::index op vanished before rewrite"))?;
+    let stop = graph.alloc_value_var();
+    graph.blocks[rb].operations[ri] = SpaceOperation {
+        result: Some(index_result),
+        kind: OpKind::GetSlice {
+            args: vec![slice, site.start.clone(), stop.clone()],
+        },
+    };
+    graph.blocks[rb].operations.insert(
+        ri,
+        SpaceOperation {
+            result: Some(stop),
+            kind: OpKind::ConstNone,
+        },
+    );
+    Ok(())
+}
+
+/// `true` when `kind` is a residual `core::slice::index::<Impl>::index` call —
+/// the `&s[range]` sub-slice residual whose `range` operand this pass folds.
+/// The scalar `Vec`/`Constants` integer index is intercepted earlier in
+/// `lower_call` (`is_vec_index_regular` / `constants_call_leaf`), so only the
+/// range-indexed slice residual reaches here.
+fn is_slice_range_index_call(kind: &OpKind) -> bool {
+    matches!(
+        kind,
+        OpKind::Call {
+            target: CallTarget::FunctionPath { segments },
+            ..
+        } if slice_index_segments_match(segments)
+    )
+}
+
+/// The residual callee spelling for `<[T]>::index` with a range index.
+/// Charon runs `monomorphize:false`, so the callee keeps the inherent-impl
+/// path `core::slice::index::<Impl>::index`.
+fn slice_index_segments_match(segments: &[String]) -> bool {
+    let n = segments.len();
+    n >= 3
+        && segments[n - 1] == "index"
+        && segments[n - 2] == "<Impl>"
+        && segments[n - 3] == "index"
+        && segments.first().map(String::as_str) == Some("core")
+}
+
+/// `true` when the `RangeFrom` value is consumed by EXACTLY its own
+/// construction (`FieldWrite`) and the one `slice::index` call whose result is
+/// `index_result`. Computes the forward alias closure of the range value
+/// (every Variable it flows into through positional `Link.args`) and rejects
+/// if any op / exitswitch / exception payload other than the construction
+/// writes or the index op reads a closure member. Mirrors
+/// `range_iter::range_feeds_only_forloop`.
+fn range_feeds_only_index(
+    graph: &FunctionGraph,
+    range_result: &Variable,
+    index_result: &Variable,
+) -> bool {
+    use std::collections::HashSet;
+    let mut closure: HashSet<Variable> = HashSet::new();
+    closure.insert(range_result.clone());
+    loop {
+        let mut grew = false;
+        for block in &graph.blocks {
+            for link in &block.exits {
+                let Some(target_idx) = graph.blocks.iter().position(|b| b.id == link.target) else {
+                    continue;
+                };
+                let target_inputargs = &graph.blocks[target_idx].inputargs;
+                for (arg_idx, arg) in link.args.iter().enumerate() {
+                    let LinkArg::Value(var) = arg else { continue };
+                    if closure.contains(var)
+                        && let Some(iarg) = target_inputargs.get(arg_idx)
+                        && closure.insert(iarg.clone())
+                    {
+                        grew = true;
+                    }
+                }
+            }
+        }
+        if !grew {
+            break;
+        }
+    }
+
+    let in_closure = |v: &Variable| closure.contains(v);
+    for block in &graph.blocks {
+        for op in &block.operations {
+            let reads_range = crate::inline::op_variable_refs(&op.kind)
+                .iter()
+                .any(&in_closure);
+            if !reads_range {
+                continue;
+            }
+            // A construction `FieldWrite` (base in the closure) writes the
+            // `RangeFrom`'s `start`; the `slice::index` op reads the range as
+            // its `range` operand. Both are removed / rewritten; anything else
+            // is a genuine second consumer.
+            let is_construction_write =
+                matches!(&op.kind, OpKind::FieldWrite { base, .. } if in_closure(base));
+            let is_index = op.result.as_ref() == Some(index_result);
+            if !(is_construction_write || is_index) {
+                return false;
+            }
+        }
+        match &block.exitswitch {
+            Some(crate::model::ExitSwitch::Value(v)) if in_closure(v) => return false,
+            Some(crate::model::ExitSwitch::Fused { args, .. }) if args.iter().any(&in_closure) => {
+                return false;
+            }
+            _ => {}
+        }
+        for link in &block.exits {
+            if link
+                .last_exception
+                .as_ref()
+                .and_then(LinkArg::as_variable)
+                .is_some_and(&in_closure)
+                || link
+                    .last_exc_value
+                    .as_ref()
+                    .and_then(LinkArg::as_variable)
+                    .is_some_and(&in_closure)
+            {
+                return false;
+            }
+        }
+    }
+    true
+}
+
+/// `true` when `var` is produced by some op or is a block inputarg — i.e. it
+/// is a well-defined value the rewritten `getslice` op can reference.
+fn graph_defines(graph: &FunctionGraph, var: &Variable) -> bool {
+    graph.blocks.iter().any(|b| {
+        b.inputargs.iter().any(|iv| iv == var)
+            || b.operations
+                .iter()
+                .any(|op| op.result.as_ref() == Some(var))
+    })
+}
+
+/// `true` when `var` is produced by an `OpKind::ConstInt(k)` op with `k >= 0`
+/// — the `&s[k..]` literal start `decompose_slice_args` selects `StartOnly`
+/// for. A `usize` slice literal decodes to `ConstInt(k)` (`decode_literal`
+/// collapses `Usize` into `DecodedConst::Int`), which
+/// `immutablevalue(ConstInt(k))` annotates as `SomeInteger` with
+/// `nonneg = k>=0`, so a const k ≥ 0 satisfies the getslice nonneg contract
+/// without a computed-stop hazard.
+fn start_is_const_nonneg(graph: &FunctionGraph, var: &Variable) -> bool {
+    graph.blocks.iter().any(|b| {
+        b.operations.iter().any(|op| {
+            op.result.as_ref() == Some(var) && matches!(&op.kind, OpKind::ConstInt(k) if *k >= 0)
+        })
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::ValueType;
+
+    fn rangefrom_ctor_target() -> CallTarget {
+        CallTarget::synthetic_transparent_ctor_with_owner(
+            vec!["core".to_string(), "ops".to_string(), "range".to_string()],
+            "RangeFrom".to_string(),
+        )
+    }
+
+    fn start_field_write(base: &Variable, value: &Variable) -> OpKind {
+        OpKind::FieldWrite {
+            base: base.clone(),
+            field: crate::model::FieldDescriptor {
+                name: "start".to_string(),
+                owner_root: Some("core::ops::range::RangeFrom".to_string()),
+                owner_id: None,
+            },
+            value: LinkArg::Value(value.clone()),
+            ty: ValueType::Ref(None),
+        }
+    }
+
+    fn slice_index_call_target() -> CallTarget {
+        CallTarget::FunctionPath {
+            segments: vec![
+                "core".into(),
+                "slice".into(),
+                "index".into(),
+                "<Impl>".into(),
+                "index".into(),
+            ],
+        }
+    }
+
+    /// Build the minimal `&s[k..]` shape — a `ConstInt(k)` start, a
+    /// `RangeFrom` ctor + `start` FieldWrite, and a residual
+    /// `slice::index(slice, range)` — and assert the rewrite drops the ctor +
+    /// FieldWrite + residual call and emits `getslice(slice, k, None)`.
+    #[test]
+    fn rewrite_lifts_rangefrom_index_to_getslice() {
+        let mut g = FunctionGraph::new("test_slice_index");
+        let a = g.startblock;
+        let slice = g.push_op_var(a, OpKind::ConstInt(0), true).unwrap();
+        let k = g.push_op_var(a, OpKind::ConstInt(1), true).unwrap();
+        let range = g
+            .push_op_var(
+                a,
+                OpKind::Call {
+                    target: rangefrom_ctor_target(),
+                    args: Vec::new(),
+                    result_ty: ValueType::Ref(Some("core::ops::range::RangeFrom".into())),
+                },
+                true,
+            )
+            .unwrap();
+        g.block_mut(a).operations.push(SpaceOperation {
+            result: None,
+            kind: start_field_write(&range, &k),
+        });
+        let sub = g
+            .push_op_var(
+                a,
+                OpKind::Call {
+                    target: slice_index_call_target(),
+                    args: vec![slice.clone(), range.clone()],
+                    result_ty: ValueType::Ref(None),
+                },
+                true,
+            )
+            .unwrap();
+        let (b, _b_args) = g.create_block_with_arg_vars(1);
+        g.set_return(b, None);
+        g.set_goto(a, b, vec![sub.clone()]);
+
+        let site = SliceIndexRangeFromSite {
+            range_result: range.clone(),
+            start: k.clone(),
+        };
+        let rewritten = rewire_slice_index_rangefrom_sites(&mut g, &[site]);
+        assert_eq!(rewritten, 1, "the slice::index RangeFrom site is rewritten");
+
+        // The residual `slice::index` call, the RangeFrom ctor, and the
+        // `start` FieldWrite are all gone.
+        let has_index = g
+            .blocks
+            .iter()
+            .flat_map(|blk| &blk.operations)
+            .any(|op| is_slice_range_index_call(&op.kind));
+        assert!(!has_index, "residual slice::index call removed");
+        let has_ctor = g.blocks.iter().flat_map(|blk| &blk.operations).any(|op| {
+            matches!(
+                &op.kind,
+                OpKind::Call {
+                    target: CallTarget::SyntheticTransparentCtor { .. },
+                    ..
+                }
+            )
+        });
+        assert!(!has_ctor, "RangeFrom ctor removed");
+        let has_start_write = g.blocks.iter().flat_map(|blk| &blk.operations).any(
+            |op| matches!(&op.kind, OpKind::FieldWrite { field, .. } if field.name == "start"),
+        );
+        assert!(!has_start_write, "start FieldWrite removed");
+
+        // A single `getslice` op with 3 args (slice, k, None) is emitted, its
+        // stop operand produced by a `ConstNone` op.
+        let getslice_ops: Vec<_> = g
+            .blocks
+            .iter()
+            .flat_map(|blk| &blk.operations)
+            .filter(|op| matches!(&op.kind, OpKind::GetSlice { .. }))
+            .collect();
+        assert_eq!(getslice_ops.len(), 1, "exactly one getslice op");
+        let OpKind::GetSlice { args } = &getslice_ops[0].kind else {
+            unreachable!()
+        };
+        assert_eq!(args.len(), 3, "getslice has [slice, start, stop]");
+        assert_eq!(args[0], slice, "arg0 = slice receiver");
+        assert_eq!(args[1], k, "arg1 = const start k");
+        let stop = &args[2];
+        let stop_is_const_none =
+            g.blocks.iter().flat_map(|blk| &blk.operations).any(|op| {
+                op.result.as_ref() == Some(stop) && matches!(&op.kind, OpKind::ConstNone)
+            });
+        assert!(stop_is_const_none, "arg2 = ConstNone (StartOnly stop)");
+    }
+
+    /// A RangeFrom whose start is a RUNTIME value (not a const) declines: a
+    /// non-nonneg runtime start would fail `decompose_slice_args` and drop the
+    /// graph to legacy carrying a bare unwired `getslice`.
+    #[test]
+    fn rewrite_declines_runtime_start() {
+        let mut g = FunctionGraph::new("test_slice_index_runtime");
+        let a = g.startblock;
+        let slice = g.push_op_var(a, OpKind::ConstInt(0), true).unwrap();
+        // A runtime start: the result of a BinOp, not a ConstInt.
+        let x = g.push_op_var(a, OpKind::ConstInt(5), true).unwrap();
+        let start = g
+            .push_op_var(
+                a,
+                OpKind::BinOp {
+                    op: "add".into(),
+                    lhs: x.clone(),
+                    rhs: x.clone(),
+                    result_ty: ValueType::Int,
+                },
+                true,
+            )
+            .unwrap();
+        let range = g
+            .push_op_var(
+                a,
+                OpKind::Call {
+                    target: rangefrom_ctor_target(),
+                    args: Vec::new(),
+                    result_ty: ValueType::Ref(Some("core::ops::range::RangeFrom".into())),
+                },
+                true,
+            )
+            .unwrap();
+        g.block_mut(a).operations.push(SpaceOperation {
+            result: None,
+            kind: start_field_write(&range, &start),
+        });
+        let sub = g
+            .push_op_var(
+                a,
+                OpKind::Call {
+                    target: slice_index_call_target(),
+                    args: vec![slice.clone(), range.clone()],
+                    result_ty: ValueType::Ref(None),
+                },
+                true,
+            )
+            .unwrap();
+        let (b, _b_args) = g.create_block_with_arg_vars(1);
+        g.set_return(b, None);
+        g.set_goto(a, b, vec![sub.clone()]);
+
+        let site = SliceIndexRangeFromSite {
+            range_result: range.clone(),
+            start: start.clone(),
+        };
+        let rewritten = rewire_slice_index_rangefrom_sites(&mut g, &[site]);
+        assert_eq!(rewritten, 0, "runtime start declines");
+        // The residual call and ctor survive untouched (census Skip).
+        assert!(
+            g.blocks
+                .iter()
+                .flat_map(|blk| &blk.operations)
+                .any(|op| is_slice_range_index_call(&op.kind)),
+            "residual slice::index call left in place"
+        );
+        assert!(
+            !g.blocks
+                .iter()
+                .flat_map(|blk| &blk.operations)
+                .any(|op| matches!(&op.kind, OpKind::GetSlice { .. })),
+            "no getslice planted on decline"
+        );
+    }
+
+    /// A RangeFrom read by a SECOND consumer (a `.start` field read, here
+    /// modeled as another op reading the range value) declines — rewriting it
+    /// would break that consumer.
+    #[test]
+    fn rewrite_declines_multi_consumer_range() {
+        let mut g = FunctionGraph::new("test_slice_index_multi");
+        let a = g.startblock;
+        let slice = g.push_op_var(a, OpKind::ConstInt(0), true).unwrap();
+        let k = g.push_op_var(a, OpKind::ConstInt(1), true).unwrap();
+        let range = g
+            .push_op_var(
+                a,
+                OpKind::Call {
+                    target: rangefrom_ctor_target(),
+                    args: Vec::new(),
+                    result_ty: ValueType::Ref(Some("core::ops::range::RangeFrom".into())),
+                },
+                true,
+            )
+            .unwrap();
+        g.block_mut(a).operations.push(SpaceOperation {
+            result: None,
+            kind: start_field_write(&range, &k),
+        });
+        let sub = g
+            .push_op_var(
+                a,
+                OpKind::Call {
+                    target: slice_index_call_target(),
+                    args: vec![slice.clone(), range.clone()],
+                    result_ty: ValueType::Ref(None),
+                },
+                true,
+            )
+            .unwrap();
+        // A second consumer: a FieldRead of `.start` on the range value.
+        g.push_op_var(
+            a,
+            OpKind::FieldRead {
+                base: range.clone(),
+                field: crate::model::FieldDescriptor {
+                    name: "start".to_string(),
+                    owner_root: Some("core::ops::range::RangeFrom".to_string()),
+                    owner_id: None,
+                },
+                ty: ValueType::Int,
+                pure: true,
+            },
+            true,
+        )
+        .unwrap();
+        let (b, _b_args) = g.create_block_with_arg_vars(1);
+        g.set_return(b, None);
+        g.set_goto(a, b, vec![sub.clone()]);
+
+        let site = SliceIndexRangeFromSite {
+            range_result: range.clone(),
+            start: k.clone(),
+        };
+        let rewritten = rewire_slice_index_rangefrom_sites(&mut g, &[site]);
+        assert_eq!(rewritten, 0, "a second range consumer declines the rewrite");
+        assert!(
+            g.blocks
+                .iter()
+                .flat_map(|blk| &blk.operations)
+                .any(|op| is_slice_range_index_call(&op.kind)),
+            "residual slice::index call left in place"
+        );
+    }
+}

--- a/majit/majit-translate/src/inline.rs
+++ b/majit/majit-translate/src/inline.rs
@@ -429,6 +429,7 @@ pub(crate) fn remap_op_kind(
         OpKind::ConstFloat(bits) => OpKind::ConstFloat(*bits),
         OpKind::ConstRef(obj) => OpKind::ConstRef(obj.clone()),
         OpKind::ConstRefNull => OpKind::ConstRefNull,
+        OpKind::ConstNone => OpKind::ConstNone,
         OpKind::ConstRefAddr(addr) => OpKind::ConstRefAddr(*addr),
         OpKind::New { owner } => OpKind::New {
             owner: owner.clone(),
@@ -876,6 +877,7 @@ pub fn op_variable_refs(kind: &OpKind) -> Vec<crate::flowspace::model::Variable>
         | OpKind::ConstFloat(_)
         | OpKind::ConstRef(_)
         | OpKind::ConstRefNull
+        | OpKind::ConstNone
         | OpKind::ConstRefAddr(_)
         | OpKind::CurrentTraceLength
         | OpKind::Live
@@ -1157,6 +1159,7 @@ pub fn is_pure_op(kind: &OpKind) -> bool {
         | OpKind::ConstFloat(_)
         | OpKind::ConstRef(_)
         | OpKind::ConstRefNull
+        | OpKind::ConstNone
         | OpKind::ConstRefAddr(_)
         // Pure reads — `getfield(_pure) getarrayitem(_pure)
         // getinteriorfield` in `enum_ops_without_sideeffects`.

--- a/majit/majit-translate/src/inline.rs
+++ b/majit/majit-translate/src/inline.rs
@@ -837,6 +837,9 @@ pub(crate) fn remap_op_kind(
         OpKind::NewList { args } => OpKind::NewList {
             args: args.iter().map(&remap_var).collect(),
         },
+        OpKind::GetSlice { args } => OpKind::GetSlice {
+            args: args.iter().map(&remap_var).collect(),
+        },
         OpKind::LoweredBlackholeOp { opname, args } => OpKind::LoweredBlackholeOp {
             opname: opname.clone(),
             args: args.iter().map(&remap_var).collect(),
@@ -885,6 +888,7 @@ pub fn op_variable_refs(kind: &OpKind) -> Vec<crate::flowspace::model::Variable>
         }
         OpKind::NewTuple { args } => args.iter().map(clone_var).collect(),
         OpKind::NewList { args } => args.iter().map(clone_var).collect(),
+        OpKind::GetSlice { args } => args.iter().map(clone_var).collect(),
         OpKind::LoweredBlackholeOp { args, .. } => args.iter().map(clone_var).collect(),
         OpKind::VableForce { base } => vec![clone_var(base)],
         OpKind::Hint { value, .. } => vec![clone_var(value)],
@@ -1171,6 +1175,10 @@ pub fn is_pure_op(kind: &OpKind) -> bool {
         // `newlist` is `PureOperation` — a fresh list allocation has no
         // observable effect on existing state.
         | OpKind::NewList { .. }
+        // `getslice` is a `PureOperation` (`operation.py:461`,
+        // `pure=True`) — the slice copy reads the source and allocates a
+        // fresh list, with no observable effect on existing state.
+        | OpKind::GetSlice { .. }
         // `isinstance` lowers to `int_between` over `obj.typeptr`'s
         // subclass-range fields plus an optional null branch — all
         // pure reads, classified `canfold=True` upstream

--- a/majit/majit-translate/src/model.rs
+++ b/majit/majit-translate/src/model.rs
@@ -568,6 +568,17 @@ pub enum OpKind {
     /// the common sentinel as `PY_NULL`; it materialises in the ref bank
     /// as address 0, not as an integer register.
     ConstRefNull,
+    /// The RPython annotator constant `None` — a `Constant(NoneType)` whose
+    /// `concretetype` is `lltype.Void`.  Distinct from [`ConstRefNull`]: the
+    /// latter is a null GCREF (`SomePtr`), whereas this folds to
+    /// `SomeValue::None_` (`SomeNone`) so the rtyper's `none_repr` /
+    /// `decompose_slice_args` `stop_is_none` selection see a true `None`.
+    /// The sole producer is the gated slice-range front recognizer, which
+    /// plants it as the `stop` operand of a `[start:]` (`StartOnly`)
+    /// `getslice`; it mirrors how `LOAD_CONST None` pushes `Constant(None)`
+    /// upstream.  Const-inlined by `legacy_const_define_hlvalue`, so no
+    /// SpaceOp reaches the assembler.
+    ConstNone,
     /// Process-wide singleton pointer that must be materialised in the
     /// ref bank (e.g. PyPy `space.fromcache(DictStrategy)` singletons
     /// represented by pyre's Rust `pub static *_DICT_STRATEGY` values).

--- a/majit/majit-translate/src/model.rs
+++ b/majit/majit-translate/src/model.rs
@@ -1155,6 +1155,20 @@ pub enum OpKind {
         args: Vec<crate::flowspace::model::Variable>,
     },
 
+    /// RPython `getslice` operation (`operation.py`) — `l[start:stop]`.
+    /// The three operands are `(list, start, stop)`; the annotator's
+    /// `getslice` handler (`unaryop.py:420-423`) builds a fresh
+    /// `listdef.offspring` (a copy, not a view), and the rtyper lowers it
+    /// through `AbstractBaseListRepr.rtype_getslice`
+    /// (`rlist.py:409-414`) to a `gendirectcall` of the per-kind
+    /// `ll_listslice_{startonly,startstop,minusone}` helper — so the op
+    /// never survives to the assembler as a bare primitive.  Emitted only
+    /// by the gated slice-range front recognizer; a graph that drops to
+    /// the legacy walker keeps the residual `slice::index` call instead.
+    GetSlice {
+        args: Vec<crate::flowspace::model::Variable>,
+    },
+
     /// A pre-lowered, register-shaped blackhole opcode emitted by the
     /// opname-dispatch convergence spine (`codewriter::jtransform_opname`).
     ///

--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -2470,6 +2470,11 @@ const FOREIGN_STDLIB_EXTERNALS: &[(&[&str], &[&str], LowLevelType)] = &[
     ),
     (&["vec", "Vec", "as_ptr"], &["self"], LowLevelType::Address),
     (
+        &["sync", "atomic", "AtomicBool", "store"],
+        &["self", "val", "order"],
+        LowLevelType::Void,
+    ),
+    (
         &["cell", "Cell", "set"],
         &["self", "val"],
         LowLevelType::Void,

--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -2235,9 +2235,8 @@ fn build_stub_pygraph_with_result_shell(
 ///
 /// `Address` maps to the untyped `SomeAddress` shell (`llmemory.py:573
 /// SomeAddress`) — the annotation-stage projection a `*const T` / `*mut T`
-/// raw pointer carries when its element type is not modeled.  A
-/// `<[T]>::as_ptr` result is consumed here only as a residual-call argument
-/// (`hash_str_hooked(ptr, len)`), for which the untyped address is faithful.
+/// raw pointer carries when its element type is not modeled, for a residual
+/// whose result is consumed only as a residual-call argument.
 pub(crate) fn default_someshell_for_lltype(
     lltype: &LowLevelType,
 ) -> Option<crate::annotator::model::SomeValue> {
@@ -2416,10 +2415,12 @@ pub(crate) fn register_unsafe_fn_stubs(
 /// - `core::f64::<Impl>::to_bits` returns `u64` reinterpreted as `i64` —
 ///   `Signed` result.
 ///
-/// A raw `*const T` / `*mut T` result maps to the untyped `Address` shell
-/// (`core::slice::<Impl>::as_ptr`, `vec::Vec::as_ptr`) — faithful when the
-/// pointer is consumed only as a residual-call argument.  Paths whose
-/// faithful result is a non-scalar value the stub carrier still cannot
+/// `<[T]>::as_ptr` / `Vec::as_ptr` are NOT registered here: in the erased
+/// array-pointer value-model the slice's data pointer is the receiver value,
+/// so they fold to the receiver in the front end
+/// (`Lowering::is_container_as_ptr_identity`, twin of the `as_slice` and
+/// `NonNull::as_ptr` identity folds), leaving no residual to annotate.  Paths
+/// whose faithful result is a non-scalar value the stub carrier still cannot
 /// express (`alloc::fmt::format` → `String`,
 /// `core::array::iter::<Impl>::into_iter` → an iterator with no Repr,
 /// `core::num::<Impl>::checked_*` → `Option<i64>`) stay intentionally
@@ -2452,12 +2453,6 @@ const FOREIGN_STDLIB_EXTERNALS: &[(&[&str], &[&str], LowLevelType)] = &[
         &["layout"],
         LowLevelType::Void,
     ),
-    (
-        &["core", "slice", "<Impl>", "as_ptr"],
-        &["self"],
-        LowLevelType::Address,
-    ),
-    (&["vec", "Vec", "as_ptr"], &["self"], LowLevelType::Address),
     (
         &["sync", "atomic", "AtomicBool", "store"],
         &["self", "val", "order"],

--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -1117,6 +1117,7 @@ fn op_result_can_remove(kind: &crate::model::OpKind) -> bool {
             | OpKind::RecordQuasiImmutField { .. }
             | OpKind::NewTuple { .. }
             | OpKind::NewList { .. }
+            | OpKind::GetSlice { .. }
             | OpKind::ConstInt(_)
             | OpKind::ConstBool(_)
             | OpKind::ConstFloat(_)

--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -2464,6 +2464,12 @@ const FOREIGN_STDLIB_EXTERNALS: &[(&[&str], &[&str], LowLevelType)] = &[
         LowLevelType::Void,
     ),
     (
+        &["core", "slice", "<Impl>", "as_ptr"],
+        &["self"],
+        LowLevelType::Address,
+    ),
+    (&["vec", "Vec", "as_ptr"], &["self"], LowLevelType::Address),
+    (
         &["cell", "Cell", "set"],
         &["self", "val"],
         LowLevelType::Void,

--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -1123,6 +1123,7 @@ fn op_result_can_remove(kind: &crate::model::OpKind) -> bool {
             | OpKind::ConstFloat(_)
             | OpKind::ConstRef(_)
             | OpKind::ConstRefNull
+            | OpKind::ConstNone
             | OpKind::ConstRefAddr(_)
             | OpKind::ConstSymbolic { .. }
     )

--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -2464,17 +2464,6 @@ const FOREIGN_STDLIB_EXTERNALS: &[(&[&str], &[&str], LowLevelType)] = &[
         LowLevelType::Void,
     ),
     (
-        &["core", "slice", "<Impl>", "as_ptr"],
-        &["self"],
-        LowLevelType::Address,
-    ),
-    (&["vec", "Vec", "as_ptr"], &["self"], LowLevelType::Address),
-    (
-        &["sync", "atomic", "AtomicBool", "store"],
-        &["self", "val", "order"],
-        LowLevelType::Void,
-    ),
-    (
         &["cell", "Cell", "set"],
         &["self", "val"],
         LowLevelType::Void,

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -343,6 +343,15 @@ pub fn build_value_to_hlvalue_map(
                 OpKind::ConstRefNull => {
                     map.insert(result, Hlvalue::Constant(const_ref_gcref_constant(None)));
                 }
+                OpKind::ConstNone => {
+                    map.insert(
+                        result,
+                        Hlvalue::Constant(Constant::with_concretetype(
+                            ConstValue::None,
+                            LowLevelType::Void,
+                        )),
+                    );
+                }
                 OpKind::ConstRefAddr(addr) => {
                     map.insert(
                         result,
@@ -1042,6 +1051,7 @@ pub fn translate_op(
         | OpKind::ConstBool(_)
         | OpKind::ConstFloat(_)
         | OpKind::ConstRefNull
+        | OpKind::ConstNone
         | OpKind::ConstRefAddr(_) => Ok(Vec::new()),
         // ─── Skipped: pyre JIT trace markers without a flowspace peer ───
         // `GuardTrue` / `GuardFalse` / `GuardValue` are JIT-side
@@ -2716,6 +2726,16 @@ fn legacy_const_define_hlvalue(
             LowLevelType::Float,
         )))),
         OpKind::ConstRefNull => Ok(Some(Hlvalue::Constant(const_ref_gcref_constant(None)))),
+        // The annotator `None` constant — `Constant(NoneType)`,
+        // `concretetype = Void`.  `immutableconstant` annotates it
+        // `SomeValue::None_` (bookkeeper `immutablevalue(&ConstValue::None)`
+        // → `s_none()`), the shape `decompose_slice_args`'s `stop_is_none`
+        // selection reads for a `[start:]` getslice.  Same `(None, Void)`
+        // carrier `set_return` uses for a void return.
+        OpKind::ConstNone => Ok(Some(Hlvalue::Constant(Constant::with_concretetype(
+            ConstValue::None,
+            LowLevelType::Void,
+        )))),
         OpKind::ConstRefAddr(addr) => Ok(Some(Hlvalue::Constant(const_ref_gcref_constant(Some(
             *addr,
         ))))),

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -1152,6 +1152,24 @@ pub fn translate_op(
             Ok(vec![FlowspaceOp::new("newlist", hl_args, result)])
         }
 
+        // ─── `getslice` — RPython `l[start:stop]` / `space.getslice` ───
+        // `PureOperation` (`operation.py:461`).  The three operands are
+        // `(list, start, stop)`, each routed through `value_map` so the
+        // legacy SpaceOperation references the Hlvalue identities
+        // `checkgraph` tracks.  The annotator's `getslice` handler
+        // (`unaryop.py:420-423`) builds a fresh `listdef.offspring`, and the
+        // rtyper's `rtype_getslice` (`rlist.py:409-414`) lowers it to a
+        // `gendirectcall` of the per-kind `ll_listslice_*` helper.
+        OpKind::GetSlice { args } => {
+            let mut hl_args: Vec<Hlvalue> = Vec::with_capacity(args.len());
+            for (i, var) in args.iter().enumerate() {
+                let role = format!("arg{i}");
+                hl_args.push(lookup_operand(value_map, var, op, &role)?);
+            }
+            let result = resolve_result_hlvalue(op, value_map)?;
+            Ok(vec![FlowspaceOp::new("getslice", hl_args, result)])
+        }
+
         // ─── `NewWithVtable` — boxing GC allocation (`fuse_boxing_alloc`) ───
         // The model-graph op carries the boxing struct leaf `owner` and flows
         // straight to the codewriter/assembler (`new_with_vtable`).  For the
@@ -4362,6 +4380,41 @@ mod tests {
         let lowered = &translated[0];
         assert_eq!(lowered.opname, "add", "opname passes through unchanged");
         assert_eq!(lowered.args.len(), 2);
+    }
+
+    #[test]
+    fn translate_op_getslice_lowers_to_getslice_spaceop() {
+        // GetSlice arm: the three `(list, start, stop)` operands route
+        // through lookup_operand and the result via resolve_result_hlvalue,
+        // producing a flowspace `getslice` SpaceOperation the annotator's
+        // list handler (unaryop.rs:1418) consumes.
+        let mut value_map: HashMap<Variable, Hlvalue> = HashMap::new();
+        let mut graph = LegacyGraph::new("translate_op_getslice_fixture");
+        let vars = mint_vars(&mut graph, 11); // vars[0..11]
+        for slot in [1, 2, 3, 4] {
+            value_map.insert(vars[slot].clone(), Hlvalue::Variable(Variable::new()));
+        }
+
+        let op = SpaceOperation {
+            result: Some(vars[4].clone()),
+            kind: OpKind::GetSlice {
+                args: vec![vars[1].clone(), vars[2].clone(), vars[3].clone()],
+            },
+        };
+        let translated =
+            translate_op(&op, &value_map, &empty_call_registry()).expect("GetSlice arm must lower");
+        assert_eq!(
+            translated.len(),
+            1,
+            "GetSlice lowers to exactly one SpaceOp"
+        );
+        let lowered = &translated[0];
+        assert_eq!(lowered.opname, "getslice", "opname is getslice");
+        assert_eq!(
+            lowered.args.len(),
+            3,
+            "getslice carries (list, start, stop)"
+        );
     }
 
     #[test]

--- a/majit/majit-translate/src/translator/rtyper/legacy_annotator.rs
+++ b/majit/majit-translate/src/translator/rtyper/legacy_annotator.rs
@@ -278,6 +278,11 @@ fn infer_op_type(kind: &OpKind) -> ValueType {
         OpKind::ConstRef(_) | OpKind::ConstRefNull | OpKind::ConstRefAddr(_) => {
             ValueType::Ref(None)
         }
+        // The annotator `None` constant is `Void`-typed (`concretetype =
+        // lltype.Void`), not a ref.  Only reaches the legacy annotator in a
+        // graph that drops before `decompose_slice_args` consumes the
+        // getslice `stop` operand (which discards it for `[start:]`).
+        OpKind::ConstNone => ValueType::Void,
         OpKind::FieldRead { ty, .. } => ty.clone(),
         OpKind::FieldWrite { .. } => ValueType::Void,
         OpKind::New { owner } => ValueType::Ref(Some(owner.clone())),

--- a/majit/majit-translate/src/translator/rtyper/legacy_annotator.rs
+++ b/majit/majit-translate/src/translator/rtyper/legacy_annotator.rs
@@ -396,6 +396,9 @@ fn infer_op_type(kind: &OpKind) -> ValueType {
         // `newlist` yields a `Ref` to the freshly allocated list object
         // (RPython `SomeList` lowers to `Ptr<GcStruct>`).
         OpKind::NewList { .. } => ValueType::Ref(None),
+        // `getslice` yields a `Ref` to the freshly copied list object
+        // (RPython `SomeList` lowers to `Ptr<GcStruct>`).
+        OpKind::GetSlice { .. } => ValueType::Ref(None),
         // `LoweredBlackholeOp` is born only in the opname-dispatch spine
         // (`jtransform_opname::lower_graph`), whose graphs re-enter the
         // shared tail at `finalize_rewritten_graph_to_jitcode` and never

--- a/majit/majit-translate/src/translator/rtyper/llinterp.rs
+++ b/majit/majit-translate/src/translator/rtyper/llinterp.rs
@@ -31,7 +31,7 @@ use crate::tool::ansi_print::AnsiLogger;
 use crate::translator::rtyper::error::TyperError;
 use crate::translator::rtyper::lltypesystem::llmemory;
 use crate::translator::rtyper::lltypesystem::lltype::{
-    _address, _ptr, malloc, LowLevelType, LowLevelValue, MallocFlavor,
+    _address, _ptr, LowLevelType, LowLevelValue, MallocFlavor, malloc,
 };
 use crate::translator::rtyper::rtyper::RPythonTyper;
 use crate::translator::tool::taskengine::TaskError;

--- a/majit/majit-translate/src/translator/rtyper/llinterp.rs
+++ b/majit/majit-translate/src/translator/rtyper/llinterp.rs
@@ -31,7 +31,7 @@ use crate::tool::ansi_print::AnsiLogger;
 use crate::translator::rtyper::error::TyperError;
 use crate::translator::rtyper::lltypesystem::llmemory;
 use crate::translator::rtyper::lltypesystem::lltype::{
-    _address, _ptr, LowLevelType, LowLevelValue, MallocFlavor, malloc,
+    _address, _ptr, malloc, LowLevelType, LowLevelValue, MallocFlavor,
 };
 use crate::translator::rtyper::rtyper::RPythonTyper;
 use crate::translator::tool::taskengine::TaskError;

--- a/majit/majit-translate/src/translator/rtyper/llinterp.rs
+++ b/majit/majit-translate/src/translator/rtyper/llinterp.rs
@@ -906,7 +906,10 @@ impl LLFrame {
                     }
                     _ => MallocFlavor::Gc,
                 };
-                let n = vals[2].as_i64(opname)? as usize;
+                let n_signed = vals[2].as_i64(opname)?;
+                let n = usize::try_from(n_signed).map_err(|_| TaskError {
+                    message: format!("{opname}: negative varsize length {n_signed}"),
+                })?;
                 let ptr = malloc((**t).clone(), Some(n), flavor, false).map_err(|e| TaskError {
                     message: format!("{opname}: {e}"),
                 })?;
@@ -1330,7 +1333,10 @@ mod tests {
         // / `op_cast_uint_to_int` folds (opimpl.py, `r_uint` templates +
         // :465-467), chained straight-line so one eval_graph run exercises
         // all four: 12345 //u 10 = 1234; 1234 %u 10 = 4; intmask(4) = 4;
-        // is_true(4) = True; cast_bool_to_int(True) = 1.
+        // is_true(4) = True; cast_bool_to_int(True) = 1. The result folds the
+        // `cast_uint_to_int` value `s` back in (`int_add(s, c) = 4 + 1 = 5`)
+        // so a broken `uint_floordiv`/`uint_mod` — which `uint_is_true` alone
+        // would collapse to 1 for any nonzero result — changes the return.
         use crate::flowspace::model::Constant as FlowConstant;
         let ten = || Hlvalue::Constant(FlowConstant::new(ConstValue::Int(10)));
 
@@ -1346,6 +1352,8 @@ mod tests {
         t.set_concretetype(Some(LowLevelType::Bool));
         let c = Variable::named("c");
         c.set_concretetype(Some(LowLevelType::Signed));
+        let d = Variable::named("d");
+        d.set_concretetype(Some(LowLevelType::Signed));
 
         let start = Block::shared(vec![x.clone().into()]);
         start.borrow_mut().operations.push(SpaceOperation::new(
@@ -1365,13 +1373,18 @@ mod tests {
         ));
         start.borrow_mut().operations.push(SpaceOperation::new(
             "uint_is_true",
-            vec![s.into()],
+            vec![s.clone().into()],
             t.clone().into(),
         ));
         start.borrow_mut().operations.push(SpaceOperation::new(
             "cast_bool_to_int",
             vec![t.into()],
             c.clone().into(),
+        ));
+        start.borrow_mut().operations.push(SpaceOperation::new(
+            "int_add",
+            vec![s.into(), c.clone().into()],
+            d.clone().into(),
         ));
 
         let retvar = Hlvalue::Variable(Variable::named("ret"));
@@ -1385,7 +1398,7 @@ mod tests {
         )));
         let returnblock = graph.borrow().returnblock.clone();
         start.closeblock(vec![
-            Link::new(vec![c.into()], Some(returnblock), None).into_ref(),
+            Link::new(vec![d.into()], Some(returnblock), None).into_ref(),
         ]);
 
         let interp = Rc::new(LLInterpreter::new(fixture_typer(), false, None));
@@ -1396,7 +1409,8 @@ mod tests {
                 false,
             )
             .expect("uint fold chain should run");
-        assert_eq!(*out.downcast::<i64>().expect("Signed return"), 1);
+        // 4 (cast_uint_to_int of 1234 %u 10) + 1 (cast_bool_to_int of is_true) = 5.
+        assert_eq!(*out.downcast::<i64>().expect("Signed return"), 5);
     }
 
     #[test]

--- a/majit/majit-translate/src/translator/rtyper/rclass.rs
+++ b/majit/majit-translate/src/translator/rtyper/rclass.rs
@@ -3501,7 +3501,24 @@ impl Repr for InstanceRepr {
         // front-end `Discriminant` niche fold's in-place null test; the
         // `option_is_none` post-pass emits this `__discriminant` FieldRead for
         // both niche and aggregate `is_some`/`is_none` receivers.
-        if attr == "__discriminant" {
+        //
+        // Gate on the receiver being a genuinely nullable instance
+        // (`SomeInstance.can_be_none`): only a niche `Option<&T>` reads its
+        // discriminant from the pointer's null-ness.  A statically non-null
+        // receiver — or one whose tag field should exist but is absent through
+        // an unpopulated `allinstancefields`, a mangled-name mismatch, or a
+        // >2-variant enum erased to a bare pointer — must fall through to the
+        // `getclsfield` path below and surface a `TyperError`, matching
+        // upstream (rclass.py:855-857 raises on a missing field), rather than
+        // fabricating a 0/1 value.
+        let receiver_is_nullable_instance = {
+            let args_s = hop.args_s.borrow();
+            matches!(
+                args_s.first(),
+                Some(SomeValue::Instance(inst)) if inst.can_be_none
+            )
+        };
+        if attr == "__discriminant" && receiver_is_nullable_instance {
             use crate::translator::rtyper::rtyper::GenopResult;
             let v_nonzero = hop
                 .genop(

--- a/majit/majit-translate/src/translator/rtyper/rlist.rs
+++ b/majit/majit-translate/src/translator/rtyper/rlist.rs
@@ -30,8 +30,9 @@ use crate::translator::rtyper::lltypesystem::lltype::{
 use crate::translator::rtyper::lltypesystem::rstr::sub_helper_funcptr_constant;
 use crate::translator::rtyper::rmodel::{RTypeResult, Repr, ReprState};
 use crate::translator::rtyper::rtyper::{
-    ConvertedTo, GenopResult, HighLevelOp, LowLevelFunction, RPythonTyper, constant_with_lltype,
-    exception_args, helper_pygraph_from_graph, variable_with_lltype, void_field_const,
+    ConvertedTo, GenopResult, HighLevelOp, LowLevelFunction, RPythonTyper, SliceKind,
+    constant_with_lltype, exception_args, helper_pygraph_from_graph, variable_with_lltype,
+    void_field_const,
 };
 
 /// RPython `class FixedSizeListRepr(AbstractFixedSizeListRepr,
@@ -320,6 +321,20 @@ impl Repr for FixedSizeListRepr {
             self.lltype.clone(),
             self.item_repr.lowleveltype().clone(),
             vlist,
+        )
+    }
+
+    /// RPython `AbstractBaseListRepr.rtype_getslice(r_lst, hop)`
+    /// (`rlist.py:409-414`) — the fixed-size receiver slices into a fresh
+    /// resized list (`hop.r_result`), reading its length via `getarraysize`.
+    fn rtype_getslice(&self, hop: &HighLevelOp) -> RTypeResult {
+        let v_lst = hop.inputarg(ConvertedTo::Repr(self), 0)?;
+        rtype_getslice_via_ll_listslice(
+            hop,
+            ListLayout::Fixed,
+            self.lltype.clone(),
+            self.item_repr.lowleveltype().clone(),
+            v_lst,
         )
     }
 
@@ -631,18 +646,6 @@ pub fn ll_extend_with_str_slice_minusone() -> Result<(), TyperError> {
 
 pub fn ll_extend_with_char_count() -> Result<(), TyperError> {
     Err(rlist_runtime_deferred("ll_extend_with_char_count"))
-}
-
-pub fn ll_listslice_startonly() -> Result<(), TyperError> {
-    Err(rlist_runtime_deferred("ll_listslice_startonly"))
-}
-
-pub fn ll_listslice_startstop() -> Result<(), TyperError> {
-    Err(rlist_runtime_deferred("ll_listslice_startstop"))
-}
-
-pub fn ll_listslice_minusone() -> Result<(), TyperError> {
-    Err(rlist_runtime_deferred("ll_listslice_minusone"))
 }
 
 pub fn ll_listdelslice_startonly() -> Result<(), TyperError> {
@@ -1179,6 +1182,20 @@ impl Repr for ListRepr {
             self.lltype.clone(),
             self.item_repr.lowleveltype().clone(),
             vlist,
+        )
+    }
+
+    /// RPython `AbstractBaseListRepr.rtype_getslice(r_lst, hop)`
+    /// (`rlist.py:409-414`) — `l[start:stop]` allocates a fresh resized list
+    /// and copies the slice via the per-kind `ll_listslice_%s` helper.
+    fn rtype_getslice(&self, hop: &HighLevelOp) -> RTypeResult {
+        let v_lst = hop.inputarg(ConvertedTo::Repr(self), 0)?;
+        rtype_getslice_via_ll_listslice(
+            hop,
+            ListLayout::Resized,
+            self.lltype.clone(),
+            self.item_repr.lowleveltype().clone(),
+            v_lst,
         )
     }
 
@@ -3304,6 +3321,372 @@ fn build_ll_copy_helper_graph(
     ))
 }
 
+/// Emit `new_lst = RESLIST.ll_newlist(newlength)` then
+/// `ll_arraycopy(src_items, dst_items, src_start, 0, newlength)`, and close
+/// `block` returning `new_lst`. Shared tail of the three `ll_listslice_*`
+/// helper graphs — the only per-kind difference (`ll_listslice_%s`,
+/// rlist.py:883-911) is how `newlength` and `src_start` are computed, which
+/// the caller has already materialised into `block`.
+fn emit_listslice_alloc_and_copy(
+    block: &BlockRef,
+    returnblock: &BlockRef,
+    source_layout: ListLayout,
+    result_ptr_lltype: LowLevelType,
+    item_lltype: &LowLevelType,
+    newlist_const: Constant,
+    copy_const: Constant,
+    l: &Variable,
+    src_start: Hlvalue,
+    newlength: &Variable,
+) {
+    let items_ptr = items_array_ptr_lltype(item_lltype);
+    // l = RESLIST.ll_newlist(newlength).
+    let new_lst = variable_with_lltype("new_lst", result_ptr_lltype);
+    block.borrow_mut().operations.push(SpaceOperation::new(
+        "direct_call",
+        vec![
+            Hlvalue::Constant(newlist_const),
+            Hlvalue::Variable(newlength.clone()),
+        ],
+        Hlvalue::Variable(new_lst.clone()),
+    ));
+    // src items (per source layout): a fixed list IS its items array; a resized
+    // header reaches the array through `items`. The result is always resized
+    // (`hop.r_result`), so its items come through `items`.
+    let src_items = match source_layout {
+        ListLayout::Fixed => Hlvalue::Variable(l.clone()),
+        ListLayout::Resized => {
+            let items = variable_with_lltype("src_items", items_ptr.clone());
+            block.borrow_mut().operations.push(SpaceOperation::new(
+                "getfield",
+                vec![Hlvalue::Variable(l.clone()), void_field_const("items")],
+                Hlvalue::Variable(items.clone()),
+            ));
+            Hlvalue::Variable(items)
+        }
+    };
+    let dst_items = variable_with_lltype("dst_items", items_ptr);
+    block.borrow_mut().operations.push(SpaceOperation::new(
+        "getfield",
+        vec![
+            Hlvalue::Variable(new_lst.clone()),
+            void_field_const("items"),
+        ],
+        Hlvalue::Variable(dst_items.clone()),
+    ));
+    // ll_arraycopy(src_items, dst_items, src_start, 0, newlength).
+    let copy_void = variable_with_lltype("v", LowLevelType::Void);
+    block.borrow_mut().operations.push(SpaceOperation::new(
+        "direct_call",
+        vec![
+            Hlvalue::Constant(copy_const),
+            src_items,
+            Hlvalue::Variable(dst_items),
+            src_start,
+            signed_const(0),
+            Hlvalue::Variable(newlength.clone()),
+        ],
+        Hlvalue::Variable(copy_void),
+    ));
+    block.closeblock(vec![
+        Link::new(
+            vec![Hlvalue::Variable(new_lst)],
+            Some(returnblock.clone()),
+            None,
+        )
+        .into_ref(),
+    ]);
+}
+
+/// Synthesise `ll_listslice_startonly(RESLIST, l1, start)` (rlist.py:883-890):
+///
+/// ```python
+/// def ll_listslice_startonly(RESLIST, l1, start):
+///     len1 = l1.ll_length()
+///     newlength = len1 - start
+///     l = RESLIST.ll_newlist(newlength)
+///     ll_arraycopy(l1, l, start, 0, newlength)
+///     return l
+/// ```
+///
+/// The `ll_assert(0 <= start <= len1)` bounds are debug-only (no production
+/// op). Single-block graph: read len, `int_sub` for newlength, then the
+/// shared alloc-and-copy tail with `src_start = start`.
+fn build_ll_listslice_startonly_helper_graph(
+    rtyper: &RPythonTyper,
+    name: &str,
+    source_layout: ListLayout,
+    source_ptr_lltype: LowLevelType,
+    result_ptr_lltype: LowLevelType,
+    item_lltype: LowLevelType,
+    newlist: &LowLevelFunction,
+    arraycopy: &LowLevelFunction,
+) -> Result<PyGraph, TyperError> {
+    let newlist_const = sub_helper_funcptr_constant(rtyper, newlist)?;
+    let copy_const = sub_helper_funcptr_constant(rtyper, arraycopy)?;
+
+    let l_arg = variable_with_lltype("l1", source_ptr_lltype);
+    let start_arg = variable_with_lltype("start", LowLevelType::Signed);
+    let startblock = Block::shared(vec![
+        Hlvalue::Variable(l_arg.clone()),
+        Hlvalue::Variable(start_arg.clone()),
+    ]);
+    let return_var = variable_with_lltype("result", result_ptr_lltype.clone());
+    let mut graph = FunctionGraph::with_return_var(
+        name.to_string(),
+        startblock.clone(),
+        Hlvalue::Variable(return_var),
+    );
+
+    // len1 = l1.ll_length(); newlength = len1 - start.
+    let len1 = emit_list_length_read(&startblock, source_layout, &l_arg);
+    let newlength = variable_with_lltype("newlength", LowLevelType::Signed);
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "int_sub",
+        vec![Hlvalue::Variable(len1), Hlvalue::Variable(start_arg.clone())],
+        Hlvalue::Variable(newlength.clone()),
+    ));
+    emit_listslice_alloc_and_copy(
+        &startblock,
+        &graph.returnblock,
+        source_layout,
+        result_ptr_lltype,
+        &item_lltype,
+        newlist_const,
+        copy_const,
+        &l_arg,
+        Hlvalue::Variable(start_arg),
+        &newlength,
+    );
+
+    let func = GraphFunc::new(
+        name.to_string(),
+        Constant::new(ConstValue::Dict(Default::default())),
+    );
+    graph.func = Some(func.clone());
+    Ok(helper_pygraph_from_graph(
+        graph,
+        vec!["l1".to_string(), "start".to_string()],
+        func,
+    ))
+}
+
+/// Synthesise `ll_listslice_minusone(RESLIST, l1)` (rlist.py:906-911):
+///
+/// ```python
+/// def ll_listslice_minusone(RESLIST, l1):
+///     newlength = l1.ll_length() - 1
+///     l = RESLIST.ll_newlist(newlength)
+///     ll_arraycopy(l1, l, 0, 0, newlength)
+///     return l
+/// ```
+///
+/// `ll_assert(newlength >= 0)` is debug-only. Single-block graph:
+/// `int_sub(len, 1)` then the shared tail with `src_start = 0`.
+fn build_ll_listslice_minusone_helper_graph(
+    rtyper: &RPythonTyper,
+    name: &str,
+    source_layout: ListLayout,
+    source_ptr_lltype: LowLevelType,
+    result_ptr_lltype: LowLevelType,
+    item_lltype: LowLevelType,
+    newlist: &LowLevelFunction,
+    arraycopy: &LowLevelFunction,
+) -> Result<PyGraph, TyperError> {
+    let newlist_const = sub_helper_funcptr_constant(rtyper, newlist)?;
+    let copy_const = sub_helper_funcptr_constant(rtyper, arraycopy)?;
+
+    let l_arg = variable_with_lltype("l1", source_ptr_lltype);
+    let startblock = Block::shared(vec![Hlvalue::Variable(l_arg.clone())]);
+    let return_var = variable_with_lltype("result", result_ptr_lltype.clone());
+    let mut graph = FunctionGraph::with_return_var(
+        name.to_string(),
+        startblock.clone(),
+        Hlvalue::Variable(return_var),
+    );
+
+    // newlength = l1.ll_length() - 1.
+    let len1 = emit_list_length_read(&startblock, source_layout, &l_arg);
+    let newlength = variable_with_lltype("newlength", LowLevelType::Signed);
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "int_sub",
+        vec![Hlvalue::Variable(len1), signed_const(1)],
+        Hlvalue::Variable(newlength.clone()),
+    ));
+    emit_listslice_alloc_and_copy(
+        &startblock,
+        &graph.returnblock,
+        source_layout,
+        result_ptr_lltype,
+        &item_lltype,
+        newlist_const,
+        copy_const,
+        &l_arg,
+        signed_const(0),
+        &newlength,
+    );
+
+    let func = GraphFunc::new(
+        name.to_string(),
+        Constant::new(ConstValue::Dict(Default::default())),
+    );
+    graph.func = Some(func.clone());
+    Ok(helper_pygraph_from_graph(
+        graph,
+        vec!["l1".to_string()],
+        func,
+    ))
+}
+
+/// Synthesise `ll_listslice_startstop(RESLIST, l1, start, stop)`
+/// (rlist.py:893-904):
+///
+/// ```python
+/// def ll_listslice_startstop(RESLIST, l1, start, stop):
+///     length = l1.ll_length()
+///     if stop > length:
+///         stop = length
+///     newlength = stop - start
+///     l = RESLIST.ll_newlist(newlength)
+///     ll_arraycopy(l1, l, start, 0, newlength)
+///     return l
+/// ```
+///
+/// The `stop > length` clamp is a two-way branch that merges `stop` back;
+/// `ll_assert(0 <= start <= length and stop >= start)` is debug-only. Three
+/// blocks: start (read len, `int_gt`) → clamp (pass `length` as the merged
+/// stop) / merge (`int_sub` newlength, then the shared alloc-and-copy tail).
+fn build_ll_listslice_startstop_helper_graph(
+    rtyper: &RPythonTyper,
+    name: &str,
+    source_layout: ListLayout,
+    source_ptr_lltype: LowLevelType,
+    result_ptr_lltype: LowLevelType,
+    item_lltype: LowLevelType,
+    newlist: &LowLevelFunction,
+    arraycopy: &LowLevelFunction,
+) -> Result<PyGraph, TyperError> {
+    let newlist_const = sub_helper_funcptr_constant(rtyper, newlist)?;
+    let copy_const = sub_helper_funcptr_constant(rtyper, arraycopy)?;
+
+    let l_arg = variable_with_lltype("l1", source_ptr_lltype.clone());
+    let start_arg = variable_with_lltype("start", LowLevelType::Signed);
+    let stop_arg = variable_with_lltype("stop", LowLevelType::Signed);
+    let startblock = Block::shared(vec![
+        Hlvalue::Variable(l_arg.clone()),
+        Hlvalue::Variable(start_arg.clone()),
+        Hlvalue::Variable(stop_arg.clone()),
+    ]);
+    let return_var = variable_with_lltype("result", result_ptr_lltype.clone());
+    let mut graph = FunctionGraph::with_return_var(
+        name.to_string(),
+        startblock.clone(),
+        Hlvalue::Variable(return_var),
+    );
+
+    // merge block carries (l1, start, stop) with stop already clamped to length.
+    let l_m = variable_with_lltype("l1", source_ptr_lltype.clone());
+    let start_m = variable_with_lltype("start", LowLevelType::Signed);
+    let stop_m = variable_with_lltype("stop", LowLevelType::Signed);
+    let block_merge = Block::shared(vec![
+        Hlvalue::Variable(l_m.clone()),
+        Hlvalue::Variable(start_m.clone()),
+        Hlvalue::Variable(stop_m.clone()),
+    ]);
+    // clamp block carries (l1, start, length) — sets stop = length on the merge edge.
+    let l_c = variable_with_lltype("l1", source_ptr_lltype);
+    let start_c = variable_with_lltype("start", LowLevelType::Signed);
+    let len_c = variable_with_lltype("length", LowLevelType::Signed);
+    let block_clamp = Block::shared(vec![
+        Hlvalue::Variable(l_c.clone()),
+        Hlvalue::Variable(start_c.clone()),
+        Hlvalue::Variable(len_c.clone()),
+    ]);
+
+    // ---- startblock: length = ll_length; too_big = int_gt(stop, length); branch.
+    let length = emit_list_length_read(&startblock, source_layout, &l_arg);
+    let too_big = variable_with_lltype("too_big", LowLevelType::Bool);
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "int_gt",
+        vec![
+            Hlvalue::Variable(stop_arg.clone()),
+            Hlvalue::Variable(length.clone()),
+        ],
+        Hlvalue::Variable(too_big.clone()),
+    ));
+    startblock.borrow_mut().exitswitch = Some(Hlvalue::Variable(too_big));
+    startblock.closeblock(vec![
+        Link::new(
+            vec![
+                Hlvalue::Variable(l_arg.clone()),
+                Hlvalue::Variable(start_arg.clone()),
+                Hlvalue::Variable(length),
+            ],
+            Some(block_clamp.clone()),
+            Some(bool_const(true)),
+        )
+        .into_ref(),
+        Link::new(
+            vec![
+                Hlvalue::Variable(l_arg),
+                Hlvalue::Variable(start_arg),
+                Hlvalue::Variable(stop_arg),
+            ],
+            Some(block_merge.clone()),
+            Some(bool_const(false)),
+        )
+        .into_ref(),
+    ]);
+
+    // ---- block_clamp: stop := length. Merge edge passes `length` as stop.
+    block_clamp.closeblock(vec![
+        Link::new(
+            vec![
+                Hlvalue::Variable(l_c),
+                Hlvalue::Variable(start_c),
+                Hlvalue::Variable(len_c),
+            ],
+            Some(block_merge.clone()),
+            None,
+        )
+        .into_ref(),
+    ]);
+
+    // ---- block_merge: newlength = stop - start; alloc + copy.
+    let newlength = variable_with_lltype("newlength", LowLevelType::Signed);
+    block_merge.borrow_mut().operations.push(SpaceOperation::new(
+        "int_sub",
+        vec![
+            Hlvalue::Variable(stop_m),
+            Hlvalue::Variable(start_m.clone()),
+        ],
+        Hlvalue::Variable(newlength.clone()),
+    ));
+    emit_listslice_alloc_and_copy(
+        &block_merge,
+        &graph.returnblock,
+        source_layout,
+        result_ptr_lltype,
+        &item_lltype,
+        newlist_const,
+        copy_const,
+        &l_m,
+        Hlvalue::Variable(start_m),
+        &newlength,
+    );
+
+    let func = GraphFunc::new(
+        name.to_string(),
+        Constant::new(ConstValue::Dict(Default::default())),
+    );
+    graph.func = Some(func.clone());
+    Ok(helper_pygraph_from_graph(
+        graph,
+        vec!["l1".to_string(), "start".to_string(), "stop".to_string()],
+        func,
+    ))
+}
+
 /// Derive the [`ListLayout`] from a list repr's `Ptr` lltype: a resized list
 /// is `Ptr(GcStruct("list", …))`, a fixed list is `Ptr(GcArray)`.
 fn list_layout_from_lltype(ptr_lltype: &LowLevelType) -> Result<ListLayout, TyperError> {
@@ -3395,6 +3778,147 @@ fn rtype_bltn_list_via_ll_copy(
         )?
     };
     hop.gendirectcall(&copy, vlist)
+}
+
+/// RPython `AbstractBaseListRepr.rtype_getslice(r_lst, hop)` (rlist.py:409-414):
+///
+/// ```python
+/// def rtype_getslice(r_lst, hop):
+///     cRESLIST = hop.inputconst(Void, hop.r_result.LIST)
+///     v_lst = hop.inputarg(r_lst, arg=0)
+///     kind, vlist = hop.decompose_slice_args()
+///     ll_listslice = globals()['ll_listslice_%s' % kind]
+///     return hop.gendirectcall(ll_listslice, cRESLIST, v_lst, *vlist)
+/// ```
+///
+/// `hop.r_result` is always the resized `ListRepr` (`listdef.offspring` yields
+/// a fresh growable list, unaryop.py:420-423); the receiver's `source_layout`
+/// varies (a `FixedSizeListRepr` slice source is possible). Mints
+/// `ll_arraycopy` (general 5-arg), `ll_newlist`, and the per-`kind`
+/// `ll_listslice_%s` helper in dependency order, then `gendirectcall`s it. The
+/// `cRESLIST` Void const is implicit — the result repr is `hop.r_result`, which
+/// the helper builders read directly.
+fn rtype_getslice_via_ll_listslice(
+    hop: &HighLevelOp,
+    source_layout: ListLayout,
+    source_ptr_lltype: LowLevelType,
+    item_lltype: LowLevelType,
+    v_lst: Hlvalue,
+) -> RTypeResult {
+    let (kind, vlist) = hop.decompose_slice_args()?;
+
+    let r_result = hop
+        .r_result
+        .borrow()
+        .as_ref()
+        .map(Arc::clone)
+        .ok_or_else(|| TyperError::message("rtype_getslice: r_result not populated"))?;
+    let result_ptr_lltype = r_result.lowleveltype().clone();
+    let items_ptr = items_array_ptr_lltype(&item_lltype);
+
+    // ll_arraycopy(src, dst, src_start, dst_start, length) — general 5-arg
+    // (rgc.py:365): a slice copies from `src_start = start != 0`, so the
+    // start=0 specialisation used by `ll_copy` does not fit.
+    let arraycopy = {
+        let item = item_lltype.clone();
+        hop.rtyper.lowlevel_helper_function_with_builder(
+            "ll_arraycopy".to_string(),
+            vec![
+                items_ptr.clone(),
+                items_ptr.clone(),
+                LowLevelType::Signed,
+                LowLevelType::Signed,
+                LowLevelType::Signed,
+            ],
+            LowLevelType::Void,
+            move |_rtyper, _args, _result| {
+                build_ll_arraycopy_general_helper_graph("ll_arraycopy", item.clone())
+            },
+        )?
+    };
+    let newlist = {
+        let result_ptr = result_ptr_lltype.clone();
+        let item = item_lltype.clone();
+        let result_layout = list_layout_from_lltype(&result_ptr_lltype)?;
+        hop.rtyper.lowlevel_helper_function_with_builder(
+            "ll_newlist".to_string(),
+            vec![LowLevelType::Signed],
+            result_ptr_lltype.clone(),
+            move |_rtyper, _args, _result| {
+                build_ll_newlist_helper_graph(
+                    "ll_newlist",
+                    result_layout,
+                    result_ptr.clone(),
+                    item.clone(),
+                )
+            },
+        )?
+    };
+
+    // The per-kind `ll_listslice_%s` helper (rlist.py:883-911).
+    let (helper_name, helper_args): (&str, Vec<LowLevelType>) = match kind {
+        SliceKind::MinusOne => ("ll_listslice_minusone", vec![source_ptr_lltype.clone()]),
+        SliceKind::StartOnly => (
+            "ll_listslice_startonly",
+            vec![source_ptr_lltype.clone(), LowLevelType::Signed],
+        ),
+        SliceKind::StartStop => (
+            "ll_listslice_startstop",
+            vec![
+                source_ptr_lltype.clone(),
+                LowLevelType::Signed,
+                LowLevelType::Signed,
+            ],
+        ),
+    };
+    let listslice = {
+        let name = helper_name.to_string();
+        let source_ptr = source_ptr_lltype.clone();
+        let result_ptr = result_ptr_lltype.clone();
+        let item = item_lltype.clone();
+        hop.rtyper.lowlevel_helper_function_with_builder(
+            helper_name.to_string(),
+            helper_args,
+            result_ptr_lltype.clone(),
+            move |rtyper, _args, _result| match kind {
+                SliceKind::MinusOne => build_ll_listslice_minusone_helper_graph(
+                    rtyper,
+                    &name,
+                    source_layout,
+                    source_ptr.clone(),
+                    result_ptr.clone(),
+                    item.clone(),
+                    &newlist,
+                    &arraycopy,
+                ),
+                SliceKind::StartOnly => build_ll_listslice_startonly_helper_graph(
+                    rtyper,
+                    &name,
+                    source_layout,
+                    source_ptr.clone(),
+                    result_ptr.clone(),
+                    item.clone(),
+                    &newlist,
+                    &arraycopy,
+                ),
+                SliceKind::StartStop => build_ll_listslice_startstop_helper_graph(
+                    rtyper,
+                    &name,
+                    source_layout,
+                    source_ptr.clone(),
+                    result_ptr.clone(),
+                    item.clone(),
+                    &newlist,
+                    &arraycopy,
+                ),
+            },
+        )?
+    };
+
+    // gendirectcall(ll_listslice, v_lst, *vlist).
+    let mut call_args = vec![v_lst];
+    call_args.extend(vlist);
+    hop.gendirectcall(&listslice, call_args)
 }
 
 /// `FixedSizeListRepr` (bare `Ptr(GcArray)`) vs the resized `ListRepr`
@@ -5458,6 +5982,253 @@ mod tests {
         );
     }
 
+    /// `l[start:stop]` on a resized `ListRepr` with non-constant nonneg int
+    /// bounds decomposes to `"startstop"` (rtyper.py:781) and lowers to
+    /// `gendirectcall(ll_listslice_startstop, l, start, stop)`, which mints the
+    /// `ll_listslice_startstop` / `ll_newlist` / `ll_arraycopy` helper graphs
+    /// (rlist.py:893-904).
+    #[test]
+    fn translate_operation_getslice_startstop_emits_ll_listslice_helpers() {
+        use crate::annotator::model::{SomeInteger, SomeValue};
+        use crate::flowspace::model::SpaceOperation;
+        use std::cell::RefCell as StdRef;
+
+        let ann = RPythonAnnotator::new(None, None, None, false);
+        let rtyper = Rc::new(RPythonTyper::new(&ann));
+        rtyper
+            .initialize_exceptiondata()
+            .expect("initialize_exceptiondata in test setup");
+        let r_int: Arc<dyn Repr> = Arc::new(IntegerRepr::new(LowLevelType::Signed, Some("int_")));
+        let r_list: Arc<dyn Repr> =
+            Arc::new(ListRepr::new(&rtyper, r_int.clone()).expect("ListRepr::new"));
+        let list_lltype = r_list.lowleveltype().clone();
+
+        let v_lst = Variable::new();
+        v_lst.set_concretetype(Some(list_lltype));
+        let v_start = Variable::new();
+        v_start.set_concretetype(Some(LowLevelType::Signed));
+        let v_stop = Variable::new();
+        v_stop.set_concretetype(Some(LowLevelType::Signed));
+        let v_lst_h = Hlvalue::Variable(v_lst);
+        let v_start_h = Hlvalue::Variable(v_start);
+        let v_stop_h = Hlvalue::Variable(v_stop);
+        let result_var = Variable::new();
+        let spaceop = SpaceOperation::new(
+            "getslice".to_string(),
+            vec![v_lst_h.clone(), v_start_h.clone(), v_stop_h.clone()],
+            Hlvalue::Variable(result_var),
+        );
+        let llops = Rc::new(StdRef::new(LowLevelOpList::new(rtyper.clone(), None)));
+        let hop = HighLevelOp::new(rtyper.clone(), spaceop, Vec::new(), llops);
+        hop.args_v.borrow_mut().push(v_lst_h);
+        hop.args_s.borrow_mut().push(SomeValue::Impossible);
+        hop.args_r.borrow_mut().push(Some(r_list.clone()));
+        // Non-constant nonneg int bounds → the "startstop" arm.
+        hop.args_v.borrow_mut().push(v_start_h);
+        hop.args_s
+            .borrow_mut()
+            .push(SomeValue::Integer(SomeInteger::new(/* nonneg */ true, false)));
+        hop.args_r.borrow_mut().push(Some(r_int.clone()));
+        hop.args_v.borrow_mut().push(v_stop_h);
+        hop.args_s
+            .borrow_mut()
+            .push(SomeValue::Integer(SomeInteger::new(/* nonneg */ true, false)));
+        hop.args_r.borrow_mut().push(Some(r_int.clone()));
+        // The slice result is a fresh resized list (listdef.offspring).
+        *hop.r_result.borrow_mut() = Some(r_list.clone());
+
+        let out = rtyper
+            .translate_operation(&hop)
+            .expect("translate_operation getslice must dispatch to rtype_getslice")
+            .expect("getslice returns the fresh list Variable");
+        let Hlvalue::Variable(_) = out else {
+            panic!("getslice must return a Variable (the ll_listslice result)");
+        };
+        // The lowering is a single `direct_call(ll_listslice_startstop, …)`.
+        let ops = hop.llops.borrow();
+        let direct_calls = ops
+            .ops
+            .iter()
+            .filter(|op| op.opname == "direct_call")
+            .count();
+        assert_eq!(
+            direct_calls, 1,
+            "expected a single ll_listslice_startstop direct_call, got {:?}",
+            ops.ops.iter().map(|op| &op.opname).collect::<Vec<_>>()
+        );
+        // The per-kind + support helper graphs were minted under their names.
+        let translator = ann.translator.clone();
+        let names: Vec<String> = translator
+            .graphs
+            .borrow()
+            .iter()
+            .map(|g| g.borrow().name.clone())
+            .collect();
+        for expected in ["ll_listslice_startstop", "ll_newlist", "ll_arraycopy"] {
+            assert!(
+                names.iter().any(|n| n == expected),
+                "getslice must mint an {expected} helper graph, got {names:?}"
+            );
+        }
+    }
+
+    /// `l[start:]` — non-constant nonneg start, constant `None` stop —
+    /// decomposes to `"startonly"` (rtyper.py:778-779) and lowers to
+    /// `gendirectcall(ll_listslice_startonly, l, start)` (rlist.py:883-890).
+    #[test]
+    fn translate_operation_getslice_startonly_emits_startonly_helper() {
+        use crate::annotator::model::{SomeInteger, SomeValue, s_none};
+        use crate::flowspace::model::{Constant, SpaceOperation};
+        use std::cell::RefCell as StdRef;
+
+        let ann = RPythonAnnotator::new(None, None, None, false);
+        let rtyper = Rc::new(RPythonTyper::new(&ann));
+        rtyper
+            .initialize_exceptiondata()
+            .expect("initialize_exceptiondata in test setup");
+        let r_int: Arc<dyn Repr> = Arc::new(IntegerRepr::new(LowLevelType::Signed, Some("int_")));
+        let r_list: Arc<dyn Repr> =
+            Arc::new(ListRepr::new(&rtyper, r_int.clone()).expect("ListRepr::new"));
+        let list_lltype = r_list.lowleveltype().clone();
+
+        let v_lst = Variable::new();
+        v_lst.set_concretetype(Some(list_lltype));
+        let v_start = Variable::new();
+        v_start.set_concretetype(Some(LowLevelType::Signed));
+        let v_lst_h = Hlvalue::Variable(v_lst);
+        let v_start_h = Hlvalue::Variable(v_start);
+        // stop is a constant None (the [start:] shape).
+        let c_stop = Hlvalue::Constant(Constant::new(ConstValue::None));
+        let result_var = Variable::new();
+        let spaceop = SpaceOperation::new(
+            "getslice".to_string(),
+            vec![v_lst_h.clone(), v_start_h.clone(), c_stop.clone()],
+            Hlvalue::Variable(result_var),
+        );
+        let llops = Rc::new(StdRef::new(LowLevelOpList::new(rtyper.clone(), None)));
+        let hop = HighLevelOp::new(rtyper.clone(), spaceop, Vec::new(), llops);
+        hop.args_v.borrow_mut().push(v_lst_h);
+        hop.args_s.borrow_mut().push(SomeValue::Impossible);
+        hop.args_r.borrow_mut().push(Some(r_list.clone()));
+        hop.args_v.borrow_mut().push(v_start_h);
+        hop.args_s
+            .borrow_mut()
+            .push(SomeValue::Integer(SomeInteger::new(/* nonneg */ true, false)));
+        hop.args_r.borrow_mut().push(Some(r_int.clone()));
+        hop.args_v.borrow_mut().push(c_stop);
+        hop.args_s.borrow_mut().push(s_none());
+        hop.args_r.borrow_mut().push(Some(r_int.clone()));
+        *hop.r_result.borrow_mut() = Some(r_list.clone());
+
+        rtyper
+            .translate_operation(&hop)
+            .expect("translate_operation getslice must dispatch to rtype_getslice")
+            .expect("getslice returns the fresh list Variable");
+        let ops = hop.llops.borrow();
+        let direct_calls = ops
+            .ops
+            .iter()
+            .filter(|op| op.opname == "direct_call")
+            .count();
+        assert_eq!(
+            direct_calls, 1,
+            "expected a single ll_listslice_startonly direct_call, got {:?}",
+            ops.ops.iter().map(|op| &op.opname).collect::<Vec<_>>()
+        );
+        let translator = ann.translator.clone();
+        let names: Vec<String> = translator
+            .graphs
+            .borrow()
+            .iter()
+            .map(|g| g.borrow().name.clone())
+            .collect();
+        assert!(
+            names.iter().any(|n| n == "ll_listslice_startonly"),
+            "getslice [start:] must mint an ll_listslice_startonly helper graph, got {names:?}"
+        );
+    }
+
+    /// `l[:-1]` decomposes to `"minusone"` (rtyper.py:772) — start const 0,
+    /// stop const -1, no runtime bound args — and lowers to
+    /// `gendirectcall(ll_listslice_minusone, l)` (rlist.py:906-911).
+    #[test]
+    fn translate_operation_getslice_minusone_emits_minusone_helper() {
+        use crate::annotator::model::{SomeInteger, SomeValue};
+        use crate::flowspace::model::{Constant, SpaceOperation};
+        use std::cell::RefCell as StdRef;
+
+        // A constant `SomeInteger` carrying `value` — `is_constant()` reads
+        // `const_box`, `const_()` reads its `ConstValue`.
+        fn const_int(value: i64) -> SomeValue {
+            let mut si = SomeInteger::new(value >= 0, false);
+            si.base.const_box = Some(Constant::new(ConstValue::Int(value)));
+            SomeValue::Integer(si)
+        }
+
+        let ann = RPythonAnnotator::new(None, None, None, false);
+        let rtyper = Rc::new(RPythonTyper::new(&ann));
+        rtyper
+            .initialize_exceptiondata()
+            .expect("initialize_exceptiondata in test setup");
+        let r_int: Arc<dyn Repr> = Arc::new(IntegerRepr::new(LowLevelType::Signed, Some("int_")));
+        let r_list: Arc<dyn Repr> =
+            Arc::new(ListRepr::new(&rtyper, r_int.clone()).expect("ListRepr::new"));
+        let list_lltype = r_list.lowleveltype().clone();
+
+        let v_lst = Variable::new();
+        v_lst.set_concretetype(Some(list_lltype));
+        let v_lst_h = Hlvalue::Variable(v_lst);
+        // start = const 0, stop = const -1 (the [:-1] shape).
+        let c_start = Hlvalue::Constant(Constant::new(ConstValue::Int(0)));
+        let c_stop = Hlvalue::Constant(Constant::new(ConstValue::Int(-1)));
+        let result_var = Variable::new();
+        let spaceop = SpaceOperation::new(
+            "getslice".to_string(),
+            vec![v_lst_h.clone(), c_start.clone(), c_stop.clone()],
+            Hlvalue::Variable(result_var),
+        );
+        let llops = Rc::new(StdRef::new(LowLevelOpList::new(rtyper.clone(), None)));
+        let hop = HighLevelOp::new(rtyper.clone(), spaceop, Vec::new(), llops);
+        hop.args_v.borrow_mut().push(v_lst_h);
+        hop.args_s.borrow_mut().push(SomeValue::Impossible);
+        hop.args_r.borrow_mut().push(Some(r_list.clone()));
+        // Constant bounds carried on the annotation (is_constant() reads const_box).
+        hop.args_v.borrow_mut().push(c_start);
+        hop.args_s.borrow_mut().push(const_int(0));
+        hop.args_r.borrow_mut().push(Some(r_int.clone()));
+        hop.args_v.borrow_mut().push(c_stop);
+        hop.args_s.borrow_mut().push(const_int(-1));
+        hop.args_r.borrow_mut().push(Some(r_int.clone()));
+        *hop.r_result.borrow_mut() = Some(r_list.clone());
+
+        rtyper
+            .translate_operation(&hop)
+            .expect("translate_operation getslice must dispatch to rtype_getslice")
+            .expect("getslice returns the fresh list Variable");
+        let ops = hop.llops.borrow();
+        let direct_calls = ops
+            .ops
+            .iter()
+            .filter(|op| op.opname == "direct_call")
+            .count();
+        assert_eq!(
+            direct_calls, 1,
+            "expected a single ll_listslice_minusone direct_call, got {:?}",
+            ops.ops.iter().map(|op| &op.opname).collect::<Vec<_>>()
+        );
+        let translator = ann.translator.clone();
+        let names: Vec<String> = translator
+            .graphs
+            .borrow()
+            .iter()
+            .map(|g| g.borrow().name.clone())
+            .collect();
+        assert!(
+            names.iter().any(|n| n == "ll_listslice_minusone"),
+            "getslice [:-1] must mint an ll_listslice_minusone helper graph, got {names:?}"
+        );
+    }
+
     #[test]
     fn makerepr_resized_somelist_routes_to_list_repr() {
         let rtyper = fresh_rtyper_live();
@@ -6313,9 +7084,9 @@ mod tests {
         assert!(err.is_missing_rtype_operation());
         assert!(err.to_string().contains("ll_append"));
 
-        let err = ll_listslice_startstop().expect_err("runtime helper deferred");
+        let err = ll_listsetslice().expect_err("runtime helper deferred");
         assert!(err.is_missing_rtype_operation());
-        assert!(err.to_string().contains("ll_listslice_startstop"));
+        assert!(err.to_string().contains("ll_listsetslice"));
     }
 
     /// The `ll_reverse` helper is a four-block swap loop: `startblock`

--- a/majit/majit-translate/src/translator/rtyper/rlist.rs
+++ b/majit/majit-translate/src/translator/rtyper/rlist.rs
@@ -3443,7 +3443,10 @@ fn build_ll_listslice_startonly_helper_graph(
     let newlength = variable_with_lltype("newlength", LowLevelType::Signed);
     startblock.borrow_mut().operations.push(SpaceOperation::new(
         "int_sub",
-        vec![Hlvalue::Variable(len1), Hlvalue::Variable(start_arg.clone())],
+        vec![
+            Hlvalue::Variable(len1),
+            Hlvalue::Variable(start_arg.clone()),
+        ],
         Hlvalue::Variable(newlength.clone()),
     ));
     emit_listslice_alloc_and_copy(
@@ -3654,14 +3657,17 @@ fn build_ll_listslice_startstop_helper_graph(
 
     // ---- block_merge: newlength = stop - start; alloc + copy.
     let newlength = variable_with_lltype("newlength", LowLevelType::Signed);
-    block_merge.borrow_mut().operations.push(SpaceOperation::new(
-        "int_sub",
-        vec![
-            Hlvalue::Variable(stop_m),
-            Hlvalue::Variable(start_m.clone()),
-        ],
-        Hlvalue::Variable(newlength.clone()),
-    ));
+    block_merge
+        .borrow_mut()
+        .operations
+        .push(SpaceOperation::new(
+            "int_sub",
+            vec![
+                Hlvalue::Variable(stop_m),
+                Hlvalue::Variable(start_m.clone()),
+            ],
+            Hlvalue::Variable(newlength.clone()),
+        ));
     emit_listslice_alloc_and_copy(
         &block_merge,
         &graph.returnblock,
@@ -6027,12 +6033,16 @@ mod tests {
         hop.args_v.borrow_mut().push(v_start_h);
         hop.args_s
             .borrow_mut()
-            .push(SomeValue::Integer(SomeInteger::new(/* nonneg */ true, false)));
+            .push(SomeValue::Integer(SomeInteger::new(
+                /* nonneg */ true, false,
+            )));
         hop.args_r.borrow_mut().push(Some(r_int.clone()));
         hop.args_v.borrow_mut().push(v_stop_h);
         hop.args_s
             .borrow_mut()
-            .push(SomeValue::Integer(SomeInteger::new(/* nonneg */ true, false)));
+            .push(SomeValue::Integer(SomeInteger::new(
+                /* nonneg */ true, false,
+            )));
         hop.args_r.borrow_mut().push(Some(r_int.clone()));
         // The slice result is a fresh resized list (listdef.offspring).
         *hop.r_result.borrow_mut() = Some(r_list.clone());
@@ -6052,7 +6062,8 @@ mod tests {
             .filter(|op| op.opname == "direct_call")
             .count();
         assert_eq!(
-            direct_calls, 1,
+            direct_calls,
+            1,
             "expected a single ll_listslice_startstop direct_call, got {:?}",
             ops.ops.iter().map(|op| &op.opname).collect::<Vec<_>>()
         );
@@ -6113,7 +6124,9 @@ mod tests {
         hop.args_v.borrow_mut().push(v_start_h);
         hop.args_s
             .borrow_mut()
-            .push(SomeValue::Integer(SomeInteger::new(/* nonneg */ true, false)));
+            .push(SomeValue::Integer(SomeInteger::new(
+                /* nonneg */ true, false,
+            )));
         hop.args_r.borrow_mut().push(Some(r_int.clone()));
         hop.args_v.borrow_mut().push(c_stop);
         hop.args_s.borrow_mut().push(s_none());
@@ -6131,7 +6144,8 @@ mod tests {
             .filter(|op| op.opname == "direct_call")
             .count();
         assert_eq!(
-            direct_calls, 1,
+            direct_calls,
+            1,
             "expected a single ll_listslice_startonly direct_call, got {:?}",
             ops.ops.iter().map(|op| &op.opname).collect::<Vec<_>>()
         );
@@ -6212,7 +6226,8 @@ mod tests {
             .filter(|op| op.opname == "direct_call")
             .count();
         assert_eq!(
-            direct_calls, 1,
+            direct_calls,
+            1,
             "expected a single ll_listslice_minusone direct_call, got {:?}",
             ops.ops.iter().map(|op| &op.opname).collect::<Vec<_>>()
         );

--- a/majit/majit-translate/src/translator/rtyper/rtyper.rs
+++ b/majit/majit-translate/src/translator/rtyper/rtyper.rs
@@ -2816,20 +2816,27 @@ impl HighLevelOp {
         }
         if let SomeValue::Integer(si) = &s_stop {
             if !si.nonneg {
-                return Err(TyperError::message("slice stop must be proved non-negative"));
+                return Err(TyperError::message(
+                    "slice stop must be proved non-negative",
+                ));
             }
         }
 
         // v_start = inputconst(Signed, 0) when start is a constant None, else inputarg.
-        let start_is_none = s_start.is_constant() && matches!(s_start.const_(), Some(ConstValue::None));
+        let start_is_none =
+            s_start.is_constant() && matches!(s_start.const_(), Some(ConstValue::None));
         let v_start = if start_is_none {
-            Hlvalue::Constant(Self::inputconst(&LowLevelType::Signed, &ConstValue::Int(0))?)
+            Hlvalue::Constant(Self::inputconst(
+                &LowLevelType::Signed,
+                &ConstValue::Int(0),
+            )?)
         } else {
             self.inputarg(&LowLevelType::Signed, 1)?
         };
 
         // stop constant None -> "startonly"; else "startstop".
-        let stop_is_none = s_stop.is_constant() && matches!(s_stop.const_(), Some(ConstValue::None));
+        let stop_is_none =
+            s_stop.is_constant() && matches!(s_stop.const_(), Some(ConstValue::None));
         if stop_is_none {
             Ok((SliceKind::StartOnly, vec![v_start]))
         } else {

--- a/majit/majit-translate/src/translator/rtyper/rtyper.rs
+++ b/majit/majit-translate/src/translator/rtyper/rtyper.rs
@@ -2754,6 +2754,104 @@ impl HighLevelOp {
         self.args_r.borrow_mut().insert(0, Some(r_newfirstarg));
         Ok(())
     }
+
+    /// RPython `HighLevelOp.decompose_slice_args(self)` (rtyper.py:764-782).
+    ///
+    /// ```python
+    /// def decompose_slice_args(self):
+    ///     # Select which kind of slicing is needed.  We support:
+    ///     #   * [start:]
+    ///     #   * [start:stop]
+    ///     #   * [:-1]
+    ///     s_start = self.args_s[1]
+    ///     s_stop = self.args_s[2]
+    ///     if (s_start.is_constant() and s_start.const in (None, 0) and
+    ///         s_stop.is_constant() and s_stop.const == -1):
+    ///         return "minusone", []
+    ///     if isinstance(s_start, annmodel.SomeInteger):
+    ///         if not s_start.nonneg:
+    ///             raise TyperError("slice start must be proved non-negative")
+    ///     if isinstance(s_stop, annmodel.SomeInteger):
+    ///         if not s_stop.nonneg:
+    ///             raise TyperError("slice stop must be proved non-negative")
+    ///     if s_start.is_constant() and s_start.const is None:
+    ///         v_start = inputconst(Signed, 0)
+    ///     else:
+    ///         v_start = self.inputarg(Signed, arg=1)
+    ///     if s_stop.is_constant() and s_stop.const is None:
+    ///         return "startonly", [v_start]
+    ///     else:
+    ///         v_stop = self.inputarg(Signed, arg=2)
+    ///         return "startstop", [v_start, v_stop]
+    /// ```
+    pub fn decompose_slice_args(&self) -> Result<(SliceKind, Vec<Hlvalue>), TyperError> {
+        let (s_start, s_stop) = {
+            let args_s = self.args_s.borrow();
+            let s_start = args_s.get(1).cloned().ok_or_else(|| {
+                TyperError::message("decompose_slice_args: args_s[1] (start) missing")
+            })?;
+            let s_stop = args_s.get(2).cloned().ok_or_else(|| {
+                TyperError::message("decompose_slice_args: args_s[2] (stop) missing")
+            })?;
+            (s_start, s_stop)
+        };
+
+        // start in (None, 0) and stop == -1 -> "minusone".
+        let start_none_or_zero = matches!(
+            s_start.const_(),
+            Some(ConstValue::None) | Some(ConstValue::Int(0))
+        );
+        let stop_minus_one = matches!(s_stop.const_(), Some(ConstValue::Int(-1)));
+        if s_start.is_constant() && start_none_or_zero && s_stop.is_constant() && stop_minus_one {
+            return Ok((SliceKind::MinusOne, vec![]));
+        }
+
+        // Non-constant integer bounds must be proved non-negative.
+        if let SomeValue::Integer(si) = &s_start {
+            if !si.nonneg {
+                return Err(TyperError::message(
+                    "slice start must be proved non-negative",
+                ));
+            }
+        }
+        if let SomeValue::Integer(si) = &s_stop {
+            if !si.nonneg {
+                return Err(TyperError::message("slice stop must be proved non-negative"));
+            }
+        }
+
+        // v_start = inputconst(Signed, 0) when start is a constant None, else inputarg.
+        let start_is_none = s_start.is_constant() && matches!(s_start.const_(), Some(ConstValue::None));
+        let v_start = if start_is_none {
+            Hlvalue::Constant(Self::inputconst(&LowLevelType::Signed, &ConstValue::Int(0))?)
+        } else {
+            self.inputarg(&LowLevelType::Signed, 1)?
+        };
+
+        // stop constant None -> "startonly"; else "startstop".
+        let stop_is_none = s_stop.is_constant() && matches!(s_stop.const_(), Some(ConstValue::None));
+        if stop_is_none {
+            Ok((SliceKind::StartOnly, vec![v_start]))
+        } else {
+            let v_stop = self.inputarg(&LowLevelType::Signed, 2)?;
+            Ok((SliceKind::StartStop, vec![v_start, v_stop]))
+        }
+    }
+}
+
+/// The three slice shapes RPython's `decompose_slice_args` selects
+/// (rtyper.py:764-782): `[:-1]`, `[start:]`, `[start:stop]`. Upstream keys
+/// the `globals()['ll_listslice_%s' % kind]` dispatch on the string name;
+/// the Rust port names them explicitly and maps each to the matching
+/// `ll_listslice_*` helper builder.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SliceKind {
+    /// `[:-1]` — drop the last element.
+    MinusOne,
+    /// `[start:]` — from `start` to the end.
+    StartOnly,
+    /// `[start:stop]` — an explicit half-open range.
+    StartStop,
 }
 
 // ____________________________________________________________


### PR DESCRIPTION
Batch of two-phase-rtyper census slices on the `rtyper-legacy` integration stack, rebased onto current `main` (8 commits, linear).

## Commits

- **model raw `*const T`/`*mut T` results as `SomeAddress`; register slice/Vec `as_ptr`** — raw-pointer result modeling.
- **residualize `sync::atomic::AtomicBool::store` as a Void external.**
- **implement `malloc_varsize`/`setfield`/`getsubstruct`/`setarrayitem`/`cast_int_to_char` in llinterp** — `getsubstruct` dispatches to `_ptr::getattr` and materialises an interior-array field into a plain container `_ptr`.
- **register `core::mem::drop` as a Void no-op external.**
- **rewrite `<[T]>::first` into a length-checked `Option` diamond** — ArrayRead `item_ty` derived from the call-site payload type.
- **lower list getslice through `ll_listslice_{startonly,startstop,minusone}`** — ports `HighLevelOp.decompose_slice_args` (rtyper.py:755-779) + fills the three `ll_listslice_*` helper builders (rlist.py:883-911), wiring `rtype_getslice` into `ListRepr`/`FixedSizeListRepr`. Dormant (no front-end emits list getslice yet).
- **guard llinterp `malloc_varsize` length + gate `__discriminant` fold on nullability.**
- **fold slice/Vec `as_ptr` to the receiver; drop the Address externals.**

## Verification

- `cargo check --workspace` clean.
- `pyre/check.py`: **dynasm 349/349, cranelift 349/349, wasm 345/345** — all bit-exact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added list slicing for fixed-size and resizable lists, including start-only, start-to-stop, and minus-one slices.
  * Improved slice and vector pointer access handling.
  * Added support for representing `None` in translated operations.
* **Bug Fixes**
  * Negative allocation lengths now produce an error instead of unsafe size conversions.
  * Improved nullable pointer attribute handling.
* **Tests**
  * Expanded coverage for list slicing, pointer behavior, and arithmetic operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->