### PR TITLE
typedef: method-wrapper and classmethod_descriptor types, plus jit-stats baselines

### DIFF
--- a/lib-python/3/inspect.py
+++ b/lib-python/3/inspect.py
@@ -165,21 +165,6 @@ from operator import attrgetter
 from collections import namedtuple, OrderedDict
 from weakref import ref as make_weakref
 
-# PyPy/pyre gateway functions are ordinary ``function`` objects carrying a
-# distinct builtin-code object.  CPython identifies native descriptors by
-# their callable object types; those aliases are broader on PyPy (notably
-# ``types.WrapperDescriptorType is types.FunctionType``), so retain the code
-# type discriminator used by PyPy's inspect port.
-try:
-    _builtin_code_type = type(dict.update.__code__)
-except AttributeError:
-    _builtin_code_type = None
-
-# ``types.WrapperDescriptorType`` cannot name the slot-wrapper type here:
-# ``object.__init__`` is an ordinary method descriptor, so that alias resolves
-# to ``MethodDescriptorType``.  ``int.__pow__`` is a real slot wrapper.
-_slot_wrapper_type = type(int.__pow__)
-
 # Create constants for the compiler flags in Include/code.h
 # We try to get them from dis to avoid duplication
 mod_dict = globals()
@@ -202,10 +187,7 @@ def isclass(object):
 
 def ismethod(object):
     """Return true if the object is an instance method."""
-    if not isinstance(object, types.MethodType):
-        return False
-    func = object.__func__
-    return not isinstance(func, types.MethodDescriptorType)
+    return isinstance(object, types.MethodType)
 
 def ispackage(object):
     """Return true if the object is a package."""
@@ -226,8 +208,7 @@ def ismethoddescriptor(object):
     tests return false from the ismethoddescriptor() test, simply because
     the other tests promise more -- you can, e.g., count on having the
     __func__ attribute (etc) when an object passes ismethod()."""
-    if (isclass(object) or ismethod(object) or isfunction(object)
-            or isbuiltin(object) or ismethodwrapper(object)):
+    if isclass(object) or ismethod(object) or isfunction(object):
         # mutual exclusion
         return False
     tp = type(object)
@@ -299,10 +280,7 @@ def isfunction(object):
         __dict__        namespace which is supporting arbitrary function attributes
         __closure__     a tuple of cells or None
         __type_params__ tuple of type parameters"""
-    if not isinstance(object, types.FunctionType):
-        return False
-    code = getattr(object, "__code__", None)
-    return not (_builtin_code_type and isinstance(code, _builtin_code_type))
+    return isinstance(object, types.FunctionType)
 
 def _has_code_flag(f, flag):
     """Return true if ``f`` is a function (or a method or functools.partial
@@ -458,26 +436,11 @@ def isbuiltin(object):
         __doc__         documentation string
         __name__        original name of this function or method
         __self__        instance to which a method is bound, or None"""
-    if isinstance(object, types.BuiltinFunctionType):
-        # A bound slot dunder shares this type; it is a method wrapper, and
-        # the two predicates are mutually exclusive.
-        return not ismethodwrapper(object)
-    if isinstance(object, types.MethodType):
-        name = getattr(object.__func__, "__name__", "")
-        if name.startswith("__") and name.endswith("__"):
-            return False
-        func = object.__func__
-        return isinstance(func, types.MethodDescriptorType)
-    return False
+    return isinstance(object, types.BuiltinFunctionType)
 
 def ismethodwrapper(object):
     """Return true if the object is a method wrapper."""
-    if not isinstance(object, types.MethodWrapperType):
-        return False
-    func = getattr(object, "__func__", None)
-    name = getattr(func, "__name__", "")
-    return (name.startswith("__") and name.endswith("__")
-            and isinstance(func, types.MethodDescriptorType))
+    return isinstance(object, types.MethodWrapperType)
 
 def isroutine(object):
     """Return true if the object is any kind of function or method."""
@@ -1945,7 +1908,7 @@ def getasyncgenlocals(agen):
 ###############################################################################
 
 
