### PR TITLE
jit: label the ABORT_BRIDGE tally for what it counts, not for its name

### DIFF
--- a/majit/majit-metainterp/src/jitprof.rs
+++ b/majit/majit-metainterp/src/jitprof.rs
@@ -175,9 +175,20 @@ struct TimingState {
 /// lets the host read them by index and print the same breakdown.
 ///
 /// Order is the contract with that host: append only, never reorder.
+///
+/// `ABORT_BRIDGE` is labelled for what it actually counts here, not for its
+/// name. [`AbortReason::Generic`] maps to the same integer 13, and that is the
+/// value `jitdriver`'s reason ladder falls back to whenever a `TraceAction::
+/// Abort` arrives with no `SwitchToBlackhole`, no staged reason and a trace
+/// that is not too long — which is every walker decline except
+/// `ForceQuasiImmutable`. So a nonzero tally here is overwhelmingly
+/// "unclassified", and reading it as "a bridge aborted" sends the next reader
+/// looking for bridge activity that is not there.
+///
+/// [`AbortReason::Generic`]: crate::pyjitpl::AbortReason::Generic
 pub const ABORT_COUNTER_KINDS: &[(i32, &str)] = &[
     (counters::ABORT_TOO_LONG, "too_long"),
-    (counters::ABORT_BRIDGE, "bridge"),
+    (counters::ABORT_BRIDGE, "bridge_or_generic"),
     (counters::ABORT_BAD_LOOP, "bad_loop"),
     (counters::ABORT_ESCAPE, "escape"),
     (counters::ABORT_FORCE_QUASIIMMUT, "force_quasiimmut"),

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -673,8 +673,7 @@ def _jit_stats_regression_floor(saved, current):
     whose healthy value IS 0, so they gate from the first run without
     re-recording. The count-valued counters have no such healthy value, so a
     baseline that does not name one is treated as not pinning it at all — a
-    baseline recorded before the field existed must not read as `0 -> 1757`,
-    and the wasm [jit-stats] line reports neither of them."""
+    baseline recorded before the field existed must not read as `0 -> 1757`."""
     old_fields = _parse_jit_stats(saved)
     new_fields = _parse_jit_stats(current)
     regressions = []

--- a/pyre/pyre-wasm-runner/src/main.rs
+++ b/pyre/pyre-wasm-runner/src/main.rs
@@ -480,7 +480,7 @@ fn run(module_path: &PathBuf, source: &str, script: &Path) -> Result<i32> {
         if let Ok(ab) = instance.get_typed_func::<u32, u64>(&mut store, "pyre_jit_abort_diag") {
             let labels = [
                 "too_long",
-                "bridge",
+                "bridge_or_generic",
                 "bad_loop",
                 "escape",
                 "force_quasiimmut",


### PR DESCRIPTION
Rebased onto `a0314863dd5`. #1009 landed the field exports, the decline-census
export and the re-recorded wasm baselines this branch previously carried, so
those commits are dropped and what remains is the part #1009 did not cover.

## The label

`abort_diag`'s `bridge` label named the upstream counter, not what the tally
holds. `AbortReason::Generic` maps to the same integer 13, and that is the value
`jitdriver`'s reason ladder falls back to whenever a `TraceAction::Abort`
arrives with no `SwitchToBlackhole`, no staged reason and a trace that is not
too long — which is every walker decline except `ForceQuasiImmutable`, the one
site that calls `stage_abort_reason`. So the tally is overwhelmingly
unclassified aborts.

Measured on `synth/pickle_terminal_raise_resume` under wasm, where it reads 8
of `loops_aborted` 13:

| probe | result |
| --- | --- |
| `bridge_diag entered` | 0 — `compile_bridge` never ran |
| all five `compile_loop` error exits (temporary counters) | 0 |
| all three `SwitchToBlackhole::giveup()` sites (temporary counters) | 0 |
| `abort_diag too_long` | 0 |

Every branch of the ladder above `Generic` is empty, so the whole tally is the
fallback. Reading it as bridge activity sends the next reader looking for
bridges that are not there — it cost this session about an hour.

`TraceAction::AbortPermanent` reaches the same bucket, which is easy to miss:
its jitdriver arm never calls `aborted_tracing`, but the `abort_trace(true)` it
runs does, under the same `Generic` default.

The decline census (#1009's export) names the population instead:

```
AbortPermanentMarkerReached=2 ForceQuasiImmutable=5
LoopBearingCalleeInlineUnsupported=1
NonStandardVableFinishPortalUnsupported=5 FrameShape::…
```

`2 + 1 + 5 = 8` is the generic tally and `ForceQuasiImmutable=5` is
`force_quasiimmut=5`, so all 13 aborts are attributed. The same decomposition
held on the pre-#1009 base with different numbers — 32 + 1 = 33 generic, 4
quasi-immut, 37 total — which is what makes it a model rather than a fit.

Cross-backend on this base, same fixture: dynasm `loops_aborted=0
loops_compiled=34`, cranelift `0 / 35`, wasm `13 / 74`. The wasm-only abort
population is real but is now 13, down from 37 before #1009.

## The docstring

`_jit_stats_regression_floor` still said the wasm `[jit-stats]` line reports
neither `loops_compiled` nor `guard_failures`. As of #1009 it reports both.

`cargo fmt --check` clean; `cargo check -p majit-metainterp` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified JIT abort statistics to identify bridge and generic aborts under a combined label.
  * Updated JIT statistics documentation to accurately describe available WebAssembly metrics.
* **Diagnostics**
  * Improved abort reporting consistency across runtime and WebAssembly outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->