### PR TITLE
jit: type-id-less field-descr parents, the missing half of verify_types, a root-walk write-back test

### DIFF
--- a/majit/majit-backend/src/call_stub.rs
+++ b/majit/majit-backend/src/call_stub.rs
@@ -1156,6 +1156,42 @@ impl CallArgs {
     }
 }
 
+/// `descr.py:615` `assert self.result_type in return_type` — the half of
+/// `verify_types` that [`collect_call_args`] does not cover.
+///
+/// `accepted` is the caller's `return_type`, the literal each `bh_call_*`
+/// passes in `llmodel.py:816/822/828/835`: `"iS"` (`history.INT + 'S'`),
+/// `"r"`, `"fL"` (`history.FLOAT + 'L'`) and `"v"`.
+///
+/// This is not redundant with the argument-class check. Nothing on the call
+/// path reads `result_type` to pick a dispatcher: the blackhole reaches one of
+/// the four entry points because the codewriter emitted
+/// `residual_call_*_i/_r/_f/_v`, so the two records can disagree. They
+/// disagree silently — the dispatcher would read the callee's result out of
+/// the register file the *opcode* named while the callee returned it in the
+/// one `result_type` names, e.g. an f64 result taken from `rax`. Comparing
+/// them here is what makes that a failure rather than a garbage value.
+///
+/// `debug_assert` mirrors upstream's `if not we_are_translated():` guard at
+/// each call site — a translated JIT does not run this. `majit-backend` is not
+/// one of the LLBC-extracted crates, so a release build really does drop it.
+///
+/// The callers check this *after* their `func == 0` early return, where
+/// upstream verifies first. That guard has no upstream counterpart: it is
+/// pyre's "no callee is installed" sentinel, and it pairs with a descr that has
+/// no result type either — `jitdriver.rs` builds a `BhJitDriverSd` whose
+/// `portal_runner_ptr` is `None` and whose `mainjitcode_calldescr` falls back
+/// to `Default`, so `result_type` is `'\0'`. Verifying the return register of a
+/// call that is not made would report that pairing instead of an ABI
+/// disagreement.
+pub fn verify_result_type(result_type: char, accepted: &str) {
+    debug_assert!(
+        accepted.contains(result_type),
+        "BhCallDescr.verify_types: result_type {result_type:?} is not one of {accepted:?}; \
+         the emitted residual_call opcode and the calldescr disagree about the return register"
+    );
+}
+
 /// Build the C-ABI class sequence and positional argument list from
 /// `args_i` / `args_r` / `args_f`, following `calldescr.arg_classes` order.
 ///
@@ -1547,5 +1583,40 @@ mod tests {
                 &[1, 2, 3, 4, 5, 6.0_f64.to_bits() as i64],
             );
         }
+    }
+
+    /// The four `return_type` literals `llmodel.py:816/822/828/835` pass, each
+    /// against every result class `type_to_argclass` can produce. `'L'` and
+    /// `'S'` ride along with the float and int sets the way upstream spells
+    /// them (`history.FLOAT + 'L'`, `history.INT + 'S'`).
+    #[test]
+    fn verify_result_type_accepts_exactly_its_caller_s_return_classes() {
+        for (accepted, ok) in [("iS", "iS"), ("r", "r"), ("fL", "fL"), ("v", "v")] {
+            for c in ok.chars() {
+                verify_result_type(c, accepted);
+            }
+        }
+    }
+
+    /// The mis-route this exists to catch: a float-returning callee reached
+    /// through the integer entry point would take its result from `rax`.
+    ///
+    /// Only meaningful where the assertion is compiled in — `verify_result_type`
+    /// is a `debug_assert`, so a release test binary would not panic.
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic(expected = "is not one of \"iS\"")]
+    fn verify_result_type_rejects_a_float_result_on_the_int_entry_point() {
+        verify_result_type('f', "iS");
+    }
+
+    /// `BhCallDescr::default()` leaves `result_type` at `char::default()`.
+    /// `jitdriver.rs` reaches that through `unwrap_or_default()`, so the
+    /// sentinel has to be rejected rather than silently matching some class.
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic(expected = "is not one of \"r\"")]
+    fn verify_result_type_rejects_the_default_descr_s_null_result_type() {
+        verify_result_type('\0', "r");
     }
 }

