### PR TITLE
gh#346 census: 5 verified rtyper-prepass slices (dict lookup/insert leaves, iterator/Option rewrites, to_exc_object classdef-less)

### DIFF
--- a/majit/majit-translate/src/annotator/unaryop.rs
+++ b/majit/majit-translate/src/annotator/unaryop.rs
@@ -4080,15 +4080,30 @@ fn init_someinstance_overrides(
                 // types the boxed `W_BaseException` result while the codewriter
                 // keeps the real fnaddr conversion.
                 if attr == "to_exc_object" {
-                    let is_pyerror = inst
-                        .classdef
-                        .as_ref()
-                        .is_some_and(|cd| cd.borrow().name.rsplit('.').next() == Some("PyError"));
+                    // Fires for a `classdef=Some(PyError)` receiver and for a
+                    // classdef-less one.  `to_exc_object` is the sole method of
+                    // that name (error.rs `PyError::to_exc_object`); it is only
+                    // lowered from `.to_exc_object()` callsites rustc typechecks
+                    // against a `PyError` receiver and from the result_exc
+                    // `?`-lowering (`Method{receiver_root: "PyError"}`,
+                    // result_exc.rs), so a classdef-less receiver here is a
+                    // pointer-erased `PyError` call-result — `OpKind::Call`
+                    // stamps a struct return `Ref(None)` with no `class_root`,
+                    // unlike the seeded `Input` arm, so a call-returned `PyError`
+                    // lifts `SomeInstance(classdef=None)`.  Same rustc-typecheck
+                    // reasoning as the `is_null` ptr-method arm above.  The
+                    // builtin result (`PyObjectRef`) and the codewriter residual
+                    // (`for_impl_method("PyError", "to_exc_object")`) are both
+                    // fixed, reading nothing off the receiver's classdef.
+                    let receiver_is_pyerror = match inst.classdef.as_ref() {
+                        Some(cd) => cd.borrow().name.rsplit('.').next() == Some("PyError"),
+                        None => true,
+                    };
                     let class_defines_attr = inst.classdef.as_ref().is_some_and(|cd| {
                         let classdesc = cd.borrow().classdesc.clone();
                         super::classdesc::ClassDesc::lookup(&classdesc, "to_exc_object").is_some()
                     });
-                    if is_pyerror && !class_defines_attr {
+                    if receiver_is_pyerror && !class_defines_attr {
                         return SomeValue::BuiltinMethod(SomeBuiltinMethod::new(
                             "pyerror_method_to_exc_object",
                             s_self.clone(),

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -2064,19 +2064,24 @@ impl SharedOpcodeHandler for PyFrame {
     }
 
     fn load_special_attr(&mut self, obj: Self::Value, name: &str) -> Result<Self::Value, PyError> {
-        let w_type = crate::typedef::r#type(obj).ok_or_else(|| {
-            PyError::type_error(format!(
-                "'{}' object does not support the context manager protocol",
-                crate::baseobjspace::object_functionstr_type_name(obj)
-            ))
-        })?;
-        let descr = unsafe { crate::baseobjspace::lookup_in_type(w_type.as_ptr(), name) }
-            .ok_or_else(|| {
-                PyError::type_error(format!(
+        let w_type = match crate::typedef::r#type(obj) {
+            Some(t) => t,
+            None => {
+                return Err(PyError::type_error(format!(
                     "'{}' object does not support the context manager protocol",
                     crate::baseobjspace::object_functionstr_type_name(obj)
-                ))
-            })?;
+                )));
+            }
+        };
+        let descr = match unsafe { crate::baseobjspace::lookup_in_type(w_type.as_ptr(), name) } {
+            Some(d) => d,
+            None => {
+                return Err(PyError::type_error(format!(
+                    "'{}' object does not support the context manager protocol",
+                    crate::baseobjspace::object_functionstr_type_name(obj)
+                )));
+            }
+        };
         Ok(unsafe { crate::baseobjspace::get(descr, obj, w_type.as_ptr()) }?.unwrap_or(descr))
     }
 

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -2049,6 +2049,12 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
     );
     push_alias_pair(
         &mut entries,
+        "pyre_object::identitydict::w_dict_store_identity_strategy",
+        "pyre_object::w_dict_store_identity_strategy",
+        pyre_object::identitydict::w_dict_store_identity_strategy as *const (),
+    );
+    push_alias_pair(
+        &mut entries,
         "pyre_interpreter::objspace::descroperation::jit_float_abs",
         "pyre_interpreter::jit_float_abs",
         crate::objspace::descroperation::jit_float_abs as *const (),

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -1921,6 +1921,78 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         "pyre_object::dict_entries_pop_last",
         pyre_object::dictmultiobject::dict_entries_pop_last as *const (),
     );
+    // The positional slot reads the post-scan lookup arms and the reentrant
+    // key scan perform: an index the caller already settled on, so no
+    // comparison runs behind these boundaries.
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::dictmultiobject::dict_entries_value_at",
+        "pyre_object::dict_entries_value_at",
+        pyre_object::dictmultiobject::dict_entries_value_at as *const (),
+    );
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::dictmultiobject::dict_entries_key_obj_at",
+        "pyre_object::dict_entries_key_obj_at",
+        pyre_object::dictmultiobject::dict_entries_key_obj_at as *const (),
+    );
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::dictmultiobject::dict_entries_key_hash_at",
+        "pyre_object::dict_entries_key_hash_at",
+        pyre_object::dictmultiobject::dict_entries_key_hash_at as *const (),
+    );
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::dictmultiobject::dict_entries_key_is_at",
+        "pyre_object::dict_entries_key_is_at",
+        pyre_object::dictmultiobject::dict_entries_key_is_at as *const (),
+    );
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::dictmultiobject::dict_entries_capacity",
+        "pyre_object::dict_entries_capacity",
+        pyre_object::dictmultiobject::dict_entries_capacity as *const (),
+    );
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::dictmultiobject::dict_entries_value_set_at",
+        "pyre_object::dict_entries_value_set_at",
+        pyre_object::dictmultiobject::dict_entries_value_set_at as *const (),
+    );
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::dictmultiobject::dict_entries_insert_object",
+        "pyre_object::dict_entries_insert_object",
+        pyre_object::dictmultiobject::dict_entries_insert_object as *const (),
+    );
+    // The index-returning twins of the `dict_entries_probe_*` pair, for
+    // `setitem_str`'s borrow-key membership test.
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::dictmultiobject::dict_entries_index_of_str_hashed",
+        "pyre_object::dict_entries_index_of_str_hashed",
+        pyre_object::dictmultiobject::dict_entries_index_of_str_hashed as *const (),
+    );
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::dictmultiobject::dict_entries_index_of_object",
+        "pyre_object::dict_entries_index_of_object",
+        pyre_object::dictmultiobject::dict_entries_index_of_object as *const (),
+    );
+    // The module-dict storage's own `String`-keyed probe / store pair.
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::celldict::module_dict_entries_get",
+        "pyre_object::module_dict_entries_get",
+        pyre_object::celldict::module_dict_entries_get as *const (),
+    );
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::celldict::module_dict_entries_insert",
+        "pyre_object::module_dict_entries_insert",
+        pyre_object::celldict::module_dict_entries_insert as *const (),
+    );
     // A runtime-mutable global counter, not a build-time constant: bind the
     // read seam by address so the JIT calls it instead of folding whatever
     // serial the build process saw.

