### PR TITLE
gateway, pycode: split the fsencode boundary; report the byte-exact co_filename from every reader

### DIFF
--- a/pyre/extra_tests/parity_tests/os_boundary_surrogateescape.py
+++ b/pyre/extra_tests/parity_tests/os_boundary_surrogateescape.py
@@ -49,14 +49,17 @@ for call in (
 
 # `interp_socket.py:157-159` deliberately uses raw `space.fsencode`: a leading
 # null byte names Linux's abstract namespace and must reach the OS unchanged.
+name = "\x00pyre-os-boundary-%d" % os.getpid()
 s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
 try:
     try:
-        s.bind("\x00pyre-os-boundary-%d" % os.getpid())
+        s.bind(name)
     except ValueError:
         raise AssertionError("AF_UNIX abstract path rejected its null") from None
     except OSError:
         pass
+    else:
+        assert s.getsockname() == name.encode(), s.getsockname()
 finally:
     s.close()
 

--- a/pyre/extra_tests/parity_tests/os_boundary_surrogateescape.py
+++ b/pyre/extra_tests/parity_tests/os_boundary_surrogateescape.py
@@ -35,6 +35,31 @@ os.waitpid(pid, 0)
 pid = os.posix_spawn(TRUE, [TRUE], {"PYRE_X": "v\udcff"})
 os.waitpid(pid, 0)
 
+for call in (
+    lambda: os.system("true a\x00b"),
+    lambda: os.posix_spawn(TRUE, [TRUE, "a\x00b"], {}),
+    lambda: open("a\x00b"),
+):
+    try:
+        call()
+    except ValueError as exc:
+        assert "embedded null byte" in str(exc), str(exc)
+    else:
+        raise AssertionError("embedded null byte was accepted")
+
+# `interp_socket.py:157-159` deliberately uses raw `space.fsencode`: a leading
+# null byte names Linux's abstract namespace and must reach the OS unchanged.
+s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+try:
+    try:
+        s.bind("\x00pyre-os-boundary-%d" % os.getpid())
+    except ValueError:
+        raise AssertionError("AF_UNIX abstract path rejected its null") from None
+    except OSError:
+        pass
+finally:
+    s.close()
+
 # AF_UNIX: bind to a path whose last byte has no UTF-8 spelling.  Whether the
 # kernel accepts it is a platform question — macOS refuses a non-UTF-8 path
 # with EILSEQ — so the assertion is that the *encoding* is not what refuses:

--- a/pyre/extra_tests/parity_tests/traceback_filename_surrogateescape.py
+++ b/pyre/extra_tests/parity_tests/traceback_filename_surrogateescape.py
@@ -1,0 +1,80 @@
+"""Every reader of `co_filename` reports the byte-exact filesystem spelling.
+
+`pycode.py:135 self.co_filename = filename` keeps the raw path, so the frame
+repr (`pyframe.py:849-853 descr_repr`), the warning location, a coroutine's
+origin and the rendered traceback all name what the `co_filename` getter hands
+out — a path byte with no UTF-8 spelling must not fold to U+FFFD on the way.
+"""
+
+import _imp
+import io
+import subprocess
+import sys
+import traceback
+import warnings
+
+FILENAME = "x\udcff.py"
+
+
+def stamped(source):
+    """A code object carrying a filename no UTF-8 encoder can spell."""
+    code = compile(source, "orig.py", "exec")
+    _imp._fix_co_filename(code, FILENAME)
+    return code
+
+
+# The stdlib formatter reads `co_filename` directly, so this is the anchor the
+# rest are measured against.
+try:
+    exec(stamped("raise ValueError('boom')"), {})
+except ValueError:
+    buf = io.StringIO()
+    traceback.print_exc(file=buf)
+    text = buf.getvalue()
+assert FILENAME in text, ascii(text)
+assert "�" not in text, ascii(text)
+
+# `descr_repr` interpolates the filename rather than its repr, so the surrogate
+# reaches the result unescaped; CPython formats that field with `%R` and spells
+# it `x\udcff.py`.  Both keep the byte, so only the folding is asserted here.
+namespace = {"sys": sys}
+exec(stamped("def capture():\n    return sys._getframe()\nframe = capture()"), namespace)
+frame_repr = repr(namespace["frame"])
+assert "�" not in frame_repr, ascii(frame_repr)
+
+# The warning's location comes from the frame's own code object.
+with warnings.catch_warnings(record=True) as caught:
+    warnings.simplefilter("always")
+    exec(stamped("import warnings\nwarnings.warn('w')"), {})
+assert caught[0].filename == FILENAME, ascii(caught[0].filename)
+
+# `cr_origin` summarises the same frames.
+sys.set_coroutine_origin_tracking_depth(2)
+namespace = {}
+try:
+    exec(stamped("async def c():\n    pass\ncoro = c()"), namespace)
+    origin = namespace["coro"].cr_origin
+    namespace["coro"].close()
+finally:
+    sys.set_coroutine_origin_tracking_depth(0)
+assert origin[0][0] == FILENAME, ascii(origin[0][0])
+
+# The unhandled-exception renderer writes to stderr with no text layer in
+# between, so the name arrives as the filesystem bytes and decodes back with
+# the same error handler that produced it.
+if sys.platform != "win32":
+    child = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import _imp\n"
+            "code = compile(\"raise ValueError('boom')\", 'orig.py', 'exec')\n"
+            "_imp._fix_co_filename(code, 'x\\udcff.py')\n"
+            "exec(code)\n",
+        ],
+        capture_output=True,
+    )
+    stderr = child.stderr.decode(errors="surrogateescape")
+    assert "�" not in stderr, ascii(stderr)
+
+print("OK")

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -14811,35 +14811,9 @@ fn open_raw_file(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         ));
     }
 
