### PR TITLE
jit,interp: lower DELETE_NAME/GLOBAL, drop invalidated celldict watchers

### DIFF
--- a/majit/majit-backend-dynasm/src/lib.rs
+++ b/majit/majit-backend-dynasm/src/lib.rs
@@ -69,6 +69,23 @@ pub fn majit_j2plan_log_enabled() -> bool {
     *ENABLED
 }
 
+/// Whether `PYRE_GC_FREELIST_DIAG` is set, cached at first access.
+///
+/// Read once per residual call and twice per compiled-trace entry, so the
+/// uncached form put `getenv` on the hottest paths the backend has.
+pub fn gc_freelist_diag_enabled() -> bool {
+    static ENABLED: std::sync::LazyLock<bool> =
+        std::sync::LazyLock::new(|| std::env::var_os("PYRE_GC_FREELIST_DIAG").is_some());
+    *ENABLED
+}
+
+/// Whether `PYRE_DYNASM_EXEC_DIAG` is set, cached at first access.
+pub fn dynasm_exec_diag_enabled() -> bool {
+    static ENABLED: std::sync::LazyLock<bool> =
+        std::sync::LazyLock::new(|| std::env::var_os("PYRE_DYNASM_EXEC_DIAG").is_some());
+    *ENABLED
+}
+
 static JIT_EXC_VALUE: AtomicI64 = AtomicI64::new(0);
 // Holds the pending exception's `typeptr` (an immortal static `PyType`), never a
 // managed object, so it is deliberately not GC-rooted.

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -597,21 +597,25 @@ fn dynasm_collect_full() {
     majit_gc::gc_sync::gc_op(|g| g.collect_full());
 }
 
