### PR TITLE
typeobject: serialize weak_subclasses behind a striped lock, with a deterministic race reproducer

### DIFF
--- a/pyre/pyre-interpreter/src/module/thread/mod.rs
+++ b/pyre/pyre-interpreter/src/module/thread/mod.rs
@@ -345,6 +345,7 @@ pub(crate) fn after_fork_child() {
     pyre_object::listobject::list_locks_after_fork_child();
     pyre_object::setobject::set_locks_after_fork_child();
     pyre_object::interp_itertools::count_locks_after_fork_child();
+    pyre_object::typeobject::subclasses_locks_after_fork_child();
     crate::objspace::std::mapdict::after_fork_child();
     pyre_object::dictmultiobject::module_dict_locks_after_fork_child();
     crate::module::_collections::deque_locks_after_fork_child();

--- a/pyre/pyre-object/src/typeobject.rs
+++ b/pyre/pyre-object/src/typeobject.rs
@@ -1576,4 +1576,52 @@ mod tests {
             assert!(!w_type_get_uses_object_setattr(PY_NULL));
         }
     }
+
+    /// Concurrent class creation against one process-global builtin parent is
+    /// the shape the striped lock exists for: `add_subclass`'s `push`
+    /// reallocates and frees the buffer `get_subclasses` is indexing, and its
+    /// null-check-then-install lets two threads each install a `Box`.
+    ///
+    /// Without `w_type_subclasses_lock` this aborts inside the allocator —
+    /// `double free or corruption (fasttop)` on glibc, `STATUS_HEAP_CORRUPTION`
+    /// on Windows, SIGSEGV in `w_weakref_deref` on macOS. Delete the three
+    /// guards and re-run to confirm the gate still bites before trusting it.
+    #[test]
+    fn subclass_registry_survives_concurrent_mutation() {
+        let w_parent = w_type_new("SharedParent", PY_NULL, std::ptr::null_mut());
+        let parent_addr = w_parent as usize;
+
+        std::thread::scope(|scope| {
+            for t in 0..4 {
+                scope.spawn(move || {
+                    let w_parent = parent_addr as PyObjectRef;
+                    // Kept alive for the whole thread so `weak_subclasses`
+                    // holds live entries rather than immediately-dead refs.
+                    let children: Vec<PyObjectRef> = (0..16)
+                        .map(|i| {
+                            w_type_new(&format!("Child{t}_{i}"), PY_NULL, std::ptr::null_mut())
+                        })
+                        .collect();
+                    for _ in 0..500 {
+                        for &w_child in &children {
+                            unsafe { w_type_add_subclass(w_parent, w_child) };
+                        }
+                        // Reads and dereferences every entry in the vector the
+                        // other threads are reallocating — a stale buffer shows
+                        // up here as a garbage `*mut Weakref`. The contents are
+                        // racy by construction, so only the read is asserted on.
+                        let seen = unsafe { w_type_get_subclasses(w_parent, false) };
+                        assert!(seen.iter().all(|w| !w.is_null()));
+                        for &w_child in &children {
+                            unsafe { w_type_remove_subclass(w_parent, w_child) };
+                        }
+                    }
+                });
+            }
+        });
+
+        // Every thread removed everything it added, and no entry outlived it.
+        let leftover = unsafe { w_type_get_subclasses(w_parent, false) };
+        assert!(leftover.is_empty(), "{} entries leaked", leftover.len());
+    }
 }

