### PR TITLE
typedef: validate the classmethod_descriptor owner and share wrap_descr_get

### DIFF
--- a/pyre/extra_tests/parity_tests/abc_subclasses_protocol.py
+++ b/pyre/extra_tests/parity_tests/abc_subclasses_protocol.py
@@ -1,0 +1,65 @@
+"""ABCMeta subclass checks observe the public ``__subclasses__`` protocol.
+
+PyPy: ``pypy/module/_abc/app_abc.py:156-158``::
+
+    for scls in cls.__subclasses__():
+        if issubclass(subclass, scls):
+            return True
+
+Calling and iterating the override is observable: invalid call signatures,
+non-iterable results, invalid members, and user exceptions must propagate.
+"""
+
+from abc import ABCMeta
+
+
+def expect_type_error(func):
+    try:
+        func()
+    except TypeError:
+        return
+    raise AssertionError("TypeError not raised")
+
+
+for override in (None, lambda arg: [], lambda: 42, lambda: [42]):
+
+    class InvalidSubclasses(metaclass=ABCMeta):
+        __subclasses__ = override
+
+    expect_type_error(lambda: issubclass(int, InvalidSubclasses))
+
+
+class MarkerError(Exception):
+    pass
+
+
+def raise_marker():
+    raise MarkerError("from __subclasses__")
+
+
+class RaisingSubclasses(metaclass=ABCMeta):
+    __subclasses__ = raise_marker
+
+
+try:
+    issubclass(int, RaisingSubclasses)
+except MarkerError as exc:
+    assert str(exc) == "from __subclasses__"
+else:
+    raise AssertionError("MarkerError not raised")
+
+
+class Base(metaclass=ABCMeta):
+    pass
+
+
+class Child(Base):
+    pass
+
+
+class Grandchild(Child):
+    pass
+
+
+assert issubclass(Grandchild, Base)
+print("OK")

