### PR TITLE
types: complete the UnionType slot surface; functools function exports; check.py startup median

### DIFF
--- a/pyre/check.py
+++ b/pyre/check.py
@@ -100,7 +100,15 @@ WIN_TIMER_QUANTUM_S = 1.0 / 64
 # not inflate the ratio/gate of a short bench. Never hardcode the startup.
 # Floored so a bench at/below its own startup (or noise) cannot drive a time
 # to <= 0 and blow up a ratio.
-STARTUP_SAMPLES = 3
+#
+# The startup is a divisor for every short bench: the baseline's exec time is
+# `bench - startup`, so a startup sample that lands high collapses that
+# denominator and inflates every ratio computed against it.  A CI runner
+# measured pypy startup at 0.031s where the same job on the same platform had
+# measured 0.013s, and three unrelated benches failed their gates in that run
+# while their pyre exec times had gone *down*.  Five samples make the median
+# robust to two outliers instead of one.
+STARTUP_SAMPLES = 5
 EXEC_TIME_FLOOR_S = WIN_TIMER_QUANTUM_S if sys.platform == "win32" else 0.005
 # A single slow sample is retried before failing a performance gate. Windows
 # needs more samples because its process CPU accounting is scheduler-tick

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -6898,10 +6898,24 @@ assert GA.__lt__(list[int], list[str]) is NotImplemented
     fn test_union_type_exposes_cpython_314_richcompare_surface() {
         let source = r#"
 UT = type(int | str)
-required = {'__getattribute__', '__ne__', '__lt__', '__le__', '__gt__', '__ge__'}
+required = {
+    '__getattribute__', '__ne__', '__lt__', '__le__', '__gt__', '__ge__',
+    '__name__', '__qualname__', '__origin__', '__iter__', '__doc__',
+}
 assert required <= UT.__dict__.keys()
 u = int | str
 assert UT.__getattribute__(u, '__args__') == (int, str)
+assert u.__name__ == 'Union'
+assert u.__qualname__ == 'Union'
+assert u.__origin__ is UT
+assert u.__module__ == 'typing'
+assert UT.__dict__['__iter__'] is None
+try:
+    iter(u)
+except TypeError:
+    pass
+else:
+    raise AssertionError('UnionType must disable __getitem__ iteration fallback')
 assert UT.__ne__(u, int | str) is False
 assert UT.__ne__(u, int | bytes) is True
 assert UT.__ne__(u, int) is NotImplemented

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -6894,6 +6894,26 @@ assert GA.__lt__(list[int], list[str]) is NotImplemented
         result.expect("GenericAlias explicit slot-method surface failed");
     }
 
+    #[test]
+    fn test_union_type_exposes_cpython_314_richcompare_surface() {
+        let source = r#"
+UT = type(int | str)
+required = {'__getattribute__', '__ne__', '__lt__', '__le__', '__gt__', '__ge__'}
+assert required <= UT.__dict__.keys()
+u = int | str
+assert UT.__getattribute__(u, '__args__') == (int, str)
+assert UT.__ne__(u, int | str) is False
+assert UT.__ne__(u, int | bytes) is True
+assert UT.__ne__(u, int) is NotImplemented
+assert UT.__lt__(u, int | bytes) is NotImplemented
+assert UT.__le__(u, int | bytes) is NotImplemented
+assert UT.__gt__(u, int | bytes) is NotImplemented
+assert UT.__ge__(u, int | bytes) is NotImplemented
+"#;
+        let (result, _frame) = run_exec_frame(source);
+        result.expect("UnionType explicit rich-compare surface failed");
+    }
+
     /// `pypy/interpreter/typedef.py BuiltinFunction.typedef.acceptable_as_base_class
     /// = False` plus CPython 3.14's null `tp_new` enforce that `type(len)()`
     /// raises `TypeError("cannot create 'builtin_function_or_method'

--- a/pyre/pyre-interpreter/src/module/_functools/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_functools/mod.rs
@@ -31,14 +31,6 @@ def cmp_to_key(mycmp):
         __hash__ = None
     return K
 
-# `_functools.cmp_to_key` is an interp-level builtin in CPython.  Unlike an
-# app-level function, it therefore does not acquire an instance when a caller
-# stores it on a class (the CPython functools tests do exactly that).  A
-# callable staticmethod preserves the app-level implementation while giving
-# the exported object the same non-binding descriptor behavior.
-cmp_to_key = staticmethod(cmp_to_key)
-
-
 _initial_missing = object()
 
 
