### PR TITLE
jit: restore the raise-bearing method-form inline, and inline a user binop/compare dunder that reads self.attr

### DIFF
--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -415,11 +415,11 @@ pub(crate) fn callee_body_contains_raise(body_code: &[u8]) -> bool {
 
 /// Whether a method-form callee body is free of `LoadAttr` residuals.
 ///
-/// Consulted only by the entries that pass `allow_method_load_attr = false`.
-/// A `self.attr` read in the body is what makes it answer `false`, which is the
-/// common shape (`def at(self, i): return self.v + i`), so an entry that opts
-/// out of the check trades a narrower inline surface for the ability to inline
-/// ordinary accessor methods.
+/// A `self.attr` read in the body is what makes it answer `false`, and that is
+/// the common shape (`def at(self, i): return self.v + i`).  No entry declines
+/// on it any more; it names the bodies that reach the inline only through the
+/// widened surface, which the two declines in
+/// `try_walker_inline_resolved_user_call` are scoped to.
 pub(crate) fn method_form_callee_body_supported(
     body_code: &[u8],
     callee_descr_refs: &[DescrRef],
@@ -1749,7 +1749,6 @@ pub(crate) fn try_walker_inline_user_call<Sym: WalkSym>(
         has_closure,
         None,
         None,
-        true,
         false,
         None,
     )
@@ -2477,7 +2476,6 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
     has_closure: bool,
     exception_receiver_guard: Option<ExceptionInlineReceiverGuard>,
     arg_class_guard: Option<ArgClassGuard>,
-    allow_method_load_attr: bool,
     require_str_result: bool,
     constructor_result: Option<(OpRef, ConcreteValue)>,
 ) -> Result<Option<(DispatchOutcome, usize)>, DispatchError> {
@@ -2724,11 +2722,10 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
     if !bridge_rec_root_selfrec && fbw_hazardous_inline_denied(callee_code_key) {
         return Ok(None);
     }
-    // True when only the widened method-form surface reaches this callee: an
-    // unbound `self.attr` accessor body, which the narrow surface declines.
+    // An unbound method-form callee whose body reads `self.attr`.  Every entry
+    // inlines one; the two declines below are what that reach costs.
     let widened_method_form = method_form
         && bound_method.is_none()
-        && allow_method_load_attr
         && !method_form_callee_body_supported(body.code, callee_descr_refs);
     // A legacy, unseeded inline sub-walk inside a FOR_ITER body resumes a guard
     // at the caller's CALL boundary, so deopt re-executes the whole callee.
@@ -2767,12 +2764,12 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
                 // body is still admitted from there — it has nothing that can
                 // abort.
                 //
-                // The widened method-form surface stays out: its deferred call
-                // is the `self.attr` read's own dispatch, which the lever
-                // resolves to a builtin rather than a body it can inline, so the
-                // admission spends the abort and then denies the callee anyway.
-                // Declining here reaches the same residual call without retiring
-                // the enclosing loop.
+                // A body that reads `self.attr` stays out as well.  Admitting
+                // one costs an abort that retires the enclosing loop before the
+                // deny takes effect -- `synth/type_metatype_method_call` went
+                // `loops_aborted` 0 -> 1 and `bridges_compiled` 47 -> 44 on the
+                // admission alone.  Declining here reaches the same residual
+                // call with the loop intact.
                 foriter_deferred_admit = arg_class_guard.is_none()
                     && !widened_method_form
                     && !fbw_foriter_deferred_call_denied(callee_code_key);
@@ -2819,23 +2816,14 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
         // Decline here instead, where the call stays residual and the loop
         // still compiles.
         //
-        // Keyed on `widened_method_form`, not on `allow_method_load_attr`: five
-        // entries pass the latter, four of which did so before the body-reads-
-        // `self.attr` widening.  A raise-bearing body with no attribute read is
-        // one those four already inlined, and declining it here costs 3.6x on
+        // Both conjuncts are load-bearing.  Without `widened_method_form` this
+        // also withdraws a raise-bearing body that reads no attribute, which
+        // every entry inlined before the widening -- 3.6x on
         // `for i in range(400000): t += b.bump(i)` over
         // `def bump(self, n): if n < 0: raise ValueError(n); return n + 1`.
-        let declined = if allow_method_load_attr {
-            widened_method_form && callee_body_contains_raise(body.code)
-        } else {
-            !method_form_callee_body_supported(body.code, callee_descr_refs)
-        };
-        if declined {
+        if widened_method_form && callee_body_contains_raise(body.code) {
             if std::env::var_os("PYRE_FBW_INLINE_DIAG").is_some() {
-                eprintln!(
-                    "[inline-method-form] decline pc={} allow_load_attr={allow_method_load_attr}",
-                    op.pc
-                );
+                eprintln!("[inline-method-form] decline pc={}", op.pc);
             }
             return Ok(None);
         }
@@ -4538,7 +4526,6 @@ pub(crate) fn try_walker_inline_type_call<Sym: WalkSym>(
         // `__init__` bodies are `self.x = ...` stores; the sub-walk folds them
         // to slot writes on the fresh instance exactly as the property-setter
         // route folds its own.
-        true,
         false,
         Some((instance, ConcreteValue::Ref(concrete_instance))),
     )?;
@@ -4686,7 +4673,6 @@ pub(crate) fn try_walker_inline_exception_string_override<Sym: WalkSym>(
         Some((r_args[2], concrete_receiver, w_class, version_tag)),
         None,
         true,
-        true,
         None,
     )?
     else {
@@ -4808,7 +4794,6 @@ pub(crate) fn try_walker_inline_property_get<Sym: WalkSym>(
         // Getter bodies commonly read `self._slot` — a LOAD_ATTR the method-form
         // support gate would otherwise reject; the sub-walk folds it to a slot
         // read (same allowance the exception `__str__`/`__repr__` override uses).
-        true,
         false,
         None,
     )
@@ -4907,7 +4892,6 @@ pub(crate) fn try_walker_inline_property_set<Sym: WalkSym>(
         has_closure,
         Some((obj, concrete_obj, w_type, version_tag)),
         None,
-        true,
         false,
         None,
     )
@@ -5064,7 +5048,6 @@ pub(crate) fn try_walker_inline_user_binop<Sym: WalkSym>(
         Some((lhs, concrete_lhs, w_class, version_tag)),
         Some((rhs, concrete_rhs, w_typ_r.as_ptr())),
         false,
-        false,
         None,
     )?
     else {
@@ -5209,7 +5192,6 @@ pub(crate) fn try_walker_inline_user_compareop<Sym: WalkSym>(
         has_closure,
         Some((lhs, concrete_lhs, w_class, version_tag)),
         Some((rhs, concrete_rhs, w_typ_r.as_ptr())),
-        false,
         false,
         None,
     )?

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -2808,17 +2808,25 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
         }
     }
     if method_form && bound_method.is_none() {
-        // Two surfaces for an unbound method-form callee.  The narrow one
-        // declines any `self.attr` read in the body.  The wide one admits it,
-        // and pays for the reach with a body that raises: the sub-walk records
-        // into the handler region, and a guard whose resume coordinate lands on
-        // the `Reraise` needs ref registers the recorded path never wrote
-        // (`collect_callee_active_boxes`).  That decline arrives mid-recording
-        // on a non-effect-free opcode, so it has no mid-body carrier and the
-        // whole enclosing loop is discarded.  Decline such a body here instead,
-        // where the call simply stays residual and the loop still compiles.
+        // The narrow surface declines any `self.attr` read in the body.
+        //
+        // The wide one admits it, and pays for the reach with a body that also
+        // raises: the sub-walk records into the handler region, and a guard
+        // whose resume coordinate lands on the `Reraise` needs ref registers
+        // the recorded path never wrote (`collect_callee_active_boxes`).  That
+        // decline arrives mid-recording on a non-effect-free opcode, so it has
+        // no mid-body carrier and the whole enclosing loop is discarded.
+        // Decline here instead, where the call stays residual and the loop
+        // still compiles.
+        //
+        // Keyed on `widened_method_form`, not on `allow_method_load_attr`: five
+        // entries pass the latter, four of which did so before the body-reads-
+        // `self.attr` widening.  A raise-bearing body with no attribute read is
+        // one those four already inlined, and declining it here costs 3.6x on
+        // `for i in range(400000): t += b.bump(i)` over
+        // `def bump(self, n): if n < 0: raise ValueError(n); return n + 1`.
         let declined = if allow_method_load_attr {
-            callee_body_contains_raise(body.code)
+            widened_method_form && callee_body_contains_raise(body.code)
         } else {
             !method_form_callee_body_supported(body.code, callee_descr_refs)
         };


### PR DESCRIPTION
Two commits. The first is a regression fix for something already on `main`.

## `jit: key the raise decline on widened_method_form, not allow_method_load_attr`

**This fixes a regression currently on `main`.** #942 was squash-merged with three of its four commits: the widening landed, the commit that scoped its decline did not. `main` today reads

```rust
let declined = if allow_method_load_attr {
    callee_body_contains_raise(body.code)     // widened_method_form missing
```

Five entries pass `allow_method_load_attr`, and four of them — the `type.__call__` `__init__` fold, the exception `__str__`/`__repr__` override, and the property getter and setter — passed it *before* the widening. So the decline also withdraws inlines that were already happening. A method-form body with no attribute read has `method_form_callee_body_supported == true`, hence `widened_method_form == false`, and is admitted again.

```python
class B:
    def bump(self, n):
        if n < 0:
            raise ValueError(n)
        return n + 1
for i in range(400000): t += b.bump(i)
```

min of 7 interleaved runs, startup subtracted:

| | `main` today | this PR |
|---|---|---|
| dynasm | 0.495s | **0.022s** (22.6x) |
| cranelift | 0.411s | **0.025s** (16.5x) |

None of the 358 synthetic benches cover this shape.

## `jit: inline a user binop/compare dunder whose body reads self.attr`

`try_walker_inline_user_binop` and `try_walker_inline_user_compareop` were the last two entries passing `allow_method_load_attr = false`, so `method_form_callee_body_supported` declined any dunder body carrying a `LoadAttr` residual — `def __lt__(self, o): return self.x < o.x`, the ordinary shape.

With both flipped, all seven `try_walker_inline_resolved_user_call` call sites pass the same value, so the parameter and the branch it selected are gone; `widened_method_form` drops its now-constant conjunct.

**There is no upstream counterpart to the check being removed.** `rpython/jit/codewriter/policy.py:35` `look_inside_function` returns `True` by default; `_reject_function` (:38-46) rejects only elidable functions and `rpython.rtyper.module.*` helpers; `look_inside_graph` (:48-64) rejects only loop-bearing graphs, `_jit_look_inside_` overrides and unsupported variable types — all on RPython graphs, never on an app-level body. App-level dunders dispatch uniformly through `pypy/objspace/descroperation.py:706`. The gate was a pyre-only deviation.

4,000,000 iterations of a `while` loop, min of 5 interleaved runs, startup subtracted, against a binary built from `origin/main`:

| body | dynasm | cranelift |
|---|---|---|
| `def __lt__(self, o): return self.x < o.x` | 3.469s → **0.056s** (62x) | 3.961s → **0.093s** (43x) |
| `def __add__(self, o): return self.x + o.x` | 3.609s → **0.047s** (76x) | 4.053s → **0.066s** (61x) |

The `for` form is unchanged (0.99x / 1.01x). The FOR_ITER `DeferredCall` admission denies `arg_class_guard.is_some()`, which is exactly these two entries, and that denial is what keeps the `BINARY_OP` abort-rewind from resuming one operand short. Left alone.

### Semantics

Eight probes in `while` form, 200000 iterations each, matching CPython on both backends and on an `origin/main` binary:

- `NotImplemented` falling through to the reflected operand
- an `AttributeError` raised inside the body escaping as `AttributeError`, with the `TypeError` counter at 0 (no confusion with the `NotImplemented` path)
- a `__getattr__` fallback inside the body
- a property getter's read count landing on exactly 200000 per operand
- a proper-subclass rhs keeping reflected priority
- a `ValueError` raised once well after the trace is hot
- the receiver's attribute mutating mid-loop
- a store committed *before* the failing rhs map guard, at exactly one execution per iteration

## Verification

- `check.py --backend dynasm` 358/358
- `check.py --backend cranelift` 358/358
- `cargo test --all --no-default-features` 7332 passed, 0 failed (`pyre-object`'s SIGABRT is the known multithread GC flake; 3/3 clean on rerun)

— *authored by Claude*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of method-form calls during inlining.
  * Method calls are now admitted more consistently, while unsupported cases involving attribute access and raised exceptions are safely declined.
  * Simplified call-processing behavior for more predictable execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->