### PR TITLE
posix, compile, display: take filesystem names as bytes across the path, compile, repr and environment boundaries

### DIFF
--- a/pyre/extra_tests/parity_tests/compile_filename_boundary.py
+++ b/pyre/extra_tests/parity_tests/compile_filename_boundary.py
@@ -87,6 +87,11 @@ replaced = code.replace(co_filename="\udcff.py")
 assert replaced.co_filename == "\udcff.py"
 assert 'file "\udcff.py"' in repr(replaced), ascii(repr(replaced))
 
+# `pycode.py:570-572` reports the zero sentinel as line -1.
+assert 'line -1>' in repr(code.replace(co_firstlineno=0)), ascii(
+    repr(code.replace(co_firstlineno=0))
+)
+
 # and a filename that never had a UTF-8 spelling reaches repr() the same way.
 from_bytes = compile(SOURCE, b"\xff.py", "exec")
 assert 'file "\udcff.py"' in repr(from_bytes), ascii(repr(from_bytes))

--- a/pyre/extra_tests/parity_tests/compile_filename_boundary.py
+++ b/pyre/extra_tests/parity_tests/compile_filename_boundary.py
@@ -1,0 +1,103 @@
+"""`compile()` takes its filename through the filesystem-encoding converter.
+
+`compiling.py:13` declares `@unwrap_spec(filename='fsencode', mode='text')`, so
+the filename accepts `bytes` and `os.PathLike` as well as `str`, keeps a byte
+with no UTF-8 spelling, and rejects an embedded NUL — while a non-`str` mode is
+a TypeError rather than a silent fall back to "exec".  Every code object reader
+then has to report that filename, including `repr()`, which reads the same
+field `co_filename` does rather than a separate compiler-side spelling.
+
+A `bytearray` filename is deliberately absent: it is a readable buffer that
+`baseobjspace.py:1975` accepts with a DeprecationWarning but CPython rejects,
+and this suite has to pass under CPython too.
+"""
+
+SOURCE = "x = 1"
+
+
+class Path:
+    def __init__(self, name):
+        self.name = name
+
+    def __fspath__(self):
+        return self.name
+
+
+# A str filename is handed through unchanged.
+assert compile(SOURCE, "plain.py", "exec").co_filename == "plain.py"
+
+# bytes decode with the filesystem encoding.  The ASCII case matters on its own:
+# it needs no surrogate to expose a filename that never reaches the code object.
+assert compile(SOURCE, b"ascii.py", "exec").co_filename == "ascii.py"
+assert compile(SOURCE, b"\xff.py", "exec").co_filename == "\udcff.py"
+
+# A str already carrying a surrogate escape encodes back to that same byte
+# instead of raising UnicodeEncodeError.
+assert compile(SOURCE, "\udcff.py", "exec").co_filename == "\udcff.py"
+
+# `__fspath__` is honoured, and may answer with either str or bytes.
+assert compile(SOURCE, Path(b"\xff.py"), "exec").co_filename == "\udcff.py"
+assert compile(SOURCE, Path("spelled.py"), "exec").co_filename == "spelled.py"
+
+# An object that is neither a path nor a string is a TypeError, not a filename
+# quietly replaced by "<string>".  The two runtimes word it differently, so only
+# the class is under test.
+for bad in (42, object(), None):
+    try:
+        compile(SOURCE, bad, "exec")
+    except TypeError:
+        pass
+    else:
+        raise AssertionError("compile() accepted %r as a filename" % (bad,))
+
+# `bytesbuf0_w` rejects an embedded NUL.
+for nul in ("a\x00b.py", b"a\x00b.py"):
+    try:
+        compile(SOURCE, nul, "exec")
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("compile() accepted a NUL in %r" % (nul,))
+
+# mode='text' — a non-str mode is rejected rather than treated as "exec".
+try:
+    compile(SOURCE, "a.py", 42)
+except TypeError:
+    pass
+else:
+    raise AssertionError("compile() accepted a non-str mode")
+
+
+# The filename a SyntaxError reports is the same one the successful compile
+# would have recorded.
+try:
+    compile("(", b"\xff.py", "exec")
+except SyntaxError as exc:
+    assert exc.filename == "\udcff.py", ascii(exc.filename)
+else:
+    raise AssertionError("compile() accepted an unterminated '('")
+
+
+# `repr()` reads `co_filename`, so it follows a replacement instead of showing
+# the name the object was compiled under.
+code = compile(SOURCE, "before.py", "exec")
+assert 'file "before.py"' in repr(code), repr(code)
+
+replaced = code.replace(co_filename="\udcff.py")
+assert replaced.co_filename == "\udcff.py"
+assert 'file "\udcff.py"' in repr(replaced), ascii(repr(replaced))
+
+# and a filename that never had a UTF-8 spelling reaches repr() the same way.
+from_bytes = compile(SOURCE, b"\xff.py", "exec")
+assert 'file "\udcff.py"' in repr(from_bytes), ascii(repr(from_bytes))
+
+
+# Every reader of a code object agrees on the filename, so a frame built from
+# one points at the real file rather than at "<string>".
+namespace = {}
+exec(compile("def f():\n    import sys\n    return sys._getframe()\n", b"\xff.py", "exec"), namespace)
+frame = namespace["f"]()
+assert frame.f_code.co_filename == "\udcff.py", ascii(frame.f_code.co_filename)
+assert "�" not in repr(frame), ascii(repr(frame))
+
+print("OK")

--- a/pyre/extra_tests/parity_tests/os_boundary_surrogateescape.py
+++ b/pyre/extra_tests/parity_tests/os_boundary_surrogateescape.py
@@ -17,6 +17,7 @@ if sys.platform == "win32":
     raise SystemExit
 
 import socket
+import subprocess
 import tempfile
 
 
@@ -133,5 +134,59 @@ with tempfile.TemporaryDirectory() as d:
                 assert exc.filename == arg, (ascii(exc.filename), ascii(arg))
             else:
                 raise AssertionError("an absent path was found")
+
+
+class _Spelled:
+    """An `os.PathLike` that is not itself a path."""
+
+    def __init__(self, name):
+        self.name = name
+
+    def __fspath__(self):
+        return self.name
+
+
+# `interp_posix.py:211-219 _unwrap_path` calls `__fspath__` and keeps its
+# result, so the name a failure reports is the path the object spelled, never
+# the object that spelled it.
+with tempfile.TemporaryDirectory() as d:
+    for spelled in (
+        os.path.join(d, "absent\udcff"),
+        os.path.join(os.fsencode(d), b"absent\xff"),
+    ):
+        for call in (os.stat, os.listdir, open):
+            try:
+                call(_Spelled(spelled))
+            except OSError as exc:
+                assert exc.filename == spelled, (ascii(exc.filename), ascii(spelled))
+            else:
+                raise AssertionError("an absent path was found")
+
+# `interp_posix.py:1814-1817` wraps a failed exec with no filename at all.
+try:
+    os.execv("/nonexistent-pyre-boundary", ["x"])
+except OSError as exc:
+    assert exc.filename is None, ascii(exc.filename)
+else:
+    raise AssertionError("execv of an absent program returned")
+
+# `interp_posix.py:1762-1769` rejects `=` only after index zero, so the `=C:`
+# form Windows uses for a working directory is a legal key.
+os.waitpid(os.posix_spawn(TRUE, [TRUE], {"=C:": "v"}), 0)
+
+# `os.putenv` takes its two halves through the same converter, and
+# `posix.environ` hands entries back as bytes, so a value spelling a byte with
+# no UTF-8 form has to survive the write rather than folding to U+FFFD.
+NAME = "PYRE_OS_BOUNDARY_%d" % os.getpid()
+os.putenv(NAME, "v\udcff")
+try:
+    read_back = subprocess.run(
+        [sys.executable, "-c", "import os,sys; sys.stdout.buffer.write(os.environb[b'%s'])" % NAME],
+        capture_output=True,
+    )
+    if read_back.returncode == 0:
+        assert read_back.stdout == b"v\xff", read_back.stdout
+finally:
+    os.unsetenv(NAME)
 
 print("OK")

--- a/pyre/extra_tests/parity_tests/os_boundary_surrogateescape.py
+++ b/pyre/extra_tests/parity_tests/os_boundary_surrogateescape.py
@@ -100,4 +100,38 @@ os.waitpid(os.posix_spawn(TRUE, [TRUE.encode()], {}), 0)
 index, name = socket.if_nameindex()[0]
 assert socket.if_nametoindex(name.encode()) == index
 
+# The encoded path has to reach the syscall as bytes.  Were it folded into text
+# first, every byte with no UTF-8 spelling would become U+FFFD and distinct
+# names would alias onto one another: a lookup of `b"\xffvictim"` would answer
+# for the file actually called `"�victim"`.  Plant that file and check the
+# lookup misses it.
+with tempfile.TemporaryDirectory() as d:
+    with open(os.path.join(d, "�victim"), "wb") as fp:
+        fp.write(b"victim")
+    probe = os.path.join(os.fsencode(d), b"\xffvictim")
+    assert not os.path.exists(probe), "a non-UTF-8 path aliased onto U+FFFD"
+    for call in (lambda: os.stat(probe), lambda: open(probe)):
+        try:
+            call()
+        except OSError:
+            pass
+        else:
+            raise AssertionError("a non-UTF-8 path aliased onto U+FFFD")
+
+# `wrap_oserror2(space, e, w_path)` reports the path object the call was given,
+# so a bytes argument reports bytes and a str keeps its surrogate escapes rather
+# than both being re-spelled through a lossy decode.
+with tempfile.TemporaryDirectory() as d:
+    for arg in (
+        os.path.join(d, "absent\udcff"),
+        os.path.join(os.fsencode(d), b"absent\xff"),
+    ):
+        for call in (os.stat, open):
+            try:
+                call(arg)
+            except OSError as exc:
+                assert exc.filename == arg, (ascii(exc.filename), ascii(arg))
+            else:
+                raise AssertionError("an absent path was found")
+
 print("OK")

--- a/pyre/extra_tests/parity_tests/repr_empty_item_separator.py
+++ b/pyre/extra_tests/parity_tests/repr_empty_item_separator.py
@@ -1,0 +1,57 @@
+"""A container's repr separates its items by position, not by what they wrote.
+
+`listobject.py:213-223` appends `', '` before every item after the first, and
+`tupleobject.py:114` / `dictmultiobject.py:388` join the rendered items the same
+way.  An item whose `__repr__` answers `''` therefore still occupies a slot, and
+`[a, b]` renders as `'[, ]'` rather than collapsing to `'[]'` — which would be
+the repr of a different, empty container.
+"""
+
+
+class Empty:
+    def __repr__(self):
+        return ""
+
+
+class EmptyKey(Empty):
+    def __hash__(self):
+        return 1
+
+    def __eq__(self, other):
+        return self is other
+
+
+import collections
+
+assert repr([Empty(), Empty()]) == "[, ]", ascii(repr([Empty(), Empty()]))
+assert repr((Empty(), Empty())) == "(, )", ascii(repr((Empty(), Empty())))
+assert repr({Empty(), Empty()}) == "{, }", ascii(repr({Empty(), Empty()}))
+assert repr(collections.deque([Empty(), Empty()])) == "deque([, ])", ascii(
+    repr(collections.deque([Empty(), Empty()]))
+)
+
+# `tupleobject.py:111-113` keeps the one-item form, whose comma is the trailing
+# one rather than a separator.
+assert repr((Empty(),)) == "(,)", ascii(repr((Empty(),)))
+
+# both halves of a dict entry
+assert repr({EmptyKey(): 1, EmptyKey(): 2}) == "{: 1, : 2}", ascii(
+    repr({EmptyKey(): 1, EmptyKey(): 2})
+)
+assert repr({1: Empty(), 2: Empty()}) == "{1: , 2: }", ascii(
+    repr({1: Empty(), 2: Empty()})
+)
+assert repr({EmptyKey(): Empty()}) == "{: }", ascii(repr({EmptyKey(): Empty()}))
+
+# `interp_exceptions.py:135-147 descr_repr` spells the args with
+# `repr(tuple(args))`, so it separates by position too.
+try:
+    raise ValueError(Empty(), Empty())
+except ValueError as exc:
+    assert repr(exc) == "ValueError(, )", ascii(repr(exc))
+
+# and the same holds one level down, where the rendered item is itself empty
+# only because the container it names is
+assert repr([[], []]) == "[[], []]", ascii(repr([[], []]))
+
+print("OK")

--- a/pyre/extra_tests/parity_tests/repr_surrogate_wtf8.py
+++ b/pyre/extra_tests/parity_tests/repr_surrogate_wtf8.py
@@ -1,0 +1,78 @@
+"""A container's repr concatenates its items' reprs as encoded bytes.
+
+`listobject.py:206-225 _listrepr_inner` builds with a `rutf8.Utf8StringBuilder`
+and appends `space.utf8_len_w(space.repr(w_item))`, so an item repr carrying a
+lone surrogate — anything a surrogateescape decode produced — reaches the
+enclosing repr as itself.  A buffer that can only hold well-formed UTF-8 would
+replace it with U+FFFD, which is both a different string and one that no longer
+round-trips back to the bytes it came from.
+"""
+
+import collections
+
+
+class C:
+    def __repr__(self):
+        return "s\udcff"
+
+
+assert repr(C()) == "s\udcff", ascii(repr(C()))
+
+# every container that re-enters repr per item
+assert repr([C()]) == "[s\udcff]", ascii(repr([C()]))
+assert repr((C(),)) == "(s\udcff,)", ascii(repr((C(),)))
+assert repr({1: C()}) == "{1: s\udcff}", ascii(repr({1: C()}))
+assert repr({C()}) == "{s\udcff}", ascii(repr({C()}))
+assert repr(frozenset({C()})) == "frozenset({s\udcff})", ascii(repr(frozenset({C()})))
+assert repr(collections.deque([C()])) == "deque([s\udcff])", ascii(
+    repr(collections.deque([C()]))
+)
+
+# and nesting, where the inner repr is itself a built buffer
+assert repr([[C()]]) == "[[s\udcff]]", ascii(repr([[C()]]))
+assert repr({1: [C()]}) == "{1: [s\udcff]}", ascii(repr({1: [C()]}))
+
+# `str()` of a container formats its items with repr, so it takes the same path
+assert str([C()]) == "[s\udcff]", ascii(str([C()]))
+
+# the conversion seams that spell a value with repr
+assert f"{C()!r}" == "s\udcff", ascii(f"{C()!r}")
+assert "{!r}".format(C()) == "s\udcff", ascii("{!r}".format(C()))
+assert "%r" % (C(),) == "s\udcff", ascii("%r" % (C(),))
+
+# an exception argument reaches repr through the args tuple
+try:
+    raise ValueError(C())
+except ValueError as exc:
+    assert repr(exc.args) == "(s\udcff,)", ascii(repr(exc.args))
+
+# a code object names a file that never had a UTF-8 spelling, and stays exact
+# when a container formats it
+code = compile("x = 1", b"\xff.py", "exec")
+assert repr(code).count("\udcff") == 1, ascii(repr(code))
+assert repr([code]).count("\udcff") == 1, ascii(repr([code]))
+
+# `listobject.py:186-204` keeps the recursion guard, so a container reachable
+# from itself still renders the inner reference as an ellipsis rather than
+# recursing forever.
+recursive_list = []
+recursive_list.append(recursive_list)
+assert repr(recursive_list) == "[[...]]", ascii(repr(recursive_list))
+
+recursive_dict = {}
+recursive_dict[1] = recursive_dict
+assert repr(recursive_dict) == "{1: {...}}", ascii(repr(recursive_dict))
+
+# and the depth check still fires, since the items are walked in the host
+# language with no Python frame pushed to trip a frame-level limit.
+deep = []
+for _ in range(200000):
+    deep = [deep]
+try:
+    repr(deep)
+except RecursionError:
+    pass
+else:
+    raise AssertionError("a 200000-deep list rendered without raising")
+
+print("OK")

--- a/pyre/pyre-interpreter/src/_structseq.rs
+++ b/pyre/pyre-interpreter/src/_structseq.rs
@@ -157,18 +157,22 @@ fn structseq_repr(args: &[PyObjectRef]) -> Result<PyObjectRef, PyError> {
             .unwrap_or_default()
     };
     let n = unsafe { pyre_object::w_tuple_len(inst) };
-    let mut parts: Vec<String> = Vec::with_capacity(n);
+    let mut out = rustpython_wtf8::Wtf8Buf::new();
+    out.push_str(&name);
+    out.push_str("(");
     for i in 0..n {
+        if i != 0 {
+            out.push_str(", ");
+        }
         let item = unsafe { pyre_object::w_tuple_getitem(inst, i as i64) }
             .unwrap_or(pyre_object::w_none());
         let fname = fields.get(i).cloned().unwrap_or_else(|| format!("?{i}"));
-        let r_str = unsafe { crate::py_repr(item)? };
-        parts.push(format!("{fname}={r_str}"));
+        out.push_str(&fname);
+        out.push_str("=");
+        out.push_wtf8(&unsafe { crate::py_repr_wtf8(item)? });
     }
-    Ok(pyre_object::w_str_new(&format!(
-        "{name}({})",
-        parts.join(", ")
-    )))
+    out.push_str(")");
+    Ok(pyre_object::w_str_from_wtf8(out))
 }
 
 /// `lib_pypy/_structseq.py structseq_reduce` — `return type(self),

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -10440,6 +10440,20 @@ fn source_as_str(
     crate::compile::decode_source_bytes(&bytes, filename, *flags & PYCF_IGNORE_COOKIE != 0)
 }
 
+fn replace_compile_syntax_error_filename(
+    mut error: crate::PyError,
+    filename: &str,
+    filename_bytes: Option<&[u8]>,
+) -> crate::PyError {
+    if error.kind == crate::PyErrorKind::SyntaxError {
+        let w_filename = crate::gateway::fsdecode_filename_bytes(
+            filename_bytes.unwrap_or_else(|| filename.as_bytes()),
+        );
+        error.replace_syntax_error_filename(w_filename);
+    }
+    error
+}
+
 fn builtin_compile(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     // `compile(source, filename, mode, flags=0, dont_inherit=False,
     // optimize=-1, *, _feature_version=-1)`: the three required parameters and
@@ -10471,16 +10485,10 @@ fn builtin_compile(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
         ],
         "compile",
     )?;
-    let filename = if unsafe { pyre_object::is_str(filename_obj) } {
-        crate::baseobjspace::str_utf8_w(filename_obj)?.to_string()
-    } else {
-        "<string>".to_string()
-    };
-    let mode = if unsafe { pyre_object::is_str(mode_obj) } {
-        crate::baseobjspace::str_utf8_w(mode_obj)?.to_string()
-    } else {
-        "exec".to_string()
-    };
+    // `compiling.py:12-13 unwrap_spec(filename='fsencode', mode='text')`.
+    let filename_bytes = crate::gateway::fsencode_bytes_w(filename_obj)?;
+    let (filename, filename_bytes) = crate::pycode::split_code_filename_bytes(filename_bytes, None);
+    let mode = crate::baseobjspace::text_w(mode_obj)?;
     // flags / dont_inherit / optimize are positional-or-keyword ints
     // (unwrap_spec flags=int, dont_inherit=int, optimize=int).
     let mut flags = match bind_pos_or_kw(pos, kwargs, 3, "flags", "compile", 4)? {
@@ -10527,7 +10535,7 @@ fn builtin_compile(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
         }
     }
 
