### PR TITLE
jit: fire the immutable-type attr raise fold, guarded on the metaclass version_tag

### DIFF
--- a/pyre/bench/synth/type_immutable_reject.py
+++ b/pyre/bench/synth/type_immutable_reject.py
@@ -1,4 +1,4 @@
-# pyre-check: max-pypy-ratio=152
+# pyre-check: max-pypy-ratio=15
 N = 200000
 
 

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -9136,6 +9136,26 @@ unsafe fn is_object_setattr_descr(w_descr: PyObjectRef) -> bool {
     }
 }
 
+/// The canonical `type.__setattr__` slot wrapper (`init_type_type`,
+/// typedef.rs), distinct from `object.__setattr__` for the Carlo Verre
+/// hackcheck but a thin forward to `object_setattr` — so it still reaches
+/// the terminal non-heaptype raise rather than diverting to user code.
+unsafe fn is_type_setattr_descr(w_descr: PyObjectRef) -> bool {
+    match lookup_in_type_where(crate::typedef::w_type(), "__setattr__") {
+        Some(d) => std::ptr::eq(w_descr, d),
+        None => false,
+    }
+}
+
+/// The `type.__delattr__` companion of [`is_type_setattr_descr`] — the
+/// canonical `type`'s own slot forwarding to `object_delattr`.
+unsafe fn is_type_delattr_descr(w_descr: PyObjectRef) -> bool {
+    match lookup_in_type_where(crate::typedef::w_type(), "__delattr__") {
+        Some(d) => std::ptr::eq(w_descr, d),
+        None => false,
+    }
+}
+
 /// typeobject.py:303-326 `getattribute_if_not_from_object` — returns the
 /// app-level `__getattribute__` if it is NOT `object.__getattribute__`,
 /// otherwise `None`.  In the interpreter the negative result is memoized
