### PR TITLE
jit: take the ordinary resume snapshot on the walk root's non-standard virtualizable leg

### DIFF
--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/bridge_subwalk.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/bridge_subwalk.rs
@@ -841,8 +841,8 @@ pub(crate) fn compute_bridge_root_parent_frame<Sym: WalkSym>(
 /// temps from `setup_reconstructed_callee_frame`) and its locals carried in the
 /// already-emitted frame vable.  Because the walk is a sub-walk, the callee's
 /// `ref_return` surfaces `SubReturn { result }` (`pyjitpl.py finishframe`)
-/// instead of the top-level `Finish` that pyre's own-portal model rejects with
-/// `NonStandardVableFinishPortalUnsupported` — the original #215 item-2 wall.
+/// instead of the top-level `Finish` that pyre's own-portal model cannot close
+/// here — the original #215 item-2 wall.
 ///
 /// The root portal is installed as `fbw_mode.snapshot_sym` and pushed onto the
 /// walk framestack for the sub-walk's lifetime, so an in-callee guard

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -2131,18 +2131,6 @@ pub enum DispatchError {
     /// region from its start and re-executes every residual the walk already
     /// ran (`pickle_terminal_raise_resume` is the corpus detector).
     ForceQuasiImmutable { pc: usize },
-    /// A callee compiled as its own Finish portal (reached via
-    /// `call_user_function_with_eval`) accessed its frame through a
-    /// `vable_*` op that found it to be a non-standard virtualizable,
-    /// emitting an internal promote `GuardValue` + force store-back. The
-    /// Finish-portal compile path does not yet wire a resume snapshot or a
-    /// `FieldDescr` for those internal ops (only the inline sub-walk path
-    /// does), so compiling the trace trips the optimizer's
-    /// `store_final_boxes_in_guard` / `optimize_setfield_gc` invariants.
-    /// Abort to the interpreter; the method runs interpreted until the
-    /// own-portal callee frame is registered as the standard virtualizable
-    /// (a perf follow-up).
-    NonStandardVableFinishPortalUnsupported { pc: usize },
     /// A residual call to a pure-Python callee that is inline-eligible
     /// (plain, exact-positional, closure-free, not recursion-bound) but
     /// whose body is NOT a straight-line leaf — it carries an internal loop
@@ -2233,9 +2221,6 @@ impl DispatchError {
             Self::SubWalkClosedLoop { .. } => "SubWalkClosedLoop",
             Self::BranchGuardKeptStackUnsupported { .. } => "BranchGuardKeptStackUnsupported",
             Self::ForceQuasiImmutable { .. } => "ForceQuasiImmutable",
-            Self::NonStandardVableFinishPortalUnsupported { .. } => {
-                "NonStandardVableFinishPortalUnsupported"
-            }
             Self::LoopBearingCalleeInlineUnsupported { .. } => "LoopBearingCalleeInlineUnsupported",
             Self::FieldDescrMissingParentDescr { .. } => "FieldDescrMissingParentDescr",
             Self::OrthodoxSubWalkTraceUnsupported { .. } => "OrthodoxSubWalkTraceUnsupported",
@@ -2303,7 +2288,6 @@ impl DispatchError {
             | Self::SubWalkClosedLoop { pc, .. }
             | Self::BranchGuardKeptStackUnsupported { pc, .. }
             | Self::ForceQuasiImmutable { pc, .. }
-            | Self::NonStandardVableFinishPortalUnsupported { pc, .. }
             | Self::LoopBearingCalleeInlineUnsupported { pc, .. }
             | Self::FieldDescrMissingParentDescr { pc, .. }
             | Self::OrthodoxSubWalkTraceUnsupported { pc, .. }
@@ -2343,7 +2327,6 @@ impl DispatchError {
                 | Self::UnfoldableListAppendResidualUnsupported { .. }
                 | Self::MayForceNullRefArgUnsupported { .. }
                 | Self::InplaceContainerMutationUnsupported { .. }
-                | Self::NonStandardVableFinishPortalUnsupported { .. }
                 | Self::InlineCallArityMismatch { .. }
                 | Self::InlineCallIntArityMismatch { .. }
                 | Self::InlineCallFloatArityMismatch { .. }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/resume_snapshot.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/resume_snapshot.rs
@@ -134,14 +134,24 @@ pub(crate) fn walker_capture_inline_nonstandard_vable_guard<Sym: WalkSym>(
         return Ok(());
     }
     if !ctx.fbw_mode.inline_subwalk {
-        // A callee compiled as its own Finish portal hit the non-standard
-        // virtualizable path. Its internal promote GuardValue + force
-        // store-back are not yet wired with a resume snapshot / FieldDescr
-        // for the own-portal compile (only the inline sub-walk path below
-        // is), so the optimizer's `store_final_boxes_in_guard` /
-        // `optimize_setfield_gc` would trip. Abort to the interpreter rather
-        // than compile a trace that cannot be finalized.
-        return Err(DispatchError::NonStandardVableFinishPortalUnsupported { pc: op_pc });
+        // The walk's own root frame reached the non-standard path: it is
+        // writing a `vable` field of a frame that is not
+        // `virtualizable_boxes[-1]`.  `_nonstandard_virtualizable`
+        // (pyjitpl.py:1120) has no special case for this — it runs
+        // `implement_guard_value(eqbox, pc)` (:1916) whatever frame the walk
+        // sits in, and that is `generate_guard(GUARD_VALUE, resumepc=orgpc)`
+        // (:2582) -> `capture_resumedata(resumepc)` (:2610).  With no paused
+        // caller frames the capture upstream takes is the ordinary
+        // single-frame one, so take that; the multi-frame publish below is
+        // for the inline sub-walk, whose chain the sentinel collapse cannot
+        // encode.
+        //
+        // The buildability precondition is the sub-walk's, hoisted: an
+        // untyped virtualizable box panics the snapshot encoder either way.
+        if !ctx.trace_ctx.vable_snapshot_buildable() {
+            return Err(DispatchError::GuardSnapshotVableUntyped { pc: op_pc });
+        }
+        return walker_capture_snapshot_for_last_guard(ctx, op_pc);
     }
     // Same buildability precondition as `walker_capture_snapshot_for_last_guard`:
     // every virtualizable box must carry `OpRef::ty()` or the snapshot

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -3451,8 +3451,8 @@ fn run_perfn_walk<Sym: WalkSym>(
                 // places frame at r2 / ec at r3, so the positional seed put
                 // `ec_box` in the frame color and every `getfield/getarrayitem
                 // _vable` of a local took the nonstandard-virtualizable leg
-                // (internal promote `GuardValue` + force store-back, no resume
-                // snapshot → `NonStandardVableFinishPortalUnsupported` abort).
+                // (internal promote `GuardValue` + force store-back against a
+                // frame that is not the standard virtualizable).
                 // pycode (the jitdriver's green ref) is read from the frame's
                 // `pycode` field via `getfield_vable`, so it needs no register
                 // seed once `frame` resolves to the standard virtualizable; the
@@ -3543,8 +3543,8 @@ fn run_perfn_walk<Sym: WalkSym>(
         // A kept operand-stack temp never occupies a red-input color, so skip
         // `reserved_red_colors`: seeding a temp over the frame color overwrites
         // the standard virtualizable identity and forces every later `vable_*`
-        // op onto the nonstandard leg (NonStandardVableFinishPortalUnsupported
-        // abort).
+        // op onto the nonstandard leg, promoting and storing back against the
+        // wrong frame.
         if is_bridge_trace {
             if sym.bridge_walk_entry_pc().is_some() {
                 // Kept-stack branch guard resumed at the guard's own jitcode
@@ -3579,8 +3579,8 @@ fn run_perfn_walk<Sym: WalkSym>(
                             // The FRAME color (`reserved_red_colors[0]`) keeps its
                             // skip unconditionally: its `frame_box` is the standard
                             // virtualizable identity and overwriting it forces every
-                            // later `vable_*` op onto the nonstandard leg (#124
-                            // `NonStandardVableFinishPortalUnsupported`).  The EC
+                            // later `vable_*` op onto the nonstandard leg (#124),
+                            // promoting the wrong frame.  The EC
                             // color carries no such identity — the EC stays
                             // recoverable from the frame — so reseeding it is safe.
                             // This applies regardless of tagged-int state: a leaf
@@ -5495,7 +5495,6 @@ fn full_body_walk_trace<Sym: WalkSym>(
                 DE::GuardSnapshotVableUntyped { .. }
                 | DE::MayForceNullRefArgUnsupported { .. }
                 | DE::BranchGuardKeptStackUnsupported { .. }
-                | DE::NonStandardVableFinishPortalUnsupported { .. }
                 | DE::LoopBearingCalleeInlineUnsupported { .. }
                 | DE::UnfoldableListAppendResidualUnsupported { .. }
                 // Plain, retryable: `ABORT_FORCE_QUASIIMMUT` abandons THIS


### PR DESCRIPTION
`walker_capture_inline_nonstandard_vable_guard` aborted with
`NonStandardVableFinishPortalUnsupported` whenever the walk emitting the
internal promote `GuardValue` was not an inline sub-walk.

## The abort has no upstream counterpart

`_nonstandard_virtualizable` (`pyjitpl.py:1120`) has no case for "this walk is
the root". It runs `implement_guard_value(eqbox, pc)` (`:1916`) whatever frame
the walk sits in, and that is `generate_guard(GUARD_VALUE, resumepc=orgpc)`
(`:2582`) → `capture_resumedata(resumepc)` (`:2610`). With no paused caller
frames the capture upstream takes is the ordinary single-frame one, so take
that.

The multi-frame publish stays the inline sub-walk's, whose chain the sentinel
collapse cannot encode. The sub-walk's `vable_snapshot_buildable` precondition
is hoisted to cover both legs.

## The stated reason does not hold

The comment claimed the own-portal compile would trip the optimizer's
`store_final_boxes_in_guard` / `optimize_setfield_gc`. It trips neither.

`synth/pickle_terminal_raise_resume` under wasm is the only fixture in the
corpus that reaches this leg. Temporary guest-side counters put 5 events there,
all `vable_setfield`, all with an empty walk framestack and
`virtualizable_boxes` already seeded. The frame being written is therefore not
the portal's own — which also rules out the remedy the removed variant's doc
comment proposed, registering the own-portal callee frame as the standard
virtualizable.

With the snapshot captured, `internal_compile_panics` stays 0 and the output is
unchanged. The walk runs on to the next wall, `ResidualCallArgUnbound`, 5 for 5,
leaving `loops_aborted` / `loops_compiled` / `guard_failures` at 13 / 74 / 451
either way. dynasm and cranelift never reach the leg: of 111 events on that
fixture, 0 are root-level.

The measured net effect is zero. The change is made on orthodoxy grounds — the
`Err` was a pyre-only wall with no upstream counterpart.

`NonStandardVableFinishPortalUnsupported` then has no construction site and is
removed, with the prose that named it reworded to the hazard it describes.

## What this does not fix

The wall the walk now reaches is not a register-seeding gap. All 5 land on the
void-residual site: a module-scope `STORE_NAME` `CallN` (`[Ref, Ref, Ref]`, at
py_pc 16 / 19 / 31) whose **value** argument carries no concrete. That is the
case the site's own comment already describes — a void call is a side effect
with no result box, so it must execute eagerly; with a non-concrete arg eager
execution is impossible and deferral drops the store, so it aborts instead.

Closing that means carrying a concrete for every value that can reach a void
residual, which upstream gets for free (metainterp boxes always hold a real
value; virtualization is the optimizer's job). It is out of scope here.

## Verification

`check.py --synthetic-only`, all three backends, compared against main's own run
at the same base sha `ff42f0e3317` (run 30882999214):

- All **38** of main's failures reproduce on this branch. The branch adds none.
- Three extra local `int_lshift_memoryerror pypy crash` lines are the reference
  `pypy3` aborting under a `PYPY_GC_MAX` cap set in the measuring shell, not a
  pyre result — the three pyre backends never run once the reference crashes.
- One extra local line, `cranelift synth/exception_inline_callee_tb_frames
  loops_compiled 6 -> 7`, did not reproduce: direct `MAJIT_STATS` measurement
  reads 6 three times out of three, and re-running that fixture through
  `check.py --synthetic-pattern` passes. It was variance under a loaded box
  (load average 10–27 during the full run).

`cargo fmt --check` and `cargo check -p pyre-jit-trace` are clean, and no
reference to the removed variant remains in the tree.

— *authored by Claude*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of non-standard virtualizable guards during root-frame tracing.
  * These cases can now produce valid guard snapshots instead of being rejected outright.
  * Updated completion and retry behavior for affected tracing paths.
* **Documentation**
  * Clarified bridge sub-walk completion expectations and virtualizable register-seeding behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->