-fn debug_validate_oldgen_freeblocks(site: &str) {
-    if std::env::var_os("PYRE_GC_FREELIST_DIAG").is_none() {
+/// Takes `format_args!` rather than a built `String`: the callers sit on the
+/// per-residual-call and per-trace-entry paths, where formatting the site name
+/// for a diagnostic that is off costs a heap allocation every time.
+fn debug_validate_oldgen_freeblocks(site: std::fmt::Arguments<'_>) {
+    if !crate::gc_freelist_diag_enabled() {
         return;
     }
+    let site = site.to_string();
     if DYNASM_ACTIVE_GC
         .with(|c| {
             c.borrow()
                 .as_deref()
-                .map(|g| g.debug_validate_oldgen_freeblocks(site))
+                .map(|g| g.debug_validate_oldgen_freeblocks(&site))
         })
         .is_some()
     {
         return;
     }
-    majit_gc::gc_sync::gc_op(|g| g.debug_validate_oldgen_freeblocks(site));
+    majit_gc::gc_sync::gc_op(|g| g.debug_validate_oldgen_freeblocks(&site));
 }
 
 pub extern "C" fn dynasm_debug_validate_oldgen_freeblocks(site: u64, frame: usize) {
@@ -623,7 +627,7 @@ pub extern "C" fn dynasm_debug_validate_oldgen_freeblocks(site: u64, frame: usiz
             majit_gc::shadow_stack::is_libc_jitframe(top),
         );
     }
-    debug_validate_oldgen_freeblocks(&format!("after residual site {site}"));
+    debug_validate_oldgen_freeblocks(format_args!("after residual site {site}"));
 }
 
 fn dynasm_get_objects(generation: i8, visitor: majit_gc::GetObjectsVisitorFn) {
@@ -892,10 +896,10 @@ pub extern "C" fn dynasm_nursery_slowpath(total_size: u64) -> u64 {
         let raw = libc::calloc(1, total_size as usize) as u64;
         if raw == 0 { 0 } else { raw + gc_hdr as u64 }
     });
-    if std::env::var_os("PYRE_GC_FREELIST_DIAG").is_some() {
+    if crate::gc_freelist_diag_enabled() {
         let nursery = dynasm_gc_is_nursery_object(ptr as usize);
         eprintln!("[malloc-slow] total={total_size} payload={ptr:#x} nursery={nursery}");
-        debug_validate_oldgen_freeblocks("after malloc slowpath");
+        debug_validate_oldgen_freeblocks(format_args!("after malloc slowpath"));
     }
     if majit_ir::debug::have_debug_prints() {
         majit_ir::debug::log_one(
@@ -2574,7 +2578,7 @@ impl Backend for DynasmBackend {
 
         let bridge_addr = codebuf::buffer_ptr(&compiled.buffer) as usize;
         let code_size = compiled.buffer.len();
-        if std::env::var_os("PYRE_DYNASM_EXEC_DIAG").is_some() {
+        if crate::dynasm_exec_diag_enabled() {
             eprintln!(
                 "[dynasm-bridge] trace={trace_id} source={}:{} addr={bridge_addr:#x} len={code_size}",
                 fail_descr.trace_id(),
@@ -2803,7 +2807,7 @@ impl Backend for DynasmBackend {
         // manual push_jf/pop_jf_to around the call.
         let func: unsafe extern "C" fn(*mut JitFrame) -> *mut JitFrame =
             unsafe { std::mem::transmute(entry) };
-        if std::env::var_os("PYRE_DYNASM_EXEC_DIAG").is_some() {
+        if crate::dynasm_exec_diag_enabled() {
             eprintln!(
                 "[dynasm-exec] trace={} header={} entry={entry:p} len={} args={args:?}",
                 compiled.trace_id,
@@ -2811,9 +2815,9 @@ impl Backend for DynasmBackend {
                 compiled.buffer.len(),
             );
         }
-        debug_validate_oldgen_freeblocks(&format!("before trace {}", compiled.trace_id));
+        debug_validate_oldgen_freeblocks(format_args!("before trace {}", compiled.trace_id));
         let result_jf = unsafe { func(jf_ptr) };
-        debug_validate_oldgen_freeblocks(&format!("after trace {}", compiled.trace_id));
+        debug_validate_oldgen_freeblocks(format_args!("after trace {}", compiled.trace_id));
 
         if crate::majit_log_enabled() {
             eprintln!(

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -8912,9 +8912,9 @@ pub unsafe fn load_method_fast_path(
 ///
 /// The metatype is read off the class (`getclass()`) and must be `type`
 /// itself, so a custom metaclass declines (its `__getattribute__` may not
-/// follow `type.__getattribute__`).  A name the metatype itself defines is
-/// declined too: a metatype attribute would shadow the class attribute (data
-/// descriptor) or be returned in its place.  An uncacheable type and any
+/// follow `type.__getattribute__`).  A name the metatype defines as a DATA
+/// DESCRIPTOR is declined too, since that is the one entry `descr_getattribute`
+/// selects ahead of the class's own MRO.  An uncacheable type and any
 /// non-`classmethod` descriptor also decline.
 ///
 /// # Safety
@@ -8937,9 +8937,12 @@ pub unsafe fn classmethod_on_type_fast_path(
     if !std::ptr::eq(metatype, crate::typedef::w_type()) {
         return None;
     }
-    // A metatype attribute of the same name would win over the class attribute,
-    // so decline any name the metatype defines.
-    if lookup_in_type(metatype, name).is_some() {
+    // `typeobject.py:813-823 descr_getattribute` orders the two lookups: the
+    // metatype entry preempts the class's own MRO only when it is a data
+    // descriptor, and otherwise `self.lookup(name)` is what gets selected.
+    // Decline exactly that case; a non-data metatype attribute loses to the
+    // class's classmethod, which is the value this fold emits.
+    if type_lookup_is_data_descr(metatype, name) {
         return None;
     }
     let version_tag = pyre_object::typeobject::w_type_get_version_tag(w_type);

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -8080,6 +8080,11 @@ pub(crate) fn collect_iterator(it: PyObjectRef) -> Result<Vec<PyObjectRef>, crat
     // (framework.py:853-856).
     let base = pyre_object::gc_roots::shadow_stack_len();
     pyre_object::gc_roots::pin_root(it);
+    // `pin_root` itself queries the collector, so read the iterator back from
+    // its slot instead of reusing the caller's copy: a foreign collection that
+    // ran inside the pin forwarded the object and rewrote the slot, not the
+    // local.
+    let it = pyre_object::gc_roots::shadow_stack_get(base);
     // Dict-view iterators are currently off-GC RPython-style carriers.  Their
     // registered raw-field walker covers frame/value-stack reachability, but
     // this helper keeps the iterator on the shadow stack directly; retain its
@@ -10799,6 +10804,9 @@ fn builtin_any(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let it = crate::baseobjspace::iter(pyre_object::gc_roots::shadow_stack_get(iterable_slot))?;
     let iterator_slot = pyre_object::gc_roots::shadow_stack_len();
     pyre_object::gc_roots::pin_root(it);
+    // The pin queries the collector, so the slot — not this local — is what
+    // holds the forwarded iterator once it returns.
+    let it = pyre_object::gc_roots::shadow_stack_get(iterator_slot);
     if unsafe { pyre_object::dictmultiobject::is_dict_view_iterator(it) } {
         let w_dict = unsafe { pyre_object::dictmultiobject::w_dict_view_iterator_get_dict(it) };
         pyre_object::gc_roots::pin_root(w_dict);
@@ -12905,6 +12913,9 @@ fn builtin_all(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let it = crate::baseobjspace::iter(pyre_object::gc_roots::shadow_stack_get(iterable_slot))?;
     let iterator_slot = pyre_object::gc_roots::shadow_stack_len();
     pyre_object::gc_roots::pin_root(it);
+    // The pin queries the collector, so the slot — not this local — is what
+    // holds the forwarded iterator once it returns.
+    let it = pyre_object::gc_roots::shadow_stack_get(iterator_slot);
     if unsafe { pyre_object::dictmultiobject::is_dict_view_iterator(it) } {
         let w_dict = unsafe { pyre_object::dictmultiobject::w_dict_view_iterator_get_dict(it) };
         pyre_object::gc_roots::pin_root(w_dict);

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -2350,13 +2350,15 @@ impl NamespaceOpcodeHandler for PyFrame {
                     && pyre_object::dictmultiobject::is_module_dict(w_globals)
             }
         };
-        // `pyopcode.py:979` reads the builtins through the METHOD
+        // `_load_global` (pyopcode.py) reads the builtins through the METHOD
         // `self.get_builtin()`, not the `builtin` field.  Under the default
-        // `honor__builtins__=False` that method answers `space.builtin` and
-        // never consults the frame at all (`pyframe.py:199-203`), so the field
-        // being unset must not be observable here.  Reading the raw field made
-        // the builtins leg silently find nothing on any frame with a null
-        // `w_builtin`, raising `NameError` for a builtin that plainly exists.
+        // `honor__builtins__=False` the constructor never assigns that field
+        // (pyframe.py) and the method answers `space.builtin` without
+        // consulting the frame at all, so the field being unset must not be
+        // observable here.  A frame the JIT materialized from a virtual is
+        // exactly such a frame: reading the raw field made the builtins leg
+        // silently find nothing there, raising `NameError` for a builtin that
+        // plainly exists.
         let w_builtin = self.get_builtin();
         if use_cache {
             let cache_hit: Option<PyObjectRef> = unsafe {

--- a/pyre/pyre-interpreter/src/pytraceback.rs
+++ b/pyre/pyre-interpreter/src/pytraceback.rs
@@ -272,14 +272,26 @@ pub unsafe fn w_pytraceback_get_w_code(obj: PyObjectRef) -> PyObjectRef {
 /// ```
 ///
 /// Pyre stamps the real line number at `record_application_traceback`
-/// time (the frame is guaranteed live there), so this reader never
-/// has to walk back through `self.frame.pycode`.  That walk is what
-/// upstream does, and it is safe there because the frame edge is
-/// unconditional; pyre's is not forwarded for a frame the GC does not
-/// own, which may already have been freed by the time `tb_lineno` is
-/// read.  The `LINENO_NOT_COMPUTED` sentinel still surfaces as `-1`
-/// for the edge case where the traceback was constructed without a
-/// frame (e.g. unit tests).
+/// time instead of resolving it here.  The upstream walk goes through
+/// `self.frame.pycode`, which this reader cannot do: `frame` is only
+/// forwarded for a frame the GC owns, so it may already have been
+/// freed by the time `tb_lineno` is read.  The `w_code` snapshot is
+/// forwarded unconditionally and IS that `pycode`, so `offset2lineno`
+/// off `w_code` and `lasti` would be safe to run lazily.  What still
+/// depends on the eager stamp is the JIT fold
+/// `walker_specialize_traceback_walk_field` (pyre-jit-trace): it reads
+/// this slot directly and declines on the sentinel, so under a lazy
+/// `get_lineno` every fresh node would decline on its first read.
+///
+/// Two `tb_lineno` answers diverge from `get_lineno` because of it.
+/// Upstream re-resolves from the CURRENT `lasti` whenever the slot
+/// still holds the sentinel, so `tb.tb_lasti = N; tb.tb_lineno` reads
+/// the new offset there and the originally-stamped line here; and a
+/// sentinel written back through `TracebackType(..., -sys.maxsize-1)`
+/// or the `tb_lineno` setter is re-resolved there and answered `-1`
+/// here.  Porting back to lazy needs the fold to call a resolver
+/// rather than decline.  The sentinel also still surfaces as `-1` for
+/// a traceback constructed without a frame (e.g. unit tests).
 ///
 /// # Safety
 /// `tb` must point to a valid `PyTraceback`.
@@ -385,12 +397,14 @@ pub unsafe fn record_application_traceback(
         crate::eval::set_in_flight_exception(w_exc_object);
         // `pytraceback.py:36 self.lineno = offset2lineno(self.frame
         // .pycode, self.lasti)` — pyre resolves the line number
-        // eagerly here rather than lazily in `get_lineno`, because a
-        // frame the GC does not own is not kept alive by the traceback
-        // and may already be freed by the time `tb_lineno` is read.
-        // Stamping at construction guarantees the value survives the
-        // frame's lifetime.  `frame.pycode` is the `PyCode` wrapper;
-        // the inner `CodeObject` is extracted via `pyframe_get_pycode`.
+        // eagerly here rather than lazily in `get_lineno`; stamping at
+        // construction guarantees the value survives the frame's
+        // lifetime, since a frame the GC does not own is not kept alive
+        // by the traceback.  See `w_pytraceback_get_lineno` for what
+        // still depends on the eager stamp and which two `tb_lineno`
+        // answers it diverges on.  `frame.pycode` is the `PyCode`
+        // wrapper; the inner `CodeObject` is extracted via
+        // `pyframe_get_pycode`.
         //
         // The `PyCode` PyObjectRef is also captured into the `w_code`
         // slot so the traceback's source-path / function name metadata

--- a/pyre/pyre-interpreter/src/runtime_ops.rs
+++ b/pyre/pyre-interpreter/src/runtime_ops.rs
@@ -128,20 +128,19 @@ pub extern "C" fn jit_load_name_from_namespace(
             return v as i64;
         }
     }
-    // Globals miss: `pyopcode.py:958-967 _load_global` falls back to
-    // `self.get_builtin().getdictvalue(space, varname)`.  The frame's
-    // picked builtin (`pyframe.py:115 self.builtin =
-    // space.builtin.pick_builtin(w_globals)`) is the authoritative
-    // builtin reference; mid-execution `__builtins__` rebind would
-    // change the picked module without touching
-    // `namespace["__builtins__"]`'s raw entry, so the extern must
-    // route through `frame.w_builtin` rather than re-reading the dict
-    // slot.
+    // Globals miss: `_load_global` (pyopcode.py) falls back to
+    // `self.get_builtin().getdictvalue(space, varname)`.  Go through the
+    // accessor, never the raw slot: the constructor (pyframe.py) assigns
+    // `self.builtin` only under `honor__builtins__`, so with the option off
+    // (`baseobjspace::HONOR_BUILTINS`) the field stays unset and
+    // `get_builtin` answers `space.builtin` instead.  A
+    // frame the JIT materialized from a virtual never wrote the slot, so a
+    // raw read there resolves no builtin at all and every builtin name
+    // raises NameError.  The accessor still prefers the picked module when a
+    // frame does carry one, so a mid-execution `__builtins__` rebind is
+    // honoured exactly as before.
     let w_builtin = if frame_ptr != 0 {
-        unsafe {
-            let p = frame_ptr as *const u8;
-            *(p.add(crate::pyframe::PYFRAME_W_BUILTIN_OFFSET) as *const PyObjectRef)
-        }
+        unsafe { (*(frame_ptr as *const crate::pyframe::PyFrame)).get_builtin() }
     } else {
         std::ptr::null_mut()
     };

--- a/pyre/pyre-jit-trace/src/call_spec.rs
+++ b/pyre/pyre-jit-trace/src/call_spec.rs
@@ -135,6 +135,13 @@ pub const PYFRAME_CALL_EFFECTS: &[CallEffectSpec] = &[
     },
     CallEffectSpec {
         target: CallTargetSpec::Method {
+            name: "delete_global",
+            receiver_root: PYFRAME_CALL_OWNER_ROOT,
+        },
+        effect: CallEffectKind::Residual,
+    },
+    CallEffectSpec {
+        target: CallTargetSpec::Method {
             name: "load_name",
             receiver_root: PYFRAME_CALL_OWNER_ROOT,
         },
@@ -171,6 +178,13 @@ pub const PYFRAME_CALL_EFFECTS: &[CallEffectSpec] = &[
     CallEffectSpec {
         target: CallTargetSpec::Method {
             name: "store_name_value",
+            receiver_root: PYFRAME_CALL_OWNER_ROOT,
+        },
+        effect: CallEffectKind::Residual,
+    },
+    CallEffectSpec {
+        target: CallTargetSpec::Method {
+            name: "delete_name",
             receiver_root: PYFRAME_CALL_OWNER_ROOT,
         },
         effect: CallEffectKind::Residual,

--- a/pyre/pyre-jit-trace/src/helpers.rs
+++ b/pyre/pyre-jit-trace/src/helpers.rs
@@ -1209,9 +1209,12 @@ pub fn emit_box_float_inline(
 /// `_opimpl_inline_call*` / `perform_call`+`setup_call` create a fresh frame
 /// per inlined call (`pyjitpl.py:2445-2476,1862-1874`); the box stays virtual
 /// on the hot path (the optimizer folds `NewWithVtable`+`SetfieldGc`) and is
-/// materialized lazily only on guard failure.  Field-complete so a forced
-/// materialization (`materialize_virtual_from_rd`) never dereferences an unset
-/// field.
+/// materialized lazily only on guard failure.  Carries every field the frame
+/// constructor assigns, so a forced materialization
+/// (`materialize_virtual_from_rd`) never dereferences a field the interpreter
+/// would have written; the class-level defaults listed at the end of the body
+/// stay at the allocation's zero-fill, exactly as they do in a frame the
+/// interpreter builds.
 pub fn emit_new_pyframe_inline_with_params(
     ctx: &mut TraceCtx,
     param_boxes: &[OpRef],
@@ -1327,6 +1330,12 @@ pub fn emit_new_pyframe_inline_with_params(
     // setfield for them; the freshly allocated payload is already zeroed
     // (zero_gc_pointers_inside, incminimark.py:960), so the fields read back
     // as PY_NULL. No explicit store here.
+    //
+    // `w_builtin` joins them: the frame constructor (pyframe.py) assigns
+    // `self.builtin` only under `honor__builtins__`, which
+    // `baseobjspace::HONOR_BUILTINS` leaves off, so the constructor writes
+    // nothing and every reader goes through `get_builtin`, which answers
+    // `space.builtin` for an unset slot.
 
     new_frame
 }
@@ -1437,6 +1446,12 @@ pub fn emit_new_pyframe_inline_self_recursive(
     // setfield for them; the freshly allocated payload is already zeroed
     // (zero_gc_pointers_inside, incminimark.py:960), so the fields read back
     // as PY_NULL. No explicit store here.
+    //
+    // `w_builtin` joins them: the frame constructor (pyframe.py) assigns
+    // `self.builtin` only under `honor__builtins__`, which
+    // `baseobjspace::HONOR_BUILTINS` leaves off, so the constructor writes
+    // nothing and every reader goes through `get_builtin`, which answers
+    // `space.builtin` for an unset slot.
 
     new_frame
 }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
@@ -1114,6 +1114,12 @@ thread_local! {
     /// Callee code keys whose deferred body reached a CALL residual the lever
     /// could not inline.  The gate declines them up front from then on, so the
     /// backstop abort costs one attempt per callee instead of storming.
+    ///
+    /// Per-thread for the reason [`FBW_HAZARDOUS_INLINE_DENY`] spells out, and
+    /// it is only a memo: what actually keeps a deferred body honest is the
+    /// live abort in [`fbw_abort_nested_unjournaled_residual`], armed by
+    /// [`FBW_FORITER_DEFERRED_INLINE`] above.  A thread that has not yet
+    /// recorded a denial pays one extra abort per callee, never a wrong answer.
     static FBW_FORITER_DEFERRED_DENY: std::cell::RefCell<std::collections::HashSet<usize>> =
         std::cell::RefCell::new(std::collections::HashSet::new());
     /// Code keys of the callees [`fbw_inline_callee_hazardous`] named when the

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -1975,8 +1975,10 @@ fn walker_specialize_traceback_walk_field<Sym: WalkSym>(
             unsafe { pyre_interpreter::pytraceback::w_pytraceback_get_lineno_raw(concrete_obj) };
         // `get_lineno` answers the sentinel with `-1`, so the slot value is the
         // getter's value only once it is pinned against the sentinel.  A node
-        // that already carries it — built from a frame with no `pycode` — has
-        // nothing to pin, so decline before recording anything.
+        // that already carries it — built from a frame with no `pycode`, or
+        // handed the sentinel through `TracebackType(..., -sys.maxsize-1)` or
+        // the `tb_lineno` setter — has nothing to pin, so decline before
+        // recording anything.
         if live == pyre_interpreter::pytraceback::LINENO_NOT_COMPUTED {
             return Ok(None);
         }

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -5852,6 +5852,49 @@ pub extern "C" fn bh_store_global_fn(frame_ptr: i64, w_name: i64, value: i64) ->
     }
 }
 
+/// DELETE_NAME residual using the frame receiver and interned-name ABI.
+/// pyopcode.py DELETE_NAME deletes from `w_locals` and raises `NameError`
+/// when the binding is absent.
+pub extern "C" fn bh_delete_name_fn(frame_ptr: i64, w_name: i64) -> i64 {
+    use pyre_interpreter::pyopcode::OpcodeStepExecutor;
+    assert!(
+        frame_ptr != 0,
+        "bh_delete_name_fn requires a non-null PyFrame; every DELETE_NAME emit \
+         site must thread portal_frame_reg as the leading ref operand"
+    );
+    let frame = unsafe { &mut *(frame_ptr as *mut PyFrame) };
+    let name =
+        unsafe { pyre_object::unicodeobject::w_str_get_value(w_name as pyre_object::PyObjectRef) };
+    match frame.delete_name(name) {
+        Ok(()) => 1,
+        Err(mut err) => {
+            publish_residual_call_exception(err.to_exc_object() as i64);
+            0
+        }
+    }
+}
+
+/// DELETE_GLOBAL residual using the frame receiver and interned-name ABI.
+/// pyopcode.py DELETE_GLOBAL deletes directly from `w_globals`.
+pub extern "C" fn bh_delete_global_fn(frame_ptr: i64, w_name: i64) -> i64 {
+    use pyre_interpreter::pyopcode::OpcodeStepExecutor;
+    assert!(
+        frame_ptr != 0,
+        "bh_delete_global_fn requires a non-null PyFrame; every DELETE_GLOBAL emit \
+         site must thread portal_frame_reg as the leading ref operand"
+    );
+    let frame = unsafe { &mut *(frame_ptr as *mut PyFrame) };
+    let name =
+        unsafe { pyre_object::unicodeobject::w_str_get_value(w_name as pyre_object::PyObjectRef) };
+    match frame.delete_global(name) {
+        Ok(()) => 1,
+        Err(mut err) => {
+            publish_residual_call_exception(err.to_exc_object() as i64);
+            0
+        }
+    }
+}
+
 /// Load a constant from the code object.
 /// jtransform.py parity: code comes from getfield_vable_r(frame, pycode).
 pub extern "C" fn bh_load_const_fn(w_code_ptr: i64, consti: i64) -> i64 {

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -2752,6 +2752,48 @@ fn emit_frontend_store_global(
     );
 }
 
+fn emit_frontend_delete_name(
+    _graph: &mut super::flow::FunctionGraph,
+    block: &super::flow::BlockRef,
+    frame: super::flow::FlowValue,
+    name: super::flow::FlowValue,
+    offset: i64,
+) {
+    // pyopcode.py DELETE_NAME -> `space.delitem(w_locals, w_varname)`, with a
+    // KeyError surfacing as NameError.  Frame-receiver call shape like
+    // `emit_frontend_store_name`, minus the value operand; lowers to
+    // `bh_delete_name_fn(frame, w_name)`
+    // (`flatten::lower_delete_name_hlop_to_insn`).
+    record_graph_op(
+        block,
+        "delete_name",
+        vec![frame.into(), name.into()],
+        None,
+        offset,
+    );
+}
+
+fn emit_frontend_delete_global(
+    _graph: &mut super::flow::FunctionGraph,
+    block: &super::flow::BlockRef,
+    frame: super::flow::FlowValue,
+    name: super::flow::FlowValue,
+    offset: i64,
+) {
+    // pyopcode.py DELETE_GLOBAL -> `space.delitem(w_globals, w_varname)`,
+    // bypassing `w_locals`.  Same frame-receiver shape as
+    // `emit_frontend_delete_name`; lowers to
+    // `bh_delete_global_fn(frame, w_name)`
+    // (`flatten::lower_delete_global_hlop_to_insn`).
+    record_graph_op(
+        block,
+        "delete_global",
+        vec![frame.into(), name.into()],
+        None,
+        offset,
+    );
+}
+
 fn emit_frontend_simple_call(
     graph: &mut super::flow::FunctionGraph,
     block: &super::flow::BlockRef,
@@ -3402,6 +3444,8 @@ struct FnPtrIndices {
     load_name_fn: HelperHandle,
     store_name_fn: HelperHandle,
     store_global_fn: HelperHandle,
+    delete_name_fn: HelperHandle,
+    delete_global_fn: HelperHandle,
     newtuple_from_array_fn: HelperHandle,
     newlist_from_array_fn: HelperHandle,
     unpack_sequence_fn: HelperHandle,
@@ -3717,6 +3761,16 @@ fn register_helper_fn_pointers(
     let store_global_fn = bind(
         assembler,
         cpu.store_global_fn as *const (),
+        CallFlavor::Plain,
+    );
+    let delete_name_fn = bind(
+        assembler,
+        cpu.delete_name_fn as *const (),
+        CallFlavor::Plain,
+    );
+    let delete_global_fn = bind(
+        assembler,
+        cpu.delete_global_fn as *const (),
         CallFlavor::Plain,
     );
     // `bh_store_attr_fn` calls `baseobjspace::setattr_str`, which can run
@@ -4166,6 +4220,8 @@ fn register_helper_fn_pointers(
         load_name_fn,
         store_name_fn,
         store_global_fn,
+        delete_name_fn,
+        delete_global_fn,
         newtuple_from_array_fn,
         newlist_from_array_fn,
         unpack_sequence_fn,
@@ -5457,6 +5513,16 @@ impl CodeWriter {
                     idx: store_global_fn_idx,
                     flavor: _store_global_fn_flavor,
                 },
+            delete_name_fn:
+                HelperHandle {
+                    idx: delete_name_fn_idx,
+                    flavor: _delete_name_fn_flavor,
+                },
+            delete_global_fn:
+                HelperHandle {
+                    idx: delete_global_fn_idx,
+                    flavor: _delete_global_fn_flavor,
+                },
             newtuple_from_array_fn:
                 HelperHandle {
                     idx: newtuple_from_array_fn_idx,
@@ -5934,6 +6000,8 @@ impl CodeWriter {
                 load_name_fn_idx,
                 store_name_fn_idx,
                 store_global_fn_idx,
+                delete_name_fn_idx,
+                delete_global_fn_idx,
                 newtuple_from_array_fn_idx,
                 newlist_from_array_fn_idx,
                 // `[u16; 15]` indexed by nargs (0..=14).  `call_fn_idx`
@@ -9767,6 +9835,45 @@ impl CodeWriter {
                                 py_pc as i64,
                             );
                         }
+                        Instruction::DeleteName { namei } => {
+                            // pyopcode.py DELETE_NAME — deletes the binding
+                            // from `w_locals` via the `delete_name` HLOp →
+                            // `bh_delete_name_fn(frame, w_name)` residual call,
+                            // which the full-body walker traces.  Touches no
+                            // operand-stack slot, so unlike the StoreName arm
+                            // it pops nothing.  A module-level `except X as e:`
+                            // compiles its implicit cleanup to this opcode, so
+                            // leaving it unlowered blacks out the whole
+                            // enclosing module loop.
+                            let name_idx = namei.get(op_arg) as usize;
+                            let name =
+                                super::flow::Constant::string(code.names[name_idx].as_str());
+                            emit_frontend_delete_name(
+                                &mut graph,
+                                &current_block.block(),
+                                frame_var.into(),
+                                name.into(),
+                                py_pc as i64,
+                            );
+                        }
+                        Instruction::DeleteGlobal { namei } => {
+                            // pyopcode.py DELETE_GLOBAL — deletes directly from
+                            // `w_globals` (bypassing `w_locals`) via the
+                            // `delete_global` HLOp →
+                            // `bh_delete_global_fn(frame, w_name)` residual
+                            // call.  Same void 2-Ref, zero-stack-effect shape
+                            // as the DeleteName arm.
+                            let name_idx = namei.get(op_arg) as usize;
+                            let name =
+                                super::flow::Constant::string(code.names[name_idx].as_str());
+                            emit_frontend_delete_global(
+                                &mut graph,
+                                &current_block.block(),
+                                frame_var.into(),
+                                name.into(),
+                                py_pc as i64,
+                            );
+                        }
                         Instruction::MakeFunction { .. } => {
                             // Pops the code object (TOS), pushes the built
                             // function. Net: 0.  `make_function_value(globals,
@@ -12302,9 +12409,7 @@ impl CodeWriter {
                         }
 
                         // Instructions that don't touch the operand stack (locals/cells only).
-                        Instruction::DeleteGlobal { .. }
-                        | Instruction::DeleteName { .. }
-                        | Instruction::SetupAnnotations => {
+                        Instruction::SetupAnnotations => {
                             emit_abort_permanent!(py_pc);
                         }
 

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -9846,8 +9846,7 @@ impl CodeWriter {
                             // leaving it unlowered blacks out the whole
                             // enclosing module loop.
                             let name_idx = namei.get(op_arg) as usize;
-                            let name =
-                                super::flow::Constant::string(code.names[name_idx].as_str());
+                            let name = super::flow::Constant::string(code.names[name_idx].as_str());
                             emit_frontend_delete_name(
                                 &mut graph,
                                 &current_block.block(),
@@ -9864,8 +9863,7 @@ impl CodeWriter {
                             // call.  Same void 2-Ref, zero-stack-effect shape
                             // as the DeleteName arm.
                             let name_idx = namei.get(op_arg) as usize;
-                            let name =
-                                super::flow::Constant::string(code.names[name_idx].as_str());
+                            let name = super::flow::Constant::string(code.names[name_idx].as_str());
                             emit_frontend_delete_global(
                                 &mut graph,
                                 &current_block.block(),

--- a/pyre/pyre-jit/src/jit/cpu.rs
+++ b/pyre/pyre-jit/src/jit/cpu.rs
@@ -319,6 +319,14 @@ pub struct Cpu {
     /// lowering of `STORE_GLOBAL` (`pyopcode.py:567`); writes directly
     /// into `w_globals`, bypassing `w_locals`.
     pub store_global_fn: extern "C" fn(i64, i64, i64) -> i64,
+    /// `bh_delete_name_fn` — `(frame: Ref, w_name: Ref) → Void`, the
+    /// lowering of `DELETE_NAME`; deletes the binding from `w_locals` and
+    /// raises `NameError` when it is absent.
+    pub delete_name_fn: extern "C" fn(i64, i64) -> i64,
+    /// `bh_delete_global_fn` — `(frame: Ref, w_name: Ref) → Void`, the
+    /// lowering of `DELETE_GLOBAL`; deletes directly from `w_globals`,
+    /// bypassing `w_locals`.
+    pub delete_global_fn: extern "C" fn(i64, i64) -> i64,
     /// `newtuple(list_w)` (`objspace.py:332`) — (ref array) → new tuple.
     /// The array is the forced `popvalues` list; length travels inside
     /// the array, so any arity fits.
@@ -511,6 +519,8 @@ impl Cpu {
             load_name_fn: crate::call_jit::bh_load_name_fn,
             store_name_fn: crate::call_jit::bh_store_name_fn,
             store_global_fn: crate::call_jit::bh_store_global_fn,
+            delete_name_fn: crate::call_jit::bh_delete_name_fn,
+            delete_global_fn: crate::call_jit::bh_delete_global_fn,
             newtuple_from_array_fn: crate::call_jit::bh_newtuple_from_array,
             build_map_from_array_fn: crate::call_jit::bh_build_map_from_array,
             build_set_from_array_fn: crate::call_jit::bh_build_set_from_array,

--- a/pyre/pyre-jit/src/jit/flatten.rs
+++ b/pyre/pyre-jit/src/jit/flatten.rs
@@ -2571,6 +2571,8 @@ pub fn graph_op_can_raise(op: &super::flow::SpaceOperation) -> bool {
             | "load_name"
             | "store_name"
             | "store_global"
+            | "delete_name"
+            | "delete_global"
             | "simple_call"
             | "getattr"
             | "load_special"
@@ -3246,6 +3248,12 @@ pub struct LoweringContext {
     /// w_name, value]`, void result) via
     /// [`lower_store_global_hlop_to_insn`].
     pub store_global_fn_idx: u16,
+    /// `delete_name_fn` descrs-pool index. DELETE_NAME lowers to a void
+    /// two-Ref residual with `[frame, w_name]` operands.
+    pub delete_name_fn_idx: u16,
+    /// `delete_global_fn` descrs-pool index. DELETE_GLOBAL lowers to a void
+    /// two-Ref residual with `[frame, w_name]` operands.
+    pub delete_global_fn_idx: u16,
     /// `bind(assembler, cpu.newtuple_from_array_fn as *const (),
     /// CallFlavor::Plain)` descrs-pool index for the production
     /// source.  BUILD_TUPLE records the rtyped `pyopcode.py:995-998`
@@ -4290,6 +4298,54 @@ where
     ))
 }
 
+/// Lower pyopcode.py DELETE_NAME to a void two-Ref residual call.
+pub fn lower_delete_name_hlop_to_insn<F, LC>(
+    op: &super::flow::SpaceOperation,
+    ctx: &LoweringContext,
+    get_register: &mut F,
+    lower_constant: &mut LC,
+) -> Option<Insn>
+where
+    F: FnMut(super::flow::Variable) -> Register,
+    LC: FnMut(&Constant) -> Operand,
+{
+    if op.opname != "delete_name" || op.args.len() != 2 || op.result.is_some() {
+        return None;
+    }
+    let frame_operand = flatten_arg_with_lowering(&op.args[0], get_register, lower_constant);
+    let name_operand = flatten_arg_with_lowering(&op.args[1], get_register, lower_constant);
+    Some(build_residual_call_r_v_insn_from_operands(
+        ctx.delete_name_fn_idx,
+        vec![frame_operand, name_operand],
+        CallFlavor::Plain,
+        majit_ir::PyreHelperKind::None,
+    ))
+}
+
+/// Lower pyopcode.py DELETE_GLOBAL to a void two-Ref residual call.
+pub fn lower_delete_global_hlop_to_insn<F, LC>(
+    op: &super::flow::SpaceOperation,
+    ctx: &LoweringContext,
+    get_register: &mut F,
+    lower_constant: &mut LC,
+) -> Option<Insn>
+where
+    F: FnMut(super::flow::Variable) -> Register,
+    LC: FnMut(&Constant) -> Operand,
+{
+    if op.opname != "delete_global" || op.args.len() != 2 || op.result.is_some() {
+        return None;
+    }
+    let frame_operand = flatten_arg_with_lowering(&op.args[0], get_register, lower_constant);
+    let name_operand = flatten_arg_with_lowering(&op.args[1], get_register, lower_constant);
+    Some(build_residual_call_r_v_insn_from_operands(
+        ctx.delete_global_fn_idx,
+        vec![frame_operand, name_operand],
+        CallFlavor::Plain,
+        majit_ir::PyreHelperKind::None,
+    ))
+}
+
 /// Construct the CALL-family `residual_call_r_r` Insn from raw
 /// register indices.  Production codewriter callsite replaces the prior `emit_residual_call(
 /// call_fn_N_idx, ...)` SSARepr emit at codewriter.rs:5747-5754
@@ -5181,6 +5237,12 @@ where
         return Some(insn);
     }
     if let Some(insn) = lower_store_global_hlop_to_insn(op, ctx, get_register, lower_constant) {
+        return Some(insn);
+    }
+    if let Some(insn) = lower_delete_name_hlop_to_insn(op, ctx, get_register, lower_constant) {
+        return Some(insn);
+    }
+    if let Some(insn) = lower_delete_global_hlop_to_insn(op, ctx, get_register, lower_constant) {
         return Some(insn);
     }
     if let Some(insn) = lower_tuple_build_hlop_to_insn(op, ctx, get_register, lower_constant) {

--- a/pyre/pyre-object/src/celldict.rs
+++ b/pyre/pyre-object/src/celldict.rs
@@ -631,14 +631,21 @@ pub fn module_dict_strategy_gc_type_id() -> u32 {
 /// traced, so the common no-watcher mutation still makes no call.
 #[majit_macros::dont_look_inside]
 pub fn sweep_version_watchers(watchers: &mut Vec<std::sync::Weak<std::sync::atomic::AtomicBool>>) {
-    watchers.retain(|w| {
+    // `QuasiImmut.invalidate` takes the list and empties it BEFORE walking it
+    // (`wrefs = self.looptokens_wrefs; self.looptokens_wrefs = []`), so a loop
+    // is invalidated exactly once and then drops out.  Keeping the live
+    // watchers instead would be doubly wrong: the flag is already `true`, so
+    // re-storing it does nothing, and the list would only ever grow — one
+    // entry per compiled loop that folded a module-global.  A module-level
+    // `except X as e:` runs `del e` every iteration, and `delitem` calls
+    // `mutated()`, so retaining would make each iteration walk every loop ever
+    // compiled in the module: O(compiled loops) per store, and the JIT
+    // compiling more loops would make the interpreter slower.
+    for w in std::mem::take(watchers) {
         if let Some(flag) = w.upgrade() {
             flag.store(true, std::sync::atomic::Ordering::Release);
-            true
-        } else {
-            false
         }
-    });
+    }
 }
 
 impl Default for ModuleDictStrategy {
@@ -856,9 +863,13 @@ impl ModuleDictStrategy {
     ///         cache.cell = w_value
     /// ```
     ///
-    /// Cell-indirection (`write_cell`) is stubbed to identity until
-    /// the `MutableCell` family ports.  Without cells, every write
-    /// reaches `storage[key] = w_value` and triggers `mutated()`.
+    /// `write_cell` absorbs a rewrite in place whenever the slot already
+    /// holds an `ObjectMutableCell` (or an `IntMutableCell` and the value is
+    /// a plain int), returning `None` so the version is left alone.  Only a
+    /// structural change — installing a key that had no cell, or replacing
+    /// the cell kind — reaches `mutated()`.  That is what keeps a hot
+    /// module-level counter increment from invalidating every loop that
+    /// folded a module-global.
     pub fn _setitem_str_cell_known(
         &mut self,
         cell: Option<PyObjectRef>,


### PR DESCRIPTION
Rebased onto `origin/main`. The previous contents of this PR (the lost
conditional store in an inlined callee + the method-form inline widening)
landed separately as #942, so this PR now carries a different set of commits;
title and description updated to match.

Seven commits, mostly exception-path JIT trace coverage plus a few
interpreter/GC correctness fixes.

## Trace coverage

**`jit: lower DELETE_NAME and DELETE_GLOBAL to residual calls`**

Both opcodes were emitted as a static `abort_permanent`, which discards the
enclosing loop trace permanently. A module-level `except X as e:` compiles its
implicit cleanup to `e = None; del e`, and at module scope `del e` is
DELETE_NAME — so any module loop containing an except-as clause could never be
traced. Function scope uses DELETE_FAST, which was already lowered, which is
why only module-level benches blacked out.

Upstream has no unsupported-opcode concept here: `pyopcode.py` DELETE_NAME is
`space.delitem(w_locals, w_varname)` and DELETE_GLOBAL the same against
`w_globals`. Adds the `delete_name` / `delete_global` HLOps in the
frame-receiver call shape of `store_name` minus the value operand (two Ref
operands, void result, zero stack effect), registered in `graph_op_can_raise`
since DELETE_NAME raises NameError on an absent binding. `SetupAnnotations`
stays on `abort_permanent`.

| bench | loops_aborted | bridges_compiled |
|---|---|---|
| `exception_reraise_tb_depth_hot` | 30 → 0 | 0 → 9 |
| `exception_reraise_tb_depth_jitstress` | 30 → 0 | 0 → 1 |
| `exception_reentry_guard_finally_residual` | 5 → 0 | 9 → 11 |

`exception_reraise_tb_depth_hot`: 692ms → 267ms CPU, 6.5x → 2.5x of pypy.

## Hot-path cost

**`celldict: drop version watchers once they are invalidated`**

`sweep_version_watchers` used `Vec::retain` and kept every watcher it could
still upgrade. `QuasiImmut.invalidate` (quasiimmut.py) instead takes the list
and empties it. Retaining is redundant (the flag is already true) and
unbounded (one entry per compiled loop that folded a module-global), so a
module-level `del e` walked every loop ever compiled in that module. Safe to
drop because registration is per compiled artifact and a flipped flag is
permanently invalid.

Largest single non-interpreter profile leaf on `exception_metadata_hot` at
N=250000 (629 samples, ahead of `eval_loop_jit`), absent afterwards;
13244ms → 12019ms CPU. `loops_compiled` is 309 either way — this removed the
walk, not the churn.

**`dynasm: take getenv and String building off the entry path`**

`execute_token` read `PYRE_DYNASM_EXEC_DIAG` once and `PYRE_GC_FREELIST_DIAG`
twice per compiled-trace entry, each an uncached `std::env::var_os` taking the
global env lock, and built `format!("before/after trace {id}")` unconditionally
so an off diagnostic still cost two heap allocations per entry. Cached in
`LazyLock` bools next to `majit_log_enabled`;
`debug_validate_oldgen_freeblocks` now takes `std::fmt::Arguments`.

## Correctness

- **`interp: read the frame builtin through get_builtin in LOAD_GLOBAL`** — the
  raw `w_builtin` read made a JIT-materialized frame raise `NameError` for
  every builtin.
- **`builtins: read the pinned iterator back from its slot`** — `any`/`all`/
  `collect_iterator` used the raw local straight after `pin_root`.
- **`interp: decline only a metatype data descriptor in the classmethod fold`**
- **`comments: name the real blockers behind three declined ports`** —
  comment-only.

## Verification

- Release build clean at the rebased tip (`b33f4e1b`).
- The per-commit gate results quoted above (`check.py` dynasm 354/354 /
  cranelift 354/354, `cargo test`) were run **before** this rebase, against the
  previous base. Ten `main` commits have landed underneath since, so CI on this
  PR is the authority for the rebased tree.
- `jit_reg_const_pool_256_slot_decline` was a gate-boundary flake during the
  celldict run (passes 3/3 solo; 984ms vs 988ms across the two binaries), not a
  regression from these commits.

## Not included

The exception-path gap is not closed. Measuring all 41 exc benches with the
startup floor subtracted shows 16 of them are too short to compare against
pypy at their stock N at all, and the real remaining cost concentrates in a
traceback-node cluster (8 of the top 16), not in the benches previously
targeted. Three follow-ups are filed rather than attempted here: the
cross-frame exception bridge, MAKE_FUNCTION virtualization (a `def` in a hot
loop can never inline today), and the traceback-node path.

A `sys.exc_info()` call fold was implemented and reverted — it produced
wrong-code. The generic `CALL_MAY_FORCE` residual turns out to be what flushes
pending ExecutionContext stores before the callee reads them, so folding it to
a plain call makes the read observe pre-handler state. Recorded so it is not
retried without first giving that state a descr identity the optimizer can
order against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
