### PR TITLE
jit: two exception-path fixes (callee is-None inline, too-long Ref image)

### DIFF
--- a/pyre/bench/synth/exception_catching_frame_tb_node.cranelift.jitstats
+++ b/pyre/bench/synth/exception_catching_frame_tb_node.cranelift.jitstats
@@ -1,8 +1,8 @@
-bridges_compiled=3
+bridges_compiled=2
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
-guard_failures=601
+guard_failures=401
 internal_compile_panics=0
 loops_aborted=0
-loops_compiled=4
+loops_compiled=3

--- a/pyre/bench/synth/exception_catching_frame_tb_node.dynasm.jitstats
+++ b/pyre/bench/synth/exception_catching_frame_tb_node.dynasm.jitstats
@@ -5,4 +5,4 @@ descr_set_stale_absent=0
 guard_failures=401
 internal_compile_panics=0
 loops_aborted=0
-loops_compiled=4
+loops_compiled=3

--- a/pyre/bench/synth/exception_try_call_inlined_callee_raise.cranelift.jitstats
+++ b/pyre/bench/synth/exception_try_call_inlined_callee_raise.cranelift.jitstats
@@ -1,8 +1,8 @@
-bridges_compiled=2
+bridges_compiled=1
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
-guard_failures=408
+guard_failures=201
 internal_compile_panics=0
-loops_aborted=1
-loops_compiled=3
+loops_aborted=0
+loops_compiled=2

--- a/pyre/bench/synth/exception_try_call_inlined_callee_raise.dynasm.jitstats
+++ b/pyre/bench/synth/exception_try_call_inlined_callee_raise.dynasm.jitstats
@@ -1,8 +1,8 @@
-bridges_compiled=2
+bridges_compiled=1
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
-guard_failures=402
+guard_failures=201
 internal_compile_panics=0
 loops_aborted=0
