### PR TITLE
jit: hand every abort_permanent the value stack the resumed opcode reads; gc: arena range cache; check.py measurement fixes

### DIFF
--- a/majit/majit-gc/src/minimarkpage.rs
+++ b/majit/majit-gc/src/minimarkpage.rs
@@ -54,6 +54,14 @@ pub struct ArenaCollection {
     /// pointer-chasing every bucket for arbitrary-word validity checks.
     /// It changes only when an arena is allocated or freed.
     arena_ranges: Vec<(usize, usize)>,
+    /// The range [`contains`] matched last.  Every field store that reaches the
+    /// write barrier asks the membership question once, and consecutive stores
+    /// name the same arena nearly always, so re-testing the previous answer
+    /// first replaces the binary search with two compares on that path.  A hit
+    /// can only be stale if the range left `arena_ranges`, so `free_arena`
+    /// clears it; inserting leaves every existing range where it was.
+    /// `(usize::MAX, 0)` is the empty state — no address satisfies it.
+    last_range_hit: std::cell::Cell<(usize, usize)>,
     min_empty_nfreepages: usize,
     pub num_uninitialized_pages: usize,
     pub total_memory_used: usize,
@@ -109,6 +117,7 @@ impl ArenaCollection {
             old_arenas_lists: vec![ptr::null_mut(); max_pages_per_arena],
             current_arena: ptr::null_mut(),
             arena_ranges: Vec::new(),
+            last_range_hit: std::cell::Cell::new((usize::MAX, 0)),
             min_empty_nfreepages: max_pages_per_arena,
             num_uninitialized_pages: 0,
             total_memory_used: 0,
@@ -492,10 +501,19 @@ impl ArenaCollection {
     /// this sorted flat index serves pyre's arbitrary-word membership query.
     #[inline]
     pub fn contains(&self, addr: usize) -> bool {
+        let (start, end) = self.last_range_hit.get();
+        if addr >= start && addr < end {
+            return true;
+        }
         let index = self
             .arena_ranges
             .partition_point(|&(start, _)| start <= addr);
-        index > 0 && addr < self.arena_ranges[index - 1].1
+        if index > 0 && addr < self.arena_ranges[index - 1].1 {
+            self.last_range_hit.set(self.arena_ranges[index - 1]);
+            true
+        } else {
+            false
+        }
     }
 
     unsafe fn free_arena(&mut self, arena: *mut ArenaReference) {
@@ -529,6 +547,7 @@ impl ArenaCollection {
                 .binary_search_by_key(&base, |&(start, _)| start)
                 .expect("freed arena missing from range index");
             self.arena_ranges.remove(index);
+            self.last_range_hit.set((usize::MAX, 0));
             alloc::dealloc((*arena).base, (*arena).layout);
             self.total_memory_alloced -= self.arena_size;
             self.arenas_count -= 1;
@@ -619,6 +638,22 @@ mod tests {
         assert_eq!(ac.total_memory_used, 0);
         assert_eq!(ac.arenas_count, 0);
         assert_eq!(ac.total_memory_alloced, 0);
+        assert!(!ac.contains(first));
+    }
+
+    #[test]
+    fn contains_cache_does_not_survive_the_arena_it_matched() {
+        let mut ac = ArenaCollection::new(ARENA_SIZE, PAGE_SIZE, THRESHOLD);
+        let first = ac.malloc(WORD) as usize;
+        while !ac.current_arena.is_null() {
+            ac.malloc(WORD);
+        }
+        // Prime the single-entry range cache on the arena about to be freed;
+        // without the invalidation in `free_arena` this hit would be replayed
+        // against returned memory.
+        assert!(ac.contains(first));
+        ac.mass_free(|_| true);
+        assert_eq!(ac.arenas_count, 0);
         assert!(!ac.contains(first));
     }
 

--- a/majit/majit-gc/src/shadow_stack.rs
+++ b/majit/majit-gc/src/shadow_stack.rs
@@ -672,6 +672,13 @@ pub unsafe fn slot_get(slot: ShadowStackSlot, index: usize) -> GcRef {
 }
 
 /// Walk all entries on the GcRef shadow stack.
+///
+/// Null entries are skipped here, on the walk, and nowhere else: a slot may
+/// legitimately hold null, because the save side stores whatever the livevar
+/// holds without testing it (`shadowcolor.py`'s `expand_one_push_roots` emits a
+/// `gc_save_root` per live GCREF with no value test, and marks slots unused
+/// through the translation-time `make_bitmask` rather than at runtime). This is
+/// `walk_stack_root`'s `if content:` in `shadowstack.py`.
 pub fn walk_roots(mut visitor: impl FnMut(&mut GcRef)) {
     SHADOW_STACK.with(|ss| {
         let mut ss = ss.borrow_mut();

--- a/pyre/bench/synth/wide_callkw_resume.cranelift.jitstats
+++ b/pyre/bench/synth/wide_callkw_resume.cranelift.jitstats
@@ -1,0 +1,8 @@
+bridges_compiled=0
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
+guard_failures=3
+internal_compile_panics=0
+loops_aborted=0
+loops_compiled=3

--- a/pyre/bench/synth/wide_callkw_resume.dynasm.jitstats
+++ b/pyre/bench/synth/wide_callkw_resume.dynasm.jitstats
@@ -1,0 +1,8 @@
+bridges_compiled=0
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
+guard_failures=3
+internal_compile_panics=0
+loops_aborted=0
+loops_compiled=3

--- a/pyre/bench/synth/wide_callkw_resume.py
+++ b/pyre/bench/synth/wide_callkw_resume.py
@@ -1,0 +1,35 @@
+# A CALL_KW past the per-arity helper ceiling (nargs > 13) reached after a hot
+# loop.  The loop exit deopts into the blackhole, which walks forward to the
+# CALL_KW and hands it back with `abort_permanent`.  The interpreter resumes AT
+# that opcode and re-runs it, so every argument has to still be readable out of
+# the frame -- the walker keeps a pushed value in its SSA register and syncs
+# only `valuestackdepth`, so the marker is what writes the slots back.
+#
+# Wrong code shows up as `UnboundLocalError: cannot access local variable 'a'`
+# raised inside the callee, because *a binds against empty argument slots.
+#
+# No `max-pypy-ratio`: pyre runs this ~80x pypy because the CALL_KW is refused
+# every time and the enclosing frame falls back to the interpreter, and pypy's
+# own execution time here sits on the harness measurement floor, so no ratio
+# computed against it is a measurement.  The fixture is a wrong-code guard; the
+# committed jit-stats and the output comparison are what gate it.
+CALLS = []
+
+
+def take(*a, **k):
+    return (a, k)
+
+
+def run(n):
+    i = 0
+    while i < n:
+        i += 1
+    CALLS.append(i)
+    return take(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, kw=99)
+
+
+total = 0
+for _ in range(3):
+    args, kwargs = run(20000)
+    total += sum(args) + kwargs["kw"]
+print(total, len(CALLS))

--- a/pyre/bench/synth/wide_callkw_resume.wasm.jitstats
+++ b/pyre/bench/synth/wide_callkw_resume.wasm.jitstats
@@ -1,0 +1,5 @@
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
+internal_compile_panics=0
+loops_aborted=0

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -93,7 +93,7 @@ BENCH_COMPARE_BUFFER_S = 0.005
 # Windows process CPU accounting advances in scheduler ticks (normally 1/64 s).
 # Keep the execution floor at least one observable tick on that platform.
 WIN_TIMER_QUANTUM_S = 1.0 / 64
-# Empty-program user-CPU startup is MEASURED per interpreter/backend (minimum of
+# Empty-program user-CPU startup is MEASURED per interpreter/backend (median of
 # STARTUP_SAMPLES runs) and subtracted from every timed run before ratios and
 # perf gates are computed, so a large fixed startup — notably wasmtime
 # recompiling the ~14MB module on every process spawn (~0.12s user-CPU) — does
@@ -106,18 +106,21 @@ WIN_TIMER_QUANTUM_S = 1.0 / 64
 # denominator and inflates every ratio computed against it.  A CI runner
 # measured pypy startup at 0.031s where the same job on the same platform had
 # measured 0.013s, and three unrelated benches failed their gates in that run
-# while their pyre exec times had gone *down*.
+# while their pyre exec times had gone *down*.  Five samples make the median
+# robust to two outliers instead of one.
 #
-# The estimator is the MINIMUM, not the median, because the quantity is a fixed
-# per-process cost and every source of error on it is one-sided: contention,
-# cache pressure and page faults only ever ADD user CPU.  The minimum of a set
-# of samples of a fixed cost is that cost; the median tracks how loaded the
-# machine was.  That distinction is what raising the sample count cannot buy —
-# under sustained load every sample is inflated, so the median is inflated with
-# them, while the minimum still recovers the floor.  Under-estimating instead is
-# the harmless direction: it inflates both exec times by the same few
-# milliseconds, which is negligible against a bench and cannot collapse a
-# denominator.
+# The estimator is the MEDIAN and not the minimum, even though the quantity is a
+# fixed per-process cost whose error sources are all one-sided — contention,
+# cache pressure and page faults only ever add user CPU.  The minimum does
+# recover that cost, but it recovers it for an *idle* machine, and it is
+# subtracted from bench runs that were not idle: under load a bench carries an
+# inflated startup inside it, and taking the unloaded minimum away leaves that
+# inflation behind in `exec`.  Pairing median with median cancels it; pairing an
+# idle minimum with a loaded bench does not.  Measured on one CI job, the
+# minimum came in 15ms under the median for dynasm and 13ms for cranelift, which
+# carried nine short benches whose baseline was pinned to EXEC_TIME_FLOOR_S over
+# their gates at once.  The estimate has to come from the same load conditions
+# as the run it is subtracted from.
 STARTUP_SAMPLES = 5
 EXEC_TIME_FLOOR_S = WIN_TIMER_QUANTUM_S if sys.platform == "win32" else 0.005
 # A single slow sample is retried before failing a performance gate. Windows
@@ -958,7 +961,7 @@ class Check:
         """Measure each timed interpreter/backend's empty-program user-CPU cost.
 
         Runs an empty script STARTUP_SAMPLES times per interpreter and records
-        the minimum user-CPU in self.startup. This is the fixed per-process cost
+        the median user-CPU in self.startup. This is the fixed per-process cost
         (interpreter init; for wasm, wasmtime recompiling the module) added to
         every bench regardless of workload; subtracting it yields an
         execution-only comparison. No-op under --no-startup-subtract.
@@ -990,11 +993,11 @@ class Check:
                         samples = []
                         break
                     samples.append(elapsed)
-                startup = min(samples) if samples else 0.0
+                startup = statistics.median(samples) if samples else 0.0
                 self.startup[key] = startup
                 parts.append(f"{key}={startup:.3f}s")
             print(dim(
-                f"startup (empty-program user-CPU, min of {STARTUP_SAMPLES}; "
+                f"startup (empty-program user-CPU, median {STARTUP_SAMPLES}; "
                 f"ratios/gates are execution-only): " + " ".join(parts)
             ))
         finally:

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -93,7 +93,7 @@ BENCH_COMPARE_BUFFER_S = 0.005
 # Windows process CPU accounting advances in scheduler ticks (normally 1/64 s).
 # Keep the execution floor at least one observable tick on that platform.
 WIN_TIMER_QUANTUM_S = 1.0 / 64
-# Empty-program user-CPU startup is MEASURED per interpreter/backend (median of
+# Empty-program user-CPU startup is MEASURED per interpreter/backend (minimum of
 # STARTUP_SAMPLES runs) and subtracted from every timed run before ratios and
 # perf gates are computed, so a large fixed startup — notably wasmtime
 # recompiling the ~14MB module on every process spawn (~0.12s user-CPU) — does
@@ -102,12 +102,22 @@ WIN_TIMER_QUANTUM_S = 1.0 / 64
 # to <= 0 and blow up a ratio.
 #
 # The startup is a divisor for every short bench: the baseline's exec time is
-# `bench - startup`, so a startup sample that lands high collapses that
+# `bench - startup`, so a startup estimate that lands high collapses that
 # denominator and inflates every ratio computed against it.  A CI runner
 # measured pypy startup at 0.031s where the same job on the same platform had
 # measured 0.013s, and three unrelated benches failed their gates in that run
-# while their pyre exec times had gone *down*.  Five samples make the median
-# robust to two outliers instead of one.
+# while their pyre exec times had gone *down*.
+#
+# The estimator is the MINIMUM, not the median, because the quantity is a fixed
+# per-process cost and every source of error on it is one-sided: contention,
+# cache pressure and page faults only ever ADD user CPU.  The minimum of a set
+# of samples of a fixed cost is that cost; the median tracks how loaded the
+# machine was.  That distinction is what raising the sample count cannot buy —
+# under sustained load every sample is inflated, so the median is inflated with
+# them, while the minimum still recovers the floor.  Under-estimating instead is
+# the harmless direction: it inflates both exec times by the same few
+# milliseconds, which is negligible against a bench and cannot collapse a
+# denominator.
 STARTUP_SAMPLES = 5
 EXEC_TIME_FLOOR_S = WIN_TIMER_QUANTUM_S if sys.platform == "win32" else 0.005
 # A single slow sample is retried before failing a performance gate. Windows
@@ -948,7 +958,7 @@ class Check:
         """Measure each timed interpreter/backend's empty-program user-CPU cost.
 
         Runs an empty script STARTUP_SAMPLES times per interpreter and records
-        the median user-CPU in self.startup. This is the fixed per-process cost
+        the minimum user-CPU in self.startup. This is the fixed per-process cost
         (interpreter init; for wasm, wasmtime recompiling the module) added to
         every bench regardless of workload; subtracting it yields an
         execution-only comparison. No-op under --no-startup-subtract.
@@ -980,11 +990,11 @@ class Check:
                         samples = []
                         break
                     samples.append(elapsed)
-                startup = statistics.median(samples) if samples else 0.0
+                startup = min(samples) if samples else 0.0
                 self.startup[key] = startup
                 parts.append(f"{key}={startup:.3f}s")
             print(dim(
-                f"startup (empty-program user-CPU, median {STARTUP_SAMPLES}; "
+                f"startup (empty-program user-CPU, min of {STARTUP_SAMPLES}; "
                 f"ratios/gates are execution-only): " + " ".join(parts)
             ))
         finally:
@@ -1455,10 +1465,23 @@ class Check:
             ratio = "-"
         else:
             ratio = f"{float(exec_m) / float(exec_b):.1f}x"
-        return (
+        # A baseline sitting exactly on EXEC_TIME_FLOOR_S was clamped: the
+        # subtraction put it at or below the floor, so its execution time could
+        # not be separated from its own startup and the ratio computed against
+        # it is an artifact of the clamp rather than a measurement.  Say so on
+        # the line, because the printed denominator otherwise reads like one.
+        clamped = (
+            not self.args.no_startup_subtract
+            and exec_b not in (None, "-")
+            and float(exec_b) <= EXEC_TIME_FLOOR_S
+        )
+        detail = (
             f"exec {exec_m:.2f}s > {baseline} {exec_b:.2f}s  "
             f"ratio {ratio} > gate {float(limit):g}x"
         )
+        if clamped:
+            detail += f"  [{baseline} exec clamped to floor; ratio not a measurement]"
+        return detail
 
     def _run_backend_bench(
         self, backend, name, script, timeout,

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -6750,11 +6750,38 @@ impl CodeWriter {
             }};
             // Terminal form: the marker ends this graph block.  Used by the
             // arms that `continue` out of the dispatch instead of completing
-            // their stack model — the `Call` nargs > 14 arm (which skips its
-            // `push_and_bump!`) and the `LoadFastCheck` unbound arm (which
-            // switches into a dedicated dead-end block that has no successor
-            // by construction).
+            // their stack model — the `Call` nargs > 14 arm (which bails
+            // before touching the operands, so nothing pushes the call result
+            // the fall-through PC expects) and the `LoadFastCheck` unbound arm
+            // (which switches into a dedicated dead-end block that has no
+            // successor by construction).  Both leave the value stack exactly
+            // as the interpreter will find it, so the resume coordinate below
+            // is emitted for this form too.
             ($py_pc:expr, closes_block) => {{
+                // Nothing follows to model the frame further, so the value
+                // stack the interpreter resumes on has to be the real one.
+                // `push_and_bump!` leaves a pushed value in its SSA register
+                // and syncs only `valuestackdepth` — the vable slot behind it
+                // still reads PY_NULL — so mirror every live slot before the
+                // bail (`pyframe.py`'s `pushvalue`, lowered by
+                // `jtransform.py`'s `do_fixed_list_setitem`).  These stores sit
+                // in a block that only ever runs into the marker, so no
+                // continuing path pays for them.
+                for (slot, value) in current_state.stack.iter().enumerate() {
+                    let v_idx: super::flow::FlowValue =
+                        super::flow::Constant::signed((stack_base_absolute + slot) as i64).into();
+                    record_graph_op(
+                        &current_block.block(),
+                        "setarrayitem_vable_r",
+                        vable_setarrayitem_ref_graph_args(
+                            frame_var.into(),
+                            v_idx.into(),
+                            value.clone().into(),
+                        ),
+                        None,
+                        ($py_pc) as i64,
+                    );
+                }
                 emit_abort_permanent!(@emit $py_pc, true)
             }};
             (@emit $py_pc:expr, $closes_block:expr) => {{
@@ -9079,6 +9106,24 @@ impl CodeWriter {
                         // Pop in reverse: args, null_or_self, callable.
                         Instruction::Call { argc } => {
                             let nargs = argc.get(op_arg) as usize;
+                            // No `call_fn_N` helper exists past nargs 14 (the
+                            // backend dispatch tops out at 16 i64 args =
+                            // callable + null_or_self + 14), so this opcode is
+                            // handed back to the interpreter.  Bail here,
+                            // ahead of the operand pops: `abort_permanent`
+                            // publishes `last_instr = py_pc - 1` and the
+                            // interpreter re-runs this CALL, which needs the
+                            // callable and its arguments still on the value
+                            // stack.  `emit_popvalue_ref!` nulls each slot it
+                            // pops and syncs the lowered `valuestackdepth`
+                            // into the vable, so a bail placed after them
+                            // resumes a wide call against an empty stack.
+                            // `closes_block`: nothing pushes the call result,
+                            // so the fall-through PC must not be walked.
+                            if nargs > 14 {
+                                emit_abort_permanent!(py_pc, closes_block);
+                                continue;
+                            }
                             let mut graph_arg_values_rev = Vec::with_capacity(nargs);
                             for _ in 0..nargs {
                                 let _arg_reg = emit_popvalue_ref!(current_depth, py_pc);
@@ -9176,50 +9221,38 @@ impl CodeWriter {
 
                             // RPython blackhole.py: call_int_function transmutes
                             // to the correct arity. Each nargs needs a matching
-                            // extern "C" fn with that many i64 parameters.
-                            // nargs > 14 → abort_permanent (no matching helper;
-                            // the backend dispatch tops out at 16 i64 args =
-                            // callable + null_or_self + 14).
-                            let call_result_value = if nargs > 14 {
-                                fresh_ref_value(&mut graph)
-                            } else {
-                                // Graph-side `simple_call(callable,
-                                // null_or_self, args...)` carries the RPython
-                                // rewrite_call shape (jtransform.py:414 — no
-                                // frame arg).  The canonical driver's
-                                // `lower_simple_call_hlop_to_insn` arm lowers
-                                // it to `residual_call_r_r(
-                                // ConstInt(call_fn_<nargs>_idx),
-                                // ListR([Reg(callable), Reg(null_or_self),
-                                // Reg(arg0), ...]), Descr) → Reg(dst)` with
-                                // `CallFlavor::MayForce` (every `call_fn_N` is
-                                // bound MayForce).  The ABI matches upstream
-                                // `bhimpl_residual_call_r_r` (no frame); the
-                                // parent frame is resolved at runtime from the
-                                // execution context inside `bh_call_fn_impl`,
-                                // which also prepends a non-null null_or_self
-                                // as arg0 (eval.rs:3216-3226).
-                                let graph_call_args: Vec<super::flow::FlowValue> =
-                                    graph_arg_values_rev.iter().rev().cloned().collect();
-                                let result = emit_frontend_simple_call(
+                            // extern "C" fn with that many i64 parameters, and
+                            // the arities past 14 were already handed back to
+                            // the interpreter above.
+                            //
+                            // Graph-side `simple_call(callable, null_or_self,
+                            // args...)` carries the shape `jtransform.py`'s
+                            // `rewrite_call` produces — no frame arg.  The
+                            // canonical driver's
+                            // `lower_simple_call_hlop_to_insn` arm lowers it to
+                            // `residual_call_r_r(
+                            // ConstInt(call_fn_<nargs>_idx),
+                            // ListR([Reg(callable), Reg(null_or_self),
+                            // Reg(arg0), ...]), Descr) → Reg(dst)` with
+                            // `CallFlavor::MayForce` (every `call_fn_N` is
+                            // bound MayForce).  The ABI matches upstream
+                            // `bhimpl_residual_call_r_r` (no frame); the
+                            // parent frame is resolved at runtime from the
+                            // execution context inside `bh_call_fn_impl`,
+                            // which also prepends a non-null null_or_self
+                            // as arg0 (`eval.rs`).
+                            let graph_call_args: Vec<super::flow::FlowValue> =
+                                graph_arg_values_rev.iter().rev().cloned().collect();
+                            let call_result_value: super::flow::FlowValue =
+                                emit_frontend_simple_call(
                                     &mut graph,
                                     &current_block.block(),
                                     callable_value,
                                     null_or_self_value.into(),
                                     graph_call_args,
                                     py_pc as i64,
-                                );
-                                result.into()
-                            };
-                            if nargs > 14 {
-                                // `closes_block`: this arm skips the
-                                // `push_and_bump!` below, so its stack model is
-                                // incomplete and the fall-through must not be
-                                // walked.  Do not record the synthetic call
-                                // result or any later operation on the block.
-                                emit_abort_permanent!(py_pc, closes_block);
-                                continue;
-                            }
+                                )
+                                .into();
                             push_and_bump!(call_result_value, py_pc);
                         }
 
@@ -12122,6 +12155,16 @@ impl CodeWriter {
 
                                 current_block = unbound_block;
                                 current_state = unbound_state;
+                                // The `push_and_bump!` above synced a
+                                // `valuestackdepth` for a LOAD_FAST_CHECK that
+                                // pushed its value.  This arm's opcode does
+                                // not: the interpreter re-runs it from the
+                                // marker and raises UnboundLocalError before
+                                // pushing.  The depth was walked back on the
+                                // abstract state only, so sync the physical
+                                // one too or the resumed frame carries a
+                                // phantom slot above its real top.
+                                emit_vsd!(current_depth, py_pc);
                                 // `closes_block`: the null arm's block is a
                                 // dead end by construction — the bound arm
                                 // already merged the fall-through PC above, so

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -6741,6 +6741,12 @@ impl CodeWriter {
         // switchover. `dispatch_op` in `assembler.rs:510` already routes
         // `"abort_permanent"` to the builder, so the external push is
         // an exact mirror of the pre-existing internal behavior.
+        // The value stack as the opcode being walked was entered, refreshed per
+        // PC below and read by `emit_abort_permanent!`.  Declared out here
+        // rather than beside the refresh because a `macro_rules!` body resolves
+        // a non-parameter identifier in the macro's DEFINITION scope.
+        let mut pre_opcode_stack: Vec<super::flow::FlowValue> = Vec::new();
+
         macro_rules! emit_abort_permanent {
             // Straight-line form: the arm has modelled this opcode's stack
             // effect and the walk falls through to the next PC.  The block is
@@ -6754,20 +6760,27 @@ impl CodeWriter {
             // before touching the operands, so nothing pushes the call result
             // the fall-through PC expects) and the `LoadFastCheck` unbound arm
             // (which switches into a dedicated dead-end block that has no
-            // successor by construction).  Both leave the value stack exactly
-            // as the interpreter will find it, so the resume coordinate below
-            // is emitted for this form too.
+            // successor by construction).
             ($py_pc:expr, closes_block) => {{
-                // Nothing follows to model the frame further, so the value
-                // stack the interpreter resumes on has to be the real one.
-                // `push_and_bump!` leaves a pushed value in its SSA register
-                // and syncs only `valuestackdepth` — the vable slot behind it
-                // still reads PY_NULL — so mirror every live slot before the
-                // bail (`pyframe.py`'s `pushvalue`, lowered by
-                // `jtransform.py`'s `do_fixed_list_setitem`).  These stores sit
-                // in a block that only ever runs into the marker, so no
-                // continuing path pays for them.
-                for (slot, value) in current_state.stack.iter().enumerate() {
+                emit_abort_permanent!(@emit $py_pc, true)
+            }};
+            (@emit $py_pc:expr, $closes_block:expr) => {{
+                // Materialize the value stack the interpreter resumes on.
+                // `pyframe.py`'s `pushvalue` lowers every push to a
+                // `setarrayitem_vable_r` (`jtransform.py`'s
+                // `do_fixed_list_setitem`), but pyre's `push_and_bump!` keeps
+                // the pushed value in its SSA register and syncs only
+                // `valuestackdepth`, so a slot last written that way still
+                // reads PY_NULL out of the vable.  Every stack slot the
+                // resumed opcode reads has to be a real one, and the walk
+                // reaches the marker only on a run that is bailing, so nothing
+                // that keeps executing pays for these stores.
+                //
+                // The snapshot, not `current_state`: the marker resumes AT this
+                // opcode, and the arms model the opcode's stack effect before
+                // they bail, so `current_state` here is the state AFTER an
+                // opcode that has not run.
+                for (slot, value) in pre_opcode_stack.iter().enumerate() {
                     let v_idx: super::flow::FlowValue =
                         super::flow::Constant::signed((stack_base_absolute + slot) as i64).into();
                     record_graph_op(
@@ -6782,9 +6795,7 @@ impl CodeWriter {
                         ($py_pc) as i64,
                     );
                 }
-                emit_abort_permanent!(@emit $py_pc, true)
-            }};
-            (@emit $py_pc:expr, $closes_block:expr) => {{
+                emit_vsd!(pre_opcode_stack.len(), $py_pc);
                 // Publish `last_instr` to the vable before the bail so the
                 // blackhole hands the interpreter the right resume
                 // coordinate.  The blackhole replays codewriter jitcode that
@@ -8232,6 +8243,14 @@ impl CodeWriter {
                     // via setfield_vable_i (jtransform.py), NOT once at opcode
                     // entry. The per-push/per-pop emit_vsd! calls below mirror that.
                     // (The old single-entry flush is removed.)
+
+                    // Snapshot the entry stack for `emit_abort_permanent!`.  The
+                    // marker resumes the interpreter AT this opcode, so what it
+                    // has to hand back is the frame the opcode has not run yet —
+                    // and an arm that aborts has usually already modelled the
+                    // opcode's stack effect on `current_state`.
+                    pre_opcode_stack.clear();
+                    pre_opcode_stack.extend(current_state.stack.iter().cloned());
 
                     // RPython jtransform.py: rewrite_operation() dispatches per opname.
                     // Each match arm is the pyre equivalent of rewrite_op_*.
@@ -12155,16 +12174,6 @@ impl CodeWriter {
 
                                 current_block = unbound_block;
                                 current_state = unbound_state;
-                                // The `push_and_bump!` above synced a
-                                // `valuestackdepth` for a LOAD_FAST_CHECK that
-                                // pushed its value.  This arm's opcode does
-                                // not: the interpreter re-runs it from the
-                                // marker and raises UnboundLocalError before
-                                // pushing.  The depth was walked back on the
-                                // abstract state only, so sync the physical
-                                // one too or the resumed frame carries a
-                                // phantom slot above its real top.
-                                emit_vsd!(current_depth, py_pc);
                                 // `closes_block`: the null arm's block is a
                                 // dead end by construction — the bound arm
                                 // already merged the fall-through PC above, so


### PR DESCRIPTION
## The defect

A call past the per-arity helper ceiling, reached after a hot loop, miscompiles.
Both backends, and in both shapes:

```python
L = []
def f(*a): return sum(a)
i = 0
while i < 50000: i += 1
L.append(1)
print(f(1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17), L)   # value-stack underflow, rc=101
```

```python
def take(*a, **k): return (a, k)
# ... after a hot loop ...
take(1,2,3,4,5,6,7,8,9,10,11,12,13,14, kw=99)
# UnboundLocalError: cannot access local variable 'a'  -- raised inside the callee
```

`abort_permanent/` publishes `last_instr = py_pc - 1`, so the interpreter resumes
**at the marker's own opcode and runs it**. Every operand that opcode reads has
to still be readable out of the frame. Two independent reasons it was not:

1. **The wide `Call` arm consumed its operands before testing the arity.** It ran
   `emit_popvalue_ref!` over every argument, `null_or_self` and the callable
   first; each of those nulls the slot *and* lowers `valuestackdepth`, so the
   frame reached the marker at depth 0. The arity test is now hoisted above the
   pop loop — `nargs` is known on the arm's first line.

2. **`push_and_bump!` never mirrors the pushed value into the vable.** It does
   `current_state.stack.push` + `current_depth += 1` + `emit_vsd!` and nothing
   else, so a slot last written that way still reads PY_NULL. `LoadSmallInt` and
   `LoadConst` push through it; only `emit_load_fast_ref!` /
   `emit_pushvalue_ref!` / `emit_pushvalue_ref_const!` write the array. After (1)
   the resumed call read seventeen NULLs. Fixed by flushing the value stack with
   `setarrayitem_vable_r` in the shared `emit_abort_permanent!` path, so **every**
   marker — not only the `closes_block` ones — hands back a real frame.

The flush uses a **per-PC snapshot of the entry stack**, not `current_state`: an
arm that aborts has usually already modelled the opcode's stack effect, so at the
marker `current_state` describes the state *after* an opcode that has not run.

Nothing on a run that keeps executing pays for the stores — the walk reaches a
marker only on a run that is bailing.

Also: the `LoadFastCheck` unbound arm walked its depth back on the abstract state
only, leaving the vable one slot above the frame's real top.

### Why it surfaced now

Before the blackhole rollback was removed, the deopt restored `locals` /
`valuestackdepth` / `last_instr` from a pre-blackhole snapshot, which overwrote
the published coordinate and hid all of this. Removing the rollback was correct —
it double-executed side effects — and made the coordinate load-bearing.

### The deviation this compensates for

`pyframe.py`'s `pushvalue` lowers **every** push to a `setarrayitem_vable_r`
(`jtransform.py`'s `do_fixed_list_setitem`); the optimizer then elides the
redundant ones and forces at a `may_force` boundary. `push_and_bump!` omitting
the store is the deviation, and the abort-site flush compensates for it. Making
`push_and_bump!` mirror is the orthodox fix, but it puts a store after every
computed push on the hot path and moves jit-stats broadly — a separate, measured
change.

## Regression coverage

`bench/synth/wide_callkw_resume.py`, verified against a binary built without the
fix, where it fails with exactly the `UnboundLocalError` above. `nargs <= 13`
(no abort) is the passing control.

It carries no `max-pypy-ratio`: the CALL_KW is refused every time so the
enclosing frame falls back to the interpreter, and pypy's own execution time here
sits on the harness measurement floor, so no ratio computed against it is a
measurement. The committed jit-stats and the output comparison are what gate it.

`check.py` never caught any of this; the probe scripts did.

## Also here

- **`gc`: cache the last `ArenaCollection::contains` range hit**, invalidated in
  `free_arena`. A doc note on `walk_roots` records that null entries are skipped
  on the walk and nowhere else — the save side stores a livevar untested
  (`shadowcolor.py`'s `expand_one_push_roots` emits a `gc_save_root` per live
  GCREF with no value test, and marks slots unused through the translation-time
  `make_bitmask`), and the only null test is `walk_stack_root`'s `if content:` in
  `shadowstack.py`.
- **`check.py`: annotate a gate failure whose baseline exec was clamped** to
  `EXEC_TIME_FLOOR_S` with `[... exec clamped to floor; ratio not a
  measurement]`, so a ratio that is an artifact of the clamp says so instead of
  reading as a regression. This is the whole behavioural delta against `main`;
  the rest of those two commits is a comment.

  The first of them also switched the startup estimator from the median of
  `STARTUP_SAMPLES` to the minimum, and the second puts it back. The minimum
  does recover a fixed per-process cost — on an idle machine. It is subtracted
  from bench runs that were not idle, and a loaded bench carries an inflated
  startup inside it, so taking the unloaded minimum away leaves that inflation
  in `exec`. On the previous CI run of this branch the minimum came in 15ms
  under the median for dynasm and 13ms for cranelift, and nine short benches
  whose pypy baseline was pinned to the floor crossed their gates at once, where
  `main` at the same base had none. The comment records this so it is not
  retried; note it cannot be reproduced locally, because on an idle box the
  median and the minimum agree.

## Verification

Locally, on both backends: the 15 probe scripts and a 12-repro comparison
against CPython all pass, and `cargo test --all --no-default-features` is
**7372 passed, 0 failed**.

CI on the previous push of this branch (base `6fbef5f7c7c`) had `cargo test`
green on all three platforms. Its `check.py` red was measured against `main`'s
own run **at that same base**, per platform. Windows is the clean comparison —
its exec floor is a scheduler tick rather than 5ms, so short benches do not sit
on the floor and the ratio-noise class is absent there:

| | `main` @ `6fbef5f7c7c` | this branch, same base |
|---|---|---|
| windows | `exception_args_virtual` ×2, `list_length_hint_validate` ×2 — 2 failed, 368 passed | the same four lines, identical counters — 2 failed, **369** passed |

Zero branch-attributable difference; the extra pass is the new bench. Those two
have since been fixed on `main` by #993 and no longer appear at this branch's
current base.

— *authored by Claude*
