### PR TITLE
jit: dispatch float residual calls through the float return register

### DIFF
--- a/majit/majit-backend/src/call_stub.rs
+++ b/majit/majit-backend/src/call_stub.rs
@@ -24,6 +24,18 @@
 /// `descr.py:598-612 create_call_stub` parity: a single ARGS×RESULT shape
 /// per dispatch; we enumerate the same shape twice (once per RESULT) instead
 /// of generating one stub per descriptor.
+///
+/// The signature is recovered from the *bucketed* `(int, float)` arity, so a
+/// callee declaring `fn(f64, i64)` is dispatched as `fn(i64, f64)`. That is
+/// ABI-preserving only where integer and floating-point parameters are
+/// assigned from two independent register files in their own relative order:
+/// SysV (rdi.. / xmm0..) and AAPCS (x0.. / d0..). The Microsoft x64
+/// convention assigns the first four arguments *by position* — argument 0
+/// takes rcx or xmm0 depending on its type, argument 1 takes rdx or xmm1 —
+/// so there the bucketing would move both arguments to the wrong register.
+/// Callers that can hold an interleaved signature must reject it before
+/// reaching here; the general fix is the libffi dispatch named in the
+/// catch-all arm below, which also removes the arity ceiling.
 macro_rules! dispatch_arity_body {
     ($func:ident, $int_args:ident, $float_args:ident, $ret:ty) => {{
         type I = i64;
@@ -420,6 +432,12 @@ pub unsafe fn bh_call_f_dispatch(func: usize, int_args: &[i64], float_args: &[f6
 /// Mirrors `rpython/jit/backend/llsupport/descr.py:614-620 verify_types`:
 /// the per-class counts in `arg_classes` must match the corresponding list
 /// length, and any unknown class is a codegen bug.
+///
+/// The two returned buckets discard the interleaving `arg_classes` encodes;
+/// see `dispatch_arity_body!` for which ABIs that reordering is sound on. This
+/// function does not itself reject an interleaved `arg_classes` — the in-tree
+/// calldescrs it is fed carry non-interleaved signatures, and rejecting here
+/// would panic on calls that are ABI-correct under SysV/AAPCS.
 pub fn collect_call_args(
     arg_classes: &str,
     args_i: Option<&[i64]>,

--- a/majit/majit-metainterp/src/executor.rs
+++ b/majit/majit-metainterp/src/executor.rs
@@ -814,13 +814,26 @@ pub fn execute_pure_call(
         // `f64::to_bits`; routing through `call_int_function` is bit-identical.
         //
         // That convention is a CALLER CONTRACT, not a property of the descr:
-        // it holds only when `func_ptr` is such a wrapper.  A funcbox baked by
-        // the codewriter instead carries the callee's own address, where the
-        // f64 comes back in the floating-point return register and this arm
-        // reads whatever was left in the integer one.  The two are
-        // indistinguishable here — `descr` records the signature, not which
-        // emitter produced the pointer — so the walker declines rather than
-        // guess (`residual_call.rs try_fold_pure_call_via_executor`).
+        // it holds only when `func_ptr` is that wrapper.  `add_fn_ptr(ptr)` is
+        // `add_call_target(ptr, ptr)` (`jitcode/assembler.rs:4617`), so a
+        // `concrete_ptr` registered that way — and every LLBC `ConstInt`
+        // fnaddr, which mints no `JitCallTarget` at all — is the callee's own
+        // address, whose f64 comes back in the floating-point return register
+        // while this arm reads whatever was left in the integer one.  `descr`
+        // records the signature, not the registration, so the two are
+        // indistinguishable here and the walker declines rather than guess
+        // (`residual_call.rs try_fold_pure_call_via_executor`).
+        //
+        // This arm is the outlier: `executor.py:66-72` dispatches FLOAT
+        // through `cpu.bh_call_f`, which pyre has already ported as
+        // `majit_backend::call_stub::bh_call_f_by_classes` and which BOTH other
+        // residual-call consumers already use on this same operand — the
+        // blackhole (`bhimpl_residual_call_irf_f`) and the metainterp's IRF_F
+        // dispatcher (`pyjitpl/dispatch.rs:6539`, on the very `concrete_ptr`
+        // the via-target emitter bakes).  Converging means choosing one
+        // registration convention, not adding a discriminator here; the
+        // CALL_ASSEMBLER arms are separate and genuinely do want the i64
+        // wrapper.
         majit_ir::Type::Float => crate::pyjitpl::call_int_function(func_ptr, args),
     }
 }

--- a/majit/majit-metainterp/src/executor.rs
+++ b/majit/majit-metainterp/src/executor.rs
@@ -808,33 +808,27 @@ pub fn execute_pure_call(
             crate::pyjitpl::call_void_function_typed(func_ptr, args, descr.arg_types());
             0
         }
-        // See `execute_varargs`'s Float arm for the i64-bits ABI rationale:
-        // `#[jit_module]` Float helpers expose `concrete_ptr` as
-        // `extern "C" fn(...) -> i64` with the f64 pre-packed via
-        // `f64::to_bits`; routing through `call_int_function` is bit-identical.
+        // executor.py:66-68 `if rettype == FLOAT: cpu.bh_call_f(...)`.  The
+        // funcbox reaching this seam is always the callee's own address —
+        // `add_fn_ptr(ptr)` is `add_call_target(ptr, ptr)`
+        // (`jitcode/assembler.rs:4617`), which is what pyre's codewriter
+        // registers, and the LLBC path bakes a plain `ConstInt` fnaddr that
+        // mints no `JitCallTarget` at all.  So the f64 comes back in the
+        // floating-point return register, exactly as the blackhole
+        // (`bhimpl_residual_call_irf_f`) and the metainterp's own IRF_F
+        // dispatcher (`pyjitpl/dispatch.rs`) already assume for it.
         //
-        // That convention is a CALLER CONTRACT, not a property of the descr:
-        // it holds only when `func_ptr` is that wrapper.  `add_fn_ptr(ptr)` is
-        // `add_call_target(ptr, ptr)` (`jitcode/assembler.rs:4617`), so a
-        // `concrete_ptr` registered that way — and every LLBC `ConstInt`
-        // fnaddr, which mints no `JitCallTarget` at all — is the callee's own
-        // address, whose f64 comes back in the floating-point return register
-        // while this arm reads whatever was left in the integer one.  `descr`
-        // records the signature, not the registration, so the two are
-        // indistinguishable here and the walker declines rather than guess
-        // (`residual_call.rs try_fold_pure_call_via_executor`).
+        // The `f64::to_bits`-packing `_concrete` wrapper `#[jit_module]` emits
+        // for a Float helper reaches a residual call only through the explicit
+        // `*_float_wrapped` call policies, which no crate declares; the
+        // CALL_ASSEMBLER arms that genuinely do want that i64 wrapper are a
+        // separate opcode family and keep `call_int_function`.
         //
-        // This arm is the outlier: `executor.py:66-72` dispatches FLOAT
-        // through `cpu.bh_call_f`, which pyre has already ported as
-        // `majit_backend::call_stub::bh_call_f_by_classes` and which BOTH other
-        // residual-call consumers already use on this same operand — the
-        // blackhole (`bhimpl_residual_call_irf_f`) and the metainterp's IRF_F
-        // dispatcher (`pyjitpl/dispatch.rs:6539`, on the very `concrete_ptr`
-        // the via-target emitter bakes).  Converging means choosing one
-        // registration convention, not adding a discriminator here; the
-        // CALL_ASSEMBLER arms are separate and genuinely do want the i64
-        // wrapper.
-        majit_ir::Type::Float => crate::pyjitpl::call_int_function(func_ptr, args),
+        // The result is returned as raw bits so the caller's `f64::from_bits`
+        // stamp is unchanged (`longlong` float-storage parity).
+        majit_ir::Type::Float => {
+            crate::pyjitpl::call_float_function(func_ptr, args, descr.arg_types()).to_bits() as i64
+        }
     }
 }
 
@@ -885,11 +879,14 @@ pub fn execute_residual_call(
             crate::pyjitpl::call_void_function_typed(func_ptr, args, descr.arg_types());
             0
         }
-        // See `execute_varargs`'s Float arm for the i64-bits ABI
-        // rationale: `#[jit_module]` Float helpers expose
-        // `concrete_ptr` as `extern "C" fn(...) -> i64` with the f64
-        // pre-packed via `f64::to_bits`.
-        majit_ir::Type::Float => crate::pyjitpl::call_int_function(func_ptr, args),
+        // executor.py:66-68 `cpu.bh_call_f` — same funcbox provenance as
+        // `execute_pure_call`'s Float arm; see its comment for why the
+        // callee's own address, not the `f64::to_bits` wrapper, is what
+        // reaches this seam.  Returned as raw bits for the caller's
+        // `f64::from_bits` stamp.
+        majit_ir::Type::Float => {
+            crate::pyjitpl::call_float_function(func_ptr, args, descr.arg_types()).to_bits() as i64
+        }
     };
     let bh_exc = crate::blackhole::BH_LAST_EXC_VALUE.with(|c| {
         let v = c.get();
@@ -989,9 +986,15 @@ mod execute_pure_call_tests {
         a.wrapping_add(b).wrapping_add(c)
     }
 
-    extern "C" fn pack_float_to_bits(x: i64) -> i64 {
-        let f = f64::from_bits(x as u64) * 2.0;
-        f.to_bits() as i64
+    extern "C" fn double_f64(x: f64) -> f64 {
+        x * 2.0
+    }
+
+    /// `jit_bigint_to_f64_or_inf`'s shape: an integer/ref parameter with a
+    /// genuine `f64` return, so the result arrives in xmm0 / d0 while nothing
+    /// occupies the FP argument file.
+    extern "C" fn halve_int_to_f64(x: i64) -> f64 {
+        x as f64 / 2.0
     }
 
     extern "C" fn void_no_op(_x: i64) {}
@@ -1016,17 +1019,33 @@ mod execute_pure_call_tests {
         assert_eq!(result, 123, "add3_i64(100, 20, 3) must return 123");
     }
 
+    /// executor.py:66-68 — a Float result is fetched through `cpu.bh_call_f`,
+    /// i.e. the floating-point return register, and a Float argument travels
+    /// in the FP argument file.  `args` carries the raw `f64::to_bits` for
+    /// both directions (`longlong` float-storage parity).
     #[test]
-    fn float_result_routes_through_call_int_function_with_bits_packing() {
+    fn float_result_and_float_arg_use_the_floating_point_register_file() {
         let descr = make_descr(vec![Type::Float], Type::Float);
-        let input_bits = 3.5_f64.to_bits() as i64;
         let result = execute_pure_call(
             &descr,
-            pack_float_to_bits as *const () as i64,
-            &[input_bits],
+            double_f64 as *const () as i64,
+            &[3.5_f64.to_bits() as i64],
         );
-        let result_f = f64::from_bits(result as u64);
-        assert_eq!(result_f, 7.0, "3.5 * 2.0 must equal 7.0");
+        assert_eq!(f64::from_bits(result as u64), 7.0, "double_f64(3.5) == 7.0");
+    }
+
+    /// The mixed shape that motivated the fix: an integer parameter with an
+    /// `f64` return.  Reading the integer return register here yielded the
+    /// argument still sitting in it rather than the result.
+    #[test]
+    fn float_result_with_an_integer_arg_reads_the_float_return_register() {
+        let descr = make_descr(vec![Type::Int], Type::Float);
+        let result = execute_pure_call(&descr, halve_int_to_f64 as *const () as i64, &[7]);
+        assert_eq!(
+            f64::from_bits(result as u64),
+            3.5,
+            "halve_int_to_f64(7) == 3.5; an integer-register read would see 7",
+        );
     }
 
     #[test]

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -9,7 +9,8 @@ pub use dispatch::{
 };
 pub use dispatch::{build_vable_snapshot_boxes, build_vref_snapshot_boxes};
 pub use dispatch::{
-    call_int_function, call_ref_function, call_void_function, call_void_function_typed,
+    call_float_function, call_int_function, call_ref_function, call_void_function,
+    call_void_function_typed,
 };
 pub use dispatch::{eval_binop_f, eval_binop_i, eval_float_cmp, eval_unary_f, eval_unary_i};
 pub use frame::{MIFrame, MIFrameStack};

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -8446,12 +8446,30 @@ pub fn call_int_function(func_ptr: *const (), args: &[i64]) -> i64 {
 /// `args[i]` for a `Type::Float` slot carries the raw `f64::to_bits`, matching
 /// the `args_f` bank convention (`longlong` float storage).
 ///
+/// `descr.py:545-569 process` also encodes `'L'` (SignedLongLong — integer
+/// register file) and `'S'` (SingleFloat — `f32`) argument classes, which the
+/// bank-fed [`majit_backend::call_stub::collect_call_args`] carries arms for.
+/// Neither can arrive here: this seam is fed by `descr.arg_types()`, and
+/// `CallDescr::arg_classes` (`majit-ir/src/descr.rs`) maps `Type` onto
+/// `'i'`/`'r'`/`'f'`/`'v'` exhaustively, so a `Type::Float` slot is always
+/// class `'f'`.  Teaching `Type` those classes must extend both sites.
+///
 /// # Panics
-/// `bh_call_f_dispatch`'s arity table is `fn(I × ints, F × floats)` — all
-/// integer/ref parameters precede all float ones.  A callee whose signature
-/// interleaves them cannot be expressed, so it panics rather than shuffle the
-/// arguments into the wrong registers.  Every float-returning helper in the
-/// tree today is non-interleaved (`jit_bigint_to_f64_or_inf(ref) -> f64`,
+/// `bh_call_f_dispatch` recovers the callee signature from the *bucketed*
+/// `(ints, floats)` arity, i.e. `fn(I × ints, F × floats)`.  Reordering an
+/// interleaved signature into that shape is ABI-preserving only where the
+/// integer and floating-point parameters are assigned from two independent
+/// register files in their own relative order (SysV, AAPCS).  The Microsoft
+/// x64 convention instead assigns the first four arguments *by position* —
+/// `fn(f64, i64)` takes xmm0/rdx where `fn(i64, f64)` takes rcx/xmm1 — so the
+/// reordering would put both arguments in the wrong register there.  An
+/// interleaved signature is therefore rejected rather than dispatched
+/// differently per target.  Upstream needs no such restriction because
+/// `descr.py:598-612 create_call_stub` generates a stub carrying the descr's
+/// real `arg_classes` signature; the convergence path for pyre is the libffi
+/// dispatch already recorded at `call_stub.rs` `dispatch_arity_body!`'s
+/// catch-all arm.  Every float-returning helper in the tree today is
+/// non-interleaved (`jit_bigint_to_f64_or_inf(ref) -> f64`,
 /// `jit_float_abs(f64) -> f64`, `jit_float_fmod(f64, f64) -> f64`).
 pub fn call_float_function(func_ptr: *const (), args: &[i64], arg_types: &[Type]) -> f64 {
     // Where a backend cannot build a `call_indirect` whose type matches the
@@ -8468,8 +8486,10 @@ pub fn call_float_function(func_ptr: *const (), args: &[i64], arg_types: &[Type]
             _ => {
                 assert!(
                     float_args.is_empty(),
-                    "call_float_function: interleaved int/float parameters are \
-                     outside `bh_call_f_dispatch`'s `fn(I.., F..)` arity table"
+                    "call_float_function: an integer/ref parameter after a float \
+                     one cannot be bucketed into `bh_call_f_dispatch`'s \
+                     `fn(I.., F..)` signature without changing which register \
+                     each argument lands in on a positional-slot ABI"
                 );
                 int_args.push(a);
             }

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -8432,6 +8432,54 @@ pub fn call_int_function(func_ptr: *const (), args: &[i64]) -> i64 {
     }
 }
 
+/// `bh_call_f` parity (`backend/model.py:270`, `llmodel.py:828`) for callers
+/// that hold their arguments in `descr.arg_types()` positional order rather
+/// than in the `args_i`/`args_r`/`args_f` banks the bytecode carries.
+///
+/// The C ABI returns `f64` in xmm0 / d0, so a float-returning callee cannot be
+/// reached through [`call_int_function`]'s `-> i64` transmute — that reads the
+/// integer return register.  Float *arguments* have the same problem in the
+/// other direction: they travel in the FP register file, so they are split out
+/// here and handed to [`bh_call_f_dispatch`], which is pyre's stand-in for the
+/// per-descr stub `descr.py:598-612 create_call_stub` generates upstream.
+///
+/// `args[i]` for a `Type::Float` slot carries the raw `f64::to_bits`, matching
+/// the `args_f` bank convention (`longlong` float storage).
+///
+/// # Panics
+/// `bh_call_f_dispatch`'s arity table is `fn(I × ints, F × floats)` — all
+/// integer/ref parameters precede all float ones.  A callee whose signature
+/// interleaves them cannot be expressed, so it panics rather than shuffle the
+/// arguments into the wrong registers.  Every float-returning helper in the
+/// tree today is non-interleaved (`jit_bigint_to_f64_or_inf(ref) -> f64`,
+/// `jit_float_abs(f64) -> f64`, `jit_float_fmod(f64, f64) -> f64`).
+pub fn call_float_function(func_ptr: *const (), args: &[i64], arg_types: &[Type]) -> f64 {
+    // Where a backend cannot build a `call_indirect` whose type matches the
+    // callee's real signature (wasm32), route through the host trampoline,
+    // which reflects the signature and returns an f64 result as its raw bits.
+    if let Some(hook) = majit_backend::call_stub::residual_host_call() {
+        return f64::from_bits(hook(func_ptr as usize, args) as u64);
+    }
+    let mut int_args: Vec<i64> = Vec::with_capacity(args.len());
+    let mut float_args: Vec<f64> = Vec::new();
+    for (i, &a) in args.iter().enumerate() {
+        match arg_types.get(i) {
+            Some(Type::Float) => float_args.push(f64::from_bits(a as u64)),
+            _ => {
+                assert!(
+                    float_args.is_empty(),
+                    "call_float_function: interleaved int/float parameters are \
+                     outside `bh_call_f_dispatch`'s `fn(I.., F..)` arity table"
+                );
+                int_args.push(a);
+            }
+        }
+    }
+    unsafe {
+        majit_backend::call_stub::bh_call_f_dispatch(func_ptr as usize, &int_args, &float_args)
+    }
+}
+
 /// `bh_call_r` parity (`backend/model.py:268`, `blackhole.py:1113`).
 ///
 /// Pyre's GC ref is a `*const PyObject` carried as `i64` via the

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -1641,18 +1641,26 @@ pub(crate) fn try_fold_pure_call_via_executor<Sym: WalkSym>(
         };
         args.push(v);
     }
-    // Refuse to invoke the helper when any Ref argument is NULL.  Pyre's
-    // getfield_gc_r walker handler propagates field reads (including
-    // pointer-valued fields like `PyFrame.f_back`) as concrete values
-    // when the parent struct is concrete-known; a top-level frame
-    // returns NULL for `f_back`, stamping `Value::Ref(GcRef(0))` into
-    // the constant pool.  Folding `helper(NULL)` would then dereference
-    // NULL and SEGV.  PyPy avoids this because its optimizer inserts
-    // `guard_nonnull` ahead of any pointer-deref residual call; pyre's
-    // walker folds before that guard exists, so guard the executor
-    // entry against NULL receivers and fall through to recording the
-    // IR op as-is.  The downstream optimizer then sees the call op and
-    // emits the necessary guards.
+    // Refuse to invoke the helper when any Ref argument is NULL.
+    //
+    // `pyjitpl.py:3586-3603 record_result_of_call_pure` folds on the weaker
+    // test "every argbox is a Const", which admits `ConstPtr(NULL)`.  It can
+    // afford to: upstream reaches that line only *after* the call has already
+    // been executed for real, and its Const arguments come from boxes the
+    // interpreter itself made constant.
+    //
+    // Pyre's walker folds from a different source of constants.  Its
+    // getfield_gc_r handler propagates field reads (including pointer-valued
+    // fields like `PyFrame.f_back`) as concrete values whenever the parent
+    // struct is concrete-known, so a top-level frame stamps
+    // `Value::Ref(GcRef(0))` into the constant pool where upstream would still
+    // hold a symbolic box guarded by the `guard_nonnull` its optimizer inserts
+    // ahead of a pointer-deref residual call.  Executing `helper(NULL)` here
+    // would dereference NULL and SEGV before that guard exists.
+    //
+    // So guard the executor entry against NULL Ref arguments and fall through
+    // to recording the IR op as-is.  The downstream optimizer then sees the
+    // call op and emits the necessary guards.
     for (i, &arg) in args.iter().enumerate() {
         if matches!(call_descr.arg_types().get(i), Some(majit_ir::Type::Ref)) && arg == 0 {
             return;

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -1596,47 +1596,6 @@ pub(crate) fn try_fold_pure_call_via_executor<Sym: WalkSym>(
     if allboxes.is_empty() {
         return;
     }
-    // A float-returning callee cannot be executed here, because operand 0's
-    // float ABI is set by how its `JitCallTarget` was REGISTERED — not by which
-    // emitter ran — and the descr records neither:
-    //
-    //   * `add_fn_ptr(ptr)` is `add_call_target(ptr, ptr)`
-    //     (`jitcode/assembler.rs:4617`), so `concrete_ptr` IS the raw callee
-    //     address and the `f64` comes back in the floating-point return
-    //     register.  This is what pyre's own codewriter registers
-    //     (`pyre-jit/src/jit/codewriter.rs:3594`).
-    //   * the policy-macro lowering registers
-    //     `add_call_target_with_save_err(trace, concrete)` where `concrete` is
-    //     `#[jit_module]`'s `_concrete` wrapper, an `extern "C" fn(i64, ..)
-    //     -> i64` with the `f64` pre-packed via `f64::to_bits` — the one
-    //     convention `execute_pure_call`'s Float arm implements.
-    //   * the LLBC codewriter bakes `fnaddr_for_target` as a plain `ConstInt`
-    //     and never mints a `JitCallTarget` at all
-    //     (`majit-translate/src/codewriter/jtransform.rs direct_funcptr_value`).
-    //
-    // `residual_call_float_canonical_via_target_with_effect_info` bakes
-    // `target.concrete_ptr` for all of them, so the emitter family does not
-    // discriminate.  Running a raw address under the wrapper's convention
-    // yields whatever was left in the integer return register (probed: 7/7
-    // garbage against `jit_bigint_to_f64_or_inf`), and the walker would stamp
-    // it as the folded constant.  Leave the recorded `CallPure*` for the
-    // backend, which calls the same pointer with the descr's real signature
-    // (`majit-backend-wasm/src/codegen.rs:1133 residual_call_float_sig` builds
-    // an `f64`-returning `call_indirect` from it).
-    //
-    // `JitCodeExecState::call_descr_to_call_target` (`jitcode/mod.rs:367`) is
-    // the discriminator.  The walker never consults it; the metainterp's own
-    // IRF_F dispatcher does (`pyjitpl/dispatch.rs:6431`) — and calls the
-    // resulting `concrete_ptr` through `bh_call_f_by_classes` (:6539), i.e. as
-    // a real `f64` return, the opposite of what this arm assumes for the same
-    // pointer.  That disagreement, not the fold, is the thing to converge:
-    // upstream has one convention (`op.args[0]` is always the callee, and
-    // `CallDescr.create_call_stub` carries the ABI) and dispatches through
-    // `cpu.bh_call_f` (`executor.py:66-72`), which pyre has already ported as
-    // `bh_call_f_by_classes`.
-    if call_descr.result_type() == majit_ir::Type::Float {
-        return;
-    }
     // pyjitpl.py `_build_allboxes`: slot 0 is funcbox, slots
     // 1.. are user args in `descr.arg_types()` ABI order.  Walker's
     // [`build_allboxes`] preserves the same layout.

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -1596,27 +1596,44 @@ pub(crate) fn try_fold_pure_call_via_executor<Sym: WalkSym>(
     if allboxes.is_empty() {
         return;
     }
-    // A float-returning callee cannot be executed here, because the funcbox's
-    // ABI depends on which emitter produced the op and the descr does not say
-    // which:
+    // A float-returning callee cannot be executed here, because operand 0's
+    // float ABI is set by how its `JitCallTarget` was REGISTERED — not by which
+    // emitter ran — and the descr records neither:
     //
-    //   * the codewriter's residual bakes the callee's OWN address, so the
-    //     `f64` comes back in the floating-point return register
-    //     (`majit-backend-wasm/src/codegen.rs:909 residual_call_float_sig`
-    //     builds an `f64`-returning `call_indirect` from that same pointer);
-    //   * the runtime emitter's `*_canonical_via_target` family bakes
-    //     `JitCallTarget::concrete_ptr` instead (`jitcode/assembler.rs:3343`),
-    //     an `extern "C" fn(...) -> i64` wrapper with the `f64` pre-packed via
-    //     `f64::to_bits` — which is the convention `execute_pure_call`'s Float
-    //     arm implements.
+    //   * `add_fn_ptr(ptr)` is `add_call_target(ptr, ptr)`
+    //     (`jitcode/assembler.rs:4617`), so `concrete_ptr` IS the raw callee
+    //     address and the `f64` comes back in the floating-point return
+    //     register.  This is what pyre's own codewriter registers
+    //     (`pyre-jit/src/jit/codewriter.rs:3594`).
+    //   * the policy-macro lowering registers
+    //     `add_call_target_with_save_err(trace, concrete)` where `concrete` is
+    //     `#[jit_module]`'s `_concrete` wrapper, an `extern "C" fn(i64, ..)
+    //     -> i64` with the `f64` pre-packed via `f64::to_bits` — the one
+    //     convention `execute_pure_call`'s Float arm implements.
+    //   * the LLBC codewriter bakes `fnaddr_for_target` as a plain `ConstInt`
+    //     and never mints a `JitCallTarget` at all
+    //     (`majit-translate/src/codewriter/jtransform.rs direct_funcptr_value`).
     //
-    // Running the first kind under the second's convention yields whatever was
-    // left in the integer return register (probed: 7/7 garbage against
-    // `jit_bigint_to_f64_or_inf`), and the walker would stamp it as the folded
-    // constant.  Leave the recorded `CallPure*` for the backend, which calls
-    // the same pointer with the descr's real signature.  `JitCode`'s
-    // `call_descr_to_call_target` side table is the discriminator a future
-    // slice would consult to fold these; nothing reads it today.
+    // `residual_call_float_canonical_via_target_with_effect_info` bakes
+    // `target.concrete_ptr` for all of them, so the emitter family does not
+    // discriminate.  Running a raw address under the wrapper's convention
+    // yields whatever was left in the integer return register (probed: 7/7
+    // garbage against `jit_bigint_to_f64_or_inf`), and the walker would stamp
+    // it as the folded constant.  Leave the recorded `CallPure*` for the
+    // backend, which calls the same pointer with the descr's real signature
+    // (`majit-backend-wasm/src/codegen.rs:1133 residual_call_float_sig` builds
+    // an `f64`-returning `call_indirect` from it).
+    //
+    // `JitCodeExecState::call_descr_to_call_target` (`jitcode/mod.rs:367`) is
+    // the discriminator.  The walker never consults it; the metainterp's own
+    // IRF_F dispatcher does (`pyjitpl/dispatch.rs:6431`) — and calls the
+    // resulting `concrete_ptr` through `bh_call_f_by_classes` (:6539), i.e. as
+    // a real `f64` return, the opposite of what this arm assumes for the same
+    // pointer.  That disagreement, not the fold, is the thing to converge:
+    // upstream has one convention (`op.args[0]` is always the callee, and
+    // `CallDescr.create_call_stub` carries the ABI) and dispatches through
+    // `cpu.bh_call_f` (`executor.py:66-72`), which pyre has already ported as
+    // `bh_call_f_by_classes`.
     if call_descr.result_type() == majit_ir::Type::Float {
         return;
     }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
@@ -11403,20 +11403,21 @@ fn ref_compare_same_box_fastpath_covers_the_instance_ptr_spellings() {
     }
 }
 
-// A float-returning residual is never folded at record time: the funcbox's
-// ABI depends on which emitter baked it (the codewriter bakes the callee's own
-// `f64`-returning address; the runtime emitter's `*_canonical_via_target`
-// family bakes `JitCallTarget::concrete_ptr`, an `i64`-returning wrapper), and
-// the descr does not record which.  See the decline in
-// `try_fold_pure_call_via_executor`.
+// pyjitpl.py:2119-2121 concretely executes and stamps a Float `CALL_PURE`
+// like any other.  The funcbox is the callee's own address on every live
+// path — `add_fn_ptr(ptr)` is `add_call_target(ptr, ptr)` and the LLBC path
+// bakes a plain `ConstInt` fnaddr — so `execute_pure_call` fetches the result
+// from the floating-point return register (`executor.py:66-68 cpu.bh_call_f`).
 
-/// A real `f64`-returning callee, i.e. the shape the codewriter bakes.
+/// A real `f64`-returning callee with an integer parameter, i.e. the
+/// `jit_bigint_to_f64_or_inf` shape.  Reading the integer return register
+/// here returned the argument still sitting in it.
 extern "C" fn halve_f64_for_walker_test(x: i64) -> f64 {
     (x as f64) / 2.0
 }
 
 #[test]
-fn walker_declines_to_fold_a_float_result_pure_call() {
+fn walker_folds_a_float_result_pure_call_from_the_float_return_register() {
     let mut tc = fresh_trace_ctx();
     let funcbox = tc.const_int(halve_f64_for_walker_test as *const () as i64);
     let arg0 = tc.const_int(7);
@@ -11506,9 +11507,9 @@ fn walker_declines_to_fold_a_float_result_pure_call() {
     );
     assert_eq!(
         tc.box_value(recorded),
-        None,
-        "a float-result pure call must stay symbolic, not be stamped with \
-         whatever the integer return register held",
+        Some(majit_ir::Value::Float(3.5)),
+        "halve_f64_for_walker_test(7) == 3.5; reading the integer return \
+         register would stamp the argument 7 instead",
     );
 }
 


### PR DESCRIPTION
Follow-up to #963, which landed a `result_type() == Float` decline in
`try_fold_pure_call_via_executor` rather than fixing the ABI underneath it.
This removes the decline by fixing the ABI.

## The defect

`execute_pure_call` and `execute_residual_call` routed a `Type::Float` result
through `call_int_function`, an `extern "C" fn(..) -> i64` transmute. The C ABI
returns `f64` in xmm0 / d0, so the result was read from the **integer** return
register — which still held an argument. Float *arguments* were wrong in the
same way, passed in the integer register file rather than the FP one.

`executor.py:66-68` dispatches FLOAT through `cpu.bh_call_f`, whose backend
implementation calls a per-descr stub built from the descr's own signature
(`llmodel.py:828` → `descr.py:598-612 create_call_stub`). **pyre has already
ported that** as `majit_backend::call_stub::bh_call_f_by_classes` /
`bh_call_f_dispatch`, and two of the three residual-call consumers already use
it on this exact operand — the blackhole's `bhimpl_residual_call_irf_f` and the
metainterp's own `BC_RESIDUAL_CALL_IRF_F` dispatcher. `executor.rs` was the lone
outlier.

## Why the decline could not just be extended

The decline covered only the pure path. The non-pure sibling
`try_execute_residual_call_via_executor` admits `CallF` / `CallLoopinvariantF` /
`CallMayForceF` with no such guard, runs the same integer read via
`execute_residual_call`, and stamps `Value::Float(f64::from_bits(..))`.

Copying the guard there is not available: its `Declined` arm runs
`fbw_abort_nested_unjournaled_residual` + `fbw_mark_unjournaled_effect`, so a
decline trades a wrong value for an unjournaled walk whose region the caller
then replays. Fixing the ABI closes both seams; declining can only ever close
one.

## The change

`call_float_function(func_ptr, args, arg_types) -> f64` — the `bh_call_f`
sibling of `call_int_function`. It splits the positional args into the int/float
banks `bh_call_f_dispatch` expects, keeps the wasm32 host-trampoline path, and
returns the `f64`. Float slots carry raw `f64::to_bits` in both directions
(`longlong` float-storage parity). Both walker seams use it; the decline is
deleted.

`bh_call_f_dispatch`'s arity table is `fn(I × ints, F × floats)` — all
integer/ref parameters precede all floats. Interleaved signatures assert rather
than shuffle registers. Every float-returning helper in the tree is
non-interleaved: `jit_bigint_to_f64_or_inf(ref) -> f64`,
`jit_float_abs(f64) -> f64`, `jit_float_fmod(f64, f64) -> f64`.

## Why this is safe: operand 0's ABI is set by REGISTRATION, not by emitter

#963's comment said the split was "codewriter vs the `*_canonical_via_target`
family". That is wrong —
`residual_call_float_canonical_via_target_with_effect_info` bakes
`target.concrete_ptr` for *every* producer. The discriminator is the
`JitCallTarget` registration site:

| registration | `concrete_ptr` is | float return |
|---|---|---|
| `add_fn_ptr(ptr)` = `add_call_target(ptr, ptr)` | the raw callee address | real f64 register |
| macro `add_call_target_with_save_err(trace, concrete)` | `#[jit_module]`'s `_concrete` wrapper, `extern "C" fn(i64,..) -> i64` with `f64::to_bits` | i64 bits |
| LLBC codewriter | plain `ConstInt(fnaddr_for_target)` — no `JitCallTarget` at all | real f64 register |

pyre's own codewriter registers via `add_fn_ptr` / `add_fn_ptr_with_slot`, so
its `concrete_ptr` is the raw address.

The i64-packing wrapper reaches a residual call **only** through the explicit
`*_float_wrapped` call policies — the macro's `HelperCallKind::Float` arm emits
an `UNSUPPORTED` policy byte for every attribute otherwise. No crate declares
one:

```
$ rg -n 'float_wrapped' --type rust -g '!target' -g '!majit/majit-macros/**' .
(no matches)
```

So every live float residual-call funcbox is a raw callee address. This is a
compile-time fact, so it needed no instrumented build.

The first commit corrects those comments in place, including two stale line
citations (`jitcode/assembler.rs:3343`, `codegen.rs:909`).

## Deliberately unchanged

* `execute_varargs`'s Float arm keeps `call_int_function` — its caller set
  includes `do_recursive_call`'s portal runner (`bh_portal_runner -> i64`), and
  that convention was not verified here.
* The `CALL_ASSEMBLER` arms (`pyjitpl/dispatch.rs`, `blackhole.rs`) genuinely do
  want the i64 wrapper and are a separate opcode family.

## Verification

`cargo test -p majit-metainterp -p pyre-jit-trace`: 1428 + 322 + siblings, 0
failed.

`pyre/check.py --backend dynasm,cranelift,wasm`: **2 failed each, byte-identical
to the pre-change run on the same base** — `exception_args_virtual` (all three),
`list_length_hint_validate` (dynasm/cranelift), `pickle_terminal_raise_resume`
(wasm). All three are inherited from `main`; the last was attributed by building
`origin/main` itself with none of these commits and measuring the same
`loops_aborted = 59`.

The corpus is neutral because no synth fixture drives a float residual call
through the walker executor (`math_sqrt_hot` / `math_log_trig_hot` short-circuit
in the walker specializers). The evidence is in the unit tests instead:

* the walker test now folds `halve_f64_for_walker_test(7)` to `3.5`; an
  integer-register read stamps the argument `7`;
* the two executor float tests use real `extern "C" fn(f64) -> f64` and
  `fn(i64) -> f64` callees, replacing hand-packed i64 helpers that had pinned
  the broken convention.

## Codex parity review disposition

Section 1: none. Sections 2–4 were checked against the cited upstream lines
before acting; both section-2 findings are reclassified, and the section-3
finding is a structural adaptation. The third commit records each reason in
code rather than changing behaviour.

**2.1 — the interleaved-signature `assert!` vs `create_call_stub`'s arbitrary
`arg_classes` order.** Reclassified. `bh_call_*_dispatch` recovers the callee
signature from the *bucketed* `(int, float)` arity, so `fn(f64, i64)` would be
dispatched as `fn(i64, f64)`. That is register-preserving under SysV and AAPCS,
which fill the integer and floating-point files in independent relative order,
and wrong under the Microsoft x64 convention, whose first four argument slots
are positional — `fn(f64, i64)` takes xmm0/rdx where `fn(i64, f64)` takes
rcx/xmm1. Upstream needs no such restriction because `create_call_stub`
generates a stub carrying the descr's real signature; the convergence path for
pyre is the libffi dispatch already named in `dispatch_arity_body!`'s catch-all
arm. The assertion is kept and its rationale restated in those terms.

Reviewing this did surface a real gap Codex did not flag: `collect_call_args`
performs the same reordering on the bank-fed path (`bh_call_{i,f,v}_by_classes`)
with no check at all. Not changed here — a blanket rejection would panic on
calls that are ABI-correct under SysV/AAPCS on the blackhole and backend hot
paths, and the correct fix is the same libffi dispatch. The gap is now stated
at the function.

**2.2 — `Type::Float` treated as `f64`, losing `'L'` (SignedLongLong) and
`'S'` (SingleFloat).** Reclassified as unreachable at this seam. The bank-fed
`collect_call_args` does carry both arms (`'L'` → integer register file, `'S'`
→ explicit panic). `call_float_function` is fed by `descr.arg_types()`, and
`CallDescr::arg_classes` maps `Type` onto `'i'`/`'r'`/`'f'`/`'v'` exhaustively,
so a `Type::Float` slot is always class `'f'`. Documented at the seam so that
teaching `Type` those classes extends both sites.

**3 — the NULL-Ref fold refusal vs `record_result_of_call_pure`.** Structural
adaptation, not pre-existing debt. Upstream's weaker test ("every argbox is a
`Const`", admitting `ConstPtr(NULL)`) is reached only after the call has already
executed for real, on constants the interpreter itself produced. Pyre's walker
folds from a different source: `getfield_gc_r` propagates pointer-valued field
reads as concrete whenever the parent struct is concrete-known, so a top-level
frame stamps `Value::Ref(GcRef(0))` where upstream still holds a symbolic box
guarded by the `guard_nonnull` its optimizer inserts ahead of a pointer-deref
residual call. Executing `helper(NULL)` before that guard exists dereferences
NULL. The comment now names the upstream test and where the divergence in
constant provenance comes from.

**4 — both items accepted as documented adaptations.** The `to_bits() as i64`
result is the `longlong` float-storage equivalent; the shared dispatch table
stands in for translation-time per-descr stub generation, and 2.2 above is the
descriptor-class semantics that entry asks it to retain.

`cargo test -p majit-metainterp -p majit-backend -p pyre-jit-trace`: 1428 + 325
+ siblings, 0 failed. The third commit changes doc comments and one assertion
message only, so the measured corpus results above still stand.

— *authored by Claude*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved support for executing calls that return floating-point values.
  - Floating-point arguments and results are now handled correctly across supported calling conventions.
  - Pure floating-point calls can now be evaluated and folded during optimization.

- **Bug Fixes**
  - Corrected mixed integer-and-floating-point call handling.
  - Added safeguards for unsupported argument layouts to prevent incorrect dispatch behavior.

- **Documentation**
  - Clarified calling-convention compatibility and dispatch limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->