-loops_compiled=3
+loops_compiled=2

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -303,6 +303,8 @@ pub unsafe fn walk_raw_code_roots(
             // shared by every function built from this code; the wrapper is
             // Box-immortal, so only this raw-root walker forwards it.
             visitor(&mut *(&mut code.w_qualname as *mut PyObjectRef as *mut majit_ir::GcRef));
+            // `co_name` is realized and retained the same way.
+            visitor(&mut *(&mut code.w_name as *mut PyObjectRef as *mut majit_ir::GcRef));
             if !code.co_consts_w.is_null() {
                 for slot in (&*code.co_consts_w).iter() {
                     let mut child = slot.load(std::sync::atomic::Ordering::Acquire);

--- a/pyre/pyre-interpreter/src/pycode.rs
+++ b/pyre/pyre-interpreter/src/pycode.rs
@@ -247,6 +247,20 @@ pub struct PyCode {
     /// same reason it forwards `w_globals`: the wrapper is Box-immortal, so
     /// nothing else would reach a movable object landing here.
     pub w_qualname: PyObjectRef,
+    /// `pycode.py:137 self.co_name = name` realized as one shared wrapped
+    /// object, the exact counterpart of `w_qualname` above.
+    ///
+    /// `function.py:51 self.name = forcename or code.co_name` copies the code
+    /// object's interp-level string into every function built from it, so the
+    /// same "all of them name one immutable string" argument applies, and the
+    /// same realize-once treatment follows.  Without it the getter ran
+    /// `w_str_new` per read — two allocations, a `String` copy and a full
+    /// `chars().count()` — which a traceback walk pays on every hop
+    /// (`tb.tb_frame.f_code.co_name`).
+    ///
+    /// `PY_NULL` until first realized by [`w_code_name_obj`]; the storage,
+    /// immortality and root-walk argument are `w_qualname`'s verbatim.
+    pub w_name: PyObjectRef,
 }
 
 /// Field offset of `code_ptr` within `PyCode`.
@@ -255,6 +269,8 @@ pub const CODE_PTR_OFFSET: usize = std::mem::offset_of!(PyCode, code_ptr);
 pub const CODE_W_GLOBALS_OFFSET: usize = std::mem::offset_of!(PyCode, w_globals);
 /// Field offset of `w_qualname` within `PyCode`.
 pub const CODE_W_QUALNAME_OFFSET: usize = std::mem::offset_of!(PyCode, w_qualname);
+/// Field offset of `w_name` within `PyCode`.
+pub const CODE_W_NAME_OFFSET: usize = std::mem::offset_of!(PyCode, w_name);
 
 /// `pycode.py:127 self.co_qualname = qualname` — the shared wrapped qualified
 /// name, realized on first demand and retained on the code object.
@@ -284,6 +300,35 @@ pub unsafe fn w_code_qualname_obj(w_code: PyObjectRef) -> PyObjectRef {
         let w_qualname = w_str_new(&(*code_ptr).qualname);
         (*(w_code as *mut PyCode)).w_qualname = w_qualname;
         w_qualname
+    }
+}
+
+/// `pycode.py:137 self.co_name = name` — the shared wrapped name, realized on
+/// first demand and retained on the code object.
+///
+/// The counterpart of [`w_code_qualname_obj`], for the same reason and with the
+/// same lifetime argument: `function.py:51 self.name = forcename or
+/// code.co_name` and the `co_name` getter both hand out the code object's own
+/// string, so they name one immutable value.
+///
+/// # Safety
+/// `w_code` must point to a valid `PyCode`.
+pub unsafe fn w_code_name_obj(w_code: PyObjectRef) -> PyObjectRef {
+    unsafe {
+        let cached = (*(w_code as *const PyCode)).w_name;
+        if !cached.is_null() {
+            return cached;
+        }
+        let code_ptr = w_code_get_ptr(w_code) as *const crate::CodeObject;
+        if code_ptr.is_null() {
+            return pyre_object::PY_NULL;
+        }
+        // `w_str_new` is a collection point, but the wrapper is Box-immortal
+        // and so never relocates; the fresh string is stored through the
+        // still-valid `w_code` before any further allocation can sweep it.
+        let w_name = w_str_new(&(*code_ptr).obj_name);
+        (*(w_code as *mut PyCode)).w_name = w_name;
+        w_name
     }
 }
 
@@ -510,6 +555,7 @@ pub fn w_code_new_with_hidden_applevel(code_ptr: *const (), hidden_applevel: boo
         mapdict_caches,
         co_consts_w,
         w_qualname: pyre_object::PY_NULL,
+        w_name: pyre_object::PY_NULL,
     }) as PyObjectRef;
     register_prebuilt_code_root(obj);
     obj
@@ -721,7 +767,8 @@ pub unsafe fn code_get_field(obj: PyObjectRef, name: &str) -> Result<PyObjectRef
         "co_freevars" => names_tuple(&code.freevars),
         "co_cellvars" => names_tuple(&code.cellvars),
         "co_filename" => w_str_new(&code.source_path),
-        "co_name" => w_str_new(&code.obj_name),
+        // Shared realized object, like `co_qualname` below.
+        "co_name" => unsafe { w_code_name_obj(obj) },
         // The realized qualname is shared with every function built from this
         // code object (`function.py:54 self.qualname = qualname or self.name`),
         // so the attribute yields the same object on each read.

--- a/pyre/pyre-jit-trace/build.rs
+++ b/pyre/pyre-jit-trace/build.rs
@@ -11,7 +11,7 @@ use walkdir::WalkDir;
 #[global_allocator]
 static ALLOC: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
-const CODEGEN_CACHE_VERSION: &str = "pyre-jit-trace-codegen-cache-v4";
+const CODEGEN_CACHE_VERSION: &str = "pyre-jit-trace-codegen-cache-v5";
 /// Retained cache entries. Each is ~6 MB, and a handful covers the
 /// configurations one checkout switches between (native/wasm × release/dev).
 const CODEGEN_CACHE_MAX_ENTRIES: usize = 8;
@@ -21,6 +21,7 @@ const CODEGEN_OUTPUTS: &[&str] = &[
     "jit_trace_gen.rs",
     "jit_metadata.json",
     "jitcodes.bin",
+    "jitcodes_index.bin",
     "indirectcalltargets.bin",
     "jit_drivers.bin",
     "insns.bin",
@@ -83,10 +84,10 @@ fn emit_llbc_extraction_placeholders() {
     )
     .unwrap();
     std::fs::write(format!("{out_dir}/jit_metadata.json"), b"{}\n").unwrap();
+    std::fs::write(format!("{out_dir}/jitcodes.bin"), b"").unwrap();
     std::fs::write(
-        format!("{out_dir}/jitcodes.bin"),
-        bincode::serialize(&Vec::<std::sync::Arc<majit_translate::jitcode::JitCode>>::new())
-            .unwrap(),
+        format!("{out_dir}/jitcodes_index.bin"),
+        bincode::serialize(&(Vec::<String>::new(), vec![0_u32])).unwrap(),
     )
     .unwrap();
     std::fs::write(
@@ -505,13 +506,26 @@ fn real_main() {
     std::fs::write(format!("{out_dir}/jit_metadata.json"), &json).unwrap();
 
     // Persist `pipeline.jitcodes` (RPython `all_jitcodes` from
-    // codewriter.py:89) as a
-    // single bincode artifact. Runtime deserializes this once into the shared
+    // codewriter.py:89) as individually encoded entries plus a name/offset
+    // index. Runtime materializes entries lazily into the shared
     // MetaInterpStaticData jitcodes store — same single-store model as
     // RPython `warmspot.py:281-282` `self.metainterp_sd.jitcodes =
     // codewriter.make_jitcodes()`.
-    let jitcodes_bin = bincode::serialize(&pipeline.jitcodes).unwrap();
+    let mut jitcodes_bin = Vec::new();
+    let mut jitcode_names = Vec::with_capacity(pipeline.jitcodes.len());
+    let mut jitcode_offsets = Vec::with_capacity(pipeline.jitcodes.len() + 1);
+    jitcode_offsets.push(0_u32);
+    for jitcode in &pipeline.jitcodes {
+        jitcode_names.push(jitcode.name.clone());
+        jitcodes_bin.extend(bincode::serialize(jitcode).unwrap());
+        jitcode_offsets.push(
+            u32::try_from(jitcodes_bin.len())
+                .expect("serialized jitcodes.bin exceeds the u32 offset range"),
+        );
+    }
+    let jitcodes_index_bin = bincode::serialize(&(jitcode_names, jitcode_offsets)).unwrap();
     std::fs::write(format!("{out_dir}/jitcodes.bin"), &jitcodes_bin).unwrap();
+    std::fs::write(format!("{out_dir}/jitcodes_index.bin"), &jitcodes_index_bin).unwrap();
     let indirectcalltargets_bin = bincode::serialize(&pipeline.indirectcalltarget_indices).unwrap();
     std::fs::write(
         format!("{out_dir}/indirectcalltargets.bin"),
@@ -634,13 +648,14 @@ fn real_main() {
 
     // Report
     eprintln!(
-        "[pyre-jit-trace build.rs] canonical analysis: {} JIT drivers, {} functions, {} blocks, {} flat ops, {} all_jitcodes ({} bytes bincode), generated {} bytes",
+        "[pyre-jit-trace build.rs] canonical analysis: {} JIT drivers, {} functions, {} blocks, {} flat ops, {} all_jitcodes ({} bytes bodies + {} bytes index), generated {} bytes",
         pipeline.jit_drivers.len(),
         pipeline.functions.len(),
         pipeline.total_blocks,
         pipeline.total_ops,
         pipeline.jitcodes.len(),
         jitcodes_bin.len(),
+        jitcodes_index_bin.len(),
         code.len(),
     );
 

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -3415,29 +3415,37 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
             if !callee_code.cellvars.is_empty() {
                 return Ok(None);
             }
-            // A POP_JUMP_IF_NONE / POP_JUMP_IF_NOT_NONE that leaves operands on
-            // the value stack cannot be inlined: the branch guard's resume has
-            // to restore those kept slots, and inside an inline sub-walk the
-            // walk mirror does not model them, so the kept Ref resolves to NULL
-            // (`BranchGuardUnrestorableKeptStackPermanent`, the `reads_null_ref`
-            // arm).  That is a permanent abort, which discards the enclosing
-            // loop trace, so the shape has to be recognised here instead.
+            // POP_JUMP_IF_NONE / POP_JUMP_IF_NOT_NONE lower to an `is`/`is_not`
+            // identity residual call whose operands must be Ref (the codewriter
+            // PopJumpIfNone arm), then a branch guard.  When the multiframe inline
+            // int-specializes the tested local, the mid-body guard resume cannot
+            // source that operand's Ref form from the callee register banks
+            // (`collect_callee_active_boxes` would read a stale/mismatched box), so
+            // the encoded liveness stream disagrees with the decoder
+            // (`resume.rs decode_ref: unexpected tag`) and the caller frame is
+            // corrupted. Decline to the ordinary residual call until
+            // the multi-frame resume reboxes int-specialized identity operands.
+            // POP_JUMP_IF_TRUE/FALSE stay inlinable: their `bool` truth folds in the
+            // int bank, so no Ref rebox is needed.  A strict straight-line callee
+            // has no branch at all, so this scan never fires for it.
+            // Stored bound methods carry their explicit receiver and callee frame,
+            // so their Ref operands remain available to the resume path.
             //
-            // `stack_depth_at` is the depth BEFORE the instruction and the
-            // branch pops the tested value, so the surviving kept stack is
-            // `depth - 1`: a statement-level `if x is None:` or
-            // `while x is not None:` reads 1 and inlines, while the same test
-            // in expression position — `acc += 1 if x is None else 0` holds
-            // `acc` across the branch — reads 2 and declines.  An unreachable
-            // pc has no depth and cannot fire a guard.
+            // This precondition used to abort the enclosing trace rather than
+            // decline the inline, because residualizing it let loops compile that
+            // then printed traceback tuples missing their OUTERMOST frame.  That
+            // node is now recorded — the two bridge handler-entry arms attach the
+            // catching frame's own node — so the decline joins every other
+            // precondition here and returns `Ok(None)`.
             //
-            // POP_JUMP_IF_TRUE/FALSE need no such scan: their `bool` truth
-            // folds in the int bank, so the guard keeps no Ref.  Stored bound
-            // methods carry their explicit receiver and callee frame, so their
-            // kept Ref operands remain available to the resume path.
-            if bound_method.is_none() {
-                let liveness = crate::liveness::liveness_for(raw_callee_code);
-                let keeps_operands = (0..callee_code.instructions.len()).any(|pc| {
+            // The abort was expensive out of all proportion to the inline it was
+            // protecting: a callee that walks a traceback (`while tb is not None`)
+            // lowers to exactly this instruction, so any handler calling such a
+            // helper aborted every retrace of the enclosing loop.  The guard whose
+            // bridge the retrace was building therefore never got one and deopted
+            // on every delivery.
+            if bound_method.is_none()
+                && (0..callee_code.instructions.len()).any(|pc| {
                     matches!(
                         pyre_interpreter::decode_instruction_at(callee_code, pc),
                         Some((
@@ -3445,14 +3453,13 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
                                 | pyre_interpreter::bytecode::Instruction::PopJumpIfNotNone { .. },
                             _
                         ))
-                    ) && liveness.stack_depth_at(pc).is_some_and(|depth| depth > 1)
-                });
-                if keeps_operands {
-                    if try_multiframe {
-                        return Ok(None);
-                    }
-                    break 'seed;
+                    )
+                })
+            {
+                if try_multiframe {
+                    return Ok(None);
                 }
+                break 'seed;
             }
             let nlocals = callee_code.varnames.len();
             let ncells = pyre_interpreter::ncells(callee_code);

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -2483,6 +2483,24 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
     } else {
         None
     };
+    // Does any incoming binding land a value the callee's register banks can
+    // hold unboxed?  Only the `is`-against-None scan below consults this; see
+    // its hazard-2 arm for why an int-specialized tested local is unsafe to
+    // inline.  A default is pushed above as a raw `Ref` without going through
+    // `ConcreteValue::from_pyobj`, so re-classify here rather than matching the
+    // variant alone — `def _read_from_buffer(self, size=-1)` reaches the scan
+    // with `size` as `Ref(<int object>)` and is exactly the shape that
+    // miscompiled.
+    let callee_binds_an_unboxed_local = callee_arg_concretes.iter().any(|c| {
+        let classified = match *c {
+            ConcreteValue::Ref(obj) => ConcreteValue::from_pyobj(obj),
+            other => other,
+        };
+        matches!(
+            classified,
+            ConcreteValue::Int(_) | ConcreteValue::Float(_) | ConcreteValue::Bool(_)
+        )
+    });
     // Vararg/over-arity calls still use the ordinary residual path. A closure
     // is admissible when it has freevars only: the existing cell objects can
     // be threaded into this callee's own frame exactly as
@@ -3444,8 +3462,9 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
             // helper aborted every retrace of the enclosing loop.  The guard whose
             // bridge the retrace was building therefore never got one and deopted
             // on every delivery.
-            if bound_method.is_none()
-                && (0..callee_code.instructions.len()).any(|pc| {
+            if bound_method.is_none() {
+                let liveness = crate::liveness::liveness_for(raw_callee_code);
+                let has_is_none_branch = (0..callee_code.instructions.len()).any(|pc| {
                     matches!(
                         pyre_interpreter::decode_instruction_at(callee_code, pc),
                         Some((
@@ -3453,13 +3472,55 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
                                 | pyre_interpreter::bytecode::Instruction::PopJumpIfNotNone { .. },
                             _
                         ))
+                    ) && (
+                        // Hazard 3 — the wasm backend cannot run the widened
+                        // shape at all, so it keeps the blanket decline.
+                        // Admitting a callee here traces into its body, and the
+                        // helper this widening exists for carries its own loop
+                        // (`while tb is not None:`), so the enclosing trace
+                        // closes with a CALL_ASSEMBLER into that loop.  Every
+                        // wasm trace is its own module and there is no
+                        // inter-module chaining, so the backend declines any
+                        // CALL_ASSEMBLER outright; that decline is the `Err`
+                        // arm of the compile step, so the enclosing loop is
+                        // aborted rather than merely left interpreted.
+                        // Measured `loops_aborted` 0 -> 3 on
+                        // `synth/exception_traceback_lineno_chain` and 0 -> 5
+                        // on `synth/exception_inline_callee_tb_frames`, each
+                        // ~5-9% slower than declining.  Drop this arm once the
+                        // backend can chain modules.
+                        cfg!(target_arch = "wasm32")
+                        // Hazard 1 — kept operands. A branch that leaves slots
+                        // on the value stack needs its guard resume to restore
+                        // them, and the inline sub-walk's mirror does not model
+                        // them, so the kept Ref reads NULL and
+                        // `walker_branch_guard` raises
+                        // BranchGuardUnrestorableKeptStackPermanent — a
+                        // permanent abort that discards the enclosing loop
+                        // trace.  `stack_depth_at` is the depth BEFORE the
+                        // instruction and the branch pops the tested value, so
+                        // `depth > 1` is exactly "a kept slot survives".  An
+                        // unreachable pc has no depth and cannot fire a guard.
+                        || liveness.stack_depth_at(pc).is_some_and(|depth| depth > 1)
+                            // Hazard 2 — the tested operand itself.  When the
+                            // multiframe inline int-specializes the tested
+                            // local, the mid-body guard resume cannot source
+                            // that operand's Ref form from the callee register
+                            // banks (`collect_callee_active_boxes` reads a
+                            // stale/mismatched box), so the encoded liveness
+                            // stream disagrees with the decoder and the caller
+                            // frame is corrupted.  This is independent of kept
+                            // depth: a statement-level `if x is None:` reads
+                            // depth 1 and still carries it.
+                            || callee_binds_an_unboxed_local
                     )
-                })
-            {
-                if try_multiframe {
-                    return Ok(None);
+                });
+                if has_is_none_branch {
+                    if try_multiframe {
+                        return Ok(None);
+                    }
+                    break 'seed;
                 }
-                break 'seed;
             }
             let nlocals = callee_code.varnames.len();
             let ncells = pyre_interpreter::ncells(callee_code);

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -2365,32 +2365,6 @@ pub(crate) fn try_walker_inline_builtin_call<Sym: WalkSym>(
     }
 }
 
-/// Whether any level already on the inline stack is a recursion unroll — the
-/// snapshot root's own code re-entered, or one code appearing twice in the
-/// chain (a mutual cycle).
-///
-/// Such a chain's levels are suspended copies of the same frame, so an unwind
-/// through it is the shape `fbw_max_rec_unroll_depth` bounds rather than the
-/// straight-line chain `fbw_max_multiframe_depth` covers.
-fn inline_chain_unrolls_recursion<Sym: WalkSym>(ctx: &WalkContext<'_, '_, Sym>) -> bool {
-    let sym_ptr = ctx.fbw_mode.snapshot_sym;
-    let root_code = if sym_ptr.is_null() {
-        0
-    } else {
-        unsafe {
-            pyre_interpreter::live_code_wrapper((*(*sym_ptr).jitcode()).raw_code() as *const ())
-                as *const () as usize
-        }
-    };
-    let session = ctx.session.borrow();
-    session.framestack.iter().enumerate().any(|(i, frame)| {
-        frame.w_code == root_code
-            || session.framestack[..i]
-                .iter()
-                .any(|outer| outer.w_code == frame.w_code)
-    })
-}
-
 /// Read one of the callee function's `_immutable_fields_` slots live and pin
 /// the value this inline baked, replacing the box so later reads fold.
 ///
@@ -2963,30 +2937,24 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
         // callee without a handler retains its after-residual live anchor.
         return Ok(None);
     }
-    // A callee that raises inline needs the cross-frame bridge (gh#343 /
-    // gh#467) the drain cannot yet build, but only when the raise has to come
-    // back INTO the traced region — i.e. when some frame already on the
-    // framestack catches it.  Measured: admitting such a callee below an
-    // intermediate frame takes `guard_failures` from 1203 to 19654 and drops
-    // `bridges_compiled` from 6 to 2 on a caught-in-loop shape, because the
-    // guards it emits keep failing with no bridge to land on.
+    // A callee that raises inline needs the cross-frame bridge the carrier
+    // drain builds once a guard inside the compiled chain fails.  The drain
+    // walks the paused middle frames between the raising leaf and the root, so
+    // one intermediate frame may sit between the loop and the raise; a middle
+    // that CATCHES is still declined, which is what holds the cap here instead
+    // of letting a raising chain run to `fbw_max_multiframe_depth`.  A
+    // value-returning chain (no raise) inlines to the full depth either way.
     //
-    // When no modelled frame catches, the raise leaves the traced region
-    // entirely and takes the guard-exception exit, which needs no such bridge —
-    // `bench/synth/exception_escape_caller_frame_tb_node`'s `d_no_try` shape.
-    // A value-returning chain (no raise) inlines to the full depth either way.
-    //
-    // The lift is one level, not the full chain depth: the shape it unlocks is
-    // a single intermediate frame between the loop and the raise, and a chain
-    // whose levels are self-recursive unrolls keeps the recursion bound
-    // instead. The unwind out of such a chain crosses suspended copies of the
-    // same frame, which is what `fbw_max_rec_unroll_depth` bounds above;
-    // letting the raising leaf inline below one costs 1.9x on
-    // `bench/synth/selfrec_tail_exception_unwind`.
+    // Measured against one drain-complete binary, nine interleaved reps per
+    // arm: `bench/synth/exception_escape_caller_frame_tb_node` runs at 0.70x
+    // of the one-level cap, `bench/synth/gc_bug_bridge_flavor_traceback_names`
+    // at 1.02x and `bench/synth/selfrec_tail_exception_unwind` at 0.99x.  A
+    // third level regresses — `selfrec_tail_exception_unwind` takes
+    // `guard_failures` from 937 to 7408 — because the unwind then crosses two
+    // suspended copies of the same frame, the shape `fbw_max_rec_unroll_depth`
+    // bounds above.
     let effective_multiframe_depth = if contains_raise {
-        let bounded = crate::jitcode_dispatch::inline_chain_catches_a_raise(ctx.session)
-            || inline_chain_unrolls_recursion(ctx);
-        if bounded { 1 } else { 2 }
+        2
     } else {
         fbw_max_multiframe_depth()
     };

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -3447,37 +3447,29 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
             if !callee_code.cellvars.is_empty() {
                 return Ok(None);
             }
-            // POP_JUMP_IF_NONE / POP_JUMP_IF_NOT_NONE lower to an `is`/`is_not`
-            // identity residual call whose operands must be Ref (the codewriter
-            // PopJumpIfNone arm), then a branch guard.  When the multiframe inline
-            // int-specializes the tested local, the mid-body guard resume cannot
-            // source that operand's Ref form from the callee register banks
-            // (`collect_callee_active_boxes` would read a stale/mismatched box), so
-            // the encoded liveness stream disagrees with the decoder
-            // (`resume.rs decode_ref: unexpected tag`) and the caller frame is
-            // corrupted. Decline to the ordinary residual call until
-            // the multi-frame resume reboxes int-specialized identity operands.
-            // POP_JUMP_IF_TRUE/FALSE stay inlinable: their `bool` truth folds in the
-            // int bank, so no Ref rebox is needed.  A strict straight-line callee
-            // has no branch at all, so this scan never fires for it.
-            // Stored bound methods carry their explicit receiver and callee frame,
-            // so their Ref operands remain available to the resume path.
+            // A POP_JUMP_IF_NONE / POP_JUMP_IF_NOT_NONE that leaves operands on
+            // the value stack cannot be inlined: the branch guard's resume has
+            // to restore those kept slots, and inside an inline sub-walk the
+            // walk mirror does not model them, so the kept Ref resolves to NULL
+            // (`BranchGuardUnrestorableKeptStackPermanent`, the `reads_null_ref`
+            // arm).  That is a permanent abort, which discards the enclosing
+            // loop trace, so the shape has to be recognised here instead.
             //
-            // This precondition used to abort the enclosing trace rather than
-            // decline the inline, because residualizing it let loops compile that
-            // then printed traceback tuples missing their OUTERMOST frame.  That
-            // node is now recorded — the two bridge handler-entry arms attach the
-            // catching frame's own node — so the decline joins every other
-            // precondition here and returns `Ok(None)`.
+            // `stack_depth_at` is the depth BEFORE the instruction and the
+            // branch pops the tested value, so the surviving kept stack is
+            // `depth - 1`: a statement-level `if x is None:` or
+            // `while x is not None:` reads 1 and inlines, while the same test
+            // in expression position — `acc += 1 if x is None else 0` holds
+            // `acc` across the branch — reads 2 and declines.  An unreachable
+            // pc has no depth and cannot fire a guard.
             //
-            // The abort was expensive out of all proportion to the inline it was
-            // protecting: a callee that walks a traceback (`while tb is not None`)
-            // lowers to exactly this instruction, so any handler calling such a
-            // helper aborted every retrace of the enclosing loop.  The guard whose
-            // bridge the retrace was building therefore never got one and deopted
-            // on every delivery.
-            if bound_method.is_none()
-                && (0..callee_code.instructions.len()).any(|pc| {
+            // POP_JUMP_IF_TRUE/FALSE need no such scan: their `bool` truth
+            // folds in the int bank, so the guard keeps no Ref.  Stored bound
+            // methods carry their explicit receiver and callee frame, so their
+            // kept Ref operands remain available to the resume path.
+            if bound_method.is_none() {
+                let liveness = crate::liveness::liveness_for(raw_callee_code);
+                let keeps_operands = (0..callee_code.instructions.len()).any(|pc| {
                     matches!(
                         pyre_interpreter::decode_instruction_at(callee_code, pc),
                         Some((
@@ -3485,13 +3477,14 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
                                 | pyre_interpreter::bytecode::Instruction::PopJumpIfNotNone { .. },
                             _
                         ))
-                    )
-                })
-            {
-                if try_multiframe {
-                    return Ok(None);
+                    ) && liveness.stack_depth_at(pc).is_some_and(|depth| depth > 1)
+                });
+                if keeps_operands {
+                    if try_multiframe {
+                        return Ok(None);
+                    }
+                    break 'seed;
                 }
-                break 'seed;
             }
             let nlocals = callee_code.varnames.len();
             let ncells = pyre_interpreter::ncells(callee_code);

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -4185,11 +4185,15 @@ fn bool_box_truth_lookup(boxed: OpRef) -> Option<OpRef> {
     })
 }
 
-/// Clear the [`BOOL_BOX_TRUTH`] map at the start of an authoritative walk so a
-/// prior aborted walk's entries never leak into the next one.  This is the
-/// reset boundary for the walk-local thread-local; it is called at the two FBW
-/// walk entry points (`trace.rs` `full_body_walk_trace` at walk start, and
-/// after `probe_walk_perfn_jitcode` discards its throwaway trace).
+/// Clear the [`BOOL_BOX_TRUTH`] map so a prior walk's entries never leak into
+/// the next one.  This is the reset boundary for the walk-local thread-local,
+/// and it is called wherever the ops a recorded key names stop existing: at
+/// walk start (`trace.rs` `full_body_walk_trace`, and the carrier drain), after
+/// `probe_walk_perfn_jitcode` discards its throwaway trace, and on every
+/// sub-walk rollback that follows `cut_trace` with a `heap_cache` reset.
+///
+/// A reset can only lose entries, never invent one, so a boundary placed too
+/// eagerly costs a fold and cannot mis-fold.
 pub fn bool_box_truth_reset() {
     BOOL_BOX_TRUTH.with(|m| m.borrow_mut().clear());
 }
@@ -5020,40 +5024,6 @@ struct InlineParentBlackhole {
     /// Float values have no concrete shadow bank; retain their OpRefs and
     /// resolve them at force time while the trace context is still live.
     float_values: Vec<(usize, OpRef)>,
-}
-
-/// Whether any frame the trace already models would catch an exception raised
-/// below it — i.e. whether a raise escaping the callee about to be inlined has
-/// to be routed back INTO the traced region.
-///
-/// Each paused caller on the framestack is asked whether its own pending CALL
-/// sits inside a try-block, the same `after_residual_call_resume` →
-/// `catch_exception/L` lookup [`decline_inline_caller_frame_for_catch_marker`]
-/// uses. Level 0's parent is the snapshot root, so the scan covers the root
-/// frame and every intermediate one; the innermost CALL needs no test here
-/// because a nested try-block CALL already declines multiframe on its own.
-///
-/// Unknown answers count as catching: a parent with no snapshot, an
-/// unresolvable jitcode, or a CALL with no recorded pc could all be hiding a
-/// handler, and admitting one wrongly costs a guard storm.
-pub(crate) fn inline_chain_catches_a_raise(session: &std::cell::RefCell<WalkSession>) -> bool {
-    session.borrow().framestack.iter().any(|frame| {
-        let Some(parent) = frame.parent.as_ref() else {
-            return true;
-        };
-        let Some(call_pc) = parent.call_jitcode_pc else {
-            return true;
-        };
-        let Some(pjc) = crate::state::pyjitcode_for_jitcode_index(parent.jitcode_index as i32)
-        else {
-            return true;
-        };
-        match pjc.after_residual_call_resume_for_jitcode_pc(call_pc) {
-            // No after-call resume marker: the CALL is not in a try-block.
-            None => false,
-            Some(resume) => try_catch_exception_at(pjc.jitcode.code.as_slice(), resume).is_some(),
-        }
-    })
 }
 
 /// The derivation flavor of a paused caller frame's Python resume pc.

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -220,9 +220,9 @@ pub use diag::*;
 /// the bytecode bytes + register-bank sizes for the fresh callee
 /// frame.
 ///
-/// Body is always `'static` — production wires the lookup to
-/// `crate::jitcode_runtime::all_jitcodes()` whose `Arc<JitCode>`
-/// entries live inside a `LazyLock<Vec<...>>` (`'static`); tests
+/// Body is always `'static` — production wires the lookup to the
+/// per-index runtime cache whose `Arc<JitCode>` entries live inside a
+/// leaked cell table; tests
 /// either use static byte arrays or `Box::leak` to surface
 /// `'static`. Constraining the body's lifetime simplifies
 /// `WalkContext`'s lifetime parameters — otherwise the closure's
@@ -259,16 +259,15 @@ pub struct SubJitCodeBody {
 /// jitcode_index, .. }` and looks up `ALL_JITCODES[idx]`. Walker
 /// inverts the dependency: the caller supplies the lookup so the
 /// walker stays decoupled from the runtime's all-jitcodes table
-/// (production passes a closure over `crate::jitcode_runtime::all_jitcodes()`,
+/// (production passes the lazy per-index runtime lookup,
 /// tests pass synthetic closures over a local fixture map).
 pub type SubJitCodeLookup = dyn Fn(usize) -> Option<SubJitCodeBody>;
 
 /// Build a [`SubJitCodeBody`] view over the build-time `ALL_JITCODES[idx]`
-/// entry (`crate::jitcode_runtime::all_jitcodes`). Returns `None` for an
+/// entry. Returns `None` for an
 /// out-of-range index.
 ///
-/// The all-jitcodes table is `Box::leak`'d at load
-/// (`jitcode_runtime::load_all_jitcodes`), so the borrowed `code` /
+/// The per-index cell table is `Box::leak`'d at initialization, so the borrowed `code` /
 /// `constants_*` slices are `'static` as [`SubJitCodeBody`] requires.
 ///
 /// This is the production sub-jitcode lookup shape — the shadow walker,
@@ -277,17 +276,15 @@ pub type SubJitCodeLookup = dyn Fn(usize) -> Option<SubJitCodeBody>;
 /// callee body through it. RPython parity: a `BhDescr::JitCode {
 /// jitcode_index }` operand resolves to `ALL_JITCODES[jitcode_index]`.
 pub fn sub_jitcode_body_by_index(idx: usize) -> Option<SubJitCodeBody> {
-    crate::jitcode_runtime::all_jitcodes()
-        .get(idx)
-        .map(|jc| SubJitCodeBody {
-            code: jc.code.as_slice(),
-            num_regs_r: jc.num_regs_r(),
-            num_regs_i: jc.num_regs_i(),
-            num_regs_f: jc.num_regs_f(),
-            constants_i: jc.constants_i.as_slice(),
-            constants_r: jc.constants_r.as_slice(),
-            constants_f: jc.constants_f.as_slice(),
-        })
+    crate::jitcode_runtime::get_jitcode_ref_by_index(idx).map(|jc| SubJitCodeBody {
+        code: jc.code.as_slice(),
+        num_regs_r: jc.num_regs_r(),
+        num_regs_i: jc.num_regs_i(),
+        num_regs_f: jc.num_regs_f(),
+        constants_i: jc.constants_i.as_slice(),
+        constants_r: jc.constants_r.as_slice(),
+        constants_f: jc.constants_f.as_slice(),
+    })
 }
 
 /// State the walker reads from / writes to while stepping. RPython
@@ -1684,7 +1681,7 @@ pub enum DispatchError {
     ExpectedJitCodeDescr { pc: usize, descr_index: usize },
     /// `inline_call_*`'s descr resolved to a `jitcode_index`, but the
     /// caller's `sub_jitcode_lookup` returned `None`. Production wires
-    /// the lookup to `crate::jitcode_runtime::all_jitcodes()`; tests
+    /// the lookup to the lazy runtime jitcode cache; tests
     /// build synthetic maps. A `None` return means the codewriter
     /// emitted an index past the runtime's jitcode table.
     SubJitCodeNotFound { pc: usize, jitcode_index: usize },
@@ -3733,7 +3730,7 @@ fn dispatch_switch_id<Sym: WalkSym>(
 /// * `descr_refs`, `sub_jitcode_lookup` — caller-provided, same
 ///   contract as direct `walk()` callers. Production callers wire
 ///   `crate::jitcode_runtime::all_descrs()` + a JitCode-resolving
-///   closure over `crate::jitcode_runtime::all_jitcodes()`.
+///   closure over the lazy runtime jitcode cache.
 ///
 /// `is_top_level` selects the outer-frame semantic:
 ///

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -595,6 +595,11 @@ pub(super) fn build_trace_too_long_single_frame_miframe<Sym: WalkSym>(
 /// arbitrary control flow to an instruction that reads it.  So `OpRef::NONE`
 /// (dead, upstream's `box is None`) is skipped, and a live color with no
 /// concrete refuses the whole frame.
+///
+/// One live Ref color carries a value neither concrete lookup can express: the
+/// dead-`box_bool` marker holds a comparison's raw truth Int in a Ref register.
+/// It is unfillable by construction rather than unknown, so the Ref bank
+/// reconstructs the singleton instead of refusing — see there.
 fn fill_trace_too_long_register_banks<Sym: WalkSym>(
     ctx: &WalkContext<'_, '_, Sym>,
     miframe: &mut majit_metainterp::MIFrame,
@@ -660,7 +665,31 @@ fn fill_trace_too_long_register_banks<Sym: WalkSym>(
                     ConcreteValue::Ref(value) => Some(value as i64),
                     _ => None,
                 });
-        if let Some(value) = forwarded.or(from_shadow) {
+        // The dead-`box_bool` marker writes a comparison's RAW TRUTH Int
+        // straight into the Ref register rather than boxing it, on
+        // `compare_box_provably_dead`'s proof that no GUARD RESUME snapshot can
+        // observe the slot.  This bank copy is not a guard resume: the
+        // blackhole runs forward from a post-step pc, and the very next opcode
+        // is the `is_true` that reads exactly this color.  Neither arm above
+        // can represent an Int in a Ref bank, so the color would be skipped and
+        // the blackhole would read NULL — `is_true(NULL)` is false, which sends
+        // a `while` straight to its exit arm and drops every remaining
+        // iteration.  The truth value is known, so materialize the immortal
+        // singleton the box would have produced and keep the image exact.
+        //
+        // The marker is recognisable because its sites record the truth against
+        // ITSELF; a genuinely boxed bool records a distinct `boxed` key and its
+        // concrete is a Ref, so it is already served by `forwarded`.
+        let from_bool_marker = opref
+            .filter(|&value| value != OpRef::NONE)
+            .filter(|&value| bool_box_truth_lookup(value) == Some(value))
+            .and_then(|value| match ctx.trace_ctx.lookup_opref_concrete(value) {
+                Some(majit_ir::Value::Int(truth)) => {
+                    Some(pyre_object::w_bool_from(truth != 0) as i64)
+                }
+                _ => None,
+            });
+        if let Some(value) = forwarded.or(from_shadow).or(from_bool_marker) {
             miframe.ref_values[color] = Some(value);
         } else if opref.is_some_and(|value| value != OpRef::NONE) {
             s2dbg!("ref color={color} opref={opref:?} has no concrete");
@@ -4031,9 +4060,9 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     // dual of the LoadName/LoadGlobal cell fold.  Fires when the target slot
     // holds a stabilised immovable `IntMutableCell` and the store value is a
     // provably-plain-int box; emits `QUASIIMMUT_FIELD` + `setfield_gc_i(cell,
-    // intvalue)`, eliding the boxing + residual dict setitem.  Same
-    // handler-free gate as the LoadName fold (the fold elides a can-raise
-    // residual a `catch_exception/L` could resume into).
+    // intvalue)`, eliding the boxing + residual dict setitem.  Carries the
+    // LoadName fold's handler-free gate, and for the reason recorded there —
+    // the retrace storm, not a raise the fold could reach.
     //
     // Two staleness bugs were fixed before enabling this unconditionally:
     // (1) the fold now eagerly applies the concrete
@@ -5111,10 +5140,8 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
 
     // LoadName fold: module-scope LOAD_NAME mirror of the LoadGlobal fold
     // above.  The residual is `bh_load_name_fn(frame, w_name, namei)`, so
-    // r_args = [frame, w_name].  Same handler-free gate (the fold elides a
-    // CanRaise residual a `catch_exception` could otherwise resume into);
-    // `try_walker_load_name_cell_fold` gates module scope at runtime and
-    // routes non-module frames back to this residual.
+    // r_args = [frame, w_name].  `try_walker_load_name_cell_fold` gates module
+    // scope at runtime and routes non-module frames back to this residual.
     if ctx.is_authoritative_executor && ei.pyre_helper == majit_ir::PyreHelperKind::LoadName {
         if let (Some(&frame_opref), Some(&name_opref)) = (r_args.first(), r_args.get(1)) {
             if let (
@@ -5138,6 +5165,23 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
             ctx.trace_ctx.reads_module_global = true;
         }
     }
+
+    // The handler-free gate is NOT the raise argument the LoadGlobal fold above
+    // rebuts.  That argument transfers cleanly: both folds lower through
+    // `emit_namespace_cell_fold`, which fires only on a name already PRESENT in
+    // the module dict and watches that slot with `QUASIIMMUT_FIELD` +
+    // `GUARD_NOT_INVALIDATED`, so a rebind or a delete fails the loop instead of
+    // reaching a NameError, and a successful fold provably cannot raise.
+    //
+    // What the gate actually holds back is a RETRACE STORM in a raising module
+    // loop.  Lifted, `exception_reraise_tb_depth_jitstress` goes 0.90s -> 5.85s
+    // at loops_compiled 305 -> 1802 and `exception_reraise_tb_depth_hot`
+    // 0.25s -> 0.64s at 4 -> 137.  The LOAD fold is the one that storms —
+    // restoring the store gate alone does not avoid it.
+    //
+    // The scan is whole-body, so one `try` anywhere in a module also charges
+    // every name access in it a live dict lookup (~83ns each, linear in the
+    // count).  Narrowing that without waking the storm is unfinished work.
     if ctx.is_authoritative_executor
         && ei.pyre_helper == majit_ir::PyreHelperKind::LoadName
         && !jitcode_has_exception_handler(code)

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -1302,7 +1302,17 @@ fn flush_with_latched_stack(ctx: &TraceCtx, frame: usize, py_pc: usize, oprefs: 
                     // portal replaying the frame from its entry.
                     stack.push(r.as_usize() as pyre_object::PyObjectRef);
                 }
-                _ => return false,
+                other => {
+                    if fbw_debug_abort_enabled() {
+                        eprintln!(
+                            "[fbw-latched-flush] DECLINE at py_pc={py_pc}: slot {} of {} \
+                             opref={opref:?} concrete={other:?}",
+                            stack.len(),
+                            oprefs.len(),
+                        );
+                    }
+                    return false;
+                }
             }
         }
         // Why this latch exists, checkable at runtime.  Measured over
@@ -4061,8 +4071,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     // holds a stabilised immovable `IntMutableCell` and the store value is a
     // provably-plain-int box; emits `QUASIIMMUT_FIELD` + `setfield_gc_i(cell,
     // intvalue)`, eliding the boxing + residual dict setitem.  Carries the
-    // LoadName fold's handler-free gate, and for the reason recorded there —
-    // the retrace storm, not a raise the fold could reach.
+    // LoadName fold's handler-free gate, for the reason recorded there.
     //
     // Two staleness bugs were fixed before enabling this unconditionally:
     // (1) the fold now eagerly applies the concrete
@@ -5173,15 +5182,26 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
     // `GUARD_NOT_INVALIDATED`, so a rebind or a delete fails the loop instead of
     // reaching a NameError, and a successful fold provably cannot raise.
     //
-    // What the gate actually holds back is a RETRACE STORM in a raising module
-    // loop.  Lifted, `exception_reraise_tb_depth_jitstress` goes 0.90s -> 5.85s
-    // at loops_compiled 305 -> 1802 and `exception_reraise_tb_depth_hot`
-    // 0.25s -> 0.64s at 4 -> 137.  The LOAD fold is the one that storms —
-    // restoring the store gate alone does not avoid it.
+    // The gate is load-bearing because the fold INSTALLS the module dict's
+    // `version?` watcher, and that watcher is what makes a later bumping write
+    // in the same program abandon the walk with `ForceQuasiImmutable`.  That
+    // abort resumes mid-expression off a latched operand mirror, and when one
+    // latched slot is unbound the flush declines to the legacy replay, which
+    // then REFUSES to re-deliver an in-flight FOR_ITER item once a body effect
+    // has committed — the iteration is dropped and its accumulator increment is
+    // silently lost.  Lifting the gate to `DELETE_NAME`/`DELETE_GLOBAL` only
+    // (the implicit `del e` an `except X as e:` emits) reaches exactly that:
+    // `bench/synth/pickle_terminal_raise_resume` then prints 214 under the JIT
+    // against 216 interpreted, off one dropped iteration.  Both halves of that
+    // chain — the unbound mirror slot and the silent drop the decline falls
+    // back to — have to be closed before the handler shape stops standing in.
     //
     // The scan is whole-body, so one `try` anywhere in a module also charges
     // every name access in it a live dict lookup (~83ns each, linear in the
-    // count).  Narrowing that without waking the storm is unfinished work.
+    // count).  Measured on a 200k-iteration
+    // `bench/synth/exc_info_module_loop_hot`, folding it is worth 1.87us ->
+    // 1.32us per iteration; at the fixture's own 3000 iterations the difference
+    // sits under this box's noise floor.
     if ctx.is_authoritative_executor
         && ei.pyre_helper == majit_ir::PyreHelperKind::LoadName
         && !jitcode_has_exception_handler(code)

--- a/pyre/pyre-jit-trace/src/jitcode_runtime.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_runtime.rs
@@ -8,9 +8,9 @@
 //!
 //! majit's build-time side lives in `majit_translate::jitcode::JitCode`
 //! (serde-serializable, emitted by `build.rs` into `$OUT_DIR/jitcodes.bin`).
-//! This module deserializes that blob once on first access and hands out
-//! `Arc<JitCode>` shells. The configured portal index is read from the
-//! separately serialized generic `CompiledJitDriver` metadata.
+//! This module uses the separately encoded name/offset index to deserialize
+//! each `Arc<JitCode>` on first access. The configured portal index is read
+//! from the separately serialized generic `CompiledJitDriver` metadata.
 //!
 //! No opcode-body side table is serialized: `pipeline.jitcodes`, in allocation
 //! order, remains the single executable store matching RPython's model
@@ -28,9 +28,13 @@ use majit_translate::jitcode::{BhDescr, JitCode};
 static REHYDRATED_CALL_DESCR_REFS: LazyLock<Mutex<Vec<Option<DescrRef>>>> =
     LazyLock::new(|| Mutex::new(Vec::new()));
 
+struct JitCodeIndex {
+    names: Vec<String>,
+    offsets: Vec<u32>,
+}
+
 thread_local! {
-    /// Per-thread cached `&'static` to the build-time `pipeline.jitcodes`
-    /// table.  Set on first access (see [`load_all_jitcodes`]).
+    /// Per-thread lazily populated build-time `pipeline.jitcodes` table.
     ///
     /// `thread_local!` rather than a process-wide `static` because the
     /// `JitCode` payload transitively holds `Variable` graphs whose
@@ -40,33 +44,73 @@ thread_local! {
     /// per-thread cache matches the RPython module-level dict semantics
     /// without forcing `Variable` to become thread-safe.
     ///
-    /// The cached value is a `&'static [Arc<JitCode>]` — produced via
-    /// `Box::leak` on the first call per thread so downstream consumers
-    /// can keep their existing `'static` lifetime contracts
+    /// The cached cells live in a leaked slice so downstream consumers can
+    /// keep their existing `'static` lifetime contracts
     /// (`SubJitCodeBody::code: &'static [u8]`, walker `WalkContext`
-    /// lifetimes, etc.).  The leak is one-time per thread; a typical
-    /// single-threaded JIT runtime leaks once for the process lifetime,
-    /// matching the previous `LazyLock<Vec<...>>` storage.
-    static ALL_JITCODES: OnceCell<&'static [Arc<JitCode>]> = const { OnceCell::new() };
+    /// lifetimes, etc.). Each cell is filled only after all runtime patching
+    /// and the dense-index assertion have completed.
+    static JITCODE_CELLS: OnceCell<&'static [OnceCell<Arc<JitCode>>]> = const { OnceCell::new() };
+
+    /// Decoded names and byte offsets; loading this never decodes a body.
+    static JITCODE_INDEX: OnceCell<&'static JitCodeIndex> = const { OnceCell::new() };
+
+    /// Compatibility accessor storage for tests and diagnostics that
+    /// explicitly request the complete table.
+    static FORCED_ALL_JITCODES: OnceCell<&'static [Arc<JitCode>]> = const { OnceCell::new() };
 
     /// Explicit build-time JIT-driver metadata for every configured driver.
     static COMPILED_JIT_DRIVERS: OnceCell<&'static [CompiledJitDriver]> = const { OnceCell::new() };
 
     /// Per-thread cached `&'static` to the frozen source-translation
     /// indirect-call-target family.  Same storage shape and the same
-    /// `Box::leak` rationale as [`ALL_JITCODES`], which it is derived from;
+    /// `Box::leak` rationale as [`JITCODE_CELLS`], which it is derived from;
     /// see [`indirectcalltargets`] for why the family is built once.
     static INDIRECTCALLTARGETS: OnceCell<&'static [Arc<majit_metainterp::jitcode::JitCode>]> =
         const { OnceCell::new() };
 }
 
-fn load_all_jitcodes() -> &'static [Arc<JitCode>] {
+fn load_jitcode_index() -> &'static JitCodeIndex {
+    const INDEX_BYTES: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/jitcodes_index.bin"));
+    const BODY_BYTES: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/jitcodes.bin"));
+    let (names, offsets): (Vec<String>, Vec<u32>) = bincode::deserialize(INDEX_BYTES)
+        .unwrap_or_else(|e| {
+            panic!(
+                "pyre-jit-trace: failed to deserialize jitcodes_index.bin \
+                 ({} bytes): {e}",
+                INDEX_BYTES.len(),
+            )
+        });
+    assert_eq!(
+        offsets.len(),
+        names.len() + 1,
+        "pyre-jit-trace: jitcode index has {} names but {} offsets",
+        names.len(),
+        offsets.len(),
+    );
+    assert_eq!(offsets.first().copied(), Some(0));
+    assert_eq!(offsets.last().copied(), Some(BODY_BYTES.len() as u32));
+    assert!(offsets.windows(2).all(|pair| pair[0] <= pair[1]));
+    Box::leak(Box::new(JitCodeIndex { names, offsets }))
+}
+
+fn jitcode_index() -> &'static JitCodeIndex {
+    JITCODE_INDEX.with(|cell| *cell.get_or_init(load_jitcode_index))
+}
+
+pub fn jitcode_count() -> usize {
+    jitcode_index().offsets.len() - 1
+}
+
+fn load_jitcode(index: usize) -> Arc<JitCode> {
     const BYTES: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/jitcodes.bin"));
-    let mut vec: Vec<Arc<JitCode>> = bincode::deserialize(BYTES).unwrap_or_else(|e| {
+    let offsets = &jitcode_index().offsets;
+    let start = offsets[index] as usize;
+    let end = offsets[index + 1] as usize;
+    let mut jitcode: Arc<JitCode> = bincode::deserialize(&BYTES[start..end]).unwrap_or_else(|e| {
         panic!(
-            "pyre-jit-trace: failed to deserialize jitcodes.bin \
-             ({} bytes): {e}",
-            BYTES.len(),
+            "pyre-jit-trace: failed to deserialize jitcodes.bin entry {index} \
+             ({start}..{end} of {} bytes): {e}",
+            BYTES.len()
         )
     });
     // RPython's translator AOT-compiles every helper into the same binary so
@@ -75,31 +119,45 @@ fn load_all_jitcodes() -> &'static [Arc<JitCode>] {
     // build-time addresses; patch each Arc<JitCode> in place — refcount is
     // still 1 here, no consumer has cloned yet — using
     // `pyre_interpreter::jit_trace_fnaddrs()`'s runtime values.
-    crate::runtime_fnaddr_patch::patch_constants_i_fnaddrs(&mut vec);
+    crate::runtime_fnaddr_patch::patch_constants_i_fnaddrs(std::slice::from_mut(&mut jitcode));
     // The codewriter also baked stale build-time host-static *data* addresses
     // (`PyType` singletons + prebuilt refs from `HostStaticAddrs`) into
     // `constants_i` — e.g. `is_int`'s `&INT_TYPE` inlined into `w_list_append`.
     // Re-pair them with the runtime addresses while refcount is still 1.
-    crate::runtime_fnaddr_patch::patch_static_addr_constants(&mut vec);
+    crate::runtime_fnaddr_patch::patch_static_addr_constants(std::slice::from_mut(&mut jitcode));
     // Deferred prebuilt-string constants the codewriter could not allocate
     // at build time (separate process) carry a non-canonical sentinel in
     // `constants_r`; materialize their immortal STR blocks and overwrite the
     // sentinels here, while refcount is still 1 — before any consumer can
     // observe a sentinel as a forged GCREF.
-    crate::runtime_fnaddr_patch::materialize_str_consts(&mut vec);
+    crate::runtime_fnaddr_patch::materialize_str_consts(std::slice::from_mut(&mut jitcode));
     // RPython codewriter.py:80: `all_jitcodes[jitcode.index] is jitcode`.
-    // Check at load time so any regression in
+    // Check per entry so any regression in
     // `collect_jitcodes_in_alloc_order` is caught immediately.
-    for (i, jc) in vec.iter().enumerate() {
-        assert_eq!(
-            jc.index(),
-            i,
-            "pyre-jit-trace: jitcode[{i}].index = {} (expected {i}); \
-             RPython invariant `all_jitcodes[i].index == i` broken",
-            jc.index(),
-        );
-    }
-    Box::leak(vec.into_boxed_slice())
+    assert_eq!(
+        jitcode.index(),
+        index,
+        "pyre-jit-trace: jitcode[{index}].index = {} (expected {index}); \
+         RPython invariant `all_jitcodes[i].index == i` broken",
+        jitcode.index(),
+    );
+    jitcode
+}
+
+fn load_jitcode_cells() -> &'static [OnceCell<Arc<JitCode>>] {
+    let cells = (0..jitcode_count())
+        .map(|_| OnceCell::new())
+        .collect::<Vec<_>>();
+    Box::leak(cells.into_boxed_slice())
+}
+
+fn jitcode_cells() -> &'static [OnceCell<Arc<JitCode>>] {
+    JITCODE_CELLS.with(|cell| *cell.get_or_init(load_jitcode_cells))
+}
+
+pub(crate) fn get_jitcode_ref_by_index(index: usize) -> Option<&'static Arc<JitCode>> {
+    let cell = jitcode_cells().get(index)?;
+    Some(cell.get_or_init(|| load_jitcode(index)))
 }
 
 fn load_compiled_jit_drivers() -> &'static [CompiledJitDriver] {
@@ -114,17 +172,24 @@ fn load_compiled_jit_drivers() -> &'static [CompiledJitDriver] {
     Box::leak(vec.into_boxed_slice())
 }
 
-/// RPython: `metainterp_sd.jitcodes` — full all_jitcodes table.
+/// RPython: `metainterp_sd.jitcodes` — explicitly force the full table.
 pub fn all_jitcodes() -> &'static [Arc<JitCode>] {
-    ALL_JITCODES.with(|cell| *cell.get_or_init(load_all_jitcodes))
+    FORCED_ALL_JITCODES.with(|cell| {
+        *cell.get_or_init(|| {
+            let all = (0..jitcode_count())
+                .map(|index| get_jitcode_by_index(index).unwrap())
+                .collect::<Vec<_>>();
+            Box::leak(all.into_boxed_slice())
+        })
+    })
 }
 
 /// RPython: `metainterp_sd.jitcodes[index]` where `index == jitcode.index`.
 ///
-/// The dense invariant (`ALL_JITCODES[i].index == i`) is asserted at load
-/// time, so direct vec indexing is correct.
+/// The dense invariant (`all_jitcodes[i].index == i`) is asserted when each
+/// entry is decoded, so direct indexed lookup is correct.
 pub fn get_jitcode_by_index(index: usize) -> Option<Arc<JitCode>> {
-    all_jitcodes().get(index).cloned()
+    get_jitcode_ref_by_index(index).cloned()
 }
 
 /// The source translator's exact `Assembler.indirectcalltargets` set as
@@ -157,7 +222,7 @@ fn build_indirectcalltargets() -> &'static [Arc<majit_metainterp::jitcode::JitCo
                 panic!(
                     "pyre-jit-trace: indirect-call target index {index} is \
                      outside all_jitcodes (len={})",
-                    all_jitcodes().len()
+                    jitcode_count()
                 )
             });
             Arc::new(majit_metainterp::jitcode::JitCode::from_canonical(
@@ -179,8 +244,7 @@ fn build_indirectcalltargets() -> &'static [Arc<majit_metainterp::jitcode::JitCo
 thread_local! {
     /// Cached portal jitcode index for the current thread.  See
     /// `portal_jitcode` for the resolution semantics.  `thread_local!`
-    /// because its initializer iterates `ALL_JITCODES` (also
-    /// thread_local).
+    /// because its initializer resolves the thread-local jitcode table.
     static PORTAL_JITCODE_INDEX: OnceCell<Option<usize>> = const { OnceCell::new() };
 }
 
@@ -190,7 +254,7 @@ fn compute_portal_jitcode_index_for_key(key: &str) -> Option<usize> {
         .iter()
         .find(|driver| driver.portal.canonical_key() == key)?;
     let index = driver.main_jitcode_index;
-    let jitcode = all_jitcodes().get(index).unwrap_or_else(|| {
+    let jitcode = get_jitcode_ref_by_index(index).unwrap_or_else(|| {
         panic!("configured portal `{key}` refers to missing JitCode index {index}",)
     });
     assert!(
@@ -252,12 +316,11 @@ pub fn portal_jitcode_for_key(key: &str) -> Option<Arc<JitCode>> {
 // builds a by-index sub-walk from `get_jitcode_by_index`.
 thread_local! {
     /// Cached `ALL_JITCODES` index of `w_list_append` for the current
-    /// thread. `thread_local!` because the initializer iterates
-    /// `ALL_JITCODES` (also thread_local).
+    /// thread. `thread_local!` because the names index is also thread-local.
     static LIST_APPEND_JITCODE_INDEX: OnceCell<Option<usize>> = const { OnceCell::new() };
 }
 
-/// Scan `ALL_JITCODES` for the unique entry whose `name` equals `name`.
+/// Scan the build-time names index for the unique entry equal to `name`.
 ///
 /// Returns `None` when no entry matches (e.g. compact test inputs that
 /// omit the helper). Panics on a duplicate leaf name — the by-name
@@ -266,11 +329,11 @@ thread_local! {
 /// regression that must surface immediately rather than silently pick
 /// the wrong body.
 fn compute_named_jitcode_index(name: &str) -> Option<usize> {
-    let all = all_jitcodes();
-    let mut hits = all
+    let mut hits = jitcode_index()
+        .names
         .iter()
         .enumerate()
-        .filter(|(_, jc)| jc.name == name)
+        .filter(|(_, jitcode_name)| *jitcode_name == name)
         .map(|(i, _)| i);
     let first = hits.next();
     if hits.next().is_some() {
@@ -1599,6 +1662,27 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn index_queries_do_not_decode_jitcode_bodies() {
+        std::thread::spawn(|| {
+            assert!(jitcode_cells().iter().all(|cell| cell.get().is_none()));
+            assert!(compute_named_jitcode_index("__missing_jitcode_name__").is_none());
+            assert!(jitcode_cells().iter().all(|cell| cell.get().is_none()));
+
+            assert!(get_jitcode_by_index(0).is_some());
+            assert!(jitcode_cells()[0].get().is_some());
+            assert_eq!(
+                jitcode_cells()
+                    .iter()
+                    .filter(|cell| cell.get().is_some())
+                    .count(),
+                1
+            );
+        })
+        .join()
+        .unwrap();
     }
 
     #[test]

--- a/pyre/pyre-jit-trace/src/runtime_fnaddr_patch.rs
+++ b/pyre/pyre-jit-trace/src/runtime_fnaddr_patch.rs
@@ -31,7 +31,7 @@
 //! invariant.
 
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 
 use majit_translate::jitcode::JitCode;
 
@@ -54,9 +54,9 @@ fn build_time_fnaddr_bindings() -> Vec<(String, i64)> {
 
 /// Apply the build → runtime fnaddr correspondence to every JitCode the
 /// caller just deserialised.  Mutates each Arc in place — refcount must
-/// be 1 on entry (the canonical `ALL_JITCODES` LazyLock satisfies this
-/// because `bincode::deserialize` produces fresh `Arc::new(...)` shells
-/// before any consumer can clone them).
+/// be 1 on entry (the per-index loader satisfies this because
+/// `bincode::deserialize` produces a fresh `Arc::new(...)` shell before any
+/// consumer can clone it).
 ///
 /// `JitCode.fnaddr` carries the shell-level fnaddr the codewriter
 /// recorded in `CallControl::get_jitcode` (`call.rs:2647`); the per-
@@ -65,7 +65,36 @@ fn build_time_fnaddr_bindings() -> Vec<(String, i64)> {
 /// `emit_const_i_from_const` path (`assembler.rs:2453-2473`).  Both
 /// surfaces are patched so the walker sees the same address regardless
 /// of which lookup it routes through.
-pub fn patch_constants_i_fnaddrs(jitcodes: &mut Vec<Arc<JitCode>>) {
+pub fn patch_constants_i_fnaddrs(jitcodes: &mut [Arc<JitCode>]) {
+    let correspondence = &*FNADDR_CORRESPONDENCE;
+
+    if correspondence.is_empty() {
+        return;
+    }
+
+    for arc in jitcodes.iter_mut() {
+        let jc = Arc::get_mut(arc).expect(
+            "patch_constants_i_fnaddrs: Arc<JitCode> already shared before patch — \
+             every caller must run this before publishing the table to consumers",
+        );
+        if let Some(&runtime) = correspondence.get(&jc.fnaddr) {
+            jc.fnaddr = runtime;
+        }
+        // Some shells reach the persisted table without a committed body
+        // (e.g. `Default::default()` placeholders kept for `Arc<JitCode>::
+        // default()` consumers in `BlackholeInterpreter::new`); they carry
+        // empty `constants_i` so skipping the body-mut access is safe.
+        if jc.try_body().is_some() {
+            for c in jc.body_mut().constants_i.iter_mut() {
+                if let Some(&runtime) = correspondence.get(c) {
+                    *c = runtime;
+                }
+            }
+        }
+    }
+}
+
+static FNADDR_CORRESPONDENCE: LazyLock<HashMap<i64, i64>> = LazyLock::new(|| {
     let build_bindings = build_time_fnaddr_bindings();
     let runtime_bindings = pyre_interpreter::jit_trace_fnaddrs();
 
@@ -117,31 +146,8 @@ pub fn patch_constants_i_fnaddrs(jitcodes: &mut Vec<Arc<JitCode>>) {
         }
     }
 
-    if correspondence.is_empty() {
-        return;
-    }
-
-    for arc in jitcodes.iter_mut() {
-        let jc = Arc::get_mut(arc).expect(
-            "patch_constants_i_fnaddrs: Arc<JitCode> already shared before patch — \
-             every caller must run this before publishing the table to consumers",
-        );
-        if let Some(&runtime) = correspondence.get(&jc.fnaddr) {
-            jc.fnaddr = runtime;
-        }
-        // Some shells reach the persisted table without a committed body
-        // (e.g. `Default::default()` placeholders kept for `Arc<JitCode>::
-        // default()` consumers in `BlackholeInterpreter::new`); they carry
-        // empty `constants_i` so skipping the body-mut access is safe.
-        if jc.try_body().is_some() {
-            for c in jc.body_mut().constants_i.iter_mut() {
-                if let Some(&runtime) = correspondence.get(c) {
-                    *c = runtime;
-                }
-            }
-        }
-    }
-}
+    correspondence
+});
 
 /// Build-time `(name, build_addr)` snapshot for the host `PyType` singleton
 /// pointers the codewriter baked into `constants_i` (supplied through
@@ -181,22 +187,8 @@ fn build_time_ref_bindings() -> Vec<(String, i64)> {
 /// constant in `constants_r`, while one consumed as an integer lands in
 /// `constants_i`.  `JitCode.fnaddr` is left untouched (these are data, not
 /// call targets).
-pub fn patch_static_addr_constants(jitcodes: &mut Vec<Arc<JitCode>>) {
-    let mut runtime_map: HashMap<&'static str, i64> = HashMap::new();
-    runtime_map.extend(pyre_interpreter::jit_static_pytype_addrs());
-    runtime_map.extend(pyre_interpreter::jit_static_ref_addrs());
-
-    let mut correspondence: HashMap<i64, i64> = HashMap::new();
-    for (name, build_addr) in build_time_pytype_bindings()
-        .into_iter()
-        .chain(build_time_ref_bindings())
-    {
-        if let Some(&runtime_addr) = runtime_map.get(name.as_str()) {
-            if build_addr != runtime_addr {
-                correspondence.insert(build_addr, runtime_addr);
-            }
-        }
-    }
+pub fn patch_static_addr_constants(jitcodes: &mut [Arc<JitCode>]) {
+    let correspondence = &*STATIC_ADDR_CORRESPONDENCE;
 
     if correspondence.is_empty() {
         return;
@@ -220,6 +212,45 @@ pub fn patch_static_addr_constants(jitcodes: &mut Vec<Arc<JitCode>>) {
             }
         }
     }
+}
+
+static STATIC_ADDR_CORRESPONDENCE: LazyLock<HashMap<i64, i64>> = LazyLock::new(|| {
+    let mut runtime_map: HashMap<&'static str, i64> = HashMap::new();
+    runtime_map.extend(pyre_interpreter::jit_static_pytype_addrs());
+    runtime_map.extend(pyre_interpreter::jit_static_ref_addrs());
+
+    let mut correspondence: HashMap<i64, i64> = HashMap::new();
+    for (name, build_addr) in build_time_pytype_bindings()
+        .into_iter()
+        .chain(build_time_ref_bindings())
+    {
+        if let Some(&runtime_addr) = runtime_map.get(name.as_str()) {
+            if build_addr != runtime_addr {
+                correspondence.insert(build_addr, runtime_addr);
+            }
+        }
+    }
+
+    correspondence
+});
+
+/// Take both build -> runtime address snapshots now.
+///
+/// Both maps are `LazyLock`, so without this they would be built at whatever
+/// moment the first jitcode happens to be decoded.  Once jitcode bodies decode
+/// lazily that moment is mid-trace, long after `init_typeobjects` has retagged
+/// the `PyType` singletons — and the map, frozen there, would then patch every
+/// later-decoded body's `constants_r` with addresses that no longer name what
+/// the runtime holds.  Those constants reach a compiled loop's gc_table, so the
+/// collector drags a bad root out of it (`GC BUG: invalid type_id`, site
+/// `minor_root_target`).
+///
+/// Calling this from `ensure_finish_setup` restores the snapshot instant the
+/// whole-table loader had, when the first `all_jitcodes()` decoded everything
+/// against one consistent view.
+pub fn prime_address_correspondences() {
+    LazyLock::force(&FNADDR_CORRESPONDENCE);
+    LazyLock::force(&STATIC_ADDR_CORRESPONDENCE);
 }
 
 /// High 16 bits of a deferred prebuilt-string sentinel (see
@@ -252,14 +283,18 @@ fn materialize_prebuilt_str(bytes: &[u8], _precomputed_hash: i64) -> i64 {
 /// sibling).  The build-time translator could not allocate a runtime STR
 /// block, so it pooled a non-canonical sentinel in the slot named by each
 /// descriptor's `constants_r_index`; here we allocate the immortal block and
-/// overwrite the sentinel with its live address.  Runs at load time, before
-/// `Box::leak` publishes the table — refcount must be 1 (`Arc::get_mut`), so
-/// no consumer can observe the sentinel as a forged GCREF.
+/// overwrite the sentinel with its live address. Runs before the per-index
+/// `OnceCell` publishes the entry — refcount must be 1 (`Arc::get_mut`), so no
+/// consumer can observe the sentinel as a forged GCREF.
 ///
 /// Identical literals are interned by bytes across the whole table so one
 /// immortal block (one identity) is shared, the runtime analog of the
-/// assembler's per-jitcode dedup.
-pub fn materialize_str_consts(jitcodes: &mut Vec<Arc<JitCode>>) {
+/// assembler's per-jitcode dedup.  `interned` is only a local fast path over
+/// that: [`materialize_prebuilt_str`] resolves through
+/// `box_str_constant`'s process-wide `STRING_INTERN_TABLE`, so the one-block
+/// identity holds across calls even though entries are materialized one
+/// jitcode at a time.
+pub fn materialize_str_consts(jitcodes: &mut [Arc<JitCode>]) {
     let mut interned: HashMap<Vec<u8>, i64> = HashMap::new();
     for arc in jitcodes.iter_mut() {
         // Body-less placeholder shells, and bodies with no deferred strings
@@ -383,6 +418,33 @@ mod tests {
             "identical literals must share one immortal W_UnicodeObject",
         );
         assert_ne!(a0, sentinel(0));
+    }
+
+    /// The lazy per-index loader materializes one entry per call, so the
+    /// call-local `interned` map cannot be what shares the block between two
+    /// jitcodes — `box_str_constant`'s process-wide intern table is.  Pins
+    /// that the one-block identity survives the split into separate calls.
+    #[test]
+    fn materialize_str_consts_interns_across_separate_calls() {
+        std::thread::spawn(|| {
+            let desc = || StrConstDescriptor {
+                constants_r_index: 0,
+                bytes: b"y".to_vec(),
+                precomputed_hash: 9,
+            };
+            let mut first = vec![jitcode_with_str_consts(vec![desc()])];
+            let mut second = vec![jitcode_with_str_consts(vec![desc()])];
+            materialize_str_consts(&mut first);
+            materialize_str_consts(&mut second);
+            assert_eq!(
+                first[0].body().constants_r[0],
+                second[0].body().constants_r[0],
+                "identical literals must share one immortal W_UnicodeObject \
+                 even when materialized one jitcode at a time",
+            );
+        })
+        .join()
+        .unwrap();
     }
 
     #[test]

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -409,7 +409,7 @@ impl MetaInterpStaticData {
     /// Keep the leading `jitcodes` slots that a build-time jitcode's baked
     /// `JitCode::index` can name out of the runtime append space.
     ///
-    /// The build-time table is dense (`all_jitcodes()[i].index == i`), so its
+    /// The build-time table is dense (`get_jitcode_by_index(i).index == i`), so its
     /// length is exactly that range, and
     /// [`install_build_time_jitcode_at`] writes into it verbatim — a resume
     /// frame records the baked index and resolves it as `sd.jitcodes[index]`.
@@ -420,7 +420,11 @@ impl MetaInterpStaticData {
     ///
     /// Idempotent: a no-op once the leading slots exist.
     fn reserve_build_time_index_space(&mut self) {
-        let reserved = crate::jitcode_runtime::all_jitcodes().len();
+        // Snapshot the build -> runtime address correspondences here, at the
+        // instant the whole-table loader used to take them, rather than
+        // wherever the first lazy body decode lands.
+        crate::runtime_fnaddr_patch::prime_address_correspondences();
+        let reserved = crate::jitcode_runtime::jitcode_count();
         while self.jitcodes.len() < reserved {
             let index = self.jitcodes.len() as i32;
             let payload = std::sync::Arc::new(crate::PyJitCode::skeleton(std::ptr::null()));
@@ -756,7 +760,7 @@ pub fn install_jitcode_for(
 /// at exactly that slot.
 ///
 /// The two index spaces no longer overlap: the leading
-/// `all_jitcodes().len()` slots are reserved for build-time indices
+/// `jitcode_count()` slots are reserved for build-time indices
 /// (`MetaInterpStaticData::reserve_build_time_index_space`) and runtime
 /// PyCode entries append above them, so the write below can only replace a
 /// reserved skeleton or an earlier install of the same portal.
@@ -1360,7 +1364,7 @@ pub fn frame_value_count_at(jitcode_index: i32, pc: i32) -> usize {
 /// CodeObject. A novable driver over an extracted interpreter body — jd1
 /// `unpackiterable_driver`, whose jitcode is the
 /// `_unpackiterable_unknown_length` graph plus its inlined build-time callees —
-/// numbers against `jitcode_runtime::all_jitcodes()`.
+/// numbers against the lazy build-time jitcode table.
 ///
 /// Decoding one space's index against the other's table does not fail loudly,
 /// which is why the store has to be picked per driver rather than tried and

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -1568,33 +1568,101 @@ fn inject_root_call_result<Sym: WalkSym>(
     true
 }
 
-/// The ROOT frame's `except` handler jitcode pc covering the CALL paused at
-/// `root_pc`, for the carrier-boundary `finishframe_exception` (a depth-2
-/// inlined callee raised).  `root_pc` is the CALL's post-call resume `-live-`,
-/// with the enclosing try's `catch_exception/L` sitting BEHIND it (the same
-/// shape the single-frame exception-edge router scans), so read backward.
-/// The handler is accepted on the catch alone, as `finishframe_exception`
-/// (`pyjitpl.py:2530-2546`) does; where the handler leads is `finishframe`'s
-/// business (`pyjitpl.py:2503-2525`).
+/// The paused frame's `except` handler jitcode pc covering its CALL, for the
+/// carrier-boundary `finishframe_exception`.  The resume pc is the CALL's
+/// post-call `-live-`, with the enclosing `catch_exception/L` sitting behind
+/// it.  The handler is accepted on the catch alone, as
+/// `pyjitpl.py finishframe_exception` does; where it leads is `finishframe`'s
+/// business.
+fn carrier_catch_target(code: &[u8], pc: usize, frame: &str) -> Option<usize> {
+    // The paused caller's resume pc is the CALL's post-call `-live-`; the
+    // `catch_exception/L` for the enclosing try sits BEHIND it (between the
+    // CALL's post-call `-live-` and the next op), so scan backward — the same
+    // lookup the single-frame exception-edge router uses.
+    // `pc` is the CALL's OWN trailing `-live-`, one op short of the
+    // block-entry `-live-` the backward scan keys off, so read forward first
+    // and keep the backward scan for callers already at that coordinate.
+    let candidate = crate::jitcode_dispatch::catch_target_after_resume_live(code, pc)
+        .or_else(|| crate::jitcode_dispatch::find_catch_before_resume_live(code, pc));
+    if crate::jitcode_dispatch::p2_diag_enabled() {
+        eprintln!("[p2-raise] frame={frame} pc={pc} catch_before={candidate:?}");
+    }
+    candidate
+}
+
+/// The `PyTraceback` node a paused middle frame contributes as an exception
+/// crosses it on the drain's unwind.
+///
+/// `pyopcode.py handle_operation_error` runs
+/// `pytraceback.record_application_traceback` for EVERY frame the exception
+/// passes through, not only the one that catches; the walk-level sub-walk arm
+/// records it for an inlined callee the same way.  A frame this drain crosses
+/// is reconstructed from resume data and never becomes a real `PyFrame`, so
+/// nothing downstream would record it — the node has to be emitted here, and at
+/// runtime as well as for the recording pass, or a `tb_frame.f_code.co_name`
+/// walk comes up one level short on exactly the deopt iterations.
+///
+/// The recipe carries no materialized frame, so this takes the fabricating
+/// hook: it builds one from the promoted code / globals, which is what
+/// `record_inline_application_traceback` falls back to for an unseeded level.
+fn record_carrier_crossed_frame_traceback(
+    ctx: &mut TraceCtx,
+    recipe: &majit_metainterp::ReconstructRecipe,
+    exc: majit_ir::OpRef,
+    exc_concrete: crate::state::ConcreteValue,
+) {
+    let crate::state::ConcreteValue::Ref(exc_ptr) = exc_concrete else {
+        return;
+    };
+    if exc_ptr.is_null() {
+        return;
+    }
+    let w_code = crate::state::recover_inline_callee_code(recipe.code_ptr);
+    // A synthetic frame carries the sentinel or null instead of a real code
+    // object; the hook dereferences it, so both checks precede `is_code`, whose
+    // type check would deref the sentinel.
+    if w_code.is_null() || w_code as usize == usize::MAX {
+        return;
+    }
+    if !unsafe { pyre_interpreter::pycode::is_code(w_code) } {
+        return;
+    }
+    let w_globals = crate::state::recover_inline_callee_globals(recipe.code_ptr);
+    majit_metainterp::record_inline_application_traceback_for_recording(
+        exc_ptr as usize as i64,
+        w_code as usize as i64,
+        w_globals as usize as i64,
+        recipe.jitcode_index,
+        recipe.jitcode_pc,
+    );
+    let hook = majit_metainterp::record_inline_application_traceback_hook_address();
+    if hook.is_null() || exc.is_none() {
+        return;
+    }
+    let w_code_op = ctx.const_ref(w_code as usize as i64);
+    let w_globals_op = ctx.const_ref(w_globals as usize as i64);
+    let jitcode_op = ctx.const_int(i64::from(recipe.jitcode_index));
+    let opcode_op = ctx.const_int(i64::from(recipe.jitcode_pc));
+    ctx.call_void_typed_with_effect(
+        hook,
+        &[exc, w_code_op, w_globals_op, jitcode_op, opcode_op],
+        &[
+            majit_ir::Type::Ref,
+            majit_ir::Type::Ref,
+            majit_ir::Type::Ref,
+            majit_ir::Type::Int,
+            majit_ir::Type::Int,
+        ],
+        majit_metainterp::default_effect_info(),
+    );
+}
+
 fn carrier_root_catch_target<Sym: WalkSym>(sym: &Sym, root_pc: usize) -> Option<usize> {
     if sym.jitcode().is_null() {
         return None;
     }
     let payload = unsafe { &(*sym.jitcode()).payload };
-    let code = payload.jitcode.code.as_slice();
-    // The paused caller's resume pc is the CALL's post-call `-live-`; the
-    // `catch_exception/L` for the enclosing try sits BEHIND it (between the
-    // CALL's post-call `-live-` and the next op), so scan backward — the same
-    // lookup the single-frame exception-edge router uses.
-    // `root_pc` is the CALL's OWN trailing `-live-`, one op short of the
-    // block-entry `-live-` the backward scan keys off, so read forward first
-    // and keep the backward scan for callers already at that coordinate.
-    let candidate = crate::jitcode_dispatch::catch_target_after_resume_live(code, root_pc)
-        .or_else(|| crate::jitcode_dispatch::find_catch_before_resume_live(code, root_pc));
-    if crate::jitcode_dispatch::p2_diag_enabled() {
-        eprintln!("[p2-raise] root_pc={root_pc} catch_before={candidate:?}");
-    }
-    candidate
+    carrier_catch_target(payload.jitcode.code.as_slice(), root_pc, "root")
 }
 
 fn discard_bridge_carrier_walk<Sym: WalkSym>(
@@ -1813,13 +1881,13 @@ fn drive_bridge_carrier_walk<Sym: WalkSym>(
     }
 
     // `finishframe_exception` at the carrier boundary: the inlined callee's
-    // sub-walk raised and had no local handler, so it surfaced `SubRaise`.  The
-    // ROOT frame paused at the CALL; if its `except` handler covers the CALL and
-    // rejoins a loop, deliver the exception to that handler and continue the
-    // root walk from it (the same handler-entry reconstruction the walk-level
-    // SubRaise routing performs, threaded across the carrier the sub-walk
-    // crossed on its own).  Without this the raise is dropped and re-interpreted
-    // every iteration (deopt-storm).
+    // sub-walk raised and had no local handler, so it surfaced `SubRaise`.
+    // Scan paused middle frames from deepest to shallowest. A frame without a
+    // covering handler closes as the exception passes through; a middle-frame
+    // handler needs its own continuation walk, so that shape still declines.
+    // Once the exception reaches the ROOT frame, deliver it to a covering
+    // handler and continue the root walk. Without this the raise is dropped and
+    // re-interpreted every iteration (deopt-storm).
     //
     // A root frame with no covering handler is the framestack-exhausted arm of
     // the same walk: `finishframe_exception` runs out of frames to scan and
@@ -1834,7 +1902,50 @@ fn drive_bridge_carrier_walk<Sym: WalkSym>(
         _ => None,
     };
     if let Some((exc, exc_concrete)) = subwalk_raise {
-        if carrier.recipes.len() == 1 {
+        // `finishframe_exception` walks the framestack from the top down,
+        // popping each frame whose pc carries no `catch_exception`.  The
+        // deepest frame is the sub-walk that just raised and its
+        // `carrier_ec_leave` already ran; the middles between it and the root
+        // are `recipes[n-2]..recipes[0]`, and the root is handled below.
+        //
+        // Decide the whole chain BEFORE closing anything: `carrier_ec_leave`
+        // performs the concrete leave as well as recording it, so a mid-chain
+        // decline that had already closed a frame would leave the interpreter's
+        // `topframeref` one level short for the blackhole replay the abort
+        // epilogue hands the iteration to.
+        let n = carrier.recipes.len();
+        let middles = &carrier.recipes[..n.saturating_sub(1)];
+        let middles_ok = n >= 1
+            && n <= crate::jitcode_dispatch::fbw_max_multiframe_depth()
+            && middles.iter().rev().all(|middle| {
+                let Some(middle_pjc) = crate::state::pyjitcode_for_code(middle.code_ptr) else {
+                    crate::jitcode_dispatch::census_record("P2Drain::NoMiddlePjc");
+                    return false;
+                };
+                // A middle that catches has to be ENTERED at its handler and
+                // walked on from there, which can put every shallower frame
+                // back on the value path.  Decline that shape; the exception
+                // passes straight through the rest.
+                if carrier_catch_target(
+                    middle_pjc.jitcode.code.as_slice(),
+                    middle.jitcode_pc as usize,
+                    "middle",
+                )
+                .is_some()
+                {
+                    crate::jitcode_dispatch::census_record("P2Drain::MiddleCatchesRaise");
+                    return false;
+                }
+                true
+            });
+        if middles_ok {
+            // Deepest-first, the order the exception actually crosses them, so
+            // the nodes prepend into the same chain order the interpreter
+            // builds.
+            for middle in middles.iter().rev() {
+                record_carrier_crossed_frame_traceback(ctx, middle, exc, exc_concrete);
+                crate::jitcode_dispatch::carrier_ec_leave(ctx, sym, true);
+            }
             let catch_target = carrier_root_catch_target(sym, root_pc);
             crate::jitcode_dispatch::set_carrier_raise_seed(
                 crate::jitcode_dispatch::CarrierRaiseSeed {


### PR DESCRIPTION
Two JIT fixes found while attributing the slowest exception benchmarks against pypy.

### `jit: key the callee is-None inline decline on the kept stack`

The multiframe seed declined any callee containing `POP_JUMP_IF_NONE` /
`POP_JUMP_IF_NOT_NONE`. Its stated premise — a residual `is`/`is_not` whose Ref
operand a mid-body guard resume cannot source — no longer holds: the codewriter
emits a bare `ptr_eq`/`ptr_ne` with a `Kind::Int` result feeding the exitswitch.
`LOAD_FAST_CHECK` emits the same shape (`ptr_nonzero/r>i`) and was never declined.

What actually breaks is narrower: a branch that leaves operands on the value
stack, whose guard resume must restore kept slots the inline sub-walk's mirror
does not model. The scan now asks `LiveVars::stack_depth_at` instead of matching
the opcode, so a statement-level `if x is None:` inlines while the same test in
expression position keeps the residual. Strictly narrower than the old predicate.

Measured on dynasm, interleaved A/B, median of 9 pairwise ratios:
`exception_nested_exc_info_restore` 1.72x, `gc_bug_bridge_flavor_traceback_names`
1.32x. Everything else lands inside this box's ±15% noise floor.

### `jit: fill the dead-box_bool Ref color in the too-long image`

Latent wrong-code on main. `fill_trace_too_long_register_banks` skips any Ref
color it cannot supply a concrete for, on the premise that an unfilled color is
one the interpreter does not read at that pc. That fails for the dead-`box_bool`
marker, which writes a comparison's raw truth Int straight into the Ref register:
neither fill arm can represent an Int in a Ref bank, so the color was skipped, the
blackhole read NULL, and `is_true(NULL)` sent a module-scope `while` to its exit
arm after one iteration.

Reachable only when the module-dict NAME cell fold fires, so a module carrying
any `try` never showed it — including `trace_too_long_effect_replay`, whose own
`try: import pypyjit` unfolds its whole body and left the phase-A contract it
documents untested.

Also corrects both cell-fold comments: the handler-free gate is not the
can-raise argument they claimed (that argument transfers from the ungated
LoadGlobal fold, which shares the emitter). Lifting it is held back by a retrace
storm instead — `exception_reraise_tb_depth_jitstress` 0.90s → 5.85s at
loops_compiled 305 → 1802 — so both gates stay.

### Verification

- `check.py --backend dynasm` 362 passed / `--backend cranelift` 362 passed, with the same 6 pre-existing jit-stats baseline failures as before the change
- JIT-on vs JIT-off identical across all 353 synth fixtures
- `cargo test --all --features dynasm` 97 suites ok; `cargo test -p pyre-object` ok


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved exception handling across nested calls with more accurate traceback information.
  - Prevented unsafe multi-frame optimizations in unsupported scenarios.
  - Fixed edge cases involving conditional checks, preserved values, and boolean reconstruction.
  - Preserved consistent string interning and repeated code-name access.

- **Performance**
  - Optimized runtime loading to materialize JIT code only when needed.
  - Reduced unnecessary compilation and guard failures in benchmarked workloads.

- **Documentation**
  - Clarified boolean state resets, trace recovery, and optimized name-access behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->