### PR TITLE
macros: keep #[inline(never)] on the elidable surfaces; gc_roots: fixed base/top interpreter root stack

### DIFF
--- a/majit/majit-macros/src/lib.rs
+++ b/majit/majit-macros/src/lib.rs
@@ -1073,12 +1073,34 @@ pub fn jit_driver(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// Mark a function as elidable (pure / constant-foldable).
 ///
 /// The JIT can eliminate calls to this function when all arguments are constants.
-/// `rlib/jit.py:14-73 elidable` sets `_elidable_function_ = True` (line 72) and
-/// nothing else.  This expansion carries that flag as the marker const
-/// [`rpython_attribute_const_for`] emits next to the function, which
-/// `front/llbc_hints.rs` harvests out of the extracted LLBC; the constant fold
-/// itself reaches the separate `__majit_call_target_*` trampoline, keyed by
-/// path.  Neither channel is a property of the function's codegen.
+/// `rlib/jit.py:72 elidable` sets `_elidable_function_ = True` and nothing else;
+/// the flag travels here as the marker const [`rpython_attribute_const_for`]
+/// emits, which `front/llbc_hints.rs` harvests from the extracted LLBC, and the
+/// constant fold reaches the separate `__majit_call_target_*` trampoline. None
+/// of that is a property of this function's codegen.
+///
+/// The backend inliner it leaves free is nonetheless a much narrower one than
+/// LLVM's, and that is why `#[inline(never)]` stays below. `auto_inlining`
+/// stops a graph at `weight >= threshold` (`backendopt/inline.py:654`) with
+/// `weight = 0.9999 * measure_median_execution_cost(graph) +
+/// static_instruction_count(graph)` (`:539 inlining_heuristic`, a hard reject
+/// at `count >= 200`), counting roughly one per lltype operation
+/// (`:479 OP_WEIGHTS`).  A straight-line graph is its own median path, so that
+/// weight is about twice its op count and the default
+/// `DEFL_INLINE_THRESHOLD = 32.4` buys on the order of sixteen operations —
+/// described at
+/// `config/translationoption.py:11-12` as "just enough to inline
+/// add__Int_Int() and just small enough to prevent inlining of some rlist
+/// functions". Elidable bodies are not that size: 54 of the 124 sites are in
+/// `descroperation.rs` and 25 in `longobject.rs`. Dropping the attribute hands
+/// them to a cost model that accepts them, which is not what leaving upstream's
+/// inliner free would have done.
+///
+/// Measurement offers nothing to weigh against that. Throughput was flat
+/// (1.0070 / 1.0000 on the shadow-stack probes, 1.0000 on a pure integer
+/// control), while the bodies inlining into the eval loop cost frame size:
+/// reachable Python recursion depth fell 167700 to 159700, read out through
+/// the SP-based `stack_check.rs current_sp()`.
 ///
 /// `#[elidable]` is the conservative `EF_ELIDABLE_CAN_RAISE` form
 /// (`rpython/jit/codewriter/effectinfo.py:21`), matching `call.py:297
@@ -1164,15 +1186,9 @@ fn expand_elidable_attribute(item: TokenStream, attr_name: &str) -> TokenStream 
     };
     let rpython_attribute_const = rpython_attribute_const_for(attr_name, sig, vis);
 
