### PR TITLE
call: translator-safe __call__-slot guard + descriptor tests; operator countOf/indexOf GC fix

### DIFF
--- a/pyre/bench/synth/call_slot_descriptor_protocol.py
+++ b/pyre/bench/synth/call_slot_descriptor_protocol.py
@@ -22,6 +22,20 @@ class UsesInstance:
 assert UsesInstance()(1, 2) == (1, 2)
 
 
+# a real descriptor as __call__ — its __get__ resolves to a different callable,
+# which is then called without a host self
+class ResolvingDescriptor:
+    def __get__(self, obj, owner):
+        return lambda x: ("resolved", type(obj).__name__, x)
+
+
+class UsesDescriptor:
+    __call__ = ResolvingDescriptor()
+
+
+assert UsesDescriptor()(6) == ("resolved", "UsesDescriptor", 6)
+
+
 # already-bound method as __call__ — bound to its own receiver, no host self
 class Holder:
     def m(self, x):
@@ -58,6 +72,18 @@ class UsesInstanceKw:
 
 
 assert UsesInstanceKw()(1, x=2) == ((1,), {"x": 2})
+
+
+class ResolvingDescriptorKw:
+    def __get__(self, obj, owner):
+        return lambda a, b=0: ("resolved", a, b)
+
+
+class UsesDescriptorKw:
+    __call__ = ResolvingDescriptorKw()
+
+
+assert UsesDescriptorKw()(1, b=2) == ("resolved", 1, 2)
 
 
 class HolderKw:

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -2098,6 +2098,38 @@ pub(crate) fn range_index_method(args: &[PyObjectRef]) -> PyResult {
     ))
 }
 
+/// `descroperation.py:538 sequence_index` — the first index whose element
+/// `eq_w`-matches `w_item` (`w is w_item or w == w_item`), iterating
+/// `w_container` through the iterator protocol; a miss raises `ValueError`.
+pub(crate) fn sequence_index(w_container: PyObjectRef, w_item: PyObjectRef) -> PyResult {
+    let w_iter = iter(w_container)?;
+    // `next`/`eq_w` re-enter Python (`__next__`/`__eq__`) and may collect while
+    // the iterator and needle are still needed on the next turn; a raw local is
+    // not scanned by the collector, so both live on the shadow stack.  (RPython
+    // stack slots are GC roots; Rust's are not.)
+    let _roots = pyre_object::gc_roots::push_roots();
+    let iter_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(w_iter);
+    let item_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(w_item);
+    let mut index: i64 = 0;
+    loop {
+        match next(pyre_object::gc_roots::shadow_stack_get(iter_slot)) {
+            Ok(w_next) => {
+                if eq_w(w_next, pyre_object::gc_roots::shadow_stack_get(item_slot))? {
+                    return Ok(w_int_new(index));
+                }
+                index += 1;
+            }
+            Err(e) if e.kind == PyErrorKind::StopIteration => break,
+            Err(e) => return Err(e),
+        }
+    }
+    Err(PyError::value_error(
+        "sequence.index(x): x not in sequence".to_string(),
+    ))
+}
+
 /// `range.__iter__()` — fresh `range_iterator` (word-fit or bignum cursor).
 pub(crate) fn range_iter_method(args: &[PyObjectRef]) -> PyResult {
     iter(args[0])

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -1355,15 +1355,11 @@ fn call_callable_with_mode(
         }
         // `user_call_slot`'s stack_check bounds a self-referential
         // `A.__call__ = A()` chain only while this self-dispatch recurses
-        // natively.  Left in tail position it is a candidate for LLVM's
-        // sibling-call optimization, which rewrites it into a loop that never
-        // grows the native stack — then neither the SP check nor the depth
-        // counter trips and the chain spins forever.  The black_box barrier
-        // keeps the call off the tail so the stack grows and the check fires.
-        // (The RPython C backend does not perform this optimization, so there
-        // is no matching guard upstream.)
-        let result = call_callable_with_mode(frame, target, args, mode);
-        return std::hint::black_box(result);
+        // natively.  The call-depth guard counts this dispatch level and, by
+        // dropping only after the call returns, keeps it off the tail so LLVM
+        // cannot rewrite the self-call into a loop that never grows the stack.
+        let _depth_guard = increment_call_depth();
+        return call_callable_with_mode(frame, target, args, mode);
     }
 
     // GenericAlias.__call__ (`_pypy_generic_alias.py:41`) —
@@ -2602,11 +2598,11 @@ pub fn call_with_kwargs(
             call_args.extend_from_slice(pos_args);
             return call_with_kwargs(frame, target, &call_args, kwargs);
         }
