### PR TITLE
type: identify object's class methods by the callable, not the qualname

### DIFF
--- a/pyre/extra_tests/parity_tests/classmethod_protocol.py
+++ b/pyre/extra_tests/parity_tests/classmethod_protocol.py
@@ -9,6 +9,7 @@ PyPy's ``__reduce_ex__`` entry and neither implementation makes the wrapper
 callable.
 """
 
+import gc
 import sys
 
 
@@ -251,11 +252,15 @@ assert Forger.__init_subclass__.__qualname__ == "Forger.__init_subclass__"
 assert int.__subclasshook__.__qualname__ == "int.__subclasshook__"
 assert int.__init_subclass__.__qualname__ == "int.__init_subclass__"
 
-# The same reads after enough allocation to drive a collection: whatever
-# records the two carriers has to survive one.
-churn = [[object() for _ in range(64)] for _ in range(2048)]
-assert len(churn) == 2048
-del churn
+# The same reads across a full collection: whatever records the two carriers
+# has to survive one, and survive it as an address rather than as a value the
+# collection is free to relocate. A small live set is allocated first so the
+# collection has something young to promote; `gc.collect()` then forces the
+# major pass without holding a large heap. Its return value differs between
+# implementations, so nothing here reads it.
+promoted = [object() for _ in range(64)]
+gc.collect()
+assert len(promoted) == 64
 assert Forger.hook.__qualname__ == "object.__subclasshook__"
 assert Forger.__subclasshook__.__qualname__ == "Forger.__subclasshook__"
 assert Forger.__init_subclass__.__qualname__ == "Forger.__init_subclass__"

--- a/pyre/extra_tests/parity_tests/classmethod_protocol.py
+++ b/pyre/extra_tests/parity_tests/classmethod_protocol.py
@@ -226,4 +226,38 @@ except TypeError:
 else:
     raise AssertionError("classmethod.__get__(None, None) must fail")
 
+
+# The two METH_CLASS methods inherited from `object` take the qualname of the
+# class they are read off.  A user classmethod is identified by the callable it
+# wraps, not by its `__qualname__`, which is writable and can spell either one.
+class Forger:
+    def hook(cls):
+        pass
+
+    hook.__qualname__ = "object.__subclasshook__"
+    hook = classmethod(hook)
+
+    def init(cls):
+        pass
+
+    init.__qualname__ = "object.__init_subclass__"
+    init = classmethod(init)
+
+
+assert Forger.hook.__qualname__ == "object.__subclasshook__"
+assert Forger.init.__qualname__ == "object.__init_subclass__"
+assert Forger.__subclasshook__.__qualname__ == "Forger.__subclasshook__"
+assert Forger.__init_subclass__.__qualname__ == "Forger.__init_subclass__"
+assert int.__subclasshook__.__qualname__ == "int.__subclasshook__"
+assert int.__init_subclass__.__qualname__ == "int.__init_subclass__"
+
+# The same reads after enough allocation to drive a collection: whatever
+# records the two carriers has to survive one.
+churn = [[object() for _ in range(64)] for _ in range(2048)]
+assert len(churn) == 2048
+del churn
+assert Forger.hook.__qualname__ == "object.__subclasshook__"
+assert Forger.__subclasshook__.__qualname__ == "Forger.__subclasshook__"
+assert Forger.__init_subclass__.__qualname__ == "Forger.__init_subclass__"
+
 print("OK")

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -5505,6 +5505,16 @@ fn getattr_str_impl(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyResul
                 // the generic type dispatch below), never forwarded.
                 "__class__" => {}
                 _ => {
+                    // The Python 3.14 METH_CLASS qualname delta, ahead of the
+                    // forwarding test below: the two carriers it applies to are
+                    // published as `builtin_function_or_method`, whose type
+                    // defines `__qualname__`, so `on_method_type` is true for
+                    // them and the forwarding branch never runs.
+                    if name == "__qualname__" {
+                        if let Some(qualname) = crate::function::method_class_bound_qualname(obj)? {
+                            return Ok(qualname);
+                        }
+                    }
                     // `classobject.c method_getattro` — attributes defined on
                     // the method type win (`__call__` / `__repr__` / `__eq__`
                     // / `__hash__`); any other name is forwarded to `__func__`
@@ -5514,17 +5524,6 @@ fn getattr_str_impl(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyResul
                         .map(|t| lookup_in_type_where(t.as_ptr(), name).is_some())
                         .unwrap_or(false);
                     if !on_method_type {
-                        // Keep the CPython-3.14 METH_CLASS qualname delta in
-                        // Method.descr_method_getattribute's single forwarding
-                        // implementation.  The fast path here otherwise
-                        // bypasses that method entirely.
-                        if name == "__qualname__" {
-                            if let Some(qualname) =
-                                crate::function::method_class_bound_qualname(obj)?
-                            {
-                                return Ok(qualname);
-                            }
-                        }
                         let func = pyre_object::function::w_method_get_func(obj);
                         if !func.is_null() {
                             return getattr_str(func, name);

--- a/pyre/pyre-interpreter/src/function.rs
+++ b/pyre/pyre-interpreter/src/function.rs
@@ -2792,6 +2792,41 @@ pub unsafe fn descr_method_getattribute(
     crate::baseobjspace::getattr_str(function, name)
 }
 
+/// The callables `object` publishes as class methods, paired with the name
+/// each is published under.
+///
+/// Only these two take a bound qualname naming the class they were read off,
+/// and `__qualname__` is writable on an ordinary function, so they have to be
+/// recognised by identity.  `Box` so a slot keeps one address for the
+/// collector's whole lifetime; the `Vec` only owns them.
+static OBJECT_CLASS_METHODS: std::sync::Mutex<Vec<(&'static str, Box<usize>)>> =
+    std::sync::Mutex::new(Vec::new());
+
+/// Publish `function` as `object.<name>` for [`method_class_bound_qualname`].
+///
+/// The address is registered as a process-lifetime GC root so the collector
+/// forwards it, the `intern_str` idiom: nothing else keeps this raw copy in
+/// step with a moving collection.
+pub fn register_object_class_method(name: &'static str, function: PyObjectRef) {
+    let mut slot = Box::new(function as usize);
+    let root_slot = (&mut *slot) as *mut usize as *mut *mut u8;
+    unsafe { pyre_object::gc_hook::try_gc_add_root(root_slot) };
+    OBJECT_CLASS_METHODS
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .push((name, slot));
+}
+
+/// The name `object` publishes `function` under, if it publishes it at all.
+fn object_class_method_name(function: PyObjectRef) -> Option<&'static str> {
+    OBJECT_CLASS_METHODS
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .iter()
+        .find(|(_, slot)| **slot == function as usize)
+        .map(|(name, _)| *name)
+}
+
 /// Python 3.14's dynamic qualname for the two METH_CLASS methods inherited
 /// from `object`; `None` for every ordinary bound method.
 pub unsafe fn method_class_bound_qualname(
@@ -2802,12 +2837,12 @@ pub unsafe fn method_class_bound_qualname(
     if !unsafe { pyre_object::is_type(instance) } {
         return Ok(None);
     }
-    let function_qualname = unsafe { function_get_qualname(function) };
-    let inherited_name = if function_qualname == "object.__subclasshook__" {
-        "__subclasshook__"
-    } else if function_qualname == "object.__init_subclass__" {
-        "__init_subclass__"
-    } else {
+    // Identify the two by the callables `object` publishes, not by their
+    // qualname: `__qualname__` is writable on an ordinary function, so a
+    // classmethod over one that spells itself `object.__subclasshook__` would
+    // otherwise be rewritten to name its own owner instead of keeping the
+    // string it was given.
+    let Some(inherited_name) = object_class_method_name(function) else {
         return Ok(None);
     };
     let owner_qualname = crate::baseobjspace::getattr_str(instance, "__qualname__")?;

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -18925,42 +18925,54 @@ fn init_object_type(ns: PyObjectRef) {
     // keywords; class-definition keywords reaching it via the builtin
     // kwargs ABI are an error, not silently dropped.
     unsafe {
+        let init_subclass = pyre_object::function::w_classmethod_new(make_builtin_function(
+            "__init_subclass__",
+            |args| {
+                let (_, kwargs) = crate::builtins::split_builtin_kwargs(args);
+                if let Some(kw) = kwargs {
+                    let has_real_kw = unsafe {
+                        pyre_object::w_dict_items(kw).into_iter().any(|(k, _)| {
+                            pyre_object::is_str(k)
+                                && pyre_object::w_str_get_wtf8(k).as_str() != Ok("__pyre_kw__")
+                        })
+                    };
+                    if has_real_kw {
+                        return Err(crate::PyError::type_error(
+                            "__init_subclass__() takes no keyword arguments",
+                        ));
+                    }
+                }
+                Ok(pyre_object::w_none())
+            },
+        ));
+        // Read the wrapped callable back out of the classmethod: allocating it
+        // can move the function, and the qualname lookup compares addresses.
+        crate::function::register_object_class_method(
+            "__init_subclass__",
+            pyre_object::function::w_classmethod_get_func(init_subclass),
+        );
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
             ns,
             "__init_subclass__",
-            pyre_object::function::w_classmethod_new(make_builtin_function(
-                "__init_subclass__",
-                |args| {
-                    let (_, kwargs) = crate::builtins::split_builtin_kwargs(args);
-                    if let Some(kw) = kwargs {
-                        let has_real_kw = unsafe {
-                            pyre_object::w_dict_items(kw).into_iter().any(|(k, _)| {
-                                pyre_object::is_str(k)
-                                    && pyre_object::w_str_get_wtf8(k).as_str() != Ok("__pyre_kw__")
-                            })
-                        };
-                        if has_real_kw {
-                            return Err(crate::PyError::type_error(
-                                "__init_subclass__() takes no keyword arguments",
-                            ));
-                        }
-                    }
-                    Ok(pyre_object::w_none())
-                },
-            )),
+            init_subclass,
         )
     };
     unsafe {
+        // objectobject.py:413 `interp2app(descr___subclasshook__,
+        // as_classmethod=True)` — the hook receives the class it is
+        // consulted for, so a read off any type binds to that type.
+        let subclasshook = pyre_object::function::w_classmethod_new(make_builtin_function(
+            "__subclasshook__",
+            |_| Ok(pyre_object::w_not_implemented()),
+        ));
+        crate::function::register_object_class_method(
+            "__subclasshook__",
+            pyre_object::function::w_classmethod_get_func(subclasshook),
+        );
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
             ns,
             "__subclasshook__",
-            // objectobject.py:413 `interp2app(descr___subclasshook__,
-            // as_classmethod=True)` — the hook receives the class it is
-            // consulted for, so a read off any type binds to that type.
-            pyre_object::function::w_classmethod_new(make_builtin_function(
-                "__subclasshook__",
-                |_| Ok(pyre_object::w_not_implemented()),
-            )),
+            subclasshook,
         )
     };
     // PyPy: objectobject.py descr___setattr__


### PR DESCRIPTION
`method_class_bound_qualname` selected `object.__subclasshook__` and
`object.__init_subclass__` by comparing the wrapped function's `__qualname__`
against those two strings. `__qualname__` is writable on an ordinary function,
so a classmethod over one that spelled itself `object.__subclasshook__` was
rewritten to name its own owner instead of answering the string it was given.

`init_object_type` now registers the two callables it publishes in slots held as
process-lifetime GC roots, and the selection compares addresses against those.
The address is read back out of the classmethod, since allocating it can move
the function.

The read off a class was reaching neither carrier: the delta sat inside
`descr__getattribute__`'s `!on_method_type` branch, and the two are published as
`builtin_function_or_method`, whose type defines `__qualname__` — so the branch
was skipped for exactly the objects the delta is about, and ran only for the
user functions it is not about. It now runs ahead of that test.

```python
class A:
    def f(cls): pass
    f.__qualname__ = "object.__subclasshook__"
    f = classmethod(f)
```

| read | before | after / CPython 3.14 |
| --- | --- | --- |
| `A.f.__qualname__` | `'A.__subclasshook__'` | `'object.__subclasshook__'` |
| `A.__subclasshook__.__qualname__` | `'object.__subclasshook__'` | `'A.__subclasshook__'` |

Both directions were wrong before, in opposite ways.

## Verification

Measured on this branch (`origin/main` + this commit), after re-extracting LLBC
for the new base:

- `pyre/check.py --backend dynasm --synthetic-only`: **357 passed, 1 failed**.
  The single failure is `int_lshift_memoryerror  pypy crash`, which is the
  *oracle* aborting: that fixture drives an allocation past the limit to prove
  the result is a catchable `MemoryError`, and the run had `PYPY_GC_MAX` set in
  its environment, under which PyPy answers `using too much memory, aborting`
  instead. Without it `pypy3` runs the fixture clean. Not attributable to this
  change.
- Parity suites, `PYRE_NO_JIT=1` and JIT, all OK: `classmethod_protocol`,
  `exception_context_generator_python314`, `object_surface_python314`,
  `function_python314`, `type_members_python314`,
  `type_descriptor_surface_python314`.
- `classmethod_protocol.py` gains the four-way check plus a re-read after enough
  allocation to drive a collection, since the registered slots have to survive
  one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected `__qualname__` reporting for inherited class methods, including `__init_subclass__` and `__subclasshook__`.
  * Ensured class method names remain accurate when accessed through subclasses or after memory-management activity.
  * Preserved existing behavior for keyword handling and unsupported subclass hooks.

* **Tests**
  * Added coverage for class method qualification and inheritance scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->