### PR TITLE
translator, jit: number fields through the heaptracker walker, restore per-frame bridge state, execute recorded allocations

### DIFF
--- a/majit/majit-gc/src/gc_sync.rs
+++ b/majit/majit-gc/src/gc_sync.rs
@@ -231,6 +231,17 @@ pub fn gc_query_reentrant<R>(f: impl FnOnce(&MiniMarkGC) -> R) -> R {
 /// Number of threads that have called `register_thread` and not yet
 /// `unregister_thread`.
 static REGISTERED_THREADS: AtomicUsize = AtomicUsize::new(0);
+/// Sticky record that the process has ever had two registered mutators.
+///
+/// A host-side root copied before it is published can only have become a
+/// nursery forwarding stub if another mutator collected in that window.  The
+/// single-mutator process therefore needs no forwarding query at every root
+/// pin.  Once a second mutator appears the race becomes possible forever
+/// (that thread may collect and unregister before the pin observes the live
+/// census), so this deliberately never clears.  This is the same sticky 1→2
+/// boundary that permanently disables shared-nursery inline allocation in
+/// [`register_thread`].
+static FOREIGN_MUTATOR_SEEN: AtomicBool = AtomicBool::new(false);
 
 /// Register the current thread as a GC mutator and take the GIL, which it then
 /// holds for as long as it runs pyre code. Paired with `unregister_thread`.
@@ -239,7 +250,17 @@ pub fn register_thread() {
         !GC_THREAD.with(|t| t.registered.get()),
         "GC mutator thread registered twice"
     );
-    REGISTERED_THREADS.fetch_add(1, Ordering::SeqCst);
+    let old = REGISTERED_THREADS.fetch_add(1, Ordering::SeqCst);
+    if old > 0 {
+        FOREIGN_MUTATOR_SEEN.store(true, Ordering::Release);
+        // A second thread is arriving, so no standing claim may survive: from
+        // here on every caller sees REGISTERED_THREADS > 1 and takes the Mutex
+        // path. The count was raised first, so the previous holder cannot make
+        // a new standing claim once this one is revoked. `gc_mutex` is what
+        // `revoke_standing_claim` requires of its callers.
+        let _guard = GC_SYNC.gc_mutex.lock().unwrap();
+        revoke_standing_claim(my_ident());
+    }
 
     let mut state = GC_SYNC.quiesce.lock().unwrap();
     state = GC_SYNC
@@ -403,6 +424,16 @@ pub(crate) struct GilCensus {
 #[inline]
 pub fn registered_threads() -> usize {
     REGISTERED_THREADS.load(Ordering::Acquire)
+}
+
+/// Whether another registered mutator has ever existed in this process.
+///
+/// Unlike [`stw_required`], this is sticky across unregister: a foreign
+/// nursery collection may already have left a forwarding stub in a raw host
+/// local copied before its next root pin.
+#[inline]
+pub fn foreign_mutator_seen() -> bool {
+    FOREIGN_MUTATOR_SEEN.load(Ordering::Acquire)
 }
 
 /// RPython `rthread.thread_after_fork()` parity for the child process.
@@ -886,7 +917,30 @@ mod tests {
         });
         blocking(|| worker.join()).unwrap();
 
+<<<<<<< HEAD
         assert_eq!(published_top(), before);
+||||||| parent of 3d06ccdce4b (gc: skip root forwarding queries before mutators are shared)
+        assert_eq!(
+            gc_query(
+                |gc| unsafe { &*(gc.nursery_top_addr() as *const AtomicUsize) }
+                    .load(Ordering::Acquire)
+            ),
+            0
+        );
+=======
+        assert!(
+            foreign_mutator_seen(),
+            "the 1→2 mutator transition must remain sticky after unregister"
+        );
+
+        assert_eq!(
+            gc_query(
+                |gc| unsafe { &*(gc.nursery_top_addr() as *const AtomicUsize) }
+                    .load(Ordering::Acquire)
+            ),
+            0
+        );
+>>>>>>> 3d06ccdce4b (gc: skip root forwarding queries before mutators are shared)
         unregister_test_mutator();
     }
 

--- a/majit/majit-gc/src/gc_sync.rs
+++ b/majit/majit-gc/src/gc_sync.rs
@@ -253,13 +253,6 @@ pub fn register_thread() {
     let old = REGISTERED_THREADS.fetch_add(1, Ordering::SeqCst);
     if old > 0 {
         FOREIGN_MUTATOR_SEEN.store(true, Ordering::Release);
-        // A second thread is arriving, so no standing claim may survive: from
-        // here on every caller sees REGISTERED_THREADS > 1 and takes the Mutex
-        // path. The count was raised first, so the previous holder cannot make
-        // a new standing claim once this one is revoked. `gc_mutex` is what
-        // `revoke_standing_claim` requires of its callers.
-        let _guard = GC_SYNC.gc_mutex.lock().unwrap();
-        revoke_standing_claim(my_ident());
     }
 
     let mut state = GC_SYNC.quiesce.lock().unwrap();
@@ -917,30 +910,11 @@ mod tests {
         });
         blocking(|| worker.join()).unwrap();
 
-<<<<<<< HEAD
-        assert_eq!(published_top(), before);
-||||||| parent of 3d06ccdce4b (gc: skip root forwarding queries before mutators are shared)
-        assert_eq!(
-            gc_query(
-                |gc| unsafe { &*(gc.nursery_top_addr() as *const AtomicUsize) }
-                    .load(Ordering::Acquire)
-            ),
-            0
-        );
-=======
         assert!(
             foreign_mutator_seen(),
             "the 1→2 mutator transition must remain sticky after unregister"
         );
-
-        assert_eq!(
-            gc_query(
-                |gc| unsafe { &*(gc.nursery_top_addr() as *const AtomicUsize) }
-                    .load(Ordering::Acquire)
-            ),
-            0
-        );
->>>>>>> 3d06ccdce4b (gc: skip root forwarding queries before mutators are shared)
+        assert_eq!(published_top(), before);
         unregister_test_mutator();
     }
 

--- a/majit/majit-ir/src/descr.rs
+++ b/majit/majit-ir/src/descr.rs
@@ -905,9 +905,11 @@ impl GcCache {
         // descr.py:120: cache[STRUCT] = sizedescr
         self._cache_size.insert(key, descr.clone());
         self._cache_size_order.push(descr.clone());
-        // descr.py:123-126: gc_fielddescrs / all_fielddescrs
-        // populated externally via SimpleSizeDescr::with_all_fielddescrs
-        // since we lack the heaptracker to auto-discover fields.
+        // descr.py:123-126: gc_fielddescrs / all_fielddescrs populated
+        // externally via SimpleSizeDescr::with_all_fielddescrs.  The walker
+        // exists (`majit-translate codewriter::heaptracker`) but lives in the
+        // crate that depends on this one, so it cannot be called from here;
+        // its callers thread the resulting list in.
         descr
     }
 
