### PR TITLE
jit: fix two backend-independent jitstats floor reds (catch-landing exc_value, str_len_descr parent)

### DIFF
--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -853,6 +853,36 @@ static W_LONG_DESCR_GROUP: LazyLock<PyreObjectDescrGroup> = LazyLock::new(|| {
     )
 });
 
+static W_UNICODE_DESCR_GROUP: LazyLock<PyreObjectDescrGroup> = LazyLock::new(|| {
+    // `str` needs a SizeDescr parent for its `len` FieldDescr so that a folded
+    // `len(const_str)` passes protect_speculative_field: descr.py:238 sets
+    // `parent_descr` unconditionally, and the fold reaches into the parent's
+    // vtable subclassrange (str's `&STR_TYPE`) to validate the constant.
+    // Single positional field mirrors the W_Int/W_Bool/W_Long groups; str is
+    // never inline-`NewWithVtable`'d (its value buffer is a residual-call
+    // allocation), so the GC-pointer slots traced by the runtime TypeInfo
+    // (value/w_slots/index_storage) stay out of the positional list.
+    build_object_descr_group_with_def_path(
+        std::mem::size_of::<pyre_object::unicodeobject::W_UnicodeObject>(),
+        W_UNICODE_GC_TYPE_ID,
+        &pyre_object::pyobject::STR_TYPE as *const _ as usize,
+        &[(
+            // `len` (codepoint count) is a `usize`: read at usize width so a
+            // wasm32 `GetfieldGcI` does not fold in the adjacent field's high
+            // half. Immutable: a str's length never changes.
+            "len",
+            UNICODE_LEN_OFFSET,
+            std::mem::size_of::<usize>(),
+            Type::Int,
+            false,
+            true,
+            false,
+        )],
+        "W_UnicodeObject",
+        "unicodeobject::W_UnicodeObject",
+    )
+});
+
 static W_BOOL_DESCR_GROUP: LazyLock<PyreObjectDescrGroup> = LazyLock::new(|| {
     build_object_descr_group_with_def_path(
         std::mem::size_of::<pyre_object::boolobject::W_BoolObject>(),
@@ -2655,17 +2685,11 @@ pub fn long_value_descr() -> DescrRef {
 }
 
 pub fn str_len_descr() -> DescrRef {
-    // Python len(str) returns codepoint count.
-    // unicodeobject.py:165 W_UnicodeObject._len() → _length field.
-    // `W_UnicodeObject.len` is a `usize`: 8 bytes on 64-bit, 4 on wasm32 — a
-    // hardcoded 8 reads the adjacent field into the high half on a 32-bit
-    // target (blackhole resume of `len(str)`).
-    make_immutable_field_descr(
-        UNICODE_LEN_OFFSET,
-        std::mem::size_of::<usize>(),
-        Type::Int,
-        false,
-    )
+    // Python len(str) returns codepoint count (unicodeobject.py:165
+    // W_UnicodeObject._len() → `len` field). Routed through the descr group so
+    // the FieldDescr carries a parent SizeDescr; a folded `len(const_str)`
+    // otherwise fails protect_speculative_field on the missing parent.
+    field_descr_from_group(&W_UNICODE_DESCR_GROUP, 0)
 }
 
 // ── Object header & allocation descriptors ──────────────────────────
@@ -5189,6 +5213,7 @@ pub(crate) fn publish_runtime_descr_groups() {
         &*W_INT_DESCR_GROUP,
         &*W_FLOAT_DESCR_GROUP,
         &*W_LONG_DESCR_GROUP,
+        &*W_UNICODE_DESCR_GROUP,
         &*W_BOOL_DESCR_GROUP,
         &*RANGE_ITER_DESCR_GROUP,
         &*RANGE_DESCR_GROUP,

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -12841,13 +12841,25 @@ impl CodeWriter {
                 // `last_exc_value` SSARepr op at flatten time only — there
                 // is no graph SpaceOperation counterpart, the Variable
                 // flows through `link.last_exc_value` and is materialised
-                // by the flatten-time emission.  Allocate a fresh Ref
-                // Variable to carry the catch-landing's exception value
-                // through `current_state.stack` and the subsequent vable
-                // push, matching the variable-lifecycle shape upstream
-                // produces — without recording a graph `last_exc_value`
-                // SpaceOp the flatten driver would have to filter.
-                let exc_value: super::flow::FlowValue = fresh_ref_value(&mut graph);
+                // by the flatten-time emission.  Reuse the landing's own
+                // `last_exception` value Variable — the edge pair set by
+                // `exception_landing_state`, whose colour `generate_last_exc`
+                // writes into — as the pushed exception value, instead of a
+                // producerless fresh Ref.  A fresh Ref has no defining op, so
+                // regalloc treats it as dead-until-first-use and coalesces it
+                // onto a body colour (e.g. a local live across the `try`); on
+                // a guard-failure bridge that re-walks the handler the body
+                // colour's def sits in the skipped prefix, so the pushed value
+                // is read unbound (`RegisterReadUnbound`).  The landing value
+                // is produced by `generate_last_exc`, is re-derived on any
+                // bridge, and interferes with the surrounding live ranges so
+                // it earns a distinct colour.  Same fix as the PUSH_EXC_INFO
+                // handler at the `last_exc_value` re-read above.
+                let exc_value: super::flow::FlowValue = current_state
+                    .last_exception
+                    .as_ref()
+                    .map(|(_, value)| value.clone())
+                    .unwrap_or_else(|| fresh_ref_value(&mut graph));
                 current_state.stack.push(exc_value.clone());
                 // pyframe.py:503-510 + eval.rs:155-158 `dropvaluesuntil` parity:
                 //


### PR DESCRIPTION
Closes the two remaining backend-independent jit-stats floor reds on `main`, both by fixing JIT code to conform to the committed baselines — no baseline re-recording.

## Commit 1 — `list_length_hint_validate` (catch-landing producerless exc_value)

The catch-landing branch in `jit/codewriter.rs` pushed the caught exception value with a producerless `fresh_ref_value`. Regalloc coalesced it onto a body colour (the local list `r`); on a guard-failure bridge that re-walks the handler, that colour's def sits in the skipped prefix, so the push reads unbound (`RegisterReadUnbound{pc:456, reg:3}` ×20) and the walk aborts.

Fix: reuse the landing's own `last_exception` value Variable (which has a `generate_last_exc` producer and is re-derived on any bridge), mirroring the existing `PUSH_EXC_INFO` twin.

Measured: `list_length_hint_validate` loops_aborted 34→14, guard_failures 4923→828 — exact match to baseline.

## Commit 2 — `exception_args_virtual` (parentless const-str getfield)

`str_len_descr()` minted the `len(str)` FieldDescr parentless via `make_immutable_field_descr`. When a trace constant-folds `len(const_str)`, `protect_speculative_field` fails closed on the missing parent (`get_parent_descr() == None`), signals `InvalidLoop`, the bridge is discarded and `compile_loop` gives up with `ABORT_BAD_LOOP`.

Fix: add `W_UNICODE_DESCR_GROUP` (vtable `&STR_TYPE`, type_id `W_UNICODE_GC_TYPE_ID`, single positional `usize` `len` field), mirroring the `W_Int`/`W_Bool`/`W_Long` single-field groups, and route `str_len_descr` through `field_descr_from_group` so the FieldDescr carries a parent SizeDescr whose subclassrange validates the folded constant. This restores PyPy's `get_field_descr` invariant (descr.py:218-239, `parent_descr` set unconditionally). No `BhDescr`/serde change, no LLBC re-extraction.

Measured: `exception_args_virtual` loops_aborted 3→0 on dynasm, cranelift and wasm.

## Verification

- Full synth jit-stats gate: **353/353 on dynasm, 353/353 on cranelift**, zero collateral.
- wasm: both fixtures verified (exception_args_virtual 3→0). `pickle_terminal_raise_resume` is provably inert to commit 2 (main and branch both read 59 on macOS; the committed wasm baseline `54` is the Linux-CI value, so the local +5 is a platform read, not a regression).
- Codex parity review (scoped to the changed files): no regressions, no introduced mismatches; the str descr group's omitted GC slots and unsigned-`usize` length are intentional Rust-layout adaptations.

— *commented by Claude*