-        // black_box: keep this self-dispatch off the tail so a self-referential
-        // `A.__call__ = A()` recurses natively for stack_check (see
-        // call_callable_with_mode).
-        let result = call_with_kwargs(frame, target, pos_args, kwargs);
-        return std::hint::black_box(result);
+        // Depth guard: count this dispatch level and, dropping after the call,
+        // keep it off the tail so a self-referential `A.__call__ = A()`
+        // recurses natively for stack_check (see call_callable_with_mode).
+        let _depth_guard = increment_call_depth();
+        return call_with_kwargs(frame, target, pos_args, kwargs);
     }
 
     // GenericAlias.__call__ (`_pypy_generic_alias.py:41`) —
@@ -2803,11 +2799,11 @@ pub fn call_function_impl_result(
                 call_args.extend_from_slice(args);
                 return call_function_impl_result(target, &call_args);
             }
-            // black_box: keep this self-dispatch off the tail so a
-            // self-referential `A.__call__ = A()` recurses natively for
-            // stack_check (see call_callable_with_mode).
-            let result = call_function_impl_result(target, args);
-            return std::hint::black_box(result);
+            // Depth guard: count this dispatch level and, dropping after the
+            // call, keep it off the tail so a self-referential
+            // `A.__call__ = A()` recurses natively for stack_check.
+            let _depth_guard = increment_call_depth();
+            return call_function_impl_result(target, args);
         }
     }
     let type_name = crate::typedef::r#type(callable)

--- a/pyre/pyre-interpreter/src/module/operator/app_operator.py
+++ b/pyre/pyre-interpreter/src/module/operator/app_operator.py
@@ -1,9 +1,18 @@
 # app_operator.py — app-level helpers for the operator module.
-# attrgetter / itemgetter / methodcaller are callable factory classes that
-# the interp-level operator module cannot express as plain functions.
-# Mirrors pypy/module/operator/app_operator.py.
+# countOf is a plain loop; attrgetter / itemgetter / methodcaller are callable
+# factory classes that the interp-level operator module cannot express as plain
+# functions.  Mirrors pypy/module/operator/app_operator.py.
 
 __name__ = 'operator'
+
+
+def countOf(a, b):
+    'countOf(a, b) -- Return the number of times b occurs in a.'
+    count = 0
+    for x in a:
+        if x is b or x == b:
+            count += 1
+    return count
 
 
 class attrgetter(object):

--- a/pyre/pyre-interpreter/src/module/operator/mod.rs
+++ b/pyre/pyre-interpreter/src/module/operator/mod.rs
@@ -132,66 +132,18 @@ use crate::baseobjspace::{
     matmul, mod_, mul, neg, or_, pos, pow, rshift, setitem, sub, truediv, xor,
 };
 