-_NonUserDefinedCallables = (# types.WrapperDescriptorType,  # function on PyPy
+_NonUserDefinedCallables = (types.WrapperDescriptorType,
                             types.MethodWrapperType,
                             types.ClassMethodDescriptorType,
                             types.BuiltinFunctionType)
@@ -1960,35 +1923,22 @@ def _signature_get_user_defined_method(cls, method_name, *, follow_wrapper_chain
         meth = getattr(cls, method_name, None)
     else:
         meth = getattr_static(cls, method_name, None)
-    # PYPY: the CPython callable-type gate is too broad here.  On PyPy and
-    # pyre WrapperDescriptorType aliases FunctionType, MethodWrapperType
-    # aliases MethodType, and ClassMethodDescriptorType aliases classmethod.
-    # Inspect the wrapped callable's concrete descriptor type instead.
     if meth is None:
         return None
-    if meth in (type.__call__, type.__init__, type.__new__,
-                object.__new__, object.__init__):
-        return None
-    if isinstance(meth, (classmethod, staticmethod)):
-        inner = meth.__func__
-    elif isinstance(meth, types.MethodType):
-        inner = meth.__func__
-        if isinstance(inner, (types.MethodDescriptorType, _slot_wrapper_type)):
-            # Bound BuiltinMethodType / MethodWrapperType remain unsupported
-            # here.  A bare FunctionWithFixedCode method descriptor below is
-            # handled separately.
-            return None
-    else:
-        inner = meth
+
+    # NOTE: The meth may wraps a non-user-defined callable.
+    # In this case, we treat the meth as non-user-defined callable too.
+    # (e.g. cls.__new__ generated by @warnings.deprecated)
+    unwrapped_meth = None
     if follow_wrapper_chains:
-        inner = unwrap(inner, stop=lambda m: hasattr(m, "__signature__"))
-    if isinstance(inner, types.BuiltinFunctionType):
+        unwrapped_meth = unwrap(meth, stop=(lambda m: hasattr(m, "__signature__")
+                                  or _signature_is_builtin(m)))
+
+    if (isinstance(meth, _NonUserDefinedCallables)
+          or isinstance(unwrapped_meth, _NonUserDefinedCallables)):
+        # Once '__signature__' will be added to 'C'-level
+        # callables, this check won't be necessary
         return None
-    if isinstance(inner, types.MethodDescriptorType):
-        own_new = (method_name == '__new__' and
-                   getattr(inner, '__objclass__', None) is cls)
-        if not getattr(inner, '__text_signature__', None) or own_new:
-            return None
     if method_name != '__new__':
         meth = _descriptor_get(meth, cls)
     return meth

--- a/pyre/bench/synth/float_div_zero_caught_loop.cranelift.jitstats
+++ b/pyre/bench/synth/float_div_zero_caught_loop.cranelift.jitstats
@@ -1,8 +1,8 @@
-bridges_compiled=2
+bridges_compiled=3
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
-guard_failures=402
+guard_failures=611
 internal_compile_panics=0
-loops_aborted=1
+loops_aborted=0
 loops_compiled=2

--- a/pyre/bench/synth/float_div_zero_caught_loop.dynasm.jitstats
+++ b/pyre/bench/synth/float_div_zero_caught_loop.dynasm.jitstats
@@ -1,8 +1,8 @@
-bridges_compiled=2
+bridges_compiled=3
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
-guard_failures=402
+guard_failures=611
 internal_compile_panics=0
-loops_aborted=1
+loops_aborted=0
 loops_compiled=2

--- a/pyre/bench/synth/float_div_zero_caught_loop.wasm.jitstats
+++ b/pyre/bench/synth/float_div_zero_caught_loop.wasm.jitstats
@@ -2,4 +2,4 @@ descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
 internal_compile_panics=0
-loops_aborted=1
+loops_aborted=0

--- a/pyre/bench/synth/hot_loop_exit_then_class_stmt.cranelift.jitstats
+++ b/pyre/bench/synth/hot_loop_exit_then_class_stmt.cranelift.jitstats
@@ -1,0 +1,8 @@
+bridges_compiled=0
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
+guard_failures=2
+internal_compile_panics=0
+loops_aborted=0
+loops_compiled=2

--- a/pyre/bench/synth/hot_loop_exit_then_class_stmt.dynasm.jitstats
+++ b/pyre/bench/synth/hot_loop_exit_then_class_stmt.dynasm.jitstats
@@ -1,0 +1,8 @@
+bridges_compiled=0
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
+guard_failures=2
+internal_compile_panics=0
+loops_aborted=0
+loops_compiled=2

--- a/pyre/bench/synth/hot_loop_exit_then_class_stmt.wasm.jitstats
+++ b/pyre/bench/synth/hot_loop_exit_then_class_stmt.wasm.jitstats
@@ -1,0 +1,5 @@
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
+internal_compile_panics=0
+loops_aborted=0

--- a/pyre/bench/synth/inline_freevar_after_mayforce.cranelift.jitstats
+++ b/pyre/bench/synth/inline_freevar_after_mayforce.cranelift.jitstats
@@ -1,0 +1,8 @@
+bridges_compiled=1
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
+guard_failures=16898
+internal_compile_panics=0
+loops_aborted=0
+loops_compiled=8

--- a/pyre/bench/synth/inline_freevar_after_mayforce.dynasm.jitstats
+++ b/pyre/bench/synth/inline_freevar_after_mayforce.dynasm.jitstats
@@ -1,0 +1,8 @@
+bridges_compiled=1
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
+guard_failures=16898
+internal_compile_panics=0
+loops_aborted=0
+loops_compiled=8

--- a/pyre/bench/synth/inline_freevar_after_mayforce.wasm.jitstats
+++ b/pyre/bench/synth/inline_freevar_after_mayforce.wasm.jitstats
@@ -1,0 +1,5 @@
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
+internal_compile_panics=0
+loops_aborted=0

--- a/pyre/bench/synth/inline_subwalk_mutating_residual.cranelift.jitstats
+++ b/pyre/bench/synth/inline_subwalk_mutating_residual.cranelift.jitstats
@@ -1,8 +1,8 @@
-bridges_compiled=3
+bridges_compiled=4
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
-guard_failures=603
+guard_failures=813
 internal_compile_panics=0
 loops_aborted=0
-loops_compiled=3
+loops_compiled=4

--- a/pyre/bench/synth/inline_subwalk_mutating_residual.dynasm.jitstats
+++ b/pyre/bench/synth/inline_subwalk_mutating_residual.dynasm.jitstats
@@ -1,8 +1,8 @@
-bridges_compiled=3
+bridges_compiled=4
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
-guard_failures=603
+guard_failures=813
 internal_compile_panics=0
 loops_aborted=0
-loops_compiled=3
+loops_compiled=4

--- a/pyre/bench/synth/inline_subwalk_mutating_residual.wasm.jitstats
+++ b/pyre/bench/synth/inline_subwalk_mutating_residual.wasm.jitstats
@@ -2,4 +2,4 @@ descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
 internal_compile_panics=0
-loops_aborted=2
+loops_aborted=1

--- a/pyre/bench/synth/inline_subwalk_property_mutates.cranelift.jitstats
+++ b/pyre/bench/synth/inline_subwalk_property_mutates.cranelift.jitstats
@@ -1,8 +1,8 @@
-bridges_compiled=2
+bridges_compiled=3
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
-guard_failures=401
+guard_failures=611
 internal_compile_panics=0
 loops_aborted=0
-loops_compiled=1
+loops_compiled=2

--- a/pyre/bench/synth/inline_subwalk_property_mutates.dynasm.jitstats
+++ b/pyre/bench/synth/inline_subwalk_property_mutates.dynasm.jitstats
@@ -1,8 +1,8 @@
-bridges_compiled=2
+bridges_compiled=3
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
-guard_failures=401
+guard_failures=611
 internal_compile_panics=0
 loops_aborted=0
-loops_compiled=1
+loops_compiled=2

--- a/pyre/bench/synth/inline_subwalk_property_mutates.wasm.jitstats
+++ b/pyre/bench/synth/inline_subwalk_property_mutates.wasm.jitstats
@@ -2,4 +2,4 @@ descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
 internal_compile_panics=0
-loops_aborted=2
+loops_aborted=1

--- a/pyre/bench/synth/math_log_trig_hot.cranelift.jitstats
+++ b/pyre/bench/synth/math_log_trig_hot.cranelift.jitstats
@@ -1,0 +1,8 @@
+bridges_compiled=0
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
+guard_failures=1
+internal_compile_panics=0
+loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/math_log_trig_hot.dynasm.jitstats
+++ b/pyre/bench/synth/math_log_trig_hot.dynasm.jitstats
@@ -1,0 +1,8 @@
+bridges_compiled=0
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
+guard_failures=1
+internal_compile_panics=0
+loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/math_log_trig_hot.wasm.jitstats
+++ b/pyre/bench/synth/math_log_trig_hot.wasm.jitstats
@@ -1,0 +1,5 @@
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
+internal_compile_panics=0
+loops_aborted=0

--- a/pyre/bench/synth/mutate_then_raise_caught.cranelift.jitstats
+++ b/pyre/bench/synth/mutate_then_raise_caught.cranelift.jitstats
@@ -1,8 +1,8 @@
-bridges_compiled=2
+bridges_compiled=3
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
-guard_failures=401
+guard_failures=611
 internal_compile_panics=0
 loops_aborted=0
-loops_compiled=1
+loops_compiled=2

--- a/pyre/bench/synth/mutate_then_raise_caught.dynasm.jitstats
+++ b/pyre/bench/synth/mutate_then_raise_caught.dynasm.jitstats
@@ -1,8 +1,8 @@
-bridges_compiled=2
+bridges_compiled=3
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
-guard_failures=401
+guard_failures=611
 internal_compile_panics=0
 loops_aborted=0
-loops_compiled=1
+loops_compiled=2

--- a/pyre/bench/synth/mutate_then_raise_caught.wasm.jitstats
+++ b/pyre/bench/synth/mutate_then_raise_caught.wasm.jitstats
@@ -2,4 +2,4 @@ descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
 internal_compile_panics=0
-loops_aborted=2
+loops_aborted=0

--- a/pyre/bench/synth/pickle_terminal_raise_resume.cranelift.jitstats
+++ b/pyre/bench/synth/pickle_terminal_raise_resume.cranelift.jitstats
@@ -1,0 +1,8 @@
+bridges_compiled=0
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
+guard_failures=676
+internal_compile_panics=0
+loops_aborted=0
+loops_compiled=34

--- a/pyre/bench/synth/pickle_terminal_raise_resume.dynasm.jitstats
+++ b/pyre/bench/synth/pickle_terminal_raise_resume.dynasm.jitstats
@@ -1,0 +1,8 @@
+bridges_compiled=0
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
+guard_failures=487
+internal_compile_panics=0
+loops_aborted=0
+loops_compiled=33

--- a/pyre/bench/synth/pickle_terminal_raise_resume.wasm.jitstats
+++ b/pyre/bench/synth/pickle_terminal_raise_resume.wasm.jitstats
@@ -1,0 +1,5 @@
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
+internal_compile_panics=0
+loops_aborted=54

--- a/pyre/bench/synth/pypy_dict_primitives_nonbinding.cranelift.jitstats
+++ b/pyre/bench/synth/pypy_dict_primitives_nonbinding.cranelift.jitstats
@@ -1,0 +1,8 @@
+bridges_compiled=0
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
+guard_failures=0
+internal_compile_panics=0
+loops_aborted=0
+loops_compiled=0

--- a/pyre/bench/synth/pypy_dict_primitives_nonbinding.dynasm.jitstats
+++ b/pyre/bench/synth/pypy_dict_primitives_nonbinding.dynasm.jitstats
@@ -1,0 +1,8 @@
+bridges_compiled=0
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
+guard_failures=0
+internal_compile_panics=0
+loops_aborted=0
+loops_compiled=0

--- a/pyre/bench/synth/pypy_dict_primitives_nonbinding.wasm.jitstats
+++ b/pyre/bench/synth/pypy_dict_primitives_nonbinding.wasm.jitstats
@@ -1,0 +1,5 @@
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
+internal_compile_panics=0
+loops_aborted=0

--- a/pyre/bench/synth/raise_reg_unbound_jitstress.cranelift.jitstats
+++ b/pyre/bench/synth/raise_reg_unbound_jitstress.cranelift.jitstats
@@ -1,0 +1,8 @@
+bridges_compiled=0
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
+guard_failures=5
+internal_compile_panics=0
+loops_aborted=2
+loops_compiled=5

--- a/pyre/bench/synth/raise_reg_unbound_jitstress.dynasm.jitstats
+++ b/pyre/bench/synth/raise_reg_unbound_jitstress.dynasm.jitstats
@@ -1,0 +1,8 @@
+bridges_compiled=0
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
+guard_failures=5
+internal_compile_panics=0
+loops_aborted=2
+loops_compiled=5

--- a/pyre/bench/synth/raise_reg_unbound_jitstress.wasm.jitstats
+++ b/pyre/bench/synth/raise_reg_unbound_jitstress.wasm.jitstats
@@ -1,0 +1,5 @@
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
+internal_compile_panics=0
+loops_aborted=2

--- a/pyre/bench/synth/tuple_unpack_array_backed_hot.cranelift.jitstats
+++ b/pyre/bench/synth/tuple_unpack_array_backed_hot.cranelift.jitstats
@@ -1,0 +1,8 @@
+bridges_compiled=0
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
+guard_failures=3
+internal_compile_panics=0
+loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/tuple_unpack_array_backed_hot.dynasm.jitstats
+++ b/pyre/bench/synth/tuple_unpack_array_backed_hot.dynasm.jitstats
@@ -1,0 +1,8 @@
+bridges_compiled=0
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
+guard_failures=3
+internal_compile_panics=0
+loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/tuple_unpack_array_backed_hot.wasm.jitstats
+++ b/pyre/bench/synth/tuple_unpack_array_backed_hot.wasm.jitstats
@@ -1,0 +1,5 @@
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
+internal_compile_panics=0
+loops_aborted=0

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -10107,7 +10107,9 @@ pub(crate) unsafe fn get(
             return Ok(Some(descr));
         }
         crate::typedef::slot_wrapper_check_instance(descr, obj)?;
-        return Ok(Some(pyre_object::w_method_new(descr, obj, w_type)));
+        return Ok(Some(crate::function::method_wrapper_new(
+            descr, obj, w_type,
+        )));
     }
 
     if crate::is_function(descr) {

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -6243,7 +6243,12 @@ exc_new_wrapper!(exc_syntax_error_new, exc_syntax_error);
 /// unlike, say, `BaseExceptionGroup.__str__`, which has no native arm and
 /// whose builtin the native path does have to call.
 pub(crate) unsafe fn is_native_exception_dunder(method: PyObjectRef) -> bool {
-    if method.is_null() || !crate::function::is_function(method) {
+    // Every fixed-code carrier, not just `is_function`: `__str__` and
+    // `__repr__` are slot names, so the namespace sweep publishes the three
+    // builtins below as `wrapper_descriptor`, which `is_function` excludes.
+    // Missing them here lets `exc_user_dunder_obj` call the native dunder back
+    // and recurse until the stack overflows.
+    if method.is_null() || !unsafe { crate::function::is_function_carrier(method) } {
         return false;
     }
     let code = crate::function::getcode(method) as PyObjectRef;

--- a/pyre/pyre-interpreter/src/function.rs
+++ b/pyre/pyre-interpreter/src/function.rs
@@ -26,6 +26,27 @@ pub static METHOD_DESCRIPTOR_TYPE: PyType = pyre_object::pyobject::new_pytype("m
 /// payload deliberately reuses [`Function`]: both are immutable BuiltinCode
 /// carriers and therefore have identical GC edges and call ABI.
 pub static SLOT_WRAPPER_TYPE: PyType = pyre_object::pyobject::new_pytype("wrapper_descriptor");
+/// The bound form of a slot wrapper — `descrobject.c PyMethodWrapper_Type`.
+///
+/// A `wrapper_descriptor` accessed on an instance yields this, the way a
+/// `method_descriptor` yields a `builtin_function_or_method`.  Like that pair
+/// the payload stays PyPy's [`Method`], so only the public class differs; the
+/// separate type is what lets `inspect.ismethodwrapper` and `inspect.isbuiltin`
+/// tell the two bound forms apart.
+pub static METHOD_WRAPPER_TYPE: PyType = pyre_object::pyobject::new_pytype("method-wrapper");
+/// A `METH_CLASS` entry of a builtin type — `descrobject.c
+/// PyClassMethodDescr_Type`.
+///
+/// `type_ready_fill_dict` wraps such an entry in the same [`ClassMethod`]
+/// carrier a `@classmethod` uses, so the payload is shared and only the public
+/// class differs.  Keeping the two apart is what makes `dict.fromkeys` a
+/// descriptor while a user `@classmethod` stays an ordinary wrapper, which
+/// `inspect._signature_get_user_defined_method` relies on to decide whether a
+/// `__init__` / `__new__` / `__call__` was written in Python.
+///
+/// [`ClassMethod`]: pyre_object::function::ClassMethod
+pub static CLASSMETHOD_DESCRIPTOR_TYPE: PyType =
+    pyre_object::pyobject::new_pytype("classmethod_descriptor");
 
 /// User-defined function object.
 ///
@@ -564,6 +585,19 @@ pub unsafe fn function_retag_method_descriptor(obj: PyObjectRef) {
     }
 }
 
+/// Retag a freshly materialised `FunctionWithFixedCode` as the public
+/// slot-wrapper carrier — the `add_operators` half of the same namespace sweep
+/// [`function_retag_method_descriptor`] serves.
+///
+/// # Safety
+/// `obj` must be a valid, live `FunctionWithFixedCode` carrier.
+pub unsafe fn function_retag_slot_wrapper(obj: PyObjectRef) {
+    unsafe {
+        (*obj).ob_type = &SLOT_WRAPPER_TYPE as *const PyType;
+        (*obj).w_class = get_instantiate(&SLOT_WRAPPER_TYPE);
+    }
+}
+
 /// Allocate an immutable ordinary method descriptor backed by `BuiltinCode`.
 pub fn function_new_method_descriptor(code: *const (), name: String) -> PyObjectRef {
     function_new_impl(&METHOD_DESCRIPTOR_TYPE, code, name, PY_NULL, PY_NULL, false)
@@ -643,6 +677,60 @@ pub fn builtin_bound_method_new(
         pyre_object::function::w_method_set_module(method, pyre_object::w_none());
     }
     method
+}
+
+/// `descrobject.c PyWrapper_New` — bind a slot wrapper to its receiver.
+///
+/// Same `Method` payload as [`builtin_bound_method_new`]; only the public class
+/// differs, so `type(object().__str__)` reports `method-wrapper` while
+/// `type([].append)` reports `builtin_function_or_method`.  `PyMethodWrapper_Type`
+/// has no `__module__`, but the field is part of the shared payload, so it is
+/// filled the same way and simply left unpublished by the typedef.
+pub fn method_wrapper_new(
+    descr: PyObjectRef,
+    obj: PyObjectRef,
+    w_class: PyObjectRef,
+) -> PyObjectRef {
+    let method = pyre_object::w_method_new(descr, obj, w_class);
+    unsafe {
+        pyre_object::function::w_method_set_public_class(
+            method,
+            crate::typedef::gettypeobject(&METHOD_WRAPPER_TYPE),
+        );
+        pyre_object::function::w_method_set_module(method, pyre_object::w_none());
+    }
+    method
+}
+
+/// Publish a `ClassMethod` carrier built for a `METH_CLASS` entry as
+/// [`CLASSMETHOD_DESCRIPTOR_TYPE`].
+///
+/// The `ob_type` stays `CLASSMETHOD_TYPE`, so `is_classmethod` and every
+/// binding path that reads the payload keep working; only the type the
+/// namespace publishes changes.
+///
+/// A namespace swept before the type object exists is retagged again by the
+/// closing pass of `init_typeobjects`, so this is a no-op until then.
+pub fn classmethod_retag_descriptor(obj: PyObjectRef) {
+    let w_class = get_instantiate(&CLASSMETHOD_DESCRIPTOR_TYPE);
+    if w_class.is_null() {
+        return;
+    }
+    unsafe {
+        pyre_object::gc_hook::try_gc_write_barrier(obj as *mut u8);
+        (*obj).w_class = w_class;
+    }
+}
+
+/// Whether `obj` is a `ClassMethod` carrier published as a
+/// `classmethod_descriptor` rather than as an ordinary `classmethod`.
+pub fn is_classmethod_descriptor(obj: PyObjectRef) -> bool {
+    !obj.is_null()
+        && unsafe { pyre_object::function::is_classmethod(obj) }
+        && std::ptr::eq(
+            unsafe { (*obj).w_class },
+            get_instantiate(&CLASSMETHOD_DESCRIPTOR_TYPE),
+        )
 }
 
 /// Function-layout carriers accepted by the interpreter call machinery.

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -611,6 +611,47 @@ pub fn init_typeobjects() {
             method_descriptor_type as usize,
         );
 
+        // CPython `method-wrapper`: the bound form of a slot wrapper. The Rust
+        // payload is the same `Method` a bound method descriptor uses, so the
+        // type differs only in its published surface.
+        let method_wrapper_type =
+            new_typeobject_with_base("method-wrapper", init_method_wrapper_type, object_type);
+        unsafe {
+            pyre_object::w_type_set_acceptable_as_base_class(method_wrapper_type, false);
+            pyre_object::w_type_set_disallow_instantiation(method_wrapper_type);
+            pyre_object::w_type_set_hasdict(method_wrapper_type, false);
+            pyre_object::w_type_set_weakrefable(method_wrapper_type, false);
+        }
+        reg.insert(
+            &crate::function::METHOD_WRAPPER_TYPE as *const PyType as usize,
+            method_wrapper_type as usize,
+        );
+
+        // CPython `classmethod_descriptor`: a builtin type's `METH_CLASS`
+        // entry.  The payload is the `ClassMethod` a `@classmethod` also uses,
+        // so this type publishes only the descriptor surface.
+        let classmethod_descriptor_type = new_typeobject_with_base(
+            "classmethod_descriptor",
+            init_classmethod_descriptor_type,
+            object_type,
+        );
+        unsafe {
+            pyre_object::w_type_set_acceptable_as_base_class(classmethod_descriptor_type, false);
+            pyre_object::w_type_set_disallow_instantiation(classmethod_descriptor_type);
+            // `PyClassMethodDescr_Type` carries no `Py_TPFLAGS_METHOD_DESCRIPTOR`:
+            // it binds to the class, not to the instance the caller pushed.
+            pyre_object::w_type_set_hasdict(classmethod_descriptor_type, false);
+            pyre_object::w_type_set_weakrefable(classmethod_descriptor_type, false);
+            pyre_object::set_instantiate(
+                &crate::function::CLASSMETHOD_DESCRIPTOR_TYPE,
+                classmethod_descriptor_type,
+            );
+        }
+        reg.insert(
+            &crate::function::CLASSMETHOD_DESCRIPTOR_TYPE as *const PyType as usize,
+            classmethod_descriptor_type as usize,
+        );
+
         // builtin-code — PyPy: BuiltinCode.typedef = TypeDef('builtin-code', ...)
         reg.insert(
             &crate::BUILTIN_CODE_TYPE as *const PyType as usize,
@@ -1491,6 +1532,14 @@ pub fn init_typeobjects() {
                 }
             }
         }
+        // `object`, `type`, `int`, `dict` and `mappingproxy` are built before
+        // the `classmethod_descriptor` type object exists, so the sweep that
+        // publishes their `METH_CLASS` entries found nothing to point at.  Redo
+        // it here, where every namespace is complete; the pass is idempotent,
+        // so the types the sweep already reached are unaffected.
+        for &w_typeobject_addr in reg.values() {
+            unsafe { retag_classmethod_descriptors(w_typeobject_addr as PyObjectRef) };
+        }
 
         reg
     });
@@ -1952,14 +2001,49 @@ unsafe fn stamp_method_owners(ns: PyObjectRef, owner: &'static crate::gateway::M
             // `type_ready_fill_dict` hands each `tp_methods` entry to
             // `PyDescr_NewMethod`, so it is a `method_descriptor` and its
             // `__get__` yields a `builtin_function_or_method`.  The slot half
-            // of the same sweep (`add_operators` → `PyDescr_NewWrapper`) wants
-            // `wrapper_descriptor`, which pyre does not tag yet, so those keep
-            // the `FunctionWithFixedCode` spelling.
-            if unsafe { pyre_object::py_type_check(descr, &crate::function::FUNCTION_TYPE) }
-                && !crate::gateway::is_slot_wrapper(owner.type_name, &key)
-            {
-                unsafe { crate::function::function_retag_method_descriptor(descr) };
+            // of the same sweep (`add_operators` → `PyDescr_NewWrapper`) is a
+            // `wrapper_descriptor`, whose `__get__` yields a `method-wrapper`.
+            if unsafe { pyre_object::py_type_check(descr, &crate::function::FUNCTION_TYPE) } {
+                let retag = if crate::gateway::is_slot_wrapper(owner.type_name, &key) {
+                    crate::function::function_retag_slot_wrapper
+                } else {
+                    crate::function::function_retag_method_descriptor
+                };
+                unsafe { retag(descr) };
             }
+        } else if unsafe { pyre_object::function::is_classmethod(entry) } {
+            // `PyDescr_NewClassMethod` — the `METH_CLASS` half of the same
+            // sweep.  A `@classmethod` written in Python never reaches here
+            // because its payload is Python bytecode, not `BuiltinCode`.
+            crate::function::classmethod_retag_descriptor(entry);
+        }
+    }
+}
+
+/// Publish `type_obj`'s `METH_CLASS` entries as `classmethod_descriptor`.
+///
+/// The per-namespace sweeps do this as each type is built; this is the
+/// order-independent form for the types built before the descriptor type
+/// object exists.
+///
+/// # Safety
+/// `type_obj` must be a live builtin type object.
+unsafe fn retag_classmethod_descriptors(type_obj: PyObjectRef) {
+    let ns = unsafe { pyre_object::w_type_get_dict_ptr(type_obj) } as PyObjectRef;
+    if ns.is_null() {
+        return;
+    }
+    for (_, entry) in pyre_object::w_dict_items(ns) {
+        if entry.is_null() || !unsafe { pyre_object::function::is_classmethod(entry) } {
+            continue;
+        }
+        let function = unsafe { pyre_object::function::w_classmethod_get_func(entry) };
+        if function.is_null() || !unsafe { crate::function::is_function_carrier(function) } {
+            continue;
+        }
+        let code = crate::function::getcode(function) as PyObjectRef;
+        if !code.is_null() && crate::gateway::is_builtin_code(code) {
+            crate::function::classmethod_retag_descriptor(entry);
         }
     }
 }
