### PR TITLE
pyframe, majit-gc: read frames back out of their roots; settle the frame allocation contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -198,7 +198,17 @@ execution-context-local, or genuinely thread-local.
 
 ## Before Committing
 - Always run `cargo check` and `cargo test` with `--features dynasm`.
-- Run full benchmark suite (all 8 benchmarks) after JIT changes - do not commit if any regress.
+- Run the full benchmark suite (all 8 benchmarks) after JIT changes. A regression
+  is a finding to explain, not an automatic veto. The `/parity` skill's
+  Principle 4 governs: *"Performance can temporarily regress. If a benchmark
+  slows down because parity-correct code replaced a clever local shortcut,
+  accept it. Performance is recovered by further line-by-line porting of the
+  upstream optimization, not by reintroducing the shortcut."* So: if the slower
+  code is the line-by-line port and the faster code was the shortcut, the port
+  stands — record the regression and name the upstream optimization that would
+  recover it. Revert only when the regression has no such explanation. This file
+  is loaded every session and Principle 4 is not; do not restate the rule here
+  in a form that contradicts it.
 - Check `git status` and `git rev-parse --show-toplevel` before staging to confirm correct worktree.
 - When rebasing/cherry-picking, verify the fix isn't already on main first (`git log main --grep=...`).
 

