### PR TITLE
Close the PR #937 review queue: GC rooting fixes, os.kill unwrap_spec, and the frame root-walk floor

### DIFF
--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -7589,8 +7589,12 @@ pub(crate) fn space_int(obj: PyObjectRef) -> Result<PyObjectRef, PyError> {
         // baseobjspace.py:321-323 `w_impl = space.lookup(self, '__index__')`
         .or_else(|| unsafe { lookup(obj, "__index__") });
     let Some(method) = w_impl else {
-        // baseobjspace.py:323 `self._typed_unwrap_error(space, "integer")`
-        return Err(PyError::type_error("expected integer"));
+        // baseobjspace.py:323 `self._typed_unwrap_error(space, "integer")`,
+        // whose body (:316-318) is `"expected %s, got %T object"`.
+        return Err(PyError::type_error(format!(
+            "expected integer, got {} object",
+            object_functionstr_type_name(obj)
+        )));
     };
     // baseobjspace.py:324 `w_result = space.get_and_call_function(w_impl, self)`
     let w_type = crate::typedef::r#type(obj)

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -709,6 +709,21 @@ unsafe fn chain_next_frame(f_backref: *mut PyFrame) -> *mut PyFrame {
     crate::executioncontext::vref_referent(f_backref)
 }
 
+/// How much of `locals_cells_stack_w` is reachable state.
+///
+/// `valuestackdepth` is an absolute index that starts at `stack_base()`
+/// (`pyframe.rs:2136`) and `pop` refuses to go below it, so for a running
+/// frame it already covers the locals/cells prefix. `PyFrame::descr_clear`
+/// is the one writer that breaks that: it rebinds every cell slot to a fresh
+/// `w_cell_new` and then sets `valuestackdepth = 0`. Clamping to the raw
+/// depth would walk zero slots for such a frame and drop cells that the
+/// array still points at, so the prefix is the floor. The array is
+/// `PY_NULL`-filled at allocation, so widening never reads uninitialised
+/// slots.
+unsafe fn walk_depth(f: &PyFrame, arr: &FixedObjectArray) -> usize {
+    f.valuestackdepth.max(f.stack_base()).min(arr.len())
+}
+
 /// Walk one captured thread's active frame and interpreter root state.
 ///
 /// # Safety
@@ -849,15 +864,12 @@ pub unsafe fn walk_pyframe_roots_area(
             // minor collection is always synchronous with respect to the
             // interpreter thread, so frames cannot be dropped mid-walk.
             //
-            // We walk the FULL fixed-length array (not just the live
-            // `valuestackdepth` prefix). Argument values in transit —
-            // popped from the caller's stack before the callee frame
-            // is installed — are briefly invisible from
-            // `valuestackdepth` alone, yet still reachable from the
-            // popped-slot storage. Non-ref slots are filtered by
-            // `is_nursery_object_start` inside the collector, so
-            // walking past the live depth is harmless for the
-            // bump-pointer nursery.
+            // The walk covers `[0, walk_depth)` — the locals/cells prefix
+            // plus the live operand stack. Slots above it are popped
+            // capacity, not roots. Non-ref slots are filtered by
+            // `is_nursery_object_start` inside the collector, so a slot
+            // holding a non-object word is harmless for the bump-pointer
+            // nursery.
             //
             // The walk runs for every frame on the chain, including
             // ones the GC owns. For nursery-allocated frames the
@@ -1002,7 +1014,7 @@ pub unsafe fn walk_pyframe_roots_area(
                     let arr = &*f.locals_cells_stack_w;
                     (
                         arr.items_ptr() as *mut PyObjectRef,
-                        f.valuestackdepth.min(arr.len()),
+                        walk_depth(f, arr),
                         next_frame,
                     )
                 }
@@ -1273,10 +1285,7 @@ pub fn walk_suspended_generator_frame(
         if !(*frame).locals_cells_stack_w.is_null() {
             let arr = &*(*frame).locals_cells_stack_w;
             let base = arr.items_ptr() as *mut PyObjectRef;
-            // Locals/cells occupy the fixed prefix and
-            // `valuestackdepth` extends it through the live operand stack.
-            // Slots above it are popped capacity, not GC roots.
-            let len = (*frame).valuestackdepth.min(arr.len());
+            let len = walk_depth(&*frame, arr);
             for i in 0..len {
                 visitor(&mut *(base.add(i) as *mut majit_ir::GcRef));
             }

--- a/pyre/pyre-interpreter/src/executioncontext.rs
+++ b/pyre/pyre-interpreter/src/executioncontext.rs
@@ -2260,12 +2260,18 @@ impl UserDelAction {
         if self.gc_disabled(current()) {
             return;
         }
+        // `__del__` runs arbitrary Python, so it can collect and move the
+        // callable that the error report names; publish it and read it back
+        // the way `current()` does for the receiver.
+        pyre_object::gc_roots::pin_root(w_del);
+        let del_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+        let del = || pyre_object::gc_roots::shadow_stack_get(del_slot);
         // pyre's combined helper cannot distinguish get-vs-call errors;
         // report through the call arm (executioncontext.py:680-690).
         if let Err(error) = unsafe {
-            crate::baseobjspace::get_and_call_function(w_del, current(), w_type.as_ptr(), &[])
+            crate::baseobjspace::get_and_call_function(del(), current(), w_type.as_ptr(), &[])
         } {
-            report_error(self.base.space, &error, "", w_del);
+            report_error(self.base.space, &error, "", del());
         }
     }
 }

--- a/pyre/pyre-interpreter/src/module/_multiprocessing/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_multiprocessing/mod.rs
@@ -1,14 +1,26 @@
 //! _multiprocessing module — PyPy: `pypy/module/_multiprocessing/`.
 //!
 //! Exposes `SemLock(kind, value, maxvalue, name, unlink)` and
-//! `sem_unlink(name)`.  Single-threaded pyre still needs the methods to
-//! exist so multiprocessing.py teardown survives.  Backed by libc
-//! `sem_t` via `rustpython_host_env::multiprocessing`; unix + host_env
-//! only — other platforms get an empty module so `import
-//! _multiprocessing` succeeds.
+//! `sem_unlink(name)`.  Backed by libc `sem_t` via
+//! `rustpython_host_env::multiprocessing`; unix + host_env only — other
+//! platforms get an empty module so `import _multiprocessing` succeeds.
+//!
+//! `W_SemLock`'s fields (`interp_semaphore.py:458-466`) live in the instance
+//! dict rather than a typed payload: `handle`, `kind`, `maxvalue` and `name`
+//! are the values behind the `GetSetProperty`s of
+//! `interp_semaphore.py:593-599`, and `count`/`last_tid` are the recursion
+//! bookkeeping `_ismine` reads.  A dict-backed field is also readable as a
+//! plain attribute, which is wider than the typedef; the alternative — a
+//! handle-keyed side table — has no upstream counterpart.
 
 #[cfg(all(unix, feature = "host_env"))]
 use pyre_object::*;
+
+/// `interp_semaphore.py:17 RECURSIVE_MUTEX, SEMAPHORE = range(2)`.
+#[cfg(all(unix, feature = "host_env"))]
+const RECURSIVE_MUTEX: i64 = 0;
+#[cfg(all(unix, feature = "host_env"))]
+const SEMAPHORE: i64 = 1;
 
 #[cfg(all(unix, feature = "host_env"))]
 fn semlock_get_handle(obj: PyObjectRef) -> *mut libc::sem_t {
@@ -22,6 +34,310 @@ fn semlock_get_handle(obj: PyObjectRef) -> *mut libc::sem_t {
         }
     }
     core::ptr::null_mut()
+}
+
+/// Read one of the integer fields of `interp_semaphore.py:458-466`.  A missing
+/// or non-int entry reads as 0, which only happens on an instance whose dict a
+/// caller has torn up.
+#[cfg(all(unix, feature = "host_env"))]
+fn semlock_get_i64(obj: PyObjectRef, key: &str) -> i64 {
+    let d = crate::baseobjspace::getdict_native(obj);
+    if d.is_null() {
+        return 0;
+    }
+    match unsafe { w_dict_getitem_str(d, key) } {
+        Some(v) if unsafe { is_int(v) } => unsafe { w_int_get_value(v) },
+        _ => 0,
+    }
+}
+
+/// Write one of those fields.  Boxing the value and materialising the dict can
+/// both collect, so every operand is published and re-read from the shadow
+/// stack at the store, exactly as `semlock_instance` does.
+#[cfg(all(unix, feature = "host_env"))]
+fn semlock_set_i64(obj: PyObjectRef, key: &str, value: i64) {
+    let _roots = pyre_object::gc_roots::push_roots();
+    let obj_slot = pyre_object::gc_roots::pin_roots(&[obj]);
+    let boxed_slot = obj_slot + 1;
+    pyre_object::gc_roots::pin_root(w_int_new(value));
+    let dict = crate::baseobjspace::getdict_native(pyre_object::gc_roots::shadow_stack_get(
+        obj_slot,
+    ));
+    if dict.is_null() {
+        return;
+    }
+    let dict_slot = boxed_slot + 1;
+    pyre_object::gc_roots::pin_root(dict);
+    unsafe {
+        w_dict_setitem_str(
+            pyre_object::gc_roots::shadow_stack_get(dict_slot),
+            key,
+            pyre_object::gc_roots::shadow_stack_get(boxed_slot),
+        )
+    };
+}
+
+/// `interp_semaphore.py:486-487 W_SemLock._ismine`.
+#[cfg(all(unix, feature = "host_env"))]
+fn semlock_ismine(obj: PyObjectRef) -> bool {
+    semlock_get_i64(obj, "count") > 0
+        && crate::module::thread::current_ident() == semlock_get_i64(obj, "last_tid")
+}
+
+#[cfg(all(unix, feature = "host_env"))]
+fn semlock_post(handle: *mut libc::sem_t) -> Result<(), crate::PyError> {
+    if unsafe { libc::sem_post(handle) } != 0 {
+        return Err(crate::PyError::os_error_with_errno(
+            std::io::Error::last_os_error().raw_os_error().unwrap_or(0),
+            "sem_post",
+        ));
+    }
+    Ok(())
+}
+
+/// `interp_semaphore.py:431-441 semlock_getvalue`.  Not built on darwin, where
+/// `sem_getvalue` always fails (`HAVE_BROKEN_SEM_GETVALUE`,
+/// `interp_semaphore.py:86-89`) and the `sem_trywait` fallbacks run instead.
+#[cfg(all(unix, feature = "host_env", not(target_vendor = "apple")))]
+fn semlock_getvalue(handle: *mut libc::sem_t) -> Result<i64, crate::PyError> {
+    let mut val: libc::c_int = 0;
+    if unsafe { libc::sem_getvalue(handle, &mut val) } != 0 {
+        return Err(crate::PyError::os_error_with_errno(
+            std::io::Error::last_os_error().raw_os_error().unwrap_or(0),
+            "sem_getvalue",
+        ));
+    }
+    // some posix implementations use negative numbers to indicate the number of
+    // waiting threads
+    Ok(if val < 0 { 0 } else { val as i64 })
+}
+
+/// `interp_semaphore.py:443-455 semlock_iszero`.
+#[cfg(all(unix, feature = "host_env"))]
+fn semlock_iszero(handle: *mut libc::sem_t) -> Result<bool, crate::PyError> {
+    #[cfg(target_vendor = "apple")]
+    {
+        if unsafe { libc::sem_trywait(handle) } == 0 {
+            semlock_post(handle)?;
+            return Ok(false);
+        }
+        let errno = std::io::Error::last_os_error().raw_os_error().unwrap_or(0);
+        if errno != libc::EAGAIN {
+            return Err(crate::PyError::os_error_with_errno(errno, "sem_trywait"));
+        }
+        Ok(true)
+    }
+    #[cfg(not(target_vendor = "apple"))]
+    {
+        Ok(semlock_getvalue(handle)? == 0)
+    }
+}
+
+/// `interp_semaphore.py:357-400 semlock_acquire` — the platform wait alone.
+/// Upstream bumps `self.last_tid`/`self.count` here (`:395-396`); the receiver
+/// stays with the caller instead, which does it on the success return.
+#[cfg(all(unix, feature = "host_env"))]
+fn semlock_acquire(
+    handle: *mut libc::sem_t,
+    block: bool,
+    timeout: Option<f64>,
+) -> Result<bool, crate::PyError> {
+    // PEP 475 — sem_wait/sem_trywait retry on EINTR; otherwise
+    // EAGAIN (only meaningful for trywait) yields False and the
+    // remaining errnos propagate as OSError instead of being
+    // silently mapped to False.
+    // `interp_semaphore.py:378-397 semlock_acquire` — on EINTR deliver
+    // a pending signal then retry; on success deliver one too before
+    // returning (`_check_signals(space)`).
+    if block && timeout.is_none() {
+        loop {
+            let r = unsafe { libc::sem_wait(handle) };
+            if r == 0 {
+                break;
+            }
+            let errno = std::io::Error::last_os_error().raw_os_error().unwrap_or(0);
+            if errno == libc::EINTR {
+                crate::module::signal::interp_signal::checksignals_now()?;
+                continue;
+            }
+            return Err(crate::PyError::os_error_with_errno(errno, "sem_wait"));
+        }
+        crate::module::signal::interp_signal::checksignals_now()?;
+        Ok(true)
+    } else if !block {
+        loop {
+            let r = unsafe { libc::sem_trywait(handle) };
+            if r == 0 {
+                crate::module::signal::interp_signal::checksignals_now()?;
+                return Ok(true);
+            }
+            let errno = std::io::Error::last_os_error().raw_os_error().unwrap_or(0);
+            if errno == libc::EINTR {
+                crate::module::signal::interp_signal::checksignals_now()?;
+                continue;
+            }
+            if errno == libc::EAGAIN {
+                return Ok(false);
+            }
+            return Err(crate::PyError::os_error_with_errno(errno, "sem_trywait"));
+        }
+    } else {
+        let deadline =
+            rustpython_host_env::multiprocessing::deadline_from_timeout(timeout.unwrap()).map_err(
+                |error| {
+                    crate::PyError::os_error_with_errno(error.raw_os_error(), error.description())
+                },
+            )?;
+        #[cfg(target_vendor = "apple")]
+        {
+            let mut delay = 0;
+            loop {
+                use rustpython_host_env::multiprocessing::PollWaitStep;
+                match rustpython_host_env::multiprocessing::sem_timedwait_poll_step(
+                    handle, &deadline, delay,
+                )
+                .map_err(|error| {
+                    crate::PyError::os_error_with_errno(error.raw_os_error(), error.description())
+                })? {
+                    PollWaitStep::Acquired => {
+                        crate::module::signal::interp_signal::checksignals_now()?;
+                        return Ok(true);
+                    }
+                    PollWaitStep::Timeout => return Ok(false),
+                    PollWaitStep::Continue(next_delay) => delay = next_delay,
+                }
+            }
+        }
+        #[cfg(not(target_vendor = "apple"))]
+        loop {
+            use rustpython_host_env::multiprocessing::WaitStatus;
+            match rustpython_host_env::multiprocessing::sem_wait_status(handle, Some(&deadline)) {
+                WaitStatus::Acquired => {
+                    crate::module::signal::interp_signal::checksignals_now()?;
+                    return Ok(true);
+                }
+                WaitStatus::TimedOut => return Ok(false),
+                WaitStatus::Interrupted => {
+                    crate::module::signal::interp_signal::checksignals_now()?;
+                }
+                WaitStatus::Error(error) => {
+                    return Err(crate::PyError::os_error_with_errno(
+                        error.raw_os_error(),
+                        error.description(),
+                    ));
+                }
+            }
+        }
+    }
+}
+
+/// `interp_semaphore.py:403-429 semlock_release`.
+#[cfg(all(unix, feature = "host_env"))]
+fn semlock_release(
+    handle: *mut libc::sem_t,
+    kind: i64,
+    maxvalue: i64,
+) -> Result<(), crate::PyError> {
+    if kind == RECURSIVE_MUTEX {
+        return semlock_post(handle);
+    }
+    #[cfg(target_vendor = "apple")]
+    {
+        // `HAVE_BROKEN_SEM_GETVALUE`: only the maxvalue == 1 case can be
+        // checked properly.
+        if maxvalue == 1 {
+            // make sure that already locked
+            if unsafe { libc::sem_trywait(handle) } == 0 {
+                // it was not locked so undo wait and raise
+                let _ = unsafe { libc::sem_post(handle) };
+                return Err(crate::PyError::value_error(
+                    "semaphore or lock released too many times",
+                ));
+            }
+            let errno = std::io::Error::last_os_error().raw_os_error().unwrap_or(0);
+            if errno != libc::EAGAIN {
+                return Err(crate::PyError::os_error_with_errno(errno, "sem_trywait"));
+            }
+            // it is already locked as expected
+        }
+    }
+    #[cfg(not(target_vendor = "apple"))]
+    {
+        // This check is not an absolute guarantee that the semaphore does not
+        // rise above maxvalue.
+        if semlock_getvalue(handle)? >= maxvalue {
+            return Err(crate::PyError::value_error(
+                "semaphore or lock released too many times",
+            ));
+        }
+    }
+    semlock_post(handle)
+}
+
+/// `interp_semaphore.py:506-523 W_SemLock.acquire` — shared by `acquire` and
+/// `__enter__`, which the class methods cannot reach through each other.
+#[cfg(all(unix, feature = "host_env"))]
+fn w_semlock_acquire(
+    self_obj: PyObjectRef,
+    block: bool,
+    timeout: Option<f64>,
+) -> Result<bool, crate::PyError> {
+    let _roots = pyre_object::gc_roots::push_roots();
+    let self_slot = pyre_object::gc_roots::pin_roots(&[self_obj]);
+    // check whether we already own the lock
+    if semlock_get_i64(self_obj, "kind") == RECURSIVE_MUTEX && semlock_ismine(self_obj) {
+        semlock_set_i64(self_obj, "count", semlock_get_i64(self_obj, "count") + 1);
+        return Ok(true);
+    }
+    let handle = semlock_get_handle(self_obj);
+    if handle.is_null() {
+        return Err(crate::PyError::value_error("SemLock handle is null"));
+    }
+    let got = semlock_acquire(handle, block, timeout)?;
+    if got {
+        // `interp_semaphore.py:512-516` — these steps need to be as close as
+        // possible to acquiring the semlock for `_ismine` to support multiple
+        // threads.  The wait can run signal handlers, so the receiver comes
+        // back off the shadow stack.
+        let self_obj = pyre_object::gc_roots::shadow_stack_get(self_slot);
+        semlock_set_i64(
+            self_obj,
+            "last_tid",
+            crate::module::thread::current_ident(),
+        );
+        semlock_set_i64(self_obj, "count", semlock_get_i64(self_obj, "count") + 1);
+    }
+    Ok(got)
+}
+
+/// `interp_semaphore.py:525-541 W_SemLock.release` — shared by `release` and
+/// `__exit__`.
+#[cfg(all(unix, feature = "host_env"))]
+fn w_semlock_release(self_obj: PyObjectRef) -> Result<(), crate::PyError> {
+    let _roots = pyre_object::gc_roots::push_roots();
+    let self_slot = pyre_object::gc_roots::pin_roots(&[self_obj]);
+    let kind = semlock_get_i64(self_obj, "kind");
+    if kind == RECURSIVE_MUTEX {
+        if !semlock_ismine(self_obj) {
+            return Err(crate::PyError::new(
+                crate::error::PyErrorKind::AssertionError,
+                "attempt to release recursive lock not owned by thread",
+            ));
+        }
+        let count = semlock_get_i64(self_obj, "count");
+        if count > 1 {
+            semlock_set_i64(self_obj, "count", count - 1);
+            return Ok(());
+        }
+    }
+    let handle = semlock_get_handle(self_obj);
+    if handle.is_null() {
+        return Err(crate::PyError::value_error("SemLock handle is null"));
+    }
+    semlock_release(handle, kind, semlock_get_i64(self_obj, "maxvalue"))?;
+    let self_obj = pyre_object::gc_roots::shadow_stack_get(self_slot);
+    semlock_set_i64(self_obj, "count", semlock_get_i64(self_obj, "count") - 1);
+    Ok(())
 }
 
 #[cfg(all(unix, feature = "host_env"))]
@@ -63,6 +379,9 @@ fn semlock_instance(
         "name",
         kept_name.map_or_else(w_none, |name| w_str_new(&name))
     );
+    // interp_semaphore.py:462,465 `self.count = 0`, `self.last_tid = -1`.
+    store!("count", w_int_new(0));
+    store!("last_tid", w_int_new(-1));
     Ok(pyre_object::gc_roots::shadow_stack_get(root_base))
 }
 
@@ -83,6 +402,10 @@ fn semlock_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
         return Err(crate::PyError::type_error("SemLock: name must be a string"));
     };
     let unlink = crate::baseobjspace::is_true(args[5])?;
