### PR TITLE
gc: port malloc_fast and the fast-path gate claim; long: unchecked rbigint digit access

### DIFF
--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -1445,7 +1445,7 @@ fn with_cranelift_gc<R>(f: impl FnOnce(&mut dyn GcAllocator) -> R) -> Option<R> 
         });
     }
     if majit_gc::gc_sync::is_initialized() {
-        return Some(majit_gc::gc_sync::gc_op(f));
+        return Some(majit_gc::gc_sync::gc_op(|gc| f(gc)));
     }
     None
 }

--- a/majit/majit-backend-dynasm/src/aarch64/assembler.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/assembler.rs
@@ -35,15 +35,36 @@ const AARCH64_GEN_REGS: [crate::regloc::RegLoc; 18] = crate::aarch64::registers:
 
 const AARCH64_FLOAT_REGS: [crate::regloc::RegLoc; 8] = crate::aarch64::registers::ALL_VFP_REGS;
 
-/// Bytes the trace entry frame reserves: the frame-pointer/link pair and the
-/// callee-saved registers the trace body clobbers. The prologue, the
-/// stack-overflow early return and the epilogue must all agree on this, or the
-/// return unwinds a corrupt SP.
-const CALL_FRAME_SIZE: u32 = 48;
+/// Bytes the trace entry frame reserves: the frame-pointer/link pair, the
+/// callee-saved registers the trace body clobbers, and the thread-local base
+/// slot. The prologue, the stack-overflow early return and the epilogue must
+/// all agree on this, or the return unwinds a corrupt SP.
+const CALL_FRAME_SIZE: u32 = 64;
+
+/// Frame offset of the thread-local base a compiled entry receives in `x1`.
+///
+/// `aarch64/assembler.py:1128-1129` names this `saved_threadlocal_addr` and
+/// spills the incoming `x1` there once per entry, so any point inside the
+/// trace can reach `pypy_threadlocal_s` without the caller keeping a register
+/// live across the body. The upstream constant is `3 * WORD` because its frame
+/// reserves eight scratch words below the callee-saved area
+/// (`_call_header`: `STP_rri(..., (i + 8) * WORD)`); this frame packs its three
+/// register pairs from offset 0, so the slot lands above them instead. The
+/// offset differs, the mechanism does not.
+///
+/// Reads must add any `sub sp, sp, #n` in effect at the read point, the way
+/// `aarch64/callbuilder.py:173` adds `self.current_sp`. The only reader today
+/// (`genop_call_assembler`) runs outside the stack-argument window.
+const SAVED_THREADLOCAL_OFS: u32 = 48;
 
 const _: () = assert!(
     CALL_FRAME_SIZE % 16 == 0,
     "aarch64 SP stays 16-byte aligned"
+);
+
+const _: () = assert!(
+    SAVED_THREADLOCAL_OFS + 8 <= CALL_FRAME_SIZE,
+    "the thread-local slot lives inside the entry frame"
 );
 
 /// Resolved argument: either a frame slot (frame-pointer-relative offset) or a constant.
