### PR TITLE
jit: fold MAKE_FUNCTION and IS_OP in the walker; size five bench fixtures above the startup floor

### DIFF
--- a/majit/majit-ir/src/effectinfo.rs
+++ b/majit/majit-ir/src/effectinfo.rs
@@ -881,6 +881,15 @@ pub enum PyreHelperKind {
     /// access) to a traced inline exception construction the optimizer
     /// can virtualize; every other shape keeps the generic residual.
     DeleteAttr,
+    /// `jit_make_function_from_globals(globals, code)` — the MAKE_FUNCTION
+    /// residual (`lower_make_function_hlop_to_insn` →
+    /// `function.py:47-57 Function.__init__`).  Both Ref operands are baked
+    /// constants: the defining frame's globals object and the popped code
+    /// object.  The full-body walker recognises this tag to emit the
+    /// construction as `NewWithVtable` + the `SetfieldGc` set, so a `def`
+    /// inside a loop virtualizes away instead of allocating a `Function` per
+    /// iteration through an opaque residual.
+    MakeFunction,
 }
 
 impl EffectInfo {

--- a/pyre/bench/synth/call_loop_local_function.py
+++ b/pyre/bench/synth/call_loop_local_function.py
@@ -14,7 +14,7 @@
 # (regalloc.py:496-499) reached the dynasm and wasm backends.  With the
 # identity guard gone this fixture no longer exercises that bucketing —
 # `bridges_compiled` stays 0 either way.
-N = 20000
+N = 1500000
 
 
 def run(n):

--- a/pyre/bench/synth/call_loop_local_function.py
+++ b/pyre/bench/synth/call_loop_local_function.py
@@ -1,20 +1,33 @@
 # pyre-check: max-pypy-ratio=8
 # A loop that defines a function in its own body and calls it.
 #
-# `MAKE_FUNCTION` hands back a fresh `Function` every iteration, so an inline
-# specialized on the callable's OBJECT IDENTITY can only ever hold by address
-# coincidence.  It never does.  What the inline actually depends on is the
-# `_immutable_fields_ = ['code?', 'w_func_globals?', 'closure?[*]', 'defs_w?[*]']`
-# set (function.py:34-42), all of which are loop-invariant here, so guarding
-# those fields off the live function keeps the trace.
+# `pyopcode.py:1457 MAKE_FUNCTION` runs `function.py:47-57 Function.__init__`
+# per execution, so `grab` is a fresh object every iteration.  Nothing here
+# escapes it: the call is inlined and the object is dead by the next
+# `MAKE_FUNCTION`.  Building the function inline — `NewWithVtable` plus one
+# `SetfieldGc` per slot the constructor writes — is what lets the optimizer see
+# that and drop the allocation; behind the residual call it could only ever
+# allocate.  The gate measures whether it was dropped: the residual costs
+# hundreds of ns per iteration against pypy's fraction of one.
 #
-# `guard_failures` in the committed `.jitstats` baseline is the signal: it is 1
-# with the field guards and 9480 with the identity guard, which also compiled
-# 47 bridges here (2497 at N=1000000) before `make_a_counter_per_value`
-# (regalloc.py:496-499) reached the dynasm and wasm backends.  With the
-# identity guard gone this fixture no longer exercises that bucketing —
-# `bridges_compiled` stays 0 either way.
-N = 1500000
+# What the inline call depends on is the
+# `_immutable_fields_ = ['code?', 'w_func_globals?', 'closure?[*]', 'defs_w?[*]']`
+# set (function.py:34-42), all loop-invariant here, so guarding those fields off
+# the live function keeps the trace across the fresh objects.  `guard_failures`
+# in the committed `.jitstats` baseline is the signal: it is 1 with the field
+# guards and 9480 with an identity guard, which also compiled 47 bridges here
+# (2497 at N=1000000) before `make_a_counter_per_value` (regalloc.py:496-499)
+# reached the dynasm and wasm backends.  With the identity guard gone this
+# fixture no longer exercises that bucketing — `bridges_compiled` stays 0.
+#
+# `N` is sized by the GATE, not by the loop.  The gate compares
+# startup-subtracted times with the baseline floored at 5ms, so below ~11M
+# iterations pypy lands on that floor and the comparison becomes a fixed
+# ~45ms budget for pyre — which is the stable regime, since only pyre's own
+# startup estimate is then left to miss.  Above it the ceiling is CPython:
+# ~195ns/iteration here against pypy's fraction of one, and this fixture must
+# not become the slowest baseline run in the suite.
+N = 10000000
 
 
 def run(n):

--- a/pyre/bench/synth/goto_if_not_same_box.py
+++ b/pyre/bench/synth/goto_if_not_same_box.py
@@ -12,7 +12,21 @@
 # exactly the concrete direction; a wrong predicate would drop the guard for a
 # genuine two-box compare and miscompile. The never-taken arms add a huge
 # sentinel so any wrong direction balloons the checksum.
-N = 125000
+#
+# `obj is obj` only reaches that fast path once the walker folds `IS_OP`
+# (`try_walker_fold_is_op`); before the fold it left as a `compare_fn`
+# may-force residual, and the ptr loop paid a `CALL_MAY_FORCE` plus its
+# `GUARD_NOT_FORCED` every iteration.
+#
+# `N` is sized by the GATE's noise model, not by the loop.  The ratio compares
+# startup-subtracted times, so a sample where pypy's execution is smaller than
+# pypy's own ~16ms startup is dominated by how far that one startup estimate
+# missed: at N=6000000 pypy executes in ~9ms and the gate swings past 6x on
+# startup noise alone.  At this N pypy executes in ~21ms, comfortably above its
+# startup, and the measured ratio settles near 2.2x.  A regression that puts
+# the residuals back is then a twenty-four-million-call blow-up, far outside
+# that margin.
+N = 12000000
 
 
 def same_box_int():

--- a/pyre/bench/synth/goto_if_not_same_box.py
+++ b/pyre/bench/synth/goto_if_not_same_box.py
@@ -12,7 +12,7 @@
 # exactly the concrete direction; a wrong predicate would drop the guard for a
 # genuine two-box compare and miscompile. The never-taken arms add a huge
 # sentinel so any wrong direction balloons the checksum.
-N = 1000
+N = 125000
 
 
 def same_box_int():

--- a/pyre/bench/synth/is_op_identity.cranelift.jitstats
+++ b/pyre/bench/synth/is_op_identity.cranelift.jitstats
@@ -1,0 +1,8 @@
+bridges_compiled=0
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
+guard_failures=2
+internal_compile_panics=0
+loops_aborted=0
+loops_compiled=3

--- a/pyre/bench/synth/is_op_identity.dynasm.jitstats
+++ b/pyre/bench/synth/is_op_identity.dynasm.jitstats
@@ -1,0 +1,8 @@
+bridges_compiled=0
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
+guard_failures=2
+internal_compile_panics=0
+loops_aborted=0
+loops_compiled=3

--- a/pyre/bench/synth/is_op_identity.py
+++ b/pyre/bench/synth/is_op_identity.py
@@ -1,0 +1,87 @@
+# `IS_OP` reaches `ptr_eq` / `ptr_ne` instead of the generic COMPARE_OP
+# residual.
+#
+# No `max-pypy-ratio`: this fixture exists to pin the fold's ANSWERS, and most
+# of its time is the `semantics` half, which deliberately runs the declined
+# residual path.  `goto_if_not_same_box` carries the fold's perf gate.
+#
+# The codewriter routes `is` / `is_not` through the same `compare_fn` residual
+# as the six ordinary comparisons (tags 8 and 9), so before the walker fold
+# every identity test in a loop cost a `CALL_MAY_FORCE` plus its
+# `GUARD_NOT_FORCED`.  `space.is_w` (baseobjspace.py:833) is pointer identity
+# for every class that does not override `is_w`, so those tests lower to a bare
+# `ptr_eq` / `ptr_ne` — and a self-compare (`a is a`) answers at `is_w`'s
+# opening `ptr::eq` whatever the class, so it folds to a constant with no op
+# and no guard at all (FASTPATHS_SAME_BOXES, pyjitpl.py:326-336).
+#
+# `hot` holds only the shapes the fold accepts; each never-taken arm adds a
+# huge sentinel, so a wrong predicate balloons the checksum.  `semantics` runs
+# the seven classes that DO override `is_w` with a value comparison — int,
+# float, complex, tuple, bytes, str, frozenset — where the fold must decline
+# and leave the residual in place.  A `GuardClass` pins only the layout, and an
+# `int` subclass instance shares `INT_TYPE` with a plain `int`, so folding
+# those to `ptr_eq` would answer `False` where the interpreter answers `True`.
+N = 200000
+
+
+class Plain:
+    pass
+
+
+def hot():
+    a = Plain()
+    b = Plain()
+    acc = 0
+    i = 0
+    while i < N:
+        if a is a:  # same box: constant True
+            acc += 1
+        if a is not a:  # same box: constant False
+            acc += 1000000
+        if a is b:  # distinct instances: ptr_eq False
+            acc += 1000000
+        if a is not b:
+            acc += 2
+        if a is None:  # NoneType keeps pointer identity
+            acc += 1000000
+        if a is not None:
+            acc += 4
+        if b is Plain:  # instance vs its type object
+            acc += 1000000
+        i += 1
+    return acc
+
+
+def semantics(n):
+    # Every operand is built from `n` so the compiler cannot fold the pair to
+    # one constant: these must be two runtime objects of equal value.
+    out = []
+    out.append((n * 0 + 1000) is (n * 0 + 1000))  # int: equal by value
+    out.append((n * 0.0 + 1.5) is (n * 0.0 + 1.5))  # float: equal by bits
+    out.append((n * 0.0 + 0.0) is -(n * 0.0 + 0.0))  # float: 0.0 is not -0.0
+    out.append(complex(n * 0, n * 0) is complex(n * 0, n * 0))  # complex
+    out.append(tuple(range(n * 0)) is tuple(range(n * 0)))  # empty tuple
+    out.append(tuple(range(n * 0 + 2)) is tuple(range(n * 0 + 2)))  # non-empty
+    out.append(bytes(n * 0) is bytes(n * 0))  # empty bytes
+    out.append(("a" * (n * 0 + 1)) is ("a" * (n * 0 + 1)))  # 1-char str
+    out.append(("ab" * (n * 0 + 1)) is ("ab" * (n * 0 + 1)))  # 2-char str
+    out.append(frozenset(range(n * 0)) is frozenset(range(n * 0)))  # empty
+    out.append(True is (n < 1))  # bool singletons
+    return out
+
+
+def main():
+    print(hot())
+    # The value-comparing classes answer `is` differently under CPython and
+    # PyPy (`1000 is 1000` is False there, True here), so the answers
+    # themselves are not printable in a fixture check.py oracles against both.
+    # What IS engine-independent, and what a wrongly-widened fold breaks, is
+    # that the compiled answer matches the interpreted one: `first` is the
+    # very first, interpreted call and `again` comes after the loop is hot.
+    first = semantics(0)
+    for _ in range(2000):
+        again = semantics(0)
+    print(again == first, len(first))
+
+
+main()

--- a/pyre/bench/synth/is_op_identity.wasm.jitstats
+++ b/pyre/bench/synth/is_op_identity.wasm.jitstats
@@ -1,0 +1,5 @@
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
+internal_compile_panics=0
+loops_aborted=0

--- a/pyre/bench/synth/make_function_inline.cranelift.jitstats
+++ b/pyre/bench/synth/make_function_inline.cranelift.jitstats
@@ -1,0 +1,8 @@
+bridges_compiled=0
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
+guard_failures=1
+internal_compile_panics=0
+loops_aborted=0
+loops_compiled=2

--- a/pyre/bench/synth/make_function_inline.dynasm.jitstats
+++ b/pyre/bench/synth/make_function_inline.dynasm.jitstats
@@ -1,0 +1,8 @@
+bridges_compiled=0
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
+guard_failures=1
+internal_compile_panics=0
+loops_aborted=0
+loops_compiled=2

--- a/pyre/bench/synth/make_function_inline.py
+++ b/pyre/bench/synth/make_function_inline.py
@@ -1,0 +1,126 @@
+# `MAKE_FUNCTION` reaches `NewWithVtable` + `SetfieldGc` instead of the
+# `jit_make_function_from_globals` residual.
+#
+# No `max-pypy-ratio`: this fixture exists to pin what the emit BUILDS.
+# `call_loop_local_function` carries the fold's perf gate.
+#
+# `pyopcode.py:1457 MAKE_FUNCTION` runs `function.py:47-57 Function.__init__`
+# per execution, so a `def` in a loop body allocates a function per iteration.
+# Emitting that construction inline lets the optimizer drop it when the
+# function never escapes; when it DOES escape, the materialized object must be
+# indistinguishable from the interpreted one.  `hot` is the escaping half — it
+# reads back every slot the emit writes and every slot it leaves null, on a
+# function built inside the hot loop, so a wrong constant or a missing store
+# shows up as a changed checksum rather than a silent divergence.
+#
+# The nursery is not zero-filled, so a pointer slot missing from the size
+# descr's census would keep recycled bytes: `probe_nulls` reads each one that
+# `Function.__init__` leaves unset.  `can_change_code` is a plain byte with no
+# NULL store behind the allocation, which `__code__` assignment checks.
+#
+# `N` only has to carry `hot` past the trace threshold: every read in its body
+# is its own residual, so raising it buys no coverage and only costs run time
+# in a suite this fixture is not a perf member of.
+N = 20000
+
+
+def probe_nulls(f):
+    # Every slot `Function.__init__` leaves unset, read through its app-level
+    # surface.  A garbage pointer here is a wild dereference, not a wrong
+    # answer, so reaching the end at all is most of the assertion.
+    out = 0
+    out += len(f.__dict__)
+    out += 1 if f.__defaults__ is None else 0
+    out += 1 if f.__kwdefaults__ is None else 0
+    out += 1 if f.__closure__ is None else 0
+    out += 1 if f.__doc__ is None else 0
+    out += len(f.__annotations__)
+    out += 1 if f.__module__ == __name__ else 0
+    return out
+
+
+def hot():
+    acc = 0
+    i = 0
+    while i < N:
+
+        def grab(a=None):
+            # `len` is absent from this module's globals, so resolving it walks
+            # the builtin mapping the constructor froze onto the function.  A
+            # wrong or missing one raises NameError instead of answering 0.
+            return len(())
+
+        # The slots the emit writes.
+        acc += grab()
+        acc += len(grab.__name__)
+        acc += len(grab.__qualname__)
+        acc += 1 if grab.__globals__ is globals() else 0
+        acc += 1 if grab.__code__ is grab.__code__ else 0
+        # `can_change_code` must be True: a byte left at whatever the recycled
+        # nursery held would raise here roughly half the time.
+        grab.__code__ = grab.__code__
+        acc += probe_nulls(grab)
+        i += 1
+    return acc
+
+
+def escapes():
+    # The same `def`, kept alive past the loop, so the virtual is forced and
+    # materialized rather than dropped.
+    fns = []
+    i = 0
+    while i < 200:
+
+        def grab():
+            return i
+
+        fns.append(grab)
+        i += 1
+    return len(fns), fns[0].__qualname__, fns[0] is not fns[1]
+
+
+def with_attributes():
+    # SET_FUNCTION_ATTRIBUTE writes land on the emitted object, so defaults and
+    # the closure tuple must survive the same construction.
+    out = []
+    i = 0
+    while i < 200:
+        cell = i
+
+        def grab(a, b=7, *, c=9):
+            return a + b + c + cell
+
+        out.append(grab(1))
+        i += 1
+    return out[-1], grab.__defaults__, grab.__kwdefaults__, len(grab.__closure__)
+
+
+def foreign_globals():
+    # `exec` with a bare dict: `__builtins__` is inserted as the builtin MODULE
+    # here, while a mapping that is not a module declines the fold and keeps
+    # the residual.  Both must build the same function.
+    src = "def made():\n    return 5\n"
+    plain = {}
+    exec(src, plain)
+    mapped = {"__builtins__": {"len": len}}
+    exec(src, mapped)
+    return (
+        plain["made"](),
+        plain["made"].__qualname__,
+        mapped["made"](),
+        plain["made"].__globals__ is plain,
+    )
+
+
+def main():
+    print(hot())
+    print(escapes())
+    print(with_attributes())
+    print(foreign_globals())
+    # The code object owns one realized `co_qualname`, so repeated reads and
+    # every function built from it name the same object.
+    c = hot.__code__
+    print(c.co_qualname is c.co_qualname, hot.__qualname__ == c.co_qualname)
+
+
+main()

--- a/pyre/bench/synth/make_function_inline.wasm.jitstats
+++ b/pyre/bench/synth/make_function_inline.wasm.jitstats
@@ -1,0 +1,5 @@
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
+internal_compile_panics=0
+loops_aborted=0

--- a/pyre/bench/synth/surrogate_class_kwargs.py
+++ b/pyre/bench/synth/surrogate_class_kwargs.py
@@ -9,31 +9,43 @@ S1 = '\udc81'
 S2 = '\udc84'
 
 
+# The walks are repeated so the measured body is larger than the process
+# startup floor; only the last round's answers are printed, so the output is
+# identical to a single round.
+REPEAT = 100
+
+
 def main():
-    # dict(**{surrogate}) keeps the key.
-    d = dict(**{S1: 1, 'plain': 2})
-    print('dict_s1', S1 in d, d[S1], len(d))
+    for _ in range(REPEAT):
+        # dict(**{surrogate}) keeps the key.
+        d = dict(**{S1: 1, 'plain': 2})
+        dict_s1 = (S1 in d, d[S1], len(d))
 
-    # update(**{surrogate}) too.
-    e = {}
-    e.update(**{S2: 9})
-    print('upd_s2', S2 in e, e[S2])
+        # update(**{surrogate}) too.
+        e = {}
+        e.update(**{S2: 9})
+        upd_s2 = (S2 in e, e[S2])
 
-    # type(name, bases, ns) with a surrogate-named namespace entry.
-    C = type('C', (), {S1: 5, 'plain': 6})
-    print('type_attr', getattr(C, S1), getattr(C, 'plain'))
+        # type(name, bases, ns) with a surrogate-named namespace entry.
+        C = type('C', (), {S1: 5, 'plain': 6})
+        type_attr = (getattr(C, S1), getattr(C, 'plain'))
 
-    # A surrogate class keyword reaches __init_subclass__.
-    seen = []
+        # A surrogate class keyword reaches __init_subclass__.
+        seen = []
 
-    class Base:
-        def __init_subclass__(cls, **kw):
-            seen.extend(sorted(kw.keys(), key=lambda s: [ord(c) for c in s]))
+        class Base:
+            def __init_subclass__(cls, **kw):
+                seen.extend(sorted(kw.keys(), key=lambda s: [ord(c) for c in s]))
 
-    class Sub(Base, **{S1: 1, S2: 2}):
-        pass
+        class Sub(Base, **{S1: 1, S2: 2}):
+            pass
 
-    print('subkw', [[ord(c) for c in s] for s in seen])
+        subkw = [[ord(c) for c in s] for s in seen]
+
+    print('dict_s1', dict_s1[0], dict_s1[1], dict_s1[2])
+    print('upd_s2', upd_s2[0], upd_s2[1])
+    print('type_attr', type_attr[0], type_attr[1])
+    print('subkw', subkw)
 
 
 main()

--- a/pyre/bench/synth/surrogate_dir.py
+++ b/pyre/bench/synth/surrogate_dir.py
@@ -14,28 +14,42 @@ class C:
     pass
 
 
+# The walks are repeated so the measured body is larger than the process
+# startup floor; only the last round's answers are printed, so the output is
+# identical to a single round.
+REPEAT = 100
+
+
 def main():
-    # Module global named by a lone surrogate appears in dir(module).
-    setattr(sys, S1, 1)
-    dm = dir(sys)
-    print('mod_s1', S1 in dm)
-    print('mod_argv', 'argv' in dm)
+    for _ in range(REPEAT):
+        # Module global named by a lone surrogate appears in dir(module).
+        setattr(sys, S1, 1)
+        dm = dir(sys)
+        mod_s1 = S1 in dm
+        mod_argv = 'argv' in dm
 
-    # Type attribute named by a surrogate appears in dir(type).
-    setattr(C, S2, 3)
-    dt = dir(C)
-    print('type_s2', S2 in dt)
+        # Type attribute named by a surrogate appears in dir(type).
+        setattr(C, S2, 3)
+        dt = dir(C)
+        type_s2 = S2 in dt
 
-    # Instance attribute named by a surrogate appears in dir(instance),
-    # alongside the surrogate name inherited from the type.
-    c = C()
-    setattr(c, S1, 4)
-    dc = dir(c)
-    print('inst_s1', S1 in dc)
-    print('inst_s2', S2 in dc)
+        # Instance attribute named by a surrogate appears in dir(instance),
+        # alongside the surrogate name inherited from the type.
+        c = C()
+        setattr(c, S1, 4)
+        dc = dir(c)
+        inst_s1 = S1 in dc
+        inst_s2 = S2 in dc
 
-    # dir() output stays sorted with surrogate names present.
-    print('type_sorted', dt == sorted(dt))
+        # dir() output stays sorted with surrogate names present.
+        type_sorted = dt == sorted(dt)
+
+    print('mod_s1', mod_s1)
+    print('mod_argv', mod_argv)
+    print('type_s2', type_s2)
+    print('inst_s1', inst_s1)
+    print('inst_s2', inst_s2)
+    print('type_sorted', type_sorted)
 
 
 main()

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -303,6 +303,10 @@ pub unsafe fn walk_raw_code_roots(
             visited.push(identity);
             let code = &mut *(value as *mut crate::pycode::PyCode);
             visitor(&mut *(&mut code.w_globals as *mut PyObjectRef as *mut majit_ir::GcRef));
+            // The realized `co_qualname` is an ordinary movable string object
+            // shared by every function built from this code; the wrapper is
+            // Box-immortal, so only this raw-root walker forwards it.
+            visitor(&mut *(&mut code.w_qualname as *mut PyObjectRef as *mut majit_ir::GcRef));
             if !code.co_consts_w.is_null() {
                 for slot in (&*code.co_consts_w).iter() {
                     let mut child = slot.load(std::sync::atomic::Ordering::Acquire);

--- a/pyre/pyre-interpreter/src/function.rs
+++ b/pyre/pyre-interpreter/src/function.rs
@@ -354,11 +354,77 @@ pub fn function_new_with_closure(
     function_new_impl(
         &FUNCTION_TYPE,
         code,
-        name,
+        FunctionName::Owned(name),
         w_func_globals_obj,
         closure,
         true,
     )
+}
+
+/// Where a new function's `name` slot points.
+///
+/// `function.py:51 self.name = forcename or code.co_name` copies the code
+/// object's own string; RPython strings are immutable and shared, so no second
+/// allocation exists upstream.  Pyre's names live in explicit storage, so the
+/// two shapes are named here: `Owned` boxes a string the caller built, while
+/// `Borrowed` hands over a pointer whose storage outlives every function that
+/// names it.
+pub enum FunctionName {
+    /// Box the string — a GC storage box for a mortal (`PyCode`) function, a
+    /// `malloc_raw` box for an immortal builtin.
+    Owned(String),
+    /// Point at existing permanent storage: a `Box::into_raw`'d `CodeObject`'s
+    /// `co_name`, which is never rewritten in place (`code.replace()` clones
+    /// first) and is never freed.  The GC walker's managed-heap guard skips the
+    /// edge for the same reason it skips an immortal builtin's `malloc_raw`
+    /// name, and `function_set_func_name` replaces this pointer instead of
+    /// writing through it, so several functions may share one string.
+    Borrowed(*const String),
+}
+
+/// `pyopcode.py:1457 MAKE_FUNCTION` construction: both the name and the
+/// qualified name come off the code object, so neither allocates.
+///
+/// `function.py:51-54`:
+///
+/// ```python
+/// self.name = forcename or code.co_name
+/// self.qualname = qualname or self.name
+/// ```
+///
+/// `w_code` is the code wrapper the new function keeps in its `code` slot; it
+/// owns the borrowed `co_name` and the shared realized `co_qualname`.
+pub fn function_new_from_code(w_code: PyObjectRef, w_func_globals_obj: PyObjectRef) -> PyObjectRef {
+    let code_ptr = unsafe { crate::w_code_get_ptr(w_code) } as *const crate::CodeObject;
+    let name = if code_ptr.is_null() {
+        FunctionName::Owned(String::new())
+    } else {
+        FunctionName::Borrowed(unsafe { &(*code_ptr).obj_name } as *const String)
+    };
+    // `function.py:54 self.qualname = qualname or self.name`.  The code object
+    // realizes one wrapped qualname and every function built from it names that
+    // object, so a later `__code__ = new_code` assignment leaves
+    // `__qualname__` alone (`pyopcode.py:1457` stamps it at construction).
+    // Realize it BEFORE the function so the one allocation that can collect
+    // runs while no unrooted function is live.
+    unsafe { crate::pycode::w_code_qualname_obj(w_code) };
+    let func = function_new_impl(
+        &FUNCTION_TYPE,
+        w_code as *const (),
+        name,
+        w_func_globals_obj,
+        PY_NULL,
+        true,
+    );
+    // `pick_builtin_obj` inside the constructor is a collection point, so read
+    // the realized qualname back through the Box-immortal code wrapper (whose
+    // slot the raw-root walker forwards) rather than through a stale pre-call
+    // copy.  This second call is a plain cache hit.
+    let w_qualname = unsafe { crate::pycode::w_code_qualname_obj(w_code) };
+    if !w_qualname.is_null() {
+        unsafe { function_set_qualname(func, w_qualname) };
+    }
+    func
 }
 
 /// Allocate a `Function` object, GC-managed for user code and immortal for
@@ -373,7 +439,7 @@ pub fn function_new_with_closure(
 pub(crate) fn function_new_impl(
     ob_type: &'static PyType,
     code: *const (),
-    name: String,
+    name: FunctionName,
     w_func_globals_obj: PyObjectRef,
     closure: PyObjectRef,
     can_change_code: bool,
@@ -435,13 +501,16 @@ pub(crate) fn function_new_impl(
     // is stored into the Function below.
     let is_builtin =
         !code.is_null() && unsafe { crate::gateway::is_builtin_code(code as PyObjectRef) };
-    let name_ptr = if is_builtin {
-        pyre_object::lltype::malloc_raw(name) as *const String
-    } else {
-        pyre_object::gc_storage::gc_alloc_storage_box(
+    let name_ptr = match name {
+        // Already-permanent storage owned by the code object; nothing to box.
+        FunctionName::Borrowed(ptr) => ptr,
+        FunctionName::Owned(name) if is_builtin => {
+            pyre_object::lltype::malloc_raw(name) as *const String
+        }
+        FunctionName::Owned(name) => pyre_object::gc_storage::gc_alloc_storage_box(
             name,
             pyre_object::typeobject::name_storage_gc_type_id(),
-        ) as *const String
+        ) as *const String,
     };
     let function = Function {
         ob: PyObject {
@@ -507,7 +576,7 @@ pub fn function_new_with_fixed_code(
     function_new_impl(
         &FUNCTION_TYPE,
         code,
-        name,
+        FunctionName::Owned(name),
         w_func_globals_obj,
         PY_NULL,
         false,
@@ -542,7 +611,7 @@ pub fn function_new_builtin(
     function_new_impl(
         &BUILTIN_FUNCTION_TYPE,
         code,
-        name,
+        FunctionName::Owned(name),
         w_func_globals_obj,
         PY_NULL,
         false,
@@ -551,7 +620,14 @@ pub fn function_new_builtin(
 
 /// Allocate an immutable slot-wrapper descriptor backed by `BuiltinCode`.
 pub fn function_new_slot_wrapper(code: *const (), name: String) -> PyObjectRef {
-    function_new_impl(&SLOT_WRAPPER_TYPE, code, name, PY_NULL, PY_NULL, false)
+    function_new_impl(
+        &SLOT_WRAPPER_TYPE,
+        code,
+        FunctionName::Owned(name),
+        PY_NULL,
+        PY_NULL,
+        false,
+    )
 }
 
 /// Retag a freshly materialised `FunctionWithFixedCode` as the public
@@ -566,7 +642,14 @@ pub unsafe fn function_retag_method_descriptor(obj: PyObjectRef) {
 
 /// Allocate an immutable ordinary method descriptor backed by `BuiltinCode`.
 pub fn function_new_method_descriptor(code: *const (), name: String) -> PyObjectRef {
-    function_new_impl(&METHOD_DESCRIPTOR_TYPE, code, name, PY_NULL, PY_NULL, false)
+    function_new_impl(
+        &METHOD_DESCRIPTOR_TYPE,
+        code,
+        FunctionName::Owned(name),
+        PY_NULL,
+        PY_NULL,
+        false,
+    )
 }
 
 /// function.py:385-388 — `_check_code_mutable(attr)`:

--- a/pyre/pyre-interpreter/src/pycode.rs
+++ b/pyre/pyre-interpreter/src/pycode.rs
@@ -231,12 +231,61 @@ pub struct PyCode {
     /// never resized; a `null` slot is unrealized.  The whole pointer is `null`
     /// when `code_ptr` is null or unaligned (test fixtures, gateway builtins).
     pub co_consts_w: *mut Vec<std::sync::atomic::AtomicPtr<PyObject>>,
+    /// `pycode.py:127 self.co_qualname = qualname` realized as one shared
+    /// wrapped object.
+    ///
+    /// `function.py:54 self.qualname = qualname or self.name` copies the code
+    /// object's interp-level string into every function built from it, so all
+    /// of them name the same immutable string. Pyre wraps names as objects, so
+    /// the code object owns the single realized instance and both
+    /// `MAKE_FUNCTION` and the `co_qualname` getter hand back that object
+    /// instead of allocating a fresh `W_UnicodeObject` per read.
+    ///
+    /// `PY_NULL` until first realized by [`w_code_qualname_obj`], which builds
+    /// it with `w_str_new` — `malloc_typed`-immortal, so the stored pointer is
+    /// fixed.  `eval::walk_raw_code_roots` forwards the slot anyway, for the
+    /// same reason it forwards `w_globals`: the wrapper is Box-immortal, so
+    /// nothing else would reach a movable object landing here.
+    pub w_qualname: PyObjectRef,
 }
 
 /// Field offset of `code_ptr` within `PyCode`.
 pub const CODE_PTR_OFFSET: usize = std::mem::offset_of!(PyCode, code_ptr);
 /// Field offset of `w_globals` within `PyCode`.
 pub const CODE_W_GLOBALS_OFFSET: usize = std::mem::offset_of!(PyCode, w_globals);
+/// Field offset of `w_qualname` within `PyCode`.
+pub const CODE_W_QUALNAME_OFFSET: usize = std::mem::offset_of!(PyCode, w_qualname);
+
+/// `pycode.py:127 self.co_qualname = qualname` — the shared wrapped qualified
+/// name, realized on first demand and retained on the code object.
+///
+/// `function.py:54 self.qualname = qualname or self.name` and the `co_qualname`
+/// getter both hand out the code object's own string, so they name one
+/// immutable value; realizing it once here reproduces that identity instead of
+/// minting a `W_UnicodeObject` per `def` and per attribute read.  Returns
+/// `PY_NULL` for a wrapper with no code body (test stubs, gateway builtins),
+/// whose callers already handle the missing name.
+///
+/// # Safety
+/// `w_code` must point to a valid `PyCode`.
+pub unsafe fn w_code_qualname_obj(w_code: PyObjectRef) -> PyObjectRef {
+    unsafe {
+        let cached = (*(w_code as *const PyCode)).w_qualname;
+        if !cached.is_null() {
+            return cached;
+        }
+        let code_ptr = w_code_get_ptr(w_code) as *const crate::CodeObject;
+        if code_ptr.is_null() {
+            return pyre_object::PY_NULL;
+        }
+        // `w_str_new` is a collection point, but the wrapper is Box-immortal
+        // and so never relocates; the fresh string is stored through the
+        // still-valid `w_code` before any further allocation can sweep it.
+        let w_qualname = w_str_new(&(*code_ptr).qualname);
+        (*(w_code as *mut PyCode)).w_qualname = w_qualname;
+        w_qualname
+    }
+}
 
 /// Box-immortal `PyCode` wrappers that own off-GC `w_globals` and
 /// `co_consts_w` slots.
@@ -454,6 +503,7 @@ pub fn w_code_new_with_hidden_applevel(code_ptr: *const (), hidden_applevel: boo
         globals_caches,
         mapdict_caches,
         co_consts_w,
+        w_qualname: pyre_object::PY_NULL,
     });
     let obj = Box::into_raw(obj) as PyObjectRef;
     register_prebuilt_code_root(obj);
@@ -667,7 +717,10 @@ pub unsafe fn code_get_field(obj: PyObjectRef, name: &str) -> Result<PyObjectRef
         "co_cellvars" => names_tuple(&code.cellvars),
         "co_filename" => w_str_new(&code.source_path),
         "co_name" => w_str_new(&code.obj_name),
-        "co_qualname" => w_str_new(&code.qualname),
+        // The realized qualname is shared with every function built from this
+        // code object (`function.py:54 self.qualname = qualname or self.name`),
+        // so the attribute yields the same object on each read.
+        "co_qualname" => unsafe { w_code_qualname_obj(obj) },
         "co_firstlineno" => w_int_new((*(obj as *const PyCode)).co_firstlineno_raw as i64),
         "co_linetable" => pyre_object::bytesobject::w_bytes_from_bytes(&code.linetable),
         "co_exceptiontable" => pyre_object::bytesobject::w_bytes_from_bytes(&code.exceptiontable),

--- a/pyre/pyre-interpreter/src/pytraceback.rs
+++ b/pyre/pyre-interpreter/src/pytraceback.rs
@@ -397,14 +397,25 @@ pub unsafe fn record_application_traceback(
         crate::eval::set_in_flight_exception(w_exc_object);
         // `pytraceback.py:36 self.lineno = offset2lineno(self.frame
         // .pycode, self.lasti)` — pyre resolves the line number
-        // eagerly here rather than lazily in `get_lineno`; stamping at
-        // construction guarantees the value survives the frame's
-        // lifetime, since a frame the GC does not own is not kept alive
-        // by the traceback.  See `w_pytraceback_get_lineno` for what
-        // still depends on the eager stamp and which two `tb_lineno`
-        // answers it diverges on.  `frame.pycode` is the `PyCode`
-        // wrapper; the inner `CodeObject` is extracted via
-        // `pyframe_get_pycode`.
+        // eagerly here rather than lazily in `get_lineno`, so the slot
+        // never holds `LINENO_NOT_COMPUTED` for a node built here.
+        //
+        // Frame lifetime is NOT what blocks the lazy form: the `w_code`
+        // slot below is forwarded unconditionally and is the same
+        // `pycode` upstream reads, so resolving off `w_code` + `lasti`
+        // would be safe at any later point.  What blocks it is the JIT
+        // fold `walker_specialize_traceback_walk_field`
+        // (pyre-jit-trace), which reads this slot directly and declines
+        // on the sentinel; under a lazy `get_lineno` every freshly
+        // recorded node carries the sentinel on its first read, so the
+        // fold would have to emit a resolver call plus the memoizing
+        // write-back in place of today's plain `getfield`.  That trades
+        // a folded field read for a call on the `tb_lineno` walk.
+        // See `w_pytraceback_get_lineno` for the two `tb_lineno`
+        // answers the eager stamp diverges on.
+        //
+        // `frame.pycode` is the `PyCode` wrapper; the inner
+        // `CodeObject` is extracted via `pyframe_get_pycode`.
         //
         // The `PyCode` PyObjectRef is also captured into the `w_code`
         // slot so the traceback's source-path / function name metadata

--- a/pyre/pyre-interpreter/src/runtime_ops.rs
+++ b/pyre/pyre-interpreter/src/runtime_ops.rs
@@ -25,24 +25,15 @@ pub fn make_function_from_code_obj_with_globals_obj(
     code_obj: PyObjectRef,
     w_globals: PyObjectRef,
 ) -> PyObjectRef {
-    let code_ptr = unsafe { w_code_get_ptr(code_obj) };
-    let code = unsafe { &*(code_ptr as *const crate::CodeObject) };
     // `function.py:51-53 __init__`:
     //   self.name = forcename or code.co_name
     //   self.qualname = qualname or self.name
     // so `name` is the bare `co_name` and `qualname` is the dotted
     // `co_qualname`.  `pyopcode.py:1457 MAKE_FUNCTION` then stamps the
     // qualified name from `codeobj.co_qualname`, which is why a later
-    // `__code__ = new_code` assignment does NOT change `__qualname__`.
-    let func = crate::function::function_new_with_closure(
-        code_obj as *const (),
-        code.obj_name.to_string(),
-        w_globals,
-        pyre_object::PY_NULL,
-    );
-    let qualname_obj = pyre_object::w_str_new(code.qualname.as_ref());
-    unsafe { crate::function::function_set_qualname(func, qualname_obj) };
-    func
+    // `__code__ = new_code` assignment does NOT change `__qualname__`.  Both
+    // are read straight off the code object, so neither allocates.
+    crate::function::function_new_from_code(code_obj, w_globals)
 }
 
 fn decode_name(name_ptr: i64, name_len: i64) -> Option<&'static str> {

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -956,8 +956,31 @@ static RANGE_DESCR_GROUP: LazyLock<PyreObjectDescrGroup> = LazyLock::new(|| {
 /// pre-invalidation equivalent.  A tuple's backing array has its own immutable
 /// descriptor and is read with `GetarrayitemGcPureR`.
 ///
-/// `field_descr_from_group` indexes positionally, so new fields append.
+/// The entries are in byte-offset order and each key is the struct's own field
+/// name, which is what makes the group's numbering agree with the analyzer's.
+/// `index_in_parent` is a field's slot number in the virtual
+/// (`virtualize.py:210 fielddescr.get_index()`) and its `PtrInfo._fields` key
+/// in the heap optimizer, so two fields sharing one number makes a read of
+/// either resolve to the other's cached value and a virtual keep only the
+/// later of the two stores.  Two things assign it: `descr.py:218-239` caches a
+/// FieldDescr per `(STRUCT, fieldname)` and a cache hit reports the analyzer's
+/// number, which counts the struct's own fields past the flattened header;
+/// a miss numbers the field by its position in this list.  Keeping the list in
+/// offset order — with the inherited `PyObject.w_class` last, since the
+/// analyzer's count does not include it — makes both answers the same one.
+/// Look fields up by offset (`function_field_descr`) so the accessors below
+/// cannot drift out of that order.
+///
+/// The census is COMPLETE — every pointer-shaped slot of `Function` is listed,
+/// not only the four the inline-call path reads.  `emit_make_function_inline`
+/// allocates a `Function` with `NewWithVtable`, and the nursery is not
+/// zero-filled: `rewrite.py:498-504 clear_gc_fields` emits the delayed NULL
+/// stores, and it walks exactly this group's `gc_fielddescrs`.  A pointer slot
+/// missing from the census would keep recycled nursery bytes and the collector
+/// would follow that word as a child reference.  `can_change_code` is a plain
+/// byte, so it gets no NULL store and the emit writes it explicitly.
 static FUNCTION_DESCR_GROUP: LazyLock<PyreObjectDescrGroup> = LazyLock::new(|| {
+    use pyre_interpreter::function as f;
     let field = |key, offset| {
         (
             key,
@@ -970,19 +993,65 @@ static FUNCTION_DESCR_GROUP: LazyLock<PyreObjectDescrGroup> = LazyLock::new(|| {
         )
     };
     build_object_descr_group_with_def_path(
-        pyre_interpreter::function::FUNCTION_OBJECT_SIZE,
+        f::FUNCTION_OBJECT_SIZE,
         FUNCTION_GC_TYPE_ID,
         &pyre_interpreter::FUNCTION_TYPE as *const _ as usize,
         &[
-            field("defs_w", pyre_interpreter::function::FUNCTION_DEFS_W_OFFSET),
-            field("code", pyre_interpreter::function::FUNCTION_CODE_OFFSET),
-            field(
-                "w_func_globals",
-                pyre_interpreter::function::FUNCTION_W_FUNC_GLOBALS_OBJ_OFFSET,
+            field("code", f::FUNCTION_CODE_OFFSET),
+            // `function.py:33 can_change_code = True`; `False` for the
+            // `FunctionWithFixedCode` / `BuiltinFunction` subclasses.  A plain
+            // byte, so `clear_gc_fields` leaves it alone and the value a
+            // materialized function reports comes from the emit's own store.
+            (
+                "can_change_code",
+                std::mem::offset_of!(pyre_interpreter::function::Function, can_change_code),
+                1,
+                Type::Int,
+                false,
+                false,
+                false,
             ),
-            field(
-                "closure",
-                pyre_interpreter::function::FUNCTION_CLOSURE_OFFSET,
+            // `function.py:51 self.name = forcename or code.co_name` — a
+            // pointer to the name string's storage.  It is pointer-shaped and
+            // the runtime walker visits it, so it belongs in the census; the
+            // storage itself may be GC-managed (a mortal function's own box) or
+            // permanent (a builtin's `malloc_raw` box, or the code object's
+            // borrowed `co_name`), which the walker's managed-heap guard sorts
+            // out.
+            field("name", f::FUNCTION_NAME_OFFSET),
+            field("closure", f::FUNCTION_CLOSURE_OFFSET),
+            field("defs_w", f::FUNCTION_DEFS_W_OFFSET),
+            field("w_kw_defs", f::FUNCTION_W_KW_DEFS_OFFSET),
+            field("w_module", f::FUNCTION_W_MODULE_OFFSET),
+            field("w_func_globals_obj", f::FUNCTION_W_FUNC_GLOBALS_OBJ_OFFSET),
+            field("w_builtins", f::FUNCTION_W_BUILTINS_OFFSET),
+            field("w_ann", f::FUNCTION_W_ANN_OFFSET),
+            field("w_annotate", f::FUNCTION_W_ANNOTATE_OFFSET),
+            field("w_func_dict", f::FUNCTION_W_FUNC_DICT_OFFSET),
+            field("w_typeparams", f::FUNCTION_W_TYPEPARAMS_OFFSET),
+            field("w_doc", f::FUNCTION_W_DOC_OFFSET),
+            field("w_qualname", f::FUNCTION_W_QUALNAME_OFFSET),
+            field("w_objclass", f::FUNCTION_W_OBJCLASS_OFFSET),
+            field("w_text_signature", f::FUNCTION_W_TEXT_SIGNATURE_OFFSET),
+            // `w_new_self` is absent from `FUNCTION_GC_PTR_OFFSETS` (it names a
+            // static-region type that is never relocated), but it is still a
+            // pointer slot an app-level `__self__` read dereferences, so it
+            // needs the census entry that gets it NULLed behind the allocation.
+            field("w_new_self", f::FUNCTION_W_NEW_SELF_OFFSET),
+            field("w_moduleobj", f::FUNCTION_W_MODULEOBJ_OFFSET),
+            // The inline emit can escape a guard and be materialized, so the
+            // inherited Python class is a proper virtual field of this group —
+            // same reasoning as the `Method` / `W_ListObject` entries.  It sits
+            // last, outside the offset ordering, because the analyzer counts
+            // only the struct's own fields.
+            (
+                "PyObject.w_class",
+                pyre_object::pyobject::W_CLASS_OFFSET,
+                8,
+                Type::Ref,
+                false,
+                false,
+                false,
             ),
         ],
         "Function",
@@ -2067,30 +2136,78 @@ pub fn method_w_function_descr() -> DescrRef {
     field_descr_from_group(&W_METHOD_DESCR_GROUP, 0)
 }
 
+/// Resolve one [`FUNCTION_DESCR_GROUP`] field by byte offset, so the accessors
+/// below stay correct however the census is ordered.
+fn function_field_descr(offset: usize) -> DescrRef {
+    let parent = FUNCTION_DESCR_GROUP.size_descr.clone() as DescrRef;
+    majit_ir::descr::field_descr_from_parent_by_offset(&parent, offset)
+}
+
 /// Live `Function.defs_w` field used by the positional-default inline path.
 /// See [`FUNCTION_DESCR_GROUP`] for why this is deliberately mutable until
 /// pyre wires the upstream quasi-immutable invalidation hook.
 pub fn function_defs_w_descr() -> DescrRef {
-    field_descr_from_group(&FUNCTION_DESCR_GROUP, 0)
+    function_field_descr(pyre_interpreter::function::FUNCTION_DEFS_W_OFFSET)
 }
 
 /// Live `Function.code` — the field `Function.getcode()` promotes
 /// (`function.py:95 jit.promote(self.code)`).  This is what identifies an
 /// inlined body, so the inline lever guards it instead of the function object.
 pub fn function_code_descr() -> DescrRef {
-    field_descr_from_group(&FUNCTION_DESCR_GROUP, 1)
+    function_field_descr(pyre_interpreter::function::FUNCTION_CODE_OFFSET)
 }
 
-/// Live `Function.w_func_globals` — the namespace an inlined callee's
+/// Live `Function.w_func_globals_obj` — the namespace an inlined callee's
 /// LOAD_GLOBAL folds against.
 pub fn function_w_globals_descr() -> DescrRef {
-    field_descr_from_group(&FUNCTION_DESCR_GROUP, 2)
+    function_field_descr(pyre_interpreter::function::FUNCTION_W_FUNC_GLOBALS_OBJ_OFFSET)
 }
 
 /// Live `Function.closure` — the freevar cell tuple threaded into the inlined
 /// callee's own frame.
 pub fn function_closure_descr() -> DescrRef {
-    field_descr_from_group(&FUNCTION_DESCR_GROUP, 3)
+    function_field_descr(pyre_interpreter::function::FUNCTION_CLOSURE_OFFSET)
+}
+
+/// `function.py:51 self.name` — the pointer to the name string's storage.
+pub fn function_name_descr() -> DescrRef {
+    function_field_descr(pyre_interpreter::function::FUNCTION_NAME_OFFSET)
+}
+
+/// `Function.w_builtins` — the builtin mapping resolved from the globals
+/// once at construction and then frozen (rebinding `globals['__builtins__']`
+/// afterwards does not change it).
+pub fn function_w_builtins_descr() -> DescrRef {
+    function_field_descr(pyre_interpreter::function::FUNCTION_W_BUILTINS_OFFSET)
+}
+
+/// `function.py:54 self.qualname = qualname or self.name` — the wrapped
+/// qualified name stamped at construction from the code object.
+pub fn function_w_qualname_descr() -> DescrRef {
+    function_field_descr(pyre_interpreter::function::FUNCTION_W_QUALNAME_OFFSET)
+}
+
+/// `function.py:33 can_change_code = True` — a plain byte, so a fresh
+/// allocation does not zero it and an emit must write it.
+pub fn function_can_change_code_descr() -> DescrRef {
+    function_field_descr(std::mem::offset_of!(
+        pyre_interpreter::function::Function,
+        can_change_code
+    ))
+}
+
+/// Inherited `PyObject.w_class` on a `Function` — the Python-level `function`
+/// class the constructor's header stamps.  Kept in the Function group (not the
+/// standalone `w_class_descr`) so an inline emit's store is a virtual field of
+/// the same size descr and materialization reproduces the header.
+pub fn function_header_w_class_descr() -> DescrRef {
+    function_field_descr(pyre_object::pyobject::W_CLASS_OFFSET)
+}
+
+/// Size descriptor for `Function` allocation via `NewWithVtable`
+/// (vtable = `&FUNCTION_TYPE`).
+pub fn w_function_size_descr() -> DescrRef {
+    FUNCTION_DESCR_GROUP.size_descr.clone()
 }
 
 pub fn dict_keys_version_descr() -> DescrRef {

--- a/pyre/pyre-jit-trace/src/helpers.rs
+++ b/pyre/pyre-jit-trace/src/helpers.rs
@@ -594,6 +594,58 @@ pub fn emit_bound_method_inline(
     new_op
 }
 
+/// Emit inline `Function` creation for `MAKE_FUNCTION` — `NewWithVtable` plus
+/// the `SetfieldGc` set `function.py:47-57 Function.__init__` performs — instead
+/// of the opaque `jit_make_function_from_globals` residual.
+///
+/// `pyopcode.py:1457 MAKE_FUNCTION` builds a fresh function on every execution,
+/// so a `def` inside a loop allocates once per iteration; emitting the
+/// allocation as `New` + `SetField` lets the optimizer virtualize it away when
+/// the function never escapes, which is what upstream gets by tracing straight
+/// through `Function.__init__`.
+///
+/// Only the non-null slots are written.  Every other pointer slot of the
+/// struct is `PY_NULL` after construction and a virtual reads an unwritten
+/// field as null, so the emit does not spell them out; the size descr's census
+/// is what makes the materialized form agree (see `FUNCTION_DESCR_GROUP`).
+/// `can_change_code` is the one exception — a plain byte gets no NULL store
+/// behind the allocation, so its `True` is written explicitly.
+#[allow(clippy::too_many_arguments)]
+pub fn emit_make_function_inline(
+    ctx: &mut TraceCtx,
+    header_w_class: OpRef,
+    code: OpRef,
+    can_change_code: OpRef,
+    name: OpRef,
+    w_func_globals: OpRef,
+    w_builtins: OpRef,
+    w_qualname: OpRef,
+) -> OpRef {
+    let new_op = ctx.record_op_with_descr(
+        OpCode::NewWithVtable,
+        &[],
+        crate::descr::w_function_size_descr(),
+    );
+    ctx.heap_cache_mut().new_object(new_op);
+    for (descr, value) in [
+        (crate::descr::function_header_w_class_descr(), header_w_class),
+        (crate::descr::function_code_descr(), code),
+        (
+            crate::descr::function_can_change_code_descr(),
+            can_change_code,
+        ),
+        (crate::descr::function_name_descr(), name),
+        (crate::descr::function_w_globals_descr(), w_func_globals),
+        (crate::descr::function_w_builtins_descr(), w_builtins),
+        (crate::descr::function_w_qualname_descr(), w_qualname),
+    ] {
+        let index = descr.index();
+        ctx.record_op_with_descr(OpCode::SetfieldGc, &[new_op, value], descr);
+        ctx.heapcache_setfield_cached(new_op, index, value);
+    }
+    new_op
+}
+
 /// Emit inline `W_ObjectObject` creation (`NewWithVtable` + `SetfieldGc` for
 /// the inherited header `PyObject.w_class` and `map`), mirroring
 /// `objectobject.rs w_instance_new`.

--- a/pyre/pyre-jit-trace/src/helpers.rs
+++ b/pyre/pyre-jit-trace/src/helpers.rs
@@ -628,7 +628,10 @@ pub fn emit_make_function_inline(
     );
     ctx.heap_cache_mut().new_object(new_op);
     for (descr, value) in [
-        (crate::descr::function_header_w_class_descr(), header_w_class),
+        (
+            crate::descr::function_header_w_class_descr(),
+            header_w_class,
+        ),
         (crate::descr::function_code_descr(), code),
         (
             crate::descr::function_can_change_code_descr(),

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -3953,6 +3953,18 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
         }
     }
 
+    // Emit MAKE_FUNCTION's `Function.__init__` as New + SetField so a `def` in a
+    // loop body virtualizes away instead of allocating through the opaque
+    // residual.  Falls through to the residual for every shape the emit cannot
+    // reproduce constant-for-constant (SAFE — never declined).
+    if ctx.is_authoritative_executor
+        && dst_bank == 'r'
+        && ei.pyre_helper == majit_ir::PyreHelperKind::MakeFunction
+        && try_walker_specialize_make_function(ctx, op.pc, &r_args, dst, dst_bank)?.is_some()
+    {
+        return Ok((DispatchOutcome::Continue, op.next_pc));
+    }
+
     // #195 / #73: virtualize an arity-2 plain-int BUILD_TUPLE
     // (`newtuple_from_array`) as a `spec_ii` `new_with_vtable` +
     // `value0` / `value1`, so the backing array build and the partner

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -5223,6 +5223,16 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
                         ctx.last_exc_value_concrete = saved_last_exc_value_concrete;
                     }
                     folded
+                } else if (op_tag == 8 || op_tag == 9) && ctx.is_authoritative_executor {
+                    // `op_tag` 8 / 9 are `is` / `is_not` (`IS_OP`), which the
+                    // codewriter routes through the same `compare_fn`
+                    // residual as the six ordinary comparisons.  Fold them to
+                    // `ptr_eq` / `ptr_ne` — or, for a self-compare, straight
+                    // to the constant — so identity tests stop paying a
+                    // may-force call and its `GuardNotForced` per iteration.
+                    // Declines (falls through to the generic residual) for an
+                    // operand layout whose class compares `is_w` by value.
+                    try_walker_fold_is_op(ctx, op.pc, op_tag, &r_args, dst, dst_bank)?
                 } else {
                     // int compare first; then long (two-bigint operands keep
                     // bigint comparison); float (incl. mixed int/float) last.

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -4121,6 +4121,171 @@ pub(crate) fn try_walker_fold_check_exc_match<Sym: WalkSym>(
     Ok(Some(()))
 }
 
+/// Does `tp` name a layout whose class overrides `is_w` with a value
+/// comparison?  `baseobjspace::is_w` gates one branch per overriding class,
+/// each demanding both operands be that exact type: `int`
+/// (`intobject.py:44`), `float` (`floatobject.py:196`), `complex`
+/// (`complexobject.py:287`), `tuple` (`tupleobject.py:47`), `bytes`
+/// (`bytesobject.py:25`), `str` (`unicodeobject.py:101`) and `frozenset`
+/// (`setobject.py:592`).  Every other class keeps the default pointer
+/// identity (`baseobjspace.py:246`).
+fn is_w_compares_by_value(tp: *const pyre_object::pyobject::PyType) -> bool {
+    [
+        &pyre_object::pyobject::INT_TYPE as *const pyre_object::pyobject::PyType,
+        &pyre_object::pyobject::FLOAT_TYPE as *const pyre_object::pyobject::PyType,
+        &pyre_object::pyobject::COMPLEX_TYPE as *const pyre_object::pyobject::PyType,
+        &pyre_object::pyobject::TUPLE_TYPE as *const pyre_object::pyobject::PyType,
+        &pyre_object::bytesobject::BYTES_TYPE as *const pyre_object::pyobject::PyType,
+        &pyre_object::pyobject::STR_TYPE as *const pyre_object::pyobject::PyType,
+        &pyre_object::setobject::FROZENSET_TYPE as *const pyre_object::pyobject::PyType,
+    ]
+    .iter()
+    .any(|special| std::ptr::eq(*special, tp))
+}
+
+/// Walker-native fold of the `IS_OP` residual — `bh_compare_fn(lhs, rhs,
+/// tag)` with tag 8 (`is`) or 9 (`is_not`), the tags
+/// `compare_op_tag_for_opname` assigns those two opnames.
+///
+/// `IS_OP` is `space.is_w(w_1, w_2)` plus a `newbool`
+/// (`pyopcode.py:1078-1092`), and `is_w` (`baseobjspace.py:833`) dispatches
+/// to `w_two.is_w(space, w_one)`, whose default is pointer identity.  Two
+/// tiers, mirroring `FASTPATHS_SAME_BOXES`' `ptr_eq`/`ptr_ne` entries
+/// (`pyjitpl.py:326-336`):
+///
+///   * Same box — `baseobjspace::is_w` answers at its opening `ptr::eq`
+///     whatever the class, so the result is the constant `True`/`False`.
+///     No op and no guard: this is the `b1 is b2` fast check itself.
+///   * Distinct boxes whose layouts both keep the default `is_w` — no
+///     value-comparison branch can fire, so `is_w` again reduces to that
+///     `ptr::eq`.  A `GuardClass` per operand pins the layout, then
+///     `ptr_eq`/`ptr_ne` replaces the may-force `compare_fn` and the
+///     `GuardNotForced` behind it.
+///
+/// Declining on a value-comparing layout is what keeps the second tier
+/// sound: `GuardClass` pins `ob_type`, and an `int` subclass instance
+/// shares `INT_TYPE` with a plain `int` while answering the exact-type gate
+/// differently, so the layout alone cannot separate them.  A tagged
+/// immediate is declined outright — it carries no `ob_type` to guard.
+pub(crate) fn try_walker_fold_is_op<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    op_pc: usize,
+    op_tag: i64,
+    r_args: &[OpRef],
+    dst: usize,
+    dst_bank: char,
+) -> Result<Option<()>, DispatchError> {
+    if r_args.len() != 2 || dst_bank != 'r' || !ctx.is_authoritative_executor {
+        return Ok(None);
+    }
+    let invert = match op_tag {
+        8 => false,
+        9 => true,
+        _ => return Ok(None),
+    };
+    let lhs = r_args[0];
+    let rhs = r_args[1];
+
+    if lhs.same_box(rhs) {
+        // `x is x` / `x is not x` — statically determined.
+        return walker_write_const_bool_result(ctx, op_pc, !invert, dst, dst_bank).map(Some);
+    }
+
+    let (Some(lhs_obj), Some(rhs_obj)) = (
+        walker_concrete_ref_object(ctx, lhs),
+        walker_concrete_ref_object(ctx, rhs),
+    ) else {
+        return Ok(None);
+    };
+    if lhs_obj.is_null() || rhs_obj.is_null() {
+        return Ok(None);
+    }
+    if pyre_object::tagged_int::CAN_BE_TAGGED
+        && (pyre_object::tagged_int::is_tagged_int(lhs_obj)
+            || pyre_object::tagged_int::is_tagged_int(rhs_obj))
+    {
+        return Ok(None);
+    }
+    let (lhs_type, rhs_type) = unsafe {
+        (
+            (*(lhs_obj as *const pyre_object::pyobject::PyObject)).ob_type,
+            (*(rhs_obj as *const pyre_object::pyobject::PyObject)).ob_type,
+        )
+    };
+    if is_w_compares_by_value(lhs_type) || is_w_compares_by_value(rhs_type) {
+        return Ok(None);
+    }
+    // The layout test above is the proof that `is_w` reduces to `ptr::eq`
+    // here; cross-check it against the real thing and decline rather than
+    // record a concrete the emitted `ptr_eq` disagrees with.
+    let same = std::ptr::eq(lhs_obj, rhs_obj);
+    if same != pyre_interpreter::baseobjspace::is_w(lhs_obj, rhs_obj) {
+        return Ok(None);
+    }
+
+    // --- commit to the fold: emit IR (no further declines) ---
+    for (operand, operand_type) in [(lhs, lhs_type), (rhs, rhs_type)] {
+        if operand.is_constant() || ctx.trace_ctx.heap_cache().is_class_known(operand) {
+            continue;
+        }
+        let type_addr = operand_type as usize as i64;
+        let type_const = ctx.trace_ctx.const_int(type_addr);
+        ctx.trace_ctx
+            .record_guard(OpCode::GuardClass, &[operand, type_const], 0);
+        walker_capture_snapshot_for_last_guard(ctx, op_pc)?;
+        ctx.trace_ctx
+            .heap_cache_mut()
+            .class_now_known(operand, type_addr);
+    }
+    let cmp = if invert {
+        OpCode::PtrNe
+    } else {
+        OpCode::PtrEq
+    };
+    let truth = ctx.trace_ctx.record_op(cmp, &[lhs, rhs]);
+    let result = same != invert;
+    ctx.trace_ctx
+        .set_opref_concrete(truth, majit_ir::Value::Int(result as i64));
+    // Same boxed-bool elision as the int compare specialization: when the
+    // Ref dst is provably consumed only by the following `is_true`, write
+    // the raw truth and let `bool_box_truth_record` resolve it.
+    if compare_box_provably_dead(ctx, op_pc, dst as u8) {
+        bool_box_truth_record(truth, truth);
+        write_residual_call_result_to_dst(ctx, op_pc, dst, dst_bank, truth)?;
+        return Ok(Some(()));
+    }
+    let boxed = crate::helpers::emit_trace_bool_value_from_truth(ctx.trace_ctx, truth, false);
+    ctx.trace_ctx.set_opref_concrete(
+        boxed,
+        majit_ir::Value::Ref(majit_ir::GcRef(pyre_object::w_bool_from(result) as usize)),
+    );
+    bool_box_truth_record(boxed, truth);
+    write_residual_call_result_to_dst(ctx, op_pc, dst, dst_bank, boxed)?;
+    Ok(Some(()))
+}
+
+/// Write an immortal `bool` singleton into a residual call's Ref dst, along
+/// with the raw truth `bool_box_truth_record` needs so an immediately
+/// following `is_true` (`POP_JUMP_IF_*`) folds to the constant instead of
+/// unboxing through a residual.
+fn walker_write_const_bool_result<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    op_pc: usize,
+    value: bool,
+    dst: usize,
+    dst_bank: char,
+) -> Result<(), DispatchError> {
+    let result_obj = pyre_object::w_bool_from(value);
+    let const_bool = ctx.trace_ctx.const_ref(result_obj as i64);
+    ctx.trace_ctx.set_opref_concrete(
+        const_bool,
+        majit_ir::Value::Ref(majit_ir::GcRef(result_obj as usize)),
+    );
+    let truth = ctx.trace_ctx.const_int(value as i64);
+    bool_box_truth_record(const_bool, truth);
+    write_residual_call_result_to_dst(ctx, op_pc, dst, dst_bank, const_bool)
+}
+
 /// Mixed W_LongObject/W_IntObject COMPARE_OP specialization.
 ///
 /// `pypy/objspace/std/longobject.py:_make_descr_cmp` selects the corresponding

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -4237,11 +4237,7 @@ pub(crate) fn try_walker_fold_is_op<Sym: WalkSym>(
             .heap_cache_mut()
             .class_now_known(operand, type_addr);
     }
-    let cmp = if invert {
-        OpCode::PtrNe
-    } else {
-        OpCode::PtrEq
-    };
+    let cmp = if invert { OpCode::PtrNe } else { OpCode::PtrEq };
     let truth = ctx.trace_ctx.record_op(cmp, &[lhs, rhs]);
     let result = same != invert;
     ctx.trace_ctx
@@ -4413,10 +4409,9 @@ pub(crate) fn try_walker_specialize_make_function<Sym: WalkSym>(
         w_builtins_const,
         w_qualname_const,
     );
-    ctx.trace_ctx.heap_cache_mut().class_now_known(
-        func_op,
-        &pyre_interpreter::FUNCTION_TYPE as *const _ as i64,
-    );
+    ctx.trace_ctx
+        .heap_cache_mut()
+        .class_now_known(func_op, &pyre_interpreter::FUNCTION_TYPE as *const _ as i64);
     // Tracing is execution: build the concrete function the rest of the walk
     // observes.  A fresh `Function` per evaluation is what MAKE_FUNCTION
     // produces anyway, so the trace allocating its own is not an identity

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -4286,6 +4286,152 @@ fn walker_write_const_bool_result<Sym: WalkSym>(
     write_residual_call_result_to_dst(ctx, op_pc, dst, dst_bank, const_bool)
 }
 
+/// MAKE_FUNCTION inline emission: replace the
+/// `jit_make_function_from_globals(globals, code)` residual with the
+/// `NewWithVtable` + `SetfieldGc` set `function.py:47-57 Function.__init__`
+/// performs, so a `def` in a loop body virtualizes away instead of allocating a
+/// `Function` per iteration.
+///
+/// Everything the constructor stores is loop-invariant here: `globals` and
+/// `code` arrive as baked constants (`codewriter.rs` MakeFunction arm bakes the
+/// frame's globals object, and the code object comes from a `LOAD_CONST`), and
+/// the remaining slots are derived from them:
+///
+/// * `name` — `function.py:51 self.name = code.co_name`, a pointer into the
+///   `Box::into_raw`'d `CodeObject`, which is never rewritten in place nor
+///   freed.  This is the same pointer the residual stores
+///   (`function_new_from_code` borrows it too), so a materialized function is
+///   indistinguishable from an interpreted one.
+/// * `w_qualname` — the code object's single realized `co_qualname`, shared by
+///   every function built from it.
+/// * `w_builtins` — CPython 3.14 `_PyEval_BuiltinsFromGlobals`, frozen at
+///   construction from `globals['__builtins__']`.  Only the allocation-free
+///   shape is reproduced: `__builtins__` naming a module, reduced to its dict.
+///   An absent or non-module `__builtins__` routes
+///   `pick_builtin_obj_checked` through `w_module_new_aliasing_dict` / the
+///   default-module build, which mint a fresh object per call and so cannot be
+///   baked — those decline to the residual.
+///
+/// Soundness rests on one guard beyond the constant operands: the module
+/// dict's `version?` is pinned, so rebinding `globals['__builtins__']` runs
+/// `mutated()` and revokes the loop, exactly as it does for a shadowing insert
+/// under the LOAD_GLOBAL cell fold.  Nothing watches the code object's
+/// `co_name` / `co_qualname` because neither is mutable in place —
+/// `code.replace()` clones first and yields a different code object, which is a
+/// different constant.
+///
+/// Declines (each falls through to the residual, which stays correct): a
+/// non-constant operand, a non-`PyCode` or bodyless code object, globals that
+/// are not a module dict, an unbakeable `__builtins__`, and any baked pointer
+/// the collector may relocate.
+pub(crate) fn try_walker_specialize_make_function<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    op_pc: usize,
+    r_args: &[OpRef],
+    dst: usize,
+    dst_bank: char,
+) -> Result<Option<()>, DispatchError> {
+    if r_args.len() != 2 {
+        return Ok(None);
+    }
+    let (globals_op, code_op) = (r_args[0], r_args[1]);
+    if !globals_op.is_constant() || !code_op.is_constant() {
+        return Ok(None);
+    }
+    let Some(w_code) = walker_concrete_ref_object(ctx, code_op) else {
+        return Ok(None);
+    };
+    // A `BuiltinCode`-backed carrier is immortal and boxes its name through
+    // `malloc_raw`; `is_code` admits only the `PyCode` shape this reproduces.
+    if !unsafe { pyre_interpreter::is_code(w_code) } {
+        return Ok(None);
+    }
+    let code_ptr =
+        unsafe { pyre_interpreter::w_code_get_ptr(w_code) } as *const pyre_interpreter::CodeObject;
+    if code_ptr.is_null() {
+        return Ok(None);
+    }
+
+    // Realizing the qualname is the fold's one collection point (it allocates
+    // once per code object and hits the cache afterwards), so it runs here,
+    // while the only live pointers are the `Box::into_raw`'d code wrapper and
+    // its `CodeObject` — neither of which the collector relocates.  Everything
+    // read below is read after it.
+    let w_qualname = unsafe { pyre_interpreter::pycode::w_code_qualname_obj(w_code) };
+    if w_qualname.is_null() {
+        return Ok(None);
+    }
+    let Some(w_globals) = walker_concrete_ref_object(ctx, globals_op) else {
+        return Ok(None);
+    };
+    // Restrict to a module namespace before probing it directly, so the slot
+    // read below walks the same storage `pick_builtin_obj_checked`'s
+    // `finditem_str` does.  This is also what `walker_pin_namespace_version`
+    // needs, but that one emits IR, so it runs only once the fold commits.
+    if unsafe { pyre_object::dictmultiobject::w_module_dict_get_strategy(w_globals) }.is_null() {
+        return Ok(None);
+    }
+    // `function_new_impl`'s `w_builtins` derivation, restricted to the branch
+    // that allocates nothing and therefore answers the same object each run.
+    let w_builtins_module = unsafe { pyre_object::w_dict_getitem_str(w_globals, "__builtins__") }
+        .unwrap_or(pyre_object::PY_NULL);
+    if w_builtins_module.is_null() || !unsafe { pyre_object::is_module(w_builtins_module) } {
+        return Ok(None);
+    }
+    let w_builtins = unsafe { pyre_object::w_module_get_w_dict(w_builtins_module) };
+    if w_builtins.is_null() {
+        return Ok(None);
+    }
+    for baked in [w_builtins, w_qualname] {
+        if majit_gc::can_move(majit_ir::GcRef(baked as usize)) {
+            return Ok(None);
+        }
+    }
+
+    // --- commit to the fold: emit IR (no further declines) ---
+    // The only mutable input: `globals['__builtins__']` may be rebound after
+    // this function is built, and a later iteration must then see the new
+    // mapping.  Pinning the namespace `version?` revokes the loop instead.
+    walker_pin_namespace_version(ctx, op_pc, w_globals)?;
+    let header_w_class = ctx
+        .trace_ctx
+        .const_ref(pyre_object::get_instantiate(&pyre_interpreter::FUNCTION_TYPE) as i64);
+    // `function.py:33 can_change_code = True` for a plain `def`.
+    let can_change_code = ctx.trace_ctx.const_int(1);
+    let name = ctx
+        .trace_ctx
+        .const_ref(unsafe { &(*code_ptr).obj_name } as *const String as i64);
+    let w_builtins_const = ctx.trace_ctx.const_ref(w_builtins as i64);
+    let w_qualname_const = ctx.trace_ctx.const_ref(w_qualname as i64);
+    let func_op = crate::helpers::emit_make_function_inline(
+        ctx.trace_ctx,
+        header_w_class,
+        code_op,
+        can_change_code,
+        name,
+        globals_op,
+        w_builtins_const,
+        w_qualname_const,
+    );
+    ctx.trace_ctx.heap_cache_mut().class_now_known(
+        func_op,
+        &pyre_interpreter::FUNCTION_TYPE as *const _ as i64,
+    );
+    // Tracing is execution: build the concrete function the rest of the walk
+    // observes.  A fresh `Function` per evaluation is what MAKE_FUNCTION
+    // produces anyway, so the trace allocating its own is not an identity
+    // divergence.
+    let func = pyre_interpreter::runtime_ops::make_function_from_code_obj_with_globals_obj(
+        w_code, w_globals,
+    );
+    ctx.trace_ctx.set_opref_concrete(
+        func_op,
+        majit_ir::Value::Ref(majit_ir::GcRef(func as usize)),
+    );
+    write_residual_call_result_to_dst(ctx, op_pc, dst, dst_bank, func_op)?;
+    Ok(Some(()))
+}
+
 /// Mixed W_LongObject/W_IntObject COMPARE_OP specialization.
 ///
 /// `pypy/objspace/std/longobject.py:_make_descr_cmp` selects the corresponding

--- a/pyre/pyre-jit/src/jit/flatten.rs
+++ b/pyre/pyre-jit/src/jit/flatten.rs
@@ -5965,7 +5965,7 @@ where
         ctx.make_function_fn_idx,
         vec![globals, code],
         CallFlavor::Plain,
-        majit_ir::PyreHelperKind::None,
+        majit_ir::PyreHelperKind::MakeFunction,
         dst_reg,
     ))
 }


### PR DESCRIPTION
Two walker folds that remove a residual call each, plus the bench-fixture
sizing that made their gates measure execution instead of startup noise.

## 1. `MAKE_FUNCTION` emits `NewWithVtable` + `SetfieldGc`

`lower_make_function_hlop_to_insn` lowered every `MAKE_FUNCTION` to a
`jit_make_function_from_globals` residual, so a `def` in a loop body allocated a
`Function` per iteration and the object could never be virtualized. The call now
carries `PyreHelperKind::MakeFunction`, and the full-body walker recognises the
tag to emit `function.py:47-57 Function.__init__` inline: one `NewWithVtable`
plus a `SetfieldGc` per slot the constructor writes.

The fold requires both operands constant, a `PyCode` code object, a module-dict
namespace, and a `__builtins__` naming a module; every other shape keeps the
residual. It pins the namespace `version?` before emitting, since
`globals['__builtins__']` is the one input that can be rebound afterwards.

`Function.name` and `qualname` now come off the code object without allocating.
`function_new_from_code` borrows the `Box::into_raw`'d `CodeObject`'s `co_name`
through a new `FunctionName::Borrowed`, and `PyCode` grows a `w_qualname` slot
holding one realized `co_qualname` per code object, forwarded by
`walk_raw_code_roots`. Both are what the emit bakes, so a materialized function
matches the interpreted one; it also makes `c.co_qualname is c.co_qualname`
true.

On `call_loop_local_function` the traced loop drops to 36 ops with no
allocation — the `Function` virtualizes away entirely. Marginal cost per
iteration, two-point slope over N=48M/96M, min of 11 runs:

| | ns/iteration |
|---|---|
| before | 427 |
| after | 1.29 |
| pypy | 0.44 |

i.e. 750x → 2.9x. check.py dynasm exec 0.43s → 0.01s, ratio 49.9x → under the
8x gate.

### The descr census bug this surfaced

`FUNCTION_DESCR_GROUP` grows from 4 fields to the complete 20-slot census,
because `clear_gc_fields` walks it to NULL a fresh object's pointer slots and
the nursery is not zero-filled. `can_change_code` is a plain byte, gets no NULL
store, and must be written explicitly.

The entries are also reordered by byte offset and `w_func_globals` renamed to
the struct's actual `w_func_globals_obj`. That rename is the substantive part:
`descr.py:218-239` caches a FieldDescr per `(STRUCT, fieldname)`, and the LLBC
analyzer has usually already minted every field under its real name, numbering
`index_in_parent` by offset rank past the flattened `PyObject` header. A key
that does not name a struct field misses that cache and gets numbered by its
position in the census list instead — here position 2, colliding with the
analyzer's `name` (rank 2).

`index_in_parent` is the field's slot number in the virtual
(`virtualize.py:210 fielddescr.get_index()`) and its `PtrInfo._fields` key in
the heap optimizer, so two fields sharing one number makes a virtual keep only
the later of the two stores. It was latent while nothing wrote `Function.name`;
the moment the emit wrote both, `Function.name` came out NULL and `f.__name__`
was a wild `w_str_new(&*NULL)` — a SIGSEGV, not a wrong answer. The accessors
now resolve by offset (`function_field_descr`) so they cannot drift out of that
order again.

## 2. `IS_OP` folds to `ptr_eq` / `ptr_ne`

`compare_op_tag_for_opname` gives `is`/`is_not` tags 8 and 9 and the codewriter
routed them through the same `compare_fn` residual as the six ordinary
comparisons, so every identity test in a trace recorded a `CALL_MAY_FORCE` and
its `GUARD_NOT_FORCED`. `try_walker_fold_is_op` handles the two tags directly,
in two tiers:

* same box on both sides — `baseobjspace::is_w` answers at its opening
  `ptr::eq` whatever the class, so the result is a constant, with no op and no
  guard (the `ptr_eq`/`ptr_ne` entries of FASTPATHS_SAME_BOXES,
  `pyjitpl.py:326-336`);
* distinct boxes whose layouts both keep the default `is_w` — a `GuardClass`
  per operand, then `PtrEq`/`PtrNe`.

`is_w_compares_by_value` names the seven layouts whose class overrides `is_w`
with a value comparison (int, float, complex, tuple, bytes, str, frozenset);
those decline to the existing residual, since `GuardClass` pins `ob_type` and an
`int` subclass instance shares `INT_TYPE` with a plain `int` while answering the
exact-type gate differently. A tagged immediate declines too — it carries no
`ob_type` to guard. The recorded concrete is cross-checked against `is_w` before
any IR is emitted.

On `goto_if_not_same_box` the ptr loop's optimized traces go from
`total=35 call_may_force=2 guard_not_forced=2` and `total=30 call_may_force=2
guard_not_forced=2` to `total=15` and `total=10`, both with zero may-force ops
and zero `guard_not_forced`.

## 3. Five bench fixtures sized above the measurement floor

`call_loop_local_function`, `goto_if_not_same_box`, `surrogate_class_kwargs` and
`surrogate_dir` all finished in ~0.01s under pypy, which is the floor
`_performance_gate_passed` compares against, so their pypy-ratio gates were
comparing noise:

| fixture | before | after |
|---|---|---|
| `call_loop_local_function` | 9.0x | 70.5x |
| `goto_if_not_same_box` | 7.3x | 11.5x |
| `surrogate_class_kwargs` | 7.5x | 4.1x (6x gate) |
| `surrogate_dir` | 6.1x | 2.9x (5x gate) |

The two surrogate fixtures were failing only on floor noise; the other two were
partly hidden by it and were genuinely further out than reported — which is what
put the two folds above on the list. The surrogate pair has no loop at all, so
their bodies now run REPEAT=100 rounds and print only the last round's answers;
stdout is byte-identical to before on both engines.

`call_loop_local_function`'s final N is 10M, sized from the gate rather than the
loop: below ~11M iterations pypy lands on the 5ms baseline floor and the
comparison becomes a fixed ~45ms budget for pyre, which is the stable regime;
above it the ceiling is CPython at ~195ns/iteration, and this fixture must not
become the slowest baseline run in the suite. A larger N wants `--synthetic-timeout`
raised with it.

## 4. Correctness fixtures

* `make_function_inline.py` pins what the emit *builds* rather than its speed:
  every slot the constructor writes and every slot it leaves null, read back
  through the app-level surface on a function built inside a hot loop, plus an
  escaping half that forces materialization, `SET_FUNCTION_ATTRIBUTE` defaults
  and closure, and an `exec`-with-bare-dict half that exercises both the
  accepted and the declined `__builtins__` shapes.
* `is_op_identity.py` pins the fold's answers: the accepted shapes with
  sentinel-weighted never-taken arms, and eleven probes over the seven
  value-comparing layouts asserting the hot answers still match the first
  interpreted call. It carries no `max-pypy-ratio` because most of its time is
  the deliberately-declined half.

Both are byte-identical across dynasm / cranelift / wasm and pypy3 / python3.

## 5. `pytraceback` comment correction

The comment at `record_application_traceback` said the line number is stamped
eagerly because a frame the GC does not own is not kept alive by the traceback.
That reason is dead — the `w_code` slot is forwarded unconditionally and is the
same pycode upstream reads, so resolving off `w_code` and `lasti` is safe at any
later point, which `w_pytraceback_get_lineno`'s own doc already said. What
actually blocks the lazy form is the `TbLineno` arm of
`walker_specialize_traceback_walk_field`, which reads the slot directly and
declines on `LINENO_NOT_COMPUTED`. Comment-only.

## Verification

* `cargo test --all --no-default-features --features dynasm` green (97 suites);
  `cargo test -p pyre-object` green separately (303 tests — the crate has no
  `dynasm` feature).
* CI clippy gate green.
* `check.py` both backends: dynasm 14 failures / 353 pass. All 14 were proven
  pre-existing by a full control arm — the changes were backed up and reverted,
  LLBC re-extracted, rebuilt, and check.py re-run; the control produced 18
  failures containing all 14, and `call_loop_local_function` is the one this
  branch removes. The set is 6 stale jit-stats baselines (all last recorded in
  one commit, `44e0c9ccb9`, with main drifted since) + 6 fixtures whose
  `.jitstats` file is absent on `origin/main` too. The perf-gate entries
  disagreed between the two arms and pass 3/3 re-run in isolation at low load.
* Codex parity review: sections 1 and 2 both None. Section 3 is the pre-existing
  eager `tb_lineno` above. Section 4 lists three structural adaptations, each
  already carrying its citation in code.

Based on `f3bddb31f2`, one commit behind `main` at the time of push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved JIT optimization for identity comparisons, including safe constant and pointer-identity folding.
  * Added optimized handling for functions created inside hot loops, including globals, closures, defaults, annotations, and qualified names.
* **Bug Fixes**
  * Improved qualified-name caching and garbage-collection safety for code and function objects.
  * Preserved correct behavior for value-comparing types and unsupported optimization cases.
* **Tests**
  * Added coverage and benchmark scenarios for optimized function creation, identity checks, surrogate behavior, and compatibility cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->