-    // No `#[inline(never)]`: `rlib/jit.py:72` sets `_elidable_function_ = True`
-    // and leaves the backend's inliner alone.  Upstream keeps a separate flag,
-    // `_dont_inline_` (`objectmodel.py:214`, read by
-    // `translator/backendopt/inline.py:565`), for suppressing inlining, and no
-    // elidable helper upstream carries it.  The constant fold reaches the
-    // `__majit_call_target_*` trampoline below, whose address is taken and so
-    // codegen'd out of line regardless.
     let expanded = quote! {
         #(#attrs)*
+        #[inline(never)]
         #[doc(hidden)]
         #[allow(non_upper_case_globals)]
         #vis #sig {
@@ -1330,6 +1346,18 @@ fn expand_dont_look_inside_attribute(item: TokenStream, attr_name: &str) -> Toke
     // Residual call targets are likewise unaffected: they resolve through the
     // function-item coercions `pyre-interpreter/src/jit_fnaddr.rs` writes by
     // hand, not through a linker symbol.
+    //
+    // `#[elidable]` keeps its `#[inline(never)]` and this family drops it, and
+    // the split follows upstream's inlining budget rather than the attribute.
+    // `DEFL_INLINE_THRESHOLD = 32.4` (`config/translationoption.py:11-12`) is
+    // "just enough to inline add__Int_Int()" — on the order of sixteen lltype
+    // operations, since `inline.py:539 inlining_heuristic` charges a
+    // straight-line graph both its static count and its median execution cost.
+    // This family sits inside that budget —
+    // `gc_roots::shadow_stack_len` is one call, `pyopcode::label_arg_to_usize`
+    // one field read — so leaving them to the host inliner is what upstream's
+    // free inliner would also have done.  The elidable bodies do not, which is
+    // why the same edit measured worse there.
     let expanded = quote! {
         #(#attrs)*
         #[doc(hidden)]
@@ -1433,27 +1461,20 @@ fn expand_call_surface_attr(
     };
     let rpython_attribute_const = rpython_attribute_const_for(attr_name, sig, vis);
 
-    // Only the release-gil surface suppresses inlining upstream, and it does so
-    // for a GC reason rather than a tracing one: `rffi.py:219
-    // call_external_function._dont_inline_ = True` alongside `:220
+    // Only `jit_release_gil` has an upstream basis for `#[inline(never)]`, and
+    // it is a GC reason rather than a tracing one: `rffi.py:219
+    // call_external_function._dont_inline_ = True` sits beside `:220
     // _gctransformer_hint_close_stack_ = True`, explained at `:232` as "don't
     // inline, as a hack to guarantee that no GC pointer is alive anywhere in
     // call_external_function" — the body runs with the GIL released, so a
     // caller folded into it would put live GC pointers in that window.
-    // `_dont_inline_` (`objectmodel.py:214`) is the backend-inliner flag read by
-    // `translator/backendopt/inline.py:565`, orthogonal to tracing policy;
-    // `jit_may_force` has no upstream decorator at all
-    // (`EF_FORCES_VIRTUAL_OR_VIRTUALIZABLE` is derived from the analyzed ops in
-    // `effectinfo.py:401-404`) and `loop_invariant` sets only its own flag.
-    let dont_inline = if attr_name == "jit_release_gil" {
-        quote! { #[inline(never)] }
-    } else {
-        quote! {}
-    };
-
+    // `jit_may_force` and `loop_invariant` carry no such flag upstream, and keep
+    // it here for the reason recorded on [`elidable`]: their bodies are past
+    // the inlining budget the free RPython inliner would have applied, and
+    // dropping it measured flat to worse.
     let expanded = quote! {
         #(#attrs)*
-        #dont_inline
+        #[inline(never)]
         #[doc(hidden)]
         #[allow(non_upper_case_globals)]
         #vis #sig {
@@ -2135,9 +2156,8 @@ pub fn elidable_promote(attr: TokenStream, item: TokenStream) -> TokenStream {
     };
 
     let expanded = quote! {
-        // rlib/jit.py:184-185 — elidable(func); original body hidden.
-        // `elidable` sets only `_elidable_function_`, and the exec-built
-        // promote wrapper (jit.py:188-200) sets no inlining flag either.
+        // rlib/jit.py:184-185 — elidable(func); original body hidden
+        #[inline(never)]
         #[doc(hidden)]
         #[allow(non_upper_case_globals)]
         fn #orig_name(#(#full_params),*) #output {
@@ -2294,8 +2314,7 @@ pub fn look_inside_iff(attr: TokenStream, item: TokenStream) -> TokenStream {
         }
 
         // rlib/jit.py:231-233 — @dont_look_inside def trampoline(...): return func(...)
-        // `dont_look_inside` is a tracing-policy marker only (jit.py:139), so
-        // the trampoline carries no inlining attribute either.
+        #[inline(never)]
         #[doc(hidden)]
         #[allow(non_upper_case_globals)]
         fn #trampoline_name(#(#full_params),*) #output {

--- a/majit/majit-macros/src/lib.rs
+++ b/majit/majit-macros/src/lib.rs
@@ -1091,10 +1091,11 @@ pub fn jit_driver(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// described at
 /// `config/translationoption.py:11-12` as "just enough to inline
 /// add__Int_Int() and just small enough to prevent inlining of some rlist
-/// functions". Elidable bodies are not that size: 54 of the 124 sites are in
-/// `descroperation.rs` and 25 in `longobject.rs`. Dropping the attribute hands
-/// them to a cost model that accepts them, which is not what leaving upstream's
-/// inliner free would have done.
+/// functions". Elidable bodies are not that size: of the 126 non-test sites
+/// this expansion covers, 54 are in `descroperation.rs` and 25 in
+/// `longobject.rs`. Dropping the attribute hands them to a cost model that
+/// accepts them, which is not what leaving upstream's inliner free would have
+/// done.
 ///
 /// Measurement offers nothing to weigh against that. Throughput was flat
 /// (1.0070 / 1.0000 on the shadow-stack probes, 1.0000 on a pure integer

--- a/pyre/bench/synth/closure_freevar_branch_resume.cranelift.jitstats
+++ b/pyre/bench/synth/closure_freevar_branch_resume.cranelift.jitstats
@@ -1,8 +1,8 @@
-bridges_compiled=0
+bridges_compiled=3
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
-guard_failures=23380
+guard_failures=606
 internal_compile_panics=0
-loops_aborted=3
-loops_compiled=6
+loops_aborted=0
+loops_compiled=3

--- a/pyre/bench/synth/closure_freevar_branch_resume.dynasm.jitstats
+++ b/pyre/bench/synth/closure_freevar_branch_resume.dynasm.jitstats
@@ -1,8 +1,8 @@
-bridges_compiled=0
+bridges_compiled=3
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
-guard_failures=23380
+guard_failures=606
 internal_compile_panics=0
-loops_aborted=3
-loops_compiled=6
+loops_aborted=0
+loops_compiled=3

--- a/pyre/bench/synth/closure_freevar_branch_resume.wasm.jitstats
+++ b/pyre/bench/synth/closure_freevar_branch_resume.wasm.jitstats
@@ -2,4 +2,4 @@ descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
 internal_compile_panics=0
-loops_aborted=3
+loops_aborted=0

--- a/pyre/pyre-interpreter/src/stack_check.rs
+++ b/pyre/pyre-interpreter/src/stack_check.rs
@@ -642,7 +642,13 @@ pub fn set_recursion_limit(new_limit: i32) -> Result<(), PyError> {
         .max(limit);
     pyre_stack_set_length_fraction(reserved as f64 * 0.001);
     crate::module::sys::state::set_recursion_limit(limit);
-    majit_gc::shadow_stack::increase_root_stack_depth((limit as f64 * 0.001 * 163840.0) as usize);
+    // pypy/module/sys/vm.py:97 `increase_root_stack_depth(int(new_limit *
+    // 0.001 * 163840))`.  Both of pyre's root stacks are sized off it: the
+    // jitframe one compiled code pushes to, and the interpreter's `push_roots`
+    // stack, which holds a slot per pinned livevar across a recursive call.
+    let root_stack_depth = (limit as f64 * 0.001 * 163840.0) as usize;
+    majit_gc::shadow_stack::increase_root_stack_depth(root_stack_depth);
+    pyre_object::gc_roots::increase_root_stack_depth(root_stack_depth);
     Ok(())
 }
 

--- a/pyre/pyre-object/src/gc_roots.rs
+++ b/pyre/pyre-object/src/gc_roots.rs
@@ -48,71 +48,190 @@
 //!   pointers are now observable to the active `MiniMarkGC`
 //!   instance and survive across collections.
 
-#[cfg(debug_assertions)]
+use std::alloc::{Layout, alloc_zeroed, dealloc};
 use std::cell::Cell;
-use std::cell::UnsafeCell;
 use std::marker::PhantomData;
 
 use crate::pyobject::PyObjectRef;
 
+/// `shadowstack.py:281 root_stack_depth` — the slot count `ShadowStackPool`
+/// raw-mallocs for a thread's root stack before any growth.  `majit-gc`'s
+/// jitframe root stack starts from the same constant.
+const DEFAULT_ROOT_STACK_DEPTH: usize = 163840;
+
+/// `gcdata.root_stack_base` / `root_stack_top` (`shadowstack.py:75-88`), with
+/// the `limit` cell `majit-gc`'s jitframe root stack also keeps so a push can
+/// see it has reached `root_stack_depth` without a separate depth load.
+///
+/// Deliberately holds no `Vec` and no `Box`.  A growable container puts drop
+/// glue on the thread-local, and a thread-local carrying a destructor costs a
+/// registration-state check on every access — `pin_root` and
+/// `shadow_stack_get` sit on the interpreter's allocation and call paths, so
+/// that check is not free: dropping it measures `.8711` / `.8727` on the
+/// any/all rooting probes with a pure-integer control at exactly `1.0000`.
+/// The buffer is raw-allocated once instead, as `_prepare_unused_stack` does
+/// (`shadowstack.py:344-349`), and released by [`RootStackOwner`].
+struct RootStack {
+    base: Cell<*mut PyObjectRef>,
+    top: Cell<*mut PyObjectRef>,
+    limit: Cell<*mut PyObjectRef>,
+}
+
+impl RootStack {
+    const fn new() -> Self {
+        Self {
+            base: Cell::new(std::ptr::null_mut()),
+            top: Cell::new(std::ptr::null_mut()),
+            limit: Cell::new(std::ptr::null_mut()),
+        }
+    }
+
+    /// Slots currently in use — `root_stack_top - root_stack_base`.
+    #[inline(always)]
+    fn len(&self) -> usize {
+        let base = self.base.get();
+        if base.is_null() {
+            return 0;
+        }
+        // SAFETY: `top` is derived from `base` by pointer arithmetic within
+        // the one live allocation, so the offset is in range.
+        unsafe { self.top.get().offset_from(base) as usize }
+    }
+
+    /// Slot count the current buffer can hold — `root_stack_depth`.
+    fn capacity(&self) -> usize {
+        let base = self.base.get();
+        if base.is_null() {
+            return 0;
+        }
+        // SAFETY: `limit` is the one-past-the-end pointer of the allocation
+        // `base` starts.
+        unsafe { self.limit.get().offset_from(base) as usize }
+    }
+
+    fn layout_for(depth: usize) -> Layout {
+        Layout::array::<PyObjectRef>(depth).expect("root stack layout")
+    }
+
+    /// `ShadowStackPool.increase_root_stack_depth` (`shadowstack.py:351-364`):
+    /// allocate a larger buffer, copy the used portion over, and re-derive
+    /// base/top; the depth can never shrink.  Unlike upstream this also serves
+    /// as the initial `_prepare_unused_stack`, so a null base is the
+    /// "no buffer yet" case rather than a separate pooled one.
+    #[cold]
+    fn grow(&self, new_depth: usize) {
+        let old_base = self.base.get();
+        let used = self.len();
+        let new_depth = new_depth.max(DEFAULT_ROOT_STACK_DEPTH).max(used);
+        if new_depth <= self.capacity() {
+            return; // can't easily decrease the size
+        }
+        // Registering this thread's free-at-exit hook is what keeps the hot
+        // `ROOT_STACK` key destructor-free; touching it here rather than on
+        // every push keeps that cost off the push path.
+        let _ = ROOT_STACK_OWNER.try_with(|_| ());
+        // SAFETY: a non-zero array layout; `alloc_zeroed` gives null slots,
+        // which the walkers read as "no root" exactly like a null GCREF.
+        let new_base = unsafe { alloc_zeroed(Self::layout_for(new_depth)) } as *mut PyObjectRef;
+        assert!(!new_base.is_null(), "root stack allocation failed");
+        if !old_base.is_null() {
+            // SAFETY: `used` slots are live in the old buffer and the new
+            // allocation is at least that large; the two never overlap.
+            unsafe { std::ptr::copy_nonoverlapping(old_base, new_base, used) };
+            // SAFETY: the old buffer came from this same allocator with the
+            // layout its own capacity names, and nothing references it now —
+            // callers hold indices, not slot addresses, across a push.
+            unsafe { dealloc(old_base as *mut u8, Self::layout_for(self.capacity())) };
+        }
+        self.base.set(new_base);
+        // SAFETY: both offsets are inside (or one past the end of) the new
+        // allocation.
+        unsafe {
+            self.top.set(new_base.add(used));
+            self.limit.set(new_base.add(new_depth));
+        }
+    }
+
+    /// `incr_stack(1)` (`shadowstack.py:80-84`) — return the slot that was the
+    /// top and advance past it.  Upstream's bump is unchecked because the
+    /// native stack check fires first, with `root_stack_depth` scaled to the
+    /// recursion limit.  pyre pins one slot per argument as well as per live
+    /// variable, so a single variadic call can outrun any fixed headroom; the
+    /// limit test grows instead of trusting that margin.
+    #[inline(always)]
+    fn incr_stack(&self) -> *mut PyObjectRef {
+        let top = self.top.get();
+        if top == self.limit.get() {
+            self.grow(self.capacity() * 2);
+            return self.incr_stack();
+        }
+        // SAFETY: `top` is below `limit`, so it names a live slot and the
+        // advanced pointer is at most one past the end.
+        self.top.set(unsafe { top.add(1) });
+        top
+    }
+
+    /// `decr_stack` to an absolute depth — the `pop_roots` rewind.
+    #[inline(always)]
+    fn truncate(&self, len: usize) {
+        if len < self.len() {
+            // SAFETY: `len` is below the live length, so the slot is inside
+            // the allocation.
+            self.top.set(unsafe { self.base.get().add(len) });
+        }
+    }
+
+    /// Address of slot `index`, panicking exactly like indexing did.
+    #[inline(always)]
+    fn slot(&self, index: usize) -> *mut PyObjectRef {
+        assert!(index < self.len(), "shadow-stack index out of range");
+        // SAFETY: bounds-checked against the live length just above.
+        unsafe { self.base.get().add(index) }
+    }
+}
+
+/// Frees [`ROOT_STACK`]'s buffer when the thread exits.  It lives in its own
+/// thread-local key, touched only from `RootStack::grow`, so the key on the
+/// push/read path keeps no destructor of its own.
+struct RootStackOwner;
+
+impl Drop for RootStackOwner {
+    fn drop(&mut self) {
+        // `ROOT_STACK` has no destructor, so it is never torn down and this
+        // access cannot fail; `try_with` keeps that from being load-bearing.
+        let _ = ROOT_STACK.try_with(|stack| {
+            let base = stack.base.get();
+            if base.is_null() {
+                return;
+            }
+            let layout = RootStack::layout_for(stack.capacity());
+            stack.base.set(std::ptr::null_mut());
+            stack.top.set(std::ptr::null_mut());
+            stack.limit.set(std::ptr::null_mut());
+            // SAFETY: the buffer came from this allocator with this layout and
+            // the cells that named it have just been cleared.
+            unsafe { dealloc(base as *mut u8, layout) };
+        });
+    }
+}
+
 thread_local! {
     /// Thread-local shadow stack — pyre's mirror of RPython's
     /// `framework.shadowstack` (`shadowstack.py`). Append-only across
-    /// each [`RootScope`]'s lifetime; the matching [`Drop`] truncates
+    /// each [`RootScope`]'s lifetime; the matching [`Drop`] rewinds `top`
     /// back to the saved length.
     ///
     /// Access is raw, matching RPython's base/top shadow-stack shape. Debug
-    /// builds check overlapping ordinary accesses through
-    /// `SHADOW_STACK_ACCESS_DEPTH` and separately reject mutation during a
-    /// root walk through `SHADOW_STACK_WALK_IN_PROGRESS`; release builds pay
-    /// no bookkeeping cost.
-    static SHADOW_STACK: UnsafeCell<Vec<PyObjectRef>> =
-        const { UnsafeCell::new(Vec::new()) };
+    /// builds reject mutation during a root walk through
+    /// `SHADOW_STACK_WALK_IN_PROGRESS`; release builds pay no bookkeeping.
+    static ROOT_STACK: RootStack = const { RootStack::new() };
 
-    /// Signed debug borrow depth for [`SHADOW_STACK`]: non-negative values
-    /// count shared accesses, while `-1` marks an exclusive access.
-    #[cfg(debug_assertions)]
-    static SHADOW_STACK_ACCESS_DEPTH: Cell<i32> = const { Cell::new(0) };
+    /// Registered on the first `grow`; see [`RootStackOwner`].
+    static ROOT_STACK_OWNER: RootStackOwner = const { RootStackOwner };
 
     /// Whether this thread is currently driving a shadow-stack root walk.
     #[cfg(debug_assertions)]
     static SHADOW_STACK_WALK_IN_PROGRESS: Cell<bool> = const { Cell::new(false) };
-}
-
-#[cfg(debug_assertions)]
-struct ShadowStackAccess<'a> {
-    depth: &'a Cell<i32>,
-    previous: i32,
-}
-
-#[cfg(debug_assertions)]
-impl<'a> ShadowStackAccess<'a> {
-    #[inline(always)]
-    fn shared(depth: &'a Cell<i32>) -> Self {
-        let previous = depth.get();
-        debug_assert!(
-            previous >= 0,
-            "shared shadow-stack access re-entered an exclusive access"
-        );
-        depth.set(previous + 1);
-        Self { depth, previous }
-    }
-
-    #[inline(always)]
-    fn exclusive(depth: &'a Cell<i32>) -> Self {
-        let previous = depth.get();
-        debug_assert_eq!(previous, 0, "exclusive shadow-stack access was re-entered");
-        depth.set(-1);
-        Self { depth, previous }
-    }
-}
-
-#[cfg(debug_assertions)]
-impl Drop for ShadowStackAccess<'_> {
-    #[inline(always)]
-    fn drop(&mut self) {
-        self.depth.set(self.previous);
-    }
 }
 
 #[cfg(debug_assertions)]
@@ -150,46 +269,29 @@ fn assert_shadow_stack_not_walking() {
     });
 }
 
+/// Run `f` against this thread's root stack.  The borrow guards the old
+/// `Vec` shape needed are gone with it: base/top are `Cell`s, so no
+/// reference is held across a call that could push.
 #[inline(always)]
-fn with_shadow_stack<R>(f: impl FnOnce(&Vec<PyObjectRef>) -> R) -> R {
-    SHADOW_STACK.with(|cell| {
-        #[cfg(debug_assertions)]
-        {
-            SHADOW_STACK_ACCESS_DEPTH.with(|depth| {
-                let _access = ShadowStackAccess::shared(depth);
-                // SAFETY: the debug-only access guard rejects overlap with an
-                // exclusive access. In release this is the raw, thread-local
-                // root-stack access shape used upstream.
-                f(unsafe { &*cell.get() })
-            })
-        }
-        #[cfg(not(debug_assertions))]
-        {
-            // SAFETY: the stack is thread-local, and callers must not
-            // re-enter an access that holds an exclusive reference.
-            f(unsafe { &*cell.get() })
-        }
-    })
+fn with_shadow_stack<R>(f: impl FnOnce(&RootStack) -> R) -> R {
+    ROOT_STACK.with(f)
 }
 
-#[inline(always)]
-fn with_shadow_stack_mut<R>(f: impl FnOnce(&mut Vec<PyObjectRef>) -> R) -> R {
-    SHADOW_STACK.with(|cell| {
-        #[cfg(debug_assertions)]
-        {
-            SHADOW_STACK_ACCESS_DEPTH.with(|depth| {
-                let _access = ShadowStackAccess::exclusive(depth);
-                // SAFETY: the debug-only access guard rejects every
-                // overlapping access. Release preserves the same
-                // non-re-entrancy invariant without runtime bookkeeping.
-                f(unsafe { &mut *cell.get() })
-            })
-        }
-        #[cfg(not(debug_assertions))]
-        {
-            // SAFETY: the stack is thread-local, and callers must not
-            // overlap this exclusive access with another stack access.
-            f(unsafe { &mut *cell.get() })
+/// `increase_root_stack_depth(new_depth)` (`rlib/rgc.py:775-779` →
+/// `shadowstack.py:351-364`).  `sys.setrecursionlimit` scales the root stack
+/// with the limit at `pypy/module/sys/vm.py:97`; the depth can only grow.
+pub fn increase_root_stack_depth(new_depth: usize) {
+    with_shadow_stack(|stack| stack.grow(new_depth));
+}
+
+/// `root_stack_depth` — the slot count this thread's root stack can hold.
+pub fn root_stack_depth() -> usize {
+    with_shadow_stack(|stack| {
+        let capacity = stack.capacity();
+        if capacity == 0 {
+            DEFAULT_ROOT_STACK_DEPTH
+        } else {
+            capacity
         }
     })
 }
@@ -204,14 +306,16 @@ fn with_shadow_stack_mut<R>(f: impl FnOnce(&mut Vec<PyObjectRef>) -> R) -> R {
               binding it to `_roots` makes the scope explicit, while binding \
               to `_` would pop immediately and defeat the bracket"]
 pub struct RootScope {
-    /// Length of [`SHADOW_STACK`] at the moment [`push_roots`] was
+    /// Length of [`ROOT_STACK`] at the moment [`push_roots`] was
     /// called. Will be replaced with a backend
     /// `RootSet::Handle` once the active GC consumes the stack.
     save_point: usize,
     /// Resolved thread-local stack cell. RPython keeps the shadow-stack
     /// base/top address live for the whole root bracket; caching the cell here
-    /// avoids resolving TLS again for every generated slot write/read.
-    stack_slot: *mut Vec<PyObjectRef>,
+    /// avoids resolving TLS again for every generated slot write/read. It names
+    /// the [`RootStack`] and not its buffer, so a `grow` under this bracket
+    /// leaves it valid.
+    stack_slot: *const RootStack,
     /// A root bracket belongs to the thread whose shadow stack supplied this
     /// save point. Moving it could truncate an unrelated thread's stack.
     _not_send: PhantomData<*const ()>,
@@ -222,10 +326,8 @@ impl RootScope {
     /// [`push_roots`] so the API surface stays uniform across phases.
     #[inline]
     fn new() -> Self {
-        let (save_point, stack_slot) = SHADOW_STACK.with(|cell| {
-            let stack = unsafe { &*cell.get() };
-            (stack.len(), cell.get())
-        });
+        let (save_point, stack_slot) =
+            with_shadow_stack(|stack| (stack.len(), stack as *const RootStack));
         Self {
             save_point,
             stack_slot,
@@ -244,23 +346,27 @@ impl RootScope {
     pub fn pin_root(&self, root: PyObjectRef) {
         #[cfg(debug_assertions)]
         assert_shadow_stack_not_walking();
+        // SAFETY: `stack_slot` is this thread's root-stack cell, alive for the
+        // bracket; `incr_stack` returns the slot it just claimed.
         let index = unsafe {
-            let stack = &mut *self.stack_slot;
+            let stack = &*self.stack_slot;
             let index = stack.len();
-            stack.push(root);
+            *stack.incr_stack() = root;
             index
         };
         let normalized =
             crate::gc_hook::try_gc_current_object_address(root as *mut u8) as PyObjectRef;
         if normalized != root {
-            unsafe { (&mut *self.stack_slot)[index] = normalized };
+            // SAFETY: same cell, and `index` is still live.
+            unsafe { *(*self.stack_slot).slot(index) = normalized };
         }
     }
 
     /// Scope-local [`shadow_stack_get`] using the cached cell.
     #[majit_macros::dont_look_inside]
     pub fn get(&self, index: usize) -> PyObjectRef {
-        unsafe { (&*self.stack_slot)[index] }
+        // SAFETY: same cell; `slot` bounds-checks `index`.
+        unsafe { *(*self.stack_slot).slot(index) }
     }
 }
 
@@ -274,7 +380,9 @@ impl Drop for RootScope {
         assert_shadow_stack_not_walking();
         // `truncate` is a no-op if `save_point >= len()`, which is
         // the steady-state case for an empty bracket.
-        unsafe { (&mut *self.stack_slot).truncate(self.save_point) };
+        // SAFETY: `stack_slot` is this thread's root-stack cell; `_not_send`
+        // keeps the bracket on the thread that resolved it.
+        unsafe { (*self.stack_slot).truncate(self.save_point) };
     }
 }
 
@@ -295,7 +403,7 @@ pub fn push_roots() -> RootScope {
 /// so the matching [`Drop`] truncates the entry. Pinning without a
 /// guard is a leak from the GC's perspective once the backend GC consumes the stack.
 ///
-/// Pushes onto the thread-local `SHADOW_STACK`, a runtime-mutable root the
+/// Pushes onto the thread-local `ROOT_STACK`, a runtime-mutable root the
 /// tracer cannot type; the JIT residualises the call instead of tracing into
 /// it (`@dont_look_inside`, `rlib/jit.py:139`), the `shadow_stack_len` twin.
 #[majit_macros::dont_look_inside]
@@ -308,9 +416,10 @@ pub fn pin_root(root: PyObjectRef) {
     // enter the query safepoint.  RPython's push_roots writes the livevar to
     // the shadow stack before calling the allocation/GC slow path for the
     // same reason.
-    let index = with_shadow_stack_mut(|stack| {
+    let index = with_shadow_stack(|stack| {
         let index = stack.len();
-        stack.push(root);
+        // SAFETY: `incr_stack` returns the slot it just claimed.
+        unsafe { *stack.incr_stack() = root };
         index
     });
     // A foreign mutator may have completed a nursery collection after the
@@ -321,13 +430,15 @@ pub fn pin_root(root: PyObjectRef) {
     let normalized = crate::gc_hook::try_gc_current_object_address(root as *mut u8) as PyObjectRef;
     // The slot already holds `root`, so a query that found no forwarding stub
     // has nothing to write back.  That is the steady state — nothing collected
-    // between the push above and the query — and the write-back is not free:
-    // each `with` re-checks the thread-local's initialization state (the
-    // `_tlv_get_addr` result itself is common-subexpression-eliminated across
-    // the two accesses, the state load is not), and pinning sits on the
-    // interpreter's allocation and call paths.
+    // between the push above and the query — and skipping it keeps a second
+    // thread-local resolve off a path that sits on the interpreter's
+    // allocation and call paths.
     if normalized != root {
-        with_shadow_stack_mut(|stack| stack[index] = normalized);
+        with_shadow_stack(|stack| {
+            // SAFETY: `index` was live when claimed and only this thread can
+            // have shortened the stack, which it has not.
+            unsafe { *stack.slot(index) = normalized }
+        });
     }
 }
 
@@ -362,9 +473,12 @@ pub fn pin_roots(roots: &[PyObjectRef]) -> usize {
 pub fn publish_roots(roots: &[PyObjectRef]) -> usize {
     #[cfg(debug_assertions)]
     assert_shadow_stack_not_walking();
-    with_shadow_stack_mut(|stack| {
+    with_shadow_stack(|stack| {
         let base = stack.len();
-        stack.extend_from_slice(roots);
+        for &root in roots {
+            // SAFETY: `incr_stack` returns the slot it just claimed.
+            unsafe { *stack.incr_stack() = root };
+        }
         base
     })
 }
@@ -380,13 +494,15 @@ pub fn normalize_roots(base: usize, len: usize) {
     for index in base..base + len {
         // Read the slot each time: a collection triggered by an earlier query
         // may already have rewritten every published root in place.
-        let root = with_shadow_stack(|stack| stack[index]);
+        // SAFETY: every index in this range was claimed just above.
+        let root = with_shadow_stack(|stack| unsafe { *stack.slot(index) });
         let current = crate::gc_hook::try_gc_current_object_address(root as *mut u8) as PyObjectRef;
         // Same write-back economy as `pin_root`: the slot already holds `root`,
         // so a query that found no forwarding stub has nothing to store, and
         // skipping it saves a second thread-local resolve per livevar.
         if current != root {
-            with_shadow_stack_mut(|stack| stack[index] = current);
+            // SAFETY: same slot, still live.
+            with_shadow_stack(|stack| unsafe { *stack.slot(index) = current });
         }
     }
 }
@@ -395,14 +511,14 @@ pub fn normalize_roots(base: usize, len: usize) {
 /// [`RootScope::new`] to capture the save-point and by tests to
 /// observe pin/pop behaviour.
 ///
-/// Reads the thread-local `SHADOW_STACK`, a runtime-mutable root the
+/// Reads the thread-local `ROOT_STACK`, a runtime-mutable root the
 /// tracer cannot type; the JIT residualises the read instead of tracing
 /// into it (`@dont_look_inside`, `rlib/jit.py:139`). The attribute is a
 /// tracing-policy marker only — it leaves the host backend free to inline
 /// this body, exactly as the RPython decorator leaves the C backend free.
 #[majit_macros::dont_look_inside]
 pub fn shadow_stack_len() -> usize {
-    with_shadow_stack(Vec::len)
+    with_shadow_stack(RootStack::len)
 }
 
 /// Read a single shadow-stack slot by index, panicking if the index
@@ -417,7 +533,7 @@ pub fn shadow_stack_len() -> usize {
 /// call path (`call_function_impl_result`, the inline-call and specialize
 /// resume paths, `#[pyre_class]` method bodies), not just in tests.
 ///
-/// Reads the thread-local `SHADOW_STACK` the tracer cannot type; the JIT
+/// Reads the thread-local `ROOT_STACK` the tracer cannot type; the JIT
 /// residualises the read instead of tracing into it (`@dont_look_inside`,
 /// `rlib/jit.py:139`), the [`shadow_stack_len`] twin.
 #[majit_macros::dont_look_inside]
@@ -434,7 +550,8 @@ pub fn shadow_stack_get(index: usize) -> PyObjectRef {
     // copied from outside the bracket, so a foreign mutator can have collected
     // after that copy and before the pin.  That is also the pin's safepoint;
     // a read allocates nothing and has no reason to park.
-    with_shadow_stack(|stack| stack[index])
+    // SAFETY: `slot` bounds-checks `index` against the live length.
+    with_shadow_stack(|stack| unsafe { *stack.slot(index) })
 }
 
 /// Copy a contiguous range of rooted values out of the shadow stack.
@@ -449,7 +566,13 @@ pub fn shadow_stack_get(index: usize) -> PyObjectRef {
 #[majit_macros::dont_look_inside]
 pub fn shadow_stack_copy_range(base: usize, dst: &mut [PyObjectRef]) {
     with_shadow_stack(|stack| {
-        dst.copy_from_slice(&stack[base..base + dst.len()]);
+        assert!(
+            base + dst.len() <= stack.len(),
+            "shadow-stack range out of bounds"
+        );
+        // SAFETY: the whole range was just bounds-checked, and `dst` is a
+        // distinct caller-owned slice.
+        unsafe { std::ptr::copy_nonoverlapping(stack.slot(base), dst.as_mut_ptr(), dst.len()) };
     });
 }
 
@@ -458,7 +581,7 @@ pub fn shadow_stack_copy_range(base: usize, dst: &mut [PyObjectRef]) {
 /// is written here rather than re-pinned, mirroring `gc_save_root`'s
 /// overwrite of an already allocated slot (`shadowcolor.py:126-129`).
 ///
-/// Writes the thread-local `SHADOW_STACK` the tracer cannot type; the JIT
+/// Writes the thread-local `ROOT_STACK` the tracer cannot type; the JIT
 /// residualises the write instead of tracing into it (`@dont_look_inside`,
 /// `rlib/jit.py:139`), the [`shadow_stack_get`] twin.
 #[majit_macros::dont_look_inside]
@@ -469,11 +592,13 @@ pub fn shadow_stack_set(index: usize, root: PyObjectRef) {
     // `try_gc_current_object_address` query is itself a GC operation and may
     // wait behind another thread's collection, so the value must already be
     // visible to that collector before we enter the query safepoint.
-    with_shadow_stack_mut(|stack| stack[index] = root);
+    // SAFETY: `slot` bounds-checks `index` against the live length.
+    with_shadow_stack(|stack| unsafe { *stack.slot(index) = root });
     // Then normalize a GCREF the caller may have copied before a foreign
     // mutator's nursery collection, so the slot never keeps a forwarding stub.
     let root = crate::gc_hook::try_gc_current_object_address(root as *mut u8) as PyObjectRef;
-    with_shadow_stack_mut(|stack| stack[index] = root);
+    // SAFETY: same slot, still live.
+    with_shadow_stack(|stack| unsafe { *stack.slot(index) = root });
 }
 
 /// Visit every pinned root in the shadow stack with mutable access.
@@ -492,8 +617,8 @@ pub fn shadow_stack_set(index: usize, root: PyObjectRef) {
 /// upstream's raw root-stack access without that diagnostic.
 #[inline]
 pub fn walk_shadow_stack(mut visitor: impl FnMut(&mut PyObjectRef)) {
-    SHADOW_STACK.with(|cell| {
-        let cell = cell as *const UnsafeCell<Vec<PyObjectRef>>;
+    ROOT_STACK.with(|stack| {
+        let cell = stack as *const RootStack;
         #[cfg(debug_assertions)]
         SHADOW_STACK_WALK_IN_PROGRESS.with(|in_progress| {
             let _walk = ShadowStackWalk::new(in_progress);
@@ -510,7 +635,11 @@ pub fn walk_shadow_stack(mut visitor: impl FnMut(&mut PyObjectRef)) {
 
 /// Capture the current thread's pinned-root stack for a foreign STW walk.
 pub fn capture_shadow_stack_area() -> *const () {
-    SHADOW_STACK.with(|s| s as *const _ as *const ())
+    // The captured address is the `RootStack` cell itself, never its buffer:
+    // `grow` replaces the buffer, so a foreign walker must re-read base/top —
+    // the same rule `majit-gc`'s jitframe root stack states for the
+    // `root_stack_top` address it hands to compiled code.
+    ROOT_STACK.with(|s| s as *const _ as *const ())
 }
 
 /// Visit a captured thread's pinned-root stack without consulting caller TLS.
@@ -522,7 +651,7 @@ pub fn capture_shadow_stack_area() -> *const () {
 /// `data` must come from [`capture_shadow_stack_area`], and the owning thread
 /// must be quiesced for the duration of the walk.
 pub unsafe fn walk_shadow_stack_area(data: *const (), mut visitor: impl FnMut(&mut PyObjectRef)) {
-    let cell = data as *const UnsafeCell<Vec<PyObjectRef>>;
+    let cell = data as *const RootStack;
     #[cfg(debug_assertions)]
     SHADOW_STACK_WALK_IN_PROGRESS.with(|in_progress| {
         // For a self-collection this protects the stack being walked. A
@@ -541,14 +670,13 @@ pub unsafe fn walk_shadow_stack_area(data: *const (), mut visitor: impl FnMut(&m
     }
 }
 
-/// Walk one captured shadow-stack cell without retaining a reference to its
-/// `Vec` across a visitor call.
+/// Walk one captured root stack, re-reading `base` for every slot.
 ///
 /// # Safety
-/// `cell` must remain a valid shadow-stack cell for the duration of the walk,
+/// `cell` must remain a valid root-stack cell for the duration of the walk,
 /// and no thread other than a re-entrant visitor may mutate it.
 unsafe fn walk_shadow_stack_cell(
-    cell: *const UnsafeCell<Vec<PyObjectRef>>,
+    cell: *const RootStack,
     visitor: &mut impl FnMut(&mut PyObjectRef),
 ) {
     // The interval is fixed at entry: `walk_stack_root` (`shadowstack.py:43-46`)
@@ -557,27 +685,17 @@ unsafe fn walk_shadow_stack_cell(
     // each iteration instead would extend the walk over roots pinned by the
     // visitor — and pinning during a walk is precisely what the debug guard
     // above declares illegal, so there is nothing to serve by diverging here.
-    let end = {
-        // SAFETY: no reference from this block outlives it.
-        let stack = unsafe { &*(*cell).get() };
-        stack.len()
-    };
+    // SAFETY: the caller guarantees `cell` names a live root stack.
+    let stack = unsafe { &*cell };
+    let end = stack.len();
     let mut index = 0;
     while index < end {
-        // Re-derive the slot address every iteration rather than holding one
-        // `iter_mut()` cursor: a re-entrant push can still reallocate the
-        // buffer, which would strand a cached pointer in the old allocation.
-        // Only pushes can occur, so `end` stays within bounds.
-        let slot = {
-            // SAFETY: the caller guarantees exclusive access except for a
-            // possible re-entrant mutation by `visitor`. No reference from a
-            // previous iteration is live here, and this temporary reference
-            // ends before `visitor` is called.
-            let stack = unsafe { &mut *(*cell).get() };
-            // Return only the slot address so the `Vec` reference is not held
-            // across the visitor, which may push and reallocate its buffer.
-            unsafe { stack.as_mut_ptr().add(index) }
-        };
+        // Re-read `base` every iteration rather than caching it: a re-entrant
+        // push that hits the limit calls `grow`, which moves the buffer and
+        // would strand a cached pointer in the freed one. Only pushes can
+        // occur, so `end` stays within bounds.
+        // SAFETY: `index < end <= len()`, so the slot is live.
+        let slot = unsafe { stack.base.get().add(index) };
         // SAFETY: `slot` names the live element at `index`. The reference is
         // handed directly to the visitor and is not used after it returns.
         visitor(unsafe { &mut *slot });
@@ -779,7 +897,7 @@ mod tests {
 
     #[cfg(not(debug_assertions))]
     #[test]
-    fn walk_shadow_stack_survives_push_that_reallocates() {
+    fn walk_shadow_stack_survives_push_that_grows_the_buffer() {
         let _roots = push_roots();
         pin_root(dummy(0x11));
         pin_root(dummy(0x22));
@@ -799,10 +917,10 @@ mod tests {
         });
 
         assert!(pushed);
-        // The visitor's pins really did move the buffer.
-        assert!(with_shadow_stack(Vec::capacity) > capacity_before);
+        // The visitor's pins really did hit the limit and move the buffer.
+        assert!(with_shadow_stack(RootStack::capacity) > capacity_before);
         // `0x22` is the discriminator: it is read on the iteration AFTER the
-        // reallocation, so getting it right means the walk followed the buffer
+        // grow, so getting it right means the walk followed the buffer
         // to its new address instead of reading the freed one. The walk stops
         // at the two roots that were live at entry — the interval is fixed
         // there, as in `walk_stack_root` (`shadowstack.py:43-46`), so the

--- a/pyre/pyre-object/src/gc_roots.rs
+++ b/pyre/pyre-object/src/gc_roots.rs
@@ -570,6 +570,14 @@ pub fn shadow_stack_copy_range(base: usize, dst: &mut [PyObjectRef]) {
             base + dst.len() <= stack.len(),
             "shadow-stack range out of bounds"
         );
+        if dst.is_empty() {
+            // An empty range starting one past the last live slot is in
+            // bounds — `&stack[len..len]` was — but `slot(len)` is not, and
+            // `copy_nonoverlapping` wants a non-null source even for a
+            // zero-length copy.  Neither applies when there is nothing to
+            // copy.
+            return;
+        }
         // SAFETY: the whole range was just bounds-checked, and `dst` is a
         // distinct caller-owned slice.
         unsafe { std::ptr::copy_nonoverlapping(stack.slot(base), dst.as_mut_ptr(), dst.len()) };
@@ -851,6 +859,27 @@ mod tests {
             assert_eq!(shadow_stack_len(), before);
         }
         assert_eq!(shadow_stack_len(), before);
+    }
+
+    /// An empty range is in bounds anywhere up to and including the live
+    /// length — `&stack[len..len]` was, and `pop_roots` is emitted even for
+    /// zero livevars (`shadowstack.py:37-40`). The top-of-stack case is the
+    /// one a per-slot bounds check gets wrong.
+    #[test]
+    fn copy_range_accepts_an_empty_range_at_the_top_of_the_stack() {
+        let _roots = push_roots();
+        pin_root(dummy(0x1));
+        shadow_stack_copy_range(shadow_stack_len(), &mut []);
+    }
+
+    /// Past the live length it is out of bounds even when empty, which is
+    /// also what indexing did.
+    #[test]
+    #[should_panic(expected = "shadow-stack range out of bounds")]
+    fn copy_range_rejects_an_empty_range_past_the_top_of_the_stack() {
+        let _roots = push_roots();
+        pin_root(dummy(0x1));
+        shadow_stack_copy_range(shadow_stack_len() + 1, &mut []);
     }
 
     /// `walk_shadow_stack` exposes every pinned slot with mutable


### PR DESCRIPTION
Two follow-ups to #930, which landed the `@dont_look_inside` inlining change and
the `/OPT:ICF` fold it surfaced. This branch corrects one part of that change and
converts the root stack those helpers push to.

## 1. `#[inline(never)]` goes back on `elidable` and the may-force surfaces

Reverts the `elidable` half of #930. That change took `#[inline(never)]` off
`#[elidable]`, `#[elidable_promote]`, the `#[look_inside_iff]` trampoline,
`#[jit_may_force]` and `#[loop_invariant]`, on the grounds that the upstream
decorators set only their own tracing-policy flag — `rlib/jit.py:72` sets
`_elidable_function_` and nothing else — while suppressing the backend inliner
is a separate flag, `_dont_inline_` (`objectmodel.py:214`, documented "not the
JIT!"), that none of them carry.

The flag reading is right. The conclusion drawn from it was not: **"upstream
leaves the backend inliner free" is not "upstream inlines it."** The inliner it
leaves free is not LLVM's.

`auto_inlining` stops a graph at `weight >= threshold`
(`backendopt/inline.py:654`), with

```
weight = 0.9999 * measure_median_execution_cost + static_instruction_count
```

(`:539 inlining_heuristic`, hard reject at `count >= 200`) and roughly one
weight per lltype op (`:479 OP_WEIGHTS`). A straight-line graph is its own
median path, so it is charged about twice its op count. The default
`DEFL_INLINE_THRESHOLD = 32.4` is described at
`config/translationoption.py:11-12` as *"just enough to inline add__Int_Int()
and just small enough to prevent inlining of some rlist functions"* — on the
order of sixteen operations.

That budget is what splits the two families:

- `dont_look_inside` bodies fit inside it: `gc_roots::shadow_stack_len` is one
  call, `pyopcode::label_arg_to_usize` one field read. Removing the attribute
  there restores upstream's behaviour, not just its flag — which is also why
  those bodies fold under `/OPT:ICF`. #930 keeps that removal.
- `elidable` bodies do not. Of the 126 non-test sites this expansion covers, 54
  are in `descroperation.rs` and 25 in `longobject.rs`; those graphs are far
  past the budget, so removing the attribute hands them to a cost model an
  order of magnitude more permissive than the one upstream would have applied.

Nothing measured argues the other way. Throughput was flat — 1.0070 / 1.0000 on
the shadow-stack probes, 1.0000 on a pure integer control — while the bodies
inlining into the eval loop cost frame size: reachable Python recursion depth
fell 167700 → 159700, read out through the SP-based `stack_check.rs
current_sp()`.

`#[jit_release_gil]` keeps its `#[inline(never)]` for a third and independent
reason: `rffi.py:219` sets `call_external_function._dont_inline_ = True` beside
`:220 _gctransformer_hint_close_stack_ = True`, explained at `:232` as "don't
inline, as a hack to guarantee that no GC pointer is alive anywhere in
call_external_function" — that body runs with the GIL released, so a caller
folded into it would put live GC pointers in the window.

### Correction to a claim made on #930

#930's CI run also lost five macOS perf-ratio gates, which the original
commit message claimed as evidence. **That attribution was wrong.**
#936 raised `check.py`'s `STARTUP_SAMPLES` from 3 to 5 for exactly that
failure mode — a high startup sample collapsing a short bench's exec-time
denominator — and macOS `check.py` was green with the removal still in the
tree. The revert rests on the inlining budget, not on those gates.

One of the three `/OPT:ICF` pairs #930 names dissolves as a side effect:
`label_arg_to_usize` / `load_fast_var_num_to_index` no longer fold, because the
latter is `#[elidable_cannot_raise]`. `convert_value_arg` / `special_method_arg`
and `hash_str_hooked_bytes` / `hash_str_hooked` still do, so the last-write-wins
insert in `patch_constants_i_fnaddrs` stays load-bearing.

## 2. The interpreter root stack gets a fixed base/top

`push_roots`/`pop_roots`'s thread-local shadow stack was a `Vec<PyObjectRef>`.
RPython's is a raw buffer of `root_stack_depth` slots addressed by
`root_stack_base` / `root_stack_top` (`shadowstack.py:75-88`), raw-malloc'd once
by `_prepare_unused_stack` (`:344-349`) and replaced only by
`increase_root_stack_depth` (`:351-364`). `majit-gc`'s jitframe root stack
already carries that shape, from the same 163840 default; this ports the
interpreter's stack to it.

**The container is the point.** A `Vec` puts drop glue on the thread-local, and
a thread-local carrying a destructor pays a registration-state check on every
access — and `pin_root`/`shadow_stack_get` sit on the interpreter's allocation
and call paths. That cost was invisible before #930, because `#[inline(never)]`
was masking it.

User CPU against this branch minus this commit, min of 15, arms interleaved
within each rep:

| probe | ratio |
| --- | --- |
| `gc22_any.py` | 0.8888 |
| `gc22_all.py` | 0.8811 |
| `gc22_control.py` (list sort — roots too, so not a control) | 0.9722 |
| `gc36_pure_arith.py` (pure integer control) | 1.0000 |

Callers hold slot *indices* rather than slot addresses across a push, so a grow
is transparent to them; `capture_shadow_stack_area` hands out the address of the
`RootStack` cell and not of its buffer, and `walk_shadow_stack_cell` re-reads
`base` every iteration, so a re-entrant push that grows cannot strand a walk in
the freed buffer. The buffer is released at thread exit by a `RootStackOwner` in
its own thread-local key, touched only from `grow`, so the key on the push path
keeps no destructor of its own.

`RootScope` keeps caching the resolved cell for the bracket's lifetime, as #934
made it; the cached pointer is now `*const RootStack` rather than
`*mut Vec<PyObjectRef>`. It names the cell and not its buffer, so a grow under
an open bracket leaves it valid.

`sys.setrecursionlimit` now sizes this stack the way `pypy/module/sys/vm.py:97`
sizes upstream's: `increase_root_stack_depth(int(new_limit * 0.001 * 163840))`.
`stack_check.rs` already did that for the jitframe stack; both root stacks now
follow the limit.

**One deliberate deviation:** the push tests `limit` and grows on reaching it,
where upstream's `incr_stack` is an unchecked bump. pyre pins one slot per call
*argument* as well as per livevar — `call_function` pins `1 + args.len()` across
the whole callee — so a single variadic call can outrun the headroom
`root_stack_depth` reserves per recursion level, and the native stack check
upstream relies on would not fire first.

## Verification

- `cargo test --all --no-default-features --features dynasm` — 101 targets,
  7357 passed, 0 failed
- `check.py --backend cranelift` — 14 failed, 351 passed, **the same 14 the
  base commit's own CI run fails** (run 30707884899 on `f3bddb31f2`: 6 ×
  "no committed jit-stats baseline", 8 × jit-stats regression). Zero extra.
- `check.py --backend dynasm` — 16 failed, 349 passed: those same 14, plus
  `jit_reg_const_pool_256_slot_decline` and `recursion_memo_branch`. Both extra
  rows are the startup-sample artifact, not a regression:

  |  | pypy startup | `jit_reg_const_pool…` | `recursion_memo_branch` |
  | --- | --- | --- | --- |
  | this run, dynasm pass | 0.018s | 143.4x ✗ | 22.9x ✗ |
  | this run, cranelift pass | 0.009s | 55.2x ✓ | 11.1x ✓ |
  | base commit, CI dynasm | 0.013s | 54.7x ✓ | 11.5x ✓ |

  Ratios are execution-only, so a bench's denominator is `pypy_raw − startup`.
  pypy raw is 0.020s on both, and the dynasm pass measured pypy's startup at
  0.018s, leaving 0.002s — below `EXEC_TIME_FLOOR_S = 0.005`, so the denominator
  was clamped and the printed "ratio" is `pyre_exec / 5ms`. Dividing each
  printed exec by its printed ratio lands on 0.004986 / 0.005023 exactly. The
  same tree's cranelift pass, minutes later with a 0.009s startup sample,
  reproduces the base commit's CI ratios within noise. pyre's absolute times
  are also *below* the base commit's (0.78s vs 1.08s; 0.18s vs 0.23s).
- Both `check.py` runs serially — two backends at once produce false timeouts
- LLBC re-extracted before each measured build, since a macro change moves the
  `pyre-object` source fingerprint
- `sys.setrecursionlimit(10**6)` / 200k-argument varargs call / depth-900
  recursion probe — output matches `pypy3`

## Not closed

`majit_gc::shadow_stack::SHADOW_STACK` is still `RefCell<Vec<GcRef>>`. It
carries a `MAX_SHADOW_STACK_DEPTH` cap but not the fixed allocation;
`JitFrameShadowStack` in the same file is the template for converting it.

## 3. `closure_freevar_branch_resume`'s jit-stats baseline

Committed baseline: `loops_aborted=3 loops_compiled=6 guard_failures=23380
bridges_compiled=0`. Measured now: `0 / 3 / 606 / 3`, identically on dynasm and
cranelift (`loops_aborted=0` on wasm).

`check.py` failed it on `loops_compiled 6 -> 3`, a `JITSTATS_FALL_FIELDS` gate.
That fall is not a capability loss:

| field | baseline | now | gate | direction |
| --- | --- | --- | --- | --- |
| `loops_aborted` | 3 | 0 | badness (any rise) | tightens |
| `guard_failures` | 23380 | 606 | rise-bounded | tightens |
| `loops_compiled` | 6 | 3 | fall | tightens (pins 3) |
| `bridges_compiled` | 0 | 3 | ungated | — |

`loops_compiled + bridges_compiled` is **6 on both sides**: the three units it
stopped compiling as separate loops are the three it now compiles as bridges,
while the aborts go to 0 and the guard failures fall 38x. Every gated field
moves the tightening way, so this re-record arms the floor further rather than
disarming it.

This PR also recorded the six fixtures that had no baseline at all
(`hot_loop_exit_then_class_stmt`, `inline_freevar_after_mayforce`,
`math_log_trig_hot`, `pypy_dict_primitives_nonbinding`,
`raise_reg_unbound_jitstress`, `tuple_unpack_array_backed_hot`). That half is
**dropped**: #970 has since recorded all six on main. Where the two recordings
disagreed — `raise_reg_unbound_jitstress`, `loops_aborted` 2 vs 10 and
`loops_compiled` 5 vs 3 — main's is both authoritative and the tighter gate,
and a build at this base reproduces main's numbers exactly.

### Deliberately left red

These four raise a `JITSTATS_BADNESS_FIELDS` counter, whose healthy value is 0.
Re-recording them would switch the floor off for those fixtures permanently, so
they are **not** recorded:

| fixture | movement |
| --- | --- |
| `exception_args_virtual` | `loops_aborted` 0 → 3 |
| `exception_multi_handler_warmup` | `loops_aborted` 0 → 23 |
| `exception_reraise_tb_depth_jitstress` | `loops_aborted` 0 → 1198, `loops_compiled` 805 → 305 |
| `list_length_hint_validate` | `loops_aborted` 14 → 34 |

They are main's own drift away from the baselines #947 recorded, not this
branch's: each reproduces with **byte-identical counters on dynasm and
cranelift**, so the movement is walker-level rather than backend-level, and all
four are unchanged across #967's IS_OP fold and #971's front-lowering folds.
Attribution did not converge on a single commit — of the nine commits main
landed after #947, #934/#938/#957 were fully green pre-merge, and reverting
#954 reproduces the counters exactly.
