### PR TITLE
dict,__pypy__: root and empty-dispatch move_to_end, pin objects_in_repr's identity_dict

### DIFF
--- a/pyre/pyre-interpreter/src/module/__pypy__/mod.rs
+++ b/pyre/pyre-interpreter/src/module/__pypy__/mod.rs
@@ -120,6 +120,12 @@ fn move_to_end(args: &[pyre_object::PyObjectRef]) -> crate::PyResult {
 /// (`objspace.py:134`): the execution-context-owned identity dict of objects
 /// currently being `repr()`'d, lazily built and cached on the EC.  `identity_dict`
 /// stays an app-level class, so the instance is constructed by calling that type.
+///
+/// `get_objects_in_repr` builds `W_IdentityDict(self)` directly (`objspace.py:136`),
+/// so the recursion guard cannot be swapped through module monkeypatching.  pyre
+/// mirrors that by constructing from the canonical type captured at module init
+/// (`CANONICAL_IDENTITY_DICT_KEY`), not the publicly reassignable
+/// `__pypy__.identity_dict` attribute.
 fn objects_in_repr(_: &[pyre_object::PyObjectRef]) -> crate::PyResult {
     let ec = crate::call::getexecutioncontext() as *mut crate::PyExecutionContext;
     if ec.is_null() {
@@ -133,13 +139,22 @@ fn objects_in_repr(_: &[pyre_object::PyObjectRef]) -> crate::PyResult {
     }
     let module = crate::importing::check_sys_modules("__pypy__")
         .ok_or_else(|| crate::PyError::runtime_error("__pypy__ module not loaded"))?;
-    let ty = crate::baseobjspace::getattr_str(module, "identity_dict")?;
+    let ty =
+        crate::baseobjspace::getattr_str(module, CANONICAL_IDENTITY_DICT_KEY).map_err(|_| {
+            crate::PyError::runtime_error("__pypy__: canonical identity_dict unavailable")
+        })?;
     let inst = crate::call::call_function_impl_result(ty, &[])?;
     // Stored immediately (no intervening allocation); thereafter forwarded by
     // `ExecutionContext::walk_builtin_roots`.
     unsafe { (*ec).py_repr = inst };
     Ok(inst)
 }
+
+/// Module-dict key holding the `identity_dict` type captured at module init.
+/// Not a valid Python identifier, so it cannot be reached — or rewritten —
+/// through `__pypy__.identity_dict` attribute access; the module dict is
+/// Box-immortal, so the entry roots the type for the lifetime of the process.
+const CANONICAL_IDENTITY_DICT_KEY: &str = "@objects_in_repr_identity_dict";
 
 crate::py_module! {
     "__pypy__",
@@ -163,6 +178,13 @@ crate::py_module! {
         // Mark as a package so `from __pypy__.builders import ...`
         // treats `__pypy__` as a package with submodules.
         crate::module_ns_store(ns, "__path__", pyre_object::w_list_new(vec![]));
+        // Snapshot the canonical `identity_dict` type before any app code can
+        // reassign `__pypy__.identity_dict`, keyed so attribute access cannot
+        // reach it.  `objects_in_repr` builds its recursion guard from this
+        // snapshot, matching PyPy's direct `W_IdentityDict` construction.
+        if let Some(ty) = crate::module_ns_get(ns, "identity_dict") {
+            crate::module_ns_store(ns, CANONICAL_IDENTITY_DICT_KEY, ty);
+        }
     }
 }
 

--- a/pyre/pyre-object/src/dictmultiobject.rs
+++ b/pyre/pyre-object/src/dictmultiobject.rs
@@ -3663,6 +3663,12 @@ pub unsafe fn w_dict_move_to_end_checked(
     key: PyObjectRef,
     last: bool,
 ) -> Result<bool, DictKeyError> {
+    // `object_key_for_checked` hashes the key (`space.hash_w`, a collection
+    // point), and the strategy switch below reallocates the backing store, so
+    // pin and reload `obj`/`key` across the lock safepoint exactly as the other
+    // checked dict primitives do — a stale `obj` or `ObjectKey.obj` after a
+    // moving GC would corrupt the `IndexMap` access.
+    lock_dict_refs!(_dict_guard, obj, key);
     if is_module_dict(obj) {
         if !w_module_dict_is_object_strategy(obj) {
             w_module_dict_switch_to_object_strategy(obj);
@@ -3696,6 +3702,21 @@ pub unsafe fn w_dict_move_to_end_checked(
     }
 
     let strategy = (*(obj as *const W_DictObject)).dstrategy;
+    // `EmptyDictStrategy.move_to_end` (dictmultiobject.py:820-821) raises
+    // `KeyError` for the requested key without hashing it: an unhashable key
+    // reports `KeyError`, not the object strategy's unhashable `TypeError`, and
+    // no user `__hash__` runs.  Dispatch through the empty strategy before
+    // switching, matching `w_dict_delitem_checked`'s empty-strategy arm (which,
+    // being `del`, does hash).
+    if strategy_is(strategy, &crate::dictmultiobject::EMPTY_DICT_STRATEGY)
+        || strategy_is(
+            strategy,
+            &crate::dictmultiobject::EMPTY_KWARGS_DICT_STRATEGY,
+        )
+    {
+        return Ok(false);
+    }
+
     let kind = strategy.strategy_kind();
 
     // Typed stores reorder in place, preserving the strategy — the
@@ -3719,7 +3740,8 @@ pub unsafe fn w_dict_move_to_end_checked(
 
     // Object and Unicode share the `IndexMap<ObjectKey>` representation, so the
     // reorder below runs in place; only a genuinely foreign store (a typed
-    // store reached with a non-native key, or Kwargs/Map/Empty) is converted.
+    // store reached with a non-native key, or a Kwargs/Map store) is converted;
+    // the empty strategies are handled above.
     if kind != StrategyKind::Object && kind != StrategyKind::Unicode {
         strategy.switch_to_object_strategy(obj);
     }


### PR DESCRIPTION
Follow-up to #957, addressing its three Codex P1 review comments.

## 1. Root `obj`/`key` across the hash in `w_dict_move_to_end_checked`

`w_dict_move_to_end_checked` hashed the key (`object_key_for_checked` → `try_hash_w` → user `__hash__`, a GC/collection point) and switched strategies without `lock_dict_refs!`, so a moving GC could leave `obj` / `ObjectKey.obj` stale before the `IndexMap` access. Added `lock_dict_refs!(_dict_guard, obj, key)` at the top, matching every sibling checked op. The dict lock is a `ReentrantMutexGuard`, so the nested guard inside the module branch's `w_module_dict_switch_to_object_strategy` does not deadlock.

## 2. Dispatch the empty dict strategy without hashing

The op unconditionally switched an empty dict to the object strategy and then hashed, so `move_to_end({}, [])` raised an unhashable `TypeError` and ran `__hash__` for missing keys. `EmptyDictStrategy.move_to_end` raises `KeyError` without hashing. Short-circuit `EMPTY_DICT_STRATEGY` / `EMPTY_KWARGS_DICT_STRATEGY` → `Ok(false)` (the wrapper maps that to `KeyError`) before switching. The `delitem` sibling *does* hash on empty because `del` hashes; `move_to_end` must not.

## 3. Build `objects_in_repr`'s guard from a canonical `identity_dict`

`objects_in_repr` resolved the mutable public `__pypy__.identity_dict` attribute, so monkeypatching it (e.g. `= lambda: 42`) broke the `OrderedDict` repr recursion guard. `get_objects_in_repr` builds `W_IdentityDict(self)` directly. `identity_dict` stays app-level here, so `extra_init` now snapshots the type under a non-identifier module-dict key `@objects_in_repr_identity_dict` (unreachable by attribute syntax; the module dict is Box-immortal so it roots the type), and `objects_in_repr` constructs from that snapshot.

---

Verified: `PYRE_JIT=0` and JIT both produce identical correct output; the #957 fixture `pypy_dict_primitives_nonbinding.py` still prints OK.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dictionary operations involving garbage-collected objects, preventing reference-related issues during key handling and strategy transitions.
  * Empty dictionaries now handle move-to-end operations consistently without unnecessary key processing.
  * Strengthened object representation handling by ensuring it uses the correct internal type information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->