### PR TITLE
jit: close the #73 walk-side coordinate split — twin flip, resume-marker census, py_coord fold

### DIFF
--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/branch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/branch.rs
@@ -114,7 +114,7 @@ pub(crate) fn decode_side_other_target(
 /// genuine not-taken-arm jitcode offset (`derived` / other_target) DIRECTLY:
 /// `decode_side_other_target` picks the not-taken arm from `orgpc` + flavor and
 /// that jitcode offset IS the returned value. The former py_pc round-trip
-/// (`python_pc_for_jitcode_pc` -> `skip_python_trivia_forward` ->
+/// (`containing_py_pc_for_jitcode_pc` -> `skip_python_trivia_forward` ->
 /// historical Python-pc translation, with its `num_instrs` overshoot clamp) is
 /// deleted:
 /// it is byte-identical because the encode self-cert
@@ -225,8 +225,8 @@ pub(crate) fn branch_resume_target_stack_depth(
     }
     // Source the not-taken-arm depth off the genuine jitcode `target` through
     // the compile-time `depth_trivia` twin, retiring the
-    // `python_pc_for_jitcode_pc` inversion + runtime
-    // `skip_python_trivia_forward` + static-liveness read. The twin is built for
+    // `containing_py_pc_for_jitcode_pc` + runtime `skip_python_trivia_forward`
+    // + static-liveness read. The twin is built for
     // every drained real-code jitcode (codewriter.rs), and the encode census
     // (`PYRE_M73_ENCODE_AUDIT`) proved the empty-twin fallback is never reached
     // here (0 fallback trips / 162 programs; this reader 1181 hits, all

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/bridge_subwalk.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/bridge_subwalk.rs
@@ -1010,7 +1010,7 @@ pub(crate) fn recipe_parent_frame_from_recipe(
         call_jitcode_pc: call_jit_pc,
         call_stack_overrides: Vec::new(),
         blackhole,
-        // The recipe's resolved word was `backxlat_py_pc(jitcode_index,
+        // The recipe's resolved word was `trivia_normalized_py_pc_for_jitcode_pc(jitcode_index,
         // jitcode_pc)` by construction, exactly the bridge-root flavor.
         resume_coord: ParentResumeCoord::Backxlat(recipe.jitcode_pc as usize),
         resume_marker_jit_pc,

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/diag.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/diag.rs
@@ -1,13 +1,12 @@
-//! pc-map inversion helpers and `PYRE_PCMAP_*` audit probes.
+//! pc-map audit probes.
 //!
-//! **Parity:** pyre-specific — the jitcode-pc <-> python-pc inversion and
-//! the `PYRE_PCMAP_*` audit probes have no `rpython/jit/metainterp/`
-//! counterpart (PyPy's pc handling is codewriter-side).
+//! **Parity:** pyre-specific — the `PYRE_PCMAP_*` audit probes have no
+//! `rpython/jit/metainterp/` counterpart (PyPy's pc handling is
+//! codewriter-side).
 //!
-//! Extracted verbatim from `jitcode_dispatch/mod.rs`: the jitcode-pc ->
-//! python-pc inversion (`python_pc_for_jitcode_pc` + floor-boundary
-//! helpers), the `skip_python_trivia_forward` boundary walker, and the
-//! report-only `PYRE_PCMAP_*` audit probes.
+//! Extracted verbatim from `jitcode_dispatch/mod.rs`: the
+//! `skip_python_trivia_forward` boundary walker and the report-only
+//! `PYRE_PCMAP_*` audit probes.
 
 use super::*;
 
@@ -31,7 +30,7 @@ pub(crate) fn pcmap_containing_audit_enabled() -> bool {
 
 /// `PYRE_PCMAP_AFTERRESIDUAL_AUDIT`: assert the Slice-C after-residual depth
 /// twin (`depth_after_residual_for_jitcode_pc`) equals the raw
-/// `depth_at_py_pc[semantic_fallthrough_pc(python_pc_for_jitcode_pc(jit_pc))]`
+/// `depth_at_py_pc[semantic_fallthrough_pc(containing_py_pc_for_jitcode_pc(jit_pc))]`
 /// read at each consumer seam. Off in production; the gated branch is the only
 /// added code.
 pub(crate) fn pcmap_afterresidual_audit_enabled() -> bool {
@@ -90,14 +89,16 @@ pub(crate) fn pcmap_recipe_resultcolor_audit_probe(site: &'static str, verdict: 
 pub(crate) fn resolve_parent_resume_py_pc(parent: &InlineParentFrame) -> Option<u32> {
     match parent.resume_coord {
         ParentResumeCoord::Backxlat(jitcode_pc) => {
-            // #73: read the forward py_pc twin (a codewriter-built,
-            // trivia-normalized twin of `backxlat_py_pc`'s result — proven equal
-            // corpus-wide in Slice 3'). The inversion survives only for the
-            // empty-twin class (skeleton / fixture jitcodes).
+            // #73: read the forward py_pc twin, a codewriter-built
+            // trivia-normalized twin of the containing coordinate. The
+            // containing lookup survives only for the empty-twin class.
             let twin = crate::state::pyjitcode_for_jitcode_index(parent.jitcode_index as i32)
                 .and_then(|pjc| pjc.forward_py_pc_for_jitcode_pc(jitcode_pc));
             Some(twin.unwrap_or_else(|| {
-                crate::state::backxlat_py_pc(parent.jitcode_index as i32, jitcode_pc as i32) as u32
+                crate::py_coord::trivia_normalized_py_pc_for_jitcode_pc(
+                    parent.jitcode_index as i32,
+                    jitcode_pc as i32,
+                ) as u32
             }))
         }
         ParentResumeCoord::CallFallthrough(call_jit_pc) => {
@@ -108,11 +109,13 @@ pub(crate) fn resolve_parent_resume_py_pc(parent: &InlineParentFrame) -> Option<
             if pjc.code_ptr.is_null() {
                 return None;
             }
-            // #73 Slice 4: read the forward after-residual fallthrough twin. The
-            // inversion survives only for the empty-twin class (populated code
-            // with no Python map) and as the audit oracle.
+            // #73 Slice 4: read the forward after-residual fallthrough twin.
+            // The containing lookup survives only for the empty-twin class
+            // (populated code with no Python map) and as the audit oracle.
             let legacy = || {
-                let call_py_pc = python_pc_for_jitcode_pc(&pjc.metadata, call_jit_pc) as usize;
+                let call_py_pc =
+                    crate::py_coord::containing_py_pc_for_jitcode_pc(&pjc.metadata, call_jit_pc)
+                        as usize;
                 let code = unsafe { &*pjc.code_ptr };
                 crate::pyjitpl::semantic_fallthrough_pc(code, call_py_pc) as u32
             };
@@ -137,43 +140,6 @@ pub(crate) fn resolve_parent_resume_py_pc(parent: &InlineParentFrame) -> Option<
     }
 }
 
-pub(crate) fn floor_boundary_at_or_after(
-    metadata: &crate::PyJitCodeMetadata,
-    jit_pc: usize,
-) -> Option<(usize, u32)> {
-    let table = &metadata.py_floor_by_jit_pc;
-    let idx = table.partition_point(|&(off, _)| (off as usize) < jit_pc);
-    table.get(idx).map(|&(off, py)| (off as usize, py))
-}
-
-pub(crate) fn first_floor_boundary_for_py(
-    metadata: &crate::PyJitCodeMetadata,
-    py_pc: u32,
-) -> Option<(usize, u32)> {
-    metadata
-        .py_floor_by_jit_pc
-        .iter()
-        .find(|&&(_, py)| py == py_pc)
-        .map(|&(off, py)| (off as usize, py))
-}
-
-pub(crate) fn python_pc_for_jitcode_pc(metadata: &crate::PyJitCodeMetadata, jit_pc: usize) -> u32 {
-    if !metadata.py_floor_by_jit_pc.is_empty() {
-        let pivot = metadata
-            .block_head_py_by_jit_pc
-            .binary_search_by_key(&jit_pc, |&(off, _)| off)
-            .ok()
-            .map(|i| metadata.block_head_py_by_jit_pc[i].1)
-            .or_else(|| {
-                crate::pyjitcode::floor_segment_for_jitcode_pc(&metadata.py_floor_by_jit_pc, jit_pc)
-                    .map(|(_, py)| py)
-            })
-            .expect("drained JitCode PC floor pivot must begin at byte offset zero");
-        return pivot;
-    }
-    0
-}
-
 /// Resolve an in-flight body channel exactly where a stash match needs its
 /// Python body pc. A missing JitCode entry is deliberately `None`: callers
 /// treat it as no match and retain the legacy replay/delivery fallback.
@@ -183,8 +149,9 @@ pub(crate) fn inflight_foriter_body_pc(body: InflightForiterBody) -> Option<usiz
         InflightForiterBody::Jit {
             outer_jitcode_index,
             op_pc,
-        } => crate::state::pyjitcode_for_jitcode_index(outer_jitcode_index as i32)
-            .map(|jc| python_pc_for_jitcode_pc(&jc.metadata, op_pc) as usize + 1),
+        } => crate::state::pyjitcode_for_jitcode_index(outer_jitcode_index as i32).map(|jc| {
+            crate::py_coord::containing_py_pc_for_jitcode_pc(&jc.metadata, op_pc) as usize + 1
+        }),
     }
 }
 

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
@@ -1692,9 +1692,10 @@ pub(crate) fn fbw_publish_exit_last_instr<Sym: WalkSym>(
         let session = ctx.session.borrow();
         (session.recording_frame_ptr, session.recording_jitcode_index)
     };
-    let Some(py_pc) =
-        crate::state::python_pc_for_jitcode_pc_public(jitcode_index, opcode_position as i32)
-    else {
+    let Some(py_pc) = crate::py_coord::containing_py_pc_for_jitcode_pc_public(
+        jitcode_index,
+        opcode_position as i32,
+    ) else {
         return;
     };
     let Some(vbox) = ctx.trace_ctx.standard_virtualizable_box() else {
@@ -1802,7 +1803,10 @@ pub(crate) fn fbw_abort_resume_py_pc<Sym: WalkSym>(
     if jc.payload.code_ptr.is_null() {
         return None;
     }
-    Some(python_pc_for_jitcode_pc(&jc.payload.metadata, abort_jit_pc) as usize)
+    Some(
+        crate::py_coord::containing_py_pc_for_jitcode_pc(&jc.payload.metadata, abort_jit_pc)
+            as usize,
+    )
 }
 
 /// Every pc in `body_code` that some op can branch to: the `goto` family and

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -2111,7 +2111,14 @@ pub(crate) fn try_walker_inline_builtin_call<Sym: WalkSym>(
                 let jc = &*sym.jitcode();
                 let jc_index = jc.index as u32;
                 let marker = jc.payload.resume_marker_for_jitcode_pc(op.pc);
-                let mut py = python_pc_for_jitcode_pc(&jc.payload.metadata, op.pc);
+                // Forward py twin first (#73 phase-3): equals the
+                // inversion-plus-trivia value by construction; the inversion
+                // survives for the empty-twin class, and the trivia skip below
+                // is an identity on the twin path.
+                let mut py = jc
+                    .payload
+                    .forward_py_pc_for_jitcode_pc(op.pc)
+                    .unwrap_or_else(|| python_pc_for_jitcode_pc(&jc.payload.metadata, op.pc));
                 if jc.payload.code_ptr.is_null() {
                     (py, sym.valuestackdepth() as i64, jc_index, marker)
                 } else {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -1004,11 +1004,13 @@ pub(crate) fn try_walker_call_assembler_self_recursive<Sym: WalkSym>(
         let caller_jitcode = unsafe { &*sym.jitcode() };
         let caller_code = unsafe { &*caller_jitcode.payload.code_ptr };
         // #73 Slice 4: forward after-residual fallthrough coordinate; the
-        // inversion survives only for the empty-twin class and as the audit
-        // oracle.
+        // containing lookup survives only for the empty-twin class and as the
+        // audit oracle.
         let legacy_resume_py_pc = || {
-            let call_py_pc =
-                python_pc_for_jitcode_pc(&caller_jitcode.payload.metadata, op.pc) as usize;
+            let call_py_pc = crate::py_coord::containing_py_pc_for_jitcode_pc(
+                &caller_jitcode.payload.metadata,
+                op.pc,
+            ) as usize;
             crate::pyjitpl::semantic_fallthrough_pc(caller_code, call_py_pc) as u32
         };
         let resume_py_pc = match caller_jitcode
@@ -2098,47 +2100,56 @@ pub(crate) fn try_walker_inline_builtin_call<Sym: WalkSym>(
     if sym.jitcode().is_null() {
         return Ok(None);
     }
-    let (call_site_py_pc, vsd_value, outer_jitcode_index, call_site_marker) =
-        if nested_helper_entry.is_some() {
-            (
-                ctx.entry_py_pc(),
-                0,
-                ctx.outer_jitcode_index,
-                ctx.outer_resume_marker_jit_pc,
-            )
-        } else {
-            unsafe {
-                let jc = &*sym.jitcode();
-                let jc_index = jc.index as u32;
-                let marker = jc.payload.resume_marker_for_jitcode_pc(op.pc);
-                // Forward py twin first (#73 phase-3): equals the
-                // inversion-plus-trivia value by construction; the inversion
-                // survives for the empty-twin class, and the trivia skip below
-                // is an identity on the twin path.
-                let mut py = jc
-                    .payload
-                    .forward_py_pc_for_jitcode_pc(op.pc)
-                    .unwrap_or_else(|| python_pc_for_jitcode_pc(&jc.payload.metadata, op.pc));
-                if jc.payload.code_ptr.is_null() {
-                    (py, sym.valuestackdepth() as i64, jc_index, marker)
+    let (call_site_py_pc, vsd_value, outer_jitcode_index, call_site_marker) = if nested_helper_entry
+        .is_some()
+    {
+        (
+            ctx.entry_py_pc(),
+            0,
+            ctx.outer_jitcode_index,
+            ctx.outer_resume_marker_jit_pc,
+        )
+    } else {
+        unsafe {
+            let jc = &*sym.jitcode();
+            let jc_index = jc.index as u32;
+            let marker = jc.payload.resume_marker_for_jitcode_pc(op.pc);
+            // Forward py twin first (#73 phase-3): equals the
+            // containing coordinate plus trivia normalization by
+            // construction; the containing lookup survives for the
+            // empty-twin class, and the trivia skip below is an identity
+            // on the twin path.
+            let mut py = jc
+                .payload
+                .forward_py_pc_for_jitcode_pc(op.pc)
+                .unwrap_or_else(|| {
+                    crate::py_coord::note_empty_twin_fallback(
+                        "builtin_call",
+                        jc.index,
+                        op.pc as i32,
+                    );
+                    crate::py_coord::containing_py_pc_for_jitcode_pc(&jc.payload.metadata, op.pc)
+                });
+            if jc.payload.code_ptr.is_null() {
+                (py, sym.valuestackdepth() as i64, jc_index, marker)
+            } else {
+                let codeobj = &*jc.payload.code_ptr;
+                py = skip_python_trivia_forward(codeobj, py as usize) as u32;
+                let depth = if jc.payload.depth_trivia_populated() {
+                    jc.payload.depth_trivia_for_jitcode_pc(op.pc)
                 } else {
-                    let codeobj = &*jc.payload.code_ptr;
-                    py = skip_python_trivia_forward(codeobj, py as usize) as u32;
-                    let depth = if jc.payload.depth_trivia_populated() {
-                        jc.payload.depth_trivia_for_jitcode_pc(op.pc)
-                    } else {
-                        crate::liveness::liveness_for(jc.payload.code_ptr)
-                            .depth_at_py_pc()
-                            .get(py as usize)
-                            .copied()
-                    };
-                    let vsd = depth
-                        .map(|d| (sym.nlocals() + d as usize) as i64)
-                        .unwrap_or(sym.valuestackdepth() as i64);
-                    (py, vsd, jc_index, marker)
-                }
+                    crate::liveness::liveness_for(jc.payload.code_ptr)
+                        .depth_at_py_pc()
+                        .get(py as usize)
+                        .copied()
+                };
+                let vsd = depth
+                    .map(|d| (sym.nlocals() + d as usize) as i64)
+                    .unwrap_or(sym.valuestackdepth() as i64);
+                (py, vsd, jc_index, marker)
             }
-        };
+        }
+    };
     let call_site_word = call_site_marker
         .map(|marker| marker as i32)
         .unwrap_or(majit_ir::resumedata::NO_JITCODE_PC);
@@ -4091,7 +4102,9 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
                     let callee_pjc =
                         crate::state::pyjitcode_for_code(w_code).ok_or("no callee pyjitcode")?;
                     let metadata = &callee_pjc.metadata;
-                    let callee_py_pc = python_pc_for_jitcode_pc(metadata, abort_pc) as usize;
+                    let callee_py_pc =
+                        crate::py_coord::containing_py_pc_for_jitcode_pc(metadata, abort_pc)
+                            as usize;
                     // Both abort kinds sit at the head of an opcode the walker
                     // could not take, behind at most that opcode's own vable
                     // spill; the marker kind is the narrower of the two.
@@ -4103,7 +4116,10 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
                         body.code,
                         callee_py_pc,
                         abort_pc,
-                        |op_pc| python_pc_for_jitcode_pc(metadata, op_pc) as usize,
+                        |op_pc| {
+                            crate::py_coord::containing_py_pc_for_jitcode_pc(metadata, op_pc)
+                                as usize
+                        },
                     );
                     if !anchor_ok {
                         if fbw_debug_abort_enabled() {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -672,7 +672,7 @@ fn record_inline_application_traceback<Sym: WalkSym>(
         // substitute `frame.last_instr`.  Whether an unmappable coordinate
         // should still contribute a node is a separate question from which
         // frame the node names.
-        let node_frame = crate::state::python_pc_for_jitcode_pc_public(
+        let node_frame = crate::py_coord::containing_py_pc_for_jitcode_pc_public(
             consts.jitcode_index,
             opcode_position as i32,
         )
@@ -811,8 +811,10 @@ fn traceback_node_site<Sym: WalkSym>(
         return None;
     }
     let jitcode = crate::state::pyjitcode_for_jitcode_index(jitcode_index)?;
-    let last_instruction =
-        crate::state::python_pc_for_jitcode_pc_public(jitcode_index, opcode_position as i32)?;
+    let last_instruction = crate::py_coord::containing_py_pc_for_jitcode_pc_public(
+        jitcode_index,
+        opcode_position as i32,
+    )?;
     let raw_code = crate::state::raw_code_for_jitcode_index(jitcode_index)?;
     let lineno =
         unsafe { pyre_interpreter::pyframe::offset2lineno(&*raw_code, last_instruction as isize) }
@@ -1081,8 +1083,9 @@ impl<Sym: WalkSym> Copy for FbwWalkMode<Sym> {}
 
 /// The outer snapshot's Python-PC coordinate. Non-root producers preserve the
 /// raw JitCode offset that produced the Python word, postponing the exact
-/// `backxlat_py_pc` inversion until a consumer needs it. Root entries and test
-/// fixtures have no such native coordinate and retain their Python value.
+/// `trivia_normalized_py_pc_for_jitcode_pc` lookup until a consumer needs it.
+/// Root entries and test fixtures have no such native coordinate and retain
+/// their Python value.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum EntryPyPc {
     Py(u32),
@@ -1387,7 +1390,7 @@ pub struct WalkContext<'frame, 'static_a: 'frame, Sym: WalkSym> {
     /// was reconciled).
     pub vstack_depth: usize,
     /// #73: the Python pc of the opcode currently being walked.  A change
-    /// in `python_pc_for_jitcode_pc(jit_pc)` from this value marks a
+    /// in `containing_py_pc_for_jitcode_pc(jit_pc)` from this value marks a
     /// Python-opcode boundary, where the previous opcode's stack effect is
     /// reconciled into `vstack_boxes` (see [`reconcile_vstack_at_boundary`]).
     pub vstack_cur_pypc: u32,
@@ -1429,7 +1432,7 @@ impl<Sym: WalkSym> WalkContext<'_, '_, Sym> {
     fn entry_py_pc(&self) -> u32 {
         match self.entry_py_pc {
             EntryPyPc::Py(py_pc) => py_pc,
-            EntryPyPc::Jit(jitcode_pc) => crate::state::forward_py_pc_or_backxlat(
+            EntryPyPc::Jit(jitcode_pc) => crate::py_coord::resume_py_pc_for_jitcode_word(
                 self.outer_jitcode_index as i32,
                 jitcode_pc as i32,
             ) as u32,
@@ -5145,11 +5148,11 @@ struct InlineParentBlackhole {
 /// The derivation flavor of a paused caller frame's Python resume pc.
 #[derive(Clone, Copy)]
 enum ParentResumeCoord {
-    /// `resume_py_pc = backxlat_py_pc(jitcode_index, jitcode_pc)`. Used by
+    /// `resume_py_pc = trivia_normalized_py_pc_for_jitcode_pc(jitcode_index, jitcode_pc)`. Used by
     /// both bridge-root and reconstructed-recipe parent frames.
     Backxlat(usize),
     /// `resume_py_pc = semantic_fallthrough_pc(code,
-    /// python_pc_for_jitcode_pc(metadata, call_jitcode_pc))`.
+    /// containing_py_pc_for_jitcode_pc(metadata, call_jitcode_pc))`.
     CallFallthrough(usize),
 }
 
@@ -8068,7 +8071,8 @@ fn walker_foriter_green_key<Sym: WalkSym>(
     if w_code.is_null() {
         return None;
     }
-    let foriter_start_pc = python_pc_for_jitcode_pc(&jitcode.payload.metadata, op_pc) as usize;
+    let foriter_start_pc =
+        crate::py_coord::containing_py_pc_for_jitcode_pc(&jitcode.payload.metadata, op_pc) as usize;
     Some(crate::driver::make_green_key(w_code, foriter_start_pc))
 }
 

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -1963,7 +1963,8 @@ pub(crate) fn probe_resid_decline_ctx<Sym: WalkSym>(
         let s = unsafe { &*sym };
         if !s.jitcode().is_null() {
             let jc = unsafe { &*s.jitcode() };
-            let pc = python_pc_for_jitcode_pc(&jc.payload.metadata, op_pc) as usize;
+            let pc = crate::py_coord::containing_py_pc_for_jitcode_pc(&jc.payload.metadata, op_pc)
+                as usize;
             let op = if !jc.payload.code_ptr.is_null() {
                 pyre_interpreter::decode_instruction_at(unsafe { &*jc.payload.code_ptr }, pc)
                     .map(|(i, _)| format!("{i:?}"))

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/resume_snapshot.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/resume_snapshot.rs
@@ -370,18 +370,24 @@ pub(crate) fn walker_capture_snapshot_for_last_guard_impl<Sym: WalkSym>(
             let mut marker_call_jit_pc: Option<usize> = None;
             let (py_pc, jitcode_index, num_instrs) = unsafe {
                 let jc = &*sym.jitcode();
-                let mut py = python_pc_for_jitcode_pc(&jc.payload.metadata, op_pc);
-                // The jitcode-pc→py-pc inversion can land on a Python trivia
-                // instruction's jitcode region (e.g. a branch target
-                // whose block lowers `NOT_TAKEN`).  A resume coordinate
-                // must be a real opcode: the interpreter resumes branches
-                // at `semantic_fallthrough_pc` / `jump_target_forward`,
-                // both of which forward-skip trivia.  Advance to the same
-                // real opcode so the resume reader's BACKWARD trivia
-                // backtrack (call_jit.rs) is a no-op — otherwise a
+                // Forward py twin first (#73 phase-3): equals the
+                // inversion-plus-trivia value by construction; the inversion
+                // survives for the empty-twin class (skeleton / fixture).
+                let mut py = jc
+                    .payload
+                    .forward_py_pc_for_jitcode_pc(op_pc)
+                    .unwrap_or_else(|| python_pc_for_jitcode_pc(&jc.payload.metadata, op_pc));
+                // A resolved py must be a real opcode, never Python trivia
+                // (e.g. a branch target whose block lowers `NOT_TAKEN`): the
+                // interpreter resumes branches at `semantic_fallthrough_pc` /
+                // `jump_target_forward`, both of which forward-skip trivia.
+                // Land on the same real opcode so the resume reader's BACKWARD
+                // trivia backtrack (call_jit.rs) is a no-op — otherwise a
                 // `NOT_TAKEN` py_pc backtracks to the preceding branch
                 // opcode, whose block-entry liveness differs from the
-                // target's and desyncs the snapshot box-count.
+                // target's and desyncs the snapshot box-count.  The twin is
+                // already trivia-normalized, so the skip below is an identity
+                // on that path and normalizes only the inversion fallback.
                 if !jc.payload.code_ptr.is_null() {
                     let code = &*jc.payload.code_ptr;
                     py = skip_python_trivia_forward(code, py as usize) as u32;
@@ -1471,7 +1477,6 @@ pub(crate) fn compute_inline_caller_frame<Sym: WalkSym>(
         if jc.payload.code_ptr.is_null() || !jc.payload.is_populated() {
             return Err(InlineCallerFrameDecline::Unavailable);
         }
-        let call_py = python_pc_for_jitcode_pc(&jc.payload.metadata, call_jit_pc) as usize;
         // A CALL inside a try-block: inline it only when its exception handler
         // rejoins the loop (the exc-edge-bridgeable shape); otherwise decline so
         // the residual path handles the raise via its after-residual catch
@@ -1482,21 +1487,30 @@ pub(crate) fn compute_inline_caller_frame<Sym: WalkSym>(
             jc.payload.jitcode.code.as_slice(),
             callee_has_freevars,
         )?;
-        let code = &*jc.payload.code_ptr;
-        let fallthrough = crate::pyjitpl::semantic_fallthrough_pc(code, call_py) as u32;
-        // #73 Slice 4 (twin-first): certify the forward `after_residual_fallthrough`
-        // twin reproduces the inverted-then-fallthrough coordinate before any
-        // consumer cuts over to it.
-        if pcmap_afterresidual_audit_enabled()
-            && jc.payload.after_residual_fallthrough_py_pc_populated()
+        // #73 phase-3 (twin-first): the forward `after_residual_fallthrough`
+        // twin carries the inverted-then-fallthrough coordinate; the inversion
+        // survives for the empty-twin class and as the audit oracle.
+        let legacy_fallthrough = || unsafe {
+            let call_py = python_pc_for_jitcode_pc(&jc.payload.metadata, call_jit_pc) as usize;
+            let code = &*jc.payload.code_ptr;
+            crate::pyjitpl::semantic_fallthrough_pc(code, call_py) as u32
+        };
+        let fallthrough = match jc
+            .payload
+            .after_residual_fallthrough_py_pc_for_jitcode_pc(call_jit_pc)
         {
-            assert_eq!(
-                jc.payload
-                    .after_residual_fallthrough_py_pc_for_jitcode_pc(call_jit_pc),
-                Some(fallthrough),
-                "PYRE_PCMAP_AFTERRESIDUAL_AUDIT: inline-caller fallthrough-py twin diverged at jit_pc {call_jit_pc} (call_py {call_py})"
-            );
-        }
+            Some(ft) => {
+                if pcmap_afterresidual_audit_enabled() {
+                    assert_eq!(
+                        ft,
+                        legacy_fallthrough(),
+                        "PYRE_PCMAP_AFTERRESIDUAL_AUDIT: inline-caller fallthrough-py twin diverged at jit_pc {call_jit_pc}"
+                    );
+                }
+                ft
+            }
+            None => legacy_fallthrough(),
+        };
         (
             jc.index as u32,
             fallthrough,

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/resume_snapshot.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/resume_snapshot.rs
@@ -43,7 +43,8 @@ pub(crate) fn after_residual_guard_marker(
 
 /// Read the Python PC paired with a native resume word.  The codewriter builds
 /// this table from Python-PC keys, including the same forward trivia skip as
-/// `backxlat_py_pc`; capture deliberately never projects the word backwards.
+/// `trivia_normalized_py_pc_for_jitcode_pc`; capture deliberately never derives
+/// it from the word.
 fn forward_snapshot_py_pc(jitcode_index: u32, pc: u32) -> Result<u32, DispatchError> {
     if pc == majit_ir::resumedata::NO_JITCODE_PC as u32 {
         return Ok(u32::MAX);
@@ -370,13 +371,23 @@ pub(crate) fn walker_capture_snapshot_for_last_guard_impl<Sym: WalkSym>(
             let mut marker_call_jit_pc: Option<usize> = None;
             let (py_pc, jitcode_index, num_instrs) = unsafe {
                 let jc = &*sym.jitcode();
-                // Forward py twin first (#73 phase-3): equals the
-                // inversion-plus-trivia value by construction; the inversion
-                // survives for the empty-twin class (skeleton / fixture).
+                // Forward py twin first (#73 phase-3): equals the containing
+                // coordinate plus trivia normalization by construction; the
+                // containing lookup survives for the empty-twin class.
                 let mut py = jc
                     .payload
                     .forward_py_pc_for_jitcode_pc(op_pc)
-                    .unwrap_or_else(|| python_pc_for_jitcode_pc(&jc.payload.metadata, op_pc));
+                    .unwrap_or_else(|| {
+                        crate::py_coord::note_empty_twin_fallback(
+                            "capture_seam",
+                            jc.index,
+                            op_pc as i32,
+                        );
+                        crate::py_coord::containing_py_pc_for_jitcode_pc(
+                            &jc.payload.metadata,
+                            op_pc,
+                        )
+                    });
                 // A resolved py must be a real opcode, never Python trivia
                 // (e.g. a branch target whose block lowers `NOT_TAKEN`): the
                 // interpreter resumes branches at `semantic_fallthrough_pc` /
@@ -1034,8 +1045,11 @@ pub(crate) fn walker_capture_snapshot_for_last_guard_impl<Sym: WalkSym>(
                 )
             } else {
                 let entry = unsafe {
-                    first_floor_boundary_for_py(&(&*sym.jitcode()).payload.metadata, liveness_py_pc)
-                        .map(|(pc, _)| pc)
+                    crate::py_coord::first_floor_boundary_for_py(
+                        &(&*sym.jitcode()).payload.metadata,
+                        liveness_py_pc,
+                    )
+                    .map(|(pc, _)| pc)
                 };
                 match entry {
                     Some(pc) => (
@@ -1334,7 +1348,7 @@ fn call_null_or_self_slot<Sym: WalkSym>(
     let jc = unsafe { caller_sym.jitcode().as_ref()? };
     let code = unsafe { (jc.payload.code_ptr as *const pyre_interpreter::CodeObject).as_ref()? };
     let py_pc =
-        crate::jitcode_dispatch::python_pc_for_jitcode_pc(&jc.payload.metadata, call_jitcode_pc)
+        crate::py_coord::containing_py_pc_for_jitcode_pc(&jc.payload.metadata, call_jitcode_pc)
             as usize;
     let (pyre_interpreter::Instruction::Call { argc }, op_arg) =
         pyre_interpreter::decode_instruction_at(code, py_pc)?
@@ -1488,10 +1502,13 @@ pub(crate) fn compute_inline_caller_frame<Sym: WalkSym>(
             callee_has_freevars,
         )?;
         // #73 phase-3 (twin-first): the forward `after_residual_fallthrough`
-        // twin carries the inverted-then-fallthrough coordinate; the inversion
-        // survives for the empty-twin class and as the audit oracle.
+        // twin carries the containing-then-fallthrough coordinate; the
+        // containing lookup survives for the empty-twin class and as the audit
+        // oracle.
         let legacy_fallthrough = || unsafe {
-            let call_py = python_pc_for_jitcode_pc(&jc.payload.metadata, call_jit_pc) as usize;
+            let call_py =
+                crate::py_coord::containing_py_pc_for_jitcode_pc(&jc.payload.metadata, call_jit_pc)
+                    as usize;
             let code = &*jc.payload.code_ptr;
             crate::pyjitpl::semantic_fallthrough_pc(code, call_py) as u32
         };
@@ -1509,7 +1526,14 @@ pub(crate) fn compute_inline_caller_frame<Sym: WalkSym>(
                 }
                 ft
             }
-            None => legacy_fallthrough(),
+            None => {
+                crate::py_coord::note_empty_twin_fallback(
+                    "inline_caller_fallthrough",
+                    jc.index,
+                    call_jit_pc as i32,
+                );
+                legacy_fallthrough()
+            }
         };
         (
             jc.index as u32,
@@ -1654,7 +1678,8 @@ pub(crate) fn compute_nested_inline_caller_frame<Sym: WalkSym>(
         callee_has_freevars,
     )?;
     let legacy_fallthrough_py_pc = || unsafe {
-        let call_py = python_pc_for_jitcode_pc(&pjc.metadata, call_jit_pc) as usize;
+        let call_py =
+            crate::py_coord::containing_py_pc_for_jitcode_pc(&pjc.metadata, call_jit_pc) as usize;
         let code = &*pjc.code_ptr;
         crate::pyjitpl::semantic_fallthrough_pc(code, call_py) as u32
     };
@@ -2115,7 +2140,10 @@ pub(crate) fn walker_capture_multi_frame_inline_snapshot<Sym: WalkSym>(
     if mf_diag || recipe_resultcolor_audit {
         let callee_py_pc = unsafe {
             let code = &*callee_pjc.code_ptr;
-            let mut py = python_pc_for_jitcode_pc(&callee_pjc.metadata, callee_op_pc);
+            let mut py = crate::py_coord::containing_py_pc_for_jitcode_pc(
+                &callee_pjc.metadata,
+                callee_op_pc,
+            );
             py = skip_python_trivia_forward(code, py as usize) as u32;
             if after_residual_call {
                 py = crate::pyjitpl::semantic_fallthrough_pc(code, py as usize) as u32;
@@ -2142,7 +2170,10 @@ pub(crate) fn walker_capture_multi_frame_inline_snapshot<Sym: WalkSym>(
             let verdict = match (scope.branch_guard_jitcode_pc, native_marker) {
                 (Some(_), _) => "branch_external",
                 (None, Some(marker)) => {
-                    let native_py = python_pc_for_jitcode_pc(&callee_pjc.metadata, marker) as usize;
+                    let native_py = crate::py_coord::containing_py_pc_for_jitcode_pc(
+                        &callee_pjc.metadata,
+                        marker,
+                    ) as usize;
                     if native_py == callee_py_pc as usize {
                         "eq"
                     } else {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -7089,7 +7089,13 @@ pub(crate) fn orthodox_list_append_commit<Sym: WalkSym>(
         let jc = &*sym.jitcode();
         let jc_index = jc.index as u32;
         let marker = jc.payload.resume_marker_for_jitcode_pc(op.pc);
-        let mut py = python_pc_for_jitcode_pc(&jc.payload.metadata, op.pc);
+        // Forward py twin first (#73 phase-3): equals the inversion-plus-trivia
+        // value by construction; the inversion survives for the empty-twin
+        // class, and the trivia skip below is an identity on the twin path.
+        let mut py = jc
+            .payload
+            .forward_py_pc_for_jitcode_pc(op.pc)
+            .unwrap_or_else(|| python_pc_for_jitcode_pc(&jc.payload.metadata, op.pc));
         if jc.payload.code_ptr.is_null() {
             (py, sym.valuestackdepth() as i64, jc_index, marker)
         } else {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -7089,20 +7089,28 @@ pub(crate) fn orthodox_list_append_commit<Sym: WalkSym>(
         let jc = &*sym.jitcode();
         let jc_index = jc.index as u32;
         let marker = jc.payload.resume_marker_for_jitcode_pc(op.pc);
-        // Forward py twin first (#73 phase-3): equals the inversion-plus-trivia
-        // value by construction; the inversion survives for the empty-twin
-        // class, and the trivia skip below is an identity on the twin path.
+        // Forward py twin first (#73 phase-3): equals the containing
+        // coordinate plus trivia normalization by construction; the containing
+        // lookup survives for the empty-twin class, and the trivia skip below
+        // is an identity on the twin path.
         let mut py = jc
             .payload
             .forward_py_pc_for_jitcode_pc(op.pc)
-            .unwrap_or_else(|| python_pc_for_jitcode_pc(&jc.payload.metadata, op.pc));
+            .unwrap_or_else(|| {
+                crate::py_coord::note_empty_twin_fallback(
+                    "list_append_commit",
+                    jc.index,
+                    op.pc as i32,
+                );
+                crate::py_coord::containing_py_pc_for_jitcode_pc(&jc.payload.metadata, op.pc)
+            });
         if jc.payload.code_ptr.is_null() {
             (py, sym.valuestackdepth() as i64, jc_index, marker)
         } else {
             let codeobj = &*jc.payload.code_ptr;
             py = skip_python_trivia_forward(codeobj, py as usize) as u32;
             // Read the depth off the jitcode-pc-keyed trivia twin, which equals
-            // `depth_at_py_pc()[skip_python_trivia_forward(python_pc_for_jitcode_pc(op.pc))]`
+            // `depth_at_py_pc()[skip_python_trivia_forward(containing_py_pc_for_jitcode_pc(op.pc))]`
             // by construction; fall back to the py_pc-keyed static-liveness read
             // where the twin is unpopulated (skeleton / fixture install).
             let depth = if jc.payload.depth_trivia_populated() {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/vstack_mirror.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/vstack_mirror.rs
@@ -637,7 +637,7 @@ pub(crate) fn reseed_vstack_from_shadow<Sym: WalkSym>(
 }
 
 /// #73: map a jitcode pc to the Python opcode whose lowering region
-/// CONTAINS it, WITHOUT the `python_pc_for_jitcode_pc` block-head marker
+/// CONTAINS it, WITHOUT the `containing_py_pc_for_jitcode_pc` block-head marker
 /// special-case.  For the operand-stack mirror we want the containing
 /// opcode (where the walk physically is), not the resume block-head a
 /// `-live-` marker names — the marker case returns an EARLIER py_pc and

--- a/pyre/pyre-jit-trace/src/lib.rs
+++ b/pyre/pyre-jit-trace/src/lib.rs
@@ -32,6 +32,7 @@ pub mod helpers;
 pub mod jitcode_dispatch;
 pub mod jitcode_runtime;
 pub mod liveness;
+pub mod py_coord;
 pub mod pyjitcode;
 pub mod pyjitpl;
 pub mod pyre_cpu;

--- a/pyre/pyre-jit-trace/src/py_coord.rs
+++ b/pyre/pyre-jit-trace/src/py_coord.rs
@@ -1,0 +1,150 @@
+//! JitCode-PC-keyed Python coordinate helpers.
+//!
+//! These helpers read the codewriter-built twin tables materialized at
+//! lowering time where the codewriter natively knows the Python PC:
+//! `block_head_py_by_jit_pc` for exact block-head markers and
+//! `py_floor_by_jit_pc` for containing floor segments. Together with the
+//! forward-carried `SnapshotFrame.py_pc` resume channel, these tables are the
+//! only Python-coordinate sources; runtime consumers never project a JitCode
+//! PC through a Python-keyed map.
+
+pub(crate) fn floor_boundary_at_or_after(
+    metadata: &crate::PyJitCodeMetadata,
+    jit_pc: usize,
+) -> Option<(usize, u32)> {
+    let table = &metadata.py_floor_by_jit_pc;
+    let idx = table.partition_point(|&(off, _)| (off as usize) < jit_pc);
+    table.get(idx).map(|&(off, py)| (off as usize, py))
+}
+
+pub(crate) fn first_floor_boundary_for_py(
+    metadata: &crate::PyJitCodeMetadata,
+    py_pc: u32,
+) -> Option<(usize, u32)> {
+    metadata
+        .py_floor_by_jit_pc
+        .iter()
+        .find(|&&(_, py)| py == py_pc)
+        .map(|&(off, py)| (off as usize, py))
+}
+
+/// Resolve a JitCode offset to the Python instruction coordinate containing it.
+///
+/// Exact block-head marker matches win first. Otherwise the floor segment is
+/// the Python instruction whose lowering region contains the JitCode PC, the
+/// coordinate the per-bytecode `last_instr` store in
+/// `pyopcode.py:200 dispatch_bytecode` would have left in the frame.
+pub(crate) fn containing_py_pc_for_jitcode_pc(
+    metadata: &crate::PyJitCodeMetadata,
+    jit_pc: usize,
+) -> u32 {
+    if !metadata.py_floor_by_jit_pc.is_empty() {
+        let pivot = metadata
+            .block_head_py_by_jit_pc
+            .binary_search_by_key(&jit_pc, |&(off, _)| off)
+            .ok()
+            .map(|i| metadata.block_head_py_by_jit_pc[i].1)
+            .or_else(|| {
+                crate::pyjitcode::floor_segment_for_jitcode_pc(&metadata.py_floor_by_jit_pc, jit_pc)
+                    .map(|(_, py)| py)
+            })
+            .expect("drained JitCode PC floor pivot must begin at byte offset zero");
+        return pivot;
+    }
+    0
+}
+
+/// Resolve `MetaInterpStaticData.jitcodes[jitcode_index]` to the containing
+/// Python instruction coordinate for a stored JitCode offset.
+pub fn containing_py_pc_for_jitcode_pc_public(jitcode_index: i32, offset: i32) -> Option<i32> {
+    let payload = crate::state::pyjitcode_for_jitcode_index(jitcode_index)?;
+    Some(containing_py_pc_for_jitcode_pc(&payload.metadata, offset as usize) as i32)
+}
+
+/// Advance a Python instruction coordinate past resume trivia when code is available.
+pub fn skip_python_trivia_forward_public(
+    jitcode_index: i32,
+    raw_py_pc: i32,
+) -> Option<(i32, bool)> {
+    let payload = crate::state::pyjitcode_for_jitcode_index(jitcode_index)?;
+    if payload.code_ptr.is_null() {
+        return Some((raw_py_pc, false));
+    }
+    let code = unsafe { &*payload.code_ptr };
+    Some((
+        crate::jitcode_dispatch::skip_python_trivia_forward(code, raw_py_pc as usize) as i32,
+        true,
+    ))
+}
+
+/// Translate a resume-frame pc word to a trivia-normalized Python coordinate.
+///
+/// A negative word (sentinel / branch-orgpc tag) has no Python coordinate; it
+/// passes through so the caller's `pc < 0` screen rejects it (the internal
+/// metadata lookups below are bounds-checked and never index with the word, so
+/// no wrap results).
+pub fn trivia_normalized_py_pc_for_jitcode_pc(jitcode_index: i32, pc_word: i32) -> i32 {
+    let fallback = pc_word;
+    match containing_py_pc_for_jitcode_pc_public(jitcode_index, pc_word)
+        .and_then(|raw_py_pc| skip_python_trivia_forward_public(jitcode_index, raw_py_pc))
+        .map(|(py_pc, _)| py_pc)
+    {
+        Some(py_pc) => py_pc,
+        None => fallback,
+    }
+}
+
+/// `PYRE_M73_BACKXLAT_TWIN_AUDIT` asserts the codewriter-built forward py_pc
+/// twin equals the [`trivia_normalized_py_pc_for_jitcode_pc`] containing lookup
+/// at every non-negative resume word before [`resume_py_pc_for_jitcode_word`]
+/// trusts the twin. Off in production; the gated assert is the only added work.
+fn m73_backxlat_twin_audit_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| std::env::var_os("PYRE_M73_BACKXLAT_TWIN_AUDIT").is_some())
+}
+
+pub(crate) fn emptytwin_census_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| std::env::var_os("PYRE_M73_EMPTYTWIN_CENSUS").is_some())
+}
+
+pub(crate) fn note_empty_twin_fallback(site: &'static str, jitcode_index: i32, jit_pc: i32) {
+    if emptytwin_census_enabled() {
+        eprintln!("[m73-emptytwin] site={site} jitcode={jitcode_index} pc={jit_pc}");
+    }
+}
+
+/// Forward Python instruction coordinate for a carried resume JitCode word.
+///
+/// Reads the codewriter-built `forward_py_pc` twin first. Empty-twin JitCodes
+/// and negative sentinel words resolve through the trivia-normalized containing
+/// lookup.
+///
+/// Negative words (`NO_JITCODE_PC` `-1`, tagged branch-orgpc words `<= -2`)
+/// cast to a huge `usize` twin key and would floor-resolve to a bogus
+/// predecessor entry, so they are delegated straight to
+/// `trivia_normalized_py_pc_for_jitcode_pc`, which resolves them identically to
+/// the pre-cutover call.
+pub fn resume_py_pc_for_jitcode_word(jitcode_index: i32, pc_word: i32) -> i32 {
+    if pc_word < 0 {
+        return trivia_normalized_py_pc_for_jitcode_pc(jitcode_index, pc_word);
+    }
+    match crate::state::pyjitcode_for_jitcode_index(jitcode_index)
+        .and_then(|pjc| pjc.forward_py_pc_for_jitcode_pc(pc_word as usize))
+    {
+        Some(twin) => {
+            if m73_backxlat_twin_audit_enabled() {
+                assert_eq!(
+                    twin as i32,
+                    trivia_normalized_py_pc_for_jitcode_pc(jitcode_index, pc_word),
+                    "PYRE_M73_BACKXLAT_TWIN_AUDIT: forward py_pc twin diverged at jitcode {jitcode_index} pc {pc_word}"
+                );
+            }
+            twin as i32
+        }
+        None => {
+            note_empty_twin_fallback("resume_word", jitcode_index, pc_word);
+            trivia_normalized_py_pc_for_jitcode_pc(jitcode_index, pc_word)
+        }
+    }
+}

--- a/pyre/pyre-jit-trace/src/pyjitcode.rs
+++ b/pyre/pyre-jit-trace/src/pyjitcode.rs
@@ -60,14 +60,14 @@ use std::ops::{Deref, DerefMut};
 pub struct PyJitCodeMetadata {
     /// Codewrite-time forward Python-PC twin for resume data.  The exact
     /// block-head and predecessor-op-start tiers mirror
-    /// `python_pc_for_jitcode_pc` and already include the forward trivia
+    /// `containing_py_pc_for_jitcode_pc` and already include the forward trivia
     /// normalization.  It is populated from Python keys while codewriting;
     /// snapshot capture must not invert a resolved JitCode PC to obtain it.
     pub forward_py_pc_marker_by_jit_pc: Vec<(usize, u32)>,
     pub forward_py_pc_pred_by_jit_pc: Vec<(usize, u32)>,
     /// Post-residual-call catch resume twin, split into the exact
     /// block-head-marker and predecessor op-start tiers used by
-    /// `python_pc_for_jitcode_pc`. Empty for skeleton / fixture metadata.
+    /// `containing_py_pc_for_jitcode_pc`. Empty for skeleton / fixture metadata.
     pub after_residual_call_resume_marker_by_jit_pc: Vec<(usize, Option<usize>)>,
     pub after_residual_call_resume_pred_by_jit_pc: Vec<(usize, Option<usize>)>,
     /// Number of Python instructions in the source CodeObject. Empty skeleton
@@ -79,7 +79,7 @@ pub struct PyJitCodeMetadata {
     /// control-flow entries, so the dense-map owner is the block entry.
     /// Sorted ascending by jitcode offset for binary search.  Replaces the
     /// former dense-map block-head scan in
-    /// `python_pc_for_jitcode_pc` (a coordinate landing exactly on a marker is
+    /// `containing_py_pc_for_jitcode_pc` (a coordinate landing exactly on a marker is
     /// a block head — branch/catch target — and belongs to the first opcode
     /// resuming there). Empty for skeleton / fixture metadata.
     pub block_head_py_by_jit_pc: Vec<(usize, u32)>,
@@ -100,10 +100,10 @@ pub struct PyJitCodeMetadata {
     pub merge_entry_by_green: Vec<(u32, u32)>,
     /// Predecessor-keyed jitcode-pc twin of `pcdep_color_slots`.
     /// Each entry `(off, colors)` maps a JitCode byte offset to the pcdep
-    /// color→slot list of the py_pc that `python_pc_for_jitcode_pc(off)` returns
+    /// color→slot list of the py_pc that `containing_py_pc_for_jitcode_pc(off)` returns
     /// (block-head marker precedence, else the predecessor op-start boundary).
     /// A PREDECESSOR binary search (largest offset ≤ jit_pc)
-    /// then reproduces `pcdep_color_slots[python_pc_for_jitcode_pc(jit_pc)]` for
+    /// then reproduces `pcdep_color_slots[containing_py_pc_for_jitcode_pc(jit_pc)]` for
     /// the carried resume coordinates reaching the decode re-inversion at
     /// `bridge_semantic_maps_at_with_jitcode_pc`. Both sides are compile-time
     /// derivations of the same resume-marker / `first_jit` coordinates, so the
@@ -111,14 +111,14 @@ pub struct PyJitCodeMetadata {
     /// skeleton / fixture.
     pub pcdep_by_jit_pc: Vec<(usize, Vec<(u8, u16, u16)>)>,
     /// Predecessor-keyed jitcode-pc twin of `depth_at_py_pc`,
-    /// built alongside `pcdep_by_jit_pc` with the same `python_pc_for_jitcode_pc`
+    /// built alongside `pcdep_by_jit_pc` with the same `containing_py_pc_for_jitcode_pc`
     /// resolution (marker precedence + op-start predecessor). Predecessor-covers
     /// op offsets, so it agrees with the depth read at the decode seam for every
     /// carried coordinate: it equals
-    /// `depth_at_py_pc[python_pc_for_jitcode_pc(jit_pc)]` by construction.
+    /// `depth_at_py_pc[containing_py_pc_for_jitcode_pc(jit_pc)]` by construction.
     pub depth_pred_by_jit_pc: Vec<(usize, u16)>,
     /// Trivia-aware STATIC-liveness depth twin, split into the
-    /// SAME two tiers as `python_pc_for_jitcode_pc` — an EXACT-match marker table
+    /// SAME two tiers as `containing_py_pc_for_jitcode_pc` — an EXACT-match marker table
     /// (`depth_trivia_marker_by_jit_pc`, block-head precedence) and a PREDECESSOR
     /// op-start table (`depth_trivia_pred_by_jit_pc`, markers EXCLUDED). Each
     /// records `liveness_for(code).depth_at_py_pc()[skip_python_trivia_forward(py)]`
@@ -149,7 +149,7 @@ pub struct PyJitCodeMetadata {
     /// Empty for skeleton / fixture metadata.
     pub depth_block_head_by_jit_pc: Vec<(usize, u16)>,
     /// Reproduces `pcdep_color_slots[skip_python_trivia_forward(
-    /// python_pc_for_jitcode_pc(jit_pc))]`, resolved with the same exact-marker
+    /// containing_py_pc_for_jitcode_pc(jit_pc))]`, resolved with the same exact-marker
     /// and predecessor-op-start tiers as the trivia-aware depth twin.
     pub pcdep_trivia_marker_by_jit_pc: Vec<(usize, Vec<(u8, u16, u16)>)>,
     /// Predecessor-op-start tier of the trivia-aware `pcdep_color_slots` twin.
@@ -168,7 +168,7 @@ pub struct PyJitCodeMetadata {
     pub result_color_trivia_marker_by_jit_pc: Vec<(usize, Option<u16>)>,
     pub result_color_trivia_pred_by_jit_pc: Vec<(usize, Option<u16>)>,
     /// Resume-marker twin split into the SAME two tiers as
-    /// `python_pc_for_jitcode_pc` — an EXACT-match marker table
+    /// `containing_py_pc_for_jitcode_pc` — an EXACT-match marker table
     /// (`resume_marker_marker_by_jit_pc`, block-head precedence) and a
     /// PREDECESSOR op-start table (`resume_marker_pred_by_jit_pc`, markers
     /// EXCLUDED). Each records the block-head `-live-` resume-marker JitCode byte
@@ -251,7 +251,7 @@ pub struct PyJitCodeMetadata {
     pub max_stackdepth: usize,
     /// Predecessor-keyed jitcode-pc const Ref operand-stack slots.
     /// Each entry `(off, slots)` maps a JitCode byte offset to the const
-    /// operand-stack slot list of the py_pc that `python_pc_for_jitcode_pc(off)`
+    /// operand-stack slot list of the py_pc that `containing_py_pc_for_jitcode_pc(off)`
     /// returns (block-head marker precedence, else the predecessor op-start
     /// boundary at-or-before `off`). A PREDECESSOR binary search (largest
     /// offset ≤ jit_pc) returns the slots for a carried resume coordinate.
@@ -585,7 +585,7 @@ impl PyJitCode {
 
     /// Predecessor index into a jitcode-pc twin — the entry
     /// with the largest offset at-or-before `jit_pc`, reproducing
-    /// `python_pc_for_jitcode_pc`'s marker-then-first_jit resolution baked into
+    /// `containing_py_pc_for_jitcode_pc`'s marker-then-first_jit resolution baked into
     /// the twin at build time. `None` when the table is empty (skeleton /
     /// fixture) or `jit_pc` precedes the first entry.
     fn predecessor_index(search: Result<usize, usize>) -> Option<usize> {
@@ -598,7 +598,7 @@ impl PyJitCode {
 
     /// The pcdep color→slot list keyed directly by a JitCode byte
     /// offset via the `pcdep_by_jit_pc` predecessor twin. Equals
-    /// `pcdep_color_slots[python_pc_for_jitcode_pc(jit_pc)]` by construction for
+    /// `pcdep_color_slots[containing_py_pc_for_jitcode_pc(jit_pc)]` by construction for
     /// a carried resume coordinate; `None` when the twin is empty (skeleton /
     /// fixture). Scaffolding for the decode-side pc_map re-inversion retirement.
     pub fn pcdep_for_jitcode_pc(&self, jit_pc: usize) -> Option<Vec<(u8, u16, u16)>> {
@@ -612,7 +612,7 @@ impl PyJitCode {
 
     /// Value-stack depth keyed by a JitCode byte offset via the
     /// `depth_pred_by_jit_pc` predecessor twin. Equals
-    /// `depth_at_py_pc[python_pc_for_jitcode_pc(jit_pc)]` by construction for a
+    /// `depth_at_py_pc[containing_py_pc_for_jitcode_pc(jit_pc)]` by construction for a
     /// carried resume coordinate; `None` when the twin is empty. Predecessor
     /// index (largest offset ≤ jit_pc).
     pub fn depth_for_jitcode_pc_pred(&self, jit_pc: usize) -> Option<u16> {
@@ -674,10 +674,10 @@ impl PyJitCode {
 
     /// Trivia-aware STATIC-liveness depth keyed by a JitCode
     /// byte offset, resolved with the SAME two tiers as
-    /// `python_pc_for_jitcode_pc`: an EXACT marker match first (block-head
+    /// `containing_py_pc_for_jitcode_pc`: an EXACT marker match first (block-head
     /// precedence), else a PREDECESSOR scan of the op-start table (markers
     /// excluded). Equals
-    /// `liveness_for(code).depth_at_py_pc()[skip_python_trivia_forward(python_pc_for_jitcode_pc(jit_pc))]`
+    /// `liveness_for(code).depth_at_py_pc()[skip_python_trivia_forward(containing_py_pc_for_jitcode_pc(jit_pc))]`
     /// by construction for ANY jitcode coordinate — including an interior
     /// not-taken offset the branch-resume readers query (which a single merged
     /// predecessor table mis-resolves onto an interior marker) and a
@@ -730,9 +730,9 @@ impl PyJitCode {
     }
 
     /// Trivia-aware result color keyed by a JitCode byte offset,
-    /// resolved with the SAME two tiers as `python_pc_for_jitcode_pc`.
+    /// resolved with the SAME two tiers as `containing_py_pc_for_jitcode_pc`.
     /// Equals
-    /// `result_color_at_pc[skip_python_trivia_forward(python_pc_for_jitcode_pc(jit_pc))]`
+    /// `result_color_at_pc[skip_python_trivia_forward(containing_py_pc_for_jitcode_pc(jit_pc))]`
     /// by construction, including a trailing-trivia overshoot as `None`.
     /// `None` when the twin is empty (skeleton / fixture) — distinguish that
     /// from an in-table `None` via [`Self::result_color_trivia_populated`].
@@ -750,7 +750,7 @@ impl PyJitCode {
     }
 
     /// Codewrite-time resume marker keyed by a JitCode byte
-    /// offset, resolved with the SAME two tiers as `python_pc_for_jitcode_pc`:
+    /// offset, resolved with the SAME two tiers as `containing_py_pc_for_jitcode_pc`:
     /// an EXACT marker match first (block-head precedence), else a PREDECESSOR
     /// scan of the op-start table (markers excluded).
     pub fn resume_marker_for_jitcode_pc(&self, jit_pc: usize) -> Option<usize> {
@@ -767,7 +767,7 @@ impl PyJitCode {
     }
 
     /// Forward Python PC paired with a carried resume JitCode PC. This is a
-    /// codewriter-built twin of `backxlat_py_pc`'s result, including its
+    /// codewriter-built twin of `trivia_normalized_py_pc_for_jitcode_pc`'s result, including its
     /// forward trivia normalization, not an encode-time inverse projection.
     pub fn forward_py_pc_for_jitcode_pc(&self, jit_pc: usize) -> Option<u32> {
         let marker = &self.metadata.forward_py_pc_marker_by_jit_pc;
@@ -792,7 +792,7 @@ impl PyJitCode {
 
     /// Codewrite-time after-residual fallthrough marker
     /// keyed by a JitCode byte offset, resolved with the SAME two tiers as
-    /// `python_pc_for_jitcode_pc`: an EXACT marker match first (block-head
+    /// `containing_py_pc_for_jitcode_pc`: an EXACT marker match first (block-head
     /// precedence), else a PREDECESSOR scan of the op-start table (markers
     /// excluded).
     pub fn after_residual_marker_for_jitcode_pc(&self, jit_pc: usize) -> Option<usize> {
@@ -812,7 +812,7 @@ impl PyJitCode {
     /// fallthrough PC, keyed by a JitCode byte offset with the SAME exact-marker
     /// / predecessor-op-start tiers as `after_residual_marker_for_jitcode_pc`.
     /// Equals the legacy
-    /// `result_color_at_pc[semantic_fallthrough_pc(python_pc_for_jitcode_pc(jit_pc))]`
+    /// `result_color_at_pc[semantic_fallthrough_pc(containing_py_pc_for_jitcode_pc(jit_pc))]`
     /// for a call-op coordinate; `u16::MAX` where the return stack is empty;
     /// `None` when the twin is empty (skeleton / fixture) or the fallthrough is
     /// past the table end.
@@ -833,7 +833,7 @@ impl PyJitCode {
     /// PC, keyed by a JitCode byte offset with the SAME exact-marker /
     /// predecessor-op-start tiers as `after_residual_marker_for_jitcode_pc`.
     /// Equals the raw
-    /// `liveness_for(code).depth_at_py_pc().get(semantic_fallthrough_pc(python_pc_for_jitcode_pc(jit_pc))).copied()`
+    /// `liveness_for(code).depth_at_py_pc().get(semantic_fallthrough_pc(containing_py_pc_for_jitcode_pc(jit_pc))).copied()`
     /// by construction for a call-op coordinate, including a fallthrough overshoot
     /// as an in-table `None`. `None` also when the twin is empty (skeleton /
     /// fixture) — distinguish via [`Self::depth_after_residual_populated`].
@@ -863,7 +863,7 @@ impl PyJitCode {
 
     /// After-residual-call resume python pc for the inline-caller frame,
     /// resolved by JitCode byte offset with the same exact-marker /
-    /// predecessor-op-start tiers as `python_pc_for_jitcode_pc`. `None` when the
+    /// predecessor-op-start tiers as `containing_py_pc_for_jitcode_pc`. `None` when the
     /// twin is empty (skeleton / fixture) — distinguish via
     /// [`Self::after_residual_fallthrough_py_pc_populated`].
     pub fn after_residual_fallthrough_py_pc_for_jitcode_pc(&self, jit_pc: usize) -> Option<u32> {
@@ -898,7 +898,7 @@ impl PyJitCode {
 
     /// Post-`residual_call` catch resume marker keyed by a JitCode byte
     /// offset, resolved with the SAME exact-marker / predecessor-op-start
-    /// tiers as `python_pc_for_jitcode_pc`.
+    /// tiers as `containing_py_pc_for_jitcode_pc`.
     pub fn after_residual_call_resume_for_jitcode_pc(&self, jit_pc: usize) -> Option<usize> {
         let marker = &self.metadata.after_residual_call_resume_marker_by_jit_pc;
         let pred = &self.metadata.after_residual_call_resume_pred_by_jit_pc;

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -920,15 +920,6 @@ pub fn pyjitcode_for_jitcode_index(jitcode_index: i32) -> Option<std::sync::Arc<
     })
 }
 
-/// Resolve a stored JitCode offset back to its Python instruction coordinate.
-pub fn python_pc_for_jitcode_pc_public(jitcode_index: i32, offset: i32) -> Option<i32> {
-    let payload = pyjitcode_for_jitcode_index(jitcode_index)?;
-    Some(
-        crate::jitcode_dispatch::python_pc_for_jitcode_pc(&payload.metadata, offset as usize)
-            as i32,
-    )
-}
-
 /// `majit_metainterp::blackhole::LiveMarkerHook` implementation: stamp the
 /// instruction the blackhole is about to replay into the frame's `last_instr`.
 ///
@@ -1002,7 +993,7 @@ pub fn publish_last_instr_at_live_marker(
         if raw_code as *const CodeObject != jitcode.payload.code_ptr {
             return;
         }
-        let py_pc = crate::jitcode_dispatch::python_pc_for_jitcode_pc(metadata, marker_pc);
+        let py_pc = crate::py_coord::containing_py_pc_for_jitcode_pc(metadata, marker_pc);
         // SAFETY: same frame, and `last_instr` carries the same compile-time
         // offset assertion.
         unsafe {
@@ -1019,87 +1010,15 @@ pub fn jitcode_pc_is_bare_reraise(jitcode_index: i32, offset: i32) -> bool {
     let Some(raw_code) = raw_code_for_jitcode_index(jitcode_index) else {
         return false;
     };
-    let Some(py_pc) = python_pc_for_jitcode_pc_public(jitcode_index, offset) else {
+    let Some(py_pc) =
+        crate::py_coord::containing_py_pc_for_jitcode_pc_public(jitcode_index, offset)
+    else {
         return false;
     };
     match unsafe { pyre_interpreter::decode_instruction_at(&*raw_code, py_pc as usize) } {
         Some((Instruction::RaiseVarargs { .. }, op_arg)) => u32::from(op_arg) == 0,
         Some((Instruction::Reraise { .. }, _)) => true,
         _ => false,
-    }
-}
-
-/// Advance a Python instruction coordinate past resume trivia when code is available.
-pub fn skip_python_trivia_forward_public(
-    jitcode_index: i32,
-    raw_py_pc: i32,
-) -> Option<(i32, bool)> {
-    let payload = pyjitcode_for_jitcode_index(jitcode_index)?;
-    if payload.code_ptr.is_null() {
-        return Some((raw_py_pc, false));
-    }
-    let code = unsafe { &*payload.code_ptr };
-    Some((
-        crate::jitcode_dispatch::skip_python_trivia_forward(code, raw_py_pc as usize) as i32,
-        true,
-    ))
-}
-
-/// Translate a resume-frame pc word to a Python instruction coordinate.
-///
-/// A negative word (sentinel / branch-orgpc tag) has no Python coordinate; it
-/// passes through so the caller's `pc < 0` screen rejects it (the internal
-/// metadata lookups below are bounds-checked and never index with the word, so
-/// no wrap results).
-pub fn backxlat_py_pc(jitcode_index: i32, pc_word: i32) -> i32 {
-    let fallback = pc_word;
-    match python_pc_for_jitcode_pc_public(jitcode_index, pc_word)
-        .and_then(|raw_py_pc| skip_python_trivia_forward_public(jitcode_index, raw_py_pc))
-        .map(|(py_pc, _)| py_pc)
-    {
-        Some(py_pc) => py_pc,
-        None => fallback,
-    }
-}
-
-/// `PYRE_M73_BACKXLAT_TWIN_AUDIT` asserts the codewriter-built forward py_pc
-/// twin equals the [`backxlat_py_pc`] inversion at every non-negative resume
-/// word before [`forward_py_pc_or_backxlat`] trusts the twin. Off in
-/// production; the gated assert is the only added work.
-fn m73_backxlat_twin_audit_enabled() -> bool {
-    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *ENABLED.get_or_init(|| std::env::var_os("PYRE_M73_BACKXLAT_TWIN_AUDIT").is_some())
-}
-
-/// Forward Python instruction coordinate for a carried resume JitCode word.
-///
-/// Reads the codewriter-built `forward_py_pc` twin — a by-construction mirror
-/// of [`backxlat_py_pc`]'s block-head/floor resolution plus its
-/// `skip_python_trivia_forward` normalization — keeping the inversion only for
-/// the empty-twin class (skeleton / fixture jitcodes) and for negative words.
-///
-/// Negative words (`NO_JITCODE_PC` `-1`, tagged branch-orgpc words `<= -2`)
-/// cast to a huge `usize` twin key and would floor-resolve to a bogus
-/// predecessor entry, so they are delegated straight to `backxlat_py_pc`, which
-/// resolves them identically to the pre-cutover call.
-pub fn forward_py_pc_or_backxlat(jitcode_index: i32, pc_word: i32) -> i32 {
-    if pc_word < 0 {
-        return backxlat_py_pc(jitcode_index, pc_word);
-    }
-    match pyjitcode_for_jitcode_index(jitcode_index)
-        .and_then(|pjc| pjc.forward_py_pc_for_jitcode_pc(pc_word as usize))
-    {
-        Some(twin) => {
-            if m73_backxlat_twin_audit_enabled() {
-                assert_eq!(
-                    twin as i32,
-                    backxlat_py_pc(jitcode_index, pc_word),
-                    "PYRE_M73_BACKXLAT_TWIN_AUDIT: forward py_pc twin diverged at jitcode {jitcode_index} pc {pc_word}"
-                );
-            }
-            twin as i32
-        }
-        None => backxlat_py_pc(jitcode_index, pc_word),
     }
 }
 
@@ -1877,7 +1796,7 @@ pub(crate) fn bridge_semantic_maps_at_with_jitcode_pc(
             // non-decodable path uses below), keeping liveness and pcdep on one
             // coordinate. A portal bridge is uncolored, so `via_py_pc` returns
             // `(0, empty)` for any resolved py; the merge-target fallback is
-            // identical to the retired `python_pc_for_jitcode_pc` re-inversion.
+            // identical to the containing JitCode-PC coordinate lookup.
             match (
                 payload.depth_for_jitcode_pc_pred(jp),
                 payload.pcdep_for_jitcode_pc(jp),
@@ -7290,7 +7209,8 @@ fn reconstruct_inline_recipe(
     if frame.pc < 0 {
         decline!("NoSnapshotPc");
     }
-    let py_pc = forward_py_pc_or_backxlat(frame.jitcode_index, frame.pc) as usize;
+    let py_pc =
+        crate::py_coord::resume_py_pc_for_jitcode_word(frame.jitcode_index, frame.pc) as usize;
     let Some(w_code) = code_for_jitcode_index(frame.jitcode_index) else {
         decline!("NoCodeForJitcodeIndex");
     };

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -527,14 +527,11 @@ fn resolve_entry_carrier_call_py_pc(
     call_jitcode_pc: usize,
 ) -> Option<usize> {
     let outer = crate::state::pyjitcode_for_jitcode_index(outer_jitcode_index as i32);
-    let outer = outer.filter(|payload| !payload.code_ptr.is_null())?;
-    let call_py_pc =
-        crate::jitcode_dispatch::python_pc_for_jitcode_pc(&outer.metadata, call_jitcode_pc)
-            as usize;
-    Some(crate::jitcode_dispatch::skip_python_trivia_forward(
-        unsafe { &*outer.code_ptr },
-        call_py_pc,
-    ))
+    outer.filter(|payload| !payload.code_ptr.is_null())?;
+    Some(crate::state::forward_py_pc_or_backxlat(
+        outer_jitcode_index as i32,
+        call_jitcode_pc as i32,
+    ) as usize)
 }
 
 #[derive(Clone, Copy)]
@@ -560,13 +557,10 @@ fn resolve_midbody_flush_words(
     let callee = crate::state::pyjitcode_for_jitcode_index(payload.callee_jitcode_index as i32);
     let outer = outer.filter(|payload| !payload.code_ptr.is_null())?;
     let callee = callee.filter(|payload| !payload.code_ptr.is_null())?;
-    let call_py_pc =
-        crate::jitcode_dispatch::python_pc_for_jitcode_pc(&outer.metadata, payload.call_jitcode_pc)
-            as usize;
-    let call_py_pc = crate::jitcode_dispatch::skip_python_trivia_forward(
-        unsafe { &*outer.code_ptr },
-        call_py_pc,
-    );
+    let call_py_pc = crate::state::forward_py_pc_or_backxlat(
+        payload.outer_jitcode_index as i32,
+        payload.call_jitcode_pc as i32,
+    ) as usize;
     // #73 walker-as-tracer P1: the callee resume py is read from the scalar
     // forward-carried on the MidBodyPayload (`callee_py_pc`, stamped at capture
     // from the same jitcode->py inversion this once performed). The `callee`
@@ -1965,7 +1959,8 @@ fn drive_bridge_carrier_walk<Sym: WalkSym>(
                 "P2Drain::CompileRootRaiseEscape"
             });
             let root_py_pc =
-                crate::state::backxlat_py_pc(carrier.root_jitcode_index, root_pc as i32) as usize;
+                crate::state::forward_py_pc_or_backxlat(carrier.root_jitcode_index, root_pc as i32)
+                    as usize;
             let action =
                 full_body_walk_trace(ctx, sym, w_code, root_py_pc, cf_addr, WalkJournals::Keep);
             // Defensive: `dispatch_via_miframe` consumes the seed, but a

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -528,7 +528,7 @@ fn resolve_entry_carrier_call_py_pc(
 ) -> Option<usize> {
     let outer = crate::state::pyjitcode_for_jitcode_index(outer_jitcode_index as i32);
     outer.filter(|payload| !payload.code_ptr.is_null())?;
-    Some(crate::state::forward_py_pc_or_backxlat(
+    Some(crate::py_coord::resume_py_pc_for_jitcode_word(
         outer_jitcode_index as i32,
         call_jitcode_pc as i32,
     ) as usize)
@@ -557,7 +557,7 @@ fn resolve_midbody_flush_words(
     let callee = crate::state::pyjitcode_for_jitcode_index(payload.callee_jitcode_index as i32);
     let outer = outer.filter(|payload| !payload.code_ptr.is_null())?;
     let callee = callee.filter(|payload| !payload.code_ptr.is_null())?;
-    let call_py_pc = crate::state::forward_py_pc_or_backxlat(
+    let call_py_pc = crate::py_coord::resume_py_pc_for_jitcode_word(
         payload.outer_jitcode_index as i32,
         payload.call_jitcode_pc as i32,
     ) as usize;
@@ -572,7 +572,7 @@ fn resolve_midbody_flush_words(
     if midbody_carry_audit_enabled() {
         use std::sync::atomic::{AtomicU64, Ordering};
         static HITS: AtomicU64 = AtomicU64::new(0);
-        let callee_py_pc_convert = crate::jitcode_dispatch::python_pc_for_jitcode_pc(
+        let callee_py_pc_convert = crate::py_coord::containing_py_pc_for_jitcode_pc(
             &callee.metadata,
             payload.abort_jitcode_pc,
         ) as usize;
@@ -1104,7 +1104,8 @@ pub fn trace_bytecode<Sym: WalkSym>(
         start_pc
     };
     let lasti_pc = if let Some(ref c) = carrier {
-        crate::state::forward_py_pc_or_backxlat(c.root_jitcode_index, c.root_pc as i32) as usize
+        crate::py_coord::resume_py_pc_for_jitcode_word(c.root_jitcode_index, c.root_pc as i32)
+            as usize
     } else {
         start_pc
     };
@@ -1717,7 +1718,8 @@ fn drive_bridge_carrier_walk<Sym: WalkSym>(
             .recipes
             .iter()
             .map(|r| {
-                crate::state::forward_py_pc_or_backxlat(r.jitcode_index, r.jitcode_pc) as usize
+                crate::py_coord::resume_py_pc_for_jitcode_word(r.jitcode_index, r.jitcode_pc)
+                    as usize
             })
             .collect();
         eprintln!(
@@ -1859,7 +1861,7 @@ fn drive_bridge_carrier_walk<Sym: WalkSym>(
         if want_compile && middles_ok {
             if inject_root_call_result(sym, root_pc, result) {
                 crate::jitcode_dispatch::census_record("P2Drain::CompileRoot");
-                let root_py_pc = crate::state::forward_py_pc_or_backxlat(
+                let root_py_pc = crate::py_coord::resume_py_pc_for_jitcode_word(
                     carrier.root_jitcode_index,
                     root_pc as i32,
                 ) as usize;
@@ -1958,9 +1960,10 @@ fn drive_bridge_carrier_walk<Sym: WalkSym>(
             } else {
                 "P2Drain::CompileRootRaiseEscape"
             });
-            let root_py_pc =
-                crate::state::forward_py_pc_or_backxlat(carrier.root_jitcode_index, root_pc as i32)
-                    as usize;
+            let root_py_pc = crate::py_coord::resume_py_pc_for_jitcode_word(
+                carrier.root_jitcode_index,
+                root_pc as i32,
+            ) as usize;
             let action =
                 full_body_walk_trace(ctx, sym, w_code, root_py_pc, cf_addr, WalkJournals::Keep);
             // Defensive: `dispatch_via_miframe` consumes the seed, but a
@@ -1978,7 +1981,7 @@ fn drive_bridge_carrier_walk<Sym: WalkSym>(
             if p2_diag {
                 eprintln!(
                     "[p2-drain] callee sub-walk OK recipe_py_pc={} entry={entry} end_pc={end_pc} outcome={outcome:?}",
-                    crate::state::forward_py_pc_or_backxlat(
+                    crate::py_coord::resume_py_pc_for_jitcode_word(
                         recipe.jitcode_index,
                         recipe.jitcode_pc
                     )
@@ -2017,7 +2020,7 @@ fn drive_bridge_carrier_walk<Sym: WalkSym>(
                     "[p2-drain] callee sub-walk STOP callee={callee_name} \
                      source={source_path} recipe_py_pc={} entry={entry} \
                      stop_op={stop_op} err={e:?}",
-                    crate::state::forward_py_pc_or_backxlat(
+                    crate::py_coord::resume_py_pc_for_jitcode_word(
                         recipe.jitcode_index,
                         recipe.jitcode_pc
                     )
@@ -3161,7 +3164,9 @@ fn publish_terminal_raise_coordinate(
     let Ok(position) = i32::try_from(last_opcode_position) else {
         return;
     };
-    let Some(py_pc) = crate::state::python_pc_for_jitcode_pc_public(jitcode_index, position) else {
+    let Some(py_pc) =
+        crate::py_coord::containing_py_pc_for_jitcode_pc_public(jitcode_index, position)
+    else {
         return;
     };
     for &addr in frames {
@@ -3239,7 +3244,7 @@ fn run_perfn_walk<Sym: WalkSym>(
         // else is a body that does not encode `start_pc`, which is exactly the
         // decline below.
         sidecar_entry.filter(|&off| {
-            crate::jitcode_dispatch::python_pc_for_jitcode_pc(&pjc.metadata, off) as usize
+            crate::py_coord::containing_py_pc_for_jitcode_pc(&pjc.metadata, off) as usize
                 >= start_pc
         })
     } else {
@@ -3287,7 +3292,7 @@ fn run_perfn_walk<Sym: WalkSym>(
         if live_stack != entry_depth as usize && entry_is_resume_marker {
             if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
                 let marker_py =
-                    crate::jitcode_dispatch::python_pc_for_jitcode_pc(&pjc.metadata, entry);
+                    crate::py_coord::containing_py_pc_for_jitcode_pc(&pjc.metadata, entry);
                 eprintln!(
                     "[fbw-abort] start_pc={start_pc} entry={entry} live_stack={live_stack} \\
                      entry_depth={entry_depth} marker_py={marker_py}; declining marker-entry walk"
@@ -3805,7 +3810,7 @@ fn run_perfn_walk<Sym: WalkSym>(
                 _end_pc,
             )) => Some(loop_header_marker_jit_pc.map_or(*loop_header_pc, |marker| {
                 let marker_py =
-                    crate::jitcode_dispatch::python_pc_for_jitcode_pc(&pjc.metadata, marker)
+                    crate::py_coord::containing_py_pc_for_jitcode_pc(&pjc.metadata, marker)
                         as usize;
                 if marker_py == *loop_header_pc
                     && pjc.merge_entry_for(*loop_header_pc) != Some(marker)
@@ -4275,7 +4280,7 @@ fn run_perfn_walk<Sym: WalkSym>(
                         );
                     }
                 } else if let Some(pjc) = pjc {
-                    let resume_py_pc = crate::jitcode_dispatch::python_pc_for_jitcode_pc(
+                    let resume_py_pc = crate::py_coord::containing_py_pc_for_jitcode_pc(
                         &pjc.metadata,
                         call_jitcode_pc,
                     ) as usize;

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -641,7 +641,7 @@ pub(crate) fn drain_backend_jit_exc() {
 
 /// #73 measurement gate. When `PYRE_M73_LASTINSTR_AUDIT` is set, the three
 /// blackhole traceback sites compare the production inversion
-/// `python_pc_for_jitcode_pc_public(last_opcode_position)` (= `orgpc`, the
+/// `containing_py_pc_for_jitcode_pc_public(last_opcode_position)` (= `orgpc`, the
 /// raising op's python pc) against the forward candidate `frame.last_instr + 1`
 /// (the JIT-vable resume convention normalized to `orgpc`). Divergence means the
 /// forward datum is stale/off-by-one and cannot yet replace the inversion; a
@@ -666,7 +666,7 @@ fn m73_lastinstr_audit(
     static DIVERGE: AtomicU64 = AtomicU64::new(0);
     static NONE: AtomicU64 = AtomicU64::new(0);
     let inv = jitcode_index.and_then(|index| {
-        pyre_jit_trace::state::python_pc_for_jitcode_pc_public(index, opcode_position)
+        pyre_jit_trace::py_coord::containing_py_pc_for_jitcode_pc_public(index, opcode_position)
     });
     let fwd = unsafe { (*frame_ptr).last_instr as i64 } + 1;
     let hits = HITS.fetch_add(1, Ordering::Relaxed) + 1;
@@ -712,9 +712,11 @@ pub(crate) extern "C" fn record_caught_blackhole_traceback(
     if frame_ptr.is_null() || exc_value == 0 {
         return;
     }
-    let last_instruction =
-        pyre_jit_trace::state::python_pc_for_jitcode_pc_public(jitcode_index, opcode_position)
-            .map_or(unsafe { (*frame_ptr).last_instr as i64 }, i64::from);
+    let last_instruction = pyre_jit_trace::py_coord::containing_py_pc_for_jitcode_pc_public(
+        jitcode_index,
+        opcode_position,
+    )
+    .map_or(unsafe { (*frame_ptr).last_instr as i64 }, i64::from);
     // One catch can be reached by two recorders: this hook, emitted into the
     // loop trace by the in-trace handler-entry arm, and the IR-virtual node the
     // bridge handler-entry arm builds when the exception edge deopts into a
@@ -770,10 +772,11 @@ pub(crate) extern "C" fn record_inline_traceback_for_recording(
     if exc_value == 0 || w_code_value == 0 {
         return;
     }
-    let Some(last_instruction) =
-        pyre_jit_trace::state::python_pc_for_jitcode_pc_public(jitcode_index, opcode_position)
-            .map(i64::from)
-    else {
+    let Some(last_instruction) = pyre_jit_trace::py_coord::containing_py_pc_for_jitcode_pc_public(
+        jitcode_index,
+        opcode_position,
+    )
+    .map(i64::from) else {
         return;
     };
     let w_exc = exc_value as PyObjectRef;
@@ -2464,7 +2467,7 @@ pub fn blackhole_resume_via_rd_numb(
                 let qualname = raw_code
                     .map(|raw| unsafe { &*raw }.qualname.as_str())
                     .unwrap_or("<null>");
-                let py_pc = pyre_jit_trace::state::python_pc_for_jitcode_pc_public(
+                let py_pc = pyre_jit_trace::py_coord::containing_py_pc_for_jitcode_pc_public(
                     frame.jitcode.index() as i32,
                     frame.position as i32,
                 );
@@ -2583,7 +2586,7 @@ pub fn blackhole_resume_via_rd_numb(
                     if !frame_ptr.is_null() {
                         let last_instruction = jitcode_index
                             .and_then(|index| {
-                                pyre_jit_trace::state::python_pc_for_jitcode_pc_public(
+                                pyre_jit_trace::py_coord::containing_py_pc_for_jitcode_pc_public(
                                     index,
                                     last_opcode_position as i32,
                                 )

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -14377,14 +14377,14 @@ impl CodeWriter {
 
         // Predecessor-keyed jitcode-pc twins of
         // `pcdep_color_slots` and `depth_at_pc`, resolving a JitCode byte
-        // offset the way `python_pc_for_jitcode_pc` does — the block-head marker
+        // offset the way `containing_py_pc_for_jitcode_pc` does — the block-head marker
         // match first, else the largest `first_jit_pc_by_py_pc[py]` at-or-before
         // the offset (predecessor op containment).  Both tiers are baked into
         // ONE table: seed every op-start offset with its own py's value, then
         // OVERRIDE each block-head marker offset with the block-head py's value
-        // (marker precedence, `python_pc_for_jitcode_pc` :9009-9024).  A
+        // (marker precedence, `containing_py_pc_for_jitcode_pc` :9009-9024).  A
         // predecessor binary search (largest offset <= jit_pc) then reproduces
-        // `table[python_pc_for_jitcode_pc(jit_pc)]` for the carried resume
+        // `table[containing_py_pc_for_jitcode_pc(jit_pc)]` for the carried resume
         // coordinates that reach the decode re-inversion at `state.rs`
         // (`bridge_semantic_maps_at_with_jitcode_pc`), which are the guard's own
         // op offset or a block-head marker — never a mid-op byte.  Both sides
@@ -14408,14 +14408,14 @@ impl CodeWriter {
         // static depth.  A predecessor lookup then equals
         // `liveness_for(code).depth_at_py_pc()[skip_python_trivia_forward(inv(jit_pc))]`.
         // The trivia twin is split into the SAME two tiers as
-        // `python_pc_for_jitcode_pc` — a marker table matched EXACTLY (the block
+        // `containing_py_pc_for_jitcode_pc` — a marker table matched EXACTLY (the block
         // -head precedence tier, `block_head_py_by_jit_pc`'s depth analog) and an
         // op-start table matched by PREDECESSOR (`first_jit_pc_by_py_pc`'s depth
         // analog).  A single merged predecessor table is WRONG for an interior
         // query: a marker byte sits inside a preceding op's emitted region, so a
         // predecessor search for a coordinate past the op-start but before the
         // next op would land on that interior marker instead of the op-start.
-        // `python_pc_for_jitcode_pc` never returns a marker py for a non-exact
+        // `containing_py_pc_for_jitcode_pc` never returns a marker py for a non-exact
         // coordinate, so the marker tier must stay OUT of the predecessor scan.
         // The decode/bridge readers only ever query exact coordinates (guard op
         // offset or exact marker), which is why the phase-1 merged twins pass;
@@ -14480,7 +14480,7 @@ impl CodeWriter {
             }
             // Marker tier: exact-match, block-head precedence. Source the
             // corrected block-entry PC from the inversion table so the direct
-            // depth twin and `python_pc_for_jitcode_pc` cannot diverge.
+            // depth twin and `containing_py_pc_for_jitcode_pc` cannot diverge.
             for &(off, py) in &block_head_py_by_jit_pc {
                 let skipped_py =
                     pyre_jit_trace::jitcode_dispatch::skip_python_trivia_forward(code, py as usize);
@@ -14579,7 +14579,7 @@ impl CodeWriter {
                 after_residual_marker_marker_by_jit_pc.push((off, value));
                 // The retired runtime read took the fallthrough of the RAW
                 // block-head py (no trivia skip); match it exactly so the twin
-                // reproduces `result_color_at_pc[fallthrough(python_pc_for_jitcode_pc(off))]`.
+                // reproduces `result_color_at_pc[fallthrough(containing_py_pc_for_jitcode_pc(off))]`.
                 let ft_rc = pyre_jit_trace::pyjitpl::semantic_fallthrough_pc(code, py as usize);
                 result_color_after_residual_marker_by_jit_pc
                     .push((off, result_color_at_pc.get(ft_rc).copied()));

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -14236,6 +14236,13 @@ impl CodeWriter {
         // and is stored here.  Sorted by py_pc for binary search; sparse (the
         // trivia-forward-carry majority derives, so only the jump-target /
         // re-key residual remains).
+        //
+        // ⚠ Keeping only the trace-entry greens is NOT sound, however small the
+        // rest looks: `resolve_marker` below is also called on `skipped_py` and
+        // fallthrough coordinates, which are exactly the trivia / jump PCs this
+        // residual is made of.  Restricting the table to greens leaves every
+        // green resolving identically and still costs fannkuch ~1000x (0.6s →
+        // >10min) — measured, not hypothesised.
         let carryfwd_resume_pc: Vec<(u32, usize)> = pc_map_bytes
             .iter()
             .enumerate()
@@ -14248,6 +14255,54 @@ impl CodeWriter {
             })
             .map(|(py, &dense)| (py as u32, dense))
             .collect();
+
+        // `PYRE_PCMAP_RESIDUAL_CENSUS=1`: name every py_pc the derivation cannot
+        // reproduce, so the classes standing between `derive_resume_marker` and
+        // the dense map's retirement can be counted instead of guessed.  A
+        // derivation that covered them all would leave `pc_map_bytes` with a
+        // single consumer (`block_head_py_by_jit_pc`).  Build-time only; off by
+        // default.
+        //
+        // Synth corpus at the time of writing: 815 jitcodes / 68,322 py PCs /
+        // 1,410 residual (2.1%).  Every residual PC emitted no op of its own —
+        // the "own first op" tier reproduces the dense marker exactly, corpus
+        // wide.  By opcode: Cache 729, EndFor 266, ToBool 176, JumpForward 146,
+        // JumpBackwardNoInterrupt 74, rest <15.
+        if std::env::var_os("PYRE_PCMAP_RESIDUAL_CENSUS").is_some() {
+            eprintln!(
+                "[pcmap-residual-sum] code={} n_py={} residual={}",
+                code.obj_name,
+                pc_map_bytes.len(),
+                carryfwd_resume_pc.len()
+            );
+            let mut scan_state = OpArgState::default();
+            let mut op_at: Vec<String> = Vec::with_capacity(code.instructions.len());
+            for i in 0..code.instructions.len() {
+                let (instr, _) = scan_state.get(code.instructions[i]);
+                op_at.push(format!("{instr:?}"));
+            }
+            for &(py, dense) in &carryfwd_resume_pc {
+                let py = py as usize;
+                let own = first_jit_pc_by_py_pc
+                    .get(py)
+                    .copied()
+                    .is_some_and(|v| v != usize::MAX);
+                let derived = pyre_jit_trace::pyjitcode::derive_resume_marker(
+                    &first_jit_pc_by_py_pc,
+                    &block_head_py_by_jit_pc,
+                    py,
+                );
+                eprintln!(
+                    "[pcmap-residual] code={} py={} op={} own={} derived={:?} dense={}",
+                    code.obj_name,
+                    py,
+                    op_at.get(py).map_or("?", String::as_str),
+                    own as u8,
+                    derived,
+                    dense
+                );
+            }
+        }
 
         // Per-trace-entry green → walk-entry sidecar. Resolve each entry
         // with the runtime translator's exact precedence while the codewriter


### PR DESCRIPTION
Closes the remaining #73 phase-2/3 work on the jitcode↔python coordinate split. Three commits:

1. **`jit: census the py_pc resume markers derive_resume_marker cannot reproduce`** — build-time `PYRE_PCMAP_RESIDUAL_CENSUS` census of the residual divergence classes (corpus: 1,410/68,322 py PCs, all in the no-own-op tier; the `own=1` tier reproduces the dense table exactly).

2. **`jit: cut six jitcode->py inversion consumers over to the forward py twins`** — flips the flippable consumers (capture seam, inline-caller fallthrough, call-site py in specialize/inline_call, trace entry-carrier/midbody, P2-drain) to the codewriter-built jitcode-pc-keyed twins, with the legacy path retained as audit oracle under `PYRE_M73_BACKXLAT_TWIN_AUDIT` / `PYRE_PCMAP_AFTERRESIDUAL_AUDIT`.

3. **`jit: fold the jitcode->py coordinate helpers into py_coord`** — the surviving walk-side "what python op am I at" reads (traceback nodes, bare-reraise, last_instr publish, foriter green key, inline-abort paths) are *not* a runtime inversion: `block_head_py_by_jit_pc` + `py_floor_by_jit_pc` are built forward in the codewriter at lowering, and the floor result equals what pyopcode.py:200's per-bytecode `last_instr` store (elided by vable optimization) would leave, memoized at build time. This commit folds the helpers into `pyre-jit-trace/src/py_coord.rs` with names matching that semantics (`containing_py_pc_for_jitcode_pc`, `trivia_normalized_py_pc_for_jitcode_pc`, `resume_py_pc_for_jitcode_word`), rewrites the "legacy inversion" comment framing, and adds a `PYRE_M73_EMPTYTWIN_CENSUS` gate reporting empty-twin fallback trips at the 5 twin-first seams.

### Verification
- check.py dynasm **371/371**. cranelift/wasm each show 1 failure (`exception_try_call_inlined_callee_raise` `loops_compiled 3 -> 2`) that reproduces on the clean committed tip too — the machine-keyed baseline red inherited from #1009's fresh baselines, not caused by this branch; not re-recorded.
- Full 371-fixture synth corpus + fannkuch with `PYRE_M73_BACKXLAT_TWIN_AUDIT` + `PYRE_PCMAP_AFTERRESIDUAL_AUDIT` + `PYRE_PCMAP_CONTAINING_AUDIT` + `PYRE_M73_EMPTYTWIN_CENSUS`: 0 audit divergences, 0 empty-twin fallback trips, fannkuch 0.69s (no compile-time regression).

Per-bytecode `last_instr` as a genuine red stays with the stale-inline-frame epic; codewriter emission is blocked by the 256-entry pool-const cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added centralized coordinate mapping for translating JIT execution positions to Python locations.
  * Improved resume and traceback location handling, including fallback behavior for missing or empty mappings.
  * Added optional diagnostics for auditing coordinate mappings and reporting residual entries.

* **Documentation**
  * Clarified coordinate terminology and mapping behavior throughout JIT tracing documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->