--- a/pyre/extra_tests/parity_tests/classmethod_descriptor_kind.py
+++ b/pyre/extra_tests/parity_tests/classmethod_descriptor_kind.py
@@ -1,0 +1,170 @@
+"""Parity test: a `METH_CLASS` entry is a `classmethod_descriptor`.
+
+`type_ready_fill_dict` hands a `PyMethodDef` carrying `METH_CLASS` to
+`PyDescr_NewClassMethod`, so `dict.__dict__['fromkeys']` is a
+`classmethod_descriptor` rather than the `classmethod` a decorated Python
+function produces.  The two halves diverge in what they validate and what
+they bind to, and `inspect`'s `_NonUserDefinedCallables` distinguishes them,
+so both are pinned here.
+
+`descrobject.c classmethod_get` requires the owner argument to be a type
+*and* a subtype of the type the descriptor was found on; `funcobject.c
+cm_descr_get`, the user `@classmethod` half, accepts anything.  Without the
+subtype check the wrapped implementation runs against an unrelated class and
+raises from inside itself instead of rejecting the call.
+
+`typeobject.c wrap_descr_get` is the `__get__` entry every descriptor type
+shares: `PyArg_UnpackTuple(args, "__get__", 1, 2)` makes the owner optional,
+so a one-argument `__get__` binds.
+"""
+
+FK = dict.__dict__["fromkeys"]
+PREPARE = type.__dict__["__prepare__"]
+FROM_BYTES = int.__dict__["from_bytes"]
+
+assert type(FK).__name__ == "classmethod_descriptor", type(FK)
+assert type(PREPARE).__name__ == "classmethod_descriptor", type(PREPARE)
+assert type(FROM_BYTES).__name__ == "classmethod_descriptor", type(FROM_BYTES)
+assert type(FK) is type(PREPARE)
+
+assert FK.__name__ == "fromkeys"
+assert FK.__qualname__ == "dict.fromkeys"
+assert FK.__objclass__ is dict
+assert repr(FK) == "<method 'fromkeys' of 'dict' objects>"
+
+# A decorated Python function is the other half and stays a `classmethod`.
+
+
+class _Plain:
+    @classmethod
+    def m(cls):
+        return cls
+
+
+assert type(_Plain.__dict__["m"]).__name__ == "classmethod"
+
+# Binding yields a builtin carrier holding the class, not a `method`.
+bound = dict.fromkeys
+assert type(bound).__name__ == "builtin_function_or_method", type(bound)
+assert bound.__self__ is dict
+assert bound(["a"]) == {"a": None}
+assert type(_Plain.m).__name__ == "method"
+
+
+class _MyDict(dict):
+    pass
+
+
+# The owner must be a type, and a subtype of the descriptor's own.
+assert FK(dict, ["x"]) == {"x": None}
+assert FK(_MyDict, ["x"]) == {"x": None}
+assert type(FK(_MyDict, ["x"])) is _MyDict
+
+for cls in (list, int):
+    try:
+        FK(cls, ["x"])
+    except TypeError as exc:
+        assert str(exc) == (
+            f"descriptor 'fromkeys' requires a subtype of 'dict' "
+            f"but received '{cls.__name__}'"
+        ), exc
+    else:
+        raise AssertionError(f"an unrelated owner must be rejected: {cls}")
+
+try:
+    PREPARE(list, "X", ())
+except TypeError as exc:
+    assert str(exc) == (
+        "descriptor '__prepare__' requires a subtype of 'type' but received 'list'"
+    ), exc
+else:
+    raise AssertionError("an unrelated owner must be rejected")
+
+try:
+    FK(3, ["x"])
+except TypeError as exc:
+    assert str(exc) == (
+        "descriptor 'fromkeys' for type 'dict' needs a type, not a 'int' as arg 2"
+    ), exc
+else:
+    raise AssertionError("an instance owner must be rejected")
+
+try:
+    FK()
+except TypeError as exc:
+    assert str(exc) == (
+        "descriptor 'fromkeys' of 'dict' object needs an argument"
+    ), exc
+else:
+    raise AssertionError("a missing owner must be rejected")
+
+# `__get__` validates the same way, and infers the owner from the instance.
+assert FK.__get__({}).__self__ is dict
+assert FK.__get__({}, None).__self__ is dict
+assert FK.__get__(None, dict).__self__ is dict
+assert FK.__get__(None, _MyDict).__self__ is _MyDict
+
+for args in ((None, list), (None, 3)):
+    try:
+        FK.__get__(*args)
+    except TypeError:
+        pass
+    else:
+        raise AssertionError(f"__get__{args} must be rejected")
+
+# `wrap_descr_get` arity, shared by all three descriptor kinds.
+APPEND = list.__dict__["append"]
+STR = object.__dict__["__str__"]
+
+assert type(APPEND).__name__ == "method_descriptor"
+assert type(STR).__name__ == "wrapper_descriptor"
+assert APPEND.__get__([1]).__self__ == [1]
+assert type(STR.__get__(3)).__name__ == "method-wrapper"
+assert STR.__get__(3)() == "3"
+
+for descr in (APPEND, STR, FK):
+    try:
+        descr.__get__()
+    except TypeError as exc:
+        assert str(exc) == "__get__ expected at least 1 argument, got 0", exc
+    else:
+        raise AssertionError(f"a zero-argument __get__ must be rejected: {descr}")
+
+    try:
+        descr.__get__(1, 2, 3)
+    except TypeError as exc:
+        assert str(exc) == "__get__ expected at most 2 arguments, got 3", exc
+    else:
+        raise AssertionError(f"a three-argument __get__ must be rejected: {descr}")
+
+    try:
+        descr.__get__(None, None)
+    except TypeError as exc:
+        assert str(exc) == "__get__(None, None) is invalid", exc
+    else:
+        raise AssertionError(f"__get__(None, None) must be rejected: {descr}")
+
+# The getsets reject a foreign receiver with the standard descriptor wording.
+for name in ("__objclass__", "__name__", "__qualname__", "__doc__",
+             "__text_signature__"):
+    try:
+        type(FK).__dict__[name].__get__(3, int)
+    except TypeError as exc:
+        assert str(exc) == (
+            f"descriptor '{name}' for 'classmethod_descriptor' objects "
+            f"doesn't apply to a 'int' object"
+        ), exc
+    else:
+        raise AssertionError(f"a foreign receiver must be rejected: {name}")
+
+# `PyClassMethodDescr_Type` carries no `__reduce__`, so pickling is refused.
+import pickle  # noqa: E402
+
+try:
+    pickle.dumps(FK)
+except TypeError as exc:
+    assert "classmethod_descriptor" in str(exc), exc
+else:
+    raise AssertionError("a classmethod_descriptor must not pickle")
+
+print("OK")