@@ -10280,16 +10300,25 @@ pub fn type_immutable_attr_raise_is_stable(obj: PyObjectRef, name: &str, is_dele
         if is_delete {
             // `delattr_str`'s type-receiver branch: a non-default metaclass
             // `__delattr__` routes to a descriptor call instead of the
-            // terminal raise.
+            // terminal raise.  The metaclass is the canonical `type` (checked
+            // above), whose own `__delattr__` slot forwards to
+            // `object_delattr` — that still reaches the immutable raise, so it
+            // is accepted alongside `object`'s default.
             if let Some(da) = lookup_in_type(metaclass, "__delattr__") {
                 let is_default = lookup_in_type(crate::typedef::w_object(), "__delattr__")
                     .is_some_and(|d| std::ptr::eq(da, d));
-                if !is_default {
+                if !is_default && !is_type_delattr_descr(da) {
                     return false;
                 }
             }
-        } else if setattr_if_not_from_object(metaclass).is_some() {
-            return false;
+        } else if let Some(sa) = setattr_if_not_from_object(metaclass) {
+            // Same reasoning for setattr: the canonical `type`'s own
+            // `__setattr__` slot forwards to `object_setattr`, so only a
+            // genuine metaclass override (neither `object`'s nor `type`'s
+            // standard slot) diverts away from the terminal raise.
+            if !is_type_setattr_descr(sa) {
+                return false;
+            }
         }
         // The terminal's metaclass-MRO descriptor walk runs before the
         // heaptype guard; any hit (`__name__`, `__dict__`, …) diverts.

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -7549,14 +7549,17 @@ pub(crate) fn try_walker_trace_immutable_type_attr_raise<Sym: WalkSym>(
     let Some(concrete_obj) = walker_concrete_ref_object(ctx, obj_op) else {
         return Ok(None);
     };
-    // STORE_ATTR needs the live value operand to run the authentic
-    // concrete `setattr_str` below (the value plays no role in the raise
-    // decision — the terminal raises before consulting it).
+    // STORE_ATTR runs the authentic concrete `setattr_str` below only for
+    // its raising exception.  The value plays no role in that raise — the
+    // stability predicate proves no data descriptor for `name`, so the
+    // terminal raises before consulting the value — so a non-constant store
+    // value (the common `int.x = i` loop case) still folds: a `None`
+    // concrete value substitutes a placeholder for the authentic run, and
+    // the value operand never enters the emitted trace.
     let concrete_value = match store_value {
-        Some(value_op) => match walker_concrete_ref_object(ctx, value_op) {
-            Some(v) => Some(v),
-            None => return Ok(None),
-        },
+        Some(value_op) => {
+            Some(walker_concrete_ref_object(ctx, value_op).unwrap_or_else(pyre_object::w_none))
+        }
         None => None,
     };
     let name = unsafe {
@@ -7578,6 +7581,24 @@ pub(crate) fn try_walker_trace_immutable_type_attr_raise<Sym: WalkSym>(
         return Ok(None);
     }
 
+    // The raise decision also reads the metaclass-MRO descriptor state — the
+    // branch-F `lookup_in_type_where(type, name)` walk and the forwarding
+    // `type.__setattr__` / `type.__delattr__` — which the receiver
+    // `GuardValue` below does not cover.  A `version_tag` guard on the
+    // metaclass pins that state (the guard the sibling method/attr folds
+    // carry, `typeobject.py promote(self.version_tag())`): mutating `type`'s
+    // dict bumps its tag directly, and mutating `object`'s dict bumps it too
+    // because `mutated()` propagates down to the `type` subclass — so one
+    // guard covers the whole `(type, object)` MRO the walk reads.  Branch C
+    // proved the metaclass is the canonical `type`.  A tagless metaclass
+    // (`version_tag == 0`) is uncacheable, so decline before emitting guards.
+    let metaclass = pyre_object::get_instantiate(&pyre_object::pyobject::TYPE_TYPE);
+    let metaclass_version_tag =
+        unsafe { pyre_object::typeobject::w_type_get_version_tag(metaclass) };
+    if metaclass_version_tag == 0 {
+        return Ok(None);
+    }
+
     // --- commit: pin the receiver, run the authentic raise, emit inline ---
     // The stability predicate makes the raise a pure function of `(obj,
     // name)`; `GuardValue` pins the one live input (`name` is a co_names
@@ -7589,6 +7610,19 @@ pub(crate) fn try_walker_trace_immutable_type_attr_raise<Sym: WalkSym>(
         walker_capture_snapshot_for_last_guard(ctx, op.pc)?;
         ctx.trace_ctx.heap_cache_mut().replace_box(obj_op, expected);
     }
+    // Pin the metaclass `version_tag` (see above): a `GETFIELD_GC_I` +
+    // `GuardValue` that side-exits on any `type`/`object` dict mutation.
+    let metaclass_const = ctx.trace_ctx.const_ref(metaclass as i64);
+    let vt_op = walker_record_getfield_gc_i_uncached(
+        ctx,
+        metaclass_const,
+        crate::descr::type_version_tag_descr(),
+    );
+    let vt_const = ctx.trace_ctx.const_int(metaclass_version_tag as i64);
+    ctx.trace_ctx
+        .record_guard(OpCode::GuardValue, &[vt_op, vt_const], 0);
+    walker_capture_snapshot_for_last_guard(ctx, op.pc)?;
+    ctx.trace_ctx.heap_cache_mut().replace_box(vt_op, vt_const);
 
     // The authoritative walk's concrete execution — the same call the
     // residual executor would have made, raising before any heap


### PR DESCRIPTION
## Summary

`int.x = v` / `del str.x` raise a deterministic `TypeError` on immutable builtin types. pyre already had a walker fold (`try_walker_trace_immutable_type_attr_raise`) meant to emit that raise as an inline, virtualizable exception construction — matching how PyPy traces `space.setattr` and lets its optimizer DCE the non-escaping exception. The fold was **dead**: every iteration residualised the raise as `call_may_force` and re-allocated the exception (`W_TypeError` + args list + traceback), so `type_immutable_reject` ran ~35x slower than pypy.

Two independent causes kept the fold from committing:

1. **Predicate rejected pyre's own `type.__setattr__` / `type.__delattr__`.** These are the standard slot wrappers `init_type_type` installs (distinct from `object`'s for the Carlo Verre hackcheck) that forward to `object_setattr` / `object_delattr` — i.e. straight to the terminal non-heaptype raise. `type_immutable_attr_raise_is_stable` treated them as a diverting metaclass override (branches D/E) and returned false.
2. **The STORE_ATTR arm required a constant store value.** A loop-carried value is never a trace-time constant, so `int.x = i` always declined.

## Changes

- **Predicate** accepts the canonical `type`'s own setattr/delattr via new `is_type_setattr_descr` / `is_type_delattr_descr` (branch C already proves the metaclass is the canonical, dict-frozen `type`).
- **Fold** drops the constant-value requirement: the value plays no role in the raise (the predicate proves no data descriptor for `name`, so the terminal raises before consulting it), so a non-constant value substitutes a `w_none` placeholder for the trace-time run; the value operand never enters the emitted trace.
- **Metaclass `version_tag` guard.** The fold pinned only the receiver identity, but the raise decision reads the metaclass-MRO descriptor state (the branch-F `lookup_in_type_where(type, name)` walk and the forwarding slots). Emit the `version_tag` `GuardValue` the sibling method/attr folds carry, so any `type`/`object` dict mutation side-exits. One guard covers the whole `(type, object)` MRO because `mutated()` propagates down to the `type` subclass of `object`. Effectively free (perf unchanged) and restores parity with the sibling folds.
- **Gate** `max-pypy-ratio` 152 → 15 (regression tripwire for the now-fast fixture).

## Results

- `type_immutable_reject`: **~35x → ~1x** vs pypy on both backends; per-iteration `call_may_force` **1 → 0** (the exception now virtualizes and DCEs).
- Full `check.py` **349/349 on both dynasm and cranelift**.
- JIT vs `PYRE_JIT=0` output verified identical across `int`/`str`/`float`/`bool`/`tuple`/`bytes`/`type` for both setattr and delattr.