@@ -59,10 +51,6 @@ def reduce(function, sequence, initial=_initial_missing):
     for element in it:
         accum = function(accum, element)
     return accum
-
-
-# Same descriptor-neutral accelerator surface as cmp_to_key above.
-reduce = staticmethod(reduce)
 
 
 # PyPy: lib_pypy/_functools.py `partial`, extended with the Placeholder

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -8851,6 +8851,50 @@ fn union_mro_entries_method(args: &[PyObjectRef]) -> crate::PyResult {
     )))
 }
 
+/// `UnionType.__ne__` — the inverse of structural union equality, preserving
+/// `NotImplemented` for non-union operands.
+fn union_ne_method(args: &[PyObjectRef]) -> crate::PyResult {
+    let self_ = args.first().copied().unwrap_or(pyre_object::PY_NULL);
+    let other = args.get(1).copied().unwrap_or(pyre_object::PY_NULL);
+    if !unsafe { pyre_object::is_union(self_) } {
+        return Err(crate::PyError::type_error(
+            "descriptor '__ne__' requires a 'types.UnionType' object",
+        ));
+    }
+    if !unsafe { pyre_object::is_union(other) } {
+        return Ok(pyre_object::w_not_implemented());
+    }
+    Ok(pyre_object::w_bool_from(
+        !crate::_pypy_generic_alias::union_set_eq(self_, other)?,
+    ))
+}
+
+/// `UnionType` has no ordering relation.  Expose the four slots explicitly,
+/// as CPython does, while retaining the normal rich-compare fallback.
+fn union_ordering_method(args: &[PyObjectRef]) -> crate::PyResult {
+    let self_ = args.first().copied().unwrap_or(pyre_object::PY_NULL);
+    if !unsafe { pyre_object::is_union(self_) } {
+        return Err(crate::PyError::type_error(
+            "descriptor comparison requires a 'types.UnionType' object",
+        ));
+    }
+    Ok(pyre_object::w_not_implemented())
+}
+
+/// `UnionType.__getattribute__` — the explicit type-dict entry delegates to
+/// the ordinary object lookup, just like the C slot.
+fn union_getattribute_method(args: &[PyObjectRef]) -> crate::PyResult {
+    let self_ = args.first().copied().unwrap_or(pyre_object::PY_NULL);
+    if !unsafe { pyre_object::is_union(self_) } {
+        return Err(crate::PyError::type_error(
+            "descriptor '__getattribute__' requires a 'types.UnionType' object",
+        ));
+    }
+    let name =
+        crate::baseobjspace::text_w(args.get(1).copied().unwrap_or_else(pyre_object::w_none))?;
+    crate::baseobjspace::object_getattribute(self_, name)
+}
+
 fn init_union_type(ns: PyObjectRef) {
     // Python 3.14's shared `types.UnionType` / `typing.Union` runtime type
     // exposes `__module__` on union *instances* as well as on the type.  Keep
@@ -9005,6 +9049,34 @@ fn init_union_type(ns: PyObjectRef) {
             ns,
             "__mro_entries__",
             make_builtin_function_with_arity("__mro_entries__", union_mro_entries_method, 2),
+        )
+    };
+    unsafe {
+        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+            ns,
+            "__ne__",
+            make_builtin_function_with_arity("__ne__", union_ne_method, 2),
+        )
+    };
+    for (name, method) in [
+        ("__lt__", union_ordering_method as DunderFn),
+        ("__le__", union_ordering_method),
+        ("__gt__", union_ordering_method),
+        ("__ge__", union_ordering_method),
+    ] {
+        unsafe {
+            pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+                ns,
+                name,
+                make_builtin_function_with_arity(name, method, 2),
+            )
+        };
+    }
+    unsafe {
+        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+            ns,
+            "__getattribute__",
+            make_builtin_function_with_arity("__getattribute__", union_getattribute_method, 2),
         )
     };
 }

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -8896,6 +8896,58 @@ fn union_getattribute_method(args: &[PyObjectRef]) -> crate::PyResult {
 }
 
 fn init_union_type(ns: PyObjectRef) {
+    // `_pypy_generic_alias.py:241-246 UnionType` docstring, plus CPython
+    // 3.14's three read-only identity getsets on union instances.
+    unsafe {
+        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+            ns,
+            "__doc__",
+            pyre_object::w_str_new("Represent a union type\n\nE.g. for int | str"),
+        )
+    };
+    for (name, getter) in [
+        (
+            "__name__",
+            (|args: &[PyObjectRef]| {
+                let self_ = args.get(1).copied().unwrap_or(pyre_object::PY_NULL);
+                if !unsafe { pyre_object::is_union(self_) } {
+                    return Err(crate::PyError::type_error(
+                        "descriptor '__name__' requires a 'types.UnionType' object",
+                    ));
+                }
+                Ok(pyre_object::w_str_new("Union"))
+            }) as DunderFn,
+        ),
+        ("__qualname__", |args: &[PyObjectRef]| {
+            let self_ = args.get(1).copied().unwrap_or(pyre_object::PY_NULL);
+            if !unsafe { pyre_object::is_union(self_) } {
+                return Err(crate::PyError::type_error(
+                    "descriptor '__qualname__' requires a 'types.UnionType' object",
+                ));
+            }
+            Ok(pyre_object::w_str_new("Union"))
+        }),
+        ("__origin__", |args: &[PyObjectRef]| {
+            let self_ = args.get(1).copied().unwrap_or(pyre_object::PY_NULL);
+            if !unsafe { pyre_object::is_union(self_) } {
+                return Err(crate::PyError::type_error(
+                    "descriptor '__origin__' requires a 'types.UnionType' object",
+                ));
+            }
+            Ok(gettypeobject(&pyre_object::UNION_TYPE))
+        }),
+    ] {
+        unsafe {
+            pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+                ns,
+                name,
+                make_getset_descriptor_named(
+                    make_builtin_function_with_arity(name, getter, 2),
+                    name,
+                ),
+            )
+        };
+    }
     // Python 3.14's shared `types.UnionType` / `typing.Union` runtime type
     // exposes `__module__` on union *instances* as well as on the type.  Keep
     // the value in the typedef namespace so generic object attribute lookup