@@ -2049,8 +2133,23 @@ unsafe fn stamp_new_descr_self(ns: PyObjectRef, type_obj: PyObjectRef) {
                 crate::function::function_set_objclass(function, type_obj);
                 let qualname = format!("{}.{}", pyre_object::w_type_get_qualname(type_obj), key);
                 crate::function::function_set_qualname(function, pyre_object::w_str_new(&qualname));
+                // Same `is_slot_wrapper` split the TypeDef sweep applies: the
+                // slot half becomes a `wrapper_descriptor`, the `tp_methods`
+                // half a `method_descriptor`.  Both sweeps reach a builtin
+                // namespace, so leaving this one ungated retagged every slot
+                // dunder as a method descriptor.
                 if is_plain_entry {
-                    crate::function::function_mark_method_descriptor(function);
+                    let retag = if crate::gateway::is_slot_wrapper(
+                        pyre_object::w_type_get_name(type_obj),
+                        &key,
+                    ) {
+                        crate::function::function_retag_slot_wrapper
+                    } else {
+                        crate::function::function_mark_method_descriptor
+                    };
+                    retag(function);
+                } else if pyre_object::function::is_classmethod(descr) {
+                    crate::function::classmethod_retag_descriptor(descr);
                 }
             }
         }
@@ -11997,29 +12096,22 @@ fn init_function_type(ns: PyObjectRef) {
     };
 }
 
