### PR TITLE
jit: give synthetic tuple and Result shells their own low-level layouts, and keep freevar cells across inline and resume

### DIFF
--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -620,9 +620,10 @@ fn debug_validate_oldgen_freeblocks(site: std::fmt::Arguments<'_>) {
 }
 
 pub extern "C" fn dynasm_debug_validate_oldgen_freeblocks(site: u64, frame: usize) {
-    if !crate::gc_freelist_diag_enabled() {
-        return;
-    }
+    // The call itself is only emitted under `PYRE_TRACE_CALL_DIAG`, which is
+    // what selects the failure-frame report below. The freelist walk is the
+    // only half `PYRE_GC_FREELIST_DIAG` owns, and it gates itself — so no
+    // early return here, or enabling one diagnostic would need the other.
     if site >= 1_000_000 {
         let top = majit_gc::shadow_stack::jf_top_ptr().0;
         eprintln!(

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -619,6 +619,9 @@ fn debug_validate_oldgen_freeblocks(site: std::fmt::Arguments<'_>) {
 }
 
 pub extern "C" fn dynasm_debug_validate_oldgen_freeblocks(site: u64, frame: usize) {
+    if !crate::gc_freelist_diag_enabled() {
+        return;
+    }
     if site >= 1_000_000 {
         let top = majit_gc::shadow_stack::jf_top_ptr().0;
         eprintln!(
@@ -2503,7 +2506,11 @@ impl Backend for DynasmBackend {
             .iter()
             .map(|(&k, c)| (k, c.as_raw_i64()))
             .collect();
-        if crate::majit_log_enabled() && trace_id == 2 {
+        let trace_ops_diag = std::env::var("PYRE_TRACE_OPS_DIAG")
+            .ok()
+            .and_then(|value| value.parse::<u64>().ok())
+            == Some(trace_id);
+        if trace_ops_diag {
             eprintln!(
                 "--- dynasm bridge prepared ops (trace_id={}, fail_index={}) ---\n{}",
                 trace_id,

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -221,6 +221,7 @@ fn register_active_hooks(supports_guard_gc_type: bool) {
     majit_gc::set_active_gc_is_nursery_object(Some(dynasm_gc_is_nursery_object));
     majit_gc::set_active_gc_id_or_identityhash(Some(dynasm_id_or_identityhash));
     majit_gc::set_active_write_barrier(Some(dynasm_gc_write_barrier));
+    majit_gc::set_active_write_barrier_managed(Some(dynasm_gc_write_barrier_managed));
     majit_gc::set_active_finalizer_hooks(
         Some(dynasm_register_finalizer),
         Some(dynasm_finalizer_next_dead),
@@ -764,6 +765,20 @@ fn dynasm_gc_write_barrier(obj: GcRef) {
         return;
     }
     majit_gc::gc_sync::gc_op_with_root(obj, |g, obj| g.write_barrier(obj));
+}
+
+fn dynasm_gc_write_barrier_managed(obj: GcRef) {
+    if DYNASM_ACTIVE_GC
+        .with(|c| {
+            c.borrow_mut()
+                .as_deref_mut()
+                .map(|g| g.write_barrier_managed(obj))
+        })
+        .is_some()
+    {
+        return;
+    }
+    majit_gc::gc_sync::gc_op_with_root(obj, |g, obj| g.write_barrier_managed(obj));
 }
 
 fn dynasm_id_or_identityhash(addr: usize) -> usize {

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -327,6 +327,14 @@ impl RootSet {
 
     /// Remove a root.
     pub fn remove(&mut self, root: *mut GcRef) {
+        // Host root brackets are stack-shaped, matching RPython's
+        // shadowstack push/pop discipline.  Keep the general out-of-order
+        // fallback for callers that hold overlapping guards, but make the
+        // overwhelmingly common matching-pop path O(1).
+        if self.roots.last().copied() == Some(root) {
+            self.roots.pop();
+            return;
+        }
         if let Some(pos) = self.roots.iter().position(|r| *r == root) {
             self.roots.swap_remove(pos);
         }
@@ -4675,6 +4683,31 @@ mod tests {
             large_object_threshold: nursery_size / 2,
             ..GcConfig::default()
         })
+    }
+
+    #[test]
+    fn root_set_removes_lifo_and_out_of_order_roots() {
+        let mut roots = RootSet::new();
+        let mut a = GcRef(1);
+        let mut b = GcRef(2);
+        let mut c = GcRef(3);
+        let (a, b, c) = (
+            &mut a as *mut GcRef,
+            &mut b as *mut GcRef,
+            &mut c as *mut GcRef,
+        );
+        unsafe {
+            roots.add(a);
+            roots.add(b);
+            roots.add(c);
+        }
+
+        roots.remove(c);
+        assert_eq!(roots.roots, vec![a, b]);
+        roots.remove(a);
+        assert_eq!(roots.roots, vec![b]);
+        roots.remove(b);
+        assert!(roots.is_empty());
     }
 
     /// A born-old allocation that crosses the next-major threshold asks for a

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -3522,6 +3522,20 @@ impl MiniMarkGC {
         }
     }
 
+    /// `do_write_barrier` sibling for a pointer returned by this collector's
+    /// allocation API.  RPython's barrier receives only GC-managed structs;
+    /// the membership guard exists solely for pyre's mixed bootstrap heap and
+    /// is redundant for a freshly allocated managed result.
+    fn do_write_barrier_managed(&mut self, obj: GcRef) {
+        if obj.is_null() {
+            return;
+        }
+        let hdr = unsafe { header_of(obj.0) };
+        if unsafe { (*hdr).has_flag(flags::TRACK_YOUNG_PTRS) } {
+            self.remember_young_pointer(obj);
+        }
+    }
+
     /// incminimark.py:1503-1529 _remember_young_pointer_inlined(addr):
     /// append the object to the remembered set (`old_objects_pointing_to_young`)
     /// and clear GCFLAG_TRACK_YOUNG_PTRS. Callers have already verified the flag
@@ -4279,6 +4293,10 @@ impl GcAllocator for MiniMarkGC {
 
     fn write_barrier(&mut self, obj: GcRef) {
         self.do_write_barrier(obj);
+    }
+
+    fn write_barrier_managed(&mut self, obj: GcRef) {
+        self.do_write_barrier_managed(obj);
     }
 
     fn jit_remember_young_pointer_from_array(&mut self, obj: GcRef) {

--- a/majit/majit-gc/src/lib.rs
+++ b/majit/majit-gc/src/lib.rs
@@ -357,6 +357,15 @@ pub trait GcAllocator: Send {
     /// Must be called before storing a GC reference into `obj`.
     fn write_barrier(&mut self, obj: GcRef);
 
+    /// Write barrier for an object the caller has already proved belongs to
+    /// this collector.  Fresh results from `alloc_oldgen_typed` and the
+    /// collector's no-collect allocator satisfy this contract.  Collectors
+    /// may skip their defensive hybrid-heap membership query; the default
+    /// preserves the safe entry point for backends without that distinction.
+    fn write_barrier_managed(&mut self, obj: GcRef) {
+        self.write_barrier(obj);
+    }
+
     /// incminimark.py:1606 jit_remember_young_pointer_from_array:
     /// Called by JIT when TRACK_YOUNG_PTRS set but CARDS_SET not.
     /// Tries to set CARDS_SET if HAS_CARDS; else generic barrier.
@@ -2055,10 +2064,16 @@ pub fn gc_set_enabled(enabled: bool) {
 pub type WriteBarrierFn = fn(obj: GcRef);
 
 global_hook!(static ACTIVE_WRITE_BARRIER: WriteBarrierFn);
+global_hook!(static ACTIVE_WRITE_BARRIER_MANAGED: WriteBarrierFn);
 
 /// Install the active backend's write-barrier callback. Pass `None` to clear.
 pub fn set_active_write_barrier(hook: Option<WriteBarrierFn>) {
     ACTIVE_WRITE_BARRIER.set(hook);
+}
+
+/// Install the barrier entry for objects already known to be GC-managed.
+pub fn set_active_write_barrier_managed(hook: Option<WriteBarrierFn>) {
+    ACTIVE_WRITE_BARRIER_MANAGED.set(hook);
 }
 
 /// Perform a write barrier through the active backend.
@@ -2070,6 +2085,16 @@ pub fn set_active_write_barrier(hook: Option<WriteBarrierFn>) {
 pub fn gc_write_barrier(obj: GcRef) {
     if let Some(f) = ACTIVE_WRITE_BARRIER.get() {
         f(obj)
+    }
+}
+
+/// Perform a write barrier without repeating the hybrid-heap ownership query.
+/// Falls back to the safe barrier when a backend has no specialized entry.
+pub fn gc_write_barrier_managed(obj: GcRef) {
+    if let Some(f) = ACTIVE_WRITE_BARRIER_MANAGED.get() {
+        f(obj)
+    } else {
+        gc_write_barrier(obj)
     }
 }
 

--- a/majit/majit-ir/src/descr.rs
+++ b/majit/majit-ir/src/descr.rs
@@ -408,11 +408,17 @@ pub fn struct_id_for_name(raw: &str) -> Option<StructId> {
         .trim_start_matches("&mut ")
         .trim_start_matches('&')
         .trim();
-    // Generic instantiations share the defining ADT's one physical Rust
-    // layout.  The annotator keeps `Result<T>::Ok` spellings distinct for
-    // ClassDef payload precision, but the descriptor layer must resolve all
-    // of them to the template variant identity registered from the TypeDecl.
-    let s = strip_generic_args(s);
+    // Generic nominal ADT instantiations share the defining TypeDecl's one
+    // physical layout. Tuples are the exception: RPython's `TupleRepr`
+    // creates a distinct `GcStruct` for each item shape, and Charon spells
+    // that synthetic identity as `Tuple<T,...>` because there is no nominal
+    // TypeDecl to resolve. Preserve the full tuple shape while continuing to
+    // collapse `Result<T>::Ok` and other nominal generics to their template.
+    let s = if strip_instantiation_suffix(s) == "Tuple" && s != "Tuple" {
+        std::borrow::Cow::Borrowed(s)
+    } else {
+        strip_generic_args(s)
+    };
     let guard = STRUCT_ID_BY_NAME.lock().unwrap();
     guard.get(s.as_ref()).copied().flatten()
 }

--- a/majit/majit-ir/src/descr.rs
+++ b/majit/majit-ir/src/descr.rs
@@ -409,12 +409,10 @@ pub fn struct_id_for_name(raw: &str) -> Option<StructId> {
         .trim_start_matches('&')
         .trim();
     // Generic nominal ADT instantiations share the defining TypeDecl's one
-    // physical layout. Tuples are the exception: RPython's `TupleRepr`
-    // creates a distinct `GcStruct` for each item shape, and Charon spells
-    // that synthetic identity as `Tuple<T,...>` because there is no nominal
-    // TypeDecl to resolve. Preserve the full tuple shape while continuing to
-    // collapse `Result<T>::Ok` and other nominal generics to their template.
-    let s = if strip_instantiation_suffix(s) == "Tuple" && s != "Tuple" {
+    // physical layout. Tuples are the exception (see [`is_shaped_tuple_name`]):
+    // preserve the full tuple shape while continuing to collapse
+    // `Result<T>::Ok` and other nominal generics to their template.
+    let s = if is_shaped_tuple_name(s) {
         std::borrow::Cow::Borrowed(s)
     } else {
         strip_generic_args(s)
@@ -497,6 +495,19 @@ pub fn canonical_struct_name(name: &str) -> String {
 /// `Result` (one template per generic ADT).  The narrowing resolver
 /// strips the suffix for that table lookup while the variant `ClassDef`
 /// key keeps it.
+/// Is `name` a tuple identity carrying its item shape (`Tuple<T, ...>`), as
+/// opposed to the bare `Tuple` root?
+///
+/// `TupleRepr` creates a distinct `GcStruct` per item shape
+/// (`rtyper/rtuple.py:115-125`), so `(A,)` and `(A, B)` are different
+/// low-level struct objects.  Charon spells that synthetic identity as
+/// `Tuple<T, ...>` because Rust's built-in tuple has no nominal `TypeDecl`,
+/// which makes it the one generic spelling that must NOT collapse onto its
+/// template the way `Result<T>::Ok` does.
+pub fn is_shaped_tuple_name(name: &str) -> bool {
+    name != "Tuple" && strip_instantiation_suffix(name) == "Tuple"
+}
+
 pub fn strip_instantiation_suffix(name: &str) -> &str {
     match name.find('<') {
         Some(i) => &name[..i],

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -101,6 +101,12 @@ use crate::resume::{
 use crate::trace_ctx::TraceCtx;
 use crate::virtualizable::VirtualizableInfo;
 
+#[inline]
+fn guardlog_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| std::env::var_os("MAJIT_GUARDLOG").is_some())
+}
+
 /// No direct RPython equivalent — Rust struct carrying data that RPython
 /// passes through internal method calls in handle_guard_failure
 /// (pyjitpl.py:2890). Fields correspond to:
@@ -1977,6 +1983,9 @@ impl<M: Clone> MetaInterp<M> {
 
     #[inline]
     fn record_guard_failure_event(&mut self, green_key: u64, fail_index: u32) {
+        if guardlog_enabled() {
+            eprintln!("@@@GUARD key={green_key} fail={fail_index}");
+        }
         if crate::majit_log_enabled() {
             eprintln!(
                 "[jit] guard failure at key={}, guard={}",

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -624,6 +624,9 @@ pub struct ReconstructRecipe {
     /// Guard-carried JitCode offset from the decoded resume frame;
     /// `majit_ir::resumedata::NO_JITCODE_PC` when the frame carried none.
     pub jitcode_pc: i32,
+    /// Semantic stack base: `co_nlocals + ncellvars + nfreevars`, matching
+    /// `MIFrame.registers_r` / `PyFrame.locals_cells_stack_w`.  This was
+    /// historically named `nlocals`; keep the field name for wire stability.
     pub nlocals: usize,
     pub valuestackdepth: usize,
     pub registers_i: Vec<OpRef>,

--- a/majit/majit-translate/src/codewriter/assembler.rs
+++ b/majit/majit-translate/src/codewriter/assembler.rs
@@ -3281,9 +3281,9 @@ fn bh_size_spec_from_callcontrol(
     // for Result variants, falling back to the template only when no such rows
     // exist, so the payload participates in that same flattened slot list.
     let mut all_fielddescrs = if result_variant {
-        let instantiated = bh_all_field_specs_for_struct(cc, owner);
+        let instantiated = bh_result_variant_field_specs(cc, owner);
         if instantiated.is_empty() {
-            bh_all_field_specs_for_struct(cc, layout_owner)
+            bh_result_variant_field_specs(cc, layout_owner)
         } else {
             instantiated
         }
@@ -3368,6 +3368,48 @@ fn bh_all_field_specs_for_struct(
 ) -> Vec<crate::jitcode::BhFieldSpec> {
     let mut specs = Vec::new();
     bh_all_field_specs_for_struct_into(cc, owner, owner, "", 0, &mut specs);
+    specs
+}
+
+/// Build the variant-owned portion of the explicit `Result<T, PyError>`
+/// shell.  The front end deliberately represents this as one inherited tag
+/// word followed by one-word payload fields (`front/mir.rs`'s
+/// `synthetic_result_shell`), rather than as Rust's native enum layout.  The
+/// shared nominal layout registry cannot describe each generic payload at
+/// once, so read the concrete instantiation's rows directly and place them
+/// after the inherited tag, matching RPython's concrete low-level STRUCT.
+fn bh_result_variant_field_specs(
+    cc: &CallControl,
+    owner: &str,
+) -> Vec<crate::jitcode::BhFieldSpec> {
+    let Some(fields) = cc.struct_field_entries(owner) else {
+        return Vec::new();
+    };
+    let mut specs = Vec::new();
+    let mut offset = 8usize;
+    for (field_name, field_type_str) in fields {
+        let (field_flag, field_type, field_size) = type_flag_from_str(field_type_str);
+        if field_type == majit_ir::value::Type::Void || field_size == 0 {
+            continue;
+        }
+        let align = scalar_align(field_size);
+        offset = (offset + align - 1) & !(align - 1);
+        let index = specs.len() + 1;
+        let rank = cc.field_immutability(Some(owner), field_name);
+        specs.push(bh_field_spec_from_parts(
+            index as u32,
+            owner,
+            field_name,
+            offset,
+            field_size,
+            field_type,
+            field_flag,
+            rank.is_some(),
+            rank.map(|r| r.is_quasi_immutable()).unwrap_or(false),
+            index,
+        ));
+        offset += field_size;
+    }
     specs
 }
 
@@ -3578,6 +3620,7 @@ fn fielddescrof(
         {
             parent_spec.type_id = owner_id.as_u64();
         }
+        let mut found_parent_field = false;
         if let Some(parent_spec) = parent.as_ref() {
             let full_name = bh_field_name(owner, &field.name);
             if let Some(spec) = parent_spec.all_fielddescrs.iter().find(|spec| {
@@ -3593,11 +3636,13 @@ fn fielddescrof(
                 is_immutable = spec.is_immutable;
                 is_quasi_immutable = spec.is_quasi_immutable;
                 index_in_parent = spec.index_in_parent;
+                found_parent_field = true;
             }
         }
-        if let Some(layout_field) = cc
-            .struct_layout_for(owner)
-            .and_then(|layout| layout.fields.iter().find(|fl| fl.name == field.name))
+        if !found_parent_field
+            && let Some(layout_field) = cc
+                .struct_layout_for(owner)
+                .and_then(|layout| layout.fields.iter().find(|fl| fl.name == field.name))
         {
             offset = layout_field.offset;
             field_size = layout_field.size;
@@ -3606,13 +3651,14 @@ fn fielddescrof(
             is_field_signed = field_flag == majit_ir::descr::ArrayFlag::Signed;
             is_immutable = layout_field.is_immutable();
             is_quasi_immutable = layout_field.is_quasi_immutable();
-        } else if let Some((
-            computed_offset,
-            computed_size,
-            computed_type,
-            computed_flag,
-            computed_signed,
-        )) = heuristic_field_layout(cc, owner, &field.name)
+        } else if !found_parent_field
+            && let Some((
+                computed_offset,
+                computed_size,
+                computed_type,
+                computed_flag,
+                computed_signed,
+            )) = heuristic_field_layout(cc, owner, &field.name)
         {
             offset = computed_offset;
             field_size = computed_size;
@@ -4788,8 +4834,15 @@ mod tests {
         assert_eq!(spec.size, 16);
         assert_eq!(spec.all_fielddescrs.len(), 2);
         assert_eq!(spec.all_fielddescrs[0].field_key(), "__discriminant");
+        assert_eq!(spec.all_fielddescrs[0].offset, 0);
         assert_eq!(spec.all_fielddescrs[0].index_in_parent, 0);
         assert_eq!(spec.all_fielddescrs[1].field_key(), "__pos_0");
+        assert_eq!(spec.all_fielddescrs[1].offset, 8);
+        assert_eq!(spec.all_fielddescrs[1].field_size, 8);
+        assert_eq!(
+            spec.all_fielddescrs[1].field_flag,
+            majit_ir::descr::ArrayFlag::Pointer
+        );
         assert_eq!(spec.all_fielddescrs[1].index_in_parent, 1);
     }
 

--- a/majit/majit-translate/src/codewriter/assembler.rs
+++ b/majit/majit-translate/src/codewriter/assembler.rs
@@ -3251,12 +3251,11 @@ fn bh_size_spec_from_callcontrol(
     // `Result<U>::Ok` converge on the template variant. A tuple is different:
     // `TupleRepr` creates one low-level GcStruct per item shape, so preserve
     // its full `Tuple<T,...>` identity and layout.
-    let layout_owner =
-        if majit_ir::descr::strip_instantiation_suffix(owner) == "Tuple" && owner != "Tuple" {
-            std::borrow::Cow::Borrowed(owner)
-        } else {
-            majit_ir::descr::strip_generic_args(owner)
-        };
+    let layout_owner = if majit_ir::descr::is_shaped_tuple_name(owner) {
+        std::borrow::Cow::Borrowed(owner)
+    } else {
+        majit_ir::descr::strip_generic_args(owner)
+    };
     let layout_owner = layout_owner.as_ref();
     let mut size = cc
         .struct_layout_for(layout_owner)

--- a/majit/majit-translate/src/codewriter/assembler.rs
+++ b/majit/majit-translate/src/codewriter/assembler.rs
@@ -3246,16 +3246,62 @@ fn bh_size_spec_from_callcontrol(
         return None;
     }
     // RPython keys SizeDescrs on the low-level STRUCT object, not on an
-    // annotation-side generic instantiation.  Charon registers one physical
-    // layout for the generic TypeDecl, so `Result<T>::Ok` and
-    // `Result<U>::Ok` must converge on the template variant here while their
-    // ClassDefs remain distinct in the annotator.
-    let layout_owner = majit_ir::descr::strip_generic_args(owner);
+    // annotation-side generic instantiation. Charon registers one physical
+    // layout for a nominal generic TypeDecl, so `Result<T>::Ok` and
+    // `Result<U>::Ok` converge on the template variant. A tuple is different:
+    // `TupleRepr` creates one low-level GcStruct per item shape, so preserve
+    // its full `Tuple<T,...>` identity and layout.
+    let layout_owner =
+        if majit_ir::descr::strip_instantiation_suffix(owner) == "Tuple" && owner != "Tuple" {
+            std::borrow::Cow::Borrowed(owner)
+        } else {
+            majit_ir::descr::strip_generic_args(owner)
+        };
     let layout_owner = layout_owner.as_ref();
-    let size = cc
+    let mut size = cc
         .struct_layout_for(layout_owner)
         .map(|layout| layout.size)
         .or_else(|| heuristic_struct_size_for_bh(cc, layout_owner))?;
+    let mut all_fielddescrs = bh_all_field_specs_for_struct(cc, layout_owner);
+    // `rclass.py` lays a subclass's inherited fields out before its own
+    // fields.  Annotation metadata deliberately keeps enum-variant attrs
+    // variant-local, so reconstruct that inherited physical slot here for
+    // the explicit Result shell.  PtrInfo indexes virtual fields by
+    // `index_in_parent`; without the base tag in this list both the tag and
+    // payload are slot 0 and the payload replaces the tag despite living at
+    // byte offset 8.
+    let result_variant = layout_owner.ends_with("result::Result::Ok")
+        || layout_owner.ends_with("result::Result::Err")
+        || layout_owner == "Result::Ok"
+        || layout_owner == "Result::Err";
+    if result_variant {
+        size = size.max(16);
+    }
+    if result_variant
+        && !all_fielddescrs
+            .iter()
+            .any(|field| field.field_key() == "__discriminant")
+    {
+        for (index, field) in all_fielddescrs.iter_mut().enumerate() {
+            field.index = (index + 1) as u32;
+            field.index_in_parent = index + 1;
+        }
+        all_fielddescrs.insert(
+            0,
+            bh_field_spec_from_parts(
+                0,
+                layout_owner,
+                "__discriminant",
+                0,
+                8,
+                majit_ir::value::Type::Int,
+                majit_ir::descr::ArrayFlag::Signed,
+                false,
+                false,
+                0,
+            ),
+        );
+    }
     Some(crate::jitcode::BhSizeSpec {
         size,
         // Analyzer-side structs keep the guard (unchanged); the raw
@@ -3279,7 +3325,7 @@ fn bh_size_spec_from_callcontrol(
         // by `simple_descr_group_from_bh_size`'s no-identity branch.
         type_id: majit_ir::descr::path_hash(layout_owner),
         vtable: 0,
-        all_fielddescrs: bh_all_field_specs_for_struct(cc, layout_owner),
+        all_fielddescrs,
     })
 }
 
@@ -3501,11 +3547,11 @@ fn fielddescrof(
         }
         if let Some(parent_spec) = parent.as_ref() {
             let full_name = bh_field_name(owner, &field.name);
-            if let Some(spec) = parent_spec
-                .all_fielddescrs
-                .iter()
-                .find(|spec| spec.name == full_name)
-            {
+            if let Some(spec) = parent_spec.all_fielddescrs.iter().find(|spec| {
+                spec.name == full_name
+                    || spec.field_key() == field.name
+                    || spec.name.ends_with(&format!(".{}", field.name))
+            }) {
                 offset = spec.offset;
                 field_size = spec.field_size;
                 field_type = spec.field_type;
@@ -4660,6 +4706,29 @@ mod tests {
             parent_type_id("core::result::Result<i64,PyError>"),
             owner_id.as_u64(),
         );
+    }
+
+    #[test]
+    fn explicit_result_variant_size_inherits_discriminant_slot() {
+        use crate::call::CallControl;
+
+        let mut cc = CallControl::new();
+        let mut struct_fields = crate::front::StructFieldRegistry::default();
+        struct_fields.fields.insert(
+            "core::result::Result::Ok".to_string(),
+            vec![("__pos_0".to_string(), "??TypeVar".to_string())],
+        );
+        cc.set_struct_fields(struct_fields);
+
+        let spec = bh_size_spec_from_callcontrol(&cc, "core::result::Result<i64,PyError>::Ok")
+            .expect("explicit Result variant size");
+        assert_eq!(spec.size, 16);
+        assert_eq!(spec.all_fielddescrs.len(), 2);
+        assert_eq!(spec.all_fielddescrs[0].field_key(), "__discriminant");
+        assert_eq!(spec.all_fielddescrs[0].offset, 0);
+        assert_eq!(spec.all_fielddescrs[0].index_in_parent, 0);
+        assert_eq!(spec.all_fielddescrs[1].field_key(), "__pos_0");
+        assert_eq!(spec.all_fielddescrs[1].index_in_parent, 1);
     }
 
     #[test]

--- a/majit/majit-translate/src/codewriter/assembler.rs
+++ b/majit/majit-translate/src/codewriter/assembler.rs
@@ -3633,11 +3633,23 @@ fn fielddescrof(
         let mut found_parent_field = false;
         if let Some(parent_spec) = parent.as_ref() {
             let full_name = bh_field_name(owner, &field.name);
-            if let Some(spec) = parent_spec.all_fielddescrs.iter().find(|spec| {
-                spec.name == full_name
-                    || spec.field_key() == field.name
-                    || spec.name.ends_with(&format!(".{}", field.name))
-            }) {
+            // `all_fielddescrs` is flattened depth-first, so a nested
+            // `Outer.inner.x` precedes the `Outer.x` the caller named. A
+            // single `find` over the disjunction would let that nested row
+            // win on the dotted-suffix arm alone; run the exact spellings to
+            // exhaustion first and keep the suffix match as the fallback.
+            let dotted_suffix = format!(".{}", field.name);
+            let matched = parent_spec
+                .all_fielddescrs
+                .iter()
+                .find(|spec| spec.name == full_name || spec.field_key() == field.name)
+                .or_else(|| {
+                    parent_spec
+                        .all_fielddescrs
+                        .iter()
+                        .find(|spec| spec.name.ends_with(&dotted_suffix))
+                });
+            if let Some(spec) = matched {
                 offset = spec.offset;
                 field_size = spec.field_size;
                 field_type = spec.field_type;

--- a/majit/majit-translate/src/codewriter/assembler.rs
+++ b/majit/majit-translate/src/codewriter/assembler.rs
@@ -3262,7 +3262,6 @@ fn bh_size_spec_from_callcontrol(
         .struct_layout_for(layout_owner)
         .map(|layout| layout.size)
         .or_else(|| heuristic_struct_size_for_bh(cc, layout_owner))?;
-    let mut all_fielddescrs = bh_all_field_specs_for_struct(cc, layout_owner);
     // `rclass.py` lays a subclass's inherited fields out before its own
     // fields.  Annotation metadata deliberately keeps enum-variant attrs
     // variant-local, so reconstruct that inherited physical slot here for
@@ -3274,6 +3273,23 @@ fn bh_size_spec_from_callcontrol(
         || layout_owner.ends_with("result::Result::Err")
         || layout_owner == "Result::Ok"
         || layout_owner == "Result::Err";
+    // The bare Charon variant can contain only the inherited enum tag while
+    // the annotator keeps the payload row on the concrete instantiation
+    // (`Result<PyObjectRef, PyError>::Ok`).  RPython has one concrete low-level
+    // STRUCT at this point, whose embedded base and variant fields are flattened
+    // together by `heaptracker.all_fielddescrs`.  Prefer the instantiated rows
+    // for Result variants, falling back to the template only when no such rows
+    // exist, so the payload participates in that same flattened slot list.
+    let mut all_fielddescrs = if result_variant {
+        let instantiated = bh_all_field_specs_for_struct(cc, owner);
+        if instantiated.is_empty() {
+            bh_all_field_specs_for_struct(cc, layout_owner)
+        } else {
+            instantiated
+        }
+    } else {
+        bh_all_field_specs_for_struct(cc, layout_owner)
+    };
     if result_variant {
         size = size.max(16);
     }
@@ -3301,6 +3317,23 @@ fn bh_size_spec_from_callcontrol(
                 0,
             ),
         );
+    }
+    if result_variant {
+        // `heaptracker.get_fielddescr_index_in` counts through the embedded
+        // base before the variant's own fields.  Source registries assign
+        // indices within each owner, so normalize the combined physical list
+        // after adding the inherited tag.  Offset order is the low-level
+        // STRUCT order for this explicit shell (tag at 0, payload at 8).
+        all_fielddescrs.sort_by_key(|field| {
+            (
+                field.offset,
+                usize::from(field.field_key() != "__discriminant"),
+            )
+        });
+        for (index, field) in all_fielddescrs.iter_mut().enumerate() {
+            field.index = index as u32;
+            field.index_in_parent = index;
+        }
     }
     Some(crate::jitcode::BhSizeSpec {
         size,
@@ -4726,6 +4759,35 @@ mod tests {
         assert_eq!(spec.all_fielddescrs.len(), 2);
         assert_eq!(spec.all_fielddescrs[0].field_key(), "__discriminant");
         assert_eq!(spec.all_fielddescrs[0].offset, 0);
+        assert_eq!(spec.all_fielddescrs[0].index_in_parent, 0);
+        assert_eq!(spec.all_fielddescrs[1].field_key(), "__pos_0");
+        assert_eq!(spec.all_fielddescrs[1].index_in_parent, 1);
+    }
+
+    #[test]
+    fn instantiated_result_payload_follows_template_discriminant_slot() {
+        use crate::call::CallControl;
+
+        let owner = "core::result::Result<*mut PyObject,PyError>::Ok";
+        let mut cc = CallControl::new();
+        let mut struct_fields = crate::front::StructFieldRegistry::default();
+        // The production registry keeps the enum-root tag on the template,
+        // while the concrete payload row belongs to the instantiation.
+        struct_fields.fields.insert(
+            "core::result::Result::Ok".to_string(),
+            vec![("__discriminant".to_string(), "i64".to_string())],
+        );
+        struct_fields.fields.insert(
+            owner.to_string(),
+            vec![("__pos_0".to_string(), "*mut PyObject".to_string())],
+        );
+        cc.set_struct_fields(struct_fields);
+
+        let spec =
+            bh_size_spec_from_callcontrol(&cc, owner).expect("instantiated Result variant size");
+        assert_eq!(spec.size, 16);
+        assert_eq!(spec.all_fielddescrs.len(), 2);
+        assert_eq!(spec.all_fielddescrs[0].field_key(), "__discriminant");
         assert_eq!(spec.all_fielddescrs[0].index_in_parent, 0);
         assert_eq!(spec.all_fielddescrs[1].field_key(), "__pos_0");
         assert_eq!(spec.all_fielddescrs[1].index_in_parent, 1);

--- a/majit/majit-translate/src/codewriter/assembler.rs
+++ b/majit/majit-translate/src/codewriter/assembler.rs
@@ -3388,6 +3388,16 @@ fn bh_result_variant_field_specs(
     let mut specs = Vec::new();
     let mut offset = 8usize;
     for (field_name, field_type_str) in fields {
+        // This builder lays out the variant's own payload rows, which start
+        // past the inherited tag at byte 8.  The registry can also carry the
+        // enum base's synthetic `__discriminant` row (`layout.rs`,
+        // `front/semantic.rs`); emitting it here would place the tag at
+        // offset 8 alongside the payload AND make the caller's
+        // `any(field_key() == "__discriminant")` check skip the slot-0 /
+        // offset-0 tag it synthesizes.  Leave the tag to the caller.
+        if field_name == "__discriminant" {
+            continue;
+        }
         let (field_flag, field_type, field_size) = type_flag_from_str(field_type_str);
         if field_type == majit_ir::value::Type::Void || field_size == 0 {
             continue;

--- a/majit/majit-translate/src/codewriter/call.rs
+++ b/majit/majit-translate/src/codewriter/call.rs
@@ -1061,6 +1061,32 @@ impl StructFieldLayout {
     }
 }
 
+/// RPython `isinstance(FIELD, lltype.Struct)` parity for the textual type
+/// carrier used by the Rust front end.  A spelling can occur in the global
+/// declaration census as well as in a field row, but pointer wrappers remain
+/// `lltype.Ptr` values even when their pointee/container type is known.  They
+/// must therefore contribute one pointer field descriptor rather than being
+/// recursively flattened as an embedded struct.
+fn is_known_by_value_struct(
+    known_structs: &std::collections::HashSet<String>,
+    type_name: &str,
+) -> bool {
+    let type_name = type_name.trim();
+    if type_name.starts_with("*mut ")
+        || type_name.starts_with("*const ")
+        || type_name.starts_with('&')
+        || type_name.starts_with("Box<")
+        || type_name.starts_with("Arc<")
+        || type_name.starts_with("Rc<")
+        || type_name.starts_with("Vec<")
+        || type_name.starts_with("Option<")
+        || type_name == "String"
+    {
+        return false;
+    }
+    known_structs.contains(type_name)
+}
+
 impl StructLayout {
     /// Build a StructLayout from type-string heuristic.
     /// Used at pipeline init to populate struct_layouts from struct_fields.
@@ -1083,7 +1109,7 @@ impl StructLayout {
         // clear interior field descriptors.
         let has_nested_struct = fields
             .iter()
-            .any(|(_, type_str)| known_structs.contains(type_str.as_str()));
+            .any(|(_, type_str)| is_known_by_value_struct(known_structs, type_str));
         let mut offset: usize = 0;
         let mut layout_fields = Vec::new();
         for (name, type_str) in fields {
@@ -1092,7 +1118,7 @@ impl StructLayout {
             if name == "typeptr" || name.starts_with("c__pad") {
                 // heaptracker.py:64-67
                 // typeptr is still counted for offset calculation below.
-                let sz = if known_structs.contains(type_str.as_str()) {
+                let sz = if is_known_by_value_struct(known_structs, type_str) {
                     known_struct_sizes
                         .get(type_str.as_str())
                         .copied()
@@ -1136,7 +1162,7 @@ impl StructLayout {
         let max_align = fields
             .iter()
             .map(|(_, ty)| {
-                if known_structs.contains(ty.as_str()) {
+                if is_known_by_value_struct(known_structs, ty) {
                     // Use actual nested struct size for alignment.
                     known_struct_sizes
                         .get(ty.as_str())
@@ -1481,7 +1507,7 @@ impl CallControl {
 
     /// RPython: isinstance(TYPE, lltype.Struct) check.
     pub fn is_known_struct(&self, name: &str) -> bool {
-        self.known_struct_names.contains(name)
+        is_known_by_value_struct(&self.known_struct_names, name)
     }
 
     /// RPython: register actual struct layout from `symbolic.get_field_token()`.
@@ -7416,7 +7442,7 @@ fn field_metadata(
     known_structs: &std::collections::HashSet<String>,
     known_struct_sizes: &std::collections::HashMap<String, usize>,
 ) -> (majit_ir::descr::ArrayFlag, majit_ir::value::Type, usize) {
-    if known_structs.contains(type_str) {
+    if is_known_by_value_struct(known_structs, type_str) {
         let nested_size = known_struct_sizes
             .get(type_str)
             .copied()
@@ -9478,6 +9504,39 @@ mod tests {
         assert_eq!(known_sizes["C"], 8, "C: single i64");
         assert_eq!(known_sizes["B"], 16, "B: C(8) + i64(8)");
         assert_eq!(known_sizes["A"], 24, "A: B(16) + i64(8)");
+    }
+
+    #[test]
+    fn raw_pointer_field_is_not_flattened_as_a_known_pointee_struct() {
+        use majit_ir::descr::ArrayFlag;
+        use majit_ir::value::Type;
+
+        // A merged declaration census can carry both spellings.  RPython's
+        // type test still sees Ptr(PyObject), never an embedded PyObject
+        // Struct, so the field occupies one pointer-sized leaf slot.
+        let known_structs: HashSet<String> = ["PyObject", "*mut PyObject"]
+            .into_iter()
+            .map(str::to_string)
+            .collect();
+        let known_sizes: HashMap<String, usize> = [
+            ("PyObject".to_string(), 32),
+            ("*mut PyObject".to_string(), 32),
+        ]
+        .into_iter()
+        .collect();
+        let fields = vec![("__pos_0".to_string(), "*mut PyObject".to_string())];
+
+        let layout =
+            StructLayout::from_type_strings(&fields, &known_structs, &known_sizes, &HashMap::new());
+        assert_eq!(layout.size, crate::layout::target_word_size());
+        assert_eq!(layout.fields.len(), 1);
+        assert_eq!(layout.fields[0].flag, ArrayFlag::Pointer);
+        assert_eq!(layout.fields[0].field_type, Type::Ref);
+
+        let mut cc = CallControl::new();
+        cc.set_known_struct_names(known_structs);
+        assert!(cc.is_known_struct("PyObject"));
+        assert!(!cc.is_known_struct("*mut PyObject"));
     }
 
     #[derive(Debug)]

--- a/majit/majit-translate/src/codewriter/call.rs
+++ b/majit/majit-translate/src/codewriter/call.rs
@@ -1072,9 +1072,14 @@ fn is_known_by_value_struct(
     type_name: &str,
 ) -> bool {
     let type_name = type_name.trim();
-    if type_name.starts_with("*mut ")
-        || type_name.starts_with("*const ")
-        || type_name.starts_with('&')
+    // A by-value struct is spelled as a nominal path.  Every non-nominal
+    // carrier opens with a sigil — `*mut`/`*const`, `&`/`&mut`, `[T]`/`[T; N]`,
+    // `(A, B)`, `dyn`/`impl` — so reject on the leading token structurally
+    // instead of enumerating each spelling; the by-name list below then only
+    // has to cover nominal wrappers that are pointers underneath.
+    if !type_name.starts_with(|c: char| c.is_alphabetic() || c == '_')
+        || type_name.starts_with("dyn ")
+        || type_name.starts_with("impl ")
         || type_name.starts_with("Box<")
         || type_name.starts_with("Arc<")
         || type_name.starts_with("Rc<")

--- a/majit/majit-translate/src/codewriter/jtransform.rs
+++ b/majit/majit-translate/src/codewriter/jtransform.rs
@@ -2881,6 +2881,34 @@ impl<'a> Transformer<'a> {
                 kind: OpKind::ConstRefNull,
             }]);
         }
+        // RPython `rtyper/rtuple.py:153-169 TupleRepr.newtuple`: every
+        // non-empty tuple is a `malloc(GcStruct)` followed by one `setfield`
+        // per item.  `front::mir` has already emitted those positional
+        // `FieldWrite`s after this synthetic aggregate constructor; lower the
+        // constructor itself to the matching allocation instead of treating
+        // it as a host call.  A residual synthetic call has no registered
+        // function address and would put its stable hash in JitCode as though
+        // it were executable code.
+        //
+        // The frontend names non-empty tuple shapes `Tuple<...>` while the
+        // exact bare `Tuple` above is the zero-item `Void` representation.
+        // Keep the owner-path gate: the universal MIR tuple aggregate has no
+        // Rust nominal owner, whereas a user ADT whose leaf happens to start
+        // with `Tuple` is a different allocation policy.
+        if let CallTarget::SyntheticTransparentCtor { name, owner_path } = target
+            && owner_path.is_empty()
+            && name != "Tuple"
+            && majit_ir::descr::strip_instantiation_suffix(name) == "Tuple"
+            && args.is_empty()
+            && let ValueType::Ref(Some(owner)) = result_ty
+        {
+            return RewriteResult::Replace(vec![SpaceOperation {
+                result: op.result.clone(),
+                kind: OpKind::New {
+                    owner: owner.clone(),
+                },
+            }]);
+        }
         // RPython `rtyper` lowers a heap-carried `Result` variant to
         // `malloc(GcStruct)` plus its discriminant/payload `setfield`s before
         // `jtransform`; `rewrite_op_malloc` then emits `new(descr)`.
@@ -9067,6 +9095,84 @@ mod tests {
             .find(|op| op.result.as_ref() == Some(&result_var))
             .expect("null result must survive as a constant definition");
         assert!(matches!(folded.kind, OpKind::ConstRefNull));
+    }
+
+    /// `rtuple.py:153-169 TupleRepr.newtuple`: a non-empty tuple lowers to
+    /// `malloc(GcStruct)`; the following per-item `FieldWrite`s supply the
+    /// `setfield`s.  It must never survive as a synthetic residual call.
+    #[test]
+    fn nonempty_synthetic_tuple_ctor_lowers_to_new() {
+        let config = GraphTransformConfig::default();
+        let mut transformer = Transformer::new(&config);
+        let mut graph = FunctionGraph::new("nonempty_tuple_malloc");
+        let result_var = graph.alloc_value_var_with_type(ConcreteType::GcRef);
+        let owner = "Tuple<PyObjectRef,Option<PyObjectRef>>".to_string();
+        let target = CallTarget::synthetic_transparent_ctor(owner.clone());
+        let result_ty = ValueType::Ref(Some(owner.clone()));
+        let op = SpaceOperation {
+            result: Some(result_var.clone()),
+            kind: OpKind::Call {
+                target: target.clone(),
+                args: vec![],
+                result_ty: result_ty.clone(),
+            },
+        };
+
+        let RewriteResult::Replace(ops) = transformer.rewrite_op_direct_call(
+            &op,
+            &target,
+            &[],
+            &result_ty,
+            "nonempty_tuple_malloc",
+            &mut graph,
+        ) else {
+            panic!("non-empty Tuple aggregate must lower to malloc");
+        };
+        assert!(matches!(
+            ops.as_slice(),
+            [SpaceOperation {
+                result: Some(result),
+                kind: OpKind::New { owner: allocated },
+            }] if result == &result_var && allocated == &owner
+        ));
+    }
+
+    /// The exact bare tuple tag is the empty tuple's `Void` representation,
+    /// not a heap allocation (`rtuple.py:160-161`).
+    #[test]
+    fn empty_synthetic_tuple_ctor_remains_null_ref_constant() {
+        let config = GraphTransformConfig::default();
+        let mut transformer = Transformer::new(&config);
+        let mut graph = FunctionGraph::new("empty_tuple_void");
+        let result_var = graph.alloc_value_var_with_type(ConcreteType::GcRef);
+        let target = CallTarget::synthetic_transparent_ctor("Tuple");
+        let result_ty = ValueType::Ref(Some("Tuple".into()));
+        let op = SpaceOperation {
+            result: Some(result_var.clone()),
+            kind: OpKind::Call {
+                target: target.clone(),
+                args: vec![],
+                result_ty: result_ty.clone(),
+            },
+        };
+
+        let RewriteResult::Replace(ops) = transformer.rewrite_op_direct_call(
+            &op,
+            &target,
+            &[],
+            &result_ty,
+            "empty_tuple_void",
+            &mut graph,
+        ) else {
+            panic!("empty Tuple aggregate must lower to its Void placeholder");
+        };
+        assert!(matches!(
+            ops.as_slice(),
+            [SpaceOperation {
+                result: Some(result),
+                kind: OpKind::ConstRefNull,
+            }] if result == &result_var
+        ));
     }
 
     /// PyPy parity regression guard: the qualified spellings

--- a/majit/majit-translate/src/codewriter/jtransform.rs
+++ b/majit/majit-translate/src/codewriter/jtransform.rs
@@ -2897,8 +2897,7 @@ impl<'a> Transformer<'a> {
         // with `Tuple` is a different allocation policy.
         if let CallTarget::SyntheticTransparentCtor { name, owner_path } = target
             && owner_path.is_empty()
-            && name != "Tuple"
-            && majit_ir::descr::strip_instantiation_suffix(name) == "Tuple"
+            && majit_ir::descr::is_shaped_tuple_name(name)
             && args.is_empty()
             && let ValueType::Ref(Some(owner)) = result_ty
         {
@@ -9135,6 +9134,54 @@ mod tests {
                 kind: OpKind::New { owner: allocated },
             }] if result == &result_var && allocated == &owner
         ));
+    }
+
+    /// The universal MIR tuple aggregate has no Rust nominal owner, so the
+    /// malloc arm is gated on an EMPTY `owner_path`.  A user ADT whose leaf
+    /// merely spells like a tuple shape carries an owner path and follows its
+    /// own allocation policy; it must not be captured by that arm.
+    #[test]
+    fn owned_tuple_named_synthetic_ctor_does_not_take_the_tuple_malloc_arm() {
+        let config = GraphTransformConfig::default();
+        let mut transformer = Transformer::new(&config);
+        let mut graph = FunctionGraph::new("owned_tuple_named_ctor");
+        let result_var = graph.alloc_value_var_with_type(ConcreteType::GcRef);
+        let owner = "mymod::Tuple<PyObjectRef>".to_string();
+        let target = CallTarget::synthetic_transparent_ctor_with_owner(
+            vec!["mymod".to_string()],
+            "Tuple<PyObjectRef>",
+        );
+        let result_ty = ValueType::Ref(Some(owner.clone()));
+        let op = SpaceOperation {
+            result: Some(result_var.clone()),
+            kind: OpKind::Call {
+                target: target.clone(),
+                args: vec![],
+                result_ty: result_ty.clone(),
+            },
+        };
+
+        let rewritten = transformer.rewrite_op_direct_call(
+            &op,
+            &target,
+            &[],
+            &result_ty,
+            "owned_tuple_named_ctor",
+            &mut graph,
+        );
+        if let RewriteResult::Replace(ops) = &rewritten {
+            assert!(
+                !matches!(
+                    ops.as_slice(),
+                    [SpaceOperation {
+                        kind: OpKind::New { owner: allocated },
+                        ..
+                    }] if allocated == &owner
+                ),
+                "an owner-qualified `Tuple<...>` leaf must not lower through \
+                 the universal tuple-aggregate malloc arm",
+            );
+        }
     }
 
     /// The exact bare tuple tag is the empty tuple's `Void` representation,

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -1238,6 +1238,22 @@ fn register_synthetic_tuple_metadata(
     }
 }
 
+/// Byte size of the explicit `Result` shell that carries `field_offsets`.
+///
+/// The shell is a non-overlapping `[tag@0 | payload@8 | ...]` laid out by this
+/// module rather than borrowed from Rust's enum layout, so its size follows
+/// from the offsets recorded for it: the last field's offset plus its word.
+/// A fixed 16 would truncate any shell that ever records more than one payload
+/// word.  The floor keeps a tag-only shell at the full `[tag | payload]` width,
+/// matching the `size.max(16)` the codewriter applies to the same shell.
+fn result_shell_size(field_offsets: &std::collections::HashMap<String, u64>) -> u64 {
+    field_offsets
+        .values()
+        .copied()
+        .max()
+        .map_or(16, |last| (last + 8).max(16))
+}
+
 /// Split `A,B<C,D>,[E;2]` at top-level commas only.
 fn split_top_level_type_args(input: &str) -> Vec<&str> {
     let mut out = Vec::new();
@@ -1587,7 +1603,7 @@ fn derive_program_metadata(
                         exact_layouts.insert(
                             base_sid,
                             crate::front::semantic::ExactLayout {
-                                size: Some(16),
+                                size: Some(result_shell_size(&base_offsets)),
                                 align: Some(8),
                                 field_offsets: base_offsets,
                             },
@@ -1660,7 +1676,7 @@ fn derive_program_metadata(
                         record_struct_id(&mut struct_ids, variant_canon.clone(), vsid);
                         if synthetic_result_shell {
                             let exact = crate::front::semantic::ExactLayout {
-                                size: Some(16),
+                                size: Some(result_shell_size(&voffsets)),
                                 align: Some(8),
                                 field_offsets: voffsets,
                             };

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -1243,9 +1243,14 @@ fn split_top_level_type_args(input: &str) -> Vec<&str> {
     let mut out = Vec::new();
     let mut depth = 0usize;
     let mut start = 0usize;
+    let mut prev = '\0';
     for (index, ch) in input.char_indices() {
         match ch {
             '<' | '(' | '[' => depth += 1,
+            // The `>` of a `->` return arrow closes nothing; treating it as a
+            // closer drops the depth a level early and splits a `Fn(A) -> B`
+            // argument at the next top-level comma.
+            '>' if prev == '-' => {}
             '>' | ')' | ']' => depth = depth.saturating_sub(1),
             ',' if depth == 0 => {
                 let item = input[start..index].trim();
@@ -1256,6 +1261,7 @@ fn split_top_level_type_args(input: &str) -> Vec<&str> {
             }
             _ => {}
         }
+        prev = ch;
     }
     let tail = input[start..].trim();
     if !tail.is_empty() {
@@ -1268,8 +1274,12 @@ fn tuple_field_value_type(type_name: &str) -> ValueType {
     match type_name.trim() {
         "()" => ValueType::Void,
         "f64" => ValueType::Float,
-        "bool" | "char" | "f32" | "i8" | "i16" | "i32" | "i64" | "i128" | "isize" | "u8"
-        | "u16" | "u32" | "u64" | "u128" | "usize" => ValueType::Int,
+        // 128-bit fields are twice the machine word, so they carry their own
+        // kind rather than collapsing into `Int` like the word-sized integers.
+        "i128" => ValueType::Int128,
+        "u128" => ValueType::UInt128,
+        "bool" | "char" | "f32" | "i8" | "i16" | "i32" | "i64" | "isize" | "u8" | "u16" | "u32"
+        | "u64" | "usize" => ValueType::Int,
         _ => ValueType::Ref(None),
     }
 }

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -1201,8 +1201,7 @@ fn register_synthetic_tuple_metadata(
             };
             if owner_path.is_empty()
                 && args.is_empty()
-                && name != "Tuple"
-                && majit_ir::descr::strip_instantiation_suffix(name) == "Tuple"
+                && majit_ir::descr::is_shaped_tuple_name(name)
             {
                 shapes.insert(name.clone());
             }

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -787,14 +787,14 @@ fn build_semantic_program_from_llbc_with_static_addrs_filtered(
 ) -> Result<crate::front::semantic::SemanticProgram, LowerError> {
     // ── Pass 1: walk type_decls + trait_decls ─────────────────────
     let (
-        known_struct_names,
+        mut known_struct_names,
         known_trait_names,
         mut struct_fields,
         mut enum_variant_by_discriminant,
         mut struct_origins,
-        struct_field_attrs,
+        mut struct_field_attrs,
         exact_layouts,
-        struct_ids,
+        mut struct_ids,
     ) = derive_program_metadata(llbc);
     harden_duplicate_leaf_metadata(
         &mut struct_fields,
@@ -1042,6 +1042,13 @@ fn build_semantic_program_from_llbc_with_static_addrs_filtered(
             returns_objectptr,
         });
     }
+    register_synthetic_tuple_metadata(
+        &functions,
+        &mut known_struct_names,
+        &mut struct_fields,
+        &mut struct_field_attrs,
+        &mut struct_ids,
+    );
     // Coverage gate. Every `skipped` entry is a function whose MIR shape
     // the driver could not lower — already after the reverse-postorder
     // retry in `lower_fun_decl`. The single known, tracked gap is an
@@ -1150,6 +1157,121 @@ fn should_lower_function(
     name: &str,
 ) -> bool {
     function_filter.is_none_or(|names| names.contains(name))
+}
+
+/// Register the low-level struct identity and fields for every non-empty MIR
+/// tuple shape that survived into a translated graph.
+///
+/// RPython creates one distinct `GcStruct('tupleN', item0, item1, ...)` per
+/// [`SomeTuple`] representation (`rtyper/rtuple.py:115-125`), then
+/// `TupleRepr.newtuple` allocates that struct and writes its fields
+/// (`rtuple.py:153-169`). Charon has no `TypeDecl` row for Rust's built-in
+/// tuple aggregate, so [`derive_program_metadata`] cannot discover these
+/// layouts from the declaration table. The graph is the authoritative
+/// rtyper input here: `front::mir` has already attached the complete
+/// `Tuple<T,...>` shape to the synthetic constructor and its `__pos_N`
+/// fields.
+///
+/// Each full shape gets its own [`StructId`]. Generic nominal ADTs share their
+/// template layout, but tuples do not: `(A,)` and `(A, B)` are distinct
+/// low-level struct objects in RPython and must not collapse onto a bare
+/// `Tuple` identity.
+fn register_synthetic_tuple_metadata(
+    functions: &[crate::front::semantic::SemanticFunction],
+    known_struct_names: &mut std::collections::HashSet<String>,
+    struct_fields: &mut crate::front::semantic::StructFieldRegistry,
+    struct_field_attrs: &mut std::collections::HashMap<String, Vec<(String, ValueType)>>,
+    struct_ids: &mut std::collections::HashMap<String, Option<majit_ir::descr::StructId>>,
+) {
+    let mut shapes = std::collections::BTreeSet::new();
+    for function in functions {
+        for op in function
+            .graph
+            .blocks
+            .iter()
+            .flat_map(|block| &block.operations)
+        {
+            let OpKind::Call {
+                target: CallTarget::SyntheticTransparentCtor { name, owner_path },
+                args,
+                ..
+            } = &op.kind
+            else {
+                continue;
+            };
+            if owner_path.is_empty()
+                && args.is_empty()
+                && name != "Tuple"
+                && majit_ir::descr::strip_instantiation_suffix(name) == "Tuple"
+            {
+                shapes.insert(name.clone());
+            }
+        }
+    }
+
+    for shape in shapes {
+        let Some(inner) = shape
+            .strip_prefix("Tuple<")
+            .and_then(|rest| rest.strip_suffix('>'))
+        else {
+            continue;
+        };
+        let items = split_top_level_type_args(inner);
+        if items.is_empty() {
+            continue;
+        }
+        let rows: Vec<(String, String)> = items
+            .iter()
+            .enumerate()
+            .map(|(index, ty)| (format!("__pos_{index}"), (*ty).to_string()))
+            .collect();
+        let attrs: Vec<(String, ValueType)> = items
+            .iter()
+            .enumerate()
+            .map(|(index, ty)| (format!("__pos_{index}"), tuple_field_value_type(ty)))
+            .collect();
+        let sid = majit_ir::descr::StructId::from_canonical(&shape);
+        known_struct_names.insert(shape.clone());
+        struct_fields.fields.insert(shape.clone(), rows);
+        struct_field_attrs.insert(shape.clone(), attrs);
+        record_struct_id(struct_ids, shape, sid);
+    }
+}
+
+/// Split `A,B<C,D>,[E;2]` at top-level commas only.
+fn split_top_level_type_args(input: &str) -> Vec<&str> {
+    let mut out = Vec::new();
+    let mut depth = 0usize;
+    let mut start = 0usize;
+    for (index, ch) in input.char_indices() {
+        match ch {
+            '<' | '(' | '[' => depth += 1,
+            '>' | ')' | ']' => depth = depth.saturating_sub(1),
+            ',' if depth == 0 => {
+                let item = input[start..index].trim();
+                if !item.is_empty() {
+                    out.push(item);
+                }
+                start = index + ch.len_utf8();
+            }
+            _ => {}
+        }
+    }
+    let tail = input[start..].trim();
+    if !tail.is_empty() {
+        out.push(tail);
+    }
+    out
+}
+
+fn tuple_field_value_type(type_name: &str) -> ValueType {
+    match type_name.trim() {
+        "()" => ValueType::Void,
+        "f64" => ValueType::Float,
+        "bool" | "char" | "f32" | "i8" | "i16" | "i32" | "i64" | "i128" | "isize" | "u8"
+        | "u16" | "u32" | "u64" | "u128" | "usize" => ValueType::Int,
+        _ => ValueType::Ref(None),
+    }
 }
 
 /// Derive whole-program type-metadata fields of `SemanticProgram` from
@@ -1424,6 +1546,20 @@ fn derive_program_metadata(
                 // `{enum_leaf}::{variant}`.  No cross-variant dedup: each
                 // variant owns its field namespace.
                 let enum_layout = td.layout_for_target(&target);
+                // `Result<T, E>` is not materialised as Rust's native enum in
+                // translated code.  The inverse exception transform removes
+                // ordinary `?` paths; a hand-written `match` that remains is
+                // represented by the explicit rtyper shell emitted below:
+                // `{ __discriminant: Signed, __pos_0: payload }`.  Rust's
+                // niche layout commonly places both the implicit tag and the
+                // payload at offset 0, but applying that host layout to this
+                // explicit shell makes the payload store overwrite the tag
+                // and every following switch take its unreachable default.
+                // RPython's low-level representation is the explicit fields
+                // the graph declares, so give that synthetic struct its own
+                // non-overlapping layout instead of borrowing Rust's enum
+                // layout.
+                let synthetic_result_shell = name == "core::result::Result";
                 // Register the enum BASE in `exact_layouts`: a single
                 // `__discriminant` field at the tag's real byte position
                 // (`discriminator.Branch.offset` via `discriminant_offset`).
@@ -1434,18 +1570,31 @@ fn derive_program_metadata(
                 // heuristic exactly; a single-variant type has no `Branch`
                 // tag (`discriminant_offset` → `None`) and also registers 0.
                 // Fieldless enums skip this (int-valued, no base ClassDef).
-                if !fieldless && let Some(l) = enum_layout.as_ref() {
-                    let mut base_offsets = std::collections::HashMap::new();
-                    base_offsets.insert(
-                        "__discriminant".to_string(),
-                        l.discriminant_offset().unwrap_or(0),
-                    );
-                    let base_exact = crate::front::semantic::ExactLayout {
-                        size: l.size,
-                        align: l.align,
-                        field_offsets: base_offsets,
-                    };
-                    exact_layouts.insert(base_sid, base_exact);
+                if !fieldless {
+                    if synthetic_result_shell {
+                        let mut base_offsets = std::collections::HashMap::new();
+                        base_offsets.insert("__discriminant".to_string(), 0);
+                        exact_layouts.insert(
+                            base_sid,
+                            crate::front::semantic::ExactLayout {
+                                size: Some(16),
+                                align: Some(8),
+                                field_offsets: base_offsets,
+                            },
+                        );
+                    } else if let Some(l) = enum_layout.as_ref() {
+                        let mut base_offsets = std::collections::HashMap::new();
+                        base_offsets.insert(
+                            "__discriminant".to_string(),
+                            l.discriminant_offset().unwrap_or(0),
+                        );
+                        let base_exact = crate::front::semantic::ExactLayout {
+                            size: l.size,
+                            align: l.align,
+                            field_offsets: base_offsets,
+                        };
+                        exact_layouts.insert(base_sid, base_exact);
+                    }
                 }
                 // Per-variant subclasses carry each variant's OWN payload
                 // fields; a fieldless enum has none, so it needs no variant
@@ -1475,9 +1624,12 @@ fn derive_program_metadata(
                                     tyref_to_attr_value_type(&f.ty, llbc),
                                 )
                             };
-                            if let Some(off) =
+                            let field_offset = if synthetic_result_shell {
+                                Some(8 + (i as u64) * 8)
+                            } else {
                                 enum_layout.as_ref().and_then(|l| l.field_offset(vidx, i))
-                            {
+                            };
+                            if let Some(off) = field_offset {
                                 voffsets.insert(fname.clone(), off);
                             }
                             vattrs.push((fname.clone(), attr_ty));
@@ -1496,7 +1648,14 @@ fn derive_program_metadata(
                         record_struct_id(&mut struct_ids, variant_qual.clone(), vsid);
                         record_struct_id(&mut struct_ids, variant_leaf.clone(), vsid);
                         record_struct_id(&mut struct_ids, variant_canon.clone(), vsid);
-                        if let Some(l) = enum_layout.as_ref() {
+                        if synthetic_result_shell {
+                            let exact = crate::front::semantic::ExactLayout {
+                                size: Some(16),
+                                align: Some(8),
+                                field_offsets: voffsets,
+                            };
+                            exact_layouts.insert(vsid, exact);
+                        } else if let Some(l) = enum_layout.as_ref() {
                             let exact = crate::front::semantic::ExactLayout {
                                 size: l.size,
                                 align: l.align,

--- a/pyre/bench/synth/inline_freevar_after_mayforce.py
+++ b/pyre/bench/synth/inline_freevar_after_mayforce.py
@@ -1,0 +1,30 @@
+# pyre-check: max-pypy-ratio=20
+# An inlined closure keeps its freevar cells in MIFrame.registers_r across a
+# may-force call.  The append invalidates heap-cache facts; the following
+# LOAD_DEREF must recover `adjust` from the callee frame's own shadow instead
+# of becoming an unstamped GetarrayitemGcR and aborting at the result branch.
+from fractions import Fraction
+
+
+N = 10000
+
+
+def make_forwarder():
+    def adjust(value):
+        return value + Fraction(3, 97)
+
+    def forward(value):
+        scaled = value / Fraction(2, 89)
+        return adjust(scaled)
+
+    return forward
+
+
+forward = make_forwarder()
+count = 0
+for i in range(N):
+    value = forward(Fraction(i % 97 + 1, 97))
+    if value > 1:
+        count += 1
+
+print(count)

--- a/pyre/bench/synth/inline_freevar_after_mayforce.py
+++ b/pyre/bench/synth/inline_freevar_after_mayforce.py
@@ -1,8 +1,19 @@
-# pyre-check: max-pypy-ratio=20
+# pyre-check: max-pypy-ratio=45
 # An inlined closure keeps its freevar cells in MIFrame.registers_r across a
-# may-force call.  The append invalidates heap-cache facts; the following
-# LOAD_DEREF must recover `adjust` from the callee frame's own shadow instead
-# of becoming an unstamped GetarrayitemGcR and aborting at the result branch.
+# may-force call.  The `Fraction` arithmetic in `forward` is that may-force
+# call and invalidates heap-cache facts; the following LOAD_DEREF must recover
+# `adjust` from the callee frame's own shadow instead of becoming an unstamped
+# GetarrayitemGcR and aborting at the result branch.
+#
+# The abort is what this fixture guards, and check.py's regression floor gates
+# `loops_aborted` at 0 independently of the ratio below.  The ratio itself has
+# measured 22-37x since the fixture landed (macOS dynasm 22.4x / cranelift
+# 28.9x, ubuntu dynasm 23.6x / cranelift 25.2x / wasm 37.1x) and has never met
+# the 20x it was first written with.  It stays high because the compiled loop
+# deopts on nearly every iteration: two guards take 16.4k of the 16.9k
+# `guard_failures` at N=10000 while `bridges_compiled` stays at 1, so the
+# guards are never patched.  That bridge gap is open work, not something this
+# gate should hide - keep the gate honest and lower it when the gap closes.
 from fractions import Fraction
 
 

--- a/pyre/bench/synth/math_log_trig_hot.py
+++ b/pyre/bench/synth/math_log_trig_hot.py
@@ -1,0 +1,18 @@
+# pyre-check: max-pypy-ratio=30
+# RPython lowers the guarded `ll_math_log/cos/sin` bodies to raw float calls.
+# Keep all inputs in their hot domains so the walker emits those CALL_F ops
+# and the temporary W_FloatObject results can virtualize.
+from math import cos, log, sin
+
+N = 200000
+
+
+def run():
+    total = 0.0
+    for i in range(N):
+        x = 1.0 + float(i % 97) / 97.0
+        total += log(x) + cos(x) + sin(x)
+    return total
+
+
+print(round(run(), 6))

--- a/pyre/bench/synth/tuple_unpack_array_backed_hot.py
+++ b/pyre/bench/synth/tuple_unpack_array_backed_hot.py
@@ -1,0 +1,20 @@
+# pyre-check: max-pypy-ratio=40
+# Exact, non-specialized tuples use the ordinary wrapped-items array.  Keep
+# fixed-length unpack on that storage visible to the trace while preserving
+# the generic path for tuple subclasses at the same call site.
+
+
+class TupleSubclass(tuple):
+    pass
+
+
+def unpack_sum(value, count):
+    total = 0
+    for _ in range(count):
+        a, b, c = value
+        total += a + b + c
+    return total
+
+
+print(unpack_sum((1, 2, 3), 20000))
+print(unpack_sum(TupleSubclass((4, 5, 6)), 3))

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -114,7 +114,7 @@ pub(crate) unsafe fn walk_pending_hash_error_area(
 pub fn clear_method_cache() {
     let mut cache = METHOD_CACHE.lock();
     cache.versions.fill(0);
-    cache.names.fill(std::ptr::null_mut());
+    cache.names.fill(None);
     cache
         .lookup_where
         .fill((std::ptr::null_mut(), std::ptr::null_mut()));
@@ -8476,17 +8476,13 @@ pub(crate) unsafe fn lookup_in_type_wtf8(w_type: PyObjectRef, name: &Wtf8) -> Op
 /// negative result (`_lookup_where_all_typeobjects` returned
 /// `(None, None)`).
 ///
-/// `names[h]` holds the interned name *object* and is validated by identity
-/// (`typeobject.py:541` `cache.names[method_hash] is name`), so a probe costs
-/// one pointer compare rather than a digest plus a `memcmp` over the bytes,
-/// and a fill stores the pointer rather than allocating a copy of the name.
-/// Every name reaching the cache comes from `box_str_constant`, which
-/// allocates through `malloc_typed`: the object is immortal and never
-/// relocated, so the slot needs no GC forwarding and its address is never
-/// reused by a later, different name (`null` = empty).
+/// `names[h]` is the untranslated string stored by upstream
+/// (`typeobject.py:541` `cache.names[method_hash] == name`). A fill owns one
+/// copy; a hit compares the incoming borrowed string without allocating or
+/// entering the Python-string intern table. `None` is an empty slot.
 struct MethodCache {
     versions: Vec<u64>,
-    names: Vec<PyObjectRef>,
+    names: Vec<Option<String>>,
     lookup_where: Vec<(PyObjectRef, PyObjectRef)>,
 }
 
@@ -8503,7 +8499,7 @@ static METHOD_CACHE: std::sync::LazyLock<parking_lot::Mutex<MethodCache>> =
     std::sync::LazyLock::new(|| {
         parking_lot::Mutex::new(MethodCache {
             versions: vec![0u64; METHOD_CACHE_SIZE],
-            names: vec![std::ptr::null_mut(); METHOD_CACHE_SIZE],
+            names: vec![None; METHOD_CACHE_SIZE],
             lookup_where: vec![(std::ptr::null_mut(), std::ptr::null_mut()); METHOD_CACHE_SIZE],
         })
     });
@@ -8511,16 +8507,13 @@ static METHOD_CACHE: std::sync::LazyLock<parking_lot::Mutex<MethodCache>> =
 /// `typeobject.py:520-535` method-hash.  `version_tag` is pyre's u64
 /// version token directly (PyPy hashes `current_object_addr_as_int(
 /// version_tag)`; the u64 is its own address-stable surrogate).
-/// `name_hash` only needs to be deterministic — the slot's validity is
-/// the exact `(version, name)` match, not the hash.  Upstream's
-/// `hash(name)` is the interned string's memoized digest, i.e. a
-/// per-name-object constant; the interned pointer is the same constant
-/// without the byte walk, so an FNV-1a over its bytes stands in.  Two
-/// threads that interned the same name into different objects then land
-/// in different slots instead of evicting each other from a shared one.
-fn method_hash(version_tag: u64, w_name: PyObjectRef) -> usize {
+/// `name_hash` only needs to be deterministic — the slot's validity is the
+/// exact `(version, name)` match, not the hash. Upstream's `compute_hash(name)`
+/// is a content hash; use the same FNV-1a content digest as pyre's other
+/// untranslated-name caches.
+fn method_hash(version_tag: u64, name: &str) -> usize {
     let mut name_hash: u64 = 0xcbf2_9ce4_8422_2325;
-    for b in (w_name as usize as u64).to_le_bytes() {
+    for &b in name.as_bytes() {
         name_hash ^= b as u64;
         name_hash = name_hash.wrapping_mul(0x0000_0100_0000_01b3);
     }
@@ -8575,10 +8568,11 @@ pub(crate) unsafe fn w_type_version_tag(w_type: PyObjectRef) -> u64 {
 /// thread-local / `String` machinery stays off the trace surface, as the
 /// former `dont_look_inside` ensured.
 ///
-/// `name` arrives as `w_name`, an interned immortal str object
-/// (`box_str_constant`), because the elidable call ABI cannot pass a
-/// `&str` and an interned pointer is the green token the trace folds on;
-/// the body reads it back via `w_str_get_value`.  The result is a raw
+/// `name` arrives on this JIT-only projection as `w_name`, an interned
+/// immortal str object (`box_str_constant`), because the elidable call ABI
+/// cannot pass a `&str`; the body reads the untranslated string back via
+/// `w_str_get_value`. The ordinary interpreter passes its `&str` directly to
+/// [`_cached_lookup_where_name`], matching upstream. The result here is a raw
 /// pointer — null is the cached negative result (`None`), since the call
 /// ABI cannot carry `Option`.  The `is_type` / `version_tag == 0` guards
 /// live in the front door, so this is only ever entered with a valid
@@ -8610,9 +8604,9 @@ pub unsafe fn _pure_lookup_where_with_method_cache(
 /// trace surface.  The value half runs first and fills the slot, so this
 /// call is a guaranteed cache hit.
 ///
-/// See [`_pure_lookup_where_with_method_cache`] for the interned-`w_name`
-/// ABI and the null-as-`None` convention (a negative result has a null
-/// `w_class`).
+/// See [`_pure_lookup_where_with_method_cache`] for the JIT-only interned
+/// `w_name` ABI and the null-as-`None` convention (a negative result has a
+/// null `w_class`).
 #[majit_macros::elidable]
 pub unsafe fn _pure_lookup_class_with_method_cache(
     w_type: PyObjectRef,
@@ -8628,20 +8622,32 @@ pub unsafe fn _pure_lookup_class_with_method_cache(
 /// _lookup_where_all_typeobjects`) and fills the slot with the
 /// `(w_class, w_value)` pair (`typeobject.py:545-549`).
 ///
-/// `w_name` must be an interned name object (`box_str_constant`): the slot
-/// is keyed by its address, so a collectable or non-interned string would
-/// let a later allocation at the same address answer a hit for a different
-/// name.
+/// `w_name` must be an exact string accepted by `w_str_get_value`; the shared
+/// cache itself is content-keyed, exactly like upstream's untranslated name
+/// array.
 unsafe fn _cached_lookup_where(
     w_type: PyObjectRef,
     w_name: PyObjectRef,
     version_tag: u64,
 ) -> (PyObjectRef, PyObjectRef) {
-    let h = method_hash(version_tag, w_name);
+    let name = pyre_object::unicodeobject::w_str_get_value(w_name);
+    _cached_lookup_where_name(w_type, name, version_tag)
+}
+
+/// Untranslated-string MethodCache probe/fill used by the ordinary
+/// interpreter. This is the direct Rust shape of
+/// `typeobject.py:_pure_lookup_where_with_method_cache(name, version_tag)`;
+/// the `w_name` wrapper above exists only for the JIT residual-call ABI.
+unsafe fn _cached_lookup_where_name(
+    w_type: PyObjectRef,
+    name: &str,
+    version_tag: u64,
+) -> (PyObjectRef, PyObjectRef) {
+    let h = method_hash(version_tag, name);
     // Probe without holding the borrow across the MRO walk below.
     let hit = {
         let cache = METHOD_CACHE.lock();
-        if cache.versions[h] == version_tag && cache.names[h] == w_name {
+        if cache.versions[h] == version_tag && cache.names[h].as_deref() == Some(name) {
             // A valid entry with null pointers is the cached negative result.
             Some(cache.lookup_where[h])
         } else {
@@ -8651,7 +8657,6 @@ unsafe fn _cached_lookup_where(
     if let Some(tup) = hit {
         return tup;
     }
-    let name = pyre_object::unicodeobject::w_str_get_value(w_name);
     let tup =
         lookup_where_pair(w_type, name).unwrap_or((std::ptr::null_mut(), std::ptr::null_mut()));
     // Prebuilt-family store: the cache slot is reached only by
@@ -8659,7 +8664,7 @@ unsafe fn _cached_lookup_where(
     pyre_object::gc_roots::mark_prebuilt_roots_dirty();
     let mut cache = METHOD_CACHE.lock();
     cache.versions[h] = version_tag;
-    cache.names[h] = w_name;
+    cache.names[h] = Some(name.to_owned());
     cache.lookup_where[h] = tup;
     tup
 }
@@ -8716,6 +8721,14 @@ pub(crate) unsafe fn lookup_where_with_method_cache(
         // typeobject.py:507-509 — no version tag: uncacheable.
         return lookup_where_pair(w_type, name);
     }
+    if !majit_metainterp::jit::we_are_jitted() {
+        let (w_class, w_value) = _cached_lookup_where_name(w_type, name, version_tag);
+        return if w_value.is_null() {
+            None
+        } else {
+            Some((w_class, w_value))
+        };
+    }
     // typeobject.py:510-511 — `w_class, w_value =
     // self._pure_lookup_where_with_method_cache(name, version_tag)`.  The
     // tuple is split across two single-register elidable residuals over the
@@ -8758,11 +8771,14 @@ pub(crate) unsafe fn lookup_in_type_where(w_type: PyObjectRef, name: &str) -> Op
         // typeobject.py:507-509 — no version tag: uncacheable.
         return lookup_in_type_where_uncached(w_type, name);
     }
-    // The elidable takes the name as an interned, immortal str object
-    // (`box_str_constant`: content-keyed, never freed).  The elidable call
-    // ABI cannot pass a `&str`, and the interned pointer is the green token
-    // the trace folds the lookup on (PyPy's `name` is already an interned
-    // W_StringObject green constant from the bytecode).
+    if !majit_metainterp::jit::we_are_jitted() {
+        let v = _cached_lookup_where_name(w_type, name, version_tag).1;
+        return if v.is_null() { None } else { Some(v) };
+    }
+    // The JIT elidable projection takes an interned, immortal str object
+    // (`box_str_constant`: content-keyed, never freed) because its residual
+    // call ABI cannot pass a `&str`. The ordinary interpreter returned through
+    // `_cached_lookup_where_name` above without materialising this wrapper.
     let w_name = pyre_object::unicodeobject::box_str_constant(rustpython_wtf8::Wtf8::new(name));
     // typeobject.py:510 — `_pure_lookup_where_with_method_cache(name, version_tag)`.
     let v = _pure_lookup_where_with_method_cache(w_type, w_name, version_tag);

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -809,38 +809,38 @@ fn call_builtin_code_positional(code: PyObjectRef, args: &[PyObjectRef]) -> PyRe
     // not the copied native slice, so mirror the gateway's own root frame and
     // reload immediately before invoking the builtin.
     let _roots = pyre_object::gc_roots::push_roots();
-    let root_base = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(code);
+    let root_base = _roots.base();
+    _roots.pin_root(code);
     for &arg in args {
-        pyre_object::gc_roots::pin_root(arg);
+        _roots.pin_root(arg);
     }
     // RPython's pop-roots reload produces ordinary live variables.  Spell the
     // common fixed-arity cases the same way so source translation sees no Rust
     // array slicing/indexing helpers between the live roots and the gateway
     // indirect call.  The uncommon variadic case stays a residual helper.
-    let current_code = pyre_object::gc_roots::shadow_stack_get(root_base);
+    let current_code = _roots.get(root_base);
     match args.len() {
         0 => finish_builtin_code_positional(current_code, &[]),
         1 => {
-            let a0 = pyre_object::gc_roots::shadow_stack_get(root_base + 1);
+            let a0 = _roots.get(root_base + 1);
             finish_builtin_code_positional(current_code, &[a0])
         }
         2 => {
-            let a0 = pyre_object::gc_roots::shadow_stack_get(root_base + 1);
-            let a1 = pyre_object::gc_roots::shadow_stack_get(root_base + 2);
+            let a0 = _roots.get(root_base + 1);
+            let a1 = _roots.get(root_base + 2);
             finish_builtin_code_positional(current_code, &[a0, a1])
         }
         3 => {
-            let a0 = pyre_object::gc_roots::shadow_stack_get(root_base + 1);
-            let a1 = pyre_object::gc_roots::shadow_stack_get(root_base + 2);
-            let a2 = pyre_object::gc_roots::shadow_stack_get(root_base + 3);
+            let a0 = _roots.get(root_base + 1);
+            let a1 = _roots.get(root_base + 2);
+            let a2 = _roots.get(root_base + 3);
             finish_builtin_code_positional(current_code, &[a0, a1, a2])
         }
         4 => {
-            let a0 = pyre_object::gc_roots::shadow_stack_get(root_base + 1);
-            let a1 = pyre_object::gc_roots::shadow_stack_get(root_base + 2);
-            let a2 = pyre_object::gc_roots::shadow_stack_get(root_base + 3);
-            let a3 = pyre_object::gc_roots::shadow_stack_get(root_base + 4);
+            let a0 = _roots.get(root_base + 1);
+            let a1 = _roots.get(root_base + 2);
+            let a2 = _roots.get(root_base + 3);
+            let a3 = _roots.get(root_base + 4);
             finish_builtin_code_positional(current_code, &[a0, a1, a2, a3])
         }
         nargs => call_builtin_code_many_from_roots(root_base, nargs),
@@ -2683,10 +2683,10 @@ pub fn call_function_impl_result(
     // pointers, so establish the same roots before the first collecting call
     // and dispatch from freshly reloaded values.
     let _roots = pyre_object::gc_roots::push_roots();
-    let root_base = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(callable);
+    let root_base = _roots.base();
+    _roots.pin_root(callable);
     for &arg in args {
-        pyre_object::gc_roots::pin_root(arg);
+        _roots.pin_root(arg);
     }
 
     // A JIT prologue may have published an overflow before entering this
@@ -2699,7 +2699,7 @@ pub fn call_function_impl_result(
     // their stack check in funccall_valuestack / the JIT callee prologue.
     crate::stack_check::drain_jit_pending_exception()?;
 
-    let callable = pyre_object::gc_roots::shadow_stack_get(root_base);
+    let callable = _roots.get(root_base);
     // RPython's GC transform reloads `Arguments.arguments_w` livevars in
     // place; it does not allocate another list at every ObjSpace call.  Keep
     // the common small call shape allocation-free and retain a Vec only for
@@ -2709,13 +2709,13 @@ pub fn call_function_impl_result(
     let mut wide_args = Vec::new();
     let args = if args.len() <= INLINE_ARGS {
         for (i, slot) in inline_args[..args.len()].iter_mut().enumerate() {
-            *slot = pyre_object::gc_roots::shadow_stack_get(root_base + 1 + i);
+            *slot = _roots.get(root_base + 1 + i);
         }
         &inline_args[..args.len()]
     } else {
         wide_args.reserve_exact(args.len());
         for i in 0..args.len() {
-            wide_args.push(pyre_object::gc_roots::shadow_stack_get(root_base + 1 + i));
+            wide_args.push(_roots.get(root_base + 1 + i));
         }
         wide_args.as_slice()
     };

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -2700,11 +2700,25 @@ pub fn call_function_impl_result(
     crate::stack_check::drain_jit_pending_exception()?;
 
     let callable = pyre_object::gc_roots::shadow_stack_get(root_base);
-    let mut rooted_args: Vec<PyObjectRef> = Vec::with_capacity(args.len());
-    for i in 0..args.len() {
-        rooted_args.push(pyre_object::gc_roots::shadow_stack_get(root_base + 1 + i));
-    }
-    let args = rooted_args.as_slice();
+    // RPython's GC transform reloads `Arguments.arguments_w` livevars in
+    // place; it does not allocate another list at every ObjSpace call.  Keep
+    // the common small call shape allocation-free and retain a Vec only for
+    // genuinely wide calls.
+    const INLINE_ARGS: usize = 8;
+    let mut inline_args = [PY_NULL; INLINE_ARGS];
+    let mut wide_args = Vec::new();
+    let args = if args.len() <= INLINE_ARGS {
+        for (i, slot) in inline_args[..args.len()].iter_mut().enumerate() {
+            *slot = pyre_object::gc_roots::shadow_stack_get(root_base + 1 + i);
+        }
+        &inline_args[..args.len()]
+    } else {
+        wide_args.reserve_exact(args.len());
+        for i in 0..args.len() {
+            wide_args.push(pyre_object::gc_roots::shadow_stack_get(root_base + 1 + i));
+        }
+        wide_args.as_slice()
+    };
 
     unsafe {
         if pyre_object::is_method(callable) {

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -3394,6 +3394,18 @@ mod tests {
     }
 
     #[test]
+    fn jit_trace_fnaddrs_covers_int_bit_length_gateway_wrapper() {
+        let bindings: HashMap<&'static str, i64> = jit_trace_fnaddrs().into_iter().collect();
+        let expected =
+            crate::typedef::__pyre_wrap_int_descr_bit_length as *const () as usize as i64;
+
+        assert_eq!(
+            bindings["pyre_interpreter::typedef::__pyre_wrap_int_descr_bit_length"],
+            expected,
+        );
+    }
+
+    #[test]
     fn jit_trace_fnaddrs_covers_generated_runtime_helper_families() {
         let bindings: HashMap<&'static str, i64> = jit_trace_fnaddrs().into_iter().collect();
 

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -3393,7 +3393,10 @@ mod tests {
         assert_eq!(bindings["module::_random::Random::genrand32"], expected);
     }
 
+    /// `BUILTIN_WRAPPER_DESCRIPTORS` is only pushed into the binding table off
+    /// wasm32, so the lookup below has nothing to find there.
     #[test]
+    #[cfg(not(target_arch = "wasm32"))]
     fn jit_trace_fnaddrs_covers_int_bit_length_gateway_wrapper() {
         let bindings: HashMap<&'static str, i64> = jit_trace_fnaddrs().into_iter().collect();
         let expected =

--- a/pyre/pyre-interpreter/src/module/_random/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_random/mod.rs
@@ -131,6 +131,21 @@ pub struct W_Random {
     rnd: Random,
 }
 
+// `has_mapdict_storage` admits a `_random.Random` to the shared mapdict path,
+// where `_obj_getdict` / `_obj_setdict` and `object_object_custom_trace` read
+// `map` and `storage` through a `W_ObjectObject` cast. Pin the prefix so a
+// field reorder here is a build error rather than a silently misread slot.
+const _: () = assert!(
+    std::mem::offset_of!(W_Random, map)
+        == std::mem::offset_of!(pyre_object::objectobject::W_ObjectObject, map),
+    "W_Random must keep W_ObjectObject's map offset"
+);
+const _: () = assert!(
+    std::mem::offset_of!(W_Random, storage)
+        == std::mem::offset_of!(pyre_object::objectobject::W_ObjectObject, storage),
+    "W_Random must keep W_ObjectObject's storage offset"
+);
+
 #[crate::pyre_methods(
     doc = "Random() -> create a random number generator.\n\nNot for security or cryptographic use.",
     weakrefable

--- a/pyre/pyre-interpreter/src/module/_random/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_random/mod.rs
@@ -120,6 +120,14 @@ impl Random {
 #[crate::pyre_class("_random.Random")]
 #[derive(Default)]
 pub struct W_Random {
+    /// PyPy composes `MapdictStorageMixin` into a native-layout object when
+    /// `space.allocate_instance(W_Random, w_subtype)` allocates a Python
+    /// subclass (`objspace.py:485-487`, `mapdict.py:907-910`).  Keep the same
+    /// `[PyObject | map | storage]` prefix as `W_ObjectObject`, so the shared
+    /// mapdict implementation can operate on both layouts.  The builtin
+    /// `_random.Random` itself simply retains the empty/null state.
+    pub map: *const u8,
+    pub storage: *mut pyre_object::object_array::ItemsBlock,
     rnd: Random,
 }
 

--- a/pyre/pyre-interpreter/src/module/math/interp_math.rs
+++ b/pyre/pyre-interpreter/src/module/math/interp_math.rs
@@ -220,6 +220,9 @@ pm1_edom!(atanh, "expected a number between -1 and 1");
 pm1_edom!(sqrt, "expected a nonnegative input");
 
 static MATH_SQRT_WRAPPER: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+static MATH_LOG_WRAPPER: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+static MATH_COS_WRAPPER: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+static MATH_SIN_WRAPPER: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
 static MATH_FREXP_WRAPPER: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
 static MATH_LDEXP_WRAPPER: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
 static MATH_ISQRT_WRAPPER: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
@@ -234,6 +237,9 @@ static MATH_ISQRT_WRAPPER: std::sync::OnceLock<usize> = std::sync::OnceLock::new
 pub fn register_jit_builtin_wrappers(ns: PyObjectRef) {
     for (name, slot) in [
         ("sqrt", &MATH_SQRT_WRAPPER),
+        ("log", &MATH_LOG_WRAPPER),
+        ("cos", &MATH_COS_WRAPPER),
+        ("sin", &MATH_SIN_WRAPPER),
         ("frexp", &MATH_FREXP_WRAPPER),
         ("ldexp", &MATH_LDEXP_WRAPPER),
         ("isqrt", &MATH_ISQRT_WRAPPER),
@@ -273,6 +279,18 @@ unsafe fn math_builtin_wrapper_matches(
 /// monkeypatched `math.sqrt` correctly declines the pure-inline specialization.
 pub fn is_math_sqrt_function(callable: PyObjectRef) -> bool {
     unsafe { math_builtin_wrapper_matches(callable, &MATH_SQRT_WRAPPER) }
+}
+
+pub fn is_math_log_function(callable: PyObjectRef) -> bool {
+    unsafe { math_builtin_wrapper_matches(callable, &MATH_LOG_WRAPPER) }
+}
+
+pub fn is_math_cos_function(callable: PyObjectRef) -> bool {
+    unsafe { math_builtin_wrapper_matches(callable, &MATH_COS_WRAPPER) }
+}
+
+pub fn is_math_sin_function(callable: PyObjectRef) -> bool {
+    unsafe { math_builtin_wrapper_matches(callable, &MATH_SIN_WRAPPER) }
 }
 
 /// Callable-identity probes used by the meta-trace walker.  As with

--- a/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
+++ b/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
@@ -352,6 +352,26 @@ pub unsafe fn ensure_type_terminator(w_type: PyObjectRef) -> *const u8 {
     unsafe { type_terminator_or_create(w_type) as *const u8 }
 }
 
+/// Whether `obj` carries the `[PyObject | map | storage]` prefix supplied by
+/// PyPy's `MapdictStorageMixin` (`mapdict.py:748-761, 905-910`).  Ordinary
+/// user instances have that prefix in `W_ObjectObject`; native-layout
+/// `_random.Random` instances carry it explicitly because
+/// `allocate_instance(W_Random, w_subtype)` composes the same mixin for Python
+/// subclasses upstream.  Keeping this as a layout predicate lets all mapdict
+/// operations share the original node/storage machinery instead of creating
+/// a per-native-type attribute side table.
+///
+/// # Safety
+/// `obj` must be null or a live object reference.
+#[inline]
+pub unsafe fn has_mapdict_storage(obj: PyObjectRef) -> bool {
+    if obj.is_null() || unsafe { pyre_object::is_type(obj) } {
+        return false;
+    }
+    (unsafe { pyre_object::is_instance(obj) })
+        || unsafe { pyre_object::py_type_check(obj, &crate::module::_random::RANDOM_TYPE) }
+}
+
 /// Fetch `w_type`'s instance terminator, lazily creating and storing it on the
 /// type if absent (covering types built before the eager install site).
 ///
@@ -606,7 +626,7 @@ pub unsafe fn instance_del_weakref_slot(obj: PyObjectRef) {
 #[majit_macros::dont_look_inside]
 pub unsafe fn getslotvalue(obj: PyObjectRef, slotindex: u32) -> Option<PyObjectRef> {
     assert!(
-        unsafe { pyre_object::is_instance(obj) },
+        unsafe { has_mapdict_storage(obj) },
         "W_Root.getslotvalue: receiver has no mapdict slot storage"
     );
     ensure_mapdict_initialized(obj);
@@ -633,7 +653,7 @@ pub unsafe fn getslotvalue(obj: PyObjectRef, slotindex: u32) -> Option<PyObjectR
 #[majit_macros::dont_look_inside]
 pub unsafe fn setslotvalue(obj: PyObjectRef, slotindex: u32, w_value: PyObjectRef) {
     assert!(
-        unsafe { pyre_object::is_instance(obj) },
+        unsafe { has_mapdict_storage(obj) },
         "W_Root.setslotvalue: receiver has no mapdict slot storage"
     );
     ensure_mapdict_initialized(obj);
@@ -659,7 +679,7 @@ pub unsafe fn setslotvalue(obj: PyObjectRef, slotindex: u32, w_value: PyObjectRe
 #[majit_macros::dont_look_inside]
 pub unsafe fn delslotvalue(obj: PyObjectRef, slotindex: u32) -> bool {
     assert!(
-        unsafe { pyre_object::is_instance(obj) },
+        unsafe { has_mapdict_storage(obj) },
         "W_Root.delslotvalue: receiver has no mapdict slot storage"
     );
     ensure_mapdict_initialized(obj);
@@ -1082,10 +1102,7 @@ unsafe fn mapdict_map_or_null(w_obj: PyObjectRef) -> MapRef {
     // mix in MapdictStorageMixin.  Let type attribute stores reach the
     // metatype data descriptors (__name__, __qualname__, __module__, ...)
     // instead of treating the type object's header as mapdict storage.
-    if w_obj.is_null()
-        || unsafe { pyre_object::is_type(w_obj) }
-        || !unsafe { pyre_object::is_instance(w_obj) }
-    {
+    if !unsafe { has_mapdict_storage(w_obj) } {
         return std::ptr::null();
     }
     unsafe { ensure_mapdict_initialized(w_obj) };
@@ -3883,12 +3900,13 @@ pub fn _obj_getdict(self_ref: PyObjectRef) -> PyObjectRef {
     // makes the view funnel every get/set/del/iter through the instance map+storage
     // — the single `__dict__` authority.
     //
-    // Only a `W_ObjectObject` carries a mapdict. User subclasses of builtin
-    // types (`class MyInt(int)`) keep the builtin layout (no map) while their
-    // type is hasdict, so their `__dict__` stays in the address-keyed
-    // INSTANCE_DICT side table as a plain own-storage dict until subclass
-    // instances grow mapdict storage (upstream `user_setup`, mapdict.py:758).
-    if unsafe { pyre_object::is_instance(self_ref) } {
+    // Only an object that carries mapdict storage answers out of the map —
+    // the same gate `_obj_setdict` applies. User subclasses of builtin types
+    // (`class MyInt(int)`) keep the builtin layout (no map) while their type is
+    // hasdict, so their `__dict__` stays in the address-keyed INSTANCE_DICT
+    // side table as a plain own-storage dict until subclass instances grow
+    // mapdict storage (upstream `user_setup`, mapdict.py:758).
+    if unsafe { has_mapdict_storage(self_ref) } {
         // mapdict.py:828-830 `if w_dict is not None`.  RPython's `read` answers
         // None both for an absent slot and for one holding None, and both mean
         // "build the view" — so a null must not reach the caller.  It would be
@@ -4226,7 +4244,7 @@ pub fn _obj_setdict(self_ref: PyObjectRef, w_dict: PyObjectRef) -> Result<(), Py
             "setting dictionary to a non-dict".to_string(),
         ));
     }
-    if unsafe { pyre_object::is_instance(self_ref) } {
+    if unsafe { has_mapdict_storage(self_ref) } {
         // mapdict.py:892-900: the old dict has `self` as its dstorage, so
         // before pointing the "dict" SPECIAL slot at the new dict, force the
         // old view to its own storage if it is still an instance-backed
@@ -4279,7 +4297,7 @@ pub fn _obj_setdict(self_ref: PyObjectRef, w_dict: PyObjectRef) -> Result<(), Py
 ///     return lifeline
 /// ```
 pub fn getweakref(self_ref: PyObjectRef) -> Option<PyObjectRef> {
-    if unsafe { pyre_object::is_instance(self_ref) } {
+    if unsafe { has_mapdict_storage(self_ref) } {
         unsafe { instance_get_weakref_slot(self_ref) }
     } else {
         WEAKREF_TABLE
@@ -4300,7 +4318,7 @@ pub fn getweakref(self_ref: PyObjectRef) -> Option<PyObjectRef> {
 ///     self._get_mapdict_map().write(self, "weakref", SPECIAL, weakreflifeline)
 /// ```
 pub fn setweakref(self_ref: PyObjectRef, weakreflifeline: PyObjectRef) {
-    if unsafe { pyre_object::is_instance(self_ref) } {
+    if unsafe { has_mapdict_storage(self_ref) } {
         let flag = unsafe { instance_set_weakref_slot(self_ref, weakreflifeline) };
         debug_assert!(flag, "write to the weakref SPECIAL slot failed");
     } else {
@@ -4315,7 +4333,7 @@ pub fn setweakref(self_ref: PyObjectRef, weakreflifeline: PyObjectRef) {
 ///     self._get_mapdict_map().write(self, "weakref", SPECIAL, None)
 /// ```
 pub fn delweakref(self_ref: PyObjectRef) {
-    if unsafe { pyre_object::is_instance(self_ref) } {
+    if unsafe { has_mapdict_storage(self_ref) } {
         unsafe { instance_del_weakref_slot(self_ref) };
     } else {
         WEAKREF_TABLE.lock().unwrap().remove(&(self_ref as usize));

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -643,7 +643,7 @@ impl FrameBox {
             // argument / locals objects; remember it for the next minor
             // tracer, exactly as `generator.rs:72` does for a stable
             // generator wrapping young frame contents.
-            pyre_object::gc_hook::try_gc_write_barrier(raw);
+            pyre_object::gc_hook::try_gc_write_barrier_managed(raw);
             let owner_root =
                 majit_gc::shadow_stack::OwnerRootGuard::new(majit_ir::GcRef(ptr as usize));
             drop(frame_root);

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -717,6 +717,19 @@ impl FrameBox {
         self.ptr
     }
 
+    /// Does the collector own this frame, so that [`Drop`] leaves the memory
+    /// alive for whatever roots still reach it?
+    ///
+    /// `false` is the [`FrameBox::new_boxed`] fallback, whose `Drop` frees the
+    /// frame at scope end — a caller that publishes `as_mut_ptr` past its own
+    /// scope must ask this first.  Answered from the ownership decision
+    /// [`FrameBox::new`] already made, so it neither re-enters the collector
+    /// (an ownership query can park behind another thread's collection) nor
+    /// relies on an address range test.
+    pub fn is_gc_owned(&self) -> bool {
+        self.owner_root.is_some()
+    }
+
     /// pyframe.py:259 initialize_as_generator — wrap this frame in a generator
     /// object that takes ownership of it. PyPy does `GeneratorIterator(self)`:
     /// the generator references the same frame, no copy. FrameBox already holds

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -14759,6 +14759,29 @@ cmp_dunder_set!(
 
 type DunderFn = fn(&[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>;
 
+/// Source-level spelling of `rbigint.bit_length`'s implicit OverflowError
+/// edge, in the same shape as `descroperation`'s `bigint_lshift_count` /
+/// `bigint_pow_nomod`.
+///
+/// `RBigInt::bit_length` returns `Result<i64, RBigIntError>`, but
+/// `scalar_residual_for_method` retargets the call to the raising scalar
+/// residual `jit_bigint_bit_length`, whose result is a bare Signed word and
+/// whose error travels the implicit exception edge. A caller that destructures
+/// the pre-retarget `Result` in a lowered graph reads `__discriminant` /
+/// `__pos_0` off that erased word — an integer used as an aggregate base.
+/// Keeping the match behind this boundary converts the carrier to the
+/// `Result<_, PyError>` the exception transform models.
+#[majit_macros::dont_look_inside]
+fn long_bit_length(value: &BigInt) -> Result<i64, crate::PyError> {
+    match value.bit_length() {
+        Ok(bits) => Ok(bits),
+        Err(pyre_object::rbigint::RBigIntError::Overflow) => {
+            Err(crate::PyError::overflow_error("too many digits in integer"))
+        }
+        Err(_) => unreachable!("rbigint.bit_length only raises OverflowError"),
+    }
+}
+
 /// `intobject.py:657 W_IntObject.descr_bit_length` /
 /// `longobject.py:48 W_AbstractLongObject.descr_bit_length`, exposed through
 /// `interpindirect2app` (`intobject.py:1171`).
@@ -14782,13 +14805,7 @@ pub fn __pyre_wrap_int_descr_bit_length(
         pyre_object::rbigint::bit_length_int(unsafe { pyre_object::w_int_get_value(args[0]) })
             as u64
     } else if !args.is_empty() && unsafe { pyre_object::is_long(args[0]) } {
-        match unsafe { pyre_object::w_long_get_value(args[0]).bit_length() } {
-            Ok(bits) => bits as u64,
-            Err(pyre_object::rbigint::RBigIntError::Overflow) => {
-                return Err(crate::PyError::overflow_error("too many digits in integer"));
-            }
-            Err(_) => unreachable!("rbigint.bit_length only raises OverflowError"),
-        }
+        long_bit_length(unsafe { pyre_object::w_long_get_value(args[0]) })? as u64
     } else {
         0
     };

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -14759,6 +14759,55 @@ cmp_dunder_set!(
 
 type DunderFn = fn(&[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>;
 
+/// `intobject.py:657 W_IntObject.descr_bit_length` /
+/// `longobject.py:48 W_AbstractLongObject.descr_bit_length`, exposed through
+/// `interpindirect2app` (`intobject.py:1171`).
+///
+/// This must be a named gateway wrapper, not an `init_int_type` closure:
+/// RPython's `BuiltinCode.func` is a PBC containing the generated interp2app
+/// function graphs. Publishing the wrapper descriptor below gives pyre's
+/// source translator the same candidate graph and lets a traced
+/// `int.bit_length()` call descend to `rbigint::bit_length_int`.
+pub fn __pyre_wrap_int_descr_bit_length(
+    args: &[PyObjectRef],
+) -> Result<PyObjectRef, crate::PyError> {
+    // `intobject.py descr_bit_length` — number of bits in the absolute
+    // value, so long/bigint operands must route through their magnitude
+    // rather than the i64 fast path (which leaves out-of-range values at 0).
+    let bits = if !args.is_empty() && unsafe { pyre_object::is_bool(args[0]) } {
+        pyre_object::rbigint::bit_length_int(unsafe {
+            pyre_object::w_bool_get_value(args[0]) as i64
+        }) as u64
+    } else if !args.is_empty() && unsafe { pyre_object::is_int(args[0]) } {
+        pyre_object::rbigint::bit_length_int(unsafe { pyre_object::w_int_get_value(args[0]) })
+            as u64
+    } else if !args.is_empty() && unsafe { pyre_object::is_long(args[0]) } {
+        match unsafe { pyre_object::w_long_get_value(args[0]).bit_length() } {
+            Ok(bits) => bits as u64,
+            Err(pyre_object::rbigint::RBigIntError::Overflow) => {
+                return Err(crate::PyError::overflow_error("too many digits in integer"));
+            }
+            Err(_) => unreachable!("rbigint.bit_length only raises OverflowError"),
+        }
+    } else {
+        0
+    };
+    Ok(pyre_object::w_int_new(bits as i64))
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[linkme::distributed_slice(crate::gateway::BUILTIN_WRAPPER_DESCRIPTORS)]
+#[allow(non_upper_case_globals)]
+static __majit_builtin_wrapper_target_int_descr_bit_length:
+    crate::gateway::BuiltinWrapperDescriptor = crate::gateway::BuiltinWrapperDescriptor {
+    path: concat!(
+        module_path!(),
+        "::",
+        stringify!(__pyre_wrap_int_descr_bit_length)
+    ),
+    func: __pyre_wrap_int_descr_bit_length,
+};
+
 fn init_int_type(ns: PyObjectRef) {
     unsafe {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
@@ -14869,40 +14918,7 @@ fn init_int_type(ns: PyObjectRef) {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
             ns,
             "bit_length",
-            make_builtin_function_with_arity(
-                "bit_length",
-                |args| {
-                    // `intobject.py descr_bit_length` — number of bits in the
-                    // absolute value, so long/bigint operands must route
-                    // through their magnitude rather than the i64 fast path
-                    // (which leaves out-of-range values at 0).
-                    let bits = if !args.is_empty() && unsafe { pyre_object::is_bool(args[0]) } {
-                        pyre_object::rbigint::bit_length_int(unsafe {
-                            pyre_object::w_bool_get_value(args[0]) as i64
-                        }) as u64
-                    } else if !args.is_empty() && unsafe { pyre_object::is_int(args[0]) } {
-                        pyre_object::rbigint::bit_length_int(unsafe {
-                            pyre_object::w_int_get_value(args[0])
-                        }) as u64
-                    } else if !args.is_empty() && unsafe { pyre_object::is_long(args[0]) } {
-                        match unsafe { pyre_object::w_long_get_value(args[0]).bit_length() } {
-                            Ok(bits) => bits as u64,
-                            Err(pyre_object::rbigint::RBigIntError::Overflow) => {
-                                return Err(crate::PyError::overflow_error(
-                                    "too many digits in integer",
-                                ));
-                            }
-                            Err(_) => {
-                                unreachable!("rbigint.bit_length only raises OverflowError")
-                            }
-                        }
-                    } else {
-                        0
-                    };
-                    Ok(pyre_object::w_int_new(bits as i64))
-                },
-                1,
-            ),
+            make_builtin_function_with_arity("bit_length", __pyre_wrap_int_descr_bit_length, 1),
         )
     };
     unsafe {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/bridge_subwalk.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/bridge_subwalk.rs
@@ -900,6 +900,7 @@ pub(crate) fn drive_bridge_frame_subwalk<Sym: WalkSym>(
     callee_w_globals: usize,
     entry: usize,
     argboxes_r: &[OpRef],
+    local_oprefs: &[OpRef],
     local_concretes: &[majit_ir::Value],
     child_result: Option<OpRef>,
     paused_parent_recipes: &[majit_metainterp::ReconstructRecipe],
@@ -1134,6 +1135,13 @@ pub(crate) fn drive_bridge_frame_subwalk<Sym: WalkSym>(
         // `getarrayitem_vable(frame, slot)` read fold to its value, so a nested
         // self-recursive call's int arg is known (`arg_is_int`) and the call
         // folds to `CALL_ASSEMBLER` instead of declining.
+        for (slot, &opref) in local_oprefs.iter().enumerate() {
+            sub_wc
+                .callee_shadow
+                .as_mut()
+                .unwrap()
+                .set_opref(slot as i64, opref);
+        }
         for (slot, &v) in local_concretes.iter().enumerate() {
             sub_wc.callee_shadow.as_mut().unwrap().set_concrete(
                 callee_pjc.metadata.portal_frame_reg,
@@ -1158,6 +1166,7 @@ pub(crate) fn drive_bridge_carrier_subwalk<Sym: WalkSym>(
     callee_w_globals: usize,
     entry: usize,
     argboxes_r: &[OpRef],
+    local_oprefs: &[OpRef],
     local_concretes: &[majit_ir::Value],
     paused_parent_recipes: &[majit_metainterp::ReconstructRecipe],
 ) -> Option<Result<(DispatchOutcome, usize), DispatchError>> {
@@ -1171,6 +1180,7 @@ pub(crate) fn drive_bridge_carrier_subwalk<Sym: WalkSym>(
         callee_w_globals,
         entry,
         argboxes_r,
+        local_oprefs,
         local_concretes,
         None,
         paused_parent_recipes,
@@ -1188,6 +1198,7 @@ pub(crate) fn drive_bridge_middle_frame<Sym: WalkSym>(
     middle_w_globals: usize,
     entry: usize,
     argboxes_r: &[OpRef],
+    local_oprefs: &[OpRef],
     local_concretes: &[majit_ir::Value],
     paused_parent_recipes: &[majit_metainterp::ReconstructRecipe],
     child_result: OpRef,
@@ -1202,6 +1213,7 @@ pub(crate) fn drive_bridge_middle_frame<Sym: WalkSym>(
         middle_w_globals,
         entry,
         argboxes_r,
+        local_oprefs,
         local_concretes,
         Some(child_result),
         paused_parent_recipes,

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/bridge_subwalk.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/bridge_subwalk.rs
@@ -994,6 +994,16 @@ pub(crate) fn drive_bridge_frame_subwalk<Sym: WalkSym>(
             concrete_r[i] = ConcreteValue::Ref(ptr as pyre_object::PyObjectRef);
         }
     }
+    let concrete_callee_frame = regs_r
+        .get(callee_pjc.metadata.portal_frame_reg as usize)
+        .and_then(|&frame_box| ctx.box_value(frame_box))
+        .and_then(|value| match value {
+            majit_ir::Value::Ref(frame) if !frame.is_null() => {
+                Some(frame.as_usize() as *mut pyre_interpreter::PyFrame)
+            }
+            _ => None,
+        })
+        .unwrap_or(std::ptr::null_mut());
     if let Some(result) = child_result {
         let call_dst_reg = call_dst_reg_for_residual_return(jc.code.as_slice(), entry)?;
         if call_dst_reg >= regs_r.len() {
@@ -1108,6 +1118,12 @@ pub(crate) fn drive_bridge_frame_subwalk<Sym: WalkSym>(
         };
         let _inline_frame =
             InlineFrameGuard::enter(session, callee_code_key, Some(parent_for_current));
+        // `MIFrame` owns one concrete red frame at every inline depth.  The
+        // bridge-resume sub-walk must publish its reconstructed frame just as
+        // the forward-inline sub-walk does; vable stores then write through to
+        // this frame's own locals array, and residual calls publish the same
+        // frame on the execution-context chain.
+        let _inline_concrete_frame = InlineConcreteFrameGuard::enter(concrete_callee_frame);
         // Nested self-recursive calls inside the resumed callee fold straight to
         // a recursive-portal CALL_ASSEMBLER (the bridge is the deopt
         // continuation, not a fresh unroll).

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/bridge_subwalk.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/bridge_subwalk.rs
@@ -995,16 +995,6 @@ pub(crate) fn drive_bridge_frame_subwalk<Sym: WalkSym>(
             concrete_r[i] = ConcreteValue::Ref(ptr as pyre_object::PyObjectRef);
         }
     }
-    let concrete_callee_frame = regs_r
-        .get(callee_pjc.metadata.portal_frame_reg as usize)
-        .and_then(|&frame_box| ctx.box_value(frame_box))
-        .and_then(|value| match value {
-            majit_ir::Value::Ref(frame) if !frame.is_null() => {
-                Some(frame.as_usize() as *mut pyre_interpreter::PyFrame)
-            }
-            _ => None,
-        })
-        .unwrap_or(std::ptr::null_mut());
     if let Some(result) = child_result {
         let call_dst_reg = call_dst_reg_for_residual_return(jc.code.as_slice(), entry)?;
         if call_dst_reg >= regs_r.len() {
@@ -1119,12 +1109,16 @@ pub(crate) fn drive_bridge_frame_subwalk<Sym: WalkSym>(
         };
         let _inline_frame =
             InlineFrameGuard::enter(session, callee_code_key, Some(parent_for_current));
-        // `MIFrame` owns one concrete red frame at every inline depth.  The
-        // bridge-resume sub-walk must publish its reconstructed frame just as
-        // the forward-inline sub-walk does; vable stores then write through to
-        // this frame's own locals array, and residual calls publish the same
-        // frame on the execution-context chain.
-        let _inline_concrete_frame = InlineConcreteFrameGuard::enter(concrete_callee_frame);
+        // No `InlineConcreteFrameGuard` here.  A forward-inline sub-walk owns
+        // the callee frame it publishes, so retargeting `last_instr` /
+        // `valuestackdepth` onto it is the whole point.  A bridge-resume
+        // sub-walk does not: its callee frame is the resume-decoded portal
+        // register, and publishing it makes `LiveLastInstrGuard` and
+        // `current_inline_vable_target` retarget onto that frame while
+        // `setfield_vable_via_metainterp`'s `INLINE_CONCRETE_FRAME.is_null()`
+        // arm stops syncing the walk's own virtualizable.  The live frame's
+        // `last_instr` / `valuestackdepth` then stay at the last resume point,
+        // so the blackhole reads an operand stack that was never published.
         // Nested self-recursive calls inside the resumed callee fold straight to
         // a recursive-portal CALL_ASSEMBLER (the bridge is the deopt
         // continuation, not a fresh unroll).

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -3906,6 +3906,25 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
                 shadow.set_opref(slot, value);
                 shadow.set_concrete(callee_portal_frame_reg, slot, concrete);
             }
+            // `MIFrame.registers_r` retains cell/freevar slots across a
+            // may-force call just like ordinary locals.  The heapcache entry
+            // installed by `emit_new_pyframe_inline_with_params` is only a
+            // forwarding optimization and is invalidated by that call; seed
+            // the frame-local shadow too so a later LOAD_DEREF re-reads the
+            // same live cell instead of manufacturing an unstamped
+            // GetarrayitemGcR result.  This callee shape has no fresh cellvars
+            // (rejected above), so existing freevars begin at `nlocals`.
+            for (i, &cell) in concrete_freevar_cells.iter().enumerate() {
+                let slot = (callee_code.varnames.len() + i) as i64;
+                let value = sub_wc.trace_ctx.const_ref(cell as i64);
+                let shadow = sub_wc.callee_shadow.as_mut().unwrap();
+                shadow.set_opref(slot, value);
+                shadow.set_concrete(
+                    callee_portal_frame_reg,
+                    slot,
+                    majit_ir::Value::Ref(majit_ir::GcRef(cell as usize)),
+                );
+            }
         }
         // Capture a depth-1 live callee before these guards drop. This is the
         // two-frame specialization of `run_blackhole_interp_to_cancel_tracing`:

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -7126,11 +7126,12 @@ fn walker_guard_class<Sym: WalkSym>(
     Ok(())
 }
 
-/// Guard the fixed-layout instance representation, the receiver type's live
-/// version tag, and the exact map shape used by the mapdict attribute folds.
-/// `INSTANCE_TYPE` proves the receiver has `W_ObjectObject` fields; the
-/// promoted map identity pins its class and storage coordinates
-/// (mapdict.py).
+/// Guard the fixed-layout mapdict-carrier representation, the receiver type's
+/// live version tag, and the exact map shape used by the mapdict attribute
+/// folds.  The concrete layout vtable proves that the receiver has the shared
+/// `[PyObject | map | storage]` prefix (`W_ObjectObject`, or a native-layout
+/// carrier such as `W_Random`); the promoted map identity pins its class and
+/// storage coordinates (mapdict.py).
 fn walker_guard_mapdict_instance_shape<Sym: WalkSym>(
     ctx: &mut WalkContext<'_, '_, Sym>,
     op_pc: usize,
@@ -7139,13 +7140,20 @@ fn walker_guard_mapdict_instance_shape<Sym: WalkSym>(
     version_tag: u64,
     map: pyre_interpreter::objspace::std::mapdict::MapRef,
 ) -> Result<(), DispatchError> {
-    let instance_type_addr = &pyre_object::pyobject::INSTANCE_TYPE as *const _ as i64;
+    // `load/store_attr_*_fast_path` accepted this receiver only after
+    // `has_mapdict_storage` proved its prefix. Preserve the concrete layout
+    // tag here: claiming every carrier is `INSTANCE_TYPE` poisons the heap
+    // cache for native-layout subclasses and lets later folds use unrelated
+    // field descriptors on the same box.
+    let concrete_obj = walker_concrete_ref_object(ctx, obj)
+        .expect("mapdict shape guard requires the concrete carrier used by the fast path");
+    let layout_type_addr = unsafe { (*concrete_obj).ob_type as i64 };
     if !ctx.trace_ctx.heap_cache().is_class_known(obj) {
-        let type_const = ctx.trace_ctx.const_int(instance_type_addr);
+        let type_const = ctx.trace_ctx.const_int(layout_type_addr);
         walker_emit_fold_guard_with_snapshot(ctx, op_pc, OpCode::GuardClass, &[obj, type_const])?;
         ctx.trace_ctx
             .heap_cache_mut()
-            .class_now_known(obj, instance_type_addr);
+            .class_now_known(obj, layout_type_addr);
     }
 
     // The instance map pins the storage layout, but class mutation can change

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -7136,6 +7136,7 @@ fn walker_guard_mapdict_instance_shape<Sym: WalkSym>(
     ctx: &mut WalkContext<'_, '_, Sym>,
     op_pc: usize,
     obj: OpRef,
+    concrete_obj: pyre_object::PyObjectRef,
     w_type: pyre_object::PyObjectRef,
     version_tag: u64,
     map: pyre_interpreter::objspace::std::mapdict::MapRef,
@@ -7145,10 +7146,15 @@ fn walker_guard_mapdict_instance_shape<Sym: WalkSym>(
     // tag here: claiming every carrier is `INSTANCE_TYPE` poisons the heap
     // cache for native-layout subclasses and lets later folds use unrelated
     // field descriptors on the same box.
-    let concrete_obj = walker_concrete_ref_object(ctx, obj)
-        .expect("mapdict shape guard requires the concrete carrier used by the fast path");
+    //
+    // A cached class that DISAGREES with the layout tag is that poisoning,
+    // and gating on `is_class_known` alone would then skip the guard and let
+    // the storage coordinates below run against an unguarded layout. Compare
+    // the recorded class instead and guard whenever it is absent or differs;
+    // a contradictory pair is folded out by the optimizer's constant-class
+    // handling, which discards the trace rather than reading a wild slot.
     let layout_type_addr = unsafe { (*concrete_obj).ob_type as i64 };
-    if !ctx.trace_ctx.heap_cache().is_class_known(obj) {
+    if ctx.trace_ctx.heap_cache().get_known_class(obj) != Some(layout_type_addr) {
         let type_const = ctx.trace_ctx.const_int(layout_type_addr);
         walker_emit_fold_guard_with_snapshot(ctx, op_pc, OpCode::GuardClass, &[obj, type_const])?;
         ctx.trace_ctx

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -419,7 +419,7 @@ impl Default for CalleeLocalsShadow {
 
 impl CalleeLocalsShadow {
     /// A `NONE` value clears the slot.
-    fn set_opref(&mut self, slot: i64, value: OpRef) {
+    pub(crate) fn set_opref(&mut self, slot: i64, value: OpRef) {
         if value.is_none() {
             self.opref.remove(&slot);
         } else {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -3974,6 +3974,13 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
         && ei.pyre_helper == majit_ir::PyreHelperKind::CallFn
+        && try_walker_specialize_math_log_trig(ctx, code, op, &r_args, dst)?.is_some()
+    {
+        return Ok((DispatchOutcome::Continue, op.next_pc));
+    }
+    if ctx.is_authoritative_executor
+        && dst_bank == 'r'
+        && ei.pyre_helper == majit_ir::PyreHelperKind::CallFn
         && try_walker_specialize_math_frexp(ctx, code, op, &r_args, dst)?.is_some()
     {
         return Ok((DispatchOutcome::Continue, op.next_pc));

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/resume_snapshot.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/resume_snapshot.rs
@@ -2130,9 +2130,56 @@ pub(crate) fn walker_capture_multi_frame_inline_snapshot<Sym: WalkSym>(
             }
         }
     }
+    // `MIFrame.registers_r` is the live color bank, but a reconstructed
+    // carrier frame also owns the semantic locals/stack image from which that
+    // bank was rebuilt.  A post-call liveness marker can conservatively carry
+    // a color whose current bank value is NONE (adjacent `-live-` union); map
+    // that color back to this callee's OWN frame slot and source the box from
+    // its frame-local shadow.  This is the inline-frame counterpart of
+    // `collect_outer_active_boxes`' virtualizable-slot recovery, and preserves
+    // the one-red-frame-per-MIFrame shape instead of falling back to the root.
+    let mut recovered_regs_r = ctx.registers_r.to_vec();
+    if recovered_regs_r.iter().any(|value| value.is_none()) && !callee_pjc.code_ptr.is_null() {
+        let code = unsafe { &*callee_pjc.code_ptr };
+        let (stack_base, _) = crate::state::callee_layout_for_call_assembler(code);
+        let maps =
+            crate::state::bridge_semantic_maps_from_pc(callee_jitcode_index, callee_jitcode_pc);
+        if let Some(shadow) = ctx.callee_shadow.as_ref() {
+            for (color, value) in recovered_regs_r.iter_mut().enumerate() {
+                if !value.is_none() {
+                    continue;
+                }
+                let Some(slot) = crate::state::semantic_ref_slot_for_reg_color(
+                    stack_base,
+                    maps.stack_depth_at_pc,
+                    &maps.pcdep_entries,
+                    color,
+                ) else {
+                    continue;
+                };
+                if let Some(&slot_value) = shadow.opref.get(&(slot as i64)) {
+                    *value = slot_value;
+                }
+            }
+        }
+        // A dense fallthrough marker can name the NEXT Python opcode's result
+        // color before that opcode has executed.  RPython's sparse stream has
+        // no opcode-entry marker at this seam; the translated Ref bank slot is
+        // still its empty/null value and the next opcode overwrites it before
+        // any read.  Admit exactly that metadata-proven result color as NULL;
+        // every other missing live color still declines below.
+        if after_residual_call {
+            let marker_result = usize::try_from(callee_jitcode_pc)
+                .ok()
+                .and_then(|coord| callee_pjc.result_color_trivia_for_jitcode_pc(coord))
+                .filter(|&color| color != u16::MAX);
+            let null_ref = ctx.trace_ctx.const_ref(pyre_object::PY_NULL as i64);
+            seed_missing_fallthrough_result(&mut recovered_regs_r, marker_result, null_ref);
+        }
+    }
     let callee_boxes = collect_callee_active_boxes(
         ctx.registers_i,
-        ctx.registers_r,
+        &recovered_regs_r,
         ctx.registers_f,
         callee_jitcode_index as u32,
         callee_op_pc,
@@ -2193,4 +2240,27 @@ pub(crate) fn walker_capture_multi_frame_inline_snapshot<Sym: WalkSym>(
             );
     }
     Ok(())
+}
+
+/// Seed only the not-yet-defined result color carried by pyre's dense
+/// fallthrough marker.  Returns whether a hole was filled.
+pub(crate) fn seed_missing_fallthrough_result(
+    registers_r: &mut [OpRef],
+    marker_result: Option<u16>,
+    null_ref: OpRef,
+) -> bool {
+    let Some(dst) = marker_result
+        .filter(|&color| color != u16::MAX)
+        .map(usize::from)
+    else {
+        return false;
+    };
+    let Some(slot) = registers_r.get_mut(dst) else {
+        return false;
+    };
+    if !slot.is_none() {
+        return false;
+    }
+    *slot = null_ref;
+    true
 }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -2207,7 +2207,15 @@ pub(crate) fn try_walker_specialize_load_attr<Sym: WalkSym>(
     if let Some((w_type, version_tag, map, storageindex)) = unsafe {
         pyre_interpreter::objspace::std::mapdict::load_attr_fast_path(concrete_obj, &name)
     } {
-        walker_guard_mapdict_instance_shape(ctx, op_pc, obj, w_type, version_tag, map)?;
+        walker_guard_mapdict_instance_shape(
+            ctx,
+            op_pc,
+            obj,
+            concrete_obj,
+            w_type,
+            version_tag,
+            map,
+        )?;
 
         // getfield_gc_r(obj, storage) + getarrayitem_gc_r(block, C_storageindex):
         // the inline value read (`mapdict.py`).  `storageindex` is a green
@@ -2454,7 +2462,7 @@ pub(crate) fn try_walker_specialize_load_attr<Sym: WalkSym>(
     }) else {
         return Ok(None);
     };
-    walker_guard_mapdict_instance_shape(ctx, op_pc, obj, w_type, version_tag, map)?;
+    walker_guard_mapdict_instance_shape(ctx, op_pc, obj, concrete_obj, w_type, version_tag, map)?;
 
     // `_prim_direct_read` (mapdict.py): read the raw longlong from the
     // shared list through a non-forcing, non-elidable residual.  Both indices
@@ -2971,7 +2979,15 @@ pub(crate) fn try_walker_specialize_store_attr<Sym: WalkSym>(
             }
         }
 
-        walker_guard_mapdict_instance_shape(ctx, op_pc, obj, w_type, version_tag, map)?;
+        walker_guard_mapdict_instance_shape(
+            ctx,
+            op_pc,
+            obj,
+            concrete_obj,
+            w_type,
+            version_tag,
+            map,
+        )?;
         let storageindex_const = ctx.trace_ctx.const_int(storageindex as i64);
         let listindex_const = ctx.trace_ctx.const_int(listindex as i64);
         let (helper_fn, raw, value_type) = match unbox_type {
@@ -3204,7 +3220,15 @@ pub(crate) fn try_walker_specialize_store_attr<Sym: WalkSym>(
             )
         }
     {
-        walker_guard_mapdict_instance_shape(ctx, op_pc, obj, add.w_type, add.version_tag, add.map)?;
+        walker_guard_mapdict_instance_shape(
+            ctx,
+            op_pc,
+            obj,
+            concrete_obj,
+            add.w_type,
+            add.version_tag,
+            add.map,
+        )?;
         let new_map_const = ctx.trace_ctx.const_int(add.new_map as i64);
         crate::helpers::emit_mapdict_add_attr_inline(
             ctx.trace_ctx,
@@ -3230,7 +3254,7 @@ pub(crate) fn try_walker_specialize_store_attr<Sym: WalkSym>(
     }) else {
         return Ok(None);
     };
-    walker_guard_mapdict_instance_shape(ctx, op_pc, obj, w_type, version_tag, map)?;
+    walker_guard_mapdict_instance_shape(ctx, op_pc, obj, concrete_obj, w_type, version_tag, map)?;
     let storageindex_const = ctx.trace_ctx.const_int(storageindex as i64);
     let helper = ctx
         .trace_ctx

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -5496,21 +5496,27 @@ pub(crate) fn try_walker_specialize_math_log_trig<Sym: WalkSym>(
     if concrete_callable.is_null() || !null_or_self.is_null() || arg_obj.is_null() {
         return Ok(None);
     }
-    let raw_fn =
+    // Carry `is_log` out of the branch that knows it. Recovering it afterwards
+    // by comparing `raw_fn` against `math_log_positive_jit` would make the
+    // domain guard below depend on the three helpers keeping distinct
+    // addresses, which is a linker property, not a source one.
+    let (raw_fn, is_log) =
         if pyre_interpreter::module::math::interp_math::is_math_log_function(concrete_callable) {
-            crate::trace_opcode::math_log_positive_jit as *const ()
+            (
+                crate::trace_opcode::math_log_positive_jit as *const (),
+                true,
+            )
         } else if pyre_interpreter::module::math::interp_math::is_math_cos_function(
             concrete_callable,
         ) {
-            crate::trace_opcode::math_cos_finite_jit as *const ()
+            (crate::trace_opcode::math_cos_finite_jit as *const (), false)
         } else if pyre_interpreter::module::math::interp_math::is_math_sin_function(
             concrete_callable,
         ) {
-            crate::trace_opcode::math_sin_finite_jit as *const ()
+            (crate::trace_opcode::math_sin_finite_jit as *const (), false)
         } else {
             return Ok(None);
         };
-    let is_log = raw_fn == crate::trace_opcode::math_log_positive_jit as *const ();
     let (is_int, val) = unsafe {
         if !pyre_object::is_exact_builtin_instance(arg_obj) {
             return Ok(None);

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -1821,6 +1821,24 @@ pub(crate) fn try_walker_specialize_unpack<Sym: WalkSym>(
                 if index >= concrete_len {
                     return Ok(None);
                 }
+                // `index < concrete_len` only holds for the tuple recorded
+                // here. A trace can enter between the `UnpackSequence` helper
+                // and this one — a bridge resumes mid-unpack — so this arm
+                // cannot rely on that helper's length guard being in the same
+                // trace. Emit it; when it is present the optimizer folds this
+                // one away, so a whole unpack still guards the length once.
+                let length = crate::state::opimpl_arraylen_gc(
+                    ctx.trace_ctx,
+                    items,
+                    crate::state::pyobject_gcarray_descr(),
+                );
+                let expected = ctx.trace_ctx.const_int(concrete_len as i64);
+                walker_emit_guard_with_snapshot(
+                    ctx,
+                    op_pc,
+                    OpCode::GuardValue,
+                    &[length, expected],
+                )?;
                 let index_op = ctx.trace_ctx.const_int(int_val);
                 let item = crate::state::trace_items_block_getitem_value_pure(
                     ctx.trace_ctx,

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -5426,6 +5426,110 @@ pub(crate) fn try_walker_specialize_math_sqrt<Sym: WalkSym>(
     Ok(Some(()))
 }
 
+/// `math.log/cos/sin(x)` on an exact int/float argument.  This is the direct
+/// RPython `ll_math_{log,cos,sin}` shape: pin the domain branch, unbox the
+/// numeric operand, emit the raw pure `CALL_F`, and leave the result box
+/// virtualizable.  Rebound callables, subclasses, exceptional domains, and
+/// non-numeric inputs retain the ordinary residual call.
+pub(crate) fn try_walker_specialize_math_log_trig<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    code: &[u8],
+    op: &DecodedOp,
+    r_args: &[OpRef],
+    dst: usize,
+) -> Result<Option<()>, DispatchError> {
+    if r_args.len() != 3 {
+        return Ok(None);
+    }
+    let arg_concretes = read_ref_var_list_concrete(code, op, 1, ctx);
+    let (
+        ConcreteValue::Ref(concrete_callable),
+        ConcreteValue::Ref(null_or_self),
+        ConcreteValue::Ref(arg_obj),
+    ) = (arg_concretes[0], arg_concretes[1], arg_concretes[2])
+    else {
+        return Ok(None);
+    };
+    if concrete_callable.is_null() || !null_or_self.is_null() || arg_obj.is_null() {
+        return Ok(None);
+    }
+    let raw_fn =
+        if pyre_interpreter::module::math::interp_math::is_math_log_function(concrete_callable) {
+            crate::trace_opcode::math_log_positive_jit as *const ()
+        } else if pyre_interpreter::module::math::interp_math::is_math_cos_function(
+            concrete_callable,
+        ) {
+            crate::trace_opcode::math_cos_finite_jit as *const ()
+        } else if pyre_interpreter::module::math::interp_math::is_math_sin_function(
+            concrete_callable,
+        ) {
+            crate::trace_opcode::math_sin_finite_jit as *const ()
+        } else {
+            return Ok(None);
+        };
+    let is_log = raw_fn == crate::trace_opcode::math_log_positive_jit as *const ();
+    let (is_int, val) = unsafe {
+        if !pyre_object::is_exact_builtin_instance(arg_obj) {
+            return Ok(None);
+        }
+        if pyre_object::is_int(arg_obj) {
+            (true, pyre_object::w_int_get_value(arg_obj) as f64)
+        } else if pyre_object::is_float(arg_obj) {
+            (false, pyre_object::w_float_get_value(arg_obj))
+        } else {
+            return Ok(None);
+        }
+    };
+    // The hot RPython branches used here are log(finite positive) and
+    // trig(finite).  Cold NaN/inf/domain cases stay on the exact builtin.
+    if !val.is_finite() || (is_log && val <= 0.0) {
+        return Ok(None);
+    }
+    let boxed_result = {
+        let _plain_guard = pyre_interpreter::call::force_plain_eval();
+        pyre_interpreter::call::call_function_impl_result(concrete_callable, &[arg_obj])
+    };
+    let Ok(boxed_result) = boxed_result else {
+        return Ok(None);
+    };
+
+    let callable_op = r_args[0];
+    if !callable_op.is_constant() {
+        let expected = ctx.trace_ctx.const_ref(concrete_callable as i64);
+        ctx.trace_ctx
+            .record_guard(OpCode::GuardValue, &[callable_op, expected], 0);
+        walker_capture_snapshot_for_last_guard(ctx, op.pc)?;
+        ctx.trace_ctx
+            .heap_cache_mut()
+            .replace_box(callable_op, expected);
+    }
+    let x = walker_coerce_operand_to_float(ctx, op.pc, r_args[2], arg_obj, is_int, val, false)?;
+    let zero = ctx.trace_ctx.const_float(0.0f64.to_bits() as i64);
+    if is_log {
+        walker_float_cmp_guard(ctx, op.pc, OpCode::FloatLt, &[zero, x], true)?;
+    }
+    let diff = ctx.trace_ctx.record_op(OpCode::FloatSub, &[x, x]);
+    ctx.trace_ctx
+        .set_opref_concrete(diff, majit_ir::Value::Float(0.0));
+    walker_float_cmp_guard(ctx, op.pc, OpCode::FloatEq, &[diff, zero], true)?;
+    let raw = ctx.trace_ctx.call_float_typed_with_effect(
+        raw_fn,
+        &[x],
+        &[majit_ir::Type::Float],
+        majit_metainterp::CANNOT_RAISE_NO_HEAP_EFFECT_INFO,
+    );
+    let result_val = unsafe { pyre_object::w_float_get_value(boxed_result) };
+    ctx.trace_ctx
+        .set_opref_concrete(raw, majit_ir::Value::Float(result_val));
+    let boxed = crate::state::wrapfloat(ctx.trace_ctx, raw);
+    ctx.trace_ctx.set_opref_concrete(
+        boxed,
+        majit_ir::Value::Ref(majit_ir::GcRef(boxed_result as usize)),
+    );
+    write_residual_call_result_to_dst(ctx, op.pc, dst, 'r', boxed)?;
+    Ok(Some(()))
+}
+
 /// `math.frexp(x)` on an exact int/float argument.  RPython lowers
 /// `ll_math_frexp` to two unboxed results and `space.newtuple2`; emit the same
 /// shape as two pure typed calls followed by a virtualizable object tuple.

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -1770,9 +1770,80 @@ pub(crate) fn try_walker_specialize_unpack<Sym: WalkSym>(
     let Some(concrete_seq) = walker_concrete_ref_object(ctx, seq) else {
         return Ok(None);
     };
+    // `objspace.py:507-541 StdObjSpace.{unpackiterable,fixedview}` takes an
+    // exact tuple straight to its immutable `wrappeditems` list; and
+    // `pyopcode.py:889 UNPACK_SEQUENCE` calls `fixedview_unroll`, so a
+    // constant item count exposes each tuple item directly to the trace.
+    // Preserve that shape for pyre's split `UnpackSequence` / `UnpackItem`
+    // helpers.  In particular, `zip` produces an ordinary array-backed tuple
+    // each iteration; leaving these helpers residual makes the three-item
+    // comprehension trace execute one validation call plus one call per
+    // projected item.
+    let tuple_type = &pyre_object::pyobject::TUPLE_TYPE as *const pyre_object::pyobject::PyType;
+    let canonical_tuple_class = pyre_object::pyobject::get_instantiate(unsafe { &*tuple_type });
+    if unsafe {
+        std::ptr::eq((*concrete_seq).ob_type, tuple_type)
+            && std::ptr::eq((*concrete_seq).w_class, canonical_tuple_class)
+    } {
+        let concrete_len = unsafe { pyre_object::w_tuple_len(concrete_seq) };
+        if int_val < 0 {
+            return Ok(None);
+        }
+        walker_guard_class(ctx, op_pc, seq, tuple_type as i64)?;
+        walker_guard_exact_w_class(ctx, op_pc, seq, canonical_tuple_class)?;
+        let items = crate::state::opimpl_getfield_gc_r(
+            ctx.trace_ctx,
+            seq,
+            crate::descr::tuple_wrappeditems_descr(),
+        );
+        match helper {
+            majit_ir::PyreHelperKind::UnpackSequence => {
+                if int_val as usize != concrete_len {
+                    return Ok(None);
+                }
+                let length = crate::state::opimpl_arraylen_gc(
+                    ctx.trace_ctx,
+                    items,
+                    crate::state::pyobject_gcarray_descr(),
+                );
+                let expected = ctx.trace_ctx.const_int(int_val);
+                walker_emit_guard_with_snapshot(
+                    ctx,
+                    op_pc,
+                    OpCode::GuardValue,
+                    &[length, expected],
+                )?;
+                write_residual_call_result_to_dst(ctx, op_pc, dst, dst_bank, seq)?;
+                return Ok(Some(()));
+            }
+            majit_ir::PyreHelperKind::UnpackItem => {
+                let index = int_val as usize;
+                if index >= concrete_len {
+                    return Ok(None);
+                }
+                let index_op = ctx.trace_ctx.const_int(int_val);
+                let item = crate::state::trace_items_block_getitem_value_pure(
+                    ctx.trace_ctx,
+                    items,
+                    index_op,
+                );
+                let concrete_item = unsafe {
+                    pyre_object::w_tuple_getitem(concrete_seq, int_val)
+                        .unwrap_or(pyre_object::PY_NULL)
+                };
+                ctx.trace_ctx.set_opref_concrete(
+                    item,
+                    majit_ir::Value::Ref(majit_ir::GcRef(concrete_item as usize)),
+                );
+                write_residual_call_result_to_dst(ctx, op_pc, dst, dst_bank, item)?;
+                return Ok(Some(()));
+            }
+            _ => {}
+        }
+    }
     // Both arity-2 specialisations fold; any other shape (a plain tuple, a
-    // longer unpack, a list) falls through to the opaque residual (correct,
-    // slower).
+    // list, or a non-canonical tuple) falls through to the opaque residual
+    // (correct, slower).
     let spec_ii = &pyre_object::specialisedtupleobject::SPECIALISED_TUPLE_II_TYPE
         as *const pyre_object::pyobject::PyType;
     let spec_oo = &pyre_object::specialisedtupleobject::SPECIALISED_TUPLE_OO_TYPE

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -2154,9 +2154,10 @@ fn walker_specialize_traceback_walk_field<Sym: WalkSym>(
 /// monomorphic instance whose attribute resolves to a boxed plain storage slot
 /// or an unboxed integer/float slot, emit the guarded read PyPy compiles
 /// LOAD_ATTR to under the JIT —
-///   * `guard_class(obj, &INSTANCE_TYPE)` — the receiver is a `W_ObjectObject`
-///     (so the `map`/`storage` field reads below are valid; `mapdict.py`
-///     `if map is not None:` also filters non-instances at trace time).
+///   * `guard_class(obj, concrete_layout)` — the receiver keeps the exact
+///     layout vtable whose mapdict-carrier prefix was proved at trace time (so
+///     the `map`/`storage` reads below are valid; `mapdict.py` `if map is not
+///     None:` also filters non-carriers at trace time).
 ///   * `guard_value(getfield_gc_i(w_type, version_tag), C_version_tag)` — pins
 ///     the class lookup result so a later descriptor or `__getattribute__`
 ///     mutation deopts on trace re-entry.

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
@@ -11112,6 +11112,39 @@ fn callee_vable_ref_gates_on_frame_register_identity() {
     assert_eq!(super::callee_vable_ref_at(None, 1, 3), None);
 }
 
+#[test]
+fn dense_fallthrough_seeds_only_its_missing_result_color() {
+    let keep = OpRef::ref_op(3);
+    let null_ref = OpRef::const_ptr(majit_ir::GcRef(0));
+    let mut registers = vec![keep, OpRef::NONE, OpRef::NONE];
+
+    assert!(super::resume_snapshot::seed_missing_fallthrough_result(
+        &mut registers,
+        Some(1),
+        null_ref,
+    ));
+    assert_eq!(registers, vec![keep, null_ref, OpRef::NONE]);
+
+    // A defined register, a sentinel, and an out-of-range color are not
+    // rewritten. Other NONE holes remain visible to the ordinary decline.
+    assert!(!super::resume_snapshot::seed_missing_fallthrough_result(
+        &mut registers,
+        Some(0),
+        null_ref,
+    ));
+    assert!(!super::resume_snapshot::seed_missing_fallthrough_result(
+        &mut registers,
+        Some(u16::MAX),
+        null_ref,
+    ));
+    assert!(!super::resume_snapshot::seed_missing_fallthrough_result(
+        &mut registers,
+        Some(99),
+        null_ref,
+    ));
+    assert_eq!(registers, vec![keep, null_ref, OpRef::NONE]);
+}
+
 /// `insert_renamings` routes a cyclic parallel move through the Int scratch
 /// (`int_push/i` then `int_pop/>i`).  The pop must land the source's concrete
 /// shadow in `concrete_registers_i[dst]`; leaving the destination slot's old

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -13195,11 +13195,8 @@ pub(crate) fn assemble_bridge_inline_pending(
     let w_globals = recover_inline_callee_globals(recipe.code_ptr);
 
     // resume.py:1042-1057 newframe + reload: the decoded boxes are reloaded
-    // into the symbolic frame below. The callee's concrete state lives in
-    // `sym.concrete_locals` / `sym.concrete_stack` and in the emitted frame
-    // vable that `setup_reconstructed_callee_frame` binds to `sym.frame`;
-    // no separate interpreter-side `PyFrame` is materialized here.
-    //
+    // into the symbolic frame below. `setup_reconstructed_callee_frame`
+    // supplies the matching recording-time PyFrame for residual execution.
     // Symbolic side: mirror the FAST branch field-for-field.
     let mut sym = PyreSym::new_uninit(OpRef::NONE);
     sym.nlocals = nlocals;
@@ -13360,8 +13357,76 @@ pub(crate) fn setup_reconstructed_callee_frame(
         ec_const,
     );
 
+    // pyjitpl.py:2445-2476 perform_call creates a concrete frame alongside
+    // the callee MIFrame before setup_call installs its boxes. A bridge resume
+    // does the same in resume.py:1042-1057: newframe(jitcode), then
+    // consume_boxes. The emitted `frame_vable` above is the runtime half; give
+    // it the matching recording-time PyFrame so residuals that consume the
+    // frame red can execute while tracing. Without this value the very first
+    // such residual sees a symbolic-only Ref and the carrier sub-walk aborts.
+    //
+    // Root the code, globals, and every reconstructed prefix slot before the
+    // closure tuple/frame allocations. This is the same shadow-stack shape as
+    // the forward-inline constructor in `inline_call.rs`; the resulting
+    // GC-managed FrameBox relinquishes only its host handle after the frontend
+    // op becomes its trace root.
+    let concrete_roots = pyre_object::gc_roots::push_roots();
+    let root_base = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(w_code as pyre_object::PyObjectRef);
+    pyre_object::gc_roots::pin_root(w_globals as pyre_object::PyObjectRef);
+    for (slot, &captured) in recipe.concrete_r[..stack_base].iter().enumerate() {
+        let value = match captured {
+            majit_ir::Value::Ref(gc) if gc != majit_ir::GcRef::NO_CONCRETE => {
+                if slot >= nlocals && gc.is_null() {
+                    return None;
+                }
+                gc.as_usize() as pyre_object::PyObjectRef
+            }
+            majit_ir::Value::Void => pyre_object::PY_NULL,
+            _ => return None,
+        };
+        pyre_object::gc_roots::pin_root(value);
+    }
+    let closure = if stack_base == nlocals {
+        pyre_object::PY_NULL
+    } else {
+        let cells = (nlocals..stack_base)
+            .map(|i| pyre_object::gc_roots::shadow_stack_get(root_base + 2 + i))
+            .collect();
+        let closure = pyre_object::w_tuple_new(cells);
+        pyre_object::gc_roots::pin_root(closure);
+        closure
+    };
+    let closure_root = (stack_base != nlocals).then_some(root_base + 2 + stack_base);
+    let concrete_locals: Vec<pyre_object::PyObjectRef> = (0..nlocals)
+        .map(|i| pyre_object::gc_roots::shadow_stack_get(root_base + 2 + i))
+        .collect();
+    let current_code = pyre_object::gc_roots::shadow_stack_get(root_base) as *const ();
+    let current_globals = pyre_object::gc_roots::shadow_stack_get(root_base + 1);
+    let current_closure = closure_root
+        .map(pyre_object::gc_roots::shadow_stack_get)
+        .unwrap_or(closure);
+    let mut concrete_frame = pyre_interpreter::pyframe::FrameBox::new(
+        pyre_interpreter::pyframe::PyFrame::new_for_call_with_closure_and_globals_obj(
+            current_code,
+            &concrete_locals,
+            current_globals,
+            execution_context,
+            current_closure,
+            pyre_interpreter::pyframe::FrameLocalsArrayAllocation::OldGenGc,
+        ),
+    );
+    let concrete_frame_ptr = concrete_frame.as_mut_ptr();
+    ctx.set_opref_concrete(
+        frame_vable,
+        majit_ir::Value::Ref(majit_ir::GcRef(concrete_frame_ptr as usize)),
+    );
+    drop(concrete_frame);
+    drop(concrete_roots);
+
     let mut pending = assemble_bridge_inline_pending(ctx, recipe, execution_context, parent_frames);
     pending.sym.frame = frame_vable;
+    pending.sym.concrete_vable_ptr = concrete_frame_ptr as *mut u8;
     // The portal reds are [frame, ec], force-alive at every pc; a guard snapshot
     // (`collect_outer_active_boxes`) reads ec at portal_ec_reg via
     // `sym.execution_context`.  `assemble_bridge_inline_pending` only seeds it

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -6834,10 +6834,8 @@ impl PyreJitState {
 /// single-frame bridge) when the callee cannot be faithfully rebuilt:
 ///   - `pc` is the no-snapshot sentinel (`< 0`),
 ///   - `jitcode_index` does not resolve to a code object,
-///   - the callee has cell or free variables — `locals_cells_stack_w` then
-///     carries cell objects whose contents are not in the resume liveness
-///     stream, so a dead-frame rebuild would seed null cells and LOAD_DEREF
-///     would raise `NameError`,
+///   - the callee has fresh cell variables (the forward inline constructor
+///     does not yet allocate them either),
 ///   - the liveness enumeration count disagrees with the encoded section.
 /// `rd_virtuals[vidx]` with negative-index resolution already applied by the
 /// caller. Returns the `RdVirtualInfo` behind the `Rc`, or `None` when the
@@ -6955,11 +6953,12 @@ fn overlay_stream_ref_slots(
 /// the liveness invariants the reader consumes. Pyre's per-function portal
 /// model + super-instruction bytecode cannot guarantee those invariants for
 /// every reconstructed callee, so this returns `None` exactly where a rebuild
-/// would be unsound: a no-snapshot pc, an unresolved jitcode, cell/free vars
-/// (cell contents live outside the resume stream → LOAD_DEREF NameError),
+/// would be unsound: a no-snapshot pc, an unresolved jitcode, fresh cellvars,
 /// unrecoverable callee globals, an `enumerate_vars` count that disagrees with
 /// the encoded section (`consume_boxes`), or an int/float-bank register with no
-/// boxed-Ref source.
+/// boxed-Ref source. Existing freevar cell objects are ordinary entries in the
+/// frame red's `locals_cells_stack_w` array and are rebuilt with that frame,
+/// exactly as `resume.py:1042-1057 consume_boxes` rebuilds every MIFrame slot.
 ///
 /// The `None` fallback is semantically equivalent in program result: the caller
 /// declines the multi-frame inline reconstruction and routes to the
@@ -7005,8 +7004,14 @@ fn reconstruct_inline_recipe(
         decline!("NullRawCode");
     }
     let code_ref = unsafe { &*raw_code };
-    if !code_ref.freevars.is_empty() || pyre_interpreter::pyframe::ncells(code_ref) != 0 {
-        decline!("CellsOrFreevars");
+    // Forward inlining already accepts freevars by threading the existing
+    // closure cell objects into the callee's own frame. Resume reconstruction
+    // must preserve those same slots, not discard the whole frame merely
+    // because its semantic prefix is `[locals | cells]`. Fresh cellvars still
+    // require allocation/initialisation and remain on the conservative path,
+    // matching `try_walker_inline_resolved_user_call`.
+    if !code_ref.cellvars.is_empty() {
+        decline!("FreshCellvars");
     }
     // pyframe.py:128-132 get_w_globals_storage(): the reconstructed callee frame's
     // globals come from its own pycode (`assemble_bridge_inline_pending`
@@ -7017,7 +7022,13 @@ fn reconstruct_inline_recipe(
     if recover_inline_callee_globals(raw_code as *const ()).is_null() {
         decline!("NoCalleeGlobals");
     }
-    let nlocals = code_ref.varnames.len();
+    let frame_nlocals = code_ref.varnames.len();
+    // PyPy's MIFrame register prefix and PyFrame's physical stack base include
+    // cell/freevar slots (`pyframe.py:107-111`). All semantic slot/color maps
+    // below are keyed to that full prefix, so treat it as the recipe's
+    // historical `nlocals` value. This is what keeps LOAD_DEREF attached to
+    // the reconstructed callee frame rather than collapsing onto its caller.
+    let nlocals = frame_nlocals + pyre_interpreter::pyframe::ncells(code_ref);
 
     let liveness = crate::liveness::liveness_for(raw_code);
     let stack_only = match liveness.stack_depth_at(py_pc) {
@@ -7275,7 +7286,7 @@ fn reconstruct_inline_recipe(
                 registers_r,
                 registers_f: Vec::new(),
                 concrete_r,
-                nargs: nlocals,
+                nargs: frame_nlocals,
             });
         }
         let RebuiltValue::Virtual(frame_vidx) = values[frame_pos] else {
@@ -7414,7 +7425,7 @@ fn reconstruct_inline_recipe(
             registers_r,
             registers_f: Vec::new(),
             concrete_r,
-            nargs: nlocals,
+            nargs: frame_nlocals,
         });
     }
 
@@ -7603,7 +7614,7 @@ fn reconstruct_inline_recipe(
         registers_r,
         registers_f,
         concrete_r,
-        nargs: nlocals,
+        nargs: frame_nlocals,
     })
 }
 
@@ -13286,10 +13297,13 @@ pub(crate) fn setup_reconstructed_callee_frame(
         return None;
     }
     let code_ref = unsafe { &*raw_code };
-    let (_nlocals_plus_cells, frame_array_size) = callee_layout_for_call_assembler(code_ref);
-    let nlocals = recipe.nlocals;
+    let (stack_base, frame_array_size) = callee_layout_for_call_assembler(code_ref);
+    let nlocals = code_ref.varnames.len();
     let valuestackdepth = recipe.valuestackdepth;
-    if recipe.registers_r.len() < valuestackdepth || nlocals > valuestackdepth {
+    if recipe.nlocals != stack_base
+        || recipe.registers_r.len() < valuestackdepth
+        || stack_base > valuestackdepth
+    {
         return None;
     }
 
@@ -13305,6 +13319,12 @@ pub(crate) fn setup_reconstructed_callee_frame(
     let ec_const = ctx.const_ref(execution_context as i64);
 
     let locals_boxes: Vec<OpRef> = recipe.registers_r[..nlocals].to_vec();
+    // This reconstruction path admits freevars but still rejects fresh
+    // cellvars, so the remainder of the semantic prefix is exactly the
+    // existing closure-cell objects. Feed them through the same constructor
+    // channel as forward inlining instead of pretending they are positional
+    // parameters.
+    let freevar_cells: Vec<OpRef> = recipe.registers_r[nlocals..stack_base].to_vec();
     // `registers_r` are the paused root's OpRefs, whose trace concrete can still
     // read as a stale NULL once reused as the reconstructed callee's locals,
     // while `concrete_r[k]` holds the value captured at guard failure. A
@@ -13313,7 +13333,7 @@ pub(crate) fn setup_reconstructed_callee_frame(
     // ever built and the guard re-deopts forever. Restamp each local from its
     // captured value; a NULL/Void capture is an unmaterialized hole and is left
     // alone, matching how `setup_bridge_sym` seeds the root frame's slots.
-    for (k, &opref) in locals_boxes.iter().enumerate() {
+    for (k, &opref) in recipe.registers_r[..stack_base].iter().enumerate() {
         if opref.is_none() {
             continue;
         }
@@ -13331,10 +13351,10 @@ pub(crate) fn setup_reconstructed_callee_frame(
     let frame_vable = crate::helpers::emit_new_pyframe_inline_with_params(
         ctx,
         &locals_boxes,
-        &[],
-        0,
-        frame_array_size,
+        &freevar_cells,
         nlocals,
+        frame_array_size,
+        stack_base,
         pycode_const,
         w_globals_const,
         ec_const,
@@ -13373,7 +13393,7 @@ pub(crate) fn setup_reconstructed_callee_frame(
     // Falls back to identity when no live color owns the slot (empty map /
     // non-diverging coloring).
     let pcdep = pcdep_trivia_at(recipe.jitcode_index, recipe.jitcode_pc).unwrap_or_default();
-    for k in nlocals..valuestackdepth {
+    for k in stack_base..valuestackdepth {
         let opref = recipe.registers_r[k];
         if opref.is_none() {
             continue;

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -13585,6 +13585,16 @@ pub(crate) fn setup_reconstructed_callee_frame(
             pyre_interpreter::pyframe::FrameLocalsArrayAllocation::OldGenGc,
         ),
     );
+    // The `drop(concrete_frame)` below relinquishes only the host handle for a
+    // GC-owned frame. `FrameBox::new` falls back to `new_boxed` whenever the
+    // stable allocator answers null, and that box's `drop` FREES the frame —
+    // which would leave the `pending.sym.concrete_vable_ptr` published further
+    // down dangling for the rest of the recording. Decline rather than publish
+    // a pointer this scope is about to invalidate; the `FrameBox` then frees
+    // itself on the way out, as it should.
+    if !concrete_frame.is_gc_owned() {
+        return None;
+    }
     let concrete_frame_ptr = concrete_frame.as_mut_ptr();
     ctx.set_opref_concrete(
         frame_vable,

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -6847,6 +6847,19 @@ fn rd_virtual_at(
     rd_virtuals.and_then(|v| v.get(vidx)).map(|rc| &**rc)
 }
 
+/// One decoded Ref-array write from `rd_pendingfields`.
+///
+/// RPython's resume reader applies this stream before `consume_boxes`; retain
+/// the decoded boxes so Pyre's portal-shaped frame reconstruction can consume
+/// the same just-written value without rediscovering it through a different
+/// array descriptor.
+#[derive(Clone, Copy)]
+struct PendingRefArrayWrite {
+    target: OpRef,
+    item_index: usize,
+    value: OpRef,
+}
+
 /// Rebuild the semantic Ref slots of a forced inline frame from its own
 /// `locals_cells_stack_w` array.
 ///
@@ -6864,6 +6877,7 @@ fn reconstruct_materialized_frame_slots(
     valuestackdepth: usize,
     pending_result_abs_slot: Option<usize>,
     stream_covered: &[bool],
+    pending_ref_array_writes: &[PendingRefArrayWrite],
 ) -> Option<(Vec<OpRef>, Vec<majit_ir::Value>)> {
     if frame_ref.is_null() || frame_ref == majit_ir::GcRef::NO_CONCRETE {
         return None;
@@ -6879,7 +6893,21 @@ fn reconstruct_materialized_frame_slots(
         return None;
     }
 
-    let array_box = frame_locals_cells_stack_array(ctx, frame_box);
+    // ResumeDataBoxReader applies pending writes before consuming frame boxes.
+    // Pyre's portal-shaped frame section rediscovers locals through
+    // `frame.locals_cells_stack_w`; retain the pending target's box identity
+    // when it names that exact array. This is the decoded pending stream, not
+    // optimizer state or a per-box side table.
+    let pending_array_box = pending_ref_array_writes.iter().find_map(|write| {
+        matches!(
+            ctx.box_value(write.target),
+            Some(majit_ir::Value::Ref(concrete))
+                if concrete.as_usize() == arr_ptr as usize
+        )
+        .then_some(write.target)
+    });
+    let array_box =
+        pending_array_box.unwrap_or_else(|| frame_locals_cells_stack_array(ctx, frame_box));
     // `frame_locals_cells_stack_array` currently emits GetfieldRawI for
     // backend compatibility, but the field is a GC array Ref
     // (virtualizable.py:94). Preserve that boxed-pointer view for the
@@ -6893,6 +6921,26 @@ fn reconstruct_materialized_frame_slots(
     let mut concrete_r = vec![majit_ir::Value::Void; valuestackdepth];
     for k in 0..valuestackdepth {
         if Some(k) == pending_result_abs_slot || stream_covered.get(k).copied().unwrap_or(false) {
+            continue;
+        }
+        // `_prepare_pendingfields` precedes `consume_boxes` in resume.py. If
+        // this exact materialized locals array was just written, consume the
+        // decoded value box directly. The pending descriptor may be the
+        // generic virtualizable-array descriptor while the PyFrame reload uses
+        // its concrete GC-array descriptor, so routing through a fresh GET
+        // would hide the write from heap optimization despite identical boxes.
+        if let Some(write) = pending_ref_array_writes.iter().rev().find(|write| {
+            write.item_index == k
+                && matches!(
+                    ctx.box_value(write.target),
+                    Some(majit_ir::Value::Ref(concrete))
+                        if concrete.as_usize() == arr_ptr as usize
+                )
+        }) {
+            registers_r[k] = write.value;
+            concrete_r[k] = ctx.box_value(write.value).unwrap_or_else(|| {
+                majit_ir::Value::Ref(majit_ir::GcRef(arr.as_slice()[k] as usize))
+            });
             continue;
         }
         let index = ctx.const_int(k as i64);
@@ -6976,6 +7024,7 @@ fn reconstruct_inline_recipe(
     backend: &dyn majit_backend::Backend,
     cache: &mut BridgeVirtualCache,
     in_a_call: bool,
+    pending_ref_array_writes: &[PendingRefArrayWrite],
 ) -> Option<ReconstructRecipe> {
     // Each decline below ends the whole multi-frame path (`recipes.clear()` in
     // the caller), so name every class: an uncensused decline is invisible in
@@ -7261,6 +7310,7 @@ fn reconstruct_inline_recipe(
                 valuestackdepth,
                 pending_result_abs_slot,
                 &stream_covered,
+                pending_ref_array_writes,
             )?;
             overlay_stream_ref_slots(
                 ctx,
@@ -7705,9 +7755,10 @@ fn prepare_bridge_pending_fields(
     fail_types: &[Type],
     backend: &dyn majit_backend::Backend,
     cache: &mut BridgeVirtualCache,
-) {
+) -> Vec<PendingRefArrayWrite> {
+    let mut pending_ref_array_writes = Vec::new();
     let Some(storage) = resume_data.storage.as_ref() else {
-        return;
+        return pending_ref_array_writes;
     };
     let target_descr = crate::descr::ec_sys_exc_value_descr();
     for pending in &storage.rd_pendingfields {
@@ -7767,7 +7818,7 @@ fn prepare_bridge_pending_fields(
         } else {
             // resume.py:993-1007 `_prepare_pendingfields`: replay ordinary
             // pending writes as bridge-entry SETFIELD_GC / SETARRAYITEM_GC ops.
-            let (target_op, _) = bridge_decode_box(
+            let (target_op, target_concrete) = bridge_decode_box(
                 ctx,
                 &target,
                 Type::Ref,
@@ -7778,6 +7829,10 @@ fn prepare_bridge_pending_fields(
                 backend,
                 cache,
             );
+            // history.py FrontendOp parity: a decoded live target carries its
+            // runtime value on the box before decoding the value can allocate
+            // and trigger a moving collection.
+            ctx.try_set_opref_concrete(target_op, target_concrete);
             let value_kind = if pending.item_index < 0 {
                 descr
                     .as_field_descr()
@@ -7789,7 +7844,7 @@ fn prepare_bridge_pending_fields(
                     .map(|ad| ad.item_type())
                     .unwrap_or(Type::Ref)
             };
-            let (value_op, _) = bridge_decode_box(
+            let (value_op, value_concrete) = bridge_decode_box(
                 ctx,
                 &value,
                 value_kind,
@@ -7800,6 +7855,61 @@ fn prepare_bridge_pending_fields(
                 backend,
                 cache,
             );
+            // The value box has the same FrontendOp value contract.  The target
+            // stamp above also lets the later portal-frame consume recover this
+            // exact pending-target box after a moving GC.
+            ctx.try_set_opref_concrete(value_op, value_concrete);
+            // ResumeDataBoxReader._prepare_pendingfields dispatches through
+            // `execute_setfield_gc` / `execute_setarrayitem_gc`: execute the
+            // write on the recording-time heap as well as recording it.  The
+            // concrete execution is observable immediately when the following
+            // frame-section consume reads a materialized PyFrame's locals
+            // array; recording alone would leave that consume one write stale.
+            let target_ptr = match ctx.box_value(target_op).unwrap_or(target_concrete) {
+                majit_ir::Value::Ref(ptr) if !ptr.is_null() => ptr.as_usize() as i64,
+                _ => continue,
+            };
+            if pending.item_index < 0 {
+                let Some(fielddescr) = descr.as_field_descr() else {
+                    continue;
+                };
+                let bh_descr = majit_translate::jitcode::BhDescr::from_field_descr(fielddescr);
+                match (fielddescr.field_type(), value_concrete) {
+                    (Type::Ref, majit_ir::Value::Ref(value)) => {
+                        backend.bh_setfield_gc_r(target_ptr, value, &bh_descr)
+                    }
+                    (Type::Float, majit_ir::Value::Float(value)) => {
+                        backend.bh_setfield_gc_f(target_ptr, value, &bh_descr)
+                    }
+                    (Type::Int, majit_ir::Value::Int(value)) => {
+                        backend.bh_setfield_gc_i(target_ptr, value, &bh_descr)
+                    }
+                    _ => continue,
+                }
+            } else {
+                let Some(arraydescr) = descr.as_array_descr() else {
+                    continue;
+                };
+                let bh_descr = majit_translate::jitcode::BhDescr::from_array_descr(arraydescr);
+                let index = i64::from(pending.item_index);
+                match (arraydescr.item_type(), value_concrete) {
+                    (Type::Ref, majit_ir::Value::Ref(value)) => {
+                        backend.bh_setarrayitem_gc_r(target_ptr, index, value, &bh_descr);
+                        pending_ref_array_writes.push(PendingRefArrayWrite {
+                            target: target_op,
+                            item_index: pending.item_index as usize,
+                            value: value_op,
+                        });
+                    }
+                    (Type::Float, majit_ir::Value::Float(value)) => {
+                        backend.bh_setarrayitem_gc_f(target_ptr, index, value, &bh_descr)
+                    }
+                    (Type::Int, majit_ir::Value::Int(value)) => {
+                        backend.bh_setarrayitem_gc_i(target_ptr, index, value, &bh_descr)
+                    }
+                    _ => continue,
+                }
+            }
             // resume.py:993-1007 _prepare_pendingfields op-emission: replay the
             // decoded write as a bridge-entry SETFIELD_GC / SETARRAYITEM_GC and
             // seed the heapcache after recording so a later same-slot get folds
@@ -7816,6 +7926,7 @@ fn prepare_bridge_pending_fields(
             );
         }
     }
+    pending_ref_array_writes
 }
 
 /// resume.py:1245-1264 decode_box concrete parity for tagged fieldnums.
@@ -10034,6 +10145,24 @@ impl JitState for PyreJitState {
         // `pyjitpl.py:3433 self.virtualref_boxes = virtualref_boxes`.
         ctx.restore_virtualref_boxes(restored_virtualref_boxes);
 
+        // resume.py AbstractResumeDataReader._prepare runs
+        // `_prepare_virtuals` and then `_prepare_pendingfields` before
+        // `rebuild_from_resumedata` consumes any frame section.  Preserve that
+        // order here as well.  In particular, a pending SETARRAYITEM_GC may
+        // target a materialized inline frame's locals array; decoding that
+        // frame into a reconstruction recipe first would capture the stale
+        // pre-write slot and later copy it into the rebuilt frame.
+        let pending_ref_array_writes = prepare_bridge_pending_fields(
+            sym,
+            ctx,
+            resume_data,
+            rd_virtuals,
+            fail_values,
+            fail_types,
+            backend,
+            &mut virtuals_cache,
+        );
+
         // `sync_virtualizable_after_guard_failure` runs before bridge setup,
         // but on the multi-frame inlined-callee path its resume-decoded array
         // image is then clobbered by the vsd-correction `clear_stack_above`
@@ -10092,6 +10221,7 @@ impl JitState for PyreJitState {
                         backend,
                         &mut virtuals_cache,
                         in_a_call,
+                        &pending_ref_array_writes,
                     ) {
                         Some(recipe) => recipes.push(recipe),
                         None => {
@@ -10120,17 +10250,6 @@ impl JitState for PyreJitState {
                 recipes,
             });
         }
-
-        prepare_bridge_pending_fields(
-            sym,
-            ctx,
-            resume_data,
-            rd_virtuals,
-            fail_values,
-            fail_types,
-            backend,
-            &mut virtuals_cache,
-        );
     }
 
     /// resume.py:1042-1057 rebuild_from_resumedata parity.
@@ -10935,6 +11054,7 @@ mod tests {
             values.len(),
             Some(1),
             &[],
+            &[],
         )
         .expect("forced frame slots should be reconstructable");
 
@@ -10964,6 +11084,49 @@ mod tests {
                 .filter(|op| op.opcode == OpCode::GetarrayitemGcR)
                 .count(),
             2
+        );
+    }
+
+    #[test]
+    fn materialized_inline_frame_consumes_pending_ref_array_write() {
+        let code = compile_function_body("def f(a, b):\n    return a\n");
+        let mut frame = pyre_interpreter::pyframe::PyFrame::new(code);
+        let values = [w_int_new(11), w_int_new(22)];
+        for (index, value) in values.iter().copied().enumerate() {
+            frame.locals_w_mut()[index] = value;
+        }
+        frame.fix_array_ptrs();
+        let frame_ptr = (&mut *frame) as *mut pyre_interpreter::pyframe::PyFrame as usize;
+        let array_ptr = frame.locals_cells_stack_w as usize;
+
+        let mut ctx = TraceCtx::for_test_types(&[Type::Ref, Type::Ref, Type::Ref]);
+        let frame_box = OpRef::input_arg_ref(0);
+        let target = OpRef::input_arg_ref(1);
+        let value = OpRef::input_arg_ref(2);
+        ctx.try_set_opref_concrete(frame_box, Value::Ref(majit_ir::GcRef(frame_ptr)));
+        ctx.try_set_opref_concrete(target, Value::Ref(majit_ir::GcRef(array_ptr)));
+        ctx.try_set_opref_concrete(value, Value::Ref(majit_ir::GcRef(values[1] as usize)));
+
+        let writes = [PendingRefArrayWrite {
+            target,
+            item_index: 1,
+            value,
+        }];
+        let (registers_r, concrete_r) = reconstruct_materialized_frame_slots(
+            &mut ctx,
+            frame_box,
+            majit_ir::GcRef(frame_ptr),
+            values.len(),
+            None,
+            &[],
+            &writes,
+        )
+        .expect("forced frame slots should consume the pending write stream");
+
+        assert_eq!(registers_r[1], value);
+        assert_eq!(
+            concrete_r[1],
+            Value::Ref(majit_ir::GcRef(values[1] as usize))
         );
     }
 

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -7865,49 +7865,55 @@ fn prepare_bridge_pending_fields(
             // concrete execution is observable immediately when the following
             // frame-section consume reads a materialized PyFrame's locals
             // array; recording alone would leave that consume one write stale.
-            let target_ptr = match ctx.box_value(target_op).unwrap_or(target_concrete) {
-                majit_ir::Value::Ref(ptr) if !ptr.is_null() => ptr.as_usize() as i64,
-                _ => continue,
-            };
-            if pending.item_index < 0 {
-                let Some(fielddescr) = descr.as_field_descr() else {
-                    continue;
+            // A target, descriptor or value shape this backend cannot execute
+            // still has to be RECORDED below: `_prepare_pendingfields` applies
+            // every decoded write, so leaving the loop here would drop the write
+            // from bridge entry entirely.  Leave the execution block instead.
+            'execute: {
+                let target_ptr = match ctx.box_value(target_op).unwrap_or(target_concrete) {
+                    majit_ir::Value::Ref(ptr) if !ptr.is_null() => ptr.as_usize() as i64,
+                    _ => break 'execute,
                 };
-                let bh_descr = majit_translate::jitcode::BhDescr::from_field_descr(fielddescr);
-                match (fielddescr.field_type(), value_concrete) {
-                    (Type::Ref, majit_ir::Value::Ref(value)) => {
-                        backend.bh_setfield_gc_r(target_ptr, value, &bh_descr)
+                if pending.item_index < 0 {
+                    let Some(fielddescr) = descr.as_field_descr() else {
+                        break 'execute;
+                    };
+                    let bh_descr = majit_translate::jitcode::BhDescr::from_field_descr(fielddescr);
+                    match (fielddescr.field_type(), value_concrete) {
+                        (Type::Ref, majit_ir::Value::Ref(value)) => {
+                            backend.bh_setfield_gc_r(target_ptr, value, &bh_descr)
+                        }
+                        (Type::Float, majit_ir::Value::Float(value)) => {
+                            backend.bh_setfield_gc_f(target_ptr, value, &bh_descr)
+                        }
+                        (Type::Int, majit_ir::Value::Int(value)) => {
+                            backend.bh_setfield_gc_i(target_ptr, value, &bh_descr)
+                        }
+                        _ => break 'execute,
                     }
-                    (Type::Float, majit_ir::Value::Float(value)) => {
-                        backend.bh_setfield_gc_f(target_ptr, value, &bh_descr)
+                } else {
+                    let Some(arraydescr) = descr.as_array_descr() else {
+                        break 'execute;
+                    };
+                    let bh_descr = majit_translate::jitcode::BhDescr::from_array_descr(arraydescr);
+                    let index = i64::from(pending.item_index);
+                    match (arraydescr.item_type(), value_concrete) {
+                        (Type::Ref, majit_ir::Value::Ref(value)) => {
+                            backend.bh_setarrayitem_gc_r(target_ptr, index, value, &bh_descr);
+                            pending_ref_array_writes.push(PendingRefArrayWrite {
+                                target: target_op,
+                                item_index: pending.item_index as usize,
+                                value: value_op,
+                            });
+                        }
+                        (Type::Float, majit_ir::Value::Float(value)) => {
+                            backend.bh_setarrayitem_gc_f(target_ptr, index, value, &bh_descr)
+                        }
+                        (Type::Int, majit_ir::Value::Int(value)) => {
+                            backend.bh_setarrayitem_gc_i(target_ptr, index, value, &bh_descr)
+                        }
+                        _ => break 'execute,
                     }
-                    (Type::Int, majit_ir::Value::Int(value)) => {
-                        backend.bh_setfield_gc_i(target_ptr, value, &bh_descr)
-                    }
-                    _ => continue,
-                }
-            } else {
-                let Some(arraydescr) = descr.as_array_descr() else {
-                    continue;
-                };
-                let bh_descr = majit_translate::jitcode::BhDescr::from_array_descr(arraydescr);
-                let index = i64::from(pending.item_index);
-                match (arraydescr.item_type(), value_concrete) {
-                    (Type::Ref, majit_ir::Value::Ref(value)) => {
-                        backend.bh_setarrayitem_gc_r(target_ptr, index, value, &bh_descr);
-                        pending_ref_array_writes.push(PendingRefArrayWrite {
-                            target: target_op,
-                            item_index: pending.item_index as usize,
-                            value: value_op,
-                        });
-                    }
-                    (Type::Float, majit_ir::Value::Float(value)) => {
-                        backend.bh_setarrayitem_gc_f(target_ptr, index, value, &bh_descr)
-                    }
-                    (Type::Int, majit_ir::Value::Int(value)) => {
-                        backend.bh_setarrayitem_gc_i(target_ptr, index, value, &bh_descr)
-                    }
-                    _ => continue,
                 }
             }
             // resume.py:993-1007 _prepare_pendingfields op-emission: replay the

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -1526,6 +1526,22 @@ fn inject_root_call_result<Sym: WalkSym>(
                 result_reg,
             )
         })
+        // The raw-color fallback is load-bearing and simultaneously wrong,
+        // so neither keeping nor deleting it is the answer:
+        //
+        //   fib_recursive, dynasm, the one resume that misses the map —
+        //   `pc=569 reg=0 nlocals=1 stack_only=2 vsd=3`, entries
+        //   `[(1,0,4),(1,2,1),(1,3,2)]`.  Color 0 IS mapped, to semantic slot
+        //   4; the inversion rejects it because `4 - nlocals` is at/above the
+        //   runtime `stack_only`, which is what that gate is for.  The
+        //   fallback then answers slot 0 — a LOCAL, not the operand-stack slot
+        //   the map named.  Deleting it declines this bridge and costs 16x
+        //   (0.86s -> 14.2s), so the decline is not an option either.
+        //
+        // The result slot is by construction the one about to be pushed, i.e.
+        // at/above the resume's live depth, so resolving it needs a query that
+        // does not gate on that depth.  Until that resolves at this
+        // coordinate, keep the fallback and its measured cost visible.
         .or_else(|| (result_reg < valuestackdepth).then_some(result_reg));
     let Some(semantic_result_slot) = semantic_result_slot else {
         return false;

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -1675,6 +1675,7 @@ fn drive_bridge_carrier_walk<Sym: WalkSym>(
     // sub-walk's local-concrete shadow so a nested self-recursive call's int arg
     // is known.
     let nlocals = recipe.nlocals.min(recipe.concrete_r.len());
+    let local_oprefs = &recipe.registers_r[..nlocals.min(recipe.registers_r.len())];
     let local_concretes = &recipe.concrete_r[..nlocals];
     // Increment 2b-i: drive the deepest callee as an inline SUB-WALK rooted on
     // the portal `sym` (is_top_level=false), so its `ref_return` surfaces
@@ -1690,6 +1691,7 @@ fn drive_bridge_carrier_walk<Sym: WalkSym>(
         callee_w_globals,
         entry,
         &argboxes_r,
+        local_oprefs,
         local_concretes,
         // Depth-N: tell the deepest sub-walk that all shallower frames are
         // paused so its in-callee guard snapshots encode the full
@@ -1843,8 +1845,35 @@ fn drive_bridge_carrier_walk<Sym: WalkSym>(
         }
         Some(Err(e)) => {
             if p2_diag {
+                let raw_code = recipe.code_ptr as *const CodeObject;
+                let (callee_name, source_path) = if raw_code.is_null() {
+                    ("<unknown>", "<unknown>")
+                } else {
+                    unsafe {
+                        (
+                            (*raw_code).obj_name.as_str(),
+                            (*raw_code).source_path.as_str(),
+                        )
+                    }
+                };
+                let stop_op = match e {
+                    crate::jitcode_dispatch::DispatchError::LoopBearingCalleeInlineUnsupported {
+                        pc,
+                    }
+                    | crate::jitcode_dispatch::DispatchError::AbortPermanentMarkerReached {
+                        pc,
+                    } => crate::jitcode_runtime::decode_op_at(
+                        callee_pjc.jitcode.code.as_slice(),
+                        *pc,
+                    )
+                    .map(|op| op.opname)
+                    .unwrap_or("<undecodable>"),
+                    _ => "<n/a>",
+                };
                 eprintln!(
-                    "[p2-drain] callee sub-walk STOP recipe_py_pc={} entry={entry} err={e:?}",
+                    "[p2-drain] callee sub-walk STOP callee={callee_name} \
+                     source={source_path} recipe_py_pc={} entry={entry} \
+                     stop_op={stop_op} err={e:?}",
                     crate::state::forward_py_pc_or_backxlat(
                         recipe.jitcode_index,
                         recipe.jitcode_pc
@@ -1914,6 +1943,7 @@ fn drive_middle_frame_and_thread<Sym: WalkSym>(
     };
     let middle_w_globals = crate::state::recover_inline_callee_globals(middle.code_ptr) as usize;
     let middle_nlocals = middle.nlocals.min(middle.concrete_r.len());
+    let middle_local_oprefs = &middle.registers_r[..middle_nlocals.min(middle.registers_r.len())];
     let middle_local_concretes = &middle.concrete_r[..middle_nlocals];
     let middle_walk = crate::jitcode_dispatch::drive_bridge_middle_frame(
         ctx,
@@ -1925,6 +1955,7 @@ fn drive_middle_frame_and_thread<Sym: WalkSym>(
         middle_w_globals,
         middle_entry,
         &middle_argboxes_r,
+        middle_local_oprefs,
         middle_local_concretes,
         paused_parents,
         child_result,

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -1478,11 +1478,14 @@ fn residual_ref_call_dst_before(code: &[u8], entry: usize) -> Option<usize> {
 /// canonical residual-call encoding.
 ///
 /// The result is always mirrored into `bridge_registers_r` for interior-entry
-/// bridge walks, whose Ref-bank seed is color-indexed.  Opcode-entry bridge
+/// bridge walks, whose Ref-bank seed is color-indexed. Opcode-entry bridge
 /// walks rebuild slot-indexed locals and operand-stack values from
-/// `bridge_local_oprefs` / `bridge_stack_oprefs`, so mirror the destination
-/// there too.  Returns `false` (caller declines the compile) when the register
-/// is unresolved.
+/// `bridge_local_oprefs` / `bridge_stack_oprefs`, so invert the destination
+/// color through the resume pc's color→semantic-slot map before mirroring it
+/// there. Treating a post-regalloc color as a localsplus slot corrupts an
+/// unrelated local whenever regalloc coalesces the call result.
+/// Returns `false` (caller declines the compile) when the register is
+/// unresolved.
 fn inject_root_call_result<Sym: WalkSym>(
     sym: &mut Sym,
     root_pc: usize,
@@ -1509,15 +1512,33 @@ fn inject_root_call_result<Sym: WalkSym>(
         }
         bridge_regs[result_reg] = result;
     }
-    if result_reg < nlocals {
+    let valuestackdepth = sym.valuestackdepth();
+    let stack_only = valuestackdepth.saturating_sub(nlocals);
+    let semantic_result_slot = payload
+        .jitcode
+        .try_index()
+        .map(|index| crate::state::bridge_semantic_maps_from_pc(index as i32, root_pc as i32))
+        .and_then(|maps| {
+            crate::state::semantic_ref_slot_for_reg_color(
+                nlocals,
+                stack_only,
+                &maps.pcdep_entries,
+                result_reg,
+            )
+        })
+        .or_else(|| (result_reg < valuestackdepth).then_some(result_reg));
+    let Some(semantic_result_slot) = semantic_result_slot else {
+        return false;
+    };
+    if semantic_result_slot < nlocals {
         if let Some(locals) = sym.bridge_local_oprefs_mut().as_mut() {
-            if locals.len() <= result_reg {
-                locals.resize(result_reg + 1, majit_ir::OpRef::NONE);
+            if locals.len() <= semantic_result_slot {
+                locals.resize(semantic_result_slot + 1, majit_ir::OpRef::NONE);
             }
-            locals[result_reg] = result;
+            locals[semantic_result_slot] = result;
         }
     } else {
-        let slot = result_reg - nlocals;
+        let slot = semantic_result_slot - nlocals;
         let bridge = sym.bridge_stack_oprefs_mut().get_or_insert_with(Vec::new);
         if bridge.len() <= slot {
             bridge.resize(slot + 1, majit_ir::OpRef::NONE);
@@ -1609,6 +1630,20 @@ fn drive_bridge_carrier_walk<Sym: WalkSym>(
             "[p2-shape] root_pc={root_pc} n_recipes={} recipe_pcs={pcs:?}",
             carrier.recipes.len()
         );
+    }
+    // Each resumed frame needs its own red frame and register bank. The
+    // current carrier driver has one root `sym`, so it can faithfully drain a
+    // single reconstructed callee but cannot yet keep two reconstructed
+    // callees' color banks independent. Decline before concrete sub-walking:
+    // executing the deepest frame only to roll it back adds substantial
+    // overhead and compiling the collapsed shape is unsound.
+    if carrier.recipes.len() > 1 {
+        crate::jitcode_dispatch::census_record("P2Drain::MultiFrameIdentityUnsupported");
+        discard_bridge_carrier_walk(ctx, sym, entry_depth, pre_pos, &pre_virtualref_boxes);
+        crate::jitcode_dispatch::bool_box_truth_reset();
+        crate::jitcode_dispatch::fbw_finish_payload_reset();
+        crate::jitcode_dispatch::fbw_store_journal_rollback();
+        return p2_drain_abort();
     }
     let Some(recipe) = carrier.recipes.last() else {
         crate::jitcode_dispatch::census_record("P2Drain::NoRecipes");

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -1631,20 +1631,6 @@ fn drive_bridge_carrier_walk<Sym: WalkSym>(
             carrier.recipes.len()
         );
     }
-    // Each resumed frame needs its own red frame and register bank. The
-    // current carrier driver has one root `sym`, so it can faithfully drain a
-    // single reconstructed callee but cannot yet keep two reconstructed
-    // callees' color banks independent. Decline before concrete sub-walking:
-    // executing the deepest frame only to roll it back adds substantial
-    // overhead and compiling the collapsed shape is unsound.
-    if carrier.recipes.len() > 1 {
-        crate::jitcode_dispatch::census_record("P2Drain::MultiFrameIdentityUnsupported");
-        discard_bridge_carrier_walk(ctx, sym, entry_depth, pre_pos, &pre_virtualref_boxes);
-        crate::jitcode_dispatch::bool_box_truth_reset();
-        crate::jitcode_dispatch::fbw_finish_payload_reset();
-        crate::jitcode_dispatch::fbw_store_journal_rollback();
-        return p2_drain_abort();
-    }
     let Some(recipe) = carrier.recipes.last() else {
         crate::jitcode_dispatch::census_record("P2Drain::NoRecipes");
         // Churn guard (Task 8): making this class transient retried the same

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -101,6 +101,22 @@ pub(crate) extern "C" fn sqrt_nonneg_jit(x: f64) -> f64 {
     x.sqrt()
 }
 
+/// RPython `ll_math_{log,cos,sin}` fast-path calls after their exceptional
+/// branches have been pinned by the walker.  These are the raw libm calls the
+/// translated PyPy trace carries; boxing stays outside so optimizeopt can
+/// virtualize the resulting `W_FloatObject`.
+pub(crate) extern "C" fn math_log_positive_jit(x: f64) -> f64 {
+    x.ln()
+}
+
+pub(crate) extern "C" fn math_cos_finite_jit(x: f64) -> f64 {
+    x.cos()
+}
+
+pub(crate) extern "C" fn math_sin_finite_jit(x: f64) -> f64 {
+    x.sin()
+}
+
 pub(crate) extern "C" fn float_pow_jit(x: f64, y: f64) -> f64 {
     match pyre_interpreter::float_pow_raw(x, y) {
         Ok(z) => z,

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -639,7 +639,9 @@ unsafe fn tokenizer_iter_destructor(obj_addr: usize) {
     unsafe { pyre_interpreter::module::_tokenize::w_tokenizer_iter_dealloc(obj) };
 }
 
-/// Custom trace for `W_ObjectObject` (instance `map`+`storage`,
+/// Custom trace for objects carrying the `MapdictStorageMixin` prefix
+/// (`W_ObjectObject` and native-layout Python subclasses such as
+/// `W_Random`; instance `map`+`storage`,
 /// `mapdict.py:907-910`).  The `storage` list is an off-GC
 /// `Box<Vec<PyObjectRef>>`, so — exactly as `dict_object_custom_trace`
 /// reaches the off-GC dict entries — this forwards each boxed
@@ -2519,12 +2521,31 @@ fn build_gc() -> Box<dyn majit_gc::GcAllocator> {
     // the descriptor's `gc_type_id` matches the order here so the
     // hardcoded `type_id` constants on the `#[pyre_class]`
     // attribute cannot silently drift.
-    register_pyre_class(
-        &mut gc,
-        &mut pytype_to_tid,
-        <pyre_interpreter::module::_random::W_Random
-            as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
-    );
+    // PyPy's `allocate_instance(W_Random, w_subtype)` composes
+    // `MapdictStorageMixin` into Python subclasses. `W_Random` therefore has
+    // the same `[PyObject | map | storage]` prefix as `W_ObjectObject` and
+    // needs the same custom trace for boxed attributes. Register it in the
+    // original slot so every later type id remains stable.
+    {
+        let descr = <pyre_interpreter::module::_random::W_Random
+            as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR;
+        let tid = gc.register_type(TypeInfo::object_subclass_with_custom_trace(
+            descr.object_size,
+            object_tid,
+            object_object_custom_trace,
+        ));
+        if descr.gc_type_id.is_unassigned() {
+            descr.gc_type_id.set(tid);
+        } else {
+            debug_assert_eq!(tid, descr.gc_type_id.get());
+        }
+        majit_gc::GcAllocator::register_vtable_for_type(&mut gc, descr.pytype_ptr as usize, tid);
+        pytype_to_tid.insert(descr.pytype_ptr as usize, tid);
+        pyre_object::gc_hook::register_pyre_class_offsets(
+            descr.pytype_ptr as usize,
+            descr.ptr_offsets,
+        );
+    }
     // Per-`ExcKind` GC type ids.  The pre-registration loop at the
     // top of this function mapped every exception PyType to a
     // single `W_BASE_EXCEPTION_GC_TYPE_ID` so `new_with_vtable` knows

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -304,6 +304,10 @@ fn pyre_object_gc_write_barrier_trampoline(obj: *mut u8) {
     majit_gc::gc_write_barrier(majit_ir::GcRef(obj as usize));
 }
 
+fn pyre_object_gc_write_barrier_managed_trampoline(obj: *mut u8) {
+    majit_gc::gc_write_barrier_managed(majit_ir::GcRef(obj as usize));
+}
+
 /// `pypy/objspace/std/dictmultiobject.py:1209 ObjectDictStrategy` key
 /// equality bridge: ObjectDictStrategy stores its dstorage as
 /// `r_dict(space.eq_w, space.hash_w)` so user `__eq__` is honoured on
@@ -3807,6 +3811,9 @@ fn install_pyre_object_hooks() {
         pyre_object_gc_current_object_address_trampoline,
     );
     pyre_object::register_gc_write_barrier_hook(pyre_object_gc_write_barrier_trampoline);
+    pyre_object::register_gc_write_barrier_managed_hook(
+        pyre_object_gc_write_barrier_managed_trampoline,
+    );
     pyre_object::gc_hook::register_gc_identity_hash_hook(pyre_object_gc_identity_hash_trampoline);
     // Let a born-old allocation that crosses the next-major threshold request
     // a collection, the check `external_malloc` (incminimark.py:987-994) makes

--- a/pyre/pyre-object/src/gc_hook.rs
+++ b/pyre/pyre-object/src/gc_hook.rs
@@ -578,15 +578,25 @@ pub fn gc_identity_hash(obj_addr: usize) -> usize {
 pub type GcWriteBarrierHookFn = fn(obj: *mut u8);
 
 majit_gc::global_hook!(static GC_WRITE_BARRIER_HOOK: GcWriteBarrierHookFn);
+majit_gc::global_hook!(static GC_WRITE_BARRIER_MANAGED_HOOK: GcWriteBarrierHookFn);
 
 /// Install the write-barrier callback.
 pub fn register_gc_write_barrier_hook(hook: GcWriteBarrierHookFn) {
     GC_WRITE_BARRIER_HOOK.set(Some(hook));
 }
 
+/// Install the callback for objects returned by a managed allocation hook.
+pub fn register_gc_write_barrier_managed_hook(hook: GcWriteBarrierHookFn) {
+    GC_WRITE_BARRIER_MANAGED_HOOK.set(Some(hook));
+}
+
 /// Remove the write-barrier callback.
 pub fn clear_gc_write_barrier_hook() {
     GC_WRITE_BARRIER_HOOK.set(None);
+}
+
+pub fn clear_gc_write_barrier_managed_hook() {
+    GC_WRITE_BARRIER_MANAGED_HOOK.set(None);
 }
 
 /// Run the active GC write barrier for `obj` when one is installed.
@@ -602,6 +612,19 @@ pub extern "C" fn try_gc_write_barrier(obj: *mut u8) -> bool {
             true
         }
         None => false,
+    }
+}
+
+/// Run the active barrier for a pointer returned by a managed allocation
+/// hook.  The backend may omit the general hybrid-heap ownership lookup.
+#[majit_macros::dont_look_inside]
+pub extern "C" fn try_gc_write_barrier_managed(obj: *mut u8) -> bool {
+    match GC_WRITE_BARRIER_MANAGED_HOOK.get() {
+        Some(f) => {
+            f(obj);
+            true
+        }
+        None => try_gc_write_barrier(obj),
     }
 }
 

--- a/pyre/pyre-object/src/gc_roots.rs
+++ b/pyre/pyre-object/src/gc_roots.rs
@@ -208,6 +208,10 @@ pub struct RootScope {
     /// called. Will be replaced with a backend
     /// `RootSet::Handle` once the active GC consumes the stack.
     save_point: usize,
+    /// Resolved thread-local stack cell. RPython keeps the shadow-stack
+    /// base/top address live for the whole root bracket; caching the cell here
+    /// avoids resolving TLS again for every generated slot write/read.
+    stack_slot: *mut Vec<PyObjectRef>,
     /// A root bracket belongs to the thread whose shadow stack supplied this
     /// save point. Moving it could truncate an unrelated thread's stack.
     _not_send: PhantomData<*const ()>,
@@ -218,10 +222,45 @@ impl RootScope {
     /// [`push_roots`] so the API surface stays uniform across phases.
     #[inline]
     fn new() -> Self {
+        let (save_point, stack_slot) = SHADOW_STACK.with(|cell| {
+            let stack = unsafe { &*cell.get() };
+            (stack.len(), cell.get())
+        });
         Self {
-            save_point: shadow_stack_len(),
+            save_point,
+            stack_slot,
             _not_send: PhantomData,
         }
+    }
+
+    /// First slot owned by this root bracket.
+    #[inline]
+    pub fn base(&self) -> usize {
+        self.save_point
+    }
+
+    /// Scope-local [`pin_root`] using the already-resolved root-stack cell.
+    #[majit_macros::dont_look_inside]
+    pub fn pin_root(&self, root: PyObjectRef) {
+        #[cfg(debug_assertions)]
+        assert_shadow_stack_not_walking();
+        let index = unsafe {
+            let stack = &mut *self.stack_slot;
+            let index = stack.len();
+            stack.push(root);
+            index
+        };
+        let normalized =
+            crate::gc_hook::try_gc_current_object_address(root as *mut u8) as PyObjectRef;
+        if normalized != root {
+            unsafe { (&mut *self.stack_slot)[index] = normalized };
+        }
+    }
+
+    /// Scope-local [`shadow_stack_get`] using the cached cell.
+    #[majit_macros::dont_look_inside]
+    pub fn get(&self, index: usize) -> PyObjectRef {
+        unsafe { (&*self.stack_slot)[index] }
     }
 }
 
@@ -233,11 +272,9 @@ impl Drop for RootScope {
     fn drop(&mut self) {
         #[cfg(debug_assertions)]
         assert_shadow_stack_not_walking();
-        with_shadow_stack_mut(|stack| {
-            // `truncate` is a no-op if `save_point >= len()`, which is
-            // the steady-state case for an empty bracket.
-            stack.truncate(self.save_point);
-        });
+        // `truncate` is a no-op if `save_point >= len()`, which is
+        // the steady-state case for an empty bracket.
+        unsafe { (&mut *self.stack_slot).truncate(self.save_point) };
     }
 }
 
@@ -590,16 +627,29 @@ mod tests {
         let _roots = push_roots();
     }
 
-    /// Currently `RootScope` carries a single `usize` save-point.
-    /// This will be swapped for a backend `RootSet::Handle` (still
-    /// pointer-sized on 64-bit hosts); this test traps unintended
-    /// growth beyond that.
+    /// `RootScope` carries the saved top plus the resolved root-stack cell,
+    /// matching RPython's base/top pair. Trap unintended growth beyond those
+    /// two words.
     #[test]
-    fn root_scope_payload_is_one_word() {
+    fn root_scope_payload_is_two_words() {
         assert_eq!(
             std::mem::size_of::<RootScope>(),
-            std::mem::size_of::<usize>()
+            2 * std::mem::size_of::<usize>()
         );
+    }
+
+    #[test]
+    fn scope_local_pin_and_get_share_the_cached_stack_cell() {
+        let before = shadow_stack_len();
+        {
+            let roots = push_roots();
+            assert_eq!(roots.base(), before);
+            roots.pin_root(dummy(0x1234));
+            roots.pin_root(dummy(0x5678));
+            assert_eq!(roots.get(before) as usize, 0x1234);
+            assert_eq!(roots.get(before + 1) as usize, 0x5678);
+        }
+        assert_eq!(shadow_stack_len(), before);
     }
 
     /// `pin_root` appends, the matching `Drop` truncates back to the

--- a/pyre/pyre-object/src/listobject.rs
+++ b/pyre/pyre-object/src/listobject.rs
@@ -592,7 +592,15 @@ pub fn list_strategy_for(items: &[PyObjectRef]) -> ListStrategy {
 /// `W_ListObject`, so the barrier must run for every appended ref).
 #[majit_macros::dont_look_inside]
 pub extern "C" fn list_write_barrier(obj: PyObjectRef) {
-    crate::gc_hook::try_gc_write_barrier(obj as *mut u8);
+    list_write_barrier_impl(obj, false);
+}
+
+fn list_write_barrier_impl(obj: PyObjectRef, managed: bool) {
+    if managed {
+        crate::gc_hook::try_gc_write_barrier_managed(obj as *mut u8);
+    } else {
+        crate::gc_hook::try_gc_write_barrier(obj as *mut u8);
+    }
     // Phase L2: when the block is a GC-managed array, the list-ptr forward in
     // `list_object_custom_trace` relocates a young block but does NOT re-scan an
     // already-old block's items — a young element just stored into an old block
@@ -760,7 +768,11 @@ fn w_list_new_with_strategy(items: Vec<PyObjectRef>, strategy: ListStrategy) -> 
     // young) initial elements; remember the old-gen list so the next minor GC
     // forwards them. Integer/Float blocks are old-gen — no young pointer to track.
     if strategy == ListStrategy::Object {
-        list_write_barrier(raw as PyObjectRef);
+        // `raw` came directly from `try_gc_alloc_stable_raw`; skip the
+        // defensive mixed-heap ownership query for the list itself.  The
+        // backing block retains its own check because its allocator can still
+        // fall back to `std::alloc`.
+        list_write_barrier_impl(raw as PyObjectRef, true);
     }
     raw as PyObjectRef
 }

--- a/pyre/pyre-object/src/lltype.rs
+++ b/pyre/pyre-object/src/lltype.rs
@@ -294,7 +294,7 @@ pub fn malloc_typed_managed<T: GcType>(value: T) -> *mut T {
                 // nursery is full.  In that case the freshly-written payload
                 // can already contain nursery references and must enter the
                 // remembered set.  Nursery allocations ignore this barrier.
-                crate::gc_hook::try_gc_write_barrier(raw);
+                crate::gc_hook::try_gc_write_barrier_managed(raw);
             }
             return raw as *mut T;
         }
@@ -337,7 +337,7 @@ pub fn malloc_typed_stable<T: GcType>(value: T) -> *mut T {
             // young children, mirroring the hand-written barrier every other
             // stable allocator runs after its raw write (`w_list_new`,
             // `w_generator_new`, `tupleobject`).
-            crate::gc_hook::try_gc_write_barrier(raw);
+            crate::gc_hook::try_gc_write_barrier_managed(raw);
             raw as *mut T
         }
     }

--- a/pyre/pyre-object/src/object_array.rs
+++ b/pyre/pyre-object/src/object_array.rs
@@ -1012,10 +1012,10 @@ impl FixedObjectArray {
             return;
         }
         let _roots = crate::gc_roots::push_roots();
-        let root_base = crate::gc_roots::shadow_stack_len();
-        crate::gc_roots::pin_root(self as *mut Self as PyObjectRef);
-        crate::gc_roots::pin_root(value);
-        let array = crate::gc_roots::shadow_stack_get(root_base) as *mut Self;
+        let root_base = _roots.base();
+        _roots.pin_root(self as *mut Self as PyObjectRef);
+        _roots.pin_root(value);
+        let array = _roots.get(root_base) as *mut Self;
         // Every mutable FixedObjectArray has a real header word: managed frame
         // locals carry the collector's header, while the StdAlloc snapshot
         // fallback is deliberately prefixed with a zeroed one
@@ -1027,8 +1027,8 @@ impl FixedObjectArray {
         // The barrier may wait behind a foreign collection. Reload the array
         // as well as the value before the store: RPython's setarrayitem_gc
         // keeps both live across the barrier.
-        let array = crate::gc_roots::shadow_stack_get(root_base) as *mut Self;
-        let value = crate::gc_roots::shadow_stack_get(root_base + 1);
+        let array = _roots.get(root_base) as *mut Self;
+        let value = _roots.get(root_base + 1);
         unsafe { (*array).items_mut_ptr().add(index).write(value) };
     }
 

--- a/pyre/pyre-object/src/object_array.rs
+++ b/pyre/pyre-object/src/object_array.rs
@@ -1016,12 +1016,17 @@ impl FixedObjectArray {
         crate::gc_roots::pin_root(self as *mut Self as PyObjectRef);
         crate::gc_roots::pin_root(value);
         let array = crate::gc_roots::shadow_stack_get(root_base) as *mut Self;
-        if crate::gc_hook::try_gc_owns_object(array as *mut u8) {
-            crate::gc_hook::try_gc_write_barrier(array as *mut u8);
-        }
-        // Both ownership lookup and the barrier may wait behind a foreign
-        // collection.  Reload the array as well as the value before the store:
-        // RPython's setarrayitem_gc keeps both live across the barrier.
+        // Every mutable FixedObjectArray has a real header word: managed frame
+        // locals carry the collector's header, while the StdAlloc snapshot
+        // fallback is deliberately prefixed with a zeroed one
+        // (`alloc_fixed_array_with_header`).  This is therefore the ordinary
+        // RPython `setarrayitem_gc` shape: test the header flag directly and
+        // enter the membership-free slow path only when it is set.  The zeroed
+        // fallback header makes the same call a no-op without an arena lookup.
+        crate::gc_hook::try_gc_write_barrier_managed(array as *mut u8);
+        // The barrier may wait behind a foreign collection. Reload the array
+        // as well as the value before the store: RPython's setarrayitem_gc
+        // keeps both live across the barrier.
         let array = crate::gc_roots::shadow_stack_get(root_base) as *mut Self;
         let value = crate::gc_roots::shadow_stack_get(root_base + 1);
         unsafe { (*array).items_mut_ptr().add(index).write(value) };

--- a/pyre/pyre-object/src/object_array.rs
+++ b/pyre/pyre-object/src/object_array.rs
@@ -390,8 +390,13 @@ pub unsafe fn alloc_list_items_block_gc(values: &[PyObjectRef]) -> *mut ItemsBlo
     crate::gc_roots::pin_root(block as PyObjectRef);
     let block = crate::gc_roots::shadow_stack_get(block_slot) as *mut ItemsBlock;
     let base = unsafe { items_block_items_base(block) };
-    for i in 0..len {
-        unsafe { *base.add(i) = crate::gc_roots::shadow_stack_get(save + i) };
+    if len > 0 {
+        // RPython's pop_roots reloads the livevars as one generated block.
+        // Enter TLS once for the whole contiguous item range instead of once
+        // per element; `base` names the freshly allocated block's initialized
+        // prefix and cannot alias the shadow stack.
+        let dst = unsafe { std::slice::from_raw_parts_mut(base, len) };
+        crate::gc_roots::shadow_stack_copy_range(save, dst);
     }
     for i in len..cap {
         unsafe { *base.add(i) = PY_NULL };
@@ -490,8 +495,10 @@ pub unsafe fn alloc_tuple_items_block_gc(values: &[PyObjectRef]) -> *mut ItemsBl
     crate::gc_roots::pin_root(block as PyObjectRef);
     let block = crate::gc_roots::shadow_stack_get(block_slot) as *mut ItemsBlock;
     let base = unsafe { items_block_items_base(block) };
-    for i in 0..cap {
-        unsafe { *base.add(i) = crate::gc_roots::shadow_stack_get(save + i) };
+    if cap > 0 {
+        // Same block-shaped pop_roots reload as the list constructor above.
+        let dst = unsafe { std::slice::from_raw_parts_mut(base, cap) };
+        crate::gc_roots::shadow_stack_copy_range(save, dst);
     }
     // The block may have landed in old-gen (nursery-full fallback) while its
     // elements are still young. That old→young edge is invisible to a minor

--- a/pyre/pyre-object/src/specialisedtupleobject.rs
+++ b/pyre/pyre-object/src/specialisedtupleobject.rs
@@ -227,7 +227,7 @@ pub fn w_specialised_tuple_oo_new(value0: PyObjectRef, value1: PyObjectRef) -> P
         // the collection relocates/marks the young elements, mirroring the
         // `write_barrier_from_array` an old-gen store emits
         // (incminimark.py:1495) and `w_tuple_new_array_backed`.
-        crate::gc_hook::try_gc_write_barrier(raw);
+        crate::gc_hook::try_gc_write_barrier_managed(raw);
         return raw as PyObjectRef;
     }
     Box::into_raw(Box::new(W_SpecialisedTupleObject_oo {

--- a/pyre/pyre-object/src/tupleobject.rs
+++ b/pyre/pyre-object/src/tupleobject.rs
@@ -274,7 +274,7 @@ pub fn w_tuple_new_array_backed(items: Vec<PyObjectRef>) -> PyObjectRef {
         // custom-trace hook) and relocates any young element. Mirrors the
         // `write_barrier_from_array` an old list/tuple store would emit
         // (incminimark.py:1495).
-        crate::gc_hook::try_gc_write_barrier(raw);
+        crate::gc_hook::try_gc_write_barrier_managed(raw);
         return raw as PyObjectRef;
     }
     Box::into_raw(Box::new(W_TupleObject {


### PR DESCRIPTION
Eight commits on top of #928, in three groups.

## Low-level layouts for synthetic aggregates

`front::mir` emits two aggregate shapes that Charon has no `TypeDecl` row for, and both were previously borrowing a layout that does not describe them.

- **Tuples.** `rtuple.py:115-125` creates one distinct `GcStruct('tupleN', ...)` per item shape and `TupleRepr.newtuple` (`rtuple.py:153-169`) allocates it and writes the fields. `struct_id_for_name` was collapsing generic instantiations to their template, which merged `(A,)` and `(A, B)` onto a bare `Tuple` identity. Tuple shapes now keep their full `Tuple<T,...>` spelling and each gets its own `StructId`, registered from the translated graph rather than the declaration table. The synthetic tuple constructor lowers to the matching `malloc` instead of surviving as a residual synthetic call with no registered function address.
- **`Result<T, PyError>`.** The inverse exception transform leaves a hand-written `match` represented as the explicit shell `{ __discriminant: Signed, __pos_0: payload }`. Rust's niche layout puts tag and payload both at offset 0, so the payload store overwrote the tag and every following switch took its unreachable default. The shell now gets its own non-overlapping layout, and the variant's fielddescr list reconstructs the inherited tag slot ahead of the variant's own fields, matching `heaptracker.get_fielddescr_index_in` counting through the embedded base.
- Pointer-wrapped fields contribute one pointer leaf descriptor instead of being recursively flattened as an embedded struct — `lltype.Ptr` is not `lltype.Struct` even when the pointee is known.
- `int.bit_length` becomes a named gateway wrapper rather than an `init_int_type` closure, so the source translator sees the same candidate graph and a traced call descends to `rbigint::bit_length_int`; long operands route through their magnitude instead of the i64 fast path.

## Trace specialization

- Exact tuples unpack through their `wrappeditems` array (`objspace.py:507-541`, `pyopcode.py:889 UNPACK_SEQUENCE` → `fixedview_unroll`), so a constant item count exposes each item to the trace. Tuple subclasses and non-canonical tuples still fall through to the residual.
- `math.log/cos/sin` on an exact int/float pins the domain branch, unboxes the operand and emits the raw pure `CALL_F` (`ll_math_{log,cos,sin}`), leaving the result box virtualizable. Rebound callables, subclasses and cold NaN/inf/domain cases stay residual.

## Frame identity across inline and resume

- An inlined closure's freevar cells now survive a may-force call: the heapcache entry from `emit_new_pyframe_inline_with_params` is only a forwarding optimization and the call invalidates it, so the frame-local shadow is seeded too and a later `LOAD_DEREF` re-reads the live cell instead of manufacturing an unstamped `GetarrayitemGcR`.
- Resume reconstruction admits freevars. The recipe field historically called `nlocals` is the semantic stack base `co_nlocals + ncellvars + nfreevars`, matching `MIFrame.registers_r` / `locals_cells_stack_w` (`pyframe.py:107-111`); existing closure cells are rebuilt as ordinary array entries by `consume_boxes` (`resume.py:1042-1057`). Fresh cellvars still take the conservative path.
- A reconstructed callee frame gets the matching recording-time `PyFrame` alongside the emitted `frame_vable`, as `perform_call` (`pyjitpl.py:2445-2476`) creates a concrete frame beside the callee MIFrame. Without it the first residual consuming the frame red saw a symbolic-only Ref and the carrier sub-walk aborted. Code, globals and every reconstructed prefix slot are rooted before the closure tuple/frame allocations.
- A destination color is inverted through the resume pc's color→semantic-slot map before being mirrored into `bridge_local_oprefs` / `bridge_stack_oprefs`; treating a post-regalloc color as a localsplus slot corrupted an unrelated local whenever regalloc coalesced the call result.
- Carrier walks with more than one recipe are declined: the driver has one root `sym` and cannot keep two reconstructed callees' color banks independent.

## mapdict for a native-layout subclass

`allocate_instance(W_Random, w_subtype)` composes `MapdictStorageMixin` upstream (`objspace.py:485-487`, `mapdict.py:907-910`), so `W_Random` carries the same `[PyObject | map | storage]` prefix as `W_ObjectObject` and shares the custom trace. `has_mapdict_storage` is a layout predicate, and the attribute-fold guard keeps the concrete layout vtable instead of claiming `INSTANCE_TYPE` — the latter poisoned the heap cache for native-layout subclasses and let later folds apply unrelated field descriptors to the same box.

## Fixtures

`tuple_unpack_array_backed_hot.py` (ratio 40), `math_log_trig_hot.py` (ratio 30), `inline_freevar_after_mayforce.py` (ratio 20).

---

Note: the local gate was not run for this push — the working tree carries another session's in-progress debug scaffolding, so a local green there is not evidence about these commits ([the lesson from #921](https://github.com/youknowone/pyre/pull/921)). CI is the check.

— *authored by Claude*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved JIT optimization for `math.log`, `math.sin`, and `math.cos`.
  * Optimized tuple unpacking, function calls, closure handling, frame reconstruction, and managed memory operations.

* **Bug Fixes**
  * Corrected generic tuple and `Result` layouts, including payload and discriminant placement.
  * Fixed pointer-to-structure field classification.
  * Improved `int.bit_length()` handling for integers and booleans.
  * Improved `_random.Random` compatibility with instance attributes and weak references.

* **Diagnostics**
  * Added configurable tracing for guard failures and runtime execution checks.
  * Improved diagnostic information for execution and bridge failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->