### PR TITLE
jit: the inlined-callee frame image and the escape attribution behind VableEscapedDuringResidualCall

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,6 +180,9 @@ Grep RPython:
 rg -t py 'lenbound|getlenbound|_x86_arglocs|_ll_loop_code' rpython/jit/
 ```
 
+For a *behavioural* question rather than a structural one — "does upstream
+really do this?" — grepping is the second step; see "The PyPy oracle" below.
+
 
 ### Workflow guideline
 
@@ -190,6 +193,40 @@ for `HashMap` only after you have proven that RPython itself uses a
 dict-like container in that exact spot. Apply the same test to TLS: locate the
 upstream owner, then preserve whether it is global, interpreter-local,
 execution-context-local, or genuinely thread-local.
+
+## The PyPy oracle: run it before you argue about orthodoxy
+
+Reading `rpython/` tells you what upstream *says*. Running a real `pypy3` tells
+you what upstream *does*. When the question is "is this JIT behaviour orthodox,
+or is it our deviation?", run the oracle FIRST — before reading source, before
+forming a theory, and certainly before recording a verdict.
+
+```
+PYPYLOG=jit-summary:- pypy3 pyre/bench/synth/<fixture>.py
+```
+
+Most `pyre/bench/synth` fixtures use no stdlib and run unmodified under the
+real interpreter, so this costs one command. Read these keys: `Total # of
+loops` / `Total # of bridges`, `forcings`, `virtualizables forced`, every
+`abort: *`, `nvirtuals`. Compare against `MAJIT_STATS=1` on the same file.
+
+**A counter that differs is a pointer, not the answer.** Go find the upstream
+line that produces it — the decision is usually one JIT hint
+(`@jit.look_inside_iff`, `@jit.dont_look_inside`, `@jit.elidable`,
+`@jit.unroll_safe`) sitting on the function in question. Cite it. If the
+summary is too coarse, `PYPYLOG=jit-log-opt:FILE` dumps the optimized trace.
+
+Worked example (2026-08-03). `getframe_inline_subwalk_multiframe` failed 8948
+GUARD_NOT_FORCED, and the standing conclusion was "a GUARD_NOT_FORCED never
+compiles a bridge (`compile.py:950-953`), so this is unfixable by construction."
+The oracle reported one loop, no bridges, **`forcings: 0`**, **`virtualizables
+forced: 0`**, no aborts — PyPy never forces here at all, so the guard should not
+exist. `pypy/module/sys/vm.py:41` then names the decision in one line:
+`@jit.look_inside_iff(lambda space, depth: jit.isconstant(depth))` on
+`getframe`, which pyre folds into a single opaque builtin. A verdict that had
+stood for weeks was overturned, and an unbounded "epic" turned into a named
+port, by one command. Note also `pypy3` is 3.11 — a fixture using newer syntax
+needs trimming to the subset that runs.
 
 ## RPython Parity Rules
 - When porting from RPython/PyPy, do STRICT line-by-line structural parity. Do NOT take shortcuts, reimplement from scratch, or declare phases 'complete' without the literal refactor.

--- a/pyre/bench/frame_inlined_callee_own_image_regression.py
+++ b/pyre/bench/frame_inlined_callee_own_image_regression.py
@@ -1,0 +1,115 @@
+# Self-checking regression guard for the image an INLINED CALLEE's own frame
+# reports (registered via check.py run_selfcheck, NOT the synthetic suite).
+#
+# Sibling of `frame_lineno_mid_replay_regression`, which reads the coordinate
+# through `sys._getframe(1)` from a callee whose caller is the portal — the
+# frame the JIT treats as the virtualizable, and whose fields the walk keeps
+# current.  The shape here is the other one: the frame handed out is the
+# INLINED CALLEE's own, materialised through a `jit.virtual_ref` rather than
+# being the virtualizable.  Such a frame is built with `last_instr = -1`
+# (`pyre-jit-trace/src/helpers.rs`) and nothing updates it through the inlined
+# body, and its locals region is not what the escape flush writes — that flush
+# is keyed on the virtualizable.  So the image has to come from the force, and
+# `offset2lineno(code, -1)` answers the `def` line when it does not.
+#
+# What routes these reads to a correct answer today is the abort:
+# `sys._getframe` forces the virtualizable, `vable_after_residual_call` reads
+# the cleared token as a callee escape, and the interpreter finishes the
+# iteration.  That makes this guard load-bearing in an unusual way — it pins
+# the ANSWER, not the mechanism, so a change that removes the abort in favour
+# of a consumer-side force has to keep the answer.  Removing the two forces in
+# `sys._getframe` and forcing from the `f_lineno` / `f_lasti` getsets instead
+# left the whole 370-fixture corpus green while making `own_lineno` below
+# report the `def` line, `own_locals` grow a second entry, and `own_combined`
+# segfault.  None of the three had a fixture; that is why this one exists.
+#
+# Splitting each survey across several calls is what makes it a test, for the
+# same reason the sibling guard does it: the loop compiles part-way through, so
+# a set over the rounds holds the interpreted answer and the compiled one
+# together, and a divergence appears as a SECOND element rather than a shifted
+# single value.
+#
+# Offsets are relative to `co_firstlineno` so the expectations survive an edit
+# above them.  It asserts rather than diffing against pypy3 because the shape
+# it pins is a pyre-internal one; cpython and pypy3 both answer the same values
+# and agree with `PYRE_NO_JIT=1`.
+import sys
+
+N = 4000
+ROUNDS = 8
+
+
+def own_lineno(x):                                   # +0
+    f = sys._getframe(0)                             # +1
+    return f.f_lineno - f.f_code.co_firstlineno      # +2
+
+
+def own_locals(x):                                   # +0
+    f = sys._getframe(0)                             # +1
+    return tuple(sorted(f.f_locals))                 # +2
+
+
+def own_combined(x):                                 # +0
+    f = sys._getframe(0)                             # +1
+    return (f.f_lineno - f.f_code.co_firstlineno, tuple(sorted(f.f_locals)), f.f_lasti >= 0)
+
+
+def drive_lineno(n):
+    seen = set()
+    i = 0
+    while i < n:
+        seen.add(own_lineno(i))
+        i += 1
+    return seen
+
+
+def drive_locals(n):
+    seen = set()
+    i = 0
+    while i < n:
+        seen.add(own_locals(i))
+        i += 1
+    return seen
+
+
+def drive_combined(n):
+    seen = set()
+    i = 0
+    while i < n:
+        seen.add(own_combined(i))
+        i += 1
+    return seen
+
+
+def main():
+    each = N // ROUNDS
+    failures = []
+
+    def check(label, got, want):
+        if got != want:
+            failures.append(f"{label}: got {got!r}, want {want!r}")
+
+    seen = set()
+    for _ in range(ROUNDS):
+        seen |= drive_lineno(each)
+    check("own_lineno", sorted(seen), [2])
+
+    seen = set()
+    for _ in range(ROUNDS):
+        seen |= drive_locals(each)
+    check("own_locals", sorted(seen), [("f", "x")])
+
+    seen = set()
+    for _ in range(ROUNDS):
+        seen |= drive_combined(each)
+    check("own_combined", sorted(seen), [(2, ("f", "x"), True)])
+
+    if failures:
+        for f in failures:
+            print("FAIL", f)
+        return 1
+    print("PASS inlined-callee own frame image")
+    return 0
+
+
+sys.exit(main())

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -2202,6 +2202,18 @@ def main():
             f"{B}/frame_lineno_mid_replay_regression.py",
             20,
         )
