### PR TITLE
jit: fix a lost conditional store in an inlined callee, widen the method-form inline

### DIFF
--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -3414,6 +3414,38 @@ impl TraceCtx {
         self.box_value(elem)
     }
 
+    /// Resolve the array-base `OpRef` (`frame.locals_cells_stack_w`) for a
+    /// NONSTANDARD virtualizable the way `opimpl_getfield_gc_r` does
+    /// (`_opimpl_getfield_gc_any_pureornot`, pyjitpl.py): forward the cached
+    /// field box on a hit, otherwise record the `GetfieldGcR` once and publish
+    /// it with `getfield_now_known`.
+    ///
+    /// Every `getarrayitem_vable` / `setarrayitem_vable` on such a frame has to
+    /// come through here, because the per-array element cache is keyed by this
+    /// base `OpRef`.  Recording a fresh base per access instead keys each store
+    /// under an `OpRef` no read ever looks up, so a store neither updates nor
+    /// invalidates the entry the reads share — a local written after the read
+    /// that seeded the cache then keeps reading its pre-store value for as long
+    /// as the base stays cached.
+    fn nonstandard_vable_array_base(&mut self, vable_opref: OpRef, fdescr: &DescrRef) -> OpRef {
+        let record_descr = self.vable_array_record_descr(fdescr);
+        let field_index = record_descr.index();
+        if let Some(cached) = self.heapcache_getfield_cached(vable_opref, field_index) {
+            self.profiler().count_ops(
+                OpCode::GetfieldGcR,
+                crate::pyjitpl::counters::HEAPCACHED_OPS,
+            );
+            return cached;
+        }
+        self.profiler()
+            .count_ops(OpCode::GetfieldGcR, crate::counters::OPS);
+        self.profiler()
+            .count_ops(OpCode::GetfieldGcR, crate::counters::RECORDED_OPS);
+        let op = self.record_op_with_descr(OpCode::GetfieldGcR, &[vable_opref], record_descr);
+        self.heapcache_getfield_now_known(vable_opref, field_index, op);
+        op
+    }
+
     /// pyjitpl.py:1167-1172 `opimpl_getfield_vable_i(box, fielddescr, pc)`.
     ///
     /// ```text