--- a/pyre/pyre-interpreter/src/module/mmap/interp_mmap.rs
+++ b/pyre/pyre-interpreter/src/module/mmap/interp_mmap.rs
@@ -143,7 +143,10 @@ fn mmap_ptr(obj: pyre_object::PyObjectRef) -> Result<(*mut u8, usize), crate::Py
 /// True when `obj` is an `mmap` instance.
 #[cfg(unix)]
 pub(crate) fn is_mmap(obj: pyre_object::PyObjectRef) -> bool {
-    crate::typedef::r#type(obj).is_some_and(|tp| std::ptr::eq(tp.as_ptr(), mmap_type()))
+    match crate::typedef::r#type(obj) {
+        Some(tp) => std::ptr::eq(tp.as_ptr(), mmap_type()),
+        None => false,
+    }
 }
 
 /// `_exports` — how many buffers are currently exported from the mapping.

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -147,11 +147,11 @@ pub mod frame_locals_proxy {
         }
 
         fn __reversed__(&self) -> Result<PyObjectRef, crate::PyError> {
-            let mut keys: Vec<_> =
-                unsafe { pyre_object::dictmultiobject::w_dict_items(self.mapping()?) }
-                    .into_iter()
-                    .map(|(key, _)| key)
-                    .collect();
+            let items = unsafe { pyre_object::dictmultiobject::w_dict_items(self.mapping()?) };
+            let mut keys: Vec<PyObjectRef> = Vec::with_capacity(items.len());
+            for (key, _) in items {
+                keys.push(key);
+            }
             keys.reverse();
             Ok(pyre_object::w_list_new(keys))
         }
