### PR TITLE
jit: fix symbolic-fnaddr misclassification on aarch64 Linux; blackhole null-arg diagnostic

### DIFF
--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -3954,7 +3954,7 @@ mod tests {
 
         /// The two `fnaddr` classifiers agree with the walker's gate.
         ///
-        /// `residual_call.rs:1117` declines a funcptr with any bit ≥ 47 set;
+        /// A symbolic hash carries the `SYMBOLIC_FNADDR_BASE` high-16-bit tag;
         /// `0` is upstream's "no address" spelling (`jitcode.py:14`) and is a
         /// no-op — not a decline — for `residual_call`, whose backend
         /// `bh_call_*` returns `0`/null for it.
@@ -3964,12 +3964,17 @@ mod tests {
             assert!(!super::is_symbolic_fnaddr(real));
             assert!(super::is_callable_fnaddr(real));
 
-            // `symbolic_fnaddr_for_path` is a `DefaultHasher` finish() cast to
-            // i64, so its high bits are set with overwhelming probability; the
-            // gate's contract is the bit-47 test, not the hash function.
-            let symbolic = 0x1234_5678_9abc_def0_u64 as i64;
+            let symbolic = majit_translate::codewriter::call::SYMBOLIC_FNADDR_BASE as i64
+                | 0x1234_5678_9abc_i64;
             assert!(super::is_symbolic_fnaddr(symbolic));
             assert!(!super::is_callable_fnaddr(symbolic));
+
+            // aarch64 Linux 48-bit-VA funcptrs set bit 47 (PIE base 0xaaab…,
+            // mmap 0xffff…); they are real addresses, not symbolic hashes.
+            for real_high in [0x0000_ffff_7122_b9c0_i64, 0x0000_aaab_1234_5678_i64] {
+                assert!(!super::is_symbolic_fnaddr(real_high));
+                assert!(super::is_callable_fnaddr(real_high));
+            }
 
             assert!(!super::is_symbolic_fnaddr(0));
             assert!(!super::is_callable_fnaddr(0));
@@ -10641,14 +10646,15 @@ fn read_inline_call_jitcode(
 /// did not publish through `jit_trace_fnaddrs()`; `patch_constants_i_fnaddrs`
 /// is keyed on the build-time address, so a hash is never rebound.
 ///
-/// User-space code addresses occupy the canonical low half on every target pyre
-/// builds for, so the top bits separate the two. This is the same discriminator
-/// the walker's residual-call path already uses to decline a symbolic funcptr —
-/// `(func_ptr as u64) >> 47 != 0` → `ResidualDecline::Symbolic`
-/// (`jitcode_dispatch/residual_call.rs:1117`).
+/// Symbolic hashes carry the `SYMBOLIC_FNADDR_BASE` high-16-bit tag stamped
+/// at generation, which no real user-space funcptr can carry on any target
+/// pyre builds for (aarch64 Linux maps code with bit 47 set, so a bit-range
+/// heuristic would misclassify every real funcptr there).  Same discriminator
+/// the walker's residual-call path uses to decline a symbolic funcptr →
+/// `ResidualDecline::Symbolic`.
 #[inline]
 pub(crate) fn is_symbolic_fnaddr(fnaddr: i64) -> bool {
-    (fnaddr as u64) >> 47 != 0
+    majit_translate::codewriter::call::is_symbolic_fnaddr(fnaddr)
 }
 
 /// Whether a jitcode's `fnaddr` can be called as a function pointer.

--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -7509,6 +7509,29 @@ fn reject_symbolic_residual_call(bh: &mut BlackholeInterpreter, func: i64) -> Di
 }
 
 // residual_call_irf_*
+
+/// `MAJIT_BH_NULL_ARG`: report a null ref argument about to be handed to a
+/// residual call, with the jitcode coordinate, before the callee can
+/// dereference it.  Some ABIs pass a legitimate null sentinel (e.g. the
+/// CallFn `null_or_self` slot), so this reports rather than aborts.
+fn bh_null_arg_report(bh: &BlackholeInterpreter, ar: &[i64], position: usize) {
+    static ARMED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    if !*ARMED.get_or_init(|| std::env::var_os("MAJIT_BH_NULL_ARG").is_some()) {
+        return;
+    }
+    if ar.iter().any(|&a| a == 0) {
+        eprintln!(
+            "[bh-null-arg] jitcode={} position={} last_opcode_position={} \
+             entry_position={} args_r={:?}",
+            bh.jitcode.name(),
+            position,
+            bh.last_opcode_position,
+            bh.entry_position,
+            ar,
+        );
+    }
+}
+
 fn handler_residual_call_irf_i(
     bh: &mut BlackholeInterpreter,
     code: &[u8],
@@ -7524,6 +7547,7 @@ fn handler_residual_call_irf_i(
     let (calldescr, p) = read_descr(bh, code, p);
     let calldescr = calldescr.as_calldescr().clone();
     let dst = code[p] as usize;
+    bh_null_arg_report(bh, &ar, position);
     // blackhole.py:1244-1246 → bhimpl_residual_call_irf_i.
     BH_LAST_EXC_VALUE.with(|c| c.set(0));
     let result = bh.bhimpl_residual_call_irf_i(func, &ai, &ar, &af, &calldescr);
@@ -7548,6 +7572,7 @@ fn handler_residual_call_irf_r(
     let (calldescr, p) = read_descr(bh, code, p);
     let calldescr = calldescr.as_calldescr().clone();
     let dst = code[p] as usize;
+    bh_null_arg_report(bh, &ar, position);
     // blackhole.py:1247-1249 → bhimpl_residual_call_irf_r.
     BH_LAST_EXC_VALUE.with(|c| c.set(0));
     let result = bh.bhimpl_residual_call_irf_r(func, &ai, &ar, &af, &calldescr);
@@ -7572,6 +7597,7 @@ fn handler_residual_call_irf_f(
     let (calldescr, p) = read_descr(bh, code, p);
     let calldescr = calldescr.as_calldescr().clone();
     let dst = code[p] as usize;
+    bh_null_arg_report(bh, &ar, position);
     // blackhole.py:1250-1252 → bhimpl_residual_call_irf_f.
     BH_LAST_EXC_VALUE.with(|c| c.set(0));
     let result = bh.bhimpl_residual_call_irf_f(func, &ai, &ar, &af, &calldescr);
@@ -7595,6 +7621,7 @@ fn handler_residual_call_irf_v(
     let (af, p) = read_list_f(bh, code, p);
     let (calldescr, p) = read_descr(bh, code, p);
     let calldescr = calldescr.as_calldescr().clone();
+    bh_null_arg_report(bh, &ar, position);
     // blackhole.py:1253-1255 routes through bhimpl_residual_call_irf_v
     // which forwards to cpu.bh_call_v.
     BH_LAST_EXC_VALUE.with(|c| c.set(0));
@@ -7619,6 +7646,7 @@ fn handler_residual_call_ir_i(
     let (calldescr, p) = read_descr(bh, code, p);
     let calldescr = calldescr.as_calldescr().clone();
     let dst = code[p] as usize;
+    bh_null_arg_report(bh, &ar, position);
     // blackhole.py:1234-1236 → bhimpl_residual_call_ir_i.
     BH_LAST_EXC_VALUE.with(|c| c.set(0));
     let result = bh.bhimpl_residual_call_ir_i(func, &ai, &ar, &calldescr);
@@ -7642,6 +7670,7 @@ fn handler_residual_call_ir_r(
     let (calldescr, p) = read_descr(bh, code, p);
     let calldescr = calldescr.as_calldescr().clone();
     let dst = code[p] as usize;
+    bh_null_arg_report(bh, &ar, position);
     // blackhole.py:1237-1239 → bhimpl_residual_call_ir_r.
     BH_LAST_EXC_VALUE.with(|c| c.set(0));
     let result = bh.bhimpl_residual_call_ir_r(func, &ai, &ar, &calldescr);
@@ -7664,6 +7693,7 @@ fn handler_residual_call_ir_v(
     let (ar, p) = read_list_r(bh, code, p);
     let (calldescr, p) = read_descr(bh, code, p);
     let calldescr = calldescr.as_calldescr().clone();
+    bh_null_arg_report(bh, &ar, position);
     // blackhole.py:1240-1242 → bhimpl_residual_call_ir_v.
     BH_LAST_EXC_VALUE.with(|c| c.set(0));
     bh.bhimpl_residual_call_ir_v(func, &ai, &ar, &calldescr);
@@ -7686,6 +7716,7 @@ fn handler_residual_call_r_i(
     let (calldescr, p) = read_descr(bh, code, p);
     let calldescr = calldescr.as_calldescr().clone();
     let dst = code[p] as usize;
+    bh_null_arg_report(bh, &ar, position);
     // blackhole.py:1225-1226 → bhimpl_residual_call_r_i.
     BH_LAST_EXC_VALUE.with(|c| c.set(0));
     let result = bh.bhimpl_residual_call_r_i(func, &ar, &calldescr);
@@ -7708,6 +7739,7 @@ fn handler_residual_call_r_r(
     let (calldescr, p) = read_descr(bh, code, p);
     let calldescr = calldescr.as_calldescr().clone();
     let dst = code[p] as usize;
+    bh_null_arg_report(bh, &ar, position);
     // blackhole.py:1227-1229 → bhimpl_residual_call_r_r.
     BH_LAST_EXC_VALUE.with(|c| c.set(0));
     let result = bh.bhimpl_residual_call_r_r(func, &ar, &calldescr);
@@ -7729,6 +7761,7 @@ fn handler_residual_call_r_v(
     let (ar, p) = read_list_r(bh, code, position + 1);
     let (calldescr, p) = read_descr(bh, code, p);
     let calldescr = calldescr.as_calldescr().clone();
+    bh_null_arg_report(bh, &ar, position);
     // blackhole.py:1230-1232 → bhimpl_residual_call_r_v.
     BH_LAST_EXC_VALUE.with(|c| c.set(0));
     bh.bhimpl_residual_call_r_v(func, &ar, &calldescr);

--- a/majit/majit-translate/src/codewriter/call.rs
+++ b/majit/majit-translate/src/codewriter/call.rs
@@ -5971,12 +5971,31 @@ impl CallControl {
     }
 }
 
+/// High-16-bit tag stamped on every symbolic fnaddr hash so consumers can
+/// discriminate a placeholder from a real code address by an exact bit
+/// pattern instead of a range heuristic.  User-space addresses keep bits
+/// 48..64 clear on every 64-bit target pyre builds for, and wasm32 addresses
+/// are 32-bit, so no real funcptr can carry the tag.  (A bit-47 range test is
+/// NOT enough: aarch64 Linux uses a 48-bit VA and maps PIE code and mmap
+/// regions with bit 47 set — 0xaaab…/0xffff… — so every real funcptr there
+/// would read as symbolic.)  Same scheme as
+/// `assembler::STR_CONST_SENTINEL_BASE`.
+pub const SYMBOLIC_FNADDR_HIGH_MASK: u64 = 0xFFFF_0000_0000_0000;
+pub const SYMBOLIC_FNADDR_BASE: u64 = 0xFADD_0000_0000_0000;
+
+/// Whether `fnaddr` is a `symbolic_fnaddr_for_path` placeholder rather than a
+/// callable code address.
+#[inline]
+pub fn is_symbolic_fnaddr(fnaddr: i64) -> bool {
+    (fnaddr as u64) & SYMBOLIC_FNADDR_HIGH_MASK == SYMBOLIC_FNADDR_BASE
+}
+
 fn stable_symbolic_fnaddr<T: std::hash::Hash>(value: &T) -> i64 {
     use std::hash::Hasher;
 
     let mut hasher = std::collections::hash_map::DefaultHasher::new();
     value.hash(&mut hasher);
-    hasher.finish() as i64
+    ((hasher.finish() & !SYMBOLIC_FNADDR_HIGH_MASK) | SYMBOLIC_FNADDR_BASE) as i64
 }
 
 pub(crate) fn symbolic_fnaddr_for_path(path: &CallPath) -> i64 {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -2359,7 +2359,7 @@ pub(crate) fn try_walker_inline_builtin_call<Sym: WalkSym>(
     let walk_result = match walk_result {
         Ok(outcome) => outcome,
         // `try_execute_residual_call_via_executor` declines an un-lowered
-        // in-body helper (a `>>47` symbolic fnaddr) while inlining a
+        // in-body helper (a tagged symbolic fnaddr) while inlining a
         // sub-jitcode, so the descent aborts instead of baking the hash as a
         // code address.  Propagating that abort from here strands the CALL:
         // this walk is the authoritative executor and the descent declined

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -6465,7 +6465,7 @@ fn direct_call_release_gil<Sym: WalkSym>(
     // un-executed-side-effect SIGBUS class already closed for the
     // may-force branch.
     // `try_execute_residual_call_via_executor` self-gates (authoritative-
-    // executor flag, const-funcbox, fnaddr ≥47-bit sanity) and degrades to
+    // executor flag, const-funcbox, symbolic-fnaddr-tag sanity) and degrades to
     // recording-only on decline; on success it stamps `recorded` with the
     // concrete result and brackets the active virtualizable token for the
     // duration of the call (its may-force arm).

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -2185,12 +2185,12 @@ pub(crate) fn try_execute_residual_call_via_executor<Sym: WalkSym>(
     // state; but a sub-walk's recorded trace is committed and compiled, so the
     // backend bakes the hash as a code address and the trace branches straight
     // to it -> SIGSEGV.  Decline the whole descent so it aborts gracefully at
-    // the first un-lowered helper.  A user-space code address fits in 47 bits
-    // on 64-bit macOS/Linux; symbolic hashes set bits >= 47.
+    // the first un-lowered helper.  Symbolic hashes carry the
+    // `SYMBOLIC_FNADDR_BASE` high-16-bit tag no real funcptr can carry.
     if ctx.fbw_mode.inline_subwalk
         && allboxes.first().is_some_and(|b| b.is_constant())
         && let Some(majit_ir::Value::Int(addr)) = ctx.trace_ctx.box_value(allboxes[0])
-        && (addr as u64) >> 47 != 0
+        && majit_translate::codewriter::call::is_symbolic_fnaddr(addr)
     {
         return Err(DispatchError::OrthodoxSubWalkTraceUnsupported { pc: op_pc });
     }
@@ -2268,13 +2268,11 @@ pub(crate) fn try_execute_residual_call_via_executor<Sym: WalkSym>(
     // these to real runtime addresses only when the path appears in
     // both the build-time and runtime registries; helpers absent from
     // the runtime registry retain the hash and dereferencing it as a
-    // code address SIGBUSes.  Valid user-space code addresses fit in
-    // 47 bits on macOS/Linux 64-bit (canonical low half); hash values
-    // typically have bits ≥ 47 set.  Reject anything outside that
-    // range — both the symbolic-hash leak class AND any other stray
-    // non-fnptr value (e.g. an int constant mistakenly routed through
-    // the funcbox slot).
-    if (func_ptr as u64) >> 47 != 0 {
+    // code address SIGBUSes.  Hashes carry the `SYMBOLIC_FNADDR_BASE`
+    // high-16-bit tag no real funcptr can carry on any target (a bit-47
+    // range test would misclassify every real funcptr on aarch64 Linux,
+    // whose 48-bit VA maps code at 0xaaab…/0xffff…).
+    if majit_translate::codewriter::call::is_symbolic_fnaddr(func_ptr) {
         return Ok(ResidualExecOutcome::Declined(ResidualDecline::Symbolic));
     }
     // A residual whose funcptr is a `PyFrame` operand-stack accessor

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -6705,7 +6705,7 @@ pub(crate) fn try_walker_specialize_builtin_divmod<Sym: WalkSym>(
 /// aggregate (`SyntheticTransparentCtor "Tuple"`) is elided to `ConstRefNull`
 /// at build time (`jtransform.rs`), so the descent completes and commits a
 /// working trace.  Safety net: if a stale build-time jitcode kept that ctor as
-/// a symbolic (`>>47`) fnaddr, `try_execute_residual_call_via_executor`
+/// a symbolic (tagged) fnaddr, `try_execute_residual_call_via_executor`
 /// declines it (`OrthodoxSubWalkTraceUnsupported`) and the method-call form
 /// records the append as a residual call instead of baking the hash as a code
 /// address and branching to garbage.
@@ -7232,7 +7232,7 @@ pub(crate) fn orthodox_list_append_commit<Sym: WalkSym>(
     // (`SyntheticTransparentCtor "Tuple"`) was elided to `ConstRefNull` at
     // build time.  Any residual that does NOT lower —
     // e.g. a stale build-time jitcode whose tuple ctor kept a symbolic
-    // `>>47` funcbox — is declined by `try_execute_residual_call_via_executor`
+    // symbolic-tagged funcbox — is declined by `try_execute_residual_call_via_executor`
     // (`OrthodoxSubWalkTraceUnsupported`) and `walk_result?` propagates that
     // abort before this point (graceful interpreter fallback, never a wrong
     // trace).  The descr-pool wiring above (strategy/header field descrs) is


### PR DESCRIPTION
## jit: tag symbolic fnaddr hashes instead of a 47-bit range test (771974faf2f)

`is_symbolic_fnaddr` classified any funcptr with bit ≥ 47 set as a symbolic path hash. On aarch64 Linux the 48-bit VA maps PIE code and mmap regions with bit 47 set (`0xaaab…`/`0xffff…`), so the blackhole rejected every real residual call during guard-failure resume, left the frame image incomplete, and the interpreter raised `TypeError: stack underflow during interpreter opcode` — deterministic on e.g. `bench/synth/arith_int_bool.py` (a 5-line `while i < n: i += 1` reproduces). macOS arm64 (low VA) and x86_64 Linux (47-bit VA) satisfied the heuristic by accident, so no CI leg could see it. The heuristic was also unsound the other way: a `DefaultHasher` hash lands in the low 47 bits with p≈2⁻¹⁷ and would then be branched to as a code address.

Fix: stamp `symbolic_fnaddr_for_path` hashes with a `SYMBOLIC_FNADDR_BASE` high-16-bit tag (same scheme as `STR_CONST_SENTINEL_BASE`) and switch the blackhole and walker discriminators to an exact tag test.

Verification:
- macOS `check.py`: dynasm 377/377, cranelift 377/377, wasm 373/373 (no jitstats movement — behavior identical where it already worked)
- aarch64-Linux container: both crashing fixtures now pass correctness; the minimal repro prints 200000

## blackhole: MAJIT_BH_NULL_ARG gated null-ref-argument report (8982925bfd5)

Env-gated diagnostic in all ten `handler_residual_call_*` variants: when a decoded ref argument is null, report the jitcode name and byte positions before the callee can dereference it. Report-only (several ABIs legitimately pass a null sentinel, e.g. the CallFn `null_or_self` slot); zero behavior change unarmed. Motivation: the intermittent test_asyncio SIGSEGV whose backtrace ends in `handler_residual_call_r_r → jit_next(NULL)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)