--- a/majit/majit-gc/src/shadow_stack.rs
+++ b/majit/majit-gc/src/shadow_stack.rs
@@ -503,20 +503,36 @@ pub fn push(gcref: GcRef) -> usize {
 
 /// Pop entries from the shadow stack back to the given depth.
 ///
+/// `shadowstack.py:86-90 decr_stack` moves `root_stack_top` and returns it;
+/// the popped slots are not read back, and `pop_stack` (`:104-106`) is the
+/// separate operation for callers that want the value.  Shortening in place
+/// mirrors that.  Returning the popped entries instead — `Vec::split_off`,
+/// which this was — makes every root-scope exit a `malloc` + `memcpy` and
+/// leaves the caller a `free`, and no caller reads the result.
+///
+/// `depth` is asserted rather than saturated: every caller pairs this with a
+/// depth it pushed, so a too-large `depth` is an unbalanced scope, and
+/// silently shortening to nothing would strand roots the collector still
+/// needs.  A plain `assert!` and not `debug_assert!` — this crate is
+/// extracted to LLBC, where debug assertions are compiled in.
+///
 /// TODO: Rust drops thread-locals in reverse order on
 /// thread exit, and a TLS-owned `Drop` (e.g. `JitDriver`'s) may call
 /// this during its own teardown. If
 /// `SHADOW_STACK`'s destructor has already fired, `.with()` panics with
 /// `AccessError`. RPython has no analogous hazard — the GIL thread does
-/// not tear down TLS mid-run. Silently return an empty Vec so the
-/// exiting thread proceeds.
-pub fn pop_to(depth: usize) -> Vec<GcRef> {
-    SHADOW_STACK
-        .try_with(|ss| {
-            let mut ss = ss.borrow_mut();
-            ss.entries.split_off(depth)
-        })
-        .unwrap_or_default()
+/// not tear down TLS mid-run. Silently do nothing so the exiting thread
+/// proceeds.
+pub fn pop_to(depth: usize) {
+    let _ = SHADOW_STACK.try_with(|ss| {
+        let mut ss = ss.borrow_mut();
+        assert!(
+            depth <= ss.entries.len(),
+            "shadow stack pop_to({depth}) above depth {}",
+            ss.entries.len(),
+        );
+        ss.entries.truncate(depth);
+    });
 }
 
 /// Like `pop_to` but silently no-ops if the shadow stack thread-local
@@ -1432,11 +1448,22 @@ mod tests {
         push(b);
         assert_eq!(super::depth(), 2);
 
-        let popped = pop_to(depth);
-        assert_eq!(popped.len(), 2);
-        assert_eq!(popped[0], a);
-        assert_eq!(popped[1], b);
+        assert_eq!(super::get(0), a);
+        assert_eq!(super::get(1), b);
+
+        pop_to(depth);
         assert_eq!(super::depth(), 0);
+    }
+
+    #[test]
+    #[should_panic(expected = "shadow stack pop_to")]
+    fn test_pop_to_above_depth_panics() {
+        let _lock = TEST_MUTEX.lock().unwrap_or_else(|p| p.into_inner());
+        clear();
+        push(GcRef(0x1000));
+        // An unbalanced scope must not silently no-op: truncating past the
+        // top would strand the roots below it.
+        pop_to(5);
     }
 
     #[test]

--- a/majit/majit-gc/src/shadow_stack.rs
+++ b/majit/majit-gc/src/shadow_stack.rs
@@ -876,6 +876,29 @@ pub fn jf_depth() -> usize {
 /// custom_trace), exactly as in RPython where `root_walker.walk_roots()`
 /// copies the jitframe, and then `jitframe_trace` (custom_trace hook)
 /// traces the gcmap-indicated ref slots during Phase 2.
+///
+/// The marker word is stepped over, not consumed. `walk_stack_root`
+/// (`shadowstack.py:44-70`) treats an odd slot as a skip bitmask: on a minor
+/// collection it negates an unmarked one and *returns* at an already-marked
+/// one, so the walk stops instead of descending further. Porting that loop
+/// here would be porting a no-op. Upstream keeps one root stack per thread, so
+/// the stoppers the JIT writes sit interleaved among interpreter roots and
+/// returning early skips those; this stack holds jitframe pointers only, and
+/// the deep interpreter stacks (`pyre_object::gc_roots`, `SHADOW_STACK`)
+/// carry no stopper to stop on. The early return becomes reachable once those
+/// stacks are one stack, not before.
+///
+/// It would also be unsound on its own: upstream disables the optimization for
+/// the first minor collection after a thread switch
+/// (`can_look_at_partial_stack`, `shadowstack.py:112-126`) and whenever the
+/// nursery holds objects pinned before the previous minor collection
+/// (`any_pinned_object_from_earlier`, `incminimark.py:1996-2006`). Neither
+/// condition has a counterpart here — `Collector::pinned_objects` does not
+/// distinguish pins carried over from an earlier cycle.
+///
+/// The marker is still written, by every backend, because the two-word entry
+/// is the layout the merge converges on; `test_jf_flat_array_layout` is what
+/// currently holds the writers to it.
 pub fn walk_jf_roots(mut visitor: impl FnMut(&mut GcRef)) {
     JF_ROOT_STACK.with(|stack| {
         let mut stack = stack.borrow_mut();

--- a/majit/majit-gc/src/shadow_stack.rs
+++ b/majit/majit-gc/src/shadow_stack.rs
@@ -584,24 +584,37 @@ pub fn release_owner_root(index: usize) {
 /// RAII owner for one fixed translated-livevar root slot.
 pub struct OwnerRootGuard {
     index: usize,
-    /// `index` names a slot in the ACQUIRING thread's `OWNER_ROOTS`, so the
-    /// guard must not outlive that thread's stack frame.  Bare `usize` would
-    /// make it auto-`Send`, and dropping it elsewhere would release a foreign
-    /// thread's slot (or trip the inactive-slot assert).  The raw-pointer
-    /// marker pins it to one thread at compile time.
-    _not_send: std::marker::PhantomData<*mut ()>,
+    /// Address of the ACQUIRING thread's `OWNER_ROOTS` cell, resolved once.
+    ///
+    /// A guard is read back on every access to the value it roots, so paying
+    /// the thread-local resolution (`_tlv_get_addr` on macOS) each time would
+    /// make re-reading the root cost more than the stale copy it replaces.
+    /// The cell never moves once created — the same invariant `MutatorEntry`
+    /// and [`ShadowStackSlot`] rely on — and RPython's translated code
+    /// likewise resolves its root-stack base once per function
+    /// (`gc_enter_roots_frame`) and then addresses slots by fixed offset.
+    ///
+    /// It also pins the guard to one thread: `index` names a slot in that
+    /// thread's `OWNER_ROOTS`, and a bare `usize` would make the guard
+    /// auto-`Send`, so dropping it elsewhere would release a foreign thread's
+    /// slot (or trip the inactive-slot assert).
+    roots: *const RefCell<Vec<Option<GcRef>>>,
 }
 
 impl OwnerRootGuard {
     pub fn new(root: GcRef) -> Self {
         Self {
             index: acquire_owner_root(root),
-            _not_send: std::marker::PhantomData,
+            roots: OWNER_ROOTS.with(|roots| roots as *const _),
         }
     }
 
+    #[inline]
     pub fn get(&self) -> GcRef {
-        OWNER_ROOTS.with(|roots| roots.borrow()[self.index].expect("inactive owner-root guard"))
+        // SAFETY: `roots` is this thread's own `OWNER_ROOTS` cell, alive for
+        // as long as the guard (which cannot leave the thread), and the slot
+        // stays acquired until `Drop`.
+        unsafe { (*self.roots).borrow()[self.index].expect("inactive owner-root guard") }
     }
 }
 

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -169,25 +169,76 @@ def green(s):  return f"\033[32m{s}\033[0m"
 def dim(s):    return f"\033[2m{s}\033[0m"
 def bold(s):   return f"\033[1m{s}\033[0m"
 
-# ── Child-process user CPU time ──────────────────────────────────────
+# ── Child-process user CPU time and peak RSS ─────────────────────────
+
+# Peak RSS in MiB of the most recent `run_timed` child, or None when the run
+# timed out or the platform cannot report it. A single slot rather than a
+# return-tuple member: `run_timed`'s 4-tuple has many callers and only the
+# memory gate reads this. Runs are sequential, so the slot is unambiguous.
+_LAST_RUN_MAXRSS_MB = [None]
+
+
+def last_run_peak_rss_mb():
+    """Peak RSS (MiB) of the child `run_timed` most recently reaped."""
+    return _LAST_RUN_MAXRSS_MB[0]
+
+
 
 def _run_timed_unix(args, timeout_s, env=None):
-    import resource
-    before = resource.getrusage(resource.RUSAGE_CHILDREN)
-    try:
-        proc = subprocess.run(
-            args, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-            timeout=timeout_s, env=env,
-        )
-    except subprocess.TimeoutExpired:
-        return "", 0.0, 124, ""
-    after = resource.getrusage(resource.RUSAGE_CHILDREN)
-    utime = max(after.ru_utime - before.ru_utime, 0.0)
+    # `os.wait4` rather than `getrusage(RUSAGE_CHILDREN)` around
+    # `subprocess.run`: `ru_maxrss` on RUSAGE_CHILDREN is a running maximum
+    # over every reaped child, not a counter, so a before/after difference
+    # attributes nothing to this run. wait4 reports the rusage of this child
+    # alone, which is what a per-fixture memory gate needs. `ru_utime` comes
+    # from the same struct, so the timing path gains a per-child number too
+    # instead of a difference of process-wide totals.
+    #
+    # The child's pipes are replaced by temporary files: `communicate()` would
+    # reap the child itself and leave nothing for wait4, and draining pipes by
+    # hand risks the classic full-buffer deadlock.
+    import resource  # noqa: F401  (documents the rusage struct's origin)
+    import tempfile
+    import threading
+
+    timed_out = False
+
+    with tempfile.TemporaryFile() as out_f, tempfile.TemporaryFile() as err_f:
+        proc = subprocess.Popen(args, stdout=out_f, stderr=err_f, env=env)
+
+        def _kill():
+            nonlocal timed_out
+            timed_out = True
+            proc.kill()
+
+        timer = threading.Timer(timeout_s, _kill) if timeout_s else None
+        if timer is not None:
+            timer.start()
+        try:
+            _pid, status, usage = os.wait4(proc.pid, 0)
+        finally:
+            if timer is not None:
+                timer.cancel()
+        # Popen still believes the child is running; tell it otherwise so its
+        # finalizer neither waits nor warns.
+        proc.returncode = -(status & 0x7F) if status & 0x7F else (status >> 8)
+
+        if timed_out:
+            _LAST_RUN_MAXRSS_MB[0] = None
+            return "", 0.0, 124, ""
+
+        out_f.seek(0)
+        err_f.seek(0)
+        stdout_bytes = out_f.read()
+        stderr_bytes = err_f.read()
+
+    # ru_maxrss is kilobytes on Linux and bytes on macOS/BSD.
+    scale = 1024 * 1024 if sys.platform == "darwin" else 1024
+    _LAST_RUN_MAXRSS_MB[0] = usage.ru_maxrss / scale
     return (
-        proc.stdout.decode("utf-8", errors="replace"),
-        utime,
+        stdout_bytes.decode("utf-8", errors="replace"),
+        max(usage.ru_utime, 0.0),
         proc.returncode,
-        proc.stderr.decode("utf-8", errors="replace"),
+        stderr_bytes.decode("utf-8", errors="replace"),
     )
 
 
@@ -281,6 +332,8 @@ def run_timed(args, timeout_s=None, env=None):
     extras).
     """
     if sys.platform == "win32":
+        # No wait4 counterpart; the memory gate reads None and stays inert.
+        _LAST_RUN_MAXRSS_MB[0] = None
         out, t, rc, err = _run_timed_win32(args, timeout_s, env)
     else:
         out, t, rc, err = _run_timed_unix(args, timeout_s, env)
@@ -673,6 +726,38 @@ def synth_perf_gate(path):
             if ratio <= 0:
                 raise ValueError(f"synthetic performance gate must be positive in {path}")
             return ratio
+    return None
+
+
+def synth_rss_gate(path):
+    """Read an optional per-fixture peak-RSS ceiling from its header:
+        # pyre-check: max-rss-mb=200
+
+    A second axis beside `max-pypy-ratio`, not a replacement: the ratio gate
+    is blind to memory, so a change that trades retained bytes for speed
+    passes it while regressing badly. Frames are the standing example —
+    every interpreted call retains an old-gen frame, and nothing in this
+    harness has ever measured that.
+
+    Absent directive means no ceiling, so adding this gate cannot fail a
+    fixture that does not opt in. Read against native backends only, like
+    the ratio gate.
+    """
+    prefix = "# pyre-check: max-rss-mb="
+    with open(path, encoding="utf-8") as source:
+        for _ in range(20):
+            line = source.readline()
+            if not line:
+                break
+            if not line.startswith(prefix):
+                continue
+            try:
+                limit = float(line[len(prefix):].strip())
+            except ValueError as e:
+                raise ValueError(f"invalid synthetic memory gate in {path}: {line.strip()}") from e
+            if limit <= 0:
+                raise ValueError(f"synthetic memory gate must be positive in {path}")
+            return limit
     return None
 
 
@@ -1378,7 +1463,7 @@ class Check:
     def _run_backend_bench(
         self, backend, name, script, timeout,
         vs_cpython, vs_pypy, t_cpython, t_pypy, pypy_output,
-        wasm_float_tol=False,
+        wasm_float_tol=False, max_rss_mb=None,
     ):
         pyre_bin = self._pyre(backend)
         effective_timeout = scaled_timeout(timeout, self._timeout_scale(backend))
@@ -1389,6 +1474,8 @@ class Check:
         output, elapsed, code, stderr = run_timed(
             [pyre_bin, script], timeout_s=effective_timeout, env=pyre_env(),
         )
+        # Read before any gate re-runs the fixture and overwrites the slot.
+        peak_rss_mb = last_run_peak_rss_mb()
 
         panic_reason = _jit_panic_reason(stderr)
         if panic_reason:
@@ -1476,6 +1563,19 @@ class Check:
                 elapsed = checked_elapsed
                 t_pypy = checked_baseline
                 ratio = _ratio(elapsed, t_pypy)
+
+        # `# pyre-check: max-rss-mb=` — the axis the ratio gates cannot see.
+        # Checked after them so a fixture that is both slow and fat reports the
+        # slowness first, matching the existing gate order.
+        if max_rss_mb is not None and peak_rss_mb is not None and peak_rss_mb > max_rss_mb:
+            detail = f"peak RSS {peak_rss_mb:.0f}MB > {max_rss_mb:.0f}MB"
+            self._record(backend, False, name, detail)
+            print(f"{red('FATTER')}  pyre {detail}")
+            self._append_comparison(
+                backend, name, t_cpython, t_pypy,
+                fmt_time(f"{elapsed:.2f}"), f"({ratio} vs pypy)",
+            )
+            return
 
         snap_status, snap_reason = self._apply_snapshot_gate(
             backend, name, script, output, stderr, elapsed,
@@ -1635,6 +1735,7 @@ class Check:
         effective_timeout = scaled_timeout(timeout, self.args.timeout_scale)
         try:
             max_pypy_ratio = synth_perf_gate(path)
+            max_rss_mb = synth_rss_gate(path)
             skip_backends = synth_skip_backends(path)
         except ValueError as e:
             print(f"{red('ERROR')}: {e}")
@@ -1705,6 +1806,7 @@ class Check:
             self._run_backend_bench(
                 backend, name, path, timeout,
                 None, vs_pypy, t_cpython, t_pypy, pypy_output,
+                max_rss_mb=None if backend == "wasm" else max_rss_mb,
             )
 
     def run_synthetic_suite(self):

--- a/pyre/gate-triage.md
+++ b/pyre/gate-triage.md
@@ -592,8 +592,35 @@ a root portal seed deliberately points it at the `snapshot_for_tracing` copy, a
 forward.  Closing it means first retiring the snapshot-as-synchronization-target
 deviation, which is a tracer change, not a rooting change.
 
-The invariant stays comment-enforced, and an attempt to check it turned up why
-it has to be.  A `debug_assert!` in `w_pytraceback_new` that the frame is not
+**The invariant is narrower than "frames are non-moving", and that is by
+design.**  A compiled trace's own `NewWithVtable(pyframe_size_descr())` really
+does lower to a nursery bump, so JIT-emitted frames are movable — the audit left
+this inferred, and it is now measured.  Making it uniform is one line, with a
+direct in-tree precedent: the `W_ObjectObject` group marks its size descr
+`non_moving` for the identical reason ("the instance layer reaches an instance
+through raw pointers it does not root"), and `rewrite.rs` then declines the
+nursery and lands on the old-gen `gen_malloc_fixedsize`.  Marking the PyFrame
+group the same way costs:
+
+| bench | nursery frames | non-moving frames |
+|---|---|---|
+| `fib_recursive` | 1193 ms | **9249 ms (7.75x)** |
+| `inline_helper` | 219 ms | 213 ms (0.97x) |
+| `nested_loop` | 298 ms | 302 ms (1.01x) |
+
+(startup-subtracted, round-interleaved, order-alternated; `check.py` turns the
+same thing into `FAIL dynasm fib_recursive timeout (>5s)`, 1 failed / 353
+passed, with no wrong output anywhere.)  So the nursery frame path is not merely
+reachable but hot on recursive calls, and uniformity is unaffordable.
+
+What the system actually maintains is the narrower rule: *a frame that escapes
+into raw-pointer-holding territory is old-gen; a frame that stays inside a
+compiled trace may be nursery.*  The two seam-local props below are how that is
+enforced — they are the design, not an unmaintained accident, and the audit
+reading them as belt-and-braces over an unreachable case was wrong.
+
+An attempt to check the rule with an assertion turned up a second reason it
+stays comment-enforced.  A `debug_assert!` in `w_pytraceback_new` that the frame is not
 nursery-resident cost three `getattr_*` perf gates (`9.1x > 6x`, `8.9x > 5x`,
 `8.1x > 5x`) even in a release build: `pyre-interpreter` is extracted to LLBC,
 so the assertion is in the JIT's view of the function regardless of the host
@@ -602,12 +629,15 @@ traced code builds — `rg gc_is_nursery_object build/llbc/pyre-interpreter.ullb
 confirms it landed there.  A `debug_assert!` is not free in an LLBC-extracted
 crate on a traced path.
 
-So the rule is upheld by two seam-local props: the dynasm runner routes a
-resume-materialized virtual `PyFrame` to oldgen on purpose, and the JIT's
-traceback recorder builds a fresh oldgen frame instead of handing
-`record_application_traceback` a materialized virtual.  A compiled trace's own
-inlined-callee frame, a `NewWithVtable` the rewriter lowers to a nursery bump,
-is what would break it.
+The two props that carry the narrow rule are therefore load-bearing: the dynasm
+runner routes a resume-materialized virtual `PyFrame` to oldgen on purpose, and
+the JIT's traceback recorder builds a fresh oldgen frame instead of handing
+`record_application_traceback` a materialized virtual.  Both sit exactly where a
+nursery frame would otherwise cross into raw-pointer territory, and the
+measurement above is why the crossing is guarded there rather than removed at
+the allocator.  This is also why the runtime half of the inlined-level traceback
+anchor stays declined: it would hand the recorder the one frame class the props
+exist to keep away from it.
 
 One thing the ON path already fixes: with a side-effecting inlined callee under
 a `while` loop that returns from inside the loop, the OFF path runs the callee's

--- a/pyre/gate-triage.md
+++ b/pyre/gate-triage.md
@@ -535,23 +535,44 @@ so it rides the same gcmap-covered jitframe slots as every other ref across a
 collecting call, and `llsupport/assembler.py:301` notes it is deliberately "not
 in a register".
 
-What is left, then, is the remaining raw copies, and two of them are structural
-rather than mechanical:
+What is left is the remaining raw copies — and chasing them to the end shows the
+non-moving frame allocation is not a deferrable TODO but a forced adaptation.
 
-- `TraceCtx::virtualizable_heap_ptr` is a cached `*const u8` where upstream
-  unwraps the box per use.  It cannot simply become a forwarded slot: a root
-  portal seed deliberately points it at the `snapshot_for_tracing` copy, which
-  is a `FrameBox::new_boxed` allocation the GC does not own, so there is no slot
-  to forward until the snapshot-as-synchronization-target deviation goes first.
-- `eval_loop(frame: &mut PyFrame)` spans `safepoint()`.  Rust cannot re-read a
-  live `&mut`, so this needs the loop to re-derive the frame from a root after
-  each safepoint — mechanical but pervasive, in the hottest function in the
-  tree, and worth nothing until frames actually move.
+`eval_loop` holds `frame: &mut PyFrame` across the loop and hands it to
+`execute_opcode_step`, which allocates.  The JIT eval loop already runs the
+RPython discipline for its own copy — `FrameRoot` pushes the frame on the shadow
+stack, caches the `ShadowStackSlot`, and every collection point is followed by a
+fresh `let f: *mut PyFrame = frame_root.frame()`, with the comments naming
+`execute_opcode_step`, `handle_exception` and the ec block as the points.  It is
+load-bearing there because a JIT-inlined callee frame really can be nursery-
+resident (`emit_new_pyframe_inline_with_params` lowers to a nursery bump).
+
+But that discipline protects only the LOOP's copy.  The reference handed *into*
+`execute_opcode_step` is live across every allocation the opcode performs, and
+so is every frame reference below it.  Making frames movable therefore requires
+re-deriving the frame after each collection point inside every handler — which
+is precisely what RPython gets for free, because the translator rewrites live
+GCREF locals in their shadow-stack slots
+(`rpython/memory/gctransform/shadowstack.py:43-46`) and the interpreter never
+writes a reload by hand.  Rust has no such pass, and hand-writing it across the
+opcode implementations is neither reviewable nor maintainable.
+
+So the enabling condition for movable frames is a mechanism, not a patch: some
+automatic rewrite of live frame references across collection points.  Until one
+exists, `FrameBox::new` allocating non-moving is the thing standing in for it,
+and it should be read as pyre's stand-in for the translator's shadow-stack
+rewrite rather than as an accident awaiting cleanup.  The same holds for what it
+props up: `PyTraceback.w_code` stays, and so does the conditional frame edge.
+
+Two cached raw copies remain that are worth closing on their own merits, both
+narrower than the above:
+
+- `TraceCtx::virtualizable_heap_ptr` caches what upstream unwraps per use.  It
+  cannot simply become a forwarded slot: a root portal seed deliberately points
+  it at the `snapshot_for_tracing` copy, a `FrameBox::new_boxed` allocation the
+  GC does not own, so there is no slot to forward until the
+  snapshot-as-synchronization-target deviation goes first.
 - The blackhole's `virtualizable_ptr: i64`.
-
-Only after those does dropping the non-moving frame allocation become safe, and
-with it the `PyTraceback.w_code` snapshot, which exists solely because the frame
-edge is conditional.
 
 The invariant stays comment-enforced, and an attempt to check it turned up why
 it has to be.  A `debug_assert!` in `w_pytraceback_new` that the frame is not

--- a/pyre/gate-triage.md
+++ b/pyre/gate-triage.md
@@ -516,20 +516,59 @@ holds a forwarding-capable `owner_root` and never reads it back, so every
 `Deref` goes through the stale raw field; `eval_loop` runs behind a
 `&mut PyFrame` across a safepoint (the exact class RPython's translated
 shadowstack enumerates for free); the blackhole keeps the virtualizable as a
-bare integer, as does `INLINE_CONCRETE_FRAME`.  Converging means, in order:
-teach `FrameBox::deref` to read its own root and root the inline concrete frame
-the same way; then give compiled code a virtualizable reload after collecting
-calls — pyre has only the JITFRAME half (`reload_frame_if_necessary` in the
-dynasm aarch64 assembler, cited against `assembler.py:1369-1377`).  Only after
-both does dropping the non-moving frame allocation become safe, and with it the
-`PyTraceback.w_code` snapshot, which exists solely because the frame edge is
-conditional.
+bare integer, as did `INLINE_CONCRETE_FRAME`.
 
-Two hand-placed props currently hold the invariant up rather than the allocator:
-the dynasm runner routes a resume-materialized virtual `PyFrame` to oldgen on
-purpose, and the JIT's traceback recorder builds a fresh oldgen frame instead of
-handing `record_application_traceback` a materialized virtual.  Both are
-comment-enforced.
+The first two of those are now closed: `FrameBox` reads its frame back out of
+its own `owner_root` instead of the raw field it had cached (and `into_raw`
+reads the slot before releasing it, which it previously did in the opposite
+order), and `INLINE_CONCRETE_FRAME` is held as a root rather than a bare
+`Cell<*mut PyFrame>`.
+
+**There is no "virtualizable reload" to port** — an earlier revision of this
+section named one, and it does not exist upstream.  `_reload_frame_if_necessary`
+reloads the JITFRAME alone (`ebp` from the root-stack top,
+`rpython/jit/backend/x86/assembler.py:1369-1377`), which pyre already has in the
+dynasm aarch64 assembler; `rg reload_frame_if_necessary rpython/jit/backend/`
+turns up no vable counterpart on any target.  Upstream needs none: the
+virtualizable is an ordinary GCREF box (`metainterp.virtualizable_boxes[-1]`),
+so it rides the same gcmap-covered jitframe slots as every other ref across a
+collecting call, and `llsupport/assembler.py:301` notes it is deliberately "not
+in a register".
+
+What is left, then, is the remaining raw copies, and two of them are structural
+rather than mechanical:
+
+- `TraceCtx::virtualizable_heap_ptr` is a cached `*const u8` where upstream
+  unwraps the box per use.  It cannot simply become a forwarded slot: a root
+  portal seed deliberately points it at the `snapshot_for_tracing` copy, which
+  is a `FrameBox::new_boxed` allocation the GC does not own, so there is no slot
+  to forward until the snapshot-as-synchronization-target deviation goes first.
+- `eval_loop(frame: &mut PyFrame)` spans `safepoint()`.  Rust cannot re-read a
+  live `&mut`, so this needs the loop to re-derive the frame from a root after
+  each safepoint — mechanical but pervasive, in the hottest function in the
+  tree, and worth nothing until frames actually move.
+- The blackhole's `virtualizable_ptr: i64`.
+
+Only after those does dropping the non-moving frame allocation become safe, and
+with it the `PyTraceback.w_code` snapshot, which exists solely because the frame
+edge is conditional.
+
+The invariant stays comment-enforced, and an attempt to check it turned up why
+it has to be.  A `debug_assert!` in `w_pytraceback_new` that the frame is not
+nursery-resident cost three `getattr_*` perf gates (`9.1x > 6x`, `8.9x > 5x`,
+`8.1x > 5x`) even in a release build: `pyre-interpreter` is extracted to LLBC,
+so the assertion is in the JIT's view of the function regardless of the host
+profile, and `gc_is_nursery_object` became a real call on every traceback the
+traced code builds — `rg gc_is_nursery_object build/llbc/pyre-interpreter.ullbc`
+confirms it landed there.  A `debug_assert!` is not free in an LLBC-extracted
+crate on a traced path.
+
+So the rule is upheld by two seam-local props: the dynasm runner routes a
+resume-materialized virtual `PyFrame` to oldgen on purpose, and the JIT's
+traceback recorder builds a fresh oldgen frame instead of handing
+`record_application_traceback` a materialized virtual.  A compiled trace's own
+inlined-callee frame, a `NewWithVtable` the rewriter lowers to a nursery bump,
+is what would break it.
 
 One thing the ON path already fixes: with a side-effecting inlined callee under
 a `while` loop that returns from inside the loop, the OFF path runs the callee's

--- a/pyre/gate-triage.md
+++ b/pyre/gate-triage.md
@@ -562,7 +562,10 @@ automatic rewrite of live frame references across collection points.  Until one
 exists, `FrameBox::new` allocating non-moving is the thing standing in for it,
 and it should be read as pyre's stand-in for the translator's shadow-stack
 rewrite rather than as an accident awaiting cleanup.  The same holds for what it
-props up: `PyTraceback.w_code` stays, and so does the conditional frame edge.
+props up: `PyTraceback.w_code` stays, and so does the conditional frame edge —
+though the edge's reachable case has narrowed to the pre-hook bootstrap frame
+(see `TraceCtx::virtualizable_heap_ptr` below), which is why the guard is now
+kept for its failure mode rather than for a case anyone has observed.
 
 Two cached raw copies were checked against upstream individually rather than
 left on a list.  Neither is a hazard, and only one is even the deviation it
@@ -585,12 +588,35 @@ place).  What the field does not do is forward *itself*, and that is exactly
 what the non-moving contract above makes unnecessary.  Rooting it would forward
 nothing.
 
-*`TraceCtx::virtualizable_heap_ptr` — blocked, and the blocker is named.*  It
-caches what upstream unwraps per use.  It cannot simply become a forwarded slot:
-a root portal seed deliberately points it at the `snapshot_for_tracing` copy, a
-`FrameBox::new_boxed` allocation the GC does not own, so there is no slot to
-forward.  Closing it means first retiring the snapshot-as-synchronization-target
-deviation, which is a tracer change, not a rooting change.
+*`TraceCtx::virtualizable_heap_ptr` — half closed; the rest is architectural.*
+It caches what upstream unwraps per use (`pyjitpl.py:3472-3474
+synchronize_virtualizable` re-derives the write target from
+`virtualizable_boxes[-1]` every time), and a root portal seed points it at the
+`snapshot_for_tracing` copy while baking the identity against the live frame,
+so the two name different objects where upstream has one.
+
+The half that was a rooting problem is gone.  The snapshot used to be a
+`FrameBox::new_boxed` allocation the GC did not own, which is what left the
+cached pointer with no slot to forward — and, downstream, what made the
+traceback the walk records against it (`pyjitpl.rs`
+`record_application_traceback(excvalue, self.vable_ptr, frame)`) carry a frame
+pointer that dangled as soon as the walk ended.  `FrameBox::new`'s `owner_root`
+now supplies the root that was missing, so `snapshot_for_tracing` allocates
+GC-owned, the traceback's conditional frame edge forwards and keeps it alive,
+and a full-corpus probe on that edge observed no non-GC frame reaching a
+traceback at all.
+
+The half that remains is not a rooting change and not a tracer change either.
+The two objects exist because pyre's tracer steps a *copy*: the walk executes
+the iteration concretely against the snapshot while the live frame stays parked
+at the loop header for the compiled loop to run from.  That forces the split in
+both directions — the identity must be the live frame or
+`patch_new_loop_to_load_virtualizable_fields` gets a frame unrelated to the
+boxes (`compile.py:458 assert i == len(inputargs)`), and the synchronization
+target must be the snapshot or `refresh_virtualizable_shadow_from_heap` reads a
+frame the walk never mutated and the shadow drifts.  Upstream needs one field
+because its metainterp *is* the interpreter for that iteration.  So this cache
+converges when the copy-walk does, and not before.
 
 **The invariant is narrower than "frames are non-moving", and that is by
 design.**  A compiled trace's own `NewWithVtable(pyframe_size_descr())` really

--- a/pyre/gate-triage.md
+++ b/pyre/gate-triage.md
@@ -564,15 +564,33 @@ and it should be read as pyre's stand-in for the translator's shadow-stack
 rewrite rather than as an accident awaiting cleanup.  The same holds for what it
 props up: `PyTraceback.w_code` stays, and so does the conditional frame edge.
 
-Two cached raw copies remain that are worth closing on their own merits, both
-narrower than the above:
+Two cached raw copies were checked against upstream individually rather than
+left on a list.  Neither is a hazard, and only one is even the deviation it
+looked like:
 
-- `TraceCtx::virtualizable_heap_ptr` caches what upstream unwraps per use.  It
-  cannot simply become a forwarded slot: a root portal seed deliberately points
-  it at the `snapshot_for_tracing` copy, a `FrameBox::new_boxed` allocation the
-  GC does not own, so there is no slot to forward until the
-  snapshot-as-synchronization-target deviation goes first.
-- The blackhole's `virtualizable_ptr: i64`.
+*The blackhole's `virtualizable_ptr: i64` — not the field it resembles.*
+Upstream's `BlackholeInterpreter` has no such field: every vable bhimpl takes
+the virtualizable as an explicit argument (`blackhole.py:1374`
+`bhimpl_getarrayitem_vable_i(cpu, vable, index, fielddescr, arraydescr)`, and
+the same shape for the `set*`/`arraylen` family), sourced from the register
+bank, which pyre roots too (`push_bh_regs`).  Pyre's field is not that carrier.
+It is the frame identity pyre's blackhole traceback recording needs —
+`record_frame_traceback` passes it to `record_application_traceback_for_recording`
+— and upstream has no counterpart to that at all, because its blackhole does not
+record application tracebacks.  Lifetime is already covered: the frame is on the
+interpreter chain, and `run` additionally pushes the vable's array-field slots
+onto the resume-ref root stack for the whole run
+(`VirtualizableInfo::push_resume_ref_roots`, which forwards those slots in
+place).  What the field does not do is forward *itself*, and that is exactly
+what the non-moving contract above makes unnecessary.  Rooting it would forward
+nothing.
+
+*`TraceCtx::virtualizable_heap_ptr` — blocked, and the blocker is named.*  It
+caches what upstream unwraps per use.  It cannot simply become a forwarded slot:
+a root portal seed deliberately points it at the `snapshot_for_tracing` copy, a
+`FrameBox::new_boxed` allocation the GC does not own, so there is no slot to
+forward.  Closing it means first retiring the snapshot-as-synchronization-target
+deviation, which is a tracer change, not a rooting change.
 
 The invariant stays comment-enforced, and an attempt to check it turned up why
 it has to be.  A `debug_assert!` in `w_pytraceback_new` that the frame is not

--- a/pyre/gate-triage.md
+++ b/pyre/gate-triage.md
@@ -634,10 +634,36 @@ group the same way costs:
 | `inline_helper` | 219 ms | 213 ms (0.97x) |
 | `nested_loop` | 298 ms | 302 ms (1.01x) |
 
-(startup-subtracted, round-interleaved, order-alternated; `check.py` turns the
-same thing into `FAIL dynasm fib_recursive timeout (>5s)`, 1 failed / 353
-passed, with no wrong output anywhere.)  So the nursery frame path is not merely
-reachable but hot on recursive calls, and uniformity is unaffordable.
+PERF-CLAIM-UNVERIFIED: this table.  The command that produced it, the sha of
+each arm, and the round count were never recorded, so it cannot be reproduced
+or falsified.  `check.py` did not produce it — `check.py:174` returns
+`("", 0.0, 124, "")` on `TimeoutExpired`, so the harness cannot report 9249 ms
+for a run it killed, and the 1193 ms denominator is stale (`fib_recursive` runs
+in ~650 ms today).  What *is* doubly attested is the `check.py` result of
+applying the change: `FAIL dynasm fib_recursive timeout (>5s)`, 1 failed / 353
+passed, with no wrong output anywhere.  Read the effect as **">4x, direction
+certain"** and the table as an unsourced elaboration of it.  The conclusion
+below does not depend on the precision.
+
+**Scope, which is the sharper limit on this experiment.** The flag it toggled
+has exactly one production reader — `rewrite.rs:1091`, on the JIT's
+`NewWithVtable` lowering.  `FrameBox::new` never consults a descr: it calls
+`try_gc_alloc_stable_raw` unconditionally (`pyre-interpreter/src/pyframe.rs`)
+and lands on `alloc_oldgen_typed` (`pyre-jit/src/eval.rs`).  Interpreter frames
+were therefore old-gen in **both** arms, and the measurement says nothing about
+them.  Every conclusion here is scoped to JIT-emitted frames.
+
+Also worth stating because it bounds how far this can be generalized: upstream
+cannot express the arm that was measured.  `rpython/jit/codewriter/jtransform.py:1012-1015`
+rejects the flag outright — `if d.get('nonmovable', False): raise UnsupportedMallocFlags(d)`
+— and upstream's own `malloc_big_fixedsize` still takes the nursery for
+frame-sized objects (`jit/backend/llsupport/rewrite.py:778-788`).  The penalty
+is the cost of enabling a behaviour with no upstream counterpart, not the cost
+of an upstream design pyre declined.
+
+So, within that scope: the nursery frame path is not merely reachable but hot on
+recursive calls, and making JIT-emitted frames uniform with interpreter frames
+is unaffordable.
 
 What the system actually maintains is the narrower rule: *a frame that escapes
 into raw-pointer-holding territory is old-gen; a frame that stays inside a

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -673,15 +673,15 @@ impl FrameBox {
         FrameBox::new_boxed(frame)
     }
 
-    /// Allocate a frame that is NOT GC-managed even when the GC hook is
-    /// installed — a plain `std::alloc` `GcFramePrefix` box reclaimed by
-    /// `Drop`.  Used for tracer snapshots (`snapshot_for_tracing`), which
-    /// a tracer holds off the `CURRENT_FRAME` chain across an entire
-    /// `trace_bytecode` walk: a major cycle can complete mid-walk, and no
-    /// root reaches the snapshot, so GC lifetime would reclaim it while the
-    /// tracer still reads it.  A deterministic scope-end free is correct
-    /// for these transient, tracer-private copies.
-    pub fn new_boxed(frame: PyFrame) -> Self {
+    /// Allocate a frame outside the GC — a plain `std::alloc`
+    /// `GcFramePrefix` box reclaimed by `Drop`.
+    ///
+    /// The sole caller is [`Self::new`]'s fallback for the window before the
+    /// GC hook is installed (bootstrap, unit tests).  Nothing is collected in
+    /// that window, so a frame allocated here is never swept and never moves,
+    /// which is what lets the rest of the interpreter treat every frame
+    /// address as stable.
+    fn new_boxed(frame: PyFrame) -> Self {
         let raw = Box::into_raw(Box::new(GcFramePrefix {
             gc_header: 0,
             frame,
@@ -700,9 +700,9 @@ impl FrameBox {
     /// which is why RPython reads a GCREF local back out of its shadow-stack
     /// slot rather than from a register it filled before the last operation
     /// that could collect; the raw `ptr` field is that stale register, so
-    /// every read of the frame goes through the slot instead.  A `new_boxed`
-    /// snapshot holds no slot and is not GC-managed, so its address is fixed
-    /// and the field is the only answer.
+    /// every read of the frame goes through the slot instead.  A
+    /// [`Self::new_boxed`] frame holds no slot and is not GC-managed, so its
+    /// address is fixed and the field is the only answer.
     #[inline]
     fn frame_ptr(&self) -> *mut PyFrame {
         match &self.owner_root {

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -577,6 +577,20 @@ impl FrameBox {
     /// reaches it, so `Drop` performs no manual free
     /// (`executioncontext.py:91-107 leave` frees nothing either).
     ///
+    /// The non-moving part is pyre's, not upstream's: `pyframe.py:52 class
+    /// PyFrame(W_Root)` declares no placement hint and a minor collection
+    /// relocates it, rewriting every referring slot
+    /// (`rpython/memory/gc/incminimark.py:2237` / `:2252`) because the
+    /// translator delivers roots as slot addresses and rewrites live GCREF
+    /// locals in them (`rpython/memory/gctransform/shadowstack.py:43-46`).
+    /// Rust has no such pass, and a running opcode holds a `&mut PyFrame`
+    /// across its own allocations, so this allocation standing still is what
+    /// takes the place of that rewrite.  It is not a rule about every frame —
+    /// a compiled trace's inlined-callee frame is a nursery allocation, and
+    /// making that uniform costs `fib_recursive` 7.75x — so the crossing into
+    /// raw-pointer territory is guarded at the seams instead
+    /// (`gate-triage.md`).
+    ///
     /// Before the hook is wired (bootstrap, tests) `try_gc_alloc_stable`
     /// returns `None`; fall back to the `std::alloc` `GcFramePrefix` box,
     /// which `Drop` frees manually.  The two regimes share one memory

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -679,10 +679,30 @@ impl FrameBox {
         }
     }
 
+    /// The frame's current address.
+    ///
+    /// `owner_root` is this handle's translated livevar slot.  A collection
+    /// rewrites the slot in place (`rpython/memory/gc/incminimark.py:2252`),
+    /// which is why RPython reads a GCREF local back out of its shadow-stack
+    /// slot rather than from a register it filled before the last operation
+    /// that could collect; the raw `ptr` field is that stale register, so
+    /// every read of the frame goes through the slot instead.  A `new_boxed`
+    /// snapshot holds no slot and is not GC-managed, so its address is fixed
+    /// and the field is the only answer.
+    #[inline]
+    fn frame_ptr(&self) -> *mut PyFrame {
+        match &self.owner_root {
+            Some(owner_root) => owner_root.get().0 as *mut PyFrame,
+            None => self.ptr,
+        }
+    }
+
     /// Relinquish ownership, returning the inner-frame pointer. The header
     /// remains at `ptr - GC_HEADER_SIZE`; reclaim via [`FrameBox::from_raw`].
     pub fn into_raw(mut self) -> *mut PyFrame {
-        let ptr = self.ptr;
+        // Read the slot before releasing it — afterwards the handle has no
+        // root to answer from and only the stale field remains.
+        let ptr = self.frame_ptr();
         drop(self.owner_root.take());
         std::mem::forget(self);
         ptr
@@ -715,7 +735,7 @@ impl FrameBox {
 
     /// Raw pointer to the inner frame (header at `ptr - GC_HEADER_SIZE`).
     pub fn as_mut_ptr(&mut self) -> *mut PyFrame {
-        self.ptr
+        self.frame_ptr()
     }
 
     /// Does the collector own this frame, so that [`Drop`] leaves the memory
@@ -886,14 +906,14 @@ impl std::ops::Deref for FrameBox {
     type Target = PyFrame;
     #[inline]
     fn deref(&self) -> &PyFrame {
-        unsafe { &*self.ptr }
+        unsafe { &*self.frame_ptr() }
     }
 }
 
 impl std::ops::DerefMut for FrameBox {
     #[inline]
     fn deref_mut(&mut self) -> &mut PyFrame {
-        unsafe { &mut *self.ptr }
+        unsafe { &mut *self.frame_ptr() }
     }
 }
 

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -2485,10 +2485,21 @@ impl PyFrame {
     pub fn snapshot_for_tracing(&self) -> FrameBox {
         // A tracer holds this snapshot off the `CURRENT_FRAME` chain across
         // the whole `trace_bytecode` walk, during which a major GC cycle can
-        // complete; no root reaches it, so it must NOT have GC lifetime —
-        // `new_boxed` gives it a deterministic scope-end free.
+        // complete.  `FrameBox::new` is what makes that safe: it acquires a
+        // translated-livevar root for the frame, held for exactly the handle's
+        // lifetime, which is the walk (`trace_bytecode` takes the box by value
+        // and hands it back).  Before that root existed the snapshot had to be
+        // `new_boxed` — GC-invisible with a deterministic scope-end free —
+        // because nothing reached it.
+        //
+        // Being GC-owned is what lets the trace's synchronization target be a
+        // forwardable object: a `new_boxed` snapshot is an address the
+        // collector does not own, so `pytraceback_object_custom_trace` has to
+        // skip its frame edge and `TraceCtx::virtualizable_heap_ptr` has no
+        // slot to read back.  Same allocation shape as
+        // `snapshot_for_generator` below, for the same reason.
         let mut frame =
-            FrameBox::new_boxed(self.build_snapshot_frame(FrameLocalsArrayAllocation::StdAlloc));
+            FrameBox::new(self.build_snapshot_frame(FrameLocalsArrayAllocation::OldGenGc));
         // fix_array_ptrs AFTER Box allocation: inline_buf ptr must
         // point to the heap-allocated frame, not a stale stack address.
         frame.fix_array_ptrs();

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -3873,14 +3873,18 @@ impl PyFrame {
         // from those forwarded slots, matching gctransform/framework.py's
         // push_roots/pop_roots around a GC allocation.
         let _roots = pyre_object::gc_roots::push_roots();
-        let root_base = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(code as PyObjectRef);
-        pyre_object::gc_roots::pin_root(w_globals);
-        pyre_object::gc_roots::pin_root(closure);
-        pyre_object::gc_roots::pin_root(w_builtin);
-        for &arg in args {
-            pyre_object::gc_roots::pin_root(arg);
-        }
+        // The scalars and `args` are two slices of one livevar set, so both are
+        // written before either is queried: a forwarding query is a safepoint,
+        // and `args` would still be off the root stack while the scalars ran
+        // theirs.
+        let root_base = pyre_object::gc_roots::publish_roots(&[
+            code as PyObjectRef,
+            w_globals,
+            closure,
+            w_builtin,
+        ]);
+        let args_base = pyre_object::gc_roots::publish_roots(args);
+        pyre_object::gc_roots::normalize_roots(root_base, 4 + args.len());
         let code_ref = unsafe {
             &*(crate::w_code_get_ptr(pyre_object::gc_roots::shadow_stack_get(root_base))
                 as *const CodeObject)
@@ -3894,10 +3898,10 @@ impl PyFrame {
         };
         // The allocation result is a translated livevar before it is stored in
         // the eventual PyFrame. Publish it before `w_cell_new`, the barrier,
-        // or any other GC operation can park this free-threaded mutator.
-        let _locals_owner_root = majit_gc::shadow_stack::OwnerRootGuard::new(majit_ir::GcRef(
-            locals_cells_stack_w as usize,
-        ));
+        // or any other GC operation can park this free-threaded mutator. It
+        // joins the bracket the call inputs already opened: its lifetime is
+        // the rest of this function body, so it needs no owner of its own.
+        pyre_object::gc_roots::pin_root(locals_cells_stack_w as PyObjectRef);
 
         {
             // Populate the freshly-allocated array via its mutable slice.
@@ -3906,7 +3910,7 @@ impl PyFrame {
             // Bind positional arguments directly -- no intermediate Vec.
             let nargs = args.len().min(num_locals);
             for i in 0..nargs {
-                arr[i] = pyre_object::gc_roots::shadow_stack_get(root_base + 4 + i);
+                arr[i] = pyre_object::gc_roots::shadow_stack_get(args_base + i);
             }
 
             // CPython 3.11+ `co_localsplusnames` unified slot layout:

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -604,26 +604,28 @@ impl FrameBox {
         // translated livevars across the frame allocation. Publish every field
         // before the first GC operation; a contended stable allocation parks
         // this mutator and lets another collector run.
-        let input_roots = [
-            majit_gc::shadow_stack::OwnerRootGuard::new(majit_ir::GcRef(
-                frame.ob_header.w_class as usize,
-            )),
-            majit_gc::shadow_stack::OwnerRootGuard::new(majit_ir::GcRef(frame.pycode as usize)),
-            majit_gc::shadow_stack::OwnerRootGuard::new(majit_ir::GcRef(
-                frame.locals_cells_stack_w as usize,
-            )),
-            majit_gc::shadow_stack::OwnerRootGuard::new(majit_ir::GcRef(frame.debugdata as usize)),
-            majit_gc::shadow_stack::OwnerRootGuard::new(majit_ir::GcRef(frame.lastblock as usize)),
-            majit_gc::shadow_stack::OwnerRootGuard::new(majit_ir::GcRef(
-                frame.f_generator_nowref as usize,
-            )),
-            majit_gc::shadow_stack::OwnerRootGuard::new(majit_ir::GcRef(
-                frame.w_yielding_from as usize,
-            )),
-            majit_gc::shadow_stack::OwnerRootGuard::new(majit_ir::GcRef(frame.f_backref as usize)),
-            majit_gc::shadow_stack::OwnerRootGuard::new(majit_ir::GcRef(frame.w_builtin as usize)),
-            majit_gc::shadow_stack::OwnerRootGuard::new(majit_ir::GcRef(frame.w_globals as usize)),
-        ];
+        //
+        // One `push_roots(hop)` bracket over the whole set, not ten
+        // independently-owned slots: their lifetime is exactly this function
+        // body, which is the lexical shape `gc_enter_roots_frame` /
+        // `gc_leave_roots_frame` express (`shadowcolor.py:462-606`), and
+        // `pin_roots` is the one-phase publish `push_roots` performs — pinning
+        // them one at a time would query for forwarding after the first write
+        // and let a foreign collection run before the later values were
+        // visible.
+        let frame_root = pyre_object::gc_roots::push_roots();
+        let inputs = pyre_object::gc_roots::pin_roots(&[
+            frame.ob_header.w_class,
+            frame.pycode as pyre_object::PyObjectRef,
+            frame.locals_cells_stack_w as pyre_object::PyObjectRef,
+            frame.debugdata as pyre_object::PyObjectRef,
+            frame.lastblock as pyre_object::PyObjectRef,
+            frame.f_generator_nowref,
+            frame.w_yielding_from,
+            frame.f_backref as pyre_object::PyObjectRef,
+            frame.w_builtin,
+            frame.w_globals,
+        ]);
         let raw = pyre_object::gc_hook::try_gc_alloc_stable_raw(
             PYFRAME_GC_TYPE_ID,
             std::mem::size_of::<PyFrame>(),
@@ -635,19 +637,20 @@ impl FrameBox {
             // GC operation: a contended barrier is an entry safepoint, so an
             // unrooted fresh frame could otherwise be swept by another
             // collector between this allocation and the barrier below.
-            let frame_root = pyre_object::gc_roots::push_roots();
             pyre_object::gc_roots::pin_root(raw as pyre_object::PyObjectRef);
-            frame.ob_header.w_class = input_roots[0].get().0 as pyre_object::PyObjectRef;
-            frame.pycode = input_roots[1].get().0 as *const ();
+            // Read back through the bracket's own cell rather than
+            // `shadow_stack_get`, which resolves the thread-local per slot.
+            frame.ob_header.w_class = frame_root.get(inputs);
+            frame.pycode = frame_root.get(inputs + 1) as *const ();
             frame.locals_cells_stack_w =
-                input_roots[2].get().0 as *mut pyre_object::FixedObjectArray;
-            frame.debugdata = input_roots[3].get().0 as *mut FrameDebugData;
-            frame.lastblock = input_roots[4].get().0 as *mut FrameBlock;
-            frame.f_generator_nowref = input_roots[5].get().0 as pyre_object::PyObjectRef;
-            frame.w_yielding_from = input_roots[6].get().0 as pyre_object::PyObjectRef;
-            frame.f_backref = input_roots[7].get().0 as *mut PyFrame;
-            frame.w_builtin = input_roots[8].get().0 as pyre_object::PyObjectRef;
-            frame.w_globals = input_roots[9].get().0 as pyre_object::PyObjectRef;
+                frame_root.get(inputs + 2) as *mut pyre_object::FixedObjectArray;
+            frame.debugdata = frame_root.get(inputs + 3) as *mut FrameDebugData;
+            frame.lastblock = frame_root.get(inputs + 4) as *mut FrameBlock;
+            frame.f_generator_nowref = frame_root.get(inputs + 5);
+            frame.w_yielding_from = frame_root.get(inputs + 6);
+            frame.f_backref = frame_root.get(inputs + 7) as *mut PyFrame;
+            frame.w_builtin = frame_root.get(inputs + 8);
+            frame.w_globals = frame_root.get(inputs + 9);
             debug_assert!(pyre_object::gc_hook::try_gc_owns_object(
                 frame.locals_cells_stack_w as *mut u8
             ));

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -587,9 +587,10 @@ impl FrameBox {
     /// across its own allocations, so this allocation standing still is what
     /// takes the place of that rewrite.  It is not a rule about every frame —
     /// a compiled trace's inlined-callee frame is a nursery allocation, and
-    /// making that uniform costs `fib_recursive` 7.75x — so the crossing into
-    /// raw-pointer territory is guarded at the seams instead
-    /// (`gate-triage.md`).
+    /// making that uniform times `fib_recursive` out of its gate — so the
+    /// crossing into raw-pointer territory is guarded at the seams instead
+    /// (`gate-triage.md`, which also records why the ratio that experiment is
+    /// often quoted with is not reproducible).
     ///
     /// Before the hook is wired (bootstrap, tests) `try_gc_alloc_stable`
     /// returns `None`; fall back to the `std::alloc` `GcFramePrefix` box,

--- a/pyre/pyre-interpreter/src/pytraceback.rs
+++ b/pyre/pyre-interpreter/src/pytraceback.rs
@@ -29,8 +29,7 @@
 //! diverges is the slot type: this struct holds a raw `*mut PyFrame`
 //! rather than a `PyObjectRef`, and the edge reaches the collector
 //! only through the hand-written `pytraceback_object_custom_trace`
-//! hook, which forwards it as a mutable slot but skips a frame the GC
-//! does not own (a `FrameBox::new_boxed` tracer snapshot).
+//! hook, which forwards it as a mutable slot.
 //!
 //! The pointee must additionally never move.  That is not an upstream
 //! requirement and nothing in this file causes it: an executing frame
@@ -72,11 +71,11 @@ pub struct PyTraceback {
     /// rather than a `PyObjectRef`, so it takes part in collection
     /// only through `pytraceback_object_custom_trace`.  That hook
     /// forwards the slot when the GC owns the frame, which keeps it
-    /// live and would rewrite it if the frame ever moved; it skips a
-    /// frame the GC does not own — a `FrameBox::new_boxed` tracer
-    /// snapshot, freed at the end of its walk — and such a pointer is
-    /// left dangling and must not be dereferenced.  The `w_code`
-    /// snapshot below is what readers use in that case.
+    /// live and would rewrite it if the frame ever moved.  Every frame
+    /// that can reach here is GC-owned: `FrameBox::new` allocates from
+    /// the GC whenever the hook is installed, and the one path that is
+    /// not — the pre-hook bootstrap window — collects nothing, so a
+    /// frame born there is never swept either way.
     pub frame: *mut crate::pyframe::PyFrame,
     /// `pytraceback.py:30 self.lasti = lasti` — bytecode index at
     /// which the exception was raised (in instruction units).
@@ -93,12 +92,20 @@ pub struct PyTraceback {
     /// Snapshot of the raising frame's `pycode`, with no upstream
     /// counterpart — `pytraceback.py` reads `self.frame.pycode`
     /// directly (`:36`), because upstream's frame edge is unconditional
-    /// and the frame therefore outlives the traceback.  Pyre's does not
-    /// hold for a frame the GC does not own, so consumers that must
-    /// keep working then (`write_traceback_chain`) read `source_path` /
-    /// `obj_name` / `qualname` through this handle instead.  Retiring
-    /// the field is blocked on making every frame that can reach a
-    /// traceback GC-owned.
+    /// and the frame therefore outlives the traceback.  Pyre's edge is
+    /// conditional on the GC owning the frame, so consumers that must
+    /// keep working otherwise (`write_traceback_chain`) read
+    /// `source_path` / `obj_name` / `qualname` through this handle
+    /// instead.
+    ///
+    /// The condition now excludes only the pre-hook bootstrap frame:
+    /// the tracer snapshot, which used to be the reachable case, is
+    /// GC-owned since `snapshot_for_tracing` moved to `FrameBox::new`,
+    /// and a full-corpus probe on the forwarding hook saw no non-GC
+    /// frame reach a traceback.  Retiring the field would still mean
+    /// deleting a guard whose failure mode is handing the collector a
+    /// `std::alloc` address, on evidence that is an absence rather than
+    /// a proof, so it stays.
     pub w_code: PyObjectRef,
 }
 

--- a/pyre/pyre-interpreter/src/pytraceback.rs
+++ b/pyre/pyre-interpreter/src/pytraceback.rs
@@ -30,10 +30,17 @@
 //! rather than a `PyObjectRef`, and the edge reaches the collector
 //! only through the hand-written `pytraceback_object_custom_trace`
 //! hook, which forwards it as a mutable slot but skips a frame the GC
-//! does not own (a `FrameBox::new_boxed` tracer snapshot).  The
-//! pointee must additionally never move, which is not an upstream
-//! requirement and is not caused by anything in this file — see
-//! `w_pytraceback_new`.
+//! does not own (a `FrameBox::new_boxed` tracer snapshot).
+//!
+//! The pointee must additionally never move.  That is not an upstream
+//! requirement and nothing in this file causes it: an executing frame
+//! is reached through a live Rust `&mut PyFrame` that spans every
+//! allocation the running opcode performs, and RPython's translator
+//! rewrites exactly those live references in their shadow-stack slots
+//! (`rpython/memory/gctransform/shadowstack.py:43-46`) where Rust has
+//! no equivalent pass.  `FrameBox::new` allocating non-moving stands
+//! in for that rewrite, and this file's conditional frame edge and
+//! `w_code` snapshot are downstream of it.
 
 use pyre_object::pyobject::*;
 

--- a/pyre/pyre-interpreter/src/pytraceback.rs
+++ b/pyre/pyre-interpreter/src/pytraceback.rs
@@ -135,6 +135,12 @@ pub fn w_pytraceback_new(
         w_code,
     };
 
+    // The rule below cannot be spelled as a `debug_assert!` here: this crate
+    // is extracted to LLBC, so an assertion lands in the JIT's view of this
+    // function and its probe becomes a real call on every traceback the
+    // traced code builds — measurably, on the `getattr_*` gates.  It stays a
+    // stated obligation.
+    //
     // `frame` was copied into `value` above and is not among the roots
     // pinned here, so the allocation below — which can safepoint — must
     // not be able to move it.  Upstream has no such rule: a minor

--- a/pyre/pyre-interpreter/src/pytraceback.rs
+++ b/pyre/pyre-interpreter/src/pytraceback.rs
@@ -41,6 +41,12 @@
 //! no equivalent pass.  `FrameBox::new` allocating non-moving stands
 //! in for that rewrite, and this file's conditional frame edge and
 //! `w_code` snapshot are downstream of it.
+//!
+//! The rule holds for frames that reach here, not for every frame: a
+//! compiled trace's own inlined-callee frame is a nursery allocation,
+//! and making that uniform costs `fib_recursive` 7.75x, so the
+//! crossing is guarded at the seams instead (see `gate-triage.md`).
+//! `record_application_traceback` is one of those seams.
 
 use pyre_object::pyobject::*;
 

--- a/pyre/pyre-interpreter/src/pytraceback.rs
+++ b/pyre/pyre-interpreter/src/pytraceback.rs
@@ -43,8 +43,8 @@
 //!
 //! The rule holds for frames that reach here, not for every frame: a
 //! compiled trace's own inlined-callee frame is a nursery allocation,
-//! and making that uniform costs `fib_recursive` 7.75x, so the
-//! crossing is guarded at the seams instead (see `gate-triage.md`).
+//! and making that uniform times `fib_recursive` out of its gate, so
+//! the crossing is guarded at the seams instead (see `gate-triage.md`).
 //! `record_application_traceback` is one of those seams.
 
 use pyre_object::pyobject::*;

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -95,8 +95,17 @@ thread_local! {
 /// brackets the corresponding per-thread execution state with
 /// [`InlineConcreteFrameGuard`].  Vable writes use this accessor to keep that
 /// frame's own heap image coherent for a later multi-frame blackhole handoff.
+///
+/// Read back out of the guard's root rather than from a raw copy: the value
+/// is compared for identity against the concrete bank's own `Value::Ref`,
+/// which the collector forwards, so a relocated frame would make the two
+/// disagree and silently drop the mirror write.
 pub(crate) fn current_inline_concrete_frame() -> usize {
-    INLINE_CONCRETE_FRAME.with(|slot| slot.get() as usize)
+    INLINE_CONCRETE_FRAME.with(|slot| {
+        slot.borrow()
+            .as_ref()
+            .map_or(0, |owner_root| owner_root.get().0)
+    })
 }
 
 pub(crate) struct EscapeFlushUndo {
@@ -775,9 +784,12 @@ pub(crate) fn escape_flush_undo_cell_ptr() -> *const std::cell::RefCell<Option<E
 
 thread_local! {
     /// The concrete `PyFrame` the innermost inline sub-walk is executing, or
-    /// null outside one.  Set by [`InlineConcreteFrameGuard`].
-    static INLINE_CONCRETE_FRAME: std::cell::Cell<*mut pyre_interpreter::PyFrame> =
-        const { std::cell::Cell::new(std::ptr::null_mut()) };
+    /// `None` outside one.  Set by [`InlineConcreteFrameGuard`], and held as
+    /// a translated-livevar root rather than a raw pointer, the way
+    /// [`ResidualFrameChainGuard`] holds the `topframeref` it displaces.
+    static INLINE_CONCRETE_FRAME: std::cell::RefCell<
+        Option<majit_gc::shadow_stack::OwnerRootGuard>,
+    > = const { std::cell::RefCell::new(None) };
 
     /// The concrete frame currently published on the interpreter chain by a
     /// live [`ResidualFrameChainGuard`], or null.  Distinct from
@@ -818,7 +830,7 @@ impl LiveLastInstrGuard {
     /// declines to latch a sub-walk's mirror), and writing it onto the outer
     /// frame strands that frame's replay on a stack depth it never had.
     fn enter(live_frame: usize, py_pc: u32) -> Option<Self> {
-        let inline = INLINE_CONCRETE_FRAME.with(|slot| slot.get());
+        let inline = current_inline_concrete_frame() as *mut pyre_interpreter::PyFrame;
         let frame = if inline.is_null() {
             live_frame as *mut pyre_interpreter::PyFrame
         } else {
@@ -860,24 +872,28 @@ impl Drop for LiveLastInstrGuard {
 /// Names the frame an inline sub-walk executes concretely for the duration of
 /// that sub-walk.  Publishing it on the interpreter chain is left to
 /// [`ResidualFrameChainGuard`], which brackets only the residual calls.
-pub(crate) struct InlineConcreteFrameGuard(*mut pyre_interpreter::PyFrame);
+pub(crate) struct InlineConcreteFrameGuard(Option<majit_gc::shadow_stack::OwnerRootGuard>);
 
 impl InlineConcreteFrameGuard {
     pub(crate) fn enter(frame: *mut pyre_interpreter::PyFrame) -> Self {
-        // Set unconditionally, null included: a nested sub-walk whose seed
-        // block bailed has no frame of its own, and inheriting the enclosing
-        // callee's frame would publish it for the inner callee's residuals —
-        // resolving one level too shallow, the error this guard exists to
-        // stop.  A null slot makes `ResidualFrameChainGuard::enter` publish
-        // nothing.
-        let previous = INLINE_CONCRETE_FRAME.with(|slot| slot.replace(frame));
-        Self(previous)
+        // Set unconditionally, the empty case included: a nested sub-walk
+        // whose seed block bailed has no frame of its own, and inheriting the
+        // enclosing callee's frame would publish it for the inner callee's
+        // residuals — resolving one level too shallow, the error this guard
+        // exists to stop.  An empty slot makes `ResidualFrameChainGuard::enter`
+        // publish nothing.
+        //
+        // The displaced root stays in this guard, so the enclosing level's
+        // frame keeps its own root for the whole nested sub-walk.
+        let entered = (!frame.is_null())
+            .then(|| majit_gc::shadow_stack::OwnerRootGuard::new(majit_ir::GcRef(frame as usize)));
+        Self(INLINE_CONCRETE_FRAME.with(|slot| slot.replace(entered)))
     }
 }
 
 impl Drop for InlineConcreteFrameGuard {
     fn drop(&mut self) {
-        INLINE_CONCRETE_FRAME.with(|slot| slot.set(self.0));
+        INLINE_CONCRETE_FRAME.with(|slot| *slot.borrow_mut() = self.0.take());
     }
 }
 
@@ -911,7 +927,7 @@ struct ResidualFrameChainGuard {
 
 impl ResidualFrameChainGuard {
     fn enter() -> Option<Self> {
-        let frame = INLINE_CONCRETE_FRAME.with(|slot| slot.get());
+        let frame = current_inline_concrete_frame() as *mut pyre_interpreter::PyFrame;
         if frame.is_null() {
             return None;
         }
@@ -2373,7 +2389,7 @@ pub(crate) fn try_execute_residual_call_via_executor<Sym: WalkSym>(
         // outer code object and reports whatever line that byte happens to sit
         // on.  [`LiveLastInstrGuard`] makes the matching retarget for the
         // concrete store, publishing onto the callee's own frame instead.
-        if INLINE_CONCRETE_FRAME.with(|slot| slot.get()).is_null() {
+        if current_inline_concrete_frame() == 0 {
             let last_instr = ctx.trace_ctx.const_int(ctx.vstack_cur_pypc as i64);
             crate::trace_opcode::mirror_vable_static_to_boxes(
                 ctx.trace_ctx,

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -554,9 +554,14 @@ unsafe fn generator_object_custom_trace(obj_addr: usize, f: &mut dyn FnMut(*mut 
 ///     `pyframe_object_custom_trace` recurses into locals/cells/
 ///     valuestack and the `f_backref` chain, so a frame reachable only
 ///     through a live traceback (the whole point of `tb_frame`) is not
-///     reclaimed.  A non-Gc frame (a `FrameBox::new_boxed` tracer
-///     snapshot, freed at the end of its walk) is left dangling exactly
-///     as before — never dereferenced.
+///     reclaimed.  The condition covers the pre-hook bootstrap frame
+///     (`FrameBox::new`'s `new_boxed` fallback), whose address the
+///     collector does not own and must never be handed; such a pointer
+///     is left alone and is never dereferenced.  A tracer snapshot used
+///     to land here too — the walk records tracebacks against it
+///     (`pyjitpl.rs record_application_traceback(.., self.vable_ptr, ..)`)
+///     — but `snapshot_for_tracing` is GC-owned now, so that traceback
+///     keeps its frame alive instead of dangling.
 unsafe fn pytraceback_object_custom_trace(
     obj_addr: usize,
     f: &mut dyn FnMut(*mut majit_ir::GcRef),

--- a/pyre/pyre-object/src/gc_roots.rs
+++ b/pyre/pyre-object/src/gc_roots.rs
@@ -338,16 +338,46 @@ pub fn pin_root(root: PyObjectRef) {
 /// later values were visible.
 ///
 /// Returns the first shadow-stack index occupied by `roots`.
+///
+/// A livevar set that does not sit in one slice publishes each slice with
+/// [`publish_roots`] and normalizes the whole range once with
+/// [`normalize_roots`]. Calling this function per slice would reopen the
+/// window it exists to close: the first call's queries are safepoints, and
+/// the later slices are not yet on the stack when they run.
 #[majit_macros::dont_look_inside]
 pub fn pin_roots(roots: &[PyObjectRef]) -> usize {
+    let base = publish_roots(roots);
+    normalize_roots(base, roots.len());
+    base
+}
+
+/// The write half of `push_roots(hop)`: store `roots` in fresh root-stack
+/// slots and return the first index, querying the GC for nothing.
+///
+/// Split out for the callers whose livevar set spans several slices — they run
+/// every `publish_roots` before the first [`normalize_roots`], so no value is
+/// still invisible to a foreign collector once this mutator starts entering
+/// safepoints.
+#[majit_macros::dont_look_inside]
+pub fn publish_roots(roots: &[PyObjectRef]) -> usize {
     #[cfg(debug_assertions)]
     assert_shadow_stack_not_walking();
-    let base = with_shadow_stack_mut(|stack| {
+    with_shadow_stack_mut(|stack| {
         let base = stack.len();
         stack.extend_from_slice(roots);
         base
-    });
-    for index in base..base + roots.len() {
+    })
+}
+
+/// Resolve forwarding across the `len` published slots starting at `base` —
+/// the half of the pin that is itself a GC operation. See [`pin_root`] for why
+/// a value copied into the bracket from outside it can already name a
+/// forwarded nursery object.
+#[majit_macros::dont_look_inside]
+pub fn normalize_roots(base: usize, len: usize) {
+    #[cfg(debug_assertions)]
+    assert_shadow_stack_not_walking();
+    for index in base..base + len {
         // Read the slot each time: a collection triggered by an earlier query
         // may already have rewritten every published root in place.
         let root = with_shadow_stack(|stack| stack[index]);
@@ -359,7 +389,6 @@ pub fn pin_roots(roots: &[PyObjectRef]) -> usize {
             with_shadow_stack_mut(|stack| stack[index] = current);
         }
     }
-    base
 }
 
 /// Current length of the thread-local shadow stack. Used by


### PR DESCRIPTION
Reads executing frames back out of their GC roots instead of raw copies, then follows where that leads.

## Frame handles read their root

`FrameBox` held a forwarding-capable `owner_root` and never read it back — every access went through the stale raw `ptr` field. `frame_ptr()` now answers from the slot, matching why RPython reads a GCREF local out of its shadow-stack slot rather than a register filled before the last collecting call (`rpython/memory/gc/incminimark.py:2252`). `INLINE_CONCRETE_FRAME` moved from a bare `Cell<*mut PyFrame>` to an `OwnerRootGuard` for the same reason, and `OwnerRootGuard` now resolves its thread-local cell once at acquisition instead of per read.

## The tracer snapshot is GC-owned

`snapshot_for_tracing` used `FrameBox::new_boxed`/`StdAlloc` because nothing rooted the snapshot across the `trace_bytecode` walk. The `owner_root` above is that root, so it now allocates like `snapshot_for_generator`.

This matters downstream rather than in the handle: `pyjitpl.rs` records tracing-time tracebacks against `self.vable_ptr`, which *is* the snapshot, so a traced traceback's `tb.frame` dangled the moment the walk ended. That is what the conditional frame edge, `PyTraceback.w_code` and the eager lineno stamp all existed for. A temporary counter on the skipped arm of `pytraceback_object_custom_trace` saw no non-GC frame across the whole corpus (dynasm 357/357, cranelift 357/357, wasm 353/353); the guard is kept anyway, since the evidence is an absence and the failure mode of dropping it is handing the collector a `std::alloc` address. `new_boxed`'s only remaining caller is `FrameBox::new`'s pre-GC-hook fallback, so it is private now and the four places describing the retired case were corrected.

Perf-neutral: 15 interleaved, startup-subtracted rounds — `fib_recursive` 0.998x median / 1.004x min, `nested_loop` 1.009x / 0.996x.

## Shadow stack shortens in place

`pop_to` returned `Vec::split_off(depth)`, allocating a second vector and memcpying the popped range for a caller to free. No caller reads it. In the release binary that is a `malloc` + `memcpy` in `pop_to` and a `free` in `CurrentFrameGuard::drop` on every root-scope exit, which includes every Python frame execution. `shadowstack.py:86-90 decr_stack` moves the top and hands back nothing; `pop_stack` (`:104-106`) is the separate read. `depth` is asserted rather than saturated, because `truncate` would silently strand roots where `split_off` panicked — a plain `assert!`, since this crate is extracted to LLBC.

## check.py gates peak RSS

The harness measured only time, so a change trading retained memory for speed passed every gate. `# pyre-check: max-rss-mb=N` adds that axis; absent directive means no ceiling, so no existing fixture changes status.

`getrusage(RUSAGE_CHILDREN).ru_maxrss` could not supply the number — it is a running maximum over every reaped child, not a counter, so a small fixture inherits a large predecessor's peak. `_run_timed_unix` now spawns onto temporary files and reaps with `os.wait4`, which reports this child's rusage alone; `ru_utime` comes from the same struct instead of a difference of process-wide totals. Verified with a 300MB child followed by a small one: 314MB then 14MB.

## AGENTS.md no longer contradicts parity Principle 4

"do not commit if any regress" is the opposite of *"Performance can temporarily regress… Neither the user nor the benchmark suite overrides the parity principle."* AGENTS.md is loaded every session and the skill is invoked on demand, so the contradicting rule was the standing default. Running the suite is still required; what changes is that a regression is a finding to explain, and if the slower code is the line-by-line port, the obligation is to name the upstream optimization that recovers the time rather than reinstate the shortcut.

## gate-triage.md

Records the upstream frame-allocation contract (a traceback's frame is an ordinary movable traced field; `rgc.pin` is not a lifetime facility), why pyre's non-moving allocation stands in for the translator's shadow-stack rewrite rather than being deferrable cleanup, and why `TraceCtx::virtualizable_heap_ptr` converges only when the copy-walk does — the identity must be the live frame for `compile.py:458`, and the synchronization target must be the snapshot for `refresh_virtualizable_shadow_from_heap`.

## Per-call root brackets replace the per-value owner roots

`FrameBox::new` opened ten `OwnerRootGuard`s — one per input livevar — and
`finish_for_call_with_globals_obj` pinned its four scalars and every argument
with a separate `pin_root`, then rooted the fresh locals array with a twelfth
guard. Each guard allocates an index out of a thread-local free list and each
`pin_root` runs its own forwarding query.

Both are now one `push_roots` bracket. `pin_roots` is the one-phase publish
`push_roots(hop)` performs, matching the lexical shape
`gc_enter_roots_frame` / `gc_leave_roots_frame` expresses
(`shadowcolor.py:462-606`).

Splitting a livevar set across two `pin_roots` calls would have reopened the
window the function exists to close — the first call's forwarding query is a
safepoint, and the second slice is not on the root stack while it runs. So
`pin_roots` is now the composition of two exported halves, `publish_roots`
(writes, queries nothing) and `normalize_roots` (resolves forwarding across an
already-published range); the frame builder publishes both slices, then
normalizes once.

### Measured

`acquire_owner_root` + `release_owner_root` self time, `sample` at 1 kHz,
three interleaved runs per arm, both binaries in `target/release`, arms
differing only in these two files:

| arm | set 1 | set 2 | **set 3** | root total | % of self |
|---|---|---|---|---|---|
| before | 50/45/59 | 179/125/117 | **137/156/170** | 346 | 3.86% |
| after | 68/80/60 | 157/149/122 | **20/14/16** | 243 | 2.68% |

Set 3 falls **156 → 16 median, ~10x, with no overlap between the arms**. Set 1
absorbs +18 of it, set 2 is untouched and its ranges overlap. Net root
machinery −30%. Totals were 8906–9040 samples in both arms.

This is ~1.2pp of self time, well under this machine's wall-clock resolution,
so no timing claim is made — the check is the named symbol's self time, not a
ratio.

Correctness: `cargo test` pyre-interpreter 482, pyre-object 303, majit-gc 226,
all passing. Output equivalence over all 370 bench fixtures shows zero real
differences; the single candidate (`loop_reentry_regression.py`) prints
nanosecond timings and differs across runs *within* each arm, which one run per
arm would have reported as a false positive.

## walk_jf_roots and the `is_minor` marker

Records why the stopper's early return is not ported. `walk_jf_roots` steps over
the marker word; all four backends write it and the only reader in the tree is
`test_jf_flat_array_layout`. Upstream's `walk_stack_root`
(`shadowstack.py:44-70`) returns early at an already-marked bitmask, which pays
off because upstream keeps one root stack per thread with JIT stoppers
interleaved among interpreter roots — pyre's stoppers sit in a separate
1–2-deep stack, and the deep stacks carry none, so porting the loop ports a
no-op. It would also be unsound alone: upstream disables it after a thread
switch (`can_look_at_partial_stack`) and when the nursery holds objects pinned
before the previous minor collection (`any_pinned_object_from_earlier`), and
neither condition has a counterpart here. The two-word entry stays, because it
is the layout an eventual root-set merge converges on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added peak memory (RSS) tracking for benchmark runs.
  * Added optional memory ceilings for synthetic benchmarks, with clear reporting when limits are exceeded.

* **Bug Fixes**
  * Improved garbage-collection handling for retained frames and traceback data, keeping references valid when objects move during collection.
  * Added validation and safeguards for shadow-stack operations, including errors for invalid depths.

* **Documentation**
  * Updated performance-checklist guidance and clarified frame ownership, tracing, and allocation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

