### PR TITLE
Reduce startup: cache the importlib bootstrap compile; hash ASCII storage directly

### DIFF
--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -9937,6 +9937,14 @@ fn _hash_bytes(bytes: &[u8]) -> i64 {
 /// selecting one-, two-, or four-byte native-endian units from the maximum
 /// code point.  Pyre stores WTF-8, so materialize only this hash input.
 fn _hash_unicode_with_key(wtf8: &rustpython_wtf8::Wtf8, secret: &[u8; 16]) -> i64 {
+    // An all-ASCII string's PEP 393 canonical code-unit storage is its
+    // one-byte-per-char form, byte-identical to the WTF-8 bytes, so hash those
+    // directly instead of materializing a separate code-unit buffer. This is
+    // the common case (identifiers, dict keys) and skips two Vec allocations.
+    let storage = wtf8.as_bytes();
+    if storage.is_ascii() {
+        return _hash_bytes_with_key(storage, secret);
+    }
     let codepoints: Vec<u32> = wtf8.code_points().map(|cp| cp.to_u32()).collect();
     let maxchar = codepoints.iter().copied().max().unwrap_or(0);
     let mut bytes = Vec::with_capacity(
@@ -9974,6 +9982,11 @@ fn _hash_unicode(wtf8: &rustpython_wtf8::Wtf8) -> i64 {
 /// without a `W_UnicodeObject`.
 #[inline]
 pub fn hash_str_bytes(bytes: &[u8]) -> i64 {
+    // ASCII fast path (see `_hash_unicode_with_key`): the storage bytes are the
+    // canonical hash input, so hash them without validating/constructing a Wtf8.
+    if bytes.is_ascii() {
+        return _hash_bytes(bytes);
+    }
     let wtf8 = rustpython_wtf8::Wtf8::from_bytes(bytes).expect("str storage is valid WTF-8");
     _hash_unicode(wtf8)
 }

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -2134,7 +2134,7 @@ fn parse_source_module(pathname: &str, source: &str) -> Result<CodeObject, Strin
 // instead of erasing the field).
 
 fn exec_code_module(
-    code: CodeObject,
+    w_code: PyObjectRef,
     w_globals: pyre_object::PyObjectRef,
     execution_context: *const PyExecutionContext,
     pathname: Option<&str>,
@@ -2195,8 +2195,6 @@ fn exec_code_module(
             }
         }
     }
-    let code_ptr = Box::into_raw(Box::new(code));
-    let w_code = crate::w_code_new(code_ptr as *const ());
     // importing.py:300 code_w.exec_code(space, w_dict, w_dict) → eval.py:31-33
     // Code.exec_code → space.createframe(...) + frame.run().  Surface
     // initialize_frame_scopes' freevar/closure mismatch (TypeError /
@@ -2309,19 +2307,46 @@ fn load_source_module(
     })?;
 
     let pathname_str = pathname.to_string_lossy();
-    let code = parse_source_module(&pathname_str, &source).map_err(|e| {
-        crate::PyError::new(
-            crate::PyErrorKind::ImportError,
-            format!("cannot compile '{}': {e}", pathname.display()),
-        )
-    })?;
+
+    let _root = pyre_object::gc_roots::push_roots();
+    // The two importlib bootstrap sources are imported by the native importer
+    // before `SourceFileLoader` exists, so they never reach the `.pyc` cache and
+    // otherwise recompile on every startup.  `_frozen_importlib._cached_compile`:
+    // reload a marshalled, source-validated code object when the cache holds one
+    // for this binary, recompiling only on a miss.
+    let cache_key = match modulename {
+        "importlib._bootstrap" | "importlib._bootstrap_external" => Some(modulename),
+        _ => None,
+    };
+    let (w_code, store) = match cache_key
+        .and_then(|key| crate::module::imp::interp_imp::frozen_cache_load(key, &source))
+    {
+        Some(w_code) => (w_code, false),
+        None => {
+            let code = parse_source_module(&pathname_str, &source).map_err(|e| {
+                crate::PyError::new(
+                    crate::PyErrorKind::ImportError,
+                    format!("cannot compile '{}': {e}", pathname.display()),
+                )
+            })?;
+            (
+                crate::w_code_new(Box::into_raw(Box::new(code)) as *const ()),
+                cache_key.is_some(),
+            )
+        }
+    };
+    // Root before any allocation (fresh_module_globals, the cache write) can
+    // collect the freshly boxed code out from under us.
+    pyre_object::gc_roots::pin_root(w_code);
+    if let (true, Some(key)) = (store, cache_key) {
+        crate::module::imp::interp_imp::frozen_cache_store(key, &source, w_code);
+    }
 
     // Create a fresh namespace for the module, seeded with builtins.
     // PyPy equivalent: Module.__init__ creates w_dict = space.newdict()
     // then exec_code_module sets __builtins__ and runs code in w_dict.
     let ctx = unsafe { &*execution_context };
     let w_globals = ctx.fresh_module_globals();
-    let _root = pyre_object::gc_roots::push_roots();
     pyre_object::gc_roots::pin_root(w_globals);
 
     // PyPy `interpreter/module.py:Module.__init__` seeds `__name__` on
@@ -2399,7 +2424,7 @@ fn load_source_module(
     // (`_bootstrap._load`) so a retried import re-runs the body instead of
     // observing a half-built module.
     if let Err(e) = exec_code_module(
-        code,
+        w_code,
         w_globals,
         execution_context,
         Some(&pathname_str),

--- a/pyre/pyre-interpreter/src/module/imp/interp_imp.rs
+++ b/pyre/pyre-interpreter/src/module/imp/interp_imp.rs
@@ -485,6 +485,17 @@ fn ascii_module_name(w_name: pyre_object::PyObjectRef) -> Result<String, crate::
 /// through here and observe the same object.
 fn frozen_code(entry: &FrozenModule) -> Result<pyre_object::PyObjectRef, crate::PyError> {
     let (source, code_name) = frozen_source(entry)?;
+    // `_frozen_importlib._cached_compile`: recompiling the frozen sources (the
+    // ~116 KB importlib bootstrap) on every startup is a large recurring cost,
+    // so reload a marshalled code object from a source-validated cache when one
+    // is present and recompile only on a miss.  A `Literal` source is trivial to
+    // recompile and has no stdlib file backing, so only stdlib sources are cached.
+    let cache_key = matches!(entry.source, FrozenSource::Stdlib(_)).then_some(entry.name);
+    if let Some(key) = cache_key
+        && let Some(code) = frozen_cache_load(key, &source)
+    {
+        return Ok(code);
+    }
     let filename = format!("<frozen {code_name}>");
     let code = crate::compile::compile_source_with_filename(
         &source,
@@ -492,10 +503,95 @@ fn frozen_code(entry: &FrozenModule) -> Result<pyre_object::PyObjectRef, crate::
         &filename,
     )
     .map_err(|error| crate::builtins::compile_err_to_syntax_error(error, &source))?;
-    Ok(crate::w_code_new(
-        Box::into_raw(Box::new(code)) as *const ()
-    ))
+    let w_code = crate::w_code_new(Box::into_raw(Box::new(code)) as *const ());
+    if let Some(key) = cache_key {
+        // `frozen_cache_store` marshals `w_code`, which can allocate and collect;
+        // keep the freshly boxed code reachable across that call.
+        let _root = pyre_object::gc_roots::push_roots();
+        pyre_object::gc_roots::pin_root(w_code);
+        frozen_cache_store(key, &source, w_code);
+    }
+    Ok(w_code)
 }
+
+/// Identity of the running interpreter binary, used to invalidate the frozen
+/// marshal cache across rebuilds: a new binary may emit a different
+/// bytecode/marshal format for the same source, and the executable's
+/// modification time changes on every rebuild.
+#[cfg(feature = "host_env")]
+fn frozen_cache_binary_mtime() -> Option<u64> {
+    let exe = std::env::current_exe().ok()?;
+    let modified = std::fs::metadata(&exe).ok()?.modified().ok()?;
+    Some(modified.duration_since(std::time::UNIX_EPOCH).ok()?.as_nanos() as u64)
+}
+
+/// Cache file for a source module's marshalled code, colocated with the stdlib
+/// bytecode cache.  `cache_key` names the entry (its frozen name, or the dotted
+/// module name for the native bootstrap import); the executable name segregates
+/// backends, which may emit differing marshal formats for the same source.
+#[cfg(feature = "host_env")]
+pub(crate) fn frozen_cache_path(cache_key: &str) -> Option<std::path::PathBuf> {
+    let exe = std::env::current_exe().ok()?;
+    let exe_name = exe.file_name()?.to_str()?;
+    let dir = crate::importing::detect_stdlib_path()?.join("__pycache__");
+    let stem = cache_key.replace(['.', '/', '\\'], "_");
+    Some(dir.join(format!("frozen.{stem}.{exe_name}.marshalcache")))
+}
+
+/// `_cached_compile` load half: return the cached marshalled code object when
+/// the file's recorded binary mtime and source prefix both match.  Any
+/// mismatch or I/O error yields `None`, so the caller recompiles.
+#[cfg(feature = "host_env")]
+pub(crate) fn frozen_cache_load(cache_key: &str, source: &str) -> Option<pyre_object::PyObjectRef> {
+    let path = frozen_cache_path(cache_key)?;
+    let mtime = frozen_cache_binary_mtime()?;
+    let bytes = std::fs::read(&path).ok()?;
+    // Header: [u64 binary_mtime][u64 source_len][source bytes][marshalled code].
+    let stored_mtime = u64::from_le_bytes(bytes.get(0..8)?.try_into().ok()?);
+    if stored_mtime != mtime {
+        return None;
+    }
+    let src_len = u64::from_le_bytes(bytes.get(8..16)?.try_into().ok()?) as usize;
+    let src_end = 16usize.checked_add(src_len)?;
+    if bytes.get(16..src_end)? != source.as_bytes() {
+        return None;
+    }
+    let code = crate::module::marshal::loads_bytes(bytes.get(src_end..)?).ok()?;
+    unsafe { crate::is_code(code) }.then_some(code)
+}
+
+/// `_cached_compile` store half (best effort): write the marshalled code with
+/// the validating header.  I/O failures (e.g. a read-only stdlib) are ignored —
+/// the next startup simply recompiles.
+#[cfg(feature = "host_env")]
+pub(crate) fn frozen_cache_store(cache_key: &str, source: &str, code: pyre_object::PyObjectRef) {
+    let Some(path) = frozen_cache_path(cache_key) else {
+        return;
+    };
+    let Some(mtime) = frozen_cache_binary_mtime() else {
+        return;
+    };
+    let Ok(marshalled) = crate::module::marshal::dumps_bytes(code) else {
+        return;
+    };
+    let mut buf = Vec::with_capacity(16 + source.len() + marshalled.len());
+    buf.extend_from_slice(&mtime.to_le_bytes());
+    buf.extend_from_slice(&(source.len() as u64).to_le_bytes());
+    buf.extend_from_slice(source.as_bytes());
+    buf.extend_from_slice(&marshalled);
+    if let Some(dir) = path.parent() {
+        let _ = std::fs::create_dir_all(dir);
+    }
+    let _ = std::fs::write(&path, &buf);
+}
+
+#[cfg(not(feature = "host_env"))]
+pub(crate) fn frozen_cache_load(_cache_key: &str, _source: &str) -> Option<pyre_object::PyObjectRef> {
+    None
+}
+
+#[cfg(not(feature = "host_env"))]
+pub(crate) fn frozen_cache_store(_cache_key: &str, _source: &str, _code: pyre_object::PyObjectRef) {}
 
 /// The `data` element of a `withdata=True` `find_frozen` result: a read-only
 /// `memoryview` over the frozen bytes, so `marshal.loads(bytes(data))`

--- a/pyre/pyre-interpreter/src/module/imp/interp_imp.rs
+++ b/pyre/pyre-interpreter/src/module/imp/interp_imp.rs
@@ -514,46 +514,81 @@ fn frozen_code(entry: &FrozenModule) -> Result<pyre_object::PyObjectRef, crate::
     Ok(w_code)
 }
 
-/// Identity of the running interpreter binary, used to invalidate the frozen
-/// marshal cache across rebuilds: a new binary may emit a different
-/// bytecode/marshal format for the same source, and the executable's
-/// modification time changes on every rebuild.
-#[cfg(feature = "host_env")]
-fn frozen_cache_binary_mtime() -> Option<u64> {
-    let exe = std::env::current_exe().ok()?;
-    let modified = std::fs::metadata(&exe).ok()?.modified().ok()?;
-    Some(modified.duration_since(std::time::UNIX_EPOCH).ok()?.as_nanos() as u64)
+/// Bytecode/marshal version token stamped into the frozen cache header and
+/// exposed as `_imp.pyc_magic_number_token`: the low half is the 3.14 magic
+/// 3627, the high half the `\r\n` marker so the number breaks when read as
+/// text.  A cache written by an interpreter with a different token is rejected.
+pub(crate) const PYC_MAGIC_NUMBER_TOKEN: u32 = 0x0A0D_0E2B;
+
+/// Per-process identity shared by every frozen-cache access: the stdlib
+/// `__pycache__` directory, the executable name (segregates backends), and the
+/// executable's modification time in ns (invalidates the cache across
+/// rebuilds).  Computed once so `current_exe`, the `stat`, and
+/// `detect_stdlib_path` each run a single time rather than once per lookup.
+///
+/// The cache is compiled out under `sandbox`: it needs `current_exe` (which the
+/// host seam has no equivalent for) and writes into the stdlib `__pycache__`
+/// (host FS mutation the seam forbids), so under sandbox the stubs below apply
+/// and the bootstrap sources simply recompile each startup.
+#[cfg(all(feature = "host_env", not(feature = "sandbox")))]
+struct FrozenCacheBase {
+    dir: std::path::PathBuf,
+    exe_name: String,
+    binary_mtime: u64,
+}
+
+#[cfg(all(feature = "host_env", not(feature = "sandbox")))]
+fn frozen_cache_base() -> Option<&'static FrozenCacheBase> {
+    use std::sync::OnceLock;
+    static BASE: OnceLock<Option<FrozenCacheBase>> = OnceLock::new();
+    BASE.get_or_init(|| {
+        let exe = std::env::current_exe().ok()?;
+        let exe_name = exe.file_name()?.to_str()?.to_owned();
+        let modified = std::fs::metadata(&exe).ok()?.modified().ok()?;
+        let binary_mtime =
+            modified.duration_since(std::time::UNIX_EPOCH).ok()?.as_nanos() as u64;
+        let dir = crate::importing::detect_stdlib_path()?.join("__pycache__");
+        Some(FrozenCacheBase { dir, exe_name, binary_mtime })
+    })
+    .as_ref()
 }
 
 /// Cache file for a source module's marshalled code, colocated with the stdlib
 /// bytecode cache.  `cache_key` names the entry (its frozen name, or the dotted
-/// module name for the native bootstrap import); the executable name segregates
-/// backends, which may emit differing marshal formats for the same source.
-#[cfg(feature = "host_env")]
+/// module name for the native bootstrap import).  The executable name segregates
+/// backends and the optimize level segregates `-O`/`-OO` bytecode, so those
+/// variants live in distinct files instead of overwriting one another.
+#[cfg(all(feature = "host_env", not(feature = "sandbox")))]
 pub(crate) fn frozen_cache_path(cache_key: &str) -> Option<std::path::PathBuf> {
-    let exe = std::env::current_exe().ok()?;
-    let exe_name = exe.file_name()?.to_str()?;
-    let dir = crate::importing::detect_stdlib_path()?.join("__pycache__");
+    let base = frozen_cache_base()?;
+    let optimize = crate::importing::optimize_flag();
     let stem = cache_key.replace(['.', '/', '\\'], "_");
-    Some(dir.join(format!("frozen.{stem}.{exe_name}.marshalcache")))
+    Some(base.dir.join(format!(
+        "frozen.{stem}.{}.opt-{optimize}.marshalcache",
+        base.exe_name
+    )))
 }
 
 /// `_cached_compile` load half: return the cached marshalled code object when
-/// the file's recorded binary mtime and source prefix both match.  Any
+/// the recorded version token, binary mtime, and full source all match.  Any
 /// mismatch or I/O error yields `None`, so the caller recompiles.
-#[cfg(feature = "host_env")]
+#[cfg(all(feature = "host_env", not(feature = "sandbox")))]
 pub(crate) fn frozen_cache_load(cache_key: &str, source: &str) -> Option<pyre_object::PyObjectRef> {
     let path = frozen_cache_path(cache_key)?;
-    let mtime = frozen_cache_binary_mtime()?;
+    let mtime = frozen_cache_base()?.binary_mtime;
     let bytes = std::fs::read(&path).ok()?;
-    // Header: [u64 binary_mtime][u64 source_len][source bytes][marshalled code].
-    let stored_mtime = u64::from_le_bytes(bytes.get(0..8)?.try_into().ok()?);
+    // Header: [u32 magic][u64 binary_mtime][u64 source_len][source bytes][marshalled code].
+    let magic = u32::from_le_bytes(bytes.get(0..4)?.try_into().ok()?);
+    if magic != PYC_MAGIC_NUMBER_TOKEN {
+        return None;
+    }
+    let stored_mtime = u64::from_le_bytes(bytes.get(4..12)?.try_into().ok()?);
     if stored_mtime != mtime {
         return None;
     }
-    let src_len = u64::from_le_bytes(bytes.get(8..16)?.try_into().ok()?) as usize;
-    let src_end = 16usize.checked_add(src_len)?;
-    if bytes.get(16..src_end)? != source.as_bytes() {
+    let src_len = u64::from_le_bytes(bytes.get(12..20)?.try_into().ok()?) as usize;
+    let src_end = 20usize.checked_add(src_len)?;
+    if bytes.get(20..src_end)? != source.as_bytes() {
         return None;
     }
     let code = crate::module::marshal::loads_bytes(bytes.get(src_end..)?).ok()?;
@@ -563,19 +598,20 @@ pub(crate) fn frozen_cache_load(cache_key: &str, source: &str) -> Option<pyre_ob
 /// `_cached_compile` store half (best effort): write the marshalled code with
 /// the validating header.  I/O failures (e.g. a read-only stdlib) are ignored —
 /// the next startup simply recompiles.
-#[cfg(feature = "host_env")]
+#[cfg(all(feature = "host_env", not(feature = "sandbox")))]
 pub(crate) fn frozen_cache_store(cache_key: &str, source: &str, code: pyre_object::PyObjectRef) {
     let Some(path) = frozen_cache_path(cache_key) else {
         return;
     };
-    let Some(mtime) = frozen_cache_binary_mtime() else {
+    let Some(base) = frozen_cache_base() else {
         return;
     };
     let Ok(marshalled) = crate::module::marshal::dumps_bytes(code) else {
         return;
     };
-    let mut buf = Vec::with_capacity(16 + source.len() + marshalled.len());
-    buf.extend_from_slice(&mtime.to_le_bytes());
+    let mut buf = Vec::with_capacity(20 + source.len() + marshalled.len());
+    buf.extend_from_slice(&PYC_MAGIC_NUMBER_TOKEN.to_le_bytes());
+    buf.extend_from_slice(&base.binary_mtime.to_le_bytes());
     buf.extend_from_slice(&(source.len() as u64).to_le_bytes());
     buf.extend_from_slice(source.as_bytes());
     buf.extend_from_slice(&marshalled);
@@ -585,12 +621,12 @@ pub(crate) fn frozen_cache_store(cache_key: &str, source: &str, code: pyre_objec
     let _ = std::fs::write(&path, &buf);
 }
 
-#[cfg(not(feature = "host_env"))]
+#[cfg(any(not(feature = "host_env"), feature = "sandbox"))]
 pub(crate) fn frozen_cache_load(_cache_key: &str, _source: &str) -> Option<pyre_object::PyObjectRef> {
     None
 }
 
-#[cfg(not(feature = "host_env"))]
+#[cfg(any(not(feature = "host_env"), feature = "sandbox"))]
 pub(crate) fn frozen_cache_store(_cache_key: &str, _source: &str, _code: pyre_object::PyObjectRef) {}
 
 /// The `data` element of a `withdata=True` `find_frozen` result: a read-only
@@ -1031,12 +1067,11 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         pyre_object::w_str_new("default"),
     );
     // `MAGIC_NUMBER = _imp.pyc_magic_number_token.to_bytes(4, 'little')`
-    // (_bootstrap_external.py) — low half is the 3.14 magic 3627, high half
-    // the `\r\n` marker so the number breaks when read as text.  Cache
-    // files are already segregated by `sys.implementation.cache_tag`.
+    // (_bootstrap_external.py).  Cache files are already segregated by
+    // `sys.implementation.cache_tag`.
     crate::module_ns_store(
         ns,
         "pyc_magic_number_token",
-        pyre_object::w_int_new(0x0A0D_0E2B),
+        pyre_object::w_int_new(i64::from(PYC_MAGIC_NUMBER_TOKEN)),
     );
 }


### PR DESCRIPTION
Two interpreter-startup optimizations. (The branch name predates the work; the
content is startup, not the int-mul bench.)

## 1. Cache the importlib bootstrap compile (`e6672ba`)

`importlib/_bootstrap.py` and `_bootstrap_external.py` are imported by the native
importer before `SourceFileLoader` exists, so they never reach the `.pyc` cache and
were recompiled on every startup — the only importlib files without a `.pyre-314.pyc`.

Port `_frozen_importlib._cached_compile`: reload a marshalled code object from a
cache validated by the binary mtime and the full source bytes, recompiling only on
a miss. `frozen_cache_load/store` are generalized to a `&str` key and applied at
both `load_source_module` (the native bootstrap import) and `frozen_code` (the
`_imp` frozen path). `exec_code_module` now takes a `w_code` so a marshal-loaded
code object flows through the same exec path; the freshly boxed `w_code` is rooted
before the following allocations can collect it.

Measured (instructions retired), warm run:
- compile bootstrap ~161M → `marshal.loads` ~66M
- empty-program startup **~647M → ~551M (~15%)**

## 2. Hash ASCII str storage bytes directly (`059a976`)

An all-ASCII string's canonical code-unit storage equals its one-byte WTF-8 form,
so hash those bytes directly instead of materializing a separate code-unit buffer.
Skips two allocations on the common identifier/dict-key path. ~13% startup.

## Verification
- `check.py --synthetic-only --backend dynasm`: **334/334 PASS** (pre-rebase);
  `cargo check` clean on the rebased base.
- GC-clean under `PYPY_GC_NURSERY=131072` (10/10); tracebacks / `co_filename` /
  `import __hello__` correct and matching pypy.

## Note on gates
`check.py` measures and **subtracts** empty-program startup before every ratio/gate
(check.py:96-102, 791-850), so these startup wins do **not** move any bench's gated
ratio — they reduce real wall-clock startup only. Empty-program startup goes from
~4× toward ~2.5× vs cpython/pypy; the remainder is init + LLBC load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
