### PR TITLE
gh#346: PR #932 review follow-ups — slice-only as_ptr fold + getslice fixed-result copy

### DIFF
--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -4489,7 +4489,8 @@ impl<'a> Lowering<'a> {
                 // the recognizer is a capstone that cannot plant its unwired
                 // `getslice` + Void `ConstNone` into the co-wall-blocked
                 // `&args[1..]` graphs without crashing the legacy walker (see
-                // the post-pass note in `simplify_and_finalize`).  Re-enable
+                // the companion note in
+                // `lower_unstructured_with_static_addrs_and_attrs`).  Re-enable
                 // the `slice_index_rangefrom_sites` push here + the post-pass
                 // once those graphs' co-walls close.
                 // Surface every operand through a separate FieldWrite so
@@ -7071,10 +7072,12 @@ impl<'a> Lowering<'a> {
                     self.graph.set_goto(bb_id, target_bb, link_args);
                     return Ok(());
                 }
-                // `<[T]>::as_ptr` / `Vec::as_ptr` — the slice's data pointer is
-                // the receiver value in the erased array-pointer model.  Alias
-                // the result to the receiver (twin of the `as_slice` identity
-                // above and `NonNull::as_ptr`).
+                // `<[T]>::as_ptr` — the slice's data pointer is the receiver
+                // value in the erased array-pointer model.  Alias the result to
+                // the receiver (twin of the `as_slice` identity above and
+                // `NonNull::as_ptr`).  A `Vec::as_ptr` is deliberately excluded
+                // (its items live behind a getfield, not the receiver) — see
+                // `is_container_as_ptr_identity`.
                 if args.len() == 1 && self.is_container_as_ptr_identity(&reg) {
                     self.local_var[dest_local] = Some(args[0].clone());
                     let target_bb = self.block_id[target];
@@ -9410,15 +9413,24 @@ impl<'a> Lowering<'a> {
         })
     }
 
