### PR TITLE
gc: fix the address hash's control byte and the __slots__ descriptor's VISITED latch; code, posix, socket: preserve filesystem bytes

### DIFF
--- a/majit/majit-gc/src/address_dict.rs
+++ b/majit/majit-gc/src/address_dict.rs
@@ -13,6 +13,34 @@ pub(crate) struct AddressHasher {
     hash: u64,
 }
 
+/// Odd 64-bit multiplier (2^64 / golden ratio) used to carry the mangled
+/// value's entropy into the high bits.  See [`AddressHasher::spread`].
+const SPREAD_MULTIPLIER: u64 = 0x9E37_79B9_7F4A_7C15;
+
+impl AddressHasher {
+    /// `mangle_hash` states its own purpose: an aligned address has zeros in
+    /// its *trailing* bits, so a table that indexes on those bits alone would
+    /// pile every key into the same bucket (`rpython/memory/support.py:10-14`).
+    /// `lldict` reuses `rdict`, which consumes the hash only that way, so the
+    /// xor-shift is the whole job there.
+    ///
+    /// `HashMap`/`HashSet` read the hash a second way: each entry also stores
+    /// a control byte taken from the **top 7 bits**, matched against the
+    /// query's before any key is compared.  A heap address leaves those bits
+    /// zero and the xor-shift moves nothing into them, so every entry in the
+    /// table carries the same control byte, the match reports every occupied
+    /// slot in the group as a candidate, and a lookup that should have ended
+    /// at the control byte instead compares keys one by one.  Multiplying by
+    /// an odd constant spreads the mangled value over the whole word, which is
+    /// the same intent applied to the bits this container actually reads; the
+    /// low half still depends only on the low half, so the bucket index keeps
+    /// the mangled distribution.
+    #[inline]
+    fn spread(value: u64) -> u64 {
+        (value ^ (value >> 4)).wrapping_mul(SPREAD_MULTIPLIER)
+    }
+}
+
 impl Hasher for AddressHasher {
     fn finish(&self) -> u64 {
         self.hash
@@ -26,11 +54,11 @@ impl Hasher for AddressHasher {
         for (shift, byte) in bytes.iter().copied().take(8).enumerate() {
             value |= (byte as u64) << (shift * 8);
         }
-        self.hash = value ^ (value >> 4);
+        self.hash = Self::spread(value);
     }
 
     fn write_usize(&mut self, value: usize) {
-        self.hash = (value ^ (value >> 4)) as u64;
+        self.hash = Self::spread(value as u64);
     }
 }
 
@@ -42,11 +70,39 @@ mod tests {
     use super::*;
     use std::hash::{Hash, Hasher};
 
-    #[test]
-    fn address_hasher_matches_rpython_mangle_hash() {
-        let address = 0x1234_5678usize;
+    fn hash_of(address: usize) -> u64 {
         let mut hasher = AddressHasher::default();
         address.hash(&mut hasher);
-        assert_eq!(hasher.finish(), (address ^ (address >> 4)) as u64);
+        hasher.finish()
+    }
+
+    #[test]
+    fn address_hasher_starts_from_rpython_mangle_hash() {
+        let address = 0x1234_5678usize;
+        assert_eq!(
+            hash_of(address),
+            ((address ^ (address >> 4)) as u64).wrapping_mul(SPREAD_MULTIPLIER)
+        );
+    }
+
+    #[test]
+    fn address_hasher_gives_aligned_heap_addresses_distinct_control_bytes() {
+        // Sixteen-byte-aligned addresses out of one heap region: what the
+        // collector's tables are keyed on. The table's control byte is the top
+        // 7 bits of the hash, which the bare mangle leaves zero for every one
+        // of them.
+        let addresses: Vec<usize> = (0..256).map(|i| 0x0001_2000_0000 + i * 0x40).collect();
+        let mangled: HashSet<u8> = addresses
+            .iter()
+            .map(|&a| (((a ^ (a >> 4)) as u64) >> 57) as u8)
+            .collect();
+        assert_eq!(mangled.len(), 1, "premise: the bare mangle collapses");
+
+        let spread: HashSet<u8> = addresses.iter().map(|&a| (hash_of(a) >> 57) as u8).collect();
+        assert!(
+            spread.len() > 64,
+            "control bytes still collapse: {} distinct",
+            spread.len()
+        );
     }
 }

--- a/majit/majit-gc/src/address_dict.rs
+++ b/majit/majit-gc/src/address_dict.rs
@@ -98,7 +98,10 @@ mod tests {
             .collect();
         assert_eq!(mangled.len(), 1, "premise: the bare mangle collapses");
 
-        let spread: HashSet<u8> = addresses.iter().map(|&a| (hash_of(a) >> 57) as u8).collect();
+        let spread: HashSet<u8> = addresses
+            .iter()
+            .map(|&a| (hash_of(a) >> 57) as u8)
+            .collect();
         assert!(
             spread.len() > 64,
             "control bytes still collapse: {} distinct",

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -448,8 +448,12 @@ impl ImportedShortPureOp {
         // The body-visible `op` and the replay `preamble_op` are distinct
         // RPython Box objects for every PureOp, not only invented aliases.
         // Keep their OpRef identities distinct as well: `source` names
-        // self.res, while `result` names the replay operation.
-        replay.pos.set(if invented_name { result } else { source });
+        // self.res, while `result` names the replay operation — including
+        // the non-invented arm, where `add_op_to_short` (shortpreamble.py:140
+        // `op.copy_and_change(opnum, args=arglist)`) still hands
+        // `ProducedShortOp` a freshly allocated replay op rather than
+        // `self.res` itself.
+        replay.pos.set(result);
         if let Some(d) = descr.clone() {
             replay.setdescr(d);
         }
@@ -3152,8 +3156,7 @@ impl OptContext {
         // allocated before the constructor, so all emit-capable kinds use it.
         let replay_pos = |source: OpRef, produced_op: &ProducedShortOp| -> OpRef {
             let installs_replace_op = match produced_op.kind {
-                PreambleOpKind::Pure => produced_op.invented_name,
-                PreambleOpKind::Heap | PreambleOpKind::LoopInvariant => true,
+                PreambleOpKind::Pure | PreambleOpKind::Heap | PreambleOpKind::LoopInvariant => true,
                 PreambleOpKind::InputArg | PreambleOpKind::Guard => false,
             };
             if installs_replace_op {

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -1585,11 +1585,7 @@ impl ProducedShortOp {
             Some(p) => {
                 debug_assert_eq!(
                     p.preamble_op.pos.get(),
-                    if self.invented_name {
-                        result_opref
-                    } else {
-                        source
-                    },
+                    result_opref,
                     "builder replay pos diverged from produce_pure replay rule"
                 );
                 crate::optimizeopt::ImportedShortPureOp {
@@ -1739,11 +1735,27 @@ impl ProducedShortOp {
         // them only through `PreambleOp(self.res, preamble_op, ...)`.
         //
         // DEVIATION: the forwarding below collapses the two onto one position.
-        // It is load-bearing as long as it stands — `force_op_from_preamble_op`
-        // keys `potential_extra_ops` off the forwarded box, and both the
-        // `force_box` pop and the post-hoc force sweep in unroll.rs carry a
-        // second lookup for the cases where the two resolutions disagree. The
-        // forwarding and those compensations have to come out together.
+        // It is what gives the imported field a body-namespace identity at all,
+        // so it cannot be lifted on its own. `self.res` names a Phase-1
+        // (preamble) OpRef; RPython has no such split, because `self.res` is one
+        // Box that both the preamble and the peeled body hold. Forwarding it to
+        // the Phase-2 replay slot is what makes the peeled body re-export the
+        // field as its own short box, which is in turn what extends the body
+        // JUMP with the slot the extended LABEL declares.
+        //
+        // Measured: dropping just this `make_equal_to` (and the GETARRAYITEM /
+        // LoopInvariant siblings) leaves the body JUMP one arg short, and
+        // `assemble_peeled_trace_with_jump_args`'s `unwrap_or(label_arg)`
+        // fallback then feeds the LABEL slot back to itself — a loop-carried
+        // `s -= 1` freezes at its entry value (`synth/unary_int_loop_carried`
+        // prints -44 instead of -29000). Removing the `force_box` dual-key pop
+        // and the unroll.rs force sweep alongside it does not address that;
+        // closing this needs the imported short box to carry a body-namespace
+        // position by construction.
+        //
+        // The non-invented Pure sibling of this collapse (the replay op sharing
+        // `source`) was a separate defect and is fixed — see mod.rs
+        // `ImportedShortPureOp::new`.
         let op_source = ctx
             .get_box_replacement_operand_opt(source)
             .unwrap_or_else(|| ctx.materialize_operand_at(source));
@@ -1887,7 +1899,8 @@ impl ProducedShortOp {
         // carried body result and the replayed GETARRAYITEM result stay
         // distinct upstream, joined only by PreambleOp bookkeeping. The same
         // DEVIATION as the GETFIELD path applies — the forwarding below
-        // collapses them.
+        // collapses them, and `produce_heap_field` records why it cannot be
+        // lifted on its own.
         let op_source = ctx
             .get_box_replacement_operand_opt(source)
             .unwrap_or_else(|| ctx.materialize_operand_at(source));
@@ -1933,7 +1946,8 @@ impl ProducedShortOp {
         // shortpreamble.py:152-159 stores `self.res` as the body-visible Box
         // and the replay call separately in PreambleOp. As with HeapOp the two
         // identities stay distinct upstream, and as with HeapOp the forwarding
-        // below is the DEVIATION that collapses them.
+        // below is the DEVIATION that collapses them; `produce_heap_field`
+        // records why it cannot be lifted on its own.
         let result_opref = *result_map.get(&source)?;
         let _ = result_type;
         let op_source = ctx

--- a/pyre/extra_tests/parity_tests/imp_fix_co_filename_surrogateescape.py
+++ b/pyre/extra_tests/parity_tests/imp_fix_co_filename_surrogateescape.py
@@ -1,0 +1,60 @@
+import _imp
+
+
+code = compile("x = 1", "orig.py", "exec")
+_imp._fix_co_filename(code, "x\udcff.py")
+assert code.co_filename == "x\udcff.py"
+
+plain = compile("x = 1", "orig.py", "exec")
+_imp._fix_co_filename(plain, "renamed.py")
+assert plain.co_filename == "renamed.py"
+
+nested = compile("def f():\n    return 1\n", "orig.py", "exec")
+_imp._fix_co_filename(nested, "x\udcff.py")
+child = next(const for const in nested.co_consts if isinstance(const, type(nested)))
+assert child.co_filename == "x\udcff.py"
+
+realized = compile("def f():\n    return 1\n", "orig.py", "exec")
+realized_child = next(
+    const for const in realized.co_consts if isinstance(const, type(realized))
+)
+_imp._fix_co_filename(realized, "x\udcff.py")
+assert realized_child.co_filename == "x\udcff.py"
+
+replaced = code.replace(co_filename="y\udcfe.py")
+assert replaced.co_filename == "y\udcfe.py"
+assert code.replace().co_filename == "x\udcff.py"
+
+replace_parent = compile("def f():\n    return 1\n", "orig.py", "exec")
+replace_parent = replace_parent.replace(co_filename="only-parent\udcfc.py")
+replace_child = next(
+    const
+    for const in replace_parent.co_consts
+    if isinstance(const, type(replace_parent))
+)
+assert replace_parent.co_filename == "only-parent\udcfc.py"
+assert replace_child.co_filename == "orig.py"
+
+constructed = type(code)(
+    code.co_argcount,
+    code.co_posonlyargcount,
+    code.co_kwonlyargcount,
+    code.co_nlocals,
+    code.co_stacksize,
+    code.co_flags,
+    code.co_code,
+    code.co_consts,
+    code.co_names,
+    code.co_varnames,
+    "z\udcfd.py",
+    code.co_name,
+    code.co_qualname,
+    code.co_firstlineno,
+    code.co_linetable,
+    code.co_exceptiontable,
+    code.co_freevars,
+    code.co_cellvars,
+)
+assert constructed.co_filename == "z\udcfd.py"
+
+print("OK")

--- a/pyre/extra_tests/parity_tests/os_boundary_surrogateescape.py
+++ b/pyre/extra_tests/parity_tests/os_boundary_surrogateescape.py
@@ -66,6 +66,7 @@ except OSError:
 # (gateway.py:365 `space.fsencode_w`), so these boundaries do too.
 assert os.system(b"true") == 0
 os.waitpid(os.posix_spawn(TRUE, [TRUE.encode()], {}), 0)
-assert socket.if_nametoindex(socket.if_indextoname(1).encode()) == 1
+index, name = socket.if_nameindex()[0]
+assert socket.if_nametoindex(name.encode()) == index
 
 print("OK")

--- a/pyre/extra_tests/parity_tests/os_boundary_surrogateescape.py
+++ b/pyre/extra_tests/parity_tests/os_boundary_surrogateescape.py
@@ -8,13 +8,16 @@ instead of raising UnicodeEncodeError.
 """
 
 import os
-import socket
 import sys
-import tempfile
 
+# Every boundary below is POSIX-only, and `_socket` is not built on Windows,
+# so the platform check has to run before `socket` is imported.
 if sys.platform == "win32":
     print("OK")
     raise SystemExit
+
+import socket
+import tempfile
 
 
 # `os.system`: the surrogate escape reaches the shell as byte 0xff.  The

--- a/pyre/extra_tests/parity_tests/os_boundary_surrogateescape.py
+++ b/pyre/extra_tests/parity_tests/os_boundary_surrogateescape.py
@@ -1,0 +1,55 @@
+"""OS boundaries take the filesystem encoding, not a strict UTF-8 encode.
+
+`os.system` (interp_posix.py:815 `command='fsencode'`), the `posix_spawn`
+argv/envp entries (interp_posix.py:1742 `space.fsencode_w(w_arg)`) and an
+AF_UNIX address (interp_socket.py:157-159 `space.fsencode(w_address)`) all
+carry OS bytes, so a name spelling a byte with no UTF-8 form must survive
+instead of raising UnicodeEncodeError.
+"""
+
+import os
+import socket
+import sys
+import tempfile
+
+if sys.platform == "win32":
+    print("OK")
+    raise SystemExit
+
+
+# `os.system`: the surrogate escape reaches the shell as byte 0xff.  The
+# command is a no-op either way; what is under test is that encoding the
+# argument does not raise.
+os.system("true 'x\udcff'")
+
+# `posix_spawn`: a surrogate-escaped argv entry, which `true` ignores.
+TRUE = "/usr/bin/true" if os.path.exists("/usr/bin/true") else "/bin/true"
+
+pid = os.posix_spawn(TRUE, [TRUE, "x\udcff"], {})
+os.waitpid(pid, 0)
+
+# and a surrogate-escaped environment value.
+pid = os.posix_spawn(TRUE, [TRUE], {"PYRE_X": "v\udcff"})
+os.waitpid(pid, 0)
+
+# AF_UNIX: bind to a path whose last byte has no UTF-8 spelling.  Whether the
+# kernel accepts it is a platform question — macOS refuses a non-UTF-8 path
+# with EILSEQ — so the assertion is that the *encoding* is not what refuses:
+# the address must reach the OS.  Where the bind does succeed, the name read
+# back proves the bytes were not mangled on the way.
+with tempfile.TemporaryDirectory() as d:
+    path = os.path.join(d, "s\udcff")
+    s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    try:
+        try:
+            s.bind(path)
+        except UnicodeEncodeError:
+            raise AssertionError("AF_UNIX path was encoded strictly") from None
+        except OSError:
+            pass
+        else:
+            assert s.getsockname() == path, s.getsockname()
+    finally:
+        s.close()
+
+print("OK")

--- a/pyre/extra_tests/parity_tests/os_boundary_surrogateescape.py
+++ b/pyre/extra_tests/parity_tests/os_boundary_surrogateescape.py
@@ -52,4 +52,20 @@ with tempfile.TemporaryDirectory() as d:
     finally:
         s.close()
 
+# `socket.if_nametoindex` reads an interface name the same way.  A surrogate
+# escape must reach the OS, which answers ENODEV/ENXIO for a name no interface
+# carries; only the encoding is under test.
+try:
+    socket.if_nametoindex("lo\udcff")
+except UnicodeEncodeError:
+    raise AssertionError("interface name was encoded strictly") from None
+except OSError:
+    pass
+
+# The `'fsencode'` converter accepts bytes and `__fspath__` as well as str
+# (gateway.py:365 `space.fsencode_w`), so these boundaries do too.
+assert os.system(b"true") == 0
+os.waitpid(os.posix_spawn(TRUE, [TRUE.encode()], {}), 0)
+assert socket.if_nametoindex(socket.if_indextoname(1).encode()) == 1
+
 print("OK")

--- a/pyre/pyre-interpreter/src/gateway.rs
+++ b/pyre/pyre-interpreter/src/gateway.rs
@@ -1531,6 +1531,12 @@ pub fn fsencode_bytes_w(obj: pyre_object::PyObjectRef) -> Result<Vec<u8>, crate:
     Ok(fsencode_bytes_w_with_kind(obj)?.0)
 }
 
+/// `objspace.py:438 newfilename(s) = fsdecode(newbytes(s))`: expose the
+/// application-level filename spelling derived from its filesystem bytes.
+pub fn fsdecode_filename_bytes(data: &[u8]) -> pyre_object::PyObjectRef {
+    crate::typedef::charp2uni(data)
+}
+
 /// [`fsencode_bytes_w`] paired with the `bytes`-ness of the resolved object;
 /// see [`fsencode_w_with_kind`] for why the two are produced together.
 pub fn fsencode_bytes_w_with_kind(

--- a/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
+++ b/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
@@ -807,6 +807,11 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                             "sethostname() requires 1 argument",
                         ));
                     }
+                    // `interp_func.py:408` fsencodes the str branch, but the
+                    // seam this reaches (`host_env::socket::sethostname`) takes
+                    // a `&str`, so a name spelling a byte with no UTF-8 form
+                    // has nowhere to travel; encoding here would only be undone
+                    // at the call. Closing this needs the seam to take bytes.
                     let name = unsafe {
                         if !pyre_object::is_str(args[0]) {
                             return Err(crate::PyError::type_error(
@@ -2168,11 +2173,13 @@ fn pack_inet_addr(
         } else {
             addr
         };
+        // `interp_socket.py:157-159 w_address = space.fsencode(w_address)`,
+        // with the upstream note that it deliberately avoids `fsencode_w`
+        // because Linux allows embedded NULs in an abstract-namespace path.
+        // The encoder used here performs no null check either.
         let path_bytes_vec: Vec<u8> = unsafe {
             if pyre_object::is_str(path_obj) {
-                crate::baseobjspace::str_utf8_w(path_obj)?
-                    .to_string()
-                    .into_bytes()
+                crate::gateway::fsencode_bytes_w(path_obj)?
             } else if pyre_object::bytesobject::is_bytes_like(path_obj) {
                 pyre_object::bytesobject::bytes_like_data(path_obj).to_vec()
             } else {

--- a/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
+++ b/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
@@ -1312,13 +1312,19 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             crate::make_builtin_function_with_arity(
                 "if_nametoindex",
                 |args| {
-                    if args.is_empty() || !unsafe { pyre_object::is_str(args[0]) } {
+                    if args.is_empty() {
                         return Err(crate::PyError::type_error(
-                            "if_nametoindex: name must be a string",
+                            "if_nametoindex() requires 1 argument",
                         ));
                     }
-                    let name = crate::baseobjspace::str_utf8_w(args[0])?.to_string();
-                    let c_name = std::ffi::CString::new(name.as_bytes())
+                    // An interface name is an OS string.  PyPy has no
+                    // `if_nametoindex`, so there is no `unwrap_spec` to port;
+                    // `socketmodule.c socket_if_nametoindex` reads it with
+                    // `PyUnicode_FSConverter`, which is the same filesystem
+                    // encoding `fsencode_w` applies and accepts the same
+                    // str / bytes / `__fspath__` argument.
+                    let name = crate::gateway::fsencode_bytes_w(args[0])?;
+                    let c_name = std::ffi::CString::new(name)
                         .map_err(|_| crate::PyError::value_error("embedded null in name"))?;
                     let idx = unsafe { libc::if_nametoindex(c_name.as_ptr()) };
                     if idx == 0 {

--- a/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
+++ b/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
@@ -2397,7 +2397,9 @@ fn unpack_inet_addr(storage: &libc::sockaddr_storage) -> pyre_object::PyObjectRe
             .position(|&b| b == 0)
             .unwrap_or(sun.sun_path.len());
         let bytes: Vec<u8> = sun.sun_path[..end].iter().map(|&b| b as u8).collect();
-        pyre_object::w_str_new(&String::from_utf8_lossy(&bytes))
+        // `interp_socket.py:47 space.newfilename(path)`: read-back uses the filesystem
+        // decoding so a byte with no UTF-8 spelling survives the round trip.
+        crate::gateway::fsdecode_filename_bytes(&bytes)
     } else {
         pyre_object::w_tuple_new(vec![])
     }

--- a/pyre/pyre-interpreter/src/module/imp/interp_imp.rs
+++ b/pyre/pyre-interpreter/src/module/imp/interp_imp.rs
@@ -1073,13 +1073,9 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                         type_name(args[1])
                     )));
                 }
-                // `co_filename` is stored as UTF-8, so the name is encoded
-                // strictly: one carrying a lone surrogate has no such spelling
-                // and is reported the way encoding the string itself reports
-                // it.  The encode succeeded, so the bytes are valid UTF-8 and
-                // the lossy decode below cannot substitute anything.
-                let encoded = crate::type_methods::encode_utf8_with_errors(args[1], "strict")?;
-                let newname = String::from_utf8_lossy(&encoded).into_owned();
+                // `interp_imp.py:157 pathname='fsencode'`: preserve the raw
+                // filesystem spelling before storing it on the code object.
+                let newname = crate::gateway::fsencode_bytes_w(args[1])?;
                 unsafe { crate::pycode::fix_co_filename(args[0], &newname) };
                 Ok(pyre_object::w_none())
             },

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -1188,15 +1188,16 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     /// A filesystem name reported back to the caller: `bytes` when the path
     /// argument was `bytes` (`posixmodule.c path_converter`), else `str`.
     ///
-    /// The name arrives as raw bytes because bytes mode exists precisely for
-    /// entries the filesystem encoding cannot round-trip: `readdir`'s `d_name`
-    /// is handed back unchanged, so a name like `b"bad_\xff"` stays openable
-    /// instead of decoding to U+FFFD first.
+    /// The name arrives as raw bytes because `readdir`'s `d_name` is handed
+    /// back unchanged. Both arms keep it openable: bytes mode returns it
+    /// verbatim, and the `str` arm takes the filesystem decoding
+    /// (`interp_posix.py:1121 space.newfilename(f)`), so a name like
+    /// `b"bad_\xff"` still names the file on disk instead of carrying U+FFFD.
     fn fs_name_obj(bytes_mode: bool, name: &[u8]) -> PyObjectRef {
         if bytes_mode {
             pyre_object::bytesobject::w_bytes_from_bytes(name)
         } else {
-            pyre_object::w_str_new(&String::from_utf8_lossy(name))
+            crate::gateway::fsdecode_filename_bytes(name)
         }
     }
 

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -4251,18 +4251,13 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     if args.is_empty() {
                         return Err(crate::PyError::type_error("system() requires 1 argument"));
                     }
-                    // `interp_posix.py:815 command='fsencode'`: the shell gets
-                    // the filesystem bytes, so a command naming a byte with no
-                    // UTF-8 spelling survives instead of being refused.
-                    let cmd = unsafe {
-                        if pyre_object::is_str(args[0]) {
-                            crate::gateway::fsencode_bytes_w(args[0])?
-                        } else {
-                            return Err(crate::PyError::type_error(
-                                "system(): command must be a string",
-                            ));
-                        }
-                    };
+                    // `interp_posix.py:815 command='fsencode'`, which
+                    // `gateway.py:365` unwraps with `space.fsencode_w`: the
+                    // shell gets the filesystem bytes, so a command naming a
+                    // byte with no UTF-8 spelling survives instead of being
+                    // refused, and `bytes` / `__fspath__` are accepted as the
+                    // converter accepts them.
+                    let cmd = crate::gateway::fsencode_bytes_w(args[0])?;
                     let c_cmd = std::ffi::CString::new(cmd)
                         .map_err(|_| crate::PyError::value_error("embedded null in command"))?;
                     let rc = rustpython_host_env::os::system(&c_cmd);
@@ -4534,18 +4529,9 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     .map(|s| {
                         // `interp_posix.py:1742 args = [space.fsencode_w(w_arg)
                         // for w_arg in args_w]`: every argv/envp entry crosses
-                        // to the new process as filesystem bytes.
-                        let bytes = unsafe {
-                            if pyre_object::is_str(s) {
-                                crate::gateway::fsencode_bytes_w(s)?
-                            } else if pyre_object::is_bytes(s) {
-                                pyre_object::w_bytes_data(s).to_vec()
-                            } else {
-                                return Err(crate::PyError::type_error(format!(
-                                    "{fn_name}(): {arg_name} entries must be str or bytes",
-                                )));
-                            }
-                        };
+                        // to the new process as filesystem bytes, and the same
+                        // converter decides what an entry may be.
+                        let bytes = crate::gateway::fsencode_bytes_w(s)?;
                         std::ffi::CString::new(bytes).map_err(|_| {
                             crate::PyError::value_error(format!(
                                 "{fn_name}(): embedded null in {arg_name}",

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -4251,16 +4251,19 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     if args.is_empty() {
                         return Err(crate::PyError::type_error("system() requires 1 argument"));
                     }
+                    // `interp_posix.py:815 command='fsencode'`: the shell gets
+                    // the filesystem bytes, so a command naming a byte with no
+                    // UTF-8 spelling survives instead of being refused.
                     let cmd = unsafe {
                         if pyre_object::is_str(args[0]) {
-                            crate::baseobjspace::str_utf8_w(args[0])?.to_string()
+                            crate::gateway::fsencode_bytes_w(args[0])?
                         } else {
                             return Err(crate::PyError::type_error(
                                 "system(): command must be a string",
                             ));
                         }
                     };
-                    let c_cmd = std::ffi::CString::new(cmd.as_bytes())
+                    let c_cmd = std::ffi::CString::new(cmd)
                         .map_err(|_| crate::PyError::value_error("embedded null in command"))?;
                     let rc = rustpython_host_env::os::system(&c_cmd);
                     Ok(pyre_object::w_int_new(rc as i64))
@@ -4529,9 +4532,12 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 items
                     .into_iter()
                     .map(|s| {
+                        // `interp_posix.py:1742 args = [space.fsencode_w(w_arg)
+                        // for w_arg in args_w]`: every argv/envp entry crosses
+                        // to the new process as filesystem bytes.
                         let bytes = unsafe {
                             if pyre_object::is_str(s) {
-                                crate::baseobjspace::str_utf8_w(s)?.as_bytes().to_vec()
+                                crate::gateway::fsencode_bytes_w(s)?
                             } else if pyre_object::is_bytes(s) {
                                 pyre_object::w_bytes_data(s).to_vec()
                             } else {

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -4524,21 +4524,27 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                         "{fn_name}(): {arg_name} must be a list or tuple",
                     )));
                 };
-                items
-                    .into_iter()
-                    .map(|s| {
-                        // `interp_posix.py:1742 args = [space.fsencode_w(w_arg)
-                        // for w_arg in args_w]`: every argv/envp entry crosses
-                        // to the new process as filesystem bytes, and the same
-                        // converter decides what an entry may be.
-                        let bytes = crate::gateway::fsencode_bytes_w(s)?;
-                        std::ffi::CString::new(bytes).map_err(|_| {
-                            crate::PyError::value_error(format!(
-                                "{fn_name}(): embedded null in {arg_name}",
-                            ))
-                        })
-                    })
-                    .collect()
+                // `interp_posix.py:1742 args = [space.fsencode_w(w_arg)
+                // for w_arg in args_w]`: every argv/envp entry crosses
+                // to the new process as filesystem bytes, and the same
+                // converter decides what an entry may be.
+                // `fsencode_bytes_w` reaches `__fspath__` for a non-str, non-bytes entry, so
+                // encoding one entry can collect and move the entries not yet converted.
+                // Publish the sequence once and read each entry back per iteration.
+                let _seq_roots = pyre_object::gc_roots::push_roots();
+                let items_base = pyre_object::gc_roots::pin_roots(&items);
+                let mut out = Vec::with_capacity(items.len());
+                for i in 0..items.len() {
+                    let bytes = crate::gateway::fsencode_bytes_w(
+                        pyre_object::gc_roots::shadow_stack_get(items_base + i),
+                    )?;
+                    out.push(std::ffi::CString::new(bytes).map_err(|_| {
+                        crate::PyError::value_error(format!(
+                            "{fn_name}(): embedded null in {arg_name}",
+                        ))
+                    })?);
+                }
+                Ok(out)
             }
             fn decode_file_actions(
                 obj: pyre_object::PyObjectRef,

--- a/pyre/pyre-interpreter/src/pycode.rs
+++ b/pyre/pyre-interpreter/src/pycode.rs
@@ -156,6 +156,24 @@ pub struct PyCode {
     /// the zero/negative values accepted by Python 3.14's CodeType
     /// constructor, so preserve the exact Python integer on the PyCode itself.
     pub co_firstlineno_raw: i32,
+    /// `pycode.py:135 self.co_filename = filename`: the byte-exact filesystem
+    /// spelling owned by this `PyCode`. Null means that `code.source_path` is
+    /// already the exact UTF-8 spelling, avoiding an allocation for compiled
+    /// source paths and ordinary filename replacements.
+    ///
+    /// Do not add the derived `w_filename` cache from `pycode.py:136` while
+    /// `PyCode` is prebuilt-immortal. An unrooted movable child would only be
+    /// marked on the first major collection after `GCFLAG_VISITED` latches.
+    /// Such a cache requires forwarding on every collection, as `w_globals`
+    /// is registered in `W_GLOBALS_STAMPED_CODES` and forwarded by
+    /// `eval::walk_raw_code_roots`.
+    pub filename_bytes: *mut Vec<u8>,
+    /// Whether an unrealized nested compiler constant selected by
+    /// `importing.py:379-391 update_code_filenames`' `oldname` guard inherits
+    /// `filename_bytes` when pyre crosses its lazy wrapping boundary. False
+    /// for `pycode.py:431` constructor/replace filenames, which affect only
+    /// the code object being constructed.
+    pub filename_inherits_to_nested: bool,
     /// PyPy: `PyCode.w_globals` — the globals dict OBJECT (`W_DictMultiObject`,
     /// `pycode.py:105 "w_globals?"`).  Module globals are `malloc_typed`-
     /// immortal, but `exec`/custom-globals dicts are `try_gc_alloc` movable.
@@ -547,6 +565,8 @@ pub fn w_code_new_with_hidden_applevel(code_ptr: *const (), hidden_applevel: boo
         },
         code_ptr,
         co_firstlineno_raw,
+        filename_bytes: std::ptr::null_mut(),
+        filename_inherits_to_nested: false,
         w_globals: pyre_object::PY_NULL,
         hidden_applevel,
         fast_natural_arity,
@@ -593,6 +613,50 @@ pub fn w_code_new(code_ptr: *const ()) -> PyObjectRef {
 pub fn box_code_constant(code: &crate::CodeObject) -> PyObjectRef {
     let code_ptr = Box::into_raw(Box::new(code.clone())) as *const ();
     w_code_new(code_ptr)
+}
+
+/// Box a nested compiler constant and inherit the enclosing `PyCode`'s raw
+/// filename when it belongs to the set selected by
+/// `importing.py:379-391 update_code_filenames`' `oldname` guard.
+fn box_code_constant_inheriting_filename(code: &crate::CodeObject, parent: &PyCode) -> PyObjectRef {
+    let obj = box_code_constant(code);
+    if parent.filename_inherits_to_nested
+        && code.source_path
+            == unsafe { &*(parent.code_ptr as *const crate::CodeObject) }.source_path
+        && !parent.filename_bytes.is_null()
+    {
+        let bytes = unsafe { (&*parent.filename_bytes).clone() };
+        unsafe { set_filename_bytes(obj, Some(bytes)) };
+        unsafe { (*(obj as *mut PyCode)).filename_inherits_to_nested = true };
+    }
+    obj
+}
+
+/// Replace the owned raw filename allocation. Code wrappers are immortal, so
+/// this is also the only point that retires an earlier spelling after a second
+/// `_fix_co_filename` call.
+unsafe fn set_filename_bytes(obj: PyObjectRef, bytes: Option<Vec<u8>>) {
+    let slot = unsafe { &mut (*(obj as *mut PyCode)).filename_bytes };
+    if let Some(bytes) = bytes {
+        if slot.is_null() {
+            *slot = Box::into_raw(Box::new(bytes));
+        } else {
+            unsafe { **slot = bytes };
+        }
+    } else if !slot.is_null() {
+        unsafe { drop(Box::from_raw(*slot)) };
+        *slot = std::ptr::null_mut();
+    }
+}
+
+unsafe fn filename_bytes(obj: PyObjectRef) -> Vec<u8> {
+    let pycode = unsafe { &*(obj as *const PyCode) };
+    if pycode.filename_bytes.is_null() {
+        let code = unsafe { &*(pycode.code_ptr as *const crate::CodeObject) };
+        code.source_path.as_bytes().to_vec()
+    } else {
+        unsafe { (&*pycode.filename_bytes).clone() }
+    }
 }
 
 fn box_code_constant_with_firstlineno(code: &crate::CodeObject, firstlineno: i32) -> PyObjectRef {
@@ -766,7 +830,14 @@ pub unsafe fn code_get_field(obj: PyObjectRef, name: &str) -> Result<PyObjectRef
         "co_varnames" => names_tuple(&code.varnames),
         "co_freevars" => names_tuple(&code.freevars),
         "co_cellvars" => names_tuple(&code.cellvars),
-        "co_filename" => w_str_new(&code.source_path),
+        "co_filename" => {
+            let filename_bytes = unsafe { (*(obj as *const PyCode)).filename_bytes };
+            if filename_bytes.is_null() {
+                w_str_new(&code.source_path)
+            } else {
+                crate::gateway::fsdecode_filename_bytes(unsafe { &*filename_bytes })
+            }
+        }
         // Shared realized object, like `co_qualname` below.
         "co_name" => unsafe { w_code_name_obj(obj) },
         // The realized qualname is shared with every function built from this
@@ -823,7 +894,7 @@ pub unsafe fn code_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErr
             "code: co_nlocals != len(co_varnames)"
         )));
     }
-    let source_path = unsafe { read_code_str(args[11], "filename")? };
+    let (source_path, filename_bytes) = unsafe { read_code_filename(args[11], "filename", None)? };
     let obj_name = unsafe { read_code_str(args[12], "name")? };
     let qualname = unsafe { read_code_str(args[13], "qualname")? };
     let first_line = unsafe { read_code_c_int(args[14])? } as i64;
@@ -893,6 +964,7 @@ pub unsafe fn code_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErr
         &code,
         first_line.clamp(i32::MIN as i64, i32::MAX as i64) as i32,
     );
+    unsafe { set_filename_bytes(result, filename_bytes) };
     unsafe { w_code_fill_consts_from_tuple(result, args[8]) };
     Ok(result)
 }
@@ -1247,6 +1319,16 @@ pub unsafe fn code_replace(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::P
     }
     let mut code = unsafe { (*code_ptr).clone() };
     let mut firstlineno_raw = unsafe { (*(w_self as *const PyCode)).co_firstlineno_raw };
+    let mut filename_bytes = unsafe {
+        let ptr = (*(w_self as *const PyCode)).filename_bytes;
+        if ptr.is_null() {
+            None
+        } else {
+            Some((&*ptr).clone())
+        }
+    };
+    let mut filename_inherits_to_nested =
+        unsafe { (*(w_self as *const PyCode)).filename_inherits_to_nested };
     let get = |name: &str| crate::builtins::kwarg_get(kwargs, name);
 
     if let Some(v) = get("co_argcount") {
@@ -1295,7 +1377,9 @@ pub unsafe fn code_replace(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::P
         code.qualname = unsafe { read_code_str(v, "co_qualname")? };
     }
     if let Some(v) = get("co_filename") {
-        code.source_path = unsafe { read_code_str(v, "co_filename")? };
+        (code.source_path, filename_bytes) =
+            unsafe { read_code_filename(v, "co_filename", Some(&code.source_path))? };
+        filename_inherits_to_nested = false;
     }
     if let Some(v) = get("co_names") {
         code.names = unsafe { read_code_names(v, "co_names")? };
@@ -1317,6 +1401,7 @@ pub unsafe fn code_replace(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::P
     }
     if let Some(v) = get("co_consts") {
         code.constants = unsafe { read_code_consts(v)? };
+        filename_inherits_to_nested = false;
     }
     if let Some(v) = get("co_code") {
         code.instructions = unsafe { read_code_units(v)? };
@@ -1361,6 +1446,10 @@ pub unsafe fn code_replace(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::P
     );
 
     let result = box_code_constant_with_firstlineno(&code, firstlineno_raw);
+    unsafe { set_filename_bytes(result, filename_bytes) };
+    unsafe {
+        (*(result as *mut PyCode)).filename_inherits_to_nested = filename_inherits_to_nested;
+    }
     if let Some(constants) = get("co_consts") {
         unsafe { w_code_fill_consts_from_tuple(result, constants) };
     } else {
@@ -1400,6 +1489,32 @@ unsafe fn read_code_str(v: PyObjectRef, field: &str) -> Result<String, crate::Py
         return Err(crate::PyError::type_error(format!("{field} must be a str")));
     }
     Ok(unsafe { pyre_object::w_str_get_value(v) }.to_string())
+}
+
+/// `pycode.py:431 filename='fsencode'`: retain filesystem bytes that the
+/// compiler dependency's UTF-8 `source_path` cannot represent. A supplied
+/// `fallback` is the last valid UTF-8 spelling used by interpreter/JIT readers;
+/// a new code object uses a lossy compiler-only spelling until those readers
+/// can consume the byte-exact field directly.
+unsafe fn read_code_filename(
+    v: PyObjectRef,
+    field: &str,
+    fallback: Option<&str>,
+) -> Result<(String, Option<Vec<u8>>), crate::PyError> {
+    if !unsafe { pyre_object::is_str(v) } {
+        return Err(crate::PyError::type_error(format!("{field} must be a str")));
+    }
+    let bytes = crate::gateway::fsencode_bytes_w(v)?;
+    Ok(match String::from_utf8(bytes) {
+        Ok(source_path) => (source_path, None),
+        Err(error) => {
+            let bytes = error.into_bytes();
+            let source_path = fallback
+                .map(str::to_owned)
+                .unwrap_or_else(|| String::from_utf8_lossy(&bytes).into_owned());
+            (source_path, Some(bytes))
+        }
+    })
 }
 
 /// A `tuple[str]` `co_*` field (names / varnames / freevars / cellvars).
@@ -1604,7 +1719,12 @@ pub unsafe fn w_code_const(w_code_obj: PyObjectRef, idx: usize) -> PyObjectRef {
         return existing;
     }
 
-    let mut realized = crate::pyframe::pyobject_from_constant(&constants[idx]);
+    let mut realized = match &constants[idx] {
+        crate::bytecode::ConstantData::Code { code } => {
+            box_code_constant_inheriting_filename(code, w_code)
+        }
+        constant => crate::pyframe::pyobject_from_constant(constant),
+    };
     // Keep the losing or winning candidate live until the CAS has either
     // published it or selected the concurrently-published canonical object.
     let candidate_root = &mut realized as *mut PyObjectRef as *mut *mut u8;
@@ -1689,13 +1809,42 @@ fn fix_code_filenames(code: &mut crate::CodeObject, oldname: &str, newname: &str
 ///
 /// # Safety
 /// `w_code` must point to a valid `PyCode` whose body is not currently running.
-pub unsafe fn fix_co_filename(w_code: PyObjectRef, newname: &str) {
+pub unsafe fn fix_co_filename(w_code: PyObjectRef, newname: &[u8]) {
     let code_ptr = unsafe { w_code_get_ptr(w_code) } as *mut crate::CodeObject;
     if code_ptr.is_null() {
         return;
     }
-    let oldname = unsafe { (*code_ptr).source_path.clone() };
-    unsafe { fix_code_filenames(&mut *code_ptr, &oldname, newname) };
+    let old_filename = unsafe { filename_bytes(w_code) };
+
+    // `importing.py:379-391 update_code_filenames` mutates already-wrapped
+    // nested `PyCode` constants. Pyre realizes that list lazily, so update the
+    // filled slots now; unrealized children inherit when they are boxed.
+    let pycode = unsafe { &*(w_code as *const PyCode) };
+    if !pycode.co_consts_w.is_null() {
+        for slot in unsafe { &*pycode.co_consts_w } {
+            let nested = slot.load(std::sync::atomic::Ordering::Acquire);
+            if !nested.is_null()
+                && unsafe { is_code(nested) }
+                && unsafe { filename_bytes(nested) } == old_filename
+            {
+                unsafe { fix_co_filename(nested, newname) };
+            }
+        }
+    }
+
+    let filename = match std::str::from_utf8(newname) {
+        Ok(newname) => {
+            let oldname = unsafe { (*code_ptr).source_path.clone() };
+            unsafe { fix_code_filenames(&mut *code_ptr, &oldname, newname) };
+            None
+        }
+        Err(_) => Some(newname.to_vec()),
+    };
+    unsafe { set_filename_bytes(w_code, filename) };
+    unsafe {
+        (*(w_code as *mut PyCode)).filename_inherits_to_nested =
+            std::str::from_utf8(newname).is_err();
+    }
 }
 
 /// Cached [`crate::pyframe::npure_cellvars`] for the code wrapper `obj`,

--- a/pyre/pyre-object/src/floatobject.rs
+++ b/pyre/pyre-object/src/floatobject.rs
@@ -53,7 +53,9 @@ impl crate::lltype::GcType for W_FloatObject {
 /// matching `gct_fv_gc_malloc`'s `c_type_id` / `c_size` constants
 /// (`framework.py:807-811`).
 ///
-/// `lltype::malloc_typed` is currently `Box::into_raw`. Future GC
+/// `lltype::malloc_typed` prepends a `GcHeader` (`alloc_with_gc_header`)
+/// but allocates outside the collector's heap, so the box carries a
+/// readable type id while staying off the sweep set. Future GC
 /// integration replaces only that body; this constructor stays
 /// unchanged.
 pub fn w_float_new(value: f64) -> PyObjectRef {

--- a/pyre/pyre-object/src/intobject.rs
+++ b/pyre/pyre-object/src/intobject.rs
@@ -84,7 +84,9 @@ static SMALL_INTS: LazyLock<Vec<W_IntObject>> = LazyLock::new(|| {
 /// `W_INT_OBJECT_SIZE` via the [`crate::lltype::GcType`] impl above —
 /// the Rust analog of `gct_fv_gc_malloc`'s compile-time `c_type_id`
 /// / `c_size` (`rpython/memory/gctransform/framework.py:807-811`).
-/// `malloc_typed` is currently `Box::into_raw`; future GC integration
+/// `malloc_typed` prepends a `GcHeader` (`alloc_with_gc_header`) but
+/// allocates outside the collector's heap, so the box carries a readable
+/// type id while staying off the sweep set; future GC integration
 /// replaces only that body, this constructor stays unchanged.
 #[inline]
 pub fn w_int_new(value: i64) -> PyObjectRef {

--- a/pyre/pyre-object/src/memoryview.rs
+++ b/pyre/pyre-object/src/memoryview.rs
@@ -115,6 +115,11 @@ pub fn w_memoryview_alloc_header(released: bool, owns_export: bool) -> PyObjectR
 
 /// Allocate CPython's `_buffer_wrapper(mv, obj)`, rooting both constructor
 /// arguments across the managed allocation.
+///
+/// Managed and non-moving, the same shape `w_memoryview_new` above uses: the
+/// wrapper's only job is to hold `w_mv`/`w_obj` alive, and a `malloc_typed`
+/// immortal is outside the sweep set, so the marker latches GCFLAG_VISITED on
+/// it at the first major and never re-marks those two children afterwards.
 pub fn w_buffer_wrapper_new(w_mv: PyObjectRef, w_obj: PyObjectRef) -> PyObjectRef {
     let _roots = crate::gc_roots::push_roots();
     let sp = crate::gc_roots::shadow_stack_len();

--- a/pyre/pyre-object/src/specialisedtupleobject.rs
+++ b/pyre/pyre-object/src/specialisedtupleobject.rs
@@ -179,11 +179,11 @@ pub fn w_specialised_tuple_ff_new(value0: f64, value1: f64) -> PyObjectRef {
 }
 
 /// Allocate an arity-2 specialised object tuple. Carries
-/// `gc_ptr_offsets = [value0, value1]` (`eval.rs:350`); the values
-/// may transiently point at `Box::into_raw`'d W_IntObject /
-/// W_FloatObject during the L1 stepping-stone window. The mark
-/// walker's `is_managed_heap_object` guard (collector.rs:991/1008)
-/// keeps that case correctness-safe.
+/// `gc_ptr_offsets = [value0, value1]` (`eval.rs:350`); the values may
+/// transiently point at an off-heap `malloc_typed` W_IntObject /
+/// W_FloatObject during the L1 stepping-stone window — headered, but
+/// outside the collector's heap. The mark walker's
+/// `is_managed_heap_object` guard keeps that case correctness-safe.
 pub fn w_specialised_tuple_oo_new(value0: PyObjectRef, value1: PyObjectRef) -> PyObjectRef {
     // `gct_fv_gc_malloc` bracket pattern (`framework.py:853-856`):
     // both inputs are live PyObjectRef roots that must survive the

--- a/pyre/pyre-object/src/typedef.rs
+++ b/pyre/pyre-object/src/typedef.rs
@@ -368,8 +368,8 @@ pub unsafe fn w_member_get_cls(obj: PyObjectRef) -> PyObjectRef {
 /// gaining a young or unmarked `w_cls` must re-enter the collector's worklist.
 pub unsafe fn w_member_set_cls(obj: PyObjectRef, w_cls: PyObjectRef) {
     crate::gc_roots::mark_prebuilt_roots_dirty();
+    unsafe { (*(obj as *mut W_MemberDescr)).w_cls = w_cls };
     crate::gc_hook::try_gc_write_barrier(obj as *mut u8);
-    unsafe { (*(obj as *mut W_MemberDescr)).w_cls = w_cls }
 }
 
 /// `typedef.py:446 Member.index` — the slot index (`base_nslots + position`),

--- a/pyre/pyre-object/src/typedef.rs
+++ b/pyre/pyre-object/src/typedef.rs
@@ -294,7 +294,17 @@ pub fn w_member_new_with_doc(
         crate::lltype::malloc_raw(doc) as *const String
     });
     let w_cls = crate::gc_roots::shadow_stack_get(root_base);
-    W_MemberDescr::allocate(W_MemberDescr {
+    // Managed (`allocate_stable`), not the movable `malloc_typed` immortal a
+    // bare `allocate` would give: a `__slots__` member outlives the statement
+    // that created it (`d = C.x` keeps the descriptor after `C` is dropped),
+    // and `w_cls` is then its only reference to the owning type.  An immortal
+    // is outside the collector's sweep set, so the marker takes GCFLAG_VISITED
+    // on it during the first major and never clears it again; from the second
+    // major on it is skipped, `w_cls` is never re-marked, and the type is swept
+    // while the descriptor still points at it.  A stable managed allocation
+    // keeps the address fixed for the raw `*mut W_MemberDescr` accessors below
+    // while putting the object under the ordinary mark-and-clear cycle.
+    W_MemberDescr::allocate_stable(W_MemberDescr {
         ob: PyObject {
             ob_type: std::ptr::null(),
             w_class: std::ptr::null_mut(),
@@ -350,8 +360,15 @@ pub unsafe fn w_member_get_cls(obj: PyObjectRef) -> PyObjectRef {
 }
 
 /// Fill a descriptor owner after the built-in type registry is published.
+///
+/// Two remembered-set notifications, because the descriptor can be either
+/// shape: the prebuilt-family bit covers a descriptor that predates the
+/// managed-allocation hooks and so fell back to `malloc_typed`, and the write
+/// barrier covers the ordinary `allocate_stable` case, where an old descriptor
+/// gaining a young or unmarked `w_cls` must re-enter the collector's worklist.
 pub unsafe fn w_member_set_cls(obj: PyObjectRef, w_cls: PyObjectRef) {
     crate::gc_roots::mark_prebuilt_roots_dirty();
+    crate::gc_hook::try_gc_write_barrier(obj as *mut u8);
     unsafe { (*(obj as *mut W_MemberDescr)).w_cls = w_cls }
 }
 


### PR DESCRIPTION
Five commits on `origin/main`, in two groups.

## GC

**`gc: spread the address hash into the control byte`**

`AddressHasher` reproduced `mangle_hash` (`rpython/memory/support.py:10-14`)
exactly, which is right for the container it was written for: `lldict` reuses
`rdict`, which consumes a hash only as a bucket index, and the xor-shift exists so
an aligned address's zero *trailing* bits do not pile every key into one bucket.

`HashMap`/`HashSet` read the hash a second way — each entry also stores a control
byte taken from the top 7 bits, matched by SIMD before any key is compared. A heap
address leaves those bits zero and the xor-shift moves nothing into them, so every
entry carried the same control byte and a lookup that should have ended at the
control byte compared keys one by one. Multiplying by an odd constant spreads the
mangled value over the whole word; the low half still depends only on the low half,
so the bucket index keeps the mangled distribution. The old test asserted equality
with the bare `mangle_hash`, which is what held the defect in place.

**`typedef: allocate __slots__ member descriptors on the managed heap`**

`W_MemberDescr` was `allocate` (`malloc_typed`), so it sat outside the collector's
sweep set. Nothing recurses into such an object's GC children unless it is on a
frame or shadow root slot at collection time, and the marker sets GCFLAG_VISITED on
it without ever clearing it — from the second major collection on it is skipped and
`w_cls` is never re-marked.

A `__slots__` descriptor outlives the statement that created it, and `w_cls` is
then its only reference to the owning type. Observed before the change: a class
built inside a function with only `[C.x]` returned, then six collect/churn rounds,
reports `<member 'x' of 'r' objects>` — `r` is whichever string reused the swept
type's slot, and renaming the loop variable changes the reported name.
`__objclass__` on the same descriptor does not return.

This is the same defect #994 fixed for the pickler types; `W_MemberDescr` was the
remaining member of that family. Note it is a **silent wrong answer** with no crash
and no `GC BUG` line, so neither `gc_stress` nor the parity corpus can see it.

Bootstrap descriptors stay reachable: `walk_global_prebuilt_roots` ->
`walk_builtin_type_dicts_gc` forwards every builtin type-dict slot and runs
unconditionally on majors.

## Filesystem bytes at the boundaries

**`code: keep a code object's filename as filesystem bytes`**

`_imp._fix_co_filename(code, 'x\udcff.py')` raised `UnicodeEncodeError` where the
name is preserved exactly, because `co_filename` came from the compiler
dependency's `CodeObject::source_path`, a Rust `String`. That field is `C::Name`
(bound `AsRef<str>`) in the rev-pinned external `rustpython-compiler-core`, so it
cannot carry the bytes.

`pycode.py:135-136` does not keep the filename as text either: it holds
`co_filename` as raw filesystem bytes and derives `w_filename` from them with
`space.newfilename` (`objspace.py:438 fsdecode(newbytes(s))`). Carry the same bytes
on pyre's own `PyCode`, the way `co_firstlineno_raw` already carries a value
`CodeObject` cannot represent; a null field means `source_path` is already the
exact spelling, so the ordinary UTF-8 path allocates nothing.
`interp_imp.py:157 pathname='fsencode'` and `pycode.py:431 filename='fsencode'`
give `_fix_co_filename`, the `CodeType` constructor and `replace()` their encoder.

`importing.py:379-391 update_code_filenames` recurses into nested code constants
under an `oldname` guard. Pyre realizes that list lazily, so already-realized
nested wrappers are updated in place and unrealized constants inherit when boxed;
a filename supplied to the constructor or to `replace()` does not propagate.

The derived `w_filename` cache from `pycode.py:136` is deliberately **not** added:
`PyCode` is prebuilt-immortal, and an unrooted movable child on such an object is
exactly the latch the second commit fixes.

**`posix, socket: hand three OS boundaries the filesystem encoding`** and
**`socket: read an interface name as an OS string, and take the fsencode
converter's argument range`**

`os.system`, the `posix_spawn` argv/envp entries, the AF_UNIX address and
`if_nametoindex` carried their argument through `str_utf8_w`, so a name spelling a
byte with no UTF-8 form was refused with `UnicodeEncodeError` instead of reaching
the OS. Upstream encodes all of them: `interp_posix.py:815 command='fsencode'`,
`interp_posix.py:1742 [space.fsencode_w(w_arg) for w_arg in args_w]`,
`interp_socket.py:157-159 space.fsencode(w_address)`; `if_nametoindex` has no PyPy
counterpart and `socketmodule.c` reads it with `PyUnicode_FSConverter`. The
encoder used here performs no embedded-null check, which is what the AF_UNIX site
needs, per the upstream note that it avoids `fsencode_w` because Linux allows a NUL
in an abstract-namespace path.

`gateway.py:365` unwraps `'fsencode'` with `space.fsencode_w`, whose job is the
str/bytes/`__fspath__` dispatch, so the `is_str` guards in front of the converter
are dropped too.

### What was checked and left alone

A census of all 51 `str_utf8_w(` call sites under `pyre/pyre-interpreter/src/module/`
found only these reaching an OS boundary with an upstream fsencode. Verified to
already match PyPy and therefore untouched: `_posixshmem.shm_open`/`shm_unlink`
(`lib_pypy/_posixshmem.py:10,30` `path.encode("utf-8")`), `posix.initgroups`
(`interp_posix.py:2137 username='text'`), `putenv`/`unsetenv`
(`interp_posix.py:1015,1037 'text'`), `_multiprocessing.SemLock` name
(`interp_semaphore.py:572 name='text'`), `pwd.getpwnam`
(`interp_pwd.py:110 'text0'`), and the `_socket` protocol-name lookups, whose host
arguments go through idna (`interp_func.py:28-30`) — a separate question.

`socket.sethostname` is the one site `interp_func.py:405-408` fsencodes that is
**not** fixed here: `host_env::socket::sethostname` takes a `&str`, so bytes have
nowhere to travel. A comment at the site records this, and the seam is fixed
upstream in RustPython/RustPython#8437.

## Verification

- both `__slots__`-descriptor reproductions and all four pickler holder variants
  (instance attribute / module global / list / frame local) pass
- `cargo test --release -p pyre-jit --test gc_stress`: 23/23
- all 140 parity-corpus programs run clean; a byte-comparison against the
  pre-change binary showed the only differences were the two new tests
- both new tests were validated against CPython first, and fail on the pre-change
  binary with the `UnicodeEncodeError` they are written to catch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved filesystem-encoding support for non-UTF-8 filenames and paths.
  * `os.system`, POSIX process spawning, Unix sockets, and network interface lookups now better handle bytes, path-like values, and surrogate-escaped names.
  * Code objects preserve and propagate non-UTF-8 filenames more reliably, including nested code and `code.replace()` scenarios.

* **Bug Fixes**
  * Improved replay handling for optimized pure operations.
  * Enhanced hash distribution for aligned heap addresses.

* **Tests**
  * Added coverage for filename handling and operating-system boundary behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->