### PR TITLE
cpython_tests: record test.test_asyncio as TIMEOUT

### DIFF
--- a/pyre/cpython_tests/baseline.json
+++ b/pyre/cpython_tests/baseline.json
@@ -56,8 +56,9 @@
       "dynasm": "CRASH"
     },
     "test.test_asyncio": {
-      "cranelift": "PASS",
-      "dynasm": "PASS"
+      "cranelift": "TIMEOUT",
+      "dynasm": "TIMEOUT",
+      "reason": "stalls in about one arm in four, at a test that wanders"
     },
     "test.test_atexit": {
       "dynasm": "IMPORTERROR"


### PR DESCRIPTION
`test.test_asyncio` was recorded as a gated `PASS`. It stalls in roughly one full-suite arm in four, so the gate is a coin flip and no `--timeout` value changes that.

## What was measured

The stalled test wanders. Four instrumented full-package arms landed on three different tests:

| base | arms | outcome |
|---|---|---|
| `e07e5258081` | 4 | 3 completed (105s / 101s / ~160s user CPU), 1 hung at `test_events.PollEventLoopTests.test_subprocess_terminate` |
| `a036267b06f` | 4 | 0 completed; hung at `test_futures.PyFutureTests.test_wrap_future` and at `test_locks.BarrierTests.test_filling_tasks_check_return_value` |

The stall wears two masks, both observed:

* **blocked** — 0% CPU, accumulated `ps` TIME frozen at `0:20.59` for 380s;
* **spinning** — 100% CPU in `eval_loop`, with a monotonically growing `minimarkpage::ArenaCollection::_rehash_arenas_lists` share of the sampled tops (141 at t=100s, 340 at t=160s, 831 at t=240s). That function is O(arenas) per major-GC sweep, so a growing share under a fixed workload means the arena count is growing.

## The spinning mask is not extra work

An interleaved A/B of all 34 `test_asyncio` submodules across the two bases totals **73.5s vs 73.3s** of user CPU, with no submodule outside the sub-0.5s noise band. The extra CPU seen at package scope is the one spinning test, not the module costing more per test.

## Why TIMEOUT and not SKIP

A non-`PASS` baseline is not run by the default gate. `SKIP` is the curated "do not run" decision reserved for `KNOWN_SKIPS`, and a `SKIP` entry is never exercised again — `TIMEOUT` is the observed result and keeps the module running under `--full` and `--update-baseline`.

The `cranelift` entry is lowered alongside `dynasm` on the measurement that this stall family reproduces under `PYRE_NO_JIT=1`, so it is not backend-specific; only `dynasm` was measured here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated asynchronous I/O test baselines to record timeout outcomes for the Cranelift and DynASM configurations.
  * Added stall information to improve diagnostic reporting for these test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->