### PR TITLE
jit(#346): rtyper-prepass census reduction batch (foreign externals + front-end lowering)

### DIFF
--- a/majit/majit-charon-reader/src/ullbc.rs
+++ b/majit/majit-charon-reader/src/ullbc.rs
@@ -336,7 +336,21 @@ impl ItemMeta {
                 out.push_str("::");
             }
             match seg {
-                NameSeg::Ident { ident: (s, _) } => out.push_str(s),
+                NameSeg::Ident {
+                    ident: (s, disambiguator),
+                } => {
+                    out.push_str(s);
+                    // Multiple anonymous closures in one function all
+                    // carry the bare segment `closure`; only the
+                    // disambiguator index distinguishes them.  Keep it
+                    // (as `closure#N`) so co-located closure envs mint
+                    // distinct ClassDefs instead of collapsing their
+                    // captured `__pos_N` fields onto one shared row.
+                    if s == "closure" && *disambiguator > 0 {
+                        out.push('#');
+                        out.push_str(&disambiguator.to_string());
+                    }
+                }
                 NameSeg::Other(v) => {
                     let label = v
                         .as_object()
@@ -350,6 +364,13 @@ impl ItemMeta {
         }
         out
     }
+}
+
+/// Whether a struct-root leaf names a closure env — the bare `closure`
+/// or a disambiguated `closure#N` (see [`ItemMeta::name_path`]).  Leaf
+/// checks that special-case closures must accept both spellings.
+pub fn is_closure_leaf(leaf: &str) -> bool {
+    leaf == "closure" || leaf.starts_with("closure#")
 }
 
 #[derive(Debug, Deserialize)]

--- a/majit/majit-translate/src/annotator/bookkeeper.rs
+++ b/majit/majit-translate/src/annotator/bookkeeper.rs
@@ -2467,8 +2467,11 @@ impl Bookkeeper {
             .trim_start_matches("*mut ")
             .trim();
         match stripped {
-            "i8" | "i16" | "i32" | "i64" | "isize" | "u8" | "u16" | "u32" | "u64" | "usize" => {
+            "i8" | "i16" | "i32" | "i64" | "isize" => {
                 return super::model::s_int();
+            }
+            "u8" | "u16" | "u32" | "u64" | "usize" => {
+                return super::model::s_uint();
             }
             "f32" => return SomeValue::SingleFloat(super::model::SomeSingleFloat::new()),
             "f64" => return SomeValue::Float(super::model::SomeFloat::new()),

--- a/majit/majit-translate/src/annotator/model.rs
+++ b/majit/majit-translate/src/annotator/model.rs
@@ -3269,6 +3269,28 @@ pub fn union(s1: &SomeValue, s2: &SomeValue) -> Result<SomeValue, UnionError> {
             )))
         }
 
+        // A classdef-less top instance — pyre's erased "top reference",
+        // e.g. a `&Foo` input whose Ref target `valuetype_to_someshell`
+        // dropped to `SomeInstance(None)` — absorbs an opaque low-level
+        // pointer denoting the same erased reference.  The Ref input
+        // lifts inconsistently (classdef-less `SomeInstance` on one CFG
+        // edge, `SomePtr` on another) and merges at `mergeinputargs`;
+        // both are type-erased pointers, so the union is the classdef-
+        // less top — the same result as the `_ => None` special case
+        // above where a classdef-less instance absorbs any instance.  A
+        // classdef-BEARING instance ∪ `Ptr` stays genuinely incompatible
+        // and falls through to the loud default.
+        (SomeValue::Instance(inst), SomeValue::Ptr(_))
+        | (SomeValue::Ptr(_), SomeValue::Instance(inst))
+            if inst.classdef.is_none() =>
+        {
+            Ok(SomeValue::Instance(SomeInstance::new(
+                None,
+                inst.can_be_none,
+                std::collections::BTreeMap::new(),
+            )))
+        }
+
         // binaryop.py forwards exception/instance and exception/None
         // through `SomeException.as_SomeInstance()`.
         (SomeValue::Exception(exc), SomeValue::Instance(inst)) => {

--- a/majit/majit-translate/src/annotator/model.rs
+++ b/majit/majit-translate/src/annotator/model.rs
@@ -2860,6 +2860,15 @@ pub(crate) fn s_int() -> SomeValue {
     SomeValue::Integer(SomeInteger::default())
 }
 
+/// `SomeInteger(unsigned=True)` — an r_uint value, the shell an unsigned
+/// scalar (`u8`..`u64`, `usize`) carries.  Matches `valuetype_to_someshell`'s
+/// `ValueType::Unsigned` projection so the string- and TyRef-derived field
+/// seeds agree; a signed shell here walls `r_uint ∪ int` when the write side
+/// keeps the unsigned knowntype.
+pub(crate) fn s_uint() -> SomeValue {
+    SomeValue::Integer(SomeInteger::new(false, true))
+}
+
 /// RPython `s_Str0 = SomeString(no_nul=True)` (model.py:693).
 pub(crate) fn s_str0() -> SomeValue {
     SomeValue::String(SomeString::new(false, true))

--- a/majit/majit-translate/src/annotator/model.rs
+++ b/majit/majit-translate/src/annotator/model.rs
@@ -209,6 +209,37 @@ pub fn commonbase(cls1: KnownType, cls2: KnownType) -> KnownType {
     }
 }
 
+/// True when two `ClassDef` name strings denote ONE struct reached by two
+/// frontend name spellings: a dot-joined crate-included constructor qualname
+/// (`pyre_object.celldict.VersionTag`, the flowspace_adapter
+/// `SyntheticTransparentCtor` arm) vs the crate-stripped `::` field-read
+/// spelling (`celldict::VersionTag`).  Pyre has no single class object to key
+/// identity on, so a non-header leaf struct minted from both spellings becomes
+/// two distinct base-less `ClassDef`s and `ClassDef::commonbase` finds no
+/// shared base — the union then fails "no common base class" even though it is
+/// one type.  Reduce the dotted crate-included spelling to the crate-stripped
+/// `::` form (the spelling `canonical_struct_name` already yields for the
+/// field-read side) and compare.
+///
+/// Deliberately a COMPARE-time identity, NOT an interning cache key: keying
+/// `pyre_struct_root_classes` on this collapse starves the header/base-chain
+/// walk for `ob_header`-bearing `W_*` structs (they mint base-less under
+/// first-mint-wins and lose their `W_Root` base — a measured +184 phaseA
+/// cascade across `_io`/`_pickle`).  This check fires only where
+/// `commonbase` is already None, which the base-bearing `W_*` structs never
+/// reach (they share `W_Root`), so it cannot perturb them.
+fn same_struct_identity(a: &str, b: &str) -> bool {
+    fn identity(name: &str) -> String {
+        if !name.contains("::") && !name.contains('<') && name.contains('.') {
+            if let Some((_crate, rest)) = name.split_once('.') {
+                return rest.replace('.', "::");
+            }
+        }
+        majit_ir::descr::canonical_struct_name(name)
+    }
+    identity(a) == identity(b)
+}
+
 // ---------------------------------------------------------------------------
 // SomeObject base — RPython `model.py:51-125`.
 // ---------------------------------------------------------------------------
@@ -3246,6 +3277,14 @@ pub fn union(s1: &SomeValue, s2: &SomeValue) -> Result<SomeValue, UnionError> {
             let merged_classdef = match (&a.classdef, &b.classdef) {
                 (Some(ca), Some(cb)) => match ClassDef::commonbase(ca, cb) {
                     Some(base) => Some(base),
+                    None if same_struct_identity(&ca.borrow().name, &cb.borrow().name) => {
+                        // One struct reached by two frontend name spellings
+                        // (dot-joined crate-included ctor qualname vs the
+                        // crate-stripped `::` field-read spelling): two
+                        // base-less leaves with no shared base but the same
+                        // canonical identity.  Unify to the lhs class.
+                        Some(ca.clone())
+                    }
                     None => {
                         // Name the two colliding classdefs so the
                         // skip-classified panic path is diagnosable

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -15212,7 +15212,10 @@ fn adt_path_of_tyref(ty: &TyRef, llbc: &Llbc) -> Option<String> {
 /// its `self.<capture>` reads would wall on.  RPython forbids closures.
 fn tyref_input_class_root(ty: &TyRef, llbc: &Llbc) -> Option<String> {
     let leaf = tyref_class_root(ty, llbc);
-    if leaf.as_deref().is_some_and(majit_charon_reader::ullbc::is_closure_leaf) {
+    if leaf
+        .as_deref()
+        .is_some_and(majit_charon_reader::ullbc::is_closure_leaf)
+    {
         adt_path_of_tyref(ty, llbc).or(leaf)
     } else {
         leaf

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -15189,7 +15189,7 @@ fn adt_path_of_tyref(ty: &TyRef, llbc: &Llbc) -> Option<String> {
 /// its `self.<capture>` reads would wall on.  RPython forbids closures.
 fn tyref_input_class_root(ty: &TyRef, llbc: &Llbc) -> Option<String> {
     let leaf = tyref_class_root(ty, llbc);
-    if leaf.as_deref() == Some("closure") {
+    if leaf.as_deref().is_some_and(majit_charon_reader::ullbc::is_closure_leaf) {
         adt_path_of_tyref(ty, llbc).or(leaf)
     } else {
         leaf

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -1293,8 +1293,17 @@ fn tuple_field_value_type(type_name: &str) -> ValueType {
         // kind rather than collapsing into `Int` like the word-sized integers.
         "i128" => ValueType::Int128,
         "u128" => ValueType::UInt128,
-        "bool" | "char" | "f32" | "i8" | "i16" | "i32" | "i64" | "isize" | "u8" | "u16" | "u32"
-        | "u64" | "usize" => ValueType::Int,
+        "bool" | "char" | "f32" | "i8" | "i16" | "i32" | "i64" | "isize" => ValueType::Int,
+        // A `u*` element shells to an unsigned `SomeInteger`
+        // (`valuetype_to_someshell(Unsigned)`), so an `r_uint` tuple element
+        // reconciles with the FORCE_ATTRIBUTES seed instead of walling
+        // `r_uint ∪ int`. Same register kind as `Int` (`getkind` = 'int').
+        "u8" | "u16" | "u32" | "u64" | "usize" => ValueType::Unsigned,
+        // A str-family element shells to `SomeString`
+        // (`valuetype_to_someshell(Str)`) rather than the classdef-less
+        // `Ref(None)` instance that walled `str ∪ Instance(classdef-less)`.
+        // `Str` is register kind 'ref'/`GcRef` downstream, identical to `Ref`.
+        "String" | "str" | "Wtf8" | "Wtf8Buf" => ValueType::Str,
         _ => ValueType::Ref(None),
     }
 }

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -7185,15 +7185,15 @@ impl<'a> Lowering<'a> {
                     self.graph.set_goto(bb_id, target_bb, link_args);
                     return Ok(());
                 }
-                // `RBigInt::digits{,_mut}` is Rust's view adapter around the
-                // RPython `_digits` GcArray:
-                // `slice::from_raw_parts(typed_items_base(_digits), capacity)`.
-                // The typed-items base call above already aliases the header
-                // pointer so the gcarray descr re-applies `base_size`; the
-                // resulting slice is therefore the same array value in the
-                // translated model. Fold only these two enclosing accessors,
-                // not arbitrary raw slices.
-                if args.len() == 2 && self.is_rbigint_digits_from_raw_parts(&reg) {
+                // `RBigInt::digits{,_mut}` and `W_ListObject::object_items_slice
+                // {,_mut}` are Rust view adapters around an `ItemsBlock` /
+                // typed-items GcArray:
+                // `slice::from_raw_parts(items_base(block), len)`.  The items-base
+                // call above already aliases the header pointer so the gcarray
+                // descr re-applies `base_size`; the resulting slice is therefore
+                // the same array value in the translated model. Fold only these
+                // enclosing accessors, not arbitrary raw slices.
+                if args.len() == 2 && self.is_container_items_view_from_raw_parts(&reg) {
                     self.local_var[dest_local] = Some(args[0].clone());
                     let target_bb = self.block_id[target];
                     let link_args = self.edge_args(mir_bb, target)?;
@@ -9507,12 +9507,26 @@ impl<'a> Lowering<'a> {
             && regular_call_is_ptr_add(reg, self.llbc)
     }
 
-    /// `slice::from_raw_parts{,_mut}` in `RBigInt::digits{,_mut}` only.
-    /// RPython stores `_digits` as the array itself; the Rust slice is a
-    /// zero-copy source adapter and aliases that same translated GcArray.
-    fn is_rbigint_digits_from_raw_parts(&self, reg: &RegularCall) -> bool {
+    /// `slice::from_raw_parts{,_mut}` inside a container's items-view adapter:
+    /// `RBigInt::digits{,_mut}` and `W_ListObject::object_items_slice{,_mut}`.
+    /// The base argument is an `items_block_items_base` / typed-items accessor,
+    /// already aliased to the block header (`graph_is_items_block_base_accessor`)
+    /// so the object/digit gcarray descr re-applies `base_size`; the resulting
+    /// slice is that same array value in the translated model.  Both back an
+    /// `ItemsBlock`, whose consumers index through a descr (the offset-mediated
+    /// case), so the receiver alias is sound.  Fold only these enclosing
+    /// accessors, not arbitrary raw slices.
+    fn is_container_items_view_from_raw_parts(&self, reg: &RegularCall) -> bool {
         if !(self.graph.name.ends_with("rbigint::<Impl>::digits")
-            || self.graph.name.ends_with("rbigint::<Impl>::digits_mut"))
+            || self.graph.name.ends_with("rbigint::<Impl>::digits_mut")
+            || self
+                .graph
+                .name
+                .ends_with("listobject::<Impl>::object_items_slice")
+            || self
+                .graph
+                .name
+                .ends_with("listobject::<Impl>::object_items_slice_mut"))
         {
             return false;
         }

--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -1935,6 +1935,30 @@ pub(crate) fn populate_call_registry_from_call_graphs(
     // `RPythonAnnotator` (`bookkeeper.annotator()` panics with
     // "backlink absent or dropped") only pay the lookup on the
     // failure path; success paths remain unaffected.
+    //
+    // Pre-pass — project each callee's declared LLBC fn-ptr signature onto
+    // its entry BEFORE any body is lifted.  The fn-const materialisation
+    // fallback (`flowspace_adapter::translate_op`) reads this to type an
+    // address-taken JIT-dead method-table entry whose pygraph is lifted but
+    // not yet rtyped: at populate time nothing is rtyped, so `getfunctionptr`
+    // (which walks the callee's args for their `concretetype`, all `None`)
+    // fails on every fn-const and, absent this, poisons every attr-lookup
+    // caller.  Runs ahead of the lift loop so a caller lifted early still
+    // sees a later callee's declared type.  A non-projectable signature
+    // leaves the slot `None` — the fallback declines and the site fails
+    // closed exactly as before.
+    {
+        let mut seeded: HashSet<*const PyreFunctionEntry> =
+            HashSet::with_capacity(by_canonical_path.len());
+        for (_key, graph, entry, _signature) in &pending {
+            if !seeded.insert(Rc::as_ptr(entry)) {
+                continue;
+            }
+            if let Some(ft) = declared_funcptr_type_from_legacy(graph) {
+                entry.set_declared_funcptr_type(ft);
+            }
+        }
+    }
     for (_key, graph, entry, signature) in &pending {
         let entry_ptr = Rc::as_ptr(entry);
         if !lifted.insert(entry_ptr) {
@@ -2299,8 +2323,19 @@ pub(crate) fn residual_return_shell(
             .expect("Ref(None) shells to a definite SomeInstance"),
         );
     }
-    let return_lltype = match token {
+    return_token_to_lltype(token).and_then(|ll| default_someshell_for_lltype(&ll))
+}
+
+/// Project a FUNC.RESULT token (the `return_type` string) to its
+/// `LowLevelType`.  `None`/`"()"` → `Void`; `"ref"` and the `*mut PyObject`
+/// token → `OBJECTPTR`; primitive tokens map directly; unrecognised → `None`
+/// (decline).  `i128`/`u128` have no token spelling here and so decline for
+/// the same `getkind`-at-the-codewriter reason [`residual_return_shell`]
+/// documents.
+fn return_token_to_lltype(token: Option<&str>) -> Option<LowLevelType> {
+    match token {
         None | Some("()") => Some(LowLevelType::Void),
+        Some("ref") => Some(crate::translator::rtyper::rclass::OBJECTPTR.clone()),
         Some("bool") => Some(LowLevelType::Bool),
         Some("i64") => Some(LowLevelType::Signed),
         Some("u64") => Some(LowLevelType::Unsigned),
@@ -2309,8 +2344,57 @@ pub(crate) fn residual_return_shell(
             Some(crate::translator::rtyper::rclass::OBJECTPTR.clone())
         }
         _ => None,
-    };
-    return_lltype.and_then(|ll| default_someshell_for_lltype(&ll))
+    }
+}
+
+/// Project a MIR `ValueType` to its rtyped `LowLevelType`, mirroring the
+/// rtyper's lowering of the `valuetype_to_someshell` annotation shell:
+/// `Str` → the string pointer, `Ref`/`State` → the erased object pointer
+/// (`OBJECTPTR`, what a classdef-less `SomeInstance` rtypes to), `Unknown`
+/// declines.  Used to build a callee's declared fn-ptr arg signature.
+fn valuetype_to_lltype(vt: &crate::model::ValueType) -> Option<LowLevelType> {
+    use crate::model::ValueType;
+    Some(match vt {
+        ValueType::Int => LowLevelType::Signed,
+        ValueType::Unsigned => LowLevelType::Unsigned,
+        ValueType::Int128 => LowLevelType::SignedLongLongLong,
+        ValueType::UInt128 => LowLevelType::UnsignedLongLongLong,
+        ValueType::Bool => LowLevelType::Bool,
+        ValueType::Float => LowLevelType::Float,
+        ValueType::Str => crate::translator::rtyper::lltypesystem::rstr::STRPTR.clone(),
+        ValueType::Ref(_) | ValueType::State => {
+            crate::translator::rtyper::rclass::OBJECTPTR.clone()
+        }
+        ValueType::Void => LowLevelType::Void,
+        ValueType::Unknown => return None,
+    })
+}
+
+/// Project a callee's declared fn-ptr `FuncType` from its `FunctionGraph`
+/// startblock `Input` ValueTypes (in `inputargs` order) + return token,
+/// mirroring `derive_subject_inputcells`'s startblock reading.  Returns
+/// `None` if any arg lacks a startblock `Input` op or an unprojectable
+/// ValueType, or the return token is unrecognised — the fn-const
+/// materialisation fallback then declines (fail-closed).
+fn declared_funcptr_type_from_legacy(
+    legacy: &LegacyGraph,
+) -> Option<crate::translator::rtyper::lltypesystem::lltype::FuncType> {
+    use crate::model::OpKind;
+    let startblock = legacy.blocks.iter().find(|b| b.id == legacy.startblock)?;
+    let mut input_ty: HashMap<crate::flowspace::model::Variable, &crate::model::ValueType> =
+        HashMap::new();
+    for op in &startblock.operations {
+        if let (Some(result), OpKind::Input { ty, .. }) = (op.result.as_ref(), &op.kind) {
+            input_ty.insert(result.clone(), ty);
+        }
+    }
+    let mut args = Vec::with_capacity(startblock.inputargs.len());
+    for var in &startblock.inputargs {
+        let ty = input_ty.get(var)?;
+        args.push(valuetype_to_lltype(ty)?);
+    }
+    let result = return_token_to_lltype(legacy.return_type.as_deref())?;
+    Some(crate::translator::rtyper::lltypesystem::lltype::FuncType { args, result })
 }
 
 /// Register a batch of unsafe-fn stub

--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -2557,6 +2557,15 @@ const FOREIGN_STDLIB_EXTERNALS: &[(&[&str], &[&str], LowLevelType)] = &[
         &["self", "val"],
         LowLevelType::Void,
     ),
+    // `usize::saturating_mul(self, rhs) -> usize` clamps the product at the
+    // type max.  The residual computes the clamped product; only the
+    // `Unsigned` scalar result is modeled.  The census uses are all `usize`
+    // capacity/count growth (`IntArray`/`FloatArray::grow`, `deque_repeat`).
+    (
+        &["core", "num", "<Impl>", "saturating_mul"],
+        &["self", "rhs"],
+        LowLevelType::Unsigned,
+    ),
     (
         &["core", "f64", "<Impl>", "is_infinite"],
         &["self"],

--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -2436,6 +2436,9 @@ const FOREIGN_STDLIB_EXTERNALS: &[(&[&str], &[&str], LowLevelType)] = &[
     // does not model destructors (the `Drop` terminator lowers to a
     // pass-through `Goto`), so a Void no-op stub is faithful.
     (&["core", "mem", "drop"], &["x"], LowLevelType::Void),
+    // `mem::forget(x)` consumes `x` without running its destructor and returns
+    // `()`; same Void no-op shape as `mem::drop`.
+    (&["core", "mem", "forget"], &["x"], LowLevelType::Void),
     // `mem::size_of::<T>() -> usize`.  A concrete-type call is folded to a
     // `ConstInt` in the front end (`Lowering::lower_call` /
     // `size_align_const_from_tyexpr`); the residual reaching the rtyper is the
@@ -2461,6 +2464,11 @@ const FOREIGN_STDLIB_EXTERNALS: &[(&[&str], &[&str], LowLevelType)] = &[
         LowLevelType::Void,
     ),
     (
+        &["sync", "atomic", "AtomicU8", "store"],
+        &["self", "val", "order"],
+        LowLevelType::Void,
+    ),
+    (
         &["cell", "Cell", "set"],
         &["self", "val"],
         LowLevelType::Void,
@@ -2477,6 +2485,11 @@ const FOREIGN_STDLIB_EXTERNALS: &[(&[&str], &[&str], LowLevelType)] = &[
     ),
     (
         &["std", "f64", "<Impl>", "floor"],
+        &["self"],
+        LowLevelType::Float,
+    ),
+    (
+        &["std", "f64", "<Impl>", "ceil"],
         &["self"],
         LowLevelType::Float,
     ),

--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -2567,6 +2567,16 @@ const FOREIGN_STDLIB_EXTERNALS: &[(&[&str], &[&str], LowLevelType)] = &[
         &["self"],
         LowLevelType::Bool,
     ),
+    // `<[T]>::contains(&self, x: &T) -> bool` scans the slice for an element
+    // equal to `*x`.  Bool scalar result; the receiver is a slice value (same
+    // shape `is_empty` already residualises) and `x` is a by-reference operand,
+    // both passed through to the residual call.  The membership scan runs in
+    // the residual, so no element `PartialEq` graph is demanded here.
+    (
+        &["core", "slice", "<Impl>", "contains"],
+        &["self", "x"],
+        LowLevelType::Bool,
+    ),
     (
         &["std", "f64", "<Impl>", "floor"],
         &["self"],

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -2309,7 +2309,7 @@ pub fn translate_op(
                             // (`tyref_input_class_root`) derives.  RPython
                             // forbids closures.
                             let colon_qual = format!("{owner_qual}::{name}");
-                            let is_closure_root = name == "closure"
+                            let is_closure_root = majit_charon_reader::ullbc::is_closure_leaf(name)
                                 && bk
                                     .pyre_struct_fields
                                     .borrow()

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -2822,23 +2822,64 @@ fn legacy_const_define_hlvalue(
                     key.segments()
                 ))
             })?;
-            if let Some(err) = entry.pyre_lift_error() {
-                return Err(TyperError::message(format!(
-                    "fn const {:?} resolved to an unbuildable callee: {err}",
-                    key.segments()
-                )));
-            }
+            // A fn-const is address-taken data for a static method table
+            // (`typedef` `[(name, fn, arity)]`).  Its LL carrier is
+            // unconditionally `ConstInt(fnaddr)` (the const-define arm below),
+            // it is never JIT-called in the compiled portal, so the `FuncType`
+            // is pure typing bookkeeping with no machine-code channel.  Taking
+            // the address does NOT need the callee's body — only its declared
+            // signature.  Three populate-time realities block the precise
+            // `getfunctionptr`, and all three fall back to the callee's
+            // DECLARED LLBC signature (projected at the populate pre-pass; same
+            // fidelity class as `FOREIGN_STDLIB_EXTERNALS`) so the caller's
+            // lift succeeds instead of recording a lazy-failure that poisons
+            // every attr-lookup caller:
+            //   1. no graph is rtyped yet (every arg `concretetype` is `None`);
+            //   2. the callee is not lifted yet (registry-population order),
+            //      so its pygraph is not cached;
+            //   3. the callee's BODY does not lift — e.g. an unregistered
+            //      iterator/container adapter, a separate front-lowering gap
+            //      (#65).  The address is still valid; only JIT-compiling the
+            //      body is blocked, and this entry is never JIT-called.
+            // A callee whose signature is not fully projectable leaves the slot
+            // `None`; the site then fails closed with the most specific
+            // diagnosis, exactly as before.
+            use crate::translator::rtyper::lltypesystem::lltype;
+            let lift_error = entry.pyre_lift_error();
             let graphs = entry.function_desc.borrow().getgraphs();
-            let graph = graphs.into_iter().next().ok_or_else(|| {
-                TyperError::message(format!(
-                    "fn const {:?} resolved to a registry entry without a cached graph",
-                    key.segments()
-                ))
-            })?;
-            let func_ptr = crate::translator::rtyper::lltypesystem::lltype::getfunctionptr(
-                &graph.graph,
-                crate::translator::rtyper::lltypesystem::lltype::_getconcretetype,
-            )?;
+            let maybe_graph = graphs.into_iter().next();
+            // Precise fn-ptr only when the callee is lifted (cached graph, no
+            // recorded lift error) AND rtyped; every other case routes to the
+            // declared-signature fallback below.
+            let precise = match (&maybe_graph, &lift_error) {
+                (Some(graph), None) => {
+                    lltype::getfunctionptr(&graph.graph, lltype::_getconcretetype).ok()
+                }
+                _ => None,
+            };
+            let func_ptr = match precise {
+                Some(func_ptr) => func_ptr,
+                None => match entry.declared_funcptr_type() {
+                    // Keep the graph backlink when a pygraph is cached;
+                    // otherwise the declared signature alone types the entry.
+                    Some(ft) => match &maybe_graph {
+                        Some(graph) => lltype::functionptr_for_graph_with_type(&graph.graph, ft),
+                        None => lltype::functionptr(ft, &key.segments().join("::"), None, None),
+                    },
+                    None => {
+                        return Err(TyperError::message(match lift_error {
+                            Some(err) => format!(
+                                "fn const {:?} resolved to an unbuildable callee: {err}",
+                                key.segments()
+                            ),
+                            None => format!(
+                                "fn const {:?} resolved to a registry entry without a cached graph",
+                                key.segments()
+                            ),
+                        }));
+                    }
+                },
+            };
             let func_ptr_type = crate::translator::rtyper::lltypesystem::lltype::LowLevelType::Ptr(
                 Box::new(func_ptr._TYPE.clone()),
             );

--- a/majit/majit-translate/src/translator/rtyper/lltypesystem/lltype.rs
+++ b/majit/majit-translate/src/translator/rtyper/lltypesystem/lltype.rs
@@ -5939,16 +5939,35 @@ pub fn getfunctionptr<F>(graph: &GraphRef, getconcretetype: F) -> Result<_ptr, T
 where
     F: Fn(&Hlvalue) -> Result<ConcretetypePlaceholder, TyperError>,
 {
-    let graph_b = graph.borrow();
-    let mut llinputs = Vec::new();
-    for arg in graph_b.getargs() {
-        llinputs.push(getconcretetype(&arg)?);
-    }
-    let lloutput = getconcretetype(&graph_b.getreturnvar())?;
-    let ft = FuncType {
-        args: llinputs,
-        result: lloutput,
+    let ft = {
+        let graph_b = graph.borrow();
+        let mut llinputs = Vec::new();
+        for arg in graph_b.getargs() {
+            llinputs.push(getconcretetype(&arg)?);
+        }
+        let lloutput = getconcretetype(&graph_b.getreturnvar())?;
+        FuncType {
+            args: llinputs,
+            result: lloutput,
+        }
     };
+    Ok(functionptr_for_graph_with_type(graph, ft))
+}
+
+/// Build a function pointer for `graph` from an explicitly supplied
+/// `FuncType` instead of walking the graph's args for their (possibly
+/// not-yet-assigned) concretetypes.
+///
+/// [`getfunctionptr`] delegates here after deriving the `FuncType` from
+/// the rtyped args; the fn-const materialisation fallback
+/// (`flowspace_adapter::translate_op`) calls this directly with the
+/// callee's DECLARED LLBC signature when the callee's pygraph is lifted
+/// but not yet rtyped (populate-time, before Phase B), where every arg's
+/// `concretetype` is still `None`.  The name / `_callable` / attrs /
+/// graph-backlink are resolved identically to `getfunctionptr`, so the
+/// pointer differs from a rtyped one only in the arg/result placeholders.
+pub fn functionptr_for_graph_with_type(graph: &GraphRef, TYPE: FuncType) -> _ptr {
+    let graph_b = graph.borrow();
     let mut name = graph_b.name.clone();
     let mut callable = graph_b.func.as_ref().map(|func| func.name.clone());
     let mut attrs = HashMap::new();
@@ -5970,13 +5989,13 @@ where
         }
     }
     drop(graph_b);
-    Ok(functionptr_with_attrs(
-        ft,
+    functionptr_with_attrs(
+        TYPE,
         &name,
         Some(GraphKey::of(graph).as_usize()),
         callable,
         attrs,
-    ))
+    )
 }
 
 /// RPython `class SomePtr(SomeObject)` (lltype.py:1520-1528).

--- a/majit/majit-translate/src/translator/rtyper/pyre_call_registry.rs
+++ b/majit/majit-translate/src/translator/rtyper/pyre_call_registry.rs
@@ -112,6 +112,20 @@ impl FunctionPathKey {
 pub struct PyreFunctionEntry {
     pub host_object: HostObject,
     pub function_desc: Rc<RefCell<FunctionDesc>>,
+    /// Declared LLBC fn-ptr signature, projected once at registry
+    /// population from the callee's `FunctionGraph` startblock `Input`
+    /// ValueTypes + return token.  Read by the fn-const materialisation
+    /// fallback in `flowspace_adapter::translate_op`: at populate time no
+    /// graph is rtyped yet, so `getfunctionptr` (which walks the callee's
+    /// args for their `concretetype`, all `None`) fails on every fn-const.
+    /// The declared signature lets an address-taken JIT-dead method-table
+    /// entry materialise its fn-ptr from its faithful Rust signature (the
+    /// same fidelity class as `FOREIGN_STDLIB_EXTERNALS`) instead of
+    /// poisoning every attr-lookup caller.  `None` when the signature is
+    /// not fully projectable — the fallback then declines and the site
+    /// fails closed exactly as before.
+    pub declared_funcptr_type:
+        RefCell<Option<crate::translator::rtyper::lltypesystem::lltype::FuncType>>,
 }
 
 impl PyreFunctionEntry {
@@ -156,6 +170,23 @@ impl PyreFunctionEntry {
     /// would partial-codewrite with a pre-real residual kind.
     pub fn pyre_lift_error(&self) -> Option<String> {
         self.function_desc.borrow().pyre_lift_error_message()
+    }
+
+    /// Store the callee's declared LLBC fn-ptr signature (see
+    /// [`PyreFunctionEntry::declared_funcptr_type`]).
+    pub fn set_declared_funcptr_type(
+        &self,
+        ft: crate::translator::rtyper::lltypesystem::lltype::FuncType,
+    ) {
+        *self.declared_funcptr_type.borrow_mut() = Some(ft);
+    }
+
+    /// Read the callee's declared LLBC fn-ptr signature, if one was
+    /// projected at registry population.
+    pub fn declared_funcptr_type(
+        &self,
+    ) -> Option<crate::translator::rtyper::lltypesystem::lltype::FuncType> {
+        self.declared_funcptr_type.borrow().clone()
     }
 }
 
@@ -850,6 +881,7 @@ impl PyreCallRegistry {
         let entry = Rc::new(PyreFunctionEntry {
             host_object,
             function_desc,
+            declared_funcptr_type: RefCell::new(None),
         });
         self.entries.borrow_mut().insert(key, entry.clone());
         entry

--- a/majit/majit-translate/src/translator/rtyper/pyre_call_registry.rs
+++ b/majit/majit-translate/src/translator/rtyper/pyre_call_registry.rs
@@ -399,7 +399,9 @@ impl PyreCallRegistry {
             // `.`-joined class the receiver getattr resolves to.  RPython
             // forbids closures (`_assert_rpythonic`), so there is no
             // upstream analogue.
-            if owner == "closure" && matches!(method.as_str(), "call_once" | "call" | "call_mut") {
+            if majit_charon_reader::ullbc::is_closure_leaf(owner)
+                && matches!(method.as_str(), "call_once" | "call" | "call_mut")
+            {
                 let stripped = segs[..segs.len() - 1].join("::");
                 let Some(&reg_key) = full_by_stripped.get(stripped.as_str()) else {
                     continue;


### PR DESCRIPTION
## Summary

A batch of gh#346 rtyper-prepass census reductions: foreign-stdlib-external
registrations and front-end lowering/annotation fixes that let more interpreter
graphs annotate through the majit rtyper prepass. Rebased onto current `main`.

## Changes (per commit)

- **register `core::num::<Impl>::saturating_mul`** as a `usize→Unsigned` foreign
  stdlib external.
- **register `core::slice::<Impl>::contains`** as a foreign stdlib external.
- **fall back to the callee's declared LLBC signature** at fn-const
  materialisation (resolves a getattr_str_impl fptr cascade).
- **register `f64::ceil`, `AtomicU8::store`, `mem::forget`** as foreign stdlib
  externals.
- **fold `object_items_slice` `from_raw_parts`** to the items-block base.
- **seed tuple `u*` elements unsigned and str elements as `SomeString`** in the
  aggregate seeding path.
- **unify two front-end name spellings of one struct** at commonbase-None.
- **seed unsigned integer field-type strings as `r_uint`** in
  `project_pyre_field_type`.
- **disambiguate co-located closures** by their `name_path` index.
- **union a classdef-less top instance with an opaque pointer.**

## Verification

- `pyre/check.py --backend dynasm` and `--backend cranelift`: green (see PR checks).
- rtyper-prepass census (`PYRE_RTYPER_VERBOSE=1`) reduced by this batch; no new
  failing-graph classes introduced.

## Not included

The shared-`Option<&T>` niche-fold census lever (a further −26) is intentionally
excluded: it surfaces a dynasm-only GC stale-root crash (a gcmap frame-slot
liveness defect on the folded borrow) that is tracked separately and not yet
resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