--- a/majit/majit-backend/src/lib.rs
+++ b/majit/majit-backend/src/lib.rs
@@ -2701,6 +2701,8 @@ pub trait Backend: Send {
         if func == 0 {
             return 0;
         }
+        // llmodel.py:818 `calldescr.verify_types(..., history.INT + 'S')`.
+        crate::call_stub::verify_result_type(calldescr.result_type, "iS");
         // SAFETY: `func` is a valid funcptr matching the ABI recovered from
         // `calldescr.arg_classes`.
         unsafe {
@@ -2727,6 +2729,8 @@ pub trait Backend: Send {
         if func == 0 {
             return GcRef::NULL;
         }
+        // llmodel.py:824 `calldescr.verify_types(..., history.REF)`.
+        crate::call_stub::verify_result_type(calldescr.result_type, "r");
         // SAFETY: see `bh_call_i`.
         let raw = unsafe {
             crate::call_stub::bh_call_i_by_classes(
@@ -2753,6 +2757,8 @@ pub trait Backend: Send {
         if func == 0 {
             return 0.0;
         }
+        // llmodel.py:830 `calldescr.verify_types(..., history.FLOAT + 'L')`.
+        crate::call_stub::verify_result_type(calldescr.result_type, "fL");
         // SAFETY: see `bh_call_i`.
         unsafe {
             crate::call_stub::bh_call_f_by_classes(
@@ -2778,6 +2784,8 @@ pub trait Backend: Send {
         if func == 0 {
             return;
         }
+        // llmodel.py:837 `calldescr.verify_types(..., history.VOID)`.
+        crate::call_stub::verify_result_type(calldescr.result_type, "v");
         // SAFETY: see `bh_call_i`.
         unsafe {
             crate::call_stub::bh_call_v_by_classes(

--- a/majit/majit-ir/src/descr.rs
+++ b/majit/majit-ir/src/descr.rs
@@ -4995,11 +4995,43 @@ pub fn make_simple_descr_group(
     vtable: usize,
     field_specs: &[SimpleFieldDescrSpec],
 ) -> SimpleDescrGroup {
-    // No-cache legacy mint sites are JIT-allocated structs; default
-    // `is_gc_managed = true` (the raw-struct path goes through the keyed
-    // factory with an explicit flag).
-    let group =
-        make_simple_descr_group_inner(index, size, type_id, 0, vtable, true, false, field_specs);
+    // No-cache legacy mint sites are JIT-allocated structs, so they get the
+    // GC-managed, headered shape.  A caller that knows the STRUCT's actual
+    // shape passes it through `make_simple_descr_group_with_flags`.
+    make_simple_descr_group_with_flags(index, size, type_id, vtable, true, false, field_specs)
+}
+
+/// [`make_simple_descr_group`] with the GC-header shape supplied rather than
+/// defaulted.
+///
+/// `descr.py:105-127 get_size_descr` reads both flags off the STRUCT itself,
+/// so they describe the parent, not the cache slot — a caller that mints
+/// without a cache key still knows them and must not lose them.  Minting a raw
+/// or header-less parent as GC-managed and headered would hand the consumer a
+/// `GUARD_GC_TYPE` and a header offset the object does not have.
+///
+/// The mint stays uncached exactly as in [`make_simple_descr_group`]:
+/// `cache_key` is 0, so the keyed `_cache_*[key]` maps are untouched and
+/// repeated calls yield distinct groups.
+pub fn make_simple_descr_group_with_flags(
+    index: u32,
+    size: usize,
+    type_id: u32,
+    vtable: usize,
+    is_gc_managed: bool,
+    headerless: bool,
+    field_specs: &[SimpleFieldDescrSpec],
+) -> SimpleDescrGroup {
+    let group = make_simple_descr_group_inner(
+        index,
+        size,
+        type_id,
+        0,
+        vtable,
+        is_gc_managed,
+        headerless,
+        field_specs,
+    );
     // descr.py:236-247 `get_size_descr` cache-miss branch — snapshot
     // order only.
     crate::descr_registry::register_size(group.size_descr.clone() as DescrRef);

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -142,7 +142,72 @@ pub fn field_descr_ref_from_bh(descr: &crate::blackhole::BhDescr) -> (usize, maj
         } => {
             if let Some(p) = parent {
                 if !p.all_fielddescrs.is_empty() {
-                    let specs: Vec<_> = p.all_fielddescrs.iter().map(field_spec_from_bh).collect();
+                    let mut specs: Vec<_> =
+                        p.all_fielddescrs.iter().map(field_spec_from_bh).collect();
+                    if p.type_id == 0 {
+                        // Same no-identity sentinel the empty-list branch below
+                        // carves out, and the same one
+                        // `simple_descr_group_from_bh_size`
+                        // (`pyre-jit-trace/src/descr.rs`) carves out for this
+                        // exact input. Here it is the more damaging of the two:
+                        // the keyed publish would put a whole *field table*
+                        // under `LLType::Struct(0)`, and `get_field_descr` keys
+                        // `_cache_field[key]` by field name — so a second
+                        // type-id-less parent that shares a field name would
+                        // resolve to the first parent's descr, and one that does
+                        // not would still mint against the first parent's size
+                        // descr, since `_cache_size` already holds that slot.
+                        // Mint fresh per resolution instead: without an identity
+                        // carrier the orthodox reading is "each of these is a
+                        // distinct STRUCT".
+                        //
+                        // `is_gc_managed`/`headerless` are dropped the way the
+                        // trace-side twin drops them — the non-keyed factory
+                        // defaults to `(true, false)`, and the raw and
+                        // header-less producers all carry a real type id because
+                        // they publish through `register_struct_layout`.
+                        if crate::majit_log_enabled() {
+                            eprintln!(
+                                "[jit] field_descr_ref_from_bh: fresh-minting a \
+                                 type-id-less parent with {} field(s) for field={name:?}",
+                                specs.len()
+                            );
+                        }
+                        // A name miss means the getfield names an inline
+                        // aggregate the flattened list only covers through its
+                        // leaves (see the note in the empty-list branch). Carry
+                        // it as one more field of this fresh parent rather than
+                        // falling through to the parentless placeholder, so
+                        // `protect_speculative_field` still has a parent.
+                        let selected = specs
+                            .iter()
+                            .position(|spec| spec.field_key == *name || spec.name == *name)
+                            .unwrap_or_else(|| {
+                                specs.push(majit_ir::descr::SimpleFieldDescrSpec {
+                                    index: u32::MAX,
+                                    field_key: name.clone(),
+                                    name: name.clone(),
+                                    offset: *offset,
+                                    field_size: *field_size,
+                                    field_type: *field_type,
+                                    is_immutable: *is_immutable,
+                                    is_quasi_immutable: *is_quasi_immutable,
+                                    flag: *field_flag,
+                                    virtualizable: false,
+                                    index_in_parent: *index_in_parent,
+                                });
+                                specs.len() - 1
+                            });
+                        let group = majit_ir::descr::make_simple_descr_group(
+                            u32::MAX,
+                            p.size,
+                            0,
+                            p.vtable as usize,
+                            &specs,
+                        );
+                        let fd = group.field_descrs[selected].clone();
+                        return (*offset, fd as majit_ir::DescrRef);
+                    }
                     // descr.py:218-239 get_field_descr: populate the
                     // gccache (first-write-wins, idempotent across the
                     // matching `new`) then return the *cached*
@@ -9093,6 +9158,130 @@ mod tests {
 
     extern "C" fn scale_f64(x: f64, k: i64) -> f64 {
         x * k as f64
+    }
+
+    /// A `BhDescr::Field` naming `field` of a parent that carries a flattened
+    /// one-entry field list and the `type_id` given.
+    fn field_descr_with_parent(
+        field: &str,
+        type_id: u64,
+        size: usize,
+        vtable: u64,
+    ) -> crate::blackhole::BhDescr {
+        let spec = majit_translate::jitcode::BhFieldSpec {
+            index: 0,
+            field_key: field.to_string(),
+            name: field.to_string(),
+            offset: 0,
+            field_size: 8,
+            field_type: Type::Int,
+            field_flag: majit_ir::descr::ArrayFlag::Signed,
+            is_field_signed: true,
+            is_immutable: false,
+            is_quasi_immutable: false,
+            index_in_parent: 0,
+        };
+        crate::blackhole::BhDescr::Field {
+            offset: 0,
+            field_size: 8,
+            field_type: Type::Int,
+            field_flag: majit_ir::descr::ArrayFlag::Signed,
+            is_field_signed: true,
+            is_immutable: false,
+            is_quasi_immutable: false,
+            index_in_parent: 0,
+            parent: Some(majit_translate::jitcode::BhSizeSpec {
+                size,
+                type_id,
+                vtable,
+                is_gc_managed: true,
+                headerless: false,
+                all_fielddescrs: vec![spec],
+            }),
+            name: field.to_string(),
+            owner: String::new(),
+        }
+    }
+
+    fn parent_size_of(descr: &majit_ir::DescrRef) -> usize {
+        descr
+            .as_field_descr()
+            .expect("field descr")
+            .get_parent_descr()
+            .expect("field descr must carry a parent")
+            .as_size_descr()
+            .expect("parent is a size descr")
+            .size()
+    }
+
+    /// `type_id == 0` is the no-STRUCT-identity sentinel, so two parents
+    /// wearing it are two different STRUCTs. Publishing them under
+    /// `LLType::Struct(0)` would put both in one `_cache_size` slot and one
+    /// `_cache_field` name space, and the second resolution would then read
+    /// back the first parent's size descr.
+    ///
+    /// Sharing a field *name* is what makes this observable: it turns the
+    /// collapse into a `_cache_field` hit, so the second field would be the
+    /// first field's Arc outright.
+    #[test]
+    fn type_id_less_parents_do_not_share_one_size_descr() {
+        let first = field_descr_ref_from_bh(&field_descr_with_parent("x", 0, 16, 0xAA)).1;
+        let second = field_descr_ref_from_bh(&field_descr_with_parent("x", 0, 48, 0xBB)).1;
+
+        assert_eq!(parent_size_of(&first), 16);
+        assert_eq!(
+            parent_size_of(&second),
+            48,
+            "the second parent must not resolve to the first one's size descr"
+        );
+        assert!(
+            !std::sync::Arc::ptr_eq(&first, &second),
+            "two type-id-less parents must not share one field descr"
+        );
+    }
+
+    /// The empty-`all_fielddescrs` twin of the above. That branch derives the
+    /// parent from `size`/`vtable` alone (`descr.py:238 parent_descr =
+    /// get_size_descr(gccache, STRUCT, vtable)`), so under `Struct(0)` the
+    /// second resolution reads back the first one's published size slot.
+    #[test]
+    fn type_id_less_parents_without_a_field_list_do_not_share_one_size_descr() {
+        let strip_fields = |mut descr: crate::blackhole::BhDescr| {
+            if let crate::blackhole::BhDescr::Field {
+                parent: Some(p), ..
+            } = &mut descr
+            {
+                p.all_fielddescrs.clear();
+            }
+            descr
+        };
+        let first =
+            field_descr_ref_from_bh(&strip_fields(field_descr_with_parent("z", 0, 24, 0xAA))).1;
+        let second =
+            field_descr_ref_from_bh(&strip_fields(field_descr_with_parent("z", 0, 56, 0xBB))).1;
+
+        assert_eq!(parent_size_of(&first), 24);
+        assert_eq!(
+            parent_size_of(&second),
+            56,
+            "the second parent must not resolve to the first one's size descr"
+        );
+    }
+
+    /// The same two parents with real, distinct type ids stay on the keyed
+    /// path — the carve-out above must not disable caching for everyone.
+    #[test]
+    fn parents_with_real_type_ids_still_resolve_through_the_keyed_cache() {
+        let a = field_descr_ref_from_bh(&field_descr_with_parent("y", 0x51A1, 16, 0xAA)).1;
+        let again = field_descr_ref_from_bh(&field_descr_with_parent("y", 0x51A1, 16, 0xAA)).1;
+        let other = field_descr_ref_from_bh(&field_descr_with_parent("y", 0x51A2, 48, 0xBB)).1;
+
+        assert!(
+            std::sync::Arc::ptr_eq(&a, &again),
+            "one type id must resolve to one cached field descr"
+        );
+        assert!(!std::sync::Arc::ptr_eq(&a, &other));
+        assert_eq!(parent_size_of(&other), 48);
     }
 
     #[test]

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -161,11 +161,9 @@ pub fn field_descr_ref_from_bh(descr: &crate::blackhole::BhDescr) -> (usize, maj
                         // carrier the orthodox reading is "each of these is a
                         // distinct STRUCT".
                         //
-                        // `is_gc_managed`/`headerless` are dropped the way the
-                        // trace-side twin drops them — the non-keyed factory
-                        // defaults to `(true, false)`, and the raw and
-                        // header-less producers all carry a real type id because
-                        // they publish through `register_struct_layout`.
+                        // The missing key says nothing about the STRUCT's
+                        // shape, so `is_gc_managed`/`headerless` are carried
+                        // through exactly as the keyed arm carries them.
                         if crate::majit_log_enabled() {
                             eprintln!(
                                 "[jit] field_descr_ref_from_bh: fresh-minting a \
@@ -204,11 +202,13 @@ pub fn field_descr_ref_from_bh(descr: &crate::blackhole::BhDescr) -> (usize, maj
                                 });
                                 specs.len() - 1
                             });
-                        let group = majit_ir::descr::make_simple_descr_group(
+                        let group = majit_ir::descr::make_simple_descr_group_with_flags(
                             u32::MAX,
                             p.size,
                             0,
                             p.vtable as usize,
+                            p.is_gc_managed,
+                            p.headerless,
                             &specs,
                         );
                         let fd = group.field_descrs[selected].clone();
@@ -300,12 +300,14 @@ pub fn field_descr_ref_from_bh(descr: &crate::blackhole::BhDescr) -> (usize, maj
                         // (`pyre-jit-trace/src/descr.rs`) takes.  Its group's
                         // size descr is registered strongly by
                         // `descr_registry::register_size`, so the field's Weak
-                        // parent back-reference still upgrades, and the factory's
-                        // `is_gc_managed`/`headerless` defaults are the only
-                        // shape that reaches here: the raw and header-less
-                        // producers all publish through `register_struct_layout`
-                        // (`struct_fields_write_effect_info` below), which routes
-                        // to the keyed factory carrying a real type id.
+                        // parent back-reference still upgrades.  The missing key
+                        // says nothing about the STRUCT's shape, so
+                        // `is_gc_managed`/`headerless` are carried through
+                        // exactly as the keyed arm carries them:
+                        // `bh_size_spec_from_descr` (`majit-translate`) reads
+                        // both straight off a descr while taking `type_id` from
+                        // `cache_key()`, so a raw or header-less parent with no
+                        // key reaches here and must not regain a GC header.
                         if crate::majit_log_enabled() {
                             eprintln!(
                                 "[jit] field_descr_ref_from_bh: fresh-minting a \
@@ -326,11 +328,13 @@ pub fn field_descr_ref_from_bh(descr: &crate::blackhole::BhDescr) -> (usize, maj
                             virtualizable: false,
                             index_in_parent: *index_in_parent,
                         };
-                        let group = majit_ir::descr::make_simple_descr_group(
+                        let group = majit_ir::descr::make_simple_descr_group_with_flags(
                             u32::MAX,
                             p.size,
                             0,
                             p.vtable as usize,
+                            p.is_gc_managed,
+                            p.headerless,
                             std::slice::from_ref(&spec),
                         );
                         let fd = group.field_descrs[0].clone();
@@ -9317,6 +9321,50 @@ mod tests {
         );
         assert!(!std::sync::Arc::ptr_eq(&a, &other));
         assert_eq!(parent_size_of(&other), 48);
+    }
+
+    /// A missing cache key says nothing about the STRUCT's shape.
+    /// `bh_size_spec_from_descr` (`majit-translate`) reads
+    /// `is_gc_managed`/`headerless` straight off a descr while taking
+    /// `type_id` from `cache_key()`, so a raw, header-less parent arrives here
+    /// with no key — and minting it as GC-managed and headered would hand the
+    /// consumer a `GUARD_GC_TYPE` and a header offset the object does not have.
+    ///
+    /// Both zero arms are covered: with the flattened field list and without.
+    #[test]
+    fn a_type_id_less_parent_keeps_its_raw_header_less_shape() {
+        let make_raw = |field: &str, drop_fields: bool| {
+            let mut descr = field_descr_with_parent(field, 0, 16, 0xAA);
+            if let crate::blackhole::BhDescr::Field {
+                parent: Some(p), ..
+            } = &mut descr
+            {
+                p.is_gc_managed = false;
+                p.headerless = true;
+                if drop_fields {
+                    p.all_fielddescrs.clear();
+                }
+            }
+            descr
+        };
+
+        for (field, drop_fields) in [("raw_listed", false), ("raw_bare", true)] {
+            let fd = field_descr_ref_from_bh(&make_raw(field, drop_fields)).1;
+            let parent = fd
+                .as_field_descr()
+                .expect("field descr")
+                .get_parent_descr()
+                .expect("field descr must carry a parent");
+            let parent = parent.as_size_descr().expect("parent is a size descr");
+            assert!(
+                !parent.is_gc_managed(),
+                "{field}: a raw parent must not be reconstructed as GC-managed"
+            );
+            assert!(
+                parent.headerless(),
+                "{field}: a header-less parent must not regain a GC header"
+            );
+        }
     }
 
     #[test]

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -217,8 +217,67 @@ pub fn field_descr_ref_from_bh(descr: &crate::blackhole::BhDescr) -> (usize, maj
                     // (`llmodel.py:560`, which asserts the parent exists) has no
                     // type to validate against and fails closed, taking the
                     // whole bridge with it.
+                    if p.type_id == 0 {
+                        // Zero is the no-STRUCT-identity sentinel, not a type.
+                        // Publishing under `LLType::Struct(0)` would collapse
+                        // every type-id-less parent onto the first-inserted size
+                        // descr and field namespace, so the second one would
+                        // validate against the first one's size/vtable and could
+                        // attach this field to the wrong parent.  Mint fresh
+                        // instead — the same carve-out
+                        // `simple_descr_group_from_bh_size`
+                        // (`pyre-jit-trace/src/descr.rs`) takes.  Its group's
+                        // size descr is registered strongly by
+                        // `descr_registry::register_size`, so the field's Weak
+                        // parent back-reference still upgrades, and the factory's
+                        // `is_gc_managed`/`headerless` defaults are the only
+                        // shape that reaches here: the raw and header-less
+                        // producers all publish through `register_struct_layout`
+                        // (`struct_fields_write_effect_info` below), which routes
+                        // to the keyed factory carrying a real type id.
+                        if crate::majit_log_enabled() {
+                            eprintln!(
+                                "[jit] field_descr_ref_from_bh: fresh-minting a \
+                                 type-id-less parent for field={name:?} size={} vtable={:#x}",
+                                p.size, p.vtable
+                            );
+                        }
+                        let spec = majit_ir::descr::SimpleFieldDescrSpec {
+                            index: u32::MAX,
+                            field_key: name.clone(),
+                            name: name.clone(),
+                            offset: *offset,
+                            field_size: *field_size,
+                            field_type: *field_type,
+                            is_immutable: *is_immutable,
+                            is_quasi_immutable: *is_quasi_immutable,
+                            flag: *field_flag,
+                            virtualizable: false,
+                            index_in_parent: *index_in_parent,
+                        };
+                        let group = majit_ir::descr::make_simple_descr_group(
+                            u32::MAX,
+                            p.size,
+                            0,
+                            p.vtable as usize,
+                            std::slice::from_ref(&spec),
+                        );
+                        let fd = group.field_descrs[0].clone();
+                        return (*offset, fd as majit_ir::DescrRef);
+                    }
                     let struct_key = majit_ir::descr::LLType::Struct(p.type_id);
                     let mut gc = majit_ir::descr::gc_cache().lock().unwrap();
+                    // `immutable_flag` is `descr.py:112
+                    // heaptracker.is_immutable_struct(STRUCT)`, which reads the
+                    // STRUCT's `immutable` hint.  A serialized parent spec
+                    // carries no such hint — size, type id, vtable, GC-managed
+                    // and headerless are its whole payload — so `false` is not a
+                    // choice made over an available alternative but the absence
+                    // of the declaration channel, the same absence
+                    // `get_field_descr`'s cache-hit branch already resolves for
+                    // per-field immutability.  The sibling keyed mint just above
+                    // lands on the same `false` through
+                    // `SimpleSizeDescr::with_vtable`.
                     gc.get_size_descr(struct_key.clone(), p.size, p.vtable as usize, false);
                     let fd = gc.get_field_descr(
                         struct_key,

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -361,6 +361,35 @@ pub fn field_descr_ref_from_bh(descr: &crate::blackhole::BhDescr) -> (usize, maj
                     return (*offset, fd as majit_ir::DescrRef);
                 }
             }
+            // No owning STRUCT at all, so the descr gets no `parent_descr` —
+            // a state `descr.py:238` never produces, since `get_field_descr`
+            // always resolves one. It is not a lost parent: every descr that
+            // reaches here names a **raw, non-GC aggregate**, which upstream
+            // gives no FieldDescr in the first place. `jtransform.py:942
+            // rewrite_op_getsubstruct` accepts only `gckind == 'raw'` and
+            // lowers the access to `int_add(ptr, ofs)` with no descr; pyre
+            // still emits a `getfield_gc`, so the descr exists with nothing to
+            // own it. Porting that lowering is what removes this branch.
+            //
+            // Censused over the built descr table (`PYRE_FIELD_IDENTITY_CENSUS`,
+            // 2026-08-04): 65 of 1514 Field slots, in three families, all raw —
+            // `__pos_N` positional slots of closures / `Tuple<K,V>` /
+            // `core::alloc::layout::Layout` (the bulk), the four fields of
+            // `Arguments` (a plain Rust struct with no `#[jit_struct]`, so no
+            // GC header and no type id), and one owner-less `Adt_0`.
+            //
+            // They are built but cold: `MAJIT_LOG=1` counts zero resolutions
+            // through this branch across `fib_recursive`, `nbody` and
+            // `spectral_norm`. So the cost today is the descr table entries,
+            // not a declined speculation.
+            //
+            // The parent stays absent rather than being synthesised. Absent,
+            // `protect_speculative_field` (`llmodel.py:555-567`) returns the
+            // decline that its own `SpeculativeError` models — the speculation
+            // is dropped, which is correct for a pointer that carries no type
+            // id. A synthesised parent would instead hand its type-id compare a
+            // fabricated `sizedescr.type_id()`, turning a safe decline into an
+            // accept whenever that invented id happened to match.
             if crate::majit_log_enabled() {
                 eprintln!(
                     "[jit] field_descr_ref_from_bh: parentless placeholder for \

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -174,8 +174,14 @@ pub fn field_descr_ref_from_bh(descr: &crate::blackhole::BhDescr) -> (usize, maj
                             );
                         }
                         // A name miss means the getfield names an inline
-                        // aggregate the flattened list only covers through its
-                        // leaves (see the note in the empty-list branch). Carry
+                        // aggregate (`ob_header`, `int_items`, an enum's
+                        // `__pos_0`) that the flattened list only covers
+                        // through its leaves — the same miss the keyed path
+                        // below takes.  `heaptracker.py:68-69` recurses into a
+                        // nested `lltype.Struct` without minting a descr for
+                        // the container, and `jtransform.py:942
+                        // rewrite_op_getsubstruct` lowers a raw one to
+                        // `int_add(ptr, offset)` with no descr at all.  Carry
                         // it as one more field of this fresh parent rather than
                         // falling through to the parentless placeholder, so
                         // `protect_speculative_field` still has a parent.

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -4220,11 +4220,20 @@ fn simple_descr_group_from_bh_size(
         // type_id-less STRUCTs don't collapse onto the first-inserted
         // descr group.  Per-STRUCT caching kicks in only when callers
         // route through a real `type_id` source.
-        return majit_ir::descr::make_simple_descr_group(
+        //
+        // The missing key says nothing about the STRUCT's shape, so carry
+        // `is_gc_managed`/`headerless` here exactly as the keyed arm below
+        // does.  `bh_size_spec_from_descr` (`majit-translate`) reads both
+        // straight off a descr while taking `type_id` from `cache_key()`, so
+        // a raw or header-less parent with no key reaches this arm; the
+        // defaulting factory would give it back a GC header it does not have.
+        return majit_ir::descr::make_simple_descr_group_with_flags(
             u32::MAX,
             spec.size,
             spec.type_id as u32,
             spec.vtable as usize,
+            spec.is_gc_managed,
+            spec.headerless,
             &field_specs,
         );
     }

--- a/pyre/pyre-object/src/gc_roots.rs
+++ b/pyre/pyre-object/src/gc_roots.rs
@@ -963,4 +963,39 @@ mod tests {
         assert_eq!(shadow_stack_get(0) as usize, 0x11);
         assert_eq!(shadow_stack_get(1) as usize, 0x22);
     }
+
+    /// The read twin above only proves the walk *reads* from the relocated
+    /// buffer. A moving collector also *writes* the forwarded address back,
+    /// and that write happens after the visitor has had its chance to grow
+    /// the stack — so the store has to resolve the buffer address again
+    /// rather than reuse the one the slot was read from.
+    #[cfg(not(debug_assertions))]
+    #[test]
+    fn walk_shadow_stack_write_back_follows_a_grow_inside_the_visitor() {
+        let _roots = push_roots();
+        pin_root(dummy(0x11));
+        pin_root(dummy(0x22));
+
+        let additional = with_shadow_stack(|stack| stack.capacity() - stack.len() + 1);
+        let mut pushed = false;
+        walk_shadow_stack(|slot| {
+            if !pushed {
+                pushed = true;
+                for offset in 0..additional {
+                    pin_root(dummy(0x1000 + offset));
+                }
+            }
+            // Forward the root the way a moving collector would, *after* the
+            // buffer has already moved under this slot.
+            *slot = dummy(*slot as usize + 0xA0_0000);
+        });
+
+        assert!(pushed);
+        // Slot 0 is the discriminator: it was read from the old buffer, and
+        // the grow happened before the visitor forwarded it. The write is
+        // only observable here if it went to the buffer the stack owns now.
+        // Slot 1 was read after the grow, so it lands correctly either way.
+        assert_eq!(shadow_stack_get(0) as usize, 0xA0_0011);
+        assert_eq!(shadow_stack_get(1) as usize, 0xA0_0022);
+    }
 }


### PR DESCRIPTION
Five commits. Two are real bugs in `field_descr_ref_from_bh`, one ports a missing upstream assert, one adds a root-walk test, and the last replaces a guess in a comment with a measurement.

## 1. Every type-id-less parent shared one size descr and one field namespace

`field_descr_ref_from_bh` reconstructs a `FieldDescr` from a serialized blackhole descr by publishing its parent into the gccache under `LLType::Struct(p.type_id)`.

`type_id == 0` is not a type. It is the no-STRUCT-identity sentinel stamped by `bh_size_spec_from_callcontrol` when the analyzer-time callcontrol has no host-type carrier. Publishing under `Struct(0)` collapses **every** type-id-less parent onto whichever one was inserted first:

- `_cache_size` already holds that slot, so a second parent of a different size validates against the first one's size and vtable.
- `get_field_descr` keys `_cache_field` by **field name**, so a second parent sharing a field name resolves to the first parent's descr outright.

The trace-side twin `simple_descr_group_from_bh_size` (`pyre-jit-trace/src/descr.rs`) already carves zero out on this exact input; the metainterp side did not. Both arms now mint fresh per resolution — without an identity carrier the orthodox reading is "each of these is a distinct STRUCT".

The two arms landed separately because the second is the more damaging one: the empty-layout arm publishes one field, the `all_fielddescrs` arm publishes a whole **field table** under `Struct(0)`.

Discriminator, with the guard removed: a second parent of size 48 resolves to the first parent's size descr of 16 (24/56 in the empty-list twin). Three tests cover both arms plus the keyed path; the keyed test passes either way, which is what shows the other two target the zero path and not caching in general.

Audited the other readers of `BhSizeSpec.type_id` that key a descr cache — `pyre-jit-trace/src/descr.rs` (two sites) and `jitcode_runtime.rs` — and all three already filter zero.

Also recorded, at the keyed arm, why it passes `immutable_flag = false`: `descr.py:112` derives it from `heaptracker.is_immutable_struct(STRUCT)`, and a serialized parent spec carries no immutability hint to derive it from.

## 2. `verify_types` was half-ported

`descr.py:614-620` has two halves. `collect_call_args` carried only the second — the per-class argument counts at `:616-620`. The first, `:615 assert self.result_type in return_type`, had no counterpart anywhere in the tree.

It is not redundant with the argument check. **Nothing on the call path reads `result_type` to pick a dispatcher.** The blackhole reaches one of `bh_call_i/r/f/v` because the codewriter emitted `residual_call_*_i/_r/_f/_v`; the opcode and the descr are two independent records of the return register, and they disagree silently — the dispatcher would read the callee's result out of the register file the *opcode* named while the callee returned it in the one `result_type` names.

`verify_result_type` is called from all four entry points with the same `return_type` literals `llmodel.py:816/822/828/835` pass: `"iS"`, `"r"`, `"fL"`, `"v"`.

Two placement decisions:

- **`debug_assert`**, mirroring the `if not we_are_translated():` guard at each upstream call site. `majit-backend` is not one of the LLBC-extracted crates, so a release build genuinely drops it.
- **After** the `func == 0` early return, where upstream verifies first. That guard has no upstream counterpart — it is pyre's "no callee is installed" sentinel, and it pairs with a `BhCallDescr::default()` whose `result_type` is `'\0'`. Verifying the return register of a call that is not made would report that pairing instead of an ABI disagreement.

Note that the `#[should_panic]` tests are `#[cfg(debug_assertions)]`: `[profile.release]` in this tree sets only `lto`/`codegen-units`, so `cargo test --release` drops every `debug_assert!` and would report those two as failures-to-panic.

## 3. The root-stack walk's write-back was untested across a grow

`walk_shadow_stack_survives_push_that_grows_the_buffer` covers only the read side — that the slot visited *after* a visitor-triggered grow is read from the new buffer.

A moving collector also writes the forwarded address back, and that write happens after the visitor has had its chance to grow, so the store has to resolve the buffer address a **second** time. The new test forwards each root inside the visitor and asserts on slot 0, which was read from the old buffer before the grow.

Restoring the store to an in-buffer `&mut` leaves both existing walk tests green and fails only this one. Release-only, like its read twin — a reentrant push during a walk panics by design in debug builds.

## 4. The parentless fallback: a guess, replaced by a census

The branch carried the claim that pyre "still emits a `getfield_gc` here" and that porting `jtransform.py:942 rewrite_op_getsubstruct` would settle it. That was written without ever counting the population.

Censused the built descr table instead: **65 of 1514 Field slots are parentless**, in three families, every one a raw non-GC aggregate —

- `__pos_N` positional slots of closures / `Tuple<K,V>` / `core::alloc::layout::Layout` (~57)
- the four fields of `Arguments`, a plain Rust struct with no `#[jit_struct]`, so no GC header and no type id
- one owner-less `Adt_0`

That is exactly `rewrite_op_getsubstruct`'s domain: it accepts only `gckind == 'raw'` and lowers to `int_add(ptr, ofs)` with **no descr at all**. So the parent is not lost — upstream never mints the descr in the first place.

They are also cold: `MAJIT_LOG=1` counts **zero** resolutions through this branch on `fib_recursive`, `nbody` and `spectral_norm`. The standing cost is descr-table entries, not a declined speculation.

And synthesising a parent would be the wrong fix. Absent one, `protect_speculative_field` (`llmodel.py:555-567`) returns the decline its own `SpeculativeError` models, which is correct for a pointer that carries no type id. A fabricated parent would instead hand the `actual_tid != sizedescr.type_id()` compare an invented id, turning a safe decline into an accept whenever it happened to match.

Disposition: **won't-fix (documented)**, not deferred. The lowering stays the named convergence path if the branch ever becomes hot. Comment-only commit.

## Method note

The first attempt at (4) went into the wrong assembler. `JitCodeBuilder` in `majit-metainterp` is the *runtime* jitcode builder and emits **zero** Field descrs for pyre itself — pyre's field descrs come from the build-time `descrs.bin` side, in `majit-translate`. Instrumentation showed `fields=0 parentless=0 pending=0`, so the whole side table was reverted rather than shipped unexercised.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of call result types to prevent incompatible integer, reference, floating-point, and void dispatches.
  * Fixed field descriptor isolation for layouts without type identifiers, preventing unrelated layouts from sharing metadata.
  * Ensured relocated garbage-collection roots are correctly written back after shadow stack growth.

* **Tests**
  * Added coverage for result-type validation, descriptor caching behavior, and relocated shadow-stack roots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->