@@ -1380,6 +1401,9 @@ impl<'a> AssemblerARM64<'a> {
             ; stp x29, x30, [sp, -(CALL_FRAME_SIZE as i32)]!
             ; stp x19, x20, [sp, #16]   // save callee-saved regs
             ; stp x21, x22, [sp, #32]   // save callee-saved regs
+            // assembler.py:1128-1129: spill the thread-local base the entry
+            // received in x1, then take the jitframe out of x0.
+            ; str x1, [sp, #SAVED_THREADLOCAL_OFS]
             ; mov x29, x0
         );
         let propagate_descr = self.propagate_exception_descr_ptr();
@@ -6105,10 +6129,17 @@ impl<'a> AssemblerARM64<'a> {
             // pre-existing adaptation; it is not part of the RPython fast
             // path and is too expensive for recursive CALL_ASSEMBLER.
             let pushed_gcmap = self.push_pending_call_gcmap();
+            // `_call_assembler_emit_call` opens with `LDR x1, [sp, ofs]` — the
+            // callee's prologue re-spills x1 into its own frame, so the base
+            // has to be reloaded here rather than assumed live. The target
+            // address goes through ip0 because x1 is now an argument.
+            dynasm!(self.mc ; .arch aarch64
+                ; ldr x1, [sp, #SAVED_THREADLOCAL_OFS]
+            );
             if let Some(addr) = target_addr.immediate {
                 let addr = addr as i64;
-                self.emit_mov_imm64(1, addr);
-                dynasm!(self.mc ; .arch aarch64 ; blr x1);
+                self.emit_mov_imm64(16, addr);
+                dynasm!(self.mc ; .arch aarch64 ; blr x16);
             } else if let Some(entry_label) = self.self_entry_label {
                 dynasm!(self.mc ; .arch aarch64 ; bl =>entry_label);
             }

--- a/majit/majit-backend-dynasm/src/lib.rs
+++ b/majit/majit-backend-dynasm/src/lib.rs
@@ -91,14 +91,19 @@ static JIT_EXC_VALUE: AtomicI64 = AtomicI64::new(0);
 // managed object, so it is deliberately not GC-rooted.
 static JIT_EXC_TYPE: AtomicI64 = AtomicI64::new(0);
 static JITFRAME_GC_TYPE_ID: AtomicU32 = AtomicU32::new(u32::MAX);
-#[allow(dead_code)]
+/// Stands in for the slot array before any slot is written, so the base a
+/// compiled entry receives is always a readable address rather than null.
+/// `llmodel.py:319-322` does the same in untranslated runs, handing the entry a
+/// dummy container instead of the real `pypy_threadlocal_s`.
 static DUMMY_THREADLOCAL_SLOT: i64 = 0;
 
 thread_local! {
-    /// llmodel.py:317-323 `threadlocalref_addr` parity: compiled entries
-    /// take the thread-local slot-array base as their second argument.
-    /// Dynasm's aarch64 CALL_ASSEMBLER path preserves and forwards that
-    /// entry ABI even before THREADLOCALREF_GET lowering exists.
+    /// llmodel.py:276-285 / :317-323 `threadlocalref_addr` parity: compiled
+    /// entries take the thread-local slot-array base as their second argument.
+    /// The aarch64 prologue spills it to `SAVED_THREADLOCAL_OFS` and the
+    /// CALL_ASSEMBLER path reloads it into x1 before invoking the callee trace,
+    /// so the ABI holds through the whole call chain even though
+    /// THREADLOCALREF_GET lowering does not exist yet.
     static JIT_THREADLOCAL_SLOTS: RefCell<Vec<i64>> = const { RefCell::new(Vec::new()) };
 }
 
@@ -186,7 +191,6 @@ pub fn jit_threadlocalref_set(offset: i64, value: i64) {
 }
 
 /// Return the base pointer passed to compiled entrypoints as x1.
-#[allow(dead_code)]
 pub(crate) fn jit_threadlocalref_base() -> *const i64 {
     JIT_THREADLOCAL_SLOTS.with(|slots| {
         let slots = slots.borrow();

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -8,6 +8,9 @@ use std::sync::Arc;
 use std::sync::atomic::Ordering;
 
 use majit_backend::{AsmInfo, Backend, BackendError, DeadFrame, JitCellToken};
+// `gc_sync` hands out the concrete collector; the trait must be in scope for
+// its methods to resolve on that type.
+use majit_gc::GcAllocator;
 use majit_ir::{FailDescr, GcRef, InputArg, Op, OpRc, OpRef, Type, Value};
 
 #[cfg(target_arch = "aarch64")]
@@ -125,7 +128,9 @@ pub(crate) fn with_dynasm_active_gc<R>(f: impl Fn(&dyn majit_gc::GcAllocator) ->
         return Some(r);
     }
     if majit_gc::gc_sync::is_initialized() {
-        return Some(majit_gc::gc_sync::gc_query_reentrant(f));
+        // The singleton is the concrete collector; the box path above is what
+        // keeps this forwarder's argument a trait object.
+        return Some(majit_gc::gc_sync::gc_query_reentrant(|gc| f(gc)));
     }
     None
 }
@@ -170,7 +175,7 @@ pub(crate) fn with_dynasm_active_gc_mut<R>(
         });
     }
     if majit_gc::gc_sync::is_initialized() {
-        return Some(majit_gc::gc_sync::gc_op(f));
+        return Some(majit_gc::gc_sync::gc_op(|gc| f(gc)));
     }
     None
 }

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -2828,12 +2828,14 @@ impl Backend for DynasmBackend {
             }
         }
 
-        // llmodel.py:323: ll_frame = func(ll_frame). The compiled
+        // llmodel.py:276-285 `make_execute_token` fixes the entry signature as
+        // `(jitframe, threadlocal_addr) -> jitframe`, and `:317-323` reads the
+        // address with `llop.threadlocalref_addr` before the call. The compiled
         // prologue (gen_shadowstack_header) / epilogue
         // (gen_footer_shadowstack) push/pop the jf_ptr onto the shadow
         // stack inline, matching aarch64/assembler.py:1422/1438 — no
         // manual push_jf/pop_jf_to around the call.
-        let func: unsafe extern "C" fn(*mut JitFrame) -> *mut JitFrame =
+        let func: unsafe extern "C" fn(*mut JitFrame, *const i64) -> *mut JitFrame =
             unsafe { std::mem::transmute(entry) };
         if crate::dynasm_exec_diag_enabled() {
             eprintln!(
@@ -2844,7 +2846,7 @@ impl Backend for DynasmBackend {
             );
         }
         debug_validate_oldgen_freeblocks(format_args!("before trace {}", compiled.trace_id));
-        let result_jf = unsafe { func(jf_ptr) };
+        let result_jf = unsafe { func(jf_ptr, crate::jit_threadlocalref_base()) };
         debug_validate_oldgen_freeblocks(format_args!("after trace {}", compiled.trace_id));
 
         if crate::majit_log_enabled() {
@@ -2966,9 +2968,9 @@ impl Backend for DynasmBackend {
             unsafe { crate::llmodel::set_int_value(jf_ptr, Self::input_slot(i), val as isize) };
         }
 
-        let func: unsafe extern "C" fn(*mut JitFrame) -> *mut JitFrame =
+        let func: unsafe extern "C" fn(*mut JitFrame, *const i64) -> *mut JitFrame =
             unsafe { std::mem::transmute(entry) };
-        let result_jf = unsafe { func(jf_ptr) };
+        let result_jf = unsafe { func(jf_ptr, crate::jit_threadlocalref_base()) };
 
         let jf_descr_raw = unsafe { crate::llmodel::get_latest_descr(result_jf) as i64 };
         let descr = self.find_descr_by_ptr(token, jf_descr_raw as usize, result_jf);

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -257,7 +257,7 @@ thread_local! {
 fn with_wasm_active_gc<R>(f: impl Fn(&dyn GcAllocator) -> R) -> Option<R> {
     if !majit_gc::gc_box_installed() {
         return majit_gc::gc_sync::is_initialized()
-            .then(|| majit_gc::gc_sync::gc_query_reentrant(f));
+            .then(|| majit_gc::gc_sync::gc_query_reentrant(|gc| f(gc)));
     }
     match WASM_ACTIVE_GC.with(|cell| cell.try_borrow().map(|g| g.as_deref().map(|gc| f(gc)))) {
         Ok(Some(r)) => return Some(r),
@@ -272,7 +272,7 @@ fn with_wasm_active_gc<R>(f: impl Fn(&dyn GcAllocator) -> R) -> Option<R> {
         }
     }
     if majit_gc::gc_sync::is_initialized() {
-        return Some(majit_gc::gc_sync::gc_query_reentrant(f));
+        return Some(majit_gc::gc_sync::gc_query_reentrant(|gc| f(gc)));
     }
     None
 }
@@ -294,7 +294,7 @@ fn with_wasm_active_gc_mut<R>(f: impl FnOnce(&mut dyn GcAllocator) -> R) -> Opti
         });
     }
     if majit_gc::gc_sync::is_initialized() {
-        return Some(majit_gc::gc_sync::gc_op(f));
+        return Some(majit_gc::gc_sync::gc_op(|gc| f(gc)));
     }
     None
 }

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -873,7 +873,7 @@ impl MiniMarkGC {
     /// indistinguishable from the slow path's, so a side table would
     /// not stay in sync.
     #[inline]
-    fn is_managed_heap_object(&self, addr: usize) -> bool {
+    pub fn is_managed_heap_object(&self, addr: usize) -> bool {
         self.is_valid_gc_object(addr) && (self.nursery.contains(addr) || self.oldgen.contains(addr))
     }
 
@@ -885,6 +885,10 @@ impl MiniMarkGC {
 
     /// Allocate a fixed-size object with the given type ID and size (excluding header).
     /// Returns a GcRef pointing to the object payload (after the header).
+    ///
+    /// Split into an inline bump and an out-of-line tail like
+    /// [`alloc_with_type_rooted`](Self::alloc_with_type_rooted).
+    #[inline]
     pub fn alloc_with_type(&mut self, type_id: u32, payload_size: usize) -> GcRef {
         // gc_stress: force a full collection *before* allocating so that any
         // object live at this allocation point but unreachable from a
@@ -905,58 +909,59 @@ impl MiniMarkGC {
             return GcRef(0);
         };
 
+        if total_size <= self.config.large_object_threshold {
+            let ptr = self.nursery.alloc(total_size);
+            if !ptr.is_null() {
+                return self.finish_nursery_object(ptr, type_id);
+            }
+        }
+        self.alloc_with_type_slow(type_id, total_size)
+    }
+
+    /// The outcomes [`alloc_with_type`](Self::alloc_with_type) leaves out of
+    /// line: a large object, and a nursery too full to serve the bump.
+    #[cold]
+    #[inline(never)]
+    fn alloc_with_type_slow(&mut self, type_id: u32, total_size: usize) -> GcRef {
         // Large objects go directly to old gen.
         if total_size > self.config.large_object_threshold {
             return self.alloc_in_oldgen(type_id, total_size);
         }
 
-        let ptr = self.nursery.alloc(total_size);
-        if ptr.is_null() {
-            // Nursery full: trigger minor collection and retry.
-            // minimark.py:1282 collect_and_reserve parity. Carry the triggering
-            // allocation size so a bounded major collection applies the
-            // PYPY_GC_MAX out-of-memory policy against it (threshold_reached).
-            self.pending_reserving_size = total_size;
-            self.do_collect_nursery();
-            self.pending_reserving_size = 0;
-            // incminimark.py:2603-2615 — a bounded major collection that leaves
-            // the heap over `max_heap_size` asks this allocation to fail so the
-            // caller raises MemoryError: NULL propagates to the compiled-code
-            // `CHECK_MEMORY_ERROR` path and to the interpreter allocation
-            // chokepoint. Never taken in the unbounded default (`PYPY_GC_MAX`
-            // unset), so the fallback below is unchanged there.
-            if std::mem::take(&mut self.oom_pending) {
-                return GcRef(0);
-            }
-            let ptr = self.nursery.alloc(total_size);
-            let ptr = if ptr.is_null() {
-                self.reserve_nursery_gap(total_size)
-            } else {
-                ptr
-            };
-            if ptr.is_null() && Self::nursery_allocation_size(total_size) > self.nursery.size() {
-                // Production incminimark keeps `nonlarge_max` below the
-                // nursery size. Tiny backend tests can configure the two
-                // independently; retain their external-allocation fallback
-                // only for an object that cannot physically fit anywhere.
-                return self.alloc_in_oldgen(type_id, total_size);
-            }
-            assert!(
-                !ptr.is_null(),
-                "collect_and_reserve could not find nursery space for a non-large object"
-            );
-            Self::init_nursery_object(ptr, type_id);
-            let obj = GcRef((ptr as usize) + GcHeader::SIZE);
-            self.register_weakref_if_needed(type_id, obj.0);
-            self.register_destructor_if_needed(type_id, obj.0);
-            return obj;
+        // Nursery full: trigger minor collection and retry.
+        // minimark.py:1282 collect_and_reserve parity. Carry the triggering
+        // allocation size so a bounded major collection applies the
+        // PYPY_GC_MAX out-of-memory policy against it (threshold_reached).
+        self.pending_reserving_size = total_size;
+        self.do_collect_nursery();
+        self.pending_reserving_size = 0;
+        // incminimark.py:2603-2615 — a bounded major collection that leaves
+        // the heap over `max_heap_size` asks this allocation to fail so the
+        // caller raises MemoryError: NULL propagates to the compiled-code
+        // `CHECK_MEMORY_ERROR` path and to the interpreter allocation
+        // chokepoint. Never taken in the unbounded default (`PYPY_GC_MAX`
+        // unset), so the fallback below is unchanged there.
+        if std::mem::take(&mut self.oom_pending) {
+            return GcRef(0);
         }
-
-        Self::init_nursery_object(ptr, type_id);
-        let obj = GcRef((ptr as usize) + GcHeader::SIZE);
-        self.register_weakref_if_needed(type_id, obj.0);
-        self.register_destructor_if_needed(type_id, obj.0);
-        obj
+        let ptr = self.nursery.alloc(total_size);
+        let ptr = if ptr.is_null() {
+            self.reserve_nursery_gap(total_size)
+        } else {
+            ptr
+        };
+        if ptr.is_null() && Self::nursery_allocation_size(total_size) > self.nursery.size() {
+            // Production incminimark keeps `nonlarge_max` below the
+            // nursery size. Tiny backend tests can configure the two
+            // independently; retain their external-allocation fallback
+            // only for an object that cannot physically fit anywhere.
+            return self.alloc_in_oldgen(type_id, total_size);
+        }
+        assert!(
+            !ptr.is_null(),
+            "collect_and_reserve could not find nursery space for a non-large object"
+        );
+        self.finish_nursery_object(ptr, type_id)
     }
 
     /// `malloc_fixedsize` / `collect_and_reserve` with one native-stack root.
@@ -968,10 +973,18 @@ impl MiniMarkGC {
     /// required; this preserves the upstream fast path instead of doing a
     /// root-set add/remove for every allocation.
     ///
+    /// Split into a `malloc_fast` body and its exceptional tail the way
+    /// `framework.py:361-382` does: the copy it declares `inline=True` carries
+    /// only the bump, so a caller pays a bump and a branch, while a large
+    /// object or a full nursery costs a call. Without the split the whole
+    /// function is a frame that saves ten callee-saved registers before it
+    /// can reach a ten-instruction bump.
+    ///
     /// # Safety
     /// `root` must point to a valid mutable `GcRef` slot until this call
     /// returns. `needs_write_barrier` must point to a valid mutable `bool`
     /// slot.
+    #[inline]
     pub unsafe fn alloc_with_type_rooted(
         &mut self,
         type_id: u32,
@@ -992,6 +1005,29 @@ impl MiniMarkGC {
             return GcRef(0);
         };
 
+        if total_size <= self.config.large_object_threshold {
+            let ptr = self.nursery.alloc(total_size);
+            if !ptr.is_null() {
+                return self.finish_nursery_object(ptr, type_id);
+            }
+        }
+        unsafe { self.alloc_with_type_rooted_slow(type_id, total_size, root, needs_write_barrier) }
+    }
+
+    /// The outcomes [`alloc_with_type_rooted`] leaves out of line: a large
+    /// object, and a nursery too full to serve the bump.
+    ///
+    /// # Safety
+    /// Same contract as [`alloc_with_type_rooted`].
+    #[cold]
+    #[inline(never)]
+    unsafe fn alloc_with_type_rooted_slow(
+        &mut self,
+        type_id: u32,
+        total_size: usize,
+        root: *mut GcRef,
+        needs_write_barrier: *mut bool,
+    ) -> GcRef {
         // Large objects never trigger a nursery collection, so the native
         // slot needs no temporary registration.
         if total_size > self.config.large_object_threshold {
@@ -999,37 +1035,35 @@ impl MiniMarkGC {
             return self.alloc_in_oldgen(type_id, total_size);
         }
 
-        let ptr = self.nursery.alloc(total_size);
-        if ptr.is_null() {
-            self.pending_reserving_size = total_size;
-            unsafe { self.roots.add(root) };
-            self.do_collect_nursery();
-            self.roots.remove(root);
-            self.pending_reserving_size = 0;
-            if std::mem::take(&mut self.oom_pending) {
-                return GcRef(0);
-            }
-            let ptr = self.nursery.alloc(total_size);
-            let ptr = if ptr.is_null() {
-                self.reserve_nursery_gap(total_size)
-            } else {
-                ptr
-            };
-            if ptr.is_null() && Self::nursery_allocation_size(total_size) > self.nursery.size() {
-                unsafe { *needs_write_barrier = true };
-                return self.alloc_in_oldgen(type_id, total_size);
-            }
-            assert!(
-                !ptr.is_null(),
-                "collect_and_reserve could not find nursery space for a non-large object"
-            );
-            Self::init_nursery_object(ptr, type_id);
-            let obj = GcRef((ptr as usize) + GcHeader::SIZE);
-            self.register_weakref_if_needed(type_id, obj.0);
-            self.register_destructor_if_needed(type_id, obj.0);
-            return obj;
+        self.pending_reserving_size = total_size;
+        unsafe { self.roots.add(root) };
+        self.do_collect_nursery();
+        self.roots.remove(root);
+        self.pending_reserving_size = 0;
+        if std::mem::take(&mut self.oom_pending) {
+            return GcRef(0);
         }
+        let ptr = self.nursery.alloc(total_size);
+        let ptr = if ptr.is_null() {
+            self.reserve_nursery_gap(total_size)
+        } else {
+            ptr
+        };
+        if ptr.is_null() && Self::nursery_allocation_size(total_size) > self.nursery.size() {
+            unsafe { *needs_write_barrier = true };
+            return self.alloc_in_oldgen(type_id, total_size);
+        }
+        assert!(
+            !ptr.is_null(),
+            "collect_and_reserve could not find nursery space for a non-large object"
+        );
+        self.finish_nursery_object(ptr, type_id)
+    }
 
+    /// The tail every nursery bump shares: `init_gc_object` plus the
+    /// weakref and destructor registration of incminimark.py:687-693.
+    #[inline]
+    fn finish_nursery_object(&mut self, ptr: *mut u8, type_id: u32) -> GcRef {
         Self::init_nursery_object(ptr, type_id);
         let obj = GcRef((ptr as usize) + GcHeader::SIZE);
         self.register_weakref_if_needed(type_id, obj.0);
@@ -1132,11 +1166,7 @@ impl MiniMarkGC {
             return self.alloc_in_oldgen(type_id, total_size);
         }
 
-        Self::init_nursery_object(ptr, type_id);
-        let obj = GcRef((ptr as usize) + GcHeader::SIZE);
-        self.register_weakref_if_needed(type_id, obj.0);
-        self.register_destructor_if_needed(type_id, obj.0);
-        obj
+        self.finish_nursery_object(ptr, type_id)
     }
 
     /// Fallible host-side counterpart of `alloc_with_type_no_collect`.
@@ -1162,9 +1192,13 @@ impl MiniMarkGC {
     /// fresh nursery allocation. The no-collect path can instead spill to
     /// old-gen, so report that exceptional placement to the initializer.
     ///
+    /// Split like [`alloc_with_type_rooted`](Self::alloc_with_type_rooted):
+    /// the bump inlines into the caller, the old-gen spill is a call.
+    ///
     /// # Safety
     /// `needs_write_barrier` must point to a valid mutable `bool` slot for the
     /// duration of this call.
+    #[inline]
     pub unsafe fn try_alloc_with_type_no_collect_with_placement(
         &mut self,
         type_id: u32,
@@ -1176,25 +1210,25 @@ impl MiniMarkGC {
             return GcRef(0);
         };
 
-        if total_size > self.config.large_object_threshold {
-            return self
-                .try_alloc_in_oldgen(type_id, total_size)
-                .unwrap_or(GcRef(0));
+        if total_size <= self.config.large_object_threshold {
+            let ptr = self.nursery.alloc(total_size);
+            if !ptr.is_null() {
+                let obj = self.finish_nursery_object(ptr, type_id);
+                unsafe { *needs_write_barrier = false };
+                return obj;
+            }
         }
+        self.spill_to_oldgen_or_null(type_id, total_size)
+    }
 
-        let ptr = self.nursery.alloc(total_size);
-        if ptr.is_null() {
-            return self
-                .try_alloc_in_oldgen(type_id, total_size)
-                .unwrap_or(GcRef(0));
-        }
-
-        Self::init_nursery_object(ptr, type_id);
-        let obj = GcRef((ptr as usize) + GcHeader::SIZE);
-        self.register_weakref_if_needed(type_id, obj.0);
-        self.register_destructor_if_needed(type_id, obj.0);
-        unsafe { *needs_write_barrier = false };
-        obj
+    /// The old-gen spill
+    /// [`try_alloc_with_type_no_collect_with_placement`](Self::try_alloc_with_type_no_collect_with_placement)
+    /// leaves out of line, for a large object or a nursery with no room.
+    #[cold]
+    #[inline(never)]
+    fn spill_to_oldgen_or_null(&mut self, type_id: u32, total_size: usize) -> GcRef {
+        self.try_alloc_in_oldgen(type_id, total_size)
+            .unwrap_or(GcRef(0))
     }
 
     /// incminimark.py:690-692 parity. When a freshly-allocated object
@@ -4322,7 +4356,7 @@ impl GcAllocator for MiniMarkGC {
     }
 
     fn is_managed_heap_object(&self, addr: usize) -> bool {
-        self.is_valid_gc_object(addr) && (self.nursery.contains(addr) || self.oldgen.contains(addr))
+        MiniMarkGC::is_managed_heap_object(self, addr)
     }
 
     fn is_nursery_object(&self, addr: usize) -> bool {

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -992,6 +992,53 @@ impl MiniMarkGC {
         root: *mut GcRef,
         needs_write_barrier: *mut bool,
     ) -> GcRef {
+        unsafe {
+            self.alloc_with_type_rooted_body::<false>(
+                type_id,
+                payload_size,
+                root,
+                needs_write_barrier,
+            )
+        }
+    }
+
+    /// [`alloc_with_type_rooted`](Self::alloc_with_type_rooted) for a type that
+    /// carries neither a finalizer nor the weakref flag: `malloc_fast`
+    /// (`framework.py:361-382`), the copy `gct_fv_gc_malloc` selects at
+    /// `framework.py:830-838` for exactly that case.
+    ///
+    /// # Safety
+    /// Same contract as [`alloc_with_type_rooted`](Self::alloc_with_type_rooted),
+    /// plus `type_id` must name a type with no destructor and no weakref flag.
+    #[inline]
+    pub unsafe fn alloc_fast_with_type_rooted(
+        &mut self,
+        type_id: u32,
+        payload_size: usize,
+        root: *mut GcRef,
+        needs_write_barrier: *mut bool,
+    ) -> GcRef {
+        unsafe {
+            self.alloc_with_type_rooted_body::<true>(
+                type_id,
+                payload_size,
+                root,
+                needs_write_barrier,
+            )
+        }
+    }
+
+    /// # Safety
+    /// See [`alloc_with_type_rooted`](Self::alloc_with_type_rooted); `FAST`
+    /// additionally carries `malloc_fast`'s obligation on `type_id`.
+    #[inline]
+    unsafe fn alloc_with_type_rooted_body<const FAST: bool>(
+        &mut self,
+        type_id: u32,
+        payload_size: usize,
+        root: *mut GcRef,
+        needs_write_barrier: *mut bool,
+    ) -> GcRef {
         unsafe { *needs_write_barrier = false };
 
         #[cfg(feature = "gc_stress")]
@@ -1008,7 +1055,7 @@ impl MiniMarkGC {
         if total_size <= self.config.large_object_threshold {
             let ptr = self.nursery.alloc(total_size);
             if !ptr.is_null() {
-                return self.finish_nursery_object(ptr, type_id);
+                return self.finish_bumped_nursery_object::<FAST>(ptr, type_id);
             }
         }
         unsafe { self.alloc_with_type_rooted_slow(type_id, total_size, root, needs_write_barrier) }
@@ -1060,8 +1107,46 @@ impl MiniMarkGC {
         self.finish_nursery_object(ptr, type_id)
     }
 
-    /// The tail every nursery bump shares: `init_gc_object` plus the
-    /// weakref and destructor registration of incminimark.py:687-693.
+    /// The tail a successful nursery bump runs: `init_gc_object`, then
+    /// incminimark.py:687-693's two registrations.
+    ///
+    /// `FAST` is `malloc_fast` (`framework.py:361-382`), the copy of
+    /// `malloc_fixedsize` annotated `s_False, s_False, s_False` — under that
+    /// annotation both `if`s constant-fold away, so the common allocation never
+    /// reaches the type's flags at all. `gct_fv_gc_malloc`
+    /// (`framework.py:830-838`) selects the copy only for a type with no
+    /// finalizer, and never passes `contains_weakptr=True` for a fixed-size
+    /// malloc: a WEAKREF is built by `gct_weakref_create` instead. The
+    /// obligation rides with the caller here too, so the `ll_assert` the
+    /// general body spells out becomes a debug assertion.
+    #[inline]
+    fn finish_bumped_nursery_object<const FAST: bool>(
+        &mut self,
+        ptr: *mut u8,
+        type_id: u32,
+    ) -> GcRef {
+        if FAST {
+            debug_assert!(
+                !self.type_needs_young_registration(type_id),
+                "malloc_fast served a type that needs a young weakref/destructor registration"
+            );
+            Self::init_nursery_object(ptr, type_id);
+            return GcRef((ptr as usize) + GcHeader::SIZE);
+        }
+        self.finish_nursery_object(ptr, type_id)
+    }
+
+    /// The `malloc_fast` precondition, as the debug build checks it.
+    fn type_needs_young_registration(&self, type_id: u32) -> bool {
+        if (type_id as usize) >= self.types.len() {
+            return false;
+        }
+        let info = self.types.get(type_id);
+        info.is_weakref || info.destructor.is_some()
+    }
+
+    /// The tail every non-`malloc_fast` nursery bump shares: `init_gc_object`
+    /// plus the weakref and destructor registration of incminimark.py:687-693.
     #[inline]
     fn finish_nursery_object(&mut self, ptr: *mut u8, type_id: u32) -> GcRef {
         Self::init_nursery_object(ptr, type_id);
@@ -1217,6 +1302,27 @@ impl MiniMarkGC {
         }
     }
 
+    /// [`try_alloc_with_type_no_collect`](Self::try_alloc_with_type_no_collect)
+    /// for a type that carries neither a finalizer nor the weakref flag:
+    /// `malloc_fast` (`framework.py:361-382`).
+    ///
+    /// # Safety
+    /// `type_id` must name a type with no destructor and no weakref flag.
+    pub unsafe fn try_alloc_fast_with_type_no_collect(
+        &mut self,
+        type_id: u32,
+        payload_size: usize,
+    ) -> GcRef {
+        let mut needs_write_barrier = true;
+        unsafe {
+            self.try_alloc_fast_with_type_no_collect_with_placement(
+                type_id,
+                payload_size,
+                &mut needs_write_barrier,
+            )
+        }
+    }
+
     /// Placement-reporting counterpart of
     /// [`try_alloc_with_type_no_collect`](Self::try_alloc_with_type_no_collect).
     ///
@@ -1237,6 +1343,50 @@ impl MiniMarkGC {
         payload_size: usize,
         needs_write_barrier: *mut bool,
     ) -> GcRef {
+        unsafe {
+            self.try_alloc_with_type_no_collect_body::<false>(
+                type_id,
+                payload_size,
+                needs_write_barrier,
+            )
+        }
+    }
+
+    /// [`try_alloc_with_type_no_collect_with_placement`](Self::try_alloc_with_type_no_collect_with_placement)
+    /// for a type that carries neither a finalizer nor the weakref flag:
+    /// `malloc_fast` (`framework.py:361-382`).
+    ///
+    /// # Safety
+    /// Same contract as
+    /// [`try_alloc_with_type_no_collect_with_placement`](Self::try_alloc_with_type_no_collect_with_placement),
+    /// plus `type_id` must name a type with no destructor and no weakref flag.
+    #[inline]
+    pub unsafe fn try_alloc_fast_with_type_no_collect_with_placement(
+        &mut self,
+        type_id: u32,
+        payload_size: usize,
+        needs_write_barrier: *mut bool,
+    ) -> GcRef {
+        unsafe {
+            self.try_alloc_with_type_no_collect_body::<true>(
+                type_id,
+                payload_size,
+                needs_write_barrier,
+            )
+        }
+    }
+
+    /// # Safety
+    /// See
+    /// [`try_alloc_with_type_no_collect_with_placement`](Self::try_alloc_with_type_no_collect_with_placement);
+    /// `FAST` additionally carries `malloc_fast`'s obligation on `type_id`.
+    #[inline]
+    unsafe fn try_alloc_with_type_no_collect_body<const FAST: bool>(
+        &mut self,
+        type_id: u32,
+        payload_size: usize,
+        needs_write_barrier: *mut bool,
+    ) -> GcRef {
         unsafe { *needs_write_barrier = true };
         let Some(total_size) = GcHeader::SIZE.checked_add(payload_size) else {
             return GcRef(0);
@@ -1245,7 +1395,7 @@ impl MiniMarkGC {
         if total_size <= self.config.large_object_threshold {
             let ptr = self.nursery.alloc(total_size);
             if !ptr.is_null() {
-                let obj = self.finish_nursery_object(ptr, type_id);
+                let obj = self.finish_bumped_nursery_object::<FAST>(ptr, type_id);
                 unsafe { *needs_write_barrier = false };
                 return obj;
             }
@@ -4265,6 +4415,16 @@ impl GcAllocator for MiniMarkGC {
         unsafe { self.alloc_with_type_rooted(type_id, size, root, needs_write_barrier) }
     }
 
+    unsafe fn alloc_fast_nursery_collecting_typed_rooted(
+        &mut self,
+        type_id: u32,
+        size: usize,
+        root: *mut GcRef,
+        needs_write_barrier: *mut bool,
+    ) -> GcRef {
+        unsafe { self.alloc_fast_with_type_rooted(type_id, size, root, needs_write_barrier) }
+    }
+
     fn alloc_nursery_no_collect(&mut self, size: usize) -> GcRef {
         self.alloc_with_type_no_collect(0, size)
     }
@@ -4277,6 +4437,14 @@ impl GcAllocator for MiniMarkGC {
         self.try_alloc_with_type_no_collect(type_id, size)
     }
 
+    unsafe fn try_alloc_fast_nursery_no_collect_typed(
+        &mut self,
+        type_id: u32,
+        size: usize,
+    ) -> GcRef {
+        unsafe { self.try_alloc_fast_with_type_no_collect(type_id, size) }
+    }
+
     unsafe fn try_alloc_nursery_no_collect_typed_with_placement(
         &mut self,
         type_id: u32,
@@ -4285,6 +4453,21 @@ impl GcAllocator for MiniMarkGC {
     ) -> GcRef {
         unsafe {
             self.try_alloc_with_type_no_collect_with_placement(type_id, size, needs_write_barrier)
+        }
+    }
+
+    unsafe fn try_alloc_fast_nursery_no_collect_typed_with_placement(
+        &mut self,
+        type_id: u32,
+        size: usize,
+        needs_write_barrier: *mut bool,
+    ) -> GcRef {
+        unsafe {
+            self.try_alloc_fast_with_type_no_collect_with_placement(
+                type_id,
+                size,
+                needs_write_barrier,
+            )
         }
     }
 

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -466,7 +466,7 @@ pub struct MiniMarkGC {
     /// incminimark.py:407 `self.young_objects_with_destructors =
     /// self.AddressStack()`. Nursery-resident objects whose type carries
     /// a lightweight `TypeInfo.destructor`. Populated by
-    /// `register_destructor_if_needed` at allocation (incminimark.py:689
+    /// `register_young_object_if_needed` at allocation (incminimark.py:689
     /// `if needs_finalizer:`). Drained at end of minor cycle by
     /// `deal_with_young_objects_with_destructors` (incminimark.py:1868,
     /// :2884-2895): a dead object's destructor runs, a survivor moves to
@@ -1066,9 +1066,41 @@ impl MiniMarkGC {
     fn finish_nursery_object(&mut self, ptr: *mut u8, type_id: u32) -> GcRef {
         Self::init_nursery_object(ptr, type_id);
         let obj = GcRef((ptr as usize) + GcHeader::SIZE);
-        self.register_weakref_if_needed(type_id, obj.0);
-        self.register_destructor_if_needed(type_id, obj.0);
+        self.register_young_object_if_needed(type_id, obj.0);
         obj
+    }
+
+    /// incminimark.py:687-693's pair of `if`s, reached the way upstream reaches
+    /// them: with both flags already in hand.
+    ///
+    /// A WEAKREF (`T_IS_WEAKREF` in its TYPE_INFO) joins the young-weakref list
+    /// so the next minor collection can invalidate the single `weakptr` slot at
+    /// `weakref::WEAKPTR_OFFSET` inside the payload (gctypelayout.py:592) if its
+    /// target dies. A type carrying a lightweight `TypeInfo.destructor` joins
+    /// the young-destructor list, so that collection either runs the destructor
+    /// or promotes the entry to `old_objects_with_destructors`.
+    /// `obj_addr` is the payload base (post-header) in both cases.
+    ///
+    /// `malloc_fixedsize` takes `needs_finalizer` and `contains_weakptr` as
+    /// arguments, so its tail costs two tests on values the caller supplied —
+    /// and in the `malloc_fast` copy (`framework.py:371-382`, annotated
+    /// `s_False, s_False, s_False`) both fold away entirely. pyre resolves them
+    /// from the type table instead, which is one row lookup, not two: probing
+    /// separately repeats the bound test, the table base load and the stride
+    /// multiply that the first probe already performed.
+    #[inline]
+    fn register_young_object_if_needed(&mut self, type_id: u32, obj_addr: usize) {
+        if (type_id as usize) >= self.types.len() {
+            return;
+        }
+        let info = self.types.get(type_id);
+        let (is_weakref, has_destructor) = (info.is_weakref, info.destructor.is_some());
+        if is_weakref {
+            self.young_objects_with_weakrefs.push(obj_addr);
+        }
+        if has_destructor {
+            self.young_objects_with_destructors.push(obj_addr);
+        }
     }
 
     /// incminimark.py:865-930 `collect_and_reserve` pinned-barrier walk.
@@ -1229,39 +1261,6 @@ impl MiniMarkGC {
     fn spill_to_oldgen_or_null(&mut self, type_id: u32, total_size: usize) -> GcRef {
         self.try_alloc_in_oldgen(type_id, total_size)
             .unwrap_or(GcRef(0))
-    }
-
-    /// incminimark.py:690-692 parity. When a freshly-allocated object
-    /// is a WEAKREF (T_IS_WEAKREF in its TYPE_INFO), push it onto the
-    /// young-weakref list so the next minor collection can invalidate
-    /// its weakptr if the target dies.
-    ///
-    /// `obj_addr` is the payload base (post-header). The weakref's
-    /// single `weakptr` slot lives at `weakref::WEAKPTR_OFFSET`
-    /// inside that payload (gctypelayout.py:592).
-    fn register_weakref_if_needed(&mut self, type_id: u32, obj_addr: usize) {
-        if (type_id as usize) >= self.types.len() {
-            return;
-        }
-        if self.types.get(type_id).is_weakref {
-            self.young_objects_with_weakrefs.push(obj_addr);
-        }
-    }
-
-    /// incminimark.py:689-690 parity. When a freshly nursery-allocated
-    /// object's type carries a lightweight `TypeInfo.destructor`, push it
-    /// onto the young-destructor list so the next minor collection runs
-    /// the destructor if the object dies (or promotes it to the
-    /// old-destructor list if it survives).
-    ///
-    /// `obj_addr` is the payload base (post-header).
-    fn register_destructor_if_needed(&mut self, type_id: u32, obj_addr: usize) {
-        if (type_id as usize) >= self.types.len() {
-            return;
-        }
-        if self.types.get(type_id).destructor.is_some() {
-            self.young_objects_with_destructors.push(obj_addr);
-        }
     }
 
     /// Run the lightweight destructor registered for `obj_addr`'s type,

--- a/majit/majit-gc/src/gc_sync.rs
+++ b/majit/majit-gc/src/gc_sync.rs
@@ -17,20 +17,25 @@
 //! ident (thread_gil.c:19-21).
 //!
 //! A claim **stands between operations**, as `rpy_fastgil` stays set for as
-//! long as its thread runs RPython code, so a repeated allocation costs a load
-//! and a compare rather than a compare-and-swap. Only the sole registered
-//! mutator claims that way; once a second registers, claims are per operation
-//! and taken under `gc_mutex`.
+//! long as its thread runs RPython code, so a repeated allocation only marks
+//! the claim it already holds instead of re-taking a free word. Only the sole
+//! registered mutator claims that way; once a second registers, claims are per
+//! operation and taken under `gc_mutex`.
 //!
 //! Upstream can leave a standing claim to its owner because every blocking
 //! call is `releasegil=True` and drops it. Pyre cannot assume that of arbitrary
 //! Rust blocking, so `revoke_standing_claim` takes it back instead, the way
 //! `RPyGilAcquireSlowPath` overwrites the holder's ident once it owns the real
-//! lock (:214-223). `GC_OP_OWNER` — nonzero exactly while a closure is running
-//! — is that real lock, and the two sides interlock through it: a revoker
-//! clears the claim before reading the owner, a claimant publishes the owner
-//! before re-reading its claim. Waiting therefore never depends on the holder
-//! running again.
+//! lock (:214-223). Waiting therefore never depends on the holder running
+//! again.
+//!
+//! What upstream reads off `mutex_gil` — whether the claimant is *using* the
+//! GIL or merely holding it — pyre keeps in `GATE_INSIDE`, the low bit of the
+//! same word. Upstream needs no such distinction (holding the GIL is being
+//! inside the GC); pyre does, because its collector re-enters for read-only
+//! queries. Keeping it in the claim makes entering one compare-and-swap and
+//! revocation one failed compare-and-swap, with no second word to interlock
+//! against.
 //!
 //! # Design
 //!
@@ -171,9 +176,13 @@ unsafe fn singleton_mut() -> &'static mut MiniMarkGC {
 // ──────────────────────────────────────────────────────────────
 
 /// Per-thread GC-sync facts, kept in one struct like pypy_threadlocal_s
-/// (threadlocal.c:46-97). Its address doubles as this thread's ident for the
-/// global owner words below, mirroring how _rpygil_get_my_ident reads the
-/// ident out of the threadlocal struct (threadlocal.h:143-146).
+/// (threadlocal.c:46-97). Its address doubles as this thread's ident in
+/// [`IN_FAST_PATH`] and [`STW_OWNER`], mirroring how _rpygil_get_my_ident reads
+/// the ident out of the threadlocal struct (threadlocal.h:143-146).
+///
+/// Aligned so that idents leave [`GATE_INSIDE`] free; the fields alone would
+/// give this struct alignment 1.
+#[repr(align(8))]
 struct GcThreadState {
     /// Completed `register_thread`, represented in the RUNNING count.
     registered: Cell<bool>,
@@ -196,57 +205,31 @@ fn my_ident() -> usize {
     GC_THREAD.with(|t| t as *const GcThreadState as usize)
 }
 
-/// Ident of the thread currently holding the exclusive `&mut MiniMarkGC`
-/// (inside a `gc_op` closure); 0 when none. `in_gc_op` compares against
-/// `my_ident()`, the `rpy_fastgil == get_ident()` idiom (thread_gil.c:21).
-static GC_OP_OWNER: AtomicUsize = AtomicUsize::new(0);
-
 /// Ident of the STW-owning collector thread; 0 when no STW. Only the owner
 /// nests (do_collect_full drives do_collect_nursery), so a global owner word
 /// plus depth replaces per-thread state.
 static STW_OWNER: AtomicUsize = AtomicUsize::new(0);
 static STW_DEPTH: AtomicUsize = AtomicUsize::new(0);
 
-/// RAII marker: sets `GC_OP_OWNER` for the exact span of a closure that holds
-/// the exclusive `&mut MiniMarkGC`. Wraps every `singleton_mut()` call.
-struct OpGuard {
-    prev: usize,
-}
-impl OpGuard {
-    #[inline]
-    fn enter() -> Self {
-        let prev = GC_OP_OWNER.swap(my_ident(), Ordering::SeqCst);
-        assert!(
-            prev == 0,
-            "GC singleton exclusivity invariant violated: concurrent &mut access"
-        );
-        OpGuard { prev }
-    }
-}
-
-/// Releases an acquired fast-path gate on both normal return and unwind.
-struct FastPathGate {
+/// Restores [`IN_FAST_PATH`] on both normal return and unwind: to the bare
+/// ident for a claim that goes on standing, to 0 for one taken per operation.
+struct GateGuard {
     restore: usize,
 }
-impl Drop for FastPathGate {
+impl Drop for GateGuard {
     #[inline]
     fn drop(&mut self) {
         IN_FAST_PATH.store(self.restore, Ordering::Release);
     }
 }
-impl Drop for OpGuard {
-    #[inline]
-    fn drop(&mut self) {
-        GC_OP_OWNER.store(self.prev, Ordering::SeqCst);
-    }
-}
 
 /// Whether this thread is already inside a `gc_op` / `request_stw` closure
-/// (i.e. a collection is running on this thread and holds the `&mut`). Uses an
-/// owner-word comparison against this thread's ident.
+/// (i.e. a collection is running on this thread and holds the `&mut`). The
+/// `rpy_fastgil == get_ident()` idiom (thread_gil.c:19-21), read against the
+/// in-use form of this thread's claim.
 #[inline]
 pub fn in_gc_op() -> bool {
-    GC_OP_OWNER.load(Ordering::Relaxed) == my_ident()
+    IN_FAST_PATH.load(Ordering::Relaxed) == my_ident() | GATE_INSIDE
 }
 
 /// Shared reference to the singleton, re-derived from the static `UnsafeCell`.
@@ -290,9 +273,10 @@ pub fn gc_query_reentrant<R>(f: impl FnOnce(&MiniMarkGC) -> R) -> R {
 /// `unregister_thread`.  When ≤ 1, `gc_op` skips the Mutex entirely.
 static REGISTERED_THREADS: AtomicUsize = AtomicUsize::new(0);
 
-/// Fast-path lock word: 0 when free, otherwise the holder thread's ident
-/// (`my_ident`), following rpy_fastgil (thread_gil.c:7-31). Self-ownership
-/// is checked by comparing against `my_ident()`.
+/// Fast-path lock word: 0 when free, otherwise the claimant's ident
+/// (`my_ident`) with [`GATE_INSIDE`] set while it is running a closure,
+/// following rpy_fastgil (thread_gil.c:7-31). Self-ownership is checked by
+/// comparing against `my_ident()`.
 ///
 /// A claim stands across operations, the way `rpy_fastgil` stays set for as
 /// long as its thread runs RPython code (thread_gil.c:15-21). Only the fast
@@ -302,7 +286,21 @@ static REGISTERED_THREADS: AtomicUsize = AtomicUsize::new(0);
 /// ([`revoke_standing_claim`]).
 static IN_FAST_PATH: AtomicUsize = AtomicUsize::new(0);
 
-/// Drop this thread's claim on the operation gate, if it still has one.
+/// Set in [`IN_FAST_PATH`] while the claimant is inside a `gc_op` closure, so
+/// the claim and the exclusive `&mut` live in one word. Upstream needs no such
+/// bit — holding `rpy_fastgil` *is* being inside the GC — but pyre's collector
+/// re-enters for read-only queries ([`gc_query_reentrant`]) and has to tell the
+/// two states apart. Keeping it in the claim makes entering a claimed gate one
+/// compare-and-swap, and makes revocation a plain failed CAS instead of a
+/// cross-word handshake.
+const GATE_INSIDE: usize = 1;
+
+const _: () = assert!(
+    std::mem::align_of::<GcThreadState>() > GATE_INSIDE,
+    "idents must leave GATE_INSIDE free"
+);
+
+/// Drop this thread's standing claim, if it still has one.
 ///
 /// `_RPyGilRelease` (threadlocal.h:163-167) is a plain store because upstream's
 /// word is only ever cleared by its owner. A standing claim here can also be
@@ -319,39 +317,41 @@ fn release_gate(ident: usize) {
 ///
 /// `RPyGilAcquireSlowPath` ends by overwriting whatever ident `rpy_fastgil`
 /// holds (thread_gil.c:214-223); it is safe there because `mutex_gil`, not the
-/// word, is the real exclusion. Here the real exclusion is [`GC_OP_OWNER`]:
-/// nonzero exactly while some thread is inside a `gc_op` closure. So the
-/// revoker clears the word first and only then reads the owner, while
-/// [`gc_op`] publishes the owner first and only then re-reads the word. Under
-/// `SeqCst` one of the two must observe the other, so a revoked operation
-/// either never starts or is waited out here — it can never run against a
-/// second claimant.
+/// word, is the real exclusion. Here the exclusion is [`GATE_INSIDE`] in the
+/// same word, so the revoke is one compare-and-swap against the idle form of
+/// the claim: it fails outright while a closure is running, and a closure can
+/// only start by winning that same word.
 ///
-/// The caller must hold `gc_mutex`, so no slow operation can be running and
-/// the word can only be carrying a standing claim. The cleared word may be
+/// The caller must hold `gc_mutex`, so no slow operation can be running and the
+/// word can only be carrying a standing claim. The cleared word may be
 /// re-claimed immediately by the revoked thread when it is still the only
-/// registered mutator; [`acquire_gate`] loops for that case. Exclusion is never
-/// at risk — only the claimant that wins the word runs.
+/// registered mutator; [`acquire_gate`] loops for that case.
 fn revoke_standing_claim(ident: usize) {
-    let holder = IN_FAST_PATH.load(Ordering::SeqCst);
-    if holder == 0 || holder == ident {
-        return;
-    }
-    let _ = IN_FAST_PATH.compare_exchange(holder, 0, Ordering::SeqCst, Ordering::SeqCst);
-    // An operation that validated its claim before the revoke landed is still
-    // inside the singleton; wait it out.
-    while GC_OP_OWNER.load(Ordering::SeqCst) != 0 {
+    loop {
+        let claim = IN_FAST_PATH.load(Ordering::Acquire);
+        if claim == 0 || claim & !GATE_INSIDE == ident {
+            return;
+        }
+        if claim & GATE_INSIDE == 0
+            && IN_FAST_PATH
+                .compare_exchange(claim, 0, Ordering::AcqRel, Ordering::Acquire)
+                .is_ok()
+        {
+            return;
+        }
+        // In use: the closure publishes the idle form when it returns.
         std::hint::spin_loop();
     }
 }
 
-/// Claim the gate for `ident`, revoking a standing claim if one is in the way
-/// — the stealer loop of `RPyGilAcquireSlowPath` (thread_gil.c:203-223).
-/// Callers hold `gc_mutex`, which excludes every other slow claimant.
+/// Claim the gate for `ident` and mark it in use, revoking a standing claim if
+/// one is in the way — the stealer loop of `RPyGilAcquireSlowPath`
+/// (thread_gil.c:203-223). Callers hold `gc_mutex`, which excludes every other
+/// slow claimant.
 fn acquire_gate(ident: usize) {
     loop {
         if IN_FAST_PATH
-            .compare_exchange(0, ident, Ordering::Acquire, Ordering::Relaxed)
+            .compare_exchange(0, ident | GATE_INSIDE, Ordering::Acquire, Ordering::Relaxed)
             .is_ok()
         {
             return;
@@ -499,7 +499,6 @@ pub fn after_fork_child() {
     let running = GC_THREAD.with(|t| t.running.get());
     REGISTERED_THREADS.store(usize::from(registered), Ordering::SeqCst);
     IN_FAST_PATH.store(0, Ordering::Release);
-    GC_OP_OWNER.store(0, Ordering::SeqCst);
     STW_OWNER.store(0, Ordering::SeqCst);
     STW_DEPTH.store(0, Ordering::SeqCst);
     GC_SYNC.stw_requested.store(false, Ordering::Release);
@@ -531,9 +530,9 @@ pub fn stw_required() -> bool {
 /// Execute a closure with exclusive `&mut MiniMarkGC` access.
 ///
 /// **Fast path** (single registered thread, no STW): direct access under
-/// `IN_FAST_PATH`, without taking the Mutex. The gate carries over from the
-/// previous operation, so the steady state is a load and a compare rather than
-/// a compare-and-swap.
+/// `IN_FAST_PATH`, without taking the Mutex. A claim this thread already holds
+/// carries over from the previous operation, so the steady state is the single
+/// compare-and-swap that marks it in use.
 ///
 /// **Slow path** (multiple threads or STW): acquires `gc_mutex`.
 /// Single-threaded production always takes the fast path.
@@ -546,32 +545,35 @@ pub fn gc_op<R>(f: impl FnOnce(&mut MiniMarkGC) -> R) -> R {
     );
     // This thread's claim is still standing. thread_gil.c:15-21 keeps
     // `rpy_fastgil` set to the holder's ident for as long as it runs RPython
-    // code and identifies the holder by `rpy_fastgil == get_ident()`;
-    // re-acquiring once per operation has no upstream counterpart.
-    if IN_FAST_PATH.load(Ordering::Relaxed) == ident {
-        let _op = OpGuard::enter();
-        // Publishing the owner above and re-reading the claim here is the
-        // half of the handshake `revoke_standing_claim` pairs with: it clears
-        // the claim before reading the owner, so a revoked operation is seen
-        // here and never reaches the singleton.
-        if IN_FAST_PATH.load(Ordering::SeqCst) == ident {
-            // `stw_requested` needs no recheck: raising it requires owning the
-            // gate, and this thread owns it.
-            debug_assert!(
-                !GC_SYNC.stw_requested.load(Ordering::Relaxed),
-                "STW was requested by a thread that does not own the operation gate"
-            );
-            // SAFETY: the claim excludes every other fast and slow operation
-            // for as long as it stands.
-            return f(unsafe { singleton_mut() });
-        }
+    // code; re-acquiring once per operation has no upstream counterpart. One
+    // compare-and-swap both proves the claim survived revocation and publishes
+    // that a closure is running under it.
+    if IN_FAST_PATH
+        .compare_exchange(
+            ident,
+            ident | GATE_INSIDE,
+            Ordering::Acquire,
+            Ordering::Relaxed,
+        )
+        .is_ok()
+    {
+        // `stw_requested` needs no recheck: raising it requires owning the
+        // gate, and this thread owns it.
+        debug_assert!(
+            !GC_SYNC.stw_requested.load(Ordering::Relaxed),
+            "STW was requested by a thread that does not own the operation gate"
+        );
+        let _gate = GateGuard { restore: ident };
+        // SAFETY: the claim excludes every other fast and slow operation for
+        // as long as it stands.
+        return f(unsafe { singleton_mut() });
     }
     // First claim: threadlocal.h:153-156 `_rpygil_acquire_fast_path`. Reached
     // once per standing claim, not once per operation.
     if REGISTERED_THREADS.load(Ordering::Acquire) <= 1
         && !GC_SYNC.stw_requested.load(Ordering::Acquire)
         && IN_FAST_PATH
-            .compare_exchange(0, ident, Ordering::Acquire, Ordering::Relaxed)
+            .compare_exchange(0, ident | GATE_INSIDE, Ordering::Acquire, Ordering::Relaxed)
             .is_ok()
     {
         // Recheck under the claim: another thread may have registered or
@@ -579,13 +581,14 @@ pub fn gc_op<R>(f: impl FnOnce(&mut MiniMarkGC) -> R) -> R {
         if REGISTERED_THREADS.load(Ordering::Acquire) <= 1
             && !GC_SYNC.stw_requested.load(Ordering::Acquire)
         {
+            let _gate = GateGuard { restore: ident };
             // SAFETY: as above — the claim is this thread's.
-            let _op = OpGuard::enter();
             return f(unsafe { singleton_mut() });
         }
-        // Ineligible after all — hand the claim straight back rather than
-        // carrying it into the slow path, which claims the gate again.
-        release_gate(ident);
+        // Ineligible after all — drop the claim entirely rather than leaving
+        // it standing for the slow path, which claims the gate again. Nothing
+        // else can touch the word while it is marked in use.
+        IN_FAST_PATH.store(0, Ordering::Release);
     }
     gc_op_slow(f)
 }
@@ -612,17 +615,20 @@ fn gc_op_slow<R>(f: impl FnOnce(&mut MiniMarkGC) -> R) -> R {
     // RUNNING, so a collector can hold the mutex while draining other threads.
     let _guard = GC_SYNC.gc_mutex.lock().unwrap();
 
-    // Drain the gate before borrowing the singleton. A fast holder never waits
-    // on gc_mutex, and `acquire_gate` asks it to hand the gate over, so this
-    // terminates. Together with CAS acquisition this makes fast and slow
-    // singleton accesses mutually exclusive.
-    let self_holds_fast_path = IN_FAST_PATH.load(Ordering::Acquire) == ident;
-    if !self_holds_fast_path {
-        // Claim rather than merely observe, so a new fast operation cannot
-        // start between the last free observation and the singleton borrow.
+    // Take the gate before borrowing the singleton. A fast claimant never waits
+    // on gc_mutex, and `acquire_gate` revokes a standing claim rather than
+    // waiting for its owner, so this terminates. This is what makes fast and
+    // slow singleton accesses mutually exclusive.
+    let carried = IN_FAST_PATH.load(Ordering::Acquire) == ident;
+    let _gate = if carried {
+        // This thread's own standing claim: mark it in use and leave it
+        // standing afterwards, as the fast path would have.
+        IN_FAST_PATH.store(ident | GATE_INSIDE, Ordering::Release);
+        GateGuard { restore: ident }
+    } else {
         acquire_gate(ident);
-    }
-    let _fast_path_gate = (!self_holds_fast_path).then_some(FastPathGate { restore: 0 });
+        GateGuard { restore: 0 }
+    };
 
     if registered {
         let mut state = GC_SYNC.quiesce.lock().unwrap();
@@ -639,14 +645,10 @@ fn gc_op_slow<R>(f: impl FnOnce(&mut MiniMarkGC) -> R) -> R {
         );
     }
 
-    let result = {
-        let _op = OpGuard::enter();
-        // There is deliberately no exit park. A returned reference is rooted
-        // by the caller before its next entry-style safepoint, matching the
-        // single-thread allocation discipline.
-        f(unsafe { singleton_mut() })
-    };
-    result
+    // There is deliberately no exit park. A returned reference is rooted by the
+    // caller before its next entry-style safepoint, matching the single-thread
+    // allocation discipline.
+    f(unsafe { singleton_mut() })
 }
 
 /// Execute a closure with `&MiniMarkGC` access (read-only query).

--- a/majit/majit-gc/src/gc_sync.rs
+++ b/majit/majit-gc/src/gc_sync.rs
@@ -28,13 +28,25 @@ use std::cell::{Cell, UnsafeCell};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Condvar, Mutex};
 
+use crate::collector::MiniMarkGC;
+// The singleton is concrete, but its `GcAllocator` methods still need the
+// trait in scope to resolve.
 use crate::GcAllocator;
 
 /// Process-global GC singleton storage.
 /// `UnsafeCell` provides interior mutability; access is serialised by
 /// `GC_SYNC.gc_mutex`. `Sync` is sound because all `&mut` access goes
 /// through the mutex.
-struct GcSingleton(UnsafeCell<Option<Box<dyn GcAllocator>>>);
+///
+/// The collector is named concretely rather than held behind
+/// `dyn GcAllocator`. `framework.py:132` resolves `GCClass` once from the
+/// translation config and `:272-338` `_declare_functions` binds every GC
+/// operation to `GCClass.<meth>.im_func`, so upstream reaches the collector
+/// through statically bound functions; nothing dispatches on an allocator
+/// value at run time. A trait object here would put a vtable call between
+/// every allocation site and the nursery bump, which is precisely what
+/// `:377-382` `getfn(malloc_fast, …, inline=True)` exists to avoid.
+struct GcSingleton(UnsafeCell<Option<Box<MiniMarkGC>>>);
 unsafe impl Sync for GcSingleton {}
 
 static GC_STORE: GcSingleton = GcSingleton(UnsafeCell::new(None));
@@ -81,7 +93,7 @@ static GC_SYNC: GcSync = GcSync {
 
 /// Store the GC singleton. Idempotent — subsequent calls are no-ops.
 /// Must be called before any `gc_op`.
-pub fn store_singleton(gc: Box<dyn GcAllocator>) {
+pub fn store_singleton(gc: Box<MiniMarkGC>) {
     if GC_INITIALIZED.load(Ordering::Acquire) {
         return;
     }
@@ -107,7 +119,7 @@ pub fn store_singleton(gc: Box<dyn GcAllocator>) {
 /// each per-worker test a pristine heap and empty root set, so a prior test's
 /// oldgen residue or stale registered roots cannot corrupt this test's
 /// collections.
-pub fn replace_singleton_leaking_old(gc: Box<dyn GcAllocator>) {
+pub fn replace_singleton_leaking_old(gc: Box<MiniMarkGC>) {
     let _guard = GC_SYNC.gc_mutex.lock().unwrap();
     // SAFETY: gc_mutex held; the gc_stress harness runs tests serially, so no
     // concurrent gc_op is in flight during the swap.
@@ -128,7 +140,7 @@ pub fn is_initialized() -> bool {
 
 /// Access the GC singleton mutably under gc_mutex protection.
 /// SAFETY: caller must hold gc_mutex.
-unsafe fn singleton_mut() -> &'static mut dyn GcAllocator {
+unsafe fn singleton_mut() -> &'static mut MiniMarkGC {
     // SAFETY: caller holds gc_mutex, so there is no concurrent access.
     unsafe { &mut *GC_STORE.0.get() }
         .as_deref_mut()
@@ -165,7 +177,7 @@ fn my_ident() -> usize {
     GC_THREAD.with(|t| t as *const GcThreadState as usize)
 }
 
-/// Ident of the thread currently holding the exclusive `&mut dyn GcAllocator`
+/// Ident of the thread currently holding the exclusive `&mut MiniMarkGC`
 /// (inside a `gc_op` closure); 0 when none. `in_gc_op` compares against
 /// `my_ident()`, the `rpy_fastgil == get_ident()` idiom (thread_gil.c:21).
 static GC_OP_OWNER: AtomicUsize = AtomicUsize::new(0);
@@ -177,7 +189,7 @@ static STW_OWNER: AtomicUsize = AtomicUsize::new(0);
 static STW_DEPTH: AtomicUsize = AtomicUsize::new(0);
 
 /// RAII marker: sets `GC_OP_OWNER` for the exact span of a closure that holds
-/// the exclusive `&mut dyn GcAllocator`. Wraps every `singleton_mut()` call.
+/// the exclusive `&mut MiniMarkGC`. Wraps every `singleton_mut()` call.
 struct OpGuard {
     prev: usize,
 }
@@ -227,7 +239,7 @@ pub fn in_gc_op() -> bool {
 /// collector. Re-derives from `GC_STORE.0.get()` each call (a pre-`&mut`-cached
 /// raw pointer would be invalidated by `singleton_mut`'s reborrow).
 #[inline]
-unsafe fn singleton_ref_reentrant() -> &'static dyn GcAllocator {
+unsafe fn singleton_ref_reentrant() -> &'static MiniMarkGC {
     unsafe { &*GC_STORE.0.get() }
         .as_deref()
         .expect("GC singleton not initialized — call store_singleton() first")
@@ -241,7 +253,7 @@ unsafe fn singleton_ref_reentrant() -> &'static dyn GcAllocator {
 /// `gc_mutex` (which would deadlock — the lock is non-recursive and, under STW,
 /// held by this very collector) or forming a second `&mut`.
 #[inline]
-pub fn gc_query_reentrant<R>(f: impl FnOnce(&dyn GcAllocator) -> R) -> R {
+pub fn gc_query_reentrant<R>(f: impl FnOnce(&MiniMarkGC) -> R) -> R {
     if in_gc_op() {
         // SAFETY: in_gc_op() ⇒ this thread holds the &mut and is the sole
         // running mutator (parked/spinning invariant); read-only, bounded to `f`.
@@ -417,7 +429,7 @@ pub fn stw_required() -> bool {
 // GC operation gate — fast path when single-threaded
 // ──────────────────────────────────────────────────────────────
 
-/// Execute a closure with exclusive `&mut dyn GcAllocator` access.
+/// Execute a closure with exclusive `&mut MiniMarkGC` access.
 ///
 /// **Fast path** (single registered thread, no STW): direct access after
 /// acquiring `IN_FAST_PATH`, without taking the Mutex.
@@ -425,7 +437,7 @@ pub fn stw_required() -> bool {
 /// **Slow path** (multiple threads or STW): acquires `gc_mutex`.
 /// Single-threaded production always takes the fast path.
 #[inline]
-pub fn gc_op<R>(f: impl FnOnce(&mut dyn GcAllocator) -> R) -> R {
+pub fn gc_op<R>(f: impl FnOnce(&mut MiniMarkGC) -> R) -> R {
     let ident = my_ident();
     debug_assert!(
         !in_gc_op(),
@@ -458,7 +470,7 @@ pub fn gc_op<R>(f: impl FnOnce(&mut dyn GcAllocator) -> R) -> R {
 
 /// Slow path: Mutex-guarded access with STW parking.
 #[cold]
-fn gc_op_slow<R>(f: impl FnOnce(&mut dyn GcAllocator) -> R) -> R {
+fn gc_op_slow<R>(f: impl FnOnce(&mut MiniMarkGC) -> R) -> R {
     let ident = my_ident();
     let registered = GC_THREAD.with(|t| t.registered.get());
     if registered {
@@ -522,10 +534,10 @@ fn gc_op_slow<R>(f: impl FnOnce(&mut dyn GcAllocator) -> R) -> R {
     result
 }
 
-/// Execute a closure with `&dyn GcAllocator` access (read-only query).
+/// Execute a closure with `&MiniMarkGC` access (read-only query).
 /// Same fast/slow path as `gc_op`.
 #[inline]
-pub fn gc_query<R>(f: impl FnOnce(&dyn GcAllocator) -> R) -> R {
+pub fn gc_query<R>(f: impl FnOnce(&MiniMarkGC) -> R) -> R {
     gc_op(|gc| f(gc))
 }
 
@@ -614,9 +626,9 @@ impl Drop for StwGuard {
 /// collector: it waits for all other threads to park, runs `collect_fn`
 /// with exclusive GC access, then resumes everyone.
 ///
-/// `collect_fn` receives `&mut dyn GcAllocator` — it can call
+/// `collect_fn` receives `&mut MiniMarkGC` — it can call
 /// `collect_nursery`, `collect_full`, etc.
-pub fn request_stw(collect_fn: impl FnOnce(&mut dyn GcAllocator)) {
+pub fn request_stw(collect_fn: impl FnOnce(&mut MiniMarkGC)) {
     gc_op(|gc| {
         let _stw = quiesce_mutators();
         collect_fn(gc);
@@ -632,7 +644,7 @@ pub fn request_stw(collect_fn: impl FnOnce(&mut dyn GcAllocator)) {
 /// forwarded value only after the operation owns the GC.
 pub fn gc_op_with_root<R>(
     root: crate::GcRef,
-    f: impl FnOnce(&mut dyn GcAllocator, crate::GcRef) -> R,
+    f: impl FnOnce(&mut MiniMarkGC, crate::GcRef) -> R,
 ) -> R {
     struct RootGuard(usize);
     impl Drop for RootGuard {

--- a/majit/majit-gc/src/gc_sync.rs
+++ b/majit/majit-gc/src/gc_sync.rs
@@ -6,23 +6,42 @@
 //! unchanged inside the STW window — it already assumes a single-threaded
 //! world during collection.
 //!
-//! # P0 simplification
+//! # The operation gate
 //!
-//! Every GC operation (alloc, collect, barrier, query) acquires `gc_mutex`
-//! briefly. Single-threaded production has zero contention (~20ns
-//! uncontended Mutex). cargo test threads serialise correctly.
-//! P1 will restore performance with TLAB (per-thread nursery chunks).
+//! Every GC operation (alloc, collect, barrier, query) runs under one word,
+//! `IN_FAST_PATH`, holding the claimant's ident — `rpy_fastgil`
+//! (thread_gil.c:1-31), down to the spelling of its protocol: a
+//! compare-and-swap claims it (`_rpygil_acquire_fast_path`,
+//! threadlocal.h:153-156), a plain store drops it (`_RPyGilRelease`,
+//! :163-167), and a thread recognises its own claim by comparing against its
+//! ident (thread_gil.c:19-21).
+//!
+//! A claim **stands between operations**, as `rpy_fastgil` stays set for as
+//! long as its thread runs RPython code, so a repeated allocation costs a load
+//! and a compare rather than a compare-and-swap. Only the sole registered
+//! mutator claims that way; once a second registers, claims are per operation
+//! and taken under `gc_mutex`.
+//!
+//! Upstream can leave a standing claim to its owner because every blocking
+//! call is `releasegil=True` and drops it. Pyre cannot assume that of arbitrary
+//! Rust blocking, so `revoke_standing_claim` takes it back instead, the way
+//! `RPyGilAcquireSlowPath` overwrites the holder's ident once it owns the real
+//! lock (:214-223). `GC_OP_OWNER` — nonzero exactly while a closure is running
+//! — is that real lock, and the two sides interlock through it: a revoker
+//! clears the claim before reading the owner, a claimant publishes the owner
+//! before re-reading its claim. Waiting therefore never depends on the holder
+//! running again.
 //!
 //! # Design
 //!
-//! This is NOT a GIL — mutators do not hold a lock during Python execution.
-//! The lock is held only for the duration of each individual GC operation.
-//! Collection begins only when every other registered thread is at an
-//! entry-style safepoint where all of its live GC references are rooted.
-//! A slow `gc_op` leaves RUNNING before blocking on `gc_mutex`, then rejoins
-//! RUNNING before its closure executes. A dispatch poll parks directly. There
-//! is no exit safepoint: a returned reference remains protected until the
-//! caller roots it before its next collection-capable call.
+//! This is not a GIL: the gate spans GC operations, not Python execution, and
+//! it is revocable by any thread that wants it. Collection begins only when
+//! every other registered thread is at an entry-style safepoint where all of
+//! its live GC references are rooted. A slow `gc_op` leaves RUNNING before
+//! blocking on `gc_mutex`, then rejoins RUNNING before its closure executes. A
+//! dispatch poll parks directly. There is no exit safepoint: a returned
+//! reference remains protected until the caller roots it before its next
+//! collection-capable call.
 
 use std::cell::{Cell, UnsafeCell};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
@@ -274,7 +293,73 @@ static REGISTERED_THREADS: AtomicUsize = AtomicUsize::new(0);
 /// Fast-path lock word: 0 when free, otherwise the holder thread's ident
 /// (`my_ident`), following rpy_fastgil (thread_gil.c:7-31). Self-ownership
 /// is checked by comparing against `my_ident()`.
+///
+/// A claim stands across operations, the way `rpy_fastgil` stays set for as
+/// long as its thread runs RPython code (thread_gil.c:15-21). Only the fast
+/// path claims it that way; [`gc_op_slow`] claims and drops it per operation,
+/// so the word is transiently nonzero in multi-mutator runs too. A standing
+/// claim is dropped by its owner ([`release_gate`]) or taken from it
+/// ([`revoke_standing_claim`]).
 static IN_FAST_PATH: AtomicUsize = AtomicUsize::new(0);
+
+/// Drop this thread's claim on the operation gate, if it still has one.
+///
+/// `_RPyGilRelease` (threadlocal.h:163-167) is a plain store because upstream's
+/// word is only ever cleared by its owner. A standing claim here can also be
+/// revoked while its owner sits idle, so the release is a compare-and-swap:
+/// a plain store would drop whichever claim replaced it. Off the hot path —
+/// a standing claim is carried, not re-taken.
+#[inline]
+fn release_gate(ident: usize) {
+    let _ = IN_FAST_PATH.compare_exchange(ident, 0, Ordering::Release, Ordering::Relaxed);
+}
+
+/// Take a standing claim away from a thread that is not using it, so waiting
+/// never depends on the holder running again.
+///
+/// `RPyGilAcquireSlowPath` ends by overwriting whatever ident `rpy_fastgil`
+/// holds (thread_gil.c:214-223); it is safe there because `mutex_gil`, not the
+/// word, is the real exclusion. Here the real exclusion is [`GC_OP_OWNER`]:
+/// nonzero exactly while some thread is inside a `gc_op` closure. So the
+/// revoker clears the word first and only then reads the owner, while
+/// [`gc_op`] publishes the owner first and only then re-reads the word. Under
+/// `SeqCst` one of the two must observe the other, so a revoked operation
+/// either never starts or is waited out here — it can never run against a
+/// second claimant.
+///
+/// The caller must hold `gc_mutex`, so no slow operation can be running and
+/// the word can only be carrying a standing claim. The cleared word may be
+/// re-claimed immediately by the revoked thread when it is still the only
+/// registered mutator; [`acquire_gate`] loops for that case. Exclusion is never
+/// at risk — only the claimant that wins the word runs.
+fn revoke_standing_claim(ident: usize) {
+    let holder = IN_FAST_PATH.load(Ordering::SeqCst);
+    if holder == 0 || holder == ident {
+        return;
+    }
+    let _ = IN_FAST_PATH.compare_exchange(holder, 0, Ordering::SeqCst, Ordering::SeqCst);
+    // An operation that validated its claim before the revoke landed is still
+    // inside the singleton; wait it out.
+    while GC_OP_OWNER.load(Ordering::SeqCst) != 0 {
+        std::hint::spin_loop();
+    }
+}
+
+/// Claim the gate for `ident`, revoking a standing claim if one is in the way
+/// — the stealer loop of `RPyGilAcquireSlowPath` (thread_gil.c:203-223).
+/// Callers hold `gc_mutex`, which excludes every other slow claimant.
+fn acquire_gate(ident: usize) {
+    loop {
+        if IN_FAST_PATH
+            .compare_exchange(0, ident, Ordering::Acquire, Ordering::Relaxed)
+            .is_ok()
+        {
+            return;
+        }
+        revoke_standing_claim(ident);
+        std::hint::spin_loop();
+    }
+}
 
 /// Register the current thread as a GC mutator. Paired with
 /// `unregister_thread`. An unregistered thread may still call `gc_op`; it is
@@ -286,12 +371,13 @@ pub fn register_thread() {
     );
     let old = REGISTERED_THREADS.fetch_add(1, Ordering::SeqCst);
     if old > 0 {
-        // A second thread is arriving. Spin until the operation gate is free;
-        // after this, existing callers see REGISTERED_THREADS > 1 and take the
-        // Mutex path. CAS acquisition makes this stricter than the old marker.
-        while IN_FAST_PATH.load(Ordering::Acquire) != 0 {
-            std::hint::spin_loop();
-        }
+        // A second thread is arriving, so no standing claim may survive: from
+        // here on every caller sees REGISTERED_THREADS > 1 and takes the Mutex
+        // path. The count was raised first, so the previous holder cannot make
+        // a new standing claim once this one is revoked. `gc_mutex` is what
+        // `revoke_standing_claim` requires of its callers.
+        let _guard = GC_SYNC.gc_mutex.lock().unwrap();
+        revoke_standing_claim(my_ident());
     }
 
     let mut state = GC_SYNC.quiesce.lock().unwrap();
@@ -320,6 +406,11 @@ pub fn unregister_thread() {
         GC_THREAD.with(|t| t.registered.get()),
         "unregistering an unregistered GC mutator thread"
     );
+    // A thread that carried the gate out of its last operation must not take
+    // it with it: nothing would ever release it again.
+    if IN_FAST_PATH.load(Ordering::Relaxed) == my_ident() {
+        release_gate(my_ident());
+    }
     let mut state = GC_SYNC.quiesce.lock().unwrap();
     assert!(
         GC_THREAD.with(|t| t.running.replace(false)),
@@ -368,6 +459,14 @@ impl Drop for BlockingGuard {
 
 #[inline]
 pub fn before_external_block() -> BlockingGuard {
+    // `rffi.aroundstate.before()` drops the GIL before a `releasegil=True`
+    // call (`_RPyGilRelease`, threadlocal.h:163-167). Dropping the standing
+    // claim here is not required for progress — `revoke_standing_claim` takes
+    // it back from a sleeping thread — but it spares the next claimant that
+    // work at a point which is already a syscall away.
+    if IN_FAST_PATH.load(Ordering::Relaxed) == my_ident() {
+        release_gate(my_ident());
+    }
     let registered = GC_THREAD.with(|t| t.registered.get());
     if registered {
         let mut state = GC_SYNC.quiesce.lock().unwrap();
@@ -431,8 +530,10 @@ pub fn stw_required() -> bool {
 
 /// Execute a closure with exclusive `&mut MiniMarkGC` access.
 ///
-/// **Fast path** (single registered thread, no STW): direct access after
-/// acquiring `IN_FAST_PATH`, without taking the Mutex.
+/// **Fast path** (single registered thread, no STW): direct access under
+/// `IN_FAST_PATH`, without taking the Mutex. The gate carries over from the
+/// previous operation, so the steady state is a load and a compare rather than
+/// a compare-and-swap.
 ///
 /// **Slow path** (multiple threads or STW): acquires `gc_mutex`.
 /// Single-threaded production always takes the fast path.
@@ -443,27 +544,48 @@ pub fn gc_op<R>(f: impl FnOnce(&mut MiniMarkGC) -> R) -> R {
         !in_gc_op(),
         "reentrant &mut gc_op — a collection-time query must use gc_query_reentrant"
     );
-    // Fast path: single thread, no STW.
+    // This thread's claim is still standing. thread_gil.c:15-21 keeps
+    // `rpy_fastgil` set to the holder's ident for as long as it runs RPython
+    // code and identifies the holder by `rpy_fastgil == get_ident()`;
+    // re-acquiring once per operation has no upstream counterpart.
+    if IN_FAST_PATH.load(Ordering::Relaxed) == ident {
+        let _op = OpGuard::enter();
+        // Publishing the owner above and re-reading the claim here is the
+        // half of the handshake `revoke_standing_claim` pairs with: it clears
+        // the claim before reading the owner, so a revoked operation is seen
+        // here and never reaches the singleton.
+        if IN_FAST_PATH.load(Ordering::SeqCst) == ident {
+            // `stw_requested` needs no recheck: raising it requires owning the
+            // gate, and this thread owns it.
+            debug_assert!(
+                !GC_SYNC.stw_requested.load(Ordering::Relaxed),
+                "STW was requested by a thread that does not own the operation gate"
+            );
+            // SAFETY: the claim excludes every other fast and slow operation
+            // for as long as it stands.
+            return f(unsafe { singleton_mut() });
+        }
+    }
+    // First claim: threadlocal.h:153-156 `_rpygil_acquire_fast_path`. Reached
+    // once per standing claim, not once per operation.
     if REGISTERED_THREADS.load(Ordering::Acquire) <= 1
         && !GC_SYNC.stw_requested.load(Ordering::Acquire)
         && IN_FAST_PATH
             .compare_exchange(0, ident, Ordering::Acquire, Ordering::Relaxed)
             .is_ok()
     {
-        let _fast_path_gate = FastPathGate { restore: 0 };
-        // Recheck after acquiring the fast-path lock: another thread may have
-        // registered or requested STW after the eligibility loads above.
+        // Recheck under the claim: another thread may have registered or
+        // requested STW after the eligibility loads above.
         if REGISTERED_THREADS.load(Ordering::Acquire) <= 1
             && !GC_SYNC.stw_requested.load(Ordering::Acquire)
         {
-            // SAFETY: the fast-path lock excludes other fast operations, and
-            // slow operations drain it before accessing the singleton.
-            let r = {
-                let _op = OpGuard::enter();
-                f(unsafe { singleton_mut() })
-            };
-            return r;
+            // SAFETY: as above — the claim is this thread's.
+            let _op = OpGuard::enter();
+            return f(unsafe { singleton_mut() });
         }
+        // Ineligible after all — hand the claim straight back rather than
+        // carrying it into the slow path, which claims the gate again.
+        release_gate(ident);
     }
     gc_op_slow(f)
 }
@@ -490,22 +612,15 @@ fn gc_op_slow<R>(f: impl FnOnce(&mut MiniMarkGC) -> R) -> R {
     // RUNNING, so a collector can hold the mutex while draining other threads.
     let _guard = GC_SYNC.gc_mutex.lock().unwrap();
 
-    // Drain a fast operation before borrowing the singleton. A fast holder
-    // never waits on gc_mutex, so this terminates. Together with CAS acquisition
-    // this makes fast and slow singleton accesses mutually exclusive.
+    // Drain the gate before borrowing the singleton. A fast holder never waits
+    // on gc_mutex, and `acquire_gate` asks it to hand the gate over, so this
+    // terminates. Together with CAS acquisition this makes fast and slow
+    // singleton accesses mutually exclusive.
     let self_holds_fast_path = IN_FAST_PATH.load(Ordering::Acquire) == ident;
-    while IN_FAST_PATH.load(Ordering::Acquire) != 0 && !self_holds_fast_path {
-        std::hint::spin_loop();
-    }
     if !self_holds_fast_path {
-        // Claim the gate after draining so a new fast operation cannot start
-        // between the final observation above and the singleton borrow.
-        while IN_FAST_PATH
-            .compare_exchange(0, ident, Ordering::Acquire, Ordering::Relaxed)
-            .is_err()
-        {
-            std::hint::spin_loop();
-        }
+        // Claim rather than merely observe, so a new fast operation cannot
+        // start between the last free observation and the singleton borrow.
+        acquire_gate(ident);
     }
     let _fast_path_gate = (!self_holds_fast_path).then_some(FastPathGate { restore: 0 });
 
@@ -722,7 +837,7 @@ fn park_until_stw_done() {
 }
 
 /// Poll for a collector request at a runtime dispatch safepoint.
-/// Steady state is one relaxed atomic load.
+/// Steady state is two relaxed atomic loads.
 #[inline]
 pub fn safepoint_poll() {
     if GC_SYNC.stw_requested.load(Ordering::Relaxed) {

--- a/majit/majit-gc/src/lib.rs
+++ b/majit/majit-gc/src/lib.rs
@@ -261,6 +261,32 @@ pub trait GcAllocator: Send {
         result
     }
 
+    /// [`Self::alloc_nursery_collecting_typed_rooted`] for a type that carries
+    /// neither a finalizer nor the weakref flag.
+    ///
+    /// `gct_fv_gc_malloc` (`framework.py:820-838`) resolves both properties at
+    /// transformation time and calls `malloc_fast` — the `inline=True` copy of
+    /// `malloc_fixedsize` annotated `s_False, s_False, s_False`
+    /// (`framework.py:361-382`) — whenever they are both false, which is the
+    /// case for every fixed-size malloc of a plain struct. The default forwards
+    /// to the general form, which is what a collector that does not distinguish
+    /// the two bodies has.
+    ///
+    /// # Safety
+    /// Same contract as [`Self::alloc_nursery_collecting_typed_rooted`], plus
+    /// `type_id` must name a type with no destructor and no weakref flag.
+    unsafe fn alloc_fast_nursery_collecting_typed_rooted(
+        &mut self,
+        type_id: u32,
+        size: usize,
+        root: *mut GcRef,
+        needs_write_barrier: *mut bool,
+    ) -> GcRef {
+        unsafe {
+            self.alloc_nursery_collecting_typed_rooted(type_id, size, root, needs_write_barrier)
+        }
+    }
+
     /// Allocate a fixed-size object without triggering collection.
     ///
     /// Implementations may fall back to old-gen allocation when the nursery
@@ -302,6 +328,20 @@ pub trait GcAllocator: Send {
         self.alloc_nursery_no_collect_typed(type_id, size)
     }
 
+    /// [`Self::try_alloc_nursery_no_collect_typed`] for a type that carries
+    /// neither a finalizer nor the weakref flag: `malloc_fast`
+    /// (`framework.py:361-382`).
+    ///
+    /// # Safety
+    /// `type_id` must name a type with no destructor and no weakref flag.
+    unsafe fn try_alloc_fast_nursery_no_collect_typed(
+        &mut self,
+        type_id: u32,
+        size: usize,
+    ) -> GcRef {
+        self.try_alloc_nursery_no_collect_typed(type_id, size)
+    }
+
     /// Fallible no-collect allocation that also reports whether initializing
     /// the fresh result with a young GC reference needs a creation barrier.
     ///
@@ -320,6 +360,29 @@ pub trait GcAllocator: Send {
     ) -> GcRef {
         unsafe { *needs_write_barrier = true };
         self.try_alloc_nursery_no_collect_typed(type_id, size)
+    }
+
+    /// [`Self::try_alloc_nursery_no_collect_typed_with_placement`] for a type
+    /// that carries neither a finalizer nor the weakref flag: `malloc_fast`
+    /// (`framework.py:361-382`).
+    ///
+    /// # Safety
+    /// Same contract as
+    /// [`Self::try_alloc_nursery_no_collect_typed_with_placement`], plus
+    /// `type_id` must name a type with no destructor and no weakref flag.
+    unsafe fn try_alloc_fast_nursery_no_collect_typed_with_placement(
+        &mut self,
+        type_id: u32,
+        size: usize,
+        needs_write_barrier: *mut bool,
+    ) -> GcRef {
+        unsafe {
+            self.try_alloc_nursery_no_collect_typed_with_placement(
+                type_id,
+                size,
+                needs_write_barrier,
+            )
+        }
     }
 
     /// Allocate a variable-size object without triggering collection.
@@ -850,6 +913,17 @@ impl GcAllocator for GcHandle {
             gc.alloc_nursery_collecting_typed_rooted(type_id, size, root, needs_write_barrier)
         })
     }
+    unsafe fn alloc_fast_nursery_collecting_typed_rooted(
+        &mut self,
+        type_id: u32,
+        size: usize,
+        root: *mut GcRef,
+        needs_write_barrier: *mut bool,
+    ) -> GcRef {
+        gc_sync::gc_op(|gc| unsafe {
+            gc.alloc_fast_nursery_collecting_typed_rooted(type_id, size, root, needs_write_barrier)
+        })
+    }
     fn alloc_nursery_no_collect(&mut self, size: usize) -> GcRef {
         gc_sync::gc_op(|gc| gc.alloc_nursery_no_collect(size))
     }
@@ -871,6 +945,13 @@ impl GcAllocator for GcHandle {
     fn try_alloc_nursery_no_collect_typed(&mut self, type_id: u32, size: usize) -> GcRef {
         gc_sync::gc_op(|gc| gc.try_alloc_nursery_no_collect_typed(type_id, size))
     }
+    unsafe fn try_alloc_fast_nursery_no_collect_typed(
+        &mut self,
+        type_id: u32,
+        size: usize,
+    ) -> GcRef {
+        gc_sync::gc_op(|gc| unsafe { gc.try_alloc_fast_nursery_no_collect_typed(type_id, size) })
+    }
     unsafe fn try_alloc_nursery_no_collect_typed_with_placement(
         &mut self,
         type_id: u32,
@@ -879,6 +960,20 @@ impl GcAllocator for GcHandle {
     ) -> GcRef {
         gc_sync::gc_op(|gc| unsafe {
             gc.try_alloc_nursery_no_collect_typed_with_placement(type_id, size, needs_write_barrier)
+        })
+    }
+    unsafe fn try_alloc_fast_nursery_no_collect_typed_with_placement(
+        &mut self,
+        type_id: u32,
+        size: usize,
+        needs_write_barrier: *mut bool,
+    ) -> GcRef {
+        gc_sync::gc_op(|gc| unsafe {
+            gc.try_alloc_fast_nursery_no_collect_typed_with_placement(
+                type_id,
+                size,
+                needs_write_barrier,
+            )
         })
     }
     fn alloc_varsize_no_collect(
@@ -1459,6 +1554,16 @@ pub fn standalone_alloc_nursery_typed(type_id: u32, payload_size: usize) -> GcRe
     gc_sync::gc_op(|g| g.try_alloc_nursery_no_collect_typed(type_id, payload_size))
 }
 
+/// [`standalone_alloc_nursery_typed`] for a type that carries neither a
+/// finalizer nor the weakref flag: `malloc_fast` (`framework.py:361-382`).
+///
+/// # Safety
+/// `type_id` must name a type with no destructor and no weakref flag.
+#[inline]
+pub unsafe fn standalone_alloc_fast_nursery_typed(type_id: u32, payload_size: usize) -> GcRef {
+    gc_sync::gc_op(|g| unsafe { g.try_alloc_fast_nursery_no_collect_typed(type_id, payload_size) })
+}
+
 /// The rooted collecting nursery allocation a backend's
 /// `AllocNurseryCollectingTypedRootedFn` performs once no per-thread box owns
 /// the request.
@@ -1475,6 +1580,30 @@ pub unsafe fn standalone_alloc_nursery_collecting_typed_rooted(
 ) -> GcRef {
     gc_sync::gc_op(|g| unsafe {
         g.alloc_nursery_collecting_typed_rooted(type_id, payload_size, root, needs_write_barrier)
+    })
+}
+
+/// [`standalone_alloc_nursery_collecting_typed_rooted`] for a type that carries
+/// neither a finalizer nor the weakref flag: `malloc_fast`
+/// (`framework.py:361-382`).
+///
+/// # Safety
+/// Same contract as [`standalone_alloc_nursery_collecting_typed_rooted`], plus
+/// `type_id` must name a type with no destructor and no weakref flag.
+#[inline]
+pub unsafe fn standalone_alloc_fast_nursery_collecting_typed_rooted(
+    type_id: u32,
+    payload_size: usize,
+    root: *mut GcRef,
+    needs_write_barrier: *mut bool,
+) -> GcRef {
+    gc_sync::gc_op(|g| unsafe {
+        g.alloc_fast_nursery_collecting_typed_rooted(
+            type_id,
+            payload_size,
+            root,
+            needs_write_barrier,
+        )
     })
 }
 
@@ -1498,6 +1627,27 @@ pub fn set_active_alloc_nursery_typed(hook: Option<AllocNurseryTypedFn>) {
 pub fn alloc_nursery_typed(type_id: u32, payload_size: usize) -> GcRef {
     match ACTIVE_ALLOC_NURSERY_TYPED.get() {
         Some(_) if !gc_box_installed() => standalone_alloc_nursery_typed(type_id, payload_size),
+        Some(f) => f(type_id, payload_size),
+        None => GcRef(0),
+    }
+}
+
+/// [`alloc_nursery_typed`] for a type that carries neither a finalizer nor the
+/// weakref flag: `malloc_fast` (`framework.py:361-382`), the copy
+/// `gct_fv_gc_malloc` (`framework.py:820-838`) selects for exactly that case.
+///
+/// Only the direct path folds the two registrations out. A per-thread GC box is
+/// a backend-test configuration, so its `AllocNurseryTypedFn` keeps running the
+/// general body — always a correct implementation of the fast one, just with
+/// the two constant-false tests still present.
+///
+/// # Safety
+/// `type_id` must name a type with no destructor and no weakref flag.
+pub unsafe fn alloc_fast_nursery_typed(type_id: u32, payload_size: usize) -> GcRef {
+    match ACTIVE_ALLOC_NURSERY_TYPED.get() {
+        Some(_) if !gc_box_installed() => unsafe {
+            standalone_alloc_fast_nursery_typed(type_id, payload_size)
+        },
         Some(f) => f(type_id, payload_size),
         None => GcRef(0),
     }
@@ -1567,6 +1717,36 @@ pub unsafe fn alloc_nursery_typed_with_placement(
         None => {
             // No backend installed placement reporting, so keep the
             // conservative creation barrier the sibling fallbacks report.
+            unsafe { *needs_write_barrier = true };
+            GcRef(0)
+        }
+    }
+}
+
+/// [`alloc_nursery_typed_with_placement`] for a type that carries neither a
+/// finalizer nor the weakref flag: `malloc_fast` (`framework.py:361-382`).
+///
+/// Like [`alloc_fast_nursery_typed`], only the direct path folds the two
+/// registrations out; a per-thread box keeps the general body.
+///
+/// # Safety
+/// Same contract as [`alloc_nursery_typed_with_placement`], plus `type_id` must
+/// name a type with no destructor and no weakref flag.
+pub unsafe fn alloc_fast_nursery_typed_with_placement(
+    type_id: u32,
+    payload_size: usize,
+    needs_write_barrier: *mut bool,
+) -> GcRef {
+    match ACTIVE_ALLOC_NURSERY_TYPED_WITH_PLACEMENT.get() {
+        Some(_) if !gc_box_installed() => gc_sync::gc_op(|g| unsafe {
+            g.try_alloc_fast_nursery_no_collect_typed_with_placement(
+                type_id,
+                payload_size,
+                needs_write_barrier,
+            )
+        }),
+        Some(f) => unsafe { f(type_id, payload_size, needs_write_barrier) },
+        None => {
             unsafe { *needs_write_barrier = true };
             GcRef(0)
         }
@@ -1672,6 +1852,38 @@ pub unsafe fn alloc_nursery_collecting_typed_rooted(
         None => {
             // No backend installed placement reporting, so keep the
             // conservative creation barrier the sibling fallbacks report.
+            unsafe { *needs_write_barrier = true };
+            GcRef(0)
+        }
+    }
+}
+
+/// [`alloc_nursery_collecting_typed_rooted`] for a type that carries neither a
+/// finalizer nor the weakref flag: `malloc_fast` (`framework.py:361-382`).
+///
+/// Like [`alloc_fast_nursery_typed`], only the direct path folds the two
+/// registrations out; a per-thread box keeps the general body.
+///
+/// # Safety
+/// Same contract as [`alloc_nursery_collecting_typed_rooted`], plus `type_id`
+/// must name a type with no destructor and no weakref flag.
+pub unsafe fn alloc_fast_nursery_collecting_typed_rooted(
+    type_id: u32,
+    payload_size: usize,
+    root: *mut GcRef,
+    needs_write_barrier: *mut bool,
+) -> GcRef {
+    match ACTIVE_ALLOC_NURSERY_COLLECTING_TYPED_ROOTED.get() {
+        Some(_) if !gc_box_installed() => unsafe {
+            standalone_alloc_fast_nursery_collecting_typed_rooted(
+                type_id,
+                payload_size,
+                root,
+                needs_write_barrier,
+            )
+        },
+        Some(f) => unsafe { f(type_id, payload_size, root, needs_write_barrier) },
+        None => {
             unsafe { *needs_write_barrier = true };
             GcRef(0)
         }

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -1266,7 +1266,7 @@ fn register_traced_storage_box<T: 'static>(
 
 /// Build and configure the MiniMarkGC with all type registrations,
 /// vtable mappings, and subclass ranges.
-fn build_gc() -> Box<dyn majit_gc::GcAllocator> {
+fn build_gc() -> Box<MiniMarkGC> {
     // translationoption.py:185 `taggedpointers` — kept in lockstep with the
     // pyre-object representation switch so the collector-core immediate
     // guards (`is_tagged_immediate`) go live exactly when small ints start

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -54,6 +54,14 @@ fn pyre_object_gc_alloc_trampoline(type_id: u32, size: usize) -> *mut u8 {
     majit_gc::alloc_nursery_typed(type_id, size).0 as *mut u8
 }
 
+/// `malloc_fast` companion of [`pyre_object_gc_alloc_trampoline`].
+///
+/// # Safety
+/// `type_id` must name a type with no destructor and no weakref flag.
+unsafe fn pyre_object_gc_alloc_fast_trampoline(type_id: u32, size: usize) -> *mut u8 {
+    unsafe { majit_gc::alloc_fast_nursery_typed(type_id, size) }.0 as *mut u8
+}
+
 /// Placement-reporting companion of [`pyre_object_gc_alloc_trampoline`].
 ///
 /// # Safety
@@ -66,6 +74,21 @@ unsafe fn pyre_object_gc_alloc_with_placement_trampoline(
 ) -> *mut u8 {
     unsafe { majit_gc::alloc_nursery_typed_with_placement(type_id, size, needs_write_barrier) }.0
         as *mut u8
+}
+
+/// `malloc_fast` companion of
+/// [`pyre_object_gc_alloc_with_placement_trampoline`].
+///
+/// # Safety
+/// Same contract, plus `type_id` must name a type with no destructor and no
+/// weakref flag.
+unsafe fn pyre_object_gc_alloc_fast_with_placement_trampoline(
+    type_id: u32,
+    size: usize,
+    needs_write_barrier: *mut bool,
+) -> *mut u8 {
+    unsafe { majit_gc::alloc_fast_nursery_typed_with_placement(type_id, size, needs_write_barrier) }
+        .0 as *mut u8
 }
 
 /// Trampoline for stable-address host-side allocations.
@@ -101,6 +124,29 @@ unsafe fn pyre_object_gc_alloc_collecting_rooted_trampoline(
 ) -> *mut u8 {
     unsafe {
         majit_gc::alloc_nursery_collecting_typed_rooted(
+            type_id,
+            size,
+            root as *mut majit_ir::GcRef,
+            needs_write_barrier,
+        )
+        .0 as *mut u8
+    }
+}
+
+/// `malloc_fast` companion of
+/// [`pyre_object_gc_alloc_collecting_rooted_trampoline`].
+///
+/// # Safety
+/// Same contract, plus `type_id` must name a type with no destructor and no
+/// weakref flag.
+unsafe fn pyre_object_gc_alloc_fast_collecting_rooted_trampoline(
+    type_id: u32,
+    size: usize,
+    root: *mut *mut u8,
+    needs_write_barrier: *mut bool,
+) -> *mut u8 {
+    unsafe {
+        majit_gc::alloc_fast_nursery_collecting_typed_rooted(
             type_id,
             size,
             root as *mut majit_ir::GcRef,
@@ -3843,8 +3889,12 @@ fn register_thread_root_areas() {
 /// `Cell` slots and do not touch interpreter state.
 fn install_pyre_object_hooks() {
     pyre_object::register_gc_alloc_hook(pyre_object_gc_alloc_trampoline);
+    pyre_object::gc_hook::register_gc_alloc_fast_hook(pyre_object_gc_alloc_fast_trampoline);
     pyre_object::register_gc_alloc_with_placement_hook(
         pyre_object_gc_alloc_with_placement_trampoline,
+    );
+    pyre_object::gc_hook::register_gc_alloc_fast_with_placement_hook(
+        pyre_object_gc_alloc_fast_with_placement_trampoline,
     );
     pyre_object::register_gc_alloc_stable_hook(pyre_object_gc_alloc_stable_trampoline);
     pyre_object::gc_hook::register_gc_alloc_collecting_hook(
@@ -3852,6 +3902,9 @@ fn install_pyre_object_hooks() {
     );
     pyre_object::gc_hook::register_gc_alloc_collecting_rooted_hook(
         pyre_object_gc_alloc_collecting_rooted_trampoline,
+    );
+    pyre_object::gc_hook::register_gc_alloc_fast_collecting_rooted_hook(
+        pyre_object_gc_alloc_fast_collecting_rooted_trampoline,
     );
     pyre_object::register_gc_collect_hook(pyre_object_gc_collect_trampoline);
     pyre_object::gc_hook::register_gc_collect_oldgen_hook(pyre_object_gc_collect_oldgen_trampoline);

--- a/pyre/pyre-object/src/gc_hook.rs
+++ b/pyre/pyre-object/src/gc_hook.rs
@@ -80,6 +80,23 @@ pub type GcAllocHookFn = fn(type_id: u32, payload_size: usize) -> *mut u8;
 majit_gc::global_hook!(static GC_ALLOC_HOOK: GcAllocHookFn);
 majit_gc::global_hook!(static GC_ALLOC_STABLE_HOOK: GcAllocHookFn);
 
+/// `malloc_fast` companion of [`GcAllocHookFn`].
+///
+/// `gct_fv_gc_malloc` (`framework.py:820-838`) resolves the allocated type's
+/// finalizer and weakref properties while transforming the malloc site, and
+/// calls the `inline=True` copy of `malloc_fixedsize` annotated
+/// `s_False, s_False, s_False` (`framework.py:361-382`) whenever both are
+/// false — which folds incminimark.py:687-693's two registrations out of the
+/// body. A pyre call site with a statically known type id is in the same
+/// position, so it selects the folded entry point the same way.
+///
+/// # Safety
+/// The caller passes a `type_id` naming a type with no destructor and no
+/// weakref flag.
+pub type GcAllocFastHookFn = unsafe fn(type_id: u32, payload_size: usize) -> *mut u8;
+
+majit_gc::global_hook!(static GC_ALLOC_FAST_HOOK: GcAllocFastHookFn);
+
 /// Placement-reporting companion of [`GcAllocHookFn`] for no-collect
 /// allocations that may spill from the nursery to old-gen.
 pub type GcAllocWithPlacementHookFn =
@@ -87,6 +104,10 @@ pub type GcAllocWithPlacementHookFn =
 
 majit_gc::global_hook!(
     static GC_ALLOC_WITH_PLACEMENT_HOOK: GcAllocWithPlacementHookFn
+);
+
+majit_gc::global_hook!(
+    static GC_ALLOC_FAST_WITH_PLACEMENT_HOOK: GcAllocWithPlacementHookFn
 );
 
 /// Install the allocation callback. Overwrites any previously-installed hook.
@@ -106,6 +127,31 @@ pub fn clear_gc_alloc_hook() {
 #[inline]
 pub fn try_gc_alloc(type_id: u32, payload_size: usize) -> Option<*mut u8> {
     GC_ALLOC_HOOK.get().map(|f| f(type_id, payload_size))
+}
+
+/// Install the `malloc_fast` allocation callback.
+pub fn register_gc_alloc_fast_hook(hook: GcAllocFastHookFn) {
+    GC_ALLOC_FAST_HOOK.set(Some(hook));
+}
+
+/// Remove the `malloc_fast` allocation callback.
+pub fn clear_gc_alloc_fast_hook() {
+    GC_ALLOC_FAST_HOOK.set(None);
+}
+
+/// [`try_gc_alloc`] for a statically-known type that carries neither a
+/// finalizer nor the weakref flag. Falls back to the general hook when no
+/// backend installed the folded one — the general body is always a correct
+/// implementation of the folded one.
+///
+/// # Safety
+/// `type_id` must name a type with no destructor and no weakref flag.
+#[inline]
+pub unsafe fn try_gc_alloc_fast(type_id: u32, payload_size: usize) -> Option<*mut u8> {
+    if let Some(f) = GC_ALLOC_FAST_HOOK.get() {
+        return Some(unsafe { f(type_id, payload_size) });
+    }
+    try_gc_alloc(type_id, payload_size)
 }
 
 pub fn register_gc_alloc_with_placement_hook(hook: GcAllocWithPlacementHookFn) {
@@ -130,6 +176,33 @@ pub fn try_gc_alloc_with_placement(
     }
     *needs_write_barrier = true;
     try_gc_alloc(type_id, payload_size)
+}
+
+/// Install the `malloc_fast` placement-reporting allocation callback.
+pub fn register_gc_alloc_fast_with_placement_hook(hook: GcAllocWithPlacementHookFn) {
+    GC_ALLOC_FAST_WITH_PLACEMENT_HOOK.set(Some(hook));
+}
+
+/// Remove the `malloc_fast` placement-reporting allocation callback.
+pub fn clear_gc_alloc_fast_with_placement_hook() {
+    GC_ALLOC_FAST_WITH_PLACEMENT_HOOK.set(None);
+}
+
+/// [`try_gc_alloc_with_placement`] for a statically-known type that carries
+/// neither a finalizer nor the weakref flag.
+///
+/// # Safety
+/// `type_id` must name a type with no destructor and no weakref flag.
+#[inline]
+pub unsafe fn try_gc_alloc_fast_with_placement(
+    type_id: u32,
+    payload_size: usize,
+    needs_write_barrier: &mut bool,
+) -> Option<*mut u8> {
+    if let Some(f) = GC_ALLOC_FAST_WITH_PLACEMENT_HOOK.get() {
+        return Some(unsafe { f(type_id, payload_size, needs_write_barrier as *mut bool) });
+    }
+    try_gc_alloc_with_placement(type_id, payload_size, needs_write_barrier)
 }
 
 /// Install the stable (old-gen) allocation callback for this thread.
@@ -211,12 +284,26 @@ majit_gc::global_hook!(
     static GC_ALLOC_COLLECTING_ROOTED_HOOK: GcAllocCollectingRootedHookFn
 );
 
+majit_gc::global_hook!(
+    static GC_ALLOC_FAST_COLLECTING_ROOTED_HOOK: GcAllocCollectingRootedHookFn
+);
+
 pub fn register_gc_alloc_collecting_rooted_hook(hook: GcAllocCollectingRootedHookFn) {
     GC_ALLOC_COLLECTING_ROOTED_HOOK.set(Some(hook));
 }
 
 pub fn clear_gc_alloc_collecting_rooted_hook() {
     GC_ALLOC_COLLECTING_ROOTED_HOOK.set(None);
+}
+
+/// Install the `malloc_fast` rooted collecting allocation callback.
+pub fn register_gc_alloc_fast_collecting_rooted_hook(hook: GcAllocCollectingRootedHookFn) {
+    GC_ALLOC_FAST_COLLECTING_ROOTED_HOOK.set(Some(hook));
+}
+
+/// Remove the `malloc_fast` rooted collecting allocation callback.
+pub fn clear_gc_alloc_fast_collecting_rooted_hook() {
+    GC_ALLOC_FAST_COLLECTING_ROOTED_HOOK.set(None);
 }
 
 /// Attempt a collecting allocation while preserving `root`.
@@ -248,6 +335,25 @@ pub unsafe fn try_gc_alloc_collecting_rooted(
         try_gc_remove_root(root);
     }
     Some(result)
+}
+
+/// [`try_gc_alloc_collecting_rooted`] for a statically-known type that carries
+/// neither a finalizer nor the weakref flag.
+///
+/// # Safety
+/// Same contract as [`try_gc_alloc_collecting_rooted`], plus `type_id` must
+/// name a type with no destructor and no weakref flag.
+#[inline]
+pub unsafe fn try_gc_alloc_fast_collecting_rooted(
+    type_id: u32,
+    payload_size: usize,
+    root: *mut *mut u8,
+    needs_write_barrier: *mut bool,
+) -> Option<*mut u8> {
+    if let Some(f) = GC_ALLOC_FAST_COLLECTING_ROOTED_HOOK.get() {
+        return Some(unsafe { f(type_id, payload_size, root, needs_write_barrier) });
+    }
+    unsafe { try_gc_alloc_collecting_rooted(type_id, payload_size, root, needs_write_barrier) }
 }
 
 /// Signature of the host-side full-collection callback. Used by

--- a/pyre/pyre-object/src/object_array.rs
+++ b/pyre/pyre-object/src/object_array.rs
@@ -753,6 +753,10 @@ pub unsafe fn alloc_typed_items_block_nursery(cap: usize, tid: u32) -> *mut Type
 }
 
 /// Fallible companion of [`alloc_typed_items_block_nursery`].
+///
+/// # Safety
+/// `tid` must name a registered array type with no destructor and no weakref
+/// flag — the `GcArray(Signed)` / `GcArray(Float)` bodies this serves.
 pub unsafe fn try_alloc_typed_items_block_nursery(
     cap: usize,
     tid: u32,
@@ -760,7 +764,10 @@ pub unsafe fn try_alloc_typed_items_block_nursery(
     let cap = cap.max(1);
     let layout = try_typed_items_block_layout(cap)?;
     if itemsblock_gc_enabled() {
-        match crate::gc_hook::try_gc_alloc(tid, layout.size()) {
+        // `GcArray(Signed)` / `GcArray(Float)` bodies: no finalizer, not a
+        // WEAKREF, so `gct_fv_gc_malloc` (`framework.py:820-838`) reaches
+        // `malloc_fast`.
+        match unsafe { crate::gc_hook::try_gc_alloc_fast(tid, layout.size()) } {
             Some(raw) if raw.is_null() => return None,
             Some(raw) => {
                 let block = raw as *mut TypedItemsBlock;

--- a/pyre/pyre-object/src/object_array.rs
+++ b/pyre/pyre-object/src/object_array.rs
@@ -754,9 +754,17 @@ pub unsafe fn alloc_typed_items_block_nursery(cap: usize, tid: u32) -> *mut Type
 
 /// Fallible companion of [`alloc_typed_items_block_nursery`].
 ///
+/// `ll_newlist` (rlist.py:324-329) allocates the items array and writes the
+/// length header; the items keep whatever the nursery held, because
+/// `malloc_zero_filled` is false for incminimark (incminimark.py:211). Callers
+/// that need `[0] * n` clear it themselves with
+/// [`typed_items_block_clear`], which is what `ll_alloc_and_set` does
+/// (rtyper/rlist.py:494-503); callers building a list display write every slot.
+///
 /// # Safety
 /// `tid` must name a registered array type with no destructor and no weakref
-/// flag — the `GcArray(Signed)` / `GcArray(Float)` bodies this serves.
+/// flag — the `GcArray(Signed)` / `GcArray(Float)` bodies this serves. Every
+/// item the caller reads must be one it has written.
 pub unsafe fn try_alloc_typed_items_block_nursery(
     cap: usize,
     tid: u32,
@@ -771,27 +779,37 @@ pub unsafe fn try_alloc_typed_items_block_nursery(
             Some(raw) if raw.is_null() => return None,
             Some(raw) => {
                 let block = raw as *mut TypedItemsBlock;
-                unsafe {
-                    (*block).capacity = cap;
-                    std::ptr::write_bytes(
-                        typed_items_block_items_base(block),
-                        0,
-                        cap * std::mem::size_of::<u64>(),
-                    );
-                }
+                unsafe { (*block).capacity = cap };
                 return Some(block);
             }
             None => {}
         }
     }
     unsafe {
-        let raw = alloc_zeroed(layout);
+        let raw = alloc(layout);
         if raw.is_null() {
             return None;
         }
         let block = raw as *mut TypedItemsBlock;
         (*block).capacity = cap;
         Some(block)
+    }
+}
+
+/// `rgc.ll_arrayclear(l.ll_items())` — zero every item of a freshly allocated
+/// block, the second half of `ll_alloc_and_set(LIST, count, 0)`
+/// (rtyper/rlist.py:494-503).
+///
+/// # Safety
+/// `block` must be a live items block.
+#[inline]
+pub unsafe fn typed_items_block_clear(block: *mut TypedItemsBlock) {
+    unsafe {
+        std::ptr::write_bytes(
+            typed_items_block_items_base(block),
+            0,
+            (*block).capacity * std::mem::size_of::<u64>(),
+        );
     }
 }
 

--- a/pyre/pyre-object/src/rbigint.rs
+++ b/pyre/pyre-object/src/rbigint.rs
@@ -147,6 +147,33 @@ fn _load_unsigned_digit(x: Digit) -> UDigit {
     x as UDigit
 }
 
+/// Address of `l->items[x]`, the way `rtype_getitem` reaches it after
+/// translation.
+///
+/// `rtype_getitem` / `rtype_setitem` (rlist.py:247-266, :272-303) select
+/// `dum_checkidx` only where the source catches `IndexError`; every digit
+/// access takes the default `dum_nocheck`, under which `ll_getitem_nonneg`
+/// keeps `ll_assert(index >= 0, ...)` and folds the length test away. Going
+/// through a `&[Digit]` instead reloads the block's length header and branches
+/// on it once per digit, which the translated form never does.
+///
+/// # Safety
+///
+/// `digits` must be a live digit block and `x` an index within its capacity.
+#[majit_macros::always_inline]
+#[inline]
+unsafe fn digits_item(digits: *mut TypedItemsBlock, x: i64) -> *mut Digit {
+    debug_assert!(x >= 0, "unexpectedly negative digit index");
+    debug_assert!(!digits.is_null());
+    debug_assert!((x as usize) < unsafe { typed_items_block_capacity(digits) });
+    unsafe {
+        (digits as *mut u8)
+            .add(TYPED_ITEMS_BLOCK_ITEMS_OFFSET)
+            .cast::<Digit>()
+            .add(x as usize)
+    }
+}
+
 pub const NULLDIGIT: Digit = 0;
 pub const ONEDIGIT: Digit = 1;
 
@@ -889,51 +916,28 @@ impl RBigInt {
         self._size = self._size.abs() * sign;
     }
 
-    /// Address of digit `x`, the way `l->items[x]` reaches it after
-    /// translation.
-    ///
-    /// `rtype_getitem` (rlist.py:247-266) picks `dum_checkidx` only where the
-    /// source catches `IndexError`; every digit access here takes the default
-    /// `dum_nocheck`, which folds `ll_getitem_nonneg`'s length test away and
-    /// leaves `ll_assert(index >= 0, ...)` alone. Going through a `&[Digit]`
-    /// instead reloads the block's length header and branches on it once per
-    /// digit, which the translated form never does.
-    #[majit_macros::always_inline]
-    #[inline]
-    fn digit_slot(&self, x: i64) -> *mut Digit {
-        debug_assert!(x >= 0, "unexpectedly negative digit index");
-        debug_assert!(!self._digits.is_null());
-        debug_assert!((x as usize) < unsafe { typed_items_block_capacity(self._digits) });
-        unsafe {
-            (self._digits as *mut u8)
-                .add(TYPED_ITEMS_BLOCK_ITEMS_OFFSET)
-                .cast::<Digit>()
-                .add(x as usize)
-        }
-    }
-
     #[majit_macros::always_inline]
     #[inline]
     pub fn digit(&self, x: i64) -> Digit {
-        unsafe { *self.digit_slot(x) }
+        unsafe { *digits_item(self._digits, x) }
     }
 
     #[majit_macros::always_inline]
     #[inline]
     pub fn widedigit(&self, x: i64) -> WideDigit {
-        _widen_digit(self.digit(x))
+        _widen_digit(unsafe { *digits_item(self._digits, x) })
     }
 
     #[majit_macros::always_inline]
     #[inline]
     pub fn uwidedigit(&self, x: i64) -> UWideDigit {
-        _unsigned_widen_digit(self.digit(x))
+        _unsigned_widen_digit(unsafe { *digits_item(self._digits, x) })
     }
 
     #[majit_macros::always_inline]
     #[inline]
     pub fn udigit(&self, x: i64) -> UDigit {
-        _load_unsigned_digit(self.digit(x))
+        _load_unsigned_digit(unsafe { *digits_item(self._digits, x) })
     }
 
     #[majit_macros::always_inline]
@@ -941,7 +945,7 @@ impl RBigInt {
     fn setdigit(&mut self, x: i64, val: Digit) {
         let val = _mask_digit(val);
         debug_assert!(val >= 0);
-        unsafe { *self.digit_slot(x) = _store_digit(val) };
+        unsafe { *digits_item(self._digits, x) = _store_digit(val) };
     }
 
     // rbigint.py:208-212 `@specialize.argtype(2) setdigit`, Unsigned graph.
@@ -950,7 +954,7 @@ impl RBigInt {
     fn setdigit_udigit(&mut self, x: i64, val: UDigit) {
         let val = _mask_udigit(val);
         debug_assert!(val >= 0);
-        unsafe { *self.digit_slot(x) = _store_digit(val) };
+        unsafe { *digits_item(self._digits, x) = _store_digit(val) };
     }
 
     // rbigint.py:208-212 `@specialize.argtype(2) setdigit`, LONG_TYPE graph.
@@ -959,7 +963,7 @@ impl RBigInt {
     fn setdigit_widedigit(&mut self, x: i64, val: WideDigit) {
         let val = _mask_widedigit(val);
         debug_assert!(val >= 0);
-        unsafe { *self.digit_slot(x) = _store_digit(val) };
+        unsafe { *digits_item(self._digits, x) = _store_digit(val) };
     }
 
     // rbigint.py:208-212 `@specialize.argtype(2) setdigit`, ULONG_TYPE graph.
@@ -968,7 +972,7 @@ impl RBigInt {
     fn setdigit_uwidedigit(&mut self, x: i64, val: UWideDigit) {
         let val = _mask_uwidedigit(val);
         debug_assert!(val >= 0);
-        unsafe { *self.digit_slot(x) = _store_digit(val) };
+        unsafe { *digits_item(self._digits, x) = _store_digit(val) };
     }
 
     #[majit_macros::always_inline]

--- a/pyre/pyre-object/src/rbigint.rs
+++ b/pyre/pyre-object/src/rbigint.rs
@@ -18,8 +18,7 @@ use std::cmp::Ordering;
 use crate::object_array::{
     GC_INT_ARRAY_GC_TYPE_ID, TYPED_ITEMS_BLOCK_ITEMS_OFFSET, TypedItemsBlock,
     alloc_typed_items_block_immortal, alloc_typed_items_block_nursery,
-    try_alloc_typed_items_block_nursery, typed_items_block_capacity,
-    typed_items_block_items_base,
+    try_alloc_typed_items_block_nursery, typed_items_block_capacity, typed_items_block_items_base,
 };
 
 pub const SUPPORT_INT128: bool = true;
@@ -518,11 +517,13 @@ pub(crate) fn alloc_rbigint_nursery_impl(
     let tid = rbigint_gc_type_id();
     let mut needs_write_barrier = true;
     if tid != 0
-        && let Some(raw) = crate::gc_hook::try_gc_alloc_with_placement(
-            tid,
-            RBIGINT_PAYLOAD_SIZE,
-            &mut needs_write_barrier,
-        )
+        && let Some(raw) = unsafe {
+            crate::gc_hook::try_gc_alloc_fast_with_placement(
+                tid,
+                RBIGINT_PAYLOAD_SIZE,
+                &mut needs_write_barrier,
+            )
+        }
         .filter(|pointer| !pointer.is_null())
     {
         unsafe {
@@ -560,10 +561,15 @@ fn alloc_rbigint_nursery_collecting_impl(
         // collecting hook preserves that shape: the common nursery bump does
         // no dynamic root-set mutation, while the nursery-full slow path
         // temporarily registers and forwards this exact digit slot.
+        //
+        // The rbigint payload registers no destructor and is not a WEAKREF —
+        // its one traced edge is `_digits` — so this malloc site is one of the
+        // `malloc_fast` sites `gct_fv_gc_malloc` (`framework.py:820-838`)
+        // selects.
         let digit_slot = (&mut value._digits as *mut *mut TypedItemsBlock).cast::<*mut u8>();
         let mut needs_write_barrier = true;
         let raw = unsafe {
-            crate::gc_hook::try_gc_alloc_collecting_rooted(
+            crate::gc_hook::try_gc_alloc_fast_collecting_rooted(
                 tid,
                 RBIGINT_PAYLOAD_SIZE,
                 digit_slot,

--- a/pyre/pyre-object/src/rbigint.rs
+++ b/pyre/pyre-object/src/rbigint.rs
@@ -18,7 +18,8 @@ use std::cmp::Ordering;
 use crate::object_array::{
     GC_INT_ARRAY_GC_TYPE_ID, TYPED_ITEMS_BLOCK_ITEMS_OFFSET, TypedItemsBlock,
     alloc_typed_items_block_immortal, alloc_typed_items_block_nursery,
-    try_alloc_typed_items_block_nursery, typed_items_block_capacity, typed_items_block_items_base,
+    try_alloc_typed_items_block_nursery, typed_items_block_capacity, typed_items_block_clear,
+    typed_items_block_items_base,
 };
 
 pub const SUPPORT_INT128: bool = true;
@@ -857,12 +858,15 @@ impl RBigInt {
         })
     }
 
-    /// Allocate the translated equivalent of `[NULLDIGIT] * size`.
+    /// Allocate the translated equivalent of `[NULLDIGIT] * size`:
+    /// `ll_alloc_and_set(LIST, size, 0)`, which is `ll_newlist` followed by
+    /// `rgc.ll_arrayclear` (rtyper/rlist.py:494-503).
     #[inline]
     fn with_size(size: i64, sign: i64) -> Self {
         debug_assert!(size >= 0);
         let block =
             unsafe { alloc_typed_items_block_nursery(size as usize, GC_INT_ARRAY_GC_TYPE_ID) };
+        unsafe { typed_items_block_clear(block) };
         Self {
             _digits: block,
             _size: size * sign,
@@ -879,6 +883,7 @@ impl RBigInt {
             try_alloc_typed_items_block_nursery(allocation_size, GC_INT_ARRAY_GC_TYPE_ID)
         }
         .ok_or(RBigIntError::Memory)?;
+        unsafe { typed_items_block_clear(block) };
         Ok(Self {
             _digits: block,
             _size: size * sign,

--- a/pyre/pyre-object/src/rbigint.rs
+++ b/pyre/pyre-object/src/rbigint.rs
@@ -16,9 +16,10 @@ use std::borrow::Cow;
 use std::cmp::Ordering;
 
 use crate::object_array::{
-    GC_INT_ARRAY_GC_TYPE_ID, TypedItemsBlock, alloc_typed_items_block_immortal,
-    alloc_typed_items_block_nursery, try_alloc_typed_items_block_nursery,
-    typed_items_block_capacity, typed_items_block_items_base,
+    GC_INT_ARRAY_GC_TYPE_ID, TYPED_ITEMS_BLOCK_ITEMS_OFFSET, TypedItemsBlock,
+    alloc_typed_items_block_immortal, alloc_typed_items_block_nursery,
+    try_alloc_typed_items_block_nursery, typed_items_block_capacity,
+    typed_items_block_items_base,
 };
 
 pub const SUPPORT_INT128: bool = true;
@@ -825,16 +826,6 @@ impl RBigInt {
     }
 
     #[inline]
-    fn digits_mut(&mut self) -> &mut [Digit] {
-        unsafe {
-            std::slice::from_raw_parts_mut(
-                typed_items_block_items_base(self._digits) as *mut Digit,
-                typed_items_block_capacity(self._digits),
-            )
-        }
-    }
-
-    #[inline]
     pub fn get_sign(&self) -> i64 {
         intsign(self._size)
     }
@@ -845,10 +836,33 @@ impl RBigInt {
         self._size = self._size.abs() * sign;
     }
 
+    /// Address of digit `x`, the way `l->items[x]` reaches it after
+    /// translation.
+    ///
+    /// `rtype_getitem` (rlist.py:247-266) picks `dum_checkidx` only where the
+    /// source catches `IndexError`; every digit access here takes the default
+    /// `dum_nocheck`, which folds `ll_getitem_nonneg`'s length test away and
+    /// leaves `ll_assert(index >= 0, ...)` alone. Going through a `&[Digit]`
+    /// instead reloads the block's length header and branches on it once per
+    /// digit, which the translated form never does.
+    #[majit_macros::always_inline]
+    #[inline]
+    fn digit_slot(&self, x: i64) -> *mut Digit {
+        debug_assert!(x >= 0, "unexpectedly negative digit index");
+        debug_assert!(!self._digits.is_null());
+        debug_assert!((x as usize) < unsafe { typed_items_block_capacity(self._digits) });
+        unsafe {
+            (self._digits as *mut u8)
+                .add(TYPED_ITEMS_BLOCK_ITEMS_OFFSET)
+                .cast::<Digit>()
+                .add(x as usize)
+        }
+    }
+
     #[majit_macros::always_inline]
     #[inline]
     pub fn digit(&self, x: i64) -> Digit {
-        self.digits()[x as usize]
+        unsafe { *self.digit_slot(x) }
     }
 
     #[majit_macros::always_inline]
@@ -874,7 +888,7 @@ impl RBigInt {
     fn setdigit(&mut self, x: i64, val: Digit) {
         let val = _mask_digit(val);
         debug_assert!(val >= 0);
-        self.digits_mut()[x as usize] = _store_digit(val);
+        unsafe { *self.digit_slot(x) = _store_digit(val) };
     }
 
     // rbigint.py:208-212 `@specialize.argtype(2) setdigit`, Unsigned graph.
@@ -883,7 +897,7 @@ impl RBigInt {
     fn setdigit_udigit(&mut self, x: i64, val: UDigit) {
         let val = _mask_udigit(val);
         debug_assert!(val >= 0);
-        self.digits_mut()[x as usize] = _store_digit(val);
+        unsafe { *self.digit_slot(x) = _store_digit(val) };
     }
 
     // rbigint.py:208-212 `@specialize.argtype(2) setdigit`, LONG_TYPE graph.
@@ -892,7 +906,7 @@ impl RBigInt {
     fn setdigit_widedigit(&mut self, x: i64, val: WideDigit) {
         let val = _mask_widedigit(val);
         debug_assert!(val >= 0);
-        self.digits_mut()[x as usize] = _store_digit(val);
+        unsafe { *self.digit_slot(x) = _store_digit(val) };
     }
 
     // rbigint.py:208-212 `@specialize.argtype(2) setdigit`, ULONG_TYPE graph.
@@ -901,7 +915,7 @@ impl RBigInt {
     fn setdigit_uwidedigit(&mut self, x: i64, val: UWideDigit) {
         let val = _mask_uwidedigit(val);
         debug_assert!(val >= 0);
-        self.digits_mut()[x as usize] = _store_digit(val);
+        unsafe { *self.digit_slot(x) = _store_digit(val) };
     }
 
     #[majit_macros::always_inline]

--- a/pyre/pyre-object/src/rbigint.rs
+++ b/pyre/pyre-object/src/rbigint.rs
@@ -164,6 +164,33 @@ static ONERBIGINT: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
 static ONENEGATIVERBIGINT: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
 static FIVERBIGINT: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
 
+/// The four owners above, in the order [`PREBUILT_DIGITS`] indexes them.
+fn prebuilt_slots() -> [&'static std::sync::OnceLock<usize>; 4] {
+    [&NULLRBIGINT, &ONERBIGINT, &ONENEGATIVERBIGINT, &FIVERBIGINT]
+}
+
+/// Digit-array identity of each prebuilt, held together and readable without
+/// touching the objects themselves.
+///
+/// A source line upstream spells `return NULLRBIGINT` — it hands back the
+/// module-global object, and nothing is rediscovered. pyre's `RBigInt` is a
+/// by-value handle that only becomes a heap object at the boxing step, so the
+/// boxing step is where that identity has to be recovered, on every allocation,
+/// almost always answering "not a prebuilt".
+///
+/// `prebuilt` gives each of the four its own one-element digit array, so that
+/// answer is decided by the digit pointer alone. Keeping the four pointers in
+/// one array makes the common case four plain loads out of a single cache line,
+/// instead of four `OnceLock` state words each followed by a dereference into a
+/// separately allocated payload. A candidate match still reads the object, so
+/// the test stays exactly as exact as it was.
+static PREBUILT_DIGITS: [std::sync::atomic::AtomicUsize; 4] = [
+    std::sync::atomic::AtomicUsize::new(0),
+    std::sync::atomic::AtomicUsize::new(0),
+    std::sync::atomic::AtomicUsize::new(0),
+    std::sync::atomic::AtomicUsize::new(0),
+];
+
 fn _check_digits(digits: &[Digit]) {
     for &digit in digits {
         debug_assert!(digit >= 0);
@@ -494,12 +521,27 @@ pub fn rbigint_gc_type_id() -> u32 {
 /// slot, not numeric equality, is intentional: upstream has a few internal
 /// zero results that must remain fresh because their digits are filled later.
 fn prebuilt_payload_pointer(value: &RBigInt) -> Option<*mut RBigInt> {
-    for slot in [&NULLRBIGINT, &ONERBIGINT, &ONENEGATIVERBIGINT, &FIVERBIGINT] {
-        let Some(&raw) = slot.get() else {
+    // All four are single-digit objects: `zero()` carries `_size == 0` and the
+    // other three `|_size| == 1` (rbigint.py:1652-1656). Their digit arrays are
+    // one element long, so a value holding two or more digits cannot alias any
+    // of them — and `_normalize` (rbigint.py:1601-1603) is the only route by
+    // which a computed result reaches the zero form, where it assigns
+    // `self._digits = NULLDIGITS` itself. Deciding that from the size leaves
+    // the table for the values that can actually match.
+    if !(-1..=1).contains(&value._size) {
+        return None;
+    }
+    let digits = value._digits as usize;
+    for index in 0..PREBUILT_DIGITS.len() {
+        // An unpublished slot reads 0, which no live digit array can equal.
+        if PREBUILT_DIGITS[index].load(std::sync::atomic::Ordering::Relaxed) != digits {
+            continue;
+        }
+        let Some(&raw) = prebuilt_slots()[index].get() else {
             continue;
         };
         let prebuilt = unsafe { &*(raw as *const RBigInt) };
-        if value._digits == prebuilt._digits && value._size == prebuilt._size {
+        if value._size == prebuilt._size {
             return Some(raw as *mut RBigInt);
         }
     }
@@ -694,8 +736,8 @@ impl RBigInt {
     }
 
     #[inline]
-    fn prebuilt(slot: &'static std::sync::OnceLock<usize>, digit: Digit, sign: i64) -> Self {
-        let raw = *slot.get_or_init(|| {
+    fn prebuilt(index: usize, digit: Digit, sign: i64) -> Self {
+        let raw = *prebuilt_slots()[index].get_or_init(|| {
             let block = unsafe { alloc_typed_items_block_immortal(1) };
             unsafe {
                 *(typed_items_block_items_base(block) as *mut Digit) = digit;
@@ -704,7 +746,12 @@ impl RBigInt {
                 _digits: block,
                 _size: sign,
             };
-            Box::into_raw(Box::new(value)) as usize
+            let raw = Box::into_raw(Box::new(value)) as usize;
+            // Publish the digit identity only once the object it names exists;
+            // `prebuilt_payload_pointer` matches on this word and then reads
+            // the object through the owner slot.
+            PREBUILT_DIGITS[index].store(block as usize, std::sync::atomic::Ordering::Release);
+            raw
         }) as *const Self;
         // RPython assignment returns the process-global rbigint itself. The
         // host needs a shallow owned handle; source translation aliases the
@@ -714,12 +761,12 @@ impl RBigInt {
 
     #[inline]
     fn negative_one() -> Self {
-        Self::prebuilt(&ONENEGATIVERBIGINT, ONEDIGIT, -1)
+        Self::prebuilt(2, ONEDIGIT, -1)
     }
 
     #[inline]
     fn five() -> Self {
-        Self::prebuilt(&FIVERBIGINT, 5, 1)
+        Self::prebuilt(3, 5, 1)
     }
 
     /// rbigint.py:159 `__init__(digits=NULLDIGITS, sign=0, size=0)`.
@@ -813,12 +860,12 @@ impl RBigInt {
 
     #[inline]
     pub fn zero() -> Self {
-        Self::prebuilt(&NULLRBIGINT, NULLDIGIT, 0)
+        Self::prebuilt(0, NULLDIGIT, 0)
     }
 
     #[inline]
     pub fn one() -> Self {
-        Self::prebuilt(&ONERBIGINT, ONEDIGIT, 1)
+        Self::prebuilt(1, ONEDIGIT, 1)
     }
 
     #[inline]
@@ -4644,7 +4691,7 @@ pub fn walk_rbigint_cache_digit_slots(mut visitor: impl FnMut(&mut *mut u8)) {
     // FIVERBIGINT are translated prebuilt roots.  Do not initialize a
     // previously-unused constant from inside the collector; visit only slots
     // already published by ordinary execution.
-    for slot in [&NULLRBIGINT, &ONERBIGINT, &ONENEGATIVERBIGINT, &FIVERBIGINT] {
+    for slot in prebuilt_slots() {
         if let Some(&raw) = slot.get() {
             let value = unsafe { &mut *(raw as *mut RBigInt) };
             visitor(unsafe {


### PR DESCRIPTION
Ten commits on top of `e2a5b6807a4`, all in the fixed-size allocation path that the bignum loop runs. Every change is grounded in `rpython/memory/gctransform/framework.py`, `rpython/memory/gc/incminimark.py` or `rpython/rlib/rbigint.py`; each was measured with an unsound ceiling probe first, so the cost of the orthodoxy gap is known before the port.

## What is here

**`c25f519251b` — name the singleton collector concretely, split the fixed-size allocators around the nursery bump.**
`gc_sync`'s store was `Box<dyn GcAllocator>`, so every `gc_op` reached the collector through a vtable — you cannot inline through that. Upstream has no allocator value to dispatch on (`framework.py:132` resolves `GCClass` once, `:167` builds one `gcdata.gc`, `:272-338` binds each op to `GCClass.<meth>.im_func`). With the vtable gone, the three fixed-size allocators split into an `#[inline]` bump and a `#[cold] #[inline(never)]` tail, the shape `framework.py:361-382` produces. The measurable defect was the *prologue*: `alloc_with_type_rooted` opened with five `stp` before reaching a ten-instruction bump, and five such frames were stacked.

**`37fab986072` — pass the thread-local base as the second compiled-entry argument on aarch64.** A missing piece of the entry ABI, restored.

**`bba413bb135` + `f1b52cf9f46` — the fast-path gate claim.**
The `gc_op` preamble was a `_tlv_get_addr` call, four acquire loads, a `casa`, a `swpal` and two `stlr` — per allocation, four to five allocations per iteration. Now `rpy_fastgil` stays claimed between operations (revocable by the next claimant) and the owner word is a low bit of the gate word, so entering is one `casa`.

**`796402515f9` — resolve the young weakref and destructor registration from one type-table row.** `incminimark.py:687-693` reaches both `if`s with the flags already in hand; probing separately repeated the bound test, the table base load and the stride multiply.

**`997f5c05e9e` + `94e42d2ee45` — read and write rbigint digits without a length-header bound test.** `rtype_getitem` (`rlist.py:247-266`) picks `dum_checkidx` only where the source catches `IndexError`; every digit access takes the default `dum_nocheck`, which folds the length test away and leaves `ll_assert(index >= 0, ...)`. Translated `_x_add` has zero bounds checks. The follow-up restores the shape of `rbigint.py:184-213`: each of the five accessors spells `self._digits[x]` itself, with the block pointer handed to a free function in `ll_getitem_nonneg`'s position, rather than sharing one `digit_slot` method that swallowed the field projection.

**`0098136c93e` — clear a digit block only where the source spells `[NULLDIGIT] * n`.**
`ll_newlist` (`rlist.py:324-329`) allocates the items array with a plain `malloc(LIST.items.TO, length)` and incminimark sets `malloc_zero_filled = False` (`incminimark.py:211`), so the items hold whatever the nursery held. The zero fill belongs to `ll_alloc_and_set`, which appends `rgc.ll_arrayclear` only when the fill item is zero (`rtyper/rlist.py:494-503`); a list display such as `rbigint([_store_digit(res & MASK), _store_digit(carry)], sign, 2)` goes through `ll_newlist` plus two setitems and is never cleared. pyre's allocator cleared unconditionally, so every `RBigInt::new` memset the slots it was about to overwrite. The clear moves to the two `[NULLDIGIT] * n` sites. The items are non-pointer words, so an uncleared block is not a GC hazard — `zero_gc_pointers_inside` is a no-op for a non-GcPtr array, which is why upstream skips the clear here too.

**`a1e495a77ff` — give the fixed-size allocators a `malloc_fast` entry point.**
`framework.py:361-382` copies `malloc_fixedsize` under a fresh name and annotates the copy `s_False, s_False, s_False`, folding the two registrations out of its body. `gct_fv_gc_malloc` (`framework.py:820-838`) selects that copy whenever the type has no finalizer, and never passes `contains_weakptr` for a fixed-size malloc — a WEAKREF is built by `gct_weakref_create`. A folded entry point now sits next to each of the three fixed-size allocators at every layer; the run-time precondition becomes a debug assertion. The three backends needed no change: the production path is the `!gc_box_installed()` arm, and a per-thread box (a backend-test configuration) can keep running the general body, which is always a correct implementation of the folded one.

A global fold would be unsound — `pyre-object/src/weakref.rs:57` allocates a WEAKREF through the generic `try_gc_alloc`, and several production types carry destructors. The fold has to be per-call-site on a statically known tid, which is the position `gct_fv_gc_malloc` is in.

**`5f0ce93e994` — decide the prebuilt rbigint identity from the size before the table.**
A source line upstream spells `return NULLRBIGINT` and hands back the module-global object. pyre's `RBigInt` is a by-value handle that only becomes a heap object at the boxing step, so the boxing step is where that identity has to be recovered — on every allocation, almost always answering "not a prebuilt". It answered by reading four `OnceLock` state words and dereferencing four separately allocated payloads.

All four of `rbigint.py:1652-1656`'s objects are single-digit: `zero()` carries `_size == 0` and the other three `|_size| == 1`. A value holding two or more digits therefore cannot alias any of their one-element digit arrays, and `_normalize` (`rbigint.py:1601-1603`) is the only route by which a computed result reaches the zero form, where it assigns `self._digits = NULLDIGITS` itself. Testing the size first is two instructions and it is the whole lever — holding the four digit pointers in one array instead of four `OnceLock`s, without the size test, measured as noise (9/15 rounds).

The adapter itself cannot be removed. Carrying box identity out of the source sites would move every rbigint method away from `rbigint.py`'s uniform `return rbigint(...)` shape — more deviation, not less — and it cannot be narrowed to the zero case, because `pow(x, 0)` reaches the same helpers through `ONERBIGINT`. Stubbing the scan out fails exactly 2 of `pyre-object`'s 303 tests, and both are tests of the canonicalization itself.

## Measurements

`synth/int_mul_ovf_bignum_promote` shape, 400M iterations, startup-subtracted CPU time, dynasm/aarch64.

The first four rows are min-of-11 interleaved, taken on a quiet machine; the arm order was reversed on a second run and the ranking did not change.

| | ns/iter | |
|---|---|---|
| gate claim: before | 28.85 | |
| gate claim: after | **26.65** | −7.6% (unsound ceiling 26.38) |
| `malloc_fast`: before | 26.55 | |
| `malloc_fast`: after | **24.52** | −7.6% |
| `malloc_fast`: registrations deleted outright (unsound ceiling) | 23.92 | −9.9% |

The `gc_op` preamble is now within 1% of its ceiling — treat it as spent. `malloc_fast` captures ~77% of its ceiling; the rest sits on allocation sites this PR does not convert.

The prebuilt identity change was measured differently, and the difference matters. min-of-N became unusable partway through — another benchmark process held a core, and min-of-N then reports whichever arm caught the one quiet window: the *same unchanged binary* measured 26.32 and 24.58 ns/iter across two runs. A −7.2% reading taken that way did not replicate and is withdrawn. The number below is a paired per-round ratio over 15 rounds with a sign test, arms run back-to-back within each round and their order alternated between rounds:

| | median ratio | rounds faster |
|---|---|---|
| prebuilt identity: size test first | **0.960** (−4.0%) | 13/15 |
| prebuilt identity: removed outright (unsound ceiling) | 0.954 | 11/15 |
| prebuilt identity: pointer table only, no size test | 0.962 | 9/15 — noise |
| zero fill removed from `ll_newlist` | **0.986** (−1.4%) | 13/15 |

## Verification

`cargo test --all` is green.

One caveat worth stating, because it invalidated an earlier claim in this description: the `majit-translate` tests read `build/llbc/*.ullbc` **as files**, and nothing in the cargo build graph regenerates them. A stale local artefact let `cargo test --all` pass here while CI failed on all three platforms, and `pyre/check.py` shares the exposure — its build consumes `build/llbc/` for the JIT front-end and only errors when the directory is *missing*, never when it is out of date. So a local check.py comparison says nothing about what a change does to the traced side. `94e42d2ee45` is the fix for the failure that hid behind this; the numbers below are taken from CI, where both sides extract their own LLBC.

`pyre/check.py` is red at `e2a5b6807a4` itself, before any commit here. Comparing the two CI runs on ubuntu:

| | failures |
|---|---|
| `e2a5b6807a4` (merge base) | 42 |
| this branch | 40 |

The jit-stats failure set is **identical, 39 on each side** — six tests from #934 with no committed `.jitstats` baseline (against the floor #947 armed), and jit-stats regressions on exception/sre shapes traced to #956. The remaining three-versus-one are all the same reason class, a perf ratio against a collapsed denominator: `call_loop_local_function` and `list_subscript_index` fail on the base at 0.05–0.08s against `pypy 0.01s`, `attr_store_add_transition` fails here at 0.07s against the same 0.01s. Those wander run to run at that absolute scale.

— *opened by Claude*
