### PR TITLE
jit/wasm: lower LOAD_LOCALS and LOAD_BUILD_CLASS, make wasm loops_aborted attributable, close the jitstats field gap

### DIFF
--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -40,11 +40,18 @@ use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
 /// that was never offered: 19 = labels published off a peeled loop, 20 =
 /// published off a non-peeled loop, 21 = a non-peeled loop's first label left
 /// unpublished (no descr, or its arity is not the inputarg count), 22 = a
-/// dropped loop retracted a published entry.
-pub static BRIDGE_DIAG: [AtomicU64; 23] = {
+/// dropped loop retracted a published entry. `compile_loop`'s own outcome
+/// split — every `Err` it returns is a `loops_aborted` bump in the metainterp,
+/// and the reason string never reaches the host from inside the guest, so the
+/// classification has to be a counter: 23 = compile_loop entered, 24 =
+/// compile_loop returned a token, 25 = declined by
+/// `wasm_unsupported_trace_reason` (the #62 loop-callee CALL_ASSEMBLER gap),
+/// 26 = the wasm host rejected the emitted module (`func_handle == 0`).
+/// Indices 2 and 4 double as compile_loop's other two declines.
+pub static BRIDGE_DIAG: [AtomicU64; 27] = {
     const Z: AtomicU64 = AtomicU64::new(0);
     [
-        Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z,
+        Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z,
     ]
 };
 
@@ -1870,6 +1877,7 @@ impl majit_backend::Backend for WasmBackend {
         ops: &[OpRc],
         token: &JitCellToken,
     ) -> Result<AsmInfo, BackendError> {
+        diag_bump(23);
         // `x86/assembler.py:514` parity — bump
         // `cpu.tracker.total_compiled_loops` at the same point PyPy
         // creates the `CompiledLoopToken`.
@@ -1960,6 +1968,7 @@ impl majit_backend::Backend for WasmBackend {
         // chaining (each trace is its own module), so it cannot execute the
         // target — declining is the #62 loop-callee gap.
         if let Some(reason) = wasm_unsupported_trace_reason(ops, allow_ca) {
+            diag_bump(25);
             return Err(BackendError::Unsupported(reason));
         }
         if allow_ca {
@@ -2095,6 +2104,7 @@ impl majit_backend::Backend for WasmBackend {
         // a backend capability limit, reported like any other unsupported shape.
         #[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
         if !defer_host_compile && func_handle == 0 {
+            diag_bump(26);
             return Err(BackendError::Unsupported(
                 "wasm host rejected the compiled trace module (oversized function body \
                  or invalid module)"
@@ -2301,6 +2311,7 @@ impl majit_backend::Backend for WasmBackend {
             }
         }
 
+        diag_bump(24);
         Ok(AsmInfo {
             code_addr: 0,
             code_size,

--- a/majit/majit-ir/src/effectinfo.rs
+++ b/majit/majit-ir/src/effectinfo.rs
@@ -725,6 +725,15 @@ pub enum PyreHelperKind {
     /// `bh_delete_global_fn(frame, w_name)` — the DELETE_GLOBAL twin of
     /// [`PyreHelperKind::DeleteName`], recognised for the same reason.
     DeleteGlobal,
+    /// `bh_load_locals_fn(frame)` — the LOAD_LOCALS frame-receiver helper
+    /// (`pyopcode.py:793-794`). Carries no fold; the tag exists so the class
+    /// body's namespace read is a residual call like every other frame
+    /// method, rather than an untranslatable op.
+    LoadLocals,
+    /// `bh_load_build_class_fn(frame)` — the LOAD_BUILD_CLASS frame-receiver
+    /// helper (`pyopcode.py:866-870`). Same standing as
+    /// [`PyreHelperKind::LoadLocals`].
+    LoadBuildClass,
     /// `bh_call_fn_N(callable, null_or_self, args...)` — the CALL-family
     /// Python-call helper.  `null_or_self` (arg index 1) is a sentinel
     /// the helper checks before use (a non-null receiver is prepended as

--- a/majit/majit-metainterp/src/lib.rs
+++ b/majit/majit-metainterp/src/lib.rs
@@ -618,17 +618,30 @@ pub fn register_stack_almost_full_hook(f: fn() -> bool) {
 /// are reachable for different reasons and only
 /// the split says which; the guest has no stderr, so `MAJIT_LOG`'s per-exit
 /// lines never reach a wasm run and this is the only channel that does.
-pub static MC_DIAG: [std::sync::atomic::AtomicU64; 40] = {
+///
+/// 40-46 are the `Counters.ABORT_*` histogram of `aborted_tracing`, in
+/// `counters` order (`ABORT_TOO_LONG` .. `ABORT_SEGMENTED_TRACE`), with 46 for
+/// a reason outside that range. Their sum is the `loops_aborted` contribution
+/// of tracing aborts, so it also separates those from the backend-`Err`
+/// aborts, which do not pass through here. The reason already reaches
+/// `profiler.count(reason)`; these slots are the same value on the one channel
+/// a wasm guest can be read through.
+///
+/// 47-49 split slot 41 (`ABORT_BRIDGE`) by which `compile.giveup()` raised it,
+/// since upstream spends that one reason id on every generic bail: 47 = the
+/// optimizer deferred an `InvalidLoop` on the root trace, 48 = the root
+/// `compile_loop` returned `Err`, 49 = a bridge compile came back `Aborted`.
+pub static MC_DIAG: [std::sync::atomic::AtomicU64; 50] = {
     const Z: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
     [
         Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z,
-        Z, Z, Z, Z, Z, Z, Z, Z, Z, Z,
+        Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z,
     ]
 };
 
 /// Short label per [`MC_DIAG`] slot, in index order, so a tally cannot be added
 /// without naming it. Readers join these with the counter values.
-pub const MC_DIAG_LABELS: [&str; 40] = [
+pub const MC_DIAG_LABELS: [&str; 50] = [
     "mc_entered",
     "decl_shortcircuit",
     "descr0_skip",
@@ -669,6 +682,16 @@ pub const MC_DIAG_LABELS: [&str; 40] = [
     "ceb_retrace_req",
     "ceb_backend_panic",
     "ceb_backend_err",
+    "abrt_too_long",
+    "abrt_bridge",
+    "abrt_bad_loop",
+    "abrt_escape",
+    "abrt_force_qmut",
+    "abrt_segmented",
+    "abrt_other",
+    "giveup_invalidloop",
+    "giveup_compileloop_err",
+    "giveup_bridge_aborted",
 ];
 
 /// Render every [`MC_DIAG`] tally as space-separated `label=count` pairs.

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -7930,6 +7930,7 @@ impl<M: Clone> MetaInterp<M> {
                 // carries the real trace key instead of 0.
                 self.pending_abort_green_key = Some(green_key);
                 self.pending_abort_permanent = true;
+                crate::mc_diag_bump(47);
                 return Err(SwitchToBlackhole::giveup());
             }
         };
@@ -8220,6 +8221,7 @@ impl<M: Clone> MetaInterp<M> {
                 // analog is pending_abort_* staged here for the catch.
                 self.pending_abort_green_key = Some(green_key);
                 self.pending_abort_permanent = false;
+                crate::mc_diag_bump(48);
                 return Err(SwitchToBlackhole::giveup());
             }
         }
@@ -12992,6 +12994,14 @@ impl<M: Clone> MetaInterp<M> {
         // pyjitpl.py:2761: profiler.count(reason) — reason-keyed bump
         // lands on the matching `staticdata.profiler.abort_*` atomic.
         self.count(reason, 1);
+        // Same reason on the diagnostic channel, which is the only one a wasm
+        // guest can be read through (`MC_DIAG` slots 40-46).
+        crate::mc_diag_bump(match reason {
+            counters::ABORT_TOO_LONG..=counters::ABORT_SEGMENTED_TRACE => {
+                40 + (reason - counters::ABORT_TOO_LONG) as usize
+            }
+            _ => 46,
+        });
         // pyjitpl.py:2786: self.staticdata.stats.aborted() — pyre's
         // mapping of the lifetime aborted-loop tally lives on
         // `JitStatsCounters.loops_aborted` (separate from the
@@ -13925,7 +13935,10 @@ impl<M: Clone> MetaInterp<M> {
                 // `SwitchToBlackhole(Counters.ABORT_BRIDGE)`.  The
                 // bridge FINISH path shares the same giveup reason as
                 // the root FINISH path.
-                CompileOutcome::Aborted => Err(SwitchToBlackhole::giveup()),
+                CompileOutcome::Aborted => {
+                    crate::mc_diag_bump(49);
+                    Err(SwitchToBlackhole::giveup())
+                }
             };
         }
         // Root branch: drain `trace_meta`, drive `finish_and_compile`.

--- a/pyre/bench/fannkuch.wasm.jitstats
+++ b/pyre/bench/fannkuch.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=22
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=5049
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=6

--- a/pyre/bench/fib_loop.wasm.jitstats
+++ b/pyre/bench/fib_loop.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=189
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/fib_recursive.wasm.jitstats
+++ b/pyre/bench/fib_recursive.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=3
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=406
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/float_loop.wasm.jitstats
+++ b/pyre/bench/float_loop.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/inline_helper.wasm.jitstats
+++ b/pyre/bench/inline_helper.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=2

--- a/pyre/bench/int_loop.wasm.jitstats
+++ b/pyre/bench/int_loop.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/nbody.wasm.jitstats
+++ b/pyre/bench/nbody.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=5
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1547
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=5

--- a/pyre/bench/nested_loop.wasm.jitstats
+++ b/pyre/bench/nested_loop.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=1
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=201
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/raise_catch_loop.wasm.jitstats
+++ b/pyre/bench/raise_catch_loop.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=1
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=201
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/spectral_norm.wasm.jitstats
+++ b/pyre/bench/spectral_norm.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=2
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=520
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=2

--- a/pyre/bench/synth/abstractmethods_metaclass_getattr.wasm.jitstats
+++ b/pyre/bench/synth/abstractmethods_metaclass_getattr.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=0

--- a/pyre/bench/synth/abstractmethods_nonstring_name.wasm.jitstats
+++ b/pyre/bench/synth/abstractmethods_nonstring_name.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=0

--- a/pyre/bench/synth/aiter_anext.wasm.jitstats
+++ b/pyre/bench/synth/aiter_anext.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=0

--- a/pyre/bench/synth/arith_int_bool.wasm.jitstats
+++ b/pyre/bench/synth/arith_int_bool.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=10
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=2214
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=7

--- a/pyre/bench/synth/array_deopt_resume.wasm.jitstats
+++ b/pyre/bench/synth/array_deopt_resume.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/assert_in_loop.wasm.jitstats
+++ b/pyre/bench/synth/assert_in_loop.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=1
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=200
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/ast_compile_roundtrip.wasm.jitstats
+++ b/pyre/bench/synth/ast_compile_roundtrip.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=0

--- a/pyre/bench/synth/attr_cache_invalidation.wasm.jitstats
+++ b/pyre/bench/synth/attr_cache_invalidation.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=5
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1002
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=2

--- a/pyre/bench/synth/attr_delete.wasm.jitstats
+++ b/pyre/bench/synth/attr_delete.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/attr_instance_shadows_class.wasm.jitstats
+++ b/pyre/bench/synth/attr_instance_shadows_class.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/attr_store_add_transition.wasm.jitstats
+++ b/pyre/bench/synth/attr_store_add_transition.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/attr_store_cache.wasm.jitstats
+++ b/pyre/bench/synth/attr_store_cache.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/bases_reassign_cache.wasm.jitstats
+++ b/pyre/bench/synth/bases_reassign_cache.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=0

--- a/pyre/bench/synth/binary_int_overflow_local_resume.wasm.jitstats
+++ b/pyre/bench/synth/binary_int_overflow_local_resume.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=5
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=647
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=5

--- a/pyre/bench/synth/binary_slice_index.wasm.jitstats
+++ b/pyre/bench/synth/binary_slice_index.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=4
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=3

--- a/pyre/bench/synth/blackhole_inlined_callee_local_after_escape.wasm.jitstats
+++ b/pyre/bench/synth/blackhole_inlined_callee_local_after_escape.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=5
+loops_compiled=1

--- a/pyre/bench/synth/bool_dunder_error_no_leak.wasm.jitstats
+++ b/pyre/bench/synth/bool_dunder_error_no_leak.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=2
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=2

--- a/pyre/bench/synth/bound_method_builtin_fold.wasm.jitstats
+++ b/pyre/bench/synth/bound_method_builtin_fold.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=2
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=433
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=7

--- a/pyre/bench/synth/break_except_live_local.wasm.jitstats
+++ b/pyre/bench/synth/break_except_live_local.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=1
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=201
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/bridge_branchy_callee.wasm.jitstats
+++ b/pyre/bench/synth/bridge_branchy_callee.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=1
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=201
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=2

--- a/pyre/bench/synth/bridge_global_fold_invalidate_hot.wasm.jitstats
+++ b/pyre/bench/synth/bridge_global_fold_invalidate_hot.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=4
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=814
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=7

--- a/pyre/bench/synth/bridge_recursion_overflow.wasm.jitstats
+++ b/pyre/bench/synth/bridge_recursion_overflow.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=3
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=798
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/build_class_surrogate_namespace.wasm.jitstats
+++ b/pyre/bench/synth/build_class_surrogate_namespace.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=0

--- a/pyre/bench/synth/build_container_return_resume.wasm.jitstats
+++ b/pyre/bench/synth/build_container_return_resume.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=5
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=5

--- a/pyre/bench/synth/build_list_resume.wasm.jitstats
+++ b/pyre/bench/synth/build_list_resume.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/build_set_hashability.wasm.jitstats
+++ b/pyre/bench/synth/build_set_hashability.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=2
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=2

--- a/pyre/bench/synth/builtin_type_surface.wasm.jitstats
+++ b/pyre/bench/synth/builtin_type_surface.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=0

--- a/pyre/bench/synth/bytes_split_whitespace_maxsplit.wasm.jitstats
+++ b/pyre/bench/synth/bytes_split_whitespace_maxsplit.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/ca_bridge_multiframe_resume_double_call.wasm.jitstats
+++ b/pyre/bench/synth/ca_bridge_multiframe_resume_double_call.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=14
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=3062
 internal_compile_panics=0
 loops_aborted=1
+loops_compiled=3

--- a/pyre/bench/synth/call_ex_kwargs_mapping.wasm.jitstats
+++ b/pyre/bench/synth/call_ex_kwargs_mapping.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=0

--- a/pyre/bench/synth/call_kw_hot_loop.wasm.jitstats
+++ b/pyre/bench/synth/call_kw_hot_loop.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/call_loop_local_function.wasm.jitstats
+++ b/pyre/bench/synth/call_loop_local_function.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/call_slot_descriptor_protocol.wasm.jitstats
+++ b/pyre/bench/synth/call_slot_descriptor_protocol.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=0

--- a/pyre/bench/synth/call_star_forms_inlined_callee.wasm.jitstats
+++ b/pyre/bench/synth/call_star_forms_inlined_callee.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=2
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=3

--- a/pyre/bench/synth/callable_iterator_type.wasm.jitstats
+++ b/pyre/bench/synth/callable_iterator_type.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/callee_return_side_effect.wasm.jitstats
+++ b/pyre/bench/synth/callee_return_side_effect.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=2
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=2

--- a/pyre/bench/synth/callee_store_global_read_after_call.wasm.jitstats
+++ b/pyre/bench/synth/callee_store_global_read_after_call.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=1
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=293
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=2

--- a/pyre/bench/synth/calls_closures.wasm.jitstats
+++ b/pyre/bench/synth/calls_closures.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=5
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=808
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=8

--- a/pyre/bench/synth/chained_comparison.wasm.jitstats
+++ b/pyre/bench/synth/chained_comparison.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/check_exc_match_invalid_class.wasm.jitstats
+++ b/pyre/bench/synth/check_exc_match_invalid_class.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/class_attrs_methods.wasm.jitstats
+++ b/pyre/bench/synth/class_attrs_methods.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/class_reassign_hot.wasm.jitstats
+++ b/pyre/bench/synth/class_reassign_hot.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=2
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=401
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/classmethod_protocol_hot.wasm.jitstats
+++ b/pyre/bench/synth/classmethod_protocol_hot.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=0

--- a/pyre/bench/synth/classmethod_type_dispatch_hot.wasm.jitstats
+++ b/pyre/bench/synth/classmethod_type_dispatch_hot.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=2

--- a/pyre/bench/synth/closure_freevar_branch_resume.wasm.jitstats
+++ b/pyre/bench/synth/closure_freevar_branch_resume.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=3
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=606
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=3

--- a/pyre/bench/synth/closure_per_call.wasm.jitstats
+++ b/pyre/bench/synth/closure_per_call.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=2
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=467
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=4

--- a/pyre/bench/synth/complex_from_index.wasm.jitstats
+++ b/pyre/bench/synth/complex_from_index.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/complex_real_imag.wasm.jitstats
+++ b/pyre/bench/synth/complex_real_imag.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=0

--- a/pyre/bench/synth/comprehension_accumulators.wasm.jitstats
+++ b/pyre/bench/synth/comprehension_accumulators.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=0

--- a/pyre/bench/synth/comprehension_module_scope.wasm.jitstats
+++ b/pyre/bench/synth/comprehension_module_scope.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/comprehension_object_append_hot.wasm.jitstats
+++ b/pyre/bench/synth/comprehension_object_append_hot.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=8
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1605
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=6

--- a/pyre/bench/synth/comprehension_param_range_call_flush.wasm.jitstats
+++ b/pyre/bench/synth/comprehension_param_range_call_flush.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=3
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=600
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/condexpr_heap_const_merge.wasm.jitstats
+++ b/pyre/bench/synth/condexpr_heap_const_merge.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=0

--- a/pyre/bench/synth/const_arg_call_resume.wasm.jitstats
+++ b/pyre/bench/synth/const_arg_call_resume.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=7
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1404
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=3

--- a/pyre/bench/synth/context_manager.wasm.jitstats
+++ b/pyre/bench/synth/context_manager.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/defaults_reassigned_midloop.wasm.jitstats
+++ b/pyre/bench/synth/defaults_reassigned_midloop.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=2
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=404
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=3

--- a/pyre/bench/synth/del_cellvar_walk_commit.wasm.jitstats
+++ b/pyre/bench/synth/del_cellvar_walk_commit.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/delete_negative_open_slice_hot.wasm.jitstats
+++ b/pyre/bench/synth/delete_negative_open_slice_hot.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=7
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1404
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=4

--- a/pyre/bench/synth/dict_ctor_consume.wasm.jitstats
+++ b/pyre/bench/synth/dict_ctor_consume.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/dict_hash_protocol.wasm.jitstats
+++ b/pyre/bench/synth/dict_hash_protocol.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/dict_set.wasm.jitstats
+++ b/pyre/bench/synth/dict_set.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=3
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=609
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=5

--- a/pyre/bench/synth/dict_set_key_eq_operand_order.wasm.jitstats
+++ b/pyre/bench/synth/dict_set_key_eq_operand_order.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=2

--- a/pyre/bench/synth/dict_update_hot.wasm.jitstats
+++ b/pyre/bench/synth/dict_update_hot.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=1
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=200
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/dict_update_source_mutation.wasm.jitstats
+++ b/pyre/bench/synth/dict_update_source_mutation.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=0

--- a/pyre/bench/synth/dict_view_set_ops.wasm.jitstats
+++ b/pyre/bench/synth/dict_view_set_ops.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/dir_custom.wasm.jitstats
+++ b/pyre/bench/synth/dir_custom.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=0

--- a/pyre/bench/synth/dir_dict_class_attrs.wasm.jitstats
+++ b/pyre/bench/synth/dir_dict_class_attrs.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=0

--- a/pyre/bench/synth/dir_full_mro.wasm.jitstats
+++ b/pyre/bench/synth/dir_full_mro.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=0

--- a/pyre/bench/synth/dunder_repr_str_errors.wasm.jitstats
+++ b/pyre/bench/synth/dunder_repr_str_errors.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=0

--- a/pyre/bench/synth/enumerate_bignum_start.wasm.jitstats
+++ b/pyre/bench/synth/enumerate_bignum_start.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=0

--- a/pyre/bench/synth/exc_bridge_entry_guard_not_removed.wasm.jitstats
+++ b/pyre/bench/synth/exc_bridge_entry_guard_not_removed.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=4
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=809
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=4

--- a/pyre/bench/synth/exc_caught_in_callee_return_loop.wasm.jitstats
+++ b/pyre/bench/synth/exc_caught_in_callee_return_loop.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=2
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=23748
 internal_compile_panics=0
 loops_aborted=1
+loops_compiled=2

--- a/pyre/bench/synth/exc_in_loop_divzero_continue.wasm.jitstats
+++ b/pyre/bench/synth/exc_in_loop_divzero_continue.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=360
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=3

--- a/pyre/bench/synth/exc_info_module_loop_hot.wasm.jitstats
+++ b/pyre/bench/synth/exc_info_module_loop_hot.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/exc_mixed_classes_bridge_flavor.wasm.jitstats
+++ b/pyre/bench/synth/exc_mixed_classes_bridge_flavor.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=4
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=802
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=2

--- a/pyre/bench/synth/except_star.wasm.jitstats
+++ b/pyre/bench/synth/except_star.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=0

--- a/pyre/bench/synth/except_tuple_clause_hot.wasm.jitstats
+++ b/pyre/bench/synth/except_tuple_clause_hot.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=2
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=2

--- a/pyre/bench/synth/exception_args_virtual.wasm.jitstats
+++ b/pyre/bench/synth/exception_args_virtual.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=2
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=401
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/exception_as_cell_cleanup.wasm.jitstats
+++ b/pyre/bench/synth/exception_as_cell_cleanup.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=2
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=401
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=2

--- a/pyre/bench/synth/exception_bare_reraise_nested_outer.wasm.jitstats
+++ b/pyre/bench/synth/exception_bare_reraise_nested_outer.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=2
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=401
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/exception_bare_reraise_restore.wasm.jitstats
+++ b/pyre/bench/synth/exception_bare_reraise_restore.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=1
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=201
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/exception_bridge_traceback_head.wasm.jitstats
+++ b/pyre/bench/synth/exception_bridge_traceback_head.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=2
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=19702
 internal_compile_panics=0
 loops_aborted=2
+loops_compiled=2

--- a/pyre/bench/synth/exception_catching_frame_tb_node.wasm.jitstats
+++ b/pyre/bench/synth/exception_catching_frame_tb_node.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=3
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=601
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=4

--- a/pyre/bench/synth/exception_const_operand_resume.wasm.jitstats
+++ b/pyre/bench/synth/exception_const_operand_resume.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=6
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1206
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=3

--- a/pyre/bench/synth/exception_context_chain_inhandler.wasm.jitstats
+++ b/pyre/bench/synth/exception_context_chain_inhandler.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/exception_dict_slot_reject.wasm.jitstats
+++ b/pyre/bench/synth/exception_dict_slot_reject.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=0

--- a/pyre/bench/synth/exception_escape_caller_frame_tb_node.wasm.jitstats
+++ b/pyre/bench/synth/exception_escape_caller_frame_tb_node.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=10
 internal_compile_panics=0
 loops_aborted=1
+loops_compiled=8

--- a/pyre/bench/synth/exception_escape_inlined_midframe_tb_node.wasm.jitstats
+++ b/pyre/bench/synth/exception_escape_inlined_midframe_tb_node.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=5
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=6

--- a/pyre/bench/synth/exception_group_type.wasm.jitstats
+++ b/pyre/bench/synth/exception_group_type.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=0

--- a/pyre/bench/synth/exception_inline_callee_tb_frames.wasm.jitstats
+++ b/pyre/bench/synth/exception_inline_callee_tb_frames.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=4
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=860
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=6

--- a/pyre/bench/synth/exception_inlined_callee_caught.wasm.jitstats
+++ b/pyre/bench/synth/exception_inlined_callee_caught.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=2
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/exception_loop_warmup.wasm.jitstats
+++ b/pyre/bench/synth/exception_loop_warmup.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=2
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=402
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/exception_metadata_hot.wasm.jitstats
+++ b/pyre/bench/synth/exception_metadata_hot.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=1
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=200
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=15

--- a/pyre/bench/synth/exception_metadata_jitstress.wasm.jitstats
+++ b/pyre/bench/synth/exception_metadata_jitstress.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=133
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=407

--- a/pyre/bench/synth/exception_multi_handler_warmup.wasm.jitstats
+++ b/pyre/bench/synth/exception_multi_handler_warmup.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=3
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=602
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/exception_nested_exc_info_restore.wasm.jitstats
+++ b/pyre/bench/synth/exception_nested_exc_info_restore.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=2
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=401
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=2

--- a/pyre/bench/synth/exception_oserror_fields.wasm.jitstats
+++ b/pyre/bench/synth/exception_oserror_fields.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=1
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=201
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/exception_raise_caught_same_frame_tb.wasm.jitstats
+++ b/pyre/bench/synth/exception_raise_caught_same_frame_tb.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=2
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=603
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=7

--- a/pyre/bench/synth/exception_reduce.wasm.jitstats
+++ b/pyre/bench/synth/exception_reduce.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/exception_reentry_guard_finally_residual.wasm.jitstats
+++ b/pyre/bench/synth/exception_reentry_guard_finally_residual.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=12
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=2459
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=3

--- a/pyre/bench/synth/exception_reraise_tb_depth_hot.wasm.jitstats
+++ b/pyre/bench/synth/exception_reraise_tb_depth_hot.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=9
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1803
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=4

--- a/pyre/bench/synth/exception_reraise_tb_depth_jitstress.wasm.jitstats
+++ b/pyre/bench/synth/exception_reraise_tb_depth_jitstress.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1798
 internal_compile_panics=0
 loops_aborted=7
+loops_compiled=900

--- a/pyre/bench/synth/exception_residual_raise_caught_in_frame.wasm.jitstats
+++ b/pyre/bench/synth/exception_residual_raise_caught_in_frame.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=6

--- a/pyre/bench/synth/exception_subclass_attrs.wasm.jitstats
+++ b/pyre/bench/synth/exception_subclass_attrs.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/exception_traceback_frame_lineno.wasm.jitstats
+++ b/pyre/bench/synth/exception_traceback_frame_lineno.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=3
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=811
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=14

--- a/pyre/bench/synth/exception_traceback_lineno_chain.wasm.jitstats
+++ b/pyre/bench/synth/exception_traceback_lineno_chain.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=4
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=802
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=5

--- a/pyre/bench/synth/exception_traceback_loop_forms.wasm.jitstats
+++ b/pyre/bench/synth/exception_traceback_loop_forms.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=4
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=810
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=8

--- a/pyre/bench/synth/exception_try_call_inlined_callee_raise.wasm.jitstats
+++ b/pyre/bench/synth/exception_try_call_inlined_callee_raise.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=1
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=821
 internal_compile_panics=0
 loops_aborted=1
+loops_compiled=3

--- a/pyre/bench/synth/exception_value_op_caught.wasm.jitstats
+++ b/pyre/bench/synth/exception_value_op_caught.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/exceptions.wasm.jitstats
+++ b/pyre/bench/synth/exceptions.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=1
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=201
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/exec_defined_global_read.wasm.jitstats
+++ b/pyre/bench/synth/exec_defined_global_read.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=196
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/fast_local_swap.wasm.jitstats
+++ b/pyre/bench/synth/fast_local_swap.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=3
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=3

--- a/pyre/bench/synth/finally_bare_raise.wasm.jitstats
+++ b/pyre/bench/synth/finally_bare_raise.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=3
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=3

--- a/pyre/bench/synth/float_builtin_hot.wasm.jitstats
+++ b/pyre/bench/synth/float_builtin_hot.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/float_div_zero_caught_loop.wasm.jitstats
+++ b/pyre/bench/synth/float_div_zero_caught_loop.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=3
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=613
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=2

--- a/pyre/bench/synth/float_pow_overflow_exp.wasm.jitstats
+++ b/pyre/bench/synth/float_pow_overflow_exp.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=3
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=602
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/float_subclass_binop_dispatch.wasm.jitstats
+++ b/pyre/bench/synth/float_subclass_binop_dispatch.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=9
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=9

--- a/pyre/bench/synth/for_iter_conditional_store_bridge.wasm.jitstats
+++ b/pyre/bench/synth/for_iter_conditional_store_bridge.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=1
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=312
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/for_iter_select_receiver_swap.wasm.jitstats
+++ b/pyre/bench/synth/for_iter_select_receiver_swap.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=4
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=802
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/foriter_call_body.wasm.jitstats
+++ b/pyre/bench/synth/foriter_call_body.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=2
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=496
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=2

--- a/pyre/bench/synth/foriter_call_resume_drops_iteration.wasm.jitstats
+++ b/pyre/bench/synth/foriter_call_resume_drops_iteration.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=23
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=5182
 internal_compile_panics=0
 loops_aborted=4
+loops_compiled=3

--- a/pyre/bench/synth/foriter_exempt_nested_foriter.wasm.jitstats
+++ b/pyre/bench/synth/foriter_exempt_nested_foriter.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=1
+loops_compiled=2

--- a/pyre/bench/synth/foriter_exempt_shared_generator.wasm.jitstats
+++ b/pyre/bench/synth/foriter_exempt_shared_generator.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=2
 internal_compile_panics=0
 loops_aborted=1
+loops_compiled=3

--- a/pyre/bench/synth/foriter_in_while.wasm.jitstats
+++ b/pyre/bench/synth/foriter_in_while.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=2
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=402
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=2

--- a/pyre/bench/synth/foriter_inplace_immutable.wasm.jitstats
+++ b/pyre/bench/synth/foriter_inplace_immutable.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=2

--- a/pyre/bench/synth/foriter_loadglobal_body.wasm.jitstats
+++ b/pyre/bench/synth/foriter_loadglobal_body.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=2
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=401
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/foriter_user_iter_kept_stack.wasm.jitstats
+++ b/pyre/bench/synth/foriter_user_iter_kept_stack.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=9
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=2421
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=6

--- a/pyre/bench/synth/format_z_negative_zero.wasm.jitstats
+++ b/pyre/bench/synth/format_z_negative_zero.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=0

--- a/pyre/bench/synth/gc_bug_bridge_flavor_traceback_names.wasm.jitstats
+++ b/pyre/bench/synth/gc_bug_bridge_flavor_traceback_names.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=7
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=20707
 internal_compile_panics=0
 loops_aborted=2
+loops_compiled=4

--- a/pyre/bench/synth/gc_deque_backing_list.wasm.jitstats
+++ b/pyre/bench/synth/gc_deque_backing_list.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=1
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=204
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=5

--- a/pyre/bench/synth/gc_iterator_source_drop.wasm.jitstats
+++ b/pyre/bench/synth/gc_iterator_source_drop.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=3
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=614
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=4

--- a/pyre/bench/synth/generator_pep479.wasm.jitstats
+++ b/pyre/bench/synth/generator_pep479.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/generator_tree_recursion.wasm.jitstats
+++ b/pyre/bench/synth/generator_tree_recursion.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=15
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1235
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=2

--- a/pyre/bench/synth/getattr_attribute_fallbacks.wasm.jitstats
+++ b/pyre/bench/synth/getattr_attribute_fallbacks.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=0

--- a/pyre/bench/synth/getattr_hook_binding.wasm.jitstats
+++ b/pyre/bench/synth/getattr_hook_binding.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=0

--- a/pyre/bench/synth/getattr_surrogate_hook.wasm.jitstats
+++ b/pyre/bench/synth/getattr_surrogate_hook.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=0

--- a/pyre/bench/synth/getattribute_intercepts_dunder.wasm.jitstats
+++ b/pyre/bench/synth/getattribute_intercepts_dunder.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=0

--- a/pyre/bench/synth/getattribute_override_no_bind.wasm.jitstats
+++ b/pyre/bench/synth/getattribute_override_no_bind.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=14
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=2

--- a/pyre/bench/synth/getframe_force_cancel_journal.wasm.jitstats
+++ b/pyre/bench/synth/getframe_force_cancel_journal.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=5
+loops_compiled=0

--- a/pyre/bench/synth/getframe_inline_subwalk_multiframe.wasm.jitstats
+++ b/pyre/bench/synth/getframe_inline_subwalk_multiframe.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=15
+loops_compiled=0

--- a/pyre/bench/synth/getframe_inlined_callee_own_frame.wasm.jitstats
+++ b/pyre/bench/synth/getframe_inlined_callee_own_frame.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=10
+loops_compiled=0

--- a/pyre/bench/synth/getframe_residual_callee_own_frame.wasm.jitstats
+++ b/pyre/bench/synth/getframe_residual_callee_own_frame.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=5
+loops_compiled=1

--- a/pyre/bench/synth/getframe_root_loop_force_blackhole_crn.wasm.jitstats
+++ b/pyre/bench/synth/getframe_root_loop_force_blackhole_crn.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=5
+loops_compiled=0

--- a/pyre/bench/synth/getframe_root_loop_force_blackhole_crn_nonidempotent.wasm.jitstats
+++ b/pyre/bench/synth/getframe_root_loop_force_blackhole_crn_nonidempotent.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=5
+loops_compiled=0

--- a/pyre/bench/synth/getframe_root_loop_force_while_merge.wasm.jitstats
+++ b/pyre/bench/synth/getframe_root_loop_force_while_merge.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=5
+loops_compiled=0

--- a/pyre/bench/synth/getframe_stored_fback_walk.wasm.jitstats
+++ b/pyre/bench/synth/getframe_stored_fback_walk.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=10
+loops_compiled=0

--- a/pyre/bench/synth/getframe_while_caller_locals_across_subwalk.wasm.jitstats
+++ b/pyre/bench/synth/getframe_while_caller_locals_across_subwalk.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=10
+loops_compiled=0

--- a/pyre/bench/synth/getframe_while_captured_frame_outlives_call.wasm.jitstats
+++ b/pyre/bench/synth/getframe_while_captured_frame_outlives_call.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=10
+loops_compiled=0

--- a/pyre/bench/synth/getframe_while_escaping_read_frame_identity.wasm.jitstats
+++ b/pyre/bench/synth/getframe_while_escaping_read_frame_identity.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=20
+loops_compiled=0

--- a/pyre/bench/synth/getframe_while_inlined_callee_subwalk.wasm.jitstats
+++ b/pyre/bench/synth/getframe_while_inlined_callee_subwalk.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=10
+loops_compiled=0

--- a/pyre/bench/synth/getframe_while_subwalk_decline_shapes.wasm.jitstats
+++ b/pyre/bench/synth/getframe_while_subwalk_decline_shapes.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=25
+loops_compiled=0

--- a/pyre/bench/synth/global_cell_shortpreamble_hot.wasm.jitstats
+++ b/pyre/bench/synth/global_cell_shortpreamble_hot.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=2
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=409
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=2

--- a/pyre/bench/synth/global_quasiimmut_invalidation.wasm.jitstats
+++ b/pyre/bench/synth/global_quasiimmut_invalidation.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=2
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=402
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=2

--- a/pyre/bench/synth/global_reassign.wasm.jitstats
+++ b/pyre/bench/synth/global_reassign.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=8
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=8

--- a/pyre/bench/synth/global_reassign_invalidation.wasm.jitstats
+++ b/pyre/bench/synth/global_reassign_invalidation.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=2

--- a/pyre/bench/synth/global_store_plain_dict_globals.wasm.jitstats
+++ b/pyre/bench/synth/global_store_plain_dict_globals.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
-loops_aborted=3
+loops_aborted=1
+loops_compiled=5

--- a/pyre/bench/synth/goto_if_not_same_box.wasm.jitstats
+++ b/pyre/bench/synth/goto_if_not_same_box.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=2
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=2

--- a/pyre/bench/synth/handler_reraise_second_exc.wasm.jitstats
+++ b/pyre/bench/synth/handler_reraise_second_exc.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=2
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1285
 internal_compile_panics=0
 loops_aborted=1
+loops_compiled=2

--- a/pyre/bench/synth/hash_subclass_disabled.wasm.jitstats
+++ b/pyre/bench/synth/hash_subclass_disabled.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=4

--- a/pyre/bench/synth/hot_loop_exit_then_class_stmt.wasm.jitstats
+++ b/pyre/bench/synth/hot_loop_exit_then_class_stmt.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=2
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=2

--- a/pyre/bench/synth/if_else_jump_forward.wasm.jitstats
+++ b/pyre/bench/synth/if_else_jump_forward.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=1
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=201
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/imp_lock_rlock_semantics.wasm.jitstats
+++ b/pyre/bench/synth/imp_lock_rlock_semantics.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=0

--- a/pyre/bench/synth/import_from_hot.wasm.jitstats
+++ b/pyre/bench/synth/import_from_hot.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/import_from_name_path.wasm.jitstats
+++ b/pyre/bench/synth/import_from_name_path.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=0

--- a/pyre/bench/synth/import_math.wasm.jitstats
+++ b/pyre/bench/synth/import_math.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/import_name.wasm.jitstats
+++ b/pyre/bench/synth/import_name.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/import_none_sentinel.wasm.jitstats
+++ b/pyre/bench/synth/import_none_sentinel.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=0

--- a/pyre/bench/synth/inheritance_dispatch.wasm.jitstats
+++ b/pyre/bench/synth/inheritance_dispatch.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=3
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=601
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/inline_bignum_bridge_twoclamp.wasm.jitstats
+++ b/pyre/bench/synth/inline_bignum_bridge_twoclamp.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=76
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/inline_callee_constructs_object.wasm.jitstats
+++ b/pyre/bench/synth/inline_callee_constructs_object.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/inline_chain_depth_typeflip.wasm.jitstats
+++ b/pyre/bench/synth/inline_chain_depth_typeflip.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=19
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=3818
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=6

--- a/pyre/bench/synth/inline_freevar_after_mayforce.wasm.jitstats
+++ b/pyre/bench/synth/inline_freevar_after_mayforce.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=1
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=471
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=6

--- a/pyre/bench/synth/inline_gate_operand_provenance.wasm.jitstats
+++ b/pyre/bench/synth/inline_gate_operand_provenance.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=10
 internal_compile_panics=0
 loops_aborted=3
+loops_compiled=7

--- a/pyre/bench/synth/inline_multiframe_branchy_carrier.wasm.jitstats
+++ b/pyre/bench/synth/inline_multiframe_branchy_carrier.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=4
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=812
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=4

--- a/pyre/bench/synth/inline_subwalk_mutating_residual.wasm.jitstats
+++ b/pyre/bench/synth/inline_subwalk_mutating_residual.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=3
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=23950
 internal_compile_panics=0
 loops_aborted=1
+loops_compiled=4

--- a/pyre/bench/synth/inline_subwalk_property_mutates.wasm.jitstats
+++ b/pyre/bench/synth/inline_subwalk_property_mutates.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=2
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=23748
 internal_compile_panics=0
 loops_aborted=1
+loops_compiled=2

--- a/pyre/bench/synth/inline_subwalk_radd_consumed.wasm.jitstats
+++ b/pyre/bench/synth/inline_subwalk_radd_consumed.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=2
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=401
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/inline_subwalk_user_iterator.wasm.jitstats
+++ b/pyre/bench/synth/inline_subwalk_user_iterator.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=2
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=402
 internal_compile_panics=0
 loops_aborted=1
+loops_compiled=3

--- a/pyre/bench/synth/inlined_callee_extended_arg_handler.wasm.jitstats
+++ b/pyre/bench/synth/inlined_callee_extended_arg_handler.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=2

--- a/pyre/bench/synth/inlined_helper_arith_hot.wasm.jitstats
+++ b/pyre/bench/synth/inlined_helper_arith_hot.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=13
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=13

--- a/pyre/bench/synth/inlined_helper_mutation.wasm.jitstats
+++ b/pyre/bench/synth/inlined_helper_mutation.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=3
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=4

--- a/pyre/bench/synth/instance_dict_reassign.wasm.jitstats
+++ b/pyre/bench/synth/instance_dict_reassign.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/instance_surrogate_attrs.wasm.jitstats
+++ b/pyre/bench/synth/instance_surrogate_attrs.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/int_base0_error_literal.wasm.jitstats
+++ b/pyre/bench/synth/int_base0_error_literal.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=0

--- a/pyre/bench/synth/int_from_bad_dunder.wasm.jitstats
+++ b/pyre/bench/synth/int_from_bad_dunder.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/int_lshift_memoryerror.wasm.jitstats
+++ b/pyre/bench/synth/int_lshift_memoryerror.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/int_max_str_digits.wasm.jitstats
+++ b/pyre/bench/synth/int_max_str_digits.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=0

--- a/pyre/bench/synth/int_mul_ovf_bignum_promote.wasm.jitstats
+++ b/pyre/bench/synth/int_mul_ovf_bignum_promote.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=1
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=321
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/is_op_identity.wasm.jitstats
+++ b/pyre/bench/synth/is_op_identity.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=2
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=3

--- a/pyre/bench/synth/iter_sentinel_stopiteration.wasm.jitstats
+++ b/pyre/bench/synth/iter_sentinel_stopiteration.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=0

--- a/pyre/bench/synth/iteration_protocol.wasm.jitstats
+++ b/pyre/bench/synth/iteration_protocol.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=2
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=401
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/itertools_cycle.wasm.jitstats
+++ b/pyre/bench/synth/itertools_cycle.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=0

--- a/pyre/bench/synth/jit_callee_raised_exc_value.wasm.jitstats
+++ b/pyre/bench/synth/jit_callee_raised_exc_value.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=2
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=402
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=2

--- a/pyre/bench/synth/jit_reg_const_pool_256_slot_decline.wasm.jitstats
+++ b/pyre/bench/synth/jit_reg_const_pool_256_slot_decline.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/kept_stack_aliased_swap_boxed.wasm.jitstats
+++ b/pyre/bench/synth/kept_stack_aliased_swap_boxed.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=1
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=201
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/kept_stack_boxed_in_handler.wasm.jitstats
+++ b/pyre/bench/synth/kept_stack_boxed_in_handler.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=2
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=401
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/kept_stack_branch_depths.wasm.jitstats
+++ b/pyre/bench/synth/kept_stack_branch_depths.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=11
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=2201
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/kept_stack_deep_var_condexpr.wasm.jitstats
+++ b/pyre/bench/synth/kept_stack_deep_var_condexpr.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=1
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=201
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/kept_stack_deep_var_nested_call.wasm.jitstats
+++ b/pyre/bench/synth/kept_stack_deep_var_nested_call.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/kept_stack_deep_var_shortcircuit.wasm.jitstats
+++ b/pyre/bench/synth/kept_stack_deep_var_shortcircuit.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=4
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=824
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=6

--- a/pyre/bench/synth/kept_stack_depth_gt1.wasm.jitstats
+++ b/pyre/bench/synth/kept_stack_depth_gt1.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=9
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1805
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=5

--- a/pyre/bench/synth/kept_stack_depth_gt1_heap.wasm.jitstats
+++ b/pyre/bench/synth/kept_stack_depth_gt1_heap.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=5
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1004
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=4

--- a/pyre/bench/synth/key_eq_resize_restart.wasm.jitstats
+++ b/pyre/bench/synth/key_eq_resize_restart.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=0

--- a/pyre/bench/synth/key_eq_restart_forgets.wasm.jitstats
+++ b/pyre/bench/synth/key_eq_restart_forgets.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/kwargs_positional_only.wasm.jitstats
+++ b/pyre/bench/synth/kwargs_positional_only.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=0

--- a/pyre/bench/synth/len_dunder_validation.wasm.jitstats
+++ b/pyre/bench/synth/len_dunder_validation.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=0

--- a/pyre/bench/synth/list_append_funcentry_helper.wasm.jitstats
+++ b/pyre/bench/synth/list_append_funcentry_helper.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=3
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=2

--- a/pyre/bench/synth/list_append_virtual_payload.wasm.jitstats
+++ b/pyre/bench/synth/list_append_virtual_payload.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=0

--- a/pyre/bench/synth/list_append_write_barrier_gc.wasm.jitstats
+++ b/pyre/bench/synth/list_append_write_barrier_gc.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=1
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=200
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/list_bound_method_mutation.wasm.jitstats
+++ b/pyre/bench/synth/list_bound_method_mutation.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=10
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=3

--- a/pyre/bench/synth/list_error_parity.wasm.jitstats
+++ b/pyre/bench/synth/list_error_parity.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/list_inplace_mul_parity.wasm.jitstats
+++ b/pyre/bench/synth/list_inplace_mul_parity.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/list_insert.wasm.jitstats
+++ b/pyre/bench/synth/list_insert.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/list_insert_pop_index.wasm.jitstats
+++ b/pyre/bench/synth/list_insert_pop_index.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/list_length_hint_validate.wasm.jitstats
+++ b/pyre/bench/synth/list_length_hint_validate.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
-loops_aborted=16
+loops_aborted=10
+loops_compiled=2

--- a/pyre/bench/synth/list_nan_identity.wasm.jitstats
+++ b/pyre/bench/synth/list_nan_identity.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/list_ops.wasm.jitstats
+++ b/pyre/bench/synth/list_ops.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=2
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=408
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=7

--- a/pyre/bench/synth/list_pop_append.wasm.jitstats
+++ b/pyre/bench/synth/list_pop_append.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/list_reverse.wasm.jitstats
+++ b/pyre/bench/synth/list_reverse.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=10
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/list_setslice.wasm.jitstats
+++ b/pyre/bench/synth/list_setslice.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/list_subscript_index.wasm.jitstats
+++ b/pyre/bench/synth/list_subscript_index.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/list_to_tuple_star.wasm.jitstats
+++ b/pyre/bench/synth/list_to_tuple_star.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=0

--- a/pyre/bench/synth/listcomp_hot.wasm.jitstats
+++ b/pyre/bench/synth/listcomp_hot.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=1
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=239
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/load_attr_blackhole_resume.wasm.jitstats
+++ b/pyre/bench/synth/load_attr_blackhole_resume.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=1
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=201
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/load_fast_check.wasm.jitstats
+++ b/pyre/bench/synth/load_fast_check.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/load_super_attr.wasm.jitstats
+++ b/pyre/bench/synth/load_super_attr.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/loop_callee_return.wasm.jitstats
+++ b/pyre/bench/synth/loop_callee_return.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=1
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=201
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=3

--- a/pyre/bench/synth/loop_callee_shared_mutation.wasm.jitstats
+++ b/pyre/bench/synth/loop_callee_shared_mutation.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=2
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=201
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=2

--- a/pyre/bench/synth/loop_exit_empty_dict_local_clobber.wasm.jitstats
+++ b/pyre/bench/synth/loop_exit_empty_dict_local_clobber.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/loops_comprehension.wasm.jitstats
+++ b/pyre/bench/synth/loops_comprehension.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=5
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1005
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=4

--- a/pyre/bench/synth/make_function_inline.wasm.jitstats
+++ b/pyre/bench/synth/make_function_inline.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=2

--- a/pyre/bench/synth/mapdict_frozen_unboxing_fold.wasm.jitstats
+++ b/pyre/bench/synth/mapdict_frozen_unboxing_fold.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=2
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=404
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=3

--- a/pyre/bench/synth/mapdict_polymorphic_map_attr.wasm.jitstats
+++ b/pyre/bench/synth/mapdict_polymorphic_map_attr.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=2
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=401
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/mapdict_unboxed_type_change_attr.wasm.jitstats
+++ b/pyre/bench/synth/mapdict_unboxed_type_change_attr.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=2
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=404
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=2

--- a/pyre/bench/synth/match_sequence_of_class_patterns.wasm.jitstats
+++ b/pyre/bench/synth/match_sequence_of_class_patterns.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=5
+loops_compiled=1

--- a/pyre/bench/synth/math_isqrt_compare_bridge_resume.wasm.jitstats
+++ b/pyre/bench/synth/math_isqrt_compare_bridge_resume.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=2
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=409
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=4

--- a/pyre/bench/synth/math_log_trig_hot.wasm.jitstats
+++ b/pyre/bench/synth/math_log_trig_hot.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/math_sqrt_hot.wasm.jitstats
+++ b/pyre/bench/synth/math_sqrt_hot.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/metaclass_conflict.wasm.jitstats
+++ b/pyre/bench/synth/metaclass_conflict.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=0

--- a/pyre/bench/synth/metaclass_getattr.wasm.jitstats
+++ b/pyre/bench/synth/metaclass_getattr.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/metaclass_getattribute_delattr.wasm.jitstats
+++ b/pyre/bench/synth/metaclass_getattribute_delattr.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/metatype_property_dunder.wasm.jitstats
+++ b/pyre/bench/synth/metatype_property_dunder.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=0

--- a/pyre/bench/synth/method_reassign_after_warmup.wasm.jitstats
+++ b/pyre/bench/synth/method_reassign_after_warmup.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=8
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=8

--- a/pyre/bench/synth/minmax_key_rooting.wasm.jitstats
+++ b/pyre/bench/synth/minmax_key_rooting.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/module_attr_message.wasm.jitstats
+++ b/pyre/bench/synth/module_attr_message.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=0

--- a/pyre/bench/synth/module_body_truncated_jitcode_replay.wasm.jitstats
+++ b/pyre/bench/synth/module_body_truncated_jitcode_replay.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/module_dir_dunder.wasm.jitstats
+++ b/pyre/bench/synth/module_dir_dunder.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=0

--- a/pyre/bench/synth/module_function_not_descriptor.wasm.jitstats
+++ b/pyre/bench/synth/module_function_not_descriptor.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=0

--- a/pyre/bench/synth/module_getattr.wasm.jitstats
+++ b/pyre/bench/synth/module_getattr.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=0

--- a/pyre/bench/synth/module_getattr_descr_error.wasm.jitstats
+++ b/pyre/bench/synth/module_getattr_descr_error.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/module_getattr_surrogate_cls.wasm.jitstats
+++ b/pyre/bench/synth/module_getattr_surrogate_cls.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/mutate_then_raise_caught.wasm.jitstats
+++ b/pyre/bench/synth/mutate_then_raise_caught.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=3
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=612
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=2

--- a/pyre/bench/synth/mutate_uncaught_raise_delivery.wasm.jitstats
+++ b/pyre/bench/synth/mutate_uncaught_raise_delivery.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=5
+loops_compiled=1

--- a/pyre/bench/synth/named_reraise_sibling_hot.wasm.jitstats
+++ b/pyre/bench/synth/named_reraise_sibling_hot.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=4
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=2648
 internal_compile_panics=0
 loops_aborted=3
+loops_compiled=4

--- a/pyre/bench/synth/nested_break_not_hot.wasm.jitstats
+++ b/pyre/bench/synth/nested_break_not_hot.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=4
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1001
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=2

--- a/pyre/bench/synth/nested_callee_chain_mutation_abort.wasm.jitstats
+++ b/pyre/bench/synth/nested_callee_chain_mutation_abort.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=2
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=402
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=2

--- a/pyre/bench/synth/nested_for_int_scratch_bridge.wasm.jitstats
+++ b/pyre/bench/synth/nested_for_int_scratch_bridge.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=3
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=601
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/nested_for_outer_local_postread.wasm.jitstats
+++ b/pyre/bench/synth/nested_for_outer_local_postread.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=9
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=2141
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=5

--- a/pyre/bench/synth/nested_for_varying_trip.wasm.jitstats
+++ b/pyre/bench/synth/nested_for_varying_trip.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=2
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=401
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/nested_foriter_poly.wasm.jitstats
+++ b/pyre/bench/synth/nested_foriter_poly.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=2
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=401
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/nested_list_comprehension_hot.wasm.jitstats
+++ b/pyre/bench/synth/nested_list_comprehension_hot.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=2
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=401
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=2

--- a/pyre/bench/synth/nested_loop_correctness.wasm.jitstats
+++ b/pyre/bench/synth/nested_loop_correctness.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=5
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1043
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=4

--- a/pyre/bench/synth/nested_loop_gate_switch.wasm.jitstats
+++ b/pyre/bench/synth/nested_loop_gate_switch.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=6
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1796
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=2

--- a/pyre/bench/synth/newslice_step_hot.wasm.jitstats
+++ b/pyre/bench/synth/newslice_step_hot.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=4
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=2

--- a/pyre/bench/synth/object_getattribute_no_hook.wasm.jitstats
+++ b/pyre/bench/synth/object_getattribute_no_hook.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=0

--- a/pyre/bench/synth/operator_error_typename.wasm.jitstats
+++ b/pyre/bench/synth/operator_error_typename.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/operator_set_inplace_ops.wasm.jitstats
+++ b/pyre/bench/synth/operator_set_inplace_ops.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/or_chain_fresh_alloc_arg.wasm.jitstats
+++ b/pyre/bench/synth/or_chain_fresh_alloc_arg.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=1
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=200
 internal_compile_panics=0
 loops_aborted=1
+loops_compiled=2

--- a/pyre/bench/synth/p2_local_result_bridge.wasm.jitstats
+++ b/pyre/bench/synth/p2_local_result_bridge.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=5
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1006
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=2

--- a/pyre/bench/synth/pickle_ctor_args.wasm.jitstats
+++ b/pyre/bench/synth/pickle_ctor_args.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=5

--- a/pyre/bench/synth/pickle_terminal_raise_resume.wasm.jitstats
+++ b/pyre/bench/synth/pickle_terminal_raise_resume.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=451
 internal_compile_panics=0
-loops_aborted=37
+loops_aborted=13
+loops_compiled=74

--- a/pyre/bench/synth/polymorphic_binary_receiver.wasm.jitstats
+++ b/pyre/bench/synth/polymorphic_binary_receiver.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=4
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1045
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=5

--- a/pyre/bench/synth/polymorphic_slot_retype.wasm.jitstats
+++ b/pyre/bench/synth/polymorphic_slot_retype.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=4
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1175
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/pow3_arg_types.wasm.jitstats
+++ b/pyre/bench/synth/pow3_arg_types.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/print_stdout_redirect.wasm.jitstats
+++ b/pyre/bench/synth/print_stdout_redirect.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=0

--- a/pyre/bench/synth/property_custom_hook_decline.wasm.jitstats
+++ b/pyre/bench/synth/property_custom_hook_decline.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/property_getattr_exceptions.wasm.jitstats
+++ b/pyre/bench/synth/property_getattr_exceptions.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/property_protocol_hot.wasm.jitstats
+++ b/pyre/bench/synth/property_protocol_hot.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/pure_listload_raw.wasm.jitstats
+++ b/pyre/bench/synth/pure_listload_raw.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=0

--- a/pyre/bench/synth/pure_tupleload.wasm.jitstats
+++ b/pyre/bench/synth/pure_tupleload.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=2
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=2

--- a/pyre/bench/synth/pypy_dict_primitives_nonbinding.wasm.jitstats
+++ b/pyre/bench/synth/pypy_dict_primitives_nonbinding.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=0

--- a/pyre/bench/synth/raise_reg_unbound_jitstress.wasm.jitstats
+++ b/pyre/bench/synth/raise_reg_unbound_jitstress.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=5
 internal_compile_panics=0
 loops_aborted=2
+loops_compiled=5

--- a/pyre/bench/synth/recursion_memo_branch.wasm.jitstats
+++ b/pyre/bench/synth/recursion_memo_branch.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=11
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=2227
 internal_compile_panics=0
 loops_aborted=1
+loops_compiled=2

--- a/pyre/bench/synth/recursive_call_frame_relocation.wasm.jitstats
+++ b/pyre/bench/synth/recursive_call_frame_relocation.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=3
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=651
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=3

--- a/pyre/bench/synth/reentrant_key_eq_mutation.wasm.jitstats
+++ b/pyre/bench/synth/reentrant_key_eq_mutation.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=0

--- a/pyre/bench/synth/residual_raise_except_resume.wasm.jitstats
+++ b/pyre/bench/synth/residual_raise_except_resume.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=5
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=5

--- a/pyre/bench/synth/reversed_disabled.wasm.jitstats
+++ b/pyre/bench/synth/reversed_disabled.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=0

--- a/pyre/bench/synth/selfrec_tail_exception_unwind.wasm.jitstats
+++ b/pyre/bench/synth/selfrec_tail_exception_unwind.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=6
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=937
 internal_compile_panics=0
 loops_aborted=1
+loops_compiled=3

--- a/pyre/bench/synth/seq_repeat_overflow.wasm.jitstats
+++ b/pyre/bench/synth/seq_repeat_overflow.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/seqiter_getitem_lazy.wasm.jitstats
+++ b/pyre/bench/synth/seqiter_getitem_lazy.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=2
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=401
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/seqiter_pickle_parity.wasm.jitstats
+++ b/pyre/bench/synth/seqiter_pickle_parity.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/seqiter_tuple_error_parity.wasm.jitstats
+++ b/pyre/bench/synth/seqiter_tuple_error_parity.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=1
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=202
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=2

--- a/pyre/bench/synth/sequence_repeat_index.wasm.jitstats
+++ b/pyre/bench/synth/sequence_repeat_index.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=1
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=201
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/set_contains_frozenset.wasm.jitstats
+++ b/pyre/bench/synth/set_contains_frozenset.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=0

--- a/pyre/bench/synth/set_hash_protocol.wasm.jitstats
+++ b/pyre/bench/synth/set_hash_protocol.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=0

--- a/pyre/bench/synth/set_intersection_operand.wasm.jitstats
+++ b/pyre/bench/synth/set_intersection_operand.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=0

--- a/pyre/bench/synth/set_key_protocol.wasm.jitstats
+++ b/pyre/bench/synth/set_key_protocol.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/set_method_arity.wasm.jitstats
+++ b/pyre/bench/synth/set_method_arity.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=0

--- a/pyre/bench/synth/set_name_filtered_dict.wasm.jitstats
+++ b/pyre/bench/synth/set_name_filtered_dict.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=0

--- a/pyre/bench/synth/set_reentrant_eq_mutation.wasm.jitstats
+++ b/pyre/bench/synth/set_reentrant_eq_mutation.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=0

--- a/pyre/bench/synth/set_remove_ord_errors.wasm.jitstats
+++ b/pyre/bench/synth/set_remove_ord_errors.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/set_update_hash_other.wasm.jitstats
+++ b/pyre/bench/synth/set_update_hash_other.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=0

--- a/pyre/bench/synth/set_update_hot.wasm.jitstats
+++ b/pyre/bench/synth/set_update_hot.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=1
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=200
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/set_update_materialize_rhs.wasm.jitstats
+++ b/pyre/bench/synth/set_update_materialize_rhs.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=0

--- a/pyre/bench/synth/short_circuit_boxed_int_cross_fn.wasm.jitstats
+++ b/pyre/bench/synth/short_circuit_boxed_int_cross_fn.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=2
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=402
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=2

--- a/pyre/bench/synth/short_circuit_falsy_func_entry_resume.wasm.jitstats
+++ b/pyre/bench/synth/short_circuit_falsy_func_entry_resume.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=2
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=201
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=2

--- a/pyre/bench/synth/short_circuit_side_effects.wasm.jitstats
+++ b/pyre/bench/synth/short_circuit_side_effects.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=7
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1972
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=4

--- a/pyre/bench/synth/short_circuit_value_kept_stack.wasm.jitstats
+++ b/pyre/bench/synth/short_circuit_value_kept_stack.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=12
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=2510
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/short_circuit_value_local_kept.wasm.jitstats
+++ b/pyre/bench/synth/short_circuit_value_local_kept.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=3
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=603
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=3

--- a/pyre/bench/synth/simple_namespace_type.wasm.jitstats
+++ b/pyre/bench/synth/simple_namespace_type.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=0

--- a/pyre/bench/synth/slots_class_var_conflict.wasm.jitstats
+++ b/pyre/bench/synth/slots_class_var_conflict.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
-loops_aborted=5
+loops_aborted=0
+loops_compiled=5

--- a/pyre/bench/synth/sre_pattern_methods.wasm.jitstats
+++ b/pyre/bench/synth/sre_pattern_methods.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=7
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=2536
 internal_compile_panics=0
 loops_aborted=1
+loops_compiled=7

--- a/pyre/bench/synth/sre_wasm_min.wasm.jitstats
+++ b/pyre/bench/synth/sre_wasm_min.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=5
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1161
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=5

--- a/pyre/bench/synth/sre_wasm_min1.wasm.jitstats
+++ b/pyre/bench/synth/sre_wasm_min1.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=3
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=603
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=4

--- a/pyre/bench/synth/store_global_hot.wasm.jitstats
+++ b/pyre/bench/synth/store_global_hot.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=2
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=401
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/store_slice_hot.wasm.jitstats
+++ b/pyre/bench/synth/store_slice_hot.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/str_encode_text_codec.wasm.jitstats
+++ b/pyre/bench/synth/str_encode_text_codec.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/str_fstring.wasm.jitstats
+++ b/pyre/bench/synth/str_fstring.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=3
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=666
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=6

--- a/pyre/bench/synth/str_getitem_len_hot.wasm.jitstats
+++ b/pyre/bench/synth/str_getitem_len_hot.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=7
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=2

--- a/pyre/bench/synth/str_index_bytes_iter_surface.wasm.jitstats
+++ b/pyre/bench/synth/str_index_bytes_iter_surface.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=1
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=461
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=10

--- a/pyre/bench/synth/str_search_index_bounds.wasm.jitstats
+++ b/pyre/bench/synth/str_search_index_bounds.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=7
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=2096
 internal_compile_panics=0
 loops_aborted=1
+loops_compiled=5

--- a/pyre/bench/synth/str_startswith_bounds.wasm.jitstats
+++ b/pyre/bench/synth/str_startswith_bounds.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/struct_pack_unpack.wasm.jitstats
+++ b/pyre/bench/synth/struct_pack_unpack.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/subscr_negative_index_deopt.wasm.jitstats
+++ b/pyre/bench/synth/subscr_negative_index_deopt.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=1
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=202
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/surrogate_class_kwargs.wasm.jitstats
+++ b/pyre/bench/synth/surrogate_class_kwargs.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=0

--- a/pyre/bench/synth/surrogate_dir.wasm.jitstats
+++ b/pyre/bench/synth/surrogate_dir.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=0

--- a/pyre/bench/synth/surrogate_kwargs.wasm.jitstats
+++ b/pyre/bench/synth/surrogate_kwargs.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/surrogate_metaclass_kwargs.wasm.jitstats
+++ b/pyre/bench/synth/surrogate_metaclass_kwargs.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=0

--- a/pyre/bench/synth/swap_except_return_resume.wasm.jitstats
+++ b/pyre/bench/synth/swap_except_return_resume.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=4
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=4

--- a/pyre/bench/synth/syntaxerror_location.wasm.jitstats
+++ b/pyre/bench/synth/syntaxerror_location.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=0

--- a/pyre/bench/synth/syntaxerror_str.wasm.jitstats
+++ b/pyre/bench/synth/syntaxerror_str.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=0

--- a/pyre/bench/synth/trace_too_long_effect_replay.wasm.jitstats
+++ b/pyre/bench/synth/trace_too_long_effect_replay.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=5
+loops_compiled=1

--- a/pyre/bench/synth/trace_too_long_inline_multiframe.wasm.jitstats
+++ b/pyre/bench/synth/trace_too_long_inline_multiframe.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=23
+loops_compiled=0

--- a/pyre/bench/synth/tuple_contains_eq_raises.wasm.jitstats
+++ b/pyre/bench/synth/tuple_contains_eq_raises.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=0

--- a/pyre/bench/synth/tuple_str_bytes_subscript_index.wasm.jitstats
+++ b/pyre/bench/synth/tuple_str_bytes_subscript_index.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/tuple_unpack_array_backed_hot.wasm.jitstats
+++ b/pyre/bench/synth/tuple_unpack_array_backed_hot.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=3
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/type_descr_get_metaclass_getattr.wasm.jitstats
+++ b/pyre/bench/synth/type_descr_get_metaclass_getattr.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=0

--- a/pyre/bench/synth/type_dict_surrogate.wasm.jitstats
+++ b/pyre/bench/synth/type_dict_surrogate.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/type_dotted_name.wasm.jitstats
+++ b/pyre/bench/synth/type_dotted_name.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=0

--- a/pyre/bench/synth/type_error_message_parity.wasm.jitstats
+++ b/pyre/bench/synth/type_error_message_parity.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=0

--- a/pyre/bench/synth/type_immutable_reject.wasm.jitstats
+++ b/pyre/bench/synth/type_immutable_reject.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/type_metatype_data_descr.wasm.jitstats
+++ b/pyre/bench/synth/type_metatype_data_descr.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=0
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=0

--- a/pyre/bench/synth/type_metatype_method_call.wasm.jitstats
+++ b/pyre/bench/synth/type_metatype_method_call.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=2

--- a/pyre/bench/synth/type_name_setter.wasm.jitstats
+++ b/pyre/bench/synth/type_name_setter.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=3
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/type_name_surrogate_reject.wasm.jitstats
+++ b/pyre/bench/synth/type_name_surrogate_reject.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=9464
 internal_compile_panics=0
 loops_aborted=1
+loops_compiled=2

--- a/pyre/bench/synth/unary_int_loop_carried.wasm.jitstats
+++ b/pyre/bench/synth/unary_int_loop_carried.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=3
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=3

--- a/pyre/bench/synth/unary_negative.wasm.jitstats
+++ b/pyre/bench/synth/unary_negative.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=5
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=2

--- a/pyre/bench/synth/unary_positive_resume.wasm.jitstats
+++ b/pyre/bench/synth/unary_positive_resume.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=3
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/unpack_drain_star_raise.wasm.jitstats
+++ b/pyre/bench/synth/unpack_drain_star_raise.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=40
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/unpack_ex_hot.wasm.jitstats
+++ b/pyre/bench/synth/unpack_ex_hot.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=2
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/unpack_wrong_arity_caught.wasm.jitstats
+++ b/pyre/bench/synth/unpack_wrong_arity_caught.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=5
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1001
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/wasm_ca_trampoline_decline.wasm.jitstats
+++ b/pyre/bench/synth/wasm_ca_trampoline_decline.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=1
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=400
 internal_compile_panics=0
 loops_aborted=1
+loops_compiled=1

--- a/pyre/bench/synth/while_is_none.wasm.jitstats
+++ b/pyre/bench/synth/while_is_none.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=1
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=200
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/bench/synth/with_except_start_function_resume.wasm.jitstats
+++ b/pyre/bench/synth/with_except_start_function_resume.wasm.jitstats
@@ -1,5 +1,8 @@
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
+loops_compiled=1

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -12179,7 +12179,11 @@ fn generator_unpack_into(
     unsafe {
         // generator.py:325-327 — `frame is None: return`.
         if w_generator_is_running(gen_obj) {
-            return Err(PyError::value_error("generator already executing"));
+            // generator.py:112 `"%s already executing" % self.KIND`.
+            return Err(PyError::value_error(format!(
+                "{} already executing",
+                generator_kind(gen_obj)
+            )));
         }
         if w_generator_is_exhausted(gen_obj) {
             return Ok(());
@@ -16120,7 +16124,11 @@ unsafe fn generator_invoke_execute_frame(
 ) -> PyResult {
     use pyre_object::generator::*;
     if w_generator_is_running(gen_obj) {
-        return Err(PyError::value_error("generator already executing"));
+        // generator.py:112 `"%s already executing" % self.KIND`.
+        return Err(PyError::value_error(format!(
+            "{} already executing",
+            generator_kind(gen_obj)
+        )));
     }
     w_generator_set_running(gen_obj, true);
     let ec = crate::call::getexecutioncontext() as *mut crate::executioncontext::ExecutionContext;
@@ -16137,22 +16145,25 @@ unsafe fn generator_invoke_execute_frame(
     let result = match result {
         Err(e) => {
             generator_frame_is_finished(gen_obj, frame);
-            if e.kind == crate::PyErrorKind::StopIteration {
-                let message = if is_async_generator(gen_obj) {
-                    "async generator raised StopIteration"
-                } else {
-                    "generator raised StopIteration"
-                };
-                Err(leak_generator_iteration(e, message))
+            // generator.py:166-179 `_leak_stopiteration` and
+            // `_leak_stopasynciteration`, which differ only in the name they
+            // format after KIND.  The second is reachable on async generators
+            // alone, which is why it tests the flavour and the first does not.
+            let leaked = if e.kind == crate::PyErrorKind::StopIteration {
+                Some("StopIteration")
             } else if is_async_generator(gen_obj)
                 && e.kind == crate::PyErrorKind::StopAsyncIteration
             {
-                Err(leak_generator_iteration(
-                    e,
-                    "async generator raised StopAsyncIteration",
-                ))
+                Some("StopAsyncIteration")
             } else {
-                Err(e)
+                None
+            };
+            match leaked {
+                Some(leaked) => {
+                    let message = format!("{} raised {leaked}", generator_kind(gen_obj));
+                    Err(leak_generator_iteration(e, &message))
+                }
+                None => Err(e),
             }
         }
         result => result,
@@ -16209,13 +16220,7 @@ fn generator_send_ex(
             if operr.is_none() && !w_arg.is_null() && !is_none(w_arg) {
                 return Err(PyError::type_error(format!(
                     "can't send non-None value to a just-started {}",
-                    if is_async_generator(gen_obj) {
-                        "async generator"
-                    } else if is_coroutine(gen_obj) {
-                        "coroutine"
-                    } else {
-                        "generator"
-                    }
+                    generator_kind(gen_obj)
                 )));
             }
         }
@@ -16345,7 +16350,10 @@ fn close_yield_from(w_yf: PyObjectRef) -> PyResult {
         if pyre_object::generator::is_generator_or_coroutine(w_yf) {
             let exit = PyError::new(PyErrorKind::GeneratorExit, String::new());
             return match generator_send_ex(w_yf, w_none(), Some(exit), None) {
-                Ok(_) => Err(PyError::runtime_error("generator ignored GeneratorExit")),
+                Ok(_) => Err(PyError::runtime_error(format!(
+                    "{} ignored GeneratorExit",
+                    generator_kind(w_yf)
+                ))),
                 Err(err)
                     if err.kind == PyErrorKind::StopIteration
                         || err.kind == PyErrorKind::GeneratorExit =>
@@ -16413,6 +16421,22 @@ fn stop_iteration_with_value(value: PyObjectRef) -> PyError {
         }
     }
     unsafe { PyError::from_exc_object(exc) }
+}
+
+/// generator.py:326 / :399 / :643 `KIND` — the class attribute every generator
+/// diagnostic is formatted against, so that one message site serves all three
+/// flavours.  `GeneratorIterator`, `Coroutine` and `AsyncGenerator` are three
+/// classes there and one object layout here, so the value is read back off the
+/// object instead of being a per-class constant.
+unsafe fn generator_kind(gen_obj: PyObjectRef) -> &'static str {
+    use pyre_object::generator::*;
+    if is_async_generator(gen_obj) {
+        "async generator"
+    } else if is_coroutine(gen_obj) {
+        "coroutine"
+    } else {
+        "generator"
+    }
 }
 
 /// generator.py:131-138 `_invoke_execute_frame` / `_leak_stopiteration`
@@ -16719,8 +16743,12 @@ pub(crate) fn generator_close_method(args: &[PyObjectRef]) -> PyResult {
     let err = PyError::new(PyErrorKind::GeneratorExit, String::new());
     match generator_send_ex(gen_obj, w_none(), Some(err), None) {
         Ok(_) => {
-            // Generator yielded after GeneratorExit — RuntimeError
-            Err(PyError::runtime_error("generator ignored GeneratorExit"))
+            // Generator yielded after GeneratorExit — RuntimeError.
+            // generator.py:267-268 `"%s ignored GeneratorExit" % self.KIND`.
+            Err(PyError::runtime_error(format!(
+                "{} ignored GeneratorExit",
+                unsafe { generator_kind(gen_obj) }
+            )))
         }
         Err(mut e) if e.kind == PyErrorKind::StopIteration => {
             // Python 3.13+ / 3.14: close() returns the value produced when

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -4192,6 +4192,12 @@ impl OpcodeStepExecutor for PyFrame {
     // `self.get_builtin().getdictvalue('__build_class__')`.  Python 3.14
     // reports a NameError when the selected builtin mapping has no entry.
     fn load_build_class(&mut self) -> Result<(), PyError> {
+        let bc = self.load_build_class_value()?;
+        self.push(bc);
+        Ok(())
+    }
+
+    fn load_build_class_value(&mut self) -> Result<PyObjectRef, PyError> {
         let w_builtin = self.get_builtin();
         let bc = if !w_builtin.is_null() && unsafe { pyre_object::is_module(w_builtin) } {
             let w_dict = unsafe { pyre_object::w_module_get_w_dict(w_builtin) };
@@ -4209,8 +4215,7 @@ impl OpcodeStepExecutor for PyFrame {
                 "__build_class__",
             ));
         };
-        self.push(bc);
-        Ok(())
+        Ok(bc)
     }
 
     // ── yield from / send ──

--- a/pyre/pyre-interpreter/src/module/_opcode/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_opcode/mod.rs
@@ -94,16 +94,24 @@ fn stack_effect(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     Ok(w_int_new(effect as i64))
 }
 
+// Both enums already carry `Invalid = 0`, whose `desc()` is the
+// `INTRINSIC_*_INVALID` entry the table starts with, so `iter()` alone produces
+// the whole table. Prepending it again shifted every real name one slot up and
+// mislabelled every intrinsic in `dis` output.
 fn get_intrinsic1_descs(_: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    let mut descriptions = vec![w_str_new("INTRINSIC_1_INVALID")];
-    descriptions.extend(oparg::IntrinsicFunction1::iter().map(|value| w_str_new(value.desc())));
-    Ok(w_list_new(descriptions))
+    Ok(w_list_new(
+        oparg::IntrinsicFunction1::iter()
+            .map(|value| w_str_new(value.desc()))
+            .collect(),
+    ))
 }
 
 fn get_intrinsic2_descs(_: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    let mut descriptions = vec![w_str_new("INTRINSIC_2_INVALID")];
-    descriptions.extend(oparg::IntrinsicFunction2::iter().map(|value| w_str_new(value.desc())));
-    Ok(w_list_new(descriptions))
+    Ok(w_list_new(
+        oparg::IntrinsicFunction2::iter()
+            .map(|value| w_str_new(value.desc()))
+            .collect(),
+    ))
 }
 
 fn get_nb_ops(_: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {

--- a/pyre/pyre-interpreter/src/pyopcode.rs
+++ b/pyre/pyre-interpreter/src/pyopcode.rs
@@ -1411,6 +1411,13 @@ pub trait OpcodeStepExecutor: SharedOpcodeHandler {
     fn load_build_class(&mut self) -> Result<(), PyError> {
         Err(crate::PyError::type_error("load_build_class not implemented").into())
     }
+    /// The value half of [`Self::load_build_class`], without the push.
+    /// The JIT's `LOAD_BUILD_CLASS` residual calls this so the lookup order
+    /// stays in one place, the way `load_name_checked_value` serves
+    /// `load_name`.
+    fn load_build_class_value(&mut self) -> Result<<Self as SharedOpcodeHandler>::Value, PyError> {
+        Err(crate::PyError::type_error("load_build_class not implemented").into())
+    }
     fn load_super_attr(&mut self) -> Result<(), PyError> {
         Err(crate::PyError::type_error("load_super_attr not implemented").into())
     }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -2310,6 +2310,17 @@ pub fn census_record_frame_shape_decline(code_ptr: usize, kind: &'static str) {
     }
 }
 
+/// The accumulated decline census as `(variant name, count)` pairs, sorted by
+/// name — the same content [`census_dump`] prints, for a reader that has no
+/// stderr to print it to.  A wasm guest is exactly that: `eprintln!` goes
+/// nowhere and `PYRE_FBW_DEBUG_ABORT` never reaches it (the runner has no
+/// environment to pass), so the `[fbw-census]` attribution of every
+/// `loops_aborted` is unreachable there unless it can be read back as data.
+/// `pyre-wasm` exports it per index; the host runner joins the pairs.
+pub fn census_entries() -> Vec<(&'static str, usize)> {
+    FBW_DECLINE_CENSUS.with(|c| c.borrow().iter().map(|(n, &v)| (*n, v)).collect())
+}
+
 /// Print the accumulated decline census as `[fbw-census] <name>: <count>`
 /// lines, sorted by name.  No-op unless [`fbw_debug_abort_enabled`].
 /// Safe to call repeatedly (a diagnostic dump, not a reset).

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -5965,6 +5965,44 @@ pub extern "C" fn bh_delete_name_fn(frame_ptr: i64, w_name: i64) -> i64 {
     }
 }
 
+/// `LOAD_LOCALS` residual using the frame receiver.
+/// `pyopcode.py:793-794` — `pushvalue(getorcreatedebug().w_locals)`, which
+/// must hand back the frame's own mapping so a metaclass `__prepare__` result
+/// keeps its type. Infallible, so unlike the name residuals there is no
+/// exception-publishing arm.
+pub extern "C" fn bh_load_locals_fn(frame_ptr: i64) -> i64 {
+    assert!(
+        frame_ptr != 0,
+        "bh_load_locals_fn requires a non-null PyFrame; every LOAD_LOCALS emit \
+         site must thread portal_frame_reg as its ref operand"
+    );
+    let frame = unsafe { &mut *(frame_ptr as *mut PyFrame) };
+    frame.get_or_create_w_locals() as i64
+}
+
+/// `LOAD_BUILD_CLASS` residual using the frame receiver.
+/// `pyopcode.py:866-870` — `get_builtin().getdictvalue('__build_class__')`,
+/// a NameError when the selected builtin mapping has no entry. Delegates to
+/// `eval.rs load_build_class_value` so the interpreter and the residual share
+/// one lookup, the same contract `bh_load_name_fn` documents. On error it
+/// publishes through both exception cells and returns 0.
+pub extern "C" fn bh_load_build_class_fn(frame_ptr: i64) -> i64 {
+    use pyre_interpreter::pyopcode::OpcodeStepExecutor;
+    assert!(
+        frame_ptr != 0,
+        "bh_load_build_class_fn requires a non-null PyFrame; every \
+         LOAD_BUILD_CLASS emit site must thread portal_frame_reg as its ref operand"
+    );
+    let frame = unsafe { &mut *(frame_ptr as *mut PyFrame) };
+    match frame.load_build_class_value() {
+        Ok(w_value) => w_value as i64,
+        Err(mut err) => {
+            publish_residual_call_exception(err.to_exc_object() as i64);
+            0
+        }
+    }
+}
+
 /// DELETE_GLOBAL residual using the frame receiver and interned-name ABI.
 /// pyopcode.py DELETE_GLOBAL deletes directly from `w_globals`.
 pub extern "C" fn bh_delete_global_fn(frame_ptr: i64, w_name: i64) -> i64 {

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -2752,6 +2752,21 @@ fn emit_frontend_store_global(
     );
 }
 
+/// `LOAD_LOCALS` / `LOAD_BUILD_CLASS` — the two class-body frame methods whose
+/// only operand is the receiver. Frame-receiver call shape like
+/// `emit_frontend_load_name`; `opname` lowers to `bh_load_locals_fn(frame)` /
+/// `bh_load_build_class_fn(frame)` (`flatten::lower_load_locals_hlop_to_insn`,
+/// `flatten::lower_load_build_class_hlop_to_insn`).
+fn emit_frontend_frame_only_ref(
+    graph: &mut super::flow::FunctionGraph,
+    block: &super::flow::BlockRef,
+    opname: &'static str,
+    frame: super::flow::FlowValue,
+    offset: i64,
+) -> super::flow::Variable {
+    emit_graph_op_with_result(graph, block, opname, vec![frame.into()], Kind::Ref, offset)
+}
+
 fn emit_frontend_delete_name(
     _graph: &mut super::flow::FunctionGraph,
     block: &super::flow::BlockRef,
@@ -3504,6 +3519,8 @@ struct FnPtrIndices {
     match_mapping_fn: HelperHandle,
     match_keys_fn: HelperHandle,
     match_class_fn: HelperHandle,
+    load_locals_fn: HelperHandle,
+    load_build_class_fn: HelperHandle,
     load_from_dict_or_globals_fn: HelperHandle,
     call_function_ex_fn: HelperHandle,
     unary_not_fn: HelperHandle,
@@ -4213,6 +4230,23 @@ fn register_helper_fn_pointers(
         cpu.match_class_fn as *const (),
         CallFlavor::MayForce,
     );
+    // Class-body frame methods; neither runs user code. `bh_load_locals_fn`
+    // hands back the frame's own `w_locals`, allocating a dict only for the
+    // degenerate unbound case, and has no error path at all →
+    // `PlainCannotRaise`, which is also what `graph_op_can_raise` says about
+    // its opname. `bh_load_build_class_fn` reads one builtin-dict entry and
+    // raises `NameError` when it is absent → `Plain`. Appended last to
+    // preserve fn_ptr indices.
+    let load_locals_fn = bind(
+        assembler,
+        cpu.load_locals_fn as *const (),
+        CallFlavor::PlainCannotRaise,
+    );
+    let load_build_class_fn = bind(
+        assembler,
+        cpu.load_build_class_fn as *const (),
+        CallFlavor::Plain,
+    );
     FnPtrIndices {
         call_fn,
         load_global_fn,
@@ -4296,6 +4330,8 @@ fn register_helper_fn_pointers(
         match_mapping_fn,
         match_keys_fn,
         match_class_fn,
+        load_locals_fn,
+        load_build_class_fn,
         load_from_dict_or_globals_fn,
         call_function_ex_fn,
         call_kw_fn_0,
@@ -5973,6 +6009,16 @@ impl CodeWriter {
                     idx: match_class_fn_idx,
                     flavor: _match_class_fn_flavor,
                 },
+            load_locals_fn:
+                HelperHandle {
+                    idx: load_locals_fn_idx,
+                    flavor: _load_locals_fn_flavor,
+                },
+            load_build_class_fn:
+                HelperHandle {
+                    idx: load_build_class_fn_idx,
+                    flavor: _load_build_class_fn_flavor,
+                },
             load_from_dict_or_globals_fn:
                 HelperHandle {
                     idx: load_from_dict_or_globals_fn_idx,
@@ -6238,6 +6284,8 @@ impl CodeWriter {
                 match_mapping_fn_idx,
                 match_keys_fn_idx,
                 match_class_fn_idx,
+                load_locals_fn_idx,
+                load_build_class_fn_idx,
                 load_from_dict_or_globals_fn_idx,
                 call_function_ex_fn_idx,
                 unary_not_fn_idx,
@@ -12237,14 +12285,37 @@ impl CodeWriter {
                             push_and_bump!(result_value.into(), py_pc);
                         }
 
-                        // Both are portable (plain value-level reads), but both
-                        // occur only in a class body, which runs once per class
-                        // definition — never a hot loop body — so no residual has
-                        // been written.
+                        // Both are frame methods whose only operand is the
+                        // receiver, so both take the `emit_frontend_load_name`
+                        // shape: `bh_load_locals_fn(frame)` /
+                        // `bh_load_build_class_fn(frame)`.
+                        //
+                        // They occur only in a class body, which runs once per
+                        // class definition, and that is why this arm used to
+                        // emit `abort_permanent` instead. Execution frequency
+                        // is the wrong measure: the full-body walk covers a
+                        // frame statically, so one unlowerable op anywhere in
+                        // the reachable region retires the whole frame, and a
+                        // class body reached by the tracer at all — every one
+                        // of them, once `threshold` is low — costs a
+                        // `loops_aborted`.
                         Instruction::LoadLocals | Instruction::LoadBuildClass => {
-                            push_fresh_ref(&mut current_state, &mut graph);
-                            current_depth += 1;
-                            emit_abort_permanent!(py_pc);
+                            let opname = if matches!(instruction, Instruction::LoadLocals) {
+                                "load_locals"
+                            } else {
+                                "load_build_class"
+                            };
+                            let loaded_dst_reg = stack_base + current_depth;
+                            let result_value = emit_frontend_frame_only_ref(
+                                &mut graph,
+                                &current_block.block(),
+                                opname,
+                                frame_var.into(),
+                                py_pc as i64,
+                            );
+                            let result_fv: super::flow::FlowValue = result_value.into();
+                            current_state.stack.push(result_fv.clone());
+                            emit_pushvalue_ref!(current_depth, loaded_dst_reg, result_fv, py_pc);
                         }
 
                         // FormatSimple: pops value, pushes str(value). Net 0.

--- a/pyre/pyre-jit/src/jit/cpu.rs
+++ b/pyre/pyre-jit/src/jit/cpu.rs
@@ -329,6 +329,14 @@ pub struct Cpu {
     /// lowering of `DELETE_GLOBAL`; deletes directly from `w_globals`,
     /// bypassing `w_locals`.
     pub delete_global_fn: extern "C" fn(i64, i64) -> i64,
+    /// `bh_load_locals_fn` — `(frame: Ref) → Ref`, the lowering of
+    /// `LOAD_LOCALS` (`pyopcode.py:793`); hands back the frame's own
+    /// `w_locals` mapping.
+    pub load_locals_fn: extern "C" fn(i64) -> i64,
+    /// `bh_load_build_class_fn` — `(frame: Ref) → Ref`, the lowering of
+    /// `LOAD_BUILD_CLASS` (`pyopcode.py:866`); reads `__build_class__` out of
+    /// the frame's builtin mapping.
+    pub load_build_class_fn: extern "C" fn(i64) -> i64,
     /// `newtuple(list_w)` (`objspace.py:332`) — (ref array) → new tuple.
     /// The array is the forced `popvalues` list; length travels inside
     /// the array, so any arity fits.
@@ -524,6 +532,8 @@ impl Cpu {
             store_global_fn: crate::call_jit::bh_store_global_fn,
             delete_name_fn: crate::call_jit::bh_delete_name_fn,
             delete_global_fn: crate::call_jit::bh_delete_global_fn,
+            load_locals_fn: crate::call_jit::bh_load_locals_fn,
+            load_build_class_fn: crate::call_jit::bh_load_build_class_fn,
             newtuple_from_array_fn: crate::call_jit::bh_newtuple_from_array,
             build_map_from_array_fn: crate::call_jit::bh_build_map_from_array,
             build_set_from_array_fn: crate::call_jit::bh_build_set_from_array,

--- a/pyre/pyre-jit/src/jit/flatten.rs
+++ b/pyre/pyre-jit/src/jit/flatten.rs
@@ -2573,6 +2573,7 @@ pub fn graph_op_can_raise(op: &super::flow::SpaceOperation) -> bool {
             | "store_global"
             | "delete_name"
             | "delete_global"
+            | "load_build_class"
             | "simple_call"
             | "getattr"
             | "load_special"
@@ -3254,6 +3255,12 @@ pub struct LoweringContext {
     /// `delete_global_fn` descrs-pool index. DELETE_GLOBAL lowers to a void
     /// two-Ref residual with `[frame, w_name]` operands.
     pub delete_global_fn_idx: u16,
+    /// `load_locals_fn` descrs-pool index. LOAD_LOCALS lowers to a one-Ref
+    /// residual with `[frame]` and a Ref result.
+    pub load_locals_fn_idx: u16,
+    /// `load_build_class_fn` descrs-pool index. LOAD_BUILD_CLASS lowers to the
+    /// same one-Ref shape as [`Self::load_locals_fn_idx`].
+    pub load_build_class_fn_idx: u16,
     /// `bind(assembler, cpu.newtuple_from_array_fn as *const (),
     /// CallFlavor::Plain)` descrs-pool index for the production
     /// source.  BUILD_TUPLE records the rtyped `pyopcode.py:995-998`
@@ -4325,6 +4332,81 @@ where
     ))
 }
 
+/// Lower `LOAD_LOCALS` / `LOAD_BUILD_CLASS` — both `(frame) → Ref` frame
+/// methods with no operand beyond the receiver — to a one-Ref residual call.
+/// `CallFlavor::Plain`: `LOAD_BUILD_CLASS` can raise `NameError` and neither
+/// forces a virtual, the same classification `load_name` carries.
+fn lower_frame_only_ref_hlop_to_insn<F, LC>(
+    op: &super::flow::SpaceOperation,
+    opname: &str,
+    fn_idx: u16,
+    pyre_helper: majit_ir::PyreHelperKind,
+    get_register: &mut F,
+    lower_constant: &mut LC,
+) -> Option<Insn>
+where
+    F: FnMut(super::flow::Variable) -> Register,
+    LC: FnMut(&Constant) -> Operand,
+{
+    if op.opname != opname || op.args.len() != 1 {
+        return None;
+    }
+    let frame_operand = flatten_arg_with_lowering(&op.args[0], get_register, lower_constant);
+    let dst_reg = match &op.result {
+        Some(super::flow::FlowValue::Variable(var)) => get_register(*var),
+        _ => return None,
+    };
+    Some(build_residual_call_r_r_insn_from_operands(
+        fn_idx,
+        vec![frame_operand],
+        CallFlavor::Plain,
+        pyre_helper,
+        dst_reg,
+    ))
+}
+
+/// Lower pyopcode.py LOAD_LOCALS to a one-Ref residual call.
+pub fn lower_load_locals_hlop_to_insn<F, LC>(
+    op: &super::flow::SpaceOperation,
+    ctx: &LoweringContext,
+    get_register: &mut F,
+    lower_constant: &mut LC,
+) -> Option<Insn>
+where
+    F: FnMut(super::flow::Variable) -> Register,
+    LC: FnMut(&Constant) -> Operand,
+{
+    lower_frame_only_ref_hlop_to_insn(
+        op,
+        "load_locals",
+        ctx.load_locals_fn_idx,
+        majit_ir::PyreHelperKind::LoadLocals,
+        get_register,
+        lower_constant,
+    )
+}
+
+/// Lower pyopcode.py LOAD_BUILD_CLASS to a one-Ref residual call.
+pub fn lower_load_build_class_hlop_to_insn<F, LC>(
+    op: &super::flow::SpaceOperation,
+    ctx: &LoweringContext,
+    get_register: &mut F,
+    lower_constant: &mut LC,
+) -> Option<Insn>
+where
+    F: FnMut(super::flow::Variable) -> Register,
+    LC: FnMut(&Constant) -> Operand,
+{
+    lower_frame_only_ref_hlop_to_insn(
+        op,
+        "load_build_class",
+        ctx.load_build_class_fn_idx,
+        majit_ir::PyreHelperKind::LoadBuildClass,
+        get_register,
+        lower_constant,
+    )
+}
+
 /// Lower pyopcode.py DELETE_GLOBAL to a void two-Ref residual call.
 pub fn lower_delete_global_hlop_to_insn<F, LC>(
     op: &super::flow::SpaceOperation,
@@ -5247,6 +5329,12 @@ where
         return Some(insn);
     }
     if let Some(insn) = lower_delete_global_hlop_to_insn(op, ctx, get_register, lower_constant) {
+        return Some(insn);
+    }
+    if let Some(insn) = lower_load_locals_hlop_to_insn(op, ctx, get_register, lower_constant) {
+        return Some(insn);
+    }
+    if let Some(insn) = lower_load_build_class_hlop_to_insn(op, ctx, get_register, lower_constant) {
         return Some(insn);
     }
     if let Some(insn) = lower_tuple_build_hlop_to_insn(op, ctx, get_register, lower_constant) {

--- a/pyre/pyre-sandbox/src/seccomp.rs
+++ b/pyre/pyre-sandbox/src/seccomp.rs
@@ -190,6 +190,19 @@ fn allowed_syscalls() -> Vec<u32> {
         libc::SYS_futex,
         libc::SYS_sched_yield,
         libc::SYS_sched_getaffinity,
+        // Which NUMA node the caller runs on. mimalloc stamps it on every new
+        // thread's TLD and on every arena it reserves (`mimalloc/src/init.c`
+        // `mi_tld_alloc`, `src/arena.c` `mi_arena_reserve`), and its
+        // `_mi_prim_numa_node` goes straight to the syscall rather than the
+        // vDSO. The lookup is skipped entirely while the cached node count is
+        // 1, so this is unreachable on a single-node machine and issued on
+        // every arena reservation on a multi-node one — which is why it can sit
+        // unnoticed until the sandbox runs on a two-socket host. The node count
+        // behind that cache is probed once, by reading `/sys/devices/system/
+        // node`, and is already warm here because the interpreter has allocated
+        // throughout startup. Reads topology, changes nothing — the same
+        // standing as `sched_getaffinity` above.
+        libc::SYS_getcpu,
         libc::SYS_getrandom,
         libc::SYS_set_robust_list,
         libc::SYS_set_tid_address,

--- a/pyre/pyre-sandbox/src/seccomp.rs
+++ b/pyre/pyre-sandbox/src/seccomp.rs
@@ -13,11 +13,24 @@
 //! curated set of host-neutral runtime syscalls (memory, signals, time, and I/O
 //! on the already-open marshalling fds 0/1/2) and TRAPs anything else to a
 //! SIGSYS handler that names the blocked syscall and exits — so
-//! `open`/`openat`/`socket`/`connect`/`execve`/`fork`/`clone`/`ptrace` and the
-//! rest of the host-affecting surface are simply unreachable. It is
+//! `open`/`openat`/`socket`/`connect`/`execve`/`ptrace` and the rest of the
+//! host-affecting surface are simply unreachable. It is
 //! installed in the child *after* interpreter startup (which legitimately opens
 //! files, allocates, seeds hashing, …) and *before* the first byte of untrusted
 //! code, so those startup syscalls run unfiltered while user code does not.
+//!
+//! `fork` is NOT among them, despite what this list used to claim. The JIT
+//! needs threads, so `clone`/`clone3` are allowlisted, and glibc builds `fork`
+//! out of `clone(SIGCHLD)` — a filter that admits thread creation by syscall
+//! number admits process creation with it. Telling the two apart means testing
+//! `CLONE_THREAD`, which classic BPF can do for `clone` (a register argument)
+//! but not for `clone3`, whose flags live in a struct behind a pointer the
+//! filter cannot dereference; forcing glibc down the `clone` path would mean
+//! answering `clone3` with `ENOSYS`. What a forked child gains is bounded: it
+//! inherits this filter, so it cannot `exec`, open a path, or reach the
+//! network, and it shares the marshalling fds with a controller that mediates
+//! every request. The reachable cost is a fork bomb and a second writer on the
+//! request pipe, not an escape.
 //!
 //! Over-listing a benign syscall here cannot widen the escape surface (every
 //! listed call is host-neutral); omitting one the runtime needs only
@@ -213,6 +226,9 @@ fn allowed_syscalls() -> Vec<u32> {
         // falls back to `clone`; allow both. A spawned thread inherits this same
         // filter, so it is confined identically — thread creation stays
         // host-neutral (its stack/sync syscalls are already listed above).
+        // Listing them by number also lets `fork` through, since glibc spells it
+        // `clone(SIGCHLD)`; see the module docs for why that is bounded and what
+        // separating the two would cost.
         libc::SYS_clone,
         libc::SYS_clone3,
         // Time (mostly served by the vDSO, but allow the syscall fallbacks).
@@ -222,7 +238,8 @@ fn allowed_syscalls() -> Vec<u32> {
         libc::SYS_nanosleep,
         libc::SYS_gettimeofday,
         // Process self-info (read-only) + own resource limits/usage + abort path
-        // + clean exit. tkill/tgkill only ever target this single-threaded child.
+        // + clean exit. tkill/tgkill reach only this process group's own threads,
+        // which are confined by the very filter they inherited.
         libc::SYS_getpid,
         libc::SYS_gettid,
         libc::SYS_getrusage,

--- a/pyre/pyre-sandbox/src/seccomp.rs
+++ b/pyre/pyre-sandbox/src/seccomp.rs
@@ -211,10 +211,9 @@ fn allowed_syscalls() -> Vec<u32> {
         // 1, so this is unreachable on a single-node machine and issued on
         // every arena reservation on a multi-node one — which is why it can sit
         // unnoticed until the sandbox runs on a two-socket host. The node count
-        // behind that cache is probed once, by reading `/sys/devices/system/
-        // node`, and is already warm here because the interpreter has allocated
-        // throughout startup. Reads topology, changes nothing — the same
-        // standing as `sched_getaffinity` above.
+        // behind that cache is what `install_runtime_filter` primes; this entry
+        // covers the lookups that keep happening afterwards. Reads topology,
+        // changes nothing — the same standing as `sched_getaffinity` above.
         libc::SYS_getcpu,
         libc::SYS_getrandom,
         libc::SYS_set_robust_list,
@@ -325,6 +324,28 @@ pub fn install_runtime_filter() -> io::Result<()> {
         let t: libc::time_t = 0;
         let mut tm: libc::tm = core::mem::zeroed();
         libc::gmtime_r(&t, &mut tm);
+    }
+
+    // mimalloc defers its NUMA detection to the first thread it builds a TLD
+    // for. The main thread uses a static `tld_main` that never asks; only
+    // `mi_tld_alloc` stamps `tld->numa_node = _mi_os_numa_node()`, and the
+    // first such call counts the nodes by `access`ing
+    // `/sys/devices/system/node/nodeN` until one is missing
+    // (`mimalloc/src/init.c`, `src/prim/unix/prim.c`). That probe is a path
+    // lookup the filter refuses, so without this a sandboxed program that
+    // starts a thread — `_thread`, `threading` — takes SIGSYS inside the new
+    // thread, and the handler's `_exit` tears down the whole child. The count
+    // is a process-global cached once and never recomputed, so priming it here,
+    // while path lookups are still allowed, settles it for every later thread.
+    // The thread has to actually allocate: mimalloc builds a thread's TLD on
+    // its first allocation, so a primer that only starts and exits leaves the
+    // detection exactly where it was.
+    if let Ok(primer) = std::thread::Builder::new().spawn(|| {
+        let n = core::hint::black_box(64usize);
+        let v: Vec<u8> = Vec::with_capacity(n);
+        core::hint::black_box(&v);
+    }) {
+        let _ = primer.join();
     }
 
     // Install the SIGSYS handler before the filter so a denied syscall is

--- a/pyre/pyre-wasm-runner/src/main.rs
+++ b/pyre/pyre-wasm-runner/src/main.rs
@@ -522,6 +522,10 @@ fn run(module_path: &PathBuf, source: &str, script: &Path) -> Result<i32> {
                 "pub_flat",
                 "pub_flat_skipped",
                 "label_retracted",
+                "cl_entered",
+                "cl_ok",
+                "cl_decl_unsupported",
+                "cl_decl_host_reject",
             ];
             let mut parts = Vec::new();
             for (i, lbl) in labels.iter().enumerate() {
@@ -626,6 +630,16 @@ fn run(module_path: &PathBuf, source: &str, script: &Path) -> Result<i32> {
                 "ceb_retrace_req",
                 "ceb_backend_panic",
                 "ceb_backend_err",
+                "abrt_too_long",
+                "abrt_bridge",
+                "abrt_bad_loop",
+                "abrt_escape",
+                "abrt_force_qmut",
+                "abrt_segmented",
+                "abrt_other",
+                "giveup_invalidloop",
+                "giveup_compileloop_err",
+                "giveup_bridge_aborted",
             ];
             let mut parts = Vec::new();
             for (i, lbl) in labels.iter().enumerate() {
@@ -635,6 +649,34 @@ fn run(module_path: &PathBuf, source: &str, script: &Path) -> Result<i32> {
                 ));
             }
             eprintln!("[jit-stats] mc_diag {}", parts.join(" "));
+        }
+        // Full-body-walk decline census: the `DispatchError` variant behind
+        // every aborted walk, which is what `loops_aborted` counts. Unlike the
+        // fixed-slot tallies above this one is name-keyed, so the guest hands
+        // back `(ptr << 32) | len` into its own memory and the name is sliced
+        // out here — `PYRE_FBW_DEBUG_ABORT`, the native channel for the same
+        // attribution, never reaches a guest with no environment.
+        if let (Ok(len_fn), Ok(name_fn), Ok(count_fn)) = (
+            instance.get_typed_func::<(), u32>(&mut store, "pyre_jit_fbw_census_len"),
+            instance.get_typed_func::<u32, u64>(&mut store, "pyre_jit_fbw_census_name"),
+            instance.get_typed_func::<u32, u64>(&mut store, "pyre_jit_fbw_census_count"),
+        ) {
+            let n = len_fn.call(&mut store, ()).unwrap_or(0);
+            let mut parts = Vec::new();
+            for i in 0..n {
+                let packed = name_fn.call(&mut store, i).unwrap_or(0);
+                let count = count_fn.call(&mut store, i).unwrap_or(0);
+                let (ptr, len) = ((packed >> 32) as usize, (packed & 0xffff_ffff) as usize);
+                let data = memory.data(&store);
+                let name = data
+                    .get(ptr..ptr + len)
+                    .and_then(|b| std::str::from_utf8(b).ok())
+                    .unwrap_or("<unreadable>");
+                parts.push(format!("{name}={count}"));
+            }
+            if !parts.is_empty() {
+                eprintln!("[jit-stats] fbw_census {}", parts.join(" "));
+            }
         }
         let guest_jit_execute_count = instance
             .get_typed_func::<(), u64>(&mut store, "pyre_jit_execute_count")

--- a/pyre/pyre-wasm-runner/src/main.rs
+++ b/pyre/pyre-wasm-runner/src/main.rs
@@ -747,7 +747,10 @@ fn run(module_path: &PathBuf, source: &str, script: &Path) -> Result<i32> {
                 0
             }
         };
+        let loops_compiled = counter("pyre_jit_loops_compiled", &mut missing);
+        let bridges_compiled = counter("pyre_jit_bridges_compiled", &mut missing);
         let loops_aborted = counter("pyre_jit_loops_aborted", &mut missing);
+        let guard_failures = counter("pyre_jit_guard_failures", &mut missing);
         let internal_compile_panics = counter("pyre_jit_internal_compile_panics", &mut missing);
         let descr_set_resolved = counter("pyre_jit_descr_set_resolved", &mut missing);
         let descr_set_absent = counter("pyre_jit_descr_set_absent", &mut missing);
@@ -762,7 +765,10 @@ fn run(module_path: &PathBuf, source: &str, script: &Path) -> Result<i32> {
             std::process::exit(1);
         }
         eprintln!(
-            "[jit-stats] loops_aborted={loops_aborted} \
+            "[jit-stats] loops_compiled={loops_compiled} \
+             bridges_compiled={bridges_compiled} \
+             loops_aborted={loops_aborted} \
+             guard_failures={guard_failures} \
              internal_compile_panics={internal_compile_panics} \
              descr_set_resolved={descr_set_resolved} \
              descr_set_absent={descr_set_absent} \

--- a/pyre/pyre-wasm/src/lib.rs
+++ b/pyre/pyre-wasm/src/lib.rs
@@ -348,6 +348,41 @@ pub extern "C" fn pyre_jit_mc_diag(i: u32) -> u64 {
     majit_metainterp::mc_diag(i as usize)
 }
 
+/// Diagnostic-only: the full-body-walk decline census
+/// (`pyre_jit_trace::jitcode_dispatch::census_entries`), which names the
+/// `DispatchError` variant behind every aborted walk. The map is always
+/// populated; only its `[fbw-census]` print is gated on
+/// `PYRE_FBW_DEBUG_ABORT`, which a wasm guest can neither read nor print, so
+/// these three exports are the only channel that carries the attribution out.
+///
+/// The names are `&'static str` in guest memory: `..._name` returns
+/// `(ptr << 32) | len` for the host to slice out of the exported memory, and
+/// `..._count` returns that entry's tally. Both index the same sorted order as
+/// `census_entries`, which is stable for a given call — read the length first
+/// and do not interleave with anything that could record a new decline.
+#[cfg(all(target_arch = "wasm32", feature = "wasm-host"))]
+#[unsafe(no_mangle)]
+pub extern "C" fn pyre_jit_fbw_census_len() -> u32 {
+    pyre_jit_trace::jitcode_dispatch::census_entries().len() as u32
+}
+
+#[cfg(all(target_arch = "wasm32", feature = "wasm-host"))]
+#[unsafe(no_mangle)]
+pub extern "C" fn pyre_jit_fbw_census_name(i: u32) -> u64 {
+    match pyre_jit_trace::jitcode_dispatch::census_entries().get(i as usize) {
+        Some((name, _)) => ((name.as_ptr() as u64) << 32) | name.len() as u64,
+        None => 0,
+    }
+}
+
+#[cfg(all(target_arch = "wasm32", feature = "wasm-host"))]
+#[unsafe(no_mangle)]
+pub extern "C" fn pyre_jit_fbw_census_count(i: u32) -> u64 {
+    pyre_jit_trace::jitcode_dispatch::census_entries()
+        .get(i as usize)
+        .map_or(0, |&(_, count)| count as u64)
+}
+
 /// Sign-stable JIT counters that read 0 in a healthy run, the same badness
 /// fields the native `[jit-stats]` line reports (`pyrex` maybe_print_jit_stats).
 /// A nonzero value means a trace aborted or an internal compile bug degraded

--- a/pyre/pyre-wasm/src/lib.rs
+++ b/pyre/pyre-wasm/src/lib.rs
@@ -417,6 +417,35 @@ pub extern "C" fn pyre_jit_internal_compile_panics() -> u64 {
         .internal_compile_panics as u64
 }
 
+/// The rest of the native `[jit-stats]` line. These are not sign-stable, so
+/// each is gated on its own terms rather than against zero: `loops_compiled`
+/// fails on any FALL, `guard_failures` on a rise past a band, and
+/// `bridges_compiled` on neither direction, since it moves both ways under
+/// ordinary tuning.
+///
+/// They come out of the same `JitStats` the fields above read, and were simply
+/// never exported. Their absence was not neutral: a count-valued field missing
+/// from a recorded baseline is skipped silently, so a change that stopped
+/// compiling a loop altogether aborted nothing and *lowered* `guard_failures` —
+/// both remaining gates read the loss as an improvement.
+#[cfg(all(target_arch = "wasm32", feature = "wasm-host"))]
+#[unsafe(no_mangle)]
+pub extern "C" fn pyre_jit_loops_compiled() -> u64 {
+    pyre_jit::eval::driver_pair().0.get_stats().loops_compiled as u64
+}
+
+#[cfg(all(target_arch = "wasm32", feature = "wasm-host"))]
+#[unsafe(no_mangle)]
+pub extern "C" fn pyre_jit_bridges_compiled() -> u64 {
+    pyre_jit::eval::driver_pair().0.get_stats().bridges_compiled as u64
+}
+
+#[cfg(all(target_arch = "wasm32", feature = "wasm-host"))]
+#[unsafe(no_mangle)]
+pub extern "C" fn pyre_jit_guard_failures() -> u64 {
+    pyre_jit::eval::driver_pair().0.get_stats().guard_failures as u64
+}
+
 /// The descr-universe invariants, the remaining `JITSTATS_BADNESS_FIELDS`. The
 /// native backends print these from `descr_set_jit_stats`; the guest has no
 /// stderr, so it exports the counts and the runner prints the line. Without


### PR DESCRIPTION
Six commits, closing the largest wasm-only `loops_aborted` item and two compat bugs found alongside it.

Note: this branch also carries three `sandbox:` commits (`17254e05eb9`, `84ea826802d`, `d565f184b63`) that were already on it and are not part of this work.

## 1. `LOAD_LOCALS` / `LOAD_BUILD_CLASS` were retiring every class-body frame

Both opcodes emitted `abort_permanent`, justified by a comment saying a class body "runs once per class definition — never a hot loop body". **That premise measures the wrong thing.** The full-body walk covers a frame *statically*, so one unlowerable op anywhere in the reachable region retires the whole frame no matter how often it executes.

And `LOAD_LOCALS` is not rare — it is the universal 3.12+ class-body prologue, at instruction index 8 of essentially every class body, between `STORE_NAME __firstlineno__` and `STORE_DEREF __classdict__`. So every class body the tracer *reached at all* cost one `loops_aborted`. 4-line repro:

```python
import pypyjit
pypyjit.set_param("threshold=1,function_threshold=1")
class A:
    def v(self): return 1
```

Both are `(frame) -> Ref` frame methods with no operand but the receiver, so both take the `load_name` template exactly. Orthodox: upstream has no runtime abort here at all — `jtransform.py _do_builtin_call` turns any op with no jitcode opcode into a residual call.

| fixture (wasm) | before | after |
|---|---:|---:|
| `pickle_terminal_raise_resume` | 37 | **13** |
| `list_length_hint_validate` | 16 | **10** |
| `slots_class_var_conflict` | 5 | **0** |
| `global_store_plain_dict_globals` | 3 | **1** |

## 2. wasm `loops_aborted` was an unattributable integer

`PYRE_FBW_DEBUG_ABORT` and `MAJIT_LOG` cannot reach a wasm guest — `std::env` on `wasm32-unknown-unknown` is permanently empty and `eprintln!` is a silent sink. The `FBW_DECLINE_CENSUS` data existed the whole time; only its print was env-gated.

Now exported and printed by the runner:

```
[jit-stats] fbw_census AbortPermanentMarkerReached=2 ForceQuasiImmutable=5 ...
[jit-stats] mc_diag abrt_too_long= abrt_bridge= ... giveup_invalidloop= ...
[jit-stats] bridge_diag cl_entered= cl_ok= cl_decl_unsupported= cl_decl_host_reject=
```

This is what produced the RCA above, and it is what refuted my first hypothesis: I assumed the 37 were backend `Err`s, since all three `loops_aborted` bump sites in `pyjitpl.rs` sit in `Err` arms of a backend compile. Instrumenting `compile_loop` showed **entered=50, ok=50, declines=0**. The aborts came from `aborted_tracing`, a fourth site.

## 3. wasm reported five of the eight `[jit-stats]` fields

The other three come out of the same `JitStats` and were simply never exported, so no baseline recorded them — and a count-valued field absent from a baseline is skipped **silently**.

`loops_compiled` is the field that mattered for: it is the sole member of `JITSTATS_FALL_FIELDS` and fails on any fall, precisely because a change that stops compiling a loop aborts nothing and *lowers* `guard_failures`, so the two gates that did run on wasm would read the loss as an improvement.

`bridges_compiled` is exported for surface parity but stays in no gating tuple, per the documented decision at `check.py:555-557`.

The 364 baselines are re-recorded in a **separate** commit from the field addition, and the diff was audited mechanically before committing: every file's added keys are exactly the three new ones, no key was removed, and no pre-existing key changed except `loops_aborted`, which fell in four fixtures and **rose in none**.

## 4. `_opcode` intrinsic tables were off by one

`IntrinsicFunction1`/`2` already define `Invalid = 0` whose `desc()` is `INTRINSIC_*_INVALID`, so `iter()` yields the whole table; prepending the name again gave 13 and 7 entries where 3.14 has 12 and 6, with every real name shifted one slot up. `dis` therefore labelled every intrinsic as its predecessor. Runtime dispatch was never affected — the tables are read only by `dis`.

## 5. Generator diagnostics were hardcoded to "generator"

`generator.py` parameterizes these on `self.KIND` (`:326` / `:399` / `:643`); six sites here spelled `"generator"` outright, so coroutines reported themselves as generators. `generator_kind()` extracts the 3-way ladder already written out at the just-started site.

`test_coroutines` failures **7 -> 4**, with `Ran 99`, `errors=11` and `skipped=3` unchanged.

## Verification

`check.py --backend dynasm,cranelift,wasm` -> **370/370, 370/370, 366/366**, with LLBC fingerprints verified fresh for all four crates so the gate was not blind.

**Caveat:** that gate ran before this branch was rebased onto current `main` (which brings #1004 and #992 — the latter touching `abort_permanent`, the same area as commit 1). CI on this PR is the authoritative check for the rebased tip; a local re-gate is running.

## Investigated, deliberately not fixed

`NonStandardVableFinishPortalUnsupported` (5 of the remaining 13 on wasm) is one abort per `class` body containing a `def`. A probe showed `isstandard=0` with the vable identity correctly seeded to the current portal frame, so "restore the seeding" does not apply. I then deleted the abort to measure whether the wired fall-through paths would take it — they do not: it becomes `GuardResumeCoordinateUnavailable` and `loops_aborted` is unchanged, because the sentinel path's carried word is `NO_JITCODE_PC`, which `resolve_resume_pc_with_jitcode_pc` rejects unconditionally.

So there is no incremental fix. The whole payoff sits behind publishing a real deopt coordinate, which needs a soundness proof the current comment asserts but does not establish — and the failure mode there is silent wrong output on resume, not a clean abort. The payoff is gate hygiene, not speed: the abort costs one wasted trace attempt per class definition and no compiled coverage. Not landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
