### PR TITLE
gc: fix the prebuilt-root misclassification behind the pickle_ctor_args major-trace panic; fbw callee stack identity across bridges

### DIFF
--- a/.github/workflows/pyre-ci.yml
+++ b/.github/workflows/pyre-ci.yml
@@ -26,8 +26,12 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: pyre-ci-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  # A PR's runs supersede each other — only the tip matters there. A push to a
+  # tracked branch must not be, or a merge train cancels every predecessor's run
+  # and the branch goes unverified: keying those by SHA gives each landed commit
+  # its own group, so nothing cancels and a red commit is attributable to itself.
+  group: pyre-ci-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -6,7 +6,7 @@
 /// - Write barrier with remembered set for old-to-young pointers
 ///
 /// Modeled after incminimark's minor/major collection.
-use indexmap::{IndexMap, IndexSet};
+use indexmap::IndexSet;
 use majit_ir::GcRef;
 use std::collections::VecDeque;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -448,6 +448,10 @@ pub struct MiniMarkGC {
     /// These are old-gen object payload addresses whose TRACK_YOUNG_PTRS
     /// flag has been cleared by the write barrier.
     remembered_set: Vec<usize>,
+    /// incminimark.py:355 `prebuilt_root_objects = AddressStack()`.
+    /// Immortal objects enter exactly once, when their first pointer write
+    /// clears NO_HEAP_PTRS in the write barrier.
+    prebuilt_root_objects: Vec<usize>,
     /// incminimark.py:346-352: objects with GCFLAG_CARDS_SET bit.
     /// Card bits are stored inline before each object's GcHeader.
     /// This list tracks which objects have at least one card bit set.
@@ -595,8 +599,10 @@ pub struct MiniMarkGC {
     /// llsupport/gc.py:563 vtable→typeid mapping. RPython derives this
     /// arithmetically from the GC `type_info_group` base; pyre's GC
     /// keeps an explicit table because frontends register vtables
-    /// independently of any translator pipeline.
-    vtable_to_type_id: IndexMap<usize, u32>,
+    /// independently of any translator pipeline. This has RPython
+    /// AddressDict hashing: keys are addresses and insertion order is not
+    /// observable at any call site.
+    vtable_to_type_id: AddressMap<u32>,
     /// `gc.py:603-622 _setup_guard_is_object` instance state.
     /// `_infobits_offset` is the byte offset of `infobits` inside
     /// `TYPE_INFO`; `_infobits_offset_plus` is the additional offset
@@ -669,6 +675,7 @@ impl MiniMarkGC {
             types: TypeRegistry::new(),
             roots: RootSet::new(),
             remembered_set: Vec::new(),
+            prebuilt_root_objects: Vec::new(),
             old_objects_with_cards_set: Vec::new(),
             young_objects_with_weakrefs: Vec::new(),
             old_objects_with_weakrefs: Vec::new(),
@@ -703,7 +710,7 @@ impl MiniMarkGC {
             pinned_objects: IndexSet::new(),
             nursery_objects_shadows: AddressMap::default(),
             compiled_code_registry: CompiledCodeRegistry::new(),
-            vtable_to_type_id: IndexMap::new(),
+            vtable_to_type_id: AddressMap::default(),
             _infobits_offset: 0,
             _infobits_offset_plus: 0,
             _T_IS_RPYTHON_INSTANCE_BYTE: 0,
@@ -2593,6 +2600,7 @@ impl MiniMarkGC {
     /// inspector.py's preallocated raw root list.
     fn enumerate_all_root_values(&self) -> Vec<GcRef> {
         let mut result = self.enumerate_root_walker_values();
+        result.extend(self.prebuilt_root_objects.iter().copied().map(GcRef));
         // incminimark.py:2734-2736 `enum_live_with_finalizers`: registered
         // finalizer objects remain roots even before they become unreachable
         // and move to an app-visible death queue. AddressDeque.foreach(..., 2)
@@ -2626,6 +2634,10 @@ impl MiniMarkGC {
         // seeds stack roots for a major marking cycle. Mirror the same
         // root sets as minor collection, but mark old objects instead of
         // copying nursery objects.
+        let prebuilt = self.prebuilt_root_objects.clone();
+        for addr in prebuilt {
+            self.seed_prebuilt_root(addr);
+        }
         let mut roots = self.enumerate_root_walker_values();
         // Objects already moved to a death queue remain ordinary roots until
         // app-level code pops them. Registered live finalizers are deliberately
@@ -2639,6 +2651,19 @@ impl MiniMarkGC {
         );
         for gcref in roots {
             self.seed_major_root(gcref);
+        }
+    }
+
+    /// incminimark.py:2706-2707 `prebuilt_root_objects.foreach(_collect_obj)`.
+    fn seed_prebuilt_root(&mut self, addr: usize) {
+        let hdr = unsafe { header_of(addr) };
+        debug_assert!(unsafe { !(*hdr).has_flag(flags::NO_HEAP_PTRS) });
+        if unsafe { !(*hdr).has_flag(flags::VISITED) } {
+            unsafe {
+                (*hdr).set_flag(flags::VISITED);
+                (*hdr).set_flag(flags::TRACK_YOUNG_PTRS);
+            }
+            self.incr_state.gray_stack.push(addr);
         }
     }
 
@@ -2833,6 +2858,10 @@ impl MiniMarkGC {
     /// roots are deliberately not repeated here: upstream repeats only
     /// `collect_nonstack_roots`, not `collect_roots`.
     fn rescan_major_nonstack_roots_and_drain(&mut self) {
+        let prebuilt = self.prebuilt_root_objects.clone();
+        for addr in prebuilt {
+            self.seed_prebuilt_root(addr);
+        }
         crate::shadow_stack::walk_extra_roots(|gcref| {
             self.seed_major_root(*gcref);
         });
@@ -3029,7 +3058,19 @@ impl MiniMarkGC {
     /// (incminimark.py:2739-2752) does not need this guard because RPython's
     /// type system guarantees every `Ptr(GcStruct)` is GC-managed; it converges
     /// away once every `gc_ptr_offsets` target is a real GC allocation.
-    fn grey_child(&mut self, addr: usize, holder_addr: usize, slot_addr: usize, site: &str) {
+    fn grey_child(
+        &mut self,
+        addr: usize,
+        holder_addr: usize,
+        slot_addr: usize,
+        site: &str,
+        header_bearing: bool,
+    ) {
+        // Custom tracers expose GcRef slots, whose targets carry a header.
+        // incminimark.py:2782-2800 ignores untouched prebuilt objects.
+        if header_bearing && unsafe { (*header_of(addr)).has_flag(flags::NO_HEAP_PTRS) } {
+            return;
+        }
         if self.is_managed_heap_object(addr) && self.may_enter_marking_worklist(addr) {
             let hdr = unsafe { header_of(addr) };
             let type_id = unsafe { (*hdr).type_id() };
@@ -3138,6 +3179,7 @@ impl MiniMarkGC {
                             obj_addr,
                             slot_ptr as usize,
                             "major_custom_trace",
+                            true,
                         );
                     }
                 });
@@ -3152,6 +3194,7 @@ impl MiniMarkGC {
                         obj_addr,
                         obj_addr + offset,
                         "major_fixed_field",
+                        false,
                     );
                 }
             }
@@ -3169,6 +3212,7 @@ impl MiniMarkGC {
                             obj_addr,
                             items_start + i * item_size,
                             "major_varsize_item",
+                            false,
                         );
                     }
                 }
@@ -3382,9 +3426,11 @@ impl MiniMarkGC {
             );
         }
 
-        // incminimark.py:2563-2564 resets VISITED on translated prebuilt root
-        // objects. Pyre creates all GC objects at runtime and has no immortal
-        // prebuilt-root list, so there is no corresponding reset pass.
+        // incminimark.py:2563-2564: prebuilt objects are outside the arena
+        // sweep, so reset their mark bit explicitly for the next cycle.
+        for &addr in &self.prebuilt_root_objects {
+            unsafe { (*header_of(addr)).clear_flag(flags::VISITED) };
+        }
         // incminimark.py:2566-2577 — set the threshold for the next major
         // collection to `major_collection_threshold` times the surviving
         // size, but no more than `max_delta` above it, floored at
@@ -3820,12 +3866,25 @@ impl MiniMarkGC {
         // pyre's GcRef is nullable (GcRef::NULL is the sentinel) and reaches the
         // safe `write_barrier`/`gc_write_barrier` entry points, so guard null
         // before reading `header_of(obj)`; the card variant guards it likewise.
-        if obj.is_null() || self.is_in_nursery(obj.0) || !self.is_managed_heap_object(obj.0) {
+        if obj.is_null() || self.is_in_nursery(obj.0) {
             return;
         }
-        let hdr = unsafe { header_of(obj.0) };
-        if unsafe { (*hdr).has_flag(flags::TRACK_YOUNG_PTRS) } {
-            self.remember_young_pointer(obj);
+        if self.is_managed_heap_object(obj.0) {
+            let hdr = unsafe { header_of(obj.0) };
+            if unsafe { (*hdr).has_flag(flags::TRACK_YOUNG_PTRS) } {
+                self.remember_young_pointer(obj);
+            }
+            return;
+        }
+        // `malloc_typed` bootstrap objects are incminimark's prebuilt family.
+        // A registered Python vtable proves that the leading word is a real
+        // GcHeader; raw jitframes and other host allocations remain ignored.
+        let vtable = unsafe { *(obj.0 as *const usize) };
+        if self.vtable_to_type_id.contains_key(&vtable) {
+            let hdr = unsafe { header_of(obj.0) };
+            if unsafe { (*hdr).has_flag(flags::TRACK_YOUNG_PTRS) } {
+                self.remember_young_pointer(obj);
+            }
         }
     }
 
@@ -3847,11 +3906,6 @@ impl MiniMarkGC {
     /// append the object to the remembered set (`old_objects_pointing_to_young`)
     /// and clear GCFLAG_TRACK_YOUNG_PTRS. Callers have already verified the flag
     /// (the inline COND_CALL_GC_WB test, or `do_write_barrier`).
-    ///
-    /// The incminimark "if tid & GCFLAG_NO_HEAP_PTRS: prebuilt_root_objects
-    /// .append(addr)" branch has no counterpart: pyre allocates every GC object
-    /// at runtime and never sets GCFLAG_NO_HEAP_PTRS (there are no immortal
-    /// prebuilt objects from translation), so no object ever reaches that arm.
     fn remember_young_pointer(&mut self, obj: GcRef) {
         // incminimark.py does not special-case STATE_SWEEPING in its barrier.
         // After the seam, every retained entry names a VISITED survivor. A new
@@ -3871,7 +3925,13 @@ impl MiniMarkGC {
                 self.gc_state
             );
         }
-        unsafe { (*hdr).clear_flag(flags::TRACK_YOUNG_PTRS) };
+        unsafe {
+            (*hdr).clear_flag(flags::TRACK_YOUNG_PTRS);
+            if (*hdr).has_flag(flags::NO_HEAP_PTRS) {
+                (*hdr).clear_flag(flags::NO_HEAP_PTRS);
+                self.prebuilt_root_objects.push(obj.0);
+            }
+        }
     }
 
     /// incminimark.py:1495-1501 write_barrier_from_array:
@@ -5784,6 +5844,40 @@ mod tests {
         assert_eq!(gc.remembered_set.len(), 1);
     }
 
+    #[test]
+    fn prebuilt_write_barrier_registers_root_once_and_traces_children() {
+        let mut gc = test_gc(1024);
+        let child_tid = gc.register_type(TypeInfo::simple(16));
+        let prebuilt_tid = gc.register_type(TypeInfo::with_gc_ptrs(
+            2 * std::mem::size_of::<usize>(),
+            vec![std::mem::size_of::<usize>()],
+        ));
+        let vtable = 0x1234_5678usize;
+        crate::GcAllocator::register_vtable_for_type(&mut gc, vtable, prebuilt_tid);
+
+        let child = gc.alloc_with_type(child_tid, 16);
+        let prebuilt = crate::header::alloc_with_gc_header([vtable, child.0], prebuilt_tid);
+        let prebuilt_ref = GcRef(prebuilt as usize);
+        let hdr = unsafe { header_of(prebuilt_ref.0) };
+        assert!(unsafe { (*hdr).has_flag(flags::NO_HEAP_PTRS) });
+
+        gc.do_write_barrier(prebuilt_ref);
+        assert!(unsafe { !(*hdr).has_flag(flags::NO_HEAP_PTRS) });
+        assert_eq!(gc.remembered_set, vec![prebuilt_ref.0]);
+        assert_eq!(gc.prebuilt_root_objects, vec![prebuilt_ref.0]);
+
+        gc.do_collect_nursery();
+        let promoted_child = unsafe { GcRef((*prebuilt)[1]) };
+        assert_ne!(promoted_child, child);
+        assert!(gc.oldgen.contains(promoted_child.0));
+
+        gc.do_write_barrier(prebuilt_ref);
+        assert_eq!(gc.prebuilt_root_objects, vec![prebuilt_ref.0]);
+        gc.collect_full();
+        assert!(gc.oldgen.contains(promoted_child.0));
+        assert!(unsafe { !(*hdr).has_flag(flags::VISITED) });
+    }
+
     // incminimark gates the write barrier solely on GCFLAG_TRACK_YOUNG_PTRS:
     // every old-gen producer sets it, and the barrier appends on the flag test
     // alone. These lock that invariant down across all four producers, plus a
@@ -5866,9 +5960,8 @@ mod tests {
     fn write_barrier_skips_object_without_track_young_ptrs() {
         let mut gc = test_gc(1024);
         gc.register_type(TypeInfo::simple(16));
-        // A zeroed-header object (the shape every non-old-gen managed object
-        // carries: FrameBox frames, leaked host objects, nursery objects) has
-        // TRACK_YOUNG_PTRS clear, so the barrier reads the flag and skips it.
+        // A fabricated header with TRACK_YOUNG_PTRS clear is skipped. Nursery
+        // objects have the same flag state but return through the range check.
         let mut buf = Box::new([0u64; 2]);
         let base = buf.as_mut_ptr() as usize;
         unsafe { *(base as *mut GcHeader) = GcHeader::new(0) };

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -3923,14 +3923,19 @@ impl MiniMarkGC {
             return;
         }
         // `malloc_typed` bootstrap objects are incminimark's prebuilt family.
-        // A registered Python vtable proves that the leading word is a real
-        // GcHeader; raw jitframes and other host allocations remain ignored.
-        let vtable = unsafe { *(obj.0 as *const usize) };
-        if self.vtable_to_type_id.contains_key(&vtable) {
-            let hdr = unsafe { header_of(obj.0) };
-            if unsafe { (*hdr).has_flag(flags::TRACK_YOUNG_PTRS) } {
-                self.remember_young_pointer(obj);
-            }
+        // The witness is `registered_pyobject_header`, not vtable membership
+        // alone: `w_tuple_new` / `w_specialisedtuple_new_*` fall back to a bare
+        // `Box::into_raw` when no GC is installed, and those objects carry the
+        // very same registered `ob_header` at offset 0 with NO preceding
+        // `GcHeader`. A vtable-only test therefore reads the allocator word in
+        // front of the box and — if its `TRACK_YOUNG_PTRS` bit happens to be
+        // set — has `remember_young_pointer` write flags back into that
+        // metadata. The tid equality is what separates the two families.
+        let Some(hdr) = self.registered_pyobject_header(obj.0) else {
+            return;
+        };
+        if unsafe { (*hdr).has_flag(flags::TRACK_YOUNG_PTRS) } {
+            self.remember_young_pointer(obj);
         }
     }
 
@@ -6085,6 +6090,58 @@ mod tests {
         // `remember_young_pointer` clears TRACK_YOUNG_PTRS, so an unchanged
         // byte also proves the barrier never wrote through the fake header.
         assert_eq!(unsafe { *flag_byte }, flag_byte_before);
+
+        unsafe { std::alloc::dealloc(base, layout) };
+    }
+
+    #[test]
+    fn write_barrier_ignores_headerless_pyobject_with_registered_vtable() {
+        // `w_tuple_new` / `w_specialisedtuple_new_*` fall back to a bare
+        // `Box::into_raw` when `try_gc_alloc_stable` finds no installed
+        // collector, and the struct they build still starts with `ob_header` —
+        // the very vtable `register_vtable_for_type` knows. Such an object is
+        // in no managed generation, so `do_write_barrier` reaches its
+        // bootstrap-prebuilt arm; a vtable-only test there would read the
+        // allocator word in FRONT of the box as a `GcHeader` and, on a set
+        // `TRACK_YOUNG_PTRS` bit, have `remember_young_pointer` write flags
+        // back into that metadata. `registered_pyobject_header`'s tid equality
+        // is what rejects it.
+        let mut gc = test_gc(1024);
+        let tid = gc.register_type(TypeInfo::simple(2 * std::mem::size_of::<usize>()));
+        let vtable = 0x1234_5678usize;
+        crate::GcAllocator::register_vtable_for_type(&mut gc, vtable, tid);
+
+        // One leading word standing in for the allocator metadata a real
+        // `Box` keeps there, then the headerless object itself.
+        let layout = std::alloc::Layout::from_size_align(
+            GcHeader::SIZE + 2 * std::mem::size_of::<usize>(),
+            GcHeader::SIZE,
+        )
+        .unwrap();
+        let base = unsafe { std::alloc::alloc_zeroed(layout) };
+        assert!(!base.is_null());
+        let obj = unsafe { base.add(GcHeader::SIZE) } as usize;
+        unsafe { (obj as *mut usize).write(vtable) };
+        assert!(!gc.is_managed_heap_object(obj));
+
+        // Make the fake header in front of the object look live: both the
+        // barrier's flag bit and a type id that is registered — but NOT this
+        // object's, which is the whole discriminator.
+        let other_tid = gc.register_type(TypeInfo::simple(8));
+        assert_ne!(other_tid, tid);
+        let fake = base as *mut GcHeader;
+        unsafe {
+            fake.write(GcHeader::new(other_tid));
+            (*fake).set_flag(flags::TRACK_YOUNG_PTRS);
+        }
+        let fake_bits_before = unsafe { (*fake).tid_and_flags };
+
+        gc.do_write_barrier(GcRef(obj));
+
+        assert_eq!(gc.remembered_set.len(), 0);
+        // `remember_young_pointer` clears TRACK_YOUNG_PTRS, so unchanged bits
+        // also prove the barrier never wrote through the fake header.
+        assert_eq!(unsafe { (*fake).tid_and_flags }, fake_bits_before);
 
         unsafe { std::alloc::dealloc(base, layout) };
     }

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -390,8 +390,8 @@ struct IncrementalMarkState {
     objects_marked: usize,
     /// Target number of bytes to trace per increment.
     ///
-    /// Mirrors incminimark's `gc_increment_step`, which defaults to
-    /// `nursery_size * 2`.
+    /// Mirrors incminimark.py:448,500-504 `gc_increment_step`, whose runtime
+    /// default is `nursery_size * 4` when `PYPY_GC_INCREMENT_STEP` is unset.
     mark_budget_per_step: usize,
     /// Reusable buffer for `mark_object`: the FIXED-part GC pointer offsets of
     /// the object currently being traced (bounded by the struct's field count),
@@ -405,10 +405,15 @@ struct IncrementalMarkState {
 
 impl IncrementalMarkState {
     fn new(nursery_size: usize) -> Self {
+        // incminimark.py:500-504: an explicit positive byte budget wins;
+        // otherwise mark four nursery sizes per incremental step.
+        let mark_budget_per_step = read_uint_from_env("PYPY_GC_INCREMENT_STEP")
+            .unwrap_or_else(|| nursery_size.saturating_mul(4))
+            .max(1);
         IncrementalMarkState {
             gray_stack: Vec::new(),
             objects_marked: 0,
-            mark_budget_per_step: (nursery_size.saturating_mul(2)).max(1),
+            mark_budget_per_step,
             mark_offsets: Vec::new(),
         }
     }

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -889,6 +889,25 @@ impl MiniMarkGC {
         self.is_valid_gc_object(addr) && (self.nursery.contains(addr) || self.oldgen.contains(addr))
     }
 
+    /// Resolve a PyObject header without asking the nursery/oldgen allocators.
+    /// A registered vtable plus the exact matching header tid is the translated
+    /// type-layout witness. The tid equality rejects headerless bootstrap
+    /// objects whose preceding allocator word happens to look like flags.
+    #[inline]
+    fn registered_pyobject_header(&self, addr: usize) -> Option<*mut GcHeader> {
+        if addr < GcHeader::SIZE || addr % GcHeader::ALIGN != 0 {
+            return None;
+        }
+        let vtable = unsafe { *(addr as *const usize) };
+        let expected_type_id = *self.vtable_to_type_id.get(&vtable)?;
+        let hdr = unsafe { header_of(addr) };
+        if unsafe { (*hdr).type_id() } == expected_type_id {
+            Some(hdr)
+        } else {
+            None
+        }
+    }
+
     /// Valid-object nursery check for arbitrary GC fields/roots.
     #[inline]
     fn is_nursery_object_start(&self, addr: usize) -> bool {
@@ -2432,13 +2451,24 @@ impl MiniMarkGC {
     }
 
     fn seed_major_root(&mut self, gcref: GcRef) {
-        if gcref.is_null()
-            || !self.is_managed_heap_object(gcref.0)
-            || !self.may_enter_marking_worklist(gcref.0)
-        {
+        if gcref.is_null() {
             return;
         }
-        let hdr = unsafe { header_of(gcref.0) };
+        let hdr = if let Some(hdr) = self.registered_pyobject_header(gcref.0) {
+            // incminimark.py:2782-2800: an untouched prebuilt object is a leaf.
+            if unsafe { (*hdr).has_flag(flags::NO_HEAP_PTRS) } {
+                return;
+            }
+            hdr
+        } else {
+            if !self.is_managed_heap_object(gcref.0) {
+                return;
+            }
+            unsafe { header_of(gcref.0) }
+        };
+        if !self.may_enter_marking_worklist(gcref.0) {
+            return;
+        }
         // SAFETY: header_of returns a raw pointer; keep each access
         // short-lived to avoid creating overlapping exclusive borrows.
         let newly_marked = unsafe {
@@ -3066,10 +3096,26 @@ impl MiniMarkGC {
         site: &str,
         header_bearing: bool,
     ) {
-        // Custom tracers expose GcRef slots, whose targets carry a header.
-        // incminimark.py:2782-2800 ignores untouched prebuilt objects.
-        if header_bearing && unsafe { (*header_of(addr)).has_flag(flags::NO_HEAP_PTRS) } {
-            return;
+        // Most custom-trace slots are PyObjectRefs. Their registered vtable
+        // gives the exact header type id, so a matching header restores
+        // incminimark.py:2739-2752's direct `_collect_obj` path without an
+        // arena-membership query. The equality check is load-bearing: pyre's
+        // same erased callback also exposes GC storage boxes, while legacy raw
+        // stepping stones can carry a Python vtable without a real header.
+        if header_bearing {
+            if let Some(hdr) = self.registered_pyobject_header(addr) {
+                if unsafe { (*hdr).has_flag(flags::NO_HEAP_PTRS) } {
+                    return;
+                }
+                if self.may_enter_marking_worklist(addr)
+                    && unsafe { !(*hdr).has_flag(flags::VISITED) }
+                {
+                    unsafe { (*hdr).set_flag(flags::VISITED) };
+                    self.incr_state.gray_stack.push(addr);
+                    self.note_nonmoving_nursery_mark(addr);
+                }
+                return;
+            }
         }
         if self.is_managed_heap_object(addr) && self.may_enter_marking_worklist(addr) {
             let hdr = unsafe { header_of(addr) };

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -893,6 +893,13 @@ impl MiniMarkGC {
     /// A registered vtable plus the exact matching header tid is the translated
     /// type-layout witness. The tid equality rejects headerless bootstrap
     /// objects whose preceding allocator word happens to look like flags.
+    ///
+    /// This is the ONLY admissible probe for an address outside both managed
+    /// generations, and both callers (`seed_major_root`, `do_write_barrier`)
+    /// must go through it. Recording every `alloc_with_gc_header` result in an
+    /// ownership table instead would make the answer exact, but that is a probe
+    /// on the allocation fast path — the same shape measured at −15% in the GC
+    /// box-probe experiment — so the tid witness stands.
     #[inline]
     fn registered_pyobject_header(&self, addr: usize) -> Option<*mut GcHeader> {
         if addr < GcHeader::SIZE || addr % GcHeader::ALIGN != 0 {

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -5905,6 +5905,14 @@ mod tests {
         let prebuilt = crate::header::alloc_with_gc_header([vtable, child.0], prebuilt_tid);
         let prebuilt_ref = GcRef(prebuilt as usize);
         let hdr = unsafe { header_of(prebuilt_ref.0) };
+        // `alloc_with_gc_header` is pyre's runtime host allocator, not a
+        // translated prebuilt (see its docstring), so it leaves the flags
+        // clear. Stamp incminimark's `init_gc_object_immortal` shape by hand
+        // to exercise the lifecycle this test is about.
+        unsafe {
+            (*hdr).set_flag(flags::NO_HEAP_PTRS);
+            (*hdr).set_flag(flags::TRACK_YOUNG_PTRS);
+        }
         assert!(unsafe { (*hdr).has_flag(flags::NO_HEAP_PTRS) });
 
         gc.do_write_barrier(prebuilt_ref);

--- a/majit/majit-gc/src/header.rs
+++ b/majit/majit-gc/src/header.rs
@@ -143,14 +143,36 @@ pub unsafe fn header_of(obj_addr: usize) -> *mut GcHeader {
 /// payload pointer (`block + SIZE`).
 ///
 /// `malloc_fixedsize` analog: reserve `size_gc_header + size` bytes,
-/// `init_gc_object_immortal(result, typeid)` at the block start, and return
-/// `obj = result + size_gc_header`. incminimark.py initializes a prebuilt
-/// object with `NO_HEAP_PTRS | TRACK_YOUNG_PTRS`. Callers
+/// `init_gc_object(result, typeid, flags=0)` at the block start, and return
+/// `obj = result + size_gc_header`. A freshly allocated object carries no
+/// flags, so the header word is exactly `type_id` (`GcHeader::new`). Callers
 /// pass the object's GC type id (`malloc_typed` threads `GcType::type_id()`;
 /// the untyped bridge and frames pass the object-root id 0).
 ///
-/// These leaked host allocations are pyre's translated prebuilt family. The
-/// first pointer write opens the object through the collector's write barrier.
+/// The header's flags are all clear, so a write barrier reading `*(obj - SIZE)`
+/// sees `TRACK_YOUNG_PTRS = 0` and skips the object. These objects are not yet
+/// routed through the managed nursery allocator; they are leaked host
+/// allocations, and the header is what lets the barrier read `*(obj - SIZE)`
+/// without dereferencing foreign memory.
+///
+/// These are NOT incminimark's prebuilt family and must not be stamped
+/// `NO_HEAP_PTRS | TRACK_YOUNG_PTRS` (`init_gc_object_immortal`). Upstream's
+/// prebuilt objects are translation-time constants whose fields name other
+/// prebuilt objects, which is what makes "an untouched prebuilt object is a
+/// leaf" (incminimark.py:2782-2800) true. These blocks are allocated at
+/// runtime and their reference fields are written directly at construction,
+/// with no write barrier — so an untouched one DOES hold heap pointers, and
+/// the targets are ordinary collectable objects that nothing else roots.
+/// Claiming the flag makes the first barrier on any *other* field enter the
+/// object into `prebuilt_root_objects`, after which a major traces every
+/// `gc_ptr_offsets` slot, including the never-barriered ones whose targets
+/// were already reclaimed. Measured on `synth/pickle_ctor_args`: the walk
+/// reaches a freed `W_ListObject` through
+/// `prebuilt+0x30 -> W_ListObject -> ItemsBlock[0]`, and under
+/// `MAJIT_GC_NURSERY_POISON=1` that list reads back `length = 0xAAAA_AAAA_AAAA_AAAA`.
+/// pyre's real prebuilt lifecycle is the interpreter-side dirty bit
+/// (`mark_prebuilt_roots_dirty` / `PYRE_GC_PREBUILT_REMEMBER`) with explicit
+/// per-structure walkers that resolve ownership before forwarding.
 ///
 /// # Safety
 /// - The result points past the header; it MUST NOT be passed to
@@ -158,6 +180,31 @@ pub unsafe fn header_of(obj_addr: usize) -> *mut GcHeader {
 /// - `align_of::<T>() <= GcHeader::SIZE`, enforced at monomorphisation: a
 ///   wider alignment would move the payload off the fixed `obj - SIZE` offset.
 pub fn alloc_with_gc_header<T>(value: T, type_id: u32) -> *mut T {
+    alloc_with_gc_header_flags(value, GcHeader::new(type_id))
+}
+
+/// [`alloc_with_gc_header`] for a genuine immortal leaf — `init_gc_object_immortal`
+/// (`NO_HEAP_PTRS | TRACK_YOUNG_PTRS`), incminimark's prebuilt shape.
+///
+/// `NO_HEAP_PTRS` asserts the object holds no reference the collector must
+/// follow, so only a payload that really is a leaf may use this: the `None` /
+/// `True` / `False` / `NotImplemented` / `Ellipsis` singletons, whose whole body
+/// is a `PyObject` header with a null `w_class`. An ordinary `#[pyre_class]`
+/// box does NOT qualify — its reference fields are written at construction with
+/// no write barrier, so once the first barrier on any other field opens the
+/// object, a major would follow those never-updated slots into freed memory.
+/// See [`alloc_with_gc_header`] for the measured failure that rule comes from.
+pub fn alloc_with_gc_header_immortal<T>(value: T, type_id: u32) -> *mut T {
+    alloc_with_gc_header_flags(
+        value,
+        GcHeader::with_flags(
+            type_id,
+            crate::flags::NO_HEAP_PTRS | crate::flags::TRACK_YOUNG_PTRS,
+        ),
+    )
+}
+
+fn alloc_with_gc_header_flags<T>(value: T, header: GcHeader) -> *mut T {
     const {
         assert!(
             std::mem::align_of::<T>() <= GcHeader::SIZE,
@@ -173,10 +220,7 @@ pub fn alloc_with_gc_header<T>(value: T, type_id: u32) -> *mut T {
         if raw.is_null() {
             std::alloc::handle_alloc_error(layout);
         }
-        (raw as *mut GcHeader).write(GcHeader::with_flags(
-            type_id,
-            crate::flags::NO_HEAP_PTRS | crate::flags::TRACK_YOUNG_PTRS,
-        ));
+        (raw as *mut GcHeader).write(header);
         let ptr = raw.add(GcHeader::SIZE) as *mut T;
         ptr.write(value);
         ptr
@@ -240,12 +284,11 @@ mod tests {
         unsafe {
             assert_eq!(*p, 0xABCD);
             let hdr = header_of(p as usize);
-            // incminimark init_gc_object_immortal flags.
+            // type id recorded; flags clear (init_gc_object flags=0).
             assert_eq!((*hdr).type_id(), 0x1357);
-            assert_eq!(
-                (*hdr).flags(),
-                flags::NO_HEAP_PTRS | flags::TRACK_YOUNG_PTRS
-            );
+            assert_eq!((*hdr).flags(), 0);
+            assert!(!(*hdr).has_flag(flags::TRACK_YOUNG_PTRS));
+            assert!(!(*hdr).has_flag(flags::NO_HEAP_PTRS));
         }
     }
 

--- a/majit/majit-gc/src/header.rs
+++ b/majit/majit-gc/src/header.rs
@@ -143,17 +143,14 @@ pub unsafe fn header_of(obj_addr: usize) -> *mut GcHeader {
 /// payload pointer (`block + SIZE`).
 ///
 /// `malloc_fixedsize` analog: reserve `size_gc_header + size` bytes,
-/// `init_gc_object(result, typeid, flags=0)` at the block start, and return
-/// `obj = result + size_gc_header`. A freshly allocated object carries no
-/// flags, so the header word is exactly `type_id` (`GcHeader::new`). Callers
+/// `init_gc_object_immortal(result, typeid)` at the block start, and return
+/// `obj = result + size_gc_header`. incminimark.py initializes a prebuilt
+/// object with `NO_HEAP_PTRS | TRACK_YOUNG_PTRS`. Callers
 /// pass the object's GC type id (`malloc_typed` threads `GcType::type_id()`;
 /// the untyped bridge and frames pass the object-root id 0).
 ///
-/// The header's flags are all clear, so a write barrier reading `*(obj - SIZE)`
-/// sees `TRACK_YOUNG_PTRS = 0` and skips the object. These objects are not yet
-/// routed through the managed nursery allocator; they are leaked host
-/// allocations, and the header is what lets the barrier read `*(obj - SIZE)`
-/// without dereferencing foreign memory.
+/// These leaked host allocations are pyre's translated prebuilt family. The
+/// first pointer write opens the object through the collector's write barrier.
 ///
 /// # Safety
 /// - The result points past the header; it MUST NOT be passed to
@@ -176,7 +173,10 @@ pub fn alloc_with_gc_header<T>(value: T, type_id: u32) -> *mut T {
         if raw.is_null() {
             std::alloc::handle_alloc_error(layout);
         }
-        (raw as *mut GcHeader).write(GcHeader::new(type_id));
+        (raw as *mut GcHeader).write(GcHeader::with_flags(
+            type_id,
+            crate::flags::NO_HEAP_PTRS | crate::flags::TRACK_YOUNG_PTRS,
+        ));
         let ptr = raw.add(GcHeader::SIZE) as *mut T;
         ptr.write(value);
         ptr
@@ -240,10 +240,12 @@ mod tests {
         unsafe {
             assert_eq!(*p, 0xABCD);
             let hdr = header_of(p as usize);
-            // type id recorded; flags clear (init_gc_object flags=0).
+            // incminimark init_gc_object_immortal flags.
             assert_eq!((*hdr).type_id(), 0x1357);
-            assert_eq!((*hdr).flags(), 0);
-            assert!(!(*hdr).has_flag(flags::TRACK_YOUNG_PTRS));
+            assert_eq!(
+                (*hdr).flags(),
+                flags::NO_HEAP_PTRS | flags::TRACK_YOUNG_PTRS
+            );
         }
     }
 

--- a/pyre/bench/synth/with_except_start_function_resume.cranelift.jitstats
+++ b/pyre/bench/synth/with_except_start_function_resume.cranelift.jitstats
@@ -1,0 +1,8 @@
+bridges_compiled=0
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
+guard_failures=1
+internal_compile_panics=0
+loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/with_except_start_function_resume.dynasm.jitstats
+++ b/pyre/bench/synth/with_except_start_function_resume.dynasm.jitstats
@@ -1,0 +1,8 @@
+bridges_compiled=0
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
+guard_failures=1
+internal_compile_panics=0
+loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/with_except_start_function_resume.py
+++ b/pyre/bench/synth/with_except_start_function_resume.py
@@ -1,0 +1,38 @@
+# pyre-check: max-pypy-ratio=50
+# A function-entry trace records only the early-return arm.  The first true
+# call then fails that guard and blackhole-replays the previously unvisited
+# `with` arm.  WITH_EXCEPT_START must read the live handler stack and call
+# `__exit__`; a disconnected graph result used to treat the caught TypeError
+# as the exit callable and leak another TypeError instead.
+try:
+    import pypyjit
+
+    pypyjit.set_param("threshold=-1,function_threshold=20")
+except ImportError:
+    pass
+
+import math
+
+seen = []
+
+
+class Context:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        seen.append(exc_type)
+        return True
+
+
+def run(raise_inside):
+    if not raise_inside:
+        return
+    with Context():
+        math.sin()
+
+
+for _ in range(30):
+    run(False)
+run(True)
+print("ok", len(seen))

--- a/pyre/bench/synth/with_except_start_function_resume.wasm.jitstats
+++ b/pyre/bench/synth/with_except_start_function_resume.wasm.jitstats
@@ -1,0 +1,5 @@
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
+internal_compile_panics=0
+loops_aborted=0

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -3196,6 +3196,24 @@ pub fn compute_load_method_bound(obj: PyObjectRef, attr: PyObjectRef, name: &str
     }
 }
 
+/// Shared WITH_EXCEPT_START call semantics for the interpreter and generated
+/// JitCode residual.  Keeping the call here preserves the bytecode operation's
+/// exact `__exit__(type, value, traceback)` argument construction on both paths.
+pub fn with_except_start_values(
+    exit_func: PyObjectRef,
+    exit_self: PyObjectRef,
+    val: PyObjectRef,
+) -> PyObjectRef {
+    let exc_type = crate::typedef::r#type(val).map_or(pyre_object::w_none(), |p| p.as_ptr());
+    let exc_tb =
+        crate::baseobjspace::getattr_str(val, "__traceback__").unwrap_or(pyre_object::w_none());
+    if exit_self.is_null() {
+        crate::call_function(exit_func, &[exc_type, val, exc_tb])
+    } else {
+        crate::call_function(exit_func, &[exit_self, exc_type, val, exc_tb])
+    }
+}
+
 impl OpcodeStepExecutor for PyFrame {
     /// SETUP_ANNOTATIONS — ensure `__annotations__` exists in the
     /// current locals namespace. PyPy: pyopcode.py SETUP_ANNOTATIONS
@@ -3262,14 +3280,7 @@ impl OpcodeStepExecutor for PyFrame {
         let val = self.locals_w()[depth - 1];
         let exit_self = self.locals_w()[depth - 4];
         let exit_func = self.locals_w()[depth - 5];
-        let exc_type = crate::typedef::r#type(val).map_or(pyre_object::w_none(), |p| p.as_ptr());
-        let exc_tb =
-            crate::baseobjspace::getattr_str(val, "__traceback__").unwrap_or(pyre_object::w_none());
-        let res = if exit_self.is_null() {
-            crate::call_function(exit_func, &[exc_type, val, exc_tb])
-        } else {
-            crate::call_function(exit_func, &[exit_self, exc_type, val, exc_tb])
-        };
+        let res = with_except_start_values(exit_func, exit_self, val);
         if res.is_null() {
             return Err(crate::call::take_call_error()
                 .unwrap_or_else(|| crate::PyError::type_error("__exit__ failed"))

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -47,8 +47,6 @@ thread_local! {
         current_frame: CURRENT_FRAME.with(|frame| frame as *const _),
         last_exec_ctx: crate::call::capture_last_exec_ctx_cell(),
         import_roots: crate::importing::capture_import_root_area(),
-        mapdict_method_cache: crate::pycode::capture_mapdict_method_cache_root_area(),
-        w_globals_stamped_codes: crate::pycode::capture_w_globals_stamped_code_root_area(),
         in_flight_exception: IN_FLIGHT_EXCEPTION.with(|cell| cell as *const _),
         bh_last_exception: majit_metainterp::blackhole::BH_LAST_EXC_VALUE
             .with(|cell| cell as *const _),
@@ -64,8 +62,6 @@ struct PyFrameRootArea {
     current_frame: *const Cell<*mut PyFrame>,
     last_exec_ctx: *const (),
     import_roots: *const (),
-    mapdict_method_cache: *const (),
-    w_globals_stamped_codes: *const (),
     in_flight_exception: *const Cell<PyObjectRef>,
     bh_last_exception: *const Cell<i64>,
     guard_exception: *const Cell<i64>,
@@ -1076,27 +1072,14 @@ pub unsafe fn walk_pyframe_roots_area(
                     walk_raw_getset_roots(*slot, visitor);
                 };
                 crate::importing::walk_import_roots_area(area.import_roots, &mut forward);
-                // The per-pycode `_mapdict_caches` LOAD_METHOD slots hold a
-                // `w_method` pointer (mapdict.py:1418) that no custom trace
-                // reaches — code objects are Box-immortal — so forward those
-                // the same way.
-                crate::pycode::walk_mapdict_method_cache_root_area(
-                    area.mapdict_method_cache,
-                    &mut forward,
-                );
-                // `pycode.py:159-165 frame_stores_global` stamps `w_globals`
-                // permanently, and upstream traces it through the GC-managed
-                // `PyCode`.  Box-immortal code objects are reached only when
-                // `walk_raw_code_roots` runs on a `frame.pycode` / `func.code`
-                // that happens to be walked, so a stamped code object sitting
-                // off the frame chain keeps a pre-move address once its
-                // globals dict is promoted.  Forward every stamped slot.
-                crate::pycode::walk_w_globals_stamped_code_root_area(
-                    area.w_globals_stamped_codes,
-                    &mut |slot| {
-                        visitor(&mut *(slot as *mut PyObjectRef as *mut majit_ir::GcRef));
-                    },
-                );
+                // The `_mapdict_caches` LOAD_METHOD `w_method` slots
+                // (mapdict.py:1418) and the stamped `w_globals` slots
+                // (`pycode.py:159-165 frame_stores_global`) used to ride here
+                // as per-thread areas.  Their holder is an immortal code
+                // object that outlives the stamping thread, so they moved to
+                // process-global walkers registered in `pyre-jit::eval`
+                // (`mapdict_method_cache_root_walker`,
+                // `w_globals_stamped_code_root_walker`).
             }
         }
     }

--- a/pyre/pyre-interpreter/src/function.rs
+++ b/pyre/pyre-interpreter/src/function.rs
@@ -2977,34 +2977,34 @@ pub fn funccall_valuestack(
         // slots cease to be roots when dropvalues() clears them, so publish
         // the same live-variable set on pyre's shadow stack before doing so.
         let _roots = pyre_object::gc_roots::push_roots();
-        let root_base = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(code as PyObjectRef);
+        let root_base = _roots.base();
+        _roots.pin_root(code as PyObjectRef);
         match nargs {
             0 => {}
             1 => {
-                pyre_object::gc_roots::pin_root(frame.peekvalue(0));
+                _roots.pin_root(frame.peekvalue(0));
             }
             2 => {
-                pyre_object::gc_roots::pin_root(frame.peekvalue(1));
-                pyre_object::gc_roots::pin_root(frame.peekvalue(0));
+                _roots.pin_root(frame.peekvalue(1));
+                _roots.pin_root(frame.peekvalue(0));
             }
             3 => {
-                pyre_object::gc_roots::pin_root(frame.peekvalue(2));
-                pyre_object::gc_roots::pin_root(frame.peekvalue(1));
-                pyre_object::gc_roots::pin_root(frame.peekvalue(0));
+                _roots.pin_root(frame.peekvalue(2));
+                _roots.pin_root(frame.peekvalue(1));
+                _roots.pin_root(frame.peekvalue(0));
             }
             4 => {
-                pyre_object::gc_roots::pin_root(frame.peekvalue(3));
-                pyre_object::gc_roots::pin_root(frame.peekvalue(2));
-                pyre_object::gc_roots::pin_root(frame.peekvalue(1));
-                pyre_object::gc_roots::pin_root(frame.peekvalue(0));
+                _roots.pin_root(frame.peekvalue(3));
+                _roots.pin_root(frame.peekvalue(2));
+                _roots.pin_root(frame.peekvalue(1));
+                _roots.pin_root(frame.peekvalue(0));
             }
             _ => unreachable!(),
         }
         frame.dropvalues(dropvalues);
 
-        let code = pyre_object::gc_roots::shadow_stack_get(root_base);
-        let rooted_arg = |index| pyre_object::gc_roots::shadow_stack_get(root_base + 1 + index);
+        let code = _roots.get(root_base);
+        let rooted_arg = |index| _roots.get(root_base + 1 + index);
         // Pyre builtins share a single fn(&[PyObjectRef]) signature, so use
         // fixed-size stack arrays instead of heap-allocating a Vec.
         let result = match nargs {

--- a/pyre/pyre-interpreter/src/pycode.rs
+++ b/pyre/pyre-interpreter/src/pycode.rs
@@ -418,6 +418,13 @@ pub fn _convert_const(_space: PyObjectRef, w_a: PyObjectRef) -> PyObjectRef {
 /// tables through direct raw allocations. Residualise the whole
 /// constructor — a `PyObjectRef` GCREF modelled by signature. Code objects are
 /// built at import/compile time, never on a traced hot path.
+///
+/// `pycode.py:93` makes `PyCode` an ordinary GC object, so upstream traces
+/// `w_globals` and the cache tables structurally through it. `malloc_typed`
+/// here makes it immortal and non-moving instead, which nothing traces into —
+/// so every GC-heap slot it owns needs an explicit root walker
+/// ([`walk_w_globals_stamped_code_roots`], [`walk_mapdict_method_cache_gc`]).
+/// Those registries retire when code objects become GC-managed.
 #[majit_macros::dont_look_inside]
 pub fn w_code_new_with_hidden_applevel(code_ptr: *const (), hidden_applevel: bool) -> PyObjectRef {
     // RPython pointer alignment idiom (`rpython/memory/gc/minimarkpage.py:159

--- a/pyre/pyre-interpreter/src/pycode.rs
+++ b/pyre/pyre-interpreter/src/pycode.rs
@@ -159,7 +159,7 @@ pub struct PyCode {
     /// PyPy: `PyCode.w_globals` — the globals dict OBJECT (`W_DictMultiObject`,
     /// `pycode.py:105 "w_globals?"`).  Module globals are `malloc_typed`-
     /// immortal, but `exec`/custom-globals dicts are `try_gc_alloc` movable.
-    /// The code object is Box-immortal, so the collector never reaches this
+    /// The code object is prebuilt-immortal, so the collector never reaches this
     /// slot by tracing into it; every stamped code object is registered in
     /// [`W_GLOBALS_STAMPED_CODES`] and forwarded from there on each
     /// collection. `eval::walk_raw_code_roots` additionally forwards it
@@ -287,13 +287,13 @@ pub unsafe fn w_code_qualname_obj(w_code: PyObjectRef) -> PyObjectRef {
     }
 }
 
-/// Box-immortal `PyCode` wrappers that own off-GC `w_globals` and
+/// Prebuilt-immortal `PyCode` wrappers that own off-GC `w_globals` and
 /// `co_consts_w` slots.
 ///
 /// PyPy's `PyCode` is GC-managed, so ordinary graph tracing reaches these
 /// fields even when a code object is stored directly in a module/container
 /// without first becoming a function or frame. Pyre's wrappers are
-/// `Box::into_raw`-immortal; retain their exact process-global lifetime and
+/// `malloc_typed`-immortal; retain their exact process-global lifetime and
 /// expose every wrapper through one small insertion-ordered registry instead
 /// of a TLS or per-value side table.
 static PREBUILT_CODE_ROOTS: std::sync::OnceLock<std::sync::Mutex<Vec<usize>>> =
@@ -414,9 +414,8 @@ pub fn _convert_const(_space: PyObjectRef, w_a: PyObjectRef) -> PyObjectRef {
 /// via `Box::into_raw`.
 ///
 /// `#[dont_look_inside]` (`@jit.dont_look_inside`, `rlib/jit.py:139`): the body
-/// boxes the `PyCode` and its per-name cache tables through direct
-/// `Box::into_raw(Box::new(...))`, whose `Box::new_uninit` primitive carries no
-/// annotator (raw allocation is deliberately unlifted). Residualise the whole
+/// boxes the `PyCode` through the prebuilt allocator and its per-name cache
+/// tables through direct raw allocations. Residualise the whole
 /// constructor — a `PyObjectRef` GCREF modelled by signature. Code objects are
 /// built at import/compile time, never on a traced hot path.
 #[majit_macros::dont_look_inside]
@@ -489,7 +488,7 @@ pub fn w_code_new_with_hidden_applevel(code_ptr: *const (), hidden_applevel: boo
             .first_line_number
             .map_or(1, |line| line.get() as i32)
     };
-    let obj = Box::new(PyCode {
+    let obj = pyre_object::lltype::malloc_typed(PyCode {
         ob_header: PyObject {
             ob_type: &CODE_TYPE as *const PyType,
             w_class: pyre_object::pyobject::get_instantiate(&CODE_TYPE),
@@ -504,8 +503,7 @@ pub fn w_code_new_with_hidden_applevel(code_ptr: *const (), hidden_applevel: boo
         mapdict_caches,
         co_consts_w,
         w_qualname: pyre_object::PY_NULL,
-    });
-    let obj = Box::into_raw(obj) as PyObjectRef;
+    }) as PyObjectRef;
     register_prebuilt_code_root(obj);
     obj
 }
@@ -1736,7 +1734,7 @@ thread_local! {
     /// holds, so the JIT need not carry the wrapper identity as a separate
     /// `w_code` courier. First-write-wins, mirroring the first-store-wins
     /// `PyCode.w_globals` semantics in `w_code_frame_stores_global`. Wrappers
-    /// are `Box::into_raw`-immortal and non-moving, so stored pointers never
+    /// are prebuilt-immortal and non-moving, so stored pointers never
     /// dangle and need no GC rooting.
     static LIVE_CODE_WRAPPERS: std::cell::RefCell<std::collections::HashMap<*const (), PyObjectRef>> =
         std::cell::RefCell::new(std::collections::HashMap::new());
@@ -2005,7 +2003,7 @@ thread_local! {
     /// Code objects whose `_mapdict_caches` hold (or once held) a filled
     /// `w_method` slot.  In PyPy `CacheEntry.w_method` (mapdict.py:1418)
     /// is traced through the GC-managed `PyCode`; pyre code objects are
-    /// Box-immortal (`w_code_new` → `Box::into_raw`), so no trace
+    /// prebuilt-immortal (`w_code_new` → `malloc_typed`), so no field trace
     /// reaches the slot — the extra-root walker forwards it through
     /// this registry instead (same family as `walk_method_cache_gc`).
     /// Entries are immortal code pointers, so they never dangle; the
@@ -2017,7 +2015,7 @@ thread_local! {
     /// strong field: the first globals object a code object runs in is kept
     /// for the code object's lifetime and never replaced.  Upstream that
     /// field is traced through the GC-managed `PyCode`; pyre code objects are
-    /// Box-immortal (`w_code_new` → `Box::into_raw`), so the only paths that
+    /// prebuilt-immortal (`w_code_new` → `malloc_typed`), so the only paths that
     /// reach the slot are the opportunistic `walk_raw_code_roots` calls on
     /// `frame.pycode` and `func.code`.  Those miss any stamped code object
     /// that is off the frame chain and not held in a walked frame slot at

--- a/pyre/pyre-interpreter/src/pycode.rs
+++ b/pyre/pyre-interpreter/src/pycode.rs
@@ -1725,19 +1725,29 @@ pub unsafe fn w_code_frame_stores_global(obj: PyObjectRef, w_globals: PyObjectRe
     !std::ptr::eq(code.w_globals, w_globals)
 }
 
-thread_local! {
-    /// Registry mapping a raw CodeObject pointer (`PyCode.code_ptr`) to the
-    /// live, globals-stamped `PyCode` wrapper. Populated where a frame stamps
-    /// the wrapper's `w_globals` — the only point both the raw pointer and the
-    /// live wrapper are in hand — and consumed by the JIT to recover the live
-    /// wrapper (and hence its `w_globals`) from a raw code pointer it already
-    /// holds, so the JIT need not carry the wrapper identity as a separate
-    /// `w_code` courier. First-write-wins, mirroring the first-store-wins
-    /// `PyCode.w_globals` semantics in `w_code_frame_stores_global`. Wrappers
-    /// are prebuilt-immortal and non-moving, so stored pointers never
-    /// dangle and need no GC rooting.
-    static LIVE_CODE_WRAPPERS: std::cell::RefCell<std::collections::HashMap<*const (), PyObjectRef>> =
-        std::cell::RefCell::new(std::collections::HashMap::new());
+/// Registry mapping a raw CodeObject pointer (`PyCode.code_ptr`) to the
+/// live, globals-stamped `PyCode` wrapper. Populated where a frame stamps
+/// the wrapper's `w_globals` — the only point both the raw pointer and the
+/// live wrapper are in hand — and consumed by the JIT to recover the live
+/// wrapper (and hence its `w_globals`) from a raw code pointer it already
+/// holds, so the JIT need not carry the wrapper identity as a separate
+/// `w_code` courier. First-write-wins, mirroring the first-store-wins
+/// `PyCode.w_globals` semantics in `w_code_frame_stores_global`. Wrappers
+/// are prebuilt-immortal and non-moving, so stored pointers never
+/// dangle and need no GC rooting.
+///
+/// Process-global, not per-thread: `pycode.py:159` keeps `w_globals` on the
+/// shared `PyCode` instance, and a code object stamped on one thread must be
+/// recoverable from every thread that later runs it — a thread-local map made
+/// the JIT's `recover_inline_callee_globals` answer `PY_NULL` there and
+/// decline the inline. Keys and values are `usize` because a raw
+/// `PyObjectRef` is not `Send`, as in `interp_sre`'s pattern registry.
+static LIVE_CODE_WRAPPERS: std::sync::OnceLock<
+    std::sync::Mutex<std::collections::HashMap<usize, usize>>,
+> = std::sync::OnceLock::new();
+
+fn live_code_wrappers() -> &'static std::sync::Mutex<std::collections::HashMap<usize, usize>> {
+    LIVE_CODE_WRAPPERS.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()))
 }
 
 /// Record `wrapper` as the live wrapper for `code_ptr`, keeping the first one
@@ -1746,9 +1756,11 @@ pub fn register_live_code_wrapper(code_ptr: *const (), wrapper: PyObjectRef) {
     if code_ptr.is_null() || wrapper.is_null() {
         return;
     }
-    LIVE_CODE_WRAPPERS.with(|m| {
-        m.borrow_mut().entry(code_ptr).or_insert(wrapper);
-    });
+    live_code_wrappers()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .entry(code_ptr as usize)
+        .or_insert(wrapper as usize);
 }
 
 /// Recover the live wrapper previously registered for `code_ptr`, or `PY_NULL`
@@ -1757,7 +1769,11 @@ pub fn live_code_wrapper(code_ptr: *const ()) -> PyObjectRef {
     if code_ptr.is_null() {
         return PY_NULL;
     }
-    LIVE_CODE_WRAPPERS.with(|m| m.borrow().get(&code_ptr).copied().unwrap_or(PY_NULL))
+    live_code_wrappers()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .get(&(code_ptr as usize))
+        .map_or(PY_NULL, |&w| w as PyObjectRef)
 }
 
 /// pycode.py:226-238 `_compute_flatcall`.
@@ -1989,9 +2005,10 @@ pub unsafe fn w_code_mapdict_caches_set(
         // `w_method` reference; register this code object so
         // `walk_mapdict_method_cache_gc` forwards the slot.
         if !entry.w_method.is_null() {
-            MAPDICT_METHOD_CACHE_CODES.with(|s| {
-                s.borrow_mut().insert(obj as usize);
-            });
+            mapdict_method_cache_codes()
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .insert(obj as usize);
             // Prebuilt-family store: the slot is reached only by
             // `walk_mapdict_method_cache_gc`, skipped on clean minors.
             pyre_object::gc_roots::mark_prebuilt_roots_dirty();
@@ -1999,60 +2016,69 @@ pub unsafe fn w_code_mapdict_caches_set(
     }
 }
 
-thread_local! {
-    /// Code objects whose `_mapdict_caches` hold (or once held) a filled
-    /// `w_method` slot.  In PyPy `CacheEntry.w_method` (mapdict.py:1418)
-    /// is traced through the GC-managed `PyCode`; pyre code objects are
-    /// prebuilt-immortal (`w_code_new` → `malloc_typed`), so no field trace
-    /// reaches the slot — the extra-root walker forwards it through
-    /// this registry instead (same family as `walk_method_cache_gc`).
-    /// Entries are immortal code pointers, so they never dangle; the
-    /// registry retires when code objects become GC-managed.
-    static MAPDICT_METHOD_CACHE_CODES: std::cell::RefCell<std::collections::HashSet<usize>> =
-        std::cell::RefCell::new(std::collections::HashSet::new());
-    /// Code objects whose `w_globals` has been stamped
-    /// (`pycode.py:159-165 frame_stores_global`).  `w_globals` is a permanent
-    /// strong field: the first globals object a code object runs in is kept
-    /// for the code object's lifetime and never replaced.  Upstream that
-    /// field is traced through the GC-managed `PyCode`; pyre code objects are
-    /// prebuilt-immortal (`w_code_new` → `malloc_typed`), so the only paths that
-    /// reach the slot are the opportunistic `walk_raw_code_roots` calls on
-    /// `frame.pycode` and `func.code`.  Those miss any stamped code object
-    /// that is off the frame chain and not held in a walked frame slot at
-    /// collection time, which leaves a pre-move nursery address in
-    /// `w_globals` once its dict is promoted — the next call through that
-    /// code object then forwards a dangling pointer.  This registry makes the
-    /// slot a root of its own, in the same family as
-    /// [`MAPDICT_METHOD_CACHE_CODES`].  Entries are immortal code pointers,
-    /// so they never dangle; the registry retires when code objects become
-    /// GC-managed.
-    static W_GLOBALS_STAMPED_CODES: std::cell::RefCell<std::collections::HashSet<usize>> =
-        std::cell::RefCell::new(std::collections::HashSet::new());
+/// Code objects whose `_mapdict_caches` hold (or once held) a filled
+/// `w_method` slot.  In PyPy `CacheEntry.w_method` (mapdict.py:1418)
+/// is traced through the GC-managed `PyCode`; pyre code objects are
+/// prebuilt-immortal (`w_code_new` → `malloc_typed`), so no field trace
+/// reaches the slot — the extra-root walker forwards it through
+/// this registry instead (same family as `walk_method_cache_gc`).
+/// The registry retires when code objects become GC-managed.
+static MAPDICT_METHOD_CACHE_CODES: std::sync::OnceLock<
+    std::sync::Mutex<std::collections::HashSet<usize>>,
+> = std::sync::OnceLock::new();
+
+fn mapdict_method_cache_codes() -> &'static std::sync::Mutex<std::collections::HashSet<usize>> {
+    MAPDICT_METHOD_CACHE_CODES
+        .get_or_init(|| std::sync::Mutex::new(std::collections::HashSet::new()))
+}
+
+/// Code objects whose `w_globals` has been stamped
+/// (`pycode.py:159-165 frame_stores_global`).  `w_globals` is a permanent
+/// strong field: the first globals object a code object runs in is kept
+/// for the code object's lifetime and never replaced.  Upstream that
+/// field is traced through the GC-managed `PyCode`; pyre code objects are
+/// prebuilt-immortal (`w_code_new` → `malloc_typed`), so the only paths that
+/// reach the slot are the opportunistic `walk_raw_code_roots` calls on
+/// `frame.pycode` and `func.code`.  Those miss any stamped code object
+/// that is off the frame chain and not held in a walked frame slot at
+/// collection time, which leaves a pre-move nursery address in
+/// `w_globals` once its dict is promoted — the next call through that
+/// code object then forwards a dangling pointer.  This registry makes the
+/// slot a root of its own, in the same family as
+/// [`MAPDICT_METHOD_CACHE_CODES`].  The registry retires when code objects
+/// become GC-managed.
+static W_GLOBALS_STAMPED_CODES: std::sync::OnceLock<
+    std::sync::Mutex<std::collections::HashSet<usize>>,
+> = std::sync::OnceLock::new();
+
+fn w_globals_stamped_codes() -> &'static std::sync::Mutex<std::collections::HashSet<usize>> {
+    W_GLOBALS_STAMPED_CODES.get_or_init(|| std::sync::Mutex::new(std::collections::HashSet::new()))
 }
 
 /// Record `obj` as a code object holding a stamped `w_globals` slot.
 fn register_w_globals_stamped_code(obj: PyObjectRef) {
-    W_GLOBALS_STAMPED_CODES.with(|s| {
-        s.borrow_mut().insert(obj as usize);
-    });
-}
-
-pub(crate) fn capture_w_globals_stamped_code_root_area() -> *const () {
-    W_GLOBALS_STAMPED_CODES.with(|codes| codes as *const _ as *const ())
+    w_globals_stamped_codes()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .insert(obj as usize);
 }
 
 /// Forward the stamped `w_globals` slot of every registered code object.
 ///
-/// # Safety
-/// `data` must come from [`capture_w_globals_stamped_code_root_area`], and the
-/// owning thread must be quiesced.
-pub(crate) unsafe fn walk_w_globals_stamped_code_root_area(
-    data: *const (),
-    forward: &mut dyn FnMut(&mut PyObjectRef),
-) {
-    let codes = unsafe {
-        &*(*(data as *const std::cell::RefCell<std::collections::HashSet<usize>>)).as_ptr()
-    };
+/// A process-global walker, not a per-mutator root area: a code object is
+/// immortal and `w_globals` is first-store-wins, so the slot outlives whichever
+/// thread happened to stamp it.  Owning the root per-thread meant
+/// `unregister_mutator` dropped that thread's area at thread exit while the
+/// code object stayed live and callable, and the slot then went unforwarded.
+/// Same ownership argument as `interp_sre`'s pattern registry.
+///
+/// Reached only from the collector's root walk, where every mutator is at a
+/// safepoint — that is what makes handing out `&mut code.w_globals` sound.
+#[majit_macros::dont_look_inside]
+pub fn walk_w_globals_stamped_code_roots(forward: &mut dyn FnMut(&mut PyObjectRef)) {
+    let codes = w_globals_stamped_codes()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
     for &code in codes.iter() {
         let code = unsafe { &mut *(code as *mut PyCode) };
         if code.w_globals.is_null() {
@@ -2068,39 +2094,15 @@ pub(crate) unsafe fn walk_w_globals_stamped_code_root_area(
 /// map/attr node pointers are immortal interned nodes and the
 /// `version_tag` is a `u64`, so `w_method` is the entry's only movable
 /// reference.
-pub(crate) unsafe fn walk_mapdict_method_cache_gc(forward: &mut dyn FnMut(&mut PyObjectRef)) {
-    MAPDICT_METHOD_CACHE_CODES.with(|s| {
-        for &code in s.borrow().iter() {
-            let code = unsafe { &*(code as *const PyCode) };
-            if code.mapdict_caches.is_null() {
-                continue;
-            }
-            let vec = unsafe { &mut *code.mapdict_caches };
-            for slot in vec.iter_mut() {
-                if let Some(entry) = slot.as_mut() {
-                    if !entry.w_method.is_null() {
-                        forward(&mut entry.w_method);
-                    }
-                }
-            }
-        }
-    });
-}
-
-pub(crate) fn capture_mapdict_method_cache_root_area() -> *const () {
-    MAPDICT_METHOD_CACHE_CODES.with(|codes| codes as *const _ as *const ())
-}
-
-/// # Safety
-/// `data` must come from [`capture_mapdict_method_cache_root_area`], and the
-/// owning thread must be quiesced.
-pub(crate) unsafe fn walk_mapdict_method_cache_root_area(
-    data: *const (),
-    forward: &mut dyn FnMut(&mut PyObjectRef),
-) {
-    let codes = unsafe {
-        &*(*(data as *const std::cell::RefCell<std::collections::HashSet<usize>>)).as_ptr()
-    };
+///
+/// Process-global for the same reason as
+/// [`walk_w_globals_stamped_code_roots`]: the holder is immortal and outlives
+/// the thread that filled the slot.
+#[majit_macros::dont_look_inside]
+pub fn walk_mapdict_method_cache_gc(forward: &mut dyn FnMut(&mut PyObjectRef)) {
+    let codes = mapdict_method_cache_codes()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
     for &code in codes.iter() {
         let code = unsafe { &*(code as *const PyCode) };
         if code.mapdict_caches.is_null() {

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -3837,10 +3837,8 @@ impl PyFrame {
         for &arg in args {
             _roots.pin_root(arg);
         }
-        let w_builtin = crate::baseobjspace::frame_builtin_obj(
-            _roots.get(root_base + 1),
-            execution_context,
-        );
+        let w_builtin =
+            crate::baseobjspace::frame_builtin_obj(_roots.get(root_base + 1), execution_context);
         let mut current_args: Vec<PyObjectRef> = Vec::with_capacity(args.len());
         for i in 0..args.len() {
             current_args.push(_roots.get(root_base + 3 + i));
@@ -3885,9 +3883,8 @@ impl PyFrame {
         ]);
         let args_base = pyre_object::gc_roots::publish_roots(args);
         pyre_object::gc_roots::normalize_roots(root_base, 4 + args.len());
-        let code_ref = unsafe {
-            &*(crate::w_code_get_ptr(_roots.get(root_base)) as *const CodeObject)
-        };
+        let code_ref =
+            unsafe { &*(crate::w_code_get_ptr(_roots.get(root_base)) as *const CodeObject) };
         let num_locals = code_ref.varnames.len();
         let num_cells = ncells(code_ref);
         let max_stack = code_ref.max_stackdepth as usize;
@@ -3941,10 +3938,7 @@ impl PyFrame {
         // pyframe.py:103 — stamp `pycode.w_globals`; side effect only (the
         // gated debugdata snapshot retired in favour of `w_globals`).
         unsafe {
-            crate::w_code_frame_stores_global(
-                _roots.get(root_base),
-                _roots.get(root_base + 1),
-            );
+            crate::w_code_frame_stores_global(_roots.get(root_base), _roots.get(root_base + 1));
         }
 
         let mut frame = PyFrame {

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -3787,27 +3787,27 @@ impl PyFrame {
         // values here; after a collection only the gcmap/shadow slots are
         // forwarded, so never carry the original slice across that call.
         let _roots = pyre_object::gc_roots::push_roots();
-        let root_base = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(code as PyObjectRef);
-        pyre_object::gc_roots::pin_root(w_globals);
-        pyre_object::gc_roots::pin_root(closure);
+        let root_base = _roots.base();
+        _roots.pin_root(code as PyObjectRef);
+        _roots.pin_root(w_globals);
+        _roots.pin_root(closure);
         for &arg in args {
-            pyre_object::gc_roots::pin_root(arg);
+            _roots.pin_root(arg);
         }
         let w_builtin = crate::baseobjspace::frame_builtin_obj_checked(
-            pyre_object::gc_roots::shadow_stack_get(root_base + 1),
+            _roots.get(root_base + 1),
             execution_context,
         )?;
         let mut current_args: Vec<PyObjectRef> = Vec::with_capacity(args.len());
         for i in 0..args.len() {
-            current_args.push(pyre_object::gc_roots::shadow_stack_get(root_base + 3 + i));
+            current_args.push(_roots.get(root_base + 3 + i));
         }
         Ok(Self::finish_for_call_with_globals_obj(
-            pyre_object::gc_roots::shadow_stack_get(root_base) as *const (),
+            _roots.get(root_base) as *const (),
             &current_args,
-            pyre_object::gc_roots::shadow_stack_get(root_base + 1),
+            _roots.get(root_base + 1),
             execution_context,
-            pyre_object::gc_roots::shadow_stack_get(root_base + 2),
+            _roots.get(root_base + 2),
             w_builtin,
             allocation,
         ))
@@ -3830,27 +3830,27 @@ impl PyFrame {
         allocation: FrameLocalsArrayAllocation,
     ) -> Self {
         let _roots = pyre_object::gc_roots::push_roots();
-        let root_base = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(code as PyObjectRef);
-        pyre_object::gc_roots::pin_root(w_globals);
-        pyre_object::gc_roots::pin_root(closure);
+        let root_base = _roots.base();
+        _roots.pin_root(code as PyObjectRef);
+        _roots.pin_root(w_globals);
+        _roots.pin_root(closure);
         for &arg in args {
-            pyre_object::gc_roots::pin_root(arg);
+            _roots.pin_root(arg);
         }
         let w_builtin = crate::baseobjspace::frame_builtin_obj(
-            pyre_object::gc_roots::shadow_stack_get(root_base + 1),
+            _roots.get(root_base + 1),
             execution_context,
         );
         let mut current_args: Vec<PyObjectRef> = Vec::with_capacity(args.len());
         for i in 0..args.len() {
-            current_args.push(pyre_object::gc_roots::shadow_stack_get(root_base + 3 + i));
+            current_args.push(_roots.get(root_base + 3 + i));
         }
         Self::finish_for_call_with_globals_obj(
-            pyre_object::gc_roots::shadow_stack_get(root_base) as *const (),
+            _roots.get(root_base) as *const (),
             &current_args,
-            pyre_object::gc_roots::shadow_stack_get(root_base + 1),
+            _roots.get(root_base + 1),
             execution_context,
-            pyre_object::gc_roots::shadow_stack_get(root_base + 2),
+            _roots.get(root_base + 2),
             w_builtin,
             allocation,
         )
@@ -3886,8 +3886,7 @@ impl PyFrame {
         let args_base = pyre_object::gc_roots::publish_roots(args);
         pyre_object::gc_roots::normalize_roots(root_base, 4 + args.len());
         let code_ref = unsafe {
-            &*(crate::w_code_get_ptr(pyre_object::gc_roots::shadow_stack_get(root_base))
-                as *const CodeObject)
+            &*(crate::w_code_get_ptr(_roots.get(root_base)) as *const CodeObject)
         };
         let num_locals = code_ref.varnames.len();
         let num_cells = ncells(code_ref);
@@ -3910,7 +3909,7 @@ impl PyFrame {
             // Bind positional arguments directly -- no intermediate Vec.
             let nargs = args.len().min(num_locals);
             for i in 0..nargs {
-                arr[i] = pyre_object::gc_roots::shadow_stack_get(args_base + i);
+                arr[i] = _roots.get(args_base + i);
             }
 
             // CPython 3.11+ `co_localsplusnames` unified slot layout:
@@ -3924,7 +3923,7 @@ impl PyFrame {
             for i in 0..npure {
                 arr[num_locals + i] = pyre_object::w_cell_new(PY_NULL);
             }
-            let closure = pyre_object::gc_roots::shadow_stack_get(root_base + 2);
+            let closure = _roots.get(root_base + 2);
             if !closure.is_null() {
                 let nfreevars = code_ref.freevars.len();
                 for i in 0..nfreevars {
@@ -3943,15 +3942,15 @@ impl PyFrame {
         // gated debugdata snapshot retired in favour of `w_globals`).
         unsafe {
             crate::w_code_frame_stores_global(
-                pyre_object::gc_roots::shadow_stack_get(root_base),
-                pyre_object::gc_roots::shadow_stack_get(root_base + 1),
+                _roots.get(root_base),
+                _roots.get(root_base + 1),
             );
         }
 
         let mut frame = PyFrame {
             ob_header: frame_ob_header(),
             execution_context,
-            pycode: pyre_object::gc_roots::shadow_stack_get(root_base) as *const (),
+            pycode: _roots.get(root_base) as *const (),
             locals_cells_stack_w,
             valuestackdepth: num_locals + num_cells,
             last_instr: -1,
@@ -3962,8 +3961,8 @@ impl PyFrame {
             f_generator_nowref: PY_NULL,
             w_yielding_from: PY_NULL,
             f_backref: std::ptr::null_mut(),
-            w_builtin: pyre_object::gc_roots::shadow_stack_get(root_base + 3),
-            w_globals: pyre_object::gc_roots::shadow_stack_get(root_base + 1),
+            w_builtin: _roots.get(root_base + 3),
+            w_globals: _roots.get(root_base + 1),
         };
         // This constructor bypasses `initialize_frame_scopes`, so apply the
         // scope binding it would have done.  `FunctionType(co, globals)` over

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/bridge_subwalk.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/bridge_subwalk.rs
@@ -1031,6 +1031,7 @@ pub(crate) fn drive_bridge_frame_subwalk<Sym: WalkSym>(
     argboxes_r: &[OpRef],
     local_oprefs: &[OpRef],
     local_concretes: &[majit_ir::Value],
+    resumed_stack_oprefs: &[OpRef],
     child_result: Option<OpRef>,
     paused_parent_recipes: &[majit_metainterp::ReconstructRecipe],
 ) -> Option<Result<(DispatchOutcome, usize), DispatchError>> {
@@ -1272,6 +1273,30 @@ pub(crate) fn drive_bridge_frame_subwalk<Sym: WalkSym>(
                 v,
             );
         }
+        // The decoded multi-frame recipe carries this callee's semantic
+        // operand stack after its locals/cells prefix.  Preserve that red
+        // frame state on the same per-frame shadow and seed the walk mirror
+        // from it; dropping these slots collapses bridge resume onto the root
+        // frame and later CALL operands reconstruct as NULL.
+        let stack_base = local_oprefs.len();
+        for (s, &opref) in resumed_stack_oprefs.iter().enumerate() {
+            sub_wc
+                .callee_shadow
+                .as_mut()
+                .unwrap()
+                .set_opref((stack_base + s) as i64, opref);
+        }
+        if let Some(frame) = ActiveResumeFrame::current(session, root_sym_ptr)
+            && frame.0.jitcode.code.as_ptr() == callee_code.as_ptr()
+            && frame.0.jitcode.code.len() == callee_code.len()
+            && let Some((py_pc, _code_ptr, depth)) = frame.vstack_coordinate_for_jitcode_pc(entry)
+            && depth == resumed_stack_oprefs.len()
+        {
+            sub_wc.vstack_boxes = resumed_stack_oprefs.to_vec();
+            sub_wc.vstack_depth = depth;
+            sub_wc.vstack_cur_pypc = py_pc;
+            sub_wc.vstack_valid = true;
+        }
         let outcome = walk(callee_code, entry, &mut sub_wc);
         // `pyjitpl.py:2914 handle_guard_failure` wraps `_handle_guard_failure`
         // in `except SwitchToBlackhole as stb:
@@ -1307,6 +1332,7 @@ pub(crate) fn drive_bridge_carrier_subwalk<Sym: WalkSym>(
     argboxes_r: &[OpRef],
     local_oprefs: &[OpRef],
     local_concretes: &[majit_ir::Value],
+    resumed_stack_oprefs: &[OpRef],
     paused_parent_recipes: &[majit_metainterp::ReconstructRecipe],
 ) -> Option<Result<(DispatchOutcome, usize), DispatchError>> {
     drive_bridge_frame_subwalk(
@@ -1321,6 +1347,7 @@ pub(crate) fn drive_bridge_carrier_subwalk<Sym: WalkSym>(
         argboxes_r,
         local_oprefs,
         local_concretes,
+        resumed_stack_oprefs,
         None,
         paused_parent_recipes,
     )
@@ -1339,6 +1366,7 @@ pub(crate) fn drive_bridge_middle_frame<Sym: WalkSym>(
     argboxes_r: &[OpRef],
     local_oprefs: &[OpRef],
     local_concretes: &[majit_ir::Value],
+    resumed_stack_oprefs: &[OpRef],
     paused_parent_recipes: &[majit_metainterp::ReconstructRecipe],
     child_result: OpRef,
 ) -> Option<Result<(DispatchOutcome, usize), DispatchError>> {
@@ -1354,6 +1382,7 @@ pub(crate) fn drive_bridge_middle_frame<Sym: WalkSym>(
         argboxes_r,
         local_oprefs,
         local_concretes,
+        resumed_stack_oprefs,
         Some(child_result),
         paused_parent_recipes,
     )

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
@@ -89,11 +89,29 @@ pub(crate) fn fbw_strict_fold_frame_reg<Sym: WalkSym>(ctx: &WalkContext<'_, '_, 
         .map_or(u16::MAX, |shadow| shadow.fold_frame_reg)
 }
 
-/// `PYRE_FBW_CALLEE_VSTACK` (default ON) — maintain a callee-local
+/// `PYRE_FBW_CALLEE_VSTACK` (default OFF) — maintain a callee-local
 /// operand-stack mirror while walking an inline sub-call.  The callee enters
 /// with an empty operand stack; subsequent boundaries must use the active
 /// callee jitcode metadata rather than the outer full-body tables.  Set to
-/// `0` or `false` to retain the stabilization-period kill switch.
+/// `1` to opt in.
+///
+/// Measured on the whole `pyre/bench/synth` corpus (dynasm): ON compiles two
+/// loops that OFF declines, and both then fail their guards with no bridge —
+/// 349 → 347 passing, no fixture improved, CPU time unchanged.  The two loops
+/// reach the bridge gaps that make the mirror unprofitable today:
+///
+///   * `getframe_inline_subwalk_multiframe` — the loop's failing guard is a
+///     GUARD_NOT_FORCED, which `compile.py:950-953
+///     ResumeGuardForcedDescr.handle_fail` never compiles ("always just
+///     blackholed"), so every one of its 8948 failures resumes through the
+///     blackhole.  No bridge is reachable for this shape by construction.
+///   * `or_chain_fresh_alloc_arg` — the failing guard needs a multi-frame
+///     inline resume, and `reconstruct_inline_recipe` declines the callee
+///     frame at `UnboxedLiveRegister`: the resumed `pick` frame holds a live
+///     int-bank register (color 0) that the per-PC `(bank, color, slot)` map
+///     gives no `locals_cells_stack_w` slot, i.e. a JitCode int temp with no
+///     boxed home in the rebuilt PyFrame.  `P2Drain::NoRecipes` then declines
+///     the guard permanently and its 9653 failures blackhole.
 pub(crate) fn fbw_callee_vstack_enabled() -> bool {
     static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     *ENABLED.get_or_init(|| match std::env::var_os("PYRE_FBW_CALLEE_VSTACK") {
@@ -101,7 +119,7 @@ pub(crate) fn fbw_callee_vstack_enabled() -> bool {
             let v = v.to_string_lossy();
             v != "0" && !v.eq_ignore_ascii_case("false")
         }
-        None => true,
+        None => false,
     })
 }
 

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
@@ -89,10 +89,11 @@ pub(crate) fn fbw_strict_fold_frame_reg<Sym: WalkSym>(ctx: &WalkContext<'_, '_, 
         .map_or(u16::MAX, |shadow| shadow.fold_frame_reg)
 }
 
-/// `PYRE_FBW_CALLEE_VSTACK` (default OFF) — maintain a callee-local
+/// `PYRE_FBW_CALLEE_VSTACK` (default ON) — maintain a callee-local
 /// operand-stack mirror while walking an inline sub-call.  The callee enters
 /// with an empty operand stack; subsequent boundaries must use the active
-/// callee jitcode metadata rather than the outer full-body tables.
+/// callee jitcode metadata rather than the outer full-body tables.  Set to
+/// `0` or `false` to retain the stabilization-period kill switch.
 pub(crate) fn fbw_callee_vstack_enabled() -> bool {
     static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     *ENABLED.get_or_init(|| match std::env::var_os("PYRE_FBW_CALLEE_VSTACK") {
@@ -100,7 +101,7 @@ pub(crate) fn fbw_callee_vstack_enabled() -> bool {
             let v = v.to_string_lossy();
             v != "0" && !v.eq_ignore_ascii_case("false")
         }
-        None => false,
+        None => true,
     })
 }
 

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -2177,6 +2177,14 @@ pub(crate) fn try_walker_inline_builtin_call<Sym: WalkSym>(
         receiver_op = Some(live_receiver);
     }
     if !callable_guard_op.is_constant() {
+        // `callable_guard_op` can be the live `Method.w_function` field read
+        // above.  The GuardValue pins it to `callable` at runtime; retain the
+        // same recording-time Box.value so a multi-frame bridge recipe does
+        // not mistake an unstamped field-read shadow for Python NULL.
+        ctx.trace_ctx.set_opref_concrete(
+            callable_guard_op,
+            majit_ir::Value::Ref(majit_ir::GcRef(callable as usize)),
+        );
         let expected = ctx.trace_ctx.const_ref(callable as i64);
         ctx.trace_ctx
             .record_guard(OpCode::GuardValue, &[callable_guard_op, expected], 0);

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -6099,6 +6099,21 @@ impl ActiveResumeFrame {
         Some((py_pc, pjc.code_ptr, depth))
     }
 
+    /// Coordinate used while stepping an already-seeded operand-stack
+    /// mirror.  A block-head metadata entry is JitCode control-flow trivia,
+    /// not a Python opcode boundary: defer reconciliation until the first
+    /// real operation in that block, whose containing coordinate is exact.
+    fn vstack_step_coordinate_for_jitcode_pc(
+        &self,
+        jit_pc: usize,
+        current_py_pc: u32,
+    ) -> Option<(u32, *const pyre_interpreter::CodeObject, usize)> {
+        let (containing_py_pc, code_ptr, depth) = self.vstack_coordinate_for_jitcode_pc(jit_pc)?;
+        let py_pc = vstack_step_py_pc(&self.0.metadata, jit_pc, current_py_pc);
+        debug_assert!(py_pc == current_py_pc || py_pc == containing_py_pc);
+        Some((py_pc, code_ptr, depth))
+    }
+
     fn body_matches(&self, sub_body: &SubJitCodeBody) -> bool {
         let code = self.0.jitcode.code.as_slice();
         code.len() == sub_body.code.len() && code.as_ptr() == sub_body.code.as_ptr()
@@ -7063,8 +7078,21 @@ fn walker_emit_guard_with_snapshot<Sym: WalkSym>(
     opcode: OpCode,
     args: &[OpRef],
 ) -> Result<(), DispatchError> {
+    stamp_guard_value_concrete(ctx.trace_ctx, opcode, args);
     ctx.trace_ctx.record_guard(opcode, args, 0);
     walker_capture_snapshot_for_last_guard(ctx, op_pc)
+}
+
+/// A recording-path `GUARD_VALUE(box, const)` has already observed equality.
+/// Mirror `FrontendOp.value` by attaching that constant to the guarded box so
+/// bridge recipe construction sees the same fact as the runtime guard.
+fn stamp_guard_value_concrete(trace_ctx: &mut TraceCtx, opcode: OpCode, args: &[OpRef]) {
+    if opcode != OpCode::GuardValue || args.len() < 2 {
+        return;
+    }
+    if let Some(expected) = trace_ctx.concrete_of_opref(args[1]) {
+        trace_ctx.set_opref_concrete(args[0], expected);
+    }
 }
 
 /// Fold-specific guard snapshot: records the guard and delegates to the
@@ -7084,6 +7112,7 @@ fn walker_emit_fold_guard_with_snapshot<Sym: WalkSym>(
     opcode: OpCode,
     args: &[OpRef],
 ) -> Result<(), DispatchError> {
+    stamp_guard_value_concrete(ctx.trace_ctx, opcode, args);
     ctx.trace_ctx.record_guard(opcode, args, 0);
     walker_capture_snapshot_for_last_guard(ctx, op_pc)
 }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/resume_snapshot.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/resume_snapshot.rs
@@ -2204,11 +2204,38 @@ pub(crate) fn walker_capture_multi_frame_inline_snapshot<Sym: WalkSym>(
     // `collect_outer_active_boxes`' virtualizable-slot recovery, and preserves
     // the one-red-frame-per-MIFrame shape instead of falling back to the root.
     let mut recovered_regs_r = ctx.registers_r.to_vec();
+    let code = unsafe { &*callee_pjc.code_ptr };
+    let (stack_base, _) = crate::state::callee_layout_for_call_assembler(code);
+    let maps = crate::state::bridge_semantic_maps_from_pc(callee_jitcode_index, callee_jitcode_pc);
+    // The kept-stack guard gate is certified by this callee frame's
+    // operand-stack mirror.  Publish the same boxes into the carried
+    // coordinate's Ref colors before collecting the frame snapshot, so the
+    // resume encoder consumes the exact per-frame state that admitted the
+    // guard.  RPython reads these values directly from the active MIFrame's
+    // register bank; the assignment below is pyre's slot-to-color lowering of
+    // that one-red-frame state, not a lookup through the outer portal frame.
+    if ctx.vstack_valid && ctx.vstack_depth <= ctx.vstack_boxes.len() {
+        for &(bank, color, slot) in &maps.pcdep_entries {
+            if bank != 1 {
+                continue;
+            }
+            let slot = slot as usize;
+            let Some(stack_slot) = slot.checked_sub(stack_base) else {
+                continue;
+            };
+            if stack_slot >= ctx.vstack_depth {
+                continue;
+            }
+            let value = ctx.vstack_boxes[stack_slot];
+            if value == OpRef::NONE || opref_is_null_const_ptr(value) {
+                continue;
+            }
+            if let Some(register) = recovered_regs_r.get_mut(color as usize) {
+                *register = value;
+            }
+        }
+    }
     if recovered_regs_r.iter().any(|value| value.is_none()) && !callee_pjc.code_ptr.is_null() {
-        let code = unsafe { &*callee_pjc.code_ptr };
-        let (stack_base, _) = crate::state::callee_layout_for_call_assembler(code);
-        let maps =
-            crate::state::bridge_semantic_maps_from_pc(callee_jitcode_index, callee_jitcode_pc);
         if let Some(shadow) = ctx.callee_shadow.as_ref() {
             for (color, value) in recovered_regs_r.iter_mut().enumerate() {
                 if !value.is_none() {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
@@ -51,6 +51,9 @@ fn vstack_permuted_for_iter_entry_uses_block_head_target() {
     assert_eq!(vstack_initial_py_pc(&pyjit.metadata, 110, false), 17);
     assert_eq!(vstack_step_py_pc(&pyjit.metadata, 110, 18), 18);
     assert_eq!(vstack_step_py_pc(&pyjit.metadata, 110, 17), 17);
+    // Entering this marker from another block must not apply the containing
+    // predecessor opcode (17); the first real target op advances to 18.
+    assert_eq!(vstack_step_py_pc(&pyjit.metadata, 110, 12), 12);
     assert_eq!(vstack_step_py_pc(&pyjit.metadata, 120, 18), 18);
 }
 

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/vstack_mirror.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/vstack_mirror.rs
@@ -519,15 +519,22 @@ pub(crate) fn reconcile_vstack_at_boundary<Sym: WalkSym>(
     // with the NONE slot left in place; `stack_sync` (USE) omits any NONE
     // mirror slot, which resume re-materializes.
     if ctx.vstack_valid {
-        let skip_shadow_fill = ctx.fbw_mode.inline_subwalk && fbw_callee_vstack_enabled();
+        let callee_local_shadow = ctx.fbw_mode.inline_subwalk && fbw_callee_vstack_enabled();
         let hole = ctx
             .vstack_boxes
             .get(..new_depth)
             .map(|s| s.iter().any(|&b| b == OpRef::NONE))
             .unwrap_or(true);
-        if hole && !skip_shadow_fill {
-            // Best-effort fill from the shadow; leave un-fillable slots NONE.
-            let _ = reseed_vstack_from_shadow(ctx, new_depth);
+        if hole {
+            // Best-effort fill from this frame's own storage; leave
+            // un-fillable slots NONE.  An inline callee's locals/stack array
+            // belongs to its CalleeLocalsShadow, never to the outer portal
+            // virtualizable.
+            if callee_local_shadow {
+                let _ = reseed_vstack_from_callee_shadow(ctx, code, new_depth);
+            } else {
+                let _ = reseed_vstack_from_shadow(ctx, new_depth);
+            }
         }
     }
     if ctx.vstack_valid {
@@ -541,6 +548,38 @@ pub(crate) fn reconcile_vstack_at_boundary<Sym: WalkSym>(
     if ctx.vstack_reorder_ceiling != u32::MAX && new_pypc > ctx.vstack_reorder_ceiling {
         ctx.vstack_reorder_ceiling = u32::MAX;
     }
+}
+
+/// Fill missing operand-stack boxes from the active inline frame's own
+/// localsplus shadow.  `CalleeLocalsShadow` is the Rust owner corresponding
+/// to that MIFrame's register/frame state; indexing begins after this code
+/// object's locals and cells, so no portal-frame slot can leak across the
+/// inline boundary.
+fn reseed_vstack_from_callee_shadow<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    code: &pyre_interpreter::CodeObject,
+    new_depth: usize,
+) -> bool {
+    if ctx.vstack_boxes.len() < new_depth {
+        ctx.vstack_boxes.resize(new_depth, OpRef::NONE);
+    }
+    let stack_base = code.varnames.len() + pyre_interpreter::pyframe::ncells(code);
+    let Some(shadow) = ctx.callee_shadow.as_ref() else {
+        return false;
+    };
+    let mut all_present = true;
+    for (s, slot) in ctx.vstack_boxes[..new_depth].iter_mut().enumerate() {
+        if *slot != OpRef::NONE {
+            continue;
+        }
+        match shadow.opref.get(&((stack_base + s) as i64)).copied() {
+            Some(value) if value != OpRef::NONE && !opref_is_null_const_ptr(value) => {
+                *slot = value;
+            }
+            _ => all_present = false,
+        }
+    }
+    all_present
 }
 
 /// #73: re-seed `ctx.vstack_boxes[0..new_depth]` from the virtualizable
@@ -641,7 +680,13 @@ pub(crate) fn vstack_step_py_pc(
     jit_pc: usize,
     current_py_pc: u32,
 ) -> u32 {
-    if metadata_block_head_py_pc(metadata, jit_pc) == Some(current_py_pc) {
+    // A block-head entry is a control-flow marker, not the lowering of a
+    // Python opcode.  Keep the current mirror coordinate until the first
+    // actual operation in the destination block.  In particular, the floor
+    // segment at a marker can still name the terminal opcode of the preceding
+    // block (for example its RETURN_VALUE); applying that opcode here corrupts
+    // the live caller stack before the destination block is entered.
+    if metadata_block_head_py_pc(metadata, jit_pc).is_some() {
         current_py_pc
     } else {
         vstack_containing_py_pc(metadata, jit_pc)
@@ -678,7 +723,8 @@ pub(crate) fn step_vstack_mirror<Sym: WalkSym>(ctx: &mut WalkContext<'_, '_, Sym
             ctx.vstack_valid = false;
             return;
         };
-        let Some(coord) = frame.vstack_coordinate_for_jitcode_pc(jit_pc) else {
+        let Some(coord) = frame.vstack_step_coordinate_for_jitcode_pc(jit_pc, ctx.vstack_cur_pypc)
+        else {
             ctx.vstack_valid = false;
             return;
         };

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -2060,6 +2060,14 @@ pub(crate) fn semantic_slot_color_for_ref_slot(
     best
 }
 
+/// Resolve a resumed semantic Ref slot to its live register color.  Empty
+/// metadata is retained for skeleton/fixture compatibility; a partially
+/// populated per-PC map is authoritative, so an absent slot has no register.
+fn reconstructed_ref_slot_color(pcdep_entries: &[(u8, u16, u16)], slot: usize) -> Option<usize> {
+    semantic_slot_color_for_ref_slot(pcdep_entries, slot)
+        .or_else(|| pcdep_entries.is_empty().then_some(slot))
+}
+
 // Sentinel null JitCode for uninitialized PyreSym.
 //
 // Cannot be `static` because `Arc::new` is not const; use a thread_local
@@ -11203,6 +11211,15 @@ mod tests {
     use pyre_object::pyobject::{INT_TYPE, LIST_TYPE, PyType, is_list};
     use std::cell::{Cell, UnsafeCell};
 
+    #[test]
+    fn reconstructed_ref_slot_does_not_invent_color_in_mapped_frame() {
+        let pcdep = [(1, 4, 0), (1, 5, 2), (1, 6, 3)];
+
+        assert_eq!(reconstructed_ref_slot_color(&pcdep, 0), Some(4));
+        assert_eq!(reconstructed_ref_slot_color(&pcdep, 1), None);
+        assert_eq!(reconstructed_ref_slot_color(&[], 1), Some(1));
+    }
+
     thread_local! {
         static TEST_CALLBACKS_INIT: Cell<bool> = const { Cell::new(false) };
         static TEST_JIT_DRIVER: UnsafeCell<crate::driver::JitDriverPair> = UnsafeCell::new({
@@ -13872,7 +13889,17 @@ pub(crate) fn setup_reconstructed_callee_frame(
         if opref.is_none() {
             continue;
         }
-        let color = semantic_slot_color_for_ref_slot(&pcdep, k).unwrap_or(k);
+        let color = match reconstructed_ref_slot_color(&pcdep, k) {
+            Some(color) => color,
+            // An entirely uncolored skeleton/fixture retains the historical
+            // identity layout.  Once a per-PC color map exists, however, an
+            // unmapped semantic slot has no register at this coordinate (for
+            // example PUSH_NULL's call sentinel).  Treating its slot number as
+            // a color can overwrite a different mapped value: `_richcmp`'s
+            // `[op, NULL, lhs, rhs]` resume otherwise writes the NULL sentinel
+            // over `op`'s color and the bridge calls a null callable.
+            None => continue,
+        };
         if color >= argboxes_r.len() {
             argboxes_r.resize(color + 1, OpRef::NONE);
         }
@@ -13886,9 +13913,17 @@ pub(crate) fn setup_reconstructed_callee_frame(
         // any resumed operand. Skips constants (`constants.get_value` is
         // authoritative) and non-value (`Void`) slots.
         if !opref.is_constant() {
-            if let Some(v @ (majit_ir::Value::Ref(_) | majit_ir::Value::Int(_))) =
-                recipe.concrete_r.get(k).copied()
+            if let Some(v @ majit_ir::Value::Int(_)) = recipe.concrete_r.get(k).copied() {
+                ctx.set_opref_concrete(opref, v);
+            } else if let Some(v @ majit_ir::Value::Ref(gc)) = recipe.concrete_r.get(k).copied()
+                && !gc.is_null()
+                && gc != majit_ir::GcRef::NO_CONCRETE
             {
+                // A NULL recipe concrete is an unmaterialized frame-image
+                // hole, not evidence that the symbolic box is Python NULL.
+                // Keep any stronger fact already attached to the OpRef (for
+                // example the non-null callable pinned by GUARD_VALUE), just
+                // as the locals-prefix restamp above does.
                 ctx.set_opref_concrete(opref, v);
             }
         }

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -1704,6 +1704,8 @@ fn drive_bridge_carrier_walk<Sym: WalkSym>(
     let nlocals = recipe.nlocals.min(recipe.concrete_r.len());
     let local_oprefs = &recipe.registers_r[..nlocals.min(recipe.registers_r.len())];
     let local_concretes = &recipe.concrete_r[..nlocals];
+    let stack_end = recipe.valuestackdepth.min(recipe.registers_r.len());
+    let resumed_stack_oprefs = &recipe.registers_r[nlocals.min(stack_end)..stack_end];
     // Increment 2b-i: drive the deepest callee as an inline SUB-WALK rooted on
     // the portal `sym` (is_top_level=false), so its `ref_return` surfaces
     // `SubReturn` instead of the top-level `Finish` pyre's own-portal model
@@ -1720,6 +1722,7 @@ fn drive_bridge_carrier_walk<Sym: WalkSym>(
         &argboxes_r,
         local_oprefs,
         local_concretes,
+        resumed_stack_oprefs,
         // Depth-N: tell the deepest sub-walk that all shallower frames are
         // paused so its in-callee guard snapshots encode the full
         // [root, ..middles.., deepest] chain (else the blackhole rebuilds a
@@ -2003,6 +2006,9 @@ fn drive_middle_frame_and_thread<Sym: WalkSym>(
     let middle_nlocals = middle.nlocals.min(middle.concrete_r.len());
     let middle_local_oprefs = &middle.registers_r[..middle_nlocals.min(middle.registers_r.len())];
     let middle_local_concretes = &middle.concrete_r[..middle_nlocals];
+    let middle_stack_end = middle.valuestackdepth.min(middle.registers_r.len());
+    let middle_stack_oprefs =
+        &middle.registers_r[middle_nlocals.min(middle_stack_end)..middle_stack_end];
     let middle_walk = crate::jitcode_dispatch::drive_bridge_middle_frame(
         ctx,
         session,
@@ -2015,6 +2021,7 @@ fn drive_middle_frame_and_thread<Sym: WalkSym>(
         &middle_argboxes_r,
         middle_local_oprefs,
         middle_local_concretes,
+        middle_stack_oprefs,
         paused_parents,
         child_result,
     );

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -5825,6 +5825,23 @@ pub extern "C" fn bh_load_special_self_fn(_obj: i64, _attr: i64, _method_kind: i
     pyre_object::PY_NULL as i64
 }
 
+/// WITH_EXCEPT_START residual.  The generated JitCode carries the five
+/// handler-stack values, and this helper performs the same `__exit__` call as
+/// `PyFrame::with_except_start` from the three semantic operands.
+pub extern "C" fn bh_with_except_start_fn(exit_func: i64, exit_self: i64, val: i64) -> i64 {
+    let result = pyre_interpreter::eval::with_except_start_values(
+        exit_func as pyre_object::PyObjectRef,
+        exit_self as pyre_object::PyObjectRef,
+        val as pyre_object::PyObjectRef,
+    );
+    if result.is_null() {
+        let mut err = pyre_interpreter::call::take_call_error()
+            .unwrap_or_else(|| pyre_interpreter::PyError::type_error("__exit__ failed"));
+        publish_residual_call_exception(err.to_exc_object() as i64);
+    }
+    result as i64
+}
+
 /// `LOAD_NAME` residual for the standalone (blackhole / deopt)
 /// per-CodeObject jitcode.  `pyopcode.py:945-955 LOAD_NAME` — when
 /// `getorcreatedebug().w_locals is not get_w_globals_storage()` the lookup

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -2419,10 +2419,7 @@ fn build_gc() -> Box<MiniMarkGC> {
         if pytype_ptr == &pyre_object::NONE_TYPE as *const _ as usize {
             debug_assert_eq!(tid, pyre_object::noneobject::W_NONE_GC_TYPE_ID);
         } else if pytype_ptr == &pyre_object::NOTIMPLEMENTED_TYPE as *const _ as usize {
-            debug_assert_eq!(
-                tid,
-                pyre_object::special::W_NOT_IMPLEMENTED_GC_TYPE_ID
-            );
+            debug_assert_eq!(tid, pyre_object::special::W_NOT_IMPLEMENTED_GC_TYPE_ID);
         } else if pytype_ptr == &pyre_object::ELLIPSIS_TYPE as *const _ as usize {
             debug_assert_eq!(tid, pyre_object::special::W_ELLIPSIS_GC_TYPE_ID);
         }
@@ -3845,6 +3842,15 @@ fn install_gc_root_walkers() {
     // pattern outlives the thread that compiled it, so its owner is a global
     // walker rather than a per-mutator area.
     majit_gc::shadow_stack::register_extra_root_walker(sre_pattern_root_walker);
+
+    // Same ownership argument for the two immortal-code-object registries.
+    // `w_globals` (`pycode.py:159-165 frame_stores_global`) is first-store-wins
+    // and `_mapdict_caches[i].w_method` (mapdict.py:1418) is filled once, so
+    // both slots outlive whichever thread stamped them; as per-mutator areas
+    // they lost their root at that thread's `unregister_mutator` while the
+    // code object stayed live and callable.
+    majit_gc::shadow_stack::register_extra_root_walker(w_globals_stamped_code_root_walker);
+    majit_gc::shadow_stack::register_extra_root_walker(mapdict_method_cache_root_walker);
 }
 
 fn register_thread_root_areas() {
@@ -4648,6 +4654,18 @@ fn signal_handler_root_walker(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
 
 fn sre_pattern_root_walker(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
     pyre_object::interp_sre::walk_sre_pattern_roots(|slot| {
+        visit_pyobject_root(slot, visitor);
+    });
+}
+
+fn w_globals_stamped_code_root_walker(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
+    pyre_interpreter::pycode::walk_w_globals_stamped_code_roots(&mut |slot| {
+        visit_pyobject_root(slot, visitor);
+    });
+}
+
+fn mapdict_method_cache_root_walker(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
+    pyre_interpreter::pycode::walk_mapdict_method_cache_gc(&mut |slot| {
         visit_pyobject_root(slot, visitor);
     });
 }

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -2416,6 +2416,16 @@ fn build_gc() -> Box<MiniMarkGC> {
             std::mem::size_of::<pyre_object::PyObject>(),
             parent_tid,
         ));
+        if pytype_ptr == &pyre_object::NONE_TYPE as *const _ as usize {
+            debug_assert_eq!(tid, pyre_object::noneobject::W_NONE_GC_TYPE_ID);
+        } else if pytype_ptr == &pyre_object::NOTIMPLEMENTED_TYPE as *const _ as usize {
+            debug_assert_eq!(
+                tid,
+                pyre_object::special::W_NOT_IMPLEMENTED_GC_TYPE_ID
+            );
+        } else if pytype_ptr == &pyre_object::ELLIPSIS_TYPE as *const _ as usize {
+            debug_assert_eq!(tid, pyre_object::special::W_ELLIPSIS_GC_TYPE_ID);
+        }
         majit_gc::GcAllocator::register_vtable_for_type(&mut gc, pytype_ptr, tid);
         pytype_to_tid.insert(pytype_ptr, tid);
     }

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -9845,6 +9845,14 @@ impl CodeWriter {
                         Instruction::WithExceptStart => {
                             // pyopcode.py WITH_EXCEPT_START preserves its five
                             // inputs and pushes `exit_func(type(val), val, tb)`.
+                            // Two slots carry the callable, not one:
+                            // `pyopcode.py:1350-1353` peeks a single already-bound
+                            // `__exit__` at depth 3, whereas LOAD_SPECIAL leaves
+                            // `exit_func` + `exit_self` (NULL when unbound) as
+                            // separate entries, so the pair is read at depths 5
+                            // and 4 and `with_except_start_values` prepends
+                            // `exit_self` only when non-NULL — the same split
+                            // `PyFrame::with_except_start` reads.
                             // This must be a real can-raise residual in JitCode:
                             // a guard resume can first enter this handler under
                             // blackhole replay, where a disconnected fresh Ref

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -3474,6 +3474,7 @@ struct FnPtrIndices {
     load_method_self_fn: HelperHandle,
     load_special_fn: HelperHandle,
     load_special_self_fn: HelperHandle,
+    with_except_start_fn: HelperHandle,
     store_attr_fn: HelperHandle,
     build_map_from_array_fn: HelperHandle,
     binary_slice_fn: HelperHandle,
@@ -3745,6 +3746,11 @@ fn register_helper_fn_pointers(
         assembler,
         cpu.load_special_self_fn as *const (),
         CallFlavor::Plain,
+    );
+    let with_except_start_fn = bind(
+        assembler,
+        cpu.with_except_start_fn as *const (),
+        CallFlavor::MayForce,
     );
     // `bh_load_name_fn` / `bh_store_name_fn` delegate to the interpreter
     // `NamespaceOpcodeHandler` impl (pyopcode.py:945 LOAD_NAME / :855
@@ -4249,6 +4255,7 @@ fn register_helper_fn_pointers(
         load_method_self_fn,
         load_special_fn,
         load_special_self_fn,
+        with_except_start_fn,
         store_attr_fn,
         build_map_from_array_fn,
         binary_slice_fn,
@@ -5743,6 +5750,11 @@ impl CodeWriter {
                 HelperHandle {
                     idx: load_special_self_fn_idx,
                     flavor: _load_special_self_fn_flavor,
+                },
+            with_except_start_fn:
+                HelperHandle {
+                    idx: with_except_start_fn_idx,
+                    flavor: _with_except_start_fn_flavor,
                 },
             store_attr_fn:
                 HelperHandle {
@@ -9831,14 +9843,56 @@ impl CodeWriter {
                         }
 
                         Instruction::WithExceptStart => {
-                            // `WITH_EXCEPT_START` leaves the existing stack
-                            // entries intact and pushes the exit-function result
-                            // on top. Preserve the net `+1` stack effect in the
-                            // shadow graph and fall back to the interpreter for
-                            // the actual helper call semantics.
-                            push_fresh_ref(&mut current_state, &mut graph);
-                            current_depth += 1;
-                            emit_vsd!(current_depth, py_pc);
+                            // pyopcode.py WITH_EXCEPT_START preserves its five
+                            // inputs and pushes `exit_func(type(val), val, tb)`.
+                            // This must be a real can-raise residual in JitCode:
+                            // a guard resume can first enter this handler under
+                            // blackhole replay, where a disconnected fresh Ref
+                            // has no producer and would make TO_BOOL suppress or
+                            // re-raise arbitrarily.
+                            // Read the three semantic operands from the live
+                            // virtualizable slots, exactly like PyFrame's
+                            // stack peeks.  Handler-entry Variables include
+                            // synthetic lasti/exception values and can legally
+                            // coalesce before the catch edge runs; using those
+                            // graph placeholders here can therefore alias the
+                            // caught exception onto `exit_func` during a
+                            // blackhole-only handler entry.
+                            let mut read_stack_slot = |depth_from_bottom: usize| {
+                                let slot = stack_base_absolute + depth_from_bottom;
+                                let slot_value: super::flow::FlowValue =
+                                    super::flow::Constant::signed(slot as i64).into();
+                                super::flow::FlowValue::from(emit_graph_op_with_result(
+                                    &mut graph,
+                                    &current_block.block(),
+                                    "getarrayitem_vable_r",
+                                    vable_getarrayitem_ref_graph_args(
+                                        frame_var.into(),
+                                        slot_value.into(),
+                                    ),
+                                    Kind::Ref,
+                                    py_pc as i64,
+                                ))
+                            };
+                            let depth = current_depth as usize;
+                            let exit_func = read_stack_slot(depth.saturating_sub(5));
+                            let exit_self = read_stack_slot(depth.saturating_sub(4));
+                            let exc = read_stack_slot(depth.saturating_sub(1));
+                            let result = residual_call!(
+                                with_except_start_fn_idx,
+                                CallFlavor::MayForce,
+                                majit_ir::PyreHelperKind::None,
+                                vec![],
+                                vec![exit_func, exit_self, exc],
+                                vec![],
+                                vec![Kind::Ref, Kind::Ref, Kind::Ref],
+                                ResKind::Ref,
+                                py_pc as i64,
+                            )
+                            .map(super::flow::FlowValue::from)
+                            .unwrap_or_else(|| fresh_ref_value(&mut graph).into());
+                            current_state.stack.push(result.clone());
+                            emit_pushvalue_ref!(current_depth, current_depth, result, py_pc);
                         }
 
                         Instruction::Copy { i } => {

--- a/pyre/pyre-jit/src/jit/cpu.rs
+++ b/pyre/pyre-jit/src/jit/cpu.rs
@@ -161,6 +161,8 @@ pub struct Cpu {
     pub load_special_fn: extern "C" fn(i64, i64) -> i64,
     /// LOAD_SPECIAL `null_or_self` half — `(obj, attr, method_kind) → bound`.
     pub load_special_self_fn: extern "C" fn(i64, i64, i64) -> i64,
+    /// WITH_EXCEPT_START — `(exit_func, exit_self, exception) → bool-like result`.
+    pub with_except_start_fn: extern "C" fn(i64, i64, i64) -> i64,
     /// STORE_ATTR residual — `(obj, value, code, name_idx) → void`.
     /// Resolves the name from the code object and runs generic `setattr`.
     pub store_attr_fn: extern "C" fn(i64, i64, i64, i64) -> i64,
@@ -470,6 +472,7 @@ impl Cpu {
             load_method_self_fn: crate::call_jit::bh_load_method_self_fn,
             load_special_fn: crate::call_jit::bh_load_special_fn,
             load_special_self_fn: crate::call_jit::bh_load_special_self_fn,
+            with_except_start_fn: crate::call_jit::bh_with_except_start_fn,
             store_attr_fn: crate::call_jit::bh_store_attr_fn,
             binary_slice_fn: crate::call_jit::bh_binary_slice_fn,
             store_slice_fn: crate::call_jit::bh_store_slice_fn,

--- a/pyre/pyre-object/src/boolobject.rs
+++ b/pyre/pyre-object/src/boolobject.rs
@@ -61,7 +61,7 @@ static FALSE_SINGLETON: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
 
 fn bool_singleton(slot: &'static std::sync::OnceLock<usize>, intval: i64) -> PyObjectRef {
     *slot.get_or_init(|| {
-        crate::lltype::malloc_typed(W_BoolObject {
+        crate::lltype::malloc_typed_immortal(W_BoolObject {
             ob_header: PyObject {
                 ob_type: &BOOL_TYPE as *const PyType,
                 w_class: std::ptr::null_mut(),

--- a/pyre/pyre-object/src/boolobject.rs
+++ b/pyre/pyre-object/src/boolobject.rs
@@ -29,12 +29,8 @@ impl crate::lltype::GcType for W_BoolObject {
     /// crate split was meant to avoid; the JIT init asserts the registered
     /// id matches the descr constant, so any drift surfaces there.
     ///
-    /// Note: there are no `malloc_typed::<W_BoolObject>` callers — every
-    /// bool flows through the `TRUE_SINGLETON` / `FALSE_SINGLETON`
-    /// statics via [`w_bool_from`]. The impl is kept as a consistency
-    /// anchor for the GC registration's `debug_assert_eq!(_, SIZE)` so
-    /// the singleton struct layout cannot drift from the registered
-    /// type info.
+    /// Every bool flows through the two process-global prebuilt allocations
+    /// owned by [`w_bool_from`].
     fn type_id() -> u32 {
         5
     }
@@ -56,24 +52,24 @@ pub unsafe fn w_bool_get_value(obj: PyObjectRef) -> bool {
 // `space.w_False` as singletons; every PyPy `space.newbool(value)`
 // call (pypy/interpreter/baseobjspace.py:893 `newbool`) returns one of
 // the two pre-allocated objects. pyre mirrors the singleton model with
-// two `static W_BoolObject` instances and routes all callers through
-// [`w_bool_from`].
+// two process-global prebuilt objects and routes all callers through
+// [`w_bool_from`]. Their host allocations carry the same GC header as an
+// RPython translated prebuilt object.
 
-static TRUE_SINGLETON: W_BoolObject = W_BoolObject {
-    ob_header: PyObject {
-        ob_type: &BOOL_TYPE as *const PyType,
-        w_class: std::ptr::null_mut(),
-    },
-    intval: 1,
-};
+static TRUE_SINGLETON: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+static FALSE_SINGLETON: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
 
-static FALSE_SINGLETON: W_BoolObject = W_BoolObject {
-    ob_header: PyObject {
-        ob_type: &BOOL_TYPE as *const PyType,
-        w_class: std::ptr::null_mut(),
-    },
-    intval: 0,
-};
+fn bool_singleton(slot: &'static std::sync::OnceLock<usize>, intval: i64) -> PyObjectRef {
+    *slot.get_or_init(|| {
+        crate::lltype::malloc_typed(W_BoolObject {
+            ob_header: PyObject {
+                ob_type: &BOOL_TYPE as *const PyType,
+                w_class: std::ptr::null_mut(),
+            },
+            intval,
+        }) as usize
+    }) as PyObjectRef
+}
 
 /// Get a boolean PyObjectRef from a bool value.
 ///
@@ -82,9 +78,9 @@ static FALSE_SINGLETON: W_BoolObject = W_BoolObject {
 #[inline]
 pub fn w_bool_from(value: bool) -> PyObjectRef {
     if value {
-        (&TRUE_SINGLETON as *const W_BoolObject).cast_mut() as PyObjectRef
+        bool_singleton(&TRUE_SINGLETON, 1)
     } else {
-        (&FALSE_SINGLETON as *const W_BoolObject).cast_mut() as PyObjectRef
+        bool_singleton(&FALSE_SINGLETON, 0)
     }
 }
 
@@ -142,7 +138,7 @@ mod tests {
         }
     }
 
-    /// `w_bool_from` returns one of the two static singletons —
+    /// `w_bool_from` returns one of the two prebuilt singletons —
     /// every call with the same value yields the same address.
     /// pypy/objspace/std/objspace.py:61 installs `space.w_True` /
     /// `space.w_False` with the same identity invariant.
@@ -155,5 +151,10 @@ mod tests {
         assert!(std::ptr::eq(a, b), "w_bool_from(true) is not a singleton");
         assert!(std::ptr::eq(c, d), "w_bool_from(false) is not a singleton");
         assert!(!std::ptr::eq(a, c));
+        unsafe {
+            let hdr = majit_gc::header::header_of(a as usize);
+            assert_eq!((*hdr).type_id(), 5);
+            assert!((*hdr).has_flag(majit_gc::flags::NO_HEAP_PTRS));
+        }
     }
 }

--- a/pyre/pyre-object/src/lltype.rs
+++ b/pyre/pyre-object/src/lltype.rs
@@ -385,14 +385,17 @@ mod tests {
     }
 
     #[test]
-    fn malloc_prepends_zeroed_gc_header() {
+    fn malloc_prepends_prebuilt_gc_header() {
         let p = malloc(0x1234_5678_u64);
         unsafe {
             assert_eq!(*p, 0x1234_5678);
-            // A zeroed GcHeader precedes the payload, so the write barrier
-            // reads `*(obj - SIZE)` as TRACK_YOUNG_PTRS=0 and skips it.
+            // incminimark init_gc_object_immortal flags.
             let hdr = majit_gc::header::header_of(p as usize);
-            assert_eq!((*hdr).tid_and_flags, 0);
+            assert_eq!((*hdr).type_id(), 0);
+            assert_eq!(
+                (*hdr).flags(),
+                majit_gc::flags::NO_HEAP_PTRS | majit_gc::flags::TRACK_YOUNG_PTRS
+            );
         }
     }
 
@@ -427,7 +430,10 @@ mod tests {
             // The header carries the real GC type id, not a 0 placeholder.
             let hdr = majit_gc::header::header_of(p as usize);
             assert_eq!((*hdr).type_id(), 0xDEAD_BEEF);
-            assert_eq!((*hdr).flags(), 0);
+            assert_eq!(
+                (*hdr).flags(),
+                majit_gc::flags::NO_HEAP_PTRS | majit_gc::flags::TRACK_YOUNG_PTRS
+            );
         }
     }
 }

--- a/pyre/pyre-object/src/lltype.rs
+++ b/pyre/pyre-object/src/lltype.rs
@@ -268,6 +268,30 @@ pub fn malloc_typed<T: GcType>(value: T) -> *mut T {
     majit_gc::header::alloc_with_gc_header(value, type_id)
 }
 
+/// [`malloc_typed`] for an immortal leaf singleton — the header carries
+/// `init_gc_object_immortal`'s `NO_HEAP_PTRS | TRACK_YOUNG_PTRS`, so the
+/// collector recognises it as a prebuilt root and stops there instead of
+/// reading a payload it has no trace shape for.
+///
+/// Restricted to payloads that hold no reference at all: `None`, `True`,
+/// `False`, `NotImplemented`, `Ellipsis`. A box with reference fields must use
+/// [`malloc_typed`] and be reached through the raw-root walkers instead —
+/// `NO_HEAP_PTRS` there would be a false claim, and
+/// `majit_gc::header::alloc_with_gc_header_immortal` records what that costs.
+#[inline]
+pub fn malloc_typed_immortal<T: GcType>(value: T) -> *mut T {
+    debug_assert_eq!(
+        std::mem::size_of::<T>(),
+        T::SIZE,
+        "GcType::SIZE drift from std::mem::size_of"
+    );
+    let type_id = match T::type_id() {
+        TypeIdCell::UNASSIGNED => 0,
+        id => id,
+    };
+    majit_gc::header::alloc_with_gc_header_immortal(value, type_id)
+}
+
 /// Managed typed allocation.
 ///
 /// `gct_fv_gc_malloc` / `init_gc_object(result, typeid, flags=0)`
@@ -385,17 +409,14 @@ mod tests {
     }
 
     #[test]
-    fn malloc_prepends_prebuilt_gc_header() {
+    fn malloc_prepends_zeroed_gc_header() {
         let p = malloc(0x1234_5678_u64);
         unsafe {
             assert_eq!(*p, 0x1234_5678);
-            // incminimark init_gc_object_immortal flags.
+            // A zeroed GcHeader precedes the payload, so the write barrier
+            // reads `*(obj - SIZE)` as TRACK_YOUNG_PTRS=0 and skips it.
             let hdr = majit_gc::header::header_of(p as usize);
-            assert_eq!((*hdr).type_id(), 0);
-            assert_eq!(
-                (*hdr).flags(),
-                majit_gc::flags::NO_HEAP_PTRS | majit_gc::flags::TRACK_YOUNG_PTRS
-            );
+            assert_eq!((*hdr).tid_and_flags, 0);
         }
     }
 
@@ -430,10 +451,7 @@ mod tests {
             // The header carries the real GC type id, not a 0 placeholder.
             let hdr = majit_gc::header::header_of(p as usize);
             assert_eq!((*hdr).type_id(), 0xDEAD_BEEF);
-            assert_eq!(
-                (*hdr).flags(),
-                majit_gc::flags::NO_HEAP_PTRS | majit_gc::flags::TRACK_YOUNG_PTRS
-            );
+            assert_eq!((*hdr).flags(), 0);
         }
     }
 }

--- a/pyre/pyre-object/src/noneobject.rs
+++ b/pyre/pyre-object/src/noneobject.rs
@@ -8,17 +8,33 @@ pub struct W_NoneObject {
     pub ob_header: PyObject,
 }
 
-/// Global None singleton.
-static NONE_SINGLETON: W_NoneObject = W_NoneObject {
-    ob_header: PyObject {
-        ob_type: &NONE_TYPE as *const PyType,
-        w_class: std::ptr::null_mut(),
-    },
-};
+/// GC type id assigned by the foreign-PyType registration sequence.
+pub const W_NONE_GC_TYPE_ID: u32 = 45;
+
+impl crate::lltype::GcType for W_NoneObject {
+    fn type_id() -> u32 {
+        W_NONE_GC_TYPE_ID
+    }
+    const SIZE: usize = std::mem::size_of::<W_NoneObject>();
+}
+
+/// Process-global translated-prebuilt None object. PyPy's `space.w_None` is
+/// one prebuilt GC object, including its GC header; storing a bare Rust static
+/// in `__DATA_CONST` loses that header and makes direct meta-traced GC marking
+/// impossible. `OnceLock<usize>` is the established process-global immortal
+/// owner used by the other pyre prebuilt objects.
+static NONE_SINGLETON: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
 
 /// Get the None singleton as a PyObjectRef.
 pub fn w_none() -> PyObjectRef {
-    &NONE_SINGLETON as *const W_NoneObject as *mut PyObject
+    *NONE_SINGLETON.get_or_init(|| {
+        crate::lltype::malloc_typed(W_NoneObject {
+            ob_header: PyObject {
+                ob_type: &NONE_TYPE as *const PyType,
+                w_class: std::ptr::null_mut(),
+            },
+        }) as usize
+    }) as PyObjectRef
 }
 
 #[cfg(test)]
@@ -33,6 +49,9 @@ mod tests {
         unsafe {
             assert!(is_none(a));
             assert!(!is_int(a));
+            let hdr = majit_gc::header::header_of(a as usize);
+            assert_eq!((*hdr).type_id(), W_NONE_GC_TYPE_ID);
+            assert!((*hdr).has_flag(majit_gc::flags::NO_HEAP_PTRS));
         }
     }
 }

--- a/pyre/pyre-object/src/noneobject.rs
+++ b/pyre/pyre-object/src/noneobject.rs
@@ -28,7 +28,7 @@ static NONE_SINGLETON: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
 /// Get the None singleton as a PyObjectRef.
 pub fn w_none() -> PyObjectRef {
     *NONE_SINGLETON.get_or_init(|| {
-        crate::lltype::malloc_typed(W_NoneObject {
+        crate::lltype::malloc_typed_immortal(W_NoneObject {
             ob_header: PyObject {
                 ob_type: &NONE_TYPE as *const PyType,
                 w_class: std::ptr::null_mut(),

--- a/pyre/pyre-object/src/object_array.rs
+++ b/pyre/pyre-object/src/object_array.rs
@@ -1019,12 +1019,24 @@ impl FixedObjectArray {
     /// conditional array write barrier, then performs the store.  A raw Rust
     /// local is not part of that generated root map, so publish it explicitly
     /// and reload it after the barrier's safepoint before writing the slot.
+    #[inline]
     pub fn set_ref(&mut self, index: usize, value: PyObjectRef) {
         assert!(index < self.len);
         // Clearing a slot cannot create an old-to-young edge.  PyPy's
         // `popvalue_maybe_none` / `dropvalues*` therefore compile to the
         // plain `None` store with no collecting write-barrier slow path.
         if value.is_null() {
+            unsafe { self.items_mut_ptr().add(index).write(value) };
+            return;
+        }
+        // minimark.py:1063-1071 `writebarrier_before_copy` / the ordinary
+        // `setarrayitem_gc` rewrite: inspect TRACK_YOUNG_PTRS inline and enter
+        // the collecting slow path only while the old array still needs to be
+        // remembered.  The barrier clears this bit, so every later store into
+        // the same array is a plain write.  Nursery arrays and StdAlloc
+        // fallback arrays also carry a zero flag word and take this arm.
+        let header = unsafe { majit_gc::header::header_of(self as *mut Self as usize) };
+        if unsafe { !(*header).has_flag(majit_gc::flags::TRACK_YOUNG_PTRS) } {
             unsafe { self.items_mut_ptr().add(index).write(value) };
             return;
         }

--- a/pyre/pyre-object/src/special.rs
+++ b/pyre/pyre-object/src/special.rs
@@ -23,7 +23,7 @@ static NOT_IMPLEMENTED_SINGLETON: std::sync::OnceLock<usize> = std::sync::OnceLo
 /// Get the NotImplemented singleton.
 pub fn w_not_implemented() -> PyObjectRef {
     *NOT_IMPLEMENTED_SINGLETON.get_or_init(|| {
-        crate::lltype::malloc_typed(NotImplemented {
+        crate::lltype::malloc_typed_immortal(NotImplemented {
             ob_header: PyObject {
                 ob_type: &NOTIMPLEMENTED_TYPE as *const PyType,
                 w_class: std::ptr::null_mut(),
@@ -53,7 +53,7 @@ static ELLIPSIS_SINGLETON: std::sync::OnceLock<usize> = std::sync::OnceLock::new
 /// Get the Ellipsis singleton.
 pub fn w_ellipsis() -> PyObjectRef {
     *ELLIPSIS_SINGLETON.get_or_init(|| {
-        crate::lltype::malloc_typed(Ellipsis {
+        crate::lltype::malloc_typed_immortal(Ellipsis {
             ob_header: PyObject {
                 ob_type: &ELLIPSIS_TYPE as *const PyType,
                 w_class: std::ptr::null_mut(),

--- a/pyre/pyre-object/src/special.rs
+++ b/pyre/pyre-object/src/special.rs
@@ -9,16 +9,27 @@ pub struct NotImplemented {
     pub ob_header: PyObject,
 }
 
-static NOT_IMPLEMENTED_SINGLETON: NotImplemented = NotImplemented {
-    ob_header: PyObject {
-        ob_type: &NOTIMPLEMENTED_TYPE as *const PyType,
-        w_class: std::ptr::null_mut(),
-    },
-};
+pub const W_NOT_IMPLEMENTED_GC_TYPE_ID: u32 = 46;
+
+impl crate::lltype::GcType for NotImplemented {
+    fn type_id() -> u32 {
+        W_NOT_IMPLEMENTED_GC_TYPE_ID
+    }
+    const SIZE: usize = std::mem::size_of::<NotImplemented>();
+}
+
+static NOT_IMPLEMENTED_SINGLETON: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
 
 /// Get the NotImplemented singleton.
 pub fn w_not_implemented() -> PyObjectRef {
-    &NOT_IMPLEMENTED_SINGLETON as *const NotImplemented as *mut PyObject
+    *NOT_IMPLEMENTED_SINGLETON.get_or_init(|| {
+        crate::lltype::malloc_typed(NotImplemented {
+            ob_header: PyObject {
+                ob_type: &NOTIMPLEMENTED_TYPE as *const PyType,
+                w_class: std::ptr::null_mut(),
+            },
+        }) as usize
+    }) as PyObjectRef
 }
 
 /// Python Ellipsis singleton (`...`).
@@ -28,14 +39,44 @@ pub struct Ellipsis {
     pub ob_header: PyObject,
 }
 
-static ELLIPSIS_SINGLETON: Ellipsis = Ellipsis {
-    ob_header: PyObject {
-        ob_type: &ELLIPSIS_TYPE as *const PyType,
-        w_class: std::ptr::null_mut(),
-    },
-};
+pub const W_ELLIPSIS_GC_TYPE_ID: u32 = 47;
+
+impl crate::lltype::GcType for Ellipsis {
+    fn type_id() -> u32 {
+        W_ELLIPSIS_GC_TYPE_ID
+    }
+    const SIZE: usize = std::mem::size_of::<Ellipsis>();
+}
+
+static ELLIPSIS_SINGLETON: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
 
 /// Get the Ellipsis singleton.
 pub fn w_ellipsis() -> PyObjectRef {
-    &ELLIPSIS_SINGLETON as *const Ellipsis as *mut PyObject
+    *ELLIPSIS_SINGLETON.get_or_init(|| {
+        crate::lltype::malloc_typed(Ellipsis {
+            ob_header: PyObject {
+                ob_type: &ELLIPSIS_TYPE as *const PyType,
+                w_class: std::ptr::null_mut(),
+            },
+        }) as usize
+    }) as PyObjectRef
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn special_singletons_are_header_bearing_prebuilt_objects() {
+        for (obj, type_id) in [
+            (w_not_implemented(), W_NOT_IMPLEMENTED_GC_TYPE_ID),
+            (w_ellipsis(), W_ELLIPSIS_GC_TYPE_ID),
+        ] {
+            unsafe {
+                let hdr = majit_gc::header::header_of(obj as usize);
+                assert_eq!((*hdr).type_id(), type_id);
+                assert!((*hdr).has_flag(majit_gc::flags::NO_HEAP_PTRS));
+            }
+        }
+    }
 }

--- a/pyre/pyrex/Cargo.toml
+++ b/pyre/pyrex/Cargo.toml
@@ -23,15 +23,15 @@ path = "src/bin/pyre-dynasm.rs"
 required-features = ["dynasm"]
 
 [features]
-default = ["dynasm"]
+default = ["dynasm", "mimalloc"]
 jit = []  # meta feature: enabled by cranelift or dynasm
 cranelift = ["jit", "pyre-jit/cranelift"]
 dynasm = ["jit", "pyre-jit/dynasm"]
-# Opt-in: use mimalloc as the global allocator. OFF by default. The bignum path
-# allocates a fresh limb Vec per rbigint op through the global allocator; the
-# platform default (notably the Windows system heap) dominates the per-op cost,
-# so mimalloc roughly halves bignum-heavy workloads (fib_loop beats PyPy).
-# Enable with e.g. `--features dynasm,mimalloc`.
+# Use mimalloc as the default global allocator. The bignum path allocates a
+# fresh limb Vec per rbigint op, and Python call/GC bookkeeping also performs
+# enough small host allocations for the platform allocator to be measurable.
+# Keep the feature separate so allocator-sensitive diagnostics can still use
+# `--no-default-features --features dynasm`.
 mimalloc = ["dep:mimalloc"]
 # Deterministic GC stress: forces a full collection at the start of every
 # allocation (opt in at runtime via MAJIT_GC_STRESS). Test/diagnostic only —

--- a/pyre/pyrex/src/bin/pyre-cranelift.rs
+++ b/pyre/pyrex/src/bin/pyre-cranelift.rs
@@ -1,4 +1,4 @@
-// Opt-in (`--features mimalloc`); see `pyre-dynasm.rs`. OFF by default.
+// Enabled by default; see `pyre-dynasm.rs`.
 #[cfg(feature = "mimalloc")]
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;

--- a/pyre/pyrex/src/bin/pyre-dynasm.rs
+++ b/pyre/pyrex/src/bin/pyre-dynasm.rs
@@ -1,6 +1,5 @@
-// Opt-in (`--features mimalloc`): mimalloc roughly halves bignum-heavy
-// workloads by replacing the platform default heap on the per-rbigint-op limb
-// Vec allocation. OFF by default.
+// Enabled by default; allocator-sensitive diagnostics can disable default
+// features and select only `dynasm`. See pyrex/Cargo.toml.
 #[cfg(feature = "mimalloc")]
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;

--- a/pyre/pyrex/src/main.rs
+++ b/pyre/pyrex/src/main.rs
@@ -1,4 +1,4 @@
-// Opt-in (`--features mimalloc`); see `bin/pyre-dynasm.rs`. OFF by default.
+// Enabled by default; see `bin/pyre-dynasm.rs`.
 #[cfg(feature = "mimalloc")]
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;


### PR DESCRIPTION
Eleven commits: interpreter/GC allocation work, the fbw callee stack-identity
work, `WITH_EXCEPT_START` on resumed paths, and a CI concurrency fix.

## GC

- `gc: restore prebuilt root lifecycle` + `perf(gc): recognize prebuilt Python
  object headers` teach the collector to skip a clean prebuilt root and to
  read a Python object header directly in `grey_child`.
- `gc: restrict the immortal prebuilt header to leaf singletons` narrows the
  first of those. `alloc_with_gc_header` backs `malloc_typed`, pyre's runtime
  leaked-host allocator — not a translated prebuilt set — so stamping it with
  `NO_HEAP_PTRS | TRACK_YOUNG_PTRS` entered ~60k ordinary boxes into
  `prebuilt_root_objects` (`prebuilt_roots=62447` after four minors, top tids
  `(90, 30006), (89, 30006)` — the benchmark's own user-class instances). Their
  ref fields are written at construction with no write barrier, so the first
  barrier on some other field cleared `NO_HEAP_PTRS` and `seed_prebuilt_root`
  then traced every `gc_ptr_offsets` slot, including never-barriered ones whose
  targets were long reclaimed:

  ```
  prebuilt(tid 0x59, size 0x58, offs[8,10,28,30,40,48]) +0x30
    -> W_ListObject(tid 7, custom_trace)  +0x18 (items)
    -> ItemsBlock(tid 9, cap=1)           +0x08 (item 0)
    -> W_ListObject  <-- reclaimed
  ```

  `pyre/bench/synth/pickle_ctor_args.py` panicked 3/3 on dynasm and cranelift
  with `GC BUG: invalid major child ... site=major_custom_trace`; under
  `MAJIT_GC_NURSERY_POISON=1` the victim list read back
  `length = 0xAAAA_AAAA_AAAA_AAAA`. Now 0/3. The genuine leaf singletons
  (`True`/`False`/`None`/the `special` pair) keep the immortal shape through a
  new `malloc_typed_immortal`.

## fbw

- `jit(fbw): preserve callee stack identity across bridges` threads the decoded
  multi-frame recipe's operand stack into the bridge sub-walk, stamps
  `GUARD_VALUE`'s observed constant onto the guarded box, and stops
  `setup_reconstructed_callee_frame` from writing a `PUSH_NULL` sentinel over a
  mapped color.
- `jit(fbw): return PYRE_FBW_CALLEE_VSTACK to default OFF` reverts only that
  commit's default flip. Measured on the whole `pyre/bench/synth` corpus
  (dynasm): ON compiles two loops OFF declines and regresses both fixtures —
  349 -> 347 passing, **no fixture improved**, user CPU flat. Neither new loop
  gets a bridge:

  | fixture | OFF | ON |
  |---|---|---|
  | `getframe_inline_subwalk_multiframe` | compiled 0, aborted 15, guards 0 | compiled 2, aborted 1, guards 8948, bridges 0 |
  | `or_chain_fresh_alloc_arg` | compiled 2, bridges 1, guards 200 | compiled 3, bridges 0, guards 9653 |

  The first fails a `GUARD_NOT_FORCED`, which `compile.py:950-953`
  `ResumeGuardForcedDescr.handle_fail` never compiles ("always just
  blackholed") — no bridge is reachable for that shape by construction. The
  second needs a multi-frame inline resume that `reconstruct_inline_recipe`
  declines at `UnboxedLiveRegister`: the resumed `pick` frame at `py_pc=37`
  carries a live int-bank register (color 0) whose per-PC `(bank, color, slot)`
  map `[(1,2,2),(1,5,3),(1,5,4)]` holds no bank-0 entry, i.e. a JitCode int temp
  with no `locals_cells_stack_w` home in the rebuilt PyFrame.
  `P2Drain::NoRecipes` then declines the guard permanently. Both readings are
  recorded on the flag's doc comment; the mechanism stays available via
  `PYRE_FBW_CALLEE_VSTACK=1`.

## Other

- `jit: execute WITH_EXCEPT_START on resumed paths`, with cranelift and wasm
  jit-stats baselines recorded for the new fixture.
- `perf(interpreter): reuse root scopes in frame calls`,
  `perf(runtime): reduce frame store overhead`.
- `jit: drop the interpreter dispatch loop's blackhole_if_trace_too_long`.
- `ci: stop a merge train from cancelling its predecessors' runs on main`.

## Verification

`cargo test --all --no-default-features --features dynasm` rc=0, and
`python3 pyre/check.py` reached dynasm 5 / cranelift 5 / wasm 2 failed — the
same names and the same numeric deltas as `main`'s own CI run 30738774634 at
`a72d9cb8d0c` (`closure_freevar_branch_resume`, `exception_args_virtual`,
`exception_multi_handler_warmup`, `exception_reraise_tb_depth_jitstress`,
`list_length_hint_validate`). No regression is introduced by this branch.

Those measurements were taken at base `a72d9cb8d0c`; the branch was
subsequently rebased onto `717d37c5e2d` and `cargo check` re-run, so CI here is
the authority on the rebased content.

— *authored by Claude*