-    /// `<[T]>::as_ptr` / `Vec::as_ptr` — the data-pointer projection of a
-    /// slice or vector receiver.  In the erased value-model a `&[T]` collapses
-    /// to a single GC array pointer (its length is read from the array header
-    /// by `ArrayLen`, not a companion fat-pointer word), so the slice's data
-    /// pointer IS the receiver value.  Alias the result to the receiver — the
-    /// same identity fold as `NonNull::as_ptr` (`nonnull_new_identity_alias`)
-    /// and `as_slice` above — instead of leaving an unregistered
-    /// `core::slice::<Impl>::as_ptr` residual whose only prior handling was a
-    /// `FOREIGN_STDLIB_EXTERNALS` `Address` annotation with no host address.
+    /// `<[T]>::as_ptr` — the data-pointer projection of a slice receiver.  In
+    /// the erased value-model a `&[T]` collapses to a single GC array pointer
+    /// (its length is read from the array header by `ArrayLen`, not a companion
+    /// fat-pointer word), so the slice's data pointer IS the receiver value.
+    /// Alias the result to the receiver — the same identity fold as
+    /// `NonNull::as_ptr` (`nonnull_new_identity_alias`) and `as_slice` above —
+    /// instead of leaving an unregistered `core::slice::<Impl>::as_ptr`
+    /// residual whose only prior handling was a `FOREIGN_STDLIB_EXTERNALS`
+    /// `Address` annotation with no host address.
+    ///
+    /// This is a fixed-array identity ONLY: it mirrors `ll_fixed_items(l) = l`
+    /// (`rlist.py:399`, a `FixedSizeListRepr` IS its items array).  A resized
+    /// list / `Vec` reaches its items buffer through `ll_items(l) = l.items`
+    /// (`rlist.py:368`, a `getfield`), so `alloc::vec::<Impl>::as_ptr` is NOT
+    /// an identity on the receiver and must not fold here — it stays a residual
+    /// (the only two callers, `IntArray`/`FloatArray::from_vec`, are host
+    /// builtins residualised to their compiled bodies, so no traced consumer
+    /// dereferences the folded header).
     fn is_container_as_ptr_identity(&self, reg: &RegularCall) -> bool {
         let CallKind::Fun(FunId::Regular { id }) = &reg.kind else {
             return false;
@@ -9426,7 +9438,7 @@ impl<'a> Lowering<'a> {
         self.llbc.fn_by_id(*id).is_some_and(|fd| {
             matches!(
                 fd.item_meta.name_path().as_str(),
-                "core::slice::<Impl>::as_ptr" | "alloc::vec::<Impl>::as_ptr"
+                "core::slice::<Impl>::as_ptr"
             )
         })
     }

--- a/majit/majit-translate/src/front/slice_index.rs
+++ b/majit/majit-translate/src/front/slice_index.rs
@@ -306,12 +306,19 @@ fn range_feeds_only_index(
             if !reads_range {
                 continue;
             }
-            // A construction `FieldWrite` (base in the closure) writes the
-            // `RangeFrom`'s `start`; the `slice::index` op reads the range as
-            // its `range` operand. Both are removed / rewritten; anything else
-            // is a genuine second consumer.
+            // A construction `FieldWrite` on the `RangeFrom` value writes its
+            // `start`; the `slice::index` op reads the range as its `range`
+            // operand. Both are removed / rewritten; anything else is a genuine
+            // second consumer. The base must be the range value ITSELF, not any
+            // aliased inputarg in the closure: `rewire_one_slice_index_site`'s
+            // removal sweep drops only a `FieldWrite` with `base == range`, so
+            // accepting an aliased-base write here would leave that write
+            // behind after its ctor is removed — an undefined-operand shape
+            // `flowspace_adapter` rejects. `front::mir` emits the ctor and the
+            // `start` write in one block (`base == range`), so this loses no
+            // real site; a range threaded across a block edge declines cleanly.
             let is_construction_write =
-                matches!(&op.kind, OpKind::FieldWrite { base, .. } if in_closure(base));
+                matches!(&op.kind, OpKind::FieldWrite { base, .. } if base == range_result);
             let is_index = op.result.as_ref() == Some(index_result);
             if !(is_construction_write || is_index) {
                 return false;

--- a/majit/majit-translate/src/translator/rtyper/llinterp.rs
+++ b/majit/majit-translate/src/translator/rtyper/llinterp.rs
@@ -1486,6 +1486,54 @@ mod tests {
     }
 
     #[test]
+    fn getoperationhandler_malloc_varsize_rejects_negative_length() {
+        // A `malloc_varsize` whose length is negative must fail before any
+        // allocation: the `usize::try_from(n_signed)` guard turns a `-1` length
+        // into a `TaskError` ("negative varsize length") rather than allocating
+        // a wrapped-huge array. Same graph shape as the write-through test,
+        // stopped at the single failing malloc.
+        use crate::flowspace::model::Constant as FlowConstant;
+        use crate::translator::rtyper::lltypesystem::lltype::Array;
+
+        let char_array = LowLevelType::Array(Box::new(Array::gc(LowLevelType::Char)));
+        let type_c = Hlvalue::Constant(FlowConstant::new(ConstValue::LowLevelType(Box::new(
+            char_array,
+        ))));
+        let flavor_c = Hlvalue::Constant(FlowConstant::new(ConstValue::Dict(
+            std::collections::HashMap::new(),
+        )));
+        let neg_len = Hlvalue::Constant(FlowConstant::new(ConstValue::Int(-1)));
+
+        let arr = Variable::named("arr");
+        let start = Block::shared(vec![]);
+        start.borrow_mut().operations.push(SpaceOperation::new(
+            "malloc_varsize",
+            vec![type_c, flavor_c, neg_len],
+            arr.clone().into(),
+        ));
+
+        let graph = Rc::new(RefCell::new(FunctionGraph::with_return_var(
+            "malloc_neg",
+            start.clone(),
+            arr.clone().into(),
+        )));
+        let returnblock = graph.borrow().returnblock.clone();
+        start.closeblock(vec![
+            Link::new(vec![arr.into()], Some(returnblock), None).into_ref(),
+        ]);
+
+        let interp = Rc::new(LLInterpreter::new(fixture_typer(), false, None));
+        let err = interp
+            .eval_graph(graph as Rc<dyn Any>, Vec::new(), false)
+            .expect_err("negative varsize length must abort evaluation before allocating");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("negative varsize length"),
+            "expected a negative-length rejection, got {msg:?}"
+        );
+    }
+
+    #[test]
     fn build_ll_int2dec_executes_to_decimal_strings() {
         // Slice C: run the synthesised `ll_int2dec` helper graph
         // (`lltypesystem/rstr.rs`) end-to-end through the interpreter and read

--- a/majit/majit-translate/src/translator/rtyper/rlist.rs
+++ b/majit/majit-translate/src/translator/rtyper/rlist.rs
@@ -3340,6 +3340,15 @@ fn emit_listslice_alloc_and_copy(
     newlength: &Variable,
 ) {
     let items_ptr = items_array_ptr_lltype(item_lltype);
+    // The result repr (`hop.r_result`) is a fixed list when the slice is never
+    // resized (`ListDef.offspring` keeps `resized=False`), so `ll_newlist`
+    // returns a bare `Ptr(GcArray)` with no `items` field; a resized result is
+    // a header reaching its array through `items`.  Read the result layout off
+    // its pointer lltype and branch `dst_items` the same way `src_items`
+    // branches on `source_layout` (`ll_arraycopy` uses `dest.ll_items()`,
+    // rlist.py:555-559, which is `ll_fixed_items(l) = l` for a fixed list).
+    let result_layout = list_layout_from_lltype(&result_ptr_lltype)
+        .expect("getslice result lltype must be a list pointer");
     // l = RESLIST.ll_newlist(newlength).
     let new_lst = variable_with_lltype("new_lst", result_ptr_lltype);
     block.borrow_mut().operations.push(SpaceOperation::new(
@@ -3351,8 +3360,7 @@ fn emit_listslice_alloc_and_copy(
         Hlvalue::Variable(new_lst.clone()),
     ));
     // src items (per source layout): a fixed list IS its items array; a resized
-    // header reaches the array through `items`. The result is always resized
-    // (`hop.r_result`), so its items come through `items`.
+    // header reaches the array through `items`.
     let src_items = match source_layout {
         ListLayout::Fixed => Hlvalue::Variable(l.clone()),
         ListLayout::Resized => {
@@ -3365,15 +3373,22 @@ fn emit_listslice_alloc_and_copy(
             Hlvalue::Variable(items)
         }
     };
-    let dst_items = variable_with_lltype("dst_items", items_ptr);
-    block.borrow_mut().operations.push(SpaceOperation::new(
-        "getfield",
-        vec![
-            Hlvalue::Variable(new_lst.clone()),
-            void_field_const("items"),
-        ],
-        Hlvalue::Variable(dst_items.clone()),
-    ));
+    // dst items (per result layout): mirror the source branch above.
+    let dst_items = match result_layout {
+        ListLayout::Fixed => Hlvalue::Variable(new_lst.clone()),
+        ListLayout::Resized => {
+            let items = variable_with_lltype("dst_items", items_ptr);
+            block.borrow_mut().operations.push(SpaceOperation::new(
+                "getfield",
+                vec![
+                    Hlvalue::Variable(new_lst.clone()),
+                    void_field_const("items"),
+                ],
+                Hlvalue::Variable(items.clone()),
+            ));
+            Hlvalue::Variable(items)
+        }
+    };
     // ll_arraycopy(src_items, dst_items, src_start, 0, newlength).
     let copy_void = variable_with_lltype("v", LowLevelType::Void);
     block.borrow_mut().operations.push(SpaceOperation::new(
@@ -3381,7 +3396,7 @@ fn emit_listslice_alloc_and_copy(
         vec![
             Hlvalue::Constant(copy_const),
             src_items,
-            Hlvalue::Variable(dst_items),
+            dst_items,
             src_start,
             signed_const(0),
             Hlvalue::Variable(newlength.clone()),
@@ -3797,13 +3812,14 @@ fn rtype_bltn_list_via_ll_copy(
 ///     return hop.gendirectcall(ll_listslice, cRESLIST, v_lst, *vlist)
 /// ```
 ///
-/// `hop.r_result` is always the resized `ListRepr` (`listdef.offspring` yields
-/// a fresh growable list, unaryop.py:420-423); the receiver's `source_layout`
-/// varies (a `FixedSizeListRepr` slice source is possible). Mints
+/// `hop.r_result` is `listdef.offspring` (unaryop.py:420-423), a fresh list
+/// whose repr is `FixedSizeListRepr` when the slice is never resized and
+/// `ListRepr` otherwise; the receiver's `source_layout` likewise varies. Mints
 /// `ll_arraycopy` (general 5-arg), `ll_newlist`, and the per-`kind`
 /// `ll_listslice_%s` helper in dependency order, then `gendirectcall`s it. The
 /// `cRESLIST` Void const is implicit — the result repr is `hop.r_result`, which
-/// the helper builders read directly.
+/// the helper builders read directly (and off whose lltype they select the
+/// result layout for the destination-items copy).
 fn rtype_getslice_via_ll_listslice(
     hop: &HighLevelOp,
     source_layout: ListLayout,
@@ -6083,6 +6099,74 @@ mod tests {
         }
     }
 
+    /// A runtime `start` that is NOT proved non-negative must be rejected by
+    /// `decompose_slice_args` (rtyper.py:768-770) with "slice start must be
+    /// proved non-negative", the guard that keeps an unsupported slice form off
+    /// the `ll_listslice_*` path. Same hop as the startstop test but with a
+    /// `nonneg == false` start annotation.
+    #[test]
+    fn translate_operation_getslice_non_nonneg_start_is_rejected() {
+        use crate::annotator::model::{SomeInteger, SomeValue};
+        use crate::flowspace::model::SpaceOperation;
+        use std::cell::RefCell as StdRef;
+
+        let ann = RPythonAnnotator::new(None, None, None, false);
+        let rtyper = Rc::new(RPythonTyper::new(&ann));
+        rtyper
+            .initialize_exceptiondata()
+            .expect("initialize_exceptiondata in test setup");
+        let r_int: Arc<dyn Repr> = Arc::new(IntegerRepr::new(LowLevelType::Signed, Some("int_")));
+        let r_list: Arc<dyn Repr> =
+            Arc::new(ListRepr::new(&rtyper, r_int.clone()).expect("ListRepr::new"));
+        let list_lltype = r_list.lowleveltype().clone();
+
+        let v_lst = Variable::new();
+        v_lst.set_concretetype(Some(list_lltype));
+        let v_start = Variable::new();
+        v_start.set_concretetype(Some(LowLevelType::Signed));
+        let v_stop = Variable::new();
+        v_stop.set_concretetype(Some(LowLevelType::Signed));
+        let v_lst_h = Hlvalue::Variable(v_lst);
+        let v_start_h = Hlvalue::Variable(v_start);
+        let v_stop_h = Hlvalue::Variable(v_stop);
+        let result_var = Variable::new();
+        let spaceop = SpaceOperation::new(
+            "getslice".to_string(),
+            vec![v_lst_h.clone(), v_start_h.clone(), v_stop_h.clone()],
+            Hlvalue::Variable(result_var),
+        );
+        let llops = Rc::new(StdRef::new(LowLevelOpList::new(rtyper.clone(), None)));
+        let hop = HighLevelOp::new(rtyper.clone(), spaceop, Vec::new(), llops);
+        hop.args_v.borrow_mut().push(v_lst_h);
+        hop.args_s.borrow_mut().push(SomeValue::Impossible);
+        hop.args_r.borrow_mut().push(Some(r_list.clone()));
+        // A runtime start that is NOT proved non-negative.
+        hop.args_v.borrow_mut().push(v_start_h);
+        hop.args_s
+            .borrow_mut()
+            .push(SomeValue::Integer(SomeInteger::new(
+                /* nonneg */ false, false,
+            )));
+        hop.args_r.borrow_mut().push(Some(r_int.clone()));
+        hop.args_v.borrow_mut().push(v_stop_h);
+        hop.args_s
+            .borrow_mut()
+            .push(SomeValue::Integer(SomeInteger::new(
+                /* nonneg */ true, false,
+            )));
+        hop.args_r.borrow_mut().push(Some(r_int.clone()));
+        *hop.r_result.borrow_mut() = Some(r_list.clone());
+
+        let err = rtyper
+            .translate_operation(&hop)
+            .expect_err("a non-nonneg slice start must fail decompose_slice_args");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("slice start must be proved non-negative"),
+            "expected the non-negative start rejection, got {msg:?}"
+        );
+    }
+
     /// `l[start:]` — non-constant nonneg start, constant `None` stop —
     /// decomposes to `"startonly"` (rtyper.py:778-779) and lowers to
     /// `gendirectcall(ll_listslice_startonly, l, start)` (rlist.py:883-890).
@@ -6159,6 +6243,96 @@ mod tests {
         assert!(
             names.iter().any(|n| n == "ll_listslice_startonly"),
             "getslice [start:] must mint an ll_listslice_startonly helper graph, got {names:?}"
+        );
+    }
+
+    /// A `[start:]` slice whose result is never resized takes a
+    /// `FixedSizeListRepr` result (`listdef.offspring` keeps `resized=False`),
+    /// so `ll_newlist` returns a bare `Ptr(GcArray)` with no `items` field. The
+    /// minted `ll_listslice_startonly` helper must therefore select `dst_items`
+    /// as the result array ITSELF (`ll_fixed_items(l) = l`, rlist.py:411) and
+    /// emit NO `getfield("items")` — a fixed source AND a fixed result yield a
+    /// getfield-free copy body. A regression that hardcodes `getfield(new_lst,
+    /// "items")` would target a nonexistent field and reintroduce a getfield.
+    #[test]
+    fn translate_operation_getslice_startonly_fixed_result_has_no_dst_items_getfield() {
+        use crate::annotator::model::{SomeInteger, SomeValue, s_none};
+        use crate::flowspace::model::{Constant, SpaceOperation};
+        use std::cell::RefCell as StdRef;
+
+        let ann = RPythonAnnotator::new(None, None, None, false);
+        let rtyper = Rc::new(RPythonTyper::new(&ann));
+        rtyper
+            .initialize_exceptiondata()
+            .expect("initialize_exceptiondata in test setup");
+        let r_int: Arc<dyn Repr> = Arc::new(IntegerRepr::new(LowLevelType::Signed, Some("int_")));
+        // Both the source and the result are FIXED lists: the receiver is a
+        // never-resized `&[T]`-shaped list and the slice result is likewise
+        // never resized, so both reach their array without an `items` field.
+        let r_list: Arc<dyn Repr> = Arc::new(
+            FixedSizeListRepr::new(&rtyper, r_int.clone()).expect("FixedSizeListRepr::new"),
+        );
+        let list_lltype = r_list.lowleveltype().clone();
+
+        let v_lst = Variable::new();
+        v_lst.set_concretetype(Some(list_lltype));
+        let v_start = Variable::new();
+        v_start.set_concretetype(Some(LowLevelType::Signed));
+        let v_lst_h = Hlvalue::Variable(v_lst);
+        let v_start_h = Hlvalue::Variable(v_start);
+        let c_stop = Hlvalue::Constant(Constant::new(ConstValue::None));
+        let result_var = Variable::new();
+        let spaceop = SpaceOperation::new(
+            "getslice".to_string(),
+            vec![v_lst_h.clone(), v_start_h.clone(), c_stop.clone()],
+            Hlvalue::Variable(result_var),
+        );
+        let llops = Rc::new(StdRef::new(LowLevelOpList::new(rtyper.clone(), None)));
+        let hop = HighLevelOp::new(rtyper.clone(), spaceop, Vec::new(), llops);
+        hop.args_v.borrow_mut().push(v_lst_h);
+        hop.args_s.borrow_mut().push(SomeValue::Impossible);
+        hop.args_r.borrow_mut().push(Some(r_list.clone()));
+        hop.args_v.borrow_mut().push(v_start_h);
+        hop.args_s
+            .borrow_mut()
+            .push(SomeValue::Integer(SomeInteger::new(
+                /* nonneg */ true, false,
+            )));
+        hop.args_r.borrow_mut().push(Some(r_int.clone()));
+        hop.args_v.borrow_mut().push(c_stop);
+        hop.args_s.borrow_mut().push(s_none());
+        hop.args_r.borrow_mut().push(Some(r_int.clone()));
+        // The slice result is a fresh FIXED list (never resized).
+        *hop.r_result.borrow_mut() = Some(r_list.clone());
+
+        rtyper
+            .translate_operation(&hop)
+            .expect("translate_operation getslice must dispatch to rtype_getslice")
+            .expect("getslice returns the fresh list Variable");
+
+        // Inspect the minted `ll_listslice_startonly` helper body: with a fixed
+        // source and a fixed result, neither `src_items` nor `dst_items` reads
+        // an `items` field, so the copy body carries zero `getfield` ops.
+        let translator = ann.translator.clone();
+        let graphs = translator.graphs.borrow();
+        let helper = graphs
+            .iter()
+            .find(|g| g.borrow().name == "ll_listslice_startonly")
+            .expect("getslice [start:] must mint an ll_listslice_startonly helper graph");
+        // The listslice helper is a single-block graph; its whole copy body
+        // lives in the startblock.
+        let getfields: usize = helper
+            .borrow()
+            .startblock
+            .borrow()
+            .operations
+            .iter()
+            .filter(|op| op.opname == "getfield")
+            .count();
+        assert_eq!(
+            getfields, 0,
+            "a fixed-source, fixed-result getslice must not read an `items` field \
+             (ll_newlist returns a bare array); found {getfields} getfield op(s)"
         );
     }
 


### PR DESCRIPTION
Follow-up to #932 (merged), addressing the automated review findings on that PR. Each finding was verified against the current tree before acting; two were real-but-latent bugs, two were declined with rationale, and two were test-coverage gaps.

## Fixed

- **`as_ptr` identity fold restricted to slices** (`front/mir.rs`). The fold aliased both `core::slice::<Impl>::as_ptr` and `alloc::vec::<Impl>::as_ptr` to the receiver. A fixed list IS its array (`ll_fixed_items(l)=l`, rlist.py:399) so the slice arm is parity-correct, but a resized list / `Vec` reaches its items via `ll_items(l)=l.items` (rlist.py:368, a getfield) — aliasing a `Vec::as_ptr` result to the receiver hands out the header, not the items buffer. Dropped the Vec arm. Census-neutral (1151→1151): the only two `Vec::as_ptr` sites (`IntArray`/`FloatArray::from_vec`) are host builtins residualised to their compiled bodies, so no traced consumer dereferenced the folded header.

- **`getslice` fixed-result `dst_items`** (`rtyper/rlist.rs`). `emit_listslice_alloc_and_copy` hardcoded `getfield(new_lst, "items")` for the destination, which is wrong for a `FixedSizeListRepr` result (`ll_newlist` returns a bare `Ptr(GcArray)` with no items field; `ListDef.offspring` keeps `resized=False` for a never-resized slice). Now branches `dst_items` on the result layout, read off `result_ptr_lltype`, mirroring the `src_items` source-layout branch. Latent today (only the dormant `front/slice_index.rs` recognizer produces a fixed-result getslice), fixed before it can activate.

## Tests added

- Fixed-result getslice asserts the minted `ll_listslice_startonly` helper carries no `items` getfield.
- Non-nonneg slice-start rejection (`decompose_slice_args` "slice start must be proved non-negative").
- Negative-length `malloc_varsize` rejection in the llinterp.

## Also

- Fixed a stale `simplify_and_finalize` cross-reference in the dormant slice_index note.
- Aligned `slice_index`'s consumer gate `FieldWrite` base (`base == range`) with its removal sweep.

## Declined (with rationale, no change)

- **`__discriminant` niche gate** (CodeRabbit): FALSE POSITIVE. The proposed `tyref_is_niche_option_ptr` tightening is unimplementable in the rtyper (`TyRef`/`LLBC` are front-only), the fabricated-0/1 case is non-constructible (aggregate enums register `__discriminant` → handled before the fold; `can_be_none==false`), and non-nullable receivers already fall through to `getclsfield`→`TyperError`.
- **`encode_op` panic on unlowered `ConstNone`/`GetSlice`** (CodeRabbit): the handler-less distinctive opnames are intentional, mirroring the NewList capstone — a dropped-to-legacy graph trips the `default_bh_builder_unwired_set` snapshot. Panicking would remove the signal the snapshot depends on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)