### PR TITLE
dictmultiobject: keep typed strategy in move_to_end for native-type keys

### DIFF
--- a/pyre/bench/synth/pypy_dict_primitives_nonbinding.py
+++ b/pyre/bench/synth/pypy_dict_primitives_nonbinding.py
@@ -122,4 +122,18 @@ if __pypy__ is not None:
     mte(noop, "r", last=True)  # "r" is already last -> no reorder
     assert first == "p" and list(it) == ["q", "r"]
 
+    # (7) typed-strategy dicts (int / bytes keys) reorder correctly, both
+    # directions, and reversed_dict enumerates them in reverse
+    di = {1: "a", 2: "b", 3: "c"}
+    mte(di, 1)
+    assert list(di) == [2, 3, 1]
+    mte(di, 3, last=False)
+    assert list(di) == [3, 2, 1]
+    assert list(rd(di)) == [1, 2, 3]
+    db = {b"x": 1, b"y": 2, b"z": 3}
+    mte(db, b"x")
+    assert list(db) == [b"y", b"z", b"x"]
+    mte(db, b"z", last=False)
+    assert list(db) == [b"z", b"y", b"x"]
+
 print("OK")

--- a/pyre/pyre-object/src/dictmultiobject.rs
+++ b/pyre/pyre-object/src/dictmultiobject.rs
@@ -3527,6 +3527,35 @@ pub unsafe fn w_dict_delitem_if_value_is_checked(
     Ok(true)
 }
 
+/// Reposition `k` to the back (`last`) or front of a native insertion-ordered
+/// typed store, bumping `keys_version` only on a real move.  Returns whether the
+/// key existed.  Shared by the Int/Bytes fast paths of
+/// [`w_dict_move_to_end_checked`]; the caller has proven the strategy so the
+/// `IndexMap<K, _>` cast matches `dstorage`.
+///
+/// # Safety
+/// `dict` must point to a valid `W_DictObject` whose `dstorage` is an
+/// `IndexMap<K, PyObjectRef>`.
+unsafe fn typed_move_to_end<K: std::hash::Hash + Eq>(
+    dict: *mut W_DictObject,
+    k: &K,
+    last: bool,
+) -> bool {
+    let dict = &mut *dict;
+    let entries = &mut *(dict.dstorage as *mut indexmap::IndexMap<K, PyObjectRef>);
+    match entries.get_index_of(k) {
+        Some(index) => {
+            let target = if last { entries.len() - 1 } else { 0 };
+            if index != target {
+                entries.move_index(index, target);
+                dict.keys_version = dict.keys_version.wrapping_add(1);
+            }
+            true
+        }
+        None => false,
+    }
+}
+
 /// PyPy `W_DictMultiObject.nondescr_move_to_end` (`dictmultiobject.py:221`):
 /// reposition an existing key to the back (`last`) or front of the insertion
 /// order, bypassing any subclass hooks.  Locates the entry callback-free,
@@ -3578,7 +3607,31 @@ pub unsafe fn w_dict_move_to_end_checked(
     }
 
     let strategy = (*(obj as *const W_DictObject)).dstrategy;
-    if strategy.strategy_kind() != StrategyKind::Object {
+    let kind = strategy.strategy_kind();
+
+    // Typed stores reorder in place, preserving the strategy — the
+    // `AbstractTypedStrategy.move_to_end` fast path (`dictmultiobject.py:1170`).
+    // Int and Bytes keep their native `IndexMap<i64>` / `IndexMap<Vec<u8>>`
+    // storage; the lookup compares native keys, so it is callback-free and
+    // needs no reentrant fallback.  A foreign-type key cannot be present in a
+    // typed store, so it falls through to the object-strategy path below.
+    if kind == StrategyKind::Int && crate::listobject::is_plain_int1(key) {
+        let k = crate::listobject::plain_int_w(key);
+        return Ok(typed_move_to_end::<i64>(obj as *mut W_DictObject, &k, last));
+    }
+    if kind == StrategyKind::Bytes && crate::is_exact_type(key, &crate::bytesobject::BYTES_TYPE) {
+        let k = crate::w_bytes_data(key).to_vec();
+        return Ok(typed_move_to_end::<Vec<u8>>(
+            obj as *mut W_DictObject,
+            &k,
+            last,
+        ));
+    }
+
+    // Object and Unicode share the `IndexMap<ObjectKey>` representation, so the
+    // reorder below runs in place; only a genuinely foreign store (a typed
+    // store reached with a non-native key, or Kwargs/Map/Empty) is converted.
+    if kind != StrategyKind::Object && kind != StrategyKind::Unicode {
         strategy.switch_to_object_strategy(obj);
     }
     let object_key = object_key_for_checked(key)?;


### PR DESCRIPTION
Follow-up to #957. `w_dict_move_to_end_checked` previously routed every non-`Object` dict through `switch_to_object_strategy` before reordering, de-specializing Int/Bytes/Unicode dicts on any `move_to_end`.

- Int and Bytes dicts reorder in their native `IndexMap<i64>` / `IndexMap<Vec<u8>>` storage for an exact int / bytes key (`typed_move_to_end`), matching `AbstractTypedStrategy.move_to_end` (`dictmultiobject.py:1170`). The lookup compares native keys, so it stays callback-free and needs no reentrant fallback.
- Unicode already shares `ObjectDictStrategy`'s `IndexMap<ObjectKey>` representation, so it reorders in place.
- Only a foreign-type key on a typed store, or the `Kwargs`/`Map`/`Empty` strategies, still convert to `Object`.

`keys_version` is bumped only on a real move (the `index != target` guard), preserving the existing no-op behavior.

## Verification
Byte-identical across CPython 3.14, PyPy3, and pyre via `bench/synth/pypy_dict_primitives_nonbinding.py`, extended (section 7) with int- and bytes-keyed `move_to_end` (both directions) and `reversed_dict` over an int dict. `cargo build --release` clean.

## Follow-up
- #46: the module-dict branches of `move_to_end` / `delitem_if_value_is` still lack a reentrant fallback (contrived, `__pypy__`-direct-only; shared limitation, not a regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dictionary entry reordering for integer- and bytes-key dictionaries.
  * Avoided unnecessary internal conversions when moving entries to the beginning or end.
  * Prevented version updates when an entry’s position does not change.

* **Tests**
  * Added coverage for moving entries and reverse iteration across supported dictionary types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->