+    // interp_semaphore.py:574-575.
+    if kind != RECURSIVE_MUTEX && kind != SEMAPHORE {
+        return Err(crate::PyError::value_error("unrecognized kind"));
+    }
     let (handle, kept_name) = rustpython_host_env::multiprocessing::SemHandle::create(
         &name,
         value as libc::c_uint,
@@ -98,29 +421,46 @@ fn semlock_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
     semlock_instance(w_subtype, raw, kind, maxvalue, kept_name)
 }
 
+/// `interp_semaphore.py:547-561 W_SemLock.rebuild`, registered as a
+/// classmethod (`:606`), so `args[0]` is the bound class.
 #[cfg(all(unix, feature = "host_env"))]
 fn semlock_rebuild(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    if args.len() != 4 {
+    if args.len() != 5 {
         return Err(crate::PyError::type_error(
             "_rebuild() takes exactly 4 arguments",
         ));
     }
-    let kind = crate::baseobjspace::int_w(args[1])?;
-    let maxvalue = crate::baseobjspace::int_w(args[2])?;
-    let name = if unsafe { is_str(args[3]) } {
-        crate::baseobjspace::str_utf8_w(args[3])?.to_string()
+    let w_cls = args[0];
+    let kind = crate::baseobjspace::int_w(args[2])?;
+    let maxvalue = crate::baseobjspace::int_w(args[3])?;
+    // `unwrap_spec(name='text_or_none')` — an unlinked semaphore carries no
+    // name and travels as its raw handle instead.
+    let name = if unsafe { is_none(args[4]) } {
+        None
+    } else if unsafe { is_str(args[4]) } {
+        Some(crate::baseobjspace::str_utf8_w(args[4])?.to_string())
     } else {
         return Err(crate::PyError::type_error(
-            "SemLock._rebuild requires a semaphore name",
+            "_rebuild() argument 'name' must be str or None",
         ));
     };
-    let handle =
-        rustpython_host_env::multiprocessing::SemHandle::open_existing(&name).map_err(|error| {
-            crate::PyError::os_error_with_errno(error.raw_os_error(), error.description())
-        })?;
-    let raw = handle.as_ptr();
-    core::mem::forget(handle);
-    semlock_instance(type_object(), raw, kind, maxvalue, Some(name))
+    let raw = match &name {
+        // interp_semaphore.py:550-555 — with a name, reopen it and ignore
+        // `w_handle`.
+        Some(name) => {
+            let handle = rustpython_host_env::multiprocessing::SemHandle::open_existing(name)
+                .map_err(|error| {
+                    crate::PyError::os_error_with_errno(error.raw_os_error(), error.description())
+                })?;
+            let raw = handle.as_ptr();
+            core::mem::forget(handle);
+            raw
+        }
+        // interp_semaphore.py:557 `handle = handle_w(space, w_handle)`
+        // (`:223-224`).
+        None => crate::baseobjspace::int_w(args[1])? as usize as *mut libc::sem_t,
+    };
+    semlock_instance(w_cls, raw, kind, maxvalue, name)
 }
 
 #[cfg(all(unix, feature = "host_env"))]
@@ -132,164 +472,70 @@ crate::py_class! {
             blocking: Option<i64>,
             timeout: Option<PyObjectRef>,
         ) -> Result<bool, crate::PyError> {
-            let handle = semlock_get_handle(self_obj);
-            if handle.is_null() {
-                return Err(crate::PyError::value_error("SemLock handle is null"));
-            }
-            let blocking = blocking.map(|v| v != 0).unwrap_or(true);
+            let block = blocking.map(|v| v != 0).unwrap_or(true);
             let timeout = match timeout {
                 Some(value) if unsafe { !is_none(value) } => {
                     Some(crate::baseobjspace::float_w(value)?)
                 }
                 _ => None,
             };
-            // PEP 475 — sem_wait/sem_trywait retry on EINTR; otherwise
-            // EAGAIN (only meaningful for trywait) yields False and the
-            // remaining errnos propagate as OSError instead of being
-            // silently mapped to False.
-            // `interp_semaphore.py:378-397 semlock_acquire` — on EINTR deliver
-            // a pending signal then retry; on success deliver one too before
-            // returning (`_check_signals(space)`).
-            if blocking && timeout.is_none() {
-                loop {
-                    let r = unsafe { libc::sem_wait(handle) };
-                    if r == 0 {
-                        break;
-                    }
-                    let errno = std::io::Error::last_os_error().raw_os_error().unwrap_or(0);
-                    if errno == libc::EINTR {
-                        crate::module::signal::interp_signal::checksignals_now()?;
-                        continue;
-                    }
-                    return Err(crate::PyError::os_error_with_errno(errno, "sem_wait"));
-                }
-                crate::module::signal::interp_signal::checksignals_now()?;
-                Ok(true)
-            } else if !blocking {
-                loop {
-                    let r = unsafe { libc::sem_trywait(handle) };
-                    if r == 0 {
-                        crate::module::signal::interp_signal::checksignals_now()?;
-                        return Ok(true);
-                    }
-                    let errno = std::io::Error::last_os_error().raw_os_error().unwrap_or(0);
-                    if errno == libc::EINTR {
-                        crate::module::signal::interp_signal::checksignals_now()?;
-                        continue;
-                    }
-                    if errno == libc::EAGAIN {
-                        return Ok(false);
-                    }
-                    return Err(crate::PyError::os_error_with_errno(errno, "sem_trywait"));
-                }
-            } else {
-                let deadline =
-                    rustpython_host_env::multiprocessing::deadline_from_timeout(timeout.unwrap())
-                        .map_err(|error| {
-                            crate::PyError::os_error_with_errno(
-                                error.raw_os_error(),
-                                error.description(),
-                            )
-                        })?;
-                #[cfg(target_vendor = "apple")]
-                {
-                    let mut delay = 0;
-                    loop {
-                        use rustpython_host_env::multiprocessing::PollWaitStep;
-                        match rustpython_host_env::multiprocessing::sem_timedwait_poll_step(
-                            handle, &deadline, delay,
-                        )
-                        .map_err(|error| {
-                            crate::PyError::os_error_with_errno(
-                                error.raw_os_error(),
-                                error.description(),
-                            )
-                        })? {
-                            PollWaitStep::Acquired => {
-                                crate::module::signal::interp_signal::checksignals_now()?;
-                                return Ok(true);
-                            }
-                            PollWaitStep::Timeout => return Ok(false),
-                            PollWaitStep::Continue(next_delay) => delay = next_delay,
-                        }
-                    }
-                }
-                #[cfg(not(target_vendor = "apple"))]
-                loop {
-                    use rustpython_host_env::multiprocessing::WaitStatus;
-                    match rustpython_host_env::multiprocessing::sem_wait_status(
-                        handle,
-                        Some(&deadline),
-                    ) {
-                        WaitStatus::Acquired => {
-                            crate::module::signal::interp_signal::checksignals_now()?;
-                            return Ok(true);
-                        }
-                        WaitStatus::TimedOut => return Ok(false),
-                        WaitStatus::Interrupted => {
-                            crate::module::signal::interp_signal::checksignals_now()?;
-                        }
-                        WaitStatus::Error(error) => {
-                            return Err(crate::PyError::os_error_with_errno(
-                                error.raw_os_error(),
-                                error.description(),
-                            ));
-                        }
-                    }
-                }
-            }
+            w_semlock_acquire(self_obj, block, timeout)
         }
         fn release(self_obj: PyObjectRef) -> Result<(), crate::PyError> {
+            w_semlock_release(self_obj)
+        }
+        // interp_semaphore.py:483-484 W_SemLock.get_count
+        fn _count(self_obj: PyObjectRef) -> i64 {
+            semlock_get_i64(self_obj, "count")
+        }
+        // interp_semaphore.py:489-490 W_SemLock.is_mine
+        fn _is_mine(self_obj: PyObjectRef) -> bool {
+            semlock_ismine(self_obj)
+        }
+        // interp_semaphore.py:544-545 W_SemLock.after_fork
+        fn _after_fork(self_obj: PyObjectRef) {
+            semlock_set_i64(self_obj, "count", 0);
+        }
+        // interp_semaphore.py:492-497 W_SemLock.is_zero
+        fn _is_zero(self_obj: PyObjectRef) -> Result<bool, crate::PyError> {
             let handle = semlock_get_handle(self_obj);
             if handle.is_null() {
                 return Err(crate::PyError::value_error("SemLock handle is null"));
             }
-            let r = unsafe { libc::sem_post(handle) };
-            if r != 0 {
-                return Err(crate::PyError::os_error_with_errno(
-                    std::io::Error::last_os_error().raw_os_error().unwrap_or(0),
-                    "sem_post",
-                ));
-            }
-            Ok(())
+            semlock_iszero(handle)
         }
-        fn _count(self_obj: PyObjectRef) -> i64 {
-            let _ = self_obj;
-            0
-        }
-        fn _is_mine(self_obj: PyObjectRef) -> bool {
-            let _ = self_obj;
-            false
-        }
-        fn _after_fork(self_obj: PyObjectRef) {
-            let _ = self_obj;
-        }
-        // `sem_getvalue` isn't available on macOS; just return false —
-        // multiprocessing.Queue teardown is the only consumer and it
-        // tolerates a conservative "not zero" answer.
-        fn _is_zero(self_obj: PyObjectRef) -> bool {
+        // interp_semaphore.py:499-504 W_SemLock.get_value
+        fn _get_value(self_obj: PyObjectRef) -> Result<i64, crate::PyError> {
             let handle = semlock_get_handle(self_obj);
-            handle.is_null()
-        }
-        fn __enter__(self_obj: PyObjectRef) -> PyObjectRef {
-            let handle = semlock_get_handle(self_obj);
-            if !handle.is_null() {
-                let _ = unsafe { libc::sem_wait(handle) };
+            if handle.is_null() {
+                return Err(crate::PyError::value_error("SemLock handle is null"));
             }
-            self_obj
+            #[cfg(target_vendor = "apple")]
+            {
+                // interp_semaphore.py:432-434.
+                let _ = handle;
+                Err(crate::PyError::not_implemented(
+                    "sem_getvalue is not implemented on this system",
+                ))
+            }
+            #[cfg(not(target_vendor = "apple"))]
+            {
+                semlock_getvalue(handle)
+            }
         }
+        // interp_semaphore.py:563-564 W_SemLock.enter
+        fn __enter__(self_obj: PyObjectRef) -> Result<bool, crate::PyError> {
+            w_semlock_acquire(self_obj, true, None)
+        }
+        // interp_semaphore.py:566-567 W_SemLock.exit
         fn __exit__(
             self_obj: PyObjectRef,
             exc_type: Option<PyObjectRef>,
             exc_value: Option<PyObjectRef>,
             traceback: Option<PyObjectRef>,
-        ) -> bool {
+        ) -> Result<(), crate::PyError> {
             let _ = (exc_type, exc_value, traceback);
-            let handle = semlock_get_handle(self_obj);
-            if !handle.is_null() {
-                let _ = unsafe { libc::sem_post(handle) };
-            }
-            false
+            w_semlock_release(self_obj)
         }
     }
 }
@@ -325,10 +571,15 @@ crate::py_module! {
                     "__new__",
                     crate::make_builtin_function("__new__", semlock_descr_new),
                 );
+                // interp_semaphore.py:606 `as_classmethod=True` — `_rebuild`
+                // allocates on the class it is called through.
                 pyre_object::w_dict_setitem_str_no_proxy(
                     semlock_ns,
                     "_rebuild",
-                    crate::make_builtin_function("_rebuild", semlock_rebuild),
+                    pyre_object::function::w_classmethod_new(crate::make_builtin_function(
+                        "_rebuild",
+                        semlock_rebuild,
+                    )),
                 );
             }
 
@@ -343,8 +594,8 @@ crate::py_module! {
                 "SEM_VALUE_MAX",
                 sem_value_max,
             );
-            crate::module_ns_store(ns, "RECURSIVE_MUTEX", w_int_new(0));
-            crate::module_ns_store(ns, "SEMAPHORE", w_int_new(1));
+            crate::module_ns_store(ns, "RECURSIVE_MUTEX", w_int_new(RECURSIVE_MUTEX));
+            crate::module_ns_store(ns, "SEMAPHORE", w_int_new(SEMAPHORE));
         }
     }
 }