-    // The OS path is a byte string.  A `str` path may carry surrogateescape
-    // code points, which spell bytes that are not valid UTF-8; folding those
-    // to U+FFFD would open a different file, so the encoded bytes are kept
-    // and handed to the seam verbatim.
-    let path_bytes = unsafe {
-        if pyre_object::is_str(path_obj) {
-            crate::gateway::fsencode_bytes_w(path_obj)?
-        } else if pyre_object::bytesobject::is_bytes_like(path_obj) {
-            pyre_object::bytesobject::bytes_like_data(path_obj).to_vec()
-        } else if let Some(fspath_fn) = crate::typedef::r#type(path_obj)
-            .and_then(|pt| crate::baseobjspace::lookup_in_type(pt.as_ptr(), "__fspath__"))
-        {
-            // `type(path).__fspath__(path)` — unbound descriptor + single arg.
-            let result = crate::call::call_function_impl_result(fspath_fn, &[path_obj])?;
-            if pyre_object::is_str(result) {
-                crate::gateway::fsencode_bytes_w(result)?
-            } else if pyre_object::bytesobject::is_bytes_like(result) {
-                pyre_object::bytesobject::bytes_like_data(result).to_vec()
-            } else {
-                return Err(crate::PyError::type_error(
-                    "open(): path should be str, bytes, os.PathLike",
-                ));
-            }
-        } else {
-            return Err(crate::PyError::type_error(
-                "open(): path should be str, bytes, os.PathLike",
-            ));
-        }
-    };
+    // Keep the encoded bytes: surrogateescape code points can spell bytes
+    // that are not valid UTF-8, and the OS seam must receive them verbatim.
+    let path_bytes = crate::gateway::fsencode_bytes_w(path_obj)?;
     // `host_env::fs` takes a `Path`; only the seam consumes the raw bytes.
     #[cfg(unix)]
     let path = std::ffi::OsString::from_vec(path_bytes.clone());

