### PR TITLE
GC rooting: tuple items block, kwargs packers, and the post-hash ObjectKey address; close the PR #937 review queue

### DIFF
--- a/lib-python/3/asyncio/tools.py
+++ b/lib-python/3/asyncio/tools.py
@@ -244,6 +244,12 @@ def exit_with_permission_help_text():
 def _get_awaited_by_tasks(pid: int) -> list:
     try:
         return get_all_awaited_by(pid)
+    except ImportError as e:
+        # `get_all_awaited_by` defers the `_remote_debugging` import to call
+        # time, so an interpreter without that extension reports here rather
+        # than at `import asyncio.tools`.
+        print(f"Error retrieving tasks: {e}")
+        sys.exit(1)
     except RuntimeError as e:
         while e.__context__ is not None:
             e = e.__context__

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -1635,13 +1635,27 @@ fn get_objects_via_active_runtime(generation: i8, visitor: majit_gc::GetObjectsV
     with_cranelift_gc(|gc| gc.get_objects(generation, &mut visit));
 }
 
+/// Split the same way [`gc_write_barrier_via_active_runtime`] is: the TLS path
+/// cannot park, so the raw address is still current there, while the `gc_op`
+/// fallback can — and a minor collection during that wait would forward `obj`,
+/// leaving the collector to answer about a forwarding stub.
 fn get_referents_via_active_runtime(obj: GcRef, visitor: majit_gc::GetObjectsVisitorFn) {
     let mut visit = visitor;
-    with_cranelift_gc(|gc| gc.get_referents(obj, &mut visit));
+    if majit_gc::gc_box_installed() && CRANELIFT_ACTIVE_GC.with(|cell| cell.borrow().is_some()) {
+        with_cranelift_gc(|gc| gc.get_referents(obj, &mut visit));
+    } else if majit_gc::gc_sync::is_initialized() {
+        majit_gc::gc_sync::gc_op_with_root(obj, |gc, obj| gc.get_referents(obj, &mut visit));
+    }
 }
 
 fn is_tracked_via_active_runtime(obj: GcRef) -> bool {
-    with_cranelift_gc(|gc| gc.is_tracked(obj)).unwrap_or(false)
+    if majit_gc::gc_box_installed() && CRANELIFT_ACTIVE_GC.with(|cell| cell.borrow().is_some()) {
+        return with_cranelift_gc(|gc| gc.is_tracked(obj)).unwrap_or(false);
+    }
+    if majit_gc::gc_sync::is_initialized() {
+        return majit_gc::gc_sync::gc_op_with_root(obj, |gc, obj| gc.is_tracked(obj));
+    }
+    false
 }
 
 /// Non-moving old-gen-only major trampoline — sweeps dead old-gen objects

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -667,7 +667,9 @@ fn dynasm_get_referents(obj: majit_ir::GcRef, visitor: majit_gc::GetObjectsVisit
     {
         return;
     }
-    majit_gc::gc_sync::gc_op(|g| g.get_referents(obj, &mut visit));
+    // See `MajitGc::get_referents`: the fallback can park, so the argument is
+    // published and reloaded rather than passed as the raw local.
+    majit_gc::gc_sync::gc_op_with_root(obj, |g, obj| g.get_referents(obj, &mut visit));
 }
 
 fn dynasm_is_tracked(obj: majit_ir::GcRef) -> bool {
@@ -676,7 +678,7 @@ fn dynasm_is_tracked(obj: majit_ir::GcRef) -> bool {
     {
         return tracked;
     }
-    majit_gc::gc_sync::gc_op(|g| g.is_tracked(obj))
+    majit_gc::gc_sync::gc_op_with_root(obj, |g, obj| g.is_tracked(obj))
 }
 
 /// Non-moving old-gen-only major. Reclaims stable-allocated interp int/float

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -2950,17 +2950,6 @@ impl MiniMarkGC {
         GcHeader::SIZE + payload_size
     }
 
-    /// Grey one child reference: if it is a managed, not-yet-visited heap
-    /// object, set VISITED and push it onto the gray stack. The
-    /// `is_managed_heap_object` guard mirrors `seed_major_root`: a
-    /// `Ptr(GcStruct)` field can transiently point at memory outside the
-    /// GC-managed heap during the L1/L2 stepping-stone state (e.g.
-    /// `W_TupleObject.wrappeditems` → `std::alloc`'d ItemsBlock). In that
-    /// window calling `header_of` on the field would dereference memory before
-    /// the std::alloc'd block. Upstream RPython `_collect_obj`
-    /// (incminimark.py:2739-2752) does not need this guard because RPython's
-    /// type system guarantees every `Ptr(GcStruct)` is GC-managed; it converges
-    /// away once every `gc_ptr_offsets` target is a real GC allocation.
     /// Total size of `addr`, or `None` when its header does not decode to a
     /// registered type. The panicking [`Self::object_total_size`] is unusable
     /// from a diagnostic that is already reporting a corrupt heap.
@@ -2995,7 +2984,8 @@ impl MiniMarkGC {
         slot_addr: usize,
         holder_words: &[usize],
     ) -> String {
-        if let Some(size) = self.try_object_total_size(holder_addr)
+        if self.is_managed_heap_object(holder_addr)
+            && let Some(size) = self.try_object_total_size(holder_addr)
             && (holder_addr..holder_addr + size).contains(&slot_addr)
         {
             return "self".to_string();
@@ -3021,6 +3011,17 @@ impl MiniMarkGC {
         "unknown".to_string()
     }
 
+    /// Grey one child reference: if it is a managed, not-yet-visited heap
+    /// object, set VISITED and push it onto the gray stack. The
+    /// `is_managed_heap_object` guard mirrors `seed_major_root`: a
+    /// `Ptr(GcStruct)` field can transiently point at memory outside the
+    /// GC-managed heap during the L1/L2 stepping-stone state (e.g.
+    /// `W_TupleObject.wrappeditems` → `std::alloc`'d ItemsBlock). In that
+    /// window calling `header_of` on the field would dereference memory before
+    /// the std::alloc'd block. Upstream RPython `_collect_obj`
+    /// (incminimark.py:2739-2752) does not need this guard because RPython's
+    /// type system guarantees every `Ptr(GcStruct)` is GC-managed; it converges
+    /// away once every `gc_ptr_offsets` target is a real GC allocation.
     fn grey_child(&mut self, addr: usize, holder_addr: usize, slot_addr: usize, site: &str) {
         if self.is_managed_heap_object(addr) && self.may_enter_marking_worklist(addr) {
             let hdr = unsafe { header_of(addr) };

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -2961,6 +2961,66 @@ impl MiniMarkGC {
     /// (incminimark.py:2739-2752) does not need this guard because RPython's
     /// type system guarantees every `Ptr(GcStruct)` is GC-managed; it converges
     /// away once every `gc_ptr_offsets` target is a real GC allocation.
+    /// Total size of `addr`, or `None` when its header does not decode to a
+    /// registered type. The panicking [`Self::object_total_size`] is unusable
+    /// from a diagnostic that is already reporting a corrupt heap.
+    fn try_object_total_size(&self, addr: usize) -> Option<usize> {
+        let type_id = unsafe { (*header_of(addr)).type_id() } as usize;
+        if type_id >= self.types.len() {
+            return None;
+        }
+        let type_info = self.types.get(type_id as u32);
+        let payload_size = if type_info.item_size > 0 {
+            let length = unsafe { *((addr + type_info.length_offset) as *const usize) };
+            type_info.total_instance_size(length)
+        } else {
+            type_info.size
+        };
+        Some(GcHeader::SIZE + payload_size)
+    }
+
+    /// Which object actually owns `slot_addr`.
+    ///
+    /// A `custom_trace` may hand the collector slots that live outside the
+    /// object it was called on — the mapdict storage block and the module-dict
+    /// storage boxes are walked that way. When the child in such a slot is
+    /// corrupt, the discriminating question is whether the *container* was
+    /// reclaimed (its own header would be a freelist link) or the child was, and
+    /// the panic's `holder_*` fields answer neither. Locate the container by
+    /// testing each of the holder's leading words for an extent that covers the
+    /// slot, and report its header.
+    fn describe_enclosing_container(
+        &self,
+        holder_addr: usize,
+        slot_addr: usize,
+        holder_words: &[usize],
+    ) -> String {
+        if let Some(size) = self.try_object_total_size(holder_addr)
+            && (holder_addr..holder_addr + size).contains(&slot_addr)
+        {
+            return "self".to_string();
+        }
+        for (index, &word) in holder_words.iter().enumerate() {
+            if !self.is_managed_heap_object(word) {
+                continue;
+            }
+            let Some(size) = self.try_object_total_size(word) else {
+                continue;
+            };
+            if !(word..word + size).contains(&slot_addr) {
+                continue;
+            }
+            let hdr = unsafe { *header_of(word) };
+            return format!(
+                "word{index}@{word:#x} tid={} tid_and_flags={:#x} size={size} slot_offset={}",
+                hdr.type_id(),
+                hdr.tid_and_flags,
+                slot_addr - word,
+            );
+        }
+        "unknown".to_string()
+    }
+
     fn grey_child(&mut self, addr: usize, holder_addr: usize, slot_addr: usize, site: &str) {
         if self.is_managed_heap_object(addr) && self.may_enter_marking_worklist(addr) {
             let hdr = unsafe { header_of(addr) };
@@ -2976,11 +3036,14 @@ impl MiniMarkGC {
                     *word = unsafe { *((addr as *const usize).add(index)) };
                 }
                 let child_vtable_type_id = self.vtable_to_type_id.get(&child_words[0]).copied();
+                let holder_hdr = unsafe { *header_of(holder_addr) };
                 panic!(
                     "GC BUG: invalid major child type_id={} at child_addr={:#x} \
                      holder_addr={:#x} holder_type_id={} slot_addr={:#x} \
                      holder_offset={:?} site={} holder_words={:#x?} \
-                     child_vtable_type_id={:?} child_words={:#x?}",
+                     child_vtable_type_id={:?} child_words={:#x?} \
+                     holder_tid_and_flags={:#x} holder_in_remembered={} \
+                     enclosing={} gc_state={:?} minors={} majors={}",
                     type_id,
                     addr,
                     holder_addr,
@@ -2991,6 +3054,12 @@ impl MiniMarkGC {
                     holder_words,
                     child_vtable_type_id,
                     child_words,
+                    holder_hdr.tid_and_flags,
+                    self.remembered_set.contains(&holder_addr),
+                    self.describe_enclosing_container(holder_addr, slot_addr, &holder_words),
+                    self.gc_state,
+                    self.minor_collections,
+                    self.major_collections,
                 );
             }
             if unsafe { !(*hdr).has_flag(flags::VISITED) } {

--- a/majit/majit-gc/src/lib.rs
+++ b/majit/majit-gc/src/lib.rs
@@ -1013,10 +1013,17 @@ impl GcAllocator for GcHandle {
         gc_sync::gc_op(|gc| gc.get_objects(generation, visitor))
     }
     fn get_referents(&mut self, obj: GcRef, visitor: &mut dyn FnMut(GcRef)) {
-        gc_sync::gc_op(|gc| gc.get_referents(obj, visitor))
+        // Rooted like `write_barrier`: a contended `gc_op` parks this mutator,
+        // so another thread's minor collection can forward `obj` while the call
+        // waits. Reading the raw argument afterwards would hand the collector a
+        // forwarding stub, which `do_get_referents` rejects — reporting a live
+        // object as having no referents at all.
+        gc_sync::gc_op_with_root(obj, |gc, obj| gc.get_referents(obj, visitor))
     }
     fn is_tracked(&mut self, obj: GcRef) -> bool {
-        gc_sync::gc_op(|gc| gc.is_tracked(obj))
+        // Same exposure as `get_referents`: a forwarded address is not a
+        // managed-heap object of the type the answer is read out of.
+        gc_sync::gc_op_with_root(obj, |gc, obj| gc.is_tracked(obj))
     }
     fn collect_oldgen_nonmoving(&mut self) {
         gc_sync::gc_op(|gc| gc.collect_oldgen_nonmoving())

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -1984,21 +1984,31 @@ pub(crate) fn resolve_kwargs(
 
     // Pack *args and **kwargs into scope — PyPy _match_signature lines 207-259.
     // This produces the final scope_w that maps directly to frame locals.
-    // `gct_fv_gc_malloc` bracket (`framework.py:853-856`) for the two tail
-    // objects: both are born in the nursery, and each allocation that follows
-    // — the other tail object, the key strings, `w_dict_store`'s strategy
-    // promotion — leaves RUNNING before taking `gc_mutex` (`gc_sync.rs:22`),
-    // so a collector on another thread relocates whatever the shadow stack
-    // does not name.  They enter `result` only after the last allocation.
-    let tail_roots = pyre_object::gc_roots::push_roots();
-    let varargs_slot = tail_roots.base();
+    // `gct_fv_gc_malloc` bracket (`framework.py:853-856`).  Every reference
+    // live across the packing is a raw copy: the parameters already bound into
+    // `result`, the unmatched keyword pairs, and the two tail objects.  Each
+    // allocation below — the tail objects, `w_dict_store`'s strategy promotion
+    // — leaves RUNNING before taking `gc_mutex` (`gc_sync.rs:22`), so a
+    // collector on another thread relocates whatever the shadow stack does not
+    // name.  Pin them all, then read every one back out.
+    let roots = pyre_object::gc_roots::push_roots();
+    let result_slot = roots.base();
+    for &value in &result {
+        roots.pin_root(value);
+    }
+    let extra_slot = result_slot + result.len();
+    for &(key, value) in &extra_kwargs {
+        roots.pin_root(key);
+        roots.pin_root(value);
+    }
+    let varargs_slot = extra_slot + extra_kwargs.len() * 2;
     if has_varargs {
         let extra_pos: Vec<PyObjectRef> = if n_pos > n_pos_params {
             args[n_pos_params..n_pos].to_vec()
         } else {
             vec![]
         };
-        tail_roots.pin_root(pyre_object::w_tuple_new(extra_pos));
+        roots.pin_root(pyre_object::w_tuple_new(extra_pos));
     }
     let varkw_slot = varargs_slot + usize::from(has_varargs);
     if has_varkw {
@@ -2006,18 +2016,25 @@ pub(crate) fn resolve_kwargs(
         // EmptyKwargsDictStrategy so the first unicode setitem promotes
         // directly to KwargsDictStrategy (parallel `(keys_w, values_w)`
         // shape) instead of stepping through UnicodeDictStrategy.
-        tail_roots.pin_root(pyre_object::w_dict_new_kwargs());
-        for (key, value) in &extra_kwargs {
+        roots.pin_root(pyre_object::w_dict_new_kwargs());
+        for i in 0..extra_kwargs.len() {
             unsafe {
-                pyre_object::w_dict_store(tail_roots.get(varkw_slot), *key, *value);
+                pyre_object::w_dict_store(
+                    roots.get(varkw_slot),
+                    roots.get(extra_slot + i * 2),
+                    roots.get(extra_slot + i * 2 + 1),
+                );
             }
         }
     }
+    let mut result: Vec<PyObjectRef> = (0..result.len())
+        .map(|i| roots.get(result_slot + i))
+        .collect();
     if has_varargs {
-        result.push(tail_roots.get(varargs_slot));
+        result.push(roots.get(varargs_slot));
     }
     if has_varkw {
-        result.push(tail_roots.get(varkw_slot));
+        result.push(roots.get(varkw_slot));
     }
 
     Ok(result)
@@ -2067,7 +2084,7 @@ pub(crate) fn bind_kwargs_to_signature(
     }
 
     // _match_keywords — match each keyword to a param name by index.
-    let mut extra_kwargs: Vec<(PyObjectRef, PyObjectRef)> = Vec::new();
+    let mut extra_kwargs: Vec<(Wtf8Buf, PyObjectRef)> = Vec::new();
     let mut unmatched_kw_names: Vec<Wtf8Buf> = Vec::new();
     // argument.py:469,481-484 — collected across the whole loop, reported
     // together instead of raising on the first violation found.
@@ -2105,11 +2122,12 @@ pub(crate) fn bind_kwargs_to_signature(
         }
         if !matched {
             if has_varkw {
-                // The key is born old-stable (non-moving) and is held in this
-                // Rust Vec only across native-only work (the rest of this loop,
-                // then w_tuple_new / w_dict_new_kwargs below): no safepoint fires
-                // before it is installed, so the unrooted buffer stays valid.
-                extra_kwargs.push((pyre_object::w_str_from_wtf8_managed(key.clone()), *value));
+                // The name stays a `Wtf8Buf` until the packing bracket below.
+                // Interning it here would allocate once per unmatched keyword,
+                // and every one of those is a safepoint that relocates the
+                // values already accumulated — and the bound parameters in
+                // `result` — while nothing names them.
+                extra_kwargs.push((key.clone(), *value));
             } else {
                 unmatched_kw_names.push(key.clone());
             }
@@ -2148,32 +2166,48 @@ pub(crate) fn bind_kwargs_to_signature(
     }
 
     // Pack `*args` / `**kwargs` tails — argument.py _match_signature 207-259.
-    // Both tail objects are born young and stay livevars until they reach
-    // `result`; see the same bracket in `bind_kwargs`.
-    let tail_roots = pyre_object::gc_roots::push_roots();
-    let varargs_slot = tail_roots.base();
+    // The bound parameters, the unmatched keyword pairs and both tail objects
+    // are all raw copies held across the packing allocations; see the same
+    // bracket in `resolve_kwargs`.
+    let roots = pyre_object::gc_roots::push_roots();
+    let result_slot = roots.base();
+    for &value in &result {
+        roots.pin_root(value);
+    }
+    let extra_slot = result_slot + result.len();
+    for &(_, value) in &extra_kwargs {
+        roots.pin_root(value);
+    }
+    let varargs_slot = extra_slot + extra_kwargs.len();
     if has_varargs {
         let extra_pos: Vec<PyObjectRef> = if n_pos > n_pos_params {
             pos_args[n_pos_params..n_pos].to_vec()
         } else {
             vec![]
         };
-        tail_roots.pin_root(pyre_object::w_tuple_new(extra_pos));
+        roots.pin_root(pyre_object::w_tuple_new(extra_pos));
     }
     let varkw_slot = varargs_slot + usize::from(has_varargs);
     if has_varkw {
-        tail_roots.pin_root(pyre_object::w_dict_new_kwargs());
-        for (key, value) in &extra_kwargs {
+        roots.pin_root(pyre_object::w_dict_new_kwargs());
+        for (i, (key, _)) in extra_kwargs.iter().enumerate() {
             unsafe {
-                pyre_object::w_dict_store(tail_roots.get(varkw_slot), *key, *value);
+                // The key allocation runs first: as the second argument it
+                // would be evaluated after the receiver, handing
+                // `w_dict_store` the pre-collection dict address.
+                let w_key = pyre_object::w_str_from_wtf8_managed(key.clone());
+                pyre_object::w_dict_store(roots.get(varkw_slot), w_key, roots.get(extra_slot + i));
             }
         }
     }
+    let mut result: Vec<PyObjectRef> = (0..result.len())
+        .map(|i| roots.get(result_slot + i))
+        .collect();
     if has_varargs {
-        result.push(tail_roots.get(varargs_slot));
+        result.push(roots.get(varargs_slot));
     }
     if has_varkw {
-        result.push(tail_roots.get(varkw_slot));
+        result.push(roots.get(varkw_slot));
     }
 
     Ok(result)
@@ -2337,7 +2371,6 @@ pub fn call_with_kwargs(
                     )
                 });
             }
-            let mut full_args = pos_args.to_vec();
             // `gct_fv_gc_malloc` bracket (`framework.py:853-856`) for the kwargs
             // dict below.  `w_dict_new` allocates in the nursery, so the fresh
             // dict is a young object no root names, and every step that follows
@@ -2347,17 +2380,27 @@ pub fn call_with_kwargs(
             // another thread runs there and relocates or reclaims anything the
             // shadow stack does not name.  The scope reaches every `return`
             // below, which is where the dict stops being a livevar.
+            //
+            // The positionals and the keyword values are already pinned by
+            // this function's entry bracket, so they are read back through
+            // `current_pos_arg` / `current_kwarg` instead of being copied —
+            // `pos_args.to_vec()` taken before these allocations would hand
+            // the callee pre-collection addresses.
             let kw_roots = pyre_object::gc_roots::push_roots();
             let kw_slot = kw_roots.base();
             if !kwargs.is_empty() {
                 kw_roots.pin_root(pyre_object::w_dict_new());
-                for (key, value) in kwargs {
+                for (index, (key, _)) in kwargs.iter().enumerate() {
                     unsafe {
                         // The key allocation runs first: as the second argument
                         // it would be evaluated after the receiver, handing
                         // `w_dict_store` the pre-collection dict address.
                         let w_key = pyre_object::w_str_from_wtf8_managed(key.clone());
-                        pyre_object::w_dict_store(kw_roots.get(kw_slot), w_key, *value);
+                        pyre_object::w_dict_store(
+                            kw_roots.get(kw_slot),
+                            w_key,
+                            current_kwarg(index),
+                        );
                     }
                 }
                 // Store the marker last so a user keyword literally named
@@ -2369,6 +2412,10 @@ pub fn call_with_kwargs(
                     let marker_value = pyre_object::kw_marker::w_kw_marker_sentinel();
                     pyre_object::w_dict_store(kw_roots.get(kw_slot), marker_key, marker_value);
                 }
+            }
+            let mut full_args: Vec<PyObjectRef> =
+                (0..pos_args.len()).map(current_pos_arg).collect();
+            if !kwargs.is_empty() {
                 full_args.push(kw_roots.get(kw_slot));
                 // Step 2 of the Arguments port: when this is a profiled
                 // builtin call AND kwargs are present, route through
@@ -2388,16 +2435,24 @@ pub fn call_with_kwargs(
                         .iter()
                         .map(|(k, _)| pyre_object::w_str_from_wtf8(k.clone()))
                         .collect();
+                    // `keyword_names_w` allocated a string per keyword, so
+                    // everything read before it — the positionals, the keyword
+                    // values, and the dict `full_args` carries — may have moved
+                    // since. Everything below reloads from the roots.
                     let keywords_w: Vec<pyre_object::PyObjectRef> =
-                        kwargs.iter().map(|(_, v)| *v).collect();
+                        (0..kwargs.len()).map(current_kwarg).collect();
+                    let refreshed_pos: Vec<pyre_object::PyObjectRef> =
+                        (0..pos_args.len()).map(current_pos_arg).collect();
                     let arguments = crate::argument::Arguments::with_kw(
-                        pos_args,
+                        &refreshed_pos,
                         &keyword_names_w,
                         &keywords_w,
                     );
-                    // `keyword_names_w` allocated a string per keyword, so the
-                    // dict `full_args` carries may have moved since the push.
-                    *full_args.last_mut().expect("kwargs dict was pushed") = kw_roots.get(kw_slot);
+                    full_args = refreshed_pos
+                        .iter()
+                        .copied()
+                        .chain(std::iter::once(kw_roots.get(kw_slot)))
+                        .collect();
                     let w_res = crate::baseobjspace::call_args_and_c_profile_args(
                         unsafe { &mut *frame_ptr },
                         callable,
@@ -3688,6 +3743,14 @@ pub(crate) fn real_build_class(args: &[PyObjectRef]) -> Result<PyObjectRef, crat
 
     // Check if last arg is a kwargs dict (from CALL_KW)
     // PyPy: __build_class__(func, name, *bases, metaclass=None, **kwds)
+    //
+    // The class-definition keywords are collected into a fresh dict that only
+    // `build_class_inner` consumes, so the guard is opened here rather than
+    // inside the arm below: `update_bases` and both `w_tuple_new` calls run
+    // between the two, and a guard scoped to the arm would unpin the dict
+    // across them. `build_class_inner` re-pins its own parameter copy.
+    let extra_roots = pyre_object::gc_roots::push_roots();
+    let extra_slot = extra_roots.base();
     let (base_args, metaclass, extra_kwargs) = if args.len() > 2 {
         let last = args[args.len() - 1];
         if unsafe { pyre_object::is_dict(last) }
@@ -3703,8 +3766,6 @@ pub(crate) fn real_build_class(args: &[PyObjectRef]) -> Result<PyObjectRef, crat
             // walks the strategy.
             // Born young, and `w_dict_store` allocates on strategy promotion —
             // the bracket in `call_with_kwargs`.
-            let extra_roots = pyre_object::gc_roots::push_roots();
-            let extra_slot = extra_roots.base();
             extra_roots.pin_root(pyre_object::w_dict_new());
             unsafe {
                 for (k, v) in pyre_object::w_dict_items(last) {
@@ -3781,7 +3842,7 @@ pub(crate) fn real_build_class(args: &[PyObjectRef]) -> Result<PyObjectRef, crat
         name,
         bases_tuple,
         w_metaclass,
-        extra_kwargs,
+        extra_kwargs.map(|_| extra_roots.get(extra_slot)),
         w_orig_bases,
     )
 }
@@ -3794,6 +3855,18 @@ fn build_class_inner(
     extra_kwargs: Option<PyObjectRef>,
     w_orig_bases: Option<PyObjectRef>,
 ) -> PyResult {
+    // The class-definition keywords survive the class body call and the whole
+    // metaclass construction below, and the parameter is a raw copy taken
+    // before any of it. Pin it once and read it back at each of the three
+    // sites that consume it.
+    let _kwds_roots = pyre_object::gc_roots::push_roots();
+    let kwds_slot = extra_kwargs.map(|kw| {
+        let slot = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(kw);
+        slot
+    });
+    let current_kwds = || kwds_slot.map(|slot| pyre_object::gc_roots::shadow_stack_get(slot));
+
     let w_code = unsafe { crate::getcode(body_fn) };
     let w_globals = unsafe { function_get_globals_obj(body_fn) };
     let closure = unsafe { function_get_closure(body_fn) };
@@ -3813,7 +3886,7 @@ fn build_class_inner(
                 // compiling.py:190-196 — call __prepare__ with the
                 // class-definition keywords ('metaclass' already popped by
                 // the caller).
-                let prepare_kwds: Vec<(Wtf8Buf, PyObjectRef)> = match extra_kwargs {
+                let prepare_kwds: Vec<(Wtf8Buf, PyObjectRef)> = match current_kwds() {
                     Some(kw) if unsafe { pyre_object::is_dict(kw) } => unsafe {
                         pyre_object::w_dict_str_entries_wtf8(kw)
                     },
@@ -4299,7 +4372,7 @@ fn build_class_inner(
             w_namespace_dict = pyre_object::gc_roots::shadow_stack_get(root);
         }
         clear_call_error();
-        let result = if let Some(kw) = extra_kwargs {
+        let result = if let Some(kw) = current_kwds() {
             // Only use kwargs path if there are actual extra kwargs
             let has_extra = unsafe { pyre_object::is_dict(kw) && pyre_object::w_dict_len(kw) > 0 };
             if has_extra {
@@ -4518,7 +4591,7 @@ fn build_class_inner(
     // which fires __init_subclass__ with the subset of keywords the
     // metaclass actually forwarded — so it must NOT be re-fired here.
     if w_metaclass.is_none() {
-        let init_subclass_kwargs: Vec<(PyObjectRef, PyObjectRef)> = match extra_kwargs {
+        let init_subclass_kwargs: Vec<(PyObjectRef, PyObjectRef)> = match current_kwds() {
             Some(kw) if unsafe { pyre_object::is_dict(kw) } => unsafe {
                 pyre_object::w_dict_items(kw)
                     .into_iter()
@@ -4542,13 +4615,24 @@ fn build_class_inner(
 /// consumes.  Mirrors the producer in `call_with_kwargs`.
 fn pack_pyre_kwargs(kw_items: &[(PyObjectRef, PyObjectRef)]) -> PyObjectRef {
     // The dict is born young, and `w_dict_store` allocates when it promotes the
-    // strategy — see the bracket in `call_with_kwargs`.
+    // strategy — see the bracket in `call_with_kwargs`. `kw_items` is the
+    // caller's array of raw references, so the pairs still to be installed are
+    // pinned as well: the first promotion relocates every one of them.
     let kw_roots = pyre_object::gc_roots::push_roots();
-    let kw_slot = kw_roots.base();
+    let item_slot = kw_roots.base();
+    for &(k, v) in kw_items {
+        kw_roots.pin_root(k);
+        kw_roots.pin_root(v);
+    }
+    let kw_slot = item_slot + kw_items.len() * 2;
     kw_roots.pin_root(pyre_object::w_dict_new());
     unsafe {
-        for (k, v) in kw_items {
-            pyre_object::w_dict_store(kw_roots.get(kw_slot), *k, *v);
+        for i in 0..kw_items.len() {
+            pyre_object::w_dict_store(
+                kw_roots.get(kw_slot),
+                kw_roots.get(item_slot + i * 2),
+                kw_roots.get(item_slot + i * 2 + 1),
+            );
         }
         // Marker stored last so a user keyword named `__pyre_kw__` cannot
         // overwrite the sentinel detection compares by identity.

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -1984,26 +1984,40 @@ pub(crate) fn resolve_kwargs(
 
     // Pack *args and **kwargs into scope — PyPy _match_signature lines 207-259.
     // This produces the final scope_w that maps directly to frame locals.
+    // `gct_fv_gc_malloc` bracket (`framework.py:853-856`) for the two tail
+    // objects: both are born in the nursery, and each allocation that follows
+    // — the other tail object, the key strings, `w_dict_store`'s strategy
+    // promotion — leaves RUNNING before taking `gc_mutex` (`gc_sync.rs:22`),
+    // so a collector on another thread relocates whatever the shadow stack
+    // does not name.  They enter `result` only after the last allocation.
+    let tail_roots = pyre_object::gc_roots::push_roots();
+    let varargs_slot = tail_roots.base();
     if has_varargs {
         let extra_pos: Vec<PyObjectRef> = if n_pos > n_pos_params {
             args[n_pos_params..n_pos].to_vec()
         } else {
             vec![]
         };
-        result.push(pyre_object::w_tuple_new(extra_pos));
+        tail_roots.pin_root(pyre_object::w_tuple_new(extra_pos));
     }
+    let varkw_slot = varargs_slot + usize::from(has_varargs);
     if has_varkw {
         // `dictmultiobject.py:77-80` — `space.newdict(kwargs=True)` selects
         // EmptyKwargsDictStrategy so the first unicode setitem promotes
         // directly to KwargsDictStrategy (parallel `(keys_w, values_w)`
         // shape) instead of stepping through UnicodeDictStrategy.
-        let kw_dict = pyre_object::w_dict_new_kwargs();
+        tail_roots.pin_root(pyre_object::w_dict_new_kwargs());
         for (key, value) in &extra_kwargs {
             unsafe {
-                pyre_object::w_dict_store(kw_dict, *key, *value);
+                pyre_object::w_dict_store(tail_roots.get(varkw_slot), *key, *value);
             }
         }
-        result.push(kw_dict);
+    }
+    if has_varargs {
+        result.push(tail_roots.get(varargs_slot));
+    }
+    if has_varkw {
+        result.push(tail_roots.get(varkw_slot));
     }
 
     Ok(result)
@@ -2134,22 +2148,32 @@ pub(crate) fn bind_kwargs_to_signature(
     }
 
     // Pack `*args` / `**kwargs` tails — argument.py _match_signature 207-259.
+    // Both tail objects are born young and stay livevars until they reach
+    // `result`; see the same bracket in `bind_kwargs`.
+    let tail_roots = pyre_object::gc_roots::push_roots();
+    let varargs_slot = tail_roots.base();
     if has_varargs {
         let extra_pos: Vec<PyObjectRef> = if n_pos > n_pos_params {
             pos_args[n_pos_params..n_pos].to_vec()
         } else {
             vec![]
         };
-        result.push(pyre_object::w_tuple_new(extra_pos));
+        tail_roots.pin_root(pyre_object::w_tuple_new(extra_pos));
     }
+    let varkw_slot = varargs_slot + usize::from(has_varargs);
     if has_varkw {
-        let kw_dict = pyre_object::w_dict_new_kwargs();
+        tail_roots.pin_root(pyre_object::w_dict_new_kwargs());
         for (key, value) in &extra_kwargs {
             unsafe {
-                pyre_object::w_dict_store(kw_dict, *key, *value);
+                pyre_object::w_dict_store(tail_roots.get(varkw_slot), *key, *value);
             }
         }
-        result.push(kw_dict);
+    }
+    if has_varargs {
+        result.push(tail_roots.get(varargs_slot));
+    }
+    if has_varkw {
+        result.push(tail_roots.get(varkw_slot));
     }
 
     Ok(result)
@@ -2314,20 +2338,26 @@ pub fn call_with_kwargs(
                 });
             }
             let mut full_args = pos_args.to_vec();
+            // `gct_fv_gc_malloc` bracket (`framework.py:853-856`) for the kwargs
+            // dict below.  `w_dict_new` allocates in the nursery, so the fresh
+            // dict is a young object no root names, and every step that follows
+            // allocates: the key strings, `w_dict_store`'s strategy promotion,
+            // and the call this frame ends in.  An allocation leaves RUNNING
+            // before taking `gc_mutex` (`gc_sync.rs:22`), so a collector on
+            // another thread runs there and relocates or reclaims anything the
+            // shadow stack does not name.  The scope reaches every `return`
+            // below, which is where the dict stops being a livevar.
+            let kw_roots = pyre_object::gc_roots::push_roots();
+            let kw_slot = kw_roots.base();
             if !kwargs.is_empty() {
-                let kwargs_dict = pyre_object::w_dict_new();
-                // Each key is born old-stable (non-moving) and this loop is
-                // straight-line native (str key hash/eq, non-collecting dict
-                // alloc): no safepoint fires between a key's allocation and its
-                // dict install, so an unrooted Rust temporary cannot be swept
-                // or relocated here — unlike a path that re-enters the eval loop.
+                kw_roots.pin_root(pyre_object::w_dict_new());
                 for (key, value) in kwargs {
                     unsafe {
-                        pyre_object::w_dict_store(
-                            kwargs_dict,
-                            pyre_object::w_str_from_wtf8_managed(key.clone()),
-                            *value,
-                        );
+                        // The key allocation runs first: as the second argument
+                        // it would be evaluated after the receiver, handing
+                        // `w_dict_store` the pre-collection dict address.
+                        let w_key = pyre_object::w_str_from_wtf8_managed(key.clone());
+                        pyre_object::w_dict_store(kw_roots.get(kw_slot), w_key, *value);
                     }
                 }
                 // Store the marker last so a user keyword literally named
@@ -2335,13 +2365,11 @@ pub fn call_with_kwargs(
                 // key always resolves to the sentinel value that detection
                 // compares by identity.
                 unsafe {
-                    pyre_object::w_dict_store(
-                        kwargs_dict,
-                        pyre_object::kw_marker::w_kw_marker_key(),
-                        pyre_object::kw_marker::w_kw_marker_sentinel(),
-                    );
+                    let marker_key = pyre_object::kw_marker::w_kw_marker_key();
+                    let marker_value = pyre_object::kw_marker::w_kw_marker_sentinel();
+                    pyre_object::w_dict_store(kw_roots.get(kw_slot), marker_key, marker_value);
                 }
-                full_args.push(kwargs_dict);
+                full_args.push(kw_roots.get(kw_slot));
                 // Step 2 of the Arguments port: when this is a profiled
                 // builtin call AND kwargs are present, route through
                 // `call_args_and_c_profile_args` with a structured
@@ -2367,6 +2395,9 @@ pub fn call_with_kwargs(
                         &keyword_names_w,
                         &keywords_w,
                     );
+                    // `keyword_names_w` allocated a string per keyword, so the
+                    // dict `full_args` carries may have moved since the push.
+                    *full_args.last_mut().expect("kwargs dict was pushed") = kw_roots.get(kw_slot);
                     let w_res = crate::baseobjspace::call_args_and_c_profile_args(
                         unsafe { &mut *frame_ptr },
                         callable,
@@ -2603,9 +2634,13 @@ pub fn call_with_kwargs(
                 pyre_object::gc_roots::pin_root(kw_dict);
                 for (key, value) in &extra_kwargs {
                     unsafe {
+                        // The key allocation runs first: as the second argument
+                        // it would be evaluated after the receiver, handing
+                        // `w_dict_store` the pre-collection dict address.
+                        let w_key = pyre_object::w_str_from_wtf8_managed(key.clone());
                         pyre_object::w_dict_store(
                             pyre_object::gc_roots::shadow_stack_get(kw_dict_slot),
-                            pyre_object::w_str_from_wtf8_managed(key.clone()),
+                            w_key,
                             pyre_object::gc_hook::try_gc_current_object_address(*value as *mut u8)
                                 as PyObjectRef,
                         );
@@ -3666,18 +3701,26 @@ pub(crate) fn real_build_class(args: &[PyObjectRef]) -> Result<PyObjectRef, crat
             // `w_dict_items` already dispatches `is_module_dict` so a
             // class statement with `**module_dict` (rare but valid)
             // walks the strategy.
-            let extra = pyre_object::w_dict_new();
+            // Born young, and `w_dict_store` allocates on strategy promotion —
+            // the bracket in `call_with_kwargs`.
+            let extra_roots = pyre_object::gc_roots::push_roots();
+            let extra_slot = extra_roots.base();
+            extra_roots.pin_root(pyre_object::w_dict_new());
             unsafe {
                 for (k, v) in pyre_object::w_dict_items(last) {
                     if pyre_object::is_str(k) {
                         let key = pyre_object::w_str_get_wtf8(k).as_str();
                         if key != Ok("metaclass") && key != Ok("__pyre_kw__") {
-                            pyre_object::w_dict_store(extra, k, v);
+                            pyre_object::w_dict_store(extra_roots.get(extra_slot), k, v);
                         }
                     }
                 }
             }
-            (&args[2..args.len() - 1], w_metaclass, Some(extra))
+            (
+                &args[2..args.len() - 1],
+                w_metaclass,
+                Some(extra_roots.get(extra_slot)),
+            )
         } else {
             (&args[2..], None, None)
         }
@@ -4498,20 +4541,22 @@ fn build_class_inner(
 /// trailing dict that the builtin kwargs ABI (`split_builtin_kwargs`)
 /// consumes.  Mirrors the producer in `call_with_kwargs`.
 fn pack_pyre_kwargs(kw_items: &[(PyObjectRef, PyObjectRef)]) -> PyObjectRef {
-    let kw_dict = pyre_object::w_dict_new();
+    // The dict is born young, and `w_dict_store` allocates when it promotes the
+    // strategy — see the bracket in `call_with_kwargs`.
+    let kw_roots = pyre_object::gc_roots::push_roots();
+    let kw_slot = kw_roots.base();
+    kw_roots.pin_root(pyre_object::w_dict_new());
     unsafe {
         for (k, v) in kw_items {
-            pyre_object::w_dict_store(kw_dict, *k, *v);
+            pyre_object::w_dict_store(kw_roots.get(kw_slot), *k, *v);
         }
         // Marker stored last so a user keyword named `__pyre_kw__` cannot
         // overwrite the sentinel detection compares by identity.
-        pyre_object::w_dict_store(
-            kw_dict,
-            pyre_object::kw_marker::w_kw_marker_key(),
-            pyre_object::kw_marker::w_kw_marker_sentinel(),
-        );
+        let marker_key = pyre_object::kw_marker::w_kw_marker_key();
+        let marker_value = pyre_object::kw_marker::w_kw_marker_sentinel();
+        pyre_object::w_dict_store(kw_roots.get(kw_slot), marker_key, marker_value);
     }
-    kw_dict
+    kw_roots.get(kw_slot)
 }
 
 /// typeobject.py:1020-1026 `_init_subclass` — after a class is created,

--- a/pyre/pyre-interpreter/src/module/_collections/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_collections/mod.rs
@@ -129,7 +129,14 @@ fn deque_len(self_obj: PyObjectRef) -> i64 {
 }
 
 /// Snapshot the backing list into a `Vec`.
+///
+/// The walk reads `leftblock`/`leftindex`/`len` and then follows `rightlink`,
+/// so it has to exclude the chain replacement in `store`: a walk interleaved
+/// with one reads endpoints belonging to two different chains and can reach a
+/// `PY_NULL` link. The stripe is reentrant, so the `store`/`append_right`
+/// nesting below costs nothing.
 fn snapshot(self_obj: PyObjectRef) -> Vec<PyObjectRef> {
+    let _deque_guard = unsafe { w_deque_lock(self_obj) };
     let Some(deque) = W_Deque::from_obj(self_obj) else {
         return vec![];
     };
@@ -148,7 +155,11 @@ fn snapshot(self_obj: PyObjectRef) -> Vec<PyObjectRef> {
 }
 
 /// Replace the block chain with `items`.
+///
+/// Held across the whole replacement, not per `append_right`, so no other
+/// thread observes the intermediate empty chain.
 fn store(self_obj: PyObjectRef, items: Vec<PyObjectRef>) {
+    let _deque_guard = unsafe { w_deque_lock(self_obj) };
     clear_blocks(self_obj);
     for item in items {
         append_right(self_obj, item);
@@ -156,6 +167,7 @@ fn store(self_obj: PyObjectRef, items: Vec<PyObjectRef>) {
 }
 
 fn clear_blocks(self_obj: PyObjectRef) {
+    let _deque_guard = unsafe { w_deque_lock(self_obj) };
     let new_block = deque_block::new(PY_NULL, PY_NULL);
     let deque = W_Deque::from_obj(self_obj).expect("deque");
     deque.leftblock = new_block;
@@ -911,7 +923,9 @@ impl W_Deque {
     fn reverse(&mut self) {
         let self_obj = self as *mut W_Deque as PyObjectRef;
         // `interp_deque.py reverse`: swap entries from both endpoints without
-        // invalidating iterators.
+        // invalidating iterators. No Python runs inside the swap loop, so the
+        // stripe covers the whole transition.
+        let _deque_guard = unsafe { w_deque_lock(self_obj) };
         let len = deque_len(self_obj);
         for index in 0..(len >> 1) {
             let (left_block, left_index) = locate(self_obj, index);
@@ -930,6 +944,11 @@ impl W_Deque {
             Some(v) => crate::builtins::getindex_w(v)?,
             None => 1,
         };
+        // Read-modify-write: `snapshot` and `store` are individually atomic,
+        // and the stripe held across both is what stops a concurrent mutation
+        // in between from being overwritten by the stale snapshot. No Python
+        // runs from here on.
+        let _deque_guard = unsafe { w_deque_lock(self_obj) };
         let mut items = snapshot(self_obj);
         let len = items.len() as i64;
         if len <= 1 {
@@ -948,6 +967,9 @@ impl W_Deque {
         // before the deque is inspected), then a bounded deque that is already
         // full raises before the element is placed.
         let index = crate::builtins::getindex_w(i)?;
+        // See `rotate`: the snapshot/store pair is the read-modify-write that
+        // the stripe has to cover as one.
+        let _deque_guard = unsafe { w_deque_lock(self_obj) };
         let mut items = snapshot(self_obj);
         if maxlen_bound(self_obj).is_some_and(|m| items.len() >= m) {
             return Err(crate::PyError::index_error(
@@ -1067,6 +1089,10 @@ impl W_Deque {
     fn __getitem__(&self, index: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
         let self_obj = self as *const W_Deque as PyObjectRef;
         let idx = deque_index(index, || deque_len(self_obj))? as i64;
+        // `locate` walks the chain and the caller then reads through the block
+        // it returns, so the pair has to exclude a concurrent `store`. The
+        // index conversion runs Python and stays outside.
+        let _deque_guard = unsafe { w_deque_lock(self_obj) };
         let (block_obj, block_index) = locate(self_obj, idx);
         Ok(block_get(block_obj, block_index))
     }
@@ -1081,6 +1107,7 @@ impl W_Deque {
         // and deliberately does not call `modified()`: deque iterators remain
         // valid and observe subsequently assigned elements (including after
         // pickle reconstruction).
+        let _deque_guard = unsafe { w_deque_lock(self_obj) };
         let (block_obj, block_index) = locate(self_obj, idx);
         block_set(block_obj, block_index, value);
         Ok(())
@@ -1088,6 +1115,9 @@ impl W_Deque {
     fn __delitem__(&mut self, index: PyObjectRef) -> Result<(), crate::PyError> {
         let self_obj = self as *mut W_Deque as PyObjectRef;
         let idx = deque_index(index, || deque_len(self_obj))?;
+        // See `rotate`: the snapshot/store pair is the read-modify-write that
+        // the stripe has to cover as one.
+        let _deque_guard = unsafe { w_deque_lock(self_obj) };
         let mut items = snapshot(self_obj);
         items.remove(idx);
         store(self_obj, items);

--- a/pyre/pyre-interpreter/src/module/_collections/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_collections/mod.rs
@@ -642,6 +642,21 @@ fn deque_index(index: PyObjectRef, len_of: impl FnOnce() -> i64) -> Result<usize
     Ok(idx as usize)
 }
 
+/// Re-bound a converted index against the deque as it stands *under* the
+/// stripe guard.
+///
+/// `deque_index` bounds against the length it read while `__index__` was still
+/// running, so by the time the guard is held another thread may have shortened
+/// the deque. `locate` would then walk past the end of the chain and
+/// `Vec::remove` would panic instead of raising, so every indexed accessor
+/// re-checks here before it addresses storage.
+fn check_index_under_guard(self_obj: PyObjectRef, idx: i64) -> Result<(), crate::PyError> {
+    if idx < 0 || idx >= deque_len(self_obj) {
+        return Err(crate::PyError::index_error("index out of range"));
+    }
+    Ok(())
+}
+
 /// `W_Deque.locate`: choose the nearer endpoint and walk whole blocks.
 fn locate(self_obj: PyObjectRef, mut index: i64) -> (PyObjectRef, i64) {
     let deque = W_Deque::from_obj(self_obj).expect("deque");
@@ -899,6 +914,18 @@ impl W_Deque {
         }
         match pos {
             Some(pos) => {
+                // The guard cannot span the loop above: `eq_w` runs arbitrary
+                // Python, and holding a stripe across it would let user code
+                // reach a second deque and invert the acquisition order. It
+                // does cover the write-back, and the epoch is re-read under it
+                // so a mutation that landed after the last comparison is
+                // reported rather than silently overwritten by the snapshot.
+                let _deque_guard = unsafe { w_deque_lock(self_obj) };
+                if lock_state(self_obj) != lock {
+                    return Err(crate::PyError::index_error(
+                        "deque mutated during iteration",
+                    ));
+                }
                 items.remove(pos);
                 store(self_obj, items);
                 Ok(())
@@ -1093,6 +1120,7 @@ impl W_Deque {
         // it returns, so the pair has to exclude a concurrent `store`. The
         // index conversion runs Python and stays outside.
         let _deque_guard = unsafe { w_deque_lock(self_obj) };
+        check_index_under_guard(self_obj, idx)?;
         let (block_obj, block_index) = locate(self_obj, idx);
         Ok(block_get(block_obj, block_index))
     }
@@ -1108,6 +1136,7 @@ impl W_Deque {
         // valid and observe subsequently assigned elements (including after
         // pickle reconstruction).
         let _deque_guard = unsafe { w_deque_lock(self_obj) };
+        check_index_under_guard(self_obj, idx)?;
         let (block_obj, block_index) = locate(self_obj, idx);
         block_set(block_obj, block_index, value);
         Ok(())
@@ -1118,6 +1147,7 @@ impl W_Deque {
         // See `rotate`: the snapshot/store pair is the read-modify-write that
         // the stripe has to cover as one.
         let _deque_guard = unsafe { w_deque_lock(self_obj) };
+        check_index_under_guard(self_obj, idx as i64)?;
         let mut items = snapshot(self_obj);
         items.remove(idx);
         store(self_obj, items);
@@ -1194,6 +1224,10 @@ impl W_Deque {
             return Ok(pyre_object::w_not_implemented());
         }
         let num = unsafe { w_int_get_value(n) };
+        // Nothing between the snapshot and the write-back runs Python, so the
+        // whole read-modify-write fits under one stripe — without it a
+        // concurrent `append` lands between them and is dropped by `store`.
+        let _deque_guard = unsafe { w_deque_lock(self_obj) };
         let base = snapshot(self_obj);
         if base.is_empty() || num == 1 {
             return Ok(self_obj);

--- a/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
+++ b/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
@@ -2812,28 +2812,36 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
             let buffer = crate::baseobjspace::simple_buffer_bytes(args[1])?.ok_or_else(|| {
                 crate::PyError::type_error("send: buffer must be bytes-like")
             })?;
-            let buf = buffer.as_bytes();
             let flags = if args.len() >= 3 {
                 (unsafe { pyre_object::w_int_get_value(args[2]) }) as libc::c_int
             } else {
                 0
             };
-            let n = loop {
-                let r = unsafe {
-                    libc::send(fd, buf.as_ptr() as *const libc::c_void, buf.len(), flags)
-                };
-                if r >= 0 {
-                    break r;
+            // `PyBuffer_Release` after the call — `SimpleBufferBytes` has no
+            // `Drop`, so an export that is never released leaves a `bytearray`
+            // argument permanently exported and unable to be resized. The
+            // borrow of `buffer` is scoped to the closure so the release also
+            // covers the error paths.
+            let result = (|| -> Result<isize, crate::PyError> {
+                let buf = buffer.as_bytes();
+                loop {
+                    let r = unsafe {
+                        libc::send(fd, buf.as_ptr() as *const libc::c_void, buf.len(), flags)
+                    };
+                    if r >= 0 {
+                        return Ok(r);
+                    }
+                    let err = std::io::Error::last_os_error();
+                    if err.raw_os_error() != Some(libc::EINTR) {
+                        return Err(socket_io_err(err));
+                    }
+                    // EINTR: deliver a pending signal, then retry
+                    // (`converted_error` eintr_retry).
+                    crate::module::signal::interp_signal::checksignals_now()?;
                 }
-                let err = std::io::Error::last_os_error();
-                if err.raw_os_error() != Some(libc::EINTR) {
-                    return Err(socket_io_err(err));
-                }
-                // EINTR: deliver a pending signal, then retry
-                // (`converted_error` eintr_retry).
-                crate::module::signal::interp_signal::checksignals_now()?;
-            };
-            Ok(pyre_object::w_int_new(n as i64))
+            })();
+            buffer.release();
+            Ok(pyre_object::w_int_new(result? as i64))
         }),
     ) };
 
@@ -2849,34 +2857,41 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
             let buffer = crate::baseobjspace::simple_buffer_bytes(args[1])?.ok_or_else(|| {
                 crate::PyError::type_error("sendall: buffer must be bytes-like")
             })?;
-            let buf = buffer.as_bytes();
             let flags = if args.len() >= 3 {
                 (unsafe { pyre_object::w_int_get_value(args[2]) }) as libc::c_int
             } else {
                 0
             };
-            let mut off = 0usize;
-            while off < buf.len() {
-                let n = unsafe {
-                    libc::send(
-                        fd,
-                        buf[off..].as_ptr() as *const libc::c_void,
-                        buf.len() - off,
-                        flags,
-                    )
-                };
-                if n < 0 {
-                    let err = std::io::Error::last_os_error();
-                    if err.raw_os_error() == Some(libc::EINTR) {
-                        // `rsocket.py:1132` signal_checker — deliver a pending
-                        // signal, then retry the remaining bytes.
-                        crate::module::signal::interp_signal::checksignals_now()?;
-                        continue;
+            // See `send` above: the export is released once the borrow of
+            // `buffer` ends, on the error path as well.
+            let result = (|| -> Result<(), crate::PyError> {
+                let buf = buffer.as_bytes();
+                let mut off = 0usize;
+                while off < buf.len() {
+                    let n = unsafe {
+                        libc::send(
+                            fd,
+                            buf[off..].as_ptr() as *const libc::c_void,
+                            buf.len() - off,
+                            flags,
+                        )
+                    };
+                    if n < 0 {
+                        let err = std::io::Error::last_os_error();
+                        if err.raw_os_error() == Some(libc::EINTR) {
+                            // `rsocket.py:1132` signal_checker — deliver a
+                            // pending signal, then retry the remaining bytes.
+                            crate::module::signal::interp_signal::checksignals_now()?;
+                            continue;
+                        }
+                        return Err(socket_io_err(err));
                     }
-                    return Err(socket_io_err(err));
+                    off += n as usize;
                 }
-                off += n as usize;
-            }
+                Ok(())
+            })();
+            buffer.release();
+            result?;
             Ok(pyre_object::w_none())
         }),
     ) };
@@ -2940,7 +2955,6 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
             let buffer = crate::baseobjspace::simple_buffer_bytes(args[1])?.ok_or_else(|| {
                 crate::PyError::type_error("sendto: buffer must be bytes-like")
             })?;
-            let buf = buffer.as_bytes();
             // 3-arg form: (buf, flags, addr).  4-arg form: (self, buf, flags, addr).
             // We always take self-as-args[0], so 3 args = (self, buf, addr) [no flags]
             // and 4 args = (self, buf, flags, addr).
@@ -2952,31 +2966,38 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
                     args[3],
                 )
             };
-            let family = socket_get_attr_i64(obj, "_family") as libc::c_int;
-            let (storage, slen) = pack_inet_addr(family, addr_obj)?;
-            let n = loop {
-                let r = unsafe {
-                    libc::sendto(
-                        fd,
-                        buf.as_ptr() as *const libc::c_void,
-                        buf.len(),
-                        flags,
-                        &storage as *const _ as *const libc::sockaddr,
-                        slen,
-                    )
-                };
-                if r >= 0 {
-                    break r;
+            // See `send` above: the export is released once the borrow of
+            // `buffer` ends, on the error path as well. `pack_inet_addr` runs
+            // Python, so it is inside the released scope too.
+            let result = (|| -> Result<isize, crate::PyError> {
+                let buf = buffer.as_bytes();
+                let family = socket_get_attr_i64(obj, "_family") as libc::c_int;
+                let (storage, slen) = pack_inet_addr(family, addr_obj)?;
+                loop {
+                    let r = unsafe {
+                        libc::sendto(
+                            fd,
+                            buf.as_ptr() as *const libc::c_void,
+                            buf.len(),
+                            flags,
+                            &storage as *const _ as *const libc::sockaddr,
+                            slen,
+                        )
+                    };
+                    if r >= 0 {
+                        return Ok(r);
+                    }
+                    let err = std::io::Error::last_os_error();
+                    if err.raw_os_error() != Some(libc::EINTR) {
+                        return Err(socket_io_err(err));
+                    }
+                    // EINTR: deliver a pending signal, then retry
+                    // (`converted_error` eintr_retry).
+                    crate::module::signal::interp_signal::checksignals_now()?;
                 }
-                let err = std::io::Error::last_os_error();
-                if err.raw_os_error() != Some(libc::EINTR) {
-                    return Err(socket_io_err(err));
-                }
-                // EINTR: deliver a pending signal, then retry
-                // (`converted_error` eintr_retry).
-                crate::module::signal::interp_signal::checksignals_now()?;
-            };
-            Ok(pyre_object::w_int_new(n as i64))
+            })();
+            buffer.release();
+            Ok(pyre_object::w_int_new(result? as i64))
         }),
     ) };
 

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -4120,18 +4120,26 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 }
                 let path = extract_path(args[0])?;
                 // interp_posix.py:744 `@unwrap_spec(mode=c_int, ...)`.
-                let mode = crate::baseobjspace::c_int_w(args[1])? as u8;
+                let mode = crate::baseobjspace::c_int_w(args[1])?;
                 #[cfg(feature = "sandbox")]
                 {
                     return Ok(pyre_object::w_bool_from(
-                        crate::host_seam::ops::access(path.as_bytes(), mode as i32)
-                            .unwrap_or(false),
+                        crate::host_seam::ops::access(path.as_bytes(), mode).unwrap_or(false),
                     ));
                 }
                 #[cfg(not(feature = "sandbox"))]
-                match host_posix::check_access(std::path::Path::new(&path), mode) {
-                    Ok(ok) => Ok(pyre_object::w_bool_from(ok)),
-                    Err(_) => Ok(pyre_object::w_bool_from(false)),
+                {
+                    // `check_access` takes the mask as a `u8` and rejects any
+                    // bit outside `R_OK | W_OK | X_OK`. Narrowing before that
+                    // check would fold a mode like 256 onto `F_OK` and answer
+                    // "exists" for a mode `access(2)` rejects with EINVAL.
+                    let Ok(mode) = u8::try_from(mode) else {
+                        return Ok(pyre_object::w_bool_from(false));
+                    };
+                    match host_posix::check_access(std::path::Path::new(&path), mode) {
+                        Ok(ok) => Ok(pyre_object::w_bool_from(ok)),
+                        Err(_) => Ok(pyre_object::w_bool_from(false)),
+                    }
                 }
             }),
         );

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -534,7 +534,7 @@ mod win_nt {
                 "_getfileinformation() missing required argument 'fd'",
             ));
         };
-        let fd = unsafe { pyre_object::w_int_get_value(arg) } as i32;
+        let fd = crate::baseobjspace::c_int_w(arg)?;
         let handle = host_nt::handle_from_fd(fd);
         let mut info: BY_HANDLE_FILE_INFORMATION = unsafe { std::mem::zeroed() };
         if unsafe { GetFileInformationByHandle(handle, &mut info) } == 0 {
@@ -572,7 +572,7 @@ mod win_nt {
                 "get_handle_inheritable() missing required argument 'handle'",
             ));
         };
-        let handle = unsafe { pyre_object::w_int_get_value(arg) } as libc::intptr_t;
+        let handle = crate::baseobjspace::c_int_w(arg)? as libc::intptr_t;
         match host_nt::get_handle_inheritable(handle) {
             Ok(value) => Ok(pyre_object::w_bool_from(value)),
             Err(error) => Err(io_err(&error, "")),
@@ -586,7 +586,7 @@ mod win_nt {
                 "set_handle_inheritable() takes 2 arguments",
             ));
         }
-        let handle = unsafe { pyre_object::w_int_get_value(args[0]) } as libc::intptr_t;
+        let handle = crate::baseobjspace::c_int_w(args[0])? as libc::intptr_t;
         let inheritable = crate::baseobjspace::is_true(args[1])?;
         match host_nt::set_handle_inheritable(handle, inheritable) {
             Ok(()) => Ok(pyre_object::w_none()),
@@ -618,7 +618,7 @@ mod win_nt {
             ));
         };
         let cookie =
-            (unsafe { pyre_object::w_int_get_value(arg) } as usize) as *mut std::ffi::c_void;
+            (crate::baseobjspace::int_w(arg)? as usize) as *mut std::ffi::c_void;
         let ok = unsafe { RemoveDllDirectory(cookie) };
         Ok(pyre_object::w_bool_from(ok != 0))
     }
@@ -1200,6 +1200,45 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         }
     }
 
+    /// interp_posix.py:259-272 `unwrap_fd`.
+    ///
+    /// ```python
+    /// def unwrap_fd(space, w_value, allowed_types='integer'):
+    ///     try:
+    ///         result = space.c_int_w(w_value)
+    ///     except OperationError as e:
+    ///         if not e.match(space, space.w_OverflowError):
+    ///             raise oefmt(space.w_TypeError,
+    ///                 "argument should be %s, not %T", allowed_types, w_value)
+    ///         else:
+    ///             raise
+    ///     if result == -1:
+    ///         # -1 is used as sentinel value for not a fd
+    ///         raise oefmt(space.w_OSError, "invalid file descriptor: -1")
+    ///     return result
+    /// ```
+    ///
+    /// `c_int_w` is the load-bearing part: it converts through `__index__`,
+    /// so an `int` subclass — an `IntEnum` member, say — reaches the syscall,
+    /// where an exact-type test would reject it and a raw payload read would
+    /// interpret the instance's first word as the descriptor.
+    fn unwrap_fd(value: PyObjectRef, allowed_types: &str) -> Result<i32, crate::PyError> {
+        let result = crate::baseobjspace::c_int_w(value).map_err(|err| {
+            if err.kind == crate::PyErrorKind::OverflowError {
+                err
+            } else {
+                crate::PyError::type_error(format!(
+                    "argument should be {allowed_types}, not {}",
+                    crate::baseobjspace::object_functionstr_type_name(value)
+                ))
+            }
+        })?;
+        if result == -1 {
+            return Err(crate::PyError::os_error("invalid file descriptor: -1"));
+        }
+        Ok(result)
+    }
+
     // ── posix.open(path, flags, mode=0o777) → fd ──
     crate::module_ns_store(
         ns,
@@ -1211,9 +1250,9 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 ));
             }
             let path = extract_path(args[0])?;
-            let flags = (unsafe { pyre_object::w_int_get_value(args[1]) }) as libc::c_int;
+            let flags = crate::baseobjspace::c_int_w(args[1])? as libc::c_int;
             let mode: u32 = if args.len() >= 3 {
-                (unsafe { pyre_object::w_int_get_value(args[2]) }) as u32
+                crate::baseobjspace::c_int_w(args[2])? as u32
             } else {
                 0o777
             };
@@ -1253,7 +1292,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 if args.is_empty() {
                     return Err(crate::PyError::type_error("close() requires 1 argument"));
                 }
-                let fd = (unsafe { pyre_object::w_int_get_value(args[0]) }) as libc::c_int;
+                let fd = crate::baseobjspace::c_int_w(args[0])? as libc::c_int;
                 #[cfg(not(feature = "sandbox"))]
                 {
                     let ret = unsafe { libc::close(fd) };
@@ -1280,8 +1319,8 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 if args.len() < 2 {
                     return Err(crate::PyError::type_error("read() requires 2 arguments"));
                 }
-                let fd = (unsafe { pyre_object::w_int_get_value(args[0]) }) as libc::c_int;
-                let n_signed = unsafe { pyre_object::w_int_get_value(args[1]) };
+                let fd = crate::baseobjspace::c_int_w(args[0])? as libc::c_int;
+                let n_signed = crate::baseobjspace::int_w(args[1])?;
                 // A negative size would wrap to a huge `usize` (and allocation);
                 // os.read rejects it with EINVAL, matching the host read(2).
                 if n_signed < 0 {
@@ -1323,7 +1362,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         crate::make_builtin_function_with_arity(
             "readinto",
             |args| {
-                let fd_value = unsafe { pyre_object::w_int_get_value(args[0]) };
+                let fd_value = crate::baseobjspace::int_w(args[0])?;
                 let fd = libc::c_int::try_from(fd_value)
                     .map_err(|_| crate::PyError::overflow_error("fd is greater than maximum"))?;
                 let mut buffer = unsafe { crate::builtins::WritableBuffer::acquire(args[1]) }?;
@@ -1374,7 +1413,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 if args.len() < 2 {
                     return Err(crate::PyError::type_error("write() requires 2 arguments"));
                 }
-                let fd = (unsafe { pyre_object::w_int_get_value(args[0]) }) as libc::c_int;
+                let fd = crate::baseobjspace::c_int_w(args[0])? as libc::c_int;
                 // CPython `os_write_impl` receives a `Py_buffer`: text is not
                 // accepted, while every contiguous readable exporter is.
                 let data = unsafe { crate::builtins::file_write_buffer_bytes(args[1]) }
@@ -1411,9 +1450,11 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 if args.len() < 3 {
                     return Err(crate::PyError::type_error("lseek() requires 3 arguments"));
                 }
-                let fd = (unsafe { pyre_object::w_int_get_value(args[0]) }) as libc::c_int;
-                let offset = (unsafe { pyre_object::w_int_get_value(args[1]) }) as libc::off_t;
-                let whence = (unsafe { pyre_object::w_int_get_value(args[2]) }) as libc::c_int;
+                // interp_posix.py:340 `@unwrap_spec(fd=c_int, position=r_longlong,
+                // how=c_int)` — the position is a 64-bit offset, not a C int.
+                let fd = crate::baseobjspace::c_int_w(args[0])? as libc::c_int;
+                let offset = crate::baseobjspace::int_w(args[1])? as libc::off_t;
+                let whence = crate::baseobjspace::c_int_w(args[2])? as libc::c_int;
                 #[cfg(not(feature = "sandbox"))]
                 let ret = {
                     let ret = unsafe { libc::lseek(fd, offset, whence) };
@@ -1497,7 +1538,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             }
             let path = extract_path(args[0])?;
             let _mode: u32 = if args.len() >= 2 {
-                (unsafe { pyre_object::w_int_get_value(args[1]) }) as u32
+                crate::baseobjspace::c_int_w(args[1])? as u32
             } else {
                 0o777
             };
@@ -1578,18 +1619,11 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         let dst = extract_path(pos[1])?;
         let dir_fd = |name: &str| -> Result<Option<i32>, crate::PyError> {
             match crate::builtins::kwarg_get(kwargs, name) {
+                // interp_posix.py:274-278 `_unwrap_dirfd` — a non-`None` value
+                // goes through `unwrap_fd` with `allowed_types="integer or
+                // None"`.
                 Some(v) if !unsafe { pyre_object::is_none(v) } => {
-                    if !unsafe { pyre_object::is_int(v) } {
-                        let type_name = crate::typedef::r#type(v)
-                            .map(|t| unsafe {
-                                pyre_object::typeobject::w_type_get_name(t.as_ptr())
-                            })
-                            .unwrap_or("object");
-                        return Err(crate::PyError::type_error(format!(
-                            "argument should be integer or None, not {type_name}"
-                        )));
-                    }
-                    Ok(Some((unsafe { pyre_object::w_int_get_value(v) }) as i32))
+                    Ok(Some(unwrap_fd(v, "integer or None")?))
                 }
                 _ => Ok(None),
             }
@@ -1676,14 +1710,9 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             None => true,
         };
         let dir_fd = match crate::builtins::kwarg_get(kwargs, "dir_fd").and_then(present) {
-            Some(v) => {
-                if !unsafe { pyre_object::is_int(v) } {
-                    return Err(crate::PyError::type_error(
-                        "argument should be integer or None, not object",
-                    ));
-                }
-                Some(unsafe { pyre_object::w_int_get_value(v) } as i32)
-            }
+            // interp_posix.py:1863 types `dir_fd` as `DirFD(...)`, whose
+            // `unwrap` is `_unwrap_dirfd` (:274-278).
+            Some(v) => Some(unwrap_fd(v, "integer or None")?),
             None => None,
         };
 
@@ -1883,7 +1912,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 if args.is_empty() {
                     return Ok(pyre_object::w_bool_from(false));
                 }
-                let fd = (unsafe { pyre_object::w_int_get_value(args[0]) }) as i32;
+                let fd = crate::baseobjspace::c_int_w(args[0])?;
                 #[cfg(feature = "sandbox")]
                 {
                     return Ok(pyre_object::w_bool_from(
@@ -2499,9 +2528,10 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     }
     fn scandir_iter_next(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         let self_obj = args[0];
-        let idx = unsafe {
-            pyre_object::w_int_get_value(crate::baseobjspace::getattr_str(self_obj, "_index")?)
-        };
+        // The type carries an instance dict, so `_index` is writable from
+        // Python and cannot be assumed to still hold the int this iterator
+        // stored.
+        let idx = crate::baseobjspace::int_w(crate::baseobjspace::getattr_str(self_obj, "_index")?)?;
         let entries = crate::baseobjspace::getattr_str(self_obj, "_entries")?;
         let len = unsafe { pyre_object::w_list_len(entries) } as i64;
         if idx >= len {
@@ -2662,7 +2692,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 if args.is_empty() {
                     return Err(crate::PyError::type_error("fstat() missing argument"));
                 }
-                let fd = (unsafe { pyre_object::w_int_get_value(args[0]) }) as i32;
+                let fd = crate::baseobjspace::c_int_w(args[0])?;
                 // `rposix_stat.py:fstat` passes the descriptor to libc, where
                 // `-1` reports EBADF.  Rust's `OwnedFd::from_raw_fd(-1)`
                 // asserts before `File::metadata` can produce that error.
@@ -3045,7 +3075,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 "strerror",
                 |args| {
                     let code = match args.first() {
-                        Some(&o) => (unsafe { pyre_object::w_int_get_value(o) }) as i32,
+                        Some(&o) => crate::baseobjspace::c_int_w(o)?,
                         None => {
                             return Err(crate::PyError::type_error(
                                 "strerror() requires 1 argument",
@@ -3111,7 +3141,8 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     if args.is_empty() {
                         return Err(crate::PyError::type_error("nice() requires 1 argument"));
                     }
-                    let inc = (unsafe { pyre_object::w_int_get_value(args[0]) }) as i32;
+                    // interp_posix.py:2565 `@unwrap_spec(increment=c_int)`.
+                    let inc = crate::baseobjspace::c_int_w(args[0])?;
                     let n = host_posix::nice(inc).map_err(|e| io_err(e, ""))?;
                     Ok(pyre_object::w_int_new(n as i64))
                 },
@@ -3129,7 +3160,8 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     if args.is_empty() {
                         return Err(crate::PyError::type_error("umask() requires 1 argument"));
                     }
-                    let mask = (unsafe { pyre_object::w_int_get_value(args[0]) }) as libc::mode_t;
+                    // interp_posix.py:1372 `@unwrap_spec(mask=c_int)`.
+                    let mask = crate::baseobjspace::c_int_w(args[0])? as libc::mode_t;
                     let prev = host_posix::umask(mask);
                     Ok(pyre_object::w_int_new(prev as i64))
                 },
@@ -3184,7 +3216,8 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                             "sched_get_priority_max() requires 1 argument",
                         ));
                     }
-                    let policy = (unsafe { pyre_object::w_int_get_value(args[0]) }) as i32;
+                    // interp_posix.py:2977 `@unwrap_spec(policy=int)`.
+                    let policy = crate::baseobjspace::int_w(args[0])? as i32;
                     let m =
                         host_posix::sched_get_priority_max(policy).map_err(|e| io_err(e, ""))?;
                     Ok(pyre_object::w_int_new(m as i64))
@@ -3205,7 +3238,8 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                             "sched_get_priority_min() requires 1 argument",
                         ));
                     }
-                    let policy = (unsafe { pyre_object::w_int_get_value(args[0]) }) as i32;
+                    // interp_posix.py:2991 `@unwrap_spec(policy=int)`.
+                    let policy = crate::baseobjspace::int_w(args[0])? as i32;
                     let m =
                         host_posix::sched_get_priority_min(policy).map_err(|e| io_err(e, ""))?;
                     Ok(pyre_object::w_int_new(m as i64))
@@ -3259,7 +3293,10 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     if args.is_empty() {
                         return Err(crate::PyError::type_error("fchdir() requires 1 argument"));
                     }
-                    let fd = (unsafe { pyre_object::w_int_get_value(args[0]) }) as i32;
+                    // interp_posix.py:458-460 `fchdir(space, w_fd)` unwraps
+                    // through `space.c_filedescriptor_w`, which takes an int or
+                    // anything exposing `fileno()`.
+                    let fd = crate::baseobjspace::c_filedescriptor_w(args[0])?;
                     host_posix::fchdir(fd).map_err(|e| io_err(e, ""))?;
                     Ok(pyre_object::w_none())
                 },
@@ -3344,7 +3381,8 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 "getsid",
                 |args| {
                     let pid = match args.first() {
-                        Some(&obj) => (unsafe { pyre_object::w_int_get_value(obj) }) as libc::pid_t,
+                        // interp_posix.py:2246 `@unwrap_spec(pid=c_int)`.
+                        Some(&obj) => crate::baseobjspace::c_int_w(obj)? as libc::pid_t,
                         None => {
                             return Err(crate::PyError::type_error("getsid() requires 1 argument"));
                         }
@@ -3369,8 +3407,9 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     if args.len() < 2 {
                         return Err(crate::PyError::type_error("waitpid() requires 2 arguments"));
                     }
-                    let pid = (unsafe { pyre_object::w_int_get_value(args[0]) }) as libc::pid_t;
-                    let options = (unsafe { pyre_object::w_int_get_value(args[1]) }) as i32;
+                    // interp_posix.py:1708 `@unwrap_spec(pid=c_int, options=c_int)`.
+                    let pid = crate::baseobjspace::c_int_w(args[0])? as libc::pid_t;
+                    let options = crate::baseobjspace::c_int_w(args[1])?;
                     let mut status: i32 = 0;
                     let res = {
                         let _blocked = crate::module::thread::before_external_block();
@@ -3416,7 +3455,8 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 "_exit",
                 |args| {
                     let code = match args.first() {
-                        Some(&o) => (unsafe { pyre_object::w_int_get_value(o) }) as i32,
+                        // interp_posix.py:1724 `@unwrap_spec(status=c_int)`.
+                        Some(&o) => crate::baseobjspace::c_int_w(o)?,
                         None => {
                             return Err(crate::PyError::type_error("_exit() requires 1 argument"));
                         }
@@ -3438,9 +3478,9 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                         $name,
                         |args| {
                             let $s = match args.first() {
-                                Some(&o) => {
-                                    (unsafe { pyre_object::w_int_get_value(o) }) as libc::c_int
-                                }
+                                // interp_posix.py:2363-2371 `declare_new_w_star`
+                                // types every wait macro `@unwrap_spec(status=c_int)`.
+                                Some(&o) => crate::baseobjspace::c_int_w(o)?,
                                 None => {
                                     return Err(crate::PyError::type_error(concat!(
                                         $name,
@@ -3500,7 +3540,8 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     if args.is_empty() {
                         return Err(crate::PyError::type_error("dup() requires 1 argument"));
                     }
-                    let fd = (unsafe { pyre_object::w_int_get_value(args[0]) }) as libc::c_int;
+                    // interp_posix.py:722 `@unwrap_spec(fd=c_int)`.
+                    let fd = crate::baseobjspace::c_int_w(args[0])?;
                     let n = unsafe { libc::dup(fd) };
                     if n < 0 {
                         return Err(io_err(std::io::Error::last_os_error(), ""));
@@ -3520,8 +3561,9 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 if args.len() < 2 {
                     return Err(crate::PyError::type_error("dup2() requires 2 arguments"));
                 }
-                let fd = (unsafe { pyre_object::w_int_get_value(args[0]) }) as libc::c_int;
-                let fd2 = (unsafe { pyre_object::w_int_get_value(args[1]) }) as libc::c_int;
+                // interp_posix.py:733 `@unwrap_spec(fd=c_int, fd2=c_int, inheritable=bool)`.
+                let fd = crate::baseobjspace::c_int_w(args[0])?;
+                let fd2 = crate::baseobjspace::c_int_w(args[1])?;
                 let n = unsafe { libc::dup2(fd, fd2) };
                 if n < 0 {
                     return Err(io_err(std::io::Error::last_os_error(), ""));
@@ -3541,7 +3583,9 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     if args.is_empty() {
                         return Err(crate::PyError::type_error("fsync() requires 1 argument"));
                     }
-                    let fd = (unsafe { pyre_object::w_int_get_value(args[0]) }) as libc::c_int;
+                    // interp_posix.py:433-435 `fsync(space, w_fd)` unwraps
+                    // through `space.c_filedescriptor_w`.
+                    let fd = crate::baseobjspace::c_filedescriptor_w(args[0])?;
                     let r = unsafe { libc::fsync(fd) };
                     if r < 0 {
                         return Err(io_err(std::io::Error::last_os_error(), ""));
@@ -3566,7 +3610,9 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                             "fdatasync() requires 1 argument",
                         ));
                     }
-                    let fd = (unsafe { pyre_object::w_int_get_value(args[0]) }) as libc::c_int;
+                    // interp_posix.py:443-446 `fdatasync(space, w_fd)` unwraps
+                    // through `space.c_filedescriptor_w`.
+                    let fd = crate::baseobjspace::c_filedescriptor_w(args[0])?;
                     #[cfg(any(target_os = "linux", target_os = "android"))]
                     let r = unsafe { libc::fdatasync(fd) };
                     #[cfg(not(any(target_os = "linux", target_os = "android")))]
@@ -3652,8 +3698,9 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     return Err(crate::PyError::type_error("mkfifo() requires 1 argument"));
                 }
                 let path = extract_path(args[0])?;
+                // interp_posix.py:1322 `@unwrap_spec(mode=c_int, ...)`.
                 let mode = if args.len() >= 2 {
-                    (unsafe { pyre_object::w_int_get_value(args[1]) }) as libc::mode_t
+                    crate::baseobjspace::c_int_w(args[1])? as libc::mode_t
                 } else {
                     0o666
                 };
@@ -3769,7 +3816,8 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     if args.is_empty() {
                         return Err(crate::PyError::type_error("fstatvfs() requires 1 argument"));
                     }
-                    let fd = (unsafe { pyre_object::w_int_get_value(args[0]) }) as i32;
+                    // interp_posix.py:693 `@unwrap_spec(fd=c_int)`.
+                    let fd = crate::baseobjspace::c_int_w(args[0])?;
                     let info = host_posix::statvfs_fd(fd).map_err(|e| io_err(e, ""))?;
                     Ok(statvfs_to_obj(info))
                 },
@@ -3875,8 +3923,9 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     if args.len() < 2 {
                         return Err(crate::PyError::type_error("fchmod() requires 2 arguments"));
                     }
-                    let fd = (unsafe { pyre_object::w_int_get_value(args[0]) }) as i32;
-                    let mode = (unsafe { pyre_object::w_int_get_value(args[1]) }) as u32;
+                    // interp_posix.py:1260 `@unwrap_spec(fd=c_int, mode=c_int)`.
+                    let fd = crate::baseobjspace::c_int_w(args[0])?;
+                    let mode = crate::baseobjspace::c_int_w(args[1])? as u32;
                     let bfd = unsafe { BorrowedFd::borrow_raw(fd) };
                     host_posix::fchmod(bfd, mode).map_err(|e| io_err(e, ""))?;
                     Ok(pyre_object::w_none())
@@ -4016,19 +4065,19 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     if args.len() < 3 {
                         return Err(crate::PyError::type_error("fchown() requires 3 arguments"));
                     }
-                    let fd = (unsafe { pyre_object::w_int_get_value(args[0]) }) as i32;
-                    let uid_raw = unsafe { pyre_object::w_int_get_value(args[1]) };
-                    let gid_raw = unsafe { pyre_object::w_int_get_value(args[2]) };
-                    let uid = if uid_raw < 0 {
-                        None
-                    } else {
-                        Some(uid_raw as u32)
-                    };
-                    let gid = if gid_raw < 0 {
-                        None
-                    } else {
-                        Some(gid_raw as u32)
-                    };
+                    // interp_posix.py:2527-2533 `@unwrap_spec(uid=c_uid_t,
+                    // gid=c_gid_t)` with the descriptor taken by
+                    // `space.c_filedescriptor_w`. The spec is applied by the
+                    // gateway before the body runs, so a bad uid/gid is
+                    // reported ahead of a bad descriptor.
+                    //
+                    // `c_uid_t_w` (baseobjspace.py:2110-2125) is what turns -1
+                    // into `UINT_MAX`, i.e. the `(uid_t)-1` "leave unchanged"
+                    // sentinel that `host_posix::fchown` spells as `None`.
+                    let unchanged = |value: u32| (value != u32::MAX).then_some(value);
+                    let uid = unchanged(crate::baseobjspace::c_uid_t_w(args[1])?);
+                    let gid = unchanged(crate::baseobjspace::c_uid_t_w(args[2])?);
+                    let fd = crate::baseobjspace::c_filedescriptor_w(args[0])?;
                     let bfd = unsafe { BorrowedFd::borrow_raw(fd) };
                     host_posix::fchown(bfd, uid, gid).map_err(|e| io_err(e, ""))?;
                     Ok(pyre_object::w_none())
@@ -4050,8 +4099,9 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                             "set_inheritable() requires 2 arguments",
                         ));
                     }
-                    let fd = (unsafe { pyre_object::w_int_get_value(args[0]) }) as i32;
-                    let inherit = unsafe { pyre_object::w_int_get_value(args[1]) } != 0;
+                    // interp_posix.py:1165 `@unwrap_spec(fd=c_int, inheritable=int)`.
+                    let fd = crate::baseobjspace::c_int_w(args[0])?;
+                    let inherit = crate::baseobjspace::int_w(args[1])? != 0;
                     let bfd = unsafe { BorrowedFd::borrow_raw(fd) };
                     host_posix::set_inheritable(bfd, inherit).map_err(|e| io_err(e, ""))?;
                     Ok(pyre_object::w_none())
@@ -4069,7 +4119,8 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     return Err(crate::PyError::type_error("access() requires 2 arguments"));
                 }
                 let path = extract_path(args[0])?;
-                let mode = (unsafe { pyre_object::w_int_get_value(args[1]) }) as u8;
+                // interp_posix.py:744 `@unwrap_spec(mode=c_int, ...)`.
+                let mode = crate::baseobjspace::c_int_w(args[1])? as u8;
                 #[cfg(feature = "sandbox")]
                 {
                     return Ok(pyre_object::w_bool_from(
@@ -4160,7 +4211,10 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                             "waitstatus_to_exitcode() requires 1 argument",
                         ));
                     }
-                    let status = (unsafe { pyre_object::w_int_get_value(args[0]) }) as libc::c_int;
+                    // app_posix.py:149-176 is app-level and reaches the status
+                    // through `posix.WIFEXITED`/`WEXITSTATUS`, each of which is
+                    // `@unwrap_spec(status=c_int)`.
+                    let status = crate::baseobjspace::c_int_w(args[0])?;
                     match rustpython_host_env::time::waitstatus_to_exitcode(status) {
                         Some(code) => Ok(pyre_object::w_int_new(code as i64)),
                         None => Err(crate::PyError::value_error(
@@ -4232,10 +4286,14 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                         "sendfile() requires 4 arguments",
                     ));
                 }
-                let out_fd = (unsafe { pyre_object::w_int_get_value(args[0]) }) as i32;
-                let in_fd = (unsafe { pyre_object::w_int_get_value(args[1]) }) as i32;
+                // interp_posix.py:2946 `@unwrap_spec(out_fd=c_int, count=int)`,
+                // with `in_ = space.c_int_w(w_in_fd)` in the body (:2955). The
+                // spec runs in the gateway, so the count is converted before
+                // the descriptor argument that follows it here.
+                let out_fd = crate::baseobjspace::c_int_w(args[0])?;
+                let count_raw = crate::baseobjspace::int_w(args[3])?;
+                let in_fd = crate::baseobjspace::c_int_w(args[1])?;
                 let w_offset = args[2];
-                let count_raw = unsafe { pyre_object::w_int_get_value(args[3]) };
                 if unsafe { pyre_object::is_none(w_offset) } {
                     // linux-only no-offset path; non-linux raises TypeError
                     // matching interp_posix.py:2946.
@@ -4260,7 +4318,8 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                         return Ok(pyre_object::w_int_new(res as i64));
                     }
                 }
-                let offset_i64 = unsafe { pyre_object::w_int_get_value(w_offset) };
+                // interp_posix.py:2968 `space.gateway_r_longlong_w(w_offset)`.
+                let offset_i64 = crate::baseobjspace::int_w(w_offset)?;
                 let out_b = unsafe { BorrowedFd::borrow_raw(out_fd) };
                 let in_b = unsafe { BorrowedFd::borrow_raw(in_fd) };
                 #[cfg(target_os = "linux")]
@@ -4480,6 +4539,18 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                         "posix_spawn: file_actions must be a list or tuple",
                     ));
                 };
+                // Every field of a `file_actions` entry is an `int` argument of
+                // `os.posix_spawn`, so it is converted rather than read as a
+                // payload: the caller controls the tuple's contents, and an
+                // `int` subclass or a plain non-int would otherwise be
+                // reinterpreted as a descriptor, flag set or mode.
+                let field = |entry: PyObjectRef, index: i64| -> Result<i32, crate::PyError> {
+                    let value = unsafe { pyre_object::w_tuple_getitem(entry, index) }
+                        .ok_or_else(|| {
+                            crate::PyError::value_error("posix_spawn: file_actions entry too short")
+                        })?;
+                    crate::baseobjspace::c_int_w(value)
+                };
                 let mut out = Vec::with_capacity(len);
                 for i in 0..len {
                     let entry = if unsafe { pyre_object::is_list(obj) } {
@@ -4501,11 +4572,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                             "posix_spawn: file_actions entry too short",
                         ));
                     }
-                    let op = (unsafe {
-                        pyre_object::w_int_get_value(
-                            pyre_object::w_tuple_getitem(entry, 0).unwrap(),
-                        )
-                    }) as i32;
+                    let op = field(entry, 0)?;
                     match op {
                         0 => {
                             // POSIX_SPAWN_OPEN: (op, fd, path, flags, mode)
@@ -4514,11 +4581,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                                     "posix_spawn: OPEN action requires fd, path, flags, mode",
                                 ));
                             }
-                            let fd = (unsafe {
-                                pyre_object::w_int_get_value(
-                                    pyre_object::w_tuple_getitem(entry, 1).unwrap(),
-                                )
-                            }) as i32;
+                            let fd = field(entry, 1)?;
                             let path_obj =
                                 unsafe { pyre_object::w_tuple_getitem(entry, 2).unwrap() };
                             let path_str = extract_path(path_obj)?;
@@ -4528,16 +4591,8 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                                         "posix_spawn: embedded null in OPEN path",
                                     )
                                 })?;
-                            let oflag = (unsafe {
-                                pyre_object::w_int_get_value(
-                                    pyre_object::w_tuple_getitem(entry, 3).unwrap(),
-                                )
-                            }) as i32;
-                            let mode = (unsafe {
-                                pyre_object::w_int_get_value(
-                                    pyre_object::w_tuple_getitem(entry, 4).unwrap(),
-                                )
-                            }) as u32;
+                            let oflag = field(entry, 3)?;
+                            let mode = field(entry, 4)? as u32;
                             out.push(PosixSpawnFileAction::Open {
                                 fd,
                                 path: cpath,
@@ -4547,11 +4602,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                         }
                         1 => {
                             // POSIX_SPAWN_CLOSE: (op, fd)
-                            let fd = (unsafe {
-                                pyre_object::w_int_get_value(
-                                    pyre_object::w_tuple_getitem(entry, 1).unwrap(),
-                                )
-                            }) as i32;
+                            let fd = field(entry, 1)?;
                             out.push(PosixSpawnFileAction::Close { fd });
                         }
                         2 => {
@@ -4561,16 +4612,8 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                                     "posix_spawn: DUP2 action requires fd, newfd",
                                 ));
                             }
-                            let fd = (unsafe {
-                                pyre_object::w_int_get_value(
-                                    pyre_object::w_tuple_getitem(entry, 1).unwrap(),
-                                )
-                            }) as i32;
-                            let newfd = (unsafe {
-                                pyre_object::w_int_get_value(
-                                    pyre_object::w_tuple_getitem(entry, 2).unwrap(),
-                                )
-                            }) as i32;
+                            let fd = field(entry, 1)?;
+                            let newfd = field(entry, 2)?;
                             out.push(PosixSpawnFileAction::Dup2 { fd, newfd });
                         }
                         _ => {
@@ -4608,7 +4651,8 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     if args.is_empty() {
                         return Err(crate::PyError::type_error("ttyname() requires fd"));
                     }
-                    let fd = (unsafe { pyre_object::w_int_get_value(args[0]) }) as i32;
+                    // interp_posix.py:2382 `@unwrap_spec(fd=c_int)`.
+                    let fd = crate::baseobjspace::c_int_w(args[0])?;
                     let bfd = unsafe { BorrowedFd::borrow_raw(fd) };
                     let name = host_posix::ttyname(bfd).map_err(|e| io_err(e, ""))?;
                     Ok(pyre_object::w_str_new(&name.to_string_lossy()))
@@ -4628,7 +4672,8 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     if args.is_empty() {
                         return Err(crate::PyError::type_error("tcgetpgrp() requires fd"));
                     }
-                    let fd = (unsafe { pyre_object::w_int_get_value(args[0]) }) as i32;
+                    // interp_posix.py:2269 `@unwrap_spec(fd=c_int)`.
+                    let fd = crate::baseobjspace::c_int_w(args[0])?;
                     let bfd = unsafe { BorrowedFd::borrow_raw(fd) };
                     let pgid = host_posix::tcgetpgrp(bfd).map_err(|e| io_err(e, ""))?;
                     Ok(pyre_object::w_int_new(pgid as i64))
@@ -4648,8 +4693,9 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     if args.len() < 2 {
                         return Err(crate::PyError::type_error("tcsetpgrp() requires fd, pgid"));
                     }
-                    let fd = (unsafe { pyre_object::w_int_get_value(args[0]) }) as i32;
-                    let pgid = (unsafe { pyre_object::w_int_get_value(args[1]) }) as libc::pid_t;
+                    // interp_posix.py:2281 `@unwrap_spec(fd=c_int, pgid=c_gid_t)`.
+                    let fd = crate::baseobjspace::c_int_w(args[0])?;
+                    let pgid = crate::baseobjspace::c_uid_t_w(args[1])? as libc::pid_t;
                     let bfd = unsafe { BorrowedFd::borrow_raw(fd) };
                     host_posix::tcsetpgrp(bfd, pgid).map_err(|e| io_err(e, ""))?;
                     Ok(pyre_object::w_none())
@@ -4670,10 +4716,10 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                             "getpriority() requires which, who",
                         ));
                     }
-                    let which = (unsafe { pyre_object::w_int_get_value(args[0]) })
-                        as host_posix::PriorityWhichType;
-                    let who = (unsafe { pyre_object::w_int_get_value(args[1]) })
-                        as host_posix::PriorityWhoType;
+                    // interp_posix.py:2340 `@unwrap_spec(which=int, who=int)`.
+                    let which =
+                        crate::baseobjspace::int_w(args[0])? as host_posix::PriorityWhichType;
+                    let who = crate::baseobjspace::int_w(args[1])? as host_posix::PriorityWhoType;
                     let prio = host_posix::getpriority(which, who).map_err(|e| io_err(e, ""))?;
                     Ok(pyre_object::w_int_new(prio as i64))
                 },
@@ -4693,11 +4739,12 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                             "setpriority() requires which, who, priority",
                         ));
                     }
-                    let which = (unsafe { pyre_object::w_int_get_value(args[0]) })
-                        as host_posix::PriorityWhichType;
-                    let who = (unsafe { pyre_object::w_int_get_value(args[1]) })
-                        as host_posix::PriorityWhoType;
-                    let prio = (unsafe { pyre_object::w_int_get_value(args[2]) }) as i32;
+                    // interp_posix.py:2352 `@unwrap_spec(which=int, who=int,
+                    // priority=int)`.
+                    let which =
+                        crate::baseobjspace::int_w(args[0])? as host_posix::PriorityWhichType;
+                    let who = crate::baseobjspace::int_w(args[1])? as host_posix::PriorityWhoType;
+                    let prio = crate::baseobjspace::int_w(args[2])? as i32;
                     host_posix::setpriority(which, who, prio).map_err(|e| io_err(e, ""))?;
                     Ok(pyre_object::w_none())
                 },
@@ -4862,7 +4909,8 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     if args.len() < 2 {
                         return Err(crate::PyError::type_error("fpathconf() requires fd, name"));
                     }
-                    let fd = (unsafe { pyre_object::w_int_get_value(args[0]) }) as i32;
+                    // interp_posix.py:2411 `@unwrap_spec(fd=c_int)`.
+                    let fd = crate::baseobjspace::c_int_w(args[0])?;
                     let name = confname_arg(args[1])?;
                     match host_posix::fpathconf(fd, name).map_err(|e| io_err(e, ""))? {
                         Some(v) => Ok(pyre_object::w_int_new(v as i64)),
@@ -4954,7 +5002,8 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     let cuser = std::ffi::CString::new(user.as_bytes()).map_err(|_| {
                         crate::PyError::value_error("initgroups: embedded null in username")
                     })?;
-                    let gid = (unsafe { pyre_object::w_int_get_value(args[1]) }) as u32;
+                    // interp_posix.py:2137 `@unwrap_spec(username='text', gid=c_gid_t)`.
+                    let gid = crate::baseobjspace::c_uid_t_w(args[1])?;
                     host_posix::initgroups(&cuser, gid).map_err(|e| io_err(e, ""))?;
                     Ok(pyre_object::w_none())
                 },
@@ -5036,9 +5085,11 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                             "setresuid() requires ruid, euid, suid",
                         ));
                     }
-                    let r = (unsafe { pyre_object::w_int_get_value(args[0]) }) as u32;
-                    let e = (unsafe { pyre_object::w_int_get_value(args[1]) }) as u32;
-                    let s = (unsafe { pyre_object::w_int_get_value(args[2]) }) as u32;
+                    // interp_posix.py:2318 `@unwrap_spec(ruid=c_uid_t,
+                    // euid=c_uid_t, suid=c_uid_t)`.
+                    let r = crate::baseobjspace::c_uid_t_w(args[0])?;
+                    let e = crate::baseobjspace::c_uid_t_w(args[1])?;
+                    let s = crate::baseobjspace::c_uid_t_w(args[2])?;
                     host_posix::setresuid(r, e, s).map_err(|e| io_err(e, ""))?;
                     Ok(pyre_object::w_none())
                 },
@@ -5059,9 +5110,11 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                             "setresgid() requires rgid, egid, sgid",
                         ));
                     }
-                    let r = (unsafe { pyre_object::w_int_get_value(args[0]) }) as u32;
-                    let e = (unsafe { pyre_object::w_int_get_value(args[1]) }) as u32;
-                    let s = (unsafe { pyre_object::w_int_get_value(args[2]) }) as u32;
+                    // interp_posix.py:2329 `@unwrap_spec(rgid=c_gid_t,
+                    // egid=c_gid_t, sgid=c_gid_t)`.
+                    let r = crate::baseobjspace::c_uid_t_w(args[0])?;
+                    let e = crate::baseobjspace::c_uid_t_w(args[1])?;
+                    let s = crate::baseobjspace::c_uid_t_w(args[2])?;
                     host_posix::setresgid(r, e, s).map_err(|e| io_err(e, ""))?;
                     Ok(pyre_object::w_none())
                 },

--- a/pyre/pyre-interpreter/src/module/thread/mod.rs
+++ b/pyre/pyre-interpreter/src/module/thread/mod.rs
@@ -1456,7 +1456,17 @@ fn spawn_thread(
     /// during bootstrap leaves the starter spinning forever.
     struct BootstrapSignal(std::sync::Arc<Bootstrap>);
     impl BootstrapSignal {
+        /// The word carries the ident *and* two reserved states, so an ident
+        /// equal to either would be misread: `0` leaves the starter looping
+        /// and `START_FAILED` raises "can't start new thread" for a thread
+        /// that started. `current_ident` is the OS thread id — `gettid` on
+        /// Linux, `pthread_threadid_np` on Darwin — and neither issues those
+        /// two values, which is the invariant this pins.
         fn publish(&self, ident: i64) {
+            debug_assert!(
+                ident as usize != 0 && ident as usize != START_FAILED,
+                "thread ident collides with a reserved rendezvous state"
+            );
             self.0.word.store(ident as usize, Ordering::Release);
         }
         /// Preserve the diagnostic the starter raises.  `os_thread.py:145`

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -9378,8 +9378,15 @@ pub(crate) fn try_walker_load_global_cell_fold<Sym: WalkSym>(
     // so the `co_names` index is `namei >> 1` (mirror `bh_load_global_fn`).
     let name_idx = (namei as usize) >> 1;
     let name = unsafe {
-        let code = &*(pyre_interpreter::w_code_get_ptr(w_code_ptr as pyre_object::PyObjectRef)
-            as *const pyre_interpreter::CodeObject);
+        // The wrapper being non-null does not make its `code_ptr` non-null:
+        // `w_code_new_with_hidden_applevel` (pycode.rs:386) leaves the field
+        // null for a gateway builtin or a test fixture, and every sibling
+        // name lookup screens it the same way.
+        let code_ptr = pyre_interpreter::w_code_get_ptr(w_code_ptr as pyre_object::PyObjectRef);
+        if code_ptr.is_null() {
+            return Ok(false);
+        }
+        let code = &*(code_ptr as *const pyre_interpreter::CodeObject);
         match pyre_interpreter::pyframe::load_name_from_code(code, name_idx) {
             Some(n) => n.to_string(),
             None => return Ok(false),

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -5146,17 +5146,28 @@ pub extern "C" fn bh_load_from_dict_or_globals_fn(
     // here as a bogus `NameError`.
     //
     // A null frame is an anticipated input — the globals leg above already
-    // treats it as one — so the builtin module is derived from the globals'
-    // `__builtins__` in that case, the way `try_walker_load_global_cell_fold`
-    // does (specialize.rs:8904-8907) and the same object `pick_builtin`
-    // resolves.
+    // treats it as one — so the builtin namespace is resolved from the globals
+    // through `pick_builtin_obj_checked`, the same resolver whose result
+    // `frame.get_builtin()` caches. Reading `globals["__builtins__"]` raw is
+    // not equivalent: `exec`/`eval` plant the builtins *dict* rather than the
+    // module (3.14 `PyEval_GetBuiltins`), and the `is_module` test below would
+    // reject that spelling and report a bogus `NameError` for every builtin
+    // name seen by a function created under an exec'd namespace.
+    // `try_walker_load_global_cell_fold` declines the fold in that case and
+    // leaves the name to this residual, so the handling has to live here.
     let w_builtin = if !parent_frame_ptr.is_null() {
         unsafe { (*parent_frame_ptr).get_builtin() }
-    } else if !w_globals.is_null() {
-        unsafe { pyre_object::w_dict_getitem_str(w_globals, "__builtins__") }
-            .unwrap_or(pyre_object::PY_NULL)
     } else {
-        pyre_object::PY_NULL
+        match pyre_interpreter::baseobjspace::pick_builtin_obj_checked(
+            w_globals,
+            pyre_interpreter::call::take_last_exec_ctx(),
+        ) {
+            Ok(w_builtin) => w_builtin,
+            Err(mut err) => {
+                publish_residual_call_exception(err.to_exc_object() as i64);
+                return 0;
+            }
+        }
     };
     if !w_builtin.is_null() && unsafe { pyre_object::is_module(w_builtin) } {
         let w_dict = unsafe { pyre_object::w_module_get_w_dict(w_builtin) };

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -2076,13 +2076,18 @@ fn reject_non_exception_channel_value(
     site: &str,
     context: impl FnOnce() -> String,
 ) -> ! {
-    let tag = unsafe { pyre_object::interp_exceptions::w_exception_kind_byte(obj) };
-    // Report the raw header before touching anything reached *through* it: if
+    // Nothing has been read out of `obj` yet, and this function only runs for a
+    // value already known not to be a `W_BaseException` — a small integer or an
+    // address at the end of a mapping reaches here too, and every read below
+    // can fault. Emit the pointer first so that a fault still leaves evidence.
+    eprintln!("[jit][BUG] {site}: not a W_BaseException: obj={obj:p}");
+    // Then the raw header, before touching anything reached *through* it: if
     // `ob_type` is itself garbage the name lookup below faults, and then this
     // line is all the evidence there is.
+    let tag = unsafe { pyre_object::interp_exceptions::w_exception_kind_byte(obj) };
     let words = unsafe { std::slice::from_raw_parts(obj as *const u64, 4) };
     eprintln!(
-        "[jit][BUG] {site}: not a W_BaseException: obj={obj:p} tag_byte={tag} \
+        "[jit][BUG] {site}: obj={obj:p} tag_byte={tag} \
          words=[{:#018x} {:#018x} {:#018x} {:#018x}]",
         words[0], words[1], words[2], words[3],
     );
@@ -2621,7 +2626,22 @@ pub fn blackhole_resume_via_rd_numb(
             // A copy, not a probe: a ref register may hold a raw non-object
             // word (a force token, an erased unboxed buffer), so anything that
             // dereferences these belongs on the failure path only.
-            let bh_regs_r = bh.registers_r.clone();
+            //
+            // The copy has to be taken here because `release_bh_rd` below ends
+            // the borrow before the diagnostic closure runs, but it is only
+            // ever read when `exit_frame_exception_ref` rejects the value, so
+            // the same screen decides whether to pay for it. A move between
+            // here and the closure does not change the answer: the class of the
+            // propagating value is what is being screened.
+            let bh_regs_r = if unsafe {
+                pyre_object::interp_exceptions::w_exception_kind_checked(exc_value as PyObjectRef)
+            }
+            .is_none()
+            {
+                bh.registers_r.clone()
+            } else {
+                Vec::new()
+            };
             let bh_code_window: Vec<u8> = bh
                 .jitcode
                 .code
@@ -5124,18 +5144,29 @@ pub extern "C" fn bh_load_from_dict_or_globals_fn(
     // `self.get_builtin().getdictvalue(space, varname)` (`pyopcode.py:979`).
     // This residual stopped after the globals leg, so a builtin name reached
     // here as a bogus `NameError`.
-    if !parent_frame_ptr.is_null() {
-        let w_builtin = unsafe { (*parent_frame_ptr).get_builtin() };
-        if !w_builtin.is_null() && unsafe { pyre_object::is_module(w_builtin) } {
-            let w_dict = unsafe { pyre_object::w_module_get_w_dict(w_builtin) };
-            if !w_dict.is_null() {
-                match pyre_interpreter::baseobjspace::finditem_str(w_dict, varname) {
-                    Ok(Some(val)) => return val as i64,
-                    Ok(None) => {}
-                    Err(mut err) => {
-                        publish_residual_call_exception(err.to_exc_object() as i64);
-                        return 0;
-                    }
+    //
+    // A null frame is an anticipated input — the globals leg above already
+    // treats it as one — so the builtin module is derived from the globals'
+    // `__builtins__` in that case, the way `try_walker_load_global_cell_fold`
+    // does (specialize.rs:8904-8907) and the same object `pick_builtin`
+    // resolves.
+    let w_builtin = if !parent_frame_ptr.is_null() {
+        unsafe { (*parent_frame_ptr).get_builtin() }
+    } else if !w_globals.is_null() {
+        unsafe { pyre_object::w_dict_getitem_str(w_globals, "__builtins__") }
+            .unwrap_or(pyre_object::PY_NULL)
+    } else {
+        pyre_object::PY_NULL
+    };
+    if !w_builtin.is_null() && unsafe { pyre_object::is_module(w_builtin) } {
+        let w_dict = unsafe { pyre_object::w_module_get_w_dict(w_builtin) };
+        if !w_dict.is_null() {
+            match pyre_interpreter::baseobjspace::finditem_str(w_dict, varname) {
+                Ok(Some(val)) => return val as i64,
+                Ok(None) => {}
+                Err(mut err) => {
+                    publish_residual_call_exception(err.to_exc_object() as i64);
+                    return 0;
                 }
             }
         }

--- a/pyre/pyre-object/src/dictmultiobject.rs
+++ b/pyre/pyre-object/src/dictmultiobject.rs
@@ -113,6 +113,14 @@ unsafe fn key_as_utf8(key: PyObjectRef) -> Option<&'static str> {
 /// fails loud rather than substituting a divergent structural hash.
 #[inline]
 pub unsafe fn object_key_for(obj: PyObjectRef) -> ObjectKey {
+    // `hash_w` runs the key's `__hash__` and is therefore a collection point,
+    // while this key caches the pointer — the hazard [`object_key_hashed`]
+    // documents. Publish `obj` across the call and build the key from the
+    // reloaded address, or the entry lands in the `IndexMap` under the
+    // pre-move pointer and every later probe dereferences reclaimed memory.
+    let _roots = crate::gc_roots::push_roots();
+    let obj_slot = crate::gc_roots::shadow_stack_len();
+    crate::gc_roots::pin_root(obj);
     let hash = crate::dict_eq_hook::try_hash_w(obj)
         .unwrap_or_else(|| crate::dict_eq_hook::missing_hash_hook());
     if crate::dict_eq_hook::take_hash_error() {
@@ -123,6 +131,7 @@ pub unsafe fn object_key_for(obj: PyObjectRef) -> ObjectKey {
     // an infallible probe's own error is then swallowed by the next key
     // construction, never leaking into a later checked op.
     crate::dict_eq_hook::take_eq_error();
+    let obj = crate::gc_roots::shadow_stack_get(obj_slot);
     ObjectKey { hash, obj }
 }
 
@@ -538,6 +547,11 @@ unsafe fn object_key_for_new_str(key: &str) -> ObjectKey {
 /// error from the interpreter-side error slot.
 #[inline]
 pub unsafe fn object_key_for_checked(obj: PyObjectRef) -> Result<ObjectKey, DictKeyError> {
+    // Same publication as [`object_key_for`]: `hash_w` can collect and this
+    // key caches the pointer, so key on the reloaded address.
+    let _roots = crate::gc_roots::push_roots();
+    let obj_slot = crate::gc_roots::shadow_stack_len();
+    crate::gc_roots::pin_root(obj);
     let hash = crate::dict_eq_hook::try_hash_w(obj)
         .unwrap_or_else(|| crate::dict_eq_hook::missing_hash_hook());
     if crate::dict_eq_hook::take_hash_error() {
@@ -546,6 +560,7 @@ pub unsafe fn object_key_for_checked(obj: PyObjectRef) -> Result<ObjectKey, Dict
     // Clean slate for the bucket probe that follows in the caller; its
     // eq error is read back via `take_dict_key_error` after the access.
     crate::dict_eq_hook::take_eq_error();
+    let obj = crate::gc_roots::shadow_stack_get(obj_slot);
     Ok(ObjectKey { hash, obj })
 }
 
@@ -2978,10 +2993,20 @@ unsafe fn w_dict_store_object_strategy_checked_inner(
     hash: Option<i64>,
 ) -> Result<(), DictKeyError> {
     debug_assert!(!value.is_null(), "w_dict_store_object_strategy: null value");
+    // `object_key_for_checked` hashes through the key's `__hash__`, so it is a
+    // collection point; the caller's `lock_dict_refs!` bindings are raw copies
+    // taken before it. Publish the receiver and the value here and reload them
+    // once the key exists, or the insert below writes a moved `value` and
+    // reaches the `IndexMap` through the dict's pre-move address.
+    let _roots = crate::gc_roots::push_roots();
+    let obj_slot = crate::gc_roots::pin_roots(&[obj, value]);
+    let value_slot = obj_slot + 1;
     let object_key = match hash {
         Some(hash) => object_key_hashed(key, hash),
         None => object_key_for_checked(key)?,
     };
+    let obj = crate::gc_roots::shadow_stack_get(obj_slot);
+    let value = crate::gc_roots::shadow_stack_get(value_slot);
     // Single setitem probe (matches `r_dict.setitem`'s one bucket scan), run
     // callback-free so no user `__eq__` mutates the dict while the `IndexMap`
     // borrow is live.  When every same-hash comparison stays inside the

--- a/pyre/pyre-object/src/generator.rs
+++ b/pyre/pyre-object/src/generator.rs
@@ -2,6 +2,13 @@
 //!
 //! Wraps a suspended frame. __next__() resumes the frame until
 //! YIELD_VALUE (produces a value) or RETURN_VALUE (raises StopIteration).
+//!
+//! # Safety
+//! The `w_generator_*` / `w_coroutine_*` accessors below cast their argument
+//! to [`GeneratorIterator`] and read or write a field at a fixed offset, with
+//! no kind check of their own. Each one therefore requires `obj` to point at a
+//! live `GeneratorIterator` — a generator, coroutine or async generator. Any
+//! other object reads or, worse, writes an unrelated byte of its payload.
 
 use crate::pyobject::*;
 use pyre_macros::pyre_class;

--- a/pyre/pyre-object/src/interp_exceptions.rs
+++ b/pyre/pyre-object/src/interp_exceptions.rs
@@ -1425,9 +1425,17 @@ pub unsafe fn w_exception_kind_byte(obj: PyObjectRef) -> u8 {
 /// after it because the class check does not prove the byte is a live
 /// discriminant, and that byte is what indexes the jump table.
 ///
+/// The screens stop at the shape of `ob_type`: they do not prove it addresses
+/// a live type. `is_exception` reads the subclass range through it, so an
+/// aligned non-null word that is not a type header still faults. Proving it
+/// would need a heap-membership test, and the only one available (`is_tracked`)
+/// runs as a `gc_op` — it leaves RUNNING and can park the mutator, which is not
+/// something a classification on the blackhole resume path may do. The caller's
+/// contract carries that obligation instead.
+///
 /// # Safety
 /// `obj` must be null or point to at least `size_of::<PyObject>()` readable
-/// bytes.
+/// bytes, and its `ob_type` must be null or address a readable type header.
 #[inline]
 pub unsafe fn w_exception_kind_checked(obj: PyObjectRef) -> Option<ExcKind> {
     // Every screen below precedes the dereference it protects, so that a value

--- a/pyre/pyre-object/src/interp_exceptions.rs
+++ b/pyre/pyre-object/src/interp_exceptions.rs
@@ -1416,25 +1416,26 @@ pub unsafe fn w_exception_kind_byte(obj: PyObjectRef) -> u8 {
 /// the class check in front of the tag read: `is_exception` is the
 /// `ll_isinstance` port.
 ///
-/// The tag byte is range-checked *before* the class check because it is the
-/// cheaper load — one dereference of `obj` rather than a dereference of the
-/// `ob_type` loaded out of it — and it is the exact byte the jump table
-/// would index.
+/// The class check runs *before* the tag range check. `kind` is a tail field
+/// past `ob_header`, so reading it out of a value that is not an exception can
+/// read past the object — `W_NoneObject` is a bare header and ends exactly
+/// where `kind` starts. `ob_type` sits at offset 0, so the class check needs
+/// only the header to be readable, and once `is_exception` holds the object is
+/// a `W_BaseException` and the tag load is in bounds. The range check stays
+/// after it because the class check does not prove the byte is a live
+/// discriminant, and that byte is what indexes the jump table.
 ///
 /// # Safety
-/// `obj` must be null or point to at least `size_of::<W_BaseException>()`
-/// readable bytes.
+/// `obj` must be null or point to at least `size_of::<PyObject>()` readable
+/// bytes.
 #[inline]
 pub unsafe fn w_exception_kind_checked(obj: PyObjectRef) -> Option<ExcKind> {
-    // Every screen below precedes the dereference it protects, cheapest
-    // first, so that a value which is not an object at all is rejected rather
-    // than faulting: alignment before the tag load, the tag range before the
-    // `ob_type` load, and `ob_type`'s own shape before `ll_issubclass` reads
-    // the subclass range through it.
+    // Every screen below precedes the dereference it protects, so that a value
+    // which is not an object at all is rejected rather than faulting:
+    // alignment before the `ob_type` load, `ob_type`'s own shape before
+    // `ll_issubclass` reads the subclass range through it, and the class
+    // before the tail-field tag load.
     if obj.is_null() || !(obj as usize).is_multiple_of(align_of::<W_BaseException>()) {
-        return None;
-    }
-    if unsafe { w_exception_kind_byte(obj) } > ExcKind::MAX_DISCRIMINANT {
         return None;
     }
     let ob_type = unsafe { (*obj).ob_type };
@@ -1444,6 +1445,9 @@ pub unsafe fn w_exception_kind_checked(obj: PyObjectRef) -> Option<ExcKind> {
         return None;
     }
     if !unsafe { is_exception(obj) } {
+        return None;
+    }
+    if unsafe { w_exception_kind_byte(obj) } > ExcKind::MAX_DISCRIMINANT {
         return None;
     }
     Some(unsafe { w_exception_get_kind(obj) })
@@ -1645,23 +1649,48 @@ mod tests {
         }
     }
 
-    /// A word that is not a `W_BaseException` must not reach
-    /// `kind_from_exc`: that match has no wildcard arm, so an out-of-range
-    /// byte indexes a bounds-check-free jump table.  The range check has to
-    /// reject before the class check dereferences `ob_type`, so this uses a
-    /// buffer whose header is deliberately not a live type pointer.
+    /// A byte that is not a live discriminant must not reach `kind_from_exc`:
+    /// that match has no wildcard arm, so an out-of-range byte indexes a
+    /// bounds-check-free jump table.
+    ///
+    /// The subject is a stack copy of a real exception, so it clears the
+    /// alignment and class screens and the tag range is the gate under test.
+    /// A `[u8; N]` buffer would not: its alignment is 1 and its header is
+    /// null, so either of the earlier screens could be the one that rejects.
     #[test]
     fn test_kind_checked_rejects_out_of_range_tag() {
-        let mut buf = [0u8; std::mem::size_of::<W_BaseException>()];
-        let kind_offset = std::mem::offset_of!(W_BaseException, kind);
+        let live = w_exception_new(ExcKind::ValueError, "bad value");
+        let mut copy: W_BaseException = unsafe { std::ptr::read(live as *const W_BaseException) };
+        let obj = std::ptr::addr_of_mut!(copy) as PyObjectRef;
+        assert_eq!(
+            unsafe { w_exception_kind_checked(obj) },
+            Some(ExcKind::ValueError),
+            "the copy must pass every screen before the tag is corrupted"
+        );
+        let tag = std::ptr::addr_of_mut!(copy.kind).cast::<u8>();
         for raw in [ExcKind::MAX_DISCRIMINANT + 1, 128, 160, u8::MAX] {
-            buf[kind_offset] = raw;
+            unsafe { tag.write(raw) };
             assert_eq!(
-                unsafe { w_exception_kind_checked(buf.as_ptr() as PyObjectRef) },
+                unsafe { w_exception_kind_checked(obj) },
                 None,
                 "tag byte {raw} must be rejected"
             );
         }
+    }
+
+    /// The class screen rejects a word whose header is not an exception type
+    /// without ever loading the tail field the tag lives in.
+    #[test]
+    fn test_kind_checked_rejects_non_exception_header() {
+        let buf = [0usize; std::mem::size_of::<W_BaseException>() / 8];
+        assert_eq!(
+            unsafe { w_exception_kind_checked(buf.as_ptr() as PyObjectRef) },
+            None
+        );
+        assert_eq!(
+            unsafe { w_exception_kind_checked(crate::noneobject::w_none()) },
+            None
+        );
     }
 
     #[test]

--- a/pyre/pyre-object/src/tupleobject.rs
+++ b/pyre/pyre-object/src/tupleobject.rs
@@ -262,14 +262,53 @@ pub fn w_tuple_new_array_backed(items: Vec<PyObjectRef>) -> PyObjectRef {
     let relocated: Vec<PyObjectRef> = (0..len)
         .map(|i| crate::gc_roots::shadow_stack_get(save_point + i))
         .collect();
-    let items_block = unsafe { alloc_tuple_items_block_gc(&relocated) };
+    let mut items_block = unsafe { alloc_tuple_items_block_gc(&relocated) };
+    // `alloc_tuple_items_block_gc` roots the fresh block only inside its own
+    // `push_roots` frame, which it pops on return, so from here the block is a
+    // livevar of *this* frame across the barrier below. That barrier is a
+    // `gc_op`: it leaves RUNNING before taking `gc_mutex` (`gc_sync.rs:22`) and
+    // roots only the object it is handed, so a foreign collector runs there
+    // with the block reachable from nowhere. Inert for a null or std::alloc
+    // block, as in `w_list_new_with_strategy`.
+    let block_root: Option<usize> = if items_block.is_null() {
+        None
+    } else {
+        let s = crate::gc_roots::shadow_stack_len();
+        crate::gc_roots::pin_root(items_block as PyObjectRef);
+        Some(s)
+    };
     let raw = raw_slot
         .map(crate::gc_roots::shadow_stack_get)
         .unwrap_or(std::ptr::null_mut()) as *mut u8;
 
     if !raw.is_null() {
+        // The tuple lives in old-gen (`try_gc_alloc_stable`); its items
+        // may still be in the nursery. The element pointers are stored in
+        // the off-GC `items_block`, so the implicit write barrier on the
+        // tuple struct never fires — register the tuple explicitly so the
+        // next minor collection scans it (via the `wrappeditems`
+        // custom-trace hook) and relocates any young element. Mirrors the
+        // `write_barrier_from_array` an old list/tuple store would emit
+        // (incminimark.py:1495).
+        //
+        // This runs BEFORE the store, against the null-items image published
+        // above: remembering an old object that holds no young pointer yet is
+        // the harmless direction. Storing first would leave the young block
+        // named by a slot no collection traces for the whole parking window —
+        // `remember_young_pointer` clears `GCFLAG_TRACK_YOUNG_PTRS` and queues
+        // the tuple only once it runs (incminimark.py:1519-1522), and a minor that
+        // lands inside that window reclaims the block and poisons the nursery
+        // under it, leaving `wrappeditems` dangling for good.
+        crate::gc_hook::try_gc_write_barrier_managed(raw);
+        // Re-read the block the barrier's park may have moved: the tuple is on
+        // the remembered set now, but its `wrappeditems` is still null, so no
+        // collection could have forwarded that slot for us.
+        if let Some(s) = block_root {
+            items_block = crate::gc_roots::shadow_stack_get(s) as *mut ItemsBlock;
+        }
         // The header went in before the root was published; only the items
-        // block is still outstanding.
+        // block is still outstanding. Nothing below can collect, so the
+        // remembered tuple keeps the block from here on.
         unsafe {
             std::ptr::write(
                 raw as *mut W_TupleObject,
@@ -281,15 +320,6 @@ pub fn w_tuple_new_array_backed(items: Vec<PyObjectRef>) -> PyObjectRef {
                 },
             );
         }
-        // The tuple lives in old-gen (`try_gc_alloc_stable`); its items
-        // may still be in the nursery. The element pointers are stored in
-        // the off-GC `items_block`, so the implicit write barrier on the
-        // tuple struct never fires — register the tuple explicitly so the
-        // next minor collection scans it (via the `wrappeditems`
-        // custom-trace hook) and relocates any young element. Mirrors the
-        // `write_barrier_from_array` an old list/tuple store would emit
-        // (incminimark.py:1495).
-        crate::gc_hook::try_gc_write_barrier_managed(raw);
         return raw as PyObjectRef;
     }
     Box::into_raw(Box::new(W_TupleObject {


### PR DESCRIPTION
Eight commits on top of `main`. The GC half continues the unrooted-young-local
audit; the rest closes the PR #937 review queue, the `posix` unwrap audit, and
the review findings raised on this PR.

## GC rooting

A `gc_op` leaves RUNNING before it blocks on `gc_mutex` (`gc_sync.rs:22`), and
every allocation and every write barrier is a `gc_op`. Once a second thread
exists, any allocation is a parking safepoint at which a foreign collector runs
a full minor, so a young object living only in a raw Rust local is named by no
root and goes stale. The bracket is `gct_fv_gc_malloc`
(`rpython/memory/gctransform/framework.py:853-856`): pin, allocate, re-read the
relocated address, then store.

- **`w_tuple_new_array_backed`** — `alloc_tuple_items_block_gc` pops its own
  `push_roots` frame on return, so the fresh block was unrooted across
  `try_gc_write_barrier_managed`, and the barrier ran *after* the store,
  against the documented order (`majit-gc/src/lib.rs`). Pin the block, barrier
  the tuple against its already-published null-items image, re-read, store.
- **The `*args` / `**kwargs` packers in `call.rs`** — `w_dict_new` allocates in
  the nursery and both the key strings and `w_dict_store`'s strategy promotion
  park. Two comments claiming the loops were safe because "no safepoint fires"
  were reasoning about `gc_interp::safepoint` (this thread's own eval-depth
  gate) and missed the foreign collector; they are deleted. Argument evaluation
  order matters: the key is allocated into a local first, because as the second
  argument it would be evaluated *after* the receiver.
- **The references already live when those brackets open** — the parameters
  bound into `result`, the unmatched keyword pairs, and the positional copies
  in `full_args`. `bind_kwargs_to_signature` also interned each unmatched
  keyword name inside the matching loop, one allocation per keyword ahead of
  any pin; the name now stays a `Wtf8Buf` until the bracket. `real_build_class`
  scoped its guard to the arm that fills the class-keyword dict, so the dict
  was unpinned across `update_bases` and both `w_tuple_new` calls and for the
  whole of `build_class_inner`, which holds it across the class body call.
- **`object_key_for` / `object_key_for_checked`** — both built `ObjectKey` from
  the `obj` they were passed, *after* calling `hash_w` on it. `hash_w` runs the
  key's `__hash__` and is a collection point, so the cached pointer could be
  the pre-move address; the sibling `object_key_hashed` already documents this
  hazard and exists for callers that hash where the key is still rooted.
  `w_dict_store_object_strategy_checked_inner` reaches that point with `obj`
  and `value` as raw copies of the caller's `lock_dict_refs!` bindings.

`scratchpad/asyncio-run/_be_main.py` × 120 under `MAJIT_GC_NURSERY_POISON=1`:
before the last fix, all three decodable SIGSEGVs were `KERN_INVALID_ADDRESS at
0xaaaaaaaaaaaaaaba` in `IndexMap::<ObjectKey, _>::get_index_of` from
`w_dict_store_object_strategy_checked_inner`; after, none are. Raw counts moved
8 → 3 across the series, which on its own proves nothing at this sample size —
the disappearing signatures are the evidence.

The `grey_child` invalid-`type_id` panic now also names the *enclosing
container*: a custom trace may hand the collector slots outside the object it
was called on (the mapdict storage block, the module-dict storage boxes), so
the old message could not tell a reclaimed container from a reclaimed child.
Abort path only.

## Review queue

- `_socket` `send`/`sendall`/`sendto`: `SimpleBufferBytes::release` on every
  exit path — the type has no `Drop`, so a dropped view left a `bytearray`
  argument permanently exported and unresizable.
- `interp_exceptions::w_exception_kind_checked`: null/alignment-check the
  object and its `ob_type` and run `is_exception` before reading the `kind`
  byte. The screens stop at the *shape* of `ob_type`; the only heap-membership
  test available (`is_tracked`) runs as a `gc_op`, which a classification on
  the blackhole resume path may not do, so the caller's contract carries that
  obligation and now says so.
- `_collections`: take the deque stripe lock in the remaining unlocked
  accessors, re-bound the converted index *under* the guard (`deque_index`
  bounds against the length it read while `__index__` was still running, so a
  concurrent shrink left `locate` walking past the end of the chain and
  `Vec::remove` panicking), and cover `__imul__`'s snapshot/store pair plus
  `remove`'s write-back. `remove`'s comparison loop stays outside the guard —
  `eq_w` runs arbitrary Python — with the mutation epoch re-read under it.
- `call_jit` / `specialize`: emit the diagnostic before dereferencing a
  rejected channel value, clone the blackhole ref bank only when the kind check
  fails, and reject a null `code_ptr` before casting it. The null-frame builtins
  leg resolves through `pick_builtin_obj_checked` rather than accepting
  `globals["__builtins__"]` only when `is_module` holds: `exec`/`eval` plant the
  builtins *dict*, and `try_walker_load_global_cell_fold` declines the fold for
  that spelling and leaves the name to this residual, so every builtin name in a
  function created under an exec'd namespace raised `NameError`.
- `majit-gc` and the dynasm/cranelift runners: route `get_referents` and
  `is_tracked` through `gc_op_with_root`.
- `posix`: unwrap integer arguments through the space helpers. `is_int` is
  exact, so a raw `w_int_get_value` read accepted an `int` subclass and read
  the wrong payload. `access` also stopped narrowing its `c_int` mode to `u8`,
  which folded `access(path, 256)` onto `F_OK` and answered "exists" for a mode
  `access(2)` rejects with EINVAL.

## Verification

`cargo fmt --all -- --check` clean. `cargo test --all --no-default-features
--features dynasm` green, 0 failures.

`pyre/check.py --backend dynasm` reports **5 failed / 363 passed** — the same
five fixtures, with the same reasons and the same counts, as a clean build of
`main` at `a72d9cb8d0c` (measured, not assumed: a detached worktree at that
commit with its own LLBC extraction and `target/`). The branch adds no
failures; all five are jit-stats count regressions inherited from `main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved garbage-collection safety during object access, calls, dictionary operations, tuple creation, and JIT execution.
  * Prevented crashes from invalid exception data, missing code objects, unsafe descriptors, and malformed system-call arguments.
  * Improved thread, deque, socket, and file-descriptor handling under concurrent or error conditions.
  * Added safer fallback behavior when runtime services or builtins are unavailable.

* **Diagnostics**
  * Expanded heap-corruption diagnostics with collection and container context.
  * Improved reporting for remote debugging failures and invalid runtime state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->