-/// `countOf(a, b)` — number of times `b` occurs in `a`, counting `x is b or
-/// x == b` while iterating `a` through the iterator protocol.
-fn op_countof(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    let iterator = baseobjspace::iter(args[0])?;
-    let mut count = 0i64;
-    loop {
-        match baseobjspace::next(iterator) {
-            Ok(item) => {
-                if std::ptr::eq(item, args[1])
-                    || is_true(baseobjspace::compare(item, args[1], CompareOp::Eq)?)?
-                {
-                    count += 1;
-                }
-            }
-            Err(e) if e.kind == crate::PyErrorKind::StopIteration => break,
-            Err(e) => return Err(e),
-        }
-    }
-    Ok(w_int_new(count))
-}
-
-/// `indexOf(a, b)` — first index `i` where `a[i] is b or a[i] == b`, iterating
-/// `a` through the iterator protocol; a miss raises
-/// `ValueError('sequence.index(x): x not in sequence')`.
-fn op_indexof(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    let iterator = baseobjspace::iter(args[0])?;
-    let mut index = 0i64;
-    loop {
-        match baseobjspace::next(iterator) {
-            Ok(item) => {
-                if std::ptr::eq(item, args[1])
-                    || is_true(baseobjspace::compare(item, args[1], CompareOp::Eq)?)?
-                {
-                    return Ok(w_int_new(index));
-                }
-                index += 1;
-            }
-            Err(e) if e.kind == crate::PyErrorKind::StopIteration => break,
-            Err(e) => return Err(e),
-        }
-    }
-    Err(crate::PyError::value_error(
-        "sequence.index(x): x not in sequence",
-    ))
-}
-
 crate::py_module! {
     "operator",
-    // Only the `itemgetter`/`attrgetter`/`methodcaller` callable factory
-    // classes stay app-level (`pypy/module/operator/app_operator.py`,
-    // `moduledef.py` `app_names`); a factory class cannot be expressed as a
-    // plain interp-level function.  `countOf`/`indexOf`/`inv`/`is_none`/
-    // `is_not_none`/`call` live in the `functions:` block below so they
-    // register as non-binding `BuiltinFunction` (no `__get__`), instead of
-    // globals-bearing app-level functions that bind `self` when stored on a
-    // class.  `concat` is interp-level (`op_concat`, `interp_operator.py:20`)
-    // so it guards both operands for `__getitem__`.
+    // `moduledef.py` `app_names` — `countOf` (a plain `app_operator.py` loop)
+    // and the `attrgetter`/`itemgetter`/`methodcaller` factory classes (which
+    // cannot be plain interp-level functions) — are the only app-level names.
+    // Everything else is interp-level: `indexOf` delegates to
+    // `space.sequence_index` (`interp_operator.py:58`) and `concat`
+    // (`op_concat`, `interp_operator.py:20`) guards both operands for
+    // `__getitem__`.
     appleveldefs: {
         "app_operator.py" => [
-            "itemgetter", "attrgetter", "methodcaller",
+            "countOf", "itemgetter", "attrgetter", "methodcaller",
         ],
     },
     functions: {
@@ -239,8 +191,7 @@ crate::py_module! {
         "is_none"     / 1 = |args| Ok(w_bool_from(std::ptr::eq(args[0], w_none()))),
         "is_not_none" / 1 = |args| Ok(w_bool_from(!std::ptr::eq(args[0], w_none()))),
         "contains" / 2 = |args| Ok(w_bool_from(contains(args[0], args[1])?)),
-        "countOf"  / 2 = op_countof,
-        "indexOf"  / 2 = op_indexof,
+        "indexOf"  / 2 = |args| baseobjspace::sequence_index(args[0], args[1]),
         // `call(obj, /, *args, **kwargs)` == `obj(*args, **kwargs)`.
         // `call_forwarding_args` re-splits the `__pyre_kw__` marker back into
         // keyword arguments before dispatching.


### PR DESCRIPTION
Post-merge review follow-ups to #927 (Codex / CodeRabbit), bundled into one PR.

## 1. Translator-safe `__call__`-slot self-dispatch guard (`d880269`)
#927 kept each `__call__`-slot self-dispatch off the tail with
`std::hint::black_box` to defeat the LLVM sibling-call TCO that otherwise made
`stack_check` blind (a self-referential `__call__` hung instead of raising
`RecursionError`). The majit translator only recognizes `core::hint::n` and
`core::convert::identity` as identity passthroughs, **not** `black_box`, so a
dynasm build could translate it incorrectly. Replaced `black_box` at all three
slot call sites with an `increment_call_depth()` RAII guard: its `Drop` after
the call keeps the dispatch off the tail **and** counts the recursion level,
and it is already translator-supported.

## 2. Descriptor-protocol `__call__` regression tests (`d880269`)
`bench/synth/call_slot_descriptor_protocol.py` now exercises the full protocol —
callable instance, a real `__get__` descriptor, a bound method, and a plain
function as `__call__` — on both the positional and keyword call paths. The
builtin-as-`__call__` case is deliberately excluded (CPython 3.14 vs PyPy
diverge, so no single expected output passes on every backend).

## 3. `operator.countOf`/`indexOf` GC soundness (`8a5c749`, #924)
The hand-rolled `op_countof`/`op_indexof` loops held the iterator and needle in
raw Rust locals across `__next__`/`__eq__`, which can trigger a collection —
raw locals are not shadow-stack roots, so a moving/freeing GC could invalidate
them mid-walk. Realigned to the PyPy structure:
- `countOf` → `app_operator.py` (`moduledef.py` `app_names`), a plain loop.
- `indexOf` → delegates to a new `baseobjspace::sequence_index`
  (`interp_operator.py:58` → `descroperation.py:538`) that pins the iterator
  and needle on the shadow stack, so they survive collection.

## Verification (`PYRE_JIT=0`, pure-interp build)
- `call_slot_descriptor_protocol.py` → OK
- countOf/indexOf: correctness, NaN identity (`eq_w`), miss `ValueError`,
  GC-stress (`__eq__` forcing `gc.collect()` mid-iteration), `indexOf`
  non-binding when stored on a class → OK, and byte-identical to CPython 3.14
  and PyPy
- `test.test_descr` → 162 OK, `test.test_operator` → 110 OK (no regression)

— *commented by Claude*