@@ -9077,6 +9129,15 @@ fn init_union_type(ns: PyObjectRef) {
             ns,
             "__getattribute__",
             make_builtin_function_with_arity("__getattribute__", union_getattribute_method, 2),
+        )
+    };
+    // `_pypy_generic_alias.py:322`: prevent the sequence protocol from using
+    // `__getitem__` as an iteration fallback.
+    unsafe {
+        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+            ns,
+            "__iter__",
+            pyre_object::w_none(),
         )
     };
 }


### PR DESCRIPTION
Stacked on `main` after #923 merged.

## UnionType slot surface
`types.UnionType` exposed only part of its 3.14 attribute surface. These two commits add the remaining rich-comparison, identity and iteration slots as explicit type-dict entries with fixed arities, so unbound calls raise the same `TypeError` CPython does instead of silently accepting any argument count.

## functools
`reduce` and `cmp_to_key` are exported as functions.

## check.py: startup median over five samples

The measured empty-program startup is subtracted from every timed run, which makes it the **divisor** for short benches — the baseline's exec time is `bench - startup`. One high sample collapses that denominator and inflates every ratio computed against it.

Observed on run 30646226633 (the #923 head):

| run | cpython | pypy | dynasm | cranelift |
|---|---|---|---|---|
| main macOS | 0.012s | **0.013s** | 0.061s | 0.059s |
| PR macOS | 0.021s | **0.031s** | 0.110s | 0.108s |

pypy startup measured 2.4x higher on the same platform. Three benches failed their gates in that run **while their pyre exec times had gone down** versus main:

| bench | dynasm | cranelift | ratio |
|---|---|---|---|
| `synth/polymorphic_binary_receiver` | 1.26s → 0.97s | 1.41s → 0.92s | 35.6x → 172.4x |
| `synth/recursion_memo_branch` | 0.33s → 0.28s | 0.44s → 0.25s | 9.8x → 27.3x |

The failing benches also did not overlap between ubuntu and macOS, which is the signature of baseline noise rather than a regression.

Five samples make the median robust to two outliers instead of one. No gate value was changed.

— *authored by Claude*