+        # The sibling shape: the frame handed out is the INLINED CALLEE's own,
+        # not the virtualizable its caller runs as. That frame carries the `-1`
+        # `last_instr` sentinel and is not what the escape flush writes, so its
+        # `f_lineno` / `f_locals` are only right because `sys._getframe` forces
+        # and the resulting abort finishes the iteration interpreted. Pins the
+        # answer so a change that retires that abort has to keep it -- the whole
+        # synthetic corpus stayed green while these three reads broke.
+        chk.run_selfcheck(
+            "frame_inlined_callee_own_image",
+            f"{B}/frame_inlined_callee_own_image_regression.py",
+            20,
+        )
         # The branchy-inlined-callee guard (gh#343) lives in the synthetic parity
         # suite as bridge_branchy_callee.py, gated against pypy by
         # `# pyre-check: max-pypy-ratio`; a decline that keeps every crossing

--- a/pyre/pyre-interpreter/src/module/sys/vm.rs
+++ b/pyre/pyre-interpreter/src/module/sys/vm.rs
@@ -533,6 +533,146 @@ fn simple_namespace_replace(args: &[PyObjectRef]) -> crate::PyResult {
 /// active context (set on eval-loop entry); see the helper's doc for
 /// the staleness gap relative to PyPy's `space.getexecutioncontext()`
 /// which always queries the thread state.
+/// `pypy/module/sys/vm.py:42 getframe` — the non-hidden frame-chain walk that
+/// `sys._getframe` hands out.
+///
+/// ```python
+/// @jit.look_inside_iff(lambda space, depth: jit.isconstant(depth))
+/// def getframe(space, depth):
+///     ec = space.getexecutioncontext()
+///     f = ec.gettopframe_nohidden()
+///     while True:
+///         if f is None:
+///             raise oefmt(space.w_ValueError, "call stack is not deep enough")
+///         if depth == 0:
+///             f.mark_as_escaped()
+///             audit(space, "sys._getframe", [f])
+///             return f
+///         depth -= 1
+///         f = ec.getnextframe_nohidden(f)
+/// ```
+///
+/// `hidden_applevel` gateway / bridge frames are skipped, matching `f_back`.
+/// The `f is None` test runs at the START of every iteration including the
+/// first, so a missing top frame raises rather than fabricating a stub, and a
+/// negative depth walks the chain to its end and raises there.
+///
+/// The returned object is the live `PyFrame` itself (`FRAME_TYPE` typedef), not
+/// a stub, so `frame.f_globals is globals()` holds and `f_back` chains lazily
+/// through `pyframe.py:767 GetSetProperty(PyFrame.fget_f_back)`.
+///
+/// DEVIATION — the two VIRTUALIZABLE forces. The distinction matters: the vref
+/// force is common to both worlds and is not optional
+/// (`ExecutionContext::gettopframe_raw`), so `gettopframe_nohidden` is not
+/// "force-free" — it is free of the *virtualizable* force that
+/// `gettopframe` adds. Upstream takes neither of those, because
+/// `look_inside_iff(isconstant(depth))` traces a constant `depth` THROUGH: the
+/// walk never becomes a residual call, and the frame it hands to app level
+/// materialises by escape analysis instead
+/// (`executioncontext::force_frame_before_locals_read` states that contract).
+/// Pyre calls this residually, so both forces are load-bearing here:
+/// `gettopframe()` because a JIT-inlined callee has no frame of its own until a
+/// force materialises one — an unforced walk would start at the caller and then
+/// read `f_back` off a frame that never existed — and `force_frame` because app
+/// code is about to read `f_lineno` / `f_locals` off a frame whose
+/// virtualizable fields the JIT may still be holding.
+///
+/// The price is that each call trips `vable_after_residual_call` and aborts the
+/// trace: measured 2026-08-03, 138 of the synth corpus's 219 `loops_aborted`,
+/// against `abort: vable escape: 0` and `forcings: 0` on the same fixtures
+/// under real pypy3.
+///
+/// A constant-depth traced-through arm does NOT reclaim that. It reaches 15 of
+/// the 138; 70 sit at call sites inside an inlined callee, whose virtual frame
+/// carries `last_instr = -1` (`pyre-jit-trace/src/helpers.rs`) with nothing
+/// updating it through the body, so folding them would compile a
+/// `_getframe().f_lineno` that reports the `def` line where the abort today
+/// falls back to the interpreter and answers correctly. Part of this abort
+/// count is load-bearing. The lever that could take the 70 is instead the
+/// escalation from a *callee* frame escape to a *portal* virtualizable force in
+/// `pyre-jit/src/eval.rs`, which has no upstream counterpart —
+/// `executioncontext.py:91-107 leave` forces the leaving frame's own vref and
+/// only *marks* `f_back`.
+pub fn getframe(depth: i64) -> crate::PyResult {
+    let ec = current_execution_context();
+    let mut current = if ec.is_null() {
+        std::ptr::null_mut()
+    } else {
+        unsafe {
+            (*ec).gettopframe();
+            (*ec).gettopframe_nohidden()
+        }
+    };
+    let mut remaining = depth;
+    loop {
+        if current.is_null() {
+            return Err(crate::PyError::value_error("call stack is not deep enough"));
+        }
+        if remaining == 0 {
+            break;
+        }
+        remaining -= 1;
+        current = crate::executioncontext::ExecutionContext::getnextframe_nohidden(current);
+    }
+    unsafe { (*current).mark_as_escaped() };
+    crate::executioncontext::force_frame(current);
+    Ok(current as PyObjectRef)
+}
+
+/// `pypy/module/sys/vm.py:29 _getframe` — `@unwrap_spec(depth=int)`, the
+/// argument surface in front of [`getframe`].
+///
+/// A named `fn` rather than a closure so [`is_builtin_getframe_function`] can
+/// compare builtin-code identity against it.
+fn sys_getframe(args: &[PyObjectRef]) -> crate::PyResult {
+    // `unwrap_spec` enforces a single optional int argument, so any extra
+    // positional arg must surface as TypeError before the depth walk runs.
+    if args.len() > 1 {
+        return Err(crate::PyError::type_error(format!(
+            "_getframe expected at most 1 argument, got {}",
+            args.len()
+        )));
+    }
+    let depth = if args.is_empty() {
+        0i64
+    } else if unsafe { pyre_object::is_int(args[0]) } {
+        unsafe { pyre_object::w_int_get_value(args[0]) }
+    } else {
+        return Err(crate::PyError::type_error(
+            "_getframe(): argument must be an int",
+        ));
+    };
+    // `vm.py:37-38 if depth < 0: raise ... "frame index must not be negative"`
+    // — the message differs from `getframe`'s exhausted-stack case.
+    if depth < 0 {
+        return Err(crate::PyError::value_error(
+            "frame index must not be negative",
+        ));
+    }
+    getframe(depth)
+}
+
+/// True iff `callable` is the canonical `sys._getframe` builtin.
+///
+/// `sys` is an ordinary mutable module, so the JIT walker has to key on
+/// builtin-code identity rather than the global name before it may reproduce
+/// [`getframe`] in a trace. Mirrors `builtins::is_builtin_len_function`.
+pub fn is_builtin_getframe_function(callable: PyObjectRef) -> bool {
+    unsafe {
+        if callable.is_null() || !crate::is_function(callable) {
+            return false;
+        }
+        let code = crate::function_get_code(callable) as PyObjectRef;
+        if code.is_null() || !crate::gateway::is_builtin_code(code) {
+            return false;
+        }
+        crate::gateway::builtin_code_fn_eq(
+            crate::gateway::builtin_code_get(code),
+            sys_getframe as crate::gateway::BuiltinCodeFn,
+        )
+    }
+}
+
 fn current_execution_context() -> *mut crate::PyExecutionContext {
     crate::call::getexecutioncontext() as *mut crate::PyExecutionContext
 }
@@ -967,93 +1107,12 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     module_ns_store(ns, "__stdout__", stdout);
     module_ns_store(ns, "__stderr__", stderr);
     module_ns_store(ns, "__stdin__", stdin);
-    // `pypy/module/sys/vm.py:30 _getframe` walks the
-    // `space.getexecutioncontext().gettopframe_nohidden()` chain,
-    // following `f_back` `depth` times.  PyPy returns the frame
-    // object directly so `frame.f_globals is module.__dict__` /
-    // `frame.f_globals is globals()` (callee's scope) holds.  Pyre
-    // mirrors the depth walk through `CURRENT_FRAME` + `f_back`,
-    // populating the stub frame's attributes from the resolved
-    // PyFrame. `f_globals` / `f_locals` use the frame's canonical dict so the
-    // `is module.__dict__` invariant survives sys._getframe access.
+    // `vm.py:29 _getframe` (arguments) over `vm.py:42 getframe` (the walk) —
+    // see [`sys_getframe`] and [`getframe`], which keep upstream's split.
     module_ns_store(
         ns,
         "_getframe",
-        crate::make_builtin_function("_getframe", |args| {
-            // `pypy/module/sys/vm.py:28-39 _getframe`:
-            //   @unwrap_spec(depth=int) def _getframe(space, depth=0)
-            // `unwrap_spec` enforces a single optional int argument, so
-            // any extra positional arg must surface as TypeError before
-            // the depth walk runs.
-            if args.len() > 1 {
-                return Err(crate::PyError::type_error(format!(
-                    "_getframe expected at most 1 argument, got {}",
-                    args.len()
-                )));
-            }
-            let depth_signed = if args.is_empty() {
-                0i64
-            } else if unsafe { pyre_object::is_int(args[0]) } {
-                unsafe { pyre_object::w_int_get_value(args[0]) }
-            } else {
-                return Err(crate::PyError::type_error(
-                    "_getframe(): argument must be an int",
-                ));
-            };
-            // `vm.py:37-38 if depth < 0: raise ... "frame index must not
-            // be negative"` — the message string differs from the
-            // exhausted-stack case below.
-            if depth_signed < 0 {
-                return Err(crate::PyError::value_error(
-                    "frame index must not be negative",
-                ));
-            }
-            // `vm.py:44-54 getframe`: start from
-            // `ec.gettopframe_nohidden()` and walk
-            // `ec.getnextframe_nohidden(f)` `depth` times, so
-            // `hidden_applevel` gateway / bridge frames are skipped
-            // (matching `f_back`).  The `f is None` guard runs at the
-            // *start* of every iteration including the first, so a
-            // missing top frame raises rather than fabricating a stub.
-            let ec = current_execution_context();
-            let mut current = if ec.is_null() {
-                std::ptr::null_mut()
-            } else {
-                // Force the frame `topframeref` names BEFORE deciding which
-                // frame to hand out.  A JIT-inlined callee has no frame of its
-                // own until that force materialises one, so a walk started on
-                // the unforced chain would skip straight to the caller and
-                // then read `f_back` off a frame that never existed.
-                // `gettopframe` is the forcing accessor; the `_nohidden` walk
-                // is force-free by design (see `force_frame`).
-                unsafe {
-                    (*ec).gettopframe();
-                    (*ec).gettopframe_nohidden()
-                }
-            };
-            let mut remaining = depth_signed as usize;
-            loop {
-                if current.is_null() {
-                    return Err(crate::PyError::value_error("call stack is not deep enough"));
-                }
-                if remaining == 0 {
-                    break;
-                }
-                remaining -= 1;
-                current = crate::executioncontext::ExecutionContext::getnextframe_nohidden(current);
-            }
-            // `pyframe.py:767 f_back = GetSetProperty(PyFrame.fget_f_back)`.
-            // Return the live `PyFrame` itself as the user-visible `frame`
-            // object (`FRAME_TYPE` typedef); `f_back` chains lazily through
-            // the getset.  Mark it escaped so the JIT keeps the frame
-            // materialised for the exposed reference (`pyframe.py`
-            // `mark_as_escaped`), and force it now: app code is about to read
-            // `f_lineno` / `f_locals` off a frame whose virtualizable fields
-            // the JIT may still be holding.
-            unsafe { (*current).mark_as_escaped() };
-            crate::executioncontext::force_frame(current);
-            Ok(current as pyre_object::PyObjectRef)
-        }),
+        crate::make_builtin_function("_getframe", sys_getframe),
     );
     // `sys._getframemodulename(depth=0)` — the module name of the frame
     // `depth` levels up, or None when the walk runs off the stack.  Used by

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -3995,6 +3995,11 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
         // Inert when `callee_portal_frame_reg == u16::MAX` (flip OFF / frame reg
         // unresolved).
         if callee_portal_frame_reg != u16::MAX {
+            {
+                let shadow = sub_wc.callee_shadow.as_mut().unwrap();
+                shadow.concrete_frame = concrete_callee_frame as usize;
+                shadow.frame_box = sub_wc.registers_r[callee_portal_frame_reg as usize];
+            }
             if !try_multiframe {
                 sub_wc.callee_shadow.as_mut().unwrap().fold_frame_reg = callee_portal_frame_reg;
             }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -910,7 +910,7 @@ pub(crate) fn try_walker_call_assembler_self_recursive<Sym: WalkSym>(
 
     // do_residual_call step 1 (`pyjitpl.py`): FORCE_TOKEN +
     // SETFIELD_GC(vable_token) before the assembler call.
-    maybe_walker_vable_and_vrefs_before_residual_call(ctx);
+    maybe_walker_vable_and_vrefs_before_residual_call(ctx, op.pc);
 
     // pyjitpl.py `execute_and_record_varargs(CALL_MAY_FORCE_R)`:
     // the forces branch EXECUTES the call during tracing —
@@ -1155,7 +1155,7 @@ pub(crate) fn emit_walker_loop_callee_call_assembler<Sym: WalkSym>(
 
     // do_residual_call step 1 (`pyjitpl.py`): FORCE_TOKEN +
     // SETFIELD_GC(vable_token) before the assembler call.
-    maybe_walker_vable_and_vrefs_before_residual_call(ctx);
+    maybe_walker_vable_and_vrefs_before_residual_call(ctx, op.pc);
 
     // `direct_assembler_call` (`pyjitpl.py`) records the CALL_ASSEMBLER with
     // exactly the target jitdriver's red args — `assert len(args) ==

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -6321,7 +6321,7 @@ fn direct_call_release_gil<Sym: WalkSym>(
     // residual-call execution path — see
     // [`walker_vable_and_vrefs_before_residual_call`] for the IR-vs-heap
     // split rationale.
-    maybe_walker_vable_and_vrefs_before_residual_call(ctx);
+    maybe_walker_vable_and_vrefs_before_residual_call(ctx, pc);
     // pyjitpl.py: realfuncaddr, saveerr = effectinfo.call_release_gil_target
     let (realfuncaddr, saveerr) = ei.call_release_gil_target;
     // pyjitpl.py: funcbox/savebox ConstInt

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -402,6 +402,11 @@ pub struct CalleeLocalsShadow {
     /// Portal frame register used to resolve own-frame vable operations.
     /// `u16::MAX` means that the strict fresh-frame fold is inactive.
     pub fold_frame_reg: u16,
+    /// Concrete `PyFrame*` backing the folded own-frame writes.
+    pub concrete_frame: usize,
+    /// Box seeded into `fold_frame_reg`; `OpRef::NONE` means the frame register
+    /// was not seeded, so the fold must not be disarmed into nonstandard ops.
+    pub frame_box: OpRef,
 }
 
 impl Default for CalleeLocalsShadow {
@@ -410,6 +415,8 @@ impl Default for CalleeLocalsShadow {
             opref: Default::default(),
             concrete: Default::default(),
             fold_frame_reg: u16::MAX,
+            concrete_frame: 0,
+            frame_box: OpRef::NONE,
         }
     }
 }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -37,6 +37,11 @@ thread_local! {
         const { std::cell::Cell::new(None) };
     static ACTIVE_FRAME_ESCAPE_STACK: std::cell::RefCell<Option<Vec<OpRef>>> =
         const { std::cell::RefCell::new(None) };
+    /// Step-0 attribution probe: classification of the most recent matched
+    /// escape, read at the force site to attribute the token clear (and hence
+    /// the abort) to the portal or the published-callee disjunct.
+    static LAST_ESCAPE_WAS_CALLEE_ONLY: std::cell::Cell<Option<bool>> =
+        const { std::cell::Cell::new(None) };
     static COMMITTED_FRAME_ESCAPE_PC: std::cell::Cell<Option<(usize, EscapeResumeKind)>> =
         const { std::cell::Cell::new(None) };
     /// Pre-flush frame state captured by [`flush_active_frame_escape`] so a
@@ -1156,6 +1161,19 @@ impl Drop for ActiveFrameEscapeGuard {
 /// committed only when the state flush succeeds (a merge point with cached
 /// depth); a directly matched frame that cannot flush still escaped and must
 /// be forced, so for it the two signals are decoupled.
+/// Step-0 attribution probe: consume the classification recorded by the most
+/// recent matched escape and tally which disjunct owns this token clear.
+pub fn attribute_last_escape_force() {
+    if let Some(callee_only) = LAST_ESCAPE_WAS_CALLEE_ONLY.with(|c| c.take()) {
+        use crate::trace::fbw_diag;
+        fbw_diag::bump(if callee_only {
+            fbw_diag::ESCAPE_FORCE_BY_CALLEE_ONLY
+        } else {
+            fbw_diag::ESCAPE_FORCE_BY_PORTAL
+        });
+    }
+}
+
 pub fn flush_active_frame_escape(ctx: &TraceCtx, frame: *mut pyre_interpreter::PyFrame) -> bool {
     // `executioncontext.py:104-106 leave` — a frame handed to application code
     // keeps a reference to its caller, so escaping the concrete frame an inline
@@ -1176,7 +1194,25 @@ pub fn flush_active_frame_escape(ctx: &TraceCtx, frame: *mut pyre_interpreter::P
     });
     ACTIVE_FRAME_ESCAPE.with(|slot| {
         if let Some((expected, py_pc)) = slot.get()
-            && (expected == frame as usize || escaped_published)
+            && {
+                let escaped_portal = expected == frame as usize;
+                if escaped_portal || escaped_published {
+                    use crate::trace::fbw_diag;
+                    match (escaped_portal, escaped_published) {
+                        (true, false) => fbw_diag::bump(fbw_diag::ESCAPE_PORTAL_ONLY),
+                        (false, true) => fbw_diag::bump(fbw_diag::ESCAPE_PUBLISHED_CALLEE_ONLY),
+                        (true, true) => {
+                            fbw_diag::bump(fbw_diag::ESCAPE_PORTAL_AND_PUBLISHED_CALLEE)
+                        }
+                        (false, false) => {}
+                    }
+                    LAST_ESCAPE_WAS_CALLEE_ONLY
+                        .with(|c| c.set(Some(!escaped_portal && escaped_published)));
+                    true
+                } else {
+                    false
+                }
+            }
         {
             // Force #2+ within this residual (`enter` resets the committed pc
             // per residual): the live frame is already heap-authoritative

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -3554,7 +3554,10 @@ pub(crate) fn walker_vable_and_vrefs_before_residual_call(ctx: &mut TraceCtx) {
 fn inline_callee_py_pc<Sym: WalkSym>(ctx: &WalkContext<'_, '_, Sym>, jit_pc: usize) -> Option<u32> {
     let consts = ctx.inline_callee_consts?;
     let pjc = crate::state::pyjitcode_for_jitcode_index(consts.jitcode_index)?;
-    Some(python_pc_for_jitcode_pc(&pjc.metadata, jit_pc))
+    Some(crate::py_coord::containing_py_pc_for_jitcode_pc(
+        &pjc.metadata,
+        jit_pc,
+    ))
 }
 
 /// Convenience wrapper for [`walker_vable_and_vrefs_before_residual_call`].
@@ -3579,7 +3582,7 @@ fn maybe_record_inline_callee_last_instr<Sym: WalkSym>(
         return;
     }
 
-    let callee_py_pc = python_pc_for_jitcode_pc(&pjc.metadata, jit_pc);
+    let callee_py_pc = crate::py_coord::containing_py_pc_for_jitcode_pc(&pjc.metadata, jit_pc);
     let last_instr = ctx.trace_ctx.const_int(callee_py_pc as i64);
     let last_instr_descr = crate::descr::pyframe_next_instr_descr();
     let last_instr_idx = last_instr_descr.index();

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -960,12 +960,18 @@ impl LiveLastInstrGuard {
     /// sub-walk's pc is in the callee's code (the same reason `escape_stack`
     /// declines to latch a sub-walk's mirror), and writing it onto the outer
     /// frame strands that frame's replay on a stack depth it never had.
-    fn enter(live_frame: usize, py_pc: u32) -> Option<Self> {
+    fn enter(live_frame: usize, py_pc: u32, inline_py_pc: Option<u32>) -> Option<Self> {
         let inline = current_inline_concrete_frame() as *mut pyre_interpreter::PyFrame;
-        let frame = if inline.is_null() {
-            live_frame as *mut pyre_interpreter::PyFrame
-        } else {
-            inline
+        // The frame and the pc have to name the same code.  Retargeting the
+        // frame to the callee while keeping the outer walk's `vstack_cur_pypc`
+        // publishes a pc from the CALLER's code onto the callee's frame — and
+        // for a sub-walk that mirror is never advanced (`vstack_valid` is
+        // false), so the published value is a constant 0 and a frame reader
+        // inside the callee reports the function's first line.
+        let (frame, py_pc) = match (inline.is_null(), inline_py_pc) {
+            (false, Some(callee_pc)) => (inline, callee_pc),
+            (false, None) => (inline, py_pc),
+            (true, _) => (live_frame as *mut pyre_interpreter::PyFrame, py_pc),
         };
         if frame.is_null() {
             return None;
@@ -2610,6 +2616,9 @@ pub(crate) fn try_execute_residual_call_via_executor<Sym: WalkSym>(
     } else {
         unsafe { (*ctx.fbw_mode.snapshot_sym).live_vable_frame_addr() }
     };
+    // Resolved against the callee's OWN metadata, because `vstack_cur_pypc` is
+    // the outer walk's mirror and a sub-walk never advances it.
+    let inline_callee_pc = inline_callee_py_pc(ctx, op_pc);
     let vable_root_depth = if let Some(obj) = vable_obj_root.as_mut() {
         let info = crate::frame_layout::build_pyframe_virtualizable_info();
         let root_depth = majit_gc::shadow_stack::resume_ref_roots_depth();
@@ -2806,7 +2815,8 @@ pub(crate) fn try_execute_residual_call_via_executor<Sym: WalkSym>(
         // `executioncontext.py:85 enter` for the inlined callee this residual
         // runs inside of.
         let _frame_chain = ResidualFrameChainGuard::enter();
-        let _last_instr = LiveLastInstrGuard::enter(live_frame, ctx.vstack_cur_pypc);
+        let _last_instr =
+            LiveLastInstrGuard::enter(live_frame, ctx.vstack_cur_pypc, inline_callee_pc);
         let _suspend = majit_metainterp::TraceContinuationSuspendGuard::enter();
         majit_metainterp::executor::execute_residual_call(call_descr, func_ptr, &args)
     };
@@ -3535,6 +3545,16 @@ pub(crate) fn walker_vable_and_vrefs_before_residual_call(ctx: &mut TraceCtx) {
     // pyjitpl.py: force_token + SETFIELD_GC vable_token_descr
     let force_token = ctx.force_token();
     ctx.vable_setfield_descr(vable_ref, force_token, info.token_field_descr());
+}
+
+/// The python pc `jit_pc` names in the inline callee's OWN code, or `None`
+/// when this walk is not inside an inline callee.  A callee `jit_pc` has no
+/// meaning in the outer jitcode's py_pc tables, so every consumer that writes
+/// a pc onto the callee's frame has to go through the callee's own metadata.
+fn inline_callee_py_pc<Sym: WalkSym>(ctx: &WalkContext<'_, '_, Sym>, jit_pc: usize) -> Option<u32> {
+    let consts = ctx.inline_callee_consts?;
+    let pjc = crate::state::pyjitcode_for_jitcode_index(consts.jitcode_index)?;
+    Some(python_pc_for_jitcode_pc(&pjc.metadata, jit_pc))
 }
 
 /// Convenience wrapper for [`walker_vable_and_vrefs_before_residual_call`].

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -1221,12 +1221,17 @@ pub fn flush_active_frame_escape(ctx: &TraceCtx, frame: *mut pyre_interpreter::P
             // write_boxes` has no decline) — otherwise the callee reads an
             // array of nulls.  That write claims no resume pc, and the undo
             // stays armed so the legacy replay re-enters the pre-flush frame.
-            // A directly matched frame escaped whether or not the flush
-            // committed, so the two signals stay decoupled.  A redirected one
-            // is reported only once the resume pc is committed: forcing
-            // without it would raise an escape the walk can only answer by
-            // replaying from entry, double-applying this residual's body.
-            return flushed || expected == frame as usize;
+            //
+            // Upstream reports the escape from the vable token state alone,
+            // independent of any resume-image write.  See
+            // `virtualizable.py:231-255` (`tracing_after_residual_call` /
+            // `force_now`), `virtualizable.py:311-330` (token states),
+            // `virtualref.py:157-167` (vref'd inlined callee), and
+            // `pyjitpl.py:3373-3390` (unconditional ABORT_ESCAPE).  Runtime
+            // forcing also resets the token before writing fields
+            // (`resume.py:1405-1408`).  Therefore a matched guard reports the
+            // escape even when the flush declined.
+            return true;
         }
         false
     })

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -2856,6 +2856,7 @@ pub(crate) fn try_execute_residual_call_via_executor<Sym: WalkSym>(
             majit_gc::shadow_stack::pop_resume_ref_roots_to(depth);
         }
         if forced {
+            disarm_folded_inline_callee_after_escape(ctx, op_pc)?;
             if fbw_debug_abort_enabled() {
                 eprintln!(
                     "[force-shape] helper={helper:?} rtype={:?} writes_live={writes_live_heap} \
@@ -3569,6 +3570,79 @@ fn maybe_record_inline_callee_last_instr<Sym: WalkSym>(
     );
     ctx.trace_ctx
         .heapcache_setfield_cached(callee_frame, last_instr_idx, last_instr);
+}
+
+fn disarm_folded_inline_callee_after_escape<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    pc: usize,
+) -> Result<(), DispatchError> {
+    let Some(consts) = ctx.inline_callee_consts else {
+        return Ok(());
+    };
+    let Some(pjc) = crate::state::pyjitcode_for_jitcode_index(consts.jitcode_index) else {
+        return Ok(());
+    };
+    let Some(shadow) = ctx.callee_shadow.as_ref() else {
+        return Ok(());
+    };
+    if shadow.fold_frame_reg == u16::MAX || shadow.frame_box == OpRef::NONE {
+        return Ok(());
+    }
+    let frame_reg = pjc.metadata.portal_frame_reg as usize;
+    let Some(&callee_frame) = ctx.registers_r.get(frame_reg) else {
+        return Ok(());
+    };
+    if callee_frame != shadow.frame_box {
+        return Ok(());
+    }
+    let Some(info) = ctx.trace_ctx.virtualizable_info() else {
+        return Ok(());
+    };
+    let Some(fdescr) = info.array_field_descrs().first().cloned() else {
+        return Ok(());
+    };
+    let Some(adescr) = info.array_descrs.first().cloned() else {
+        return Ok(());
+    };
+    let mut slots: Vec<(i64, OpRef, Value)> = shadow
+        .opref
+        .iter()
+        .filter_map(|(&slot, &value)| {
+            (slot >= 0).then(|| {
+                let concrete = shadow
+                    .concrete
+                    .get(&slot)
+                    .filter(|entry| entry.frame_reg == shadow.fold_frame_reg)
+                    .map(|entry| entry.value)
+                    .or_else(|| ctx.trace_ctx.concrete_of_opref(value))
+                    .unwrap_or(Value::Void);
+                (slot, value, concrete)
+            })
+        })
+        .collect();
+    slots.sort_by_key(|(slot, _, _)| *slot);
+
+    for (slot, value, concrete) in slots {
+        let index = ctx.trace_ctx.const_int(slot);
+        let guards_before = ctx.trace_ctx.num_guards();
+        ctx.trace_ctx.vable_setarrayitem_indexed(
+            pc,
+            callee_frame,
+            index,
+            slot,
+            fdescr.clone(),
+            adescr.clone(),
+            value,
+            concrete,
+        );
+        walker_capture_inline_nonstandard_vable_guard(ctx, pc, guards_before)?;
+    }
+    if let Some(shadow) = ctx.callee_shadow.as_mut()
+        && shadow.frame_box == callee_frame
+    {
+        shadow.fold_frame_reg = u16::MAX;
+    }
+    Ok(())
 }
 
 pub(crate) fn maybe_walker_vable_and_vrefs_before_residual_call<Sym: WalkSym>(

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -3499,9 +3499,42 @@ pub(crate) fn walker_vable_and_vrefs_before_residual_call(ctx: &mut TraceCtx) {
 /// Kept as a thin pass-through so the dispatcher call sites stay
 /// readable; collapses to direct `walker_*` once the dispatchers
 /// inline.
+fn maybe_record_inline_callee_last_instr<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    jit_pc: usize,
+) {
+    let Some(consts) = ctx.inline_callee_consts else {
+        return;
+    };
+    let Some(pjc) = crate::state::pyjitcode_for_jitcode_index(consts.jitcode_index) else {
+        return;
+    };
+    let frame_reg = pjc.metadata.portal_frame_reg as usize;
+    let Some(&callee_frame) = ctx.registers_r.get(frame_reg) else {
+        return;
+    };
+    if callee_frame == OpRef::NONE {
+        return;
+    }
+
+    let callee_py_pc = python_pc_for_jitcode_pc(&pjc.metadata, jit_pc);
+    let last_instr = ctx.trace_ctx.const_int(callee_py_pc as i64);
+    let last_instr_descr = crate::descr::pyframe_next_instr_descr();
+    let last_instr_idx = last_instr_descr.index();
+    ctx.trace_ctx.record_op_with_descr(
+        OpCode::SetfieldGc,
+        &[callee_frame, last_instr],
+        last_instr_descr,
+    );
+    ctx.trace_ctx
+        .heapcache_setfield_cached(callee_frame, last_instr_idx, last_instr);
+}
+
 pub(crate) fn maybe_walker_vable_and_vrefs_before_residual_call<Sym: WalkSym>(
     ctx: &mut WalkContext<'_, '_, Sym>,
+    jit_pc: usize,
 ) {
+    maybe_record_inline_callee_last_instr(ctx, jit_pc);
     walker_vable_and_vrefs_before_residual_call(ctx.trace_ctx);
 }
 
@@ -4714,7 +4747,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
         // [`walker_vable_and_vrefs_before_residual_call`] for the IR-vs-heap
         // split rationale.
         if emit_guard_not_forced {
-            maybe_walker_vable_and_vrefs_before_residual_call(ctx);
+            maybe_walker_vable_and_vrefs_before_residual_call(ctx, op.pc);
         }
 
         // pyjitpl.py:2669-2682 `execute_and_record_varargs`; may-force
@@ -5756,7 +5789,7 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
         // See `dispatch_residual_call_iRd_kind` for the upstream-citation
         // walkthrough.
         if emit_guard_not_forced {
-            maybe_walker_vable_and_vrefs_before_residual_call(ctx);
+            maybe_walker_vable_and_vrefs_before_residual_call(ctx, op.pc);
         }
 
         if matches!(
@@ -5988,7 +6021,7 @@ pub(crate) fn dispatch_residual_call_iIRFd_kind<Sym: WalkSym>(
         // See `dispatch_residual_call_iRd_kind` for the upstream-citation
         // walkthrough.
         if emit_guard_not_forced {
-            maybe_walker_vable_and_vrefs_before_residual_call(ctx);
+            maybe_walker_vable_and_vrefs_before_residual_call(ctx, op.pc);
         }
 
         if matches!(

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/vable_ops.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/vable_ops.rs
@@ -272,6 +272,22 @@ pub(crate) fn setfield_vable_via_metainterp<Sym: WalkSym>(
     // `fresh_virtualizable` OptVirtualize elision (jtransform.py).
     let fold_frame_reg = fbw_strict_fold_frame_reg(ctx);
     if fold_frame_reg != u16::MAX && code[op.pc + 1] as u16 == fold_frame_reg {
+        let value = match value_bank {
+            'i' => read_int_reg(code, op, 1, ctx)?,
+            'r' => read_ref_reg(code, op, 1, ctx)?,
+            'f' => read_float_reg(code, op, 1, ctx)?,
+            _ => unreachable!("value_bank must be 'i', 'r' or 'f'"),
+        };
+        let descr = read_descr(code, op, 2, ctx)?;
+        if let (Some(Value::Int(value)), Some(field_index), Some(shadow)) = (
+            vable_value_concrete(code, op, 1, ctx, value_bank, value),
+            ctx.trace_ctx
+                .virtualizable_info()
+                .and_then(|info| info.static_field_by_descr(&descr)),
+            ctx.callee_shadow.as_ref(),
+        ) {
+            crate::state::store_live_frame_static_int(shadow.concrete_frame, field_index, value);
+        }
         return Ok((DispatchOutcome::Continue, op.next_pc));
     }
     let obj = read_ref_reg_raw(code, op, 0, ctx)?;
@@ -614,6 +630,23 @@ pub(crate) fn setarrayitem_vable_via_metainterp<Sym: WalkSym>(
             if let Some(shadow) = ctx.callee_shadow.as_mut() {
                 shadow.set_opref(slot, value);
                 shadow.set_concrete(fold_frame_reg, slot, concrete);
+            }
+            // `locals_cells_stack_w` is a `FixedObjectArray` of boxed refs, so a
+            // folded store should only ever carry one.  `store_live_frame_array_slot`
+            // already ignores anything else, so this stays a debug assertion rather
+            // than a release panic on a path the corpus does not exercise.
+            debug_assert!(
+                matches!(concrete, majit_ir::Value::Ref(_) | majit_ir::Value::Void),
+                "folded locals_cells_stack_w store must carry a Ref-compatible value"
+            );
+            if matches!(concrete, majit_ir::Value::Ref(_))
+                && let Some(shadow) = ctx.callee_shadow.as_ref()
+            {
+                crate::state::store_live_frame_array_slot(
+                    shadow.concrete_frame,
+                    slot as usize,
+                    concrete,
+                );
             }
             return Ok((DispatchOutcome::Continue, op.next_pc));
         }

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -5904,12 +5904,17 @@ pub mod fbw_diag {
     pub const MIDBODY_LATCH_NEW_UNJOURNALED: usize = 3;
     pub const ESCAPE_PLAIN_FALLBACK: usize = 4;
     pub const ESCAPE_PLAIN_FALLBACK_UNCLEAN: usize = 5;
+    pub const ESCAPE_PORTAL_ONLY: usize = 6;
+    pub const ESCAPE_PUBLISHED_CALLEE_ONLY: usize = 7;
+    pub const ESCAPE_PORTAL_AND_PUBLISHED_CALLEE: usize = 8;
+    pub const ESCAPE_FORCE_BY_PORTAL: usize = 9;
+    pub const ESCAPE_FORCE_BY_CALLEE_ONLY: usize = 10;
 
     /// One ring entry per walk: four slots of outcome name (8 ASCII bytes per
     /// slot, little-endian) followed by one slot of packed counters.  A `u64`
     /// export cannot carry a string, and the outcome set is far too large to
     /// spend a tally slot per variant.
-    pub const RING_BASE: usize = 6;
+    pub const RING_BASE: usize = 11;
     pub const RING_ENTRIES: usize = 24;
     pub const RING_STRIDE: usize = 5;
     pub const NAME_SLOTS: usize = 4;

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -4339,6 +4339,11 @@ unsafe extern "C" fn force_pyframe(frame: *mut pyre_interpreter::PyFrame) {
         // with no committed resume pc, so the walk replays from entry —
         // double-applying the residual's non-journaled body effects.
         if traced_frame_escaped && let Some(ptr) = tracing_frame {
+            // Step-0 attribution probe: this clear of the PORTAL's token is
+            // what the post-residual probe reads as an escape and turns into
+            // `VableEscapedDuringResidualCall`, so attributing it names which
+            // disjunct actually owns each abort.
+            pyre_jit_trace::jitcode_dispatch::attribute_last_escape_force();
             force(ptr);
         }
         if live_frame_armed {

--- a/pyre/pyre-jit/src/lib.rs
+++ b/pyre/pyre-jit/src/lib.rs
@@ -63,6 +63,10 @@ pub use pyre_jit_trace::{
     trace_int_binop_ovf, trace_int_compare, trace_unbox_float, trace_unbox_int,
 };
 
+pub fn fbw_diag_counter(i: usize) -> u64 {
+    pyre_jit_trace::trace::fbw_diag::get(i)
+}
+
 /// Diagnostic only: `(oldgen_total_bytes, nursery_used_bytes)` of the wasm
 /// backend's GC on this thread. Lets the wasm runner attribute guest
 /// linear-memory growth to GC-retained objects vs. host-heap allocations.

--- a/pyre/pyre-wasm-runner/src/main.rs
+++ b/pyre/pyre-wasm-runner/src/main.rs
@@ -543,7 +543,7 @@ fn run(module_path: &PathBuf, source: &str, script: &Path) -> Result<i32> {
         // which the guest cannot read. Slot layout in
         // `pyre_jit_trace::trace::fbw_diag`.
         if let Ok(fbw) = instance.get_typed_func::<u32, u64>(&mut store, "pyre_fbw_diag") {
-            const RING_BASE: u32 = 6;
+            const RING_BASE: u32 = 11;
             const RING_ENTRIES: u32 = 24;
             const RING_STRIDE: u32 = 5;
             const NAME_SLOTS: u32 = 4;

--- a/pyre/pyrex/src/lib.rs
+++ b/pyre/pyrex/src/lib.rs
@@ -998,6 +998,17 @@ fn maybe_print_jit_stats() {
         "[jit-stats] mc_diag {} all_descrs={all_descrs_len}",
         majit_metainterp::mc_diag_summary()
     );
+    eprintln!(
+        "[jit-stats] fbw_escape_split portal_only={} published_callee_only={} portal_and_published_callee={}",
+        pyre_jit::fbw_diag_counter(6),
+        pyre_jit::fbw_diag_counter(7),
+        pyre_jit::fbw_diag_counter(8),
+    );
+    eprintln!(
+        "[jit-stats] fbw_force_attrib by_portal={} by_callee_only={}",
+        pyre_jit::fbw_diag_counter(9),
+        pyre_jit::fbw_diag_counter(10),
+    );
     let stats = pyre_jit::eval::driver_pair().0.get_stats();
     eprintln!(
         "[jit-stats] loops_compiled={} bridges_compiled={} loops_aborted={} \


### PR DESCRIPTION
## What this is

Nine commits on the path to removing `VableEscapedDuringResidualCall` (the port of
`pyjitpl.py:3389 vable_after_residual_call` → `SwitchToBlackhole(ABORT_ESCAPE)`), which is
the single largest abort class in the synthetic corpus: **138 of 219 `loops_aborted`**,
against `abort: vable escape: 0` and `forcings: 0` on the same fixtures under real
`pypy3` 7.3.22.

Eight of the nine are **behaviour-neutral at the default configuration** — they build the
frame image that the abort's removal will expose, plus the counters that measure it. The
ninth is a new self-check guard. No committed `.jitstats` baseline moves.

## The commits

| # | what it does |
|---|---|
| 1 | `AGENTS.md`: run the PyPy oracle (`PYPYLOG=jit-summary:- pypy3 <fixture>`) as the first step for a behavioural orthodoxy question |
| 2 | split `sys._getframe` into `sys_getframe` (the `@unwrap_spec` wrapper) and `getframe` (the non-hidden chain walk), matching `pypy/module/sys/vm.py:30` / `:42`, and add `is_builtin_getframe_function` |
| 3 | `check.py` self-check guard: an inlined callee reading its **own** frame image (`_getframe(0)`), the shape `frame_lineno_mid_replay_regression` does not cover |
| 4 | record the inlined callee's Python pc on its virtual frame at may-force boundaries — the coalesced form of `pyopcode.py:200 dispatch_bytecode`'s per-bytecode `last_instr` store |
| 5 | report a virtualizable escape from the vable-token state alone, not from whether the image flush committed (`virtualizable.py:231-246 tracing_after_residual_call`) |
| 6 | attribute every escape force to the **portal** or the **published-callee** disjunct, and export both through `MAJIT_STATS` |
| 7 | write the folded inline-callee `setfield_vable` / `setarrayitem_vable` through to the live frame |
| 8 | materialize the folded inline-callee locals when a residual forces the frames |
| 9 | publish the **callee's own** pc when `LiveLastInstrGuard` retargets to its frame |

## What the counters now say

dynasm release, 356 synthetic fixtures:

```
loops_aborted                  207
attributed escape forces       138   (66.7% of aborts)
  by_portal                     93
  by_callee_only                45   (32.6% of the class, 21.7% of aborts)
```

Per fixture the attribution sums to that fixture's abort count exactly (r1 `5+5=10`,
r3 `5+10=15`) — the check that the counters name aborts rather than calls to the flush.

## Why the abort itself is not removed here

Removing it is measured (`207 → 128`) but regresses one fixture, and this PR does not
carry a change that would need a `.jitstats` re-record to look green.

`getframe_inline_subwalk_multiframe` evaluates `sys._getframe(2).f_locals["base"] + x`.
Suppressing the published-callee disjunct takes it from `loops_aborted=15 /
loops_compiled=0 / guard_failures=0` to `1 / 2 / **8948**` — the loop compiles and then
deopts on every iteration. The compiled loop holds exactly three `CALL_MAY_FORCE`, each
with its own `GUARD_NOT_FORCED`:

| op | source |
|---|---|
| `v35` | `sys._getframe(2)` |
| `v42` | `.f_locals` (`jit_getattr`) |
| `v48` | `["base"]` |

All 8947 deopts report `fail=4` — the guard after **`v42`**, not after `_getframe`.
`GUARD_NOT_FORCED` is one word compare, `cmp [jf_descr], 0`, and the only writer of
`jf_descr` is `Runner::force`, so the guard cannot tell the portal force from the vref
force. Folding `_getframe` alone therefore just moves the deopt one op later:
`.f_locals` lowers to `jit_getattr`, which is `#[jit_may_force]`, and its getset body
calls `force_frame_before_locals_read` unconditionally on the same portal frame.

PyPy has neither residual: `pypy/module/sys/vm.py:41` carries
`@jit.look_inside_iff(lambda space, depth: jit.isconstant(depth))`, and its `f_locals`
read is ordinary looked-inside RPython whose virtualizable force
`jtransform.py:2164-2172` deletes. The `jit-log-opt` oracle for this fixture shows
`force_token()` ×2, `ptr_eq(p41, p0)` + `guard_true` and **no call at all**.

So the remaining work is transparency, not gate-tuning: the constant-depth `_getframe`
arm **and** a non-forcing `f_locals` read. Tracked as follow-ups; this PR lands the frame
image they both depend on.

## Verification

Rebased onto `origin/main` (`9c3888c4`), `.ullbc` re-extracted, all three backends measured
on the rebased tip:

- `check.py --backend dynasm` **372/372**, `cranelift` **372/372**, `wasm` **368/368**
- `cargo test --all --no-default-features --features dynasm` — clean
- `cargo fmt --all -- --check` — clean
- committed `.jitstats` baselines unmoved; `getframe_inline_subwalk_multiframe` stays at
  `loops_aborted=15 / loops_compiled=0 / guard_failures=0 / bridges_compiled=0`
- both `bench/frame_*_regression.py` self-check guards pass
- `r1`–`r10` frame-read repros agree with `PYRE_NO_JIT=1`, CPython and `pypy3`, with two
  exceptions: `r3` and `r8` read `sys._getframe(1).f_lineno` from an inlined callee and
  report the caller's `def` line. Each commit here was measured to leave the `r1`–`r5`
  answers unchanged, and no corpus fixture covers the shape. Filed as a separate
  follow-up; not addressed by this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved `sys._getframe()` behavior, including frame-depth validation and reliable traversal.
  - Fixed frame information exposed by optimized and inlined calls, including line numbers, local variables, and instruction positions.
  - Improved handling of frame state during optimized calls and execution escapes.

- **Diagnostics**
  - Added clearer JIT diagnostics for frame escapes and force decisions.

- **Tests**
  - Added automated regression checks covering repeated frame inspection and multiple execution backends.

- **Documentation**
  - Added guidance for comparing behavior with PyPy when investigating discrepancies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->