### PR TITLE
jit: stop the residual escape flush from stamping a foreign pc on the caller frame

### DIFF
--- a/pyre/bench/frame_caller_image_from_inlined_callee_regression.py
+++ b/pyre/bench/frame_caller_image_from_inlined_callee_regression.py
@@ -1,0 +1,57 @@
+# Self-checking regression guard for a caller frame read from inside an inlined
+# callee while the caller's compiled loop is still running.
+#
+# The callee reads non-forcing coordinate fields from `sys._getframe(1)`.  A
+# stale caller `last_instr` shows up as an extra pre-loop row during the first
+# compiled survey rounds, before the final steady row hides it in a set-only
+# check.
+import sys
+
+N = 20000
+ROUNDS = 4
+
+
+def callee_d1(i):
+    frame = sys._getframe(1)
+    return (
+        frame.f_code.co_name,
+        frame.f_lasti,
+        frame.f_lineno,
+        frame.f_code.co_firstlineno,
+    )
+
+
+def hot_d1(n):
+    rows = {}
+    i = 0
+    while i < n:
+        row = callee_d1(i)
+        rows[row] = rows.get(row, 0) + 1
+        i += 1
+    return rows
+
+
+def main():
+    cold_rows = hot_d1(1)
+    if len(cold_rows) != 1:
+        print("FAIL cold rows:", sorted(cold_rows.items()))
+        return 1
+    cold_row = next(iter(cold_rows))
+
+    observed = {}
+    for _ in range(ROUNDS):
+        for row, count in hot_d1(N).items():
+            observed[row] = observed.get(row, 0) + count
+
+    expected = {cold_row: N * ROUNDS}
+    if observed != expected:
+        print("FAIL caller frame image from inlined callee")
+        print("expected:", sorted(expected.items()))
+        print("observed:", sorted(observed.items()))
+        return 1
+
+    print("PASS caller frame image from inlined callee")
+    return 0
+
+
+sys.exit(main())

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -2408,6 +2408,17 @@ def main():
             f"{B}/frame_inlined_callee_own_image_regression.py",
             20,
         )
