### PR TITLE
jit: refuse the abort image again on a live color with no concrete, and census the parent-frame bank hole

### DIFF
--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/bridge_subwalk.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/bridge_subwalk.rs
@@ -966,6 +966,22 @@ pub(crate) fn recipe_parent_frame_from_recipe(
         bh_float.push((color as usize, opref));
     }
     if boxes.iter().any(|b| b.is_none()) {
+        // Name which bank left the hole.  `ReconstructRecipe`'s bank vectors are
+        // SEMANTIC-slot indexed (`trace_ctx.rs:628`), and every semantic slot in
+        // a `locals_cells_stack_w` array is a boxed ref — so the recipe decode
+        // fills the ref bank only, and the two loops above read `OpRef::NONE`
+        // for every live int/float COLOR.  A callee with any live unboxed
+        // register at its resume pc can therefore never be a carrier; that is a
+        // coverage bound, not a shape the walk could not have handled.
+        crate::jitcode_dispatch::census_record(
+            if bh_int.iter().any(|&(_, b)| b.is_none())
+                || bh_float.iter().any(|&(_, b)| b.is_none())
+            {
+                "P2Parent::UnboxedBankHole"
+            } else {
+                "P2Parent::RefBankHole"
+            },
+        );
         return None;
     }
 

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -572,8 +572,7 @@ pub(super) fn build_trace_too_long_single_frame_miframe<Sym: WalkSym>(
     resume_pc: usize,
 ) -> Option<majit_metainterp::MIFrame> {
     let mut miframe = majit_metainterp::MIFrame::new(jitcode, resume_pc);
-    fill_trace_too_long_register_banks(ctx, &mut miframe);
-    Some(miframe)
+    fill_trace_too_long_register_banks(ctx, &mut miframe).then_some(miframe)
 }
 
 /// Fill every currently-known register color, matching
@@ -587,25 +586,26 @@ pub(super) fn build_trace_too_long_single_frame_miframe<Sym: WalkSym>(
 /// all three complete MIFrame banks; do the same for this abort instead of
 /// relying on the narrower resume-liveness cache.
 ///
-/// A color the walk cannot supply a concrete for is **skipped**, not a reason
-/// to refuse the frame.  `blackhole.py:1713-1730 _copy_data_from_miframe`
-/// guards every bank entry with `if box is not None` and calls `setarg_*` only
-/// for the ones that have a value; it has no failing path, and neither does
-/// its caller `convert_and_run_from_pyjitpl` (`blackhole.py:1799-1821`).  An
-/// unfilled color is one the interpreter does not read at this pc — that is
-/// what makes it unfilled — so refusing the whole frame over it only cost the
-/// abort its handoff.
+/// `_copy_data_from_miframe` (`blackhole.py:1713-1730`) guards every bank entry
+/// with `if box is not None` and has no failing path — but there, a `None`
+/// register is a **dead** one the jitcode's liveness already cleared, and every
+/// register that survives holds a box with a value.  "Live, but the walk knows
+/// no value" has no upstream counterpart, and skipping such a color would leave
+/// its pre-sized blackhole register at zero for a resume that can follow
+/// arbitrary control flow to an instruction that reads it.  So `OpRef::NONE`
+/// (dead, upstream's `box is None`) is skipped, and a live color with no
+/// concrete refuses the whole frame.
 fn fill_trace_too_long_register_banks<Sym: WalkSym>(
     ctx: &WalkContext<'_, '_, Sym>,
     miframe: &mut majit_metainterp::MIFrame,
-) {
-    // Name the skipped bank and color under `PYRE_FBW_DEBUG_ABORT`, the way
+) -> bool {
+    // Name the declining bank and color under `PYRE_FBW_DEBUG_ABORT`, the way
     // `build_multi_frame_miframe` names its own: "innermost declined" alone
     // does not say which register had no concrete.
     macro_rules! s2dbg {
         ($($a:tt)*) => {
             if fbw_debug_abort_enabled() {
-                eprintln!("[s2-fill-skip] {}", format!($($a)*));
+                eprintln!("[s2-fill-decline] {}", format!($($a)*));
             }
         };
     }
@@ -632,7 +632,7 @@ fn fill_trace_too_long_register_banks<Sym: WalkSym>(
             }
             let Some(majit_ir::Value::Int(value)) = ctx.trace_ctx.concrete_of_opref(opref) else {
                 s2dbg!("int color={color} opref={opref:?} has no concrete");
-                continue;
+                return false;
             };
             miframe.int_values[color] = Some(value);
         }
@@ -664,6 +664,7 @@ fn fill_trace_too_long_register_banks<Sym: WalkSym>(
             miframe.ref_values[color] = Some(value);
         } else if opref.is_some_and(|value| value != OpRef::NONE) {
             s2dbg!("ref color={color} opref={opref:?} has no concrete");
+            return false;
         }
     }
 
