### PR TITLE
jit(#346): carry usize slice bounds through annotation; dominance-threaded operands; oparg signedness

### DIFF
--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -14868,11 +14868,14 @@ fn tyref_to_value_type(ty: &TyRef, llbc: &Llbc) -> ValueType {
         return inner;
     }
     // `OpArg` and compiler-core's `newtype_oparg!` wrappers are transparent
-    // u32 bytecode operands.  Their dependency declarations are opaque in
-    // interpreter LLBC, so model the exact upstream family as bare integers
-    // (`tyref_is_oparg`).
+    // `u32` bytecode operands.  Their dependency declarations are opaque in
+    // interpreter LLBC, so model the exact upstream family as unsigned
+    // integers (`tyref_is_oparg`).  This is not merely a register-bank
+    // choice: `SomeInteger(unsigned=True)` carries the non-negative fact
+    // through annotation, which is required when an oparg-derived count is
+    // passed to a `u32`/`usize` helper.
     if tyref_is_oparg(ty, llbc) {
-        return ValueType::Int;
+        return ValueType::Unsigned;
     }
     // A fieldless (C-like) enum is represented by-value as its
     // discriminant integer — RPython has no enum type; a fieldless enum

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -2159,26 +2159,6 @@ fn lower_unstructured_with_static_addrs_and_attrs(
                 &lo.next_call_results,
             );
         }
