### PR TITLE
majit: run the force_finish_trace segmenting check at the merge point

### DIFF
--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -2616,7 +2616,7 @@ impl<S: JitState> JitDriver<S> {
         loop {
             // Phase 1: split-borrow self into meta and sym, run closure.
             // self.meta and self.sym are disjoint fields → standard split-borrow.
-            let mut action = {
+            let action = {
                 let Some(sym) = self.sym.as_mut() else {
                     crate::debug::log_one("jit-abort", "mp: abort:sym_none2");
                     self.meta.abort_trace(false);
@@ -2626,144 +2626,16 @@ impl<S: JitState> JitDriver<S> {
                 trace_fn(&mut self.meta, sym)
             }; // borrows dropped here
 
-            // pyjitpl.py:1618 force_finish_trace segmenting check.
-            //
-            // pyjitpl.py:1622 _create_segmented_trace_and_blackhole:
-            //   1. generate_guard(GUARD_ALWAYS_FAILS)
-            //   2. unreachable FINISH(exception_descr)
-            //   3. compile_simple_loop(patch_jumpop_at_end=False)  ← inserts Label
-            //   4. SwitchToBlackhole(ABORT_SEGMENTED_TRACE)
-            // pyjitpl.py:1618 force_finish_trace segmenting fallback.
-            // The proc-macro path handles this inside the closure (where __pc
-            // is captured). For non-macro consumers whose trace_fn doesn't
-            // emit SegmentedLoop, this fallback uses ctx.last_traced_pc
-            // (recorded by proc-macro or pyre trace_fn) as the guard-point pc.
-            if matches!(action, TraceAction::Continue) && self.meta.force_finish_trace {
-                let should_segment = self
-                    .meta
-                    .trace_ctx()
-                    .map(|ctx| ctx.num_ops() > ctx.trace_limit() * 4 / 5)
-                    .unwrap_or(false);
-                if should_segment {
-                    // RPython `pyjitpl.py:2558-2602 MetaInterp.generate_guard`
-                    // pairs every guard recording with `capture_resumedata`,
-                    // and segmenting itself is independent of whether the
-                    // sym-side framestack-lift override is wired:
-                    // `_create_segmented_trace_and_blackhole`
-                    // (`pyjitpl.py:1622`) always emits
-                    // `generate_guard(GUARD_ALWAYS_FAILS) + Finish +
-                    // SwitchToBlackhole`.  When
-                    // `JitState::populate_frame_for_guard` is overridden
-                    // (state-field-JIT macro consumers), pair the guard with
-                    // the bridge snapshot.
-                    //
-                    // TODO: when the default no-op
-                    // returns `None`, this low-level driver has no MIFrame
-                    // to walk — it only knows the active jump boxes from
-                    // `S::collect_jump_args`.  We feed those into
-                    // `capture_snapshot_for_last_guard`, which records a
-                    // single placeholder frame in lieu of the RPython
-                    // `framestack` walk (`pyjitpl.py:2586
-                    // capture_resumedata`).  Bounded scope: this branch is
-                    // only reached on the segmented-loop force path of the
-                    // low-level driver and dissolves once lifts
-                    // `S::Sym` into `MIFrame::populate_for_guard` so every
-                    // path captures uniformly via the framestack walk.
-                    let op_live = self.meta.staticdata.op_live as u8;
-                    let all_liveness = self.meta.staticdata.liveness_info.clone();
-                    // pyjitpl.py:2586 `capture_resumedata(framestack,
-                    // virtualizable_boxes, virtualref_boxes,
-                    // last_snapshot)` — pull the live box lists off the
-                    // active trace ctx before borrowing `self.meta.framestack`
-                    // mutably below.  Cloning is acceptable because this is
-                    // the segmented-loop force path (slow path).
-                    let (vable_boxes, vref_boxes) = self
-                        .meta
-                        .trace_ctx()
-                        .map(|ctx| {
-                            (
-                                ctx.virtualizable_boxes.clone().unwrap_or_default(),
-                                ctx.virtualref_boxes.clone(),
-                            )
-                        })
-                        .unwrap_or_default();
-                    let pre_snapshot = self.sym.as_ref().and_then(|sym| {
-                        S::populate_frame_for_guard(
-                            sym,
-                            &mut self.meta.framestack,
-                            op_live,
-                            &all_liveness,
-                            &vable_boxes,
-                            &vref_boxes,
-                        )
-                    });
-                    let mut current_live = self
-                        .sym
-                        .as_ref()
-                        .map(|sym| S::collect_jump_args(sym))
-                        .unwrap_or_default();
-                    // RPython `pyjitpl.py:2586 capture_resumedata` reads
-                    // `frame.jitcode.index` from the live framestack.  Pull
-                    // the same value here so the placeholder snapshot
-                    // captures real coordinates instead of `0`.
-                    let frame_jitcode_index = self
-                        .meta
-                        .framestack
-                        .frames
-                        .last()
-                        .map(|f| f.jitcode.index() as u32)
-                        .unwrap_or(0);
-                    if let Some(ctx) = self.meta.trace_ctx() {
-                        // pyjitpl.py:2594: use last_traced_pc
-                        // (= frame.pc at the guard point), not header_pc.
-                        let pc_opref = ctx.const_int(ctx.last_traced_pc as i64);
-                        current_live.push(pc_opref);
-                        // history.py:802 strict-types parity: every active
-                        // OpRef must resolve to a known Box.type; a miss is
-                        // a tracer bookkeeping bug, not a recoverable case.
-                        let live_types: Vec<majit_ir::Type> = current_live
-                            .iter()
-                            .map(|opref| {
-                                ctx.get_opref_type(*opref)
-                                    .expect("force_finish_trace: active OpRef missing Box.type")
-                            })
-                            .collect();
-                        let guard_opref = ctx.record_guard_typed(
-                            majit_ir::OpCode::GuardAlwaysFails,
-                            &[],
-                            live_types,
-                        );
-                        if let Some(snapshot) = pre_snapshot {
-                            let snapshot_id = ctx.capture_resumedata(snapshot);
-                            ctx.set_last_guard_resume_position(snapshot_id);
-                        } else {
-                            // TODO: see header comment.
-                            // No framestack-lift override available, so
-                            // capture the active low-level boxes via the
-                            // segmented-driver placeholder helper instead
-                            // of inventing a fail_args-only fallback.
-                            let frame_pc = ctx.last_traced_pc as u32;
-                            ctx.capture_snapshot_for_last_guard(
-                                &current_live,
-                                frame_jitcode_index,
-                                frame_pc,
-                            );
-                            ctx.set_fail_args(guard_opref, &current_live);
-                        }
-                        let dummy = ctx.const_int(0);
-                        ctx.record_finish(dummy, majit_ir::Type::Int);
-                        if crate::majit_log_enabled() {
-                            eprintln!(
-                                "[jit] force_finish_trace: segmenting at {} ops (limit {}) pc={}",
-                                ctx.num_ops(),
-                                ctx.trace_limit(),
-                                ctx.last_traced_pc
-                            );
-                        }
-                    }
-                    action = TraceAction::SegmentedLoop;
-                }
-            }
+            // pyjitpl.py:1617-1620 places the `force_finish_trace` segmenting
+            // check INSIDE the tracing loop, in `MIFrame.debug_merge_point`, so
+            // a JC_FORCE_FINISH key segments before the 1.0x too-long check can
+            // abort it.  Pyre's counterpart lives at the same place — the
+            // walker's `BC_JIT_MERGE_POINT` handler
+            // (`pyjitpl/dispatch.rs::create_segmented_trace`) — and reaches this
+            // driver as `TraceAction::SegmentedLoop`.  A check here instead
+            // would be unreachable: the walk returns `Continue` only once its
+            // framestack drains, and an over-budget walk returns `Abort` from
+            // inside its own loop.
 
             // Phase 2: handle trace result with full access to self
             match action {
@@ -3491,6 +3363,29 @@ impl<S: JitState> JitDriver<S> {
                     //   target_token = compile.compile_simple_loop(...)
                     //   warmstate.attach_procedure_to_interp(greenkey, token)
                     // + pyjitpl.py:1673 SwitchToBlackhole(ABORT_SEGMENTED_TRACE)
+                    //
+                    // pyjitpl.py:1671-1672 blackholes back to the interpreter
+                    // rather than jumping to compiled code.  Publish the
+                    // single-pass handoff first — the walk executed everything
+                    // it recorded, so the interpreter has to continue from where
+                    // the walk stopped (`create_segmented_trace` stashed that
+                    // pc) and with the walk's scalar / virtualizable state.
+                    // Read before `take_trace_meta` drains the session.
+                    let pc = self.meta.trace_ctx().and_then(|ctx| ctx.walk_final_pc);
+                    if let Some(pc) = pc {
+                        self.meta.single_pass_outcome = Some((pc, Vec::new()));
+                        if let Some(sym) = self.sym.as_ref() {
+                            let scalars = S::collect_scalar_state_field_values(sym);
+                            self.meta.single_pass_scalar_values = Some(scalars);
+                        }
+                        let virt_elems = self
+                            .meta
+                            .trace_ctx()
+                            .and_then(|ctx| ctx.collect_virtualizable_element_values());
+                        if let Some(elems) = virt_elems {
+                            self.meta.single_pass_virt_array_values = Some(elems);
+                        }
+                    }
                     let meta = self.meta.take_trace_meta().unwrap();
                     if let Some(green_key) = self.meta.compile_simple_loop(meta) {
                         // pyjitpl.py:1662-1663 line-by-line: pass the compiled
@@ -3529,6 +3424,12 @@ impl<S: JitState> JitDriver<S> {
                     self.sym = None;
                     self.meta.leave_profiler_tracing();
                     self.meta.clear_trace_session();
+                    // pyjitpl.py:1673 `raise SwitchToBlackhole(
+                    // Counters.ABORT_SEGMENTED_TRACE)` — upstream's handler
+                    // (pyjitpl.py:2949) runs `aborted_tracing(stb.reason)`, so a
+                    // segmented trace counts as an abort with its own reason.
+                    self.meta
+                        .aborted_tracing(crate::counters::ABORT_SEGMENTED_TRACE);
                 }
                 // Consumed inside the metainterp dispatch loop
                 // (PyreMetaInterp::step_inline_frame pops the inline frame and

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -2822,17 +2822,11 @@ impl<S: JitState> JitDriver<S> {
                             .meta
                             .trace_ctx()
                             .and_then(|ctx| ctx.close_greens.clone());
-                        let resolved_key = match close_greens.as_ref() {
-                            // Closed on a merge point: the token is the one keyed by
-                            // THOSE greens.  When no compiled loop lives there the
-                            // greenkey simply has no procedure token, and upstream
-                            // keeps tracing / compiles a loop (pyjitpl.py:3012-3060)
-                            // — it never falls back to the origin loop's token.
-                            Some(greens) => self.meta.compiled_key_for_greens(greens),
-                            // No merge-point greens recorded (the walk did not close
-                            // on one): the trace's own key stands in.
-                            None => self.current_trace_green_key(),
-                        };
+                        let resolved_key = self
+                            .meta
+                            .trace_ctx()
+                            .and_then(|ctx| ctx.close_green_key_hash())
+                            .or_else(|| self.current_trace_green_key());
                         if crate::closedbg_enabled() {
                             eprintln!(
                                 "@@@CLOSE BRIDGE-TARGET close_greens={close_greens:?} resolved_key={} origin_key={}",

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -2782,6 +2782,107 @@ impl<S: JitState> JitDriver<S> {
                         }
                         None => Vec::new(),
                     };
+                    // pyjitpl.py:3001-3007 reached_loop_header:
+                    //
+                    //     if not self.partial_trace:
+                    //         ptoken = self.get_procedure_token(greenboxes)
+                    //         if has_compiled_targets(ptoken):
+                    //             self.compile_trace(live_arg_boxes, ptoken)
+                    //     # raises in case it works
+                    //
+                    // The walker published the token key it reached (`close_jump_into_key`); this is
+                    // the `compile_trace` call, and its success ends the trace exactly the way
+                    // `raise_if_successful` (pyjitpl.py:3119-3123) does.
+                    if let Some(target_key) = self
+                        .meta
+                        .trace_ctx()
+                        .and_then(|ctx| ctx.take_close_jump_into_key())
+                    {
+                        let mut compiled = false;
+                        let mut continue_running_normally_values = None;
+                        // pyjitpl.py:3003 `if not self.partial_trace:` — a retrace must not bridge
+                        // into the very loop it exists to respecialize.
+                        if self.meta.partial_trace().is_none()
+                            && self.meta.has_compiled_targets(target_key)
+                        {
+                            continue_running_normally_values = {
+                                let trace_meta = self.meta.trace_meta().cloned();
+                                match (trace_meta, self.sym.as_ref()) {
+                                    (Some(meta), Some(sym)) => {
+                                        self.meta.trace_ctx().and_then(|ctx| {
+                                            S::close_loop_live_values(
+                                                ctx,
+                                                sym,
+                                                &meta,
+                                                &live_arg_boxes,
+                                            )
+                                        })
+                                    }
+                                    _ => None,
+                                }
+                            };
+                            // pyjitpl.py:3211 `compile.compile_trace(self, self.resumekey, ...)`:
+                            // the resumekey decides the bridge shape.  A guard origin is a
+                            // ResumeGuardDescr (`close_bridge` patches the failing guard); no bridge
+                            // origin is a ResumeFromInterpDescr entry bridge
+                            // (`compile_trace_from_interp`, compile.py:1002-1021).
+                            let bridge_origin =
+                                self.meta.bridge_info().map(|b| (b.trace_id, b.fail_index));
+                            compiled = match bridge_origin {
+                                Some((trace_id, fail_index)) => matches!(
+                                    self.meta.close_bridge(
+                                        target_key,
+                                        trace_id,
+                                        fail_index,
+                                        &live_arg_boxes,
+                                    ),
+                                    crate::pyjitpl::BridgeCompileResult::Compiled
+                                ),
+                                None => match self.compile_trace_entry_data() {
+                                    Some((original_green_key, entry_meta)) => matches!(
+                                        self.meta.compile_trace_from_interp(
+                                            target_key,
+                                            &live_arg_boxes,
+                                            original_green_key,
+                                            entry_meta,
+                                        ),
+                                        crate::CompileOutcome::Compiled { .. }
+                                    ),
+                                    None => false,
+                                },
+                            };
+                        }
+                        if compiled {
+                            // pyjitpl.py:3220 raise_if_successful → raise_continue_running_normally:
+                            // the trace is over, the interpreter enters the loop it jumped into.
+                            self.sym = None;
+                            self.meta.clear_trace_session();
+                            self.note_continue_running_normally(
+                                continue_running_normally_values,
+                                None,
+                            );
+                            self.meta.finish_trace_live();
+                            self.meta.clear_pending_abort();
+                            return;
+                        }
+                        // pyjitpl.py:3009-3010: `compile_trace` returned without raising, so the
+                        // trace is NOT given up — tracing continues.  Latch the decline so the walk
+                        // does not re-run the optimizer over the same key, and re-enter the walk at
+                        // the merge point's own pc (pyjitpl.py:1577 `self.pc = saved_pc`).
+                        if let Some(ctx) = self.meta.trace_ctx() {
+                            ctx.note_cross_loop_close_declined(target_key);
+                            ctx.close_greens = None;
+                            ctx.close_green_pc = None;
+                            ctx.merge_point_resumed = true;
+                        }
+                        // The walk-final handoff staged at the top of this arm describes a trace
+                        // that ENDED; discard it, same as the `take_keep_tracing_after_close` path
+                        // at the bottom of this arm.
+                        self.meta.single_pass_outcome = None;
+                        self.meta.single_pass_scalar_values = None;
+                        self.meta.single_pass_virt_array_values = None;
+                        continue;
+                    }
                     // pyjitpl.py:2979-3036 reached_loop_header parity.
                     // Path 1: bridge — only if has_compiled_targets (line 2982).
                     //

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -5725,16 +5725,21 @@ impl<M: Clone> MetaInterp<M> {
                 .expect("compile_loop: no active trace ctx");
             let outer = ctx.green_key;
             let cut_inner = ctx.cut_inner_green_key;
-            // compile.py:269-270: cross-loop cut → store under inner loop's
-            // jitcell_token. RPython: jitcell_token = cross_loop.jitcell_token.
-            (cut_inner.unwrap_or(outer), cut_inner)
+            // pyjitpl.py:3005 / :3183-3189: the key is
+            // `original_boxes[:num_green_args]`, i.e. the greens of the
+            // merge point that closed the trace.  A bridge may start from a
+            // guard in the origin loop and close at a different merge point,
+            // so the origin key is only the fallback for traces that did not
+            // close on a merge point.  If older traces lack typed close
+            // greens, preserve the existing cross-loop-cut inner key path.
+            let closed = ctx.close_green_key_hash();
+            (closed.or(cut_inner).unwrap_or(outer), cut_inner)
         };
 
         // pyjitpl.py:3185-3189: has_compiled_targets(ptoken) →
         // raise SwitchToBlackhole(ABORT_BAD_LOOP).  The key is the one the
         // loop would be stored under — `original_boxes[:num_green_args]`,
-        // the greens of the merge point that was closed at, which for a
-        // cross-loop cut is the inner loop's key, not the trace's own.
+        // the greens of the merge point that was closed at.
         if self.has_compiled_targets(green_key) {
             if crate::majit_log_enabled() {
                 eprintln!(

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -8894,6 +8894,15 @@ impl<M: Clone> MetaInterp<M> {
         // the typed variant tag), so no raw-u32 type side-table
         // propagation is needed for either pooled constants or
         // inputargs.
+        //
+        // optimizer.py:34 `self.inputargs` — the run needs the trace's own
+        // InputArg list, not just its length.  Without it a guard snapshot
+        // naming an inputarg no op in the body consumes reaches
+        // `store_final_boxes_in_guard` with nothing to bind it to
+        // (`_number_boxes` → `Operand::from_opref` on a position-only ref).
+        // Same seeding as the no-unroll retry inside `compile_loop`.
+        let inputarg_types: Vec<majit_ir::Type> = trace.inputargs.iter().map(|ia| ia.tp).collect();
+        optimizer.trace_inputargs = majit_ir::OpRef::inputarg_refs(&inputarg_types);
 
         let (
             mut snapshot_map,

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -5466,12 +5466,48 @@ where
                                 .as_ref()
                                 .is_some_and(|f| f(inner_key));
                             if already_compiled_here {
-                                if crate::majit_log_enabled() {
-                                    eprintln!(
-                                        "[jit] merge point pc={pc} already has compiled loop \
-                                         key={inner_key} — declining the cross-loop cut \
-                                         (pyjitpl.py:3005)"
-                                    );
+                                // pyjitpl.py:3004-3007 — the merge point just reached already owns a
+                                // procedure token, so upstream JUMPs into it rather than deriving a second
+                                // copy of that loop by cutting this trace.  `compile_trace` raises on
+                                // success (`raise_if_successful`, pyjitpl.py:3119-3123), which is why the
+                                // `current_merge_points` scan below is never reached in that case.
+                                //
+                                // The dispatcher holds no `&mut MetaInterp`, so the attempt is published to
+                                // the driver: `close_jump_into_key` names the token, `close_greens` /
+                                // `close_green_pc` name the greens it is keyed by (pyjitpl.py:3005
+                                // `get_procedure_token(greenboxes)` reads the greens of the merge point just
+                                // reached, not the trace-start header's).
+                                //
+                                // A key whose attempt already ran and did not compile keeps today's
+                                // behaviour — decline and keep tracing.  Re-attempting would re-run the
+                                // optimizer over a growing trace-so-far for a deterministic decline; the
+                                // same latch (`TraceCtx::declined_cross_loop_closes`) guards the equivalent
+                                // site in the other frontend.
+                                if ctx.cross_loop_close_declined(inner_key) {
+                                    if crate::majit_log_enabled() {
+                                        eprintln!(
+                                            "[jit] merge point pc={pc} already has compiled loop \
+                                             key={inner_key} — declining the cross-loop cut \
+                                             (pyjitpl.py:3005)"
+                                        );
+                                    }
+                                } else {
+                                    ctx.close_greens = Some(mp_greens.clone());
+                                    ctx.close_green_pc = Some(pc);
+                                    ctx.close_jump_into_key = Some(inner_key);
+                                    if capture_walk_reds {
+                                        ctx.walk_final_pc = Some(pc as usize);
+                                        ctx.walk_final_reds = std::mem::take(&mut walk_reds);
+                                    }
+                                    if crate::majit_log_enabled() {
+                                        eprintln!(
+                                            "[jit] merge point pc={pc} has compiled loop key={inner_key} \
+                                             — compile_trace JUMP (pyjitpl.py:3005)"
+                                        );
+                                    }
+                                    // GUARD_FUTURE_CONDITION was already emitted unconditionally at the
+                                    // reached_loop_header entry above (pyjitpl.py:2993).
+                                    return TraceAction::CloseLoop;
                                 }
                             } else if ctx.has_merge_point_at(inner_key, header_pc) {
                                 if crate::jitdriver::spdiag_enabled() {

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -1543,6 +1543,68 @@ where
         }
     }
 
+    /// pyjitpl.py:1622 `MIFrame._create_segmented_trace_and_blackhole`,
+    /// recording half.
+    ///
+    /// ```python
+    /// metainterp.generate_guard(rop.GUARD_ALWAYS_FAILS)
+    /// ...
+    /// metainterp.history.record1(rop.FINISH, exception_box, None, descr=token)
+    /// ```
+    ///
+    /// The trace is close enough to `trace_limit` that aborting it would
+    /// waste the whole recording, so it is terminated here instead: an
+    /// always-failing guard takes every execution back to the interpreter,
+    /// and the FINISH behind it exists only to give the segment a
+    /// terminator.  The compile half — `compile_simple_loop` plus
+    /// `attach_procedure_to_interp` (pyjitpl.py:1658-1663) — needs the
+    /// `MetaInterp` the walker does not hold, so it runs in the
+    /// [`TraceAction::SegmentedLoop`] arm of the driver.
+    ///
+    /// `compile_simple_loop` puts a LABEL at the segment's entry, which is
+    /// what lets a later trace close back into it; without it the segmented
+    /// loop could never be completed (pyjitpl.py:1641-1643).
+    fn create_segmented_trace(
+        &mut self,
+        ctx: &mut TraceCtx,
+        sym: &mut S,
+        mp_opcode_pc: usize,
+        mp_green_pc: Option<i64>,
+    ) -> TraceAction {
+        // pyjitpl.py:1626 `generate_guard(rop.GUARD_ALWAYS_FAILS)`.  The
+        // resume position is the merge-point op, whose preceding `-live-`
+        // marker names the boxes the blackhole resumes with — the same
+        // `(pc, after_residual_call=false)` pair the GUARD_FUTURE_CONDITION
+        // emitted at loop close uses.
+        self.record_state_guard(
+            ctx,
+            sym,
+            OpCode::GuardAlwaysFails,
+            &[],
+            mp_opcode_pc,
+            /* after_residual_call */ false,
+        );
+        // pyjitpl.py:1633-1637: an unreachable FINISH carrying the
+        // AssertionError typeptr and `exit_frame_with_exception_descr_ref`.
+        // Pyre's FINISH takes neither — `record_finish` records the op with
+        // its result operand alone — and the op is unreachable behind a
+        // guard that always fails, so the operand is a placeholder.
+        let exception_box = ctx.const_int(0);
+        ctx.record_finish(exception_box, majit_ir::Type::Int);
+        // pyjitpl.py:1671-1673: "we now need to blackhole back to the
+        // interpreter instead of jumping to some existing code, because we
+        // are at a really arbitrary place here."  Under single-pass tracing
+        // the walk already RAN everything it recorded, so the interpreter
+        // must resume at this merge point's own green pc rather than at the
+        // one it was left holding — the same handoff the abort path
+        // publishes (`jitdriver.rs` `TraceAction::Abort` arm).  Without it
+        // the walked iterations are executed a second time.
+        ctx.walk_final_pc = mp_green_pc.map(|p| p as usize);
+        ctx.walk_final_reds = Vec::new();
+        // pyjitpl.py:1673 `raise SwitchToBlackhole(ABORT_SEGMENTED_TRACE)`.
+        TraceAction::SegmentedLoop
+    }
+
     /// Resolve the box operand for a vable opcode. The canonical
     /// bytecode (Stage 3a-3c) carries the live struct register as the
     /// leading `r` operand — pyjitpl.py:1166-1170
@@ -4850,6 +4912,37 @@ where
                 // A seen>=0 (or `no_loop_header` auto-stamped) depth>0 merge
                 // point falls through into the close protocol at the else-branch
                 // cut below (pyjitpl.py:1579-1602).
+                // pyjitpl.py:1617-1620 `debug_merge_point`, the tail of the
+                // method every `jit_merge_point` runs through:
+                //
+                //     if (metainterp.force_finish_trace and
+                //             (metainterp.history.length() >
+                //              warmrunnerstate.trace_limit * 0.8)):
+                //         self._create_segmented_trace_and_blackhole()
+                //
+                // A green key that already overflowed once carries
+                // JC_FORCE_FINISH (set by `prepare_trace_segmenting`,
+                // pyjitpl.py:2820).  Its next attempt must not overflow
+                // again: closing the trace as a segment here — strictly
+                // before `_interpret`'s 1.0x `blackhole_if_trace_too_long`
+                // (pyjitpl.py:2861-2867) can be reached — is what stops the
+                // key from retracing forever.  The check belongs at a merge
+                // point and nowhere else: the guard this records resumes
+                // through the `-live-` marker that precedes every
+                // `jit_merge_point` op, which an arbitrary mid-walk position
+                // has no counterpart for.
+                if ctx.force_finish_trace() && ctx.num_ops() > ctx.trace_limit() * 4 / 5 {
+                    // pyjitpl.py:1639-1640 `if metainterp.current_merge_points
+                    // and isinstance(metainterp.resumekey,
+                    // ResumeFromInterpDescr):` — the loop arm.  A bridge takes
+                    // upstream's `compile_trace(resumekey)` else-arm instead,
+                    // which is not ported; it keeps aborting, as before.
+                    let is_loop_trace = ctx.current_merge_points_first_greenkey().is_some()
+                        && ctx.resumekey_original_loop_token().is_none();
+                    if is_loop_trace {
+                        return self.create_segmented_trace(ctx, sym, mp_opcode_pc, mp_green_pc);
+                    }
+                }
                 // pyjitpl.py:1547 `jitdriver_sd =
                 // self.metainterp.staticdata.jitdrivers_sd[jdindex]` reads the
                 // owning driver's `no_loop_header`.  Upstream this is the same

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -5280,6 +5280,54 @@ where
                                 "@@@SPDIAG HEADER-CLOSE close_target_pc={close_target_pc} mp_green_pc={mp_green_pc:?} walk_reds={walk_reds:?}"
                             );
                         }
+                        // pyjitpl.py:3005 `get_procedure_token(greenboxes)` —
+                        // the greens of the merge point just reached.
+                        let close_greens = (
+                            mp_green_ints.clone(),
+                            mp_green_refs.clone(),
+                            mp_green_floats.clone(),
+                        );
+                        ctx.close_greens = Some(close_greens.clone());
+                        if ctx.is_bridge_trace {
+                            // pyjitpl.py:3001-3060: a guard-origin bridge
+                            // first consults the procedure token for the
+                            // merge point just reached.  If none has compiled
+                            // targets, it does NOT close on the first visit;
+                            // it falls through to the current_merge_points
+                            // scan, appends first visits, and only closes on a
+                            // repeated same-greenkey merge point.
+                            let already_compiled_here = ctx
+                                .compiled_key_for_greens_fn
+                                .as_ref()
+                                .and_then(|f| f(&close_greens))
+                                .is_some();
+                            let close_key = ctx.close_green_key_hash().unwrap_or(ctx.green_key);
+                            if !already_compiled_here
+                                && !ctx.has_merge_point_at(close_key, ctx.header_pc)
+                            {
+                                let vable_boxes =
+                                    ctx.collect_virtualizable_typed_boxes().unwrap_or_default();
+                                let original_boxes = match sym.loop_carried_boxes(&vable_boxes) {
+                                    Some(mut boxes) => {
+                                        ctx.remove_consts_and_duplicates(&mut boxes);
+                                        boxes
+                                            .into_iter()
+                                            .map(|(o, ty)| crate::trace_ctx::GreenBox::new(o, ty))
+                                            .collect()
+                                    }
+                                    None => live_arg_boxes.clone(),
+                                };
+                                if crate::mptrace_enabled() {
+                                    eprintln!(
+                                        "@@@MPTRACE bridge-add-mp key={close_key} header_pc={} num_ops={}",
+                                        ctx.header_pc,
+                                        ctx.num_ops(),
+                                    );
+                                }
+                                ctx.add_merge_point(close_key, original_boxes, ctx.header_pc);
+                                return TraceAction::Continue;
+                            }
+                        }
                         if capture_walk_reds {
                             // Single-pass: stash the resume-aligned close pc (the
                             // interpreter green pc, NOT the JitCode op cursor) so
@@ -5291,13 +5339,6 @@ where
                             ctx.walk_final_pc = mp_green_pc.map(|p| p as usize);
                             ctx.walk_final_reds = std::mem::take(&mut walk_reds);
                         }
-                        // pyjitpl.py:3005 `get_procedure_token(greenboxes)` —
-                        // the greens of the merge point just reached.
-                        ctx.close_greens = Some((
-                            mp_green_ints.clone(),
-                            mp_green_refs.clone(),
-                            mp_green_floats.clone(),
-                        ));
                         // GUARD_FUTURE_CONDITION already emitted unconditionally at
                         // the reached_loop_header entry above (pyjitpl.py:2993).
                         return TraceAction::CloseLoop;

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -5054,17 +5054,29 @@ where
                         // merge point, and — once `retrace_needed` has armed
                         // `partial_trace` — a close storm that leaves no room
                         // for the one extra iteration a retrace has to trace.
-                        let has_targets = ctx
-                            .compiled_key_for_greens_fn
-                            .as_ref()
-                            .and_then(|f| {
-                                f(&(
-                                    mp_green_ints.clone(),
-                                    mp_green_refs.clone(),
-                                    mp_green_floats.clone(),
-                                ))
-                            })
-                            .is_some();
+                        //
+                        // The key must be the one the INTERPRETER enters by:
+                        // `get_procedure_token` is `jit_cell_at_key(greenkey)`,
+                        // and `compile_loop` attaches the token to that same
+                        // cell, so upstream cannot own a compiled loop the
+                        // interpreter cannot reach and this predicate is always
+                        // false for a key being traced for the first time —
+                        // which is what makes :1554-1555 `return` the guard
+                        // against closing a trace on its own first merge point.
+                        // A lookup keyed on anything else (e.g. scanning a side
+                        // table for a loop whose header greens happen to match)
+                        // can answer yes for a loop stored under a key nothing
+                        // enters, auto-stamp here, and close with nothing but
+                        // the green-promotion ops recorded.
+                        let mp_greens = (
+                            mp_green_ints.clone(),
+                            mp_green_refs.clone(),
+                            mp_green_floats.clone(),
+                        );
+                        let has_targets = mp_green_pc
+                            .and_then(|pc| ctx.merge_point_green_key_hash(pc, &mp_greens))
+                            .zip(ctx.has_compiled_targets_fn.as_ref())
+                            .is_some_and(|(key, f)| f(key));
                         depth_zero && has_targets
                     };
                     if should_auto_stamp {
@@ -5288,6 +5300,7 @@ where
                             mp_green_floats.clone(),
                         );
                         ctx.close_greens = Some(close_greens.clone());
+                        ctx.close_green_pc = mp_green_pc;
                         if ctx.is_bridge_trace {
                             // pyjitpl.py:3001-3060: a guard-origin bridge
                             // first consults the procedure token for the
@@ -5297,10 +5310,9 @@ where
                             // scan, appends first visits, and only closes on a
                             // repeated same-greenkey merge point.
                             let already_compiled_here = ctx
-                                .compiled_key_for_greens_fn
-                                .as_ref()
-                                .and_then(|f| f(&close_greens))
-                                .is_some();
+                                .close_green_key_hash()
+                                .zip(ctx.has_compiled_targets_fn.as_ref())
+                                .is_some_and(|(key, f)| f(key));
                             let close_key = ctx.close_green_key_hash().unwrap_or(ctx.green_key);
                             if !already_compiled_here
                                 && !ctx.has_merge_point_at(close_key, ctx.header_pc)
@@ -5366,8 +5378,6 @@ where
                     if inner_close {
                         if let Some(pc) = mp_green_pc {
                             let header_pc = ctx.header_pc;
-                            let inner_key =
-                                crate::green_key_from_code_ptr(ctx.green_key_raw.0, pc as usize);
                             // pyjitpl.py:3001-3007, which runs BEFORE the
                             // `current_merge_points` scan:
                             //
@@ -5447,15 +5457,19 @@ where
                                 mp_green_refs.clone(),
                                 mp_green_floats.clone(),
                             );
+                            let Some(inner_key) = ctx.merge_point_green_key_hash(pc, &mp_greens)
+                            else {
+                                return TraceAction::Continue;
+                            };
                             let already_compiled_here = ctx
-                                .compiled_key_for_greens_fn
+                                .has_compiled_targets_fn
                                 .as_ref()
-                                .and_then(|f| f(&mp_greens));
-                            if let Some(ptoken_key) = already_compiled_here {
+                                .is_some_and(|f| f(inner_key));
+                            if already_compiled_here {
                                 if crate::majit_log_enabled() {
                                     eprintln!(
                                         "[jit] merge point pc={pc} already has compiled loop \
-                                         key={ptoken_key} — declining the cross-loop cut \
+                                         key={inner_key} — declining the cross-loop cut \
                                          (pyjitpl.py:3005)"
                                     );
                                 }
@@ -5491,6 +5505,7 @@ where
                                     mp_green_refs.clone(),
                                     mp_green_floats.clone(),
                                 ));
+                                ctx.close_green_pc = Some(pc);
                                 if capture_walk_reds {
                                     // Single-pass: resume at the inner loop's
                                     // interpreter green pc (the loop variable the

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -320,6 +320,11 @@ pub struct TraceCtx {
     /// greens, so reconstructing the interpreter-entered key for a close needs
     /// this target in addition to the merge-point green tuple.
     pub(crate) close_green_pc: Option<i64>,
+    /// pyjitpl.py:3005-3007 `compile_trace(live_arg_boxes, ptoken)`: the procedure
+    /// token key of the merge point the trace just reached, set when that merge point
+    /// already has compiled targets.  A close carrying this JUMPs into the existing
+    /// loop instead of compiling a new one, and is read-and-cleared by the driver.
+    pub(crate) close_jump_into_key: Option<u64>,
     /// pyjitpl.py:2979 reached_loop_header parity: callback to check
     /// has_compiled_targets(ptoken) for a given green key. Bridge traces
     /// skip loop headers without compiled targets. Live lookup (not snapshot)
@@ -1444,6 +1449,7 @@ impl TraceCtx {
             header_greens: None,
             close_greens: None,
             close_green_pc: None,
+            close_jump_into_key: None,
             heap_cache: HeapCache::new(),
             force_finish: false,
             last_traced_pc: 0,
@@ -1529,6 +1535,7 @@ impl TraceCtx {
             header_greens: None,
             close_greens: None,
             close_green_pc: None,
+            close_jump_into_key: None,
             heap_cache: HeapCache::new(),
             force_finish: false,
             last_traced_pc: 0,
@@ -1925,6 +1932,12 @@ impl TraceCtx {
         }
     }
 
+    /// See [`TraceCtx::close_jump_into_key`].  Read-and-clear: the answer is only
+    /// meaningful to the close that just set it.
+    pub fn take_close_jump_into_key(&mut self) -> Option<u64> {
+        self.close_jump_into_key.take()
+    }
+
     /// Mark that the current back-edge was reached inside an inline callee
     /// frame and must not be unrolled (opimpl_jit_merge_point
     /// portal_call_depth>0). The trace step drains this via
@@ -2044,7 +2057,9 @@ impl TraceCtx {
             );
             key.types.get(1..)?.to_vec()
         } else {
-            self.driver_descriptor.as_ref().map(|d| d.green_args_spec())?
+            self.driver_descriptor
+                .as_ref()
+                .map(|d| d.green_args_spec())?
         };
 
         let mut values = Vec::with_capacity(spec.len() + 1);

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -315,6 +315,11 @@ pub struct TraceCtx {
     /// from.  Set by both close paths; `None` when the trace did not close on
     /// a merge point.
     pub(crate) close_greens: Option<(Vec<i64>, Vec<i64>, Vec<i64>)>,
+    /// The int pc green that belongs to [`Self::close_greens`].  The structured
+    /// `can_enter_jit` key prepends the back-edge target before the declared
+    /// greens, so reconstructing the interpreter-entered key for a close needs
+    /// this target in addition to the merge-point green tuple.
+    pub(crate) close_green_pc: Option<i64>,
     /// pyjitpl.py:2979 reached_loop_header parity: callback to check
     /// has_compiled_targets(ptoken) for a given green key. Bridge traces
     /// skip loop headers without compiled targets. Live lookup (not snapshot)
@@ -1438,6 +1443,7 @@ impl TraceCtx {
             }],
             header_greens: None,
             close_greens: None,
+            close_green_pc: None,
             heap_cache: HeapCache::new(),
             force_finish: false,
             last_traced_pc: 0,
@@ -1522,6 +1528,7 @@ impl TraceCtx {
             }],
             header_greens: None,
             close_greens: None,
+            close_green_pc: None,
             heap_cache: HeapCache::new(),
             force_finish: false,
             last_traced_pc: 0,
@@ -2012,18 +2019,38 @@ impl TraceCtx {
 
     /// pyjitpl.py:3183-3189: `compile_loop` keys the JitCell by
     /// `original_boxes[:num_green_args]`, i.e. the greens captured at the
-    /// merge point that closed the trace. `close_greens` is grouped by
-    /// JitCode register bank; rebuild the declared green order before hashing
-    /// so this matches warmstate.py:584-593 `JitCell.get_uhash`.
+    /// merge point that closed the trace.
     pub fn close_green_key_hash(&self) -> Option<u64> {
-        let (ints, refs, floats) = self.close_greens.as_ref()?;
-        let spec = self
-            .green_key_values
-            .as_ref()
-            .map(|key| key.types.clone())
-            .or_else(|| self.driver_descriptor.as_ref().map(|d| d.green_args_spec()))?;
+        let greens = self.close_greens.as_ref()?;
+        let pc = self.close_green_pc?;
+        self.merge_point_green_key_hash(pc, greens)
+    }
 
-        let mut values = Vec::with_capacity(spec.len());
+    /// pyjitpl.py:1553 / :3005 `get_procedure_token(greenboxes)` analog: the
+    /// jitcell key the INTERPRETER would enter by for these greens.  The
+    /// grouping is per JitCode register bank; rebuild the declared green order
+    /// before hashing so this matches warmstate.py:584-593 `JitCell.get_uhash`.
+    pub fn merge_point_green_key_hash(
+        &self,
+        pc: i64,
+        greens: &(Vec<i64>, Vec<i64>, Vec<i64>),
+    ) -> Option<u64> {
+        let (ints, refs, floats) = greens;
+        let spec = if let Some(key) = self.green_key_values.as_ref() {
+            debug_assert_eq!(
+                key.types.first().copied(),
+                Some(GreenType::Int),
+                "structured green key must start with the prepended target pc",
+            );
+            key.types.get(1..)?.to_vec()
+        } else {
+            self.driver_descriptor.as_ref().map(|d| d.green_args_spec())?
+        };
+
+        let mut values = Vec::with_capacity(spec.len() + 1);
+        let mut types = Vec::with_capacity(spec.len() + 1);
+        values.push(pc);
+        types.push(GreenType::Int);
         let mut int_i = 0;
         let mut ref_i = 0;
         let mut float_i = 0;
@@ -2047,7 +2074,8 @@ impl TraceCtx {
             };
             values.push(value);
         }
-        Some(crate::green_key_hash_typed(&values, &spec))
+        types.extend(spec);
+        Some(crate::green_key_hash_typed(&values, &types))
     }
 
     /// Set the structured green key values.

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -23,7 +23,7 @@ use crate::heapcache::HeapCache;
 use crate::opencoder::Box as OcBox;
 use crate::recorder::Trace;
 use indexmap::IndexMap;
-use majit_ir::{DescrRef, GreenKey, OpCode, OpRef, Type, Value};
+use majit_ir::{DescrRef, GreenKey, GreenType, OpCode, OpRef, Type, Value};
 
 use majit_backend::JitCellToken;
 
@@ -2008,6 +2008,46 @@ impl TraceCtx {
     /// The structured green key values, if provided.
     pub fn green_key_values(&self) -> Option<&GreenKey> {
         self.green_key_values.as_ref()
+    }
+
+    /// pyjitpl.py:3183-3189: `compile_loop` keys the JitCell by
+    /// `original_boxes[:num_green_args]`, i.e. the greens captured at the
+    /// merge point that closed the trace. `close_greens` is grouped by
+    /// JitCode register bank; rebuild the declared green order before hashing
+    /// so this matches warmstate.py:584-593 `JitCell.get_uhash`.
+    pub fn close_green_key_hash(&self) -> Option<u64> {
+        let (ints, refs, floats) = self.close_greens.as_ref()?;
+        let spec = self
+            .green_key_values
+            .as_ref()
+            .map(|key| key.types.clone())
+            .or_else(|| self.driver_descriptor.as_ref().map(|d| d.green_args_spec()))?;
+
+        let mut values = Vec::with_capacity(spec.len());
+        let mut int_i = 0;
+        let mut ref_i = 0;
+        let mut float_i = 0;
+        for tp in &spec {
+            let value = match tp {
+                GreenType::Int | GreenType::Void => {
+                    let value = *ints.get(int_i)?;
+                    int_i += 1;
+                    value
+                }
+                GreenType::Ref | GreenType::Str | GreenType::Unicode => {
+                    let value = *refs.get(ref_i)?;
+                    ref_i += 1;
+                    value
+                }
+                GreenType::Float => {
+                    let value = *floats.get(float_i)?;
+                    float_i += 1;
+                    value
+                }
+            };
+            values.push(value);
+        }
+        Some(crate::green_key_hash_typed(&values, &spec))
     }
 
     /// Set the structured green key values.


### PR DESCRIPTION
`prepare_trace_segmenting` marks an overflowed green key `JC_FORCE_FINISH`, but
nothing ever consumed the flag. The check sat in `JitDriver::merge_point`, gated
on `TraceAction::Continue` — and `JitCodeMachine::run_to_end` returns `Continue`
only once its framestack drains, while it returns `Abort` from inside its own
loop the instant `is_too_long()` trips (`dispatch.rs:2247`). So the gate could
never hold while a trace was over budget, and `TraceAction::SegmentedLoop` was
never produced. Measured over a whole aheui run: `merge_point` called 825 times,
`Continue` returned **0** times.

Upstream fires this inside the tracing loop instead, in
`MIFrame.debug_merge_point` (pyjitpl.py:1617-1620), so a marked key always
segments on attempt #2 and never reaches the 1.0× `blackhole_if_trace_too_long`
check.

## Three defects, not one

The first only exposes the other two.

**1. The trigger is in the wrong place.** Moved to the walker's
`BC_JIT_MERGE_POINT` handler, with `create_segmented_trace` as the recording
half: `record_state_guard(GUARD_ALWAYS_FAILS)` at the merge-point pc plus the
unreachable `FINISH` of pyjitpl.py:1626-1637. It has to be at a merge point —
the guard resumes through the `-live-` marker that precedes every
`jit_merge_point` op, and an arbitrary mid-walk position has none. The
driver-side fallback is deleted; its placeholder
`capture_snapshot_for_last_guard` branch fed unbound `InputArgRef`s into the
guard.

**2. `compile_simple_loop` never seeded `optimizer.trace_inputargs`** — only its
length. A guard snapshot naming an inputarg the body never consumes then reached
`store_final_boxes_in_guard` -> `_number_boxes` -> `Operand::from_opref`, which
panics on a position-only ref with no producer to bind. Seeded from
`trace.inputargs`, the way the no-unroll retry in `compile_loop` already does.

**3. Single-pass tracing needs the walk handoff.** The walk *executed* what it
recorded, so the `SegmentedLoop` arm must publish `walk_final_pc` + scalars +
virtualizable elements exactly like the `TraceAction::Abort` arm does. Without
it the segment compiles, the walked iterations run a second time, and output is
silently **wrong** — no counter notices. Caught only by byte-comparing stdout at
an artificially small trace limit, where it differed at byte 2134.

Plus the accounting half of pyjitpl.py:1673: the arm now calls
`aborted_tracing(ABORT_SEGMENTED_TRACE)`.

## Measured

aheui `pi/pi.jinseo` (rpaheui corpus), production trace limit. The 784 aborts
came from only 7 distinct green keys — ~112 retraces each.

| | before | after |
|---|---|---|
| `loops_aborted` | 814 | **39** |
| `abort_too_long` | 784 | **7** (one per key, the upstream shape) |
| `abort_segmented_trace` | 0 | **1** |
| `loops_compiled` | 12 | 11 |
| user time (3 rounds) | 35.5 / 33.6 / 33.8 s | **3.44 / 3.37 / 3.24 s** |
| stdout | — | byte-identical to the reference |

Refuted on the way in: the trace budget (a 16x `trace_limit` sweep, 35k->280k,
is flat at 816/814/813/807 — every trace burns whatever budget exists) and
`find_biggest_function` (always `None` here, but upstream also yields `None` for
a single non-recursive jitdriver, so it is not a divergence).

## Gates

`python3 pyre/check.py` on this tip, with the three consumed LLBC artefacts
regenerated first:

| backend | result |
|---|---|
| dynasm | 370/370 |
| cranelift | 370/370 |
| wasm | 366/366 |

`cargo test -p majit-metainterp --release` passes. aheui's own jit-stats floor
(4 fixtures, un-compiled A/B on each) passes unchanged.

## Not in this change

Upstream's **bridge arm** of `_create_segmented_trace_and_blackhole`
(`compile_trace(resumekey)`, pyjitpl.py:1665-1669) is still unported, so a
bridge carrying `FORCE_BRIDGE_SEGMENTING` keeps aborting. `pi.jinseo` has
`abort_bridge=0`, so nothing here exercises it.

At an artificially small `trace_limit` an installed segment draws an
`abort_bad_loop` storm — later traces do not close back into the segment's
`LABEL`. At the production limit that counter is 31 vs 30, i.e. unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