@@ -1241,7 +1243,8 @@ impl GcCache {
     /// `struct_key`: LLType::Struct — the owning type identity.
     /// `index_in_parent`: descr.py:228 heaptracker.get_fielddescr_index_in(STRUCT, fieldname).
     ///   The structural slot number within the parent struct's field list.
-    ///   Caller must provide this — Rust has no heaptracker auto-discovery.
+    ///   Caller must provide it: `heaptracker::get_fielddescr_index_in` runs
+    ///   in `majit-translate`, one crate above this one.
     /// `flag`: descr.py:226 get_type_flag(FIELDTYPE).
     ///
     /// descr.py:234-238: parent_descr = get_size_descr(gccache, STRUCT, vtable).
@@ -3418,8 +3421,9 @@ pub trait SizeDescr: Descr {
 
     /// descr.py:76 `get_all_fielddescrs(self): return self.all_fielddescrs`.
     /// Populated by `heaptracker.all_fielddescrs(gccache, STRUCT)` at
-    /// `get_size_descr` construction time (descr.py:125-126).  pyre has no
-    /// lltype STRUCT walker, so concrete impls thread this in via a
+    /// `get_size_descr` construction time (descr.py:125-126).  That walker
+    /// is `majit-translate codewriter::heaptracker::all_fielddescrs`, one
+    /// crate above this one, so concrete impls thread the list in via a
     /// builder; the default is empty.
     fn all_fielddescrs(&self) -> &[Arc<dyn FieldDescr>] {
         &[]
@@ -4687,7 +4691,8 @@ impl SimpleSizeDescr {
 
     /// descr.py:123-126 — `get_size_descr` calls
     /// `heaptracker.gc_fielddescrs(...)` / `heaptracker.all_fielddescrs(...)`
-    /// and stores both onto the descriptor.  pyre lacks heaptracker, so
+    /// and stores both onto the descriptor.  That walker lives one crate
+    /// above this one (`majit-translate codewriter::heaptracker`), so
     /// callers thread `all_fielddescrs` in via this builder; the
     /// `gc_fielddescrs` subset is derived by filtering on
     /// `FieldDescr::is_pointer_field()` (heaptracker.py:70).

--- a/majit/majit-ir/src/descr.rs
+++ b/majit/majit-ir/src/descr.rs
@@ -3546,7 +3546,7 @@ pub trait FieldDescr: Descr {
 
     /// descr.py:227 — field name. Format is either:
     /// - `"STRUCT.fieldname"` (from codewriter: descr.py:227)
-    /// - `"typeptr"` (from pyre tracer: ob_type_descr)
+    /// - `"object.typeptr"` (the vtable field, `make_vtable_field_descr`)
     /// - `""` (unnamed/dynamic field descriptors)
     fn field_name(&self) -> &str {
         ""
@@ -3565,8 +3565,9 @@ pub trait FieldDescr: Descr {
     /// already created, so we check the name at use time.
     ///
     /// Handles both formats:
-    /// - `"typeptr"` (pyre tracer ob_type_descr)
-    /// - `"STRUCT.typeptr"` (codewriter format, descr.py:227)
+    /// - `"STRUCT.typeptr"` (codewriter format, descr.py:227), which
+    ///   `make_vtable_field_descr` spells `"object.typeptr"`
+    /// - a bare `"typeptr"`, which no producer mints today
     fn is_typeptr(&self) -> bool {
         let name = self.field_name();
         name == "typeptr" || name.ends_with(".typeptr")

--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -3952,6 +3952,22 @@ mod tests {
             }
         }
 
+        /// `random.gauss` contains a float-to-int conversion. A guard failure
+        /// can resume forward through that byte, so RPython
+        /// `blackhole.py:66 setup_insns` must bind the already-ported
+        /// `bhimpl_cast_float_to_int` handler in the production builder.
+        #[test]
+        fn production_bh_builder_wires_cast_float_to_int() {
+            let builder = super::build_inline_call_only_bh_builder();
+            let placeholder = super::unwired_handler_placeholder as super::BhOpcodeHandler;
+            let byte = majit_translate::insns::BC_CAST_FLOAT_TO_INT;
+            let slot = builder.dispatch_table[byte as usize];
+            assert_ne!(
+                slot as usize, placeholder as usize,
+                "`cast_float_to_int/f>i` (byte {byte}) is unwired in the production builder",
+            );
+        }
+
         /// The two `fnaddr` classifiers agree with the walker's gate.
         ///
         /// `residual_call.rs:1117` declines a funcptr with any bit ≥ 47 set;
@@ -8648,6 +8664,10 @@ pub fn build_inline_call_only_bh_builder() -> BlackholeInterpBuilder {
     // / `new_with_vtable` read `bh.cpu`, which this builder sets above.
     for (key, byte) in [
         ("arraylen_gc/rd>i", majit_translate::insns::BC_ARRAYLEN_GC),
+        (
+            "cast_float_to_int/f>i",
+            majit_translate::insns::BC_CAST_FLOAT_TO_INT,
+        ),
         (
             "cast_ptr_to_int/r>i",
             majit_translate::insns::BC_CAST_PTR_TO_INT,

--- a/majit/majit-metainterp/src/box_trace.rs
+++ b/majit/majit-metainterp/src/box_trace.rs
@@ -241,7 +241,7 @@ pub fn trace_int_compare(
 /// Unbox a Python float object: emit GuardClass + GetfieldGc(F|PureF).
 ///
 /// Returns the raw f64 OpRef.
-fn getfield_gc_f_pureornot(
+pub fn getfield_gc_f_pureornot(
     ctx: &mut crate::TraceCtx,
     obj: majit_ir::OpRef,
     descr: majit_ir::DescrRef,

--- a/majit/majit-metainterp/src/box_trace.rs
+++ b/majit/majit-metainterp/src/box_trace.rs
@@ -98,7 +98,6 @@ pub fn trace_unbox_int(
     ctx: &mut crate::TraceCtx,
     obj: majit_ir::OpRef,
     int_type_addr: i64,
-    _ob_type_descr: majit_ir::DescrRef,
     intval_descr: majit_ir::DescrRef,
 ) -> majit_ir::OpRef {
     use majit_ir::OpCode;
@@ -128,7 +127,6 @@ pub fn trace_box_int(
     ctx: &mut crate::TraceCtx,
     value: majit_ir::OpRef,
     size_descr: majit_ir::DescrRef,
-    _ob_type_descr: majit_ir::DescrRef,
     intval_descr: majit_ir::DescrRef,
     int_type_addr: i64,
 ) -> majit_ir::OpRef {
@@ -165,25 +163,12 @@ pub fn trace_int_binop_ovf(
     b: majit_ir::OpRef,
     opcode: majit_ir::OpCode,
     int_type_addr: i64,
-    ob_type_descr: majit_ir::DescrRef,
     intval_descr: majit_ir::DescrRef,
     size_descr: majit_ir::DescrRef,
 ) -> majit_ir::OpRef {
     use majit_ir::OpCode;
-    let a_val = trace_unbox_int(
-        ctx,
-        a,
-        int_type_addr,
-        ob_type_descr.clone(),
-        intval_descr.clone(),
-    );
-    let b_val = trace_unbox_int(
-        ctx,
-        b,
-        int_type_addr,
-        ob_type_descr.clone(),
-        intval_descr.clone(),
-    );
+    let a_val = trace_unbox_int(ctx, a, int_type_addr, intval_descr.clone());
+    let b_val = trace_unbox_int(ctx, b, int_type_addr, intval_descr.clone());
     let result = ctx.record_op(opcode, &[a_val, b_val]);
     // Box(value) parity: derive the concrete result from the operands'
     // stamped Box.value carriers (BoxInt(value) — wrap semantics match
@@ -202,14 +187,7 @@ pub fn trace_int_binop_ovf(
     // (`trace_verify.rs`) without a synthetic snapshot — convergence
     // path is convergence to register-machine jitcode.
     ctx.record_guard_typed(OpCode::GuardNoOverflow, &[], Vec::new());
-    trace_box_int(
-        ctx,
-        result,
-        size_descr,
-        ob_type_descr,
-        intval_descr,
-        int_type_addr,
-    )
+    trace_box_int(ctx, result, size_descr, intval_descr, int_type_addr)
 }
 
 /// Emit a non-overflow binary int operation (bitwise ops, shifts).
@@ -219,24 +197,11 @@ pub fn trace_int_binop(
     b: majit_ir::OpRef,
     opcode: majit_ir::OpCode,
     int_type_addr: i64,
-    ob_type_descr: majit_ir::DescrRef,
     intval_descr: majit_ir::DescrRef,
     size_descr: majit_ir::DescrRef,
 ) -> majit_ir::OpRef {
-    let a_val = trace_unbox_int(
-        ctx,
-        a,
-        int_type_addr,
-        ob_type_descr.clone(),
-        intval_descr.clone(),
-    );
-    let b_val = trace_unbox_int(
-        ctx,
-        b,
-        int_type_addr,
-        ob_type_descr.clone(),
-        intval_descr.clone(),
-    );
+    let a_val = trace_unbox_int(ctx, a, int_type_addr, intval_descr.clone());
+    let b_val = trace_unbox_int(ctx, b, int_type_addr, intval_descr.clone());
     let result = ctx.record_op(opcode, &[a_val, b_val]);
     // Box(value) parity: derive the concrete result from the operands'
     // stamped Box.value carriers.
@@ -246,14 +211,7 @@ pub fn trace_int_binop(
         let folded = crate::eval_binop_i(opcode, la, rb);
         ctx.set_opref_concrete(result, majit_ir::Value::Int(folded));
     }
-    trace_box_int(
-        ctx,
-        result,
-        size_descr,
-        ob_type_descr,
-        intval_descr,
-        int_type_addr,
-    )
+    trace_box_int(ctx, result, size_descr, intval_descr, int_type_addr)
 }
 
 /// Emit a comparison between two Python ints.
@@ -263,23 +221,10 @@ pub fn trace_int_compare(
     b: majit_ir::OpRef,
     opcode: majit_ir::OpCode,
     int_type_addr: i64,
-    ob_type_descr: majit_ir::DescrRef,
     intval_descr: majit_ir::DescrRef,
 ) -> majit_ir::OpRef {
-    let a_val = trace_unbox_int(
-        ctx,
-        a,
-        int_type_addr,
-        ob_type_descr.clone(),
-        intval_descr.clone(),
-    );
-    let b_val = trace_unbox_int(
-        ctx,
-        b,
-        int_type_addr,
-        ob_type_descr.clone(),
-        intval_descr.clone(),
-    );
+    let a_val = trace_unbox_int(ctx, a, int_type_addr, intval_descr.clone());
+    let b_val = trace_unbox_int(ctx, b, int_type_addr, intval_descr.clone());
     let result = ctx.record_op(opcode, &[a_val, b_val]);
     // Box(value) parity: stamp the bool result from the operands' Box.value
     // carriers (BoxInt(0|1) — IntEq/IntNe/IntLt/IntLe/IntGt/IntGe all map
@@ -377,7 +322,6 @@ pub fn trace_unbox_float(
     ctx: &mut crate::TraceCtx,
     obj: majit_ir::OpRef,
     float_type_addr: i64,
-    _ob_type_descr: majit_ir::DescrRef,
     floatval_descr: majit_ir::DescrRef,
 ) -> majit_ir::OpRef {
     use majit_ir::OpCode;
@@ -394,7 +338,6 @@ pub fn trace_box_float(
     ctx: &mut crate::TraceCtx,
     value: majit_ir::OpRef,
     size_descr: majit_ir::DescrRef,
-    _ob_type_descr: majit_ir::DescrRef,
     floatval_descr: majit_ir::DescrRef,
     float_type_addr: i64,
 ) -> majit_ir::OpRef {
@@ -422,24 +365,11 @@ pub fn trace_float_binop(
     b: majit_ir::OpRef,
     opcode: majit_ir::OpCode,
     float_type_addr: i64,
-    ob_type_descr: majit_ir::DescrRef,
     floatval_descr: majit_ir::DescrRef,
     size_descr: majit_ir::DescrRef,
 ) -> majit_ir::OpRef {
-    let a_val = trace_unbox_float(
-        ctx,
-        a,
-        float_type_addr,
-        ob_type_descr.clone(),
-        floatval_descr.clone(),
-    );
-    let b_val = trace_unbox_float(
-        ctx,
-        b,
-        float_type_addr,
-        ob_type_descr.clone(),
-        floatval_descr.clone(),
-    );
+    let a_val = trace_unbox_float(ctx, a, float_type_addr, floatval_descr.clone());
+    let b_val = trace_unbox_float(ctx, b, float_type_addr, floatval_descr.clone());
     let result = ctx.record_op(opcode, &[a_val, b_val]);
     // Box(value) parity: derive the concrete result from the operands'
     // stamped Box.value carriers (BoxFloat(value)).
@@ -449,14 +379,7 @@ pub fn trace_float_binop(
         let bits = crate::eval_binop_f(opcode, a.to_bits() as i64, b.to_bits() as i64);
         ctx.set_opref_concrete(result, majit_ir::Value::Float(f64::from_bits(bits as u64)));
     }
-    trace_box_float(
-        ctx,
-        result,
-        size_descr,
-        ob_type_descr,
-        floatval_descr,
-        float_type_addr,
-    )
+    trace_box_float(ctx, result, size_descr, floatval_descr, float_type_addr)
 }
 
 /// Emit a comparison between two Python floats.
@@ -466,23 +389,10 @@ pub fn trace_float_compare(
     b: majit_ir::OpRef,
     opcode: majit_ir::OpCode,
     float_type_addr: i64,
-    ob_type_descr: majit_ir::DescrRef,
     floatval_descr: majit_ir::DescrRef,
 ) -> majit_ir::OpRef {
-    let a_val = trace_unbox_float(
-        ctx,
-        a,
-        float_type_addr,
-        ob_type_descr.clone(),
-        floatval_descr.clone(),
-    );
-    let b_val = trace_unbox_float(
-        ctx,
-        b,
-        float_type_addr,
-        ob_type_descr.clone(),
-        floatval_descr.clone(),
-    );
+    let a_val = trace_unbox_float(ctx, a, float_type_addr, floatval_descr.clone());
+    let b_val = trace_unbox_float(ctx, b, float_type_addr, floatval_descr.clone());
     let result = ctx.record_op(opcode, &[a_val, b_val]);
     // Box(value) parity: stamp the bool result from the operands' Box.value
     // carriers (BoxInt(0|1) — FloatLt/FloatLe/FloatEq/FloatNe/FloatGt/FloatGe

--- a/majit/majit-metainterp/src/optimizeopt/info.rs
+++ b/majit/majit-metainterp/src/optimizeopt/info.rs
@@ -522,10 +522,25 @@ impl PtrInfoExt for PtrInfo {
                         ));
                     }
                 } else if let Some(descr) = &info.descr {
+                    // info.py:346-352 reads `self.descr.get_vtable()`
+                    // unconditionally once the descr is present. Every pyre
+                    // producer of an `InstancePtrInfo` descr proves the
+                    // downcast: `ensure_ptr_info_arg0` unwraps the identical
+                    // `parent_descr` with `.expect` before it builds the info
+                    // (mod.rs:8362-8366), and `deserialize_optheap` asserts
+                    // the same shape on the same value (heap.rs:3691-3696).
+                    // A fabricated `0` would reach the backend as classptr 0
+                    // and panic in the subclass-range lookup
+                    // (aarch64/assembler.rs:3785-3792), naming the wrong layer.
+                    // A real `SizeDescr` whose `vtable()` is 0 is left alone:
+                    // that is the headerless state, not a manufactured one.
                     let vtable = descr
                         .as_size_descr()
-                        .map(|sd| sd.vtable() as i64)
-                        .unwrap_or(0);
+                        .expect(
+                            "InstancePtrInfo.descr must be a SizeDescr \
+                             (optimizer.py:480-481 InstancePtrInfo(parent_descr))",
+                        )
+                        .vtable() as i64;
                     let vtable_const = alloc_const(ctx, Value::Int(vtable));
                     short.push(Op::new(OpCode::GuardNonnull, &[op_b.clone()]));
                     if !ctx.remove_gctypeptr {
@@ -548,24 +563,33 @@ impl PtrInfoExt for PtrInfo {
                 //       short.extend([GUARD_NONNULL[op],
                 //                     GUARD_GC_TYPE[op, c_typeid]])
                 short.push(Op::new(OpCode::GuardNonnull, &[op_b.clone()]));
+                // `StructPtrInfo.descr` is a plain `DescrRef`
+                // (ptr_info.rs:232-239), so info.py:361 `if self.descr is not
+                // None` is unconditionally true here and the `SizeDescr`
+                // downcast cannot legitimately fail: `ensure_ptr_info_arg0`
+                // proves it on the same `parent_descr` one line before it
+                // builds the info (mod.rs:8362-8366), and the VirtualStruct
+                // force path hands its descr to `handle_new`, which unwraps a
+                // `SizeDescr` (majit-gc/src/rewrite.rs:1109-1112).  A tid may
+                // not be invented for a descr that cannot name one: the
+                // allocator never mints 0 (majit-ir/src/descr.rs:766-769,
+                // `next_type_id = 1`, `gctypelayout.py:328-331`) while the
+                // runtime header tid 0 is the live `rclass.OBJECT` root
+                // (pyre-jit-trace/src/descr.rs:475), so a fabricated 0 would
+                // pass on any plain `object` instance and certify a layout the
+                // optimizer never named.
+                let sd = info.descr.as_size_descr().expect(
+                    "StructPtrInfo.descr must be a SizeDescr \
+                     (optimizer.py:481 info.StructPtrInfo(parent_descr))",
+                );
                 // GUARD_GC_TYPE only for a real headered `GcStruct`: it
                 // reads a type-id word at `ref - 8` (the GC header).  A raw
                 // native struct and a headerless nursery allocation both lack
                 // that word, so the guard would read payload bytes and fail
                 // spuriously.  RPython emits GUARD_GC_TYPE only when a header
                 // exists; headerless structs get GUARD_NONNULL only.
-                // No descr → preserve the guard (default true).
-                let has_gc_type_header = info
-                    .descr
-                    .as_size_descr()
-                    .map(|sd| sd.is_gc_managed() && !sd.headerless())
-                    .unwrap_or(true);
-                if has_gc_type_header {
-                    let type_id = info
-                        .descr
-                        .as_size_descr()
-                        .map(|sd| sd.type_id() as i64)
-                        .unwrap_or(0);
+                if sd.is_gc_managed() && !sd.headerless() {
+                    let type_id = sd.type_id() as i64;
                     let type_id_const = alloc_const(ctx, Value::Int(type_id));
                     short.push(Op::new(
                         OpCode::GuardGcType,
@@ -587,6 +611,18 @@ impl PtrInfoExt for PtrInfo {
                 //       short.append(lenop)
                 //       self.lenbound.make_guards(lenop, short, optimizer)
                 short.push(Op::new(OpCode::GuardNonnull, &[op_b.clone()]));
+                // `ArrayPtrInfo.descr` is a plain `DescrRef`
+                // (ptr_info.rs:245-255) and info.py:634 reads
+                // `self.descr.get_type_id()` unconditionally.  Every producer
+                // feeds an array-op descr (optimizer.py:485-487
+                // `info.ArrayPtrInfo(op.getdescr())`, mod.rs:8383-8388) — the
+                // same Arc the mandatory GC rewrite unwraps as an `ArrayDescr`
+                // (majit-gc/src/rewrite.rs:2038-2040, :2186-2189, :2469-2472),
+                // including for the ARRAYLEN_GC this arm itself emits below.
+                let ad = info.descr.as_array_descr().expect(
+                    "ArrayPtrInfo.descr must be an ArrayDescr \
+                     (optimizer.py:487 info.ArrayPtrInfo(op.getdescr()))",
+                );
                 // GUARD_GC_TYPE reads a type-id word at `ptr -
                 // GcHeader::SIZE`; a header-less raw native pointer-array
                 // (a `pool_arrays` base minted by `add_ptr_array_descr`,
@@ -594,18 +630,8 @@ impl PtrInfoExt for PtrInfo {
                 // would read content-dependent memory before the array
                 // and fail on every short-preamble re-entry.  Gate it the
                 // same way the `PtrInfo::Struct` arm gates a raw struct.
-                // No descr → preserve the guard (default true).
-                let is_gc_managed = info
-                    .descr
-                    .as_array_descr()
-                    .map(|ad| ad.is_gc_managed())
-                    .unwrap_or(true);
-                if is_gc_managed {
-                    let type_id = info
-                        .descr
-                        .as_array_descr()
-                        .map(|ad| ad.type_id() as i64)
-                        .unwrap_or(0);
+                if ad.is_gc_managed() {
+                    let type_id = ad.type_id() as i64;
                     let type_id_const = alloc_const(ctx, Value::Int(type_id));
                     short.push(Op::new(
                         OpCode::GuardGcType,

--- a/majit/majit-metainterp/src/optimizeopt/virtualize.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualize.rs
@@ -628,10 +628,30 @@ impl OptVirtualize {
                     let b = Operand::from_bound_op(op_rc);
                     ctx.set_ptr_info(&b, PtrInfo::VirtualArrayStruct(vinfo));
                 } else {
-                    let items = vec![Operand::None; size as usize];
+                    // virtualize.py:27-35 `make_varray` passes
+                    // `optimizer.new_const_item(arraydescr)` into
+                    // `ArrayPtrInfo`; info.py:507-514 `_init_items` fills a
+                    // NEW_ARRAY_CLEAR with that typed zero/null constant.
+                    // NEW_ARRAY deliberately keeps `None` for unreadable,
+                    // uninitialized elements.
+                    let clear = matches!(op.opcode, OpCode::NewArrayClear);
+                    let items = if clear {
+                        let item_type = descr
+                            .as_array_descr()
+                            .expect("non-struct NEW_ARRAY descr must be an ArrayDescr")
+                            .item_type();
+                        let default_ref = match item_type {
+                            Type::Int | Type::Void => ctx.make_constant_int(0),
+                            Type::Ref => ctx.make_constant_ref(majit_ir::GcRef::NULL),
+                            Type::Float => ctx.make_constant_float(0.0),
+                        };
+                        vec![ctx.materialize_operand_at(default_ref); size as usize]
+                    } else {
+                        vec![Operand::None; size as usize]
+                    };
                     let vinfo = VirtualArrayInfo {
                         descr,
-                        clear: matches!(op.opcode, OpCode::NewArrayClear),
+                        clear,
                         items,
                         last_guard_pos: -1,
                         avpi: crate::optimizeopt::info::AbstractVirtualPtrInfo::new(),
@@ -3954,6 +3974,54 @@ mod tests {
             "all array ops on virtual should be removed; got {} ops: {:?}",
             result.len(),
             result.iter().map(|o| o.opcode).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_new_array_clear_unwritten_item_is_typed_zero() {
+        // virtualize.py:27-35 + info.py:507-514: NEW_ARRAY_CLEAR seeds every
+        // virtual slot with optimizer.new_const_item(arraydescr), so reading
+        // an unwritten integer item folds to zero instead of raising
+        // InvalidLoop("reading uninitialized virtual array items").
+        let ad: DescrRef = Arc::new(majit_ir::descr::SimpleArrayDescr::with_flag(
+            21,
+            0,
+            8,
+            21,
+            Type::Int,
+            majit_ir::ArrayFlag::Signed,
+        ));
+        let mut ops = vec![
+            Op::with_descr(
+                OpCode::NewArrayClear,
+                &[crate::history::test_support::rooted_resop_operand(
+                    Type::Int,
+                    50,
+                )],
+                ad.clone(),
+            ),
+            Op::with_descr(
+                OpCode::GetarrayitemGcI,
+                &[
+                    crate::history::test_support::rooted_resop_operand(Type::Ref, 0),
+                    crate::history::test_support::rooted_resop_operand(Type::Int, 51),
+                ],
+                ad,
+            ),
+        ];
+        assign_positions(&mut ops);
+
+        let result = run_pass_with_constants(
+            &ops,
+            &[
+                (OpRef::int_op(50), Value::Int(3)),
+                (OpRef::int_op(51), Value::Int(1)),
+            ],
+        );
+        assert!(
+            result.is_empty(),
+            "clear-array read should fold to its typed zero; got {:?}",
+            result.iter().map(|op| op.opcode).collect::<Vec<_>>()
         );
     }
 

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -99,6 +99,18 @@ fn descr_to_bh_array_descr(descr: &DescrRef) -> Option<majit_translate::jitcode:
     })
 }
 
+fn descr_to_bh_size_descr(descr: &DescrRef) -> Option<majit_translate::jitcode::BhDescr> {
+    let size = descr.as_size_descr()?;
+    Some(majit_translate::jitcode::BhDescr::Size {
+        size: size.size(),
+        type_id: size.type_id() as u64,
+        vtable: size.vtable() as u64,
+        owner: String::new(),
+        all_fielddescrs: majit_translate::jitcode::bh_field_specs_from_size_descr(size),
+        is_gc_managed: size.is_gc_managed(),
+    })
+}
+
 /// Inverse of `heap_value_for`: encode a typed `Value` into the raw i64
 /// bit-pattern that `VirtualizableInfo::write_field`/`write_array_item`
 /// interpret per field/item type.
@@ -809,6 +821,24 @@ impl TraceCtx {
             array_ptr,
             &bh_descr,
         )))
+    }
+
+    /// `pyjitpl.py:624-629 execute_new[_with_vtable]` concrete execution.
+    /// RPython executes the allocation before recording the matching trace op,
+    /// so later residual calls and field operations observe a real pointer
+    /// while the optimizer remains free to virtualize the recorded allocation.
+    pub fn execute_new_allocation(&self, descr: &DescrRef, with_vtable: bool) -> Option<Value> {
+        let cpu = unsafe { &*self.cpu? };
+        let bh_descr = descr_to_bh_size_descr(descr)?;
+        let ptr = if with_vtable {
+            cpu.bh_new_with_vtable(&bh_descr)
+        } else {
+            cpu.bh_new(&bh_descr)
+        };
+        if ptr == 0 {
+            return None;
+        }
+        Some(Value::Ref(majit_ir::GcRef(ptr as usize)))
     }
 
     /// `executor.py:200 do_getfield_raw_{i,r,f}` analog — read a raw

--- a/majit/majit-translate/src/codewriter/call.rs
+++ b/majit/majit-translate/src/codewriter/call.rs
@@ -7348,6 +7348,15 @@ fn all_interiorfielddescrs(
 /// that matched `field_name`, so a refusal here means the two disagree about
 /// what a field is — reported rather than papered over with a second opinion.
 fn field_pos_in(cc: &CallControl, owner: &str, field_name: &str) -> usize {
+    // A header word has no place in the positional census the walker numbers,
+    // so asking for its index is not a question `descr.py:228` can answer.
+    // The runtime mints the same descr with `index_in_parent: 0` and documents
+    // that consumers resolve it through `FieldDescr::is_w_class()` rather than
+    // by index (`pyre-jit-trace/src/descr.rs new_w_class_field_descr`); answer
+    // with the same number so both sides agree on the slot nobody reads.
+    if crate::codewriter::heaptracker::is_header_word(owner, field_name) {
+        return 0;
+    }
     let walked = crate::codewriter::heaptracker::get_fielddescr_index_in(cc, owner, field_name, 0);
     usize::try_from(walked).unwrap_or_else(|_| {
         panic!(
@@ -10148,6 +10157,51 @@ mod tests {
         assert_eq!(get_fielddescr_index_in(&cc, "Outer", "b", 0), 4);
         // `heaptracker.py:113` `-cur_index - 1` over the 5 leaves above.
         assert_eq!(get_fielddescr_index_in(&cc, "Outer", "missing", 0), -6);
+    }
+
+    /// The embedded object header contributes no slot, the way recursing
+    /// into RPython's `OBJECT` contributes none: its one field is `typeptr`
+    /// and `heaptracker.py:64-66` skips it by name.
+    ///
+    /// `w_class` is a header word only inside `PyObject`.  `Method.w_class`
+    /// is an ordinary value field, and numbering it against the header's
+    /// `w_class` is what the early `if r >= 0 { return r }` at
+    /// `heaptracker.py:106-107` does once the header is left countable.
+    #[test]
+    fn object_header_contributes_no_field_slot() {
+        use crate::codewriter::heaptracker::get_fielddescr_index_in;
+        let mut cc = CallControl::new();
+        cc.struct_fields.fields.insert(
+            "PyObject".to_string(),
+            vec![
+                ("ob_type".to_string(), "*const PyType".to_string()),
+                ("w_class".to_string(), "*mut PyObject".to_string()),
+            ],
+        );
+        cc.struct_fields.fields.insert(
+            "Method".to_string(),
+            vec![
+                ("ob".to_string(), "PyObject".to_string()),
+                ("w_function".to_string(), "*mut PyObject".to_string()),
+                ("w_self".to_string(), "*mut PyObject".to_string()),
+                ("w_class".to_string(), "*mut PyObject".to_string()),
+                ("w_module".to_string(), "*mut PyObject".to_string()),
+            ],
+        );
+        cc.set_known_struct_names(["PyObject".to_string()].into_iter().collect());
+
+        // The census is the four value fields, in declaration order — the
+        // same list `W_METHOD_DESCR_GROUP` publishes.
+        assert_eq!(get_fielddescr_index_in(&cc, "Method", "w_function", 0), 0);
+        assert_eq!(get_fielddescr_index_in(&cc, "Method", "w_self", 0), 1);
+        assert_eq!(get_fielddescr_index_in(&cc, "Method", "w_class", 0), 2);
+        assert_eq!(get_fielddescr_index_in(&cc, "Method", "w_module", 0), 3);
+        // Walked on its own the header has no countable field either, so it
+        // reports "not found" over zero leaves.
+        assert_eq!(get_fielddescr_index_in(&cc, "PyObject", "w_class", 0), -1);
+        // …which is why the mint site answers a header word without walking.
+        assert_eq!(field_pos_in(&cc, "PyObject", "w_class"), 0);
+        assert_eq!(field_pos_in(&cc, "Method", "w_class"), 2);
     }
 
     #[test]

--- a/majit/majit-translate/src/codewriter/call.rs
+++ b/majit/majit-translate/src/codewriter/call.rs
@@ -1213,8 +1213,9 @@ impl StructLayout {
     /// resolves on the inner struct directly (owner = the inner type), so
     /// the offset lookup never asks for an `{outer}.{inner}` name here; the
     /// by-value nested struct field's contribution to a sibling field's
-    /// **index** is recovered by the `get_fielddescr_index_in` recursion in
-    /// the `fielddescrof_concrete` walk ([`Self::recursive_field_count`]).
+    /// **index** is recovered by the
+    /// [`get_fielddescr_index_in`](crate::codewriter::heaptracker::get_fielddescr_index_in)
+    /// recursion the mint sites ask for that number.
     /// The header-embedding convention (`ob_header` / `base`) is flattened
     /// upstream by the subclass chain in `intern_class_by_qualname` (the
     /// embedded base's fields live on the base class, not in these `rows`).
@@ -1964,36 +1965,6 @@ impl CallControl {
         self.fielddescrof_concrete(idx, owner_root, owner_id, field_name)
     }
 
-    /// Number of leaf fielddescr slots a struct contributes to its parent
-    /// — `heaptracker.py:97-113 get_fielddescr_index_in`'s `-r - 1`
-    /// advancement.  Skips `Void` and `typeptr` and RECURSES into a
-    /// by-value nested struct field (`isinstance(FIELD, lltype.Struct)`),
-    /// so an embedded struct contributes its inner leaves' count, not one
-    /// slot.  A pointer-to-struct field has a non-struct type string
-    /// (`*const X` / `&X` / `Box<X>`), so `is_known_struct` returns false
-    /// and it counts as the single pointer slot it is.
-    fn recursive_field_count(&self, struct_name: &str) -> usize {
-        let Some(fields) = self.struct_fields.fields.get(struct_name) else {
-            return 1;
-        };
-        let mut count = 0;
-        for (fname, fty) in fields {
-            let (_flag, ir_type, _size) = get_type_flag(fty);
-            if matches!(ir_type, majit_ir::value::Type::Void) {
-                continue;
-            }
-            if fname == "typeptr" {
-                continue;
-            }
-            if self.is_known_struct(fty) {
-                count += self.recursive_field_count(fty);
-            } else {
-                count += 1;
-            }
-        }
-        count
-    }
-
     /// Trait-object sibling of [`Self::fielddescrof`] returning the
     /// resolved field-descr `Arc<dyn FieldDescr>` so analyzer and
     /// runtime share the SAME Arc — `set_ei_index` stamps land on
@@ -2034,19 +2005,6 @@ impl CallControl {
         use majit_ir::descr::{LLType, path_hash};
         let fields = self.struct_fields.fields.get(owner_root)?;
         let mut offset: usize = 0;
-        // `heaptracker.py:97-113 get_fielddescr_index_in(STRUCT, fieldname)`
-        // — positional index in `STRUCT._names`, skipping `Void` and
-        // `typeptr`.  Pyre's `struct_fields.fields[owner_root]` is the
-        // flat field list (no nested-struct inlining at analyzer time),
-        // so the enumeration position with `typeptr` skipped matches
-        // PyPy's `index_in_parent`.  Threaded into
-        // `gc_cache.get_field_descr` so the optimizer's
-        // `field_index_in_parent`-keyed slot maps
-        // (`optimizeopt/heap.rs FieldDescr::index_in_parent` consumer)
-        // get the slot-per-field discrimination PyPy's heaptracker
-        // assigns; the previous `0`-for-every-field stamp collided
-        // every field of one struct onto slot 0.
-        let mut field_pos: usize = 0;
         for (fname, fty) in fields {
             let (flag, ir_type, field_size) = get_type_flag(fty);
             if fname == "typeptr" {
@@ -2055,15 +2013,14 @@ impl CallControl {
             }
             // heaptracker.py:108-110: a by-value nested struct field is not
             // itself a leaf descr — `get_fielddescr_index_in` recurses into
-            // it, so it contributes its inner leaves' positions (and bytes),
-            // never matching as this `field_name` (an inner-field access
-            // resolves on the inner struct directly).  Checked before the
-            // name match to mirror the upstream `elif isinstance(FIELD,
-            // lltype.Struct)` ordering.  A pointer-to-struct field has a
-            // `*`/`&`/`Box<…>` type string, so `is_known_struct` is false
-            // and it stays a single pointer leaf.
+            // it, so it contributes its inner leaves' bytes, never matching
+            // as this `field_name` (an inner-field access resolves on the
+            // inner struct directly).  Checked before the name match to
+            // mirror the upstream `elif isinstance(FIELD, lltype.Struct)`
+            // ordering.  A pointer-to-struct field has a `*`/`&`/`Box<…>`
+            // type string, so `is_known_struct` is false and it stays a
+            // single pointer leaf.
             if self.is_known_struct(fty) {
-                field_pos += self.recursive_field_count(fty);
                 offset = offset.saturating_add(compute_struct_size(self, fty));
                 continue;
             }
@@ -2215,6 +2172,9 @@ impl CallControl {
                 // divergence that matters for enum variant payloads keyed
                 // by `{enum_leaf}::{variant}`.  Falls back to the
                 // accumulator only for a struct absent from `struct_layouts`.
+                // descr.py:228: index = heaptracker.get_fielddescr_index_in(
+                // STRUCT, fieldname).
+                let index_in_parent = field_pos_in(self, owner_root, field_name);
                 let descr = majit_ir::descr::gc_cache().lock().unwrap().get_field_descr(
                     struct_key,
                     field_name,
@@ -2227,7 +2187,7 @@ impl CallControl {
                     flag,
                     u32::MAX,
                     false,
-                    field_pos,
+                    index_in_parent,
                 );
                 descr.set_index(idx);
                 // Same arguments this `get_field_descr` miss just used, kept so
@@ -2243,13 +2203,12 @@ impl CallControl {
                         flag,
                         is_immutable,
                         is_quasi_immutable,
-                        index_in_parent: field_pos,
+                        index_in_parent,
                     },
                 );
                 return Some((descr as majit_ir::descr::DescrRef, member));
             }
             offset = offset.saturating_add(field_size);
-            field_pos += 1;
         }
         None
     }
@@ -2318,20 +2277,18 @@ impl CallControl {
         // FieldDescr / InteriorFieldDescr index namespace split.
         let fields = self.struct_fields.fields.get(&elem_name)?;
         let mut offset: usize = 0;
-        let mut field_pos: usize = 0;
         let mut found: Option<std::sync::Arc<dyn majit_ir::descr::FieldDescr>> = None;
         for (fname, fty) in fields {
             let (flag, ir_type, field_size) = get_type_flag(fty);
             if fname == "typeptr" {
                 continue;
             }
-            // heaptracker.py:108-110: recurse past a by-value nested struct
-            // field so the inner FieldDescr's index matches
-            // `get_fielddescr_index_in`.  Mirrors the `fielddescrof_concrete`
-            // walk; the corpus's array-element structs carry no by-value
-            // nested struct field, so this never fires there.
+            // heaptracker.py:108-110: step past a by-value nested struct
+            // field's bytes; `get_fielddescr_index_in` recurses into it for
+            // the position.  Mirrors the `fielddescrof_concrete` walk; the
+            // corpus's array-element structs carry no by-value nested struct
+            // field, so this never fires there.
             if self.is_known_struct(fty) {
-                field_pos += self.recursive_field_count(fty);
                 offset = offset.saturating_add(compute_struct_size(self, fty));
                 continue;
             }
@@ -2381,7 +2338,11 @@ impl CallControl {
                 }
                 if found.is_none() {
                     // No runtime publish for this `(STRUCT, fieldname)` —
-                    // analyzer-only mint.
+                    // analyzer-only mint.  Index from the same walker
+                    // `fielddescrof_concrete` uses, so the inner FieldDescr of
+                    // an interior access and the direct field access agree
+                    // (`descr.py:228`, one numberer per STRUCT).
+                    let index_in_parent = field_pos_in(self, &elem_name, field_name);
                     let mut gc = majit_ir::descr::gc_cache().lock().unwrap();
                     let mint = gc.get_field_descr(
                         struct_key,
@@ -2395,7 +2356,7 @@ impl CallControl {
                         flag,
                         u32::MAX,
                         false,
-                        field_pos,
+                        index_in_parent,
                     );
                     found = Some(mint as std::sync::Arc<dyn majit_ir::descr::FieldDescr>);
                 }
@@ -2469,7 +2430,6 @@ impl CallControl {
                 return Some((descr as majit_ir::descr::DescrRef, member));
             }
             offset = offset.saturating_add(field_size);
-            field_pos += 1;
         }
         None
     }
@@ -7373,6 +7333,31 @@ fn all_interiorfielddescrs(
     (result, item_size)
 }
 
+/// `descr.py:228 index = heaptracker.get_fielddescr_index_in(STRUCT, fieldname)`.
+///
+/// What makes `all_fielddescrs(S)[i].get_index() == i` a theorem upstream is
+/// that ONE walker answers both questions: `heaptracker.py:51-72
+/// all_fielddescrs` and `:97-113 get_fielddescr_index_in` share a skip set.
+/// The mint sites named that walker in their comments while counting the
+/// position themselves, and the two do not agree — a bare enumeration numbers
+/// `Void` fields, which `heaptracker.py:104-105` skips.
+///
+/// The negative return (`heaptracker.py:113` `-cur_index - 1`, "no such
+/// field") is not a state `descr.py:228` can reach: it asks only for fields
+/// the same walker already numbered. Both mint sites are inside the branch
+/// that matched `field_name`, so a refusal here means the two disagree about
+/// what a field is — reported rather than papered over with a second opinion.
+fn field_pos_in(cc: &CallControl, owner: &str, field_name: &str) -> usize {
+    let walked = crate::codewriter::heaptracker::get_fielddescr_index_in(cc, owner, field_name, 0);
+    usize::try_from(walked).unwrap_or_else(|_| {
+        panic!(
+            "get_fielddescr_index_in declined to number {owner}.{field_name} \
+             (returned {walked}) while the mint site had matched it \
+             (descr.py:228, heaptracker.py:97-113)"
+        )
+    })
+}
+
 /// RPython: `symbolic.get_array_token(ARRAY, tsc)[1]` — struct item_size.
 ///
 /// Layout source priority:
@@ -10120,12 +10105,21 @@ mod tests {
     }
 
     /// finding 3b: a by-value nested struct field contributes its inner
-    /// leaves' fielddescr slots (`heaptracker.py:108-110
+    /// leaves' fielddescr slots (`heaptracker.py:104-109
     /// get_fielddescr_index_in` recursion), not one container slot, so a
-    /// field after it gets the right `field_pos`.  A pointer-to-struct
-    /// field stays a single leaf.
+    /// field after it gets the right index.  A pointer-to-struct field stays
+    /// a single leaf.
+    ///
+    /// The embedded struct sits FIRST, which is the only position where
+    /// `heaptracker.py:108`'s `cur_index += -r - 1` is exact: the recursion
+    /// is seeded with the running `cur_index` (`:105`) and reports failure as
+    /// `-(cur_index + leaves) - 1` (`:113`), so the advancement is the leaf
+    /// count only while `cur_index` is still 0.  Both walkers upstream and
+    /// here rely on that — an inherited base is `_names[0]` in RPython
+    /// (`rclass` `super`) and `ob_header` is at offset 0 in pyre.
     #[test]
-    fn recursive_field_count_flattens_by_value_nested_struct() {
+    fn field_index_flattens_by_value_nested_struct() {
+        use crate::codewriter::heaptracker::get_fielddescr_index_in;
         let mut cc = CallControl::new();
         cc.struct_fields.fields.insert(
             "Inner".to_string(),
@@ -10134,23 +10128,26 @@ mod tests {
                 ("y".to_string(), "i64".to_string()),
             ],
         );
-        // Outer embeds Inner by value between two scalars, plus a
+        // Outer embeds Inner by value as its header, then two scalars and a
         // pointer-to-Inner that must NOT recurse.
         cc.struct_fields.fields.insert(
             "Outer".to_string(),
             vec![
+                ("hdr".to_string(), "Inner".to_string()),
                 ("a".to_string(), "i64".to_string()),
-                ("inner".to_string(), "Inner".to_string()),
                 ("p".to_string(), "&Inner".to_string()),
                 ("b".to_string(), "i64".to_string()),
             ],
         );
         cc.set_known_struct_names(["Inner".to_string()].into_iter().collect());
 
-        // Inner contributes its two leaves.
-        assert_eq!(cc.recursive_field_count("Inner"), 2);
-        // Outer: a(1) + inner→{x,y}(2) + `&Inner` pointer(1) + b(1) = 5.
-        assert_eq!(cc.recursive_field_count("Outer"), 5);
+        assert_eq!(get_fielddescr_index_in(&cc, "Inner", "y", 0), 1);
+        // Outer: hdr→{x,y} takes 0 and 1, a=2, `&Inner` pointer=3, b=4.
+        assert_eq!(get_fielddescr_index_in(&cc, "Outer", "a", 0), 2);
+        assert_eq!(get_fielddescr_index_in(&cc, "Outer", "p", 0), 3);
+        assert_eq!(get_fielddescr_index_in(&cc, "Outer", "b", 0), 4);
+        // `heaptracker.py:113` `-cur_index - 1` over the 5 leaves above.
+        assert_eq!(get_fielddescr_index_in(&cc, "Outer", "missing", 0), -6);
     }
 
     #[test]

--- a/majit/majit-translate/src/codewriter/heaptracker.rs
+++ b/majit/majit-translate/src/codewriter/heaptracker.rs
@@ -78,6 +78,27 @@ pub fn set_testing_vtable_for_gcstruct<V>(
         .insert(gcstruct._name.clone(), vtable);
 }
 
+/// `heaptracker.py:64-66` `if name == 'typeptr': continue`, spelled in the
+/// source field-name domain this walker actually sees.
+///
+/// Upstream's positional census never numbers the object header: `typeptr`
+/// lives in `OBJECT`, the substructure every instance embeds first, and the
+/// walk skips it by name, so recursing into that substructure contributes
+/// zero leaves. Pyre embeds `PyObject { ob_type, w_class }` as `ob_header`
+/// instead, and neither word is spelled `typeptr`, so the existing skip never
+/// fires and the header contributes two leaves the runtime publish does not
+/// have.
+///
+/// `w_class` is qualified by its owner because it is a header word only
+/// inside `PyObject`; `Method.w_class` is an ordinary value field that the
+/// census must keep numbering.
+pub(crate) fn is_header_word(struct_name: &str, field_name: &str) -> bool {
+    let owner_leaf = struct_name.rsplit("::").next().unwrap_or(struct_name);
+    field_name == "typeptr"
+        || field_name == "ob_type"
+        || (owner_leaf == "PyObject" && field_name == "w_class")
+}
+
 pub fn all_fielddescrs(
     gccache: &CallControl,
     struct_name: &str,
@@ -181,7 +202,7 @@ pub fn get_fielddescr_index_in(
         if ir_type == majit_ir::value::Type::Void {
             continue;
         }
-        if name == "typeptr" {
+        if is_header_word(struct_name, name) {
             continue;
         }
         if gccache.is_known_struct(field_type) {
@@ -217,7 +238,7 @@ fn all_fielddescrs_into(
         if ir_type == majit_ir::value::Type::Void {
             continue;
         }
-        if name.starts_with("c__pad") || name == "typeptr" {
+        if name.starts_with("c__pad") || is_header_word(struct_name, &name) {
             continue;
         }
         if gccache.is_known_struct(&field_type) {

--- a/majit/majit-translate/src/codewriter/jtransform.rs
+++ b/majit/majit-translate/src/codewriter/jtransform.rs
@@ -521,6 +521,60 @@ fn autodetect_jit_markers_redvars(
     reds_v
 }
 
+/// Read the rich graph's declared unsigned type for a value while production
+/// jtransform still consumes that graph instead of the rtyper-specialized
+/// flowspace graph. This is the signedness half of RPython's
+/// `Variable.concretetype == lltype.Unsigned`; JIT register kinds intentionally
+/// collapse Signed/Unsigned to `'i'`, so `get_value_kind_var` cannot answer it.
+fn variable_has_declared_unsigned_type(
+    graph: &FunctionGraph,
+    variable: &crate::flowspace::model::Variable,
+) -> bool {
+    graph
+        .blocks
+        .iter()
+        .flat_map(|block| &block.operations)
+        .any(|op| {
+            if op.result.as_ref() != Some(variable) {
+                return false;
+            }
+            matches!(
+                &op.kind,
+                OpKind::Input {
+                    ty: ValueType::Unsigned,
+                    ..
+                } | OpKind::FieldRead {
+                    ty: ValueType::Unsigned,
+                    ..
+                } | OpKind::VableFieldRead {
+                    ty: ValueType::Unsigned,
+                    ..
+                } | OpKind::ArrayRead {
+                    item_ty: ValueType::Unsigned,
+                    ..
+                } | OpKind::InteriorFieldRead {
+                    item_ty: ValueType::Unsigned,
+                    ..
+                } | OpKind::VableArrayRead {
+                    item_ty: ValueType::Unsigned,
+                    ..
+                } | OpKind::Call {
+                    result_ty: ValueType::Unsigned,
+                    ..
+                } | OpKind::IndirectCall {
+                    result_ty: ValueType::Unsigned,
+                    ..
+                } | OpKind::BinOp {
+                    result_ty: ValueType::Unsigned,
+                    ..
+                } | OpKind::UnaryOp {
+                    result_ty: ValueType::Unsigned,
+                    ..
+                }
+            )
+        })
+}
+
 impl<'a> Transformer<'a> {
     /// RPython: `Transformer.__init__(cpu=None, callcontrol=None, portal_jd=None)`
     /// (`jtransform.py:62-66`). Pyre keeps `cpu` / `callcontrol` behind
@@ -1795,13 +1849,13 @@ impl<'a> Transformer<'a> {
             // runtime helpers reproduce the same IEEE-754 mantissa
             // decomposition so runtime and const-fold agree.
             //
-            // Coverage: today these arms are unreachable from pyre
-            // source — no producer emits the `cast_uint_to_float` /
-            // `cast_float_to_uint` opnames in practice, so these
-            // const-fold + residual-helper arms stay dormant.  The
-            // wiring is staged for the eventual producer flip;
-            // unsigned parameter classification lives in the MIR
-            // front-end (`front::mir`).
+            // The rich-graph compatibility path in
+            // `rewrite_op_direct_call` projects `float(r_uint)` onto this
+            // low-level opname, matching the real rtyper's
+            // `IntegerRepr.rtype_float` conversion.  Once production
+            // jtransform consumes the already-rtyped flowspace graph, that
+            // projection disappears and this arm receives the rtyper op
+            // directly.
             OpKind::UnaryOp {
                 op: unop_name,
                 operand,
@@ -2826,6 +2880,34 @@ impl<'a> Transformer<'a> {
             "CallTarget::Indirect must be lowered by translator/rtyper/rpbc.rs \
              before reaching rewrite_op_direct_call",
         );
+        // RPython `IntegerRepr.rtype_float` (`rint.py:144-147`) converts an
+        // Unsigned input to Float, emitting `cast_uint_to_float`; jtransform
+        // then applies `_do_builtin_call` (`jtransform.py:587`) and reaches
+        // `support.py:274 _ll_1_cast_uint_to_float`.
+        //
+        // Production still feeds jtransform the rich MIR graph while the
+        // real rtyper specializes an ephemeral flowspace graph (see
+        // `jtransform_shadow.rs`).  Project this one source-level
+        // `float(r_uint)` call to the exact low-level op the rtyper produced,
+        // then dispatch through the ordinary rewrite arm above.  This keeps
+        // the helper address/effect descriptor and unsigned rounding on the
+        // upstream path; it is removed when jtransform consumes the rtyped
+        // graph directly.
+        if matches!(target, CallTarget::FunctionPath { segments } if segments == &["float"])
+            && args.len() == 1
+            && matches!(result_ty, ValueType::Float)
+            && variable_has_declared_unsigned_type(graph, &args[0])
+        {
+            let cast_op = SpaceOperation {
+                result: op.result.clone(),
+                kind: OpKind::UnaryOp {
+                    op: "cast_uint_to_float".into(),
+                    operand: args[0].clone(),
+                    result_ty: ValueType::Float,
+                },
+            };
+            return self.rewrite_operation(&cast_op, graph_name, graph);
+        }
         // RPython `jtransform.py:1658-1663 rewrite_op_jit_marker`:
         // marker calls never reach `guess_call_kind` — they dispatch straight
         // to `handle_jit_marker__*`. Upstream keys on `op.args[0].value`;
@@ -7714,6 +7796,49 @@ mod tests {
             other => panic!("expected CallResidual with runtime funcptr, got {other:?}"),
         }
         assert!(matches!(ops[3].kind, OpKind::Live));
+    }
+
+    #[test]
+    fn float_of_unsigned_projects_to_registered_cast_helper() {
+        let mut cc = crate::call::CallControl::new();
+        cc.register_macro_helper_trace_fnaddr("majit_metainterp::cast_uint_to_float", 0x1234);
+        let mut graph = FunctionGraph::new("cast_uint_to_float_test");
+        let arg = graph
+            .push_op_var(
+                graph.startblock,
+                OpKind::Input {
+                    name: "arg".into(),
+                    ty: ValueType::Unsigned,
+                    class_root: None,
+                },
+                true,
+            )
+            .unwrap();
+        let result = graph
+            .push_op_var(
+                graph.startblock,
+                OpKind::Call {
+                    target: CallTarget::function_path(["float"]),
+                    args: vec![arg],
+                    result_ty: ValueType::Float,
+                },
+                true,
+            )
+            .unwrap();
+        graph.set_return(graph.startblock, Some(result));
+
+        let config = GraphTransformConfig::default();
+        let transformed = Transformer::new(&config)
+            .with_callcontrol(&mut cc)
+            .transform(&graph);
+        assert!(
+            transformed
+                .graph
+                .block(graph.startblock)
+                .operations
+                .iter()
+                .any(|op| matches!(op.kind, OpKind::ConstInt(0x1234)))
+        );
     }
 
     #[test]

--- a/majit/majit-translate/src/codewriter/jtransform.rs
+++ b/majit/majit-translate/src/codewriter/jtransform.rs
@@ -338,6 +338,37 @@ enum JitMarkerKey {
 /// JitDriver receiver types whose `jit_merge_point`/`can_enter_jit`/`loop_header` markers are recognized; each becomes its own portal via `portal_jd_index`.
 const RECOGNIZED_JITDRIVER_RECEIVER_ROOTS: &[&str] = &["PyPyJitDriver", "UnpackIterableJitDriver"];
 
+/// The null-pointer builtins `HostEnv::bootstrap` registers
+/// (`flowspace/model.rs`), spelled as `HostObject::qualname`.
+const NULL_PTR_BUILTIN_QUALNAMES: &[&str] = &[
+    "core.ptr.null",
+    "core.ptr.null_mut",
+    "std.ptr.null",
+    "std.ptr.null_mut",
+];
+
+/// Whether a 0-arg `FunctionPath` call names one of those builtins.
+///
+/// A guest const-global defined as `std::ptr::null_mut()` is bound to the SAME
+/// `HostObject` as the spelled-out call (`flowspace/model.rs` binds the attr to
+/// `core.ptr.null_mut` rather than minting a second callable), which is how
+/// `flowspace_adapter`'s Branch 3b types the two identically. The surviving
+/// model graph still carries whichever path the source spelled, so resolve it
+/// through that same registry instead of listing the guest's spellings here —
+/// the alias keeps one owner, and no guest name is repeated in the codewriter.
+fn resolves_to_null_ptr_builtin(segments: &[String]) -> bool {
+    let Some((leaf, module_path)) = segments.split_last() else {
+        return false;
+    };
+    if module_path.is_empty() {
+        return false;
+    }
+    crate::flowspace::model::HOST_ENV
+        .import_module(&module_path.join("."))
+        .and_then(|module| module.module_get(leaf))
+        .is_some_and(|attr| NULL_PTR_BUILTIN_QUALNAMES.contains(&attr.qualname()))
+}
+
 fn jit_marker_key_from_target(target: &CallTarget) -> Option<JitMarkerKey> {
     let CallTarget::Method {
         name,
@@ -3055,13 +3086,7 @@ impl<'a> Transformer<'a> {
         if let CallTarget::FunctionPath { segments } = target
             && args.is_empty()
             && matches!(result_ty, ValueType::Ref(_))
-            && matches!(
-                segments.as_slice(),
-                [owner, ptr, leaf]
-                    if matches!(owner.as_str(), "core" | "std")
-                        && ptr == "ptr"
-                        && matches!(leaf.as_str(), "null" | "null_mut")
-            )
+            && resolves_to_null_ptr_builtin(segments)
         {
             return RewriteResult::Replace(vec![SpaceOperation {
                 result: op.result.clone(),
@@ -9198,32 +9223,37 @@ mod tests {
 
     #[test]
     fn ptr_null_builtin_rewrites_to_null_ref_constant() {
-        let config = GraphTransformConfig::default();
-        let mut graph = FunctionGraph::new("ptr_null_constant");
-        let entry = graph.startblock;
-        let result_var = graph
-            .push_op_var(
-                entry,
-                OpKind::Call {
-                    target: CallTarget::function_path(["core", "ptr", "null_mut"]),
-                    args: vec![],
-                    result_ty: ValueType::Ref(None),
-                },
-                true,
-            )
-            .unwrap();
-        FunctionGraph::set_concretetype_of_inline(&result_var, ConcreteType::GcRef);
-        graph.set_return(entry, Some(result_var.clone()));
+        for path in [
+            vec!["core", "ptr", "null_mut"],
+            vec!["pyre_object", "pyobject", "PY_NULL"],
+        ] {
+            let config = GraphTransformConfig::default();
+            let mut graph = FunctionGraph::new("ptr_null_constant");
+            let entry = graph.startblock;
+            let result_var = graph
+                .push_op_var(
+                    entry,
+                    OpKind::Call {
+                        target: CallTarget::function_path(path),
+                        args: vec![],
+                        result_ty: ValueType::Ref(None),
+                    },
+                    true,
+                )
+                .unwrap();
+            FunctionGraph::set_concretetype_of_inline(&result_var, ConcreteType::GcRef);
+            graph.set_return(entry, Some(result_var.clone()));
 
-        let result = transform_graph(&graph, &config);
-        let folded = result
-            .graph
-            .blocks
-            .iter()
-            .flat_map(|block| &block.operations)
-            .find(|op| op.result.as_ref() == Some(&result_var))
-            .expect("null result must survive as a constant definition");
-        assert!(matches!(folded.kind, OpKind::ConstRefNull));
+            let result = transform_graph(&graph, &config);
+            let folded = result
+                .graph
+                .blocks
+                .iter()
+                .flat_map(|block| &block.operations)
+                .find(|op| op.result.as_ref() == Some(&result_var))
+                .expect("null result must survive as a constant definition");
+            assert!(matches!(folded.kind, OpKind::ConstRefNull));
+        }
     }
 
     /// `rtuple.py:153-169 TupleRepr.newtuple`: a non-empty tuple lowers to

--- a/majit/majit-translate/src/model.rs
+++ b/majit/majit-translate/src/model.rs
@@ -3015,18 +3015,16 @@ pub fn fuse_boxing_alloc(
 /// (`flowspace_adapter::function_graph_to_flowspace`) requires — every
 /// referenced operand defined as a block inputarg or op result.
 ///
-/// An operand is threaded only when its definition is reachable from the use
-/// block through a chain of single-predecessor blocks — i.e. the definition
-/// dominates the use along a strictly linear path, exactly the shape the
-/// boxing cluster's `alloc → cast → cast → return` chain has.  This is the
-/// precondition under which [`FunctionGraph::ensure_variable_at_block`] threads
-/// cleanly: with one predecessor at every step, every path into the use block
-/// passes through the definition, so no predecessor edge is left unable to
-/// supply the value.  An operand reaching a join or loop block (multiple
-/// predecessors), or one with no upstream definition at all, is left untouched
-/// — the adapter still Skips that graph, and the no-definition panic is never
-/// reached.  Graphs with no cross-block-undefined operand collect no work and
-/// stay byte-identical.
+/// An operand is threaded only when it is available on every predecessor path
+/// into the use block.  This is the same condition `SSA_to_SSI` enforces while
+/// adding one inputarg to every block and one argument to every incoming link
+/// (`rpython/translator/backendopt/ssa.py:171-190`).  Diamond joins are valid
+/// when the definition dominates the split; a value defined in only one arm,
+/// or one with no upstream definition, is left untouched so the adapter can
+/// Skip the malformed graph.  Back edges provisionally satisfy the recursive
+/// check, but a separate ancestor-definition check prevents a source-less SCC
+/// from manufacturing a definition.  Graphs with no cross-block-undefined
+/// operand collect no work and stay byte-identical.
 pub fn thread_undefined_op_operands(graph: &mut FunctionGraph) {
     use crate::flowspace::model::Variable;
     use std::collections::{HashMap, HashSet};
@@ -3039,33 +3037,53 @@ pub fn thread_undefined_op_operands(graph: &mut FunctionGraph) {
         }
     }
 
-    // `var` is defined in a block reachable from `block` by walking
-    // single-predecessor edges only.  Mirrors the success condition of
-    // `ensure_variable_at_block` for a linear predecessor chain.
-    fn defined_via_single_pred_chain(
+    fn ancestor_has_definition(
         graph: &FunctionGraph,
         preds: &HashMap<BlockId, Vec<BlockId>>,
         block: BlockId,
         var: &Variable,
+        seen: &mut HashSet<BlockId>,
     ) -> bool {
-        let mut cur = block;
-        let mut seen: HashSet<BlockId> = HashSet::new();
-        loop {
-            if !seen.insert(cur) {
-                return false;
-            }
-            let Some(ps) = preds.get(&cur) else {
-                return false;
-            };
-            if ps.len() != 1 {
-                return false;
-            }
-            let p = ps[0];
-            if graph.variable_defined_in_block(p, var) {
-                return true;
-            }
-            cur = p;
+        if !seen.insert(block) {
+            return false;
         }
+        graph.variable_defined_in_block(block, var)
+            || preds.get(&block).is_some_and(|ps| {
+                ps.iter()
+                    .any(|&pred| ancestor_has_definition(graph, preds, pred, var, seen))
+            })
+    }
+
+    fn available_on_every_predecessor_path(
+        graph: &FunctionGraph,
+        preds: &HashMap<BlockId, Vec<BlockId>>,
+        block: BlockId,
+        var: &Variable,
+        visiting: &mut HashSet<BlockId>,
+        memo: &mut HashMap<BlockId, bool>,
+    ) -> bool {
+        if graph.variable_defined_in_block(block, var) {
+            return true;
+        }
+        if let Some(&known) = memo.get(&block) {
+            return known;
+        }
+        // `ensure_variable_at_block` installs the target inputarg before
+        // following a back edge.  Treat the same in-progress cycle as
+        // available here; an acyclic entry path still has to reach a real
+        // definition, and `ancestor_has_definition` rejects a source-less SCC.
+        if !visiting.insert(block) {
+            return true;
+        }
+        let available = preds.get(&block).is_some_and(|ps| {
+            !ps.is_empty()
+                && ps.iter().all(|&pred| {
+                    available_on_every_predecessor_path(graph, preds, pred, var, visiting, memo)
+                })
+        });
+        visiting.remove(&block);
+        memo.insert(block, available);
+        available
     }
 
     let mut work: Vec<(BlockId, Variable)> = Vec::new();
@@ -3075,9 +3093,20 @@ pub fn thread_undefined_op_operands(graph: &mut FunctionGraph) {
         }
         for op in &block.operations {
             for var in crate::inline::op_variable_refs(&op.kind) {
-                if !graph.variable_defined_in_block(block.id, &var)
-                    && defined_via_single_pred_chain(graph, &preds, block.id, &var)
-                {
+                if graph.variable_defined_in_block(block.id, &var) {
+                    continue;
+                }
+                let has_definition =
+                    ancestor_has_definition(graph, &preds, block.id, &var, &mut HashSet::new());
+                let available = available_on_every_predecessor_path(
+                    graph,
+                    &preds,
+                    block.id,
+                    &var,
+                    &mut HashSet::new(),
+                    &mut HashMap::new(),
+                );
+                if has_definition && available {
                     work.push((block.id, var));
                 }
             }
@@ -8010,6 +8039,129 @@ mod tests {
             1,
             "header → body_tail link args extended (body_tail demands v)",
         );
+    }
+
+    #[test]
+    fn thread_undefined_op_operand_across_diamond_when_definition_dominates_split() {
+        let mut graph = FunctionGraph::new("thread_operand_diamond");
+        let entry = graph.startblock;
+        let left = graph.create_block();
+        let right = graph.create_block();
+        let join = graph.create_block();
+        let value = graph
+            .push_op_var(
+                entry,
+                OpKind::Input {
+                    name: "value".into(),
+                    ty: ValueType::Float,
+                    class_root: None,
+                },
+                true,
+            )
+            .unwrap();
+        let cond = graph
+            .push_op_var(
+                entry,
+                OpKind::Input {
+                    name: "cond".into(),
+                    ty: ValueType::Bool,
+                    class_root: None,
+                },
+                true,
+            )
+            .unwrap();
+        graph.set_branch(entry, cond, left, vec![], right, vec![]);
+        graph.set_goto(left, join, vec![]);
+        graph.set_goto(right, join, vec![]);
+        let base = graph
+            .push_op_var(
+                join,
+                OpKind::Call {
+                    target: CallTarget::synthetic_transparent_ctor("Box"),
+                    args: vec![],
+                    result_ty: ValueType::Ref(Some("Box".into())),
+                },
+                true,
+            )
+            .unwrap();
+        graph.block_mut(join).operations.push(SpaceOperation {
+            result: None,
+            kind: OpKind::FieldWrite {
+                base,
+                field: FieldDescriptor {
+                    name: "payload".into(),
+                    owner_root: Some("Box".into()),
+                    owner_id: None,
+                },
+                value: LinkArg::Value(value.clone()),
+                ty: ValueType::Float,
+            },
+        });
+
+        thread_undefined_op_operands(&mut graph);
+
+        for block in [left, right, join] {
+            assert!(
+                graph.block(block).inputargs.contains(&value),
+                "dominating value is threaded through {block:?}",
+            );
+        }
+        assert!(graph.block(entry).exits.iter().all(|link| {
+            link.args
+                .iter()
+                .any(|arg| matches!(arg, LinkArg::Value(v) if v == &value))
+        }));
+    }
+
+    #[test]
+    fn thread_undefined_op_operand_declines_value_defined_in_one_diamond_arm() {
+        let mut graph = FunctionGraph::new("thread_operand_partial_diamond");
+        let entry = graph.startblock;
+        let left = graph.create_block();
+        let right = graph.create_block();
+        let join = graph.create_block();
+        let cond = graph
+            .push_op_var(
+                entry,
+                OpKind::Input {
+                    name: "cond".into(),
+                    ty: ValueType::Bool,
+                    class_root: None,
+                },
+                true,
+            )
+            .unwrap();
+        graph.set_branch(entry, cond, left, vec![], right, vec![]);
+        let value = graph
+            .push_op_var(
+                left,
+                OpKind::Input {
+                    name: "left_only".into(),
+                    ty: ValueType::Float,
+                    class_root: None,
+                },
+                true,
+            )
+            .unwrap();
+        graph.set_goto(left, join, vec![]);
+        graph.set_goto(right, join, vec![]);
+        let result = graph.alloc_value_var();
+        graph.block_mut(join).operations.push(SpaceOperation {
+            result: Some(result),
+            kind: OpKind::UnaryOp {
+                op: "same_as".into(),
+                operand: value.clone(),
+                result_ty: ValueType::Float,
+            },
+        });
+
+        thread_undefined_op_operands(&mut graph);
+
+        assert!(
+            !graph.block(join).inputargs.contains(&value),
+            "one-arm definition must not be invented at the join",
+        );
+        assert!(graph.block(right).inputargs.is_empty());
     }
 
     /// `framestate.py:50-51 getvariables` walks `locals + flatten(stack) +

--- a/majit/majit-translate/src/model.rs
+++ b/majit/majit-translate/src/model.rs
@@ -2869,6 +2869,7 @@ pub fn fuse_boxing_alloc(
     struct Site {
         block: usize,
         op: usize,
+        aggregate: crate::flowspace::model::Variable,
         result: crate::flowspace::model::Variable,
         owner: String,
         vtable: i64,
@@ -2962,6 +2963,7 @@ pub fn fuse_boxing_alloc(
             sites.push(Site {
                 block: bi,
                 op: oi,
+                aggregate: agg.clone(),
                 result: result.clone(),
                 owner,
                 vtable,
@@ -2971,6 +2973,7 @@ pub fn fuse_boxing_alloc(
     }
 
     let fused = sites.len();
+    let fused_aggregates: Vec<_> = sites.iter().map(|site| site.aggregate.clone()).collect();
     // Rewrite in reverse (block, op) order so the per-site `insert` does not
     // shift the indices of not-yet-processed sites in the same block.
     for site in sites.into_iter().rev() {
@@ -2999,7 +3002,136 @@ pub fn fuse_boxing_alloc(
             );
         }
     }
+    sink_fused_boxing_aggregates_at_raw_writes(graph, &fused_aggregates);
     fused
+}
+
+/// Rematerialize a fused boxing aggregate only at a raw `ptr::write` use.
+///
+/// `gc_interp`'s stable-allocation arm writes the original by-value Rust
+/// aggregate into memory, while the ordinary arm passes that same aggregate
+/// to `lltype::malloc_typed`.  After the latter is lowered to
+/// `NewWithVtable`, leaving the shared aggregate in the dominator would make
+/// its synthetic constructors execute on the ordinary JIT path even though
+/// only the GC-interpreter arm still reads it.  RPython's
+/// `remove_simple_mallocs` performs the equivalent escape-sensitive motion:
+/// keep the materialization at the escaping store, and let the dead-variable
+/// sweep remove it from paths on which it does not escape.
+///
+/// A rename map is the direct equivalent of RPython's per-clone variable
+/// mapping: it preserves the nested header/outer-object shape without a
+/// side-table that survives this local graph rewrite.
+fn sink_fused_boxing_aggregates_at_raw_writes(
+    graph: &mut FunctionGraph,
+    aggregates: &[crate::flowspace::model::Variable],
+) -> usize {
+    use crate::flowspace::model::Variable;
+    use std::collections::{HashMap, HashSet};
+
+    let is_ctor = |op: &SpaceOperation| {
+        matches!(
+            op.kind,
+            OpKind::Call {
+                target: CallTarget::SyntheticTransparentCtor { .. },
+                ..
+            }
+        )
+    };
+    let is_raw_write = |kind: &OpKind| {
+        matches!(kind, OpKind::Call { target: CallTarget::FunctionPath { segments }, args, .. }
+            if args.len() == 2
+                && segments.iter().map(String::as_str).eq(["core", "ptr", "write"]))
+    };
+
+    let mut sinks = Vec::new();
+    for aggregate in aggregates {
+        for (bi, block) in graph.blocks.iter().enumerate() {
+            for (oi, op) in block.operations.iter().enumerate() {
+                if is_raw_write(&op.kind)
+                    && matches!(&op.kind, OpKind::Call { args, .. } if &args[1] == aggregate)
+                {
+                    sinks.push((bi, oi, aggregate.clone()));
+                }
+            }
+        }
+    }
+    sinks.sort_by_key(|(bi, oi, _)| (*bi, *oi));
+
+    let mut moved = 0;
+    for (bi, oi, aggregate) in sinks.into_iter().rev() {
+        // Include the outer aggregate plus nested aggregate values stored into
+        // it (notably `PyObject ob_header`).  Scalar payloads and type-pointer
+        // casts remain ordinary operands and are threaded to the sink by the
+        // existing SSA-to-SSI repair pass.
+        let mut allocs = HashSet::from([aggregate.clone()]);
+        loop {
+            let mut added = false;
+            for op in graph.blocks.iter().flat_map(|block| &block.operations) {
+                let OpKind::FieldWrite { base, value, .. } = &op.kind else {
+                    continue;
+                };
+                if !allocs.contains(base) {
+                    continue;
+                }
+                let Some(value) = value.as_variable() else {
+                    continue;
+                };
+                let produced_by_ctor =
+                    graph
+                        .blocks
+                        .iter()
+                        .flat_map(|block| &block.operations)
+                        .any(|candidate| {
+                            candidate.result.as_ref() == Some(value) && is_ctor(candidate)
+                        });
+                if produced_by_ctor && allocs.insert(value.clone()) {
+                    added = true;
+                }
+            }
+            if !added {
+                break;
+            }
+        }
+
+        let template: Vec<_> = graph
+            .blocks
+            .iter()
+            .flat_map(|block| &block.operations)
+            .filter(|op| {
+                op.result
+                    .as_ref()
+                    .is_some_and(|result| allocs.contains(result) && is_ctor(op))
+                    || matches!(&op.kind, OpKind::FieldWrite { base, .. } if allocs.contains(base))
+            })
+            .cloned()
+            .collect();
+        if template.is_empty() {
+            continue;
+        }
+
+        let mut renaming = HashMap::new();
+        for alloc in &allocs {
+            let mut fresh = Variable::new();
+            fresh.rename_from(alloc);
+            renaming.insert(alloc.clone(), fresh);
+        }
+        let remap = |var: &Variable| renaming.get(var).cloned().unwrap_or_else(|| var.clone());
+        let cloned: Vec<_> = template
+            .iter()
+            .map(|op| SpaceOperation {
+                result: op.result.as_ref().map(&remap),
+                kind: crate::inline::remap_op_kind(&op.kind, &remap),
+            })
+            .collect();
+
+        let block = &mut graph.blocks[bi];
+        if let OpKind::Call { args, .. } = &mut block.operations[oi].kind {
+            args[1] = remap(&aggregate);
+        }
+        moved += cloned.len();
+        block.operations.splice(oi..oi, cloned);
+    }
+    moved
 }
 
 /// Re-thread op operands the boxing lowering left referenced across a block

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -2076,7 +2076,7 @@ use pyre_object::interp_exceptions::{
     ExcKind, W_BASE_EXCEPTION_GC_PTR_OFFSETS, W_BASE_EXCEPTION_SIZE, exc_kind_to_pytype,
 };
 use pyre_object::intobject::W_IntObject;
-use pyre_object::pyobject::{OB_TYPE_OFFSET, W_CLASS_OFFSET};
+use pyre_object::pyobject::W_CLASS_OFFSET;
 use pyre_object::{
     BOOL_INTVAL_OFFSET, FLOAT_ARRAY_BLOCK_OFFSET, FLOAT_ARRAY_LEN_OFFSET, INT_ARRAY_BLOCK_OFFSET,
     INT_ARRAY_LEN_OFFSET, INT_INTVAL_OFFSET, W_ListObject, W_TupleObject,
@@ -2740,32 +2740,6 @@ pub fn str_len_descr() -> DescrRef {
 }
 
 // ── Object header & allocation descriptors ──────────────────────────
-
-/// Field descriptor for ob_type (PyObject.ob_type pointer) — immutable.
-/// heaptracker.py:66: `if name == 'typeptr': continue`
-///
-/// One object per run, for the identity reason documented on
-/// [`W_CLASS_FIELD_DESCR`].
-static OB_TYPE_FIELD_DESCR: LazyLock<Arc<dyn FieldDescr>> = LazyLock::new(new_ob_type_field_descr);
-
-pub fn ob_type_descr() -> DescrRef {
-    OB_TYPE_FIELD_DESCR.clone() as DescrRef
-}
-
-fn new_ob_type_field_descr() -> Arc<dyn FieldDescr> {
-    Arc::new(PyreFieldDescr {
-        offset: OB_TYPE_OFFSET,
-        field_size: std::mem::size_of::<*const pyre_object::PyType>(),
-        field_type: Type::Int,
-        signed: false,
-        immutable: true,
-        quasi_immutable: false,
-        name: "typeptr",
-        index_in_parent: 0,
-        parent_descr: None,
-        ei_index: AtomicU32::new(u32::MAX),
-    })
-}
 
 /// Size descriptor for W_IntObject allocation via NewWithVtable.
 /// vtable = &INT_TYPE (ob_type for virtual materialization).

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/bridge_subwalk.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/bridge_subwalk.rs
@@ -1034,6 +1034,7 @@ pub(crate) fn drive_bridge_frame_subwalk<Sym: WalkSym>(
     local_oprefs: &[OpRef],
     local_concretes: &[majit_ir::Value],
     resumed_stack_oprefs: &[OpRef],
+    resumed_stack_concretes: &[majit_ir::Value],
     child_result: Option<OpRef>,
     paused_parent_recipes: &[majit_metainterp::ReconstructRecipe],
 ) -> Option<Result<(DispatchOutcome, usize), DispatchError>> {
@@ -1312,6 +1313,13 @@ pub(crate) fn drive_bridge_frame_subwalk<Sym: WalkSym>(
                 .unwrap()
                 .set_opref((stack_base + s) as i64, opref);
         }
+        for (s, &value) in resumed_stack_concretes.iter().enumerate() {
+            sub_wc.callee_shadow.as_mut().unwrap().set_concrete(
+                callee_pjc.metadata.portal_frame_reg,
+                (stack_base + s) as i64,
+                value,
+            );
+        }
         if let Some(frame) = ActiveResumeFrame::current(session, root_sym_ptr)
             && frame.0.jitcode.code.as_ptr() == callee_code.as_ptr()
             && frame.0.jitcode.code.len() == callee_code.len()
@@ -1377,6 +1385,7 @@ pub(crate) fn drive_bridge_carrier_subwalk<Sym: WalkSym>(
     local_oprefs: &[OpRef],
     local_concretes: &[majit_ir::Value],
     resumed_stack_oprefs: &[OpRef],
+    resumed_stack_concretes: &[majit_ir::Value],
     paused_parent_recipes: &[majit_metainterp::ReconstructRecipe],
 ) -> Option<Result<(DispatchOutcome, usize), DispatchError>> {
     drive_bridge_frame_subwalk(
@@ -1394,6 +1403,7 @@ pub(crate) fn drive_bridge_carrier_subwalk<Sym: WalkSym>(
         local_oprefs,
         local_concretes,
         resumed_stack_oprefs,
+        resumed_stack_concretes,
         None,
         paused_parent_recipes,
     )
@@ -1415,6 +1425,7 @@ pub(crate) fn drive_bridge_middle_frame<Sym: WalkSym>(
     local_oprefs: &[OpRef],
     local_concretes: &[majit_ir::Value],
     resumed_stack_oprefs: &[OpRef],
+    resumed_stack_concretes: &[majit_ir::Value],
     paused_parent_recipes: &[majit_metainterp::ReconstructRecipe],
     child_result: OpRef,
 ) -> Option<Result<(DispatchOutcome, usize), DispatchError>> {
@@ -1433,6 +1444,7 @@ pub(crate) fn drive_bridge_middle_frame<Sym: WalkSym>(
         local_oprefs,
         local_concretes,
         resumed_stack_oprefs,
+        resumed_stack_concretes,
         Some(child_result),
         paused_parent_recipes,
     )

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
@@ -715,8 +715,9 @@ pub fn fbw_foriter_inflight_take_for_resume(
         // re-reached the consume, so this item's body already ran) must never
         // be delivered either — that is the header-flush-without-delivery
         // shape ([`fbw_foriter_inflight_completed_at_resume`]).  Also refuse if
-        // either journal is non-empty or an unjournaled effect stands (same
-        // signals as `fbw_foriter_inflight_take`).
+        // either journal is non-empty or an unjournaled effect stands. Unlike
+        // legacy replay delivery, this branch adopts the walk's end state, so
+        // recorded-but-unexecuted residual work also makes it unsafe to flush.
         if stack[at].body_effect_since_consume
             || stack[at].body_completed
             || fbw_store_journal_len() != 0
@@ -781,20 +782,21 @@ pub(crate) fn fbw_foriter_inflight_top_body_pc() -> Option<usize> {
     })
 }
 
-/// Whether ANY of the three R1 body-effect signals is currently present:
-/// the body-effect-since-consume flag, either journal non-empty, or the
-/// unjournaled-effect flag.  These are the exact signals
+/// Whether ANY R1 committed-body-effect signal is currently present: the
+/// body-effect-since-consume flag or either journal non-empty. These are the
+/// exact signals
 /// [`fbw_foriter_inflight_take`] consults to REFUSE delivery, and `take`
 /// leaves them untouched.  Exposed for the deliver-path loud-failure
 /// debug-assert (#57 Finding #3): a successful take (delivery) while any
 /// signal stands would be a silent double, so the deliver site asserts this
-/// is `false` in debug builds.
+/// is `false` in debug builds. An unjournaled effect is deliberately NOT a
+/// member: it is recorded-but-unexecuted work that only this legacy replay
+/// will apply, so it requires delivery rather than making delivery unsafe.
 pub fn fbw_foriter_any_body_effect_signal() -> bool {
     fbw_foriter_body_effect_since_consume()
         || fbw_store_journal_len() != 0
         || FBW_APPEND_JOURNAL.with(|j| j.borrow().len()) != 0
         || FBW_CELL_STORE_JOURNAL.with(|j| j.borrow().len()) != 0
-        || fbw_has_unjournaled_effect()
 }
 
 /// Take the in-flight FOR_ITER continuation for delivery on a trace abort
@@ -805,7 +807,7 @@ pub fn fbw_foriter_any_body_effect_signal() -> bool {
 /// body, so any body op that ALREADY ran concretely during the aborted walk
 /// would be re-applied.  C may DELIVER only when it can PROVE no body effect
 /// committed for the in-flight iteration — then re-running the body cannot
-/// double.  Three signals together cover every committed body effect:
+/// double. Two signal classes cover every committed body effect:
 ///
 /// * `fbw_foriter_body_effect_since_consume()` — a non-elidable concrete
 ///   residual mutated the heap OUTSIDE the journals after the consume (a dict
@@ -817,12 +819,13 @@ pub fn fbw_foriter_any_body_effect_signal() -> bool {
 ///   `fbw_store_journal_rollback` empties these BEFORE this take, so this is
 ///   normally false here; the check is a belt-and-suspenders refusal in case
 ///   a future caller takes before the rollback.
-/// * `fbw_has_unjournaled_effect()` — a void/symbolic residual only the
-///   legacy replay applies, which the rollback cannot undo.
-///
 /// Any signal set → refuse delivery (drop the stash → the legacy bypass keeps
 /// the prior drop-on-abort behaviour for that shape, never a double).
-/// `for_mutate` aborts BEFORE the append's effect, so all three signals are
+/// `fbw_has_unjournaled_effect()` is the converse: the residual was recorded
+/// but NOT executed, and only the legacy replay applies it. It prevents an
+/// end-state commit, but it must not suppress delivery of the consumed item
+/// or that replay starts at the next iteration and drops this one.
+/// `for_mutate` aborts BEFORE the append's effect, so both signal classes are
 /// clear at the abort point — the clean continuation case.
 pub fn fbw_foriter_inflight_take() -> Option<(pyre_object::PyObjectRef, usize)> {
     // Take the MOST-RECENT (top) entry and drop the rest, matching the
@@ -844,7 +847,7 @@ pub fn fbw_foriter_inflight_take() -> Option<(pyre_object::PyObjectRef, usize)> 
     let append_len = FBW_APPEND_JOURNAL.with(|j| j.borrow().len());
     let cell_store_len = FBW_CELL_STORE_JOURNAL.with(|j| j.borrow().len());
     let unjournaled = fbw_has_unjournaled_effect();
-    if body_effect || store_len != 0 || append_len != 0 || cell_store_len != 0 || unjournaled {
+    if body_effect || store_len != 0 || append_len != 0 || cell_store_len != 0 {
         if fbw_debug_abort_enabled() {
             eprintln!(
                 "[fbw-foriter] deliver REFUSED (body effect committed since consume) body_pc={} \
@@ -864,6 +867,37 @@ pub fn fbw_foriter_inflight_take() -> Option<(pyre_object::PyObjectRef, usize)> 
         );
     }
     Some((stash.item, body_pc))
+}
+
+#[cfg(test)]
+mod foriter_delivery_tests {
+    use super::*;
+
+    #[test]
+    fn recorded_but_unexecuted_residual_keeps_consumed_item_for_replay() {
+        fbw_store_journal_reset();
+        let item = 1usize as pyre_object::PyObjectRef;
+        fbw_foriter_inflight_capture(item, InflightForiterBody::Py(34));
+        fbw_mark_unjournaled_effect(ResidualDecline::Symbolic);
+
+        assert!(!fbw_foriter_any_body_effect_signal());
+        assert_eq!(fbw_foriter_inflight_take(), Some((item, 34)));
+
+        fbw_store_journal_reset();
+    }
+
+    #[test]
+    fn executed_body_effect_still_refuses_consumed_item_delivery() {
+        fbw_store_journal_reset();
+        let item = 1usize as pyre_object::PyObjectRef;
+        fbw_foriter_inflight_capture(item, InflightForiterBody::Py(34));
+        fbw_mark_foriter_body_effect_since_consume();
+
+        assert!(fbw_foriter_any_body_effect_signal());
+        assert_eq!(fbw_foriter_inflight_take(), None);
+
+        fbw_store_journal_reset();
+    }
 }
 
 /// Non-commit epilogue: restore each displaced element in reverse push

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -468,10 +468,10 @@ pub struct WalkSession {
     /// `Snapshot.frames`; a caller is pushed at its inline CALL and popped
     /// when the callee sub-walk returns.
     pub framestack: Vec<InlineFrame>,
-    /// Whether the terminating permanent abort fired inside an inline
-    /// sub-walk. Its `op.pc` is then a callee coordinate with no meaning in
-    /// the outer snapshot root's py_pc→jitcode translation, so abort-point
-    /// flushing must decline after the sub-walk unwinds.
+    /// Whether an abort fired inside an inline sub-walk. Its `op.pc` is then a
+    /// callee coordinate with no meaning in an enclosing frame's JitCode, so
+    /// neither abort-point flushing nor a later caller-level blackhole latch
+    /// may consume it after the sub-walk unwinds.
     pub abort_in_subwalk: bool,
     /// Blackhole `tmpreg_r`/`tmpreg_i`/`tmpreg_f` (`blackhole.py`):
     /// the single-slot scratch that `insert_renamings` (`flatten.py`)
@@ -514,6 +514,24 @@ impl Default for WalkSession {
             recording_jitcode_index: -1,
             recording_opcode_position: 0,
         }
+    }
+}
+
+impl WalkSession {
+    /// Claim an abort coordinate for the frame whose `walk()` observed it.
+    ///
+    /// The first inline sub-walk to see the error owns its `pc` and may build
+    /// a multi-frame blackhole image from that coordinate. If that build
+    /// declines, enclosing `walk()` calls see the same `DispatchError`, but
+    /// its `pc` is still in the innermost JitCode. Returning `false` there
+    /// prevents a caller from pairing the callee coordinate with its own
+    /// frame — RPython keeps both on the same `MIFrame` throughout unwind.
+    pub(crate) fn claim_abort_coordinate(&mut self, inline_subwalk: bool) -> bool {
+        let claimed_by_deeper_frame = self.abort_in_subwalk;
+        if inline_subwalk {
+            self.abort_in_subwalk = true;
+        }
+        !claimed_by_deeper_frame
     }
 }
 
@@ -2634,6 +2652,10 @@ pub fn walk<Sym: WalkSym>(
                 // reset.  `VableEscapedDuringResidualCall` needs no exclusion —
                 // it latches its narrower resume-marker image at force time,
                 // before the error unwinds here, so the guard below defers to it.
+                let coordinate_belongs_to_this_frame = ctx
+                    .session
+                    .borrow_mut()
+                    .claim_abort_coordinate(ctx.fbw_mode.inline_subwalk);
                 let carrier_owned = matches!(
                     error,
                     DispatchError::AbortPermanentMarkerReached { .. }
@@ -2643,7 +2665,11 @@ pub fn walk<Sym: WalkSym>(
                 // reports a MISSING value cannot be converted, because the
                 // image it would hand the blackhole is the one that just
                 // failed to resolve ([`DispatchError::leaves_complete_image`]).
-                if error.leaves_complete_image() && !carrier_owned && !abort_blackhole_latched() {
+                if coordinate_belongs_to_this_frame
+                    && error.leaves_complete_image()
+                    && !carrier_owned
+                    && !abort_blackhole_latched()
+                {
                     let _ = latch_abort_blackhole(ctx, error.stop_pc());
                 }
                 return Err(error);

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -7100,7 +7100,6 @@ fn walker_unbox_int_typed<Sym: WalkSym>(
         ctx.trace_ctx,
         obj,
         type_addr,
-        crate::descr::ob_type_descr(),
         intval_descr,
     ))
 }
@@ -7193,7 +7192,6 @@ fn walker_unbox_float<Sym: WalkSym>(
         ctx.trace_ctx,
         obj,
         float_type_addr,
-        crate::descr::ob_type_descr(),
         crate::descr::float_floatval_descr(),
     ))
 }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -2652,10 +2652,15 @@ pub fn walk<Sym: WalkSym>(
                 // reset.  `VableEscapedDuringResidualCall` needs no exclusion —
                 // it latches its narrower resume-marker image at force time,
                 // before the error unwinds here, so the guard below defers to it.
-                let coordinate_belongs_to_this_frame = ctx
-                    .session
-                    .borrow_mut()
-                    .claim_abort_coordinate(ctx.fbw_mode.inline_subwalk);
+                // Do not consume the session's one-shot coordinate claim for
+                // a transparent helper: its opcode coordinate is not a Python
+                // resume coordinate, and the enclosing Python walk must still
+                // be able to claim and latch the propagated abort.
+                let coordinate_belongs_to_this_frame = !ctx.fbw_mode.transparent_helper_subwalk
+                    && ctx
+                        .session
+                        .borrow_mut()
+                        .claim_abort_coordinate(ctx.fbw_mode.inline_subwalk);
                 let carrier_owned = matches!(
                     error,
                     DispatchError::AbortPermanentMarkerReached { .. }
@@ -2665,6 +2670,15 @@ pub fn walk<Sym: WalkSym>(
                 // reports a MISSING value cannot be converted, because the
                 // image it would hand the blackhole is the one that just
                 // failed to resolve ([`DispatchError::leaves_complete_image`]).
+                //
+                // A translated builtin gateway is not an MIFrame.  Let its
+                // error unwind to the enclosing Python walk, where the same
+                // latch is built from that frame's own register banks.  If we
+                // latch here, `build_multi_frame_miframe` appends the helper's
+                // r0 args-slice as though it were a Python red frame and the
+                // blackhole resume loses per-frame identity.  This is the
+                // abort counterpart of the transparent-helper guard snapshot
+                // and trace-limit handling below.
                 if coordinate_belongs_to_this_frame
                     && error.leaves_complete_image()
                     && !carrier_owned
@@ -2706,7 +2720,16 @@ pub fn walk<Sym: WalkSym>(
         // fallback because replay would apply an irreversible effect twice.
         // The remaining overshoot is tallied so an unsupported multi-frame
         // shape cannot silently become unbounded.
-        if ctx.trace_ctx.is_too_long() {
+        // A translated builtin gateway is transparent to the Python MIFrame
+        // stack and has no blackhole entry point of its own.  Its bytecode is
+        // one implementation detail of the enclosing Python CALL step, so do
+        // not split the trace in the middle of it: doing so would have to pair
+        // helper registers (r0 is commonly an args slice) with a Python
+        // JitCode's red-frame register.  Finish the helper and let the
+        // enclosing Python `walk()` perform this same post-step limit check at
+        // its real per-frame coordinate, matching RPython's one-red-frame
+        // ownership.
+        if !ctx.fbw_mode.transparent_helper_subwalk && ctx.trace_ctx.is_too_long() {
             // `step` has advanced the register banks for `Continue`. The
             // other outcomes still need the match below to perform their
             // frame transition: in particular, `SubRaise` may enter this

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -9796,6 +9796,7 @@ fn handle<Sym: WalkSym>(
         // vtable word, so nothing is known about its class.
         "new/d>r" => {
             let descr = read_descr(code, op, 0, ctx)?;
+            let concrete = ctx.trace_ctx.execute_new_allocation(&descr, false);
             // pyjitpl.py:624-629 `execute_new`.
             ctx.trace_ctx
                 .profiler()
@@ -9806,7 +9807,16 @@ fn handle<Sym: WalkSym>(
             let resbox = ctx.trace_ctx.record_op_with_descr(OpCode::New, &[], descr);
             ctx.trace_ctx.heap_cache_mut().new_object(resbox);
             let dst = code[op.pc + 3] as usize;
-            write_ref_reg(ctx, op.pc, dst, resbox, ConcreteValue::Null)?;
+            if let Some(value) = concrete {
+                ctx.trace_ctx.set_opref_concrete(resbox, value);
+            }
+            let concrete = match concrete {
+                Some(Value::Ref(majit_ir::GcRef(ptr))) => {
+                    ConcreteValue::Ref(ptr as pyre_object::PyObjectRef)
+                }
+                _ => ConcreteValue::Null,
+            };
+            write_ref_reg(ctx, op.pc, dst, resbox, concrete)?;
             Ok((DispatchOutcome::Continue, op.next_pc))
         }
         // RPython `pyjitpl.py opimpl_new_with_vtable` delegates straight to
@@ -9821,6 +9831,15 @@ fn handle<Sym: WalkSym>(
         // `new_with_vtable` pushes the descr u16 then the result reg).
         "new_with_vtable/d>r" => {
             let descr = read_descr(code, op, 0, ctx)?;
+            let concrete = ctx.trace_ctx.execute_new_allocation(&descr, true);
+            if let Some(Value::Ref(majit_ir::GcRef(ptr))) = concrete
+                && let Some(w_class) = descr.as_size_descr().and_then(|size| size.w_class_obj())
+            {
+                unsafe {
+                    (*(ptr as *mut pyre_object::PyObject)).w_class =
+                        w_class as pyre_object::PyObjectRef;
+                }
+            }
             // `class_now_known` takes the vtable address: pyre tracks the
             // concrete class pointer where upstream only raises HF_KNOWN_CLASS.
             let known_class = descr.as_size_descr().map(|size| size.vtable() as i64);
@@ -9842,11 +9861,16 @@ fn handle<Sym: WalkSym>(
                     .class_now_known(resbox, class);
             }
             let dst = code[op.pc + 3] as usize;
-            // No recording-time concrete: the walk never allocated a real
-            // object, so readers of the result decline instead of consuming a
-            // stale value — the posture `new_array_clear` keeps whenever it
-            // cannot materialize a backing block.
-            write_ref_reg(ctx, op.pc, dst, resbox, ConcreteValue::Null)?;
+            if let Some(value) = concrete {
+                ctx.trace_ctx.set_opref_concrete(resbox, value);
+            }
+            let concrete = match concrete {
+                Some(Value::Ref(majit_ir::GcRef(ptr))) => {
+                    ConcreteValue::Ref(ptr as pyre_object::PyObjectRef)
+                }
+                _ => ConcreteValue::Null,
+            };
+            write_ref_reg(ctx, op.pc, dst, resbox, concrete)?;
             Ok((DispatchOutcome::Continue, op.next_pc))
         }
         // RPython `pyjitpl.py opimpl_new_array_clear` —

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/resume_snapshot.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/resume_snapshot.rs
@@ -1884,9 +1884,12 @@ pub(crate) fn compute_nested_inline_caller_frame<Sym: WalkSym>(
 }
 
 /// Capture the current inlined Python frame at a translated helper call's
-/// entry boundary. The helper has no blackhole frame, so a guard inside it
-/// must rebuild this frame at the CALL and re-execute the helper, while the
-/// already-paused outer frames remain below it.
+/// entry boundary. The helper has no Python/blackhole frame of its own, so a
+/// guard inside it must rebuild its Python caller at the CALL and re-execute
+/// the helper, while the already-paused outer frames remain below it. The
+/// caller still needs its own concrete blackhole image: without it the
+/// multi-frame conversion declines and the helper-local abort pc can escape
+/// into an outer frame's coordinate space.
 pub(crate) fn compute_inline_helper_call_entry_frame<Sym: WalkSym>(
     ctx: &mut WalkContext<'_, '_, Sym>,
     call_jit_pc: usize,
@@ -1921,7 +1924,7 @@ pub(crate) fn compute_inline_helper_call_entry_frame<Sym: WalkSym>(
         jitcode_index,
         call_jitcode_pc: None,
         call_stack_overrides: Vec::new(),
-        blackhole: None,
+        blackhole: capture_inline_parent_blackhole(ctx, jitcode_index, call_jit_pc),
         resume_coord: ParentResumeCoord::Backxlat(resume_marker_jit_pc),
         resume_marker_jit_pc: Some(resume_marker_jit_pc),
         boxes,

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -1739,6 +1739,32 @@ pub(crate) fn try_walker_specialize_truediv_op_long<Sym: WalkSym>(
     Ok(Some(()))
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum SpecialisedPairKind {
+    Int,
+    Float,
+    Object,
+}
+
+/// Identify the three classes produced by
+/// `specialisedtupleobject.py:169-179 makespecialisedtuple2`.
+pub(crate) fn specialised_pair_kind(
+    seq_type: *const pyre_object::pyobject::PyType,
+) -> Option<SpecialisedPairKind> {
+    use pyre_object::specialisedtupleobject::{
+        SPECIALISED_TUPLE_FF_TYPE, SPECIALISED_TUPLE_II_TYPE, SPECIALISED_TUPLE_OO_TYPE,
+    };
+    if std::ptr::eq(seq_type, &SPECIALISED_TUPLE_II_TYPE) {
+        Some(SpecialisedPairKind::Int)
+    } else if std::ptr::eq(seq_type, &SPECIALISED_TUPLE_FF_TYPE) {
+        Some(SpecialisedPairKind::Float)
+    } else if std::ptr::eq(seq_type, &SPECIALISED_TUPLE_OO_TYPE) {
+        Some(SpecialisedPairKind::Object)
+    } else {
+        None
+    }
+}
+
 /// FBW fold of the UNPACK_SEQUENCE two-residual lowering (`unpack_sequence_fn`
 /// validator + per-index `unpack_item_fn` reader emitted by the codewriter
 /// UNPACK_SEQUENCE arm) for an arity-2 specialised tuple: guard the
@@ -1755,6 +1781,8 @@ pub(crate) fn try_walker_specialize_truediv_op_long<Sym: WalkSym>(
 ///     `getfield_gc_pure_i` + `wrapint` and the items stay unboxed through the
 ///     downstream BINARY_OP int fold (the walker analogue of the retired
 ///     MIFrame `W_SpecialisedTupleObject_ii` reads);
+///   * `ff` — the same shape with `getfield_gc_pure_f` + `wrapfloat`; this is
+///     the representation `zip` produces for a pair of exact floats;
 ///   * `oo` — `wraps[i]` for an object slot is the identity
 ///     (`specialisedtupleobject.py:26-27`), so the `getfield_gc_r` result is
 ///     already the item. This is the layout a `divmod(long, long)` result pair
@@ -1879,16 +1907,11 @@ pub(crate) fn try_walker_specialize_unpack<Sym: WalkSym>(
     // Both arity-2 specialisations fold; any other shape (a plain tuple, a
     // list, or a non-canonical tuple) falls through to the opaque residual
     // (correct, slower).
-    let spec_ii = &pyre_object::specialisedtupleobject::SPECIALISED_TUPLE_II_TYPE
-        as *const pyre_object::pyobject::PyType;
-    let spec_oo = &pyre_object::specialisedtupleobject::SPECIALISED_TUPLE_OO_TYPE
-        as *const pyre_object::pyobject::PyType;
     let seq_type = unsafe { (*concrete_seq).ob_type };
-    let is_oo = std::ptr::eq(seq_type, spec_oo);
-    if !is_oo && !std::ptr::eq(seq_type, spec_ii) {
+    let Some(pair_kind) = specialised_pair_kind(seq_type) else {
         return Ok(None);
-    }
-    let spec_type = if is_oo { spec_oo } else { spec_ii };
+    };
+    let spec_type = seq_type;
     match helper {
         majit_ir::PyreHelperKind::UnpackSequence => {
             // Either specialisation is always arity 2, so the class guard
@@ -1911,7 +1934,7 @@ pub(crate) fn try_walker_specialize_unpack<Sym: WalkSym>(
             // which case this is a no-op; guard here too so a fold that only
             // catches the item reads still proves the layout it loads from.
             walker_guard_specialised_pair_class(ctx, op_pc, seq, spec_type)?;
-            if is_oo {
+            if pair_kind == SpecialisedPairKind::Object {
                 let descr = if int_val == 0 {
                     crate::descr::specialised_tuple_oo_value0_descr()
                 } else {
@@ -1924,11 +1947,34 @@ pub(crate) fn try_walker_specialize_unpack<Sym: WalkSym>(
                 write_residual_call_result_to_dst(ctx, op_pc, dst, dst_bank, item)?;
                 return Ok(Some(()));
             }
-            // Authentic boxed element (small-int caching / identity); fall
-            // through to the opaque residual if it cannot be executed.
+            // Authentic boxed element supplies the concrete shadow / identity
+            // while the emitted field read and transparent wrapper replace
+            // the residual call in machine code. Fall through if execution
+            // raises or cannot provide that box.
             let Some(elem_ptr) = walker_execute_may_force_boxed(ctx, allboxes, call_descr) else {
                 return Ok(None);
             };
+            if pair_kind == SpecialisedPairKind::Float {
+                let descr = if int_val == 0 {
+                    crate::descr::specialised_tuple_ff_value0_descr()
+                } else {
+                    crate::descr::specialised_tuple_ff_value1_descr()
+                };
+                let raw =
+                    majit_metainterp::box_trace::getfield_gc_f_pureornot(ctx.trace_ctx, seq, descr);
+                let elem =
+                    unsafe { pyre_object::w_float_get_value(elem_ptr as pyre_object::PyObjectRef) };
+                ctx.trace_ctx
+                    .set_opref_concrete(raw, majit_ir::Value::Float(elem));
+                let boxed = crate::state::wrapfloat(ctx.trace_ctx, raw);
+                ctx.trace_ctx.set_opref_concrete(
+                    boxed,
+                    majit_ir::Value::Ref(majit_ir::GcRef(elem_ptr as usize)),
+                );
+                write_residual_call_result_to_dst(ctx, op_pc, dst, dst_bank, boxed)?;
+                return Ok(Some(()));
+            }
+            // `ii`: preserve authentic small-int caching / identity.
             let descr = if int_val == 0 {
                 crate::descr::specialised_tuple_ii_value0_descr()
             } else {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
@@ -3,6 +3,15 @@ use crate::jitcode_runtime::{insns_opname_to_byte, named_jitcode};
 use majit_ir::Type;
 use majit_metainterp::make_fail_descr;
 
+#[test]
+fn propagated_subwalk_abort_cannot_rebind_its_pc_to_a_caller_frame() {
+    let mut session = WalkSession::default();
+
+    assert!(session.claim_abort_coordinate(true));
+    assert!(!session.claim_abort_coordinate(true));
+    assert!(!session.claim_abort_coordinate(false));
+}
+
 fn test_fbw_mode() -> FbwWalkMode<crate::state::PyreSym> {
     FbwWalkMode::default()
 }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
@@ -173,12 +173,19 @@ fn item_pool_descr_index(code: &[u8], at: usize) -> u32 {
 
 #[test]
 fn random_core_residuals_use_registered_genrand32_address() {
-    let expected = pyre_interpreter::jit_trace_fnaddrs()
-        .into_iter()
-        .find_map(|(path, address)| {
+    let bindings = pyre_interpreter::jit_trace_fnaddrs();
+    let expected = bindings
+        .iter()
+        .find_map(|&(path, address)| {
             (path == "module::_random::Random::genrand32").then_some(address)
         })
         .expect("genrand32 runtime fnaddr");
+    let cast_uint_to_float = bindings
+        .iter()
+        .find_map(|&(path, address)| {
+            (path == "majit_metainterp::cast_uint_to_float").then_some(address)
+        })
+        .expect("cast_uint_to_float runtime fnaddr");
     let random = crate::jitcode_runtime::all_jitcodes()
         .iter()
         .find(|jitcode| {
@@ -198,6 +205,15 @@ fn random_core_residuals_use_registered_genrand32_address() {
             .count(),
         1,
         "the two genrand32 calls share one runtime-patched constant-pool address"
+    );
+    assert_eq!(
+        random
+            .constants_i
+            .iter()
+            .filter(|&&address| address == cast_uint_to_float)
+            .count(),
+        1,
+        "the two unsigned-to-float conversions share the registered support-helper address"
     );
 }
 

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
@@ -12,6 +12,17 @@ fn propagated_subwalk_abort_cannot_rebind_its_pc_to_a_caller_frame() {
     assert!(!session.claim_abort_coordinate(false));
 }
 
+#[test]
+fn specialised_pair_unpack_recognises_the_float_layout() {
+    use super::specialize::{SpecialisedPairKind, specialised_pair_kind};
+    use pyre_object::specialisedtupleobject::SPECIALISED_TUPLE_FF_TYPE;
+
+    assert_eq!(
+        specialised_pair_kind(&SPECIALISED_TUPLE_FF_TYPE),
+        Some(SpecialisedPairKind::Float),
+    );
+}
+
 fn test_fbw_mode() -> FbwWalkMode<crate::state::PyreSym> {
     FbwWalkMode::default()
 }

--- a/pyre/pyre-jit-trace/src/jitcode_runtime.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_runtime.rs
@@ -2122,7 +2122,6 @@ mod tests {
         let expected = [
             "abort/>r",
             "assert_not_none/r",
-            "cast_float_to_int/f>i",
             "cast_int_to_float/i>f",
             "cast_int_to_ptr/i>r",
             "check_neg_index/rid>i",

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -3627,13 +3627,7 @@ pub(crate) fn trace_unbox_int_with_resume_descr<F: crate::walker_frame_ops::Walk
             .heap_cache_mut()
             .class_now_known(obj, type_addr);
     }
-    crate::trace_unbox_int(
-        frame.ctx_mut(),
-        obj,
-        type_addr,
-        crate::descr::ob_type_descr(),
-        intval_descr,
-    )
+    crate::trace_unbox_int(frame.ctx_mut(), obj, type_addr, intval_descr)
 }
 
 /// Unbox a `W_LongObject` (whose BigInt fits in i64) into a raw i64 OpRef.
@@ -3717,7 +3711,6 @@ pub(crate) fn trace_unbox_float_with_resume<F: crate::walker_frame_ops::WalkerFr
         frame.ctx_mut(),
         obj,
         float_type_addr,
-        crate::descr::ob_type_descr(),
         crate::descr::float_floatval_descr(),
     )
 }
@@ -11237,10 +11230,9 @@ mod tests {
     use pyre_interpreter::bytecode::{CodeObject, ConstantData, Instruction};
     use pyre_interpreter::pyopcode::decode_instruction_at;
     use pyre_interpreter::{Mode, compile_exec, compile_source};
-    use pyre_object::OB_TYPE_OFFSET;
     use pyre_object::floatobject::w_float_get_value;
     use pyre_object::listobject::w_list_getitem;
-    use pyre_object::pyobject::{INT_TYPE, LIST_TYPE, PyType, is_list};
+    use pyre_object::pyobject::{INT_TYPE, PyType, is_list};
     use std::cell::{Cell, UnsafeCell};
 
     #[test]
@@ -12278,18 +12270,6 @@ mod tests {
     }
 
     #[test]
-    fn test_trace_ob_type_descr_uses_immutable_header_field_descr() {
-        let descr = crate::descr::ob_type_descr();
-        let field = descr
-            .as_field_descr()
-            .expect("ob_type descr must be a field descr");
-        assert_eq!(field.offset(), OB_TYPE_OFFSET);
-        assert_eq!(field.field_type(), Type::Int);
-        assert!(descr.is_always_pure());
-        assert!(field.is_immutable());
-    }
-
-    #[test]
     fn test_pypyjit_driver_descriptor_matches_interp_jit_layout() {
         let descriptor = PyreJitState::pypyjit_driver_descriptor();
 
@@ -12879,10 +12859,6 @@ mod tests {
             descr: None,
             type_id: 0,
             fields: vec![
-                (
-                    crate::descr::ob_type_descr().index(),
-                    MaterializedValue::Value(&LIST_TYPE as *const PyType as usize as i64),
-                ),
                 (
                     crate::descr::list_length_descr().index(),
                     MaterializedValue::Value(2),

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -1950,6 +1950,30 @@ pub(crate) fn semantic_ref_slot_for_reg_color(
     semantic_slot_for_reg_color(nlocals, stack_only, pcdep_entries, 1, reg)
 }
 
+/// Every live semantic Ref slot owned by one post-regalloc color at this PC.
+/// A COPY/short-circuit shape may deliberately map the same MIFrame register
+/// to more than one semantic stack slot; rebuilding pyre's slot-indexed frame
+/// mirror must fan that single register value out to all of them.
+pub(crate) fn semantic_ref_slots_for_reg_color(
+    nlocals: usize,
+    stack_only: usize,
+    pcdep_entries: &[(u8, u16, u16)],
+    reg: usize,
+) -> Vec<usize> {
+    let mut slots = Vec::new();
+    for &(bank, color, slot) in pcdep_entries {
+        if bank != 1 || color as usize != reg {
+            continue;
+        }
+        let slot = slot as usize;
+        let live = slot < nlocals || slot - nlocals < stack_only;
+        if live && slots.last().copied() != Some(slot) {
+            slots.push(slot);
+        }
+    }
+    slots
+}
+
 /// Per-PC `(bank, color, slot)` map inversion: given a register bank and
 /// color, return the semantic `locals_cells_stack_w` slot it maps to at the
 /// current PC. Prefer stack slots over locals (stack_match.or(local_match)).
@@ -2524,6 +2548,7 @@ pub trait WalkSym {
     fn registers_f_mut(&mut self) -> &mut Vec<OpRef>;
     fn nlocals(&self) -> usize;
     fn valuestackdepth(&self) -> usize;
+    fn set_valuestackdepth(&mut self, value: usize);
     fn jitcode(&self) -> *const JitCode;
     fn concrete_execution_context(&self) -> *const pyre_interpreter::PyExecutionContext;
     /// Interpreter-frame snapshot the authoritative walker steps concretely.
@@ -2626,6 +2651,11 @@ impl WalkSym for PyreSym {
     #[inline]
     fn valuestackdepth(&self) -> usize {
         self.valuestackdepth
+    }
+
+    #[inline]
+    fn set_valuestackdepth(&mut self, value: usize) {
+        self.valuestackdepth = value;
     }
 
     #[inline]
@@ -7496,27 +7526,33 @@ fn reconstruct_inline_recipe(
         let mut stream_slots: Vec<(usize, usize)> = Vec::new();
         let mut stream_covered = vec![false; valuestackdepth];
         for (pos, &color) in reg_indices.ref_.iter().enumerate() {
-            if color == pframe_reg || color == pec_reg {
-                continue;
-            }
-            let Some(slot) = semantic_ref_slot_for_reg_color(
+            let slots = semantic_ref_slots_for_reg_color(
                 nlocals,
                 stack_only,
                 &maps.pcdep_entries,
                 color as usize,
-            ) else {
-                continue;
-            };
-            // The pending call result is delivered by `make_result_of_lastop`,
-            // not from resumedata, so its slot stays unwritten here.
-            if slot >= valuestackdepth
-                || Some(slot) == pending_result_abs_slot
-                || stream_covered[slot]
-            {
+            );
+            if slots.is_empty() {
+                // A portal red is a scratch value only when this per-PC map
+                // gives its color no semantic owner.  The entry-time frame/ec
+                // colors may be reused for live operands at arbitrary resume
+                // PCs; in that case the resume stream is authoritative and
+                // must overlay the callee's own frame image below.
                 continue;
             }
-            stream_covered[slot] = true;
-            stream_slots.push((pos, slot));
+            for slot in slots {
+                // The pending call result is delivered by
+                // `make_result_of_lastop`, not from resumedata, so its slot
+                // stays unwritten here.
+                if slot >= valuestackdepth
+                    || Some(slot) == pending_result_abs_slot
+                    || stream_covered[slot]
+                {
+                    continue;
+                }
+                stream_covered[slot] = true;
+                stream_slots.push((pos, slot));
+            }
         }
         if !stream_slots.is_empty() {
             crate::jitcode_dispatch::census_record("P2Recipe::StreamSlotOverImage");
@@ -11808,6 +11844,22 @@ mod tests {
         assert_eq!(
             semantic_ref_slot_for_reg_color(2, 1, &[(1, 0, 0), (1, 0, 2), (1, 1, 1)], 0),
             Some(2),
+        );
+    }
+
+    #[test]
+    fn semantic_ref_slots_fan_out_a_copied_live_stack_color() {
+        // JUMP_IF_FALSE_OR_POP/COPY can keep the same MIFrame register in two
+        // semantic stack positions.  A slot-indexed reconstructed frame must
+        // restore both positions from that one resume-stream value.
+        assert_eq!(
+            semantic_ref_slots_for_reg_color(
+                2,
+                2,
+                &[(1, 0, 0), (1, 4, 2), (1, 4, 3), (1, 5, 4)],
+                4,
+            ),
+            vec![2, 3],
         );
     }
 

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -1444,7 +1444,7 @@ fn select_recipe_entry(
         .flatten()
 }
 
-fn residual_ref_call_dst_before(code: &[u8], entry: usize) -> Option<usize> {
+fn residual_ref_call_before(code: &[u8], entry: usize) -> Option<(usize, usize)> {
     crate::jitcode_runtime::decoded_ops(code)
         .find(|op| op.next_pc == entry && op.opname.starts_with("residual_call"))
         .and_then(|op| {
@@ -1452,8 +1452,17 @@ fn residual_ref_call_dst_before(code: &[u8], entry: usize) -> Option<usize> {
                 .ends_with(">r")
                 .then(|| code.get(entry - 1).copied())
                 .flatten()
+                .map(|dst| (op.pc, usize::from(dst)))
         })
-        .map(usize::from)
+}
+
+/// `MIFrame.make_result_of_lastop` pushes a completed call's result at the
+/// top of the caller's post-call operand stack.  This semantic slot is
+/// independent of the post-regalloc result color.
+fn pending_call_result_semantic_slot(nlocals: usize, post_call_depth: usize) -> Option<usize> {
+    post_call_depth
+        .checked_sub(1)
+        .and_then(|top| nlocals.checked_add(top))
 }
 
 /// Issue #215 item 2 (P2 drain): drive a multiframe bridge-carrier resume via
@@ -1484,27 +1493,15 @@ fn residual_ref_call_dst_before(code: &[u8], entry: usize) -> Option<usize> {
 /// The result is always mirrored into `bridge_registers_r` for interior-entry
 /// bridge walks, whose Ref-bank seed is color-indexed. Opcode-entry bridge
 /// walks rebuild slot-indexed locals and operand-stack values from
-/// `bridge_local_oprefs` / `bridge_stack_oprefs`, so invert the destination
-/// color through the resume pc's color→semantic-slot map before mirroring it
-/// there. Treating a post-regalloc color as a localsplus slot corrupts an
-/// unrelated local whenever regalloc coalesces the call result.
+/// `bridge_local_oprefs` / `bridge_stack_oprefs`.  RPython's
+/// `MIFrame.make_result_of_lastop` puts the return value at the top of the
+/// caller's post-call operand stack, so derive that semantic slot from the
+/// codewriter's after-residual depth twin.  The result is not a live Variable
+/// at this coordinate and therefore need not have a pcdep color→slot entry.
+/// Treating its post-regalloc color as a localsplus slot corrupts an unrelated
+/// local whenever regalloc coalesces the call result.
 /// Returns `false` (caller declines the compile) when the register is
 /// unresolved.
-/// `PYRE_INJECT_RCA`: report each engagement of the raw-color result-slot
-/// fallback below, with its coordinate.
-fn inject_rca_enabled() -> bool {
-    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *ENABLED.get_or_init(|| std::env::var_os("PYRE_INJECT_RCA").is_some())
-}
-
-/// `PYRE_INJECT_FALLBACK_DECLINE`: decline the bridge compile instead of
-/// engaging the raw-color fallback — the A/B control for attributing a
-/// wrong-slot injection.
-fn inject_fallback_decline_enabled() -> bool {
-    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *ENABLED.get_or_init(|| std::env::var_os("PYRE_INJECT_FALLBACK_DECLINE").is_some())
-}
-
 fn inject_root_call_result<Sym: WalkSym>(
     sym: &mut Sym,
     root_pc: usize,
@@ -1514,13 +1511,13 @@ fn inject_root_call_result<Sym: WalkSym>(
         return false;
     }
     let payload = unsafe { &(*sym.jitcode()).payload };
-    let result_reg = residual_ref_call_dst_before(payload.jitcode.code.as_slice(), root_pc)
-        .or_else(|| {
-            payload
-                .result_color_trivia_for_jitcode_pc(root_pc)
-                .map(|c| c as usize)
-                .filter(|&c| c != u16::MAX as usize)
-        });
+    let residual_call = residual_ref_call_before(payload.jitcode.code.as_slice(), root_pc);
+    let result_reg = residual_call.map(|(_, dst)| dst).or_else(|| {
+        payload
+            .result_color_trivia_for_jitcode_pc(root_pc)
+            .map(|c| c as usize)
+            .filter(|&c| c != u16::MAX as usize)
+    });
     let Some(result_reg) = result_reg else {
         return false;
     };
@@ -1531,48 +1528,13 @@ fn inject_root_call_result<Sym: WalkSym>(
         }
         bridge_regs[result_reg] = result;
     }
-    let valuestackdepth = sym.valuestackdepth();
-    let stack_only = valuestackdepth.saturating_sub(nlocals);
-    let semantic_result_slot = payload
-        .jitcode
-        .try_index()
-        .map(|index| crate::state::bridge_semantic_maps_from_pc(index as i32, root_pc as i32))
-        .and_then(|maps| {
-            crate::state::semantic_ref_slot_for_reg_color(
-                nlocals,
-                stack_only,
-                &maps.pcdep_entries,
-                result_reg,
-            )
-        })
-        // The raw-color fallback is load-bearing and simultaneously wrong,
-        // so neither keeping nor deleting it is the answer:
-        //
-        //   fib_recursive, dynasm, the one resume that misses the map —
-        //   `pc=569 reg=0 nlocals=1 stack_only=2 vsd=3`, entries
-        //   `[(1,0,4),(1,2,1),(1,3,2)]`.  Color 0 IS mapped, to semantic slot
-        //   4; the inversion rejects it because `4 - nlocals` is at/above the
-        //   runtime `stack_only`, which is what that gate is for.  The
-        //   fallback then answers slot 0 — a LOCAL, not the operand-stack slot
-        //   the map named.  Deleting it declines this bridge and costs 16x
-        //   (0.86s -> 14.2s), so the decline is not an option either.
-        //
-        // The result slot is by construction the one about to be pushed, i.e.
-        // at/above the resume's live depth, so resolving it needs a query that
-        // does not gate on that depth.  Until that resolves at this
-        // coordinate, keep the fallback and its measured cost visible.
-        .or_else(|| {
-            if inject_rca_enabled() {
-                eprintln!(
-                    "[inject-rca] FALLBACK jitcode={:?} pc={root_pc} reg={result_reg} nlocals={nlocals} stack_only={stack_only} vsd={valuestackdepth}",
-                    payload.jitcode.try_index()
-                );
-            }
-            if inject_fallback_decline_enabled() {
-                return None;
-            }
-            (result_reg < valuestackdepth).then_some(result_reg)
-        });
+    let post_call_depth = residual_call
+        .and_then(|(call_pc, _)| payload.depth_after_residual_for_jitcode_pc(call_pc))
+        .map(usize::from);
+    let Some(post_call_depth) = post_call_depth else {
+        return false;
+    };
+    let semantic_result_slot = pending_call_result_semantic_slot(nlocals, post_call_depth);
     let Some(semantic_result_slot) = semantic_result_slot else {
         return false;
     };
@@ -1591,6 +1553,11 @@ fn inject_root_call_result<Sym: WalkSym>(
         }
         bridge[slot] = result;
     }
+    // `MIFrame.make_result_of_lastop` both stores the value and advances the
+    // caller's stack pointer.  Without the matching depth update,
+    // `init_symbolic` sizes its resumed stack from the pre-call depth and
+    // truncates the just-injected top slot.
+    sym.set_valuestackdepth(nlocals + post_call_depth);
     true
 }
 
@@ -1801,6 +1768,9 @@ fn drive_bridge_carrier_walk<Sym: WalkSym>(
     let local_concretes = &recipe.concrete_r[..nlocals];
     let stack_end = recipe.valuestackdepth.min(recipe.registers_r.len());
     let resumed_stack_oprefs = &recipe.registers_r[nlocals.min(stack_end)..stack_end];
+    let concrete_stack_end = recipe.valuestackdepth.min(recipe.concrete_r.len());
+    let resumed_stack_concretes =
+        &recipe.concrete_r[nlocals.min(concrete_stack_end)..concrete_stack_end];
     // Increment 2b-i: drive the deepest callee as an inline SUB-WALK rooted on
     // the portal `sym` (is_top_level=false), so its `ref_return` surfaces
     // `SubReturn` instead of the top-level `Finish` pyre's own-portal model
@@ -1820,6 +1790,7 @@ fn drive_bridge_carrier_walk<Sym: WalkSym>(
         local_oprefs,
         local_concretes,
         resumed_stack_oprefs,
+        resumed_stack_concretes,
         // Depth-N: tell the deepest sub-walk that all shallower frames are
         // paused so its in-callee guard snapshots encode the full
         // [root, ..middles.., deepest] chain (else the blackhole rebuilds a
@@ -2151,6 +2122,9 @@ fn drive_middle_frame_and_thread<Sym: WalkSym>(
     let middle_stack_end = middle.valuestackdepth.min(middle.registers_r.len());
     let middle_stack_oprefs =
         &middle.registers_r[middle_nlocals.min(middle_stack_end)..middle_stack_end];
+    let middle_concrete_stack_end = middle.valuestackdepth.min(middle.concrete_r.len());
+    let middle_stack_concretes = &middle.concrete_r
+        [middle_nlocals.min(middle_concrete_stack_end)..middle_concrete_stack_end];
     let middle_walk = crate::jitcode_dispatch::drive_bridge_middle_frame(
         ctx,
         session,
@@ -2166,6 +2140,7 @@ fn drive_middle_frame_and_thread<Sym: WalkSym>(
         middle_local_oprefs,
         middle_local_concretes,
         middle_stack_oprefs,
+        middle_stack_concretes,
         paused_parents,
         child_result,
     );
@@ -3661,6 +3636,29 @@ fn run_perfn_walk<Sym: WalkSym>(
                         let color = (nl + i) as u8;
                         seed(color, opref);
                     }
+                }
+                // The value just returned by an in-flight callee is the one
+                // non-pcdep operand at this opcode-entry coordinate.  RPython
+                // has already installed it in the caller MIFrame's result
+                // register via `make_result_of_lastop`; mirror that exact
+                // color from the resumed bank.  Slot-position seeding above
+                // cannot recover it under free register coloring (for
+                // Fraction.__rpow__, semantic slot 3 is color r9).
+                let pending_result_color =
+                    residual_ref_call_before(pjc.jitcode.code.as_slice(), entry)
+                        .map(|(_, dst)| dst)
+                        .or_else(|| {
+                            pjc.result_color_trivia_for_jitcode_pc(entry)
+                                .map(usize::from)
+                                .filter(|&color| color != usize::from(u16::MAX))
+                        });
+                if let Some((color, opref)) = pending_result_color.and_then(|color| {
+                    sym.bridge_registers_r()
+                        .and_then(|regs| regs.get(color).copied())
+                        .filter(|opref| !opref.is_none())
+                        .map(|opref| (color, opref))
+                }) {
+                    seed(color as u8, opref);
                 }
             }
         }
@@ -5787,6 +5785,15 @@ mod tests {
                 bank: "r",
             }
         ));
+    }
+
+    #[test]
+    fn pending_call_result_uses_post_call_stack_top_not_register_color() {
+        // The motivating coalesced shape has result color 0, nlocals=1, and
+        // post-call operand depth 4.  The result belongs to semantic slot 4;
+        // writing color 0 as slot 0 would overwrite the caller's local.
+        assert_eq!(super::pending_call_result_semantic_slot(1, 4), Some(4));
+        assert_eq!(super::pending_call_result_semantic_slot(1, 0), None);
     }
 
     #[test]

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -510,9 +510,8 @@ fn concrete_list_strategy_id(concrete: PyObjectRef) -> Option<i64> {
 }
 
 use crate::descr::{
-    float_floatval_descr, int_intval_descr, list_strategy_descr, ob_type_descr,
-    slice_w_start_descr, slice_w_step_descr, slice_w_stop_descr, w_float_size_descr,
-    w_int_size_descr,
+    float_floatval_descr, int_intval_descr, list_strategy_descr, slice_w_start_descr,
+    slice_w_step_descr, slice_w_stop_descr, w_float_size_descr, w_int_size_descr,
 };
 use crate::frame_layout::{
     PYFRAME_DEBUGDATA_OFFSET, PYFRAME_LASTBLOCK_OFFSET, PYFRAME_PYCODE_OFFSET,
@@ -1910,7 +1909,6 @@ impl MIFrame {
                         ctx,
                         value,
                         w_int_size_descr(),
-                        ob_type_descr(),
                         int_intval_descr(),
                         int_type_addr,
                     )
@@ -1921,7 +1919,6 @@ impl MIFrame {
                         ctx,
                         value,
                         w_float_size_descr(),
-                        ob_type_descr(),
                         float_floatval_descr(),
                         float_type_addr,
                     )

--- a/pyre/pyre-jit/src/lib.rs
+++ b/pyre/pyre-jit/src/lib.rs
@@ -184,13 +184,11 @@ mod tests {
             majit_ir::OpRef,
             i64,
             majit_ir::DescrRef,
-            majit_ir::DescrRef,
         ) -> majit_ir::OpRef = trace_unbox_int;
 
         let _: fn(
             &mut majit_metainterp::TraceCtx,
             majit_ir::OpRef,
-            majit_ir::DescrRef,
             majit_ir::DescrRef,
             majit_ir::DescrRef,
             i64,
@@ -202,7 +200,6 @@ mod tests {
             majit_ir::OpRef,
             majit_ir::OpCode,
             i64,
-            majit_ir::DescrRef,
             majit_ir::DescrRef,
             majit_ir::DescrRef,
         ) -> majit_ir::OpRef = trace_int_binop_ovf;

--- a/pyre/pyre-jit/src/trace_verify.rs
+++ b/pyre/pyre-jit/src/trace_verify.rs
@@ -8,14 +8,8 @@ mod tests {
     use majit_ir::{OpCode, OpRef};
     use majit_metainterp::TraceCtx;
 
-    fn ob_type_descr() -> majit_ir::DescrRef {
-        make_field_descr(0, 8, majit_ir::Type::Int, false)
-    }
     fn intval_descr() -> majit_ir::DescrRef {
         make_field_descr(8, 8, majit_ir::Type::Int, true)
-    }
-    fn immutable_ob_type_descr() -> majit_ir::DescrRef {
-        make_immutable_field_descr(0, 8, majit_ir::Type::Int, false)
     }
     fn immutable_intval_descr() -> majit_ir::DescrRef {
         make_immutable_field_descr(8, 8, majit_ir::Type::Int, true)
@@ -53,13 +47,7 @@ mod tests {
     fn test_unbox_int_ops() {
         let mut ctx = TraceCtx::for_test(1);
         let obj = OpRef::input_arg_ref(0);
-        let _intval = crate::trace_unbox_int(
-            &mut ctx,
-            obj,
-            FAKE_INT_TYPE,
-            ob_type_descr(),
-            intval_descr(),
-        );
+        let _intval = crate::trace_unbox_int(&mut ctx, obj, FAKE_INT_TYPE, intval_descr());
         let ops = get_ops(ctx);
         // GUARD_CLASS(box, cls): backend loads typeptr from obj at offset 0
         // (llgraph/runner.py:1245), no explicit pre-read. Followed by the
@@ -75,7 +63,6 @@ mod tests {
             &mut ctx,
             OpRef::input_arg_ref(0),
             w_int_size_descr(),
-            ob_type_descr(),
             intval_descr(),
             FAKE_INT_TYPE,
         );
@@ -96,7 +83,6 @@ mod tests {
             OpRef::input_arg_ref(1),
             OpCode::IntAddOvf,
             FAKE_INT_TYPE,
-            ob_type_descr(),
             intval_descr(),
             w_int_size_descr(),
         );
@@ -121,13 +107,7 @@ mod tests {
     fn test_unbox_float_ops() {
         let mut ctx = TraceCtx::for_test(1);
         let obj = OpRef::input_arg_ref(0);
-        let _floatval = crate::trace_unbox_float(
-            &mut ctx,
-            obj,
-            FAKE_FLOAT_TYPE,
-            ob_type_descr(),
-            floatval_descr(),
-        );
+        let _floatval = crate::trace_unbox_float(&mut ctx, obj, FAKE_FLOAT_TYPE, floatval_descr());
         let ops = get_ops(ctx);
         assert_eq!(ops, vec![OpCode::GuardClass, OpCode::GetfieldGcF]);
         eprintln!("✓ trace_unbox_float: {:?}", ops);
@@ -137,13 +117,8 @@ mod tests {
     fn test_unbox_int_ops_read_immutable_descrs_as_plain_getfield() {
         let mut ctx = TraceCtx::for_test(1);
         let obj = OpRef::input_arg_ref(0);
-        let _intval = crate::trace_unbox_int(
-            &mut ctx,
-            obj,
-            FAKE_INT_TYPE,
-            immutable_ob_type_descr(),
-            immutable_intval_descr(),
-        );
+        let _intval =
+            crate::trace_unbox_int(&mut ctx, obj, FAKE_INT_TYPE, immutable_intval_descr());
         let ops = get_ops(ctx);
         // The tracer records the plain GetfieldGcI even for an immutable
         // descr; OptHeap re-derives purity from the descr. GuardClass takes
@@ -155,13 +130,8 @@ mod tests {
     fn test_unbox_float_ops_read_immutable_descrs_as_plain_getfield() {
         let mut ctx = TraceCtx::for_test(1);
         let obj = OpRef::input_arg_ref(0);
-        let _floatval = crate::trace_unbox_float(
-            &mut ctx,
-            obj,
-            FAKE_FLOAT_TYPE,
-            immutable_ob_type_descr(),
-            immutable_floatval_descr(),
-        );
+        let _floatval =
+            crate::trace_unbox_float(&mut ctx, obj, FAKE_FLOAT_TYPE, immutable_floatval_descr());
         let ops = get_ops(ctx);
         assert_eq!(ops, vec![OpCode::GuardClass, OpCode::GetfieldGcF]);
     }
@@ -173,7 +143,6 @@ mod tests {
             &mut ctx,
             OpRef::input_arg_ref(0),
             w_float_size_descr(),
-            ob_type_descr(),
             floatval_descr(),
             FAKE_FLOAT_TYPE,
         );
@@ -191,7 +160,6 @@ mod tests {
             OpRef::input_arg_ref(1),
             OpCode::FloatAdd,
             FAKE_FLOAT_TYPE,
-            ob_type_descr(),
             floatval_descr(),
             w_float_size_descr(),
         );

--- a/pyre/pyre-object/src/gc_roots.rs
+++ b/pyre/pyre-object/src/gc_roots.rs
@@ -354,11 +354,18 @@ impl RootScope {
             *stack.incr_stack() = root;
             index
         };
-        let normalized =
-            crate::gc_hook::try_gc_current_object_address(root as *mut u8) as PyObjectRef;
-        if normalized != root {
-            // SAFETY: same cell, and `index` is still live.
-            unsafe { *(*self.stack_slot).slot(index) = normalized };
+        // RPython has one active mutator under the GIL, so the value just
+        // published cannot have been forwarded between the caller's copy and
+        // this root write.  Pyre's free-threaded seam needs the normalization
+        // only after a second mutator has existed; the sticky predicate also
+        // covers one which collected and unregistered before this point.
+        if majit_gc::gc_sync::foreign_mutator_seen() {
+            let normalized =
+                crate::gc_hook::try_gc_current_object_address(root as *mut u8) as PyObjectRef;
+            if normalized != root {
+                // SAFETY: same cell, and `index` is still live.
+                unsafe { *(*self.stack_slot).slot(index) = normalized };
+            }
         }
     }
 
@@ -427,6 +434,9 @@ pub fn pin_root(root: PyObjectRef) {
     // bracket.  RPython's `_trace_drag_out` always rewrites a root that names
     // an already-forwarded nursery object; normalize the host-side copy at
     // the same boundary so the shadow stack never gains a forwarding stub.
+    if !majit_gc::gc_sync::foreign_mutator_seen() {
+        return;
+    }
     let normalized = crate::gc_hook::try_gc_current_object_address(root as *mut u8) as PyObjectRef;
     // The slot already holds `root`, so a query that found no forwarding stub
     // has nothing to write back.  That is the steady state — nothing collected
@@ -491,6 +501,9 @@ pub fn publish_roots(roots: &[PyObjectRef]) -> usize {
 pub fn normalize_roots(base: usize, len: usize) {
     #[cfg(debug_assertions)]
     assert_shadow_stack_not_walking();
+    if !majit_gc::gc_sync::foreign_mutator_seen() {
+        return;
+    }
     for index in base..base + len {
         // Read the slot each time: a collection triggered by an earlier query
         // may already have rewritten every published root in place.
@@ -604,6 +617,9 @@ pub fn shadow_stack_set(index: usize, root: PyObjectRef) {
     with_shadow_stack(|stack| unsafe { *stack.slot(index) = root });
     // Then normalize a GCREF the caller may have copied before a foreign
     // mutator's nursery collection, so the slot never keeps a forwarding stub.
+    if !majit_gc::gc_sync::foreign_mutator_seen() {
+        return;
+    }
     let root = crate::gc_hook::try_gc_current_object_address(root as *mut u8) as PyObjectRef;
     // SAFETY: same slot, still live.
     with_shadow_stack(|stack| unsafe { *stack.slot(index) = root });


### PR DESCRIPTION
Sixteen commits, rebased onto `a8f3cdb36ed`. They fall into four groups.

## Positional field census (`heaptracker.py` port)

`majit-translate codewriter::heaptracker` is the port of `all_fielddescrs` /
`get_fielddescr_index_in`, and it is what numbers `index_in_parent`.

- **Number fields through the walker** instead of a caller-supplied index, and
  drop the standalone `typeptr` field descr. `ob_type_descr()` built a
  `PyreFieldDescr` with `immutable: true` and `parent_descr: None` — the pair
  that made `protect_speculative_field` fail closed before #989 — and reached
  six call sites that all bound it to an unused parameter, so no operation was
  ever recorded against it. `heaptracker.py:60-67` skips `typeptr` before a
  descr exists for it.
- **Keep the object header out of the census.** `heaptracker.py:64-66` skips
  `typeptr` by name, and `typeptr` is the only field of the `OBJECT`
  substructure every instance embeds first, so recursing into that header
  contributes zero slots. Pyre embeds `PyObject { ob_type, w_class }` and
  spells neither word `typeptr`, so the skip never fired: the walker counted
  two header leaves that no runtime publish has, and every value field was
  numbered two high.

  Worse, the header's own `w_class` matched by name before the outer struct's —
  `get_fielddescr_index_in` returns the recursion's result as soon as it is
  non-negative — so `Method.w_class` numbered **1**, the header's slot.

  Measured against `W_METHOD_DESCR_GROUP`, whose runtime census is complete:

  | field | before | after | runtime publish |
  |---|---|---|---|
  | `Method.w_function` | 2 | 0 | 0 |
  | `Method.w_self` | 3 | 1 | 1 |
  | `Method.w_class` | **1** | 2 | 2 |
  | `Method.w_module` | 5 | 3 | 3 |

  `w_class` is skipped only when its owner is `PyObject`, so `Method.w_class`
  stays an ordinary value field.

- Four comments claimed pyre has no heaptracker / no lltype STRUCT walker.
  Corrected to the real reason the field list is threaded in: the walker lives
  in the crate that depends on `majit-ir`.

## Bridge and subwalk frame state

- **Per-frame ref stack across bridges.** `MIFrame.make_result_of_lastop` puts
  a completed call's return value at the top of the caller's post-call operand
  stack; derive that semantic slot from the codewriter's after-residual depth
  twin rather than inverting a post-regalloc colour. This retires the raw-colour
  fallback that was simultaneously load-bearing and wrong (it answered a *local*
  slot where the map named an operand-stack slot). The matching
  `set_valuestackdepth` is what keeps `init_symbolic` from truncating the
  just-injected top slot.
- **Preserve subwalk abort frame coordinates**, and **keep transparent helper
  subwalks out of the frame-owned abort and limit paths.** A translated builtin
  gateway is transparent to the Python MIFrame stack and has no blackhole entry
  of its own, so it must not consume the session's one-shot
  `claim_abort_coordinate` (after which the enclosing Python walk can no longer
  latch the propagated abort) and must not run the post-step `is_too_long()`
  split at its own opcode coordinate.

## Recording and optimizer

- **Execute the `new` / `new_with_vtable` allocation while recording.**
  `pyjitpl.py:624-629 execute_new` runs the allocation for its side effect and
  records the trace op over the resulting pointer; pyre recorded the op but
  wrote `ConcreteValue::Null`, so readers of the result declined instead of
  seeing a real object. The recorded op is unchanged, so the optimizer remains
  free to virtualize.
- Read the descr's own type id in `make_guards` instead of falling back to 0.
- Seed virtual `NEW_ARRAY_CLEAR` slots with typed zeroes.
- Inline specialised float tuple unpack; trace unsigned random conversion
  without dropping iterations.

## Translator front-end and GC sync

- **Rematerialize fused boxing aggregates at raw `ptr::write` uses.**
  `fuse_boxing_alloc` lowers `lltype::malloc_typed` to `NewWithVtable` but
  leaves the by-value Rust aggregate it consumed in the dominator, where
  `gc_interp`'s stable-allocation arm writes it out with `core::ptr::write`.
  `remove_simple_mallocs` performs the equivalent escape-sensitive motion.
- **Resolve the ptr-null call fold through the host builtin registry.** The
  0-arg fold matched `[core|std, ptr, null|null_mut]` literally, so a guest
  const-global bound to the same `HostObject`
  (`pyre_object::pyobject::PY_NULL` → `core.ptr.null_mut`) kept its call. Now
  resolved through `HOST_ENV::import_module`/`module_get`, so the alias keeps
  one owner and the codewriter repeats no guest spelling.
- Skip root forwarding queries before mutators are shared; repair gc sync state.

## Verification

- `cargo test --workspace --no-default-features --features dynasm` — RC=0, 101
  suites ok.
- `cargo fmt --all --check` — clean.
- `python3 pyre/check.py --backend dynasm` — **372 passed, 1 failed**.

The single red is `synth/raise_reg_unbound_jitstress`
(`loops_aborted 1 → 2, loops_compiled 6 → 8`) and it is **base-owned**, not
this branch's. `origin/main` at `a8f3cdb36ed`, built and run on the same host,
misses its own committed baseline by exactly the same amount:

| | `loops_compiled` | `bridges_compiled` | `loops_aborted` | `guard_failures` |
|---|---|---|---|---|
| committed baseline | 6 | 0 | 1 | 5 |
| `origin/main` a8f3cdb36ed | 8 | 0 | 2 | 5 |
| this branch | 8 | 0 | 2 | 5 |

The two sides are identical, so the baseline is left at its committed value
rather than re-recorded here.

No `.jitstats` file is touched by this branch.

— *authored by Claude*