-/// PyPy typedef.py:813-820:
+/// Whether `obj` is a `Method` payload published as
+/// `builtin_function_or_method`.
 ///
-/// ```text
-/// BuiltinFunction.typedef = TypeDef("builtin_function",
-///                                   **Function.typedef.rawdict)
-/// BuiltinFunction.typedef.rawdict.update({
-///     '__new__': interp2app(BuiltinFunction.descr_builtinfunction__new__.im_func),
-///     '__self__': GetSetProperty(always_none, cls=BuiltinFunction),
-///     '__repr__': interp2app(BuiltinFunction.descr_function_repr),
-///     '__doc__': getset_func_doc,
-/// })
-/// del BuiltinFunction.typedef.rawdict['__get__']
-/// ```
-///
-/// `init_function_type_common` provides the shared `**rawdict` slots; the
-/// missing `dict_storage_store(ns, "__get__", ...)` call after it expresses the
-/// `del rawdict['__get__']` step. The `update({...})` overrides go below as
-/// pyre starts modeling them.
+/// Both `PyDescr_NewMethod` and `PyDescr_NewClassMethod` bind through
+/// `PyCFunction_NewEx`, so the wrapped callable is a `method_descriptor` in the
+/// first case and the plain builtin a `classmethod_descriptor` holds in the
+/// second.  The published class is what the two have in common, and it is also
+/// what separates them from a `method-wrapper`, whose payload is identical.
 #[inline]
 fn is_bound_builtin_method(obj: PyObjectRef) -> bool {
     !obj.is_null()
         && unsafe { pyre_object::function::is_method(obj) }
-        && unsafe { crate::function::is_method_descriptor(pyre_object::w_method_get_func(obj)) }
+        && std::ptr::eq(
+            unsafe { (*obj).w_class },
+            gettypeobject(&crate::function::BUILTIN_FUNCTION_TYPE),
+        )
 }
 
 fn builtin_function_receiver(obj: PyObjectRef, name: &str) -> Result<PyObjectRef, crate::PyError> {
@@ -12087,6 +12179,24 @@ fn builtin_function_qualname(obj: PyObjectRef) -> crate::PyResult {
     }
 }
 
