### PR TITLE
gc_roots: walk the root stack by value; name the entry-bridge InvalidLoop reason

### DIFF
--- a/majit/majit-backend/src/model.rs
+++ b/majit/majit-backend/src/model.rs
@@ -84,43 +84,50 @@ pub trait Cpu: Send + Sync {
     /// it unconditionally; if pyre cannot resolve the same metadata
     /// (parent_descr missing, vtable subclassrange unknown, typeid
     /// unresolvable, downcast fails), the speculative check fails
-    /// closed (`Err(())`) so the fold caller declines.  Matching
-    /// PyPy's "raise SpeculativeError" on any path where the
-    /// type-validity verdict cannot be produced.
+    /// closed so the fold caller declines.  Matching PyPy's "raise
+    /// SpeculativeError" on any path where the type-validity verdict
+    /// cannot be produced.  The `Err` names which of those paths fired, so
+    /// the `InvalidLoop` the caller signals says more than that one did.
     fn protect_speculative_field(
         &self,
         gcptr: GcRef,
         fielddescr: &dyn FieldDescr,
-    ) -> Result<(), ()> {
+    ) -> Result<(), &'static str> {
         if gcptr.is_null() {
-            return Err(());
+            return Err("protect_speculative_field: null gcptr");
         }
         if !majit_gc::supports_guard_gc_type() {
             return Ok(());
         }
-        let parent = fielddescr.get_parent_descr().ok_or(())?;
-        let sizedescr = parent.as_size_descr().ok_or(())?;
+        let parent = fielddescr
+            .get_parent_descr()
+            .ok_or("protect_speculative_field: field descr has no parent_descr")?;
+        let sizedescr = parent
+            .as_size_descr()
+            .ok_or("protect_speculative_field: parent_descr is not a size descr")?;
         if sizedescr.is_object() {
             if !majit_gc::check_is_object(gcptr) {
-                return Err(());
+                return Err("protect_speculative_field: gcptr is not an object");
             }
             // descr.py:217-229 is_valid_class_for — subclassrange
             // containment of gcref's typeptr inside sizedescr.vtable's
             // range.
-            let (expected_min, expected_max) =
-                majit_gc::subclass_range(sizedescr.vtable()).ok_or(())?;
+            let (expected_min, expected_max) = majit_gc::subclass_range(sizedescr.vtable())
+                .ok_or("protect_speculative_field: descr vtable has no range")?;
             let actual_vtable = self.cls_of_gcref(gcptr);
             if actual_vtable == 0 {
-                return Err(());
+                return Err("protect_speculative_field: gcptr has no class");
             }
-            let (actual_min, _) = majit_gc::subclass_range(actual_vtable as usize).ok_or(())?;
+            let (actual_min, _) = majit_gc::subclass_range(actual_vtable as usize)
+                .ok_or("protect_speculative_field: gcptr class has no range")?;
             if !(expected_min <= actual_min && actual_min <= expected_max) {
-                return Err(());
+                return Err("protect_speculative_field: class outside the descr's subclass range");
             }
         } else {
-            let actual_tid = majit_gc::get_actual_typeid(gcptr).ok_or(())?;
+            let actual_tid = majit_gc::get_actual_typeid(gcptr)
+                .ok_or("protect_speculative_field: gcptr has no typeid")?;
             if actual_tid != sizedescr.type_id() {
-                return Err(());
+                return Err("protect_speculative_field: typeid does not match the descr");
             }
         }
         Ok(())

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -6779,8 +6779,15 @@ impl OptContext {
                 .as_ref()
                 .and_then(|d| d.as_field_descr())
                 .expect("GETFIELD_GC_PURE_* descr must be a FieldDescr");
-            if self.cpu.protect_speculative_field(gcref, fd).is_err() {
-                self.signal_invalid_loop("protect_speculative_field");
+            if let Err(reason) = self.cpu.protect_speculative_field(gcref, fd) {
+                if crate::majit_log_enabled() {
+                    eprintln!(
+                        "[jit] {reason} — field={:?} descr={}",
+                        fd.field_name(),
+                        fd.repr_of_descr()
+                    );
+                }
+                self.signal_invalid_loop(reason);
             }
             return;
         }

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -10679,8 +10679,8 @@ impl<M: Clone> MetaInterp<M> {
                 crate::mc_diag_bump(36); // compile_entry_bridge: optimize_bridge InvalidLoop
                 if crate::majit_log_enabled() {
                     eprintln!(
-                        "[jit] compile_entry_bridge: {invalid_loop} target={green_key} \
-                         original={original_green_key}",
+                        "[jit] compile_entry_bridge: InvalidLoop({}) target={} original={}",
+                        invalid_loop.0, green_key, original_green_key
                     );
                 }
                 return false;

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -206,7 +206,44 @@ pub fn field_descr_ref_from_bh(descr: &crate::blackhole::BhDescr) -> (usize, maj
                         );
                         return (*offset, fd as majit_ir::DescrRef);
                     }
+                } else {
+                    // `all_fielddescrs` empty is not the same as "no owning
+                    // struct": `descr.py:238 parent_descr = get_size_descr(
+                    // gccache, STRUCT, vtable)` derives the parent from the
+                    // STRUCT itself, and the flattened field list only supplies
+                    // `index_in_parent` (`descr.py:228`).  Mint the SizeDescr
+                    // from what the producer did attach so the field carries a
+                    // parent; without one `protect_speculative_field`
+                    // (`llmodel.py:560`, which asserts the parent exists) has no
+                    // type to validate against and fails closed, taking the
+                    // whole bridge with it.
+                    let struct_key = majit_ir::descr::LLType::Struct(p.type_id);
+                    let mut gc = majit_ir::descr::gc_cache().lock().unwrap();
+                    gc.get_size_descr(struct_key.clone(), p.size, p.vtable as usize, false);
+                    let fd = gc.get_field_descr(
+                        struct_key,
+                        name,
+                        None,
+                        *offset,
+                        *field_size,
+                        *field_type,
+                        *is_immutable,
+                        *is_quasi_immutable,
+                        *field_flag,
+                        *index_in_parent as u32,
+                        false,
+                        *index_in_parent,
+                    );
+                    return (*offset, fd as majit_ir::DescrRef);
                 }
+            }
+            if crate::majit_log_enabled() {
+                eprintln!(
+                    "[jit] field_descr_ref_from_bh: parentless placeholder for \
+                     field={name:?} offset={offset} size={field_size} type={field_type:?} \
+                     has_parent={}",
+                    parent.is_some()
+                );
             }
             (
                 *offset,

--- a/pyre/pyre-interpreter/src/stack_check.rs
+++ b/pyre/pyre-interpreter/src/stack_check.rs
@@ -646,6 +646,12 @@ pub fn set_recursion_limit(new_limit: i32) -> Result<(), PyError> {
     // 0.001 * 163840))`.  Both of pyre's root stacks are sized off it: the
     // jitframe one compiled code pushes to, and the interpreter's `push_roots`
     // stack, which holds a slot per pinned livevar across a recursive call.
+    // The allocation is eager (`shadowstack.py:351-364` resizes on the spot),
+    // and the `MAX_RECURSION_LIMIT` clamp above is the only thing bounding it:
+    // `vm.py:83-88` adds that same 10**6 ceiling precisely "because huge values
+    // cause huge shadowstacks to be allocated (or MemoryErrors)".  A tighter
+    // bound here would cap the root stack below the recursion limit it is
+    // sized for.
     let root_stack_depth = (limit as f64 * 0.001 * 163840.0) as usize;
     majit_gc::shadow_stack::increase_root_stack_depth(root_stack_depth);
     pyre_object::gc_roots::increase_root_stack_depth(root_stack_depth);

--- a/pyre/pyre-object/src/gc_roots.rs
+++ b/pyre/pyre-object/src/gc_roots.rs
@@ -703,10 +703,15 @@ unsafe fn walk_shadow_stack_cell(
         // would strand a cached pointer in the freed one. Only pushes can
         // occur, so `end` stays within bounds.
         // SAFETY: `index < end <= len()`, so the slot is live.
-        let slot = unsafe { stack.base.get().add(index) };
-        // SAFETY: `slot` names the live element at `index`. The reference is
-        // handed directly to the visitor and is not used after it returns.
-        visitor(unsafe { &mut *slot });
+        let mut root = unsafe { *stack.base.get().add(index) };
+        visitor(&mut root);
+        // Store back through a re-read `base` rather than handing the visitor
+        // a `&mut` into the buffer: a re-entrant push that grows the stack
+        // frees the buffer the slot was read from, and a visitor that writes
+        // its reference after allocating would then write into the freed one.
+        // `grow` copies the live prefix, so `index` still names this slot.
+        // SAFETY: `index < end <= len()`, so the slot is live.
+        unsafe { *stack.base.get().add(index) = root };
         index += 1;
     }
 }


### PR DESCRIPTION
Two review responses from PR #966, plus the diagnostic that found them.

### `gc_roots`: walk the root stack by value

`walk_shadow_stack_cell` already re-reads `base` for every slot so a re-entrant
push that calls `grow` cannot strand the walk in the freed buffer — but it still
handed the visitor a `&mut PyObjectRef` pointing *into* that buffer. A visitor
that pins a root and then writes through its reference writes into the
allocation `grow` had already freed.

The slot is now read into a local, the visitor gets `&mut` to the local, and the
value is stored back through a re-read `base`. `PyObjectRef` is
`*mut PyObject`, so it is a register copy either way, and `grow` copies the live
prefix, so the index still names the same slot. `walk_shadow_stack` and
`walk_shadow_stack_area` both go through this one loop.

`cargo test --release -p pyre-object gc_roots`: 10 passed, 0 failed.

### `stack_check`: record why `MAX_RECURSION_LIMIT` is the bound

The review also asked for a bound on `root_stack_depth` before the eager
allocation. That bound already exists and is upstream's: `shadowstack.py:351-364`
resizes on the spot, and `vm.py:83-88` adds its 10**6 ceiling for exactly that
reason — "because huge values cause huge shadowstacks to be allocated (or
MemoryErrors)". `MAX_RECURSION_LIMIT` is that same 10**6. A tighter bound would
size the root stack below the recursion limit it exists to serve, so the change
here is the citation, not a new clamp.

### `jit`: name the `InvalidLoop` reason in the entry-bridge log

`compile_entry_bridge` discarded the `InvalidLoop` payload, so the log said only
that the bridge was abandoned. The reason string is what separates a
speculative-field rejection from a quasi-immutable invalidation, and both reach
that arm. With it, `exception_reraise_tb_depth_jitstress`'s 1198 aborts resolved
1:1 to `InvalidLoop(quasi immutable field changed during tracing)` — the failure
#977 has since fixed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved diagnostic logging for invalid loop handling by including associated error details.
  - Improved garbage-collection root handling during stack growth, helping prevent stale references during re-entrant operations.
  - Improved speculative optimization validation and error reporting with more specific failure details.
  - Improved field resolution for layouts with incomplete metadata, supporting more reliable JIT compilation.

- **Documentation**
  - Added documentation clarifying recursion-limit behavior and root-stack memory allocation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->