### PR TITLE
jit: install the quasi-immutable mutate field at the record, and abort the walk at the namespace write

### DIFF
--- a/majit/majit-ir/src/effectinfo.rs
+++ b/majit/majit-ir/src/effectinfo.rs
@@ -709,6 +709,18 @@ pub enum PyreHelperKind {
     /// `store_global_value`).  Recognised for the same `IntMutableCell`
     /// in-place store fold as [`PyreHelperKind::StoreName`].
     StoreGlobal,
+    /// `bh_delete_name_fn(frame, w_name)` — the DELETE_NAME frame-receiver
+    /// helper (`pyopcode.py:869-880`, delegates to `delitem_str`).  Recognised
+    /// by the walker only to answer upstream's
+    /// `opimpl_jit_force_quasi_immutable` question (`pyjitpl.py:1094-1118`)
+    /// ahead of the call: a successful delete runs `mutated()`
+    /// (`celldict.py:106-126`), which assigns the `version?` quasi-immutable
+    /// field.  Pyre's write lives inside this residual, so the walker never
+    /// meets the rtyper operation and has to ask before executing.
+    DeleteName,
+    /// `bh_delete_global_fn(frame, w_name)` — the DELETE_GLOBAL twin of
+    /// [`PyreHelperKind::DeleteName`], recognised for the same reason.
+    DeleteGlobal,
     /// `bh_call_fn_N(callable, null_or_self, args...)` — the CALL-family
     /// Python-call helper.  `null_or_self` (arg index 1) is a sentinel
     /// the helper checks before use (a non-null receiver is prepended as

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -3382,7 +3382,16 @@ impl<S: JitState> JitDriver<S> {
                 let abort_raising_exception = pending_stb
                     .as_ref()
                     .is_some_and(|stb| stb.raising_exception);
-                let reason_int = match pending_stb.map(|stb| stb.reason) {
+                // A walker raise site outside this crate cannot reach
+                // `TraceCtx::pending_switch_to_blackhole`, so its
+                // `Counters.ABORT_*` travels in `stage_abort_reason` instead.
+                // It ranks with `stb.reason` rather than below the too-long
+                // fallback: upstream raises at the site and never reaches the
+                // `blackhole_if_trace_too_long` check on that unwind.
+                let reason_int = match pending_stb
+                    .map(|stb| stb.reason)
+                    .or_else(|| self.meta.take_pending_abort_reason())
+                {
                     Some(r) => r,
                     None => self
                         .meta

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -7617,10 +7617,29 @@ impl<M: Clone> MetaInterp<M> {
         // one accounting event, as `aborted_tracing(stb.reason)` does for the
         // reason the `SwitchToBlackhole` raise carried.
         let reason = self
-            .pending_abort_reason
-            .take()
+            .take_pending_abort_reason()
             .unwrap_or(AbortReason::Generic.as_int());
         self.aborted_tracing(reason);
+    }
+
+    /// Name the `Counters.ABORT_*` reason the abort that is about to happen
+    /// carries, for callers that decide to give the trace up somewhere the
+    /// `abort_trace` call itself cannot see.
+    ///
+    /// RPython carries the reason on the `SwitchToBlackhole` instance from the
+    /// raise site to the `_interpret` catch (`pyjitpl.py:2906-2910`); pyre's
+    /// walker returns a `DispatchError` up through layers that do not spell
+    /// abort reasons, so the reason travels in this slot instead and
+    /// `abort_trace` consumes it exactly once.
+    pub fn stage_abort_reason(&mut self, reason: i32) {
+        self.pending_abort_reason = Some(reason);
+    }
+
+    /// Consume the reason [`MetaInterp::stage_abort_reason`] staged, for the
+    /// abort paths that do their own `abort_trace_live` + `aborted_tracing`
+    /// pair instead of calling `abort_trace`.
+    pub fn take_pending_abort_reason(&mut self) -> Option<i32> {
+        self.pending_abort_reason.take()
     }
 
     /// Live-cleanup half of `abort_trace` — no stats, no hooks.

--- a/pyre/bench/synth/exception_reraise_tb_depth_jitstress.cranelift.jitstats
+++ b/pyre/bench/synth/exception_reraise_tb_depth_jitstress.cranelift.jitstats
@@ -1,8 +1,8 @@
-bridges_compiled=1
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
 guard_failures=1798
 internal_compile_panics=0
-loops_aborted=0
-loops_compiled=805
+loops_aborted=7
+loops_compiled=900

--- a/pyre/bench/synth/exception_reraise_tb_depth_jitstress.dynasm.jitstats
+++ b/pyre/bench/synth/exception_reraise_tb_depth_jitstress.dynasm.jitstats
@@ -1,8 +1,8 @@
-bridges_compiled=1
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
 guard_failures=1798
 internal_compile_panics=0
-loops_aborted=0
-loops_compiled=805
+loops_aborted=7
+loops_compiled=900

--- a/pyre/bench/synth/exception_reraise_tb_depth_jitstress.wasm.jitstats
+++ b/pyre/bench/synth/exception_reraise_tb_depth_jitstress.wasm.jitstats
@@ -2,4 +2,4 @@ descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
 internal_compile_panics=0
-loops_aborted=1198
+loops_aborted=7

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
@@ -355,6 +355,8 @@ pub(crate) fn fbw_store_journal_reset() {
     // gh#467: reset the executed-effect odometer and any stale
     // forward-flush carrier a prior aborted walk latched.
     FBW_EXECUTED_EFFECT_COUNT.with(|c| c.set(0));
+    FBW_OPCODE_ENTRY_EFFECTS.with(|c| c.set(None));
+    FBW_QMUT_ABORT_STACK.with(|c| *c.borrow_mut() = None);
     FBW_STRUCTURAL_ABORT_OPCODE_EFFECTS.with(|c| c.set(None));
     FBW_ABORT_CALL_RESUME.with(|c| *c.borrow_mut() = None);
     // #57 Option C: drop any in-flight FOR_ITER items a prior aborted walk
@@ -1010,6 +1012,37 @@ pub(crate) fn fbw_executed_effect_count() -> usize {
 
 pub(crate) fn fbw_structural_abort_opcode_is_effect_free(pc: usize) -> bool {
     FBW_STRUCTURAL_ABORT_OPCODE_EFFECTS.with(|c| c.get() == Some((pc, 0)))
+}
+
+/// Latch the resume coordinate + operand-stack mirror for an
+/// `ABORT_FORCE_QUASIIMMUT` abort (see [`FBW_QMUT_ABORT_STACK`]).
+pub(crate) fn fbw_qmut_abort_stack_latch(py_pc: usize, stack: Vec<OpRef>) {
+    FBW_QMUT_ABORT_STACK.with(|c| *c.borrow_mut() = Some((py_pc, stack)));
+}
+
+/// Take the latch above.  `None` when the abort could not offer a mirror (a
+/// sub-walk, a bridge walk, or an invalidated mirror), which leaves the flush
+/// leg to decline and the legacy replay to stand.
+pub(crate) fn fbw_qmut_abort_stack_take() -> Option<(usize, Vec<OpRef>)> {
+    FBW_QMUT_ABORT_STACK.with(|c| c.borrow_mut().take())
+}
+
+/// Record the executed-effect odometer as the walk enters Python opcode
+/// `py_pc` (see [`FBW_OPCODE_ENTRY_EFFECTS`]).
+pub(crate) fn fbw_note_opcode_entry_effects(py_pc: usize) {
+    FBW_OPCODE_ENTRY_EFFECTS.with(|c| c.set(Some((py_pc, fbw_executed_effect_count()))));
+}
+
+/// The odometer sampled on entry to `py_pc`, for a leg that resumes the
+/// interpreter there.  `None` — no sample, or one taken at a different opcode —
+/// leaves the rewind unproven, which [`walk_end_resume_provable`] declines.
+///
+/// [`walk_end_resume_provable`]: crate::trace::walk_end_resume_provable
+pub(crate) fn fbw_opcode_entry_effects_at(py_pc: usize) -> Option<usize> {
+    FBW_OPCODE_ENTRY_EFFECTS.with(|c| match c.get() {
+        Some((sampled_py_pc, effects)) if sampled_py_pc == py_pc => Some(effects),
+        _ => None,
+    })
 }
 
 /// gh#467 bump the executed-effect odometer (see [`FBW_EXECUTED_EFFECT_COUNT`]).

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -1990,6 +1990,20 @@ pub enum DispatchError {
     /// through pyre's abort ceiling, so the permanent mapping records the
     /// structural nature of this abort without changing runtime behavior.
     BranchGuardUnrestorableKeptStackPermanent { pc: usize },
+    /// `pyjitpl.py:1112-1116 opimpl_jit_force_quasi_immutable`: the mutate
+    /// field was already non-null when the walk reached a write that bumps the
+    /// guarded version, so the tracer forced the invalidation itself and
+    /// abandons the attempt (`raise SwitchToBlackhole(ABORT_FORCE_QUASIIMMUT)`).
+    ///
+    /// Carried as a typed error rather than a `SwitchToBlackhole` OUTCOME so it
+    /// reaches the abort-pc flush leg: upstream's blackhole resumes at the
+    /// `-live-` in front of the write with every earlier residual already
+    /// applied, and pyre's only equivalent is committing the walk and resuming
+    /// the interpreter AT the enclosing Python opcode.  An `Ok` outcome falls
+    /// through to the plain `Abort`, whose journal rollback replays the walked
+    /// region from its start and re-executes every residual the walk already
+    /// ran (`pickle_terminal_raise_resume` is the corpus detector).
+    ForceQuasiImmutable { pc: usize },
     /// A callee compiled as its own Finish portal (reached via
     /// `call_user_function_with_eval`) accessed its frame through a
     /// `vable_*` op that found it to be a non-standard virtualizable,
@@ -2091,6 +2105,7 @@ impl DispatchError {
             Self::LoopHeaderJdIndexUnresolved { .. } => "LoopHeaderJdIndexUnresolved",
             Self::SubWalkClosedLoop { .. } => "SubWalkClosedLoop",
             Self::BranchGuardKeptStackUnsupported { .. } => "BranchGuardKeptStackUnsupported",
+            Self::ForceQuasiImmutable { .. } => "ForceQuasiImmutable",
             Self::NonStandardVableFinishPortalUnsupported { .. } => {
                 "NonStandardVableFinishPortalUnsupported"
             }
@@ -2160,6 +2175,7 @@ impl DispatchError {
             | Self::LoopHeaderJdIndexUnresolved { pc, .. }
             | Self::SubWalkClosedLoop { pc, .. }
             | Self::BranchGuardKeptStackUnsupported { pc, .. }
+            | Self::ForceQuasiImmutable { pc, .. }
             | Self::NonStandardVableFinishPortalUnsupported { pc, .. }
             | Self::LoopBearingCalleeInlineUnsupported { pc, .. }
             | Self::FieldDescrMissingParentDescr { pc, .. }
@@ -5253,6 +5269,35 @@ thread_local! {
     /// discarded and re-executed without risking a double.
     static FBW_EXECUTED_EFFECT_COUNT: std::cell::Cell<usize> =
         const { std::cell::Cell::new(0) };
+
+    /// `ABORT_FORCE_QUASIIMMUT` resume carrier: `(py_pc, operand-stack OpRef
+    /// mirror)` taken at the abort, for the flush leg that resumes the
+    /// interpreter at that opcode.
+    ///
+    /// The mirror is needed because the abort lands MID-EXPRESSION: the vable
+    /// shadow's stack region reads NULL outside a merge point, so the plain
+    /// flush declines on the first operand slot and the walk falls back to the
+    /// replay this leg exists to avoid.  Holds symbolic `OpRef`s only — the
+    /// concrete refs are resolved and rooted inside the flush.
+    static FBW_QMUT_ABORT_STACK: std::cell::RefCell<Option<(usize, Vec<OpRef>)>> =
+        const { std::cell::RefCell::new(None) };
+
+    /// [`FBW_EXECUTED_EFFECT_COUNT`] sampled as the walk ENTERED the Python
+    /// opcode it is currently inside, as `(py_pc, odometer)`.
+    ///
+    /// A leg that resumes the interpreter at a Python opcode re-executes that
+    /// whole opcode — `flush_walk_end_state_to_frame` sets `last_instr = pc - 1`
+    /// — so it owes a proof that the opcode has applied nothing yet.  This is
+    /// that proof's sample point, and it must be the OPCODE boundary: a
+    /// per-`-live-` or per-jitcode-op sample would read zero for an opcode whose
+    /// earlier ops already ran effects.
+    ///
+    /// Recorded only on the top-level walk (`reconcile_vstack_at_boundary`, the
+    /// boundary detector).  A callee sub-walk's `py_pc` names a different code
+    /// object, so leaving the sample absent there makes the gate decline rather
+    /// than compare coordinates from two universes.
+    static FBW_OPCODE_ENTRY_EFFECTS: std::cell::Cell<Option<(usize, usize)>> =
+        const { std::cell::Cell::new(None) };
 
     /// Effect-count delta of the exact JitCode opcode that most recently
     /// returned `LoopBearingCalleeInlineUnsupported`.  The structural

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -1256,12 +1256,7 @@ fn flush_escape_state_with_latched_stack(ctx: &TraceCtx, frame: usize, py_pc: us
 /// ([`flush_qmut_abort_state`]): both resume the interpreter
 /// mid-expression, where the vable shadow's stack region reads NULL and only the
 /// walk's own mirror can say what the operands are.
-fn flush_with_latched_stack(
-    ctx: &TraceCtx,
-    frame: usize,
-    py_pc: usize,
-    oprefs: &[OpRef],
-) -> bool {
+fn flush_with_latched_stack(ctx: &TraceCtx, frame: usize, py_pc: usize, oprefs: &[OpRef]) -> bool {
     {
         let mut stack = Vec::with_capacity(oprefs.len());
         for &opref in oprefs.iter() {
@@ -3751,8 +3746,9 @@ fn try_walker_force_quasi_immut_namespace_write<Sym: WalkSym>(
     } {
         return None;
     }
-    let name =
-        unsafe { pyre_object::unicodeobject::w_str_get_value(w_name_ptr as pyre_object::PyObjectRef) };
+    let name = unsafe {
+        pyre_object::unicodeobject::w_str_get_value(w_name_ptr as pyre_object::PyObjectRef)
+    };
     let slot = crate::state::module_dict_cell_slot_direct(w_globals, name);
     let bumps = if is_store {
         let &value_opref = r_args.get(2)?;
@@ -4057,6 +4053,11 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
         && dst_bank == 'v'
         && try_walker_force_quasi_immut_namespace_write(ctx, ei.pyre_helper, &r_args).is_some()
     {
+        // Carry the reason to the `abort_trace` that follows, the way upstream
+        // carries it on the `SwitchToBlackhole` instance (pyjitpl.py:2906-2910).
+        // Without it the abort lands in the `Generic` catch-all and the
+        // `abort: force quasi-immut` counter stays at 0.
+        crate::state::note_force_quasi_immut_abort();
         return Err(DispatchError::ForceQuasiImmutable { pc: op.pc });
     }
 

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -1245,6 +1245,24 @@ fn flush_escape_state_with_latched_stack(ctx: &TraceCtx, frame: usize, py_pc: us
         let Some(oprefs) = latched.as_ref() else {
             return false;
         };
+        flush_with_latched_stack(ctx, frame, py_pc, oprefs)
+    })
+}
+
+/// Resolve a latched operand-stack OpRef mirror to concrete refs and flush the
+/// walk-end state with it, keeping the resolved refs rooted across the call.
+///
+/// Shared by the escape flush above and the `ABORT_FORCE_QUASIIMMUT` leg
+/// ([`flush_qmut_abort_state`]): both resume the interpreter
+/// mid-expression, where the vable shadow's stack region reads NULL and only the
+/// walk's own mirror can say what the operands are.
+fn flush_with_latched_stack(
+    ctx: &TraceCtx,
+    frame: usize,
+    py_pc: usize,
+    oprefs: &[OpRef],
+) -> bool {
+    {
         let mut stack = Vec::with_capacity(oprefs.len());
         for &opref in oprefs.iter() {
             match ctx.concrete_of_opref(opref) {
@@ -1316,7 +1334,19 @@ fn flush_escape_state_with_latched_stack(ctx: &TraceCtx, frame: usize, py_pc: us
             crate::state::flush_walk_end_state_to_frame_with_full_stack(ctx, frame, py_pc, &stack);
         majit_gc::shadow_stack::pop_resume_ref_roots_to(root_depth);
         committed
-    })
+    }
+}
+
+/// The `ABORT_FORCE_QUASIIMMUT` leg's flush: resume the interpreter at the
+/// opcode carrying the forcing write, with the operand stack the walk mirrored
+/// on entry to it ([`fbw_qmut_abort_stack_take`]).
+pub(crate) fn flush_qmut_abort_state(
+    ctx: &TraceCtx,
+    frame: usize,
+    py_pc: usize,
+    oprefs: &[OpRef],
+) -> bool {
+    flush_with_latched_stack(ctx, frame, py_pc, oprefs)
 }
 
 /// Take the committed escape resume pc and which flush produced it (the
@@ -3636,6 +3666,133 @@ pub(crate) fn residual_call_is_proven_truth(
     };
     numeric_ref_regs[arg_reg as usize] || bool_ref_regs[arg_reg as usize]
 }
+/// `pyjitpl.py:1094-1118 opimpl_jit_force_quasi_immutable` for the module
+/// namespace's `version?` (`celldict.py:34 _immutable_fields_ = ["version?"]`),
+/// asked ahead of an opaque STORE_NAME / STORE_GLOBAL / DELETE_NAME /
+/// DELETE_GLOBAL residual.
+///
+/// ```text
+///  mutatebox = self.execute_with_descr(rop.GETFIELD_GC_R, mutatefielddescr, box)
+///  if mutatebox.nonnull():
+///      do_force_quasi_immutable(cpu, box.getref_base(), mutatefielddescr)
+///      raise SwitchToBlackhole(Counters.ABORT_FORCE_QUASIIMMUT)
+///  self.metainterp.generate_guard(rop.GUARD_ISNULL, mutatebox, resumepc=orgpc)
+/// ```
+///
+/// Upstream meets the rtyper's `jit_force_quasi_immutable` inside the traced
+/// write (`rclass.py:715-718`) and abandons the attempt cheaply, which is why
+/// PyPy reports thousands of `abort: force quasi-immut` on this program shape
+/// and still compiles its loops. Pyre's write runs inside a frontend helper the
+/// walker never looks into, so the walker asks the same question here instead of
+/// meeting the operation; without it the trace completes carrying a `version`
+/// constant that is already stale, and the optimizer's revalidation then
+/// discards the loop *and* every interpreter entry bridge.
+///
+/// `is_installed()` is `mutatebox.nonnull()`; the bump predicate is
+/// [`pyre_object::celldict::store_would_bump_version`], the side-effect-free
+/// twin of `write_cell`, because only the write that replaces the stored
+/// pointer reaches `mutated()` (`celldict.py:80-90`) — an in-place cell write
+/// leaves `version` alone and a hot module-scope loop must keep its trace.
+///
+/// Deliberately NO `GUARD_ISNULL` arm on the not-installed path. Upstream's
+/// guard licenses the traced *inline* setfield that bypasses the invalidation
+/// function (`pyjitpl.py:1095-1102`); pyre's write stays inside the residual,
+/// which runs `notify_version_watchers` itself at runtime, so there is no
+/// bypass to license.
+///
+/// Fires BEFORE the residual executes, so the write is still entirely ahead of
+/// the walk — that is what lets the abort resume the interpreter at this opcode
+/// and have the write happen exactly once.  Everything the walk applied EARLIER
+/// stays applied: [`DispatchError::ForceQuasiImmutable`] carries the abort to
+/// the flush leg that commits the journal instead of replaying the region.
+fn try_walker_force_quasi_immut_namespace_write<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    helper: majit_ir::PyreHelperKind,
+    r_args: &[OpRef],
+) -> Option<()> {
+    use majit_ir::PyreHelperKind as K;
+    let is_store = matches!(helper, K::StoreName | K::StoreGlobal);
+    if !is_store && !matches!(helper, K::DeleteName | K::DeleteGlobal) {
+        return None;
+    }
+    let (&frame_opref, &name_opref) = (r_args.first()?, r_args.get(1)?);
+    let (
+        Some(majit_ir::Value::Ref(majit_ir::GcRef(frame_ptr))),
+        Some(majit_ir::Value::Ref(majit_ir::GcRef(w_name_ptr))),
+    ) = (
+        ctx.trace_ctx.box_value(frame_opref),
+        ctx.trace_ctx.box_value(name_opref),
+    )
+    else {
+        return None;
+    };
+    if frame_ptr == 0 || w_name_ptr == 0 {
+        return None;
+    }
+    let frame = unsafe { &*(frame_ptr as *const pyre_interpreter::pyframe::PyFrame) };
+    let w_globals = frame.get_w_globals();
+    if w_globals.is_null() {
+        return None;
+    }
+    // A `*_NAME` opcode writes `w_locals`; only a module frame — where
+    // `w_locals` aliases `w_globals` — touches the namespace the folds pin.
+    // Same test as `try_walker_load_name_cell_fold`.
+    if matches!(helper, K::StoreName | K::DeleteName) {
+        let w_locals = frame.get_w_locals();
+        if !w_locals.is_null() && !std::ptr::eq(w_locals, w_globals) {
+            return None;
+        }
+    }
+    let strategy = unsafe { pyre_object::dictmultiobject::w_module_dict_get_strategy(w_globals) };
+    // `mutatebox.nonnull()` — nothing is watching, so there is nothing to
+    // abandon the trace for. The write still runs its own invalidation.
+    if !unsafe {
+        pyre_object::dictmultiobject::module_dict_strategy_version_qmut_installed(strategy)
+    } {
+        return None;
+    }
+    let name =
+        unsafe { pyre_object::unicodeobject::w_str_get_value(w_name_ptr as pyre_object::PyObjectRef) };
+    let slot = crate::state::module_dict_cell_slot_direct(w_globals, name);
+    let bumps = if is_store {
+        let &value_opref = r_args.get(2)?;
+        let Some(majit_ir::Value::Ref(majit_ir::GcRef(value_ptr))) =
+            ctx.trace_ctx.box_value(value_opref)
+        else {
+            return None;
+        };
+        if value_ptr == 0 {
+            return None;
+        }
+        let cell = slot.and_then(|s| crate::state::module_dict_cell_value_direct(w_globals, s));
+        unsafe {
+            pyre_object::celldict::store_would_bump_version(
+                cell,
+                value_ptr as pyre_object::PyObjectRef,
+            )
+        }
+    } else {
+        // `celldict.py:106-126 delitem` reaches `mutated()` only after a
+        // successful removal — `delitem_str` returns early on a missing key.
+        slot.is_some()
+    };
+    if !bumps {
+        return None;
+    }
+    // pyjitpl.py:1113-1115: the tracer performs the invalidation itself and
+    // then abandons the attempt. Idempotent (`quasiimmut.py:47-48`), so the
+    // interpreter re-running the opcode forces nothing a second time.
+    unsafe { pyre_object::dictmultiobject::module_dict_strategy_force_version_qmut(strategy) };
+    // Offer the flush leg the operand stack this opcode began with.  Same
+    // preconditions as the escape latch: a sub-walk's mirror describes the
+    // CALLEE frame, and a bridge walk's abort path never reaches the epilogue
+    // that would adopt the flush.
+    if ctx.vstack_valid && !ctx.fbw_mode.inline_subwalk && !ctx.trace_ctx.is_bridge_trace {
+        fbw_qmut_abort_stack_latch(ctx.vstack_cur_pypc as usize, ctx.vstack_boxes.clone());
+    }
+    Some(())
+}
+
 pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     code: &[u8],
     op: &DecodedOp,
@@ -3886,6 +4043,21 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
                 }
             }
         }
+    }
+
+    // pyjitpl.py:1094-1118 `opimpl_jit_force_quasi_immutable`, asked at the
+    // residual boundary because pyre's namespace write lives inside one.
+    //
+    // Ordered AFTER the cell fold above (a successful in-place fold IS the
+    // no-bump case) and BEFORE `try_execute_residual_call_via_executor`, so
+    // nothing has been applied when the abort fires and the resume re-runs the
+    // whole opcode cleanly. Executing first — the order `do_not_in_trace_call`
+    // uses for its own contract — would double-apply the store or the delete.
+    if ctx.is_authoritative_executor
+        && dst_bank == 'v'
+        && try_walker_force_quasi_immut_namespace_write(ctx, ei.pyre_helper, &r_args).is_some()
+    {
+        return Err(DispatchError::ForceQuasiImmutable { pc: op.pc });
     }
 
     // pyjitpl.py OS_NOT_IN_TRACE guard — see helper docstring

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/vstack_mirror.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/vstack_mirror.rs
@@ -736,6 +736,13 @@ pub(crate) fn step_vstack_mirror<Sym: WalkSym>(ctx: &mut WalkContext<'_, '_, Sym
     if new_pypc == ctx.vstack_cur_pypc {
         return;
     }
+    // The Python-opcode boundary: sample the executed-effect odometer for any
+    // abort leg that resumes the interpreter AT this opcode, which re-executes
+    // it whole (`FBW_OPCODE_ENTRY_EFFECTS`).  Top-level only — a sub-walk's
+    // `py_pc` indexes the callee's code object.
+    if !ctx.fbw_mode.inline_subwalk {
+        fbw_note_opcode_entry_effects(new_pypc as usize);
+    }
     let code = unsafe { &*code_ptr };
     reconcile_vstack_at_boundary(ctx, code, new_pypc, new_depth);
 }

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -3413,6 +3413,7 @@ pub(crate) fn opimpl_getfield_gc_i(ctx: &mut TraceCtx, obj: OpRef, descr: DescrR
                 majit_metainterp::counters::HEAPCACHED_OPS,
             );
         } else {
+            install_quasiimmut_field(ctx, obj, &descr);
             ctx.heap_cache_mut().quasi_immut_now_known(field_index, obj);
             ctx.record_op_with_descr(OpCode::QuasiimmutField, &[obj], descr.clone());
             if ctx.heap_cache_mut().check_and_clear_guard_not_invalidated() {
@@ -3516,6 +3517,7 @@ pub(crate) fn opimpl_getfield_gc_r(ctx: &mut TraceCtx, obj: OpRef, descr: DescrR
                 majit_metainterp::counters::HEAPCACHED_OPS,
             );
         } else {
+            install_quasiimmut_field(ctx, obj, &descr);
             ctx.heap_cache_mut().quasi_immut_now_known(field_index, obj);
             ctx.record_op_with_descr(OpCode::QuasiimmutField, &[obj], descr.clone());
             if ctx.heap_cache_mut().check_and_clear_guard_not_invalidated() {
@@ -4443,6 +4445,7 @@ pub(crate) fn record_quasiimmut_field(ctx: &mut TraceCtx, obj: OpRef, descr: Des
     // captured here; by the time the optimizer runs, the change it is looking
     // for has already happened.
     let constantfieldbox = current_quasiimmut_field_value(ctx, obj, &descr);
+    install_quasiimmut_field(ctx, obj, &descr);
     ctx.heap_cache_mut().quasi_immut_now_known(field_index, obj);
     // Upstream carries the captured value on the per-op `QuasiImmutDescr`
     // (quasiimmut.py:113-159), a descr minted fresh for every recorded
@@ -4455,6 +4458,45 @@ pub(crate) fn record_quasiimmut_field(ctx: &mut TraceCtx, obj: OpRef, descr: Des
     };
     if ctx.heap_cache_mut().check_and_clear_guard_not_invalidated() {
         ctx.set_pending_guard_not_invalidated(Some(ctx.last_traced_pc));
+    }
+}
+
+/// `quasiimmut.py:116-126 get_current_qmut_instance`, reached from
+/// `pyjitpl.py:1081 QuasiImmutDescr(...)` — install the qmut instance at RECORD
+/// time.
+///
+/// Upstream builds a `QuasiImmutDescr` for every recorded `QUASIIMMUT_FIELD`,
+/// and its `__init__` installs the instance. It therefore exists for the rest of
+/// the recording, which is what arms `opimpl_jit_force_quasi_immutable`'s
+/// `mutatebox.nonnull()` (`pyjitpl.py:1112`) for a write reached later in that
+/// same trace.
+///
+/// Pyre installed only from `register_quasi_immutable_deps`
+/// (`pyre-jit/src/eval.rs`), which runs at COMPILE time, and every invalidation
+/// uninstalls — so through a whole recording the field stayed null and no
+/// write-side test could ever fire. This is the read dual of that function and
+/// resolves `(object, field_index)` → owner the same way it does.
+fn install_quasiimmut_field(ctx: &mut TraceCtx, obj: OpRef, descr: &DescrRef) {
+    let Some(majit_ir::Value::Ref(struct_ref)) = ctx.box_value(obj) else {
+        return;
+    };
+    let struct_ptr = struct_ref.0 as i64;
+    if struct_ptr == 0 || struct_ptr == usize::MAX as i64 {
+        return;
+    }
+    // The non-module owner is a `W_TypeObject`; the accessor re-checks
+    // `is_type`, so a descr naming neither owner is a no-op rather than a
+    // mistyped write.
+    unsafe {
+        if descr.index() == crate::descr::module_dict_version_descr().index() {
+            pyre_object::dictmultiobject::module_dict_strategy_install_version_watcher(
+                struct_ptr as *mut pyre_object::celldict::ModuleDictStrategy,
+            );
+        } else {
+            pyre_object::typeobject::w_type_install_quasi_immut(
+                struct_ptr as pyre_object::PyObjectRef,
+            );
+        }
     }
 }
 

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -3200,6 +3200,17 @@ pub(crate) fn note_root_trace_too_long(
     }
 }
 
+/// Name `Counters.ABORT_FORCE_QUASIIMMUT` as the reason for the abort the
+/// walker is returning (`pyjitpl.py:1116`), so the single `aborted_tracing`
+/// that follows counts it under `profiler.abort_force_quasiimmut` instead of
+/// the `Generic` catch-all.
+pub(crate) fn note_force_quasi_immut_abort() {
+    let (driver, _) = crate::driver::driver_pair();
+    driver
+        .meta_interp_mut()
+        .stage_abort_reason(majit_metainterp::counters::ABORT_FORCE_QUASIIMMUT);
+}
+
 pub(crate) fn wrapfloat(ctx: &mut TraceCtx, value: OpRef) -> OpRef {
     emit_box_float_inline(ctx, value, w_float_size_descr(), float_floatval_descr())
 }

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -4073,6 +4073,83 @@ fn run_perfn_walk<Sym: WalkSym>(
             }
         }
 
+        // `SwitchToBlackhole(ABORT_FORCE_QUASIIMMUT)` (pyjitpl.py:1116) landed
+        // as a resume, not a replay.  Upstream's blackhole picks up at the
+        // `-live-` in front of the forcing write with every earlier residual
+        // already applied and never re-runs one; the walker's equivalent is to
+        // keep the journal and resume the interpreter AT the Python opcode the
+        // write belongs to, which has not run yet (the abort fires before the
+        // residual executes).  Falling through to the plain `Abort` instead
+        // rolls the journal back and replays the walked region from its start,
+        // re-executing every residual the walk already ran.
+        if let Err(crate::jitcode_dispatch::DispatchError::ForceQuasiImmutable { pc }) = &walk_result
+        {
+            let abort_jit_pc = *pc;
+            // A recorded-but-unexecuted residual is applied only by the replay
+            // this leg removes, so committing would DROP it; a sub-walk abort's
+            // resume coordinate names the callee's code object, not `sym`'s.
+            if crate::jitcode_dispatch::fbw_has_unjournaled_effect()
+                || session.borrow().abort_in_subwalk
+            {
+                if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
+                    eprintln!(
+                        "[fbw-qmut-flush] declined at abort_jit_pc={abort_jit_pc} \
+                         (unjournaled effect or inline sub-walk) — legacy replay kept"
+                    );
+                }
+            } else if let Some((resume_py_pc, oprefs)) =
+                crate::jitcode_dispatch::fbw_qmut_abort_stack_take()
+            {
+                // The resume RE-RUNS this opcode (`last_instr = pc - 1`), so it
+                // owes the `Rewind` proof: nothing of it may have been applied
+                // yet.  The sample is taken at the opcode boundary itself, and
+                // its absence (no boundary crossed, or a different opcode)
+                // leaves the leg unprovable — `walk_end_resume_provable`
+                // declines and the legacy replay stands.
+                let resume = match crate::jitcode_dispatch::fbw_opcode_entry_effects_at(
+                    resume_py_pc,
+                ) {
+                    Some(effects_at_resume_point) => WalkEndResume::Rewind {
+                        effects_at_resume_point,
+                    },
+                    None => WalkEndResume::RewindUnproven,
+                };
+                if !walk_end_resume_provable(resume) {
+                    if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
+                        eprintln!(
+                            "[fbw-qmut-flush] declined at resume_py_pc={resume_py_pc} \
+                             (opcode already applied an effect, or no entry sample) \
+                             — legacy replay kept"
+                        );
+                    }
+                } else if crate::jitcode_dispatch::flush_qmut_abort_state(
+                    ctx,
+                    cf_addr,
+                    resume_py_pc,
+                    &oprefs,
+                ) {
+                    if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
+                        eprintln!(
+                            "[fbw-qmut-flush] COMMIT abort_jit_pc={abort_jit_pc} \
+                             resume_py_pc={resume_py_pc}"
+                        );
+                    }
+                    let committed = commit_walk_end(WalkEndCommitLeg::AbortPc, resume);
+                    debug_assert!(committed, "provability re-checked after a pure flush");
+                } else if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
+                    eprintln!(
+                        "[fbw-qmut-flush] declined at resume_py_pc={resume_py_pc} \
+                         (operand slot without concrete / depth / lastblock) — legacy replay kept"
+                    );
+                }
+            } else if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
+                eprintln!(
+                    "[fbw-qmut-flush] declined at abort_jit_pc={abort_jit_pc} \
+                     (no operand-stack mirror latched) — legacy replay kept"
+                );
+            }
+        }
+
         // #32 S2: a kept-stack branch guard whose not-taken arm cannot be
         // restored for the COMPILED trace aborts (`AbortPermanent` for the
         // unrestorable-Ref shape, decline + `Abort` for the depth>1
@@ -5137,6 +5214,13 @@ fn full_body_walk_trace<Sym: WalkSym>(
                 | DE::NonStandardVableFinishPortalUnsupported { .. }
                 | DE::LoopBearingCalleeInlineUnsupported { .. }
                 | DE::UnfoldableListAppendResidualUnsupported { .. }
+                // Plain, retryable: `ABORT_FORCE_QUASIIMMUT` abandons THIS
+                // attempt because the version was live when the walk met the
+                // write.  The forcing already ran, so the next attempt finds a
+                // stabilised namespace and traces — the reason PyPy reports
+                // thousands of these and still compiles the loop.  Retiring the
+                // location would be strictly wrong.
+                | DE::ForceQuasiImmutable { .. }
                 | DE::ResidualCallArgUnbound { .. } => TraceAction::Abort,
                 // #68 multiframe: a data-dependent
                 // `goto_if_not` whose branch input is not concrete at trace-time

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -4082,7 +4082,8 @@ fn run_perfn_walk<Sym: WalkSym>(
         // residual executes).  Falling through to the plain `Abort` instead
         // rolls the journal back and replays the walked region from its start,
         // re-executing every residual the walk already ran.
-        if let Err(crate::jitcode_dispatch::DispatchError::ForceQuasiImmutable { pc }) = &walk_result
+        if let Err(crate::jitcode_dispatch::DispatchError::ForceQuasiImmutable { pc }) =
+            &walk_result
         {
             let abort_jit_pc = *pc;
             // A recorded-but-unexecuted residual is applied only by the replay
@@ -4106,14 +4107,13 @@ fn run_perfn_walk<Sym: WalkSym>(
                 // its absence (no boundary crossed, or a different opcode)
                 // leaves the leg unprovable — `walk_end_resume_provable`
                 // declines and the legacy replay stands.
-                let resume = match crate::jitcode_dispatch::fbw_opcode_entry_effects_at(
-                    resume_py_pc,
-                ) {
-                    Some(effects_at_resume_point) => WalkEndResume::Rewind {
-                        effects_at_resume_point,
-                    },
-                    None => WalkEndResume::RewindUnproven,
-                };
+                let resume =
+                    match crate::jitcode_dispatch::fbw_opcode_entry_effects_at(resume_py_pc) {
+                        Some(effects_at_resume_point) => WalkEndResume::Rewind {
+                            effects_at_resume_point,
+                        },
+                        None => WalkEndResume::RewindUnproven,
+                    };
                 if !walk_end_resume_provable(resume) {
                     if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
                         eprintln!(

--- a/pyre/pyre-jit/src/jit/flatten.rs
+++ b/pyre/pyre-jit/src/jit/flatten.rs
@@ -4318,7 +4318,10 @@ where
         ctx.delete_name_fn_idx,
         vec![frame_operand, name_operand],
         CallFlavor::Plain,
-        majit_ir::PyreHelperKind::None,
+        // Tagged so the walker can run the `jit_force_quasi_immutable` test
+        // (`pyjitpl.py:1094-1118`) before executing the delete — `delitem_str`
+        // calls `mutated()` on a successful removal.
+        majit_ir::PyreHelperKind::DeleteName,
     ))
 }
 
@@ -4342,7 +4345,8 @@ where
         ctx.delete_global_fn_idx,
         vec![frame_operand, name_operand],
         CallFlavor::Plain,
-        majit_ir::PyreHelperKind::None,
+        // See [`lower_delete_name_hlop_to_insn`].
+        majit_ir::PyreHelperKind::DeleteGlobal,
     ))
 }
 

--- a/pyre/pyre-object/src/celldict.rs
+++ b/pyre/pyre-object/src/celldict.rs
@@ -369,10 +369,7 @@ unsafe fn classify_cell_write(w_cell: Option<PyObjectRef>, w_value: PyObjectRef)
 ///
 /// # Safety
 /// `w_cell` (when `Some`) and `w_value` must point at live objects.
-pub unsafe fn store_would_bump_version(
-    w_cell: Option<PyObjectRef>,
-    w_value: PyObjectRef,
-) -> bool {
+pub unsafe fn store_would_bump_version(w_cell: Option<PyObjectRef>, w_value: PyObjectRef) -> bool {
     matches!(
         classify_cell_write(w_cell, w_value),
         CellWrite::StoreBare | CellWrite::Replace

--- a/pyre/pyre-object/src/celldict.rs
+++ b/pyre/pyre-object/src/celldict.rs
@@ -292,29 +292,91 @@ pub unsafe fn write_cell(w_cell: Option<PyObjectRef>, w_value: PyObjectRef) -> O
     // prebuilt-family root walk; record the store so the next minor
     // collection rescans it (gc_roots.rs prebuilt-root write tracking).
     crate::gc_roots::mark_prebuilt_roots_dirty();
+    match classify_cell_write(w_cell, w_value) {
+        CellWrite::InPlaceObject(cell) => {
+            (*(cell as *mut ObjectMutableCell)).w_value = w_value;
+            None
+        }
+        CellWrite::InPlaceInt(cell, intvalue) => {
+            (*(cell as *mut IntMutableCell)).intvalue = intvalue;
+            None
+        }
+        CellWrite::Unchanged => None,
+        CellWrite::StoreBare => Some(w_value),
+        CellWrite::Replace => {
+            if crate::listobject::is_plain_int1(w_value) {
+                return Some(w_int_mutable_cell_new(crate::listobject::plain_int_w(
+                    w_value,
+                )));
+            }
+            Some(w_object_mutable_cell_new(w_value))
+        }
+    }
+}
+
+/// What [`write_cell`] will do with the slot.
+///
+/// Split out from the mutation so the tracer's bump predicate
+/// ([`store_would_bump_version`]) cannot drift from the write it predicts.
+enum CellWrite {
+    /// Write through the existing cell; the stored pointer, and therefore
+    /// `version?`, stands.
+    InPlaceObject(PyObjectRef),
+    InPlaceInt(PyObjectRef, i64),
+    /// The slot already holds this exact value.
+    Unchanged,
+    /// No cell yet: store the value itself, without a level of indirection.
+    /// A later write over it is what promotes the slot to a cell.
+    StoreBare,
+    /// A cell is there but cannot take the value in place, so the slot gets a
+    /// fresh one.
+    Replace,
+}
+
+/// The decision half of [`write_cell`]; performs no store.
+unsafe fn classify_cell_write(w_cell: Option<PyObjectRef>, w_value: PyObjectRef) -> CellWrite {
     let Some(w_cell) = w_cell else {
         // attribute does not exist at all, write it without a cell first
-        return Some(w_value);
+        return CellWrite::StoreBare;
     };
     if is_object_mutable_cell(w_cell) {
-        (*(w_cell as *mut ObjectMutableCell)).w_value = w_value;
-        return None;
+        return CellWrite::InPlaceObject(w_cell);
     }
     if is_int_mutable_cell(w_cell) && crate::listobject::is_plain_int1(w_value) {
-        (*(w_cell as *mut IntMutableCell)).intvalue = crate::listobject::plain_int_w(w_value);
-        return None;
+        return CellWrite::InPlaceInt(w_cell, crate::listobject::plain_int_w(w_value));
     }
     // If the new value and the current value are the same, don't
     // create a level of indirection, or mutate the version.
     if std::ptr::eq(w_cell, w_value) {
-        return None;
+        return CellWrite::Unchanged;
     }
-    if crate::listobject::is_plain_int1(w_value) {
-        return Some(w_int_mutable_cell_new(crate::listobject::plain_int_w(
-            w_value,
-        )));
-    }
-    Some(w_object_mutable_cell_new(w_value))
+    CellWrite::Replace
+}
+
+/// Whether storing `w_value` over the raw slot contents `w_cell` would reach
+/// `mutated()`, i.e. would assign the `version?` quasi-immutable field.
+///
+/// This is the tracer's stand-in for the rtyper-inserted
+/// `jit_force_quasi_immutable` that upstream places on that write
+/// (`rclass.py:715-718`). Pyre's store runs inside a residual helper the walker
+/// never looks into, so the walker has to ask the question ahead of the call
+/// instead of meeting the operation inside it. Side-effect-free by
+/// construction — it only classifies.
+///
+/// An in-place cell write must answer `false`: it leaves the stored pointer
+/// alone, so `version` stays valid and a hot module-scope loop must keep its
+/// compiled trace.
+///
+/// # Safety
+/// `w_cell` (when `Some`) and `w_value` must point at live objects.
+pub unsafe fn store_would_bump_version(
+    w_cell: Option<PyObjectRef>,
+    w_value: PyObjectRef,
+) -> bool {
+    matches!(
+        classify_cell_write(w_cell, w_value),
+        CellWrite::StoreBare | CellWrite::Replace
+    )
 }
 
 /// `pypy/objspace/std/celldict.py:20-21 VersionTag`:
@@ -683,6 +745,27 @@ impl ModuleDictStrategy {
     /// `JitCellToken.invalidation_flag()`.
     pub fn register_version_watcher(&self, flag: &std::sync::Arc<std::sync::atomic::AtomicBool>) {
         self.version_watchers.register_loop_token(flag);
+    }
+
+    /// `quasiimmut.py:116-126 get_current_qmut_instance` alone — install the
+    /// instance while the trace is still recording, so a `mutated()` reached
+    /// later in the same trace finds the field non-null.
+    pub fn install_version_watcher(&self) {
+        self.version_watchers.ensure_installed();
+    }
+
+    /// `pyjitpl.py:1112 mutatebox.nonnull()` — whether some trace or loop is
+    /// watching `version?` right now.
+    pub fn version_qmut_installed(&self) -> bool {
+        self.version_watchers.is_installed()
+    }
+
+    /// `quasiimmut.py:46-51 do_force_quasi_immutable`, which the tracer calls
+    /// itself before aborting (`pyjitpl.py:1113-1115`). Idempotent: a field
+    /// already taken returns early, so the interpreter re-running the opcode
+    /// after the abort forces nothing a second time.
+    pub fn force_version_qmut(&self) {
+        self.version_watchers.invalidate();
     }
 
     /// Invalidate every loop watching `version`

--- a/pyre/pyre-object/src/dictmultiobject.rs
+++ b/pyre/pyre-object/src/dictmultiobject.rs
@@ -1151,6 +1151,48 @@ pub unsafe fn module_dict_strategy_register_version_watcher(
     (*strategy).register_version_watcher(flag);
 }
 
+/// Install this strategy's `version?` qmut instance without registering a loop
+/// (`quasiimmut.py:116-126 get_current_qmut_instance`).
+///
+/// The recording-time half, for the reason spelled out on
+/// [`crate::typeobject::w_type_install_quasi_immut`].
+///
+/// # Safety
+/// `strategy` must be null or point at a valid `ModuleDictStrategy`.
+pub unsafe fn module_dict_strategy_install_version_watcher(
+    strategy: *mut crate::celldict::ModuleDictStrategy,
+) {
+    if strategy.is_null() {
+        return;
+    }
+    (*strategy).install_version_watcher();
+}
+
+/// `pyjitpl.py:1112 mutatebox.nonnull()` for this strategy's `version?`.
+///
+/// # Safety
+/// `strategy` must be null or point at a valid `ModuleDictStrategy`.
+pub unsafe fn module_dict_strategy_version_qmut_installed(
+    strategy: *const crate::celldict::ModuleDictStrategy,
+) -> bool {
+    !strategy.is_null() && (*strategy).version_qmut_installed()
+}
+
+/// `quasiimmut.py:46-51 do_force_quasi_immutable` for this strategy's
+/// `version?` — the invalidation the tracer performs itself before aborting
+/// (`pyjitpl.py:1113-1115`).
+///
+/// # Safety
+/// `strategy` must be null or point at a valid `ModuleDictStrategy`.
+pub unsafe fn module_dict_strategy_force_version_qmut(
+    strategy: *const crate::celldict::ModuleDictStrategy,
+) {
+    if strategy.is_null() {
+        return;
+    }
+    (*strategy).force_version_qmut();
+}
+
 /// Allocate a new empty dict per `dictmultiobject.py:67-69
 /// allocate_and_init_instance`:
 ///

--- a/pyre/pyre-object/src/quasiimmut.rs
+++ b/pyre/pyre-object/src/quasiimmut.rs
@@ -150,6 +150,33 @@ impl QuasiImmutField {
         !self.ptr.load(Ordering::Acquire).is_null()
     }
 
+    /// `quasiimmut.py:116-126 get_current_qmut_instance` on its own — create the
+    /// instance when the field is still null and register nothing.
+    ///
+    /// Upstream installs while RECORDING the read: `pyjitpl.py:1081` builds a
+    /// `QuasiImmutDescr`, whose `__init__` calls `get_current_qmut_instance`,
+    /// which `bh_setfield_gc_r`s a fresh instance into the hidden field
+    /// (`quasiimmut.py:26`). No loop token exists yet at that point; the token
+    /// joins later through [`Self::register_loop_token`].
+    ///
+    /// Pyre only ever had the fused create-and-register, driven from compile
+    /// time (`pyre-jit/src/eval.rs register_quasi_immutable_deps`). Since every
+    /// invalidation uninstalls, the field was null for the whole of tracing, so
+    /// the write path's [`Self::is_installed`] — pyre's `mutatebox.nonnull()` —
+    /// could never fire during a recording.
+    pub fn ensure_installed(&self) {
+        // The null test is the fast path a hot read must not pay a lock for.
+        if !self.ptr.load(Ordering::Acquire).is_null() {
+            return;
+        }
+        let _guard = self.lock.lock();
+        // Re-read under the lock: another thread may have installed it.
+        if self.ptr.load(Ordering::Acquire).is_null() {
+            let qmut_ptr = Box::into_raw(Box::new(QuasiImmut::new()));
+            self.ptr.store(qmut_ptr, Ordering::Release);
+        }
+    }
+
     /// `quasiimmut.py:116-126 get_current_qmut_instance` followed by
     /// `:72-75 register_loop_token`: create the instance if the field is still
     /// null, then record this loop's invalidation flag on it.

--- a/pyre/pyre-object/src/quasiimmut.rs
+++ b/pyre/pyre-object/src/quasiimmut.rs
@@ -166,15 +166,23 @@ impl QuasiImmutField {
     /// could never fire during a recording.
     pub fn ensure_installed(&self) {
         // The null test is the fast path a hot read must not pay a lock for.
-        if !self.ptr.load(Ordering::Acquire).is_null() {
+        if self.is_installed() {
             return;
         }
         let _guard = self.lock.lock();
-        // Re-read under the lock: another thread may have installed it.
-        if self.ptr.load(Ordering::Acquire).is_null() {
-            let qmut_ptr = Box::into_raw(Box::new(QuasiImmut::new()));
-            self.ptr.store(qmut_ptr, Ordering::Release);
+        let _ = self.locked_get_current_qmut_instance();
+    }
+
+    /// `quasiimmut.py:116-126 get_current_qmut_instance`.  Caller holds
+    /// [`Self::lock`].
+    fn locked_get_current_qmut_instance(&self) -> *mut QuasiImmut {
+        let qmut_ptr = self.ptr.load(Ordering::Acquire);
+        if !qmut_ptr.is_null() {
+            return qmut_ptr;
         }
+        let fresh = Box::into_raw(Box::new(QuasiImmut::new()));
+        self.ptr.store(fresh, Ordering::Release);
+        fresh
     }
 
     /// `quasiimmut.py:116-126 get_current_qmut_instance` followed by
@@ -182,11 +190,7 @@ impl QuasiImmutField {
     /// null, then record this loop's invalidation flag on it.
     pub fn register_loop_token(&self, flag: &Arc<AtomicBool>) {
         let _guard = self.lock.lock();
-        let mut qmut_ptr = self.ptr.load(Ordering::Acquire);
-        if qmut_ptr.is_null() {
-            qmut_ptr = Box::into_raw(Box::new(QuasiImmut::new()));
-            self.ptr.store(qmut_ptr, Ordering::Release);
-        }
+        let qmut_ptr = self.locked_get_current_qmut_instance();
         // Safe: the pointer is only ever cleared under the same lock, and the
         // instance is freed by whoever wins that clear.
         unsafe { (*qmut_ptr).register_loop_token(flag) };

--- a/pyre/pyre-object/src/typeobject.rs
+++ b/pyre/pyre-object/src/typeobject.rs
@@ -782,6 +782,26 @@ pub unsafe fn w_type_register_quasi_immut_watcher(
         .register_loop_token(flag);
 }
 
+/// Install this type's `_version_tag?` qmut instance without registering a
+/// loop (`quasiimmut.py:116-126 get_current_qmut_instance`).
+///
+/// The recording half of the protocol: upstream's `QuasiImmutDescr.__init__`
+/// (`pyjitpl.py:1081`) installs while the trace is still being recorded, so a
+/// write reached later in that same trace sees a non-null `mutate_*` field and
+/// aborts the attempt. [`w_type_register_quasi_immut_watcher`] is the compile-
+/// time half and runs far too late to arm that test.
+///
+/// # Safety
+/// `obj` must be null or point at a valid `W_TypeObject`.
+pub unsafe fn w_type_install_quasi_immut(obj: PyObjectRef) {
+    if obj.is_null() || !is_type(obj) {
+        return;
+    }
+    (*(obj as *const W_TypeObject))
+        .quasi_immut_watchers
+        .ensure_installed();
+}
+
 /// Revoke every loop that baked this type's `version_tag` as a constant
 /// (`quasiimmut.py:129-134 make_invalidation_function._invalidate_now`).
 ///


### PR DESCRIPTION
`record_quasiimmut_field` captured `get_current_constant_fieldvalue` but never
called `get_current_qmut_instance`. Upstream's `QuasiImmutDescr.__init__`
(`quasiimmut.py:119-125`) does both, and the second half is load-bearing: it
*installs* the hidden `mutate_<name>` field when it is null.

So through the whole recording pyre's `QuasiImmutField` stayed null and every
`mutated()` took the `is_installed() == false` early return — the version
advanced and nothing was forced. The trace completed with a stale baked
constant, and #956's optimizer backstop caught it later at
`compile_entry_bridge`: `ceb_invalidloop 2396/2396` → no front door →
`cl_hct_giveup` 1198 `ABORT_BAD_LOOP`.

Measured on `exception_reraise_tb_depth_jitstress`: 301 sweeps against 1198
revalidation failures.

## What changed

**Install at the record.** `QuasiImmutField::ensure_installed()` is
`get_current_qmut_instance` with no token to register, reached from
`record_quasiimmut_field` and the two generic quasi-immut getfield arms.
It shares `locked_get_current_qmut_instance` with `register_loop_token`
instead of each open-coding the null-check-and-create.

**Ask upstream's question at the write.** The rtyper inserts
`jit_force_quasi_immutable(vinst, 'mutate_<field>')` *before* every setfield to
a `?` field (`rclass.py:712-718`), and `opimpl_jit_force_quasi_immutable`
(`pyjitpl.py:1094-1118`) raises `SwitchToBlackhole(ABORT_FORCE_QUASIIMMUT)` when
the mutate field is non-null. Pyre residualises the module-namespace store, so
the walker asks the same question *before* executing that residual —
recognising `bh_store_name_fn` / `bh_delete_name_fn` by their `PyreHelperKind`
tag, and answering `mutatebox.nonnull()` from the module dict strategy plus
`celldict::store_would_bump_version`. Asking before the residual runs means the
write still happens exactly once, in the interpreter.

`PyreHelperKind::DeleteName` / `DeleteGlobal` are added so the delete lowering
carries a tag instead of `None`.

**Land the abort.** The new `DispatchError::ForceQuasiImmutable { pc }` lands on
the shared `WalkEndCommitLeg::AbortPc` leg with a `WalkEndResume::Rewind` proof
sampled at the Python-opcode boundary, and takes its operand stack from the
walk's own `vstack_boxes` mirror — the vable shadow's stack region reads NULL
mid-expression, so the leg cannot commit from it. It declines to a plain
replaying abort whenever the effect journal is unflushed, the abort happened in
a subwalk, or the resume point is unprovable.

**Account it.** `MetaInterp::stage_abort_reason` carries the reason from a raise
site that cannot reach `TraceCtx::pending_switch_to_blackhole` (it is
`pub(crate)`, and the walker lives in another crate). `jitdriver.rs`'s
`TraceAction::Abort` arm bypasses `abort_trace` — the only consumer of
`pending_abort_reason` — so its `reason_int` derivation now consults the staged
reason after `stb.reason` and before the `blackhole_if_trace_too_long` fallback.
The staged reason ranks with `stb.reason` because upstream raises at the site
and never reaches the too-long check on that unwind. This is the first site to
raise `ABORT_FORCE_QUASIIMMUT`; it was a dead counter.

## Results

`exception_reraise_tb_depth_jitstress`, one base, one binary, dynasm:

| | loops_compiled | loops_aborted | guard_failures | CPU |
|---|---|---|---|---|
| before | 305 | 1198 | 1199 | 1.45s |
| after | **900** | **7** | **1798** | **0.46s** |

`cl_hct_giveup` / `ct_entry_bridge_failed` 1198 → 0, `wct_declined` 2396 → 0,
`abort: force quasi-immut` 0 → 7 with `abort: compiling` 7 → 0. Cranelift
reaches the same 900/7/1798. Output is byte-identical to `PYRE_NO_JIT=1`, and
the eight global-write fixtures are within noise. Baselines re-recorded for the
fixture on all three backends (wasm 1198 → 7).

### Why 7 and not PyPy's 2100

`PYPYLOG=jit-summary:log pypy3 <fixture>` reports `abort: force quasi-immut:
2100`. PyPy *inlines* `celldict.py setitem_str`/`delitem` into the trace, so each
write is a traced `jit_force_quasi_immutable` op and every one aborts. Pyre
residualises the same code, so one residual covers a whole store and the walk
aborts once per force it observes. Fewer aborts at the same correctness is the
expected shape here, not a sign the hook misses events.

## Verification

`pyre/check.py` on dynasm and cranelift: 4 failed / 364 passed each, identical
failure sets. The four (`closure_freevar_branch_resume`,
`exception_args_virtual`, `exception_multi_handler_warmup`,
`list_length_hint_validate`) are a strict subset of `main`'s own eight
jit-stats-floor failures at f3bddb31f28 — same numeric deltas — and the
quasi-immut abort fires zero times in all four.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of compiled code when module or global names are deleted or updated.
  - Prevented stale optimized assumptions from causing incorrect execution.
  - Improved recovery when optimized execution encounters invalidated runtime state.

- **Performance**
  - Enabled safer continuation of tracing after recoverable invalidations, reducing unnecessary replay and disabling of optimized locations.

- **Tests**
  - Updated JIT benchmark results to reflect improved loop compilation and revised abort behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->