+/// PyPy typedef.py:813-820:
+///
+/// ```text
+/// BuiltinFunction.typedef = TypeDef("builtin_function",
+///                                   **Function.typedef.rawdict)
+/// BuiltinFunction.typedef.rawdict.update({
+///     '__new__': interp2app(BuiltinFunction.descr_builtinfunction__new__.im_func),
+///     '__self__': GetSetProperty(always_none, cls=BuiltinFunction),
+///     '__repr__': interp2app(BuiltinFunction.descr_function_repr),
+///     '__doc__': getset_func_doc,
+/// })
+/// del BuiltinFunction.typedef.rawdict['__get__']
+/// ```
+///
+/// `init_function_type_common` provides the shared `**rawdict` slots; the
+/// missing `dict_storage_store(ns, "__get__", ...)` call after it expresses the
+/// `del rawdict['__get__']` step. The `update({...})` overrides go below as
+/// pyre starts modeling them.
 fn init_builtin_function_type(ns: PyObjectRef) {
     init_function_type_common(ns);
 
@@ -12646,6 +12756,19 @@ pub(crate) fn slot_wrapper_check_instance(
     )))
 }
 
+/// `descrobject.c descr_reduce` — a descriptor reconstructs through
+/// `getattr(objclass, name)`.  Shared by `wrapper_descriptor` and
+/// `method_descriptor`; without it `copyreg._reduce_ex` refuses the object at
+/// protocols 0 and 1.
+fn descr_reduce(descr: PyObjectRef) -> crate::PyResult {
+    let owner = unsafe { crate::function::fget_func_objclass(descr)? };
+    let name = pyre_object::w_str_new(unsafe { crate::function::function_get_name(descr) });
+    Ok(pyre_object::w_tuple_new(vec![
+        crate::baseobjspace::builtin_callable("getattr"),
+        pyre_object::w_tuple_new(vec![owner, name]),
+    ]))
+}
+
 fn init_slot_wrapper_type(ns: PyObjectRef) {
     // CPython 3.14 Objects/descrobject.c `PyWrapperDescr_Type` metadata.
     // The descriptor payload remains PyPy's FunctionWithFixedCode and keeps
@@ -12738,6 +12861,21 @@ fn init_slot_wrapper_type(ns: PyObjectRef) {
                 function_descr_call_impl(positional, kwargs, descr)
             }),
         );
+        pyre_object::w_dict_setitem_str_no_proxy(
+            ns,
+            "__reduce__",
+            make_builtin_function_with_arity(
+                "__reduce__",
+                |args| {
+                    let descr = slot_wrapper_receiver(
+                        args.first().copied().unwrap_or(pyre_object::PY_NULL),
+                        "__reduce__",
+                    )?;
+                    descr_reduce(descr)
+                },
+                1,
+            ),
+        );
     }
 }
 
@@ -12818,7 +12956,210 @@ fn bind_slot_wrapper(descr: PyObjectRef, obj: PyObjectRef, w_type: PyObjectRef) 
     if !obj.is_null() {
         slot_wrapper_check_instance(descr, obj)?;
     }
