### PR TITLE
majit-gc, thread: port rgil, hold the GIL across pyre code, and release it at every blocking call

### DIFF
--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -430,14 +430,10 @@ pub struct MiniMarkGC {
     /// The nursery (young generation).
     nursery: Nursery,
     /// gc.py:525-531 published nursery-top slot read by generated inline
-    /// allocation paths. Kept separately from the real top so free-threaded
-    /// execution can pin the published limit to zero without changing the
-    /// Rust allocator's nursery bounds. The atomic publishes limit changes to
-    /// generated code and Rust-side readers. The Box keeps its baked address
-    /// stable even if the containing GC value moves.
+    /// allocation paths. The atomic publishes limit changes to generated code
+    /// and Rust-side readers. The Box keeps its baked address stable even if
+    /// the containing GC value moves.
     published_nursery_top: Box<AtomicUsize>,
-    /// Whether generated code may use the shared nursery bump fast path.
-    inline_alloc_enabled: bool,
     /// The old generation.
     oldgen: OldGen,
     /// Type registry for tracing objects.
@@ -670,7 +666,6 @@ impl MiniMarkGC {
         let mut gc = MiniMarkGC {
             nursery,
             published_nursery_top,
-            inline_alloc_enabled: true,
             oldgen: OldGen::new(),
             types: TypeRegistry::new(),
             roots: RootSet::new(),
@@ -735,17 +730,10 @@ impl MiniMarkGC {
     }
 
     /// Refresh the gc.py:525-531 published nursery-top slot from the real
-    /// allocator bound, unless free-threading has disabled the non-atomic
-    /// shared bump fast path.
+    /// allocator bound.
     fn refresh_published_nursery_top(&mut self) {
-        self.published_nursery_top.store(
-            if self.inline_alloc_enabled {
-                self.nursery.top_ptr() as usize
-            } else {
-                0
-            },
-            Ordering::Release,
-        );
+        self.published_nursery_top
+            .store(self.nursery.top_ptr() as usize, Ordering::Release);
     }
 
     // ── incminimark.py:1292-1308 card marking geometry ──
@@ -4876,11 +4864,6 @@ impl GcAllocator for MiniMarkGC {
         self.published_nursery_top.as_ptr() as usize
     }
 
-    fn set_inline_alloc_enabled(&mut self, enabled: bool) {
-        self.inline_alloc_enabled = enabled;
-        self.refresh_published_nursery_top();
-    }
-
     fn max_nursery_object_size(&self) -> usize {
         self.config.large_object_threshold
     }
@@ -5525,34 +5508,6 @@ mod tests {
         let obj = gc.alloc_nursery(16);
         assert!(!obj.is_null());
         assert!(gc.is_in_nursery(obj.0));
-    }
-
-    #[test]
-    fn disabled_inline_alloc_keeps_published_top_zero_without_disabling_allocator() {
-        let mut gc = test_gc(4096);
-        gc.register_type(TypeInfo::simple(16));
-        let published_addr = gc.nursery_top_addr();
-
-        gc.set_inline_alloc_enabled(false);
-        assert_eq!(
-            unsafe { &*(published_addr as *const AtomicUsize) }.load(Ordering::Acquire),
-            0
-        );
-        assert!(!gc.alloc_nursery(16).is_null());
-        assert!(!gc.alloc_with_type(0, 16).is_null());
-
-        gc.collect_nursery();
-        assert_eq!(
-            unsafe { &*(published_addr as *const AtomicUsize) }.load(Ordering::Acquire),
-            0
-        );
-        assert!(!gc.alloc_nursery(16).is_null());
-
-        gc.set_inline_alloc_enabled(true);
-        assert_eq!(
-            unsafe { &*(published_addr as *const AtomicUsize) }.load(Ordering::Acquire),
-            gc.nursery_top() as usize
-        );
     }
 
     #[test]

--- a/majit/majit-gc/src/gc_sync.rs
+++ b/majit/majit-gc/src/gc_sync.rs
@@ -237,7 +237,7 @@ pub fn register_thread() {
         !GC_THREAD.with(|t| t.registered.get()),
         "GC mutator thread registered twice"
     );
-    let old = REGISTERED_THREADS.fetch_add(1, Ordering::SeqCst);
+    REGISTERED_THREADS.fetch_add(1, Ordering::SeqCst);
 
     let mut state = GC_SYNC.quiesce.lock().unwrap();
     state = GC_SYNC
@@ -253,14 +253,6 @@ pub fn register_thread() {
     // `rgil.acquire_maybe_in_new_thread` (rgil.py:186-193). Everything below
     // this line already runs pyre code and so needs it held.
     crate::rgil::acquire_maybe_in_new_thread();
-
-    if old > 0 && is_initialized() {
-        // gc.py:525-531 publishes the nursery slots used by generated inline
-        // allocation. A shared free-threaded nursery cannot safely use its
-        // non-atomic bump sequence, so the 1→2 transition pins that path off.
-        // This is sticky: unregistering threads never republishes the top.
-        gc_op(|gc| gc.set_inline_alloc_enabled(false));
-    }
 }
 
 /// Unregister the current thread. It stops running pyre code, so it gives the
@@ -863,18 +855,23 @@ mod tests {
         unregister_test_mutator();
     }
 
+    /// gc.py:525-531 publishes the nursery slots unconditionally, and
+    /// `llsupport/gc.py:525-531 get_nursery_free_addr/get_nursery_top_addr`
+    /// have no thread-count gate: the non-atomic bump in generated code is safe
+    /// because the GIL serialises the mutators that run it.  A second mutator
+    /// must therefore leave the published top alone.
     #[test]
-    #[ignore = "requires exclusive process — mutates the sticky singleton inline-allocation state"]
-    fn second_registered_thread_pins_published_nursery_top() {
+    #[ignore = "requires exclusive process — registers process-global mutators"]
+    fn second_registered_thread_leaves_published_nursery_top_live() {
         ensure_gc();
         register_test_mutator();
-        assert_ne!(
-            gc_query(
-                |gc| unsafe { &*(gc.nursery_top_addr() as *const AtomicUsize) }
-                    .load(Ordering::Acquire)
-            ),
-            0
-        );
+        fn published_top() -> usize {
+            gc_query(|gc| {
+                unsafe { &*(gc.nursery_top_addr() as *const AtomicUsize) }.load(Ordering::Acquire)
+            })
+        }
+        let before = published_top();
+        assert_ne!(before, 0);
 
         let worker = std::thread::spawn(|| {
             register_test_mutator();
@@ -882,13 +879,7 @@ mod tests {
         });
         blocking(|| worker.join()).unwrap();
 
-        assert_eq!(
-            gc_query(
-                |gc| unsafe { &*(gc.nursery_top_addr() as *const AtomicUsize) }
-                    .load(Ordering::Acquire)
-            ),
-            0
-        );
+        assert_eq!(published_top(), before);
         unregister_test_mutator();
     }
 

--- a/majit/majit-gc/src/gc_sync.rs
+++ b/majit/majit-gc/src/gc_sync.rs
@@ -6,47 +6,29 @@
 //! unchanged inside the STW window — it already assumes a single-threaded
 //! world during collection.
 //!
-//! # The operation gate
+//! # The operation gate is the GIL
 //!
-//! Every GC operation (alloc, collect, barrier, query) runs under one word,
-//! `IN_FAST_PATH`, holding the claimant's ident — `rpy_fastgil`
-//! (thread_gil.c:1-31), down to the spelling of its protocol: a
-//! compare-and-swap claims it (`_rpygil_acquire_fast_path`,
-//! threadlocal.h:153-156), a plain store drops it (`_RPyGilRelease`,
-//! :163-167), and a thread recognises its own claim by comparing against its
-//! ident (thread_gil.c:19-21).
+//! GC operations (alloc, collect, barrier, query) take no lock of their own.
+//! Exclusion comes from [`crate::rgil`]: a thread holds the GIL for as long as
+//! it runs pyre code, so between two external calls arbitrarily many
+//! allocations run with no synchronisation, and [`gc_op`] is a bare borrow of
+//! the singleton — `malloc_fixedsize` bumps `nursery_free` under exactly the
+//! same terms (incminimark.py, framework.py:361-402).
 //!
-//! A claim **stands between operations**, as `rpy_fastgil` stays set for as
-//! long as its thread runs RPython code, so a repeated allocation only marks
-//! the claim it already holds instead of re-taking a free word. Only the sole
-//! registered mutator claims that way; once a second registers, claims are per
-//! operation and taken under `gc_mutex`.
-//!
-//! Upstream can leave a standing claim to its owner because every blocking
-//! call is `releasegil=True` and drops it. Pyre cannot assume that of arbitrary
-//! Rust blocking, so `revoke_standing_claim` takes it back instead, the way
-//! `RPyGilAcquireSlowPath` overwrites the holder's ident once it owns the real
-//! lock (:214-223). Waiting therefore never depends on the holder running
-//! again.
-//!
-//! What upstream reads off `mutex_gil` — whether the claimant is *using* the
-//! GIL or merely holding it — pyre keeps in `GATE_INSIDE`, the low bit of the
-//! same word. Upstream needs no such distinction (holding the GIL is being
-//! inside the GC); pyre does, because its collector re-enters for read-only
-//! queries. Keeping it in the claim makes entering one compare-and-swap and
-//! revocation one failed compare-and-swap, with no second word to interlock
-//! against.
+//! The GIL is therefore the safepoint too. A thread that does not hold it is
+//! either waiting for it in `RPyGilAcquireSlowPath` or blocked in an external
+//! call, and both leave the RUNNING census — so a collector, which by
+//! definition holds the GIL, never waits for a thread that is running pyre
+//! code.
 //!
 //! # Design
 //!
-//! This is not a GIL: the gate spans GC operations, not Python execution, and
-//! it is revocable by any thread that wants it. Collection begins only when
-//! every other registered thread is at an entry-style safepoint where all of
-//! its live GC references are rooted. A slow `gc_op` leaves RUNNING before
-//! blocking on `gc_mutex`, then rejoins RUNNING before its closure executes. A
-//! dispatch poll parks directly. There is no exit safepoint: a returned
-//! reference remains protected until the caller roots it before its next
-//! collection-capable call.
+//! Collection begins only when every other registered thread is at an
+//! entry-style safepoint where all of its live GC references are rooted.
+//! Waiting for the GIL and entering an external block are both such
+//! safepoints; a dispatch poll parks directly. There is no exit safepoint: a
+//! returned reference remains protected until the caller roots it before its
+//! next collection-capable call.
 
 use std::cell::{Cell, UnsafeCell};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
@@ -58,9 +40,8 @@ use crate::collector::MiniMarkGC;
 use crate::GcAllocator;
 
 /// Process-global GC singleton storage.
-/// `UnsafeCell` provides interior mutability; access is serialised by
-/// `GC_SYNC.gc_mutex`. `Sync` is sound because all `&mut` access goes
-/// through the mutex.
+/// `UnsafeCell` provides interior mutability; access is serialised by the GIL.
+/// `Sync` is sound because every `&mut` is formed by its holder.
 ///
 /// The collector is named concretely rather than held behind
 /// `dyn GcAllocator`. `framework.py:132` resolves `GCClass` once from the
@@ -78,15 +59,16 @@ static GC_INITIALIZED: AtomicBool = AtomicBool::new(false);
 
 /// STW safepoint state.
 pub struct GcSync {
-    /// Mutex serialising all GC operations. Held briefly per alloc/barrier
-    /// (P0). Held for full STW duration during collection.
-    gc_mutex: Mutex<()>,
+    /// Serialises installation of the singleton itself, which happens before
+    /// the installing thread has taken the GIL. Every *use* of the singleton
+    /// is serialised by the GIL instead.
+    install_mutex: Mutex<()>,
     /// Set while a collector is draining other mutators to entry-style
-    /// safepoints. Cleared before the collector releases `gc_mutex`.
+    /// safepoints. Cleared when the collector's `StwGuard` is dropped.
     stw_requested: AtomicBool,
-    /// RUNNING registered-mutator count. A slow `gc_op` removes itself before
-    /// waiting on `gc_mutex`, so a mutex-holding collector can drain every
-    /// other mutator while remaining counted itself.
+    /// RUNNING registered-mutator count. A thread waiting for the GIL removes
+    /// itself for the wait, so a collector — which holds the GIL — can drain
+    /// every other mutator while remaining counted itself.
     quiesce: Mutex<QuiesceState>,
     /// Signalled whenever RUNNING decreases toward the collector-inclusive
     /// drain target (one when the collector is counted, otherwise zero).
@@ -103,7 +85,7 @@ struct QuiesceState {
 }
 
 static GC_SYNC: GcSync = GcSync {
-    gc_mutex: Mutex::new(()),
+    install_mutex: Mutex::new(()),
     stw_requested: AtomicBool::new(false),
     quiesce: Mutex::new(QuiesceState { running: 0 }),
     quiesced: Condvar::new(),
@@ -121,12 +103,13 @@ pub fn store_singleton(gc: Box<MiniMarkGC>) {
     if GC_INITIALIZED.load(Ordering::Acquire) {
         return;
     }
-    let _guard = GC_SYNC.gc_mutex.lock().unwrap();
+    let _guard = GC_SYNC.install_mutex.lock().unwrap();
     // Double-check after acquiring mutex.
     if GC_INITIALIZED.load(Ordering::Acquire) {
         return;
     }
-    // SAFETY: gc_mutex held, no concurrent access.
+    // SAFETY: install_mutex held and no mutator has registered yet, so there is
+    // no concurrent access.
     unsafe {
         *GC_STORE.0.get() = Some(gc);
         crate::publish_singleton_nursery(&**(*GC_STORE.0.get()).as_ref().unwrap());
@@ -144,9 +127,9 @@ pub fn store_singleton(gc: Box<MiniMarkGC>) {
 /// oldgen residue or stale registered roots cannot corrupt this test's
 /// collections.
 pub fn replace_singleton_leaking_old(gc: Box<MiniMarkGC>) {
-    let _guard = GC_SYNC.gc_mutex.lock().unwrap();
-    // SAFETY: gc_mutex held; the gc_stress harness runs tests serially, so no
-    // concurrent gc_op is in flight during the swap.
+    let _guard = GC_SYNC.install_mutex.lock().unwrap();
+    // SAFETY: install_mutex held; the gc_stress harness runs tests serially, so
+    // no concurrent gc_op is in flight during the swap.
     unsafe {
         if let Some(old) = (*GC_STORE.0.get()).take() {
             std::mem::forget(old);
@@ -162,10 +145,10 @@ pub fn is_initialized() -> bool {
     GC_INITIALIZED.load(Ordering::Acquire)
 }
 
-/// Access the GC singleton mutably under gc_mutex protection.
-/// SAFETY: caller must hold gc_mutex.
+/// Access the GC singleton mutably.
+/// SAFETY: caller must hold the GIL.
 unsafe fn singleton_mut() -> &'static mut MiniMarkGC {
-    // SAFETY: caller holds gc_mutex, so there is no concurrent access.
+    // SAFETY: caller holds the GIL, so there is no concurrent access.
     unsafe { &mut *GC_STORE.0.get() }
         .as_deref_mut()
         .expect("GC singleton not initialized — call store_singleton() first")
@@ -177,18 +160,14 @@ unsafe fn singleton_mut() -> &'static mut MiniMarkGC {
 
 /// Per-thread GC-sync facts, kept in one struct like pypy_threadlocal_s
 /// (threadlocal.c:46-97). Its address doubles as this thread's ident in
-/// [`IN_FAST_PATH`] and [`STW_OWNER`], mirroring how _rpygil_get_my_ident reads
+/// `rpy_fastgil` and [`STW_OWNER`], mirroring how _rpygil_get_my_ident reads
 /// the ident out of the threadlocal struct (threadlocal.h:143-146).
-///
-/// Aligned so that idents leave [`GATE_INSIDE`] free; the fields alone would
-/// give this struct alignment 1.
-#[repr(align(8))]
 struct GcThreadState {
     /// Completed `register_thread`, represented in the RUNNING count.
     registered: Cell<bool>,
-    /// Registered mutators are normally RUNNING. Outermost slow gc_op
-    /// regions waiting on gc_mutex and dispatch safepoint parks flip this
-    /// to false.
+    /// Registered mutators are normally RUNNING. Waiting for the GIL,
+    /// entering an external block, and dispatch safepoint parks flip this to
+    /// false.
     running: Cell<bool>,
 }
 
@@ -201,7 +180,7 @@ thread_local! {
 /// Stable nonzero ident of the current thread: the address of its
 /// `GC_THREAD` struct.
 #[inline]
-fn my_ident() -> usize {
+pub(crate) fn my_ident() -> usize {
     GC_THREAD.with(|t| t as *const GcThreadState as usize)
 }
 
@@ -211,37 +190,15 @@ fn my_ident() -> usize {
 static STW_OWNER: AtomicUsize = AtomicUsize::new(0);
 static STW_DEPTH: AtomicUsize = AtomicUsize::new(0);
 
-/// Restores [`IN_FAST_PATH`] on both normal return and unwind: to the bare
-/// ident for a claim that goes on standing, to 0 for one taken per operation.
-struct GateGuard {
-    restore: usize,
-}
-impl Drop for GateGuard {
-    #[inline]
-    fn drop(&mut self) {
-        IN_FAST_PATH.store(self.restore, Ordering::Release);
-    }
-}
-
-/// Whether this thread is already inside a `gc_op` / `request_stw` closure
-/// (i.e. a collection is running on this thread and holds the `&mut`). The
-/// `rpy_fastgil == get_ident()` idiom (thread_gil.c:19-21), read against the
-/// in-use form of this thread's claim.
-#[inline]
-pub fn in_gc_op() -> bool {
-    IN_FAST_PATH.load(Ordering::Relaxed) == my_ident() | GATE_INSIDE
-}
-
 /// Shared reference to the singleton, re-derived from the static `UnsafeCell`.
 ///
-/// SAFETY: only sound when [`in_gc_op`] holds on this thread — the collector
-/// already owns the exclusive `&mut`, all other mutators are parked (STW) or
-/// spinning (single-thread fast path), and the returned `&dyn` is used only for
-/// a read-only query whose lifetime ends before control returns to the
-/// collector. Re-derives from `GC_STORE.0.get()` each call (a pre-`&mut`-cached
-/// raw pointer would be invalidated by `singleton_mut`'s reborrow).
+/// SAFETY: only sound while this thread holds the GIL — no other mutator can
+/// then be running pyre code, and the returned reference is used only for a
+/// read-only query whose lifetime ends before control returns. Re-derives from
+/// `GC_STORE.0.get()` each call (a pre-`&mut`-cached raw pointer would be
+/// invalidated by `singleton_mut`'s reborrow).
 #[inline]
-unsafe fn singleton_ref_reentrant() -> &'static MiniMarkGC {
+unsafe fn singleton_ref() -> &'static MiniMarkGC {
     unsafe { &*GC_STORE.0.get() }
         .as_deref()
         .expect("GC singleton not initialized — call store_singleton() first")
@@ -250,135 +207,37 @@ unsafe fn singleton_ref_reentrant() -> &'static MiniMarkGC {
 /// Read-only query that is safe both at top level and reentrantly from inside a
 /// collection (an extra-root walker's `gc_owns_object` / ownership query).
 ///
-/// Top level (`!in_gc_op()`): takes the fully-synchronised [`gc_query`] path.
-/// Reentrant (`in_gc_op()`): reads the singleton directly, without re-locking
-/// `gc_mutex` (which would deadlock — the lock is non-recursive and, under STW,
-/// held by this very collector) or forming a second `&mut`.
+/// It cannot go through [`gc_op`]: a collection in progress already holds the
+/// exclusive `&mut`, and forming a second one from inside its own root walk
+/// would alias it. Holding the GIL is what makes the shared borrow sound in
+/// both cases.
 #[inline]
 pub fn gc_query_reentrant<R>(f: impl FnOnce(&MiniMarkGC) -> R) -> R {
-    if in_gc_op() {
-        // SAFETY: in_gc_op() ⇒ this thread holds the &mut and is the sole
-        // running mutator (parked/spinning invariant); read-only, bounded to `f`.
-        f(unsafe { singleton_ref_reentrant() })
-    } else {
-        gc_query(f)
-    }
+    debug_assert!(
+        crate::rgil::am_i_holding_the_gil(),
+        "a GC query needs the GIL"
+    );
+    // SAFETY: the GIL is held, so no other mutator is running pyre code;
+    // read-only and bounded to `f`.
+    f(unsafe { singleton_ref() })
 }
 
 // ──────────────────────────────────────────────────────────────
-// Mutator registry — single-thread fast path
+// Mutator registry
 // ──────────────────────────────────────────────────────────────
 
 /// Number of threads that have called `register_thread` and not yet
-/// `unregister_thread`.  When ≤ 1, `gc_op` skips the Mutex entirely.
+/// `unregister_thread`.
 static REGISTERED_THREADS: AtomicUsize = AtomicUsize::new(0);
 
-/// Fast-path lock word: 0 when free, otherwise the claimant's ident
-/// (`my_ident`) with [`GATE_INSIDE`] set while it is running a closure,
-/// following rpy_fastgil (thread_gil.c:7-31). Self-ownership is checked by
-/// comparing against `my_ident()`.
-///
-/// A claim stands across operations, the way `rpy_fastgil` stays set for as
-/// long as its thread runs RPython code (thread_gil.c:15-21). Only the fast
-/// path claims it that way; [`gc_op_slow`] claims and drops it per operation,
-/// so the word is transiently nonzero in multi-mutator runs too. A standing
-/// claim is dropped by its owner ([`release_gate`]) or taken from it
-/// ([`revoke_standing_claim`]).
-static IN_FAST_PATH: AtomicUsize = AtomicUsize::new(0);
-
-/// Set in [`IN_FAST_PATH`] while the claimant is inside a `gc_op` closure, so
-/// the claim and the exclusive `&mut` live in one word. Upstream needs no such
-/// bit — holding `rpy_fastgil` *is* being inside the GC — but pyre's collector
-/// re-enters for read-only queries ([`gc_query_reentrant`]) and has to tell the
-/// two states apart. Keeping it in the claim makes entering a claimed gate one
-/// compare-and-swap, and makes revocation a plain failed CAS instead of a
-/// cross-word handshake.
-const GATE_INSIDE: usize = 1;
-
-const _: () = assert!(
-    std::mem::align_of::<GcThreadState>() > GATE_INSIDE,
-    "idents must leave GATE_INSIDE free"
-);
-
-/// Drop this thread's standing claim, if it still has one.
-///
-/// `_RPyGilRelease` (threadlocal.h:163-167) is a plain store because upstream's
-/// word is only ever cleared by its owner. A standing claim here can also be
-/// revoked while its owner sits idle, so the release is a compare-and-swap:
-/// a plain store would drop whichever claim replaced it. Off the hot path —
-/// a standing claim is carried, not re-taken.
-#[inline]
-fn release_gate(ident: usize) {
-    let _ = IN_FAST_PATH.compare_exchange(ident, 0, Ordering::Release, Ordering::Relaxed);
-}
-
-/// Take a standing claim away from a thread that is not using it, so waiting
-/// never depends on the holder running again.
-///
-/// `RPyGilAcquireSlowPath` ends by overwriting whatever ident `rpy_fastgil`
-/// holds (thread_gil.c:214-223); it is safe there because `mutex_gil`, not the
-/// word, is the real exclusion. Here the exclusion is [`GATE_INSIDE`] in the
-/// same word, so the revoke is one compare-and-swap against the idle form of
-/// the claim: it fails outright while a closure is running, and a closure can
-/// only start by winning that same word.
-///
-/// The caller must hold `gc_mutex`, so no slow operation can be running and the
-/// word can only be carrying a standing claim. The cleared word may be
-/// re-claimed immediately by the revoked thread when it is still the only
-/// registered mutator; [`acquire_gate`] loops for that case.
-fn revoke_standing_claim(ident: usize) {
-    loop {
-        let claim = IN_FAST_PATH.load(Ordering::Acquire);
-        if claim == 0 || claim & !GATE_INSIDE == ident {
-            return;
-        }
-        if claim & GATE_INSIDE == 0
-            && IN_FAST_PATH
-                .compare_exchange(claim, 0, Ordering::AcqRel, Ordering::Acquire)
-                .is_ok()
-        {
-            return;
-        }
-        // In use: the closure publishes the idle form when it returns.
-        std::hint::spin_loop();
-    }
-}
-
-/// Claim the gate for `ident` and mark it in use, revoking a standing claim if
-/// one is in the way — the stealer loop of `RPyGilAcquireSlowPath`
-/// (thread_gil.c:203-223). Callers hold `gc_mutex`, which excludes every other
-/// slow claimant.
-fn acquire_gate(ident: usize) {
-    loop {
-        if IN_FAST_PATH
-            .compare_exchange(0, ident | GATE_INSIDE, Ordering::Acquire, Ordering::Relaxed)
-            .is_ok()
-        {
-            return;
-        }
-        revoke_standing_claim(ident);
-        std::hint::spin_loop();
-    }
-}
-
-/// Register the current thread as a GC mutator. Paired with
-/// `unregister_thread`. An unregistered thread may still call `gc_op`; it is
-/// not counted for STW, but serialises through the same operation gate.
+/// Register the current thread as a GC mutator and take the GIL, which it then
+/// holds for as long as it runs pyre code. Paired with `unregister_thread`.
 pub fn register_thread() {
     assert!(
         !GC_THREAD.with(|t| t.registered.get()),
         "GC mutator thread registered twice"
     );
     let old = REGISTERED_THREADS.fetch_add(1, Ordering::SeqCst);
-    if old > 0 {
-        // A second thread is arriving, so no standing claim may survive: from
-        // here on every caller sees REGISTERED_THREADS > 1 and takes the Mutex
-        // path. The count was raised first, so the previous holder cannot make
-        // a new standing claim once this one is revoked. `gc_mutex` is what
-        // `revoke_standing_claim` requires of its callers.
-        let _guard = GC_SYNC.gc_mutex.lock().unwrap();
-        revoke_standing_claim(my_ident());
-    }
 
     let mut state = GC_SYNC.quiesce.lock().unwrap();
     state = GC_SYNC
@@ -390,6 +249,11 @@ pub fn register_thread() {
     GC_THREAD.with(|t| t.registered.set(true));
     drop(state);
 
+    // os_thread.py:bootstrap takes the GIL as its first act, through
+    // `rgil.acquire_maybe_in_new_thread` (rgil.py:186-193). Everything below
+    // this line already runs pyre code and so needs it held.
+    crate::rgil::acquire_maybe_in_new_thread();
+
     if old > 0 && is_initialized() {
         // gc.py:525-531 publishes the nursery slots used by generated inline
         // allocation. A shared free-threaded nursery cannot safely use its
@@ -399,17 +263,17 @@ pub fn register_thread() {
     }
 }
 
-/// Unregister the current thread. Subsequent `gc_op` calls remain serialised,
-/// but this thread no longer participates in STW quiescence.
+/// Unregister the current thread. It stops running pyre code, so it gives the
+/// GIL back and no longer participates in STW quiescence.
 pub fn unregister_thread() {
     assert!(
         GC_THREAD.with(|t| t.registered.get()),
         "unregistering an unregistered GC mutator thread"
     );
-    // A thread that carried the gate out of its last operation must not take
-    // it with it: nothing would ever release it again.
-    if IN_FAST_PATH.load(Ordering::Relaxed) == my_ident() {
-        release_gate(my_ident());
+    // A thread that took the GIL with it would leave nothing to release it
+    // again — os_thread.py:bootstrap likewise ends on `rgil.release`.
+    if crate::rgil::am_i_holding_the_gil() {
+        crate::rgil::release();
     }
     let mut state = GC_SYNC.quiesce.lock().unwrap();
     assert!(
@@ -426,21 +290,32 @@ pub fn unregister_thread() {
     GC_SYNC.quiesced.notify_all();
 }
 
-/// Temporarily remove the current mutator from the RUNNING census while it
-/// blocks in an external operation.
+/// Drop the GIL and leave the RUNNING census while the mutator blocks in an
+/// external operation — `rffi.aroundstate.before()` /
+/// `gil.before_external_call()`.
 ///
-/// This is the free-threaded counterpart of RPython's
-/// `rffi.aroundstate.before()` / `gil.before_external_call()`: a thread which
-/// is asleep in `pthread_cond_wait`, `join`, or `nanosleep` cannot poll the
-/// eval breaker, so it must not remain in the set that a collector waits to
-/// drain.  Dropping the guard waits for an in-flight STW request to finish and
-/// then makes the mutator RUNNING again.
+/// **Every blocking call must go through this.** A thread asleep in
+/// `pthread_cond_wait`, `join`, or `nanosleep` while still holding the GIL
+/// stops every other mutator until it wakes, and if what it waits for is
+/// another mutator's progress, forever. It also cannot poll the eval breaker,
+/// so it must not remain in the set a collector waits to drain.
+///
+/// Dropping the guard retakes the GIL, waits out an in-flight STW request, and
+/// makes the mutator RUNNING again.
 pub struct BlockingGuard {
     registered: bool,
+    held_gil: bool,
 }
 
 impl Drop for BlockingGuard {
     fn drop(&mut self) {
+        // `rffi.aroundstate.after()` retakes the GIL on return from a
+        // `releasegil=True` call (`_RPyGilAcquire`, threadlocal.h:158-161).
+        // Before rejoining RUNNING, so that the wait for the GIL itself is
+        // spent outside the census a collector drains.
+        if self.held_gil {
+            crate::rgil::acquire();
+        }
         if !self.registered {
             return;
         }
@@ -460,12 +335,11 @@ impl Drop for BlockingGuard {
 #[inline]
 pub fn before_external_block() -> BlockingGuard {
     // `rffi.aroundstate.before()` drops the GIL before a `releasegil=True`
-    // call (`_RPyGilRelease`, threadlocal.h:163-167). Dropping the standing
-    // claim here is not required for progress — `revoke_standing_claim` takes
-    // it back from a sleeping thread — but it spares the next claimant that
-    // work at a point which is already a syscall away.
-    if IN_FAST_PATH.load(Ordering::Relaxed) == my_ident() {
-        release_gate(my_ident());
+    // call (`_RPyGilRelease`, threadlocal.h:162-166), so that a thread asleep
+    // in the external call holds nothing another mutator needs.
+    let held_gil = crate::rgil::am_i_holding_the_gil();
+    if held_gil {
+        crate::rgil::release();
     }
     let registered = GC_THREAD.with(|t| t.registered.get());
     if registered {
@@ -480,7 +354,50 @@ pub fn before_external_block() -> BlockingGuard {
             .expect("RUNNING underflow entering external block");
         GC_SYNC.quiesced.notify_all();
     }
-    BlockingGuard { registered }
+    BlockingGuard {
+        registered,
+        held_gil,
+    }
+}
+
+/// Leave the RUNNING census for the duration of a wait for the GIL, and report
+/// whether rejoining is this caller's job.
+///
+/// A thread which does not hold the GIL runs no pyre code, so a collector must
+/// not wait for it. Upstream needs no counterpart: there the collector *is* the
+/// GIL holder, so waiting for the GIL and being drained are the same state.
+pub(crate) fn leave_running_for_gil() -> GilCensus {
+    if !GC_THREAD.with(|t| t.registered.get() && t.running.get()) {
+        return GilCensus { rejoin: false };
+    }
+    let mut state = GC_SYNC.quiesce.lock().unwrap();
+    GC_THREAD.with(|t| t.running.set(false));
+    state.running = state
+        .running
+        .checked_sub(1)
+        .expect("RUNNING underflow entering a GIL wait");
+    GC_SYNC.quiesced.notify_all();
+    GilCensus { rejoin: true }
+}
+
+/// Rejoin the RUNNING census after [`leave_running_for_gil`]. The caller now
+/// holds the GIL, and a collector requesting STW holds it too, so there is
+/// never a pending request to wait out here.
+pub(crate) fn rejoin_running_after_gil(census: GilCensus) {
+    if !census.rejoin {
+        return;
+    }
+    let mut state = GC_SYNC.quiesce.lock().unwrap();
+    debug_assert!(
+        !GC_SYNC.stw_requested.load(Ordering::Acquire),
+        "the GIL was acquired while a collector was draining mutators"
+    );
+    state.running += 1;
+    GC_THREAD.with(|t| t.running.set(true));
+}
+
+pub(crate) struct GilCensus {
+    rejoin: bool,
 }
 
 /// Number of registered GC mutators.
@@ -498,7 +415,9 @@ pub fn after_fork_child() {
     let registered = GC_THREAD.with(|t| t.registered.get());
     let running = GC_THREAD.with(|t| t.running.get());
     REGISTERED_THREADS.store(usize::from(registered), Ordering::SeqCst);
-    IN_FAST_PATH.store(0, Ordering::Release);
+    // `fork()` runs inside `request_stw`, so this thread held the GIL across
+    // it and still does; only the queue behind it has to be rebuilt.
+    crate::rgil::after_fork_child();
     STW_OWNER.store(0, Ordering::SeqCst);
     STW_DEPTH.store(0, Ordering::SeqCst);
     GC_SYNC.stw_requested.store(false, Ordering::Release);
@@ -524,131 +443,57 @@ pub fn stw_required() -> bool {
 }
 
 // ──────────────────────────────────────────────────────────────
-// GC operation gate — fast path when single-threaded
+// GC operations — unsynchronised under the GIL
 // ──────────────────────────────────────────────────────────────
 
 /// Execute a closure with exclusive `&mut MiniMarkGC` access.
 ///
-/// **Fast path** (single registered thread, no STW): direct access under
-/// `IN_FAST_PATH`, without taking the Mutex. A claim this thread already holds
-/// carries over from the previous operation, so the steady state is the single
-/// compare-and-swap that marks it in use.
+/// The caller holds the GIL — it has held it since it started running pyre
+/// code — so this is a bare borrow of the singleton with no atomic and no
+/// thread-ident read. `malloc_fixedsize` is unsynchronised for the same
+/// reason: framework.py's `malloc_fast` (:361-402) bumps `nursery_free` with
+/// nothing but the GIL behind it.
 ///
-/// **Slow path** (multiple threads or STW): acquires `gc_mutex`.
-/// Single-threaded production always takes the fast path.
+/// There is deliberately no exit safepoint. A returned reference is rooted by
+/// the caller before its next entry-style safepoint.
 #[inline]
 pub fn gc_op<R>(f: impl FnOnce(&mut MiniMarkGC) -> R) -> R {
-    let ident = my_ident();
     debug_assert!(
-        !in_gc_op(),
-        "reentrant &mut gc_op — a collection-time query must use gc_query_reentrant"
+        crate::rgil::am_i_holding_the_gil(),
+        "a GC operation needs the GIL"
     );
-    // This thread's claim is still standing. thread_gil.c:15-21 keeps
-    // `rpy_fastgil` set to the holder's ident for as long as it runs RPython
-    // code; re-acquiring once per operation has no upstream counterpart. One
-    // compare-and-swap both proves the claim survived revocation and publishes
-    // that a closure is running under it.
-    if IN_FAST_PATH
-        .compare_exchange(
-            ident,
-            ident | GATE_INSIDE,
-            Ordering::Acquire,
-            Ordering::Relaxed,
-        )
-        .is_ok()
-    {
-        // `stw_requested` needs no recheck: raising it requires owning the
-        // gate, and this thread owns it.
-        debug_assert!(
-            !GC_SYNC.stw_requested.load(Ordering::Relaxed),
-            "STW was requested by a thread that does not own the operation gate"
-        );
-        let _gate = GateGuard { restore: ident };
-        // SAFETY: the claim excludes every other fast and slow operation for
-        // as long as it stands.
-        return f(unsafe { singleton_mut() });
-    }
-    // First claim: threadlocal.h:153-156 `_rpygil_acquire_fast_path`. Reached
-    // once per standing claim, not once per operation.
-    if REGISTERED_THREADS.load(Ordering::Acquire) <= 1
-        && !GC_SYNC.stw_requested.load(Ordering::Acquire)
-        && IN_FAST_PATH
-            .compare_exchange(0, ident | GATE_INSIDE, Ordering::Acquire, Ordering::Relaxed)
-            .is_ok()
-    {
-        // Recheck under the claim: another thread may have registered or
-        // requested STW after the eligibility loads above.
-        if REGISTERED_THREADS.load(Ordering::Acquire) <= 1
-            && !GC_SYNC.stw_requested.load(Ordering::Acquire)
-        {
-            let _gate = GateGuard { restore: ident };
-            // SAFETY: as above — the claim is this thread's.
-            return f(unsafe { singleton_mut() });
-        }
-        // Ineligible after all — drop the claim entirely rather than leaving
-        // it standing for the slow path, which claims the gate again. Nothing
-        // else can touch the word while it is marked in use.
-        IN_FAST_PATH.store(0, Ordering::Release);
-    }
-    gc_op_slow(f)
+    let _reentry = ReentryGuard::enter();
+    // SAFETY: the GIL excludes every other mutator from running pyre code.
+    f(unsafe { singleton_mut() })
 }
 
-/// Slow path: Mutex-guarded access with STW parking.
-#[cold]
-fn gc_op_slow<R>(f: impl FnOnce(&mut MiniMarkGC) -> R) -> R {
-    let ident = my_ident();
-    let registered = GC_THREAD.with(|t| t.registered.get());
-    if registered {
-        let mut state = GC_SYNC.quiesce.lock().unwrap();
+/// Catches a second `&mut` formed from inside a collection, which the GIL
+/// cannot rule out because both borrows belong to the same thread. Only the
+/// GIL holder can reach it, so one plain global replaces per-thread state —
+/// and it compiles away entirely outside debug builds.
+struct ReentryGuard;
+
+#[cfg(debug_assertions)]
+static IN_GC_OP: AtomicBool = AtomicBool::new(false);
+
+impl ReentryGuard {
+    #[inline]
+    fn enter() -> Self {
+        #[cfg(debug_assertions)]
         assert!(
-            GC_THREAD.with(|t| t.running.replace(false)),
-            "GC mutator entered a gc_op safepoint twice"
+            !IN_GC_OP.swap(true, Ordering::Relaxed),
+            "reentrant &mut gc_op — a collection-time query must use gc_query_reentrant"
         );
-        state.running = state
-            .running
-            .checked_sub(1)
-            .expect("RUNNING underflow entering gc_op safepoint");
-        GC_SYNC.quiesced.notify_all();
+        ReentryGuard
     }
+}
 
-    // Blocking on gc_mutex is the park: this thread is already excluded from
-    // RUNNING, so a collector can hold the mutex while draining other threads.
-    let _guard = GC_SYNC.gc_mutex.lock().unwrap();
-
-    // Take the gate before borrowing the singleton. A fast claimant never waits
-    // on gc_mutex, and `acquire_gate` revokes a standing claim rather than
-    // waiting for its owner, so this terminates. This is what makes fast and
-    // slow singleton accesses mutually exclusive.
-    let carried = IN_FAST_PATH.load(Ordering::Acquire) == ident;
-    let _gate = if carried {
-        // This thread's own standing claim: mark it in use and leave it
-        // standing afterwards, as the fast path would have.
-        IN_FAST_PATH.store(ident | GATE_INSIDE, Ordering::Release);
-        GateGuard { restore: ident }
-    } else {
-        acquire_gate(ident);
-        GateGuard { restore: 0 }
-    };
-
-    if registered {
-        let mut state = GC_SYNC.quiesce.lock().unwrap();
-        // An STW requester holds gc_mutex and clears its request before
-        // releasing it, so a thread that acquired gc_mutex cannot need to wait.
-        debug_assert!(
-            !GC_SYNC.stw_requested.load(Ordering::Acquire),
-            "gc_mutex holder observed an active STW request"
-        );
-        state.running += 1;
-        assert!(
-            !GC_THREAD.with(|t| t.running.replace(true)),
-            "GC mutator re-entered RUNNING twice"
-        );
+impl Drop for ReentryGuard {
+    #[inline]
+    fn drop(&mut self) {
+        #[cfg(debug_assertions)]
+        IN_GC_OP.store(false, Ordering::Relaxed);
     }
-
-    // There is deliberately no exit park. A returned reference is rooted by the
-    // caller before its next entry-style safepoint, matching the single-thread
-    // allocation discipline.
-    f(unsafe { singleton_mut() })
 }
 
 /// Execute a closure with `&MiniMarkGC` access (read-only query).
@@ -754,11 +599,10 @@ pub fn request_stw(collect_fn: impl FnOnce(&mut MiniMarkGC)) {
 
 /// Run a GC operation whose object argument is a translated livevar.
 ///
-/// A contended [`gc_op`] temporarily removes this mutator from the RUNNING
-/// census before it acquires `gc_mutex`. Publish the argument on the
-/// per-mutator shadow stack first so a collector which runs during that wait
-/// preserves (and, for a moving minor, forwards) it. Reload the possibly
-/// forwarded value only after the operation owns the GC.
+/// Publish the argument on the per-mutator shadow stack first, so that a
+/// collection driven from inside the operation preserves (and, for a moving
+/// minor, forwards) it. Reload the possibly forwarded value only after the
+/// operation owns the GC.
 pub fn gc_op_with_root<R>(
     root: crate::GcRef,
     f: impl FnOnce(&mut MiniMarkGC, crate::GcRef) -> R,
@@ -778,13 +622,13 @@ pub fn gc_op_with_root<R>(
 }
 
 /// Register a caller-owned root slot without leaving its current value
-/// unprotected while a contended GC operation parks this mutator.
+/// unprotected across the registering operation.
 ///
 /// RPython publishes shadow-stack roots before entering a collecting slow
 /// path.  Pyre's host frames additionally register long-lived slots in
-/// [`crate::RootSet`]; the registration itself must use the same ordering or
-/// a collector already holding `gc_mutex` can reclaim the value before the
-/// slot becomes visible in that set.
+/// [`crate::RootSet`]; the registration itself must use the same ordering or a
+/// collection can reclaim the value before the slot becomes visible in that
+/// set.
 ///
 /// # Safety
 /// `slot` must remain valid for this call and until the matching
@@ -884,6 +728,14 @@ mod tests {
         unregister_thread();
     }
 
+    /// A mutator that blocks lets go of the GIL first — every
+    /// `releasegil=True` call does, and a test mutator that does not deadlocks
+    /// every thread waiting to register behind it.
+    fn blocking<R>(f: impl FnOnce() -> R) -> R {
+        let _blocked = before_external_block();
+        f()
+    }
+
     fn load_eval_breaker_word() -> usize {
         let addr = majit_ir::eval_breaker_word::eval_breaker_word_addr();
         assert_ne!(addr, 0);
@@ -978,6 +830,9 @@ mod tests {
     fn registered_and_unregistered_gc_ops_are_mutually_exclusive() {
         ensure_gc();
         register_test_mutator();
+        // Registration leaves the GIL standing on this thread. Hand it back so
+        // both threads contend for it once per operation.
+        crate::rgil::release();
 
         const OPS_PER_THREAD: usize = 100_000;
         let counter = Arc::new(GcOpCounter(UnsafeCell::new(0)));
@@ -986,10 +841,11 @@ mod tests {
             let counter = counter.clone();
             let start = start.clone();
             std::thread::spawn(move || {
-                // An unregistered thread's gc_op is legal and must serialize
-                // through the same fast-path lock as a registered caller.
+                // An unregistered thread's gc_op is legal, but like every other
+                // caller it has to take the GIL first.
                 start.wait();
                 for _ in 0..OPS_PER_THREAD {
+                    let _gil = crate::rgil::GilGuard::acquire();
                     gc_op(|_| unsafe { *counter.0.get() += 1 });
                 }
             })
@@ -997,10 +853,12 @@ mod tests {
 
         start.wait();
         for _ in 0..OPS_PER_THREAD {
+            let _gil = crate::rgil::GilGuard::acquire();
             gc_op(|_| unsafe { *counter.0.get() += 1 });
         }
         worker.join().unwrap();
 
+        crate::rgil::acquire();
         assert_eq!(unsafe { *counter.0.get() }, OPS_PER_THREAD * 2);
         unregister_test_mutator();
     }
@@ -1018,12 +876,11 @@ mod tests {
             0
         );
 
-        std::thread::spawn(|| {
+        let worker = std::thread::spawn(|| {
             register_test_mutator();
             unregister_test_mutator();
-        })
-        .join()
-        .unwrap();
+        });
+        blocking(|| worker.join()).unwrap();
 
         assert_eq!(
             gc_query(
@@ -1050,7 +907,7 @@ mod tests {
                 let b = barrier.clone();
                 std::thread::spawn(move || {
                     register_test_mutator();
-                    b.wait();
+                    blocking(|| b.wait());
                     for _ in 0..100 {
                         gc_op(|_gc| {
                             // Simulate work under GC lock
@@ -1064,10 +921,10 @@ mod tests {
             .collect();
 
         for h in handles {
-            h.join().unwrap();
+            blocking(|| h.join()).unwrap();
         }
 
-        // With gc_mutex serialisation, counter should be exactly 200.
+        // With the GIL serialising every operation, the counter is exactly 200.
         assert_eq!(counter.load(Ordering::Relaxed), 200);
         unregister_test_mutator();
     }
@@ -1080,18 +937,15 @@ mod tests {
 
         let stw_ran = Arc::new(AtomicBool::new(false));
         let stw_ran2 = stw_ran.clone();
+        let arrived = Arc::new(AtomicBool::new(false));
+        let arrived2 = arrived.clone();
 
-        // Spawn a thread that will try gc_op while STW is in progress.
-        let barrier = Arc::new(Barrier::new(2));
-        let b2 = barrier.clone();
-
+        // The collector holds the GIL for the whole episode, so this thread
+        // cannot reach its gc_op until the collection has finished and handed
+        // the GIL back — registering is where it waits.
         let worker = std::thread::spawn(move || {
+            arrived2.store(true, Ordering::Release);
             register_test_mutator();
-            b2.wait();
-            while !GC_SYNC.stw_requested.load(Ordering::Acquire) {
-                std::hint::spin_loop();
-            }
-            // This gc_op should block until STW finishes.
             gc_op(|_gc| {
                 assert!(
                     stw_ran2.load(Ordering::Acquire),
@@ -1101,15 +955,17 @@ mod tests {
             unregister_test_mutator();
         });
 
-        barrier.wait();
+        while !arrived.load(Ordering::Acquire) {
+            std::hint::spin_loop();
+        }
         request_stw(|_gc| {
             stw_ran.store(true, Ordering::Release);
             // Simulate collection work.
             std::thread::sleep(std::time::Duration::from_millis(20));
         });
 
-        worker.join().unwrap();
         unregister_test_mutator();
+        worker.join().unwrap();
     }
 
     #[test]
@@ -1136,10 +992,10 @@ mod tests {
             let finished = finished.clone();
             std::thread::spawn(move || {
                 register_test_mutator();
-                start.wait();
+                blocking(|| start.wait());
                 while finished.load(Ordering::Acquire) != MUTATORS {
                     gc_op(|gc| gc.collect_nursery());
-                    std::thread::yield_now();
+                    blocking(std::thread::yield_now);
                 }
                 unregister_test_mutator();
             })
@@ -1151,7 +1007,7 @@ mod tests {
                 let finished = finished.clone();
                 std::thread::spawn(move || {
                     register_test_mutator();
-                    start.wait();
+                    blocking(|| start.wait());
 
                     for round in 0..ROUNDS {
                         let expected =
@@ -1159,9 +1015,10 @@ mod tests {
                         let fresh = gc_op(|gc| gc.alloc_nursery_typed(0, 16));
                         unsafe { *(fresh.0 as *mut u64) = expected };
 
-                        // Widen the allocation-return window. Collection must
-                        // wait for the next entry safepoint, after this fresh
-                        // reference has been installed in the shadow stack.
+                        // Widen the allocation-return window. Holding the GIL
+                        // is what keeps this still-unrooted reference alive
+                        // until it reaches the shadow stack — so this yield is
+                        // deliberately *not* a `blocking` one.
                         std::thread::yield_now();
                         let root_depth = crate::shadow_stack::push(fresh);
                         gc_op(|gc| {
@@ -1208,7 +1065,7 @@ mod tests {
                 let start = start.clone();
                 std::thread::spawn(move || {
                     register_test_mutator();
-                    start.wait();
+                    blocking(|| start.wait());
 
                     let expected = 0xCAFE_0000_0000_0000u64 | thread_index as u64;
                     let root_depth = gc_op(|gc| {
@@ -1287,14 +1144,18 @@ mod tests {
                         let object = crate::shadow_stack::get(root_depth);
                         assert_eq!(unsafe { *(object.0 as *const u64) }, EXPECTED);
                     });
-                    std::thread::yield_now();
+                    // Let the collector thread in: it can only take the GIL
+                    // once this mutator gives it up.
+                    blocking(std::thread::yield_now);
                 }
                 while !done.load(Ordering::Acquire) {
                     gc_op(|_gc| {
                         let object = crate::shadow_stack::get(root_depth);
                         assert_eq!(unsafe { *(object.0 as *const u64) }, EXPECTED);
                     });
-                    std::thread::yield_now();
+                    // Let the collector thread in: it can only take the GIL
+                    // once this mutator gives it up.
+                    blocking(std::thread::yield_now);
                 }
                 gc_op(|_gc| {
                     let object = crate::shadow_stack::get(root_depth);
@@ -1307,7 +1168,7 @@ mod tests {
         };
 
         while !ready.load(Ordering::Acquire) {
-            std::thread::yield_now();
+            blocking(std::thread::yield_now);
         }
         for _ in 0..3 {
             gc_op(|gc| {
@@ -1323,7 +1184,7 @@ mod tests {
         }
 
         done.store(true, Ordering::Release);
-        worker.join().unwrap();
+        blocking(|| worker.join()).unwrap();
         unregister_test_mutator();
         assert_eq!(registered_threads(), 0);
     }

--- a/majit/majit-gc/src/gc_sync.rs
+++ b/majit/majit-gc/src/gc_sync.rs
@@ -209,8 +209,10 @@ unsafe fn singleton_ref() -> &'static MiniMarkGC {
 ///
 /// It cannot go through [`gc_op`]: a collection in progress already holds the
 /// exclusive `&mut`, and forming a second one from inside its own root walk
-/// would alias it. Holding the GIL is what makes the shared borrow sound in
-/// both cases.
+/// would alias it. Holding the GIL is what rules out a *second thread*; what
+/// rules out the aliasing on this one is that the shared borrow dies with `f`
+/// and `f` reads only. A caller which resumed using the collection's `&mut`
+/// during `f` would still be forming overlapping borrows.
 #[inline]
 pub fn gc_query_reentrant<R>(f: impl FnOnce(&MiniMarkGC) -> R) -> R {
     debug_assert!(
@@ -294,9 +296,13 @@ pub fn unregister_thread() {
 ///
 /// Dropping the guard retakes the GIL, waits out an in-flight STW request, and
 /// makes the mutator RUNNING again.
+#[must_use = "the GIL is only released for as long as the guard is alive"]
 pub struct BlockingGuard {
     registered: bool,
     held_gil: bool,
+    /// The guard hands the GIL back to the thread that released it, and
+    /// rejoins *that* thread's census entry, so it must not cross threads.
+    _not_send: std::marker::PhantomData<*const ()>,
 }
 
 impl Drop for BlockingGuard {
@@ -349,6 +355,7 @@ pub fn before_external_block() -> BlockingGuard {
     BlockingGuard {
         registered,
         held_gil,
+        _not_send: std::marker::PhantomData,
     }
 }
 

--- a/majit/majit-gc/src/lib.rs
+++ b/majit/majit-gc/src/lib.rs
@@ -1028,7 +1028,7 @@ impl GcAllocator for GcHandle {
         gc_sync::gc_op(|gc| gc.disable())
     }
     fn isenabled(&self) -> bool {
-        gc_sync::gc_query(|gc| gc.isenabled())
+        gc_sync::gc_query_reentrant(|gc| gc.isenabled())
     }
     fn register_finalizer(&mut self, fq_index: usize, obj: GcRef, trigger: FinalizerTriggerFn) {
         gc_sync::gc_op(|gc| gc.register_finalizer(fq_index, obj, trigger))

--- a/majit/majit-gc/src/lib.rs
+++ b/majit/majit-gc/src/lib.rs
@@ -582,13 +582,6 @@ pub trait GcAllocator: Send {
     /// Address of the published nursery_top slot that JIT code reads.
     fn nursery_top_addr(&self) -> usize;
 
-    /// Enable or disable JIT inline nursery allocation.
-    ///
-    /// Collectors without a published nursery fast path need no action.
-    fn set_inline_alloc_enabled(&mut self, enabled: bool) {
-        let _ = enabled;
-    }
-
     /// Maximum size for nursery allocation (larger objects go to old gen directly).
     fn max_nursery_object_size(&self) -> usize;
 
@@ -1072,9 +1065,6 @@ impl GcAllocator for GcHandle {
     }
     fn nursery_top_addr(&self) -> usize {
         gc_sync::gc_query_reentrant(|gc| gc.nursery_top_addr())
-    }
-    fn set_inline_alloc_enabled(&mut self, enabled: bool) {
-        gc_sync::gc_op(|gc| gc.set_inline_alloc_enabled(enabled))
     }
     fn max_nursery_object_size(&self) -> usize {
         gc_sync::gc_query_reentrant(|gc| gc.max_nursery_object_size())

--- a/majit/majit-gc/src/lib.rs
+++ b/majit/majit-gc/src/lib.rs
@@ -21,6 +21,7 @@ pub mod minimarkpage;
 pub mod nursery;
 pub mod oldgen;
 pub mod rewrite;
+pub mod rgil;
 pub mod shadow_stack;
 pub mod trace;
 pub mod weakref;
@@ -877,17 +878,16 @@ pub trait GcAllocator: Send {
 
 /// Forwarding handle to the process-global GC singleton via `gc_sync`.
 ///
-/// `&mut self` methods route through `gc_sync::gc_op` (mutex-guarded);
-/// `&self` read-only queries route through `gc_sync::gc_query_reentrant` so
-/// they stay correct when a collection-time extra-root walker re-enters the GC
-/// (ownership / type queries) while this thread already holds the `&mut` — a
-/// plain `gc_query` would re-lock the non-recursive `gc_mutex` (deadlock) or, on
-/// the fast path, form a second `&mut`. No raw pointer at this layer.
+/// `&mut self` methods route through `gc_sync::gc_op`; `&self` read-only
+/// queries route through `gc_sync::gc_query_reentrant` so they stay correct
+/// when a collection-time extra-root walker re-enters the GC (ownership / type
+/// queries) while this thread already holds the `&mut`, which a `&mut` path
+/// would alias. No raw pointer at this layer.
 ///
 /// # Thread safety
 ///
-/// All `&mut self` methods acquire `gc_sync::gc_mutex` internally.
-/// Concurrent calls from different threads serialise correctly.
+/// Exclusion comes from the GIL (`rgil`), which the caller holds for
+/// as long as it runs pyre code, so these methods take no lock of their own.
 /// Collection uses STW safepoint protocol (`gc_sync::request_stw`).
 /// See gh#396 for the full free-threading GC design.
 pub struct GcHandle;

--- a/majit/majit-gc/src/rgil.rs
+++ b/majit/majit-gc/src/rgil.rs
@@ -1,0 +1,357 @@
+//! rgil — the GIL.
+//!
+//! Ported from thread_gil.c, its fast path in threadlocal.h:150-170, and the
+//! rgil.py surface that drives it.
+//!
+//! # The composite lock (thread_gil.c:2-31)
+//!
+//! "The GIL" is two locks, and it is held when both are locked:
+//!
+//! 1. [`RPY_FASTGIL`], a plain word. 0 means unlocked; otherwise it holds the
+//!    ident of the owning thread, so a thread checks whether it owns the GIL
+//!    with `rpy_fastgil == get_ident()`.
+//! 2. [`MUTEX_GIL`], a regular mutex which the fast path never unlocks.
+//!
+//! Releasing is a plain store of 0; acquiring is a compare-and-swap against 0.
+//! Whoever loses the compare-and-swap enters [`acquire_slow_path`], becomes
+//! "the stealer" by taking [`MUTEX_GIL_STEALER`], and alternates between
+//! retrying the fast path and a timed wait on [`MUTEX_GIL`].
+//!
+//! # Lifetime
+//!
+//! A thread holds the GIL for as long as it runs pyre code, not for the
+//! duration of one GC operation: it is taken once when the thread starts and
+//! whenever an external call returns, and dropped before every external call
+//! (`rffi.aroundstate.before`/`.after`, spelled here as
+//! `gc_sync::before_external_block`). Between two external calls arbitrarily
+//! many allocations run with no synchronisation at all, which is what lets
+//! `gc_sync::gc_op` be a bare borrow of the singleton.
+//!
+//! Because a thread can therefore hold the GIL while running a long stretch of
+//! bytecode, `GILReleaseAction` (gil.py:44-50) yields it from the periodic
+//! action; [`yield_thread`] is that yield.
+
+use std::sync::atomic::{AtomicIsize, AtomicUsize, Ordering};
+use std::sync::{Condvar, Mutex, MutexGuard};
+use std::time::Duration;
+
+use crate::gc_sync;
+
+/// thread_gil.c:86 `Signed rpy_fastgil`. 0 when the GIL is unlocked, otherwise
+/// the ident of the thread holding it (point (3)).
+static RPY_FASTGIL: AtomicUsize = AtomicUsize::new(0);
+
+/// thread_gil.c:87 `rpy_waiting_threads`, the number of threads inside
+/// [`acquire_slow_path`]. Negative until [`allocate`] has run.
+static RPY_WAITING_THREADS: AtomicIsize = AtomicIsize::new(GIL_NOT_INITIALIZED);
+
+/// thread_gil.c:87 spells the uninitialised marker -42 and asserts on it.
+const GIL_NOT_INITIALIZED: isize = -42;
+
+/// thread_gil.c:88 `rpy_early_poll_n`, the running seed for the randomised
+/// early-poll count.
+static RPY_EARLY_POLL_N: AtomicIsize = AtomicIsize::new(0);
+
+/// thread_gil.c:111-112.
+const RPY_GIL_POKE_MIN: isize = 40;
+const RPY_GIL_POKE_MAX: isize = 400;
+
+/// thread_gil.c:217 waits on `mutex_gil` in 0.1 ms intervals.
+const MUTEX_GIL_POLL_INTERVAL: Duration = Duration::from_micros(100);
+
+/// thread.h:39 `RPY_FASTGIL_LOCKED`.
+#[inline]
+fn fastgil_locked() -> bool {
+    RPY_FASTGIL.load(Ordering::Relaxed) != 0
+}
+
+// ──────────────────────────────────────────────────────────────
+// mutex1_t / mutex2_t (thread_pthread.c:547-595)
+// ──────────────────────────────────────────────────────────────
+
+/// thread_pthread.c:559-563 `mutex2_t`: a `locked` flag with the mutex and
+/// condition variable that guard it. It is not a plain mutex because the
+/// stealer must be able to wait on it with a timeout while another thread
+/// unlocks it without ever having locked it in the fast path.
+struct Mutex2 {
+    locked: Mutex<bool>,
+    cond: Condvar,
+}
+
+impl Mutex2 {
+    /// thread_pthread.c:565-569 `mutex2_init_locked`.
+    const fn new_locked() -> Self {
+        Mutex2 {
+            locked: Mutex::new(true),
+            cond: Condvar::new(),
+        }
+    }
+
+    /// thread_pthread.c:570-575 `mutex2_unlock`. The signal is sent after the
+    /// mutex is dropped, as in the C.
+    fn unlock(&self) {
+        *self.locked.lock().unwrap() = false;
+        self.cond.notify_one();
+    }
+
+    /// thread_pthread.c:576-578 `mutex2_loop_start`. The returned guard is the
+    /// lock the stealer keeps for the whole steal loop, and is dropped in place
+    /// of `mutex2_loop_stop` (:579-581).
+    fn loop_start(&self) -> MutexGuard<'_, bool> {
+        self.locked.lock().unwrap()
+    }
+
+    /// thread_pthread.c:582-595 `mutex2_lock_timeout`. Returns the guard along
+    /// with whether the mutex was observed unlocked, i.e. whether this thread
+    /// just relocked it.
+    fn lock_timeout<'a>(
+        &'a self,
+        guard: MutexGuard<'a, bool>,
+        delay: Duration,
+    ) -> (MutexGuard<'a, bool>, bool) {
+        let mut guard = if *guard {
+            self.cond.wait_timeout(guard, delay).unwrap().0
+        } else {
+            guard
+        };
+        let result = !*guard;
+        *guard = true;
+        (guard, result)
+    }
+}
+
+/// thread_gil.c:89-90.
+static MUTEX_GIL_STEALER: Mutex<()> = Mutex::new(());
+static MUTEX_GIL: Mutex2 = Mutex2::new_locked();
+
+// ──────────────────────────────────────────────────────────────
+// rgil.py surface
+// ──────────────────────────────────────────────────────────────
+
+/// rgil.py:161-167 `allocate` / thread_gil.c:100-109 `RPyGilAllocate`.
+///
+/// The mutexes are const-initialised as statics, so all that is left of
+/// `rpy_init_mutexes` is publishing that the GIL may now be waited on. Until
+/// then [`acquire_slow_path`] is a fatal error, exactly as upstream: a program
+/// which never set threads up can only ever take the compare-and-swap.
+pub fn allocate() {
+    let _ = RPY_WAITING_THREADS.compare_exchange(
+        GIL_NOT_INITIALIZED,
+        0,
+        Ordering::SeqCst,
+        Ordering::Relaxed,
+    );
+}
+
+/// `rpy_init_mutexes` re-runs through `pthread_atfork` (thread_gil.c:105-107).
+/// Only the forking thread survives, so nothing can be waiting and the surviving
+/// holder's claim, if any, is restored by the caller.
+pub(crate) fn after_fork_child() {
+    *MUTEX_GIL.locked.lock().unwrap() = true;
+    RPY_WAITING_THREADS.store(0, Ordering::SeqCst);
+}
+
+/// threadlocal.h:152-156 `_rpygil_acquire_fast_path`.
+#[inline]
+fn acquire_fast_path(ident: usize) -> bool {
+    RPY_FASTGIL
+        .compare_exchange(0, ident, Ordering::Acquire, Ordering::Relaxed)
+        .is_ok()
+}
+
+/// threadlocal.h:158-161 `_RPyGilAcquire`, called on return from an external
+/// call and when a thread starts running pyre code.
+#[inline]
+pub fn acquire() {
+    let ident = gc_sync::my_ident();
+    if !acquire_fast_path(ident) {
+        acquire_slow_path(ident);
+    }
+}
+
+/// rgil.py:186-193 `acquire_maybe_in_new_thread`, the acquire used by a thread
+/// which has not run pyre code before. Reading [`gc_sync::my_ident`] is what
+/// makes sure this thread's thread-locals exist, standing in for
+/// `rthread.get_or_make_ident()`.
+#[inline]
+pub fn acquire_maybe_in_new_thread() {
+    allocate();
+    acquire();
+}
+
+/// threadlocal.h:162-166 `_RPyGilRelease`, called before an external call.
+///
+/// A plain store: the word is only ever cleared by its owner. `RPyGilReleaseSignal`
+/// (thread_gil.c:258-276) has no counterpart because its body is `_WIN32`-only.
+#[inline]
+pub fn release() {
+    debug_assert!(
+        am_i_holding_the_gil(),
+        "releasing the GIL without holding it"
+    );
+    RPY_FASTGIL.store(0, Ordering::Release);
+}
+
+/// threadlocal.h:170-172 `_RPyGilGetHolder`.
+#[inline]
+pub fn gil_get_holder() -> usize {
+    RPY_FASTGIL.load(Ordering::Relaxed)
+}
+
+/// rgil.py:236-239 `am_I_holding_the_GIL`, the `rpy_fastgil == get_ident()`
+/// idiom of thread_gil.c:19-21.
+#[inline]
+pub fn am_i_holding_the_gil() -> bool {
+    gil_get_holder() == gc_sync::my_ident()
+}
+
+/// thread_gil.c:114-233 `RPyGilAcquireSlowPath`: another thread is busy with
+/// the GIL.
+///
+/// A waiting thread runs no pyre code, so it leaves the RUNNING census for the
+/// whole wait ([`gc_sync::leave_running_for_gil`]). Upstream needs no such step
+/// — a collector there *is* the GIL holder, so anything waiting for the GIL is
+/// by construction not running — but pyre's collector drains that census
+/// explicitly and would otherwise wait for a thread that is itself waiting for
+/// the collector.
+#[cold]
+fn acquire_slow_path(ident: usize) {
+    assert!(
+        RPY_WAITING_THREADS.load(Ordering::Relaxed) >= 0,
+        "a thread is trying to wait for the GIL, but the GIL was not initialized"
+    );
+
+    let census = gc_sync::leave_running_for_gil();
+
+    // Register me as one of the threads that is actively waiting for the GIL.
+    let waiting_threads = RPY_WAITING_THREADS.fetch_add(1, Ordering::SeqCst) + 1;
+
+    // Early polling (:144-190): check a bounded number of times whether the GIL
+    // becomes free before entering the waiting queue, because there are use
+    // cases where it is released very soon after this call. The count is
+    // "randomised" between the two pokes to avoid falling into bad cases.
+    let mut n = RPY_EARLY_POLL_N.load(Ordering::Relaxed) * 2 + 1;
+    while n >= RPY_GIL_POKE_MAX {
+        n -= RPY_GIL_POKE_MAX - RPY_GIL_POKE_MIN;
+    }
+    RPY_EARLY_POLL_N.store(n, Ordering::Relaxed);
+    while n >= 0 {
+        n -= 1;
+        if waiting_threads != RPY_WAITING_THREADS.load(Ordering::Relaxed) {
+            // The number changed because another thread entered or left this
+            // function. If one left, the GIL has been acquired by it; if one
+            // entered, running this loop twice is pointless.
+            break;
+        }
+        std::hint::spin_loop();
+
+        if !fastgil_locked() && acquire_fast_path(ident) {
+            // We got the GIL before entering the waiting queue. Wake the
+            // stealer thread anyway, for fairness, and go to the waiting queue
+            // regardless — the loop below then relocks `mutex_gil` on its first
+            // pass, restoring the invariant that the GIL's two locks are both
+            // held. Leaving here instead would hand the next stealer a mutex it
+            // can take while we still own the word.
+            MUTEX_GIL.unlock();
+            break;
+        }
+    }
+
+    // Now we are in point (3): mutex_gil might be released, but rpy_fastgil
+    // might still contain an arbitrary ident.
+    //
+    // Enter the waiting queue from the end. Assuming a roughly
+    // first-in-first-out order, this gives the threads a round-robin chance.
+    {
+        let _stealer = MUTEX_GIL_STEALER.lock().unwrap();
+        let mut gil = MUTEX_GIL.loop_start();
+
+        // We are now the stealer thread. Steals!
+        loop {
+            // Busy-looping here. Look again whether `rpy_fastgil` is released.
+            if !fastgil_locked() && acquire_fast_path(ident) {
+                // point (8.A)
+                break;
+            }
+            // Sleep for one interval of time. We may be woken up earlier if
+            // `mutex_gil` is released. Point (8.B).
+            let (guard, relocked) = MUTEX_GIL.lock_timeout(gil, MUTEX_GIL_POLL_INTERVAL);
+            gil = guard;
+            if relocked {
+                // `mutex_gil` was recently released and we just relocked it;
+                // restore the invariant of point (3).
+                RPY_FASTGIL.store(ident, Ordering::Release);
+                break;
+            }
+        }
+    }
+
+    RPY_WAITING_THREADS.fetch_sub(1, Ordering::SeqCst);
+    gc_sync::rejoin_running_after_gil(census);
+    debug_assert!(fastgil_locked());
+}
+
+/// thread_gil.c:235-256 `RPyGilYieldThread`, driven by the periodic
+/// `GILReleaseAction` (gil.py:44-50). Returns whether the GIL was actually
+/// handed over.
+///
+/// Releasing `mutex_gil` leaves nobody holding the GIL — `rpy_fastgil` is still
+/// locked, but the second lock is not — so the immediately following acquire
+/// enqueues this thread at the end of the stealer queue behind the threads that
+/// were already waiting.
+pub fn yield_thread() -> bool {
+    debug_assert!(am_i_holding_the_gil(), "yielding a GIL we do not hold");
+    if RPY_WAITING_THREADS.load(Ordering::Relaxed) <= 0 {
+        return false;
+    }
+    MUTEX_GIL.unlock();
+    acquire();
+    true
+}
+
+/// RAII bracket for code that enters pyre from outside — a thread that has to
+/// take the GIL before it may touch the GC, and give it back afterwards.
+/// `rffi`'s callback wrappers hold it the same way around the RPython side of a
+/// call that arrived from C.
+pub struct GilGuard {
+    _not_send: std::marker::PhantomData<*const ()>,
+}
+
+impl GilGuard {
+    pub fn acquire() -> Self {
+        acquire_maybe_in_new_thread();
+        GilGuard {
+            _not_send: std::marker::PhantomData,
+        }
+    }
+}
+
+impl Drop for GilGuard {
+    fn drop(&mut self) {
+        release();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fast_path_round_trip_leaves_the_word_free() {
+        allocate();
+        let guard = GilGuard::acquire();
+        assert!(am_i_holding_the_gil());
+        assert_eq!(gil_get_holder(), gc_sync::my_ident());
+        drop(guard);
+        assert_eq!(gil_get_holder(), 0);
+        assert!(!am_i_holding_the_gil());
+    }
+
+    #[test]
+    fn yield_thread_without_waiters_keeps_the_gil() {
+        allocate();
+        let _guard = GilGuard::acquire();
+        assert!(!yield_thread());
+        assert!(am_i_holding_the_gil());
+    }
+}

--- a/majit/majit-gc/src/rgil.rs
+++ b/majit/majit-gc/src/rgil.rs
@@ -94,6 +94,15 @@ impl Mutex2 {
         self.cond.notify_one();
     }
 
+    /// thread_win7.c:594-600 `mutex2_signal`: wake a stealer sleeping in
+    /// [`Mutex2::lock_timeout`] without changing `locked`, so it can re-check
+    /// `rpy_fastgil`. Safe without the mutex held, and a missed wakeup is
+    /// benign because that wait has its own timeout.
+    #[cfg(windows)]
+    fn signal(&self) {
+        self.cond.notify_one();
+    }
+
     /// thread_pthread.c:576-578 `mutex2_loop_start`. The returned guard is the
     /// lock the stealer keeps for the whole steal loop, and is dropped in place
     /// of `mutex2_loop_stop` (:579-581).
@@ -232,8 +241,8 @@ pub fn acquire_maybe_in_new_thread() {
 
 /// threadlocal.h:162-166 `_RPyGilRelease`, called before an external call.
 ///
-/// A plain store: the word is only ever cleared by its owner. `RPyGilReleaseSignal`
-/// (thread_gil.c:258-276) has no counterpart because its body is `_WIN32`-only.
+/// A plain store — the word is only ever cleared by its owner — followed by
+/// [`release_signal`].
 #[inline]
 pub fn release() {
     debug_assert!(
@@ -241,7 +250,26 @@ pub fn release() {
         "releasing the GIL without holding it"
     );
     RPY_FASTGIL.store(0, Ordering::Release);
+    release_signal();
 }
+
+/// thread_gil.c:258-276 `RPyGilReleaseSignal`, whose body is `_WIN32`-only and
+/// says why: a stealer asleep in `mutex2_lock_timeout` would otherwise have to
+/// wait out its timed wait, and Windows' default 10-15 ms timer resolution
+/// makes that "severe latency for any code that releases the GIL". On POSIX
+/// the 0.1 ms timeout is short enough that the extra wakeup is not needed and
+/// its scheduling interference hangs `test_interrupt_non_main`.
+#[cfg(windows)]
+#[inline]
+fn release_signal() {
+    if RPY_WAITING_THREADS.load(Ordering::Relaxed) > 0 {
+        mutexes().gil.signal();
+    }
+}
+
+#[cfg(not(windows))]
+#[inline]
+fn release_signal() {}
 
 /// threadlocal.h:170-172 `_RPyGilGetHolder`.
 #[inline]

--- a/majit/majit-gc/src/rgil.rs
+++ b/majit/majit-gc/src/rgil.rs
@@ -10,12 +10,12 @@
 //! 1. [`RPY_FASTGIL`], a plain word. 0 means unlocked; otherwise it holds the
 //!    ident of the owning thread, so a thread checks whether it owns the GIL
 //!    with `rpy_fastgil == get_ident()`.
-//! 2. [`MUTEX_GIL`], a regular mutex which the fast path never unlocks.
+//! 2. `mutex_gil`, a regular mutex which the fast path never unlocks.
 //!
 //! Releasing is a plain store of 0; acquiring is a compare-and-swap against 0.
 //! Whoever loses the compare-and-swap enters [`acquire_slow_path`], becomes
-//! "the stealer" by taking [`MUTEX_GIL_STEALER`], and alternates between
-//! retrying the fast path and a timed wait on [`MUTEX_GIL`].
+//! "the stealer" by taking `mutex_gil_stealer`, and alternates between
+//! retrying the fast path and a timed wait on `mutex_gil`.
 //!
 //! # Lifetime
 //!
@@ -120,9 +120,50 @@ impl Mutex2 {
     }
 }
 
-/// thread_gil.c:89-90.
-static MUTEX_GIL_STEALER: Mutex<()> = Mutex::new(());
-static MUTEX_GIL: Mutex2 = Mutex2::new_locked();
+/// thread_gil.c:89-90. Held in one cell because `rpy_init_mutexes` re-creates
+/// both of them together, and a `std::sync::Mutex` can only be reset by
+/// overwriting it.
+struct GilMutexes {
+    stealer: Mutex<()>,
+    gil: Mutex2,
+}
+
+impl GilMutexes {
+    const fn new() -> Self {
+        GilMutexes {
+            stealer: Mutex::new(()),
+            gil: Mutex2::new_locked(),
+        }
+    }
+}
+
+struct GilMutexCell(std::cell::UnsafeCell<GilMutexes>);
+
+// SAFETY: the contents are `Sync`; the cell exists only so that
+// `init_mutexes` can replace them in a forked child, where this thread is the
+// only one alive.
+unsafe impl Sync for GilMutexCell {}
+
+static MUTEXES: GilMutexCell = GilMutexCell(std::cell::UnsafeCell::new(GilMutexes::new()));
+
+#[inline]
+fn mutexes() -> &'static GilMutexes {
+    // SAFETY: only `init_mutexes` ever writes, and only in a forked child
+    // before any other thread exists.
+    unsafe { &*MUTEXES.0.get() }
+}
+
+/// thread_gil.c:92-98 `rpy_init_mutexes`.
+///
+/// `mutex1_init` / `mutex2_init_locked` are `pthread_mutex_init` calls, which
+/// reset an already-locked mutex and abandon whatever state it held. The
+/// overwrite is the same operation: the old value is not dropped, because a
+/// thread which vanished in `fork()` may still "hold" it.
+fn init_mutexes() {
+    // SAFETY: reached only from the surviving thread of a `fork()`, which is
+    // the child's only thread, so no reference into the old value is live.
+    unsafe { std::ptr::write(MUTEXES.0.get(), GilMutexes::new()) };
+}
 
 // ──────────────────────────────────────────────────────────────
 // rgil.py surface
@@ -130,10 +171,11 @@ static MUTEX_GIL: Mutex2 = Mutex2::new_locked();
 
 /// rgil.py:161-167 `allocate` / thread_gil.c:100-109 `RPyGilAllocate`.
 ///
-/// The mutexes are const-initialised as statics, so all that is left of
-/// `rpy_init_mutexes` is publishing that the GIL may now be waited on. Until
-/// then [`acquire_slow_path`] is a fatal error, exactly as upstream: a program
-/// which never set threads up can only ever take the compare-and-swap.
+/// The mutexes are const-initialised, so all [`init_mutexes`] would do at
+/// startup is rewrite them with the value they already hold; what is left is
+/// publishing that the GIL may now be waited on. Until then
+/// [`acquire_slow_path`] is a fatal error, exactly as upstream: a program which
+/// never set threads up can only ever take the compare-and-swap.
 pub fn allocate() {
     let _ = RPY_WAITING_THREADS.compare_exchange(
         GIL_NOT_INITIALIZED,
@@ -146,8 +188,17 @@ pub fn allocate() {
 /// `rpy_init_mutexes` re-runs through `pthread_atfork` (thread_gil.c:105-107).
 /// Only the forking thread survives, so nothing can be waiting and the surviving
 /// holder's claim, if any, is restored by the caller.
+///
+/// Both mutexes are re-created rather than only re-flagged: a thread which was
+/// in [`acquire_slow_path`] when the parent forked holds `stealer` and the
+/// `gil.locked` guard, and the child inherits them locked by a thread that no
+/// longer exists.
 pub(crate) fn after_fork_child() {
-    *MUTEX_GIL.locked.lock().unwrap() = true;
+    debug_assert!(
+        am_i_holding_the_gil(),
+        "the forking thread must hold the GIL across fork()"
+    );
+    init_mutexes();
     RPY_WAITING_THREADS.store(0, Ordering::SeqCst);
 }
 
@@ -252,7 +303,7 @@ fn acquire_slow_path(ident: usize) {
             // pass, restoring the invariant that the GIL's two locks are both
             // held. Leaving here instead would hand the next stealer a mutex it
             // can take while we still own the word.
-            MUTEX_GIL.unlock();
+            mutexes().gil.unlock();
             break;
         }
     }
@@ -263,8 +314,9 @@ fn acquire_slow_path(ident: usize) {
     // Enter the waiting queue from the end. Assuming a roughly
     // first-in-first-out order, this gives the threads a round-robin chance.
     {
-        let _stealer = MUTEX_GIL_STEALER.lock().unwrap();
-        let mut gil = MUTEX_GIL.loop_start();
+        let mutexes = mutexes();
+        let _stealer = mutexes.stealer.lock().unwrap();
+        let mut gil = mutexes.gil.loop_start();
 
         // We are now the stealer thread. Steals!
         loop {
@@ -275,7 +327,7 @@ fn acquire_slow_path(ident: usize) {
             }
             // Sleep for one interval of time. We may be woken up earlier if
             // `mutex_gil` is released. Point (8.B).
-            let (guard, relocked) = MUTEX_GIL.lock_timeout(gil, MUTEX_GIL_POLL_INTERVAL);
+            let (guard, relocked) = mutexes.gil.lock_timeout(gil, MUTEX_GIL_POLL_INTERVAL);
             gil = guard;
             if relocked {
                 // `mutex_gil` was recently released and we just relocked it;
@@ -288,7 +340,12 @@ fn acquire_slow_path(ident: usize) {
 
     RPY_WAITING_THREADS.fetch_sub(1, Ordering::SeqCst);
     gc_sync::rejoin_running_after_gil(census);
-    debug_assert!(fastgil_locked());
+    // Both exits from the steal loop leave *this* thread's ident in the word,
+    // so the exit condition is ownership, not merely that the word is taken.
+    debug_assert!(
+        am_i_holding_the_gil(),
+        "acquire_slow_path returned without owning rpy_fastgil"
+    );
 }
 
 /// thread_gil.c:235-256 `RPyGilYieldThread`, driven by the periodic
@@ -304,7 +361,7 @@ pub fn yield_thread() -> bool {
     if RPY_WAITING_THREADS.load(Ordering::Relaxed) <= 0 {
         return false;
     }
-    MUTEX_GIL.unlock();
+    mutexes().gil.unlock();
     acquire();
     true
 }
@@ -336,8 +393,14 @@ impl Drop for GilGuard {
 mod tests {
     use super::*;
 
+    /// `RPY_FASTGIL` and `RPY_WAITING_THREADS` are process-global and the test
+    /// harness runs test functions on concurrent threads, so a second test
+    /// holding the GIL would be indistinguishable from a failure here.
+    static TEST_SERIAL: Mutex<()> = Mutex::new(());
+
     #[test]
     fn fast_path_round_trip_leaves_the_word_free() {
+        let _serial = TEST_SERIAL.lock().unwrap_or_else(|e| e.into_inner());
         allocate();
         let guard = GilGuard::acquire();
         assert!(am_i_holding_the_gil());
@@ -349,6 +412,7 @@ mod tests {
 
     #[test]
     fn yield_thread_without_waiters_keeps_the_gil() {
+        let _serial = TEST_SERIAL.lock().unwrap_or_else(|e| e.into_inner());
         allocate();
         let _guard = GilGuard::acquire();
         assert!(!yield_thread());

--- a/pyre/bench/synth/attr_store_add_transition.py
+++ b/pyre/bench/synth/attr_store_add_transition.py
@@ -10,7 +10,16 @@
 # copied into the wider block) — so the ratio measures the fold itself.  The
 # shapes the fold declines or that force materialization are exercised once
 # each in `edges()`, for agreement with the interpreter rather than for speed.
-N = 200000
+#
+# `N` is sized so the measured time clears the ratio's noise floor: check.py
+# subtracts each interpreter's empty-program startup, and below roughly ten
+# million iterations what is left on the pypy side is startup jitter rather
+# than the loop.  `total` accumulates a fixed amount per iteration, so it
+# scales exactly with `N`; dividing by the ratio to `OUTPUT_N` keeps stdout
+# stable across resizings, which is what every interpreter's output is
+# compared against.
+OUTPUT_N = 200000
+N = 64000000
 
 
 class Fresh:
@@ -69,7 +78,7 @@ def main():
         total = total + len(two.a) + len(two.b)
 
         i = i + 1
-    print(total, edges())
+    print(total // (N // OUTPUT_N), edges())
 
 
 main()

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -114,6 +114,7 @@ EXEC_TIME_FLOOR_S = WIN_TIMER_QUANTUM_S if sys.platform == "win32" else 0.005
 # needs more samples because its process CPU accounting is scheduler-tick
 # quantized (see WIN_TIMER_QUANTUM_S above).
 PERF_RETRY_RUNS = 5 if sys.platform == "win32" else 3
+SYNTHETIC_CPYTHON_REFERENCE_TIMEOUT_S = 5
 CARGO_CONFIG = {
     "dynasm": {
         "extra": ["--no-default-features", "--features", "dynasm"],
@@ -697,7 +698,10 @@ def fmt_time(t):
         return "-"
     if isinstance(t, (int, float)):
         return f"{t:.2f}s"
-    return f"{t}s"
+    try:
+        return f"{float(t):.2f}s"
+    except ValueError:
+        return t
 
 
 def synth_perf_gate(path):
@@ -908,6 +912,9 @@ class Check:
         self.args = args
         self.results = []
         self.comparisons = []
+        # Synthetic fixtures whose cpython reference run exceeded its budget,
+        # so pypy alone was the baseline for them.
+        self.cpython_reference_skips = []
         # Per-backend bookkeeping, keyed by backend name so any backend
         # (dynasm / cranelift / wasm / a single `--pyre-path` binary) is tracked
         # uniformly.
@@ -1746,9 +1753,18 @@ class Check:
         sys.stdout.write(f"    {'cpython':<10s}")
         sys.stdout.flush()
         cpython_output, cpython_time, cpython_code, _ = run_timed(
-            [PYTHON3, path], timeout_s=effective_timeout,
+            [PYTHON3, path], timeout_s=SYNTHETIC_CPYTHON_REFERENCE_TIMEOUT_S,
         )
-        if cpython_code != 0:
+        if cpython_code == 124:
+            # Not a crash: the fixture is sized for the JITs and cpython is
+            # only the reference. Drop it and let pypy be the baseline the
+            # backends are compared against, rather than spend the fixture's
+            # whole timeout on an interpreter nothing is gated on.
+            cpython_output = None
+            t_cpython = f"skip (>{SYNTHETIC_CPYTHON_REFERENCE_TIMEOUT_S:g}s)"
+            print(dim(t_cpython))
+            self.cpython_reference_skips.append(name)
+        elif cpython_code != 0:
             print(f"{red('CRASH')} (exit {cpython_code})")
             cpython_output = None
             t_cpython = "-"
@@ -1812,6 +1828,8 @@ class Check:
     def run_synthetic_suite(self):
         pattern = self.args.synthetic_pattern
         paths = sorted(Path(SYNTHETIC_BENCH_DIR).glob(pattern))
+        if not paths and not Path(pattern).suffix:
+            paths = sorted(Path(SYNTHETIC_BENCH_DIR).glob(f"{pattern}.py"))
         paths = [p for p in paths if p.is_file() and p.suffix == ".py"]
         if not paths:
             print(f"{red('ERROR')}: no synthetic benchmarks matched {pattern!r}")
@@ -1822,6 +1840,19 @@ class Check:
         for path in paths:
             self.run_synthetic_bench(
                 str(path), self.args.synthetic_timeout,
+            )
+        # A fixture that loses its cpython reference also loses the
+        # cpython/pypy output cross-check, so the count belongs in the summary
+        # rather than only in the per-fixture line it scrolled past. A fixture
+        # appearing here for the first time is a fixture whose baseline just
+        # got weaker.
+        if self.cpython_reference_skips:
+            names = ", ".join(self.cpython_reference_skips)
+            print(
+                dim(
+                    f"cpython reference skipped (>{SYNTHETIC_CPYTHON_REFERENCE_TIMEOUT_S:g}s) "
+                    f"for {len(self.cpython_reference_skips)}: {names}"
+                )
             )
 
     # ── printing ──

--- a/pyre/design.md
+++ b/pyre/design.md
@@ -146,18 +146,21 @@ de-specialization. majit expresses these as proc-macro attributes with the
 exact RPython names. Adding a new kind of hint to work around a translator
 weakness is the wrong direction; fix the translator (A1).
 
-### 3.3 Threading: the aspect argument, inverted to no-GIL
+### 3.3 Threading: the aspect argument, with no-GIL as the target
 
 D05.4 treats the GIL as one pluggable concurrency model among several and
 keeps all concurrency policy out of interpreter semantics. pyre accepts the
-framing and picks the other plug: **free-threaded from day one**. The same
-separation argument does the work — because PyPy's interpreter source never
-encoded GIL assumptions into *semantics*, a no-GIL port is even expressible.
-Consequences that are already policy:
+framing, and **free-threaded is the target, not the present mechanism**. The
+same separation argument is what makes that target reachable — because PyPy's
+interpreter source never encoded GIL assumptions into *semantics*, a no-GIL
+port is even expressible — but what ships today is a port of RPython's own GIL
+(`thread_gil.c` → `majit-gc/src/rgil.rs`); see "GC under free threading"
+below for why. Consequences that are already policy:
 
-- GIL-dependent RPython machinery (heapcache reset on GIL release,
-  `release_gil` effect info) keeps its names for parity but has no
-  production call sites.
+- GIL-dependent RPython machinery is ported, not merely named: `rgil` has
+  production call sites, and a thread holds the GIL for as long as it runs
+  pyre code. The pieces that remain name-only (heapcache reset on GIL
+  release, `release_gil` effect info) are the JIT-side ones.
 - Where RPython used ambient singletons justified by the GIL, pyre must
   justify each adaptation explicitly (TLS with a documented PyPy audit —
   the BACK_EDGE_BH_BUILDER precedent), never silently.
@@ -165,26 +168,36 @@ Consequences that are already policy:
   aspect-layer concern* (majit-gc), not by sprinkling atomics through
   pyre-object.
 
-**GC under free threading (settled 2026-07, gh#396).** The architecture is a
-**stop-the-world safepoint harness around an unchanged incminimark core** —
-the HotSpot/SGen shape, explicitly not PEP 703's non-moving route.
+**GC under free threading (gh#396).** The core is an unchanged incminimark;
+what supplies its exclusive-heap-access requirement has changed once.
 
+- *Settled 2026-07:* a **stop-the-world safepoint harness** — the HotSpot/SGen
+  shape, explicitly not PEP 703's non-moving route.
+- *Superseded 2026-08:* pyre supplies exclusive heap access with **a port of
+  RPython's own GIL** (`thread_gil.c` → `majit-gc/src/rgil.rs`). The harness's
+  per-`gc_op` gate could not be made cheap on its own terms — its entry needs
+  per-thread state, which on Mach-O is a `_tlv_get_addr` call on every
+  allocation — and upstream has no such gate at all (`rg threadlocalref_addr
+  rpython/memory/gctransform/framework.py rpython/memory/gc/incminimark.py`
+  has no hits: the allocation path reads no thread identity). Holding the GIL
+  across pyre code instead measured **−15.0%** on
+  `synth/int_mul_ovf_bignum_promote`, 12/12 rounds faster, and makes `gc_op` a
+  bare borrow of the singleton. The safepoint harness is still in the tree
+  behind the GIL; retiring it is tracked separately. TLABs and per-thread
+  store buffers were never built.
 - *Contract restatement.* What incminimark actually relies on is (a)
   exclusive heap access during each collection **step**, (b) enumerability
   of all roots at that instant, (c) all inter-step mutations caught by the
-  write barrier. The GIL was PyPy's implementation of (a); safepoints are
-  pyre's implementation of the same contract. The audit that this holds for
-  the *incremental* major is source-verified: major slices already execute
+  write barrier. Only (a) is what the two mechanisms above disagree about;
+  (b) and (c) are the same either way. The audit that this holds for the
+  *incremental* major is source-verified: major slices already execute
   at minor-collection time (`minor_collection_with_major_progress`,
   incminimark.py:824), hence inside STW windows; the barrier is deliberately
   newvalue-agnostic ("the incremental GC nowadays relies on this fact",
   incminimark.py:1516-1518) and its records are consumed at the next minor
   (VISITED clear + `more_objects_to_trace` re-append, incminimark.py:
-  2079-2083). Concurrency therefore lives entirely in the harness — mutator
-  registry, safepoint polls (allocation sites, runtime entry/exit, loop
-  back-edges: precisely the sites where the existing rooting invariant
-  already holds), TLABs, per-thread store buffers — and the ported
-  collection algorithms are not rewritten.
+  2079-2083). Concurrency therefore lives entirely in whatever supplies (a),
+  and the ported collection algorithms are not rewritten either way.
 - *Moving nursery is kept.* JIT inline nursery allocation is a performance
   pillar; embedder-boundary pointer stability is solved by pinning (upstream
   already has it: `GCFLAG_PINNED`, incminimark.py:148) or oldgen promotion,
@@ -198,7 +211,7 @@ the HotSpot/SGen shape, explicitly not PEP 703's non-moving route.
   `nursery_free` baked static address → thread-context-relative, with the
   inline fast-path shape unchanged; (4) the safepoint subsystem itself,
   which has no upstream counterpart (and therefore no merge surface).
-- *Non-options, with their failure mode*: a GIL (contradicts this section);
+- *Non-options, with their failure mode*:
   per-access locks on the GC handle (fixes the data race, not the
   moving-collector root-visibility race — demonstrated by the gh#396
   cargo-test heap corruption); interior mutability without synchronization

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -12789,13 +12789,14 @@ fn fd_read_into(fd: i32, buf: &mut [u8]) -> std::io::Result<usize> {
     loop {
         // `count` is `size_t` on Unix but `c_uint` on Windows; `as _` casts
         // to whichever the platform's `libc::read` expects.
-        let n = unsafe { libc::read(fd, buf.as_mut_ptr() as *mut libc::c_void, buf.len() as _) };
+        let (n, errno) = crate::module::thread::call_external_function(|| unsafe {
+            libc::read(fd, buf.as_mut_ptr() as *mut libc::c_void, buf.len() as _)
+        });
         if n < 0 {
-            let e = std::io::Error::last_os_error();
-            if e.raw_os_error() == Some(libc::EINTR) {
+            if errno == libc::EINTR {
                 continue;
             }
-            return Err(e);
+            return Err(std::io::Error::from_raw_os_error(errno));
         }
         return Ok(n as usize);
     }
@@ -13026,11 +13027,11 @@ fn file_method_write(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
             #[cfg(not(feature = "sandbox"))]
             let n = {
                 // `count` is `size_t` on Unix but `c_uint` on Windows.
-                let n = unsafe {
+                let (n, errno) = crate::module::thread::call_external_function(|| unsafe {
                     libc::write(fd, bytes.as_ptr() as *const libc::c_void, bytes.len() as _)
-                };
+                });
                 if n < 0 {
-                    return Err(fd_io_err(std::io::Error::last_os_error()));
+                    return Err(fd_io_err(std::io::Error::from_raw_os_error(errno)));
                 }
                 n as i64
             };

--- a/pyre/pyre-interpreter/src/compile.rs
+++ b/pyre/pyre-interpreter/src/compile.rs
@@ -17,6 +17,7 @@ pub use rustpython_compiler_core::bytecode::{
 /// The `CompileError` is returned unflattened so the SyntaxError builders
 /// can read its `python_location` / `python_end_location` / `source_path`.
 pub fn compile_source(source: &str, mode: Mode) -> Result<CodeObject, CompileError> {
+    crate::module::thread::ensure_runtime_thread();
     rp_compile(source, mode, "<string>".into(), default_compile_opts())
 }
 
@@ -51,6 +52,7 @@ pub fn compile_source_with_opts(
     filename: &str,
     opts: CompileOpts,
 ) -> Result<CodeObject, CompileError> {
+    crate::module::thread::ensure_runtime_thread();
     rp_compile(source, mode, filename.into(), opts)
 }
 
@@ -200,12 +202,10 @@ pub fn decode_source_bytes(
 
 /// Compile a Python expression.
 pub fn compile_eval(source: &str) -> Result<CodeObject, CompileError> {
-    crate::module::thread::ensure_runtime_thread();
     compile_source(source, Mode::Eval)
 }
 
 /// Compile a Python script (module).
 pub fn compile_exec(source: &str) -> Result<CodeObject, CompileError> {
-    crate::module::thread::ensure_runtime_thread();
     compile_source(source, Mode::Exec)
 }

--- a/pyre/pyre-interpreter/src/compile.rs
+++ b/pyre/pyre-interpreter/src/compile.rs
@@ -200,10 +200,12 @@ pub fn decode_source_bytes(
 
 /// Compile a Python expression.
 pub fn compile_eval(source: &str) -> Result<CodeObject, CompileError> {
+    crate::module::thread::ensure_runtime_thread();
     compile_source(source, Mode::Eval)
 }
 
 /// Compile a Python script (module).
 pub fn compile_exec(source: &str) -> Result<CodeObject, CompileError> {
+    crate::module::thread::ensure_runtime_thread();
     compile_source(source, Mode::Exec)
 }

--- a/pyre/pyre-interpreter/src/executioncontext.rs
+++ b/pyre/pyre-interpreter/src/executioncontext.rs
@@ -288,6 +288,11 @@ pub struct ExecutionContext {
     /// pointer into the leaked action owned by `module::_signal`
     /// (`install_signal_handling`); `None` until installed.
     pub check_signal_action: Option<*mut dyn AsyncActionOps>,
+    /// `gil.py:20-23 GILThreadLocals.initialize` — the `GILReleaseAction`
+    /// registered on the ticker, which yields the GIL every
+    /// `sys.getcheckinterval()` bytecodes. Stored as a trait pointer into the
+    /// leaked action owned by `module::thread::gil`; `None` until installed.
+    pub gil_release_action: Option<*mut dyn AsyncActionOps>,
     /// `executioncontext.py sys_exc_operror` — the active exception for
     /// `sys.exc_info()` / bare `raise`, saved/restored across handler
     /// regions by PUSH_EXC_INFO / POP_EXCEPT.  Single source of truth
@@ -377,6 +382,7 @@ impl ExecutionContext {
             builtins_module,
             builtin_dict_cache: std::cell::Cell::new(pyre_object::PY_NULL),
             check_signal_action: None,
+            gil_release_action: None,
             sys_exc_value: pyre_object::PY_NULL,
             coroutine_origin_tracking_depth: 0,
             current_gen_or_coroutine: pyre_object::PY_NULL,
@@ -405,6 +411,9 @@ impl ExecutionContext {
         ec.profile_all_generation = 0;
         ec.thread_local_refs.clear();
         ec.actionflag = ActionFlag::new();
+        // The periodic actions are registered on the actionflag just replaced,
+        // so the new thread registers its own.
+        ec.gil_release_action = None;
         ec.user_del_action = std::ptr::null_mut();
         // The cached Module wrapper is execution-context-owned and movable.
         // A new thread lazily builds its own wrapper over the shared

--- a/pyre/pyre-interpreter/src/executioncontext.rs
+++ b/pyre/pyre-interpreter/src/executioncontext.rs
@@ -290,8 +290,11 @@ pub struct ExecutionContext {
     pub check_signal_action: Option<*mut dyn AsyncActionOps>,
     /// `gil.py:20-23 GILThreadLocals.initialize` — the `GILReleaseAction`
     /// registered on the ticker, which yields the GIL every
-    /// `sys.getcheckinterval()` bytecodes. Stored as a trait pointer into the
-    /// leaked action owned by `module::thread::gil`; `None` until installed.
+    /// `sys.getcheckinterval()` bytecodes. There is one per execution context,
+    /// because the ticker it is registered on is too, so unlike the
+    /// process-global signal action it is owned rather than leaked: the
+    /// pointer is the box `module::thread::gil::shutdown` gives back. `None`
+    /// until installed.
     pub gil_release_action: Option<*mut dyn AsyncActionOps>,
     /// `executioncontext.py sys_exc_operror` — the active exception for
     /// `sys.exc_info()` / bare `raise`, saved/restored across handler

--- a/pyre/pyre-interpreter/src/host_seam.rs
+++ b/pyre/pyre-interpreter/src/host_seam.rs
@@ -396,7 +396,12 @@ macro_rules! declare_seam {
             $(
                 fn $name($($a : seam_arg_ty!($aty)),*) -> SeamResult<seam_ret_ty!($rty)> {
                     let args = [ $( seam_marshal!($aty, $a) ),* ];
-                    let result = client::syscall($ll, &args, seam_result_kind!($rty))?;
+                    // Every trampolined op is a round trip to the controller
+                    // and blocks for its reply.
+                    let result = {
+                        let _blocked = crate::module::thread::before_external_block();
+                        client::syscall($ll, &args, seam_result_kind!($rty))
+                    }?;
                     seam_unwrap!($rty, result)
                 }
             )*
@@ -593,44 +598,60 @@ mod real {
         CString::new(path).map_err(|_| SeamError::Value)
     }
 
+    /// `rffi.py:193-211 call_external_function` for the real-host bodies: an OS
+    /// call blocks, so drop the GIL around it.  `last_os_error` is read inside
+    /// `f`, which keeps it ahead of the re-acquire the way `_errno_after`
+    /// precedes `rgil.acquire()`.
+    #[inline]
+    fn blocking<R>(f: impl FnOnce() -> R) -> R {
+        let _blocked = crate::module::thread::before_external_block();
+        f()
+    }
+
     fn real_stat(path: &[u8], symlink: bool) -> SeamResult<StatBuf> {
         let c = cstr(path)?;
-        // SAFETY: stat(2)/lstat(2) into a zeroed, owned `libc::stat`.
-        let mut st: libc::stat = unsafe { std::mem::zeroed() };
-        let r = unsafe {
-            if symlink {
-                libc::lstat(c.as_ptr(), &mut st)
-            } else {
-                libc::stat(c.as_ptr(), &mut st)
+        blocking(|| {
+            // SAFETY: stat(2)/lstat(2) into a zeroed, owned `libc::stat`.
+            let mut st: libc::stat = unsafe { std::mem::zeroed() };
+            let r = unsafe {
+                if symlink {
+                    libc::lstat(c.as_ptr(), &mut st)
+                } else {
+                    libc::stat(c.as_ptr(), &mut st)
+                }
+            };
+            if r < 0 {
+                return Err(last_os_error());
             }
-        };
-        if r < 0 {
-            return Err(last_os_error());
-        }
-        Ok(StatBuf::from_libc(&st))
+            Ok(StatBuf::from_libc(&st))
+        })
     }
 
     impl SandboxableHost for RealHost {
         fn open(path: &[u8], flags: i32, mode: u32) -> SeamResult<i32> {
             let c = cstr(path)?;
-            // SAFETY: open(2) with an owned NUL-terminated path.
-            let fd = unsafe { libc::open(c.as_ptr(), flags, mode as libc::c_uint) };
-            if fd < 0 { Err(last_os_error()) } else { Ok(fd) }
+            blocking(|| {
+                // SAFETY: open(2) with an owned NUL-terminated path.
+                let fd = unsafe { libc::open(c.as_ptr(), flags, mode as libc::c_uint) };
+                if fd < 0 { Err(last_os_error()) } else { Ok(fd) }
+            })
         }
 
         fn close(fd: i32) -> SeamResult<()> {
-            if unsafe { libc::close(fd) } < 0 {
-                Err(last_os_error())
-            } else {
-                Ok(())
-            }
+            blocking(|| {
+                if unsafe { libc::close(fd) } < 0 {
+                    Err(last_os_error())
+                } else {
+                    Ok(())
+                }
+            })
         }
 
         fn read(fd: i32, size: i64) -> SeamResult<Vec<u8>> {
             let n = size.max(0) as usize;
             let mut buf = vec![0u8; n];
             // SAFETY: read(2) into a buffer we own and sized to `n`.
-            let got = unsafe { libc::read(fd, buf.as_mut_ptr() as *mut c_void, n) };
+            let got = blocking(|| unsafe { libc::read(fd, buf.as_mut_ptr() as *mut c_void, n) });
             if got < 0 {
                 return Err(last_os_error());
             }
@@ -642,20 +663,24 @@ mod real {
             use std::io::Read;
             let n = size.max(0) as usize;
             let mut buf = vec![0u8; n];
-            std::fs::File::open("/dev/urandom")
-                .and_then(|mut f| f.read_exact(&mut buf))
-                .map_err(|_| last_os_error())?;
+            blocking(|| {
+                std::fs::File::open("/dev/urandom")
+                    .and_then(|mut f| f.read_exact(&mut buf))
+                    .map_err(|_| last_os_error())
+            })?;
             Ok(buf)
         }
 
         fn write(fd: i32, data: &[u8]) -> SeamResult<i64> {
-            // SAFETY: write(2) from a slice held for the call.
-            let n = unsafe { libc::write(fd, data.as_ptr() as *const c_void, data.len()) };
-            if n < 0 {
-                Err(last_os_error())
-            } else {
-                Ok(n as i64)
-            }
+            blocking(|| {
+                // SAFETY: write(2) from a slice held for the call.
+                let n = unsafe { libc::write(fd, data.as_ptr() as *const c_void, data.len()) };
+                if n < 0 {
+                    Err(last_os_error())
+                } else {
+                    Ok(n as i64)
+                }
+            })
         }
 
         fn lseek(fd: i32, pos: i64, how: i32) -> SeamResult<i64> {
@@ -676,17 +701,19 @@ mod real {
         }
 
         fn fstat(fd: i32) -> SeamResult<StatBuf> {
-            // SAFETY: fstat(2) into a zeroed, owned `libc::stat`.
-            let mut st: libc::stat = unsafe { std::mem::zeroed() };
-            if unsafe { libc::fstat(fd, &mut st) } < 0 {
-                return Err(last_os_error());
-            }
-            Ok(StatBuf::from_libc(&st))
+            blocking(|| {
+                // SAFETY: fstat(2) into a zeroed, owned `libc::stat`.
+                let mut st: libc::stat = unsafe { std::mem::zeroed() };
+                if unsafe { libc::fstat(fd, &mut st) } < 0 {
+                    return Err(last_os_error());
+                }
+                Ok(StatBuf::from_libc(&st))
+            })
         }
 
         fn access(path: &[u8], mode: i32) -> SeamResult<bool> {
             let c = cstr(path)?;
-            Ok(unsafe { libc::access(c.as_ptr(), mode) } == 0)
+            Ok(blocking(|| unsafe { libc::access(c.as_ptr(), mode) }) == 0)
         }
 
         fn isatty(fd: i32) -> SeamResult<bool> {
@@ -694,19 +721,23 @@ mod real {
         }
 
         fn getcwd() -> SeamResult<Vec<u8>> {
-            std::env::current_dir()
-                .map(|p| p.into_os_string().into_vec())
-                .map_err(|_| last_os_error())
+            blocking(|| {
+                std::env::current_dir()
+                    .map(|p| p.into_os_string().into_vec())
+                    .map_err(|_| last_os_error())
+            })
         }
 
         fn listdir(path: &[u8]) -> SeamResult<Vec<Vec<u8>>> {
             let p = std::path::Path::new(std::ffi::OsStr::from_bytes(path));
-            let mut names = Vec::new();
-            for entry in std::fs::read_dir(p).map_err(|_| last_os_error())? {
-                let entry = entry.map_err(|_| last_os_error())?;
-                names.push(entry.file_name().into_vec());
-            }
-            Ok(names)
+            blocking(|| {
+                let mut names = Vec::new();
+                for entry in std::fs::read_dir(p).map_err(|_| last_os_error())? {
+                    let entry = entry.map_err(|_| last_os_error())?;
+                    names.push(entry.file_name().into_vec());
+                }
+                Ok(names)
+            })
         }
 
         fn getenv(name: &[u8]) -> SeamResult<Option<Vec<u8>>> {
@@ -749,20 +780,24 @@ mod real {
 
         fn unlink(path: &[u8]) -> SeamResult<()> {
             let c = cstr(path)?;
-            if unsafe { libc::unlink(c.as_ptr()) } < 0 {
-                Err(last_os_error())
-            } else {
-                Ok(())
-            }
+            blocking(|| {
+                if unsafe { libc::unlink(c.as_ptr()) } < 0 {
+                    Err(last_os_error())
+                } else {
+                    Ok(())
+                }
+            })
         }
 
         fn mkdir(path: &[u8], mode: u32) -> SeamResult<()> {
             let c = cstr(path)?;
-            if unsafe { libc::mkdir(c.as_ptr(), mode as libc::mode_t) } < 0 {
-                Err(last_os_error())
-            } else {
-                Ok(())
-            }
+            blocking(|| {
+                if unsafe { libc::mkdir(c.as_ptr(), mode as libc::mode_t) } < 0 {
+                    Err(last_os_error())
+                } else {
+                    Ok(())
+                }
+            })
         }
 
         fn time() -> SeamResult<f64> {
@@ -785,7 +820,7 @@ mod real {
 
         fn sleep(seconds: f64) -> SeamResult<()> {
             if seconds > 0.0 {
-                std::thread::sleep(std::time::Duration::from_secs_f64(seconds));
+                blocking(|| std::thread::sleep(std::time::Duration::from_secs_f64(seconds)));
             }
             Ok(())
         }

--- a/pyre/pyre-interpreter/src/host_seam.rs
+++ b/pyre/pyre-interpreter/src/host_seam.rs
@@ -651,9 +651,15 @@ mod real {
             let n = size.max(0) as usize;
             let mut buf = vec![0u8; n];
             // SAFETY: read(2) into a buffer we own and sized to `n`.
-            let got = blocking(|| unsafe { libc::read(fd, buf.as_mut_ptr() as *mut c_void, n) });
+            let (got, err) = blocking(|| {
+                let got = unsafe { libc::read(fd, buf.as_mut_ptr() as *mut c_void, n) };
+                // Read `errno` before the guard hands the GIL back: the
+                // re-acquire can enter the stealer loop, whose mutex and
+                // condvar waits overwrite it.
+                (got, last_os_error())
+            });
             if got < 0 {
-                return Err(last_os_error());
+                return Err(err);
             }
             buf.truncate(got as usize);
             Ok(buf)

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -1320,13 +1320,17 @@ pub(crate) fn detect_stdlib_path() -> Option<PathBuf> {
             return Some(path);
         }
         // Last resort: borrow a host CPython's stdlib.
-        let output = std::process::Command::new("python3")
-            .args([
-                "-c",
-                "import sysconfig; print(sysconfig.get_paths()['stdlib'])",
-            ])
-            .output()
-            .ok()?;
+        let output = {
+            // Spawning and reaping a child process blocks.
+            let _blocked = crate::module::thread::before_external_block();
+            std::process::Command::new("python3")
+                .args([
+                    "-c",
+                    "import sysconfig; print(sysconfig.get_paths()['stdlib'])",
+                ])
+                .output()
+        }
+        .ok()?;
         if !output.status.success() {
             return None;
         }

--- a/pyre/pyre-interpreter/src/module/_ctypes/funcptr.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/funcptr.rs
@@ -530,7 +530,15 @@ fn cfuncptr_call(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         use_errno,
         ..Default::default()
     };
-    let result = host_ctypes::call(addr, &host_args, restype, options).map_err(|e| match e {
+    // `clibffi.py:350-352` declares `ffi_call` with the default
+    // `releasegil='auto'`, i.e. released: the callee is arbitrary foreign code
+    // and may block on another Python thread's progress.  `owned` / `keepalive`
+    // hold the marshalled buffers across the released window.
+    let result = {
+        let _blocked = crate::module::thread::before_external_block();
+        host_ctypes::call(addr, &host_args, restype, options)
+    }
+    .map_err(|e| match e {
         host_ctypes::CallError::NullFunctionPointer => {
             crate::PyError::value_error("NULL function pointer")
         }

--- a/pyre/pyre-interpreter/src/module/_multiprocessing/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_multiprocessing/mod.rs
@@ -150,11 +150,11 @@ fn semlock_acquire(
     // returning (`_check_signals(space)`).
     if block && timeout.is_none() {
         loop {
-            let r = unsafe { libc::sem_wait(handle) };
+            let (r, errno) =
+                crate::module::thread::call_external_function(|| unsafe { libc::sem_wait(handle) });
             if r == 0 {
                 break;
             }
-            let errno = std::io::Error::last_os_error().raw_os_error().unwrap_or(0);
             if errno == libc::EINTR {
                 crate::module::signal::interp_signal::checksignals_now()?;
                 continue;
@@ -192,10 +192,14 @@ fn semlock_acquire(
             let mut delay = 0;
             loop {
                 use rustpython_host_env::multiprocessing::PollWaitStep;
-                match rustpython_host_env::multiprocessing::sem_timedwait_poll_step(
-                    handle, &deadline, delay,
-                )
-                .map_err(|error| {
+                // The poll step sleeps between `sem_trywait` attempts.
+                let step = {
+                    let _blocked = crate::module::thread::before_external_block();
+                    rustpython_host_env::multiprocessing::sem_timedwait_poll_step(
+                        handle, &deadline, delay,
+                    )
+                };
+                match step.map_err(|error| {
                     crate::PyError::os_error_with_errno(error.raw_os_error(), error.description())
                 })? {
                     PollWaitStep::Acquired => {
@@ -210,7 +214,11 @@ fn semlock_acquire(
         #[cfg(not(target_vendor = "apple"))]
         loop {
             use rustpython_host_env::multiprocessing::WaitStatus;
-            match rustpython_host_env::multiprocessing::sem_wait_status(handle, Some(&deadline)) {
+            let status = {
+                let _blocked = crate::module::thread::before_external_block();
+                rustpython_host_env::multiprocessing::sem_wait_status(handle, Some(&deadline))
+            };
+            match status {
                 WaitStatus::Acquired => {
                     crate::module::signal::interp_signal::checksignals_now()?;
                     return Ok(true);

--- a/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
+++ b/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
@@ -1684,7 +1684,11 @@ fn init_socket_getaddrinfo(ns: pyre_object::PyObjectRef) {
                 .as_ref()
                 .map(|c| c.as_ptr())
                 .unwrap_or(std::ptr::null());
-            let rc = unsafe { libc::getaddrinfo(host_ptr, port_ptr, &hints, &mut res) };
+            // A name lookup goes to the resolver and can take seconds.
+            let rc = {
+                let _blocked = crate::module::thread::before_external_block();
+                unsafe { libc::getaddrinfo(host_ptr, port_ptr, &hints, &mut res) }
+            };
             if rc != 0 {
                 let msg = unsafe {
                     std::ffi::CStr::from_ptr(libc::gai_strerror(rc))
@@ -1783,8 +1787,9 @@ fn init_socket_getaddrinfo(ns: pyre_object::PyObjectRef) {
                 hints.ai_socktype = libc::SOCK_DGRAM;
                 hints.ai_flags = libc::AI_NUMERICHOST;
                 let mut res: *mut libc::addrinfo = std::ptr::null_mut();
-                let rc = unsafe {
-                    libc::getaddrinfo(c_host.as_ptr(), c_port.as_ptr(), &hints, &mut res)
+                let rc = {
+                    let _blocked = crate::module::thread::before_external_block();
+                    unsafe { libc::getaddrinfo(c_host.as_ptr(), c_port.as_ptr(), &hints, &mut res) }
                 };
                 if rc != 0 {
                     let msg = unsafe {
@@ -1806,16 +1811,20 @@ fn init_socket_getaddrinfo(ns: pyre_object::PyObjectRef) {
                 }
                 let mut host_buf = [0 as libc::c_char; libc::NI_MAXHOST as usize];
                 let mut serv_buf = [0 as libc::c_char; 32];
-                let nrc = unsafe {
-                    libc::getnameinfo(
-                        ai.ai_addr,
-                        ai.ai_addrlen,
-                        host_buf.as_mut_ptr(),
-                        host_buf.len() as libc::socklen_t,
-                        serv_buf.as_mut_ptr(),
-                        serv_buf.len() as libc::socklen_t,
-                        flags,
-                    )
+                // A reverse lookup goes to the resolver and can take seconds.
+                let nrc = {
+                    let _blocked = crate::module::thread::before_external_block();
+                    unsafe {
+                        libc::getnameinfo(
+                            ai.ai_addr,
+                            ai.ai_addrlen,
+                            host_buf.as_mut_ptr(),
+                            host_buf.len() as libc::socklen_t,
+                            serv_buf.as_mut_ptr(),
+                            serv_buf.len() as libc::socklen_t,
+                            flags,
+                        )
+                    }
                 };
                 unsafe { libc::freeaddrinfo(head) };
                 if nrc != 0 {
@@ -2182,8 +2191,9 @@ fn pack_inet_addr(
             let mut hints: libc::addrinfo = unsafe { std::mem::zeroed() };
             hints.ai_family = libc::AF_INET;
             let mut result: *mut libc::addrinfo = std::ptr::null_mut();
-            let rc = unsafe {
-                libc::getaddrinfo(c_host.as_ptr(), std::ptr::null(), &hints, &mut result)
+            let rc = {
+                let _blocked = crate::module::thread::before_external_block();
+                unsafe { libc::getaddrinfo(c_host.as_ptr(), std::ptr::null(), &hints, &mut result) }
             };
             if rc != 0 || result.is_null() {
                 return Err(crate::PyError::os_error(format!(
@@ -2656,15 +2666,14 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
                 let mut storage: libc::sockaddr_storage = unsafe { std::mem::zeroed() };
                 let mut slen = core::mem::size_of::<libc::sockaddr_storage>() as libc::socklen_t;
                 let cfd = loop {
-                    let r = unsafe {
+                    let (r, errno) = crate::module::thread::call_external_function(|| unsafe {
                         libc::accept(fd, &mut storage as *mut _ as *mut libc::sockaddr, &mut slen)
-                    };
+                    });
                     if r >= 0 {
                         break r;
                     }
-                    let err = std::io::Error::last_os_error();
-                    if err.raw_os_error() != Some(libc::EINTR) {
-                        return Err(socket_io_err(err));
+                    if errno != libc::EINTR {
+                        return Err(socket_io_err(std::io::Error::from_raw_os_error(errno)));
                     }
                     // EINTR: deliver a pending signal, then retry
                     // (`converted_error` eintr_retry).
@@ -2700,15 +2709,14 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
                 let mut storage: libc::sockaddr_storage = unsafe { std::mem::zeroed() };
                 let mut slen = core::mem::size_of::<libc::sockaddr_storage>() as libc::socklen_t;
                 let cfd = loop {
-                    let r = unsafe {
+                    let (r, errno) = crate::module::thread::call_external_function(|| unsafe {
                         libc::accept(fd, &mut storage as *mut _ as *mut libc::sockaddr, &mut slen)
-                    };
+                    });
                     if r >= 0 {
                         break r;
                     }
-                    let err = std::io::Error::last_os_error();
-                    if err.raw_os_error() != Some(libc::EINTR) {
-                        return Err(socket_io_err(err));
+                    if errno != libc::EINTR {
+                        return Err(socket_io_err(std::io::Error::from_raw_os_error(errno)));
                     }
                     // EINTR: deliver a pending signal, then retry
                     // (`converted_error` eintr_retry).
@@ -2741,15 +2749,14 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
                 let family = socket_get_attr_i64(obj, "_family") as libc::c_int;
                 let (storage, slen) = pack_inet_addr(family, args[1])?;
                 loop {
-                    let r = unsafe {
+                    let (r, errno) = crate::module::thread::call_external_function(|| unsafe {
                         libc::connect(fd, &storage as *const _ as *const libc::sockaddr, slen)
-                    };
+                    });
                     if r == 0 {
                         break;
                     }
-                    let err = std::io::Error::last_os_error();
-                    if err.raw_os_error() != Some(libc::EINTR) {
-                        return Err(socket_io_err(err));
+                    if errno != libc::EINTR {
+                        return Err(socket_io_err(std::io::Error::from_raw_os_error(errno)));
                     }
                     // EINTR: deliver a pending signal, then retry
                     // (`converted_error` eintr_retry).
@@ -2780,13 +2787,12 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
                 // `interp_socket.py:387-391` — retry while the call is
                 // interrupted (EINTR), otherwise return the errno.
                 let err = loop {
-                    let r = unsafe {
+                    let (r, e) = crate::module::thread::call_external_function(|| unsafe {
                         libc::connect(fd, &storage as *const _ as *const libc::sockaddr, slen)
-                    };
+                    });
                     if r == 0 {
                         break 0;
                     }
-                    let e = std::io::Error::last_os_error().raw_os_error().unwrap_or(0);
                     if e != libc::EINTR {
                         break e;
                     }
@@ -2825,15 +2831,14 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
             let result = (|| -> Result<isize, crate::PyError> {
                 let buf = buffer.as_bytes();
                 loop {
-                    let r = unsafe {
+                    let (r, errno) = crate::module::thread::call_external_function(|| unsafe {
                         libc::send(fd, buf.as_ptr() as *const libc::c_void, buf.len(), flags)
-                    };
+                    });
                     if r >= 0 {
                         return Ok(r);
                     }
-                    let err = std::io::Error::last_os_error();
-                    if err.raw_os_error() != Some(libc::EINTR) {
-                        return Err(socket_io_err(err));
+                    if errno != libc::EINTR {
+                        return Err(socket_io_err(std::io::Error::from_raw_os_error(errno)));
                     }
                     // EINTR: deliver a pending signal, then retry
                     // (`converted_error` eintr_retry).
@@ -2868,23 +2873,22 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
                 let buf = buffer.as_bytes();
                 let mut off = 0usize;
                 while off < buf.len() {
-                    let n = unsafe {
+                    let (n, errno) = crate::module::thread::call_external_function(|| unsafe {
                         libc::send(
                             fd,
                             buf[off..].as_ptr() as *const libc::c_void,
                             buf.len() - off,
                             flags,
                         )
-                    };
+                    });
                     if n < 0 {
-                        let err = std::io::Error::last_os_error();
-                        if err.raw_os_error() == Some(libc::EINTR) {
+                        if errno == libc::EINTR {
                             // `rsocket.py:1132` signal_checker — deliver a
                             // pending signal, then retry the remaining bytes.
                             crate::module::signal::interp_signal::checksignals_now()?;
                             continue;
                         }
-                        return Err(socket_io_err(err));
+                        return Err(socket_io_err(std::io::Error::from_raw_os_error(errno)));
                     }
                     off += n as usize;
                 }
@@ -2923,13 +2927,14 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
             };
             let mut buf = vec![0u8; n];
             let got = loop {
-                let r = unsafe { libc::recv(fd, buf.as_mut_ptr() as *mut libc::c_void, n, flags) };
+                let (r, errno) = crate::module::thread::call_external_function(|| unsafe {
+                    libc::recv(fd, buf.as_mut_ptr() as *mut libc::c_void, n, flags)
+                });
                 if r >= 0 {
                     break r;
                 }
-                let err = std::io::Error::last_os_error();
-                if err.raw_os_error() != Some(libc::EINTR) {
-                    return Err(socket_io_err(err));
+                if errno != libc::EINTR {
+                    return Err(socket_io_err(std::io::Error::from_raw_os_error(errno)));
                 }
                 // EINTR: deliver a pending signal, then retry
                 // (`converted_error` eintr_retry).
@@ -2974,7 +2979,7 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
                 let family = socket_get_attr_i64(obj, "_family") as libc::c_int;
                 let (storage, slen) = pack_inet_addr(family, addr_obj)?;
                 loop {
-                    let r = unsafe {
+                    let (r, errno) = crate::module::thread::call_external_function(|| unsafe {
                         libc::sendto(
                             fd,
                             buf.as_ptr() as *const libc::c_void,
@@ -2983,13 +2988,12 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
                             &storage as *const _ as *const libc::sockaddr,
                             slen,
                         )
-                    };
+                    });
                     if r >= 0 {
                         return Ok(r);
                     }
-                    let err = std::io::Error::last_os_error();
-                    if err.raw_os_error() != Some(libc::EINTR) {
-                        return Err(socket_io_err(err));
+                    if errno != libc::EINTR {
+                        return Err(socket_io_err(std::io::Error::from_raw_os_error(errno)));
                     }
                     // EINTR: deliver a pending signal, then retry
                     // (`converted_error` eintr_retry).
@@ -3036,7 +3040,7 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
             let mut storage: libc::sockaddr_storage = unsafe { std::mem::zeroed() };
             let mut slen = core::mem::size_of::<libc::sockaddr_storage>() as libc::socklen_t;
             let got = loop {
-                let r = unsafe {
+                let (r, errno) = crate::module::thread::call_external_function(|| unsafe {
                     libc::recvfrom(
                         fd,
                         buf.as_mut_ptr() as *mut libc::c_void,
@@ -3045,13 +3049,12 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
                         &mut storage as *mut _ as *mut libc::sockaddr,
                         &mut slen,
                     )
-                };
+                });
                 if r >= 0 {
                     break r;
                 }
-                let err = std::io::Error::last_os_error();
-                if err.raw_os_error() != Some(libc::EINTR) {
-                    return Err(socket_io_err(err));
+                if errno != libc::EINTR {
+                    return Err(socket_io_err(std::io::Error::from_raw_os_error(errno)));
                 }
                 // EINTR: deliver a pending signal, then retry
                 // (`converted_error` eintr_retry).
@@ -3114,15 +3117,14 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
             };
             let fd = socket_fd(obj)?;
             let got = loop {
-                let r = unsafe {
+                let (r, errno) = crate::module::thread::call_external_function(|| unsafe {
                     libc::recv(fd, slot.as_mut_ptr() as *mut libc::c_void, nbytes, flags)
-                };
+                });
                 if r >= 0 {
                     break r;
                 }
-                let err = std::io::Error::last_os_error();
-                if err.raw_os_error() != Some(libc::EINTR) {
-                    return Err(socket_io_err(err));
+                if errno != libc::EINTR {
+                    return Err(socket_io_err(std::io::Error::from_raw_os_error(errno)));
                 }
                 // EINTR: deliver a pending signal, then retry
                 // (`converted_error` eintr_retry).
@@ -3182,7 +3184,7 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
             let mut storage: libc::sockaddr_storage = unsafe { std::mem::zeroed() };
             let mut slen = core::mem::size_of::<libc::sockaddr_storage>() as libc::socklen_t;
             let got = loop {
-                let r = unsafe {
+                let (r, errno) = crate::module::thread::call_external_function(|| unsafe {
                     libc::recvfrom(
                         fd,
                         slot.as_mut_ptr() as *mut libc::c_void,
@@ -3191,13 +3193,12 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
                         &mut storage as *mut _ as *mut libc::sockaddr,
                         &mut slen,
                     )
-                };
+                });
                 if r >= 0 {
                     break r;
                 }
-                let err = std::io::Error::last_os_error();
-                if err.raw_os_error() != Some(libc::EINTR) {
-                    return Err(socket_io_err(err));
+                if errno != libc::EINTR {
+                    return Err(socket_io_err(std::io::Error::from_raw_os_error(errno)));
                 }
                 // EINTR: deliver a pending signal, then retry
                 // (`converted_error` eintr_retry).
@@ -3280,13 +3281,14 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
                     msg.msg_control = control.as_mut_ptr() as *mut libc::c_void;
                     msg.msg_controllen = ancbufsize as _;
                 }
-                let r = unsafe { libc::recvmsg(fd, &mut msg, flags) };
+                let (r, errno) = crate::module::thread::call_external_function(|| unsafe {
+                    libc::recvmsg(fd, &mut msg, flags)
+                });
                 if r >= 0 {
                     break (r, msg.msg_flags);
                 }
-                let err = std::io::Error::last_os_error();
-                if err.raw_os_error() != Some(libc::EINTR) {
-                    return Err(socket_io_err(err));
+                if errno != libc::EINTR {
+                    return Err(socket_io_err(std::io::Error::from_raw_os_error(errno)));
                 }
                 // EINTR: deliver a pending signal, then retry
                 // (`converted_error` eintr_retry).
@@ -3424,13 +3426,14 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
                     msg.msg_control = control.as_mut_ptr() as *mut libc::c_void;
                     msg.msg_controllen = ancbufsize as _;
                 }
-                let r = unsafe { libc::recvmsg(fd, &mut msg, flags) };
+                let (r, errno) = crate::module::thread::call_external_function(|| unsafe {
+                    libc::recvmsg(fd, &mut msg, flags)
+                });
                 if r >= 0 {
                     break (r, msg.msg_flags, msg.msg_controllen);
                 }
-                let err = std::io::Error::last_os_error();
-                if err.raw_os_error() != Some(libc::EINTR) {
-                    return Err(socket_io_err(err));
+                if errno != libc::EINTR {
+                    return Err(socket_io_err(std::io::Error::from_raw_os_error(errno)));
                 }
                 // EINTR: deliver a pending signal, then retry
                 // (`converted_error` eintr_retry).
@@ -3640,13 +3643,14 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
             }
 
             let sent = loop {
-                let r = unsafe { libc::sendmsg(fd, &msg, flags) };
+                let (r, errno) = crate::module::thread::call_external_function(|| unsafe {
+                    libc::sendmsg(fd, &msg, flags)
+                });
                 if r >= 0 {
                     break r;
                 }
-                let err = std::io::Error::last_os_error();
-                if err.raw_os_error() != Some(libc::EINTR) {
-                    return Err(socket_io_err(err));
+                if errno != libc::EINTR {
+                    return Err(socket_io_err(std::io::Error::from_raw_os_error(errno)));
                 }
                 // EINTR: deliver a pending signal, then retry
                 // (`converted_error` eintr_retry).

--- a/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
+++ b/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
@@ -163,21 +163,83 @@ fn socket_converted_error(
     err
 }
 
-/// baseobjspace.py `writebuf_w` — the writable byte slice backing a
-/// scatter/gather buffer argument.  PyPy accepts any object exporting a
-/// writable buffer; pyre's writable byte stores are `bytearray` and a
-/// `memoryview` over one, so those are resolved here and anything else is
-/// rejected as `writebuf_w` does.
+/// One `space.acquire_writebuf` export held for the whole of a `recv_into`
+/// family call, the way `with rwbuffer:` keeps it across `c_recv`.
+///
+/// The syscall runs with the GIL released, so without the export another
+/// thread could resize the exporter and reallocate the storage the kernel is
+/// writing through; the count is what makes that resize raise instead.  The
+/// requested object and the concrete storage owner are both rooted, because
+/// the release in `Drop` has to name the owner after whatever Python ran in
+/// between.
 #[cfg(unix)]
-fn socket_writebuf(obj: pyre_object::PyObjectRef) -> Result<&'static mut [u8], crate::PyError> {
+struct SocketWritableBuffer {
+    _roots: pyre_object::gc_roots::RootScope,
+    owner_slot: usize,
+    held: bool,
+    address: *mut u8,
+    length: usize,
+}
+
+#[cfg(unix)]
+impl SocketWritableBuffer {
+    unsafe fn acquire(obj: pyre_object::PyObjectRef) -> Result<Self, crate::PyError> {
+        let roots = pyre_object::gc_roots::push_roots();
+        pyre_object::gc_roots::pin_root(obj);
+        let obj_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+        let (data, owner) =
+            socket_writebuf(pyre_object::gc_roots::shadow_stack_get(obj_slot))?;
+        pyre_object::gc_roots::pin_root(owner);
+        let owner_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+        let owner = pyre_object::gc_roots::shadow_stack_get(owner_slot);
+        let held = crate::builtins::buffer_export_incref(owner);
+        Ok(Self {
+            _roots: roots,
+            owner_slot,
+            held,
+            address: data.as_mut_ptr(),
+            length: data.len(),
+        })
+    }
+
+    unsafe fn as_mut_slice(&mut self) -> &mut [u8] {
+        std::slice::from_raw_parts_mut(self.address, self.length)
+    }
+}
+
+#[cfg(unix)]
+impl Drop for SocketWritableBuffer {
+    fn drop(&mut self) {
+        if self.held {
+            let owner = pyre_object::gc_roots::shadow_stack_get(self.owner_slot);
+            unsafe { crate::builtins::buffer_export_decref(owner) };
+        }
+    }
+}
+
+/// baseobjspace.py `writebuf_w` — the writable byte slice backing a
+/// scatter/gather buffer argument, with the object the export count lives on.
+/// PyPy accepts any object exporting a writable buffer; pyre's writable byte
+/// stores are `bytearray` and a `memoryview` over one, so those are resolved
+/// here and anything else is rejected as `writebuf_w` does.
+#[cfg(unix)]
+fn socket_writebuf(
+    obj: pyre_object::PyObjectRef,
+) -> Result<(&'static mut [u8], pyre_object::PyObjectRef), crate::PyError> {
     if unsafe { pyre_object::bytearrayobject::is_bytearray(obj) } {
-        return Ok(unsafe { pyre_object::bytearrayobject::w_bytearray_data_mut(obj) });
+        return Ok((
+            unsafe { pyre_object::bytearrayobject::w_bytearray_data_mut(obj) },
+            obj,
+        ));
     }
     if unsafe { pyre_object::interp_array::is_array(obj) } {
         // `space.writebuf_w` accepts any writable buffer exporter; an
         // `array.array` exposes its element bytes as one writable window
         // regardless of typecode (recv writes raw bytes into them).
-        return Ok(unsafe { pyre_object::interp_array::w_array_vec_mut(obj).as_mut_slice() });
+        return Ok((
+            unsafe { pyre_object::interp_array::w_array_vec_mut(obj).as_mut_slice() },
+            obj,
+        ));
     }
     if unsafe { pyre_object::memoryview::is_w_memoryview(obj) } {
         // `space.buffer_w` rejects a released view before exposing its storage.
@@ -199,6 +261,10 @@ fn socket_writebuf(obj: pyre_object::PyObjectRef) -> Result<&'static mut [u8], c
             ));
         }
         let view = unsafe { pyre_object::memoryview::w_memoryview_view(obj) };
+        // The view itself carries the export, as it does for `readinto`. Its
+        // backing is already held by the view's own construction, so nothing
+        // can resize the storage underneath while this one is alive either.
+        let owner = obj;
         // A writable view's backing is a `bytearray` or an `array.array`; both
         // expose a mutable byte store.  Honour the view window: write only into
         // `[offset, offset+length)` of the backing storage (itself already the
@@ -215,7 +281,7 @@ fn socket_writebuf(obj: pyre_object::PyObjectRef) -> Result<&'static mut [u8], c
                 "memoryview buffer is no longer valid",
             ));
         }
-        return Ok(&mut full[off..off + len]);
+        return Ok((&mut full[off..off + len], owner));
     }
     Err(crate::PyError::type_error(
         "a writable bytes-like object is required",
@@ -3081,7 +3147,8 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
             }
             let obj = args[0];
             let buf_obj = args[1];
-            let slot = socket_writebuf(buf_obj)?;
+            let mut buffer = unsafe { SocketWritableBuffer::acquire(buf_obj) }?;
+            let slot = unsafe { buffer.as_mut_slice() };
             let buf_len = slot.len();
             let nbytes = if args.len() >= 3 {
                 if !unsafe { pyre_object::is_int(args[2]) } {
@@ -3146,7 +3213,8 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
             }
             let obj = args[0];
             let buf_obj = args[1];
-            let slot = socket_writebuf(buf_obj)?;
+            let mut buffer = unsafe { SocketWritableBuffer::acquire(buf_obj) }?;
+            let slot = unsafe { buffer.as_mut_slice() };
             let buf_len = slot.len();
             let nbytes = if args.len() >= 3 {
                 if !unsafe { pyre_object::is_int(args[2]) } {
@@ -3367,7 +3435,7 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
                     pyre_object::w_tuple_len(seq)
                 }
             };
-            let mut buffers: Vec<&'static mut [u8]> = Vec::with_capacity(nbufs);
+            let mut buffers: Vec<SocketWritableBuffer> = Vec::with_capacity(nbufs);
             for i in 0..nbufs {
                 let item = unsafe {
                     if is_list {
@@ -3377,7 +3445,7 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
                     }
                 }
                 .ok_or_else(|| crate::PyError::type_error("recvmsg_into: buffer item missing"))?;
-                buffers.push(socket_writebuf(item)?);
+                buffers.push(unsafe { SocketWritableBuffer::acquire(item) }?);
             }
             let ancbufsize = if args.len() >= 3 {
                 if !unsafe { pyre_object::is_int(args[2]) } {
@@ -3408,10 +3476,13 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
             let fd = socket_fd(args[0])?;
 
             let mut iovs: Vec<libc::iovec> = buffers
-                .into_iter()
-                .map(|slice| libc::iovec {
+                .iter_mut()
+                .map(|buffer| {
+                    let slice = unsafe { buffer.as_mut_slice() };
+                    libc::iovec {
                     iov_base: slice.as_mut_ptr() as *mut libc::c_void,
                     iov_len: slice.len(),
+                    }
                 })
                 .collect();
             let mut control = vec![0u8; ancbufsize];

--- a/pyre/pyre-interpreter/src/module/fcntl/interp_fcntl.rs
+++ b/pyre/pyre-interpreter/src/module/fcntl/interp_fcntl.rs
@@ -36,7 +36,12 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 } else {
                     0
                 };
-                match rustpython_host_env::fcntl::fcntl_int(fd, cmd, arg) {
+                // F_SETLKW waits for the lock, so this is a blocking call.
+                let outcome = {
+                    let _blocked = crate::module::thread::before_external_block();
+                    rustpython_host_env::fcntl::fcntl_int(fd, cmd, arg)
+                };
+                match outcome {
                     Ok(v) => Ok(pyre_object::w_int_new(v as i64)),
                     Err(e) => Err(crate::PyError::os_error_with_errno(
                         e.raw_os_error().unwrap_or(0),
@@ -80,7 +85,11 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 } else {
                     0
                 };
-                match rustpython_host_env::fcntl::ioctl_int(fd, request, arg) {
+                let outcome = {
+                    let _blocked = crate::module::thread::before_external_block();
+                    rustpython_host_env::fcntl::ioctl_int(fd, request, arg)
+                };
+                match outcome {
                     Ok(v) => Ok(pyre_object::w_int_new(v as i64)),
                     Err(e) => Err(crate::PyError::os_error_with_errno(
                         e.raw_os_error().unwrap_or(0),
@@ -117,7 +126,12 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     }
                     let fd = (unsafe { pyre_object::w_int_get_value(args[0]) }) as i32;
                     let op = (unsafe { pyre_object::w_int_get_value(args[1]) }) as i32;
-                    match rustpython_host_env::fcntl::flock(fd, op) {
+                    // Without LOCK_NB this waits for the lock.
+                    let outcome = {
+                        let _blocked = crate::module::thread::before_external_block();
+                        rustpython_host_env::fcntl::flock(fd, op)
+                    };
+                    match outcome {
                         Ok(_) => Ok(pyre_object::w_none()),
                         Err(e) => Err(crate::PyError::os_error_with_errno(
                             e.raw_os_error().unwrap_or(0),
@@ -172,7 +186,12 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 } else {
                     0
                 };
-                match rustpython_host_env::fcntl::lockf(fd, cmd, len, start, whence) {
+                // F_LOCK waits for the lock.
+                let outcome = {
+                    let _blocked = crate::module::thread::before_external_block();
+                    rustpython_host_env::fcntl::lockf(fd, cmd, len, start, whence)
+                };
+                match outcome {
                     // `interp_fcntl.py:226 fcntl_lockf` returns
                     // space.w_None; the integer return value of the C
                     // helper was an internal pyre detail.

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -1269,9 +1269,12 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 let flags = flags | libc::O_NOINHERIT;
                 let c_path = std::ffi::CString::new(path.as_bytes())
                     .map_err(|_| crate::PyError::value_error("embedded null in path"))?;
-                let fd = unsafe { libc::open(c_path.as_ptr(), flags, mode as libc::c_uint) };
+                // Opening a FIFO without O_NONBLOCK waits for a peer.
+                let (fd, errno) = crate::module::thread::call_external_function(|| unsafe {
+                    libc::open(c_path.as_ptr(), flags, mode as libc::c_uint)
+                });
                 if fd < 0 {
-                    return Err(io_err(std::io::Error::last_os_error(), &path));
+                    return Err(io_err(std::io::Error::from_raw_os_error(errno), &path));
                 }
                 fd
             };
@@ -1333,12 +1336,11 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 #[cfg(not(feature = "sandbox"))]
                 let buf = {
                     let mut buf = vec![0u8; n];
-                    let ret = {
-                        let _blocked = crate::module::thread::before_external_block();
-                        unsafe { libc::read(fd, buf.as_mut_ptr() as *mut libc::c_void, n as _) }
-                    };
+                    let (ret, errno) = crate::module::thread::call_external_function(|| unsafe {
+                        libc::read(fd, buf.as_mut_ptr() as *mut libc::c_void, n as _)
+                    });
                     if ret < 0 {
-                        return Err(io_err(std::io::Error::last_os_error(), ""));
+                        return Err(io_err(std::io::Error::from_raw_os_error(errno), ""));
                     }
                     buf.truncate(ret as usize);
                     buf
@@ -1420,14 +1422,11 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     .map_err(|_| crate::PyError::type_error("write() arg 2 must be bytes-like"))?;
                 #[cfg(not(feature = "sandbox"))]
                 let ret = {
-                    let ret = {
-                        let _blocked = crate::module::thread::before_external_block();
-                        unsafe {
-                            libc::write(fd, data.as_ptr() as *const libc::c_void, data.len() as _)
-                        }
-                    };
+                    let (ret, errno) = crate::module::thread::call_external_function(|| unsafe {
+                        libc::write(fd, data.as_ptr() as *const libc::c_void, data.len() as _)
+                    });
                     if ret < 0 {
-                        return Err(io_err(std::io::Error::last_os_error(), ""));
+                        return Err(io_err(std::io::Error::from_raw_os_error(errno), ""));
                     }
                     ret as i64
                 };
@@ -3586,9 +3585,11 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     // interp_posix.py:433-435 `fsync(space, w_fd)` unwraps
                     // through `space.c_filedescriptor_w`.
                     let fd = crate::baseobjspace::c_filedescriptor_w(args[0])?;
-                    let r = unsafe { libc::fsync(fd) };
+                    let (r, errno) = crate::module::thread::call_external_function(|| unsafe {
+                        libc::fsync(fd)
+                    });
                     if r < 0 {
-                        return Err(io_err(std::io::Error::last_os_error(), ""));
+                        return Err(io_err(std::io::Error::from_raw_os_error(errno), ""));
                     }
                     Ok(pyre_object::w_none())
                 },
@@ -3613,12 +3614,18 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     // interp_posix.py:443-446 `fdatasync(space, w_fd)` unwraps
                     // through `space.c_filedescriptor_w`.
                     let fd = crate::baseobjspace::c_filedescriptor_w(args[0])?;
-                    #[cfg(any(target_os = "linux", target_os = "android"))]
-                    let r = unsafe { libc::fdatasync(fd) };
-                    #[cfg(not(any(target_os = "linux", target_os = "android")))]
-                    let r = unsafe { libc::fsync(fd) };
+                    let (r, errno) = crate::module::thread::call_external_function(|| unsafe {
+                        #[cfg(any(target_os = "linux", target_os = "android"))]
+                        {
+                            libc::fdatasync(fd)
+                        }
+                        #[cfg(not(any(target_os = "linux", target_os = "android")))]
+                        {
+                            libc::fsync(fd)
+                        }
+                    });
                     if r < 0 {
-                        return Err(io_err(std::io::Error::last_os_error(), ""));
+                        return Err(io_err(std::io::Error::from_raw_os_error(errno), ""));
                     }
                     Ok(pyre_object::w_none())
                 },
@@ -4318,10 +4325,12 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                         // libc::sendfile directly with a null pointer, matching
                         // rposix.sendfile_no_offset (rposix.py:3066-3069).
                         let count = count_raw as libc::size_t;
-                        let res =
-                            unsafe { libc::sendfile(out_fd, in_fd, core::ptr::null_mut(), count) };
+                        let (res, errno) =
+                            crate::module::thread::call_external_function(|| unsafe {
+                                libc::sendfile(out_fd, in_fd, core::ptr::null_mut(), count)
+                            });
                         if res < 0 {
-                            return Err(io_err(std::io::Error::last_os_error(), ""));
+                            return Err(io_err(std::io::Error::from_raw_os_error(errno), ""));
                         }
                         return Ok(pyre_object::w_int_new(res as i64));
                     }
@@ -4334,20 +4343,26 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 {
                     let count = count_raw as usize;
                     let mut offset: rustpython_host_env::crt_fd::Offset = offset_i64 as _;
-                    let n = host_posix::sendfile(out_b, in_b, &mut offset, count)
-                        .map_err(|e| io_err(e, ""))?;
+                    let n = {
+                        let _blocked = crate::module::thread::before_external_block();
+                        host_posix::sendfile(out_b, in_b, &mut offset, count)
+                    }
+                    .map_err(|e| io_err(e, ""))?;
                     return Ok(pyre_object::w_int_new(n as i64));
                 }
                 #[cfg(target_os = "macos")]
                 {
-                    let (res, written) = host_posix::sendfile(
-                        in_b,
-                        out_b,
-                        offset_i64 as rustpython_host_env::crt_fd::Offset,
-                        count_raw,
-                        None,
-                        None,
-                    );
+                    let (res, written) = {
+                        let _blocked = crate::module::thread::before_external_block();
+                        host_posix::sendfile(
+                            in_b,
+                            out_b,
+                            offset_i64 as rustpython_host_env::crt_fd::Offset,
+                            count_raw,
+                            None,
+                            None,
+                        )
+                    };
                     // rposix.py:3086-3095: BSD sendfile reports a partial
                     // transfer through sbytes even when the syscall result is
                     // EAGAIN/EBUSY. Return that progress so asyncio advances

--- a/pyre/pyre-interpreter/src/module/select/interp_kqueue.rs
+++ b/pyre/pyre-interpreter/src/module/select/interp_kqueue.rs
@@ -166,7 +166,7 @@ impl W_Kqueue {
             None
         };
         let nfds = loop {
-            let r = unsafe {
+            let (r, errno) = crate::module::thread::call_external_function(|| unsafe {
                 libc::kevent(
                     self.kqfd,
                     pchangelist,
@@ -175,12 +175,11 @@ impl W_Kqueue {
                     max_events as libc::c_int,
                     ptimeout,
                 )
-            };
+            });
             if r >= 0 {
                 break r;
             }
-            let e = std::io::Error::last_os_error();
-            if e.raw_os_error() == Some(libc::EINTR) {
+            if errno == libc::EINTR {
                 // `interp_kqueue.py:223-226` — deliver a pending signal, then
                 // retry with the remaining timeout recomputed.
                 crate::module::signal::interp_signal::checksignals_now()?;
@@ -196,8 +195,9 @@ impl W_Kqueue {
                 }
                 continue;
             }
+            let e = std::io::Error::from_raw_os_error(errno);
             return Err(crate::PyError::os_error_with_errno(
-                e.raw_os_error().unwrap_or(0),
+                errno,
                 format!("kevent: {e}"),
             ));
         };

--- a/pyre/pyre-interpreter/src/module/select/interp_select.rs
+++ b/pyre/pyre-interpreter/src/module/select/interp_select.rs
@@ -178,13 +178,13 @@ impl Poll {
         let mut cur_timeout = timeout;
         self.running = true;
         let ret = loop {
-            let r =
-                unsafe { libc::poll(pollfds.as_mut_ptr(), pollfds.len() as _, cur_timeout) };
+            let (r, errno) = crate::module::thread::call_external_function(|| unsafe {
+                libc::poll(pollfds.as_mut_ptr(), pollfds.len() as _, cur_timeout)
+            });
             if r >= 0 {
                 break r;
             }
-            let e = std::io::Error::last_os_error();
-            if e.raw_os_error() == Some(libc::EINTR) {
+            if errno == libc::EINTR {
                 // `interp_select.py:94-100` — deliver a pending signal, then
                 // retry with a recomputed timeout.  Reset `running` first so
                 // a raised handler does not leave the poll object wedged
@@ -204,8 +204,9 @@ impl Poll {
                 continue;
             }
             self.running = false;
+            let e = std::io::Error::from_raw_os_error(errno);
             return Err(crate::PyError::os_error_with_errno(
-                e.raw_os_error().unwrap_or(0),
+                errno,
                 format!("poll: {e}"),
             ));
         };
@@ -356,13 +357,19 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                             Some(&mut tv_storage)
                         }
                     };
-                    match host_select::select(
-                        nfds + 1,
-                        &mut rset,
-                        &mut wset,
-                        &mut xset,
-                        timeout_ref,
-                    ) {
+                    // `select` already carries its errno in the returned
+                    // `io::Error`, so the guard only has to span the call.
+                    let outcome = {
+                        let _blocked = crate::module::thread::before_external_block();
+                        host_select::select(
+                            nfds + 1,
+                            &mut rset,
+                            &mut wset,
+                            &mut xset,
+                            timeout_ref,
+                        )
+                    };
+                    match outcome {
                         Ok(_) => break,
                         Err(e) if e.raw_os_error() == Some(libc::EINTR) => {
                             // `interp_select.py:182` — deliver a pending

--- a/pyre/pyre-interpreter/src/module/signal/interp_signal.rs
+++ b/pyre/pyre-interpreter/src/module/signal/interp_signal.rs
@@ -924,7 +924,10 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                         }
                         let mut signum: libc::c_int = 0;
                         // sigwait returns the error number directly, not via errno.
-                        let ret = unsafe { libc::sigwait(&set, &mut signum) };
+                        let ret = {
+                            let _blocked = crate::module::thread::before_external_block();
+                            unsafe { libc::sigwait(&set, &mut signum) }
+                        };
                         if ret != 0 {
                             return Err(errno_exception("OSError", ret));
                         }

--- a/pyre/pyre-interpreter/src/module/thread/gil.rs
+++ b/pyre/pyre-interpreter/src/module/thread/gil.rs
@@ -1,0 +1,79 @@
+//! Global Interpreter Lock — `pypy/module/thread/gil.py`.
+//!
+//! The lock itself lives in `majit_gc::rgil` (the `rpython/translator/c/src`
+//! side). What this module adds is the half that belongs to the object space:
+//! a thread holds the GIL for as long as it runs pyre code, so without a
+//! periodic hand-off a compute-bound thread would never let another one run.
+//! `GILReleaseAction` is that hand-off — an action registered on the ticker
+//! which yields the GIL every `sys.getcheckinterval()` bytecodes.
+
+use crate::executioncontext::{
+    AsyncAction, AsyncActionOps, ExecutionContext, PeriodicAsyncAction, PeriodicAsyncActionOps,
+};
+use crate::pyframe::PyFrame;
+use pyre_object::PyObjectRef;
+
+/// gil.py:44-50 `GILReleaseAction` — "an action called every
+/// `sys.checkinterval` bytecodes. It releases the GIL to give some other
+/// thread a chance to run."
+pub struct GilReleaseAction {
+    base: PeriodicAsyncAction,
+}
+
+impl GilReleaseAction {
+    fn new(space: PyObjectRef) -> Box<Self> {
+        Box::new(Self {
+            base: *PeriodicAsyncAction::new(space),
+        })
+    }
+}
+
+impl AsyncActionOps for GilReleaseAction {
+    /// gil.py:48-50 `perform`: `rgil.yield_thread()`.
+    fn perform(
+        &mut self,
+        _ec: &mut ExecutionContext,
+        _frame: *mut PyFrame,
+    ) -> Result<(), crate::PyError> {
+        majit_gc::rgil::yield_thread();
+        Ok(())
+    }
+
+    fn async_action(&self) -> &AsyncAction {
+        &self.base.base
+    }
+
+    fn async_action_mut(&mut self) -> &mut AsyncAction {
+        &mut self.base.base
+    }
+}
+
+impl PeriodicAsyncActionOps for GilReleaseAction {}
+
+/// gil.py:20-23 `GILThreadLocals.initialize` — "add the GIL-releasing callback
+/// as an action on the space".
+///
+/// `use_bytecode_counter=True` is what puts it at the end of the periodic list
+/// (executioncontext.py:503-504: "hack to put the release-the-GIL one at the
+/// end of the list"), behind the signal check. Idempotent; the action is leaked
+/// deliberately because the actionflag holds a pointer into it for the whole
+/// run, exactly as `install_signal_handling` does.
+pub fn initialize(ec: &mut ExecutionContext) {
+    if ec.gil_release_action.is_some() {
+        return;
+    }
+    let action: &'static mut GilReleaseAction = Box::leak(GilReleaseAction::new(ec.space));
+    let async_ptr: *mut dyn AsyncActionOps = &mut *action;
+    action.register_periodic_action(&mut ec.actionflag, true);
+    ec.gil_release_action = Some(async_ptr);
+}
+
+/// gil.py:25-34 `GILThreadLocals.setup_threads` — "enable threads in the object
+/// space, if they haven't already been". Returns whether this call is the one
+/// that set them up.
+pub fn setup_threads(ec: &mut ExecutionContext) -> bool {
+    let first = ec.gil_release_action.is_none();
+    majit_gc::rgil::allocate();
+    initialize(ec);
+    first
+}

--- a/pyre/pyre-interpreter/src/module/thread/gil.rs
+++ b/pyre/pyre-interpreter/src/module/thread/gil.rs
@@ -55,9 +55,9 @@ impl PeriodicAsyncActionOps for GilReleaseAction {}
 ///
 /// `use_bytecode_counter=True` is what puts it at the end of the periodic list
 /// (executioncontext.py:503-504: "hack to put the release-the-GIL one at the
-/// end of the list"), behind the signal check. Idempotent; the action is leaked
-/// deliberately because the actionflag holds a pointer into it for the whole
-/// run, exactly as `install_signal_handling` does.
+/// end of the list"), behind the signal check. Idempotent; the actionflag
+/// holds the action's heap address, so ownership stays with the execution
+/// context until [`shutdown`] gives it back.
 pub fn initialize(ec: &mut ExecutionContext) {
     if ec.gil_release_action.is_some() {
         return;
@@ -66,6 +66,25 @@ pub fn initialize(ec: &mut ExecutionContext) {
     let async_ptr: *mut dyn AsyncActionOps = &mut *action;
     action.register_periodic_action(&mut ec.actionflag, true);
     ec.gil_release_action = Some(async_ptr);
+}
+
+/// Reclaim what [`initialize`] registered.
+///
+/// Upstream has nothing to reclaim: one `GILReleaseAction` is registered on
+/// `space.actionflag` for the process. pyre gives each execution context its
+/// own ticker, so each one also allocates its own action, and a thread which
+/// leaves without giving it back leaks it.
+///
+/// The caller's execution context, and with it the actionflag that still names
+/// this action, is dropped immediately afterwards without running any Python
+/// in between.
+pub fn shutdown(ec: &mut ExecutionContext) {
+    let Some(action) = ec.gil_release_action.take() else {
+        return;
+    };
+    // SAFETY: the pointer is the one `initialize` leaked out of a `Box`, and
+    // this is the only place that takes it back.
+    drop(unsafe { Box::from_raw(action) });
 }
 
 /// gil.py:25-34 `GILThreadLocals.setup_threads` — "enable threads in the object

--- a/pyre/pyre-interpreter/src/module/thread/gil.rs
+++ b/pyre/pyre-interpreter/src/module/thread/gil.rs
@@ -7,6 +7,8 @@
 //! `GILReleaseAction` is that hand-off — an action registered on the ticker
 //! which yields the GIL every `sys.getcheckinterval()` bytecodes.
 
+use std::sync::atomic::{AtomicBool, Ordering};
+
 use crate::executioncontext::{
     AsyncAction, AsyncActionOps, ExecutionContext, PeriodicAsyncAction, PeriodicAsyncActionOps,
 };
@@ -87,12 +89,36 @@ pub fn shutdown(ec: &mut ExecutionContext) {
     drop(unsafe { Box::from_raw(action) });
 }
 
+/// gil.py:17-18 `GILThreadLocals.gil_ready`, quasi-immutable and "changed (to
+/// True) only if it was really False before". It belongs to the object space,
+/// and pyre runs one per process, so the space slot is a process-global. Its
+/// writer holds the GIL, which is what upstream's plain attribute assignment
+/// relies on too.
+static GIL_READY: AtomicBool = AtomicBool::new(false);
+
 /// gil.py:25-34 `GILThreadLocals.setup_threads` — "enable threads in the object
 /// space, if they haven't already been". Returns whether this call is the one
-/// that set them up.
+/// that set them up, which is a property of the space and not of the calling
+/// thread.
 pub fn setup_threads(ec: &mut ExecutionContext) -> bool {
-    let first = ec.gil_release_action.is_none();
-    majit_gc::rgil::allocate();
+    debug_assert!(
+        majit_gc::rgil::am_i_holding_the_gil(),
+        "setup_threads needs the GIL"
+    );
+    let first = !GIL_READY.load(Ordering::Acquire);
+    if first {
+        // gil.py:29-31 allocates before publishing the flag.
+        majit_gc::rgil::allocate();
+        GIL_READY.store(true, Ordering::Release);
+    }
+    // Registering the action is per-execution-context, unlike upstream's
+    // once-per-space `initialize`, because the ticker it hangs on is too.
     initialize(ec);
     first
+}
+
+/// gil.py:37-38 `GILThreadLocals.threads_initialized`, reached through
+/// `os_thread.py:155-156 threads_initialized(space)`.
+pub fn threads_initialized() -> bool {
+    GIL_READY.load(Ordering::Acquire)
 }

--- a/pyre/pyre-interpreter/src/module/thread/mod.rs
+++ b/pyre/pyre-interpreter/src/module/thread/mod.rs
@@ -42,8 +42,10 @@ static ACTIVE_HANDLES: Mutex<Vec<usize>> = parking_lot::const_mutex(Vec::new());
 static EXECUTION_CONTEXTS: LazyLock<Mutex<indexmap::IndexMap<i64, usize>>> =
     LazyLock::new(|| Mutex::new(indexmap::IndexMap::new()));
 
-/// A blocking host call leaves the free-threaded collector's RUNNING census.
-/// This is a GC safepoint transition only; pyre has no process GIL.
+pub mod gil;
+
+/// `rffi.aroundstate.before()`: drop the GIL and leave the collector's RUNNING
+/// census for the duration of a blocking host call.
 pub(crate) fn before_external_block() -> majit_gc::gc_sync::BlockingGuard {
     majit_gc::gc_sync::before_external_block()
 }
@@ -1413,6 +1415,8 @@ fn spawn_thread(
     if parent_ec.is_null() {
         return Err(crate::PyError::runtime_error("no execution context"));
     }
+    // os_thread.py:172 `start_new_thread` begins with `setup_threads(space)`.
+    gil::setup_threads(unsafe { &mut *(parent_ec as *mut crate::PyExecutionContext) });
 
     let roots = pyre_object::gc_roots::push_roots();
     let base = pyre_object::gc_roots::shadow_stack_len();
@@ -1532,6 +1536,10 @@ fn spawn_thread(
             // first, matching OSThreadLocals.enter_thread() installing the
             // ExecutionContext before thread bootstrap invokes Python code.
             ec.install_user_del_action();
+            // Each mutator owns its ticker, so the GIL-releasing action has to
+            // be registered on this thread's own actionflag; without it a
+            // worker would hold the GIL until its next external call.
+            gil::initialize(&mut ec);
             let ident = current_ident();
             if has_handle {
                 let h = W_ThreadHandle::from_obj(handle_addr as PyObjectRef).unwrap();

--- a/pyre/pyre-interpreter/src/module/thread/mod.rs
+++ b/pyre/pyre-interpreter/src/module/thread/mod.rs
@@ -46,8 +46,23 @@ pub mod gil;
 
 /// `rffi.aroundstate.before()`: drop the GIL and leave the collector's RUNNING
 /// census for the duration of a blocking host call.
-pub(crate) fn before_external_block() -> majit_gc::gc_sync::BlockingGuard {
+pub fn before_external_block() -> majit_gc::gc_sync::BlockingGuard {
     majit_gc::gc_sync::before_external_block()
+}
+
+/// `rffi.py:193-211 call_external_function`: release the GIL, run the external
+/// call, read `errno`, and only then take the GIL back.  The returned `i32` is
+/// the saved `errno`, meaningful exactly when the call reports failure.
+///
+/// The read belongs inside the released window because `_errno_after` runs
+/// ahead of `rgil.acquire()` (rffi.py:207-210).  Taking the GIL back can enter
+/// the stealer loop, whose mutex and condvar waits overwrite `errno`, so a
+/// caller reading it after the guard drops can see the wrong value.
+pub(crate) fn call_external_function<R>(f: impl FnOnce() -> R) -> (R, i32) {
+    let _blocked = before_external_block();
+    let result = f();
+    let errno = std::io::Error::last_os_error().raw_os_error().unwrap_or(0);
+    (result, errno)
 }
 
 pub fn set_finalizing() {

--- a/pyre/pyre-interpreter/src/module/thread/mod.rs
+++ b/pyre/pyre-interpreter/src/module/thread/mod.rs
@@ -50,6 +50,61 @@ pub fn before_external_block() -> majit_gc::gc_sync::BlockingGuard {
     majit_gc::gc_sync::before_external_block()
 }
 
+thread_local! {
+    /// Set once this thread owns a mutator registration, so the entry below
+    /// stays a single thread-local read on every later entry.
+    static RUNTIME_THREAD_ENTERED: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+
+    /// Armed after `shadow_stack::register_mutator` has captured this thread's
+    /// root slots, so the destructor removes the registry entry before those
+    /// slots are destroyed and only then gives the GIL back.
+    static RUNTIME_THREAD: RuntimeThread = const { RuntimeThread };
+}
+
+struct RuntimeThread;
+
+impl Drop for RuntimeThread {
+    fn drop(&mut self) {
+        majit_gc::shadow_stack::unregister_mutator();
+        majit_gc::gc_sync::unregister_thread();
+    }
+}
+
+/// `rgil.py:186-193 acquire_maybe_in_new_thread`: a thread that has not run
+/// pyre code before becomes a GC mutator and takes the GIL before it runs any.
+///
+/// Upstream reaches every RPython thread through `rpython_startup_code` or
+/// rffi's callback path, both of which acquire before the first RPython
+/// instruction (entrypoint.c:49,78). pyre is entered from Rust at several
+/// points instead — the launcher, a spawned Python thread, and the unit tests
+/// that drive the interpreter directly — so the acquire is idempotent per
+/// thread and each entry point names it. The registration is given back by
+/// `RUNTIME_THREAD`'s destructor when the thread exits, which is what lets a
+/// second thread run pyre code afterwards.
+#[inline]
+pub fn ensure_runtime_thread() {
+    if RUNTIME_THREAD_ENTERED.with(|entered| entered.get()) {
+        return;
+    }
+    enter_runtime_thread();
+}
+
+#[cold]
+fn enter_runtime_thread() {
+    RUNTIME_THREAD_ENTERED.with(|entered| entered.set(true));
+    majit_gc::gc_sync::register_thread();
+    majit_gc::shadow_stack::register_mutator();
+    RUNTIME_THREAD.with(|_| {});
+}
+
+/// Whether this thread already owns its mutator registration.
+///
+/// pyre-jit's GC bootstrap has per-thread work of its own to hang off the same
+/// registration, so it asks rather than keeping a second flag.
+pub fn runtime_thread_entered() -> bool {
+    RUNTIME_THREAD_ENTERED.with(|entered| entered.get())
+}
+
 /// `rffi.py:193-211 call_external_function`: release the GIL, run the external
 /// call, read `errno`, and only then take the GIL back.  The returned `i32` is
 /// the saved `errno`, meaningful exactly when the call reports failure.

--- a/pyre/pyre-interpreter/src/module/thread/mod.rs
+++ b/pyre/pyre-interpreter/src/module/thread/mod.rs
@@ -1374,6 +1374,9 @@ fn thread_is_stopping(ec: &mut crate::PyExecutionContext) {
             local.thread_is_stopping(ident);
         }
     }
+    // Last: nothing above runs bytecode, so nothing can reach the ticker this
+    // action is registered on after it is gone.
+    gil::shutdown(ec);
 }
 
 /// The calling thread's identity.

--- a/pyre/pyre-interpreter/src/module/time/interp_time.rs
+++ b/pyre/pyre-interpreter/src/module/time/interp_time.rs
@@ -179,7 +179,8 @@ pub fn sleep(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     #[cfg(feature = "sandbox")]
     {
         // The controller services the sleep; signal handling is its concern.
-        let _blocking = crate::module::thread::before_external_block();
+        // Every trampolined seam op already brackets its round trip, and the
+        // bracket does not nest — a second one would leave the census twice.
         crate::host_seam::ops::sleep(dur.as_secs_f64())
             .map_err(|e| crate::host_seam::seam_os_err(e, ""))?;
         Ok(w_none())

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -2997,6 +2997,11 @@ impl PyFrame {
         w_inputvalue: Option<PyObjectRef>,
         operr: Option<crate::PyError>,
     ) -> crate::PyResult {
+        // A frame can be executed by a thread that has not run pyre code
+        // before — the launcher's interpreter thread, and the Rust tests that
+        // drive a frame directly — so this is one of the entry points that
+        // takes the GIL (rgil.py:186-193).
+        crate::module::thread::ensure_runtime_thread();
         // pyframe.py:360 `execute_frame.insert_stack_check_here = True`.
         // RPython's transform inserts the check at this graph entry, so
         // builtin/object-space calls remain usable while an existing frame is

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -4024,10 +4024,6 @@ pub fn reset_gc_fresh_for_test() {
 /// `set_active_*` install.
 pub fn init_gc_subsystem() {
     build_gc_global();
-    // rbigint.py constructs `_parts_cache_10` at module import.  Force pyre's
-    // translated prebuilt equivalent before any collector root walk rather
-    // than lazily manufacturing it from inside the walker.
-    pyre_object::rbigint::initialize_rbigint_parts_cache();
     pyre_interpreter::call::register_thread_entry_hook(|| {
         init_jit_hooks();
         init_gc_root_walkers();
@@ -4040,6 +4036,11 @@ pub fn init_gc_subsystem() {
         install_gc_into_backend();
         GC_TLS_INSTALLED.with(|c| c.set(true));
     }
+    // rbigint.py constructs `_parts_cache_10` at module import.  Force pyre's
+    // translated prebuilt equivalent before any collector root walk rather
+    // than lazily manufacturing it from inside the walker. After registration,
+    // because it allocates and so needs this thread to hold the GIL.
+    pyre_object::rbigint::initialize_rbigint_parts_cache();
     PYRE_OBJECT_HOOKS_INSTALLED.call_once(install_pyre_object_hooks);
 }
 

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -1249,27 +1249,13 @@ type JitDriverPair = (
 );
 
 thread_local! {
-    /// Per-thread flag: this thread has registered with the gc_sync
-    /// mutator registry and installed the backend GC handle into the
-    /// backend's per-thread TLS box. The majit_gc set_active_* fn-ptrs and
-    /// pyre_object gc_hook cells are now process-global (#396), so they are
-    /// installed once (not gated by this flag); only the per-thread backend
-    /// box and mutator registration remain per-thread here.
+    /// Per-thread flag: this thread has installed the backend GC handle into
+    /// the backend's per-thread TLS box and registered its root areas. The
+    /// majit_gc set_active_* fn-ptrs and pyre_object gc_hook cells are now
+    /// process-global (#396), so they are installed once (not gated by this
+    /// flag). The mutator registration itself belongs to pyre-interpreter's
+    /// thread entry.
     static GC_TLS_INSTALLED: Cell<bool> = const { Cell::new(false) };
-
-    /// Initialized after shadow_stack::register_mutator has captured all four
-    /// root TLS slots. Its destructor therefore removes the registry entry
-    /// before those slots are destroyed, then removes the thread from RUNNING.
-    static GC_MUTATOR_REGISTRATION: GcMutatorRegistration = const { GcMutatorRegistration };
-}
-
-struct GcMutatorRegistration;
-
-impl Drop for GcMutatorRegistration {
-    fn drop(&mut self) {
-        majit_gc::shadow_stack::unregister_mutator();
-        majit_gc::gc_sync::unregister_thread();
-    }
 }
 
 fn write_subclass_ranges<I, F>(classptrs: I, mut range_for: F)
@@ -4028,11 +4014,12 @@ pub fn init_gc_subsystem() {
         init_jit_hooks();
         init_gc_root_walkers();
     });
+    // The mutator registration and the GIL that comes with it belong to
+    // pyre-interpreter's thread entry, which the interpreter reaches on its own
+    // from every point pyre code is entered at.
+    pyre_interpreter::module::thread::ensure_runtime_thread();
     if !GC_TLS_INSTALLED.with(|c| c.get()) {
-        majit_gc::gc_sync::register_thread();
-        majit_gc::shadow_stack::register_mutator();
         register_thread_root_areas();
-        GC_MUTATOR_REGISTRATION.with(|_| {});
         install_gc_into_backend();
         GC_TLS_INSTALLED.with(|c| c.set(true));
     }

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -3894,12 +3894,7 @@ fn register_thread_root_areas() {
         register(forced_virtuals_root_walker_area, jit_driver);
         // The ephemeron half of the walker above, on the same `data` so the
         // prune reaches exactly the drivers the root walk reaches.
-        unsafe {
-            majit_gc::shadow_stack::register_mutator_pruner(
-                forced_virtuals_pruner_area,
-                jit_driver,
-            );
-        }
+        majit_gc::shadow_stack::register_mutator_pruner(forced_virtuals_pruner_area, jit_driver);
     }
 }
 

--- a/pyre/pyre-jit/src/lib.rs
+++ b/pyre/pyre-jit/src/lib.rs
@@ -122,6 +122,10 @@ mod tests {
     fn stack_overflow_probe_raises_into_pending_exception_slot() {
         use pyre_interpreter::stack_check;
 
+        // The slowpath is reached from generated code, which runs with the GIL
+        // held; driving it directly makes this thread the mutator instead.
+        pyre_interpreter::module::thread::ensure_runtime_thread();
+
         // Install the same backend bridge call_jit::install_jit_call_bridge
         // wires up at runtime, so the registered slowpath addresses
         // really are the ones the cranelift / dynasm prologues invoke.

--- a/pyre/pyrex/src/repl_readline.rs
+++ b/pyre/pyrex/src/repl_readline.rs
@@ -106,7 +106,11 @@ impl Readline {
         }
     }
 
+    /// Waiting for a line waits on the user, so the GIL is dropped for the
+    /// whole read: a `threading` timer or a daemon thread has to keep running
+    /// while the prompt sits there.
     pub fn readline(&mut self, prompt: &str) -> ReadlineResult {
+        let _blocked = pyre_interpreter::module::thread::before_external_block();
         match &mut self.backend {
             ReadlineBackend::Basic => read_basic_line(prompt),
             ReadlineBackend::Editor(editor) => {


### PR DESCRIPTION
pyre had no GIL. Mutual exclusion for GC operations came from `gc_sync`'s own per-operation gate: every `gc_op` compare-and-swapped a claim word whose expected value was the calling thread's ident, so **every allocation** paid a `_tlv_get_addr` call (Mach-O `thread_local!`), a CAS, and a release store.

A design pass over that gate concluded it cannot be made cheaper on its own terms. A constant token instead of the ident dies on `in_gc_op()` — `gc_query_reentrant` asks "am *I* already inside a `gc_op`", and a shared token only answers "*someone* is". Both error directions are fatal, and `register_thread`'s own doc admits the reachable case: an unregistered thread may still call `gc_op`. Every repair needs per-thread state on the entry path, which on Mach-O is the TLS call being removed.

Upstream does not have this problem, and not because its gate is cheaper — it has no gate. `rg threadlocalref_addr rpython/memory/gctransform/framework.py rpython/memory/gc/incminimark.py` has **no hits**: the allocation path reads no thread identity at all. The GIL is held, so `malloc_fixedsize` just bumps `gcdata.gc.nursery_free`.

So this ports the GIL, and specifically its *lifetime*.

## What is ported

`majit/majit-gc/src/rgil.rs` is `rpython/translator/c/src/thread_gil.c` plus the `mutex2_t` half of `thread_pthread.c:559-595` and the `rgil.py` surface.

The composite GIL is two locks (thread_gil.c:2-31). `rpy_fastgil` is a plain word — 0 means unlocked, anything else is the holder's ident; release is a plain store of 0, acquire is a CAS against 0. `mutex_gil` is a mutex the fast path never unlocks; the loser of the CAS goes to `RPyGilAcquireSlowPath`, becomes the stealer via `mutex_gil_stealer`, and alternates between retrying the fast path and `mutex2_lock_timeout(&mutex_gil, 0.0001)`. `rpy_waiting_threads`, the randomised early poll (`n = rpy_early_poll_n*2+1` wrapped into `[40, 400)`), `RPyGilYieldThread`, `gil_get_holder` and `am_I_holding_the_GIL` all come across.

`pyre-interpreter/src/module/thread/gil.rs` is `pypy/module/thread/gil.py:44-50` — `GILReleaseAction`, a `PeriodicAsyncAction` with `use_bytecode_counter=True` whose `perform` calls `rgil.yield_thread()`. It is registered **per `ExecutionContext`** rather than once per space, because each pyre mutator owns its own ticker and actionflag; `clone_for_thread` clears the slot.

The lifetime: acquire in `register_thread` and on return from an external block, release in `unregister_thread` and in `before_external_block`. A thread therefore holds the GIL for as long as it runs pyre code, which is the whole point — between two external calls arbitrarily many allocations run with zero synchronisation.

One deviation, stated deliberately: a thread waiting for the GIL leaves the RUNNING census (`leave_running_for_gil` / `rejoin_running_after_gil`). pyre's collector drains that census explicitly; upstream needs no equivalent because there the collector *is* the GIL holder.

## What that lets go

Deleted from `gc_sync`: `IN_FAST_PATH`, `GATE_INSIDE`, `GateGuard`, `release_gate`, `revoke_standing_claim`, `acquire_gate`, `in_gc_op`, `gc_op_slow`. `gc_mutex` no longer guards any operation and is renamed `install_mutex`.

```rust
pub fn gc_op<R>(f: impl FnOnce(&mut MiniMarkGC) -> R) -> R {
    debug_assert!(crate::rgil::am_i_holding_the_gil(), "a GC operation needs the GIL");
    let _reentry = ReentryGuard::enter();
    f(unsafe { singleton_mut() })
}
```

In release that is a bare borrow: no atomic, no TLS read. The reentrant-`&mut` check moves to a `#[cfg(debug_assertions)]` global bool — under a GIL one global replaces per-thread state.

`revoke_standing_claim` in particular existed *because* pyre had no guaranteed release points. It now has them.

## Measurement

`synth/int_mul_ovf_bignum_promote`, 400M iterations, dynasm/aarch64. Paired per-round ratio and a sign test, because the machine is shared. Both arms are built from the same tip — the baseline is `git checkout HEAD~1 -- majit/majit-gc pyre/pyre-interpreter pyre/pyre-jit` **without** re-extracting `.ullbc`, so the only difference between the two binaries is the GIL. They produce identical benchmark output.

| run | load avg | median ratio | rounds faster |
|---|---|---|---|
| 15 rounds | 44 → 13 | 0.8790 (−12.1%) | 13/15 |
| 12 rounds | 6 | **0.8498 (−15.0%)** | **12/12** |

This is more than the −6.8% ceiling an earlier unsound probe predicted, and the reason is that the probe only stubbed `my_ident()` — it still paid the CAS and the gate-release store on every allocation. The GIL removes all three.

## The commits on top

**`thread, modules: release the GIL around the remaining blocking host calls`.** Under a GIL a missed release is a deadlock, not a delay, because the sleeper holds it. `rffi.llexternal`'s `releasegil` default is *release* (rffi.py:151 — `invoke_around_handlers = not sandboxsafe and not _nowrapper`), so an audit of every blocking host call in the interpreter was owed. Newly bracketed: `select.poll`/`select.select`, `kqueue.control`, socket `accept`/`connect`/`send`/`sendall`/`sendto`/`sendmsg`/`recv`/`recvfrom`/`recvmsg` and the `getaddrinfo`/`getnameinfo` lookups, `signal.sigwait`, `_multiprocessing`'s `sem_wait` and both timed-wait arms, the fd read and write behind file objects, posix `open`/`fsync`/`fdatasync`/`sendfile`, fcntl `fcntl`/`ioctl`/`flock`/`lockf`, the `host_seam` real-host bodies and the sandbox trampoline, the stdlib-path `python3` subprocess, and the REPL line read.

It also adds `call_external_function`, which is `rffi.py:193-211`: release, call, **read errno, then** re-acquire. Upstream runs `_errno_after` ahead of `rgil.acquire()` (rffi.py:207-210) and pyre's existing brackets did not — `posix.read` and `posix.write` read `last_os_error()` after their guard had dropped, so a re-acquire that went through the stealer's mutex and condvar waits could overwrite the value they then reported.

Demonstrated with a smoke test that runs a counter thread while the main thread blocks: every one of `select.select`, `select.poll`, `os.read` on an empty pipe, `socket.accept` and `socket.recv` now lets the peer advance ~240k iterations across a 0.2s wait, where before it would have advanced none.

**`thread: take the GIL at the points Rust enters pyre code`.** This is what turned CI red on all three platforms, and it is not a test artefact. The registration — and the GIL that comes with it — was owned by pyre-jit's `init_gc_subsystem`, which only the launcher thread and spawned Python threads reach. A thread entering pyre code anywhere else allocated without ever becoming a mutator, so `gc_op`'s assertion fired in debug and, in release, the operation had **no exclusion at all**; before this port, `gc_op`'s own gate covered exactly that thread.

The fix cannot live inside `gc_op`: `am_i_holding_the_gil()` needs `my_ident()`, the `_tlv_get_addr` call that *was* the entire −6.8% ceiling, so a per-operation check costs back about half the win. The invariant has to be established by the threads instead. `module/thread::ensure_runtime_thread` is `rgil.py:186-193 acquire_maybe_in_new_thread`: idempotent per thread, it registers the mutator, takes the GIL, and arms a thread-local whose destructor unregisters and gives the GIL back at thread exit. That destructor is the load-bearing half — without it the first test thread would hold the GIL forever and every later one would deadlock instead of assert. the compile entries and `PyFrame::execute_frame` name it, and `init_gc_subsystem` now delegates rather than registering itself, so the registration has one owner.

**`majit-gc: keep the published nursery top live with more than one mutator`.** `register_thread` pinned the `gc.py:525-531` published nursery-top slot to zero on the 1→2 registration transition, so generated inline allocation stopped using the non-atomic bump once a second mutator registered. `llsupport/gc.py:525-531 get_nursery_free_addr`/`get_nursery_top_addr` carry no thread-count gate — the bump is serialised by the GIL. The transition goes, and with it `inline_alloc_enabled`, `set_inline_alloc_enabled` and its `GcHandle` forwarder, which had no other caller.

**`majit-gc, thread: address the GIL-port review findings`.** The fixes the bot reviews earned. `rgil::after_fork_child` re-created only `mutex_gil`'s `locked` flag; a thread that vanished in `fork()` inside `acquire_slow_path` leaves `mutex_gil_stealer` locked too, so both are now overwritten the way `rpy_init_mutexes` (thread_gil.c:92-98) `pthread_mutex_init`s them. `cfuncptr_call` held the GIL across `host_ctypes::call`, but `clibffi.py:350-352` declares `ffi_call` with the default `releasegil='auto'`, i.e. released. Under `sandbox`, `interp_time::sleep` entered an external block and then called `ops::sleep`, whose trampoline enters another one — the nested guard trips the RUNNING-census assertion; the redundant outer bracket goes. `RealHost::read` read `errno` after `blocking` had re-acquired the GIL. Plus: `BlockingGuard` is `#[must_use]` and `!Send`, `isenabled` stops being the one `&self` query routed through `gc_op`, the runtime-thread entry moves into `compile_source`/`compile_source_with_opts`, and `gil::shutdown` gives back the `GILReleaseAction` each execution context allocated. The full triage of all 22 findings, including four refuted with their disproofs, is in a comment below.

**`_socket: hold a writable-buffer export across the recv_into family`**, **`thread: answer setup_threads from the space, not the execution context`** and **`majit-gc: port RPyGilReleaseSignal`**. The remaining review findings. The first is demonstrable: a thread blocked in `recv_into(bytearray(64))` while the main thread appends to the same bytearray used to have the append accepted and the peer's five bytes land in the freed allocation (`buf[:5] == b'\x00\x00\x00\x00\x00'`); it now raises `BufferError` and reads back `b'hello'`. The third is from the Codex parity review: `RPyGilReleaseSignal`'s `_WIN32` guard is the point of it, not a reason to skip it — without it a Windows stealer waits out its timed wait at the 10-15 ms timer quantum.

## Verification

`cargo test --all --no-default-features --features dynasm`: 7380 passed, 0 failed. `cargo check --workspace` clean, and the CI clippy gate (`pyre-interpreter --features sandbox,dynasm`) clean.

`pyre/check.py` after `scripts/extract-llbc.py`: **dynasm 370/370, cranelift 370/370, wasm 366/366 — all three backends green.**

## What was dropped

`majit-gc: delete the stop-the-world protocol the GIL replaced` was on this branch and has been taken off it. It bisects to a SIGBUS in `gc_table_extra_root_walker` under `finalize_runtime`'s full collection — `MAJIT_GC_NURSERY_POISON=1 ./pyre-dynasm pyre/bench/synth/mutate_then_raise_caught.py`, interleaved A/B: 0/100 at its parent, 10/100 with it, 0/140 at the branch base. The argument for the deletion still holds; what it exposes does not, so it is being finished separately rather than landed here. The safepoint harness therefore stays underneath the GIL for now, and `pyre/design.md` says so.

`pyre/design.md`'s §3.3 declared free threading as present policy and listed a GIL among the non-options. It now records the GIL as the shipped mechanism, free threading as the target, and the measurement above.

— *opened by Claude*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added coordinated interpreter locking for safer execution across runtime threads.
  * Blocking networking, filesystem, subprocess, synchronization, and input operations now yield execution appropriately.
  * Runtime and compiled code initialize consistently on the correct interpreter thread.
  * Crash diagnostics now include macOS reports and more complete captured output.

* **Bug Fixes**
  * Improved garbage-collection coordination, root preservation, allocation safety, signal interruption, and error reporting.
  * Improved fork and finalization behavior during concurrent execution.

* **Documentation**
  * Updated runtime and garbage-collection guidance for the new locking and synchronization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
