### PR TITLE
jit: make W_TypeObject._version_tag quasi-immutable (method-cache pair 41 → 38 ops)

### DIFF
--- a/pyre/bench/synth/method_reassign_after_warmup.py
+++ b/pyre/bench/synth/method_reassign_after_warmup.py
@@ -1,0 +1,103 @@
+# pyre-check: max-pypy-ratio=60
+# The ratio is deliberately loose: pypy folds this loop to near nothing
+# (0.01s at any N tried), so the denominator is collapsed and the number
+# measures pypy's constant folding rather than pyre's throughput. What this
+# fixture gates is the differential OUTPUT — pyre must agree with cpython and
+# pypy that the rebound method wins after the loop compiled.
+# `typeobject.py:177 _immutable_fields_ = ['_version_tag?']` — the LOAD_METHOD
+# fold bakes the resolved method into the compiled loop under a
+# QUASIIMMUT_FIELD on the receiver type's `_version_tag`, with no per-iteration
+# read of the tag to re-prove it. Rebinding the method afterwards bumps the tag
+# (`mutated()`, typeobject.py:285-286) and must revoke every loop that baked
+# the old identity, or the compiled code keeps calling the replaced method.
+#
+# Second half covers the subclass walk: `mutated()` recurses through
+# `weak_subclasses` (typeobject.py:288-291), so rebinding on a BASE has to
+# revoke a loop warmed on a subclass instance.
+N = 120000
+
+
+class P:
+    def get(self):
+        return 1
+
+
+class Base:
+    def val(self):
+        return 10
+
+
+class Sub(Base):
+    pass
+
+
+def run_get(p, n):
+    total = 0
+    i = 0
+    while i < n:
+        total = total + p.get()
+        i = i + 1
+    return total
+
+
+def run_val(s, n):
+    total = 0
+    i = 0
+    while i < n:
+        total = total + s.val()
+        i = i + 1
+    return total
+
+
+def run_mutating(q, n):
+    """Rebind the method from INSIDE the loop being traced and compiled.
+
+    This is the sharp case: a live read + `guard_value` of the tag would catch a
+    mid-trace rebinding on the spot, so under `_version_tag?` the per-iteration
+    `GUARD_NOT_INVALIDATED` has to catch it instead. Returns the distinct values
+    observed, in order, so a stale trace shows up as a missing transition rather
+    than only as a wrong total.
+    """
+    seen = []
+    i = 0
+    while i < n:
+        if i == n // 8:
+            Q.run = lambda self: 3
+        if i == n // 2:
+            Q.run = lambda self: 9
+        v = q.run()
+        if not seen or seen[-1] != v:
+            seen.append(v)
+        i = i + 1
+    return seen
+
+
+class Q:
+    def run(self):
+        return 1
+
+
+def main():
+    p = P()
+    # Phase 1: warm and compile the call loop against the original method.
+    a1 = run_get(p, N)
+    # Phase 2: rebind on the class itself.
+    P.get = lambda self: 2
+    a2 = run_get(p, N)
+    # Phase 3: rebind again, so a stale second-generation trace is caught too.
+    P.get = lambda self: 5
+    a3 = run_get(p, N)
+
+    s = Sub()
+    b1 = run_val(s, N)
+    # Phase 4: rebind on the BASE of the warmed receiver's class.
+    Base.val = lambda self: 20
+    b2 = run_val(s, N)
+
+    # Phase 5: rebind twice from inside the loop itself.
+    c = run_mutating(Q(), N)
+
+    print(a1 // N, a2 // N, a3 // N, b1 // N, b2 // N, c)
+
+
+main()

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -2147,24 +2147,34 @@ pub fn w_list_size_descr() -> DescrRef {
 
 /// `typeobject.py:162 _version_tag` — the method-cache version (`u64`, 8
 /// bytes, unsigned) on `W_TypeObject`. The `LOAD_METHOD` fast path reads it
-/// LIVE and `guard_value`s it (`promote(self.version_tag())`,
-/// typeobject.py:506) so the `_pure_lookup_where_with_method_cache`
-/// `CALL_PURE_R` folds on a green version. Mutable (not immutable /
-/// quasi-immutable): `mutated()` (typeobject.py:285-286) bumps it on any
-/// type-dict change, and the per-iteration `guard_value` re-checks it.
+/// through `promote(self.version_tag())` (typeobject.py:506) so the
+/// `_pure_lookup_where_with_method_cache` `CALL_PURE_R` folds on a green
+/// version.
 ///
-/// Upstream `_version_tag?` is quasi-immutable, so the JIT folds the read
-/// away and relies on the write barrier to invalidate dependent traces; the
-/// convergence path here is a `QUASIIMMUT_FIELD` once pyre wires that write
-/// barrier into `mutated()`. Until then a live read + `guard_value` is the
-/// sound interim.
-pub fn type_version_tag_descr() -> DescrRef {
-    make_field_descr(
+/// Quasi-immutable, per `typeobject.py:177 _immutable_fields_ =
+/// ['_version_tag?']`: the read is replaced by a `QUASIIMMUT_FIELD` plus one
+/// `GUARD_NOT_INVALIDATED` per trace, and `mutated()` (typeobject.py:285-286)
+/// revokes the dependent loops through
+/// [`pyre_object::typeobject::w_type_set_version_tag`] instead of the trace
+/// re-checking a live value every iteration. A residual call cannot flush a
+/// quasi-immutable field, which is the whole point — the interim live read +
+/// `guard_value` had to be re-done after every un-inlined call in the body.
+///
+/// One object per run, for the identity reason documented on
+/// [`W_CLASS_FIELD_DESCR`], and load-bearing here: `heap.rs:3274` keys
+/// `quasi_immut_cache` on `field_cache_identity`, which is the `Arc` pointer,
+/// so a per-call descriptor would miss its own cache on every read.
+static TYPE_VERSION_TAG_FIELD_DESCR: LazyLock<DescrRef> = LazyLock::new(|| {
+    make_quasi_immutable_field_descr(
         core::mem::offset_of!(pyre_object::typeobject::W_TypeObject, version_tag),
         8,
         Type::Int,
         false,
     )
+});
+
+pub fn type_version_tag_descr() -> DescrRef {
+    TYPE_VERSION_TAG_FIELD_DESCR.clone()
 }
 
 /// `W_ObjectObject` SizeDescr group (`objectobject.rs:34-46`) — the instance

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -4273,21 +4273,7 @@ pub(crate) fn try_walker_inline_type_call<Sym: WalkSym>(
     ctx.trace_ctx
         .heap_cache_mut()
         .replace_box(r_args[0], type_const);
-    let live_version = crate::state::opimpl_getfield_gc_i(
-        ctx.trace_ctx,
-        type_const,
-        crate::descr::type_version_tag_descr(),
-    );
-    let version_const = ctx.trace_ctx.const_int(version_tag as i64);
-    walker_emit_fold_guard_with_snapshot(
-        ctx,
-        op.pc,
-        OpCode::GuardValue,
-        &[live_version, version_const],
-    )?;
-    ctx.trace_ctx
-        .heap_cache_mut()
-        .replace_box(live_version, version_const);
+    walker_pin_type_version_tag(ctx, op.pc, type_const)?;
 
     // The walker is the executor here, so the instance the rest of this walk
     // reads has to be a real one — the same split `trace_box_int` makes between

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -7149,25 +7149,11 @@ fn walker_guard_mapdict_instance_shape<Sym: WalkSym>(
     }
 
     // The instance map pins the storage layout, but class mutation can change
-    // lookup precedence without changing that map. Re-read the receiver type's
-    // live version tag at every trace entry and deopt before the folded storage
-    // access when it changes.
+    // lookup precedence without changing that map. Pin the receiver type's
+    // version tag so such a mutation revokes the loop before the folded
+    // storage access is reused.
     let w_type_const = ctx.trace_ctx.const_ref(w_type as i64);
-    let version_op = crate::state::opimpl_getfield_gc_i(
-        ctx.trace_ctx,
-        w_type_const,
-        crate::descr::type_version_tag_descr(),
-    );
-    let version_const = ctx.trace_ctx.const_int(version_tag as i64);
-    walker_emit_fold_guard_with_snapshot(
-        ctx,
-        op_pc,
-        OpCode::GuardValue,
-        &[version_op, version_const],
-    )?;
-    ctx.trace_ctx
-        .heap_cache_mut()
-        .replace_box(version_op, version_const);
+    walker_pin_type_version_tag(ctx, op_pc, w_type_const)?;
 
     // guard_value(getfield_gc_i(obj, map), C_map): `jit.promote(self.map)`
     // (`mapdict.py`).  The map nodes are interned + immortal, so the
@@ -7235,21 +7221,7 @@ fn walker_guard_exception_attr_slot<Sym: WalkSym>(
         .replace_box(live_w_class, w_class_const);
 
     let type_const = ctx.trace_ctx.const_ref(w_type as i64);
-    let live_version = crate::state::opimpl_getfield_gc_i(
-        ctx.trace_ctx,
-        type_const,
-        crate::descr::type_version_tag_descr(),
-    );
-    let version_const = ctx.trace_ctx.const_int(version_tag as i64);
-    walker_emit_fold_guard_with_snapshot(
-        ctx,
-        op_pc,
-        OpCode::GuardValue,
-        &[live_version, version_const],
-    )?;
-    ctx.trace_ctx
-        .heap_cache_mut()
-        .replace_box(live_version, version_const);
+    walker_pin_type_version_tag(ctx, op_pc, type_const)?;
     Ok(())
 }
 
@@ -7276,6 +7248,34 @@ fn walker_record_getfield_gc_i_uncached<Sym: WalkSym>(
     // purity from the descr. There is no pure getfield opnum.
     ctx.trace_ctx
         .record_op_with_descr(OpCode::GetfieldGcI, &[obj], descr)
+}
+
+/// Pin a type's method-cache version without reading it, per
+/// `typeobject.py:177 _immutable_fields_ = ['_version_tag?']`.
+///
+/// `promote(self.version_tag())` (typeobject.py:506) needs the tag green so the
+/// `_pure_lookup_where_with_method_cache` fold can run. On a quasi-immutable
+/// field that costs a `QUASIIMMUT_FIELD` marker plus one
+/// `GUARD_NOT_INVALIDATED` per trace, not a load and a `GUARD_VALUE` per read:
+/// `mutated()` revokes the loop instead of the trace re-proving the tag. The
+/// difference is load-bearing inside a body with un-inlined calls, since a
+/// residual `CALL_MAY_FORCE` flushes a mutable field's cache but cannot flush a
+/// quasi-immutable one.
+///
+/// `w_type_const` must already be pinned to the receiver's type — the caller
+/// guards `w_class` first, so the marker attaches to a constant the optimizer
+/// can hand to `register_quasi_immutable_deps` as the watched object.
+fn walker_pin_type_version_tag<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    op_pc: usize,
+    w_type_const: OpRef,
+) -> Result<(), DispatchError> {
+    crate::state::record_quasiimmut_field(
+        ctx.trace_ctx,
+        w_type_const,
+        crate::descr::type_version_tag_descr(),
+    );
+    walker_flush_guard_not_invalidated(ctx, op_pc)
 }
 
 fn walker_record_getfield_gc_r_uncached<Sym: WalkSym>(

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -2559,14 +2559,7 @@ pub(crate) fn try_walker_specialize_load_method_attr<Sym: WalkSym>(
 
     // typeobject.py `promote(self.version_tag())`: class mutation or method
     // reassignment bumps `_version_tag`, so the old `w_descr` side-exits.
-    let vt_op = walker_record_getfield_gc_i_uncached(
-        ctx,
-        w_type_const,
-        crate::descr::type_version_tag_descr(),
-    );
-    let vt_const = ctx.trace_ctx.const_int(version_tag as i64);
-    walker_emit_fold_guard_with_snapshot(ctx, op_pc, OpCode::GuardValue, &[vt_op, vt_const])?;
-    ctx.trace_ctx.heap_cache_mut().replace_box(vt_op, vt_const);
+    walker_pin_type_version_tag(ctx, op_pc, w_type_const)?;
 
     // Re-prove the shadowing precondition: growing an instance attribute named
     // like the method must side-exit before the constant descriptor is reused.
@@ -2658,14 +2651,7 @@ pub(crate) fn try_walker_specialize_load_classmethod_attr<Sym: WalkSym>(
     // typeobject.py `promote(self.version_tag())`: class mutation or classmethod
     // reassignment in the class or any base bumps `_version_tag`, so the pinned
     // `__func__` side-exits.
-    let vt_op = walker_record_getfield_gc_i_uncached(
-        ctx,
-        w_type_const,
-        crate::descr::type_version_tag_descr(),
-    );
-    let vt_const = ctx.trace_ctx.const_int(version_tag as i64);
-    walker_emit_fold_guard_with_snapshot(ctx, op_pc, OpCode::GuardValue, &[vt_op, vt_const])?;
-    ctx.trace_ctx.heap_cache_mut().replace_box(vt_op, vt_const);
+    walker_pin_type_version_tag(ctx, op_pc, w_type_const)?;
 
     let func_const = ctx.trace_ctx.const_ref(w_func as i64);
     write_residual_call_result_to_dst(ctx, op_pc, dst, dst_bank, func_const)?;
@@ -2756,14 +2742,7 @@ pub(crate) fn try_walker_specialize_load_bound_method_attr<Sym: WalkSym>(
 
     // typeobject.py `promote(self.version_tag())`: reassigning the method on
     // the type bumps the tag, so the constant `w_descr` side-exits.
-    let vt_op = walker_record_getfield_gc_i_uncached(
-        ctx,
-        w_type_const,
-        crate::descr::type_version_tag_descr(),
-    );
-    let vt_const = ctx.trace_ctx.const_int(version_tag as i64);
-    walker_emit_fold_guard_with_snapshot(ctx, op_pc, OpCode::GuardValue, &[vt_op, vt_const])?;
-    ctx.trace_ctx.heap_cache_mut().replace_box(vt_op, vt_const);
+    walker_pin_type_version_tag(ctx, op_pc, w_type_const)?;
 
     // `w_method_new(w_descr, obj, w_type)` + the header stamp its allocation
     // performs (`ob_type` comes from the NewWithVtable's size descr).
@@ -6994,27 +6973,13 @@ pub(crate) fn try_walker_trace_exception_new<Sym: WalkSym>(
             .heap_cache_mut()
             .replace_box(callable_op, expected);
     }
-    if let Some(version_tag) = subclass_version_tag {
-        // Guard the promoted class version that made both MRO descriptor
+    if subclass_version_tag.is_some() {
+        // Pin the promoted class version that made both MRO descriptor
         // identities constant.  `W_TypeObject.mutated` recursively changes
         // subclass tags (`typeobject.py`), so mutating this class or a
-        // base side-exits before reusing the folded constructor.
+        // base revokes the loop before the folded constructor is reused.
         let class_const = ctx.trace_ctx.const_ref(concrete_callable as i64);
-        let live_version = crate::state::opimpl_getfield_gc_i(
-            ctx.trace_ctx,
-            class_const,
-            crate::descr::type_version_tag_descr(),
-        );
-        let version_const = ctx.trace_ctx.const_int(version_tag as i64);
-        walker_emit_fold_guard_with_snapshot(
-            ctx,
-            op.pc,
-            OpCode::GuardValue,
-            &[live_version, version_const],
-        )?;
-        ctx.trace_ctx
-            .heap_cache_mut()
-            .replace_box(live_version, version_const);
+        walker_pin_type_version_tag(ctx, op.pc, class_const)?;
     }
 
     if fills_os_error_slots && exact_os_error {

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -4429,6 +4429,33 @@ pub(crate) fn record_namespace_quasiimmut_field(
     }
 }
 
+/// pyjitpl.py:1074-1089 `opimpl_record_quasiimmut_field` for a real struct
+/// field, the [`record_namespace_quasiimmut_field`] twin.
+///
+/// The namespace variant keys on a synthetic `(dict, slot)` pair because a
+/// module-dict cell has no field descriptor; a genuine quasi-immutable field
+/// carries one, so the op is recorded with the descr and the heapcache keys on
+/// `descr.index()` the same way [`opimpl_getfield_gc_i`] does.
+///
+/// The caller has already resolved the field's value and is baking it as a
+/// constant, so unlike `opimpl_getfield_gc_i` this records no load — that is
+/// exactly what quasi-immutability buys.
+pub(crate) fn record_quasiimmut_field(ctx: &mut TraceCtx, obj: OpRef, descr: DescrRef) {
+    let field_index = descr.index();
+    if ctx.heap_cache().is_quasi_immut_known(obj, field_index) {
+        ctx.profiler().count_ops(
+            OpCode::QuasiimmutField,
+            majit_metainterp::counters::HEAPCACHED_OPS,
+        );
+        return;
+    }
+    ctx.heap_cache_mut().quasi_immut_now_known(obj, field_index);
+    ctx.record_op_with_descr(OpCode::QuasiimmutField, &[obj], descr);
+    if ctx.heap_cache_mut().check_and_clear_guard_not_invalidated() {
+        ctx.set_pending_guard_not_invalidated(Some(ctx.last_traced_pc));
+    }
+}
+
 /// virtualizable.py:44 + interp_jit.py:25-31 —
 /// `locals_cells_stack_w[*]` is declared as a W_Root array, so every
 /// item's JIT type is GCREF (Type::Ref). W_IntObject/W_FloatObject are

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -5275,10 +5275,20 @@ fn register_quasi_immutable_deps(_green_key: u64) {
     // place without bumping the version and is observed by the live
     // `cell.w_value` read instead.  `ns_ptr` is the `const_ref`-folded
     // `w_globals` object pointer; `slot` is unused for version keying.
-    for (ns_ptr, _slot) in deps {
-        let obj = ns_ptr as pyre_object::PyObjectRef;
+    //
+    // `typeobject.py:177 _immutable_fields_ = ['_version_tag?']`: the
+    // LOAD_METHOD / LOAD_ATTR method-cache fold bakes a type's `version_tag`
+    // as a constant under a `QUASIIMMUT_FIELD(w_type)`, so the same loop flag
+    // registers against the type. `mutated()` (typeobject.py:285-291) bumps
+    // the tag and walks subclasses, and the setter revokes each level's loops.
+    //
+    // Both registrations self-filter on the object's kind, so a dep of either
+    // kind reaches exactly its own watcher list.
+    for (dep_ptr, _slot) in deps {
+        let obj = dep_ptr as pyre_object::PyObjectRef;
         unsafe {
             pyre_object::dictmultiobject::module_dict_register_version_watcher(obj, &flag);
+            pyre_object::typeobject::w_type_register_quasi_immut_watcher(obj, &flag);
         }
     }
 }

--- a/pyre/pyre-object/src/typeobject.rs
+++ b/pyre/pyre-object/src/typeobject.rs
@@ -218,6 +218,15 @@ pub struct W_TypeObject {
     /// typeobject.py:166/216 `flag_abstract?` — set from the
     /// `__abstractmethods__` setattr hook; gates `object.__new__`.
     pub flag_abstract: std::sync::atomic::AtomicBool,
+    /// The hidden `mutate__version_tag` field for `typeobject.py:177
+    /// _immutable_fields_ = ['_version_tag?']` — see [`QuasiImmut`].
+    ///
+    /// Heap allocated on the first registration and null until then, exactly
+    /// like [`W_TypeObject::weak_subclasses`], which it also matches in never
+    /// being freed: this tree has no `W_TypeObject` teardown path. Holds no GC
+    /// pointers, so the `W_TYPE_GC_TYPE_ID` custom trace has nothing to walk
+    /// here.
+    pub quasi_immut_watchers: *mut QuasiImmut,
 }
 
 /// Source of fresh `version_tag` identities (`VersionTag()`, typeobject.py:73).
@@ -387,6 +396,8 @@ pub fn w_type_new(name: &str, bases: PyObjectRef, dict_ptr: *mut u8) -> PyObject
         // slot wrapper); only builtin disallow-types flip this.
         flag_disallow_instantiation: std::sync::atomic::AtomicBool::new(false),
         flag_abstract: std::sync::atomic::AtomicBool::new(false),
+        // Allocated lazily on the first loop registration.
+        quasi_immut_watchers: std::ptr::null_mut(),
     };
     let (w_type, gc_managed) = if !raw.is_null() {
         unsafe { std::ptr::write(raw as *mut W_TypeObject, value) };
@@ -504,6 +515,8 @@ pub fn w_type_new_builtin(
         // `w_type_set_disallow_instantiation`.
         flag_disallow_instantiation: std::sync::atomic::AtomicBool::new(false),
         flag_abstract: std::sync::atomic::AtomicBool::new(false),
+        // Allocated lazily on the first loop registration.
+        quasi_immut_watchers: std::ptr::null_mut(),
     }) as PyObjectRef;
     // A builtin type is Box-immortal, so its namespace values and `bases` are reachable only
     // through `walk_builtin_type_dicts_gc` (`pyre_interpreter::eval`).
@@ -721,10 +734,140 @@ pub unsafe fn w_type_get_version_tag(obj: PyObjectRef) -> u64 {
         .load(std::sync::atomic::Ordering::Acquire)
 }
 /// Store a new version-tag identity (typeobject.py:286 `mutated`).
+///
+/// Revokes the loops that baked the old identity as a constant before
+/// publishing the new one. This is the only writer of the field, so placing the
+/// `_version_tag?` invalidation here covers every way the tag can change —
+/// `mutated()`'s fresh identity and the two demotions to `0`
+/// (uncacheable) alike — rather than leaving each caller to remember it.
 pub unsafe fn w_type_set_version_tag(obj: PyObjectRef, v: u64) {
+    w_type_notify_quasi_immut_watchers(obj);
     (*(obj as *const W_TypeObject))
         .version_tag
         .store(v, std::sync::atomic::Ordering::Release);
+}
+
+/// `quasiimmut.py:55-109 QuasiImmut` — the loops that baked one quasi-immutable
+/// field's value as a constant, and must be revoked when it changes.
+///
+/// Upstream reaches this object through the hidden `mutate_<name>` field the
+/// rtyper adds for each `_immutable_fields_` entry spelled with a `?`
+/// (`get_mutate_field_name`), created on demand by
+/// `get_current_qmut_instance`. Pyre has no rtyper to synthesise the field, so
+/// [`W_TypeObject::quasi_immut_watchers`] is that field, spelled out and
+/// likewise allocated on the first registration.
+///
+/// The flag stands in for upstream's `looptoken` + `cpu.invalidate_loop`: the
+/// backend already routes `GUARD_NOT_INVALIDATED` through a per-artifact
+/// `AtomicBool`, so setting it is what `looptoken.invalidated = True` buys.
+pub struct QuasiImmut {
+    /// `quasiimmut.py:62-63` — weak so a retired loop drops out instead of
+    /// being kept alive by the type that it read.
+    looptokens_wrefs: Vec<std::sync::Weak<std::sync::atomic::AtomicBool>>,
+    /// `quasiimmut.py:57 compress_limit = 30`.
+    compress_limit: usize,
+}
+
+impl Default for QuasiImmut {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl QuasiImmut {
+    /// `quasiimmut.py:59-64 __init__`. The initial limit is the growth formula
+    /// in [`Self::compress_looptokens_list`] evaluated at length zero.
+    pub fn new() -> Self {
+        Self {
+            looptokens_wrefs: Vec::new(),
+            compress_limit: 30,
+        }
+    }
+
+    /// `quasiimmut.py:72-75 register_loop_token`.
+    fn register_loop_token(&mut self, flag: &std::sync::Arc<std::sync::atomic::AtomicBool>) {
+        if self.looptokens_wrefs.len() > self.compress_limit {
+            self.compress_looptokens_list();
+        }
+        self.looptokens_wrefs.push(std::sync::Arc::downgrade(flag));
+    }
+
+    /// `quasiimmut.py:77-82 compress_looptokens_list` — drop the entries whose
+    /// loop is gone and re-derive the limit from what is left, so a type that
+    /// is recompiled many times and never mutated cannot grow without bound.
+    ///
+    /// Upstream's note that already-invalidated tokens must be kept applies
+    /// here too: the flag stays live while its artifact does, and re-flipping
+    /// an already-set flag is what keeps a multiply-invalidated loop revoked.
+    fn compress_looptokens_list(&mut self) {
+        self.looptokens_wrefs.retain(|w| w.strong_count() > 0);
+        self.compress_limit = (self.looptokens_wrefs.len() + 15) * 2;
+    }
+
+    /// `quasiimmut.py:84-109 invalidate` — every loop recorded here becomes
+    /// invalid, so each `GUARD_NOT_INVALIDATED` in it (and in its bridges) must
+    /// now fail. The list is emptied like upstream's `self.looptokens_wrefs =
+    /// []`; a loop that recompiles registers again.
+    ///
+    /// `#[dont_look_inside]` (`@jit.dont_look_inside`, `rlib/jit.py:139`):
+    /// upstream never reaches `invalidate` from traced code — it hangs off the
+    /// residual `jit_force_quasi_immutable` path — and the `Vec` walk has no
+    /// lowering either way. The caller's null check stays traced, so the
+    /// common no-watcher mutation still makes no call.
+    #[majit_macros::dont_look_inside]
+    fn invalidate(&mut self) {
+        for wref in std::mem::take(&mut self.looptokens_wrefs) {
+            if let Some(flag) = wref.upgrade() {
+                flag.store(true, std::sync::atomic::Ordering::Release);
+            }
+        }
+    }
+}
+
+/// Register a compiled loop's invalidation flag against this type's
+/// `_version_tag?` (`quasiimmut.py:72-74 QuasiImmut.register_loop_token`).
+///
+/// The compile-time glue (`register_quasi_immutable_deps`) calls this once per
+/// type-keyed dependency the optimizer collected from a `QUASIIMMUT_FIELD`, so
+/// [`w_type_notify_quasi_immut_watchers`] can revoke the loop when the tag is
+/// bumped.
+///
+/// # Safety
+/// `obj` must be null or point at a valid `W_TypeObject`.
+pub unsafe fn w_type_register_quasi_immut_watcher(
+    obj: PyObjectRef,
+    flag: &std::sync::Arc<std::sync::atomic::AtomicBool>,
+) {
+    if obj.is_null() || !is_type(obj) {
+        return;
+    }
+    let w_type = &mut *(obj as *mut W_TypeObject);
+    if w_type.quasi_immut_watchers.is_null() {
+        w_type.quasi_immut_watchers = Box::into_raw(Box::new(QuasiImmut::new()));
+    }
+    (*w_type.quasi_immut_watchers).register_loop_token(flag);
+}
+
+/// Revoke every loop that baked this type's `version_tag` as a constant
+/// (`quasiimmut.py:84-109 QuasiImmut.invalidate`).
+///
+/// Called from [`w_type_set_version_tag`] right before the new tag is
+/// published. Upstream runs the whole walk outside traced code — `invalidate`
+/// is reached from the residual `jit_force_quasi_immutable` path, never from a
+/// trace — so the sweep is residualised the same way. The null check stays
+/// traced, so mutating a type no loop depends on still makes no call.
+///
+/// # Safety
+/// `obj` must be null or point at a valid `W_TypeObject`.
+pub unsafe fn w_type_notify_quasi_immut_watchers(obj: PyObjectRef) {
+    if obj.is_null() || !is_type(obj) {
+        return;
+    }
+    let w_type = &mut *(obj as *mut W_TypeObject);
+    if w_type.quasi_immut_watchers.is_null() {
+        return;
+    }
+    (*w_type.quasi_immut_watchers).invalidate();
 }
 
 /// typeobject.py:183-185 `uses_object_getattribute` reader.  Returns the
@@ -1323,6 +1466,59 @@ mod tests {
             <W_TypeObject as crate::lltype::GcType>::SIZE,
             W_TYPE_OBJECT_SIZE
         );
+    }
+
+    /// `quasiimmut.py:84-109 invalidate` flips every registered flag and empties
+    /// the list, and a flag whose loop is gone is simply skipped.
+    #[test]
+    fn quasi_immut_invalidate_flips_live_flags_and_clears() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        let mut qi = QuasiImmut::new();
+        let live = Arc::new(AtomicBool::new(false));
+        let dead = Arc::new(AtomicBool::new(false));
+        qi.register_loop_token(&live);
+        qi.register_loop_token(&dead);
+        drop(dead);
+
+        qi.invalidate();
+        assert!(live.load(Ordering::Acquire), "a live loop must be revoked");
+        assert!(
+            qi.looptokens_wrefs.is_empty(),
+            "invalidate empties the list; a recompile registers again",
+        );
+
+        // A second invalidate with nothing registered is a no-op, and the flag
+        // stays set — `GUARD_NOT_INVALIDATED` has no un-set edge.
+        qi.invalidate();
+        assert!(live.load(Ordering::Acquire));
+    }
+
+    /// `quasiimmut.py:72-82` — a type recompiled many times and never mutated
+    /// must not grow an unbounded watcher list.
+    #[test]
+    fn quasi_immut_register_compresses_dead_loop_tokens() {
+        use std::sync::Arc;
+        use std::sync::atomic::AtomicBool;
+
+        let mut qi = QuasiImmut::new();
+        assert_eq!(qi.compress_limit, 30, "quasiimmut.py:57 compress_limit");
+        for _ in 0..500 {
+            // Each "recompile" drops its artifact immediately, so every
+            // registered weak ref is already dead by the next round.
+            let flag = Arc::new(AtomicBool::new(false));
+            qi.register_loop_token(&flag);
+        }
+        assert!(
+            qi.looptokens_wrefs.len() <= qi.compress_limit + 1,
+            "compress must bound the list, got {} against limit {}",
+            qi.looptokens_wrefs.len(),
+            qi.compress_limit,
+        );
+        // With every entry dead the limit collapses back to the empty-list
+        // value rather than ratcheting upward.
+        assert_eq!(qi.compress_limit, 30);
     }
 
     #[test]


### PR DESCRIPTION
Follow-up to #931. That PR closed the `w_class` half of the LOAD_METHOD method-cache pair by deduplicating a descr split; this closes the `_version_tag` half, and it turned out **not** to be a descr problem at all.

## The hypothesis I started with was wrong

The plan was "apply the same bridge shape — the parentless descr blocks the fold". `type_version_tag_descr()` really did mint a fresh `Arc` on every call, at eight emit sites, with `name: ""`, `index_in_parent: 0`, `parent_descr: None`.

It cost nothing. The read is always off the **pinned type constant**, and the constant path does not key on `descr_identity`; it slots by `OptHeap::field_slot_index` → `Descr::index()` → `stable_field_index(offset, field_size, field_type, signed)`, which is content-derived. Two `Arc`s describing the same field land in the same slot, so the fold hit anyway. Measured on two natively-folded `xs.append` in one body: **2 `_version_tag` reads before opt → 1 in the steady body.** Already deduped.

## What it actually was

The pair survived **only across a residual `CALL_MAY_FORCE`** — and that flush is *correct*, because pyre modelled `_version_tag` as a plain mutable field. Two un-inlined method calls on one instance gave a 41-op steady body with ops 8/11-15 repeated verbatim as 22-27.

The control that settles it: op 26 in that repeat is `W_ObjectObject.map`, a **group-backed descr with a real parent** — and it duplicated too. The cause is the call flush, not the parentless spelling.

Upstream pays none of this: `typeobject.py:177 _immutable_fields_ = ['_version_tag?']`. The read becomes a `QUASIIMMUT_FIELD` marker plus one `GUARD_NOT_INVALIDATED` per trace, which no residual call can flush. `type_version_tag_descr`'s own doc comment already named this as the convergence path, "once pyre wires that write barrier into `mutated()`".

## The blocker was one function

`QuasiimmutField` is fully ported and live — `state.rs:3394` emits it, `heap.rs:3236-3280` records the dep and `Remove`s the op, module globals already use it. But `register_quasi_immutable_deps` (`pyre-jit/src/eval.rs`) sent **every** dep to `module_dict_register_version_watcher`, which early-returns on a non-dict. A type-object dep had nowhere to register, so the flag was never flipped — which is exactly why the field had to stay mutable.

## What this does

Ports `rpython/jit/metainterp/quasiimmut.py`'s `QuasiImmut` — `register_loop_token`, `compress_looptokens_list` (`compress_limit = 30`, `(len + 15) * 2`), and `invalidate` (which empties the list) — onto a new `W_TypeObject.quasi_immut_watchers`. That field stands in for the hidden `mutate__version_tag` the rtyper synthesises upstream; pyre has no rtyper to synthesise it, so it is spelled out, allocated on first registration exactly like its sibling `weak_subclasses`. Pyre's per-artifact `AtomicBool` replaces `looptoken.invalidated = True` + `cpu.invalidate_loop`.

Four seams, deliberately one commit — the invalidation has to exist before the read is folded away:

1. `type_version_tag_descr()` → a `LazyLock` singleton **carrying the quasi-immutable flag**. Not optional: `heap.rs:3274` keys `quasi_immut_cache` on `field_cache_identity`, which is the `Arc` pointer, so a per-call descriptor missed its own cache on every read.
2. The eight fold sites emit through a shared `walker_pin_type_version_tag` — no load, no `GUARD_VALUE`.
3. The invalidation hangs on `w_type_set_version_tag`, the field's **only** writer, so it covers `mutated()`'s fresh identity and both demotions to `0` without asking each caller to remember.
4. `register_quasi_immutable_deps` offers each dep to the type watcher as well as the module-dict one; both registrations self-filter on the object's kind.

## Measurements

| steady body | before | after |
|---|---|---|
| append loop (`v_build`) | 33 | **32** |
| two un-inlined method calls on one instance | 41 | **38** |

Both `_version_tag` reads and both their guards are replaced by a single `GuardNotInvalidated()`, which sits *inside* the steady body — so it re-checks every iteration — and which the residual call between the two call sites no longer flushes.

## Regression coverage, and proof it is not vacuous

New `synth/method_reassign_after_warmup`, four phases: rebind on the class, rebind again (so a stale second-generation trace is caught), rebind on a **base** of the warmed receiver's class (`mutated()`'s subclass walk), and rebind **from inside the loop being traced**. That last one is the case the old live read + `guard_value` used to catch for free; it is closed because the guard is per-iteration.

Commenting out the single `w_type_notify_quasi_immut_watchers` call makes the fixture return **`1 1 1 10 10`** — the stale methods survive. So the fixture is not vacuous and the invalidation is exactly load-bearing.

Its `max-pypy-ratio` is deliberately loose (60) and the header says why: pypy folds this loop to 0.01s at every N tried, so the denominator is collapsed and the ratio measures pypy's constant folding. The differential output is the gate.

## Verification

- `check.py`: **dynasm 355/355, cranelift 355/355**
- `cargo test --release -p pyre-object -p pyre-jit-trace -p majit-metainterp`: **2152 passed, 0 failed**, including two new `QuasiImmut` unit tests (invalidate flips + clears; register compresses dead tokens)
- `w_subclass2`, `retag_force`, `v_build` unchanged on both backends and under `PYRE_NO_JIT`
- Rebased onto current `origin/main` (#931 merged as `f0627903782`) and re-built, re-measured and re-gated on that base

## Known, unchanged by this PR

`W_TypeObject` has no teardown path in this tree — `weak_subclasses` is never freed either — so the watcher box outlives a collected heap type. `compress_looptokens_list` bounds the growth that matters. Registration and notify are unsynchronised `Vec` operations, matching `ModuleDictStrategy::register_version_watcher` and `w_type_add_subclass`.

`str_len_descr()` still mints a fresh `Arc` per call. Same latent shape, currently unobservable — the reads get hoisted out of the loop entirely — so it is left alone rather than changed on speculation.

— *authored by Claude*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime correctness when methods or class attributes are rebound, preventing stale compiled behavior.
  * Ensured optimized execution paths invalidate cached assumptions when type versions change.

* **Performance**
  * Streamlined type-version checks and cache invalidation in optimized code paths.

* **Tests**
  * Added benchmark coverage for method rebinding after warmup, including superclass changes.
  * Added validation for watcher invalidation, cleanup, and bounded resource growth.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->