--- a/pyre/pyre-interpreter/src/module/_abc/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_abc/mod.rs
@@ -176,32 +176,53 @@ fn subclass_of(cls: PyObjectRef, subclass: PyObjectRef) -> Result<bool, crate::P
             "issubclass() arg 1 must be a class",
         ));
     }
+
+    // The hook, registry walk, and `__subclasses__` walk below can all run
+    // arbitrary Python.  Keep the two arguments live and reload them after
+    // every such call, matching the translated livevars carried by PyPy's
+    // `ABCMeta.__subclasscheck__`.
+    let roots = pyre_object::gc_roots::push_roots();
+    let cls_slot = roots.base();
+    roots.pin_root(cls);
+    let subclass_slot = cls_slot + 1;
+    roots.pin_root(subclass);
+
     // _py_abc.py:122-130 — `ok = cls.__subclasshook__(subclass)`.
-    if let Ok(hook) = crate::baseobjspace::getattr_str(cls, "__subclasshook__") {
-        if !hook.is_null() {
-            let ok = crate::call::call_function_impl_result(hook, &[subclass])?;
-            if !unsafe { is_not_implemented(ok) } {
-                return crate::baseobjspace::is_true(ok);
-            }
+    let hook = crate::baseobjspace::getattr_str(roots.get(cls_slot), "__subclasshook__")?;
+    if !hook.is_null() {
+        let hook_roots = pyre_object::gc_roots::push_roots();
+        let hook_slot = hook_roots.base();
+        hook_roots.pin_root(hook);
+        let ok = crate::call::call_function_impl_result(
+            hook_roots.get(hook_slot),
+            &[roots.get(subclass_slot)],
+        )?;
+        if !unsafe { is_not_implemented(ok) } {
+            return crate::baseobjspace::is_true(ok);
         }
     }
     // _py_abc.py:131-134 — direct subclass via `__mro__`.
     unsafe {
-        let mro_ptr = w_type_get_mro(subclass);
+        let mro_ptr = w_type_get_mro(roots.get(subclass_slot));
         if !mro_ptr.is_null() {
             for &t in (*mro_ptr).as_slice() {
-                if std::ptr::eq(t, cls) {
+                if std::ptr::eq(t, roots.get(cls_slot)) {
                     return Ok(true);
                 }
             }
         }
     }
     // _py_abc.py:135-139 — subclass of a registered class (recursive).
-    if let Ok(registry) = crate::baseobjspace::getattr_str(cls, "_abc_registry") {
+    if let Ok(registry) = crate::baseobjspace::getattr_str(roots.get(cls_slot), "_abc_registry") {
         if !registry.is_null() && unsafe { is_list(registry) } {
-            let n = unsafe { w_list_len(registry) };
+            let registry_roots = pyre_object::gc_roots::push_roots();
+            let registry_slot = registry_roots.base();
+            registry_roots.pin_root(registry);
+            let n = unsafe { w_list_len(registry_roots.get(registry_slot)) };
             for i in 0..n {
-                if let Some(rcls) = unsafe { w_list_getitem(registry, i as i64) } {
+                if let Some(rcls) =
+                    unsafe { w_list_getitem(registry_roots.get(registry_slot), i as i64) }
+                {
                     // A registered entry that is not a class cannot be a base
                     // class, so it can never make `subclass` a subclass — skip
                     // it rather than letting `issubclass` raise.  `range` is
@@ -211,16 +232,44 @@ fn subclass_of(cls: PyObjectRef, subclass: PyObjectRef) -> Result<bool, crate::P
                     if !unsafe { is_type(rcls) } {
                         continue;
                     }
-                    if crate::baseobjspace::issubclass(subclass, rcls)? {
+                    let item_roots = pyre_object::gc_roots::push_roots();
+                    let rcls_slot = item_roots.base();
+                    item_roots.pin_root(rcls);
+                    if crate::baseobjspace::issubclass(
+                        roots.get(subclass_slot),
+                        item_roots.get(rcls_slot),
+                    )? {
                         return Ok(true);
                     }
                 }
             }
         }
     }
-    // _py_abc.py:140-144 — subclass of a subclass (recursive).
-    for scls in unsafe { w_type_get_subclasses(cls, false) } {
-        if crate::baseobjspace::issubclass(subclass, scls)? {
+    // _py_abc.py:140-144 — `for scls in cls.__subclasses__():`.  This must go
+    // through normal attribute lookup, call, and iteration.  Reading the
+    // internal type subclass vector directly hides user overrides and their
+    // TypeError/custom exceptions, which are observable ABCMeta semantics.
+    let subclasses_method =
+        crate::baseobjspace::getattr_str(roots.get(cls_slot), "__subclasses__")?;
+    let walk_roots = pyre_object::gc_roots::push_roots();
+    let method_slot = walk_roots.base();
+    walk_roots.pin_root(subclasses_method);
+    let subclasses = crate::call::call_function_impl_result(walk_roots.get(method_slot), &[])?;
+    let subclasses_slot = method_slot + 1;
+    walk_roots.pin_root(subclasses);
+    let iterator = crate::baseobjspace::iter(walk_roots.get(subclasses_slot))?;
+    let iterator_slot = subclasses_slot + 1;
+    walk_roots.pin_root(iterator);
+    loop {
+        let scls = match crate::baseobjspace::next(walk_roots.get(iterator_slot)) {
+            Ok(scls) => scls,
+            Err(err) if err.kind == crate::PyErrorKind::StopIteration => break,
+            Err(err) => return Err(err),
+        };
+        let item_roots = pyre_object::gc_roots::push_roots();
+        let scls_slot = item_roots.base();
+        item_roots.pin_root(scls);
+        if crate::baseobjspace::issubclass(roots.get(subclass_slot), item_roots.get(scls_slot))? {
             return Ok(true);
         }
     }

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -12828,23 +12828,7 @@ fn init_slot_wrapper_type(ns: PyObjectRef) {
         pyre_object::w_dict_setitem_str_no_proxy(
             ns,
             "__get__",
-            make_builtin_function_with_arity(
-                "__get__",
-                |args| {
-                    let obj = if pyre_object::is_none(args[1]) {
-                        pyre_object::PY_NULL
-                    } else {
-                        args[1]
-                    };
-                    let w_type = if pyre_object::is_none(args[2]) {
-                        pyre_object::PY_NULL
-                    } else {
-                        args[2]
-                    };
-                    bind_slot_wrapper(args[0], obj, w_type)
-                },
-                3,
-            ),
+            make_builtin_function("__get__", |args| wrap_descr_get(args, bind_slot_wrapper)),
         );
         pyre_object::w_dict_setitem_str_no_proxy(
             ns,
@@ -12957,6 +12941,32 @@ fn bind_slot_wrapper(descr: PyObjectRef, obj: PyObjectRef, w_type: PyObjectRef) 
         slot_wrapper_check_instance(descr, obj)?;
     }
     bind_fixed_code_descriptor(descr, obj, w_type, crate::function::method_wrapper_new)
+}
+
+/// `typeobject.c wrap_descr_get` — the `__get__` namespace entry every
+/// descriptor type shares.  `PyArg_UnpackTuple(args, "__get__", 1, 2)` makes
+/// the owner optional and `None` collapses to the absent operand in both
+/// positions, so `list.__dict__['append'].__get__([1])` binds while
+/// `__get__(None, None)` is rejected before the type's own binder runs.
+fn wrap_descr_get(
+    args: &[PyObjectRef],
+    bind: fn(PyObjectRef, PyObjectRef, PyObjectRef) -> crate::PyResult,
+) -> crate::PyResult {
+    crate::type_methods::arity_at_least(args, "__get__", 1)?;
+    crate::type_methods::arity_at_most(args, "__get__", 2)?;
+    let collapse = |value: PyObjectRef| {
+        if value.is_null() || unsafe { pyre_object::is_none(value) } {
+            PY_NULL
+        } else {
+            value
+        }
+    };
+    let obj = collapse(args[1]);
+    let w_type = collapse(args.get(2).copied().unwrap_or(PY_NULL));
+    if obj.is_null() && w_type.is_null() {
+        return Err(crate::PyError::type_error("__get__(None, None) is invalid"));
+    }
+    bind(args[0], obj, w_type)
 }
 
 /// Whether `obj` is a slot wrapper bound to a receiver — the `Method` payload
@@ -13217,23 +13227,9 @@ fn init_method_descriptor_type(ns: PyObjectRef) {
         pyre_object::w_dict_setitem_str_no_proxy(
             ns,
             "__get__",
-            make_builtin_function_with_arity(
-                "__get__",
-                |args| {
-                    let obj = if pyre_object::is_none(args[1]) {
-                        pyre_object::PY_NULL
-                    } else {
-                        args[1]
-                    };
-                    let w_type = if pyre_object::is_none(args[2]) {
-                        pyre_object::PY_NULL
-                    } else {
-                        args[2]
-                    };
-                    bind_method_descriptor(args[0], obj, w_type)
-                },
-                3,
-            ),
+            make_builtin_function("__get__", |args| {
+                wrap_descr_get(args, bind_method_descriptor)
+            }),
         );
         pyre_object::w_dict_setitem_str_no_proxy(
             ns,
@@ -13292,11 +13288,58 @@ fn classmethod_descriptor_function(
     name: &str,
 ) -> Result<PyObjectRef, crate::PyError> {
     if !crate::function::is_classmethod_descriptor(obj) {
+        let received = if obj.is_null() {
+            "object"
+        } else {
+            crate::typedef::r#type(obj)
+                .map(|tp| unsafe { pyre_object::w_type_get_name(tp.as_ptr()) })
+                .unwrap_or("object")
+        };
         return Err(crate::PyError::type_error(format!(
-            "descriptor '{name}' requires a 'classmethod_descriptor' object"
+            "descriptor '{name}' for 'classmethod_descriptor' objects doesn't apply to a '{received}' object"
         )));
     }
     Ok(unsafe { pyre_object::function::w_classmethod_get_func(obj) })
+}
+
+/// `descrobject.c classmethod_get` — the owner argument must be a type, and a
+/// subtype of the one the descriptor was found on.  `funcobject.c
+/// cm_descr_get`, the user `@classmethod` half, has no such check, so this
+/// runs only for a `classmethod_descriptor`.
+fn classmethod_descriptor_check_owner(
+    function: PyObjectRef,
+    w_klass: PyObjectRef,
+) -> Result<(), crate::PyError> {
+    let name = unsafe { crate::function::function_get_name(function) };
+    let owner = unsafe { crate::function::fget_func_objclass(function)? };
+    let owner_name = unsafe { pyre_object::w_type_get_name(owner) };
+    if w_klass.is_null() || !unsafe { pyre_object::is_type(w_klass) } {
+        let got = if w_klass.is_null() {
+            "object".to_string()
+        } else {
+            type_name_of(w_klass)
+        };
+        return Err(crate::PyError::type_error(format!(
+            "descriptor '{name}' for type '{owner_name}' needs a type, \
+             not a '{got}' as arg 2"
+        )));
+    }
+    if !unsafe { crate::baseobjspace::issubtype_w(w_klass, owner) } {
+        let got = unsafe { pyre_object::w_type_get_name(w_klass) };
+        return Err(crate::PyError::type_error(format!(
+            "descriptor '{name}' requires a subtype of '{owner_name}' but received '{got}'"
+        )));
+    }
+    Ok(())
+}
+
+fn bind_classmethod_descriptor(
+    descr: PyObjectRef,
+    obj: PyObjectRef,
+    w_type: PyObjectRef,
+) -> crate::PyResult {
+    classmethod_descriptor_function(descr, "__get__")?;
+    classmethod_descr_get(&[descr, obj, w_type])
 }
 
 fn init_classmethod_descriptor_type(ns: PyObjectRef) {
@@ -13349,14 +13392,9 @@ fn init_classmethod_descriptor_type(ns: PyObjectRef) {
         pyre_object::w_dict_setitem_str_no_proxy(
             ns,
             "__get__",
-            make_builtin_function_with_arity(
-                "__get__",
-                |args| {
-                    classmethod_descriptor_function(args[0], "__get__")?;
-                    classmethod_descr_get(args)
-                },
-                3,
-            ),
+            make_builtin_function("__get__", |args| {
+                wrap_descr_get(args, bind_classmethod_descriptor)
+            }),
         );
         pyre_object::w_dict_setitem_str_no_proxy(
             ns,
@@ -13366,25 +13404,18 @@ fn init_classmethod_descriptor_type(ns: PyObjectRef) {
                 let descr = positional.first().copied().unwrap_or(pyre_object::PY_NULL);
                 let function = classmethod_descriptor_function(descr, "__call__")?;
                 // `descrobject.c classmethoddescr_call` — the receiver is the
-                // class itself, so it must be a type rather than an instance.
-                let name = crate::function::function_get_name(function);
-                let owner_name =
-                    pyre_object::w_type_get_name(crate::function::fget_func_objclass(function)?);
-                match positional.get(1) {
-                    Some(&cls) if pyre_object::is_type(cls) => {}
-                    Some(&cls) => {
-                        let got = type_name_of(cls);
-                        return Err(crate::PyError::type_error(format!(
-                            "descriptor '{name}' for type '{owner_name}' needs a type, \
-                             not a '{got}' as arg 2"
-                        )));
-                    }
-                    None => {
-                        return Err(crate::PyError::type_error(format!(
-                            "descriptor '{name}' of '{owner_name}' object needs an argument"
-                        )));
-                    }
-                }
+                // class itself, and it is validated by binding it through
+                // `classmethod_get` before the wrapped callable runs.
+                let Some(&cls) = positional.get(1) else {
+                    let name = crate::function::function_get_name(function);
+                    let owner_name = pyre_object::w_type_get_name(
+                        crate::function::fget_func_objclass(function)?,
+                    );
+                    return Err(crate::PyError::type_error(format!(
+                        "descriptor '{name}' of '{owner_name}' object needs an argument"
+                    )));
+                };
+                classmethod_descriptor_check_owner(function, cls)?;
                 function_descr_call_impl(positional, kwargs, function)
             }),
         );
@@ -14715,8 +14746,10 @@ fn classmethod_descr_get(args: &[PyObjectRef]) -> crate::PyResult {
     let function = unsafe { pyre_object::function::w_classmethod_get_func(cm) };
     // `classmethod_get` binds a `METH_CLASS` entry through `PyCMethod_New`, so
     // `dict.fromkeys` is a `builtin_function_or_method`, while a Python
-    // `@classmethod` binds to an ordinary `method`.
+    // `@classmethod` binds to an ordinary `method`.  Only the descriptor half
+    // validates the owner argument.
     let new_bound = if crate::function::is_classmethod_descriptor(cm) {
+        classmethod_descriptor_check_owner(function, w_klass)?;
         crate::function::builtin_bound_method_new
     } else {
         pyre_object::w_method_new


### PR DESCRIPTION
Follow-up to #970, which merged while this work was in flight.

## `typedef`: validate the `classmethod_descriptor` owner and share `wrap_descr_get`

Three defects the #970 review found, verified against a CPython 3.14.2 oracle
before and after.

**The owner argument was not validated.** `descrobject.c classmethod_get`
requires it to be a type *and* a subtype of the type the descriptor was found
on:

| | CPython | #970 |
|---|---|---|
| `dict.__dict__['fromkeys'](list, ['x'])` | `TypeError: descriptor 'fromkeys' requires a subtype of 'dict' but received 'list'` | `TypeError: list indices must be integers or slices, not str` — the call reached `dict.fromkeys` with `list` |
| `type.__dict__['__prepare__'](list, 'X', ())` | the same `TypeError` | returned `{}` |
| `dict.__dict__['fromkeys'].__get__(None, list)` | the same `TypeError` | bound successfully |
| `dict.__dict__['fromkeys'].__get__(None, 3)` | `needs a type, not a 'int' as arg 2` | bound successfully |

The check is gated on `is_classmethod_descriptor`: `funcobject.c cm_descr_get`,
the user `@classmethod` half that shares `classmethod_descr_get`, has none.
`classmethoddescr_call` reaches the same validation, mirroring its delegation to
`classmethod_get`.

**`__get__` took a fixed three arguments.** `typeobject.c wrap_descr_get`
unpacks 1..2, so `list.__dict__['append'].__get__([1])`,
`object.__dict__['__str__'].__get__(3)` and
`dict.__dict__['fromkeys'].__get__({})` all raised
`__get__ expected 2 arguments, got 1`. All three descriptor types now share a
`wrap_descr_get` helper that collapses `None` in either position and rejects
`__get__(None, None)`.

**The `classmethod_descriptor` getsets used the wrong receiver-mismatch
wording** — `descriptor '__objclass__' requires a 'classmethod_descriptor'
object` where the sibling receiver helpers already produce
`descriptor '__objclass__' for 'classmethod_descriptor' objects doesn't apply to
a 'int' object`.

`extra_tests/parity_tests/classmethod_descriptor_kind.py` pins the descriptor
kind, both binding halves, the owner validation, the `__get__` arity and the
getset wording.

### Two review findings that do not hold

**`bh_load_global_fn` resolving from the wrong namespace after the arg-0
exemption.** The helper already discarded `namespace_ptr` before #970 —
`let _ = namespace_ptr;` is untouched by that branch — so the exemption decides
only whether the walk aborts, never which namespace is read. Measured the named
scenario: one code object driven through 200k iterations under two different
`__globals__` yields `('module', 'alt')` on dynasm with `loops_compiled=4`,
identical to CPython and to `PYRE_JIT=0`. The custom-`__builtins__` variant does
diverge from CPython, but identically with the JIT off, so it is a pre-existing
interpreter gap rather than a JIT defect.

**`descr_reduce` needing its fields rooted across the allocations.** Both values
come from non-moving allocators — the owner is a `W_TypeObject`
(`w_type_new_builtin`) and `w_str_new` allocates through off-GC
`lltype::malloc_typed` (`w_str_new_managed` is the collectable sibling). Beyond
that, `w_tuple_new` roots its own items: `w_tuple_new_array_backed` pins each
one and fills the items block from the relocated shadow-stack slots, and
`w_specialised_tuple_oo_new` does the same for the arity-2 path.

One divergence is left alone: `method_descriptor.__objclass__` and `__name__`
report `doesn't apply to 'int' object` without CPython's article. That is
`Member.typecheck` (`pypy/interpreter/typedef.py:498-502`) verbatim.

## `stdlib`: honor ABC `__subclasses__` protocol

`_abc` plus a parity script.

## Gates

Run on the pre-rebase tree (this branch was rebased onto `1ac12147314` after the
runs, and the commit contents are byte-identical across the rebase):

- `extra_tests/parity_tests/run.py` — all pass on cpython, dynasm and cranelift
- `cpython_tests/run.py --backend dynasm` — 46 pass, 0 fail, no regressions
- `check.py --backend dynasm` — 5 failed, 361 passed
- `check.py --backend cranelift` — 5 failed, 361 passed

Both backends fail on exactly the five benches #970 documents as main's own
drift against stale #947 baselines — closure_freevar_branch_resume,
exception_args_virtual, exception_multi_handler_warmup,
exception_reraise_tb_depth_jitstress and list_length_hint_validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved abstract base class subclass checks to honor custom subclass providers, including correct iteration, validation, and exception handling.
  * Improved descriptor binding behavior and error handling for invalid or missing receivers.
  * Added validation to ensure classmethod descriptors are accessed only through compatible class owners.

* **Tests**
  * Added coverage for subclass-checking protocols and built-in classmethod descriptor behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->