-    let mode = match mode.as_str() {
+    let mode = match mode {
         "exec" => crate::compile::Mode::Exec,
         "eval" => crate::compile::Mode::Eval,
         "single" => crate::compile::Mode::Single,
@@ -10563,13 +10571,18 @@ fn builtin_compile(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
     let source_str = if source_is_ast {
         None
     } else {
-        Some(source_as_str(
-            source,
-            "compile",
-            "string, bytes or AST",
-            &filename,
-            &mut flags,
-        )?)
+        Some(
+            source_as_str(
+                source,
+                "compile",
+                "string, bytes or AST",
+                &filename,
+                &mut flags,
+            )
+            .map_err(|error| {
+                replace_compile_syntax_error_filename(error, &filename, filename_bytes.as_deref())
+            })?,
+        )
     };
 
     // Assemble CompileOpts: the __future__ feature bits, the two PyCF_*
@@ -10586,7 +10599,7 @@ fn builtin_compile(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
         // plain ONLY_AST runs syntax-only preprocessing; OPTIMIZED_AST
         // includes ONLY_AST and enables constant folding.
         let syntax_check_only = flags & PYCF_OPTIMIZED_AST == PYCF_ONLY_AST;
-        return if source_is_ast {
+        let result = if source_is_ast {
             // An already materialised AST under plain `PyCF_ONLY_AST` is
             // handed straight back, so `compile(tree, ..., PyCF_ONLY_AST) is
             // tree`.  Re-converting it would hand out a copy instead.
@@ -10611,23 +10624,28 @@ fn builtin_compile(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
                 syntax_check_only,
             )
         };
+        return result.map_err(|error| {
+            replace_compile_syntax_error_filename(error, &filename, filename_bytes.as_deref())
+        });
     }
-    if source_str.is_none() {
-        let code = crate::module::_ast::convert::compile_object(source, &filename, mode, opts)?;
-        let code_ptr = Box::into_raw(Box::new(code)) as *const ();
-        return Ok(crate::w_code_new(code_ptr));
-    }
-    let source = source_str.as_deref().expect("non-AST source");
-    let code =
+    let code = if let Some(source) = source_str.as_deref() {
         crate::compile::compile_source_with_opts(source, mode, &filename, opts).map_err(|e| {
             compile_err_to_syntax_error_maybe_incomplete(
                 e,
                 source,
                 flags & PYCF_ALLOW_INCOMPLETE_INPUT != 0,
             )
-        })?;
+        })
+    } else {
+        crate::module::_ast::convert::compile_object(source, &filename, mode, opts)
+    }
+    .map_err(|error| {
+        replace_compile_syntax_error_filename(error, &filename, filename_bytes.as_deref())
+    })?;
     let code_ptr = Box::into_raw(Box::new(code)) as *const ();
-    Ok(crate::w_code_new(code_ptr))
+    let result = crate::w_code_new(code_ptr);
+    unsafe { crate::pycode::set_compilation_unit_filename_bytes(result, filename_bytes) };
+    Ok(result)
 }
 
 /// `exec(source_or_code, globals=None, locals=None)` — PyPy:

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -14882,7 +14882,8 @@ fn open_raw_file(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
 
     // Keep the encoded bytes: surrogateescape code points can spell bytes
     // that are not valid UTF-8, and the OS seam must receive them verbatim.
-    let path_bytes = crate::gateway::fsencode_bytes_w(path_obj)?;
+    let resolved_path = crate::gateway::fsencode_path_w(path_obj)?;
+    let path_bytes = &resolved_path.as_bytes;
     // `host_env::fs` takes a `Path`; only the seam consumes the raw bytes.
     #[cfg(unix)]
     let path = std::ffi::OsString::from_vec(path_bytes.clone());
@@ -14914,7 +14915,7 @@ fn open_raw_file(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
                 return Err(crate::PyError::value_error(format!("opener returned {fd}")));
             }
             #[cfg(unix)]
-            if let Err(error) = fileio_validate_fd(fd, path_obj) {
+            if let Err(error) = fileio_validate_fd(fd, resolved_path.w_path()) {
                 fileio_close_owned_fd(fd);
                 return Err(error);
             }
@@ -14940,11 +14941,11 @@ fn open_raw_file(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     {
         let _ = (reading, writing);
         let flags = open_flags_for_mode(&mode);
-        // The failure names the path object the call was given, not a spelling
-        // rebuilt from the bytes: `interp_fileio.py` wraps `w_name`.
-        let fd = crate::host_seam::ops::open(&path_bytes, flags, 0o666)
-            .map_err(|e| crate::host_seam::seam_os_err_with_filename(e, path_obj))?;
-        if let Err(error) = fileio_validate_fd(fd, path_obj) {
+        // `interp_fileio.py` wraps the resolved `w_name`, not the PathLike
+        // wrapper from which it came.
+        let fd = crate::host_seam::ops::open(path_bytes, flags, 0o666)
+            .map_err(|e| crate::host_seam::seam_os_err_with_filename(e, resolved_path.w_path()))?;
+        if let Err(error) = fileio_validate_fd(fd, resolved_path.w_path()) {
             fileio_close_owned_fd(fd);
             return Err(error);
         }
@@ -14970,11 +14971,11 @@ fn open_raw_file(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         // close(), which is not the W_FileIO storage shape.
         let _ = (reading, writing);
         let flags = open_flags_for_mode(&mode);
-        // The failure names the path object the call was given, not a spelling
-        // rebuilt from the bytes: `interp_fileio.py` wraps `w_name`.
-        let fd = crate::host_seam::ops::open(&path_bytes, flags, 0o666)
-            .map_err(|e| crate::host_seam::seam_os_err_with_filename(e, path_obj))?;
-        if let Err(error) = fileio_validate_fd(fd, path_obj) {
+        // `interp_fileio.py` wraps the resolved `w_name`, not the PathLike
+        // wrapper from which it came.
+        let fd = crate::host_seam::ops::open(path_bytes, flags, 0o666)
+            .map_err(|e| crate::host_seam::seam_os_err_with_filename(e, resolved_path.w_path()))?;
+        if let Err(error) = fileio_validate_fd(fd, resolved_path.w_path()) {
             fileio_close_owned_fd(fd);
             return Err(error);
         }
@@ -15014,12 +15015,11 @@ fn open_raw_file(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
                 Ok(bytes) => bytes,
                 Err(_e) if writing => Vec::new(),
                 Err(e) => {
-                    // Report the original path object as `.filename`, keeping a
-                    // bytes path a bytes object (`interp_fileio.py` wraps the raw
-                    // `w_name`, not the decoded buffer).
+                    // Keep the resolved `w_name` as `.filename`, including a
+                    // bytes result from `__fspath__`.
                     return Err(crate::PyError::os_error_syscall(
                         io_error_posix_errno(&e, 2),
-                        path_obj,
+                        resolved_path.w_path(),
                     ));
                 }
             }
@@ -15057,7 +15057,10 @@ fn open_raw_file(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
                     std::io::ErrorKind::PermissionDenied => libc::EACCES,
                     _ => io_error_posix_errno(&e, libc::EACCES),
                 };
-                return Err(crate::PyError::os_error_syscall(errno, path_obj));
+                return Err(crate::PyError::os_error_syscall(
+                    errno,
+                    resolved_path.w_path(),
+                ));
             }
         }
 

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -14922,9 +14922,10 @@ fn open_raw_file(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     {
         let _ = (reading, writing);
         let flags = open_flags_for_mode(&mode);
-        let path_display = String::from_utf8_lossy(&path_bytes);
+        // The failure names the path object the call was given, not a spelling
+        // rebuilt from the bytes: `interp_fileio.py` wraps `w_name`.
         let fd = crate::host_seam::ops::open(&path_bytes, flags, 0o666)
-            .map_err(|e| crate::host_seam::seam_os_err(e, &path_display))?;
+            .map_err(|e| crate::host_seam::seam_os_err_with_filename(e, path_obj))?;
         if let Err(error) = fileio_validate_fd(fd, path_obj) {
             fileio_close_owned_fd(fd);
             return Err(error);
@@ -14951,9 +14952,10 @@ fn open_raw_file(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         // close(), which is not the W_FileIO storage shape.
         let _ = (reading, writing);
         let flags = open_flags_for_mode(&mode);
-        let path_display = String::from_utf8_lossy(&path_bytes);
+        // The failure names the path object the call was given, not a spelling
+        // rebuilt from the bytes: `interp_fileio.py` wraps `w_name`.
         let fd = crate::host_seam::ops::open(&path_bytes, flags, 0o666)
-            .map_err(|e| crate::host_seam::seam_os_err(e, &path_display))?;
+            .map_err(|e| crate::host_seam::seam_os_err_with_filename(e, path_obj))?;
         if let Err(error) = fileio_validate_fd(fd, path_obj) {
             fileio_close_owned_fd(fd);
             return Err(error);

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -6920,12 +6920,12 @@ fn base_exception_str_method(args: &[PyObjectRef]) -> crate::PyResult {
 fn exception_str_method(args: &[PyObjectRef]) -> crate::PyResult {
     let obj = args[0];
     let text = unsafe {
-        match crate::display::exception_kind_str(obj)? {
+        match crate::display::exception_kind_str_wtf8(obj)? {
             Some(s) => s,
-            None => crate::display::base_exception_str(obj)?,
+            None => crate::display::base_exception_str_wtf8(obj)?,
         }
     };
-    Ok(pyre_object::w_str_new(&text))
+    Ok(pyre_object::w_str_from_wtf8(text))
 }
 
 /// `interp_exceptions.py:135-151 W_BaseException.descr_repr` — every builtin
@@ -6933,8 +6933,8 @@ fn exception_str_method(args: &[PyObjectRef]) -> crate::PyResult {
 /// alone and reads the receiver's own class name.
 fn exception_repr_method(args: &[PyObjectRef]) -> crate::PyResult {
     let obj = args[0];
-    Ok(pyre_object::w_str_new(&unsafe {
-        crate::display::py_repr(obj)?
+    Ok(pyre_object::w_str_from_wtf8(unsafe {
+        crate::display::py_repr_wtf8(obj)?
     }))
 }
 

--- a/pyre/pyre-interpreter/src/display.rs
+++ b/pyre/pyre-interpreter/src/display.rs
@@ -11,24 +11,6 @@ use crate::{
     builtin_code_name, function_get_name, function_get_qualname,
 };
 
-/// Try to call a dunder method (__repr__, __str__, etc.) on an instance.
-///
-/// PyPy: `ObjSpace.call_function(space.lookup(w_obj, name), w_obj)`
-/// Uses the unified `call_function` instead of a dedicated callback.
-///
-/// An override may answer with a lone surrogate, which this caller's `String`
-/// cannot hold; drop it rather than aborting on it. [`try_call_dunder_wtf8`]
-/// is the accessor that keeps such a result exact.
-fn try_call_dunder(obj: PyObjectRef, name: &str) -> Result<Option<String>, crate::PyError> {
-    unsafe {
-        Ok(try_call_dunder_obj(obj, name)?.map(|result| {
-            pyre_object::w_str_get_wtf8(result)
-                .to_string_lossy()
-                .into_owned()
-        }))
-    }
-}
-
 /// Try to call a dunder method (__repr__, __str__, etc.) on an instance,
 /// returning the raw result object when it is a `str`.
 pub(crate) unsafe fn try_call_dunder_obj(
@@ -226,55 +208,71 @@ impl Drop for ReprGuard {
 /// # Safety
 /// `obj` must be a real `W_DictObject` (caller resolves any subclass
 /// backing via `resolve_dict_backing` first).
-pub unsafe fn dict_repr(obj: PyObjectRef) -> Result<String, crate::PyError> {
+pub unsafe fn dict_repr(obj: PyObjectRef) -> Result<Wtf8Buf, crate::PyError> {
     let Some(_guard) = ReprGuard::enter(obj) else {
-        return Ok("{...}".to_string());
+        return Ok(Wtf8Buf::from_string("{...}".to_string()));
     };
     let entries = pyre_object::w_dict_items(obj);
-    let mut parts = Vec::with_capacity(entries.len());
+    let mut out = Wtf8Buf::new();
+    out.push_str("{");
     for (k, v) in entries {
-        parts.push(format!("{}: {}", py_repr(k)?, py_repr(v)?));
+        if out.len() > 1 {
+            out.push_str(", ");
+        }
+        out.push_wtf8(&py_repr_wtf8(k)?);
+        out.push_str(": ");
+        out.push_wtf8(&py_repr_wtf8(v)?);
     }
-    Ok(format!("{{{}}}", parts.join(", ")))
+    out.push_str("}");
+    Ok(out)
 }
 
 /// `listobject.py W_ListObject.descr_repr`, factored out so the TypeDef slot
 /// and the native `py_repr` fast path use the same recursion guard and item
 /// walk. Calling the base descriptor on a subclass must not redispatch its
 /// overriding `__repr__`.
-pub unsafe fn list_repr(obj: PyObjectRef) -> Result<String, crate::PyError> {
+pub unsafe fn list_repr(obj: PyObjectRef) -> Result<Wtf8Buf, crate::PyError> {
     let Some(_guard) = ReprGuard::enter(obj) else {
-        return Ok("[...]".to_string());
+        return Ok(Wtf8Buf::from_string("[...]".to_string()));
     };
     let n = pyre_object::w_list_len(obj);
-    let mut parts = Vec::with_capacity(n);
+    let mut out = Wtf8Buf::new();
+    out.push_str("[");
     for i in 0..n {
         if let Some(item) = pyre_object::w_list_getitem(obj, i as i64) {
-            parts.push(py_repr(item)?);
+            if out.len() > 1 {
+                out.push_str(", ");
+            }
+            out.push_wtf8(&py_repr_wtf8(item)?);
         }
     }
-    Ok(format!("[{}]", parts.join(", ")))
+    out.push_str("]");
+    Ok(out)
 }
 
 /// `tupleobject.py W_AbstractTupleObject.descr_repr`. This is the base slot
 /// body, so it formats tuple storage directly even when invoked through
 /// `super().__repr__()` on a subtype.
-pub unsafe fn tuple_repr(obj: PyObjectRef) -> Result<String, crate::PyError> {
+pub unsafe fn tuple_repr(obj: PyObjectRef) -> Result<Wtf8Buf, crate::PyError> {
     let Some(_guard) = ReprGuard::enter(obj) else {
-        return Ok("(...)".to_string());
+        return Ok(Wtf8Buf::from_string("(...)".to_string()));
     };
     let n = pyre_object::w_tuple_len(obj);
-    let mut parts = Vec::with_capacity(n);
+    let mut out = Wtf8Buf::new();
+    out.push_str("(");
     for i in 0..n {
         if let Some(item) = pyre_object::w_tuple_getitem(obj, i as i64) {
-            parts.push(py_repr(item)?);
+            if out.len() > 1 {
+                out.push_str(", ");
+            }
+            out.push_wtf8(&py_repr_wtf8(item)?);
         }
     }
     if n == 1 {
-        Ok(format!("({},)", parts[0]))
-    } else {
-        Ok(format!("({})", parts.join(", ")))
+        out.push_str(",");
     }
+    out.push_str(")");
+    Ok(out)
 }
 
 /// Format a PyObjectRef for debug display.
@@ -332,34 +330,6 @@ unsafe fn builtin_leaf_repr_string(
 /// `ob_type`-keyed formatters ignore a subclass override.  Returns `Some`
 /// only when the dunder resolves above `object` (whose inherited default
 /// must fall through to the builtin formatting instead of re-entering).
-pub(crate) unsafe fn builtin_subclass_dunder(
-    obj: PyObjectRef,
-    tp: *const PyType,
-    name: &str,
-) -> Result<Option<String>, crate::PyError> {
-    unsafe {
-        let Some(r) = builtin_subclass_dunder_obj(obj, tp, name)? else {
-            return Ok(None);
-        };
-        let w = pyre_object::w_str_get_wtf8(r).to_wtf8_buf();
-        // A surrogate-bearing override cannot fold into a Rust `String`; the
-        // WTF-8 callers (`py_str_wtf8` / `py_repr_wtf8`) preserve it, while
-        // this `String` path (used for container elements) degrades through
-        // the codec's `backslashreplace` handler rather than panicking.
-        let valid = w.as_str().map(str::to_owned).ok();
-        Ok(Some(match valid {
-            Some(s) => s,
-            None => {
-                let s_obj = pyre_object::w_str_from_wtf8(w);
-                crate::type_methods::encode_object(s_obj, "utf-8", "backslashreplace")
-                    .ok()
-                    .and_then(|b| String::from_utf8(b).ok())
-                    .unwrap_or_default()
-            }
-        }))
-    }
-}
-
 /// `builtin_subclass_dunder` returning the raw `str` result object so a
 /// WTF-8-preserving caller (`py_str_wtf8`) can read a lone-surrogate result
 /// via `w_str_get_wtf8` instead of the panicking `w_str_get_value`.
@@ -472,65 +442,6 @@ pub(crate) unsafe fn type_metaclass_dunder_obj(
     }
 }
 
-/// `repr(obj)` preserving a lone-surrogate result, the WTF-8 dual of
-/// [`py_repr`] (as [`py_str_wtf8`] is to [`py_str`]).  A builtin leaf
-/// subclass or plain instance whose `__repr__` returns a surrogate-bearing
-/// str is read through `w_str_get_wtf8` instead of the panicking
-/// `w_str_get_value`; every other object's `repr` is plain and delegates to
-/// `py_repr`.
-///
-/// # Safety
-/// `obj` must point to a valid `PyObject`.
-pub unsafe fn py_repr_wtf8(obj: PyObjectRef) -> Result<Wtf8Buf, crate::PyError> {
-    unsafe {
-        if pyre_object::tagged_int::CAN_BE_TAGGED && pyre_object::tagged_int::is_tagged_int(obj) {
-            return Ok(Wtf8Buf::from_string(format!(
-                "{}",
-                pyre_object::tagged_int::untag_int(obj)
-            )));
-        }
-        if !obj.is_null() {
-            let tp = (*obj).ob_type;
-            // `pyframe.py:849-853 descr_repr` may carry a lone surrogate in
-            // the filename, so keep an exact frame on the WTF-8 path instead
-            // of delegating through `py_repr`'s Rust `String` result.
-            if std::ptr::eq(tp, &crate::pyframe::FRAME_TYPE as *const PyType) {
-                return Ok((&*(obj as *const crate::PyFrame)).descr_repr());
-            }
-            // `pycode.py:570 repr` interpolates the filename the same way, and
-            // reaches for its `utf8_w` rather than a `&str`, so a code object
-            // needs the same exact path as the frame above.
-            if std::ptr::eq(tp, &crate::pycode::CODE_TYPE as *const PyType) {
-                let r = crate::pycode::code_repr(obj)?;
-                return Ok(pyre_object::w_str_get_wtf8(r).to_wtf8_buf());
-            }
-            // A builtin leaf subclass's `__repr__` override may return a
-            // lone surrogate; read it as WTF-8 rather than folding to `&str`.
-            if let Some(r) = builtin_subclass_dunder_obj(obj, tp, "__repr__")? {
-                return Ok(pyre_object::w_str_get_wtf8(r).to_wtf8_buf());
-            }
-            if let Some(r) = type_metaclass_dunder_obj(obj, "__repr__")? {
-                return Ok(pyre_object::w_str_get_wtf8(r).to_wtf8_buf());
-            }
-            if std::ptr::eq(tp, &INSTANCE_TYPE as *const PyType) {
-                if let Some(w) = try_call_dunder_wtf8(obj, "__repr__")? {
-                    return Ok(w);
-                }
-            }
-            // A `types.ModuleType` subclass `__repr__` override may likewise
-            // return a lone surrogate; read it as WTF-8 rather than folding to
-            // `&str`. Without an override, the native module repr is plain and
-            // delegates to `py_repr` below.
-            if std::ptr::eq(tp, &MODULE_TYPE as *const PyType) {
-                if let Some(r) = module_user_dunder_obj(obj, "__repr__")? {
-                    return Ok(pyre_object::w_str_get_wtf8(r).to_wtf8_buf());
-                }
-            }
-        }
-        Ok(Wtf8Buf::from_string(py_repr(obj)?))
-    }
-}
-
 /// Dispatch a user-defined `__str__` / `__repr__` override on an
 /// exception subclass.  The builtin `descr_str` / `descr_repr` are
 /// handled natively in `py_str` / `py_repr`, but a Python subclass
@@ -539,12 +450,6 @@ pub unsafe fn py_repr_wtf8(obj: PyObjectRef) -> Result<Wtf8Buf, crate::PyError> 
 /// Returns `None` only when `__str__`/`__repr__` resolves to the builtin
 /// `BaseException` / `object` registration (no override). A raising override
 /// propagates, and a non-string result raises `TypeError`.
-unsafe fn exc_user_dunder(obj: PyObjectRef, name: &str) -> Result<Option<String>, crate::PyError> {
-    unsafe {
-        Ok(exc_user_dunder_obj(obj, name)?.map(|r| pyre_object::w_str_get_value(r).to_string()))
-    }
-}
-
 /// `exc_user_dunder` variant returning the raw `str` result object so a
 /// WTF-8-preserving caller (`exception_descr_str_wtf8`) can read the
 /// lone-surrogate-carrying bytes directly. A raising override propagates and
@@ -624,43 +529,46 @@ unsafe fn module_user_dunder_obj(
     }
 }
 
-pub unsafe fn py_repr(obj: PyObjectRef) -> Result<String, crate::PyError> {
+pub unsafe fn py_repr_wtf8(obj: PyObjectRef) -> Result<Wtf8Buf, crate::PyError> {
     // A tagged immediate must be formatted before `ob_type` touches it as a
     // pointer; `repr` of a plain `int` is its
     // decimal value. Gated on `CAN_BE_TAGGED` (default false).
     if pyre_object::tagged_int::CAN_BE_TAGGED && pyre_object::tagged_int::is_tagged_int(obj) {
-        return Ok(format!("{}", pyre_object::tagged_int::untag_int(obj)));
+        return Ok(Wtf8Buf::from_string(format!(
+            "{}",
+            pyre_object::tagged_int::untag_int(obj)
+        )));
     }
     // The recursive container branches below (dict/list/tuple/set/deque/
-    // slice/range) re-enter `py_repr` on each element in native Rust with
+    // slice/range) re-enter `py_repr_wtf8` on each element in native Rust with
     // no Python frame push, so a deeply nested structure blows the C stack
     // before any frame-level check fires. Guard the stack here so
     // `repr(deeply_nested)` raises RecursionError instead of overflowing.
     crate::stack_check::stack_check()?;
     if obj.is_null() {
-        return Ok("NULL".to_string());
+        return Ok(Wtf8Buf::from_string("NULL".to_string()));
     }
     unsafe {
         let tp = (*obj).ob_type;
         // A builtin leaf subclass keeps `ob_type` at the canonical storage
         // type but carries the Python class in `w_class`; dispatch its
         // `__repr__` override before the `ob_type`-keyed formatting below.
-        if let Some(s) = builtin_subclass_dunder(obj, tp, "__repr__")? {
-            return Ok(s);
+        if let Some(r) = builtin_subclass_dunder_obj(obj, tp, "__repr__")? {
+            return Ok(pyre_object::w_str_get_wtf8(r).to_wtf8_buf());
         }
         // A class object is an instance of its metaclass.  PyPy's
         // `space.repr` therefore resolves `__repr__` on that metaclass before
         // `type`'s native `<class ...>` representation.  This is observable
         // for EnumType and any user metaclass defining `__repr__`.
         if let Some(result) = type_metaclass_dunder_obj(obj, "__repr__")? {
-            return Ok(pyre_object::w_str_get_value(result).to_string());
+            return Ok(pyre_object::w_str_get_wtf8(result).to_wtf8_buf());
         }
         let formatted = if let Some(s) = builtin_leaf_repr_string(obj, tp)? {
             s
         } else if pyre_object::interp_array::is_array(obj) {
-            crate::module::array::array_repr_string(obj)?
+            return crate::module::array::array_repr_wtf8(obj);
         } else if std::ptr::eq(tp, &pyre_object::pyobject::LIST_TYPE as *const PyType) {
-            list_repr(obj)?
+            return list_repr(obj);
         } else if pyre_object::is_tuple(obj) {
             // `pyre_object::is_tuple` covers `TUPLE_TYPE` plus the
             // arity-2 specialisations (`SPECIALISED_TUPLE_{II,FF,OO}_TYPE`,
@@ -697,44 +605,33 @@ pub unsafe fn py_repr(obj: PyObjectRef) -> Result<String, crate::PyError> {
                         // a TypeError like every other `__repr__` override.
                         let r = crate::builtins::call_and_check(method, &[obj])?;
                         if pyre_object::is_str(r) {
-                            // An override may answer with a lone surrogate, which
-                            // this caller's `String` cannot hold; drop it here the
-                            // way every other plain-`String` reader does rather
-                            // than aborting. `py_repr_wtf8` keeps it exact.
-                            return Ok(pyre_object::w_str_get_wtf8(r)
-                                .to_string_lossy()
-                                .into_owned());
+                            return Ok(pyre_object::w_str_get_wtf8(r).to_wtf8_buf());
                         }
                         return Err(dunder_returned_non_string("__repr__", r));
                     }
                 }
             }
-            let Some(_guard) = ReprGuard::enter(obj) else {
-                return Ok("(...)".to_string());
-            };
-            let n = pyre_object::w_tuple_len(obj);
-            let mut parts = Vec::with_capacity(n);
-            for i in 0..n {
-                if let Some(item) = pyre_object::w_tuple_getitem(obj, i as i64) {
-                    parts.push(py_repr(item)?);
-                }
-            }
-            if n == 1 {
-                format!("({},)", parts[0])
-            } else {
-                format!("({})", parts.join(", "))
-            }
+            return tuple_repr(obj);
         } else if unsafe { pyre_object::is_dict(obj) } {
-            unsafe { dict_repr(obj)? }
+            return unsafe { dict_repr(obj) };
         } else if pyre_object::sliceobject::is_slice(obj) {
             // `pypy/objspace/std/sliceobject.py descr_repr` —
             // `slice(%r, %r, %r)`.
-            format!(
-                "slice({}, {}, {})",
-                py_repr(pyre_object::sliceobject::w_slice_get_start(obj))?,
-                py_repr(pyre_object::sliceobject::w_slice_get_stop(obj))?,
-                py_repr(pyre_object::sliceobject::w_slice_get_step(obj))?,
-            )
+            let mut out = Wtf8Buf::new();
+            out.push_str("slice(");
+            out.push_wtf8(&py_repr_wtf8(pyre_object::sliceobject::w_slice_get_start(
+                obj,
+            ))?);
+            out.push_str(", ");
+            out.push_wtf8(&py_repr_wtf8(pyre_object::sliceobject::w_slice_get_stop(
+                obj,
+            ))?);
+            out.push_str(", ");
+            out.push_wtf8(&py_repr_wtf8(pyre_object::sliceobject::w_slice_get_step(
+                obj,
+            ))?);
+            out.push_str(")");
+            return Ok(out);
         } else if pyre_object::is_bytes_like(obj) {
             // `bytesobject.py W_BytesObject.descr_repr` — ASCII-printable
             // bytes pass through, control/high bytes use `\xNN`, and the
@@ -764,20 +661,31 @@ pub unsafe fn py_repr(obj: PyObjectRef) -> Result<String, crate::PyError> {
                 .map(|w_type| pyre_object::w_type_get_name(w_type.as_ptr()))
                 .unwrap_or(if is_frozen { "frozenset" } else { "set" });
             let Some(_guard) = ReprGuard::enter(obj) else {
-                return Ok(format!("{class_name}(...)"));
+                return Ok(Wtf8Buf::from_string(format!("{class_name}(...)")));
             };
             let items = pyre_object::w_set_items(obj);
-            let parts: Vec<String> = items
-                .iter()
-                .map(|&v| py_repr(v))
-                .collect::<Result<Vec<String>, _>>()?;
+            let mut out = Wtf8Buf::new();
             if items.is_empty() {
-                format!("{class_name}()")
-            } else if is_exact_set {
-                format!("{{{}}}", parts.join(", "))
-            } else {
-                format!("{class_name}({{{}}})", parts.join(", "))
+                out.push_str(class_name);
+                out.push_str("()");
+                return Ok(out);
             }
+            if !is_exact_set {
+                out.push_str(class_name);
+                out.push_str("(");
+            }
+            out.push_str("{");
+            for (i, &item) in items.iter().enumerate() {
+                if i != 0 {
+                    out.push_str(", ");
+                }
+                out.push_wtf8(&py_repr_wtf8(item)?);
+            }
+            out.push_str("}");
+            if !is_exact_set {
+                out.push_str(")");
+            }
+            return Ok(out);
         } else if std::ptr::eq(tp, &STR_TYPE as *const PyType) {
             format_wtf8_repr(pyre_object::w_str_get_wtf8(obj))
         } else if std::ptr::eq(tp, &NONE_TYPE as *const PyType) {
@@ -826,8 +734,8 @@ pub unsafe fn py_repr(obj: PyObjectRef) -> Result<String, crate::PyError> {
             // A user subclass that overrides `__repr__` shadows the builtin
             // `W_BaseException.descr_repr`; dispatch it before the native
             // formatting below.
-            if let Some(s) = exc_user_dunder(obj, "__repr__")? {
-                return Ok(s);
+            if let Some(r) = exc_user_dunder_obj(obj, "__repr__")? {
+                return Ok(pyre_object::w_str_get_wtf8(r).to_wtf8_buf());
             }
             // `pypy/module/exceptions/interp_exceptions.py:135-147
             // W_BaseException.descr_repr` →
@@ -860,29 +768,29 @@ pub unsafe fn py_repr(obj: PyObjectRef) -> Result<String, crate::PyError> {
                 .to_string()
             };
             let args_obj = unsafe { pyre_object::interp_exceptions::w_exception_get_args(obj) };
-            let inner = if !args_obj.is_null() && pyre_object::is_tuple(args_obj) {
+            let mut inner = Wtf8Buf::new();
+            if !args_obj.is_null() && pyre_object::is_tuple(args_obj) {
                 let n = pyre_object::w_tuple_len(args_obj);
-                if n == 0 {
-                    String::new()
-                } else if n == 1 {
+                if n == 1 {
                     let item = pyre_object::w_tuple_getitem(args_obj, 0).unwrap_or(args_obj);
-                    py_repr(item)?
+                    inner.push_wtf8(&py_repr_wtf8(item)?);
                 } else {
-                    let mut parts = Vec::with_capacity(n);
                     for i in 0..n {
                         if let Some(item) = pyre_object::w_tuple_getitem(args_obj, i as i64) {
-                            parts.push(py_repr(item)?);
+                            if !inner.is_empty() {
+                                inner.push_str(", ");
+                            }
+                            inner.push_wtf8(&py_repr_wtf8(item)?);
                         }
                     }
-                    parts.join(", ")
                 }
-            } else {
-                // `w_exception_get_args` always yields a tuple (empty for
-                // an argless exception), so the args branch above covers
-                // every case; nothing left to render here.
-                String::new()
-            };
-            format!("{class_name}({inner})")
+            }
+            let mut out = Wtf8Buf::new();
+            out.push_str(&class_name);
+            out.push_str("(");
+            out.push_wtf8(&inner);
+            out.push_str(")");
+            return Ok(out);
         } else if std::ptr::eq(tp, &TYPE_TYPE as *const PyType) {
             let name = crate::baseobjspace::type_repr_qualified_name(obj);
             format!("<class '{name}'>")
@@ -911,13 +819,13 @@ pub unsafe fn py_repr(obj: PyObjectRef) -> Result<String, crate::PyError> {
             parts.join(" | ")
         } else if std::ptr::eq(tp, &pyre_object::GENERIC_ALIAS_TYPE as *const PyType) {
             // GenericAlias.__repr__ (`_pypy_generic_alias.py:57`).
-            return crate::_pypy_generic_alias::repr(obj);
+            return Ok(Wtf8Buf::from_string(crate::_pypy_generic_alias::repr(obj)?));
         } else if std::ptr::eq(tp, &MODULE_TYPE as *const PyType) {
             // A `types.ModuleType` subclass carries its class in `w_class`; a
             // subclass `__repr__` override wins over the native module
             // formatting.
             if let Some(r) = module_user_dunder_obj(obj, "__repr__")? {
-                pyre_object::w_str_get_value(r).to_string()
+                return Ok(pyre_object::w_str_get_wtf8(r).to_wtf8_buf());
             } else {
                 crate::typedef::module_repr_string(obj)?
             }
@@ -928,7 +836,11 @@ pub unsafe fn py_repr(obj: PyObjectRef) -> Result<String, crate::PyError> {
             // `pypy/objspace/std/dictproxyobject.py:47 descr_repr` →
             // `b"mappingproxy(%s)" % space.utf8_w(space.repr(self.w_mapping))`.
             let inner = pyre_object::w_dict_proxy_get_mapping(obj);
-            format!("mappingproxy({})", py_repr(inner)?)
+            let mut out = Wtf8Buf::new();
+            out.push_str("mappingproxy(");
+            out.push_wtf8(&py_repr_wtf8(inner)?);
+            out.push_str(")");
+            return Ok(out);
         } else if pyre_object::typedef::is_getset_property(obj) {
             // CPython 3.14 `PyGetSetDescr_Type.tp_repr`.
             crate::typedef::getset_descriptor_repr(obj)
@@ -953,7 +865,7 @@ pub unsafe fn py_repr(obj: PyObjectRef) -> Result<String, crate::PyError> {
             // This is distinct from the owning dict's `{...}` placeholder: a
             // dict may contain one of its own values/items views.
             let Some(_guard) = ReprGuard::enter(obj) else {
-                return Ok("...".to_string());
+                return Ok(Wtf8Buf::from_string("...".to_string()));
             };
             let kind = pyre_object::dictmultiobject::w_dict_view_get_kind(obj);
             let label = match kind {
@@ -962,11 +874,17 @@ pub unsafe fn py_repr(obj: PyObjectRef) -> Result<String, crate::PyError> {
                 pyre_object::dictmultiobject::DictViewKind::Items => "dict_items",
             };
             let snapshot = crate::type_methods::dict_view_snapshot(obj);
-            let parts: Vec<String> = snapshot
-                .iter()
-                .map(|&item| py_repr(item))
-                .collect::<Result<Vec<String>, _>>()?;
-            format!("{label}([{}])", parts.join(", "))
+            let mut out = Wtf8Buf::new();
+            out.push_str(label);
+            out.push_str("([");
+            for (i, &item) in snapshot.iter().enumerate() {
+                if i != 0 {
+                    out.push_str(", ");
+                }
+                out.push_wtf8(&py_repr_wtf8(item)?);
+            }
+            out.push_str("])");
+            return Ok(out);
         } else if pyre_object::is_w_range(obj) {
             // `functional.py W_Range.descr_repr` —
             // `range(start, stop)`, with the step appended only when
@@ -975,16 +893,17 @@ pub unsafe fn py_repr(obj: PyObjectRef) -> Result<String, crate::PyError> {
             let (start, stop, step) = pyre_object::w_range_fields(obj);
             let step_is_one =
                 pyre_object::range_obj_to_bigint(step) == pyre_object::rbigint::RBigInt::from(1);
-            if step_is_one {
-                format!("range({}, {})", py_repr(start)?, py_repr(stop)?)
-            } else {
-                format!(
-                    "range({}, {}, {})",
-                    py_repr(start)?,
-                    py_repr(stop)?,
-                    py_repr(step)?
-                )
+            let mut out = Wtf8Buf::new();
+            out.push_str("range(");
+            out.push_wtf8(&py_repr_wtf8(start)?);
+            out.push_str(", ");
+            out.push_wtf8(&py_repr_wtf8(stop)?);
+            if !step_is_one {
+                out.push_str(", ");
+                out.push_wtf8(&py_repr_wtf8(step)?);
             }
+            out.push_str(")");
+            return Ok(out);
         } else if pyre_object::interp_sre::is_sre_pattern(obj) {
             // `pypy/module/_sre/interp_sre.py:153 W_SRE_Pattern.repr_w`.
             crate::module::_sre::interp_sre::sre_pattern_repr_str(obj)?
@@ -1002,11 +921,11 @@ pub unsafe fn py_repr(obj: PyObjectRef) -> Result<String, crate::PyError> {
             format!("<{label} at {obj:?}>")
         } else if std::ptr::eq(tp, &INSTANCE_TYPE as *const PyType) {
             // Try __repr__ first, then __str__
-            if let Some(s) = try_call_dunder(obj, "__repr__")? {
-                return Ok(s);
+            if let Some(w) = try_call_dunder_wtf8(obj, "__repr__")? {
+                return Ok(w);
             }
-            if let Some(s) = try_call_dunder(obj, "__str__")? {
-                return Ok(s);
+            if let Some(w) = try_call_dunder_wtf8(obj, "__str__")? {
+                return Ok(w);
             }
             let name = crate::baseobjspace::getfulltypename(obj);
             format!("<{name} object at {obj:?}>")
@@ -1023,11 +942,7 @@ pub unsafe fn py_repr(obj: PyObjectRef) -> Result<String, crate::PyError> {
                     if !std::ptr::eq(src, crate::typedef::w_object()) && !method.is_null() {
                         let r = crate::builtins::call_and_check(method, &[obj])?;
                         if pyre_object::is_str(r) {
-                            // As above: a lone surrogate is dropped for the
-                            // `String` caller instead of aborting on it.
-                            return Ok(pyre_object::w_str_get_wtf8(r)
-                                .to_string_lossy()
-                                .into_owned());
+                            return Ok(pyre_object::w_str_get_wtf8(r).to_wtf8_buf());
                         }
                         return Err(dunder_returned_non_string("__repr__", r));
                     }
@@ -1036,41 +951,51 @@ pub unsafe fn py_repr(obj: PyObjectRef) -> Result<String, crate::PyError> {
             let name = crate::baseobjspace::getfulltypename(obj);
             format!("<{name} object at {obj:?}>")
         };
-        Ok(formatted)
+        Ok(Wtf8Buf::from_string(formatted))
     }
 }
 
+pub unsafe fn py_repr(obj: PyObjectRef) -> Result<String, crate::PyError> {
+    Ok(unsafe { py_repr_wtf8(obj) }?.to_string_lossy().into_owned())
+}
+
 /// Format for str() — tries __str__ first, then __repr__.
-pub unsafe fn py_str(obj: PyObjectRef) -> Result<String, crate::PyError> {
+pub unsafe fn py_str_wtf8(obj: PyObjectRef) -> Result<Wtf8Buf, crate::PyError> {
     unsafe {
         // `str` of a tagged `int` immediate is its decimal value; format
         // it before `ob_type` deref. Gated on
         // `CAN_BE_TAGGED` (default false).
         if pyre_object::tagged_int::CAN_BE_TAGGED && pyre_object::tagged_int::is_tagged_int(obj) {
-            return Ok(format!("{}", pyre_object::tagged_int::untag_int(obj)));
+            return Ok(Wtf8Buf::from_string(format!(
+                "{}",
+                pyre_object::tagged_int::untag_int(obj)
+            )));
         }
         if obj.is_null() {
-            return Ok("NULL".to_string());
+            return Ok(Wtf8Buf::from_string("NULL".to_string()));
         }
         let tp = (*obj).ob_type;
         // For strings, return the value directly (no quotes).
         if std::ptr::eq(tp, &STR_TYPE as *const PyType) {
-            if let Some(s) = builtin_subclass_dunder(obj, tp, "__str__")? {
-                return Ok(s);
+            if let Some(r) = builtin_subclass_dunder_obj(obj, tp, "__str__")? {
+                return Ok(pyre_object::w_str_get_wtf8(r).to_wtf8_buf());
             }
-            return Ok(pyre_object::w_str_get_value(obj).to_string());
+            return Ok(pyre_object::w_str_get_wtf8(obj).to_wtf8_buf());
         }
         if std::ptr::eq(tp, &INSTANCE_TYPE as *const PyType) {
-            if let Some(s) = try_call_dunder(obj, "__str__")? {
-                return Ok(s);
+            if let Some(w) = try_call_dunder_wtf8(obj, "__str__")? {
+                return Ok(w);
             }
-            if let Some(s) = try_call_dunder(obj, "__repr__")? {
-                return Ok(s);
+            if let Some(w) = try_call_dunder_wtf8(obj, "__repr__")? {
+                return Ok(w);
             }
         }
         if unsafe { pyre_object::is_exception(obj) } {
-            if let Some(s) = exception_kind_str(obj)? {
-                return Ok(s);
+            if let Some(w) = exception_descr_str_wtf8(obj)? {
+                return Ok(w);
+            }
+            if let Some(w) = exception_kind_str_wtf8(obj)? {
+                return Ok(w);
             }
             // A user subclass that overrides `__str__` shadows the builtin
             // `W_BaseException.descr_str`; dispatch it before the generic
@@ -1078,28 +1003,29 @@ pub unsafe fn py_str(obj: PyObjectRef) -> Result<String, crate::PyError> {
             // the Unicode / OSError / KeyError `__str__` overrides, so a
             // non-overridden exception here resolves `__str__` to the
             // BaseException builtin and falls through unchanged.
-            if let Some(s) = exc_user_dunder(obj, "__str__")? {
-                return Ok(s);
-            }
-            return base_exception_str(obj);
+            return base_exception_str_wtf8(obj);
         }
         // `int`/`float`/... define no `tp_str`, so `str()` falls back to
         // `repr()` (a `__str__` override wins, otherwise the `__repr__`
         // override or builtin formatting from `py_repr`).  `str` itself
         // has its own `tp_str` and is handled by the `STR_TYPE` branch
         // above, so this fallthrough never reaches a bare-`str` subclass.
-        if let Some(s) = builtin_subclass_dunder(obj, tp, "__str__")? {
-            return Ok(s);
+        if let Some(r) = builtin_subclass_dunder_obj(obj, tp, "__str__")? {
+            return Ok(pyre_object::w_str_get_wtf8(r).to_wtf8_buf());
         }
         // A `types.ModuleType` subclass `__str__` override wins; without one,
         // `str` falls back to `__repr__` through `py_repr`.
         if pyre_object::is_module(obj) {
             if let Some(r) = module_user_dunder_obj(obj, "__str__")? {
-                return Ok(pyre_object::w_str_get_value(r).to_string());
+                return Ok(pyre_object::w_str_get_wtf8(r).to_wtf8_buf());
             }
         }
-        py_repr(obj)
+        py_repr_wtf8(obj)
     }
+}
+
+pub unsafe fn py_str(obj: PyObjectRef) -> Result<String, crate::PyError> {
+    Ok(unsafe { py_str_wtf8(obj) }?.to_string_lossy().into_owned())
 }
 
 /// `pypy/module/exceptions/interp_exceptions.py:126-133
@@ -1122,23 +1048,29 @@ pub unsafe fn py_str(obj: PyObjectRef) -> Result<String, crate::PyError> {
 /// # Safety
 /// `obj` must be a live `W_BaseException`.
 pub(crate) unsafe fn base_exception_str(obj: PyObjectRef) -> Result<String, crate::PyError> {
+    Ok(unsafe { base_exception_str_wtf8(obj) }?
+        .to_string_lossy()
+        .into_owned())
+}
+
+pub(crate) unsafe fn base_exception_str_wtf8(obj: PyObjectRef) -> Result<Wtf8Buf, crate::PyError> {
     unsafe {
         let args = pyre_object::interp_exceptions::w_exception_get_args(obj);
         if args.is_null() {
-            return Ok(String::new());
+            return Ok(Wtf8Buf::new());
         }
         if !pyre_object::is_tuple(args) {
-            return py_str(args);
+            return py_str_wtf8(args);
         }
         let n: usize = pyre_object::w_tuple_len(args);
         if n == 0 {
-            return Ok(String::new());
+            return Ok(Wtf8Buf::new());
         }
         if n == 1 {
             let first = pyre_object::w_tuple_getitem(args, 0).unwrap_or(args);
-            return py_str(first);
+            return py_str_wtf8(first);
         }
-        py_str(args)
+        py_str_wtf8(args)
     }
 }
 
@@ -1152,6 +1084,12 @@ pub(crate) unsafe fn base_exception_str(obj: PyObjectRef) -> Result<String, crat
 pub(crate) unsafe fn exception_kind_str(
     obj: PyObjectRef,
 ) -> Result<Option<String>, crate::PyError> {
+    Ok(unsafe { exception_kind_str_wtf8(obj) }?.map(|w| w.to_string_lossy().into_owned()))
+}
+
+pub(crate) unsafe fn exception_kind_str_wtf8(
+    obj: PyObjectRef,
+) -> Result<Option<Wtf8Buf>, crate::PyError> {
     unsafe {
         // `pypy/module/exceptions/interp_exceptions.py:447-459`
         // `W_UnicodeTranslateError.descr_str`,
@@ -1184,7 +1122,7 @@ pub(crate) unsafe fn exception_kind_str(
                     && pyre_object::w_tuple_len(args) == 1
                 {
                     let first = pyre_object::w_tuple_getitem(args, 0).unwrap_or(args);
-                    return Ok(Some(py_repr(first)?));
+                    return Ok(Some(py_repr_wtf8(first)?));
                 }
             }
             // `interp_exceptions.py:667-703 W_OSError.descr_str` reads
@@ -1226,8 +1164,13 @@ pub(crate) unsafe fn exception_kind_str(
                     1,
                 );
                 if let (Some(w_errno), Some(w_strerror)) = (w_errno, w_strerror) {
-                    let errno = py_str(w_errno)?;
-                    let strerror = py_str(w_strerror)?;
+                    let errno = py_str_wtf8(w_errno)?;
+                    let strerror = py_str_wtf8(w_strerror)?;
+                    let mut out = Wtf8Buf::new();
+                    out.push_str("[Errno ");
+                    out.push_wtf8(&errno);
+                    out.push_str("] ");
+                    out.push_wtf8(&strerror);
                     let w_filename = slot_or_arg(
                         pyre_object::interp_exceptions::w_exception_get_filename(obj),
                         2,
@@ -1240,18 +1183,17 @@ pub(crate) unsafe fn exception_kind_str(
                         )
                         .filter(|&f| !pyre_object::is_none(f));
                         if let Some(fname2) = w_filename2 {
-                            return Ok(Some(format!(
-                                "[Errno {errno}] {strerror}: {} -> {}",
-                                py_repr(fname)?,
-                                py_repr(fname2)?
-                            )));
+                            out.push_str(": ");
+                            out.push_wtf8(&py_repr_wtf8(fname)?);
+                            out.push_str(" -> ");
+                            out.push_wtf8(&py_repr_wtf8(fname2)?);
+                            return Ok(Some(out));
                         }
-                        return Ok(Some(format!(
-                            "[Errno {errno}] {strerror}: {}",
-                            py_repr(fname)?
-                        )));
+                        out.push_str(": ");
+                        out.push_wtf8(&py_repr_wtf8(fname)?);
+                        return Ok(Some(out));
                     }
-                    return Ok(Some(format!("[Errno {errno}] {strerror}")));
+                    return Ok(Some(out));
                 }
             }
             // `interp_exceptions.py:859-883 W_SyntaxError.descr_str` —
@@ -1262,77 +1204,12 @@ pub(crate) unsafe fn exception_kind_str(
             // lone surrogates for the plain-`String` caller.
             pyre_object::interp_exceptions::ExcKind::SyntaxError => {
                 if let Some(w) = exception_descr_str_wtf8(obj)? {
-                    return Ok(Some(w.to_string_lossy().into_owned()));
+                    return Ok(Some(w));
                 }
             }
             _ => {}
         }
         Ok(None)
-    }
-}
-
-/// WTF-8 preserving variant of `py_str` for the `str(x)` path.
-///
-/// Mirrors `py_str` but returns a `Wtf8Buf`, preserving lone surrogates
-/// for the two shapes whose `str()` can carry them: a `str` (returned
-/// verbatim) and a `W_BaseException` whose single argument is a `str`
-/// (`descr_str` returns `space.str(self.args_w[0])`).  Every other
-/// object's `str()` is plain UTF-8, so it delegates to `py_str` and
-/// wraps the result.
-///
-/// # Safety
-/// `obj` must point to a valid `PyObject`.
-pub unsafe fn py_str_wtf8(obj: PyObjectRef) -> Result<Wtf8Buf, crate::PyError> {
-    unsafe {
-        // A tagged `int` immediate stringifies to its decimal value
-        // (plain ASCII); format it before `ob_type`
-        // touch it as a pointer. Gated on `CAN_BE_TAGGED` (default false).
-        if pyre_object::tagged_int::CAN_BE_TAGGED && pyre_object::tagged_int::is_tagged_int(obj) {
-            return Ok(Wtf8Buf::from_string(format!(
-                "{}",
-                pyre_object::tagged_int::untag_int(obj)
-            )));
-        }
-        if !obj.is_null() {
-            let tp = (*obj).ob_type;
-            if std::ptr::eq(tp, &STR_TYPE as *const PyType) {
-                // A `str` subclass's `__str__` override wins over the raw value,
-                // mirroring `py_str`'s STR_TYPE branch. Read the result via
-                // `w_str_get_wtf8` so a lone-surrogate return is preserved
-                // rather than panicking in `w_str_get_value`.
-                if let Some(r) = builtin_subclass_dunder_obj(obj, tp, "__str__")? {
-                    return Ok(pyre_object::w_str_get_wtf8(r).to_wtf8_buf());
-                }
-                return Ok(pyre_object::w_str_get_wtf8(obj).to_wtf8_buf());
-            }
-            if pyre_object::is_exception(obj) {
-                if let Some(w) = exception_descr_str_wtf8(obj)? {
-                    return Ok(w);
-                }
-            }
-            // An instance whose `__str__`/`__repr__` returns a
-            // surrogate-bearing str must keep WTF-8; the String-based
-            // `py_str` path would panic folding it to `&str`.
-            if std::ptr::eq(tp, &INSTANCE_TYPE as *const PyType) {
-                if let Some(w) = try_call_dunder_wtf8(obj, "__str__")? {
-                    return Ok(w);
-                }
-                if let Some(w) = try_call_dunder_wtf8(obj, "__repr__")? {
-                    return Ok(w);
-                }
-            }
-            // A `types.ModuleType` subclass `__str__` override may likewise
-            // return a lone surrogate; read it as WTF-8. Without one, `str`
-            // falls back to `__repr__`, kept on the WTF-8 path so a
-            // surrogate-bearing module `__repr__` is preserved too.
-            if pyre_object::is_module(obj) {
-                if let Some(r) = module_user_dunder_obj(obj, "__str__")? {
-                    return Ok(pyre_object::w_str_get_wtf8(r).to_wtf8_buf());
-                }
-                return py_repr_wtf8(obj);
-            }
-        }
-        Ok(Wtf8Buf::from_string(py_str(obj)?))
     }
 }
 
@@ -1396,7 +1273,7 @@ unsafe fn exception_descr_str_wtf8(obj: PyObjectRef) -> Result<Option<Wtf8Buf>, 
             let w_msg = crate::baseobjspace::syntax_error_attr(obj, "msg");
             // `type(self.msg) is not str` → `return str(self.msg)`.
             if w_msg.is_null() || !pyre_object::pyobject::is_exact_type(w_msg, &STR_TYPE) {
-                return Ok(Some(Wtf8Buf::from_string(py_str(w_msg)?)));
+                return Ok(Some(py_str_wtf8(w_msg)?));
             }
             let compose = |extra: Option<Wtf8Buf>| -> Wtf8Buf {
                 let mut out = pyre_object::w_str_get_wtf8(w_msg).to_wtf8_buf();
@@ -1513,16 +1390,16 @@ unsafe fn unicode_err_int_slot(stored: PyObjectRef) -> Result<i64, String> {
 /// non-str at construction time; this helper covers the
 /// post-construction mutation case (`e.encoding = 42`,
 /// `e.reason = None`, etc.) the way PyPy would via `%s`-coerce.
-unsafe fn unicode_err_str_slot(stored: PyObjectRef) -> Result<String, crate::PyError> {
+unsafe fn unicode_err_str_slot(stored: PyObjectRef) -> Result<Wtf8Buf, crate::PyError> {
     unsafe {
         if stored.is_null() {
-            return Ok(String::new());
+            return Ok(Wtf8Buf::new());
         }
         if pyre_object::is_exact_type(stored, &pyre_object::STR_TYPE) {
-            return Ok(pyre_object::w_str_get_value(stored).to_string());
+            return Ok(pyre_object::w_str_get_wtf8(stored).to_wtf8_buf());
         }
         // `%s` propagates an exception raised by the value's `__str__`.
-        py_str(stored)
+        py_str_wtf8(stored)
     }
 }
 
@@ -1577,14 +1454,14 @@ fn unicode_err_end_minus_one_repr(slot: &Result<i64, String>) -> String {
 /// shape with a `<?>` placeholder for the indexed character — never
 /// silently degrading to the plural-range message when the shape
 /// `end == start + 1` says single-char.
-unsafe fn unicode_translate_error_str(obj: PyObjectRef) -> Result<String, crate::PyError> {
+unsafe fn unicode_translate_error_str(obj: PyObjectRef) -> Result<Wtf8Buf, crate::PyError> {
     unsafe {
         let _roots = pyre_object::gc_roots::push_roots();
         pyre_object::gc_roots::pin_root(obj);
         let obj_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let initial = pyre_object::interp_exceptions::w_exception_get_object(obj);
         if initial.is_null() || pyre_object::is_none(initial) {
-            return Ok(String::new());
+            return Ok(Wtf8Buf::new());
         }
         // Each of these three reads can run Python — `int_w` walks
         // `__index__` and `unicode_err_str_slot` calls `__str__` — so the
@@ -1640,19 +1517,21 @@ unsafe fn unicode_translate_error_str(obj: PyObjectRef) -> Result<String, crate:
             } else {
                 None
             };
-            return Ok(format!(
-                "can't translate character {} in position {}: {}",
+            let mut out = Wtf8Buf::from_string(format!(
+                "can't translate character {} in position {}: ",
                 badchar_repr.unwrap_or_else(|| "<?>".to_string()),
                 start_repr,
-                reason
             ));
+            out.push_wtf8(&reason);
+            return Ok(out);
         }
-        Ok(format!(
-            "can't translate characters in position {}-{}: {}",
+        let mut out = Wtf8Buf::from_string(format!(
+            "can't translate characters in position {}-{}: ",
             start_repr,
             unicode_err_end_minus_one_repr(&end_slot),
-            reason
-        ))
+        ));
+        out.push_wtf8(&reason);
+        Ok(out)
     }
 }
 
@@ -1675,14 +1554,14 @@ unsafe fn unicode_translate_error_str(obj: PyObjectRef) -> Result<String, crate:
 /// non-bytes-like `w_object` keeps the single-byte format shape with
 /// `0x??` for the byte position — the shape never silently degrades
 /// to the plural-range message when `end == start + 1`.
-unsafe fn unicode_decode_error_str(obj: PyObjectRef) -> Result<String, crate::PyError> {
+unsafe fn unicode_decode_error_str(obj: PyObjectRef) -> Result<Wtf8Buf, crate::PyError> {
     unsafe {
         let _roots = pyre_object::gc_roots::push_roots();
         pyre_object::gc_roots::pin_root(obj);
         let obj_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let initial = pyre_object::interp_exceptions::w_exception_get_object(obj);
         if initial.is_null() || pyre_object::is_none(initial) {
-            return Ok(String::new());
+            return Ok(Wtf8Buf::new());
         }
         let encoding =
             unicode_err_str_slot(pyre_object::interp_exceptions::w_exception_get_encoding(
@@ -1722,21 +1601,27 @@ unsafe fn unicode_decode_error_str(obj: PyObjectRef) -> Result<String, crate::Py
             } else {
                 None
             };
-            return Ok(format!(
-                "'{}' codec can't decode byte {} in position {}: {}",
-                encoding,
+            let mut out = Wtf8Buf::new();
+            out.push_str("'");
+            out.push_wtf8(&encoding);
+            out.push_str(&format!(
+                "' codec can't decode byte {} in position {}: ",
                 byte_repr.unwrap_or_else(|| "0x??".to_string()),
                 start_repr,
-                reason
             ));
+            out.push_wtf8(&reason);
+            return Ok(out);
         }
-        Ok(format!(
-            "'{}' codec can't decode bytes in position {}-{}: {}",
-            encoding,
+        let mut out = Wtf8Buf::new();
+        out.push_str("'");
+        out.push_wtf8(&encoding);
+        out.push_str(&format!(
+            "' codec can't decode bytes in position {}-{}: ",
             start_repr,
             unicode_err_end_minus_one_repr(&end_slot),
-            reason
-        ))
+        ));
+        out.push_wtf8(&reason);
+        Ok(out)
     }
 }
 
@@ -1745,14 +1630,14 @@ unsafe fn unicode_decode_error_str(obj: PyObjectRef) -> Result<String, crate::Py
 /// `W_UnicodeTranslateError` but prefixed with the encoding name.
 /// Non-int / non-str / OOR mutations match the parity rules in
 /// [`unicode_translate_error_str`] / [`unicode_decode_error_str`].
-unsafe fn unicode_encode_error_str(obj: PyObjectRef) -> Result<String, crate::PyError> {
+unsafe fn unicode_encode_error_str(obj: PyObjectRef) -> Result<Wtf8Buf, crate::PyError> {
     unsafe {
         let _roots = pyre_object::gc_roots::push_roots();
         pyre_object::gc_roots::pin_root(obj);
         let obj_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let initial = pyre_object::interp_exceptions::w_exception_get_object(obj);
         if initial.is_null() || pyre_object::is_none(initial) {
-            return Ok(String::new());
+            return Ok(Wtf8Buf::new());
         }
         let encoding =
             unicode_err_str_slot(pyre_object::interp_exceptions::w_exception_get_encoding(
@@ -1806,21 +1691,27 @@ unsafe fn unicode_encode_error_str(obj: PyObjectRef) -> Result<String, crate::Py
             } else {
                 None
             };
-            return Ok(format!(
-                "'{}' codec can't encode character {} in position {}: {}",
-                encoding,
+            let mut out = Wtf8Buf::new();
+            out.push_str("'");
+            out.push_wtf8(&encoding);
+            out.push_str(&format!(
+                "' codec can't encode character {} in position {}: ",
                 badchar_repr.unwrap_or_else(|| "<?>".to_string()),
                 start_repr,
-                reason
             ));
+            out.push_wtf8(&reason);
+            return Ok(out);
         }
-        Ok(format!(
-            "'{}' codec can't encode characters in position {}-{}: {}",
-            encoding,
+        let mut out = Wtf8Buf::new();
+        out.push_str("'");
+        out.push_wtf8(&encoding);
+        out.push_str(&format!(
+            "' codec can't encode characters in position {}-{}: ",
             start_repr,
             unicode_err_end_minus_one_repr(&end_slot),
-            reason
-        ))
+        ));
+        out.push_wtf8(&reason);
+        Ok(out)
     }
 }
 

--- a/pyre/pyre-interpreter/src/display.rs
+++ b/pyre/pyre-interpreter/src/display.rs
@@ -15,10 +15,17 @@ use crate::{
 ///
 /// PyPy: `ObjSpace.call_function(space.lookup(w_obj, name), w_obj)`
 /// Uses the unified `call_function` instead of a dedicated callback.
+///
+/// An override may answer with a lone surrogate, which this caller's `String`
+/// cannot hold; drop it rather than aborting on it. [`try_call_dunder_wtf8`]
+/// is the accessor that keeps such a result exact.
 fn try_call_dunder(obj: PyObjectRef, name: &str) -> Result<Option<String>, crate::PyError> {
     unsafe {
-        Ok(try_call_dunder_obj(obj, name)?
-            .map(|result| pyre_object::w_str_get_value(result).to_string()))
+        Ok(try_call_dunder_obj(obj, name)?.map(|result| {
+            pyre_object::w_str_get_wtf8(result)
+                .to_string_lossy()
+                .into_owned()
+        }))
     }
 }
 
@@ -490,6 +497,13 @@ pub unsafe fn py_repr_wtf8(obj: PyObjectRef) -> Result<Wtf8Buf, crate::PyError> 
             if std::ptr::eq(tp, &crate::pyframe::FRAME_TYPE as *const PyType) {
                 return Ok((&*(obj as *const crate::PyFrame)).descr_repr());
             }
+            // `pycode.py:570 repr` interpolates the filename the same way, and
+            // reaches for its `utf8_w` rather than a `&str`, so a code object
+            // needs the same exact path as the frame above.
+            if std::ptr::eq(tp, &crate::pycode::CODE_TYPE as *const PyType) {
+                let r = crate::pycode::code_repr(obj)?;
+                return Ok(pyre_object::w_str_get_wtf8(r).to_wtf8_buf());
+            }
             // A builtin leaf subclass's `__repr__` override may return a
             // lone surrogate; read it as WTF-8 rather than folding to `&str`.
             if let Some(r) = builtin_subclass_dunder_obj(obj, tp, "__repr__")? {
@@ -683,7 +697,13 @@ pub unsafe fn py_repr(obj: PyObjectRef) -> Result<String, crate::PyError> {
                         // a TypeError like every other `__repr__` override.
                         let r = crate::builtins::call_and_check(method, &[obj])?;
                         if pyre_object::is_str(r) {
-                            return Ok(pyre_object::w_str_get_value(r).to_string());
+                            // An override may answer with a lone surrogate, which
+                            // this caller's `String` cannot hold; drop it here the
+                            // way every other plain-`String` reader does rather
+                            // than aborting. `py_repr_wtf8` keeps it exact.
+                            return Ok(pyre_object::w_str_get_wtf8(r)
+                                .to_string_lossy()
+                                .into_owned());
                         }
                         return Err(dunder_returned_non_string("__repr__", r));
                     }
@@ -1003,7 +1023,11 @@ pub unsafe fn py_repr(obj: PyObjectRef) -> Result<String, crate::PyError> {
                     if !std::ptr::eq(src, crate::typedef::w_object()) && !method.is_null() {
                         let r = crate::builtins::call_and_check(method, &[obj])?;
                         if pyre_object::is_str(r) {
-                            return Ok(pyre_object::w_str_get_value(r).to_string());
+                            // As above: a lone surrogate is dropped for the
+                            // `String` caller instead of aborting on it.
+                            return Ok(pyre_object::w_str_get_wtf8(r)
+                                .to_string_lossy()
+                                .into_owned());
                         }
                         return Err(dunder_returned_non_string("__repr__", r));
                     }

--- a/pyre/pyre-interpreter/src/display.rs
+++ b/pyre/pyre-interpreter/src/display.rs
@@ -215,8 +215,10 @@ pub unsafe fn dict_repr(obj: PyObjectRef) -> Result<Wtf8Buf, crate::PyError> {
     let entries = pyre_object::w_dict_items(obj);
     let mut out = Wtf8Buf::new();
     out.push_str("{");
-    for (k, v) in entries {
-        if out.len() > 1 {
+    for (i, (k, v)) in entries.into_iter().enumerate() {
+        // `dictmultiobject.py:388` joins the pairs by position, so a key or
+        // value whose `__repr__` answers `""` still gets its separator.
+        if i != 0 {
             out.push_str(", ");
         }
         out.push_wtf8(&py_repr_wtf8(k)?);
@@ -239,12 +241,17 @@ pub unsafe fn list_repr(obj: PyObjectRef) -> Result<Wtf8Buf, crate::PyError> {
     let mut out = Wtf8Buf::new();
     out.push_str("[");
     for i in 0..n {
-        if let Some(item) = pyre_object::w_list_getitem(obj, i as i64) {
-            if out.len() > 1 {
-                out.push_str(", ");
-            }
-            out.push_wtf8(&py_repr_wtf8(item)?);
+        // `listobject.py:217-221` stops rather than skipping when an item is
+        // gone, since an item's `__repr__` may have shortened the list.
+        let Some(item) = pyre_object::w_list_getitem(obj, i as i64) else {
+            break;
+        };
+        // The separator goes by position, not by how much has been written:
+        // an item whose `__repr__` answers `""` still takes a slot.
+        if i != 0 {
+            out.push_str(", ");
         }
+        out.push_wtf8(&py_repr_wtf8(item)?);
     }
     out.push_str("]");
     Ok(out)
@@ -262,7 +269,9 @@ pub unsafe fn tuple_repr(obj: PyObjectRef) -> Result<Wtf8Buf, crate::PyError> {
     out.push_str("(");
     for i in 0..n {
         if let Some(item) = pyre_object::w_tuple_getitem(obj, i as i64) {
-            if out.len() > 1 {
+            // `tupleobject.py:114` joins by position, so an item whose
+            // `__repr__` answers `""` still gets its separator.
+            if i != 0 {
                 out.push_str(", ");
             }
             out.push_wtf8(&py_repr_wtf8(item)?);
@@ -529,6 +538,13 @@ unsafe fn module_user_dunder_obj(
     }
 }
 
+/// `space.repr` — the whole type dispatch, answering the encoded bytes.
+///
+/// `listobject.py:206-225 _listrepr_inner` assembles a container's repr in a
+/// `rutf8.Utf8StringBuilder` from each item's `space.utf8_len_w(space.repr(...))`,
+/// so a lone surrogate an item wrote survives being nested. A `Wtf8Buf` is the
+/// buffer that can hold the same thing here; a Rust `String` cannot, which is
+/// why [`py_repr`] is a lossy view of this rather than the other way round.
 pub unsafe fn py_repr_wtf8(obj: PyObjectRef) -> Result<Wtf8Buf, crate::PyError> {
     // A tagged immediate must be formatted before `ob_type` touches it as a
     // pointer; `repr` of a plain `int` is its
@@ -777,7 +793,11 @@ pub unsafe fn py_repr_wtf8(obj: PyObjectRef) -> Result<Wtf8Buf, crate::PyError> 
                 } else {
                     for i in 0..n {
                         if let Some(item) = pyre_object::w_tuple_getitem(args_obj, i as i64) {
-                            if !inner.is_empty() {
+                            // `interp_exceptions.py:135-147` spells the args
+                            // with `repr(tuple(args))`, which separates by
+                            // position — an argument whose `__repr__` answers
+                            // `""` still takes a slot.
+                            if i != 0 {
                                 inner.push_str(", ");
                             }
                             inner.push_wtf8(&py_repr_wtf8(item)?);

--- a/pyre/pyre-interpreter/src/gateway.rs
+++ b/pyre/pyre-interpreter/src/gateway.rs
@@ -1521,7 +1521,7 @@ mod tests {
 /// as itself. Folding it into a Rust `String` first replaces it with U+FFFD,
 /// which both loses the name and makes distinct names alias onto one another.
 pub fn fsencode_bytes_w(obj: pyre_object::PyObjectRef) -> Result<Vec<u8>, crate::PyError> {
-    Ok(fsencode_bytes_w_with_kind(obj)?.0)
+    Ok(fsencode_path_w(obj)?.as_bytes)
 }
 
 /// `objspace.py:438 newfilename(s) = fsdecode(newbytes(s))`: expose the
@@ -1538,22 +1538,31 @@ pub fn fsdecode_filename_wtf8(data: &[u8]) -> rustpython_wtf8::Wtf8Buf {
     crate::typedef::charp2uni_wtf8(data)
 }
 
-/// [`fsencode_bytes_w`] paired with the discriminator `posixmodule.c
-/// path_converter` derives from the same resolution: `true` when the path
-/// resolved to `bytes`, which makes the names the call reports back `bytes`
-/// too.  Callers that need both must use this rather than re-resolving,
-/// because `path_converter` calls `__fspath__` exactly **once** — a second
-/// call would let a stateful implementation observe duplicate side effects, or
-/// answer `str` first and `bytes` second and leave the reported names
-/// describing a different path than the one that was listed.
-pub fn fsencode_bytes_w_with_kind(
-    obj: pyre_object::PyObjectRef,
-) -> Result<(Vec<u8>, bool), crate::PyError> {
-    let _roots = pyre_object::gc_roots::push_roots();
+/// `interp_posix.py:194-219 Path`: the syscall spelling and the resolved path
+/// object travel together. For `os.PathLike`, `w_path` is the result of the
+/// single `__fspath__` call, not the wrapper that supplied it.
+pub struct FsEncodedPath {
+    pub as_bytes: Vec<u8>,
+    w_path_slot: usize,
+    _roots: pyre_object::gc_roots::RootScope,
+}
+
+impl FsEncodedPath {
+    pub fn w_path(&self) -> pyre_object::PyObjectRef {
+        pyre_object::gc_roots::shadow_stack_get(self.w_path_slot)
+    }
+
+    pub unsafe fn is_bytes(&self) -> bool {
+        unsafe { pyre_object::bytesobject::is_bytes_like(self.w_path()) }
+    }
+}
+
+pub fn fsencode_path_w(obj: pyre_object::PyObjectRef) -> Result<FsEncodedPath, crate::PyError> {
+    let roots = pyre_object::gc_roots::push_roots();
     let obj_slot = pyre_object::gc_roots::shadow_stack_len();
     pyre_object::gc_roots::pin_root(obj);
 
-    let (data, is_bytes) = unsafe {
+    let (data, w_path_slot) = unsafe {
         let obj = pyre_object::gc_roots::shadow_stack_get(obj_slot);
         if pyre_object::bytesobject::is_bytes_like(obj) {
             // baseobjspace.py:1975-1977: pyre's readable-buffer set here is
@@ -1567,10 +1576,10 @@ pub fn fsencode_bytes_w_with_kind(
             let obj = pyre_object::gc_roots::shadow_stack_get(obj_slot);
             (
                 pyre_object::bytesobject::bytes_like_data(obj).to_vec(),
-                true,
+                obj_slot,
             )
         } else if pyre_object::is_str(obj) {
-            (fsencode(obj)?, false)
+            (fsencode(obj)?, obj_slot)
         } else {
             // `type(path).__fspath__(path)` — the descriptor read off the type is
             // unbound, so `path` is supplied as the sole argument.
@@ -1596,10 +1605,10 @@ pub fn fsencode_bytes_w_with_kind(
             if pyre_object::bytesobject::is_bytes(result) {
                 (
                     pyre_object::bytesobject::w_bytes_data(result).to_vec(),
-                    true,
+                    result_slot,
                 )
             } else if pyre_object::is_str(result) {
-                (fsencode(result)?, false)
+                (fsencode(result)?, result_slot)
             } else {
                 // interp_posix.py:3053-3058 names both the object that was asked
                 // and the type its `__fspath__` answered with.
@@ -1616,7 +1625,11 @@ pub fn fsencode_bytes_w_with_kind(
     if data.contains(&0) {
         return Err(crate::PyError::value_error("embedded null byte"));
     }
-    Ok((data, is_bytes))
+    Ok(FsEncodedPath {
+        as_bytes: data,
+        w_path_slot,
+        _roots: roots,
+    })
 }
 
 /// `baseobjspace.py:1962 space.fsencode` — the plain filesystem encode of a

--- a/pyre/pyre-interpreter/src/gateway.rs
+++ b/pyre/pyre-interpreter/src/gateway.rs
@@ -1513,33 +1513,13 @@ mod tests {
     }
 }
 
-// ── fsencode_w ───────────────────────────────────────────────────────
-// PyPy equivalent: `space.fsencode_w(w_obj)` —
-// `pypy/interpreter/baseobjspace.py:1232 fsencode_w` accepts str,
-// bytes, or any object implementing `__fspath__` and returns the
-// filesystem-encoded path as a Rust string.  Used by the
-// `#[pyre_function]` / `#[pyre_methods]` `PyPath` typed-receiver alias
-// (gateway.py visit_fsencode line 365) and by posix call sites that
-// previously inlined the same extraction.
-pub fn fsencode_w(obj: pyre_object::PyObjectRef) -> Result<String, crate::PyError> {
-    Ok(fsencode_w_with_kind(obj)?.0)
-}
-
-/// [`fsencode_w`] paired with the discriminator `posixmodule.c
-/// path_converter` derives from the same resolution: `true` when the path
-/// resolved to `bytes`, which makes the names the call reports back `bytes`
-/// too.  Callers that need both must use this rather than re-resolving,
-/// because `path_converter` calls `__fspath__` exactly **once** — a second
-/// call would let a stateful implementation observe duplicate side effects, or
-/// answer `str` first and `bytes` second and leave the reported names
-/// describing a different path than the one that was listed.
-pub fn fsencode_w_with_kind(
-    obj: pyre_object::PyObjectRef,
-) -> Result<(String, bool), crate::PyError> {
-    let (data, is_bytes) = fsencode_bytes_w_with_kind(obj)?;
-    Ok((String::from_utf8_lossy(&data).into_owned(), is_bytes))
-}
-
+// ── fsencode_bytes_w ─────────────────────────────────────────────────
+/// `baseobjspace.py:1970 fsencode_w` accepts str, bytes, or an object
+/// implementing `__fspath__`, and answers with the filesystem-encoded bytes.
+///
+/// Bytes, not text: a path byte with no UTF-8 spelling has to reach the syscall
+/// as itself. Folding it into a Rust `String` first replaces it with U+FFFD,
+/// which both loses the name and makes distinct names alias onto one another.
 pub fn fsencode_bytes_w(obj: pyre_object::PyObjectRef) -> Result<Vec<u8>, crate::PyError> {
     Ok(fsencode_bytes_w_with_kind(obj)?.0)
 }
@@ -1558,8 +1538,14 @@ pub fn fsdecode_filename_wtf8(data: &[u8]) -> rustpython_wtf8::Wtf8Buf {
     crate::typedef::charp2uni_wtf8(data)
 }
 
-/// [`fsencode_bytes_w`] paired with the `bytes`-ness of the resolved object;
-/// see [`fsencode_w_with_kind`] for why the two are produced together.
+/// [`fsencode_bytes_w`] paired with the discriminator `posixmodule.c
+/// path_converter` derives from the same resolution: `true` when the path
+/// resolved to `bytes`, which makes the names the call reports back `bytes`
+/// too.  Callers that need both must use this rather than re-resolving,
+/// because `path_converter` calls `__fspath__` exactly **once** — a second
+/// call would let a stateful implementation observe duplicate side effects, or
+/// answer `str` first and `bytes` second and leave the reported names
+/// describing a different path than the one that was listed.
 pub fn fsencode_bytes_w_with_kind(
     obj: pyre_object::PyObjectRef,
 ) -> Result<(Vec<u8>, bool), crate::PyError> {

--- a/pyre/pyre-interpreter/src/host_seam.rs
+++ b/pyre/pyre-interpreter/src/host_seam.rs
@@ -149,15 +149,22 @@ pub type SeamResult<T> = Result<T, SeamError>;
 /// the `""` the fd call sites pass). Both real and trampoline-backed opens
 /// use this conversion so they expose the same Python exception shape.
 pub fn seam_os_err(e: SeamError, context: &str) -> crate::PyError {
+    let w_filename = if context.is_empty() {
+        pyre_object::PY_NULL
+    } else {
+        pyre_object::w_str_new(context)
+    };
+    seam_os_err_with_filename(e, w_filename)
+}
+
+/// `wrap_oserror2(space, e, w_path)` in `interp_posix.py`: retain the exact
+/// argument object for `OSError.filename` instead of rebuilding its spelling.
+pub fn seam_os_err_with_filename(
+    e: SeamError,
+    w_filename: pyre_object::PyObjectRef,
+) -> crate::PyError {
     match e {
-        SeamError::Os(errno) => {
-            let w_filename = if context.is_empty() {
-                pyre_object::PY_NULL
-            } else {
-                pyre_object::w_str_new(context)
-            };
-            crate::PyError::os_error_syscall(errno, w_filename)
-        }
+        SeamError::Os(errno) => crate::PyError::os_error_syscall(errno, w_filename),
         SeamError::Io => crate::PyError::os_error_with_errno(libc::EIO, "I/O error"),
         SeamError::Value => crate::PyError::value_error("embedded null in path"),
         SeamError::Overflow => crate::PyError::overflow_error("integer overflow"),

--- a/pyre/pyre-interpreter/src/module/_collections/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_collections/mod.rs
@@ -1277,27 +1277,32 @@ impl W_Deque {
         store(self_obj, items);
         Ok(self_obj)
     }
-    fn __repr__(&self) -> Result<String, crate::PyError> {
+    fn __repr__(&self) -> Result<PyObjectRef, crate::PyError> {
         let self_obj = self as *const W_Deque as PyObjectRef;
         // `dequerepr` — a deque reachable from its own items renders
         // the inner reference as `[...]` instead of recursing.
         let Some(_guard) = crate::display::ReprGuard::enter(self_obj) else {
-            return Ok("[...]".to_string());
+            return Ok(pyre_object::w_str_new("[...]"));
         };
         // The repr uses the short class name, so strip any dotted
         // module prefix from the builtin tp_name (`collections.deque`
         // → `deque`); a user subclass name has no dot.
         let full = unsafe { w_type_get_name(w_instance_get_type(self_obj)) };
         let name = full.rsplit('.').next().unwrap_or(full);
-        let listrepr = snapshot(self_obj)
-            .into_iter()
-            .map(|it| unsafe { crate::py_repr(it) })
-            .collect::<Result<Vec<_>, _>>()?
-            .join(", ");
-        Ok(match maxlen_bound(self_obj) {
-            Some(m) => format!("{name}([{listrepr}], maxlen={m})"),
-            None => format!("{name}([{listrepr}])"),
-        })
+        let mut out = rustpython_wtf8::Wtf8Buf::new();
+        out.push_str(name);
+        out.push_str("([");
+        for (i, item) in snapshot(self_obj).into_iter().enumerate() {
+            if i != 0 {
+                out.push_str(", ");
+            }
+            out.push_wtf8(&unsafe { crate::py_repr_wtf8(item)? });
+        }
+        match maxlen_bound(self_obj) {
+            Some(m) => out.push_str(&format!("], maxlen={m})")),
+            None => out.push_str("])"),
+        }
+        Ok(pyre_object::w_str_from_wtf8(out))
     }
 
     #[getter]

--- a/pyre/pyre-interpreter/src/module/_random/macro_smoke.rs
+++ b/pyre/pyre-interpreter/src/module/_random/macro_smoke.rs
@@ -57,13 +57,13 @@ impl Demo {
 /// `PyPath` typed-receiver alias.
 #[crate::pyre_function]
 fn _seed_from_path(path: PyPath) -> i64 {
-    path.bytes().map(|b| b as i64).sum()
+    path.into_iter().map(|b| b as i64).sum()
 }
 
 /// `Vec<i64>` auto return-wrap.
 #[crate::pyre_function]
 fn _path_bytes(path: PyPath) -> Vec<i64> {
-    path.bytes().map(|b| b as i64).collect()
+    path.into_iter().map(|b| b as i64).collect()
 }
 
 /// One parameter per text / int unwrap alias, so the generated unwrap +

--- a/pyre/pyre-interpreter/src/module/array/mod.rs
+++ b/pyre/pyre-interpreter/src/module/array/mod.rs
@@ -926,28 +926,37 @@ fn array_copy_method(args: &[PyObjectRef]) -> PyResult {
 /// `array.__repr__` formatting (`interp_array.py descr_repr`).  Shared with
 /// `display::py_repr` so an array nested in a list / error / tuple formats
 /// the same way.
-pub fn array_repr_string(obj: PyObjectRef) -> Result<String, PyError> {
+pub fn array_repr_wtf8(obj: PyObjectRef) -> Result<rustpython_wtf8::Wtf8Buf, PyError> {
     let tc = unsafe { arr::w_array_typecode(obj) } as char;
     let len = unsafe { arr::w_array_len(obj) };
     if len == 0 {
-        return Ok(format!("array('{tc}')"));
+        return Ok(rustpython_wtf8::Wtf8Buf::from_string(format!(
+            "array('{tc}')"
+        )));
     }
+    let mut out = rustpython_wtf8::Wtf8Buf::new();
+    out.push_str(&format!("array('{tc}', "));
     if matches!(tc, 'u' | 'w') {
         let s = array_tounicode_method(&[obj])?;
-        let inner_s = unsafe { crate::display::py_repr(s)? };
-        return Ok(format!("array('{tc}', {inner_s})"));
+        out.push_wtf8(&unsafe { crate::display::py_repr_wtf8(s)? });
+        out.push_str(")");
+        return Ok(out);
     }
-    let mut parts = Vec::with_capacity(len);
+    out.push_str("[");
     for i in 0..len {
+        if i != 0 {
+            out.push_str(", ");
+        }
         let w_item = unsafe { arr::w_array_unpack_item(obj, i) };
-        parts.push(unsafe { crate::display::py_repr(w_item)? });
+        out.push_wtf8(&unsafe { crate::display::py_repr_wtf8(w_item)? });
     }
-    Ok(format!("array('{tc}', [{}])", parts.join(", ")))
+    out.push_str("])");
+    Ok(out)
 }
 
 fn array_repr_method(args: &[PyObjectRef]) -> PyResult {
     check_arity(args, 1, "array.__repr__")?;
-    Ok(pyre_object::w_str_new(&array_repr_string(args[0])?))
+    Ok(pyre_object::w_str_from_wtf8(array_repr_wtf8(args[0])?))
 }
 
 // `interp_array.py compare_arrays`: compare each element with the requested

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -3176,7 +3176,10 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                         argv_ptrs.as_ptr(),
                         Some(env_ptrs.as_ptr()),
                     ) as i32;
-                    Err(errno_err_with_filename(errno, args[0]))
+                    // `interp_posix.py:1812,1817` wraps the failure with
+                    // `wrap_oserror`, which names no file, so the path stays
+                    // out of the error the same way `execv` leaves it out.
+                    Err(errno_err(errno, ""))
                 },
                 3,
             ),

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -477,6 +477,16 @@ mod win_nt {
         crate::PyError::os_error_syscall(errno, filename)
     }
 
+    fn io_err_with_filename(
+        error: &std::io::Error,
+        filename: PyObjectRef,
+    ) -> crate::PyError {
+        crate::PyError::os_error_syscall(
+            crate::builtins::io_error_posix_errno(error, 0),
+            filename,
+        )
+    }
+
     /// Read argument 0 as a filesystem path; the flag reports whether the
     /// input was bytes so the result can be encoded back to match.
     fn arg_path(args: &[PyObjectRef], func: &str) -> Result<(String, bool), crate::PyError> {
@@ -486,7 +496,10 @@ mod win_nt {
             )));
         };
         let as_bytes = unsafe { pyre_object::bytesobject::is_bytes_like(arg) };
-        let path = crate::gateway::fsencode_w(arg)?;
+        let bytes = crate::gateway::fsencode_bytes_w(arg)?;
+        // Windows names files in UTF-16, so there is no byte spelling to keep
+        // here the way there is on a unix path; the host API takes text.
+        let path = String::from_utf8_lossy(&bytes).into_owned();
         Ok((path, as_bytes))
     }
 
@@ -505,7 +518,7 @@ mod win_nt {
         let (path, as_bytes) = arg_path(args, "_getfullpathname")?;
         match host_nt::getfullpathname(Path::new(&path)) {
             Ok(result) => Ok(wrap_path(&result, as_bytes)),
-            Err(error) => Err(io_err(&error, &path)),
+            Err(error) => Err(io_err_with_filename(&error, args[0])),
         }
     }
 
@@ -518,7 +531,7 @@ mod win_nt {
         }
         match host_nt::getfinalpathname(Path::new(&path)) {
             Ok(result) => Ok(wrap_path(&result, as_bytes)),
-            Err(error) => Err(io_err(&error, &path)),
+            Err(error) => Err(io_err_with_filename(&error, args[0])),
         }
     }
 
@@ -560,7 +573,7 @@ mod win_nt {
                 pyre_object::w_int_new(total as i64),
                 pyre_object::w_int_new(free as i64),
             ])),
-            Err(error) => Err(io_err(&error, &path)),
+            Err(error) => Err(io_err_with_filename(&error, args[0])),
         }
     }
 
@@ -604,7 +617,10 @@ mod win_nt {
         let wide: Vec<u16> = path.encode_utf16().chain(std::iter::once(0)).collect();
         let cookie = unsafe { AddDllDirectory(wide.as_ptr()) };
         if cookie.is_null() {
-            return Err(io_err(&std::io::Error::last_os_error(), &path));
+            return Err(io_err_with_filename(
+                &std::io::Error::last_os_error(),
+                args[0],
+            ));
         }
         Ok(pyre_object::w_int_new(cookie as usize as i64))
     }
@@ -732,7 +748,8 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         /// The environment block is a list of NUL-terminated `NAME=VALUE`
         /// strings, so neither half may embed a NUL.
         fn env_str(arg: PyObjectRef) -> Result<String, crate::PyError> {
-            let text = crate::gateway::fsencode_w(arg)?;
+            let bytes = crate::gateway::fsencode_bytes_w(arg)?;
+            let text = String::from_utf8_lossy(&bytes).into_owned();
             if text.contains('\0') {
                 return Err(crate::PyError::value_error("embedded null byte"));
             }
@@ -1166,10 +1183,25 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         crate::make_builtin_function("set_blocking", set_blocking),
     );
 
-    // PyPy `space.fsencode_w` — promoted to `crate::gateway::fsencode_w`
-    // so the `#[pyre_function]` / `#[pyre_methods]` `PyPath` alias and
-    // these posix call sites share one extraction path.
-    use crate::gateway::fsencode_w as extract_path;
+    // `baseobjspace.py:1970 fsencode_w` returns filesystem bytes; syscall
+    // boundaries must not pass through a Rust `String`.
+    use crate::gateway::fsencode_bytes_w as extract_path;
+
+    fn path_from_bytes(path: &[u8]) -> std::borrow::Cow<'_, std::path::Path> {
+        #[cfg(unix)]
+        {
+            use std::os::unix::ffi::OsStrExt;
+            std::borrow::Cow::Borrowed(std::path::Path::new(std::ffi::OsStr::from_bytes(path)))
+        }
+        #[cfg(not(unix))]
+        {
+            // This platform has no byte spelling for paths, so the host API
+            // necessarily receives its best text representation.
+            std::borrow::Cow::Owned(std::path::PathBuf::from(
+                String::from_utf8_lossy(path).into_owned(),
+            ))
+        }
+    }
 
     // ── Helper: convert std::io::Error → PyError (OSError) ──
     fn errno_err(errno: i32, path: &str) -> crate::PyError {
@@ -1181,8 +1213,18 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         crate::PyError::os_error_syscall(errno, w_filename)
     }
 
+    // `interp_posix.py:332 wrap_oserror2(space, e, w_path)` keeps the exact
+    // object supplied by the caller as `OSError.filename`.
+    fn errno_err_with_filename(errno: i32, w_path: PyObjectRef) -> crate::PyError {
+        crate::PyError::os_error_syscall(errno, w_path)
+    }
+
     fn io_err(e: std::io::Error, path: &str) -> crate::PyError {
         errno_err(crate::builtins::io_error_posix_errno(&e, 0), path)
+    }
+
+    fn io_err_with_filename(e: std::io::Error, w_path: PyObjectRef) -> crate::PyError {
+        errno_err_with_filename(crate::builtins::io_error_posix_errno(&e, 0), w_path)
     }
 
     /// A filesystem name reported back to the caller: `bytes` when the path
@@ -1268,20 +1310,23 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 let flags = flags | libc::O_CLOEXEC;
                 #[cfg(windows)]
                 let flags = flags | libc::O_NOINHERIT;
-                let c_path = std::ffi::CString::new(path.as_bytes())
+                let c_path = std::ffi::CString::new(path.as_slice())
                     .map_err(|_| crate::PyError::value_error("embedded null in path"))?;
                 // Opening a FIFO without O_NONBLOCK waits for a peer.
                 let (fd, errno) = crate::module::thread::call_external_function(|| unsafe {
                     libc::open(c_path.as_ptr(), flags, mode as libc::c_uint)
                 });
                 if fd < 0 {
-                    return Err(io_err(std::io::Error::from_raw_os_error(errno), &path));
+                    return Err(io_err_with_filename(
+                        std::io::Error::from_raw_os_error(errno),
+                        args[0],
+                    ));
                 }
                 fd
             };
             #[cfg(feature = "sandbox")]
-            let fd = crate::host_seam::ops::open(path.as_bytes(), flags, mode)
-                .map_err(|e| crate::host_seam::seam_os_err(e, &path))?;
+            let fd = crate::host_seam::ops::open(&path, flags, mode)
+                .map_err(|e| crate::host_seam::seam_os_err_with_filename(e, args[0]))?;
             Ok(pyre_object::w_int_new(fd as i64))
         }),
     );
@@ -1494,16 +1539,19 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         let path = extract_path(args[0])?;
         #[cfg(not(feature = "sandbox"))]
         {
-            let c_path = std::ffi::CString::new(path.as_bytes())
+            let c_path = std::ffi::CString::new(path.as_slice())
                 .map_err(|_| crate::PyError::value_error("embedded null in path"))?;
             let ret = unsafe { libc::unlink(c_path.as_ptr()) };
             if ret < 0 {
-                return Err(io_err(std::io::Error::last_os_error(), &path));
+                return Err(io_err_with_filename(
+                    std::io::Error::last_os_error(),
+                    args[0],
+                ));
             }
         }
         #[cfg(feature = "sandbox")]
-        crate::host_seam::ops::unlink(path.as_bytes())
-            .map_err(|e| crate::host_seam::seam_os_err(e, &path))?;
+        crate::host_seam::ops::unlink(&path)
+            .map_err(|e| crate::host_seam::seam_os_err_with_filename(e, args[0]))?;
         Ok(pyre_object::w_none())
     }
     crate::module_ns_store(
@@ -1532,10 +1580,13 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 .first()
                 .copied()
                 .ok_or_else(|| crate::PyError::type_error("readlink() requires 1 argument"))?;
-            let path = extract_path(arg)?;
-            match std::fs::read_link(&path) {
-                Ok(target) => Ok(pyre_object::w_str_new(&target.to_string_lossy())),
-                Err(e) => Err(io_err(e, &path)),
+            let (path, bytes_mode) = crate::gateway::fsencode_bytes_w_with_kind(arg)?;
+            match std::fs::read_link(path_from_bytes(&path).as_ref()) {
+                Ok(target) => {
+                    let target = target.as_os_str().as_encoded_bytes();
+                    Ok(fs_name_obj(bytes_mode, target))
+                }
+                Err(e) => Err(io_err_with_filename(e, arg)),
             }
         }),
     );
@@ -1556,19 +1607,22 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             };
             #[cfg(not(feature = "sandbox"))]
             {
-                let c_path = std::ffi::CString::new(path.as_bytes())
+                let c_path = std::ffi::CString::new(path.as_slice())
                     .map_err(|_| crate::PyError::value_error("embedded null in path"))?;
                 #[cfg(unix)]
                 let ret = unsafe { libc::mkdir(c_path.as_ptr(), _mode as libc::mode_t) };
                 #[cfg(windows)]
                 let ret = unsafe { libc::mkdir(c_path.as_ptr()) };
                 if ret < 0 {
-                    return Err(io_err(std::io::Error::last_os_error(), &path));
+                    return Err(io_err_with_filename(
+                        std::io::Error::last_os_error(),
+                        args[0],
+                    ));
                 }
             }
             #[cfg(feature = "sandbox")]
-            crate::host_seam::ops::mkdir(path.as_bytes(), _mode)
-                .map_err(|e| crate::host_seam::seam_os_err(e, &path))?;
+            crate::host_seam::ops::mkdir(&path, _mode)
+                .map_err(|e| crate::host_seam::seam_os_err_with_filename(e, args[0]))?;
             Ok(pyre_object::w_none())
         }),
     );
@@ -1587,11 +1641,14 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     return Err(crate::PyError::type_error("rmdir() requires 1 argument"));
                 }
                 let path = extract_path(args[0])?;
-                let c_path = std::ffi::CString::new(path.as_bytes())
+                let c_path = std::ffi::CString::new(path.as_slice())
                     .map_err(|_| crate::PyError::value_error("embedded null in path"))?;
                 let ret = unsafe { libc::rmdir(c_path.as_ptr()) };
                 if ret < 0 {
-                    return Err(io_err(std::io::Error::last_os_error(), &path));
+                    return Err(io_err_with_filename(
+                        std::io::Error::last_os_error(),
+                        args[0],
+                    ));
                 }
                 Ok(pyre_object::w_none())
             },
@@ -1659,23 +1716,18 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             }
             (None, None)
         };
+        let src_path = path_from_bytes(&src);
+        let dst_path = path_from_bytes(&dst);
         let result = if name == "replace" {
-            host_os::replace(&src, src_b, &dst, dst_b)
+            host_os::replace(src_path.as_ref(), src_b, dst_path.as_ref(), dst_b)
         } else {
-            host_os::rename(&src, src_b, &dst, dst_b)
+            host_os::rename(src_path.as_ref(), src_b, dst_path.as_ref(), dst_b)
         };
         result.map_err(|e| {
             let errno = crate::builtins::io_error_posix_errno(&e, 0);
-            // The source string must survive the destination's allocation.
-            let _roots = pyre_object::gc_roots::push_roots();
-            let src_slot = pyre_object::gc_roots::shadow_stack_len();
-            pyre_object::gc_roots::pin_root(pyre_object::w_str_new(&src));
-            let w_dst = pyre_object::w_str_new(&dst);
-            crate::PyError::os_error_syscall2(
-                errno,
-                pyre_object::gc_roots::shadow_stack_get(src_slot),
-                w_dst,
-            )
+            // interp_posix.py:654 hands both original objects to
+            // `wrap_oserror2`, preserving bytes and path-like arguments.
+            crate::PyError::os_error_syscall2(errno, pos[0], pos[1])
         })?;
         Ok(pyre_object::w_none())
     }
@@ -1785,13 +1837,13 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     "utime: dir_fd and follow_symlinks=False are unavailable on this platform",
                 ));
             }
-            host_os::set_file_times(std::path::Path::new(&path), access, modified)
-                .map_err(|e| io_err(e, &path))?;
+            host_os::set_file_times(path_from_bytes(&path).as_ref(), access, modified)
+                .map_err(|e| io_err_with_filename(e, pos[0]))?;
             return Ok(pyre_object::w_none());
         }
         #[cfg(all(unix, not(feature = "sandbox")))]
         {
-            let c_path = std::ffi::CString::new(path.as_bytes())
+            let c_path = std::ffi::CString::new(path.as_slice())
                 .map_err(|_| crate::PyError::value_error("embedded null character"))?;
             rustpython_host_env::posix::set_file_times_at(
                 dir_fd.unwrap_or(libc::AT_FDCWD),
@@ -1800,12 +1852,12 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 modified,
                 follow_symlinks,
             )
-            .map_err(|e| io_err(e, &path))?;
+            .map_err(|e| io_err_with_filename(e, pos[0]))?;
             return Ok(pyre_object::w_none());
         }
         #[allow(unreachable_code)]
         {
-            let _ = (access, modified, dir_fd, follow_symlinks, &path);
+            let _ = (access, modified, dir_fd, follow_symlinks, &path, pos);
             Err(crate::PyError::not_implemented(
                 "utime is unavailable on this platform",
             ))
@@ -1833,6 +1885,10 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     ));
                 };
                 let path = extract_path(arg)?;
+                // Splitting a drive or UNC prefix is a text operation on a
+                // Windows path, and both halves are handed back as `str`, so
+                // this one stays in the text domain rather than the byte one.
+                let path = String::from_utf8_lossy(&path);
                 let (root, tail) = split_root(&path);
                 Ok(pyre_object::w_tuple_new(vec![
                     pyre_object::w_str_new(root),
@@ -1884,16 +1940,19 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         "listdir",
         crate::make_builtin_function("listdir", |args| {
             // One resolution yields both the path and its bytes-ness, so
-            // `__fspath__` runs exactly once (`fsencode_w_with_kind`).
+            // `__fspath__` runs exactly once.
             let (path, bytes_mode) = if args.is_empty() || unsafe { pyre_object::is_none(args[0]) } {
-                (".".to_string(), false)
+                (b".".to_vec(), false)
             } else {
-                crate::gateway::fsencode_w_with_kind(args[0])?
+                crate::gateway::fsencode_bytes_w_with_kind(args[0])?
             };
+            // The omitted argument defaults to `"."` but reports no filename,
+            // since there was no path object for the failure to name.
+            let w_path = args.first().copied().unwrap_or(pyre_object::PY_NULL);
             #[cfg(feature = "sandbox")]
             {
-                let names = crate::host_seam::ops::listdir(path.as_bytes())
-                    .map_err(|e| crate::host_seam::seam_os_err(e, &path))?;
+                let names = crate::host_seam::ops::listdir(&path)
+                    .map_err(|e| crate::host_seam::seam_os_err_with_filename(e, w_path))?;
                 let items = names
                     .into_iter()
                     .map(|n| fs_name_obj(bytes_mode, &n))
@@ -1902,10 +1961,11 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             }
             #[cfg(not(feature = "sandbox"))]
             {
-                let entries = host_fs::read_dir(&path).map_err(|e| io_err(e, &path))?;
+                let entries = host_fs::read_dir(path_from_bytes(&path).as_ref())
+                    .map_err(|e| io_err_with_filename(e, w_path))?;
                 let mut items = Vec::new();
                 for entry in entries {
-                    let entry = entry.map_err(|e| io_err(e, &path))?;
+                    let entry = entry.map_err(|e| io_err_with_filename(e, w_path))?;
                     let name = entry.file_name();
                     items.push(fs_name_obj(bytes_mode, name.as_encoded_bytes()));
                 }
@@ -2063,7 +2123,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     // Under sandbox the stat path is mediated (st_flags arrives over the wire),
     // so this raw-libc helper is compiled out.
     #[cfg(all(target_os = "macos", not(feature = "sandbox")))]
-    fn macos_path_st_flags(path: &str, follow: bool) -> u32 {
+    fn macos_path_st_flags(path: &[u8], follow: bool) -> u32 {
         let Ok(c) = std::ffi::CString::new(path) else {
             return 0;
         };
@@ -2357,37 +2417,37 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             return Err(crate::PyError::type_error("stat() missing argument"));
         }
         let path_obj = args[0];
-        let path_str = crate::gateway::fsencode_w(path_obj).map_err(|_| {
+        let path = crate::gateway::fsencode_bytes_w(path_obj).map_err(|_| {
             crate::PyError::type_error("stat: path should be string, bytes, os.PathLike")
         })?;
         #[cfg(feature = "sandbox")]
         {
             let buf = if follow_symlinks {
-                crate::host_seam::ops::stat(path_str.as_bytes())
+                crate::host_seam::ops::stat(&path)
             } else {
-                crate::host_seam::ops::lstat(path_str.as_bytes())
+                crate::host_seam::ops::lstat(&path)
             }
-            .map_err(|e| crate::host_seam::seam_os_err(e, &path_str))?;
+            .map_err(|e| crate::host_seam::seam_os_err_with_filename(e, path_obj))?;
             return Ok(make_stat_result_from_statbuf(&buf));
         }
         #[cfg(not(feature = "sandbox"))]
         {
             let meta = if follow_symlinks {
-                host_fs::metadata(&path_str)
+                host_fs::metadata(path_from_bytes(&path).as_ref())
             } else {
-                host_fs::symlink_metadata(&path_str)
+                host_fs::symlink_metadata(path_from_bytes(&path).as_ref())
             };
             match meta {
                 Ok(m) => {
                     #[cfg(target_os = "macos")]
-                    let st_flags = macos_path_st_flags(&path_str, follow_symlinks);
+                    let st_flags = macos_path_st_flags(&path, follow_symlinks);
                     #[cfg(not(target_os = "macos"))]
                     let st_flags = 0u32;
                     Ok(make_stat_result(&m, st_flags))
                 }
-                Err(e) => Err(errno_err(
+                Err(e) => Err(errno_err_with_filename(
                     crate::builtins::io_error_posix_errno(&e, 2),
-                    &path_str,
+                    path_obj,
                 )),
             }
         }
@@ -2403,9 +2463,10 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     // the stored path on demand.
     type PyObjectRef = pyre_object::PyObjectRef;
 
-    fn dir_entry_path(self_obj: PyObjectRef) -> Result<String, crate::PyError> {
+    fn dir_entry_path(self_obj: PyObjectRef) -> Result<(PyObjectRef, Vec<u8>), crate::PyError> {
         let p = crate::baseobjspace::getattr_str(self_obj, "path")?;
-        Ok(unsafe { pyre_object::w_str_get_value(p) }.to_string())
+        let path = extract_path(p)?;
+        Ok((p, path))
     }
     fn dir_entry_follow(args: &[PyObjectRef]) -> Result<bool, crate::PyError> {
         let (_pos, kwargs) = crate::builtins::split_builtin_kwargs(args);
@@ -2415,33 +2476,33 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         }
     }
     fn dir_entry_is_dir(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-        let path = dir_entry_path(args[0])?;
+        let (_, path) = dir_entry_path(args[0])?;
         let follow = dir_entry_follow(args)?;
         let meta = if follow {
-            host_fs::metadata(&path)
+            host_fs::metadata(path_from_bytes(&path).as_ref())
         } else {
-            host_fs::symlink_metadata(&path)
+            host_fs::symlink_metadata(path_from_bytes(&path).as_ref())
         };
         Ok(pyre_object::w_bool_from(
             meta.map(|m| m.is_dir()).unwrap_or(false),
         ))
     }
     fn dir_entry_is_file(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-        let path = dir_entry_path(args[0])?;
+        let (_, path) = dir_entry_path(args[0])?;
         let follow = dir_entry_follow(args)?;
         let meta = if follow {
-            host_fs::metadata(&path)
+            host_fs::metadata(path_from_bytes(&path).as_ref())
         } else {
-            host_fs::symlink_metadata(&path)
+            host_fs::symlink_metadata(path_from_bytes(&path).as_ref())
         };
         Ok(pyre_object::w_bool_from(
             meta.map(|m| m.is_file()).unwrap_or(false),
         ))
     }
     fn dir_entry_is_symlink(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-        let path = dir_entry_path(args[0])?;
+        let (_, path) = dir_entry_path(args[0])?;
         Ok(pyre_object::w_bool_from(
-            host_fs::symlink_metadata(&path)
+            host_fs::symlink_metadata(path_from_bytes(&path).as_ref())
                 .map(|m| m.file_type().is_symlink())
                 .unwrap_or(false),
         ))
@@ -2451,8 +2512,9 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         Ok(pyre_object::w_bool_from(false))
     }
     fn dir_entry_inode(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-        let path = dir_entry_path(args[0])?;
-        let meta = host_fs::symlink_metadata(&path).map_err(|e| io_err(e, &path))?;
+        let (w_path, path) = dir_entry_path(args[0])?;
+        let meta = host_fs::symlink_metadata(path_from_bytes(&path).as_ref())
+            .map_err(|e| io_err_with_filename(e, w_path))?;
         #[cfg(unix)]
         let ino = {
             use std::os::unix::fs::MetadataExt;
@@ -2466,12 +2528,12 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         Ok(pyre_object::w_int_new(ino))
     }
     fn dir_entry_stat(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-        let path = dir_entry_path(args[0])?;
+        let (w_path, path) = dir_entry_path(args[0])?;
         let follow = dir_entry_follow(args)?;
         let meta = if follow {
-            host_fs::metadata(&path)
+            host_fs::metadata(path_from_bytes(&path).as_ref())
         } else {
-            host_fs::symlink_metadata(&path)
+            host_fs::symlink_metadata(path_from_bytes(&path).as_ref())
         };
         match meta {
             Ok(m) => {
@@ -2481,7 +2543,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 let st_flags = 0u32;
                 Ok(make_stat_result(&m, st_flags))
             }
-            Err(e) => Err(io_err(e, &path)),
+            Err(e) => Err(io_err_with_filename(e, w_path)),
         }
     }
     fn dir_entry_fspath(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
@@ -2585,16 +2647,20 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
 
     fn scandir_fn(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         // One resolution yields both the path and its bytes-ness, so
-        // `__fspath__` runs exactly once (`fsencode_w_with_kind`).
+        // `__fspath__` runs exactly once.
         let (path, bytes_mode) = if args.is_empty() || unsafe { pyre_object::is_none(args[0]) } {
-            (".".to_string(), false)
+            (b".".to_vec(), false)
         } else {
-            crate::gateway::fsencode_w_with_kind(args[0])?
+            crate::gateway::fsencode_bytes_w_with_kind(args[0])?
         };
-        let entries = host_fs::read_dir(&path).map_err(|e| io_err(e, &path))?;
+        // The omitted argument defaults to `"."` but reports no filename,
+        // since there was no path object for the failure to name.
+        let w_path = args.first().copied().unwrap_or(pyre_object::PY_NULL);
+        let entries = host_fs::read_dir(path_from_bytes(&path).as_ref())
+            .map_err(|e| io_err_with_filename(e, w_path))?;
         let list = pyre_object::w_list_new(Vec::new());
         for entry in entries {
-            let entry = entry.map_err(|e| io_err(e, &path))?;
+            let entry = entry.map_err(|e| io_err_with_filename(e, w_path))?;
             let name = entry.file_name();
             let full = entry.path().into_os_string();
             let de = pyre_object::w_instance_new(dir_entry_type());
@@ -2980,7 +3046,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             let mut argv = Vec::with_capacity(items.len());
             for item in items {
                 let value = extract_path(item)?;
-                argv.push(std::ffi::CString::new(value.as_bytes()).map_err(|_| {
+                argv.push(std::ffi::CString::new(value).map_err(|_| {
                     crate::PyError::value_error(format!(
                         "{function}() arg 2 contains an embedded null byte"
                     ))
@@ -3009,14 +3075,14 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 "execv",
                 |args| {
                     let command = extract_path(args[0])?;
-                    let command_c = std::ffi::CString::new(command.as_bytes()).map_err(|_| {
+                    let command_c = std::ffi::CString::new(command).map_err(|_| {
                         crate::PyError::value_error("execv() path contains an embedded null byte")
                     })?;
                     let argv = exec_argv(args[1], "execv")?;
                     let argv_ptrs = exec_pointer_array(&argv);
                     let errno =
                         host_posix::exec_replace(&[command_c], argv_ptrs.as_ptr(), None) as i32;
-                    Err(errno_err(errno, &command))
+                    Err(errno_err_with_filename(errno, args[0]))
                 },
                 2,
             ),
@@ -3031,7 +3097,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 "execve",
                 |args| {
                     let command = extract_path(args[0])?;
-                    let command_c = std::ffi::CString::new(command.as_bytes()).map_err(|_| {
+                    let command_c = std::ffi::CString::new(command).map_err(|_| {
                         crate::PyError::value_error("execve() path contains an embedded null byte")
                     })?;
                     let argv = exec_argv(args[1], "execve")?;
@@ -3050,22 +3116,20 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                         let key = extract_path(key_obj)?;
                         let value = extract_path(value_obj)?;
                         if key.is_empty()
-                            || key
-                                .as_bytes()
-                                .get(1..)
-                                .is_some_and(|tail| tail.contains(&b'='))
+                            || key.get(1..).is_some_and(|tail| tail.contains(&b'='))
                         {
                             return Err(crate::PyError::value_error(
                                 "illegal environment variable name",
                             ));
                         }
-                        env.push(std::ffi::CString::new(format!("{key}={value}")).map_err(
-                            |_| {
-                                crate::PyError::value_error(
-                                    "execve() environment contains an embedded null byte",
-                                )
-                            },
-                        )?);
+                        let mut entry = key;
+                        entry.push(b'=');
+                        entry.extend_from_slice(&value);
+                        env.push(std::ffi::CString::new(entry).map_err(|_| {
+                            crate::PyError::value_error(
+                                "execve() environment contains an embedded null byte",
+                            )
+                        })?);
                     }
                     let env_ptrs = exec_pointer_array(&env);
                     let errno = host_posix::exec_replace(
@@ -3073,7 +3137,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                         argv_ptrs.as_ptr(),
                         Some(env_ptrs.as_ptr()),
                     ) as i32;
-                    Err(errno_err(errno, &command))
+                    Err(errno_err_with_filename(errno, args[0]))
                 },
                 3,
             ),
@@ -3286,9 +3350,10 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                         return Err(crate::PyError::type_error("chdir() requires 1 argument"));
                     }
                     let path = extract_path(args[0])?;
-                    let c_path = std::ffi::CString::new(path.as_bytes())
+                    let c_path = std::ffi::CString::new(path.as_slice())
                         .map_err(|_| crate::PyError::value_error("embedded null in path"))?;
-                    host_posix::chdir(&c_path).map_err(|e| errno_err(e as i32, &path))?;
+                    host_posix::chdir(&c_path)
+                        .map_err(|e| errno_err_with_filename(e as i32, args[0]))?;
                     Ok(pyre_object::w_none())
                 },
                 1,
@@ -3724,11 +3789,14 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 } else {
                     0o666
                 };
-                let c_path = std::ffi::CString::new(path.as_bytes())
+                let c_path = std::ffi::CString::new(path.as_slice())
                     .map_err(|_| crate::PyError::value_error("embedded null in path"))?;
                 let r = unsafe { libc::mkfifo(c_path.as_ptr(), mode) };
                 if r < 0 {
-                    return Err(io_err(std::io::Error::last_os_error(), &path));
+                    return Err(io_err_with_filename(
+                        std::io::Error::last_os_error(),
+                        args[0],
+                    ));
                 }
                 Ok(pyre_object::w_none())
             }),
@@ -3818,9 +3886,10 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                         return Err(crate::PyError::type_error("statvfs() requires 1 argument"));
                     }
                     let path = extract_path(args[0])?;
-                    let c_path = std::ffi::CString::new(path.as_bytes())
+                    let c_path = std::ffi::CString::new(path.as_slice())
                         .map_err(|_| crate::PyError::value_error("embedded null in path"))?;
-                    let info = host_posix::statvfs_path(&c_path).map_err(|e| io_err(e, &path))?;
+                    let info = host_posix::statvfs_path(&c_path)
+                        .map_err(|e| io_err_with_filename(e, args[0]))?;
                     Ok(statvfs_to_obj(info))
                 },
                 1,
@@ -3891,15 +3960,18 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 }
                 let src = extract_path(args[0])?;
                 let dst = extract_path(args[1])?;
-                let c_src = std::ffi::CString::new(src.as_bytes())
+                let c_src = std::ffi::CString::new(src)
                     .map_err(|_| crate::PyError::value_error("embedded null in src"))?;
-                let c_dst = std::ffi::CString::new(dst.as_bytes())
+                let c_dst = std::ffi::CString::new(dst)
                     .map_err(|_| crate::PyError::value_error("embedded null in dst"))?;
                 // host_env::posix only exposes symlinkat on non-redox unices;
                 // call libc::symlink directly so we don't need an at-cwd dance.
                 let ret = unsafe { libc::symlink(c_src.as_ptr(), c_dst.as_ptr()) };
                 if ret < 0 {
-                    return Err(io_err(std::io::Error::last_os_error(), &dst));
+                    return Err(io_err_with_filename(
+                        std::io::Error::last_os_error(),
+                        args[1],
+                    ));
                 }
                 Ok(pyre_object::w_none())
             }),
@@ -3920,11 +3992,14 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     // `posix.chmod` unwraps `mode` as `c_int`, so a non-integer
                     // raises TypeError instead of reinterpreting its layout.
                     let mode = crate::baseobjspace::c_int_w(args[1])? as u32;
-                    let c_path = std::ffi::CString::new(path.as_bytes())
+                    let c_path = std::ffi::CString::new(path.as_slice())
                         .map_err(|_| crate::PyError::value_error("embedded null in path"))?;
                     let ret = unsafe { libc::chmod(c_path.as_ptr(), mode as libc::mode_t) };
                     if ret < 0 {
-                        return Err(io_err(std::io::Error::last_os_error(), &path));
+                        return Err(io_err_with_filename(
+                            std::io::Error::last_os_error(),
+                            args[0],
+                        ));
                     }
                     Ok(pyre_object::w_none())
                 },
@@ -4055,12 +4130,12 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             let cwd = unsafe { BorrowedFd::borrow_raw(libc::AT_FDCWD) };
             host_posix::fchownat(
                 cwd,
-                std::ffi::OsStr::new(path.as_str()),
+                path_from_bytes(&path).as_os_str(),
                 uid,
                 gid,
                 follow_symlinks,
             )
-            .map_err(|e| io_err(e, &path))?;
+            .map_err(|e| io_err_with_filename(e, path_obj))?;
             Ok(pyre_object::w_none())
         }
         crate::module_ns_store(
@@ -4144,7 +4219,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 #[cfg(feature = "sandbox")]
                 {
                     return Ok(pyre_object::w_bool_from(
-                        crate::host_seam::ops::access(path.as_bytes(), mode).unwrap_or(false),
+                        crate::host_seam::ops::access(&path, mode).unwrap_or(false),
                     ));
                 }
                 #[cfg(not(feature = "sandbox"))]
@@ -4156,7 +4231,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     let Ok(mode) = u8::try_from(mode) else {
                         return Ok(pyre_object::w_bool_from(false));
                     };
-                    match host_posix::check_access(std::path::Path::new(&path), mode) {
+                    match host_posix::check_access(path_from_bytes(&path).as_ref(), mode) {
                         Ok(ok) => Ok(pyre_object::w_bool_from(ok)),
                         Err(_) => Ok(pyre_object::w_bool_from(false)),
                     }
@@ -4175,8 +4250,8 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                         return Err(crate::PyError::type_error("chroot() requires 1 argument"));
                     }
                     let path = extract_path(args[0])?;
-                    host_posix::chroot(std::path::Path::new(&path))
-                        .map_err(|e| io_err(e, &path))?;
+                    host_posix::chroot(path_from_bytes(&path).as_ref())
+                        .map_err(|e| io_err_with_filename(e, args[0]))?;
                     Ok(pyre_object::w_none())
                 },
                 1,
@@ -4412,8 +4487,8 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                         "posix_spawn() requires path, argv, env",
                     ));
                 }
-                let path_str = extract_path(positional[0])?;
-                let c_path = std::ffi::CString::new(path_str.as_bytes()).map_err(|_| {
+                let path = extract_path(positional[0])?;
+                let c_path = std::ffi::CString::new(path).map_err(|_| {
                     crate::PyError::value_error("posix_spawn: embedded null in path")
                 })?;
                 let argv = collect_cstring_seq(positional[1], "posix_spawn", "argv")?;
@@ -4445,7 +4520,8 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     setsigmask: None,
                     spawnp,
                 };
-                let pid = host_posix::posix_spawn(config).map_err(|e| io_err(e, ""))?;
+                let pid = host_posix::posix_spawn(config)
+                    .map_err(|e| io_err_with_filename(e, positional[0]))?;
                 Ok(pyre_object::w_int_new(pid as i64))
             }
             fn collect_spawn_env(
@@ -4618,9 +4694,9 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                             let fd = field(entry, 1)?;
                             let path_obj =
                                 unsafe { pyre_object::w_tuple_getitem(entry, 2).unwrap() };
-                            let path_str = extract_path(path_obj)?;
+                            let path = extract_path(path_obj)?;
                             let cpath =
-                                std::ffi::CString::new(path_str.as_bytes()).map_err(|_| {
+                                std::ffi::CString::new(path).map_err(|_| {
                                     crate::PyError::value_error(
                                         "posix_spawn: embedded null in OPEN path",
                                     )
@@ -4920,11 +4996,13 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                         return Err(crate::PyError::type_error("pathconf() requires path, name"));
                     }
                     let path = extract_path(args[0])?;
-                    let cpath = std::ffi::CString::new(path.as_bytes()).map_err(|_| {
+                    let cpath = std::ffi::CString::new(path).map_err(|_| {
                         crate::PyError::value_error("pathconf: embedded null in path")
                     })?;
                     let name = confname_arg(args[1])?;
-                    match host_posix::pathconf(&cpath, name).map_err(|e| io_err(e, ""))? {
+                    match host_posix::pathconf(&cpath, name)
+                        .map_err(|e| io_err_with_filename(e, args[0]))?
+                    {
                         Some(v) => Ok(pyre_object::w_int_new(v as i64)),
                         None => Ok(pyre_object::w_none()),
                     }

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -489,18 +489,21 @@ mod win_nt {
 
     /// Read argument 0 as a filesystem path; the flag reports whether the
     /// input was bytes so the result can be encoded back to match.
-    fn arg_path(args: &[PyObjectRef], func: &str) -> Result<(String, bool), crate::PyError> {
+    fn arg_path(
+        args: &[PyObjectRef],
+        func: &str,
+    ) -> Result<(String, bool, crate::gateway::FsEncodedPath), crate::PyError> {
         let Some(&arg) = args.first() else {
             return Err(crate::PyError::type_error(format!(
                 "{func}() missing required argument 'path'"
             )));
         };
-        let as_bytes = unsafe { pyre_object::bytesobject::is_bytes_like(arg) };
-        let bytes = crate::gateway::fsencode_bytes_w(arg)?;
+        let resolved = crate::gateway::fsencode_path_w(arg)?;
+        let as_bytes = unsafe { resolved.is_bytes() };
         // Windows names files in UTF-16, so there is no byte spelling to keep
         // here the way there is on a unix path; the host API takes text.
-        let path = String::from_utf8_lossy(&bytes).into_owned();
-        Ok((path, as_bytes))
+        let path = String::from_utf8_lossy(&resolved.as_bytes).into_owned();
+        Ok((path, as_bytes, resolved))
     }
 
     fn wrap_path(s: &std::ffi::OsStr, as_bytes: bool) -> PyObjectRef {
@@ -515,23 +518,23 @@ mod win_nt {
     /// ntpath.abspath helper — resolves `.`/`..` and the drive without
     /// requiring the path to exist.
     pub fn _getfullpathname(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-        let (path, as_bytes) = arg_path(args, "_getfullpathname")?;
+        let (path, as_bytes, resolved) = arg_path(args, "_getfullpathname")?;
         match host_nt::getfullpathname(Path::new(&path)) {
             Ok(result) => Ok(wrap_path(&result, as_bytes)),
-            Err(error) => Err(io_err_with_filename(&error, args[0])),
+            Err(error) => Err(io_err_with_filename(&error, resolved.w_path())),
         }
     }
 
     /// ntpath.realpath helper — the canonical `\\?\`-prefixed path, via a
     /// backup-semantics handle so directories open too.
     pub fn _getfinalpathname(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-        let (path, as_bytes) = arg_path(args, "_getfinalpathname")?;
+        let (path, as_bytes, resolved) = arg_path(args, "_getfinalpathname")?;
         if path.contains('\0') {
             return Err(crate::PyError::value_error("embedded null character"));
         }
         match host_nt::getfinalpathname(Path::new(&path)) {
             Ok(result) => Ok(wrap_path(&result, as_bytes)),
-            Err(error) => Err(io_err_with_filename(&error, args[0])),
+            Err(error) => Err(io_err_with_filename(&error, resolved.w_path())),
         }
     }
 
@@ -564,7 +567,7 @@ mod win_nt {
     /// retries against the parent directory when the path names a file
     /// (ERROR_DIRECTORY).
     pub fn _getdiskusage(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-        let (path, _) = arg_path(args, "_getdiskusage")?;
+        let (path, _, resolved) = arg_path(args, "_getdiskusage")?;
         if path.contains('\0') {
             return Err(crate::PyError::value_error("embedded null character"));
         }
@@ -573,7 +576,7 @@ mod win_nt {
                 pyre_object::w_int_new(total as i64),
                 pyre_object::w_int_new(free as i64),
             ])),
-            Err(error) => Err(io_err_with_filename(&error, args[0])),
+            Err(error) => Err(io_err_with_filename(&error, resolved.w_path())),
         }
     }
 
@@ -613,13 +616,13 @@ mod win_nt {
     /// no AddDllDirectory wrapper, so call windows-sys directly.
     pub fn _add_dll_directory(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         use windows_sys::Win32::System::LibraryLoader::AddDllDirectory;
-        let (path, _) = arg_path(args, "_add_dll_directory")?;
+        let (path, _, resolved) = arg_path(args, "_add_dll_directory")?;
         let wide: Vec<u16> = path.encode_utf16().chain(std::iter::once(0)).collect();
         let cookie = unsafe { AddDllDirectory(wide.as_ptr()) };
         if cookie.is_null() {
             return Err(io_err_with_filename(
                 &std::io::Error::last_os_error(),
-                args[0],
+                resolved.w_path(),
             ));
         }
         Ok(pyre_object::w_int_new(cookie as usize as i64))
@@ -747,18 +750,21 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     {
         /// The environment block is a list of NUL-terminated `NAME=VALUE`
         /// strings, so neither half may embed a NUL.
-        fn env_str(arg: PyObjectRef) -> Result<String, crate::PyError> {
+        ///
+        /// Bytes, like the path boundary: an entry the process was started with
+        /// can hold a byte with no UTF-8 spelling, and `posix.environ` already
+        /// hands those back as bytes, so writing one must not fold it first.
+        fn env_bytes(arg: PyObjectRef) -> Result<Vec<u8>, crate::PyError> {
             let bytes = crate::gateway::fsencode_bytes_w(arg)?;
-            let text = String::from_utf8_lossy(&bytes).into_owned();
-            if text.contains('\0') {
+            if bytes.contains(&0) {
                 return Err(crate::PyError::value_error("embedded null byte"));
             }
-            Ok(text)
+            Ok(bytes)
         }
         /// A name that is empty or contains `=` cannot be expressed in the
         /// environment block.
-        fn illegal_name(name: &str) -> bool {
-            name.is_empty() || name.contains('=')
+        fn illegal_name(name: &[u8]) -> bool {
+            name.is_empty() || name.contains(&b'=')
         }
         crate::module_ns_store(
             ns,
@@ -767,14 +773,16 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 "putenv",
                 |args| {
                     // interp_posix.py putenv_impl rejects the name itself...
-                    let name = env_str(args[0])?;
+                    let name = env_bytes(args[0])?;
                     if illegal_name(&name) {
                         return Err(crate::PyError::value_error(
                             "illegal environment variable name",
                         ));
                     }
-                    let value = env_str(args[1])?;
-                    unsafe { host_os::set_var(&name, &value) };
+                    let value = env_bytes(args[1])?;
+                    unsafe {
+                        host_os::set_var(os_str_from_bytes(&name), os_str_from_bytes(&value))
+                    };
                     Ok(pyre_object::w_none())
                 },
                 2,
@@ -786,7 +794,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             crate::make_builtin_function_with_arity(
                 "unsetenv",
                 |args| {
-                    let name = env_str(args[0])?;
+                    let name = env_bytes(args[0])?;
                     // ...while unsetenv leaves the same rejection to the
                     // syscall, which reports EINVAL.
                     if illegal_name(&name) {
@@ -795,7 +803,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                             pyre_object::PY_NULL,
                         ));
                     }
-                    unsafe { host_os::remove_var(&name) };
+                    unsafe { host_os::remove_var(os_str_from_bytes(&name)) };
                     Ok(pyre_object::w_none())
                 },
                 1,
@@ -1187,19 +1195,28 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     // boundaries must not pass through a Rust `String`.
     use crate::gateway::fsencode_bytes_w as extract_path;
 
-    fn path_from_bytes(path: &[u8]) -> std::borrow::Cow<'_, std::path::Path> {
+    /// The host-API view of OS bytes — a filename, or a half of an environment
+    /// entry. Unix spells both in bytes and takes them back unchanged.
+    fn os_str_from_bytes(bytes: &[u8]) -> std::borrow::Cow<'_, std::ffi::OsStr> {
         #[cfg(unix)]
         {
             use std::os::unix::ffi::OsStrExt;
-            std::borrow::Cow::Borrowed(std::path::Path::new(std::ffi::OsStr::from_bytes(path)))
+            std::borrow::Cow::Borrowed(std::ffi::OsStr::from_bytes(bytes))
         }
         #[cfg(not(unix))]
         {
-            // This platform has no byte spelling for paths, so the host API
-            // necessarily receives its best text representation.
-            std::borrow::Cow::Owned(std::path::PathBuf::from(
-                String::from_utf8_lossy(path).into_owned(),
+            // This platform has no byte spelling, so the host API necessarily
+            // receives the best text representation of these bytes.
+            std::borrow::Cow::Owned(std::ffi::OsString::from(
+                String::from_utf8_lossy(bytes).into_owned(),
             ))
+        }
+    }
+
+    fn path_from_bytes(path: &[u8]) -> std::borrow::Cow<'_, std::path::Path> {
+        match os_str_from_bytes(path) {
+            std::borrow::Cow::Borrowed(s) => std::borrow::Cow::Borrowed(std::path::Path::new(s)),
+            std::borrow::Cow::Owned(s) => std::borrow::Cow::Owned(std::path::PathBuf::from(s)),
         }
     }
 
@@ -1213,8 +1230,8 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         crate::PyError::os_error_syscall(errno, w_filename)
     }
 
-    // `interp_posix.py:332 wrap_oserror2(space, e, w_path)` keeps the exact
-    // object supplied by the caller as `OSError.filename`.
+    // `interp_posix.py:211-219,332` keeps the resolved `Path.w_path` as
+    // `OSError.filename`.
     fn errno_err_with_filename(errno: i32, w_path: PyObjectRef) -> crate::PyError {
         crate::PyError::os_error_syscall(errno, w_path)
     }
@@ -1292,7 +1309,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     "open() requires at least 2 arguments",
                 ));
             }
-            let path = extract_path(args[0])?;
+            let path = crate::gateway::fsencode_path_w(args[0])?;
             let flags = crate::baseobjspace::c_int_w(args[1])? as libc::c_int;
             let mode: u32 = if args.len() >= 3 {
                 crate::baseobjspace::c_int_w(args[2])? as u32
@@ -1310,7 +1327,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 let flags = flags | libc::O_CLOEXEC;
                 #[cfg(windows)]
                 let flags = flags | libc::O_NOINHERIT;
-                let c_path = std::ffi::CString::new(path.as_slice())
+                let c_path = std::ffi::CString::new(path.as_bytes.as_slice())
                     .map_err(|_| crate::PyError::value_error("embedded null in path"))?;
                 // Opening a FIFO without O_NONBLOCK waits for a peer.
                 let (fd, errno) = crate::module::thread::call_external_function(|| unsafe {
@@ -1319,14 +1336,14 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 if fd < 0 {
                     return Err(io_err_with_filename(
                         std::io::Error::from_raw_os_error(errno),
-                        args[0],
+                        path.w_path(),
                     ));
                 }
                 fd
             };
             #[cfg(feature = "sandbox")]
-            let fd = crate::host_seam::ops::open(&path, flags, mode)
-                .map_err(|e| crate::host_seam::seam_os_err_with_filename(e, args[0]))?;
+            let fd = crate::host_seam::ops::open(&path.as_bytes, flags, mode)
+                .map_err(|e| crate::host_seam::seam_os_err_with_filename(e, path.w_path()))?;
             Ok(pyre_object::w_int_new(fd as i64))
         }),
     );
@@ -1536,22 +1553,22 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         if args.is_empty() {
             return Err(crate::PyError::type_error("unlink() requires 1 argument"));
         }
-        let path = extract_path(args[0])?;
+        let path = crate::gateway::fsencode_path_w(args[0])?;
         #[cfg(not(feature = "sandbox"))]
         {
-            let c_path = std::ffi::CString::new(path.as_slice())
+            let c_path = std::ffi::CString::new(path.as_bytes.as_slice())
                 .map_err(|_| crate::PyError::value_error("embedded null in path"))?;
             let ret = unsafe { libc::unlink(c_path.as_ptr()) };
             if ret < 0 {
                 return Err(io_err_with_filename(
                     std::io::Error::last_os_error(),
-                    args[0],
+                    path.w_path(),
                 ));
             }
         }
         #[cfg(feature = "sandbox")]
-        crate::host_seam::ops::unlink(&path)
-            .map_err(|e| crate::host_seam::seam_os_err_with_filename(e, args[0]))?;
+        crate::host_seam::ops::unlink(&path.as_bytes)
+            .map_err(|e| crate::host_seam::seam_os_err_with_filename(e, path.w_path()))?;
         Ok(pyre_object::w_none())
     }
     crate::module_ns_store(
@@ -1580,13 +1597,14 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 .first()
                 .copied()
                 .ok_or_else(|| crate::PyError::type_error("readlink() requires 1 argument"))?;
-            let (path, bytes_mode) = crate::gateway::fsencode_bytes_w_with_kind(arg)?;
-            match std::fs::read_link(path_from_bytes(&path).as_ref()) {
+            let path = crate::gateway::fsencode_path_w(arg)?;
+            let bytes_mode = unsafe { path.is_bytes() };
+            match std::fs::read_link(path_from_bytes(&path.as_bytes).as_ref()) {
                 Ok(target) => {
                     let target = target.as_os_str().as_encoded_bytes();
                     Ok(fs_name_obj(bytes_mode, target))
                 }
-                Err(e) => Err(io_err_with_filename(e, arg)),
+                Err(e) => Err(io_err_with_filename(e, path.w_path())),
             }
         }),
     );
@@ -1599,7 +1617,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             if args.is_empty() {
                 return Err(crate::PyError::type_error("mkdir() requires 1 argument"));
             }
-            let path = extract_path(args[0])?;
+            let path = crate::gateway::fsencode_path_w(args[0])?;
             let _mode: u32 = if args.len() >= 2 {
                 crate::baseobjspace::c_int_w(args[1])? as u32
             } else {
@@ -1607,7 +1625,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             };
             #[cfg(not(feature = "sandbox"))]
             {
-                let c_path = std::ffi::CString::new(path.as_slice())
+                let c_path = std::ffi::CString::new(path.as_bytes.as_slice())
                     .map_err(|_| crate::PyError::value_error("embedded null in path"))?;
                 #[cfg(unix)]
                 let ret = unsafe { libc::mkdir(c_path.as_ptr(), _mode as libc::mode_t) };
@@ -1616,13 +1634,13 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 if ret < 0 {
                     return Err(io_err_with_filename(
                         std::io::Error::last_os_error(),
-                        args[0],
+                        path.w_path(),
                     ));
                 }
             }
             #[cfg(feature = "sandbox")]
-            crate::host_seam::ops::mkdir(&path, _mode)
-                .map_err(|e| crate::host_seam::seam_os_err_with_filename(e, args[0]))?;
+            crate::host_seam::ops::mkdir(&path.as_bytes, _mode)
+                .map_err(|e| crate::host_seam::seam_os_err_with_filename(e, path.w_path()))?;
             Ok(pyre_object::w_none())
         }),
     );
@@ -1640,14 +1658,14 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 if args.is_empty() {
                     return Err(crate::PyError::type_error("rmdir() requires 1 argument"));
                 }
-                let path = extract_path(args[0])?;
-                let c_path = std::ffi::CString::new(path.as_slice())
+                let path = crate::gateway::fsencode_path_w(args[0])?;
+                let c_path = std::ffi::CString::new(path.as_bytes.as_slice())
                     .map_err(|_| crate::PyError::value_error("embedded null in path"))?;
                 let ret = unsafe { libc::rmdir(c_path.as_ptr()) };
                 if ret < 0 {
                     return Err(io_err_with_filename(
                         std::io::Error::last_os_error(),
-                        args[0],
+                        path.w_path(),
                     ));
                 }
                 Ok(pyre_object::w_none())
@@ -1684,8 +1702,8 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             )));
         }
         crate::builtins::kwarg_reject_unknown(kwargs, &["src_dir_fd", "dst_dir_fd"], name)?;
-        let src = extract_path(pos[0])?;
-        let dst = extract_path(pos[1])?;
+        let src = crate::gateway::fsencode_path_w(pos[0])?;
+        let dst = crate::gateway::fsencode_path_w(pos[1])?;
         let dir_fd = |name: &str| -> Result<Option<i32>, crate::PyError> {
             match crate::builtins::kwarg_get(kwargs, name) {
                 // interp_posix.py:274-278 `_unwrap_dirfd` — a non-`None` value
@@ -1716,8 +1734,8 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             }
             (None, None)
         };
-        let src_path = path_from_bytes(&src);
-        let dst_path = path_from_bytes(&dst);
+        let src_path = path_from_bytes(&src.as_bytes);
+        let dst_path = path_from_bytes(&dst.as_bytes);
         let result = if name == "replace" {
             host_os::replace(src_path.as_ref(), src_b, dst_path.as_ref(), dst_b)
         } else {
@@ -1725,9 +1743,9 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         };
         result.map_err(|e| {
             let errno = crate::builtins::io_error_posix_errno(&e, 0);
-            // interp_posix.py:654 hands both original objects to
-            // `wrap_oserror2`, preserving bytes and path-like arguments.
-            crate::PyError::os_error_syscall2(errno, pos[0], pos[1])
+            // interp_posix.py:654 hands both resolved `Path.w_path` objects to
+            // `wrap_oserror2`.
+            crate::PyError::os_error_syscall2(errno, src.w_path(), dst.w_path())
         })?;
         Ok(pyre_object::w_none())
     }
@@ -1764,7 +1782,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             &["ns", "dir_fd", "follow_symlinks"],
             "utime",
         )?;
-        let path = extract_path(pos[0])?;
+        let path = crate::gateway::fsencode_path_w(pos[0])?;
 
         let present = |v: PyObjectRef| (!unsafe { pyre_object::is_none(v) }).then_some(v);
         let times = pos.get(1).copied().and_then(present);
@@ -1837,13 +1855,13 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     "utime: dir_fd and follow_symlinks=False are unavailable on this platform",
                 ));
             }
-            host_os::set_file_times(path_from_bytes(&path).as_ref(), access, modified)
-                .map_err(|e| io_err_with_filename(e, pos[0]))?;
+            host_os::set_file_times(path_from_bytes(&path.as_bytes).as_ref(), access, modified)
+                .map_err(|e| io_err_with_filename(e, path.w_path()))?;
             return Ok(pyre_object::w_none());
         }
         #[cfg(all(unix, not(feature = "sandbox")))]
         {
-            let c_path = std::ffi::CString::new(path.as_slice())
+            let c_path = std::ffi::CString::new(path.as_bytes.as_slice())
                 .map_err(|_| crate::PyError::value_error("embedded null character"))?;
             rustpython_host_env::posix::set_file_times_at(
                 dir_fd.unwrap_or(libc::AT_FDCWD),
@@ -1852,7 +1870,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 modified,
                 follow_symlinks,
             )
-            .map_err(|e| io_err_with_filename(e, pos[0]))?;
+            .map_err(|e| io_err_with_filename(e, path.w_path()))?;
             return Ok(pyre_object::w_none());
         }
         #[allow(unreachable_code)]
@@ -1941,18 +1959,28 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         crate::make_builtin_function("listdir", |args| {
             // One resolution yields both the path and its bytes-ness, so
             // `__fspath__` runs exactly once.
-            let (path, bytes_mode) = if args.is_empty() || unsafe { pyre_object::is_none(args[0]) } {
-                (b".".to_vec(), false)
+            let resolved = if args.is_empty() || unsafe { pyre_object::is_none(args[0]) } {
+                None
             } else {
-                crate::gateway::fsencode_bytes_w_with_kind(args[0])?
+                Some(crate::gateway::fsencode_path_w(args[0])?)
             };
+            let bytes_mode = unsafe { resolved.as_ref().is_some_and(|path| path.is_bytes()) };
+            let path = resolved
+                .as_ref()
+                .map(|path| path.as_bytes.as_slice())
+                .unwrap_or(b".");
             // The omitted argument defaults to `"."` but reports no filename,
             // since there was no path object for the failure to name.
-            let w_path = args.first().copied().unwrap_or(pyre_object::PY_NULL);
+            let w_path = || {
+                resolved
+                    .as_ref()
+                    .map(|path| path.w_path())
+                    .unwrap_or(pyre_object::PY_NULL)
+            };
             #[cfg(feature = "sandbox")]
             {
-                let names = crate::host_seam::ops::listdir(&path)
-                    .map_err(|e| crate::host_seam::seam_os_err_with_filename(e, w_path))?;
+                let names = crate::host_seam::ops::listdir(path)
+                    .map_err(|e| crate::host_seam::seam_os_err_with_filename(e, w_path()))?;
                 let items = names
                     .into_iter()
                     .map(|n| fs_name_obj(bytes_mode, &n))
@@ -1961,11 +1989,11 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             }
             #[cfg(not(feature = "sandbox"))]
             {
-                let entries = host_fs::read_dir(path_from_bytes(&path).as_ref())
-                    .map_err(|e| io_err_with_filename(e, w_path))?;
+                let entries = host_fs::read_dir(path_from_bytes(path).as_ref())
+                    .map_err(|e| io_err_with_filename(e, w_path()))?;
                 let mut items = Vec::new();
                 for entry in entries {
-                    let entry = entry.map_err(|e| io_err_with_filename(e, w_path))?;
+                    let entry = entry.map_err(|e| io_err_with_filename(e, w_path()))?;
                     let name = entry.file_name();
                     items.push(fs_name_obj(bytes_mode, name.as_encoded_bytes()));
                 }
@@ -2416,38 +2444,37 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         if args.is_empty() {
             return Err(crate::PyError::type_error("stat() missing argument"));
         }
-        let path_obj = args[0];
-        let path = crate::gateway::fsencode_bytes_w(path_obj).map_err(|_| {
+        let path = crate::gateway::fsencode_path_w(args[0]).map_err(|_| {
             crate::PyError::type_error("stat: path should be string, bytes, os.PathLike")
         })?;
         #[cfg(feature = "sandbox")]
         {
             let buf = if follow_symlinks {
-                crate::host_seam::ops::stat(&path)
+                crate::host_seam::ops::stat(&path.as_bytes)
             } else {
-                crate::host_seam::ops::lstat(&path)
+                crate::host_seam::ops::lstat(&path.as_bytes)
             }
-            .map_err(|e| crate::host_seam::seam_os_err_with_filename(e, path_obj))?;
+            .map_err(|e| crate::host_seam::seam_os_err_with_filename(e, path.w_path()))?;
             return Ok(make_stat_result_from_statbuf(&buf));
         }
         #[cfg(not(feature = "sandbox"))]
         {
             let meta = if follow_symlinks {
-                host_fs::metadata(path_from_bytes(&path).as_ref())
+                host_fs::metadata(path_from_bytes(&path.as_bytes).as_ref())
             } else {
-                host_fs::symlink_metadata(path_from_bytes(&path).as_ref())
+                host_fs::symlink_metadata(path_from_bytes(&path.as_bytes).as_ref())
             };
             match meta {
                 Ok(m) => {
                     #[cfg(target_os = "macos")]
-                    let st_flags = macos_path_st_flags(&path, follow_symlinks);
+                    let st_flags = macos_path_st_flags(&path.as_bytes, follow_symlinks);
                     #[cfg(not(target_os = "macos"))]
                     let st_flags = 0u32;
                     Ok(make_stat_result(&m, st_flags))
                 }
                 Err(e) => Err(errno_err_with_filename(
                     crate::builtins::io_error_posix_errno(&e, 2),
-                    path_obj,
+                    path.w_path(),
                 )),
             }
         }
@@ -2648,19 +2675,29 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     fn scandir_fn(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         // One resolution yields both the path and its bytes-ness, so
         // `__fspath__` runs exactly once.
-        let (path, bytes_mode) = if args.is_empty() || unsafe { pyre_object::is_none(args[0]) } {
-            (b".".to_vec(), false)
+        let resolved = if args.is_empty() || unsafe { pyre_object::is_none(args[0]) } {
+            None
         } else {
-            crate::gateway::fsencode_bytes_w_with_kind(args[0])?
+            Some(crate::gateway::fsencode_path_w(args[0])?)
         };
+        let bytes_mode = unsafe { resolved.as_ref().is_some_and(|path| path.is_bytes()) };
+        let path = resolved
+            .as_ref()
+            .map(|path| path.as_bytes.as_slice())
+            .unwrap_or(b".");
         // The omitted argument defaults to `"."` but reports no filename,
         // since there was no path object for the failure to name.
-        let w_path = args.first().copied().unwrap_or(pyre_object::PY_NULL);
-        let entries = host_fs::read_dir(path_from_bytes(&path).as_ref())
-            .map_err(|e| io_err_with_filename(e, w_path))?;
+        let w_path = || {
+            resolved
+                .as_ref()
+                .map(|path| path.w_path())
+                .unwrap_or(pyre_object::PY_NULL)
+        };
+        let entries = host_fs::read_dir(path_from_bytes(path).as_ref())
+            .map_err(|e| io_err_with_filename(e, w_path()))?;
         let list = pyre_object::w_list_new(Vec::new());
         for entry in entries {
-            let entry = entry.map_err(|e| io_err_with_filename(e, w_path))?;
+            let entry = entry.map_err(|e| io_err_with_filename(e, w_path()))?;
             let name = entry.file_name();
             let full = entry.path().into_os_string();
             let de = pyre_object::w_instance_new(dir_entry_type());
@@ -3082,7 +3119,9 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     let argv_ptrs = exec_pointer_array(&argv);
                     let errno =
                         host_posix::exec_replace(&[command_c], argv_ptrs.as_ptr(), None) as i32;
-                    Err(errno_err_with_filename(errno, args[0]))
+                    // interp_posix.py:1814-1817 uses `wrap_oserror`, which does
+                    // not attach the command path.
+                    Err(errno_err(errno, ""))
                 },
                 2,
             ),
@@ -3349,11 +3388,11 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     if args.is_empty() {
                         return Err(crate::PyError::type_error("chdir() requires 1 argument"));
                     }
-                    let path = extract_path(args[0])?;
-                    let c_path = std::ffi::CString::new(path.as_slice())
+                    let path = crate::gateway::fsencode_path_w(args[0])?;
+                    let c_path = std::ffi::CString::new(path.as_bytes.as_slice())
                         .map_err(|_| crate::PyError::value_error("embedded null in path"))?;
                     host_posix::chdir(&c_path)
-                        .map_err(|e| errno_err_with_filename(e as i32, args[0]))?;
+                        .map_err(|e| errno_err_with_filename(e as i32, path.w_path()))?;
                     Ok(pyre_object::w_none())
                 },
                 1,
@@ -3782,20 +3821,20 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 if args.is_empty() {
                     return Err(crate::PyError::type_error("mkfifo() requires 1 argument"));
                 }
-                let path = extract_path(args[0])?;
+                let path = crate::gateway::fsencode_path_w(args[0])?;
                 // interp_posix.py:1322 `@unwrap_spec(mode=c_int, ...)`.
                 let mode = if args.len() >= 2 {
                     crate::baseobjspace::c_int_w(args[1])? as libc::mode_t
                 } else {
                     0o666
                 };
-                let c_path = std::ffi::CString::new(path.as_slice())
+                let c_path = std::ffi::CString::new(path.as_bytes.as_slice())
                     .map_err(|_| crate::PyError::value_error("embedded null in path"))?;
                 let r = unsafe { libc::mkfifo(c_path.as_ptr(), mode) };
                 if r < 0 {
                     return Err(io_err_with_filename(
                         std::io::Error::last_os_error(),
-                        args[0],
+                        path.w_path(),
                     ));
                 }
                 Ok(pyre_object::w_none())
@@ -3885,11 +3924,11 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     if args.is_empty() {
                         return Err(crate::PyError::type_error("statvfs() requires 1 argument"));
                     }
-                    let path = extract_path(args[0])?;
-                    let c_path = std::ffi::CString::new(path.as_slice())
+                    let path = crate::gateway::fsencode_path_w(args[0])?;
+                    let c_path = std::ffi::CString::new(path.as_bytes.as_slice())
                         .map_err(|_| crate::PyError::value_error("embedded null in path"))?;
                     let info = host_posix::statvfs_path(&c_path)
-                        .map_err(|e| io_err_with_filename(e, args[0]))?;
+                        .map_err(|e| io_err_with_filename(e, path.w_path()))?;
                     Ok(statvfs_to_obj(info))
                 },
                 1,
@@ -3958,11 +3997,11 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 if args.len() < 2 {
                     return Err(crate::PyError::type_error("symlink() requires 2 arguments"));
                 }
-                let src = extract_path(args[0])?;
-                let dst = extract_path(args[1])?;
-                let c_src = std::ffi::CString::new(src)
+                let src = crate::gateway::fsencode_path_w(args[0])?;
+                let dst = crate::gateway::fsencode_path_w(args[1])?;
+                let c_src = std::ffi::CString::new(src.as_bytes.as_slice())
                     .map_err(|_| crate::PyError::value_error("embedded null in src"))?;
-                let c_dst = std::ffi::CString::new(dst)
+                let c_dst = std::ffi::CString::new(dst.as_bytes.as_slice())
                     .map_err(|_| crate::PyError::value_error("embedded null in dst"))?;
                 // host_env::posix only exposes symlinkat on non-redox unices;
                 // call libc::symlink directly so we don't need an at-cwd dance.
@@ -3970,7 +4009,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 if ret < 0 {
                     return Err(io_err_with_filename(
                         std::io::Error::last_os_error(),
-                        args[1],
+                        dst.w_path(),
                     ));
                 }
                 Ok(pyre_object::w_none())
@@ -3988,17 +4027,17 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     if args.len() < 2 {
                         return Err(crate::PyError::type_error("chmod() requires 2 arguments"));
                     }
-                    let path = extract_path(args[0])?;
+                    let path = crate::gateway::fsencode_path_w(args[0])?;
                     // `posix.chmod` unwraps `mode` as `c_int`, so a non-integer
                     // raises TypeError instead of reinterpreting its layout.
                     let mode = crate::baseobjspace::c_int_w(args[1])? as u32;
-                    let c_path = std::ffi::CString::new(path.as_slice())
+                    let c_path = std::ffi::CString::new(path.as_bytes.as_slice())
                         .map_err(|_| crate::PyError::value_error("embedded null in path"))?;
                     let ret = unsafe { libc::chmod(c_path.as_ptr(), mode as libc::mode_t) };
                     if ret < 0 {
                         return Err(io_err_with_filename(
                             std::io::Error::last_os_error(),
-                            args[0],
+                            path.w_path(),
                         ));
                     }
                     Ok(pyre_object::w_none())
@@ -4078,7 +4117,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             // object's error, not a statement that the argument was the wrong
             // type.  Rewriting every failure into a `TypeError` here would also
             // swallow the `UnicodeEncodeError` a lone surrogate produces.
-            let path = extract_path(path_obj)?;
+            let path = crate::gateway::fsencode_path_w(path_obj)?;
             // `_Py_Uid_Converter` / `_Py_Gid_Converter`: `uid_t` is unsigned, yet
             // -1 is always accepted as the "leave unchanged" sentinel.  Only
             // that one value means unchanged; every other id is judged by
@@ -4130,12 +4169,12 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             let cwd = unsafe { BorrowedFd::borrow_raw(libc::AT_FDCWD) };
             host_posix::fchownat(
                 cwd,
-                path_from_bytes(&path).as_os_str(),
+                path_from_bytes(&path.as_bytes).as_os_str(),
                 uid,
                 gid,
                 follow_symlinks,
             )
-            .map_err(|e| io_err_with_filename(e, path_obj))?;
+            .map_err(|e| io_err_with_filename(e, path.w_path()))?;
             Ok(pyre_object::w_none())
         }
         crate::module_ns_store(
@@ -4249,9 +4288,9 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     if args.is_empty() {
                         return Err(crate::PyError::type_error("chroot() requires 1 argument"));
                     }
-                    let path = extract_path(args[0])?;
-                    host_posix::chroot(path_from_bytes(&path).as_ref())
-                        .map_err(|e| io_err_with_filename(e, args[0]))?;
+                    let path = crate::gateway::fsencode_path_w(args[0])?;
+                    host_posix::chroot(path_from_bytes(&path.as_bytes).as_ref())
+                        .map_err(|e| io_err_with_filename(e, path.w_path()))?;
                     Ok(pyre_object::w_none())
                 },
                 1,
@@ -4487,8 +4526,8 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                         "posix_spawn() requires path, argv, env",
                     ));
                 }
-                let path = extract_path(positional[0])?;
-                let c_path = std::ffi::CString::new(path).map_err(|_| {
+                let path = crate::gateway::fsencode_path_w(positional[0])?;
+                let c_path = std::ffi::CString::new(path.as_bytes.as_slice()).map_err(|_| {
                     crate::PyError::value_error("posix_spawn: embedded null in path")
                 })?;
                 let argv = collect_cstring_seq(positional[1], "posix_spawn", "argv")?;
@@ -4521,7 +4560,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     spawnp,
                 };
                 let pid = host_posix::posix_spawn(config)
-                    .map_err(|e| io_err_with_filename(e, positional[0]))?;
+                    .map_err(|e| io_err_with_filename(e, path.w_path()))?;
                 Ok(pyre_object::w_int_new(pid as i64))
             }
             fn collect_spawn_env(
@@ -4576,7 +4615,9 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     let value = crate::gateway::fsencode_bytes_w(
                         pyre_object::gc_roots::shadow_stack_get(value_slot),
                     )?;
-                    if key.is_empty() || key.contains(&b'=') {
+                    // interp_posix.py:1762-1769 permits the Windows `=C:`
+                    // spelling and rejects `=` only after the first byte.
+                    if key.is_empty() || key.get(1..).is_some_and(|tail| tail.contains(&b'=')) {
                         return Err(crate::PyError::value_error(
                             "illegal environment variable name",
                         ));
@@ -4995,13 +5036,13 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     if args.len() < 2 {
                         return Err(crate::PyError::type_error("pathconf() requires path, name"));
                     }
-                    let path = extract_path(args[0])?;
-                    let cpath = std::ffi::CString::new(path).map_err(|_| {
+                    let path = crate::gateway::fsencode_path_w(args[0])?;
+                    let cpath = std::ffi::CString::new(path.as_bytes.as_slice()).map_err(|_| {
                         crate::PyError::value_error("pathconf: embedded null in path")
                     })?;
                     let name = confname_arg(args[1])?;
                     match host_posix::pathconf(&cpath, name)
-                        .map_err(|e| io_err_with_filename(e, args[0]))?
+                        .map_err(|e| io_err_with_filename(e, path.w_path()))?
                     {
                         Some(v) => Ok(pyre_object::w_int_new(v as i64)),
                         None => Ok(pyre_object::w_none()),

--- a/pyre/pyre-interpreter/src/pycode.rs
+++ b/pyre/pyre-interpreter/src/pycode.rs
@@ -1151,10 +1151,14 @@ pub unsafe fn code_hash(obj: PyObjectRef) -> Result<i64, crate::PyError> {
 pub unsafe fn code_repr(obj: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
     let code = unsafe { require_code(obj, "__repr__")? };
     let line = (*(obj as *const PyCode)).co_firstlineno_raw as i64;
-    Ok(w_str_new(&format!(
-        "<code object {} at {obj:p}, file \"{}\", line {line}>",
-        code.obj_name, code.source_path,
-    )))
+    let mut repr = rustpython_wtf8::Wtf8Buf::from_string(format!(
+        "<code object {} at {obj:p}, file \"",
+        code.obj_name,
+    ));
+    let filename = crate::gateway::fsdecode_filename_wtf8(&unsafe { code_filename_bytes(obj) });
+    repr.push_wtf8(&filename);
+    repr.push_str(&format!("\", line {line}>"));
+    Ok(pyre_object::w_str_from_wtf8_managed(repr))
 }
 
 pub unsafe fn code_sizeof(obj: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {

--- a/pyre/pyre-interpreter/src/pycode.rs
+++ b/pyre/pyre-interpreter/src/pycode.rs
@@ -1166,7 +1166,9 @@ pub unsafe fn code_hash(obj: PyObjectRef) -> Result<i64, crate::PyError> {
 
 pub unsafe fn code_repr(obj: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
     let code = unsafe { require_code(obj, "__repr__")? };
-    let line = (*(obj as *const PyCode)).co_firstlineno_raw as i64;
+    // pycode.py:570-572 represents the internal zero sentinel as line -1.
+    let raw_line = (*(obj as *const PyCode)).co_firstlineno_raw as i64;
+    let line = if raw_line == 0 { -1 } else { raw_line };
     let mut repr = rustpython_wtf8::Wtf8Buf::from_string(format!(
         "<code object {} at {obj:p}, file \"",
         code.obj_name,

--- a/pyre/pyre-interpreter/src/pycode.rs
+++ b/pyre/pyre-interpreter/src/pycode.rs
@@ -674,6 +674,22 @@ fn box_code_constant_inheriting_filename(code: &crate::CodeObject, parent: &PyCo
     obj
 }
 
+/// Attach the filesystem bytes a whole compilation unit was named with.
+///
+/// `compiling.py:13 filename='fsencode'` names the unit, not one object, so
+/// the nested constants this code object still holds unrealized take the same
+/// spelling when they are boxed. That is the difference from `pycode.py:431`,
+/// whose constructor and `replace` filenames rename only the object being
+/// built and leave every nested constant on the name it compiled under.
+pub(crate) unsafe fn set_compilation_unit_filename_bytes(
+    w_code: PyObjectRef,
+    bytes: Option<Vec<u8>>,
+) {
+    let inherits = bytes.is_some();
+    unsafe { set_filename_bytes(w_code, bytes) };
+    unsafe { (*(w_code as *mut PyCode)).filename_inherits_to_nested = inherits };
+}
+
 /// Replace the owned raw filename allocation. Code wrappers are immortal, so
 /// this is also the only point that retires an earlier spelling after a second
 /// `_fix_co_filename` call.
@@ -1544,7 +1560,16 @@ unsafe fn read_code_filename(
         return Err(crate::PyError::type_error(format!("{field} must be a str")));
     }
     let bytes = crate::gateway::fsencode_bytes_w(v)?;
-    Ok(match String::from_utf8(bytes) {
+    Ok(split_code_filename_bytes(bytes, fallback))
+}
+
+/// Split the authoritative filesystem bytes from the compiler dependency's
+/// UTF-8-only `source_path` spelling (`objspace.py:438 newfilename`).
+pub(crate) fn split_code_filename_bytes(
+    bytes: Vec<u8>,
+    fallback: Option<&str>,
+) -> (String, Option<Vec<u8>>) {
+    match String::from_utf8(bytes) {
         Ok(source_path) => (source_path, None),
         Err(error) => {
             let bytes = error.into_bytes();
@@ -1553,7 +1578,7 @@ unsafe fn read_code_filename(
                 .unwrap_or_else(|| String::from_utf8_lossy(&bytes).into_owned());
             (source_path, Some(bytes))
         }
-    })
+    }
 }
 
 /// A `tuple[str]` `co_*` field (names / varnames / freevars / cellvars).

--- a/pyre/pyre-interpreter/src/runtime_ops.rs
+++ b/pyre/pyre-interpreter/src/runtime_ops.rs
@@ -642,8 +642,12 @@ pub fn convert_value(value: PyObjectRef, conv: i64) -> Result<PyObjectRef, crate
         let w = unsafe { crate::py_str_wtf8(value)? };
         return Ok(pyre_object::w_str_from_wtf8_managed(w));
     }
+    if conv == 1 {
+        return Ok(pyre_object::w_str_from_wtf8_managed(unsafe {
+            crate::py_repr_wtf8(value)?
+        }));
+    }
     let s = match conv {
-        1 => unsafe { crate::py_repr(value)? },
         2 => crate::builtins::py_ascii(value)?,
         _ => unsafe { crate::py_str(value)? },
     };

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -1673,7 +1673,7 @@ fn format_render(
             None => val,
             Some(cp) => match cp.to_char_lossy() {
                 's' => pyre_object::w_str_from_wtf8(unsafe { crate::py_str_wtf8(val)? }),
-                'r' => pyre_object::w_str_new(&unsafe { crate::py_repr(val)? }),
+                'r' => pyre_object::w_str_from_wtf8(unsafe { crate::py_repr_wtf8(val)? }),
                 'a' => pyre_object::w_str_new(&crate::builtins::py_ascii(val)?),
                 c => {
                     return Err(crate::PyError::value_error(format!(

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -3985,8 +3985,8 @@ fn init_super_type(ns: PyObjectRef) {
 
 /// `functional.py W_Range.descr_repr`.
 fn range_descr_repr(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    Ok(w_str_new_managed(&unsafe {
-        crate::display::py_repr(args[0])?
+    Ok(pyre_object::w_str_from_wtf8_managed(unsafe {
+        crate::display::py_repr_wtf8(args[0])?
     }))
 }
 
@@ -4723,7 +4723,7 @@ fn init_list_type(ns: PyObjectRef) {
                 "__repr__",
                 |args| {
                     let list = crate::type_methods::require_list_receiver(args, "__repr__", false)?;
-                    Ok(w_str_new_managed(&unsafe {
+                    Ok(pyre_object::w_str_from_wtf8_managed(unsafe {
                         crate::display::list_repr(list)?
                     }))
                 },
@@ -6180,9 +6180,9 @@ fn init_dict_type(ns: PyObjectRef) {
                         )));
                     }
                     unsafe {
-                        Ok(pyre_object::w_str_new_managed(&crate::display::dict_repr(
-                            dict,
-                        )?))
+                        Ok(pyre_object::w_str_from_wtf8_managed(
+                            crate::display::dict_repr(dict)?,
+                        ))
                     }
                 },
                 1,
@@ -6725,8 +6725,8 @@ fn init_dict_view_common_slots(
                     if args.is_empty() {
                         return Ok(pyre_object::w_str_new(""));
                     }
-                    Ok(pyre_object::w_str_new(&unsafe {
-                        crate::display::py_repr(args[0])?
+                    Ok(pyre_object::w_str_from_wtf8(unsafe {
+                        crate::display::py_repr_wtf8(args[0])?
                     }))
                 },
                 1,
@@ -8016,9 +8016,9 @@ fn init_mappingproxy_type(ns: PyObjectRef) {
                     return Ok(pyre_object::w_str_new("mappingproxy({})"));
                 }
                 unsafe {
-                    Ok(pyre_object::w_str_new_managed(&crate::display::py_repr(
-                        args[0],
-                    )?))
+                    Ok(pyre_object::w_str_from_wtf8_managed(
+                        crate::display::py_repr_wtf8(args[0])?,
+                    ))
                 }
             }),
         )
@@ -8342,7 +8342,7 @@ fn init_tuple_type(ns: PyObjectRef) {
                 |args| {
                     let tuple =
                         crate::type_methods::require_tuple_receiver(args, "__repr__", false)?;
-                    Ok(w_str_new_managed(&unsafe {
+                    Ok(pyre_object::w_str_from_wtf8_managed(unsafe {
                         crate::display::tuple_repr(tuple)?
                     }))
                 },
@@ -8726,8 +8726,8 @@ fn slice_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
 /// sliceobject.py `descr_repr` — `"slice(%r, %r, %r)"`.
 fn slice_descr_repr(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let self_ = slice_receiver(args, "__repr__")?;
-    Ok(w_str_new_managed(&unsafe {
-        crate::display::py_repr(self_)?
+    Ok(pyre_object::w_str_from_wtf8_managed(unsafe {
+        crate::display::py_repr_wtf8(self_)?
     }))
 }
 
@@ -9111,8 +9111,9 @@ fn union_repr_method(args: &[PyObjectRef]) -> crate::PyResult {
             "descriptor '__repr__' requires a 'types.UnionType' object",
         ));
     }
-    let rendered = unsafe { crate::display::py_repr(self_)? };
-    Ok(pyre_object::w_str_new(&rendered))
+    Ok(pyre_object::w_str_from_wtf8(unsafe {
+        crate::display::py_repr_wtf8(self_)?
+    }))
 }
 
 /// `UnionType.__hash__` (`_pypy_generic_alias.py:275`).
@@ -18783,8 +18784,8 @@ fn init_object_type(ns: PyObjectRef) {
                     crate::type_methods::arity_no_args(args, "__str__")?;
                     // Delegate to __repr__ to avoid infinite recursion
                     // PyPy: objectobject.py descr___str__ → space.repr(w_self)
-                    Ok(pyre_object::w_str_new_managed(&unsafe {
-                        crate::py_repr(args[0])?
+                    Ok(pyre_object::w_str_from_wtf8_managed(unsafe {
+                        crate::py_repr_wtf8(args[0])?
                     }))
                 },
                 1,
@@ -23555,9 +23556,9 @@ fn setlike_descr_iter(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErro
 
 fn setlike_descr_repr(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     unsafe {
-        Ok(pyre_object::w_str_new_managed(&crate::display::py_repr(
-            args[0],
-        )?))
+        Ok(pyre_object::w_str_from_wtf8_managed(
+            crate::display::py_repr_wtf8(args[0])?,
+        ))
     }
 }
 

--- a/pyre/pyre-macros/src/lib.rs
+++ b/pyre/pyre-macros/src/lib.rs
@@ -412,7 +412,7 @@ fn unwrap_arg(
         }
     };
     // Typed-receiver aliases erase to the binding type declared in
-    // `typed_alias` (PyObjectRef for passthrough, String for PyPath).
+    // `typed_alias` (PyObjectRef for passthrough, Vec<u8> for PyPath).
     // The inner fn signature is rewritten in parallel by
     // `rewrite_alias_args` so user code sees the same type.
     let binding_ty = if let Type::Path(p) = unwrap_type_group(ty) {
@@ -475,7 +475,7 @@ fn arg_default(pt: &PatType) -> syn::Result<Option<proc_macro2::TokenStream>> {
 /// * Convert-to-rust (`PyPath`) — mirrors PyPy
 ///   `@unwrap_spec(path='fsencode')` (`gateway.py:visit_fsencode` line
 ///   365) which lowers to `space.fsencode_w(...)`.  Binding type is the
-///   Rust value the conversion produces (`String` for PyPath); the
+///   Rust value the conversion produces (`Vec<u8>` for PyPath); the
 ///   inner-fn signature is rewritten the same way and the body sees the
 ///   converted Rust value directly.
 ///
@@ -516,8 +516,8 @@ fn typed_alias(
         "PySet" => passthrough(quote! { ::pyre_object::is_set }),
         "PyFrozenSet" => passthrough(quote! { ::pyre_object::is_frozenset }),
         "PyPath" => (
-            quote! { ::std::string::String },
-            quote! { crate::gateway::fsencode_w(args[#idx])? },
+            quote! { ::std::vec::Vec<u8> },
+            quote! { crate::gateway::fsencode_bytes_w(args[#idx])? },
         ),
         "PyIndex" => (
             // Mirrors PyPy `space.getindex_w(w_obj, None)`: consults
@@ -599,13 +599,13 @@ fn typed_alias(
         ),
         "PyPathOrNone" => (
             // space.fsencode_or_none_w — None passes through, otherwise
-            // fsencode_w (same conversion as the `PyPath` alias).
-            quote! { ::std::option::Option<::std::string::String> },
+            // fsencode_bytes_w (same conversion as the `PyPath` alias).
+            quote! { ::std::option::Option<::std::vec::Vec<u8>> },
             quote! {
                 if unsafe { ::pyre_object::is_none(args[#idx]) } {
                     ::std::option::Option::None
                 } else {
-                    ::std::option::Option::Some(crate::gateway::fsencode_w(args[#idx])?)
+                    ::std::option::Option::Some(crate::gateway::fsencode_bytes_w(args[#idx])?)
                 }
             },
         ),
@@ -664,8 +664,8 @@ fn typed_alias_binding_ty(name: &str) -> Option<proc_macro2::TokenStream> {
 fn unwrap_expr(ty: &Type, idx: usize) -> syn::Result<proc_macro2::TokenStream> {
     let ty = unwrap_type_group(ty);
     // Typed-receiver aliases — `state: PyTuple` becomes a typecheck +
-    // PyObjectRef binding; `path: PyPath` becomes an fsencode_w call +
-    // `String` binding.  Inner fn signatures get rewritten elsewhere so
+    // PyObjectRef binding; `path: PyPath` becomes an fsencode_bytes_w call +
+    // `Vec<u8>` binding.  Inner fn signatures get rewritten elsewhere so
     // the body's parameter type matches the binding type the alias
     // resolves to.
     if let Type::Path(p) = ty {


### PR DESCRIPTION
Four independent fixes at the filesystem-name boundary. The first is a
wrong-behaviour bug, not a reporting one.

## posix paths aliased onto one another

`gateway::fsencode_w` ended in `String::from_utf8_lossy`, and the posix module
used it for every path argument, so a path byte with no UTF-8 spelling folded to
U+FFFD **before the syscall was made**. Two names differing only in such a byte
became one name:

```python
# a file named '�victim' exists (U+FFFD is valid UTF-8)
os.stat(b"\xffvictim")          # was: succeeds, stats the U+FFFD file
                                # now: FileNotFoundError, as CPython and PyPy
os.path.exists(b"\xffvictim")   # was: True    now: False
```

Upstream never folds: `space.fsencode_w` (`baseobjspace.py:1970`) answers with a
byte string and `dispatch_filename` (`interp_posix.py:56-115`) hands those bytes
to the call unchanged. The extraction now yields bytes, and `OsStr::from_bytes`
carries them to the syscall on unix; the text form stays only where the platform
has no byte spelling of a path.

`fsencode_w` and `fsencode_w_with_kind` are deleted rather than left reachable,
and the `PyPath` / `PyPathOrNone` macro bindings — which stand for
`gateway.py:365` `unwrap_spec` `'fsencode'` — bind `Vec<u8>`.

`OSError.filename` now carries the path object the call was given
(`interp_posix.py:332 wrap_oserror2(space, e, w_path)`), so a bytes path reports
bytes and a str keeps its surrogate escapes. For an `os.PathLike`, that object is
the result of the single `__fspath__` call, not the wrapper that supplied it
(`interp_posix.py:211-219 _unwrap_path`), so the two travel together in one
record. All eight rows across `os.stat` / `os.open` / `open` / `io.FileIO`
match CPython and PyPy.

## compile() dropped its filename, silently

`compiling.py:13` declares `unwrap_spec(filename='fsencode', mode='text')`, but
`builtin_compile` bound both as `if is_str { ... } else { <default> }`:

| call | CPython | PyPy | before |
|---|---|---|---|
| `compile(s, b"ascii.py", "exec").co_filename` | `'ascii.py'` | `'ascii.py'` | `'<string>'` |
| `compile(s, b"\xff.py", "exec").co_filename` | `'\udcff.py'` | `'\udcff.py'` | `'<string>'` |
| `compile(s, '\udcff.py', "exec")` | `'\udcff.py'` | `'\udcff.py'` | UnicodeEncodeError |
| filename with `__fspath__` | `'\udcff.py'` | `'\udcff.py'` | `'<string>'` |
| `compile(s, 42, "exec")` | TypeError | TypeError | `'<string>'` |
| `compile(s, bytearray(b"ba.py"), "exec")` | TypeError | `'ba.py'` + warning | `'<string>'` |
| `compile(s, "a\x00b.py", "exec")` | ValueError | ValueError | accepted |
| `compile(s, "a.py", 42)` | TypeError | TypeError | silently `exec` |

The first row needs no exotic encoding: a plain ASCII `bytes` filename was lost,
and every traceback, warning and frame built from that code object pointed at
`<string>`. Routing filename through `fsencode_bytes_w` and mode through
`text_w` yields the whole table, since the converter already carries the
deprecation warning, both TypeError spellings and the NUL rejection. The
`bytearray` row is where CPython and PyPy differ; we follow PyPy.

The filename names the whole compilation unit, so nested constants inherit it
when they are boxed — otherwise `outer.co_filename` was exact while
`outer.co_consts[0]` and the function's `__code__` stayed lossy. That is what
separates it from `pycode.py:431`, whose constructor and `replace` filenames
rename only the object being built, so the two get separate entry points.

## repr built in a buffer that could not hold what it was given

`code_repr` formatted `source_path`, so after `c.replace(co_filename=...)` it
reported the name the object was compiled under, not the current one. It now
builds from `code_filename_bytes` as WTF-8, the way `pycode.py:570 repr` reaches
for the filename's `utf8_w`.

That made a code object the second thing whose repr can carry a lone surrogate,
and `py_repr_wtf8` was a hand-maintained prelude listing such types before
delegating to `py_repr`, whose `String` cannot hold one. Frames were on the list
and code objects were not, so `repr(code)` **aborted** in `w_str_get_value`.
Any new such type repeats that, and the delegation also lost the surrogate for
every container — reachable on `main` today, independent of this change:

```python
class C:
    def __repr__(self): return "s\udcff"
repr(C())     # 's\udcff'   exact
repr([C()])   # was '[s�]'; CPython and PyPy give '[s\udcff]'
```

So the two are inverted: `py_repr_wtf8` / `py_str_wtf8` carry the whole
dispatch, `py_repr` / `py_str` are lossy views of them for the ~109 callers that
genuinely want a Rust `String` (error-message interpolation and the like), and
the prelude's per-type carve-outs are deleted rather than extended. `dict_repr`,
`list_repr`, `tuple_repr`, `array_repr_wtf8`, the deque / set / frozenset /
slice / range / structseq / exception formatting, and the `!r` conversion in
f-strings, `str.format` and the descriptor slots build a `Wtf8Buf` and recurse
through `py_repr_wtf8` — the same shape as `listobject.py:206-225
_listrepr_inner`, which appends `space.utf8_len_w(space.repr(w_item))` into a
`rutf8.Utf8StringBuilder`.

No repr's text changes. `ReprGuard::enter` and the `stack_check()` are
untouched, so `[[...]]`, `{1: {...}}` and the `RecursionError` on a
200000-deep list all still hold, and every slot keeps the allocation kind it
had (a per-call `__repr__` result stays GC-managed rather than becoming an
immortal `malloc_raw` buffer).

Buffer assembly did cost one thing, caught by the Codex parity review: the
`parts.join(", ")` it replaced separates by **position**, while emitting a
separator whenever the buffer is non-empty separates by *what was written*. An
item whose `__repr__` answers `""` writes nothing, so the next item lost its
separator — `repr([E(), E()])` gave `[]`, and `repr(ValueError(E(), E()))`
gave `ValueError()`. All four sites now go by index, `dict_repr` included
(which was accidentally safe, since its `": "` always lands).

## putenv wrote its value through a lossy decode

`os.putenv` / `os.unsetenv` take both halves through the same `'fsencode'`
converter, and `posix.environ` already hands entries back as bytes, so a value
spelling a byte with no UTF-8 form has to survive the write. They now carry
`Vec<u8>` to `set_var` / `remove_var` — which already accept `impl AsRef<OsStr>`,
so no change outside pyre was needed — with the NUL rejection and the
`interp_posix.py:1762-1769` key rule (`=` illegal only after index 0, so the
`=C:` form Windows uses for a working directory stays legal).

## Verification

- `pyre/extra_tests/parity_tests` (176): **no `dynasm=FAIL`**. The one failure is
  `type_members_python314.py cpython=FAIL`, the system CPython, not pyre.
- `pyre/extra_tests` dynasm: **235/241**, up from 234; the remaining six are a
  subset of the previous seven.
- `cargo test -p pyre-interpreter --features dynasm`: 490 passed, 0 failed.
- New `compile_filename_boundary.py`, `repr_surrogate_wtf8.py`,
  `repr_empty_item_separator.py` and the extended
  `os_boundary_surrogateescape.py` pass under CPython and PyPy too; the
  `bytearray` filename row is left out because CPython and PyPy disagree there.

## Not in this change

- `_path_splitroot` and the Windows `arg_path` still go through text. Both are
  text-level operations on a name rather than a syscall boundary, and each
  carries the reason in place.
- `os.execve` reports no filename, which is what `interp_posix.py:1812,1817`
  does and what this branch's base did. CPython reports the program path there;
  the divergence predates this change.
- A `String`-returning `#[pymethod]` is wrapped with `w_str_new`, which is the
  immortal `malloc_raw` path — so `deque.__repr__` and its neighbours leak per
  call. That predates this change and is a macro-level fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved non-UTF-8 filesystem paths and surrogate characters across file operations, process execution, environment handling, and related errors.
  * Improved `compile()` filename handling, including path-like values, invalid inputs, syntax errors, and code-object representations.
  * Corrected string and representation formatting for nested containers, exceptions, deques, arrays, and empty items.
* **Tests**
  * Added comprehensive coverage for path boundaries, surrogate escaping, WTF-8 representations, and filesystem error behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->