@@ -161,29 +161,30 @@ pub mod frame_locals_proxy {
         }
 
         fn keys(&self) -> Result<PyObjectRef, crate::PyError> {
-            let keys = unsafe { pyre_object::dictmultiobject::w_dict_items(self.mapping()?) }
-                .into_iter()
-                .map(|(key, _)| key)
-                .collect();
+            let items = unsafe { pyre_object::dictmultiobject::w_dict_items(self.mapping()?) };
+            let mut keys: Vec<PyObjectRef> = Vec::with_capacity(items.len());
+            for (key, _) in items {
+                keys.push(key);
+            }
             Ok(pyre_object::w_list_new(keys))
         }
 
         fn values(&self) -> Result<PyObjectRef, crate::PyError> {
-            let values = unsafe { pyre_object::dictmultiobject::w_dict_items(self.mapping()?) }
-                .into_iter()
-                .map(|(_, value)| value)
-                .collect();
+            let items = unsafe { pyre_object::dictmultiobject::w_dict_items(self.mapping()?) };
+            let mut values: Vec<PyObjectRef> = Vec::with_capacity(items.len());
+            for (_, value) in items {
+                values.push(value);
+            }
             Ok(pyre_object::w_list_new(values))
         }
 
         fn items(&self) -> Result<PyObjectRef, crate::PyError> {
             let items = unsafe { pyre_object::dictmultiobject::w_dict_items(self.mapping()?) };
-            Ok(pyre_object::w_list_new(
-                items
-                    .into_iter()
-                    .map(|(key, value)| pyre_object::w_tuple_new(vec![key, value]))
-                    .collect(),
-            ))
+            let mut out: Vec<PyObjectRef> = Vec::with_capacity(items.len());
+            for (key, value) in items {
+                out.push(pyre_object::w_tuple_new(vec![key, value]));
+            }
+            Ok(pyre_object::w_list_new(out))
         }
 
         fn copy(&self) -> Result<PyObjectRef, crate::PyError> {

--- a/pyre/pyre-object/src/bufferview.rs
+++ b/pyre/pyre-object/src/bufferview.rs
@@ -63,13 +63,14 @@ fn copy_rec(
 unsafe fn read_dims(t: PyObjectRef) -> Vec<i64> {
     unsafe {
         let n = crate::tupleobject::w_tuple_len(t);
-        (0..n)
-            .map(|i| {
-                crate::tupleobject::w_tuple_getitem(t, i as i64)
-                    .map(|w| crate::intobject::w_int_get_value(w))
-                    .unwrap_or(0)
-            })
-            .collect()
+        let mut dims: Vec<i64> = Vec::with_capacity(n as usize);
+        for i in 0..n {
+            let d = crate::tupleobject::w_tuple_getitem(t, i as i64)
+                .map(|w| crate::intobject::w_int_get_value(w))
+                .unwrap_or(0);
+            dims.push(d);
+        }
+        dims
     }
 }
 

--- a/pyre/pyre-object/src/celldict.rs
+++ b/pyre/pyre-object/src/celldict.rs
@@ -408,6 +408,44 @@ pub fn module_dict_storage_gc_type_id() -> u32 {
     MODULE_DICT_STORAGE_GC_TYPE_ID.load(std::sync::atomic::Ordering::Relaxed)
 }
 
+/// The single `IndexMap` probe [`ModuleDictStorage::get`] runs —
+/// `celldict.py:143-145 getitem_str`'s
+/// `self.unerase(w_dict.dstorage).get(key)`.
+///
+/// Residualise the probe alone (`@dont_look_inside`, `rlib/jit.py:139`), the
+/// twin of `dictmultiobject::dict_entries_probe_str`: the `IndexMap::get` it
+/// wraps is an external-crate heap lookup the tracer cannot model — the
+/// oopspec'd residual arm of `rordereddict.ll_dict_getitem` (traced only for a
+/// virtual dict).  The keys are owned `String`s, so no user `__eq__` or
+/// `__hash__` can run inside the boundary at all.
+#[majit_macros::dont_look_inside]
+pub fn module_dict_entries_get(
+    entries: &indexmap::IndexMap<String, PyObjectRef>,
+    key: &str,
+) -> Option<PyObjectRef> {
+    entries.get(key).copied()
+}
+
+/// The store side of [`module_dict_entries_get`] — `celldict.py:47`'s
+/// `self.unerase(w_dict.dstorage)[key] = w_value`, returning the displaced
+/// value so the caller can tell an overwrite from an insert.
+///
+/// `IndexMap::insert` preserves the existing slot's position on overwrite,
+/// matching Python `{}`'s assignment semantics (rewriting an existing key does
+/// not move it to the end).  Residualised for [`module_dict_entries_get`]'s
+/// reason; upstream's `_ll_dict_setitem_lookup_done` (`rordereddict.py:674`)
+/// is likewise `@jit.look_inside_iff(jit.isvirtual(d) and jit.isconstant(key))`
+/// and neither conjunct can hold for an `IndexMap` here.  The borrowed name is
+/// copied to the owned `String` the entry table stores inside the boundary.
+#[majit_macros::dont_look_inside]
+pub fn module_dict_entries_insert(
+    entries: &mut indexmap::IndexMap<String, PyObjectRef>,
+    key: &str,
+    w_value: PyObjectRef,
+) -> Option<PyObjectRef> {
+    entries.insert(key.to_string(), w_value)
+}
+
 impl ModuleDictStorage {
     pub fn new() -> Self {
         Self {
@@ -427,7 +465,7 @@ impl ModuleDictStorage {
     /// `dict.__getitem__(key)` returning the raw stored value (or
     /// cell — eventually).  None when absent.
     pub fn get(&self, key: &str) -> Option<PyObjectRef> {
-        self.entries.get(key).copied()
+        module_dict_entries_get(&self.entries, key)
     }
 
     /// `dict[key] = w_value` — insertion-ordered.  Returns the
@@ -436,10 +474,7 @@ impl ModuleDictStorage {
         // Prebuilt-family store (see `write_cell`): the module-dict storage
         // is Box-immortal, so the write-tracking bit is its write barrier.
         crate::gc_roots::mark_prebuilt_roots_dirty();
-        // `IndexMap::insert` preserves the existing slot's position
-        // on overwrite, matching Python `{}`'s assignment semantics
-        // (rewriting an existing key does not move it to the end).
-        self.entries.insert(key.to_string(), w_value)
+        module_dict_entries_insert(&mut self.entries, key, w_value)
     }
 
     /// `del dict[key]` — returns the removed value or None.

--- a/pyre/pyre-object/src/dictmultiobject.rs
+++ b/pyre/pyre-object/src/dictmultiobject.rs
@@ -2734,7 +2734,7 @@ pub unsafe fn w_dict_setdefault_checked(
                 match index {
                     Some(i) => Some(*entries.get_index(i).unwrap().1),
                     None => {
-                        entries.insert(object_key, value);
+                        dict_entries_insert_hashed(entries, object_key.hash, object_key.obj, value);
                         w_dict_bump_keys_version(obj);
                         dict_write_barrier(obj);
                         Some(value)
@@ -2767,7 +2767,7 @@ pub unsafe fn w_dict_setdefault_checked(
         crate::dict_eq_hook::begin_callback_free_probe();
         let dict = &mut *(obj as *mut W_DictObject);
         let entries = &mut *(dict.dstorage as *mut indexmap::IndexMap<ObjectKey, PyObjectRef>);
-        entries.insert(object_key, value);
+        dict_entries_insert_hashed(entries, object_key.hash, object_key.obj, value);
         let _ = crate::dict_eq_hook::end_callback_free_probe();
         w_dict_bump_keys_version(obj);
         dict_write_barrier(obj);
@@ -2911,7 +2911,7 @@ unsafe fn w_dict_store_object_strategy_checked_inner(
                     *entries.get_index_mut(i).unwrap().1 = value;
                 }
                 None => {
-                    entries.insert(object_key, value);
+                    dict_entries_insert_hashed(entries, object_key.hash, object_key.obj, value);
                     dict.keys_version = dict.keys_version.wrapping_add(1);
                 }
             }
@@ -2942,7 +2942,7 @@ unsafe fn w_dict_store_object_strategy_checked_inner(
             crate::dict_eq_hook::begin_callback_free_probe();
             let dict = &mut *(obj as *mut W_DictObject);
             let entries = &mut *(dict.dstorage as *mut indexmap::IndexMap<ObjectKey, PyObjectRef>);
-            entries.insert(object_key, value);
+            dict_entries_insert_hashed(entries, object_key.hash, object_key.obj, value);
             let _ = crate::dict_eq_hook::end_callback_free_probe();
             dict.keys_version = dict.keys_version.wrapping_add(1);
         }
@@ -2974,7 +2974,9 @@ pub unsafe fn w_module_dict_store_inner(obj: PyObjectRef, key: PyObjectRef, valu
         w_module_dict_switch_to_object_strategy(obj);
     }
     let entries = w_module_dict_object_storage_mut(obj);
-    let inserted = entries.insert(object_key_for(key), value).is_none();
+    let object_key = object_key_for(key);
+    let inserted =
+        dict_entries_insert_hashed(entries, object_key.hash, object_key.obj, value).is_none();
     let strategy = &mut *(*(obj as *mut W_ModuleDictObject)).mstrategy;
     strategy.mutated();
     if inserted {
@@ -5772,7 +5774,7 @@ impl DictStrategy for UnicodeDictStrategy {
             }
             None => {
                 let stored_key = object_key_for_new_str(key);
-                entries.insert(stored_key, w_value);
+                dict_entries_insert_hashed(entries, stored_key.hash, stored_key.obj, w_value);
                 dict.keys_version = dict.keys_version.wrapping_add(1);
             }
         };

--- a/pyre/pyre-object/src/dictmultiobject.rs
+++ b/pyre/pyre-object/src/dictmultiobject.rs
@@ -294,6 +294,132 @@ pub unsafe fn dict_entries_insert_hashed(
     entries.insert(ObjectKey { hash, obj }, value)
 }
 
+/// Read the value stored at an entry index the caller already settled on —
+/// `rordereddict.py:709 ll_dict_getitem`'s `d.entries[i].value` after
+/// `ll_dict_lookup` returned the slot.
+///
+/// Residualised for [`dict_entries_probe_hashed`]'s reason: `IndexMap` has no
+/// lowering, so `get_index` is the last modellable point.  No comparison runs
+/// here — the index is already known, so this is a pure slot read and the
+/// residual boundary swallows no user code at all.
+///
+/// # Safety
+/// Same as [`dict_entries_probe_hashed`]; `index` must be a live entry index.
+#[majit_macros::dont_look_inside]
+pub unsafe fn dict_entries_value_at(
+    entries: &indexmap::IndexMap<ObjectKey, PyObjectRef>,
+    index: usize,
+) -> PyObjectRef {
+    *entries.get_index(index).unwrap().1
+}
+
+/// Overwrite the value at an entry index the caller already settled on —
+/// `dictmultiobject.py:1220-1221 setitem_str`'s in-place update, which reuses
+/// the stored key rather than re-inserting.
+///
+/// Residualised for [`dict_entries_value_at`]'s reason, and the store twin of
+/// it: the index is already known, so the boundary swallows a slot write and
+/// no comparison.
+///
+/// # Safety
+/// Same as [`dict_entries_value_at`].
+#[majit_macros::dont_look_inside]
+pub unsafe fn dict_entries_value_set_at(
+    entries: &mut indexmap::IndexMap<ObjectKey, PyObjectRef>,
+    index: usize,
+    value: PyObjectRef,
+) {
+    *entries.get_index_mut(index).unwrap().1 = value;
+}
+
+/// The owned-key store — [`dict_entries_probe_object`]'s twin, hashing `key`
+/// through [`object_key_for`] the way `dict_entries_remove_object` does.
+///
+/// Residualised for [`dict_entries_insert_hashed`]'s reason: `IndexMap` has no
+/// lowering, and upstream's `_ll_dict_setitem_lookup_done`
+/// (`rordereddict.py:674`) is `@jit.look_inside_iff(jit.isvirtual(d) and
+/// jit.isconstant(key))`, neither conjunct of which can hold here.
+///
+/// # Safety
+/// Same as [`dict_entries_probe_object`].
+#[majit_macros::dont_look_inside]
+pub unsafe fn dict_entries_insert_object(
+    entries: &mut indexmap::IndexMap<ObjectKey, PyObjectRef>,
+    key: PyObjectRef,
+    value: PyObjectRef,
+) {
+    entries.insert(object_key_for(key), value);
+}
+
+/// The stored key's object word at an entry index, `None` once the walk has
+/// passed the last entry — `rordereddict.py:1051-1052 ll_dict_lookup`'s
+/// `entries[i].key` plus the bound that ends its scan.
+///
+/// Residualised for [`dict_entries_value_at`]'s reason: a positional slot read
+/// runs no comparison, so the boundary swallows no user code.  It is the read
+/// [`scan_dict_key_reentrant`] performs per step; the scan's `keyeq` loop and
+/// its paranoia restart stay traced around it, which is what
+/// `ll_dict_lookup`'s own `@jit.look_inside_iff(jit.isvirtual(d))` keeps
+/// visible for a dict the tracer can see.
+///
+/// # Safety
+/// Same as [`dict_entries_value_at`].
+#[majit_macros::dont_look_inside]
+pub unsafe fn dict_entries_key_obj_at(
+    entries: &indexmap::IndexMap<ObjectKey, PyObjectRef>,
+    index: usize,
+) -> Option<PyObjectRef> {
+    entries.get_index(index).map(|(stored, _)| stored.obj)
+}
+
+/// The stored key's cached digest at an entry index — `rordereddict.py:1053
+/// entries.hash(i)`, the hash compared before `keyeq` is allowed to run.
+///
+/// Split from [`dict_entries_key_obj_at`] rather than returned beside it: an
+/// `ObjectKey` by value is not a residual-ABI argument shape, and the caller
+/// reads both words at the same index with no callback in between.
+///
+/// # Safety
+/// Same as [`dict_entries_value_at`].
+#[majit_macros::dont_look_inside]
+pub unsafe fn dict_entries_key_hash_at(
+    entries: &indexmap::IndexMap<ObjectKey, PyObjectRef>,
+    index: usize,
+) -> i64 {
+    entries.get_index(index).unwrap().0.hash
+}
+
+/// `entries.valid(index) && entries[index].key == checkingkey` — the second
+/// half of `ll_dict_lookup`'s paranoia condition (`rordereddict.py:1058`),
+/// answered against the two key words the caller sampled before the
+/// comparison it is validating.
+///
+/// # Safety
+/// Same as [`dict_entries_value_at`].
+#[majit_macros::dont_look_inside]
+pub unsafe fn dict_entries_key_is_at(
+    entries: &indexmap::IndexMap<ObjectKey, PyObjectRef>,
+    index: usize,
+    hash: i64,
+    obj: PyObjectRef,
+) -> bool {
+    entries
+        .get_index(index)
+        .is_some_and(|(stored, _)| stored.hash == hash && stored.obj == obj)
+}
+
+/// The table's allocation identity, as `ll_dict_lookup`'s paranoia restart
+/// reads it (`rordereddict.py:1058 entries != d.entries`): a grow reallocates
+/// every entry, so a capacity change is the observable that a stale index can
+/// no longer be trusted.
+///
+/// # Safety
+/// Same as [`dict_entries_value_at`].
+#[majit_macros::dont_look_inside]
+pub unsafe fn dict_entries_capacity(entries: &indexmap::IndexMap<ObjectKey, PyObjectRef>) -> usize {
+    entries.capacity()
+}
+
 /// Drop the last entry — the undo the checked store runs when a user `__eq__`
 /// raised mid-probe and `insert` therefore appended a spurious entry.
 ///
@@ -343,10 +469,49 @@ unsafe fn dict_entries_index_of_str(
     match crate::dict_eq_hook::try_hash_str(key.as_bytes()) {
         Some(hash) => {
             crate::dict_eq_hook::take_eq_error();
-            entries.get_index_of(&StrLookupKey { hash, key })
+            dict_entries_index_of_str_hashed(entries, hash, key)
         }
-        None => entries.get_index_of(&object_key_for(crate::w_str_new(key))),
+        None => dict_entries_index_of_object(entries, crate::w_str_new(key)),
     }
+}
+
+/// The borrow-key membership probe [`dict_entries_index_of_str`] runs once the
+/// str hash hook has produced `hash` — [`dict_entries_probe_str`]'s twin,
+/// returning the entry index instead of the value.
+///
+/// Residualised for [`dict_entries_probe_str`]'s reason: the
+/// `IndexMap::get_index_of` it wraps is the same external-crate heap lookup,
+/// and the user `__eq__` a str-subclass key can run sits inside the probe
+/// upstream too (`rdict.py:576 ll_dict_lookup` carries
+/// `@jit.oopspec('dict.lookup')` over the whole `keyeq` loop).  The enclosing
+/// router keeps its hook gate and its allocating fallback visible.
+///
+/// # Safety
+/// Same as [`dict_entries_probe_str`].
+#[majit_macros::dont_look_inside]
+pub unsafe fn dict_entries_index_of_str_hashed(
+    entries: &indexmap::IndexMap<ObjectKey, PyObjectRef>,
+    hash: i64,
+    key: &str,
+) -> Option<usize> {
+    entries.get_index_of(&StrLookupKey { hash, key })
+}
+
+/// The owned-key membership probe [`dict_entries_index_of_str`]'s no-hook arm
+/// runs — [`dict_entries_probe_object`]'s twin.
+///
+/// Residualised for [`dict_entries_probe_object`]'s reason: a body that
+/// reaches either `get_index_of` stops there, so leaving one arm traced keeps
+/// the enclosing graph blocked no matter what the other arm does.
+///
+/// # Safety
+/// Same as [`dict_entries_probe_object`].
+#[majit_macros::dont_look_inside]
+pub unsafe fn dict_entries_index_of_object(
+    entries: &indexmap::IndexMap<ObjectKey, PyObjectRef>,
+    key: PyObjectRef,
+) -> Option<usize> {
+    entries.get_index_of(&object_key_for(key))
 }
 
 /// Build the persistent exact-str key for a new `setitem_str` entry.
@@ -1721,11 +1886,11 @@ unsafe fn w_module_dict_setitem_str_internal(obj: PyObjectRef, key: &str, w_valu
         let entries = w_module_dict_object_storage_mut(obj);
         match dict_entries_index_of_str(entries, key) {
             Some(idx) => {
-                *entries.get_index_mut(idx).unwrap().1 = w_value;
+                dict_entries_value_set_at(entries, idx, w_value);
             }
             None => {
                 let w_key = crate::w_str_new(key);
-                entries.insert(object_key_for(w_key), w_value);
+                dict_entries_insert_object(entries, w_key, w_value);
                 w_dict_bump_keys_version(obj);
             }
         };
@@ -2180,22 +2345,23 @@ unsafe fn scan_dict_key_reentrant(
         let (table_capacity, clear_generation) = {
             let dict = &*(obj as *const W_DictObject);
             (
-                (*(dict.dstorage as *const indexmap::IndexMap<ObjectKey, PyObjectRef>)).capacity(),
+                dict_entries_capacity(
+                    &*(dict.dstorage as *const indexmap::IndexMap<ObjectKey, PyObjectRef>),
+                ),
                 dict.clear_gen,
             )
         };
         let mut i = 0;
         loop {
             obj = crate::gc_roots::shadow_stack_get(obj_slot);
-            let Some((stored_hash, stored_obj)) = ({
+            let (stored_hash, stored_obj) = {
                 let dict = &*(obj as *const W_DictObject);
                 let entries =
                     &*(dict.dstorage as *const indexmap::IndexMap<ObjectKey, PyObjectRef>);
-                entries
-                    .get_index(i)
-                    .map(|(stored, _)| (stored.hash, stored.obj))
-            }) else {
-                return Ok((None, key, obj));
+                let Some(stored_obj) = dict_entries_key_obj_at(entries, i) else {
+                    return Ok((None, key, obj));
+                };
+                (dict_entries_key_hash_at(entries, i), stored_obj)
             };
 
             if stored_hash == key.hash {
@@ -2224,12 +2390,10 @@ unsafe fn scan_dict_key_reentrant(
                     // `entries != d.entries`: a realloc grew the table, or a
                     // `clear` reset it in place (`clear_gen`) — either
                     // reallocates `d.entries` in `ll_dict_lookup`'s eyes.
-                    entries.capacity() != table_capacity
+                    dict_entries_capacity(entries) != table_capacity
                         || dict.clear_gen != clear_generation
                         // `entries.valid(index) && entries[index].key == checkingkey`.
-                        || !entries.get_index(i).is_some_and(|(stored, _)| {
-                            stored.hash == stored_hash && stored.obj == stored_obj
-                        })
+                        || !dict_entries_key_is_at(entries, i, stored_hash, stored_obj)
                 };
                 if disturbed {
                     continue 'restart;
@@ -2266,7 +2430,7 @@ pub unsafe fn w_dict_lookup_object_strategy_checked(
     if let Some(result) = callback_free_dict_op!({
         let dict = &*(obj as *const W_DictObject);
         let entries = &*(dict.dstorage as *const indexmap::IndexMap<ObjectKey, PyObjectRef>);
-        entries.get(&object_key).copied()
+        dict_entries_probe_hashed(entries, object_key.hash, object_key.obj)
     }) {
         return result;
     }
@@ -2274,7 +2438,7 @@ pub unsafe fn w_dict_lookup_object_strategy_checked(
     Ok(found.map(|i| {
         let dict = &*(obj as *const W_DictObject);
         let entries = &*(dict.dstorage as *const indexmap::IndexMap<ObjectKey, PyObjectRef>);
-        *entries.get_index(i).unwrap().1
+        dict_entries_value_at(entries, i)
     }))
 }
 

--- a/pyre/pyre-object/src/identitydict.rs
+++ b/pyre/pyre-object/src/identitydict.rs
@@ -116,6 +116,32 @@ pub unsafe fn w_dict_delete_identity_strategy(obj: PyObjectRef, key: PyObjectRef
         .is_some()
 }
 
+/// `dictmultiobject.py:1061-1067 setitem`'s identity-keyed store — insert
+/// `value` under the address-identity of `key`, reporting whether the slot was
+/// newly filled so the caller bumps the keys-version only on a real insert.
+///
+/// Residualise the storage insert alone (`@dont_look_inside`,
+/// `rlib/jit.py:139`), the store twin of [`w_dict_lookup_identity_strategy`]:
+/// upstream's `_ll_dict_setitem_lookup_done` (`rordereddict.py:674`) is
+/// `@jit.look_inside_iff(jit.isvirtual(d) and jit.isconstant(key))`, and an
+/// `IndexMap` can never be virtual to this front end, so neither conjunct can
+/// hold and the residual arm is the only one reachable.  [`IdentityKey`]
+/// hashes and compares by address, so the store runs no user Python code at
+/// all; the keys-version bump and the GC write barrier stay traced.
+///
+/// # Safety
+/// `obj` must point to a valid `W_DictObject` on [`IDENTITY_DICT_STRATEGY`].
+#[majit_macros::dont_look_inside]
+pub unsafe fn w_dict_store_identity_strategy(
+    obj: PyObjectRef,
+    key: PyObjectRef,
+    value: PyObjectRef,
+) -> bool {
+    identity_storage_mut(obj)
+        .insert(IdentityKey(key), value)
+        .is_none()
+}
+
 /// `dictmultiobject.py:1143-1150 AbstractTypedStrategy.switch_to_object_strategy`
 /// instantiation for IdentityDictStrategy — `wrap` is identity (`:26-27`), so
 /// the migration ports each `IdentityKey(obj)` into
@@ -252,8 +278,7 @@ impl DictStrategy for IdentityDictStrategy {
     /// on mismatch, promote to Object.
     unsafe fn setitem(&self, w_dict: PyObjectRef, w_key: PyObjectRef, w_value: PyObjectRef) {
         if Self::is_correct_type(w_key) {
-            let entries = identity_storage_mut(w_dict);
-            if entries.insert(IdentityKey(w_key), w_value).is_none() {
+            if w_dict_store_identity_strategy(w_dict, w_key, w_value) {
                 crate::dictmultiobject::w_dict_bump_keys_version(w_dict);
             }
             crate::gc_hook::try_gc_write_barrier(w_dict as *mut u8);


### PR DESCRIPTION
Stacked on #929 (base `aggregate-return-abi`). Five gh#346 rtyper-prepass census slices, each verified `pyre/check.py` **dynasm 351/351 + cranelift 351/351** on both backends. Net census phaseA ~1192 → 1182.

- **residualise the per-key dict-lookup IndexMap leaves** — route the object-strategy lookup / reentrant scan slot reads / str-keyed probe / module-dict probe through `dont_look_inside` leaves (PyPy `dict.lookup` oopspec). phaseA 1192→1188.
- **rewrite FrameLocalsProxy views + read_dims iterator-collect chains as explicit loops** — `Iterator::map/collect` has no RPython counterpart; explicit `for` loops lift. phaseA 1188→1183.
- **rewrite is_some_and/ok_or_else on classdef-less Options to explicit match** — Option combinators on a classdef-less `type(obj)` result walled at `getattr`; `match` lowers via the modeled discriminant switch. phaseA 1183→1182.
- **resolve classdef-less getattr("to_exc_object") to the pyerror builtin** — a `PyError` call-result lifts `SomeInstance(classdef=None)` (`OpKind::Call` carries no `class_root`); broaden the `to_exc_object` arm to fire for the pointer-erased receiver, mirroring the `is_null` arm. `to_exc_object` is the sole method of that name, and the builtin result / codewriter residual are both classdef-independent. 4 `object_setattr` records cleared.
- **residualise the dict-setitem IndexMap::insert leaves** — identity-dict `setitem` behind a `dont_look_inside` leaf (PyPy `dict.setitem` oopspec), continuation of the dict-lookup slice's untouched store path. IndexMap::insert gap 58→0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