-    bind_fixed_code_descriptor(descr, obj, w_type, pyre_object::w_method_new)
+    bind_fixed_code_descriptor(descr, obj, w_type, crate::function::method_wrapper_new)
+}
+
+/// Whether `obj` is a slot wrapper bound to a receiver — the `Method` payload
+/// [`crate::function::method_wrapper_new`] publishes as `method-wrapper`.
+/// The mirror of [`is_bound_builtin_method`] for the other descriptor half.
+pub(crate) fn is_bound_method_wrapper(obj: PyObjectRef) -> bool {
+    !obj.is_null()
+        && unsafe { pyre_object::function::is_method(obj) }
+        && unsafe { crate::function::is_slot_wrapper(pyre_object::w_method_get_func(obj)) }
+}
+
+fn method_wrapper_receiver(obj: PyObjectRef, name: &str) -> Result<PyObjectRef, crate::PyError> {
+    if !is_bound_method_wrapper(obj) {
+        let received = if obj.is_null() {
+            "object"
+        } else {
+            crate::typedef::r#type(obj)
+                .map(|tp| unsafe { pyre_object::w_type_get_name(tp.as_ptr()) })
+                .unwrap_or("object")
+        };
+        return Err(crate::PyError::type_error(format!(
+            "descriptor '{name}' for 'method-wrapper' objects doesn't apply to a '{received}' object"
+        )));
+    }
+    Ok(obj)
+}
+
+/// Two method wrappers are the same when they wrap the same slot on the same
+/// receiver — `descrobject.c wrapper_richcompare` compares `self` and `descr`.
+fn method_wrappers_equal(a: PyObjectRef, b: PyObjectRef) -> bool {
+    unsafe {
+        std::ptr::eq(
+            pyre_object::w_method_get_self(a),
+            pyre_object::w_method_get_self(b),
+        ) && std::ptr::eq(
+            pyre_object::w_method_get_func(a),
+            pyre_object::w_method_get_func(b),
+        )
+    }
+}
+
+fn init_method_wrapper_type(ns: PyObjectRef) {
+    // `descrobject.c PyMethodWrapper_Type`.  Every published attribute reads
+    // through to the wrapped `wrapper_descriptor`, which already answers them
+    // for the unbound form, so the getters delegate rather than duplicate.
+    type WrapperGetter = fn(&[PyObjectRef]) -> crate::PyResult;
+    fn descr_of(obj: PyObjectRef) -> PyObjectRef {
+        unsafe { pyre_object::w_method_get_func(obj) }
+    }
+    for (name, getter) in [
+        (
+            "__self__",
+            (|args: &[PyObjectRef]| {
+                let obj = method_wrapper_receiver(args[1], "__self__")?;
+                Ok(unsafe { pyre_object::w_method_get_self(obj) })
+            }) as WrapperGetter,
+        ),
+        ("__name__", |args: &[PyObjectRef]| {
+            let obj = method_wrapper_receiver(args[1], "__name__")?;
+            Ok(unsafe { crate::function::fget_func_name(descr_of(obj)) })
+        }),
+        ("__qualname__", |args: &[PyObjectRef]| {
+            let obj = method_wrapper_receiver(args[1], "__qualname__")?;
+            crate::baseobjspace::getattr_str(descr_of(obj), "__qualname__")
+        }),
+        ("__objclass__", |args: &[PyObjectRef]| {
+            let obj = method_wrapper_receiver(args[1], "__objclass__")?;
+            unsafe { crate::function::fget_func_objclass(descr_of(obj)) }
+        }),
+        ("__doc__", |args: &[PyObjectRef]| {
+            let obj = method_wrapper_receiver(args[1], "__doc__")?;
+            Ok(unsafe { crate::function::fget_func_doc(descr_of(obj)) })
+        }),
+        ("__text_signature__", |args: &[PyObjectRef]| {
+            let obj = method_wrapper_receiver(args[1], "__text_signature__")?;
+            match unsafe { crate::function::fget_func_text_signature(descr_of(obj)) } {
+                Ok(value) => Ok(value),
+                Err(err) if err.kind == crate::PyErrorKind::AttributeError => {
+                    Ok(pyre_object::w_none())
+                }
+                Err(err) => Err(err),
+            }
+        }),
+    ] {
+        unsafe {
+            pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+                ns,
+                name,
+                make_getset_descriptor(make_builtin_function_with_arity(name, getter, 2)),
+            )
+        };
+    }
+
+    unsafe {
+        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+            ns,
+            "__call__",
+            make_builtin_function("__call__", |args| {
+                method_wrapper_receiver(
+                    args.first().copied().unwrap_or(pyre_object::PY_NULL),
+                    "__call__",
+                )?;
+                crate::function::descr_method_call(args)
+            }),
+        );
+        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+            ns,
+            "__repr__",
+            make_builtin_function_with_arity(
+                "__repr__",
+                |args| {
+                    let obj = method_wrapper_receiver(
+                        args.first().copied().unwrap_or(pyre_object::PY_NULL),
+                        "__repr__",
+                    )?;
+                    let name = unsafe { crate::function_get_name(descr_of(obj)) };
+                    let w_self = unsafe { pyre_object::w_method_get_self(obj) };
+                    let type_name = crate::typedef::r#type(w_self)
+                        .map(|tp| unsafe { pyre_object::w_type_get_name(tp.as_ptr()) })
+                        .unwrap_or("object");
+                    Ok(pyre_object::w_str_new(&format!(
+                        "<method-wrapper '{name}' of {type_name} object at {w_self:p}>"
+                    )))
+                },
+                1,
+            ),
+        );
+        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+            ns,
+            "__reduce__",
+            make_builtin_function_with_arity(
+                "__reduce__",
+                |args| unsafe {
+                    let obj = method_wrapper_receiver(
+                        args.first().copied().unwrap_or(pyre_object::PY_NULL),
+                        "__reduce__",
+                    )?;
+                    crate::function::descr_method__reduce__(obj)
+                },
+                1,
+            ),
+        );
+        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+            ns,
+            "__hash__",
+            make_builtin_function_with_arity(
+                "__hash__",
+                |args| {
+                    let obj = method_wrapper_receiver(
+                        args.first().copied().unwrap_or(pyre_object::PY_NULL),
+                        "__hash__",
+                    )?;
+                    let instance = unsafe { pyre_object::w_method_get_self(obj) };
+                    let mut value = (pyre_object::gc_hook::gc_identity_hash(instance as usize)
+                        ^ pyre_object::gc_hook::gc_identity_hash(descr_of(obj) as usize))
+                        as i64;
+                    if value == -1 {
+                        value = -2;
+                    }
+                    Ok(pyre_object::w_int_new(value))
+                },
+                1,
+            ),
+        );
+    }
+
+    for (name, method) in [
+        (
+            "__eq__",
+            (|args: &[PyObjectRef]| {
+                let obj = method_wrapper_receiver(
+                    args.first().copied().unwrap_or(pyre_object::PY_NULL),
+                    "__eq__",
+                )?;
+                if !is_bound_method_wrapper(args[1]) {
+                    return Ok(pyre_object::w_not_implemented());
+                }
+                Ok(pyre_object::w_bool_from(method_wrappers_equal(
+                    obj, args[1],
+                )))
+            }) as WrapperGetter,
+        ),
+        ("__ne__", |args: &[PyObjectRef]| {
+            let obj = method_wrapper_receiver(
+                args.first().copied().unwrap_or(pyre_object::PY_NULL),
+                "__ne__",
+            )?;
+            if !is_bound_method_wrapper(args[1]) {
+                return Ok(pyre_object::w_not_implemented());
+            }
+            Ok(pyre_object::w_bool_from(!method_wrappers_equal(
+                obj, args[1],
+            )))
+        }),
+    ] {
+        unsafe {
+            pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+                ns,
+                name,
+                make_builtin_function_with_arity(name, method, 2),
+            )
+        };
+    }
 }
 
 fn init_method_descriptor_type(ns: PyObjectRef) {
@@ -12911,6 +13252,21 @@ fn init_method_descriptor_type(ns: PyObjectRef) {
         );
         pyre_object::w_dict_setitem_str_no_proxy(
             ns,
+            "__reduce__",
+            make_builtin_function_with_arity(
+                "__reduce__",
+                |args| {
+                    let descr = method_descriptor_receiver(
+                        args.first().copied().unwrap_or(pyre_object::PY_NULL),
+                        "__reduce__",
+                    )?;
+                    descr_reduce(descr)
+                },
+                1,
+            ),
+        );
+        pyre_object::w_dict_setitem_str_no_proxy(
+            ns,
             "__repr__",
             make_builtin_function_with_arity(
                 "__repr__",
@@ -12918,6 +13274,131 @@ fn init_method_descriptor_type(ns: PyObjectRef) {
                     let descr = method_descriptor_receiver(args[0], "__repr__")?;
                     let name = crate::function::function_get_name(descr);
                     let owner = crate::function::fget_func_objclass(descr)?;
+                    let owner_name = pyre_object::w_type_get_name(owner);
+                    Ok(pyre_object::w_str_new(&format!(
+                        "<method '{name}' of '{owner_name}' objects>"
+                    )))
+                },
+                1,
+            ),
+        );
+    }
+}
+
+/// The wrapped builtin callable of a `classmethod_descriptor`, which carries
+/// the owner, name, doc and signature the descriptor publishes.
+fn classmethod_descriptor_function(
+    obj: PyObjectRef,
+    name: &str,
+) -> Result<PyObjectRef, crate::PyError> {
+    if !crate::function::is_classmethod_descriptor(obj) {
+        return Err(crate::PyError::type_error(format!(
+            "descriptor '{name}' requires a 'classmethod_descriptor' object"
+        )));
+    }
+    Ok(unsafe { pyre_object::function::w_classmethod_get_func(obj) })
+}
+
+fn init_classmethod_descriptor_type(ns: PyObjectRef) {
+    // `descrobject.c PyClassMethodDescr_Type`.  Every attribute reads through
+    // the wrapped callable, which the namespace sweeps stamp with the owning
+    // type and the qualified name.
+    for (name, getter) in [
+        (
+            "__objclass__",
+            (|args: &[PyObjectRef]| {
+                let function = classmethod_descriptor_function(args[1], "__objclass__")?;
+                unsafe { crate::function::fget_func_objclass(function) }
+            }) as crate::gateway::BuiltinCodeFn,
+        ),
+        ("__name__", |args: &[PyObjectRef]| {
+            let function = classmethod_descriptor_function(args[1], "__name__")?;
+            Ok(pyre_object::w_str_new(unsafe {
+                crate::function::function_get_name(function)
+            }))
+        }),
+        ("__qualname__", |args: &[PyObjectRef]| {
+            let function = classmethod_descriptor_function(args[1], "__qualname__")?;
+            crate::baseobjspace::getattr_str(function, "__qualname__")
+        }),
+        ("__doc__", |args: &[PyObjectRef]| {
+            let function = classmethod_descriptor_function(args[1], "__doc__")?;
+            Ok(unsafe { crate::function::fget_func_doc(function) })
+        }),
+        ("__text_signature__", |args: &[PyObjectRef]| {
+            let function = classmethod_descriptor_function(args[1], "__text_signature__")?;
+            match unsafe { crate::function::fget_func_text_signature(function) } {
+                Ok(value) => Ok(value),
+                Err(err) if err.kind == crate::PyErrorKind::AttributeError => {
+                    Ok(pyre_object::w_none())
+                }
+                Err(err) => Err(err),
+            }
+        }),
+    ] {
+        unsafe {
+            pyre_object::w_dict_setitem_str_no_proxy(
+                ns,
+                name,
+                make_getset_descriptor(make_builtin_function_with_arity(name, getter, 2)),
+            )
+        };
+    }
+
+    unsafe {
+        pyre_object::w_dict_setitem_str_no_proxy(
+            ns,
+            "__get__",
+            make_builtin_function_with_arity(
+                "__get__",
+                |args| {
+                    classmethod_descriptor_function(args[0], "__get__")?;
+                    classmethod_descr_get(args)
+                },
+                3,
+            ),
+        );
+        pyre_object::w_dict_setitem_str_no_proxy(
+            ns,
+            "__call__",
+            make_builtin_function("__call__", |args| {
+                let (positional, kwargs) = crate::builtins::split_builtin_kwargs(args);
+                let descr = positional.first().copied().unwrap_or(pyre_object::PY_NULL);
+                let function = classmethod_descriptor_function(descr, "__call__")?;
+                // `descrobject.c classmethoddescr_call` — the receiver is the
+                // class itself, so it must be a type rather than an instance.
+                let name = crate::function::function_get_name(function);
+                let owner_name =
+                    pyre_object::w_type_get_name(crate::function::fget_func_objclass(function)?);
+                match positional.get(1) {
+                    Some(&cls) if pyre_object::is_type(cls) => {}
+                    Some(&cls) => {
+                        let got = type_name_of(cls);
+                        return Err(crate::PyError::type_error(format!(
+                            "descriptor '{name}' for type '{owner_name}' needs a type, \
+                             not a '{got}' as arg 2"
+                        )));
+                    }
+                    None => {
+                        return Err(crate::PyError::type_error(format!(
+                            "descriptor '{name}' of '{owner_name}' object needs an argument"
+                        )));
+                    }
+                }
+                function_descr_call_impl(positional, kwargs, function)
+            }),
+        );
+        // No `__reduce__`: `PyClassMethodDescr_Type` has none, so pickling one
+        // falls through to `copyreg._reduce_ex` and is rejected.
+        pyre_object::w_dict_setitem_str_no_proxy(
+            ns,
+            "__repr__",
+            make_builtin_function_with_arity(
+                "__repr__",
+                |args| {
+                    let function = classmethod_descriptor_function(args[0], "__repr__")?;
+                    let name = crate::function::function_get_name(function);
+                    let owner = crate::function::fget_func_objclass(function)?;
                     let owner_name = pyre_object::w_type_get_name(owner);
                     Ok(pyre_object::w_str_new(&format!(
                         "<method '{name}' of '{owner_name}' objects>"
@@ -14232,7 +14713,15 @@ fn classmethod_descr_get(args: &[PyObjectRef]) -> crate::PyResult {
         w_klass = r#type(w_obj).map_or(PY_NULL, |p| p.as_ptr());
     }
     let function = unsafe { pyre_object::function::w_classmethod_get_func(cm) };
-    Ok(pyre_object::w_method_new(function, w_klass, w_klass))
+    // `classmethod_get` binds a `METH_CLASS` entry through `PyCMethod_New`, so
+    // `dict.fromkeys` is a `builtin_function_or_method`, while a Python
+    // `@classmethod` binds to an ordinary `method`.
+    let new_bound = if crate::function::is_classmethod_descriptor(cm) {
+        crate::function::builtin_bound_method_new
+    } else {
+        pyre_object::w_method_new
+    };
+    Ok(new_bound(function, w_klass, w_klass))
 }
 
 fn classmethod_func_attr(args: &[PyObjectRef]) -> crate::PyResult {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -1690,11 +1690,24 @@ pub(crate) fn walker_abort_if_mayforce_null_ref_arg<Sym: WalkSym>(
     // `try_execute_residual_call_via_executor`.
     let is_store_deref =
         call_descr.get_extra_info().pyre_helper == majit_ir::PyreHelperKind::StoreDeref;
+    // `bh_load_global_fn(namespace_ptr, w_code, frame, namei)` — `namespace_ptr`
+    // (arg index 0) is never dereferenced.  The helper discards it and resolves
+    // the namespace from the executing frame or the callee's own promoted
+    // `w_code`, because an inlined / chained callee's frame register aliases an
+    // outer frame; the operand survives only as the cell-fold recogniser's hint.
+    // A nested function's `LOAD_GLOBAL` folds it to the NULL constant, so
+    // aborting on it stops the walk after an effectful residual has already run
+    // concretely and the caller replays that region.
+    let is_load_global =
+        call_descr.get_extra_info().pyre_helper == majit_ir::PyreHelperKind::LoadGlobal;
     for (i, &ty) in call_descr.arg_types().iter().enumerate() {
         if ty != majit_ir::Type::Ref {
             continue;
         }
         if is_call_fn && i == 1 {
+            continue;
+        }
+        if is_load_global && i == 0 {
             continue;
         }
         if is_call_function_ex && (i == 1 || i == 3) {
@@ -2098,8 +2111,16 @@ pub(crate) fn try_execute_residual_call_via_executor<Sym: WalkSym>(
     // the region on top of the residuals the walk already ran concretely.
     let is_store_deref =
         call_descr.get_extra_info().pyre_helper == majit_ir::PyreHelperKind::StoreDeref;
+    // Same `bh_load_global_fn` `namespace_ptr` exemption as
+    // `walker_abort_if_mayforce_null_ref_arg`: arg index 0 is discarded by the
+    // helper, so a concrete NULL there is the normal nested-function shape.
+    let is_load_global =
+        call_descr.get_extra_info().pyre_helper == majit_ir::PyreHelperKind::LoadGlobal;
     for (i, &arg) in args.iter().enumerate() {
         if is_call_fn && i == 1 {
+            continue;
+        }
+        if is_load_global && i == 0 {
             continue;
         }
         if is_call_kw && i == 1 {


### PR DESCRIPTION
Follow-up work on top of #845.

## `jit`: exempt the load-global namespace operand from the NULL-Ref walk abort

`pickle_terminal_raise_resume` produced wrong code. The residual-call walk
aborted on a NULL `Ref` operand that a `LOAD_GLOBAL` namespace slot legitimately
carries.

## `typedef`: add `method-wrapper` and `classmethod_descriptor` types

`method_descriptor_kind.py` reported `(list, '__len__', method_descriptor)`
where the descriptor is a `wrapper_descriptor`. Gating the second retag sweep on
`gateway::is_slot_wrapper` needs a bound form for the retagged
`wrapper_descriptor`, so both missing types are added:

| type | payload | published via |
|---|---|---|
| `method-wrapper` | the `Method` a bound method descriptor uses | `w_method_set_public_class` in `function::method_wrapper_new` |
| `classmethod_descriptor` | the `ClassMethod` a `@classmethod` uses | `w_class` write in `function::classmethod_retag_descriptor` |

Neither writes `ob_type`, so `py_type_check` predicates (`is_method`,
`is_classmethod`) and every binding path are unaffected — only `typedef::r#type`,
which prefers `w_class`, sees the new type.

- `classmethod_descr_get` picks `builtin_bound_method_new` for a
  `classmethod_descriptor` and `w_method_new` otherwise, so `dict.fromkeys` is a
  `builtin_function_or_method` while a user `@classmethod` binds to `method`.
- `is_bound_builtin_method` widens from "wraps a `method_descriptor`" to
  "published as `builtin_function_or_method`" — the classmethod case wraps a
  plain builtin, so the old test rejected it and `repr(dict.fromkeys)` raised.
- `wrapper_descriptor` and `method_descriptor` get `__reduce__`
  (`getattr(objclass, name)`); `copyreg._reduce_ex` refuses them otherwise.
  `classmethod_descriptor` deliberately gets none — pickling one raises
  "cannot pickle 'classmethod_descriptor' object".
- `builtins::is_native_exception_dunder` guarded on `is_function`, which excludes
  `SLOT_WRAPPER_TYPE`; once `__str__`/`__repr__` retag, the anti-recursion guard
  stopped firing and `str(SyntaxError("bad"))` overflowed the native stack. It
  now guards on `is_function_carrier`.

The `classmethod_descriptor` retag is two-phase: `init_typeobjects` runs the
sweeps inside `TYPEOBJECT_CACHE.get_or_init`, where `gettypeobject` returns
nothing, so the type is registered with `set_instantiate` at creation, the retag
reads `get_instantiate` and no-ops on null, and an idempotent closing pass over
`reg.values()` covers the namespaces built earlier (`object`, `type`, `int`,
`dict`, `mappingproxy`).

`lib-python/3/inspect.py` returns to pristine CPython 3.14 for `ismethod`,
`isbuiltin`, `ismethodwrapper`, `ismethoddescriptor`, `_NonUserDefinedCallables`
and `_signature_get_user_defined_method`. `_slot_wrapper_type` and the
`_builtin_code_type` block are deleted — `dict.update.__code__` stops resolving
after the split, so the `isfunction` override it fed was already dead.

## `bench`: record the seven missing jit-stats baselines

21 files for hot_loop_exit_then_class_stmt, inline_freevar_after_mayforce,
math_log_trig_hot, pickle_terminal_raise_resume, pypy_dict_primitives_nonbinding,
raise_reg_unbound_jitstress and tuple_unpack_array_backed_hot on all three
backends. All seven were inherited without a baseline.

Two nonzero badness values are pinned as-is: `raise_reg_unbound_jitstress`
`loops_aborted=2` on every backend, and `pickle_terminal_raise_resume`
`loops_aborted=54` on wasm against 0 on both native backends — unexplained, and
the baseline only pins it against a rise.

## `bench`: re-record the four caught-in-callee jit-stats baselines

float_div_zero_caught_loop, mutate_then_raise_caught,
inline_subwalk_property_mutates and inline_subwalk_mutating_residual. The cause
is the `try_walker_inline_resolved_user_call` decline for a branchy callee with
its own exception handler when `fbw_callee_body_replay_safety` is not `Clean` —
reverting that hunk alone puts all four back on the old numbers exactly.

The re-record raises no gated badness field:

| field | movement | gate class |
|---|---|---|
| `guard_failures` | 402→611, 401→611, 401→611, 603→813 | rise-bounded (what failed) |
| `bridges_compiled` | +1 each | ungated |
| `loops_aborted` | 1→0, 2→1, 2→0, unchanged | badness — falls |
| `loops_compiled` | 1→2, 3→4 where it moves | fall-gated — rises |

## Gates

`pyre/check.py --backend dynasm`: 5 failed, 361 passed (16 failed, 350 passed
before this branch).

The five are left red on purpose — closure_freevar_branch_resume,
exception_args_virtual, exception_multi_handler_warmup,
exception_reraise_tb_depth_jitstress and list_length_hint_validate raise
`loops_aborted` and lower `loops_compiled` with no attributed cause, and
re-recording them would disarm the floor.

`pyre/check.py --backend cranelift`: 7 failed, 359 passed — the same five plus
two perf-ratio rows that are the pypy-startup clamp, not a regression:

| bench | full suite | isolated ×2 | gate |
|---|---|---|---|
| jit_reg_const_pool_256_slot_decline | 131.2x (exec 0.66s) | 50.8x / 53.1x (exec 0.70s) | 122x |
| recursion_memo_branch | 24.8x (exec 0.12s) | 10.7x / 11.4x (exec 0.19s) | 20x |

`0.66/131.2 = 0.00503` and `0.12/24.8 = 0.00484` are both `EXEC_TIME_FLOOR_S`, so
the pypy denominator was clamped and the ratio is `pyre_exec / 5ms`. The isolated
pyre times are higher while the ratios fall.

`extra_tests/parity_tests/run.py`: green on cpython, dynasm and cranelift.
`cpython_tests/run.py --backend dynasm`: 46 pass, no regressions.
`test_inspect`: 362/362.

Descriptor kinds and bound/unbound type pairs were diffed against a CPython
3.14 oracle for `object.__init_subclass__`, `object.__subclasshook__`,
`type.__prepare__`, `int.from_bytes`, `dict.fromkeys`, `dict.__class_getitem__`,
`float.fromhex`, `bytes.fromhex` and `set.__class_getitem__`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added CPython-compatible method-wrapper and classmethod-descriptor behavior, including binding, invocation, representation, comparison, hashing, and attribute access.
  - Improved handling of built-in slot wrappers and class methods.

- **Bug Fixes**
  - Prevented recursive dispatch when formatting native exception representations.
  - Improved introspection of callable types and signatures.
  - Fixed nested global lookups involving nullable namespaces.

- **Tests**
  - Expanded JIT benchmark coverage and refreshed performance statistics across multiple execution paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->