### PR TITLE
gh#346: fold fmt::Arguments::from_str_nonconst to its &str operand

### DIFF
--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -9777,6 +9777,12 @@ impl<'a> Lowering<'a> {
     /// instead of emitting the unregistered ctor.  The result then flows
     /// either to a residualized panic (`Abort` → `RaiseImplicit`) or to
     /// `alloc::fmt::format` (handled by [`Self::traces_to_str_const`]).
+    ///
+    /// `from_str_nonconst(s) { Arguments::from_str(s) }` is the identical
+    /// constructor the compiler emits when the no-placeholder `format_args!`
+    /// sits in a non-`const` body (the `#[new]`/setter gateways) — same
+    /// `&'static str` argument, same constant-string `Arguments` — so it
+    /// takes the same alias.
     fn is_arguments_from_str(&self, reg: &RegularCall) -> bool {
         let CallKind::Fun(FunId::Regular { id }) = &reg.kind else {
             return false;
@@ -9788,7 +9794,8 @@ impl<'a> Lowering<'a> {
         // "from_str"]` `FunctionPath` (via `impl_method_owner_for_fundecl`).
         self.llbc.fn_by_id(*id).is_some_and(|fd| {
             impl_method_owner_for_fundecl(self.llbc, fd).is_some_and(|(owner, leaf)| {
-                leaf == "from_str" && owner.ends_with("fmt::Arguments")
+                (leaf == "from_str" || leaf == "from_str_nonconst")
+                    && owner.ends_with("fmt::Arguments")
             })
         })
     }
@@ -10512,7 +10519,13 @@ impl<'a> Lowering<'a> {
         // into `Write::write_fmt` (whose own graph-less extern keeps those
         // subjects residual) — no `alloc::fmt::format` consumes one.  This
         // is the same transparent passthrough `must_use` / `identity` take.
-        if fmt_path_ends_with(segments, &["Arguments", "from_str"]) {
+        // `from_str_nonconst(s) { Arguments::from_str(s) }` is the identical
+        // constructor emitted for a no-placeholder `format_args!` in a
+        // non-`const` body (the C-module `#[new]`/setter gateways), so it
+        // aliases the same way.
+        if fmt_path_ends_with(segments, &["Arguments", "from_str"])
+            || fmt_path_ends_with(segments, &["Arguments", "from_str_nonconst"])
+        {
             return Some(arg.clone());
         }
         let [a, b, c] = segments else {
@@ -21496,6 +21509,48 @@ mod tests {
         );
         assert_eq!(chain.args.len(), 1);
         assert_eq!(chain.args[0].kind, FmtArgKind::Display);
+    }
+
+    /// Anchor the `Arguments::from_str_nonconst` alias to the real lowered IR
+    /// of `constructor_args` (the `_collections` deque-iterator `__new__`
+    /// helper), whose cold error branches build no-placeholder messages
+    /// (`type_error(format!("must be collections.deque, not {name}"))` renders
+    /// its one placeholder through the multi-arg chain; the arity guard's
+    /// `format!("…got {}", n)` and the descriptor-preamble
+    /// `concat!(…)`-message emit the const-string `from_str_nonconst`
+    /// constructor in this non-`const` body).  The identity alias must drop
+    /// every `fmt::Arguments::from_str_nonconst` extern — none may survive as
+    /// a residual Call to wall the rtyper.  Ignored by default (loads the real
+    /// LLBC).
+    #[test]
+    #[ignore]
+    fn arguments_from_str_nonconst_alias_real_constructor_args() {
+        use crate::model::{CallTarget, OpKind};
+
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../build/llbc/pyre-interpreter.ullbc"
+        );
+        let llbc = Llbc::load(path).expect("load real LLBC");
+        let graph =
+            super::lower_function(&llbc, "constructor_args").expect("lower constructor_args");
+
+        let residual = graph
+            .blocks
+            .iter()
+            .flat_map(|b| b.operations.iter())
+            .filter(|op| {
+                matches!(
+                    &op.kind,
+                    OpKind::Call { target: CallTarget::FunctionPath { segments }, .. }
+                        if super::fmt_path_ends_with(segments, &["Arguments", "from_str_nonconst"])
+                )
+            })
+            .count();
+        assert_eq!(
+            residual, 0,
+            "no residual Arguments::from_str_nonconst extern survives the identity alias"
+        );
     }
 
     /// Anchor compiler-core's exact


### PR DESCRIPTION
## What

Extends the existing `fmt::Arguments::from_str` identity-alias fold to its sibling constructor `fmt::Arguments::from_str_nonconst`, clearing the #2 root-cause wall in the two-phase-rtyper census (gh#346).

The const `from_str(s)` no-placeholder `format_args!` constructor already folds to its sole `&'static str` operand at two sites in the front lowering (`is_arguments_from_str`, `identity_passthrough_alias`). Rust emits the sibling `from_str_nonconst` for the same no-placeholder `format_args!` when it sits in a non-`const` body — the C-module `#[new]`/setter gateways. Std defines it as:

```rust
pub fn from_str_nonconst(s: &'static str) -> Arguments<'a> { Arguments::from_str(s) }
```

Byte-identical delegation, same single `&'static str`, same constant-string `Arguments` — so the destination aliases to the operand exactly as the const `from_str` already does. Both recognizers now accept the sibling leaf; the arity-1 guard (`let [arg] = args`) leaves any placeholder-bearing call untouched, so it is pattern-completion, not a new mechanism.

## Why

`from_str_nonconst` reached `translate_op` as an unregistered `FunctionPath` and was the top actionable root after the GC-gated `__array_repeat`: **26 phaseA heads, all direct**, on the clinic `__pyre_wrap___new__` / `__pyre_wrap_set_*` gateways of `_collections` / `_io` / `_pickle` / `_random` / `_tokenize` / `select` / `struct` / `thread` / `pyframe`, whose cold error branches build no-placeholder diagnostic messages.

## Verification

- **Census A/B** (two-phase-rtyper prepass): phaseA **1196 → 1193 (−3)**, `from_str_nonconst` **26 → 0**, **0 new heads**, collected 207 unchanged. The 3 cleared are the graphs where it was the sole wall (`_pickle` setters); the other 23 re-root on their next wall (budget-at-roots).
- `cargo test -p majit-translate --lib`: **3086 passed**, plus a new ignored real-LLBC anchor (`arguments_from_str_nonconst_alias_real_constructor_args`) asserting `constructor_args` lowers with no residual `from_str_nonconst` extern.
- `pyre/check.py --backend dynasm,cranelift`: `pickle_ctor_args` (the only fixture touching a folded gateway) **PASSES** both backends. The 4 remaining SNAPDIFF failures (`exception_args_virtual`, `list_length_hint_validate`) are inherited-red on `main` — measured byte-identical (`0→3/401→1002`, `14→34/828→4923`) on clean `origin/main` with none of this change, and both fixtures are mechanistically outside the fmt gateway blast radius.

Assisted-by: Claude

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved translation of formatted string arguments.
  * Prevented residual internal formatting calls from appearing in translated output.
  * Improved handling of constructor arguments to produce cleaner, more reliable translated code.

* **Tests**
  * Added coverage to verify constructor argument translation and confirm that internal formatting calls are fully removed from the output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->