+        # The third frame-image shape: an inlined callee reads its CALLER's
+        # real frame via `sys._getframe(1)` while the caller's compiled loop is
+        # still active.  The two sibling guards miss this because one reads
+        # after the loop and the other reads the callee's own frame.  The read
+        # stays on non-forcing coordinates (`f_lasti` / `f_lineno`) so a bad
+        # escape flush cannot be masked by routing back through the interpreter.
+        chk.run_selfcheck(
+            "frame_caller_image_from_inlined_callee",
+            f"{B}/frame_caller_image_from_inlined_callee_regression.py",
+            20,
+        )
         # The branchy-inlined-callee guard (gh#343) lives in the synthetic parity
         # suite as bridge_branchy_callee.py, gated against pypy by
         # `# pyre-check: max-pypy-ratio`; a decline that keeps every crossing

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -2334,6 +2334,7 @@ pub(crate) fn try_walker_inline_builtin_call<Sym: WalkSym>(
     ctx.raw_descrs = RawDescrPool::Global;
     ctx.sub_jitcode_lookup = &GLOBAL_SUB_JITCODE_LOOKUP_FN;
     ctx.fbw_mode.inline_subwalk = true;
+    ctx.fbw_mode.inline_caller_py_pc = Some(call_site_py_pc);
     ctx.fbw_mode.transparent_helper_subwalk = nested_helper_entry.is_some();
     let _helper_frame =
         nested_helper_entry.map(|frame| InlineFrameGuard::enter(ctx.session, 0, Some(frame)));
@@ -2491,6 +2492,25 @@ fn latch_abort_call_resume<Sym: WalkSym>(
     if let Some(stack) = reconstructed_all_ref_call_stack(code, op, ctx) {
         fbw_set_abort_call_resume(outer_jitcode_index, call_jitcode_pc, stack);
     }
+}
+
+fn inline_caller_py_pc_from_snapshot<Sym: WalkSym>(
+    ctx: &WalkContext<'_, '_, Sym>,
+    call_jitcode_pc: usize,
+) -> Option<u32> {
+    let sym_ptr = ctx.fbw_mode.snapshot_sym;
+    if sym_ptr.is_null() {
+        return None;
+    }
+    let sym = unsafe { &*sym_ptr };
+    if sym.jitcode().is_null() {
+        return None;
+    }
+    let jc = unsafe { &*sym.jitcode() };
+    Some(
+        crate::py_coord::containing_py_pc_for_jitcode_pc(&jc.payload.metadata, call_jitcode_pc)
+            as u32,
+    )
 }
 
 pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
@@ -3831,6 +3851,7 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
         inline_outer_entry_py_pc,
         inline_outer_jc_index,
         inline_outer_resume_marker_jit_pc,
+        inline_caller_py_pc,
     ) = if ctx.outer_active_boxes.is_empty() {
         let sym_ptr = ctx.fbw_mode.snapshot_sym;
         if sym_ptr.is_null() {
@@ -3839,6 +3860,7 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
                 ctx.entry_py_pc,
                 ctx.outer_jitcode_index,
                 ctx.outer_resume_marker_jit_pc,
+                inline_caller_py_pc_from_snapshot(ctx, op.pc).or(ctx.fbw_mode.inline_caller_py_pc),
             )
         } else {
             let sym = unsafe { &*sym_ptr };
@@ -3848,6 +3870,8 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
                     ctx.entry_py_pc,
                     ctx.outer_jitcode_index,
                     ctx.outer_resume_marker_jit_pc,
+                    inline_caller_py_pc_from_snapshot(ctx, op.pc)
+                        .or(ctx.fbw_mode.inline_caller_py_pc),
                 )
             } else {
                 // Liveness coordinate is the CALL op's own (jitcode index,
@@ -3859,10 +3883,18 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
                 // snapshot encodes the wrong frame boxes.  Derive the
                 // coordinate from the snapshot sym's jitcode at the CALL op's
                 // pc, matching `orthodox_list_append_commit`.
-                let (call_site_jc_index, call_site_marker) = unsafe {
+                let (call_site_jc_index, call_site_marker, call_site_py_pc) = unsafe {
                     let jc = &*sym.jitcode();
                     let jc_index = jc.index as u32;
-                    (jc_index, jc.payload.resume_marker_for_jitcode_pc(op.pc))
+                    let py_pc = crate::py_coord::containing_py_pc_for_jitcode_pc(
+                        &jc.payload.metadata,
+                        op.pc,
+                    );
+                    (
+                        jc_index,
+                        jc.payload.resume_marker_for_jitcode_pc(op.pc),
+                        py_pc as u32,
+                    )
                 };
                 let call_site_word = match call_site_marker {
                     Some(m) => m as i32,
@@ -3891,6 +3923,7 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
                     EntryPyPc::Jit(op.pc),
                     call_site_jc_index,
                     call_site_marker,
+                    Some(call_site_py_pc),
                 )
             }
         }
@@ -3904,6 +3937,7 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
             ctx.entry_py_pc,
             ctx.outer_jitcode_index,
             ctx.outer_resume_marker_jit_pc,
+            inline_caller_py_pc_from_snapshot(ctx, op.pc).or(ctx.fbw_mode.inline_caller_py_pc),
         )
     };
     // `executioncontext.py:88 enter` — emitted here, past every decline gate,
