### PR TITLE
jit: gate the module-dict strategy read on the dict actually being one

### DIFF
--- a/majit/majit-ir/src/effectinfo.rs
+++ b/majit/majit-ir/src/effectinfo.rs
@@ -676,7 +676,11 @@ pub enum OopSpecIndex {
 /// them so the production reghint / vstring passes treat them as ordinary
 /// calls, and the CanRaise members (`load_const` / `load_global` / `box_int`)
 /// would otherwise violate the `_OS_CANRAISE` invariant (effectinfo.py:198).
-/// Discriminants are pyre-internal (no upstream meaning).
+/// Discriminants are pyre-internal (no upstream meaning) and variant order is
+/// free: nothing decodes the tag numerically, and the one bincode artefact that
+/// carries it (`descrs.bin`) is written and read back within a single build
+/// whose codegen cache is content-keyed on this file.  Group a new helper with
+/// its siblings rather than appending it.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Default, Serialize, Deserialize)]
 #[repr(u8)]
 pub enum PyreHelperKind {
@@ -880,10 +884,6 @@ pub enum PyreHelperKind {
     /// binding half (`callmethod.py:25-85`).  The full-body walker recognises
     /// this tag to fold the pure `compute_load_method_bound` decision once the
     /// paired [`LoadAttr`] method-cache fold has made `attr` concrete.
-    ///
-    /// Keep this at the enum tail: [`PyreHelperKind`] is `repr(u8)`, and
-    /// inserting a helper in the middle changes existing discriminants consumed
-    /// by serialized/stable helper metadata.
     LoadMethodSelf,
     /// `bh_delete_attr_fn(obj, code, name_idx)` — the plain DELETE_ATTR
     /// residual (`lower_delete_attr_hlop_to_insn` → `space.delattr`), the

--- a/pyre/bench/synth/global_store_plain_dict_globals.cranelift.jitstats
+++ b/pyre/bench/synth/global_store_plain_dict_globals.cranelift.jitstats
@@ -1,0 +1,8 @@
+bridges_compiled=0
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
+guard_failures=1
+internal_compile_panics=0
+loops_aborted=0
+loops_compiled=4

--- a/pyre/bench/synth/global_store_plain_dict_globals.dynasm.jitstats
+++ b/pyre/bench/synth/global_store_plain_dict_globals.dynasm.jitstats
@@ -1,0 +1,8 @@
+bridges_compiled=0
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
+guard_failures=1
+internal_compile_panics=0
+loops_aborted=0
+loops_compiled=4

--- a/pyre/bench/synth/global_store_plain_dict_globals.py
+++ b/pyre/bench/synth/global_store_plain_dict_globals.py
@@ -1,0 +1,52 @@
+# Regression guard: a hot STORE_GLOBAL / DELETE_GLOBAL whose namespace is an
+# ordinary dict rather than a module dict.
+#
+# `exec(src, {})` and `types.FunctionType(code, {})` both hand the frame a plain
+# `dict` for globals, so every module-dict specialization the walker owns has to
+# recognise that shape and decline. Reading the module-dict strategy off such a
+# frame lands on a different field, and the quasi-immutable version watcher it
+# then reaches is not one — the write that follows targets read-only memory.
+#
+# The loop must stay hot enough to trace, and it must actually write the
+# namespace on every iteration so the store specializations are reached.
+try:
+    import pypyjit
+
+    pypyjit.set_param("threshold=1,function_threshold=1")
+except ImportError:
+    pass
+
+import types
+
+N = 4000
+
+SRC = """
+def bump(n):
+    global counter, scratch
+    counter = 0
+    for i in range(n):
+        counter = counter + i
+        scratch = i
+        del scratch
+    return counter
+"""
+
+# exec into a bare dict: the frame's globals is a plain W_DictObject.
+exec_ns = {}
+exec(SRC, exec_ns)
+print("exec", exec_ns["bump"](N))
+print("exec-counter", exec_ns["counter"])
+print("exec-scratch", "scratch" in exec_ns)
+
+# Same code object rebound onto another plain dict through FunctionType.
+alias_ns = {"__builtins__": __builtins__}
+rebound = types.FunctionType(exec_ns["bump"].__code__, alias_ns)
+print("rebound", rebound(N))
+print("rebound-counter", alias_ns["counter"])
+
+# A module-scope loop over the real module dict, so both namespace shapes run in
+# one process and the plain-dict decline cannot be mistaken for "never traced".
+total = 0
+for i in range(N):
+    total = total + i
+print("module", total)

--- a/pyre/bench/synth/global_store_plain_dict_globals.wasm.jitstats
+++ b/pyre/bench/synth/global_store_plain_dict_globals.wasm.jitstats
@@ -1,0 +1,5 @@
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
+internal_compile_panics=0
+loops_aborted=3

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -7460,7 +7460,7 @@ fn walker_pin_namespace_version<Sym: WalkSym>(
     op_pc: usize,
     ns: pyre_object::PyObjectRef,
 ) -> Result<bool, DispatchError> {
-    let strategy = unsafe { pyre_object::dictmultiobject::w_module_dict_get_strategy(ns) };
+    let strategy = unsafe { pyre_object::dictmultiobject::w_module_dict_strategy_or_null(ns) };
     if strategy.is_null() {
         return Ok(false);
     }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -3731,16 +3731,22 @@ fn try_walker_force_quasi_immut_namespace_write<Sym: WalkSym>(
     if w_globals.is_null() {
         return None;
     }
-    // A `*_NAME` opcode writes `w_locals`; only a module frame — where
-    // `w_locals` aliases `w_globals` — touches the namespace the folds pin.
-    // Same test as `try_walker_load_name_cell_fold`.
+    // A `*_NAME` opcode writes `get_or_create_w_locals`; only a module frame —
+    // where `w_locals` aliases `w_globals` — touches the namespace the folds
+    // pin.  An absent `w_locals` is a fresh throwaway mapping, not globals, so
+    // it declines rather than forcing for a write that never reaches here.
     if matches!(helper, K::StoreName | K::DeleteName) {
         let w_locals = frame.get_w_locals();
-        if !w_locals.is_null() && !std::ptr::eq(w_locals, w_globals) {
+        if !std::ptr::eq(w_locals, w_globals) {
             return None;
         }
     }
-    let strategy = unsafe { pyre_object::dictmultiobject::w_module_dict_get_strategy(w_globals) };
+    // A plain `W_DictObject` for globals (`exec(src, {})`,
+    // `FunctionType(code, {})`) has no `version?` field at all, so
+    // `hook_setfield` (rclass.py:714-718) emits no `jit_force_quasi_immutable`
+    // for its write and there is nothing to abandon the trace for.
+    let strategy =
+        unsafe { pyre_object::dictmultiobject::w_module_dict_strategy_or_null(w_globals) };
     // `mutatebox.nonnull()` — nothing is watching, so there is nothing to
     // abandon the trace for. The write still runs its own invalidation.
     if !unsafe {
@@ -4035,8 +4041,14 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
                 ctx.trace_ctx.box_value(frame_opref),
                 ctx.trace_ctx.box_value(name_opref),
             ) {
-                if try_walker_store_name_cell_fold(ctx, op.pc, frame_ptr, w_name_ptr, value_opref)?
-                {
+                if try_walker_store_name_cell_fold(
+                    ctx,
+                    op.pc,
+                    ei.pyre_helper,
+                    frame_ptr,
+                    w_name_ptr,
+                    value_opref,
+                )? {
                     return Ok((DispatchOutcome::Continue, op.next_pc));
                 }
             }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -4364,7 +4364,8 @@ pub(crate) fn try_walker_specialize_make_function<Sym: WalkSym>(
     // read below walks the same storage `pick_builtin_obj_checked`'s
     // `finditem_str` does.  This is also what `walker_pin_namespace_version`
     // needs, but that one emits IR, so it runs only once the fold commits.
-    if unsafe { pyre_object::dictmultiobject::w_module_dict_get_strategy(w_globals) }.is_null() {
+    if unsafe { pyre_object::dictmultiobject::w_module_dict_strategy_or_null(w_globals) }.is_null()
+    {
         return Ok(None);
     }
     // `function_new_impl`'s `w_builtins` derivation, restricted to the branch
@@ -9553,6 +9554,7 @@ pub(crate) fn try_walker_load_name_cell_fold<Sym: WalkSym>(
 pub(crate) fn try_walker_store_name_cell_fold<Sym: WalkSym>(
     ctx: &mut WalkContext<'_, '_, Sym>,
     op_pc: usize,
+    helper: majit_ir::PyreHelperKind,
     frame_ptr: usize,
     w_name_ptr: usize,
     value_opref: OpRef,
@@ -9565,11 +9567,18 @@ pub(crate) fn try_walker_store_name_cell_fold<Sym: WalkSym>(
     if w_globals.is_null() {
         return Ok(false);
     }
-    // Module scope gate: `w_locals` aliases `w_globals` (same as the LOAD
-    // fold); a distinct `w_locals` routes to the live residual.
-    let w_locals = frame.get_w_locals();
-    if !w_locals.is_null() && !std::ptr::eq(w_locals, w_globals) {
-        return Ok(false);
+    // STORE_NAME writes `get_or_create_w_locals`, so only a module frame —
+    // where `w_locals` aliases `w_globals` — targets the dict this folds.  An
+    // ABSENT `w_locals` does NOT stand in for globals on the write path (unlike
+    // the LOAD fold): the store would land in a fresh locals mapping while the
+    // fold set the module cell.  STORE_GLOBAL names globals outright, and its
+    // frame is a function frame whose `w_locals` is legitimately null, so the
+    // gate must not apply to it.
+    if helper == majit_ir::PyreHelperKind::StoreName {
+        let w_locals = frame.get_w_locals();
+        if !std::ptr::eq(w_locals, w_globals) {
+            return Ok(false);
+        }
     }
     let name = unsafe {
         pyre_object::unicodeobject::w_str_get_value(w_name_ptr as pyre_object::PyObjectRef)

--- a/pyre/pyre-object/src/celldict.rs
+++ b/pyre/pyre-object/src/celldict.rs
@@ -1397,4 +1397,40 @@ mod tests {
             assert_eq!(crate::intobject::w_int_get_value(got), 8);
         }
     }
+
+    /// `store_would_bump_version` is the tracer's stand-in for the write it
+    /// never looks into, so it has to answer for the same five shapes
+    /// `classify_cell_write` distinguishes.  Pin both halves against one table
+    /// so neither can drift from the other.
+    #[test]
+    fn store_bump_prediction_matches_the_write() {
+        unsafe {
+            let int7 = crate::intobject::w_int_new(7);
+            let int8 = crate::intobject::w_int_new(8);
+            let s = crate::w_str_new("s");
+            let obj_cell = w_object_mutable_cell_new(s);
+            let int_cell = w_int_mutable_cell_new(7);
+
+            // (raw slot contents, value written, bumps?, what the write does)
+            let cases: [(Option<PyObjectRef>, PyObjectRef, bool, &str); 6] = [
+                (None, int7, true, "no cell: the value is stored bare"),
+                (Some(obj_cell), s, false, "object cell: written in place"),
+                (
+                    Some(int_cell),
+                    int8,
+                    false,
+                    "int cell + plain int: in place",
+                ),
+                (Some(int_cell), s, true, "int cell + non-int: fresh cell"),
+                (Some(s), s, false, "bare value, identical: unchanged"),
+                (Some(int7), int8, true, "bare value, different: fresh cell"),
+            ];
+            for (w_cell, w_value, bumps, what) in cases {
+                assert_eq!(store_would_bump_version(w_cell, w_value), bumps, "{what}");
+                // The write agrees: it returns a replacement slot value exactly
+                // when it bumps, and `None` (wrote through / no-op) otherwise.
+                assert_eq!(write_cell(w_cell, w_value).is_some(), bumps, "{what}");
+            }
+        }
+    }
 }

--- a/pyre/pyre-object/src/dictmultiobject.rs
+++ b/pyre/pyre-object/src/dictmultiobject.rs
@@ -1915,6 +1915,28 @@ pub unsafe fn w_module_dict_get_strategy(
     (*(obj as *const W_ModuleDictObject)).mstrategy
 }
 
+/// [`w_module_dict_get_strategy`] for a caller that has not yet proven the
+/// layout — null for anything that is not a `W_ModuleDictObject`.
+///
+/// `mstrategy` sits at the same offset as `W_DictObject`'s `dstrategy`, which
+/// is a `&'static dyn DictStrategy` fat pointer, so the unchecked read on a
+/// plain dict returns one half of that pair.  Every strategy singleton is a
+/// zero-sized static, so the result is non-null and points into read-only
+/// memory: a caller testing `.is_null()` to mean "not a module dict" gets
+/// `false` and then reads — or atomically writes — past the static.
+///
+/// # Safety
+/// `obj` must be null or a valid `PyObjectRef`.
+#[inline]
+pub unsafe fn w_module_dict_strategy_or_null(
+    obj: PyObjectRef,
+) -> *mut crate::celldict::ModuleDictStrategy {
+    if obj.is_null() || !is_module_dict(obj) {
+        return std::ptr::null_mut();
+    }
+    w_module_dict_get_strategy(obj)
+}
+
 /// Strategy identity stamp used by `_new_next` parity (`dictmultiobject
 /// .py:829 self.strategy is self.w_dict.get_strategy()`).
 ///


### PR DESCRIPTION
Follow-up to #977, from its review round. The first item is a crash.

## The crash

`W_ModuleDictObject.mstrategy` sits at the same byte offset as `W_DictObject`'s
`dstrategy`, which is a `&'static dyn DictStrategy` — a **fat pointer**. So an
unchecked `w_module_dict_get_strategy` on a plain dict returns one half of that
pair. Every strategy singleton is a zero-sized static, so the result is non-null
and points into read-only memory: a caller testing `.is_null()` to mean "not a
module dict" gets `false`, and then reads — or atomically writes — past the
static.

```python
exec("for i in range(200000):\n x = i\n", {})
```

dies with SIGBUS in `QuasiImmutField::invalidate`, on the parking_lot Mutex
compare-and-swap, 36 bytes past `EMPTY_KWARGS_DICT_STRATEGY` in `__TEXT.__const`.
`exec(src, {})` and `types.FunctionType(code, {})` both hand the frame a plain
`W_DictObject` for globals — `exec_or_eval` passes `globals_arg` through
verbatim — and #977's force check read the strategy off it.

`w_module_dict_strategy_or_null` is `w_module_dict_get_strategy` plus the
`is_module_dict` test, for callers that have not proven the layout. All three
walker sites take it. Two of them predate #977 — the MAKE_FUNCTION fold and
`walker_pin_namespace_version` — and their `.is_null()` tests now mean what
their comments claim instead of being unconditionally false.

Declining is also the orthodox answer, not a heuristic: a plain dict has no
`version?` field, so `hook_setfield` (`rclass.py:714-718`) emits no
`jit_force_quasi_immutable` for its write and there is nothing to abandon the
trace for.

`global_store_plain_dict_globals` covers a hot STORE_GLOBAL / DELETE_GLOBAL
under `exec(src, {})` and under `FunctionType(code, {})`, plus a module-scope
loop so the plain-dict decline cannot be mistaken for "never traced".

## The `w_locals` gate

The module-scope gate now applies to STORE_NAME only.

STORE_NAME writes `get_or_create_w_locals`, so an ABSENT `w_locals` is a fresh
throwaway mapping rather than globals, and a fold that set the module cell would
write the wrong dict — the LOAD fold's null arm is correct (`load_name_value`
really does fall through to globals) but the store's was not.

STORE_GLOBAL names globals outright and its frame is a function frame whose
`w_locals` is legitimately null, so the same gate applied there declined every
function-scope global store. That showed up as `store_global_hot` 0.09s against
a 14x ratio gate on both native backends, which is how the over-application was
caught.

## Two smaller items

- `store_bump_prediction_matches_the_write` pins `store_would_bump_version`
  against `write_cell` across all six slot/value shapes. The two were split
  apart in #977 precisely so the tracer's prediction could not drift from the
  write it predicts; this is the test that holds that.
- Dropped the `PyreHelperKind` "keep this at the enum tail" note. Serde derives
  `serialize_unit_variant` with the positional variant index, nothing decodes
  the tag numerically, and the one bincode artefact carrying it (`descrs.bin`)
  is written and read back within a single build whose codegen cache is
  content-keyed on that file. The note was also attached to a variant that has
  not been the tail since #815.

## Verification

`pyre/check.py`, all three backends:

| backend | result |
|---|---|
| dynasm | 2 failed / 367 passed |
| cranelift | 2 failed / 367 passed |
| wasm | 2 failed / 363 passed |

`exception_args_virtual` and `list_length_hint_validate` fail identically in
main's own CI at `a72d9cb8d0c` (run 30738774634), with the same numeric deltas.

One item I could not attribute and did not re-record: wasm
`pickle_terminal_raise_resume` reads `loops_aborted 54 -> 59` locally, and main's
base CI passes it. The native backends are bit-identical to that fixture's
committed baseline (33 loops / 0 aborted / 487 guard failures) and
`abort: force quasi-immut` is 0 there, so it is not this change's semantics; the
counter is layout-sensitive on that fixture. Whether it reproduces on the CI
host is the open question this PR's wasm leg answers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