--- a/pyre/pyre-interpreter/src/module/_multiprocessing/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_multiprocessing/mod.rs
@@ -347,7 +347,11 @@ fn semlock_instance(
     let _roots = pyre_object::gc_roots::push_roots();
     let root_base = pyre_object::gc_roots::shadow_stack_len();
     pyre_object::gc_roots::pin_root(obj);
-    let dict = crate::baseobjspace::getdict_native(obj);
+    // `getdict_native` materialises the instance dict, so it can collect and
+    // move `obj`; read the receiver back from its slot the way every store
+    // below does, rather than handing over the pre-pin copy.
+    let dict =
+        crate::baseobjspace::getdict_native(pyre_object::gc_roots::shadow_stack_get(root_base));
     if dict.is_null() {
         return Err(crate::PyError::runtime_error(
             "SemLock instance has no storage",

--- a/pyre/pyre-interpreter/src/module/_multiprocessing/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_multiprocessing/mod.rs
@@ -60,9 +60,8 @@ fn semlock_set_i64(obj: PyObjectRef, key: &str, value: i64) {
     let obj_slot = pyre_object::gc_roots::pin_roots(&[obj]);
     let boxed_slot = obj_slot + 1;
     pyre_object::gc_roots::pin_root(w_int_new(value));
-    let dict = crate::baseobjspace::getdict_native(pyre_object::gc_roots::shadow_stack_get(
-        obj_slot,
-    ));
+    let dict =
+        crate::baseobjspace::getdict_native(pyre_object::gc_roots::shadow_stack_get(obj_slot));
     if dict.is_null() {
         return;
     }
@@ -182,12 +181,12 @@ fn semlock_acquire(
             return Err(crate::PyError::os_error_with_errno(errno, "sem_trywait"));
         }
     } else {
-        let deadline =
-            rustpython_host_env::multiprocessing::deadline_from_timeout(timeout.unwrap()).map_err(
-                |error| {
-                    crate::PyError::os_error_with_errno(error.raw_os_error(), error.description())
-                },
-            )?;
+        let deadline = rustpython_host_env::multiprocessing::deadline_from_timeout(
+            timeout.unwrap(),
+        )
+        .map_err(|error| {
+            crate::PyError::os_error_with_errno(error.raw_os_error(), error.description())
+        })?;
         #[cfg(target_vendor = "apple")]
         {
             let mut delay = 0;
@@ -300,11 +299,7 @@ fn w_semlock_acquire(
         // threads.  The wait can run signal handlers, so the receiver comes
         // back off the shadow stack.
         let self_obj = pyre_object::gc_roots::shadow_stack_get(self_slot);
-        semlock_set_i64(
-            self_obj,
-            "last_tid",
-            crate::module::thread::current_ident(),
-        );
+        semlock_set_i64(self_obj, "last_tid", crate::module::thread::current_ident());
         semlock_set_i64(self_obj, "count", semlock_get_i64(self_obj, "count") + 1);
     }
     Ok(got)

--- a/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
+++ b/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
@@ -3468,13 +3468,18 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
             // the copied strings.  In particular, asyncio passes an
             // `itertools.islice` of memoryviews here, not a list or tuple.
             let _roots = pyre_object::gc_roots::push_roots();
-            pyre_object::gc_roots::pin_root(args[1]);
-            let data_items = crate::baseobjspace::unpackiterable(args[1], -1)?;
-            for &item in &data_items {
-                pyre_object::gc_roots::pin_root(item);
-            }
+            let data_slot = pyre_object::gc_roots::pin_roots(&[args[1]]);
+            let data_items = crate::baseobjspace::unpackiterable(
+                pyre_object::gc_roots::shadow_stack_get(data_slot),
+                -1,
+            )?;
+            let items_base = pyre_object::gc_roots::pin_roots(&data_items);
             let mut data_buffers: Vec<Vec<u8>> = Vec::with_capacity(data_items.len());
-            for item in data_items {
+            // `simple_buffer_bytes` looks up `__buffer__` and builds a
+            // memoryview, so every iteration can collect; read each item back
+            // from its slot instead of consuming the unrooted vector.
+            for i in 0..data_items.len() {
+                let item = pyre_object::gc_roots::shadow_stack_get(items_base + i);
                 let Some(buffer) = crate::baseobjspace::simple_buffer_bytes(item)? else {
                     return Err(crate::PyError::type_error(
                         "sendmsg: data items must be bytes-like",

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -4583,23 +4583,25 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         let w_sysconf_names = pyre_object::w_dict_new();
         let _sysconf_names_root = pyre_object::gc_roots::push_roots();
         pyre_object::gc_roots::pin_root(w_sysconf_names);
+        let names_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         for (name, value) in sysconf_names() {
+            // Build the value first: call arguments evaluate left to right, so
+            // reading the rooted dict inline would take its address before
+            // `w_int_new` allocates, and a collection there would leave the
+            // store writing through the pre-move address.
+            let w_value = pyre_object::w_int_new(*value as i64);
             unsafe {
                 pyre_object::w_dict_setitem_str(
-                    pyre_object::gc_roots::shadow_stack_get(
-                        pyre_object::gc_roots::shadow_stack_len() - 1,
-                    ),
+                    pyre_object::gc_roots::shadow_stack_get(names_slot),
                     name,
-                    pyre_object::w_int_new(*value as i64),
+                    w_value,
                 );
             }
         }
         crate::module_ns_store(
             ns,
             "sysconf_names",
-            pyre_object::gc_roots::shadow_stack_get(
-                pyre_object::gc_roots::shadow_stack_len() - 1,
-            ),
+            pyre_object::gc_roots::shadow_stack_get(names_slot),
         );
 
         // os.initgroups(username, gid) -> None

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -3600,8 +3600,13 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     if args.len() < 2 {
                         return Err(crate::PyError::type_error("kill() requires 2 arguments"));
                     }
-                    let pid = (unsafe { pyre_object::w_int_get_value(args[0]) }) as libc::pid_t;
-                    let sig = (unsafe { pyre_object::w_int_get_value(args[1]) }) as libc::c_int;
+                    // interp_posix.py:1386 `@unwrap_spec(pid=c_int, signal=c_int)`.
+                    // Both arguments go through `c_int_w`: a raw payload read
+                    // would accept any object, and `is_int` is an exact-type
+                    // check, so an `int` subclass instance — `signal.SIGHUP` is
+                    // an `IntEnum` member — never reaches the checked path.
+                    let pid = crate::baseobjspace::c_int_w(args[0])? as libc::pid_t;
+                    let sig = crate::baseobjspace::c_int_w(args[1])? as libc::c_int;
                     let r = unsafe { libc::kill(pid, sig) };
                     if r < 0 {
                         return Err(io_err(std::io::Error::last_os_error(), ""));
@@ -3621,8 +3626,9 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     if args.len() < 2 {
                         return Err(crate::PyError::type_error("killpg() requires 2 arguments"));
                     }
-                    let pgid = (unsafe { pyre_object::w_int_get_value(args[0]) }) as libc::pid_t;
-                    let sig = (unsafe { pyre_object::w_int_get_value(args[1]) }) as libc::c_int;
+                    // interp_posix.py:1394 `@unwrap_spec(pgid=c_int, signal=c_int)`.
+                    let pgid = crate::baseobjspace::c_int_w(args[0])? as libc::pid_t;
+                    let sig = crate::baseobjspace::c_int_w(args[1])? as libc::c_int;
                     let r = unsafe { libc::killpg(pgid, sig) };
                     if r < 0 {
                         return Err(io_err(std::io::Error::last_os_error(), ""));

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -4184,11 +4184,28 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     }));
                 }
                 let keys = crate::baseobjspace::unpackiterable(keys_obj, -1)?;
+                // `getitem` runs the mapping's `__getitem__` and both encodes
+                // allocate, so the mapping and every key are published once and
+                // read back per iteration rather than kept in plain locals.
+                let _env_roots = pyre_object::gc_roots::push_roots();
+                let mapping_slot = pyre_object::gc_roots::pin_roots(&[mapping]);
+                let keys_base = pyre_object::gc_roots::pin_roots(&keys);
                 let mut env = Vec::with_capacity(keys.len());
-                for key_obj in keys {
-                    let value_obj = crate::baseobjspace::getitem(mapping, key_obj)?;
-                    let key = crate::gateway::fsencode_bytes_w(key_obj)?;
-                    let value = crate::gateway::fsencode_bytes_w(value_obj)?;
+                for i in 0..keys.len() {
+                    let _entry_roots = pyre_object::gc_roots::push_roots();
+                    let value_obj = crate::baseobjspace::getitem(
+                        pyre_object::gc_roots::shadow_stack_get(mapping_slot),
+                        pyre_object::gc_roots::shadow_stack_get(keys_base + i),
+                    )?;
+                    // Encoding the key can collect, so the value it was fetched
+                    // beside has to be published before that call.
+                    let value_slot = pyre_object::gc_roots::pin_roots(&[value_obj]);
+                    let key = crate::gateway::fsencode_bytes_w(
+                        pyre_object::gc_roots::shadow_stack_get(keys_base + i),
+                    )?;
+                    let value = crate::gateway::fsencode_bytes_w(
+                        pyre_object::gc_roots::shadow_stack_get(value_slot),
+                    )?;
                     if key.is_empty() || key.contains(&b'=') {
                         return Err(crate::PyError::value_error(
                             "illegal environment variable name",

--- a/pyre/pyre-interpreter/src/module/thread/mod.rs
+++ b/pyre/pyre-interpreter/src/module/thread/mod.rs
@@ -347,7 +347,6 @@ pub(crate) fn after_fork_child() {
     pyre_object::interp_itertools::count_locks_after_fork_child();
     crate::objspace::std::mapdict::after_fork_child();
     pyre_object::dictmultiobject::module_dict_locks_after_fork_child();
-    pyre_object::setobject::set_locks_after_fork_child();
     crate::module::_collections::deque_locks_after_fork_child();
     majit_gc::shadow_stack::after_fork_child();
     majit_gc::gc_sync::after_fork_child();

--- a/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
+++ b/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
@@ -3046,9 +3046,26 @@ unsafe fn node_materialize_dict<O: MapdictObject>(
 /// `obj` must be a live `W_ObjectObject`; `w_dict` a live `W_DictObject` on
 /// its post-switch strategy.
 unsafe fn materialize_dict(obj: PyObjectRef, w_dict: PyObjectRef) {
-    let inst = unsafe { &mut *(obj as *mut pyre_object::W_ObjectObject) };
-    let map = inst._get_mapdict_map();
-    let new_obj = unsafe { node_materialize_dict(map, &*inst, w_dict) };
+    // Filling `w_dict` allocates — boxed attribute names, the dict stores, and
+    // the rebuilt carrier's own transitions — so both operands are published
+    // and the transplant writes through the instance's post-collection address.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let obj_slot = pyre_object::gc_roots::pin_roots(&[obj, w_dict]);
+    let dict_slot = obj_slot + 1;
+    let new_obj = unsafe {
+        let inst = &*(pyre_object::gc_roots::shadow_stack_get(obj_slot)
+            as *const pyre_object::W_ObjectObject);
+        let map = inst._get_mapdict_map();
+        node_materialize_dict(
+            map,
+            inst,
+            pyre_object::gc_roots::shadow_stack_get(dict_slot),
+        )
+    };
+    let inst = unsafe {
+        &mut *(pyre_object::gc_roots::shadow_stack_get(obj_slot)
+            as *mut pyre_object::W_ObjectObject)
+    };
     inst._set_mapdict_storage_and_map(new_obj.storage, new_obj.map);
 }
 
@@ -3855,13 +3872,44 @@ pub fn _obj_getdict(self_ref: PyObjectRef) -> PyObjectRef {
     // INSTANCE_DICT side table as a plain own-storage dict until subclass
     // instances grow mapdict storage (upstream `user_setup`, mapdict.py:758).
     if unsafe { pyre_object::is_instance(self_ref) } {
-        if let Some(w_dict) = unsafe { instance_get_dict_slot(self_ref) } {
+        // mapdict.py:828-830 `if w_dict is not None`.  RPython's `read` answers
+        // None both for an absent slot and for one holding None, and both mean
+        // "build the view" — so a null must not reach the caller.  It would be
+        // reported as "the receiver has no dict", which is how
+        // `descr__setattr__` decides an ordinary instance store is
+        // `"'%T' object attribute '%s' is read-only"` (descroperation.py:58-67).
+        if let Some(w_dict) = unsafe { instance_get_dict_slot(self_ref) }
+            && !w_dict.is_null()
+        {
             return w_dict;
         }
-        let w_dict = pyre_object::w_dict_new_with(&MAP_DICT_STRATEGY, self_ref as *mut u8);
-        let flag = unsafe { instance_set_dict_slot(self_ref, w_dict) };
-        debug_assert!(flag, "write to the \"dict\" SPECIAL slot failed");
-        w_dict
+        // Allocating the wrapper and claiming the SPECIAL slot both collect, so
+        // the instance is published first and every use below reads back the
+        // relocated address.
+        let _roots = pyre_object::gc_roots::push_roots();
+        let self_slot = pyre_object::gc_roots::pin_roots(&[self_ref]);
+        let dict_slot = self_slot + 1;
+        pyre_object::gc_roots::pin_root(pyre_object::w_dict_new_with(
+            &MAP_DICT_STRATEGY,
+            pyre_object::gc_roots::shadow_stack_get(self_slot) as *mut u8,
+        ));
+        unsafe {
+            let w_dict = pyre_object::gc_roots::shadow_stack_get(dict_slot);
+            // `dstorage` is the view's only link to its backing instance
+            // (mapdict.py:1502) and `walk_gc_refs` forwards it — but only from
+            // the collection after the wrapper became reachable.  The
+            // allocation that produced the wrapper is not covered, so restate
+            // the back-pointer from the instance's current address.
+            (*(w_dict as *mut pyre_object::W_DictObject)).dstorage =
+                pyre_object::gc_roots::shadow_stack_get(self_slot) as *mut u8;
+            pyre_object::gc_hook::try_gc_write_barrier(w_dict as *mut u8);
+            let flag = instance_set_dict_slot(
+                pyre_object::gc_roots::shadow_stack_get(self_slot),
+                pyre_object::gc_roots::shadow_stack_get(dict_slot),
+            );
+            debug_assert!(flag, "write to the \"dict\" SPECIAL slot failed");
+        }
+        pyre_object::gc_roots::shadow_stack_get(dict_slot)
     } else {
         let existing = INSTANCE_DICT
             .lock()
@@ -4165,7 +4213,12 @@ pub fn _obj_setdict(self_ref: PyObjectRef, w_dict: PyObjectRef) -> Result<(), Py
         // delegating to the instance once the slot is overwritten — otherwise
         // `old = obj.__dict__; obj.__dict__ = {}` leaves `old` an empty shell
         // that still mirrors the live instance.
-        let w_olddict = _obj_getdict(self_ref);
+        // Materialising the old view and claiming the slot both allocate, so
+        // the receiver and the incoming dict are published across them.
+        let _roots = pyre_object::gc_roots::push_roots();
+        let self_slot = pyre_object::gc_roots::pin_roots(&[self_ref, w_dict]);
+        let dict_slot = self_slot + 1;
+        let w_olddict = _obj_getdict(pyre_object::gc_roots::shadow_stack_get(self_slot));
         let old_backing = crate::type_methods::resolve_dict_backing(w_olddict);
         let is_map_view = unsafe {
             pyre_object::dictmultiobject::w_dict_get_strategy(old_backing).strategy_kind()
@@ -4174,7 +4227,12 @@ pub fn _obj_setdict(self_ref: PyObjectRef, w_dict: PyObjectRef) -> Result<(), Py
         if is_map_view {
             unsafe { mapdict_switch_to_object_strategy(old_backing) };
         }
-        let flag = unsafe { instance_set_dict_slot(self_ref, w_dict) };
+        let flag = unsafe {
+            instance_set_dict_slot(
+                pyre_object::gc_roots::shadow_stack_get(self_slot),
+                pyre_object::gc_roots::shadow_stack_get(dict_slot),
+            )
+        };
         debug_assert!(flag, "write to the \"dict\" SPECIAL slot failed");
     } else {
         // Non-instance hasdict objects (property/member, baseobjspace

--- a/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
+++ b/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
@@ -2236,45 +2236,47 @@ fn instance_write_barrier(obj: PyObjectRef) {
     pyre_object::gc_hook::try_gc_write_barrier(obj as *mut u8);
 }
 
-/// The one storage slot of `map` that holds the erased `Vec<i64>` unboxing
-/// bank, if the chain has one.
+/// Whether `index` is the storage slot of a `firstunwrapped` attribute in
+/// `map`'s chain. Such a slot holds an erased `Vec<i64>` unboxing bank, not a
+/// GCREF, and must never enter the shadow stack or the marking worklist.
 ///
-/// A chain has at most one: `_compute_storageindex_listindex`
-/// (mapdict.py:549-562) walks back and breaks at the first
-/// `UnboxedPlainAttribute` ancestor, reusing its `storageindex`, and only sets
-/// `firstunwrapped` when the walk finds none. Every later unboxed attribute
-/// therefore shares that same slot and differs only in `listindex`.
+/// The whole chain is scanned rather than stopping at the first
+/// `firstunwrapped` node. `_compute_storageindex_listindex`
+/// (mapdict.py:549-562) does imply a chain holds at most one — it breaks at
+/// the first `UnboxedPlainAttribute` ancestor and only sets `firstunwrapped`
+/// when it finds none — but the collector is the wrong place to depend on
+/// that, since under-reporting one slot hands the marker a raw `Vec` pointer.
 ///
 /// Allocation-free by contract: the GC trace hook calls this while marking,
 /// where taking the global allocator would be a reentrancy hazard.
-unsafe fn unboxed_storage_index(map: MapRef) -> Option<usize> {
+unsafe fn storage_index_is_unboxed(map: MapRef, index: usize) -> bool {
     let mut node = map;
     while !node.is_null() {
         match unsafe { &*node } {
             MapNode::Plain(p) => {
                 if let Some(u) = &p.unboxed
                     && u.firstunwrapped
+                    && p.storageindex == index
                 {
-                    return Some(p.storageindex);
+                    return true;
                 }
                 node = p.back;
             }
             MapNode::Terminator(_) => break,
         }
     }
-    None
+    false
 }
 
-/// Return the storage indices that contain real GCREFs for `map`; the slot
-/// owned by the first `UnboxedPlainAttribute` contains an erased `Vec<i64>`
-/// pointer and must never enter the shadow stack.
+/// Return the storage indices that contain real GCREFs for `map`.
 unsafe fn boxed_storage_indices(map: MapRef, len: usize) -> Vec<usize> {
-    let unboxed = unsafe { unboxed_storage_index(map) };
-    (0..len).filter(|&i| Some(i) != unboxed).collect()
+    (0..len)
+        .filter(|&i| !unsafe { storage_index_is_unboxed(map, i) })
+        .collect()
 }
 
 unsafe fn storage_index_is_boxed(map: MapRef, index: usize) -> bool {
-    unsafe { unboxed_storage_index(map) != Some(index) }
+    !unsafe { storage_index_is_unboxed(map, index) }
 }
 
 impl MapdictObject for pyre_object::W_ObjectObject {
@@ -3979,12 +3981,11 @@ pub unsafe fn instance_walk_boxed_storage(obj: PyObjectRef, f: &mut dyn FnMut(*m
         // The storage block is exact-size (capacity == map.storage_needed()).
         let len = pyre_object::object_array::items_block_capacity(inst.storage);
         let base = pyre_object::object_array::items_block_items_base(inst.storage);
-        // Resolve the mask once and iterate in place: this runs inside the
-        // collector's marking walk, where a heap allocation per traced instance
-        // is both a per-object cost and a reentrancy hazard.
-        let unboxed = unboxed_storage_index(inst.map as MapRef);
+        // Test each slot in place: this runs inside the collector's marking
+        // walk, where the previous `Vec` pair per traced instance was both a
+        // per-object cost and a reentrancy hazard.
         for i in 0..len {
-            if Some(i) != unboxed {
+            if !storage_index_is_unboxed(inst.map as MapRef, i) {
                 f(base.add(i));
             }
         }

--- a/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
+++ b/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
@@ -2236,30 +2236,45 @@ fn instance_write_barrier(obj: PyObjectRef) {
     pyre_object::gc_hook::try_gc_write_barrier(obj as *mut u8);
 }
 
-/// Return the storage indices that contain real GCREFs for `map`; slots owned
-/// by the first `UnboxedPlainAttribute` contain erased `Vec<i64>` pointers and
-/// must never enter the shadow stack.
-unsafe fn boxed_storage_indices(map: MapRef, len: usize) -> Vec<usize> {
-    let mut unboxed = vec![false; len];
+/// The one storage slot of `map` that holds the erased `Vec<i64>` unboxing
+/// bank, if the chain has one.
+///
+/// A chain has at most one: `_compute_storageindex_listindex`
+/// (mapdict.py:549-562) walks back and breaks at the first
+/// `UnboxedPlainAttribute` ancestor, reusing its `storageindex`, and only sets
+/// `firstunwrapped` when the walk finds none. Every later unboxed attribute
+/// therefore shares that same slot and differs only in `listindex`.
+///
+/// Allocation-free by contract: the GC trace hook calls this while marking,
+/// where taking the global allocator would be a reentrancy hazard.
+unsafe fn unboxed_storage_index(map: MapRef) -> Option<usize> {
     let mut node = map;
     while !node.is_null() {
         match unsafe { &*node } {
             MapNode::Plain(p) => {
-                if let Some(u) = &p.unboxed {
-                    if u.firstunwrapped && p.storageindex < len {
-                        unboxed[p.storageindex] = true;
-                    }
+                if let Some(u) = &p.unboxed
+                    && u.firstunwrapped
+                {
+                    return Some(p.storageindex);
                 }
                 node = p.back;
             }
             MapNode::Terminator(_) => break,
         }
     }
-    (0..len).filter(|&i| !unboxed[i]).collect()
+    None
+}
+
+/// Return the storage indices that contain real GCREFs for `map`; the slot
+/// owned by the first `UnboxedPlainAttribute` contains an erased `Vec<i64>`
+/// pointer and must never enter the shadow stack.
+unsafe fn boxed_storage_indices(map: MapRef, len: usize) -> Vec<usize> {
+    let unboxed = unsafe { unboxed_storage_index(map) };
+    (0..len).filter(|&i| Some(i) != unboxed).collect()
 }
 
 unsafe fn storage_index_is_boxed(map: MapRef, index: usize) -> bool {
-    unsafe { boxed_storage_indices(map, index + 1).contains(&index) }
+    unsafe { unboxed_storage_index(map) != Some(index) }
 }
 
 impl MapdictObject for pyre_object::W_ObjectObject {
@@ -3964,8 +3979,14 @@ pub unsafe fn instance_walk_boxed_storage(obj: PyObjectRef, f: &mut dyn FnMut(*m
         // The storage block is exact-size (capacity == map.storage_needed()).
         let len = pyre_object::object_array::items_block_capacity(inst.storage);
         let base = pyre_object::object_array::items_block_items_base(inst.storage);
-        for i in boxed_storage_indices(inst.map as MapRef, len) {
-            f(base.add(i));
+        // Resolve the mask once and iterate in place: this runs inside the
+        // collector's marking walk, where a heap allocation per traced instance
+        // is both a per-object cost and a reentrancy hazard.
+        let unboxed = unboxed_storage_index(inst.map as MapRef);
+        for i in 0..len {
+            if Some(i) != unboxed {
+                f(base.add(i));
+            }
         }
     }
 }

--- a/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
+++ b/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
@@ -4985,6 +4985,42 @@ mod tests {
     }
 
     #[test]
+    fn obj_getdict_rebuilds_the_view_when_the_dict_slot_reads_null() {
+        use pyre_object::dictmultiobject::{DictStrategy, StrategyKind};
+        // mapdict.py:828-830 `if w_dict is not None` — RPython's `read` answers
+        // None both for an absent slot and for one holding None, and both mean
+        // "build the view".  Surfacing the null instead makes `getdict` report
+        // that the receiver has no dict, which is the single state
+        // `descr__setattr__` turns into
+        // `"'%T' object attribute '%s' is read-only"` — for any name the type
+        // carries, a class-variable default being enough to arm that branch.
+        crate::test_hooks::install_hash_hook();
+        unsafe {
+            let term = boxed_dict_terminator();
+            let obj_ref = pyre_object::w_instance_new(pyre_object::PY_NULL);
+            let obj = &mut *(obj_ref as *mut pyre_object::W_ObjectObject);
+            obj._set_mapdict_map(term);
+
+            let w1 = _obj_getdict(obj_ref);
+            assert!(!w1.is_null());
+            assert_eq!(instance_get_dict_slot(obj_ref), Some(w1));
+
+            // The state a write that never landed leaves behind: the map still
+            // claims the SPECIAL attribute, its storage slot holds NULL.
+            assert!(instance_set_dict_slot(obj_ref, pyre_object::PY_NULL));
+            assert_eq!(instance_get_dict_slot(obj_ref), Some(pyre_object::PY_NULL));
+
+            let w2 = _obj_getdict(obj_ref);
+            assert!(!w2.is_null(), "a null SPECIAL slot must rebuild the view");
+            assert_eq!(instance_get_dict_slot(obj_ref), Some(w2));
+            let dict = &*(w2 as *const pyre_object::W_DictObject);
+            assert_eq!(dict.dstrategy.strategy_kind(), StrategyKind::Map);
+            // The rebuilt view backs onto the instance it was built for.
+            assert_eq!(dict.dstorage as PyObjectRef, obj_ref);
+        }
+    }
+
+    #[test]
     fn instance_custom_trace_walks_special_wrapper_and_values() {
         // The wrapper stored in the "dict" SPECIAL slot is forwarded by the
         // instance custom trace (it is one of the storage slots), and a

--- a/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
+++ b/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
@@ -2320,6 +2320,16 @@ impl MapdictObject for pyre_object::W_ObjectObject {
     }
     fn _mapdict_pop_attribute(&mut self, map: MapRef) {
         // mapdict.py:926-939; structure mirrors the MockObj test impl.
+        // Both arms can collect — the unboxed one through
+        // `_mapdict_write_storage`, the other through the storage shrink — so
+        // the receiver is published for the whole function and every write
+        // goes through the reloaded address, as in
+        // `_set_mapdict_increase_storage1` and `_set_mapdict_storage_and_map`.
+        // `&mut self` is a bare address that a moving collection invalidates;
+        // writing `map` through it would leave the live instance on its old
+        // map, claiming a storage slot the shrunk block no longer has.
+        let _roots = pyre_object::gc_roots::push_roots();
+        let self_slot = pyre_object::gc_roots::pin_roots(&[self as *const Self as PyObjectRef]);
         let current_map = self.map as MapRef;
         let unboxed_slot: Option<(usize, usize)> = unsafe {
             match &(*current_map).as_plain().unboxed {
@@ -2339,16 +2349,16 @@ impl MapdictObject for pyre_object::W_ObjectObject {
                     let list: &Vec<i64> = &*unerase_unboxed(slot);
                     list[..listindex].to_vec()
                 };
-                self._mapdict_write_storage(storageindex, erase_unboxed(Box::new(new_list)));
+                let owner = unsafe {
+                    &mut *(pyre_object::gc_roots::shadow_stack_get(self_slot) as *mut Self)
+                };
+                owner._mapdict_write_storage(storageindex, erase_unboxed(Box::new(new_list)));
             }
             // mapdict.py:935-938: truncate storage to the parent map's size.
             // The block is exact-size, so shrink it to a fresh cap-N block; the
             // dropped tail slots are gone with the old block. NULL-fill is
             // implicit in `grow_instance_items_block` (new_cap <= live_len here).
             None => {
-                let _roots = pyre_object::gc_roots::push_roots();
-                let self_slot = pyre_object::gc_roots::shadow_stack_len();
-                pyre_object::gc_roots::pin_root(self as *const Self as PyObjectRef);
                 let storage_needed = unsafe { (*map).storage_needed() };
                 unsafe {
                     let owner =
@@ -2370,7 +2380,10 @@ impl MapdictObject for pyre_object::W_ObjectObject {
                 }
             }
         }
-        self.map = map as *const u8;
+        unsafe {
+            let owner = &mut *(pyre_object::gc_roots::shadow_stack_get(self_slot) as *mut Self);
+            owner.map = map as *const u8;
+        }
     }
     fn _set_mapdict_increase_storage1(&mut self, map: MapRef, value: PyObjectRef) {
         // grow storage by one, append value (mapdict.py:942-959). The first

--- a/pyre/pyre-object/src/gc_roots.rs
+++ b/pyre/pyre-object/src/gc_roots.rs
@@ -302,6 +302,8 @@ pub fn pin_root(root: PyObjectRef) {
 /// Returns the first shadow-stack index occupied by `roots`.
 #[majit_macros::dont_look_inside]
 pub fn pin_roots(roots: &[PyObjectRef]) -> usize {
+    #[cfg(debug_assertions)]
+    assert_shadow_stack_not_walking();
     let base = with_shadow_stack_mut(|stack| {
         let base = stack.len();
         stack.extend_from_slice(roots);


### PR DESCRIPTION
Follow-ups to the review comments left on #937 (the Codex CI report and the 37
CodeRabbit inline comments), plus the `_multiprocessing` port that motivated
looking there.

## GC rooting

- `eval`: both walks over `locals_cells_stack_w` took `valuestackdepth.min(len)`
  as the walk length. That index starts at `stack_base()` (`pyframe.rs:2136`)
  and `pop` refuses to go below it, so it covers the locals/cells prefix for a
  running frame — but `PyFrame::descr_clear` rebinds every cell slot to a fresh
  `w_cell_new` and then sets it to `0`. Both walks then scanned **zero** slots
  for a cleared frame while the array still pointed at those cells. The length
  now floors at `stack_base()`, which only ever widens the walk.
- `mapdict`: a null `"dict"` SPECIAL slot is treated as absent and rebuilt
  (`mapdict.py:828-830` — both "absent" and "holds None" mean rebuild), the
  receiver is published across the three allocating dict paths, and
  `_mapdict_pop_attribute` writes its map through the rooted receiver.
- `gc_roots`: `pin_roots` did not carry `pin_root`'s debug-only
  `assert_shadow_stack_not_walking`, so callers moving between them lost the
  guard.
- `executioncontext`: `_call_finalizer` passed the pre-call `__del__` callable
  to `report_error` after running arbitrary Python.
- `posix`: `posix_spawn`'s env loop kept the mapping and key vector in plain
  locals across `getitem` and two `fsencode_bytes_w` calls; `sysconf_names`
  read the rooted dict as argument 1 while `w_int_new` allocated as argument 3.
- `_socket`: `sendmsg` pinned each data item and then iterated the unrooted
  vector, handing pre-pin copies to `simple_buffer_bytes`.
- `_multiprocessing`: `semlock_instance` passed the pre-pin receiver to
  `getdict_native`, which materialises the instance dict and can therefore
  collect.

## `object_object_custom_trace` allocation

`boxed_storage_indices` built a `vec![false; len]` and a result `Vec` per call.
`instance_walk_boxed_storage` calls it from inside the trace hook, so the
collector allocated twice per traced instance while marking, and
`_mapdict_write_storage` paid it on every attribute store.
`storage_index_is_unboxed` answers the same question by scanning the chain
without allocating. It scans the whole chain rather than stopping at the first
`firstunwrapped` node: `_compute_storageindex_listindex`
(`mapdict.py:549-562`) does imply at most one per chain, but under-reporting a
slot hands the marker a raw `Vec<i64>` pointer, so the collector does not rely
on it. The computed set is identical to the pre-change one.

## unwrap_spec

`os.kill` / `os.killpg` read both arguments with `w_int_get_value`, a raw
payload read. `is_int` compares `ob_type` for exact identity, so no non-`int`
argument took a checked path — `os.kill(pid, None)`, `os.kill(pid, [30])` and
`os.kill("x", 30)` passed whatever word sat at that offset to `kill(2)` instead
of raising `TypeError`. Both now go through `c_int_w`, matching
`@unwrap_spec(pid=c_int, signal=c_int)` (`interp_posix.py:1386,1394`).
`space_int`'s failure message also dropped the `%T` half of
`_typed_unwrap_error`'s `"expected %s, got %T object"`
(`baseobjspace.py:316-318`).

## `_multiprocessing`

Ports `W_SemLock`'s recursion state (`count` / `last_tid` / `_ismine`), the
release-side ownership and maxvalue checks, and registers `_rebuild` as a
classmethod.

## Verification

`cargo test --all --no-default-features --features dynasm` — no failures.
`python3 pyre/check.py --backend dynasm` — `ALL PASSED: dynasm 357/357`.
`cargo fmt --all -- --check` — clean.

One CodeRabbit finding was **refuted** rather than fixed: the claim that
`_set_mapdict_increase_storage1`'s `unboxed.is_none()` contradicts
`boxed_storage_indices`' `firstunwrapped` test. The two answer different
questions, and `mapdict.py:629-638` calls that function only inside
`if self.firstunwrapped:`, so the disagreeing input cannot arise.

Not addressed here: the asyncio-suite instability. An A/B over 23 default and 19
`PYRE_NO_JIT=1` full-suite arms shows 35% vs 26% anomaly rates, so it is not
JIT-attributable; the stalls, one SEGV in the `hasattr` miss path, and one
`GC BUG: invalid major child ... site=major_custom_trace` all reproduce with the
JIT off. None of them are closed by this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added fuller POSIX semaphore support, including recursive locking, timed acquisition, context-manager use, and value checks.
  * Added semaphore constants and expanded reconstruction support.

* **Bug Fixes**
  * Improved error messages for invalid integer conversions.
  * Increased reliability of socket messaging, process launching, signal handling, and system configuration access.
  * Fixed frame, object storage, finalizer, and fork-related issues that could cause instability or incorrect behavior.
  * Improved recovery when object dictionaries are accessed after collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->