@@ -679,10 +680,11 @@ fn fill_trace_too_long_register_banks<Sym: WalkSym>(
         }
         let Some(majit_ir::Value::Float(value)) = ctx.trace_ctx.concrete_of_opref(opref) else {
             s2dbg!("float color={color} opref={opref:?} has no concrete");
-            continue;
+            return false;
         };
         miframe.float_values[color] = Some(value.to_bits() as i64);
     }
+    true
 }
 
 #[derive(Clone, Copy)]

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -4336,11 +4336,10 @@ fn register_helper_fn_pointers(
 /// produces one SSA-driven alive set as the sole authority, and
 /// `assembler.py:150-152` only splits that set by kind.
 ///
-/// Note: `live_r` carries an extra LV∩SSA
-/// `retain` step on top of the SSA bank — see the inline comment
-/// in the loop body below.  Removing it requires extending the
-/// encoder + symbolic-state pair to track scratch Ref colors,
-/// matching `pyjitpl.py:218-225` line by line.
+/// `live_r` is the SSA bank plus the frame-live colors backward
+/// liveness cannot reach — the portal reds and the FOR_ITER
+/// loop-carried operands — see the inline comments in the loop
+/// body below.
 ///
 /// Unreachable PCs still get emptied in place via the bytecode
 /// `LiveVars` analysis. The direct-dispatch walker emits one
@@ -4541,15 +4540,20 @@ fn filter_liveness_in_place(
                 }
             }
 