@@ -3943,6 +3977,7 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
             // tables.
             fbw_mode: FbwWalkMode {
                 inline_subwalk: true,
+                inline_caller_py_pc,
                 ..ctx.fbw_mode
             },
             session: ctx.session,

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -1132,6 +1132,10 @@ pub struct FbwWalkMode<Sym: WalkSym> {
     /// boundary rather than mapping the callee `op_pc` through the outer
     /// jitcode in `walker_capture_snapshot_for_last_guard`.
     pub inline_subwalk: bool,
+    /// Python pc of the caller CALL instruction an inline sub-walk is
+    /// executing under.  Used only for the temporary live-frame coordinate a
+    /// residual frame reader observes; it is not a walk-end resume claim.
+    pub inline_caller_py_pc: Option<u32>,
     /// The current sub-walk is a translated builtin gateway helper, which has
     /// no Python blackhole frame of its own. Guard snapshots therefore encode
     /// only the precomputed Python caller chain on `framestack`, omitting the
@@ -1203,6 +1207,7 @@ impl<Sym: WalkSym> Default for FbwWalkMode<Sym> {
         Self {
             snapshot_sym: std::ptr::null(),
             inline_subwalk: false,
+            inline_caller_py_pc: None,
             transparent_helper_subwalk: false,
             carrier_resume: false,
             current_exception_seed: None,

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -33,7 +33,7 @@ pub(crate) enum EscapeResumeKind {
 }
 
 thread_local! {
-    static ACTIVE_FRAME_ESCAPE: std::cell::Cell<Option<(usize, usize)>> =
+    static ACTIVE_FRAME_ESCAPE: std::cell::Cell<Option<(usize, Option<usize>)>> =
         const { std::cell::Cell::new(None) };
     static ACTIVE_FRAME_ESCAPE_STACK: std::cell::RefCell<Option<Vec<OpRef>>> =
         const { std::cell::RefCell::new(None) };
@@ -973,6 +973,10 @@ impl LiveLastInstrGuard {
             (false, None) => (inline, py_pc),
             (true, _) => (live_frame as *mut pyre_interpreter::PyFrame, py_pc),
         };
+        Self::enter_frame(frame, py_pc)
+    }
+
+    fn enter_frame(frame: *mut pyre_interpreter::PyFrame, py_pc: u32) -> Option<Self> {
         if frame.is_null() {
             return None;
         }
@@ -998,8 +1002,9 @@ impl Drop for LiveLastInstrGuard {
         // guard displaced (see [`capture_escape_flush_undo`]), so a later
         // commit withdrawal still restores the resume pc rather than the
         // executing one.
-        let flushed = ESCAPE_FLUSH_UNDO.with(|slot| slot.borrow().as_ref().map(|undo| undo.frame))
-            == Some(self.frame as usize);
+        let flushed = ESCAPE_FLUSH_UNDO.with(|slot| {
+            slot.borrow().as_ref().map(|undo| undo.frame) == Some(self.frame as usize)
+        });
         if !flushed {
             unsafe { (*self.frame).last_instr = self.saved };
         }
@@ -1133,12 +1138,12 @@ impl Drop for ResidualFrameChainGuard {
 }
 
 struct ActiveFrameEscapeGuard {
-    prev: Option<(usize, usize)>,
+    prev: Option<(usize, Option<usize>)>,
     prev_stack: Option<Vec<OpRef>>,
 }
 
 impl ActiveFrameEscapeGuard {
-    fn enter(frame: usize, py_pc: usize, stack: Option<Vec<OpRef>>) -> Self {
+    fn enter(frame: usize, py_pc: Option<usize>, stack: Option<Vec<OpRef>>) -> Self {
         let current = (frame != 0).then_some((frame, py_pc));
         COMMITTED_FRAME_ESCAPE_PC.with(|slot| slot.set(None));
         let latched = if current.is_some() { stack } else { None };
@@ -1199,7 +1204,7 @@ pub fn flush_active_frame_escape(ctx: &TraceCtx, frame: *mut pyre_interpreter::P
         matched
     });
     ACTIVE_FRAME_ESCAPE.with(|slot| {
-        if let Some((expected, py_pc)) = slot.get()
+        if let Some((expected, portal_py_pc)) = slot.get()
             && {
                 let escaped_portal = expected == frame as usize;
                 if escaped_portal || escaped_published {
@@ -1234,13 +1239,21 @@ pub fn flush_active_frame_escape(ctx: &TraceCtx, frame: *mut pyre_interpreter::P
                 return true;
             }
             capture_escape_flush_undo(expected);
-            let latched = flush_escape_state_with_latched_stack(ctx, expected, py_pc);
-            let flushed =
-                latched || crate::state::flush_walk_end_state_to_frame(ctx, expected, py_pc);
+            let (latched, flushed) = if let Some(py_pc) = portal_py_pc {
+                let latched = flush_escape_state_with_latched_stack(ctx, expected, py_pc);
+                let flushed =
+                    latched || crate::state::flush_walk_end_state_to_frame(ctx, expected, py_pc);
+                (latched, flushed)
+            } else {
+                (false, false)
+            };
             // Reachability probe: the latched-stack path is gated on
             // `escape_opcode_window_clean`, the plain fallback is not, and this
             // resume pc re-runs the whole escaping opcode.
-            if !latched && flushed {
+            if let Some(py_pc) = portal_py_pc
+                && !latched
+                && flushed
+            {
                 use crate::trace::fbw_diag;
                 fbw_diag::bump(fbw_diag::ESCAPE_PLAIN_FALLBACK);
                 if !escape_opcode_window_clean(py_pc) {
@@ -1253,7 +1266,9 @@ pub fn flush_active_frame_escape(ctx: &TraceCtx, frame: *mut pyre_interpreter::P
                 } else {
                     EscapeResumeKind::RerunsOpcode
                 };
-                COMMITTED_FRAME_ESCAPE_PC.with(|committed| committed.set(Some((py_pc, kind))));
+                if let Some(py_pc) = portal_py_pc {
+                    COMMITTED_FRAME_ESCAPE_PC.with(|committed| committed.set(Some((py_pc, kind))));
+                }
             } else if !crate::state::flush_locals_region_to_frame(ctx, expected) {
                 // All-or-nothing decline: nothing was written, nothing to undo.
                 discard_escape_flush_undo();
@@ -2871,19 +2886,29 @@ pub(crate) fn try_execute_residual_call_via_executor<Sym: WalkSym>(
         // Not latched on a bridge walk: its abort path bypasses the
         // run_perfn_walk epilogue that adopts (or restores) a committed
         // escape flush, so a commit there would strand a moved frame.
-        let escape_stack = (escape_frame != 0
-            && !ctx.fbw_mode.inline_subwalk
-            && !ctx.trace_ctx.is_bridge_trace
-            && ctx.vstack_valid
-            && escape_opcode_window_clean(ctx.vstack_cur_pypc as usize))
-        .then(|| ctx.vstack_boxes.clone());
-        let _frame_escape =
-            ActiveFrameEscapeGuard::enter(escape_frame, ctx.vstack_cur_pypc as usize, escape_stack);
+        let escape_py_pc = (!ctx.fbw_mode.inline_subwalk && ctx.vstack_valid)
+            .then_some(ctx.vstack_cur_pypc as usize);
+        let escape_stack = escape_py_pc
+            .filter(|py_pc| {
+                escape_frame != 0
+                    && !ctx.trace_ctx.is_bridge_trace
+                    && escape_opcode_window_clean(*py_pc)
+            })
+            .map(|_| ctx.vstack_boxes.clone());
+        let _frame_escape = ActiveFrameEscapeGuard::enter(escape_frame, escape_py_pc, escape_stack);
         // `executioncontext.py:85 enter` for the inlined callee this residual
         // runs inside of.
         let _frame_chain = ResidualFrameChainGuard::enter();
-        let _last_instr =
-            LiveLastInstrGuard::enter(live_frame, ctx.vstack_cur_pypc, inline_callee_pc);
+        let live_py_pc = if ctx.fbw_mode.inline_subwalk {
+            ctx.vstack_cur_pypc
+        } else {
+            live_py_pc_from_snapshot(ctx, op_pc).unwrap_or(ctx.vstack_cur_pypc)
+        };
+        let _callee_last_instr =
+            LiveLastInstrGuard::enter(live_frame, live_py_pc, inline_callee_pc);
+        let _caller_last_instr = ctx.fbw_mode.inline_caller_py_pc.map(|py_pc| {
+            LiveLastInstrGuard::enter_frame(live_frame as *mut pyre_interpreter::PyFrame, py_pc)
+        });
         let _suspend = majit_metainterp::TraceContinuationSuspendGuard::enter();
         majit_metainterp::executor::execute_residual_call(call_descr, func_ptr, &args)
     };
@@ -3573,6 +3598,25 @@ fn inline_callee_py_pc<Sym: WalkSym>(ctx: &WalkContext<'_, '_, Sym>, jit_pc: usi
     let pjc = crate::state::pyjitcode_for_jitcode_index(consts.jitcode_index)?;
     Some(crate::py_coord::containing_py_pc_for_jitcode_pc(
         &pjc.metadata,
+        jit_pc,
+    ))
+}
+
+fn live_py_pc_from_snapshot<Sym: WalkSym>(
+    ctx: &WalkContext<'_, '_, Sym>,
+    jit_pc: usize,
+) -> Option<u32> {
+    let sym_ptr = ctx.fbw_mode.snapshot_sym;
+    if sym_ptr.is_null() {
+        return None;
+    }
+    let sym = unsafe { &*sym_ptr };
+    if sym.jitcode().is_null() {
+        return None;
+    }
+    let jc = unsafe { &*sym.jitcode() };
+    Some(crate::py_coord::containing_py_pc_for_jitcode_pc(
+        &jc.payload.metadata,
         jit_pc,
     ))
 }


### PR DESCRIPTION
## What this PR is now

The branch was rebased onto `origin/main`. Its previous commit — "record the three
#950 jit-stats rows #945's re-record left out" — dropped out: all three files it
touched are now **byte-identical to `origin/main`**, which landed the same values
independently.

| file | PR head `4033ccc058f` vs `origin/main` |
|---|---|
| `raise_reg_unbound_jitstress.dynasm.jitstats` | SAME |
| `raise_reg_unbound_jitstress.cranelift.jitstats` | SAME |
| `exception_inline_callee_tb_frames.wasm.jitstats` | SAME |

The 43 `jit-stats change` rows that were red on the old head were entirely
inherited base red — the `_fill_cache` platform ladder (ubuntu 7 / committed 8 /
windows 9), closed at the source by #1034's `PYTHONSAFEPATH=1`. Not one of them
was a file that commit touched.

## The change that replaces it

A correctness fix for the image a caller frame reports while its compiled loop is
running, read from inside an inlined callee.

`try_execute_residual_call_via_executor` latched the escape with
`ctx.vstack_cur_pypc` unconditionally. Inside an inline sub-walk that mirror
belongs to the outer walk and is never advanced (`vstack_valid` is false), so it
reads a constant 0 — `LiveLastInstrGuard::enter` says exactly this in its own
comment. `flush_active_frame_escape` passed that 0 to
`flush_walk_end_state_to_frame`, which writes `last_instr = resume_py_pc - 1` and
`valuestackdepth = end_vsd` onto the **portal** frame. The escaping code then read
that image inside the same residual.

Measured at the pre-fix tip, both native backends, 20000 iterations:

```
sys._getframe(1) from an inlined callee, id() compared against the true frame

ORACLE (PYRE_NO_JIT=1)   same_object=True  f_lasti=110   count=20000
dynasm AND cranelift     same_object=True  f_lasti=-2    count=5      <-- wrong
                         same_object=True  f_lasti=110   count=19995
```

`f_lasti == last_instr * 2`, so `-2` is the `-1` sentinel; `f_lineno` collapsed to
the `def` line through `pyframe.rs:1511-1515`. The bad-iteration count equalled
`[jit-stats] fbw_escape_split published_callee_only` exactly.

Two layers, both closed here:

1. `ACTIVE_FRAME_ESCAPE` now carries the pc as an `Option`. An escape whose mirror
   does not describe the portal claims no resume pc and falls through to
   `flush_locals_region_to_frame` — the locals-only write `virtualizable.py:101-138
   write_boxes` performs with no decline. `executioncontext.py:91-107 leave` forces
   the leaving frame's own vref and only marks `f_back`; nothing upstream rewrites
   a caller frame's pc at an escape.
2. That exposed the caller carrying its **pre-loop** `last_instr` (`f_lasti=84`, a
   `STORE_FAST`, not a call site) — the walk dispatches opcodes itself and
   `LiveLastInstrGuard` retargets to the callee for a sub-walk's duration. The
   caller's CALL pc is now threaded through the inline sub-walk entry points as
   `FbwWalkMode::inline_caller_py_pc` and published on the caller frame for the
   residual's duration, under the same save/restore discipline — `last_instr`
   doubles as the resume coordinate, so the executing meaning may not outlive the
   call.

## Coverage

`pyre/bench/frame_caller_image_from_inlined_callee_regression.py`, registered in
`check.py`. The two existing frame-image guards miss this shape:
`frame_lineno_mid_replay` reads the caller **once, after** the loop, so its
`sys._getframe(1)` never runs inside an inline sub-walk of a compiled loop; and
`frame_inlined_callee_own_image` reads the **callee's own** frame. Across 18 synth
`sys._getframe` fixtures the only attributes read off the result are `.f_locals`
(which forces — and the force routes the read back to the interpreter, masking
this) and `.f_code` (frame-invariant). The new fixture stays on `f_lasti` /
`f_lineno` for that reason.

Teeth demonstrated: with the caller publish temporarily reverted the fixture fails
with a pre-loop row; restored, it passes.

## Verification

Measured on this commit, this host (macOS/arm64):

```
python3 ./pyre/check.py
  ALL PASSED: dynasm 378/378
  ALL PASSED: cranelift 378/378
  ALL PASSED: wasm 374/374
  ALL PASSED: 3/3 backend run(s)

cargo test --all --no-default-features --features dynasm   ok
cargo fmt --all -- --check                                 ok
```

**Zero `.jitstats` baselines changed** — no counter moved in either direction, so
nothing here is a re-record.

— *authored by Claude*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime handling of inlined calls and residual execution so frame metadata, instruction positions, and line numbers remain accurate.
  * Prevented invalid resume information from affecting execution after optimized code exits or falls back.
  * Improved stability when inspecting caller frames during active compiled loops.

* **Tests**
  * Added regression checks covering cold runs, repeated hot-loop execution, and caller frame information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->