### PR TITLE
jit: decline to fold float-result pure calls in the walker; majit-ir clippy allows; record 6 missing jit-stats baselines

### DIFF
--- a/majit/majit-ir/src/eval_breaker_word.rs
+++ b/majit/majit-ir/src/eval_breaker_word.rs
@@ -139,6 +139,10 @@ pub fn take_gc() -> bool {
 /// Every flag must fit in the word the poll actually loads. Checked per target,
 /// so a flag too wide for a 32-bit `usize` fails the wasm32 build rather than
 /// silently reading as unarmed there.
+// `ineffective_bit_mask` reads the fold as a runtime `x | 16` tested against a
+// constant; both sides here are constants and the whole item is a static
+// assertion, so there is no operand to compare directly.
+#[allow(clippy::ineffective_bit_mask)]
 const _: () = assert!(
     (EB_ASYNC | EB_STW | EB_FINALIZING | EB_GC_INTERP | EB_GC)
         < (1 << (EVAL_BREAKER_WORD_SIZE * 8 - 1))

--- a/majit/majit-ir/src/resoperation.rs
+++ b/majit/majit-ir/src/resoperation.rs
@@ -2179,6 +2179,10 @@ impl OpCode {
 
     // ── Category classification (mirrors rop.is_* static methods) ──
 
+    // `FINAL_FIRST` is `OpCode::Jump as u16` == 0, so the lower bound is
+    // vacuous today. It is kept symbolic to match the sibling classifiers and
+    // to stay correct if the category ever stops leading the enum.
+    #[allow(clippy::absurd_extreme_comparisons)]
     pub fn is_final(self) -> bool {
         let n = self.as_u16();
         FINAL_FIRST <= n && n <= FINAL_LAST

--- a/majit/majit-ir/src/value.rs
+++ b/majit/majit-ir/src/value.rs
@@ -227,6 +227,10 @@ impl SharedConstPool {
     ///
     /// The caller must be the exclusive GC root walker; no resume-data reader
     /// may run concurrently.
+    // The pool is `UnsafeCell`-backed precisely so the walker can mutate it
+    // through a shared reference; `mut_from_ref` is the signature that escape
+    // hatch has to have, and the contract above is what makes it sound.
+    #[allow(clippy::mut_from_ref)]
     pub unsafe fn as_mut_vec_for_gc(&self) -> &mut Vec<Const> {
         unsafe { &mut *self.values.get() }
     }

--- a/majit/majit-metainterp/src/executor.rs
+++ b/majit/majit-metainterp/src/executor.rs
@@ -812,6 +812,15 @@ pub fn execute_pure_call(
         // `#[jit_module]` Float helpers expose `concrete_ptr` as
         // `extern "C" fn(...) -> i64` with the f64 pre-packed via
         // `f64::to_bits`; routing through `call_int_function` is bit-identical.
+        //
+        // That convention is a CALLER CONTRACT, not a property of the descr:
+        // it holds only when `func_ptr` is such a wrapper.  A funcbox baked by
+        // the codewriter instead carries the callee's own address, where the
+        // f64 comes back in the floating-point return register and this arm
+        // reads whatever was left in the integer one.  The two are
+        // indistinguishable here — `descr` records the signature, not which
+        // emitter produced the pointer — so the walker declines rather than
+        // guess (`residual_call.rs try_fold_pure_call_via_executor`).
         majit_ir::Type::Float => crate::pyjitpl::call_int_function(func_ptr, args),
     }
 }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -1596,6 +1596,30 @@ pub(crate) fn try_fold_pure_call_via_executor<Sym: WalkSym>(
     if allboxes.is_empty() {
         return;
     }
+    // A float-returning callee cannot be executed here, because the funcbox's
+    // ABI depends on which emitter produced the op and the descr does not say
+    // which:
+    //
+    //   * the codewriter's residual bakes the callee's OWN address, so the
+    //     `f64` comes back in the floating-point return register
+    //     (`majit-backend-wasm/src/codegen.rs:909 residual_call_float_sig`
+    //     builds an `f64`-returning `call_indirect` from that same pointer);
+    //   * the runtime emitter's `*_canonical_via_target` family bakes
+    //     `JitCallTarget::concrete_ptr` instead (`jitcode/assembler.rs:3343`),
+    //     an `extern "C" fn(...) -> i64` wrapper with the `f64` pre-packed via
+    //     `f64::to_bits` — which is the convention `execute_pure_call`'s Float
+    //     arm implements.
+    //
+    // Running the first kind under the second's convention yields whatever was
+    // left in the integer return register (probed: 7/7 garbage against
+    // `jit_bigint_to_f64_or_inf`), and the walker would stamp it as the folded
+    // constant.  Leave the recorded `CallPure*` for the backend, which calls
+    // the same pointer with the descr's real signature.  `JitCode`'s
+    // `call_descr_to_call_target` side table is the discriminator a future
+    // slice would consult to fold these; nothing reads it today.
+    if call_descr.result_type() == majit_ir::Type::Float {
+        return;
+    }
     // pyjitpl.py `_build_allboxes`: slot 0 is funcbox, slots
     // 1.. are user args in `descr.arg_types()` ABI order.  Walker's
     // [`build_allboxes`] preserves the same layout.

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
@@ -11373,3 +11373,112 @@ fn ref_compare_same_box_fastpath_covers_the_instance_ptr_spellings() {
         );
     }
 }
+
+// A float-returning residual is never folded at record time: the funcbox's
+// ABI depends on which emitter baked it (the codewriter bakes the callee's own
+// `f64`-returning address; the runtime emitter's `*_canonical_via_target`
+// family bakes `JitCallTarget::concrete_ptr`, an `i64`-returning wrapper), and
+// the descr does not record which.  See the decline in
+// `try_fold_pure_call_via_executor`.
+
+/// A real `f64`-returning callee, i.e. the shape the codewriter bakes.
+extern "C" fn halve_f64_for_walker_test(x: i64) -> f64 {
+    (x as f64) / 2.0
+}
+
+#[test]
+fn walker_declines_to_fold_a_float_result_pure_call() {
+    let mut tc = fresh_trace_ctx();
+    let funcbox = tc.const_int(halve_f64_for_walker_test as *const () as i64);
+    let arg0 = tc.const_int(7);
+    let allboxes = [funcbox, arg0];
+    let descr = make_call_descr(
+        6,
+        vec![Type::Int],
+        Type::Float,
+        majit_ir::ExtraEffect::ElidableCannotRaise,
+    );
+    let recorded = tc.record_op_with_descr(majit_ir::OpCode::CallPureF, &allboxes, descr.clone());
+    let call_descr = descr.as_call_descr().expect("CallPureF descr");
+
+    // Same shape as the Int sibling above, which DOES fold — so a failure here
+    // is the float arm specifically, not the fixture.
+    let int_descr = make_call_descr(
+        7,
+        vec![Type::Int, Type::Int],
+        Type::Int,
+        majit_ir::ExtraEffect::ElidableCannotRaise,
+    );
+    let int_boxes = [
+        tc.const_int(add2_for_walker_test as *const () as i64),
+        tc.const_int(40),
+        tc.const_int(2),
+    ];
+    let int_recorded =
+        tc.record_op_with_descr(majit_ir::OpCode::CallPureI, &int_boxes, int_descr.clone());
+    let int_call_descr = int_descr.as_call_descr().expect("CallPureI descr");
+
+    let mut regs_i: Vec<OpRef> = Vec::new();
+    let mut regs_r: Vec<OpRef> = Vec::new();
+    let session = std::cell::RefCell::new(WalkSession::default());
+    let mut wc = WalkContext {
+        callee_shadow: None,
+        inline_callee_consts: None,
+        fbw_mode: test_fbw_mode(),
+        session: &session,
+        registers_r: &mut regs_r,
+        registers_i: &mut regs_i,
+        registers_f: &mut [],
+        concrete_registers_r: &mut [],
+        concrete_registers_i: &mut [],
+        descr_refs: &[],
+        raw_descrs: RawDescrPool::Global,
+        is_authoritative_executor: true,
+        trace_ctx: &mut tc,
+        is_top_level: true,
+        sub_jitcode_lookup: &no_sub_jitcodes,
+        last_exc_value: None,
+        last_exc_value_concrete: ConcreteValue::Null,
+        entry_py_pc: EntryPyPc::Py(0),
+        outer_resume_marker_jit_pc: None,
+        outer_jitcode_index: 0,
+        outer_active_boxes: Vec::new(),
+        store_subscr_fn_addr: None,
+        pending_guard_snapshot_error: None,
+        vstack_boxes: Vec::new(),
+        vstack_depth: 0,
+        vstack_cur_pypc: 0,
+        vstack_valid: false,
+        vstack_last_ref: OpRef::NONE,
+        vstack_reorder_ceiling: u32::MAX,
+        live_before_jit_pc: usize::MAX,
+        live_after_jit_pc: usize::MAX,
+    };
+    try_fold_pure_call_via_executor(
+        &mut wc,
+        majit_ir::OpCode::CallPureF,
+        &allboxes,
+        call_descr,
+        recorded,
+    );
+    try_fold_pure_call_via_executor(
+        &mut wc,
+        majit_ir::OpCode::CallPureI,
+        &int_boxes,
+        int_call_descr,
+        int_recorded,
+    );
+    drop(wc);
+
+    assert_eq!(
+        tc.box_value(int_recorded),
+        Some(majit_ir::Value::Int(42)),
+        "control: the Int sibling folds, so the fixture reaches the executor",
+    );
+    assert_eq!(
+        tc.box_value(recorded),
+        None,
+        "a float-result pure call must stay symbolic, not be stamped with \
+         whatever the integer return register held",
+    );
+}

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
@@ -11482,3 +11482,98 @@ fn walker_declines_to_fold_a_float_result_pure_call() {
          whatever the integer return register held",
     );
 }
+
+/// `bh_load_global_fn`'s `namespace` operand (arg 0) is never dereferenced —
+/// the helper resolves the globals from the executing frame or from `w_code`'s
+/// own live `w_globals`. The codewriter bakes it from `w_code_get_w_globals`,
+/// which is `PY_NULL` until some frame for that code object stamps it, so a
+/// jitcode built before the callee's first frame carries a concrete-NULL there.
+/// Aborting the walk on it is a false positive whose replay re-executes every
+/// residual the walk already ran concretely.
+#[test]
+fn mayforce_null_ref_arg_exempts_the_unread_load_global_namespace() {
+    fn descr_for(pyre_helper: majit_ir::PyreHelperKind) -> DescrRef {
+        let mut effect = majit_ir::EffectInfo::default();
+        effect.pyre_helper = pyre_helper;
+        std::sync::Arc::new(majit_ir::SimpleCallDescr::new(
+            9,
+            vec![Type::Ref, Type::Ref, Type::Ref, Type::Int],
+            Type::Ref,
+            false,
+            std::mem::size_of::<usize>(),
+            effect,
+        ))
+    }
+
+    let mut tc = fresh_trace_ctx();
+    // funcbox, then `bh_load_global_fn(namespace=NULL, w_code, frame, namei)`.
+    let allboxes = [
+        tc.const_int(0x1234),
+        tc.const_ref(0),
+        tc.const_ref(0xC0DE_1000),
+        tc.const_ref(0xC0DE_2000),
+        tc.const_int(2),
+    ];
+    let load_global = descr_for(majit_ir::PyreHelperKind::LoadGlobal);
+    let untagged = descr_for(majit_ir::PyreHelperKind::None);
+
+    let mut regs_i: Vec<OpRef> = Vec::new();
+    let mut regs_r: Vec<OpRef> = Vec::new();
+    let session = std::cell::RefCell::new(WalkSession::default());
+    let wc = WalkContext {
+        callee_shadow: None,
+        inline_callee_consts: None,
+        fbw_mode: test_fbw_mode(),
+        session: &session,
+        registers_r: &mut regs_r,
+        registers_i: &mut regs_i,
+        registers_f: &mut [],
+        concrete_registers_r: &mut [],
+        concrete_registers_i: &mut [],
+        descr_refs: &[],
+        raw_descrs: RawDescrPool::Global,
+        is_authoritative_executor: true,
+        trace_ctx: &mut tc,
+        is_top_level: true,
+        sub_jitcode_lookup: &no_sub_jitcodes,
+        last_exc_value: None,
+        last_exc_value_concrete: ConcreteValue::Null,
+        entry_py_pc: EntryPyPc::Py(0),
+        outer_resume_marker_jit_pc: None,
+        outer_jitcode_index: 0,
+        outer_active_boxes: Vec::new(),
+        store_subscr_fn_addr: None,
+        pending_guard_snapshot_error: None,
+        vstack_boxes: Vec::new(),
+        vstack_depth: 0,
+        vstack_cur_pypc: 0,
+        vstack_valid: false,
+        vstack_last_ref: OpRef::NONE,
+        vstack_reorder_ceiling: u32::MAX,
+        live_before_jit_pc: usize::MAX,
+        live_after_jit_pc: usize::MAX,
+    };
+
+    assert_eq!(
+        walker_abort_if_mayforce_null_ref_arg(
+            majit_ir::OpCode::CallMayForceR,
+            &allboxes,
+            load_global.as_call_descr().expect("call descr"),
+            &wc,
+            186,
+        ),
+        Ok(()),
+    );
+    // Control: the same NULL in the same slot without the helper tag is still
+    // the broken baked-NULL shape the guard exists for.
+    assert!(matches!(
+        walker_abort_if_mayforce_null_ref_arg(
+            majit_ir::OpCode::CallMayForceR,
+            &allboxes,
+            untagged.as_call_descr().expect("call descr"),
+            &wc,
+            186,
+        ),
+        Err(DispatchError::MayForceNullRefArgUnsupported { pc: 186 }),
+    ));
+}


### PR DESCRIPTION
Two independent changes.

## 1. Decline to fold float-result pure calls in the walker

`try_fold_pure_call_via_executor` routed every constant-funcbox `CallPure*`
through `executor::execute_pure_call`, whose `Float` arm calls
`call_int_function` and reinterprets the **integer** return register via
`f64::from_bits`.

That convention is a caller contract, not a property of the descr. Two emitters
bake operand 0 of a residual call, with opposite float conventions:

| emitter | funcbox | float return |
|---|---|---|
| `majit-translate` codewriter (LLBC path) | the callee's **own address** | real `f64` register |
| runtime `*_canonical_via_target` (`jitcode/assembler.rs:3343`) | `JitCallTarget::concrete_ptr` | `i64` with `f64::to_bits` pre-packed |

Both land in the same walker handlers and dispatch on `descr.result_type()`
alone. `CallDescr` records the signature, not which emitter produced the
pointer, so no descr-based dispatch can be right for both — feeding a
codewriter funcbox to the `i64`-bits arm reads whatever was left in the integer
return register.

The fix returns early on `result_type() == Type::Float` and leaves the recorded
`CallPure*` for the backend, which calls the same pointer with the descr's real
signature (`majit-backend-wasm/src/codegen.rs:909 residual_call_float_sig`
builds an `f64`-returning `call_indirect` from it). `execute_pure_call`'s
`Float` arm keeps the `i64`-bits convention, now documented as a caller
contract.

Adding a `bh_call_f` instead would only *flip* which channel is broken. The
discriminator does exist in the data — `JitCode::call_descr_to_call_target`
(`jitcode/mod.rs:367`) maps a descr slot back to its `JitCallTarget` — but
nothing in `pyre/` reads it today, so folding these is left to a future change.

**Evidence.** New regression test `walker_declines_to_fold_a_float_result_pure_call`
drives a real `WalkContext` over an `f64`-returning callee plus an `Int`
control. Without the decline the float box folds to `Float(3.5e-323)` =
`f64::from_bits(7)` — the argument still sitting in the integer register —
while the `CallPureI` sibling in the same fixture folds to `42`, so the fixture
is not the problem. A standalone probe against `jit_bigint_to_f64_or_inf`
mismatches 7/7 (`std::hint::black_box` is required, or LLVM sees through the
transmute and re-emits a correctly-ABI'd direct call, which is why the
pre-existing `float_result_routes_through_call_int_function_with_bits_packing`
test passed).

**Latent, not live.** Instrumenting the fold for `result_type() == Float` and
sweeping all ~1400 files of `pyre/bench` + `pyre/bench/synth` (check.py's
corpus) found zero occurrences.

## 2. Allow three deny-by-default clippy lints in `majit-ir`

`cargo clippy -p majit-ir` failed to compile on three deny-by-default lints, so
the crate could not be linted at all. Each is a false positive against
deliberate structure and gets a scoped `#[allow]` plus a comment stating why:

- `ineffective_bit_mask` on the eval-breaker flag-width static assertion — every
  operand is a constant, so there is no runtime value to compare.
- `absurd_extreme_comparisons` on `OpCode::is_final` — `FINAL_FIRST` is
  `OpCode::Jump as u16` == 0 today; the bound is kept symbolic to match the
  sibling classifiers and to stay correct if the category stops leading the enum.
- `mut_from_ref` on `SharedConstPool::as_mut_vec_for_gc` — the pool is
  `UnsafeCell`-backed so the GC root walker can mutate through a shared
  reference, and the existing `# Safety` clause carries the contract.

No behavior change; the crate now reports 0 errors and 41 warnings.

## Verification

- `python3 pyre/check.py --backend dynasm,cranelift`: 14 failed / 351 passed per
  backend, **byte-identical failure set to the clean-HEAD control** and to a
  repeat run. All 14 are pre-existing (6 missing jit-stats baselines from #934,
  8 jit-stats regressions incl. the `exception_reraise_tb_depth_jitstress`
  family).
- `cargo test -p pyre-jit-trace -p majit-metainterp --features dynasm`: green.
- `cargo test -p majit-ir`: 307 passed.
- `cargo clippy -p majit-ir --no-deps`: 0 errors.
- `cargo fmt --all --check`: clean.



## 3. Record the six missing synthetic jit-stats baselines

`hot_loop_exit_then_class_stmt` (#890) and five fixtures from #934/#948 were
added without a committed `.jitstats`, so check.py failed them on both backends
with "no committed jit-stats baseline". Recorded one fixture at a time with
`--snapshot --synthetic-pattern <name>.py`, so no existing baseline is
rewritten; 350 synth scripts now have 350 dynasm and 350 cranelift baselines.

Two record a weak floor worth revisiting: `pypy_dict_primitives_nonbinding`
compiles no loop at all (`loops_compiled=0`), and `raise_reg_unbound_jitstress`
enters at `loops_aborted=10`.

## CI status — the remaining 8 failures are pre-existing on `main`

`main` at `f3bddb31f28` fails `pyre/check.py` on all three platforms with
**exactly the same 14 fixtures and the same numbers** as this branch did before
commit 3 (compare run 30707884899 against 30713388334). This PR introduces no
check.py regression; the 6 baseline recordings above take it from 14 to **8
failed / 357 passed** per backend.

The 8 that remain are jit-stats floor regressions that entered `main` between
#947 (which recorded the baselines) and the current tip. Measured root split —
one build with an env-gated early `return true` in
`optimizeopt/heap.rs quasiimmut_field_still_valid`, all 8 fixtures re-run both
ways:

| fixture | with #956's backstop | backstop disabled |
|---|---|---|
| `exception_reraise_tb_depth_jitstress` | aborted 0→1198, compiled 805→305 | **passes** |
| the other 7 | as reported | unchanged |

So exactly one is #956's quasi-immutable revalidation. Reverting #956 is not
the fix: PyPy aborts 2100× on this same script (`abort: force quasi-immut`), so
firing here is faithful — what pyre lacks is upstream's *primary* mechanism,
`opimpl_jit_force_quasi_immut` (`pyjitpl.py:1104-1118`), which aborts early at
the write instead of letting every event fall through to the optimizer
backstop. `ABORT_FORCE_QUASIIMMUT` is a dead counter in pyre today
(`pyjitpl.rs:15634`, no site raises it). That port is a separate slice.

The other 7 (`closure_freevar_branch_resume`, `exception_args_virtual`,
`exception_multi_handler_warmup`, `list_length_hint_validate`,
`sre_pattern_methods`, `sre_wasm_min`, `sre_wasm_min1`) have a different,
still-unbisected root in the same window.

— *authored by Claude*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of pure calls that return floating-point values, preventing incorrect result folding and ensuring they execute with the appropriate calling convention.
  * Corrected validation for global-loading calls that legitimately omit a namespace value.
  * Preserved error reporting for other calls that provide an invalid null namespace argument.

* **Tests**
  * Added regression coverage for floating-point and integer call results, along with valid and invalid namespace handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->