### PR TITLE
shutdown, gc, jit: skip the no-op teardown collection, PYRE_GC_DIAG, direct forwarding query

### DIFF
--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -2506,10 +2506,12 @@ impl MiniMarkGC {
         // incminimark.py:2717 collect_roots: root_walker.walk_roots()
         // walks the same root sets as minor collection.
         let mut result = Vec::new();
-        let roots: Vec<*mut GcRef> = self.roots.roots.iter().copied().collect();
-        for root_ptr in roots {
-            let gcref = unsafe { *root_ptr };
-            result.push(gcref);
+        // Read the registered roots in place. The minor path copies this list
+        // first because `drag_out_root` takes `&mut self` while it walks; here
+        // the walk only reads, so the copy would be one allocation and one pass
+        // over every registered root per collection for nothing.
+        for &root_ptr in &self.roots.roots {
+            result.push(unsafe { *root_ptr });
         }
 
         let walk_all_mutators = crate::gc_sync::mutators_quiesced();

--- a/majit/majit-gc/src/lib.rs
+++ b/majit/majit-gc/src/lib.rs
@@ -2148,6 +2148,10 @@ pub fn disarm_published_nursery() {
 }
 
 /// Whether `addr` is a live object in the active backend's nursery.
+///
+/// `#[inline]`: the armed path is a two-word range compare, and the callers
+/// that matter are the per-pin / per-barrier queries next door.
+#[inline]
 pub fn gc_is_nursery_object(addr: usize) -> bool {
     if PUBLISHED_NURSERY_ARMED.load(std::sync::atomic::Ordering::Acquire) {
         // `is_nursery_object_start` = `is_valid_gc_object && is_in_nursery`.
@@ -2172,6 +2176,7 @@ pub fn gc_is_nursery_object(addr: usize) -> bool {
 /// Return the current address for a managed object without treating it as a
 /// root. During a minor collection this follows an already-installed nursery
 /// forwarding pointer; otherwise it returns `addr` unchanged.
+#[inline]
 pub fn gc_current_object_address(addr: usize) -> usize {
     // Only a nursery address can carry a forwarding stub: `_trace_drag_out`
     // installs one at the young object's old address, and the major collection

--- a/majit/majit-gc/src/minimarkpage.rs
+++ b/majit/majit-gc/src/minimarkpage.rs
@@ -490,6 +490,7 @@ impl ArenaCollection {
     /// live blocks from free/uninitialized bytes inside a live arena.  The
     /// allocator's bucketed arena lists remain the source of allocation state;
     /// this sorted flat index serves pyre's arbitrary-word membership query.
+    #[inline]
     pub fn contains(&self, addr: usize) -> bool {
         let index = self
             .arena_ranges

--- a/majit/majit-gc/src/oldgen.rs
+++ b/majit/majit-gc/src/oldgen.rs
@@ -269,8 +269,20 @@ impl OldGen {
 
     /// Arena membership is intentionally an address-range answer, not a live
     /// block answer.  Rawmalloced objects retain exact payload membership.
+    ///
+    /// Split so the arena range test can inline into the caller and the payload
+    /// set cannot. Major marking asks this question once per root and once per
+    /// traced edge, and the arena answer settles almost all of them; keeping the
+    /// hashed lookup in the same body made the whole thing too large to inline,
+    /// so every edge paid a call.
+    #[inline]
     pub fn contains(&self, obj_addr: usize) -> bool {
-        self.ac.contains(obj_addr) || self.rawmalloced_payloads.contains(&obj_addr)
+        self.ac.contains(obj_addr) || self.rawmalloced_contains(obj_addr)
+    }
+
+    #[inline(never)]
+    fn rawmalloced_contains(&self, obj_addr: usize) -> bool {
+        !self.rawmalloced_payloads.is_empty() && self.rawmalloced_payloads.contains(&obj_addr)
     }
 
     pub fn mark_visited(obj_addr: usize) {

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -1735,9 +1735,15 @@ impl ProducedShortOp {
             }
         });
         // shortpreamble.py:62-75 keeps `self.res` (the body-visible Box)
-        // distinct from `preamble_op` (the replayed GETFIELD result).  Do not
-        // forward one to the other: `force_op_from_preamble` returns
-        // `PreambleOp.op` and records the replay operation separately.
+        // distinct from `preamble_op` (the replayed GETFIELD result), joining
+        // them only through `PreambleOp(self.res, preamble_op, ...)`.
+        //
+        // DEVIATION: the forwarding below collapses the two onto one position.
+        // It is load-bearing as long as it stands — `force_op_from_preamble_op`
+        // keys `potential_extra_ops` off the forwarded box, and both the
+        // `force_box` pop and the post-hoc force sweep in unroll.rs carry a
+        // second lookup for the cases where the two resolutions disagree. The
+        // forwarding and those compensations have to come out together.
         let op_source = ctx
             .get_box_replacement_operand_opt(source)
             .unwrap_or_else(|| ctx.materialize_operand_at(source));
@@ -1877,9 +1883,11 @@ impl ProducedShortOp {
                 }
             });
         }
-        // shortpreamble.py:80-85 has the same two-Box shape as GETFIELD:
-        // the carried body result and replayed GETARRAYITEM result remain
-        // distinct and are joined only by PreambleOp bookkeeping.
+        // shortpreamble.py:80-85 has the same two-Box shape as GETFIELD: the
+        // carried body result and the replayed GETARRAYITEM result stay
+        // distinct upstream, joined only by PreambleOp bookkeeping. The same
+        // DEVIATION as the GETFIELD path applies — the forwarding below
+        // collapses them.
         let op_source = ctx
             .get_box_replacement_operand_opt(source)
             .unwrap_or_else(|| ctx.materialize_operand_at(source));
@@ -1923,8 +1931,9 @@ impl ProducedShortOp {
             _ => return None,
         };
         // shortpreamble.py:152-159 stores `self.res` as the body-visible Box
-        // and the replay call separately in PreambleOp.  As with HeapOp, the
-        // two identities must not be collapsed.
+        // and the replay call separately in PreambleOp. As with HeapOp the two
+        // identities stay distinct upstream, and as with HeapOp the forwarding
+        // below is the DEVIATION that collapses them.
         let result_opref = *result_map.get(&source)?;
         let _ = result_type;
         let op_source = ctx

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -757,10 +757,17 @@ impl ShortBoxes {
         // `materialize_operand_at(arg)` lookup returns the same key (ptr_eq).
         let arg_res = ctx.materialize_operand_at(arg);
         let mut same_as = Op::new(OpCode::same_as_for_type(arg_type), &[arg_res.clone()]);
-        // ShortInputArg.preamble_op is the freshly renamed InputArg in
-        // RPython.  `ProducedShortOp` stores an OpRc, so majit uses a
-        // non-emitted SAME_AS stand-in whose result position is that renamed
-        // box; `res` above remains the original label box.
+        // `ProducedShortOp` stores an OpRc, so the fresh renamed InputArg
+        // that shortpreamble.py:257 carries as `preamble_op` is stood in for
+        // by this non-emitted SAME_AS. The stand-in stays at the ORIGINAL
+        // label box: exported entries carry original positions, and the
+        // rename is applied at import, where `produce_arg` maps the entry to
+        // its `short_inputargs` slot through `label_arg_idx`.
+        //
+        // Moving it to `renamed` splits the two halves of that contract —
+        // metadata stays seeded at the original while the replay consumes it
+        // from `preamble_op.pos` — and an input short box then loses its
+        // exported info and guards.
         same_as.pos.set(arg);
         // shortpreamble.py:259 `self.potential_ops[box] = ShortInputArg(...)`
         // — keyed by the label-arg Box itself; `arg_res` is its canonical

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -5002,20 +5002,32 @@ pub(crate) fn try_walker_inline_user_binop<Sym: WalkSym>(
         return Ok(None);
     }
 
+    // Name every bail, as the CallFn inline path does: a BINARY_OP that stays
+    // residual costs a full interpreter dispatch per execution, and without a
+    // reason line the only observable is the runtime.
+    macro_rules! decline {
+        ($why:expr) => {{
+            if std::env::var_os("PYRE_FBW_INLINE_DIAG").is_some() {
+                eprintln!("[binop-inline-decline] pc={} why={}", op.pc, $why);
+            }
+            return Ok(None);
+        }};
+    }
+
     let Some(op_kind) = pyre_interpreter::runtime_ops::binary_op_from_tag(op_tag) else {
-        return Ok(None);
+        decline!(format_args!("unknown binary op tag {op_tag}"));
     };
     let Some(dunder) = user_binop_forward_dunder(op_kind) else {
-        return Ok(None);
+        decline!(format_args!("no forward dunder for {op_kind:?}"));
     };
 
     let lhs = r_args[0];
     let rhs = r_args[1];
     let Some(concrete_lhs) = walker_concrete_ref_object(ctx, lhs) else {
-        return Ok(None);
+        decline!("lhs has no concrete ref");
     };
     let Some(concrete_rhs) = walker_concrete_ref_object(ctx, rhs) else {
-        return Ok(None);
+        decline!("rhs has no concrete ref");
     };
 
     // A tagged immediate is an exact builtin `int` with C-level operator slots:
@@ -5027,36 +5039,45 @@ pub(crate) fn try_walker_inline_user_binop<Sym: WalkSym>(
         && (pyre_object::tagged_int::is_tagged_int(concrete_lhs)
             || pyre_object::tagged_int::is_tagged_int(concrete_rhs))
     {
-        return Ok(None);
+        decline!("tagged immediate operand");
     }
 
     let w_class = unsafe { (*concrete_lhs).w_class };
     if w_class.is_null() || !unsafe { pyre_object::is_type(w_class) } {
-        return Ok(None);
+        decline!("lhs w_class is not a type");
     }
     let version_tag = unsafe { pyre_object::typeobject::w_type_get_version_tag(w_class) };
     if version_tag == 0 {
-        return Ok(None);
+        decline!(format_args!("lhs class {} has no version tag", unsafe {
+            pyre_object::typeobject::w_type_get_name(w_class)
+        }));
     }
 
     let Some(w_typ_r) = pyre_interpreter::typedef::r#type(concrete_rhs) else {
-        return Ok(None);
+        decline!("rhs has no type");
     };
     if !std::ptr::eq(w_class, w_typ_r.as_ptr())
         && unsafe { pyre_object::typeobject::w_type_issubtype(w_typ_r.as_ptr(), w_class) }
     {
-        return Ok(None);
+        decline!("rhs is a proper subclass; its reflected dunder has priority");
     }
 
     let Some(method) = (unsafe { pyre_interpreter::baseobjspace::lookup_in_type(w_class, dunder) })
     else {
-        return Ok(None);
+        decline!(format_args!("{} has no {dunder}", unsafe {
+            pyre_object::typeobject::w_type_get_name(w_class)
+        }));
     };
     let Some((w_code, nparams, has_closure)) = (unsafe { resolve_inlinable_callee(method) }) else {
-        return Ok(None);
+        decline!(format_args!(
+            "{}.{dunder} is not inlinable Python code",
+            unsafe { pyre_object::typeobject::w_type_get_name(w_class) }
+        ));
     };
     if nparams != 2 {
-        return Ok(None);
+        decline!(format_args!("{}.{dunder} takes {nparams} params", unsafe {
+            pyre_object::typeobject::w_type_get_name(w_class)
+        }));
     }
 
     let arg_concretes = vec![
@@ -5095,7 +5116,9 @@ pub(crate) fn try_walker_inline_user_binop<Sym: WalkSym>(
         None,
     )?
     else {
-        return Ok(None);
+        decline!(format_args!("callee inline of {}.{dunder} declined", unsafe {
+            pyre_object::typeobject::w_type_get_name(w_class)
+        }));
     };
 
     if matches!(inlined.0, DispatchOutcome::Continue) {
@@ -5105,6 +5128,13 @@ pub(crate) fn try_walker_inline_user_binop<Sym: WalkSym>(
             ConcreteValue::Ref(obj)
                 if std::ptr::eq(obj, pyre_object::special::w_not_implemented())
         ) {
+            if std::env::var_os("PYRE_FBW_INLINE_DIAG").is_some() {
+                eprintln!(
+                    "[binop-inline-abort] pc={} why={}.{dunder} returned NotImplemented",
+                    op.pc,
+                    unsafe { pyre_object::typeobject::w_type_get_name(w_class) }
+                );
+            }
             return Err(DispatchError::callee_inline_unsupported(op.pc));
         }
         if !result.is_constant() {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -5116,9 +5116,10 @@ pub(crate) fn try_walker_inline_user_binop<Sym: WalkSym>(
         None,
     )?
     else {
-        decline!(format_args!("callee inline of {}.{dunder} declined", unsafe {
-            pyre_object::typeobject::w_type_get_name(w_class)
-        }));
+        decline!(format_args!(
+            "callee inline of {}.{dunder} declined",
+            unsafe { pyre_object::typeobject::w_type_get_name(w_class) }
+        ));
     };
 
     if matches!(inlined.0, DispatchOutcome::Continue) {

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -338,10 +338,6 @@ fn pyre_object_gc_owns_object_trampoline(addr: usize) -> bool {
     majit_gc::gc_owns_object(addr)
 }
 
-fn pyre_object_gc_current_object_address_trampoline(addr: usize) -> usize {
-    majit_gc::gc_current_object_address(addr)
-}
-
 fn pyre_object_gc_identity_hash_trampoline(addr: usize) -> usize {
     majit_gc::gc_id_or_identityhash(addr)
 }
@@ -3942,9 +3938,6 @@ fn install_pyre_object_hooks() {
         pyre_object_gc_remove_root_trampoline,
     );
     pyre_object::register_gc_owns_object_hook(pyre_object_gc_owns_object_trampoline);
-    pyre_object::register_gc_current_object_address_hook(
-        pyre_object_gc_current_object_address_trampoline,
-    );
     pyre_object::register_gc_write_barrier_hook(pyre_object_gc_write_barrier_trampoline);
     pyre_object::register_gc_write_barrier_managed_hook(
         pyre_object_gc_write_barrier_managed_trampoline,

--- a/pyre/pyre-jit/src/lib.rs
+++ b/pyre/pyre-jit/src/lib.rs
@@ -78,6 +78,28 @@ pub fn wasm_gc_collection_counts() -> (usize, usize) {
     majit_backend_wasm::active_gc_collection_counts()
 }
 
+/// `(minor_collections, major_collections, heap_bytes, nursery_bytes)` for the
+/// process GC, or all zeroes before one exists.
+///
+/// These are the GC-side counterpart of the `[jit-stats]` tallies, and they
+/// exist for the same reason: they are DETERMINISTIC. The same program run
+/// twice collects the same number of times, so a change that allocates less
+/// shows up here even on a machine whose clock cannot resolve it — a minor
+/// collection happens per nursery-full, so `minor_collections` is a direct
+/// proxy for cumulative allocation, which `heap_bytes` (a current-usage
+/// reading) is not.
+pub fn gc_diag_counters() -> (usize, usize, usize, usize) {
+    use majit_gc::GcAllocator;
+    if !majit_gc::gc_sync::is_initialized() {
+        return (0, 0, 0, 0);
+    }
+    majit_gc::gc_sync::gc_query_reentrant(|gc| {
+        let (minor, major) = gc.collection_counts();
+        let (heap, nursery) = gc.heap_byte_stats();
+        (minor, major, heap, nursery)
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/pyre/pyre-object/src/gc_hook.rs
+++ b/pyre/pyre-object/src/gc_hook.rs
@@ -597,10 +597,8 @@ pub fn try_gc_remove_root(slot: *mut *mut u8) -> bool {
 /// window) use this to discriminate GC-managed blocks from
 /// `std::alloc`-backed ones at dealloc time.
 pub type GcOwnsObjectHookFn = fn(addr: usize) -> bool;
-pub type GcCurrentObjectAddressHookFn = fn(addr: usize) -> usize;
 
 majit_gc::global_hook!(static GC_OWNS_OBJECT_HOOK: GcOwnsObjectHookFn);
-majit_gc::global_hook!(static GC_CURRENT_OBJECT_ADDRESS_HOOK: GcCurrentObjectAddressHookFn);
 
 /// Install the GC-ownership predicate. Overwrites any previously-
 /// installed hook.
@@ -611,16 +609,6 @@ pub fn register_gc_owns_object_hook(hook: GcOwnsObjectHookFn) {
 /// Remove the GC-ownership predicate.
 pub fn clear_gc_owns_object_hook() {
     GC_OWNS_OBJECT_HOOK.set(None);
-}
-
-/// Install the non-rooting current-address lookup hook.
-pub fn register_gc_current_object_address_hook(hook: GcCurrentObjectAddressHookFn) {
-    GC_CURRENT_OBJECT_ADDRESS_HOOK.set(Some(hook));
-}
-
-/// Remove the current-address lookup hook.
-pub fn clear_gc_current_object_address_hook() {
-    GC_CURRENT_OBJECT_ADDRESS_HOOK.set(None);
 }
 
 /// Whether `addr` lies inside the active backend's managed GC heap.
@@ -641,14 +629,21 @@ pub extern "C" fn try_gc_owns_object(addr: *mut u8) -> bool {
 }
 
 /// Return the current address for `addr` without registering it as a root.
-/// When no hook is installed, or the active GC does not know the object, the
-/// address is unchanged.
+/// When the active GC does not know the object, the address is unchanged.
+///
+/// Unlike the allocation and barrier hooks around it this one calls
+/// `majit_gc` outright.  The module rule those hooks encode is that
+/// `pyre-object` must not bind itself to a GC *implementation*;
+/// `gc_current_object_address` is not one — it is a backend-agnostic query
+/// that dispatches internally through `gc_is_nursery_object`'s own published
+/// bounds and hook, and answers `addr` for every address no GC owns,
+/// including before any GC exists.  Routing it through a second fn-pointer
+/// cell therefore bought nothing but an opaque call: every root pin and every
+/// root reload pays it, and behind it sits a two-word range compare that
+/// wants to be inlined into the caller.
 #[inline]
 pub fn try_gc_current_object_address(addr: *mut u8) -> *mut u8 {
-    match GC_CURRENT_OBJECT_ADDRESS_HOOK.get() {
-        Some(f) => f(addr as usize) as *mut u8,
-        None => addr,
-    }
+    majit_gc::gc_current_object_address(addr as usize) as *mut u8
 }
 
 /// minimark.py:1900-1915 `identityhash` hook.

--- a/pyre/pyrex/src/lib.rs
+++ b/pyre/pyrex/src/lib.rs
@@ -1193,6 +1193,58 @@ fn collect_and_run_finalizers(ec_ptr: *const PyExecutionContext) {
     }
 }
 
+/// Whether releasing this binding can remove anything from the reachable set,
+/// and so whether the collection that follows it could find garbage an earlier
+/// one did not. Answering `false` skips a full mark-and-sweep of the whole
+/// heap, which is what the release loop below otherwise costs per name.
+///
+/// Two values answer `false` outright:
+///
+/// * An exact `int`, `float`, `bool`, `str`, `bytes` or `None`. It holds no
+///   reference to another object, so nothing but the value itself can lose its
+///   last referrer, and no builtin scalar type defines `__del__`, so nothing
+///   observes it going. `is_exact_type` is what makes this safe rather than
+///   `is_str`/`is_int`, which key off the layout `ob_type` a subclass keeps: a
+///   `class MyStr(str)` instance retags `w_class` and is rejected here, so its
+///   `__del__` and its own attributes stay on the collecting path.
+/// * A module still registered in `sys.modules` under its own `__name__`. It
+///   stays reachable from there no matter what `__main__` does, so the release
+///   removes no object at all from the reachable set. This is every `import`
+///   name. Reading the live `sys.modules` rather than assuming is what keeps a
+///   program that replaced or deleted the entry on the collecting path.
+///
+/// The point is not that these values are cheap to collect — it is that the
+/// collection cannot reach a different answer, so every `__del__` still runs at
+/// exactly the same place in the loop.
+fn release_frees_nothing(value: pyre_object::PyObjectRef) -> bool {
+    if value.is_null() {
+        return true;
+    }
+    unsafe {
+        if pyre_object::is_none(value)
+            || pyre_object::is_exact_type(value, &pyre_object::INT_TYPE)
+            || pyre_object::is_exact_type(value, &pyre_object::BOOL_TYPE)
+            || pyre_object::is_exact_type(value, &pyre_object::FLOAT_TYPE)
+            || pyre_object::is_exact_type(value, &pyre_object::STR_TYPE)
+            || pyre_object::is_exact_type(value, &pyre_object::BYTES_TYPE)
+        {
+            return true;
+        }
+        if pyre_object::is_module(value) {
+            // `Module.name` is the interpreter's own field, not the
+            // program-writable `__name__` attribute, so it is always a string —
+            // but `types.ModuleType.__new__` leaves it empty until `__init__`
+            // seeds it. An anonymous module proves nothing about reachability,
+            // so it takes the collecting path rather than a `sys.modules[""]`
+            // lookup that only an adversarial program could satisfy.
+            let name = pyre_object::w_module_get_name(value);
+            return !name.is_empty()
+                && importing::get_sys_module(name).is_some_and(|m| m == value);
+        }
+    }
+    false
+}
+
 /// PyPy `ObjSpace.finish()` / module teardown ordering: join non-daemon
 /// threads, collect already-unreachable cycles, then release `__main__`
 /// globals from newest to oldest while the older globals their `__del__`
@@ -1228,11 +1280,22 @@ fn finalize_runtime(canonical: pyre_object::PyObjectRef, ec_ptr: *const PyExecut
         if name == "__builtins__" {
             continue;
         }
+        // Re-read rather than trusting the snapshot: a `__del__` already run by
+        // this loop may have rebound the name, and the decision below is only
+        // sound about the value actually being released.
+        let value = unsafe { pyre_object::w_dict_getitem_str(canonical, &name) };
+        let frees_nothing = value.is_none_or(release_frees_nothing);
         unsafe {
             pyre_object::w_dict_setitem_str(canonical, &name, pyre_object::w_none());
         }
-        collect_and_run_finalizers(ec_ptr);
+        if !frees_nothing {
+            collect_and_run_finalizers(ec_ptr);
+        }
     }
+    // The loop ends on a collection whenever it releases anything collectable;
+    // this is the one for the case where the last releases were all skipped, so
+    // teardown still finishes with the heap swept and the queue drained.
+    collect_and_run_finalizers(ec_ptr);
 }
 
 /// Resolve a pending `SystemExit`'s status, then finalize and exit with it.

--- a/pyre/pyrex/src/lib.rs
+++ b/pyre/pyrex/src/lib.rs
@@ -937,6 +937,7 @@ fn maybe_print_jit_stats() {
         }
     }
     maybe_print_mc_diag();
+    maybe_print_gc_diag();
     if std::env::var_os("MAJIT_STATS").is_none() {
         return;
     }
@@ -1003,6 +1004,27 @@ use majit_metainterp::MC_DIAG_LABELS as MC_DIAG_FIELDS;
 /// `_jit_stats_snapshot` keeps the LAST such line, so a second one would
 /// silently replace the committed per-bench baseline. Its own env gate keeps it
 /// off the default `check.py` run, which sets `MAJIT_STATS` for every bench.
+/// Print the GC's deterministic pressure counters.
+///
+/// The perf question this answers is the one a loaded machine's clock cannot:
+/// "did that change actually allocate less?".  A minor collection happens once
+/// per nursery-full, so `minor` is a direct proxy for cumulative allocation and
+/// is identical across runs of the same program — unlike wall or even user CPU
+/// time, which on this tree can swing by more than any single change is worth.
+///
+/// Same prefix discipline as [`maybe_print_mc_diag`]: not `[jit-stats]`, and
+/// behind its own env gate, so the committed per-bench baselines never see it.
+fn maybe_print_gc_diag() {
+    if std::env::var_os("PYRE_GC_DIAG").is_none() {
+        return;
+    }
+    let (minor, major, heap_bytes, nursery_bytes) = pyre_jit::gc_diag_counters();
+    eprintln!(
+        "[jit-gc-diag] minor={minor} major={major} heap_bytes={heap_bytes} \
+         nursery_bytes={nursery_bytes}"
+    );
+}
+
 fn maybe_print_mc_diag() {
     if std::env::var_os("PYRE_MC_DIAG").is_none() {
         return;

--- a/pyre/pyrex/src/lib.rs
+++ b/pyre/pyrex/src/lib.rs
@@ -1197,6 +1197,22 @@ fn collect_and_run_finalizers(ec_ptr: *const PyExecutionContext) {
 /// threads, collect already-unreachable cycles, then release `__main__`
 /// globals from newest to oldest while the older globals their `__del__`
 /// methods may reference are still present.
+///
+/// Newest-to-oldest is what keeps those references working, and it is not
+/// interchangeable with the insertion order `_PyModule_ClearDict` uses. A name
+/// is bound before every name that could be finalized while reading it — most
+/// of all `import sys`, which is usually the very first — so releasing in
+/// insertion order strands `sys` at `None` and every finalizer that writes to
+/// `sys.stderr` dies with an `AttributeError` instead of running. Refcounting
+/// makes the question moot upstream: a finalizer there runs from the decref of
+/// the name being released, while every other slot still holds its original
+/// value, which is not reproducible without leaving dangling pointers in the
+/// dict.
+///
+/// The value is rebound to `None` rather than deleted, as `_PyModule_ClearDict`
+/// does: a `__del__` that reads an already-released name then sees `None`, the
+/// way it would upstream, instead of raising `NameError` at a name the program
+/// can see is still defined.
 fn finalize_runtime(canonical: pyre_object::PyObjectRef, ec_ptr: *const PyExecutionContext) {
     run_threading_shutdown();
     // baseobjspace.py:498-501 `finish()` runs every started module's shutdown
@@ -1213,7 +1229,7 @@ fn finalize_runtime(canonical: pyre_object::PyObjectRef, ec_ptr: *const PyExecut
             continue;
         }
         unsafe {
-            pyre_object::w_dict_delitem_str(canonical, &name);
+            pyre_object::w_dict_setitem_str(canonical, &name, pyre_object::w_none());
         }
         collect_and_run_finalizers(ec_ptr);
     }

--- a/pyre/pyrex/src/lib.rs
+++ b/pyre/pyrex/src/lib.rs
@@ -1238,8 +1238,7 @@ fn release_frees_nothing(value: pyre_object::PyObjectRef) -> bool {
             // so it takes the collecting path rather than a `sys.modules[""]`
             // lookup that only an adversarial program could satisfy.
             let name = pyre_object::w_module_get_name(value);
-            return !name.is_empty()
-                && importing::get_sys_module(name).is_some_and(|m| m == value);
+            return !name.is_empty() && importing::get_sys_module(name).is_some_and(|m| m == value);
         }
     }
     false


### PR DESCRIPTION
Seven commits: the shutdown teardown loop stops paying one full major collection per `__main__` global, a deterministic GC-pressure readout to measure that with, one indirection removal on the root-pin path, and four comment-only slices recording contracts the JIT code does not keep.

## Commits (bottom → top of stack)

**`jit(shortpreamble): correct the ShortInputArg stand-in position comment`**
The comment said the non-emitted SAME_AS stand-in sits at the renamed `InputArg`, while `same_as.pos.set(arg)` positions it at the original label box. Describes the position the code uses, and records what moving it to `renamed` would cost: metadata stays seeded at the original while the replay consumes it from `preamble_op.pos`, so an input short box would lose its exported info and guards.

**`jit(shortpreamble): describe the identity forwarding the import path performs`**
Three import producers state the upstream contract — `shortpreamble.py:62-75`, `:80-85`, `:152-159` keep the body-visible box distinct from the replayed result and join them only through `PreambleOp` — and then call `make_equal_to(source, result)` unconditionally. `produce_pure` guards its forwarding on `invented_name` and already matched its comment; the heap-field, heap-array and loop-invariant producers did not. Records what depends on the forwarding: the `potential_extra_ops` key, the second lookup in the `force_box` pop, and the post-hoc force sweep in `unroll.rs` all read the forwarded position, so it cannot be removed on its own.

**`jit(inline): name every decline in the binop dunder inline path`**
`try_walker_inline_user_binop` returned `Ok(None)` from eleven distinct gates without recording which one fired, so a residual `BINARY_OP` was indistinguishable from one never attempted. Adds the same `decline!` macro the CallFn inline path uses, under `PYRE_FBW_INLINE_DIAG`, plus a line on the `NotImplemented` abort. The class is read with `w_type_get_name(w_class)`, not `type_name_of(concrete_lhs)` — the latter reports the physical layout type, which is `object` for every heap instance.

**`gc: call gc_current_object_address directly instead of through a hook`**
Every root pin and root reload routed its forwarding query through a process-global fn-pointer cell whose only installer was JIT driver init and whose only implementation forwarded to `majit_gc::gc_current_object_address`. Calls it directly and deletes the cell, its register/clear pair, the type alias and the trampoline. `gc_is_nursery_object` and `gc_current_object_address` become `#[inline]` — behind the cell sat a two-word range compare that wants to be inlined into the pin.

**`pyrex: add PYRE_GC_DIAG, a deterministic GC pressure readout`**
`[jit-gc-diag] minor= major= heap_bytes= nursery_bytes=`, printed only under `PYRE_GC_DIAG`. The counters do not move with machine load, so an allocation-reducing change is verifiable on a box whose clock is not. Prefix and gating follow `maybe_print_mc_diag` — not `[jit-stats]`, and behind its own env var — so `check.py`'s committed per-bench baselines never see the line.

**`shutdown: rebind released __main__ globals to None instead of deleting`**
`finalize_runtime` released each global with `w_dict_delitem_str`, so a `__del__` reading an already-released name raised `NameError`. `_PyModule_ClearDict` rebinds to `None`; match that spelling. Also records why the newest-to-oldest release order is not interchangeable with the insertion order `_PyModule_ClearDict` uses: `import sys` is usually the first global bound, so insertion order strands `sys` at `None` and every finalizer writing to `sys.stderr` raises `AttributeError` instead of running.

**`shutdown: skip the teardown collection when the release frees nothing`**
`finalize_runtime` ran a full major collection after releasing each `__main__` global — one mark-and-sweep of the whole heap per module-level name. Skipped for two values where it cannot reach a different answer:

- an exact `int`/`float`/`bool`/`str`/`bytes`/`None`, which references no other object and whose type defines no `__del__`. The test is `is_exact_type`, not `is_str`/`is_int`: those compare the layout `ob_type` a subclass keeps, so `class MyStr(str)` with a `__del__` would be skipped.
- a module still registered in `sys.modules` under its own `__name__`, which stays reachable from there. The live mapping is read rather than assumed, so a replaced or deleted entry stays on the collecting path; an anonymous module (`types.ModuleType.__new__` leaves the name empty until `__init__` seeds it) proves nothing and takes that path too.

Every `__del__` still runs at the same point in the loop. The value is re-read from the dict rather than taken from the snapshot, since a `__del__` already run by the loop may have rebound the name, and an unconditional collection closes the loop for the case where the last releases were all skipped.

## Verification

Major collections and user CPU, dynasm release:

| | before | after |
|---|---|---|
| `print(1)` + 800 globals | 808 majors, 3.57 s | 3 majors, 0.03 s |
| 19-global script | 21 majors, 0.18 s | 8 majors, 0.08 s |
| `pyre/bench/fib_loop.py` | 12 majors, 0.28 s | 6 majors, 0.17 s |

- **Shutdown behavior**: 752 programs under `pyre/extra_tests` and `pyre/bench` run against a control binary built from the parent commit. 9 differ; 8 of those also differ when the *same* binary is run twice (addresses, pids, timestamps), and the last is `sys.executable` reporting the binary's own path. Real differences: 0.
- **Subclass soundness**: `str`/`int`/`bytes`/`float` subclasses carrying `__del__`, and a `types.ModuleType` subclass, all still finalize.
- **`gc_current_object_address`**: all 350 synth benches byte-identical against a control binary from the parent commit; `majit-gc` 225 tests and `pyre-jit` 350 tests pass; binary grows 128 bytes. Landed as a strict removal of work per pin, not on a measured win — this machine resolves about ±5% (same-binary A/B reads 1.000x/0.985x on the pairwise-ratio median) and the change reads 1.015x/0.984x on the two benches where the query is hottest.

Local verification was run against `e1b5fa7ec40`; the branch was then rebased onto `a72d9cb8d0c` (+#970, #971) and has not been rebuilt locally since, so CI is the check on that base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional garbage-collection diagnostics through `PYRE_GC_DIAG`, including collection counts and heap/nursery memory statistics.
  * Added diagnostic reporting for unsupported or declined JIT binary-operation inlining cases.

* **Performance**
  * Improved garbage-collection root scanning and object lookup efficiency.
  * Reduced unnecessary full garbage-collection passes during runtime shutdown.

* **Reliability**
  * Simplified current-object address handling while preserving correct behavior for unmanaged objects.
  * Improved runtime teardown and reachability handling for released values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->