-            // Note: LV∩SSA retain narrows the Ref bank to post-rename
-            // colors that correspond to LV-live Python locals or live
-            // stack slots at this PC.  Scratch registers (temporaries
-            // SSA-live but with no Python-frame slot) remain
-            // `OpRef::NONE` in `registers_r` because no trace-time
-            // writer populates them.  Removing this retain requires
-            // either (a) populating scratch colors during tracing
-            // (graph regalloc) or (b) the encoder tolerating
-            // NONE for non-frame live registers.
+            // `pc_live_r` ships whole.  `liveness.py:5-12` expands a
+            // `-live-` marker's args to "all values that are alive at this
+            // point (written to before, and read afterwards)" — the SSA-live
+            // set, under no frame-slot condition.  Narrowing it to
+            // frame-backed colors drops a temporary that is SSA-live across
+            // the marker but whose value sits in no frame slot at that PC
+            // (`r = frame[12]` read before a guard and consumed after it,
+            // while slot 12 is itself dead at the guard): the guard's resume
+            // data then names no box for that color and a bridge resuming
+            // there reads it unbound.
+            //
+            // `lv_live` below is the converse set — colors that are
+            // frame-live but SSA-DEAD, which backward liveness cannot
+            // supply.  It feeds the portal reds and the FOR_ITER re-add.
             let lv_live: std::collections::BTreeSet<u16> = {
                 // #348 Part (2): the per-PC map's entries at this PC are the
                 // live frame colors — each slot's TRUE per-program-point SSA
@@ -4571,9 +4575,8 @@ fn filter_liveness_in_place(
                 // RPython force-alive mechanism (`liveness.py:11-12`):
                 // `emit_live_placeholder!` emits every PC's `-live-` op
                 // with explicit Register args for `portal_frame_reg` /
-                // `portal_ec_reg`.  Gate the portal colors past the
-                // LV∩SSA retain so the retain does not drop the
-                // RPython-tracked live registers.  Portal-bridge
+                // `portal_ec_reg`.  Carry the portal colors in `lv_live`
+                // so the re-add paths below name them.  Portal-bridge
                 // installs sentinel-skip (`u16::MAX`).
                 if portal_frame_reg != u16::MAX {
                     s.insert(portal_frame_reg);
@@ -4583,9 +4586,8 @@ fn filter_liveness_in_place(
                 }
                 s
             };
-            pc_live_r.retain(|idx| lv_live.contains(idx));
-            // Re-add the per-PC frame-live colors the SSA-backward retain
-            // dropped — FOR_ITER body PCs only.  A loop-carried operand-
+            // Re-add the per-PC frame-live colors backward liveness
+            // omitted — FOR_ITER body PCs only.  A loop-carried operand-
             // stack value (the iterator) is frame-live at a body PC but
             // SSA-backward-DEAD there, so `pc_live_r` omits it and the
             // guard snapshot leaves the slot `OpRef::NONE`.  Re-adding
@@ -4602,12 +4604,10 @@ fn filter_liveness_in_place(
             }
 
             // Restore the portal red args (`interp_jit.py:67 reds =
-            // ['frame', 'ec']`) on the splice path.  The retain above only
-            // KEEPS a color present in `pc_live_r`; it cannot re-add a color
-            // the marker dropped.  The walker's explicit per-PC `-live-`
-            // markers always carry `portal_frame_reg` / `portal_ec_reg`
-            // (RPython force-alive, `liveness.py:11-12`), so `pc_live_r`
-            // holds them and the retain keeps them.  The canonical
+            // ['frame', 'ec']`) on the splice path.  The walker's explicit
+            // per-PC `-live-` markers always carry `portal_frame_reg` /
+            // `portal_ec_reg` (RPython force-alive, `liveness.py:11-12`), so
+            // `pc_live_r` already holds them.  The canonical
             // `flatten_graph` stream's markers are filled by backward
             // `compute_liveness`, which drops a portal red never read in the
             // body (a leaf function's `ec`), leaving `pc_live_r` short.  The
@@ -15762,8 +15762,14 @@ mod tests {
         assert_eq!(state.variable_slot(&v_absent), None);
     }
 
+    /// `liveness.py:5-12` expands a `-live-` marker to "all values that are
+    /// alive at this point", under no frame-slot condition: a Ref color that
+    /// is SSA-live across the marker but names no frame slot at that PC stays
+    /// in the bank.  Narrowing it to frame-backed colors leaves the guard's
+    /// resume data naming no box for that color, and a bridge resuming there
+    /// reads the register unbound.
     #[test]
-    fn filter_liveness_drops_non_lv_live_colors_from_live_r() {
+    fn filter_liveness_keeps_ssa_live_ref_color_with_no_frame_slot() {
         let code = pyre_interpreter::compile_exec("x = 1\n").expect("source must compile");
         let live_vars = pyre_jit_trace::state::liveness_for(&code as *const _);
         let reachable_pc = (0..code.instructions.len())
@@ -15785,8 +15791,8 @@ mod tests {
             ]));
         }
 
-        // Drive `lv_live` via the per-PC map: color 0 (the live local `x`) maps
-        // to slot 0, so the LV∩SSA retain keeps color 0 and drops color 7.
+        // Per-PC map: color 0 (the live local `x`) maps to slot 0; color 7
+        // maps to nothing, so it stands in for an SSA-live scratch temp.
         let pcdep_color_slots: Vec<Vec<(u8, u16, u16)>> =
             vec![vec![(1, 0, 0)]; code.instructions.len()];
         let (post_remove_live_indices, _after_call_post_merge, _first_insn_post_merge, _) =
@@ -15812,9 +15818,10 @@ mod tests {
                 _ => None,
             })
             .collect();
-        assert!(
-            !refs.contains(&7),
-            "scratch-stand-in color 7 must be dropped by LV∩SSA retain",
+        assert_eq!(
+            refs,
+            std::collections::BTreeSet::from([0, 7]),
+            "the Ref bank must keep every SSA-live color, frame-backed or not",
         );
         let ints: std::collections::BTreeSet<u16> = live_args
             .iter()
@@ -15832,7 +15839,7 @@ mod tests {
 
     #[test]
     fn filter_liveness_clears_int_float_banks_under_splice() {
-        // Mirror of `filter_liveness_drops_non_lv_live_colors_from_live_r`
+        // Mirror of `filter_liveness_keeps_ssa_live_ref_color_with_no_frame_slot`
         // but with `clear_unboxed_banks = true` (the splice path).  Under
         // the splice, the canonical jitcode-level stream surfaces unboxed
         // int/float temporaries the interpreter-frame resume cannot supply;


### PR DESCRIPTION
<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary


## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 will be run automatically when this is ready for review.
The prompt is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
-->

- [ ] I fully resolved all reasonable code review comments from Codex and CodeRabbit.
  - [ ] Auto-review section 1 is clear. This check is mandatory.
  - [ ] Auto-review section 2 is clear. If this is not checked, please add a comment explaining why.
- [ ] I did not use AI to write the code of this patch.
  - If this is not checked, commits must include `Assisted-by`