--- a/pyre/pyre-interpreter/src/display.rs
+++ b/pyre/pyre-interpreter/src/display.rs
@@ -484,6 +484,12 @@ pub unsafe fn py_repr_wtf8(obj: PyObjectRef) -> Result<Wtf8Buf, crate::PyError> 
         }
         if !obj.is_null() {
             let tp = (*obj).ob_type;
+            // `pyframe.py:849-853 descr_repr` may carry a lone surrogate in
+            // the filename, so keep an exact frame on the WTF-8 path instead
+            // of delegating through `py_repr`'s Rust `String` result.
+            if std::ptr::eq(tp, &crate::pyframe::FRAME_TYPE as *const PyType) {
+                return Ok((&*(obj as *const crate::PyFrame)).descr_repr());
+            }
             // A builtin leaf subclass's `__repr__` override may return a
             // lone surrogate; read it as WTF-8 rather than folding to `&str`.
             if let Some(r) = builtin_subclass_dunder_obj(obj, tp, "__repr__")? {

--- a/pyre/pyre-interpreter/src/error.rs
+++ b/pyre/pyre-interpreter/src/error.rs
@@ -2748,9 +2748,6 @@ fn write_traceback_chain_from_tb<W: Write>(
         writer.write_all(b"  File \"")?;
         writer.write_all(&filename)?;
         writeln!(writer, "\", line {lineno}, in {funcname}")?;
-        // A source path with no UTF-8 spelling simply does not resolve, and
-        // `error.py:150 linecache.getline` likewise renders nothing then.
-        let source_filename = String::from_utf8_lossy(&filename);
         // `FrameSummary._set_lines` collects every line the failing
         // instruction spans, so a statement written across several lines (a
         // class body, a multi-line call) shows all of them, dedented by the
@@ -2761,7 +2758,7 @@ fn write_traceback_chain_from_tb<W: Write>(
         {
             let span: Vec<String> = (start_line..=end_line)
                 .map(|n| {
-                    read_source_line(&source_filename, n as i64)
+                    read_source_line(&filename, n as i64)
                         .map_or(String::new(), |l| l.trim_end().to_string())
                 })
                 .collect();
@@ -2770,7 +2767,7 @@ fn write_traceback_chain_from_tb<W: Write>(
                     writeln!(writer, "    {line}")?;
                 }
             }
-        } else if let Some(line) = read_source_line(&source_filename, lineno) {
+        } else if let Some(line) = read_source_line(&filename, lineno) {
             let raw_line = line.trim_end_matches(['\n', '\r']);
             let shown_line = raw_line.trim_start();
             writeln!(writer, "    {shown_line}")?;
@@ -2952,10 +2949,26 @@ fn traceback_anchors(raw_line: &str, start_col: usize, end_col: usize) -> Option
 /// Open `filename` and return its `lineno`-th line (1-indexed).  Returns
 /// `None` for synthetic / unreadable sources — matches PyPy's silent
 /// `linecache.getline` fallback at `error.py:150`.
-fn read_source_line(filename: &str, lineno: i64) -> Option<String> {
-    if lineno <= 0 || filename.is_empty() || filename.starts_with('<') {
+///
+/// The name arrives as the filesystem bytes the code object carries, because
+/// `linecache.getline` is handed `co_filename` itself: a path spelling a byte
+/// with no UTF-8 form still has to open the file it names, which the lossy
+/// spelling no longer does.
+fn read_source_line(filename: &[u8], lineno: i64) -> Option<String> {
+    if lineno <= 0 || filename.is_empty() || filename.first() == Some(&b'<') {
         return None;
     }
+    #[cfg(all(feature = "host_env", unix))]
+    let path = {
+        use std::os::unix::ffi::OsStrExt;
+        std::path::Path::new(std::ffi::OsStr::from_bytes(filename))
+    };
+    // Elsewhere the platform has no bytes spelling of a path, so a name that is
+    // not valid UTF-8 simply does not resolve.
+    #[cfg(all(feature = "host_env", not(unix)))]
+    let lossy = String::from_utf8_lossy(filename);
+    #[cfg(all(feature = "host_env", not(unix)))]
+    let path = std::path::Path::new(lossy.as_ref());
     #[cfg(feature = "host_env")]
     {
         // Read through the import machinery's source provider, not std::fs:
@@ -2964,11 +2977,15 @@ fn read_source_line(filename: &str, lineno: i64) -> Option<String> {
         // On wasm32 the provider is the embedder's — the host-FS bridge for the
         // native-host build, `NullSourceProvider` in a browser — so the same
         // call renders the offending line wherever one is actually reachable.
-        let bytes = crate::importing::read_source_bytes(std::path::Path::new(filename)).ok()?;
+        let bytes = crate::importing::read_source_bytes(path).ok()?;
         // `linecache` opens with `tokenize.open`, so the BOM and the PEP 263
         // cookie decide the encoding; a plain UTF-8 read drops the whole line
-        // for a file declaring anything else.
-        let content = crate::compile::decode_source_bytes(&bytes, filename, false).ok()?;
+        // for a file declaring anything else.  The name reaches the decode only
+        // to report a failure this caller discards, so the lossy spelling of a
+        // path with no UTF-8 form is enough there.
+        let content =
+            crate::compile::decode_source_bytes(&bytes, &String::from_utf8_lossy(filename), false)
+                .ok()?;
         content
             .lines()
             .nth((lineno - 1) as usize)

--- a/pyre/pyre-interpreter/src/error.rs
+++ b/pyre/pyre-interpreter/src/error.rs
@@ -2688,7 +2688,7 @@ fn write_traceback_chain_from_tb<W: Write>(
     let _roots = pyre_object::gc_roots::push_roots();
     // `StackSummary.format` dedup state: the previous frame's identity and how
     // many consecutive frames have carried it.
-    let mut last: Option<(String, i64, String)> = None;
+    let mut last: Option<(Vec<u8>, i64, String)> = None;
     let mut repeats: usize = 0;
     while !tb.is_null() {
         let tb_slot = pyre_object::gc_roots::shadow_stack_len();
@@ -2701,14 +2701,14 @@ fn write_traceback_chain_from_tb<W: Write>(
         let lineno = unsafe { crate::pytraceback::w_pytraceback_get_lineno(current_tb) };
         let lasti = unsafe { crate::pytraceback::w_pytraceback_get_lasti(current_tb) };
         let (filename, funcname, location) = if w_code.is_null() {
-            (String::from("<unknown>"), String::from("<unknown>"), None)
+            (b"<unknown>".to_vec(), String::from("<unknown>"), None)
         } else {
             // `w_code` is a GC-rooted `PyCode` pointer captured
             // at `record_application_traceback` time; the inner
             // `CodeObject` lives as long as `w_code` is reachable.
             let code_obj = unsafe { crate::w_code_get_ptr(w_code) } as *const crate::CodeObject;
             if code_obj.is_null() {
-                (String::from("<unknown>"), String::from("<unknown>"), None)
+                (b"<unknown>".to_vec(), String::from("<unknown>"), None)
             } else {
                 let code = unsafe { &*code_obj };
                 let location = usize::try_from(lasti)
@@ -2723,7 +2723,7 @@ fn write_traceback_chain_from_tb<W: Write>(
                         )
                     });
                 (
-                    code.source_path.to_string(),
+                    unsafe { crate::pycode::code_filename_bytes(w_code) },
                     code.obj_name.to_string(),
                     location,
                 )
@@ -2742,11 +2742,15 @@ fn write_traceback_chain_from_tb<W: Write>(
             continue;
         }
         let (filename, lineno, funcname) = key;
-        writeln!(
-            writer,
-            "  File \"{}\", line {}, in {}",
-            filename, lineno, funcname
-        )?;
+        // The filesystem bytes, not their WTF-8 decoding: a lone surrogate has
+        // no UTF-8 spelling either way, and the byte form is the one that
+        // still names the file to whatever reads the stream.
+        writer.write_all(b"  File \"")?;
+        writer.write_all(&filename)?;
+        writeln!(writer, "\", line {lineno}, in {funcname}")?;
+        // A source path with no UTF-8 spelling simply does not resolve, and
+        // `error.py:150 linecache.getline` likewise renders nothing then.
+        let source_filename = String::from_utf8_lossy(&filename);
         // `FrameSummary._set_lines` collects every line the failing
         // instruction spans, so a statement written across several lines (a
         // class body, a multi-line call) shows all of them, dedented by the
@@ -2757,7 +2761,7 @@ fn write_traceback_chain_from_tb<W: Write>(
         {
             let span: Vec<String> = (start_line..=end_line)
                 .map(|n| {
-                    read_source_line(&filename, n as i64)
+                    read_source_line(&source_filename, n as i64)
                         .map_or(String::new(), |l| l.trim_end().to_string())
                 })
                 .collect();
@@ -2766,7 +2770,7 @@ fn write_traceback_chain_from_tb<W: Write>(
                     writeln!(writer, "    {line}")?;
                 }
             }
-        } else if let Some(line) = read_source_line(&filename, lineno) {
+        } else if let Some(line) = read_source_line(&source_filename, lineno) {
             let raw_line = line.trim_end_matches(['\n', '\r']);
             let shown_line = raw_line.trim_start();
             writeln!(writer, "    {shown_line}")?;

--- a/pyre/pyre-interpreter/src/gateway.rs
+++ b/pyre/pyre-interpreter/src/gateway.rs
@@ -1605,9 +1605,11 @@ pub fn fsencode_bytes_w_with_kind(
             let result_slot = pyre_object::gc_roots::shadow_stack_len();
             pyre_object::gc_roots::pin_root(result);
             let result = pyre_object::gc_roots::shadow_stack_get(result_slot);
-            if pyre_object::bytesobject::is_bytes_like(result) {
+            // interp_posix.py:3049-3051 accepts only `str` or `bytes` back from
+            // `__fspath__`; a `bytearray` is a readable buffer but not a path.
+            if pyre_object::bytesobject::is_bytes(result) {
                 (
-                    pyre_object::bytesobject::bytes_like_data(result).to_vec(),
+                    pyre_object::bytesobject::w_bytes_data(result).to_vec(),
                     true,
                 )
             } else if pyre_object::is_str(result) {

--- a/pyre/pyre-interpreter/src/gateway.rs
+++ b/pyre/pyre-interpreter/src/gateway.rs
@@ -1550,6 +1550,14 @@ pub fn fsdecode_filename_bytes(data: &[u8]) -> pyre_object::PyObjectRef {
     crate::typedef::charp2uni(data)
 }
 
+/// [`fsdecode_filename_bytes`]'s buffer, for a caller that assembles the
+/// filename into a larger piece of text rather than handing it out as an
+/// object. A Rust `String` cannot hold the lone surrogate a non-UTF-8 path byte
+/// decodes to, so that text has to be built as WTF-8 throughout.
+pub fn fsdecode_filename_wtf8(data: &[u8]) -> rustpython_wtf8::Wtf8Buf {
+    crate::typedef::charp2uni_wtf8(data)
+}
+
 /// [`fsencode_bytes_w`] paired with the `bytes`-ness of the resolved object;
 /// see [`fsencode_w_with_kind`] for why the two are produced together.
 pub fn fsencode_bytes_w_with_kind(

--- a/pyre/pyre-interpreter/src/gateway.rs
+++ b/pyre/pyre-interpreter/src/gateway.rs
@@ -1555,37 +1555,78 @@ pub fn fsdecode_filename_bytes(data: &[u8]) -> pyre_object::PyObjectRef {
 pub fn fsencode_bytes_w_with_kind(
     obj: pyre_object::PyObjectRef,
 ) -> Result<(Vec<u8>, bool), crate::PyError> {
-    unsafe {
-        if pyre_object::is_str(obj) {
-            return Ok((fsencode_str_bytes(obj)?, false));
-        }
+    let _roots = pyre_object::gc_roots::push_roots();
+    let obj_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(obj);
+
+    let (data, is_bytes) = unsafe {
+        let obj = pyre_object::gc_roots::shadow_stack_get(obj_slot);
         if pyre_object::bytesobject::is_bytes_like(obj) {
-            let data = pyre_object::bytesobject::bytes_like_data(obj);
-            return Ok((data.to_vec(), true));
-        }
-    }
-    // `type(path).__fspath__(path)` — the descriptor read off the type is
-    // unbound, so `path` is supplied as the sole argument.
-    if let Some(fspath_fn) = crate::typedef::r#type(obj)
-        .and_then(|pt| unsafe { crate::baseobjspace::lookup_in_type(pt.as_ptr(), "__fspath__") })
-    {
-        let result = crate::call::call_function_impl_result(fspath_fn, &[obj])?;
-        unsafe {
-            if pyre_object::is_str(result) {
-                return Ok((fsencode_str_bytes(result)?, false));
+            // baseobjspace.py:1975-1977: pyre's readable-buffer set here is
+            // bytes | bytearray, so a buffer that is not bytes is bytearray.
+            if !pyre_object::bytesobject::is_bytes(obj) {
+                let type_name = crate::type_methods::arg_type_name(obj);
+                crate::warn::warn_deprecation(&format!(
+                    "path should be string, bytes, or os.PathLike, not {type_name}"
+                ))?;
             }
+            let obj = pyre_object::gc_roots::shadow_stack_get(obj_slot);
+            (
+                pyre_object::bytesobject::bytes_like_data(obj).to_vec(),
+                true,
+            )
+        } else if pyre_object::is_str(obj) {
+            (fsencode(obj)?, false)
+        } else {
+            // `type(path).__fspath__(path)` — the descriptor read off the type is
+            // unbound, so `path` is supplied as the sole argument.
+            let Some(fspath_fn) = crate::typedef::r#type(obj)
+                .and_then(|pt| crate::baseobjspace::lookup_in_type(pt.as_ptr(), "__fspath__"))
+            else {
+                return Err(crate::PyError::type_error(format!(
+                    "expected str, bytes or os.PathLike object, not {}",
+                    crate::type_methods::arg_type_name(obj)
+                )));
+            };
+            let fspath_slot = pyre_object::gc_roots::shadow_stack_len();
+            pyre_object::gc_roots::pin_root(fspath_fn);
+            let result = crate::call::call_function_impl_result(
+                pyre_object::gc_roots::shadow_stack_get(fspath_slot),
+                &[pyre_object::gc_roots::shadow_stack_get(obj_slot)],
+            )?;
+            let result_slot = pyre_object::gc_roots::shadow_stack_len();
+            pyre_object::gc_roots::pin_root(result);
+            let result = pyre_object::gc_roots::shadow_stack_get(result_slot);
             if pyre_object::bytesobject::is_bytes_like(result) {
-                let data = pyre_object::bytesobject::bytes_like_data(result);
-                return Ok((data.to_vec(), true));
+                (
+                    pyre_object::bytesobject::bytes_like_data(result).to_vec(),
+                    true,
+                )
+            } else if pyre_object::is_str(result) {
+                (fsencode(result)?, false)
+            } else {
+                // interp_posix.py:3053-3058 names both the object that was asked
+                // and the type its `__fspath__` answered with.
+                let obj = pyre_object::gc_roots::shadow_stack_get(obj_slot);
+                return Err(crate::PyError::type_error(format!(
+                    "expected {}.__fspath__() to return str or bytes, not {}",
+                    crate::type_methods::arg_type_name(obj),
+                    crate::type_methods::arg_type_name(result)
+                )));
             }
         }
+    };
+    // baseobjspace.py:2016-2017 `bytesbuf0_w` rejects embedded nulls.
+    if data.contains(&0) {
+        return Err(crate::PyError::value_error("embedded null byte"));
     }
-    Err(crate::PyError::type_error(
-        "expected str, bytes or os.PathLike",
-    ))
+    Ok((data, is_bytes))
 }
 
-fn fsencode_str_bytes(obj: pyre_object::PyObjectRef) -> Result<Vec<u8>, crate::PyError> {
+/// `baseobjspace.py:1962 space.fsencode` — the plain filesystem encode of a
+/// `str`, with no argument conversion, `DeprecationWarning`, or embedded-null
+/// rejection. The caller must already have established that `obj` is a `str`.
+pub fn fsencode(obj: pyre_object::PyObjectRef) -> Result<Vec<u8>, crate::PyError> {
     let wtf8 = unsafe { pyre_object::w_str_get_wtf8(obj) };
     let mut out = Vec::with_capacity(wtf8.len());
     for (pos, cp) in wtf8.code_points().enumerate() {

--- a/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
+++ b/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
@@ -2182,10 +2182,10 @@ fn pack_inet_addr(
         // `interp_socket.py:157-159 w_address = space.fsencode(w_address)`,
         // with the upstream note that it deliberately avoids `fsencode_w`
         // because Linux allows embedded NULs in an abstract-namespace path.
-        // The encoder used here performs no null check either.
+        // The raw `fsencode` preserves that carve-out.
         let path_bytes_vec: Vec<u8> = unsafe {
             if pyre_object::is_str(path_obj) {
-                crate::gateway::fsencode_bytes_w(path_obj)?
+                crate::gateway::fsencode(path_obj)?
             } else if pyre_object::bytesobject::is_bytes_like(path_obj) {
                 pyre_object::bytesobject::bytes_like_data(path_obj).to_vec()
             } else {

--- a/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
+++ b/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
@@ -1797,7 +1797,7 @@ fn init_socket_getaddrinfo(ns: pyre_object::PyObjectRef) {
                         &mut storage as *mut _ as *mut u8,
                         copy_len,
                     );
-                    let addr = unpack_inet_addr(&storage);
+                    let addr = unpack_inet_addr(&storage, copy_len as libc::socklen_t);
                     items.push(pyre_object::w_tuple_new(vec![
                         pyre_object::w_int_new(ai.ai_family as i64),
                         pyre_object::w_int_new(ai.ai_socktype as i64),
@@ -2162,6 +2162,12 @@ fn socket_get_so_protocol(_fd: libc::c_int) -> Result<libc::c_int, crate::PyErro
 // (host, port, flowinfo, scopeid).  These helpers convert to/from
 // `sockaddr_storage`.
 
+/// `offsetof(_c.sockaddr_un, 'c_sun_path')` (`rsocket.py:403 minlen`) — where
+/// the name starts inside the address, and therefore the part of an address
+/// length that is not name.
+#[cfg(unix)]
+const SUN_PATH_OFFSET: usize = core::mem::offset_of!(libc::sockaddr_un, sun_path);
+
 #[cfg(unix)]
 fn pack_inet_addr(
     family: libc::c_int,
@@ -2196,17 +2202,21 @@ fn pack_inet_addr(
         };
         let sun = unsafe { &mut *(&mut storage as *mut _ as *mut libc::sockaddr_un) };
         sun.sun_family = libc::AF_UNIX as libc::sa_family_t;
-        if path_bytes_vec.len() >= sun.sun_path.len() {
+        let abstract_name = cfg!(target_os = "linux") && path_bytes_vec.first() == Some(&0);
+        // `rsocket.py:412-420 UNIXAddress.__init__`: an abstract name may fill
+        // `sun_path` exactly, a regular one has to leave room for its
+        // terminator.
+        let capacity = sun.sun_path.len() - usize::from(!abstract_name);
+        if path_bytes_vec.len() > capacity {
             return Err(crate::PyError::os_error("AF_UNIX path too long"));
         }
         for (i, &b) in path_bytes_vec.iter().enumerate() {
             sun.sun_path[i] = b as libc::c_char;
         }
-        return Ok((
-            storage,
-            (core::mem::size_of::<libc::sa_family_t>() + path_bytes_vec.len() + 1)
-                as libc::socklen_t,
-        ));
+        // `rsocket.py:409-410 self.setdata(sun, baseofs + len(path))`: the
+        // terminator is counted only for a regular name that has one.
+        let addrlen = SUN_PATH_OFFSET + path_bytes_vec.len() + usize::from(!abstract_name);
+        return Ok((storage, addrlen as libc::socklen_t));
     }
 
     if !unsafe { pyre_object::is_tuple(addr) } {
@@ -2343,7 +2353,10 @@ fn pack_inet_addr(
 }
 
 #[cfg(unix)]
-fn unpack_inet_addr(storage: &libc::sockaddr_storage) -> pyre_object::PyObjectRef {
+fn unpack_inet_addr(
+    storage: &libc::sockaddr_storage,
+    addrlen: libc::socklen_t,
+) -> pyre_object::PyObjectRef {
     let family = storage.ss_family as libc::c_int;
     if family == libc::AF_INET {
         let sin = unsafe { &*(storage as *const _ as *const libc::sockaddr_in) };
@@ -2391,15 +2404,27 @@ fn unpack_inet_addr(storage: &libc::sockaddr_storage) -> pyre_object::PyObjectRe
         ])
     } else if family == libc::AF_UNIX {
         let sun = unsafe { &*(storage as *const _ as *const libc::sockaddr_un) };
-        let end = sun
-            .sun_path
-            .iter()
-            .position(|&b| b == 0)
-            .unwrap_or(sun.sun_path.len());
+        let maxlength = (addrlen as usize)
+            .saturating_sub(SUN_PATH_OFFSET)
+            .min(sun.sun_path.len());
+        let abstract_name = cfg!(target_os = "linux") && maxlength > 0 && sun.sun_path[0] == 0;
+        let end = if abstract_name {
+            maxlength
+        } else {
+            sun.sun_path[..maxlength]
+                .iter()
+                .position(|&b| b == 0)
+                .unwrap_or(maxlength)
+        };
         let bytes: Vec<u8> = sun.sun_path[..end].iter().map(|&b| b as u8).collect();
-        // `interp_socket.py:47 space.newfilename(path)`: read-back uses the filesystem
-        // decoding so a byte with no UTF-8 spelling survives the round trip.
-        crate::gateway::fsdecode_filename_bytes(&bytes)
+        if abstract_name {
+            // `interp_socket.py:45 space.newbytes(path)`: abstract names are bytes.
+            pyre_object::bytesobject::w_bytes_from_bytes(&bytes)
+        } else {
+            // `interp_socket.py:47 space.newfilename(path)`: read-back uses the filesystem
+            // decoding so a byte with no UTF-8 spelling survives the round trip.
+            crate::gateway::fsdecode_filename_bytes(&bytes)
+        }
     } else {
         pyre_object::w_tuple_new(vec![])
     }
@@ -2767,7 +2792,7 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
                     libc::fcntl(cfd, libc::F_SETFD, libc::FD_CLOEXEC);
                 }
                 let new_sock = socket_from_fd(cfd, family, ty, proto);
-                let addr = unpack_inet_addr(&storage);
+                let addr = unpack_inet_addr(&storage, slen);
                 Ok(pyre_object::w_tuple_new(vec![new_sock, addr]))
             },
             1,
@@ -2806,7 +2831,7 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
                 unsafe {
                     libc::fcntl(cfd, libc::F_SETFD, libc::FD_CLOEXEC);
                 }
-                let addr = unpack_inet_addr(&storage);
+                let addr = unpack_inet_addr(&storage, slen);
                 Ok(pyre_object::w_tuple_new(vec![
                     pyre_object::w_int_new(cfd as i64),
                     addr,
@@ -3142,7 +3167,7 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
                 crate::module::signal::interp_signal::checksignals_now()?;
             };
             buf.truncate(got as usize);
-            let addr = unpack_inet_addr(&storage);
+            let addr = unpack_inet_addr(&storage, slen);
             Ok(pyre_object::w_tuple_new(vec![
                 pyre_object::bytesobject::w_bytes_from_bytes(&buf),
                 addr,
@@ -3287,7 +3312,7 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
                 // (`converted_error` eintr_retry).
                 crate::module::signal::interp_signal::checksignals_now()?;
             };
-            let addr = unpack_inet_addr(&storage);
+            let addr = unpack_inet_addr(&storage, slen);
             Ok(pyre_object::w_tuple_new(vec![
                 pyre_object::w_int_new(got as i64),
                 addr,
@@ -3350,7 +3375,7 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
             let mut data = vec![0u8; bufsize];
             let mut control = vec![0u8; ancbufsize];
             let mut storage: libc::sockaddr_storage = unsafe { std::mem::zeroed() };
-            let (got, msg_flags) = loop {
+            let (got, msg_flags, msg_namelen) = loop {
                 let mut iov = libc::iovec {
                     iov_base: data.as_mut_ptr() as *mut libc::c_void,
                     iov_len: bufsize,
@@ -3368,7 +3393,7 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
                     libc::recvmsg(fd, &mut msg, flags)
                 });
                 if r >= 0 {
-                    break (r, msg.msg_flags);
+                    break (r, msg.msg_flags, msg.msg_namelen);
                 }
                 if errno != libc::EINTR {
                     return Err(socket_io_err(std::io::Error::from_raw_os_error(errno)));
@@ -3413,7 +3438,7 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
                     }
                 }
             }
-            let addr = unpack_inet_addr(&storage);
+            let addr = unpack_inet_addr(&storage, msg_namelen);
             Ok(pyre_object::w_tuple_new(vec![
                 pyre_object::bytesobject::w_bytes_from_bytes(&data),
                 pyre_object::w_list_new(anc_items),
@@ -3502,7 +3527,7 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
                 .collect();
             let mut control = vec![0u8; ancbufsize];
             let mut storage: libc::sockaddr_storage = unsafe { std::mem::zeroed() };
-            let (got, msg_flags, controllen) = loop {
+            let (got, msg_flags, msg_namelen, controllen) = loop {
                 let mut msg: libc::msghdr = unsafe { std::mem::zeroed() };
                 msg.msg_name = &mut storage as *mut _ as *mut libc::c_void;
                 msg.msg_namelen = core::mem::size_of::<libc::sockaddr_storage>() as libc::socklen_t;
@@ -3516,7 +3541,7 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
                     libc::recvmsg(fd, &mut msg, flags)
                 });
                 if r >= 0 {
-                    break (r, msg.msg_flags, msg.msg_controllen);
+                    break (r, msg.msg_flags, msg.msg_namelen, msg.msg_controllen);
                 }
                 if errno != libc::EINTR {
                     return Err(socket_io_err(std::io::Error::from_raw_os_error(errno)));
@@ -3558,7 +3583,7 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
                     }
                 }
             }
-            let addr = unpack_inet_addr(&storage);
+            let addr = unpack_inet_addr(&storage, msg_namelen);
             Ok(pyre_object::w_tuple_new(vec![
                 pyre_object::w_int_new(got as i64),
                 pyre_object::w_list_new(anc_items),
@@ -3782,7 +3807,7 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
                 if r != 0 {
                     return Err(socket_io_err(std::io::Error::last_os_error()));
                 }
-                Ok(unpack_inet_addr(&storage))
+                Ok(unpack_inet_addr(&storage, slen))
             },
             1,
         ),
@@ -3803,7 +3828,7 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
                 if r != 0 {
                     return Err(socket_io_err(std::io::Error::last_os_error()));
                 }
-                Ok(unpack_inet_addr(&storage))
+                Ok(unpack_inet_addr(&storage, slen))
             },
             1,
         ),

--- a/pyre/pyre-interpreter/src/module/_warnings/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_warnings/mod.rs
@@ -219,9 +219,8 @@ fn setup_context(
         (w_str_new("sys"), 1, globals)
     } else {
         let frame = unsafe { &*frame };
-        let code = unsafe { &*crate::pyframe::pyframe_get_pycode(frame) };
         (
-            w_str_new(&code.source_path),
+            unsafe { crate::pycode::w_code_filename_obj(frame.fget_f_code()) },
             frame.get_last_lineno() as i64,
             frame.get_w_globals(),
         )

--- a/pyre/pyre-interpreter/src/pycode.rs
+++ b/pyre/pyre-interpreter/src/pycode.rs
@@ -161,12 +161,12 @@ pub struct PyCode {
     /// already the exact UTF-8 spelling, avoiding an allocation for compiled
     /// source paths and ordinary filename replacements.
     ///
-    /// Do not add the derived `w_filename` cache from `pycode.py:136` while
-    /// `PyCode` is prebuilt-immortal. An unrooted movable child would only be
-    /// marked on the first major collection after `GCFLAG_VISITED` latches.
-    /// Such a cache requires forwarding on every collection, as `w_globals`
-    /// is registered in `W_GLOBALS_STAMPED_CODES` and forwarded by
-    /// `eval::walk_raw_code_roots`.
+    /// Do not add the derived `pycode.py:136 w_filename` cache without giving
+    /// the slot everything `w_globals` gets. The filesystem decode hands back a
+    /// movable managed string, so a retained slot has to be visited by a managed
+    /// wrapper's own custom trace and forwarded by `eval::walk_raw_code_roots`
+    /// for the bootstrap family; without both it holds a pre-move address after
+    /// the first collection that moves the string.
     pub filename_bytes: *mut Vec<u8>,
     /// Whether an unrealized nested compiler constant selected by
     /// `importing.py:379-391 update_code_filenames`' `oldname` guard inherits
@@ -344,6 +344,29 @@ pub unsafe fn w_code_name_obj(w_code: PyObjectRef) -> PyObjectRef {
         let w_name = w_str_new(&(*code_ptr).obj_name);
         (*(w_code as *mut PyCode)).w_name = w_name;
         w_name
+    }
+}
+
+/// `pycode.py:135 self.co_filename = filename` as an application-level object,
+/// decoded with the filesystem encoding (`objspace.py:438 newfilename`) so a
+/// path byte with no UTF-8 spelling survives instead of folding to U+FFFD.
+///
+/// Unlike [`w_code_name_obj`] and [`w_code_qualname_obj`] this realizes a fresh
+/// object per call rather than retaining one on the `PyCode`. Those two build
+/// their string with `w_str_new`, whose address is fixed, so the slot they store
+/// stays valid on its own; the filesystem decode returns a movable managed
+/// string, which the `filename_bytes` field doc explains a retained slot cannot
+/// hold unless it is traced and forwarded the way `w_globals` is.
+///
+/// # Safety
+/// `w_code` must point to a valid `PyCode` whose `code_ptr` is live.
+pub unsafe fn w_code_filename_obj(w_code: PyObjectRef) -> PyObjectRef {
+    let pycode = unsafe { &*(w_code as *const PyCode) };
+    if pycode.filename_bytes.is_null() {
+        let code = unsafe { &*(pycode.code_ptr as *const crate::CodeObject) };
+        w_str_new(&code.source_path)
+    } else {
+        crate::gateway::fsdecode_filename_bytes(unsafe { &*pycode.filename_bytes })
     }
 }
 
@@ -668,8 +691,8 @@ unsafe fn set_filename_bytes(obj: PyObjectRef, bytes: Option<Vec<u8>>) {
     }
 }
 
-unsafe fn filename_bytes(obj: PyObjectRef) -> Vec<u8> {
-    let pycode = unsafe { &*(obj as *const PyCode) };
+pub(crate) unsafe fn code_filename_bytes(w_code: PyObjectRef) -> Vec<u8> {
+    let pycode = unsafe { &*(w_code as *const PyCode) };
     if pycode.filename_bytes.is_null() {
         let code = unsafe { &*(pycode.code_ptr as *const crate::CodeObject) };
         code.source_path.as_bytes().to_vec()
@@ -849,14 +872,7 @@ pub unsafe fn code_get_field(obj: PyObjectRef, name: &str) -> Result<PyObjectRef
         "co_varnames" => names_tuple(&code.varnames),
         "co_freevars" => names_tuple(&code.freevars),
         "co_cellvars" => names_tuple(&code.cellvars),
-        "co_filename" => {
-            let filename_bytes = unsafe { (*(obj as *const PyCode)).filename_bytes };
-            if filename_bytes.is_null() {
-                w_str_new(&code.source_path)
-            } else {
-                crate::gateway::fsdecode_filename_bytes(unsafe { &*filename_bytes })
-            }
-        }
+        "co_filename" => unsafe { w_code_filename_obj(obj) },
         // Shared realized object, like `co_qualname` below.
         "co_name" => unsafe { w_code_name_obj(obj) },
         // The realized qualname is shared with every function built from this
@@ -1833,7 +1849,7 @@ pub unsafe fn fix_co_filename(w_code: PyObjectRef, newname: &[u8]) {
     if code_ptr.is_null() {
         return;
     }
-    let old_filename = unsafe { filename_bytes(w_code) };
+    let old_filename = unsafe { code_filename_bytes(w_code) };
 
     // `importing.py:379-391 update_code_filenames` mutates already-wrapped
     // nested `PyCode` constants. Pyre realizes that list lazily, so update the
@@ -1844,7 +1860,7 @@ pub unsafe fn fix_co_filename(w_code: PyObjectRef, newname: &[u8]) {
             let nested = slot.load(std::sync::atomic::Ordering::Acquire);
             if !nested.is_null()
                 && unsafe { is_code(nested) }
-                && unsafe { filename_bytes(nested) } == old_filename
+                && unsafe { code_filename_bytes(nested) } == old_filename
             {
                 unsafe { fix_co_filename(nested, newname) };
             }

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -926,13 +926,13 @@ fn capture_coroutine_origin(ec: *const PyExecutionContext) -> PyObjectRef {
         }
         // `fget_f_lineno` below reads `last_instr`, a virtualizable field.
         crate::executioncontext::force_frame(frame);
-        let code = unsafe { (*frame).code() };
+        let w_code = unsafe { (*frame).fget_f_code() };
         let filename_slot = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(w_str_new(&code.source_path));
+        pyre_object::gc_roots::pin_root(unsafe { crate::pycode::w_code_filename_obj(w_code) });
         let lineno_slot = pyre_object::gc_roots::shadow_stack_len();
         pyre_object::gc_roots::pin_root(w_int_new(unsafe { (*frame).fget_f_lineno() } as i64));
         let funcname_slot = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(w_str_new(&code.obj_name));
+        pyre_object::gc_roots::pin_root(unsafe { crate::pycode::w_code_name_obj(w_code) });
         let summary = w_tuple_new(vec![
             pyre_object::gc_roots::shadow_stack_get(filename_slot),
             pyre_object::gc_roots::shadow_stack_get(lineno_slot),
@@ -3196,15 +3196,22 @@ impl PyFrame {
 
     /// pyframe.py:849-853 descr_repr — `<frame at 0x…, file '…', line …,
     /// code …>` via `getrepr(space, "frame", moreinfo)`.
-    pub fn descr_repr(&self) -> String {
+    pub fn descr_repr(&self) -> rustpython_wtf8::Wtf8Buf {
         let code = self.code();
-        format!(
-            "<frame at {:p}, file '{}', line {}, code {}>",
-            self as *const PyFrame,
-            code.source_path.as_str(),
+        let mut out = rustpython_wtf8::Wtf8Buf::from_string(format!(
+            "<frame at {:p}, file '",
+            self as *const PyFrame
+        ));
+        let filename = crate::gateway::fsdecode_filename_wtf8(&unsafe {
+            crate::pycode::code_filename_bytes(self.pycode as pyre_object::PyObjectRef)
+        });
+        out.push_wtf8(&filename);
+        out.push_str(&format!(
+            "', line {}, code {}>",
             self.get_last_lineno(),
-            code.obj_name.as_str(),
-        )
+            code.obj_name.as_str()
+        ));
+        out
     }
 
     /// `frame_clear` (`frame.clear()`): clear most references held by the

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -7561,7 +7561,9 @@ fn init_frame_type(ns: PyObjectRef) {
                     if f.is_null() {
                         return Ok(pyre_object::w_str_new("<frame (null)>"));
                     }
-                    Ok(pyre_object::w_str_new_managed(&unsafe { &*f }.descr_repr()))
+                    Ok(pyre_object::w_str_from_wtf8_managed(
+                        unsafe { &*f }.descr_repr(),
+                    ))
                 },
                 1,
             ),
@@ -21866,10 +21868,13 @@ fn invalid_byte_2_of_4(ch1: u8, ch2: u8) -> bool {
 /// `str(bytes, 'utf-8', 'surrogateescape')` does: valid UTF-8 passes
 /// through and any other byte becomes a lone `0xDC00 + byte` surrogate.
 /// `surrogateescape` rescues every byte, so the decode never fails.
+pub(crate) fn charp2uni_wtf8(data: &[u8]) -> Wtf8Buf {
+    decode_utf8_with_errors(data, "surrogateescape")
+        .expect("surrogateescape rescues every byte, so the decode never fails")
+}
+
 pub(crate) fn charp2uni(data: &[u8]) -> PyObjectRef {
-    let decoded = decode_utf8_with_errors(data, "surrogateescape")
-        .expect("surrogateescape rescues every byte, so the decode never fails");
-    pyre_object::w_str_from_wtf8_managed(decoded)
+    pyre_object::w_str_from_wtf8_managed(charp2uni_wtf8(data))
 }
 
 /// unicodehelper.py:377-537 _str_decode_utf8_slowpath


### PR DESCRIPTION
Follow-up to #1001, closing the two items its review left open.

## 1. Split the fsencode boundary into the converter and the raw encode

Upstream has two distinct things here and the difference is load-bearing:

- `baseobjspace.py:1970-1983 space.fsencode_w` — the argument converter. It warns
  `path should be %s, not %s` as a `DeprecationWarning` for a readable buffer
  that is not `bytes`, and ends in `bytesbuf0_w` (`:2005-2018`), which rejects an
  embedded null with `ValueError: embedded null byte`.
- `baseobjspace.py:1962 space.fsencode` — the plain unicode→bytes filesystem
  encode, with neither. `interp_socket.py:157` takes this one deliberately:
  *"Not using space.fsencode_w since Linux allows embedded NULs."*

pyre collapsed both into one encoder, so it had neither the warning nor the null
check anywhere, and could not express the socket carve-out at all.

`fsencode_bytes_w` now follows `fsencode_w`: it resolves a readable buffer before
`__fspath__`, warns for a buffer that is not `bytes`, names the types in both
`TypeError`s (`interp_posix.py:3043` and `:3053`), and applies the null check.
`gateway::fsencode` is the raw form, and the AF_UNIX address packer takes it.

`open()` drops its own hand-rolled str / bytes-like / `__fspath__` resolution for
the converter, the way `interp_fileio.py:134-137 _open_fd` reaches
`interp_posix.py:64 space.fsencode_w` through `dispatch_filename`.

The four resulting messages match CPython 3.14 character for character:

```
TypeError: expected G.__fspath__() to return str or bytes, not int
TypeError: expected str, bytes or os.PathLike object, not object
ValueError: embedded null byte          # open("a\0b")
ValueError: embedded null byte          # os.system("a\0b")
```

## 2. Report the byte-exact `co_filename` from every reader

`PyCode` owns the raw path (`pycode.py:135 self.co_filename = filename`) and the
`co_filename` getter decodes it with `objspace.py:438 newfilename`. Every other
reader still went to `CodeObject::source_path` — the lossy UTF-8 spelling, where
a path byte with no UTF-8 form has already become U+FFFD. So a module imported
from `x\udcff.py` showed `x<?>.py` in its traceback, its warnings and its frame
repr while `code.co_filename` showed the correct name.

`w_code_filename_obj` realizes the filename the way `w_code_name_obj` realizes
`co_name`. It deliberately does **not** cache on the `PyCode`: the wrapper is
prebuilt-immortal and the decode hands back a movable managed string, which is
exactly the combination the `filename_bytes` field doc rules out.

Routed through it: the warning location, a coroutine's `cr_origin` summary, the
rendered traceback, and `pyframe.py:849-853 descr_repr`.

The last two were the half that looked blocked, because a Rust `String` cannot
hold the lone surrogate:

- the traceback writer is `std::io::Write`, so it keys its
  `StackSummary.format` dedup on the filename **bytes** and emits them with
  `write_all`. `read_source_line` keeps the lossy spelling, which simply fails to
  resolve — `error.py:150 linecache.getline` renders nothing then too.
- `descr_repr` returns a `Wtf8Buf`, and `py_repr_wtf8` takes it directly instead
  of folding through `py_repr`'s `String`. Upstream interpolates the filename
  (`"%s" % code.co_filename`) rather than its repr, so the surrogate reaches the
  result unescaped; CPython spells the same field with `%R`. Both keep the byte.

## Verification

All four readers now report the exact name (`x\udcff.py`), and the traceback's
bytes are `78 ff 2e 70 79`:

```
frame_repr     EXACT "<frame at 0x…, file 'x\udcff.py', line 2, code cap>"
warn_filename  EXACT 'x\udcff.py'
coro_origin    EXACT 'x\udcff.py'
```

New parity test `traceback_filename_surrogateescape.py`, plus assertions added to
`os_boundary_surrogateescape.py` for the null boundary and for the AF_UNIX
abstract-namespace carve-out. Both green on CPython 3.14 and on pyre.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved non-standard filesystem filenames, including surrogate-escaped characters, in tracebacks, warnings, frame displays, and coroutine diagnostics.
  * Improved filesystem path handling, including clearer validation and rejection of embedded NUL bytes.
  * Added support for Unix abstract socket names and more accurate socket address handling.
* **Tests**
  * Added coverage for path validation, abstract sockets, and surrogate-escaped filenames across error and diagnostic output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->