### PR TITLE
gc: nursery placement around pinned objects and varsize overflow rejection; majit-translate: scope a fixture's lowering

### DIFF
--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -975,7 +975,13 @@ pub extern "C" fn dynasm_nursery_slowpath_varsize(
             .0 as u64
     });
     result.unwrap_or_else(|| {
-        let total = base_size as usize + item_size as usize * length as usize + gc_hdr;
+        let Some(total) = (item_size as usize)
+            .checked_mul(length as usize)
+            .and_then(|var_size| (base_size as usize).checked_add(var_size))
+            .and_then(|payload_size| gc_hdr.checked_add(payload_size))
+        else {
+            return 0;
+        };
         unsafe {
             // `libc::calloc` returns NULL on real OOM; the previous
             // unconditional `raw + gc_hdr` masked failure as a tiny
@@ -1119,7 +1125,12 @@ fn dynasm_alloc_oldgen_varsize_typed_and_set_len(
     length_ofs: usize,
     length: usize,
 ) -> u64 {
-    let payload_size = base_size + item_size * length;
+    let Some(payload_size) = item_size
+        .checked_mul(length)
+        .and_then(|var_size| base_size.checked_add(var_size))
+    else {
+        return 0;
+    };
     let obj = dynasm_alloc_oldgen_typed(type_id, payload_size);
     let ptr = obj.0;
     if ptr != 0 {
@@ -3893,6 +3904,15 @@ mod tests {
     };
     use std::sync::Arc;
     use std::sync::atomic::{AtomicU32, Ordering};
+
+    #[test]
+    fn varsize_slowpaths_return_null_on_size_overflow() {
+        assert_eq!(dynasm_nursery_slowpath_varsize(0, 2, u64::MAX), 0);
+        assert_eq!(
+            dynasm_alloc_oldgen_varsize_typed_and_set_len(1, 0, 2, 0, usize::MAX),
+            0
+        );
+    }
 
     fn install_test_libc_jitframe_tracer() {
         majit_gc::shadow_stack::register_libc_jitframe_tracer(

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -919,10 +919,22 @@ impl MiniMarkGC {
                 return GcRef(0);
             }
             let ptr = self.nursery.alloc(total_size);
-            if ptr.is_null() {
-                // Still no space after collection. Allocate in old gen as fallback.
+            let ptr = if ptr.is_null() {
+                self.reserve_nursery_gap(total_size)
+            } else {
+                ptr
+            };
+            if ptr.is_null() && Self::nursery_allocation_size(total_size) > self.nursery.size() {
+                // Production incminimark keeps `nonlarge_max` below the
+                // nursery size. Tiny backend tests can configure the two
+                // independently; retain their external-allocation fallback
+                // only for an object that cannot physically fit anywhere.
                 return self.alloc_in_oldgen(type_id, total_size);
             }
+            assert!(
+                !ptr.is_null(),
+                "collect_and_reserve could not find nursery space for a non-large object"
+            );
             Self::init_nursery_object(ptr, type_id);
             let obj = GcRef((ptr as usize) + GcHeader::SIZE);
             self.register_weakref_if_needed(type_id, obj.0);
@@ -986,10 +998,19 @@ impl MiniMarkGC {
                 return GcRef(0);
             }
             let ptr = self.nursery.alloc(total_size);
-            if ptr.is_null() {
+            let ptr = if ptr.is_null() {
+                self.reserve_nursery_gap(total_size)
+            } else {
+                ptr
+            };
+            if ptr.is_null() && Self::nursery_allocation_size(total_size) > self.nursery.size() {
                 unsafe { *needs_write_barrier = true };
                 return self.alloc_in_oldgen(type_id, total_size);
             }
+            assert!(
+                !ptr.is_null(),
+                "collect_and_reserve could not find nursery space for a non-large object"
+            );
             Self::init_nursery_object(ptr, type_id);
             let obj = GcRef((ptr as usize) + GcHeader::SIZE);
             self.register_weakref_if_needed(type_id, obj.0);
@@ -1002,6 +1023,69 @@ impl MiniMarkGC {
         self.register_weakref_if_needed(type_id, obj.0);
         self.register_destructor_if_needed(type_id, obj.0);
         obj
+    }
+
+    /// incminimark.py:865-930 `collect_and_reserve` pinned-barrier walk.
+    ///
+    /// A minor collection can leave `nursery_free` after the highest pinned
+    /// object, where the tail is too short for the triggering allocation even
+    /// though an earlier gap is large enough. Upstream walks the ordered
+    /// `nursery_barriers` and reserves from the first fitting gap; it never
+    /// changes a non-large malloc into an old-generation allocation. Preserve
+    /// that young-result contract because the GC rewrite elides write barriers
+    /// while initializing a fresh nursery object (`rewrite.py:911`).
+    fn nursery_allocation_size(total_size: usize) -> usize {
+        total_size
+            .max(GcHeader::MIN_NURSERY_OBJ_SIZE)
+            .checked_add(7)
+            .map(|size| size & !7)
+            .unwrap_or(usize::MAX)
+    }
+
+    fn reserve_nursery_gap(&mut self, total_size: usize) -> *mut u8 {
+        if self.pinned_objects.is_empty() {
+            return std::ptr::null_mut();
+        }
+
+        let aligned_size = Self::nursery_allocation_size(total_size);
+        let nursery_start = self.nursery.start_ptr() as usize;
+        let nursery_end = nursery_start + self.nursery.size();
+        let mut barriers = Vec::with_capacity(self.pinned_objects.len());
+        for &obj_addr in &self.pinned_objects {
+            let type_id = unsafe { (*header_of(obj_addr)).type_id() };
+            let type_info = self.types.get(type_id);
+            let payload_size = if type_info.item_size > 0 {
+                let length = unsafe { *((obj_addr + type_info.length_offset) as *const usize) };
+                type_info.total_instance_size(length)
+            } else {
+                type_info.size
+            };
+            let object_size = Self::nursery_allocation_size(GcHeader::SIZE + payload_size);
+            barriers.push((obj_addr - GcHeader::SIZE, object_size));
+        }
+        barriers.sort_unstable_by_key(|&(header_start, _)| header_start);
+
+        let mut gap_start = nursery_start;
+        for (header_start, object_size) in barriers {
+            if header_start.saturating_sub(gap_start) >= aligned_size {
+                unsafe {
+                    self.nursery.set_free_ptr(gap_start as *mut u8);
+                    self.nursery.set_top_ptr(header_start as *const u8);
+                }
+                self.refresh_published_nursery_top();
+                return self.nursery.alloc(total_size);
+            }
+            gap_start = gap_start.max(header_start.saturating_add(object_size));
+        }
+        if nursery_end.saturating_sub(gap_start) >= aligned_size {
+            unsafe {
+                self.nursery.set_free_ptr(gap_start as *mut u8);
+                self.nursery.set_top_ptr(nursery_end as *const u8);
+            }
+            self.refresh_published_nursery_top();
+            return self.nursery.alloc(total_size);
+        }
+        std::ptr::null_mut()
     }
 
     /// Allocate without triggering collection.
@@ -3722,6 +3806,7 @@ impl MiniMarkGC {
     /// and sets the free pointer past the highest pinned object.
     fn reset_nursery_with_pinned(&mut self) {
         let nursery_start = self.nursery.start_ptr() as usize;
+        let nursery_end = nursery_start + self.nursery.size();
 
         // Collect (header_start, total_size, data) for each pinned object.
         let mut saved: Vec<(usize, usize, Vec<u8>)> = Vec::new();
@@ -3741,6 +3826,13 @@ impl MiniMarkGC {
                 std::slice::from_raw_parts(header_start as *const u8, total_size).to_vec()
             };
             saved.push((header_start, total_size, data));
+        }
+
+        // Rebuild the barrier range from the whole arena. A preceding
+        // `reserve_nursery_gap` may have shortened `nursery_top` to the next
+        // pinned object, exactly as upstream does while consuming one gap.
+        unsafe {
+            self.nursery.set_top_ptr(nursery_end as *const u8);
         }
 
         // Zero-fill the entire nursery.
@@ -4755,6 +4847,45 @@ mod tests {
         let obj = gc.alloc_with_type(0, 16);
         assert!(!obj.is_null());
         assert!(gc.is_in_nursery(obj.0));
+    }
+
+    #[test]
+    fn collect_and_reserve_uses_gap_before_pinned_object() {
+        fn arrange_pinned_tail(gc: &mut MiniMarkGC) -> (u32, GcRef) {
+            let pinned_tid = gc.register_type(TypeInfo::simple(440));
+            let result_tid = gc.register_type(TypeInfo::simple(400));
+            let _dead_prefix = gc.alloc_with_type(pinned_tid, 440);
+            let pinned = gc.alloc_with_type(pinned_tid, 440);
+            assert!(gc.pin(pinned));
+            (result_tid, pinned)
+        }
+
+        // incminimark.py:865-930 walks back to the free gap before a pinned
+        // object. The old fallback returned an old-gen object here, violating
+        // the fresh nursery allocation contract used by the GC rewrite.
+        let mut gc = test_gc(1024);
+        let (result_tid, pinned) = arrange_pinned_tail(&mut gc);
+        let result = gc.alloc_with_type(result_tid, 400);
+        assert!(gc.is_in_nursery(result.0));
+        assert!(result.0 < pinned.0);
+        assert_eq!(
+            unsafe { &*(gc.nursery_top_addr() as *const AtomicUsize) }.load(Ordering::Acquire),
+            pinned.0 - GcHeader::SIZE,
+            "compiled allocators must stop at the same pinned barrier",
+        );
+
+        // The rooted slow path has the same collect-and-reserve contract and
+        // must continue reporting that initialization needs no write barrier.
+        let mut gc = test_gc(1024);
+        let (result_tid, pinned) = arrange_pinned_tail(&mut gc);
+        let mut root = GcRef::NULL;
+        let mut needs_write_barrier = true;
+        let result = unsafe {
+            gc.alloc_with_type_rooted(result_tid, 400, &mut root, &mut needs_write_barrier)
+        };
+        assert!(gc.is_in_nursery(result.0));
+        assert!(result.0 < pinned.0);
+        assert!(!needs_write_barrier);
     }
 
     /// incminimark.py:2601-2615 `PYPY_GC_MAX` out-of-memory policy: a bounded

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -893,7 +893,9 @@ impl MiniMarkGC {
             self.do_collect_full();
         }
 
-        let total_size = GcHeader::SIZE + payload_size;
+        let Some(total_size) = GcHeader::SIZE.checked_add(payload_size) else {
+            return GcRef(0);
+        };
 
         // Large objects go directly to old gen.
         if total_size > self.config.large_object_threshold {
@@ -978,7 +980,9 @@ impl MiniMarkGC {
             self.roots.remove(root);
         }
 
-        let total_size = GcHeader::SIZE + payload_size;
+        let Some(total_size) = GcHeader::SIZE.checked_add(payload_size) else {
+            return GcRef(0);
+        };
 
         // Large objects never trigger a nursery collection, so the native
         // slot needs no temporary registration.
@@ -1042,6 +1046,19 @@ impl MiniMarkGC {
             .unwrap_or(usize::MAX)
     }
 
+    /// `incminimark.py:978-983 external_malloc` parity: both the variable
+    /// portion and the final payload sum are overflow-checked.  The caller
+    /// turns `None` into NULL so compiled code raises `MemoryError`.
+    fn checked_varsize_payload_size(
+        base_size: usize,
+        item_size: usize,
+        length: usize,
+    ) -> Option<usize> {
+        item_size
+            .checked_mul(length)
+            .and_then(|var_size| base_size.checked_add(var_size))
+    }
+
     fn reserve_nursery_gap(&mut self, total_size: usize) -> *mut u8 {
         if self.pinned_objects.is_empty() {
             return std::ptr::null_mut();
@@ -1094,7 +1111,9 @@ impl MiniMarkGC {
     /// old-gen allocation so compiled code can keep running without needing
     /// stack-map-mediated collection.
     pub fn alloc_with_type_no_collect(&mut self, type_id: u32, payload_size: usize) -> GcRef {
-        let total_size = GcHeader::SIZE + payload_size;
+        let Some(total_size) = GcHeader::SIZE.checked_add(payload_size) else {
+            return GcRef(0);
+        };
 
         if total_size > self.config.large_object_threshold {
             return self.alloc_in_oldgen(type_id, total_size);
@@ -4144,7 +4163,10 @@ impl GcAllocator for MiniMarkGC {
     }
 
     fn alloc_varsize(&mut self, base_size: usize, item_size: usize, length: usize) -> GcRef {
-        let payload_size = base_size + item_size * length;
+        let Some(payload_size) = Self::checked_varsize_payload_size(base_size, item_size, length)
+        else {
+            return GcRef(0);
+        };
         self.alloc_with_type(0, payload_size)
     }
 
@@ -4155,7 +4177,10 @@ impl GcAllocator for MiniMarkGC {
         item_size: usize,
         length: usize,
     ) -> GcRef {
-        let payload_size = base_size + item_size * length;
+        let Some(payload_size) = Self::checked_varsize_payload_size(base_size, item_size, length)
+        else {
+            return GcRef(0);
+        };
         self.alloc_with_type(type_id, payload_size)
     }
 
@@ -4165,12 +4190,17 @@ impl GcAllocator for MiniMarkGC {
         item_size: usize,
         length: usize,
     ) -> GcRef {
-        let payload_size = base_size + item_size * length;
+        let Some(payload_size) = Self::checked_varsize_payload_size(base_size, item_size, length)
+        else {
+            return GcRef(0);
+        };
         self.alloc_with_type_no_collect(0, payload_size)
     }
 
     fn alloc_oldgen_typed(&mut self, type_id: u32, size: usize) -> GcRef {
-        let total_size = GcHeader::SIZE + size;
+        let Some(total_size) = GcHeader::SIZE.checked_add(size) else {
+            return GcRef(0);
+        };
         self.alloc_in_oldgen(type_id, total_size)
     }
 
@@ -5661,6 +5691,24 @@ mod tests {
 
         gc.collect_nursery();
         gc.collect_full();
+    }
+
+    #[test]
+    fn varsize_allocation_overflow_returns_null() {
+        let mut gc = test_gc(4096);
+        let tid = gc.register_type(TypeInfo::simple(16));
+
+        // incminimark.py external_malloc turns either multiplication or
+        // addition overflow into MemoryError; the JIT allocator reports that
+        // condition as NULL to its CHECK_MEMORY_ERROR caller.
+        assert!(gc.alloc_varsize(0, 2, usize::MAX).is_null());
+        assert!(gc.alloc_varsize_typed(tid, usize::MAX, 1, 1).is_null());
+        assert!(gc.alloc_varsize_no_collect(0, usize::MAX, 2).is_null());
+
+        // Include the GC header in the same checked-size contract.
+        assert!(gc.alloc_nursery(usize::MAX).is_null());
+        assert!(gc.alloc_nursery_no_collect(usize::MAX).is_null());
+        assert!(gc.alloc_oldgen_typed(tid, usize::MAX).is_null());
     }
 
     /// llsupport/gc.py:563 GcLLDescr_framework

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -127,7 +127,7 @@ pub fn build_semantic_program_from_llbcs_with_static_addrs(
     llbcs: &[Llbc],
     static_addrs: crate::HostStaticAddrs<'_>,
 ) -> Result<crate::front::semantic::SemanticProgram, LowerError> {
-    build_semantic_program_from_llbcs_with_static_addrs_filtered(llbcs, static_addrs, None)
+    build_semantic_program_from_llbcs_with_static_addrs_filtered(llbcs, static_addrs, None, None)
 }
 
 pub fn build_semantic_program_from_llbcs_with_static_addrs_and_module_paths(
@@ -140,6 +140,37 @@ pub fn build_semantic_program_from_llbcs_with_static_addrs_and_module_paths(
         llbcs,
         static_addrs,
         module_filter.as_ref(),
+        None,
+    )
+}
+
+/// The `module_paths` entry point narrowed further to a set of leaf
+/// function names.
+///
+/// A fixture that asserts on a handful of named graphs pays for lowering
+/// every function the module filter admits, which for `pyre-interpreter`
+/// is thousands of bodies. `function_names` keeps the same whole-program
+/// metadata — the type and trait tables that decide how a body lowers are
+/// still derived from the entire `llbc` — and only skips building the
+/// bodies nothing will read. A name that matches in several modules
+/// lowers in each; the allowlist is a leaf name, not a path.
+///
+/// Only the bodies are dropped, so a fixture that reaches for a graph it
+/// forgot to list fails loudly on the missing lookup rather than
+/// silently asserting over a smaller program.
+pub fn build_semantic_program_from_llbcs_with_static_addrs_and_function_names(
+    llbcs: &[Llbc],
+    static_addrs: crate::HostStaticAddrs<'_>,
+    module_paths: &[&str],
+    function_names: &[&str],
+) -> Result<crate::front::semantic::SemanticProgram, LowerError> {
+    let module_filter = normalize_module_filter(module_paths);
+    let function_filter = normalize_function_filter(function_names);
+    build_semantic_program_from_llbcs_with_static_addrs_filtered(
+        llbcs,
+        static_addrs,
+        module_filter.as_ref(),
+        function_filter.as_ref(),
     )
 }
 
@@ -147,6 +178,7 @@ fn build_semantic_program_from_llbcs_with_static_addrs_filtered(
     llbcs: &[Llbc],
     static_addrs: crate::HostStaticAddrs<'_>,
     module_filter: Option<&std::collections::HashSet<String>>,
+    function_filter: Option<&std::collections::HashSet<String>>,
 ) -> Result<crate::front::semantic::SemanticProgram, LowerError> {
     let mut merged: Option<crate::front::semantic::SemanticProgram> = None;
     // Dedup key combines `self_ty_root` (the impl owner, when known),
@@ -177,6 +209,7 @@ fn build_semantic_program_from_llbcs_with_static_addrs_filtered(
             llbc,
             static_addrs,
             module_filter,
+            function_filter,
         )?;
         match &mut merged {
             None => {
@@ -288,6 +321,16 @@ fn normalize_module_filter(module_paths: &[&str]) -> Option<std::collections::Ha
         .map(str::to_string)
         .collect();
     (!modules.is_empty()).then_some(modules)
+}
+
+fn normalize_function_filter(function_names: &[&str]) -> Option<std::collections::HashSet<String>> {
+    let names: std::collections::HashSet<String> = function_names
+        .iter()
+        .copied()
+        .filter(|name| !name.is_empty())
+        .map(str::to_string)
+        .collect();
+    (!names.is_empty()).then_some(names)
 }
 
 /// Build a [`SemanticProgram`] by lowering every local function
@@ -636,7 +679,7 @@ pub fn build_semantic_program_from_llbc_with_static_addrs(
     llbc: &Llbc,
     static_addrs: crate::HostStaticAddrs<'_>,
 ) -> Result<crate::front::semantic::SemanticProgram, LowerError> {
-    build_semantic_program_from_llbc_with_static_addrs_filtered(llbc, static_addrs, None)
+    build_semantic_program_from_llbc_with_static_addrs_filtered(llbc, static_addrs, None, None)
 }
 
 /// One block's slot-indexed `Option<Variable>` row, stored by bound slot.
@@ -740,6 +783,7 @@ fn build_semantic_program_from_llbc_with_static_addrs_filtered(
     llbc: &Llbc,
     static_addrs: crate::HostStaticAddrs<'_>,
     module_filter: Option<&std::collections::HashSet<String>>,
+    function_filter: Option<&std::collections::HashSet<String>>,
 ) -> Result<crate::front::semantic::SemanticProgram, LowerError> {
     // ── Pass 1: walk type_decls + trait_decls ─────────────────────
     let (
@@ -846,13 +890,6 @@ fn build_semantic_program_from_llbc_with_static_addrs_filtered(
     let mut functions = Vec::new();
     let mut skipped: Vec<(String, String)> = Vec::new();
     for fd in llbc.iter_local_fns() {
-        // `FunDecl::body` is raw JSON and `unstructured()` re-parses it on
-        // every call, so hold the one projection this iteration needs: it
-        // is both the "has a lowerable body" gate and the input the
-        // lowering below reads.
-        let Some(body) = fd.unstructured() else {
-            continue;
-        };
         // Charon emits static / const initialiser bodies (e.g. the
         // body that builds `static NONE_SINGLETON`) as ordinary
         // `FunDecl` entries with `is_global_initializer` set to the
@@ -879,6 +916,9 @@ fn build_semantic_program_from_llbc_with_static_addrs_filtered(
         if !should_lower_module(module_filter, &module_path) {
             continue;
         }
+        if !should_lower_function(function_filter, &name) {
+            continue;
+        }
         let fn_path = if module_path.is_empty() {
             name.clone()
         } else {
@@ -887,6 +927,15 @@ fn build_semantic_program_from_llbc_with_static_addrs_filtered(
         if not_rpython.contains(&fn_path) {
             continue;
         }
+        // `FunDecl::body` is raw JSON and `unstructured()` re-parses it on
+        // every call, so hold the one projection this iteration needs: it
+        // is both the "has a lowerable body" gate and the input the
+        // lowering below reads.  Every gate above reads the declaration's
+        // name path or header alone, so they run first and a filtered-out
+        // declaration never pays for the parse.
+        let Some(body) = fd.unstructured() else {
+            continue;
+        };
         // A single function whose body the driver does not yet handle
         // should not abort the whole-program build.  Capture
         // per-function errors into a side bucket and continue; they are
@@ -1089,6 +1138,18 @@ fn should_lower_module(
     // under `pyre_interpreter::module::*`, whose large dispatch/register
     // bodies are not part of the JIT portal closure.
     !(module_path == "module" || module_path.starts_with("module::"))
+}
+
+/// Leaf-name allowlist companion to [`should_lower_module`].
+///
+/// `None` lowers every name the module gate admitted — the production
+/// pipeline's shape, where the entry-point closure rather than a name list
+/// decides what matters.
+fn should_lower_function(
+    function_filter: Option<&std::collections::HashSet<String>>,
+    name: &str,
+) -> bool {
+    function_filter.is_none_or(|names| names.contains(name))
 }
 
 /// Derive whole-program type-metadata fields of `SemanticProgram` from

--- a/majit/majit-translate/tests/test_rbigint_mir.rs
+++ b/majit/majit-translate/tests/test_rbigint_mir.rs
@@ -10,7 +10,10 @@ use majit_translate::{
     HostStaticAddrs,
     front::{
         llbc_hints::harvest_hints_from_llbcs,
-        mir::build_semantic_program_from_llbcs_with_static_addrs_and_module_paths,
+        mir::{
+            build_semantic_program_from_llbcs_with_static_addrs_and_function_names,
+            build_semantic_program_from_llbcs_with_static_addrs_and_module_paths,
+        },
     },
     model::{CallTarget, OpKind, ValueType},
 };
@@ -1141,6 +1144,87 @@ fn rbigint_inherent_constructors_keep_their_owner_and_graph() {
     }
 }
 
+/// Callers whose mixed long/int arm must reach the machine-word residual
+/// named beside it, and must not fall back to a full `RBigInt::int_*` call.
+const MIXED_INT_RESIDUAL_CALLERS: &[(&str, &str)] = &[
+    ("long_add", "jit_bigint_int_add"),
+    ("long_sub", "jit_bigint_int_sub"),
+    ("long_mul", "jit_bigint_int_mul"),
+    ("long_bitand", "jit_bigint_int_and"),
+    ("long_bitor", "jit_bigint_int_or"),
+    ("long_bitxor", "jit_bigint_int_xor"),
+];
+
+/// `(module suffix, caller)` pairs that must borrow their long operand's
+/// payload instead of allocating a translated `jit_bigint_clone`.
+const BORROWED_PAYLOAD_CALLERS: &[(&str, &str)] = &[
+    ("objspace::descroperation", "long_pow"),
+    ("objspace::descroperation", "try_int_long_pow_with_modulo"),
+    ("objspace::descroperation", "long_lshift"),
+    ("objspace::descroperation", "long_rshift"),
+    ("objspace::descroperation", "long_floordiv"),
+    ("objspace::descroperation", "long_mod"),
+    ("objspace::descroperation", "integer_divmod_pair"),
+    ("objspace::descroperation", "bigint_mod_inverse"),
+    ("objspace::descroperation", "complex_richcompare"),
+    ("objspace::descroperation", "compare_slot"),
+    ("baseobjspace", "compute_slice_indices3_big"),
+    ("baseobjspace", "uint_w"),
+    ("baseobjspace", "truncatedint_w"),
+    ("baseobjspace", "getindex_w"),
+    ("baseobjspace", "index_int_w_preserve_negative"),
+    ("baseobjspace", "space_index"),
+    ("builtins", "builtin_abs"),
+    ("builtins", "ensure_baseint_result"),
+    ("builtins", "int_to_decimal_string"),
+    ("typedef", "int_descr_new"),
+    ("typedef", "slice_method_indices"),
+    ("builtins", "format_index_radix"),
+    ("type_methods", "format_with_spec"),
+    ("builtins", "obj_to_bigint"),
+    ("objspace::std::formatting", "arg_to_bigint"),
+    ("module::math::interp_math", "comb"),
+    ("module::math::interp_math", "perm"),
+];
+
+/// Floor-division callers and the floor-semantics residual each must take.
+const FLOOR_DIVMOD_CALLERS: &[(&str, &str)] = &[
+    ("long_floordiv", "jit_bigint_div_floor"),
+    ("long_mod", "jit_bigint_mod_floor"),
+];
+
+/// Unary callers that must borrow their input and allocate only the result.
+const UNARY_RESIDUAL_CALLERS: &[(&str, &str)] = &[
+    ("bigint_neg", "jit_bigint_neg"),
+    ("bigint_invert", "jit_bigint_invert"),
+];
+
+/// Graphs the test reaches for one at a time rather than through a table.
+const SINGLE_GRAPHS: &[&str] = &[
+    "bigint_add",
+    "long_int_compare",
+    "long_pow",
+    "long_lshift",
+    "int_lshift",
+];
+
+/// Every graph name the assertions below look up.
+///
+/// This is what scopes the lowering: `pyre-interpreter.ullbc` declares tens
+/// of thousands of functions and the module filter alone still admits
+/// thousands of bodies, none of which these assertions read. Deriving the
+/// list from the same tables the assertions iterate keeps the two from
+/// drifting — a caller added to a table is lowered by construction, and a
+/// name that goes missing fails the lookup it was added for.
+fn asserted_graph_names() -> Vec<&'static str> {
+    let mut names: Vec<&'static str> = SINGLE_GRAPHS.to_vec();
+    names.extend(MIXED_INT_RESIDUAL_CALLERS.iter().map(|(caller, _)| *caller));
+    names.extend(BORROWED_PAYLOAD_CALLERS.iter().map(|(_, caller)| *caller));
+    names.extend(FLOOR_DIVMOD_CALLERS.iter().map(|(caller, _)| *caller));
+    names.extend(UNARY_RESIDUAL_CALLERS.iter().map(|(caller, _)| *caller));
+    names
+}
+
 #[test]
 fn dependent_crate_rbigint_identity_retargets_opaque_llbc_declaration() {
     if !std::path::Path::new(INTERPRETER_LLBC).is_file() {
@@ -1217,7 +1301,7 @@ fn dependent_crate_rbigint_identity_retargets_opaque_llbc_declaration() {
             "{path} must preserve rbigint ovfcheck's OverflowError edge, got {values:?}"
         );
     }
-    let program = build_semantic_program_from_llbcs_with_static_addrs_and_module_paths(
+    let program = build_semantic_program_from_llbcs_with_static_addrs_and_function_names(
         &[llbc],
         HostStaticAddrs::default(),
         &[
@@ -1229,6 +1313,7 @@ fn dependent_crate_rbigint_identity_retargets_opaque_llbc_declaration() {
             "type_methods",
             "objspace::std::formatting",
         ],
+        &asserted_graph_names(),
     )
     .expect("lower descroperation module");
     let helper = program
@@ -1288,14 +1373,7 @@ fn dependent_crate_rbigint_identity_retargets_opaque_llbc_declaration() {
          calls={calls:?}; targets={call_targets:?}"
     );
 
-    for (caller_name, residual_name) in [
-        ("long_add", "jit_bigint_int_add"),
-        ("long_sub", "jit_bigint_int_sub"),
-        ("long_mul", "jit_bigint_int_mul"),
-        ("long_bitand", "jit_bigint_int_and"),
-        ("long_bitor", "jit_bigint_int_or"),
-        ("long_bitxor", "jit_bigint_int_xor"),
-    ] {
+    for &(caller_name, residual_name) in MIXED_INT_RESIDUAL_CALLERS {
         let caller = program
             .functions
             .iter()
@@ -1432,35 +1510,7 @@ fn dependent_crate_rbigint_identity_retargets_opaque_llbc_declaration() {
         "the host Result wrapper must not survive in the translated graph: {pow_calls:?}"
     );
 
-    for (module_suffix, caller_name) in [
-        ("objspace::descroperation", "long_pow"),
-        ("objspace::descroperation", "try_int_long_pow_with_modulo"),
-        ("objspace::descroperation", "long_lshift"),
-        ("objspace::descroperation", "long_rshift"),
-        ("objspace::descroperation", "long_floordiv"),
-        ("objspace::descroperation", "long_mod"),
-        ("objspace::descroperation", "integer_divmod_pair"),
-        ("objspace::descroperation", "bigint_mod_inverse"),
-        ("objspace::descroperation", "complex_richcompare"),
-        ("objspace::descroperation", "compare_slot"),
-        ("baseobjspace", "compute_slice_indices3_big"),
-        ("baseobjspace", "uint_w"),
-        ("baseobjspace", "truncatedint_w"),
-        ("baseobjspace", "getindex_w"),
-        ("baseobjspace", "index_int_w_preserve_negative"),
-        ("baseobjspace", "space_index"),
-        ("builtins", "builtin_abs"),
-        ("builtins", "ensure_baseint_result"),
-        ("builtins", "int_to_decimal_string"),
-        ("typedef", "int_descr_new"),
-        ("typedef", "slice_method_indices"),
-        ("builtins", "format_index_radix"),
-        ("type_methods", "format_with_spec"),
-        ("builtins", "obj_to_bigint"),
-        ("objspace::std::formatting", "arg_to_bigint"),
-        ("module::math::interp_math", "comb"),
-        ("module::math::interp_math", "perm"),
-    ] {
+    for &(module_suffix, caller_name) in BORROWED_PAYLOAD_CALLERS {
         let caller = program
             .functions
             .iter()
@@ -1563,10 +1613,7 @@ fn dependent_crate_rbigint_identity_retargets_opaque_llbc_declaration() {
         "the specialized host Result wrapper must not survive: {int_lshift_calls:?}"
     );
 
-    for (caller_name, residual_name) in [
-        ("long_floordiv", "jit_bigint_div_floor"),
-        ("long_mod", "jit_bigint_mod_floor"),
-    ] {
+    for &(caller_name, residual_name) in FLOOR_DIVMOD_CALLERS {
         let caller = program
             .functions
             .iter()
@@ -1596,10 +1643,7 @@ fn dependent_crate_rbigint_identity_retargets_opaque_llbc_declaration() {
         );
     }
 
-    for (caller_name, residual_name) in [
-        ("bigint_neg", "jit_bigint_neg"),
-        ("bigint_invert", "jit_bigint_invert"),
-    ] {
+    for &(caller_name, residual_name) in UNARY_RESIDUAL_CALLERS {
         let caller = program
             .functions
             .iter()


### PR DESCRIPTION
This branch bundles three independent commits that accumulated in the same working tree. They are unrelated to each other and can be reviewed separately — two GC changes and one `majit-translate` test-cost change.

## 1. `gc: preserve nursery placement around pinned objects` (8d1eda312d3)

`incminimark.py:865-930` `collect_and_reserve` walks the ordered `nursery_barriers` and reserves from the first gap that fits; it never converts a non-large malloc into an old-generation allocation. Our `collect_and_reserve` had no such walk: when a minor collection left `nursery_free` past the highest pinned object, a tail too short for the triggering allocation fell straight through to `alloc_in_oldgen`, even if an earlier gap was large enough.

That matters beyond placement — the GC rewrite elides write barriers while initializing a fresh nursery object (`rewrite.py:911`), so the young-result contract is load-bearing.

- Adds `reserve_nursery_gap`, which rebuilds the barrier list from `pinned_objects` (sorted by header start), reserves the first fitting gap by moving `nursery_free`/`nursery_top`, and republishes the nursery top so compiled allocators stop at the same barrier.
- The old-gen fallback survives only for an object that cannot physically fit anywhere (`nursery_allocation_size(total_size) > nursery.size()`), which production incminimark cannot reach because it keeps `nonlarge_max` below the nursery size — small backend tests configure the two independently. Otherwise a non-null nursery pointer is asserted.
- `reset_nursery_with_pinned` now rebuilds the barrier range from the whole arena, since a preceding `reserve_nursery_gap` may have shortened `nursery_top` to the next pinned object.
- Test `collect_and_reserve_uses_gap_before_pinned_object` covers both the plain and the rooted entry point: the result lands in the nursery below the pinned object, the published nursery top equals the pinned barrier, and the rooted path still reports `needs_write_barrier == false`.

## 2. `gc: reject overflowing varsize allocations` (053cf1fb4c8)

`incminimark.py:978-983` `external_malloc` overflow-checks both the variable portion and the final payload sum. Our size computations were plain `base_size + item_size * length` / `GcHeader::SIZE + payload_size`, so an overflowing request wrapped to a small size and produced an undersized object.

- `MiniMarkGC::checked_varsize_payload_size` centralizes the checked `item_size * length + base_size`. The `GcAllocator` varsize entry points, `alloc_oldgen_typed`, `alloc_with_type`, `alloc_with_type_rooted` and `alloc_with_type_no_collect` return `GcRef(0)` on overflow so compiled code raises `MemoryError`.
- The dynasm runner slow paths `dynasm_nursery_slowpath_varsize` and `dynasm_alloc_oldgen_varsize_typed_and_set_len` get the same checked arithmetic and return 0.
- Tests: `varsize_allocation_overflow_returns_null` (collector) and `varsize_slowpaths_return_null_on_size_overflow` (dynasm runner).

## 3. `majit-translate: scope a fixture's lowering to the graphs it asserts on` (d697905c89e)

A test-cost change; production entry points are unchanged.

- Adds `build_semantic_program_from_llbcs_with_static_addrs_and_function_names`, a leaf-name allowlist alongside the existing module-path filter. Whole-program metadata is still derived from the entire LLBC; only the *bodies* of functions outside the allowlist are left unbuilt. Existing entry points pass `None` and are unchanged.
- Moves the lowering loop's global-initializer / module / name gates ahead of `FunDecl::unstructured`, so a declaration that no gate admits no longer parses its body JSON.
- `test_rbigint_mir`'s four caller tables became consts, and the allowlist is derived from those same tables so the two cannot drift.

Measured against `pyre-interpreter.ullbc`: the dependent-crate test lowered 8580 of 30380 declarations in order to assert on 41 graphs; it now lowers those 41. The 41 graphs are byte-identical to an unfiltered control run after masking the global variable-id counter. The test binary went from 156.5 s to 80.9 s of CPU (154.1 s to 113.6 s wall).

## Gates

Run locally on this branch:

- `python3 ./pyre/check.py` → ALL PASSED — dynasm 352/352, cranelift 352/352, wasm 348/348, 3/3 backends.
- `cargo test --all --no-default-features --features dynasm` passed apart from a transient `majit-charon-reader --test corpus` failure caused by the shared worktree momentarily lacking `majit/charon-corpus/corpus.ullbc`; re-running that target alone gave 6 passed / 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented oversized allocations from wrapping around, improving memory safety and returning a failure result when requested sizes exceed supported limits.
  - Improved nursery allocation placement by checking available gaps before falling back to older memory regions.
  - Ensured allocation placement reporting remains consistent across allocation paths.

- **New Features**
  - Added optional filtering by function name when building semantic programs, allowing targeted processing without loading excluded function bodies.

- **Tests**
  - Added coverage for allocation overflow, pinned-object gaps, and function-specific semantic program construction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->