@@ -4025,13 +4057,7 @@ impl TraceCtx {
         if self.is_nonstandard_virtualizable(pc, vable_opref, &fdescr, concrete) {
             // arraybox = self.opimpl_getfield_gc_r(box, fdescr)
             // return self.opimpl_getarrayitem_gc_i(arraybox, indexbox, adescr)
-            let record_descr = self.vable_array_record_descr(&fdescr);
-            self.profiler()
-                .count_ops(OpCode::GetfieldGcR, crate::counters::OPS);
-            self.profiler()
-                .count_ops(OpCode::GetfieldGcR, crate::counters::RECORDED_OPS);
-            let array_opref =
-                self.record_op_with_descr(OpCode::GetfieldGcR, &[vable_opref], record_descr);
+            let array_opref = self.nonstandard_vable_array_base(vable_opref, &fdescr);
             return (
                 self.vable_getarrayitem_int_descr(array_opref, index, adescr),
                 None,
@@ -4103,13 +4129,7 @@ impl TraceCtx {
                 index,
                 adescr.index(),
             );
-            let record_descr = self.vable_array_record_descr(&fdescr);
-            self.profiler()
-                .count_ops(OpCode::GetfieldGcR, crate::counters::OPS);
-            self.profiler()
-                .count_ops(OpCode::GetfieldGcR, crate::counters::RECORDED_OPS);
-            let array_opref =
-                self.record_op_with_descr(OpCode::GetfieldGcR, &[vable_opref], record_descr);
+            let array_opref = self.nonstandard_vable_array_base(vable_opref, &fdescr);
             let item = self.vable_getarrayitem_ref_descr(array_opref, index, adescr);
             if let Some(v) = fwd {
                 self.set_opref_concrete(item, v);
@@ -4174,13 +4194,7 @@ impl TraceCtx {
     ) -> (OpRef, Option<Value>) {
         let concrete = self.concrete_of_opref(vable_opref);
         if self.is_nonstandard_virtualizable(pc, vable_opref, &fdescr, concrete) {
-            let record_descr = self.vable_array_record_descr(&fdescr);
-            self.profiler()
-                .count_ops(OpCode::GetfieldGcR, crate::counters::OPS);
-            self.profiler()
-                .count_ops(OpCode::GetfieldGcR, crate::counters::RECORDED_OPS);
-            let array_opref =
-                self.record_op_with_descr(OpCode::GetfieldGcR, &[vable_opref], record_descr);
+            let array_opref = self.nonstandard_vable_array_base(vable_opref, &fdescr);
             return (
                 self.vable_getarrayitem_float_descr(array_opref, index, adescr),
                 None,
@@ -4244,18 +4258,12 @@ impl TraceCtx {
     ) -> bool {
         let vable_concrete = self.concrete_of_opref(vable_opref);
         if self.is_nonstandard_virtualizable(pc, vable_opref, &fdescr, vable_concrete) {
-            let record_descr = self.vable_array_record_descr(&fdescr);
-            self.profiler()
-                .count_ops(OpCode::GetfieldGcR, crate::counters::OPS);
-            self.profiler()
-                .count_ops(OpCode::GetfieldGcR, crate::counters::RECORDED_OPS);
-            let array_opref =
-                self.record_op_with_descr(OpCode::GetfieldGcR, &[vable_opref], record_descr);
+            let array_opref = self.nonstandard_vable_array_base(vable_opref, &fdescr);
             self.profiler()
                 .count_ops(OpCode::SetarrayitemGc, crate::counters::OPS);
             self.profiler()
                 .count_ops(OpCode::SetarrayitemGc, crate::counters::RECORDED_OPS);
-            self.vable_setarrayitem_descr(array_opref, index, value, adescr);
+            self.execute_setarrayitem_gc(array_opref, index, value, adescr);
             return true;
         }
         // index = self._get_arrayitem_vable_index(pc, fdescr, indexbox)
@@ -4487,6 +4495,29 @@ impl TraceCtx {
         descr: DescrRef,
     ) {
         self.record_op_with_descr(OpCode::SetarrayitemGc, &[array_opref, index, value], descr);
+    }
+
+    /// `execute_setarrayitem_gc(arraydescr, arraybox, indexbox, itembox)`
+    /// (pyjitpl.py): record the `SETARRAYITEM_GC`, then publish the stored item
+    /// to the heapcache.  `gen_store_back_in_vable` deliberately does NOT come
+    /// through here — it records the op directly — so the raw recording form
+    /// stays available as `vable_setarrayitem_descr`.
+    ///
+    /// The heapcache write is what keeps a later read of the same slot from
+    /// forwarding the value the cache was seeded with: the element cache is the
+    /// only thing a nonstandard virtualizable's reads consult for the stored
+    /// box, so a store that skips it leaves every subsequent read answering the
+    /// pre-store value.
+    fn execute_setarrayitem_gc(
+        &mut self,
+        array_opref: OpRef,
+        index: OpRef,
+        value: OpRef,
+        descr: DescrRef,
+    ) {
+        let descr_index = descr.index();
+        self.vable_setarrayitem_descr(array_opref, index, value, descr);
+        self.heapcache_setarrayitem(array_opref, index, descr_index, value);
     }
 }
 

--- a/pyre/bench/synth/inline_subwalk_mutating_residual.py
+++ b/pyre/bench/synth/inline_subwalk_mutating_residual.py
@@ -1,4 +1,4 @@
-# pyre-check: max-pypy-ratio=200
+# pyre-check: max-pypy-ratio=40
 # gh#495 guard: an inlined subwalk whose callee makes an unjournaled mutation
 # through a nested residual CALL, in the two miss-handling shapes.
 #

--- a/pyre/bench/synth/inline_subwalk_property_mutates.py
+++ b/pyre/bench/synth/inline_subwalk_property_mutates.py
@@ -1,4 +1,4 @@
-# pyre-check: max-pypy-ratio=80
+# pyre-check: max-pypy-ratio=50
 # gh#495 guard: inlined property residual mutates before branch and caught miss.
 # @property value-returning mutating + try/except-inside-callee raising branch
 N = 60000

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -413,6 +413,13 @@ pub(crate) fn callee_body_contains_raise(body_code: &[u8]) -> bool {
     false
 }
 
+/// Whether a method-form callee body is free of `LoadAttr` residuals.
+///
+/// Consulted only by the entries that pass `allow_method_load_attr = false`.
+/// A `self.attr` read in the body is what makes it answer `false`, which is the
+/// common shape (`def at(self, i): return self.v + i`), so an entry that opts
+/// out of the check trades a narrower inline surface for the ability to inline
+/// ordinary accessor methods.
 pub(crate) fn method_form_callee_body_supported(
     body_code: &[u8],
     callee_descr_refs: &[DescrRef],
@@ -1742,7 +1749,7 @@ pub(crate) fn try_walker_inline_user_call<Sym: WalkSym>(
         has_closure,
         None,
         None,
-        false,
+        true,
         false,
         None,
     )

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -2696,6 +2696,12 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
     if !bridge_rec_root_selfrec && fbw_hazardous_inline_denied(callee_code_key) {
         return Ok(None);
     }
+    // True when only the widened method-form surface reaches this callee: an
+    // unbound `self.attr` accessor body, which the narrow surface declines.
+    let widened_method_form = method_form
+        && bound_method.is_none()
+        && allow_method_load_attr
+        && !method_form_callee_body_supported(body.code, callee_descr_refs);
     // A legacy, unseeded inline sub-walk inside a FOR_ITER body resumes a guard
     // at the caller's CALL boundary, so deopt re-executes the whole callee.
     // Replaying a live-heap mutation would double it, so a Dirty body stays on
@@ -2732,8 +2738,16 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
                 // iteration's contribution is dropped, silently.  A `Clean`
                 // body is still admitted from there — it has nothing that can
                 // abort.
-                foriter_deferred_admit =
-                    arg_class_guard.is_none() && !fbw_foriter_deferred_call_denied(callee_code_key);
+                //
+                // The widened method-form surface stays out: its deferred call
+                // is the `self.attr` read's own dispatch, which the lever
+                // resolves to a builtin rather than a body it can inline, so the
+                // admission spends the abort and then denies the callee anyway.
+                // Declining here reaches the same residual call without retiring
+                // the enclosing loop.
+                foriter_deferred_admit = arg_class_guard.is_none()
+                    && !widened_method_form
+                    && !fbw_foriter_deferred_call_denied(callee_code_key);
                 foriter_deferred_admit
             }
             CalleeReplaySafety::Dirty => {
@@ -2765,12 +2779,30 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
             return Ok(None);
         }
     }
-    if method_form
-        && bound_method.is_none()
-        && !allow_method_load_attr
-        && !method_form_callee_body_supported(body.code, callee_descr_refs)
-    {
-        return Ok(None);
+    if method_form && bound_method.is_none() {
+        // Two surfaces for an unbound method-form callee.  The narrow one
+        // declines any `self.attr` read in the body.  The wide one admits it,
+        // and pays for the reach with a body that raises: the sub-walk records
+        // into the handler region, and a guard whose resume coordinate lands on
+        // the `Reraise` needs ref registers the recorded path never wrote
+        // (`collect_callee_active_boxes`).  That decline arrives mid-recording
+        // on a non-effect-free opcode, so it has no mid-body carrier and the
+        // whole enclosing loop is discarded.  Decline such a body here instead,
+        // where the call simply stays residual and the loop still compiles.
+        let declined = if allow_method_load_attr {
+            callee_body_contains_raise(body.code)
+        } else {
+            !method_form_callee_body_supported(body.code, callee_descr_refs)
+        };
+        if declined {
+            if std::env::var_os("PYRE_FBW_INLINE_DIAG").is_some() {
+                eprintln!(
+                    "[inline-method-form] decline pc={} allow_load_attr={allow_method_load_attr}",
+                    op.pc
+                );
+            }
+            return Ok(None);
+        }
     }
     if std::env::var("PYRE_FBW_INLINE_DIAG").is_ok() {
         let mut pc = 0usize;


### PR DESCRIPTION
Four commits. **The performance table in the original description of this PR was wrong; it has been replaced — see "Correction" at the bottom.**

### `majit: keep the nonstandard vable element heapcache in sync`

Wrong-code fix, and the reason this branch exists. A force-materialized inline-callee frame's `locals_cells_stack_w` takes the nonstandard-virtualizable path, whose element heapcache (a) keyed reads and writes off different `GetfieldGcR` array-base `OpRef`s and (b) recorded a `SETARRAYITEM_GC` without updating the cache. Reads therefore kept returning the value seeded at frame construction.

Repro — `i += 1` writes `W_Int(2189)` to slot 1, and the immediately following `LOAD_FAST i` pushes the stale `W_Int(2188)`:

```python
def step(s, i):
    c = s[i]
    if c == 9:
        i += 1
        c = c + s[i]
    return c, i + 1

src = [9, 2, 5, 6] * 1000
i = 0; out = []
while i < len(src):
    c, i = step(src, i)
    out.append(c)
# want [11, 5, 6] * 1000; got a 3001-element list with c == 18 entries
```

`origin/main` prints `BAD len=3001`; this branch prints `OK`.

`trace_ctx.rs` gains `nonstandard_vable_array_base` (forwards the cached field box on a hit, publishes with `getfield_now_known`) and `TraceCtx::execute_setarrayitem_gc` (records, then calls `heapcache.setarrayitem`). `gen_store_back_in_vable` keeps the raw `vable_setarrayitem_descr`.

This commit is worth **0.98x–1.00x** — it is a correctness fix with no measurable performance effect.

### `jit: inline a method-form callee whose body reads self.attr`

`try_walker_inline_user_call` passed `allow_method_load_attr = false`, so `method_form_callee_body_supported` declined every `b.at(i)` whose callee body contains a `LoadAttr` residual — the ordinary accessor shape `def at(self, i): return self.v + i`. The same callee already inlined when stored as a bound method (`m = b.at; m(i)`).

### `jit: decline the widened method-form inline for raise-bearing and FOR_ITER-deferred callees`

The widening on its own discarded the enclosing loop for two body shapes:

- A body containing a `raise`. The sub-walk records into the handler region, and a guard whose resume coordinate lands on the `Reraise` asks `collect_callee_active_boxes` for ref registers the recorded path never wrote. The decline arrives mid-recording on an opcode that is not effect-free, so it has no mid-body carrier.
- A FOR_ITER `CalleeReplaySafety::DeferredCall` admission whose deferred call resolves to a builtin: `fbw_abort_nested_unjournaled_residual` spends one abort and then denies the callee.

### `jit: key the raise decline on widened_method_form, not allow_method_load_attr`

The commit above keyed the raise decline on `allow_method_load_attr`. Five entries pass that flag, and four of them — the `type.__call__` `__init__` fold, the exception `__str__`/`__repr__` override, and the property getter and setter — passed it *before* the widening, so the decline also withdrew inlines that already happened. A method-form body with no attribute read has `method_form_callee_body_supported == true`, hence `widened_method_form == false`, and is now admitted again.

```python
class B:
    def bump(self, n):
        if n < 0:
            raise ValueError(n)
        return n + 1
for i in range(400000): t += b.bump(i)
```

| | origin/main | before | after |
|---|---|---|---|
| dynasm | 0.011s | 0.504s | 0.022s |
| cranelift | 0.021s | 0.418s | 0.018s |

None of the 357 synthetic benches covered this shape.

## Measurements

Against a binary built from `origin/main`, min of 7 interleaved runs, user+sys CPU with empty-program startup subtracted. The two binaries were checked apart by the wrong-code repro above (`main` → `BAD len=3001`, branch → `OK`).

| bench | dynasm main → branch | cranelift main → branch |
|---|---|---|
| `synth/inline_subwalk_mutating_residual` | 0.225s → 0.075s (**3.0x**) | 0.363s → 0.089s (**4.1x**) |
| `synth/sre_pattern_methods` | 0.592s → 0.600s (0.99x) | 0.652s → 0.658s (0.99x) |
| `synth/sre_wasm_min` | 0.325s → 0.341s (0.95x) | 0.381s → 0.380s (1.00x) |
| `synth/sre_wasm_min1` | 0.250s → 0.248s (1.01x) | 0.285s → 0.285s (1.00x) |
| `synth/type_metatype_method_call` | 0.079s → 0.091s (0.88x) | 0.086s → 0.075s (1.15x) |
| `property_mutates` / `radd_consumed` / `user_iterator` / `getframe_multiframe` | 0.94x–1.08x | 0.94x–1.03x |

Splitting the win by commit on `inline_subwalk_mutating_residual` (min of 9 interleaved runs): the heapcache fix alone is 0.98x (dynasm) / 1.00x (cranelift); the widening plus its declines is 3.89x / 3.82x. **The entire measured gain comes from the widening, and the entire correctness gain from the fix.**

`inline_subwalk_mutating_residual`'s gate moves 200 → 40 and `inline_subwalk_property_mutates`'s 80 → 50.

## Verification

- `check.py --backend dynasm` 357/357
- `check.py --backend cranelift` 357/357
- `cargo test --all --no-default-features` 7324 passed, 0 failed (run before the last commit)

## Correction

The first version of this description claimed `sre_pattern_methods` 0.90s → 0.67s, `sre_wasm_min` 0.55s → 0.43s and similar gains on four benches. Those numbers were real but did not mean what the description said: the "before" arm carried the heapcache fix and differed from the "after" arm only by the widening, so the table measured the widening's own regression being repaired, not an improvement over `main`. Against `main` those four benches are flat. A second error compounded it — `check.py` runs `cargo build` itself (`pyre/check.py:993`), so an A/B done by swapping prebuilt binaries into `target/release` runs the same build on both arms.

## Note on #935

#935 carries `0d8413d3c4` and `3f560c4ca0`, which are patch-id-identical to this PR's first two commits (`b2a00ef0…` and `c36e7c6e…`), plus five unrelated commits. It does not carry the two decline commits, so it is expected to reproduce both the loop-discard on the sre benches and the 46x/20x raise-body regression. This repository squash-merges, so after this PR lands the squashed commit's patch-id will match neither original and rebase dedup will not drop them — they have to be dropped from #935 explicitly.

— *authored by Claude*