-        // The consumer-gated RangeTo sub-slice capstone remains built but
-        // dormant: aggregate lowering records no sites. If capture is safely
-        // restored, it becomes `getslice(s, 0, k)`; a structural decline
-        // leaves the residual ctor + index chain intact.
-        // `prune_dead_phis` to reclaim the dead threaded RangeTo inputarg /
-        // link args (the getslice never reads them) — run it unconditionally
-        // on any rewrite rather than relying on the gated sweep in
-        // `simplify_lowered_graph`. Fail-safe: a structural mismatch leaves
-        // the residual ctor + index call (rtyper Skip) and touches nothing.
-        let slice_index_rangeto_rewritten = if lo.slice_index_rangeto_sites.is_empty() {
-            0
-        } else {
-            crate::front::slice_index::rewire_slice_index_rangeto_sites(
-                &mut lo.graph,
-                &lo.slice_index_rangeto_sites,
-            )
-        };
-        if slice_index_rangeto_rewritten > 0 {
-            crate::model::prune_dead_phis(&mut lo.graph);
-        }
         let next_rewritten = if lo.next_call_results.is_empty() {
             0
         } else {
@@ -2810,9 +2790,6 @@ struct Lowering<'a> {
     /// after the body lowering completes (see
     /// [`crate::front::slice_first::SliceFirstSite`]).
     slice_first_sites: Vec<crate::front::slice_first::SliceFirstSite>,
-    /// `RangeTo` aggregates recorded for the orthodox sub-slice copy rewrite
-    /// in `front::slice_index`.
-    slice_index_rangeto_sites: Vec<crate::front::slice_index::SliceIndexRangeToSite>,
     /// `{uN}::saturating_sub(a, b)` call sites recorded for the unsigned clamp
     /// diamond (`if a < b { 0 } else { a - b }`) the
     /// `front::saturating_sub` post-pass synthesizes after body lowering (see
@@ -3050,7 +3027,6 @@ impl<'a> Lowering<'a> {
             option_try_sites: Vec::new(),
             bool_then_sites: Vec::new(),
             slice_first_sites: Vec::new(),
-            slice_index_rangeto_sites: Vec::new(),
             saturating_sub_sites: Vec::new(),
             range_inclusive_new_sites: Vec::new(),
             range_iter_new_sites: Vec::new(),
@@ -4763,10 +4739,11 @@ impl<'a> Lowering<'a> {
                 // legacy walker with an uncolored Void stop. Activating
                 // RangeTo later exposed bare `getslice/rii>r` in both
                 // `split_builtin_kwargs` and `do_warn_explicit`: both stops
-                // are statically unsigned, so the non-negative-stop gate
-                // cannot distinguish the unsafe sites. Leave both captures
-                // disabled until the codewriter is guaranteed to consume the
-                // rtyped graph where `rtype_getslice` has replaced the op.
+                // are `args.len() - 1`, statically unsigned but not constant.
+                // The recognizer's const-nonnegative gate declines them; both
+                // captures remain disabled until the codewriter is guaranteed
+                // to consume the rtyped graph where `rtype_getslice` has
+                // replaced the op.
                 // Surface every operand through a separate FieldWrite so
                 // the field-to-value binding survives into the
                 // codewriter / annotator.  Field names default to

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -2159,21 +2159,26 @@ fn lower_unstructured_with_static_addrs_and_attrs(
                 &lo.next_call_results,
             );
         }
-        // NOTE: the `&s[k..]` (`RangeFrom` sub-slice) → orthodox `getslice`
-        // copy recognizer (`front::slice_index`) is DORMANT — it is not wired
-        // into the pipeline here.  Empirically (census build 8c68710) it is a
-        // CAPSTONE, not a standalone slice: `getslice` + its Void `ConstNone`
-        // stop are UNWIRED at the legacy walker (unlike `slice_first`'s
-        // legacy-safe `ArrayRead`/`ConstInt`/discriminant ops), so planting
-        // them into a graph that still drops to legacy — which every real
-        // `&args[1..]` interpreter method does, blocked by a co-wall such as
-        // the scalar `args[1..][0]` slice index or a `compute_at_fixpoint`
-        // failure — crashes regalloc on the Void `ConstNone`
-        // (`assembler.rs:2529 lookup_coloring`) or breaks the unwired-opname
-        // snapshot on the bare `getslice`.  The recognizer, `ConstNone`, and
-        // the `getslice` rtyper lowering stay built + tested so the capstone
-        // can activate once these graphs' co-walls close (mirrors the dormant
-        // vec!/`NewList` recognizer, `design-346-foreign-lib-cluster-epic.md`).
+        // The consumer-gated RangeTo sub-slice capstone remains built but
+        // dormant: aggregate lowering records no sites. If capture is safely
+        // restored, it becomes `getslice(s, 0, k)`; a structural decline
+        // leaves the residual ctor + index chain intact.
+        // `prune_dead_phis` to reclaim the dead threaded RangeTo inputarg /
+        // link args (the getslice never reads them) — run it unconditionally
+        // on any rewrite rather than relying on the gated sweep in
+        // `simplify_lowered_graph`. Fail-safe: a structural mismatch leaves
+        // the residual ctor + index call (rtyper Skip) and touches nothing.
+        let slice_index_rangeto_rewritten = if lo.slice_index_rangeto_sites.is_empty() {
+            0
+        } else {
+            crate::front::slice_index::rewire_slice_index_rangeto_sites(
+                &mut lo.graph,
+                &lo.slice_index_rangeto_sites,
+            )
+        };
+        if slice_index_rangeto_rewritten > 0 {
+            crate::model::prune_dead_phis(&mut lo.graph);
+        }
         let next_rewritten = if lo.next_call_results.is_empty() {
             0
         } else {
@@ -2805,6 +2810,9 @@ struct Lowering<'a> {
     /// after the body lowering completes (see
     /// [`crate::front::slice_first::SliceFirstSite`]).
     slice_first_sites: Vec<crate::front::slice_first::SliceFirstSite>,
+    /// `RangeTo` aggregates recorded for the orthodox sub-slice copy rewrite
+    /// in `front::slice_index`.
+    slice_index_rangeto_sites: Vec<crate::front::slice_index::SliceIndexRangeToSite>,
     /// `{uN}::saturating_sub(a, b)` call sites recorded for the unsigned clamp
     /// diamond (`if a < b { 0 } else { a - b }`) the
     /// `front::saturating_sub` post-pass synthesizes after body lowering (see
@@ -3042,6 +3050,7 @@ impl<'a> Lowering<'a> {
             option_try_sites: Vec::new(),
             bool_then_sites: Vec::new(),
             slice_first_sites: Vec::new(),
+            slice_index_rangeto_sites: Vec::new(),
             saturating_sub_sites: Vec::new(),
             range_inclusive_new_sites: Vec::new(),
             range_iter_new_sites: Vec::new(),
@@ -4213,11 +4222,17 @@ impl<'a> Lowering<'a> {
                 // (`SignedLongLongLong` / `UnsignedLongLongLong`), so
                 // collapsing an i128/u128 destination to the word-sized
                 // `Int` carrier here loses the exact RPython low-level type
-                // before the rtyper can see it.  f64 similarly stays Float;
-                // comparisons (bool), ordinary integer math, and
-                // checked-arithmetic `(int, bool)` tuple destinations use
-                // the word-sized Int carrier.
-                let result_ty = match tyref_to_value_type(dest_ty, self.llbc) {
+                // before the rtyper can see it. f64 similarly stays Float.
+                // Charon represents a checked arithmetic result as
+                // `(numeric, bool)`, but this lowering deliberately binds the
+                // destination local to the scalar `.0` value (see
+                // `binop_result_locals`). Project that numeric element's Rust
+                // type before choosing the annotation shell: in particular,
+                // a `usize` subtraction is an unsigned/non-negative value by
+                // type, even though its MIR destination is a tuple.
+                let scalar_ty = tyref_checked_binop_value_type(dest_ty, self.llbc)
+                    .unwrap_or_else(|| tyref_to_value_type(dest_ty, self.llbc));
+                let result_ty = match scalar_ty {
                     ValueType::Float => ValueType::Float,
                     ValueType::Unsigned => ValueType::Unsigned,
                     ValueType::Int128 => ValueType::Int128,
@@ -4742,15 +4757,16 @@ impl<'a> Lowering<'a> {
                             end: arg_vars[1].clone(),
                         });
                 }
-                // NOTE: `RangeFrom { start }` aggregate (`&s[k..]`) capture for
-                // `front::slice_index`'s orthodox `getslice` copy is DORMANT —
-                // the recognizer is a capstone that cannot plant its unwired
-                // `getslice` + Void `ConstNone` into the co-wall-blocked
-                // `&args[1..]` graphs without crashing the legacy walker (see
-                // the companion note in
-                // `lower_unstructured_with_static_addrs_and_attrs`).  Re-enable
-                // the `slice_index_rangefrom_sites` push here + the post-pass
-                // once those graphs' co-walls close.
+                // NOTE: RangeFrom and RangeTo capture are DORMANT. Their
+                // rewrites plant `getslice`, which has no blackhole handler.
+                // RangeFrom first exposed this when a graph dropped to the
+                // legacy walker with an uncolored Void stop. Activating
+                // RangeTo later exposed bare `getslice/rii>r` in both
+                // `split_builtin_kwargs` and `do_warn_explicit`: both stops
+                // are statically unsigned, so the non-negative-stop gate
+                // cannot distinguish the unsafe sites. Leave both captures
+                // disabled until the codewriter is guaranteed to consume the
+                // rtyped graph where `rtype_getslice` has replaced the op.
                 // Surface every operand through a separate FieldWrite so
                 // the field-to-value binding survives into the
                 // codewriter / annotator.  Field names default to
@@ -15872,6 +15888,32 @@ fn tyref_is_tuple(ty: &TyRef, llbc: &Llbc) -> bool {
     is_tuple && non_empty
 }
 
+/// The numeric `.0` type of Charon's checked-arithmetic `(numeric, bool)`
+/// destination. The MIR front-end represents that tuple local as the scalar
+/// arithmetic result, so its [`ValueType`] must come from the tuple's first
+/// Rust type argument rather than from the aggregate tuple itself.
+fn tyref_checked_binop_value_type(ty: &TyRef, llbc: &Llbc) -> Option<ValueType> {
+    let adt = tyref_node(ty, llbc)?.as_object()?.get("Adt")?.as_object()?;
+    if adt.get("id").and_then(serde_json::Value::as_str) != Some("Tuple") {
+        return None;
+    }
+    let types = adt.get("generics")?.as_object()?.get("types")?.as_array()?;
+    if types.len() != 2 {
+        return None;
+    }
+    let overflow_ty = strip_ty_wrappers(&types[1], llbc)?;
+    if overflow_ty
+        .as_object()?
+        .get("Literal")
+        .and_then(serde_json::Value::as_str)
+        != Some("Bool")
+    {
+        return None;
+    }
+    let value_ty = strip_ty_wrappers(&types[0], llbc)?;
+    Some(tyref_to_value_type(&TyRef::Other(value_ty.clone()), llbc))
+}
+
 /// True when `ty` is Charon's unit type `()`.
 ///
 /// Unit serializes as an `Adt` carrying the synthetic `"Tuple"`
@@ -23130,6 +23172,56 @@ mod tests {
             lt_guards >= 1 && subs >= 1,
             "generic_alias_class_getitem: expected the a<b guard and the a-b subtraction \
              (lt={lt_guards}, sub={subs})"
+        );
+    }
+
+    /// Real-LLBC anchor for the `usize` stop in
+    /// `split_builtin_kwargs`'s `&args[..args.len() - 1]`. Rust's checked
+    /// MIR represents the subtraction destination as `(usize, bool)`, while
+    /// the graph deliberately collapses its `.0` projection to the scalar
+    /// arithmetic result. That scalar must retain the tuple's `usize`
+    /// element type so annotation learns it is unsigned/non-negative.
+    #[test]
+    #[ignore]
+    fn split_builtin_kwargs_getslice_stop_is_unsigned() {
+        use crate::model::{OpKind, ValueType};
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../build/llbc/pyre-interpreter.ullbc"
+        );
+        let llbc = Llbc::load(path).expect("load real LLBC");
+        let graph = super::lower_function(&llbc, "split_builtin_kwargs")
+            .expect("lower split_builtin_kwargs");
+        let stop = graph
+            .blocks
+            .iter()
+            .flat_map(|b| b.operations.iter())
+            .find_map(|op| match &op.kind {
+                OpKind::GetSlice { args } => args.get(2).cloned(),
+                _ => None,
+            })
+            .expect("RangeTo rewrite must emit getslice stop");
+        let producer = graph
+            .blocks
+            .iter()
+            .flat_map(|b| b.operations.iter())
+            .find(|op| {
+                op.result
+                    .as_ref()
+                    .is_some_and(|result| result.id() == stop.id())
+            })
+            .expect("getslice stop producer");
+        assert!(
+            matches!(
+                &producer.kind,
+                OpKind::BinOp {
+                    op,
+                    result_ty: ValueType::Unsigned,
+                    ..
+                } if op == "sub"
+            ),
+            "usize stop producer must be an unsigned subtraction, got {:?}",
+            producer.kind
         );
     }
 

--- a/majit/majit-translate/src/front/slice_index.rs
+++ b/majit/majit-translate/src/front/slice_index.rs
@@ -9,9 +9,11 @@
 //! `pyre_interpreter::module::_io::buffered_rwpair::<Impl>::readinto` graph
 //! dropped to the legacy walker. Activating RangeTo later emitted bare
 //! `getslice/rii>r` from both `split_builtin_kwargs` and `do_warn_explicit`;
-//! both stops are statically unsigned, so that gate cannot prove the planted
-//! op will be consumed from the rtyped graph. Both capture arms remain dormant
-//! and leave the original residual ctor + call chain untouched.
+//! both stops are `args.len() - 1`, statically unsigned but not constant. An
+//! unsigned gate would admit those measured failures, while the same
+//! constant-nonnegative gate used for RangeFrom declines them. Both capture
+//! arms remain dormant and leave the original residual ctor + call chain
+//! untouched.
 #![allow(dead_code)]
 //!
 //! ## Positioning
@@ -190,8 +192,8 @@ fn rewire_one_slice_index_site(
         ));
     }
 
-    // 3. Validate the selected bounds before mutating. A RangeFrom `start`
-    // must be a NON-NEGATIVE CONSTANT. `decompose_slice_args`
+    // 3. Validate the selected bounds before mutating. Both bounds must be a
+    // NON-NEGATIVE CONSTANT. `decompose_slice_args`
     //     (rtyper.rs:2809-2816) raises "slice start must be proved
     //     non-negative" for a `nonneg==false` runtime `SomeInteger` start, and
     //     a `usize` literal decodes to a bare `OpKind::ConstInt(k)` with no
@@ -202,7 +204,11 @@ fn rewire_one_slice_index_site(
     //     (the `&s[1..]` / `&s[k..]` literal shape, which
     //     `immutablevalue(ConstInt(k))` annotates `nonneg = k>=0`) keeps every
     //     rewritten graph lift-able; a computed start declines cleanly
-    //     (residual, census Skip).
+    //     (residual, census Skip). RangeTo uses the same constant gate because
+    //     activating it admitted bare unwired `getslice/rii>r` from
+    //     `split_builtin_kwargs` and `do_warn_explicit`; both measured ends
+    //     were `args.len() - 1`, statically unsigned but not constant, so an
+    //     unsigned-only gate would not decline them.
     match bounds {
         SliceIndexBounds::RangeFrom { start } => {
             if !graph_defines(graph, start) {
@@ -210,7 +216,7 @@ fn rewire_one_slice_index_site(
                     "{name}: RangeFrom start is not defined in the graph"
                 ));
             }
-            if !start_is_const_nonneg(graph, start) {
+            if !bound_is_const_nonneg(graph, start) {
                 return Err(format!(
                     "{name}: RangeFrom start is not a non-negative constant — declining"
                 ));
@@ -219,6 +225,11 @@ fn rewire_one_slice_index_site(
         SliceIndexBounds::RangeTo { end } => {
             if !graph_defines(graph, end) {
                 return Err(format!("{name}: RangeTo end is not defined in the graph"));
+            }
+            if !bound_is_const_nonneg(graph, end) {
+                return Err(format!(
+                    "{name}: RangeTo end is not a non-negative constant — declining"
+                ));
             }
         }
     }
@@ -426,7 +437,7 @@ fn graph_defines(graph: &FunctionGraph, var: &Variable) -> bool {
 /// `immutablevalue(ConstInt(k))` annotates as `SomeInteger` with
 /// `nonneg = k>=0`, so a const k ≥ 0 satisfies the getslice nonneg contract
 /// without a computed-stop hazard.
-fn start_is_const_nonneg(graph: &FunctionGraph, var: &Variable) -> bool {
+fn bound_is_const_nonneg(graph: &FunctionGraph, var: &Variable) -> bool {
     graph.blocks.iter().any(|b| {
         b.operations.iter().any(|op| {
             op.result.as_ref() == Some(var) && matches!(&op.kind, OpKind::ConstInt(k) if *k >= 0)
@@ -591,20 +602,7 @@ mod tests {
         let mut g = FunctionGraph::new("test_slice_index_rangeto");
         let a = g.startblock;
         let slice = g.push_op_var(a, OpKind::ConstInt(0), true).unwrap();
-        let len = g.push_op_var(a, OpKind::ConstInt(8), true).unwrap();
-        let one = g.push_op_var(a, OpKind::ConstInt(1), true).unwrap();
-        let end = g
-            .push_op_var(
-                a,
-                OpKind::BinOp {
-                    op: "sub".into(),
-                    lhs: len,
-                    rhs: one,
-                    result_ty: ValueType::Int,
-                },
-                true,
-            )
-            .unwrap();
+        let end = g.push_op_var(a, OpKind::ConstInt(7), true).unwrap();
         let range = g
             .push_op_var(
                 a,
@@ -672,6 +670,83 @@ mod tests {
                 .iter()
                 .flat_map(|blk| &blk.operations)
                 .any(|op| is_slice_range_index_call(&op.kind))
+        );
+    }
+
+    /// A RangeTo whose end is computed at runtime declines even when its Rust
+    /// type is unsigned. The measured `args.len() - 1` sites have this shape
+    /// and produced bare unwired `getslice/rii>r` when admitted.
+    #[test]
+    fn rewrite_declines_runtime_end() {
+        let mut g = FunctionGraph::new("test_slice_index_rangeto_runtime");
+        let a = g.startblock;
+        let slice = g.push_op_var(a, OpKind::ConstInt(0), true).unwrap();
+        let len = g.push_op_var(a, OpKind::ConstInt(8), true).unwrap();
+        let one = g.push_op_var(a, OpKind::ConstInt(1), true).unwrap();
+        let end = g
+            .push_op_var(
+                a,
+                OpKind::BinOp {
+                    op: "sub".into(),
+                    lhs: len,
+                    rhs: one,
+                    result_ty: ValueType::Unsigned,
+                },
+                true,
+            )
+            .unwrap();
+        let range = g
+            .push_op_var(
+                a,
+                OpKind::Call {
+                    target: rangeto_ctor_target(),
+                    args: Vec::new(),
+                    result_ty: ValueType::Ref(Some("core::ops::range::RangeTo".into())),
+                },
+                true,
+            )
+            .unwrap();
+        g.block_mut(a).operations.push(SpaceOperation {
+            result: None,
+            kind: end_field_write(&range, &end),
+        });
+        let sub = g
+            .push_op_var(
+                a,
+                OpKind::Call {
+                    target: slice_index_call_target(),
+                    args: vec![slice, range.clone()],
+                    result_ty: ValueType::Ref(None),
+                },
+                true,
+            )
+            .unwrap();
+        let (b, _b_args) = g.create_block_with_arg_vars(1);
+        g.set_return(b, None);
+        g.set_goto(a, b, vec![sub]);
+
+        let site = SliceIndexRangeToSite {
+            range_result: range,
+            end,
+        };
+        assert_eq!(
+            rewire_slice_index_rangeto_sites(&mut g, &[site]),
+            0,
+            "runtime RangeTo end declines"
+        );
+        assert!(
+            g.blocks
+                .iter()
+                .flat_map(|blk| &blk.operations)
+                .any(|op| is_slice_range_index_call(&op.kind)),
+            "residual slice::index call remains"
+        );
+        assert!(
+            !g.blocks
+                .iter()
+                .flat_map(|blk| &blk.operations)
+                .any(|op| matches!(&op.kind, OpKind::GetSlice { .. })),
+            "no getslice is planted on decline"
         );
     }
 

--- a/majit/majit-translate/src/front/slice_index.rs
+++ b/majit/majit-translate/src/front/slice_index.rs
@@ -7,11 +7,19 @@
 //! `front::mir`: its rewrite plants a Void `ConstNone` stop, which had no
 //! regalloc coloring when the rewritten
 //! `pyre_interpreter::module::_io::buffered_rwpair::<Impl>::readinto` graph
-//! dropped to the legacy walker. Activating RangeTo later emitted bare
-//! `getslice/rii>r` from both `split_builtin_kwargs` and `do_warn_explicit`;
-//! both stops are `args.len() - 1`, statically unsigned but not constant. An
-//! unsigned gate would admit those measured failures, while the same
-//! constant-nonnegative gate used for RangeFrom declines them. Both capture
+//! dropped to the legacy walker.
+//!
+//! RangeTo's primary blocker is semantic: Rust's `&s[..end]` panics when
+//! `end > s.len()`, but `build_ll_listslice_startstop_helper_graph` clamps an
+//! oversized stop to the list length and returns the whole slice
+//! (`translator/rtyper/rlist.rs:3563-3576`). Until lowering can prove
+//! `end <= len`, emitting `getslice(s, 0, end)` would turn an interpreter
+//! failure into success. Its secondary blocker is non-negativity: activating
+//! RangeTo previously emitted bare `getslice/rii>r` from
+//! `split_builtin_kwargs` and `do_warn_explicit`; both stops are
+//! `args.len() - 1`, statically unsigned but not constant. An unsigned gate
+//! would admit those measured failures, while the constant-nonnegative gate
+//! declines them. The upper-bound proof is still missing, so both capture
 //! arms remain dormant and leave the original residual ctor + call chain
 //! untouched.
 #![allow(dead_code)]
@@ -122,7 +130,9 @@ pub(crate) fn rewire_slice_index_rangefrom_sites(
 }
 
 /// Rewrite captured `RangeTo { end }` indexes into
-/// `getslice(slice, 0, end)` (`SliceKind::StartStop`).
+/// `getslice(slice, 0, end)` (`SliceKind::StartStop`). Production capture must
+/// remain dormant until it can prove `end <= slice.len()`; the StartStop
+/// helper clamps instead of preserving Rust's out-of-bounds panic.
 pub(crate) fn rewire_slice_index_rangeto_sites(
     graph: &mut FunctionGraph,
     sites: &[SliceIndexRangeToSite],
@@ -204,11 +214,15 @@ fn rewire_one_slice_index_site(
     //     (the `&s[1..]` / `&s[k..]` literal shape, which
     //     `immutablevalue(ConstInt(k))` annotates `nonneg = k>=0`) keeps every
     //     rewritten graph lift-able; a computed start declines cleanly
-    //     (residual, census Skip). RangeTo uses the same constant gate because
-    //     activating it admitted bare unwired `getslice/rii>r` from
-    //     `split_builtin_kwargs` and `do_warn_explicit`; both measured ends
-    //     were `args.len() - 1`, statically unsigned but not constant, so an
-    //     unsigned-only gate would not decline them.
+    //     (residual, census Skip). RangeTo's constant-nonnegative gate is only
+    //     the secondary blocker: activating it admitted bare unwired
+    //     `getslice/rii>r` from `split_builtin_kwargs` and
+    //     `do_warn_explicit`; both measured ends were `args.len() - 1`,
+    //     statically unsigned but not constant, so an unsigned-only gate would
+    //     not decline them. Even a non-negative constant must not be wired in
+    //     production without the primary `end <= slice.len()` proof: the
+    //     StartStop helper clamps an oversized stop (`rlist.rs:3563-3576`),
+    //     whereas Rust indexing panics.
     match bounds {
         SliceIndexBounds::RangeFrom { start } => {
             if !graph_defines(graph, start) {

--- a/majit/majit-translate/src/front/slice_index.rs
+++ b/majit/majit-translate/src/front/slice_index.rs
@@ -1,25 +1,25 @@
-//! `&s[k..]` (a `RangeFrom` sub-slice index) → orthodox `getslice` copy.
+//! `&s[k..]` / `&s[..k]` sub-slice indexes → orthodox `getslice` copies.
 //!
-//! ## Status: DORMANT capstone (built + tested, not yet wired)
+//! ## Status: RangeTo and RangeFrom dormant
 //!
-//! This recognizer is a CAPSTONE, not a standalone census slice. `getslice`
-//! and its Void `ConstNone` stop operand are UNWIRED at the legacy walker
-//! (unlike `slice_first`'s legacy-safe `ArrayRead`/`ConstInt`/discriminant
-//! ops). Every real `&args[1..]` interpreter method still drops to the legacy
-//! walker — blocked by a co-wall such as the scalar `args[1..][0]` slice index
-//! or a `compute_at_fixpoint` failure — so planting these ops crashes regalloc
-//! on the Void `ConstNone` (`assembler.rs:2529 lookup_coloring`) or breaks the
-//! unwired-opname snapshot on the bare `getslice`. The recognizer therefore
-//! stays built + unit-tested but is NOT invoked from `front::mir`; activate it
-//! (the capture site + post-pass call, both marked with re-enable notes) once
-//! these graphs' co-walls close. Mirrors the dormant vec!/`NewList` capstone
-//! (`design-346-foreign-lib-cluster-epic.md`).
+//! These recognizers are CAPSTONES, not independently wired primitives. The
+//! RangeFrom arm is built and unit-tested but is not captured or invoked from
+//! `front::mir`: its rewrite plants a Void `ConstNone` stop, which had no
+//! regalloc coloring when the rewritten
+//! `pyre_interpreter::module::_io::buffered_rwpair::<Impl>::readinto` graph
+//! dropped to the legacy walker. Activating RangeTo later emitted bare
+//! `getslice/rii>r` from both `split_builtin_kwargs` and `do_warn_explicit`;
+//! both stops are statically unsigned, so that gate cannot prove the planted
+//! op will be consumed from the rtyped graph. Both capture arms remain dormant
+//! and leave the original residual ctor + call chain untouched.
 #![allow(dead_code)]
 //!
 //! ## Positioning
 //!
 //! `&s[k..]` on a `&[T]` slice desugars to
 //! `<[T] as Index<RangeFrom<usize>>>::index(s, RangeFrom { start: k })`.
+//! Its sibling `&s[..k]` uses `RangeTo { end: k }` and rewrites to
+//! `getslice(s, 0, k)` (`SliceKind::StartStop`).
 //! `lower_call` keeps `core::slice::index::<Impl>::index` as an unregistered
 //! residual (the gh#346 census wall), and the `RangeFrom { start }` operand is
 //! built by `front::mir`'s `Rvalue::Aggregate` arm as a
@@ -84,6 +84,14 @@ pub(crate) struct SliceIndexRangeFromSite {
     pub start: Variable,
 }
 
+/// A recognized `RangeTo { end }` aggregate feeding a residual
+/// `core::slice::index::<Impl>::index(slice, range)` call.
+#[derive(Clone)]
+pub(crate) struct SliceIndexRangeToSite {
+    pub range_result: Variable,
+    pub end: Variable,
+}
+
 /// Rewrite every captured `RangeFrom` aggregate that feeds exactly one
 /// residual `slice::index` call into an orthodox `getslice(slice, start,
 /// None)` op. Fail-safe: a site that does not match the expected single-
@@ -95,7 +103,11 @@ pub(crate) fn rewire_slice_index_rangefrom_sites(
 ) -> usize {
     let mut rewritten = 0;
     for site in sites {
-        match rewire_one_slice_index_site(graph, site) {
+        match rewire_one_slice_index_site(
+            graph,
+            &site.range_result,
+            SliceIndexBounds::RangeFrom { start: &site.start },
+        ) {
             Ok(()) => rewritten += 1,
             Err(_decline) => {
                 // Leave the ctor + FieldWrite + residual `slice::index` call;
@@ -107,12 +119,42 @@ pub(crate) fn rewire_slice_index_rangefrom_sites(
     rewritten
 }
 
+/// Rewrite captured `RangeTo { end }` indexes into
+/// `getslice(slice, 0, end)` (`SliceKind::StartStop`).
+pub(crate) fn rewire_slice_index_rangeto_sites(
+    graph: &mut FunctionGraph,
+    sites: &[SliceIndexRangeToSite],
+) -> usize {
+    let mut rewritten = 0;
+    for site in sites {
+        match rewire_one_slice_index_site(
+            graph,
+            &site.range_result,
+            SliceIndexBounds::RangeTo { end: &site.end },
+        ) {
+            Ok(()) => rewritten += 1,
+            Err(_decline) => {
+                // Leave the residual chain intact so legacy keeps its prior
+                // census Skip and never sees a newly planted `getslice`.
+            }
+        }
+    }
+    rewritten
+}
+
+#[derive(Clone, Copy)]
+enum SliceIndexBounds<'a> {
+    RangeFrom { start: &'a Variable },
+    RangeTo { end: &'a Variable },
+}
+
 fn rewire_one_slice_index_site(
     graph: &mut FunctionGraph,
-    site: &SliceIndexRangeFromSite,
+    range_result: &Variable,
+    bounds: SliceIndexBounds<'_>,
 ) -> Result<(), String> {
     let name = graph.name.clone();
-    let range = site.range_result.clone();
+    let range = range_result.clone();
 
     // 1. Locate the residual `slice::index` call consuming the `RangeFrom`
     //    value as its `range` operand (args[1]). Capture its `slice` operand
@@ -148,14 +190,8 @@ fn rewire_one_slice_index_site(
         ));
     }
 
-    // 3. The `start` bound must be defined so the `getslice` op is well-formed.
-    if !graph_defines(graph, &site.start) {
-        return Err(format!(
-            "{name}: RangeFrom start is not defined in the graph"
-        ));
-    }
-
-    // 3a. The `start` must be a NON-NEGATIVE CONSTANT. `decompose_slice_args`
+    // 3. Validate the selected bounds before mutating. A RangeFrom `start`
+    // must be a NON-NEGATIVE CONSTANT. `decompose_slice_args`
     //     (rtyper.rs:2809-2816) raises "slice start must be proved
     //     non-negative" for a `nonneg==false` runtime `SomeInteger` start, and
     //     a `usize` literal decodes to a bare `OpKind::ConstInt(k)` with no
@@ -167,10 +203,24 @@ fn rewire_one_slice_index_site(
     //     `immutablevalue(ConstInt(k))` annotates `nonneg = k>=0`) keeps every
     //     rewritten graph lift-able; a computed start declines cleanly
     //     (residual, census Skip).
-    if !start_is_const_nonneg(graph, &site.start) {
-        return Err(format!(
-            "{name}: RangeFrom start is not a non-negative constant — declining"
-        ));
+    match bounds {
+        SliceIndexBounds::RangeFrom { start } => {
+            if !graph_defines(graph, start) {
+                return Err(format!(
+                    "{name}: RangeFrom start is not defined in the graph"
+                ));
+            }
+            if !start_is_const_nonneg(graph, start) {
+                return Err(format!(
+                    "{name}: RangeFrom start is not a non-negative constant — declining"
+                ));
+            }
+        }
+        SliceIndexBounds::RangeTo { end } => {
+            if !graph_defines(graph, end) {
+                return Err(format!("{name}: RangeTo end is not defined in the graph"));
+            }
+        }
     }
 
     // --- All structural validation passed; mutate the graph. ---
@@ -214,18 +264,26 @@ fn rewire_one_slice_index_site(
                 .map(|oi| (bi, oi))
         })
         .ok_or_else(|| format!("{name}: slice::index op vanished before rewrite"))?;
-    let stop = graph.alloc_value_var();
+    let synthetic_bound = graph.alloc_value_var();
+    let (args, synthetic_kind) = match bounds {
+        SliceIndexBounds::RangeFrom { start } => (
+            vec![slice, start.clone(), synthetic_bound.clone()],
+            OpKind::ConstNone,
+        ),
+        SliceIndexBounds::RangeTo { end } => (
+            vec![slice, synthetic_bound.clone(), end.clone()],
+            OpKind::ConstInt(0),
+        ),
+    };
     graph.blocks[rb].operations[ri] = SpaceOperation {
         result: Some(index_result),
-        kind: OpKind::GetSlice {
-            args: vec![slice, site.start.clone(), stop.clone()],
-        },
+        kind: OpKind::GetSlice { args },
     };
     graph.blocks[rb].operations.insert(
         ri,
         SpaceOperation {
-            result: Some(stop),
-            kind: OpKind::ConstNone,
+            result: Some(synthetic_bound),
+            kind: synthetic_kind,
         },
     );
     Ok(())
@@ -388,12 +446,32 @@ mod tests {
         )
     }
 
+    fn rangeto_ctor_target() -> CallTarget {
+        CallTarget::synthetic_transparent_ctor_with_owner(
+            vec!["core".to_string(), "ops".to_string(), "range".to_string()],
+            "RangeTo".to_string(),
+        )
+    }
+
     fn start_field_write(base: &Variable, value: &Variable) -> OpKind {
         OpKind::FieldWrite {
             base: base.clone(),
             field: crate::model::FieldDescriptor {
                 name: "start".to_string(),
                 owner_root: Some("core::ops::range::RangeFrom".to_string()),
+                owner_id: None,
+            },
+            value: LinkArg::Value(value.clone()),
+            ty: ValueType::Ref(None),
+        }
+    }
+
+    fn end_field_write(base: &Variable, value: &Variable) -> OpKind {
+        OpKind::FieldWrite {
+            base: base.clone(),
+            field: crate::model::FieldDescriptor {
+                name: "end".to_string(),
+                owner_root: Some("core::ops::range::RangeTo".to_string()),
                 owner_id: None,
             },
             value: LinkArg::Value(value.clone()),
@@ -504,6 +582,97 @@ mod tests {
                 op.result.as_ref() == Some(stop) && matches!(&op.kind, OpKind::ConstNone)
             });
         assert!(stop_is_const_none, "arg2 = ConstNone (StartOnly stop)");
+    }
+
+    /// `&s[..k]` uses the existing StartStop contract: a synthetic constant
+    /// zero start and the aggregate's real `end` value as stop.
+    #[test]
+    fn rewrite_lifts_rangeto_index_to_getslice() {
+        let mut g = FunctionGraph::new("test_slice_index_rangeto");
+        let a = g.startblock;
+        let slice = g.push_op_var(a, OpKind::ConstInt(0), true).unwrap();
+        let len = g.push_op_var(a, OpKind::ConstInt(8), true).unwrap();
+        let one = g.push_op_var(a, OpKind::ConstInt(1), true).unwrap();
+        let end = g
+            .push_op_var(
+                a,
+                OpKind::BinOp {
+                    op: "sub".into(),
+                    lhs: len,
+                    rhs: one,
+                    result_ty: ValueType::Int,
+                },
+                true,
+            )
+            .unwrap();
+        let range = g
+            .push_op_var(
+                a,
+                OpKind::Call {
+                    target: rangeto_ctor_target(),
+                    args: Vec::new(),
+                    result_ty: ValueType::Ref(Some("core::ops::range::RangeTo".into())),
+                },
+                true,
+            )
+            .unwrap();
+        g.block_mut(a).operations.push(SpaceOperation {
+            result: None,
+            kind: end_field_write(&range, &end),
+        });
+        let sub = g
+            .push_op_var(
+                a,
+                OpKind::Call {
+                    target: slice_index_call_target(),
+                    args: vec![slice.clone(), range.clone()],
+                    result_ty: ValueType::Ref(None),
+                },
+                true,
+            )
+            .unwrap();
+        // Model the production failure shape: the now-dead RangeTo value is
+        // also threaded into a successor phi beside the live slice result.
+        let (b, b_args) = g.create_block_with_arg_vars(2);
+        g.set_return(b, Some(b_args[0].clone()));
+        g.set_goto(a, b, vec![sub, range.clone()]);
+
+        let site = SliceIndexRangeToSite {
+            range_result: range.clone(),
+            end: end.clone(),
+        };
+        assert_eq!(rewire_slice_index_rangeto_sites(&mut g, &[site]), 1);
+        crate::model::prune_dead_phis(&mut g);
+
+        assert_eq!(g.block(b).inputargs, vec![b_args[0].clone()]);
+        assert_eq!(g.block(a).exits[0].args.len(), 1);
+        assert_ne!(
+            g.block(a).exits[0].args[0].as_variable(),
+            Some(&range),
+            "orphan RangeTo link arg must be removed"
+        );
+
+        let getslice = g
+            .blocks
+            .iter()
+            .flat_map(|blk| &blk.operations)
+            .find_map(|op| match &op.kind {
+                OpKind::GetSlice { args } => Some(args),
+                _ => None,
+            })
+            .expect("RangeTo index becomes getslice");
+        assert_eq!(getslice[0], slice);
+        assert_eq!(getslice[2], end);
+        let start = &getslice[1];
+        assert!(g.blocks.iter().flat_map(|blk| &blk.operations).any(|op| {
+            op.result.as_ref() == Some(start) && matches!(&op.kind, OpKind::ConstInt(0))
+        }));
+        assert!(
+            !g.blocks
+                .iter()
+                .flat_map(|blk| &blk.operations)
+                .any(|op| is_slice_range_index_call(&op.kind))
+        );
     }
 
     /// A RangeFrom whose start is a RUNTIME value (not a const) declines: a

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -1254,16 +1254,50 @@ pub fn translate_op(
             op: opname,
             lhs,
             rhs,
-            ..
+            result_ty,
         } => {
             let l = lookup_operand(value_map, lhs, op, "lhs")?;
             let r = lookup_operand(value_map, rhs, op, "rhs")?;
             let result = resolve_result_hlvalue(op, value_map)?;
-            Ok(vec![FlowspaceOp::new(
-                normalize_binop_name(opname)?,
-                vec![l, r],
-                result,
-            )])
+            let normalized = normalize_binop_name(opname)?;
+            if result_ty == &crate::model::ValueType::Unsigned && !opname.ends_with("_ovf") {
+                // The model graph retains the Rust result type, while the
+                // RPython annotator derives arithmetic signedness solely from
+                // operand annotations. This matters for checked Rust MIR:
+                // `(usize, bool)` is scalarized to its `.0` value, but `len`
+                // and an integer literal otherwise make `sub` infer a signed
+                // SomeInteger. Re-express the result's Rust `usize` type as
+                // the orthodox RPython `r_uint(value)` conversion. Its
+                // extregistry annotation is
+                // `SomeInteger(unsigned=True, knowntype=Ruint)`, which also
+                // carries non-negativity by type (`unsigned or nonneg`).
+                let module = HOST_ENV
+                    .import_module("rpython.rlib.rarithmetic")
+                    .ok_or_else(|| {
+                        TyperError::message(
+                            "rpython.rlib.rarithmetic missing from HOST_ENV bootstrap".to_string(),
+                        )
+                    })?;
+                let callable_host = module.module_get("r_uint").ok_or_else(|| {
+                    TyperError::message(
+                        "rarithmetic.r_uint missing from HOST_ENV bootstrap".to_string(),
+                    )
+                })?;
+                let scalar = Variable::new();
+                Ok(vec![
+                    FlowspaceOp::new(normalized, vec![l, r], Hlvalue::Variable(scalar.clone())),
+                    FlowspaceOp::new(
+                        "simple_call",
+                        vec![
+                            Hlvalue::Constant(Constant::new(ConstValue::HostObject(callable_host))),
+                            Hlvalue::Variable(scalar),
+                        ],
+                        result,
+                    ),
+                ])
+            } else {
+                Ok(vec![FlowspaceOp::new(normalized, vec![l, r], result)])
+            }
         }
 
         // ─── Pre-rtyper opname normalization for unary ops ───
@@ -5516,6 +5550,52 @@ mod tests {
             msg.contains("as lhs of BinOp") && msg.contains("result Some(Variable("),
             "verbose diagnostic must include arg role + op variant + result variable, got: {msg}"
         );
+    }
+
+    #[test]
+    fn translate_unsigned_binop_carries_rust_type_through_r_uint() {
+        let mut value_map: HashMap<Variable, Hlvalue> = HashMap::new();
+        let mut graph = LegacyGraph::new("translate_unsigned_binop");
+        let vars = mint_vars(&mut graph, 3);
+        let lhs = Variable::new();
+        let rhs = Variable::new();
+        let result = Variable::new();
+        value_map.insert(vars[0].clone(), Hlvalue::Variable(lhs));
+        value_map.insert(vars[1].clone(), Hlvalue::Variable(rhs));
+        value_map.insert(vars[2].clone(), Hlvalue::Variable(result.clone()));
+        let op = SpaceOperation {
+            result: Some(vars[2].clone()),
+            kind: OpKind::BinOp {
+                op: "sub".to_string(),
+                lhs: vars[0].clone(),
+                rhs: vars[1].clone(),
+                result_ty: ValueType::Unsigned,
+            },
+        };
+
+        let translated = translate_op(&op, &value_map, &empty_call_registry())
+            .expect("unsigned BinOp must lower");
+        assert_eq!(translated.len(), 2);
+        assert_eq!(translated[0].opname, "sub");
+        assert_eq!(translated[1].opname, "simple_call");
+        let Hlvalue::Variable(ref scalar_result) = translated[0].result else {
+            panic!("sub result must be a temporary Variable");
+        };
+        let Hlvalue::Variable(ref cast_arg) = translated[1].args[1] else {
+            panic!("r_uint operand must be the sub result Variable");
+        };
+        assert_eq!(scalar_result.id(), cast_arg.id());
+        let Hlvalue::Variable(ref cast_result) = translated[1].result else {
+            panic!("r_uint result must be the model result Variable");
+        };
+        assert_eq!(cast_result.id(), result.id());
+        let Hlvalue::Constant(callable) = &translated[1].args[0] else {
+            panic!("r_uint callable must be a Constant");
+        };
+        let ConstValue::HostObject(host) = &callable.value else {
+            panic!("r_uint callable must be a HostObject");
+        };
+        assert_eq!(host.qualname(), "rarithmetic.r_uint");
     }
 
     // ───── topology assembly ─────

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -5595,7 +5595,15 @@ mod tests {
         let ConstValue::HostObject(host) = &callable.value else {
             panic!("r_uint callable must be a HostObject");
         };
-        assert_eq!(host.qualname(), "rarithmetic.r_uint");
+        let expected = HOST_ENV
+            .import_module("rpython.rlib.rarithmetic")
+            .expect("HOST_ENV bootstrap must register rpython.rlib.rarithmetic")
+            .module_get("r_uint")
+            .expect("rarithmetic module must expose r_uint");
+        assert_eq!(
+            host, &expected,
+            "callable must be the registered r_uint object"
+        );
     }
 
     // ───── topology assembly ─────

--- a/pyre/pyre-object/src/boolobject.rs
+++ b/pyre/pyre-object/src/boolobject.rs
@@ -59,6 +59,7 @@ pub unsafe fn w_bool_get_value(obj: PyObjectRef) -> bool {
 static TRUE_SINGLETON: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
 static FALSE_SINGLETON: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
 
+#[majit_macros::dont_look_inside]
 fn bool_singleton(slot: &'static std::sync::OnceLock<usize>, intval: i64) -> PyObjectRef {
     *slot.get_or_init(|| {
         crate::lltype::malloc_typed_immortal(W_BoolObject {

--- a/pyre/pyre-object/src/gc_roots.rs
+++ b/pyre/pyre-object/src/gc_roots.rs
@@ -280,11 +280,13 @@ fn with_shadow_stack<R>(f: impl FnOnce(&RootStack) -> R) -> R {
 /// `increase_root_stack_depth(new_depth)` (`rlib/rgc.py:775-779` →
 /// `shadowstack.py:351-364`).  `sys.setrecursionlimit` scales the root stack
 /// with the limit at `pypy/module/sys/vm.py:97`; the depth can only grow.
+#[majit_macros::dont_look_inside]
 pub fn increase_root_stack_depth(new_depth: usize) {
     with_shadow_stack(|stack| stack.grow(new_depth));
 }
 
 /// `root_stack_depth` — the slot count this thread's root stack can hold.
+#[majit_macros::dont_look_inside]
 pub fn root_stack_depth() -> usize {
     with_shadow_stack(|stack| {
         let capacity = stack.capacity();
@@ -453,6 +455,7 @@ impl Drop for RootScope {
 /// execute the matching `pop_roots(hop, livevars)`. See the module
 /// docstring for the multi-phase plan.
 #[inline]
+#[majit_macros::dont_look_inside]
 pub fn push_roots() -> RootScope {
     RootScope::new()
 }

--- a/pyre/pyre-object/src/gc_roots.rs
+++ b/pyre/pyre-object/src/gc_roots.rs
@@ -454,8 +454,9 @@ impl Drop for RootScope {
 /// Open a `push_roots(hop)` bracket. Drop the returned guard to
 /// execute the matching `pop_roots(hop, livevars)`. See the module
 /// docstring for the multi-phase plan.
+// Do not mark this `dont_look_inside`: `RootScope` is a two-word by-value ADT,
+// but the residual-call classifier would encode it as a one-word `ref` token.
 #[inline]
-#[majit_macros::dont_look_inside]
 pub fn push_roots() -> RootScope {
     RootScope::new()
 }

--- a/pyre/pyre-object/src/noneobject.rs
+++ b/pyre/pyre-object/src/noneobject.rs
@@ -26,6 +26,7 @@ impl crate::lltype::GcType for W_NoneObject {
 static NONE_SINGLETON: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
 
 /// Get the None singleton as a PyObjectRef.
+#[majit_macros::dont_look_inside]
 pub fn w_none() -> PyObjectRef {
     *NONE_SINGLETON.get_or_init(|| {
         crate::lltype::malloc_typed_immortal(W_NoneObject {

--- a/pyre/pyre-object/src/special.rs
+++ b/pyre/pyre-object/src/special.rs
@@ -21,6 +21,7 @@ impl crate::lltype::GcType for NotImplemented {
 static NOT_IMPLEMENTED_SINGLETON: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
 
 /// Get the NotImplemented singleton.
+#[majit_macros::dont_look_inside]
 pub fn w_not_implemented() -> PyObjectRef {
     *NOT_IMPLEMENTED_SINGLETON.get_or_init(|| {
         crate::lltype::malloc_typed_immortal(NotImplemented {


### PR DESCRIPTION
Four rtyper-prepass census commits (gh#346).

## Commits

- **`dont_look_inside` on `push_roots` / `increase_root_stack_depth` / `root_stack_depth`** — residualises the root-stack calls instead of tracing into them.
- **Thread undefined operands by dominance, not the single-predecessor chain** — adds the iterative dominator-set computation and threads an operand only when its definition dominates the use.
- **Fix oparg signedness lowering** — `tyref_to_value_type` yields `ValueType::Unsigned` for transparent `u32` opargs, so `SomeInteger(unsigned=True)` carries the non-negative fact through annotation.
- **Carry usize slice bounds through annotation; keep the sub-slice capstone dormant** — preserves the checked `usize` arithmetic tuple's element type through flowspace lowering as `r_uint`, and adds the `RangeTo` recognizer (`&s[..k]` → `getslice(s, 0, k)`) plus the `prune_dead_phis` wiring it needs. Both capstone arms stay dormant.

## Why the sub-slice capstone stays dormant

`front/slice_index.rs` was already a built, unit-tested, deliberately unwired capstone. Activating the `RangeTo` arm was tried and measured, and it does not hold:

- With both arms active, the `RangeFrom` rewrite's Void `ConstNone` stop had no regalloc coloring once `_io::buffered_rwpair::<Impl>::readinto` dropped to the legacy walker.
- With `RangeTo` alone, a bare `getslice/rii>r` reached the codewriter from `builtins::split_builtin_kwargs` and `_warnings::do_warn_explicit`, failing `production_bh_builder_covers_every_build_emitted_opname` and `default_bh_builder_unwired_set_matches_task_85_snapshot` (`pyre/pyre-jit-trace/src/jitcode_runtime.rs:2031,2179`). No blackhole handler dispatches `getslice`, and none should: upstream `rtype_getslice` (`rlist.py:409-414`) always replaces it with a `gendirectcall`, so a surviving bare op means the graph did not rtype.
- Both stops are statically unsigned, so signedness does not separate the sites whose planted op is consumed from an rtyped graph from those that drop.

Neither assertion was widened and no `bhimpl` alias was added. The recognizers and their tests stay in the tree, and the module doc now records the measured reason with the observed graph names.

## Measurements

phaseA **1272**, phaseB **3** — unchanged. The `RangeTo` activation did reach phaseA 1271 (clearing `split_builtin_kwargs`), but that is not kept, because it emitted the bare `getslice` above. A correct build beats −1.

`cargo test --all --no-default-features --features dynasm` — green (the CI command; a `-p majit-translate` run does not cover the two `pyre-jit-trace` tests above).

## Note on `core::slice::index`

While the activation was live it removed the `slice::index` wall from 140 of 172 census records, yet only `split_builtin_kwargs` left the census — the caller graphs re-rooted onto walls behind it, mostly the per-wrapper `__PYRE_PARAM_NAMES` statics (117 records, 101 of them single-wall). Blast radius is a ceiling, not a yield.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for open-ended slice ranges, including start-to-end and beginning-to-end forms.
  * Slice operations now validate constant non-negative bounds and safely preserve original behavior when bounds cannot be handled.
* **Bug Fixes**
  * Improved handling of unsigned arithmetic and subtraction, preserving correct `usize` results.
  * Corrected lowering of unsigned operations to maintain expected runtime behavior.
* **Documentation**
  * Documented supported and deferred slice-range handling, including safety constraints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->