### PR TITLE
majit: the interp-origin entry-bridge close (pyjitpl.py:3001-3007 jump half), default off

### DIFF
--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -8200,17 +8200,35 @@ impl CraneliftBackend {
     // `compile_tmp_callback` and other backend-agnostic consumers can
     // reach them through `&mut dyn Backend`.
 
-    fn gc_rewriter(&self) -> Option<GcRewriterImpl> {
-        with_cranelift_gc(|gc| GcRewriterImpl {
-            nursery_free_addr: gc.nursery_free_addr(),
-            nursery_top_addr: gc.nursery_top_addr(),
-            max_nursery_size: gc.max_nursery_object_size(),
+    /// Built unconditionally, for the reasons spelled out on the dynasm
+    /// backend's `gc_rewriter`: `x86/regalloc.py:187` calls
+    /// `cpu.gc_ll_descr.rewrite_assembler` straight through and `gc.py:109-112`
+    /// defines it on the base `GcLLDescription`, so the pass runs even for a
+    /// configuration with no nursery and no write barrier. Only four fields are
+    /// collector-derived; with no collector they take the upstream base values
+    /// (`can_use_nursery_malloc -> False`, gc.py:81-82, spelled
+    /// `max_nursery_size: 0`; `write_barrier_descr = None`, gc.py:156).
+    fn gc_rewriter(&self) -> GcRewriterImpl {
+        let (nursery_free_addr, nursery_top_addr, max_nursery_size, wb_descr) =
+            with_cranelift_gc(|gc| {
+                (
+                    gc.nursery_free_addr(),
+                    gc.nursery_top_addr(),
+                    gc.max_nursery_object_size(),
+                    gc.get_write_barrier_descr(),
+                )
+            })
+            .unwrap_or((0, 0, 0, None));
+        GcRewriterImpl {
+            nursery_free_addr,
+            nursery_top_addr,
+            max_nursery_size,
             // gc.py:401 `gc_ll_descr.write_barrier_descr` — the collector
             // answers (gc.py:259-283 WriteBarrierDescr parity, card marking
             // included), and `None` from one that needs no barrier
             // (`gc.py:156 GcLLDescr_boehm`) keeps `rewrite.py:393` from
             // emitting `COND_CALL_GC_WB*` the backend could not assemble.
-            wb_descr: gc.get_write_barrier_descr(),
+            wb_descr,
             jitframe_info: JITFRAME_LAYOUT
                 .get()
                 .and_then(|info| info.jitframe_descrs.clone()),
@@ -8303,7 +8321,7 @@ impl CraneliftBackend {
                     }
                 })
             })),
-        })
+        }
     }
 
     fn prepare_ops_for_compile(
@@ -8314,7 +8332,8 @@ impl CraneliftBackend {
     ) -> (Vec<Op>, Vec<GcRef>) {
         let mut normalized = normalize_ops_for_codegen_simple(inputargs, ops);
         inject_builtin_string_descrs(&mut normalized);
-        if let Some(rewriter) = self.gc_rewriter() {
+        {
+            let rewriter = self.gc_rewriter();
             // The rewriter takes the typed `Const` pool directly; each box
             // variant carries its own type (`Const::get_type`).
             let (result, new_constants, gcrefs) =
@@ -8327,8 +8346,6 @@ impl CraneliftBackend {
                 self.constants.entry(k).or_insert(c);
             }
             (result, gcrefs)
-        } else {
-            (normalized, Vec::new())
         }
     }
 
@@ -12346,7 +12363,7 @@ impl CraneliftBackend {
 
                     // Load flag byte from object header.
                     let rw = self.gc_rewriter();
-                    let wb = rw.as_ref().and_then(|r| r.wb_descr.as_ref());
+                    let wb = rw.wb_descr.as_ref();
                     let wb_byteofs = wb.map(|d| d.jit_wb_if_flag_byteofs as i32).unwrap_or(0);
                     let wb_mask_raw = wb.map(|d| d.jit_wb_if_flag_singlebyte).unwrap_or(0);
                     let wb_cards_set = wb.map(|d| d.jit_wb_cards_set).unwrap_or(0);

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -12496,12 +12496,6 @@ impl CraneliftBackend {
                         OpCode::GcLoadF => Type::Float,
                         _ => unreachable!(),
                     };
-                    if value_type != Type::Int && item_size < 0 {
-                        return Err(unsupported_semantics(
-                            op.opcode,
-                            "negative GC_LOAD itemsize is only valid for integer loads",
-                        ));
-                    }
                     let addr = emit_dynamic_offset_addr(
                         &mut builder,
                         &constants,
@@ -12559,12 +12553,6 @@ impl CraneliftBackend {
                         OpCode::GcLoadIndexedF => Type::Float,
                         _ => unreachable!(),
                     };
-                    if value_type != Type::Int && item_size < 0 {
-                        return Err(unsupported_semantics(
-                            op.opcode,
-                            "negative GC_LOAD_INDEXED itemsize is only valid for integer loads",
-                        ));
-                    }
                     let addr = emit_scaled_index_addr(
                         &mut builder,
                         &constants,
@@ -20424,7 +20412,13 @@ mod tests {
         item_type: Type,
         len_offset: Option<usize>,
     ) -> majit_ir::DescrRef {
-        make_array_descr_with_signedness(base_size, item_size, item_type, true, len_offset)
+        // descr.py:311-312 `is_item_signed = flag == FLAG_SIGNED`, over flags
+        // that are one value and not a set (descr.py:132-138), so only an
+        // integer array answers yes. `SimpleArrayDescr::new` derives it the
+        // same way; a signed float array is a descr the rewriter's
+        // itemsize-negating sign encoding cannot express.
+        let signed = item_type == Type::Int;
+        make_array_descr_with_signedness(base_size, item_size, item_type, signed, len_offset)
     }
 
     fn make_array_descr_with_signedness(
@@ -21546,7 +21540,14 @@ mod tests {
         assert!((backend.get_float_value(&frame, 0) - 6.25).abs() < 1e-10);
     }
 
+    /// rewrite.py:319-330 reads `GC_LOAD_INDEXED`'s scale, offset and size
+    /// under `assert isinstance(..., ConstInt)`, and x86/regalloc.py:1178-1182
+    /// asserts the same three again in the backend: a variable scale violates
+    /// the opcode's contract rather than asking the backend for a capability
+    /// it lacks. The rewriter states it the same way and runs ahead of the
+    /// backend, so that is where the trace stops.
     #[test]
+    #[should_panic(expected = "GC_LOAD_INDEXED scale must be ConstInt")]
     fn test_gc_load_indexed_rejects_nonconstant_scale() {
         let mut backend = CraneliftBackend::new();
 
@@ -21585,15 +21586,7 @@ mod tests {
         backend.set_constants(constants);
 
         let mut token = JitCellToken::new(100);
-        let err = backend
-            .compile_loop(&inputargs, &ops, &mut token)
-            .unwrap_err();
-        match err {
-            BackendError::Unsupported(msg) => {
-                assert!(msg.contains("scale must be a compile-time constant"));
-            }
-            other => panic!("expected Unsupported, got {other:?}"),
-        }
+        let _ = backend.compile_loop(&inputargs, &ops, &mut token);
     }
 
     #[test]

--- a/majit/majit-backend-dynasm/src/regalloc.rs
+++ b/majit/majit-backend-dynasm/src/regalloc.rs
@@ -2407,6 +2407,24 @@ impl<'a> RegAlloc<'a> {
                 continue;
             }
 
+            // aarch64/assembler.py:1191-1195 `_walk_operations`: an
+            // `INT_*_OVF` op publishes its overflow answer in the condition
+            // flags, and the guard that reads them is `operations[i + 1]`.
+            // Anything emitted in between overwrites NZCV, so the guard would
+            // branch on the wrong comparison. Upstream asserts the adjacency
+            // rather than tolerating it; so do we — `compile_loop` catches the
+            // panic and declines the trace, which beats a silent wrong answer.
+            assert!(
+                !op.opcode.is_ovf()
+                    || matches!(
+                        operations.get(i + 1).map(|n| n.opcode),
+                        Some(OpCode::GuardOverflow) | Some(OpCode::GuardNoOverflow)
+                    ),
+                "{:?} at {i} is not followed by GUARD_[NO_]OVERFLOW (got {:?})",
+                op.opcode,
+                operations.get(i + 1).map(|n| n.opcode),
+            );
+
             // x86/regalloc.py:390 dispatch to consider_* method.
             // The dynasm backend now enters through the j2-style lowered
             // operation. The legacy opcode dispatch below is only a guard
@@ -2919,9 +2937,14 @@ impl<'a> RegAlloc<'a> {
             OpCode::CastFloatToInt if !args.is_empty() => {
                 self.consider_cast_float_to_int_j2(dst.unwrap_or(op.pos.get()), args[0], i, output);
             }
-            OpCode::ConvertFloatBytesToLonglong
-            | OpCode::ConvertLonglongBytesToFloat
-            | OpCode::CastPtrToInt
+            // Same bank split as the non-j2 arm — see the citation there.
+            OpCode::ConvertFloatBytesToLonglong if !args.is_empty() => {
+                self.consider_cast_float_to_int_j2(dst.unwrap_or(op.pos.get()), args[0], i, output);
+            }
+            OpCode::ConvertLonglongBytesToFloat if !args.is_empty() => {
+                self.consider_cast_int_to_float_j2(dst.unwrap_or(op.pos.get()), args[0], i, output);
+            }
+            OpCode::CastPtrToInt
             | OpCode::CastIntToPtr
             | OpCode::CastOpaquePtr
             | OpCode::SameAsI
@@ -3132,8 +3155,21 @@ impl<'a> RegAlloc<'a> {
             OpCode::CastFloatToSinglefloat | OpCode::CastSinglefloatToFloat => {
                 self.consider_float_unary(op, i, output);
             }
-            OpCode::ConvertFloatBytesToLonglong | OpCode::ConvertLonglongBytesToFloat => {
-                self.consider_same_as(op, i, output);
+            // aarch64/regalloc.py:515-516 aliases both converts to the same
+            // `prepare_unary` (:456-462) as `prepare_op_cast_float_to_int` /
+            // `prepare_op_cast_int_to_float` (:502-503): the argument is read
+            // through the manager owning the ARGUMENT's type and the result is
+            // allocated through the manager owning the OP's type. x86 spells
+            // the same split out at x86/regalloc.py:719-727 / :730-738
+            // (`xrm.make_sure_var_in_reg` + `rm.force_allocate_reg`, and the
+            // mirror image). These ops REINTERPRET the bits across the two
+            // register files, so `consider_same_as` — which reads the argument
+            // out of the RESULT's bank — reads the wrong register file.
+            OpCode::ConvertFloatBytesToLonglong => {
+                self.consider_cast_float_to_int(op, i, output);
+            }
+            OpCode::ConvertLonglongBytesToFloat => {
+                self.consider_cast_int_to_float(op, i, output);
             }
             OpCode::CastPtrToInt | OpCode::CastIntToPtr | OpCode::CastOpaquePtr => {
                 self.consider_same_as(op, i, output);
@@ -6335,6 +6371,59 @@ mod tests {
             "deopt-only failarg should be captured from a register: {:?}",
             faillocs
         );
+    }
+
+    /// Build `[IntMulOvf -> i2, <optional interposed IntGt>, GuardNoOverflow,
+    /// Finish(i2)]` and walk it. The `Finish` use keeps the OVF result live so
+    /// the dead-op skip does not swallow the OVF op before the adjacency check.
+    fn walk_ovf_trace(interpose_comparison: bool) {
+        let i0 = OpRef::input_arg_int(0);
+        let i1 = OpRef::input_arg_int(1);
+        let i2 = OpRef::int_op(2);
+        let i3 = OpRef::int_op(3);
+
+        let inputargs = vec![
+            InputArg::from_type(Type::Int, i0.raw()),
+            InputArg::from_type(Type::Int, i1.raw()),
+        ];
+
+        let mul_ovf = Op::new(OpCode::IntMulOvf, &[rb(i0), rb(i1)]);
+        mul_ovf.pos.set(i2);
+        let guard = Op::new(OpCode::GuardNoOverflow, &[]);
+        guard.pos.set(OpRef::int_op(4));
+        guard.setfailargs(vec![rb(i2)].into());
+        let finish = Op::new(OpCode::Finish, &[rb(i2)]);
+        finish.pos.set(OpRef::int_op(5));
+        finish.setfailargs(vec![].into());
+        finish.set_fail_arg_types(vec![]);
+
+        let mut ops = vec![mul_ovf];
+        if interpose_comparison {
+            let gt = Op::new(OpCode::IntGt, &[rb(i0), rb(i1)]);
+            gt.pos.set(i3);
+            ops.push(gt);
+        }
+        ops.push(guard);
+        ops.push(finish);
+
+        let mut ra = RegAlloc::new(indexmap::IndexMap::new(), &inputargs, &ops);
+        ra.prepare_loop();
+        ra.walk_operations();
+    }
+
+    /// aarch64/assembler.py:1191-1195: the OVF op's answer lives in NZCV, so
+    /// its guard must be `operations[i + 1]`. Adjacent is accepted.
+    #[test]
+    fn test_ovf_op_adjacent_to_its_guard_walks() {
+        walk_ovf_trace(false);
+    }
+
+    /// ...and an op emitted between them — which overwrites NZCV — is rejected
+    /// rather than silently compiled into a guard on the wrong comparison.
+    #[test]
+    #[should_panic(expected = "is not followed by GUARD_[NO_]OVERFLOW")]
+    fn test_ovf_op_separated_from_its_guard_is_rejected() {
+        walk_ovf_trace(true);
     }
 
     #[test]

--- a/majit/majit-backend-dynasm/src/regalloc.rs
+++ b/majit/majit-backend-dynasm/src/regalloc.rs
@@ -768,26 +768,48 @@ pub struct RegisterManager {
 
 /// Resolve a constant `OpRef` to its `i64` bit pattern.
 ///
+/// Every caller is an operand slot that RPython reads with `.getint()` —
+/// a GC_LOAD offset (aarch64/regalloc.py:535), a GC_LOAD_INDEXED scale
+/// (:566), an itemsize (:568). Upstream can spell those as bare `getint()`
+/// calls because the rewrite pass guarantees the slot holds a `ConstInt`
+/// before the backend ever sees the op (rewrite.py:199-205 builds every one
+/// of them out of `ConstInt(...)`).
+///
 /// Inline-Const variants (history.py:227/268/314 `ConstXxx.value`) carry the
-/// value directly. The legacy pool-indexed variants (`ConstInt(u32)` etc.)
-/// must be present in the optimizer's `constants` snapshot. A legacy const
-/// absent from `constants` means the optimizer producer never seeded it —
-/// `ConstInt.value` is always present in RPython, so the backend must never
-/// silently substitute `0`, which would miscompile the constant as zero.
-/// Panic at the parity hole instead, matching the Cranelift backend's
+/// value directly. The legacy pool-indexed variants must be present in the
+/// optimizer's `constants` snapshot. Either way the backend must never
+/// silently substitute `0`, which would miscompile the constant as zero, so
+/// this panics at the parity hole instead — matching the Cranelift backend's
 /// `missing_legacy_constant`.
+///
+/// The two failures it separates are different bugs and want different fixes:
+/// a *constant-namespace* raw that is missing means the producer never seeded
+/// the pool, while a *body* OpRef arriving at all means the slot was filled
+/// with a runtime value — an op that should have been lowered upstream of the
+/// backend and was not. `#[track_caller]` reports which slot, because the
+/// `consider_*` body is the only thing that identifies the op.
+#[track_caller]
 fn const_bits_or_panic(v: OpRef, constants: &indexmap::IndexMap<u32, i64>, where_: &str) -> i64 {
     if let Some(bits) = v.inline_const_bits() {
         return bits;
     }
-    constants.get(&v.raw()).copied().unwrap_or_else(|| {
-        panic!(
-            "dynasm {where_}: legacy pool-indexed const OpRef (raw={}) is absent \
-             from the constants snapshot — the optimizer producer must seed it \
-             (or mint an inline Const) instead of the backend baking 0. RPython \
-             ConstInt.value (history.py:227) is always present.",
-            v.raw()
-        )
+    let caller = std::panic::Location::caller();
+    let raw = v.raw();
+    constants.get(&raw).copied().unwrap_or_else(|| {
+        let diagnosis = if OpRef::raw_is_constant(raw) {
+            "legacy pool-indexed const absent from the constants snapshot — the \
+             optimizer producer must seed it (or mint an inline Const) instead of \
+             the backend baking 0; RPython ConstInt.value (history.py:227) is \
+             always present"
+        } else {
+            "a BODY OpRef, not a constant at all — this operand slot is one \
+             RPython reads with `.getint()`, so a runtime value reaching it means \
+             the op was never lowered. Upstream guarantees the slot by rewriting \
+             before assembly (aarch64/regalloc.py:188 -> gc.py:109-112), e.g. \
+             RAW_LOAD_I becomes GC_LOAD_INDEXED_I with ConstInt scale/offset/size \
+             (rewrite.py:228-232)"
+        };
+        panic!("dynasm {where_} at {caller}: {v:?} (raw={raw}) is {diagnosis}.")
     })
 }
 
@@ -2361,6 +2383,7 @@ impl<'a> RegAlloc<'a> {
     /// CONST_BIT tag preserved) — see `convert_to_imm` at regalloc.rs
     /// line 1475 and the fail-args handling at line 2079. This helper
     /// must use the same key convention.
+    #[track_caller]
     pub(crate) fn const_value(&self, v: OpRef) -> i64 {
         const_bits_or_panic(v, &self.constants, "const_value")
     }

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -1610,96 +1610,135 @@ impl DynasmBackend {
     // reach them through `&mut dyn Backend`.
 
     /// gc.py:525-531 parity: build a GcRewriterImpl from the active GC.
-    fn gc_rewriter(&self) -> Option<majit_gc::rewrite::GcRewriterImpl> {
-        with_dynasm_active_gc(|gc| {
-            majit_gc::rewrite::GcRewriterImpl {
-                nursery_free_addr: gc.nursery_free_addr(),
-                nursery_top_addr: gc.nursery_top_addr(),
-                max_nursery_size: gc.max_nursery_object_size(),
-                // gc.py:401 `gc_ll_descr.write_barrier_descr` — ask the active
-                // collector rather than assuming the MiniMark layout, so the
-                // rewriter and `emit_write_barrier_fastpath_for_base` agree on
-                // whether barriers exist at all. A collector that needs none
-                // reports `None` (`gc.py:156 GcLLDescr_boehm`), and
-                // `rewrite.py:393` then emits no `COND_CALL_GC_WB*`.
-                wb_descr: gc.get_write_barrier_descr(),
-                jitframe_info: crate::jitframe_layout().and_then(|info| info.jitframe_descrs),
-                // rewrite.py:673 — read compiled_loop_token._ll_initial_locs +
-                // ptr2int(compiled_loop_token.frame_info), both sourced from the
-                // CLT Arc on the registered DynasmCaTarget (model.py:292-338).
-                call_assembler_callee_locs: Some(Box::new(|token_number| {
-                    lookup_call_assembler_callee_locs(token_number)
-                })),
-                // x86/runner.py:31 `load_supported_factors = (1, 2, 4, 8)`
-                // vs llmodel.py:39 default `(1,)` used by the aarch64
-                // backend (which has no scaled store addressing mode and
-                // asserts boxes[3].getint() == 1 in its regalloc — see
-                // `consider_gc_store_indexed` cfg(target_arch = "aarch64")).
-                load_supported_factors: gc_store_supported_factors(),
-                // x86/runner.py:22 overrides model.py:22 base default
-                // `False` to `True`.  aarch64/runner.py inherits the
-                // base `False`, so the rewriter expands LEA to
-                // INT_LSHIFT + INT_ADD + INT_ADD (rewrite.py:1089-1098)
-                // even though the aarch64 backend has a native
-                // `genop_load_effective_address` lowering.
-                supports_load_effective_address: supports_load_effective_address(),
-                // incminimark.py:211 `malloc_zero_filled = False`:
-                // clear_gc_fields / clear_varsize_gc_fields emit only the
-                // per-object GC-pointer initialization required by
-                // rewrite.py:498-535.
-                malloc_zero_filled: false,
-                // gc.py:39 `self.memcpy_fn = memcpy_fn` cast through
-                // `cast_ptr_to_adr` + `cast_adr_to_int` (rewrite.py:1046-1047).
-                memcpy_fn: majit_ir::memcpy_fn_addr(),
-                // gc.py:40-43 `self.memcpy_descr = get_call_descr(...)`.
-                memcpy_descr: majit_ir::make_memcpy_calldescr(),
-                // gc.py:46 `self.str_descr = get_array_descr(self, rstr.STR)`.
-                str_descr: builtin_string_array_descr(majit_ir::OpCode::Newstr)
-                    .expect("Newstr must produce a str ArrayDescr"),
-                // gc.py:47 `self.unicode_descr = get_array_descr(self, rstr.UNICODE)`.
-                unicode_descr: builtin_string_array_descr(majit_ir::OpCode::Newunicode)
-                    .expect("Newunicode must produce a unicode ArrayDescr"),
-                // gc.py:48 `self.str_hash_descr = get_field_descr(self, rstr.STR, 'hash')`.
-                str_hash_descr: builtin_string_hash_field_descr(majit_ir::OpCode::Strhash)
-                    .expect("Strhash must produce a str hash FieldDescr"),
-                // gc.py:49 `self.unicode_hash_descr = get_field_descr(self, rstr.UNICODE, 'hash')`.
-                unicode_hash_descr: builtin_string_hash_field_descr(majit_ir::OpCode::Unicodehash)
-                    .expect("Unicodehash must produce a unicode hash FieldDescr"),
-                // gc.py:33-37 `self.fielddescr_vtable = get_field_descr(
-                // self, rclass.OBJECT, 'typeptr')`.  pyre always emits
-                // a typeptr slot (no `gcremovetypeptr` build), so we
-                // install Some unconditionally.
-                fielddescr_vtable: Some(majit_ir::make_vtable_field_descr()),
-                // gc.py:394 `self.fielddescr_tid = get_field_descr(self,
-                // self.GCClass.HDR, 'tid')` — framework GC.  pyre's GC
-                // is always framework-style; gen_initialize_tid translates
-                // the descr's offset by `-HDR_SIZE` because pyre's HDR
-                // sits before the object pointer.
-                fielddescr_tid: Some(majit_ir::make_tid_field_descr()),
-                malloc_array_fn: dynasm_malloc_array as *const () as i64,
-                malloc_array_nonstandard_fn: dynasm_malloc_array_nonstandard as *const () as i64,
-                malloc_array_oldgen_fn: dynasm_malloc_array_oldgen as *const () as i64,
-                malloc_array_nonstandard_oldgen_fn: dynasm_malloc_array_nonstandard_oldgen
-                    as *const () as i64,
-                malloc_str_fn: dynasm_malloc_str as *const () as i64,
-                malloc_unicode_fn: dynasm_malloc_unicode as *const () as i64,
-                malloc_big_fixedsize_fn: dynasm_malloc_big_fixedsize as *const () as i64,
-                malloc_array_descr: majit_ir::make_malloc_array_calldescr(),
-                malloc_array_nonstandard_descr: majit_ir::make_malloc_array_nonstandard_calldescr(),
-                malloc_str_descr: majit_ir::make_malloc_str_calldescr(),
-                malloc_unicode_descr: majit_ir::make_malloc_unicode_calldescr(),
-                malloc_big_fixedsize_descr: majit_ir::make_malloc_big_fixedsize_calldescr(),
-                standard_array_basesize: std::mem::size_of::<usize>(),
-                standard_array_length_ofs: 0,
-            }
-        })
+    ///
+    /// Built unconditionally. Upstream never asks whether a collector
+    /// exists before rewriting: `aarch64/regalloc.py:188` (and
+    /// `x86/regalloc.py:187`) call `cpu.gc_ll_descr.rewrite_assembler`
+    /// straight through, and `gc.py:109-112` defines it on the base
+    /// `GcLLDescription`, so `GcLLDescr_boehm` — a configuration with no
+    /// nursery and no write barrier — still runs the whole pass. The
+    /// collector decides which *arms* fire inside `rewrite()`, never
+    /// whether the pass runs.
+    ///
+    /// That distinction is load-bearing because the pass is not only about
+    /// the GC. `transform_to_gc_load` (rewrite.py:212-342) is the memory-op
+    /// lowering, and it reads only descrs and CPU addressing capability:
+    /// skip it and `RAW_LOAD_I` never becomes `GC_LOAD_INDEXED_I`
+    /// (rewrite.py:228-232 via :199-205), so a variable index box reaches a
+    /// backend whose only surviving load op wants a *constant* offset
+    /// (`aarch64/regalloc.py:535` `op.getarg(1).getint()`).
+    ///
+    /// Exactly four fields come from the collector. With none installed
+    /// they take upstream's base-class values: `can_use_nursery_malloc`
+    /// returns False (gc.py:81-82, inherited by `GcLLDescr_boehm`), spelled
+    /// here as `max_nursery_size: 0`, and `write_barrier_descr = None`
+    /// (gc.py:156). Allocation then declines to the `dynasm_malloc_*`
+    /// helpers, which already answer without a collector by falling back to
+    /// a raw alloc (`dynasm_alloc_oldgen_typed_or_raw`). Note this default
+    /// differs deliberately from `dynasm_write_barrier_descr`, which
+    /// substitutes the MiniMark layout when the *mutator thread* is not the
+    /// one compiling; here `None` from `with_dynasm_active_gc` means no
+    /// collector is registered at all (the `gc_sync` singleton arm has
+    /// already been consulted), and emitting barriers for a program that
+    /// has no collector would call through an absent helper.
+    fn gc_rewriter(&self) -> majit_gc::rewrite::GcRewriterImpl {
+        let (nursery_free_addr, nursery_top_addr, max_nursery_size, wb_descr) =
+            with_dynasm_active_gc(|gc| {
+                (
+                    gc.nursery_free_addr(),
+                    gc.nursery_top_addr(),
+                    gc.max_nursery_object_size(),
+                    gc.get_write_barrier_descr(),
+                )
+            })
+            .unwrap_or((0, 0, 0, None));
+        majit_gc::rewrite::GcRewriterImpl {
+            nursery_free_addr,
+            nursery_top_addr,
+            max_nursery_size,
+            // gc.py:401 `gc_ll_descr.write_barrier_descr` — ask the active
+            // collector rather than assuming the MiniMark layout, so the
+            // rewriter and `emit_write_barrier_fastpath_for_base` agree on
+            // whether barriers exist at all. A collector that needs none
+            // reports `None` (`gc.py:156 GcLLDescr_boehm`), and
+            // `rewrite.py:393` then emits no `COND_CALL_GC_WB*`.
+            wb_descr,
+            jitframe_info: crate::jitframe_layout().and_then(|info| info.jitframe_descrs),
+            // rewrite.py:673 — read compiled_loop_token._ll_initial_locs +
+            // ptr2int(compiled_loop_token.frame_info), both sourced from the
+            // CLT Arc on the registered DynasmCaTarget (model.py:292-338).
+            call_assembler_callee_locs: Some(Box::new(|token_number| {
+                lookup_call_assembler_callee_locs(token_number)
+            })),
+            // x86/runner.py:31 `load_supported_factors = (1, 2, 4, 8)`
+            // vs llmodel.py:39 default `(1,)` used by the aarch64
+            // backend (which has no scaled store addressing mode and
+            // asserts boxes[3].getint() == 1 in its regalloc — see
+            // `consider_gc_store_indexed` cfg(target_arch = "aarch64")).
+            load_supported_factors: gc_store_supported_factors(),
+            // x86/runner.py:22 overrides model.py:22 base default
+            // `False` to `True`.  aarch64/runner.py inherits the
+            // base `False`, so the rewriter expands LEA to
+            // INT_LSHIFT + INT_ADD + INT_ADD (rewrite.py:1089-1098)
+            // even though the aarch64 backend has a native
+            // `genop_load_effective_address` lowering.
+            supports_load_effective_address: supports_load_effective_address(),
+            // incminimark.py:211 `malloc_zero_filled = False`:
+            // clear_gc_fields / clear_varsize_gc_fields emit only the
+            // per-object GC-pointer initialization required by
+            // rewrite.py:498-535.
+            malloc_zero_filled: false,
+            // gc.py:39 `self.memcpy_fn = memcpy_fn` cast through
+            // `cast_ptr_to_adr` + `cast_adr_to_int` (rewrite.py:1046-1047).
+            memcpy_fn: majit_ir::memcpy_fn_addr(),
+            // gc.py:40-43 `self.memcpy_descr = get_call_descr(...)`.
+            memcpy_descr: majit_ir::make_memcpy_calldescr(),
+            // gc.py:46 `self.str_descr = get_array_descr(self, rstr.STR)`.
+            str_descr: builtin_string_array_descr(majit_ir::OpCode::Newstr)
+                .expect("Newstr must produce a str ArrayDescr"),
+            // gc.py:47 `self.unicode_descr = get_array_descr(self, rstr.UNICODE)`.
+            unicode_descr: builtin_string_array_descr(majit_ir::OpCode::Newunicode)
+                .expect("Newunicode must produce a unicode ArrayDescr"),
+            // gc.py:48 `self.str_hash_descr = get_field_descr(self, rstr.STR, 'hash')`.
+            str_hash_descr: builtin_string_hash_field_descr(majit_ir::OpCode::Strhash)
+                .expect("Strhash must produce a str hash FieldDescr"),
+            // gc.py:49 `self.unicode_hash_descr = get_field_descr(self, rstr.UNICODE, 'hash')`.
+            unicode_hash_descr: builtin_string_hash_field_descr(majit_ir::OpCode::Unicodehash)
+                .expect("Unicodehash must produce a unicode hash FieldDescr"),
+            // gc.py:33-37 `self.fielddescr_vtable = get_field_descr(
+            // self, rclass.OBJECT, 'typeptr')`.  pyre always emits
+            // a typeptr slot (no `gcremovetypeptr` build), so we
+            // install Some unconditionally.
+            fielddescr_vtable: Some(majit_ir::make_vtable_field_descr()),
+            // gc.py:394 `self.fielddescr_tid = get_field_descr(self,
+            // self.GCClass.HDR, 'tid')` — framework GC.  pyre's GC
+            // is always framework-style; gen_initialize_tid translates
+            // the descr's offset by `-HDR_SIZE` because pyre's HDR
+            // sits before the object pointer.
+            fielddescr_tid: Some(majit_ir::make_tid_field_descr()),
+            malloc_array_fn: dynasm_malloc_array as *const () as i64,
+            malloc_array_nonstandard_fn: dynasm_malloc_array_nonstandard as *const () as i64,
+            malloc_array_oldgen_fn: dynasm_malloc_array_oldgen as *const () as i64,
+            malloc_array_nonstandard_oldgen_fn: dynasm_malloc_array_nonstandard_oldgen as *const ()
+                as i64,
+            malloc_str_fn: dynasm_malloc_str as *const () as i64,
+            malloc_unicode_fn: dynasm_malloc_unicode as *const () as i64,
+            malloc_big_fixedsize_fn: dynasm_malloc_big_fixedsize as *const () as i64,
+            malloc_array_descr: majit_ir::make_malloc_array_calldescr(),
+            malloc_array_nonstandard_descr: majit_ir::make_malloc_array_nonstandard_calldescr(),
+            malloc_str_descr: majit_ir::make_malloc_str_calldescr(),
+            malloc_unicode_descr: majit_ir::make_malloc_unicode_calldescr(),
+            malloc_big_fixedsize_descr: majit_ir::make_malloc_big_fixedsize_calldescr(),
+            standard_array_basesize: std::mem::size_of::<usize>(),
+            standard_array_length_ofs: 0,
+        }
     }
 
     /// rewrite.py:345 parity: run GC rewriter on ops before assembly.
     /// Returns the rewritten ops plus the per-loop reference-constant
     /// list (`rewrite.py:352 gcrefs_output_list`) the caller turns into a
-    /// `GcTable`. The list is empty when no rewriter is configured or the
-    /// trace references no reference constants.
+    /// `GcTable`. The list is empty when the trace references no reference
+    /// constants.
     fn prepare_ops_for_compile(
         &mut self,
         inputargs: &[InputArg],
@@ -1725,7 +1764,8 @@ impl DynasmBackend {
             .collect();
         // rewrite.py:489 parity: inject str_descr/unicode_descr for NEWSTR/NEWUNICODE
         inject_builtin_string_descrs(&mut normalized);
-        if let Some(rewriter) = self.gc_rewriter() {
+        {
+            let rewriter = self.gc_rewriter();
             use majit_gc::GcRewriter;
             // The rewriter takes the typed `Const` pool directly; each box
             // variant carries its own type (`Const::get_type`).
@@ -1741,8 +1781,6 @@ impl DynasmBackend {
             // like aheui's logo).
             self.constants = new_constants;
             (result, gcrefs)
-        } else {
-            (normalized, Vec::new())
         }
     }
 

--- a/majit/majit-gc/src/rewrite.rs
+++ b/majit/majit-gc/src/rewrite.rs
@@ -3112,22 +3112,24 @@ impl GcRewriter for GcRewriterImpl {
                 counts_toward_high_water(pos).then(|| pos.raw())
             })
             .max();
+        // A trace whose ops all carry void results — `Label` /
+        // `SETARRAYITEM_GC` / `FINISH` is one — leaves `max_result_pos` at
+        // `None`, so the argument scan has to run on its own rather than under
+        // a result-derived floor: the mark it produces is the only thing
+        // separating a minted position from a live input arg.
         let mut max_raw_pos = max_result_pos;
-        if let Some(result_high_water) = max_result_pos {
-            let mut reserve_later_box = |pos: OpRef| {
-                if counts_toward_high_water(pos) && pos.raw() > result_high_water {
-                    max_raw_pos =
-                        Some(max_raw_pos.map_or(pos.raw(), |old: u32| old.max(pos.raw())));
-                }
-            };
-            for op in &ops {
-                for arg in op.getarglist() {
+        let mut reserve_later_box = |pos: OpRef| {
+            if counts_toward_high_water(pos) {
+                max_raw_pos = Some(max_raw_pos.map_or(pos.raw(), |old: u32| old.max(pos.raw())));
+            }
+        };
+        for op in &ops {
+            for arg in op.getarglist() {
+                reserve_later_box(arg.to_opref());
+            }
+            if let Some(fail_args) = op.getfailargs() {
+                for arg in fail_args {
                     reserve_later_box(arg.to_opref());
-                }
-                if let Some(fail_args) = op.getfailargs() {
-                    for arg in fail_args {
-                        reserve_later_box(arg.to_opref());
-                    }
                 }
             }
         }
@@ -4280,8 +4282,13 @@ mod tests {
         let gc_fields = vec![ref_field_descr_at(24), ref_field_descr_at(32)];
         let descr = size_descr_with_gc_fields(48, 42, gc_fields);
         let val = OpRef::const_ptr(majit_ir::GcRef(0x1234));
+        // The SETFIELD_GC names the allocation by position, so the allocation
+        // has to carry that position rather than rely on the rewriter minting
+        // it there.
+        let new_op = Op::with_descr(OpCode::New, &[], descr);
+        new_op.pos.set(OpRef::ref_op(0));
         let ops = vec![
-            Op::with_descr(OpCode::New, &[], descr),
+            new_op,
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[ro(OpRef::ref_op(0)), ro(val)],
@@ -4488,11 +4495,14 @@ mod tests {
         rw.rewrite_for_gc(&ops);
 
         // Now rewrite a SetfieldGc that stores a ref into the new object.
+        // The allocation carries the position the store names it by.
+        let new_op = Op::with_descr(OpCode::New, &[], size_descr(32, 1));
+        new_op.pos.set(OpRef::ref_op(0));
         let ops2 = vec![
-            Op::with_descr(OpCode::New, &[], size_descr(32, 1)),
+            new_op,
             Op::with_descr(
                 OpCode::SetfieldGc,
-                &[ro(OpRef::ref_op(0)), ro(OpRef::ref_op(99))], // arg(0) = pos of the alloc = 0
+                &[ro(OpRef::ref_op(0)), ro(OpRef::ref_op(99))], // arg(0) = pos of the alloc
                 ref_field_descr(),
             ),
         ];
@@ -4707,6 +4717,63 @@ mod tests {
                 .filter(|op| op.opcode == OpCode::GcStore)
                 .all(|op| op.pos.get().is_none())
         );
+    }
+
+    /// A trace whose ops all carry void results has no result position to
+    /// seed the fresh-box high-water mark, and then the argument scan is the
+    /// only thing keeping a minted position off a live input arg.
+    /// `OpRef::raw()` folds `InputArgRef(0)` and `IntOp(0)` onto one payload
+    /// and the backends key their SSA values by it, so a mark left at 0 hands
+    /// the pre-scale `INT_LSHIFT` (rewrite.py:1127-1131) the array base
+    /// pointer's slot and the store loses its base.
+    #[test]
+    fn test_result_less_trace_reserves_input_arg_positions() {
+        let rw = make_rewriter();
+        let none = OpRef::NONE.raw();
+        let ops = vec![
+            mk_op(
+                OpCode::Label,
+                &[
+                    OpRef::input_arg_ref(0),
+                    OpRef::input_arg_int(1),
+                    OpRef::input_arg_int(2),
+                ],
+                none,
+            ),
+            // 4-byte items, and `make_rewriter` takes the llmodel.py:39
+            // `load_supported_factors = (1,)` default, so the factor forces a
+            // pre-scale rather than an addressing-mode scale.
+            mk_op_with_descr(
+                OpCode::SetarrayitemGc,
+                &[
+                    OpRef::input_arg_ref(0),
+                    OpRef::input_arg_int(1),
+                    OpRef::input_arg_int(2),
+                ],
+                none,
+                array_descr_int(),
+            ),
+            mk_op(OpCode::Finish, &[], none),
+        ];
+
+        let result = rw.rewrite_for_gc(&ops);
+
+        assert!(
+            result.iter().any(|op| op.opcode == OpCode::IntLshift),
+            "expected a pre-scale op; without one the test proves nothing"
+        );
+        for pos in result
+            .iter()
+            .map(|op| op.pos.get())
+            .filter(|p| !p.is_none())
+        {
+            assert!(
+                pos.raw() > 2,
+                "minted position {} aliases input arg {}",
+                pos.raw(),
+                pos.raw()
+            );
+        }
     }
 
     #[test]

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -2838,6 +2838,27 @@ impl<S: JitState> JitDriver<S> {
                                     ),
                                     crate::pyjitpl::BridgeCompileResult::Compiled
                                 ),
+                                // compile.py:269-270: a cross-loop CUT keeps its cut prefix
+                                // in `front_target_tokens[0]`, where a loop closed at its own
+                                // header keeps its PREAMBLE — the peeled iteration that
+                                // re-derives the specialized label's invariants from the
+                                // loop's entry state, which is what makes `jump_to_preamble`
+                                // (unroll.py:238-242) sound as the no-matching-label
+                                // fallback. The cut prefix's invariants instead hold only
+                                // after the guards preceding the cut point have run.
+                                // `ResumeFromInterpDescr.get_resumestorage()` is None, so an
+                                // entry bridge carries no runtime values, `generate_guards`
+                                // rejects every specialized label, and the JUMP always
+                                // reaches that slot; on cel's
+                                // `batch_chain_eager_fold_traps` the unproven index bound
+                                // became an out-of-bounds store and a SIGSEGV on the reload.
+                                //
+                                // Scoped to this arm alone. A `ResumeGuardDescr` has resume
+                                // storage, so a specialized label can match and the fallback
+                                // need not be reached — and declining the guard origin too
+                                // makes `pi/pi.jinseo` at `MAJIT_THRESHOLD=50` compute wrong
+                                // digits from byte 865, same length, no crash.
+                                None if self.meta.is_cross_loop_cut_key(target_key) => false,
                                 None => match self.compile_trace_entry_data() {
                                     Some((original_green_key, entry_meta)) => matches!(
                                         self.meta.compile_trace_from_interp(
@@ -8126,5 +8147,189 @@ mod tests {
         // return None from index().
         let driver = JitDriver::<TypedRestoreState>::new(1);
         assert_eq!(driver.index(), None);
+    }
+}
+
+/// pyjitpl.py:3001-3007's JUMP arm, over the one target class it must not
+/// take: a loop stored under a cross-loop cut's inner jitcell token
+/// (compile.py:269-270).
+#[cfg(test)]
+mod cross_loop_cut_close_tests {
+    use super::*;
+    use majit_ir::{OpCode, OpRef};
+
+    /// Greens the compiled inner loop is registered under.
+    fn inner_greens() -> (Vec<i64>, Vec<i64>, Vec<i64>) {
+        (vec![4242], vec![], vec![])
+    }
+
+    /// A trace whose closing JUMP carries ONE int, matching the inner loop's
+    /// single inputarg (compile.py:334 `jump.numargs() == label.numargs()`).
+    #[derive(Default)]
+    struct CutCloseState;
+
+    impl JitState for CutCloseState {
+        type Meta = ();
+        type Sym = ();
+        type Env = ();
+
+        fn build_meta(&self, _header_pc: usize, _env: &Self::Env) -> Self::Meta {}
+
+        fn extract_live(&self, _meta: &Self::Meta) -> Vec<i64> {
+            vec![0]
+        }
+
+        fn create_sym(_meta: &Self::Meta, _header_pc: usize) -> Self::Sym {}
+
+        fn is_compatible(&self, _meta: &Self::Meta) -> bool {
+            true
+        }
+
+        fn restore(&mut self, _meta: &Self::Meta, _values: &[i64]) {}
+
+        fn collect_jump_args(_sym: &Self::Sym) -> Vec<OpRef> {
+            vec![OpRef::input_arg_int(0)]
+        }
+
+        fn validate_close(_sym: &Self::Sym, _meta: &Self::Meta) -> bool {
+            true
+        }
+    }
+
+    /// Trace and compile a one-inputarg loop at `key`, registering it under
+    /// `inner_greens()`. `cut` routes `compile_loop` through the cross-loop cut
+    /// (compile.py:269-270) so the loop is stored under the inner token.
+    fn compile_inner_loop(driver: &mut JitDriver<CutCloseState>, key: u64, cut: bool) {
+        assert!(matches!(
+            driver.meta.on_back_edge(key, &[0]),
+            BackEdgeAction::Interpret
+        ));
+        assert!(matches!(
+            driver.meta.on_back_edge(key, &[0]),
+            BackEdgeAction::StartedTracing
+        ));
+        {
+            let ctx = driver.meta.trace_ctx().expect("should be tracing");
+            let i0 = OpRef::input_arg_int(0);
+            let c1 = ctx.const_int(1);
+            let sum = ctx.record_op(OpCode::IntAdd, &[i0, c1]);
+            // The optimizer rejects a guardless loop.
+            let g = ctx.record_guard(OpCode::GuardTrue, &[i0], 0);
+            ctx.capture_snapshot_for_last_guard(&[sum], 0, 0);
+            ctx.set_fail_args(g, &[sum]);
+            if cut {
+                ctx.cut_inner_green_key = Some(key);
+            }
+        }
+        driver.meta.compile_loop(&[OpRef::input_arg_int(0)], ());
+        assert!(driver.has_compiled_loop(key), "inner loop must compile");
+        driver.meta.record_loop_header_greens(key, inner_greens());
+        assert_eq!(
+            driver.meta.is_cross_loop_cut_key(key),
+            cut,
+            "the cut mark must follow the key compile_loop stored under",
+        );
+    }
+
+    /// Start an interp-origin trace (pyjitpl.py:2905 `ResumeFromInterpDescr`)
+    /// and record one op into it.
+    fn start_outer_trace(driver: &mut JitDriver<CutCloseState>, outer_key: u64) {
+        let mut state = CutCloseState;
+        driver.force_start_tracing(outer_key, outer_key as usize, &mut state, &());
+        assert!(driver.is_tracing(), "outer trace must start");
+        assert!(
+            driver.meta.bridge_info().is_none(),
+            "force_start_tracing is the interp origin",
+        );
+        let ctx = driver.meta.trace_ctx().expect("tracing ⇒ trace ctx");
+        let i0 = OpRef::input_arg_int(0);
+        let c2 = ctx.const_int(2);
+        let sum = ctx.record_op(OpCode::IntAdd, &[i0, c2]);
+        let g = ctx.record_guard(OpCode::GuardTrue, &[i0], 0);
+        ctx.capture_snapshot_for_last_guard(&[sum], 0, 0);
+        ctx.set_fail_args(g, &[sum]);
+    }
+
+    /// The publish the walker makes at a merge point that already owns a
+    /// procedure token (pyjitpl.py:3005 `get_procedure_token(greenboxes)`).
+    fn close_jumping_into(driver: &mut JitDriver<CutCloseState>, target: u64) {
+        driver.merge_point(|meta, _sym| {
+            let Some(ctx) = meta.trace_ctx() else {
+                return TraceAction::Continue;
+            };
+            if std::mem::take(&mut ctx.merge_point_resumed) {
+                return TraceAction::Continue;
+            }
+            ctx.close_greens = Some(inner_greens());
+            ctx.close_jump_into_key = Some(target);
+            TraceAction::CloseLoop
+        });
+    }
+
+    /// A cross-loop cut leaves no PREAMBLE in `front_target_tokens[0]` — that
+    /// slot holds the cut prefix, whose entry invariants only the cutting trace
+    /// has proven. `jump_to_preamble` (unroll.py:238-242) is the fallback
+    /// whenever no specialized label matches, and an interp-origin entry bridge
+    /// always reaches it, so a cut target would be entered with the specialized
+    /// label's bounds unestablished.
+    #[test]
+    fn interp_origin_close_declines_a_cross_loop_cut_target() {
+        let mut driver = JitDriver::<CutCloseState>::new(2);
+        driver.meta.finish_setup_descrs_for_jitdrivers();
+        let inner_key = 7031u64;
+        compile_inner_loop(&mut driver, inner_key, /* cut */ true);
+
+        start_outer_trace(&mut driver, 7032);
+        close_jumping_into(&mut driver, inner_key);
+
+        // pyjitpl.py:3009-3010: `compile_trace` returned without raising, so
+        // the trace is NOT given up — the walk keeps recording.
+        assert!(
+            driver.is_tracing(),
+            "a cut target must not be entered by an entry bridge",
+        );
+        assert!(
+            driver
+                .meta
+                .trace_ctx()
+                .is_some_and(|ctx| ctx.cross_loop_close_declined(inner_key)),
+            "the decline must be latched so the walk does not re-attempt it",
+        );
+    }
+
+    /// The control the decline is measured against: the same close into a loop
+    /// compiled at its own header does take the JUMP, and a successful
+    /// `compile_trace` ends the trace (pyjitpl.py:3119-3123
+    /// `raise_if_successful`).
+    #[test]
+    fn interp_origin_close_takes_a_non_cut_target() {
+        let mut driver = JitDriver::<CutCloseState>::new(2);
+        driver.meta.finish_setup_descrs_for_jitdrivers();
+        let inner_key = 7051u64;
+        compile_inner_loop(&mut driver, inner_key, /* cut */ false);
+
+        start_outer_trace(&mut driver, 7052);
+        close_jumping_into(&mut driver, inner_key);
+
+        assert!(
+            !driver.is_tracing(),
+            "a non-cut target closes: compile_trace raises and tracing ends",
+        );
+    }
+
+    /// Retiring the loop retires the cut mark with it, so a later loop compiled
+    /// at the same key is not judged by its predecessor.
+    #[test]
+    fn retiring_a_cut_loop_forgets_its_cut_mark() {
+        let mut driver = JitDriver::<CutCloseState>::new(2);
+        driver.meta.finish_setup_descrs_for_jitdrivers();
+        let inner_key = 7041u64;
+        compile_inner_loop(&mut driver, inner_key, /* cut */ true);
+
+        driver.meta.remove_compiled_loop(inner_key);
+        assert!(
+            !driver.meta.is_cross_loop_cut_key(inner_key),
+            "the cut mark must not outlive the loop it describes",
+        );
     }
 }

--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -1353,6 +1353,37 @@ impl OptHeap {
         }
     }
 
+    /// Run a guard's `force_lazy_sets_for_guard` at heap's OWN `emit()` point
+    /// (heap.py:417-418: `emitting_operation(op)` precedes `emit_postponed_op()`)
+    /// instead of waiting for the deferred `emitting_operation` callback that
+    /// `Optimizer::emit_operation` fires at final emission. A guard that pairs
+    /// with a postponed op — GUARD_NOT_FORCED with its CALL_MAY_FORCE,
+    /// GUARD_[NO_]OVERFLOW with its INT_*_OVF — must not get a lazy SETFIELD_GC
+    /// scheduled between the two.
+    ///
+    /// The virtual-valued sets `force_lazy_sets_for_guard` hands back are put
+    /// straight back into the caches, so the later `emitting_operation` call
+    /// re-collects them into `ctx.pending_for_guard` and the guard's
+    /// `rd_pendingfields` is unchanged.
+    fn force_lazy_sets_for_guard_early(&mut self, ctx: &mut OptContext) {
+        let pending_virtual = self.force_lazy_sets_for_guard(ctx.current_pass_idx, ctx);
+        for pending_op in pending_virtual {
+            let descr = pending_op.getdescr().unwrap().clone();
+            if pending_op.opcode == OpCode::SetarrayitemGc {
+                // A non-constant index has no `arrayitem_cache` slot to hold
+                // it, so it cannot be re-collected — emit it here.
+                match ctx.get_constant_int_box(&pending_op.arg(1).get_box_replacement(false)) {
+                    Some(index) => self.arrayitem_cache(&descr, index).lazy_set = Some(pending_op),
+                    None => {
+                        ctx.emit(pending_op);
+                    }
+                }
+            } else {
+                self.field_cache(&descr).lazy_set = Some(pending_op);
+            }
+        }
+    }
+
     /// heap.py:608-637 force_lazy_sets_for_guard()
     ///
     /// Returns pendingfields: SetfieldGc/SetarrayitemGc ops where the stored
@@ -3222,24 +3253,7 @@ impl OptHeap {
                 // its paired guard, breaking the backend's strict
                 // guard_not_forced-at-+1 invariant
                 // (x86/assembler.py:2225-2244 _store_force_index).
-                let pending_virtual = self.force_lazy_sets_for_guard(ctx.current_pass_idx, ctx);
-                for pending_op in pending_virtual {
-                    if pending_op.opcode == OpCode::SetarrayitemGc {
-                        let descr = pending_op.getdescr().unwrap().clone();
-                        if let Some(index) =
-                            ctx.get_constant_int_box(&pending_op.arg(1).get_box_replacement(false))
-                        {
-                            let cai = self.arrayitem_cache(&descr, index);
-                            cai.lazy_set = Some(pending_op);
-                        } else {
-                            ctx.emit(pending_op);
-                        }
-                    } else {
-                        let descr = pending_op.getdescr().unwrap().clone();
-                        let cf = self.field_cache(&descr);
-                        cf.lazy_set = Some(pending_op);
-                    }
-                }
+                self.force_lazy_sets_for_guard_early(ctx);
                 if let Some(postponed) = self.postponed_op.take() {
                     if crate::majit_log_enabled() {
                         eprintln!(
@@ -3260,6 +3274,21 @@ impl OptHeap {
                     );
                 }
                 return OptimizationResult::Emit(op.clone());
+            }
+
+            // heap.py: GUARD_OVERFLOW / GUARD_NO_OVERFLOW — same ordering rule
+            // as GUARD_NOT_FORCED above, for the same reason. The postponed op
+            // here is the INT_*_OVF that OptPure released (pure.py:139-155),
+            // and its overflow answer lives in the condition flags, so a lazy
+            // SETFIELD_GC flushed after it lands BETWEEN the arithmetic and its
+            // guard. `aarch64/assembler.py:1191-1195 _walk_operations` asserts
+            // that pair is `operations[i]` / `operations[i + 1]`.
+            OpCode::GuardOverflow | OpCode::GuardNoOverflow => {
+                self.force_lazy_sets_for_guard_early(ctx);
+                // The generic `emit()` wrapper below flushes `postponed_op`
+                // for every op it downstreams (heap.py:418), which now runs
+                // after the lazy-set flush — the upstream order.
+                OptimizationResult::Emit(op.clone())
             }
 
             // ── heap.py: COND_CALL handling ──

--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -1353,13 +1353,17 @@ impl OptHeap {
         }
     }
 
-    /// Run a guard's `force_lazy_sets_for_guard` at heap's OWN `emit()` point
-    /// (heap.py:417-418: `emitting_operation(op)` precedes `emit_postponed_op()`)
-    /// instead of waiting for the deferred `emitting_operation` callback that
-    /// `Optimizer::emit_operation` fires at final emission. A guard that pairs
-    /// with a postponed op — GUARD_NOT_FORCED with its CALL_MAY_FORCE,
-    /// GUARD_[NO_]OVERFLOW with its INT_*_OVF — must not get a lazy SETFIELD_GC
-    /// scheduled between the two.
+    /// heap.py:432-434 `emitting_operation`'s guard case, run at heap's OWN
+    /// `emit()` point (heap.py:417, which precedes `emit_postponed_op()` on
+    /// heap.py:418) instead of at the deferred `emitting_operation` callback
+    /// that `Optimizer::emit_operation` fires at final emission.
+    ///
+    /// The order matters for every guard that arrives with a postponed op
+    /// pending: GUARD_NOT_FORCED after its CALL_MAY_FORCE, GUARD_[NO_]OVERFLOW
+    /// after its INT_*_OVF, GUARD_TRUE / GUARD_FALSE after the comparison they
+    /// test. A lazy SETFIELD_GC forced late lands between the pair, and the
+    /// backend reads the second of the two out of the first
+    /// (`aarch64/assembler.py:1187-1193`).
     ///
     /// The virtual-valued sets `force_lazy_sets_for_guard` hands back are put
     /// straight back into the caches, so the later `emitting_operation` call
@@ -3060,15 +3064,10 @@ impl OptHeap {
             return OptimizationResult::Emit(op.clone());
         }
 
-        // Note: postponed_op (from CallMayForce) must only be emitted at
-        // GuardNotForced, not at arbitrary guards. RPython's emit() callback
-        // calls emit_postponed_op() before every op, but the postpone→emit
-        // cycle is specifically CallMayForce→GuardNotForced. Don't emit here.
-
         if opcode.is_guard() {
-            // force_lazy_sets_for_guard is now called via emitting_operation
-            // callback (which runs for ALL guards regardless of which pass emits
-            // them). No need to force here — it was already done.
+            // Every guard heap keeps is downstreamed as `Emit`, and
+            // `propagate_forward` then runs heap.py:417-418 for it — the
+            // lazy-set flush, then the postponed op. Neither step belongs here.
             return OptimizationResult::Emit(op.clone());
         }
 
@@ -3240,56 +3239,13 @@ impl OptHeap {
                 return OptimizationResult::Remove;
             }
 
-            // heap.py: GUARD_NOT_FORCED — emit the postponed call_may_force,
-            // then handle as a guard. RPython uses force_lazy_sets_for_guard
-            // (not force_all_lazy) — immutable caches survive.
-            OpCode::GuardNotForced | OpCode::GuardNotForced2 => {
-                // heap.py emit() runs emitting_operation(op) BEFORE
-                // emit_postponed_op(): the guard's lazy-set flush
-                // (force_lazy_sets_for_guard) emits non-virtual lazy
-                // setfields first, THEN the postponed call_may_force is
-                // emitted, THEN the guard itself.  Flushing after the
-                // call would schedule a SETFIELD_GC between the call and
-                // its paired guard, breaking the backend's strict
-                // guard_not_forced-at-+1 invariant
-                // (x86/assembler.py:2225-2244 _store_force_index).
-                self.force_lazy_sets_for_guard_early(ctx);
-                if let Some(postponed) = self.postponed_op.take() {
-                    if crate::majit_log_enabled() {
-                        eprintln!(
-                            "[opt-heap] emit postponed {:?} pos={:?} before {:?} pos={:?}",
-                            postponed.opcode,
-                            postponed.pos.get(),
-                            op.opcode,
-                            op.pos.get()
-                        );
-                    }
-                    // RPython emit_postponed_op: route through next_optimization
-                    ctx.emit_extra(ctx.current_pass_idx, postponed);
-                } else if crate::majit_log_enabled() {
-                    eprintln!(
-                        "[opt-heap] no postponed op before {:?} pos={:?}",
-                        op.opcode,
-                        op.pos.get()
-                    );
-                }
-                return OptimizationResult::Emit(op.clone());
-            }
-
-            // heap.py: GUARD_OVERFLOW / GUARD_NO_OVERFLOW — same ordering rule
-            // as GUARD_NOT_FORCED above, for the same reason. The postponed op
-            // here is the INT_*_OVF that OptPure released (pure.py:139-155),
-            // and its overflow answer lives in the condition flags, so a lazy
-            // SETFIELD_GC flushed after it lands BETWEEN the arithmetic and its
-            // guard. `aarch64/assembler.py:1191-1195 _walk_operations` asserts
-            // that pair is `operations[i]` / `operations[i + 1]`.
-            OpCode::GuardOverflow | OpCode::GuardNoOverflow => {
-                self.force_lazy_sets_for_guard_early(ctx);
-                // The generic `emit()` wrapper below flushes `postponed_op`
-                // for every op it downstreams (heap.py:418), which now runs
-                // after the lazy-set flush — the upstream order.
-                OptimizationResult::Emit(op.clone())
-            }
+            // GUARD_NOT_FORCED (with its postponed CALL_MAY_FORCE) and
+            // GUARD_[NO_]OVERFLOW (with its postponed INT_*_OVF) need no arms of
+            // their own: `propagate_forward` runs heap.py:417-418 — the guard's
+            // `force_lazy_sets_for_guard`, then the postponed op — for every
+            // guard, so both pairs stay adjacent. heap.py likewise has no
+            // `optimize_GUARD_NOT_FORCED` and no `optimize_GUARD_NO_OVERFLOW`;
+            // its only guard-named methods are the two below.
 
             // ── heap.py: COND_CALL handling ──
             OpCode::CondCallN => {
@@ -3420,16 +3376,65 @@ impl Optimization for OptHeap {
         ctx: &mut OptContext,
     ) -> OptimizationResult {
         let result = self.dispatch_propagate(op, op_rc, ctx);
-        // heap.py:417-425 emit() override parity:
-        // Before emitting any new op, flush the postponed op. Then
-        // postpone comparison/ovf ops (call_may_force already handled
-        // in its own match arm).
-        if let OptimizationResult::Emit(ref emit_op) = result {
-            // Step 1: emit_postponed_op — flush previous postponed
+        // heap.py:417-424 `emit()` override parity, in upstream's order:
+        //
+        //     self.emitting_operation(op)     # heap.py:417
+        //     self.emit_postponed_op()        # heap.py:418
+        //     ... postpone comparison / call_may_force / ovf, else pass on
+        //
+        // Both of the first two fire for EVERY op that reaches `heap.emit()` —
+        // any op this pass downstreams, not only the ones it returns as `Emit`.
+        // PassOn / Replace / Restart hand the op to the next pass (eventually
+        // `Optimizer::emit_operation`), so they reach `emit()` too. Gating on
+        // `Emit` alone held a postponed comparison past a following non-`Emit`
+        // consumer (e.g. a COND_CALL whose condition is the comparison),
+        // emitting the comparison after its use. A removed op never reaches
+        // `emit()`, so Remove / InvalidLoop must run neither step.
+        let downstreamed = matches!(
+            result,
+            OptimizationResult::Emit(_)
+                | OptimizationResult::PassOn
+                | OptimizationResult::Replace(_)
+                | OptimizationResult::Restart(_)
+        );
+        if downstreamed {
+            // heap.py:417 `emitting_operation(op)`, whose guard case is
+            // heap.py:432-434: ONE `rop.is_guard(op.opnum)` test covering every
+            // guard opcode, running `force_lazy_sets_for_guard`.
+            //
+            // This is about ORDER, not coverage. The force already ran for every
+            // guard — `Optimizer::emit_operation` fires `emitting_operation` for
+            // all passes at final emission — but it ran too LATE, after the
+            // postponed op had been released. Running it here, at heap's own
+            // emit point, puts the forced SETFIELD_GC in FRONT of the op
+            // released on the next line instead of between that op and its
+            // guard. Both consumers want the adjacency: an `INT_*_OVF`
+            // publishes its answer in the condition flags, and there is nothing
+            // to re-test if it is lost (`aarch64/assembler.py:1191-1193`
+            // asserts it); a comparison is merely fused into its guard by
+            // `next_op_can_accept_cc` (`aarch64/assembler.py:1187-1190`) and
+            // falls back to materialise-and-re-test when it is not, so for that
+            // one the cost is an extra `tst`, not a wrong answer.
+            if op.opcode.is_guard() {
+                self.force_lazy_sets_for_guard_early(ctx);
+            }
+            // heap.py:418 `emit_postponed_op()`.
             if let Some(postponed) = self.postponed_op.take() {
+                if crate::majit_log_enabled() {
+                    eprintln!(
+                        "[opt-heap] emit postponed {:?} pos={:?} before {:?} pos={:?}",
+                        postponed.opcode,
+                        postponed.pos.get(),
+                        op.opcode,
+                        op.pos.get()
+                    );
+                }
                 ctx.emit_extra(ctx.current_pass_idx, postponed);
             }
-            // Step 2: postpone comparison/ovf
+        }
+        // heap.py:419-423 — postpone comparison / ovf ops. CALL_MAY_FORCE is
+        // postponed in its own arm, which returns Remove before reaching here.
+        if let OptimizationResult::Emit(ref emit_op) = result {
             if emit_op.opcode.is_comparison() || emit_op.opcode.is_ovf() {
                 self.postponed_op = Some(emit_op.clone());
                 // optimizer.py:84-87 — postponed ops do NOT call
@@ -3439,27 +3444,6 @@ impl Optimization for OptHeap {
                 // before this comparison still observes REMOVED.
                 return OptimizationResult::Remove;
             }
-        }
-        // heap.py:419 `emit_postponed_op()` fires for EVERY op that reaches
-        // `heap.emit()` — i.e. any op the heap pass downstreams, not only the
-        // ones it returns as `Emit`. PassOn / Replace / Restart hand the op to
-        // the next pass (eventually `Optimizer::emit_operation`), so the
-        // previously postponed comparison/ovf must flush BEFORE them. The drain
-        // at `propagate_from_pass` (after this pass returns) emits the flushed
-        // op ahead of the current one. Gating the flush on `Emit` alone held a
-        // postponed comparison past a following non-`Emit` consumer (e.g. a
-        // COND_CALL whose condition is the comparison), emitting the comparison
-        // after its use. A removed op never reaches `emit()`, so Remove /
-        // InvalidLoop must NOT flush.
-        match &result {
-            OptimizationResult::PassOn
-            | OptimizationResult::Replace(_)
-            | OptimizationResult::Restart(_) => {
-                if let Some(postponed) = self.postponed_op.take() {
-                    ctx.emit_extra(ctx.current_pass_idx, postponed);
-                }
-            }
-            _ => {}
         }
         // optimizer.py:84-92 — `Optimization.emit(op)` and
         // `Optimization.emit_result(opt_result)` BOTH set
@@ -4726,6 +4710,65 @@ mod tests {
         assert!(
             last_setfield_at < guard_at,
             "both stores must be emitted before the guard they precede",
+        );
+    }
+
+    /// heap.py:417-419 `emit()` runs `emitting_operation(op)` — for a guard,
+    /// `force_lazy_sets_for_guard` — BEFORE `emit_postponed_op()`. That order is
+    /// what keeps a postponed op adjacent to the guard that reads it:
+    ///
+    ///   setfield_gc(p0, i1, descr=d)   <- lazy
+    ///   i3 = int_gt(i2, 10)            <- heap.py:420-423 postpones comparisons
+    ///   guard_true(i3)
+    ///
+    /// must emit `[setfield_gc][int_gt][guard_true]`. Emitting the forced set
+    /// between the comparison and its guard costs the fusion that
+    /// `aarch64/assembler.py:1187-1190` performs via `next_op_can_accept_cc`.
+    #[test]
+    fn test_lazy_set_flushes_before_a_postponed_comparison_not_between_it_and_its_guard() {
+        let d = descr(0);
+        let mut ops = vec![
+            Op::with_descr(
+                OpCode::SetfieldGc,
+                &[
+                    rooted_inputarg_operand(Type::Ref, 100),
+                    rooted_inputarg_operand(Type::Int, 101),
+                ],
+                d.clone(),
+            ),
+            Op::new(
+                OpCode::IntGt,
+                &[
+                    rooted_inputarg_operand(Type::Int, 102),
+                    Operand::const_from_value(majit_ir::Value::Int(10)),
+                ],
+            ),
+            Op::new(OpCode::GuardTrue, &[rooted_resop_operand(Type::Int, 1)]),
+            Op::new(OpCode::Jump, &[]),
+        ];
+        let result = run_heap_opt_typed(&mut ops, &[101, 102]);
+
+        let emitted: Vec<OpCode> = result.iter().map(|o| o.opcode).collect();
+
+        // Pin the whole sequence, not just the relative order. The store has a
+        // non-virtual target (an inputarg pointer, so OptVirtualize never claims
+        // it and it does reach `cached_fields`) and a non-virtual stored value
+        // (an inputarg int, so heap.py:618-620 `is_virtual(op.getarg(1))` is
+        // false and `force_lazy_set` EMITS it rather than parking it in
+        // `pendingfields`). Both are required for this to be a real control:
+        // with a virtual on either side no SETFIELD_GC is emitted at all and the
+        // test would pass under either ordering.
+        assert_eq!(
+            emitted,
+            vec![
+                OpCode::SetfieldGc,
+                OpCode::IntGt,
+                OpCode::GuardTrue,
+                OpCode::Jump,
+            ],
+            "heap.py:417-418: the guard's forced lazy set is emitted BEFORE the \
+             postponed comparison, leaving the comparison adjacent to the guard \
+             that tests it (aarch64/assembler.py:1187-1190 next_op_can_accept_cc)",
         );
     }
 

--- a/majit/majit-metainterp/src/optimizeopt/pure.rs
+++ b/majit/majit-metainterp/src/optimizeopt/pure.rs
@@ -715,6 +715,23 @@ impl OptPure {
         true
     }
 
+    /// Hand a released `postponed_op` to the passes AFTER OptPure.
+    ///
+    /// pure.py:139-155 releases the postponed OVF op as the
+    /// `DefaultOptimizationResult.op`, so `send_extra_operation`
+    /// (optimizer.py:594-612) carries it to `opt.next_optimization` —
+    /// OptEarlyForce and then OptHeap — exactly like any other op OptPure
+    /// passes on. Emitting it straight into `new_operations` would skip
+    /// OptHeap, whose own `emit()` override (heap.py:417-424) postpones
+    /// comparisons and flushes the pending one before the next op. Skipping
+    /// it strands a preceding comparison in `OptHeap::postponed_op`, which
+    /// then flushes BETWEEN the OVF op and its GUARD_NO_OVERFLOW — breaking
+    /// the adjacency `aarch64/assembler.py:1191-1195 _walk_operations`
+    /// asserts and the backends rely on to read the overflow flags.
+    fn emit_postponed_downstream(&mut self, postponed: Op, ctx: &mut OptContext) {
+        ctx.emit_extra(ctx.current_pass_idx, postponed);
+    }
+
     /// pure.py:240-247 _same_args
     ///
     /// Compare two argument lists with optional skip-prefixes on each side
@@ -962,10 +979,9 @@ impl Optimization for OptPure {
                     }
                 }
 
-                // RPython emits the postponed op through Optimizer.emit(),
-                // which force_box()es every arg before final emission.
-                // ctx.emit() bypasses that optimizer path, so mirror the
-                // force_box step here before recording the postponed op.
+                // Resolve the args to their forwarded terminals before the op
+                // is recorded in `self.cache` under its arg identities
+                // (optimizer.py:623-625 force_box loop).
                 for i in 0..postponed.num_args() {
                     let forced = self.force_box(&postponed.arg(i), ctx);
                     postponed.setarg(i, ctx.materialize_operand_at(forced));
@@ -978,7 +994,7 @@ impl Optimization for OptPure {
                 // replays it and a loop-invariant overflow-checked op is computed
                 // once in the peeled preamble instead of every iteration.
                 self.short_preamble_pure_ops.push(postponed.clone());
-                ctx.emit(postponed);
+                self.emit_postponed_downstream(postponed, ctx);
                 return OptimizationResult::PassOn; // guard passes through
             } else {
                 // Not a GUARD_NO_OVERFLOW: emit the postponed op now.
@@ -986,7 +1002,7 @@ impl Optimization for OptPure {
                     let forced = self.force_box(&postponed.arg(i), ctx);
                     postponed.setarg(i, ctx.materialize_operand_at(forced));
                 }
-                ctx.emit(postponed);
+                self.emit_postponed_downstream(postponed, ctx);
             }
         }
 

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -6861,10 +6861,20 @@ impl<M: Clone> MetaInterp<M> {
             std::panic::resume_unwind(payload);
         }
         self.internal_compile_panics += 1;
-        eprintln!(
+        let msg = format!(
             "[jit] internal compile panic in {where_} at key={green_key}: JIT \
              disabled for this trace (set MAJIT_STRICT=1 to fail hard)"
         );
+        eprintln!("{msg}");
+        // This is the one compilation failure that disables the JIT outright,
+        // and it was the only one not reaching the "compilation failed" hook —
+        // so an embedder watching `on_compile_error` saw every recoverable
+        // failure and missed the unrecoverable one. A degraded trace then reads
+        // as `compiles=0 aborts=0` on any dashboard fed by the hooks, which is
+        // indistinguishable from "this loop was never hot".
+        if let Some(ref cb) = self.hooks.on_compile_error {
+            cb(green_key, &msg);
+        }
         false
     }
 

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -1103,6 +1103,21 @@ pub struct MetaInterp<M: Clone> {
     /// of the loop living AT that merge point (pyjitpl.py:3005), which the
     /// `u64` key alone cannot be inverted to.
     pub(crate) loop_header_greens: indexmap::IndexMap<u64, (Vec<i64>, Vec<i64>, Vec<i64>)>,
+    /// Keys whose compiled loop came from a cross-loop CUT (compile.py:269-270,
+    /// `TraceCtx::cut_inner_green_key`), rather than from a loop closing at its
+    /// own header.
+    ///
+    /// A cut loop's `front_target_tokens[0]` is not a general procedure entry.
+    /// For a loop compiled at its own header that slot is the PREAMBLE — the
+    /// peeled first iteration that re-derives, from the loop's entry state,
+    /// every invariant the specialized label carries — which is what makes
+    /// `jump_to_preamble` (unroll.py:238-242) sound as the fallback when no
+    /// specialized label matches. A cut has no such peeled entry: its first
+    /// target token is the cut prefix, whose entry invariants were established
+    /// by the guards the CUTTING trace had already executed before it reached
+    /// the cut point. Only that trace's own closing JUMP arrives with them
+    /// proven.
+    pub(crate) cut_compiled_keys: indexmap::IndexSet<u64>,
     pub(crate) tracing: Option<TraceCtx>,
     /// Single-pass tracing: the `(walk_final_pc, walk_final_reds)` snapshot
     /// copied off the active `TraceCtx` at the CloseLoop point BEFORE
@@ -2660,6 +2675,7 @@ impl<M: Clone> MetaInterp<M> {
             compiled_loops: indexmap::IndexMap::new(),
             loop_header_pcs: indexmap::IndexMap::new(),
             loop_header_greens: indexmap::IndexMap::new(),
+            cut_compiled_keys: indexmap::IndexSet::new(),
             tracing: None,
             single_pass_outcome: None,
             single_pass_finish: false,
@@ -5790,6 +5806,15 @@ impl<M: Clone> MetaInterp<M> {
             return CompileOutcome::Cancelled;
         }
 
+        // compile.py:269-270 `jitcell_token = cross_loop.jitcell_token`: mark
+        // the key this loop is about to be stored under as cut-owned, before
+        // the ctx that carries `cut_inner_green_key` is drained. Recorded on
+        // the way in rather than on success so a retried compile at the same
+        // key cannot leave the mark behind; `forget_loop_side_tables` retires
+        // it with the loop.
+        if let Some(cut_key) = cut_inner_green_key {
+            self.cut_compiled_keys.insert(cut_key);
+        }
         self.force_finish_trace = false;
         let mut ctx = self.tracing.take().unwrap();
         // Cache driver descriptor before ctx is partially consumed below;
@@ -9225,6 +9250,16 @@ impl<M: Clone> MetaInterp<M> {
             .map(|(key, _)| *key)
     }
 
+    /// compile.py:269-270 parity: whether the loop at `green_key` was stored
+    /// under a cross-loop cut's inner jitcell token.
+    ///
+    /// See [`MetaInterp::cut_compiled_keys`] for why the distinction matters to
+    /// anything that wants to JUMP into the loop from outside the trace that
+    /// cut it.
+    pub fn is_cross_loop_cut_key(&self, green_key: u64) -> bool {
+        self.cut_compiled_keys.contains(&green_key)
+    }
+
     /// Actual key the last compile_loop stored under. Returns inner key
     /// for cross-loop cuts, otherwise the tracing key.
     pub fn last_compiled_key(&self) -> Option<u64> {
@@ -10052,6 +10087,7 @@ impl<M: Clone> MetaInterp<M> {
     fn forget_loop_side_tables(&mut self, green_key: u64) {
         self.loop_header_pcs.swap_remove(&green_key);
         self.loop_header_greens.swap_remove(&green_key);
+        self.cut_compiled_keys.swap_remove(&green_key);
     }
 
     /// rpython/rlib/rstack.py:75-90 `stack_almost_full` — delegates to
@@ -10684,6 +10720,7 @@ impl<M: Clone> MetaInterp<M> {
         self.compiled_loops.clear();
         self.loop_header_pcs.clear();
         self.loop_header_greens.clear();
+        self.cut_compiled_keys.clear();
     }
 
     /// warmstate.py:385 — whether this driver's portal returns a raw int.


### PR DESCRIPTION
`pyjitpl.py:2996-3007` has a decline half and a jump half. pyre implemented
only the decline: when a compiled loop already sits at the close greens, the
cross-loop cut is refused and the loop body is re-traced inline instead of
JUMPing into reachable code. This branch adds the jump half for the
`ResumeFromInterpDescr` origin, plus the give-up and safety conditions it
needs, and leaves it behind an off-by-default env gate because one shape
regresses (below).

## The entry-bridge close (last four commits)

The driver's `CloseLoop` arm (`jitdriver.rs:2843-3226`) already transcribes
`reached_loop_header` (`pyjitpl.py:2974-3060`): `live_arg_boxes` built once,
the `:3001-3007` compile attempt wired for `ResumeGuardDescr` (`close_bridge`),
fallthrough to `compile_and_record_loop`, `keep_tracing_after_close` resume.
What was missing was that attempt's `ResumeFromInterpDescr` half, not a new
`TraceAction`.

- **value-space `compile_loop` give-up.** Upstream's give-up
  (`pyjitpl.py:3182-3189`) tests `get_procedure_token(greenkey)` BY VALUE.
  majit's gate tested the driver-hash key, which misses a cross-loop cut
  exactly, because a cut's key comes from `green_key_from_code_ptr` — a
  different key space. Adds the value-space test alongside the hash one
  (`mc_diag` 54).
- **the close itself.** The inner merge point publishes `close_greens` and
  returns the existing `CloseLoop`; the driver arm, which holds
  `&mut MetaInterp`, runs `compile_trace_from_interp` against the target the
  greens name, mirrors `close_bridge`'s teardown on success, and on a decline
  discards the single-pass handoff, records the decline for that target, and
  resumes via the `merge_point_resumed` latch (`pyjitpl.py:1577` `saved_pc`
  parity).
- **cut targets are declined.** An entry bridge carries no runtime values
  (`ResumeFromInterpDescr.get_resumestorage()` is None), so `generate_guards`
  rejects every specialized label and the JUMP falls to `jump_to_preamble`
  → `target_tokens[0]` (`unroll.py:228-242`). That is sound only where the
  token is a PREAMBLE — upstream asserts `virtual_state is None`
  (`unroll.py:239`). A cross-loop cut keeps its cut prefix there, whose bounds
  presuppose the guards before the cut point, so the jump reaches an unproven
  index bound and stores out of bounds (reproduced as a SIGSEGV in cel).
  `cut_compiled_keys` on `MetaInterp` makes the close decline those targets.
- **`MAJIT_ENTRY_BRIDGE_CLOSE`, default off.** With the gate off both call
  sites take the pre-lever route byte for byte; a test asserts that, including
  the second registration under crossed greens.

Registration safety is structural rather than checked:
`record_loop_header_greens` has exactly one production caller
(`compile_and_record_loop`), and the entry-bridge path registers nothing, so
the two-keys-one-green-tuple collision cannot arise from this path.

## Why it is gated off

Priced on both backends (cel, 4000 rows, deopt counts identical on cranelift
and dynasm):

| case | before | after |
| --- | --- | --- |
| `constant8` | 9 | 201 |
| `alternating` | 210 | 201 |
| `cycle` | 1609 | **201** |
| `spread 0..32` | 1105 | **451** (200k rows: 1825 → 607) |

The 201 is `trace_eagerness=200` (`rlib/jit.py:590`) — the orthodox shape;
`constant8`'s 9 was the non-orthodox inline close. Shape-varying nested loops
win by 2.4-8x.

But `batch_nested_independent_list_comprehensions` collapses ≥10000x on BOTH
backends (0.09s → >90s and still progressing). That refutes the reading that
the nested-shape gap is the cranelift cross-artifact edge price: replacing an
already-amortized zero-hop inlined shape with per-iteration portal re-entry
loses at any hop price. It is shape economics, filed as a follow-up, and it is
why the gate stays off.

## The six earlier commits

Independent majit fixes that landed on this branch first:

- run the GC rewrite pass whether or not a collector is installed
  (`gc.py:109-112`; upstream never gates it — `GcLLDescr_boehm` runs the whole
  pass and the collector selects arms inside `rewrite()`).
- keep an `is_ovf` op adjacent to its guard, and read the bit-reinterpret
  converts from the argument's bank (`pure.py:139-155` /
  `optimizer.py:594-612`: release postponed ops as
  `DefaultOptimizationResult.op` so they reach OptHeap).
- run the guard lazy-set flush at OptHeap's own emit point for every guard
  (`heap.py:417-434`), deleting the two per-opcode special cases the tree had
  accumulated.
- three comment corrections recording what the JUMP-into-ptoken lever actually
  measures, and that the earlier "no callers" / "resolves to itself" claims
  were wrong.

## Verification

- `cargo test -p majit-metainterp`: 1442 pass.
- `pyre/check.py`: dynasm 374/374, cranelift 374/374. The three wasm jit-stats
  rows are inherited from the base — controlled by running the same gate at the
  commit before this work, with identical rows and numbers.
- cel: the full evidence suite green with the gate off; with the gate on, the
  four cases above plus the one collapsing case.
- Codex parity review run on the diff: no parity regression attributable to
  these commits. Two pre-existing findings filed as follow-ups (per-thread
  `MetaInterpStaticData`; `gc.collect()` over unrooted stack refs).
