### PR TITLE
jit: give W_UnicodeObject.len a parent SizeDescr; read the trailing -live- first for after-residual-call guards

### DIFF
--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -872,6 +872,79 @@ static W_BOOL_DESCR_GROUP: LazyLock<PyreObjectDescrGroup> = LazyLock::new(|| {
     )
 });
 
+// RPython `descr.py:218-239 get_field_descr` returns a FieldDescr owned by
+// the cached parent SizeDescr.  Keep the Unicode fields in the same
+// object-descriptor group as every other runtime PyObject layout: in
+// particular, `str_len_descr()` must not mint a detached FieldDescr whose
+// weak `parent_descr` immediately upgrades to `None`.  The optimizer's
+// `protect_speculative_field` asks that parent for the expected type before a
+// pure length read, exactly as `llmodel.py:protect_speculative_field` does.
+static W_UNICODE_DESCR_GROUP: LazyLock<PyreObjectDescrGroup> = LazyLock::new(|| {
+    build_object_descr_group_with_def_path(
+        pyre_object::unicodeobject::W_UNICODE_OBJECT_SIZE,
+        W_UNICODE_GC_TYPE_ID,
+        &pyre_object::pyobject::STR_TYPE as *const _ as usize,
+        &[
+            (
+                "value",
+                pyre_object::unicodeobject::UNICODE_VALUE_OFFSET,
+                std::mem::size_of::<*mut rustpython_wtf8::Wtf8Buf>(),
+                Type::Ref,
+                false,
+                true,
+                false,
+            ),
+            (
+                "byte_len",
+                pyre_object::unicodeobject::UNICODE_BYTE_LEN_OFFSET,
+                std::mem::size_of::<usize>(),
+                Type::Int,
+                false,
+                true,
+                false,
+            ),
+            (
+                "len",
+                pyre_object::unicodeobject::UNICODE_LEN_OFFSET,
+                std::mem::size_of::<usize>(),
+                Type::Int,
+                false,
+                true,
+                false,
+            ),
+            (
+                "w_slots",
+                pyre_object::unicodeobject::UNICODE_W_SLOTS_OFFSET,
+                std::mem::size_of::<pyre_object::PyObjectRef>(),
+                Type::Ref,
+                false,
+                false,
+                false,
+            ),
+            (
+                "index_storage",
+                pyre_object::unicodeobject::UNICODE_INDEX_STORAGE_OFFSET,
+                std::mem::size_of::<*mut pyre_object::rutf8::Utf8IndexStorage>(),
+                Type::Ref,
+                false,
+                false,
+                false,
+            ),
+            (
+                "hash",
+                std::mem::offset_of!(pyre_object::unicodeobject::W_UnicodeObject, hash),
+                std::mem::size_of::<i64>(),
+                Type::Int,
+                true,
+                false,
+                false,
+            ),
+        ],
+        "W_UnicodeObject",
+        "unicodeobject::W_UnicodeObject",
+    )
+});
+
 static RANGE_ITER_DESCR_GROUP: LazyLock<PyreObjectDescrGroup> = LazyLock::new(|| {
     build_object_descr_group_with_def_path(
         std::mem::size_of::<pyre_object::functional::W_IntRangeIterator>(),
@@ -2000,7 +2073,6 @@ use pyre_object::interp_exceptions::{
 };
 use pyre_object::intobject::W_IntObject;
 use pyre_object::pyobject::{OB_TYPE_OFFSET, W_CLASS_OFFSET};
-use pyre_object::unicodeobject::UNICODE_LEN_OFFSET;
 use pyre_object::{
     BOOL_INTVAL_OFFSET, FLOAT_ARRAY_BLOCK_OFFSET, FLOAT_ARRAY_LEN_OFFSET, INT_ARRAY_BLOCK_OFFSET,
     INT_ARRAY_LEN_OFFSET, INT_INTVAL_OFFSET, W_ListObject, W_TupleObject,
@@ -2660,12 +2732,7 @@ pub fn str_len_descr() -> DescrRef {
     // `W_UnicodeObject.len` is a `usize`: 8 bytes on 64-bit, 4 on wasm32 — a
     // hardcoded 8 reads the adjacent field into the high half on a 32-bit
     // target (blackhole resume of `len(str)`).
-    make_immutable_field_descr(
-        UNICODE_LEN_OFFSET,
-        std::mem::size_of::<usize>(),
-        Type::Int,
-        false,
-    )
+    field_descr_from_group(&W_UNICODE_DESCR_GROUP, 2)
 }
 
 // ── Object header & allocation descriptors ──────────────────────────
@@ -3396,6 +3463,31 @@ pub fn pyframe_flags_descr() -> DescrRef {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn str_len_descr_keeps_its_unicode_parent_alive() {
+        let descr = str_len_descr();
+        let field = descr.as_field_descr().expect("str len FieldDescr");
+        assert_eq!(
+            field.offset(),
+            pyre_object::unicodeobject::UNICODE_LEN_OFFSET
+        );
+        assert!(field.is_immutable());
+
+        let parent = field
+            .get_parent_descr()
+            .expect("W_UnicodeObject.len must retain its parent SizeDescr");
+        let size = parent
+            .as_size_descr()
+            .expect("Unicode field parent must be a SizeDescr");
+        assert_eq!(
+            size.size(),
+            pyre_object::unicodeobject::W_UNICODE_OBJECT_SIZE
+        );
+        assert_eq!(size.type_id(), W_UNICODE_GC_TYPE_ID);
+        let parent_field = size.all_fielddescrs()[2].clone() as DescrRef;
+        assert!(std::sync::Arc::ptr_eq(&parent_field, &descr));
+    }
 
     #[test]
     fn pyobject_size_descrs_include_inherited_w_class_gc_field() {
@@ -5190,6 +5282,7 @@ pub(crate) fn publish_runtime_descr_groups() {
         &*W_FLOAT_DESCR_GROUP,
         &*W_LONG_DESCR_GROUP,
         &*W_BOOL_DESCR_GROUP,
+        &*W_UNICODE_DESCR_GROUP,
         &*RANGE_ITER_DESCR_GROUP,
         &*RANGE_DESCR_GROUP,
         &*W_METHOD_DESCR_GROUP,

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/resume_snapshot.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/resume_snapshot.rs
@@ -25,6 +25,22 @@ fn trailing_live_marker(payload: &crate::PyJitCode, call_pc: usize) -> Option<us
     (marker.opname == "live").then_some(marker.pc)
 }
 
+/// Select the resume marker for an after-residual-call guard.  The bytecode's
+/// immediate trailing `-live-` is the RPython authority; metadata twins are
+/// compatibility fallbacks for incomplete/fixture bodies.
+pub(crate) fn after_residual_guard_marker(
+    payload: &crate::PyJitCode,
+    op_pc: usize,
+    marker_call_jit_pc: Option<usize>,
+) -> Option<usize> {
+    trailing_live_marker(payload, op_pc).or_else(|| {
+        marker_call_jit_pc
+            .and_then(|call_jit_pc| payload.after_residual_call_resume_for_jitcode_pc(call_jit_pc))
+            .or_else(|| payload.after_residual_marker_for_jitcode_pc(op_pc))
+            .or_else(|| payload.after_residual_call_resume_for_jitcode_pc(op_pc))
+    })
+}
+
 /// Read the Python PC paired with a native resume word.  The codewriter builds
 /// this table from Python-PC keys, including the same forward trivia skip as
 /// `backxlat_py_pc`; capture deliberately never projects the word backwards.
@@ -886,22 +902,15 @@ pub(crate) fn walker_capture_snapshot_for_last_guard_impl<Sym: WalkSym>(
                 // `-live-` marker). Fall back to the sentinel on a map miss.
                 let marker = unsafe {
                     let jc = &*sym.jitcode();
-                    match marker_call_jit_pc {
-                        Some(call_jit_pc) => jc
-                            .payload
-                            .after_residual_call_resume_for_jitcode_pc(call_jit_pc),
-                        None => {
-                            // Every plain post-call guard capture is emitted
-                            // after its fallthrough `-live-` marker, so this
-                            // populated twin is total at the capture point.
-                            jc.payload
-                                .after_residual_marker_for_jitcode_pc(op_pc)
-                                .or_else(|| {
-                                    jc.payload.after_residual_call_resume_for_jitcode_pc(op_pc)
-                                })
-                                .or_else(|| trailing_live_marker(&jc.payload, op_pc))
-                        }
-                    }
+                    // RPython `pyjitpl.py capture_resumedata(
+                    // after_residual_call=True)` snapshots the `-live-`
+                    // immediately following the residual call.  Read that
+                    // structural marker first for every after-call guard.  In
+                    // a try-block it sits before `catch_exception/L`, so its
+                    // liveness includes both the normal continuation and the
+                    // handler; a Python-PC fallthrough twin may instead name a
+                    // later normal-path marker and lose handler-only locals.
+                    after_residual_guard_marker(&jc.payload, op_pc, marker_call_jit_pc)
                 };
                 match marker {
                     Some(jp) => jp as i32,

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
@@ -40,6 +40,32 @@ fn test_outer_resume_jitcode_index() -> u32 {
 }
 
 #[test]
+fn after_residual_guard_uses_trailing_live_before_fallthrough_twin() {
+    let int_add = *insns_opname_to_byte()
+        .get("int_add/ii>i")
+        .expect("int_add/ii>i must be in the insns table");
+    let live = crate::state::op_live();
+    let runtime_jc = majit_metainterp::jitcode::JitCode::new("after_residual_marker_test");
+    runtime_jc.set_body(majit_translate::jitcode::JitCodeBody {
+        // The immediate marker at pc=4 models the call's trailing `-live-`;
+        // pc=7 models the later normal-fallthrough marker a Python-PC twin can
+        // resolve to after `catch_exception/L`.
+        code: vec![int_add, 0, 1, 2, live, 0, 0, live, 0, 0],
+        startpoints: Some([0_usize, 4, 7].into_iter().collect()),
+        ..Default::default()
+    });
+    let mut pyjit = crate::PyJitCode::skeleton(std::ptr::null());
+    pyjit.jitcode = std::sync::Arc::new(runtime_jc);
+    pyjit.metadata.after_residual_call_resume_pred_by_jit_pc = vec![(0, Some(7))];
+
+    assert_eq!(
+        super::resume_snapshot::after_residual_guard_marker(&pyjit, 0, Some(0)),
+        Some(4),
+        "handler liveness must come from the trailing live before catch_exception",
+    );
+}
+
+#[test]
 fn vstack_permuted_for_iter_entry_uses_block_head_target() {
     let mut pyjit = crate::PyJitCode::skeleton(std::ptr::null());
     pyjit.metadata.n_py_instrs = 19;


### PR DESCRIPTION
Closes the two `loops_aborted` jit-stats regressions that were red on `main`:

```
FAIL {dynasm,cranelift} synth/exception_args_virtual
  jit-stats regression: loops_aborted 0 -> 3, guard_failures 401 -> 1002
FAIL {dynasm,cranelift} synth/list_length_hint_validate
  jit-stats regression: loops_aborted 14 -> 34, guard_failures 828 -> 4923
```

Both trace back to a single parentless field descriptor.

## Root cause

```
str_len_descr() → make_immutable_field_descr(…)   # parent_descr: None
  → FieldDescr::get_parent_descr() == None
  → protect_speculative_field fails closed
  → SpeculativeError → optimize_peeled_loop → InvalidLoop
  → bridge rejected, but its procedure token stays at the greenkey
  → next compile_loop hits has_compiled_targets → SwitchToBlackhole(ABORT_BAD_LOOP)
```

The `abort: bad loop` is the *consequence*; the bridge rejection is the cause.

Instrumenting `protect_speculative_field` pinned every failure to one descr:
`GetfieldGcI off=32 always_pure=true no parent_descr`. `PyObject` is 16 bytes
(`ob_type`@0, `w_class`@8), so `W_UnicodeObject` lays out `value`@16,
`byte_len`@24, **`len`@32** — that is `str_len_descr()`.

`descr.py:238` sets `fielddescr.parent_descr = get_size_descr(gccache, STRUCT,
vtable)` for every field descriptor it builds, unconditionally, and creates the
size descr if it is not cached yet. The pyre side had no parent to hand back,
so a check that cannot fail upstream failed here.

## What changed

- `pyre-jit-trace/src/descr.rs`: publish the `W_UnicodeObject` layout as a
  `PyreObjectDescrGroup` and take the length field from it, so the field keeps
  its parent `SizeDescr` alive.
- `pyre-jit-trace/src/jitcode_dispatch/resume_snapshot.rs`: read the bytecode's
  immediately trailing `-live-` first when choosing the resume marker for an
  after-residual-call guard, keeping the Python-PC metadata twins as fallbacks.
  `pyjitpl.py capture_resumedata(after_residual_call=True)` snapshots that
  marker; inside a try block a fallthrough twin can instead name a later
  normal-path marker, past `catch_exception/L`, and lose the handler-only
  locals. Extracted as `after_residual_guard_marker` so the order is testable.

## Verification

`cargo fmt --all -- --check` clean. `cargo test -p pyre-jit-trace
--no-default-features --features dynasm`: **336 passed, 0 failed**, including
two new tests — `str_len_descr_keeps_its_unicode_parent_alive` and
`after_residual_guard_uses_trailing_live_before_fallthrough_twin`.

jit-stats, dynasm, 3/3 runs in each direction — fully deterministic, not a
flake. The "before" column was measured in an isolated detached worktree at the
pre-fix commit with its own `CARGO_TARGET_DIR` and its own LLBC extraction:

| fixture | before | after | committed baseline |
|---|---|---|---|
| `synth/exception_args_virtual` | `loops_aborted=3 guard_failures=1002` | `loops_aborted=0 guard_failures=401` | `loops_aborted=0 guard_failures=401` |
| `synth/list_length_hint_validate` | `loops_aborted=34 guard_failures=4923` | `loops_aborted=14 guard_failures=828` | `loops_aborted=14 guard_failures=828` |

`bridges_compiled` moves with them (`2→2` and `3→4`), which is the same story
read from the other side: the rejected bridge is restored, and the guard that
kept failing without it stops.

## Refuted hypothesis

pyre's `optimizeopt/mod.rs protect_speculative_operation` gates the getfield
branch on `opnum.is_getfield()`, where `optimizer.py:829` uses
`OpHelpers.is_pure_getfield(opnum, descr)` — opcode **and**
`descr.is_always_pure()`. That is a real parity gap, but it is not this bug:
the failing descr probes `always_pure=true`, so the upstream gate admits it
too. Left alone here.

## Follow-up not taken

`ob_type_descr()` (`descr.rs`) is `immutable: true` with `parent_descr: None` —
the same class, and likewise exposed to a pure fold. `OB_TYPE_OFFSET == 0`
never reached the probe in these fixtures, so it is dormant rather than live,
and fixing it is out of scope for this PR. The other three `parent_descr: None`
sites (`PYFRAME_VABLE_TOKEN_OFFSET`, `array_lendescr_at_offset`,
`new_w_class_field_descr`) are `immutable: false` and so never pass the
pure-getfield gate; the arraylen descr legitimately has no parent upstream
either (`descr.py:265`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JIT resume handling after residual guards, including exception-handler paths.
  * Ensured Unicode length descriptors consistently retain their canonical metadata and relationships.

* **Tests**
  * Added regression coverage for selecting the correct resume marker.
  * Added validation for Unicode descriptor identity and parent linkage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->