### PR TITLE
jit(wasm): export the Counters.ABORT_* split behind loops_aborted

### DIFF
--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -4884,6 +4884,14 @@ impl<S: JitState> JitDriver<S> {
         self.meta.get_stats()
     }
 
+    /// Read the `i`th reason-keyed abort tally, indexed as
+    /// [`crate::jitprof::ABORT_COUNTER_KINDS`]. Breaks a `loops_aborted`
+    /// total down by `Counters.ABORT_*` for a caller that cannot reach the
+    /// profiler directly.
+    pub fn abort_diag(&self, i: usize) -> u64 {
+        self.meta.staticdata.profiler.abort_diag(i)
+    }
+
     /// Get direct access to the underlying MetaInterp.
     pub fn meta_interp(&self) -> &MetaInterp<S::Meta> {
         &self.meta

--- a/majit/majit-metainterp/src/jitprof.rs
+++ b/majit/majit-metainterp/src/jitprof.rs
@@ -165,6 +165,25 @@ struct TimingState {
 /// out-of-range id raises `IndexError` upstream, but that has only ever
 /// fired for hand-rolled counter ids that are not part of the
 /// canonical `Counters` enum — pyre never produces such ids).
+/// The reason-keyed `Counters.ABORT_*` tallies in a fixed order, with the
+/// short label each one carries in a `[jit-stats]` line.
+///
+/// `loops_aborted` is one number, and the split that explains it normally
+/// comes from `MAJIT_LOG`'s summary — a guest-side knob. The wasm32 guest has
+/// no environment, so on that backend the knob is inert and a `loops_aborted`
+/// regression arrives with no reason attached. Enumerating the tallies here
+/// lets the host read them by index and print the same breakdown.
+///
+/// Order is the contract with that host: append only, never reorder.
+pub const ABORT_COUNTER_KINDS: &[(i32, &str)] = &[
+    (counters::ABORT_TOO_LONG, "too_long"),
+    (counters::ABORT_BRIDGE, "bridge"),
+    (counters::ABORT_BAD_LOOP, "bad_loop"),
+    (counters::ABORT_ESCAPE, "escape"),
+    (counters::ABORT_FORCE_QUASIIMMUT, "force_quasiimmut"),
+    (counters::ABORT_SEGMENTED_TRACE, "segmented_trace"),
+];
+
 #[derive(Default, Debug)]
 pub struct JitProfiler {
     /// jit.py:1416 `Counters.TRACING` — RPython tracks this as wall-clock
@@ -511,6 +530,17 @@ impl JitProfiler {
         }
         self.field_for_kind(kind)
             .map(|field| field.load(Ordering::Relaxed))
+    }
+
+    /// Read the `i`th [`ABORT_COUNTER_KINDS`] tally.  Out of range reads 0,
+    /// so a reader holding a longer list than the profiler it queries — the
+    /// wasm host, which knows the labels but reaches the counters only by
+    /// index across the module boundary — degrades instead of trapping.
+    pub fn abort_diag(&self, i: usize) -> u64 {
+        ABORT_COUNTER_KINDS
+            .get(i)
+            .and_then(|&(kind, _)| self.get_counter(kind))
+            .unwrap_or(0) as u64
     }
 
     /// `cpu.tracker.total_freed_loops += 1` parity.  Fired from the

--- a/pyre/pyre-wasm-runner/src/main.rs
+++ b/pyre/pyre-wasm-runner/src/main.rs
@@ -470,6 +470,29 @@ fn run(module_path: &PathBuf, source: &str, script: &Path) -> Result<i32> {
                 eprintln!("[jit-stats] heap_buckets {}", parts.join(" "));
             }
         }
+        // The `Counters.ABORT_*` split behind `loops_aborted` (diagnostic).
+        // The native backends get this from MAJIT_LOG's summary, which the
+        // guest cannot read; without it a wasm-only `loops_aborted` regression
+        // names no reason. Labels mirror
+        // `majit_metainterp::jitprof::ABORT_COUNTER_KINDS`, which is
+        // append-only, so a guest older than this runner just reads 0 for a
+        // trailing label.
+        if let Ok(ab) = instance.get_typed_func::<u32, u64>(&mut store, "pyre_jit_abort_diag") {
+            let labels = [
+                "too_long",
+                "bridge",
+                "bad_loop",
+                "escape",
+                "force_quasiimmut",
+                "segmented_trace",
+            ];
+            let mut parts = Vec::with_capacity(labels.len());
+            for (i, lbl) in labels.iter().enumerate() {
+                let n = ab.call(&mut store, i as u32).unwrap_or(0);
+                parts.push(format!("{lbl}={n}"));
+            }
+            eprintln!("[jit-stats] abort_diag {}", parts.join(" "));
+        }
         // compile_bridge outcome tallies (diagnostic). 0=entered 1=declCALL_ASM
         // 2=declMultiPeel 3=declNotDirect 4=declRefHome 5=BRIDGE_OK
         // 6=loopClosing 7=srcHasPreamble 15=declCAHostTrampoline,

--- a/pyre/pyre-wasm/src/lib.rs
+++ b/pyre/pyre-wasm/src/lib.rs
@@ -360,6 +360,19 @@ pub extern "C" fn pyre_jit_loops_aborted() -> u64 {
     pyre_jit::eval::driver_pair().0.get_stats().loops_aborted as u64
 }
 
+/// The `Counters.ABORT_*` split behind `pyre_jit_loops_aborted`, indexed as
+/// `majit_metainterp::jitprof::ABORT_COUNTER_KINDS`. On the native backends
+/// that breakdown comes from `MAJIT_LOG`'s summary, but the wasm32 guest has
+/// no environment, so a `loops_aborted` regression that only reproduces here
+/// otherwise carries no reason at all. Exported rather than imported for the
+/// same reason as `pyre_jit_bridge_diag`. The host prints it at
+/// `PYRE_WASM_JIT_STATS` time.
+#[cfg(all(target_arch = "wasm32", feature = "wasm-host"))]
+#[unsafe(no_mangle)]
+pub extern "C" fn pyre_jit_abort_diag(i: u32) -> u64 {
+    pyre_jit::eval::driver_pair().0.abort_diag(i as usize)
+}
+
 #[cfg(all(target_arch = "wasm32", feature = "wasm-host"))]
 #[unsafe(no_mangle)]
 pub extern "C" fn pyre_jit_internal_compile_panics() -> u64 {


### PR DESCRIPTION
`loops_aborted` is a single number. On the native backends its reason
breakdown comes from `MAJIT_LOG`'s summary — a guest-side knob. The wasm32
guest has no environment, so on that backend every such knob is inert (the
runner says so itself):

```
[pyre-wasm-runner] ignoring MAJIT_STRICT, PYRE_DESCR_SPELLING_GATE, PYRE_FBW_DEBUG_ABORT:
the wasm guest has no environment, so guest-side knobs and probes do nothing here
```

So a `loops_aborted` regression that reproduces only on wasm arrives with no
reason attached, and the counters that would explain it are already being
maintained — just not reachable across the module boundary.

This enumerates the reason-keyed profiler tallies as `ABORT_COUNTER_KINDS`,
reads them by index through `JitProfiler::abort_diag` / `JitDriver::abort_diag`,
exports `pyre_jit_abort_diag` from the guest, and prints the labelled split
from the runner under `PYRE_WASM_JIT_STATS` — alongside the `bridge_diag`,
`fbw_diag` and `mc_diag` lines that already follow this pattern.

On the one fixture main's jit-stats floor is currently red for,
`synth/pickle_terminal_raise_resume` (`loops_aborted 54 -> 59`, wasm only):

```
[jit-stats] abort_diag too_long=0 bridge=38 bad_loop=17 escape=0 force_quasiimmut=4 segmented_trace=0
```

`38 + 17 + 4 = 59`, so the split accounts for the whole total rather than a
sample of it. dynasm reports 0 for every abort kind on the same fixture.

Notes:

- Exported, not imported, for the same reason as `pyre_jit_bridge_diag`:
  reading it cannot perturb the JIT's table/function indices. `loops_aborted`
  measures 59 on that fixture both before and after the export exists.
- `ABORT_COUNTER_KINDS` order is the contract with the host, which reads by
  index — append only, never reorder.
- Gated behind `PYRE_WASM_JIT_STATS`, which `check.py` does not set, so the
  new `[jit-stats]` line cannot enter a gate snapshot.

Verified: native build, `cargo test -p majit-metainterp` green, `cargo fmt
--check` clean.

This is diagnostic only — it does not change the red. The remaining step is
the baseline's own split (the 54), which needs a guest build at the sha the
baseline was recorded at.
