### PR TITLE
_hashlib: make new and openssl_<name> constructors non-binding interp functions

### DIFF
--- a/pyre/pyre-interpreter/src/module/_hashlib/_hashlib_app.py
+++ b/pyre/pyre-interpreter/src/module/_hashlib/_hashlib_app.py
@@ -2,8 +2,8 @@
 
 `HASH` accumulates the fed data and re-computes the digest through the
 interp-level `_hashlib._oneshot_digest` primitive on demand.  The
-`openssl_<name>` constructors and `new` mirror the OpenSSL surface
-`hashlib.py` expects.
+`openssl_<name>` constructors and `new` are interp-level (non-binding) and
+build a `HASH`.
 """
 
 _DIGEST_SIZE = {
@@ -65,30 +65,3 @@ class HASH:
         clone = HASH(self._name)
         clone._data = bytearray(self._data)
         return clone
-
-
-def new(name, string=b"", *, usedforsecurity=True, **kwargs):
-    return HASH(name, string)
-
-
-def _ctor(_name):
-    def constructor(string=b"", *, usedforsecurity=True, **kwargs):
-        return HASH(_name, string)
-    constructor.__name__ = "openssl_" + _name
-    return constructor
-
-
-openssl_md5 = _ctor("md5")
-openssl_sha1 = _ctor("sha1")
-openssl_sha224 = _ctor("sha224")
-openssl_sha256 = _ctor("sha256")
-openssl_sha384 = _ctor("sha384")
-openssl_sha512 = _ctor("sha512")
-openssl_sha3_224 = _ctor("sha3_224")
-openssl_sha3_256 = _ctor("sha3_256")
-openssl_sha3_384 = _ctor("sha3_384")
-openssl_sha3_512 = _ctor("sha3_512")
-openssl_shake_128 = _ctor("shake_128")
-openssl_shake_256 = _ctor("shake_256")
-openssl_blake2b = _ctor("blake2b")
-openssl_blake2s = _ctor("blake2s")

--- a/pyre/pyre-interpreter/src/module/_hashlib/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_hashlib/mod.rs
@@ -1,11 +1,12 @@
 //! _hashlib module — the OpenSSL-backed digest surface `hashlib.py` probes.
 //!
 //! The actual digests are computed by `pyre-native` through
-//! [`oneshot_digest`]; the `HASH` object and the `openssl_<name>` /
-//! `new` constructors live in the app-level `_hashlib_app.py`, which
-//! calls back into `_oneshot_digest` at digest time.  Accumulating the
-//! data and re-hashing on `digest()` keeps the object model trivial at
-//! the cost of recomputation.
+//! [`oneshot_digest`]; the `HASH` object lives in the app-level
+//! `_hashlib_app.py`, while the non-binding `openssl_<name>` and `new`
+//! constructors are interp-level here and build a `HASH`, which calls back
+//! into `_oneshot_digest` at digest time.  Accumulating the data and
+//! re-hashing on `digest()` keeps the object model trivial at the cost of
+//! recomputation.
 
 use pyre_object::*;
 
@@ -84,21 +85,21 @@ fn oneshot_digest(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     }
 }
 
-/// `HASH(name)` name resolution — the Python name of the digest `name`
-/// selects.  OpenSSL resolves the digest when the context is created, so an
-/// unknown name is reported there rather than when the digest is finally
-/// taken.
-fn resolve_digest_name(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    let name_obj = args.first().copied().unwrap_or_else(w_none);
-    if !unsafe { is_str(name_obj) } {
+/// The `name: str` clinic conversion: `name` must be a str (or subclass, per
+/// `PyUnicode_Check`), and its utf-8 form must exist — a lone surrogate raises
+/// `UnicodeEncodeError`, an embedded null raises `ValueError`.  This runs as
+/// part of the argument parse, before the constructor body, so `new` validates
+/// the name ahead of the `data`/`string` and buffer handling.
+fn check_digest_name(name_obj: PyObjectRef) -> Result<(), crate::PyError> {
+    if !unsafe { crate::baseobjspace::isinstance_str_w(name_obj) } {
         return Err(crate::PyError::type_error(format!(
             "new() argument 'name' must be str, not {}",
             crate::type_methods::arg_type_name(name_obj)
         )));
     }
-    // Read off the buffer and report the failures the utf-8 conversion of the
-    // name would: a lone surrogate does not encode, and an embedded null ends
-    // the C string the digest is looked up by.
+    // Report the failures the utf-8 conversion of the name would: a lone
+    // surrogate does not encode, and an embedded null ends the C string the
+    // digest is looked up by.
     let name = unsafe { w_str_get_wtf8(name_obj) };
     if let Some(pos) = name
         .code_points()
@@ -115,6 +116,17 @@ fn resolve_digest_name(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErr
     if name.as_bytes().contains(&0) {
         return Err(crate::PyError::value_error("embedded null character"));
     }
+    Ok(())
+}
+
+/// `HASH(name)` name resolution — the Python name of the digest `name`
+/// selects.  OpenSSL resolves the digest when the context is created, so an
+/// unknown name is reported there rather than when the digest is finally
+/// taken.
+fn resolve_digest_name(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let name_obj = args.first().copied().unwrap_or_else(w_none);
+    check_digest_name(name_obj)?;
+    let name = unsafe { w_str_get_wtf8(name_obj) };
     match lookup_digest_name(name.as_bytes()) {
         Some(python_name) => Ok(w_str_new(python_name)),
         None => Err(unsupported_digestmod(&format!(
@@ -182,6 +194,138 @@ fn compare_digest(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     Ok(w_bool_from(result == 0))
 }
 
+/// Keyword names `new` accepts (`_hashopenssl.c` `_hashlib_new`): the
+/// positional-or-keyword `name`/`data`, then keyword-only `usedforsecurity`
+/// (accepted and ignored) and `string` (a deprecated alias for `data`).
+const NEW_KEYWORDS: &[&str] = &["name", "data", "usedforsecurity", "string"];
+
+/// Keyword names the `openssl_<name>` factories accept (`EVP_new`) — the same
+/// tail as [`NEW_KEYWORDS`] without the leading `name`.
+const OPENSSL_KEYWORDS: &[&str] = &["data", "usedforsecurity", "string"];
+
+/// Read `obj` as a contiguous byte buffer through the `PyBUF_SIMPLE` protocol,
+/// raising the `GET_BUFFER_VIEW_OR_ERROR` TypeErrors a str or other non-buffer
+/// draws.  A caller reaches this only for a value that was actually supplied;
+/// absent data leaves the digest empty and never lands here.
+fn read_hash_buffer(obj: PyObjectRef) -> Result<Vec<u8>, crate::PyError> {
+    if unsafe { crate::baseobjspace::isinstance_str_w(obj) } {
+        return Err(crate::PyError::type_error(
+            "Strings must be encoded before hashing",
+        ));
+    }
+    match crate::baseobjspace::simple_buffer_bytes(obj)? {
+        Some(buf) => {
+            let bytes = buf.as_bytes().to_vec();
+            buf.release();
+            Ok(bytes)
+        }
+        None => Err(crate::PyError::type_error(
+            "object supporting the buffer API required",
+        )),
+    }
+}
+
+/// Coerce `usedforsecurity` and resolve the mutually-exclusive `data`/`string`
+/// argument, then build `HASH(name, data)`.  `usedforsecurity: bool` is a
+/// clinic converter, so `PyObject_IsTrue` runs — and a raising `__bool__`
+/// propagates — before the body; its value has no effect, so only the side
+/// effect is kept.  `data` and `string` may not both be given; a supplied
+/// value is read through the buffer protocol before the digest name is looked
+/// up, and an absent one leaves the digest empty.
+fn make_hash(
+    name: PyObjectRef,
+    data: Option<PyObjectRef>,
+    string: Option<PyObjectRef>,
+    usedforsecurity: Option<PyObjectRef>,
+) -> Result<PyObjectRef, crate::PyError> {
+    // `usedforsecurity`'s truth test and the buffer acquisition can both
+    // re-enter Python (`__bool__` / `__buffer__`) and move objects under the
+    // moving GC, so every incoming object is a shadow-stack root read back
+    // from its slot after each re-entry.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let name_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(name);
+    let pin = |obj: PyObjectRef| {
+        let slot = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(obj);
+        slot
+    };
+    let data_slot = data.map(pin);
+    let string_slot = string.map(pin);
+    if let Some(flag) = usedforsecurity {
+        let flag_slot = pin(flag);
+        crate::baseobjspace::is_true(pyre_object::gc_roots::shadow_stack_get(flag_slot))?;
+    }
+    if data_slot.is_some() && string_slot.is_some() {
+        return Err(crate::PyError::type_error(
+            "'data' and 'string' are mutually exclusive and support for 'string' \
+             keyword parameter is slated for removal in a future version.",
+        ));
+    }
+    let data_bytes = match data_slot.or(string_slot) {
+        Some(slot) => read_hash_buffer(pyre_object::gc_roots::shadow_stack_get(slot))?,
+        None => Vec::new(),
+    };
+    let bytes_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(w_bytes_from_bytes(&data_bytes));
+    let module = crate::importing::check_sys_modules("_hashlib")
+        .ok_or_else(|| crate::PyError::runtime_error("_hashlib module not loaded"))?;
+    let hash_cls = crate::baseobjspace::getattr_str(module, "HASH")?;
+    crate::call::call_function_impl_result(
+        hash_cls,
+        &[
+            pyre_object::gc_roots::shadow_stack_get(name_slot),
+            pyre_object::gc_roots::shadow_stack_get(bytes_slot),
+        ],
+    )
+}
+
+/// `new(name, data=b'', *, usedforsecurity=True, string=None)` — build a
+/// `HASH` for `name`.  Non-binding so it demotes to a plain
+/// `builtin_function_or_method`.
+fn new_hash(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let (positional, kwargs) = crate::builtins::split_builtin_kwargs(args);
+    crate::builtins::clinic_arity(
+        "new",
+        positional.len(),
+        crate::builtins::real_kwarg_count(kwargs),
+        1,
+        2,
+        2,
+    )?;
+    let name = crate::builtins::bind_pos_or_kw(positional, kwargs, 0, "name", "new", 1)?;
+    let data = crate::builtins::bind_pos_or_kw(positional, kwargs, 1, "data", "new", 2)?;
+    let name = name.ok_or_else(|| {
+        crate::PyError::type_error("new() missing required argument 'name' (pos 1)")
+    })?;
+    crate::builtins::kwarg_reject_unknown(kwargs, NEW_KEYWORDS, "new")?;
+    check_digest_name(name)?;
+    let string = crate::builtins::kwarg_get(kwargs, "string");
+    let usedforsecurity = crate::builtins::kwarg_get(kwargs, "usedforsecurity");
+    make_hash(name, data, string, usedforsecurity)
+}
+
+/// `openssl_<digest>(data=b'', *, usedforsecurity=True, string=None)` — the
+/// fixed-name factories, non-binding so they demote to
+/// `builtin_function_or_method`.
+fn make_openssl_hash(digest: &str, args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let fn_name = format!("openssl_{digest}");
+    let (positional, kwargs) = crate::builtins::split_builtin_kwargs(args);
+    crate::builtins::clinic_arity(
+        &fn_name,
+        positional.len(),
+        crate::builtins::real_kwarg_count(kwargs),
+        0,
+        1,
+        2,
+    )?;
+    let data = crate::builtins::bind_pos_or_kw(positional, kwargs, 0, "data", &fn_name, 1)?;
+    crate::builtins::kwarg_reject_unknown(kwargs, OPENSSL_KEYWORDS, &fn_name)?;
+    let string = crate::builtins::kwarg_get(kwargs, "string");
+    let usedforsecurity = crate::builtins::kwarg_get(kwargs, "usedforsecurity");
+    make_hash(w_str_new(digest), data, string, usedforsecurity)
+}
+
 crate::py_module! {
     "_hashlib",
     interpleveldefs: {
@@ -197,15 +341,22 @@ crate::py_module! {
             .expect("ValueError installed"),
     },
     appleveldefs: {
-        "_hashlib_app.py" => [
-            "HASH", "new",
-            "openssl_md5", "openssl_sha1", "openssl_sha224", "openssl_sha256",
-            "openssl_sha384", "openssl_sha512", "openssl_sha3_224", "openssl_sha3_256",
-            "openssl_sha3_384", "openssl_sha3_512", "openssl_shake_128", "openssl_shake_256",
-            "openssl_blake2b", "openssl_blake2s",
-        ],
+        "_hashlib_app.py" => ["HASH"],
     },
     functions: {
+        "new" / * = new_hash,
+        "openssl_md5" / * = |args| make_openssl_hash("md5", args),
+        "openssl_sha1" / * = |args| make_openssl_hash("sha1", args),
+        "openssl_sha224" / * = |args| make_openssl_hash("sha224", args),
+        "openssl_sha256" / * = |args| make_openssl_hash("sha256", args),
+        "openssl_sha384" / * = |args| make_openssl_hash("sha384", args),
+        "openssl_sha512" / * = |args| make_openssl_hash("sha512", args),
+        "openssl_sha3_224" / * = |args| make_openssl_hash("sha3_224", args),
+        "openssl_sha3_256" / * = |args| make_openssl_hash("sha3_256", args),
+        "openssl_sha3_384" / * = |args| make_openssl_hash("sha3_384", args),
+        "openssl_sha3_512" / * = |args| make_openssl_hash("sha3_512", args),
+        "openssl_shake_128" / * = |args| make_openssl_hash("shake_128", args),
+        "openssl_shake_256" / * = |args| make_openssl_hash("shake_256", args),
         "_oneshot_digest" / * = oneshot_digest,
         "_resolve_digest_name" / 1 = resolve_digest_name,
         "compare_digest" / 2 = compare_digest,


### PR DESCRIPTION
Part of epic #40 (make C-module module-level functions non-binding: appleveldef → interpleveldef). `_hashlib` is a **pyre-original** module (PyPy implements `_hashlib` via CFFI, so there is no upstream interp-level structure to mirror), so the parity target is **CPython 3.14 behavior**.

## What changed
- `new` and `openssl_md5`…`openssl_shake_256` moved from the app-level `_hashlib_app.py` into interp-level `functions:` entries, so they demote to non-binding `builtin_function_or_method` (the point of #40). The `HASH` class stays app-level.
- Argument handling composes the existing `builtins.rs` primitives — `clinic_arity` / `bind_pos_or_kw` / `kwarg_reject_unknown` / `kwarg_get` — to reproduce CPython's `_PyArg_UnpackKeywords` order **without** touching the shared `bind_builtin_kwargs` (which hardcodes `kwonly=0` and so can't model the keyword-only `usedforsecurity`/`string`).
- Data/string buffer is read through `simple_buffer_bytes` (PyBUF_SIMPLE), fixing the old app path's `bytes()` which wrongly accepted `int`/`list`/`None`.
- `openssl_blake2b`/`openssl_blake2s` removed from the `functions:` block: CPython's `_hashlib` exposes **12** `openssl_*`, not 14 (blake2 lives in `_blake2`). `DIGEST_NAMES` keeps blake2b/blake2s so `new('blake2b')` and `openssl_md_meth_names` still resolve them; `hashlib.blake2b` (via `_blake2`) is unaffected.

## CPython 3.14 argument order reproduced (`_hashopenssl.c` clinic)
arity → dup (pos+kw) → missing-required → unknown-keyword → name str-type + utf-8 validation (surrogate → `UnicodeEncodeError`, embedded-null → `ValueError`) → `usedforsecurity` coerced via `PyObject_IsTrue` (a raising `__bool__` propagates) → `data`/`string` mutual-exclusion → buffer read (str → "Strings must be encoded before hashing", other non-buffer → "object supporting the buffer API required"). A `str` subclass is accepted as a name and rejected as data (subclass-inclusive `isinstance_str_w`).

## Verification
- **Byte-identical to CPython 3.14** across ~90 cases (arg parsing, error ordering + messages, digests, non-binding property, str-subclass, `usedforsecurity` coercion), both `PYRE_JIT=0` and JIT.
- `hmac` / `hashlib` downstream identical to CPython.
- 3000-iteration GC-stress of the re-entrant paths (`__bool__` / `__buffer__` forcing collection) — no crash, all digests correct, jit == nojit.
- Adversarial 3-lens review (GC-rooting / error-order / lifecycle): the 5 confirmed parity edges above are all fixed in this PR; the GC-rooting lens found no memory hazards.

## Deferred
- CPython appends a ". Did you mean 'X'?" suggestion to unknown-keyword errors (`_Py_CalculateSuggestions`); pyre's shared `kwarg_reject_unknown` does not. This is a systemic, interpreter-wide divergence (all builtins), not specific to this slice — tracked as a follow-up.

— *commented by Claude*