### PR TITLE
_contextvars: make copy_context a non-binding interp-level builtin (epic #40)

### DIFF
--- a/pyre/pyre-interpreter/src/module/_contextvars/_contextvars_app.py
+++ b/pyre/pyre-interpreter/src/module/_contextvars/_contextvars_app.py
@@ -14,14 +14,6 @@ class Unsubclassable(type):
         return type.__new__(cls, name, bases, dict(dct))
 
 
-def get_context():
-    context = get_contextvar_context()
-    if context is None:
-        context = Context()
-        set_contextvar_context(context)
-    return context
-
-
 class Context(metaclass=Unsubclassable):
 
     #_data: Map
@@ -41,7 +33,7 @@ class Context(metaclass=Unsubclassable):
             raise RuntimeError(
                 f'cannot enter context: {self} is already entered')
 
-        # don't use get_context() here, to avoid creating a Context object
+        # read the raw context directly, to avoid creating a Context object
         _prev_context = get_contextvar_context()
         try:
             self._is_entered = True
@@ -100,10 +92,6 @@ class Context(metaclass=Unsubclassable):
         if not isinstance(other, Context):
             return NotImplemented
         return dict(self.items()) == dict(other.items())
-
-
-def copy_context():
-    return get_context().copy()
 
 
 Context.__module__ = '_contextvars'

--- a/pyre/pyre-interpreter/src/module/_contextvars/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_contextvars/mod.rs
@@ -3,7 +3,9 @@
 //! `Context` is the app-level line-by-line port because its persistent Map
 //! operations and `run()`'s try/finally are already expressed exactly there.
 //! ContextVar and Token remain interpreter-level while their state operations
-//! are ported incrementally.
+//! are ported incrementally.  `copy_context` is interp-level too — a
+//! non-binding builtin over `current_context`; PyPy keeps it in
+//! `lib_pypy/_contextvars.py`, but `Python/context.c` ships it as a C function.
 
 use pyre_object::*;
 use std::sync::OnceLock;
@@ -401,6 +403,15 @@ crate::py_module! {
         "ContextVar" => context_var_type(),
         "Token" => token_type(),
     },
+    functions: {
+        // `copy_context()` — snapshot the current context; `Context.copy()`
+        // shares the persistent `_data` Map.  `current_context(true)` is the
+        // same "read-or-create the thread's Context" step `set`/`reset` use.
+        "copy_context" / 0 = |_| {
+            let context = current_context(true)?.expect("create=true returns a Context");
+            call_method_result(context, "copy", &[])
+        },
+    },
     extra_init: |ns| {
         let context_var = crate::module_ns_get(ns, "ContextVar")
             .expect("_contextvars.ContextVar must be installed first");
@@ -408,7 +419,7 @@ crate::py_module! {
             ns,
             include_str!("_contextvars_app.py"),
             "_contextvars_app.py",
-            &["Context", "copy_context"],
+            &["Context"],
             &[("ContextVar", context_var)],
         );
         let context = crate::module_ns_get(ns, "Context")


### PR DESCRIPTION
## What

Move `_contextvars.copy_context` from an `_contextvars_app.py` `def` into the
module's `functions:` block. It now computes
`current_context(true)?.copy()` — the same "read-or-create the thread's
Context" step that `ContextVar.set`/`reset` already use — so
`copy_context` is a non-binding `builtin_function_or_method` instead of an
app-level function. The now-dead app-level `get_context` helper (its only
caller was `copy_context`) is removed.

## Why (epic #40, task #40)

`Python/context.c` ships `copy_context` as a C function; the app-level `def`
gave the wrong type identity and bound `self` when stored as a class
attribute. This is the last of the two remaining function-conversion targets
the module survey found (the other, `operator.countOf`, is PR #975); after it,
epic #40's function conversions are complete. Everything else in the modules
with appleveldefs is a `type`/class (already non-binding) or already
interp-level.

## Parity

Byte-identical to CPython 3.14 (JIT and nojit):
`type(copy_context).__name__` is `builtin_function_or_method`,
`contextvars.copy_context is _contextvars.copy_context`, it does not bind
`self` via an instance, returns a `Context`, and the snapshot semantics
(`copy()` shares the persistent `_data` Map; a later `set` replaces it),
`run()` isolation, membership/len/iter, and the `copy_context(1)` /
`copy_context(x=1)` arity errors all match exactly.

`current_context(true)` is behaviourally identical to the removed app
`get_context()` for every reachable state (both read the EC's context and
create+install one when absent); PyPy keeps `copy_context` app-level in
`lib_pypy/_contextvars.py`, so the interp-level form is a deliberate deviation
toward `Python/context.c`'s C exposure (same pattern as `_hashlib` #969 /
`operator.countOf` #975).

## CI

check.py's dynasm/cranelift jit-stats floor failures (`exception_*`,
`closure_freevar_branch_resume`, `list_length_hint_validate`) are inherited
from `origin/main` — byte-identical to PR #971's CI (which became the base
commit) — and are fixed on a separate parallel branch (quasiimmut
`d0a0529f041` etc.) not yet merged. No synth imports `contextvars`, and this
interp-only change touches no traced code, so it adds zero jit-stats delta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)