--- a/pyre/pyre-object/src/typeobject.rs
+++ b/pyre/pyre-object/src/typeobject.rs
@@ -1187,6 +1187,62 @@ pub unsafe fn w_type_set_acceptable_as_base_class(obj: PyObjectRef, v: bool) {
 
 // ── Subclass tree (typeobject.py:640-689) ────────────────────────────
 
+// `add_subclass` / `remove_subclass` / `get_subclasses` are indivisible under
+// PyPy's GIL: each one reallocates or reindexes the same out-of-line
+// `weak_subclasses` vector.  Pyre keeps the parent type as the sole semantic
+// owner and uses the same narrow address-striped reentrant synchronization
+// `w_list_lock` / `w_dict_lock` use around those transitions.  Reentrant
+// because `get_subclasses` can be reached from inside a mutation on the same
+// thread through the `mutated()` recursion.
+struct ForkSubclassesLock(std::cell::UnsafeCell<parking_lot::ReentrantMutex<()>>);
+unsafe impl Sync for ForkSubclassesLock {}
+
+impl ForkSubclassesLock {
+    fn new() -> Self {
+        Self(std::cell::UnsafeCell::new(
+            parking_lot::ReentrantMutex::new(()),
+        ))
+    }
+
+    fn get(&self) -> &parking_lot::ReentrantMutex<()> {
+        unsafe { &*self.0.get() }
+    }
+
+    unsafe fn reinit_after_fork(&self) {
+        unsafe { self.0.get().write(parking_lot::ReentrantMutex::new(())) };
+    }
+}
+
+static SUBCLASSES_LOCKS: std::sync::LazyLock<Vec<ForkSubclassesLock>> =
+    std::sync::LazyLock::new(|| (0..256).map(|_| ForkSubclassesLock::new()).collect());
+
+type SubclassesGuard = parking_lot::lock_api::ReentrantMutexGuard<
+    'static,
+    parking_lot::RawMutex,
+    parking_lot::RawThreadId,
+    (),
+>;
+
+/// Only the acquire is opaque to the tracer, the same split `w_list_lock` uses:
+/// the guard-holding bodies stay look-inside.
+#[majit_macros::dont_look_inside]
+unsafe fn w_type_subclasses_lock(w_parent: PyObjectRef) -> SubclassesGuard {
+    let lock = SUBCLASSES_LOCKS[(w_parent as usize >> 4) & (SUBCLASSES_LOCKS.len() - 1)].get();
+    if let Some(guard) = lock.try_lock() {
+        return guard;
+    }
+    let blocked = majit_gc::gc_sync::before_external_block();
+    let guard = lock.lock();
+    drop(blocked);
+    guard
+}
+
+pub fn subclasses_locks_after_fork_child() {
+    for lock in SUBCLASSES_LOCKS.iter() {
+        unsafe { lock.reinit_after_fork() };
+    }
+}
+
 /// `typeobject.py:640-662 W_TypeObject.add_subclass`.
 ///
 /// Records `w_subclass` in `w_parent.weak_subclasses` if not
@@ -1208,6 +1264,10 @@ pub unsafe fn w_type_add_subclass(w_parent: PyObjectRef, w_subclass: PyObjectRef
     if !is_type(w_parent) || !is_type(w_subclass) {
         return;
     }
+    // Serialize against a concurrent `remove_subclass` / `get_subclasses` /
+    // `add_subclass` on the same parent: the null-check-then-install below and
+    // the `push` reallocation both invalidate what another thread is indexing.
+    let _subclasses_guard = w_type_subclasses_lock(w_parent);
     let parent = &mut *(w_parent as *mut W_TypeObject);
     if parent.weak_subclasses.is_null() {
         parent.weak_subclasses = Box::into_raw(Box::new(Vec::new()));
@@ -1271,6 +1331,7 @@ pub unsafe fn w_type_remove_subclass(w_parent: PyObjectRef, w_subclass: PyObject
     if !is_type(w_parent) {
         return;
     }
+    let _subclasses_guard = w_type_subclasses_lock(w_parent);
     let parent = &mut *(w_parent as *mut W_TypeObject);
     if parent.weak_subclasses.is_null() {
         return;
@@ -1305,6 +1366,7 @@ pub unsafe fn w_type_get_subclasses(
     if w_parent.is_null() || !is_type(w_parent) {
         return Vec::new();
     }
+    let _subclasses_guard = w_type_subclasses_lock(w_parent);
     let parent = &*(w_parent as *const W_TypeObject);
     if parent.weak_subclasses.is_null() {
         return Vec::new();


### PR DESCRIPTION
`W_TypeObject.weak_subclasses` is a raw `*mut Vec<*mut Weakref>` and all three
accessors touched it with no synchronization. Builtin parent types are
process-global, so concurrent class creation reaches the *same* vector:

- `w_type_add_subclass` — `if parent.weak_subclasses.is_null() { … = Box::into_raw(…) }`
  lets two threads each install a `Box`, and the `push` below **reallocates and frees
  the buffer** the others are indexing.
- `w_type_remove_subclass` — indexes `subs[i]`, then `remove(i)`.
- `w_type_get_subclasses` — iterates and dereferences every entry.

A stale `subs[i]` is a garbage `*mut Weakref` that `w_weakref_deref` dereferences; the
freed-buffer half is the malloc view. One race, four spellings: `double free or
corruption (fasttop)` on glibc, `STATUS_HEAP_CORRUPTION 0xc0000374` on Windows,
SIGSEGV/SIGTRAP on macOS.

## The fix

The first commit is unchanged from its original author — a 256-entry address-striped
`ReentrantMutex` keyed on the parent, taken in all three functions, plus
`subclasses_locks_after_fork_child()` registered next to `list_locks_after_fork_child()`.
It is the repo's established answer for "PyPy's GIL made this indivisible", mirroring
`w_list_lock` (`listobject.rs:61`), `w_dict_lock`, `w_count_lock`, `ForkSetLock` and
`ForkDequeLock`.

Two details worth re-stating, because they are what make it safe rather than a deadlock:

- The blocking acquire is wrapped in `majit_gc::gc_sync::before_external_block()`, which
  drops this thread out of RUNNING before it parks. Without that, a thread waiting on the
  stripe would stall a collector that is draining mutators to safepoints.
- The GC trace and `type_object_destructor` keep reading the field **unlocked**, and that
  is sound: they run inside stop-the-world, and a mutator can only be at a safepoint
  either at `before_external_block` (before it has touched the vector) or at
  `note_weak_subclass_store`'s write barrier (after the mutation completed). Neither is a
  torn state. Taking the lock there would instead risk deadlocking against a parked
  mutator.

Reentrant because `get_subclasses` is reachable from inside a mutation on the same thread
through the `mutated()` recursion.

## The regression test

The second commit adds `subclass_registry_survives_concurrent_mutation`: four threads,
each with its own 16 child types, registering / enumerating / unregistering against one
shared parent for 500 rounds.

| | result |
|---|---|
| three `w_type_subclasses_lock` guards deleted | **SIGABRT 3/3**, one round from `weakref.rs:81` |
| guards in place | **5/5 clean**, 0.03s |

`weakref.rs:81` is the frame every platform-specific spelling of this abort family names.
Until now the attribution to `weak_subclasses` rested on code reading plus a post-fix rate
change (macOS `cargo test --all --features dynasm` 0 failures in 8 rounds, against a
~1-in-3 baseline) with no captured trace. It is now reproducible on demand, and the
control run proves the gate is not vacuous.

## Provenance

The lock commit was authored earlier today but never reached a remote: its SHA
(`e555409c204`) is orphaned — `git branch -a --contains` returns nothing — and the code
survived only on the long-running local `wasm-jit` branch. This branch carries a
byte-identical copy, so a later `wasm-jit` rebase will drop its own as an
already-applied patch.

## Verification

- `check.py --backend dynasm,cranelift` — 358/358 each, 2/2 backend runs
- `cargo test --release -p pyre-object -p pyre-jit-trace -p majit-metainterp -p majit-trace` — 2208 passed, 0 failed
- `cargo test --release -p pyre-jit --features dynasm --test gc_stress` — 23/23
- `cargo fmt --all --check` clean

— *authored by Claude*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when managing class inheritance relationships across concurrent operations.
  * Prevented potential issues with subclass tracking after a process forks.
  * Added safeguards for consistent subclass registration, lookup, and removal during concurrent activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->