### PR TITLE
jit(wasm): fix the entry-bridge decline chain — record inputarg types on the token, and publish a peeled loop's resume-label prefix

### DIFF
--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -514,10 +514,15 @@ impl LabelResumeData {
         let mut per_label = Vec::new();
         let mut uncapturable = Vec::new();
 
+        // Only the labels the entry dispatch can land on need a capture plan;
+        // an in-body label is never resumed, so reserving frame slots for its
+        // live-ins would only inflate the frozen geometry.
+        let resumable = resumable_label_count(ops);
         for (label_pos, label) in ops
             .iter()
             .enumerate()
             .filter(|(_, op)| op.opcode == OpCode::Label)
+            .take(resumable)
         {
             let mut available = vec![false; num_vars as usize];
             let mut defined_before = vec![false; num_vars as usize];
@@ -2006,18 +2011,23 @@ fn build_function(
     // and the fall-through path `br`s over each loader. Key 0 (and any
     // out-of-range key) runs the function from its entry (the preamble).
     let key_dispatch = is_resumable_peeled(ops);
-    let num_labels = ops.iter().filter(|op| op.opcode == OpCode::Label).count();
-    let all_label_args: Vec<Vec<OpRef>> = if key_dispatch {
-        ops.iter()
-            .filter(|op| op.opcode == OpCode::Label)
-            .map(|op| op.getarglist().iter().map(|a| a.to_opref()).collect())
-            .collect()
+    // Labels after the loop header sit inside the `loop` and get no block pair
+    // (`resumable_label_count`); every count below is over the resumable
+    // prefix, which is exactly labels 0..=header in ops order.
+    let num_labels = if key_dispatch {
+        resumable_label_count(ops)
     } else {
-        Vec::new()
+        0
     };
+    let all_label_args: Vec<Vec<OpRef>> = ops
+        .iter()
+        .filter(|op| op.opcode == OpCode::Label)
+        .take(num_labels)
+        .map(|op| op.getarglist().iter().map(|a| a.to_opref()).collect())
+        .collect();
     if key_dispatch {
         // block $exit (A) — guard/Finish exits br here -> epilogue.
-        // Per label j (opened outermost = last label):
+        // Per resumable label j (opened outermost = the loop header):
         //   block $past_loader_j (B_j) — the fall-through path br's over the
         //     label-j resume loader.
         //   block $loader_j (C_j) — the `br_table` lands here (its end) for
@@ -2107,7 +2117,7 @@ fn build_function(
     let mut ovf_flag_live = false;
 
     for (op_idx, op) in ops.iter().enumerate() {
-        if op.opcode == OpCode::Label && key_dispatch {
+        if op.opcode == OpCode::Label && key_dispatch && labels_passed < num_labels {
             // End of the segment before label j (key-0 / earlier-label path).
             // Branch over the resume loader, then close C_j, emit the loader
             // (resume path only), and close B_j. From inside C_j, `br 1`
@@ -4702,10 +4712,11 @@ fn build_function(
 
 /// A peeled loop — real work (the unrolled first iteration = preamble) precedes
 /// the loop-header LABEL — whether it carries one LABEL or several. `loop` is
-/// emitted at the LAST label, so `build_function` wraps the trace in the
-/// resume-at-LABEL entry `br_table` (keyed on the frame dispatch-key slot,
-/// key = label ordinal + 1) and a loop-closing bridge re-enters at ANY of the
-/// loop's labels, in-module. `build_function` keys its wrapper on this
+/// emitted at the JUMP's target label, so `build_function` wraps the trace in
+/// the resume-at-LABEL entry `br_table` (keyed on the frame dispatch-key slot,
+/// key = label ordinal + 1) and a loop-closing bridge re-enters at any of the
+/// loop's labels up to and including the header, in-module
+/// (`resumable_label_count`). `build_function` keys its wrapper on this
 /// predicate; `compile_loop` records it on `CompiledWasmLoop` as
 /// `has_preamble`. `compile_bridge` accepts a loop-closing bridge only when
 /// its JUMP's descr identifies one of the source loop's OWN labels
@@ -4714,16 +4725,25 @@ pub fn is_resumable_peeled(ops: &[Op]) -> bool {
     let Some(loop_label) = find_loop_label_index(ops) else {
         return false;
     };
-    // The current entry br_table closes every label-loader block before it
-    // opens the wasm `loop`, so it supports only the shape whose actual JUMP
-    // target is the last LABEL. Other multi-label shapes still compile as a
-    // normal local loop but do not advertise in-module label re-entry.
-    if ops.iter().rposition(|op| op.opcode == OpCode::Label) != Some(loop_label) {
-        return false;
-    }
     ops[..loop_label]
         .iter()
         .any(|op| op.opcode != OpCode::Label)
+}
+
+/// How many of a peeled loop's LABELs the entry `br_table` can re-enter at:
+/// those at or before the loop header. Each resume point costs a
+/// (past_loader, loader) block pair opened before the wasm `loop`, so a pair
+/// belonging to a label INSIDE the loop body would have to close inside the
+/// loop — which structured control flow forbids. Such a label stays an in-body
+/// marker: it emits nothing and is not published as a target.
+pub fn resumable_label_count(ops: &[Op]) -> usize {
+    let Some(loop_label) = find_loop_label_index(ops) else {
+        return 0;
+    };
+    ops[..=loop_label]
+        .iter()
+        .filter(|op| op.opcode == OpCode::Label)
+        .count()
 }
 
 /// The single-label subset of `is_resumable_peeled`: exactly one LABEL.

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -2165,8 +2165,12 @@ impl majit_backend::Backend for WasmBackend {
         // the label's arity equals that (the standard loop shape, whose
         // first label's args ARE the inputargs).
         if has_preamble {
-            let last = label_descrs.len().saturating_sub(1);
-            for (j, &id) in label_descrs.iter().enumerate() {
+            // Only labels at or before the loop header have a resume loader
+            // (`codegen::resumable_label_count`); the header is the last of
+            // them, and a bridge landing there re-runs no advancing segment.
+            let resumable = codegen::resumable_label_count(ops);
+            let header = resumable.saturating_sub(1);
+            for (j, &id) in label_descrs.iter().enumerate().take(resumable) {
                 if id == 0 {
                     continue;
                 }
@@ -2179,7 +2183,7 @@ impl majit_backend::Backend for WasmBackend {
                         num_args: label_num_args[j],
                         resume_safe: label_resume_info[j].0,
                         requires_own_frame: label_resume_info[j].1,
-                        is_last_label: j == last,
+                        is_last_label: j == header,
                         frame,
                     },
                 );

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -1345,12 +1345,14 @@ fn normalize_ops_for_codegen(inputargs: &[InputArg], ops: &[OpRc]) -> Vec<Op> {
 
 /// Report why a trace cannot be compiled by the wasm backend, or `None` if it
 /// can. Declined traces fall back to the interpreter (correct, unaccelerated)
-/// instead of producing an invalid trace module. `is_loop` is true for
-/// `compile_loop`, false for `compile_bridge`. `allow_ca` (set by
-/// `compile_bridge` when every CALL_ASSEMBLER target is admitted) lifts the
-/// CALL_ASSEMBLER decline so the CA arm (guest→guest `call_indirect`) lowers
-/// it instead.
-fn wasm_unsupported_trace_reason(ops: &[Op], is_loop: bool, allow_ca: bool) -> Option<String> {
+/// instead of producing an invalid trace module. `allow_ca` (set when every
+/// CALL_ASSEMBLER target is admitted) lifts the CALL_ASSEMBLER decline so the
+/// CA arm (guest→guest `call_indirect`) lowers it instead.
+///
+/// A JUMP with no local LABEL — the cross-loop terminal jump — is not judged
+/// here: it is lowered to `return_call_indirect(external_jump_slot)` and both
+/// callers resolve that slot through [`resolve_cross_loop_jump_target`].
+fn wasm_unsupported_trace_reason(ops: &[Op], allow_ca: bool) -> Option<String> {
     for op in ops {
         if op.opcode.is_call_assembler() && !allow_ca {
             // CALL_ASSEMBLER inlines a loop-bearing callee by jumping into another
@@ -1363,26 +1365,84 @@ fn wasm_unsupported_trace_reason(ops: &[Op], is_loop: bool, allow_ca: bool) -> O
             ));
         }
     }
-    if is_loop {
-        // A JUMP with no local LABEL is lowered by codegen (`Jump if !has_loop`)
-        // to `return_call_indirect(external_jump_slot)`. Only `compile_bridge`
-        // knows the re-entry target (the source loop's table slot) and plumbs it
-        // through `external_jump_slot`; `compile_loop` passes 0, so such a trace
-        // here is a jump-to-existing-trace (terminal JUMP into a *different*
-        // loop) that would tail-call table slot 0 — the wrong function. Decline
-        // it; the interpreter performs the cross-loop jump correctly.
-        let has_label = ops.iter().any(|op| op.opcode == majit_ir::OpCode::Label);
-        let has_jump = ops.iter().any(|op| op.opcode == majit_ir::OpCode::Jump);
-        if has_jump && !has_label {
-            return Some(
-                "wasm backend: loop trace with cross-loop terminal JUMP (no local LABEL)".into(),
-            );
-        }
-    }
-    // A JUMP with no local LABEL inside a bridge (a loop-closing bridge) is
-    // lowered to a `return_call_indirect` into the source loop's table slot — a
-    // wasm tail call — so it is accepted.
     None
+}
+
+/// Whether a trace's terminal is a cross-loop `JUMP`: a JUMP with no local
+/// LABEL to close back onto, so codegen lowers it to a tail call into another
+/// module rather than a `br`.
+fn has_cross_loop_terminal_jump(ops: &[Op]) -> bool {
+    let has_label = ops.iter().any(|op| op.opcode == majit_ir::OpCode::Label);
+    let has_jump = ops.iter().any(|op| op.opcode == majit_ir::OpCode::Jump);
+    has_jump && !has_label
+}
+
+/// Resolve the re-entry target of a cross-loop terminal JUMP BY DESCR IDENTITY
+/// through the `LABEL_TARGETS` registry — the JUMP and its target LABEL share
+/// the loop-target descr Arc, and every compiled loop published its enterable
+/// labels there. The stamped `label_block_id` ordinal is NOT identity: a
+/// retraced loop has several sibling specializations whose start labels all
+/// carry ordinal 0, and a trace legitimately closes into a SIBLING
+/// (jump-to-existing-trace) — the registry resolves the owning module's table
+/// slot and resume key, so the tail call chains into the RIGHT loop.
+///
+/// Decline (`None`, after tallying which question answered) when the target is
+/// unpublished (descr stripped, or its loop declined/was dropped), the JUMP
+/// arity differs from the label's arg count (the resume loader reads exactly
+/// that many positional frame slots), or the label's args are not the complete
+/// live set of the target trace's remainder (`resume_safe` — resuming there
+/// would read a null local).
+///
+/// `source` is the frame a chained bridge already runs on, with the table slot
+/// of the loop that owns it. `compile_bridge` supplies it: that bridge shares
+/// the source token's frozen layout, so the target's geometry must agree with
+/// it exactly, and a target whose backend capture slots were filled by its own
+/// fall-through (`requires_own_frame`) is resumable only when it IS that source
+/// loop. `compile_loop` passes `None` for an entry bridge, which owns its
+/// module and its frame: it has no source slot, so `requires_own_frame` always
+/// declines, and instead of matching a geometry it ADOPTS the target's (the
+/// caller checks its own slots fit, then compiles against `t.frame`).
+fn resolve_cross_loop_jump_target(
+    ops: &[Op],
+    source: Option<(u32, codegen::FrameGeometry)>,
+) -> Option<LabelTarget> {
+    let closing_jump = ops
+        .iter()
+        .rev()
+        .find(|op| op.opcode == majit_ir::OpCode::Jump);
+    let target_descr_id = closing_jump
+        .and_then(|j| j.getdescr())
+        .map(|d| std::sync::Arc::as_ptr(&d) as *const () as usize)
+        .filter(|id| *id != 0);
+    let target = target_descr_id.and_then(label_target);
+    let arity = closing_jump.map_or(0, |j| j.getarglist().len());
+    match target {
+        // Descr stripped, or the target label was never published.
+        None => {
+            diag_bump(8);
+            diag_bump(if target_descr_id.is_none() { 17 } else { 18 });
+            None
+        }
+        Some(t) if arity != t.num_args => {
+            diag_bump(10); // arity mismatch
+            None
+        }
+        Some(t) if !t.resume_safe => {
+            diag_bump(9); // label args not the full live set
+            None
+        }
+        Some(t) if t.requires_own_frame && Some(t.func_handle) != source.map(|(slot, _)| slot) => {
+            // The target's high capture homes were populated by its own
+            // fall-through path, not by this sibling source loop.
+            diag_bump(9);
+            None
+        }
+        Some(t) if source.is_some_and(|(_, frame)| t.frame != frame) => {
+            diag_bump(4); // target uses different frozen frame offsets
+            None
+        }
+        Some(t) => Some(t),
+    }
 }
 
 /// Resolve every distinct compiled target used by CALL_ASSEMBLER ops in this
@@ -1827,11 +1887,49 @@ impl majit_backend::Backend for WasmBackend {
         let raw_frame_value_slots = codegen::frame_value_slots(inputargs, ops);
         let raw_num_ref_homes = codegen::count_ref_homes(inputargs, ops);
         let label_ref_slots = codegen::label_ref_capture_slots(inputargs, ops);
-        let frame = codegen::FrameGeometry::compact(
-            raw_frame_value_slots.max(FROZEN_CHAIN_VALUE_SLOTS),
-            raw_num_ref_homes.max(FROZEN_CHAIN_REF_HOMES) + label_ref_slots,
-            label_ref_slots,
-        );
+        // An entry bridge (`compile.py:1006-1022 ResumeFromInterpDescr`) is sent
+        // to the backend through `compile_loop` like any loop, but it is not one:
+        // it has no LABEL of its own and ends in a JUMP into an
+        // already-compiled loop. Resolve that loop the same way `compile_bridge`
+        // resolves a loop-closing bridge's target, and ADOPT its frozen
+        // geometry — `LabelTarget::frame` exists because a tail call reuses the
+        // caller's frame, so the two layouts must agree offset for offset, not
+        // merely in size. Compiling against the target's geometry makes them
+        // agree by construction.
+        let entry_bridge_target = if has_cross_loop_terminal_jump(ops) {
+            let Some(target) = resolve_cross_loop_jump_target(ops, None) else {
+                diag_bump(2); // declined: JUMP target not chainable
+                return Err(BackendError::Unsupported(
+                    "wasm backend: cross-loop terminal JUMP target is not a \
+                     chainable published label"
+                        .into(),
+                ));
+            };
+            // Same fit test a chained bridge gets against its source frame: the
+            // adopted layout must hold everything this trace spills.
+            if raw_frame_value_slots > target.frame.value_slots
+                || raw_num_ref_homes > target.frame.ordinary_home_slots()
+            {
+                diag_bump(4);
+                return Err(BackendError::Unsupported(format!(
+                    "wasm backend: entry bridge needs values={raw_frame_value_slots}, \
+                     homes={raw_num_ref_homes}; target frozen layout has values={}, homes={}",
+                    target.frame.value_slots,
+                    target.frame.ordinary_home_slots(),
+                )));
+            }
+            Some(target)
+        } else {
+            None
+        };
+        let frame = match entry_bridge_target {
+            Some(target) => target.frame,
+            None => codegen::FrameGeometry::compact(
+                raw_frame_value_slots.max(FROZEN_CHAIN_VALUE_SLOTS),
+                raw_num_ref_homes.max(FROZEN_CHAIN_REF_HOMES) + label_ref_slots,
+                label_ref_slots,
+            ),
+        };
         let input_types: Vec<majit_ir::Type> = inputargs.iter().map(|ia| ia.tp).collect();
         // Count with CA direct-lowering enabled.  This is the safety census
         // for a pending self target: no CompiledWasmLoop exists yet to inspect.
@@ -1857,15 +1955,11 @@ impl majit_backend::Backend for WasmBackend {
         // Decline traces the wasm backend cannot compile correctly, so the
         // metainterp falls back to the interpreter (correct, if unaccelerated)
         // rather than installing a structurally-invalid trace module:
-        //   * CALL_ASSEMBLER inlines a loop-bearing callee by jumping into
-        //     another trace's compiled token. The wasm backend has no
-        //     inter-module trace chaining (each trace is its own module), so it
-        //     cannot execute the target — declining is the #62 loop-callee gap.
-        //   * A JUMP with no LABEL targets a *different* existing loop
-        //     (jump-to-existing-trace); compile_loop cannot supply the target
-        //     table slot, so codegen would tail-call slot 0 — the wrong
-        //     function. Declined here (is_loop=true).
-        if let Some(reason) = wasm_unsupported_trace_reason(ops, true, allow_ca) {
+        // CALL_ASSEMBLER inlines a loop-bearing callee by jumping into another
+        // trace's compiled token. The wasm backend has no inter-module trace
+        // chaining (each trace is its own module), so it cannot execute the
+        // target — declining is the #62 loop-callee gap.
+        if let Some(reason) = wasm_unsupported_trace_reason(ops, allow_ca) {
             return Err(BackendError::Unsupported(reason));
         }
         if allow_ca {
@@ -1901,8 +1995,11 @@ impl majit_backend::Backend for WasmBackend {
                 Arc::as_ptr(&token.invalidated) as usize as u32,
                 gc_table_base,
                 fail_index_base,
-                0, // external_jump_slot: a loop's JUMP is a local back-edge `br`
-                0, // external_jump_key: unused without an external JUMP
+                // A real loop's JUMP is a local back-edge `br` and needs
+                // neither; an entry bridge tail-calls the target loop's table
+                // slot and resumes at the label `external_jump_key` selects.
+                entry_bridge_target.map_or(0, |t| t.func_handle),
+                entry_bridge_target.map_or(0, |t| t.key),
                 frame,
                 ca_targets.as_ref().map_or_else(
                     || codegen::CaParams {
@@ -1946,6 +2043,15 @@ impl majit_backend::Backend for WasmBackend {
         if let Some(table) = gc_table {
             Self::register_gc_table(token, table);
         }
+
+        // `runner.rs:2269` / `compiler.rs:15613` parity: the entry path reads
+        // this to size the live-value list it hands `execute_token`
+        // (`jitdriver.rs extend_compiled_live_values` →
+        // `warmstate.py:188 cell.loop_token`). Leaving it unset makes a trace
+        // whose inputargs outnumber the portal's live values be entered with
+        // the short list, so every frame slot past it reads as a zero the
+        // prologue then loads as a null Ref.
+        token.set_inputarg_types(inputargs.iter().map(|ia| ia.tp).collect());
 
         let max_output_slots = guard_exits
             .iter()
@@ -2370,7 +2476,7 @@ impl majit_backend::Backend for WasmBackend {
             diag_bump(15);
             allow_ca = false;
         }
-        if let Some(reason) = wasm_unsupported_trace_reason(ops, false, allow_ca) {
+        if let Some(reason) = wasm_unsupported_trace_reason(ops, allow_ca) {
             diag_bump(1); // declined: CALL_ASSEMBLER
             return Err(BackendError::Unsupported(
                 ca_trampoline_decline.unwrap_or(reason.as_str()).to_string(),
@@ -2430,81 +2536,25 @@ impl majit_backend::Backend for WasmBackend {
         // `declined_bridge_guards` stops the metainterp re-tracing it.
         // Non-peeled loops (entry == LABEL) re-enter correctly and keep
         // chaining.
-        let bridge_is_loop_closing = {
-            let has_label = ops.iter().any(|op| op.opcode == majit_ir::OpCode::Label);
-            let has_jump = ops.iter().any(|op| op.opcode == majit_ir::OpCode::Jump);
-            has_jump && !has_label
-        };
+        let bridge_is_loop_closing = has_cross_loop_terminal_jump(ops);
         if bridge_is_loop_closing {
             diag_bump(6); // loop-closing shape
         }
         if source_has_preamble {
             diag_bump(7); // source loop has preamble
         }
-        // Resolve the terminal JUMP's target label BY DESCR IDENTITY through
-        // the `LABEL_TARGETS` registry — the JUMP and its target LABEL share
-        // the loop-target descr Arc, and every compiled loop published its
-        // enterable labels there. The stamped `label_block_id` ordinal is NOT
-        // identity: a retraced loop has several sibling specializations whose
-        // start labels all carry ordinal 0, and a bridge legitimately closes
-        // into a SIBLING (jump-to-existing-trace) — the registry resolves the
-        // owning module's table slot and resume key, so the tail call chains
-        // into the RIGHT loop, own or sibling. Decline when the target is
-        // unpublished (descr stripped, or its loop declined/was dropped), the
-        // JUMP arity differs from the label's arg count (the resume loader
-        // reads exactly that many positional frame slots), the label's args
-        // are not the complete live set of the target trace's remainder
-        // (`resume_safe` — resuming there would read a null local), or the
-        // target loop's frozen frame geometry differs from the source frame.
-        // A declined guard falls back to blackhole resume and
-        // `declined_bridge_guards` stops the metainterp re-tracing it.
         let mut external_jump_key: u32 = 0;
         let mut external_jump_slot: u32 = source_func_handle;
         let mut resumes_at_loop_header = false;
         if bridge_is_loop_closing {
-            let closing_jump = ops
-                .iter()
-                .rev()
-                .find(|op| op.opcode == majit_ir::OpCode::Jump);
-            let target_descr_id = closing_jump
-                .and_then(|j| j.getdescr())
-                .map(|d| std::sync::Arc::as_ptr(&d) as *const () as usize)
-                .filter(|id| *id != 0);
-            let target = target_descr_id.and_then(label_target);
-            let arity = closing_jump.map_or(0, |j| j.getarglist().len());
-            let accepted_target = match target {
-                // Descr stripped, or the target label was never published.
-                None => {
-                    diag_bump(8);
-                    diag_bump(if target_descr_id.is_none() { 17 } else { 18 });
-                    false
-                }
-                Some(t) if arity != t.num_args => {
-                    diag_bump(10); // arity mismatch
-                    false
-                }
-                Some(t) if !t.resume_safe => {
-                    diag_bump(9); // label args not the full live set
-                    false
-                }
-                Some(t) if t.requires_own_frame && t.func_handle != source_func_handle => {
-                    // The target's high capture homes were populated by its
-                    // own fall-through path, not by this sibling source loop.
-                    diag_bump(9);
-                    false
-                }
-                Some(t) if t.frame != source_frame => {
-                    diag_bump(4); // target uses different frozen frame offsets
-                    false
-                }
-                Some(t) => {
-                    external_jump_key = t.key;
-                    external_jump_slot = t.func_handle;
-                    resumes_at_loop_header = t.is_last_label;
-                    true
-                }
-            };
-            if !accepted_target {
+            let target =
+                resolve_cross_loop_jump_target(ops, Some((source_func_handle, source_frame)));
+            if let Some(t) = target {
+                external_jump_key = t.key;
+                external_jump_slot = t.func_handle;
+                resumes_at_loop_header = t.is_last_label;
+            }
+            if target.is_none() {
                 diag_bump(2); // declined: JUMP target not chainable
                 return Err(BackendError::Unsupported(
                     "wasm backend: loop-closing bridge JUMP target is not a \

--- a/majit/majit-backend-wasm/tests/codegen_test.rs
+++ b/majit/majit-backend-wasm/tests/codegen_test.rs
@@ -1145,9 +1145,11 @@ fn test_non_last_label_backedge_validates() {
         jump,
     ];
 
-    // The key-dispatch wrapper intentionally remains restricted to a last-label
-    // target, but ordinary local lowering must accept this shape.
-    assert!(!codegen::is_resumable_peeled(&ops));
+    // The wide entry label precedes the header, so it is a resume point; the
+    // narrow one sits inside the `loop` and gets no block pair, which is what
+    // keeps the wrapper's structured control flow well-formed here.
+    assert!(codegen::is_resumable_peeled(&ops));
+    assert_eq!(codegen::resumable_label_count(&ops), 1);
     let (bytes, _) = build_module_default(&inputargs, &ops, &constants);
     validate_wasm(&bytes);
 }

--- a/majit/majit-metainterp/src/lib.rs
+++ b/majit/majit-metainterp/src/lib.rs
@@ -609,17 +609,26 @@ pub fn register_stack_almost_full_hook(f: fn() -> bool) {
 /// bridge did not compile, 32 = `compile_trace` had neither a guard origin nor
 /// entry-bridge data to close against, 33 = `compile_trace` was called with no
 /// tracing session.
-pub static MC_DIAG: [std::sync::atomic::AtomicU64; 34] = {
+///
+/// 34-39 split slot 31 by which of `compile_entry_bridge`'s exits answered:
+/// 34 = the target green key has no compiled loop, 35 = its JitCellToken is
+/// dead, 36 = `optimize_bridge` raised `InvalidLoop`, 37 = the optimizer asked
+/// for a retrace instead, 38 = the backend's own `compile_loop` panicked,
+/// 39 = the backend returned `Err` from it. Slot 31 stays their total. The six
+/// are reachable for different reasons and only
+/// the split says which; the guest has no stderr, so `MAJIT_LOG`'s per-exit
+/// lines never reach a wasm run and this is the only channel that does.
+pub static MC_DIAG: [std::sync::atomic::AtomicU64; 40] = {
     const Z: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
     [
         Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z,
-        Z, Z, Z, Z,
+        Z, Z, Z, Z, Z, Z, Z, Z, Z, Z,
     ]
 };
 
 /// Short label per [`MC_DIAG`] slot, in index order, so a tally cannot be added
 /// without naming it. Readers join these with the counter values.
-pub const MC_DIAG_LABELS: [&str; 34] = [
+pub const MC_DIAG_LABELS: [&str; 40] = [
     "mc_entered",
     "decl_shortcircuit",
     "descr0_skip",
@@ -654,6 +663,12 @@ pub const MC_DIAG_LABELS: [&str; 34] = [
     "ct_entry_bridge_failed",
     "ct_no_entry_data",
     "ct_not_tracing",
+    "ceb_no_loop",
+    "ceb_dead_token",
+    "ceb_invalidloop",
+    "ceb_retrace_req",
+    "ceb_backend_panic",
+    "ceb_backend_err",
 ];
 
 /// Render every [`MC_DIAG`] tally as space-separated `label=count` pairs.

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -10532,6 +10532,7 @@ impl<M: Clone> MetaInterp<M> {
         snapshot_frame_pcs: SnapshotFramePcs,
     ) -> bool {
         if !self.compiled_loops.contains_key(&green_key) {
+            crate::mc_diag_bump(34); // compile_entry_bridge: target has no compiled loop
             return false;
         }
 
@@ -10541,6 +10542,7 @@ impl<M: Clone> MetaInterp<M> {
         let (retraced_count, loop_num_inputs, parent_next_global_opref) = {
             let compiled = self.compiled_loops.get(&green_key).unwrap();
             let Some(tok) = compiled.live_token() else {
+                crate::mc_diag_bump(35); // compile_entry_bridge: target token dead
                 return false;
             };
             (
@@ -10672,11 +10674,12 @@ impl<M: Clone> MetaInterp<M> {
             // guard proven to always fail, or a speculative heap access proven
             // ill-typed (now surfaced as a deferred `InvalidLoop` signal rather
             // than a panic), abandons the function-entry bridge.
-            Err(_invalid_loop) => {
+            Err(invalid_loop) => {
+                crate::mc_diag_bump(36); // compile_entry_bridge: optimize_bridge InvalidLoop
                 if crate::majit_log_enabled() {
                     eprintln!(
-                        "[jit] compile_entry_bridge: InvalidLoop target={} original={}",
-                        green_key, original_green_key
+                        "[jit] compile_entry_bridge: {invalid_loop} target={green_key} \
+                         original={original_green_key}",
                     );
                 }
                 return false;
@@ -10694,6 +10697,7 @@ impl<M: Clone> MetaInterp<M> {
             {
                 tok.set_retraced_count(tok.get_retraced_count() + 1);
             }
+            crate::mc_diag_bump(37); // compile_entry_bridge: optimizer asked for a retrace
             if let Some(es) = optimizer.exported_loop_state.take() {
                 let renamed_inputargs: Vec<InputArg> = es
                     .renamed_inputargs
@@ -10776,6 +10780,7 @@ impl<M: Clone> MetaInterp<M> {
         let compile_result = match compile_result {
             Ok(r) => r,
             Err(payload) => {
+                crate::mc_diag_bump(38); // compile_entry_bridge: backend compile_loop panicked
                 self.note_jit_panic_or_reraise(payload, "compile_entry_bridge backend", green_key);
                 return false;
             }
@@ -10904,7 +10909,10 @@ impl<M: Clone> MetaInterp<M> {
                 }
                 true
             }
-            Err(_) => false,
+            Err(_) => {
+                crate::mc_diag_bump(39); // compile_entry_bridge: backend refused the loop
+                false
+            }
         }
     }
 

--- a/pyre/bench/fannkuch.wasm.jitstats
+++ b/pyre/bench/fannkuch.wasm.jitstats
@@ -2,4 +2,4 @@ descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
 internal_compile_panics=0
-loops_aborted=2
+loops_aborted=0

--- a/pyre/bench/synth/blackhole_inlined_callee_local_after_escape.wasm.jitstats
+++ b/pyre/bench/synth/blackhole_inlined_callee_local_after_escape.wasm.jitstats
@@ -2,4 +2,4 @@ descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
 internal_compile_panics=0
-loops_aborted=10
+loops_aborted=5

--- a/pyre/bench/synth/closure_per_call.wasm.jitstats
+++ b/pyre/bench/synth/closure_per_call.wasm.jitstats
@@ -2,4 +2,4 @@ descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
 internal_compile_panics=0
-loops_aborted=1
+loops_aborted=0

--- a/pyre/bench/synth/exc_bridge_entry_guard_not_removed.wasm.jitstats
+++ b/pyre/bench/synth/exc_bridge_entry_guard_not_removed.wasm.jitstats
@@ -2,4 +2,4 @@ descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
 internal_compile_panics=0
-loops_aborted=4
+loops_aborted=0

--- a/pyre/bench/synth/exc_caught_in_callee_return_loop.wasm.jitstats
+++ b/pyre/bench/synth/exc_caught_in_callee_return_loop.wasm.jitstats
@@ -2,4 +2,4 @@ descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
 internal_compile_panics=0
-loops_aborted=2
+loops_aborted=1

--- a/pyre/bench/synth/exc_mixed_classes_bridge_flavor.wasm.jitstats
+++ b/pyre/bench/synth/exc_mixed_classes_bridge_flavor.wasm.jitstats
@@ -2,4 +2,4 @@ descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
 internal_compile_panics=0
-loops_aborted=1
+loops_aborted=0

--- a/pyre/bench/synth/exception_catching_frame_tb_node.wasm.jitstats
+++ b/pyre/bench/synth/exception_catching_frame_tb_node.wasm.jitstats
@@ -2,4 +2,4 @@ descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
 internal_compile_panics=0
-loops_aborted=2
+loops_aborted=0

--- a/pyre/bench/synth/exception_inline_callee_tb_frames.wasm.jitstats
+++ b/pyre/bench/synth/exception_inline_callee_tb_frames.wasm.jitstats
@@ -2,4 +2,4 @@ descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
 internal_compile_panics=0
-loops_aborted=7
+loops_aborted=0

--- a/pyre/bench/synth/exception_loop_warmup.wasm.jitstats
+++ b/pyre/bench/synth/exception_loop_warmup.wasm.jitstats
@@ -2,4 +2,4 @@ descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
 internal_compile_panics=0
-loops_aborted=9
+loops_aborted=0

--- a/pyre/bench/synth/exception_oserror_fields.wasm.jitstats
+++ b/pyre/bench/synth/exception_oserror_fields.wasm.jitstats
@@ -2,4 +2,4 @@ descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
 internal_compile_panics=0
-loops_aborted=1
+loops_aborted=0

--- a/pyre/bench/synth/exception_reentry_guard_finally_residual.wasm.jitstats
+++ b/pyre/bench/synth/exception_reentry_guard_finally_residual.wasm.jitstats
@@ -2,4 +2,4 @@ descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
 internal_compile_panics=0
-loops_aborted=6
+loops_aborted=0

--- a/pyre/bench/synth/exception_reraise_tb_depth_hot.wasm.jitstats
+++ b/pyre/bench/synth/exception_reraise_tb_depth_hot.wasm.jitstats
@@ -2,4 +2,4 @@ descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
 internal_compile_panics=0
-loops_aborted=44
+loops_aborted=0

--- a/pyre/bench/synth/exception_traceback_frame_lineno.wasm.jitstats
+++ b/pyre/bench/synth/exception_traceback_frame_lineno.wasm.jitstats
@@ -2,4 +2,4 @@ descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
 internal_compile_panics=0
-loops_aborted=4
+loops_aborted=0

--- a/pyre/bench/synth/exception_traceback_lineno_chain.wasm.jitstats
+++ b/pyre/bench/synth/exception_traceback_lineno_chain.wasm.jitstats
@@ -2,4 +2,4 @@ descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
 internal_compile_panics=0
-loops_aborted=4
+loops_aborted=0

--- a/pyre/bench/synth/exception_traceback_loop_forms.wasm.jitstats
+++ b/pyre/bench/synth/exception_traceback_loop_forms.wasm.jitstats
@@ -2,4 +2,4 @@ descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
 internal_compile_panics=0
-loops_aborted=20
+loops_aborted=0

--- a/pyre/bench/synth/exception_try_call_inlined_callee_raise.wasm.jitstats
+++ b/pyre/bench/synth/exception_try_call_inlined_callee_raise.wasm.jitstats
@@ -2,4 +2,4 @@ descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
 internal_compile_panics=0
-loops_aborted=2
+loops_aborted=1

--- a/pyre/bench/synth/foriter_call_resume_drops_iteration.wasm.jitstats
+++ b/pyre/bench/synth/foriter_call_resume_drops_iteration.wasm.jitstats
@@ -2,4 +2,4 @@ descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
 internal_compile_panics=0
-loops_aborted=7
+loops_aborted=4

--- a/pyre/bench/synth/gc_bug_bridge_flavor_traceback_names.wasm.jitstats
+++ b/pyre/bench/synth/gc_bug_bridge_flavor_traceback_names.wasm.jitstats
@@ -2,4 +2,4 @@ descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
 internal_compile_panics=0
-loops_aborted=26
+loops_aborted=2

--- a/pyre/bench/synth/gc_deque_backing_list.wasm.jitstats
+++ b/pyre/bench/synth/gc_deque_backing_list.wasm.jitstats
@@ -2,4 +2,4 @@ descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
 internal_compile_panics=0
-loops_aborted=14
+loops_aborted=0

--- a/pyre/bench/synth/gc_iterator_source_drop.wasm.jitstats
+++ b/pyre/bench/synth/gc_iterator_source_drop.wasm.jitstats
@@ -2,4 +2,4 @@ descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
 internal_compile_panics=0
-loops_aborted=7
+loops_aborted=0

--- a/pyre/bench/synth/loop_callee_return.wasm.jitstats
+++ b/pyre/bench/synth/loop_callee_return.wasm.jitstats
@@ -2,4 +2,4 @@ descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
 internal_compile_panics=0
-loops_aborted=1
+loops_aborted=0

--- a/pyre/bench/synth/nested_callee_chain_mutation_abort.wasm.jitstats
+++ b/pyre/bench/synth/nested_callee_chain_mutation_abort.wasm.jitstats
@@ -2,4 +2,4 @@ descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
 internal_compile_panics=0
-loops_aborted=1
+loops_aborted=0

--- a/pyre/bench/synth/pickle_terminal_raise_resume.wasm.jitstats
+++ b/pyre/bench/synth/pickle_terminal_raise_resume.wasm.jitstats
@@ -2,4 +2,4 @@ descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
 internal_compile_panics=0
-loops_aborted=54
+loops_aborted=37

--- a/pyre/bench/synth/str_search_index_bounds.wasm.jitstats
+++ b/pyre/bench/synth/str_search_index_bounds.wasm.jitstats
@@ -2,4 +2,4 @@ descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
 internal_compile_panics=0
-loops_aborted=35
+loops_aborted=1

--- a/pyre/bench/synth/trace_too_long_inline_multiframe.wasm.jitstats
+++ b/pyre/bench/synth/trace_too_long_inline_multiframe.wasm.jitstats
@@ -2,4 +2,4 @@ descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
 internal_compile_panics=0
-loops_aborted=30
+loops_aborted=23

--- a/pyre/bench/synth/type_name_surrogate_reject.wasm.jitstats
+++ b/pyre/bench/synth/type_name_surrogate_reject.wasm.jitstats
@@ -2,4 +2,4 @@ descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
 internal_compile_panics=0
-loops_aborted=2
+loops_aborted=1

--- a/pyre/pyre-sandbox/src/seccomp.rs
+++ b/pyre/pyre-sandbox/src/seccomp.rs
@@ -22,6 +22,10 @@
 //! Over-listing a benign syscall here cannot widen the escape surface (every
 //! listed call is host-neutral); omitting one the runtime needs only
 //! over-restricts and kills the child — i.e. it fails in the safe direction.
+//! That reasoning is what keeps [`allowed_syscalls`] a plain list of numbers,
+//! and it is also why `prctl` is not on it: as a multiplexer it is host-neutral
+//! in only one of its options, so [`build_filter_program`] admits it on the
+//! option as well as the number.
 //!
 //! Because pyre has no genc backend, this is the *only* whole-program guarantee
 //! in the sandbox — the compile-time seam + clippy fence are selective, not a
@@ -46,9 +50,12 @@ const LD_ABS_W: u16 = BPF_LD | BPF_W | BPF_ABS; // load a 32-bit word at an abso
 const JEQ_K: u16 = BPF_JMP | BPF_JEQ | BPF_K; // jump-if-equal against an immediate
 const RET_K: u16 = BPF_RET | BPF_K; // return an immediate action
 
-// Byte offsets into `struct seccomp_data` (the BPF input): `nr` then `arch`.
+// Byte offsets into `struct seccomp_data` (the BPF input): `nr`, `arch`, then
+// the low half of `args[0]` (8-byte `instruction_pointer` sits between them, and
+// classic BPF loads 32 bits at a time — little-endian, so the low half is first).
 const SECCOMP_DATA_NR_OFFSET: u32 = 0;
 const SECCOMP_DATA_ARCH_OFFSET: u32 = 4;
+const SECCOMP_DATA_ARG0_LOW_OFFSET: u32 = 16;
 
 // AUDIT_ARCH_* (`linux/audit.h`) = EM_<arch> | __AUDIT_ARCH_64BIT | __AUDIT_ARCH_LE.
 #[cfg(target_arch = "x86_64")]
@@ -220,6 +227,54 @@ fn allowed_syscalls() -> Vec<u32> {
     nums.iter().map(|&n| n as u32).collect()
 }
 
+/// Assemble the classic-BPF allowlist: `syscalls` pass on their number alone,
+/// `prctl` passes only for `PR_SET_VMA`, everything else traps.
+///
+/// `prctl` is a multiplexer, so listing it by number would hand untrusted code
+/// every option at once — `PR_SET_SPECULATION_CTRL` can drop this process's
+/// Spectre mitigations, `PR_SET_DUMPABLE`/`PR_SET_PTRACER` open its memory to a
+/// sibling. Only the naming of one's own anonymous mapping is host-neutral, and
+/// mimalloc (the default global allocator) issues exactly that after each of its
+/// `mmap`s (`mimalloc/src/prim/unix/prim.c` `unix_mmap_prim`), so the first
+/// region it reserves past lockdown would otherwise trap. `option` is an `int`,
+/// so the kernel sees only the low 32 bits this checks.
+fn build_filter_program(syscalls: &[u32]) -> Vec<libc::sock_filter> {
+    let n = syscalls.len();
+    // Layout (indices): 0 load-arch, 1 arch-check, 2 arch-mismatch kill, 3
+    // load-nr, 4..4+n per-syscall allow checks, 4+n prctl check, 4+n+1 default
+    // trap, 4+n+2 load-arg0, 4+n+3 option check, 4+n+4 trap, 4+n+5 allow.
+    let allow_idx = n + 9;
+    // The per-syscall jumps are the longest and are encoded in a `u8`; a list
+    // that outgrew the range would truncate them into the middle of the program
+    // and silently allow the wrong calls.
+    assert!(
+        allow_idx <= 4 + usize::from(u8::MAX),
+        "allowlist of {n} outgrew the reach of a u8 BPF jump",
+    );
+    let mut prog: Vec<libc::sock_filter> = Vec::with_capacity(allow_idx + 1);
+    prog.push(stmt(LD_ABS_W, SECCOMP_DATA_ARCH_OFFSET));
+    // arch == AUDIT_ARCH -> skip the next (kill) instruction; else fall into it.
+    prog.push(jeq(AUDIT_ARCH, 1));
+    prog.push(stmt(RET_K, libc::SECCOMP_RET_KILL_PROCESS));
+    prog.push(stmt(LD_ABS_W, SECCOMP_DATA_NR_OFFSET));
+    for (i, &sc) in syscalls.iter().enumerate() {
+        // From the check at index 4+i, taking jt lands at 4+i+1+jt, and the
+        // ALLOW terminator is at n+9, so jt = n + 4 - i.
+        prog.push(jeq(sc, (n + 4 - i) as u8));
+    }
+    // prctl reaches the option check one instruction past the default trap.
+    prog.push(jeq(libc::SYS_prctl as u32, 1));
+    // Default deny: trap to the SIGSYS handler, which names the syscall and
+    // exits. (The arch-mismatch path above stays an unconditional kill.)
+    prog.push(stmt(RET_K, libc::SECCOMP_RET_TRAP));
+    prog.push(stmt(LD_ABS_W, SECCOMP_DATA_ARG0_LOW_OFFSET));
+    prog.push(jeq(libc::PR_SET_VMA as u32, 1));
+    prog.push(stmt(RET_K, libc::SECCOMP_RET_TRAP));
+    prog.push(stmt(RET_K, libc::SECCOMP_RET_ALLOW));
+    debug_assert_eq!(prog.len(), allow_idx + 1);
+    prog
+}
+
 /// Install the syscall allowlist on the current (single) thread/process. After
 /// it returns `Ok`, any syscall outside [`allowed_syscalls`] traps to the
 /// SIGSYS handler ([`report_blocked_syscall`]), which writes the blocked
@@ -254,25 +309,7 @@ pub fn install_runtime_filter() -> io::Result<()> {
         return Err(io::Error::last_os_error());
     }
 
-    let syscalls = allowed_syscalls();
-    let n = syscalls.len();
-    // Layout (indices): 0 load-arch, 1 arch-check, 2 arch-mismatch kill,
-    // 3 load-nr, 4..4+n per-syscall allow checks, 4+n default trap, 4+n+1 allow.
-    let mut prog: Vec<libc::sock_filter> = Vec::with_capacity(n + 6);
-    prog.push(stmt(LD_ABS_W, SECCOMP_DATA_ARCH_OFFSET));
-    // arch == AUDIT_ARCH -> skip the next (kill) instruction; else fall into it.
-    prog.push(jeq(AUDIT_ARCH, 1));
-    prog.push(stmt(RET_K, libc::SECCOMP_RET_KILL_PROCESS));
-    prog.push(stmt(LD_ABS_W, SECCOMP_DATA_NR_OFFSET));
-    for (i, &sc) in syscalls.iter().enumerate() {
-        // From the check at index 4+i, taking jt lands at 4+i+1+jt; the ALLOW
-        // terminator is at 4+n+1, so jt = n - i.
-        prog.push(jeq(sc, (n - i) as u8));
-    }
-    // Default deny: trap to the SIGSYS handler, which names the syscall and
-    // exits. (The arch-mismatch path above stays an unconditional kill.)
-    prog.push(stmt(RET_K, libc::SECCOMP_RET_TRAP));
-    prog.push(stmt(RET_K, libc::SECCOMP_RET_ALLOW));
+    let mut prog = build_filter_program(&allowed_syscalls());
 
     // A non-privileged process may only install a filter after NO_NEW_PRIVS, so
     // the filter can never be used to gain privileges via a set-uid exec.
@@ -294,4 +331,98 @@ pub fn install_runtime_filter() -> io::Result<()> {
         return Err(io::Error::last_os_error());
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Run the filter the way the kernel would: the subset of classic BPF
+    /// [`build_filter_program`] emits, over a synthetic `seccomp_data`. Asserting
+    /// on the returned action rather than on instruction indices is what makes
+    /// the jump offsets — the part that silently breaks when a rule is added —
+    /// actually covered.
+    fn run_filter(prog: &[libc::sock_filter], arch: u32, nr: u32, arg0: u64) -> u32 {
+        let mut data = [0u8; 24];
+        data[0..4].copy_from_slice(&nr.to_le_bytes());
+        data[4..8].copy_from_slice(&arch.to_le_bytes());
+        data[16..24].copy_from_slice(&arg0.to_le_bytes());
+
+        let mut pc = 0usize;
+        let mut acc = 0u32;
+        for _ in 0..prog.len() {
+            let ins = &prog[pc];
+            match ins.code {
+                LD_ABS_W => {
+                    let off = ins.k as usize;
+                    acc = u32::from_le_bytes(data[off..off + 4].try_into().unwrap());
+                    pc += 1;
+                }
+                JEQ_K => {
+                    pc += 1 + usize::from(if acc == ins.k { ins.jt } else { ins.jf });
+                }
+                RET_K => return ins.k,
+                other => panic!("unexpected opcode {other:#x} at {pc}"),
+            }
+        }
+        panic!("filter ran off the end without returning");
+    }
+
+    #[test]
+    fn filter_allows_listed_calls_and_traps_the_rest() {
+        let syscalls = allowed_syscalls();
+        let prog = build_filter_program(&syscalls);
+
+        // Every listed number reaches ALLOW — including the last one, whose jump
+        // is the longest and so the first to break on a layout change.
+        for &sc in &syscalls {
+            assert_eq!(
+                run_filter(&prog, AUDIT_ARCH, sc, 0),
+                libc::SECCOMP_RET_ALLOW,
+                "syscall {sc} should be allowed",
+            );
+        }
+        // An unlisted host-access call traps.
+        assert_eq!(
+            run_filter(&prog, AUDIT_ARCH, libc::SYS_openat as u32, 0),
+            libc::SECCOMP_RET_TRAP,
+        );
+        // A foreign syscall personality is killed outright, whatever the number.
+        assert_eq!(
+            run_filter(&prog, !AUDIT_ARCH, libc::SYS_read as u32, 0),
+            libc::SECCOMP_RET_KILL_PROCESS,
+        );
+    }
+
+    #[test]
+    fn filter_admits_prctl_only_for_vma_naming() {
+        let prog = build_filter_program(&allowed_syscalls());
+        let prctl = libc::SYS_prctl as u32;
+
+        // mimalloc's post-lockdown mapping tag.
+        assert_eq!(
+            run_filter(&prog, AUDIT_ARCH, prctl, libc::PR_SET_VMA as u64),
+            libc::SECCOMP_RET_ALLOW,
+        );
+        // The kernel truncates `option` to an `int`, so the high half is not
+        // ours to police — the low half still decides.
+        assert_eq!(
+            run_filter(&prog, AUDIT_ARCH, prctl, 0xdead_0000_5356_4d41),
+            libc::SECCOMP_RET_ALLOW,
+        );
+        // Every other option stays denied.
+        for option in [
+            libc::PR_SET_DUMPABLE,
+            libc::PR_SET_PTRACER,
+            libc::PR_SET_NAME,
+            libc::PR_SET_NO_NEW_PRIVS,
+            libc::PR_SET_SECCOMP,
+        ] {
+            assert_eq!(
+                run_filter(&prog, AUDIT_ARCH, prctl, option as u64),
+                libc::SECCOMP_RET_TRAP,
+                "prctl option {option} should be denied",
+            );
+        }
+    }
 }

--- a/pyre/pyre-wasm-runner/src/main.rs
+++ b/pyre/pyre-wasm-runner/src/main.rs
@@ -556,7 +556,11 @@ fn run(module_path: &PathBuf, source: &str, script: &Path) -> Result<i32> {
                 );
             }
         }
-        // must_compile / start_retrace gate tallies (diagnostic).
+        // must_compile / start_retrace gate tallies (diagnostic). Positional
+        // mirror of `majit_metainterp::MC_DIAG_LABELS`; the runner links no
+        // majit crate, so a new slot must be appended in both. Appending keeps
+        // the existing indices, which is the only edit that cannot silently
+        // rename every tally after it.
         if let Ok(mc) = instance.get_typed_func::<u32, u64>(&mut store, "pyre_jit_mc_diag") {
             let labels = [
                 "mc_entered",
@@ -593,6 +597,12 @@ fn run(module_path: &PathBuf, source: &str, script: &Path) -> Result<i32> {
                 "ct_entry_bridge_failed",
                 "ct_no_entry_data",
                 "ct_not_tracing",
+                "ceb_no_loop",
+                "ceb_dead_token",
+                "ceb_invalidloop",
+                "ceb_retrace_req",
+                "ceb_backend_panic",
+                "ceb_backend_err",
             ];
             let mut parts = Vec::new();
             for (i, lbl) in labels.iter().enumerate() {


### PR DESCRIPTION
Two wasm-backend defects that together kept the entry-bridge path from ever compiling, plus the diagnostic split that located them and a baseline re-record.

## 1. `compile_loop` never recorded the trace's inputarg types

`majit-backend-wasm`'s `Backend::compile_loop` was missing

```rust
token.set_inputarg_types(inputargs.iter().map(|ia| ia.tp).collect());
```

which both native backends do (`majit-backend-dynasm/src/runner.rs:2269`, `majit-backend-cranelift/src/compiler.rs:15613`).

`jitdriver.rs extend_compiled_live_values` sizes the live-value list handed to `execute_token` from that list. On wasm it read `0`, so the virtualizable extension was **always** skipped and a trace whose inputargs outnumber the portal's live values was entered with the short list: `execute_token` wrote only `args.len()` words at `FRAME_SLOT_BASE + k`, the module prologue loaded `inputargs.len()`, and every slot past the args read the zero-filled frame — a null Ref per Ref input, surfacing far away inside a blackhole resume. Upstream basis: `warmstate.py:188 cell.loop_token`.

This also closes a long-open wasm bug whose memo had concluded it was a metainterp vable-sync defect. Its 8-line repro (`len([j for j in range(3)])` in a hot loop) now prints `6000` instead of raising.

The same commit lifts `compile_loop`'s blanket decline of a terminal JUMP with no local LABEL: it now shares `has_cross_loop_terminal_jump` / `resolve_cross_loop_jump_target` with `compile_bridge`, resolves the entry bridge's target through `LABEL_TARGETS`, and adopts `LabelTarget::frame` after checking its own value slots and Ref homes fit. ⚠️The two halves must land together — the one-liner alone turns the comprehension repro from a wrong answer into a `blackhole::handler_raise` panic.

## 2. The peel predicate refused a prefix it could have kept

`is_resumable_peeled` returned false whenever the closing JUMP's target LABEL was not the trace's last one, so `build_function` emitted no resume dispatch and `compile_loop` published **no** `LABEL_TARGETS` entry for any of that loop's labels — every bridge naming one then declined as unpublished.

The underlying constraint is real but per-label: each label's `(past_loader, loader)` pair is opened before the wasm `loop`, so a pair belonging to a label *inside* the loop body would have to close inside the loop. That excludes the in-body labels, not the ones at or before the header. `resumable_label_count` names that prefix; `build_function`, `LabelResumeData::collect` and `compile_loop` all work over it, and the header — not the trace's last label — is what `is_last_label` now marks.

## Measured (wasm `loops_aborted`)

| bench | before | after | dynasm |
|---|---|---|---|
| `exception_reraise_tb_depth_hot` | 44 | **0** | 0 |
| `str_search_index_bounds` | 35 | **1** | 1 |
| `trace_too_long_inline_multiframe` | 30 | **23** | — |
| `gc_bug_bridge_flavor_traceback_names` | 26 | **2** | 1 |
| `exception_traceback_loop_forms` | 20 | **0** | 0 |
| `gc_deque_backing_list` | 14 | **0** | — |
| `blackhole_inlined_callee_local_after_escape` | 10 | **5** | — |
| `exception_loop_warmup` | 9 | **0** | — |
| `exception_inline_callee_tb_frames` / `gc_iterator_source_drop` / `foriter_call_resume_drops_iteration` | 7 | **0 / 0 / 4** | — |
| `pickle_terminal_raise_resume` | 54 | **37** | — |

26 fixtures in all, every one a reduction. Attribution comes from `check.py --snapshot-diff --backend wasm` run twice — once as-is, once with the backend change reverted and the wasm module rebuilt: `exception_traceback_loop_forms` is the only fixture the peel-prefix commit moves; the other 25 belong to the inputarg-types commit.

## Baseline re-record

`_jit_stats_regression_floor` treats `loops_aborted` as a badness field, so it fails only on a *rise* — every reduction above passed while leaving the recorded ceiling untouched (`exception_reraise_tb_depth_hot` was still free to go back from 0 to 44). The last commit re-records those 26 baselines. The one fixture whose number **rose** — `exception_args_virtual` `loops_aborted 0 -> 3`, a base-inherited red that reproduces on a build of this base with none of these commits — was deliberately restored from HEAD rather than recorded. On the current base it is back at its recorded value, so leaving it untouched is what keeps it green.

## Verification

- `cargo test -p majit-backend-wasm` 22/22, plus all three `--ignored` runtime integration tests, including `global_reassign_retraces_non_last_label_backedge_at_runtime` — an existing test for exactly the non-last-label shape, which runs it under wasmtime and compares stdout against dynasm.
- `check.py --backend wasm` on the current base (`b44c30bae3b`, #989): **366/366 all passed** — the 26 re-recorded baselines hold, and `exception_args_virtual` passes here too, which is the base-inherited failure resolving on the newer base.
- `check.py --backend dynasm,cranelift` unchanged (this is a wasm-only backend change).

The abort counts in the table were measured on the previous base (`c0891858087`); an earlier three-backend gate was invalidated mid-run by a concurrent rebase onto #989, and the re-run above covers wasm on the new base. CI on this PR is the authority for the other two backends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
